### PR TITLE
Add git commit to the version as a suffix

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -637,9 +637,17 @@ def get_entry_points():
     return entry_points
 
 
+def get_git_commit_hash(length=8):
+    try:
+        cmd = ['git', 'rev-parse', f'--short={length}', 'HEAD']
+        return "+git{}".format(subprocess.check_output(cmd).strip().decode('utf-8'))
+    except Exception:
+        return ""
+
+
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.0.0" + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.0.0" + get_git_commit_hash() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",


### PR DESCRIPTION
It's very common that we need to figure out the exact commit from which the current installed triton package is compiled. Right now it will just show a version number like `3.0.0` which isn't quite helpful.

With this commit we have

```
> pip show triton
Name: triton
Version: 3.0.0+git78e4f837
```