### PR TITLE
Print a stacktrace on fatal signal.

### DIFF
--- a/python/src/main.cc
+++ b/python/src/main.cc
@@ -1,4 +1,7 @@
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Signals.h"
 #include <pybind11/pybind11.h>
+
 namespace py = pybind11;
 
 #define FOR_EACH_1(MACRO, X) MACRO(X)
@@ -41,6 +44,7 @@ FOR_EACH_P(DECLARE_BACKEND, TRITON_BACKENDS_TUPLE)
 
 PYBIND11_MODULE(libtriton, m) {
   m.doc() = "Python bindings to the C++ Triton API";
+  llvm::sys::PrintStackTraceOnErrorSignal("triton_python");
   init_triton_env_vars(m);
   init_triton_ir(m.def_submodule("ir"));
   init_triton_passes(m.def_submodule("passes"));

--- a/unittest/Analysis/UtilityTest.cpp
+++ b/unittest/Analysis/UtilityTest.cpp
@@ -1,9 +1,6 @@
-//===- UtilityTest.cpp - Tests for
-// Utility----------------------------------===//
-//
-//===----------------------------------------------------------------------===//
-
 #include "triton/Dialect/Triton/IR/Utility.h"
+
+#include "llvm/Support/Signals.h"
 #include <gtest/gtest.h>
 
 namespace mlir {
@@ -27,3 +24,9 @@ TEST(Analysis, reorder) {
 }
 
 } // namespace mlir
+
+int main(int argc, char *argv[]) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittest/Conversion/TritonGPUToLLVM/EmitIndicesTest.cpp
+++ b/unittest/Conversion/TritonGPUToLLVM/EmitIndicesTest.cpp
@@ -35,11 +35,10 @@
 
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "llvm/Support/Signals.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace mlir {
-namespace triton {
-namespace gpu {
+namespace mlir::triton::gpu {
 
 //===----------------------------------------------------------------------===//
 // EmitIndicesTest
@@ -1840,15 +1839,10 @@ INSTANTIATE_TEST_SUITE_P(TestCases, LoadSharedToDistributedLLTest,
                                      },
                                  })));
 
-} // namespace gpu
-} // namespace triton
-} // namespace mlir
-
-//===----------------------------------------------------------------------===//
-// Main
-//===----------------------------------------------------------------------===//
+} // namespace mlir::triton::gpu
 
 int main(int argc, char *argv[]) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/unittest/Conversion/TritonGPUToLLVM/PTXAsmFormatTest.cpp
+++ b/unittest/Conversion/TritonGPUToLLVM/PTXAsmFormatTest.cpp
@@ -2,6 +2,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Builders.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/Support/Signals.h"
 
 #include <gtest/gtest.h>
 
@@ -145,3 +146,9 @@ TEST_F(PTXAsmFormatTest, onlyAttachMLIRArgs) {
 
 } // namespace triton
 } // namespace mlir
+
+int main(int argc, char *argv[]) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -6,6 +6,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Tools/StrUtil.h"
+#include "llvm/Support/Signals.h"
 
 namespace {
 
@@ -520,3 +521,9 @@ TEST_F(InferLayoutTest, FuzzReshape) {
 
 } // anonymous namespace
 } // namespace mlir::triton::gpu
+
+int main(int argc, char *argv[]) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -3,7 +3,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
-
+#include "llvm/Support/Signals.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -740,3 +740,9 @@ TEST_F(LinearLayoutConversionsTest, Shared1DSwizzle) {
 
 } // anonymous namespace
 } // namespace mlir::triton::gpu
+
+int main(int argc, char *argv[]) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -1,4 +1,5 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/Support/Signals.h"
 #include <gtest/gtest.h>
 
 using namespace mlir;
@@ -56,3 +57,9 @@ INSTANTIATE_TEST_SUITE_P(TestDotOperands, SwizzleDotOperandTestFixture,
                                            ParamT{{32, 32}, 1, 16, {8, 2, 4}},
                                            ParamT{{16, 16}, 0, 16, {8, 4, 2}},
                                            ParamT{{16, 16}, 1, 16, {8, 4, 2}}));
+
+int main(int argc, char *argv[]) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -1,10 +1,9 @@
 #include "triton/Tools/LinearLayout.h"
-#include "mlir/Support/LLVM.h"
-#include "llvm/Support/MathExtras.h"
 
+#include "mlir/Support/LLVM.h"
+#include "llvm/Support/Signals.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <iterator>
 
 namespace mlir {
 std::ostream &operator<<(std::ostream &os, StringAttr str) {
@@ -539,3 +538,9 @@ TEST_F(LinearLayoutTest, NumConsecutiveInOut) {
 
 } // anonymous namespace
 } // namespace mlir::triton
+
+int main(int argc, char *argv[]) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
I noticed that triton-opt printed a stack but our Python and C++ unit tests
didn't.  After some digging I figured out how LLVM was turning on stacktraces.
This PR turns them on for our C++ unit tests and Triton when run from Python
(!!).
