### PR TITLE
[FRONTEND] cleaner handling of DEBUG=1

### DIFF
--- a/include/triton/Dialect/Triton/Transforms/Passes.h
+++ b/include/triton/Dialect/Triton/Transforms/Passes.h
@@ -7,7 +7,7 @@ namespace mlir {
 namespace triton {
 
 std::unique_ptr<Pass> createCombineOpsPass();
-
+std::unique_ptr<Pass> createDisableAssertsPass();
 std::unique_ptr<Pass> createReorderBroadcastPass();
 std::unique_ptr<Pass> createRewriteTensorPointerPass();
 

--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -24,6 +24,14 @@ def TritonCombineOps : Pass</*cli-arg*/"triton-combine", /*Op*/"mlir::ModuleOp">
   let dependentDialects = ["mlir::arith::ArithDialect"];
 }
 
+def TritonDisableAsserts : Pass</*cli-args*/"triton-disable-asserts", "mlir::ModuleOp"> {
+  let summary = "disable device-side assertions";
+
+  let constructor = "mlir::triton::createDisableAssertsPass()";
+
+  let dependentDialects = ["mlir::triton::TritonDialect"];
+}
+
 def TritonReorderBroadcast : Pass</*cli-arg*/"triton-reorder-broadcast", /*Op*/"mlir::ModuleOp"> {
   let summary = "Moves broadcast and splat after elementwise operations";
   let description = [{

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_public_tablegen_target(TritonCombineIncGen)
 
 add_triton_library(TritonTransforms
   Combine.cpp
+  DisableAsserts.cpp
   ReorderBroadcast.cpp
   RewriteTensorPointer.cpp
 

--- a/lib/Dialect/Triton/Transforms/DisableAsserts.cpp
+++ b/lib/Dialect/Triton/Transforms/DisableAsserts.cpp
@@ -1,0 +1,27 @@
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/Transforms/Passes.h"
+#include <memory>
+
+#define GEN_PASS_DEF_TRITONDISABLEASSERTS
+#include "triton/Dialect/Triton/Transforms/Passes.h.inc"
+
+namespace mlir::triton {
+namespace {
+
+class DisableAssertsPass
+    : public ::impl::TritonDisableAssertsBase<DisableAssertsPass> {
+public:
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+    m.walk([&](triton::AssertOp assertOp) { assertOp.erase(); });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> createDisableAssertsPass() {
+  return std::make_unique<DisableAssertsPass>();
+}
+
+} // namespace mlir::triton

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -35,6 +35,7 @@ void init_triton_passes_common(py::module &&m) {
 
 void init_triton_passes_ttir(py::module &&m) {
   using namespace mlir::triton;
+  ADD_PASS_WRAPPER_0("add_disable_asserts", createDisableAssertsPass);
   ADD_PASS_WRAPPER_0("add_combine", createCombineOpsPass);
   ADD_PASS_WRAPPER_0("add_reorder_broadcast", createReorderBroadcastPass);
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_pointer",

--- a/python/test/unit/test_debug.py
+++ b/python/test/unit/test_debug.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+import torch
+import triton.language as tl
+import triton
+
+@pytest.mark.parametrize('cond, opt_flag, env_var', [
+    (cond, opt_flag, env_var) for cond in [True, False] \
+                              for opt_flag in [True, False] \
+                              for env_var in [True, False]\
+])
+@pytest.mark.forked
+def test_assert(cond, opt_flag, env_var, device="cuda"):
+    os.environ['TRITON_DEBUG'] = str(int(env_var))
+    torch.zeros([1], dtype=torch.int32, device=device)
+
+    @triton.jit(debug=opt_flag)
+    def _kernel(COND: tl.constexpr):
+        tl.device_assert(COND, 'test')
+
+    if not cond and (opt_flag or env_var):
+        with pytest.raises(RuntimeError):
+            _kernel[(1, )](cond)
+            torch.cuda.synchronize()
+        return
+
+    _kernel[(1, )](cond)
+    torch.cuda.synchronize()

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1100,9 +1100,6 @@ class CodeGenerator(ast.NodeVisitor):
 
         kws = dict(self.visit(keyword) for keyword in node.keywords)
         args = [self.visit(arg) for arg in node.args]
-        # TODO: this should not be so hardcoded
-        if fn is language.core.device_assert and not self.debug:
-            return
         if isinstance(fn, JITFunction):
             _check_fn_args(node, fn, args)
             return self.call_JitFunction(fn, args, kws)


### PR DESCRIPTION
- no longer condition ASTVisitor codegen of device_assert on DEBUG=1
- always codegen asserts and conditionally run a pass to remove them before passing TTIR to the backend
