### PR TITLE
Allow h.asm["sass"] to work

### DIFF
--- a/python/test/unit/tools/test_disasm.py
+++ b/python/test/unit/tools/test_disasm.py
@@ -3,7 +3,6 @@ import torch
 import triton
 import pytest
 import triton.language as tl
-from triton.tools.disasm import get_sass
 
 
 def test_disam_cubin():
@@ -17,6 +16,6 @@ def test_disam_cubin():
     x = torch.empty(1, dtype=torch.int32, device='cuda')
     h = kernel[(1, )](x, i=12)
     assert x[0] == 12
-    sass = get_sass(h.asm["cubin"])
+    sass = h.asm["sass"]
     # check that the sass has a store instruction.
     assert "STG.E" in sass

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -387,10 +387,10 @@ class CompiledKernel:
         # stores the text of each level of IR that was generated during compilation
         asm_files = [Path(p) for c, p in metadata_group.items() if not c.endswith(".json")]
         binary_ext = backend.binary_ext
-        self.asm = {
+        self.asm = AsmDict({
             file.suffix[1:]: file.read_bytes() if file.suffix[1:] == binary_ext else file.read_text()
             for file in asm_files
-        }
+        })
         self.kernel = self.asm[binary_ext]
         # binaries are lazily initialized
         # because it involves doing runtime things

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -8,6 +8,7 @@ from .. import __version__
 from ..runtime.autotuner import OutOfResources
 from ..runtime.cache import get_cache_manager, get_dump_manager, get_override_manager
 from ..runtime.driver import driver
+from ..tools.disasm import get_sass
 # TODO: this shouldn't be here
 from dataclasses import dataclass
 from .code_generator import ast_to_ttir
@@ -346,6 +347,19 @@ class LazyDict:
 
     def add(self, func, args):
         self.extras.append((func, args))
+
+
+class AsmDict(dict):
+
+    def __missing__(self, key):
+
+        if key == "sass":
+            value = get_sass(self["cubin"])
+        else:
+            raise KeyError("Unknown key: '%s'" % key)
+
+        self[key] = value
+        return value
 
 
 class CompiledKernel:


### PR DESCRIPTION
This is less tedious than having to manually import `get_sass` and call `get_sass(h.asm["cubin"])`. Moreover, this is done lazily the first time that we want the SASS, so there is no overhead.