### PR TITLE
[TUTORIAL][softmax] Use jit warmup interface for pre-compilation.

### DIFF
--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -26,7 +26,6 @@ import torch
 import triton
 import triton.language as tl
 from triton.runtime import driver
-import triton.compiler as tc
 
 
 @torch.jit.script
@@ -128,18 +127,14 @@ def softmax(x):
     # Number of software piepling stages.
     num_stages = 4
 
+    # Allocate output
+    y = torch.empty_like(x)
+
     # pre-compile kernel to get register usage and compute thread occupancy.
     kernel, num_programs = kernels.get(BLOCK_SIZE, (None, 0))
     if kernel is None:
-        opts = {"num_warps": 8, "num_stages": 4}
-        attrs = triton.compiler.AttrsDescriptor(tuple(range(6)), ()) if n_cols % 16 == 0 else None
-        src = tc.ASTSource(
-            fn=softmax_kernel,
-            constants={"BLOCK_SIZE": BLOCK_SIZE, "num_stages": num_stages},
-            signature="*fp32,*fp32,i32,i32,i32,i32",
-            attrs=attrs,
-        )
-        kernel = triton.compile(src=src, target=target, options=opts)
+        kernel = softmax_kernel.warmup(y, x, x.stride(0), y.stride(0), n_rows, n_cols, BLOCK_SIZE=BLOCK_SIZE,
+                                       num_stages=num_stages, num_warps=num_warps, grid=(1, ))
         kernel._init_handles()
         n_regs = kernel.n_regs
         size_smem = kernel.metadata.shared
@@ -149,9 +144,6 @@ def softmax(x):
         kernels[BLOCK_SIZE] = (kernel, num_programs)
 
     num_programs = min(num_programs, n_rows)
-
-    # Allocate output
-    y = torch.empty_like(x)
 
     # Create a number of persistent programs.
     kernel[(num_programs, 1, 1)](


### PR DESCRIPTION
Using the `warmup` interface hides parameter/configure details, and is flexible for supporting different data types.