### PR TITLE
Hoist reduction outside a loop

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -58,6 +58,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUAccelerateMatmul();
   mlir::registerTritonAMDGPUOptimizeEpilogue();
   mlir::registerTritonAMDGPUReorderInstructions();
+  mlir::registerTritonAMDGPUHoistReduction();
   mlir::registerTritonAMDGPUStreamPipeline();
   mlir::registerTritonAMDGPUStreamPipelineV2();
 

--- a/test/Conversion/amd/hoist-reduction.mlir
+++ b/test/Conversion/amd/hoist-reduction.mlir
@@ -1,0 +1,37 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-hoist-reduction | FileCheck %s
+
+// CHECK-LABEL: hoist_reduction
+// CHECK: %[[CST:.+]] = arith.constant dense<0>
+// CHECK: %[[PRE_DOT_CVT:.+]] = triton_gpu.convert_layout %[[CST]]
+// CHECK: %[[FOR_RESULT:.+]] = scf.for {{.*}}
+// CHECK: %[[DOT_RESULT:.+]] = tt.dot
+// CHECK: scf.yield %[[DOT_RESULT]]
+// CHECK: %[[REDUCED:.+]] = "tt.reduce"(%[[FOR_RESULT]])
+// CHECK: %[[FINAL_RESULT:.+]] = triton_gpu.convert_layout %[[REDUCED]]
+// CHECK: tt.store {{.*}} %[[FINAL_RESULT]]
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 2, 2], order = [2, 1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 2, 2], order = [2, 1, 0]}>
+module attributes {"triton_gpu.target" = "hip:gfx1030", "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @hoist_reduction(%x : tensor<8x1x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>, %y : tensor<8x64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>, %ptr : tensor<1x32x!tt.ptr<i32>, #blocked1>) {
+    %iter_begin = arith.constant 0 : i32
+    %iter_end = arith.constant 3 : i32
+    %iter_step = arith.constant 1 : i32
+    %zero = arith.constant dense<0> : tensor<1x32xi32, #blocked1>
+    %acc = scf.for %iter = %iter_begin to %iter_end step %iter_step iter_args(%acc = %zero) -> (tensor<1x32xi32, #blocked1>)  : i32 {
+      %acc_ext = tt.reshape %acc {allow_reorder = true} : tensor<1x32xi32, #blocked1> -> tensor<1x1x32xi32, #blocked2>
+      %acc3d_batched = tt.broadcast %acc_ext : tensor<1x1x32xi32, #blocked2> -> tensor<8x1x32xi32, #blocked2>
+      %acc3d_in = triton_gpu.convert_layout %acc3d_batched : tensor<8x1x32xi32, #blocked2> -> tensor<8x1x32xi32, #blocked>
+      %acc3d_out = tt.dot %x, %y, %acc3d_in : tensor<8x1x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<8x64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<8x1x32xi32, #blocked>
+      %acc_next_slice = "tt.reduce"(%acc3d_out) <{axis = 0 : i32}> ({
+        ^bb0(%arg0: i32, %arg1: i32):
+            %sum = arith.addi %arg0, %arg1 : i32
+            tt.reduce.return %sum : i32
+      }) : (tensor<8x1x32xi32, #blocked>) -> tensor<1x32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %acc_next = triton_gpu.convert_layout %acc_next_slice : tensor<1x32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked1>
+      scf.yield %acc_next : tensor<1x32xi32, #blocked1>
+    }
+    tt.store %ptr, %acc : tensor<1x32x!tt.ptr<i32>, #blocked1>
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -152,6 +152,7 @@ class HIPBackend(BaseBackend):
         passes.ttgpuir.add_optimize_thread_locality(pm)
         amd.passes.ttgpuir.add_accelerate_matmul(pm, options.arch, options.matrix_instr_nonkdim, options.kpack)
         passes.ttgpuir.add_remove_layout_conversions(pm)
+        amd.passes.ttgpuir.add_hoist_reduction(pm)
         amd.passes.ttgpuir.add_optimize_epilogue(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, True)
         use_new_pipeliner = os.getenv("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0") == "1"

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -23,6 +23,8 @@ std::unique_ptr<Pass> createTritonAMDGPUVerifier();
 
 std::unique_ptr<Pass> createTritonAMDGPUOptimizeEpiloguePass();
 
+std::unique_ptr<Pass> createTritonAMDGPUHoistReductionPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "TritonAMDGPUTransforms/Passes.h.inc"

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -84,4 +84,30 @@ def TritonAMDGPUReorderInstructions: Pass<"tritonamdgpu-reorder-instructions", "
   let dependentDialects = [];
 }
 
+
+def TritonAMDGPUHoistReduction : Pass<"tritonamdgpu-hoist-reduction", "mlir::ModuleOp"> {
+  let summary = "hoist reduction operation applied to dot accumulator outside of loop over K";
+
+  let description = [{
+    Optimization hoists reduction operation out of the loop:
+
+    %acc = <zero tensor>
+    for k tiles:
+      %acc3d_input = reshape %acc
+      %acc3d_out = dot3d(%x, %y, %acc3d_input)
+      %acc = reduction batch %acc3d_out
+
+    transformed to:
+
+    %acc3d = <zero tensor>
+    for k tiles:
+      %acc3d = dot3d(%x, %y, %acc3d)
+    %acc = reduction batch %acc3d
+  }];
+
+  let constructor = "mlir::createTritonAMDGPUHoistReductionPass()";
+
+  let dependentDialects = [];
+}
+
 #endif

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_triton_library(TritonAMDGPUTransforms
   ReorderInstructions.cpp
   StreamPipeline.cpp
   StreamPipelineV2.cpp
+  HoistReduction.cpp
   MfmaGroup.cpp
 
   DEPENDS

--- a/third_party/amd/lib/TritonAMDGPUTransforms/HoistReduction.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/HoistReduction.cpp
@@ -1,0 +1,213 @@
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+// This pass hoists auxiliar operations over dot outside the K loop
+// Example of optimized loop:
+//
+//   void kernel() {
+//     x = tensor<8, 1, 64>
+//     y = tensor<8, 64, 32>
+//     acc = tensor<1, 32>
+//     for (iter = 0; iter < 3; ++iter) {
+//       acc = reshape(acc, <1, 1, 32>)
+//       acc = broadcast(acc, <8, 1, 32>)
+//       acc = dot(x, y, acc)
+//       acc = reduce_sum(acc, axis = 0)
+//     }
+//     store(acc)
+//   }
+//
+// Transforms to:
+//
+//   void kernel() {
+//     x = tensor<8, 1, 64>
+//     y = tensor<8, 64, 32>
+//     acc = tensor<1, 32>
+//     acc = reshape(acc, <1, 1, 32>)
+//     acc = broadcast(acc, <8, 1, 32>)
+//     for (iter = 0; iter < 3; ++iter) {
+//       acc = dot(x, y, acc)
+//     }
+//     acc = reduce_sum(acc, axis = 0)
+//     store(acc)
+//   }
+
+using namespace mlir;
+
+namespace {
+
+bool isPermutableOp(const mlir::Operation &op) {
+  return isa<mlir::arith::AddIOp>(op) || isa<mlir::arith::AddFOp>(op);
+}
+
+bool isApproprateReduction(triton::ReduceOp op) {
+  if (op.getAxis() != 0)
+    return false;
+  auto redBody = op.getBody();
+  if (redBody->getNumSuccessors() != 0)
+    return false;
+  auto &redBodyOps = redBody->getOperations();
+  if (redBodyOps.size() != 2)
+    return false;
+  auto &redBaseOp = redBodyOps.front();
+  auto returnOp = cast<triton::ReduceReturnOp>(redBodyOps.back());
+  if (redBaseOp.getNumResults() != 1)
+    return false;
+  if (!isPermutableOp(redBaseOp) &&
+      returnOp.getOperand(0) != redBaseOp.getResult(0))
+    return false;
+  return true;
+}
+
+struct dotReductionChainOperations {
+  BlockArgument loopBlockArg;
+  triton::ReshapeOp reshape;
+  triton::BroadcastOp broadcast;
+  triton::gpu::ConvertLayoutOp preDotConvert;
+  triton::DotOp dot;
+  triton::ReduceOp reduction;
+  triton::gpu::ConvertLayoutOp postDotConversion;
+  scf::YieldOp yield;
+  int yieldOpNo;
+};
+
+OpOperand *getSingleUse(Operation *op) {
+  if (!op->getResult(0).hasOneUse())
+    return nullptr;
+  return &(*op->getUses().begin());
+}
+
+std::optional<dotReductionChainOperations>
+matchDotReductionInLoopPattern(triton::ReduceOp redOp) {
+  dotReductionChainOperations chain;
+  chain.reduction = redOp;
+  auto postDotConversionOperand = getSingleUse(redOp);
+  if (!postDotConversionOperand)
+    return std::nullopt;
+  chain.postDotConversion = dyn_cast<triton::gpu::ConvertLayoutOp>(
+      postDotConversionOperand->getOwner());
+  if (!chain.postDotConversion)
+    return std::nullopt;
+  auto yieldOperand = getSingleUse(chain.postDotConversion);
+  if (!yieldOperand)
+    return std::nullopt;
+  chain.yieldOpNo = yieldOperand->getOperandNumber();
+  chain.yield = dyn_cast<scf::YieldOp>(yieldOperand->getOwner());
+  if (!chain.yield)
+    return std::nullopt;
+  chain.dot = dyn_cast<triton::DotOp>(redOp->getOperand(0).getDefiningOp());
+  if (!chain.dot)
+    return std::nullopt;
+  chain.preDotConvert =
+      dyn_cast<triton::gpu::ConvertLayoutOp>(chain.dot.getC().getDefiningOp());
+  if (!chain.preDotConvert)
+    return std::nullopt;
+  chain.broadcast = dyn_cast<triton::BroadcastOp>(
+      chain.preDotConvert.getSrc().getDefiningOp());
+  if (!chain.broadcast)
+    return std::nullopt;
+  chain.reshape =
+      dyn_cast<triton::ReshapeOp>(chain.broadcast.getSrc().getDefiningOp());
+  if (!chain.reshape)
+    return std::nullopt;
+  auto loopArgument = dyn_cast<BlockArgument>(chain.reshape.getSrc());
+  if (!loopArgument || loopArgument.getArgNumber() != chain.yieldOpNo + 1)
+    return std::nullopt;
+  chain.loopBlockArg = loopArgument;
+  return chain;
+}
+
+void hoistReductionOps(mlir::PatternRewriter &rewriter, scf::ForOp loopOp,
+                       dotReductionChainOperations dfChain) {
+  auto accInitializer = loopOp.getInitArgs()[dfChain.yieldOpNo];
+
+  // hoist operations outside the loop
+  rewriter.moveOpBefore(dfChain.reshape, loopOp);
+  rewriter.moveOpBefore(dfChain.broadcast, loopOp);
+  rewriter.moveOpBefore(dfChain.preDotConvert, loopOp);
+
+  rewriter.moveOpAfter(dfChain.reduction, loopOp);
+  rewriter.moveOpAfter(dfChain.postDotConversion, dfChain.reduction);
+
+  // adjust operations DF
+  dfChain.reshape.setOperand(accInitializer);
+  loopOp.setOperand(dfChain.yieldOpNo + 3, dfChain.preDotConvert);
+  dfChain.dot.setOperand(2, dfChain.loopBlockArg);
+  dfChain.yield.setOperand(dfChain.yieldOpNo, dfChain.dot);
+
+  rewriter.replaceAllUsesWith(loopOp.getResult(dfChain.yieldOpNo),
+                              dfChain.postDotConversion);
+  dfChain.reduction.setOperand(0, loopOp.getResult(dfChain.yieldOpNo));
+
+  // adjust loop types
+  auto newAccTy = dfChain.preDotConvert.getType();
+  // loopOp.getOperand(dfChain.yieldOpNo + 3).setType(newAccTy);
+  loopOp.getResult(dfChain.yieldOpNo).setType(newAccTy);
+  dfChain.loopBlockArg.setType(newAccTy);
+}
+
+class HoistReduction : public mlir::RewritePattern {
+
+public:
+  explicit HoistReduction(mlir::MLIRContext *context)
+      : mlir::RewritePattern(triton::ReduceOp::getOperationName(), 1, context) {
+  }
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto redOp = llvm::cast<triton::ReduceOp>(op);
+    if (!isApproprateReduction(redOp))
+      return failure();
+
+    auto loopOp = dyn_cast<scf::ForOp>(redOp->getParentOp());
+    if (!loopOp)
+      return failure();
+
+    auto matchedDotReduction = matchDotReductionInLoopPattern(redOp);
+    if (!matchedDotReduction.has_value())
+      return failure();
+
+    hoistReductionOps(rewriter, loopOp, matchedDotReduction.value());
+
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+#define GEN_PASS_CLASSES
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+
+class TritonAMDGPUHoistReductionPass
+    : public TritonAMDGPUHoistReductionBase<TritonAMDGPUHoistReductionPass> {
+
+public:
+  TritonAMDGPUHoistReductionPass() = default;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp m = getOperation();
+
+    mlir::RewritePatternSet patterns(context);
+
+    patterns.add<HoistReduction>(context);
+
+    if (applyPatternsAndFoldGreedily(m, std::move(patterns)).failed()) {
+      signalPassFailure();
+    }
+  }
+};
+
+std::unique_ptr<Pass> mlir::createTritonAMDGPUHoistReductionPass() {
+  return std::make_unique<TritonAMDGPUHoistReductionPass>();
+}

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -54,6 +54,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_3("add_accelerate_matmul",
                      mlir::createTritonAMDGPUAccelerateMatmulPass,
                      const std::string, int, int);
+  ADD_PASS_WRAPPER_0("add_hoist_reduction",
+                     mlir::createTritonAMDGPUHoistReductionPass);
   ADD_PASS_WRAPPER_0("add_optimize_epilogue",
                      mlir::createTritonAMDGPUOptimizeEpiloguePass);
   ADD_PASS_WRAPPER_0("add_reorder_instructions",


### PR DESCRIPTION
This PR introduces an optimization that hoists reduction operation of dot accumulator outside a loop over K dimension:

  %acc = <zero tensor>
  for k tiles:
    %acc3d_input = reshape %acc
    %acc3d_out = dot3d(%x, %y, %acc3d_input)
    %acc = reduction batch %acc3d_out

transforms to:

  %acc3d = <zero tensor>
  for k tiles:
    %acc3d = dot3d(%x, %y, %acc3d)
  %acc = reduction batch %acc3d

This PR is a part of PR series. Final goal is to improve efficiency of small dot operations and bypass as much shared memory accesses as possible.

Rough list of PRs:
- [ ] Basic FMA dot fixes, dot 3d support and relaxing small dimensions for dot #4516
- [ ] Blocked->dotOp shared memory bypassing #4538
- [ ] Accelerate AMD Matmul + emit dot operations #4594
- [ ] Layout optimization, so operand B is loaded in proper mfma layout and do not need to go through LDS #4581 
- [ ] Vectorization optimization of dot operands/results (in case llvm can not do this internally)
- [ ] Reduction operation hoisting out of the K loop (reduction operation is a byproduct of layout optimization step) **(this PR)** #4559