### PR TITLE
Verify the `tt.dot` operation thru the dot verification interface of the dialect which defines the C layout.

### DIFF
--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -72,6 +72,19 @@ module attributes {"triton_gpu.num-warps" = 1 : i32} {
 // -----
 
 #mma0 = #triton_gpu.nvidia_mma<{versionMajor=2, warpsPerCTA=[1,1]}>
+#dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mma0, kWidth=2}>
+#dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mma0, kWidth=2}>
+module attributes {"triton_gpu.num-warps" = 1 : i32} {
+  tt.func @convert_dot(%A: tensor<16x16xf16, #dot_operand_a>, %B: tensor<16x16xf16, #dot_operand_b>, %C: tensor<16x16xf32>) {
+    // expected-error@+1 {{miss encoding of C operand}}
+    %D = tt.dot %A, %B, %C : tensor<16x16xf16, #dot_operand_a> * tensor<16x16xf16, #dot_operand_b> -> tensor<16x16xf32>
+    tt.return
+  }
+}
+
+// -----
+
+#mma0 = #triton_gpu.nvidia_mma<{versionMajor=2, warpsPerCTA=[1,1]}>
 #dot_operand_a = #triton_gpu.dot_op<{opIdx=0, parent=#mma0, kWidth=1}>
 #dot_operand_b = #triton_gpu.dot_op<{opIdx=1, parent=#mma0, kWidth=2}>
 module attributes {"triton_gpu.num-warps" = 1 : i32} {


### PR DESCRIPTION
The Triton `tt.dot` operation maybe materialized by `MMA` encoding defined by the out-of-tree dialect. 
The verifier of the `tt.dot` operation dispatches the verification to the dialect of the A and B operands which are mostly `DotOp` layout defined in-tree TritonGPU dialect. 
The TritonGPU dialect only verifies the `tt.dot` operation for in-tree backend.

To use the dialect of the C operand layout verifying the `tt.dot` operation for out-of-tree backends. (And also works for NV and AMD's `MMA` which are defined in-tree TritonGPU dialect.)

- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
