### PR TITLE
[FRONTEND] Wrap experimental TMA descriptor creation into a helper

### DIFF
--- a/python/test/unit/hopper/test_experimental_tma.py
+++ b/python/test/unit/hopper/test_experimental_tma.py
@@ -1,10 +1,10 @@
-import numpy as np
 import pytest
 import torch
 import tempfile
 
 import triton
 import triton.language as tl
+from triton.tools.experimental_descriptor import create_1d_tma_descriptor, create_2d_tma_descriptor
 
 
 def test_descriptor_load_ttgir():
@@ -15,8 +15,7 @@ def test_descriptor_load_ttgir():
     SIZE = 128
 
     x = torch.randn(SIZE, dtype=torch.float32, device=device)
-    desc = np.empty(SIZE, dtype=np.int8)
-    triton.runtime.driver.active.utils.fill_1d_tma_descriptor(x.data_ptr(), SIZE, SIZE, x.element_size(), desc)
+    desc = create_1d_tma_descriptor(x.data_ptr(), SIZE, SIZE, x.element_size())
     size_in_bytes = SIZE * x.element_size()
 
     ir = f"""
@@ -46,7 +45,6 @@ def test_descriptor_load_ttgir():
         f.flush()
         kernel = triton.compile(f.name)
 
-    desc = torch.tensor(desc, device=device)
     z_tri = torch.empty_like(x)
     kernel[(1, 1, 1)](z_tri, desc)
     assert torch.equal(x, z_tri)
@@ -67,9 +65,7 @@ def test_experimetal_descriptor_load():
         tl.store(Z + off, x)
 
     x = torch.randn(SIZE, dtype=torch.float32, device=device)
-    desc = np.empty(SIZE, dtype=np.int8)
-    triton.runtime.driver.active.utils.fill_1d_tma_descriptor(x.data_ptr(), SIZE, SIZE, x.element_size(), desc)
-    desc = torch.tensor(desc, device=device)
+    desc = create_1d_tma_descriptor(x.data_ptr(), SIZE, SIZE, x.element_size())
     z_tri = torch.empty_like(x)
     kernel[(1, )](z_tri, desc, SIZE=SIZE, num_warps=4)
     assert torch.equal(x, z_tri)
@@ -107,20 +103,9 @@ def test_experimental_tma_matmul(num_stages, BLOCK_M, BLOCK_N, BLOCK_K):
     A = torch.randn((M, K), dtype=torch.float16, device=device)
     B = torch.randn((K, N), dtype=torch.float16, device=device)
     C = torch.empty((M, N), dtype=torch.float16, device=device)
-    TMA_SIZE = 128
-    desc_a = np.empty(TMA_SIZE, dtype=np.int8)
-    desc_b = np.empty(TMA_SIZE, dtype=np.int8)
-    desc_c = np.empty(TMA_SIZE, dtype=np.int8)
-    triton.runtime.driver.active.utils.fill_2d_tma_descriptor(A.data_ptr(), M, K, BLOCK_M, BLOCK_K, A.element_size(),
-                                                              desc_a)
-    triton.runtime.driver.active.utils.fill_2d_tma_descriptor(B.data_ptr(), K, N, BLOCK_K, BLOCK_N, B.element_size(),
-                                                              desc_b)
-    triton.runtime.driver.active.utils.fill_2d_tma_descriptor(C.data_ptr(), M, N, BLOCK_M, BLOCK_N, C.element_size(),
-                                                              desc_c)
-
-    desc_a = torch.tensor(desc_a, device=device)
-    desc_b = torch.tensor(desc_b, device=device)
-    desc_c = torch.tensor(desc_c, device=device)
+    desc_a = create_2d_tma_descriptor(A.data_ptr(), M, K, BLOCK_M, BLOCK_K, A.element_size())
+    desc_b = create_2d_tma_descriptor(B.data_ptr(), K, N, BLOCK_K, BLOCK_N, B.element_size())
+    desc_c = create_2d_tma_descriptor(C.data_ptr(), M, N, BLOCK_M, BLOCK_N, C.element_size())
     kernel = matmul_kernel_tma[(triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), 1,
                                 1)](desc_a, desc_b, desc_c, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, num_warps=8,
                                     num_stages=num_stages)

--- a/python/triton/tools/experimental_descriptor.py
+++ b/python/triton/tools/experimental_descriptor.py
@@ -1,0 +1,35 @@
+import torch
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def flush_TMA_cache(desc_ptr):
+    tl.inline_asm_elementwise("fence.proxy.tensormap::generic.acquire.gpu [$1], 128; // $0 dummy reg", "=r, l",
+                              [desc_ptr], dtype=tl.int32, is_pure=False, pack=1)
+
+
+def create_1d_tma_descriptor(ptr, dim, block_dim, element_size):
+    TMA_SIZE = 128
+    desc = torch.empty(TMA_SIZE, dtype=torch.int8)
+    triton.runtime.driver.active.utils.fill_1d_tma_descriptor(ptr, dim, block_dim, element_size, desc.data_ptr())
+    gpu_desc = desc.cuda()
+    # TMA cache is not being flushed in between dispacthes, therefore we should
+    # manually flush the cache every time we create a new TMA descriptor to make
+    # sure the following dispatch don't use stale cache when accessing TMA.
+    flush_TMA_cache[(1, )](gpu_desc, num_warps=1)
+    return gpu_desc
+
+
+def create_2d_tma_descriptor(ptr, dim1, dim0, block_dim1, block_dim0, element_size):
+    TMA_SIZE = 128
+    desc = torch.empty(TMA_SIZE, dtype=torch.int8)
+    triton.runtime.driver.active.utils.fill_2d_tma_descriptor(ptr, dim1, dim0, block_dim1, block_dim0, element_size,
+                                                              desc.data_ptr())
+    gpu_desc = desc.cuda()
+    # TMA cache is not being flushed in between dispacthes, therefore we should
+    # manually flush the cache every time we create a new TMA descriptor to make
+    # sure the following dispatch don't use stale cache when accessing TMA.
+    flush_TMA_cache[(1, )](gpu_desc, num_warps=1)
+    return gpu_desc

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -263,12 +263,11 @@ static PyObject *fill1DTMADescriptor(PyObject *self, PyObject *args) {
   uint64_t dim;
   uint32_t tensorDim;
   int elementSize;
-  Py_buffer desc_buffer;
-  if (!PyArg_ParseTuple(args, "KKiiy*", &global_address, &dim, &tensorDim,
-                        &elementSize, &desc_buffer)) {
+  unsigned long long desc_address;
+  if (!PyArg_ParseTuple(args, "KKiiK", &global_address, &dim, &tensorDim,
+                        &elementSize, &desc_address)) {
     return NULL;
   }
-  char *desc = (char *)desc_buffer.buf;
   uint64_t dims[1] = {dim};
   uint64_t globalStrides[1] = {dim * elementSize};
   uint32_t boxDim[1] = {tensorDim};
@@ -290,7 +289,7 @@ static PyObject *fill1DTMADescriptor(PyObject *self, PyObject *args) {
   assert((elementSize * tensorDim) >= 32 && "block size too small.");
   int rank = 1;
   CUresult result = cuTensorMapEncodeTiled(
-      (CUtensorMap *)desc, type, rank, (void *)global_address, dims,
+      (CUtensorMap *)desc_address, type, rank, (void *)global_address, dims,
       globalStrides, boxDim, elementStrides, CU_TENSOR_MAP_INTERLEAVE_NONE,
       CU_TENSOR_MAP_SWIZZLE_NONE, CU_TENSOR_MAP_L2_PROMOTION_NONE,
       CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
@@ -305,13 +304,12 @@ static PyObject *fill2DTMADescriptor(PyObject *self, PyObject *args) {
   uint64_t dims[2];
   uint32_t tensorDims[2];
   int elementSize;
-  Py_buffer desc_buffer;
-  if (!PyArg_ParseTuple(args, "KKKiiiy*", &global_address, &dims[1], &dims[0],
+  unsigned long long desc_address;
+  if (!PyArg_ParseTuple(args, "KKKiiiK", &global_address, &dims[1], &dims[0],
                         &tensorDims[1], &tensorDims[0], &elementSize,
-                        &desc_buffer)) {
+                        &desc_address)) {
     return NULL;
   }
-  char *desc = (char *)desc_buffer.buf;
   uint64_t globalStrides[2] = {dims[0] * elementSize,
                                dims[0] * dims[1] * elementSize};
   uint32_t elementStrides[2] = {1, 1};
@@ -351,7 +349,7 @@ static PyObject *fill2DTMADescriptor(PyObject *self, PyObject *args) {
     tensorDims[0] = 128 / elementSize;
   }
   CUresult result = cuTensorMapEncodeTiled(
-      (CUtensorMap *)desc, type, rank, (void *)global_address, dims,
+      (CUtensorMap *)desc_address, type, rank, (void *)global_address, dims,
       globalStrides, tensorDims, elementStrides, CU_TENSOR_MAP_INTERLEAVE_NONE,
       swizzle, CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
       CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);


### PR DESCRIPTION
We need to potentially flush the TMA cache when re-using TMA memory. In order to make it safe we flush the cache for every TMA descriptor created.
