### PR TITLE
[PROTON] Flush ops before activating sessions

### DIFF
--- a/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
@@ -66,7 +66,7 @@ processActivityKernel(CuptiProfiler::CorrIdToExternIdMap &corrIdToExternId,
     }
   } else {
     // Graph kernels
-    // A single grpah launch can trigger multiple kernels.
+    // A single graph launch can trigger multiple kernels.
     // Our solution is to construct the following maps:
     // --- Application threads ---
     // 1. graphId -> numKernels
@@ -321,7 +321,7 @@ void CuptiProfiler::CuptiProfilerPimpl::doFlush() {
   // This is a blocking call but it doesn’t issue any CUDA synchronization calls
   // implicitly thus it’s not guaranteed that all activities are completed on
   // the underlying devices.
-  // We do an "oppurtunistic" synchronization here to try to ensure that all
+  // We do an "opportunistic" synchronization here to try to ensure that all
   // activities are completed on the current context.
   // If the current context is not set, we don't do any synchronization.
   CUcontext cuContext = nullptr;

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -41,6 +41,7 @@ makeContextSource(const std::string &contextSourceName) {
 
 void Session::activate() {
   profiler->start();
+  profiler->flush();
   profiler->registerData(data.get());
 }
 


### PR DESCRIPTION
To ensure that metrics from kernels launched before are not attributed to the current active session.