### PR TITLE
Pass `repr=key` when calling JITFunction.cache_hook

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -525,8 +525,6 @@ class JITFunction(KernelInterface[T]):
 
         name = self.fn.__name__
         module = self.fn.__module__
-        arg_reprs = ", ".join([f"{param.name}: {ty}" for param, ty in zip(self.params, key[1])])
-        repr = f"{name}[num_warps={options.num_warps}, num_ctas={options.num_ctas}, num_stages={options.num_stages}, enable_fp_fusion={options.enable_fp_fusion}]({arg_reprs})"
 
         class JitFunctionInfo:
 
@@ -553,7 +551,7 @@ class JITFunction(KernelInterface[T]):
 
         return JITFunction.cache_hook(
             key=key,
-            repr=repr,
+            repr=key,
             fn=JitFunctionInfo(module, name, self),
             compile={"key": key, **kwargs},
             is_manual_warmup=False,


### PR DESCRIPTION
Before this PR, we had two key-like strings for JITFunctions.

   - key: Guaranteed unique per compiled kernel, suitable for caching.
   - repr: Not guaranteed-unique, missing some fields (for example, can't
     distinguish between fp32 and fp16 params), but perhaps more human-readable
     than `key`?
    
This PR removes repr and replaces it with key, thus removing a footgun.