### PR TITLE
[TMA] Increment refcount for Py_None in TMA descriptor runtime helpers

### DIFF
--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -274,6 +274,7 @@ static PyObject *setPrintfFifoSize(PyObject *self, PyObject *args) {
   }
 
   Py_END_ALLOW_THREADS;
+  Py_INCREF(Py_None);
   return Py_None;
 }
 

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -318,6 +318,7 @@ static PyObject *fill1DTMADescriptor(PyObject *self, PyObject *args) {
       globalStrides, boxDim, elementStrides, CU_TENSOR_MAP_INTERLEAVE_NONE,
       CU_TENSOR_MAP_SWIZZLE_NONE, CU_TENSOR_MAP_L2_PROMOTION_NONE,
       CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE));
+  Py_INCREF(Py_None);
   return Py_None;
 }
 
@@ -380,6 +381,7 @@ static PyObject *fill2DTMADescriptor(PyObject *self, PyObject *args) {
       globalStrides, tensorDims, elementStrides, CU_TENSOR_MAP_INTERLEAVE_NONE,
       swizzle, CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
       CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE));
+  Py_INCREF(Py_None);
   return Py_None;
 }
 


### PR DESCRIPTION
Incrementing refcount for Py_None in TMA descriptor runtime helpers to avoid deallocating the None object. This fixes a runtime failure like

Fatal Python error: none_dealloc: deallocating None

