### PR TITLE
[AMD] Enable integration tests for MI300

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -383,7 +383,7 @@ jobs:
           cd python/test/unit
           ## test_subprocess.py is flaky on the AMD CI.
           ## TODO (lixun) find a solution and re-enable it.
-          pytest --capture=tee-sys -rfs -n 32 language \
+          pytest --capture=tee-sys -rfs -n 16 language \
                 hopper/test_mixed_io.py \
                 hopper/test_gemm.py \
                 hopper/test_tma_store_gemm.py \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -381,25 +381,15 @@ jobs:
           fi
           pytest --capture=tee-sys -rfs python/tutorials/06-fused-attention.py
           cd python/test/unit
-          if [[ "${{ matrix.runner }}" == *"gfx942"* ]]; then
           ## test_subprocess.py is flaky on the AMD CI.
           ## TODO (lixun) find a solution and re-enable it.
-            pytest --capture=tee-sys -rfs -n 32 language \
+          pytest --capture=tee-sys -rfs -n 32 language \
                 hopper/test_mixed_io.py \
-                hopper/test_flashattention.py \
-                hopper/test_persistent_warp_specialized_fused-attention.py
+                hopper/test_gemm.py \
+                hopper/test_tma_store_gemm.py \
+                hopper/test_persistent_warp_specialized_fused-attention.py \
                 --ignore=language/test_line_info.py \
-                --ignore=language/test_core.py:: \
-                --ignreo=language/test_pipeliner.py
-          else
-            pytest --capture=tee-sys -rfs -n 32 language \
-                 hopper/test_mixed_io.py \
-                 hopper/test_gemm.py \
-                 hopper/test_tma_store_gemm.py \
-                 hopper/test_persistent_warp_specialized_fused-attention.py \
-                 --ignore=language/test_line_info.py \
-                 --ignore=language/test_subprocess.py
-          fi
+                --ignore=language/test_subprocess.py
           TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${SHARED_LIB_DIR}/libGPUHello.so \
           pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           if [ x"${{ github.repository }}" == x"triton-lang/triton" ]; then
             echo '::set-output name=matrix-CUDA::[["a100-runner-set"], ["h100-runner-set"]]'
-            echo '::set-output name=matrix-HIP::[["self-hosted", "gfx90a"]]'
+            echo '::set-output name=matrix-HIP::[["self-hosted", "gfx90a"], ["self-hosted", "gfx942"]]'
             echo '::set-output name=matrix-MACOS::[["macos-latest"]]'
           else
             echo '::set-output name=matrix-CUDA::["ubuntu-latest"]'
@@ -381,15 +381,25 @@ jobs:
           fi
           pytest --capture=tee-sys -rfs python/tutorials/06-fused-attention.py
           cd python/test/unit
+          if [[ "${{ matrix.runner }}" == *"gfx942"* ]]; then
           ## test_subprocess.py is flaky on the AMD CI.
           ## TODO (lixun) find a solution and re-enable it.
-          pytest --capture=tee-sys -rfs -n 32 language \
+            pytest --capture=tee-sys -rfs -n 32 language \
+                hopper/test_mixed_io.py \
+                hopper/test_flashattention.py \
+                hopper/test_persistent_warp_specialized_fused-attention.py
+                --ignore=language/test_line_info.py \
+                --ignore=language/test_core.py:: \
+                --ignreo=language/test_pipeliner.py
+          else
+            pytest --capture=tee-sys -rfs -n 32 language \
                  hopper/test_mixed_io.py \
                  hopper/test_gemm.py \
                  hopper/test_tma_store_gemm.py \
                  hopper/test_persistent_warp_specialized_fused-attention.py \
                  --ignore=language/test_line_info.py \
                  --ignore=language/test_subprocess.py
+          fi
           TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${SHARED_LIB_DIR}/libGPUHello.so \
           pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -384,12 +384,12 @@ jobs:
           ## test_subprocess.py is flaky on the AMD CI.
           ## TODO (lixun) find a solution and re-enable it.
           pytest --capture=tee-sys -rfs -n 16 language \
-                hopper/test_mixed_io.py \
-                hopper/test_gemm.py \
-                hopper/test_tma_store_gemm.py \
-                hopper/test_persistent_warp_specialized_fused-attention.py \
-                --ignore=language/test_line_info.py \
-                --ignore=language/test_subprocess.py
+                 hopper/test_mixed_io.py \
+                 hopper/test_gemm.py \
+                 hopper/test_tma_store_gemm.py \
+                 hopper/test_persistent_warp_specialized_fused-attention.py \
+                 --ignore=language/test_line_info.py \
+                 --ignore=language/test_subprocess.py
           TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${SHARED_LIB_DIR}/libGPUHello.so \
           pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
 

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -385,25 +385,15 @@ jobs:
           fi
           pytest --capture=tee-sys -rfs python/tutorials/06-fused-attention.py
           cd python/test/unit
-          if [[ "${{ matrix.runner }}" == *"gfx942"* ]]; then
           ## test_subprocess.py is flaky on the AMD CI.
           ## TODO (lixun) find a solution and re-enable it.
-            pytest --capture=tee-sys -rfs -n 32 language \
+          pytest --capture=tee-sys -rfs -n 32 language \
                 hopper/test_mixed_io.py \
-                hopper/test_flashattention.py \
-                hopper/test_persistent_warp_specialized_fused-attention.py
+                hopper/test_gemm.py \
+                hopper/test_tma_store_gemm.py \
+                hopper/test_persistent_warp_specialized_fused-attention.py \
                 --ignore=language/test_line_info.py \
-                --ignore=language/test_core.py:: \
-                --ignreo=language/test_pipeliner.py
-          else
-            pytest --capture=tee-sys -rfs -n 32 language \
-                 hopper/test_mixed_io.py \
-                 hopper/test_gemm.py \
-                 hopper/test_tma_store_gemm.py \
-                 hopper/test_persistent_warp_specialized_fused-attention.py \
-                 --ignore=language/test_line_info.py \
-                 --ignore=language/test_subprocess.py
-          fi
+                --ignore=language/test_subprocess.py
           TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${SHARED_LIB_DIR}/libGPUHello.so \
           pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
 

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -388,12 +388,12 @@ jobs:
           ## test_subprocess.py is flaky on the AMD CI.
           ## TODO (lixun) find a solution and re-enable it.
           pytest --capture=tee-sys -rfs -n 16 language \
-                hopper/test_mixed_io.py \
-                hopper/test_gemm.py \
-                hopper/test_tma_store_gemm.py \
-                hopper/test_persistent_warp_specialized_fused-attention.py \
-                --ignore=language/test_line_info.py \
-                --ignore=language/test_subprocess.py
+                 hopper/test_mixed_io.py \
+                 hopper/test_gemm.py \
+                 hopper/test_tma_store_gemm.py \
+                 hopper/test_persistent_warp_specialized_fused-attention.py \
+                 --ignore=language/test_line_info.py \
+                 --ignore=language/test_subprocess.py
           TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${SHARED_LIB_DIR}/libGPUHello.so \
           pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
 

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -115,7 +115,7 @@ jobs:
         run: |
           if [ x"${{ github.repository }}" == x"triton-lang/triton" ]; then
             echo '::set-output name=matrix-CUDA::[["a100-runner-set"], ["h100-runner-set"]]'
-            echo '::set-output name=matrix-HIP::[["self-hosted", "gfx90a"]]'
+            echo '::set-output name=matrix-HIP::[["self-hosted", "gfx90a"], ["self-hosted", "gfx942"]]'
             echo '::set-output name=matrix-MACOS::[["macos-latest"]]'
           else
             echo '::set-output name=matrix-CUDA::["ubuntu-latest"]'
@@ -385,15 +385,25 @@ jobs:
           fi
           pytest --capture=tee-sys -rfs python/tutorials/06-fused-attention.py
           cd python/test/unit
+          if [[ "${{ matrix.runner }}" == *"gfx942"* ]]; then
           ## test_subprocess.py is flaky on the AMD CI.
           ## TODO (lixun) find a solution and re-enable it.
-          pytest --capture=tee-sys -rfs -n 32 language \
+            pytest --capture=tee-sys -rfs -n 32 language \
+                hopper/test_mixed_io.py \
+                hopper/test_flashattention.py \
+                hopper/test_persistent_warp_specialized_fused-attention.py
+                --ignore=language/test_line_info.py \
+                --ignore=language/test_core.py:: \
+                --ignreo=language/test_pipeliner.py
+          else
+            pytest --capture=tee-sys -rfs -n 32 language \
                  hopper/test_mixed_io.py \
                  hopper/test_gemm.py \
                  hopper/test_tma_store_gemm.py \
                  hopper/test_persistent_warp_specialized_fused-attention.py \
                  --ignore=language/test_line_info.py \
                  --ignore=language/test_subprocess.py
+          fi
           TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${SHARED_LIB_DIR}/libGPUHello.so \
           pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
 

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -387,7 +387,7 @@ jobs:
           cd python/test/unit
           ## test_subprocess.py is flaky on the AMD CI.
           ## TODO (lixun) find a solution and re-enable it.
-          pytest --capture=tee-sys -rfs -n 32 language \
+          pytest --capture=tee-sys -rfs -n 16 language \
                 hopper/test_mixed_io.py \
                 hopper/test_gemm.py \
                 hopper/test_tma_store_gemm.py \

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5156,9 +5156,12 @@ def test_dot_max_num_imprecise_acc(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, in_type_s
         if cc[0] >= 9 and in_type_str == "float8e4b15":
             pytest.skip("Dot op does not support fp8e4b15 on CUDA arch >= 90")
     elif is_hip():
-        ## TODO: Figure out why float8e5 input fails on MI300
-        if in_type_str != 'float8e5' or is_hip_mi300():
+        if in_type_str != 'float8e5':
             pytest.skip('test_fp8_dot_acc for HIP currently broken in upstream.')
+
+        ## TODO: Figure out why block size (128, 256, 128) fails on MI300
+        if is_hip_mi300() and BLOCK_M == 128:
+            pytest.skip('BLOCK size (128, 256, 128) fails on MI300')
 
     check_type_supported(in_type_str, device)
     A = numpy_random((M, K), dtype_str=in_type_str)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -32,6 +32,11 @@ def is_hip():
         triton.runtime.driver.active.get_current_target().backend == "hip"
 
 
+def is_hip_mi300():
+    target = triton.runtime.driver.active.get_current_target()
+    return target.backend == 'hip' and target.arch == 'gfx942'
+
+
 int_dtypes = ['int8', 'int16', 'int32', 'int64']
 uint_dtypes = ['uint8', 'uint16', 'uint32', 'uint64']
 float_dtypes = ['float16', 'float32', 'float64']
@@ -5151,7 +5156,8 @@ def test_dot_max_num_imprecise_acc(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, in_type_s
         if cc[0] >= 9 and in_type_str == "float8e4b15":
             pytest.skip("Dot op does not support fp8e4b15 on CUDA arch >= 90")
     elif is_hip():
-        if in_type_str != 'float8e5':
+        ## TODO: Figure out why float8e5 input fails on MI300
+        if in_type_str != 'float8e5' or is_hip_mi300():
             pytest.skip('test_fp8_dot_acc for HIP currently broken in upstream.')
 
     check_type_supported(in_type_str, device)

--- a/python/test/unit/language/test_pipeliner.py
+++ b/python/test/unit/language/test_pipeliner.py
@@ -128,7 +128,7 @@ def test_pipeline_matmul(device):
                                       output.stride(0), output.stride(1), BLOCK_M, BLOCK_N, BLOCK_K,
                                       NUM_STAGES=NUM_STAGES)
     ref_out = torch.matmul(a, b)
-    atol = 1e-2 if is_hip() else None
+    atol = 1e-2 if is_hip_mi200() else None
     # Bigger tolerance for AMD MI200 devices.
     # MI200 devices use reduced precision fp16 and bf16 and flush input and
     # output denormal values to zero. Detailed info is at: https://pytorch.org/docs/stable/notes/numerical_accuracy.html#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices


### PR DESCRIPTION
This PR updates CI script to enable integration tests for MI300.

This only enables coverage the same as the MI250 machine.
There is one test failure left as TODO in test_core.py to be
figured out and fixed.