### PR TITLE
Enable FP8 matmul tests on NVIDIA Ada GPUs

### DIFF
--- a/python/test/unit/operators/test_matmul.py
+++ b/python/test/unit/operators/test_matmul.py
@@ -119,8 +119,8 @@ def test_op(BLOCK_M, BLOCK_N, BLOCK_K, SPLIT_K, NWARP, NSTAGE, M, N, K, AT, BT, 
         pytest.skip("Only test tl.dot() on devices with sm >= 70")
     if capability[0] < 8 and (ADTYPE == "bfloat16" or BDTYPE == "bfloat16"):
         pytest.skip("Only test bfloat16 on devices with sm >= 80")
-    if capability[0] < 9 and (ADTYPE == "float8e4nv" or BDTYPE == "float8e4nv"):
-        pytest.skip("Only test float8e4nv on devices with sm >= 90")
+    if capability[0] < 9 and capability[1] < 9 and (ADTYPE == "float8e4nv" or BDTYPE == "float8e4nv"):
+        pytest.skip("Only test float8e4nv on devices with sm >= 89")
     if (ADTYPE == "bfloat16" or BDTYPE == "bfloat16") and SPLIT_K != 1:
         pytest.skip("bfloat16 matmuls don't allow split_k for now")
     torch.manual_seed(0)

--- a/python/test/unit/runtime/test_cublas.py
+++ b/python/test/unit/runtime/test_cublas.py
@@ -15,10 +15,8 @@ def is_cuda():
 
 @pytest.mark.parametrize("m, n, k", [(16, 16, 16), (32, 16, 16), (16, 32, 16), (16, 16, 32)])
 def test_cublas_fp8(m, n, k, device):
-    if is_cuda():
-        capability = torch.cuda.get_device_capability()
-        if capability[0] < 9 and capability[1] < 9:
-            pytest.skip("test_cublas_fp8 is only supported on CUDA with cc >= 89")
+    if not (is_cuda() and torch.cuda.get_device_capability()[0] >= 9):
+        pytest.skip("test_cublas_fp8 is only supported on CUDA with cc >= 90")
 
     from triton._C.libtriton import nvidia
 

--- a/python/test/unit/runtime/test_cublas.py
+++ b/python/test/unit/runtime/test_cublas.py
@@ -15,8 +15,10 @@ def is_cuda():
 
 @pytest.mark.parametrize("m, n, k", [(16, 16, 16), (32, 16, 16), (16, 32, 16), (16, 16, 32)])
 def test_cublas_fp8(m, n, k, device):
-    if not (is_cuda() and torch.cuda.get_device_capability()[0] >= 9):
-        pytest.skip("test_cublas_fp8 is only supported on CUDA with cc >= 90")
+    if is_cuda():
+        capability = torch.cuda.get_device_capability()
+        if capability[0] < 9 and capability[1] < 9:
+            pytest.skip("test_cublas_fp8 is only supported on CUDA with cc >= 89")
 
     from triton._C.libtriton import nvidia
 


### PR DESCRIPTION
Enable FP8 matmul tests on NVIDIA Ada GPUs (compute capability 8.9). These tests now pass with CUDA 12.4 and PTX ISA 8.4.

Issue #3041 

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it enables existing tests`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added are "minimal" -- they contain only the
    instructions necessary to exercise the bug.  (Usually running Python code
    and using the instructions it generates is not minimal.)
