### PR TITLE
[Analysis] Added padding to avoid bank conflicts (based on TODO)

### DIFF
--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -69,8 +69,11 @@ static SmallVector<unsigned> getRepShapeForCvt(RankedTensorType srcTy,
   }
 
   if (shouldUseDistSmem(srcLayout, dstLayout)) {
-    // TODO: padding to avoid bank conflicts
-    return convertType<unsigned, int64_t>(getShapePerCTA(srcTy));
+    auto shape = convertType<unsigned, int64_t>(getShapePerCTA(srcTy));
+    for (auto &dim : shape) {
+      dim += 1; // Add padding to avoid bank conflicts
+    }
+    return shape;
   }
 
   assert(srcLayout && dstLayout && "Unexpected layout in getRepShapeForCvt()");


### PR DESCRIPTION
[Analysis] in Allocation.cpp, implemented padding by adding 1 to each block dimension. I have not added tests yet because I do not know what the rightful location would be and how to implement.

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
