### PR TITLE
Use `device` fixture for `test_subprocess.py::test_print`

### DIFF
--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -83,15 +83,15 @@ def kernel_print_pointer(X, Y, BLOCK: tl.constexpr):
     tl.device_print("ptr ", X + tl.arange(0, BLOCK))
 
 
-def test_print(func: str, data_type: str):
+def test_print(func: str, data_type: str, device: str):
     N = 128  # This value should match with test_print in test_subprocess.py.
     # TODO(antiagainst): Currently the warp count is chosen to make sure wedon't have multiple
     # threads printing duplicated messages due to broadcasting. Improve print op lowering logic
     # to filter out duplicated data range.
     num_warps = N // get_current_target_warp_size()
 
-    x = torch.arange(0, N, dtype=torch.int32, device='cuda').to(getattr(torch, data_type))
-    y = torch.zeros((N, ), dtype=x.dtype, device="cuda")
+    x = torch.arange(0, N, dtype=torch.int32, device=device).to(getattr(torch, data_type))
+    y = torch.zeros((N, ), dtype=x.dtype, device=device)
     if func == "device_print":
         kernel_device_print[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "print":
@@ -122,4 +122,4 @@ def test_print(func: str, data_type: str):
 
 
 if __name__ == "__main__":
-    test_print(sys.argv[1], sys.argv[2])
+    test_print(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -37,8 +37,8 @@ def is_interpreter():
     ("device_print_hex", "int64"),
     ("device_print_pointer", "int32"),
 ])
-def test_print(func_type: str, data_type: str):
-    proc = subprocess.Popen([sys.executable, print_path, func_type, data_type], stdout=subprocess.PIPE,
+def test_print(func_type: str, data_type: str, device: str):
+    proc = subprocess.Popen([sys.executable, print_path, func_type, data_type, device], stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, shell=False)
     outs, err = proc.communicate()
     assert proc.returncode == 0


### PR DESCRIPTION
**This pull request adds the use of the `device` fixture to the test to make it not only CUDA specific. This simplifies testing of various devices in the downstream, without having to modify the test code itself.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

~- [ ] I am not making a trivial change, such as fixing a typo in a comment.~

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it only modifies the test`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
