### PR TITLE
[backend]Ensure coalescing and saturation for every memop in a slice.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -75,7 +75,7 @@ struct CoalescePass : public TritonGPUCoalesceBase<CoalescePass> {
       unsigned currPerThread =
           getNumElementsPerThread(opSameOrder, order, axisInfoAnalysis);
       LDBG("perThread for opSameOrder: " << currPerThread);
-      perThread = std::max(perThread, currPerThread);
+      perThread = std::min(perThread, currPerThread);
     }
 
     perThread = std::min<int>(perThread, std::max(numElems / numThreads, 1));

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3000,7 +3000,10 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
     ptx = pgm.asm['ptx']
     if (K > 16 or N > 16 or M > 16) and (M * N // (num_warps * 32) >= 4):
         # XXX: skip small sizes because they are not vectorized
-        assert 'ld.global.v4' in ptx
+        if in_dtype == 'bfloat16' and out_dtype == tl.float32:
+            assert 'ld.global.v2' in ptx
+        else:
+            assert 'ld.global.v4' in ptx
         if 'float8' in in_dtype:
             assert 'st.global.v2' in ptx
         else:

--- a/test/TritonGPU/coalesce.mlir
+++ b/test/TritonGPU/coalesce.mlir
@@ -120,3 +120,39 @@ tt.func public @load_tensors_two_types(%arg0: !tt.ptr<f32, 1> {tt.divisibility =
 }
 
 }
+
+
+// -----
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+
+
+// CHECK: [[NARROW_LAYOUT:#.*]] = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+// CHECK: [[WIDE_LAYOUT:#.*]] = #triton_gpu.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+tt.func public @load_tensors_subtype_types(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16, 1>, %arg3: i32) attributes {noinline = false} {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %3 = tt.splat %1 : i32 -> tensor<1024xi32, #blocked>
+    %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked>
+    %5 = tt.splat %arg3 : i32 -> tensor<1024xi32, #blocked>
+    %6 = arith.cmpi "slt", %4, %5 : tensor<1024xi32, #blocked>
+    %7 = tt.splat %arg0 : !tt.ptr<f16, 1> -> tensor<1024x!tt.ptr<f16, 1>, #blocked>
+    %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f16, 1>, #blocked>, tensor<1024xi32, #blocked>
+    // CHECK: tt.load {{.*}} : tensor<1024xf16, [[WIDE_LAYOUT]]>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf16, #blocked>
+    %10 = tt.splat %arg1 : !tt.ptr<f16, 1> -> tensor<1024x!tt.ptr<f16, 1>, #blocked>
+    %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f16, 1>, #blocked>, tensor<1024xi32, #blocked>
+    // CHECK: tt.load {{.*}} : tensor<1024xf16, [[WIDE_LAYOUT]]>
+    %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf16, #blocked>
+    %14 = arith.addf %9, %12 : tensor<1024xf16, #blocked>
+    %15 = tt.splat %arg2 : !tt.ptr<f16, 1> -> tensor<1024x!tt.ptr<f16, 1>, #blocked>
+    %16 = tt.addptr %15, %4 : tensor<1024x!tt.ptr<f16, 1>, #blocked>, tensor<1024xi32, #blocked>
+    // CHECK: tt.store {{.*}} : tensor<1024xf16, [[NARROW_LAYOUT]]>
+    tt.store %16, %14, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf16, #blocked>
+    tt.return
+}
+
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -466,7 +466,6 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
           a = packLLElements(loc, typeConverter, regA, rewriter, regATy);
         }
         auto b = bLoader.smemLoad(n, k, rewriter, loc);
-        ValueRange operands{a, b, d};
         numLowPrecisionAcc += K;
         // If using native accumulation would cause use to do more low precion
         // accumulation than allowed do a separate allocation.
@@ -484,7 +483,7 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
         // If we need accumulate separately to have higher precision, insert
         // adds.
         if (requireAddAccumulator) {
-          d = faddAccumulate(rewriter, loc, d, partialAcc);
+          d = d ? faddAccumulate(rewriter, loc, d, partialAcc) : partialAcc;
           numLowPrecisionAcc = 0;
           partialAcc = Value();
         }


### PR DESCRIPTION
While current memory coalescing heuristics works quite well, a couple opportunities may be missing:
- It uses the narrowest data type for the layouts of all memops in a slice which may break memory coalescing of wider memops. Actually, we have seen this issue (https://github.com/pytorch/pytorch/issues/120667) where a full vectorization of a narrower memop breaks memory coalescing of a wider memop. This occurs in a way that the wider memop will end up fulfilled by two consecutive memop ops, and each is not consecutive across threads. It seems that in general full memory coalescing should always be ensured (within or across threads). And on top of that, maximizing vectorization for each memop is a plus.
- All memops could end up non-vectorizable if any memop in the slice is non-vectorizable.
	
This patch tries to fix the issues by trading off between the performance of individual memop and overall performance. It takes bandwidth saturation and correct alignment for every memop into considering and tries to compute a unified layout among the memops while favoring vectorization of each memop as much as possible. 
	
An overview of what the new heuristics does
	
1. Compute a slice of same-shaped memory ops that have a dataflow connection.
2. For each mem op in the slice, compute the 
    i. The maximum consecutive elements each thread (named `maxPerThread`) should own that does not break cross-thread memory coalescing.
    ii. The minimum consecutive elements each thread (named `minPerThread`) should own to saturate the memory bandwidth and avoid alignment issue.
3. The unified `perThread` should be no bigger than the minimal `maxPerThread` and no smaller than the maximal `minPerThread`.
	 
The new heuristics could also takes into account of the execution frequency of each memop to be more accurate, which is not included in this work. 
