### PR TITLE
09-persistent-matmul.py bugfix

### DIFF
--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -554,7 +554,7 @@ def bench(K, dtype, tiles_per_update, reps=10):
     if cublas is not None:
         for _ in range(reps):
             cublas_matmul(a, b)
-        time.sleep(0.01)
+            time.sleep(0.01)
     if dtype == torch.float16:
         for _ in range(reps):
             torch_matmul(a, b)


### PR DESCRIPTION
Currently we sleep between each rep for Triton kernels, but not for the cuBLAS kernel. This may improve cuBLAS performance on fp8 due to thermal issues.