### PR TITLE
[BACKEND][TMA] Fixing two bugs related to _experimental_descriptor_store lowering

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -224,11 +224,11 @@ def TTG_LocalStoreOp : TTG_Op<"local_store", [MemoryEffects<[MemWrite<SharedMemo
   let description = [{
     Store a distributed tensor into a buffer in local memory.
   }];
-  let arguments = (ins TT_Tensor:$src, TT_MemDescType:$result);
+  let arguments = (ins TT_Tensor:$src, TT_MemDescType:$dst);
 
   // Use qualified() otherwise "!tt.memdesc<X>" is printed as "<X>".
   let assemblyFormat = [{
-    $src `,` $result attr-dict `:` type($src) `->` qualified(type($result))
+    $src `,` $dst attr-dict `:` type($src) `->` qualified(type($dst))
   }];
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -16,7 +16,8 @@ using namespace mlir::triton::gpu;
 // Swizzling in shared memory to avoid bank conflict. Normally used for
 // A/B operands of dots.
 void lowerDistributedToShared(Location loc, Value src, Value dst,
-                              Value adaptorSrc, SharedMemoryObject smemObj,
+                              Value adaptorSrc,
+                              const SharedMemoryObject &smemObj,
                               const LLVMTypeConverter *typeConverter,
                               ConversionPatternRewriter &rewriter,
                               const TargetInfoBase &targetInfo) {

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -26,8 +26,8 @@ void lowerDistributedToShared(Operation *op, Value src, Value dst,
   auto dstShapePerCTA = triton::gpu::getShapePerCTA(dstTy);
   auto srcLayout = srcTy.getEncoding();
   auto outOrd = mlir::cast<SharedEncodingAttr>(dstTy.getEncoding()).getOrder();
-  assert(srcTy.getShape().size() == 2 ||
-         (srcTy.getShape().size() <= 3 && outOrd[2] == 0) &&
+  assert(srcTy.getShape().size() <= 2 ||
+         (srcTy.getShape().size() == 3 && outOrd[2] == 0) &&
              "Unexpected rank of ConvertLayout(blocked->shared)");
   Value smemBase = LLVM::getSharedMemoryBase(loc, rewriter, op);
   auto elemTy = typeConverter->convertType(srcTy.getElementType());

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -15,12 +15,11 @@ using namespace mlir::triton::gpu;
 // blocked -> shared.
 // Swizzling in shared memory to avoid bank conflict. Normally used for
 // A/B operands of dots.
-void lowerDistributedToShared(Operation *op, Value src, Value dst,
-                              Value adaptorSrc, Value smemBase,
+void lowerDistributedToShared(Location loc, Value src, Value dst,
+                              Value adaptorSrc, SharedMemoryObject smemObj,
                               const LLVMTypeConverter *typeConverter,
                               ConversionPatternRewriter &rewriter,
                               const TargetInfoBase &targetInfo) {
-  auto loc = op->getLoc();
   auto srcTy = cast<RankedTensorType>(src.getType());
   auto dstTy = cast<MemDescType>(dst.getType());
   auto dstShapePerCTA = triton::gpu::getShapePerCTA(dstTy);
@@ -31,10 +30,10 @@ void lowerDistributedToShared(Operation *op, Value src, Value dst,
              "Unexpected rank of ConvertLayout(blocked->shared)");
   auto elemTy = typeConverter->convertType(srcTy.getElementType());
 
+  auto smemBase = smemObj.getBase();
   int32_t elemSize = elemTy.getIntOrFloatBitWidth();
   unsigned numElems = triton::gpu::getTotalElemsPerThread(srcTy);
-  auto dstStrides =
-      LLVM::getStridesFromShapeAndOrder(dstShapePerCTA, outOrd, loc, rewriter);
+  auto dstStrides = smemObj.getStrides();
   auto inVals = unpackLLElements(loc, adaptorSrc, rewriter);
   storeDistributedToShared(src, inVals, dstStrides, dst, smemBase, elemTy, loc,
                            rewriter, targetInfo);
@@ -71,18 +70,16 @@ struct LocalAllocOpConversion
       newOrder = SmallVector<unsigned>(order.begin(), order.end());
     }
 
-    // If there is an initial tensor, store it into the shared memory.
-    if (op.getSrc()) {
-      Value smemBase = LLVM::getSharedMemoryBase(loc, rewriter, op);
-      lowerDistributedToShared(op, op.getSrc(), op.getResult(),
-                               adaptor.getSrc(), smemBase, typeConverter,
-                               rewriter, targetInfo);
-    }
-
     auto llvmElemTy = typeConverter->convertType(resultTy.getElementType());
     auto shapePerCTA = getShapePerCTA(sharedLayout, resultTy.getShape());
     auto smemObj = SharedMemoryObject(smemBase, llvmElemTy, shapePerCTA,
                                       newOrder, loc, rewriter);
+    // If there is an initial tensor, store it into the shared memory.
+    if (op.getSrc()) {
+      lowerDistributedToShared(loc, op.getSrc(), op.getResult(),
+                               adaptor.getSrc(), smemObj, typeConverter,
+                               rewriter, targetInfo);
+    }
     auto retVal = getStructFromSharedMemoryObject(loc, smemObj, rewriter);
     rewriter.replaceOp(op, retVal);
     return success();
@@ -120,13 +117,15 @@ public:
   LogicalResult
   matchAndRewrite(triton::gpu::LocalStoreOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value smemBase = LLVM::getSharedMemoryBase(op.getLoc(), rewriter,
-                                               op.getDst().getDefiningOp());
-    lowerDistributedToShared(op, op.getSrc(), op.getDst(), adaptor.getSrc(),
-                             smemBase, getTypeConverter(), rewriter,
-                             targetInfo);
+    Value memDescVal = op.getDst();
+    auto llvmElemTy =
+        getTypeConverter()->convertType(op.getDst().getType().getElementType());
+    auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
+        op.getLoc(), adaptor.getDst(), llvmElemTy, rewriter);
+    lowerDistributedToShared(op.getLoc(), op.getSrc(), op.getDst(),
+                             adaptor.getSrc(), smemObj, getTypeConverter(),
+                             rewriter, targetInfo);
     rewriter.eraseOp(op);
-
     return success();
   }
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2647,7 +2647,7 @@ struct CanonicalizeConvertFromLocalStore
     if (!convert)
       return failure();
     rewriter.replaceOpWithNewOp<triton::gpu::LocalStoreOp>(op, convert.getSrc(),
-                                                           op.getResult());
+                                                           op.getDst());
     return mlir::success();
   }
 };

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1579,6 +1579,20 @@ module attributes {"triton_gpu.target" = "cuda:80", "triton_gpu.num-ctas" = 1 : 
 }
 
 // -----
+#blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], hasLeadingOffset = false}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: test_local_store
+  // CHECK: llvm.store
+  tt.func public @test_local_store(%arg0: tensor<1xf32, #blocked>) {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = triton_gpu.local_alloc {allocation.offset = 0 : i32} : () -> !tt.memdesc<1xf32, #shared, mutable>
+    triton_gpu.local_store %arg0, %0 : tensor<1xf32, #blocked> -> !tt.memdesc<1xf32, #shared, mutable>
+    tt.return
+  }
+}
+
+// -----
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32} {


### PR DESCRIPTION
Fixing the assert in lowerDistributedToShared to allow rank 1 tensor stores.
Fix for trying to get shared memory base based on the incorrect op (not the alloca).