### PR TITLE
[Doc template] Add github issue templates 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,92 @@
+name: 🐛 Bug Report
+description: Create a report to help us reproduce and fix the bug
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/triton-lang/triton/issues).
+
+- type: textarea
+  attributes:
+    label: 🐛 Describe the bug
+    description: |
+      Please provide a clear and concise description of what the bug is.
+    placeholder: |
+      A clear and concise description of what the bug is.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Reproduce
+    description: |
+      If applicable, add a minimal example so that we can reproduce the error by running the code. It is very important for the snippet to be as succinct (minimal) as possible, so please take time to trim down any irrelevant code to help us debug efficiently. We are going to copy-paste your code and we expect to get the same result as you did: avoid any external data, and include the relevant imports, etc. For example:
+
+      ```python
+
+      # All necessary imports at the beginning
+      import torch
+      import triton
+      import triton.language as tl
+
+      # A succinct reproducing example trimmed down to the essential parts:
+      @triton.jit
+      def add_kernel(
+          x_ptr, 
+          y_ptr,
+          output_ptr,
+          n_elements,
+          BLOCK_SIZE # Note: the bug is here, we should pass tl.constexpr
+      ):
+          pid = tl.program_id(axis=0)
+          block_start = pid * BLOCK_SIZE
+          offsets = block_start + tl.arange(0, BLOCK_SIZE)
+          mask = offsets < n_elements
+          x = tl.load(x_ptr + offsets, mask=mask)
+          y = tl.load(y_ptr + offsets, mask=mask)
+          output = x + y
+          tl.store(output_ptr + offsets, output, mask=mask)
+
+      def add(x: torch.Tensor, y: torch.Tensor):
+          output = torch.empty_like(x)
+          n_elements = output.numel()
+          grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']), )
+          add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=1024)
+          return output
+
+      x = torch.rand(8, device='cuda')
+      y = torch.rand(8, device='cuda')
+      output_triton = add(x, y)
+
+
+      ```
+
+      If the code is too long (hopefully, it isn't), feel free to put it in a public gist and link it in the issue: https://gist.github.com.
+
+      Please also paste or describe the results you observe instead of the expected results. If you observe an error, please paste the error message including the **full** traceback of the exception. It may be relevant to wrap error messages in ```` ```triple quotes blocks``` ````.
+    placeholder: |
+      A clear and concise description of what the bug is.
+
+      ```python
+      # Sample code to reproduce the problem
+      ```
+
+      ```
+      The error message you got, with the full traceback.
+      ```
+  validations:
+    required: false
+
+
+- type: textarea
+  attributes:
+    label: Versions
+    description: |
+      Please provide triton, torch, hardware, and other necessary versions to reproduce the bug.
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,20 @@
+name: 📚 Documentation
+description: Report an issue related to https://triton-lang.org/main/index.html
+
+body:
+- type: textarea
+  attributes:
+    label: 📚 The doc issue
+    description: >
+      A clear and concise description of what content in https://triton-lang.org/main/index.html is an issue.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Suggest a potential alternative/fix
+    description: >
+      Tell us how we could improve the documentation in this regard.
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,25 @@
+name: 🚀 Feature request
+description: Submit a proposal/request for a new Triton feature
+
+body:
+- type: textarea
+  attributes:
+    label: 🚀 The feature, motivation and pitch
+    description: >
+      A clear and concise description of the feature proposal. Please outline the motivation for the proposal. Is your feature request related to a specific problem? e.g., *"I'm working on X and would like Y to be possible"*. If this is related to another GitHub issue, please link here too.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Alternatives
+    description: >
+      A description of any alternative solutions or features you've considered, if any.
+- type: textarea
+  attributes:
+    label: Additional context
+    description: >
+      Add any other context or screenshots about the feature request.
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🎉!


### PR DESCRIPTION
## Why the changes are needed?

Currently, there are no issue templates for users to follow, so users are likely to write an issue with insufficient information. This PR adds issue templates adapted from [pytorch repo](https://github.com/pytorch/pytorch/tree/main/.github/ISSUE_TEMPLATE) to help users write better issues

## What are the changes?

Reduce maintainers' burden and help users elaborate the issues

## Demo

https://www.loom.com/share/a2e430b4362040a588fe32b459b818b0?sid=fc46fb2d-504e-46bd-8a0d-abd5118dc7a9
