### PR TITLE
[ANALYSIS] Fixed an infinite loop for Membar pass

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -11,7 +11,6 @@ namespace mlir {
 class OpBuilder;
 
 struct BlockInfo {
-  using BufferIdSetT = Allocation::BufferIdSetT;
   using IntervalSetT = std::set<Interval<size_t>>;
 
   IntervalSetT syncReadIntervals;

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -43,7 +43,6 @@ void MembarAnalysis::resolve(FunctionOpInterface funcOp,
   while (!blockList.empty()) {
     auto *block = blockList.front();
     blockList.pop_front();
-    // llvm::errs() << "block: " << block << "\n";
     //  Make a copy of the inputblockInfo but not update
     auto inputBlockInfo = inputBlockInfoMap[block];
     SmallVector<Block *> successors;
@@ -61,36 +60,10 @@ void MembarAnalysis::resolve(FunctionOpInterface funcOp,
       // the outputBlockInfo, we skip the successors
       continue;
     }
-    //// Update the current block
-    // llvm::errs() << "input writes: " <<
-    // inputBlockInfo.syncWriteIntervals.size() << "\n"; for (auto &interval :
-    // inputBlockInfo.syncWriteIntervals) {
-    //   llvm::errs() << "write: [" << interval.start() << ", " <<
-    //   interval.end() << "]\n";
-    // }
-    // llvm::errs() << "input reads: " <<
-    // inputBlockInfo.syncReadIntervals.size() << "\n"; for (auto &interval :
-    // inputBlockInfo.syncReadIntervals) {
-    //   llvm::errs() << "read: [" << interval.start() << ", " << interval.end()
-    //   << "]\n";
-    // }
+    // Update the current block
     outputBlockInfoMap[block].join(inputBlockInfo);
-    // llvm::errs() << "output reads: " <<
-    // outputBlockInfoMap[block].syncReadIntervals.size() << "\n"; for (auto
-    // &interval : outputBlockInfoMap[block].syncReadIntervals) {
-    //   llvm::errs() << "read: [" << interval.start() << ", " << interval.end()
-    //   << "]\n";
-    // }
-    // llvm::errs() << "output writes: " <<
-    // outputBlockInfoMap[block].syncWriteIntervals.size() << "\n"; for (auto
-    // &interval : outputBlockInfoMap[block].syncWriteIntervals) {
-    //   llvm::errs() << "write: [" << interval.start() << ", " <<
-    //   interval.end() << "]\n";
-    // }
     //  Update the successors
     for (auto *successor : successors) {
-      if (successor == block)
-        continue;
       inputBlockInfoMap[successor].join(outputBlockInfoMap[block]);
       blockList.emplace_back(successor);
     }
@@ -127,15 +100,6 @@ void MembarAnalysis::insertBarrier(Operation *op, OpBuilder *builder) {
 void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
                             FuncBlockInfoMapT *funcBlockInfoMap,
                             OpBuilder *builder) {
-  // llvm::errs() << "op: " << *op << "\n";
-  // for (auto &interval : blockInfo->syncWriteIntervals) {
-  //   llvm::errs() << "write: [" << interval.start() << ", " << interval.end()
-  //   << "]\n";
-  // }
-  // for (auto &interval : blockInfo->syncReadIntervals) {
-  //   llvm::errs() << "read: [" << interval.start() << ", " << interval.end()
-  //   << "]\n";
-  // }
   if (isa<gpu::BarrierOp>(op)) {
     // If the current op is a barrier, we sync previous reads and writes
     blockInfo->sync();

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -43,7 +43,7 @@ void MembarAnalysis::resolve(FunctionOpInterface funcOp,
   while (!blockList.empty()) {
     auto *block = blockList.front();
     blockList.pop_front();
-    //  Make a copy of the inputblockInfo but not update
+    // Make a copy of the inputblockInfo but not update
     auto inputBlockInfo = inputBlockInfoMap[block];
     SmallVector<Block *> successors;
     for (auto &op : block->getOperations()) {
@@ -62,7 +62,7 @@ void MembarAnalysis::resolve(FunctionOpInterface funcOp,
     }
     // Update the current block
     outputBlockInfoMap[block].join(inputBlockInfo);
-    //  Update the successors
+    // Update the successors
     for (auto *successor : successors) {
       inputBlockInfoMap[successor].join(outputBlockInfoMap[block]);
       blockList.emplace_back(successor);

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -154,12 +154,19 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
   // read/write operations, and ending with a shared memory read, i.e., shared
   // memory write -> ... -> shared memory read.
   if (scratchBufferId != Allocation::InvalidBufferId) {
+    if (!curBlockInfo.syncReadIntervals.empty() ||
+        !curBlockInfo.syncWriteIntervals.empty()) {
+      llvm::report_fatal_error(
+          "scratch buffer operations should not have any shared memory "
+          "dependencies");
+    }
     auto interval = allocation->getAllocatedInterval(scratchBufferId);
     curBlockInfo.syncWriteIntervals.insert(interval);
     if (blockInfo->isIntersected(curBlockInfo)) {
       builder->setInsertionPoint(op);
       insertBarrier(op, builder);
     }
+    // Ops with a scratch buffer internally syncs read/write on shared memory
     blockInfo->sync();
     curBlockInfo.syncReadIntervals.insert(interval);
   } else if (blockInfo->isIntersected(curBlockInfo)) {

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -1,8 +1,6 @@
 import multiprocessing
 import shutil
 
-import torch
-
 import triton
 import triton.language as tl
 from triton.compiler import ASTSource
@@ -10,7 +8,7 @@ from triton.compiler import ASTSource
 target = triton.runtime.driver.active.get_current_target()
 
 
-def compile_fn(attrs, capability):
+def compile_fn(attrs):
 
     @triton.jit
     def kernel_sub(a, b, o, N: tl.constexpr):
@@ -27,18 +25,15 @@ def compile_fn(attrs, capability):
 
 
 def test_compile_in_subproc() -> None:
-    major, minor = torch.cuda.get_device_capability(0)
-    cc = major * 10 + minor
     config = triton.compiler.AttrsDescriptor(tuple(range(4)), ())
-
     multiprocessing.set_start_method('fork')
-    proc = multiprocessing.Process(target=compile_fn, args=(config, cc))
+    proc = multiprocessing.Process(target=compile_fn, args=(config, ))
     proc.start()
     proc.join()
     assert proc.exitcode == 0
 
 
-def compile_fn_dot(attrs, capability):
+def compile_fn_dot(attrs):
 
     @triton.jit
     def kernel_dot(Z):
@@ -52,12 +47,9 @@ def compile_fn_dot(attrs, capability):
 
 
 def test_compile_in_forked_subproc(fresh_triton_cache) -> None:
-    major, minor = torch.cuda.get_device_capability(0)
-    capability = major * 10 + minor
     config = triton.compiler.AttrsDescriptor(tuple(range(1)), ())
-
     assert multiprocessing.get_start_method() == 'fork'
-    proc = multiprocessing.Process(target=compile_fn_dot, args=(config, capability))
+    proc = multiprocessing.Process(target=compile_fn_dot, args=(config, ))
     proc.start()
     proc.join()
     assert proc.exitcode == 0


### PR DESCRIPTION
tt.cond_br may jump to the containing block. In such a case, we cannot place this block into its successors during the analysis, because the same block would be added back to blockList and cause an infinite loop.

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
