### PR TITLE
[CI] Fix dependency checks

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,15 +45,6 @@ jobs:
         with:
           # Only fetch two commits to check the latest changed files.
           fetch-depth: 2
-      - name: Detect if build deps (e.g., LLVM hash) exist
-        if: github.event_name == 'push'
-        uses: andstor/file-existence-action@v3
-        with:
-          fail: true
-          files: |
-            cmake/llvm-hash.txt
-            cmake/nvidia-toolchain-version.json
-            cmake/json-version.txt
       - name: Detect if build deps (e.g. LLVM hash) changed
         id: detect-change
         if: github.event_name == 'push'
@@ -175,9 +166,20 @@ jobs:
       - name: Compute cache keys
         id: cache-key
         run: |
-          echo "llvm=$(cat cmake/llvm-hash.txt | cut -c 1-8)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(sha256sum cmake/nvidia-toolchain-version.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-          echo "json=$(cat cmake/json-version.txt)" >> $GITHUB_OUTPUT
+          llvm_file="cmake/llvm-hash.txt"
+          nvidia_file="cmake/nvidia-toolchain-version.json"
+          json_file="cmake/json-version.txt"
+
+          # Check if files exist before proceeding
+          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$json_file" ]]; then
+            echo "Error: Required dependency files are missing."
+            exit 1
+          fi
+
+          # Process the files if they exist
+          echo "llvm=$(cat $llvm_file | cut -c 1-8)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(sha256sum $nvidia_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "json=$(cat $json_file)" >> $GITHUB_OUTPUT
           echo "datetime=$(date -u -Iseconds)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache build dependencies
@@ -316,9 +318,20 @@ jobs:
       - name: Compute cache keys
         id: cache-key
         run: |
-          echo "llvm=$(cat cmake/llvm-hash.txt | cut -c 1-8)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(sha256sum cmake/nvidia-toolchain-version.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-          echo "json=$(cat cmake/json-version.txt)" >> $GITHUB_OUTPUT
+          llvm_file="cmake/llvm-hash.txt"
+          nvidia_file="cmake/nvidia-toolchain-version.json"
+          json_file="cmake/json-version.txt"
+
+          # Check if files exist before proceeding
+          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$json_file" ]]; then
+            echo "Error: Required dependency files are missing."
+            exit 1
+          fi
+
+          # Process the files if they exist
+          echo "llvm=$(cat $llvm_file | cut -c 1-8)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(sha256sum $nvidia_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "json=$(cat $json_file)" >> $GITHUB_OUTPUT
           echo "datetime=$(date -u -Iseconds)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache build dependencies
@@ -451,9 +464,20 @@ jobs:
       - name: Compute cache keys
         id: cache-key
         run: |
-          echo "llvm=$(cat cmake/llvm-hash.txt | cut -c 1-8)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(sha256sum cmake/nvidia-toolchain-version.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-          echo "json=$(cat cmake/json-version.txt)" >> $GITHUB_OUTPUT
+          llvm_file="cmake/llvm-hash.txt"
+          nvidia_file="cmake/nvidia-toolchain-version.json"
+          json_file="cmake/json-version.txt"
+
+          # Check if files exist before proceeding
+          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$json_file" ]]; then
+            echo "Error: Required dependency files are missing."
+            exit 1
+          fi
+
+          # Process the files if they exist
+          echo "llvm=$(cat $llvm_file | cut -c 1-8)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(sha256sum $nvidia_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "json=$(cat $json_file)" >> $GITHUB_OUTPUT
           echo "datetime=$(date -u -Iseconds)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache build dependencies

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,6 +45,15 @@ jobs:
         with:
           # Only fetch two commits to check the latest changed files.
           fetch-depth: 2
+      - name: Detect if build deps (e.g., LLVM hash) exist
+        if: github.event_name == 'push'
+        uses: andstor/file-existence-action@v3
+        with:
+          fail: true
+          files: |
+            cmake/llvm-hash.txt
+            cmake/nvidia-toolchain-version.json
+            cmake/json-version.txt
       - name: Detect if build deps (e.g. LLVM hash) changed
         id: detect-change
         if: github.event_name == 'push'
@@ -52,6 +61,7 @@ jobs:
         with:
           files: |
             cmake/*.txt
+            cmake/*.json
       - name: Detect if enough time has passed since last post-submit run
         id: detect-time
         if: github.event_name == 'push'
@@ -127,7 +137,7 @@ jobs:
       - name: Compute hash of pre-commit config
         id: cache-key
         run: |
-          echo "pre_commit_hash=$(sha256sum .pre-commit-config.yaml)" >> $GITHUB_OUTPUT
+          echo "pre_commit_hash=$(sha256sum .pre-commit-config.yaml | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache pre-commit's cache dir
         uses: actions/cache@v4
@@ -166,7 +176,7 @@ jobs:
         id: cache-key
         run: |
           echo "llvm=$(cat cmake/llvm-hash.txt | cut -c 1-8)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(cat cmake/nvidia-toolchain-version.txt)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(sha256sum cmake/nvidia-toolchain-version.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
           echo "json=$(cat cmake/json-version.txt)" >> $GITHUB_OUTPUT
           echo "datetime=$(date -u -Iseconds)" >> $GITHUB_OUTPUT
         shell: bash
@@ -307,7 +317,7 @@ jobs:
         id: cache-key
         run: |
           echo "llvm=$(cat cmake/llvm-hash.txt | cut -c 1-8)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(cat cmake/nvidia-toolchain-version.txt)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(sha256sum cmake/nvidia-toolchain-version.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
           echo "json=$(cat cmake/json-version.txt)" >> $GITHUB_OUTPUT
           echo "datetime=$(date -u -Iseconds)" >> $GITHUB_OUTPUT
         shell: bash
@@ -442,7 +452,7 @@ jobs:
         id: cache-key
         run: |
           echo "llvm=$(cat cmake/llvm-hash.txt | cut -c 1-8)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(cat cmake/nvidia-toolchain-version.txt)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(sha256sum cmake/nvidia-toolchain-version.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
           echo "json=$(cat cmake/json-version.txt)" >> $GITHUB_OUTPUT
           echo "datetime=$(date -u -Iseconds)" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -51,6 +51,16 @@ jobs:
           # Only fetch two commits to check the latest changed files.
           fetch-depth: 2
 
+      - name: Detect if build deps (e.g., LLVM hash) exist
+        if : github.event_name == 'push'
+        uses: andstor/file-existence-action@v3
+        with:
+          fail: true
+          files: |
+            cmake/llvm-hash.txt
+            cmake/nvidia-toolchain-version.json
+            cmake/json-version.txt
+
       - name: Detect if build deps (e.g. LLVM hash) changed
         id: detect-change
         if: github.event_name == 'push'
@@ -58,6 +68,7 @@ jobs:
         with:
           files: |
             cmake/*.txt
+            cmake/*.json
 
       - name: Detect if enough time has passed since last post-submit run
         id: detect-time
@@ -140,7 +151,7 @@ jobs:
       - name: Compute hash of pre-commit config
         id: cache-key
         run: |
-          echo "pre_commit_hash=$(sha256sum .pre-commit-config.yaml)" >> $GITHUB_OUTPUT
+          echo "pre_commit_hash=$(sha256sum .pre-commit-config.yaml | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Cache pre-commit's cache dir
@@ -189,7 +200,7 @@ jobs:
         id: cache-key
         run: |
           echo "llvm=$(cat cmake/llvm-hash.txt | cut -c 1-8)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(cat cmake/nvidia-toolchain-version.txt)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(sha256sum cmake/nvidia-toolchain-version.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
           echo "json=$(cat cmake/json-version.txt)" >> $GITHUB_OUTPUT
           echo "datetime=$(date -u -Iseconds)" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -51,16 +51,6 @@ jobs:
           # Only fetch two commits to check the latest changed files.
           fetch-depth: 2
 
-      - name: Detect if build deps (e.g., LLVM hash) exist
-        if : github.event_name == 'push'
-        uses: andstor/file-existence-action@v3
-        with:
-          fail: true
-          files: |
-            cmake/llvm-hash.txt
-            cmake/nvidia-toolchain-version.json
-            cmake/json-version.txt
-
       - name: Detect if build deps (e.g. LLVM hash) changed
         id: detect-change
         if: github.event_name == 'push'
@@ -199,9 +189,20 @@ jobs:
         name: Compute cache keys
         id: cache-key
         run: |
-          echo "llvm=$(cat cmake/llvm-hash.txt | cut -c 1-8)" >> $GITHUB_OUTPUT
-          echo "nvidia=$(sha256sum cmake/nvidia-toolchain-version.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-          echo "json=$(cat cmake/json-version.txt)" >> $GITHUB_OUTPUT
+          llvm_file="cmake/llvm-hash.txt"
+          nvidia_file="cmake/nvidia-toolchain-version.json"
+          json_file="cmake/json-version.txt"
+
+          # Check if files exist before proceeding
+          if [[ ! -f "$llvm_file" || ! -f "$nvidia_file" || ! -f "$json_file" ]]; then
+            echo "Error: Required dependency files are missing."
+            exit 1
+          fi
+
+          # Process the files if they exist
+          echo "llvm=$(cat $llvm_file | cut -c 1-8)" >> $GITHUB_OUTPUT
+          echo "nvidia=$(sha256sum $nvidia_file | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "json=$(cat $json_file)" >> $GITHUB_OUTPUT
           echo "datetime=$(date -u -Iseconds)" >> $GITHUB_OUTPUT
         shell: bash
 


### PR DESCRIPTION
This PR enhances dependency checks with the following changes:

- Checks if all dependency files exist; if not, the GitHub action will fail.
- Calculates a hash to determine if any NVIDIA dependencies have changed.
- Extracts only the hash when using `sha256sum` (by default, its output is `<hash> <filename>`).