### PR TITLE
[Frontend] Add TRITON_PRINT_AUTOTUNING_ALL flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ For detailed instructions on how to debug Triton's frontend, please refer to thi
   from the IR to llir/ptx. When used with performance tools, it can provide a
   breakdown on IR instructions.
 - `TRITON_PRINT_AUTOTUNING=1` prints out the best autotuning config and total time
-  spent for each kernel after autotuning is complete.
+- `TRITON_PRINT_AUTOTUNING_ALL=1` prints out all autotuning configs and their
+  timings in sorted order (based on the timings for each config).
 - `DISABLE_LLVM_OPT` will disable llvm optimizations for make_llir and make_ptx
   if its value is true when parsing as Bool. Otherwise, it will be parsed as a list
   of flags to disable llvm optimizations. One usage case is

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -153,6 +153,15 @@ class Autotuner(KernelInterface):
                 timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
                 bench_end = time.time()
                 self.bench_time = bench_end - bench_start
+
+                if os.getenv("TRITON_PRINT_AUTOTUNING_ALL", None) == "1":
+                    print(
+                        f'\nPrinting ALL Multiple Triton autotuning Configs with timings in sorted order for kernel {self.fn}:'
+                    )
+                    sorted_configs = builtins.sorted(timings, key=timings.get)
+                    for config in sorted_configs:
+                        print(f'Triton autotune config: [{config}]; Triton autotune timing: {timings[config]}')
+
                 self.cache[key] = builtins.min(timings, key=timings.get)
                 self.pre_hook(args, reset_only=True)
                 self.configs_timings = timings


### PR DESCRIPTION
When the `TRITON_PRINT_AUTOTUNING_ALL` envvar is set to 1, we print all of the autotuning configurations for a given kernel in a sorted order based on the kernel timings including the timing data.

For example:

```
Printing ALL Multiple Triton autotuning Configs with timings in sorted order for kernel JITFunction(_ragged_hstu_attn_fwd):
Triton autotune config: [BLOCK_M: 64, BLOCK_N: 64, num_warps: 4, num_stages: 2]; Triton autotune timing: [1.4173120260238647, 1.4117120504379272, 1.4213504791259766]
Triton autotune config: [BLOCK_M: 64, BLOCK_N: 32, num_warps: 4, num_stages: 4]; Triton autotune timing: [1.4553600549697876, 1.4507968425750732, 1.4593983888626099]
```

The purpose of this change is to bring more clarity to how different configs stack up; it is especially useful as we are lately beginning to autotune on on operations (ie tma and others) that may not bring benefit to all configurations equally. 

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.
  
  Still deciding how to test this one, it is a print debugging feature.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices]