### PR TITLE
[AMD] Search libamdhip64.so in PyTorch user site installation

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -33,7 +33,7 @@ def _get_path_to_hip_runtime_dylib():
     site_packages = site.getsitepackages()
     user_site = site.getusersitepackages()
     if site.ENABLE_USER_SITE:  # ENABLE_USER_SITE is initialized in getusersitepackages()
-        site_packages += [user_site]
+        site_packages = [user_site] + site_packages
     for path in site_packages:
         path = os.path.join(path, "torch", "lib", lib_name)
         if os.path.exists(path):

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -30,7 +30,11 @@ def _get_path_to_hip_runtime_dylib():
     # First search the HIP runtime dynamic library packaged with PyTorch. It's very likely
     # that we run Triton together with PyTorch. This makes sure we use the same dynamic
     # library to avoid version mismatch.
-    for path in site.getsitepackages():
+    site_packages = site.getsitepackages()
+    user_site = site.getusersitepackages()
+    if site.ENABLE_USER_SITE:  # ENABLE_USER_SITE is initialized in getusersitepackages()
+        site_packages += [user_site]
+    for path in site_packages:
         path = os.path.join(path, "torch", "lib", lib_name)
         if os.path.exists(path):
             return path


### PR DESCRIPTION
## Add extra search path of hipruntime

Previously Triton cannot find the HIP runtime bundled in PyTorch if the wheel
is installed with `--user`. Searching the user site-packages directory may
solve this problem.


## Complete the following tasks before sending your PR, and replace `[ ]` with `[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it does not add new features.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
