### PR TITLE
Move sections in triton-semantics.rst from ==== to ----

### DIFF
--- a/docs/python-api/triton-semantics.rst
+++ b/docs/python-api/triton-semantics.rst
@@ -1,7 +1,9 @@
+Triton Semantics
+================
 Triton mostly follows the semantics of NumPy with minor exceptions. In this document, we go over some of the array computing features supported in Triton, and we cover the exceptions where Triton's semantics deviate from that NumPy.
 
 Type Promotion
-==============
+--------------
 
 **Type Promotion** occurs when tensors of different data types are used in an operation. For binary operations associated to `dunder methods <https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types>`_ and the ternary function ``tl.where`` on its last two arguments, Triton automatically converts the input tensors to a common data type following a hierarchy of kinds (sets of dtypes): ``{bool} < {integral dypes} < {floating point dtypes}``.
 
@@ -27,7 +29,7 @@ When an operation involves a tensor and a scalar:
 
 
 Broadcasting
-============
+------------
 
 **Broadcasting** allows operations on tensors of different shapes by automatically expanding their shapes to a compatible size without copying the data. This follows the following rules:
 
@@ -37,7 +39,7 @@ Broadcasting
 
 
 Differences with NumPy
-======================
+----------------------
 
 **C rounding in integer division** Operators in Triton follow C semantics rather than Python semantics for efficiency. As such, ``int // int`` implements `rounding towards zero as in C <https://en.wikipedia.org/wiki/Modulo#In_programming_languages>`_ for integers of mixed signs, rather than rounding towards minus infinity as in Python. For the same reason, the modulus operator ``int % int`` (which is defined as ``a % b = a - b * (a // b)``) also follows C semantics rather than Python semantics.
 


### PR DESCRIPTION
Before, the ===== sections were being shown in the sidebar of the
docs.
