### PR TITLE
[NFC] Make the decomposeTensorCoreToDotLayoutConversion to be useable for the third party backend.

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Patterns.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Patterns.h
@@ -17,48 +17,12 @@ void decomposeBlockedToDotLayoutConversion(ModuleOp module);
 /// |module| op.
 void decomposeSplatOpToSharedLayoutConversion(ModuleOp module);
 
-namespace {
-static void addAttrs(Operation *op, ArrayRef<mlir::NamedAttribute> attrs) {
-  for (const NamedAttribute attr : attrs)
-    op->setAttr(attr.getName(), attr.getValue());
-}
-} // namespace
-
 /// Replaces `mma/mfma -> dot_op` with `mma/mfma -> blocked -> dot_op` in the
 /// given |module| op, but bypass the decomposition if |shortcutFn| returns
 /// true.
 using ShortcutFn = std::function<bool(RankedTensorType, RankedTensorType)>;
-template <typename TensorCoreEncodingAttr>
 void decomposeTensorCoreToDotLayoutConversion(ModuleOp module,
-                                              ShortcutFn shortcutFn) {
-  int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(module);
-  int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(module);
-  int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(module);
-
-  module.walk([&](triton::gpu::ConvertLayoutOp cvtOp) -> void {
-    OpBuilder builder(cvtOp);
-    auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
-    auto dstType = cast<RankedTensorType>(cvtOp.getType());
-    auto srcMma = dyn_cast<TensorCoreEncodingAttr>(srcType.getEncoding());
-    auto dstDotOp =
-        dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
-    if (srcMma && dstDotOp && !shortcutFn(srcType, dstType)) {
-      auto tmpType = RankedTensorType::get(
-          dstType.getShape(), dstType.getElementType(),
-          triton::gpu::BlockedEncodingAttr::get(
-              module.getContext(), srcType.getShape(), getSizePerThread(srcMma),
-              getOrder(srcMma), numWarps, threadsPerWarp, numCTAs));
-      auto tmp = builder.create<triton::gpu::ConvertLayoutOp>(
-          cvtOp.getLoc(), tmpType, cvtOp.getSrc());
-      addAttrs(tmp, cvtOp->getAttrs());
-      auto newConvert = builder.create<triton::gpu::ConvertLayoutOp>(
-          cvtOp.getLoc(), dstType, tmp);
-      addAttrs(newConvert, cvtOp->getAttrs());
-      cvtOp.replaceAllUsesWith(newConvert.getResult());
-      cvtOp.erase();
-    }
-  });
-}
+                                              ShortcutFn shortcutFn);
 
 } // namespace triton::gpu
 

--- a/include/triton/Conversion/TritonGPUToLLVM/Patterns.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Patterns.h
@@ -17,13 +17,48 @@ void decomposeBlockedToDotLayoutConversion(ModuleOp module);
 /// |module| op.
 void decomposeSplatOpToSharedLayoutConversion(ModuleOp module);
 
+namespace {
+static void addAttrs(Operation *op, ArrayRef<mlir::NamedAttribute> attrs) {
+  for (const NamedAttribute attr : attrs)
+    op->setAttr(attr.getName(), attr.getValue());
+}
+} // namespace
+
 /// Replaces `mma/mfma -> dot_op` with `mma/mfma -> blocked -> dot_op` in the
 /// given |module| op, but bypass the decomposition if |shortcutFn| returns
 /// true.
 using ShortcutFn = std::function<bool(RankedTensorType, RankedTensorType)>;
 template <typename TensorCoreEncodingAttr>
 void decomposeTensorCoreToDotLayoutConversion(ModuleOp module,
-                                              ShortcutFn shortcutFn);
+                                              ShortcutFn shortcutFn) {
+  int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(module);
+  int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(module);
+  int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(module);
+
+  module.walk([&](triton::gpu::ConvertLayoutOp cvtOp) -> void {
+    OpBuilder builder(cvtOp);
+    auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
+    auto dstType = cast<RankedTensorType>(cvtOp.getType());
+    auto srcMma = dyn_cast<TensorCoreEncodingAttr>(srcType.getEncoding());
+    auto dstDotOp =
+        dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
+    if (srcMma && dstDotOp && !shortcutFn(srcType, dstType)) {
+      auto tmpType = RankedTensorType::get(
+          dstType.getShape(), dstType.getElementType(),
+          triton::gpu::BlockedEncodingAttr::get(
+              module.getContext(), srcType.getShape(), getSizePerThread(srcMma),
+              getOrder(srcMma), numWarps, threadsPerWarp, numCTAs));
+      auto tmp = builder.create<triton::gpu::ConvertLayoutOp>(
+          cvtOp.getLoc(), tmpType, cvtOp.getSrc());
+      addAttrs(tmp, cvtOp->getAttrs());
+      auto newConvert = builder.create<triton::gpu::ConvertLayoutOp>(
+          cvtOp.getLoc(), dstType, tmp);
+      addAttrs(newConvert, cvtOp->getAttrs());
+      cvtOp.replaceAllUsesWith(newConvert.getResult());
+      cvtOp.erase();
+    }
+  });
+}
 
 } // namespace triton::gpu
 

--- a/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -7,15 +7,6 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-namespace {
-
-static void addAttrs(Operation *op, ArrayRef<mlir::NamedAttribute> attrs) {
-  for (const NamedAttribute attr : attrs)
-    op->setAttr(attr.getName(), attr.getValue());
-}
-
-} // namespace
-
 namespace mlir::triton::gpu {
 
 void decomposeSplatOpToSharedLayoutConversion(ModuleOp module) {
@@ -43,44 +34,6 @@ void decomposeSplatOpToSharedLayoutConversion(ModuleOp module) {
     }
   });
 }
-
-template <typename TensorCoreEncodingAttr>
-void decomposeTensorCoreToDotLayoutConversion(ModuleOp module,
-                                              ShortcutFn shortcutFn) {
-  int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(module);
-  int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(module);
-  int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(module);
-
-  module.walk([&](triton::gpu::ConvertLayoutOp cvtOp) -> void {
-    OpBuilder builder(cvtOp);
-    auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
-    auto dstType = cast<RankedTensorType>(cvtOp.getType());
-    auto srcMma = dyn_cast<TensorCoreEncodingAttr>(srcType.getEncoding());
-    auto dstDotOp =
-        dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
-    if (srcMma && dstDotOp && !shortcutFn(srcType, dstType)) {
-      auto tmpType = RankedTensorType::get(
-          dstType.getShape(), dstType.getElementType(),
-          triton::gpu::BlockedEncodingAttr::get(
-              module.getContext(), srcType.getShape(), getSizePerThread(srcMma),
-              getOrder(srcMma), numWarps, threadsPerWarp, numCTAs));
-      auto tmp = builder.create<triton::gpu::ConvertLayoutOp>(
-          cvtOp.getLoc(), tmpType, cvtOp.getSrc());
-      addAttrs(tmp, cvtOp->getAttrs());
-      auto newConvert = builder.create<triton::gpu::ConvertLayoutOp>(
-          cvtOp.getLoc(), dstType, tmp);
-      addAttrs(newConvert, cvtOp->getAttrs());
-      cvtOp.replaceAllUsesWith(newConvert.getResult());
-      cvtOp.erase();
-    }
-  });
-}
-
-template void decomposeTensorCoreToDotLayoutConversion<
-    triton::gpu::NvidiaMmaEncodingAttr>(ModuleOp, ShortcutFn);
-template void
-    decomposeTensorCoreToDotLayoutConversion<triton::gpu::AMDMfmaEncodingAttr>(
-        ModuleOp, ShortcutFn);
 
 void decomposeBlockedToDotLayoutConversion(ModuleOp module) {
   int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(module);

--- a/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -7,6 +7,15 @@
 using namespace mlir;
 using namespace mlir::triton;
 
+namespace {
+
+static void addAttrs(Operation *op, ArrayRef<mlir::NamedAttribute> attrs) {
+  for (const NamedAttribute attr : attrs)
+    op->setAttr(attr.getName(), attr.getValue());
+}
+
+} // namespace
+
 namespace mlir::triton::gpu {
 
 void decomposeSplatOpToSharedLayoutConversion(ModuleOp module) {
@@ -31,6 +40,37 @@ void decomposeSplatOpToSharedLayoutConversion(ModuleOp module) {
           splatOp.getLoc(), dstType, newSplat.getResult());
       splatOp.replaceAllUsesWith(newConvert.getResult());
       splatOp.erase();
+    }
+  });
+}
+
+void decomposeTensorCoreToDotLayoutConversion(ModuleOp module,
+                                              ShortcutFn shortcutFn) {
+  int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(module);
+  int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(module);
+  int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(module);
+
+  module.walk([&](triton::gpu::ConvertLayoutOp cvtOp) -> void {
+    OpBuilder builder(cvtOp);
+    auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
+    auto dstType = cast<RankedTensorType>(cvtOp.getType());
+    auto srcMma = dyn_cast<MmaEncodingTrait>(srcType.getEncoding());
+    auto dstDotOp =
+        dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
+    if (srcMma && dstDotOp && !shortcutFn(srcType, dstType)) {
+      auto tmpType = RankedTensorType::get(
+          dstType.getShape(), dstType.getElementType(),
+          triton::gpu::BlockedEncodingAttr::get(
+              module.getContext(), srcType.getShape(), getSizePerThread(srcMma),
+              getOrder(srcMma), numWarps, threadsPerWarp, numCTAs));
+      auto tmp = builder.create<triton::gpu::ConvertLayoutOp>(
+          cvtOp.getLoc(), tmpType, cvtOp.getSrc());
+      addAttrs(tmp, cvtOp->getAttrs());
+      auto newConvert = builder.create<triton::gpu::ConvertLayoutOp>(
+          cvtOp.getLoc(), dstType, tmp);
+      addAttrs(newConvert, cvtOp->getAttrs());
+      cvtOp.replaceAllUsesWith(newConvert.getResult());
+      cvtOp.erase();
     }
   });
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -113,8 +113,8 @@ struct DecomposeUnsupportedAMDConversions
 
     triton::gpu::decomposeSplatOpToSharedLayoutConversion(mod);
 
-    triton::gpu::decomposeTensorCoreToDotLayoutConversion<
-        triton::gpu::AMDMfmaEncodingAttr>(mod, isMfmaToDotShortcut);
+    triton::gpu::decomposeTensorCoreToDotLayoutConversion(mod,
+                                                          isMfmaToDotShortcut);
 
     /* -------------------------------- */
     // Replace `wmma -> dot_op` with `wmma -> blocked -> dot_op`

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -72,8 +72,8 @@ struct DecomposeUnsupportedConversions
   void runOnOperation() override {
     ModuleOp mod = getOperation();
     triton::gpu::decomposeSplatOpToSharedLayoutConversion(mod);
-    triton::gpu::decomposeTensorCoreToDotLayoutConversion<
-        triton::gpu::NvidiaMmaEncodingAttr>(mod, isMmaToDotShortcut);
+    triton::gpu::decomposeTensorCoreToDotLayoutConversion(mod,
+                                                          isMmaToDotShortcut);
     triton::gpu::decomposeBlockedToDotLayoutConversion(mod);
 
     mlir::RewritePatternSet patterns(&getContext());


### PR DESCRIPTION
Change the template function `decomposeTensorCoreToDotLayoutConversion` to a normal C++ function.

The template function `decomposeTensorCoreToDotLayoutConversion` is defined in cpp file which is not visible for the out of tree third party backends.

Change it to a normal C++ function to make it available for the out of tree backends. 

- [x] I have written a PR description following these https://cbea.ms/git-commit/#why-not-how

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] This PR does not need a test because just move the template function definition from cpp file to the header file.

- [x] I have not added any `lit` tests.
