### PR TITLE
Skip 13 tests that fail on GPUs with less than 128 KB of shared memory

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3272,7 +3272,7 @@ def test_dot3d(B, num_warps, M, N, K, in_dtype_str, out_dtype_str, device):
 
     capability = torch.cuda.get_device_capability()
     if B == 8 and M == 64 and in_dtype_str == "float32" and out_dtype_str == "float32" and capability not in {(8, 0), (8, 7), (9, 0)}:
-        pytest.skip("Skipping tests with B = 8 and M = 64 due to insufficient shared memory on this GPU")
+        pytest.skip("Skipping tests with B = 8, M = 64, in_type = float32, out_type = float32 due to insufficient shared memory (less than 128 KB per SM) on this GPU.")
 
     @triton.jit
     def kernel(

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3271,8 +3271,12 @@ def test_dot3d(B, num_warps, M, N, K, in_dtype_str, out_dtype_str, device):
         input_precision = "tf32" if in_dtype_str == 'float32' else "ieee"
 
     capability = torch.cuda.get_device_capability()
-    if B == 8 and M == 64 and in_dtype_str == "float32" and out_dtype_str == "float32" and capability not in {(8, 0), (8, 7), (9, 0)}:
-        pytest.skip("Skipping tests with B = 8, M = 64, in_type = float32, out_type = float32 due to insufficient shared memory (less than 128 KB per SM) on this GPU.")
+    if B == 8 and M == 64 and in_dtype_str == "float32" and out_dtype_str == "float32" and capability not in {(8, 0),
+                                                                                                              (8, 7),
+                                                                                                              (9, 0)}:
+        pytest.skip(
+            "Skipping tests with B = 8, M = 64, in_type = float32, out_type = float32 due to insufficient shared memory (less than 128 KB per SM) on this GPU."
+        )
 
     @triton.jit
     def kernel(

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3270,13 +3270,11 @@ def test_dot3d(B, num_warps, M, N, K, in_dtype_str, out_dtype_str, device):
     else:
         input_precision = "tf32" if in_dtype_str == 'float32' else "ieee"
 
-    capability = torch.cuda.get_device_capability()
-    if B == 8 and M == 64 and in_dtype_str == "float32" and out_dtype_str == "float32" and capability not in {(8, 0),
-                                                                                                              (8, 7),
-                                                                                                              (9, 0)}:
-        pytest.skip(
-            "Skipping tests with B = 8, M = 64, in_type = float32, out_type = float32 due to insufficient shared memory (less than 128 KB per SM) on this GPU."
-        )
+    if B == 8 and M == 64 and in_dtype_str == "float32" and out_dtype_str == "float32":
+        if triton.runtime.driver.active.utils.get_device_properties(torch.cuda.current_device())["max_shared_mem"] < 131072:
+            pytest.skip(
+                "Skipping tests with B = 8, M = 64, in_type = float32, out_type = float32 due to insufficient shared memory (less than 128 KB per SM) on this GPU."
+            )
 
     @triton.jit
     def kernel(

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3271,7 +3271,8 @@ def test_dot3d(B, num_warps, M, N, K, in_dtype_str, out_dtype_str, device):
         input_precision = "tf32" if in_dtype_str == 'float32' else "ieee"
 
     if B == 8 and M == 64 and in_dtype_str == "float32" and out_dtype_str == "float32":
-        if triton.runtime.driver.active.utils.get_device_properties(torch.cuda.current_device())["max_shared_mem"] < 131072:
+        if triton.runtime.driver.active.utils.get_device_properties(
+                torch.cuda.current_device())["max_shared_mem"] < 131072:
             pytest.skip(
                 "Skipping tests with B = 8, M = 64, in_type = float32, out_type = float32 due to insufficient shared memory (less than 128 KB per SM) on this GPU."
             )

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3270,6 +3270,10 @@ def test_dot3d(B, num_warps, M, N, K, in_dtype_str, out_dtype_str, device):
     else:
         input_precision = "tf32" if in_dtype_str == 'float32' else "ieee"
 
+    capability = torch.cuda.get_device_capability()
+    if B == 8 and M == 64 and in_dtype_str == "float32" and out_dtype_str == "float32" and capability not in {(8, 0), (8, 7), (9, 0)}:
+        pytest.skip("Skipping tests with B = 8 and M = 64 due to insufficient shared memory on this GPU")
+
     @triton.jit
     def kernel(
         q_ptr,

--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -21,7 +21,9 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype, causal, seq_par, device):
     if capability[0] < 8:
         pytest.skip("Flash attention only supported for compute capability >= 80")
     if D_HEAD == 128 and capability not in {(8, 0), (8, 7), (9, 0)}:
-        pytest.skip("Skipping tests with head_dim = 128 due to insufficient shared memory (less than 128 KB per SM) on this GPU.")
+        pytest.skip(
+            "Skipping tests with head_dim = 128 due to insufficient shared memory (less than 128 KB per SM) on this GPU."
+        )
     if dtype == torch.bfloat16 and os.environ.get("TRITON_INTERPRET", "0") == "1":
         pytest.skip("Flash attention bfloat16 not supported in interpreter mode")
     torch.manual_seed(20)

--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -21,7 +21,8 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype, causal, seq_par, device):
     if capability[0] < 8:
         pytest.skip("Flash attention only supported for compute capability >= 80")
     if D_HEAD == 128:
-        if triton.runtime.driver.active.utils.get_device_properties(torch.cuda.current_device())["max_shared_mem"] < 131072:
+        if triton.runtime.driver.active.utils.get_device_properties(
+                torch.cuda.current_device())["max_shared_mem"] < 131072:
             pytest.skip(
                 "Skipping tests with head_dim = 128 due to insufficient shared memory (less than 128 KB per SM) on this GPU."
             )

--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -21,7 +21,7 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype, causal, seq_par, device):
     if capability[0] < 8:
         pytest.skip("Flash attention only supported for compute capability >= 80")
     if D_HEAD == 128 and capability not in {(8, 0), (8, 7), (9, 0)}:
-        pytest.skip("Skipping tests with head dim = 128 due to insufficient shared memory on this GPU")
+        pytest.skip("Skipping tests with head_dim = 128 due to insufficient shared memory (less than 128 KB per SM) on this GPU.")
     if dtype == torch.bfloat16 and os.environ.get("TRITON_INTERPRET", "0") == "1":
         pytest.skip("Flash attention bfloat16 not supported in interpreter mode")
     torch.manual_seed(20)

--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -20,10 +20,11 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype, causal, seq_par, device):
     capability = torch.cuda.get_device_capability()
     if capability[0] < 8:
         pytest.skip("Flash attention only supported for compute capability >= 80")
-    if D_HEAD == 128 and capability not in {(8, 0), (8, 7), (9, 0)}:
-        pytest.skip(
-            "Skipping tests with head_dim = 128 due to insufficient shared memory (less than 128 KB per SM) on this GPU."
-        )
+    if D_HEAD == 128:
+        if triton.runtime.driver.active.utils.get_device_properties(torch.cuda.current_device())["max_shared_mem"] < 131072:
+            pytest.skip(
+                "Skipping tests with head_dim = 128 due to insufficient shared memory (less than 128 KB per SM) on this GPU."
+            )
     if dtype == torch.bfloat16 and os.environ.get("TRITON_INTERPRET", "0") == "1":
         pytest.skip("Flash attention bfloat16 not supported in interpreter mode")
     torch.manual_seed(20)

--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -20,6 +20,8 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype, causal, seq_par, device):
     capability = torch.cuda.get_device_capability()
     if capability[0] < 8:
         pytest.skip("Flash attention only supported for compute capability >= 80")
+    if D_HEAD == 128 and capability not in {(8, 0), (8, 7), (9, 0)}:
+        pytest.skip("Skipping tests with head dim = 128 due to insufficient shared memory on this GPU")
     if dtype == torch.bfloat16 and os.environ.get("TRITON_INTERPRET", "0") == "1":
         pytest.skip("Flash attention bfloat16 not supported in interpreter mode")
     torch.manual_seed(20)

--- a/python/test/unit/tools/test_aot.py
+++ b/python/test/unit/tools/test_aot.py
@@ -263,11 +263,7 @@ def link_aot_kernels(dir):
 
     # link all desired configs
     h_files = glob.glob(os.path.join(dir, "*.h"))
-    print(linker_path)
-    print(h_files)
-    result = subprocess.run([sys.executable, linker_path] + h_files + ["-o", "kernel"], check=True, cwd=dir, capture_output=True, text=True)
-    print("Linker stdout:", result.stdout)
-    print("Linker stderr:", result.stderr)
+    subprocess.run([sys.executable, linker_path] + h_files + ["-o", "kernel"], check=True, cwd=dir)
 
 
 def generate_matmul_test_data(dir, M, N, K):

--- a/python/test/unit/tools/test_aot.py
+++ b/python/test/unit/tools/test_aot.py
@@ -263,7 +263,11 @@ def link_aot_kernels(dir):
 
     # link all desired configs
     h_files = glob.glob(os.path.join(dir, "*.h"))
-    subprocess.run([sys.executable, linker_path] + h_files + ["-o", "kernel"], check=True, cwd=dir)
+    print(linker_path)
+    print(h_files)
+    result = subprocess.run([sys.executable, linker_path] + h_files + ["-o", "kernel"], check=True, cwd=dir, capture_output=True, text=True)
+    print("Linker stdout:", result.stdout)
+    print("Linker stderr:", result.stderr)
 
 
 def generate_matmul_test_data(dir, M, N, K):


### PR DESCRIPTION
This PR skips 13 tests which currently fail on GPUs with less than 128 KB of shared memory per SM, including the RTX 4090 (compute capability 8.9) and other consumer GPUs. These tests pass on datacenter GPUs with compute capabilities 8.0 (A100), 8.7 (some Jetson products), and 9.0 (H100), which have 128 KB or more of shared memory per SM. 

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have used an LLM to copyedit my PR description and and code comments.

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `fix to existing tests`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added are "minimal" -- they contain only the
    instructions necessary to exercise the bug.  (Usually running Python code
    and using the instructions it generates is not minimal.)
