### PR TITLE
[AMD] Implement dotOperandMfma to linear layout conversion

### DIFF
--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -717,9 +717,54 @@ SliceEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   return ret;
 }
 
-// TODO: DotOperandEncoding doesn't support LinearLayout conversion yet.
 std::optional<LinearLayout>
 DotOperandEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
+
+  if (auto mfmaLayout = llvm::dyn_cast<AMDMfmaEncodingAttr>(getParent())) {
+
+    if (getOpIdx() == 0) {
+      return std::nullopt;
+    }
+
+    int rank = shape.size();
+    assert(rank == getWarpsPerCTA().size());
+
+    auto kWidth = getKWidth();
+    auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
+
+    if (kWidth != 8 || warpsPerCTA[0] != 1) {
+      return std::nullopt;
+    }
+
+    MLIRContext *ctx = getContext();
+    SmallVector<StringAttr> outDimNames = standardOutDimNames(ctx, rank);
+
+    StringAttr kRegister = S("register");
+    StringAttr kLane = S("lane");
+
+    SmallVector<unsigned> order = triton::gpu::getOrder(*this);
+    auto tileLayout = LinearLayout::empty();
+
+    if (mfmaLayout.getMDim() == 32) {
+      tileLayout = LinearLayout(
+          {{kRegister, {{1, 0}, {2, 0}, {4, 0}}},
+           {kLane, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {8, 0}}}},
+          {outDimNames[order[1]], outDimNames[order[0]]});
+    } else {
+      assert(mfmaLayout.getMDim() == 16);
+      tileLayout = LinearLayout(
+          {{kRegister, {{1, 0}, {2, 0}, {4, 0}}},
+           {kLane, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}, {16, 0}}}},
+          {outDimNames[order[1]], outDimNames[order[0]]});
+    }
+    LinearLayout warpLayout =
+        identityND(S("warp"), warpsPerCTA, {order[1], order[0]},
+                   {outDimNames[order[1]], outDimNames[order[0]]});
+    LinearLayout ctaLayout = tileLayout * warpLayout;
+
+    return combineCtaCgaWithShape(ctaLayout, mfmaLayout.getCTALayout(), shape);
+  }
+
   return std::nullopt;
 }
 

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -540,6 +540,75 @@ AMDMfmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
 }
 
 std::optional<LinearLayout>
+dotOperandMfmaToLinearLayout(DotOperandEncodingAttr dotMfmaLayout,
+                             ArrayRef<int64_t> shape) {
+
+  auto mfmaLayout =
+      llvm::dyn_cast<AMDMfmaEncodingAttr>(dotMfmaLayout.getParent());
+  assert(mfmaLayout);
+
+  if (dotMfmaLayout.getOpIdx() == 0) {
+    return std::nullopt;
+  }
+  auto rank = shape.size();
+  bool hasBatchDim = rank == 3;
+  auto kWidth = dotMfmaLayout.getKWidth();
+  auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
+
+  if (kWidth != 8 || warpsPerCTA[0] != 1) {
+    return std::nullopt;
+  }
+
+  MLIRContext *ctx = dotMfmaLayout.getContext();
+  SmallVector<StringAttr> outDimNames = standardOutDimNames(ctx, rank);
+
+  StringAttr kRegister = S("register");
+  StringAttr kLane = S("lane");
+
+  SmallVector<unsigned> order = triton::gpu::getOrder(dotMfmaLayout);
+  auto tileLayout = LinearLayout::empty();
+
+  if (mfmaLayout.getMDim() == 32) {
+    // Based on canonical MFMA linear layout, which handles 4 consecutive
+    // elements along the register dimension, kWidth=8 means we have 8
+    // consecutive elements, so we have an additional {4, 0} base vector here.
+    // For lane dim, since threadsPerWarp is {2, 32}, this means that mapping
+    // of first 5 base (up to thread 16) vectors will be an identity along N
+    // dim. Thread 32 will be mapped to element 8 in K dimension, because
+    // kWidth == 8.
+    tileLayout = LinearLayout(
+        {{kRegister, {{1, 0}, {2, 0}, {4, 0}}},
+         {kLane, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {8, 0}}}},
+        {outDimNames[order[0]], outDimNames[order[1]]});
+  } else {
+    assert(mfmaLayout.getMDim() == 16);
+    // For lane dim, since threadsPerWarp is {4, 16}, this means that mapping
+    // of first 4 base (up to thread 16) vectors will be an identity along N
+    // dim. Thread 16 will be mapped to element 8 in K dimension, because
+    // kWidth == 8. Thread 32 is mapped to element 16 as that is 2*KWidth in K
+    // dim.
+    tileLayout = LinearLayout(
+        {{kRegister, {{1, 0}, {2, 0}, {4, 0}}},
+         {kLane, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}, {16, 0}}}},
+        {outDimNames[order[0]], outDimNames[order[1]]});
+  }
+
+  if (hasBatchDim) {
+    assert(order[2] == 0);
+    // Extend the base vector with one value to accomodate for the batch
+    // dimension, which appears at the last.
+    tileLayout *= LinearLayout::identity1D(1, kRegister, outDimNames[order[2]]);
+    tileLayout *= LinearLayout::identity1D(1, kLane, outDimNames[order[2]]);
+  }
+
+  LinearLayout warpLayout =
+      identityND(S("warp"), warpsPerCTA, order, outDimNames);
+  LinearLayout ctaLayout = tileLayout * warpLayout;
+
+  return combineCtaCgaWithShape(ctaLayout, mfmaLayout.getCTALayout(), shape);
+}
+
+std::optional<LinearLayout>
 AMDWmmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   int rank = shape.size();
   assert(rank == getWarpsPerCTA().size());
@@ -721,48 +790,7 @@ std::optional<LinearLayout>
 DotOperandEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
 
   if (auto mfmaLayout = llvm::dyn_cast<AMDMfmaEncodingAttr>(getParent())) {
-
-    if (getOpIdx() == 0) {
-      return std::nullopt;
-    }
-
-    int rank = shape.size();
-    assert(rank == getWarpsPerCTA().size());
-
-    auto kWidth = getKWidth();
-    auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
-
-    if (kWidth != 8 || warpsPerCTA[0] != 1) {
-      return std::nullopt;
-    }
-
-    MLIRContext *ctx = getContext();
-    SmallVector<StringAttr> outDimNames = standardOutDimNames(ctx, rank);
-
-    StringAttr kRegister = S("register");
-    StringAttr kLane = S("lane");
-
-    SmallVector<unsigned> order = triton::gpu::getOrder(*this);
-    auto tileLayout = LinearLayout::empty();
-
-    if (mfmaLayout.getMDim() == 32) {
-      tileLayout = LinearLayout(
-          {{kRegister, {{1, 0}, {2, 0}, {4, 0}}},
-           {kLane, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {8, 0}}}},
-          {outDimNames[order[1]], outDimNames[order[0]]});
-    } else {
-      assert(mfmaLayout.getMDim() == 16);
-      tileLayout = LinearLayout(
-          {{kRegister, {{1, 0}, {2, 0}, {4, 0}}},
-           {kLane, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}, {16, 0}}}},
-          {outDimNames[order[1]], outDimNames[order[0]]});
-    }
-    LinearLayout warpLayout =
-        identityND(S("warp"), warpsPerCTA, {order[1], order[0]},
-                   {outDimNames[order[1]], outDimNames[order[0]]});
-    LinearLayout ctaLayout = tileLayout * warpLayout;
-
-    return combineCtaCgaWithShape(ctaLayout, mfmaLayout.getCTALayout(), shape);
+    return dotOperandMfmaToLinearLayout(*this, shape);
   }
 
   return std::nullopt;

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -656,7 +656,7 @@ TEST_F(LinearLayoutConversionsTest, MFMA32_2x4x1Warps) {
                 {S("dim0"), S("dim1"), S("dim2")}));
 }
 
-TEST_F(LinearLayoutConversionsTest, AMDDOT_1_8_32_1_8) {
+TEST_F(LinearLayoutConversionsTest, warp1onK_mfma32_rhs_kwidth8) {
   auto parentMfma_1_8 = mfma(/*warps=*/{1, 8}, /*mDim=*/32, /*nDim=*/32,
                              /*isTransposed=*/false);
   auto amdDot_1_8 = amdDot(parentMfma_1_8, /*opIdx=*/1, /*kWidth=*/8);
@@ -716,7 +716,7 @@ TEST_F(LinearLayoutConversionsTest, AMDDOT_1_8_32_1_8) {
                 {S("dim0"), S("dim1")}));
 }
 
-TEST_F(LinearLayoutConversionsTest, AMDDOT_1_8_16_1_8) {
+TEST_F(LinearLayoutConversionsTest, warp1onK_mfma16_rhs_kwidth8) {
   auto parentMfma_1_4 = mfma(/*warps=*/{1, 4}, /*mDim=*/16, /*nDim=*/16,
                              /*isTransposed=*/false);
   auto amdDot_1_4 = amdDot(parentMfma_1_4, /*opIdx=*/1, /*kWidth=*/8);
@@ -761,24 +761,43 @@ TEST_F(LinearLayoutConversionsTest, AMDDOT_1_8_16_1_8) {
                  {S("block"), {}}},
                 {S("dim0"), S("dim1")}));
 
-  auto parentMfma_1_8 = mfma(/*warps=*/{1, 4}, /*mDim=*/16, /*nDim=*/16,
+
+  auto parentMfma_1_8 = mfma(/*warps=*/{1, 8}, /*mDim=*/16, /*nDim=*/16,
                              /*isTransposed=*/false);
   auto amdDot_1_8 = amdDot(parentMfma_1_8, /*opIdx=*/1, /*kWidth=*/8);
-  EXPECT_EQ(toLinearLayout({256, 256}, amdDot_1_8),
-            LinearLayout(
-                {{S("register"),
-                  {{1, 0},
-                   {2, 0},
-                   {4, 0},
-                   {32, 0},
-                   {64, 0},
-                   {128, 0},
-                   {0, 64},
-                   {0, 128}}},
-                 {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}, {16, 0}}},
-                 {S("warp"), {{0, 16}, {0, 32}}},
-                 {S("block"), {}}},
-                {S("dim0"), S("dim1")}));
+  EXPECT_EQ(
+      toLinearLayout({256, 256}, amdDot_1_8),
+      LinearLayout(
+          {{S("register"),
+            {{1, 0}, {2, 0}, {4, 0}, {32, 0}, {64, 0}, {128, 0}, {0, 128}}},
+           {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}, {16, 0}}},
+           {S("warp"), {{0, 16}, {0, 32}, {0, 64}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+
+  auto parentMfma_1_8_1 = mfma(/*warps=*/{1, 1, 8}, /*mDim=*/16, /*nDim=*/16,
+                             /*isTransposed=*/false);
+  auto amdDot_1_8_1 = amdDot(parentMfma_1_8_1, /*opIdx=*/1, /*kWidth=*/8);
+
+  EXPECT_EQ(toLinearLayout({1, 256, 256}, amdDot_1_8_1),
+            LinearLayout({{S("register"),
+                           {{0, 1, 0},
+                            {0, 2, 0},
+                            {0, 4, 0},
+                            {0, 32, 0},
+                            {0, 64, 0},
+                            {0, 128, 0},
+                            {0, 0, 128}}},
+                          {S("lane"),
+                           {{0, 0, 1},
+                            {0, 0, 2},
+                            {0, 0, 4},
+                            {0, 0, 8},
+                            {0, 8, 0},
+                            {0, 16, 0}}},
+                          {S("warp"), {{0, 0, 16}, {0, 0, 32}, {0, 0, 64}}},
+                          {S("block"), {}}},
+                         {S("dim0"), S("dim1"), S("dim2")}));
 }
 
 TEST_F(LinearLayoutConversionsTest, WMMA_2x4Warps) {

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -51,6 +51,11 @@ public:
         isTransposed, CTALayoutAttr::get(&ctx, cpg, cSplit, cOrd));
   }
 
+  DotOperandEncodingAttr amdDot(AMDMfmaEncodingAttr mfma, unsigned opIdx,
+                                unsigned kWidth) {
+    return DotOperandEncodingAttr::get(&ctx, opIdx, mfma, kWidth);
+  }
+
   AMDWmmaEncodingAttr wmma(ArrayRef<unsigned> warps) {
     SmallVector<unsigned> cpg(warps.size(), 1u);
     SmallVector<unsigned> cSplit(warps.size(), 1u);
@@ -649,6 +654,131 @@ TEST_F(LinearLayoutConversionsTest, MFMA32_2x4x1Warps) {
                  {S("warp"), {{0, 32, 0}, {0, 0, 0}, {1, 0, 0}}},
                  {S("block"), {}}},
                 {S("dim0"), S("dim1"), S("dim2")}));
+}
+
+TEST_F(LinearLayoutConversionsTest, AMDDOT_1_8_32_1_8) {
+  auto parentMfma_1_8 = mfma(/*warps=*/{1, 8}, /*mDim=*/32, /*nDim=*/32,
+                             /*isTransposed=*/false);
+  auto amdDot_1_8 = amdDot(parentMfma_1_8, /*opIdx=*/1, /*kWidth=*/8);
+  EXPECT_EQ(
+      toLinearLayout({128, 128}, amdDot_1_8),
+      LinearLayout(
+          {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {16, 0}, {32, 0}, {64, 0}}},
+           {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {8, 0}}},
+           {S("warp"), {{0, 32}, {0, 64}, {0, 0}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+
+  EXPECT_EQ(
+      toLinearLayout({128, 256}, amdDot_1_8),
+      LinearLayout(
+          {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {16, 0}, {32, 0}, {64, 0}}},
+           {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {8, 0}}},
+           {S("warp"), {{0, 32}, {0, 64}, {0, 128}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+
+  EXPECT_EQ(toLinearLayout({32, 64}, amdDot_1_8),
+            LinearLayout(
+                {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {16, 0}}},
+                 {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {8, 0}}},
+                 {S("warp"), {{0, 32}, {0, 0}, {0, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+
+  EXPECT_EQ(
+      toLinearLayout({256, 256}, amdDot_1_8),
+      LinearLayout(
+          {{S("register"),
+            {{1, 0}, {2, 0}, {4, 0}, {16, 0}, {32, 0}, {64, 0}, {128, 0}}},
+           {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {8, 0}}},
+           {S("warp"), {{0, 32}, {0, 64}, {0, 128}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+
+  auto parentMfma_1_4 = mfma(/*warps=*/{1, 4}, /*mDim=*/32, /*nDim=*/32,
+                             /*isTransposed=*/false);
+  auto amdDot_1_4 = amdDot(parentMfma_1_4, /*opIdx=*/1, /*kWidth=*/8);
+  EXPECT_EQ(toLinearLayout({256, 256}, amdDot_1_4),
+            LinearLayout(
+                {{S("register"),
+                  {{1, 0},
+                   {2, 0},
+                   {4, 0},
+                   {16, 0},
+                   {32, 0},
+                   {64, 0},
+                   {128, 0},
+                   {0, 128}}},
+                 {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {8, 0}}},
+                 {S("warp"), {{0, 32}, {0, 64}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+}
+
+TEST_F(LinearLayoutConversionsTest, AMDDOT_1_8_16_1_8) {
+  auto parentMfma_1_4 = mfma(/*warps=*/{1, 4}, /*mDim=*/16, /*nDim=*/16,
+                             /*isTransposed=*/false);
+  auto amdDot_1_4 = amdDot(parentMfma_1_4, /*opIdx=*/1, /*kWidth=*/8);
+  EXPECT_EQ(
+      toLinearLayout({128, 128}, amdDot_1_4),
+      LinearLayout(
+          {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {32, 0}, {64, 0}, {0, 64}}},
+           {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}, {16, 0}}},
+           {S("warp"), {{0, 16}, {0, 32}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+
+  EXPECT_EQ(toLinearLayout({1, 128}, amdDot_1_4),
+            LinearLayout(
+                {{S("register"), {{0, 0}, {0, 0}, {0, 0}, {0, 64}}},
+                 {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 0}, {0, 0}}},
+                 {S("warp"), {{0, 16}, {0, 32}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+
+  EXPECT_EQ(toLinearLayout({128, 1}, amdDot_1_4),
+            LinearLayout(
+                {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {32, 0}, {64, 0}}},
+                 {S("lane"), {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {8, 0}, {16, 0}}},
+                 {S("warp"), {{0, 0}, {0, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+
+  EXPECT_EQ(toLinearLayout({256, 256}, amdDot_1_4),
+            LinearLayout(
+                {{S("register"),
+                  {{1, 0},
+                   {2, 0},
+                   {4, 0},
+                   {32, 0},
+                   {64, 0},
+                   {128, 0},
+                   {0, 64},
+                   {0, 128}}},
+                 {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}, {16, 0}}},
+                 {S("warp"), {{0, 16}, {0, 32}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+
+  auto parentMfma_1_8 = mfma(/*warps=*/{1, 4}, /*mDim=*/16, /*nDim=*/16,
+                             /*isTransposed=*/false);
+  auto amdDot_1_8 = amdDot(parentMfma_1_8, /*opIdx=*/1, /*kWidth=*/8);
+  EXPECT_EQ(toLinearLayout({256, 256}, amdDot_1_8),
+            LinearLayout(
+                {{S("register"),
+                  {{1, 0},
+                   {2, 0},
+                   {4, 0},
+                   {32, 0},
+                   {64, 0},
+                   {128, 0},
+                   {0, 64},
+                   {0, 128}}},
+                 {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}, {16, 0}}},
+                 {S("warp"), {{0, 16}, {0, 32}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
 }
 
 TEST_F(LinearLayoutConversionsTest, WMMA_2x4Warps) {

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -761,7 +761,6 @@ TEST_F(LinearLayoutConversionsTest, warp1onK_mfma16_rhs_kwidth8) {
                  {S("block"), {}}},
                 {S("dim0"), S("dim1")}));
 
-
   auto parentMfma_1_8 = mfma(/*warps=*/{1, 8}, /*mDim=*/16, /*nDim=*/16,
                              /*isTransposed=*/false);
   auto amdDot_1_8 = amdDot(parentMfma_1_8, /*opIdx=*/1, /*kWidth=*/8);
@@ -776,7 +775,7 @@ TEST_F(LinearLayoutConversionsTest, warp1onK_mfma16_rhs_kwidth8) {
           {S("dim0"), S("dim1")}));
 
   auto parentMfma_1_8_1 = mfma(/*warps=*/{1, 1, 8}, /*mDim=*/16, /*nDim=*/16,
-                             /*isTransposed=*/false);
+                               /*isTransposed=*/false);
   auto amdDot_1_8_1 = amdDot(parentMfma_1_8_1, /*opIdx=*/1, /*kWidth=*/8);
 
   EXPECT_EQ(toLinearLayout({1, 256, 256}, amdDot_1_8_1),


### PR DESCRIPTION
This commit implements dotOperandMfma layout to linear layout conversion under following conditions: 
- opIdx == 1
- kWidth == 8
- warpsPerCTA[0] == 1.

This serves as a preparation for a next PR, which will add a bypassLDS pass.

