### PR TITLE
[AMD] enabled `fast_dividef` op for the amd backend

### DIFF
--- a/python/triton/language/extra/hip/libdevice.py
+++ b/python/triton/language/extra/hip/libdevice.py
@@ -58,6 +58,13 @@ def exp2(arg0, _builder=None):
 
 
 @core.extern
+def fast_dividef(arg0, arg1, _builder=None):
+    return core.extern_elementwise("", "", [arg0, arg1], {
+        (core.dtype("fp32"), core.dtype("fp32")): ("__triton_hip_fast_fdividef", core.dtype("fp32")),
+    }, is_pure=True, _builder=_builder)
+
+
+@core.extern
 def sqrt(arg0, _builder=None):
     return core.extern_elementwise(
         "", "", [arg0], {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
@@ -138,6 +138,15 @@ private:
                                                     operands[0]);
       replacementOp =
           rewriter.create<LLVM::FPToSIOp>(loc, returnType, op->getResult(0));
+    } else if (calleeName == "__triton_hip_fast_fdividef") {
+      assert(operands.size() == 2);
+      auto name = StringAttr::get(callOp.getContext(), "llvm.amdgcn.rcp.f32");
+      LLVM::FastmathFlagsAttr defaultFlags{};
+      auto rcpOp = rewriter.create<LLVM::CallIntrinsicOp>(
+          loc, returnType, name, operands[1], defaultFlags);
+
+      replacementOp = rewriter.create<LLVM::FMulOp>(
+          loc, returnType, operands[0], rcpOp->getResult(0), defaultFlags);
     }
 
     if (replacementOp) {


### PR DESCRIPTION
This PR adds `fast_dividef` extra op to the hip backend