### PR TITLE
[Frontend] Add TRITON_DEV_MODE for easier debugging of frontend errors

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -196,6 +196,9 @@ def filter_traceback(e: BaseException):
 
     These are uninteresting to the user -- "just show me *my* code!"
     """
+    if os.getenv("TRITON_DEV_MODE", "0") == "1":
+        return
+
     if e.__cause__ is not None:
         filter_traceback(e.__cause__)
     if e.__context__ is not None:

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -196,7 +196,7 @@ def filter_traceback(e: BaseException):
 
     These are uninteresting to the user -- "just show me *my* code!"
     """
-    if os.getenv("TRITON_DEV_MODE", "0") == "1":
+    if os.getenv("TRITON_FRONT_END_DEBUGGING", "0") == "1":
         return
 
     if e.__cause__ is not None:


### PR DESCRIPTION
Currently triton filters out parts of the stack trace that come from inside the compiler itself which is great for not confusing users. However this adds the ability to disable it by setting `TRITON_DEV_MODE=1` in the environment (open to bikeshedding on the name) for when you're trying to debug the frontend itself.