### PR TITLE
[AMD] Add barrier at the beginning of each atomic operations.

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -404,6 +404,11 @@ struct AtomicCASOpConversion
     auto vecTy = vec_ty(valueElemTy, vec);
     SmallVector<Value> resultVals(elemsPerThread);
 
+    // Synchronize warps before atomic operation.
+    // Prevent warps from being left behind while another warp
+    // finish evaluating and update the atomic operation.
+    barrier();
+
     // atomic ops
     for (size_t i = 0; i < elemsPerThread; i += vec) {
       Value casVal = undef(vecTy);
@@ -554,6 +559,11 @@ struct AtomicRMWOpConversion
     SmallVector<Value> maskElements;
     if (llMask)
       maskElements = unpackLLElements(loc, llMask, rewriter);
+
+    // Synchronize warps before atomic operation.
+    // Prevent warps from being left behind while another warp
+    // finish evaluating and update the atomic operation.
+    barrier();
 
     Value opResult = op.getResult();
     auto tensorTy = dyn_cast<RankedTensorType>(opResult.getType());


### PR DESCRIPTION
Fix regression in test_core.py::test_atomic_cas.
All the warps in a block need to be synchronized before entering into the atomic operation. It doesn't change the result of the atomic operations but changes the execution timing of other warps.
When shared memory is used, barrier was implicitly added by MembarAnalysis.
