### PR TITLE
[Backend][AMD] Use common target ISA utils in AccelerateAMDMatmul

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -665,10 +665,12 @@ public:
     case ISAFamily::CDNA3:
       patterns.add<::BlockedToMFMA>(context, getMfmaVersion(isaFamily),
                                     matrixInstructionSize, kPack);
+      break;
     case ISAFamily::RDNA1:
     case ISAFamily::RDNA2:
     case ISAFamily::RDNA3:
       patterns.add<::BlockedToWMMA>(context);
+      break;
     default:
       break;
     }


### PR DESCRIPTION
This commit changes the AccelerateAMDMatmul pass to use common target utils to avoid duplication.

While here, cleaned up `using` namespaces and symbols.
