### PR TITLE
Add platform info into cache key for compatibility

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -45,8 +45,16 @@ def library_dirs():
     return [libdevice_dir, *libcuda_dirs()]
 
 
+@functools.lru_cache()
+def extra_cache_key():
+    # we need platform info (x86_64, aarch64 etc) to avoid incompatibility
+    # with the cached objects
+    from platform import machine, system, architecture
+    return ",".join([machine(), system(), *architecture()])
+
+
 def compile_module_from_src(src, name):
-    key = hashlib.sha256(src.encode("utf-8")).hexdigest()
+    key = hashlib.sha256((src + extra_cache_key()).encode("utf-8")).hexdigest()
     cache = get_cache_manager(key)
     cache_path = cache.get_file(f"{name}.so")
     if cache_path is None:


### PR DESCRIPTION
We have seen in a few cases, we're failing to load the shared object from the cache, because: 1. the cached object is built in aarch64 and we're trying to load it on a x86_64 machine (especially if we have remote cache); 2. if the cached object is built with e.g. ROCm 6.0 and we're loading it under ROCm 6.2. hip_utils.so will fail to load due to some ABI changes in the HIP runtime. Therefore, we'll need to add platform and HIP version info into the cache key

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it just adds more info to the cache key. The cache code is already tested in python/test/unit/runtime/test_cache.py.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
