### PR TITLE
[BUILD] Avoid using lld as the linker on macOS

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -429,11 +429,14 @@ class CMakeBuild(build_ext):
             cmake_args += [
                 "-DCMAKE_C_COMPILER=clang",
                 "-DCMAKE_CXX_COMPILER=clang++",
-                "-DCMAKE_LINKER=lld",
-                "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld",
-                "-DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld",
-                "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld",
             ]
+            if platform.system() != "Darwin":
+                cmake_args += [
+                    "-DCMAKE_LINKER=lld",
+                    "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld",
+                    "-DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld",
+                    "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld",
+                ]
 
         # Note that asan doesn't work with binaries that use the GPU, so this is
         # only useful for tools like triton-opt that don't run code on the GPU.


### PR DESCRIPTION
LLD is not supported on macOS. This addresses failures like

> clang: error: invalid linker name in argument '-fuse-ld=lld'

See https://github.com/triton-lang/triton/actions/runs/11099205977/job/30833066194#step:10:61