### PR TITLE
[NFC] Generalize some DotTrait handling

### DIFF
--- a/include/triton/Dialect/Triton/IR/Traits.h
+++ b/include/triton/Dialect/Triton/IR/Traits.h
@@ -71,7 +71,7 @@ public:
       return op->emitOpError("expected 3 operands");
     auto aTy = cast<TensorOrMemDesc>(op->getOperand(0).getType());
     auto bTy = cast<TensorOrMemDesc>(op->getOperand(1).getType());
-    auto cTy = cast<TensorType>(op->getOperand(2).getType());
+    auto cTy = cast<TensorOrMemDesc>(op->getOperand(2).getType());
     auto aShape = aTy.getShape();
     auto bShape = bTy.getShape();
     auto cShape = cTy.getShape();

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -214,11 +214,6 @@ public:
       return failure();
 
     auto dot = *allocOp->getUsers().begin();
-    auto dotEnc = dyn_cast<NvidiaMmaEncodingAttr>(
-        cast<RankedTensorType>(dot->getResult(0).getType()).getEncoding());
-    if (!dotEnc || dotEnc.getVersionMajor() != 3)
-      return failure();
-
     if (!allocOp.getSrc())
       return failure();
 


### PR DESCRIPTION
Remove some unnecessary restrictions on code related to DotLike.

Only Hopper Dot can take shared memory operands so remove some redundant checks.
