### PR TITLE
Short-term solution for TMA descriptor cache management

### DIFF
--- a/python/triton/tools/experimental_descriptor.py
+++ b/python/triton/tools/experimental_descriptor.py
@@ -1,35 +1,28 @@
 import torch
 
 import triton
-import triton.language as tl
 
 
-@triton.jit
-def flush_TMA_cache(desc_ptr):
-    tl.inline_asm_elementwise("fence.proxy.tensormap::generic.acquire.gpu [$1], 128; // $0 dummy reg", "=r, l",
-                              [desc_ptr], dtype=tl.int32, is_pure=False, pack=1)
-
-
+# Constructs a 1D TMA descriptor in mutable GPU memory.
+#
+# Note: on the first use of a new descriptor, each SM must invalidate the descriptor's
+# address in TMA cache via fence.proxy.tensormap::generic.acquire.gpu.
 def create_1d_tma_descriptor(ptr, dim, block_dim, element_size):
     TMA_SIZE = 128
     desc = torch.empty(TMA_SIZE, dtype=torch.int8)
     triton.runtime.driver.active.utils.fill_1d_tma_descriptor(ptr, dim, block_dim, element_size, desc.data_ptr())
     gpu_desc = desc.cuda()
-    # TMA cache is not being flushed in between dispacthes, therefore we should
-    # manually flush the cache every time we create a new TMA descriptor to make
-    # sure the following dispatch don't use stale cache when accessing TMA.
-    flush_TMA_cache[(1, )](gpu_desc, num_warps=1)
     return gpu_desc
 
 
+# Constructs a 2D TMA descriptor in mutable GPU memory.
+#
+# Note: on the first use of a new descriptor, each SM must invalidate the descriptor's
+# address in TMA cache via fence.proxy.tensormap::generic.acquire.gpu.
 def create_2d_tma_descriptor(ptr, dim1, dim0, block_dim1, block_dim0, element_size):
     TMA_SIZE = 128
     desc = torch.empty(TMA_SIZE, dtype=torch.int8)
     triton.runtime.driver.active.utils.fill_2d_tma_descriptor(ptr, dim1, dim0, block_dim1, block_dim0, element_size,
                                                               desc.data_ptr())
     gpu_desc = desc.cuda()
-    # TMA cache is not being flushed in between dispacthes, therefore we should
-    # manually flush the cache every time we create a new TMA descriptor to make
-    # sure the following dispatch don't use stale cache when accessing TMA.
-    flush_TMA_cache[(1, )](gpu_desc, num_warps=1)
     return gpu_desc

--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -259,6 +259,14 @@ def matmul_kernel_tma_persistent(a_desc_ptr, b_desc_ptr, c_desc_ptr,  #
                                  GROUP_SIZE_M: tl.constexpr,  #
                                  FP8_OUTPUT: tl.constexpr,  #
                                  NUM_SMS: tl.constexpr):  #
+    # TODO(embg) remove TMA fence after __grid_constant__ lands
+    tl.inline_asm_elementwise("fence.proxy.tensormap::generic.acquire.gpu [$1], 128; // $0 dummy reg", "=r, l",
+                              [a_desc_ptr], dtype=tl.int32, is_pure=False, pack=1)
+    tl.inline_asm_elementwise("fence.proxy.tensormap::generic.acquire.gpu [$1], 128; // $0 dummy reg", "=r, l",
+                              [b_desc_ptr], dtype=tl.int32, is_pure=False, pack=1)
+    tl.inline_asm_elementwise("fence.proxy.tensormap::generic.acquire.gpu [$1], 128; // $0 dummy reg", "=r, l",
+                              [c_desc_ptr], dtype=tl.int32, is_pure=False, pack=1)
+
     dtype = tl.float8e4nv if FP8_OUTPUT else tl.float16
     start_pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)


### PR DESCRIPTION
This PR fixes the bug demonstrated [here](https://github.com/embg/triton/blob/ed125e4a44e397e9a40e691bb7ce40c698120a1a/tma_repro.py), which is the probable root cause of https://github.com/triton-lang/triton/issues/4332.

## The problem
NVIDIA docs [recommend](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#using-tma-to-transfer-multi-dimensional-arrays) that TMA descriptors should be passed through immutable device memory, but Triton currently passes them through mutable device memory. This is unsafe unless the TMA descriptor cache is flushed *on every SM*.

The current implementation attempts to flush the cache by launching a [dedicated TMA flush kernel](https://github.com/triton-lang/triton/blob/3aeb223819d632303dd2b45f4dc533d6af90dc46/python/triton/tools/experimental_descriptor.py#L34). Unfortunately, this kernel does not run on all SMs. As a result, Triton TMA kernels may hang or return incorrect results.

According to @ThomasRaoux, it isn't possible to guarantee a kernel will run on every SM (as there may be another workload on a different CUDA stream). So flushing in a separate kernel is not possible.

## Proposed solution
* Add fences to all example code via inline assembly.
* Add documentation to inform users about the fence issue.
* Remove the existing cache flush code since it is incorrect.

## Why this solution?
Since each kernel needs to issue its own fence instruction, we have three options:
* Inline assembly
* Add a new op, like `tl._experimental_tma_acquire_fence(addr)`
* Use compiler analysis to insert the fence automatically

I believe we should not add a new op or analysis pass until both `__grid_constant__` and on-device descriptor mutation are landed. Once host-side descriptors switch to `__grid_constant__`, the fence will only be needed for on-device mutation, which won't require a separate op or analysis pass (simply add a fence while lowering the mutation op).

If I'm wrong and we do end up needing a separate op or analysis pass, it will be trivial to clean up 6 lines of inline assembly.

## Checklist

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.

- Select one of the following.
  - [x] I have not added any `lit` tests.
