### PR TITLE
[BUILD] Fix compilation errors under RelWithDebugInfo

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1650,7 +1650,8 @@ void init_triton_ir(py::module &&m) {
                           });
 
           ::llvm::DebugFlag = true;
-          ::llvm::setCurrentDebugTypes(debugTypes.data(), debugTypes.size());
+          using namespace llvm;
+          setCurrentDebugTypes(debugTypes.data(), debugTypes.size());
         }
 
         bool haveTiming = ::triton::tools::getBoolEnv("MLIR_ENABLE_TIMING");


### PR DESCRIPTION
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

Flags used by the CXX compiler during RELWITHDEBINFO builds.
```
CMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING=-O2 -g -DNDEBUG
```

`setCurrentDebugTypes` is a different type of symbol (function or macro) under the control of the NDEBUG macro, so `llvm::setCurrentDebug` cannot be used directly; otherwise, it will cause compilation errors.

https://github.com/llvm/llvm-project/blob/00c622e596f918d9d83674b58097c8982ae1af95/llvm/include/llvm/Support/Debug.h#L71

https://github.com/llvm/llvm-project/blob/959ff45bdad1777598c89b662fc98653a19eb8a3/mlir/lib/CAPI/Debug/Debug.cpp#L28-L31
