### PR TITLE
Add maxnreg kernel config.

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -87,6 +87,7 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
       // Set an attribute to indicate this function is a kernel entry.
       newFuncOp->setAttr("nvvm.kernel",
                          rewriter.getIntegerAttr(type::u1Ty(ctx), 1));
+      newFuncOp.setLinkage(LLVM::Linkage::External);
     } else {
       // The noinline attribute will be used by the LLVM codegen to prevent
       // inlining.
@@ -94,6 +95,7 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
       newFuncOp.setPassthroughAttr(
           ArrayAttr::get(ctx, rewriter.getStringAttr("noinline")));
       rewriter.eraseOp(amendedFuncOp);
+      newFuncOp.setLinkage(LLVM::Linkage::Internal);
     }
     // Set an attribute for maxntidx, it could be used in latter LLVM codegen
     // for `nvvm.annotation` metadata.

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5317,6 +5317,9 @@ def maxnreg_noinline2(X):
 def test_maxnreg(device):
     assert not is_interpreter(), "this test won't work with the interpreter"
     check_cuda_only(device)
+    print("XXX device", device)
+    print("XXX is_hip:", is_hip())
+    print("XXX current_target:", triton.runtime.driver.active.get_current_target())
 
     # triton kernel
     @triton.jit

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5316,10 +5316,8 @@ def maxnreg_noinline2(X):
 
 def test_maxnreg(device):
     assert not is_interpreter(), "this test won't work with the interpreter"
-    check_cuda_only(device)
-    print("XXX device", device)
-    print("XXX is_hip:", is_hip())
-    print("XXX current_target:", triton.runtime.driver.active.get_current_target())
+    if is_hip():
+        pytest.skip('maxnreg only works on CUDA')
 
     # triton kernel
     @triton.jit

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5328,7 +5328,6 @@ def test_maxnreg(device):
 
     X = torch.empty(1, dtype=torch.int32, device=device)
     k = kernel[(1, )](X, maxnreg=42)
-    print(k.asm["ptx"])
 
     # Ensure that .maxnreg is set on the kernel function (marked with .entry)
     # and not on either of the noinline functions (marked with .func).

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -116,6 +116,7 @@ class Autotuner(KernelInterface):
                     *args,
                     num_warps=config.num_warps,
                     num_stages=config.num_stages,
+                    maxnreg=config.maxnreg,
                     num_ctas=config.num_ctas,
                     **current,
                 )
@@ -177,6 +178,7 @@ class Autotuner(KernelInterface):
             *args,
             num_warps=config.num_warps,
             num_stages=config.num_stages,
+            maxnreg=config.maxnreg,
             num_ctas=config.num_ctas,
             **kwargs,
             **config.kwargs,
@@ -200,6 +202,7 @@ class Autotuner(KernelInterface):
                         **kwargs,
                         **config.kwargs,
                         num_stages=config.num_stages,
+                        maxnreg=config.maxnreg,
                         num_warps=config.num_warps,
                         num_ctas=config.num_ctas,
                     )
@@ -218,6 +221,7 @@ class Autotuner(KernelInterface):
                     num_warps=config.num_warps,
                     num_ctas=config.num_ctas,
                     num_stages=config.num_stages,
+                    maxnreg=config.maxnreg,
                     **kwargs,
                     **config.kwargs,
                 ))
@@ -239,15 +243,19 @@ class Config:
                        Mostly useful for matrix multiplication workloads on SM80+ GPUs.
     :type num_ctas: int
     :ivar num_ctas: number of blocks in a block cluster. SM90+ only.
+    :type maxnreg: Optional[int]
+    :ivar maxnreg: maximum number of registers one thread can use.  Corresponds
+                       to ptx .maxnreg directive.  Not supported on all platforms.
     :ivar pre_hook: a function that will be called before the kernel is called. Parameters of this
                     function are args.
     """
 
-    def __init__(self, kwargs, num_warps=4, num_stages=2, num_ctas=1, pre_hook=None):
+    def __init__(self, kwargs, num_warps=4, num_stages=2, num_ctas=1, maxnreg=None, pre_hook=None):
         self.kwargs = kwargs
         self.num_warps = num_warps
         self.num_ctas = num_ctas
         self.num_stages = num_stages
+        self.maxnreg = maxnreg
         self.pre_hook = pre_hook
 
     def __str__(self):
@@ -257,6 +265,8 @@ class Config:
         res.append(f"num_warps: {self.num_warps}")
         res.append(f"num_ctas: {self.num_ctas}")
         res.append(f"num_stages: {self.num_stages}")
+        if self.maxnreg is not None:
+            res.append(f"maxnreg: {self.maxnreg}")
         return ", ".join(res)
 
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1027,7 +1027,7 @@ def _implicit_cvt(arg):
 interpreter_builder = InterpreterBuilder()
 
 # These keywords are not supported by the interpreter
-RESERVED_KWS = ["num_warps", "num_stages", "num_ctas", "enable_fp_fusion", "grid"]
+RESERVED_KWS = ["num_warps", "num_stages", "num_ctas", "enable_fp_fusion", "grid", "maxnreg"]
 
 
 class GridExecutor:

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -185,13 +185,13 @@ class HIPBackend(BaseBackend):
         amd.set_bool_control_constant(llvm_mod, "__oclc_wavefrontsize64", options.warp_size == 64)
 
         # Set kernel attributes first given this may affect later optimizations.
-        kernels = [fn for fn in llvm_mod.get_functions() if not fn.is_declaration()]
+        fns = [fn for fn in llvm_mod.get_functions() if not fn.is_declaration()]
         # The public kernel should be kernel 0.
-        kernels[0].set_calling_conv(amd.CALLING_CONV_AMDGPU_KERNEL)
-        kernels[0].add_fn_attr("amdgpu-flat-work-group-size", f"1,{options.num_warps*options.warp_size}")
-        kernels[0].add_fn_attr("amdgpu-waves-per-eu", f"{options.waves_per_eu}")
+        fns[0].set_calling_conv(amd.CALLING_CONV_AMDGPU_KERNEL)
+        fns[0].add_fn_attr("amdgpu-flat-work-group-size", f"1,{options.num_warps*options.warp_size}")
+        fns[0].add_fn_attr("amdgpu-waves-per-eu", f"{options.waves_per_eu}")
         denormal_mode = "preserve-sign" if options.allow_flush_denorm else "ieee"
-        kernels[0].add_fn_attr("denormal-fp-math-f32", denormal_mode)
+        fns[0].add_fn_attr("denormal-fp-math-f32", denormal_mode)
 
         if options.extern_libs:
             paths = [path for (name, path) in options.extern_libs if amd.need_extern_lib(llvm_mod, name)]

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -223,7 +223,7 @@ class CUDABackend(BaseBackend):
         # Set maxnreg on all kernels, if it was provided.
         if options.maxnreg is not None:
             for k in llvm_mod.get_functions():
-                if k.is_nvvm_kernel():
+                if not k.is_declaration() and k.is_external_linkage():
                     k.set_nvvm_maxnreg(options.maxnreg)
 
         if options.extern_libs:


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Add maxnreg kernel config.
    
    Like num_stages and num_warps, this tunes the generated kernel, controlling the
    maximum number of registers that one thread can consume.
1. Don't pass maxnreg to the kernel if it's None.
1. Add maxnreg to interpreter reserved_kws
1. Add debugging printfs for AMD
1. Don't use check_cuda_only, which does not skip HIP.
1. Use linkage to find kernel functions

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3944 👈 **YOU ARE HERE**


</git-pr-chain>






