### PR TITLE
Fixes for running the 09-persistent-matmul tutorial on SM80

### DIFF
--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -475,7 +475,7 @@ if __name__ == "__main__":
     if args.K and args.K_range is None:
         args.K_range = [args.K, args.K]
         args.K_step = 1  # doesn't matter as long as it's not 0
-
+ 
     torch.manual_seed(0)
 
     validate(32, 32, 32, dtype)

--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -27,6 +27,7 @@ else:
 def is_cuda():
     return triton.runtime.driver.active.get_current_target().backend == "cuda"
 
+
 def supports_tma():
     return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
 
@@ -447,7 +448,7 @@ def validate(M, N, K, dtype):
                                                 atol=1.0) else "❌"
     if tma_persistent_result is not None:
         naive_vs_tma_persistent = "✅" if torch.allclose(cublas_result.to(torch.float16),
-                                                    tma_persistent_result.to(torch.float16), atol=1.0) else "❌"
+                                                        tma_persistent_result.to(torch.float16), atol=1.0) else "❌"
     print(f"M={M}, N={N}, K={K} verification naive vs: ", end="")
     if torch_result is not None:
         print(f"torch: {naive_vs_torch} ", end="")
@@ -475,7 +476,7 @@ if __name__ == "__main__":
     if args.K and args.K_range is None:
         args.K_range = [args.K, args.K]
         args.K_step = 1  # doesn't matter as long as it's not 0
- 
+
     torch.manual_seed(0)
 
     validate(32, 32, 32, dtype)

--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -27,6 +27,9 @@ else:
 def is_cuda():
     return triton.runtime.driver.active.get_current_target().backend == "cuda"
 
+def supports_tma():
+    return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
+
 
 def _matmul_launch_metadata(grid, kernel, args):
     ret = {}
@@ -415,9 +418,10 @@ def bench(K, dtype, reps=10):
     for _ in range(reps):
         matmul_persistent(a, b.T)
         time.sleep(0.01)
-    for _ in range(reps):
-        matmul_tma_persistent(a, b)
-        time.sleep(0.01)
+    if supports_tma():
+        for _ in range(reps):
+            matmul_tma_persistent(a, b)
+            time.sleep(0.01)
 
     proton.deactivate(0)
 
@@ -431,7 +435,7 @@ def validate(M, N, K, dtype):
     cublas_result = cublas_matmul(a, b) if cublas is not None else None
     naive_result = matmul(a, b.T)
     persistent_result = matmul_persistent(a, b.T)
-    tma_persistent_result = matmul_tma_persistent(a, b)
+    tma_persistent_result = matmul_tma_persistent(a, b) if supports_tma() else None
 
     if torch_result is not None:
         naive_vs_torch = "✅" if torch.allclose(naive_result.to(torch.float16), torch_result.to(torch.float16),
@@ -441,7 +445,8 @@ def validate(M, N, K, dtype):
                                                 atol=1.0) else "❌"
     naive_vs_persistent = "✅" if torch.allclose(naive_result.to(torch.float16), persistent_result.to(torch.float16),
                                                 atol=1.0) else "❌"
-    naive_vs_tma_persistent = "✅" if torch.allclose(cublas_result.to(torch.float16),
+    if tma_persistent_result is not None:
+        naive_vs_tma_persistent = "✅" if torch.allclose(cublas_result.to(torch.float16),
                                                     tma_persistent_result.to(torch.float16), atol=1.0) else "❌"
     print(f"M={M}, N={N}, K={K} verification naive vs: ", end="")
     if torch_result is not None:
@@ -449,7 +454,8 @@ def validate(M, N, K, dtype):
     if cublas_result is not None:
         print(f"cublas: {naive_vs_cublas} ", end="")
     print(f"persistent: {naive_vs_persistent} ", end="")
-    print(f"TMA persistent: {naive_vs_tma_persistent}")
+    if tma_persistent_result is not None:
+        print(f"TMA persistent: {naive_vs_tma_persistent}")
 
 
 if __name__ == "__main__":
@@ -457,7 +463,7 @@ if __name__ == "__main__":
     parser.add_argument("-K", type=int, required=False, default=512)
     parser.add_argument("--K_range", type=int, nargs=2)
     parser.add_argument("--K_step", type=int, default=512)
-    parser.add_argument("--prec", type=str, choices=["fp8", "fp16"], default="fp8")
+    parser.add_argument("--prec", type=str, choices=["fp8", "fp16"], default="fp16")
     args = parser.parse_args()
 
     if args.prec == 'fp8' and (not hasattr(torch, "float8_e4m3fn") or not is_cuda()):


### PR DESCRIPTION
Setting fp16 as a default mode, as fp8 is compatible only with sm90.
Disabling TMA test for sm80 and below.
There is still the issue of shapes not fitting into shmem for some platforms, to be addressed as a follow-up.