### PR TITLE
Workaround for MLIR_ENABLE_DUMP being ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ For detailed instructions on how to debug Triton's frontend, please refer to thi
 
 - `MLIR_ENABLE_DUMP=1` dumps the IR before every MLIR pass Triton runs, for all
    kernels. Use `MLIR_ENABLE_DUMP=kernelName` to dump for a specific kernel only.
+  - Triton cache can interfere with the dump. In cases where `MLIR_ENABLE_DUMP=1` does not work, try cleaning your triton cache: `rm -r ~/.triton/cache/*`
 - `LLVM_IR_ENABLE_DUMP=1` dumps the IR before every pass run over the LLVM IR.
 - `TRITON_INTERPRET=1` uses the Triton interpreter instead of running on the
   GPU.  You can insert Python breakpoints in your kernel code!


### PR DESCRIPTION
When running kernel compilation with`MLIR_ENABLE_DUMP=1`, the dump doesn't always work when the compiled kernel is the triton cache. 

Repro:

```
MLIR_ENABLE_DUMP=1 python3 python/triton/tools/compile.py \
  --kernel-name add_kernel \
  --signature "*fp32,*fp32,*fp32,i32,64" \
  --grid=1024,1024,1024 \
  python/tutorials/01-vector-add.py
```
prints MLIR, However, running it a second time results in no dump.

Adding this to README since it was not obvious to me and took me some time to figure this out.