### PR TITLE
[Release 3.1.0] Bump version to 3.1.0 and remove temporary change

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -67,20 +67,6 @@ jobs:
           export CIBW_BUILD="cp3*-manylinux_x86_64"
           python3 -m cibuildwheel python --output-dir wheelhouse
 
-      - name: Append build number
-        run: |
-          set -ex
-          mkdir -p wheelhouse-1
-          find wheelhouse -type f
-          # This makes sure wheel latest version
-          python3 -m pip install wheel --force-reinstall
-          for i in $(find wheelhouse -type f); do
-            echo "Patching $i"
-            python3 -m wheel unpack $i
-            python3 -m wheel pack triton-3.0.0 --build-number 1 --dest-dir wheelhouse-1
-            rm -rf triton-3.0.0
-          done
-
       - name: Upload wheels to PyPI
         run: |
-          python3 -m twine upload wheelhouse-1/* -u __token__ -p ${{ secrets.PYPY_API_TOKEN }}
+          python3 -m twine upload wheelhouse/* -u __token__ -p ${{ secrets.PYPY_API_TOKEN }}

--- a/python/setup.py
+++ b/python/setup.py
@@ -581,7 +581,7 @@ def get_install_requires():
 
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.0.0" + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.1.0" + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 # ---------------------------------------
 # Note: import order is significant here.


### PR DESCRIPTION
1. Set build version to 3.1.0
2. Remove: https://github.com/triton-lang/triton/pull/4354 change deployed to build ``wheel-1``