### PR TITLE
[backend] Pass target machine DataLayout to llir creation. Fix for issue 4060.

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -248,6 +248,23 @@ void init_triton_llvm(py::module &&m) {
       },
       py::keep_alive<0, 2>());
 
+  m.def("attach_datalayout", [](llvm::Module *mod, const std::string triple,
+                                const std::string proc,
+                                const std::string features) {
+    std::string error;
+    auto target = llvm::TargetRegistry::lookupTarget(triple, error);
+    if (!target) {
+      throw std::runtime_error("target lookup error: " + error);
+    }
+    llvm::TargetOptions opt;
+    // Target machine is only used to create the data layout.
+    std::unique_ptr<llvm::TargetMachine> machine{target->createTargetMachine(
+        triple, proc, features, opt, llvm::Reloc::PIC_, std::nullopt,
+        llvm::CodeGenOptLevel::None)};
+    // set data layout
+    mod->setDataLayout(machine->createDataLayout());
+  });
+
   m.def("optimize_module", [](llvm::Module *mod,
                               const llvm::OptimizationLevel &opt) {
     if (mlir::triton::tools::getBoolEnv("DISABLE_LLVM_OPT"))

--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -35,6 +35,13 @@ def kernel_print(X, Y, BLOCK: tl.constexpr):
 
 
 @triton.jit
+def kernel_device_print_scalar(SCALAR):
+    x = tl.load(SCALAR)
+    # Triton should add a space after this prefix.
+    print("x:", x)
+
+
+@triton.jit
 def kernel_device_print_large(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -94,6 +101,9 @@ def test_print(func: str, data_type: str, device: str):
     y = torch.zeros((N, ), dtype=x.dtype, device=device)
     if func == "device_print":
         kernel_device_print[(1, )](x, y, num_warps=num_warps, BLOCK=N)
+    elif func == "device_print_scalar":
+        scalar = torch.tensor(42, dtype=x.dtype, device="cuda")
+        kernel_device_print_scalar[(1, )](scalar, num_warps=num_warps)
     elif func == "print":
         kernel_print[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "device_print_large":
@@ -117,7 +127,7 @@ def test_print(func: str, data_type: str, device: str):
 
     if func != "print_no_arg" and func != "no_arg_print" and func != "device_print_large" and \
        func != "print_multiple_args" and func != "device_print_multiple_args" and \
-       func != "device_print_pointer":
+       func != "device_print_pointer" and func != "device_print_scalar":
         assert_close(y, x)
 
 

--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -24,19 +24,21 @@ def is_interpreter():
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("func_type, data_type", [("device_print", data_type) for data_type in torch_types] + [
-    ("print", "int32"),
-    ("static_print", "int32"),
-    ("no_arg_print", "int32"),
-    ("print_no_arg", "int32"),
-    ("device_print_large", "int32"),
-    ("print_multiple_args", "int32"),
-    ("device_print_multiple_args", "int32"),
-    ("device_print_hex", "int16"),
-    ("device_print_hex", "int32"),
-    ("device_print_hex", "int64"),
-    ("device_print_pointer", "int32"),
-])
+@pytest.mark.parametrize("func_type, data_type", [(fn, data_type)
+                                                  for fn in ["device_print", "device_print_scalar"]
+                                                  for data_type in torch_types] + [
+                                                      ("print", "int32"),
+                                                      ("static_print", "int32"),
+                                                      ("no_arg_print", "int32"),
+                                                      ("print_no_arg", "int32"),
+                                                      ("device_print_large", "int32"),
+                                                      ("print_multiple_args", "int32"),
+                                                      ("device_print_multiple_args", "int32"),
+                                                      ("device_print_hex", "int16"),
+                                                      ("device_print_hex", "int32"),
+                                                      ("device_print_hex", "int64"),
+                                                      ("device_print_pointer", "int32"),
+                                                  ])
 def test_print(func_type: str, data_type: str, device: str):
     proc = subprocess.run(
         [sys.executable, print_path, "test_print", func_type, data_type, device],
@@ -54,6 +56,9 @@ def test_print(func_type: str, data_type: str, device: str):
     # The total number of elements in the 1-D tensor to print.
     N = 128
 
+    # Constant for testing the printing of scalar values
+    SCALAR_VAL = 42
+
     # Format is
     #   pid (<x>, <y>, <z>) idx (<i1>, <i2>, ...) <prefix> (operand <n>) <elem>
     expected_lines = Counter()
@@ -63,6 +68,11 @@ def test_print(func_type: str, data_type: str, device: str):
             if data_type.startswith("float"):
                 line += ".000000"
             expected_lines[line] = 1
+    elif func_type == "device_print_scalar":
+        line = f"pid (0, 0, 0) idx () x: {SCALAR_VAL}"
+        if data_type.startswith("float"):
+            line += ".000000"
+        expected_lines[line] = N
     elif func_type == "device_print_hex":
         for i in range(N):
             line = f"pid (0, 0, 0) idx ({i:3}) x: 0x"


### PR DESCRIPTION
Changes to pass target machine DataLayout to llir creation. Fixes issue [4060.](https://github.com/triton-lang/triton/issues/4060)

Triton was passing in the default DataLayout to llir creation and the target machine DataLayout to the llir->asm translation.
This makes the llvm optimization passes use default alignments from llvm/lib/IR/DataLayout.cpp instead of the target machine's alignment.
For i64 on nvidia, this results in alignment of 4(abi)/8(pref) instead of the 8(abi)/8(pref) target alignment expected by functions like vprintf.
This PR adds a attach_datalayout function that allows a backend to create a target DataLayout and attach it to a llvm::Module.
This PR also adds print_device_scalar tests to cover the bug reported in issue 4060.

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [ x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
