### PR TITLE
[FRONTEND] Have do_bench_cudagraph create its own benchmarking stream

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -126,9 +126,7 @@ class Autotuner(KernelInterface):
 
         try:
             if self.use_cuda_graph:
-                import torch
-                with torch.cuda.stream(torch.cuda.Stream()):
-                    return do_bench_cudagraph(kernel_call, rep=self.num_reps, quantiles=(0.5, 0.2, 0.8))
+                return do_bench_cudagraph(kernel_call, rep=self.num_reps, quantiles=(0.5, 0.2, 0.8))
             return do_bench(kernel_call, warmup=self.num_warmups, rep=self.num_reps, quantiles=(0.5, 0.2, 0.8))
         except (OutOfResources, CompileTimeAssertionFailure):
             return [float("inf"), float("inf"), float("inf")]

--- a/third_party/proton/tutorials/matmul.py
+++ b/third_party/proton/tutorials/matmul.py
@@ -261,9 +261,6 @@ def benchmark(M, N, K, provider):
     a = torch.randn((M, K), device="cuda", dtype=torch.float16)
     b = torch.randn((K, N), device="cuda", dtype=torch.float16)
     quantiles = [0.5, 0.2, 0.8]
-    if args.cudagraph:
-        stream = torch.cuda.Stream()
-        torch.cuda.set_stream(stream)
     with proton.scope(f"matmul_{M}_{N}_{K}"):
         if provider == "cublas":
 


### PR DESCRIPTION
Per https://github.com/pytorch/pytorch/pull/9938, which fixes https://github.com/pytorch/pytorch/issues/9646, CUDA streams are now cheap to create under PyTorch. Let's have the benchmarking function create one per run instead of requiring its callers to do so.