### PR TITLE
Adding note regarding TRITON_HIP_LLD_PATH environment variable

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -101,7 +101,7 @@ class HIPBackend(BaseBackend):
         lld = Path("/usr/bin/ld.lld")
         if lld.is_file():
             return lld
-        raise Exception("ROCm linker /opt/rocm/llvm/bin/ld.lld not found")
+        raise Exception("ROCm linker /opt/rocm/llvm/bin/ld.lld not found. Set 'TRITON_HIP_LLD_PATH' to its path.")
 
     @staticmethod
     def make_ttir(mod, metadata, options):


### PR DESCRIPTION
I was stuck for some time trying to get Triton to run because ROCm is installed in a different path on our HPC system. I only realized the environment variable existed when I looked at Triton's code. A note about the TRITON_HIP_LLD_PATH in the exception message would have been very helpful.