### PR TITLE
[BACKEND] Fix workaround for unsupported cases in maybeDeduplicate

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -87,10 +87,12 @@ public:
     if (!encoding)
       // encoding not available
       return resultVals;
-    if (!dyn_cast<BlockedEncodingAttr>(encoding) &&
-        !dyn_cast<SliceEncodingAttr>(encoding)) {
-      // TODO: constraining the ecndoing type here is necessary for avoiding
-      // crashes in the getElemsPerThread call below happening in the
+    Attribute baseEncoding = encoding;
+    while (auto sliced = dyn_cast<SliceEncodingAttr>(baseEncoding))
+      baseEncoding = sliced.getParent();
+    if (!isa<BlockedEncodingAttr>(baseEncoding)) {
+      // TODO: this logic seems to only be correct for blocked layout.
+      // The following test crashes and some other miscompile:
       // test_core::test_fp8_dot_acc
       return resultVals;
     }


### PR DESCRIPTION
The logic of maybeDeduplicate doesn't seem to handle layouts other than blocked layout. Fix the check we have to prevent it to be used for layouts that are not blocked or sliced of blocked.