### PR TITLE
Support FP8 constant

### DIFF
--- a/include/triton/Conversion/MLIRTypes.h
+++ b/include/triton/Conversion/MLIRTypes.h
@@ -33,6 +33,12 @@ inline bool isFloat(Type type) {
          type.isFloat8E5M2FNUZ();
 }
 
+inline bool isFloat8(Type type) {
+  return type.isFloat8E4M3B11FNUZ() || type.isFloat8E4M3FN() ||
+         type.isFloat8E4M3FNUZ() || type.isFloat8E5M2() ||
+         type.isFloat8E5M2FNUZ();
+}
+
 inline bool isInt(Type type) { return type.isIntOrFloat() && !isFloat(type); }
 
 } // namespace type

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -83,6 +83,10 @@ struct ArithConstantSplatOpConversion
                    << value.getType() << "\n";
       return failure();
     }
+    // Lower FP8 constant to int8 constant since FP8 types are not supported on
+    // LLVM IR.
+    if (type::isFloat8(elemType))
+      elemType = rewriter.getIntegerType(8);
     auto constOp = rewriter.create<LLVM::ConstantOp>(loc, elemType, val);
     auto typeConverter = getTypeConverter();
     auto llStruct = SplatOpConversion::convertSplatLikeOp(

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1418,8 +1418,9 @@ def where(condition: tl.tensor, x: tl.tensor, y: tl.tensor, builder: ir.builder)
         condition, x = broadcast_impl_value(condition, x, builder)
         x, y = broadcast_impl_value(x, y, builder)
         condition, x = broadcast_impl_value(condition, x, builder)
-
-    x, y = binary_op_type_checking_impl(x, y, builder, True, True)
+    # Bypass arithmetic type check for FP8 types where they are not supported.
+    is_fp8 = x.type == y.type and x.type.is_fp8() and y.type.is_fp8()
+    x, y = binary_op_type_checking_impl(x, y, builder, True, True, not is_fp8)
     if not condition.type.is_block():
         condition, _ = broadcast_impl_value(condition, x, builder)
     ret_ty = x.type

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -80,9 +80,12 @@ def computation_type_impl(a_ty: tl.dtype, b_ty: tl.dtype, div_or_mod: bool) -> t
         if a_ty.is_bf16() and b_ty.is_bf16():
             return tl.bfloat16
         return tl.float32
+    # 5) return fp16 if operands are different fp8
+    if a_ty.is_fp8() and b_ty.is_fp8():
+        return a_ty if a_ty == b_ty else tl.float16
     if not a_ty.is_int() or not b_ty.is_int():
         raise TypeError(f"unexpected type {a_ty} and {b_ty}")
-    # 5 ) both operands are integer and undergo
+    # 6 ) both operands are integer and undergo
     #    integer promotion
     if div_or_mod and a_ty.int_signedness != b_ty.int_signedness:
         raise TypeError("Cannot use /, #, or % with " + a_ty.__repr__() + " and " + b_ty.__repr__() +
@@ -1418,8 +1421,7 @@ def where(condition: tl.tensor, x: tl.tensor, y: tl.tensor, builder: ir.builder)
         condition, x = broadcast_impl_value(condition, x, builder)
         x, y = broadcast_impl_value(x, y, builder)
         condition, x = broadcast_impl_value(condition, x, builder)
-    # Bypass arithmetic type check when inputs are same-typed.
-    x, y = binary_op_type_checking_impl(x, y, builder, True, True, x.type != y.type)
+    x, y = binary_op_type_checking_impl(x, y, builder, True, True)
     if not condition.type.is_block():
         condition, _ = broadcast_impl_value(condition, x, builder)
     ret_ty = x.type

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1418,9 +1418,8 @@ def where(condition: tl.tensor, x: tl.tensor, y: tl.tensor, builder: ir.builder)
         condition, x = broadcast_impl_value(condition, x, builder)
         x, y = broadcast_impl_value(x, y, builder)
         condition, x = broadcast_impl_value(condition, x, builder)
-    # Bypass arithmetic type check for FP8 types where they are not supported.
-    is_fp8 = x.type == y.type and x.type.is_fp8() and y.type.is_fp8()
-    x, y = binary_op_type_checking_impl(x, y, builder, True, True, not is_fp8)
+    # Bypass arithmetic type check when inputs are same-typed.
+    x, y = binary_op_type_checking_impl(x, y, builder, True, True, x.type != y.type)
     if not condition.type.is_block():
         condition, _ = broadcast_impl_value(condition, x, builder)
     ret_ty = x.type

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -228,3 +228,16 @@ module attributes {"triton_gpu.target" = "cuda:90", "triton_gpu.num-ctas" = 1 : 
     tt.return
   }
 }
+
+// -----
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"triton_gpu.target" = "cuda:90", "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @fp8_const(%arg0: tensor<1024xi1, #blocked>, %arg1: tensor<1024xf8E4M3FNUZ, #blocked>) attributes {noinline = false} {
+    // CHECK-LABEL: @fp8_const
+    // CHECK: llvm.mlir.constant(0.000000e+00 : f8E4M3FNUZ) : i8
+    %cst = arith.constant dense<0.000000e+00> : tensor<1024xf8E4M3FNUZ, #blocked>
+    %a = arith.select %arg0, %arg1, %cst : tensor<1024xi1, #blocked>, tensor<1024xf8E4M3FNUZ, #blocked>
+    tt.return
+  }
+}


### PR DESCRIPTION
To unblock the compilation of kernels like below which don't operate arithmetically on FP8.

```
@triton.jit
def triton_poi_fused__scaled_mm__to_copy_constant_pad_nd_lift_fresh_2(in_ptr0, out_ptr0, xnumel, XBLOCK : tl.constexpr):
    xnumel = 400624
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.arange(0, XBLOCK)[:]
    xmask = xindex < xnumel
    x0 = xindex % 784
    x1 = (xindex // 784)
    x2 = xindex
    tmp0 = x0
    tmp1 = tl.full([1], 769, tl.int64)
    tmp2 = tmp0 < tmp1
    tmp3 = tl.load(in_ptr0 + (x0 + (769*x1)), tmp2 & xmask, other=0.0)
    tmp4 = tmp3.to(tl.float8e4nv)
    tmp5 = tl.full(tmp4.shape, 0.0, tmp4.dtype)
    tmp6 = tl.where(tmp2, tmp4, tmp5)
    tl.store(out_ptr0 + (x2), tmp6, xmask)
```