### PR TITLE
Fix deduplication code to apply only to simple encodings

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -526,6 +526,18 @@ public:
       : ConvertTritonGPUOpToLLVMPattern<SourceOp>(typeConverter, benefit),
         axisAnalysisPass(axisAnalysisPass) {}
 
+  // True if elements allocated to a thread are contiguous within the axis. This
+  // is not the case in MMA-like encodings wherea thread might have elements
+  // (0,0),(0,1) and (8,0),(8,1) for example. The problem with this is that the
+  // deduplication mechanism assumes that for example constancy=4 and
+  // elements/thread=4 that if a thread has all elements constant.
+  bool contiguouslyMapped(Attribute encoding) const {
+    if (auto slice = encoding.dyn_cast<triton::gpu::SliceEncodingAttr>()) {
+      return contiguouslyMapped(slice.getParent());
+    }
+    return encoding.isa<triton::gpu::BlockedEncodingAttr>();
+  }
+
   // Try to deduplicate the resultVals based on the
   // constancy properties of the result discovered by
   // the axis analysis pass. If possible, redundant
@@ -551,8 +563,7 @@ public:
     if (!encoding)
       // encoding not available
       return resultVals;
-    if (!encoding.dyn_cast<triton::gpu::BlockedEncodingAttr>() &&
-        !encoding.dyn_cast<triton::gpu::SliceEncodingAttr>()) {
+    if (!contiguouslyMapped(encoding)) {
       // TODO: constraining the ecndoing type here is necessary
       // for avoiding crashes in the triton::gpu::getElemsPerThread
       // call below happening in the test_core::test_fp8_dot_acc

--- a/python/test/regression/test_dedup_mma.py
+++ b/python/test/regression/test_dedup_mma.py
@@ -16,9 +16,6 @@ import numpy as np
 import triton.language as tl
 from triton import jit
 
-input_dtypes = ["float32", "float64"]
-out_dtypes = ["float16", "float32"]
-
 
 def test_elementwise_dedupe():
     # XXX: Could probably be achieved with interpreter mode aswell.

--- a/python/test/regression/test_dedup_mma.py
+++ b/python/test/regression/test_dedup_mma.py
@@ -1,0 +1,48 @@
+"""When triton is lowered to llvm it no longer deals with tensors and
+ encodings. At this stage all tensor operations are lowered to
+ thread-specific code. During this lowering elementwise ops an
+ optimization happens where if N elements of an elementwise op are the
+ same they are both computed by the same operation. The code was
+ buggy, however, at some point and it assumed that each thread is
+ assigned contiguous blocks of elements to be computed.
+
+"""
+import pytest
+import torch
+import numpy as np
+
+import triton.language as tl
+from triton import jit
+
+input_dtypes = ["float32", "float64"]
+out_dtypes = ["float16", "float32"]
+
+
+def test_elementwise_dedupe():
+
+    def numpy_kernel():
+        mask = np.ones((16, 16), dtype=bool)
+        mask[:2, :] = False
+        masked = np.where(mask, np.zeros((16, 16)), 1)
+        return masked @ np.ones((16, 16))
+
+    @jit
+    def kernel(out_ptr):
+        # Make a 16x16 mask where `mask[0:2,:] == False`
+        mask_qk = tl.full([16, 16], 1, dtype=tl.int1)
+        mask_qk &= (tl.arange(0, 16) < 2)[:,None]
+        # Force the mask encoding to #mma so it needs convert to #dot.
+        x = tl.zeros([16,16], tl.float32)
+        dot = tl.dot(x, x)
+        # make sure it converts to dot. If the layout is not properly
+        # taken into account (8, 0) may not be masked.
+        res = tl.where(mask_qk, dot, 1)
+        res = tl.dot(res, tl.full(x.shape, 1, x.dtype))
+        tl.store(to_uniblock16(out_ptr), res)
+
+    grid = (1,)
+    triton_res = torch.zeros((16, 16))
+    kernel[grid](triton_res)
+    numpy_res = numpy_kernel()
+
+    torch.testing.assert_close(triton_res, numpy_res)

--- a/python/test/regression/test_dedup_mma.py
+++ b/python/test/regression/test_dedup_mma.py
@@ -7,6 +7,8 @@
  assigned contiguous blocks of elements to be computed.
 
 """
+
+import os
 import pytest
 import torch
 import numpy as np
@@ -19,30 +21,39 @@ out_dtypes = ["float16", "float32"]
 
 
 def test_elementwise_dedupe():
-
+    # XXX: Could probably be achieved with interpreter mode aswell.
     def numpy_kernel():
         mask = np.ones((16, 16), dtype=bool)
-        mask[:2, :] = False
-        masked = np.where(mask, np.zeros((16, 16)), 1)
-        return masked @ np.ones((16, 16))
+        mask &= (np.arange(0, 16) < 2)[:, None]
+        x = np.zeros((16, 16), dtype=np.float32)
+        dot = x @ x
+        masked = np.where(mask, dot, 1)
+        return masked @ np.ones((16, 16), dtype=np.float32)
 
     @jit
     def kernel(out_ptr):
         # Make a 16x16 mask where `mask[0:2,:] == False`
-        mask_qk = tl.full([16, 16], 1, dtype=tl.int1)
-        mask_qk &= (tl.arange(0, 16) < 2)[:,None]
+        mask = tl.full([16, 16], 1, dtype=tl.int1)
+        mask &= (tl.arange(0, 16) < 2)[:, None]
         # Force the mask encoding to #mma so it needs convert to #dot.
-        x = tl.zeros([16,16], tl.float32)
+        x = tl.zeros([16, 16], tl.float32)
+        # make sure it converts to dot
         dot = tl.dot(x, x)
-        # make sure it converts to dot. If the layout is not properly
-        # taken into account (8, 0) may not be masked.
-        res = tl.where(mask_qk, dot, 1)
+        res = tl.where(mask, dot, 1)
         res = tl.dot(res, tl.full(x.shape, 1, x.dtype))
-        tl.store(to_uniblock16(out_ptr), res)
+        out_ptr = tl.make_block_ptr(
+            out_ptr,
+            shape=(16, 16),
+            strides=(16, 1),
+            offsets=(0, 0),
+            block_shape=(16, 16),
+            order=(0, 1),
+        )
+        tl.store(out_ptr, res)
 
-    grid = (1,)
-    triton_res = torch.zeros((16, 16))
-    kernel[grid](triton_res)
-    numpy_res = numpy_kernel()
+    baseline_res = numpy_kernel()
 
-    torch.testing.assert_close(triton_res, numpy_res)
+    gpu_res = torch.zeros((16, 16))
+    kernel[(1,)](gpu_res)
+
+    torch.testing.assert_close(triton_res, baseline_res)


### PR DESCRIPTION
The code that deduplicates elementwise operations does not take into account the fact that MMA encoding does not distribute contiguous blocks across threads. For example for a tensor `tensor<16xf16>` lowered to LLVM, each thread (lane) gets 8 values but they are `x[0:4,0]` and `x[0:4,8]` ([ref](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#mma-16816-a-i8)). Deduplication, however uses constancy which refers to the logical concancy, for example constancy 8 means that `ax[:8,0]` so it is assumed that each thread can evaluateall its values with one op, which is not the case for MMA encoding.