### PR TITLE
[CI][AMD] Create a CI docker with non-root user

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -299,7 +299,7 @@ jobs:
     name: Integration-Tests (${{matrix.runner[1] == 'gfx90a' && 'mi210' || 'mi300x'}})
     container:
       image: rocm/pytorch:rocm6.1_ubuntu22.04_py3.10_pytorch_2.4
-      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --user root
+      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -417,10 +417,6 @@ jobs:
           mkdir -p ~/.cache/ccache
           ls -alh ~/.cache/ccache
           du -sh ~/.cache/ccache
-      - name: Clean up caches
-        run: |
-          rm -rf ~/.triton
-          rm -rf ~/.cache
   Build-Tests:
     needs: Runner-Preparation
     if: needs.Runner-Preparation.outputs.matrix-MACOS != ''

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -347,7 +347,7 @@ jobs:
 
     container:
       image: rocm/pytorch:rocm6.1_ubuntu22.04_py3.10_pytorch_2.4
-      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --user root
+      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video
 
     steps:
       - name: Checkout
@@ -402,11 +402,6 @@ jobs:
       - *run-cpp-unittests-step
       - *save-build-artifacts-step
       - *inspect-cache-directories-step
-
-      - name: Clean up caches
-        run: |
-          rm -rf ~/.triton
-          rm -rf ~/.cache
 
   Build-Tests:
     needs: Runner-Preparation


### PR DESCRIPTION
Upstream CI uses the root user to create a Docker container for integration tests on AMD servers. As a result, we have to manually delete the ~/.triton and ~/.cache directories. Switch to a non-root user for Docker so that these directories can be cleaned up automatically.