### PR TITLE
Enable verbose asm

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -116,6 +116,8 @@ std::string translateLLVMIRToASM(llvm::Module &module,
   opt.NoInfsFPMath = false;
   opt.NoNaNsFPMath = true;
   opt.TrapUnreachable = true;
+  opt.MCOptions.AsmVerbose = true;
+  opt.MCOptions.PreserveAsmComments = true;
   std::unique_ptr<llvm::TargetMachine> machine{target->createTargetMachine(
       module.getTargetTriple(), proc, features, opt, llvm::Reloc::PIC_,
       std::nullopt,


### PR DESCRIPTION
This PR adds verbosity to assembly code after LLVM backend passes.

Regarding the AMDGPU backend, the PR results in leaving references to the source code. For example:

```bash
.LBB0_11:                               ;   in Loop: Header=BB0_13 Depth=1
        .loc    1 131 18                        ; gemm.py:131:18
        v_lshl_add_u64 v[6:7], v[14:15], 0, v[18:19]
        .loc    1 126 22                        ; gemm.py:126:22
        v_lshl_add_u64 v[2:3], v[16:17], 0, v[18:19]
        .loc    1 128 20                        ; gemm.py:128:20
        global_load_dwordx4 v[2:5], v[2:3], off
        s_nop 0
        global_load_dwordx4 v[10:13], v[6:7], off
        .loc    1 127 20                        ; gemm.py:127:20
        s_nop 0
        global_load_dwordx4 v[6:9], v[20:21], off offset:32
        v_mov_b64_e32 v[24:25], v[22:23]
```

Additionally, the PR results in adding `Kernel Info` at the end of a file. For example:

```bash
; Kernel info:                                                                                                                                                                                                
; codeLenInByte = 7732                                                                                                                                                                                        
; NumSgprs: 24                                                                                                                                                                                                
; NumVgprs: 154                                                                                                                                                                                               
; NumAgprs: 128                                                                                                                                                                                               
; TotalNumVgprs: 284                                                                                                                                                                                          
; ScratchSize: 0                                                                                                                                                                                              
; MemoryBound: 1                                                                                                                                                                                              
; FloatMode: 240                                                                                                                                                                                              
; IeeeMode: 1                                                                                                                                                                                                 
; LDSByteSize: 0 bytes/workgroup (compile time only)                                                                                                                                                          
; SGPRBlocks: 2                                                                                                                                                                                               
; VGPRBlocks: 35                                                                                                                                                                                              
; NumSGPRsForWavesPerEU: 24                                                                                                                                                                                   
; NumVGPRsForWavesPerEU: 284                                                                                                                                                                                  
; AccumOffset: 156                                                                                                                                                                                            
; Occupancy: 1                                                                                                                                                                                                
; WaveLimiterHint : 0                                                                                                                                                                                         
; COMPUTE_PGM_RSRC2:SCRATCH_EN: 0                                                                                                                                                                             
; COMPUTE_PGM_RSRC2:USER_SGPR: 2                                                                                                                                                                              
; COMPUTE_PGM_RSRC2:TRAP_HANDLER: 0                                                                                                                                                                           
; COMPUTE_PGM_RSRC2:TGID_X_EN: 1                                                                                                                                                                              
; COMPUTE_PGM_RSRC2:TGID_Y_EN: 0                                                                                                                                                                              
; COMPUTE_PGM_RSRC2:TGID_Z_EN: 0                                                                                                                                                                              
; COMPUTE_PGM_RSRC2:TIDIG_COMP_CNT: 0                                                                                                                                                                         
; COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: 38
; COMPUTE_PGM_RSRC3_GFX90A:TG_SPLIT: 0
```
