### PR TITLE
[BACKEND] Fp8E5M2Nv to Fp16 conversion support added to NV backend

### DIFF
--- a/test/TritonGPU/f8-convert.mlir
+++ b/test/TritonGPU/f8-convert.mlir
@@ -1,0 +1,32 @@
+// RUN: triton-reduce --convert-triton-gpu-to-llvm %s | FileCheck %s
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {
+  "triton_gpu.num-ctas" = 1 : i32,
+  "triton_gpu.num-warps" = 4 : i32,
+  triton_gpu.target = "cuda:90",
+  "triton_gpu.threads-per-warp" = 32 : i32
+} {
+  tt.func public @triton_(%arg0: !tt.ptr<f8E5M2FNUZ> {tt.divisibility = 16 : i32},
+                          %arg4: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                          %arg5: i32 {tt.divisibility = 16 : i32}
+                         ) attributes {noinline = false} {
+    %c256_i32 = arith.constant 256 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c256_i32 : i32
+    %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked>
+    %3 = tt.splat %1 : i32 -> tensor<256xi32, #blocked>
+    %4 = arith.addi %3, %2 : tensor<256xi32, #blocked>
+    %5 = tt.splat %arg5 : i32 -> tensor<256xi32, #blocked>
+    %6 = arith.cmpi slt, %4, %5 : tensor<256xi32, #blocked>
+    %7 = tt.splat %arg0 : !tt.ptr<f8E5M2FNUZ> -> tensor<256x!tt.ptr<f8E5M2FNUZ>, #blocked>
+    %8 = tt.addptr %7, %4 : tensor<256x!tt.ptr<f8E5M2FNUZ>, #blocked>, tensor<256xi32, #blocked>
+    %9 = tt.load %8, %6 : tensor<256x!tt.ptr<f8E5M2FNUZ>, #blocked>
+    // CHECK: cvt.rn.f16x2.e5m2x2
+    %19 = tt.fp_to_fp %9 : tensor<256xf8E5M2FNUZ, #blocked> -> tensor<256xf32, #blocked>
+    %26 = tt.splat %arg4 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>, #blocked>
+    %27 = tt.addptr %26, %4 : tensor<256x!tt.ptr<f32>, #blocked>, tensor<256xi32, #blocked>
+    tt.store %27, %19, %6 : tensor<256x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -176,6 +176,13 @@ static const Fp8ConversionDesc Bf16_to_Fp8E5M2(bool hasNativeFP) {
 }
 
 // Fp8E4M3 (x2) -> Fp16 (x2) (packed)
+static const Fp8ConversionDesc Fp8E5M2Nv_to_Fp16 = {
+    "{ \n"
+    "cvt.rn.f16x2.e5m2x2 $0, $1; \n"
+    "}",
+    16, 32, 2};
+
+// Fp8E4M3 (x2) -> Fp16 (x2) (packed)
 static const Fp8ConversionDesc Fp8E4M3Nv_to_Fp16 = {
     "{ \n"
     "cvt.rn.f16x2.e4m3x2 $0, $1; \n"
@@ -388,6 +395,7 @@ struct FpToFpOpConversion
                     std::optional<RoundingMode> roundingMode) const {
     auto F8E4M3TyID = TypeID::get<Float8E4M3FNUZType>();
     auto F8E5M2TyID = TypeID::get<Float8E5M2Type>();
+    auto F8E5M2FNUZTyID = TypeID::get<Float8E5M2FNUZType>();
     auto F16TyID = TypeID::get<Float16Type>();
     auto BF16TyID = TypeID::get<BFloat16Type>();
     auto F32TyID = TypeID::get<Float32Type>();
@@ -398,6 +406,7 @@ struct FpToFpOpConversion
     static DenseMap<std::tuple<TypeID, TypeID, RoundingMode>, Fp8ConversionDesc>
         srcMap = {
             // F8 -> F16
+            {{F8E5M2FNUZTyID, F16TyID, undefRounding}, Fp8E5M2Nv_to_Fp16},
             {{F8E4M3TyID, F16TyID, undefRounding}, Fp8E4M3Nv_to_Fp16},
             {{F8E5M2TyID, F16TyID, undefRounding},
              Fp8E5M2_to_Fp16(computeCapability >= 90)},


### PR DESCRIPTION
This is a fix for a missing conversion in the srcMap for getConversionFunc for the nvidia backend, it adds Fp8E5M2Nv_to_Fp16


- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices)
