### PR TITLE
[PROTON] Improve user experience on the CUPTI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ ptxas
 
 # Third-party include
 third_party/nvidia/backend/include
+third_party/nvidia/backend/lib/cupti
 
 # Docs
 docs/_build/

--- a/third_party/proton/CMakeLists.txt
+++ b/third_party/proton/CMakeLists.txt
@@ -40,6 +40,11 @@ if(APPLE)
   set(PROTON_PYTHON_LDFLAGS "-undefined dynamic_lookup")
 endif()
 
+if(DEFINED CUPTI_LIB_DIR)
+  message(STATUS "CUPTI lib directory: ${CUPTI_LIB_DIR}")
+  add_compile_definitions(CUPTI_LIB_DIR=${CUPTI_LIB_DIR})
+endif()
+
 include_directories(${CUPTI_INCLUDE_DIR})
 include_directories(SYSTEM ${ROCTRACER_INCLUDE_DIR})
 target_compile_definitions(proton PRIVATE __HIP_PLATFORM_AMD__)

--- a/third_party/proton/csrc/include/Driver/Dispatch.h
+++ b/third_party/proton/csrc/include/Driver/Dispatch.h
@@ -44,8 +44,9 @@ namespace proton {
 
 struct ExternLibBase {
   using RetType = int; // Generic type, can be overridden in derived structs
-  static constexpr const char *name = ""; // Placeholder
-  static constexpr RetType success = 0;   // Placeholder
+  static constexpr const char *name = "";        // Placeholder
+  static constexpr const char *defaultPath = ""; // Placeholder
+  static constexpr RetType success = 0;          // Placeholder
   ExternLibBase() = delete;
   ExternLibBase(const ExternLibBase &) = delete;
   ExternLibBase &operator=(const ExternLibBase &) = delete;
@@ -64,6 +65,14 @@ public:
     if (*lib == nullptr) {
       // If not found, try to load it
       *lib = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
+    }
+    if (*lib == nullptr) {
+      // Still not found, try to load it from the default path
+      auto dir = std::string(ExternLib::defaultPath);
+      if (dir.length() > 0) {
+        auto fullPath = dir + "/" + name;
+        *lib = dlopen(fullPath.c_str(), RTLD_LOCAL | RTLD_LAZY);
+      }
     }
     if (*lib == nullptr) {
       throw std::runtime_error("Could not find `" + std::string(name) +

--- a/third_party/proton/csrc/include/Driver/Dispatch.h
+++ b/third_party/proton/csrc/include/Driver/Dispatch.h
@@ -71,7 +71,7 @@ public:
       }
     }
     if (*lib == nullptr) {
-      // If still not found, try to load it LD_LIBRARY_PATH
+      // If still not found, try to load it from LD_LIBRARY_PATH
       *lib = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
     }
     if (*lib == nullptr) {

--- a/third_party/proton/csrc/include/Driver/Dispatch.h
+++ b/third_party/proton/csrc/include/Driver/Dispatch.h
@@ -44,9 +44,9 @@ namespace proton {
 
 struct ExternLibBase {
   using RetType = int; // Generic type, can be overridden in derived structs
-  static constexpr const char *name = "";        // Placeholder
-  static constexpr const char *defaultPath = ""; // Placeholder
-  static constexpr RetType success = 0;          // Placeholder
+  static constexpr const char *name = "";       // Placeholder
+  static constexpr const char *defaultDir = ""; // Placeholder
+  static constexpr RetType success = 0;         // Placeholder
   ExternLibBase() = delete;
   ExternLibBase(const ExternLibBase &) = delete;
   ExternLibBase &operator=(const ExternLibBase &) = delete;
@@ -64,7 +64,7 @@ public:
     }
     if (*lib == nullptr) {
       // If not found, try to load it from the default path
-      auto dir = std::string(ExternLib::defaultPath);
+      auto dir = std::string(ExternLib::defaultDir);
       if (dir.length() > 0) {
         auto fullPath = dir + "/" + name;
         *lib = dlopen(fullPath.c_str(), RTLD_LOCAL | RTLD_LAZY);

--- a/third_party/proton/csrc/include/Driver/Dispatch.h
+++ b/third_party/proton/csrc/include/Driver/Dispatch.h
@@ -63,16 +63,16 @@ public:
       *lib = dlopen(name, RTLD_NOLOAD);
     }
     if (*lib == nullptr) {
-      // If not found, try to load it
-      *lib = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
-    }
-    if (*lib == nullptr) {
-      // Still not found, try to load it from the default path
+      // If not found, try to load it from the default path
       auto dir = std::string(ExternLib::defaultPath);
       if (dir.length() > 0) {
         auto fullPath = dir + "/" + name;
         *lib = dlopen(fullPath.c_str(), RTLD_LOCAL | RTLD_LAZY);
       }
+    }
+    if (*lib == nullptr) {
+      // If still not found, try to load it LD_LIBRARY_PATH
+      *lib = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
     }
     if (*lib == nullptr) {
       throw std::runtime_error("Could not find `" + std::string(name) +

--- a/third_party/proton/csrc/lib/Driver/GPU/CudaApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/CudaApi.cpp
@@ -11,7 +11,7 @@ struct ExternLibCuda : public ExternLibBase {
   // On WSL, "libcuda.so" and "libcuda.so.1" may not be linked, so we use
   // "libcuda.so.1" instead.
   static constexpr const char *name = "libcuda.so.1";
-  static constexpr const char *defaultPath = "";
+  static constexpr const char *defaultDir = "";
   static constexpr RetType success = CUDA_SUCCESS;
   static void *lib;
 };

--- a/third_party/proton/csrc/lib/Driver/GPU/CudaApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/CudaApi.cpp
@@ -11,6 +11,7 @@ struct ExternLibCuda : public ExternLibBase {
   // On WSL, "libcuda.so" and "libcuda.so.1" may not be linked, so we use
   // "libcuda.so.1" instead.
   static constexpr const char *name = "libcuda.so.1";
+  static constexpr const char *defaultPath = "";
   static constexpr RetType success = CUDA_SUCCESS;
   static void *lib;
 };

--- a/third_party/proton/csrc/lib/Driver/GPU/CuptiApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/CuptiApi.cpp
@@ -6,11 +6,16 @@ namespace proton {
 
 namespace cupti {
 
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
 struct ExternLibCupti : public ExternLibBase {
   using RetType = CUptiResult;
   static constexpr const char *name = "libcupti.so";
-  static constexpr const char *defaultPath =
-      "/usr/local/cuda/extras/CUPTI/lib64";
+#ifdef CUPTI_LIB_DIR
+  static constexpr const char *defaultPath = TOSTRING(CUPTI_LIB_DIR);
+#else
+  static constexpr const char *defaultPath = "";
+#endif
   static constexpr RetType success = CUPTI_SUCCESS;
   static void *lib;
 };

--- a/third_party/proton/csrc/lib/Driver/GPU/CuptiApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/CuptiApi.cpp
@@ -12,9 +12,9 @@ struct ExternLibCupti : public ExternLibBase {
   using RetType = CUptiResult;
   static constexpr const char *name = "libcupti.so";
 #ifdef CUPTI_LIB_DIR
-  static constexpr const char *defaultPath = TOSTRING(CUPTI_LIB_DIR);
+  static constexpr const char *defaultDir = TOSTRING(CUPTI_LIB_DIR);
 #else
-  static constexpr const char *defaultPath = "";
+  static constexpr const char *defaultDir = "";
 #endif
   static constexpr RetType success = CUPTI_SUCCESS;
   static void *lib;

--- a/third_party/proton/csrc/lib/Driver/GPU/CuptiApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/CuptiApi.cpp
@@ -9,6 +9,8 @@ namespace cupti {
 struct ExternLibCupti : public ExternLibBase {
   using RetType = CUptiResult;
   static constexpr const char *name = "libcupti.so";
+  static constexpr const char *defaultPath =
+      "/usr/local/cuda/extras/CUPTI/lib64";
   static constexpr RetType success = CUPTI_SUCCESS;
   static void *lib;
 };

--- a/third_party/proton/csrc/lib/Driver/GPU/HipApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/HipApi.cpp
@@ -10,7 +10,7 @@ namespace hip {
 struct ExternLibHip : public ExternLibBase {
   using RetType = hipError_t;
   static constexpr const char *name = "libamdhip64.so";
-  static constexpr const char *defaultPath = "";
+  static constexpr const char *defaultDir = "";
   static constexpr RetType success = hipSuccess;
   static void *lib;
 };

--- a/third_party/proton/csrc/lib/Driver/GPU/HipApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/HipApi.cpp
@@ -10,6 +10,7 @@ namespace hip {
 struct ExternLibHip : public ExternLibBase {
   using RetType = hipError_t;
   static constexpr const char *name = "libamdhip64.so";
+  static constexpr const char *defaultPath = "";
   static constexpr RetType success = hipSuccess;
   static void *lib;
 };

--- a/third_party/proton/csrc/lib/Driver/GPU/HsaApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/HsaApi.cpp
@@ -8,7 +8,7 @@ namespace hsa {
 struct ExternLibHsa : public ExternLibBase {
   using RetType = hsa_status_t;
   static constexpr const char *name = "libhsa-runtime64.so";
-  static constexpr const char *defaultPath = "";
+  static constexpr const char *defaultDir = "";
   static constexpr RetType success = HSA_STATUS_SUCCESS;
   static void *lib;
 };

--- a/third_party/proton/csrc/lib/Driver/GPU/HsaApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/HsaApi.cpp
@@ -8,6 +8,7 @@ namespace hsa {
 struct ExternLibHsa : public ExternLibBase {
   using RetType = hsa_status_t;
   static constexpr const char *name = "libhsa-runtime64.so";
+  static constexpr const char *defaultPath = "";
   static constexpr RetType success = HSA_STATUS_SUCCESS;
   static void *lib;
 };

--- a/third_party/proton/csrc/lib/Driver/GPU/RoctracerApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/RoctracerApi.cpp
@@ -8,7 +8,7 @@ namespace roctracer {
 struct ExternLibRoctracer : public ExternLibBase {
   using RetType = roctracer_status_t;
   static constexpr const char *name = "libroctracer64.so";
-  static constexpr const char *defaultPath = "";
+  static constexpr const char *defaultDir = "";
   static constexpr RetType success = ROCTRACER_STATUS_SUCCESS;
   static void *lib;
 };

--- a/third_party/proton/csrc/lib/Driver/GPU/RoctracerApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/RoctracerApi.cpp
@@ -8,6 +8,7 @@ namespace roctracer {
 struct ExternLibRoctracer : public ExternLibBase {
   using RetType = roctracer_status_t;
   static constexpr const char *name = "libroctracer64.so";
+  static constexpr const char *defaultPath = "";
   static constexpr RetType success = ROCTRACER_STATUS_SUCCESS;
   static void *lib;
 };

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -42,7 +42,7 @@ def start(
         name (str, optional): The name (with path) of the profiling session.
                               If not provided, the default name is "~/proton.hatchet".
         backend (str, optional): The backend to use for profiling.
-                                 Available options are ["cupti"].
+                                 Available options are [None, "cupti", "roctracer"].
                                  Defaults to None, which automatically selects the backend matching the current active runtime.
         context (str, optional): The context to use for profiling.
                                  Available options are ["shadow", "python"].


### PR DESCRIPTION
Previously, we would search for `libcupti.so` in the `LD_LIBRARY_PATH`. However, we already have `libcupti.so` downloaded from the conda package, and it is the version that exactly matches the CUPTI header file. Therefore, we can simply copy and paste `libcupti.so` to `third_party/nvidia/lib/cupti` and search there first. This eliminates the need to set `LD_LIBRARY_PATH` in many cases.