### PR TITLE
Add mechanism for remapping device-specific module imports

### DIFF
--- a/python/test/unit/runtime/test_bindings.py
+++ b/python/test/unit/runtime/test_bindings.py
@@ -75,10 +75,11 @@ def test_module_walk(device):
     backend = triton.compiler.compiler.make_backend(target)
     options = backend.parse_options(dict())
     codegen_fns = dict()
+    module_map = backend.get_module_map()
     triton._C.libtriton.ir.load_dialects(context)
     backend.load_dialects(context)
 
-    ttir_module = src.make_ir(options, codegen_fns, context)
+    ttir_module = src.make_ir(options, codegen_fns, module_map, context)
     ttir_module.walk(walk_fn)
 
 

--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -4,7 +4,8 @@ import subprocess
 
 from abc import ABCMeta, abstractmethod, abstractclassmethod
 from dataclasses import dataclass
-from typing import Union
+from typing import Dict, Union
+from types import ModuleType
 
 
 @dataclass(frozen=True)
@@ -72,5 +73,12 @@ class BaseBackend(metaclass=ABCMeta):
     def load_dialects(self, context):
         """
         Load additional MLIR dialects into the provided `context`
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_module_map(self) -> Dict[str, ModuleType]:
+        """
+        Return a map of interface modules to their device-specific implementations.
         """
         raise NotImplementedError

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -188,8 +188,8 @@ class ContainsReturnChecker(ast.NodeVisitor):
 class CodeGenerator(ast.NodeVisitor):
 
     def __init__(self, context, prototype, gscope, attributes, constants, function_name, jit_fn: JITFunction, options,
-                 codegen_fns, debug=None, module=None, is_kernel=False, function_types: Optional[Dict] = None,
-                 noinline=False, file_name: Optional[str] = None, begin_line=0):
+                 codegen_fns, module_map, debug=None, module=None, is_kernel=False,
+                 function_types: Optional[Dict] = None, noinline=False, file_name: Optional[str] = None, begin_line=0):
         self.context = context
         self.builder = ir.builder(context)
         self.file_name = file_name
@@ -201,10 +201,23 @@ class CodeGenerator(ast.NodeVisitor):
         # Convert custom types not natively supported on HW.
         # convert_custom_types(intput_tensor, dtype, fp_downcast_rounding=None, _builder=None)
         self.builder.codegen_fns = codegen_fns
+        self.builder.module_map = {} if module_map is None else module_map
         self.module = self.builder.create_module() if module is None else module
         self.function_ret_types = {} if function_types is None else function_types
         self.prototype = prototype
-        self.gscope = gscope
+
+        self.gscope = {}
+        for k, v in gscope.items():
+            if isinstance(v, ModuleType):
+                self.gscope[k] = module_map.get(v.__name__, v)
+                continue
+
+            module_name = getattr(v, "__module__", "")
+            if module_name in module_map:
+                self.gscope[k] = getattr(module_map[module_name], k)
+            else:
+                self.gscope[k] = v
+
         self.lscope = {}
         self.attributes = attributes
         self.constants = constants
@@ -1049,7 +1062,8 @@ class CodeGenerator(ast.NodeVisitor):
             generator = CodeGenerator(self.context, prototype, gscope, attributes, constants, module=self.module,
                                       jit_fn=fn, function_name=fn_name, function_types=self.function_ret_types,
                                       noinline=fn.noinline, file_name=file_name, begin_line=begin_line,
-                                      options=self.builder.options, codegen_fns=self.builder.codegen_fns, debug=debug)
+                                      options=self.builder.options, codegen_fns=self.builder.codegen_fns,
+                                      module_map=self.builder.module_map, debug=debug)
             try:
                 generator.visit(fn.parse())
             except Exception as e:
@@ -1252,7 +1266,7 @@ def kernel_suffix(signature, specialization):
     return suffix
 
 
-def ast_to_ttir(fn, specialization, context, options, codegen_fns):
+def ast_to_ttir(fn, specialization, context, options, codegen_fns, module_map):
     attrs = specialization.attrs
     # create kernel prototype
     cst_key = lambda i: fn.arg_names.index(i) if isinstance(i, str) else i
@@ -1272,7 +1286,7 @@ def ast_to_ttir(fn, specialization, context, options, codegen_fns):
     prototype = language.function_type([], arg_types)
     generator = CodeGenerator(context, prototype, gscope=gscope, constants=all_constants, function_name=function_name,
                               jit_fn=fn, attributes=new_attrs, is_kernel=True, file_name=file_name,
-                              begin_line=begin_line, options=options, codegen_fns=codegen_fns)
+                              begin_line=begin_line, options=options, codegen_fns=codegen_fns, module_map=module_map)
     generator.visit(fn.parse())
 
     ret = generator.module

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -109,8 +109,9 @@ class ASTSource:
         key = f"{self.fn.cache_key}-{self.attrs.hash()}-{sorted_sig}-{sorted_constants}"
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
-    def make_ir(self, options, codegen_fns, context):
-        return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns)
+    def make_ir(self, options, codegen_fns, module_map, context):
+        return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
+                           module_map=module_map)
 
     def parse_options(self):
         return dict()
@@ -132,7 +133,7 @@ class IRSource:
     def hash(self):
         return hashlib.sha256(self.src.encode("utf-8")).hexdigest()
 
-    def make_ir(self, options, codegen_fns, context):
+    def make_ir(self, options, codegen_fns, module_map, context):
         module = ir.parse_mlir_module(self.path, context)
         module.context = context
         return module
@@ -277,8 +278,9 @@ def compile(src, target=None, options=None):
     ir.load_dialects(context)
     backend.load_dialects(context)
     codegen_fns = backend.get_codegen_implementation()
+    module_map = backend.get_module_map()
     try:
-        module = src.make_ir(options, codegen_fns, context)
+        module = src.make_ir(options, codegen_fns, module_map, context)
     except Exception as e:
         filter_traceback(e)
         raise

--- a/python/triton/language/extra/libdevice.py
+++ b/python/triton/language/extra/libdevice.py
@@ -1,1213 +1,786 @@
-from .cuda import libdevice as cuda_libdevice
-from .hip import libdevice as hip_libdevice
-from triton.language import core
-from functools import wraps
-from typing import TypeVar
-
-T = TypeVar('T')
-
-
-def dispatch(fn: T) -> T:
-    """Dispatch a function to a correct implementation."""
-    assert callable(fn)
-
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        _backend = kwargs["_builder"].options.backend_name
-        if _backend == 'cuda':
-            _curr_libdevice_module = cuda_libdevice
-        elif _backend == 'hip':
-            _curr_libdevice_module = hip_libdevice
-        else:
-            raise RuntimeError('unknown backend')
-
-        try:
-            _impl = getattr(_curr_libdevice_module, fn.__name__)
-        except AttributeError:
-            raise RuntimeError(f'`{_backend}` does not provide support for `{fn.__name__}` extra function')
-
-        return _impl(*args, **kwargs)
-
-    return wrapper
-
-
-@core.extern
-@dispatch
-def clz(arg0, _builder=None):
+def clz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def popc(arg0, _builder=None):
+def popc(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def byte_perm(arg0, arg1, arg2, _builder=None):
+def byte_perm(arg0, arg1, arg2):
     ...
 
 
-@core.extern
-@dispatch
-def mulhi(arg0, arg1, _builder=None):
+def mulhi(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def mul24(arg0, arg1, _builder=None):
+def mul24(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def brev(arg0, _builder=None):
+def brev(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def sad(arg0, arg1, arg2, _builder=None):
+def sad(arg0, arg1, arg2):
     ...
 
 
-@core.extern
-@dispatch
-def abs(arg0, _builder=None):
+def abs(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def floor(arg0, _builder=None):
+def floor(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def rcp64h(arg0, _builder=None):
+def rcp64h(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def rsqrt(arg0, _builder=None):
+def rsqrt(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ceil(arg0, _builder=None):
+def ceil(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def trunc(arg0, _builder=None):
+def trunc(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def exp2(arg0, _builder=None):
+def exp2(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def saturatef(arg0, _builder=None):
+def saturatef(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def fma_rn(arg0, arg1, arg2, _builder=None):
+def fma_rn(arg0, arg1, arg2):
     ...
 
 
-@core.extern
-@dispatch
-def fma_rz(arg0, arg1, arg2, _builder=None):
+def fma_rz(arg0, arg1, arg2):
     ...
 
 
-@core.extern
-@dispatch
-def fma_rd(arg0, arg1, arg2, _builder=None):
+def fma_rd(arg0, arg1, arg2):
     ...
 
 
-@core.extern
-@dispatch
-def fma_ru(arg0, arg1, arg2, _builder=None):
+def fma_ru(arg0, arg1, arg2):
     ...
 
 
-@core.extern
-@dispatch
-def fast_dividef(arg0, arg1, _builder=None):
+def fast_dividef(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def div_rn(arg0, arg1, _builder=None):
+def div_rn(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def div_rz(arg0, arg1, _builder=None):
+def div_rz(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def div_rd(arg0, arg1, _builder=None):
+def div_rd(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def div_ru(arg0, arg1, _builder=None):
+def div_ru(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def rcp_rn(arg0, _builder=None):
+def rcp_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def rcp_rz(arg0, _builder=None):
+def rcp_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def rcp_rd(arg0, _builder=None):
+def rcp_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def rcp_ru(arg0, _builder=None):
+def rcp_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def sqrt_rn(arg0, _builder=None):
+def sqrt_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def sqrt_rz(arg0, _builder=None):
+def sqrt_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def sqrt_rd(arg0, _builder=None):
+def sqrt_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def sqrt_ru(arg0, _builder=None):
+def sqrt_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def sqrt(arg0, _builder=None):
+def sqrt(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def add_rn(arg0, arg1, _builder=None):
+def add_rn(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def add_rz(arg0, arg1, _builder=None):
+def add_rz(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def add_rd(arg0, arg1, _builder=None):
+def add_rd(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def add_ru(arg0, arg1, _builder=None):
+def add_ru(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def mul_rn(arg0, arg1, _builder=None):
+def mul_rn(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def mul_rz(arg0, arg1, _builder=None):
+def mul_rz(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def mul_rd(arg0, arg1, _builder=None):
+def mul_rd(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def mul_ru(arg0, arg1, _builder=None):
+def mul_ru(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def double2float_rn(arg0, _builder=None):
+def double2float_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2float_rz(arg0, _builder=None):
+def double2float_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2float_rd(arg0, _builder=None):
+def double2float_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2float_ru(arg0, _builder=None):
+def double2float_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2int_rn(arg0, _builder=None):
+def double2int_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2int_rz(arg0, _builder=None):
+def double2int_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2int_rd(arg0, _builder=None):
+def double2int_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2int_ru(arg0, _builder=None):
+def double2int_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2uint_rn(arg0, _builder=None):
+def double2uint_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2uint_rz(arg0, _builder=None):
+def double2uint_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2uint_rd(arg0, _builder=None):
+def double2uint_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2uint_ru(arg0, _builder=None):
+def double2uint_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def int2double_rn(arg0, _builder=None):
+def int2double_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def uint2double_rn(arg0, _builder=None):
+def uint2double_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2int_rn(arg0, _builder=None):
+def float2int_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2int_rz(arg0, _builder=None):
+def float2int_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2int_rd(arg0, _builder=None):
+def float2int_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2int_ru(arg0, _builder=None):
+def float2int_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2uint_rn(arg0, _builder=None):
+def float2uint_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2uint_rz(arg0, _builder=None):
+def float2uint_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2uint_rd(arg0, _builder=None):
+def float2uint_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2uint_ru(arg0, _builder=None):
+def float2uint_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def int2float_rn(arg0, _builder=None):
+def int2float_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def int2float_rz(arg0, _builder=None):
+def int2float_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def int2float_rd(arg0, _builder=None):
+def int2float_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def int2float_ru(arg0, _builder=None):
+def int2float_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def uint2float_rn(arg0, _builder=None):
+def uint2float_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def uint2float_rz(arg0, _builder=None):
+def uint2float_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def uint2float_rd(arg0, _builder=None):
+def uint2float_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def uint2float_ru(arg0, _builder=None):
+def uint2float_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def hiloint2double(arg0, arg1, _builder=None):
+def hiloint2double(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def double2loint(arg0, _builder=None):
+def double2loint(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2hiint(arg0, _builder=None):
+def double2hiint(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2ll_rn(arg0, _builder=None):
+def float2ll_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2ll_rz(arg0, _builder=None):
+def float2ll_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2ll_rd(arg0, _builder=None):
+def float2ll_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2ll_ru(arg0, _builder=None):
+def float2ll_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2ull_rn(arg0, _builder=None):
+def float2ull_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2ull_rz(arg0, _builder=None):
+def float2ull_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2ull_rd(arg0, _builder=None):
+def float2ull_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float2ull_ru(arg0, _builder=None):
+def float2ull_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2ll_rn(arg0, _builder=None):
+def double2ll_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2ll_rz(arg0, _builder=None):
+def double2ll_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2ll_rd(arg0, _builder=None):
+def double2ll_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2ll_ru(arg0, _builder=None):
+def double2ll_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2ull_rn(arg0, _builder=None):
+def double2ull_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2ull_rz(arg0, _builder=None):
+def double2ull_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2ull_rd(arg0, _builder=None):
+def double2ull_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double2ull_ru(arg0, _builder=None):
+def double2ull_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ll2float_rn(arg0, _builder=None):
+def ll2float_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ll2float_rz(arg0, _builder=None):
+def ll2float_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ll2float_rd(arg0, _builder=None):
+def ll2float_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ll2float_ru(arg0, _builder=None):
+def ll2float_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ull2float_rn(arg0, _builder=None):
+def ull2float_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ull2float_rz(arg0, _builder=None):
+def ull2float_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ull2float_rd(arg0, _builder=None):
+def ull2float_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ull2float_ru(arg0, _builder=None):
+def ull2float_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ll2double_rn(arg0, _builder=None):
+def ll2double_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ll2double_rz(arg0, _builder=None):
+def ll2double_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ll2double_rd(arg0, _builder=None):
+def ll2double_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ll2double_ru(arg0, _builder=None):
+def ll2double_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ull2double_rn(arg0, _builder=None):
+def ull2double_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ull2double_rz(arg0, _builder=None):
+def ull2double_rz(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ull2double_rd(arg0, _builder=None):
+def ull2double_rd(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ull2double_ru(arg0, _builder=None):
+def ull2double_ru(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def int_as_float(arg0, _builder=None):
+def int_as_float(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float_as_int(arg0, _builder=None):
+def float_as_int(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def uint_as_float(arg0, _builder=None):
+def uint_as_float(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def float_as_uint(arg0, _builder=None):
+def float_as_uint(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def longlong_as_double(arg0, _builder=None):
+def longlong_as_double(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def double_as_longlong(arg0, _builder=None):
+def double_as_longlong(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def fast_sinf(arg0, _builder=None):
+def fast_sinf(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def fast_cosf(arg0, _builder=None):
+def fast_cosf(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def fast_log2f(arg0, _builder=None):
+def fast_log2f(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def fast_logf(arg0, _builder=None):
+def fast_logf(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def fast_expf(arg0, _builder=None):
+def fast_expf(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def fast_tanf(arg0, _builder=None):
+def fast_tanf(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def fast_exp10f(arg0, _builder=None):
+def fast_exp10f(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def fast_log10f(arg0, _builder=None):
+def fast_log10f(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def fast_powf(arg0, arg1, _builder=None):
+def fast_powf(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def hadd(arg0, arg1, _builder=None):
+def hadd(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def rhadd(arg0, arg1, _builder=None):
+def rhadd(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def sub_rn(arg0, arg1, _builder=None):
+def sub_rn(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def sub_rz(arg0, arg1, _builder=None):
+def sub_rz(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def sub_rd(arg0, arg1, _builder=None):
+def sub_rd(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def sub_ru(arg0, arg1, _builder=None):
+def sub_ru(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def rsqrt_rn(arg0, _builder=None):
+def rsqrt_rn(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ffs(arg0, _builder=None):
+def ffs(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def rint(arg0, _builder=None):
+def rint(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def llrint(arg0, _builder=None):
+def llrint(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def nearbyint(arg0, _builder=None):
+def nearbyint(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def isnan(arg0, _builder=None):
+def isnan(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def signbit(arg0, _builder=None):
+def signbit(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def copysign(arg0, arg1, _builder=None):
+def copysign(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def finitef(arg0, _builder=None):
+def finitef(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def isinf(arg0, _builder=None):
+def isinf(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def nextafter(arg0, arg1, _builder=None):
+def nextafter(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def sin(arg0, _builder=None):
+def sin(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def cos(arg0, _builder=None):
+def cos(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def sinpi(arg0, _builder=None):
+def sinpi(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def cospi(arg0, _builder=None):
+def cospi(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def tan(arg0, _builder=None):
+def tan(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def log2(arg0, _builder=None):
+def log2(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def exp(arg0, _builder=None):
+def exp(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def exp10(arg0, _builder=None):
+def exp10(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def cosh(arg0, _builder=None):
+def cosh(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def sinh(arg0, _builder=None):
+def sinh(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def tanh(arg0, _builder=None):
+def tanh(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def atan2(arg0, arg1, _builder=None):
+def atan2(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def atan(arg0, _builder=None):
+def atan(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def asin(arg0, _builder=None):
+def asin(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def acos(arg0, _builder=None):
+def acos(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def log(arg0, _builder=None):
+def log(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def log10(arg0, _builder=None):
+def log10(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def log1p(arg0, _builder=None):
+def log1p(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def acosh(arg0, _builder=None):
+def acosh(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def asinh(arg0, _builder=None):
+def asinh(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def atanh(arg0, _builder=None):
+def atanh(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def expm1(arg0, _builder=None):
+def expm1(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def hypot(arg0, arg1, _builder=None):
+def hypot(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def rhypot(arg0, arg1, _builder=None):
+def rhypot(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def norm3d(arg0, arg1, arg2, _builder=None):
+def norm3d(arg0, arg1, arg2):
     ...
 
 
-@core.extern
-@dispatch
-def rnorm3d(arg0, arg1, arg2, _builder=None):
+def rnorm3d(arg0, arg1, arg2):
     ...
 
 
-@core.extern
-@dispatch
-def norm4d(arg0, arg1, arg2, arg3, _builder=None):
+def norm4d(arg0, arg1, arg2, arg3):
     ...
 
 
-@core.extern
-@dispatch
-def rnorm4d(arg0, arg1, arg2, arg3, _builder=None):
+def rnorm4d(arg0, arg1, arg2, arg3):
     ...
 
 
-@core.extern
-@dispatch
-def cbrt(arg0, _builder=None):
+def cbrt(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def rcbrt(arg0, _builder=None):
+def rcbrt(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def j0(arg0, _builder=None):
+def j0(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def j1(arg0, _builder=None):
+def j1(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def y0(arg0, _builder=None):
+def y0(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def y1(arg0, _builder=None):
+def y1(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def yn(arg0, arg1, _builder=None):
+def yn(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def jn(arg0, arg1, _builder=None):
+def jn(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def cyl_bessel_i0(arg0, _builder=None):
+def cyl_bessel_i0(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def cyl_bessel_i1(arg0, _builder=None):
+def cyl_bessel_i1(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def erf(arg0, _builder=None):
+def erf(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def erfinv(arg0, _builder=None):
+def erfinv(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def erfc(arg0, _builder=None):
+def erfc(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def erfcx(arg0, _builder=None):
+def erfcx(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def erfcinv(arg0, _builder=None):
+def erfcinv(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def normcdfinv(arg0, _builder=None):
+def normcdfinv(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def normcdf(arg0, _builder=None):
+def normcdf(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def lgamma(arg0, _builder=None):
+def lgamma(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def ldexp(arg0, arg1, _builder=None):
+def ldexp(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def scalbn(arg0, arg1, _builder=None):
+def scalbn(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def fmod(arg0, arg1, _builder=None):
+def fmod(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def remainder(arg0, arg1, _builder=None):
+def remainder(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def fma(arg0, arg1, arg2, _builder=None):
+def fma(arg0, arg1, arg2):
     ...
 
 
-@core.extern
-@dispatch
-def pow(arg0, arg1, _builder=None):
+def pow(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def tgamma(arg0, _builder=None):
+def tgamma(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def round(arg0, _builder=None):
+def round(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def llround(arg0, _builder=None):
+def llround(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def fdim(arg0, arg1, _builder=None):
+def fdim(arg0, arg1):
     ...
 
 
-@core.extern
-@dispatch
-def ilogb(arg0, _builder=None):
+def ilogb(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def logb(arg0, _builder=None):
+def logb(arg0):
     ...
 
 
-@core.extern
-@dispatch
-def isfinited(arg0, _builder=None):
+def isfinited(arg0):
     ...

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -1,7 +1,8 @@
 from triton.backends.compiler import BaseBackend, GPUTarget
 from triton._C.libtriton import ir, passes, llvm, amd
 from dataclasses import dataclass
-from typing import Any, Tuple
+from typing import Any, Dict, Tuple
+from types import ModuleType
 import hashlib
 import tempfile
 import os
@@ -94,6 +95,10 @@ class HIPBackend(BaseBackend):
     def get_codegen_implementation(self):
         codegen_fns = {"min_dot_size": min_dot_size(self.target)}
         return codegen_fns
+
+    def get_module_map(self) -> Dict[str, ModuleType]:
+        from triton.language.extra.hip import libdevice
+        return {"triton.language.extra.libdevice": libdevice}
 
     def load_dialects(self, ctx):
         amd.load_dialects(ctx)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -3,7 +3,8 @@ from triton._C.libtriton import ir, passes, llvm, nvidia
 
 from dataclasses import dataclass
 import functools
-from typing import Any, Tuple, Optional
+from typing import Any, Dict, Tuple, Optional
+from types import ModuleType
 import hashlib
 import re
 import tempfile
@@ -154,6 +155,10 @@ class CUDABackend(BaseBackend):
             "min_dot_size": min_dot_size(self.target)
         }
         return codegen_fns
+
+    def get_module_map(self) -> Dict[str, ModuleType]:
+        from triton.language.extra.cuda import libdevice
+        return {"triton.language.extra.libdevice": libdevice}
 
     def load_dialects(self, ctx):
         nvidia.load_dialects(ctx)


### PR DESCRIPTION
This is motivated by #4509. The crux of the problem is that the Triton code generator needs to inspect a function's arguments / attributes / types in order to determine how it should be called. This meant that "implementation details" like whether a function is a builtin needed to be exposed in the "interface" `tl.extra.libdevice` module, instead of just residing in `tl.extra.cuda.libdevice`. Moreover, this meant that libdevice functions marked as `@core.extern` in the interface could not be implemented via JitFunctions.

Allowing each backend to provide its own module map solves this problem as the code generator can inspect the actual function implementation.