### PR TITLE
[BACKEND] Add a loop unroller pass

### DIFF
--- a/include/triton/Dialect/Triton/Transforms/Passes.h
+++ b/include/triton/Dialect/Triton/Transforms/Passes.h
@@ -10,6 +10,7 @@ std::unique_ptr<Pass> createCombineOpsPass();
 
 std::unique_ptr<Pass> createReorderBroadcastPass();
 std::unique_ptr<Pass> createRewriteTensorPointerPass();
+std::unique_ptr<Pass> createLoopUnrollPass();
 
 } // namespace triton
 

--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -53,7 +53,8 @@ def TritonRewriteTensorPointer : Pass</*cli-arg*/"triton-rewrite-tensor-pointer"
 def TritonLoopUnroll : Pass</*cli-arg*/"triton-loop-unroll", /*Op*/"mlir::ModuleOp"> {
   let summary = "Loop unroller";
   let description = [{
-    unroll scf loops
+    The pass unrolls a scf loop with tt.loop_unroll_factor attribute. The attribute specialises how many iterations
+    the loop should be unrolled.
   }];
   let constructor = "mlir::triton::createLoopUnrollPass()";
   let dependentDialects = ["mlir::triton::TritonDialect"];

--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -50,4 +50,13 @@ def TritonRewriteTensorPointer : Pass</*cli-arg*/"triton-rewrite-tensor-pointer"
   let dependentDialects = ["mlir::triton::TritonDialect"];
 }
 
+def TritonLoopUnroll : Pass</*cli-arg*/"triton-loop-unroll", /*Op*/"mlir::ModuleOp"> {
+  let summary = "Loop unroller";
+  let description = [{
+    unroll scf loops
+  }];
+  let constructor = "mlir::triton::createLoopUnrollPass()";
+  let dependentDialects = ["mlir::triton::TritonDialect"];
+}
+
 #endif

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -4,9 +4,9 @@ add_public_tablegen_target(TritonCombineIncGen)
 
 add_triton_library(TritonTransforms
   Combine.cpp
+  LoopUnroll.cpp
   ReorderBroadcast.cpp
   RewriteTensorPointer.cpp
-  LoopUnroll.cpp
 
   DEPENDS
   TritonTransformsIncGen

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_triton_library(TritonTransforms
   Combine.cpp
   ReorderBroadcast.cpp
   RewriteTensorPointer.cpp
+  LoopUnroll.cpp
 
   DEPENDS
   TritonTransformsIncGen

--- a/lib/Dialect/Triton/Transforms/LoopUnroll.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopUnroll.cpp
@@ -32,7 +32,7 @@ class LoopUnrollPass : public TritonLoopUnrollBase<LoopUnrollPass> {
     // Use the attribute attached to the loop if it exists otherwise use the
     // global control.
     if (!forOp->hasAttr(mlir::triton::loopUnrollFactorAttrName))
-      return unrollFactor;
+      return 1;
     return mlir::cast<IntegerAttr>(
                forOp->getAttr(mlir::triton::loopUnrollFactorAttrName))
         .getInt();
@@ -57,10 +57,6 @@ public:
       (void)loopUnrollByFactor(loop, unrollFactor);
     }
   }
-
-  Option<uint64_t> unrollFactor{*this, "unroll-factor",
-                                llvm::cl::desc("Default loop unroll factor."),
-                                llvm::cl::init(1)};
 };
 
 } // anonymous namespace

--- a/lib/Dialect/Triton/Transforms/LoopUnroll.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopUnroll.cpp
@@ -22,7 +22,7 @@
 
 namespace mlir::triton {
 
-static const char *loopUnrollFactorAttrName = "tt.unrolled_iteration";
+static const char *loopUnrollFactorAttrName = "tt.loop_unroll_factor";
 
 namespace {
 
@@ -31,11 +31,11 @@ class LoopUnrollPass : public TritonLoopUnrollBase<LoopUnrollPass> {
   int getUnrollFactorOrDefault(scf::ForOp forOp) {
     // Use the attribute attached to the loop if it exists otherwise use the
     // global control.
-    if (!forOp->hasAttr(mlir::triton::loopUnrollFactorAttrName))
-      return 1;
-    return mlir::cast<IntegerAttr>(
-               forOp->getAttr(mlir::triton::loopUnrollFactorAttrName))
-        .getInt();
+    if (forOp->hasAttr(mlir::triton::loopUnrollFactorAttrName))
+      return mlir::cast<IntegerAttr>(
+                 forOp->getAttr(mlir::triton::loopUnrollFactorAttrName))
+          .getInt();
+    return 1;
   }
 
 public:

--- a/lib/Dialect/Triton/Transforms/LoopUnroll.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopUnroll.cpp
@@ -29,12 +29,11 @@ namespace {
 class LoopUnrollPass : public TritonLoopUnrollBase<LoopUnrollPass> {
 
   int getUnrollFactorOrDefault(scf::ForOp forOp) {
-    // Use the attribute attached to the loop if it exists otherwise use the
-    // global control.
-    if (forOp->hasAttr(mlir::triton::loopUnrollFactorAttrName))
-      return mlir::cast<IntegerAttr>(
-                 forOp->getAttr(mlir::triton::loopUnrollFactorAttrName))
-          .getInt();
+    // Use the attribute attached to the loop if it exists otherwise set the
+    // factor to 1 to suppress the unrolling.
+    if (auto factor = forOp->getAttrOfType<IntegerAttr>(
+            mlir::triton::loopUnrollFactorAttrName))
+      return factor.getInt();
     return 1;
   }
 

--- a/lib/Dialect/Triton/Transforms/LoopUnroll.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopUnroll.cpp
@@ -1,0 +1,72 @@
+#include <memory>
+
+#include "mlir/Dialect/SCF/Utils/Utils.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
+
+#define GEN_PASS_CLASSES
+#include "triton/Dialect/Triton/Transforms/Passes.h.inc"
+
+#define DEBUG_TYPE "triton-loop-unroll"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir::triton {
+
+static const char *loopUnrollFactorAttrName = "tt.unrolled_iteration";
+
+namespace {
+
+class LoopUnrollPass : public TritonLoopUnrollBase<LoopUnrollPass> {
+
+  int getUnrollFactorOrDefault(scf::ForOp forOp) {
+    // Use the attribute attached to the loop if it exists otherwise use the
+    // global control.
+    if (!forOp->hasAttr(mlir::triton::loopUnrollFactorAttrName))
+      return unrollFactor;
+    return mlir::cast<IntegerAttr>(
+               forOp->getAttr(mlir::triton::loopUnrollFactorAttrName))
+        .getInt();
+  }
+
+public:
+  LoopUnrollPass() = default;
+  LoopUnrollPass(const LoopUnrollPass &) {}
+  void runOnOperation() override {
+    LDBG("Loop unroll pass");
+    SmallVector<scf::ForOp, 4> loops;
+    getOperation()->walk([&](scf::ForOp forOp) {
+      // Bail out for loops with unroll factor <= 1.
+      if (getUnrollFactorOrDefault(forOp) > 1)
+        loops.push_back(forOp);
+    });
+
+    for (auto loop : loops) {
+      auto unrollFactor = getUnrollFactorOrDefault(loop);
+      loop->removeAttr(mlir::triton::loopUnrollFactorAttrName);
+      LDBG("Unrolling loop by " << unrollFactor << " times\n" << loop);
+      (void)loopUnrollByFactor(loop, unrollFactor);
+    }
+  }
+
+  Option<uint64_t> unrollFactor{*this, "unroll-factor",
+                                llvm::cl::desc("Default loop unroll factor."),
+                                llvm::cl::init(1)};
+};
+
+} // anonymous namespace
+
+std::unique_ptr<mlir::Pass> createLoopUnrollPass() {
+  return std::make_unique<LoopUnrollPass>();
+}
+
+} // namespace mlir::triton

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -39,6 +39,7 @@ void init_triton_passes_ttir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_reorder_broadcast", createReorderBroadcastPass);
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_pointer",
                      createRewriteTensorPointerPass);
+  ADD_PASS_WRAPPER_0("add_loop_unroll", createLoopUnrollPass);
   ADD_PASS_WRAPPER_4("add_convert_to_ttgpuir",
                      createConvertTritonToTritonGPUPass, const std::string &,
                      int, int, int);

--- a/test/Triton/loop-unroll.mlir
+++ b/test/Triton/loop-unroll.mlir
@@ -6,14 +6,19 @@ module {
     %cst = arith.constant 0.000000e+00 : f32
     %0 = tt.splat %c1_i32 : i32 -> tensor<256xi32>
     %1 = tt.splat %cst : f32 -> tensor<256xf32>
+    // Check the loop is unrolled by factor of 2 and is followed by a reminder loop.
+    // CHECK: scf.for
+    // CHECK-COUNT-2: tt.load
+    // CHECK-NOT: tt.load
+    // CHECK: scf.for
+    // CHECK: tt.load
+    // CHECK-NOT: tt.load
     %2:2 = scf.for %arg3 = %c1_i32 to %arg1 step %c1_i32 iter_args(%arg4 = %1, %arg5 = %arg0) -> (tensor<256xf32>, tensor<256x!tt.ptr<f32>>)  : i32 {
-      // CHECK: scf.for
-      // CHECK-COUNT-2: tt.load
-      %3 = tt.load %arg5 : tensor<256x!tt.ptr<f32>>
+       %3 = tt.load %arg5 : tensor<256x!tt.ptr<f32>>
       %4 = arith.addf %arg4, %3 : tensor<256xf32>
       %5 = tt.addptr %arg5, %0 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
       scf.yield %4, %5 : tensor<256xf32>, tensor<256x!tt.ptr<f32>>
-    } {tt.unrolled_iteration = 2 : i32}
+    } {tt.loop_unroll_factor = 2 : i32}
     tt.return
   }
 }

--- a/test/Triton/loop-unroll.mlir
+++ b/test/Triton/loop-unroll.mlir
@@ -1,24 +1,45 @@
-// RUN: triton-opt %s -triton-loop-unroll | FileCheck %s
+// RUN: triton-opt --split-input-file %s -triton-loop-unroll | FileCheck %s
 
-module {
-  tt.func @add_kernel(%arg0: tensor<256x!tt.ptr<f32>>, %arg1: i32) {
-    %c1_i32 = arith.constant 1 : i32
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = tt.splat %c1_i32 : i32 -> tensor<256xi32>
-    %1 = tt.splat %cst : f32 -> tensor<256xf32>
-    // Check the loop is unrolled by factor of 2 and is followed by a reminder loop.
-    // CHECK: scf.for
-    // CHECK-COUNT-2: tt.load
-    // CHECK-NOT: tt.load
-    // CHECK: scf.for
-    // CHECK: tt.load
-    // CHECK-NOT: tt.load
-    %2:2 = scf.for %arg3 = %c1_i32 to %arg1 step %c1_i32 iter_args(%arg4 = %1, %arg5 = %arg0) -> (tensor<256xf32>, tensor<256x!tt.ptr<f32>>)  : i32 {
-       %3 = tt.load %arg5 : tensor<256x!tt.ptr<f32>>
-      %4 = arith.addf %arg4, %3 : tensor<256xf32>
-      %5 = tt.addptr %arg5, %0 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
-      scf.yield %4, %5 : tensor<256xf32>, tensor<256x!tt.ptr<f32>>
-    } {tt.loop_unroll_factor = 2 : i32}
-    tt.return
+tt.func @add_kernel_unroll(%arg0: tensor<256x!tt.ptr<f32>>, %arg1: i32) {
+  %c1_i32 = arith.constant 1 : i32
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tt.splat %c1_i32 : i32 -> tensor<256xi32>
+  %1 = tt.splat %cst : f32 -> tensor<256xf32>
+  // Check the loop is unrolled by factor of 2 and is followed by a reminder loop.
+  // CHECK-LABEL: add_kernel_unroll
+  // CHECK: scf.for
+  // CHECK-COUNT-2: tt.load
+  // CHECK-NOT: tt.load
+  // CHECK: scf.for
+  // CHECK: tt.load
+  // CHECK-NOT: tt.load
+  %2:2 = scf.for %arg3 = %c1_i32 to %arg1 step %c1_i32 iter_args(%arg4 = %1, %arg5 = %arg0) -> (tensor<256xf32>, tensor<256x!tt.ptr<f32>>)  : i32 {
+      %3 = tt.load %arg5 : tensor<256x!tt.ptr<f32>>
+    %4 = arith.addf %arg4, %3 : tensor<256xf32>
+    %5 = tt.addptr %arg5, %0 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    scf.yield %4, %5 : tensor<256xf32>, tensor<256x!tt.ptr<f32>>
+  } {tt.loop_unroll_factor = 2 : i32}
+  tt.return
+}
+
+// -----
+
+tt.func @add_kernel_nounroll(%arg0: tensor<256x!tt.ptr<f32>>, %arg1: i32) {
+  %c1_i32 = arith.constant 1 : i32
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tt.splat %c1_i32 : i32 -> tensor<256xi32>
+  %1 = tt.splat %cst : f32 -> tensor<256xf32>
+  // Check the loop is not unrolled.
+  // CHECK-LABEL: add_kernel_nounroll
+  // CHECK: scf.for
+  // CHECK-COUNT-1: tt.load
+  // CHECK-NOT: tt.load
+  // CHECK-NOT: scf.for
+  %2:2 = scf.for %arg3 = %c1_i32 to %arg1 step %c1_i32 iter_args(%arg4 = %1, %arg5 = %arg0) -> (tensor<256xf32>, tensor<256x!tt.ptr<f32>>)  : i32 {
+      %3 = tt.load %arg5 : tensor<256x!tt.ptr<f32>>
+    %4 = arith.addf %arg4, %3 : tensor<256xf32>
+    %5 = tt.addptr %arg5, %0 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    scf.yield %4, %5 : tensor<256xf32>, tensor<256x!tt.ptr<f32>>
   }
+  tt.return
 }

--- a/test/Triton/loop-unroll.mlir
+++ b/test/Triton/loop-unroll.mlir
@@ -1,37 +1,19 @@
 // RUN: triton-opt %s -triton-loop-unroll | FileCheck %s
 
 module {
-  tt.func @add_kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: i32, %arg4: i32) {
-    %0 = tt.get_program_id x : i32
-    %c256_i32 = arith.constant 256 : i32
-    %1 = arith.muli %0, %c256_i32 : i32
-    %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
-    %3 = tt.splat %1 : i32 -> tensor<256xi32>
-    %4 = arith.addi %3, %2 : tensor<256xi32>
-    %5 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
-    %6 = tt.addptr %5, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
-    %7 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
-    %8 = tt.addptr %7, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+  tt.func @add_kernel(%arg0: tensor<256x!tt.ptr<f32>>, %arg1: i32) {
+    %c1_i32 = arith.constant 1 : i32
     %cst = arith.constant 0.000000e+00 : f32
-    %9 = tt.splat %cst : f32 -> tensor<256xf32>
-    %c0_i32 = arith.constant 0 : i32
-    %c32_i32 = arith.constant 32 : i32
-    // CHECK: scf.for
-    // CHECK-COUNT-4: tt.load
-    %10:3 = scf.for %arg5 = %c0_i32 to %arg3 step %c32_i32 iter_args(%arg6 = %9, %arg7 = %6, %arg8 = %8) -> (tensor<256xf32>, tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>)  : i32 {
-      %13 = tt.load %arg7 : tensor<256x!tt.ptr<f32>>
-      %14 = tt.load %arg8 : tensor<256x!tt.ptr<f32>>
-      %15 = arith.addf %13, %14 : tensor<256xf32>
-      %16 = arith.addf %arg6, %15 : tensor<256xf32>
-      %17 = tt.splat %arg4 : i32 -> tensor<256xi32>
-      %18 = tt.addptr %arg7, %17 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
-      %19 = tt.splat %arg4 : i32 -> tensor<256xi32>
-      %20 = tt.addptr %arg8, %19 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
-      scf.yield %16, %18, %20 : tensor<256xf32>, tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>
+    %0 = tt.splat %c1_i32 : i32 -> tensor<256xi32>
+    %1 = tt.splat %cst : f32 -> tensor<256xf32>
+    %2:2 = scf.for %arg3 = %c1_i32 to %arg1 step %c1_i32 iter_args(%arg4 = %1, %arg5 = %arg0) -> (tensor<256xf32>, tensor<256x!tt.ptr<f32>>)  : i32 {
+      // CHECK: scf.for
+      // CHECK-COUNT-2: tt.load
+      %3 = tt.load %arg5 : tensor<256x!tt.ptr<f32>>
+      %4 = arith.addf %arg4, %3 : tensor<256xf32>
+      %5 = tt.addptr %arg5, %0 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      scf.yield %4, %5 : tensor<256xf32>, tensor<256x!tt.ptr<f32>>
     } {tt.unrolled_iteration = 2 : i32}
-    %11 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
-    %12 = tt.addptr %11, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
-    tt.store %12, %10#0 : tensor<256x!tt.ptr<f32>>
     tt.return
   }
 }

--- a/test/Triton/loop-unroll.mlir
+++ b/test/Triton/loop-unroll.mlir
@@ -1,0 +1,37 @@
+// RUN: triton-opt %s -triton-loop-unroll | FileCheck %s
+
+module {
+  tt.func @add_kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id x : i32
+    %c256_i32 = arith.constant 256 : i32
+    %1 = arith.muli %0, %c256_i32 : i32
+    %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %3 = tt.splat %1 : i32 -> tensor<256xi32>
+    %4 = arith.addi %3, %2 : tensor<256xi32>
+    %5 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %6 = tt.addptr %5, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    %7 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    %cst = arith.constant 0.000000e+00 : f32
+    %9 = tt.splat %cst : f32 -> tensor<256xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    // CHECK: scf.for
+    // CHECK-COUNT-4: tt.load
+    %10:3 = scf.for %arg5 = %c0_i32 to %arg3 step %c32_i32 iter_args(%arg6 = %9, %arg7 = %6, %arg8 = %8) -> (tensor<256xf32>, tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>)  : i32 {
+      %13 = tt.load %arg7 : tensor<256x!tt.ptr<f32>>
+      %14 = tt.load %arg8 : tensor<256x!tt.ptr<f32>>
+      %15 = arith.addf %13, %14 : tensor<256xf32>
+      %16 = arith.addf %arg6, %15 : tensor<256xf32>
+      %17 = tt.splat %arg4 : i32 -> tensor<256xi32>
+      %18 = tt.addptr %arg7, %17 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      %19 = tt.splat %arg4 : i32 -> tensor<256xi32>
+      %20 = tt.addptr %arg8, %19 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      scf.yield %16, %18, %20 : tensor<256xf32>, tensor<256x!tt.ptr<f32>>, tensor<256x!tt.ptr<f32>>
+    } {tt.unrolled_iteration = 2 : i32}
+    %11 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>>
+    %12 = tt.addptr %11, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    tt.store %12, %10#0 : tensor<256x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -204,6 +204,7 @@ class CUDABackend(BaseBackend):
         # TTIR -> TTGIR
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
+        passes.ttir.add_loop_unroll(pm)
         passes.ttir.add_convert_to_ttgpuir(pm, f"cuda:{capability}", opt.num_warps, 32, opt.num_ctas)
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -186,6 +186,7 @@ class CUDABackend(BaseBackend):
         passes.common.add_cse(pm)
         passes.common.add_licm(pm)
         passes.common.add_symbol_dce(pm)
+        passes.ttir.add_loop_unroll(pm)
         pm.run(mod)
         return mod
 
@@ -204,7 +205,6 @@ class CUDABackend(BaseBackend):
         # TTIR -> TTGIR
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        passes.ttir.add_loop_unroll(pm)
         passes.ttir.add_convert_to_ttgpuir(pm, f"cuda:{capability}", opt.num_warps, 32, opt.num_ctas)
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)


### PR DESCRIPTION
Adding a loop unroller pass which applies to only loops with unroll annotation.

An annotated loop will look like:


```
    scf.for %arg5 = %c0_i32 to %arg3 step %c32_i32 : i32 {
      ...
    } {tt.loop_unroll_factor = 2 : i32}
```