### PR TITLE
[AMD] Support K=8 cases for dot

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3107,9 +3107,8 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
             pytest.skip("kpack too large for K")
         if not is_hip() and kpack == 2:
             pytest.skip("Skip duplicated tests on nv path")
-        if not is_hip() and (M, N, K) == (16, 16, 8)
+        if not is_hip() and (M, N, K) == (16, 16, 8):
             pytest.skip("Unsupported dot sizes on nv path")
-
 
     torch.backends.cuda.matmul.allow_tf32 = input_precision == "tf32"
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -35,7 +35,7 @@ def is_hip():
 def get_arch():
     if is_interpreter():
         return ""
-    return triton.runtime.driver.active.get_current_target().arch
+    return str(triton.runtime.driver.active.get_current_target().arch)
 
 
 int_dtypes = ['int8', 'int16', 'int32', 'int64']

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3056,7 +3056,7 @@ def convert_fp8_to_fp32(x, device, dtype_str):
 @pytest.mark.parametrize(
     "M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack",
     [(*shape, 4, False, False, epilogue, input_precision, in_dtype, out_dtype, 1)
-     for shape in [(64, 64, 64), (32, 32, 32), (16, 16, 16), (16, 16, 8)]
+     for shape in [(64, 64, 64), (32, 32, 32), (16, 16, 16)] + ([(16, 16, 8)] if "gfx9" in get_arch() else [])
      for epilogue in ['none', 'trans', 'add-matrix', 'add-rows', 'add-cols', 'softmax', 'chain-dot']
      for input_precision in ['tf32', 'tf32x3', 'ieee']
      for in_dtype, out_dtype in [('float16', 'float16'), ('float16', 'float32'), ('float32', 'float32')]
@@ -3107,8 +3107,6 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
             pytest.skip("kpack too large for K")
         if not is_hip() and kpack == 2:
             pytest.skip("Skip duplicated tests on nv path")
-        if "gfx9" not in get_arch() and (M, N, K) == (16, 16, 8):
-            pytest.skip("Unsupported dot sizes on non-gfx9 path")
 
     torch.backends.cuda.matmul.allow_tf32 = input_precision == "tf32"
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3056,7 +3056,7 @@ def convert_fp8_to_fp32(x, device, dtype_str):
 @pytest.mark.parametrize(
     "M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack",
     [(*shape, 4, False, False, epilogue, input_precision, in_dtype, out_dtype, 1)
-     for shape in [(64, 64, 64), (32, 32, 32), (16, 16, 16)]
+     for shape in [(64, 64, 64), (32, 32, 32), (16, 16, 16), (16, 16, 8)]
      for epilogue in ['none', 'trans', 'add-matrix', 'add-rows', 'add-cols', 'softmax', 'chain-dot']
      for input_precision in ['tf32', 'tf32x3', 'ieee']
      for in_dtype, out_dtype in [('float16', 'float16'), ('float16', 'float32'), ('float32', 'float32')]
@@ -3107,6 +3107,9 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
             pytest.skip("kpack too large for K")
         if not is_hip() and kpack == 2:
             pytest.skip("Skip duplicated tests on nv path")
+        if not is_hip() and (M, N, K) == (16, 16, 8)
+            pytest.skip("Unsupported dot sizes on nv path")
+
 
     torch.backends.cuda.matmul.allow_tf32 = input_precision == "tf32"
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1370,7 +1370,7 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optiona
     assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
     assert lhs.shape[-1].value == rhs.shape[
         -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
-    if "gfx9" in builder.options.arch:
+    if hasattr(builder.options, "arch") and "gfx9" in builder.options.arch:
         assert lhs.shape[-2].value >= 16 and lhs.shape[-1].value >= 8 \
             and rhs.shape[-1].value >= 16, \
             f"The first input shape MxN = {lhs.shape} and the second input shape NxK = {rhs.shape} must have M>=16, N>=16, K>=8 for arch gfx9x"

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1322,7 +1322,7 @@ def _str_to_dot_input_precision(input_precision, builder):
 def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optional[str], max_num_imprecise_acc: int,
         out_dtype: tl.dtype, builder: ir.builder) -> tl.tensor:
 
-    def support_smaller_sizes():
+    def support_m16n16k8():
         return (hasattr(builder.options, "arch") and "gfx9" in str(builder.options.arch))
 
     def assert_dtypes_valid(lhs_dtype, rhs_dtype, options):
@@ -1373,7 +1373,7 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optiona
     assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
     assert lhs.shape[-1].value == rhs.shape[
         -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
-    if support_smaller_sizes():
+    if support_m16n16k8():
         assert lhs.shape[-2].value >= 16 and lhs.shape[-1].value >= 8 \
             and rhs.shape[-1].value >= 16, \
             f"The first input shape MxN = {lhs.shape} and the second input shape NxK = {rhs.shape} must have M>=16, N>=16, K>=8 for arch gfx9x"

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1322,6 +1322,9 @@ def _str_to_dot_input_precision(input_precision, builder):
 def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optional[str], max_num_imprecise_acc: int,
         out_dtype: tl.dtype, builder: ir.builder) -> tl.tensor:
 
+    def support_smaller_sizes():
+        return (hasattr(builder.options, "arch") and "gfx9" in str(builder.options.arch))
+
     def assert_dtypes_valid(lhs_dtype, rhs_dtype, options):
         if not options.allow_fp8e4nv:
             assert not lhs_dtype.is_fp8e4nv() and not rhs_dtype.is_fp8e4nv(
@@ -1370,7 +1373,7 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optiona
     assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
     assert lhs.shape[-1].value == rhs.shape[
         -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
-    if hasattr(builder.options, "arch") and "gfx9" in builder.options.arch:
+    if support_smaller_sizes():
         assert lhs.shape[-2].value >= 16 and lhs.shape[-1].value >= 8 \
             and rhs.shape[-1].value >= 16, \
             f"The first input shape MxN = {lhs.shape} and the second input shape NxK = {rhs.shape} must have M>=16, N>=16, K>=8 for arch gfx9x"

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1370,9 +1370,14 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optiona
     assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
     assert lhs.shape[-1].value == rhs.shape[
         -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
-    assert lhs.shape[-2].value >= 16 and lhs.shape[-1].value >= 16 \
-        and rhs.shape[-1].value >= 16, \
-        f"All non-batch values in both first input shape ({lhs.shape}) and second input shape ({rhs.shape}) must be >= 16!"
+    if "gfx9" in builder.options.arch:
+        assert lhs.shape[-2].value >= 16 and lhs.shape[-1].value >= 8 \
+            and rhs.shape[-1].value >= 16, \
+            f"The first input shape MxN = {lhs.shape} and the second input shape NxK = {rhs.shape} must have M>=16, N>=16, K>=8 for arch gfx9x"
+    else:
+        assert lhs.shape[-2].value >= 16 and lhs.shape[-1].value >= 16 \
+            and rhs.shape[-1].value >= 16, \
+            f"All non-batch values in both first input shape ({lhs.shape}) and second input shape ({rhs.shape}) must be >= 16!"
     if lhs.type.scalar.is_int():
         assert lhs.type.scalar == tl.int8, "only int8 supported!"
         # TODO: This is CUDA specific, check if ROCm has the same limitation

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1326,13 +1326,13 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optiona
     def support_m16n16k8():
         if not hasattr(builder.options, "arch"):
             return False
-        archStr = str(builder.options.arch)
+        arch_str = str(builder.options.arch)
         # CDNA 3.0 supports k==8 in all mfma variants except for int8
         # (where the smallest `k` supported is 16)
-        if "gfx94" in archStr:
-            return not (lhs.dtype.is_int8 or rhs.dtype.is_int8)
+        if "gfx94" in arch_str:
+            return not (lhs.dtype.is_int8() or rhs.dtype.is_int8())
         # CDNA 2.0 always supports `k==8`
-        return "gfx9" in archStr
+        return "gfx9" in arch_str
 
     def assert_dtypes_valid(lhs_dtype, rhs_dtype, options):
         if not options.allow_fp8e4nv:
@@ -1392,7 +1392,6 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optiona
             f"All non-batch values in both first input shape ({lhs.shape}) and second input shape ({rhs.shape}) must be >= 16!"
     if lhs.type.scalar.is_int():
         assert lhs.type.scalar == tl.int8, "only int8 supported!"
-        # TODO: This is CUDA specific, check if ROCm has the same limitation
         assert builder.options.backend_name != "cuda" or lhs.shape[1].value >= 32, "small blocks not supported!"
         _0 = builder.get_int32(0)
         ret_scalar_ty = tl.int32

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -81,6 +81,7 @@ class InterpreterOptions:
     default_dot_input_precision: str = "tf32"
     allowed_dot_input_precisions: Tuple[str] = ("tf32", "tf32x3", "ieee")
     max_num_imprecise_acc_default: int = 0
+    backend_name: str = "interpreter"
 
 
 def _get_signed_np_dtype(dtype):

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -18,7 +18,10 @@ def min_dot_size(target: GPUTarget):
     if "gfx94" in arch_str:
         return lambda lhsType, rhsType: (16, 16, 16) if (lhsType.is_int8() or rhsType.is_int8()) else (16, 16, 8)
     # CDNA 2.0 always supports `k==8`
-    return lambda lhsType, rhsType: (16, 16, 8)
+    if "gfx9" in arch_str:
+        return lambda lhsType, rhsType: (16, 16, 8)
+    # Other architectures will only support 16,16,16
+    return lambda lhsType, rhsType: (16, 16, 16)
 
 
 @dataclass(frozen=True)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -13,6 +13,10 @@ import subprocess
 from pathlib import Path
 
 
+def min_dot_size(target: GPUTarget):
+    return lambda lhsType, rhsType: (16, 32, 16) if lhsType.is_int8() else (16, 16, 16)
+
+
 @functools.lru_cache()
 def _path_to_binary(binary: str):
     paths = [
@@ -129,7 +133,8 @@ class CUDABackend(BaseBackend):
         import triton.language.extra.cuda as cuda
         codegen_fns = {
             "convert_custom_types":
-            cuda.convert_custom_float8_sm80 if self.capability >= 80 else cuda.convert_custom_float8_sm70
+            cuda.convert_custom_float8_sm80 if self.capability >= 80 else cuda.convert_custom_float8_sm70,
+            "min_dot_size": min_dot_size(self.target)
         }
         return codegen_fns
 


### PR DESCRIPTION
This is my first PR in Triton, and it is trying to fix the limitation on `dot` to support sizes bigger than `(M,N,K)==(16,16,16)`. 

I modified `semantic.py` to relax the `tt.dot` limitations on the size of the matrices (for `gfx9` architectures). Please note that there is a [supportMFMA function](https://github.com/triton-lang/triton/blob/d7c8b3d7890125f5fc1b9f046e3189baa2665be4/lib/Analysis/Utility.cpp#L458)  that only accepts `MN` sizes multiple of 16 and `K` sizes multiple of 8.

Based on that, I relaxed the restriction in `semantics.py` to support `(M,N,K)>=(16,16,8)`.  This is the minimal change. 

If we want to push further, we would need change `supportMFMA` and add tests for smaller layouts (many of those smaller layouts are broadcast layouts. Do we support this in the AMD backend?)

Please note: for now, if I try to feed a smaller layout (e.g., 8x8x8) the test fails by mismatches. 