### PR TITLE
[TEST] Insert barriers in test_atomic_cas to sequence store and atomic

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1537,7 +1537,7 @@ def test_atomic_cas(sem, num_ctas, device):
 
         # insert barrier to set a fence between tl.store and
         # tl.atomic_xchg in a block.
-        tl.debug_barrier
+        tl.debug_barrier()
 
         # release lock
         tl.atomic_xchg(Lock, 0)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1535,6 +1535,10 @@ def test_atomic_cas(sem, num_ctas, device):
 
         tl.store(ptrs, tl.load(ptrs) + 1.0)
 
+        # insert barrier to set a fence between tl.store and
+        # tl.atomic_xchg in a block.
+        tl.debug_barrier
+
         # release lock
         tl.atomic_xchg(Lock, 0)
 


### PR DESCRIPTION
Add tl.debug_barrier to perform a sync in the atomic_cas test implementing spinning lock.

Detailed analysis and discussion can be found [here](https://github.com/triton-lang/triton/pull/4504)
This is a quick fix to avoid failures in the CI until the `tl.debug_barrier` is renamed.
