### PR TITLE
Allow np.bool_ in the condition types

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1,5 +1,6 @@
 import ast
 import inspect
+import numpy as np
 import re
 import sys
 import warnings
@@ -94,7 +95,7 @@ def _get_fn_file_line(fn):
     return file_name, begin_line
 
 
-_condition_types = {bool, int, type(None)}  # Python types accepted for conditionals inside kernels
+_condition_types = {bool, int, type(None), np.bool_}  # Python types accepted for conditionals inside kernels
 
 
 class enter_sub_region:


### PR DESCRIPTION
We can sometimes pass in np.bool_ by accident. e.g. we have such code

```
multiple_q = attn_bias.q_seqinfo.max_seqlen > 1
IS_CAUSAL = multiple_q and _is_supported_causal_bias(attn_bias)
```

If the max_seqlen is numpy.int, multiple_q will be np.bool_. And depending on whether it's np.bool_(True) or np.bool_(False), "and" with a python bool will end up with a python bool (if multiple_q is np.bool_(True)) or np.bool_ (if multiple_q is np.bool_(False).

Obviously this can be fixed in the user program, but I'm just wondering if it's ok to take a np.bool_ for condition_types to make it easier