### PR TITLE
SWP: add dependency from use of async load to waitOp for the async load

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -85,7 +85,8 @@ public:
   }
 
   void insertDepsOfOp(Operation *op, int stage, CoarseSchedule::Cluster cluster,
-                      bool includeArg);
+                      bool includeArg,
+                      DenseMap<Operation *, Operation *> *additionalDep);
 
   void erase(Operation *op) { opToStageAndCluster.erase(op); }
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -74,6 +74,15 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
     return op;
   }
 
+  // Create if statement around wait_barrier
+  if (auto wait = dyn_cast<ttng::WaitBarrierOp>(op)) {
+    rewriter.setInsertionPoint(wait);
+    auto ifOp =
+        rewriter.create<scf::IfOp>(wait->getLoc(), pred, /*else=*/false);
+    // move wait to ifOp
+    rewriter.moveOpBefore(wait, ifOp.thenBlock(), ifOp.thenBlock()->begin());
+    return ifOp;
+  }
   assert("don't know how to predicate this op" && false);
   return op;
 }


### PR DESCRIPTION
Summary: use of async load is actually a viewLoad operation. In createAsyncCopy and createTMAAsyncCopy, we save the dependency pair of (viewLoad, waitOp) as a DenseMap. The DenseMap will be passed up the call chain to createAsyncOps and used by scheduleDependencies.

insertDepsOfOp will take an additional DenseMap so waitOp will be correctly added to the right stage (i.e the same stage as the viewLoad).

This patch also handles predication for WaitBarrierOp. It adds an if statement around it. This is needed when WaitBarrierOp is not at the last stage so we need to predicate it.
