### PR TITLE
[PROTON] Add missing C++ includes

### DIFF
--- a/third_party/proton/csrc/lib/Context/Python.cpp
+++ b/third_party/proton/csrc/lib/Context/Python.cpp
@@ -1,5 +1,6 @@
 #include "Context/Python.h"
 #include "pybind11/pybind11.h"
+#include <algorithm>
 #include <string>
 
 namespace proton {


### PR DESCRIPTION
Like #3689, include missing C++ header `algorithm`, otherwise clang 19 throws errors like this:
```
/home/vitalyr/projects/dev/cpp/triton/third_party/proton/csrc/lib/Context/Python.cpp:92:8: error: no member named 'reverse' in namespace 'std'
   92 |   std::reverse(contexts.begin(), contexts.end());
      |   ~~~~~^
1 error generated.
```