### PR TITLE
Use dictionary unpacking instead of merge operator for python 3.8 compatibility

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -239,15 +239,16 @@ class Config:
         self.pre_hook = pre_hook
 
     def all_kwargs(self):
-        return self.kwargs | {
-            k: v
-            for (k, v) in (
-                ("num_warps", self.num_warps),
-                ("num_ctas", self.num_ctas),
-                ("num_stages", self.num_stages),
-                ("maxnreg", self.maxnreg),
-            )
-            if v is not None
+        return {
+            **self.kwargs, **{
+                k: v
+                for (k, v) in (
+                    ("num_warps", self.num_warps),
+                    ("num_ctas", self.num_ctas),
+                    ("num_stages", self.num_stages),
+                    ("maxnreg", self.maxnreg),
+                ) if v is not None
+            }
         }
 
     def __str__(self):


### PR DESCRIPTION
The dictionary merge operator was introduced in Python 3.9 and unfortunately PyTorch still supports 3.8. I think for this use case there is no downside to unpacking, other than that it's a bit ugly. 