### PR TITLE
[do_bench_cudagraph] estimate runtime without creating a graph

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -43,10 +43,15 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None, quantiles=None, return_mod
     """
     import torch
     assert return_mode in ["min", "max", "mean", "median", "all"]
-   
+
     with torch.cuda.stream(torch.cuda.Stream()):
         # warmup
         fn()
+        if grad_to_none is not None:
+            for x in grad_to_none:
+                x.detach_()
+                x.requires_grad_(True)
+                x.grad = None
         # step 1 - we estimate the amount of time the kernel call takes
         # NOTE: this estimate isn't super accurate because the GPU isn't warmed up at this point
         #       but it is probably good enough


### PR DESCRIPTION
Copy/pasted the estimation loop from `do_bench` into `do_bench_cudagraph` in favor of the original create graph -> measure replay methodology. Creating a graph is expensive (~300ms on A100 for me), even if the kernel is relatively inexpensive. Since we just want a rough estimation of the runtime, we can probably go the same route `do_bench` does and save 50% of the overhead in `do_bench_cudagraph` by reducing the total number of graphs created from 2 to 1. Keeping inline with the original function of `do_bench_cudagraph` I removed the L2 cache flush from the estimation loop, which seems fine since there is already no L2 cache flush in the actual benchmarking loop.

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is already covered by tests for `do_bench_cudagraph`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
