### PR TITLE
Use custom stacktrace signal handler w/ python interrupt

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -425,8 +425,13 @@ void init_triton_llvm(py::module &&m) {
   });
 }
 
+void triton_stacktrace_signal_handler(void *) {
+  llvm::sys::PrintStackTrace(llvm::errs());
+  PyErr_SetInterrupt();
+}
+
 void init_triton_stacktrace_hook(pybind11::module &m) {
   if (!mlir::triton::tools::getBoolEnv("TRITON_DISABLE_PYTHON_STACKTRACE")) {
-    llvm::sys::PrintStackTraceOnErrorSignal("triton_python");
+    llvm::sys::AddSignalHandler(triton_stacktrace_signal_handler, nullptr);
   }
 }

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -23,6 +23,7 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/InstCombine/InstCombine.h"
+#include <csignal>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <stdexcept>
@@ -427,7 +428,7 @@ void init_triton_llvm(py::module &&m) {
 
 void triton_stacktrace_signal_handler(void *) {
   llvm::sys::PrintStackTrace(llvm::errs());
-  PyErr_SetInterrupt();
+  raise(SIGABRT);
 }
 
 void init_triton_stacktrace_hook(pybind11::module &m) {


### PR DESCRIPTION
The LLVM signal handler appears to supersede the Python signal handler. Calling PyErr_SetInterrupt is equivalent to raising SIGINT and ensures the program terminates after the stack trace is printed. This Python function is also thread safe. It might be better to raise the original signal, but LLVM does not appear to pass the signal to its handler when captured, and the Python function to raise a specific signal is only supported in 3.10+.

Using the repro from #4129:

<details><summary>Before this change:</summary>

```
$ python repro.py abort                                                                                               
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  libtriton.so 0x00007c5fff21e850
1  libtriton.so 0x00007c5fff21bbbf
2  libtriton.so 0x00007c5fff21bd15
3  libc.so.6    0x00007c6002e42520
4  libc.so.6    0x00007c6002e4275b kill + 11
5  python       0x000062e75f1b1004
6  python       0x000062e75f090c59
7  python       0x000062e75f07ecfa _PyEval_EvalFrameDefault + 24906
8  python       0x000062e75f0759c6
9  python       0x000062e75f16b256 PyEval_EvalCode + 134
10 python       0x000062e75f196108
11 python       0x000062e75f18f9cb
12 python       0x000062e75f195e55
13 python       0x000062e75f195338 _PyRun_SimpleFileObject + 424
14 python       0x000062e75f194f83 _PyRun_AnyFileObject + 67
15 python       0x000062e75f187a5e Py_RunMain + 702
16 python       0x000062e75f15e02d Py_BytesMain + 45
17 libc.so.6    0x00007c6002e29d90
18 libc.so.6    0x00007c6002e29e40 __libc_start_main + 128
19 python       0x000062e75f15df25 _start + 37
Still alive
```

</details>

<details><summary>After this change:</summary>

```
$ python repro.py abort                                                                       
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  libtriton.so 0x000078ca9e21fd90
1  libtriton.so 0x000078ca99fc3dd7
2  libtriton.so 0x000078ca9e21d0ff
3  libtriton.so 0x000078ca9e21d255
4  libc.so.6    0x000078caa1e42520
5  libc.so.6    0x000078caa1e4275b kill + 11
6  python       0x0000636f2ee16004
7  python       0x0000636f2ecf5c59
8  python       0x0000636f2ece3cfa _PyEval_EvalFrameDefault + 24906
9  python       0x0000636f2ecda9c6
10 python       0x0000636f2edd0256 PyEval_EvalCode + 134
11 python       0x0000636f2edfb108
12 python       0x0000636f2edf49cb
13 python       0x0000636f2edfae55
14 python       0x0000636f2edfa338 _PyRun_SimpleFileObject + 424
15 python       0x0000636f2edf9f83 _PyRun_AnyFileObject + 67
16 python       0x0000636f2edeca5e Py_RunMain + 702
17 python       0x0000636f2edc302d Py_BytesMain + 45
18 libc.so.6    0x000078caa1e29d90
19 libc.so.6    0x000078caa1e29e40 __libc_start_main + 128
20 python       0x0000636f2edc2f25 _start + 37
Traceback (most recent call last):
  File "/localdisk/abaden/Projects/triton/repro.py", line 7, in <module>
    os.kill(os.getpid(), signal.SIGABRT)
KeyboardInterrupt
```
</details> 

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `not trivial to test within pytest framework as signals would interrupt the test`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
