### PR TITLE
[BACKEND] Fallback to MMAv2 for batch matmul on hopper GPUs

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -21,12 +21,17 @@ class SharedEncodingAttr;
 }
 } // namespace triton
 
+// Returns a tuple of two or three entries representing the shape of the
+// instruction used to perform a matrix multiplication operation.
+// Version = 1: <m, n>
+// Version = 2: <1, m, n>
+// Version = 3: <m, n, k>
 SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
                                                 const ArrayRef<int64_t> &shape,
                                                 RankedTensorType type,
                                                 int numWarps);
 
-/// Returns true if the Load uses block pointer.
+// Returns true if the Load uses block pointer.
 bool isLoadFromTensorPtr(triton::LoadOp op);
 
 // Return an array of indices enumerating the elements of 'arr' in descending

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -21,7 +21,7 @@ class SharedEncodingAttr;
 }
 } // namespace triton
 
-// Returns a tuple of two or three entries representing the shape of the
+// Return a tuple of two or three entries representing the shape of the
 // instruction used to perform a matrix multiplication operation.
 // Version = 1: <m, n>
 // Version = 2: <1, m, n>
@@ -31,7 +31,7 @@ SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
                                                 RankedTensorType type,
                                                 int numWarps);
 
-// Returns true if the Load uses block pointer.
+// Return true if the Load uses block pointer.
 bool isLoadFromTensorPtr(triton::LoadOp op);
 
 // Return an array of indices enumerating the elements of 'arr' in descending

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -496,6 +496,9 @@ bool supportMMA(triton::DotOp op, int version) {
     auto rank = retShapePerCTA.size();
     auto mod = op->getParentOfType<ModuleOp>();
     int numWarps = TritonGPUDialect::getNumWarps(mod);
+    // TODO(Keren): for now, fallback to MMAv2 if handling batch matmul.
+    if (rank == 3)
+      return false;
     if (!(numWarps % 4 == 0 && retShapePerCTA[rank - 2] % 64 == 0 &&
           retShapePerCTA[rank - 1] % 8 == 0 &&
           (aElemTy.isFloat8E5M2() || aElemTy.isFloat8E4M3FNUZ() ||

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3315,7 +3315,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
                           for in_dtype_str, out_dtype_str in [('int8', 'int8'), ('float16', 'float16'),
                                                               ('float16', 'float32'), ('float32', 'float32')]] +
                          # Large block sizes
-                         [(4, 4, 128, 128, 128, 64, 64, 'float16', 'float16')])
+                         [(4, 4, 128, 128, 64, 64, 64, 'float16', 'float16')])
 def test_dot3d(B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str, device):
     if is_hip():
         # hip does not support tf32 precision, so use ieee for all tests

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3306,12 +3306,16 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("B", [1, 2, 4, 8])
-@pytest.mark.parametrize("num_warps", [1, 2, 4, 8, 16])
-@pytest.mark.parametrize("M, N, K", [(64, 64, 64), (32, 32, 32)])
-@pytest.mark.parametrize("in_dtype_str, out_dtype_str", [('int8', 'int8'), ('float16', 'float16'),
-                                                         ('float16', 'float32'), ('float32', 'float32')])
-def test_dot3d(B, num_warps, M, N, K, in_dtype_str, out_dtype_str, device):
+@pytest.mark.parametrize("B, num_warps, M, N, K, in_dtype_str, out_dtype_str",
+                         [(B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str)
+                          for B in [1, 2, 4, 8]
+                          for num_warps in [1, 2, 4, 8, 16]
+                          for BLOCK_M, BLOCK_N in [(32, 32)]
+                          for M, N, K in [(64, 64, 64), (32, 32, 32)]
+                          for in_dtype_str, out_dtype_str in [('int8', 'int8'), ('float16', 'float16'),
+                                                              ('float16', 'float32'), ('float32', 'float32')]] +
+                         [(4, 4, 128, 128, 128, 64, 64, 'float16', 'float16')])
+def test_dot3d(B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str, device):
     if is_hip():
         # hip does not support tf32 precision, so use ieee for all tests
         input_precision = "ieee"
@@ -3388,7 +3392,6 @@ def test_dot3d(B, num_warps, M, N, K, in_dtype_str, out_dtype_str, device):
     out_tri = to_triton(out, device=device)
 
     BLOCK_B = B
-    BLOCK_M, BLOCK_N = 32, 32
     BLOCK_K = K
 
     grid = (

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3306,7 +3306,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("B, num_warps, M, N, K, in_dtype_str, out_dtype_str",
+@pytest.mark.parametrize("B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str",
                          [(B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str)
                           for B in [1, 2, 4, 8]
                           for num_warps in [1, 2, 4, 8, 16]
@@ -3314,6 +3314,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
                           for M, N, K in [(64, 64, 64), (32, 32, 32)]
                           for in_dtype_str, out_dtype_str in [('int8', 'int8'), ('float16', 'float16'),
                                                               ('float16', 'float32'), ('float32', 'float32')]] +
+                         # Large block sizes
                          [(4, 4, 128, 128, 128, 64, 64, 'float16', 'float16')])
 def test_dot3d(B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_str, device):
     if is_hip():


### PR DESCRIPTION
Also enhanced the test case (i.e., `test_dot3d`) with a larger block size to trigger the problem