### PR TITLE
[FRONTEND] Adding unroll loops count to tl.range for scf for

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -904,6 +904,7 @@ class CodeGenerator(ast.NodeVisitor):
                     ast.NodeVisitor.generic_visit(self, stmt)
             return
         num_stages = None
+        loop_unroll_factor = None
         if IteratorClass is language.range:
             iterator = IteratorClass(*iter_args, **iter_kwargs)
             # visit iterator arguments
@@ -913,6 +914,7 @@ class CodeGenerator(ast.NodeVisitor):
             ub = iterator.end
             step = iterator.step
             num_stages = iterator.num_stages
+            loop_unroll_factor = iterator.loop_unroll_factor
         elif IteratorClass is range:
             # visit iterator arguments
             # note: only `range` iterator is supported now
@@ -986,6 +988,8 @@ class CodeGenerator(ast.NodeVisitor):
             for_op = self.builder.create_for_op(lb, ub, step, [arg.handle for arg in init_args])
             if num_stages is not None:
                 for_op.set_attr("tt.num_stages", self.builder.get_int32_attr(num_stages))
+            if loop_unroll_factor is not None:
+                for_op.set_attr("tt.loop_unroll_factor", self.builder.get_int32_attr(loop_unroll_factor))
 
             self.scf_stack.append(node)
             self.builder.set_insertion_point_to_start(for_op.get_body(0))

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2528,9 +2528,12 @@ class range:
         kernel argument.  The kernel argument only pipelines loads that feed
         into :code:`dot` operations, while this attribute tries to pipeline most
         (though not all) loads in this loop.
+    :param loop_unroll_factor: Tells the Triton IR level loop unroller how many
+        times to unroll a for loop that this range is used with. Less than 2 for
+        this value implies no unrolling.
     """
 
-    def __init__(self, arg1, arg2=None, step=None, num_stages=None):
+    def __init__(self, arg1, arg2=None, step=None, num_stages=None, loop_unroll_factor=None):
         if step is None:
             self.step = constexpr(1)
         else:
@@ -2542,6 +2545,7 @@ class range:
             self.start = arg1
             self.end = arg2
         self.num_stages = num_stages
+        self.loop_unroll_factor = loop_unroll_factor
 
     def __iter__(self):
         raise RuntimeError("tl.range can only be used in @triton.jit'd functions")


### PR DESCRIPTION
This change exposes the scf For Loop attribute used in PR #4645 the frontend. It does this by adding a field to tl.range (the same `as num_stages`), this will allow setting loop unrolling factors like so:

```
@triton.jit
def _kernel(dst, v):
    pid = tl.program_id(axis=0)
    for i in tl.range(0, 10, loop_unroll_factor=2):
        tl.atomic_add(dst + pid, i + pid)
```

Unroll factors of less than 2 do nothing, but 2 or more results in the loop body being replicated that number of times (similar to a clang `#pragma unroll`). 


- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/python/test` for end-to-end tests
