### PR TITLE
[PROTON] Fix option conflict with subcommands

### DIFF
--- a/third_party/proton/proton/proton.py
+++ b/third_party/proton/proton/proton.py
@@ -18,8 +18,9 @@ def parse_arguments():
                         choices=["shadow", "python"])
     parser.add_argument("-d", "--data", type=str, help="Profiling data", default="tree", choices=["tree"])
     parser.add_argument("-k", "--hook", type=str, help="Profiling hook", default=None, choices=[None, "triton"])
-    args, target_args = parser.parse_known_args()
-    return args, target_args
+    parser.add_argument('target_args', nargs=argparse.REMAINDER, help='Subcommand and its arguments')
+    args = parser.parse_args()
+    return args, args.target_args
 
 
 def is_pytest(script):

--- a/third_party/proton/test/test_cmd.py
+++ b/third_party/proton/test/test_cmd.py
@@ -22,7 +22,8 @@ def test_exec(mode):
             ret = subprocess.check_call(["python3", "-m", "triton.profiler.proton", "-n", name, helper_file, "test"],
                                         stdout=subprocess.DEVNULL)
         elif mode == "pytest":
-            ret = subprocess.check_call(["proton", "-n", name, "pytest", helper_file], stdout=subprocess.DEVNULL)
+            ret = subprocess.check_call(["proton", "-n", name, "pytest", "-k", "test_main", helper_file],
+                                        stdout=subprocess.DEVNULL)
         assert ret == 0
         data = json.load(f, )
         kernels = data[0]["children"]


### PR DESCRIPTION
Previously, if both the subcommand (e.g., pytest) and proton had the same option (e.g., -k), proton would fail due to an option conflict. By using argparse.REMAINDER—though its behavior is not well documented in the Python documentation—we now allow proton to parse the -k option only before the subcommand.