### PR TITLE
Make tests more device-independent using the device fixture

### DIFF
--- a/python/test/unit/language/assert_helper.py
+++ b/python/test/unit/language/assert_helper.py
@@ -47,7 +47,7 @@ def kernel_static_assert(X, Y, BLOCK: tl.constexpr):
     tl.store(Y + tl.arange(0, BLOCK), x)
 
 
-def test_assert(func: str):
+def test_assert(func: str, device: str):
     N = 128  # This value should match with test_print in test_subprocess.py.
     num_warps = N // get_current_target_warp_size()
 
@@ -132,12 +132,12 @@ def kernel_device_assert_nested_false(X, Y, BLOCK: tl.constexpr, jit_debug: tl.c
     tl.store(Y + tl.arange(0, BLOCK), x)
 
 
-def test_assert_nested(caller: str, callee: str):
+def test_assert_nested(caller: str, callee: str, device: str):
     N = 128  # This value should match with test_print in test_subprocess.py.
     num_warps = N // get_current_target_warp_size()
 
-    x = torch.arange(0, N, dtype=torch.int32, device='cuda')
-    y = torch.zeros((N, ), dtype=x.dtype, device="cuda")
+    x = torch.arange(0, N, dtype=torch.int32, device=device)
+    y = torch.zeros((N, ), dtype=x.dtype, device=device)
     if caller == "none":
         kernel_device_assert_nested[(1, )](x, y, num_warps=num_warps, BLOCK=N, jit_debug=callee)
     elif caller == "true":
@@ -148,7 +148,5 @@ def test_assert_nested(caller: str, callee: str):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) == 3:
-        test_assert_nested(sys.argv[1], sys.argv[2])
-    else:
-        test_assert(sys.argv[1])
+    fn = globals()[sys.argv[1]]
+    fn(*sys.argv[2:])

--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -122,4 +122,5 @@ def test_print(func: str, data_type: str, device: str):
 
 
 if __name__ == "__main__":
-    test_print(sys.argv[1], sys.argv[2], sys.argv[3])
+    fn = globals()[sys.argv[1]]
+    fn(*sys.argv[2:])

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -6,10 +6,10 @@ import pytest
 
 
 @pytest.mark.parametrize('use_cuda_graph', [False, True])
-def test_kwargs(use_cuda_graph: bool):
+def test_kwargs(use_cuda_graph: bool, device: str):
     N = 1024
-    src = torch.empty(N, device='cuda')
-    dst = torch.empty(N, device='cuda')
+    src = torch.empty(N, device=device)
+    dst = torch.empty(N, device=device)
 
     configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
 
@@ -25,9 +25,9 @@ def test_kwargs(use_cuda_graph: bool):
     _kernel[grid](dst=dst, src=src, N=N)
 
 
-def test_restore():
+def test_restore(device):
     N = 1024
-    src = torch.zeros(N, device='cuda')
+    src = torch.zeros(N, device=device)
 
     configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
 
@@ -43,10 +43,10 @@ def test_restore():
     triton.testing.assert_close(src, torch.ones_like(src))
 
 
-def test_hooks():
+def test_hooks(device):
     # Autotuner's pre- and post- hooks should be called the same number of times
     N = 4096
-    src = torch.zeros(N, device='cuda')
+    src = torch.zeros(N, device=device)
 
     configs = [triton.Config(kwargs={'BLOCK_SIZE': 4096}), triton.Config(kwargs={'BLOCK_SIZE': 32})]
 
@@ -87,10 +87,10 @@ def test_hooks():
 
 
 @pytest.mark.parametrize('with_perf_model', [False, True])
-def test_prune_configs(with_perf_model: bool):
+def test_prune_configs(with_perf_model: bool, device: str):
     N = 1024
-    src = torch.empty(N, device='cuda')
-    dst = torch.empty(N, device='cuda')
+    src = torch.empty(N, device=device)
+    dst = torch.empty(N, device=device)
     records = {}
 
     def early_config_prune(configs, named_args, **kwargs):

--- a/python/test/unit/runtime/test_bindings.py
+++ b/python/test/unit/runtime/test_bindings.py
@@ -28,9 +28,9 @@ def add_kernel(
     tl.store(out_ptr + offsets, output, mask=mask)
 
 
-def test_module_walk():
+def test_module_walk(device):
     """
-    Test the MLIR bindings exposed for the out-ot-tree walk.
+    Test the MLIR bindings exposed for the out-of-tree walk.
     """
 
     def walk_fn(op):
@@ -53,10 +53,10 @@ def test_module_walk():
 
     kernel = add_kernel
     args = [
-        torch.empty((32, 32), device="cuda"),  # in_ptr0
-        torch.empty((32, 32), device="cuda"),  # in_ptr1
+        torch.empty((32, 32), device=device),  # in_ptr0
+        torch.empty((32, 32), device=device),  # in_ptr1
         1024,  # n_elements
-        torch.empty((32, 32), device="cuda"),  # out_ptr
+        torch.empty((32, 32), device=device),  # out_ptr
         16,  # BLOCK_SIZE
     ]
     src = triton.compiler.compiler.ASTSource(

--- a/python/test/unit/test_debug_dump.py
+++ b/python/test/unit/test_debug_dump.py
@@ -4,9 +4,9 @@ import os
 import torch
 
 
-def test_fn_dump(capfd):
+def test_fn_dump(capfd, device):
     N = 1024
-    src = torch.zeros(N, device='cuda')
+    src = torch.zeros(N, device=device)
 
     grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
 


### PR DESCRIPTION
This makes it easier to reuse the tests for other non-CUDA backends.

-----

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)