### PR TITLE
Add fp8 types to prune

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -426,7 +426,16 @@ def get_max_tensorcore_tflops(dtype, clock_rate, device=None):
             ops_per_sub_core = 256
         elif dtype in [torch.float16, torch.bfloat16, torch.int16]:
             ops_per_sub_core = 512
-        elif dtype in [torch.int8, tl.float8e4nv, tl.float8e4b15, tl.float8e5]:
+        elif dtype in [
+            torch.int8,
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+            torch.float8_e5m2,
+            torch.float8_e5m2fnuz,
+            tl.float8e4nv,
+            tl.float8e4b15,
+            tl.float8e5,
+        ]:
             ops_per_sub_core = 1024
         else:
             raise RuntimeError("dtype not supported")

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -427,14 +427,14 @@ def get_max_tensorcore_tflops(dtype, clock_rate, device=None):
         elif dtype in [torch.float16, torch.bfloat16, torch.int16]:
             ops_per_sub_core = 512
         elif dtype in [
-            torch.int8,
-            torch.float8_e4m3fn,
-            torch.float8_e4m3fnuz,
-            torch.float8_e5m2,
-            torch.float8_e5m2fnuz,
-            tl.float8e4nv,
-            tl.float8e4b15,
-            tl.float8e5,
+                torch.int8,
+                torch.float8_e4m3fn,
+                torch.float8_e4m3fnuz,
+                torch.float8_e5m2,
+                torch.float8_e5m2fnuz,
+                tl.float8e4nv,
+                tl.float8e4b15,
+                tl.float8e5,
         ]:
             ops_per_sub_core = 1024
         else:


### PR DESCRIPTION
Currently `get_max_tensorcore_tflops` requires that fp8 types be reinterpreted to triton datatypes. This requires any triton function that operates on FP8 to handle it specially with reinterprets. However, pytorch has full support for FP8 now and there is no need to treat them specially. This small diff includes torch fp8 types in `get_max_tensorcore_tflops` so that we can compile fp8 kernels without reinterpreting.

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is a simple extension of 8 bit types and `get_max_tensorcore_tflops` does not have any dedicated unit tests.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
