### PR TITLE
Add support for TMA store accumulate

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
+++ b/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
@@ -118,4 +118,19 @@ def TT_InputPrecisionAttr : I32EnumAttr<
   let cppNamespace = "::mlir::triton";
 }
 
+// Store reduction operations.
+def TT_DescStoreReductionAttr : I32EnumAttr<
+    "DescStoreReduction", "",
+    [
+      I32EnumAttrCase<"NONE", 0, "none">,
+      I32EnumAttrCase<"ADD", 1, "add">,
+      I32EnumAttrCase<"MIN", 2, "min">,
+      I32EnumAttrCase<"MAX", 3, "max">,
+      I32EnumAttrCase<"AND", 4, "and">,
+      I32EnumAttrCase<"OR", 5, "or">,
+      I32EnumAttrCase<"XOR", 6, "xor">,
+    ]>{
+  let cppNamespace = "::mlir::triton";
+}
+
 #endif

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -1137,11 +1137,12 @@ def TT_ExperimentalDescriptorStoreOp : TT_Op<"experimental_descriptor_store", [
       ins
       TT_PtrType:$desc_ptr,
       TT_Tensor:$src,
-      Variadic<I32>:$indices
+      Variadic<I32>:$indices,
+      TT_DescStoreReductionAttr:$reduction_op
     );
 
     let assemblyFormat = [{
-      $desc_ptr `[` $indices `]` `,` $src
+      $desc_ptr `[` $indices `]` `,` $src `,` `reduction_op` `=` $reduction_op
       attr-dict `:` qualified(type($desc_ptr)) `,` type($src)
     }];
 }

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -206,10 +206,11 @@ def TTNG_AsyncTMACopyLocalToGlobalOp : TTNG_Op<"async_tma_copy_local_to_global",
   let arguments = (
     ins TT_PtrType:$desc_ptr,
     Variadic<I32>:$coord,
-    TT_MemDescType:$src);
+    TT_MemDescType:$src,
+    TT_DescStoreReductionAttr:$reduction_op);
 
   let assemblyFormat = [{
-    $desc_ptr `[` $coord `]` $src
+    $desc_ptr `[` $coord `]` $src `,` `reduction_op` `=` $reduction_op
     attr-dict `:` type($desc_ptr) `,` type($src)
   }];
 }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
@@ -61,8 +61,9 @@ static void createTMAAsyncCopy(scf::ForOp &forOp,
   builder.create<ttng::TMAStoreWait>(loc, 0);
   builder.create<ttg::LocalStoreOp>(loc, storeOp.getSrc(), alloc);
   builder.create<ttng::FenceAsyncSharedOp>(loc, false);
-  builder.create<ttng::AsyncTMACopyLocalToGlobalOp>(
-      loc, storeOp.getDescPtr(), storeOp.getIndices(), alloc);
+  builder.create<ttng::AsyncTMACopyLocalToGlobalOp>(loc, storeOp.getDescPtr(),
+                                                    storeOp.getIndices(), alloc,
+                                                    storeOp.getReductionOp());
 
   storeOp->erase();
 }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -83,7 +83,7 @@ public:
     Value alloc = rewriter.create<LocalAllocOp>(loc, memDescType, op.getSrc());
     rewriter.create<triton::nvidia_gpu::FenceAsyncSharedOp>(loc, false);
     rewriter.create<triton::nvidia_gpu::AsyncTMACopyLocalToGlobalOp>(
-        loc, op.getDescPtr(), op.getIndices(), alloc);
+        loc, op.getDescPtr(), op.getIndices(), alloc, op.getReductionOp());
     rewriter.create<triton::nvidia_gpu::TMAStoreWait>(loc, 0);
     rewriter.eraseOp(op);
     return success();

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1,4 +1,4 @@
-#include <pybind11/functional.h>
+﻿#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -198,6 +198,15 @@ void init_triton_ir(py::module &&m) {
       .value("TF32x3", InputPrecision::TF32x3)
       .value("IEEE", InputPrecision::IEEE)
       .export_values();
+
+  py::enum_<DescStoreReduction>(m, "DESC_STORE_REDCUTION", py::module_local())
+      .value("NONE", DescStoreReduction::NONE)
+      .value("ADD", DescStoreReduction::ADD)
+      .value("MIN", DescStoreReduction::MIN)
+      .value("MAX", DescStoreReduction::MAX)
+      .value("AND", DescStoreReduction::AND)
+      .value("OR", DescStoreReduction::OR)
+      .value("XOR", DescStoreReduction::XOR);
 
   py::class_<MLIRContext>(m, "context", py::module_local()).def(py::init<>());
 
@@ -1255,9 +1264,10 @@ void init_triton_ir(py::module &&m) {
            })
       .def("create_descriptor_store",
            [](TritonOpBuilder &self, Value &desc_ptr, Value value,
-              std::vector<Value> &indices) -> void {
+              std::vector<Value> &indices,
+              DescStoreReduction reductionOp) -> void {
              self.create<ExperimentalDescriptorStoreOp>(desc_ptr, value,
-                                                        indices);
+                                                        indices, reductionOp);
            })
       .def("create_reshape",
            [](TritonOpBuilder &self, Value &arg, std::vector<int64_t> &shape,

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1611,14 +1611,16 @@ def _experimental_descriptor_load(desc_pointer, offsets, shape, dtype, _builder=
 
 
 @builtin
-def _experimental_descriptor_store(desc_pointer, value, offsets, _builder=None):
+def _experimental_descriptor_store(desc_pointer, value, offsets, accumulator_fn="", _builder=None):
     """
     Experimental feature to access TMA descriptors stores. This is an escape hatch to easily exercise TTGIR operations.
     This will be removed in the future and shouldn't be used in production code.
 
-    This stores a tensor of data based on the descriptor and offsets.
+    This stores a tensor of data based on the descriptor and offsets. If accumulator_fn is provided the store will combine
+    the value with the existing memory using the provided function.
+    accumulator_fn supported are `add`, `max`, `min`, `and`, `or`, `xor`.
     """
-    return semantic.descriptor_store(desc_pointer, value, offsets, _builder)
+    return semantic.descriptor_store(desc_pointer, value, offsets, accumulator_fn, _builder)
 
 
 @_tensor_member_fn

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -50,7 +50,21 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
   // CHECK: "@$0 cp.async.bulk.tensor.2d.global.shared::cta.bulk_group [$1, {$2, $3}], [$4];", "b,l,r,r,r" {{.*}} : (i1, !llvm.ptr<1>, i32, i32, !llvm.ptr<3>) -> !llvm.void
   // CHECK: cp.async.bulk.commit_group
   tt.func @tma_copy_local_to_global(%tma: !tt.ptr<i64>, %alloc: !tt.memdesc<128x128xf32, #shared1>, %x: i32) {
-    triton_nvidia_gpu.async_tma_copy_local_to_global %tma[%x, %x] %alloc : <i64>, <128x128xf32, #shared1>
+    triton_nvidia_gpu.async_tma_copy_local_to_global %tma[%x, %x] %alloc, reduction_op = none : <i64>, <128x128xf32, #shared1>
+    tt.return
+  }
+}
+
+// -----
+
+#shared1 = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32} {
+  // CHECK-LABEL: tma_copy_local_to_global_add
+  // CHECK: elect.sync
+  // CHECK: "@$0 cp.reduce.async.bulk.tensor.2d.global.shared::cta.add.bulk_group [$1, {$2, $3}], [$4];", "b,l,r,r,r" {{.*}} : (i1, !llvm.ptr<1>, i32, i32, !llvm.ptr<3>) -> !llvm.void
+  // CHECK: cp.async.bulk.commit_group
+  tt.func @tma_copy_local_to_global_add(%tma: !tt.ptr<i64>, %alloc: !tt.memdesc<128x128xf32, #shared1>, %x: i32) {
+    triton_nvidia_gpu.async_tma_copy_local_to_global %tma[%x, %x] %alloc, reduction_op = add : <i64>, <128x128xf32, #shared1>
     tt.return
   }
 }

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -705,7 +705,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
       // CHECK-NEXT: triton_gpu.local_store
       // CHECK-NEXT: triton_nvidia_gpu.fence_async_shared
       // CHECK-NEXT: triton_nvidia_gpu.async_tma_copy_local_to_global
-      tt.experimental_descriptor_store %arg1[%1], %arg0 : !tt.ptr<i8>, tensor<1xf32, #blocked>
+      tt.experimental_descriptor_store %arg1[%1], %arg0, reduction_op = none : !tt.ptr<i8>, tensor<1xf32, #blocked>
     }
     tt.return
   }

--- a/test/TritonNvidiaGPU/tma_lowering.mlir
+++ b/test/TritonNvidiaGPU/tma_lowering.mlir
@@ -23,9 +23,9 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
 // CHECK-LABEL: tma_store
 //       CHECK: triton_gpu.local_alloc
 //       CHECK: triton_nvidia_gpu.fence_async_shared {bCluster = false}
-//       CHECK: triton_nvidia_gpu.async_tma_copy_local_to_global
+//       CHECK: triton_nvidia_gpu.async_tma_copy_local_to_global {{.*}} reduction_op = none
   tt.func public @tma_store(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: tensor<128x256xf32, #blocked>) {
-    tt.experimental_descriptor_store %arg0[%arg1, %arg1], %arg2 : !tt.ptr<i8>, tensor<128x256xf32, #blocked>
+    tt.experimental_descriptor_store %arg0[%arg1, %arg1], %arg2, reduction_op = none : !tt.ptr<i8>, tensor<128x256xf32, #blocked>
     tt.return
   }
 }


### PR DESCRIPTION
When using TMA we can accumulate into memory instead of doing an overwrite store. Expose this by adding an accumulate_fn operand to the experimental store.