### PR TITLE
[PROTON] Fix python call path

### DIFF
--- a/third_party/proton/csrc/lib/Context/Python.cpp
+++ b/third_party/proton/csrc/lib/Context/Python.cpp
@@ -78,7 +78,6 @@ std::vector<Context> PythonContextSource::getContexts() {
 
   std::vector<Context> contexts;
   while (frame != nullptr) {
-
     PyCodeObject *f_code = getFrameCodeObject(frame);
     size_t lineno = PyFrame_GetLineNumber(frame);
     size_t firstLineNo = f_code->co_firstlineno;
@@ -90,6 +89,7 @@ std::vector<Context> PythonContextSource::getContexts() {
     Py_DECREF(frame);
     frame = newFrame;
   }
+  std::reverse(contexts.begin(), contexts.end());
   return contexts;
 }
 

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -23,7 +23,7 @@ def test_torch(context):
             assert data[0]["children"][0]["frame"]["name"] == "test"
         elif context == "python":
             assert len(data[0]["children"]) == 1
-            assert ".py" in data[0]["children"][0]["frame"]["name"]
+            assert "pytest:<module>" in data[0]["children"][0]["frame"]["name"]
 
 
 def test_triton():

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -23,7 +23,13 @@ def test_torch(context):
             assert data[0]["children"][0]["frame"]["name"] == "test"
         elif context == "python":
             assert len(data[0]["children"]) == 1
-            assert "pytest:<module>" in data[0]["children"][0]["frame"]["name"]
+            # The last frame is the torch kernel
+            prev_frame = data
+            curr_frame = data[0]["children"]
+            while len(curr_frame) > 0:
+                prev_frame = curr_frame
+                curr_frame = curr_frame[0]["children"]
+            assert "elementwise_kernel" in prev_frame[0]["frame"]["name"]
 
 
 def test_triton():


### PR DESCRIPTION
We should return the call path from the root to the leaf by reversing the unwound frames