### PR TITLE
Update the 07-extern-functions tutorial and include a unit test for extern function

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5467,8 +5467,8 @@ def test_num_programs(device):
 
 @pytest.mark.parametrize("dtype_str", ['float32', 'float64'])
 def test_math_extern(dtype_str):
-    if not is_cuda():
-        pytest.skip('math_extern test only works on CUDA')
+    if is_interpreter():
+        pytest.skip('math_extern does not work in the interpreter mode')
 
     @triton.jit
     def kernel(

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5463,7 +5463,6 @@ def test_num_programs(device):
 # test extern functions
 # -----------------------
 
-from triton.language.extra import libdevice
 
 @pytest.mark.parametrize("dtype_str", ['float32', 'float64'])
 def test_math_extern(dtype_str):
@@ -5482,15 +5481,15 @@ def test_math_extern(dtype_str):
         x = tl.load(x_ptr + offsets, mask=mask)
         y = GENERATE_TEST_HERE
         tl.store(y_ptr + offsets, y, mask=mask)
-        
+
     shape = (128, )
     rs = RandomState(17)
     kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': 'libdevice.tanh(x)'})
-    
+
     x = numpy_random(shape, dtype_str=dtype_str, rs=rs)
     y_ref = np.tanh(x)
     x_tri = to_triton(x, device='cuda')
     y_tri = to_triton(numpy_random(shape, dtype_str=dtype_str, rs=rs), device='cuda')
-    kernel[(1,)](x_tri, y_tri, shape[0], BLOCK_SIZE=shape[0])
+    kernel[(1, )](x_tri, y_tri, shape[0], BLOCK_SIZE=shape[0])
     # compare
     np.testing.assert_allclose(y_ref, to_numpy(y_tri), rtol=0.01)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5457,3 +5457,40 @@ def test_num_programs(device):
 
     kernel[grid](input)
     assert torch.all(input == torch.tensor(grid, device=device))
+
+
+# -----------------------
+# test extern functions
+# -----------------------
+
+from triton.language.extra import libdevice
+
+@pytest.mark.parametrize("dtype_str", ['float32', 'float64'])
+def test_math_extern(dtype_str):
+
+    @triton.jit
+    def kernel(
+        x_ptr,
+        y_ptr,
+        n_elements,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(x_ptr + offsets, mask=mask)
+        y = GENERATE_TEST_HERE
+        tl.store(y_ptr + offsets, y, mask=mask)
+        
+    shape = (128, )
+    rs = RandomState(17)
+    kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': 'libdevice.tanh(x)'})
+    
+    x = numpy_random(shape, dtype_str=dtype_str, rs=rs)
+    y_ref = np.tanh(x)
+    x_tri = to_triton(x, device='cuda')
+    y_tri = to_triton(numpy_random(shape, dtype_str=dtype_str, rs=rs), device='cuda')
+    kernel[(1,)](x_tri, y_tri, shape[0], BLOCK_SIZE=shape[0])
+    # compare
+    np.testing.assert_allclose(y_ref, to_numpy(y_tri), rtol=0.01)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5467,8 +5467,8 @@ def test_num_programs(device):
 
 @pytest.mark.parametrize("dtype_str", ['float32', 'float64'])
 def test_math_extern(dtype_str):
-    if is_hip():
-        pytest.skip('math_extern only works on CUDA')
+    if not is_cuda():
+        pytest.skip('math_extern test only works on CUDA')
 
     @triton.jit
     def kernel(

--- a/python/tutorials/07-extern-functions.py
+++ b/python/tutorials/07-extern-functions.py
@@ -65,9 +65,9 @@ print(f'The maximum difference between torch and triton is '
 # This example uses the path from the `third_party/nvidia/backend/lib` directory (the default path).
 
 libdir = Path(__file__).parent.parent.parent / 'third_party/nvidia/backend/lib'
-extern_libs = {} 
+extern_libs = {}
 extern_libs['libdevice'] = os.getenv("TRITON_LIBDEVICE_PATH", str(libdir / 'libdevice.10.bc'))
-        
+
 output_triton = torch.empty_like(x)
 asin_kernel[grid](x, output_triton, n_elements, BLOCK_SIZE=1024, extern_libs=extern_libs)
 print(output_torch)

--- a/python/tutorials/07-extern-functions.py
+++ b/python/tutorials/07-extern-functions.py
@@ -6,7 +6,6 @@ In this example, we will use the `libdevice` library to apply `asin` on a tensor
 Please refer to https://docs.nvidia.com/cuda/libdevice-users-guide/index.html (CUDA) and/or https://github.com/ROCm/llvm-project/tree/amd-staging/amd/device-libs/ocml/src (HIP) regarding the semantics of all available libdevice functions.
 In `libdevice.py`, we try to aggregate functions with the same computation but different data types together.
 For example, both `__nv_asin` and `__nv_asinf` calculate the principal value of the arc sine of the input, but `__nv_asin` operates on `double` and `__nv_asinf` operates on `float`.
-Using triton, you can simply call `tl.math.asin`.
 Triton automatically selects the correct underlying device function to invoke based on input and output types.
 """
 
@@ -14,11 +13,14 @@ Triton automatically selects the correct underlying device function to invoke ba
 #  asin Kernel
 # ------------
 
+import os
 import torch
 
 import triton
 import triton.language as tl
 from triton.language.extra import libdevice
+
+from pathlib import Path
 
 
 @triton.jit
@@ -60,9 +62,14 @@ print(f'The maximum difference between torch and triton is '
 #  Customize the libdevice library path
 # -------------------------------------
 # We can also customize the libdevice library path by passing the path to the `libdevice` library to the `asin` kernel.
+# This example uses the path from the `third_party/nvidia/backend/lib` directory (the default path).
 
+libdir = Path(__file__).parent.parent.parent / 'third_party/nvidia/backend/lib'
+extern_libs = {} 
+extern_libs['libdevice'] = os.getenv("TRITON_LIBDEVICE_PATH", str(libdir / 'libdevice.10.bc'))
+        
 output_triton = torch.empty_like(x)
-asin_kernel[grid](x, output_triton, n_elements, BLOCK_SIZE=1024)
+asin_kernel[grid](x, output_triton, n_elements, BLOCK_SIZE=1024, extern_libs=extern_libs)
 print(output_torch)
 print(output_triton)
 print(f'The maximum difference between torch and triton is '


### PR DESCRIPTION
## Description
1 Updated the doc of 07-extern-functions tutorial

tl.math.fn no longer works in the nightly (following change as a reference)

https://github.com/triton-lang/triton/pull/3172/files#diff-8bb547c8082ddf083d49bdb5e6f126c1cebae899390c95afc0f713229982f516L35

2 Added an example of extern_lib path (just use the default path explicitly to showcase the usage).

3 Added a unit test. In the case of future backward breaking changes of extern math function usage, the unit test should break.
Picked tanh since it is heavily used in gelu.

## Testing
Executed in cuda.