### PR TITLE
Emit code so LLVM knows the range of `threadid`.

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -395,18 +395,25 @@ inline Value getSharedMemoryBase(Location loc,
 } // namespace LLVM
 
 /* ------------------------------------ */
-// Returns CTA level thread idx
-inline Value getThreadIdInCTA(RewriterBase &rewriter, Location loc) {
-  Value tid =
-      rewriter.create<::mlir::gpu::ThreadIdOp>(loc, ::mlir::gpu::Dimension::x);
-  return rewriter.create<arith::IndexCastOp>(loc, i32_ty, tid);
-}
 
 // Returns CTA level thread idx.
 inline Value getThreadId(RewriterBase &rewriter, Location loc) {
-  Value tid = getThreadIdInCTA(rewriter, loc);
   auto mod = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
-  return tid;
+  int threadsPerBlock = triton::gpu::TritonGPUDialect::getNumWarps(mod) *
+                        triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
+
+  Value tid =
+      rewriter.create<::mlir::gpu::ThreadIdOp>(loc, ::mlir::gpu::Dimension::x);
+  tid = rewriter.create<arith::IndexCastOp>(loc, i32_ty, tid);
+
+  // Emit `tid & (threadsPerBlock - 1)` so that LLVM knows the range of the tid
+  // value.  If we wanted to get rid of this unnecessary & op, we could add an
+  // LLVM pass to set range metadata on the call to the intrinsic that gets the
+  // tid, something like LLVM's NVVMIntrRangePass except taking into account the
+  // kernel's actual limit rather than just the hardware's limit.  But ptxas,
+  // which does know the kernel's actual limit, seems to get rid of the op in
+  // the conversion to SASS, so it really shouldn't matter.
+  return and_(tid, i32_val(threadsPerBlock - 1));
 }
 
 // -----------------------------------------------------------------------

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -39,23 +39,6 @@ const std::string Cluster_Cta_Id_Op = "{\n"
                                       "mad.lo.u32 a1, a2, a4, a1;     \n"
                                       "mad.lo.u32 $0, a1, a3, a0;     \n"
                                       "}";
-const std::string Canonical_Warp_Id_Op =
-    "{\n"
-    ".reg .u32 a<5>;              \n"
-    "mov.u32 a0, %tid.x;          \n" // x
-    "mov.u32 a1, %tid.y;          \n" // y
-    "mov.u32 a2, %tid.z;          \n" // z
-    "mov.u32 a3, %ntid.x;         \n" // nx
-    "mov.u32 a4, %ntid.y;         \n" // ny
-    "mad.lo.u32 a1, a2, a4, a1;   \n"
-    "mad.lo.u32 a0, a1, a3, a0;   \n"
-    "shr.u32 a0, a0, 5;           \n"
-    ".reg .b32         %tmp<3>;   \n"
-    "mov.u32   %tmp0, -1;         \n"
-    "mov.u32   %tmp1, 31;         \n"
-    "mov.u32   %tmp2, 0;          \n"
-    "shfl.sync.idx.b32         $0, a0, %tmp2, %tmp1, %tmp0;           \n"
-    "}";
 
 bool isNumber(const std::string &s) {
   return !s.empty() && std::find_if(s.begin(), s.end(), [](unsigned char c) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -209,9 +209,18 @@ DotOpMmaV3SmemLoader loadA(const LLVMTypeConverter *typeConverter,
   int numRepM = ceil<unsigned>(shapePerCTA[0], instrShape[0] * wpt[0]);
   int numRepK = ceil<unsigned>(shapePerCTA[1], instrShape[2]);
 
-  // The descriptor should be calculated based on the first warp of the
-  // warpgroup.
-  Value warp = and_(udiv(thread, i32_val(32)), i32_val(0xFFFFFFFC));
+  Value warp = udiv(thread, i32_val(32));
+
+  // Mask the warp with -4 because the descriptor should be calculated based on
+  // the first warp of the warpgroup.  But only do this when there are more than
+  // 4 warps.  `thread` is emitted as `threadId & (maxtid - 1)`.  If there are
+  // only 4 warps, then ptxas can tell that (warp & -4) is always 0.  It then
+  // seems to get rid of the shuffle below, and thus defeats the workaround that
+  // shuffle is in place for!
+  if (product(wpt) > 4) {
+    warp = and_(warp, i32_val(0xFFFFFFFC));
+  }
+
   // Workaround for a bug in ptxas 12.3 that cause a failure in
   // test_core.py::test_dot. The shuffle will force the compiler to treat the
   // value as uniform and prevent wrong optimizations.

--- a/unittest/Conversion/TritonGPUToLLVM/DumpLayout.cpp
+++ b/unittest/Conversion/TritonGPUToLLVM/DumpLayout.cpp
@@ -76,7 +76,6 @@ public:
     auto func = builder.create<mlir::triton::FuncOp>(loc, "test_func", funcTy);
     auto mlirModule = mlir::ModuleOp::create(loc);
     mlirModule.push_back(func);
-
     auto *block = func.addEntryBlock();
     rewriter.setInsertionPointToStart(block);
   }

--- a/unittest/Conversion/TritonGPUToLLVM/EmitIndicesTest.cpp
+++ b/unittest/Conversion/TritonGPUToLLVM/EmitIndicesTest.cpp
@@ -751,8 +751,8 @@ void DistributedLegacyVsLinearLayoutsTest<LayoutT, ParamsT>::DoIt() {
                                     legacyLayout);
 
   int threadsPerWarp = product(triton::gpu::getThreadsPerWarp(legacyLayout));
-  int numThreads = product(triton::gpu::getThreadsPerWarp(legacyLayout)) *
-                   product(triton::gpu::getWarpsPerCTA(legacyLayout));
+  int warpsPerCTA = product(triton::gpu::getNumWarpsPerCTA(legacyLayout));
+  int threadsPerCTA = threadsPerWarp * warpsPerCTA;
 
   // Can't call getCTAsPerCGA on a SliceEncodingAttr.  But all we care about is
   // the total number of CTAs, which we can just as easily get from the slice
@@ -766,6 +766,9 @@ void DistributedLegacyVsLinearLayoutsTest<LayoutT, ParamsT>::DoIt() {
   mlir::OpBuilder builder(&context);
   Location loc = UnknownLoc::get(&context);
   auto mlirModule = mlir::ModuleOp::create(loc);
+  mlirModule->setAttr("triton_gpu.num-warps",
+                      builder.getI32IntegerAttr(warpsPerCTA));
+
   auto func = builder.create<mlir::triton::FuncOp>(
       loc, "test_func", builder.getFunctionType({}, {}));
   mlirModule.push_back(func);
@@ -820,7 +823,7 @@ void DistributedLegacyVsLinearLayoutsTest<LayoutT, ParamsT>::DoIt() {
         SCOPED_TRACE("Dimension " + std::to_string(j));
         iterate(numCTAs, [&](int ctaId) {
           SCOPED_TRACE("CTA " + std::to_string(ctaId));
-          iterate(numThreads, [&](int tid) {
+          iterate(threadsPerCTA, [&](int tid) {
             SCOPED_TRACE("Thread " + std::to_string(tid));
             int llValue = evalValue((*llIndices)[i][j], ctaId, tid);
             int legacyValue = evalValue(legacyIndices[i][j], ctaId, tid);
@@ -857,7 +860,7 @@ void DistributedLegacyVsLinearLayoutsTest<LayoutT, ParamsT>::DoIt() {
     llvm::errs() << "  }},\n";
 
     llvm::errs() << "  {S(\"lane\"), {\n";
-    for (int tid = 1; tid < numThreads; tid *= 2) {
+    for (int tid = 1; tid < threadsPerCTA; tid *= 2) {
       if (tid == threadsPerWarp) {
         llvm::errs() << "  }},\n";
         llvm::errs() << "  {S(\"warp\"), {\n";


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Emit code so LLVM knows the range of `threadid`.
    
    This recovers a bit of performance lost from linear layouts, by letting LLVM
    optimize code better.
1. Work around ptxas bug.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3956 👈 **YOU ARE HERE**


</git-pr-chain>


