### PR TITLE
[CI] Remove `--no-build-isolation`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -218,7 +218,7 @@ jobs:
         run: |
           echo "PATH is '$PATH'"
           cd python
-          python3 -m pip install --no-build-isolation '.[tests]'
+          python3 -m pip install '.[tests]'
       - name: Run lit tests
         run: |
           cd python

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -248,7 +248,7 @@ jobs:
         run: |
           echo "PATH is '$PATH'"
           cd python
-          python3 -m pip install --no-build-isolation '.[tests]'
+          python3 -m pip install '.[tests]'
 
       - &run-lit-tests-step
         name: Run lit tests


### PR DESCRIPTION
https://github.com/LLNL/hatchet/pull/125#issuecomment-2130102636

Previously `no-build-isolation` is used to take advantage of the incremental build.
Now that we have containerized the CI, it probably doesn't help much.




