### PR TITLE
Add parameter `interleave` to the `warpReduce` interface of `TargetInfo` which was missed.

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -33,7 +33,8 @@ public:
 
   virtual bool warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                           SmallVector<Value> &acc, triton::ReduceOp op,
-                          unsigned numLaneToReduce) const = 0;
+                          unsigned numLaneToReduce,
+                          unsigned interleave) const = 0;
 
   virtual bool processReplicaUsingStMatrix(
       ConversionPatternRewriter &rewriter, Location loc, Value smemBase,

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -176,8 +176,8 @@ private:
   void warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                   SmallVector<Value> &acc, triton::ReduceOp op,
                   unsigned numLaneToReduce, unsigned interleave) const {
-    auto success =
-        targetInfo.warpReduce(rewriter, loc, acc, op, numLaneToReduce);
+    auto success = targetInfo.warpReduce(rewriter, loc, acc, op,
+                                         numLaneToReduce, interleave);
     if (success)
       return;
     for (unsigned N = numLaneToReduce / 2; N > 0; N >>= 1) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -118,7 +118,8 @@ Value TargetInfo::programId(ConversionPatternRewriter &rewriter, Location loc,
 
 bool TargetInfo::warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                             SmallVector<Value> &acc, triton::ReduceOp op,
-                            unsigned numLaneToReduce) const {
+                            unsigned numLaneToReduce,
+                            unsigned interleave) const {
   return false;
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -41,7 +41,7 @@ public:
 
   bool warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                   SmallVector<Value> &acc, triton::ReduceOp op,
-                  unsigned numLaneToReduce) const override;
+                  unsigned numLaneToReduce, unsigned interleave) const override;
 
   bool processReplicaUsingStMatrix(
       ConversionPatternRewriter &rewriter, Location loc, Value smemBase,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -323,7 +323,8 @@ Value TargetInfo::programId(ConversionPatternRewriter &rewriter, Location loc,
 }
 bool TargetInfo::warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                             SmallVector<Value> &acc, triton::ReduceOp op,
-                            unsigned numLaneToReduce) const {
+                            unsigned numLaneToReduce,
+                            unsigned interleave) const {
   if (auto kind = matchReduxKind(op, computeCapability)) {
     // Based on benchmarking on A100 redux op gives a speed up only when doing
     // a single reduction (not partitioned) and when the mask is static.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -36,7 +36,7 @@ public:
 
   bool warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                   SmallVector<Value> &acc, triton::ReduceOp op,
-                  unsigned numLaneToReduce) const override;
+                  unsigned numLaneToReduce, unsigned interleave) const override;
 
   bool processReplicaUsingStMatrix(
       ConversionPatternRewriter &rewriter, Location loc, Value smemBase,


### PR DESCRIPTION
The reduce lowering pattern, ReduceOpConversion, calls the backend target-specific interface to generate a high-performance operation for horizontal warp reduction across lanes. If the backend target doesn't support this, it falls back to the common horizontal warp reduction with the ShuffleXor operation, which might be suboptimal.

There is a parameter interleave in warpReduce that is not defined in the TargetInfoBase interface warpReduce.

The backend may generate incorrect code without information about how to reduce the value across lanes with an interleave stride.

This issue doesn't impact the in-tree backends, AMD and NV GPU.

- The AMD backend always uses ShuffleXor for horizontal warp reduction.
- The NV backend only generates high-performance horizontal warp reduction when numLaneToReduce equals 32. (The interleave is always 1 when numLaneToReduce is 32 on NV, where the warp size is always 32.)
 
This issue impacts the out-of-tree backend, Intel GPU.

- The Intel GPU supports various high-performance horizontal warp reduction operations for different numLaneToReduce and interleave values.

To fix this, we add the interleave parameter to the TargetInfo's warpReduce method and use the same interleave value as when generating the horizontal reduction with ShuffleXor.