### PR TITLE
setup.py: introduce TRITON_OFFLINE_BUILD

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -113,6 +113,22 @@ def get_env_with_keys(key: list):
     return ""
 
 
+def is_offline_build() -> bool:
+    """
+    Downstream projects and distributions which bootstrap their own dependencies from scratch
+    and run builds in offline sandboxes
+    may set `TRITON_OFFLINE_BUILD` in the build environment to prevent any attempts at downloading
+    pinned dependencies from the internet or at using dependencies vendored in-tree.
+
+    Dependencies must be defined using respective search paths (cf. `syspath_var_name` in `Package`).
+    Missing dependencies lead to an early abortion.
+    Dependencies' compatibility is not verified.
+
+    Note that this flag isn't tested by the CI and does not provide any guarantees.
+    """
+    return os.environ.get("TRITON_OFFLINE_BUILD", "") != ""
+
+
 # --- third party packages -----
 
 
@@ -220,8 +236,14 @@ def get_thirdparty_packages(packages: list):
         if os.environ.get(p.syspath_var_name):
             package_dir = os.environ[p.syspath_var_name]
         version_file_path = os.path.join(package_dir, "version.txt")
-        if p.syspath_var_name not in os.environ and\
-           (not os.path.exists(version_file_path) or Path(version_file_path).read_text() != p.url):
+
+        input_defined = p.syspath_var_name not in os.environ
+        input_exists = input_defined and os.path.exists(version_file_path)
+        input_compatible = input_exists and Path(version_file_path).read_text() == p.url
+
+        if is_offline_build() and not input_defined:
+            raise RuntimeError(f"Requested an offline build but {p.syspath_var_name} is not set")
+        if not is_offline_build() and not input_compatible:
             with contextlib.suppress(Exception):
                 shutil.rmtree(package_root_dir)
             os.makedirs(package_root_dir, exist_ok=True)
@@ -245,6 +267,8 @@ def get_thirdparty_packages(packages: list):
 
 
 def download_and_copy(name, src_path, variable, version, url_func):
+    if is_offline_build():
+        return
     triton_cache_path = get_triton_cache_path()
     if variable in os.environ:
         return


### PR DESCRIPTION
In e.g. Nixpkgs (probably in other similar distributions as well) it's important to be able to inject dependencies rather than use vendored/locked dependencies. When we fail to provide complete dependencies for triton we want to get an immediate error, rather than an attempt to download a substitute from the internet (which fails after a timeout anyway, because we the actual builds offline). Sometimes we'd also try to override a recipe with a different version of a dependency than declared upstream, so e.g. we tend to treat strict semantic version checking as an optional feature.

This PR proposes an additional boolean environment variable meant to disable vendoring and fetching attempts in favour of either an immediate error ("input declared but not defined") or a later compile/link time error.

I'm happy to maintain a patch on the Nixpkgs side as well if you think this doesn't belong in your repo.

I'm waiting for the builds to finish.

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
