### PR TITLE
Optimize code generated by EmitIndices for LinearLayout

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -74,11 +74,6 @@ public:
                           StringRef message, StringRef file, StringRef func,
                           int line) const = 0;
 
-  // Whether to enable linear layout. This is a per-backend temporary escape
-  // hatch to disable linear layout while figuring out issues. Eventually we
-  // want to enable linear layout everywhere and delete this control.
-  virtual bool enableLinearLayout() const { return true; }
-
   virtual ~TargetInfoBase() {}
 };
 } // namespace mlir::triton

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -1211,7 +1211,7 @@ emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
             bool allowLL = true) {
   // Eventually the LinearLayout path will be the only one.  For now we allow
   // both paths so we can test that they produce the same results.
-  if (allowLL && target.enableLinearLayout()) {
+  if (allowLL) {
     std::optional<SmallVector<SmallVector<Value>>> llOffsets =
         emitIndicesUsingLinearLayouts(loc, rewriter, target, layout, type,
                                       withCTAOffset);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -231,12 +231,22 @@ emitIndicesUsingLinearLayouts(Location loc, RewriterBase &rewriter,
       withCTAOffset ? target.getClusterCTAId(rewriter, loc) : i32_val(0);
   unsigned rank = shape.size();
   SmallVector<SmallVector<Value>> ret;
+  auto idxsBase = applyLinearLayout(loc, rewriter, *ll,
+                                    {{kRegister, i32_val(0)},
+                                     {kLane, laneId},
+                                     {kWarp, warpId},
+                                     {kBlock, blockId}});
   for (unsigned reg = 0; reg < ll->getInDimSize(str_attr("register")); reg++) {
-    auto idxs = applyLinearLayout(loc, rewriter, *ll,
-                                  {{kRegister, i32_val(reg)},
-                                   {kLane, laneId},
-                                   {kWarp, warpId},
-                                   {kBlock, blockId}});
+    auto idxsReg =
+        ll->apply({{kRegister, reg}, {kLane, 0}, {kWarp, 0}, {kBlock, 0}});
+    SmallVector<std::pair<StringAttr, Value>> idxs;
+    for (auto [idxBase, idxReg] : llvm::zip(idxsBase, idxsReg)) {
+      auto dimName = idxBase.first;
+      assert(dimName == idxReg.first &&
+             "dim names of block+warp+thread and register idx should be equal");
+      auto idx = xor_(idxBase.second, i32_val(idxReg.second));
+      idxs.emplace_back(dimName, idx);
+    }
     assert(idxs.size() == rank);
     for (unsigned k = 0; k < rank; ++k) {
       assert(idxs[k].first == str_attr("dim" + std::to_string(k)));

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -235,7 +235,8 @@ emitIndicesUsingLinearLayouts(Location loc, RewriterBase &rewriter,
   // L(r, t, w, b) = L(0, t, w, b) xor L(r, 0, 0, 0)
   //     idxs      =    idxsBase   xor    idxsReg
   //
-  // L(0, t, w, b) part is same for all registers, nested out of reg loop
+  // L(0, t, w, b) part is the same for all registers,
+  // so we hoist it out of the main register loop in the below.
   //
   // This approach produces code with lower register pressure and
   // less computations, compared to fused L(r,t,w,b) method.

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -231,6 +231,8 @@ emitIndicesUsingLinearLayouts(Location loc, RewriterBase &rewriter,
       withCTAOffset ? target.getClusterCTAId(rewriter, loc) : i32_val(0);
   unsigned rank = shape.size();
   SmallVector<SmallVector<Value>> ret;
+  // TODO Investigate why LLVM do no optimize one "apply" call
+  // and applyLinearLayout + LL::apply produces better code
   auto idxsBase = applyLinearLayout(loc, rewriter, *ll,
                                     {{kRegister, i32_val(0)},
                                      {kLane, laneId},

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -60,7 +60,7 @@ public:
   void assertFail(RewriterBase &rewriter, Location loc, StringRef message,
                   StringRef file, StringRef func, int line) const override;
 
-  bool enableLinearLayout() const override { return false; }
+  bool enableLinearLayout() const override { return true; }
 
 private:
   void printfImpl(Value formatStrStart, int formatStrByteCount, ValueRange args,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -60,8 +60,6 @@ public:
   void assertFail(RewriterBase &rewriter, Location loc, StringRef message,
                   StringRef file, StringRef func, int line) const override;
 
-  bool enableLinearLayout() const override { return true; }
-
 private:
   void printfImpl(Value formatStrStart, int formatStrByteCount, ValueRange args,
                   RewriterBase &rewriter, bool useStdErr) const;


### PR DESCRIPTION
1. Split LinearLayout conversion in block+warp+thread and register parts
2. Move block+warp+thread part out of register loop in emitIndicesUsingLinearLayouts

LLVM optimizes generated IR better and number of required registers is lowered.
