### PR TITLE
[WIP] Support small dots and optimization of dot operands

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -60,6 +60,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUOptimizeEpilogue();
   mlir::registerTritonAMDGPUOptimizeFMADot();
   mlir::registerTritonAMDGPUReorderInstructions();
+  mlir::registerTritonAMDGPUHoistReduction();
   mlir::registerTritonAMDGPUStreamPipeline();
   mlir::registerTritonAMDGPUStreamPipelineV2();
   mlir::registerTritonAMDGPUCanonicalizePointers();

--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -58,6 +58,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   // TritonAMDGPUTransforms passes
   mlir::registerTritonAMDGPUAccelerateMatmul();
   mlir::registerTritonAMDGPUOptimizeEpilogue();
+  mlir::registerTritonAMDGPUOptimizeFMADot();
   mlir::registerTritonAMDGPUReorderInstructions();
   mlir::registerTritonAMDGPUStreamPipeline();
   mlir::registerTritonAMDGPUStreamPipelineV2();

--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -203,6 +203,8 @@ bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy);
 
 bool atomicNeedsSharedMemory(Value result);
 
+bool isBlockedToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstT);
+
 bool isMfmaToDotShortcut(RankedTensorType srcTy, RankedTensorType dstTy);
 
 bool isMmaToDotShortcut(RankedTensorType srcTy, RankedTensorType dstTy);

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -1473,6 +1473,22 @@ inline bool isLayoutMmaV1(Attribute layout) {
   return isMmaV1;
 }
 
+inline SharedMemoryObject
+getExpandedSharedMemoryObject(ConversionPatternRewriter &rewriter, Location loc,
+                              SharedMemoryObject smemObj,
+                              ArrayRef<int64_t> shape) {
+  auto strides = smemObj.getStrides();
+  auto offsets = smemObj.getOffsets();
+  auto rank = strides.size();
+  if (rank == 3)
+    return smemObj;
+  strides.insert(strides.begin(), i32_val(shape[0] * shape[1]));
+  offsets.insert(offsets.begin(), i32_val(0));
+  auto expandedSmemObj = SharedMemoryObject(
+      smemObj.getBase(), smemObj.getBaseElemType(), strides, offsets);
+  return expandedSmemObj;
+}
+
 } // namespace mlir
 
 #endif

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -102,6 +102,8 @@ using namespace mlir::triton;
 #define undef(...) rewriter.create<LLVM::UndefOp>(loc, __VA_ARGS__)
 #define null(...) rewriter.create<LLVM::ZeroOp>(loc, __VA_ARGS__)
 #define call(...) rewriter.create<LLVM::CallOp>(loc, __VA_ARGS__)
+#define call_intrinsic(...)                                                    \
+  rewriter.create<LLVM::CallIntrinsicOp>(loc, __VA_ARGS__)
 
 // Types
 #define int_ty(width) rewriter.getIntegerType(width)

--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -131,6 +131,16 @@ void dumpHWLayout(RankedTensorType tensorType);
 // Return a string representation of the layout of the tensor.
 std::string getLayoutStr(RankedTensorType tensorType, bool useHWPointOfView);
 
+template <typename T>
+llvm::SmallVector<T> expandMatrixShapeWithBatch(llvm::ArrayRef<T> s) {
+  llvm::SmallVector<T> expanded(3 - s.size(), 1);
+  expanded.append(s.begin(), s.end());
+  return expanded;
+}
+
+llvm::SmallVector<unsigned>
+expandMatrixOrderWithBatch(llvm::ArrayRef<unsigned> o);
+
 } // namespace gpu
 } // namespace triton
 } // namespace mlir

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -193,6 +193,9 @@ bool isPureUnaryInlineAsm(Operation *op);
 // read the compute capability from the module attributes
 int getNVIDIAComputeCapability(Operation *module);
 
+// read the amd target from the module attributes
+StringRef getAMDArch(Operation *module);
+
 } // namespace mlir
 
 #endif // TRITON_DIALECT_TRITONGPU_TRANSFORMS_UTILITY_H_

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -537,6 +537,50 @@ bool supportMMA(Value value, int version) {
          (elemTy.isInteger(8) && version >= 2);
 }
 
+bool isBlockedToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstTy) {
+  auto blockedLayout = dyn_cast<BlockedEncodingAttr>(srcTy.getEncoding());
+  auto dotOperandLayout = dyn_cast<DotOperandEncodingAttr>(dstTy.getEncoding());
+  if (blockedLayout == nullptr || dotOperandLayout == nullptr)
+    return false;
+  auto parentLayout =
+      dyn_cast<BlockedEncodingAttr>(dotOperandLayout.getParent());
+  if (parentLayout == nullptr)
+    return false;
+  auto opShape = srcTy.getShape();
+  auto rank = opShape.size();
+
+  int kDim = dotOperandLayout.getOpIdx() == 0 ? rank - 1 : rank - 2;
+  int nonKDim = dotOperandLayout.getOpIdx() == 0 ? rank - 2 : rank - 1;
+  auto ctaLayout = blockedLayout.getCTALayout();
+
+  bool ctaLayoutCompatible =
+      ctaLayout.getCTASplitNum()[kDim] == 1 &&
+      blockedLayout.getCTALayout() == parentLayout.getCTALayout();
+  bool threadHoldsWholeKDim =
+      blockedLayout.getSizePerThread()[kDim] == opShape[kDim];
+  bool nonKDimCompatible =
+      blockedLayout.getOrder() == parentLayout.getOrder() &&
+      blockedLayout.getSizePerThread()[nonKDim] ==
+          parentLayout.getSizePerThread()[nonKDim] &&
+      blockedLayout.getThreadsPerWarp()[nonKDim] ==
+          parentLayout.getThreadsPerWarp()[nonKDim] &&
+      blockedLayout.getWarpsPerCTA()[nonKDim] ==
+          parentLayout.getWarpsPerCTA()[nonKDim];
+  bool matrixDimsCompatible =
+      ctaLayoutCompatible && threadHoldsWholeKDim && nonKDimCompatible;
+  if (rank == 2)
+    return matrixDimsCompatible;
+  // additional check for batch dimension
+  assert(rank == 3);
+  bool bDimCompatible =
+      blockedLayout.getSizePerThread()[0] ==
+          parentLayout.getSizePerThread()[0] &&
+      blockedLayout.getThreadsPerWarp()[0] ==
+          parentLayout.getThreadsPerWarp()[0] &&
+      blockedLayout.getWarpsPerCTA()[0] == parentLayout.getWarpsPerCTA()[0];
+  return matrixDimsCompatible && bDimCompatible;
+}
+
 bool isMfmaToDotShortcut(RankedTensorType srcTy, RankedTensorType dstTy) {
   auto mfmaLayout = dyn_cast<AMDMfmaEncodingAttr>(srcTy.getEncoding());
   auto dotOperandLayout = dyn_cast<DotOperandEncodingAttr>(dstTy.getEncoding());
@@ -625,12 +669,13 @@ bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
 }
 
 bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy) {
-  // TODO(jlebar): Remove these special cases (`isMmaToDotShortcut` and
-  // `isMfmaToDotShortcut`) once they're fully subsumed by the linear-layout
-  // checks.
+  // TODO(jlebar): Remove these special cases (`isMmaToDotShortcut`,
+  // `isBlockedToDotShortcut` and `isMfmaToDotShortcut`) once they're fully
+  // subsumed by the linear-layout checks.
   // TODO(Keren): We didn't check `cvtNeedsWarpShuffle` here because it's not
   // supported yet in Triton's backend.
   return !cvtReordersRegisters(srcTy, dstTy) &&
+         !isBlockedToDotShortcut(srcTy, dstTy) &&
          !isMmaToDotShortcut(srcTy, dstTy) &&
          !isMfmaToDotShortcut(srcTy, dstTy);
 }

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -236,6 +236,36 @@ private:
   const TargetInfoBase &targetInfo;
 };
 
+struct ConvertLayoutOpBlockedToDotOpShortcutConversion
+    : public ConvertOpToLLVMPattern<ConvertLayoutOp> {
+  const TargetInfoBase &targetInfo;
+  explicit ConvertLayoutOpBlockedToDotOpShortcutConversion(
+      LLVMTypeConverter &typeConverter, const TargetInfoBase &targetInfo,
+      PatternBenefit benefit = 1)
+      : ConvertOpToLLVMPattern(typeConverter, benefit), targetInfo(targetInfo) {
+  }
+
+  LogicalResult
+  matchAndRewrite(ConvertLayoutOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MLIRContext *ctx = op.getContext();
+
+    const auto &shape = op.getType().getShape();
+    auto srcTy = op.getSrc().getType();
+    auto dstTy = op.getType();
+    auto dstDotEncoding = dyn_cast<DotOperandEncodingAttr>(dstTy.getEncoding());
+    if (!dstDotEncoding)
+      return failure();
+    if (!dyn_cast<BlockedEncodingAttr>(srcTy.getEncoding()) ||
+        !dyn_cast<BlockedEncodingAttr>(dstDotEncoding.getParent()))
+      return failure();
+    if (cvtNeedsSharedMemory(srcTy, dstTy))
+      return failure();
+    rewriter.replaceOp(op, adaptor.getSrc());
+    return success();
+  }
+};
+
 struct ConvertLayoutOpUsingLinearLayoutsConversion
     : public ConvertOpToLLVMPattern<ConvertLayoutOp> {
   const TargetInfoBase &targetInfo;
@@ -651,5 +681,7 @@ void mlir::triton::populateConvertLayoutOpToLLVMPatterns(
   // one left.
   mlir::triton::populateConvertLayoutOpUsingLinearLayoutsToLLVMPattern(
       typeConverter, targetInfo, patterns, benefit.getBenefit() + 1);
+  patterns.add<ConvertLayoutOpBlockedToDotOpShortcutConversion>(
+      typeConverter, targetInfo, benefit);
   patterns.add<ConvertLayoutOpConversion>(typeConverter, targetInfo, benefit);
 }

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
@@ -1,5 +1,6 @@
 #include "mlir/Support/LLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 using ValueTable = std::map<std::pair<int, int>, Value>;
 using ::mlir::LLVM::delinearize;
@@ -7,6 +8,8 @@ using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
 using ::mlir::LLVM::getStridesFromShapeAndOrder;
 using ::mlir::LLVM::linearize;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;
+using ::mlir::triton::gpu::expandMatrixOrderWithBatch;
+using ::mlir::triton::gpu::expandMatrixShapeWithBatch;
 using ::mlir::triton::gpu::getContigPerThread;
 using ::mlir::triton::gpu::getOrder;
 using ::mlir::triton::gpu::getShapePerCTA;
@@ -14,47 +17,6 @@ using ::mlir::triton::gpu::getSizePerThread;
 using ::mlir::triton::gpu::getTotalElemsPerThread;
 using ::mlir::triton::gpu::isaDistributedLayout;
 using ::mlir::triton::gpu::SharedEncodingAttr;
-
-SmallVector<Value>
-getThreadIds(Value threadId, ArrayRef<unsigned int> shapePerCTATile,
-             ArrayRef<unsigned int> sizePerThread, ArrayRef<unsigned int> order,
-             ConversionPatternRewriter &rewriter, Location loc) {
-  int dim = order.size();
-  SmallVector<Value> threadIds(dim);
-  for (unsigned k = 0; k < dim - 1; k++) {
-    Value dimK = i32_val(shapePerCTATile[order[k]] / sizePerThread[order[k]]);
-    Value rem = urem(threadId, dimK);
-    threadId = udiv(threadId, dimK);
-    threadIds[order[k]] = rem;
-  }
-  Value dimK = i32_val(shapePerCTATile[order[dim - 1]]);
-  threadIds[order[dim - 1]] = urem(threadId, dimK);
-  return threadIds;
-}
-
-// Get shapePerCTATile for M or N axis.
-int getShapePerCTATileForMN(BlockedEncodingAttr layout, bool isM) {
-  auto order = layout.getOrder();
-  auto shapePerCTATile = getShapePerCTATile(layout);
-
-  int mShapePerCTATile =
-      order[0] == 1 ? shapePerCTATile[order[1]] : shapePerCTATile[order[0]];
-  int nShapePerCTATile =
-      order[0] == 0 ? shapePerCTATile[order[1]] : shapePerCTATile[order[0]];
-  return isM ? mShapePerCTATile : nShapePerCTATile;
-}
-
-// Get sizePerThread for M or N axis.
-int getSizePerThreadForMN(BlockedEncodingAttr layout, bool isM) {
-  auto order = layout.getOrder();
-  auto sizePerThread = getSizePerThread(layout);
-
-  int mSizePerThread =
-      order[0] == 1 ? sizePerThread[order[1]] : sizePerThread[order[0]];
-  int nSizePerThread =
-      order[0] == 0 ? sizePerThread[order[1]] : sizePerThread[order[0]];
-  return isM ? mSizePerThread : nSizePerThread;
-}
 
 Value getStructFromValueTable(ArrayRef<Value> vals,
                               ConversionPatternRewriter &rewriter, Location loc,
@@ -71,154 +33,154 @@ Value getStructFromValueTable(ArrayRef<Value> vals,
   return packLLElements(loc, typeConverter, elems, rewriter, structTy);
 }
 
-ValueTable getValueTableFromStruct(Value val, int K, int n0, int shapePerCTA,
-                                   int sizePerThread,
-                                   ConversionPatternRewriter &rewriter,
-                                   Location loc,
-                                   const LLVMTypeConverter *typeConverter,
-                                   Type type) {
-  ValueTable res;
-  auto elems = unpackLLElements(loc, val, rewriter);
-  int index = 0;
-  for (unsigned k = 0; k < K; ++k) {
-    for (unsigned m = 0; m < n0; m += shapePerCTA)
-      for (unsigned mm = 0; mm < sizePerThread; ++mm) {
-        res[{m + mm, k}] = elems[index++];
-      }
-  }
-  return res;
+SmallVector<Value> swizzleIndices(ConversionPatternRewriter &rewriter,
+                                  Location loc, SmallVector<Value> rawIndices,
+                                  SharedEncodingAttr layout) {
+  const auto &order = layout.getOrder();
+  auto rank = order.size();
+
+  if (layout.getMaxPhase() == 1)
+    return rawIndices;
+
+  auto vec = i32_val(layout.getVec());
+  auto perPhase = i32_val(layout.getPerPhase());
+  auto maxPhase = i32_val(layout.getMaxPhase());
+
+  auto fastIdx = rawIndices[order[0]];
+  auto secondIdx = rawIndices[order[1]];
+  // Original algorithm taken from getSwizzledSharedPtrs function
+  // (TritonGPUToLLVMBase.h)
+  //
+  // phase = (secondIdx // perPhase) % maxPhase
+  // swizzledGroup = ((fastIdx // vec) ^ phase) * vec
+  // groupRemainder = fastIdx % vec
+  // colOff = swizzledGroup + groupRemainder
+  auto phase = urem(udiv(secondIdx, perPhase), maxPhase);
+  auto swizzledGroup = mul(xor_(udiv(fastIdx, vec), phase), vec);
+  auto groupRemainder = urem(fastIdx, vec);
+  auto colOff = add(swizzledGroup, groupRemainder);
+
+  SmallVector<Value> swizzledIndices = rawIndices;
+  swizzledIndices[order[0]] = colOff;
+
+  return swizzledIndices;
 }
 
-Value loadAFMA(Value A, Value llA, BlockedEncodingAttr dLayout, Value thread,
-               Location loc, const LLVMTypeConverter *typeConverter,
-               ConversionPatternRewriter &rewriter) {
-  auto aTensorTy = cast<MemDescType>(A.getType());
-  auto aLayout = cast<SharedEncodingAttr>(aTensorTy.getEncoding());
-  auto aShapePerCTA = getShapePerCTA(aTensorTy);
+Value loadFMAOp(Value dotOp, Value llA, BlockedEncodingAttr dLayout,
+                Value thread, Location loc,
+                const LLVMTypeConverter *typeConverter,
+                ConversionPatternRewriter &rewriter, const int dotOpNo) {
+  auto ctx = dotOp.getContext();
+  const int bDim = 0;
+  const int kDim = dotOpNo == 0 ? 2 : 1;
+  const int nonKDim = dotOpNo == 0 ? 1 : 2;
+  auto opTensorTy = cast<MemDescType>(dotOp.getType());
+  auto opLayout = cast<SharedEncodingAttr>(opTensorTy.getEncoding());
+  auto opShapePerCTA =
+      expandMatrixShapeWithBatch(ArrayRef(getShapePerCTA(opTensorTy)));
 
-  auto aOrder = aLayout.getOrder();
-  auto order = dLayout.getOrder();
+  auto order = expandMatrixOrderWithBatch(dLayout.getOrder());
 
-  bool isARow = aOrder[0] == 1;
-
-  auto aSmem = getSharedMemoryObjectFromStruct(
-      loc, llA, typeConverter->convertType(aTensorTy.getElementType()),
+  auto origSmem = getSharedMemoryObjectFromStruct(
+      loc, llA, typeConverter->convertType(opTensorTy.getElementType()),
       rewriter);
-  Value strideAM = aSmem.strides[0];
-  Value strideAK = aSmem.strides[1];
-  Value strideA0 = isARow ? strideAK : strideAM;
-  Value strideA1 = isARow ? strideAM : strideAK;
-  int aNumPtr = 8;
-  int K = aShapePerCTA[1];
-  int M = aShapePerCTA[0];
+  auto smem = getExpandedSharedMemoryObject(rewriter, loc, origSmem,
+                                            opTensorTy.getShape());
+  auto strides = smem.strides;
+  int B = opShapePerCTA[bDim];
+  int K = opShapePerCTA[kDim];
+  int NonK = opShapePerCTA[nonKDim];
 
-  auto shapePerCTATile = getShapePerCTATile(dLayout);
-  auto sizePerThread = getSizePerThread(dLayout);
-
-  Value _0 = i32_val(0);
-
-  Value mContig = i32_val(sizePerThread[order[1]]);
+  auto shapePerCTATile =
+      expandMatrixShapeWithBatch(ArrayRef(getShapePerCTATile(dLayout)));
+  auto sizePerThread =
+      expandMatrixShapeWithBatch(ArrayRef(getSizePerThread(dLayout)));
+  auto threadsPerWarp =
+      expandMatrixShapeWithBatch(ArrayRef(dLayout.getThreadsPerWarp()));
+  auto warpsPerCTA =
+      expandMatrixShapeWithBatch(ArrayRef(dLayout.getWarpsPerCTA()));
 
   // threadId in blocked layout
-  auto threadIds = getThreadIds(thread, shapePerCTATile, sizePerThread, order,
-                                rewriter, loc);
-  Value threadIdM = threadIds[0];
+  auto warpSize = i32_val(triton::gpu::getWarpSize(dLayout));
+  auto laneId = urem(thread, warpSize);
+  auto warpId = udiv(thread, warpSize);
+  auto laneIds =
+      mlir::LLVM::delinearize(rewriter, loc, laneId, threadsPerWarp, order);
+  auto warpIds =
+      mlir::LLVM::delinearize(rewriter, loc, warpId, warpsPerCTA, order);
+  auto sizePerWarpB = sizePerThread[bDim] * threadsPerWarp[bDim];
+  auto sizePerWarpNonK = sizePerThread[nonKDim] * threadsPerWarp[nonKDim];
 
-  Value offA0 = isARow ? _0 : mul(threadIdM, mContig);
-  Value offA1 = isARow ? mul(threadIdM, mContig) : _0;
-  SmallVector<Value> aOff(aNumPtr);
-  for (int i = 0; i < aNumPtr; ++i) {
-    aOff[i] = add(mul(offA0, strideA0), mul(offA1, strideA1));
-  }
-  auto elemTy = typeConverter->convertType(aTensorTy.getElementType());
+  Value bTileOffset = mul(laneIds[bDim], i32_val(sizePerThread[bDim]));
+  bTileOffset = add(bTileOffset, mul(warpIds[bDim], i32_val(sizePerWarpB)));
+  Value nonKTileOffset = mul(laneIds[nonKDim], i32_val(sizePerThread[nonKDim]));
+  nonKTileOffset =
+      add(nonKTileOffset, mul(warpIds[nonKDim], i32_val(sizePerWarpNonK)));
 
-  Type ptrTy = ptr_ty(rewriter.getContext(), 3);
-  SmallVector<Value> aPtrs(aNumPtr);
-  for (int i = 0; i < aNumPtr; ++i)
-    aPtrs[i] = gep(ptrTy, elemTy, aSmem.base, aOff[i]);
+  auto elemTy = typeConverter->convertType(opTensorTy.getElementType());
+  Type ptrTy = ptr_ty(ctx, 3);
 
-  SmallVector<Value> vas;
+  unsigned vectorSize = order[0] == kDim ? K : sizePerThread[order[0]];
+  if (opLayout.getMaxPhase() > 1)
+    vectorSize = std::min(vectorSize, opLayout.getVec());
+  // limit vector size with maximum width of load available on hardware
+  // TODO: get maximum vector size from target hardware info
+  vectorSize = std::min(16u, vectorSize);
+  auto vecTy = vec_ty(elemTy, vectorSize);
 
-  int mShapePerCTATile = getShapePerCTATileForMN(dLayout, true /*isM*/);
-  int mSizePerThread = getSizePerThreadForMN(dLayout, true /*isM*/);
+  unsigned dimStep[3] = {1, 1, 1};
+  dimStep[order[0]] = vectorSize;
 
-  for (unsigned k = 0; k < K; ++k)
-    for (unsigned m = 0; m < M; m += mShapePerCTATile)
-      for (unsigned mm = 0; mm < mSizePerThread; ++mm) {
-        Value offset =
-            add(mul(i32_val(m + mm), strideAM), mul(i32_val(k), strideAK));
-        Value pa = gep(ptrTy, elemTy, aPtrs[0], offset);
-        Value va = load(elemTy, pa);
-        vas.emplace_back(va);
-      }
+  int shapePerCTABTile = shapePerCTATile[bDim];
+  int shapePerCTANonKTile = shapePerCTATile[nonKDim];
+  int sizeBPerThread = sizePerThread[bDim];
+  int sizeNonKPerThread = sizePerThread[nonKDim];
+  int numBTiles = std::max(1, B / shapePerCTABTile);
+  int numNonKTiles = std::max(1, NonK / shapePerCTANonKTile);
 
-  return getStructFromValueTable(vas, rewriter, loc, typeConverter, elemTy);
-}
+  SmallVector<Value> opValues(numBTiles * sizeBPerThread * K * numNonKTiles *
+                              sizeNonKPerThread);
 
-Value loadBFMA(Value B, Value llB, BlockedEncodingAttr dLayout, Value thread,
-               Location loc, const LLVMTypeConverter *typeConverter,
-               ConversionPatternRewriter &rewriter) {
-  auto bTensorTy = cast<MemDescType>(B.getType());
-  auto bLayout = cast<SharedEncodingAttr>(bTensorTy.getEncoding());
-  auto bShapePerCTA = getShapePerCTA(bTensorTy);
+  for (unsigned bTile = 0; bTile < numBTiles; ++bTile)
+    for (unsigned b = 0; b < sizeBPerThread; b += dimStep[bDim])
+      for (unsigned k = 0; k < K; k += dimStep[kDim])
+        for (unsigned nonKTile = 0; nonKTile < numNonKTiles; ++nonKTile)
+          for (unsigned nonK = 0; nonK < sizeNonKPerThread;
+               nonK += dimStep[nonKDim]) {
+            SmallVector<Value> rawIndices(3);
+            rawIndices[bDim] =
+                add(bTileOffset, i32_val(bTile * shapePerCTABTile + b));
+            rawIndices[nonKDim] = add(
+                nonKTileOffset, i32_val(nonKTile * shapePerCTANonKTile + nonK));
+            rawIndices[kDim] = i32_val(k);
 
-  auto bOrder = bLayout.getOrder();
-  auto order = dLayout.getOrder();
+            SmallVector<Value> swizzledIndices =
+                swizzleIndices(rewriter, loc, rawIndices, opLayout);
 
-  bool isBRow = bOrder[0] == 1;
+            Value offset = i32_val(0);
+            for (int dim = 0; dim < order.size(); ++dim)
+              offset = add(offset, mul(urem(swizzledIndices[dim],
+                                            i32_val(opShapePerCTA[dim])),
+                                       strides[dim]));
 
-  auto bSmem = getSharedMemoryObjectFromStruct(
-      loc, llB, typeConverter->convertType(bTensorTy.getElementType()),
-      rewriter);
-  Value strideBN = bSmem.strides[1];
-  Value strideBK = bSmem.strides[0];
-  Value strideB0 = isBRow ? strideBN : strideBK;
-  Value strideB1 = isBRow ? strideBK : strideBN;
-  int bNumPtr = 8;
-  int K = bShapePerCTA[0];
-  int N = bShapePerCTA[1];
+            Value elemAddr = gep(ptrTy, elemTy, smem.base, offset);
+            Value vecAddr = bitcast(elemAddr, ptr_ty(ctx, 3));
+            Value vec = load(vecTy, elemAddr);
+            for (int elem = 0; elem < vectorSize; ++elem) {
+              int outIdx[3] = {};
+              outIdx[bDim] = bTile * sizeBPerThread + b;
+              outIdx[kDim] = k;
+              outIdx[nonKDim] = nonKTile * sizeNonKPerThread + nonK;
+              outIdx[order[0]] += elem;
+              int idx = (outIdx[bDim] * K + outIdx[kDim]) * numNonKTiles *
+                            sizeNonKPerThread +
+                        outIdx[nonKDim];
+              opValues[idx] = extract_element(elemTy, vec, i32_val(elem));
+            }
+          }
 
-  auto shapePerCTATile = getShapePerCTATile(dLayout);
-  auto sizePerThread = getSizePerThread(dLayout);
-
-  Value _0 = i32_val(0);
-
-  Value nContig = i32_val(sizePerThread[order[0]]);
-
-  // threadId in blocked layout
-  auto threadIds = getThreadIds(thread, shapePerCTATile, sizePerThread, order,
-                                rewriter, loc);
-  Value threadIdN = threadIds[1];
-
-  Value offB0 = isBRow ? mul(threadIdN, nContig) : _0;
-  Value offB1 = isBRow ? _0 : mul(threadIdN, nContig);
-  SmallVector<Value> bOff(bNumPtr);
-  for (int i = 0; i < bNumPtr; ++i) {
-    bOff[i] = add(mul(offB0, strideB0), mul(offB1, strideB1));
-  }
-  auto elemTy = typeConverter->convertType(bTensorTy.getElementType());
-
-  Type ptrTy = ptr_ty(rewriter.getContext(), 3);
-  SmallVector<Value> bPtrs(bNumPtr);
-  for (int i = 0; i < bNumPtr; ++i)
-    bPtrs[i] = gep(ptrTy, elemTy, bSmem.base, bOff[i]);
-
-  SmallVector<Value> vbs;
-
-  int nShapePerCTATile = getShapePerCTATileForMN(dLayout, false /*isM*/);
-  int nSizePerThread = getSizePerThreadForMN(dLayout, false /*isM*/);
-
-  for (unsigned k = 0; k < K; ++k)
-    for (unsigned n = 0; n < N; n += nShapePerCTATile)
-      for (unsigned nn = 0; nn < nSizePerThread; ++nn) {
-        Value offset =
-            add(mul(i32_val(n + nn), strideBN), mul(i32_val(k), strideBK));
-        Value pb = gep(ptrTy, elemTy, bPtrs[0], offset);
-        Value vb = load(elemTy, pb);
-        vbs.emplace_back(vb);
-      }
-
-  return getStructFromValueTable(vbs, rewriter, loc, typeConverter, elemTy);
+  return getStructFromValueTable(opValues, rewriter, loc, typeConverter,
+                                 elemTy);
 }
 
 namespace SharedToDotOperandFMA {
@@ -226,9 +188,7 @@ Value convertLayout(int opIdx, Value val, Value llVal,
                     BlockedEncodingAttr dLayout, Value thread, Location loc,
                     const LLVMTypeConverter *typeConverter,
                     ConversionPatternRewriter &rewriter) {
-  if (opIdx == 0)
-    return loadAFMA(val, llVal, dLayout, thread, loc, typeConverter, rewriter);
-  else
-    return loadBFMA(val, llVal, dLayout, thread, loc, typeConverter, rewriter);
+  return loadFMAOp(val, llVal, dLayout, thread, loc, typeConverter, rewriter,
+                   opIdx);
 }
 } // namespace SharedToDotOperandFMA

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
@@ -33,13 +33,15 @@ Value getStructFromValueTable(ArrayRef<Value> vals,
   return packLLElements(loc, typeConverter, elems, rewriter, structTy);
 }
 
+bool isSwizzled(SharedEncodingAttr layout) { return layout.getMaxPhase() != 1; }
+
 SmallVector<Value> swizzleIndices(ConversionPatternRewriter &rewriter,
                                   Location loc, SmallVector<Value> rawIndices,
                                   SharedEncodingAttr layout) {
   const auto &order = layout.getOrder();
   auto rank = order.size();
 
-  if (layout.getMaxPhase() == 1)
+  if (!isSwizzled(layout))
     return rawIndices;
 
   auto vec = i32_val(layout.getVec());
@@ -66,16 +68,52 @@ SmallVector<Value> swizzleIndices(ConversionPatternRewriter &rewriter,
   return swizzledIndices;
 }
 
+/**
+ * @brief put elements from Value vec to appropriate indexes in opValues array
+ *
+ * This function maps elements of 3d sub-tensor in linear array.
+ * Axes are arranged in following order from fastest to slowest: [nonKdim, kDim,
+ * bDim]
+ */
+void storeValuesInLinearVector(PatternRewriter &rewriter, Location loc,
+                               SmallVector<Value> &opValues, Value vec,
+                               unsigned kElems, unsigned nonKElems,
+                               unsigned kIdx, unsigned nonKIdx, unsigned bIdx,
+                               int kDim, int nonKDim, int bDim, int fastDim) {
+  auto vecTy = cast<VectorType>(vec.getType());
+  auto vectorSize = vecTy.getNumElements();
+  auto elemTy = vecTy.getElementType();
+  for (int elem = 0; elem < vectorSize; ++elem) {
+    unsigned outIdx[3] = {};
+    outIdx[bDim] = bIdx;
+    outIdx[kDim] = kIdx;
+    outIdx[nonKDim] = nonKIdx;
+
+    outIdx[fastDim] += elem;
+    auto idx = outIdx[bDim] * kElems * nonKElems + outIdx[kDim] * nonKElems +
+               outIdx[nonKDim];
+    opValues[idx] = extract_element(elemTy, vec, i32_val(elem));
+  }
+}
+
 Value loadFMAOp(Value dotOp, Value llA, BlockedEncodingAttr dLayout,
                 Value thread, Location loc,
                 const LLVMTypeConverter *typeConverter,
                 ConversionPatternRewriter &rewriter, const int dotOpNo) {
+  auto ctaSplit = dLayout.getCTALayout().getCTASplitNum();
+  for (auto split : ctaSplit) {
+    if (split != 1)
+      llvm::report_fatal_error("tensors splited in CGA(thread group clusters) "
+                               "are not supported in FMA dot yet.");
+  }
+
   auto ctx = dotOp.getContext();
   const int bDim = 0;
   const int kDim = dotOpNo == 0 ? 2 : 1;
   const int nonKDim = dotOpNo == 0 ? 1 : 2;
   auto opTensorTy = cast<MemDescType>(dotOp.getType());
-  auto opLayout = cast<SharedEncodingAttr>(opTensorTy.getEncoding());
+  auto opTensorShape = expandMatrixShapeWithBatch(opTensorTy.getShape());
+  auto sharedLayout = cast<SharedEncodingAttr>(opTensorTy.getEncoding());
   auto opShapePerCTA =
       expandMatrixShapeWithBatch(ArrayRef(getShapePerCTA(opTensorTy)));
 
@@ -87,9 +125,9 @@ Value loadFMAOp(Value dotOp, Value llA, BlockedEncodingAttr dLayout,
   auto smem = getExpandedSharedMemoryObject(rewriter, loc, origSmem,
                                             opTensorTy.getShape());
   auto strides = smem.strides;
-  int B = opShapePerCTA[bDim];
-  int K = opShapePerCTA[kDim];
-  int NonK = opShapePerCTA[nonKDim];
+  int B = opTensorShape[bDim];
+  int K = opTensorShape[kDim];
+  int NonK = opTensorShape[nonKDim];
 
   auto shapePerCTATile =
       expandMatrixShapeWithBatch(ArrayRef(getShapePerCTATile(dLayout)));
@@ -100,7 +138,6 @@ Value loadFMAOp(Value dotOp, Value llA, BlockedEncodingAttr dLayout,
   auto warpsPerCTA =
       expandMatrixShapeWithBatch(ArrayRef(dLayout.getWarpsPerCTA()));
 
-  // threadId in blocked layout
   auto warpSize = i32_val(triton::gpu::getWarpSize(dLayout));
   auto laneId = urem(thread, warpSize);
   auto warpId = udiv(thread, warpSize);
@@ -120,64 +157,94 @@ Value loadFMAOp(Value dotOp, Value llA, BlockedEncodingAttr dLayout,
   auto elemTy = typeConverter->convertType(opTensorTy.getElementType());
   Type ptrTy = ptr_ty(ctx, 3);
 
-  unsigned vectorSize = order[0] == kDim ? K : sizePerThread[order[0]];
-  if (opLayout.getMaxPhase() > 1)
-    vectorSize = std::min(vectorSize, opLayout.getVec());
-  // limit vector size with maximum width of load available on hardware
-  // TODO: get maximum vector size from target hardware info
-  vectorSize = std::min(16u, vectorSize);
+  auto sharedOrder = expandMatrixOrderWithBatch(sharedLayout.getOrder());
+  unsigned vectorSize =
+      sharedOrder[0] == kDim ? K : sizePerThread[sharedOrder[0]];
+  if (sharedLayout.getMaxPhase() > 1)
+    vectorSize = std::min(vectorSize, sharedLayout.getVec());
   auto vecTy = vec_ty(elemTy, vectorSize);
 
   unsigned dimStep[3] = {1, 1, 1};
-  dimStep[order[0]] = vectorSize;
+  dimStep[sharedOrder[0]] = vectorSize;
 
-  int shapePerCTABTile = shapePerCTATile[bDim];
-  int shapePerCTANonKTile = shapePerCTATile[nonKDim];
-  int sizeBPerThread = sizePerThread[bDim];
-  int sizeNonKPerThread = sizePerThread[nonKDim];
-  int numBTiles = std::max(1, B / shapePerCTABTile);
-  int numNonKTiles = std::max(1, NonK / shapePerCTANonKTile);
+  auto shapePerCTABTile = shapePerCTATile[bDim];
+  auto shapePerCTANonKTile = shapePerCTATile[nonKDim];
+  auto sizeBPerThread = sizePerThread[bDim];
+  auto sizeNonKPerThread = sizePerThread[nonKDim];
+  auto numBTiles = std::max(1u, B / shapePerCTABTile);
+  auto numNonKTiles = std::max(1u, NonK / shapePerCTANonKTile);
 
   SmallVector<Value> opValues(numBTiles * sizeBPerThread * K * numNonKTiles *
                               sizeNonKPerThread);
+  if (isSwizzled(sharedLayout)) {
+    for (unsigned bTile = 0; bTile < numBTiles; ++bTile)
+      for (unsigned b = 0; b < sizeBPerThread; b += dimStep[bDim])
+        for (unsigned k = 0; k < K; k += dimStep[kDim])
+          for (unsigned nonKTile = 0; nonKTile < numNonKTiles; ++nonKTile)
+            for (unsigned nonK = 0; nonK < sizeNonKPerThread;
+                 nonK += dimStep[nonKDim]) {
+              SmallVector<Value> rawIndices(3);
+              rawIndices[bDim] =
+                  add(bTileOffset, i32_val(bTile * shapePerCTABTile + b));
+              rawIndices[nonKDim] =
+                  add(nonKTileOffset,
+                      i32_val(nonKTile * shapePerCTANonKTile + nonK));
+              rawIndices[kDim] = i32_val(k);
 
-  for (unsigned bTile = 0; bTile < numBTiles; ++bTile)
-    for (unsigned b = 0; b < sizeBPerThread; b += dimStep[bDim])
-      for (unsigned k = 0; k < K; k += dimStep[kDim])
-        for (unsigned nonKTile = 0; nonKTile < numNonKTiles; ++nonKTile)
-          for (unsigned nonK = 0; nonK < sizeNonKPerThread;
-               nonK += dimStep[nonKDim]) {
-            SmallVector<Value> rawIndices(3);
-            rawIndices[bDim] =
-                add(bTileOffset, i32_val(bTile * shapePerCTABTile + b));
-            rawIndices[nonKDim] = add(
-                nonKTileOffset, i32_val(nonKTile * shapePerCTANonKTile + nonK));
-            rawIndices[kDim] = i32_val(k);
+              SmallVector<Value> swizzledIndices =
+                  swizzleIndices(rewriter, loc, rawIndices, sharedLayout);
 
-            SmallVector<Value> swizzledIndices =
-                swizzleIndices(rewriter, loc, rawIndices, opLayout);
+              Value offset = i32_val(0);
+              for (int dim = 0; dim < order.size(); ++dim) {
+                auto wrappedDimIndex =
+                    urem(swizzledIndices[dim], i32_val(opTensorShape[dim]));
+                auto dimOffset = mul(wrappedDimIndex, strides[dim]);
+                offset = add(offset, dimOffset);
+              }
 
-            Value offset = i32_val(0);
-            for (int dim = 0; dim < order.size(); ++dim)
-              offset = add(offset, mul(urem(swizzledIndices[dim],
-                                            i32_val(opShapePerCTA[dim])),
-                                       strides[dim]));
-
-            Value elemAddr = gep(ptrTy, elemTy, smem.base, offset);
-            Value vecAddr = bitcast(elemAddr, ptr_ty(ctx, 3));
-            Value vec = load(vecTy, elemAddr);
-            for (int elem = 0; elem < vectorSize; ++elem) {
-              int outIdx[3] = {};
-              outIdx[bDim] = bTile * sizeBPerThread + b;
-              outIdx[kDim] = k;
-              outIdx[nonKDim] = nonKTile * sizeNonKPerThread + nonK;
-              outIdx[order[0]] += elem;
-              int idx = (outIdx[bDim] * K + outIdx[kDim]) * numNonKTiles *
-                            sizeNonKPerThread +
-                        outIdx[nonKDim];
-              opValues[idx] = extract_element(elemTy, vec, i32_val(elem));
+              Value elemAddr = gep(ptrTy, elemTy, smem.base, offset);
+              Value vec = load(vecTy, elemAddr);
+              storeValuesInLinearVector(
+                  rewriter, loc, opValues, vec, /*kElems*/ K,
+                  /*nonKElems*/ numNonKTiles * sizeNonKPerThread, /*kIdx*/ k,
+                  /*nonKIdx*/ nonKTile * sizeNonKPerThread + nonK,
+                  /*bIdx*/ bTile * sizeBPerThread + b, kDim, nonKDim, bDim,
+                  sharedOrder[0]);
             }
-          }
+  } else {
+    auto bOffset = mul(urem(bTileOffset, i32_val(B)), strides[bDim]);
+    auto nonKOffset =
+        mul(urem(nonKTileOffset, i32_val(NonK)), strides[nonKDim]);
+    Value threadDependantOffset = add(bOffset, nonKOffset);
+
+    auto basePtr = gep(ptrTy, elemTy, smem.base, threadDependantOffset);
+
+    for (unsigned bTile = 0; bTile < numBTiles; ++bTile)
+      for (unsigned b = 0; b < sizeBPerThread; b += dimStep[bDim])
+        for (unsigned k = 0; k < K; k += dimStep[kDim])
+          for (unsigned nonKTile = 0; nonKTile < numNonKTiles; ++nonKTile)
+            for (unsigned nonK = 0; nonK < sizeNonKPerThread;
+                 nonK += dimStep[nonKDim]) {
+              SmallVector<Value> offsetIndices(3);
+              offsetIndices[bDim] = i32_val((bTile * shapePerCTABTile + b) % B);
+              offsetIndices[nonKDim] =
+                  i32_val((nonKTile * shapePerCTANonKTile + nonK) % NonK);
+              offsetIndices[kDim] = i32_val(k);
+
+              Value offset = i32_val(0);
+              for (int dim = 0; dim < order.size(); ++dim)
+                offset = add(offset, mul(offsetIndices[dim], strides[dim]));
+
+              Value elemAddr = gep(ptrTy, elemTy, basePtr, offset);
+              Value vec = load(vecTy, elemAddr);
+              storeValuesInLinearVector(
+                  rewriter, loc, opValues, vec, /*kElems*/ K,
+                  /*nonKElems*/ numNonKTiles * sizeNonKPerThread, /*kIdx*/ k,
+                  /*nonKIdx*/ nonKTile * sizeNonKPerThread + nonK,
+                  /*bIdx*/ bTile * sizeBPerThread + b, kDim, nonKDim, bDim,
+                  sharedOrder[0]);
+            }
+  }
 
   return getStructFromValueTable(opValues, rewriter, loc, typeConverter,
                                  elemTy);

--- a/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -83,6 +83,8 @@ void decomposeBlockedToDotLayoutConversion(ModuleOp module) {
     OpBuilder builder(cvtOp);
     auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
     auto dstType = cast<RankedTensorType>(cvtOp.getType());
+    if (!cvtNeedsSharedMemory(srcType, dstType))
+      return;
     auto srcBlocked =
         dyn_cast<triton::gpu::BlockedEncodingAttr>(srcType.getEncoding());
     auto dstDotOp =

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -1,29 +1,30 @@
 #include "mlir/Support/LLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
 using namespace mlir;
 using namespace mlir::triton;
+using namespace ::mlir::triton::gpu;
 
-using ::mlir::triton::gpu::DotOperandEncodingAttr;
+using ::mlir::triton::gpu::expandMatrixOrderWithBatch;
+using ::mlir::triton::gpu::expandMatrixShapeWithBatch;
 using ::mlir::triton::gpu::getShapePerCTA;
-using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
+using ::mlir::triton::gpu::getSizePerThread;
 
-using ValueTableFMA = std::map<std::pair<int, int>, Value>;
+using ValueTableFMA = std::map<std::tuple<int, int, int>, Value>;
 
 static ValueTableFMA
-getValueTableFromStructFMA(Value val, int K, int n0, int shapePerCTATile,
-                           int sizePerThread,
-                           ConversionPatternRewriter &rewriter, Location loc,
-                           const LLVMTypeConverter *typeConverter, Type type) {
+getValueTableFromStructFMA(Value val, int batch, int nonK, int K,
+                           ConversionPatternRewriter &rewriter, Location loc) {
   ValueTableFMA res;
   auto elems = unpackLLElements(loc, val, rewriter);
+  assert(elems.size() == K * nonK * batch);
   int index = 0;
-  for (unsigned k = 0; k < K; ++k) {
-    for (unsigned m = 0; m < n0; m += shapePerCTATile)
-      for (unsigned mm = 0; mm < sizePerThread; ++mm) {
-        res[{m + mm, k}] = elems[index++];
-      }
-  }
+  for (unsigned b = 0; b < batch; ++b)
+    for (unsigned k = 0; k < K; ++k)
+      for (unsigned i = 0; i < nonK; ++i)
+        res[{b, i, k}] = elems[index++];
   return res;
 }
 
@@ -39,61 +40,56 @@ LogicalResult convertFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   auto D = op.getResult();
 
   auto aTensorTy = cast<RankedTensorType>(A.getType());
-  auto bTensorTy = cast<RankedTensorType>(B.getType());
   auto dTensorTy = cast<RankedTensorType>(D.getType());
+  auto dElemTy = dTensorTy.getElementType();
 
-  auto aShapePerCTA = getShapePerCTA(aTensorTy);
-  auto bShapePerCTA = getShapePerCTA(bTensorTy);
+  SmallVector<int64_t> aShapePerCTA =
+      expandMatrixShapeWithBatch(ArrayRef(getShapePerCTA(aTensorTy)));
+  auto dShapePerCTA =
+      expandMatrixShapeWithBatch(ArrayRef(getShapePerCTA(dTensorTy)));
 
   BlockedEncodingAttr dLayout =
       cast<BlockedEncodingAttr>(dTensorTy.getEncoding());
-  auto order = dLayout.getOrder();
+  auto order = expandMatrixOrderWithBatch(dLayout.getOrder());
   auto cc = unpackLLElements(loc, adaptor.getC(), rewriter);
 
   Value llA = adaptor.getA();
   Value llB = adaptor.getB();
 
-  auto sizePerThread = getSizePerThread(dLayout);
-  auto shapePerCTATile = getShapePerCTATile(dLayout);
+  auto sizePerThread =
+      expandMatrixShapeWithBatch(ArrayRef(getSizePerThread(dLayout)));
+  auto shapePerCTATile =
+      expandMatrixShapeWithBatch(ArrayRef(getShapePerCTATile(dLayout)));
 
-  int K = aShapePerCTA[1];
-  int M = aShapePerCTA[0];
-  int N = bShapePerCTA[1];
+  int K = aShapePerCTA[2];
 
-  int mShapePerCTATile =
-      order[0] == 1 ? shapePerCTATile[order[1]] : shapePerCTATile[order[0]];
-  int mSizePerThread =
-      order[0] == 1 ? sizePerThread[order[1]] : sizePerThread[order[0]];
-  int nShapePerCTATile =
-      order[0] == 0 ? shapePerCTATile[order[1]] : shapePerCTATile[order[0]];
-  int nSizePerThread =
-      order[0] == 0 ? sizePerThread[order[1]] : sizePerThread[order[0]];
+  unsigned retSize[3];
+  for (int i = 0; i < 3; ++i) {
+    unsigned numRep = dShapePerCTA[i] / shapePerCTATile[i];
+    numRep = std::max(static_cast<unsigned>(1), numRep);
+    retSize[i] = numRep * sizePerThread[i];
+  }
 
   auto has =
-      getValueTableFromStructFMA(llA, K, M, mShapePerCTATile, mSizePerThread,
-                                 rewriter, loc, typeConverter, aTensorTy);
+      getValueTableFromStructFMA(llA, retSize[0], retSize[1], K, rewriter, loc);
   auto hbs =
-      getValueTableFromStructFMA(llB, K, N, nShapePerCTATile, nSizePerThread,
-                                 rewriter, loc, typeConverter, bTensorTy);
+      getValueTableFromStructFMA(llB, retSize[0], retSize[2], K, rewriter, loc);
 
   SmallVector<Value> ret = cc;
-  bool isCRow = order[0] == 1;
 
-  for (unsigned k = 0; k < K; k++) {
-    for (unsigned m = 0; m < M; m += mShapePerCTATile)
-      for (unsigned n = 0; n < N; n += nShapePerCTATile)
-        for (unsigned mm = 0; mm < mSizePerThread; ++mm)
-          for (unsigned nn = 0; nn < nSizePerThread; ++nn) {
-            int mIdx = m / mShapePerCTATile * mSizePerThread + mm;
-            int nIdx = n / nShapePerCTATile * nSizePerThread + nn;
-
-            int z = isCRow
-                        ? mIdx * N / nShapePerCTATile * mSizePerThread + nIdx
-                        : nIdx * M / mShapePerCTATile * nSizePerThread + mIdx;
-            ret[z] = rewriter.create<LLVM::FMulAddOp>(loc, has[{m + mm, k}],
-                                                      hbs[{n + nn, k}], ret[z]);
-          }
-  }
+  for (unsigned b = 0; b < retSize[0]; ++b)
+    for (unsigned m = 0; m < retSize[1]; ++m)
+      for (unsigned n = 0; n < retSize[2]; ++n) {
+        unsigned idx[] = {b, m, n};
+        unsigned linearIdx = 0;
+        for (auto dim : llvm::reverse(order)) {
+          linearIdx = linearIdx * retSize[dim] + idx[dim];
+        }
+        for (unsigned k = 0; k < K; ++k) {
+          ret[linearIdx] = rewriter.create<LLVM::FMulAddOp>(
+              loc, has[{b, m, k}], hbs[{b, n, k}], ret[linearIdx]);
+        }
+      }
 
   auto res = packLLElements(loc, typeConverter, ret, rewriter, dTensorTy);
   rewriter.replaceOp(op, res);

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -235,6 +235,11 @@ struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
       retSizePerThread[rank - 1] = 4;
       retSizePerThread[rank - 2] = 4;
     }
+    retSizePerThread[rank - 1] = std::min(
+        retSizePerThread[rank - 1], static_cast<unsigned>(origShape[rank - 1]));
+    retSizePerThread[rank - 2] = std::min(
+        retSizePerThread[rank - 2], static_cast<unsigned>(origShape[rank - 2]));
+
     SmallVector<unsigned> retOrder(rank);
     for (unsigned i = 0; i < rank; ++i)
       retOrder[i] = rank - 1 - i;

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -939,29 +939,26 @@ unsigned DotOperandEncodingAttr::getTotalElemsPerThread(ArrayRef<int64_t> shape,
                                                        getKWidth(), getOpIdx());
   }
   if (auto blockedLayout = mlir::dyn_cast<BlockedEncodingAttr>(getParent())) {
-    auto shapePerCTA = getShapePerCTA(*this, shape);
-    auto shapePerCTATile = ::getShapePerCTATile(blockedLayout);
-    auto order = blockedLayout.getOrder();
-    auto sizePerThread = ::getSizePerThread(blockedLayout);
+    auto shapePerCTA =
+        expandMatrixShapeWithBatch(ArrayRef(getShapePerCTA(*this, shape)));
+    auto shapePerCTATile = expandMatrixShapeWithBatch(
+        ArrayRef(::getShapePerCTATile(blockedLayout)));
+    auto sizePerThread =
+        expandMatrixShapeWithBatch(ArrayRef(::getSizePerThread(blockedLayout)));
 
-    int K = getOpIdx() == 0 ? shapePerCTA[1] : shapePerCTA[0];
-    int otherDim = getOpIdx() == 1 ? shapePerCTA[1] : shapePerCTA[0];
+    int batchDim = 0;
+    int kDim = getOpIdx() == 0 ? 2 : 1;
+    int nonKDim = getOpIdx() == 0 ? 1 : 2;
 
-    bool isM = getOpIdx() == 0;
+    int batchSize =
+        std::max<int>(shapePerCTA[batchDim] / shapePerCTATile[batchDim], 1) *
+        sizePerThread[batchDim];
+    int kSize = shapePerCTA[kDim];
+    int nonKSize =
+        std::max<int>(shapePerCTA[nonKDim] / shapePerCTATile[nonKDim], 1) *
+        sizePerThread[nonKDim];
 
-    int mSizePerThread =
-        order[0] == 1 ? sizePerThread[order[1]] : sizePerThread[order[0]];
-    int nSizePerThread =
-        order[0] == 0 ? sizePerThread[order[1]] : sizePerThread[order[0]];
-    int sizePerThreadMN = isM ? mSizePerThread : nSizePerThread;
-
-    int mShapePerCTATile =
-        order[0] == 1 ? shapePerCTATile[order[1]] : shapePerCTATile[order[0]];
-    int nShapePerCTATile =
-        order[0] == 0 ? shapePerCTATile[order[1]] : shapePerCTATile[order[0]];
-    int shapePerCTAMNTile = isM ? mShapePerCTATile : nShapePerCTATile;
-
-    return K * std::max<int>(otherDim / shapePerCTAMNTile, 1) * sizePerThreadMN;
+    return batchSize * kSize * nonKSize;
   }
   llvm_unreachable("unknown dot operand parent layout");
   return 0;
@@ -3163,6 +3160,15 @@ std::string mlir::triton::gpu::getLayoutStr(RankedTensorType tensorType,
     }
   }
   return layoutStr;
+}
+
+llvm::SmallVector<unsigned>
+mlir::triton::gpu::expandMatrixOrderWithBatch(llvm::ArrayRef<unsigned> o) {
+  int oldRank = o.size();
+  llvm::SmallVector<unsigned> expanded(3, 0);
+  for (int i = 0; i < oldRank; ++i)
+    expanded[i] += o[i] + 3 - oldRank;
+  return expanded;
 }
 
 void mlir::triton::gpu::dumpLayout(RankedTensorType tensorType) {

--- a/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
@@ -42,22 +42,8 @@ public:
           dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
       if (!dstDotOp)
         return;
-      if (auto srcMmaEncoding =
-              dyn_cast<triton::gpu::NvidiaMmaEncodingAttr>(srcEncoding)) {
-
-        if (srcMmaEncoding.getVersionMajor() != 2 ||
-            (srcMmaEncoding.getWarpsPerCTA()[1] == 1 &&
-             dstDotOp.getParent() == srcMmaEncoding))
-          return;
-      }
-      if (auto srcMfmaEncoding =
-              dyn_cast<triton::gpu::AMDMfmaEncodingAttr>(srcEncoding)) {
-
-        if (srcMfmaEncoding.getWarpsPerCTA()[1] == 1 &&
-            srcMfmaEncoding.getIsTransposed() &&
-            dstDotOp.getParent() == srcMfmaEncoding)
-          return;
-      }
+      if (!cvtNeedsSharedMemory(srcType, dstType))
+        return;
       auto srcOrder = triton::gpu::getOrder(srcEncoding);
       auto rank = srcOrder.size();
       SmallVector<unsigned> sharedOrder;

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -933,6 +933,21 @@ int getNVIDIAComputeCapability(Operation *module) {
   return computeCapability;
 }
 
+StringRef getAMDArch(Operation *module) {
+  assert(module->hasAttr(triton::AttrTargetName) &&
+         "Expected a target attribute on the module operation");
+
+  StringAttr targetAttr =
+      cast<StringAttr>(module->getAttr(triton::AttrTargetName));
+
+  StringRef ref = targetAttr.strref();
+  assert(ref.starts_with("hip:") &&
+         "expected target attribute to be prefixed with \"cuda:\"");
+
+  StringRef archStr = ref.drop_front(4); // drop the "hip:"
+  return archStr;
+}
+
 namespace {
 
 /// Detect dead arguments in scf.for op by assuming all the values are dead and

--- a/test/Conversion/amd/decompose-unsupported-conversions.mlir
+++ b/test/Conversion/amd/decompose-unsupported-conversions.mlir
@@ -1,15 +1,43 @@
-// RUN: triton-opt %s --split-input-file --decompose-unsupported-amd-conversions=arch=gfx942 | FileCheck %s
+// RUN: triton-opt %s --split-input-file --decompose-unsupported-amd-conversions | FileCheck %s
 
 // CHECK: #[[BLOCKED:.+]] = #triton_gpu.blocked<{{.*}}>
 // CHECK: #[[WMMA:.+]] = #triton_gpu.amd_wmma<{{.*}}>
 // CHECK: #[[SHARED:.+]] = #triton_gpu.shared<{{.*}}>
 #mma = #triton_gpu.amd_wmma<{version = 1, warpsPerCTA = [2, 2]}>
-module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx1130", "triton_gpu.threads-per-warp" = 32 : i32} {
   tt.func @wmma_to_wmma_dot_op(%arg0: tensor<16x16xf16, #mma>) {
     // CHECK: %[[SRC_BLOCKED:.+]] = triton_gpu.convert_layout %{{.*}} : tensor<16x16xf16, #[[WMMA]]> -> tensor<16x16xf16, #[[BLOCKED]]>
     // CHECK-NEXT: %[[INT_SHARED:.+]] = triton_gpu.local_alloc %[[SRC_BLOCKED]] : {{.*}} -> !tt.memdesc<16x16xf16, #[[SHARED]], #triton_gpu.shared_memory>
     // CHECK-NEXT: %[[DST_DOT_OP:.+]] = triton_gpu.local_load %[[INT_SHARED]] : {{.*}} -> tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #[[WMMA]], kWidth = 16}>>
     %0 = triton_gpu.convert_layout %arg0 : tensor<16x16xf16, #mma> -> tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 16}>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: blocked_to_dot_op_shortcut_gfx1130
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx1130", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @blocked_to_dot_op_shortcut_gfx1130(%arg0: tensor<32x32xf16, #blocked>) {
+    // CHECK-NOT: triton_gpu.local_alloc
+    // CHECK: triton_gpu.convert_layout
+    // CHECK-NOT: triton_gpu.local_alloc
+    %0 = triton_gpu.convert_layout %arg0 : tensor<32x32xf16, #blocked> -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: blocked_to_dot_op_shortcut_gfx940
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 2], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx940", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @blocked_to_dot_op_shortcut_gfx940(%arg0: tensor<32x32xf16, #blocked>) {
+    // CHECK-NOT: triton_gpu.local_alloc
+    // CHECK: triton_gpu.convert_layout
+    // CHECK-NOT: triton_gpu.local_alloc
+    %0 = triton_gpu.convert_layout %arg0 : tensor<32x32xf16, #blocked> -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>
     tt.return
   }
 }

--- a/test/Conversion/amd/hoist-reduction.mlir
+++ b/test/Conversion/amd/hoist-reduction.mlir
@@ -1,0 +1,37 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-hoist-reduction | FileCheck %s
+
+// CHECK-LABEL: hoist_reduction
+// CHECK: %[[CST:.+]] = arith.constant dense<0>
+// CHECK: %[[PRE_DOT_CVT:.+]] = triton_gpu.convert_layout %[[CST]]
+// CHECK: %[[FOR_RESULT:.+]] = scf.for {{.*}}
+// CHECK: %[[DOT_RESULT:.+]] = tt.dot
+// CHECK: scf.yield %[[DOT_RESULT]]
+// CHECK: %[[REDUCED:.+]] = "tt.reduce"(%[[FOR_RESULT]])
+// CHECK: %[[FINAL_RESULT:.+]] = triton_gpu.convert_layout %[[REDUCED]]
+// CHECK: tt.store {{.*}} %[[FINAL_RESULT]]
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 2, 2], order = [2, 1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 2, 2], order = [2, 1, 0]}>
+module attributes {"triton_gpu.target" = "hip:gfx1030", "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @hoist_reduction(%x : tensor<8x1x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>, %y : tensor<8x64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>, %ptr : tensor<1x32x!tt.ptr<i32>, #blocked1>) {
+    %iter_begin = arith.constant 0 : i32
+    %iter_end = arith.constant 3 : i32
+    %iter_step = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<1x32xi32, #blocked1>
+    %acc = scf.for %iter = %iter_begin to %iter_end step %iter_step iter_args(%acc = %zero) -> (tensor<1x32xi32, #blocked1>)  : i32 {
+      %acc_ext = tt.reshape %acc {allow_reorder = true} : tensor<1x32xi32, #blocked1> -> tensor<1x1x32xi32, #blocked2>
+      %acc3d_batched = tt.broadcast %acc_ext : tensor<1x1x32xi32, #blocked2> -> tensor<8x1x32xi32, #blocked2>
+      %acc3d_in = triton_gpu.convert_layout %acc3d_batched : tensor<8x1x32xi32, #blocked2> -> tensor<8x1x32xi32, #blocked>
+      %acc3d_out = tt.dot %x, %y, %acc3d_in : tensor<8x1x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<8x64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<8x1x32xi32, #blocked>
+      %acc_next_slice = "tt.reduce"(%acc3d_out) <{axis = 0 : i32}> ({
+        ^bb0(%arg0: i32, %arg1: i32):
+            %sum = arith.addi %arg0, %arg1 : i32
+            tt.reduce.return %sum : i32
+      }) : (tensor<8x1x32xi32, #blocked>) -> tensor<1x32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %acc_next = triton_gpu.convert_layout %acc_next_slice : tensor<1x32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked1>
+      scf.yield %acc_next : tensor<1x32xi32, #blocked1>
+    }
+    tt.store %ptr, %acc : tensor<1x32x!tt.ptr<i32>, #blocked1>
+    tt.return
+  }
+}

--- a/test/Conversion/amd/hoist-reduction.mlir
+++ b/test/Conversion/amd/hoist-reduction.mlir
@@ -1,6 +1,6 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-hoist-reduction | FileCheck %s
 
-// CHECK-LABEL: hoist_reduction
+// CHECK-LABEL: hoist_reduction_accumulate
 // CHECK: %[[CST:.+]] = arith.constant dense<0>
 // CHECK: %[[PRE_DOT_CVT:.+]] = triton_gpu.convert_layout %[[CST]]
 // CHECK: %[[FOR_RESULT:.+]] = scf.for {{.*}}
@@ -30,6 +30,35 @@ module attributes {"triton_gpu.target" = "hip:gfx1030", "triton_gpu.num-ctas" = 
       }) : (tensor<8x1x32xi32, #blocked>) -> tensor<1x32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
       %acc_next = triton_gpu.convert_layout %acc_next_slice : tensor<1x32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked1>
       scf.yield %acc_next : tensor<1x32xi32, #blocked1>
+    }
+    tt.store %ptr, %acc : tensor<1x32x!tt.ptr<i32>, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: hoist_reduction_add
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 2, 2], order = [2, 1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 2, 2], order = [2, 1, 0]}>
+module attributes {"triton_gpu.target" = "hip:gfx1030", "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @hoist_reduction(%x : tensor<8x1x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>, %y : tensor<8x64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>, %ptr : tensor<1x32x!tt.ptr<i32>, #blocked1>) {
+    %iter_begin = arith.constant 0 : i32
+    %iter_end = arith.constant 3 : i32
+    %iter_step = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<1x32xi32, #blocked1>
+    %acc = scf.for %iter = %iter_begin to %iter_end step %iter_step iter_args(%acc = %zero) -> (tensor<1x32xi32, #blocked1>)  : i32 {
+      %acc3d_in = arith.constant dense<0> : tensor<8x1x32xi32, #blocked>
+      %acc3d_out = tt.dot %x, %y, %acc3d_in : tensor<8x1x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<8x64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<8x1x32xi32, #blocked>
+      %acc_next_slice = "tt.reduce"(%acc3d_out) <{axis = 0 : i32}> ({
+        ^bb0(%arg0: i32, %arg1: i32):
+            %sum = arith.addi %arg0, %arg1 : i32
+            tt.reduce.return %sum : i32
+      }) : (tensor<8x1x32xi32, #blocked>) -> tensor<1x32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %acc_next = triton_gpu.convert_layout %acc_next_slice : tensor<1x32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked1>
+      %acc_next_add = arith.addi %acc, %acc_next : tensor<1x32xi32, #blocked1>
+      scf.yield %acc_next_add : tensor<1x32xi32, #blocked1>
     }
     tt.store %ptr, %acc : tensor<1x32x!tt.ptr<i32>, #blocked1>
     tt.return

--- a/test/Conversion/amd/optimize-small-dot-operands.mlir
+++ b/test/Conversion/amd/optimize-small-dot-operands.mlir
@@ -1,0 +1,93 @@
+// RUN: triton-opt %s --tritonamdgpu-optimize-fma-dot=ksplit=8 -split-input-file | FileCheck --check-prefixes=K8,CHECK %s
+// RUN: triton-opt %s --tritonamdgpu-optimize-fma-dot=ksplit=64 -split-input-file | FileCheck --check-prefixes=K64,CHECK %s
+
+// CHECK-LABEL: dot_m1_n32
+// K8:       %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<1x512xi8, #{{.*}}> -> tensor<1x8x64xi8, #{{.*}}>
+// K64:      %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<1x512xi8, #{{.*}}> -> tensor<1x64x8xi8, #{{.*}}>
+// CHECK:    %[[DOT_A_TMP2:.*]] = tt.trans %[[DOT_A_TMP1:.*]]
+// CHECK:    %[[DOT_A:.*]] = triton_gpu.convert_layout %[[DOT_A_TMP2:.*]]
+// CHECK:    %[[DOT_B_TMP1:.*]] = tt.load {{.*}} : tensor<512x32x!tt.ptr<i8>
+// K8:       %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x32xi8, #{{.*}}> -> tensor<8x64x32xi8, #{{.*}}>
+// K64:      %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x32xi8, #{{.*}}> -> tensor<64x8x32xi8, #{{.*}}>
+// CHECK:    %[[DOT_B:.*]] = triton_gpu.convert_layout %[[DOT_B_TMP2]]
+// K8:       %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<8x1x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<8x64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<8x1x32xi32, #{{.*}}>
+// K64:      %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<64x1x8xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<64x8x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<64x1x32xi32, #{{.*}}>
+// CHECK:    %[[RED:.*]] = "tt.reduce"(%[[DOT_D]])
+// CHECK:    %[[STORE_VAL:.*]] = triton_gpu.convert_layout %[[RED]]
+// CHECK:    tt.store {{.*}}, %[[STORE_VAL]]
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 4], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @dot_m1_n32(%a: tensor<1x512xi8, #blocked>, %bPtr: tensor<512x32x!tt.ptr<i8>, #blocked>, %outPtr: tensor<1x32x!tt.ptr<i32>, #blocked>) {
+    %aOp = triton_gpu.convert_layout %a : tensor<1x512xi8, #blocked> -> tensor<1x512xi8, #dot_operand_a>
+    %b = tt.load %bPtr {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x32x!tt.ptr<i8>, #blocked>
+    %bOp = triton_gpu.convert_layout %b : tensor<512x32xi8, #blocked> -> tensor<512x32xi8, #dot_operand_b>
+    %c = arith.constant dense<0> : tensor<1x32xi32, #blocked>
+    %0 = tt.dot %aOp, %bOp, %c, inputPrecision = tf32 : tensor<1x512xi8, #dot_operand_a> * tensor<512x32xi8, #dot_operand_b> -> tensor<1x32xi32, #blocked>
+    tt.store %outPtr, %0 : tensor<1x32x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: dot_m1_n256
+// K8:       %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<1x512xi8, #{{.*}}> -> tensor<1x8x64xi8, #{{.*}}>
+// K64:      %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<1x512xi8, #{{.*}}> -> tensor<1x64x8xi8, #{{.*}}>
+// CHECK:    %[[DOT_A_TMP2:.*]] = tt.trans %[[DOT_A_TMP1:.*]]
+// CHECK:    %[[DOT_A:.*]] = triton_gpu.convert_layout %[[DOT_A_TMP2:.*]]
+// CHECK:    %[[DOT_B_TMP1:.*]] = tt.load {{.*}} : tensor<512x256x!tt.ptr<i8>
+// K8:       %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x256xi8, #{{.*}}> -> tensor<8x64x256xi8, #{{.*}}>
+// K64:      %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x256xi8, #{{.*}}> -> tensor<64x8x256xi8, #{{.*}}>
+// CHECK:    %[[DOT_B:.*]] = triton_gpu.convert_layout %[[DOT_B_TMP2]]
+// K8:       %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<8x1x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<8x64x256xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<8x1x256xi32, #{{.*}}>
+// K64:      %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<64x1x8xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<64x8x256xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<64x1x256xi32, #{{.*}}>
+// CHECK:    %[[RED:.*]] = "tt.reduce"(%[[DOT_D]])
+// CHECK:    %[[STORE_VAL:.*]] = triton_gpu.convert_layout %[[RED]]
+// CHECK:    tt.store {{.*}}, %[[STORE_VAL]]
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 4], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @dot_m1_n256(%a: tensor<1x512xi8, #blocked>, %bPtr: tensor<512x256x!tt.ptr<i8>, #blocked>, %outPtr: tensor<1x256x!tt.ptr<i32>, #blocked>) {
+    %aOp = triton_gpu.convert_layout %a : tensor<1x512xi8, #blocked> -> tensor<1x512xi8, #dot_operand_a>
+    %b = tt.load %bPtr {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256x!tt.ptr<i8>, #blocked>
+    %bOp = triton_gpu.convert_layout %b : tensor<512x256xi8, #blocked> -> tensor<512x256xi8, #dot_operand_b>
+    %c = arith.constant dense<0> : tensor<1x256xi32, #blocked>
+    %0 = tt.dot %aOp, %bOp, %c, inputPrecision = tf32 : tensor<1x512xi8, #dot_operand_a> * tensor<512x256xi8, #dot_operand_b> -> tensor<1x256xi32, #blocked>
+    tt.store %outPtr, %0 : tensor<1x256x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: dot_m2_n32
+// K8:       %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<2x512xi8, #{{.*}}> -> tensor<2x8x64xi8, #{{.*}}>
+// K64:      %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<2x512xi8, #{{.*}}> -> tensor<2x64x8xi8, #{{.*}}>
+// CHECK:    %[[DOT_A_TMP2:.*]] = tt.trans %[[DOT_A_TMP1:.*]]
+// CHECK:    %[[DOT_A:.*]] = triton_gpu.convert_layout %[[DOT_A_TMP2:.*]]
+// CHECK:    %[[DOT_B_TMP1:.*]] = tt.load {{.*}} : tensor<512x32x!tt.ptr<i8>
+// K8:       %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x32xi8, #{{.*}}> -> tensor<8x64x32xi8, #{{.*}}>
+// K64:      %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x32xi8, #{{.*}}> -> tensor<64x8x32xi8, #{{.*}}>
+// CHECK:    %[[DOT_B:.*]] = triton_gpu.convert_layout %[[DOT_B_TMP2]]
+// K8:       %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<8x2x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<8x64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<8x2x32xi32, #{{.*}}>
+// K64:      %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<64x2x8xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<64x8x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<64x2x32xi32, #{{.*}}>
+// CHECK:    %[[RED:.*]] = "tt.reduce"(%[[DOT_D]])
+// CHECK:    %[[STORE_VAL:.*]] = triton_gpu.convert_layout %[[RED]]
+// CHECK:    tt.store {{.*}}, %[[STORE_VAL]]
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @dot_m2_n32(%a: tensor<2x512xi8, #blocked>, %bPtr: tensor<512x32x!tt.ptr<i8>, #blocked>, %outPtr: tensor<2x32x!tt.ptr<i32>, #blocked>) {
+    %aOp = triton_gpu.convert_layout %a : tensor<2x512xi8, #blocked> -> tensor<2x512xi8, #dot_operand_a>
+    %b = tt.load %bPtr {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x32x!tt.ptr<i8>, #blocked>
+    %bOp = triton_gpu.convert_layout %b : tensor<512x32xi8, #blocked> -> tensor<512x32xi8, #dot_operand_b>
+    %c = arith.constant dense<0> : tensor<2x32xi32, #blocked>
+    %0 = tt.dot %aOp, %bOp, %c, inputPrecision = tf32 : tensor<2x512xi8, #dot_operand_a> * tensor<512x32xi8, #dot_operand_b> -> tensor<2x32xi32, #blocked>
+    tt.store %outPtr, %0 : tensor<2x32x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -34,3 +34,39 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     tt.return
   }
 }
+
+// -----
+
+// CHECK-LABEL: v_dot_i8
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+module attributes {"triton_gpu.target" = "hip:gfx942", "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @v_dot_i8(%arg0: tensor<16x16xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<16x16xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<16x16xi32, #blocked>) {
+    // CHECK-4: llvm.call_intrinsic "llvm.amdgcn.sdot4"
+    %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x16xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<16x16xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: v_dot_fp16
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+module attributes {"triton_gpu.target" = "hip:gfx942", "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @v_dot_fp16(%arg0: tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<16x16xf32, #blocked>) {
+    // CHECK-8: llvm.call_intrinsic "llvm.amdgcn.fdot2"
+    %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<16x16xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: v_dot_fp16_fp16
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+module attributes {"triton_gpu.target" = "hip:gfx942", "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @v_dot_fp16_fp16(%arg0: tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<16x16xf16, #blocked>) {
+    // CHECK-4: llvm.call_intrinsic "llvm.amdgcn.sdot4"
+    %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<16x16xf16, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm_block_dot_shortcut.mlir
+++ b/test/Conversion/tritongpu_to_llvm_block_dot_shortcut.mlir
@@ -1,0 +1,47 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-gpu-to-llvm | FileCheck %s
+
+// CHECK-LABEL: blocked_to_dot_op_shortcut_warp32
+#blocked = #triton_gpu.blocked<{sizePerThread = [32, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [0, 1]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:80", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @blocked_to_dot_op_shortcut_warp32(%arg0: tensor<32x32xf16, #blocked>, %arg1: tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    %0 = triton_gpu.convert_layout %arg0 : tensor<32x32xf16, #blocked> -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>
+    // CHECK-NOT: load
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: blocked_to_dot_op_shortcut_warp64
+#blocked = #triton_gpu.blocked<{sizePerThread = [32, 1], threadsPerWarp = [2, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx940", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @blocked_to_dot_op_shortcut_warp64(%arg0: tensor<32x32xf16, #blocked>) {
+    %0 = triton_gpu.convert_layout %arg0 : tensor<32x32xf16, #blocked> -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>
+    // CHECK-NOT: load
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: blocked_to_dot3d_op_shortcut_warp32
+#blocked = #triton_gpu.blocked<{sizePerThread = [2, 32, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [2, 1, 2], order = [1, 2, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:80", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @blocked_to_dot3d_op_shortcut_warp32(%arg0: tensor<8x32x32xf16, #blocked>) {
+    %0 = triton_gpu.convert_layout %arg0 : tensor<8x32x32xf16, #blocked> -> tensor<8x32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>
+    // CHECK-NOT: load
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: blocked_to_dot3d_op_shortcut_warp64
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 32, 1], threadsPerWarp = [1, 2, 32], warpsPerCTA = [2, 2, 1], order = [2, 1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx940", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @blocked_to_dot3d_op_shortcut_warp64(%arg0: tensor<8x32x32xf16, #blocked>) {
+    %0 = triton_gpu.convert_layout %arg0 : tensor<8x32x32xf16, #blocked> -> tensor<8x32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>
+    // CHECK-NOT: load
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/accelerate-amd-matmul-fma.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-fma.mlir
@@ -1,0 +1,107 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul='arch-generation-name=gfx942' | FileCheck %s
+
+// CHECK: fma_dot_fp16_fp16
+// CHECK: tt.dot {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf16, {{.*}}>
+#blocked = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx942", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_fp16_fp16(
+      %arg0: tensor<2x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<f16>, #blocked> ) {
+    %cst = arith.constant dense<0.0> : tensor<2x64xf16, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xf16, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: fma_dot_fp32_fp32
+// CHECK: tt.dot {{.*}} : tensor<2x64xf32, {{.*}}> * tensor<64x64xf32, {{.*}}> -> tensor<2x64xf32, {{.*}}>
+#blocked = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx942", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_fp32_fp32(
+      %arg0: tensor<2x64xf32, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xf32, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<f32>, #blocked> ) {
+    %cst = arith.constant dense<0.0> : tensor<2x64xf32, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xf32, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xf32, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xf32, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: #[[BLOCKED:.*]] = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+// CHECK: fma_dot_i8
+// CHECK: tt.dot {{.*}} : tensor<2x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #[[BLOCKED]]}>> * tensor<64x64xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #[[BLOCKED]]}>> -> tensor<2x64xi32, #[[BLOCKED]]>
+#blocked = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx942", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_i8(
+      %arg0: tensor<2x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<i32>, #blocked> ) {
+    %cst = arith.constant dense<0> : tensor<2x64xi32, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xi32, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: #[[BLOCKED:.*]] = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+// CHECK: fma_dot_f16
+// CHECK: tt.dot {{.*}} : tensor<2x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #[[BLOCKED]]}>> * tensor<64x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #[[BLOCKED]]}>> -> tensor<2x64xf32, #[[BLOCKED]]>
+#blocked = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx942", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_f16(
+      %arg0: tensor<2x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<f32>, #blocked> ) {
+    %cst = arith.constant dense<0.0> : tensor<2x64xf32, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xf32, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: #[[BLOCKED:.*]] = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+// CHECK: fma_dot_f8
+// CHECK: tt.dot {{.*}} : tensor<2x64xf32, #triton_gpu.dot_op<{opIdx = 0, parent = #[[BLOCKED]]}>> * tensor<64x64xf32, #triton_gpu.dot_op<{opIdx = 1, parent = #[[BLOCKED]]}>> -> tensor<2x64xf32, #[[BLOCKED]]>
+#blocked = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx942", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_f8(
+      %arg0: tensor<2x64xf8E5M2, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xf8E5M2, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<f32>, #blocked> ) {
+    %cst = arith.constant dense<0.0> : tensor<2x64xf32, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xf8E5M2, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xf8E5M2, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xf32, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: fma_dot_i8_i8
+// CHECK-DAG: %[[A:.*]] = arith.sitofp
+// CHECK-DAG: %[[B:.*]] = arith.sitofp
+// CHECK: %[[D:.*]] = tt.dot %[[A]], %[[B]], {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf16, {{.*}}>
+// CHECK: arith.fptosi %[[D]]
+#blocked = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx942", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_i8_i8(
+      %arg0: tensor<2x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<i8>, #blocked> ) {
+    %cst = arith.constant dense<0> : tensor<2x64xi8, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xi8, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<i8>, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen1.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen1.mlir
@@ -133,14 +133,12 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
    // CHECK-SAME: %[[DOT3_ARG_B:.+]]: tensor<64x32xi16, #triton_gpu.dot_op<{opIdx = 1, parent = #[[DOT_OP_PARENT]]}>>
    %1: tensor<64x32xi16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>,
    %2: tensor<128x32x!tt.ptr<i16>, #blocked>) {
-    // CHECK: %[[DOT3_ARG_C:.+]] = arith.constant dense<0> : tensor<128x32xi16, #[[DOT_OP_PARENT]]>
+    // CHECK: %[[DOT3_OP_C:.+]] = arith.constant dense<0.000000e+00> : tensor<128x32xf32, #[[DOT_OP_PARENT]]>
     %3 = arith.constant dense<0> : tensor<128x32xi16, #blocked>
     // CHECK: %[[DOT3_OP_A:.+]] = arith.sitofp %[[DOT3_ARG_A]]
     // CHECK-SAME: to tensor<128x64xf32, #triton_gpu.dot_op<{opIdx = 0, parent = #[[DOT_OP_PARENT]]
     // CHECK: %[[DOT3_OP_B:.+]] = arith.sitofp %[[DOT3_ARG_B]]
     // CHECK-SAME: to tensor<64x32xf32, #triton_gpu.dot_op<{opIdx = 1, parent = #[[DOT_OP_PARENT]]
-    // CHECK: %[[DOT3_OP_C:.+]] = arith.sitofp %[[DOT3_ARG_C]]
-    // CHECK-SAME: to tensor<128x32xf32, #[[DOT_OP_PARENT]]
     // CHECK: %[[DOT3_FMA_RES:.+]] = tt.dot %[[DOT3_OP_A]], %[[DOT3_OP_B]], %[[DOT3_OP_C]]
     // CHECK-SAME: -> tensor<128x32xf32, #[[DOT_OP_PARENT]]>
     %4 = tt.dot %0, %1, %3 : tensor<128x64xi16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x32xi16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x32xi16, #blocked>

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -13,16 +13,30 @@ from pathlib import Path
 
 
 def min_dot_size(target: GPUTarget):
+
+    def fma_supported(lhsType, rhsType):
+        return lhsType == rhsType and (lhsType.is_fp16() or lhsType.is_fp32())
+
+    def gfx94_limits(lhsType, rhsType):
+        if fma_supported(lhsType.scalar, rhsType.scalar):
+            return (1, 1, 1)
+        # CDNA 3.0 supports k==8 in all mfma variants except for int8
+        # (where the smallest `k` supported is 16)
+        return (16, 16, 16) if (lhsType.scalar.is_int8() or rhsType.scalar.is_int8()) else (16, 16, 8)
+
+    def gfx9_limits(lhsType, rhsType):
+        if fma_supported(lhsType.scalar, rhsType.scalar):
+            return (1, 1, 1)
+        # CDNA 2.0 always supports `k==8`
+        return (16, 16, 8)
+
     arch_str = target.arch
-    # CDNA 3.0 supports k==8 in all mfma variants except for int8
-    # (where the smallest `k` supported is 16)
     if "gfx94" in arch_str:
-        return lambda lhsType, rhsType: (16, 16, 16) if (lhsType.is_int8() or rhsType.is_int8()) else (16, 16, 8)
-    # CDNA 2.0 always supports `k==8`
+        return gfx94_limits
     if "gfx9" in arch_str:
-        return lambda lhsType, rhsType: (16, 16, 8)
-    # Other architectures will only support 16,16,16
-    return lambda lhsType, rhsType: (16, 16, 16)
+        return gfx9_limits
+    # Other architectures will only support 16,16,16 with mfma instructions
+    return lambda lhsType, rhsType: (1, 1, 1) if fma_supported(lhsType.scalar, rhsType.scalar) else (16, 16, 16)
 
 
 @dataclass(frozen=True)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -166,6 +166,7 @@ class HIPBackend(BaseBackend):
         passes.ttgpuir.add_optimize_thread_locality(pm)
         amd.passes.ttgpuir.add_accelerate_matmul(pm, options.arch, options.matrix_instr_nonkdim, options.kpack)
         passes.ttgpuir.add_remove_layout_conversions(pm)
+        amd.passes.ttgpuir.add_hoist_reduction(pm)
         amd.passes.ttgpuir.add_optimize_epilogue(pm)
         amd.passes.ttgpuir.add_optimize_small_dot_operands(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, True)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -167,6 +167,7 @@ class HIPBackend(BaseBackend):
         amd.passes.ttgpuir.add_accelerate_matmul(pm, options.arch, options.matrix_instr_nonkdim, options.kpack)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         amd.passes.ttgpuir.add_optimize_epilogue(pm)
+        amd.passes.ttgpuir.add_optimize_small_dot_operands(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, True)
         use_new_pipeliner = os.getenv("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0") == "1"
         if amd.has_matrix_core_feature(options.arch):

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -166,9 +166,9 @@ class HIPBackend(BaseBackend):
         passes.ttgpuir.add_optimize_thread_locality(pm)
         amd.passes.ttgpuir.add_accelerate_matmul(pm, options.arch, options.matrix_instr_nonkdim, options.kpack)
         passes.ttgpuir.add_remove_layout_conversions(pm)
-        amd.passes.ttgpuir.add_hoist_reduction(pm)
         amd.passes.ttgpuir.add_optimize_epilogue(pm)
-        amd.passes.ttgpuir.add_optimize_small_dot_operands(pm)
+        amd.passes.ttgpuir.add_optimize_fma_dot(pm)
+        amd.passes.ttgpuir.add_hoist_reduction(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, True)
         use_new_pipeliner = os.getenv("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0") == "1"
         if amd.has_matrix_core_feature(options.arch):

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -13,30 +13,7 @@ from pathlib import Path
 
 
 def min_dot_size(target: GPUTarget):
-
-    def fma_supported(lhsType, rhsType):
-        return lhsType == rhsType and (lhsType.is_fp16() or lhsType.is_fp32())
-
-    def gfx94_limits(lhsType, rhsType):
-        if fma_supported(lhsType.scalar, rhsType.scalar):
-            return (1, 1, 1)
-        # CDNA 3.0 supports k==8 in all mfma variants except for int8
-        # (where the smallest `k` supported is 16)
-        return (16, 16, 16) if (lhsType.scalar.is_int8() or rhsType.scalar.is_int8()) else (16, 16, 8)
-
-    def gfx9_limits(lhsType, rhsType):
-        if fma_supported(lhsType.scalar, rhsType.scalar):
-            return (1, 1, 1)
-        # CDNA 2.0 always supports `k==8`
-        return (16, 16, 8)
-
-    arch_str = target.arch
-    if "gfx94" in arch_str:
-        return gfx94_limits
-    if "gfx9" in arch_str:
-        return gfx9_limits
-    # Other architectures will only support 16,16,16 with mfma instructions
-    return lambda lhsType, rhsType: (1, 1, 1) if fma_supported(lhsType.scalar, rhsType.scalar) else (16, 16, 16)
+    return lambda lhsType, rhsType: (1, 1, 1)
 
 
 @dataclass(frozen=True)

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -25,6 +25,8 @@ std::unique_ptr<Pass> createTritonAMDGPUOptimizeEpiloguePass();
 
 std::unique_ptr<Pass> createTritonAMDGPUCanonicalizePointersPass();
 
+std::unique_ptr<Pass> createTritonAMDGPUOptimizeFMADotPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "TritonAMDGPUTransforms/Passes.h.inc"

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -27,6 +27,8 @@ std::unique_ptr<Pass> createTritonAMDGPUCanonicalizePointersPass();
 
 std::unique_ptr<Pass> createTritonAMDGPUOptimizeFMADotPass();
 
+std::unique_ptr<Pass> createTritonAMDGPUHoistReductionPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "TritonAMDGPUTransforms/Passes.h.inc"

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -139,4 +139,30 @@ def TritonAMDGPUReorderInstructions: Pass<"tritonamdgpu-reorder-instructions", "
   let dependentDialects = [];
 }
 
+
+def TritonAMDGPUHoistReduction : Pass<"tritonamdgpu-hoist-reduction", "mlir::ModuleOp"> {
+  let summary = "hoist reduction operation applied to dot accumulator outside of loop over K";
+
+  let description = [{
+    Optimization hoists reduction operation out of the loop:
+
+    %acc = <zero tensor>
+    for k tiles:
+      %acc3d_input = reshape %acc
+      %acc3d_out = dot3d(%x, %y, %acc3d_input)
+      %acc = reduction batch %acc3d_out
+
+    transformed to:
+
+    %acc3d = <zero tensor>
+    for k tiles:
+      %acc3d = dot3d(%x, %y, %acc3d)
+    %acc = reduction batch %acc3d
+  }];
+
+  let constructor = "mlir::createTritonAMDGPUHoistReductionPass()";
+
+  let dependentDialects = [];
+}
+
 #endif

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -109,6 +109,7 @@ def TritonAMDGPUCanonicalizePointers : Pass<"tritonamdgpu-canonicalize-pointers"
   let constructor = "mlir::createTritonAMDGPUCanonicalizePointersPass()";
 
   let dependentDialects = [];
+}
 
 def TritonAMDGPUOptimizeFMADot : Pass<"tritonamdgpu-optimize-fma-dot", "mlir::ModuleOp"> {
   let summary = "Optimize small matrices operands: Load dot operands in layout compatible to dotOp.";

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -110,6 +110,21 @@ def TritonAMDGPUCanonicalizePointers : Pass<"tritonamdgpu-canonicalize-pointers"
 
   let dependentDialects = [];
 
+def TritonAMDGPUOptimizeFMADot : Pass<"tritonamdgpu-optimize-fma-dot", "mlir::ModuleOp"> {
+  let summary = "Optimize small matrices operands: Load dot operands in layout compatible to dotOp.";
+
+  let description = [{
+  }];
+
+  let constructor = "mlir::createTritonAMDGPUOptimizeFMADotPass()";
+
+  let options = [
+  Option<"kSplit", "ksplit",
+          "int32_t", /*default*/"64",
+          "split k dim up to given number of pieces, compute them in different threads and then reduce">,
+];
+
+  let dependentDialects = [];
 }
 
 def TritonAMDGPUReorderInstructions: Pass<"tritonamdgpu-reorder-instructions", "mlir::ModuleOp"> {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonAMDGPUToLLVM
     ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
     ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
     ConvertLayoutOpToLLVM.cpp
+    DotOpToLLVM/FMA.cpp
     DotOpToLLVM/MFMA.cpp
     DotOpToLLVM/WMMA.cpp
     DotOpToLLVM.cpp

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
@@ -7,6 +7,10 @@ using ::mlir::triton::gpu::AMDWmmaEncodingAttr;
 using ::mlir::triton::gpu::getShapePerCTA;
 
 namespace mlir::triton::AMD {
+LogicalResult convertAMDFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
+                               const LLVMTypeConverter *typeConverter,
+                               ConversionPatternRewriter &rewriter);
+
 LogicalResult convertMFMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                           const LLVMTypeConverter *typeConverter,
                           ConversionPatternRewriter &rewriter);
@@ -46,7 +50,7 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
 
     if (isa<BlockedEncodingAttr>(
             cast<RankedTensorType>(D.getType()).getEncoding()))
-      return convertFMADot(op, adaptor, getTypeConverter(), rewriter);
+      return AMD::convertAMDFMADot(op, adaptor, getTypeConverter(), rewriter);
 
     llvm::report_fatal_error(
         "Unsupported DotOp found when converting TritonGPU to LLVM.");

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -1,0 +1,192 @@
+#include "mlir/Support/LLVM.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace ::mlir::triton::gpu;
+
+using ::mlir::triton::gpu::expandMatrixOrderWithBatch;
+using ::mlir::triton::gpu::expandMatrixShapeWithBatch;
+using ::mlir::triton::gpu::getShapePerCTA;
+using ::mlir::triton::gpu::getSizePerThread;
+
+namespace {
+
+using ValueTableFMA = std::map<std::tuple<int, int, int>, Value>;
+
+static ValueTableFMA
+getValueTableFromStructFMA(Value val, int batch, int nonK, int K,
+                           ConversionPatternRewriter &rewriter, Location loc) {
+  ValueTableFMA res;
+  auto elems = unpackLLElements(loc, val, rewriter);
+  assert(elems.size() == K * nonK * batch);
+  int index = 0;
+  for (unsigned b = 0; b < batch; ++b)
+    for (unsigned k = 0; k < K; ++k)
+      for (unsigned i = 0; i < nonK; ++i)
+        res[{b, i, k}] = elems[index++];
+  return res;
+}
+
+struct DotIntrinsic {
+  int vectorSize;
+  Type outElemTy;
+  StringRef intrinsicName;
+  SmallVector<Value> additionalArgs;
+};
+
+DotIntrinsic chooseIntrinsic(ConversionPatternRewriter &rewriter, Location loc,
+                             triton::DotOp op) {
+  auto aOpTy = cast<RankedTensorType>(op.getA().getType());
+  auto aElemTy = aOpTy.getElementType();
+  auto dOpTy = cast<RankedTensorType>(op.getD().getType());
+  auto dElemTy = dOpTy.getElementType();
+  auto mod = op->getParentOfType<ModuleOp>();
+  auto arch = getAMDArch(mod);
+  DotIntrinsic chosenOp;
+  bool dotAvailable = arch == "gfx908" || arch == "gfx90a" ||
+                      arch.starts_with("gfx94") || arch.starts_with("gfx11") ||
+                      arch.starts_with("gfx103");
+  if (dotAvailable) {
+    if (aElemTy.isF16() && dElemTy.isF32()) {
+      chosenOp.vectorSize = 2;
+      chosenOp.outElemTy = f32_ty;
+      chosenOp.intrinsicName = "llvm.amdgcn.fdot2";
+      chosenOp.additionalArgs = {false_val()};
+      return chosenOp;
+    }
+    if (aElemTy.isInteger(8) && dElemTy.isInteger(32)) {
+      chosenOp.vectorSize = 4;
+      chosenOp.outElemTy = i32_ty;
+      chosenOp.intrinsicName = "llvm.amdgcn.sdot4";
+      chosenOp.additionalArgs = {false_val()};
+      return chosenOp;
+    }
+  }
+  // choose one of FMA intrinsics
+  assert(aElemTy.isIntOrFloat() && !aElemTy.isIntOrIndex());
+  assert(aElemTy == dElemTy);
+  assert(cast<RankedTensorType>(op.getA().getType()).getElementType() ==
+         dElemTy);
+  chosenOp.vectorSize = 1;
+  chosenOp.outElemTy = aElemTy;
+  if (aElemTy.isF32())
+    chosenOp.intrinsicName = "llvm.fmuladd.f32";
+  if (aElemTy.isF16())
+    chosenOp.intrinsicName = "llvm.fmuladd.f16";
+  chosenOp.additionalArgs = {};
+  return chosenOp;
+}
+
+Value packOperand(ConversionPatternRewriter &rewriter, Location loc,
+                  ValueTableFMA scalarValues, unsigned b, unsigned nonK,
+                  unsigned k, unsigned vectorSize) {
+  if (vectorSize == 1)
+    return scalarValues[{b, nonK, k}];
+  auto elemTy = scalarValues[{b, nonK, k}].getType();
+  auto vecTy = vec_ty(elemTy, vectorSize);
+  Value vec = undef(vecTy);
+  for (int elem = 0; elem < vectorSize; ++elem) {
+    vec = insert_element(vecTy, vec, scalarValues[{b, nonK, k + elem}],
+                         i32_val(elem));
+  }
+  if (elemTy.isInteger(8)) {
+    assert(vectorSize == 4);
+    vec = bitcast(vec, i32_ty);
+  }
+  return vec;
+}
+
+Value generateDotOp(ConversionPatternRewriter &rewriter, Location loc,
+                    DotIntrinsic op, Value a, Value b, Value c) {
+  SmallVector<Value> args{a, b, c};
+  args.append(op.additionalArgs.begin(), op.additionalArgs.end());
+  SmallVector<Type> argTypes;
+  for (auto arg : args)
+    argTypes.push_back(arg.getType());
+  auto funcType = LLVM::LLVMFunctionType::get(op.outElemTy, argTypes);
+  auto d = call_intrinsic(op.outElemTy, op.intrinsicName, args);
+  return d.getResult(0);
+}
+
+} // namespace
+
+namespace mlir::triton::AMD {
+
+LogicalResult convertAMDFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
+                               const LLVMTypeConverter *typeConverter,
+                               ConversionPatternRewriter &rewriter) {
+  auto *ctx = rewriter.getContext();
+  auto loc = op.getLoc();
+
+  auto A = op.getA();
+  auto B = op.getB();
+  auto C = op.getC();
+  auto D = op.getResult();
+
+  auto aTensorTy = cast<RankedTensorType>(A.getType());
+  auto dTensorTy = cast<RankedTensorType>(D.getType());
+  auto dElemTy = dTensorTy.getElementType();
+
+  SmallVector<int64_t> aShapePerCTA =
+      expandMatrixShapeWithBatch(ArrayRef(getShapePerCTA(aTensorTy)));
+  auto dShapePerCTA =
+      expandMatrixShapeWithBatch(ArrayRef(getShapePerCTA(dTensorTy)));
+
+  BlockedEncodingAttr dLayout =
+      cast<BlockedEncodingAttr>(dTensorTy.getEncoding());
+  auto order = expandMatrixOrderWithBatch(dLayout.getOrder());
+  auto cc = unpackLLElements(loc, adaptor.getC(), rewriter);
+
+  Value llA = adaptor.getA();
+  Value llB = adaptor.getB();
+
+  auto sizePerThread =
+      expandMatrixShapeWithBatch(ArrayRef(getSizePerThread(dLayout)));
+  auto shapePerCTATile =
+      expandMatrixShapeWithBatch(ArrayRef(getShapePerCTATile(dLayout)));
+
+  int K = aShapePerCTA[2];
+
+  unsigned retSize[3];
+  for (int i = 0; i < 3; ++i) {
+    unsigned numRep = dShapePerCTA[i] / shapePerCTATile[i];
+    numRep = std::max(static_cast<unsigned>(1), numRep);
+    retSize[i] = numRep * sizePerThread[i];
+  }
+
+  auto has =
+      getValueTableFromStructFMA(llA, retSize[0], retSize[1], K, rewriter, loc);
+  auto hbs =
+      getValueTableFromStructFMA(llB, retSize[0], retSize[2], K, rewriter, loc);
+
+  SmallVector<Value> ret = cc;
+  auto selectedOp = chooseIntrinsic(rewriter, loc, op);
+
+  for (unsigned b = 0; b < retSize[0]; ++b)
+    for (unsigned m = 0; m < retSize[1]; ++m)
+      for (unsigned n = 0; n < retSize[2]; ++n) {
+        unsigned idx[] = {b, m, n};
+        unsigned linearIdx = 0;
+        for (auto dim : llvm::reverse(order)) {
+          linearIdx = linearIdx * retSize[dim] + idx[dim];
+        }
+        for (unsigned k = 0; k < K; k += selectedOp.vectorSize) {
+          auto aOp =
+              packOperand(rewriter, loc, has, b, m, k, selectedOp.vectorSize);
+          auto bOp =
+              packOperand(rewriter, loc, hbs, b, n, k, selectedOp.vectorSize);
+          ret[linearIdx] = generateDotOp(rewriter, loc, selectedOp, aOp, bOp,
+                                         ret[linearIdx]);
+        }
+      }
+
+  auto res = packLLElements(loc, typeConverter, ret, rewriter, dTensorTy);
+  rewriter.replaceOp(op, res);
+
+  return success();
+}
+
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonAMDGPUTransforms
   AccelerateAMDMatmul.cpp
   CanonicalizePointers.cpp
   OptimizeEpilogue.cpp
+  OptimizeFMADot.cpp
   ReorderInstructions.cpp
   StreamPipeline.cpp
   StreamPipelineV2.cpp

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_triton_library(TritonAMDGPUTransforms
   ReorderInstructions.cpp
   StreamPipeline.cpp
   StreamPipelineV2.cpp
+  HoistReduction.cpp
   MfmaGroup.cpp
 
   DEPENDS

--- a/third_party/amd/lib/TritonAMDGPUTransforms/HoistReduction.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/HoistReduction.cpp
@@ -1,0 +1,213 @@
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+// This pass hoists auxiliar operations over dot outside the K loop
+// Example of optimized loop:
+//
+//   void kernel() {
+//     x = tensor<8, 1, 64>
+//     y = tensor<8, 64, 32>
+//     acc = tensor<1, 32>
+//     for (iter = 0; iter < 3; ++iter) {
+//       acc = reshape(acc, <1, 1, 32>)
+//       acc = broadcast(acc, <8, 1, 32>)
+//       acc = dot(x, y, acc)
+//       acc = reduce_sum(acc, axis = 0)
+//     }
+//     store(acc)
+//   }
+//
+// Transforms to:
+//
+//   void kernel() {
+//     x = tensor<8, 1, 64>
+//     y = tensor<8, 64, 32>
+//     acc = tensor<1, 32>
+//     acc = reshape(acc, <1, 1, 32>)
+//     acc = broadcast(acc, <8, 1, 32>)
+//     for (iter = 0; iter < 3; ++iter) {
+//       acc = dot(x, y, acc)
+//     }
+//     acc = reduce_sum(acc, axis = 0)
+//     store(acc)
+//   }
+
+using namespace mlir;
+
+namespace {
+
+bool isPermutableOp(const mlir::Operation &op) {
+  return isa<mlir::arith::AddIOp>(op) || isa<mlir::arith::AddFOp>(op);
+}
+
+bool isApproprateReduction(triton::ReduceOp op) {
+  if (op.getAxis() != 0)
+    return false;
+  auto redBody = op.getBody();
+  if (redBody->getNumSuccessors() != 0)
+    return false;
+  auto &redBodyOps = redBody->getOperations();
+  if (redBodyOps.size() != 2)
+    return false;
+  auto &redBaseOp = redBodyOps.front();
+  auto returnOp = cast<triton::ReduceReturnOp>(redBodyOps.back());
+  if (redBaseOp.getNumResults() != 1)
+    return false;
+  if (!isPermutableOp(redBaseOp) &&
+      returnOp.getOperand(0) != redBaseOp.getResult(0))
+    return false;
+  return true;
+}
+
+struct dotReductionChainOperations {
+  BlockArgument loopBlockArg;
+  triton::ReshapeOp reshape;
+  triton::BroadcastOp broadcast;
+  triton::gpu::ConvertLayoutOp preDotConvert;
+  triton::DotOp dot;
+  triton::ReduceOp reduction;
+  triton::gpu::ConvertLayoutOp postDotConversion;
+  scf::YieldOp yield;
+  int yieldOpNo;
+};
+
+OpOperand *getSingleUse(Operation *op) {
+  if (!op->getResult(0).hasOneUse())
+    return nullptr;
+  return &(*op->getUses().begin());
+}
+
+std::optional<dotReductionChainOperations>
+matchDotReductionInLoopPattern(triton::ReduceOp redOp) {
+  dotReductionChainOperations chain;
+  chain.reduction = redOp;
+  auto postDotConversionOperand = getSingleUse(redOp);
+  if (!postDotConversionOperand)
+    return std::nullopt;
+  chain.postDotConversion = dyn_cast<triton::gpu::ConvertLayoutOp>(
+      postDotConversionOperand->getOwner());
+  if (!chain.postDotConversion)
+    return std::nullopt;
+  auto yieldOperand = getSingleUse(chain.postDotConversion);
+  if (!yieldOperand)
+    return std::nullopt;
+  chain.yieldOpNo = yieldOperand->getOperandNumber();
+  chain.yield = dyn_cast<scf::YieldOp>(yieldOperand->getOwner());
+  if (!chain.yield)
+    return std::nullopt;
+  chain.dot = dyn_cast<triton::DotOp>(redOp->getOperand(0).getDefiningOp());
+  if (!chain.dot)
+    return std::nullopt;
+  chain.preDotConvert =
+      dyn_cast<triton::gpu::ConvertLayoutOp>(chain.dot.getC().getDefiningOp());
+  if (!chain.preDotConvert)
+    return std::nullopt;
+  chain.broadcast = dyn_cast<triton::BroadcastOp>(
+      chain.preDotConvert.getSrc().getDefiningOp());
+  if (!chain.broadcast)
+    return std::nullopt;
+  chain.reshape =
+      dyn_cast<triton::ReshapeOp>(chain.broadcast.getSrc().getDefiningOp());
+  if (!chain.reshape)
+    return std::nullopt;
+  auto loopArgument = dyn_cast<BlockArgument>(chain.reshape.getSrc());
+  if (!loopArgument || loopArgument.getArgNumber() != chain.yieldOpNo + 1)
+    return std::nullopt;
+  chain.loopBlockArg = loopArgument;
+  return chain;
+}
+
+void hoistReductionOps(mlir::PatternRewriter &rewriter, scf::ForOp loopOp,
+                       dotReductionChainOperations dfChain) {
+  auto accInitializer = loopOp.getInitArgs()[dfChain.yieldOpNo];
+
+  // hoist operations outside the loop
+  rewriter.moveOpBefore(dfChain.reshape, loopOp);
+  rewriter.moveOpBefore(dfChain.broadcast, loopOp);
+  rewriter.moveOpBefore(dfChain.preDotConvert, loopOp);
+
+  rewriter.moveOpAfter(dfChain.reduction, loopOp);
+  rewriter.moveOpAfter(dfChain.postDotConversion, dfChain.reduction);
+
+  // adjust operations DF
+  dfChain.reshape.setOperand(accInitializer);
+  loopOp.setOperand(dfChain.yieldOpNo + 3, dfChain.preDotConvert);
+  dfChain.dot.setOperand(2, dfChain.loopBlockArg);
+  dfChain.yield.setOperand(dfChain.yieldOpNo, dfChain.dot);
+
+  rewriter.replaceAllUsesWith(loopOp.getResult(dfChain.yieldOpNo),
+                              dfChain.postDotConversion);
+  dfChain.reduction.setOperand(0, loopOp.getResult(dfChain.yieldOpNo));
+
+  // adjust loop types
+  auto newAccTy = dfChain.preDotConvert.getType();
+  // loopOp.getOperand(dfChain.yieldOpNo + 3).setType(newAccTy);
+  loopOp.getResult(dfChain.yieldOpNo).setType(newAccTy);
+  dfChain.loopBlockArg.setType(newAccTy);
+}
+
+class HoistReduction : public mlir::RewritePattern {
+
+public:
+  explicit HoistReduction(mlir::MLIRContext *context)
+      : mlir::RewritePattern(triton::ReduceOp::getOperationName(), 1, context) {
+  }
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto redOp = llvm::cast<triton::ReduceOp>(op);
+    if (!isApproprateReduction(redOp))
+      return failure();
+
+    auto loopOp = dyn_cast<scf::ForOp>(redOp->getParentOp());
+    if (!loopOp)
+      return failure();
+
+    auto matchedDotReduction = matchDotReductionInLoopPattern(redOp);
+    if (!matchedDotReduction.has_value())
+      return failure();
+
+    hoistReductionOps(rewriter, loopOp, matchedDotReduction.value());
+
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+#define GEN_PASS_CLASSES
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+
+class TritonAMDGPUHoistReductionPass
+    : public TritonAMDGPUHoistReductionBase<TritonAMDGPUHoistReductionPass> {
+
+public:
+  TritonAMDGPUHoistReductionPass() = default;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp m = getOperation();
+
+    mlir::RewritePatternSet patterns(context);
+
+    patterns.add<HoistReduction>(context);
+
+    if (applyPatternsAndFoldGreedily(m, std::move(patterns)).failed()) {
+      signalPassFailure();
+    }
+  }
+};
+
+std::unique_ptr<Pass> mlir::createTritonAMDGPUHoistReductionPass() {
+  return std::make_unique<TritonAMDGPUHoistReductionPass>();
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeFMADot.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeFMADot.cpp
@@ -1,0 +1,432 @@
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+using namespace mlir;
+
+namespace {
+
+class OptimizeFMADotPattern : public mlir::RewritePattern {
+
+  int kSplit;
+
+  unsigned choosekSplit(unsigned m, unsigned n, unsigned k, unsigned numWarps,
+                        unsigned numThreads) const {
+    // TODO experiment with this value
+    return std::min(std::min(static_cast<unsigned>(kSplit), k), numThreads);
+  }
+
+  triton::gpu::BlockedEncodingAttr
+  generateNewDotLayout(mlir::MLIRContext *ctx, unsigned m, unsigned n,
+                       unsigned kSplit, unsigned numWarps,
+                       unsigned numThreads) const {
+    assert(kSplit > 0 && kSplit <= numThreads);
+    SmallVector<unsigned> order{2, 1, 0};
+    triton::gpu::CTALayoutAttr ctaLayout =
+        triton::gpu::CTALayoutAttr::get(ctx, {1, 1, 1}, {1, 1, 1}, {2, 1, 0});
+
+    // TODO experiment with M/N first distribution of warps
+    unsigned bWarps = 1;
+    unsigned mWarps = std::min(m, numWarps);
+    unsigned nWarps = numWarps / mWarps;
+    SmallVector<unsigned> warpsPerCTA{bWarps, mWarps, nWarps};
+
+    unsigned bThreads = kSplit;
+    unsigned nThreads = std::min(n / nWarps, numThreads / bThreads);
+    unsigned mThreads = numThreads / bThreads / nThreads;
+    SmallVector<unsigned> threadsPerWarp{bThreads, mThreads, nThreads};
+
+    unsigned bElems = 1;
+    unsigned mElems = std::max(1u, m / (mThreads * mWarps));
+    unsigned nElems = std::max(1u, n / (nThreads * nWarps));
+    SmallVector<unsigned> elemsPerThread{bElems, mElems, nElems};
+
+    auto dotLayout = triton::gpu::BlockedEncodingAttr::get(
+        ctx, elemsPerThread, threadsPerWarp, warpsPerCTA, order, ctaLayout);
+    return dotLayout;
+  }
+
+  static SmallVector<unsigned> splitOrder(ArrayRef<unsigned> origOrder,
+                                          int axis) {
+    SmallVector<unsigned> order;
+    for (int i = 0; i < 2; ++i) {
+      auto idx = origOrder[i];
+      if (idx < axis)
+        order.push_back(idx);
+      else if (idx > axis)
+        order.push_back(idx + 1);
+      else {
+        assert(origOrder[i] == axis);
+        order.push_back(idx + 1);
+        order.push_back(idx);
+      }
+    }
+    return order;
+  }
+
+  std::optional<RankedTensorType> splitTypeDim(RankedTensorType ty, int axis,
+                                               int splitSize,
+                                               Location loc) const {
+    auto origShape = ty.getShape();
+    SmallVector<int64_t> shape{origShape};
+    assert(shape[axis] % splitSize == 0);
+    shape.insert(shape.begin() + axis, splitSize);
+    shape[axis + 1] /= splitSize;
+    Attribute splitLayout;
+    auto origEncoding =
+        cast<triton::gpu::BlockedEncodingAttr>(ty.getEncoding());
+    if (splitSize == 1) {
+      // TODO: investigate why this case is not processed in
+      // inferReshapeOpNoReorderEncoding properly
+      auto ctx = ty.getContext();
+      SmallVector<unsigned> sizePerThread = origEncoding.getSizePerThread();
+      sizePerThread.insert(sizePerThread.begin() + axis, 1);
+      SmallVector<unsigned> threadsPerWarp = origEncoding.getThreadsPerWarp();
+      threadsPerWarp.insert(threadsPerWarp.begin() + axis, 1);
+      SmallVector<unsigned> warpsPerCTA = origEncoding.getWarpsPerCTA();
+      warpsPerCTA.insert(warpsPerCTA.begin() + axis, 1);
+      SmallVector<unsigned> order = splitOrder(origEncoding.getOrder(), axis);
+
+      auto ctaPerCGA = origEncoding.getCTAsPerCGA();
+      ctaPerCGA.insert(ctaPerCGA.begin() + axis, 1);
+      auto ctaSplit = origEncoding.getCTASplitNum();
+      ctaSplit.insert(ctaSplit.begin() + axis, 1);
+      auto ctaOrder = splitOrder(origEncoding.getCTAOrder(), axis);
+      auto ctaLayout =
+          triton::gpu::CTALayoutAttr::get(ctx, ctaPerCGA, ctaSplit, ctaOrder);
+
+      splitLayout = triton::gpu::BlockedEncodingAttr::get(
+          ctx, sizePerThread, threadsPerWarp, warpsPerCTA, order, ctaLayout);
+    } else {
+      auto layoutHelper = llvm::cast<triton::DialectInferLayoutInterface>(
+          &origEncoding.getDialect());
+      auto layoutInferResult = layoutHelper->inferReshapeOpNoReorderEncoding(
+          origShape, origEncoding, shape, splitLayout, loc);
+      if (layoutInferResult.failed())
+        return std::nullopt;
+    }
+
+    auto newType =
+        RankedTensorType::get(shape, ty.getElementType(), splitLayout);
+    return newType;
+  }
+
+  triton::gpu::BlockedEncodingAttr
+  transposeLayout(triton::gpu::BlockedEncodingAttr layout,
+                  ArrayRef<int> permOrder) const {
+    auto ctx = layout.getContext();
+    triton::gpu::CTALayoutAttr ctaLayout =
+        triton::gpu::CTALayoutAttr::get(ctx, {1, 1, 1}, {1, 1, 1}, {2, 1, 0});
+    // TODO adjust this if better performance is possible
+    SmallVector<unsigned> order{2, 1, 0};
+    SmallVector<unsigned> sizePerThread;
+    SmallVector<unsigned> threadsPerWarp;
+    SmallVector<unsigned> warpsPerCTA;
+    for (auto idx : permOrder) {
+      sizePerThread.push_back(layout.getSizePerThread()[idx]);
+      threadsPerWarp.push_back(layout.getThreadsPerWarp()[idx]);
+      warpsPerCTA.push_back(layout.getWarpsPerCTA()[idx]);
+    }
+    return triton::gpu::BlockedEncodingAttr::get(
+        ctx, sizePerThread, threadsPerWarp, warpsPerCTA, order, ctaLayout);
+  }
+
+  triton::gpu::BlockedEncodingAttr
+  convertDotOpBToBlockedLayout(triton::gpu::DotOperandEncodingAttr layout,
+                               int kSize) const {
+    auto parentLayout =
+        cast<triton::gpu::BlockedEncodingAttr>(layout.getParent());
+    auto ctx = layout.getContext();
+    SmallVector<unsigned> sizePerThread(parentLayout.getSizePerThread());
+    sizePerThread[1] = kSize;
+    SmallVector<unsigned> threadsPerWarp(parentLayout.getThreadsPerWarp());
+    auto numWarps = triton::gpu::getNumWarpsPerCTA(parentLayout);
+    auto warpsPerCTA = layout.getWarpsPerCTA();
+    SmallVector<unsigned> order(parentLayout.getOrder());
+    auto ctaLayout = parentLayout.getCTALayout();
+    return triton::gpu::BlockedEncodingAttr::get(
+        ctx, sizePerThread, threadsPerWarp, warpsPerCTA, order, ctaLayout);
+  }
+
+  triton::gpu::BlockedEncodingAttr
+  mergeSlowDimLayoutToFaster(triton::gpu::BlockedEncodingAttr layout,
+                             int slowDim) const {
+    int rank = layout.getOrder().size();
+    assert(slowDim >= 0 && slowDim < rank - 1);
+    assert(slowDim != layout.getOrder()[0]);
+    auto ctx = layout.getContext();
+    SmallVector<unsigned> order;
+    int fasterDim = -1;
+    for (int i = 0; i < rank; ++i) {
+      int dimIdx = layout.getOrder()[i];
+      if (dimIdx > slowDim)
+        order.push_back(dimIdx - 1);
+      if (dimIdx < slowDim)
+        order.push_back(dimIdx);
+      if (dimIdx == slowDim)
+        fasterDim = layout.getOrder()[i - 1];
+    }
+    SmallVector<unsigned> sizePerThread(layout.getSizePerThread());
+    sizePerThread[fasterDim] *= sizePerThread[slowDim];
+    sizePerThread.erase(sizePerThread.begin() + slowDim);
+
+    SmallVector<unsigned> threadsPerWarp(layout.getThreadsPerWarp());
+    threadsPerWarp[fasterDim] *= threadsPerWarp[slowDim];
+    threadsPerWarp.erase(threadsPerWarp.begin() + slowDim);
+
+    SmallVector<unsigned> warpsPerCTA(layout.getWarpsPerCTA());
+    warpsPerCTA[fasterDim] *= warpsPerCTA[slowDim];
+    warpsPerCTA.erase(warpsPerCTA.begin() + slowDim);
+    assert(rank == 3);
+    auto ctaLayout =
+        triton::gpu::CTALayoutAttr::get(ctx, {1, 1}, {1, 1}, {1, 0});
+    return triton::gpu::BlockedEncodingAttr::get(
+        ctx, sizePerThread, threadsPerWarp, warpsPerCTA, order, ctaLayout);
+  }
+
+  mlir::LogicalResult optimizeLargeBOp(mlir::PatternRewriter &rewriter,
+                                       unsigned m, unsigned n, unsigned k,
+                                       triton::DotOp dotOp,
+                                       triton::gpu::ConvertLayoutOp aCvt,
+                                       triton::gpu::ConvertLayoutOp bCvt,
+                                       triton::LoadOp bLoadOp) const {
+    auto loadTy = llvm::cast<RankedTensorType>(bLoadOp.getResult().getType());
+    auto oldBLoadLayout = loadTy.getEncoding();
+    auto ctx = dotOp.getContext();
+    auto cOrigType = dotOp.getC().getType();
+    auto cOrigLayout = llvm::dyn_cast<triton::gpu::BlockedEncodingAttr>(
+        cOrigType.getEncoding());
+    auto dotLoc = dotOp.getLoc();
+    assert(cOrigLayout &&
+           "non-blocked layouts are filtered outside this pattern");
+    unsigned numWarps = triton::gpu::getNumWarpsPerCTA(cOrigLayout);
+    unsigned numThreads = product(triton::gpu::getThreadsPerWarp(cOrigLayout));
+    auto kSplit = choosekSplit(m, n, k, numWarps, numThreads);
+
+    // create new dot output and argument layouts
+    auto cBatchedOpLayout =
+        generateNewDotLayout(ctx, m, n, kSplit, numWarps, numThreads);
+    auto elTy = bCvt.getType().getElementType();
+    auto aBatchedOpLayout = triton::gpu::DotOperandEncodingAttr::get(
+        ctx, 0, cBatchedOpLayout, elTy);
+    auto bBatchedOpLayout = triton::gpu::DotOperandEncodingAttr::get(
+        ctx, 1, cBatchedOpLayout, elTy);
+
+    // create layouts and values related to A operand
+    //
+    // A operand data flow before transformation:
+    //   aOrig (NxK aOrigLayout)   -layout_convert->
+    //         (NxK dot op layout)
+    // After transformation:
+    //   aOrig      (MxK aOrigLayout)         -reshape->
+    //   aExtended  (MxSxK' aExtendedLayout)  -trans->
+    //   aBatched   (SxMxK' aBatchedLayout)   -layout_convert->
+    //   aBatchedOp (SxMxK' aBatchedOpLayout)
+    // "S" in shapes represents kSplit value
+    auto aOrig = aCvt.getSrc();
+    auto aCvtLoc = aCvt.getLoc();
+    auto aOrigLayout = dyn_cast<triton::gpu::BlockedEncodingAttr>(
+        aOrig.getType().getEncoding());
+    if (!aOrigLayout)
+      return failure();
+    auto aOrigType = aOrig.getType();
+    auto optAExtendedType = splitTypeDim(aOrigType, 1, kSplit, aCvtLoc);
+    if (!optAExtendedType.has_value())
+      return failure();
+    auto aExtendedType = optAExtendedType.value();
+    auto aExtendedLayout = llvm::cast<triton::gpu::BlockedEncodingAttr>(
+        aExtendedType.getEncoding());
+    rewriter.setInsertionPoint(aCvt);
+    assert(!triton::gpu::isExpensiveView(aOrig.getType(), aExtendedType));
+    auto aExtended =
+        rewriter.create<triton::ReshapeOp>(aCvtLoc, aExtendedType, aOrig, true);
+    auto aBatchedLayout = transposeLayout(aExtendedLayout, {1, 0, 2});
+    auto aBatchedType =
+        RankedTensorType::get({kSplit, m, k / kSplit}, elTy, aBatchedLayout);
+    auto aBatched = rewriter.create<triton::TransOp>(
+        aCvtLoc, aExtended, ArrayRef<int32_t>({1, 0, 2}));
+    auto aBatchedOpType =
+        RankedTensorType::get({kSplit, m, k / kSplit}, elTy, aBatchedOpLayout);
+    auto aBatchedOp = rewriter.create<triton::gpu::ConvertLayoutOp>(
+        dotLoc, aBatchedOpType, aBatched);
+
+    // create layouts and values related to B operand
+    //
+    // B operand data flow before transformation:
+    //   bOrigAddr, bOrigMask (KxN bOrigLoadLayout) -global load->
+    //   bOrigLoad            (KxN bOrigLoadLayout) -layout_convert->
+    //                        (KxN dot op layout)
+    // After transformation:
+    //   bOrigAddr, bOrigMask (KxN bOrigLoadLayout)    -layout_convert->
+    //   bAddr, bMask         (KxN bLoadLayout)        -global load->
+    //   bLoad                (KxN bLoadLayout)        -reshape->
+    //   bBatched             (SxK'xN bBatchedLayout)  -layout_convert->
+    //   bBatchedOp           (SxK'xN bBatchedOpLayout)
+    auto bOrigAddr = bLoadOp.getPtr();
+    auto bOrigMask = bLoadOp.getMask();
+    auto bLoadLoc = bLoadOp.getLoc();
+
+    auto bBatchedLayout =
+        convertDotOpBToBlockedLayout(bBatchedOpLayout, k / kSplit);
+    auto bLoadLayout = mergeSlowDimLayoutToFaster(bBatchedLayout, 0);
+    auto bLoadElTy = llvm::cast<RankedTensorType>(bLoadOp.getPtr().getType())
+                         .getElementType();
+    rewriter.setInsertionPoint(bLoadOp);
+    auto bAddrType = RankedTensorType::get({k, n}, bLoadElTy, bLoadLayout);
+    auto bAddr = rewriter.create<triton::gpu::ConvertLayoutOp>(
+        bLoadLoc, bAddrType, bOrigAddr);
+    Value bMask;
+    if (bOrigMask) {
+      auto bOrigMaskElTy =
+          cast<RankedTensorType>(bOrigMask.getType()).getElementType();
+      auto bMaskType =
+          RankedTensorType::get({k, n}, bOrigMaskElTy, bLoadLayout);
+      bMask = rewriter.create<triton::gpu::ConvertLayoutOp>(bLoadLoc, bMaskType,
+                                                            bOrigMask);
+    }
+    auto bLoad = rewriter.create<triton::LoadOp>(
+        bLoadLoc, bAddr, bMask, bLoadOp.getCache(), bLoadOp.getEvict(),
+        bLoadOp.getIsVolatile());
+    auto bBatchedType =
+        RankedTensorType::get({kSplit, k / kSplit, n}, elTy, bBatchedLayout);
+    assert(!triton::gpu::isExpensiveView(bLoad.getType(), bBatchedType));
+    auto bBatched =
+        rewriter.create<triton::ReshapeOp>(bLoadLoc, bBatchedType, bLoad, true);
+    auto bBatchedOpType =
+        RankedTensorType::get({kSplit, k / kSplit, n}, elTy, bBatchedOpLayout);
+    assert(!cvtNeedsSharedMemory(bBatchedType, bBatchedOpType));
+    auto bBatchedOp = rewriter.create<triton::gpu::ConvertLayoutOp>(
+        dotLoc, bBatchedOpType, bBatched);
+
+    // create layouts and values related to C operand
+    //
+    // C operand data flow before transformation:
+    //   cOrig (MxN cOrigLayout)
+    // After transformation:
+    //   cOrig      (MxN cOrigLayout)   -reshape->
+    //   cShaped    (1xMxN cOrigLayout) -broadcast->
+    //   cBatched   (SxMxN cOrigLayout) -layout_convert->
+    //   cBatchedOp (SxMxN cLayout)
+    auto cOrig = dotOp.getC();
+    auto cElTy = dotOp.getC().getType().getElementType();
+    auto optCShapedType = splitTypeDim(cOrigType, 0, 1, cOrig.getLoc());
+    if (!optCShapedType.has_value())
+      return failure();
+    auto cShapedType = optCShapedType.value();
+    auto cShapedLayout = cShapedType.getEncoding();
+    rewriter.setInsertionPoint(dotOp);
+    assert(!triton::gpu::isExpensiveView(cOrig.getType(), cShapedType));
+    auto cShaped =
+        rewriter.create<triton::ReshapeOp>(dotLoc, cShapedType, cOrig, false);
+    auto cBatchedType =
+        RankedTensorType::get({kSplit, m, n}, cElTy, cShapedLayout);
+    auto cBatched =
+        rewriter.create<triton::BroadcastOp>(dotLoc, cBatchedType, cShaped);
+    auto cBatchedOpType =
+        RankedTensorType::get({kSplit, m, n}, cElTy, cBatchedOpLayout);
+    auto cBatchedOp = rewriter.create<triton::gpu::ConvertLayoutOp>(
+        dotLoc, cBatchedOpType, cBatched);
+
+    // Create new dot and reduction
+    rewriter.setInsertionPoint(dotOp);
+
+    auto newDot = rewriter.create<triton::DotOp>(
+        dotLoc, aBatchedOp, bBatchedOp, cBatchedOp, dotOp.getInputPrecision(),
+        dotOp.getMaxNumImpreciseAcc());
+
+    auto reduceOp = rewriter.create<triton::ReduceOp>(
+        dotLoc, ArrayRef<Value>{newDot.getD()}, 0);
+    auto reduceConvert =
+        rewriter.replaceOpWithNewOp<triton::gpu::ConvertLayoutOp>(
+            dotOp, cOrigType, reduceOp.getResult());
+
+    auto reduceBody = rewriter.createBlock(&reduceOp.getRegion(), {},
+                                           {cElTy, cElTy}, {dotLoc, dotLoc});
+    auto blockArgs = reduceBody->getArguments();
+    rewriter.setInsertionPoint(reduceBody, reduceBody->begin());
+    Value reduceOperation;
+    if (elTy.isInteger())
+      reduceOperation =
+          rewriter.create<arith::AddIOp>(dotLoc, blockArgs[0], blockArgs[1]);
+    else
+      reduceOperation =
+          rewriter.create<arith::AddFOp>(dotLoc, blockArgs[0], blockArgs[1]);
+    rewriter.create<triton::ReduceReturnOp>(dotLoc, reduceOperation);
+    return success();
+  }
+
+public:
+  explicit OptimizeFMADotPattern(mlir::MLIRContext *context, int kSplit)
+      : mlir::RewritePattern(triton::DotOp::getOperationName(), 1, context),
+        kSplit(kSplit) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto dotOp = cast<triton::DotOp>(op);
+    auto dEncoding = dotOp.getD().getType().getEncoding();
+    if (!llvm::dyn_cast<triton::gpu::BlockedEncodingAttr>(dEncoding))
+      return failure();
+    auto aCvt = dyn_cast_or_null<triton::gpu::ConvertLayoutOp>(
+        dotOp.getA().getDefiningOp());
+    auto bCvt = dyn_cast_or_null<triton::gpu::ConvertLayoutOp>(
+        dotOp.getB().getDefiningOp());
+    auto cOp = dotOp.getC();
+    if (!aCvt || !bCvt)
+      return mlir::failure();
+    auto cShape = cOp.getType().getShape();
+    auto aShape = aCvt.getType().getShape();
+    if (cShape.size() != 2)
+      return mlir::failure();
+    unsigned m = cShape[0];
+    unsigned n = cShape[1];
+    unsigned k = aShape[1];
+    // TODO: Think of better heuristic
+    if (m > 8 || n < 8)
+      return failure();
+
+    auto loadOp =
+        llvm::dyn_cast_or_null<triton::LoadOp>(bCvt.getSrc().getDefiningOp());
+    if (!loadOp)
+      return mlir::failure();
+    return optimizeLargeBOp(rewriter, m, n, k, dotOp, aCvt, bCvt, loadOp);
+  }
+};
+
+} // namespace
+
+#define GEN_PASS_CLASSES
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+
+class TritonAMDGPUOptimizeFMADotPass
+    : public TritonAMDGPUOptimizeFMADotBase<TritonAMDGPUOptimizeFMADotPass> {
+
+public:
+  TritonAMDGPUOptimizeFMADotPass() = default;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp m = getOperation();
+    mlir::RewritePatternSet patterns(context);
+
+    patterns.add<OptimizeFMADotPattern>(context, this->kSplit);
+
+    if (applyPatternsAndFoldGreedily(m, std::move(patterns)).failed()) {
+      signalPassFailure();
+    }
+  }
+};
+
+std::unique_ptr<Pass> mlir::createTritonAMDGPUOptimizeFMADotPass() {
+  return std::make_unique<TritonAMDGPUOptimizeFMADotPass>();
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeFMADot.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeFMADot.cpp
@@ -317,17 +317,10 @@ class OptimizeFMADotPattern : public mlir::RewritePattern {
     //   cShaped    (1xMxN cOrigLayout) -broadcast->
     //   cBatched   (SxMxN cOrigLayout) -layout_convert->
     //   cBatchedOp (SxMxN cLayout)
-    TypedAttr zeroValueAttr;
     auto cElTy = dotOp.getC().getType().getElementType();
     auto cBatchedOpType =
-        RankedTensorType::get({splitK, m, n}, cElTy, cBatchedOpLayout);
-    if (cElTy.isInteger()) {
-      // zeroValueAttr = rewriter.getIntegerAttr(cElTy, 0);
-      zeroValueAttr = mlir::DenseIntElementsAttr::get(cBatchedOpType, 0);
-    } else {
-      // zeroValueAttr = rewriter.getFloatAttr(cElTy, 0);
-      zeroValueAttr = mlir::DenseFPElementsAttr::get(cBatchedOpType, 0.0f);
-    }
+        RankedTensorType::get({kSplit, m, n}, cElTy, cBatchedOpLayout);
+    TypedAttr zeroValueAttr = rewriter.getZeroAttr(cBatchedOpType);
     Value cBatchedOp = rewriter.create<arith::ConstantOp>(
         dotLoc, cBatchedOpType, zeroValueAttr);
 

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -58,6 +58,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
                      mlir::createTritonAMDGPUOptimizeEpiloguePass);
   ADD_PASS_WRAPPER_0("add_canonicalize_pointers",
                      mlir::createTritonAMDGPUCanonicalizePointersPass);
+  ADD_PASS_WRAPPER_0("add_optimize_fma_dot",
+                     mlir::createTritonAMDGPUOptimizeFMADotPass);
   ADD_PASS_WRAPPER_0("add_reorder_instructions",
                      mlir::createTritonAMDGPUReorderInstructionsPass);
   ADD_PASS_WRAPPER_0("add_stream_pipeline",

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -54,6 +54,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_3("add_accelerate_matmul",
                      mlir::createTritonAMDGPUAccelerateMatmulPass,
                      const std::string, int, int);
+  ADD_PASS_WRAPPER_0("add_hoist_reduction",
+                     mlir::createTritonAMDGPUHoistReductionPass);
   ADD_PASS_WRAPPER_0("add_optimize_epilogue",
                      mlir::createTritonAMDGPUOptimizeEpiloguePass);
   ADD_PASS_WRAPPER_0("add_canonicalize_pointers",

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -15,7 +15,16 @@ from pathlib import Path
 
 
 def min_dot_size(target: GPUTarget):
-    return lambda lhsType, rhsType: (16, 32, 16) if lhsType.is_int8() else (16, 16, 16)
+
+    def fma_supported(lhsType, rhsType):
+        return lhsType == rhsType and (lhsType.is_fp16() or lhsType.is_fp32())
+
+    def limits(lhsType, rhsType):
+        if fma_supported(lhsType.scalar, rhsType.scalar):
+            return (1, 1, 1)
+        return (16, 16, 16)
+
+    return limits
 
 
 @functools.lru_cache()

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2.cpp
@@ -743,23 +743,6 @@ MemDescType getExpandedDesc(MemDescType descTy) {
   return expandedDesc;
 }
 
-SharedMemoryObject
-getExpandedSharedMemoryObject(ConversionPatternRewriter &rewriter, Location loc,
-                              SharedMemoryObject smemObj,
-                              ArrayRef<int64_t> shape) {
-  auto strides = smemObj.getStrides();
-  auto offsets = smemObj.getOffsets();
-  auto rank = strides.size();
-  if (rank == 3)
-    return smemObj;
-  auto expandedStrides = insertValue(strides, 0, i32_val(shape[0] * shape[1]));
-  auto expandedOffsets = insertValue(offsets, 0, i32_val(0));
-  auto expandedSmemObj =
-      SharedMemoryObject(smemObj.getBase(), smemObj.getBaseElemType(),
-                         expandedStrides, expandedOffsets);
-  return expandedSmemObj;
-}
-
 namespace SharedToDotOperandMMAv2 {
 Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
                     Location loc, Value tensor, DotOperandEncodingAttr encoding,


### PR DESCRIPTION
This PR
- Introduces several fixes in FMA dot implementation
- Enables support of small dots with MNK dimensions down to 1
- Introduces dot operand optimization for dots with small M(<=8), large N and K dimensions
- Introduces generation of v_dot2/v_dot4 instructions for AMD backend

These changes are needed to reduce granularity loss on dots with small M or N dimension, like (1x256)x(256x64)