### PR TITLE
[TUTORIALS] fix improper type checks

### DIFF
--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -89,7 +89,7 @@ def matmul_kernel(a_ptr, b_ptr, c_ptr,  #
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk
 
-    if (c_ptr.dtype == tl.float8e4nv):
+    if (c_ptr.dtype.element_ty == tl.float8e4nv):
         c = accumulator.to(tl.float8e4nv)
     else:
         c = accumulator.to(tl.float16)
@@ -204,7 +204,7 @@ def matmul_kernel_persistent(a_ptr, b_ptr, c_ptr,  #
             offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
             c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
             c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-            if (c_ptr.dtype == tl.float8e4nv):
+            if (c_ptr.dtype.element_ty == tl.float8e4nv):
                 c = accumulator.to(tl.float8e4nv)
             else:
                 c = accumulator.to(tl.float16)


### PR DESCRIPTION
Fixing a type cast issue that only repros for fp8. Element type should be used instead of the pointer type, otherwise the fp32 accumulator results would be converted to fp16 first then converted to fp8, resulting in precision loss due to different rounding.

Before:

```
python 09-persistent-matmul.py --prec fp8
M=32, N=32, K=32 verification naive vs: cublas: ✅ persistent: ✅ TMA persistent: ✅
M=8192, N=8192, K=512 verification naive vs: cublas: ❌ persistent: ✅ TMA persistent: ✅
```

After:
```
FM=32, N=32, K=32 verification naive vs: cublas: ✅ persistent: ✅ TMA persistent: ✅
M=8192, N=8192, K=512 verification naive vs: cublas: ✅ persistent: ✅ TMA persistent: ✅
```