### PR TITLE
[WIP] Optimize fma dot

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -57,6 +57,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   // TritonAMDGPUTransforms passes
   mlir::registerTritonAMDGPUAccelerateMatmul();
   mlir::registerTritonAMDGPUOptimizeEpilogue();
+  mlir::registerTritonAMDGPUOptimizeFMADot();
   mlir::registerTritonAMDGPUReorderInstructions();
   mlir::registerTritonAMDGPUStreamPipeline();
   mlir::registerTritonAMDGPUStreamPipelineV2();

--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -203,6 +203,8 @@ bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy);
 
 bool atomicNeedsSharedMemory(Value result);
 
+bool isBlockedToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstT);
+
 bool isMfmaToDotShortcut(RankedTensorType srcTy, RankedTensorType dstTy);
 
 bool isMmaToDotShortcut(RankedTensorType srcTy, RankedTensorType dstTy);

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -236,6 +236,36 @@ private:
   const TargetInfoBase &targetInfo;
 };
 
+struct ConvertLayoutOpBlockedToDotOpShortcutConversion
+    : public ConvertOpToLLVMPattern<ConvertLayoutOp> {
+  const TargetInfoBase &targetInfo;
+  explicit ConvertLayoutOpBlockedToDotOpShortcutConversion(
+      LLVMTypeConverter &typeConverter, const TargetInfoBase &targetInfo,
+      PatternBenefit benefit = 1)
+      : ConvertOpToLLVMPattern(typeConverter, benefit), targetInfo(targetInfo) {
+  }
+
+  LogicalResult
+  matchAndRewrite(ConvertLayoutOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MLIRContext *ctx = op.getContext();
+
+    const auto &shape = op.getType().getShape();
+    auto srcTy = op.getSrc().getType();
+    auto dstTy = op.getType();
+    auto dstDotEncoding = dyn_cast<DotOperandEncodingAttr>(dstTy.getEncoding());
+    if (!dstDotEncoding)
+      return failure();
+    if (!dyn_cast<BlockedEncodingAttr>(srcTy.getEncoding()) ||
+        !dyn_cast<BlockedEncodingAttr>(dstDotEncoding.getParent()))
+      return failure();
+    if (cvtNeedsSharedMemory(srcTy, dstTy))
+      return failure();
+    rewriter.replaceOp(op, adaptor.getSrc());
+    return success();
+  }
+};
+
 struct ConvertLayoutOpUsingLinearLayoutsConversion
     : public ConvertOpToLLVMPattern<ConvertLayoutOp> {
   const TargetInfoBase &targetInfo;
@@ -649,5 +679,7 @@ void mlir::triton::populateConvertLayoutOpToLLVMPatterns(
   // one left.
   mlir::triton::populateConvertLayoutOpUsingLinearLayoutsToLLVMPattern(
       typeConverter, targetInfo, patterns, benefit.getBenefit() + 1);
+  patterns.add<ConvertLayoutOpBlockedToDotOpShortcutConversion>(
+      typeConverter, targetInfo, benefit);
   patterns.add<ConvertLayoutOpConversion>(typeConverter, targetInfo, benefit);
 }

--- a/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -83,6 +83,8 @@ void decomposeBlockedToDotLayoutConversion(ModuleOp module) {
     OpBuilder builder(cvtOp);
     auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
     auto dstType = cast<RankedTensorType>(cvtOp.getType());
+    if (!cvtNeedsSharedMemory(srcType, dstType))
+      return;
     auto srcBlocked =
         dyn_cast<triton::gpu::BlockedEncodingAttr>(srcType.getEncoding());
     auto dstDotOp =

--- a/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
@@ -42,22 +42,8 @@ public:
           dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
       if (!dstDotOp)
         return;
-      if (auto srcMmaEncoding =
-              dyn_cast<triton::gpu::NvidiaMmaEncodingAttr>(srcEncoding)) {
-
-        if (srcMmaEncoding.getVersionMajor() != 2 ||
-            (srcMmaEncoding.getWarpsPerCTA()[1] == 1 &&
-             dstDotOp.getParent() == srcMmaEncoding))
-          return;
-      }
-      if (auto srcMfmaEncoding =
-              dyn_cast<triton::gpu::AMDMfmaEncodingAttr>(srcEncoding)) {
-
-        if (srcMfmaEncoding.getWarpsPerCTA()[1] == 1 &&
-            srcMfmaEncoding.getIsTransposed() &&
-            dstDotOp.getParent() == srcMfmaEncoding)
-          return;
-      }
+      if (!cvtNeedsSharedMemory(srcType, dstType))
+        return;
       auto srcOrder = triton::gpu::getOrder(srcEncoding);
       auto rank = srcOrder.size();
       SmallVector<unsigned> sharedOrder;

--- a/test/Conversion/amd/decompose-unsupported-conversions.mlir
+++ b/test/Conversion/amd/decompose-unsupported-conversions.mlir
@@ -1,15 +1,43 @@
-// RUN: triton-opt %s --split-input-file --decompose-unsupported-amd-conversions=arch=gfx942 | FileCheck %s
+// RUN: triton-opt %s --split-input-file --decompose-unsupported-amd-conversions | FileCheck %s
 
 // CHECK: #[[BLOCKED:.+]] = #triton_gpu.blocked<{{.*}}>
 // CHECK: #[[WMMA:.+]] = #triton_gpu.amd_wmma<{{.*}}>
 // CHECK: #[[SHARED:.+]] = #triton_gpu.shared<{{.*}}>
 #mma = #triton_gpu.amd_wmma<{version = 1, warpsPerCTA = [2, 2]}>
-module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx1130", "triton_gpu.threads-per-warp" = 32 : i32} {
   tt.func @wmma_to_wmma_dot_op(%arg0: tensor<16x16xf16, #mma>) {
     // CHECK: %[[SRC_BLOCKED:.+]] = triton_gpu.convert_layout %{{.*}} : tensor<16x16xf16, #[[WMMA]]> -> tensor<16x16xf16, #[[BLOCKED]]>
     // CHECK-NEXT: %[[INT_SHARED:.+]] = triton_gpu.local_alloc %[[SRC_BLOCKED]] : {{.*}} -> !tt.memdesc<16x16xf16, #[[SHARED]], #triton_gpu.shared_memory>
     // CHECK-NEXT: %[[DST_DOT_OP:.+]] = triton_gpu.local_load %[[INT_SHARED]] : {{.*}} -> tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #[[WMMA]], kWidth = 16}>>
     %0 = triton_gpu.convert_layout %arg0 : tensor<16x16xf16, #mma> -> tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 16}>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: blocked_to_dot_op_shortcut_gfx1130
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx1130", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @blocked_to_dot_op_shortcut_gfx1130(%arg0: tensor<32x32xf16, #blocked>) {
+    // CHECK-NOT: triton_gpu.local_alloc
+    // CHECK: triton_gpu.convert_layout
+    // CHECK-NOT: triton_gpu.local_alloc
+    %0 = triton_gpu.convert_layout %arg0 : tensor<32x32xf16, #blocked> -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: blocked_to_dot_op_shortcut_gfx940
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 2], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx940", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @blocked_to_dot_op_shortcut_gfx940(%arg0: tensor<32x32xf16, #blocked>) {
+    // CHECK-NOT: triton_gpu.local_alloc
+    // CHECK: triton_gpu.convert_layout
+    // CHECK-NOT: triton_gpu.local_alloc
+    %0 = triton_gpu.convert_layout %arg0 : tensor<32x32xf16, #blocked> -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>
     tt.return
   }
 }

--- a/test/Conversion/amd/optimize-small-dot-operands.mlir
+++ b/test/Conversion/amd/optimize-small-dot-operands.mlir
@@ -1,0 +1,93 @@
+// RUN: triton-opt %s --tritonamdgpu-optimize-fma-dot=ksplit=8 -split-input-file | FileCheck --check-prefixes=K8,CHECK %s
+// RUN: triton-opt %s --tritonamdgpu-optimize-fma-dot=ksplit=64 -split-input-file | FileCheck --check-prefixes=K64,CHECK %s
+
+// CHECK-LABEL: dot_m1_n32
+// K8:       %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<1x512xi8, #{{.*}}> -> tensor<1x8x64xi8, #{{.*}}>
+// K64:      %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<1x512xi8, #{{.*}}> -> tensor<1x64x8xi8, #{{.*}}>
+// CHECK:    %[[DOT_A_TMP2:.*]] = tt.trans %[[DOT_A_TMP1:.*]]
+// CHECK:    %[[DOT_A:.*]] = triton_gpu.convert_layout %[[DOT_A_TMP2:.*]]
+// CHECK:    %[[DOT_B_TMP1:.*]] = tt.load {{.*}} : tensor<512x32x!tt.ptr<i8>
+// K8:       %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x32xi8, #{{.*}}> -> tensor<8x64x32xi8, #{{.*}}>
+// K64:      %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x32xi8, #{{.*}}> -> tensor<64x8x32xi8, #{{.*}}>
+// CHECK:    %[[DOT_B:.*]] = triton_gpu.convert_layout %[[DOT_B_TMP2]]
+// K8:       %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<8x1x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<8x64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<8x1x32xi32, #{{.*}}>
+// K64:      %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<64x1x8xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<64x8x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<64x1x32xi32, #{{.*}}>
+// CHECK:    %[[RED:.*]] = "tt.reduce"(%[[DOT_D]])
+// CHECK:    %[[STORE_VAL:.*]] = triton_gpu.convert_layout %[[RED]]
+// CHECK:    tt.store {{.*}}, %[[STORE_VAL]]
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 4], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @dot_m1_n32(%a: tensor<1x512xi8, #blocked>, %bPtr: tensor<512x32x!tt.ptr<i8>, #blocked>, %outPtr: tensor<1x32x!tt.ptr<i32>, #blocked>) {
+    %aOp = triton_gpu.convert_layout %a : tensor<1x512xi8, #blocked> -> tensor<1x512xi8, #dot_operand_a>
+    %b = tt.load %bPtr {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x32x!tt.ptr<i8>, #blocked>
+    %bOp = triton_gpu.convert_layout %b : tensor<512x32xi8, #blocked> -> tensor<512x32xi8, #dot_operand_b>
+    %c = arith.constant dense<0> : tensor<1x32xi32, #blocked>
+    %0 = tt.dot %aOp, %bOp, %c, inputPrecision = tf32 : tensor<1x512xi8, #dot_operand_a> * tensor<512x32xi8, #dot_operand_b> -> tensor<1x32xi32, #blocked>
+    tt.store %outPtr, %0 : tensor<1x32x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: dot_m1_n256
+// K8:       %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<1x512xi8, #{{.*}}> -> tensor<1x8x64xi8, #{{.*}}>
+// K64:      %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<1x512xi8, #{{.*}}> -> tensor<1x64x8xi8, #{{.*}}>
+// CHECK:    %[[DOT_A_TMP2:.*]] = tt.trans %[[DOT_A_TMP1:.*]]
+// CHECK:    %[[DOT_A:.*]] = triton_gpu.convert_layout %[[DOT_A_TMP2:.*]]
+// CHECK:    %[[DOT_B_TMP1:.*]] = tt.load {{.*}} : tensor<512x256x!tt.ptr<i8>
+// K8:       %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x256xi8, #{{.*}}> -> tensor<8x64x256xi8, #{{.*}}>
+// K64:      %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x256xi8, #{{.*}}> -> tensor<64x8x256xi8, #{{.*}}>
+// CHECK:    %[[DOT_B:.*]] = triton_gpu.convert_layout %[[DOT_B_TMP2]]
+// K8:       %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<8x1x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<8x64x256xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<8x1x256xi32, #{{.*}}>
+// K64:      %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<64x1x8xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<64x8x256xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<64x1x256xi32, #{{.*}}>
+// CHECK:    %[[RED:.*]] = "tt.reduce"(%[[DOT_D]])
+// CHECK:    %[[STORE_VAL:.*]] = triton_gpu.convert_layout %[[RED]]
+// CHECK:    tt.store {{.*}}, %[[STORE_VAL]]
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 4], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @dot_m1_n256(%a: tensor<1x512xi8, #blocked>, %bPtr: tensor<512x256x!tt.ptr<i8>, #blocked>, %outPtr: tensor<1x256x!tt.ptr<i32>, #blocked>) {
+    %aOp = triton_gpu.convert_layout %a : tensor<1x512xi8, #blocked> -> tensor<1x512xi8, #dot_operand_a>
+    %b = tt.load %bPtr {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256x!tt.ptr<i8>, #blocked>
+    %bOp = triton_gpu.convert_layout %b : tensor<512x256xi8, #blocked> -> tensor<512x256xi8, #dot_operand_b>
+    %c = arith.constant dense<0> : tensor<1x256xi32, #blocked>
+    %0 = tt.dot %aOp, %bOp, %c, inputPrecision = tf32 : tensor<1x512xi8, #dot_operand_a> * tensor<512x256xi8, #dot_operand_b> -> tensor<1x256xi32, #blocked>
+    tt.store %outPtr, %0 : tensor<1x256x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: dot_m2_n32
+// K8:       %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<2x512xi8, #{{.*}}> -> tensor<2x8x64xi8, #{{.*}}>
+// K64:      %[[DOT_A_TMP1:.*]] = tt.reshape {{.*}} {allow_reorder = true} : tensor<2x512xi8, #{{.*}}> -> tensor<2x64x8xi8, #{{.*}}>
+// CHECK:    %[[DOT_A_TMP2:.*]] = tt.trans %[[DOT_A_TMP1:.*]]
+// CHECK:    %[[DOT_A:.*]] = triton_gpu.convert_layout %[[DOT_A_TMP2:.*]]
+// CHECK:    %[[DOT_B_TMP1:.*]] = tt.load {{.*}} : tensor<512x32x!tt.ptr<i8>
+// K8:       %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x32xi8, #{{.*}}> -> tensor<8x64x32xi8, #{{.*}}>
+// K64:      %[[DOT_B_TMP2:.*]] = tt.reshape %[[DOT_B_TMP1]] {allow_reorder = true} : tensor<512x32xi8, #{{.*}}> -> tensor<64x8x32xi8, #{{.*}}>
+// CHECK:    %[[DOT_B:.*]] = triton_gpu.convert_layout %[[DOT_B_TMP2]]
+// K8:       %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<8x2x64xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<8x64x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<8x2x32xi32, #{{.*}}>
+// K64:      %[[DOT_D:.*]] = tt.dot %[[DOT_A]], %[[DOT_B]], %{{.*}} : tensor<64x2x8xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #{{.*}}}>> * tensor<64x8x32xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #{{.*}}}>> -> tensor<64x2x32xi32, #{{.*}}>
+// CHECK:    %[[RED:.*]] = "tt.reduce"(%[[DOT_D]])
+// CHECK:    %[[STORE_VAL:.*]] = triton_gpu.convert_layout %[[RED]]
+// CHECK:    tt.store {{.*}}, %[[STORE_VAL]]
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#blocked}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#blocked}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @dot_m2_n32(%a: tensor<2x512xi8, #blocked>, %bPtr: tensor<512x32x!tt.ptr<i8>, #blocked>, %outPtr: tensor<2x32x!tt.ptr<i32>, #blocked>) {
+    %aOp = triton_gpu.convert_layout %a : tensor<2x512xi8, #blocked> -> tensor<2x512xi8, #dot_operand_a>
+    %b = tt.load %bPtr {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x32x!tt.ptr<i8>, #blocked>
+    %bOp = triton_gpu.convert_layout %b : tensor<512x32xi8, #blocked> -> tensor<512x32xi8, #dot_operand_b>
+    %c = arith.constant dense<0> : tensor<2x32xi32, #blocked>
+    %0 = tt.dot %aOp, %bOp, %c, inputPrecision = tf32 : tensor<2x512xi8, #dot_operand_a> * tensor<512x32xi8, #dot_operand_b> -> tensor<2x32xi32, #blocked>
+    tt.store %outPtr, %0 : tensor<2x32x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm_block_dot_shortcut.mlir
+++ b/test/Conversion/tritongpu_to_llvm_block_dot_shortcut.mlir
@@ -1,0 +1,47 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-gpu-to-llvm | FileCheck %s
+
+// CHECK-LABEL: blocked_to_dot_op_shortcut_warp32
+#blocked = #triton_gpu.blocked<{sizePerThread = [32, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [0, 1]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:80", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @blocked_to_dot_op_shortcut_warp32(%arg0: tensor<32x32xf16, #blocked>, %arg1: tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) {
+    %0 = triton_gpu.convert_layout %arg0 : tensor<32x32xf16, #blocked> -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>
+    // CHECK-NOT: load
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: blocked_to_dot_op_shortcut_warp64
+#blocked = #triton_gpu.blocked<{sizePerThread = [32, 1], threadsPerWarp = [2, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx940", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @blocked_to_dot_op_shortcut_warp64(%arg0: tensor<32x32xf16, #blocked>) {
+    %0 = triton_gpu.convert_layout %arg0 : tensor<32x32xf16, #blocked> -> tensor<32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>
+    // CHECK-NOT: load
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: blocked_to_dot3d_op_shortcut_warp32
+#blocked = #triton_gpu.blocked<{sizePerThread = [2, 32, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [2, 1, 2], order = [1, 2, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:80", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @blocked_to_dot3d_op_shortcut_warp32(%arg0: tensor<8x32x32xf16, #blocked>) {
+    %0 = triton_gpu.convert_layout %arg0 : tensor<8x32x32xf16, #blocked> -> tensor<8x32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>
+    // CHECK-NOT: load
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: blocked_to_dot3d_op_shortcut_warp64
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 32, 1], threadsPerWarp = [1, 2, 32], warpsPerCTA = [2, 2, 1], order = [2, 1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "hip:gfx940", "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @blocked_to_dot3d_op_shortcut_warp64(%arg0: tensor<8x32x32xf16, #blocked>) {
+    %0 = triton_gpu.convert_layout %arg0 : tensor<8x32x32xf16, #blocked> -> tensor<8x32x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>
+    // CHECK-NOT: load
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -153,6 +153,7 @@ class HIPBackend(BaseBackend):
         amd.passes.ttgpuir.add_accelerate_matmul(pm, options.arch, options.matrix_instr_nonkdim, options.kpack)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         amd.passes.ttgpuir.add_optimize_epilogue(pm)
+        amd.passes.ttgpuir.add_optimize_small_dot_operands(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, True)
         use_new_pipeliner = os.getenv("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0") == "1"
         if amd.has_matrix_core_feature(options.arch):

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -23,6 +23,8 @@ std::unique_ptr<Pass> createTritonAMDGPUVerifier();
 
 std::unique_ptr<Pass> createTritonAMDGPUOptimizeEpiloguePass();
 
+std::unique_ptr<Pass> createTritonAMDGPUOptimizeFMADotPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "TritonAMDGPUTransforms/Passes.h.inc"

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -72,6 +72,23 @@ def TritonAMDGPUOptimizeEpilogue : Pass<"tritonamdgpu-optimize-epilogue", "mlir:
 
 }
 
+def TritonAMDGPUOptimizeFMADot : Pass<"tritonamdgpu-optimize-fma-dot", "mlir::ModuleOp"> {
+  let summary = "Optimize small matrices operands: Load dot operands in layout compatible to dotOp.";
+
+  let description = [{
+  }];
+
+  let constructor = "mlir::createTritonAMDGPUOptimizeFMADotPass()";
+
+  let options = [
+  Option<"kSplit", "ksplit",
+          "int32_t", /*default*/"64",
+          "split k dim up to given number of pieces, compute them in different threads and then reduce">,
+];
+
+  let dependentDialects = [];
+}
+
 def TritonAMDGPUReorderInstructions: Pass<"tritonamdgpu-reorder-instructions", "mlir::ModuleOp"> {
   let summary = "Reorder instructions";
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(TritonAMDGPUTransforms
   AccelerateAMDMatmul.cpp
   OptimizeEpilogue.cpp
+  OptimizeFMADot.cpp
   ReorderInstructions.cpp
   StreamPipeline.cpp
   StreamPipelineV2.cpp

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeFMADot.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeFMADot.cpp
@@ -1,0 +1,432 @@
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+using namespace mlir;
+
+namespace {
+
+class OptimizeFMADotPattern : public mlir::RewritePattern {
+
+  int kSplit;
+
+  unsigned choosekSplit(unsigned m, unsigned n, unsigned k, unsigned numWarps,
+                        unsigned numThreads) const {
+    // TODO experiment with this value
+    return std::min(std::min(static_cast<unsigned>(kSplit), k), numThreads);
+  }
+
+  triton::gpu::BlockedEncodingAttr
+  generateNewDotLayout(mlir::MLIRContext *ctx, unsigned m, unsigned n,
+                       unsigned kSplit, unsigned numWarps,
+                       unsigned numThreads) const {
+    assert(kSplit > 0 && kSplit <= numThreads);
+    SmallVector<unsigned> order{2, 1, 0};
+    triton::gpu::CTALayoutAttr ctaLayout =
+        triton::gpu::CTALayoutAttr::get(ctx, {1, 1, 1}, {1, 1, 1}, {2, 1, 0});
+
+    // TODO experiment with M/N first distribution of warps
+    unsigned bWarps = 1;
+    unsigned mWarps = std::min(m, numWarps);
+    unsigned nWarps = numWarps / mWarps;
+    SmallVector<unsigned> warpsPerCTA{bWarps, mWarps, nWarps};
+
+    unsigned bThreads = kSplit;
+    unsigned nThreads = std::min(n / nWarps, numThreads / bThreads);
+    unsigned mThreads = numThreads / bThreads / nThreads;
+    SmallVector<unsigned> threadsPerWarp{bThreads, mThreads, nThreads};
+
+    unsigned bElems = 1;
+    unsigned mElems = std::max(1u, m / (mThreads * mWarps));
+    unsigned nElems = std::max(1u, n / (nThreads * nWarps));
+    SmallVector<unsigned> elemsPerThread{bElems, mElems, nElems};
+
+    auto dotLayout = triton::gpu::BlockedEncodingAttr::get(
+        ctx, elemsPerThread, threadsPerWarp, warpsPerCTA, order, ctaLayout);
+    return dotLayout;
+  }
+
+  static SmallVector<unsigned> splitOrder(ArrayRef<unsigned> origOrder,
+                                          int axis) {
+    SmallVector<unsigned> order;
+    for (int i = 0; i < 2; ++i) {
+      auto idx = origOrder[i];
+      if (idx < axis)
+        order.push_back(idx);
+      else if (idx > axis)
+        order.push_back(idx + 1);
+      else {
+        assert(origOrder[i] == axis);
+        order.push_back(idx + 1);
+        order.push_back(idx);
+      }
+    }
+    return order;
+  }
+
+  std::optional<RankedTensorType> splitTypeDim(RankedTensorType ty, int axis,
+                                               int splitSize,
+                                               Location loc) const {
+    auto origShape = ty.getShape();
+    SmallVector<int64_t> shape{origShape};
+    assert(shape[axis] % splitSize == 0);
+    shape.insert(shape.begin() + axis, splitSize);
+    shape[axis + 1] /= splitSize;
+    Attribute splitLayout;
+    auto origEncoding =
+        cast<triton::gpu::BlockedEncodingAttr>(ty.getEncoding());
+    if (splitSize == 1) {
+      // TODO: investigate why this case is not processed in
+      // inferReshapeOpNoReorderEncoding properly
+      auto ctx = ty.getContext();
+      SmallVector<unsigned> sizePerThread = origEncoding.getSizePerThread();
+      sizePerThread.insert(sizePerThread.begin() + axis, 1);
+      SmallVector<unsigned> threadsPerWarp = origEncoding.getThreadsPerWarp();
+      threadsPerWarp.insert(threadsPerWarp.begin() + axis, 1);
+      SmallVector<unsigned> warpsPerCTA = origEncoding.getWarpsPerCTA();
+      warpsPerCTA.insert(warpsPerCTA.begin() + axis, 1);
+      SmallVector<unsigned> order = splitOrder(origEncoding.getOrder(), axis);
+
+      auto ctaPerCGA = origEncoding.getCTAsPerCGA();
+      ctaPerCGA.insert(ctaPerCGA.begin() + axis, 1);
+      auto ctaSplit = origEncoding.getCTASplitNum();
+      ctaSplit.insert(ctaSplit.begin() + axis, 1);
+      auto ctaOrder = splitOrder(origEncoding.getCTAOrder(), axis);
+      auto ctaLayout =
+          triton::gpu::CTALayoutAttr::get(ctx, ctaPerCGA, ctaSplit, ctaOrder);
+
+      splitLayout = triton::gpu::BlockedEncodingAttr::get(
+          ctx, sizePerThread, threadsPerWarp, warpsPerCTA, order, ctaLayout);
+    } else {
+      auto layoutHelper = llvm::cast<triton::DialectInferLayoutInterface>(
+          &origEncoding.getDialect());
+      auto layoutInferResult = layoutHelper->inferReshapeOpNoReorderEncoding(
+          origShape, origEncoding, shape, splitLayout, loc);
+      if (layoutInferResult.failed())
+        return std::nullopt;
+    }
+
+    auto newType =
+        RankedTensorType::get(shape, ty.getElementType(), splitLayout);
+    return newType;
+  }
+
+  triton::gpu::BlockedEncodingAttr
+  transposeLayout(triton::gpu::BlockedEncodingAttr layout,
+                  ArrayRef<int> permOrder) const {
+    auto ctx = layout.getContext();
+    triton::gpu::CTALayoutAttr ctaLayout =
+        triton::gpu::CTALayoutAttr::get(ctx, {1, 1, 1}, {1, 1, 1}, {2, 1, 0});
+    // TODO adjust this if better performance is possible
+    SmallVector<unsigned> order{2, 1, 0};
+    SmallVector<unsigned> sizePerThread;
+    SmallVector<unsigned> threadsPerWarp;
+    SmallVector<unsigned> warpsPerCTA;
+    for (auto idx : permOrder) {
+      sizePerThread.push_back(layout.getSizePerThread()[idx]);
+      threadsPerWarp.push_back(layout.getThreadsPerWarp()[idx]);
+      warpsPerCTA.push_back(layout.getWarpsPerCTA()[idx]);
+    }
+    return triton::gpu::BlockedEncodingAttr::get(
+        ctx, sizePerThread, threadsPerWarp, warpsPerCTA, order, ctaLayout);
+  }
+
+  triton::gpu::BlockedEncodingAttr
+  convertDotOpBToBlockedLayout(triton::gpu::DotOperandEncodingAttr layout,
+                               int kSize) const {
+    auto parentLayout =
+        cast<triton::gpu::BlockedEncodingAttr>(layout.getParent());
+    auto ctx = layout.getContext();
+    SmallVector<unsigned> sizePerThread(parentLayout.getSizePerThread());
+    sizePerThread[1] = kSize;
+    SmallVector<unsigned> threadsPerWarp(parentLayout.getThreadsPerWarp());
+    auto numWarps = triton::gpu::getNumWarpsPerCTA(parentLayout);
+    auto warpsPerCTA = layout.getWarpsPerCTA();
+    SmallVector<unsigned> order(parentLayout.getOrder());
+    auto ctaLayout = parentLayout.getCTALayout();
+    return triton::gpu::BlockedEncodingAttr::get(
+        ctx, sizePerThread, threadsPerWarp, warpsPerCTA, order, ctaLayout);
+  }
+
+  triton::gpu::BlockedEncodingAttr
+  mergeSlowDimLayoutToFaster(triton::gpu::BlockedEncodingAttr layout,
+                             int slowDim) const {
+    int rank = layout.getOrder().size();
+    assert(slowDim >= 0 && slowDim < rank - 1);
+    assert(slowDim != layout.getOrder()[0]);
+    auto ctx = layout.getContext();
+    SmallVector<unsigned> order;
+    int fasterDim = -1;
+    for (int i = 0; i < rank; ++i) {
+      int dimIdx = layout.getOrder()[i];
+      if (dimIdx > slowDim)
+        order.push_back(dimIdx - 1);
+      if (dimIdx < slowDim)
+        order.push_back(dimIdx);
+      if (dimIdx == slowDim)
+        fasterDim = layout.getOrder()[i - 1];
+    }
+    SmallVector<unsigned> sizePerThread(layout.getSizePerThread());
+    sizePerThread[fasterDim] *= sizePerThread[slowDim];
+    sizePerThread.erase(sizePerThread.begin() + slowDim);
+
+    SmallVector<unsigned> threadsPerWarp(layout.getThreadsPerWarp());
+    threadsPerWarp[fasterDim] *= threadsPerWarp[slowDim];
+    threadsPerWarp.erase(threadsPerWarp.begin() + slowDim);
+
+    SmallVector<unsigned> warpsPerCTA(layout.getWarpsPerCTA());
+    warpsPerCTA[fasterDim] *= warpsPerCTA[slowDim];
+    warpsPerCTA.erase(warpsPerCTA.begin() + slowDim);
+    assert(rank == 3);
+    auto ctaLayout =
+        triton::gpu::CTALayoutAttr::get(ctx, {1, 1}, {1, 1}, {1, 0});
+    return triton::gpu::BlockedEncodingAttr::get(
+        ctx, sizePerThread, threadsPerWarp, warpsPerCTA, order, ctaLayout);
+  }
+
+  mlir::LogicalResult optimizeLargeBOp(mlir::PatternRewriter &rewriter,
+                                       unsigned m, unsigned n, unsigned k,
+                                       triton::DotOp dotOp,
+                                       triton::gpu::ConvertLayoutOp aCvt,
+                                       triton::gpu::ConvertLayoutOp bCvt,
+                                       triton::LoadOp bLoadOp) const {
+    auto loadTy = llvm::cast<RankedTensorType>(bLoadOp.getResult().getType());
+    auto oldBLoadLayout = loadTy.getEncoding();
+    auto ctx = dotOp.getContext();
+    auto cOrigType = dotOp.getC().getType();
+    auto cOrigLayout = llvm::dyn_cast<triton::gpu::BlockedEncodingAttr>(
+        cOrigType.getEncoding());
+    auto dotLoc = dotOp.getLoc();
+    assert(cOrigLayout &&
+           "non-blocked layouts are filtered outside this pattern");
+    unsigned numWarps = triton::gpu::getNumWarpsPerCTA(cOrigLayout);
+    unsigned numThreads = product(triton::gpu::getThreadsPerWarp(cOrigLayout));
+    auto kSplit = choosekSplit(m, n, k, numWarps, numThreads);
+
+    // create new dot output and argument layouts
+    auto cBatchedOpLayout =
+        generateNewDotLayout(ctx, m, n, kSplit, numWarps, numThreads);
+    auto elTy = bCvt.getType().getElementType();
+    auto aBatchedOpLayout = triton::gpu::DotOperandEncodingAttr::get(
+        ctx, 0, cBatchedOpLayout, elTy);
+    auto bBatchedOpLayout = triton::gpu::DotOperandEncodingAttr::get(
+        ctx, 1, cBatchedOpLayout, elTy);
+
+    // create layouts and values related to A operand
+    //
+    // A operand data flow before transformation:
+    //   aOrig (NxK aOrigLayout)   -layout_convert->
+    //         (NxK dot op layout)
+    // After transformation:
+    //   aOrig      (MxK aOrigLayout)         -reshape->
+    //   aExtended  (MxSxK' aExtendedLayout)  -trans->
+    //   aBatched   (SxMxK' aBatchedLayout)   -layout_convert->
+    //   aBatchedOp (SxMxK' aBatchedOpLayout)
+    // "S" in shapes represents kSplit value
+    auto aOrig = aCvt.getSrc();
+    auto aCvtLoc = aCvt.getLoc();
+    auto aOrigLayout = dyn_cast<triton::gpu::BlockedEncodingAttr>(
+        aOrig.getType().getEncoding());
+    if (!aOrigLayout)
+      return failure();
+    auto aOrigType = aOrig.getType();
+    auto optAExtendedType = splitTypeDim(aOrigType, 1, kSplit, aCvtLoc);
+    if (!optAExtendedType.has_value())
+      return failure();
+    auto aExtendedType = optAExtendedType.value();
+    auto aExtendedLayout = llvm::cast<triton::gpu::BlockedEncodingAttr>(
+        aExtendedType.getEncoding());
+    rewriter.setInsertionPoint(aCvt);
+    assert(!triton::gpu::isExpensiveView(aOrig.getType(), aExtendedType));
+    auto aExtended =
+        rewriter.create<triton::ReshapeOp>(aCvtLoc, aExtendedType, aOrig, true);
+    auto aBatchedLayout = transposeLayout(aExtendedLayout, {1, 0, 2});
+    auto aBatchedType =
+        RankedTensorType::get({kSplit, m, k / kSplit}, elTy, aBatchedLayout);
+    auto aBatched = rewriter.create<triton::TransOp>(
+        aCvtLoc, aExtended, ArrayRef<int32_t>({1, 0, 2}));
+    auto aBatchedOpType =
+        RankedTensorType::get({kSplit, m, k / kSplit}, elTy, aBatchedOpLayout);
+    auto aBatchedOp = rewriter.create<triton::gpu::ConvertLayoutOp>(
+        dotLoc, aBatchedOpType, aBatched);
+
+    // create layouts and values related to B operand
+    //
+    // B operand data flow before transformation:
+    //   bOrigAddr, bOrigMask (KxN bOrigLoadLayout) -global load->
+    //   bOrigLoad            (KxN bOrigLoadLayout) -layout_convert->
+    //                        (KxN dot op layout)
+    // After transformation:
+    //   bOrigAddr, bOrigMask (KxN bOrigLoadLayout)    -layout_convert->
+    //   bAddr, bMask         (KxN bLoadLayout)        -global load->
+    //   bLoad                (KxN bLoadLayout)        -reshape->
+    //   bBatched             (SxK'xN bBatchedLayout)  -layout_convert->
+    //   bBatchedOp           (SxK'xN bBatchedOpLayout)
+    auto bOrigAddr = bLoadOp.getPtr();
+    auto bOrigMask = bLoadOp.getMask();
+    auto bLoadLoc = bLoadOp.getLoc();
+
+    auto bBatchedLayout =
+        convertDotOpBToBlockedLayout(bBatchedOpLayout, k / kSplit);
+    auto bLoadLayout = mergeSlowDimLayoutToFaster(bBatchedLayout, 0);
+    auto bLoadElTy = llvm::cast<RankedTensorType>(bLoadOp.getPtr().getType())
+                         .getElementType();
+    rewriter.setInsertionPoint(bLoadOp);
+    auto bAddrType = RankedTensorType::get({k, n}, bLoadElTy, bLoadLayout);
+    auto bAddr = rewriter.create<triton::gpu::ConvertLayoutOp>(
+        bLoadLoc, bAddrType, bOrigAddr);
+    Value bMask;
+    if (bOrigMask) {
+      auto bOrigMaskElTy =
+          cast<RankedTensorType>(bOrigMask.getType()).getElementType();
+      auto bMaskType =
+          RankedTensorType::get({k, n}, bOrigMaskElTy, bLoadLayout);
+      bMask = rewriter.create<triton::gpu::ConvertLayoutOp>(bLoadLoc, bMaskType,
+                                                            bOrigMask);
+    }
+    auto bLoad = rewriter.create<triton::LoadOp>(
+        bLoadLoc, bAddr, bMask, bLoadOp.getCache(), bLoadOp.getEvict(),
+        bLoadOp.getIsVolatile());
+    auto bBatchedType =
+        RankedTensorType::get({kSplit, k / kSplit, n}, elTy, bBatchedLayout);
+    assert(!triton::gpu::isExpensiveView(bLoad.getType(), bBatchedType));
+    auto bBatched =
+        rewriter.create<triton::ReshapeOp>(bLoadLoc, bBatchedType, bLoad, true);
+    auto bBatchedOpType =
+        RankedTensorType::get({kSplit, k / kSplit, n}, elTy, bBatchedOpLayout);
+    assert(!cvtNeedsSharedMemory(bBatchedType, bBatchedOpType));
+    auto bBatchedOp = rewriter.create<triton::gpu::ConvertLayoutOp>(
+        dotLoc, bBatchedOpType, bBatched);
+
+    // create layouts and values related to C operand
+    //
+    // C operand data flow before transformation:
+    //   cOrig (MxN cOrigLayout)
+    // After transformation:
+    //   cOrig      (MxN cOrigLayout)   -reshape->
+    //   cShaped    (1xMxN cOrigLayout) -broadcast->
+    //   cBatched   (SxMxN cOrigLayout) -layout_convert->
+    //   cBatchedOp (SxMxN cLayout)
+    auto cOrig = dotOp.getC();
+    auto cElTy = dotOp.getC().getType().getElementType();
+    auto optCShapedType = splitTypeDim(cOrigType, 0, 1, cOrig.getLoc());
+    if (!optCShapedType.has_value())
+      return failure();
+    auto cShapedType = optCShapedType.value();
+    auto cShapedLayout = cShapedType.getEncoding();
+    rewriter.setInsertionPoint(dotOp);
+    assert(!triton::gpu::isExpensiveView(cOrig.getType(), cShapedType));
+    auto cShaped =
+        rewriter.create<triton::ReshapeOp>(dotLoc, cShapedType, cOrig, false);
+    auto cBatchedType =
+        RankedTensorType::get({kSplit, m, n}, cElTy, cShapedLayout);
+    auto cBatched =
+        rewriter.create<triton::BroadcastOp>(dotLoc, cBatchedType, cShaped);
+    auto cBatchedOpType =
+        RankedTensorType::get({kSplit, m, n}, cElTy, cBatchedOpLayout);
+    auto cBatchedOp = rewriter.create<triton::gpu::ConvertLayoutOp>(
+        dotLoc, cBatchedOpType, cBatched);
+
+    // Create new dot and reduction
+    rewriter.setInsertionPoint(dotOp);
+
+    auto newDot = rewriter.create<triton::DotOp>(
+        dotLoc, aBatchedOp, bBatchedOp, cBatchedOp, dotOp.getInputPrecision(),
+        dotOp.getMaxNumImpreciseAcc());
+
+    auto reduceOp = rewriter.create<triton::ReduceOp>(
+        dotLoc, ArrayRef<Value>{newDot.getD()}, 0);
+    auto reduceConvert =
+        rewriter.replaceOpWithNewOp<triton::gpu::ConvertLayoutOp>(
+            dotOp, cOrigType, reduceOp.getResult());
+
+    auto reduceBody = rewriter.createBlock(&reduceOp.getRegion(), {},
+                                           {cElTy, cElTy}, {dotLoc, dotLoc});
+    auto blockArgs = reduceBody->getArguments();
+    rewriter.setInsertionPoint(reduceBody, reduceBody->begin());
+    Value reduceOperation;
+    if (elTy.isInteger())
+      reduceOperation =
+          rewriter.create<arith::AddIOp>(dotLoc, blockArgs[0], blockArgs[1]);
+    else
+      reduceOperation =
+          rewriter.create<arith::AddFOp>(dotLoc, blockArgs[0], blockArgs[1]);
+    rewriter.create<triton::ReduceReturnOp>(dotLoc, reduceOperation);
+    return success();
+  }
+
+public:
+  explicit OptimizeFMADotPattern(mlir::MLIRContext *context, int kSplit)
+      : mlir::RewritePattern(triton::DotOp::getOperationName(), 1, context),
+        kSplit(kSplit) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto dotOp = cast<triton::DotOp>(op);
+    auto dEncoding = dotOp.getD().getType().getEncoding();
+    if (!llvm::dyn_cast<triton::gpu::BlockedEncodingAttr>(dEncoding))
+      return failure();
+    auto aCvt = dyn_cast_or_null<triton::gpu::ConvertLayoutOp>(
+        dotOp.getA().getDefiningOp());
+    auto bCvt = dyn_cast_or_null<triton::gpu::ConvertLayoutOp>(
+        dotOp.getB().getDefiningOp());
+    auto cOp = dotOp.getC();
+    if (!aCvt || !bCvt)
+      return mlir::failure();
+    auto cShape = cOp.getType().getShape();
+    auto aShape = aCvt.getType().getShape();
+    if (cShape.size() != 2)
+      return mlir::failure();
+    unsigned m = cShape[0];
+    unsigned n = cShape[1];
+    unsigned k = aShape[1];
+    // TODO: Think of better heuristic
+    if (m > 8 || n < 8)
+      return failure();
+
+    auto loadOp =
+        llvm::dyn_cast_or_null<triton::LoadOp>(bCvt.getSrc().getDefiningOp());
+    if (!loadOp)
+      return mlir::failure();
+    return optimizeLargeBOp(rewriter, m, n, k, dotOp, aCvt, bCvt, loadOp);
+  }
+};
+
+} // namespace
+
+#define GEN_PASS_CLASSES
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+
+class TritonAMDGPUOptimizeFMADotPass
+    : public TritonAMDGPUOptimizeFMADotBase<TritonAMDGPUOptimizeFMADotPass> {
+
+public:
+  TritonAMDGPUOptimizeFMADotPass() = default;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp m = getOperation();
+    mlir::RewritePatternSet patterns(context);
+
+    patterns.add<OptimizeFMADotPattern>(context, this->kSplit);
+
+    if (applyPatternsAndFoldGreedily(m, std::move(patterns)).failed()) {
+      signalPassFailure();
+    }
+  }
+};
+
+std::unique_ptr<Pass> mlir::createTritonAMDGPUOptimizeFMADotPass() {
+  return std::make_unique<TritonAMDGPUOptimizeFMADotPass>();
+}

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -56,6 +56,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
                      const std::string, int, int);
   ADD_PASS_WRAPPER_0("add_optimize_epilogue",
                      mlir::createTritonAMDGPUOptimizeEpiloguePass);
+  ADD_PASS_WRAPPER_0("add_optimize_fma_dot",
+                     mlir::createTritonAMDGPUOptimizeFMADotPass);
   ADD_PASS_WRAPPER_0("add_reorder_instructions",
                      mlir::createTritonAMDGPUReorderInstructionsPass);
   ADD_PASS_WRAPPER_0("add_stream_pipeline",


### PR DESCRIPTION
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

This PR is a part of PR series. Final goal is to improve efficiency of small dot operations and bypass as much shared memory accesses as possible.

Rough list of PRs:
- [ ] Basic FMA dot fixes, dot 3d support and relaxing small dimensions for dot #4516
- [x] Blocked->dotOp shared memory bypassing #4538
- [ ] Accelerate AMD Matmul + emit dot operations #4594
- [ ] Layout optimization, so operand B is loaded in proper mfma layout and do not need to go through LDS **(this PR)** #4581
- [ ] Vectorization optimization of dot operands/results (in case llvm can not do this internally)
- [ ] Reduction operation hoisting out of the K loop (reduction operation is a byproduct of layout optimization step) #4559