### PR TITLE
Improve offline builds

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -127,7 +127,7 @@ def is_offline_build() -> bool:
 
     Note that this flag isn't tested by the CI and does not provide any guarantees.
     """
-    return os.environ.get("TRITON_OFFLINE_BUILD", "") != ""
+    return check_env_flag("TRITON_OFFLINE_BUILD", "")
 
 
 # --- third party packages -----
@@ -449,6 +449,10 @@ class CMakeBuild(build_ext):
             cmake_args += self.get_proton_cmake_args()
         else:
             cmake_args += ["-DTRITON_BUILD_PROTON=OFF"]
+
+        if is_offline_build():
+            # unit test builds fetch googletests from GitHub
+            cmake_args += ["-DTRITON_BUILD_UT=OFF"]
 
         cmake_args_append = os.getenv("TRITON_APPEND_CMAKE_ARGS")
         if cmake_args_append is not None:


### PR DESCRIPTION
`is_offline_build()` now uses `check_env_flag()` like the rest of the `setup.py` code. `TRITON_OFFLINE_BUILD=YES` and
`TRITON_OFFLINE_BUILD=NO` work as expected.

Offline builds now disable unit test builds. The default `TRITON_BUILD_UT=YES` triggers a download of `googletests` code from GitHub.

See: #4414

- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because it improves the build system.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
