### PR TITLE
[RUNTIME] Simplify caching API

### DIFF
--- a/python/test/backend/test_device_backend.py
+++ b/python/test/backend/test_device_backend.py
@@ -100,7 +100,7 @@ class ExtensionUtils:
                     f.write(src)
                 so = build_for_backend("ext_utils", src_path, tmpdir)
                 with open(so, "rb") as f:
-                    cache_path = cache.put(f.read(), fname, binary=True)
+                    cache_path = cache.put(fname, fname.encode("utf-8"))
         import importlib.util
         spec = importlib.util.spec_from_file_location("ext_utils", cache_path)
         mod = importlib.util.module_from_spec(spec)
@@ -185,7 +185,7 @@ class ExtensionBackend(BaseBackend):
                     f.write(src)
                 so = build_for_backend(name, src_path, tmpdir)
                 with open(so, "rb") as f:
-                    so_path = so_cache_manager.put(f.read(), so_name, binary=True)
+                    so_path = so_cache_manager.put(so_name, f.read())
                     type(self).stub_so_path = so_path
                     return so_path
         else:

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -22,7 +22,7 @@ def compile_module_from_src(src, name):
                 f.write(src)
             so = _build(name, src_path, tmpdir, library_dir, include_dir, libraries)
             with open(so, "rb") as f:
-                cache_path = cache.put(f.read(), f"{name}.so", binary=True)
+                cache_path = cache.put(f"{name}.so", f.read())
     import importlib.util
     spec = importlib.util.spec_from_file_location(name, cache_path)
     mod = importlib.util.module_from_spec(spec)

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -55,7 +55,7 @@ def compile_module_from_src(src, name):
                 f.write(src)
             so = _build(name, src_path, tmpdir, library_dirs(), include_dir, libraries)
             with open(so, "rb") as f:
-                cache_path = cache.put(f.read(), f"{name}.so", binary=True)
+                cache_path = cache.put(f"{name}.so", f.read())
     import importlib.util
     spec = importlib.util.spec_from_file_location(name, cache_path)
     mod = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
This simplifies the caching API to require callers pass the entire list
of files to cache in a "group" in the `put_group` method.  This allows
caching backends to e.g. serialize these files into a single cache blob,
which can avoid issues with caching atomicity.