### PR TITLE
Implementation of Computation Pipelining

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -84,8 +84,10 @@ public:
     return true;
   }
 
-  void insertDepsOfOp(Operation *op, int stage, CoarseSchedule::Cluster cluster,
-                      bool includeArg);
+  void
+  insertDepsOfOp(Operation *op, int stage, CoarseSchedule::Cluster cluster,
+                 bool includeArg,
+                 DenseMap<Operation *, Operation *> *additionalDep = nullptr);
 
   void erase(Operation *op) { opToStageAndCluster.erase(op); }
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -56,7 +56,8 @@ static void createAsyncCopy(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
                             tt::CoarseSchedule &schedule,
                             tt::CoarseSchedule::Cluster prefetchCluster,
                             llvm::MapVector<Operation *, LoadInfo> &loadToInfo,
-                            int numStages) {
+                            int numStages,
+                            DenseMap<Operation *, Operation *> &TMAUserToWait) {
   OpBuilder builder(forOp);
   Value zero = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 0, 32);
   // Replace the load with insert/extract slice.
@@ -113,6 +114,7 @@ static void createAsyncCopy(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
   loadOffsets[0] = extractIdx;
   auto viewLoad =
       builder.create<ttg::MemDescSubviewOp>(loc, subviewTy, alloc, loadOffsets);
+  TMAUserToWait[viewLoad] = wait; // viewLoad will depend on barrierWait
   if (isMMV3Load) {
     auto alloc = cast<ttg::LocalAllocOp>((*loadOp->getUsers().begin()));
     replaceUsesAndPropagateType(builder, alloc, viewLoad.getResult());
@@ -157,7 +159,8 @@ static void createTMAAsyncCopy(
     scf::ForOp &forOp, tt::ExperimentalDescriptorLoadOp loadOp, Value alloc,
     Value insertIdx, Value extractIdx, Value barrier, Operation *waitOp,
     Value phase, tt::CoarseSchedule &schedule,
-    llvm::MapVector<Operation *, LoadInfo> &loadToInfo, int numStages) {
+    llvm::MapVector<Operation *, LoadInfo> &loadToInfo, int numStages,
+    DenseMap<Operation *, Operation *> &TMAUserToWait) {
   assert(phase && "Phase value is required for TMA async copy.");
   OpBuilder builder(forOp);
   Attribute sharedMemorySpace =
@@ -189,6 +192,7 @@ static void createTMAAsyncCopy(
   loadOffsets[0] = extractIdx;
   auto viewLoad =
       builder.create<ttg::MemDescSubviewOp>(loc, subviewTy, alloc, loadOffsets);
+  TMAUserToWait[viewLoad] = waitOp; // viewLoad will depend on barrierWait
   if (isMMV3Load) {
     auto alloc = cast<ttg::LocalAllocOp>((*loadOp->getUsers().begin()));
     replaceUsesAndPropagateType(builder, alloc, viewLoad.getResult());
@@ -661,8 +665,10 @@ schedulePrologueAndEpilogue(scf::ForOp forOp, tt::CoarseSchedule &schedule,
 
 // Add dependencies of anchor ops to the coarse schedule. Schedule them to
 // the same stage and ordering cluster as the anchor op.
-static void scheduleDependencies(scf::ForOp forOp, tt::CoarseSchedule &schedule,
-                                 int numStages) {
+static void
+scheduleDependencies(scf::ForOp forOp, tt::CoarseSchedule &schedule,
+                     int numStages,
+                     DenseMap<Operation *, Operation *> &TMAUserToWait) {
   SmallVector<std::tuple<Operation *, int, tt::CoarseSchedule::Cluster>>
       opsInOrder = schedule.getOpsInOrder(forOp);
   // Schedule dependencies stage by stage.
@@ -670,7 +676,7 @@ static void scheduleDependencies(scf::ForOp forOp, tt::CoarseSchedule &schedule,
     for (auto [op, stage_, cluster] : opsInOrder) {
       if (stage_ != stage)
         continue;
-      schedule.insertDepsOfOp(op, stage, cluster, false);
+      schedule.insertDepsOfOp(op, stage, cluster, false, &TMAUserToWait);
     }
   }
 }
@@ -827,7 +833,7 @@ struct AsyncLoad {
 };
 
 // Create barriers and wait ops for the async loads. Barriers may be shared by
-// multiple loads is the schedule allows it.
+// multiple loads if the schedule allows it.
 static void createTMABarrierAndWait(
     scf::ForOp &forOp, SmallVector<AsyncLoad> &asyncLoads, Value insertIdx,
     Value extractIdx, Value phase, int numBuffers, tt::CoarseSchedule &schedule,
@@ -935,7 +941,8 @@ static void createTMABarrierAndWait(
 static SmallVector<Value>
 createAsyncOps(scf::ForOp &forOp, tt::CoarseSchedule &schedule,
                llvm::MapVector<Operation *, LoadInfo> &loadToInfo,
-               SmallVector<Value> &barriers, int numStages) {
+               SmallVector<Value> &barriers, int numStages,
+               DenseMap<Operation *, Operation *> &TMAUserToWait) {
   // Calculate the number of buffers needed for each load.
   // TODO pawel: we could do more fine-grained allocation here and
   // allocate only the number of buffers that specific loads need.
@@ -1026,12 +1033,13 @@ createAsyncOps(scf::ForOp &forOp, tt::CoarseSchedule &schedule,
   for (AsyncLoad &asyncLoad : asyncLoads) {
     if (auto loadOp = dyn_cast<tt::LoadOp>(asyncLoad.loadOp)) {
       createAsyncCopy(forOp, loadOp, asyncLoad.alloc, insertIdx, extractIdx,
-                      schedule, prefetchCluster, loadToInfo, numStages);
+                      schedule, prefetchCluster, loadToInfo, numStages,
+                      TMAUserToWait);
     } else {
       auto descLoad = cast<tt::ExperimentalDescriptorLoadOp>(asyncLoad.loadOp);
       createTMAAsyncCopy(forOp, descLoad, asyncLoad.alloc, insertIdx,
                          extractIdx, asyncLoad.barrier, asyncLoad.waitOp, phase,
-                         schedule, loadToInfo, numStages);
+                         schedule, loadToInfo, numStages, TMAUserToWait);
     }
   }
   SmallVector<Value> newYieldOperands = {insertIdx, extractIdx};
@@ -1080,9 +1088,10 @@ bool mlir::triton::preProcessLoopAndGetSchedule(
   });
 
   SmallVector<Value> barriers;
+  DenseMap<Operation *, Operation *> TMAUserToWait;
   // Convert the loads into async loads and create the allocs.
-  SmallVector<Value> allocs =
-      createAsyncOps(forOp, coarseSchedule, loadToInfo, barriers, numStages);
+  SmallVector<Value> allocs = createAsyncOps(
+      forOp, coarseSchedule, loadToInfo, barriers, numStages, TMAUserToWait);
 
   LLVM_DEBUG({
     LDBG("Coarse schedule with async loads:");
@@ -1096,7 +1105,7 @@ bool mlir::triton::preProcessLoopAndGetSchedule(
     coarseSchedule.dump();
   });
 
-  scheduleDependencies(forOp, coarseSchedule, numStages);
+  scheduleDependencies(forOp, coarseSchedule, numStages, TMAUserToWait);
   LLVM_DEBUG({
     LDBG("Coarse schedule with dependencies:");
     coarseSchedule.dump();

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -74,6 +74,9 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
     return op;
   }
 
+  if (isa<ttng::WarpGroupDotOp>(op))
+    return op;
+
   assert("don't know how to predicate this op" && false);
   return op;
 }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -76,6 +76,13 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
 
   if (isa<ttng::WarpGroupDotOp>(op))
     return op;
+  if (auto wait = dyn_cast<ttng::WaitBarrierOp>(op)) {
+    rewriter.setInsertionPoint(wait);
+    auto ifOp =
+        rewriter.create<scf::IfOp>(wait->getLoc(), pred, /*else=*/false);
+    rewriter.moveOpBefore(wait, ifOp.thenBlock(), ifOp.thenBlock()->begin());
+    return ifOp;
+  }
 
   assert("don't know how to predicate this op" && false);
   return op;

--- a/test/TritonGPU/comp-pipeline.mlir
+++ b/test/TritonGPU/comp-pipeline.mlir
@@ -27,10 +27,10 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 8 :
     %30 = arith.extsi %arg17 : i32 to i64
     // CHECK: tt.experimental_descriptor_load
     // CHECK: %[[QLOC:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<128x128xf16
-    // CHECK: %[[KLOC:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<4x128x128xf16
-    // CHECK: %[[VLOC:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<4x128x128xf16
-    // CHECK: %[[KBAR:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<4xi64
-    // CHECK: %[[VBAR:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<4xi64
+    // CHECK: %[[KLOC:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<3x128x128xf16
+    // CHECK: %[[VLOC:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<3x128x128xf16
+    // CHECK: %[[KBAR:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<3xi64
+    // CHECK: %[[VBAR:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<3xi64
     // stage 0 iteration 0
     // CHECK: %[[K0:.+]] = triton_gpu.memdesc_subview %[[KLOC]][%c0_i32, %c0_i32, %c0_i32]
     // CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local{{.*}} %[[K0]]

--- a/test/TritonGPU/comp-pipeline.mlir
+++ b/test/TritonGPU/comp-pipeline.mlir
@@ -1,0 +1,101 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-pipeline=num-stages=4 -debug-only=triton-matmul-loop-pipeline 2>&1 | FileCheck %s --check-prefix=DEBUG
+// RUN: triton-opt %s -split-input-file -tritongpu-pipeline=num-stages=4 | FileCheck %s
+
+// DEBUG: Final coarse schedule:
+// DEBUG: Ops in stage 2
+// DEBUG: triton_nvidia_gpu.warp_group_dot
+// DEBUG: Ops in stage 3
+// DEBUG: triton_nvidia_gpu.wait_barrier
+// DEBUG: triton_nvidia_gpu.wait_barrier
+// DEBUG: Original loop:
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 4], order = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 128, 16]}>
+#shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = true}>
+#shared1 = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [0, 1], hasLeadingOffset = true}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 8 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @_attn_fwd_tma(%arg3: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg6: f32, %arg8: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg9: i32, %arg10: i32, %arg11: i64, %arg14: i32 {tt.divisibility = 16 : i32}, %arg17: i32 {tt.divisibility = 16 : i32}, %arg23: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %cst_2 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
+    %25 = tt.experimental_descriptor_load %arg3[%arg9, %c0_i32] : !tt.ptr<i8> -> tensor<128x128xf16, #blocked1>
+    %26 = triton_gpu.local_alloc %25 : (tensor<128x128xf16, #blocked1>) -> !tt.memdesc<128x128xf16, #shared, #triton_gpu.shared_memory>
+    %27 = arith.extsi %arg14 : i32 to i64
+    %28 = tt.splat %arg6 : f32 -> tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+    %29 = tt.splat %arg6 : f32 -> tensor<128x128xf32, #mma>
+    %30 = arith.extsi %arg17 : i32 to i64
+    // CHECK: tt.experimental_descriptor_load
+    // CHECK: %[[QLOC:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<128x128xf16
+    // CHECK: %[[KLOC:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<4x128x128xf16
+    // CHECK: %[[VLOC:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<4x128x128xf16
+    // CHECK: %[[KBAR:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<4xi64
+    // CHECK: %[[VBAR:.+]] = triton_gpu.local_alloc {{.*}}tt.memdesc<4xi64
+    // stage 0 iteration 0
+    // CHECK: %[[K0:.+]] = triton_gpu.memdesc_subview %[[KLOC]][%c0_i32, %c0_i32, %c0_i32]
+    // CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local{{.*}} %[[K0]]
+    // stage 0 iteration 1
+    // CHECK: %[[K1:.+]] = triton_gpu.memdesc_subview %[[KLOC]][%c1_i32, %c0_i32, %c0_i32]
+    // CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local{{.*}} %[[K1]]
+    // stage 1 iteration 0
+    // CHECK: %[[V0:.+]] = triton_gpu.memdesc_subview %[[VLOC]][%c0_i32, %c0_i32, %c0_i32]
+    // CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local{{.*}} %[[V0]]
+    // stage 2 iteration 0
+    // CHECK: %[[FIRSTDOT:.+]] = triton_nvidia_gpu.warp_group_dot
+    // stage 0 iteration 2
+    // CHECK: %[[K2:.+]] = triton_gpu.memdesc_subview %[[KLOC]][%c2_i32, %c0_i32, %c0_i32]
+    // CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local{{.*}} %[[K2]]
+    // stage 1 iteration 1
+    // CHECK: %[[V1:.+]] = triton_gpu.memdesc_subview %[[VLOC]][%c1_i32, %c0_i32, %c0_i32]
+    // CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local{{.*}} %[[V1]]
+    // CHECK: scf.for {{.*}} %[[ARG:.+]] = %[[FIRSTDOT]]
+    // CHECK: %[[KBARSUB:.+]] = triton_gpu.memdesc_subview %[[KBAR]][%[[KBARIDX:.+]]]
+    // CHECK: triton_nvidia_gpu.wait_barrier %[[KBARSUB]]
+    // CHECK: %[[KLOOP:.+]] = triton_gpu.memdesc_subview %[[KLOC]]
+    // CHECK: tt.trans %[[KLOOP]]
+    // CHECK: %[[FIRSTDOTLOOP:.+]] = triton_nvidia_gpu.warp_group_dot
+    // CHECK: %[[WAIT:.+]]:{{[0-9]+}} = triton_nvidia_gpu.warp_group_dot_wait
+    // CHECK: "tt.reduce"(%[[ARG]])
+    // CHECK: %[[VBARSUB:.+]] = triton_gpu.memdesc_subview %[[VBAR]][%[[KBARIDX]]]
+    // CHECK: triton_nvidia_gpu.wait_barrier %[[VBARSUB]]
+    // CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local
+    // CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local
+    // CHECK: scf.yield {{.*}}%[[WAIT]]#0
+    // arg26 is acc
+    %31:1 = scf.for %arg24 = %c0_i32 to %arg23 step %c128_i32 iter_args(%arg26 = %cst_2) -> (tensor<128x128xf32, #mma>)  : i32 {
+      %48 = arith.divsi %arg11, %27 : i64
+      %49 = arith.trunci %48 : i64 to i32
+      %50 = arith.addi %arg24, %49 : i32
+      // loads in different stages
+      %51 = tt.experimental_descriptor_load %arg4[%50, %c0_i32] {loop.stage = 0 : i32} : !tt.ptr<i8> -> tensor<128x128xf16, #blocked1>
+      %52 = triton_gpu.local_alloc %51 : (tensor<128x128xf16, #blocked1>) -> !tt.memdesc<128x128xf16, #shared, #triton_gpu.shared_memory>
+      %53 = tt.trans %52 {order = array<i32: 1, 0>} : !tt.memdesc<128x128xf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x128xf16, #shared1, #triton_gpu.shared_memory>
+      %54 = triton_nvidia_gpu.warp_group_dot %26, %53, %cst_2 {inputPrecision = 0 : i32, loop.stage = 2} : !tt.memdesc<128x128xf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x128xf16, #shared1, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
+      %55 = "tt.reduce"(%54) <{axis = 1 : i32}> ({
+      ^bb0(%arg28: f32 loc(unknown), %arg29: f32 loc(unknown)):
+        %80 = arith.maxnumf %arg28, %arg29 : f32
+        tt.reduce.return %80 : f32
+      }) : (tensor<128x128xf32, #mma>) -> tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+      %56 = arith.mulf %55, %28 : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+      %58 = arith.mulf %54, %29 : tensor<128x128xf32, #mma>
+      %59 = tt.expand_dims %56 {axis = 1 : i32} : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>> -> tensor<128x1xf32, #mma>
+      %60 = tt.broadcast %59 : tensor<128x1xf32, #mma> -> tensor<128x128xf32, #mma>
+      %61 = arith.subf %58, %60 : tensor<128x128xf32, #mma>
+      %62 = math.exp2 %61 : tensor<128x128xf32, #mma>
+      %71 = arith.divsi %arg11, %30 : i64
+      %72 = arith.extsi %arg24 : i32 to i64
+      %73 = arith.addi %71, %72 : i64
+      %74 = arith.trunci %73 : i64 to i32
+      %75 = tt.experimental_descriptor_load %arg5[%74, %c0_i32] {loop.stage = 1 : i32} : !tt.ptr<i8> -> tensor<128x128xf16, #blocked1>
+      %76 = triton_gpu.local_alloc %75 : (tensor<128x128xf16, #blocked1>) -> !tt.memdesc<128x128xf16, #shared, #triton_gpu.shared_memory>
+      %77 = arith.truncf %62 : tensor<128x128xf32, #mma> to tensor<128x128xf16, #mma>
+      %78 = triton_gpu.convert_layout %77 : tensor<128x128xf16, #mma> -> tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>>
+      %79 = triton_nvidia_gpu.warp_group_dot %78, %76, %arg26 {inputPrecision = 0 : i32, loop.stage = 3 : i32} : tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>> * !tt.memdesc<128x128xf16, #shared, #triton_gpu.shared_memory> -> tensor<128x128xf32, #mma>
+      scf.yield %79 : tensor<128x128xf32, #mma>
+    } {tt.divisibility_arg1 = dense<128> : tensor<1xi32>}
+    %42 = arith.truncf %31#0 : tensor<128x128xf32, #mma> to tensor<128x128xf16, #mma>
+    %43 = triton_gpu.convert_layout %42 : tensor<128x128xf16, #mma> -> tensor<128x128xf16, #blocked1>
+    tt.experimental_descriptor_store %arg8[%arg10, %c0_i32], %43 : !tt.ptr<i8>, tensor<128x128xf16, #blocked1>
+    tt.return
+  }
+}

--- a/test/TritonGPU/comp-pipeline.mlir
+++ b/test/TritonGPU/comp-pipeline.mlir
@@ -3,9 +3,9 @@
 
 // DEBUG: Final coarse schedule:
 // DEBUG: Ops in stage 2
-// DEBUG: triton_nvidia_gpu.warp_group_dot
+// DEBUG-DAG: triton_nvidia_gpu.wait_barrier
+// DEBUG-DAG: triton_nvidia_gpu.warp_group_dot
 // DEBUG: Ops in stage 3
-// DEBUG: triton_nvidia_gpu.wait_barrier
 // DEBUG: triton_nvidia_gpu.wait_barrier
 // DEBUG: Original loop:
 
@@ -50,13 +50,14 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 8 :
     // CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local{{.*}} %[[V1]]
     // CHECK: scf.for {{.*}} %[[ARG:.+]] = %[[FIRSTDOT]]
     // CHECK: %[[KBARSUB:.+]] = triton_gpu.memdesc_subview %[[KBAR]][%[[KBARIDX:.+]]]
+    // CHECK: scf.if
     // CHECK: triton_nvidia_gpu.wait_barrier %[[KBARSUB]]
     // CHECK: %[[KLOOP:.+]] = triton_gpu.memdesc_subview %[[KLOC]]
     // CHECK: tt.trans %[[KLOOP]]
     // CHECK: %[[FIRSTDOTLOOP:.+]] = triton_nvidia_gpu.warp_group_dot
     // CHECK: %[[WAIT:.+]]:{{[0-9]+}} = triton_nvidia_gpu.warp_group_dot_wait
     // CHECK: "tt.reduce"(%[[ARG]])
-    // CHECK: %[[VBARSUB:.+]] = triton_gpu.memdesc_subview %[[VBAR]][%[[KBARIDX]]]
+    // CHECK: %[[VBARSUB:.+]] = triton_gpu.memdesc_subview %[[VBAR]]
     // CHECK: triton_nvidia_gpu.wait_barrier %[[VBARSUB]]
     // CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local
     // CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local


### PR DESCRIPTION
Summary:
The idea of computation pipelining comes from FA3 paper. The goal is to divide computation ops into stages and to overlap ops that use cuda core with ops that use tensor core.

Use flash attention with num_stages=3 as an example, currently the two loads are in stage 0 (S0), all other ops are in the last stage (stage 2). The loop body will look like
S2(i)      S2(i+1) S2(i+2)
S0(i+2) S0(i+3) S0(i+4)
With computation pipelining enabled, we can put the load for the first dot in S0, the load for the second dot in S1, the first dot in S2, and the rest in S3. The loop body will look like
S2(i+1) S2(i+2) S2(i+3)
S3(i)     S3(i+1) S3(i+2)
S0(i+3) S0(i+4) S0(i+5)
S1(i+2) S1(i+3) S1(i+4)

Note that the distance between the load and the corresponding usage stays the same (i.e 2 stages from the load of k in S0(i+3) to the use in S2(i+3), 2 stages from the load of v in S1(i+2) to the use in S3(i+2)), number of buffers stays at 3. The live range for output of S2 is increased to span the loop (i.e from S2(i+1) to S3(i+1)).

Details:
SWP_FIRST_DOT: move first dot in numStages - 2 instead of numStages - 1
--> for this to work, we need to support predicate on barrier_wait or use PEEL_EPILOGUE
LOAD_DIFFERENT_STAGE: put two loads in two different stages
FIRST_USE_OF_LOAD: only consider the first use of each load, for example load of k is used by the first dot and indirectly used by the 2nd dot, but we should only consider the use by the first dot to calculate the use distance.

For both createAsyncCopy and createTMAAsyncCopy, update TMAUserToWait so there will be an extra dependency from the view of the load to the barrier_wait op:
TMAUserToWait[viewLoad] = waitOp; // viewLoad will depend on barrierWait
In scheduleDependencies, waitOp will be added to the same stage/cluster as viewLoad.

LOAD_DIFFERENT_STAGE=1 FIRST_LOAD_OF_USE=1 SWP_FIRST_DOT=1 together with a TMA variant of FA (https://github.com/pytorch/benchmark/pull/2379) seems to improve performance for headDim 128 and 256.

This implementation is kind of specific to flash attention, and needs rework. We can make it more general by adding a dependency analyzer that analyzes dependency and resource usages of ttgir ops, decides how to break ops into stages, and feeds the decisions to SWP. Another less general option is to only support num_computation_stage being 2 (i.e separate computation ops into two stages). In this restricted form, lifting the first dot into its own stage seems reasonable.

Open to discussions and reworks.
