### PR TITLE
Use base64 for shorter cache directories

### DIFF
--- a/python/triton/runtime/cache.py
+++ b/python/triton/runtime/cache.py
@@ -5,6 +5,7 @@ import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict, List, Optional
+import base64
 import hashlib
 
 
@@ -255,6 +256,11 @@ __cache_cls = FileCacheManager
 __cache_cls_nme = "DEFAULT"
 
 
+def _base64(key):
+    # Assume key is a hex string.
+    return base64.urlsafe_b64encode(bytes.fromhex(key)).decode("utf-8").rstrip("=")
+
+
 def get_cache_manager(key) -> CacheManager:
     import os
 
@@ -268,15 +274,15 @@ def get_cache_manager(key) -> CacheManager:
         __cache_cls = getattr(module, clz_nme)
         __cache_cls_nme = user_cache_manager
 
-    return __cache_cls(key)
+    return __cache_cls(_base64(key))
 
 
 def get_override_manager(key) -> CacheManager:
-    return __cache_cls(key, override=True)
+    return __cache_cls(_base64(key), override=True)
 
 
 def get_dump_manager(key) -> CacheManager:
-    return __cache_cls(key, dump=True)
+    return __cache_cls(_base64(key), dump=True)
 
 
 def make_so_cache_key(version_hash, signature, constants, ids, **kwargs):
@@ -286,4 +292,4 @@ def make_so_cache_key(version_hash, signature, constants, ids, **kwargs):
     for kw in kwargs:
         key = f"{key}-{kwargs.get(kw)}"
     key = hashlib.sha256(key.encode("utf-8")).hexdigest()
-    return key
+    return _base64(key)


### PR DESCRIPTION
Not sure this is worthy to make it? I was annoyed by long sha256-based cache directory names, mostly 64 chars. So I quickly added base64-based shorter cache directory names.

Instead of fixing a dozen places that use `hashlib.sha256`, I patched the cache manager. 64-char names are mostly reduced to 43-44 chars.

A comparison:
```
> % ls -l $TRITON_CACHE_DIR
total 0
drwxr-xr-x 1 minjang users  40 Aug 21 19:02 44ae4aee7ef0ee0dd54e860cf44627e3b6cedabe87a228ac75988301b8a6bf60
drwxr-xr-x 1 minjang users  26 Aug 21 19:02 82dc2c9a5508bf07c72e02353c1e751dc54aae85666f139b2867b0a1e95e0e7b
drwxr-xr-x 1 minjang users 226 Aug 21 19:02 b8e240968a85711ba57b17bf8450f1ffbc85a8de8cd1f47aa87b241b53f9bf60
drwxr-xr-x 1 minjang users  26 Aug 21 19:03 gtwsmlUIvwfHLgI1PB51HcVKroVmbxObKGewoeleDns
drwxr-xr-x 1 minjang users  40 Aug 21 19:03 RK5K7n7w7g3VToYM9EYn47bO2r6HoiisdZiDAbimv2A
drwxr-xr-x 1 minjang users 226 Aug 21 19:03 uOJAloqFcRulexe_hFDx_7yFqN6M0fR6qHskG1P5v2A
```

`test_core.py` runs without any errors, and the cache directory has all base64-based shorter names.