### PR TITLE
[BE][PIPELINE] Add fix for the wgmma pipelining bug with subview dist 1

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -1402,8 +1402,7 @@ static std::optional<int> dotCanBeProperlyAsync(ttng::WarpGroupDotOp dotOp,
         transitiveOperand =
             cast<scf::YieldOp>(blockArg.getOwner()->getTerminator())
                 .getOperand(blockArg.getArgNumber() - 1);
-      }
-      if (Operation *def = transitiveOperand.getDefiningOp()) {
+      } else if (Operation *def = transitiveOperand.getDefiningOp()) {
         transitiveOperand = def->getOperand(0);
       }
     }


### PR DESCRIPTION
If the subview for the mma operand is in the previous iteration of the loop, it would be skipped by the code that looks for it, if it feeds directly into the loop yield. This PR fixes that issue allowing for them subview to be found and enabling the pipelining in some cases skipped previously.