### PR TITLE
[BUILD] Add setup.py cmake options for lld standalone or mold for linking

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -379,6 +379,22 @@ class CMakeBuild(build_ext):
                 "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld",
             ]
 
+        if check_env_flag("TRITON_LINK_WITH_LLD"):
+            cmake_args += [
+                "-DCMAKE_LINKER=lld",
+                "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld",
+                "-DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld",
+                "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld",
+            ]
+
+        if check_env_flag("TRITON_LINK_WITH_MOLD"):
+            cmake_args += [
+                "-DCMAKE_LINKER=mold",
+                "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold",
+                "-DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=mold",
+                "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=mold",
+            ]
+
         # Note that asan doesn't work with binaries that use the GPU, so this is
         # only useful for tools like triton-opt that don't run code on the GPU.
         #


### PR DESCRIPTION
TRITON_BUILD_WITH_CLANG_LLD already allows for changing the build to use clang+lld instead of gcc+bfd but it doesn't allow for leaving the C/C++ compiler on gcc and mixing and matching linkers like lld as well as mold. This patch allows for enabling only a different linker.