### PR TITLE
[CI][AMD] Update docker image to use PyTorch 2.4

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -298,7 +298,7 @@ jobs:
         runner: ${{fromJson(needs.Runner-Preparation.outputs.matrix-HIP)}}
     name: Integration-Tests (${{matrix.runner[1] == 'gfx90a' && 'mi210' || 'mi300x'}})
     container:
-      image: rocm/pytorch:rocm6.1_ubuntu22.04_py3.10_pytorch_2.1.2
+      image: rocm/pytorch:rocm6.1_ubuntu22.04_py3.10_pytorch_2.4
       options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --user root
     steps:
       - name: Checkout

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -346,7 +346,7 @@ jobs:
     name: Integration-Tests (${{matrix.runner[1] == 'gfx90a' && 'mi210' || 'mi300x'}})
 
     container:
-      image: rocm/pytorch:rocm6.1_ubuntu22.04_py3.10_pytorch_2.1.2
+      image: rocm/pytorch:rocm6.1_ubuntu22.04_py3.10_pytorch_2.4
       options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --user root
 
     steps:


### PR DESCRIPTION
PyTorch 2.4 was officially released on July 24, 2024: https://pytorch.org/blog/pytorch2-4/.

This makes sure we pick up the latest features in
PyTorch in the CI.