### PR TITLE
[AMD] Fix an issue with deduplication with mfma layout

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -95,6 +95,13 @@ public:
       return resultVals;
     }
 
+    // cannot utilize duplication with parent mfma layout
+    if (auto slice = encoding.dyn_cast<SliceEncodingAttr>()) {
+      if (slice.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
+        return resultVals;
+      }
+    }
+
     SmallVector<unsigned> elemsPerThread = getElemsPerThread(rtType);
     int rank = elemsPerThread.size();
     if (product<unsigned>(elemsPerThread) != resultVals.size())

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -1208,7 +1208,9 @@ def SliceEncodingAttr : DistributedEncoding<"SliceEncoding", "slice_encoding"> {
 
     SmallVector<unsigned> getContigPerThread() {
       auto parentLayout = mlir::cast<DistributedEncodingTrait>(getParent());
-      return parentLayout.getContigPerThread();
+      auto parentContigPerThread = parentLayout.getContigPerThread();
+      parentContigPerThread.erase(parentContigPerThread.begin() + getDim());
+      return parentContigPerThread;
     };
   }];
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3369,6 +3369,7 @@ def test_dot_optimize_epilogue(device):
     out_ref = np.matmul(x, y)
     out_ref_ones = np.ones((M, N), dtype='float16')
     np.testing.assert_allclose(out_ref, to_numpy(out_tri[0:M, :]), rtol=0.01, atol=1e-3)
+    # check output is not written out of bound
     np.testing.assert_allclose(out_ref_ones, to_numpy(out_tri[M:]), rtol=0.01, atol=1e-3)
 
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3334,13 +3334,8 @@ def test_dot_optimize_epilogue(device):
 
     # triton kernel
     @triton.jit
-    def kernel(X, stride_xm, stride_xk, 
-               Y, stride_yk, stride_yn,
-               M, N, K,
-               BLOCK_M:tl.constexpr, 
-               BLOCK_N:tl.constexpr, 
-               BLOCK_K:tl.constexpr,
-               Out, stride_om, stride_on):
+    def kernel(X, stride_xm, stride_xk, Y, stride_yk, stride_yn, M, N, K, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+               BLOCK_K: tl.constexpr, Out, stride_om, stride_on):
         off_m = tl.arange(0, BLOCK_M)
         off_n = tl.arange(0, BLOCK_N)
         off_k = tl.arange(0, BLOCK_K)
@@ -3367,15 +3362,13 @@ def test_dot_optimize_epilogue(device):
     out = np.ones((2 * M, N), dtype='float16')
 
     x_tri = to_triton(x, device=device)
-    y_tri = to_triton(y, device=device)    
+    y_tri = to_triton(y, device=device)
     out_tri = to_triton(out, device=device)
-    kernel[(1, 1)](x_tri, x_tri.stride(0), x_tri.stride(1),
-                   y_tri, y_tri.stride(0), y_tri.stride(1),
-                   M, N, K, BLOCK_M, BLOCK_N, BLOCK_K,
-                   out_tri, out_tri.stride(0), out_tri.stride(1))
+    kernel[(1, 1)](x_tri, x_tri.stride(0), x_tri.stride(1), y_tri, y_tri.stride(0), y_tri.stride(1), M, N, K, BLOCK_M,
+                   BLOCK_N, BLOCK_K, out_tri, out_tri.stride(0), out_tri.stride(1))
     out_ref = np.matmul(x, y)
-    out_ref_ones = np.ones((M, N), dtype = 'float16')
-    np.testing.assert_allclose(out_ref, to_numpy(out_tri[0:M,:]), rtol=0.01, atol=1e-3)
+    out_ref_ones = np.ones((M, N), dtype='float16')
+    np.testing.assert_allclose(out_ref, to_numpy(out_tri[0:M, :]), rtol=0.01, atol=1e-3)
     np.testing.assert_allclose(out_ref_ones, to_numpy(out_tri[M:]), rtol=0.01, atol=1e-3)
 
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3330,6 +3330,56 @@ def test_dot3d(B, num_warps, M, N, K, in_dtype_str, out_dtype_str, device):
 
 
 @pytest.mark.interpreter
+def test_dot_optimize_epilogue(device):
+
+    # triton kernel
+    @triton.jit
+    def kernel(X, stride_xm, stride_xk, 
+               Y, stride_yk, stride_yn,
+               M, N, K,
+               BLOCK_M:tl.constexpr, 
+               BLOCK_N:tl.constexpr, 
+               BLOCK_K:tl.constexpr,
+               Out, stride_om, stride_on):
+        off_m = tl.arange(0, BLOCK_M)
+        off_n = tl.arange(0, BLOCK_N)
+        off_k = tl.arange(0, BLOCK_K)
+        Xs = X + off_m[:, None] * stride_xm + off_k[None, :] * stride_xk
+        Ys = Y + off_k[:, None] * stride_yk + off_n[None, :] * stride_yn
+        mask_x = (off_m < M)[:, None] & (off_k < K)[None, :]
+        mask_y = (off_m < K)[:, None] & (off_n < N)[None, :]
+
+        x = tl.load(Xs, mask=mask_x, other=0.0)
+        y = tl.load(Ys, mask=mask_y, other=0.0)
+
+        z = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        z += tl.dot(x, y)
+        Outs = Out + off_m[:, None] * stride_om + off_n[None, :] * stride_on
+        mask_o = (off_m < M)[:, None] & (off_n < N)[None, :]
+
+        tl.store(Outs, z.to(tl.float16), mask=mask_o)
+
+    M, N, K = 16, 32, 32
+    BLOCK_M, BLOCK_N, BLOCK_K = 32, 32, 32
+    rs = RandomState(17)
+    x = numpy_random((M, K), dtype_str='float16', rs=rs)
+    y = numpy_random((K, N), dtype_str='float16', rs=rs)
+    out = np.ones((2 * M, N), dtype='float16')
+
+    x_tri = to_triton(x, device=device)
+    y_tri = to_triton(y, device=device)    
+    out_tri = to_triton(out, device=device)
+    kernel[(1, 1)](x_tri, x_tri.stride(0), x_tri.stride(1),
+                   y_tri, y_tri.stride(0), y_tri.stride(1),
+                   M, N, K, BLOCK_M, BLOCK_N, BLOCK_K,
+                   out_tri, out_tri.stride(0), out_tri.stride(1))
+    out_ref = np.matmul(x, y)
+    out_ref_ones = np.ones((M, N), dtype = 'float16')
+    np.testing.assert_allclose(out_ref, to_numpy(out_tri[0:M,:]), rtol=0.01, atol=1e-3)
+    np.testing.assert_allclose(out_ref_ones, to_numpy(out_tri[M:]), rtol=0.01, atol=1e-3)
+
+
+@pytest.mark.interpreter
 def test_max_num_imprecise_acc(device):
 
     if not hasattr(torch, 'float8_e5m2'):

--- a/test/Conversion/amd/dedup-by-constancy.mlir
+++ b/test/Conversion/amd/dedup-by-constancy.mlir
@@ -1,0 +1,20 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=arch=gfx942 --convert-builtin-func-to-llvm | FileCheck %s
+
+// CHECK-LABEL: dedup_by_constancy_mfma
+// CHECK-COUNT-4: llvm.icmp "slt"
+// CHECK-NOT: llvm.icmp "slt"
+#mma = #triton_gpu.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, triton_gpu.target = "hip:gfx942", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func public @dedup_by_constancy_mfma(%arg0: i32 {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+    %1 = tt.splat %arg0 : i32 -> tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+    %2 = arith.cmpi slt, %0, %1 : tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+    %3 = tt.expand_dims %2 {axis = 1 : i32} : tensor<32xi1, #triton_gpu.slice<{dim = 1, parent = #mma}>> -> tensor<32x1xi1, #mma>
+    %4 = tt.broadcast %3 : tensor<32x1xi1, #mma> -> tensor<32x32xi1, #mma>
+    %cst = arith.constant dense<0.100000e+00> : tensor<32x32xf16, #mma>
+    %5 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<32x1x!tt.ptr<f16>, #mma>
+    %6 = tt.broadcast %5 : tensor<32x1x!tt.ptr<f16>, #mma> -> tensor<32x32x!tt.ptr<f16>, #mma>
+    tt.store %6, %cst, %4 : tensor<32x32x!tt.ptr<f16>, #mma>
+    tt.return
+  }
+}

--- a/test/Conversion/amd/dedup-by-constancy.mlir
+++ b/test/Conversion/amd/dedup-by-constancy.mlir
@@ -3,6 +3,16 @@
 // CHECK-LABEL: dedup_by_constancy_mfma
 // CHECK-COUNT-4: llvm.icmp "slt"
 // CHECK-NOT: llvm.icmp "slt"
+// Here is why we expect exactly 4 icmp:
+// For a 32x32 tensor A with mfma layout, each thread holds 16 elements, which are divided
+// into 4 groups. E.g. thread 0 holds elements A[0:3,0], A[8:11,0], A[16:19,0], and A[24:27,0].
+// In this example, constancy of the tensor is 16 for dim 0, meaning A[0:15,0] have same values
+// and A[16:31,0] have same values. Therefore, for thread 0, the first 8 elements are duplicated
+// and the last 8 elements are duplicated. Ideally, thread 0 only needs two icmp, one for the
+// first 8 elements and the other for the last 8 elements. In practice, the dedup analysis
+// only allows duplication within each group of 4 elemnets. Therefore, we expect 4 icmp, one
+// for each group of 4 elements.
+// In the future, we can reduce the icmp to 2 in such case.
 #mma = #triton_gpu.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [1, 1], instrShape = [32, 32], isTransposed = false}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, triton_gpu.target = "hip:gfx942", "triton_gpu.threads-per-warp" = 64 : i32} {
   tt.func public @dedup_by_constancy_mfma(%arg0: i32 {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {


### PR DESCRIPTION
This PR fixes the following two issues
1. `getContigPerThread()` for sliceLayout should erase the `dim` after getting the vector from its parent
2. `maybeDeduplicate()` should use `getContigPerThread()` instead of `getSizePerThread()` 

Note that `sizePerThread` and `contigPerThread` are the same for blocked layout and sliceLayout with blocked layout as parent. But they are different for mfma layout. Using sizePerThread in maybeDeduplicate causes an issue when we do masked store with mfma layout. Because the `constancy` is not adjusted properly, mask values that are not supposed to be duplicated are duplicated, which leads to out-of-bound memory access.