### PR TITLE
[Interpreter] [Tests] Fix condition in test_dot3d

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3340,7 +3340,7 @@ def test_dot3d(B, num_warps, M, N, K, BLOCK_M, BLOCK_N, in_dtype_str, out_dtype_
         input_precision = "tf32" if is_cuda() and in_dtype_str == 'float32' else "ieee"
 
     if B == 8 and M == 64 and in_dtype_str == "float32" and out_dtype_str == "float32":
-        if triton.runtime.driver.active.utils.get_device_properties(
+        if not is_interpreter() and triton.runtime.driver.active.utils.get_device_properties(
                 torch.cuda.current_device())["max_shared_mem"] < 131072:
             pytest.skip(
                 "Skipping tests with B = 8, M = 64, in_type = float32, out_type = float32 due to insufficient shared memory (less than 128 KB per SM) on this GPU."


### PR DESCRIPTION
This PR fixes condition in test_dot3d that failed on systems without GPU:
If test is run in interpreter mode on system with no GPU, `torch.cuda.current_device()` does not return valid value.