### PR TITLE
[FRONTEND] Support passing dtype as constexpr for tma load

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1613,7 +1613,7 @@ def _experimental_descriptor_load(desc_pointer, offsets, shape, dtype, _builder=
 
     This loads a tensor of data based on the descriptor and offsets.
     """
-    type = block_type(dtype, shape)
+    type = block_type(_constexpr_to_value(dtype), shape)
     return semantic.descriptor_load(desc_pointer, offsets, "", "", type, _builder)
 
 


### PR DESCRIPTION
Fixing an compile error like below when passing dtype through kernel arg for `tl._experimental_descriptor_load`:

 AttributeError: 'constexpr' object has no attribute 'to_ir'