### PR TITLE
Fix an issue in DeadArgElim where we fail to mark condition op of scf.if as live

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -896,6 +896,8 @@ struct ForOpDeadArgElimination : public OpRewritePattern<scf::ForOp> {
       }
       if (auto nestedIf = value.getDefiningOp<scf::IfOp>()) {
         auto result = mlir::cast<OpResult>(value);
+        // mark condition as live.
+        markLive(nestedIf.getCondition());
         for (scf::YieldOp nestedYieldOp :
              {nestedIf.thenYield(), nestedIf.elseYield()}) {
           Value nestedYieldOperand =


### PR DESCRIPTION
Summary: When scf.if is marked as live in ForOpDeadArgElim, we should mark its condition as live too. Without this fix, with the test case added in this patch, the scf.if will be removed.
