### PR TITLE
[PROTON] Drop hip_ostream_ops.h in roctracer headers

### DIFF
--- a/third_party/amd/backend/include/roctracer/roctracer_hip.h
+++ b/third_party/amd/backend/include/roctracer/roctracer_hip.h
@@ -25,7 +25,6 @@
 
 #include <hip/hip_runtime.h>
 #include <hip/hip_deprecated.h>
-#include "hip_ostream_ops.h"
 #include <hip/amd_detail/hip_prof_str.h>
 
 typedef enum {


### PR DESCRIPTION
This header contains a bunch of `operator<<` definitions for print effectively. We don't use them. It's not good to touch public headers but the problem is it uses `__locale_struct` which is missing on macOS and breaks builds.