### PR TITLE
[INTERPRETER] Define `min_dot_size`

### DIFF
--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -241,6 +241,7 @@ class InterpreterBuilder:
         self.options = InterpreterOptions()
         self.codegen_fns = {}
         self.codegen_fns["convert_custom_types"] = ExtraFunctions._convert_custom_types
+        self.codegen_fns["min_dot_size"] = lambda lhsType, rhsType: (16, 16, 16)
 
     def set_grid_idx(self, x, y, z):
         if not x < self.grid_dim[0]:


### PR DESCRIPTION
538556a added assertion in semantic checking of `dot`. 
This commit defines `min_dot_size` for interpreter, 
so kernels including `dot` can be run correctly for interpreter.