### PR TITLE
fix a misuse of `FailureOr<T>`

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -74,9 +74,10 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     auto amendedFuncOp = funcOp;
     if (!LLVM::isKernel(funcOp))
       amendedFuncOp = amendFuncOp(funcOp, rewriter);
-    
-    FailureOr<LLVM::LLVMFuncOp> maybeNewFuncOp = mlir::convertFuncOpToLLVMFuncOp(
-        amendedFuncOp, rewriter, *getTypeConverter());
+
+    FailureOr<LLVM::LLVMFuncOp> maybeNewFuncOp =
+        mlir::convertFuncOpToLLVMFuncOp(amendedFuncOp, rewriter,
+                                        *getTypeConverter());
     if (failed(maybeNewFuncOp)) {
       return failure();
     }

--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -74,12 +74,14 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     auto amendedFuncOp = funcOp;
     if (!LLVM::isKernel(funcOp))
       amendedFuncOp = amendFuncOp(funcOp, rewriter);
-
-    LLVM::LLVMFuncOp newFuncOp = *mlir::convertFuncOpToLLVMFuncOp(
+    
+    FailureOr<LLVM::LLVMFuncOp> maybeNewFuncOp = mlir::convertFuncOpToLLVMFuncOp(
         amendedFuncOp, rewriter, *getTypeConverter());
-    if (!newFuncOp) {
+    if (failed(maybeNewFuncOp)) {
       return failure();
     }
+
+    LLVM::LLVMFuncOp newFuncOp = *maybeNewFuncOp;
 
     auto ctx = funcOp->getContext();
 


### PR DESCRIPTION
`FailureOr<T>` should be checked against whether it contains a failure before using its value. This PR fixes one such misuse.

I also checked all functions returning `FailureOr<T>` in Triton code base and did not find other misuses.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `this does not involves change in features`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
