### PR TITLE
set warp synchronous true for reducing RankedTensorType without layout

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -168,6 +168,8 @@ unsigned ReduceOpHelper::getThreadsReductionAxis() {
 
 bool ReduceOpHelper::isWarpSynchronous() {
   auto srcLayout = getSrcLayout();
+  if (!srcLayout)
+    return true;
   auto srcShape = getSrcShape();
   return getWarpsPerCTAWithUniqueData(srcLayout, srcShape)[axis] == 1;
 }


### PR DESCRIPTION

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `It's just a change about ReduceOpHelper,  not in a lower pipeline`.
