### PR TITLE
Fix reduction for slicing of a 3D tensor

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -73,6 +73,20 @@ unsigned ReduceOpHelper::getThreadOffsetOnReductionAxis() {
     auto parentLayout = sliceLayout.getParent();
     auto threadsPerWarp = getThreadsPerWarp(parentLayout);
     threadOffset = threadsPerWarp[sliceLayout.getDim()];
+    // For cases where there is another dimension in between sliceDim and axis:
+    auto sliceDim = sliceLayout.getDim();
+    auto order = getOrder(parentLayout);
+    int axisOrder = -1, sliceDimOrder = -1;
+    for (unsigned i = 0; i < order.size(); i++) {
+      if (order[i] == axis)
+        axisOrder = i;
+      if (order[i] == sliceDim)
+        sliceDimOrder = i;
+    }
+    assert(axisOrder >= 0 && sliceDimOrder >= 0);
+    // This loop does nothing if sliceDimOrder >= axisDimOrder.
+    for (unsigned i = sliceDimOrder + 1; i < axisOrder; i++)
+      threadOffset *= threadsPerWarp[order[i]];
   } else {
     auto threadsPerWarp = getThreadsPerWarp(srcLayout);
     auto order = getOrder(srcLayout);


### PR DESCRIPTION
Summary: Incorrect results were observed when the order is [2, 0, 1]. When calculating the thread index offset, we should consider dimensions that are in between the order for sliceDim and the order for axis.

Fix https://github.com/triton-lang/triton/issues/4116. Thanks Thomas for the code pointer.
