### PR TITLE
[DOCS] Fix docs and improve a test case

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1096,7 +1096,7 @@ def test_shapes_as_params(device):
 
         a = tl.arange(0, 32).reshape(4, 8).trans()
         tl.static_assert(a.shape == [tl.constexpr(8), tl.constexpr(4)])
-        
+
         a = tl.arange(0, 32).reshape(4, 8).reshape(32)
         tl.static_assert(a.shape == [tl.constexpr(32)])
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1094,6 +1094,9 @@ def test_shapes_as_params(device):
         a = tl.arange(0, 32).reshape(4, 8).permute(1, 0)
         tl.static_assert(a.shape == [tl.constexpr(8), tl.constexpr(4)])
 
+        a = tl.arange(0, 32).reshape(4, 8).trans()
+        tl.static_assert(a.shape == [tl.constexpr(8), tl.constexpr(4)])
+        
         a = tl.arange(0, 32).reshape(4, 8).reshape(32)
         tl.static_assert(a.shape == [tl.constexpr(32)])
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1268,7 +1268,7 @@ def trans(input: tensor, *dims, _builder=None):
     """
     Permutes the dimensions of a tensor.
 
-    If the parameter :code:`dims` is not specified, the function defaults to a (1,0) permutation, 
+    If the parameter :code:`dims` is not specified, the function defaults to a (1,0) permutation,
     effectively transposing a 2D tensor.
 
     :param input: The input tensor.

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1179,7 +1179,7 @@ def arange(start, end, _builder=None):
     """
     Returns contiguous values within the half-open interval :code:`[start,
     end)`.  :code:`end - start` must be less than or equal to
-    :code:`TRITON_MAX_TENSOR_NUMEL`
+    :code:`TRITON_MAX_TENSOR_NUMEL = {TRITON_MAX_TENSOR_NUMEL}`
 
     :param start: Start of the interval. Must be a power of two.
     :type start: int32

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1179,7 +1179,7 @@ def arange(start, end, _builder=None):
     """
     Returns contiguous values within the half-open interval :code:`[start,
     end)`.  :code:`end - start` must be less than or equal to
-    :code:`TRITON_MAX_TENSOR_NUMEL = 131072`
+    :code:`TRITON_MAX_TENSOR_NUMEL = 1048576`
 
     :param start: Start of the interval. Must be a power of two.
     :type start: int32
@@ -1268,9 +1268,9 @@ def trans(input: tensor, *dims, _builder=None):
     """
     Permutes the dimensions of a tensor.
 
-    If no permutation is specified, tries to do a (1,0) permutation, i.e. tries
-    to transpose a 2D tensor.
-
+    If the parameter :code:`dims` is not specified, the function defaults to a (1,0) permutation, 
+    effectively transposing a 2D tensor.
+    
     :param input: The input tensor.
     :param dims: The desired ordering of dimensions.  For example,
         :code:`(2, 1, 0)` reverses the order dims in a a 3D tensor.

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1176,7 +1176,7 @@ def num_programs(axis, _builder=None):
 
 @builtin
 def arange(start, end, _builder=None):
-    """
+    f"""
     Returns contiguous values within the half-open interval :code:`[start,
     end)`.  :code:`end - start` must be less than or equal to
     :code:`TRITON_MAX_TENSOR_NUMEL = {TRITON_MAX_TENSOR_NUMEL}`

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1179,7 +1179,7 @@ def arange(start, end, _builder=None):
     """
     Returns contiguous values within the half-open interval :code:`[start,
     end)`.  :code:`end - start` must be less than or equal to
-    :code:`TRITON_MAX_TENSOR_NUMEL = 1048576`
+    :code:`TRITON_MAX_TENSOR_NUMEL`
 
     :param start: Start of the interval. Must be a power of two.
     :type start: int32
@@ -1270,7 +1270,7 @@ def trans(input: tensor, *dims, _builder=None):
 
     If the parameter :code:`dims` is not specified, the function defaults to a (1,0) permutation, 
     effectively transposing a 2D tensor.
-    
+
     :param input: The input tensor.
     :param dims: The desired ordering of dimensions.  For example,
         :code:`(2, 1, 0)` reverses the order dims in a a 3D tensor.


### PR DESCRIPTION
## PR Description
Updated 1 test in test_core.py and 2 docs in core.py.

## Tests
[`python/test/unit/language/test_core.py`](diffhunk://#diff-ac90f00a03feff6747a9c9ac5af1f44bb67e56bf911e05db71a2c1e818e897e7R1097-R1099): The `kernel` function has been updated to include a test for the `trans` function without specifying the `dims` parameter.

## Documentation
[`python/triton/language/core.py`](diffhunk://#diff-1d96a0ed473569188c00d6e16c54dd7050e0a66040438ac630c889aef7cbbbe8L1182-R1182): The `TRITON_MAX_TENSOR_NUMEL` constant in the `arange` function has been updated to be consistent  with https://github.com/triton-lang/triton/blob/03b84666a1991a0addd6b0d80c911de98b7e6c31/python/triton/language/core.py#L19. 


[`python/triton/language/core.py`](diffhunk://#diff-1d96a0ed473569188c00d6e16c54dd7050e0a66040438ac630c889aef7cbbbe8L1271-R1272): The default behavior (without `dims`) for the `trans` function has been clarified.


## Pre-commit 
checks passed
