### PR TITLE
[DOC] Improve core doc and test_core

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3762,7 +3762,7 @@ def test_load_cache_modifier(cache, device):
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_vectorization(N, num_ctas, device):
     block_size = 1024 * num_ctas
-    src = torch.empty(block_size, device=device)
+    src = torch.randn(block_size, device=device)
     dst = torch.empty(block_size, device=device)
 
     @triton.jit
@@ -3781,7 +3781,7 @@ def test_vectorization(N, num_ctas, device):
         assert "ld.global.v4.b32" in ptx
     else:
         assert "ld.global.b32" in ptx
-    # np.testing.assert_allclose(dst, src[:N])
+    torch.testing.assert_close(dst[:N], src[:N], atol=1e-6, rtol=0)
 
 
 @pytest.mark.interpreter

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1581,7 +1581,9 @@ def load(pointer, mask=None, other=None, boundary_check=(), padding_option="", c
     :type boundary_check: tuple of ints, optional
     :param padding_option: should be one of {"", "zero", "nan"}, do padding while out of bound
     :param cache_modifier: changes cache option in NVIDIA PTX
-    :type cache_modifier: str, optional
+    :type cache_modifier: str, optional, should be one of {"", "ca", "cg"}, where "ca" stands for
+        cache at all levels and "cg" stands for cache at global level (cache in L2 and below, not L1), see
+        [cache operator](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#cache-operators) for more details.
     :param eviction_policy: changes eviction policy in NVIDIA PTX
     :type eviction_policy: str, optional
     :param volatile: changes volatile option in NVIDIA PTX

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1324,7 +1324,8 @@ def cat(input, other, can_reorder=False, _builder=None):
     :type other:
     :param reorder: Compiler hint. If true, the compiler is
         allowed to reorder elements while concatenating inputs.  Only use if the
-        order does not matter (e.g., result is only used in reduction ops)
+        order does not matter (e.g., result is only used in reduction ops).
+        Current implementation of `cat` supports only can_reorder=True.
     """
     return semantic.cat(input, other, can_reorder, _builder)
 


### PR DESCRIPTION
## Description

* python/test/unit/language/test_core.py::test_vectorization is improved to actually compare the src and dst. There was no value comparison before.

* [`python/triton/language/core.py`](diffhunk://#diff-1d96a0ed473569188c00d6e16c54dd7050e0a66040438ac630c889aef7cbbbe8L1327-R1328): The comment in the `cat` function has been updated to clarify that the current implementation only supports `can_reorder=True`. 
If set False or leave as default, compilation error.
Due to 
https://github.com/triton-lang/triton/blob/b0faf9b202846434bdd67d7ffec17c8924abe316/python/triton/language/semantic.py#L571

* python/triton/language/core.py: The `cache_modifier` parameter in the `load` function now includes more detailed information about the accepted values and their meanings, linking to external documentation for further details. 


## Template

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you fill out the following
checklist and include it in your PR description.**

Fill out the checklist by replacing `[ ]` with `[x]`.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have used an LLM to copyedit my PR description and and code comments.

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.
  A test case is improved to be more robust.






- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added are "minimal" -- they contain only the
    instructions necessary to exercise the bug.  (Usually running Python code
    and using the instructions it generates is not minimal.)
