### PR TITLE
[AMD] Disable LDS optimization for tensors of rank=1

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUsage.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUsage.cpp
@@ -97,6 +97,8 @@ class OptimizeAMDLDSUsage
 
     auto ctx = srcEnc.getContext();
     auto rank = srcType.getShape().size();
+    if (rank < 2)
+      return;
     unsigned numWarps = triton::gpu::getNumWarpsPerCTA(srcEnc);
     auto warpSize = triton::gpu::getWarpSize(srcEnc);
 


### PR DESCRIPTION
Fix for crash in issue https://github.com/ROCm/triton-internal/issues/263.
