### PR TITLE
Enhance triton functionality to allow use of custom cuda toolkit at runtime

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -342,7 +342,7 @@ class CMakeBuild(build_ext):
 
     def get_proton_cmake_args(self):
         cmake_args = get_thirdparty_packages([get_json_package_info(), get_pybind11_package_info()])
-        cupti_include_dir = get_env_with_keys(["CUPTI_INCLUDE_PATH"])
+        cupti_include_dir = get_env_with_keys(["CUPTI_INCLUDE_PATH", "TRITON_CUPTI_PATH"])
         if cupti_include_dir == "":
             cupti_include_dir = os.path.join(get_base_dir(), "third_party", "nvidia", "backend", "include")
         cmake_args += ["-DCUPTI_INCLUDE_DIR=" + cupti_include_dir]

--- a/python/setup.py
+++ b/python/setup.py
@@ -342,7 +342,7 @@ class CMakeBuild(build_ext):
 
     def get_proton_cmake_args(self):
         cmake_args = get_thirdparty_packages([get_json_package_info(), get_pybind11_package_info()])
-        cupti_include_dir = get_env_with_keys(["CUPTI_INCLUDE_PATH", "TRITON_CUPTI_PATH"])
+        cupti_include_dir = get_env_with_keys(["TRITON_CUPTI_PATH"])
         if cupti_include_dir == "":
             cupti_include_dir = os.path.join(get_base_dir(), "third_party", "nvidia", "backend", "include")
         cmake_args += ["-DCUPTI_INCLUDE_DIR=" + cupti_include_dir]

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -40,11 +40,12 @@ def _build(name, src, srcdir, library_dirs, include_dirs, libraries):
     if scheme == 'posix_local':
         scheme = 'posix_prefix'
     py_include_dir = sysconfig.get_paths(scheme=scheme)["include"]
-    include_dirs = include_dirs + [srcdir, py_include_dir]
+    custom_backend_dirs = set(os.getenv(var) for var in ('TRITON_CUDACRT_PATH', 'TRITON_CUDART_PATH', 'TRITON_CUPTI_PATH'))
+    include_dirs = include_dirs + [srcdir, py_include_dir, *custom_backend_dirs]
     cc_cmd = [cc, src, "-O3", "-shared", "-fPIC", "-o", so]
     cc_cmd += [f'-l{lib}' for lib in libraries]
     cc_cmd += [f"-L{dir}" for dir in library_dirs]
-    cc_cmd += [f"-I{dir}" for dir in include_dirs]
+    cc_cmd += [f"-I{dir}" for dir in include_dirs if dir is not None]
     ret = subprocess.check_call(cc_cmd)
     if ret == 0:
         return so

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -40,7 +40,7 @@ def _build(name, src, srcdir, library_dirs, include_dirs, libraries):
     if scheme == 'posix_local':
         scheme = 'posix_prefix'
     py_include_dir = sysconfig.get_paths(scheme=scheme)["include"]
-    custom_backend_dirs = set(os.getenv(var) for var in ('TRITON_CUDACRT_PATH', 'TRITON_CUDART_PATH', 'TRITON_CUPTI_PATH'))
+    custom_backend_dirs = set(os.getenv(var) for var in ('TRITON_CUDACRT_PATH', 'TRITON_CUDART_PATH'))
     include_dirs = include_dirs + [srcdir, py_include_dir, *custom_backend_dirs]
     cc_cmd = [cc, src, "-O3", "-shared", "-fPIC", "-o", so]
     cc_cmd += [f'-l{lib}' for lib in libraries]


### PR DESCRIPTION
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because `This PR enhances custom build options and won't affect the default build. Default build will be validated by existing CI`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

---

Fixes https://github.com/triton-lang/triton/issues/4224

As introduced in https://github.com/triton-lang/triton/issues/4224, this PR addresses two main issues in source build Triton with custom cuda toolkit:

1. `cupti_include_dir` lookup path for CMake should also include `TRITON_CUPTI_PATH`, as the `TRITON_XXX_PATH` seems to the standard for a custom triton build environment variables.
2. As described in the linked issue, when we specify a `TRITON_CUDART_PATH`, those cuda RT headers from conda will not be downloaded to triton/third_party paths. This makes the default include path bundled in Triton python package empty and thus leads to `fatal error: cuda.h: No such file or directory` error.
  If we're supporting users to "bring your own cuda toolkit" to build triton from source, we should also support them to run triton compile with their own cuda toolkit runtime. 
