### PR TITLE
Resolve ambiguity differently in LinearLayout::invertAndCompose.

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -188,10 +188,14 @@ bool supportMMA(Value value, int version);
 
 bool isSingleValue(Value value);
 
+bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy);
+
 bool isMfmaToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstTy);
 
 bool isMmaToDotShortcut(RankedTensorType srcTy, RankedTensorType dstTy);
 
+// TODO(jlebar): Remove this function; it's subsumed by the linear-layout case
+// in cvtNeedsSharedMemory.
 bool isMmaToMmaShortcut(RankedTensorType srcTy, RankedTensorType dstTy);
 
 // Return true if the src and dst layout match.

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -607,6 +607,10 @@ public:
 
   // Inverts or pseudo-inverts `outer` and composes it with `this`.
   //
+  // Formally, if C = A.invertAndCompose(B), then for all x, C(x) = y implies
+  // A(x) = B(y), or in other words A(x) = B(C(x)).  If B is invertible, then
+  // C(x) = B^-1(A(x)), which is how this function gets its name.
+  //
   // For example, suppose you have the following two LLs.
   //
   //   - R is an LL representing registers, mapping (lane, warp) to a 2D index.

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -493,6 +493,8 @@ public:
   //
   // This only works across the first (i.e. the most-minor) dimension of in/out.
   // If you want it to work across more dimensions, flatten the layout.
+  //
+  // DO NOT SUBMIT: Delete me and use divideLeft instead.
   int32_t getNumConsecutiveInOut() const;
 
   // Reorders the in/out dimensions of the layout.  This is mostly cosmetic
@@ -574,10 +576,11 @@ public:
     return *this;
   }
 
-  // TODO(jlebar): Implement the inverse of operator*, namely
-  //   std::optional<LinearLayout> divideLeft(const LinearLayout&);
-  //   std::optional<LinearLayout> divideRight(const LinearLayout&);
-  // In particular, these might subsume getNumConsecutiveInOut.
+  // divideLeft and divideRight are the inverses of operator*.
+  //
+  // If c = a * b, then a = c.divideRight(b) and b = c.divideLeft(a).
+  std::optional<LinearLayout> divideLeft(const LinearLayout &divisor);
+  std::optional<LinearLayout> divideRight(const LinearLayout &divisor);
 
   // Computes and returns L(x, y, z).
   //

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -268,6 +268,7 @@ private:
       inNumCTAs[d] = ceil<unsigned>(shapePerCTA[d], inPerCTA);
       outNumCTAs[d] = ceil<unsigned>(shapePerCTA[d], outPerCTA);
     }
+
     // Potentially we need to store for multiple CTAs in this replication
     auto accumNumReplicates = product<unsigned>(numReplicates);
     auto vals = unpackLLElements(loc, adaptor.getSrc(), rewriter);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -335,17 +335,8 @@ bool emitTransferBetweenRegistersAndShared(
                       [&](auto offset) { return offset == 0; })) {
       return false;
     }
-
-    // We now have
-    //   regToSharedLayout(0, ..., block=inBlock) => (0, ..., block=outBlock).
-    // To confirm that there's no cross-block communication, we must also have
-    // outBlock == inBlock or outBlock == 0.
-    //
-    // The fact that outBlock == 0 works is nonobvious.  It occurs when the
-    // shared layout is broadcasted in its block dim, i.e. multiple blocks
-    // contain the same data.
     int32_t outBlock = idx.back();
-    if (outBlock != inBlock && outBlock != 0) {
+    if (outBlock != inBlock) {
       return false;
     }
   }

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -179,28 +179,28 @@ tt.func @longlive(%A : !tt.ptr<f16>) {
 tt.func @multi_color(%A : !tt.ptr<f16>) {
   // CHECK: offset = 0, size = 64
   %cst = triton_gpu.local_alloc : () -> !tt.memdesc<4x8xf16, #A_SHARED, #triton_gpu.shared_memory>
-  // CHECK-NEXT: offset = 1536, size = 32
+  // CHECK-NEXT: offset = 256, size = 32
   %cst_0 = triton_gpu.local_alloc : () -> !tt.memdesc<4x4xf16, #A_SHARED, #triton_gpu.shared_memory>
   // CHECK-NEXT: offset = 1664, size = 128
   %cst_1 = triton_gpu.local_alloc : () -> !tt.memdesc<16x4xf16, #A_SHARED, #triton_gpu.shared_memory>
   %cst_2 = arith.constant dense<0.000000e+00> : tensor<16x32xf16, #AL>
-  // CHECK-NEXT: scratch offset = 128, size = 1152
+  // CHECK-NEXT: scratch offset = 128, size = 2
   %0 = triton_gpu.convert_layout %cst_2 : tensor<16x32xf16, #AL> -> tensor<16x32xf16, #AL>
   %1 = triton_gpu.local_load %cst : !tt.memdesc<4x8xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<4x8xf16, #AL>
   // CHECK-NEXT: offset = 0, size = 128
   %cst_3 = triton_gpu.local_alloc : () -> !tt.memdesc<4x16xf16, #A_SHARED, #triton_gpu.shared_memory>
   %2 = triton_gpu.local_load %cst_0 : !tt.memdesc<4x4xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<4x4xf16, #AL>
-  // CHECK-NEXT: scratch offset = 0, size = 1152
+  // CHECK-NEXT: scratch offset = 0, size = 2
   %3 = triton_gpu.convert_layout %cst_2 : tensor<16x32xf16, #AL> -> tensor<16x32xf16, #AL>
   // CHECK-NEXT: offset = 0, size = 256
   %cst_4 = triton_gpu.local_alloc : () -> !tt.memdesc<4x32xf16, #A_SHARED, #triton_gpu.shared_memory>
-  // CHECK-NEXT: offset = 256, size = 64
+  // CHECK-NEXT: offset = 288, size = 64
   %cst_5 = triton_gpu.local_alloc : () -> !tt.memdesc<4x8xf16, #A_SHARED, #triton_gpu.shared_memory>
   %4 = triton_gpu.local_load %cst_5 : !tt.memdesc<4x8xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<4x8xf16, #AL>
   %5 = triton_gpu.local_load %cst_5 : !tt.memdesc<4x8xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<4x8xf16, #AL>
   // CHECK-NEXT: offset = 1024, size = 512
   %cst_6 = triton_gpu.local_alloc : () -> !tt.memdesc<8x32xf16, #A_SHARED, #triton_gpu.shared_memory>
-  // CHECK-NEXT: offset = 1792, size = 128
+  // CHECK-NEXT: offset = 1536, size = 128
   %cst_7 = triton_gpu.local_alloc : () -> !tt.memdesc<2x32xf16, #A_SHARED, #triton_gpu.shared_memory>
   %6 = triton_gpu.local_load %cst_0 : !tt.memdesc<4x4xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<4x4xf16, #AL>
   // CHECK-NEXT: offset = 1024, size = 512
@@ -211,13 +211,13 @@ tt.func @multi_color(%A : !tt.ptr<f16>) {
   %cst_10 = triton_gpu.local_alloc : () -> !tt.memdesc<1x16x16xf16, #A_SHARED, #triton_gpu.shared_memory>
   %7 = triton_gpu.local_load %cst_1 : !tt.memdesc<16x4xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<16x4xf16, #AL>
   %8 = triton_gpu.local_load %cst_4 : !tt.memdesc<4x32xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<4x32xf16, #AL>
-  // CHECK-NEXT: scratch offset = 0, size = 1152
+  // CHECK-NEXT: scratch offset = 0, size = 2
   %9 = triton_gpu.convert_layout %cst_2 : tensor<16x32xf16, #AL> -> tensor<16x32xf16, #AL>
   %cst_11 = arith.constant dense<0.000000e+00> : tensor<4x4xf16, #AL>
   %10 = triton_gpu.local_load %cst_7 : !tt.memdesc<2x32xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<2x32xf16, #AL>
   %cst_12 = arith.constant dense<0.000000e+00> : tensor<4x16xf16, #AL>
   %cst_13 = arith.constant dense<0.000000e+00> : tensor<8x32xf16, #AL>
-  // CHECK-NEXT: size = 1920
+  // CHECK-NEXT: size = 1792
   tt.return
 }
 
@@ -226,25 +226,25 @@ tt.func @multi_color(%A : !tt.ptr<f16>) {
 tt.func @multi_color_multi_rounds(%arg0: !tt.ptr<f16>) {
   // CHECK: offset = 0, size = 32
   %cst = triton_gpu.local_alloc : () -> !tt.memdesc<4x4xf16, #A_SHARED, #triton_gpu.shared_memory>
-  // CHECK-NEXT: offset = 1280, size = 128
+  // CHECK-NEXT: offset = 512, size = 128
   %cst_0 = triton_gpu.local_alloc : () -> !tt.memdesc<16x4xf16, #A_SHARED, #triton_gpu.shared_memory>
-  // CHECK-NEXT: offset = 2048, size = 8192
+  // CHECK-NEXT: offset = 1024, size = 8192
   %cst_1 = triton_gpu.local_alloc : () -> !tt.memdesc<1024x4xf16, #A_SHARED, #triton_gpu.shared_memory>
   %cst_2 = arith.constant dense<0.000000e+00> : tensor<16x32xf16, #AL>
-  // CHECK-NEXT: scratch offset = 128, size = 1152
+  // CHECK-NEXT: scratch offset = 128, size = 2
   %0 = triton_gpu.convert_layout %cst_2 : tensor<16x32xf16, #AL> -> tensor<16x32xf16, #AL>
   %1 = triton_gpu.local_load %cst : !tt.memdesc<4x4xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<4x4xf16, #AL>
-  // CHECK-NEXT: offset = 1152, size = 128
+  // CHECK-NEXT: offset = 9216, size = 128
   %cst_3 = triton_gpu.local_alloc : () -> !tt.memdesc<2x32xf16, #A_SHARED, #triton_gpu.shared_memory>
   %2 = triton_gpu.local_load %cst : !tt.memdesc<4x4xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<4x4xf16, #AL>
   // CHECK-NEXT: offset = 0, size = 512
   %cst_4 = triton_gpu.local_alloc : () -> !tt.memdesc<1x16x16xf16, #A_SHARED, #triton_gpu.shared_memory>
   %3 = triton_gpu.local_load %cst_0 : !tt.memdesc<16x4xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<16x4xf16, #AL>
   %4 = triton_gpu.local_load %cst_1 : !tt.memdesc<1024x4xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<1024x4xf16, #AL>
-  // CHECK-NEXT: scratch offset = 0, size = 1152
+  // CHECK-NEXT: scratch offset = 0, size = 2
   %5 = triton_gpu.convert_layout %cst_2 : tensor<16x32xf16, #AL> -> tensor<16x32xf16, #AL>
   %6 = triton_gpu.local_load %cst_3 : !tt.memdesc<2x32xf16, #A_SHARED, #triton_gpu.shared_memory> -> tensor<2x32xf16, #AL>
-  // CHECK-NEXT: size = 10240
+  // CHECK-NEXT: size = 9344
   tt.return
 }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -817,7 +817,12 @@ struct AsyncCopyGlobalToLocalOpConversion
       assert(srcElems.size() == otherElems.size());
     }
 
-    // TODO: Explain this.
+    // We can load N elements at a time if:
+    //  1. Every group of N source pointers are contiguous.  For example, if
+    //     N=2, then the pointers should be [x, x+1, y, y+1, ...].
+    //  2. The mask (if present) has "alignment" N, meaning that each group of N
+    //     mask bits are the same.  For example if N=2, the mask must be
+    //     [x, x, y, y, ...].
     unsigned maxVec = getContiguity(op.getSrc());
     if (mask) {
       maxVec = std::min(maxVec, getMaskAlignment(mask));

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -505,6 +505,26 @@ TEST_F(LinearLayoutTest, InvertAndCompose_Multidim) {
             l2.transposeOuts(llvm::to_vector(l1.getOutDimNames())));
 }
 
+TEST_F(LinearLayoutTest, InvertAndCompose_BroadcastedDims) {
+  LinearLayout l1({{S("in1"), {{1}, {2}, {4}}}, {S("in2"), {{0}}}}, {S("out")});
+  LinearLayout l2({{S("in3"), {{1}, {2}, {4}}}, {S("in4"), {{0}}}}, {S("out")});
+  LinearLayout c = l1.invertAndCompose(l2);
+  EXPECT_EQ(c, LinearLayout::identity1D(8, S("in1"), S("in3")) *
+                   LinearLayout::identity1D(2, S("in2"), S("in4")));
+  EXPECT_EQ(c.compose(l2),
+            l1.transposeOuts(llvm::to_vector(l2.getOutDimNames())));
+}
+
+TEST_F(LinearLayoutTest, InvertAndCompose_BroadcastedDims2) {
+  LinearLayout a({{S("in1"), {{1}, {2}}}, {S("in2"), {{0}}}}, {S("out")});
+  LinearLayout b({{S("in3"), {{2}, {1}}}, {S("in4"), {{0}}}}, {S("out")});
+  LinearLayout c = a.invertAndCompose(b);
+  EXPECT_EQ(c,
+            LinearLayout({{S("in1"), {{2, 0}, {1, 0}}}, {S("in2"), {{0, 1}}}},
+                         {S("in3"), S("in4")}));
+  EXPECT_EQ(c.compose(b), a.transposeOuts(llvm::to_vector(b.getOutDimNames())));
+}
+
 TEST_F(LinearLayoutTest, NumConsecutiveInOut) {
   EXPECT_EQ(
       1,

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -556,6 +556,36 @@ TEST_F(LinearLayoutTest, NumConsecutiveInOut) {
                    .getNumConsecutiveInOut());
 }
 
+TEST_F(LinearLayoutTest, DivideRight_Simple) {
+  EXPECT_EQ(LinearLayout::identity1D(8, S("in"), S("out"))
+                .divideRight(LinearLayout::identity1D(4, S("in"), S("out"))),
+            LinearLayout::identity1D(2, S("in"), S("out")));
+
+  EXPECT_EQ(LinearLayout::identity1D(8, S("in"), S("out"))
+                .divideRight(LinearLayout::identity1D(8, S("in"), S("out"))),
+            LinearLayout::empty());
+}
+
+TEST_F(LinearLayoutTest, DivideRight_Assertion) {
+  LinearLayout l1({{S("register"),
+                    {{0, 1, 0, 0}, {0, 2, 0, 0}, {0, 0, 2, 0}, {1, 0, 0, 0}}},
+                   {S("lane"),
+                    {{0, 4, 0, 0},
+                     {0, 8, 0, 0},
+                     {0, 16, 0, 0},
+                     {0, 0, 1, 0},
+                     {2, 0, 0, 0}}},
+                   {S("warp"), {{4, 0, 0, 0}, {8, 0, 0, 0}}},
+                   {S("block"), {}}},
+                  {S("register"), S("lane"), S("warp"), S("block")});
+  LinearLayout l2 = LinearLayout::identity1D(32, S("lane"), S("lane")) *
+                    LinearLayout::identity1D(4, S("warp"), S("warp")) *
+                    LinearLayout::identity1D(1, S("block"), S("block"));
+  EXPECT_EQ(l1.divideRight(l2), std::nullopt);
+}
+
+// XXX: Lots more tests.
+
 } // anonymous namespace
 } // namespace mlir::triton
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Resolve ambiguity differently in LinearLayout::invertAndCompose.
    
    For example, suppose we're computing C = A.invertAndCompose(B) and we have
    
      A(thread=1, block=0) = 1
      A(thread=2, block=0) = 2
      A(thread=0, block=1) = 0
    
      B(thread=1, block=0) = 2
      B(thread=2, block=0) = 1
      B(thread=0, block=1) = 0
    
    we will now choose
    
      C(thread=1, block=0) = (thread=2, block=0)
      C(thread=2, block=0) = (thread=1, block=0)
      C(thread=0, block=1) = (thread=0, block=1),
    
    whereas before we would have chosen C(thread=0, block=1) = (thread=0, block=0).
    
    The new behavior is better because it means we prefer to load data from the
    same block, instead of the old behavior where we would load data from the
    lowest-valued possible block.
1. [WIP] Use LLs for register-to-register convert-layout ops.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #4124 👈 **YOU ARE HERE**


</git-pr-chain>
