### PR TITLE
Resolve ambiguity differently in LinearLayout::invertAndCompose.

### DIFF
--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -607,6 +607,10 @@ public:
 
   // Inverts or pseudo-inverts `outer` and composes it with `this`.
   //
+  // Formally, if C = A.invertAndCompose(B), then for all x, C(x) = y implies
+  // A(x) = B(y), or in other words A(x) = B(C(x)).  If B is invertible, then
+  // C(x) = B^-1(A(x)), which is how this function gets its name.
+  //
   // For example, suppose you have the following two LLs.
   //
   //   - R is an LL representing registers, mapping (lane, warp) to a 2D index.

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -268,6 +268,7 @@ private:
       inNumCTAs[d] = ceil<unsigned>(shapePerCTA[d], inPerCTA);
       outNumCTAs[d] = ceil<unsigned>(shapePerCTA[d], outPerCTA);
     }
+
     // Potentially we need to store for multiple CTAs in this replication
     auto accumNumReplicates = product<unsigned>(numReplicates);
     auto vals = unpackLLElements(loc, adaptor.getSrc(), rewriter);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -335,17 +335,8 @@ bool emitTransferBetweenRegistersAndShared(
                       [&](auto offset) { return offset == 0; })) {
       return false;
     }
-
-    // We now have
-    //   regToSharedLayout(0, ..., block=inBlock) => (0, ..., block=outBlock).
-    // To confirm that there's no cross-block communication, we must also have
-    // outBlock == inBlock or outBlock == 0.
-    //
-    // The fact that outBlock == 0 works is nonobvious.  It occurs when the
-    // shared layout is broadcasted in its block dim, i.e. multiple blocks
-    // contain the same data.
     int32_t outBlock = idx.back();
-    if (outBlock != inBlock && outBlock != 0) {
+    if (outBlock != inBlock) {
       return false;
     }
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -817,7 +817,12 @@ struct AsyncCopyGlobalToLocalOpConversion
       assert(srcElems.size() == otherElems.size());
     }
 
-    // TODO: Explain this.
+    // We can load N elements at a time if:
+    //  1. Every group of N source pointers are contiguous.  For example, if
+    //     N=2, then the pointers should be [x, x+1, y, y+1, ...].
+    //  2. The mask (if present) has "alignment" N, meaning that each group of N
+    //     mask bits are the same.  For example if N=2, the mask must be
+    //     [x, x, y, y, ...].
     unsigned maxVec = getContiguity(op.getSrc());
     if (mask) {
       maxVec = std::min(maxVec, getMaskAlignment(mask));

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -505,6 +505,26 @@ TEST_F(LinearLayoutTest, InvertAndCompose_Multidim) {
             l2.transposeOuts(llvm::to_vector(l1.getOutDimNames())));
 }
 
+TEST_F(LinearLayoutTest, InvertAndCompose_BroadcastedDims) {
+  LinearLayout l1({{S("in1"), {{1}, {2}, {4}}}, {S("in2"), {{0}}}}, {S("out")});
+  LinearLayout l2({{S("in3"), {{1}, {2}, {4}}}, {S("in4"), {{0}}}}, {S("out")});
+  LinearLayout c = l1.invertAndCompose(l2);
+  EXPECT_EQ(c, LinearLayout::identity1D(8, S("in1"), S("in3")) *
+                   LinearLayout::identity1D(2, S("in2"), S("in4")));
+  EXPECT_EQ(c.compose(l2),
+            l1.transposeOuts(llvm::to_vector(l2.getOutDimNames())));
+}
+
+TEST_F(LinearLayoutTest, InvertAndCompose_BroadcastedDims2) {
+  LinearLayout a({{S("in1"), {{1}, {2}}}, {S("in2"), {{0}}}}, {S("out")});
+  LinearLayout b({{S("in3"), {{2}, {1}}}, {S("in4"), {{0}}}}, {S("out")});
+  LinearLayout c = a.invertAndCompose(b);
+  EXPECT_EQ(c,
+            LinearLayout({{S("in1"), {{2, 0}, {1, 0}}}, {S("in2"), {{0, 1}}}},
+                         {S("in3"), S("in4")}));
+  EXPECT_EQ(c.compose(b), a.transposeOuts(llvm::to_vector(b.getOutDimNames())));
+}
+
 TEST_F(LinearLayoutTest, NumConsecutiveInOut) {
   EXPECT_EQ(
       1,


### PR DESCRIPTION
<git-pr-chain>


Resolve ambiguity differently in LinearLayout::invertAndCompose.

For example, suppose we're computing C = A.invertAndCompose(B) and we have

  A(thread=1, block=0) = 1
  A(thread=2, block=0) = 2
  A(thread=0, block=1) = 0

  B(thread=1, block=0) = 2
  B(thread=2, block=0) = 1
  B(thread=0, block=1) = 0

we will now choose

  C(thread=1, block=0) = (thread=2, block=0)
  C(thread=2, block=0) = (thread=1, block=0)
  C(thread=0, block=1) = (thread=0, block=1),

whereas before we would have chosen C(thread=0, block=1) = (thread=0, block=0).

The new behavior is better because it means we prefer to load data from the
same block, instead of the old behavior where we would load data from the
lowest-valued possible block.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #4115 👈 **YOU ARE HERE**


</git-pr-chain>
