### PR TITLE
change default fence as relaxed for atomic instructions

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -902,7 +902,7 @@ def _str_to_padding_option(padding_option):
 
 
 def _str_to_sem(sem_option):
-    sem = ir.MEM_SEMANTIC.ACQUIRE_RELEASE
+    sem = ir.MEM_SEMANTIC.RELAXED
     if sem_option:
         if sem_option == "acquire":
             sem = ir.MEM_SEMANTIC.ACQUIRE


### PR DESCRIPTION
PR [1739](https://github.com/triton-lang/triton/pull/1739) set the default atomic fence as ACQUIRE_RELEASE, which is too strong for atomic instructions. Switching to a RELAXED fence significantly enhances performance.
Here are the test results on the A100:
| Model              | Default ACQUIRERELEASE TIME | Default RELAXED TIME | ACQUIRERELEASE / RELAXED |
|--------------------|---------------------|--------------|------------------------------------|
| XLNetLMHeadModel   | 119499873           | 116788154    | 0.97730777                         |
| YituTechConvBert   | 70402629            | 68810627     | 0.9773871796747817                 |
| basic_gnn_edgecnn  | 3017286             | 2840769      | 0.94149809                         |
| basic_gnn_gcn      | 1033020             | 792229       | 0.7669057714274651                 |
| basic_gnn_gin      | 679423              | 552928       | 0.8138199619382918                 |
| basic_gnn_sage     | 1023554             | 900968       | 0.8802349460800309                 |
| Background_Matting | 102233209           | 95391970     | 0.9330820281695354                 |
| Super_SloMo        | 57648576            | 54698308     | 0.9488232285217244                 |
| timm_regnet        | 56469685            | 55805099     | 0.9882311013422511                 |
| volo_d1_224        | 58435643            | 57578337     | 0.9853290567881661                 |
