### PR TITLE
[BUILD] Fix `input_defined` bug

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -238,7 +238,7 @@ def get_thirdparty_packages(packages: list):
             package_dir = os.environ[p.syspath_var_name]
         version_file_path = os.path.join(package_dir, "version.txt")
 
-        input_defined = p.syspath_var_name not in os.environ
+        input_defined = p.syspath_var_name in os.environ
         input_exists = input_defined and os.path.exists(version_file_path)
         input_compatible = input_exists and Path(version_file_path).read_text() == p.url
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -239,12 +239,12 @@ def get_thirdparty_packages(packages: list):
         version_file_path = os.path.join(package_dir, "version.txt")
 
         input_defined = p.syspath_var_name in os.environ
-        input_exists = input_defined and os.path.exists(version_file_path)
+        input_exists = os.path.exists(version_file_path)
         input_compatible = input_exists and Path(version_file_path).read_text() == p.url
 
         if is_offline_build() and not input_defined:
             raise RuntimeError(f"Requested an offline build but {p.syspath_var_name} is not set")
-        if not is_offline_build() and not input_compatible:
+        if not is_offline_build() and not (input_defined or input_compatible):
             with contextlib.suppress(Exception):
                 shutil.rmtree(package_root_dir)
             os.makedirs(package_root_dir, exist_ok=True)

--- a/python/setup.py
+++ b/python/setup.py
@@ -244,7 +244,7 @@ def get_thirdparty_packages(packages: list):
 
         if is_offline_build() and not input_defined:
             raise RuntimeError(f"Requested an offline build but {p.syspath_var_name} is not set")
-        if not is_offline_build() and not (input_defined or input_compatible):
+        if not is_offline_build() and not input_defined and not input_compatible:
             with contextlib.suppress(Exception):
                 shutil.rmtree(package_root_dir)
             os.makedirs(package_root_dir, exist_ok=True)


### PR DESCRIPTION
A small bug fix for `input_defined` variable used in `setup.py`.

I think the only case for downloading shall satisfy all following requirements:
1. `is_offline_build()` is False
2. `input_defined = p.syspath_var_name in os.environ` is False, which means using the cache dir.
3. `input_compatible` is False, which means the current cached version is not correct.

However, the current codes have following issues:
1. `input_defined = p.syspath_var_name not in os.environ`, which is not consistent with the variable name.
2. When `p.syspath_var_name in os.environ` and version is correct in that path, it still downloads.

The bug is introduced in commit https://github.com/triton-lang/triton/commit/0503565f57fbf2571ee15ce00b2a9587c2ac96b0

Codes with bug after https://github.com/triton-lang/triton/commit/0503565f57fbf2571ee15ce00b2a9587c2ac96b0:
```python3
        input_defined = p.syspath_var_name not in os.environ
        input_exists = input_defined and os.path.exists(version_file_path)
        input_compatible = input_exists and Path(version_file_path).read_text() == p.url

        if is_offline_build() and not input_defined:
            raise RuntimeError(f"Requested an offline build but {p.syspath_var_name} is not set")
        if not is_offline_build() and not input_compatible:
            with contextlib.suppress(Exception):
                shutil.rmtree(package_root_dir)
```

Old codes without bug before https://github.com/triton-lang/triton/commit/0503565f57fbf2571ee15ce00b2a9587c2ac96b0:
```python3
        if p.syspath_var_name not in os.environ and\
           (not os.path.exists(version_file_path) or Path(version_file_path).read_text() != p.url):
            with contextlib.suppress(Exception):
                shutil.rmtree(package_root_dir)
```
------------------------------
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `It's a small bug fix`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
