### PR TITLE
Fix mantissa width for fp64

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -378,7 +378,7 @@ class dtype:
                 self.primitive_bitwidth = 32
                 self.exponent_bias = 127
             elif name == 'fp64':
-                self.fp_mantissa_width = 53
+                self.fp_mantissa_width = 52
                 self.primitive_bitwidth = 64
                 self.exponent_bias = 1023
             else:


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/Double-precision_floating-point_format, it should be 52 bits.