### PR TITLE
[INTERPRETER] fixed `int_to_ptr` / `ptr_to_int` bug

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -389,7 +389,7 @@ class pointer_type(dtype):
 
     def __init__(self, element_ty: dtype, address_space: int = 1):
         if not isinstance(element_ty, dtype):
-            raise TypeError(f'element_ty is a {type(element_ty).__name__}.')
+            raise TypeError(f'element_ty has type `{type(element_ty).__name__}`; expected `dtype`.')
         self.element_ty = element_ty
         self.address_space = address_space
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -460,6 +460,8 @@ class InterpreterBuilder:
     create_and = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.bitwise_and)
     create_xor = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.bitwise_xor)
     create_or = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.bitwise_or)
+    create_int_to_ptr = create_bitcast
+    create_ptr_to_int = create_bitcast
 
     def create_idiv(self, lhs, rhs):
         # Triton has IEEE, not numpy/torch, semantics for %, and those carry
@@ -583,12 +585,6 @@ class InterpreterBuilder:
 
     def create_broadcast(self, arg, shape):
         return TensorHandle(np.broadcast_to(arg.data, shape), arg.dtype.scalar)
-
-    def create_int_to_ptr(self, val, dst_ty):
-        return TensorHandle(val.data.astype(np.uint64), dst_ty.scalar)
-
-    def create_ptr_to_int(self, val, dst_ty):
-        return TensorHandle(val.data.astype(np.uint64), dst_ty.scalar)
 
     def create_cat(self, lhs, rhs):
         return TensorHandle(np.concatenate([lhs.data, rhs.data]), lhs.dtype.scalar)


### PR DESCRIPTION
operand should be casted to the type provided by the user (ie, either `int64` or `uint64`) rather than always `uint64`