### PR TITLE
Add support for lower block ptr to load/store lowering

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -102,6 +102,10 @@ void populatePrintOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                   const TargetInfoBase &targetInfo,
                                   PatternBenefit benefit);
 
+void populateBlockPtrOpToLLVMPattern(LLVMTypeConverter &typeConverter,
+                                     RewritePatternSet &patterns,
+                                     PatternBenefit benefit);
+
 } // namespace triton
 } // namespace mlir
 

--- a/lib/Conversion/TritonGPUToLLVM/BlockPtrOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/BlockPtrOpToLLVM.cpp
@@ -1,0 +1,74 @@
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+struct MakeTensorPtrOpConversion
+    : public ConvertOpToLLVMPattern<triton::MakeTensorPtrOp> {
+  using ConvertOpToLLVMPattern<triton::MakeTensorPtrOp>::ConvertOpToLLVMPattern;
+  LogicalResult
+  matchAndRewrite(triton::MakeTensorPtrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto ptrType = cast<triton::PointerType>(op.getType());
+    auto tensorType = cast<RankedTensorType>(ptrType.getPointeeType());
+
+    SmallVector<Value> resultVals;
+
+    // TODO:  offset should be 64 bits
+    auto offsets = op.getOffsets();
+    auto strides = adaptor.getStrides();
+    auto shape = adaptor.getShape();
+    for (int i = 0; i < offsets.size(); i++) {
+      resultVals.push_back(offsets[i]);
+    }
+    for (int i = 0; i < shape.size(); i++) {
+      resultVals.push_back(shape[i]);
+    }
+    for (int i = 0; i < strides.size(); i++) {
+      resultVals.push_back(strides[i]);
+    }
+
+    resultVals.push_back(adaptor.getBase());
+    Type structTy = getTypeConverter()->convertType(ptrType);
+    Value resultStruct =
+        packLLElements(loc, getTypeConverter(), resultVals, rewriter, structTy);
+    rewriter.replaceOp(op, {resultStruct});
+    return success();
+  }
+};
+
+struct AdvanceOpConversion : public ConvertOpToLLVMPattern<triton::AdvanceOp> {
+  using ConvertOpToLLVMPattern<triton::AdvanceOp>::ConvertOpToLLVMPattern;
+  LogicalResult
+  matchAndRewrite(triton::AdvanceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto ptrType = cast<triton::PointerType>(op.getType());
+    auto addedOffsets = adaptor.getOffsets();
+    auto blockPointerElems = unpackLLElements(loc, adaptor.getPtr(), rewriter);
+    auto rank = (blockPointerElems.size() - 1) / 3;
+    // TODO: maybe offset in op should be 64 bit
+    SmallVector<Value> origOffsets(blockPointerElems.begin(),
+                                   blockPointerElems.begin() + rank);
+    SmallVector<Value> newOffsets;
+    for (int i = 0; i < addedOffsets.size(); i++) {
+      auto newOffset = add(addedOffsets[i], origOffsets[i]);
+      newOffsets.push_back(newOffset);
+    }
+
+    std::copy(newOffsets.begin(), newOffsets.end(), blockPointerElems.begin());
+    Type structTy = getTypeConverter()->convertType(ptrType);
+    Value resultStruct = packLLElements(loc, getTypeConverter(),
+                                        blockPointerElems, rewriter, structTy);
+    rewriter.replaceOp(op, {resultStruct});
+    return success();
+  }
+};
+
+void mlir::triton::populateBlockPtrOpToLLVMPattern(
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    PatternBenefit benefit) {
+  patterns.add<MakeTensorPtrOpConversion>(typeConverter, benefit);
+  patterns.add<AdvanceOpConversion>(typeConverter, benefit);
+}

--- a/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_triton_library(TritonGPUToLLVM
+    BlockPtrOpToLLVM.cpp
     ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
     DotOpToLLVM/FMA.cpp
     TypeConverter.cpp

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -410,8 +410,8 @@ assignMemoryLayouts(llvm::SmallVector<std::tuple<Operation *, int, Operation *>>
     LoadInfo loadInfo;
 
     if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
-      assert(!isLoadFromTensorPtr(loadOp) &&
-             "Block ptr should have been lowered before this pass.");
+      if (!isLoadFromTensorPtr(loadOp))
+        continue;
       auto ptr = loadOp.getPtr();
       unsigned vec = axisInfoAnalysis.getPtrContiguity(ptr);
       if (auto mask = loadOp.getMask())

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -179,7 +179,6 @@ class CUDABackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         passes.common.add_inliner(pm)
-        passes.ttir.add_rewrite_tensor_pointer(pm)
         passes.ttir.add_combine(pm)
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_reorder_broadcast(pm)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -175,6 +175,8 @@ struct ConvertTritonGPUToLLVM
                                                 patterns, benefit);
     mlir::triton::populateMakeRangeOpToLLVMPattern(typeConverter, targetInfo,
                                                    patterns, benefit);
+    mlir::triton::populateBlockPtrOpToLLVMPattern(typeConverter, patterns,
+                                                  benefit);
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))
       return signalPassFailure();
 


### PR DESCRIPTION
Currently RewriteTensorPointer lowers loads and stores using block pointers to loads and stores using a tensor of pointers. It lowers the block pointer to a combination of Triton ops that create a tensor of pointers from the information in the block pointer.

It is more natural for loads and stores to be aware of the block pointers and for MakeTensorPtrOp/AdvanceOp to lower to a LLVM Struct containing all this information. Additionally, this means that loads/stores with block pointers preserve the information in the block pointer (such as strides, offsets, etc) till LLVM lowering. These are currently lost during the RewriteTensorPointer pass and information such as contiguity needs to be reconstructed through the AxisInfo analysis. 

The RewriteTensorPointer pass is also complicated and unnecessary, since it needs to be aware of control flow ops to manually propagate the information about the offsets to the block arguments. 

Thus, this PR enables the removal of the RewriteTensorPointer pass. I've not currently added support to the AMD backend - but if the maintainers are fine with the direction of this PR, I can update the AMD backend too.


The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because `test_block_pointer.py` tests block pointers.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
