### PR TITLE
[RFC] To support the lowering of nested layout "#slice->#dot->#mma"

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -797,6 +797,15 @@ def MmaEncodingTrait : AttrInterface<"MmaEncodingTrait"> {
                     "SmallVector<unsigned>",
                     "getSizePerThreadForOperands",
                     (ins "unsigned":$opIdx)>,
+
+    InterfaceMethod<"Return element sizes per thread for dot operands.", "SmallVector<unsigned>",
+      "getElemsPerThreadForOperands", (ins "ArrayRef<int64_t>":$tensorShape,
+                                           "Type":$eltTy,
+                                           "unsigned":$opIdx),
+                                           /*methodBody=*/[{}],
+                                           /*defaultImplementation=*/[{
+                                            llvm_unreachable("getElemsPerThreadForOperands is not supported.");
+                                          }]>,
   ];
 }
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -928,6 +928,9 @@ unsigned SharedEncodingAttr::getTotalElemsPerThread(ArrayRef<int64_t> shape,
 SmallVector<unsigned>
 DotOperandEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape,
                                           Type eltTy) const {
+  if (auto mmaParent = mlir::dyn_cast<MmaEncodingTrait>(getParent())) {
+    return mmaParent.getElemsPerThreadForOperands(shape, eltTy, getOpIdx());
+  }
   llvm_unreachable("getElemsPerThread is not supported for dot operand");
   return SmallVector<unsigned>();
 }


### PR DESCRIPTION
The method `DotOperandEncodingAttr::getElemsPerThread` is required for lowering the nested layout like: \#slice->\#dot->\#mma.  

But the method is not implemented yet.
The idea solution is to convert the DotOp layout to LL for lowering.  
Before the DotOp to LL conversion is ready, can we add a new interface as a quick implementation for complementary?

The changes works for the Intel GPU to extend the implementation to support the case.


