### PR TITLE
Support PARs in backend discover

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -29,6 +29,15 @@ def compile_module_from_src(src, name):
     spec.loader.exec_module(mod)
     return mod
 
+def _read_from_par():
+    import sys
+    import zipfile
+
+    par_path = sys.argv[0]
+    with zipfile.ZipFile(par_path, "r") as z:
+        return z.read("triton/backends/amd/driver.c").decode("utf-8")
+
+
 class HIPUtils(object):
 
     def __new__(cls):
@@ -37,7 +46,11 @@ class HIPUtils(object):
         return cls.instance
 
     def __init__(self):
-        mod = compile_module_from_src(Path(os.path.join(dirname, "driver.c")).read_text(), "hip_utils")
+        try:
+            src = Path(os.path.join(dirname, "driver.c")).read_text()
+        except OSError:
+            src = _read_from_par()
+        mod = compile_module_from_src(src, "hip_utils")
         self.load_binary = mod.load_binary
         self.get_device_properties = mod.get_device_properties
 

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -68,6 +68,15 @@ def compile_module_from_src(src, name):
 # ------------------------
 
 
+def _read_from_par():
+    import sys
+    import zipfile
+
+    par_path = sys.argv[0]
+    with zipfile.ZipFile(par_path, "r") as z:
+        return z.read("triton/backends/nvidia/driver.c").decode("utf-8")
+
+
 class CudaUtils(object):
 
     def __new__(cls):
@@ -76,7 +85,11 @@ class CudaUtils(object):
         return cls.instance
 
     def __init__(self):
-        mod = compile_module_from_src(Path(os.path.join(dirname, "driver.c")).read_text(), "cuda_utils")
+        try:
+            src = Path(os.path.join(dirname, "driver.c")).read_text()
+        except OSError:
+            src = _read_from_par()
+        mod = compile_module_from_src(src, "cuda_utils")
         self.load_binary = mod.load_binary
         self.get_device_properties = mod.get_device_properties
         self.cuOccupancyMaxActiveClusters = mod.cuOccupancyMaxActiveClusters


### PR DESCRIPTION
At Meta we (sometimes) distribute python in .par archives (more or less just a big zipfile with the python content) and this plays poorly with the backend discovery mechanism that expects to find real files.  You end up with errors like `NotADirectoryError: [Errno 20] Not a directory: '/proc/self/fd/6/triton/backends'`, because it's trying to read something that's piped from a zipfile extraction.

This PR works around that by adding zipfile reading logic at the places that want to walk the filesystem.  I'm really not sure if this is the cleanest or best way to do it, but at least its a fairly mild amount of complexity.