### PR TITLE
[PROTON] Fixed flops viewer and refactored unit tests

### DIFF
--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -18,7 +18,7 @@ def match_available_metrics(metrics, raw_metrics):
                     ret.append(raw_metric + " (inc)")
                     break
     else:
-        ret = [raw_metrics[0]] + " (inc)"
+        ret = [raw_metrics[0] + " (inc)"]
     if len(ret) == 0:
         raise RuntimeError(f"Metric {metric} is not found. Use the --list flag to list available metrics")
     return ret
@@ -88,6 +88,8 @@ derivable_metrics = {
 }
 
 # FLOPS have a specific width to their metric
+default_flop_factor_dict = {f"flop/s": 1, f"gflop/s": 1e9, f"tflop/s": 1e12}
+derivable_metrics.update({key: FactorDict("flops", default_flop_factor_dict) for key in default_flop_factor_dict.keys()})
 for width in TritonHook.flops_width:
     factor_name = f"flops{width}"
     factor_dict = {f"flop{width}/s": 1, f"gflop{width}/s": 1e9, f"tflop{width}/s": 1e12}

--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -13,15 +13,14 @@ def match_available_metrics(metrics, raw_metrics):
         for metric in metrics:
             metric = metric.lower()
             for raw_metric in raw_metrics:
-                raw_metric_names = [
-                    raw_metric,
-                    raw_metric.split("(")[0].strip().lower(), 'flops' if 'flops' in raw_metric else ""
-                ]
-                if metric in raw_metric_names:
+                raw_metric_no_unit = raw_metric.split("(")[0].strip().lower()
+                if metric in (raw_metric, raw_metric_no_unit):
                     ret.append(raw_metric + " (inc)")
                     break
     else:
         ret = [raw_metrics[0]] + " (inc)"
+    if len(ret) == 0:
+        raise RuntimeError(f"Metric {metric} is not found. Use the --list flag to list available metrics")
     return ret
 
 
@@ -81,15 +80,18 @@ def get_min_time_bytes(df, device_info):
 FactorDict = namedtuple("FactorDict", ["name", "factor"])
 time_factor_dict = FactorDict("time", {"time/s": 1, "time/ms": 1e-3, "time/us": 1e-6, "time/ns": 1e-9})
 avg_time_factor_dict = FactorDict("avg_time", {f"avg_{key}": value for key, value in time_factor_dict.factor.items()})
-flops_factor_dict = FactorDict("flops", {"flop/s": 1, "gflop/s": 1e9, "tflop/s": 1e12})
 bytes_factor_dict = FactorDict("bytes", {"byte/s": 1, "gbyte/s": 1e9, "tbyte/s": 1e12})
 
 derivable_metrics = {
-    **{key: flops_factor_dict
-       for key in flops_factor_dict.factor.keys()},
     **{key: bytes_factor_dict
        for key in bytes_factor_dict.factor.keys()},
 }
+
+# FLOPS have a specific width to their metric
+for width in TritonHook.flops_width:
+    factor_name = f"flops{width}"
+    factor_dict = {f"flop{width}/s": 1, f"gflop{width}/s": 1e9, f"tflop{width}/s": 1e12}
+    derivable_metrics.update({key: FactorDict(factor_name, factor_dict) for key in factor_dict.keys()})
 
 
 def derive_metrics(gf, metrics, raw_metrics, device_info):
@@ -192,8 +194,8 @@ def main():
         help="""List available metrics. Metric names are case insensitive and ignore units.
 Derived metrics can be created when source metrics are available.
 - time/s, time/ms, time/us, time/ns: time
-- avg_time/s, avg_time/ms, avg_time/us, avg_time/ns: time / kernel_exec_count
-- flop/s, gflop/s, tflop/s: flops / time
+- avg_time/s, avg_time/ms, avg_time/us, avg_time/ns: time / count
+- flop<8/16/32/64>/s, gflop<8/16/32/64>/s, tflop<8/16/32/64>/s: flops / time
 - byte/s, gbyte/s, tbyte/s: bytes / time
 - util: max(sum(flops<width>) / peak_flops<width>_time, sum(bytes) / peak_bandwidth_time)
 """,

--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -13,8 +13,12 @@ def match_available_metrics(metrics, raw_metrics):
         for metric in metrics:
             metric = metric.lower()
             for raw_metric in raw_metrics:
-                raw_metric_no_unit = raw_metric.split("(")[0].strip().lower()
-                if metric in (raw_metric, raw_metric_no_unit):
+                raw_metric_names = [
+                    raw_metric,
+                    raw_metric.split("(")[0].strip().lower(),
+                    'flops' if 'flops' in raw_metric else ""
+                ]
+                if metric in raw_metric_names:
                     ret.append(raw_metric + " (inc)")
                     break
     else:

--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -15,8 +15,7 @@ def match_available_metrics(metrics, raw_metrics):
             for raw_metric in raw_metrics:
                 raw_metric_names = [
                     raw_metric,
-                    raw_metric.split("(")[0].strip().lower(),
-                    'flops' if 'flops' in raw_metric else ""
+                    raw_metric.split("(")[0].strip().lower(), 'flops' if 'flops' in raw_metric else ""
                 ]
                 if metric in raw_metric_names:
                     ret.append(raw_metric + " (inc)")

--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -89,7 +89,9 @@ derivable_metrics = {
 
 # FLOPS have a specific width to their metric
 default_flop_factor_dict = {f"flop/s": 1, f"gflop/s": 1e9, f"tflop/s": 1e12}
-derivable_metrics.update({key: FactorDict("flops", default_flop_factor_dict) for key in default_flop_factor_dict.keys()})
+derivable_metrics.update(
+    {key: FactorDict("flops", default_flop_factor_dict)
+     for key in default_flop_factor_dict.keys()})
 for width in TritonHook.flops_width:
     factor_name = f"flops{width}"
     factor_dict = {f"flop{width}/s": 1, f"gflop{width}/s": 1e9, f"tflop{width}/s": 1e12}

--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -199,7 +199,7 @@ def main():
 Derived metrics can be created when source metrics are available.
 - time/s, time/ms, time/us, time/ns: time
 - avg_time/s, avg_time/ms, avg_time/us, avg_time/ns: time / count
-- flop<8/16/32/64>/s, gflop<8/16/32/64>/s, tflop<8/16/32/64>/s: flops / time
+- flop[<8/16/32/64>]/s, gflop[<8/16/32/64>]/s, tflop[<8/16/32/64>]/s: flops / time
 - byte/s, gbyte/s, tbyte/s: bytes / time
 - util: max(sum(flops<width>) / peak_flops<width>_time, sum(bytes) / peak_bandwidth_time)
 """,
@@ -246,7 +246,7 @@ There are two modes:
     )
     argparser.add_argument(
         "-f", "--format", type=str, choices=["full", "file_function_line", "function_line", "file_function"],
-        default="full", help="""Formating the frame name.
+        default="full", help="""Formatting the frame name.
 - full: include the path, file name, function name and line number.
 - file_function_line: include the file name, function name and line number.
 - function_line: include the function name and line number.

--- a/third_party/proton/test/test_viewer.py
+++ b/third_party/proton/test/test_viewer.py
@@ -73,28 +73,72 @@ def test_min_time_bytes():
         np.testing.assert_allclose(ret[device1_idx].to_numpy(), [[1.93378e-05]], atol=1e-6)
 
 
-def test_avg_time_derivation():
-    metrics = ["avg_time/s", "avg_time/ms", "avg_time/us", "avg_time/ns"]
-    with open(cuda_example_file, "r") as f:
-        expected_data = {
-            'avg_time/s (inc)': [np.nan, 0.0000205, 0.000205], 'avg_time/ms (inc)': [np.nan, 0.02048, 0.2048],
-            'avg_time/us (inc)': [np.nan, 20.48, 204.8], 'avg_time/ns (inc)': [np.nan, 20480.0, 204800.0]
-        }
+def derivation_metrics_test(metrics, expected_data, sample_file, rtol=1e-7, atol=1e-6):
+    with open(sample_file, "r") as f:
         gf, raw_metrics, device_info = get_raw_metrics(f)
         assert len(raw_metrics) > 0, "No metrics found in the input file"
         gf.update_inclusive_columns()
         derived_metrics = derive_metrics(gf, metrics, raw_metrics, device_info)
         for derived_metric in derived_metrics:
             np.testing.assert_allclose(gf.dataframe[derived_metric].to_numpy(), expected_data[derived_metric],
-                                       atol=1e-6)
+                                       rtol=rtol, atol=atol)
+
+
+def test_avg_time_derivation():
+    derivation_metrics_test(
+        metrics=["avg_time/s", "avg_time/ms", "avg_time/us", "avg_time/ns"],
+        expected_data={
+            'avg_time/s (inc)': [np.nan, 0.0000205, 0.000205],
+            'avg_time/ms (inc)': [np.nan, 0.02048, 0.2048],
+            'avg_time/us (inc)': [np.nan, 20.48, 204.8],
+            'avg_time/ns (inc)': [np.nan, 20480.0, 204800.0]
+        },
+        sample_file=cuda_example_file
+    )
 
 
 def test_util():
-    metrics = ["util"]
-    with open(cuda_example_file, "r") as f:
-        gf, raw_metrics, device_info = get_raw_metrics(f)
-        assert len(raw_metrics) > 0, "No metrics found in the input file"
-        gf.update_inclusive_columns()
-        derived_metrics = derive_metrics(gf, metrics, raw_metrics, device_info)
-        np.testing.assert_allclose(gf.dataframe[derived_metrics].to_numpy(), [[np.nan], [0.247044], [0.147830]],
-                                   atol=1e-6)
+    derivation_metrics_test(
+        metrics=["util"],
+        expected_data={
+            'util (inc)': [np.nan, 0.247044, 0.147830],
+        },
+        sample_file=cuda_example_file
+    )
+
+
+def test_time_derivation():
+    derivation_metrics_test(
+        metrics=["time/s", "time/ms", "time/us", "time/ns"],
+        expected_data={
+            'time/s (inc)': [0.0004096, 0.0002048, 0.0002048],
+            'time/ms (inc)': [0.4096, 0.2048, 0.2048],
+            'time/us (inc)': [409.6, 204.8, 204.8],
+            'time/ns (inc)': [409600.0, 204800.0, 204800.0]
+        },
+        sample_file=cuda_example_file
+    )
+
+
+def test_bytes_derivation():
+    derivation_metrics_test(
+        metrics=["byte/s", "gbyte/s", "tbyte/s"],
+        expected_data={
+            'byte/s (inc)': [2.68554687e+11, 4.88281250e+11, 4.88281250e+10],
+            'gbyte/s (inc)': [268.5546875, 488.28125, 48.828125],
+            'tbyte/s (inc)': [0.26855469, 0.48828125, 0.04882812]
+        },
+        sample_file=cuda_example_file
+    )
+
+
+def test_flops_derivation():
+    derivation_metrics_test(
+        metrics=["flop/s", "gflop/s", "tflop/s"],
+        expected_data={
+            'flop/s (inc)': [2.68554687e+14, 4.88281250e+14, 4.88281250e+13],
+            'gflop/s (inc)': [268554.6875, 488281.25, 48828.125],
+            'tflop/s (inc)': [268.554687, 488.28125, 48.828125]
+        },
+        sample_file=cuda_example_file,
+    )

--- a/third_party/proton/test/test_viewer.py
+++ b/third_party/proton/test/test_viewer.py
@@ -86,59 +86,40 @@ def derivation_metrics_test(metrics, expected_data, sample_file, rtol=1e-7, atol
 
 def test_avg_time_derivation():
     derivation_metrics_test(
-        metrics=["avg_time/s", "avg_time/ms", "avg_time/us", "avg_time/ns"],
-        expected_data={
-            'avg_time/s (inc)': [np.nan, 0.0000205, 0.000205],
-            'avg_time/ms (inc)': [np.nan, 0.02048, 0.2048],
-            'avg_time/us (inc)': [np.nan, 20.48, 204.8],
-            'avg_time/ns (inc)': [np.nan, 20480.0, 204800.0]
-        },
-        sample_file=cuda_example_file
-    )
+        metrics=["avg_time/s", "avg_time/ms", "avg_time/us", "avg_time/ns"], expected_data={
+            'avg_time/s (inc)': [np.nan, 0.0000205, 0.000205], 'avg_time/ms (inc)': [np.nan, 0.02048, 0.2048],
+            'avg_time/us (inc)': [np.nan, 20.48, 204.8], 'avg_time/ns (inc)': [np.nan, 20480.0, 204800.0]
+        }, sample_file=cuda_example_file)
 
 
 def test_util():
-    derivation_metrics_test(
-        metrics=["util"],
-        expected_data={
-            'util (inc)': [np.nan, 0.247044, 0.147830],
-        },
-        sample_file=cuda_example_file
-    )
+    derivation_metrics_test(metrics=["util"], expected_data={
+        'util (inc)': [np.nan, 0.247044, 0.147830],
+    }, sample_file=cuda_example_file)
 
 
 def test_time_derivation():
     derivation_metrics_test(
-        metrics=["time/s", "time/ms", "time/us", "time/ns"],
-        expected_data={
-            'time/s (inc)': [0.0004096, 0.0002048, 0.0002048],
-            'time/ms (inc)': [0.4096, 0.2048, 0.2048],
-            'time/us (inc)': [409.6, 204.8, 204.8],
-            'time/ns (inc)': [409600.0, 204800.0, 204800.0]
-        },
-        sample_file=cuda_example_file
-    )
+        metrics=["time/s", "time/ms", "time/us", "time/ns"], expected_data={
+            'time/s (inc)': [0.0004096, 0.0002048, 0.0002048], 'time/ms (inc)': [0.4096, 0.2048, 0.2048],
+            'time/us (inc)': [409.6, 204.8, 204.8], 'time/ns (inc)': [409600.0, 204800.0, 204800.0]
+        }, sample_file=cuda_example_file)
 
 
 def test_bytes_derivation():
     derivation_metrics_test(
-        metrics=["byte/s", "gbyte/s", "tbyte/s"],
-        expected_data={
-            'byte/s (inc)': [2.68554687e+11, 4.88281250e+11, 4.88281250e+10],
-            'gbyte/s (inc)': [268.5546875, 488.28125, 48.828125],
-            'tbyte/s (inc)': [0.26855469, 0.48828125, 0.04882812]
-        },
-        sample_file=cuda_example_file
-    )
+        metrics=["byte/s", "gbyte/s", "tbyte/s"], expected_data={
+            'byte/s (inc)': [2.68554687e+11, 4.88281250e+11, 4.88281250e+10], 'gbyte/s (inc)':
+            [268.5546875, 488.28125, 48.828125], 'tbyte/s (inc)': [0.26855469, 0.48828125, 0.04882812]
+        }, sample_file=cuda_example_file)
 
 
 def test_flops_derivation():
     derivation_metrics_test(
         metrics=["flop/s", "gflop/s", "tflop/s"],
         expected_data={
-            'flop/s (inc)': [2.68554687e+14, 4.88281250e+14, 4.88281250e+13],
-            'gflop/s (inc)': [268554.6875, 488281.25, 48828.125],
-            'tflop/s (inc)': [268.554687, 488.28125, 48.828125]
+            'flop/s (inc)': [2.68554687e+14, 4.88281250e+14, 4.88281250e+13], 'gflop/s (inc)':
+            [268554.6875, 488281.25, 48828.125], 'tflop/s (inc)': [268.554687, 488.28125, 48.828125]
         },
         sample_file=cuda_example_file,
     )

--- a/third_party/proton/test/test_viewer.py
+++ b/third_party/proton/test/test_viewer.py
@@ -116,10 +116,10 @@ def test_bytes_derivation():
 
 def test_flops_derivation():
     derivation_metrics_test(
-        metrics=["flop/s", "gflop/s", "tflop/s"],
+        metrics=["flop8/s", "gflop8/s", "tflop8/s"],
         expected_data={
-            'flop/s (inc)': [2.68554687e+14, 4.88281250e+14, 4.88281250e+13], 'gflop/s (inc)':
-            [268554.6875, 488281.25, 48828.125], 'tflop/s (inc)': [268.554687, 488.28125, 48.828125]
+            'flop8/s (inc)': [2.68554687e+14, 4.88281250e+14, 4.88281250e+13], 'gflop8/s (inc)':
+            [268554.6875, 488281.25, 48828.125], 'tflop8/s (inc)': [268.554687, 488.28125, 48.828125]
         },
         sample_file=cuda_example_file,
     )


### PR DESCRIPTION
Fixed FLOPS viewer (which wasn't showing before since flops have a width)

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
