### PR TITLE
[FRONTEND] Expose CompiledKernel to grid

### DIFF
--- a/python/test/unit/runtime/test_launch.py
+++ b/python/test/unit/runtime/test_launch.py
@@ -71,6 +71,21 @@ def test_memory_leak() -> None:
         tracemalloc.stop()
 
 
+def test_grid() -> None:
+
+    def grid(META):
+        kernel = META["COMPILED_KERNEL"]
+        assert kernel
+        return (1, 1)
+
+    @triton.jit
+    def kernel(x):
+        pass
+
+    # launch kernel
+    kernel[grid](6)
+
+
 # LATENCY_THRESHOLD_US = 46
 
 # def test_kernel_launch_latency() -> None:

--- a/python/test/unit/runtime/test_launch.py
+++ b/python/test/unit/runtime/test_launch.py
@@ -15,6 +15,21 @@ import triton.language as tl
 # from typing import Tuple
 
 
+def test_grid() -> None:
+
+    def grid(META):
+        kernel = META["COMPILED_KERNEL"]
+        assert kernel
+        return (1, 1)
+
+    @triton.jit
+    def kernel(x):
+        pass
+
+    # launch kernel
+    kernel[grid](6)
+
+
 def test_metadata() -> None:
 
     used_hook = False
@@ -69,21 +84,6 @@ def test_memory_leak() -> None:
         assert end - begin < 30000
     finally:
         tracemalloc.stop()
-
-
-def test_grid() -> None:
-
-    def grid(META):
-        kernel = META["COMPILED_KERNEL"]
-        assert kernel
-        return (1, 1)
-
-    @triton.jit
-    def kernel(x):
-        pass
-
-    # launch kernel
-    kernel[grid](6)
 
 
 # LATENCY_THRESHOLD_US = 46

--- a/python/test/unit/runtime/test_launch.py
+++ b/python/test/unit/runtime/test_launch.py
@@ -18,8 +18,9 @@ import triton.language as tl
 def test_grid() -> None:
 
     def grid(META):
-        kernel = META["COMPILED_KERNEL"]
-        assert kernel
+        assert "num_warps" in META
+        assert "n_regs" in META
+        assert "size_smem" in META
         return (1, 1)
 
     @triton.jit

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -361,8 +361,11 @@ class CompiledKernel:
         # (e.g., checking amount of shared memory on current device)
         self.module = None
         self.function = None
+        self._handles_initialized = False
 
     def _init_handles(self):
+        if self._handles_initialized:
+            return
         if self.module is not None:
             return
         device = driver.active.get_current_device()
@@ -375,6 +378,7 @@ class CompiledKernel:
         # TODO: n_regs, n_spills should be metadata generated when calling `ptxas`
         self.module, self.function, self.n_regs, self.n_spills = driver.active.utils.load_binary(
             self.name, self.kernel, self.metadata.shared, device)
+        self._handles_initialized = True
 
     def __getattribute__(self, name):
         if name == 'run':

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -361,11 +361,8 @@ class CompiledKernel:
         # (e.g., checking amount of shared memory on current device)
         self.module = None
         self.function = None
-        self._handles_initialized = False
 
     def _init_handles(self):
-        if self._handles_initialized:
-            return
         if self.module is not None:
             return
         device = driver.active.get_current_device()
@@ -378,7 +375,6 @@ class CompiledKernel:
         # TODO: n_regs, n_spills should be metadata generated when calling `ptxas`
         self.module, self.function, self.n_regs, self.n_spills = driver.active.utils.load_binary(
             self.name, self.kernel, self.metadata.shared, device)
-        self._handles_initialized = True
 
     def __getattribute__(self, name):
         if name == 'run':

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -662,6 +662,9 @@ class JITFunction(KernelInterface[T]):
                 # Arguments are passed as a dict to `grid`, by contract.
                 # TODO(jlebar): In the new launch API, pass the compiler flags as a
                 # second parameter to `grid`.
+                kernel._init_handles()
+                assert "COMPILEDKERNEL" not in bound_args, "special argument COMPILEDKERNEL should not be used"
+                bound_args["COMPILEDKERNEL"] = kernel
                 grid = grid(bound_args)
             grid_size = len(grid)
             grid_0 = grid[0]

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -841,6 +841,7 @@ def jit(
            * python primitives,
            * builtins within the triton package,
            * arguments to this function,
+           * meta-parameters through keyword arguments or the :code:`META` dictionary argument,
            * other jit'd functions
 
     :param fn: the function to be jit-compiled

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -663,8 +663,8 @@ class JITFunction(KernelInterface[T]):
                 # TODO(jlebar): In the new launch API, pass the compiler flags as a
                 # second parameter to `grid`.
                 kernel._init_handles()
-                assert "COMPILEDKERNEL" not in bound_args, "special argument COMPILEDKERNEL should not be used"
-                bound_args["COMPILEDKERNEL"] = kernel
+                assert "COMPILED_KERNEL" not in bound_args, "special argument COMPILED_KERNEL should not be used"
+                bound_args["COMPILED_KERNEL"] = kernel
                 grid = grid(bound_args)
             grid_size = len(grid)
             grid_0 = grid[0]

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -663,8 +663,9 @@ class JITFunction(KernelInterface[T]):
                 # TODO(jlebar): In the new launch API, pass the compiler flags as a
                 # second parameter to `grid`.
                 kernel._init_handles()
-                assert "COMPILED_KERNEL" not in bound_args, "special argument COMPILED_KERNEL should not be used"
-                bound_args["COMPILED_KERNEL"] = kernel
+                bound_args["num_warps"] = kernel.metadata.num_warps
+                bound_args["n_regs"] = kernel.n_regs
+                bound_args["size_smem"] = kernel.metadata.shared
                 grid = grid(bound_args)
             grid_size = len(grid)
             grid_0 = grid[0]


### PR DESCRIPTION
Exposing the CompiledKernel object to the grid callable so that it can be used to decide launch size for persistent kernels. 

An example usage:


```
def grid(META):
      kernel = META["COMPILED_KERNEL"]
      num_warps = kernel.metadata.num_warps
      n_regs = kernel.n_regs
      size_smem = kernel.metadata.shared
      occupancy = NUM_REGS // (n_regs * WARP_SIZE * num_warps)
      occupancy = min(occupancy, SIZE_SMEM // size_smem)
      num_programs = NUM_SM * occupancy
      return (num_programs, 1)
```
