### PR TITLE
Don't eagerly import all backends from tl.extra

### DIFF
--- a/python/triton/language/extra/__init__.py
+++ b/python/triton/language/extra/__init__.py
@@ -1,4 +1,0 @@
-from . import cuda
-from . import hip
-
-__all__ = ['cuda', 'hip']


### PR DESCRIPTION
This made it impossible to have `triton.jit` imported at the top-level in the libdevice backend-specific implementations because it would create a circular import.

Note that the only advantage of specifying `__all__` is to determine what gets included via `from triton.language.extra import *`, but we almost never want to do that anyway. Per https://stackoverflow.com/a/64130:

> Members that are not mentioned in __all__ are still accessible from
> outside the module and can be imported with from `<module>` import
> `<member>`.