### PR TITLE
[TEST] Fix numpy out-of-bound warnings/failures

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2061,7 +2061,7 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, device):
         'argmax-tie-break-left': np.argmax,
     }[op]
     if 'tie-break-left' in op:
-        x[3:10] = numpy_op(x)
+        x[3:10] = x[numpy_op(x)]
     x_tri = to_triton(x, device=device)
     # numpy result
     z_dtype_str = 'int32' if op in ('argmin', 'argmax') else dtype_str

--- a/python/test/unit/language/test_random.py
+++ b/python/test/unit/language/test_random.py
@@ -54,9 +54,10 @@ class CustomPhilox4x:
 
     def _into_pieces(self, n, pad=4):
         res = []
+        bits = np.dtype(self._dtype).itemsize * 8
         while len(res) < pad:
-            res.append(np.array(n, dtype=self._dtype))
-            n >>= (np.dtype(self._dtype).itemsize * 8)
+            res.append(np.array((n & ((1 << bits) - 1)), dtype=self._dtype))
+            n >>= bits
         assert n == 0
         return tuple(res)
 


### PR DESCRIPTION
In newer versions of numpy, converting python integers that are out of bounds results in a failure - e.g. see this warning that currently appears in CI:

```
DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of 67830198458 to uint32 will fail in the future.
```

This PR fixes two tests which fail when using numpy 2.0.0:
* test_randint - explicitly truncate the integer that was too large
* test_reduce1d: previously, the test would set `x[3:10] = argmax(x)`. However: (1) this now errors due to overflow, e.g. if argmax() returns a value >= 256; and (2) it appears that the intent is actually to set x[3:10] = x[argmax(x)], so that there are duplicate elements with the max value. I've changed this line to `x[3:10] = argmax(x)`.

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `this PR fixes tests`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
