### PR TITLE
[Frontend] [BC breaking] Implement PyTorch/JAX/NumPy 2.0 typecast semantics for scalars

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Python API
 - :doc:`triton <python-api/triton>`
 - :doc:`triton.language <python-api/triton.language>`
 - :doc:`triton.testing <python-api/triton.testing>`
+- :doc:`Triton semantics <python-api/triton-semantics>`
 
 
 .. toctree::
@@ -35,6 +36,7 @@ Python API
    python-api/triton
    python-api/triton.language
    python-api/triton.testing
+   python-api/triton-semantics
 
 
 Triton MLIR Dialects and Ops

--- a/docs/python-api/triton-semantics.rst
+++ b/docs/python-api/triton-semantics.rst
@@ -1,0 +1,44 @@
+Triton mostly follows the semantics of NumPy with minor exceptions. In this document, we go over some of the array computing features supported in Triton, and we cover the exceptions where Triton's semantics deviate from that NumPy.
+
+Type Promotion
+==============
+
+**Type Promotion** occurs when tensors of different data types are used in an operation. For binary operations associated to `dunder methods <https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types>`_ and the ternary function ``tl.where`` on its last two arguments, Triton automatically converts the input tensors to a common data type following a hierarchy of kinds (sets of dtypes): ``{bool} < {integral dypes} < {floating point dtypes}``.
+
+The algorithm is as follows:
+
+1. **Kind** If one tensor is of a dtype of a higher kind, the other tensor is promoted to this dtype: ``(int32, bfloat16) -> bfloat16``
+
+2. **Width** If both tensors are of dtypes of the same kind, and one of them is of a higher width, the other one is promoted to this dtype: ``(float32, float16) -> float32``
+
+3. **Supremum** If both tensors are of the same width and signedness but different dtypes, they are both promoted to the next larger dtype. ``(float16, bfloat16) -> float32``
+
+   3.1 If both tensors are of different ``fp8`` dtypes, they are both cast to ``float16``.
+
+4. **Prefer unsigned** Otherwise (same width, different signedness), they are promoted to the unsigned dtype: ``(int32, uint32) -> uint32``
+
+The rules are a bit different when they involve a scalar. By scalar here we mean a numeric literal, a variable marked with `tl.constexpr` or a combination of these.
+
+When an operation involves a tensor and a scalar:
+
+1. If the scalar is of a kind lower or equal to the tensor, it will not participate in the promotion: ``(uint8, int) -> uint8``
+
+2. If the scalar is of a higher kind, we choose the lowest dtype in which it fits among ``int32`` < ``uint32`` < ``int64`` < ``uint64`` for ints and ``float32`` < ``float64`` for floats. Then, both the tensor and the scalar are promoted to this dtype: ``(int16, 4.0) -> float32``
+
+
+Broadcasting
+============
+
+**Broadcasting** allows operations on tensors of different shapes by automatically expanding their shapes to a compatible size without copying the data. This follows the following rules:
+
+1. If one of the tensor shapes is shorter, pad it on the left with ones until both tensors have the same number of dimensions: ``((3, 4), (5, 3, 4)) -> ((1, 3, 4), (5, 3, 4))``
+
+2. Two dimensions are compatible if they are equal, or if one of them is 1. A dimension of 1 will be expanded to match the dimension of the other tensor. ``((1, 3, 4), (5, 3, 4)) -> ((5, 3, 4), (5, 3, 4))``
+
+
+Differences with NumPy
+======================
+
+**C rounding in integer division** Operators in Triton follow C semantics rather than Python semantics for efficiency. As such, ``int // int`` implements `rounding towards zero as in C <https://en.wikipedia.org/wiki/Modulo#In_programming_languages>`_ for integers of mixed signs, rather than rounding towards minus infinity as in Python. For the same reason, the modulus operator ``int % int`` (which is defined as ``a % b = a - b * (a // b)``) also follows C semantics rather than Python semantics.
+
+Perhaps confusingly, integer division and modulus follow Python semantics for computations where all the inputs are scalars.

--- a/docs/python-api/triton-semantics.rst
+++ b/docs/python-api/triton-semantics.rst
@@ -17,7 +17,7 @@ The algorithm is as follows:
 
 4. **Prefer unsigned** Otherwise (same width, different signedness), they are promoted to the unsigned dtype: ``(int32, uint32) -> uint32``
 
-The rules are a bit different when they involve a scalar. By scalar here we mean a numeric literal, a variable marked with `tl.constexpr` or a combination of these.
+The rules are a bit different when they involve a scalar. By scalar here we mean a numeric literal, a variable marked with `tl.constexpr` or a combination of these. These are represented by NumPy scalars and have types ``bool``, ``int`` and ``float``.
 
 When an operation involves a tensor and a scalar:
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1,4 +1,5 @@
 # flake8: noqa: F821,F841
+import contextlib
 import itertools
 import re
 from typing import Optional
@@ -18,11 +19,16 @@ import triton.language as tl
 from triton.language.extra import libdevice
 
 from triton._internal_testing import (
+    integral_dtypes,
     int_dtypes,
     uint_dtypes,
     float_dtypes,
     dtypes,
     dtypes_with_bfloat16,
+    is_cuda,
+    is_interpreter,
+    is_hip,
+    get_arch,
     torch_float8_dtypes,
     torch_dtypes,
     numpy_random,
@@ -32,29 +38,14 @@ from triton._internal_testing import (
 )
 
 
-def is_interpreter():
-    return os.environ.get('TRITON_INTERPRET', '0') == '1'
-
-
-def get_current_target():
-    if is_interpreter():
-        return None
-    return triton.runtime.driver.active.get_current_target()
-
-
-def is_cuda():
-    target = get_current_target()
-    return False if target is None else target.backend == "cuda"
-
-
-def is_hip():
-    target = get_current_target()
-    return False if target is None else target.backend == "hip"
-
-
-def get_arch():
-    target = get_current_target()
-    return "" if target is None else str(target.arch)
+@contextlib.contextmanager
+def promotion_numpy_2_0():
+    state = np._get_promotion_state()
+    np._set_promotion_state("weak")
+    try:
+        yield
+    finally:
+        np._set_promotion_state(state)
 
 
 # TODO: enable multiple cta cluster testing.
@@ -276,7 +267,7 @@ def _binary_op_dtype_override(a: str, b: str) -> Optional[np.dtype]:
 
 
 def _test_binary(dtype_x, dtype_y, expr, numpy_expr=None, mode_x='real', mode_y='real', device='cuda', num_ctas=1,
-                 y_low=None, y_high=None, test_broadcast=True):
+                 y_low=None, y_high=None, filter_y=None, test_broadcast=True, test_scalar=True):
     check_type_supported(dtype_x, device)  # early return if dtype_x is not supported
     check_type_supported(dtype_y, device)
     SIZE = 128
@@ -306,45 +297,92 @@ def _test_binary(dtype_x, dtype_y, expr, numpy_expr=None, mode_x='real', mode_y=
         z = GENERATE_TEST_HERE
         tl.store(Z + off, z)
 
+    @triton.jit
+    def kernel_scalar_rhs(Z, X, y: tl.constexpr, SIZE: tl.constexpr):
+        off = tl.arange(0, SIZE)
+        x = tl.load(X + off)
+        z = GENERATE_TEST_HERE
+        tl.store(Z + off, z)
+
     replacements = {'GENERATE_TEST_HERE': expr}
     kernel = patch_kernel(kernel, replacements)
     kernel_broadcast_lhs = patch_kernel(kernel_broadcast_lhs, replacements)
     kernel_broadcast_rhs = patch_kernel(kernel_broadcast_rhs, replacements)
+    kernel_scalar_rhs = patch_kernel(kernel_scalar_rhs, replacements)
 
     # inputs
     rs = RandomState(17)
     x = numpy_random(SIZE, dtype_str=dtype_x, rs=rs)
     y = numpy_random(SIZE, dtype_str=dtype_y, rs=rs, low=y_low, high=y_high)
+    if filter_y:
+        y[filter_y(y)] = 1
     if mode_x == 'nan':
         x[:] = float('nan')
     if mode_y == 'nan':
         y[:] = float('nan')
 
     def do_test(x, y, kernel_fn):
-        # reference result
-        z_ref = eval(expr if numpy_expr is None else numpy_expr)
+        x_is_scalar = isinstance(x, (bool, int, float))
+        y_is_scalar = isinstance(y, (bool, int, float))
+        scalar_test = x_is_scalar or y_is_scalar
+
+        # For scalars, we follow the NumPy 2.0 (and JAX/PyTorch pretty much) casting rules.
+        if scalar_test:
+            # We remove any explicit casting
+            pattern = r'\.astype\(np\.\w+\)'
+            scalar_expr = expr if numpy_expr is None else re.sub(pattern, '', numpy_expr)
+            with promotion_numpy_2_0():
+                z_ref = eval(scalar_expr)
+        else:
+            z_ref = eval(expr if numpy_expr is None else numpy_expr)
+
         dtype_z = _binary_op_dtype_override(dtype_x, dtype_y)
-        if dtype_z is not None:
+        if not scalar_test and dtype_z is not None:
             z_ref = z_ref.astype(dtype_z)
+
         # triton result
-        x_tri = to_triton(x, device=device, dst_type=dtype_x)
-        y_tri = to_triton(y, device=device, dst_type=dtype_y)
+        x_tri = x if x_is_scalar else to_triton(x, device=device, dst_type=dtype_x)
+        y_tri = y if y_is_scalar else to_triton(y, device=device, dst_type=dtype_y)
         z_tri = to_triton(np.empty(SIZE, dtype=z_ref.dtype), device=device)
         kernel_fn[(1, )](z_tri, x_tri, y_tri, SIZE=SIZE, num_warps=4, num_ctas=num_ctas)
         err_msg = f"{expr}, {kernel_fn.__name__}"
-        np.testing.assert_allclose(z_ref, to_numpy(z_tri), err_msg=err_msg, atol=1e-3, rtol=0.01)
+        np.testing.assert_allclose(z_ref, to_numpy(z_tri), err_msg=err_msg, atol=3e-3, rtol=0.01)
+
+    def get_scalar(x, dtype, low, high, filter):
+        # If dtype is int, don't choose a huge number for the scalar
+        # as it'll overflow easily when converted to the other dtype
+        if dtype in integral_dtypes:
+            # Choose in range [-7, 7] ([0, 7] for uints)
+            low_x = 0 if dtype in uint_dtypes else -7
+            if low is not None:
+                low_x = max(low_x, low)
+            high_x = 7
+            if high is not None:
+                high_x = min(high_x, high)
+            scalar = numpy_random((), dtype_str=dtype, rs=rs, low=low_x, high=high_x).item()
+            if filter and filter(scalar):
+                #  https://xkcd.com/221/
+                scalar = 4
+        else:
+            scalar = x.flat[0].item()
+        return scalar
 
     do_test(x, y, kernel)
+    if mode_y != 'nan' and test_scalar:
+        if dtype_x in uint_dtypes:
+            low = 0 if y_low is None else max(y_low, 0)
+        else:
+            low = y_low
+        y_scalar = get_scalar(y, dtype_y, low, y_high, filter_y)
+        do_test(x, y_scalar, kernel_scalar_rhs)
     if test_broadcast:
         do_test(x[:1].reshape(()), y, kernel_broadcast_lhs)
         do_test(x, y[:1].reshape(()), kernel_broadcast_rhs)
 
 
 def _mod_operation_ill_conditioned(dtype_x, dtype_y) -> bool:
-    # The result of x % y is ill-conditioned if x % y is much smaller than x.
-    # pytorch/CUDA has slightly different (probably better) rounding on
-    # remainders than stock LLVM. We currently don't expect to match it
-    # bit-for-bit.
+    # FIXME For large x, we are casting x to a floating point where it does not fit
+    #       For small y, we are computing floor(div(float(x), y)) which may not fit
     return (dtype_x, dtype_y) in [
         ('int32', 'bfloat16'),
         ('int32', 'float16'),
@@ -386,7 +424,7 @@ def test_dtype_codegen():
 ])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_bin_op(dtype_x, dtype_y, op, num_ctas, device):
-    expr = f' x {op} y'
+    expr = f'x {op} y'
     if op == '%' and dtype_x in int_dtypes + uint_dtypes and dtype_y in int_dtypes + uint_dtypes:
         # LLVM has 'numpy.fmod', not 'numpy.remainder', semantics on integer remainders.
         numpy_expr = 'np.fmod(x, y)'
@@ -410,11 +448,25 @@ def test_bin_op(dtype_x, dtype_y, op, num_ctas, device):
         with pytest.raises(triton.TritonError, match='Cannot use .* because they have different signedness'):
             _test_binary(dtype_x, dtype_y, expr, numpy_expr, device=device, num_ctas=num_ctas)
     else:
+        # skip when bfloat16, as NumPy's ref performs the computation in float32
+        # while Triton performs it in bfloat16
+        # We also skip mod when it is ill-conditioned
+        skip_scalar_test = ((dtype_x == "bfloat16" and "float" in dtype_y)
+                            or (expr == "x % y" and dtype_x in int_dtypes + uint_dtypes and dtype_y in float_dtypes
+                                and _mod_operation_ill_conditioned(dtype_x, "float32")))
+        # can't divide by zero
+        not_zero = op in ('/', '%') and dtype_x in integral_dtypes and dtype_y in integral_dtypes
+        # can't represent -int(max)
+        not_minus_one = op in ('*', '/') and dtype_x in int_dtypes and dtype_y in int_dtypes
+        if not_zero or not_minus_one:
+            filter_y = lambda y: not_zero * (y == 0) | not_minus_one * (y == -1)
+        else:
+            filter_y = None
         _test_binary(
             dtype_x, dtype_y, expr, numpy_expr, device=device, num_ctas=num_ctas,
             # fails with values where fmod(x, y) is roughly zero, but happens to
             # pass with the random values chosen for non-broadcast tests
-            test_broadcast=(op != "%"))
+            test_broadcast=(op != "%"), filter_y=filter_y, test_scalar=not skip_scalar_test)
 
 
 @pytest.mark.interpreter
@@ -454,7 +506,13 @@ def test_floordiv(dtype_x, dtype_y, num_ctas, device):
     # reference result for //.
     expr = 'x // y'
     numpy_expr = '((x - np.fmod(x, y)) / y)'
-    _test_binary(dtype_x, dtype_y, expr, numpy_expr, device=device, num_ctas=num_ctas)
+    # can't represent -int(max)
+    not_minus_one = dtype_x in int_dtypes and dtype_y in int_dtypes
+    if not_minus_one:
+        filter_y = lambda y: y == -1
+    else:
+        filter_y = None
+    _test_binary(dtype_x, dtype_y, expr, numpy_expr, filter_y=filter_y, device=device, num_ctas=num_ctas)
 
 
 def test_unsigned_name_mangling(device):
@@ -519,10 +577,7 @@ def test_bitwise_op(dtype_x, dtype_y, op, num_ctas, device):
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_x, dtype_y, op", [  #
-    (dtype_x, dtype_y, op)
-    for op in ['<<', '>>']
-    for dtype_x in int_dtypes + uint_dtypes
-    for dtype_y in int_dtypes + uint_dtypes
+    (dtype_x, dtype_y, op) for op in ['<<', '>>'] for dtype_x in int_dtypes + uint_dtypes for dtype_y in uint_dtypes
 ])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_shift_op(dtype_x, dtype_y, op, num_ctas, device):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -296,6 +296,11 @@ class dtype:
         SIGNED = 0
         UNSIGNED = 1
 
+    class KIND(Enum):
+        BOOLEAN = 0
+        INTEGRAL = 1
+        FLOATING = 2
+
     def __init__(self, name):
         name = _unwrap_if_constexpr(name)
         self.name = name
@@ -428,12 +433,12 @@ class dtype:
     def kind(self):
         # Return int value following the type ordering bool < integer < fp
         if self.is_bool():
-            return 0
+            return dtype.KIND.BOOLEAN
         elif self.is_int():
-            return 1
+            return dtype.KIND.INTEGRAL
         else:
             assert self.is_floating()
-            return 2
+            return dtype.KIND.FLOATING
 
     @staticmethod
     def is_dtype(type_str):

--- a/python/triton/language/extra/cuda/_experimental_tma.py
+++ b/python/triton/language/extra/cuda/_experimental_tma.py
@@ -32,14 +32,14 @@ def experimental_device_tensormap_create1d(
     _builder: ir.builder,
 ):
     load_size = core._constexpr_to_value(load_size)
-    global_size = core._to_tensor(global_size, _builder)
+    global_size = semantic.to_tensor(global_size, _builder)
     element_ty = core._constexpr_to_value(element_ty)
     element_stride = [core.full([], 1, core.int32, _builder=_builder)]
 
     semantic.tensormap_create(
         desc_ptr=desc_ptr,
         global_address=global_address,
-        box_dim=[core._to_tensor(load_size, _builder)],
+        box_dim=[semantic.to_tensor(load_size, _builder)],
         global_dim=[global_size],
         global_stride=[],
         element_stride=element_stride,
@@ -63,13 +63,13 @@ def experimental_device_tensormap_create2d(
     assert len(load_size) == 2
     assert len(global_size) == 2
     load_size = [core._constexpr_to_value(x) for x in load_size]
-    global_size = [core._to_tensor(x, _builder) for x in global_size]
+    global_size = [semantic.to_tensor(x, _builder) for x in global_size]
 
     element_size = element_ty.primitive_bitwidth // 8
     element_size_t = core.full([], element_size, core.int64, _builder=_builder)
     global_stride = semantic.mul(element_size_t, global_size[-1], _builder)
     # Undocumented, but global_stride seems to be divided by 16
-    global_stride = semantic.ashr(global_stride, core._to_tensor(4, _builder), _builder)
+    global_stride = semantic.ashr(global_stride, semantic.to_tensor(4, _builder), _builder)
 
     contig_dim_size_in_bytes = element_size * load_size[-1]
     if contig_dim_size_in_bytes > 128:
@@ -80,7 +80,7 @@ def experimental_device_tensormap_create2d(
     semantic.tensormap_create(
         desc_ptr=desc_ptr,
         global_address=global_address,
-        box_dim=[core._to_tensor(x, _builder) for x in load_size[::-1]],
+        box_dim=[semantic.to_tensor(x, _builder) for x in load_size[::-1]],
         global_dim=global_size[::-1],
         global_stride=[global_stride],
         element_stride=[elem_stride, elem_stride],

--- a/python/triton/language/math.py
+++ b/python/triton/language/math.py
@@ -86,8 +86,8 @@ def _add_math_3arg_docstr(name: str) -> core.Callable[[T], T]:
 @_check_dtype(dtypes=["int32", "int64", "uint32", "uint64"])
 @_add_math_2arg_docstr("most significant N bits of the 2N-bit product")
 def umulhi(x, y, _builder=None):
-    x = core._to_tensor(x, _builder)
-    y = core._to_tensor(y, _builder)
+    x = semantic.to_tensor(x, _builder)
+    y = semantic.to_tensor(y, _builder)
     x, y = core.binary_op_type_legalization(x, y, _builder)
     return core.tensor(_builder.create_umulhi(x.handle, y.handle), x.type)
 
@@ -97,7 +97,7 @@ def umulhi(x, y, _builder=None):
 @_add_math_1arg_docstr("exponential")
 @core._tensor_member_fn
 def exp(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_exp(x.handle), x.type)
 
 
@@ -106,7 +106,7 @@ def exp(x, _builder=None):
 @_add_math_1arg_docstr("exponential (base 2)")
 @core._tensor_member_fn
 def exp2(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_exp2(x.handle), x.type)
 
 
@@ -115,7 +115,7 @@ def exp2(x, _builder=None):
 @_add_math_1arg_docstr("natural logarithm")
 @core._tensor_member_fn
 def log(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_log(x.handle), x.type)
 
 
@@ -124,7 +124,7 @@ def log(x, _builder=None):
 @_add_math_1arg_docstr("logarithm (base 2)")
 @core._tensor_member_fn
 def log2(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_log2(x.handle), x.type)
 
 
@@ -133,7 +133,7 @@ def log2(x, _builder=None):
 @_add_math_1arg_docstr("cosine")
 @core._tensor_member_fn
 def cos(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_cos(x.handle), x.type)
 
 
@@ -142,7 +142,7 @@ def cos(x, _builder=None):
 @_add_math_1arg_docstr("sine")
 @core._tensor_member_fn
 def sin(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_sin(x.handle), x.type)
 
 
@@ -151,7 +151,7 @@ def sin(x, _builder=None):
 @_add_math_1arg_docstr("fast square root")
 @core._tensor_member_fn
 def sqrt(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_sqrt(x.handle), x.type)
 
 
@@ -160,7 +160,7 @@ def sqrt(x, _builder=None):
 @_add_math_1arg_docstr("precise square root (rounding to nearest wrt the IEEE standard)")
 @core._tensor_member_fn
 def sqrt_rn(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_precise_sqrt(x.handle), x.type)
 
 
@@ -169,7 +169,7 @@ def sqrt_rn(x, _builder=None):
 @_add_math_1arg_docstr("inverse square root")
 @core._tensor_member_fn
 def rsqrt(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_rsqrt(x.handle), x.type)
 
 
@@ -177,7 +177,7 @@ def rsqrt(x, _builder=None):
 @_add_math_1arg_docstr("absolute value")
 @core._tensor_member_fn
 def abs(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     dtype = x.dtype
     if dtype.is_fp8e4b15():
         mask = core.full(x.shape, 0x7F, core.int8, _builder=_builder)
@@ -196,8 +196,8 @@ def abs(x, _builder=None):
 @_add_math_2arg_docstr("fast division")
 def fdiv(x, y, ieee_rounding=False, _builder=None):
     ieee_rounding = core._constexpr_to_value(ieee_rounding)
-    x = core._to_tensor(x, _builder)
-    y = core._to_tensor(y, _builder)
+    x = semantic.to_tensor(x, _builder)
+    y = semantic.to_tensor(y, _builder)
     return semantic.fdiv(x, y, ieee_rounding, _builder)
 
 
@@ -205,8 +205,8 @@ def fdiv(x, y, ieee_rounding=False, _builder=None):
 @_check_dtype(dtypes=["fp32"])
 @_add_math_2arg_docstr("precise division (rounding to nearest wrt the IEEE standard)")
 def div_rn(x, y, _builder=None):
-    x = core._to_tensor(x, _builder)
-    y = core._to_tensor(y, _builder)
+    x = semantic.to_tensor(x, _builder)
+    y = semantic.to_tensor(y, _builder)
     x, y = core.binary_op_type_legalization(x, y, _builder)
     return core.tensor(_builder.create_precise_divf(x.handle, y.handle), x.type)
 
@@ -216,7 +216,7 @@ def div_rn(x, y, _builder=None):
 @_add_math_1arg_docstr("error function")
 @core._tensor_member_fn
 def erf(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_erf(x.handle), x.type)
 
 
@@ -225,7 +225,7 @@ def erf(x, _builder=None):
 @_add_math_1arg_docstr("floor")
 @core._tensor_member_fn
 def floor(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_floor(x.handle), x.type)
 
 
@@ -234,16 +234,16 @@ def floor(x, _builder=None):
 @_add_math_1arg_docstr("ceil")
 @core._tensor_member_fn
 def ceil(x, _builder=None):
-    x = core._to_tensor(x, _builder)
+    x = semantic.to_tensor(x, _builder)
     return core.tensor(_builder.create_ceil(x.handle), x.type)
 
 
 @core.builtin
 @_add_math_3arg_docstr("fused multiply-add")
 def fma(x, y, z, _builder=None):
-    x = core._to_tensor(x, _builder)
-    y = core._to_tensor(y, _builder)
-    z = core._to_tensor(z, _builder)
+    x = semantic.to_tensor(x, _builder)
+    y = semantic.to_tensor(y, _builder)
+    z = semantic.to_tensor(z, _builder)
     x, y = core.binary_op_type_legalization(x, y, _builder)
     z, x = core.binary_op_type_legalization(z, x, _builder)
     z, y = core.binary_op_type_legalization(z, y, _builder)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -65,7 +65,7 @@ def computation_type_impl(a_ty: tl.dtype, a_is_scalar: bool, b_ty: tl.dtype, b_i
     #   it doesn't participate in the pomotion
     if a_is_scalar != b_is_scalar:
         scalar_ty, tensor_ty = (a_ty, b_ty) if a_is_scalar else (b_ty, a_ty)
-        if scalar_ty.kind() <= tensor_ty.kind():
+        if scalar_ty.kind().value <= tensor_ty.kind().value:
             # Upcast because of 3) and 4) below!
             if div_or_mod and (tensor_ty in (tl.float16, tl.bfloat16)):
                 return tl.float32

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -2,6 +2,7 @@ from __future__ import annotations  # remove after python 3.11
 import warnings
 
 from typing import List, Optional, Sequence, Tuple, TypeVar
+import numbers
 
 from .._C.libtriton import ir
 from . import core as tl
@@ -57,7 +58,19 @@ def integer_promote_impl(a_ty: tl.dtype, b_ty: tl.dtype) -> tl.dtype:
     raise TypeError(f"unexpected signedness {a_sn} and {b_sn}")
 
 
-def computation_type_impl(a_ty: tl.dtype, b_ty: tl.dtype, div_or_mod: bool) -> tl.dtype:
+def computation_type_impl(a_ty: tl.dtype, a_is_scalar: bool, b_ty: tl.dtype, b_is_scalar: bool,
+                          div_or_mod: bool) -> tl.dtype:
+    # 0) For scalars we follow semantics similar to PyTorch, namely:
+    # - If the scalar is of a lower or equal kind (bool < uint < int < fp),
+    #   it doesn't participate in the pomotion
+    if a_is_scalar != b_is_scalar:
+        scalar_ty, tensor_ty = (a_ty, b_ty) if a_is_scalar else (b_ty, a_ty)
+        if scalar_ty.kind() <= tensor_ty.kind():
+            # Upcast because of 3) and 4) below!
+            if div_or_mod and (tensor_ty in (tl.float16, tl.bfloat16)):
+                return tl.float32
+            return tensor_ty
+
     # 1) if one operand is double, the other is implicitly
     #    converted to double
     if a_ty.is_fp64() or b_ty.is_fp64():
@@ -95,6 +108,44 @@ def computation_type_impl(a_ty: tl.dtype, b_ty: tl.dtype, div_or_mod: bool) -> t
     return integer_promote_impl(a_ty, b_ty)
 
 
+def to_tensor(x, builder, check_type: bool = True):
+    if isinstance(x, bool):
+        return tl.tensor(builder.get_int1(x), tl.int1)
+    # Note: compile-time const integers are represented by unsigned values
+    elif isinstance(x, int):
+        if -2**31 <= x < 2**31:
+            dtype = tl.int32
+        elif 2**31 <= x < 2**32:
+            dtype = tl.uint32
+        elif -2**63 <= x < 2**63:
+            dtype = tl.int64
+        elif 2**63 <= x < 2**64:
+            dtype = tl.uint64
+        else:
+            raise ValueError(f'Nonrepresentable integer {x}.')
+        return full((), x, dtype=dtype, builder=builder)
+    elif isinstance(x, float):
+        min_float32 = 2**-126
+        max_float32 = (2 - 2**-23) * 2**127
+        abs_x = __builtins__['abs'](x)
+        if abs_x == float("inf") or\
+           abs_x == 0.0 or \
+           x != x or \
+           min_float32 <= abs_x <= max_float32:
+            dtype = tl.float32
+        else:
+            dtype = tl.float64
+        return full((), x, dtype=dtype, builder=builder)
+
+    elif isinstance(x, tl.constexpr):
+        return to_tensor(x.value, builder)
+    elif isinstance(x, tl.tensor):
+        return x
+    if check_type:
+        raise TypeError(f"cannot convert {x} of type {type(x)} to tensor")
+    return x
+
+
 # ===----------------------------------------------------------------------===//
 #                               Binary Operators
 # ===----------------------------------------------------------------------===//
@@ -112,24 +163,36 @@ def check_ptr_type_impl(type_a: tl.dtype, type_b: tl.dtype, allow_ptr_a: bool) -
             raise IncompatibleTypeErrorImpl(type_a, type_b)
 
 
-def binary_op_type_checking_impl(lhs: tl.tensor, rhs: tl.tensor, builder: ir.builder, allow_lhs_ptr=False,
-                                 allow_rhs_ptr=False, arithmetic_check=True,
+def binary_op_type_checking_impl(lhs: tl.tensor | numbers.Number, rhs: tl.tensor | numbers.Number, builder: ir.builder,
+                                 allow_lhs_ptr=False, allow_rhs_ptr=False, arithmetic_check=True,
                                  div_or_mod=False) -> Tuple[tl.tensor, tl.tensor]:
-    # implicit broadcasting
-    lhs, rhs = broadcast_impl_value(lhs, rhs, builder)
+    lhs_is_scalar = isinstance(lhs, numbers.Number)
+    rhs_is_scalar = isinstance(rhs, numbers.Number)
+    if lhs_is_scalar:
+        lhs_scalar = lhs
+        lhs = to_tensor(lhs, builder)
+    if rhs_is_scalar:
+        rhs_scalar = rhs
+        rhs = to_tensor(rhs, builder)
+
     # implicit typecasting
     lhs_sca_ty = lhs.type.scalar
     rhs_sca_ty = rhs.type.scalar
     check_ptr_type_impl(lhs_sca_ty, rhs_sca_ty, allow_lhs_ptr)
     check_ptr_type_impl(rhs_sca_ty, lhs_sca_ty, allow_rhs_ptr)
     if arithmetic_check and not lhs_sca_ty.is_ptr() and not rhs_sca_ty.is_ptr():
-        ret_sca_ty = computation_type_impl(lhs_sca_ty, rhs_sca_ty, div_or_mod)
-        lhs = cast(lhs, ret_sca_ty, builder)
-        rhs = cast(rhs, ret_sca_ty, builder)
+        ret_sca_ty = computation_type_impl(lhs_sca_ty, lhs_is_scalar, rhs_sca_ty, rhs_is_scalar, div_or_mod)
+        lhs = full(
+            (), lhs_scalar, dtype=ret_sca_ty, builder=builder) if lhs_is_scalar else cast(lhs, ret_sca_ty, builder)
+        rhs = full(
+            (), rhs_scalar, dtype=ret_sca_ty, builder=builder) if rhs_is_scalar else cast(rhs, ret_sca_ty, builder)
+
+    # implicit broadcasting
+    lhs, rhs = broadcast_impl_value(lhs, rhs, builder)
     return lhs, rhs
 
 
-def add(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
+def add(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, builder: ir.builder) -> tl.tensor:
     input, other = binary_op_type_checking_impl(input, other, builder, True, True)
     input_scalar_ty = input.type.scalar
     other_scalar_ty = other.type.scalar
@@ -153,7 +216,7 @@ def add(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
     raise TypeError(f"unexpected type {input_scalar_ty}")
 
 
-def sub(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
+def sub(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, builder: ir.builder) -> tl.tensor:
     input, other = binary_op_type_checking_impl(input, other, builder, True, False)
     scalar_ty = input.type.scalar
     # ptr - offset
@@ -168,7 +231,7 @@ def sub(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
     raise TypeError(f"unexpected type {scalar_ty}")
 
 
-def mul(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
+def mul(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, builder: ir.builder) -> tl.tensor:
     input, other = binary_op_type_checking_impl(input, other, builder)
     scalar_ty = input.type.scalar
     # float * float
@@ -180,7 +243,7 @@ def mul(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
     raise TypeError(f"unexpected type {scalar_ty}")
 
 
-def truediv(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
+def truediv(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, builder: ir.builder) -> tl.tensor:
     input, other = binary_op_type_checking_impl(input, other, builder, False, False, True, True)
     input_scalar_ty = input.type.scalar
     other_scalar_ty = other.type.scalar
@@ -206,7 +269,7 @@ def truediv(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tenso
     return tl.tensor(builder.create_fdiv(input.handle, other.handle), input.type)
 
 
-def floordiv(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
+def floordiv(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, builder: ir.builder) -> tl.tensor:
     input, other = binary_op_type_checking_impl(input, other, builder, False, False, True, True)
     input_scalar_ty = input.type.scalar
     other_scalar_ty = other.type.scalar
@@ -221,7 +284,8 @@ def floordiv(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tens
     raise TypeError(f"unexpected type {input_scalar_ty}")
 
 
-def fdiv(input: tl.tensor, other: tl.tensor, ieee_rounding: bool, builder: ir.builder) -> tl.tensor:
+def fdiv(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, ieee_rounding: bool,
+         builder: ir.builder) -> tl.tensor:
     input_scalar_ty = input.type.scalar
     other_scalar_ty = other.type.scalar
     if not input_scalar_ty.is_floating() or not other_scalar_ty.is_floating():
@@ -231,7 +295,7 @@ def fdiv(input: tl.tensor, other: tl.tensor, ieee_rounding: bool, builder: ir.bu
     return tl.tensor(ret, input.type)
 
 
-def mod(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
+def mod(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, builder: ir.builder) -> tl.tensor:
     input, other = binary_op_type_checking_impl(input, other, builder, False, False, True, True)
     scalar_ty = input.type.scalar
     other_scalar_ty = other.type.scalar
@@ -313,7 +377,7 @@ def clamp(x: tl.tensor, min: tl.tensor, max: tl.tensor, propagate_nan: tl.Propag
 
 def bitwise_op_type_checking_impl(input: tl.tensor, other: tl.tensor,
                                   builder: ir.builder) -> Tuple[tl.tensor, tl.tensor]:
-    input, other = binary_op_type_checking_impl(input, other, builder, False, False, False)
+    input, other = binary_op_type_checking_impl(input, other, builder)
     input_sca_ty = input.type.scalar
     other_sca_ty = other.type.scalar
     if not input_sca_ty.is_int() or not other_sca_ty.is_int():
@@ -1439,12 +1503,12 @@ def where(condition: tl.tensor, x: tl.tensor, y: tl.tensor, builder: ir.builder)
             f"tl.where with a non-boolean condition is deprecated and will error out in a future triton release. Got {condition.dtype}"
         )
     condition = cast(condition, tl.int1, builder)
+    x, y = binary_op_type_checking_impl(x, y, builder, True, True)
+    # x, y are broadcasted
     if condition.type.is_block():
         condition, x = broadcast_impl_value(condition, x, builder)
         x, y = broadcast_impl_value(x, y, builder)
-        condition, x = broadcast_impl_value(condition, x, builder)
-    x, y = binary_op_type_checking_impl(x, y, builder, True, True)
-    if not condition.type.is_block():
+    else:
         condition, _ = broadcast_impl_value(condition, x, builder)
     ret_ty = x.type
     return tl.tensor(builder.create_select(condition.handle, x.handle, y.handle), ret_ty)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1114,12 +1114,12 @@ class ASTTransformer(ast.NodeTransformer):
         if len(names) > 1:
             raise ValueError("Multiple assignments are not supported")
         # Modify the assignment x = value to
-        # triton.core.language._to_tensor(value, interpreter_builder, False)
+        # triton.language.semantic.to_tensor(value, interpreter_builder, False)
         node.value = ast.Call(
             func=ast.Attribute(
                 value=ast.Attribute(
                     value=ast.Attribute(value=ast.Name(id='triton', ctx=ast.Load()), attr='language', ctx=ast.Load()),
-                    attr='core', ctx=ast.Load()), attr='_to_tensor', ctx=ast.Load()),
+                    attr='semantic', ctx=ast.Load()), attr='to_tensor', ctx=ast.Load()),
             args=[node.value, ast.Name(id='interpreter_builder', ctx=ast.Load()),
                   ast.Constant(value=False)], keywords=[])
         return node


### PR DESCRIPTION
The idea here is that if you have a tensor `t` of dtype `uint8` and you want
to do `t << 2`, the result should be of dtype `uint8`, not `int32`!

We do this for all dunder ops that don't output booleans.

This follows roughly the semantics of PyTorch, JAX and NumPy 2.0.

I would like to document this behaviour, but it's not clear to me where
is the best place to say so.

The PR has much more churn than I would like, as I had to move the
`to_tensor` method to `semantic` (which is where it belongs anyway).
For reviewers, the only two relevant changes are in `computation_type_impl` and
in `bitwise_op_type_checking_impl`, where we say that we do perform casting
for bitwise ops.
