### PR TITLE
Refactor compiler specializations to consider backend

### DIFF
--- a/python/test/unit/runtime/test_bindings.py
+++ b/python/test/unit/runtime/test_bindings.py
@@ -59,6 +59,8 @@ def test_module_walk(device):
         torch.empty((32, 32), device=device),  # out_ptr
         16,  # BLOCK_SIZE
     ]
+    target = triton.runtime.driver.active.get_current_target()
+    backend = triton.compiler.compiler.make_backend(target)
     src = triton.compiler.compiler.ASTSource(
         fn=kernel,
         signature={
@@ -69,12 +71,10 @@ def test_module_walk(device):
         constants={kernel.arg_names[i]: arg
                    for i, arg in enumerate(args)
                    if not isinstance(arg, torch.Tensor)},
-        attrs=kernel._get_config(*args, ),
+        attrs=backend.get_attrs_descriptor(args, kernel.params),
     )
 
     context = triton._C.libtriton.ir.context()
-    target = triton.runtime.driver.active.get_current_target()
-    backend = triton.compiler.compiler.make_backend(target)
     options = backend.parse_options(dict())
     codegen_fns = dict()
     module_map = backend.get_module_map()

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -25,7 +25,7 @@ def compile_fn(attrs):
 
 
 def test_compile_in_subproc() -> None:
-    config = triton.compiler.AttrsDescriptor(tuple(range(4)), ())
+    config = triton.compiler.AttrsDescriptor(target.backend, tuple(range(4)), ())
     multiprocessing.set_start_method('fork')
     proc = multiprocessing.Process(target=compile_fn, args=(config, ))
     proc.start()
@@ -47,7 +47,7 @@ def compile_fn_dot(attrs):
 
 
 def test_compile_in_forked_subproc(fresh_triton_cache) -> None:
-    config = triton.compiler.AttrsDescriptor(tuple(range(1)), ())
+    config = triton.compiler.AttrsDescriptor(target.backend, tuple(range(1)), ())
     assert multiprocessing.get_start_method() == 'fork'
     proc = multiprocessing.Process(target=compile_fn_dot, args=(config, ))
     proc.start()
@@ -86,7 +86,7 @@ def test_compile_in_forked_subproc_with_forced_gc(fresh_triton_cache) -> None:
     gc.disable()
 
     # stage 1.p
-    config = triton.compiler.AttrsDescriptor(tuple(range(1)), ())
+    config = triton.compiler.AttrsDescriptor(target.backend, tuple(range(1)), ())
     compile_empty_kernel_with_gc(config)
 
     # stage 2.p

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -3,6 +3,7 @@ import shutil
 
 import triton
 import triton.language as tl
+from triton.backends.compiler import AttrsDescriptor
 from triton.compiler import ASTSource
 
 target = triton.runtime.driver.active.get_current_target()
@@ -25,7 +26,7 @@ def compile_fn(attrs):
 
 
 def test_compile_in_subproc() -> None:
-    config = triton.compiler.AttrsDescriptor(target.backend, tuple(range(4)), ())
+    config = AttrsDescriptor.from_hints({i: 16 for i in range(4)})
     multiprocessing.set_start_method('fork')
     proc = multiprocessing.Process(target=compile_fn, args=(config, ))
     proc.start()
@@ -47,7 +48,7 @@ def compile_fn_dot(attrs):
 
 
 def test_compile_in_forked_subproc(fresh_triton_cache) -> None:
-    config = triton.compiler.AttrsDescriptor(target.backend, tuple(range(1)), ())
+    config = AttrsDescriptor.from_hints({0: 16})
     assert multiprocessing.get_start_method() == 'fork'
     proc = multiprocessing.Process(target=compile_fn_dot, args=(config, ))
     proc.start()
@@ -86,7 +87,7 @@ def test_compile_in_forked_subproc_with_forced_gc(fresh_triton_cache) -> None:
     gc.disable()
 
     # stage 1.p
-    config = triton.compiler.AttrsDescriptor(target.backend, tuple(range(1)), ())
+    config = AttrsDescriptor.from_hints({0: 16})
     compile_empty_kernel_with_gc(config)
 
     # stage 2.p

--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -1,11 +1,107 @@
 import os
 import re
+import hashlib
 import subprocess
 
 from abc import ABCMeta, abstractmethod, abstractclassmethod
 from dataclasses import dataclass
 from typing import Dict, Union
 from types import ModuleType
+
+
+# This class handles the properties for the given function parameters
+# Different backends can add more properties to the common ones
+class AttrsDescriptor:
+    arg_properties: dict[str, list]
+    property_val: dict[str, int]
+
+    def __init__(self, params=None, args=None):
+        self.arg_properties = {}
+        self.property_val = {"tt.divisibility": 16, "tt.equal_to_1": 1}
+
+        if (params is None) or (args is None):
+            return
+
+        assert (len(params) == len(args))
+
+        # Divisibility property
+        self.arg_properties["tt.divisibility"] = [
+            param.num for param, arg in zip(params, args) if AttrsDescriptor.is_divisible_by_16(arg)
+            and not param.do_not_specialize and not param.do_not_specialize_on_alignment
+        ]
+
+        # Equal to 1 property
+        self.arg_properties["tt.equal_to_1"] = [
+            param.num for param, arg in zip(params, args) if AttrsDescriptor.is_1(arg) and not param.do_not_specialize
+        ]
+
+    # Get the function attributes as a dict like:
+    # {
+    #   "arg0" : [(prop_name00, val00), (prop_name01, val01), ...)]}
+    #   "arg1" : [(prop_name10, val10), (prop_name11, val11), ...)]}
+    # }
+    def get_fn_attrs(self):
+        attrs = {}
+        for prop_name, arg_set in self.arg_properties.items():
+            for arg in arg_set:
+                attrs[arg] = attrs.get(arg, []) + [(prop_name, 16)]
+        return attrs
+
+    # Return the same object, without the given attribute `attr_name`
+    def erase_property(self, attr_name):
+        import copy
+        c = copy.deepcopy(self)
+        if attr_name in c.arg_properties:
+            c.arg_properties.pop(attr_name)
+        return c
+
+    def __getitem__(self, attr_name):
+        if attr_name in self.arg_properties:
+            return self.arg_properties[attr_name]
+        return None
+
+    def hash(self):
+        key = str([sorted(x) for x in self.__dict__.values()])
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+    def to_dict(self):
+        return self.arg_properties
+
+    # Create the class from a set of hints that are passed out. So instead
+    # of calling the specializations, it's the user that tells us what property
+    # each argument has
+    @staticmethod
+    def from_hints(hints):
+        attrsDescriptor = AttrsDescriptor()
+        for prop_name, prop_val in attrsDescriptor.property_val.items():
+            attrsDescriptor.arg_properties[prop_name] = [i for i, h in hints.items() if h == prop_val]
+        return attrsDescriptor
+
+    @staticmethod
+    def is_divisible_by_16(x):
+        if hasattr(x, "data_ptr"):
+            return x.data_ptr() % 16 == 0
+        elif isinstance(x, int):
+            return x % 16 == 0
+        if x is None:
+            return True
+        return False
+
+    @staticmethod
+    def is_equal_to_1(x):
+        return True if isinstance(x, int) and not isinstance(x, bool) and x == 1 else False
+
+    @staticmethod
+    def from_dict(data):
+        return AttrsDescriptor(data)
+
+    @staticmethod
+    def get_property_key(val, align):
+        if align and AttrsDescriptor.is_divisible_by_16(val):
+            return "D"
+        if AttrsDescriptor.is_equal_to_1(val):
+            return "1"
+        return "N"
 
 
 @dataclass(frozen=True)
@@ -82,3 +178,17 @@ class BaseBackend(metaclass=ABCMeta):
         Return a map of interface modules to their device-specific implementations.
         """
         raise NotImplementedError
+
+    def get_attrs_descriptor(self, params, args):
+        """
+        Return an attribute descriptor: given a set of parameters and arguments
+        the descriptor stores a set of compile time properties that can improve code
+        generation. Different backends might benefit from different properties
+        """
+        return AttrsDescriptor(params, args)
+
+    def compute_spec_key(self, arg, align):
+        """
+        Return the ascii key for a given argument with a given set of properties
+        """
+        return AttrsDescriptor.get_property_key(arg, align)

--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -54,11 +54,11 @@ class AttrsDescriptor:
         self.property_values = {}
         self.constant_properties = set()
 
-        self.add_common_properties(params, values)
-        self.add_additional_properties(params, values)
-        self.init_slots()
+        self._add_common_properties(params, values)
+        self._add_backend_properties(params, values)
+        self._init_slots()
 
-    def add_common_properties(self, params, values):
+    def _add_common_properties(self, params, values):
         """ Add common compile-time properties """
         self.property_values["tt.divisibility"] = 16
         self.property_values["tt.equal_to_1"] = 1
@@ -83,11 +83,11 @@ class AttrsDescriptor:
             if AttrsDescriptor.is_equal_to_1(arg) and not param.do_not_specialize
         ]
 
-    def add_additional_properties(self, params=None, values=None):
+    def _add_backend_properties(self, params=None, values=None):
         """ This method is for different subclasses to implement their own compile-time properties """
         pass
 
-    def init_slots(self):
+    def _init_slots(self):
         """ Initialize the slots of this class """
         for name, val in self.arg_properties.items():
             setattr(self, name.removeprefix('tt.'), val)
@@ -142,7 +142,7 @@ class AttrsDescriptor:
         attrsDescriptor = AttrsDescriptor()
         for prop_name, param_ids in data.items():
             attrsDescriptor.arg_properties[prop_name] = param_ids
-        attrsDescriptor.init_slots()
+        attrsDescriptor._init_slots()
         return attrsDescriptor
 
     @staticmethod
@@ -159,7 +159,7 @@ class AttrsDescriptor:
         attrsDescriptor = AttrsDescriptor()
         for prop_name, prop_val in attrsDescriptor.property_values.items():
             attrsDescriptor.arg_properties[prop_name] = [i for i, h in hints.items() if h == prop_val]
-        attrsDescriptor.init_slots()
+        attrsDescriptor._init_slots()
         return attrsDescriptor
 
     @staticmethod

--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -37,7 +37,7 @@ class AttrsDescriptor:
     `constant_properties`: a set containing the properties that can be used to determine if a parameter is constant
 
     """
-    __slots__ = ('divisibility', 'equal_to_1', 'arg_properties', 'property_values', 'constant_properties')
+    __slots__ = ('divisibility_16', 'equal_to_1', 'arg_properties', 'property_values', 'constant_properties')
 
     def __init__(self, params=None, values=None):
         """
@@ -61,8 +61,8 @@ class AttrsDescriptor:
     def _add_common_properties(self, params, values):
         """ Add common compile-time properties """
         self.property_values["tt.divisibility"] = 16
-        self.property_values["tt.equal_to_1"] = 1
-        self.constant_properties.add("tt.equal_to_1")
+        self.property_values["tt.equal_to"] = 1
+        self.constant_properties.add("tt.equal_to")
 
         if (params is None) or (values is None):
             return
@@ -77,7 +77,7 @@ class AttrsDescriptor:
         ]
 
         # Equal to 1 property
-        self.arg_properties["tt.equal_to_1"] = [
+        self.arg_properties["tt.equal_to"] = [
             param.num
             for param, arg in zip(params, values)
             if AttrsDescriptor.is_equal_to_1(arg) and not param.do_not_specialize
@@ -90,7 +90,7 @@ class AttrsDescriptor:
     def _init_slots(self):
         """ Initialize the slots of this class """
         for name, val in self.arg_properties.items():
-            setattr(self, name.removeprefix('tt.'), val)
+            setattr(self, name.removeprefix('tt.') + '_' + str(self.property_values[name]), val)
 
     def get_fn_attrs(self) -> Dict:
         """

--- a/python/triton/compiler/__init__.py
+++ b/python/triton/compiler/__init__.py
@@ -1,4 +1,4 @@
-from .compiler import CompiledKernel, ASTSource, compile, AttrsDescriptor, make_backend, LazyDict
+from .compiler import CompiledKernel, ASTSource, compile, make_backend, LazyDict
 from .errors import CompilationError
 
 __all__ = ["compile", "make_backend", "ASTSource", "AttrsDescriptor", "CompiledKernel", "CompilationError", "LazyDict"]

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1270,7 +1270,7 @@ def kernel_suffix(signature, specialization):
         suffix += str(i)
         if i in specialization.equal_to_1:
             suffix += 'c'
-        if i in specialization.divisibility:
+        if i in specialization.divisibility_16:
             suffix += 'd'
     return suffix
 

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1285,8 +1285,7 @@ def ast_to_ttir(fn, specialization, context, options, codegen_fns, module_map):
     function_name = fn.repr(specialization)
     tys = list(specialization.signature.values())
     new_constants = {k: True if k in tys and tys[k] == "i1" else 1 for k in attrs["tt.equal_to_1"]}
-    print(new_constants)
-    new_attrs = attrs.erase_property("tt.equal_to_1")
+    new_attrs = attrs.filter_out_property("tt.equal_to_1")
     fn_attrs = new_attrs.get_fn_attrs()
     all_constants = constants.copy()
     all_constants.update(new_constants)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1268,9 +1268,9 @@ def kernel_suffix(signature, specialization):
     suffix = ''
     for i, _ in enumerate(signature):
         suffix += str(i)
-        if i in specialization.equal_to_1:
+        if (i, 1) in specialization["tt.equal_to_1"]:
             suffix += 'c'
-        if i in specialization.divisible_by_16:
+        if (i, 16) in specialization["tt.divisibility"]:
             suffix += 'd'
     return suffix
 
@@ -1284,9 +1284,9 @@ def ast_to_ttir(fn, specialization, context, options, codegen_fns, module_map):
     gscope = fn.__globals__.copy()
     function_name = fn.repr(specialization)
     tys = list(specialization.signature.values())
-    new_constants = {k: True if k in tys and tys[k] == "i1" else 1 for k in attrs.equal_to_1}
-    new_attrs = {k: [("tt.divisibility", 16)] for k in attrs.divisible_by_16}
-
+    new_constants = {k: True if k in tys and tys[k] == "i1" else 1 for (k, _) in attrs["tt.equal_to_1"]}
+    new_attrs = attrs.erase_property("tt.equal_to_1")
+    fn_attrs = new_attrs.get_fn_attrs()
     all_constants = constants.copy()
     all_constants.update(new_constants)
     arg_types = [str_to_ty(v) for k, v in specialization.signature.items() if k not in specialization.constants]
@@ -1294,7 +1294,7 @@ def ast_to_ttir(fn, specialization, context, options, codegen_fns, module_map):
 
     prototype = language.function_type([], arg_types)
     generator = CodeGenerator(context, prototype, gscope=gscope, constants=all_constants, function_name=function_name,
-                              jit_fn=fn, attributes=new_attrs, is_kernel=True, file_name=file_name,
+                              jit_fn=fn, attributes=fn_attrs, is_kernel=True, file_name=file_name,
                               begin_line=begin_line, options=options, codegen_fns=codegen_fns, module_map=module_map)
     generator.visit(fn.parse())
 

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1268,9 +1268,9 @@ def kernel_suffix(signature, specialization):
     suffix = ''
     for i, _ in enumerate(signature):
         suffix += str(i)
-        if i in specialization["tt.equal_to_1"]:
+        if i in specialization.equal_to_1:
             suffix += 'c'
-        if i in specialization["tt.divisibility"]:
+        if i in specialization.divisibility:
             suffix += 'd'
     return suffix
 
@@ -1284,8 +1284,12 @@ def ast_to_ttir(fn, specialization, context, options, codegen_fns, module_map):
     gscope = fn.__globals__.copy()
     function_name = fn.repr(specialization)
     tys = list(specialization.signature.values())
-    new_constants = {k: True if k in tys and tys[k] == "i1" else 1 for k in attrs["tt.equal_to_1"]}
-    new_attrs = attrs.filter_out_property("tt.equal_to_1")
+    new_constants = attrs.get_constants()
+    for k in new_constants:
+        if k in tys and tys[k] == "i1" and new_constants[k] == 1:
+            new_constants[k] = True
+
+    new_attrs = attrs.filter_out_constants()
     fn_attrs = new_attrs.get_fn_attrs()
     all_constants = constants.copy()
     all_constants.update(new_constants)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1268,9 +1268,9 @@ def kernel_suffix(signature, specialization):
     suffix = ''
     for i, _ in enumerate(signature):
         suffix += str(i)
-        if (i, 1) in specialization["tt.equal_to_1"]:
+        if i in specialization["tt.equal_to_1"]:
             suffix += 'c'
-        if (i, 16) in specialization["tt.divisibility"]:
+        if i in specialization["tt.divisibility"]:
             suffix += 'd'
     return suffix
 
@@ -1284,7 +1284,8 @@ def ast_to_ttir(fn, specialization, context, options, codegen_fns, module_map):
     gscope = fn.__globals__.copy()
     function_name = fn.repr(specialization)
     tys = list(specialization.signature.values())
-    new_constants = {k: True if k in tys and tys[k] == "i1" else 1 for (k, _) in attrs["tt.equal_to_1"]}
+    new_constants = {k: True if k in tys and tys[k] == "i1" else 1 for k in attrs["tt.equal_to_1"]}
+    print(new_constants)
     new_attrs = attrs.erase_property("tt.equal_to_1")
     fn_attrs = new_attrs.get_fn_attrs()
     all_constants = constants.copy()

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -605,10 +605,11 @@ class JITFunction(KernelInterface[T]):
             signature = {k: ('*i8' if (v == 'none') else v) for (k, v) in zip(sigkeys, sigvals)}
 
             configs = (backend.get_attrs_descriptor(self.params, bound_vals), )
+            constant_params = configs[0].get_constants()
             constants = {
                 p.name: v
                 for (v, p) in zip(bound_vals, self.params)
-                if p.is_constexpr or p.num in configs[0]["tt.equal_to_1"] or v is None
+                if p.is_constexpr or (p.num in constant_params) or v is None
             }
             for i, arg in constants.items():
                 if callable(arg):

--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -108,8 +108,8 @@ if __name__ == "__main__":
     for h in hints.values():
         assert h in [1, 16], f"Only 1 and 16 are valid hints, got {h}"
     attrs = triton.backends.compiler.AttrsDescriptor.from_hints(hints)
-    for i in attrs["tt.equal_to_1"]:
-        constants.update({kernel.arg_names[i]: 1})
+    for p, v in attrs.get_constants().items():
+        constants.update({kernel.arg_names[p]: v})
     src = triton.compiler.ASTSource(fn=kernel, constants=constants, signature=signature, attrs=attrs)
     opts = {"num_warps": args.num_warps, "num_stages": args.num_stages}
     ccinfo = triton.compile(src, options=opts)

--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
             arg_types.append(signature[arg_name])
             arg_names_not_1.append(arg_name)
             arg_types_not_1.append(signature[arg_name])
-        elif i in attrs["tt.equal_to_1"]:
+        elif i in attrs.equal_to_1:
             arg_names.append(arg_name)
             arg_types.append(signature[arg_name])
 

--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -106,9 +106,10 @@ if __name__ == "__main__":
     # compile ast into cubin
     for h in hints.values():
         assert h in [1, 16], f"Only 1 and 16 are valid hints, got {h}"
-    divisible_by_16 = [i for i, h in hints.items() if h == 16]
-    equal_to_1 = [i for i, h in hints.items() if h == 1]
-    attrs = triton.compiler.AttrsDescriptor(divisible_by_16=divisible_by_16, equal_to_1=equal_to_1)
+    divisible_by_16 = [(i, 16) for i, h in hints.items() if h == 16]
+    equal_to_1 = [(i, 1) for i, h in hints.items() if h == 1]
+    attrs = triton.compiler.AttrsDescriptor.from_hints(
+        {"tt.divisibility": divisible_by_16, "tt.equal_to_1": equal_to_1})
     for i in equal_to_1:
         constants.update({kernel.arg_names[i]: 1})
     src = triton.compiler.ASTSource(fn=kernel, constants=constants, signature=signature, attrs=attrs)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -1,4 +1,4 @@
-from triton.backends.compiler import BaseBackend, GPUTarget, AttrsDescriptor
+from triton.backends.compiler import BaseBackend, GPUTarget
 from triton._C.libtriton import ir, passes, llvm, amd
 from dataclasses import dataclass
 from typing import Any, Dict, Tuple

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -1,4 +1,4 @@
-from triton.backends.compiler import BaseBackend, GPUTarget
+from triton.backends.compiler import BaseBackend, GPUTarget, AttrsDescriptor
 from triton._C.libtriton import ir, passes, llvm, amd
 from dataclasses import dataclass
 from typing import Any, Dict, Tuple


### PR DESCRIPTION
In this PR I am trying to refactor the specializations that we apply to the signature of a given function in Triton. 

Basically, given a kernel there are some argument properties that can help compilation. E.g., divisibility by 16 and the fact that an integer is equal to 1. 

In a previous PR: https://github.com/triton-lang/triton/pull/4716, I needed other specializations to add buffer support in the AMD backend (and get back some performance when we were using unaligned masked loads). 

So this is my attempt to redesign the specialization support to introduce per-backend specializations. The idea is that `AttrsDescriptor` is now the class that is taking care of doing the analysis of the parameters and adding the specialization. It also has a function table where more specializations can be added per-backend. 

