### PR TITLE
[AMD] Emit AMD specific intrinsics for dot 

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -194,6 +194,9 @@ bool isPureUnaryInlineAsm(Operation *op);
 // read the compute capability from the module attributes
 int getNVIDIAComputeCapability(Operation *module);
 
+// Read the amd target from the module attributes
+StringRef getAMDArch(Operation *module);
+
 std::optional<mlir::triton::gpu::SharedEncodingAttr>
 getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible);
 

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -966,7 +966,7 @@ int getNVIDIAComputeCapability(Operation *module) {
          "Expected a target attribute on the module operation");
 
   StringAttr targetAttr =
-      cast<StringAttr>(module->getAttr(triton::AttrTargetName));
+      module->getAttrOfType<StringAttr>(triton::AttrTargetName);
 
   StringRef ref = targetAttr.strref();
   assert(ref.starts_with("cuda:") &&
@@ -986,11 +986,11 @@ StringRef getAMDArch(Operation *module) {
          "Expected a target attribute on the module operation");
 
   StringAttr targetAttr =
-      cast<StringAttr>(module->getAttr(triton::AttrTargetName));
+      module->getAttrOfType<StringAttr>(triton::AttrTargetName);
 
   StringRef ref = targetAttr.strref();
   assert(ref.starts_with("hip:") &&
-         "expected target attribute to be prefixed with \"cuda:\"");
+         "expected target attribute to be prefixed with \"hip:\"");
 
   StringRef archStr = ref.drop_front(4); // drop the "hip:"
   return archStr;

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -981,6 +981,21 @@ int getNVIDIAComputeCapability(Operation *module) {
   return computeCapability;
 }
 
+StringRef getAMDArch(Operation *module) {
+  assert(module->hasAttr(triton::AttrTargetName) &&
+         "Expected a target attribute on the module operation");
+
+  StringAttr targetAttr =
+      cast<StringAttr>(module->getAttr(triton::AttrTargetName));
+
+  StringRef ref = targetAttr.strref();
+  assert(ref.starts_with("hip:") &&
+         "expected target attribute to be prefixed with \"cuda:\"");
+
+  StringRef archStr = ref.drop_front(4); // drop the "hip:"
+  return archStr;
+}
+
 // If all the transitive uses of the given value have are used by a convert to
 // the same dot operand encoding, return the shared encoding that needs to be
 // used to be compatible with users' layouts. If there are incompatible shared

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -992,8 +992,7 @@ StringRef getAMDArch(Operation *module) {
   assert(ref.starts_with("hip:") &&
          "expected target attribute to be prefixed with \"hip:\"");
 
-  StringRef archStr = ref.drop_front(4); // drop the "hip:"
-  return archStr;
+  return ref.drop_front(4); // drop the "hip:"
 }
 
 // If all the transitive uses of the given value have are used by a convert to

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -408,7 +408,7 @@ def test_min_dot_size(dtype):
             error_msg += "M >= 16, N >= 16 and K >= 32"
         else:
             error_msg = "M >= 16, N >= 16 and K >= 16"
-    if is_hip():
+    elif is_hip():
         # hip supports arbitrary sizes
         error_msg = None
     else:

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -7,7 +7,7 @@ import triton
 import triton.language as tl
 from triton.compiler.errors import CompilationError, CompileTimeAssertionFailure
 import traceback
-from triton._internal_testing import is_interpreter, is_cuda, is_hip, is_hip_mi300, is_hip_mi200
+from triton._internal_testing import is_interpreter, is_cuda, is_hip, is_hip_mi300
 
 
 def format_exception(type, value, tb):
@@ -408,23 +408,9 @@ def test_min_dot_size(dtype):
             error_msg += "M >= 16, N >= 16 and K >= 32"
         else:
             error_msg = "M >= 16, N >= 16 and K >= 16"
-    elif is_hip_mi300():
-        if dtype == tl.float16:
-            pytest.skip("fp16 FMA path supports all sizes")
-        elif dtype == tl.int8:
-            error_msg += "M >= 16, N >= 16 and K >= 1"
-        else:
-            error_msg += "M >= 16, N >= 16 and K >= 1"
-    elif is_hip_mi200():
-        if dtype == tl.float16:
-            pytest.skip("fp16 FMA path supports all sizes")
-        else:
-            error_msg += "M >= 16, N >= 16 and K >= 1"
-    elif is_hip():
-        if dtype == tl.float16:
-            pytest.skip("fp16 FMA path supports all sizes")
-        else:
-            error_msg = "M >= 16, N >= 16 and K >= 16"
+    if is_hip():
+        # hip supports arbitrary sizes
+        error_msg = None
     else:
         pytest.skip("Test only supported on CUDA and HIP")
 
@@ -435,13 +421,17 @@ def test_min_dot_size(dtype):
         b = tl.full((SIZE, SIZE), 0.0, dtype)
         tl.dot(a, b)
 
-    with pytest.raises(CompilationError) as e:
+    if error_msg is None:
         triton.compile(
             triton.compiler.ASTSource(fn=dot_kernel, signature={"dtype": "constexpr"}, constexprs={"dtype": dtype}))
-    try:
-        assert (error_msg in str(e.value.__cause__))
-    except AssertionError as assertion_err:
-        raise assertion_err from e.value
+    else:
+        with pytest.raises(CompilationError) as e:
+            triton.compile(
+                triton.compiler.ASTSource(fn=dot_kernel, signature={"dtype": "constexpr"}, constexprs={"dtype": dtype}))
+        try:
+            assert (error_msg in str(e.value.__cause__))
+        except AssertionError as assertion_err:
+            raise assertion_err from e.value
 
 
 def test_max_num_imprecise_acc_limit():

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -324,7 +324,7 @@ module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.n
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   tt.func @v_dot_fp16_fp16(%arg0: tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<16x16xf16, #blocked>) {
-    // CHECK-4: llvm.call_intrinsic "llvm.amdgcn.sdot4"
+    // CHECK-COUNT-16: llvm.call_intrinsic "llvm.fmuladd.f16"
     %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<16x16xf16, #blocked>
     tt.return
   }

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -210,7 +210,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   }
 }
 
-
 // -----
 
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
@@ -291,6 +290,42 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // CHECK: inttoptr
     // CHECK: llvm.atomicrmw
     %0 = tt.atomic_rmw fadd, relaxed, gpu, %arg0, %arg2 {allocation.offset = 0 : i32} : (tensor<64x!tt.ptr<f32>, #blocked5>, tensor<64xf32, #blocked5>) -> tensor<64xf32, #blocked5>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: v_dot_i8
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @v_dot_i8(%arg0: tensor<16x16xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<16x16xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<16x16xi32, #blocked>) {
+    // CHECK-4: llvm.call_intrinsic "llvm.amdgcn.sdot4"
+    %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x16xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<16x16xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: v_dot_fp16
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @v_dot_fp16(%arg0: tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<16x16xf32, #blocked>) {
+    // CHECK-8: llvm.call_intrinsic "llvm.amdgcn.fdot2"
+    %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<16x16xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: v_dot_fp16_fp16
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @v_dot_fp16_fp16(%arg0: tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<16x16xf16, #blocked>) {
+    // CHECK-4: llvm.call_intrinsic "llvm.amdgcn.sdot4"
+    %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<16x16xf16, #blocked>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/accelerate-amd-matmul-fma.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-fma.mlir
@@ -1,8 +1,7 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul='arch-generation-name=gfx942' | FileCheck %s
 
 // CHECK: fma_dot_fp16_fp16
-// CHECK: %[[D:.*]] = tt.dot {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf32, {{.*}}>
-// CHECK: tt.fp_to_fp %[[D]], rounding = rtne : tensor<2x64xf32, {{.*}}> -> tensor<2x64xf16, {{.*}}>
+// CHECK: %[[D:.*]] = tt.dot {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf16, {{.*}}>
 #blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @fma_dot_fp16_fp16(
@@ -92,9 +91,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: fma_dot_i8_i8
 // CHECK-DAG: %[[A:.*]] = arith.sitofp
 // CHECK-DAG: %[[B:.*]] = arith.sitofp
-// CHECK: %[[D:.*]] = tt.dot %[[A]], %[[B]], {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf32, {{.*}}>
-// CHECK: %[[D_CAST:.*]] = tt.fp_to_fp %[[D]], rounding = rtne
-// CHECK: arith.fptosi %[[D_CAST]]
+// CHECK: %[[D:.*]] = tt.dot %[[A]], %[[B]], {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf16, {{.*}}>
 #blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @fma_dot_i8_i8(

--- a/test/TritonGPU/amd/accelerate-amd-matmul-fma.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-fma.mlir
@@ -1,0 +1,107 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul='arch-generation-name=gfx942' | FileCheck %s
+
+// CHECK: fma_dot_fp16_fp16
+// CHECK: tt.dot {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf16, {{.*}}>
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_fp16_fp16(
+      %arg0: tensor<2x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<f16>, #blocked> ) {
+    %cst = arith.constant dense<0.0> : tensor<2x64xf16, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xf16, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: fma_dot_fp32_fp32
+// CHECK: tt.dot {{.*}} : tensor<2x64xf32, {{.*}}> * tensor<64x64xf32, {{.*}}> -> tensor<2x64xf32, {{.*}}>
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_fp32_fp32(
+      %arg0: tensor<2x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<f32>, #blocked> ) {
+    %cst = arith.constant dense<0.0> : tensor<2x64xf32, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xf32, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: #[[BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+// CHECK: fma_dot_i8
+// CHECK: tt.dot {{.*}} : tensor<2x64xi8, #ttg.dot_op<{opIdx = 0, parent = #[[BLOCKED]]}>> * tensor<64x64xi8, #ttg.dot_op<{opIdx = 1, parent = #[[BLOCKED]]}>> -> tensor<2x64xi32, #[[BLOCKED]]>
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_i8(
+      %arg0: tensor<2x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<i32>, #blocked> ) {
+    %cst = arith.constant dense<0> : tensor<2x64xi32, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xi32, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: #[[BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+// CHECK: fma_dot_f16
+// CHECK: tt.dot {{.*}} : tensor<2x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[BLOCKED]]}>> * tensor<64x64xf16, #ttg.dot_op<{opIdx = 1, parent = #[[BLOCKED]]}>> -> tensor<2x64xf32, #[[BLOCKED]]>
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_f16(
+      %arg0: tensor<2x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<f32>, #blocked> ) {
+    %cst = arith.constant dense<0.0> : tensor<2x64xf32, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xf32, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: #[[BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+// CHECK: fma_dot_f8
+// CHECK: tt.dot {{.*}} : tensor<2x64xf32, #ttg.dot_op<{opIdx = 0, parent = #[[BLOCKED]]}>> * tensor<64x64xf32, #ttg.dot_op<{opIdx = 1, parent = #[[BLOCKED]]}>> -> tensor<2x64xf32, #[[BLOCKED]]>
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_f8(
+      %arg0: tensor<2x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<f32>, #blocked> ) {
+    %cst = arith.constant dense<0.0> : tensor<2x64xf32, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xf32, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: fma_dot_i8_i8
+// CHECK-DAG: %[[A:.*]] = arith.sitofp
+// CHECK-DAG: %[[B:.*]] = arith.sitofp
+// CHECK: %[[D:.*]] = tt.dot %[[A]], %[[B]], {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf16, {{.*}}>
+// CHECK: arith.fptosi %[[D]]
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_i8_i8(
+      %arg0: tensor<2x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+      %arg1: tensor<64x64xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+      %arg2: tensor<2x64x!tt.ptr<i8>, #blocked> ) {
+    %cst = arith.constant dense<0> : tensor<2x64xi8, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<2x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x64xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<2x64xi8, #blocked>
+    tt.store %arg2, %1 : tensor<2x64x!tt.ptr<i8>, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/accelerate-amd-matmul-fma.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-fma.mlir
@@ -1,7 +1,8 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul='arch-generation-name=gfx942' | FileCheck %s
 
 // CHECK: fma_dot_fp16_fp16
-// CHECK: tt.dot {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf16, {{.*}}>
+// CHECK: %[[D:.*]] = tt.dot {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf32, {{.*}}>
+// CHECK: tt.fp_to_fp %[[D]], rounding = rtne : tensor<2x64xf32, {{.*}}> -> tensor<2x64xf16, {{.*}}>
 #blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @fma_dot_fp16_fp16(
@@ -91,8 +92,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: fma_dot_i8_i8
 // CHECK-DAG: %[[A:.*]] = arith.sitofp
 // CHECK-DAG: %[[B:.*]] = arith.sitofp
-// CHECK: %[[D:.*]] = tt.dot %[[A]], %[[B]], {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf16, {{.*}}>
-// CHECK: arith.fptosi %[[D]]
+// CHECK: %[[D:.*]] = tt.dot %[[A]], %[[B]], {{.*}} : tensor<2x64xf16, {{.*}}> * tensor<64x64xf16, {{.*}}> -> tensor<2x64xf32, {{.*}}>
+// CHECK: %[[D_CAST:.*]] = tt.fp_to_fp %[[D]], rounding = rtne
+// CHECK: arith.fptosi %[[D_CAST]]
 #blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @fma_dot_i8_i8(

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen1.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen1.mlir
@@ -133,14 +133,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
    // CHECK-SAME: %[[DOT3_ARG_B:.+]]: tensor<64x32xi16, #ttg.dot_op<{opIdx = 1, parent = #[[DOT_OP_PARENT]]}>>
    %1: tensor<64x32xi16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
    %2: tensor<128x32x!tt.ptr<i16>, #blocked>) {
-    // CHECK: %[[DOT3_ARG_C:.+]] = arith.constant dense<0> : tensor<128x32xi16, #[[DOT_OP_PARENT]]>
+    // CHECK: %[[DOT3_OP_C:.+]] = arith.constant dense<0.000000e+00> : tensor<128x32xf32, #[[DOT_OP_PARENT]]>
     %3 = arith.constant dense<0> : tensor<128x32xi16, #blocked>
     // CHECK: %[[DOT3_OP_A:.+]] = arith.sitofp %[[DOT3_ARG_A]]
     // CHECK-SAME: to tensor<128x64xf32, #ttg.dot_op<{opIdx = 0, parent = #[[DOT_OP_PARENT]]
     // CHECK: %[[DOT3_OP_B:.+]] = arith.sitofp %[[DOT3_ARG_B]]
     // CHECK-SAME: to tensor<64x32xf32, #ttg.dot_op<{opIdx = 1, parent = #[[DOT_OP_PARENT]]
-    // CHECK: %[[DOT3_OP_C:.+]] = arith.sitofp %[[DOT3_ARG_C]]
-    // CHECK-SAME: to tensor<128x32xf32, #[[DOT_OP_PARENT]]
     // CHECK: %[[DOT3_FMA_RES:.+]] = tt.dot %[[DOT3_OP_A]], %[[DOT3_OP_B]], %[[DOT3_OP_C]]
     // CHECK-SAME: -> tensor<128x32xf32, #[[DOT_OP_PARENT]]>
     %4 = tt.dot %0, %1, %3 : tensor<128x64xi16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x32xi16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x32xi16, #blocked>

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -13,27 +13,8 @@ from pathlib import Path
 
 
 def min_dot_size(target: GPUTarget):
-
-    def is_fma_supported(lhsType, rhsType):
-        return lhsType == rhsType and (lhsType.is_fp16() or lhsType.is_fp32())
-
-    def get_gfx94_limits(lhsType, rhsType):
-        if is_fma_supported(lhsType.scalar, rhsType.scalar):
-            return (1, 1, 1)
-        return (16, 16, 1)
-
-    def get_gfx9_limits(lhsType, rhsType):
-        if is_fma_supported(lhsType.scalar, rhsType.scalar):
-            return (1, 1, 1)
-        return (16, 16, 1)
-
-    arch_str = target.arch
-    if "gfx94" in arch_str:
-        return get_gfx94_limits
-    if "gfx9" in arch_str:
-        return get_gfx9_limits
-    # gfx11 and gfx12 architectures will only support 16,16,16 with wmma instructions
-    return lambda lhsType, rhsType: (1, 1, 1) if is_fma_supported(lhsType.scalar, rhsType.scalar) else (16, 16, 16)
+    # If some given configuration is not supported in hardware we fallback to FMA and cast arguments
+    return lambda lhsType, rhsType: (1, 1, 1)
 
 
 @dataclass(frozen=True)

--- a/third_party/amd/include/TritonAMDGPUToLLVM/TargetUtils.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/TargetUtils.h
@@ -16,6 +16,9 @@ enum class ISAFamily {
   RDNA3,
 };
 
+// Retursn true if given architecture support V_DOT instruction.
+bool isVDotSupported(llvm::StringRef arch);
+
 // Deduces the corresponding ISA family for the given target gfx |arch|.
 ISAFamily deduceISAFamily(llvm::StringRef arch);
 

--- a/third_party/amd/include/TritonAMDGPUToLLVM/TargetUtils.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/TargetUtils.h
@@ -16,11 +16,11 @@ enum class ISAFamily {
   RDNA3,
 };
 
-// Retursn true if given architecture support V_DOT instruction.
-bool isVDotSupported(llvm::StringRef arch);
-
 // Deduces the corresponding ISA family for the given target gfx |arch|.
 ISAFamily deduceISAFamily(llvm::StringRef arch);
+
+// Retursn true if given architecture support V_DOT instruction.
+bool supportsVDot(llvm::StringRef arch);
 
 // Here is a partial definition of DppCtrl enums. For the complete definition,
 // please check:

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
@@ -5,6 +5,7 @@ add_triton_library(TritonAMDGPUToLLVM
     ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
     ConvertLayoutOpToLLVM.cpp
     MemoryOpToLLVM.cpp
+    DotOpToLLVM/FMA.cpp
     DotOpToLLVM/MFMA.cpp
     DotOpToLLVM/WMMA.cpp
     DotOpToLLVM.cpp

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
@@ -7,6 +7,10 @@ using ::mlir::triton::gpu::AMDWmmaEncodingAttr;
 using ::mlir::triton::gpu::getShapePerCTA;
 
 namespace mlir::triton::AMD {
+LogicalResult convertAMDFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
+                               const LLVMTypeConverter *typeConverter,
+                               ConversionPatternRewriter &rewriter);
+
 LogicalResult convertMFMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                           const LLVMTypeConverter *typeConverter,
                           ConversionPatternRewriter &rewriter);
@@ -37,7 +41,7 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
 
     if (isa<BlockedEncodingAttr>(
             cast<RankedTensorType>(D.getType()).getEncoding()))
-      return convertFMADot(op, adaptor, getTypeConverter(), rewriter);
+      return AMD::convertAMDFMADot(op, adaptor, getTypeConverter(), rewriter);
 
     llvm::report_fatal_error(
         "Unsupported DotOp found when converting TritonGPU to LLVM.");

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -1,3 +1,4 @@
+#include "TritonAMDGPUToLLVM/TargetUtils.h"
 #include "triton/Conversion/TritonGPUToLLVM/FMADotUtility.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -31,9 +32,8 @@ class AMDFMAVectorMultiplier : public FMAVectorMultiplier {
     auto mod = op->getParentOfType<ModuleOp>();
     auto arch = getAMDArch(mod);
     DotIntrinsic chosenOp;
-    bool dotAvailable = arch == "gfx908" || arch == "gfx90a" ||
-                        arch.starts_with("gfx94") ||
-                        arch.starts_with("gfx11") || arch.starts_with("gfx103");
+
+    bool dotAvailable = AMD::isVDotSupported(arch);
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     if (dotAvailable) {
       if (aElemTy.isF16() && dElemTy.isF32()) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -20,7 +20,7 @@ class AMDFMAVectorMultiplier : public FMAVectorMultiplier {
   Location loc;
   DotIntrinsic intrinsic;
 
-  DotIntrinsic chooseIntrinsic(triton::DotOp op) {
+  DotIntrinsic chooseIntrinsic(DotOp op) {
     auto aOpTy = cast<RankedTensorType>(op.getA().getType());
     auto aElemTy = aOpTy.getElementType();
     auto bOpTy = cast<RankedTensorType>(op.getA().getType());
@@ -100,15 +100,14 @@ class AMDFMAVectorMultiplier : public FMAVectorMultiplier {
   }
 
 public:
-  AMDFMAVectorMultiplier(ConversionPatternRewriter &rewriter, triton::DotOp op)
+  AMDFMAVectorMultiplier(ConversionPatternRewriter &rewriter, DotOp op)
       : rewriter(rewriter), loc(op.getLoc()), intrinsic(chooseIntrinsic(op)) {}
 
-  mlir::Value multiplyVectors(mlir::ArrayRef<mlir::Value> a,
-                              mlir::ArrayRef<mlir::Value> b,
-                              mlir::Value c) override {
+  Value multiplyVectors(ArrayRef<Value> a, ArrayRef<Value> b,
+                        Value c) override {
     auto kSize = a.size();
     assert(b.size() == kSize);
-    mlir::Value accum = c;
+    Value accum = c;
     for (int k = 0; k < kSize; k += intrinsic.vectorSize) {
       auto aOp = packOperand(a, k, intrinsic.vectorSize);
       auto bOp = packOperand(b, k, intrinsic.vectorSize);
@@ -122,7 +121,7 @@ public:
 
 namespace mlir::triton::AMD {
 
-LogicalResult convertAMDFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
+LogicalResult convertAMDFMADot(DotOp op, DotOp::Adaptor adaptor,
                                const LLVMTypeConverter *typeConverter,
                                ConversionPatternRewriter &rewriter) {
   AMDFMAVectorMultiplier multiplier(rewriter, op);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -1,0 +1,132 @@
+#include "triton/Conversion/TritonGPUToLLVM/FMADotUtility.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace ::mlir::triton::gpu;
+
+namespace {
+
+struct DotIntrinsic {
+  int vectorSize;
+  Type outElemTy;
+  StringRef intrinsicName;
+  SmallVector<Value> additionalArgs;
+};
+
+class AMDFMAVectorMultiplier : public FMAVectorMultiplier {
+  ConversionPatternRewriter &rewriter;
+  Location loc;
+  DotIntrinsic intrinsic;
+
+  DotIntrinsic chooseIntrinsic(triton::DotOp op) {
+    auto aOpTy = cast<RankedTensorType>(op.getA().getType());
+    auto aElemTy = aOpTy.getElementType();
+    auto bOpTy = cast<RankedTensorType>(op.getA().getType());
+    auto bElemTy = aOpTy.getElementType();
+    assert(aElemTy == bElemTy);
+    auto dOpTy = cast<RankedTensorType>(op.getD().getType());
+    auto dElemTy = dOpTy.getElementType();
+    auto mod = op->getParentOfType<ModuleOp>();
+    auto arch = getAMDArch(mod);
+    DotIntrinsic chosenOp;
+    bool dotAvailable = arch == "gfx908" || arch == "gfx90a" ||
+                        arch.starts_with("gfx94") ||
+                        arch.starts_with("gfx11") || arch.starts_with("gfx103");
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    if (dotAvailable) {
+      if (aElemTy.isF16() && dElemTy.isF32()) {
+        chosenOp.vectorSize = 2;
+        chosenOp.outElemTy = f32_ty;
+        chosenOp.intrinsicName = "llvm.amdgcn.fdot2";
+        chosenOp.additionalArgs = {b.false_val()};
+        return chosenOp;
+      }
+      if (aElemTy.isInteger(8) && dElemTy.isInteger(32)) {
+        chosenOp.vectorSize = 4;
+        chosenOp.outElemTy = i32_ty;
+        chosenOp.intrinsicName = "llvm.amdgcn.sdot4";
+        chosenOp.additionalArgs = {b.false_val()};
+        return chosenOp;
+      }
+    }
+    // choose one of FMA intrinsics
+    assert(aElemTy.isIntOrFloat() && !aElemTy.isIntOrIndex());
+    assert(aElemTy == dElemTy);
+    assert(cast<RankedTensorType>(op.getA().getType()).getElementType() ==
+           dElemTy);
+    chosenOp.vectorSize = 1;
+    chosenOp.outElemTy = aElemTy;
+    if (aElemTy.isF32())
+      chosenOp.intrinsicName = "llvm.fmuladd.f32";
+    if (aElemTy.isF16())
+      chosenOp.intrinsicName = "llvm.fmuladd.f16";
+    chosenOp.additionalArgs = {};
+    return chosenOp;
+  }
+
+  Value packOperand(ArrayRef<Value> scalarValues, int firstElemPos,
+                    unsigned vectorSize) {
+    if (vectorSize == 1)
+      return scalarValues[firstElemPos];
+    auto elemTy = scalarValues[firstElemPos].getType();
+    auto vecTy = vec_ty(elemTy, vectorSize);
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    Value vec = b.undef(vecTy);
+    for (int elem = 0; elem < vectorSize; ++elem) {
+      int elemPos = firstElemPos + elem;
+      vec =
+          b.insert_element(vecTy, vec, scalarValues[elemPos], b.i32_val(elem));
+    }
+    if (elemTy.isInteger(8)) {
+      assert(vectorSize == 4);
+      vec = b.bitcast(vec, i32_ty);
+    }
+    return vec;
+  }
+
+  Value generateDotInstr(Value a, Value b, Value c) {
+    SmallVector<Value> args{a, b, c};
+    args.append(intrinsic.additionalArgs.begin(),
+                intrinsic.additionalArgs.end());
+    SmallVector<Type> argTypes;
+    for (auto arg : args)
+      argTypes.push_back(arg.getType());
+    auto funcType = LLVM::LLVMFunctionType::get(intrinsic.outElemTy, argTypes);
+    auto d = LLVM::createLLVMIntrinsicCallOp(
+        rewriter, loc, intrinsic.intrinsicName, intrinsic.outElemTy, args);
+    return d.getResult(0);
+  }
+
+public:
+  AMDFMAVectorMultiplier(ConversionPatternRewriter &rewriter, triton::DotOp op)
+      : rewriter(rewriter), loc(op.getLoc()), intrinsic(chooseIntrinsic(op)) {}
+
+  mlir::Value multiplyVectors(mlir::ArrayRef<mlir::Value> a,
+                              mlir::ArrayRef<mlir::Value> b,
+                              mlir::Value c) override {
+    auto kSize = a.size();
+    assert(b.size() == kSize);
+    mlir::Value accum = c;
+    for (int k = 0; k < kSize; k += intrinsic.vectorSize) {
+      auto aOp = packOperand(a, k, intrinsic.vectorSize);
+      auto bOp = packOperand(b, k, intrinsic.vectorSize);
+      accum = generateDotInstr(aOp, bOp, accum);
+    }
+    return accum;
+  }
+};
+
+} // namespace
+
+namespace mlir::triton::AMD {
+
+LogicalResult convertAMDFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
+                               const LLVMTypeConverter *typeConverter,
+                               ConversionPatternRewriter &rewriter) {
+  AMDFMAVectorMultiplier multiplier(rewriter, op);
+  return parametricConvertFMADot(op, adaptor, typeConverter, rewriter,
+                                 multiplier);
+}
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -33,7 +33,7 @@ class AMDFMAVectorMultiplier : public FMAVectorMultiplier {
     auto arch = getAMDArch(mod);
     DotIntrinsic chosenOp;
 
-    bool dotAvailable = AMD::isVDotSupported(arch);
+    bool dotAvailable = AMD::supportsVDot(arch);
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     if (dotAvailable) {
       if (aElemTy.isF16() && dElemTy.isF32()) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetUtils.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetUtils.cpp
@@ -3,16 +3,6 @@
 
 namespace mlir::triton::AMD {
 
-bool isVDotSupported(llvm::StringRef arch) {
-  auto isaFamily = triton::AMD::deduceISAFamily(arch);
-  bool dotAvailable = isaFamily == AMD::ISAFamily::CDNA1 ||
-                      isaFamily == AMD::ISAFamily::CDNA2 ||
-                      isaFamily == AMD::ISAFamily::CDNA3 ||
-                      isaFamily == AMD::ISAFamily::RDNA2 ||
-                      isaFamily == AMD::ISAFamily::RDNA3;
-  return dotAvailable;
-}
-
 ISAFamily deduceISAFamily(llvm::StringRef arch) {
   llvm::AMDGPU::GPUKind kind = llvm::AMDGPU::parseArchAMDGCN(arch);
 
@@ -43,6 +33,20 @@ ISAFamily deduceISAFamily(llvm::StringRef arch) {
     return ISAFamily::RDNA1;
 
   return ISAFamily::Unknown;
+}
+
+bool supportsVDot(llvm::StringRef arch) {
+  switch (deduceISAFamily(arch)) {
+  case AMD::ISAFamily::CDNA1:
+  case AMD::ISAFamily::CDNA2:
+  case AMD::ISAFamily::CDNA3:
+  case AMD::ISAFamily::RDNA2:
+  case AMD::ISAFamily::RDNA3:
+    return true;
+  default:
+    break;
+  }
+  return false;
 }
 
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetUtils.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetUtils.cpp
@@ -3,6 +3,16 @@
 
 namespace mlir::triton::AMD {
 
+bool isVDotSupported(llvm::StringRef arch) {
+  auto isaFamily = triton::AMD::deduceISAFamily(arch);
+  bool dotAvailable = isaFamily == AMD::ISAFamily::CDNA1 ||
+                      isaFamily == AMD::ISAFamily::CDNA2 ||
+                      isaFamily == AMD::ISAFamily::CDNA3 ||
+                      isaFamily == AMD::ISAFamily::RDNA2 ||
+                      isaFamily == AMD::ISAFamily::RDNA3;
+  return dotAvailable;
+}
+
 ISAFamily deduceISAFamily(llvm::StringRef arch) {
   llvm::AMDGPU::GPUKind kind = llvm::AMDGPU::parseArchAMDGCN(arch);
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -865,12 +865,13 @@ public:
         return true;
       }
 
+      // TODO: enable this condition, when fp32 -> fp16 cast works correctly
       // Consider this case as non legal,
       // despite this case is covered by fp16 FMA.
       // because v_dot expected to give
       // both better performance and computational precision
-      if (dotTypes.a.isF16() && dotTypes.b.isF16() && dotTypes.c.isF16() &&
-          dotTypes.d.isF16() && k % 2 == 0) {
+      if (false && dotTypes.a.isF16() && dotTypes.b.isF16() &&
+          dotTypes.c.isF16() && dotTypes.d.isF16() && k % 2 == 0) {
         return false;
       }
 
@@ -973,7 +974,9 @@ public:
       return failure();
     }
 
-    if (tryAccelerateF16WithVDot(dotOp, rewriter, dotTypes).succeeded()) {
+    // TODO: enable this condition, when fp32 -> fp16 cast works correctly
+    if (false &&
+        tryAccelerateF16WithVDot(dotOp, rewriter, dotTypes).succeeded()) {
       return success();
     }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -713,58 +713,8 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
               ? AElType
               : BElType;
     } else {
-      // FMA case.
-      Type AElType = dotOp.getA().getType().getElementType();
-      Type DElType = D.getType().getElementType();
-
-      // Convert int operands to FP32 to apply FMA case
-      // Do it here instead of introducing new pattern because the pass is more
-      // about MMA dots.
-      // TODO: Introduce new pass for FMA dots legalization.
-      if (AElType.isIntOrIndex()) {
-        assert(dotOp.getB().getType().getElementType().isIntOrIndex() &&
-               dotOp.getC().getType().getElementType().isIntOrIndex() &&
-               DElType.isIntOrIndex());
-        auto convertTensorIToFP = [&](Value v) -> Value {
-          RankedTensorType vTy = cast<RankedTensorType>(v.getType());
-          Type dstType = vTy.cloneWith(std::nullopt, builder.getF32Type());
-          Type srcElType = vTy.getElementType();
-          return !srcElType.isUnsignedInteger()
-                     ? builder
-                           .create<arith::SIToFPOp>(dotOp.getLoc(), dstType, v)
-                           .getResult()
-                     : builder
-                           .create<arith::UIToFPOp>(dotOp.getLoc(), dstType, v)
-                           .getResult();
-        };
-        auto convertTensorFPToI = [&](Type dstElType, Value v) -> Value {
-          RankedTensorType vTy = cast<RankedTensorType>(v.getType());
-          Type dstType = vTy.cloneWith(std::nullopt, dstElType);
-          return !dstElType.isUnsignedInteger()
-                     ? builder
-                           .create<arith::FPToSIOp>(dotOp.getLoc(), dstType, v)
-                           .getResult()
-                     : builder
-                           .create<arith::FPToUIOp>(dotOp.getLoc(), dstType, v)
-                           .getResult();
-        };
-
-        auto newAOperand = convertTensorIToFP(dotOp.getA());
-        auto newBOperand = convertTensorIToFP(dotOp.getB());
-        auto newCOperand = convertTensorIToFP(dotOp.getC());
-        auto newDot = builder.create<tt::DotOp>(
-            dotOp.getLoc(), newCOperand.getType(), newAOperand, newBOperand,
-            newCOperand, dotOp.getInputPrecision(),
-            dotOp.getMaxNumImpreciseAcc());
-        auto newD = convertTensorFPToI(DElType, newDot.getResult());
-        D.replaceAllUsesWith(newD);
-        dotOp.erase();
-        return;
-      }
-
-      if (AElType == DElType)
-        return;
-      promoteType = DElType;
+      // FMA case is processed in AccelerateBlocked
+      return;
     }
     Location loc = dotOp.getLoc();
     Value promotedA = promoteOperand(builder, loc, dotOp.getA(), promoteType);
@@ -867,6 +817,136 @@ public:
     return success();
   }
 };
+
+class AccelerateBlocked : public mlir::RewritePattern {
+  StringRef arch;
+
+public:
+  AccelerateBlocked(mlir::MLIRContext *context, StringRef arch)
+      : mlir::RewritePattern(tt::DotOp::getOperationName(), 1, context),
+        arch(arch) {}
+
+  bool isFloat(Type t) const { return t.isIntOrFloat() && !t.isIntOrIndex(); }
+
+  Value castToElTy(mlir::PatternRewriter &rewriter, Value v, Type elTy) const {
+    Location loc = v.getLoc();
+    auto srcTy = cast<RankedTensorType>(v.getType());
+    auto dstTy = srcTy.cloneWith(std::nullopt, elTy);
+    if (srcTy == dstTy)
+      return v;
+    auto srcElTy = srcTy.getElementType();
+    auto dstElTy = dstTy.getElementType();
+    if (isFloat(srcElTy) && isFloat(dstElTy))
+      return rewriter.create<triton::FpToFpOp>(loc, dstTy, v);
+    if (!isFloat(srcElTy) && isFloat(dstElTy))
+      return rewriter.create<mlir::arith::SIToFPOp>(loc, dstTy, v);
+    if (isFloat(srcElTy) && !isFloat(dstElTy))
+      return rewriter.create<mlir::arith::FPToSIOp>(loc, dstTy, v);
+    assert(false && "int -> int cast is unexpected in FMA legalization");
+    return Value();
+  }
+
+  bool legalFMAForm(tt::DotOp dotOp) const {
+    auto expectedElTy = dotOp.getA().getType().getElementType();
+    for (auto operand : dotOp.getOperands()) {
+      auto opTy = cast<RankedTensorType>(operand.getType());
+      auto elTy = opTy.getElementType();
+      if (elTy != expectedElTy)
+        return false;
+      if (!elTy.isF16() && !elTy.isF32())
+        return false;
+    }
+    return true;
+  }
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto dotOp = cast<tt::DotOp>(op);
+    auto a = dotOp.getA();
+    auto b = dotOp.getB();
+    auto c = dotOp.getC();
+    auto d = dotOp.getD();
+
+    if (!llvm::isa<triton::gpu::BlockedEncodingAttr>(d.getType().getEncoding()))
+      return failure();
+
+    Type aElTy = a.getType().getElementType();
+    Type bElTy = b.getType().getElementType();
+    Type cElTy = c.getType().getElementType();
+    Type dElTy = d.getType().getElementType();
+
+    int rank = a.getType().getShape().size();
+    int k = a.getType().getShape()[rank - 1];
+
+    bool dotAvailable = arch == "gfx908" || arch == "gfx90a" ||
+                        arch.starts_with("gfx94") ||
+                        arch.starts_with("gfx11") || arch.starts_with("gfx103");
+
+    // Try Fp16 x Fp16 -> Fp32 dot
+    if (dotAvailable && aElTy.isF16() && bElTy.isF16() && cElTy.isF32() &&
+        dElTy.isF32()) {
+      if (k % 2 == 0) {
+        // nothing to do for this dot
+        return failure();
+      }
+      // if k % 2 != 0: can not use DOT instruction, continue with FMA
+    }
+    // Try I8 x I8 -> I32 dot
+    if (dotAvailable && aElTy.isInteger(8) && bElTy.isInteger(8) &&
+        cElTy.isInteger(32) && dElTy.isInteger(32)) {
+      if (k % 4 == 0) {
+        // nothing to do for this dot
+        return failure();
+      }
+      // if k % 4 != 0: can not use DOT instruction, continue with FMA
+    }
+
+    // check that dot is not legalized already
+    if (legalFMAForm(dotOp)) {
+      return failure();
+    }
+
+    // Legalize dot for FMA case
+
+    // find common type, larger or equal of all operand types
+    SmallVector<Type> opElTy{aElTy, bElTy, cElTy, dElTy};
+    unsigned maxBitsize = 8;
+    for (auto elTy : opElTy)
+      maxBitsize = std::max(maxBitsize, elTy.getIntOrFloatBitWidth());
+    assert(maxBitsize <= 32);
+    Type commonTy =
+        maxBitsize <= 16 ? rewriter.getF16Type() : rewriter.getF32Type();
+
+    // check that type is compatible with all operands
+    // fallback to fp32 if not
+    if (commonTy.isF16()) {
+      for (auto elTy : opElTy) {
+        if (elTy.isInteger() && elTy.getIntOrFloatBitWidth() > 8) {
+          commonTy = rewriter.getF32Type();
+          break;
+        }
+        if (elTy.isBF16()) {
+          commonTy = rewriter.getF32Type();
+          break;
+        }
+      }
+    }
+
+    auto newA = castToElTy(rewriter, a, commonTy);
+    auto newB = castToElTy(rewriter, b, commonTy);
+    auto newC = castToElTy(rewriter, c, commonTy);
+
+    auto newDot = rewriter.create<tt::DotOp>(
+        dotOp.getLoc(), newC.getType(), newA, newB, newC,
+        dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc());
+    auto newD = castToElTy(rewriter, newDot.getResult(), dElTy);
+    d.replaceAllUsesWith(newD);
+    dotOp.erase();
+    return success();
+  }
+};
+
 } // namespace
 
 #define GEN_PASS_CLASSES
@@ -903,6 +983,7 @@ public:
     default:
       break;
     }
+    patterns.add<AccelerateBlocked>(context, archGenerationName);
     if (applyPatternsGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();
     }


### PR DESCRIPTION
This PR:

- Makes AccelerateAMDMatmul pass to emit FMA i8xi8->i32 and fp16xfp16->fp32 cases
- Extends AMD FMA Dot code generation with new v_dot instructions for fp16xfp16 and int8 dtypes

~This PR is a part of PR series. Final goal is to improve efficiency of small dot operations and bypass as much shared memory accesses as possible.~

Rough list of PRs:
- [x] Basic FMA dot fixes, dot 3d support and relaxing small dimensions for dot #4516
- [x] Blocked->dotOp shared memory bypassing #4538
- [ ] Accelerate AMD Matmul + emit dot operations **(this PR)** #4594
- [ ] ~Layout optimization, so operand B is loaded in proper mfma layout and do not need to go through LDS #4581~
- [ ] ~Vectorization optimization of dot operands/results (in case llvm can not do this internally)~
- [ ] ~Reduction operation hoisting out of the K loop (reduction operation is a byproduct of layout optimization step) #4559~