### PR TITLE
[BACKEND] Optimize TMA barriers when pipelining

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -138,6 +138,26 @@ def TTNG_InvalBarrierOp : TTNG_Op<"inval_barrier", [MemoryEffects<[MemWrite<Shar
     let assemblyFormat = "$alloc attr-dict `:` type($alloc)";
 }
 
+def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [
+  MemoryEffects<[MemRead<GlobalMemory>, MemWrite<SharedMemory>]>]> {
+  let summary = "Signal a barrier of an expected number of bytes to be copied.";
+
+  let description = [{
+    This signal the barrier that `size` bytes are expected to be copied. The
+    associated barrier wait will block until the expected number of bytes are copied.
+  }];
+
+  let hasVerifier = 1;
+  let arguments = (
+    ins TT_MemDescType:$alloc,
+    I32Attr:$size,
+    I1:$pred
+  );
+
+  let assemblyFormat = [{
+    $alloc `,` $size attr-dict `,` $pred `:` type($alloc)
+  }];
+}
 
 def TTNG_WaitBarrierOp : TTNG_Op<"wait_barrier", []> {
     let summary = "wait until the mbarrier phase completes.";

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -309,12 +309,11 @@ static void createAsyncCopy(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
   loadOp.erase();
 }
 
-static void
-createTMAAsyncCopy(scf::ForOp &forOp, tt::ExperimentalDescriptorLoadOp loadOp,
-                   Value alloc, Value insertIdx, Value extractIdx,
-                   Value barrier, Value phase, CoarseSchedule &schedule,
-                   llvm::MapVector<Operation *, LoadInfo> &loadToInfo,
-                   int numStages) {
+static void createTMAAsyncCopy(
+    scf::ForOp &forOp, tt::ExperimentalDescriptorLoadOp loadOp, Value alloc,
+    Value insertIdx, Value extractIdx, Value barrier, Operation *waitOp,
+    Value phase, CoarseSchedule &schedule,
+    llvm::MapVector<Operation *, LoadInfo> &loadToInfo, int numStages) {
   assert(phase && "Phase value is required for TMA async copy.");
   OpBuilder builder(forOp);
   Value zero = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 0, 32);
@@ -329,27 +328,16 @@ createTMAAsyncCopy(scf::ForOp &forOp, tt::ExperimentalDescriptorLoadOp loadOp,
   auto view =
       builder.create<ttg::MemDescSubviewOp>(loc, subviewTy, alloc, copyOffsets);
 
-  tt::MemDescType barrierTy = tt::MemDescType::get(
-      {1}, builder.getI64Type(),
-      cast<tt::MemDescType>(barrier.getType()).getEncoding(),
-      /*mutableMemory=*/true);
-  Value barrierViewCopy = builder.create<ttg::MemDescSubviewOp>(
-      loc, barrierTy, barrier, ArrayRef<Value>({insertIdx}));
   Value pred = builder.create<arith::ConstantIntOp>(loc, 1, 1);
   Operation *copy = builder.create<ttng::AsyncTMACopyGlobalToLocalOp>(
-      loc, loadOp.getDescPtr(), loadOp.getIndices(), barrierViewCopy, view,
-      pred);
-
-  Value barrierViewWait = builder.create<ttg::MemDescSubviewOp>(
-      loc, barrierTy, barrier, ArrayRef<Value>({extractIdx}));
-  Operation *wait =
-      builder.create<ttng::WaitBarrierOp>(loc, barrierViewWait, phase);
+      loc, loadOp.getDescPtr(), loadOp.getIndices(), barrier, view, pred);
 
   bool isMMV3Load = loadToInfo[loadOp].loadIsMMAV3;
   auto [stage, cluster] = schedule[loadOp];
   schedule.erase(loadOp);
   schedule.insert(copy, stage, cluster);
 
+  builder.setInsertionPointAfter(waitOp);
   // Extract part.
   SmallVector<Value> loadOffsets(allocTy.getRank(), zero);
   loadOffsets[0] = extractIdx;
@@ -950,18 +938,122 @@ static Value createBarrierAlloc(scf::ForOp &forOp, unsigned distance) {
   return barrierAlloc;
 }
 
+struct AsyncLoad {
+  AsyncLoad(Operation *loadOp, Value alloc) : loadOp(loadOp), alloc(alloc) {}
+  Operation *loadOp;
+  Value alloc;
+  Value barrier;
+  Operation *waitOp = nullptr;
+  bool isTMALoad = false;
+};
+
+// Create barriers and wait ops for the async loads. Barriers may be shared by
+// multiple loads is the schedule allows it.
+static void createTMABarrierAndWait(
+    scf::ForOp &forOp, SmallVector<AsyncLoad> &asyncLoads, Value insertIdx,
+    Value extractIdx, Value phase, int numBuffers, CoarseSchedule &schedule,
+    SmallVector<Value> &barriers,
+    const llvm::MapVector<Operation *, LoadInfo> &loadToInfo) {
+  llvm::SmallDenseMap<Operation *, AsyncLoad *> loadToAsyncLoad;
+  for (AsyncLoad &asyncLoad : asyncLoads) {
+    loadToAsyncLoad[asyncLoad.loadOp] = &asyncLoad;
+  }
+  SmallVector<SmallVector<AsyncLoad *>> loadGroups;
+  llvm::SmallDenseSet<Operation *> visited;
+  Block *forBlock = forOp.getBody();
+  // Find groups of loads that can share the same barrier. We look consecutive
+  // loads and check that there are uses in between.
+  for (AsyncLoad &asyncLoad : asyncLoads) {
+    if (!asyncLoad.isTMALoad || visited.count(asyncLoad.loadOp))
+      continue;
+    llvm::SmallDenseSet<Operation *> users;
+    SmallVector<AsyncLoad *> group;
+    auto addToGroup = [&](AsyncLoad *loadInfo) {
+      group.push_back(loadInfo);
+      visited.insert(loadInfo->loadOp);
+      for (Operation *user : loadInfo->loadOp->getUsers()) {
+        auto it = loadToInfo.find(loadInfo->loadOp);
+        if (it != loadToInfo.end()) {
+          // Special case for MMAv3 loads, we can ignore the alloc and only
+          // consider uses of the alloc op since it will be removed.
+          if (it->second.loadIsMMAV3) {
+            auto alloc = cast<ttg::LocalAllocOp>(
+                (*loadInfo->loadOp->getUsers().begin()));
+            if (alloc->getBlock() == forBlock) {
+              users.insert(alloc->getUsers().begin(), alloc->getUsers().end());
+              continue;
+            }
+          }
+        }
+        Operation *userInBlock = forBlock->findAncestorOpInBlock(*user);
+        if (userInBlock)
+          users.insert(userInBlock);
+      }
+    };
+    addToGroup(&asyncLoad);
+    Operation *nextOp = asyncLoad.loadOp->getNextNode();
+    while (nextOp) {
+      if (users.count(nextOp) || visited.count(nextOp))
+        break;
+      if (isa<tt::ExperimentalDescriptorLoadOp>(nextOp)) {
+        auto it = loadToAsyncLoad.find(nextOp);
+        if (it != loadToAsyncLoad.end() && it->second->isTMALoad) {
+          addToGroup(it->second);
+        }
+      }
+      nextOp = nextOp->getNextNode();
+    }
+    loadGroups.push_back(group);
+  }
+
+  // For each group calculate the size and insert the barrier after the last
+  // load.
+  for (SmallVector<AsyncLoad *> &group : loadGroups) {
+    int sizeInBytes = 0;
+    for (AsyncLoad *asyncLoad : group) {
+      auto tensorTy =
+          cast<RankedTensorType>(asyncLoad->loadOp->getResult(0).getType());
+      int loadSize = product(tensorTy.getShape());
+      sizeInBytes +=
+          loadSize * tensorTy.getElementType().getIntOrFloatBitWidth() / 8;
+    }
+
+    Value barrierAlloc = createBarrierAlloc(forOp, numBuffers);
+    barriers.push_back(barrierAlloc);
+    Location loc = forOp.getLoc();
+    OpBuilder builder(forOp);
+    tt::MemDescType barrierTy = tt::MemDescType::get(
+        {1}, builder.getI64Type(),
+        cast<tt::MemDescType>(barrierAlloc.getType()).getEncoding(),
+        /*mutableMemory=*/true);
+    builder.setInsertionPoint(group[0]->loadOp);
+    Value barrier = builder.create<ttg::MemDescSubviewOp>(
+        loc, barrierTy, barrierAlloc, ArrayRef<Value>({insertIdx}));
+    Value pred = builder.create<arith::ConstantIntOp>(loc, 1, 1);
+    Operation *expect = builder.create<ttng::BarrierExpectOp>(
+        forOp.getLoc(), barrier, sizeInBytes, pred);
+    auto [stage, cluster] = schedule[asyncLoads[0].loadOp];
+    schedule.insert(expect, stage, cluster);
+
+    builder.setInsertionPointAfter(group.back()->loadOp);
+    Value barrierViewWait = builder.create<ttg::MemDescSubviewOp>(
+        loc, barrierTy, barrierAlloc, ArrayRef<Value>({extractIdx}));
+    Operation *wait =
+        builder.create<ttng::WaitBarrierOp>(loc, barrierViewWait, phase);
+    // Update the async loads info.
+    for (AsyncLoad *asyncLoad : group) {
+      asyncLoad->barrier = barrier;
+      asyncLoad->waitOp = wait;
+    }
+  }
+}
+
 // Convert load ops into their asyn version and apply multi-buffering based on
 // the required number of buffers.
 static SmallVector<Value>
 createAsyncOps(scf::ForOp &forOp, CoarseSchedule &schedule,
                llvm::MapVector<Operation *, LoadInfo> &loadToInfo,
                SmallVector<Value> &barriers, int numStages) {
-  struct AsyncLoad {
-    AsyncLoad(Operation *loadOp, Value alloc) : loadOp(loadOp), alloc(alloc) {}
-    Operation *loadOp;
-    Value alloc;
-    Value barrier;
-  };
   // Calculate the number of buffers needed for each load.
   // TODO pawel: we could do more fine-grained allocation here and
   // allocate only the number of buffers that specific loads need.
@@ -990,8 +1082,7 @@ createAsyncOps(scf::ForOp &forOp, CoarseSchedule &schedule,
     asyncLoads.emplace_back(loadOp, alloc);
     if (isa<tt::ExperimentalDescriptorLoadOp>(loadOp)) {
       hasTMALoad = true;
-      asyncLoads.back().barrier = createBarrierAlloc(forOp, numBuffers);
-      barriers.push_back(asyncLoads.back().barrier);
+      asyncLoads.back().isTMALoad = true;
     }
   }
 
@@ -1043,6 +1134,8 @@ createAsyncOps(scf::ForOp &forOp, CoarseSchedule &schedule,
     Value nextPhase = builder.create<arith::XOrIOp>(loc, phase, one);
     phase = builder.create<arith::SelectOp>(loc, cndExt, phase, nextPhase);
   }
+  createTMABarrierAndWait(forOp, asyncLoads, insertIdx, extractIdx, phase,
+                          numBuffers, schedule, barriers, loadToInfo);
 
   // Create a cluster for the prefetches. It may end up being empty, but this
   // is OK.
@@ -1055,8 +1148,8 @@ createAsyncOps(scf::ForOp &forOp, CoarseSchedule &schedule,
     } else {
       auto descLoad = cast<tt::ExperimentalDescriptorLoadOp>(asyncLoad.loadOp);
       createTMAAsyncCopy(forOp, descLoad, asyncLoad.alloc, insertIdx,
-                         extractIdx, asyncLoad.barrier, phase, schedule,
-                         loadToInfo, numStages);
+                         extractIdx, asyncLoad.barrier, asyncLoad.waitOp, phase,
+                         schedule, loadToInfo, numStages);
     }
   }
   SmallVector<Value> newYieldOperands = {insertIdx, extractIdx};

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -61,6 +61,13 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
     copyOp.getPredMutable().assign(mask);
     return op;
   }
+  if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op)) {
+    rewriter.setInsertionPoint(expectOp);
+    Value mask = getPredMask(rewriter, expectOp.getPred().getType(),
+                             expectOp.getPred(), pred);
+    expectOp.getPredMutable().assign(mask);
+    return op;
+  }
 
   assert("don't know how to predicate this op" && false);
   return op;

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -90,6 +90,13 @@ LogicalResult InvalBarrierOp::verify() {
   return success();
 }
 
+// -- BarrierExpectOp --
+LogicalResult BarrierExpectOp::verify() {
+  if (failed(verifyBarrierType(*this, getAlloc().getType())))
+    return failure();
+  return success();
+}
+
 // -- WaitBarrierOp --
 LogicalResult WaitBarrierOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -32,8 +32,6 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_global_to_local
   // CHECK: elect.sync
-  // CHECK: "@$0 mbarrier.arrive.expect_tx.shared.b64 _, [$1], 65536;", "b,r" %{{.*}}, %{{.*}} : (i1, !llvm.ptr<3>) -> !llvm.void
-  // CHECK: nvvm.barrier0
   // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];", "b,r,l,r,r,r" {{.*}} : (i1, !llvm.ptr<3>, !llvm.ptr<1>, i32, i32, !llvm.ptr<3>) -> !llvm.void
   tt.func @tma_copy_global_to_local(%tma: !tt.ptr<i64>, %alloc: !tt.memdesc<128x128xf32, #shared1>, %x: i32, %barrier: !tt.memdesc<1xi64, #shared0>, %pred: i1) {
     triton_nvidia_gpu.async_tma_copy_global_to_local %tma[%x, %x] %alloc, %barrier, %pred : !tt.ptr<i64>, !tt.memdesc<1xi64, #shared0> -> !tt.memdesc<128x128xf32, #shared1>
@@ -63,6 +61,18 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
   // CHECK: "cp.async.bulk.wait_group.read 0x0;", ""  : () -> !llvm.void
   tt.func @async_tma_store_wait() {
     triton_nvidia_gpu.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#shared0 = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32} {
+  // CHECK-LABEL: expect_barrier
+  // CHECK: @$0 mbarrier.arrive.expect_tx.shared.b64 _, [$1], 16384;
+  tt.func @expect_barrier(%barrier: !tt.memdesc<1xi64, #shared0, mutable>, %pred: i1) {
+    triton_nvidia_gpu.barrier_expect %barrier, 16384, %pred : <1xi64, #shared0, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -1569,14 +1569,13 @@ module attributes {"triton_gpu.target" = "cuda:90", "triton_gpu.num-ctas" = 1 : 
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
 //   CHECK-LABEL: @matmul_tma
 //     CHECK-DAG:   triton_gpu.local_alloc  : () -> !tt.memdesc<3x128x64xf16, #{{.+}}, mutable>
-//     CHECK-DAG:   triton_gpu.local_alloc  : () -> !tt.memdesc<3xi64, #{{.+}}, mutable>
-//         CHECK:   triton_nvidia_gpu.init_barrier
 //     CHECK-DAG:   triton_gpu.local_alloc  : () -> !tt.memdesc<3x64x256xf16, #{{.+}}, mutable>
 //     CHECK-DAG:   triton_gpu.local_alloc  : () -> !tt.memdesc<3xi64, #{{.+}}, mutable>
 // CHECK-COUNT-3:   triton_nvidia_gpu.init_barrier
 // CHECK-COUNT-4:   triton_nvidia_gpu.async_tma_copy_global_to_local
 //         CHECK:   scf.for
-// CHECK-COUNT-2:     triton_nvidia_gpu.wait_barrier
+//         CHECK:     triton_nvidia_gpu.wait_barrier
+//     CHECK-NOT:     triton_nvidia_gpu.wait_barrier
 // CHECK-COUNT-2:     triton_nvidia_gpu.async_tma_copy_global_to_local
 //         CHECK:     scf.yield
   tt.func public @matmul_tma(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i8> {tt.divisibility = 16 : i32}) -> tensor<128x256xf32, #mma> {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -934,16 +934,6 @@ struct AsyncTMACopyGlobalToLocalOpConversion
         op.getResult().getType().getElementType().getIntOrFloatBitWidth() / 8;
     int totalNumElements = product(op.getResult().getType().getShape());
     int64_t size = totalNumElements * elementSizeInBytes;
-    ::mlir::triton::PTXBuilder ptxBuilder;
-    auto &arrive = *ptxBuilder.create<>(
-        "@$0 mbarrier.arrive.expect_tx.shared.b64 _, [$1], " +
-        std::to_string(size) + ";");
-    arrive({ptxBuilder.newOperand(pred, "b"),
-            ptxBuilder.newOperand(barrierMemObj.getBase(), "r")},
-           /*onlyAttachMLIRArgs=*/true);
-    ptxBuilder.launch(rewriter, loc, voidTy);
-
-    barrier();
 
     int innerBlockSize = op.getResult().getType().getShape().back();
     int contigDimSizeInByte = innerBlockSize * elementSizeInBytes;


### PR DESCRIPTION
Allow re-using barriers for multiple copies to reduce the number of barriers op.