### PR TITLE
[FRONTEND]enhance combine select and mask load pattern in combine.cpp

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -64,11 +64,12 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUCanonicalizePointers();
 
   // TODO: register Triton & TritonGPU passes
-  registry.insert<mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,
-                  mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect,
-                  mlir::triton::gpu::TritonGPUDialect, mlir::math::MathDialect,
-                  mlir::arith::ArithDialect, mlir::scf::SCFDialect,
-                  mlir::gpu::GPUDialect, mlir::LLVM::LLVMDialect,
-                  mlir::NVVM::NVVMDialect, mlir::triton::nvgpu::NVGPUDialect,
-                  mlir::ROCDL::ROCDLDialect>();
+  registry
+      .insert<mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,
+              mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect,
+              mlir::triton::gpu::TritonGPUDialect, mlir::math::MathDialect,
+              mlir::arith::ArithDialect, mlir::scf::SCFDialect,
+              mlir::tensor::TensorDialect, mlir::gpu::GPUDialect,
+              mlir::LLVM::LLVMDialect, mlir::NVVM::NVVMDialect,
+              mlir::triton::nvgpu::NVGPUDialect, mlir::ROCDL::ROCDLDialect>();
 }

--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -11,8 +11,8 @@ def TritonCombineOps : Pass</*cli-arg*/"triton-combine", /*Op*/"mlir::ModuleOp">
 
     - `addptr(addptr(ptr, idx0), idx1) => addptr(ptr, AddI(idx0, idx1))`
 
-    - `select(cond, load(ptrs, broadcast(cond), ???), other) =>
-         load(ptrs, broadcast(cond), other)`
+    - `select(cond, load(ptrs, mask, ???), other) =>
+         load(ptrs, mask, other) if mask is a dense value related to cond`
 
     - `broadcast(constant) => reshaped_constant`
     - `torch.sum(x[:,:,None].expand(-1,-1,n) * y[None,:,:].expand(m,-1,-1),1)
@@ -21,7 +21,8 @@ def TritonCombineOps : Pass</*cli-arg*/"triton-combine", /*Op*/"mlir::ModuleOp">
 
   let constructor = "mlir::triton::createCombineOpsPass()";
 
-  let dependentDialects = ["mlir::arith::ArithDialect"];
+  let dependentDialects = ["mlir::arith::ArithDialect",
+                           "mlir::tensor::TensorDialect"];
 }
 
 def TritonReorderBroadcast : Pass</*cli-arg*/"triton-reorder-broadcast", /*Op*/"mlir::ModuleOp"> {


### PR DESCRIPTION
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

---

Hello, maintainers and reviewers!

While reading the [combine.cpp](https://github.com/triton-lang/triton/blob/main/lib/Dialect/Triton/Transforms/Combine.cpp) pass, I noticed that the current **CombineSelectMaskedLoadPattern has strict limitations**, missing some potential optimization opportunities. This PR aims to extend support for CombineSelectMaskedLoadPattern to cover additional scenarios.

PR description：

Enhance combine select and mask load pattern in combine.cpp for the following  four scenarios.

- mask = cond

```milr
    %load = tt.load %ptr, %cond, %false_val : !tt.ptr<f32>
    %res = arith.select %cond, %load, %false_val : f32
```
- cond = extract(mask) &&  mask = denseVal

```mlir
    %load = tt.load %ptr, %mask : tensor<1x1x!tt.ptr<f32>>
    %cond = tensor.extract %mask[%c0, %c0] : tensor<1x1xi1>
    %res = arith.select %cond, %load, %false_val : tensor<1x1xf32>
```
- cond = extract(mask) &&  mask = splat(boolVal)

```mlir
    %mask = tt.splat %bool : i1 -> tensor<8x8xi1>
    %load = tt.load %ptr, %mask : tensor<8x8x!tt.ptr<f32>>
    %cond = tensor.extract %mask[%c0, %c0] : tensor<8x8xi1>
    %res = arith.select %cond, %load, %false_val : tensor<8x8xf32>
```

- cond = extract(mask) &&  mask = broadcast(denseVal)

```mlir
    %mask = tt.broadcast %dense : tensor<1x1xi1> -> tensor<8x8xi1>
    %load = tt.load %ptr, %mask : tensor<8x8x!tt.ptr<f32>>
    %cond = tensor.extract %mask[%c0, %c0] : tensor<8x8xi1>
    %res = arith.select %cond, %load, %false_val : tensor<8x8xf32>
```
