### PR TITLE
Add powerpc as a possible installation target and link in correct LLV…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,8 +226,13 @@ if(TRITON_BUILD_PYTHON_MODULE)
           LLVMX86CodeGen
           LLVMX86AsmParser
       )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
+      list(APPEND TRITON_LIBRARIES
+        LLVMPowerPCAsmParser
+        LLVMPowerPCCodeGen
+      )
   else()
-      message(FATAL_ERROR "LLVM codegen/ASM parser libs: This HW architecture is not configured in cmake lib dependencies.")
+    message(FATAL_ERROR "LLVM codegen/ASM parser libs: This HW architecture (${CMAKE_SYSTEM_PROCESSOR}) is not configured in cmake lib dependencies.")
   endif()
 
   # Define triton library


### PR DESCRIPTION
Support the PowerPC architecture when installing from source code and add the respective LLVM libraries as dependencies.

All tests (lit/ ctests) pass in the powerpc cluster I am working on. 

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X ] This PR does not need a test because it modifies the CPU installation architecture

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
