### PR TITLE
Fix min_float32 for parsing float literals

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3503,8 +3503,8 @@ def test_full(dtype_str, shape, device):
     assert torch.all(out_dynamic == 2)
 
 
-@pytest.mark.parametrize("literal, dtype_str", [(1e+50, "f64"), (1e+10, "f32"), (1.0, "f32"), ('float("inf")', "f32"),
-                                                ('float("-inf")', "f32"), ('float("nan")', "f32"),
+@pytest.mark.parametrize("literal, dtype_str", [(1e-45, "f64"), (1e+50, "f64"), (1e-44, "f32"), (1e+10, "f32"), (1.0, "f32"),
+                                                ('float("inf")', "f32"), ('float("-inf")', "f32"), ('float("nan")', "f32"),
                                                 ('float("-nan")', "f32"), (0., "f32"), (5, "i32"), (2**40, "i64")])
 def test_constexpr(literal, dtype_str, device):
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -131,7 +131,7 @@ def _to_tensor(x, builder, check_type: bool = True):
         else:
             raise ValueError(f'Nonrepresentable integer {x}.')
     elif isinstance(x, float):
-        min_float32 = 2**-126
+        min_float32 = 2**-126 * 2**-23
         max_float32 = (2 - 2**-23) * 2**127
         abs_x = __builtins__['abs'](x)
         if abs_x == float("inf") or\


### PR DESCRIPTION
The minimum normal 2**-126, but the minimum denormal is 2**-23 times smaller than that.