### PR TITLE
Fix conflicting multithreading and fork management

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -207,9 +207,13 @@ void init_triton_ir(py::module &&m) {
       .def(py::init<>())
       .def("printOpOnDiagnostic",
            [](MLIRContext &self, bool v) { self.printOpOnDiagnostic(v); })
-      .def("printStackTraceOnDiagnostic", [](MLIRContext &self, bool v) {
-        self.printStackTraceOnDiagnostic(v);
-      });
+      .def("printStackTraceOnDiagnostic",
+           [](MLIRContext &self, bool v) {
+             self.printStackTraceOnDiagnostic(v);
+           })
+      .def("disable_multithreading",
+           [](MLIRContext &self) { self.disableMultithreading(); });
+
   py::class_<SourceMgrDiagnosticHandler>(m, "source_mgr_diag",
                                          py::module_local())
       .def(py::init<llvm::SourceMgr &, MLIRContext *>());

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -88,6 +88,7 @@ def compile_empty_kernel_with_gc(attrs):
 def test_compile_in_forked_subproc_with_forced_gc() -> None:
     reset_tmp_dir()
     import gc
+    old_gc_state = gc.isenabled()
     gc.disable()
 
     config = triton.compiler.AttrsDescriptor(tuple(range(1)), ())
@@ -98,4 +99,8 @@ def test_compile_in_forked_subproc_with_forced_gc() -> None:
     proc = multiprocessing.Process(target=compile_empty_kernel_with_gc, args=(config, ))
     proc.start()
     proc.join()
+
+    # restore gc state
+    if old_gc_state:
+        gc.enable()
     assert proc.exitcode == 0

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -87,15 +87,16 @@ def compile_empty_kernel_with_gc(attrs):
 
 def test_compile_in_forked_subproc_with_forced_gc() -> None:
     '''
-    Test checks that compilation artifacts can safely live in forked process.
+    Tests that compilation artifacts can safely live in forked process.
 
-    Scenario that is tested here is following ("p" stands for parent process, "c" is child process):
-    1.p compile kernel 1, produce compilation artifacts.
-    2.p fork process
-    3.c Delete compilation artifacts inherited from parent process, compile kernel 2, terminate child
-    3.p wait for child process and join it
+    Scenario being tested here ("p" stands for parent process, "c" is child process):
+    1. p compiles a kernel 1, and produces compilation artifacts.
+    2. p forks the process to create c.
+    3. c deletes compilation artifacts inherited from p, compiles kernel 2, and terminates.
+    3. p wait for c and join it.
 
-    This is a regression test that ensures thread pool in MLIRContext is released safely after compilation.
+    This is a regression test that ensures thread pool in MLIRContext is released
+    safely after compilation.
     '''
     reset_tmp_dir()
     import gc

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -304,9 +304,9 @@ def compile(src, target=None, options=None):
                                                              binary=False)
     fn_cache_manager.put_group(metadata_filename, metadata_group)
     # Compilation completed, disabling multithreading in context.
-    # This is needed to safely finalize threads pool inside context:
-    # if current process forks before python GC deletes context object,
-    # thread pool in child process will be invalid, which could lead to child crash or hang
+    # This is needed to safely finalize threads pool inside context: if current process forks before
+    # python GC deletes context object, thread pool in child process will be invalid, which could
+    # lead to child crash or hang.
     context.disable_multithreading()
     # return handle to compiled kernel
     return CompiledKernel(src, metadata_group, hash)

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -303,7 +303,10 @@ def compile(src, target=None, options=None):
     metadata_group[metadata_filename] = fn_cache_manager.put(json.dumps(metadata, default=vars), metadata_filename,
                                                              binary=False)
     fn_cache_manager.put_group(metadata_filename, metadata_group)
-    # disable multithreading to safely finalize threads pool inside context
+    # Compilation completed, disabling multithreading in context.
+    # This is needed to safely finalize threads pool inside context:
+    # if current process forks before python GC deletes context object,
+    # thread pool in child process will be invalid, which could lead to child crash or hang
     context.disable_multithreading()
     # return handle to compiled kernel
     return CompiledKernel(src, metadata_group, hash)

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -303,6 +303,8 @@ def compile(src, target=None, options=None):
     metadata_group[metadata_filename] = fn_cache_manager.put(json.dumps(metadata, default=vars), metadata_filename,
                                                              binary=False)
     fn_cache_manager.put_group(metadata_filename, metadata_group)
+    # disable multithreading to safely finalize threads pool inside context
+    context.disable_multithreading()
     # return handle to compiled kernel
     return CompiledKernel(src, metadata_group, hash)
 


### PR DESCRIPTION
This PR disables multithreading in MLIR context after compilation ends. This is done to safely finalize thread pool implemented in MLIRContext. Not properly finalized thread pool can hang or crash in child process after fork.
