### PR TITLE
[docs] Fix comment in 03-matrix-multiplication.py

### DIFF
--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -101,10 +101,9 @@ You will specifically learn about:
 #
 #  .. code-block:: Python
 #
-#    pid = triton.program_id(0);
-#    grid_m = (M + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M;
+#    pid = triton.program_id(axis=0);
 #    grid_n = (N + BLOCK_SIZE_N - 1) // BLOCK_SIZE_N;
-#    pid_m = pid / grid_n;
+#    pid_m = pid // grid_n;
 #    pid_n = pid % grid_n;
 #
 # is just not going to cut it.

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -101,10 +101,10 @@ You will specifically learn about:
 #
 #  .. code-block:: Python
 #
-#    pid = triton.program_id(axis=0);
-#    grid_n = (N + BLOCK_SIZE_N - 1) // BLOCK_SIZE_N;
-#    pid_m = pid // grid_n;
-#    pid_n = pid % grid_n;
+#    pid = tl.program_id(axis=0)
+#    grid_n = tl.cdiv(N, BLOCK_SIZE_N)
+#    pid_m = pid // grid_n
+#    pid_n = pid % grid_n
 #
 # is just not going to cut it.
 #


### PR DESCRIPTION
Correct a few issues in example code for the naive (row-major) ordering. I verified the corrected code using `torch.allclose()`.