### PR TITLE
Flush Exact L2 Cache Size in Benchmarking

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -24,8 +24,8 @@ class Autotuner(KernelInterface):
         pre_hook=None,
         post_hook=None,
         prune_configs_by: Dict = None,
-        warmup=25,
-        rep=100,
+        warmup=15,
+        rep=60,
         use_cuda_graph=False,
     ):
         """
@@ -261,7 +261,7 @@ class Config:
 
 
 def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_value=None, pre_hook=None, post_hook=None,
-             warmup=25, rep=100, use_cuda_graph=False):
+             warmup=15, rep=60, use_cuda_graph=False):
     """
     Decorator for auto-tuning a :code:`triton.jit`'d function.
 

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -92,7 +92,7 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None, return_mode="mean"):
     return getattr(torch, return_mode)(times).item()
 
 
-def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flush=True, return_mode="mean"):
+def do_bench(fn, warmup=15, rep=60, grad_to_none=None, quantiles=None, fast_flush=True, return_mode="mean"):
     """
     Benchmark the runtime of the provided function. By default, return the median runtime of :code:`fn` along with
     the 20-th and 80-th performance percentile.

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -130,12 +130,12 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
 
   // create a struct to hold device properties
   return Py_BuildValue(
-      "{s:i, s:i, s:i, s:i, s:i, s:i, s:s, s:i}", "max_shared_mem",
+      "{s:i, s:i, s:i, s:i, s:i, s:i, s:s, s:i, s:i}", "max_shared_mem",
       props.sharedMemPerBlock, "max_num_regs", props.regsPerBlock,
       "multiprocessor_count", props.multiProcessorCount, "sm_clock_rate",
       props.clockRate, "mem_clock_rate", props.memoryClockRate, "mem_bus_width",
       props.memoryBusWidth, "arch", props.gcnArchName, "warpSize",
-      props.warpSize);
+      props.warpSize, "L2_cache_size", props.l2CacheSize);
 }
 
 static PyObject *loadBinary(PyObject *self, PyObject *args) {

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -55,6 +55,7 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
   int sm_clock_rate;
   int mem_clock_rate;
   int mem_bus_width;
+  int L2_cache_size;
   CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
       &max_shared_mem, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
       device));
@@ -70,13 +71,15 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
       &mem_clock_rate, CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, device));
   CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
       &mem_bus_width, CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH, device));
+  CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+      &L2_cache_size, CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, device));
 
-  return Py_BuildValue("{s:i, s:i, s:i, s:i, s:i, s:i, s:i}", "max_shared_mem",
+  return Py_BuildValue("{s:i, s:i, s:i, s:i, s:i, s:i, s:i, s:i}", "max_shared_mem",
                        max_shared_mem, "max_num_regs", max_num_regs,
                        "multiprocessor_count", multiprocessor_count, "warpSize",
                        warp_size, "sm_clock_rate", sm_clock_rate,
                        "mem_clock_rate", mem_clock_rate, "mem_bus_width",
-                       mem_bus_width);
+                       mem_bus_width, "L2_cache_size", L2_cache_size);
 }
 
 static PyObject *loadBinary(PyObject *self, PyObject *args) {


### PR DESCRIPTION
I'm currently working on reducing Inductor's compile time overhead in max-autotune-gemm mode. As part of this effort, I profiled some individual matmul autotunings and noticed that `do_bench` was particularly expensive. At first I thought, "well that makes sense, that is where the benchmarking takes place after all", but something still seemed off. Benchmarking ~30 template choices, for a relatively small kernel whose runtime should be about ~0.1ms, was still taking upwards of 30s. Numbers didn't seem to add up; we use the default warmup/rep settings (25ms and 100ms, respectively), and I was assuming even with overhead we shouldn't be taking more than 0.5s to benchmark each choice. So, I dug into the source code of `do_bench`. Some lines immediately jumped out at me...

> `# We maintain a buffer of 256 MB that we clear`
> `# before each kernel call to make sure that the L2`
> `# doesn't contain any input data before the run`
> `if fast_flush:`
> `   cache = torch.empty(int(256e6 // 4), dtype=torch.int, device='cuda')`
> `else:`
>  `  cache = torch.empty(int(256e6), dtype=torch.int8, device='cuda').`

Wow, 256MB seems like a lot to flush especially if we're doing so for each timing iteration. For small kernels we might do >1000 timing iterations, that's a total of 256GB flushed to benchmark a single template choice!

Just to be sure, I went ahead and removed the cache flushing. Obviously, the performance results were totally bogus as we were now hitting the cache left and right! But, more importantly, the benchmarking overhead dropped like a rock! We were now observing an overhead much closer to warmup + rep.

So, is there a way to reduce the size of the flush without impacting performance? Yes! We can flush the actual cache size, that should reduce overhead without impacting performance! We tried exactly that; by querying and flushing the exact L2 cache size from the third-party drivers we were able to reduce the runtime of the matrix multiplication tutorial from 48s to 30s on our local H100 machine. Important notice here that we decided to hardcode n_warmup/n_repetition to 100/400 since the current calculation to set these values is actually dependent on the cache flushing overhead (since the cache flushing is included in the runtime estimation timing).

But do these numbers make sense? Let's check it out. An H100 has a 50MB L2 cache, so we've effectively reduced the size of each cache flush by 206MB. Cache flushing doesn't occur in the warmup stage, so for each benchmark we only do 5 (estimation loop) + 400 (timing loop) = 405 individual flushes. Saving 206MB per flush that is a total of 83.43GB of flushing saved per benchmark. The matrix multiplication tutorial covers 31 different matmuls, and each is given 16 different configs during the autotuning stage. So, in total we need to do 31 * 16 = 496 benchmarks. That gives us an overall savings of ~41.4TB of flushing! Assuming all cache flushes occur at or close to the 2TB/s memory bandwidth limit on H100, this equates to ~20s saved. This seems to check out, since in practice we saved 18s!