### PR TITLE
Improve scheduling of prefetched dot

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
@@ -291,6 +291,20 @@ scf::ForOp Prefetcher::createNewForOp() {
   mapping.map(forOp.getInductionVar(), newForOp.getInductionVar());
 
   for (Operation &op : forOp.getBody()->without_terminator()) {
+    // If we're currently trying to sink a prefetched dot, we need to stop
+    // sinking it (by resetting the insertion point to the end) if we find
+    // control flow, or anything that depends on the dot op.
+    if (op.getNumRegions() > 0) {
+      builder.setInsertionPointToEnd(newForOp.getBody());
+    }
+    for (auto operand : op.getOperands()) {
+      if (auto def = operand.getDefiningOp()) {
+        auto dot = dyn_cast<triton::DotOp>(def);
+        if (dot && dots.contains(dot)) {
+          builder.setInsertionPointToEnd(newForOp.getBody());
+        }
+      }
+    }
     Operation *newOp = builder.clone(op, mapping);
     auto dot = dyn_cast<triton::DotOp>(&op);
     if (dot && dots.contains(dot)) {
@@ -329,6 +343,13 @@ scf::ForOp Prefetcher::createNewForOp() {
         prevDot = newOp;
         kOff += kShape;
         kRem -= kShape;
+        if (kRem == 0) {
+          // We want to delay issuing the last dot as long as possible, ideally
+          // until after the prefetch.  To accomplish this, set the insertion
+          // point above the dot.  If we find anything dependent on the dot (at
+          // the top of this loop), we resume inserting after it.
+          builder.setInsertionPoint(prevDot);
+        }
       }
     }
     // update mapping of results
@@ -353,6 +374,7 @@ scf::ForOp Prefetcher::createNewForOp() {
     yieldValues.push_back(bToYield);
   }
   // Update ops of yield
+  builder.setInsertionPointToEnd(newForOp.getBody());
   if (!yieldValues.empty())
     builder.create<scf::YieldOp>(yieldOp.getLoc(), yieldValues);
   return newForOp;

--- a/test/TritonGPU/prefetch.mlir
+++ b/test/TritonGPU/prefetch.mlir
@@ -26,12 +26,12 @@
 // CHECK-DAG:   %[[B_REM_SMEM:.*]] = triton_gpu.memdesc_subview %[[arg_b0]][%[[C16]], %[[C0]]]
 // CHECK-DAG:   %[[B_REM:.*]] = triton_gpu.local_load %[[B_REM_SMEM]]
 // CHECK:       %[[D_FIRST:.*]] = tt.dot %[[a0_prefetch]], %[[b0_prefetch:.*]], {{.*}}
-// CHECK:       tt.dot %[[A_REM_CVT]], %[[B_REM]], %[[D_FIRST:.*]]
 // CHECK-DAG:   %[[NEXT_A_PREFETCH_SMEM:.*]] = triton_gpu.memdesc_subview {{.*}}[%[[C0]], %[[C0]]]
 // CHECK-DAG:   %[[NEXT_A_PREFETCH:.*]] = triton_gpu.local_load %[[NEXT_A_PREFETCH_SMEM]]
 // CHECK-DAG:   %[[NEXT_A_PREFETCH_CVT:.*]] = tt.fp_to_fp %[[NEXT_A_PREFETCH]]
 // CHECK-DAG:   %[[NEXT_B_PREFETCH_SMEM:.*]] = triton_gpu.memdesc_subview {{.*}}[%[[C0]], %[[C0]]]
 // CHECK-DAG:   %[[NEXT_B_PREFETCH:.*]] = triton_gpu.local_load %[[NEXT_B_PREFETCH_SMEM]]
+// CHECK:       tt.dot %[[A_REM_CVT]], %[[B_REM]], %[[D_FIRST:.*]]
 // CHECK:     scf.yield {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[NEXT_A_PREFETCH_CVT]], %[[NEXT_B_PREFETCH]]
 module attributes { "triton_gpu.num-warps" = 4 : i32 } {
 tt.func @matmul_loop_mixed(%lb : index, %ub : index, %step : index, %A : !tt.ptr<f8E5M2>, %B : !tt.ptr<f16>) -> tensor<128x128xf32, #C>{


### PR DESCRIPTION
While analyzing performance of tf32 gemm on A100,  I found a surprising number of stalls on ldmatrix.  Looking at the ttgir:
```
local_load
tt.dot
tt.dot
async_copy, etc...
local_load
```
suggested that the prefetching wasn't really helping to hide latency

Instead, we want to delay the second `dot` until after the second `local_load`:
```
local_load
tt.dot
async_copy, etc...
local_load
tt.dot
```

With this scheduling tweak tf32 perf is more or less on par with cuBLAS:
```
matmul-performance-fp32:
         M       N       K      cublas  triton prev    triton now
0    256.0   256.0   256.0    2.502568     3.057073      2.953735
1    384.0   384.0   384.0    7.643507     8.406043      8.759763
2    512.0   512.0   512.0   18.078896    14.413416     15.477137
3    640.0   640.0   640.0   30.284659    23.883382     25.801575
4    768.0   768.0   768.0   39.050414    34.317033     35.345259
5    896.0   896.0   896.0   56.550561    48.973525     49.787038
6   1024.0  1024.0  1024.0   59.440979    50.043897     56.631955
7   1152.0  1152.0  1152.0   75.148633    63.828650     72.995792
8   1280.0  1280.0  1280.0   95.533530    79.776017     88.383007
9   1408.0  1408.0  1408.0   72.298729    67.645144     72.750969
10  1536.0  1536.0  1536.0   87.787755    81.943708     87.280315
11  1664.0  1664.0  1664.0   96.892725    88.768552     96.600192
12  1792.0  1792.0  1792.0  112.464534   104.189331    112.148915
13  1920.0  1920.0  1920.0   88.553303    81.844219     89.061408
14  2048.0  2048.0  2048.0   99.715994    93.279631    100.745155
15  2176.0  2176.0  2176.0  112.031443   101.714853    113.193314
16  2304.0  2304.0  2304.0  124.659473   114.142437    127.253524
17  2432.0  2432.0  2432.0  114.685912   102.933691    112.230552
18  2560.0  2560.0  2560.0  126.976992   114.236412    124.386234
19  2688.0  2688.0  2688.0  108.215904    98.208559    108.758878
20  2816.0  2816.0  2816.0  118.406265   107.830851    119.501210
21  2944.0  2944.0  2944.0  129.108891   117.898422    130.610400
22  3072.0  3072.0  3072.0  125.246376   112.788009    122.885002
23  3200.0  3200.0  3200.0  133.159950   119.121699    129.833900
24  3328.0  3328.0  3328.0  124.957773   110.181092    121.741877
25  3456.0  3456.0  3456.0  134.411287   118.765808    130.945595
26  3584.0  3584.0  3584.0  129.718790   116.785078    127.570664
27  3712.0  3712.0  3712.0  135.099099   121.469581    133.193687
28  3840.0  3840.0  3840.0  123.986410   115.455567    127.355116
29  3968.0  3968.0  3968.0  128.467381   123.054516    135.546859
30  4096.0  4096.0  4096.0  136.270295   122.945194    134.175797
```

The implementation is ... mildly hacky, so would definitely like some feedback on it.  But also I figure that this pass is limited to A100 (we don't use prefetch on cc > 80), so it has a short shelf life and might not be worth making too general.  (I do want it for some critical workloads that are going to be important for a while longer yet though)