### PR TITLE
[AMD] Support int DotOp for RDNA3

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -491,7 +491,7 @@ static bool supportWMMATypes(Type a, Type b, Type c, Type d) {
   if (a.isIntOrIndex()) {
     if (!c.isIntOrIndex())
       return false;
-    bool aValid = a.isUnsignedInteger() && aWidth <= 8;
+    bool aValid = aWidth <= 8;
     bool cValid = cWidth <= 32;
     return aValid && cValid;
   } else if (isa<FloatType>(a) && isa<FloatType>(c)) {
@@ -499,7 +499,7 @@ static bool supportWMMATypes(Type a, Type b, Type c, Type d) {
       return c.isBF16() || c.isF32();
     if (a.isF16())
       return c.isF16() || c.isF32();
-    return aWidth <= cWidth;
+    return aWidth <= cWidth && aWidth <= 16;
   }
   return false;
 }

--- a/test/TritonGPU/amd/accelerate-amd-matmul.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul.mlir
@@ -73,6 +73,50 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     // CHECK: triton_gpu.convert_layout %[[DOT2_WMMA_RES]]
     // CHECK-SAME: -> tensor<32x64xf16, #[[DOT_OP_PARENT]]>
     tt.store %2, %4 : tensor<32x64x!tt.ptr<f16>, #blocked>
+        tt.return
+  }
+  tt.func public @wmma_dot_i8_i32(
+   // CHECK: %[[DOT1_ARG_A:.+]]: tensor<32x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #[[DOT_OP_PARENT]]}>>
+   %0: tensor<32x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
+   // CHECK-SAME: %[[DOT1_ARG_B:.+]]: tensor<64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #[[DOT_OP_PARENT]]}>>
+   %1: tensor<64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>,
+   %2: tensor<32x32x!tt.ptr<i32>, #blocked>) {
+    // CHECK: %[[DOT1_ARG_C:.+]] = arith.constant dense<0> : tensor<32x32xi32, #[[DOT_OP_PARENT]]>
+    // CHECK: %[[DOT1_OP_C:.+]] = triton_gpu.convert_layout %[[DOT1_ARG_C]]
+    // CHECK-SAME: -> tensor<32x32xi32, #[[WMMA_1]]
+    %3 = arith.constant dense<0> : tensor<32x32xi32, #blocked>
+    // CHECK: %[[DOT1_OP_A:.+]] = triton_gpu.convert_layout %[[DOT1_ARG_A]]
+    // CHECK-SAME: -> tensor<32x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #[[WMMA_1]]
+    // CHECK: %[[DOT1_OP_B:.+]] = triton_gpu.convert_layout %[[DOT1_ARG_B]]
+    // CHECK-SAME: -> tensor<64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #[[WMMA_1]]
+    // CHECK: %[[DOT1_WMMA_RES:.+]] = tt.dot %[[DOT1_OP_A]], %[[DOT1_OP_B]], %[[DOT1_OP_C]]
+    // CHECK-SAME: -> tensor<32x32xi32, #[[WMMA_1]]
+    %4 = tt.dot %0, %1, %3 : tensor<32x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x32xi32, #blocked>
+    // CHECK: triton_gpu.convert_layout %[[DOT1_WMMA_RES]]
+    // CHECK-SAME: -> tensor<32x32xi32, #[[DOT_OP_PARENT]]>
+    tt.store %2, %4 : tensor<32x32x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+  tt.func public @fma_dot_i16_i16(
+   // CHECK: %[[DOT3_ARG_A:.+]]: tensor<128x64xi16, #triton_gpu.dot_op<{opIdx = 0, parent = #[[DOT_OP_PARENT]]}>>
+   %0: tensor<128x64xi16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
+   // CHECK-SAME: %[[DOT3_ARG_B:.+]]: tensor<64x32xi16, #triton_gpu.dot_op<{opIdx = 1, parent = #[[DOT_OP_PARENT]]}>>
+   %1: tensor<64x32xi16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>,
+   %2: tensor<128x32x!tt.ptr<i16>, #blocked>) {
+    // CHECK: %[[DOT3_ARG_C:.+]] = arith.constant dense<0> : tensor<128x32xi16, #[[DOT_OP_PARENT]]>
+    %3 = arith.constant dense<0> : tensor<128x32xi16, #blocked>
+    // CHECK: %[[DOT3_OP_A:.+]] = arith.sitofp %[[DOT3_ARG_A]]
+    // CHECK-SAME: to tensor<128x64xf32, #triton_gpu.dot_op<{opIdx = 0, parent = #[[DOT_OP_PARENT]]
+    // CHECK: %[[DOT3_OP_B:.+]] = arith.sitofp %[[DOT3_ARG_B]]
+    // CHECK-SAME: to tensor<64x32xf32, #triton_gpu.dot_op<{opIdx = 1, parent = #[[DOT_OP_PARENT]]
+    // CHECK: %[[DOT3_OP_C:.+]] = arith.sitofp %[[DOT3_ARG_C]]
+    // CHECK-SAME: to tensor<128x32xf32, #[[DOT_OP_PARENT]]
+    // CHECK: %[[DOT3_FMA_RES:.+]] = tt.dot %[[DOT3_OP_A]], %[[DOT3_OP_B]], %[[DOT3_OP_C]]
+    // CHECK-SAME: -> tensor<128x32xf32, #[[DOT_OP_PARENT]]>
+    %4 = tt.dot %0, %1, %3 : tensor<128x64xi16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x32xi16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x32xi16, #blocked>
+    // CHECK: arith.fptosi %[[DOT3_FMA_RES]]
+    // CHECK-SAME: to tensor<128x32xi16, #[[DOT_OP_PARENT]]>
+    tt.store %2, %4 : tensor<128x32x!tt.ptr<i16>, #blocked>
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -450,6 +450,56 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
       // FMA case.
       Type AElType = dotOp.getA().getType().getElementType();
       Type DElType = D.getType().getElementType();
+
+      // Convert int operands to FP32 to apply FMA case
+      // Do it here instead of introducing new pattern because the pass is more
+      // about MMA dots.
+      // TODO: Introduce new pass for FMA dots legalization.
+      if (AElType.isIntOrIndex()) {
+        assert(dotOp.getB().getType().getElementType().isIntOrIndex() &&
+               dotOp.getC().getType().getElementType().isIntOrIndex() &&
+               DElType.isIntOrIndex());
+        auto convertTensorIToFP = [&](Value v) -> Value {
+          RankedTensorType vTy = cast<RankedTensorType>(v.getType());
+          Type dstType = vTy.cloneWith(std::nullopt, builder.getF32Type());
+          Type srcElType = vTy.getElementType();
+          return !srcElType.isUnsignedInteger()
+                     ? builder
+                           .create<mlir::arith::SIToFPOp>(dotOp.getLoc(),
+                                                          dstType, v)
+                           .getResult()
+                     : builder
+                           .create<mlir::arith::UIToFPOp>(dotOp.getLoc(),
+                                                          dstType, v)
+                           .getResult();
+        };
+        auto convertTensorFPToI = [&](Type dstElType, Value v) -> Value {
+          RankedTensorType vTy = cast<RankedTensorType>(v.getType());
+          Type dstType = vTy.cloneWith(std::nullopt, dstElType);
+          return !dstElType.isUnsignedInteger()
+                     ? builder
+                           .create<mlir::arith::FPToSIOp>(dotOp.getLoc(),
+                                                          dstType, v)
+                           .getResult()
+                     : builder
+                           .create<mlir::arith::FPToUIOp>(dotOp.getLoc(),
+                                                          dstType, v)
+                           .getResult();
+        };
+
+        auto newAOperand = convertTensorIToFP(dotOp.getA());
+        auto newBOperand = convertTensorIToFP(dotOp.getB());
+        auto newCOperand = convertTensorIToFP(dotOp.getC());
+        auto newDot = builder.create<tt::DotOp>(
+            dotOp.getLoc(), newCOperand.getType(), newAOperand, newBOperand,
+            newCOperand, dotOp.getInputPrecision(),
+            dotOp.getMaxNumImpreciseAcc());
+        auto newD = convertTensorFPToI(DElType, newDot.getResult());
+        D.replaceAllUsesWith(newD);
+        dotOp.erase();
+        return;
+      }
+
       if (AElType == DElType)
         return;
       promoteType = DElType;


### PR DESCRIPTION
- Fixed int8 tests for Navi31
- Generate wmma instructions for int8 or int4 operands
- Convert operands to fp32 if initial type more than int8
- Convert result back to initial type after dot
- Add lit tests
