### PR TITLE
[BACKEND][AMD] NFC: Fix initialization order.

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -69,7 +69,7 @@ using namespace mlir;
 class PointerCanonicalizer {
 public:
   explicit PointerCanonicalizer(ModuleOp moduleOp)
-      : mod(moduleOp), rewriter(moduleOp.getContext()) {}
+      : rewriter(moduleOp.getContext()), mod(moduleOp) {}
 
   // Propagate fat pointers in all the functions of the module
   LogicalResult run();


### PR DESCRIPTION
Fixes `reorder-ctor` warning.