### PR TITLE
Fix incorrect nans in float8e4b8 on AMD

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -660,11 +660,10 @@ static Value Fp16_to_Fp8E4M3FNUZ_oneValue(Location loc,
 
   // In nuz format, -0 is NaN. We need to explicitly handle this case.
   auto re_m = or_(i16_ty, re, m);
-  // If mantissa and exponent are non-zero, add sign
-  // back into return value. Otherwise, dont use sign
-  // and instead return zero.
-  auto use_sign = icmp_sgt(re_m, int_val(16, 0));
-  auto r = select(use_sign, or_(i16_ty, s, re_m), int_val(16, 0));
+  // If mantissa and exponent are zero, return positive zero.
+  // Otherwise mix sign back into return value.
+  auto all_zero = icmp_eq(re_m, int_val(16, 0));
+  auto r = select(all_zero, int_val(16, 0), or_(i16_ty, s, re_m));
   auto fp8x2VecTy = vec_ty(i8_ty, 2);
   auto res = bitcast(r, fp8x2VecTy);
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -231,20 +231,25 @@ static Value Fp16_to_Fp8E5M2FNUZ_oneValue(Location loc,
   // normal value
   auto a = and_(i16_ty, vi16, int_val(16, 0x7FFFF));
   auto a1 = add(i16_ty, a, int_val(16, 0x0400));
-  auto o1 = or_(i16_ty, a1, sign);
 
   // subnormal value, e is 0
   auto m = and_(i16_ty, vi16, int_val(16, 0x03FF));
   auto m2 = shl(m, int_val(16, 1));
-  auto o2 = or_(i16_ty, sign, or_(i16_ty, int_val(16, 1), m2));
+  auto o2 = or_(i16_ty, int_val(16, 1), m2);
 
   auto e_is_zero = icmp_eq(e, int_val(16, 0));
   auto e_is_all1 = icmp_eq(e, int_val(16, 0x7C00));
 
-  auto ot = select(e_is_zero, o2, o1);
+  auto ot = select(e_is_zero, o2, a1);
   auto o = select(e_is_all1, vi16, ot);
+
+  // Handle -0 case, since it represents NaN we instead return
+  // positive 0.
+  auto o_is_zero = icmp_eq(o, int_val(16, 0));
+  // Return 0 if exponent and mantissa are zero, otherwise add in sign.
+  auto r = select(o_is_zero, int_val(16, 0), or_(i16_ty, sign, o));
   auto fp8x2VecTy = vec_ty(i8_ty, 2);
-  auto res = bitcast(o, fp8x2VecTy);
+  auto res = bitcast(r, fp8x2VecTy);
 
   return extract_element(i8_ty, res, i32_val(1));
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -241,7 +241,8 @@ static Value Fp16_to_Fp8E5M2FNUZ_oneValue(Location loc,
   auto e_is_all1 = icmp_eq(e, int_val(16, 0x7C00));
 
   auto ot = select(e_is_zero, o2, a1);
-  auto o = select(e_is_all1, vi16, ot);
+  // When e is all one, value represents inf and should be cast to nan.
+  auto o = select(e_is_all1, int_val(16, 0x8000), ot);
 
   // Handle -0 case, since it represents NaN we instead return
   // positive 0.
@@ -668,6 +669,11 @@ static Value Fp16_to_Fp8E4M3FNUZ_oneValue(Location loc,
   // Otherwise mix sign back into return value.
   auto all_zero = icmp_eq(re_m, int_val(16, 0));
   auto r = select(all_zero, int_val(16, 0), or_(i16_ty, s, re_m));
+  // Also check inf. If so, return nan.
+  auto inf = int_val(16, 0x7C00);
+  auto is_inf = icmp_eq(e10, inf);
+  auto r2 = select(is_inf, int_val(16, 0x8000), r);
+  // Finally cast to fp8 and extract high byte.
   auto fp8x2VecTy = vec_ty(i8_ty, 2);
   auto res = bitcast(r, fp8x2VecTy);
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -657,7 +657,6 @@ static Value Fp16_to_Fp8E4M3FNUZ_oneValue(Location loc,
   auto c23 = icmp_sle(e, int_val(16, 7));
   auto re = select(c23, e2, e13);
 
-
   // In nuz format, -0 is NaN. We need to explicitly handle this case.
   auto re_m = or_(i16_ty, re, m);
   // If mantissa and exponent are zero, return positive zero.


### PR DESCRIPTION
In the `float8e4b8` format, `0x80` represents nan. In other float8 formats, it represents `-0` instead. The AMD type converter for `float8e4b8` did not check for this case so would return nan for any small negative value. This PR adds a simple check to prevent this behavior on AMD.

The current type checking tests look like they should have caught this bug, but I assume they aren't running on AMD. I'd appreciate any feedback on if there are tests that should be added.