### PR TITLE
[frontend] Improve error messages about the support of fp8 types

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -244,9 +244,15 @@ def downcast_test(src_dtype, dst_dtype, rounding, exponent_bits, mantissa_bits, 
         raise ValueError('%d elements mismatch' % (dst != dst2).sum())
 
 
-def upcast_test(src_dtype, dst_dtype, exponent_bits, mantissa_bits, exponent_bias, max_repr, device):
+def upcast_test(src_dtype, dst_dtype, exponent_bits, mantissa_bits, exponent_bias, max_repr, error, device):
 
     numbits_src = exponent_bits + mantissa_bits + 1
+
+    # If the dtype should error out in the given device, we assert that and return
+    if error is not None:
+        with pytest.raises(triton.CompilationError, match=error):
+            src = launch_exhaustive_populate(src_dtype, 0, 65536, False, numbits_src, max_repr, device=device)
+        return
 
     src = launch_exhaustive_populate(src_dtype, 0, 65536, False, numbits_src, max_repr, device=device)
 
@@ -282,14 +288,15 @@ def upcast_test(src_dtype, dst_dtype, exponent_bits, mantissa_bits, exponent_bia
 ])
 def test_typeconvert_upcast(src_dtype, dst_dtype, device):
 
+    error = None
     if src_dtype == 'float8e4nv' and is_cuda() and torch.cuda.get_device_capability(0) < (9, 0):
-        pytest.skip("float8e4nv upcast tests only supported on NVGPU with compute capability 9.0+")
+        error = 'fp8e4nv not supported for capability <9.0'
 
     if src_dtype in ('float8e4nv', 'float8e4b15') and is_hip():
-        pytest.skip(f"{src_dtype} upcast tests not supported on ROCm")
+        error = 'not supported on ROCm'
 
     if src_dtype in ('float8e4b8', 'float8e5b16') and (is_cuda() or not is_on_mi300()):
-        pytest.skip("{src_dtype} upcast tests only supported on AMDGPU MI300")
+        error = 'only supported on AMDGPU MI300'
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias, max_repr)
     stuff = {
@@ -302,7 +309,7 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
         'bfloat16': (8, 7, 127, 0x7f7f),
     }[src_dtype]
 
-    upcast_test(getattr(tl, src_dtype), getattr(tl, dst_dtype), *stuff, device=device)
+    upcast_test(getattr(tl, src_dtype), getattr(tl, dst_dtype), *stuff, error=error, device=device)
 
 @pytest.mark.parametrize("src_dtype, dst_dtype, rounding, max_repr", [
     ('float32', 'float16', 'rtne', 0x477fe000),

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2948,9 +2948,9 @@ def test_generic_reduction(device):
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_permute(dtype_str, shape, perm, num_ctas, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
+    if dtype_str == "float8e4b15" and (is_hip() or is_cuda() and (torch.cuda.get_device_capability() >= (9, 0))):
+        pytest.skip("float8e4b15 not supported on ROCm or CUDA >= 9.0")
     if is_hip():
-        if dtype == "float8e4b15":
-            pytest.skip("float8e4b15 not supported on ROCm")
         if shape == (128, 128) and dtype_str == 'float32':
             pytest.skip("TODO Out of LDS for float32 with shape 128x128")
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2948,8 +2948,11 @@ def test_generic_reduction(device):
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_permute(dtype_str, shape, perm, num_ctas, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
-    if is_hip() and shape == (128, 128) and dtype_str == 'float32':
-        pytest.skip("TODO Out of LDS for float32 with shape 128x128")
+    if is_hip():
+        if dtype == "float8e4b15":
+            pytest.skip("float8e4b15 not supported on ROCm")
+        if shape == (128, 128) and dtype_str == 'float32':
+            pytest.skip("TODO Out of LDS for float32 with shape 128x128")
 
     # triton kernel
     @triton.jit

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2948,7 +2948,7 @@ def test_generic_reduction(device):
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_permute(dtype_str, shape, perm, num_ctas, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
-    if dtype_str == "float8e4b15" and (is_hip() or is_cuda() and (torch.cuda.get_device_capability() >= (9, 0))):
+    if dtype_str == "float8e4b15" and (is_hip() or (is_cuda() and torch.cuda.get_device_capability() >= (9, 0))):
         pytest.skip("float8e4b15 not supported on ROCm or CUDA >= 9.0")
     if is_hip():
         if shape == (128, 128) and dtype_str == 'float32':

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1068,6 +1068,12 @@ def test_abs(dtype_x, device):
 def test_abs_fp8(in_dtype, device):
     if is_hip():
         pytest.skip('test_abs_fp8 not supported on HIP.')
+    elif is_cuda():
+        cc = torch.cuda.get_device_capability()
+        if in_dtype == tl.float8e4b15 and cc >= (9, 0):
+            pytest.skip("float8e4b15 not supported on CUDA >= 9.0")
+        if in_dtype == tl.float8e4nv and cc < (8, 9):
+            pytest.skip("float8e4nv not supported on CUDA < 8.9")
 
     @triton.jit
     def abs_kernel(X, Z, SIZE: tl.constexpr):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -496,7 +496,35 @@ class dtype:
     def scalar(self):
         return self
 
+    def check_fp8_types(self):
+        import triton
+        import torch
+
+        def is_interpreter():
+            return os.environ.get('TRITON_INTERPRET', '0') == '1'
+
+        def is_cuda():
+            return not is_interpreter() and triton.runtime.driver.active.get_current_target().backend == "cuda"
+
+        def is_hip():
+            return not is_interpreter() and triton.runtime.driver.active.get_current_target().backend == "hip"
+
+        def is_on_mi300():
+            return is_hip() and triton.runtime.driver.active.get_current_target().arch in ('gfx940', 'gfx941', 'gfx942')
+
+        cc = torch.cuda.get_device_capability(0)
+        if self.is_fp8e4nv() and is_cuda() and cc < (9, 0):
+            raise ValueError(f'{self.name} not supported for capability <9.0. '
+                             'Got {}'.format(*cc))
+        if self.name in ('fp8e4nv', 'fp8e4b15') and is_hip():
+            raise ValueError(f"{self.name} not supported on ROCm")
+
+        if self.name in ('fp8e4b8', 'fp8e5b16') and (is_cuda() or not is_on_mi300()):
+            raise ValueError(f"{self.name} only supported on AMDGPU MI300")
+
     def to_ir(self, builder: ir.builder) -> ir.type:
+        self.check_fp8_types()
+
         if self.name == 'void':
             return builder.get_void_ty()
         elif self.name == 'int1':

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1318,20 +1318,18 @@ def _str_to_dot_input_precision(input_precision, builder):
 
 def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optional[str], max_num_imprecise_acc: int,
         out_dtype: tl.dtype, builder: ir.builder) -> tl.tensor:
-
-    def assert_dtypes_valid(lhs_dtype, rhs_dtype, options):
-        if lhs_dtype.is_int() or rhs_dtype.is_int():
-            assert lhs_dtype.int_bit_width == 1 and rhs_dtype.int_bit_width == 1, f"Both operands must be either int8 or uint8. Operand type ({lhs_dtype}, {rhs_dtype})"
-        elif lhs_dtype.is_fp8() and rhs_dtype.is_fp8():
-            # All combinations of supported fp8 x fp8 are permitted
-            return
-        else:
-            assert lhs_dtype in (tl.float16, tl.bfloat16, tl.float32), f"Unsupported lhs dtype {lhs_dtype}"
-            assert rhs_dtype in (tl.float16, tl.bfloat16, tl.float32), f"Unsupported rhs dtype {lhs_dtype}"
-            assert lhs_dtype == rhs_dtype, f"Both operands must be same dtype. Got {lhs_dtype} and {rhs_dtype}"
-
     assert lhs.type.is_block() and rhs.type.is_block()
-    assert_dtypes_valid(lhs.dtype, rhs.dtype, builder.options)
+
+    if lhs.dtype.is_fp8() and rhs.dtype.is_fp8():
+        # All combinations of supported fp8 x fp8 are permitted
+        pass
+    else:
+        assert lhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16,
+                             tl.float32), f"Unsupported lhs dtype {lhs.dtype}"
+        assert rhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16,
+                             tl.float32), f"Unsupported rhs dtype {rhs.dtype}"
+        assert lhs.dtype == rhs.dtype, f"Both operands must be same dtype. Got {lhs.dtype} and {rhs.dtype}"
+
     if lhs.dtype.is_fp8e4b15() or rhs.dtype.is_fp8e4b15():
         lhs = cast(lhs, tl.float16, builder)
         rhs = cast(rhs, tl.float16, builder)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -758,9 +758,6 @@ def cast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder,
             raise ValueError("fp_downcast_rounding should be set only for truncating fp conversions. "
                              "Source scalar type is " + str(src_sca_ty) + " and destination type is " + str(dst_sca_ty))
 
-    if (src_sca_ty.is_fp8e4nv() or dst_sca_ty.is_fp8e4nv()):
-        assert builder.options.allow_fp8e4nv, "fp8e4nv data type is not supported on CUDA arch < 89"
-
     if (src_sca_ty.is_fp8e4b15() or dst_sca_ty.is_fp8e4b15()):
         assert builder.codegen_fns.get(
             "convert_custom_types") is not None, "target doesn't provide conversion for this type."
@@ -1323,36 +1320,15 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optiona
         out_dtype: tl.dtype, builder: ir.builder) -> tl.tensor:
 
     def assert_dtypes_valid(lhs_dtype, rhs_dtype, options):
-        if not options.allow_fp8e4nv:
-            assert not lhs_dtype.is_fp8e4nv() and not rhs_dtype.is_fp8e4nv(
-            ), "Dot op does not support fp8e4nv on CUDA arch < 90"
-            if lhs_dtype.is_fp8() and rhs_dtype.is_fp8():
-                return
-            assert lhs_dtype == rhs_dtype, f"First input ({lhs_dtype}) and second input ({rhs_dtype}) must have the same dtype!"
+        if lhs_dtype.is_int() or rhs_dtype.is_int():
+            assert lhs_dtype.int_bit_width == 1 and rhs_dtype.int_bit_width == 1, f"Both operands must be either int8 or uint8. Operand type ({lhs_dtype}, {rhs_dtype})"
+        elif lhs_dtype.is_fp8() and rhs_dtype.is_fp8():
+            # All combinations of supported fp8 x fp8 are permitted
+            return
         else:
-            if lhs_dtype.is_int() or rhs_dtype.is_int():
-                assert lhs_dtype == rhs_dtype, f"Both operands must be same type. First operand ({lhs_dtype}) and second operand ({rhs_dtype})"
-                assert lhs_dtype.is_int8() or lhs_dtype.is_uint8(
-                ), f"Both operands must be either int8 or uint8. Operand type ({lhs_dtype})"
-            elif lhs_dtype.is_fp8() or rhs_dtype.is_fp8():
-                if options.allow_fp8e4b15:
-                    allowed_types = ['fp8e4nv', 'fp8e5', 'fp8e4b15']
-                else:
-                    allowed_types = ['fp8e4nv', 'fp8e5']
-
-                def _validate_dtype(dtype, allowed_types, operand_name):
-                    if not any(getattr(dtype, f'is_{dtype_name}')() for dtype_name in allowed_types):
-                        supported_types = ', '.join(allowed_types)
-                        raise AssertionError(f"Only supports {supported_types}. {operand_name} ({dtype})")
-
-                _validate_dtype(lhs_dtype, allowed_types, "First operand")
-                _validate_dtype(rhs_dtype, allowed_types, "Second operand")
-            else:
-                assert lhs_dtype.is_fp16() or lhs_dtype.is_bf16() or lhs_dtype.is_fp32() or lhs_dtype.is_int1(
-                ), f"Unsupported dtype {lhs_dtype}"
-                assert rhs_dtype.is_fp16() or rhs_dtype.is_bf16() or rhs_dtype.is_fp32() or rhs_dtype.is_int1(
-                ), f"Unsupported dtype {rhs_dtype}"
-                assert lhs_dtype == rhs_dtype, f"First input ({lhs_dtype}) and second input ({rhs_dtype}) must have the same dtype!"
+            assert lhs_dtype in (tl.float16, tl.bfloat16, tl.float32), f"Unsupported lhs dtype {lhs_dtype}"
+            assert rhs_dtype in (tl.float16, tl.bfloat16, tl.float32), f"Unsupported rhs dtype {lhs_dtype}"
+            assert lhs_dtype == rhs_dtype, f"Both operands must be same dtype. Got {lhs_dtype} and {rhs_dtype}"
 
     assert lhs.type.is_block() and rhs.type.is_block()
     assert_dtypes_valid(lhs.dtype, rhs.dtype, builder.options)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -76,8 +76,7 @@ class InterpreterOptions:
     extern_libs: dict = None
     debug: bool = False
     arch: str = None
-    allow_fp8e4nv: bool = True
-    allow_fp8e4b15: bool = True
+    supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e5b16", "fp8e4nv", "fp8e4b8", "fp8e4b15")
     default_dot_input_precision: str = "tf32"
     allowed_dot_input_precisions: Tuple[str] = ("tf32", "tf32x3", "ieee")
     max_num_imprecise_acc_default: int = 0

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -81,7 +81,7 @@ class HIPBackend(BaseBackend):
             supported_fp8_dtypes = set(HIPOptions.supported_fp8_dtypes)
             if self.target.arch in ('gfx940', 'gfx941', 'gfx942'):
                 supported_fp8_dtypes.update({'fp8e4b8', 'fp8e5b16'})
-            args["supported_fp8_dtypes"] = sorted(tuple(supported_fp8_dtypes))
+            args["supported_fp8_dtypes"] = tuple(sorted(supported_fp8_dtypes))
 
         if "enable_fp_fusion" not in opts:
             args["enable_fp_fusion"] = os.getenv("TRITON_DEFAULT_FP_FUSION", "1") == "1"

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -35,8 +35,7 @@ class HIPOptions:
     cluster_dims: tuple = (1, 1, 1)
     debug: bool = False
     arch: str = None
-    allow_fp8e4nv: bool = False
-    allow_fp8e4b15: bool = False
+    supported_fp8_dtypes: Tuple[str] = ("fp8e5", )
     default_dot_input_precision: str = "ieee"
     allowed_dot_input_precisions: Tuple[str] = ("ieee", )
     enable_fp_fusion: bool = True
@@ -77,7 +76,14 @@ class HIPBackend(BaseBackend):
 
     def parse_options(self, opts) -> Any:
         args = {'arch': self.target.arch}
-        if not "enable_fp_fusion" in args:
+
+        if "supported_fp8_dtypes" not in opts:
+            supported_fp8_dtypes = set(HIPOptions.supported_fp8_dtypes)
+            if self.target.arch in ('gfx940', 'gfx941', 'gfx942'):
+                supported_fp8_dtypes.update({'fp8e4b8', 'fp8e5b16'})
+            args["supported_fp8_dtypes"] = sorted(tuple(supported_fp8_dtypes))
+
+        if "enable_fp_fusion" not in opts:
             args["enable_fp_fusion"] = os.getenv("TRITON_DEFAULT_FP_FUSION", "1") == "1"
         args.update({k: opts[k] for k in HIPOptions.__dataclass_fields__.keys() if k in opts})
         return HIPOptions(**args)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -94,8 +94,7 @@ class CUDAOptions:
     cluster_dims: tuple = (1, 1, 1)
     ptx_version: int = None
     enable_fp_fusion: bool = True
-    allow_fp8e4nv: bool = False
-    allow_fp8e4b15: bool = False
+    supported_fp8_dtypes: Tuple[str] = ("fp8e5", )
     default_dot_input_precision: str = "tf32"
     allowed_dot_input_precisions: Tuple[str] = ("tf32", "tf32x3", "ieee")
     max_num_imprecise_acc_default: bool = None
@@ -133,9 +132,15 @@ class CUDABackend(BaseBackend):
 
     def parse_options(self, opts) -> Any:
         args = {k: opts[k] for k in CUDAOptions.__dataclass_fields__.keys() if k in opts}
-        args["allow_fp8e4nv"] = self.capability >= 89
-        args["allow_fp8e4b15"] = self.capability < 90
-        if not "enable_fp_fusion" in args:
+        if "supported_fp8_dtypes" not in args:
+            supported_fp8_dtypes = set(CUDAOptions.supported_fp8_dtypes)
+            if self.capability < 90:
+                supported_fp8_dtypes.add("fp8e4b15")
+            if self.capability >= 89:
+                supported_fp8_dtypes.add("fp8e4nv")
+            args["supported_fp8_dtypes"] = tuple(sorted(supported_fp8_dtypes))
+
+        if "enable_fp_fusion" not in args:
             args["enable_fp_fusion"] = os.getenv("TRITON_DEFAULT_FP_FUSION", "1") == "1"
         args["max_num_imprecise_acc_default"] = 2**30 if self.capability == 90 else 0
         return CUDAOptions(**args)


### PR DESCRIPTION
We unify the support rules for `fp8` dtypes within triton on a per-backend basis.

While doing that, we heavily simplify the check code for `tl.dot`, given that we now have much stronger preconditions on the possible dtypes.
