### PR TITLE
Allow FP8 types in `arith.constant` initializers

### DIFF
--- a/include/triton/Conversion/MLIRTypes.h
+++ b/include/triton/Conversion/MLIRTypes.h
@@ -27,7 +27,10 @@ inline Type f64Ty(MLIRContext *ctx) { return FloatType::getF64(ctx); }
 inline Type bf16Ty(MLIRContext *ctx) { return FloatType::getBF16(ctx); }
 
 inline bool isFloat(Type type) {
-  return type.isF32() || type.isF64() || type.isF16() || type.isF128();
+  return type.isF32() || type.isF64() || type.isF16() || type.isF128() ||
+         type.isBF16() || type.isFloat8E4M3B11FNUZ() || type.isFloat8E4M3FN() ||
+         type.isFloat8E4M3FNUZ() || type.isFloat8E5M2() ||
+         type.isFloat8E5M2FNUZ();
 }
 
 inline bool isInt(Type type) { return type.isIntOrFloat() && !isFloat(type); }

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -74,7 +74,7 @@ struct ArithConstantSplatOpConversion
     auto values = mlir::dyn_cast<SplatElementsAttr>(op.getValue());
     auto elemType = values.getElementType();
     Attribute val;
-    if (elemType.isBF16() || type::isFloat(elemType)) {
+    if (type::isFloat(elemType)) {
       val = values.getValues<FloatAttr>()[0];
     } else if (type::isInt(elemType)) {
       val = values.getValues<IntegerAttr>()[0];


### PR DESCRIPTION
There was a bug in lowering `arith.constant` where only "regular" FP types and BF16 were allowed as initializers (we couldn't even lower 0 init for FP8).
I have included all the FP8 types in the `isFloat` helper. Let me know if it makes sense.