### PR TITLE
[backend][nvidia] Fix shift exponent is too large ASAN error.

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -254,6 +254,12 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       }
 
       if (other) {
+        if (otherIsSplatConstInt) {
+          for (size_t s = valueElemNBits; s < movWidth; s += valueElemNBits) {
+            splatVal |= splatVal << valueElemNBits;
+          }
+        }
+
         for (size_t ii = 0; ii < nWords; ++ii) {
           // PTX doesn't support mov.u8, so we need to use mov.u16
           PTXInstr &mov =
@@ -274,8 +280,6 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
           PTXInstr::Operand *opr{};
 
           if (otherIsSplatConstInt) {
-            for (size_t s = 0; s < 32; s += valueElemNBits)
-              splatVal |= splatVal << valueElemNBits;
             opr = ptxBuilder.newConstantOperand(splatVal);
           } else
             opr = ptxBuilder.newOperand(v, readConstraint);


### PR DESCRIPTION
When lowering tt.load to PTX we need to generate a mov instruction to set default value into the register for value that are not masked.

For small types (pred, u8, 16) we use vector registers with 2 or 4 value and issue one mov instruction. For example, a lot of u8 tensor will have mov.u16. This mean the default splat value should be concantenated to set multiple value in the vector register.

The current loops uses a hard coded mov width of 32, always does 1 iteration too many and runs inside the loop, so the splat value is shifted more times than necessary.

If the "other" value is 0x1, current code can generate:

mov.u16 $0, 0x101010101;
mov.u16 $0, 0x101010101010101;

We want:

mov.u16 $0, 0x101;

The splat loop should be hoisted even higher, but that would be a much bigger code motion.