### PR TITLE
Improve JITFunction pre-run hooks

### DIFF
--- a/python/test/unit/runtime/test_jit.py
+++ b/python/test/unit/runtime/test_jit.py
@@ -28,7 +28,7 @@ def test_pre_call_hooks(device):
     class MyTensor(torch.Tensor):
         pass
 
-    def my_hook(*args, **kwargs):
+    def my_hook(kernel, *args, **kwargs):
         for arg in itertools.chain(args, kwargs.values()):
             if isinstance(arg, MyTensor):
                 raise Exception("MyTensor is not allowed")
@@ -40,3 +40,67 @@ def test_pre_call_hooks(device):
     out = torch.zeros_like(x)
     with pytest.raises(Exception):
         add_kernel[(4, )](x, y, out, 4, 4)
+
+
+def test_pre_call_hooks_can_stop_execution(device):
+    @triton.jit
+    def add_kernel(
+        in_ptr0,
+        in_ptr1,
+        out_ptr,
+        n_elements,
+        BLOCK_SIZE: "tl.constexpr",
+    ):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(in_ptr0 + offsets, mask=mask)
+        y = tl.load(in_ptr1 + offsets, mask=mask)
+        output = x + y
+        tl.store(out_ptr + offsets, output, mask=mask)
+
+    called = 0
+
+    def my_hook(kernel, *args, **kwargs):
+        nonlocal called
+        called += 1
+        return True
+
+    add_kernel.add_pre_run_hook(my_hook)
+    x = torch.ones(4, device=device)
+    y = torch.ones(4, device=device)
+    out = torch.zeros_like(x)
+    add_kernel[(4, )](x, y, out, 4, 4)
+    assert called == 1
+    assert torch.allclose(out, torch.zeros_like(out))
+
+
+def test_pre_call_hooks_can_stop_execution_autotuned(device):
+    N = 1024
+    src = torch.empty(N, device=device)
+    dst = torch.empty(N, device=device)
+    dst_clone = dst.clone()
+
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
+
+    @triton.autotune(configs=configs, key=['N'], warmup=1, rep=1)
+    @triton.jit
+    def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + offsets, mask=offsets < N)
+        tl.store(dst + offsets, x, mask=offsets < N)
+
+    called = 0
+
+    def my_hook(kernel, *args, grid, warmup, **kwargs):
+        nonlocal called
+        called += 1
+        return True
+
+    _kernel.add_pre_run_hook(my_hook)
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
+    _kernel[grid](dst, src, N)
+
+    assert called == 1
+    assert torch.allclose(dst, torch.zeros_like(dst_clone))

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -562,7 +562,7 @@ class JITFunction(KernelInterface[T]):
     def add_pre_run_hook(self, hook):
         '''
         Add a hook that will be executed prior to the execution of run
-        function with args and kwargs passed into the kernel
+        function with (self, *args, **kwargs) passed into the kernel
         '''
         assert callable(hook)
         self.pre_run_hooks.append(hook)
@@ -591,7 +591,9 @@ class JITFunction(KernelInterface[T]):
 
         # Execute pre run hooks with args and kwargs
         for hook in self.pre_run_hooks:
-            hook(*args, **kwargs)
+            result = hook(self, *args, grid=grid, warmup=warmup, **kwargs)
+            if result:
+                return
 
         if self.binder is None:
             self.create_binder()


### PR DESCRIPTION
Follow-up to https://github.com/triton-lang/triton/pull/3314

The context is that the PyTorch team wants to be able to override the behavior of triton kernels under various contexts. @Chillee discussed this ask with triton folks previously and they seemed amenable to it.

Some examples include:
- PyTorch has FakeTensors, tensor subclasses that don't have storage. These can be sent through models, but today they error out when passed to a triton kernel.
- PyTorch has symbolic tracing (torch.fx). torch.fx replaces Tensors with Proxy objects that then get passed to a function that may contain a triton kernel. Today that errors out.

The PR makes the following changes:
- add `add_pre_run_hook` API to Autotuner
- if the pre-run-hook returns something that is not None, then we immediately bail out of the execution of the triton kernel.

Test Plan:
- added new tests

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`. (Sorry I couldn't figure out how to do this, are there instructions for how to install the pre-commit hooks?)

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
