### PR TITLE
[AMD] Disable test_subprocess.py on AMD backend

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -372,12 +372,15 @@ jobs:
         run: |
           pytest --capture=tee-sys -rfs python/tutorials/06-fused-attention.py
           cd python/test/unit
+          ## test_subprocess.py is flaky on the AMD CI.
+          ## TODO (lixun) find a solution and re-enable it.
           pytest --capture=tee-sys -rfs -n 32 language operators \
                  hopper/test_mixed_io.py \
                  hopper/test_gemm.py \
                  hopper/test_tma_store_gemm.py \
                  hopper/test_persistent_warp_specialized_fused-attention.py \
-                 --ignore=language/test_line_info.py
+                 --ignore=language/test_line_info.py \
+                 --ignore=language/test_subprocess.py
           # Run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
           TRITON_DISABLE_LINE_INFO=0 python3 -m pytest -s -n 8 language/test_line_info.py
 

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -375,12 +375,15 @@ jobs:
         run: |
           pytest --capture=tee-sys -rfs python/tutorials/06-fused-attention.py
           cd python/test/unit
+          ## test_subprocess.py is flaky on the AMD CI.
+          ## TODO (lixun) find a solution and re-enable it.
           pytest --capture=tee-sys -rfs -n 32 language operators \
                  hopper/test_mixed_io.py \
                  hopper/test_gemm.py \
                  hopper/test_tma_store_gemm.py \
                  hopper/test_persistent_warp_specialized_fused-attention.py \
-                 --ignore=language/test_line_info.py
+                 --ignore=language/test_line_info.py \
+                 --ignore=language/test_subprocess.py
           # Run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
           TRITON_DISABLE_LINE_INFO=0 python3 -m pytest -s -n 8 language/test_line_info.py
 


### PR DESCRIPTION
About 1 out of 10 runs of the CI test have failed tests in test_subprocess.py on AMD backend. This PR disables this test until we find a solution.
