### PR TITLE
[PROTON] Added avg_time metric

### DIFF
--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -110,8 +110,7 @@ def derive_metrics(gf, metrics, raw_metrics, device_info):
             metric_name = deriveable_metric.name
             metric_factor_dict = deriveable_metric.factor
             matched_metric_name = match_available_metrics([metric_name], raw_metrics)[0]
-            gf.dataframe[f"{metric} (inc)"] = (gf.dataframe[matched_metric_name] /
-                                               (get_time_seconds(gf.dataframe)) /
+            gf.dataframe[f"{metric} (inc)"] = (gf.dataframe[matched_metric_name] / (get_time_seconds(gf.dataframe)) /
                                                metric_factor_dict[metric])
             derived_metrics.append(f"{metric} (inc)")
         elif metric in time_factor_dict.factor:
@@ -122,8 +121,7 @@ def derive_metrics(gf, metrics, raw_metrics, device_info):
         elif metric in avg_time_factor_dict.factor:
             metric_time_unit = avg_time_factor_dict.name + "/" + metric.split("/")[1]
             gf.dataframe[f"{metric} (inc)"] = (get_time_seconds(gf.dataframe) / gf.dataframe['Count'] /
-                                               avg_time_factor_dict.factor[metric_time_unit]
-                                               ).replace([inf, -inf], nan)
+                                               avg_time_factor_dict.factor[metric_time_unit]).replace([inf, -inf], nan)
             derived_metrics.append(f"{metric} (inc)")
         else:
             original_metrics.append(metric)

--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -2,7 +2,7 @@ import argparse
 from collections import namedtuple
 import json
 import pandas as pd
-
+from numpy import inf, nan
 import hatchet as ht
 from triton.profiler.hook import COMPUTE_METADATA_SCOPE_NAME, TritonHook
 
@@ -93,12 +93,15 @@ def derive_metrics(gf, metrics, raw_metrics, device_info):
     original_metrics = []
     time_metric_name = match_available_metrics([time_factor_dict.name], raw_metrics)[0]
     time_unit = (time_factor_dict.name + "/" + time_metric_name.split("(")[1].split(")")[0])
+
+    def get_time_seconds(df):
+        return df[time_metric_name] * time_factor_dict.factor[time_unit]
+
     for metric in metrics:
         if metric == "util":  # Tensor core only
             min_time_bytes = get_min_time_bytes(gf.dataframe, device_info)
             min_time_flops = get_min_time_flops(gf.dataframe, device_info)
-            time_sec = gf.dataframe[time_metric_name] * (time_factor_dict.factor[time_unit] /
-                                                         time_factor_dict.factor["time/s"])
+            time_sec = get_time_seconds(gf.dataframe, time_metric_name, time_unit)
             gf.dataframe["util (inc)"] = min_time_flops["min_time"].combine(min_time_bytes["min_time"], max) / time_sec
             derived_metrics.append("util (inc)")
         elif metric in derivable_metrics:
@@ -107,19 +110,24 @@ def derive_metrics(gf, metrics, raw_metrics, device_info):
             metric_factor_dict = deriveable_metric.factor
             matched_metric_name = match_available_metrics([metric_name], raw_metrics)[0]
             gf.dataframe[f"{metric} (inc)"] = (gf.dataframe[matched_metric_name] /
-                                               (gf.dataframe[time_metric_name] * time_factor_dict.factor[time_unit]) /
+                                               (get_time_seconds(gf.dataframe)) /
                                                metric_factor_dict[metric])
             derived_metrics.append(f"{metric} (inc)")
-        elif metric in time_factor_dict.factor:
+        elif metric in time_factor_dict.factor or metric.split("/")[0] == "avgtime":
             metric_time_unit = time_factor_dict.name + "/" + metric.split("/")[1]
-            gf.dataframe[f"{metric} (inc)"] = gf.dataframe[time_metric_name] * (
-                time_factor_dict.factor[time_unit] / time_factor_dict.factor[metric_time_unit])
+            converted_time_df = (get_time_seconds(gf.dataframe) /
+                                                time_factor_dict.factor[metric_time_unit])
+            if metric.split("/")[0] == "avgtime":
+                gf.dataframe[f"{metric} (inc)"] = (converted_time_df/gf.dataframe['Count']).replace([inf, -inf], nan)
+            else:
+                gf.dataframe[f"{metric} (inc)"] = converted_time_df
             derived_metrics.append(f"{metric} (inc)")
         else:
             original_metrics.append(metric)
 
     if original_metrics:
         original_metrics = match_available_metrics(original_metrics, raw_metrics)
+    gf.dataframe.to_csv("./mytest.csv")
     return derived_metrics + original_metrics
 
 
@@ -178,6 +186,7 @@ def main():
         help="""List available metrics. Metric names are case insensitive and ignore units.
 Derived metrics can be created when source metrics are available.
 - time/s, time/ms, time/us, time/ns: time
+- avgtime/s, avgtime/ms, avgtime/us, avgtime/ns: time / kernel_exec_count
 - flop/s, gflop/s, tflop/s: flops / time
 - byte/s, gbyte/s, tbyte/s: bytes / time
 - util: max(sum(flops<width>) / peak_flops<width>_time, sum(bytes) / peak_bandwidth_time)

--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -130,7 +130,6 @@ def derive_metrics(gf, metrics, raw_metrics, device_info):
 
     if original_metrics:
         original_metrics = match_available_metrics(original_metrics, raw_metrics)
-    gf.dataframe.to_csv("./mytest.csv")
     return derived_metrics + original_metrics
 
 

--- a/third_party/proton/test/test_viewer.py
+++ b/third_party/proton/test/test_viewer.py
@@ -1,7 +1,8 @@
 import pytest
 import subprocess
-from triton.profiler.viewer import get_min_time_flops, get_min_time_bytes, get_raw_metrics, format_frames
+from triton.profiler.viewer import get_min_time_flops, get_min_time_bytes, get_raw_metrics, format_frames, derive_metrics
 import numpy as np
+import pandas as pd
 
 file_path = __file__
 cuda_example_file = file_path.replace("test_viewer.py", "example_cuda.json")
@@ -71,3 +72,21 @@ def test_min_time_bytes():
         np.testing.assert_allclose(ret[device0_idx].to_numpy(), [[6.10351e-06]], atol=1e-6)
         # MI300
         np.testing.assert_allclose(ret[device1_idx].to_numpy(), [[1.93378e-05]], atol=1e-6)
+
+
+def test_avg_time_derivation():
+    metrics = ["avg_time/s", "avg_time/ms", "avg_time/us", "avg_time/ns"]
+    with open(cuda_example_file, "r") as f:
+        expected_data = {
+            'avg_time/s (inc)': [np.nan, 0.000205, 0.000205],
+            'avg_time/ms (inc)': [np.nan, 0.2048, 0.2048],
+            'avg_time/us (inc)': [np.nan, 204.8, 204.8],
+            'avg_time/ns (inc)': [np.nan, 204800.0, 204800.0]
+        }
+        gf, raw_metrics, device_info = get_raw_metrics(f)
+        gf = format_frames(gf, format)
+        assert len(raw_metrics) > 0, "No metrics found in the input file"
+        gf.update_inclusive_columns()
+        d_metrics = derive_metrics(gf, metrics, raw_metrics, device_info)
+        for metric in d_metrics:
+            np.testing.assert_allclose(gf.dataframe[metric].to_numpy(), expected_data[metric], atol=1e-6)

--- a/third_party/proton/test/test_viewer.py
+++ b/third_party/proton/test/test_viewer.py
@@ -78,10 +78,8 @@ def test_avg_time_derivation():
     metrics = ["avg_time/s", "avg_time/ms", "avg_time/us", "avg_time/ns"]
     with open(cuda_example_file, "r") as f:
         expected_data = {
-            'avg_time/s (inc)': [np.nan, 0.000205, 0.000205],
-            'avg_time/ms (inc)': [np.nan, 0.2048, 0.2048],
-            'avg_time/us (inc)': [np.nan, 204.8, 204.8],
-            'avg_time/ns (inc)': [np.nan, 204800.0, 204800.0]
+            'avg_time/s (inc)': [np.nan, 0.000205, 0.000205], 'avg_time/ms (inc)': [np.nan, 0.2048, 0.2048],
+            'avg_time/us (inc)': [np.nan, 204.8, 204.8], 'avg_time/ns (inc)': [np.nan, 204800.0, 204800.0]
         }
         gf, raw_metrics, device_info = get_raw_metrics(f)
         gf = format_frames(gf, format)


### PR DESCRIPTION
Added a specific derived metric in the viewer for `avg_time`, which is the time divided by count. This is a more meaningful metric than just looking at the sum of the time spent on all kernel executions.

For inner nodes of the profiling tree, the metric is omitted as a `nan`. The reasoning is as follows:
`count(inner_node)  = sum(count(kernel_i_within_node))`, meaning that the count for the inner node isn't necessarily how many times the inner_node was executed, but the sum of all the kernels it contains. 
Therefore, the `avg` statistic is not as meaningful here.


---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
