### PR TITLE
[Backend] Fix access to empty std::optional in LinearLayout debug code

### DIFF
--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -681,11 +681,11 @@ LinearLayout::divideRight(const LinearLayout &divisor) const {
       std::move(newBases), std::move(newOutDims.takeVector()),
       /*requireSurjective=*/false);
   LDBG("candidate_quotient:" << candidateQuotient);
-  LDBG("*candidate_quotient * divisor=" << *candidateQuotient * divisor);
   if (!candidateQuotient.has_value()) {
     LDBG("candidate quotient failed invariant checks");
     return std::nullopt;
   }
+  LDBG("*candidate_quotient * divisor=" << *candidateQuotient * divisor);
   if (*candidateQuotient * divisor != *this) {
     LDBG("candidate quotient failed invariant checks");
     return std::nullopt;


### PR DESCRIPTION
Moving the access of a `std::optional` after the check if it has a value. This does cause a crash right now when running with `TRITON_ENABLE_LLVM_DEBUG=1` in combination with some test cases.