### PR TITLE
Fix dynamic failure in `test_subprocess.py`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -382,7 +382,7 @@ jobs:
           pytest --capture=tee-sys -rfs python/tutorials/06-fused-attention.py
           cd python/test/unit
           pytest --capture=tee-sys -rfs -n 16 language runtime \
-                 --ignore=language/test_line_info.py \
+                 --ignore=language/test_line_info.py
           TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${SHARED_LIB_DIR}/libGPUHello.so \
           pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -381,11 +381,8 @@ jobs:
           fi
           pytest --capture=tee-sys -rfs python/tutorials/06-fused-attention.py
           cd python/test/unit
-          ## test_subprocess.py is flaky on the AMD CI.
-          ## TODO (lixun) find a solution and re-enable it.
           pytest --capture=tee-sys -rfs -n 16 language runtime \
                  --ignore=language/test_line_info.py \
-                 --ignore=language/test_subprocess.py
           TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${SHARED_LIB_DIR}/libGPUHello.so \
           pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
 

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -387,7 +387,7 @@ jobs:
           pytest --capture=tee-sys -rfs python/tutorials/06-fused-attention.py
           cd python/test/unit
           pytest --capture=tee-sys -rfs -n 16 language runtime \
-                 --ignore=language/test_line_info.py \
+                 --ignore=language/test_line_info.py
           TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${SHARED_LIB_DIR}/libGPUHello.so \
           pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
 

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -386,11 +386,8 @@ jobs:
           fi
           pytest --capture=tee-sys -rfs python/tutorials/06-fused-attention.py
           cd python/test/unit
-          ## test_subprocess.py is flaky on the AMD CI.
-          ## TODO (lixun) find a solution and re-enable it.
           pytest --capture=tee-sys -rfs -n 16 language runtime \
                  --ignore=language/test_line_info.py \
-                 --ignore=language/test_subprocess.py
           TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${SHARED_LIB_DIR}/libGPUHello.so \
           pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
 

--- a/python/test/unit/language/assert_helper.py
+++ b/python/test/unit/language/assert_helper.py
@@ -79,7 +79,7 @@ def test_assert(func: str, device: str):
         kernel_device_assert[(1, )](x, y, num_warps=num_warps, BLOCK=N)
         kernel_assert_passes[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     assert_close(y, x)
-    # To guarantee driver completes all the jobs for
+    # GPU/host synchronization before exiting the test.
     torch.cuda.synchronize()
 
 

--- a/python/test/unit/language/assert_helper.py
+++ b/python/test/unit/language/assert_helper.py
@@ -79,6 +79,8 @@ def test_assert(func: str, device: str):
         kernel_device_assert[(1, )](x, y, num_warps=num_warps, BLOCK=N)
         kernel_assert_passes[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     assert_close(y, x)
+    # To guarantee driver completes all the jobs for
+    torch.cuda.synchronize()
 
 
 @triton.jit

--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -136,6 +136,10 @@ def test_print(func: str, data_type: str, device: str):
        func != "device_print_pointer" and func != "device_print_scalar":
         assert_close(y, x)
 
+    # Wait until driver complete all the jobs for the device_print, especially test_subprocess
+    # require this which captures stdout when child exits.
+    torch.cuda.synchronize()
+
 
 if __name__ == "__main__":
     fn = globals()[sys.argv[1]]

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -243,6 +243,9 @@ void TargetInfo::assertFail(RewriterBase &rewriter, Location loc,
   printfImpl(msgValue, msgBuffer.size_in_bytes(), /*args=*/ValueRange(),
              rewriter, /*useStdError=*/true);
 
+  // Set block barrrier before aborting kernel, give a chance for all
+  // the threads in a block to check/print the assert failure.
+  barrier();
   // Perform the trap to abort the kernel.
   rewriter.create<LLVM::Trap>(loc);
 }


### PR DESCRIPTION
There was a reported test failure https://github.com/triton-lang/triton/actions/runs/9357367045/job/25756933587 and test_subprocess.py has been skipped in AMD-CI. 
We've investigated that it was caused by a missing GPU/host synchronization before test checking the stdout/err in the test. Normally Triton use case rely GPU/host synchronization on torch tensor but printf test doesn't write output to the tensor and test needs to wait until driver finishes the job. This PR adds `torch.cuda.synchronize()` at the end of the tests which require the synchronization.

Also, we found one more change needed in the AMD backend - set block barrier before we call llvm::trap, guarantees all the assertion message to be printed out before the abortion. This issue has been found after stack trace was disabled by default.

No failure has been observed after applying two changes.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `This fixes a test failure of the existing test`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
