### PR TITLE
[AMD] Cherry-pick commits from mainline to support Flex attention on AMD gpus

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -183,7 +183,7 @@ def get_llvm_package_info():
     with open(llvm_hash_path, "r") as llvm_hash_file:
         rev = llvm_hash_file.read(8)
     name = f"llvm-{rev}-{system_suffix}"
-    url = f"https://tritonlang.blob.core.windows.net/llvm-builds/{name}.tar.gz"
+    url = f"https://oaitriton.blob.core.windows.net/public/llvm-builds/{name}.tar.gz"
     return Package("llvm", name, url, "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
 
 

--- a/test/Conversion/amd/amd-convert-builtin-func.mlir
+++ b/test/Conversion/amd/amd-convert-builtin-func.mlir
@@ -1,0 +1,63 @@
+// RUN: triton-opt --convert-builtin-func-to-llvm %s | FileCheck %s
+
+// Trying to merge those blocks will cause a lot of duplication in the block arguments, which will cause
+// an exponential growth of the argument length. Make sure we don't try to merge those blocks.
+module {
+  llvm.func @rand() -> i1
+  llvm.func @"__predicated_store_!llvm.void_!llvm.ptr<1>_i32_i1_"(!llvm.ptr<1>, i32, i1) attributes {libname = "", libpath = ""}
+
+  llvm.func @top(%arg0: i64, %1 : !llvm.ptr<1>, %2 : !llvm.ptr<1>, %3 : !llvm.ptr<1>, %4 : !llvm.ptr<1>) {
+    %0 = llvm.mlir.constant(0 : i64) : i64
+    %10 = llvm.icmp "eq" %arg0, %0 : i64
+    %true = llvm.mlir.constant(1 : i1) : i1
+    %c = llvm.mlir.constant(1 : i32) : i32
+    // CHECK: llvm.cond_br {{.*}}, ^bb{{.*}}, ^bb{{.*}}
+    llvm.cond_br %10, ^bb1, ^bb14
+  ^bb1:  // pred: ^bb0
+    %11 = llvm.call @rand() : () -> i1
+    // CHECK: llvm.cond_br {{.*}}, ^bb{{.*}}, ^bb{{.*}}
+    llvm.cond_br %11, ^bb2, ^bb3
+  ^bb2:  // pred: ^bb1
+    llvm.call @"__predicated_store_!llvm.void_!llvm.ptr<1>_i32_i1_"(%1, %c, %true) : (!llvm.ptr<1>, i32, i1) -> ()
+    llvm.br ^bb4
+  ^bb3:  // pred: ^bb1
+    llvm.call @"__predicated_store_!llvm.void_!llvm.ptr<1>_i32_i1_"(%2, %c, %true) : (!llvm.ptr<1>, i32, i1) -> ()
+    llvm.br ^bb4
+  ^bb4:  // 2 preds: ^bb2, ^bb3
+    %14 = llvm.call @rand() : () -> i1
+    // CHECK: llvm.cond_br {{.*}}, ^bb{{.*}}, ^bb{{.*}}
+    llvm.cond_br %14, ^bb5, ^bb6
+  ^bb5:  // pred: ^bb4
+    llvm.call @"__predicated_store_!llvm.void_!llvm.ptr<1>_i32_i1_"(%3, %c, %true) : (!llvm.ptr<1>, i32, i1) -> ()
+    llvm.br ^bb13
+  ^bb6:  // pred: ^bb4
+    llvm.call @"__predicated_store_!llvm.void_!llvm.ptr<1>_i32_i1_"(%4, %c, %true) : (!llvm.ptr<1>, i32, i1) -> ()
+    llvm.br ^bb13
+  ^bb13:  // 2 preds: ^bb11, ^bb12
+    llvm.br ^bb27
+  ^bb14:  // pred: ^bb0
+    %23 = llvm.call @rand() : () -> i1
+    // CHECK: llvm.cond_br {{.*}}, ^bb{{.*}}, ^bb{{.*}}
+    llvm.cond_br %23, ^bb15, ^bb16
+  ^bb15:  // pred: ^bb14
+    llvm.call @"__predicated_store_!llvm.void_!llvm.ptr<1>_i32_i1_"(%4, %c, %true) : (!llvm.ptr<1>, i32, i1) -> ()
+    llvm.br ^bb17
+  ^bb16:  // pred: ^bb14
+    llvm.call @"__predicated_store_!llvm.void_!llvm.ptr<1>_i32_i1_"(%3, %c, %true) : (!llvm.ptr<1>, i32, i1) -> ()
+    llvm.br ^bb17
+  ^bb17:  // 2 preds: ^bb15, ^bb16
+    %26 = llvm.call @rand() : () -> i1
+    // CHECK: llvm.cond_br {{.*}}, ^bb{{.*}}, ^bb{{.*}}
+    llvm.cond_br %26, ^bb18, ^bb19
+  ^bb18:  // pred: ^bb17
+    llvm.call @"__predicated_store_!llvm.void_!llvm.ptr<1>_i32_i1_"(%2, %c, %true) : (!llvm.ptr<1>, i32, i1) -> ()
+    llvm.br ^bb26
+  ^bb19:  // pred: ^bb17
+    llvm.call @"__predicated_store_!llvm.void_!llvm.ptr<1>_i32_i1_"(%1, %c, %true) : (!llvm.ptr<1>, i32, i1) -> ()
+    llvm.br ^bb26
+  ^bb26:  // 2 preds: ^bb24, ^bb25
+    llvm.br ^bb27
+  ^bb27:  // 2 preds: ^bb13, ^bb26
+    llvm.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
@@ -165,10 +165,17 @@ struct ConvertBuiltinFuncToLLVM
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
 
+    // Disable block merging because of:
+    // https://github.com/llvm/llvm-project/issues/63230
+    // TODO(giuseros): enable block merging once the above ticket is completed
+    GreedyRewriteConfig config;
+    config.enableRegionSimplification = GreedySimplifyRegionLevel::Normal;
+
     RewritePatternSet patterns(context);
     patterns.add<CallOpConversion>(context);
 
-    if (mlir::applyPatternsAndFoldGreedily(mod, std::move(patterns)).failed()) {
+    if (mlir::applyPatternsAndFoldGreedily(mod, std::move(patterns), config)
+            .failed()) {
       signalPassFailure();
     }
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
@@ -169,7 +169,7 @@ struct ConvertBuiltinFuncToLLVM
     // https://github.com/llvm/llvm-project/issues/63230
     // TODO(giuseros): enable block merging once the above ticket is completed
     GreedyRewriteConfig config;
-    config.enableRegionSimplification = GreedySimplifyRegionLevel::Normal;
+    config.enableRegionSimplification = false;
 
     RewritePatternSet patterns(context);
     patterns.add<CallOpConversion>(context);


### PR DESCRIPTION
* Cherry-pick 06e6799f4eba6035ec35c528e8fefd3d4d724b6f to 3.0.x to fix build issue
* Cherry-pick cf2ad02324fc253970c3ab2666e775406405f213 to fix hang while running flex attention on AMD gpus
*  Fix build issue with cherry-pick of cf2ad02324fc253970c3ab2666e775406405f213
    * `enableRegionSimplification` was changed from boolen type to enum in mainline branch
