### PR TITLE
[BUILD] Allow disabling Proton from Python build

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -416,7 +416,10 @@ class CMakeBuild(build_ext):
                 "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
             ]
 
-        cmake_args += self.get_proton_cmake_args()
+        if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
+            cmake_args += self.get_proton_cmake_args()
+        else:
+            cmake_args += ["-DTRITON_BUILD_PROTON=OFF"]
 
         env = os.environ.copy()
         cmake_dir = get_cmake_dir()
@@ -502,7 +505,8 @@ def add_link_to_proton():
 
 def add_links():
     add_link_to_backends()
-    add_link_to_proton()
+    if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
+        add_link_to_proton()
 
 
 class plugin_install(install):
@@ -561,9 +565,12 @@ def get_packages():
 
 
 def get_entry_points():
-    entry_points = {
-        "console_scripts": ["proton-viewer = triton.profiler.viewer:main", "proton = triton.profiler.proton:main"]
-    }
+    entry_points = {}
+    if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
+        entry_points["console_scripts"] = [
+            "proton-viewer = triton.profiler.viewer:main",
+            "proton = triton.profiler.proton:main",
+        ]
     return entry_points
 
 

--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -14,6 +14,13 @@ cd triton/python
 pip install .
 ```
 
+To not build Proton, you can set the `TRITON_BUILD_PROTON` environment variable to `OFF`:
+
+```bash
+TRITON_BUILD_PROTON=OFF pip install .
+```
+
+
 ## Usage
 
 ### Basic usage


### PR DESCRIPTION
Proton is a third_party component and not necessarily always needed for everybody. So allow disabling building it with an environment variable.