### PR TITLE
Use shlex.split for TRITON_APPEND_CMAKE_ARGS

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -2,6 +2,7 @@ import os
 import platform
 import re
 import contextlib
+import shlex
 import shutil
 import subprocess
 import sys
@@ -451,7 +452,7 @@ class CMakeBuild(build_ext):
 
         cmake_args_append = os.getenv("TRITON_APPEND_CMAKE_ARGS")
         if cmake_args_append is not None:
-            cmake_args += cmake_args_append.split(" ")
+            cmake_args += shlex.split(cmake_args_append)
 
         env = os.environ.copy()
         cmake_dir = get_cmake_dir()


### PR DESCRIPTION
To enable support for spaces in additional CMake arguments passed using TRITON_APPEND_CMAKE_ARGS environment variable.

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it changes setup.py behavior under specific conditions (TRITON_APPEND_CMAKE_ARGS environment variable is set).

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
