### PR TITLE
[FrontEnd] Allow MLIR dumping a single kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ For detailed instructions on how to debug Triton's frontend, please refer to thi
 
 **Helpful environment variables**
 
-- `MLIR_ENABLE_DUMP=1` dumps the IR before every MLIR pass Triton runs.
+- `MLIR_ENABLE_DUMP=1` dumps the IR before every MLIR pass Triton runs, for all
+   kernels. Use `MLIR_ENABLE_DUMP=kernelName` to dump for a specific kernel only.
 - `LLVM_IR_ENABLE_DUMP=1` dumps the IR before every pass run over the LLVM IR.
 - `TRITON_INTERPRET=1` uses the Triton interpreter instead of running on the
   GPU.  You can insert Python breakpoints in your kernel code!

--- a/python/test/unit/test_debug_dump.py
+++ b/python/test/unit/test_debug_dump.py
@@ -1,0 +1,39 @@
+import triton
+import triton.language as tl
+import os
+import torch
+
+
+def test_fn_dump(capfd):
+    N = 1024
+    src = torch.zeros(N, device='cuda')
+
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
+
+    @triton.jit
+    def _kernel(src, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + offsets, mask=offsets < N) + 1
+        tl.store(src + offsets, x, mask=offsets < N)
+
+    os.environ['MLIR_ENABLE_DUMP'] = '1'
+    BLOCK_SIZE = 16
+    _kernel[grid](src, N, BLOCK_SIZE)
+    captured = capfd.readouterr()
+    assert "IR Dump Before" in captured.err
+    assert "tt.func public @_kernel" in captured.err
+
+    os.environ['MLIR_ENABLE_DUMP'] = '_kernel'
+    BLOCK_SIZE = 32
+    _kernel[grid](src, N, BLOCK_SIZE)
+    captured = capfd.readouterr()
+    assert "IR Dump Before" in captured.err
+    assert "tt.func public @_kernel" in captured.err
+
+    os.environ['MLIR_ENABLE_DUMP'] = '_kernel2'
+    BLOCK_SIZE = 64
+    _kernel[grid](src, N, BLOCK_SIZE)
+    captured = capfd.readouterr()
+    assert "IR Dump Before" not in captured.err
+
+    os.environ['MLIR_ENABLE_DUMP'] = '0'


### PR DESCRIPTION
A pytorch run can consist of lots of triton kernel runs. Adding the functionality to allow for dumping the IRs for a particularly interesting kernel.