### PR TITLE
[Tutorial] 06-fused-attention.py - add tma

### DIFF
--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -866,7 +866,7 @@ for mode in ["fwd", "bwd"]:
 @triton.testing.perf_report(configs)
 def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, causal, mode, provider, device="cuda"):
     assert mode in ["fwd", "bwd"]
-    warmup = 100
+    warmup = 25
     rep = 100
     dtype = torch.float16
     if "triton" in provider:

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -834,7 +834,7 @@ except BaseException:
     HAS_FLASH = False
 
 TORCH_HAS_FP8 = hasattr(torch, 'float8_e5m2')
-BATCH, N_HEADS, HEAD_DIM = 4, 32, 256
+BATCH, N_HEADS, HEAD_DIM = 4, 32, 64
 # vary seq length for fixed head and batch=4
 configs = []
 for mode in ["fwd", "bwd"]:


### PR DESCRIPTION
The 06-fused-attention.py tutorial in main branch uses wgmma + ampere style data global <-> shared data movement for h100, this PR follows the [09-persistent-matmul](https://github.com/triton-lang/triton/blob/9678b7bc5ad33ff39e9f2d9832d3ddf647c22e5e/python/tutorials/09-persistent-matmul.py) and uses TMA to accelerate fmha example.

For `head_dim=128`, before this PR:
```
fused-attention-batch4-head32-d128-fwd-causal=True:
     N_CTX  Triton [FP16]  Triton [FP8]
0   1024.0     255.001455    380.843146
1   2048.0     339.603041    518.101187
2   4096.0     367.804545    607.757811
3   8192.0     393.788176    616.632098
4  16384.0     409.263439    643.386141
fused-attention-batch4-head32-d128-fwd-causal=False:
     N_CTX  Triton [FP16]  Triton [FP8]
0   1024.0     356.375551    518.155324
1   2048.0     387.535175    614.806708
2   4096.0     406.549204    649.706238
3   8192.0     413.173759    634.801467
4  16384.0     418.687253    657.212211
```

after this PR:
```
fused-attention-batch4-head32-d128-fwd-causal=True:
     N_CTX  Triton [FP16]  Triton [FP8]
0   1024.0     254.176899    381.703473
1   2048.0     361.485787    514.115450
2   4096.0     426.777702    569.721516
3   8192.0     406.660984    619.809159
4  16384.0     499.860504    646.409083
fused-attention-batch4-head32-d128-fwd-causal=False:
     N_CTX  Triton [FP16]  Triton [FP8]
0   1024.0     375.001262    513.416653
1   2048.0     461.075326    606.167586
2   4096.0     487.595498    631.766760
3   8192.0     515.922185    635.139286
4  16384.0     507.458845    654.998838
```

When input is fp8, the `SoftwarePipeliner` pass failed (segmentation fault) at https://github.com/triton-lang/triton/blob/9678b7bc5ad33ff39e9f2d9832d3ddf647c22e5e/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp#L208-L209, so I disabled TMA for fp8 inputs at the moment.

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
