### PR TITLE
[CI] Preserve environment variables when building docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,7 +37,7 @@ jobs:
           export PATH=$(python3 -c "import cmake; print(cmake.CMAKE_BIN_DIR)"):$PATH
           # Limit the number of threads to reduce CPU memory usage
           # This CI node has 24 cores
-          MAX_JOBS=24 sudo python3 -m sphinx . _build/html/main
+          MAX_JOBS=24 sudo -E python3 -m sphinx . _build/html/main
 
       - name: Update docs
         run: |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,6 +98,8 @@ def setup(app):
     import sphinx
 
     app.connect("autodoc-process-signature", process_sig)
+    max_jobs = os.getenv("MAX_JOBS", str(2 * os.cpu_count()))
+    print(f"Installing Triton Python package using {max_jobs} threads")
     subprocess.run("pip install -e ../python", shell=True, env=os.environ.copy())
 
     setup_generated_mlir_docs()


### PR DESCRIPTION
Added a `print` statement in `conf.py` for debugging purposes. Apologies for the back-and-forth on this issue.