### PR TITLE
feat: support `sem`/`scope` in `tl.{load,store}`

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -252,7 +252,9 @@ def TT_LoadOp : TT_Op<"load", [
       OptionalAttr<TT_PaddingOptionAttr>:$padding,
       DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
       DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict,
-      DefaultValuedAttr<BoolAttr, "false">:$isVolatile
+      DefaultValuedAttr<BoolAttr, "false">:$isVolatile,
+      OptionalAttr<TT_MemSemanticAttr>:$sem,
+      OptionalAttr<TT_MemSyncScopeAttr>:$scope
     );
 
     let results = (outs TT_Type:$result);
@@ -260,32 +262,42 @@ def TT_LoadOp : TT_Op<"load", [
     let builders = [
         // A tensor of pointers or a pointer to a scalar
         OpBuilder<(ins "Value":$ptr, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>,
+                       "triton::EvictionPolicy":$evict, "bool":$isVolatile,
+                       "std::optional<triton::MemSemantic>":$sem,
+                       "std::optional<triton::MemSyncScope>":$scope)>,
         // A tensor pointer with boundary check and padding
         OpBuilder<(ins "Value":$ptr, "ArrayRef<int32_t>":$boundaryCheck,
                        "std::optional<triton::PaddingOption>":$padding, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>,
+                       "triton::EvictionPolicy":$evict, "bool":$isVolatile,
+                       "std::optional<triton::MemSemantic>":$sem,
+                       "std::optional<triton::MemSyncScope>":$scope)>,
         // A tensor of pointers or a pointer to a scalar with mask
         OpBuilder<(ins "Value":$ptr, "Value":$mask, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>,
+                       "triton::EvictionPolicy":$evict, "bool":$isVolatile,
+                       "std::optional<triton::MemSemantic>":$sem,
+                       "std::optional<triton::MemSyncScope>":$scope)>,
         // A tensor of pointers or a pointer to a scalar with mask and other
         OpBuilder<(ins "Value":$ptr, "Value":$mask, "Value":$other, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>,
+                       "triton::EvictionPolicy":$evict, "bool":$isVolatile,
+                       "std::optional<triton::MemSemantic>":$sem,
+                       "std::optional<triton::MemSyncScope>":$scope)>,
         // A utility function to build the operation with all attributes
         OpBuilder<(ins "Value":$ptr, "Value":$mask, "Value":$other,
                        "ArrayRef<int32_t>":$boundaryCheck,
                        "std::optional<triton::PaddingOption>":$padding, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>
+                       "triton::EvictionPolicy":$evict, "bool":$isVolatile,
+                       "std::optional<triton::MemSemantic>":$sem,
+                       "std::optional<triton::MemSyncScope>":$scope)>
     ];
 
-    // Specify `cacheModifier` and `evictionPolicy` explicitly in the
-    // assemblyFormat instead of as part of attr-dict so that they get printed
-    // as strings rather than opaque integers.
+    // Specify cacheModifier, evictionPolicy, memSemantic and memSyncScope
+    // explicitly, instead of leaving them in attr-dict, because this way their
+    // values get printed as strings, rather than as opaque integers.
     //
     // Note there's no comma between `other` and `cacheModifier` and between
-    // `cacheModifier` and `evictionPolicy`.  This is due to an apparent
-    // limitation in the MLIR custom-format parser.  In oilist, the initial
-    // keywords of each clause have to be unique, so they can't be `,`.
+    // names in oilist.  This is due to an apparent limitation in the MLIR
+    // custom-format parser.  In oilist, the initial keywords of each clause
+    // have to be unique, so they can't be `,`.
     //
     // Even if we gave up on order-independence and used vanilla optional
     // clauses, the format (`,` `foo` `=` $foo^)? (`,` `bar` `=` $bar^)?  will
@@ -295,7 +307,9 @@ def TT_LoadOp : TT_Op<"load", [
       $ptr (`,` $mask^)? (`,` $other^)?
       oilist(
         `cacheModifier` `=` $cache |
-        `evictionPolicy` `=` $evict
+        `evictionPolicy` `=` $evict |
+        `memSemantic` `=` $sem |
+        `memSyncScope` `=` $scope
       )
       attr-dict `:` type($ptr)
     }];
@@ -322,29 +336,49 @@ def TT_StoreOp : TT_Op<"store", [
       Optional<TT_BoolLike>:$mask,
       DefaultValuedAttr<DenseI32ArrayAttr, "::llvm::ArrayRef<int32_t>{}">:$boundaryCheck,
       DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache,
-      DefaultValuedAttr<TT_EvictionPolicyAttr, "triton::EvictionPolicy::NORMAL">:$evict
+      DefaultValuedAttr<TT_EvictionPolicyAttr, "triton::EvictionPolicy::NORMAL">:$evict,
+      OptionalAttr<TT_MemSemanticAttr>:$sem,
+      OptionalAttr<TT_MemSyncScopeAttr>:$scope
     );
 
     let builders = [
         // A tensor of pointers or a pointer to a scalar
-        OpBuilder<(ins "Value":$ptr, "Value":$value, "triton::CacheModifier":$cache, "triton::EvictionPolicy":$evict)>,
+        OpBuilder<(ins "Value":$ptr, "Value":$value, "triton::CacheModifier":$cache, "triton::EvictionPolicy":$evict,
+                       "std::optional<triton::MemSemantic>":$sem,
+                       "std::optional<triton::MemSyncScope>":$scope)>,
         // A tensor of pointers or a pointer to a scalar with mask
         OpBuilder<(ins "Value":$ptr, "Value":$value, "Value":$mask, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict)>,
+                       "triton::EvictionPolicy":$evict,
+                       "std::optional<triton::MemSemantic>":$sem,
+                       "std::optional<triton::MemSyncScope>":$scope)>,
         // A tensor pointer with boundary check
         OpBuilder<(ins "Value":$ptr, "Value":$value, "ArrayRef<int32_t>":$boundaryCheck, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict)>
+                       "triton::EvictionPolicy":$evict,
+                       "std::optional<triton::MemSemantic>":$sem,
+                       "std::optional<triton::MemSyncScope>":$scope)>,
+        // A utility function to build the operation with all attributes
+        OpBuilder<(ins "Value":$ptr, "Value":$value, "Value":$mask,
+                       "ArrayRef<int32_t>":$boundaryCheck,
+                       "triton::CacheModifier":$cache,
+                       "triton::EvictionPolicy":$evict,
+                       "std::optional<triton::MemSemantic>":$sem,
+                       "std::optional<triton::MemSyncScope>":$scope)>
     ];
 
-    // Specify cacheModifier and evictionPolicy explicitly, instead of leaving
-    // them in attr-dict, because this way their values get printed as strings,
-    // rather than as opaque integers.
+    // Specify cacheModifier, evictionPolicy, memSemantic and memSyncScope
+    // explicitly, instead of leaving them in attr-dict, because this way their
+    // values get printed as strings, rather than as opaque integers.
     //
-    // Note there are no commas between mask, cacheModifier, and evictionPolicy,
-    // due to limitations in MLIR's asm parser.
+    // Note there are no commas between mask, cacheModifier / ..., due to
+    // limitations in MLIR's asm parser.
     let assemblyFormat = [{
       $ptr `,` $value (`,` $mask^)?
-      oilist(`cacheModifier` `=` $cache | `evictionPolicy` `=` $evict)
+      oilist(
+        `cacheModifier` `=` $cache |
+        `evictionPolicy` `=` $evict |
+        `memSemantic` `=` $sem |
+        `memSyncScope` `=` $scope
+      )
       attr-dict `:` type($ptr)
     }];
 

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -134,7 +134,8 @@ public:
     rewriter.replaceOpWithNewOp<LoadOp>(
         op, loadOp.getPtr(), loadOp.getMask(), /*other=*/falseValue,
         loadOp.getBoundaryCheckAttr(), loadOp.getPaddingAttr(),
-        loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
+        loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile(),
+        loadOp.getSemAttr(), loadOp.getScopeAttr());
     return success();
   }
 };

--- a/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
@@ -311,12 +311,14 @@ public:
     if (auto loadOp = dyn_cast<triton::LoadOp>(op)) {
       auto newResult = builder.create<triton::LoadOp>(
           loadOp.getLoc(), newPtr, newMask, newOther, loadOp.getCache(),
-          loadOp.getEvict(), loadOp.getIsVolatile());
+          loadOp.getEvict(), loadOp.getIsVolatile(), loadOp.getSem(),
+          loadOp.getScope());
       op->getResult(0).replaceAllUsesWith(newResult);
     } else if (auto storeOp = dyn_cast<triton::StoreOp>(op)) {
       builder.create<triton::StoreOp>(storeOp.getLoc(), newPtr,
                                       storeOp.getValue(), newMask,
-                                      storeOp.getCache(), storeOp.getEvict());
+                                      storeOp.getCache(), storeOp.getEvict(),
+                                      storeOp.getSem(), storeOp.getScope());
     }
 
     // Erase the original operation

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1226,47 +1226,56 @@ void init_triton_ir(py::module &&m) {
       // Input/Output
       .def("create_load",
            [](TritonOpBuilder &self, Value &ptrs, CacheModifier cacheModifier,
-              EvictionPolicy evictionPolicy, bool isVolatile) -> Value {
+              EvictionPolicy evictionPolicy, bool isVolatile,
+              std::optional<MemSemantic> sem,
+              std::optional<MemSyncScope> scope) -> Value {
              return self.create<LoadOp>(ptrs, cacheModifier, evictionPolicy,
-                                        isVolatile);
+                                        isVolatile, sem, scope);
            })
       .def("create_store",
            [](TritonOpBuilder &self, Value &ptrs, Value &value,
-              CacheModifier cacheModifier,
-              EvictionPolicy evictionPolicy) -> void {
-             self.create<StoreOp>(ptrs, value, cacheModifier, evictionPolicy);
+              CacheModifier cacheModifier, EvictionPolicy evictionPolicy,
+              std::optional<MemSemantic> sem,
+              std::optional<MemSyncScope> scope) -> void {
+             self.create<StoreOp>(ptrs, value, cacheModifier, evictionPolicy,
+                                  sem, scope);
            })
       .def("create_tensor_pointer_load",
            [](TritonOpBuilder &self, Value &ptr,
               std::vector<int32_t> &boundaryCheck,
               std::optional<PaddingOption> paddingOption,
               CacheModifier cacheModifier, EvictionPolicy evictionPolicy,
-              bool isVolatile) -> Value {
+              bool isVolatile, std::optional<MemSemantic> sem,
+              std::optional<MemSyncScope> scope) -> Value {
              return self.create<LoadOp>(ptr, boundaryCheck, paddingOption,
                                         cacheModifier, evictionPolicy,
-                                        isVolatile);
+                                        isVolatile, sem, scope);
            })
       .def("create_tensor_pointer_store",
            [](TritonOpBuilder &self, Value &ptr, Value &val,
               std::vector<int32_t> &boundaryCheck, CacheModifier cacheModifier,
-              EvictionPolicy evictionPolicy) -> void {
+              EvictionPolicy evictionPolicy, std::optional<MemSemantic> sem,
+              std::optional<MemSyncScope> scope) -> void {
              self.create<StoreOp>(ptr, val, boundaryCheck, cacheModifier,
-                                  evictionPolicy);
+                                  evictionPolicy, sem, scope);
            })
       .def("create_masked_load",
            [](TritonOpBuilder &self, Value &ptrs, Value &mask,
               std::optional<Value> &other, CacheModifier cacheModifier,
-              EvictionPolicy evictionPolicy, bool isVolatile) -> Value {
+              EvictionPolicy evictionPolicy, bool isVolatile,
+              std::optional<MemSemantic> sem,
+              std::optional<MemSyncScope> scope) -> Value {
              return self.create<LoadOp>(ptrs, mask, other.value_or(Value()),
                                         cacheModifier, evictionPolicy,
-                                        isVolatile);
+                                        isVolatile, sem, scope);
            })
       .def("create_masked_store",
            [](TritonOpBuilder &self, Value &ptrs, Value &val, Value &mask,
-              CacheModifier cacheModifier,
-              EvictionPolicy evictionPolicy) -> void {
+              CacheModifier cacheModifier, EvictionPolicy evictionPolicy,
+              std::optional<MemSemantic> sem,
+              std::optional<MemSyncScope> scope) -> void {
              self.create<StoreOp>(ptrs, val, mask, cacheModifier,
-                                  evictionPolicy);
+                                  evictionPolicy, sem, scope);
            })
       .def("create_descriptor_load",
            [](TritonOpBuilder &self, Value &desc_ptr,

--- a/test/TritonGPU/loadstore.mlir
+++ b/test/TritonGPU/loadstore.mlir
@@ -1,0 +1,10 @@
+// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu=target=cuda:80 -convert-triton-gpu-to-llvm 2>&1 | FileCheck %s
+
+// CHECK-LABEL: @load_store_ops_atomic
+tt.func @load_store_ops_atomic(%ptr: !tt.ptr<f32>) {
+  // CHECK: llvm.inline_asm {{.*}} "mov.u32 $0, 0x0;\0A\09@$2 ld.relaxed.gpu.global.b32 { $0 }, [ $1 + 0 ];", "=r,l,b"
+  %0 = tt.load %ptr memSemantic = relaxed memSyncScope = gpu : !tt.ptr<f32>
+  // CHECK: llvm.inline_asm {{.*}} "@$2 st.acquire.cta.global.b32 [ $1 + 0 ], { $0 };", "r,l,b"
+  tt.store %ptr, %0 memSemantic = acquire memSyncScope = cta : !tt.ptr<f32>
+  tt.return
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
@@ -154,7 +154,8 @@ public:
     }
 
     rewriter.replaceOpWithNewOp<triton::StoreOp>(
-        stOp, newPtr, newVal, newMask, stOp.getCache(), stOp.getEvict());
+        stOp, newPtr, newVal, newMask, stOp.getCache(), stOp.getEvict(),
+        stOp.getSem(), stOp.getScope());
     return mlir::success();
   }
 };

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -246,9 +246,14 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       auto *addrOpr =
           ptxBuilder.newAddrOperand(ptrElems[vecStart], "l", in_off);
 
+      auto sem = op.getSem() ? stringifyMemSemantic(*op.getSem()).str() : "";
+      auto scope =
+          op.getScope() ? stringifyMemSyncScope(*op.getScope()).str() : "";
       // Define the instruction opcode
       auto &ld = ptxBuilder.create<>("ld")
                      ->o("volatile", op.getIsVolatile())
+                     .o(sem, !!op.getSem())
+                     .o(scope, !!op.getScope())
                      .global()
                      .o("ca", op.getCache() == triton::CacheModifier::CA)
                      .o("cg", op.getCache() == triton::CacheModifier::CG)
@@ -441,9 +446,14 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
       auto *asmAddr =
           ptxBuilder.newAddrOperand(ptrElems[vecStart], "l", in_off);
 
+      auto sem = op.getSem() ? stringifyMemSemantic(*op.getSem()).str() : "";
+      auto scope =
+          op.getScope() ? stringifyMemSyncScope(*op.getScope()).str() : "";
       auto &ptxStoreInstr =
           ptxBuilder.create<>("st")
-              ->global()
+              ->o(sem, !!op.getSem())
+              .o(scope, !!op.getScope())
+              .global()
               .o("wb", op.getCache() == triton::CacheModifier::WB)
               .o("cg", op.getCache() == triton::CacheModifier::CG)
               .o("cs", op.getCache() == triton::CacheModifier::CS)


### PR DESCRIPTION
This patch adds `sem` / `scope` option to `tl.{load,store}`. These options allow even more refined synchronization when necessary.

One of such optimization possibility would be L180, L187 of [`LayerNorm` tutorial](https://github.com/triton-lang/triton/blob/main/python/tutorials/05-layer-norm.py#L180), where `atomic_xchg` can be replaced with `tl.store(..., sem="release")` instead.

The reason why `tl.store` is superior here is that `st.global.acquire` is a fire-and-forget operation. Such operations don't block threadblock from exiting and releasing the SM for subsequent threadblocks to execute. `tl.atomic_xchg`, to the contrary, cannot be retired until the old value is returned from memory subsystem, therefore incurring a latency of costly memory roundtrip.

---

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
