### PR TITLE
thread-locality: Do not segfault for reduce on forOp arguments

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -121,8 +121,7 @@ class TritonGPUOptimizeThreadLocalityPass
       if (!(isa<triton::gpu::BlockedEncodingAttr>(srcEncoding) && rank > 1))
         return;
       for (auto operand : reduce->getOperands()) {
-        auto def = operand.getDefiningOp();
-        if (def == nullptr || !isa<triton::LoadOp>(def))
+        if (!operand.getDefiningOp<triton::LoadOp>())
           return;
       }
       auto elemsPerThread =

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -122,7 +122,7 @@ class TritonGPUOptimizeThreadLocalityPass
         return;
       for (auto operand : reduce->getOperands()) {
         auto def = operand.getDefiningOp();
-        if (!isa<triton::LoadOp>(def))
+        if (def == nullptr || !isa<triton::LoadOp>(def))
           return;
       }
       auto elemsPerThread =


### PR DESCRIPTION
If definingOp for the reduce operands is nullptr, bail out instead of seg fault.