### PR TITLE
s/ConversionPatternRewriter/RewriterBase/ in utils (NFC)

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -10,34 +10,34 @@ public:
 
   virtual Value getClusterCTAId(RewriterBase &rewriter, Location loc) const = 0;
 
-  virtual Value ballot(ConversionPatternRewriter &rewriter, Location loc,
-                       Type type, Value cmp) const = 0;
+  virtual Value ballot(RewriterBase &rewriter, Location loc, Type type,
+                       Value cmp) const = 0;
 
-  virtual void storeShared(ConversionPatternRewriter &rewriter, Location loc,
-                           Value ptr, Value val, Value pred) const = 0;
-  virtual Value loadShared(ConversionPatternRewriter &rewriter, Location loc,
+  virtual void storeShared(RewriterBase &rewriter, Location loc, Value ptr,
+                           Value val, Value pred) const = 0;
+  virtual Value loadShared(RewriterBase &rewriter, Location loc,
                            const TypeConverter *converter, Value ptr,
                            Type elemTy, Value pred) const = 0;
 
-  virtual Value shuffleXor(ConversionPatternRewriter &rewriter, Location loc,
-                           Value val, int i) const = 0;
-  virtual Value shuffleUp(ConversionPatternRewriter &rewriter, Location loc,
-                          Value val, int i) const = 0;
-  virtual Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc,
-                           Value val, int i) const = 0;
-  virtual Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc,
-                           Value val, Value i) const = 0;
+  virtual Value shuffleXor(RewriterBase &rewriter, Location loc, Value val,
+                           int i) const = 0;
+  virtual Value shuffleUp(RewriterBase &rewriter, Location loc, Value val,
+                          int i) const = 0;
+  virtual Value shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
+                           int i) const = 0;
+  virtual Value shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
+                           Value i) const = 0;
 
-  virtual Value programId(ConversionPatternRewriter &rewriter, Location loc,
+  virtual Value programId(RewriterBase &rewriter, Location loc,
                           ModuleOp moduleOp, int axis) const = 0;
 
-  virtual bool warpReduce(ConversionPatternRewriter &rewriter, Location loc,
+  virtual bool warpReduce(RewriterBase &rewriter, Location loc,
                           SmallVector<Value> &acc, triton::ReduceOp op,
                           unsigned numLaneToReduce,
                           unsigned interleave) const = 0;
 
   virtual bool processReplicaUsingStMatrix(
-      ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
+      RewriterBase &rewriter, Location loc, Value smemBase,
       SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
       ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
       ArrayRef<unsigned> outOrd, unsigned accumNumReplicates,
@@ -48,11 +48,11 @@ public:
   // format from the device. |formatStrStart| is the pointer to the start of
   // the format string global variable; |args| are the arguments to fill
   // placeholders in the format string.
-  virtual void printf(ConversionPatternRewriter &rewriter, Value formatStrStart,
+  virtual void printf(RewriterBase &rewriter, Value formatStrStart,
                       int formatStrByteCount, ValueRange args) const = 0;
   // Emits LLVM code with |rewriter| to perform assertion failure with the given
   // |message| from the given |func| in |file|.
-  virtual void assertFail(ConversionPatternRewriter &rewriter, Location loc,
+  virtual void assertFail(RewriterBase &rewriter, Location loc,
                           StringRef message, StringRef file, StringRef func,
                           int line) const = 0;
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -18,51 +18,52 @@ public:
 
   Value getClusterCTAId(RewriterBase &rewriter, Location loc) const override;
 
-  Value ballot(ConversionPatternRewriter &rewriter, Location loc, Type type,
+  Value ballot(RewriterBase &rewriter, Location loc, Type type,
                Value cmp) const override;
 
-  void storeShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
-                   Value val, Value pred) const override;
-  Value loadShared(ConversionPatternRewriter &rewriter, Location loc,
+  void storeShared(RewriterBase &rewriter, Location loc, Value ptr, Value val,
+                   Value pred) const override;
+  Value loadShared(RewriterBase &rewriter, Location loc,
                    const TypeConverter *converter, Value ptr, Type elemTy,
                    Value pred) const override;
 
-  Value shuffleXor(ConversionPatternRewriter &rewriter, Location loc, Value val,
+  Value shuffleXor(RewriterBase &rewriter, Location loc, Value val,
                    int i) const override;
-  Value shuffleUp(ConversionPatternRewriter &rewriter, Location loc, Value val,
+  Value shuffleUp(RewriterBase &rewriter, Location loc, Value val,
                   int i) const override;
-  Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc, Value val,
+  Value shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
                    int i) const override;
-  Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc, Value val,
+  Value shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
                    Value i) const override;
 
-  Value programId(ConversionPatternRewriter &rewriter, Location loc,
-                  ModuleOp moduleOp, int axis) const override;
+  Value programId(RewriterBase &rewriter, Location loc, ModuleOp moduleOp,
+                  int axis) const override;
 
-  bool warpReduce(ConversionPatternRewriter &rewriter, Location loc,
-                  SmallVector<Value> &acc, triton::ReduceOp op,
-                  unsigned numLaneToReduce, unsigned interleave) const override;
+  bool warpReduce(RewriterBase &rewriter, Location loc, SmallVector<Value> &acc,
+                  triton::ReduceOp op, unsigned numLaneToReduce,
+                  unsigned interleave) const override;
 
-  bool processReplicaUsingStMatrix(
-      ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
-      SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
-      ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
-      ArrayRef<unsigned> outOrd, unsigned accumNumReplicates,
-      int swizzleByteWidth) const override;
+  bool processReplicaUsingStMatrix(RewriterBase &rewriter, Location loc,
+                                   Value smemBase, SmallVector<Value> &vals,
+                                   RankedTensorType srcTy, Type elemTy,
+                                   ArrayRef<unsigned> paddedRepShape,
+                                   ArrayRef<unsigned> origRepShape,
+                                   ArrayRef<unsigned> outOrd,
+                                   unsigned accumNumReplicates,
+                                   int swizzleByteWidth) const override;
 
   std::string getMulhiFuncName(Type resultElementTy) const override;
 
-  void printf(ConversionPatternRewriter &rewriter, Value formatStrStart,
+  void printf(RewriterBase &rewriter, Value formatStrStart,
               int formatStrByteCount, ValueRange args) const override;
-  void assertFail(ConversionPatternRewriter &rewriter, Location loc,
-                  StringRef message, StringRef file, StringRef func,
-                  int line) const override;
+  void assertFail(RewriterBase &rewriter, Location loc, StringRef message,
+                  StringRef file, StringRef func, int line) const override;
 
   bool enableLinearLayout() const override { return false; }
 
 private:
   void printfImpl(Value formatStrStart, int formatStrByteCount, ValueRange args,
-                  ConversionPatternRewriter &rewriter, bool useStdErr) const;
+                  RewriterBase &rewriter, bool useStdErr) const;
 
   std::string arch;
 };

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -13,26 +13,22 @@ namespace mlir::LLVM::AMD {
 const char Predicated_Load[] = "__predicated_load";
 const char Predicated_Store[] = "__predicated_store";
 
-Value shuffleXor(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                 int i);
-Value shuffleUp(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                int i);
-Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                 int i);
-Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                 Value i);
+Value shuffleXor(Location loc, RewriterBase &rewriter, Value val, int i);
+Value shuffleUp(Location loc, RewriterBase &rewriter, Value val, int i);
+Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, int i);
+Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i);
 
-Value llGetPid(Location loc, ConversionPatternRewriter &rewriter,
-               ModuleOp moduleOp, int axis);
+Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
+               int axis);
 
 // Loads from shared or global memory with predication.
 // `otherElems` is used to mask out the elements that are not loaded
-Value llLoad(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
-             Type elemTy, Value pred, Value falseVal);
+Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
+             Value pred, Value falseVal);
 
 // Stores to shared or global memory with predication.
-void llStore(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
-             Value val, Value pred);
+void llStore(RewriterBase &rewriter, Location loc, Value ptr, Value val,
+             Value pred);
 } // namespace mlir::LLVM::AMD
 
 #endif

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -14,8 +14,7 @@ using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::getShapePerCTATile;
 namespace {
 Value computeStMatrixAddr(Value laneId, int matStride, Location loc,
-                          ConversionPatternRewriter &rewriter,
-                          int swizzleByteWidth) {
+                          RewriterBase &rewriter, int swizzleByteWidth) {
   Value rowInMat = urem(laneId, i32_val(8)); // row in the 8x8 matrix
   // linear index of the matrix in the 2x2 matrices
   // Decompose matIndex => s_0, s_1, that is the coordinate in 2x2 matrices in
@@ -34,7 +33,7 @@ Value computeStMatrixAddr(Value laneId, int matStride, Location loc,
 
 void stMatrixm8n8x4(Value offset, ArrayRef<Value> vals, int indexOffset,
                     Value smemBase, Type elemTy, Location loc,
-                    ConversionPatternRewriter &rewriter) {
+                    RewriterBase &rewriter) {
   SmallVector<Value> inputs;
   auto prTy = ptr_ty(rewriter.getContext(), 3);
   // Pack the input into 2xf16
@@ -53,8 +52,8 @@ void stMatrixm8n8x4(Value offset, ArrayRef<Value> vals, int indexOffset,
 void storeDistributedToSharedWithStMatrix(
     RankedTensorType tensorTy, Type elemTy, SmallVector<Value> &inVals,
     Value smemBase, ArrayRef<unsigned> paddedRepShape,
-    ArrayRef<unsigned> origRepShape, Location loc,
-    ConversionPatternRewriter &rewriter, int swizzlingByteWidth) {
+    ArrayRef<unsigned> origRepShape, Location loc, RewriterBase &rewriter,
+    int swizzlingByteWidth) {
   auto shapePerCTA = getShapePerCTA(tensorTy);
   auto mmaLayout = mlir::cast<NvidiaMmaEncodingAttr>(tensorTy.getEncoding());
   auto order = triton::gpu::getOrder(mmaLayout);
@@ -140,7 +139,7 @@ bool isStMatrixCompatible(RankedTensorType tensorTy, int swizzlingByteWidth) {
 }
 
 // declare vprintf(i8*, i8*) as external function
-LLVM::LLVMFuncOp getVprintfDeclaration(ConversionPatternRewriter &rewriter) {
+LLVM::LLVMFuncOp getVprintfDeclaration(RewriterBase &rewriter) {
   auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
   StringRef funcName("vprintf");
   Operation *funcOp = moduleOp.lookupSymbol(funcName);
@@ -152,7 +151,7 @@ LLVM::LLVMFuncOp getVprintfDeclaration(ConversionPatternRewriter &rewriter) {
   SmallVector<Type> argsType{ptr_ty(context), ptr_ty(context)};
   auto funcType = LLVM::LLVMFunctionType::get(i32_ty, argsType);
 
-  ConversionPatternRewriter::InsertionGuard guard(rewriter);
+  RewriterBase::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointToStart(moduleOp.getBody());
 
   return rewriter.create<LLVM::LLVMFuncOp>(UnknownLoc::get(context), funcName,
@@ -161,8 +160,7 @@ LLVM::LLVMFuncOp getVprintfDeclaration(ConversionPatternRewriter &rewriter) {
 
 // extend integer to int32, extend float to float64
 // this comes from vprintf alignment requirements.
-std::pair<Type, Value> printfPromoteValue(ConversionPatternRewriter &rewriter,
-                                          Value value) {
+std::pair<Type, Value> printfPromoteValue(RewriterBase &rewriter, Value value) {
   auto *context = rewriter.getContext();
   auto type = value.getType();
   Value newOp = value;
@@ -186,7 +184,7 @@ std::pair<Type, Value> printfPromoteValue(ConversionPatternRewriter &rewriter,
   return {newType, newOp};
 }
 
-LLVM::LLVMFuncOp getAssertfailDeclaration(ConversionPatternRewriter &rewriter) {
+LLVM::LLVMFuncOp getAssertfailDeclaration(RewriterBase &rewriter) {
   auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
   StringRef funcName("__assertfail");
   {
@@ -200,7 +198,7 @@ LLVM::LLVMFuncOp getAssertfailDeclaration(ConversionPatternRewriter &rewriter) {
   SmallVector<Type> argsType{ptr_ty(ctx), ptr_ty(ctx), i32_ty, ptr_ty(ctx),
                              rewriter.getIntegerType(sizeof(size_t) * 8)};
   auto funcType = LLVM::LLVMFunctionType::get(void_ty(ctx), argsType);
-  ConversionPatternRewriter::InsertionGuard guard(rewriter);
+  RewriterBase::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointToStart(moduleOp.getBody());
   auto funcOp = rewriter.create<LLVM::LLVMFuncOp>(UnknownLoc::get(ctx),
                                                   funcName, funcType);
@@ -260,13 +258,13 @@ Value TargetInfo::getClusterCTAId(RewriterBase &rewriter, Location loc) const {
                                                         rewriter.getI32Type());
 }
 
-Value TargetInfo::ballot(ConversionPatternRewriter &rewriter, Location loc,
-                         Type type, Value cmp) const {
+Value TargetInfo::ballot(RewriterBase &rewriter, Location loc, Type type,
+                         Value cmp) const {
   Value threadMask = int_val(type.getIntOrFloatBitWidth(), -1);
   return rewriter.create<NVVM::VoteBallotOp>(loc, type, threadMask, cmp);
 }
-void TargetInfo::storeShared(ConversionPatternRewriter &rewriter, Location loc,
-                             Value ptr, Value val, Value pred) const {
+void TargetInfo::storeShared(RewriterBase &rewriter, Location loc, Value ptr,
+                             Value val, Value pred) const {
   MLIRContext *ctx = rewriter.getContext();
   unsigned bits = std::max(8u, val.getType().getIntOrFloatBitWidth());
   const char *c = bits == 64 ? "l" : (bits == 16 ? "h" : "r");
@@ -279,7 +277,7 @@ void TargetInfo::storeShared(ConversionPatternRewriter &rewriter, Location loc,
   builder.launch(rewriter, loc, void_ty(ctx));
 }
 
-Value TargetInfo::loadShared(ConversionPatternRewriter &rewriter, Location loc,
+Value TargetInfo::loadShared(RewriterBase &rewriter, Location loc,
                              const TypeConverter *converter, Value ptr,
                              Type elemTy, Value pred) const {
   MLIRContext *ctx = rewriter.getContext();
@@ -297,31 +295,31 @@ Value TargetInfo::loadShared(ConversionPatternRewriter &rewriter, Location loc,
   return builder.launch(rewriter, loc, elemTy);
 }
 
-Value TargetInfo::shuffleXor(ConversionPatternRewriter &rewriter, Location loc,
-                             Value val, int i) const {
+Value TargetInfo::shuffleXor(RewriterBase &rewriter, Location loc, Value val,
+                             int i) const {
   return LLVM::NVIDIA::shuffleXor(loc, rewriter, val, i);
 }
 
-Value TargetInfo::shuffleUp(ConversionPatternRewriter &rewriter, Location loc,
-                            Value val, int i) const {
+Value TargetInfo::shuffleUp(RewriterBase &rewriter, Location loc, Value val,
+                            int i) const {
   return LLVM::NVIDIA::shuffleUp(loc, rewriter, val, i);
 }
 
-Value TargetInfo::shuffleIdx(ConversionPatternRewriter &rewriter, Location loc,
-                             Value val, int i) const {
+Value TargetInfo::shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
+                             int i) const {
   return LLVM::NVIDIA::shuffleIdx(loc, rewriter, val, i);
 }
 
-Value TargetInfo::shuffleIdx(ConversionPatternRewriter &rewriter, Location loc,
-                             Value val, Value i) const {
+Value TargetInfo::shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
+                             Value i) const {
   return LLVM::NVIDIA::shuffleIdx(loc, rewriter, val, i);
 }
 
-Value TargetInfo::programId(ConversionPatternRewriter &rewriter, Location loc,
+Value TargetInfo::programId(RewriterBase &rewriter, Location loc,
                             ModuleOp moduleOp, int axis) const {
   return LLVM::NVIDIA::llGetPid(loc, rewriter, moduleOp, axis);
 }
-bool TargetInfo::warpReduce(ConversionPatternRewriter &rewriter, Location loc,
+bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
                             SmallVector<Value> &acc, triton::ReduceOp op,
                             unsigned numLaneToReduce,
                             unsigned interleave) const {
@@ -362,7 +360,7 @@ bool TargetInfo::warpReduce(ConversionPatternRewriter &rewriter, Location loc,
   return false;
 }
 bool TargetInfo::processReplicaUsingStMatrix(
-    ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
+    RewriterBase &rewriter, Location loc, Value smemBase,
     SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
     ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
     ArrayRef<unsigned> outOrd, unsigned accumNumReplicates,
@@ -383,9 +381,8 @@ std::string TargetInfo::getMulhiFuncName(Type resultElementTy) const {
   return funcName;
 }
 
-void TargetInfo::printf(ConversionPatternRewriter &rewriter,
-                        Value formatStrStart, int /*formatStrByteCount*/,
-                        ValueRange args) const {
+void TargetInfo::printf(RewriterBase &rewriter, Value formatStrStart,
+                        int /*formatStrByteCount*/, ValueRange args) const {
   auto *ctx = rewriter.getContext();
   Type ptr = ptr_ty(ctx);
   auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
@@ -426,7 +423,7 @@ void TargetInfo::printf(ConversionPatternRewriter &rewriter,
   call(funcOp, operands);
 }
 
-void TargetInfo::assertFail(ConversionPatternRewriter &rewriter, Location loc,
+void TargetInfo::assertFail(RewriterBase &rewriter, Location loc,
                             StringRef message, StringRef file, StringRef func,
                             int line) const {
   auto funcOp = getAssertfailDeclaration(rewriter);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -13,45 +13,46 @@ public:
 
   Value getClusterCTAId(RewriterBase &rewriter, Location loc) const override;
 
-  Value ballot(ConversionPatternRewriter &rewriter, Location loc, Type type,
+  Value ballot(RewriterBase &rewriter, Location loc, Type type,
                Value cmp) const override;
 
-  void storeShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
-                   Value val, Value pred) const override;
-  Value loadShared(ConversionPatternRewriter &rewriter, Location loc,
+  void storeShared(RewriterBase &rewriter, Location loc, Value ptr, Value val,
+                   Value pred) const override;
+  Value loadShared(RewriterBase &rewriter, Location loc,
                    const TypeConverter *converter, Value ptr, Type elemTy,
                    Value pred) const override;
 
-  Value shuffleXor(ConversionPatternRewriter &rewriter, Location loc, Value val,
+  Value shuffleXor(RewriterBase &rewriter, Location loc, Value val,
                    int i) const override;
-  Value shuffleUp(ConversionPatternRewriter &rewriter, Location loc, Value val,
+  Value shuffleUp(RewriterBase &rewriter, Location loc, Value val,
                   int i) const override;
-  Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc, Value val,
+  Value shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
                    int i) const override;
-  Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc, Value val,
+  Value shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
                    Value i) const override;
 
-  Value programId(ConversionPatternRewriter &rewriter, Location loc,
-                  ModuleOp moduleOp, int axis) const override;
+  Value programId(RewriterBase &rewriter, Location loc, ModuleOp moduleOp,
+                  int axis) const override;
 
-  bool warpReduce(ConversionPatternRewriter &rewriter, Location loc,
-                  SmallVector<Value> &acc, triton::ReduceOp op,
-                  unsigned numLaneToReduce, unsigned interleave) const override;
+  bool warpReduce(RewriterBase &rewriter, Location loc, SmallVector<Value> &acc,
+                  triton::ReduceOp op, unsigned numLaneToReduce,
+                  unsigned interleave) const override;
 
-  bool processReplicaUsingStMatrix(
-      ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
-      SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
-      ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
-      ArrayRef<unsigned> outOrd, unsigned accumNumReplicates,
-      int swizzleByteWidth) const override;
+  bool processReplicaUsingStMatrix(RewriterBase &rewriter, Location loc,
+                                   Value smemBase, SmallVector<Value> &vals,
+                                   RankedTensorType srcTy, Type elemTy,
+                                   ArrayRef<unsigned> paddedRepShape,
+                                   ArrayRef<unsigned> origRepShape,
+                                   ArrayRef<unsigned> outOrd,
+                                   unsigned accumNumReplicates,
+                                   int swizzleByteWidth) const override;
 
   std::string getMulhiFuncName(Type resultElementTy) const override;
 
-  void printf(ConversionPatternRewriter &rewriter, Value formatStrStart,
+  void printf(RewriterBase &rewriter, Value formatStrStart,
               int formatStrByteCount, ValueRange args) const override;
-  void assertFail(ConversionPatternRewriter &rewriter, Location loc,
-                  StringRef message, StringRef file, StringRef func,
-                  int line) const override;
+  void assertFail(RewriterBase &rewriter, Location loc, StringRef message,
+                  StringRef file, StringRef func, int line) const override;
 
 private:
   int computeCapability;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -8,9 +8,8 @@ namespace LLVM {
 namespace NVIDIA {
 using namespace mlir::triton;
 
-static Value shuffleCommon(Location loc, ConversionPatternRewriter &rewriter,
-                           Value val, Value i, NVVM::ShflKind mode,
-                           Value clamp) {
+static Value shuffleCommon(Location loc, RewriterBase &rewriter, Value val,
+                           Value i, NVVM::ShflKind mode, Value clamp) {
   unsigned bits = val.getType().getIntOrFloatBitWidth();
 
   if (bits == 64) {
@@ -42,31 +41,27 @@ static Value shuffleCommon(Location loc, ConversionPatternRewriter &rewriter,
   return result;
 }
 
-Value shuffleXor(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                 int i) {
+Value shuffleXor(Location loc, RewriterBase &rewriter, Value val, int i) {
   return shuffleCommon(loc, rewriter, val, i32_val(i), NVVM::ShflKind::bfly,
                        i32_val(0x1f));
 }
 
-Value shuffleUp(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                int i) {
+Value shuffleUp(Location loc, RewriterBase &rewriter, Value val, int i) {
   return shuffleCommon(loc, rewriter, val, i32_val(i), NVVM::ShflKind::up,
                        i32_val(0x0));
 }
 
-Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                 int i) {
+Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, int i) {
   return shuffleIdx(loc, rewriter, val, i32_val(i));
 }
 
-Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                 Value i) {
+Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i) {
   return shuffleCommon(loc, rewriter, val, i, NVVM::ShflKind::idx,
                        i32_val(0x1f));
 }
 
-Value llGetPid(Location loc, ConversionPatternRewriter &rewriter,
-               ModuleOp moduleOp, int axis) {
+Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
+               int axis) {
   assert(axis >= 0);
   assert(axis < 3);
   assert(moduleOp);
@@ -92,8 +87,8 @@ Value getSRegValue(OpBuilder &b, Location loc, const std::string &sRegStr) {
   return val;
 }
 
-Value permute(Location loc, ConversionPatternRewriter &rewriter, Value a,
-              Value b, Value mask) {
+Value permute(Location loc, RewriterBase &rewriter, Value a, Value b,
+              Value mask) {
   PTXBuilder builder;
   auto &prmt = builder.create("prmt")->o("b32");
   auto *destOpr = builder.newOperand("=r");

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
@@ -40,19 +40,15 @@ namespace LLVM {
 namespace NVIDIA {
 
 Value getSRegValue(OpBuilder &b, Location loc, const std::string &sRegStr);
-Value shuffleXor(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                 int i);
-Value shuffleUp(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                int i);
-Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                 int i);
-Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
-                 Value i);
-Value permute(Location loc, ConversionPatternRewriter &rewriter, Value a,
-              Value b, Value mask);
+Value shuffleXor(Location loc, RewriterBase &rewriter, Value val, int i);
+Value shuffleUp(Location loc, RewriterBase &rewriter, Value val, int i);
+Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, int i);
+Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i);
+Value permute(Location loc, RewriterBase &rewriter, Value a, Value b,
+              Value mask);
 
-Value llGetPid(Location loc, ConversionPatternRewriter &rewriter,
-               ModuleOp moduleOp, int axis);
+Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
+               int axis);
 
 /// Usage of macro load_dsmem
 /// (1) load_dsmem(addr, ctaId)


### PR DESCRIPTION
<git-pr-chain>


s/ConversionPatternRewriter/RewriterBase/ in utils (NFC)

You can't create a ConversionPatternRewriter in C++ unit tests, so this means
that anything which is touched from a C++ unit test cannot transitively touch
anything which uses a ConversionPatternRewriter.

This is a simple search+replace, there's no functional difference between these
types for our purposes.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #4140 👈 **YOU ARE HERE**
1. #4141


</git-pr-chain>



