### PR TITLE
[WIP][Performance Remarks] Add a performance warning when sizePerThread = 1

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -97,8 +97,9 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
     }
 
     if (perThread == 1) {
-      op->emitRemark() << "Warning: operation accesses only 1 element per thread. \n"
-      << "Performance may be suboptimal. \n";
+      op->emitRemark()
+          << "Warning: operation accesses only 1 element per thread. \n"
+          << "Performance may be suboptimal. \n";
     }
     SmallVector<unsigned> sizePerThread(refTensorType.getRank(), 1);
     sizePerThread[order[0]] = perThread;

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -95,6 +95,11 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
       perThread = std::min<int>(
           perThread, getNumElementsPerThread(op, order, axisInfoAnalysis));
     }
+
+    if (perThread == 1) {
+      op->emitRemark() << "Warning: operation accesses only 1 element per thread. \n"
+      << "Performance may be suboptimal. \n";
+    }
     SmallVector<unsigned> sizePerThread(refTensorType.getRank(), 1);
     sizePerThread[order[0]] = perThread;
 

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -94,13 +94,15 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
       // cache.
       perThread = std::min<int>(
           perThread, getNumElementsPerThread(op, order, axisInfoAnalysis));
+    } else {
+      // loading 1 element per thread may not utilize the vectorization
+      if (perThread == 1) {
+            op->emitRemark()
+                << "Warning: loading only 1 element per thread. \n"
+                << "Performance may be suboptimal. \n";
+          }
     }
-
-    if (perThread == 1) {
-      op->emitRemark()
-          << "Warning: operation accesses only 1 element per thread. \n"
-          << "Performance may be suboptimal. \n";
-    }
+    
     SmallVector<unsigned> sizePerThread(refTensorType.getRank(), 1);
     sizePerThread[order[0]] = perThread;
 

--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -100,21 +100,17 @@ def test_remark_size_per_thread_equals_one(capfd, fresh_triton_cache):
 
     @triton.jit
     def triton_per_fused_sum(in_ptr0, out_ptr0, XBLOCK: tl.constexpr):
-        xnumel = 8134407
-        rnumel = 33
+        xnumel: tl.constexpr = 8134407
+        rnumel: tl.constexpr = 33
         RBLOCK: tl.constexpr = 64
         xoffset = tl.program_id(0) * XBLOCK
         xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
         xmask = xindex < xnumel
         rindex = tl.arange(0, RBLOCK)[None, :]
         rmask = rindex < rnumel
-        r1 = rindex
-        x0 = xindex
-        tmp0 = tl.load(in_ptr0 + (r1 + (rnumel * x0)), rmask & xmask, other=0.0)
-        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, RBLOCK])
-        tmp3 = tl.where(rmask & xmask, tmp1, 0)
-        tmp4 = tl.sum(tmp3, 1)[:, None]
-        tl.store(out_ptr0 + (x0), tmp4, xmask)
+        tmp0 = tl.load(in_ptr0 + (rindex + (rnumel * xindex)), rmask & xmask, other=0.0)
+        tmp4 = tl.sum(tmp0, 1)[:, None]
+        tl.store(out_ptr0 + (xindex), tmp4, xmask)
 
     with enable_remark_context():
         triton.compile(
@@ -126,5 +122,31 @@ def test_remark_size_per_thread_equals_one(capfd, fresh_triton_cache):
                                       })
 
     _, err = capfd.readouterr()
-    assert ("remark: Warning: operation accesses only 1 element per thread."
+    assert ("remark: Warning: loading only 1 element per thread."
+            in err), "expect performance warning remark:" + err
+
+
+def test_remark_size_per_thread_equals_one_(capfd, fresh_triton_cache):
+
+    @triton.jit
+    def triton_per_fused_sum(in_ptr0, out_ptr0, XBLOCK: tl.constexpr):
+        xnumel: tl.constexpr = 8134408
+        xoffset = tl.program_id(0) * XBLOCK
+        xindex = xoffset + tl.arange(0, XBLOCK)
+        xmask = xindex < xnumel
+        tmp0 = tl.load(in_ptr0 + xindex, xmask, other=0.0)
+        tmp4 = tl.sum(tmp0, 0)
+        tl.store(out_ptr0 + xindex, tmp4, xmask)
+
+    with enable_remark_context():
+        triton.compile(
+            triton.compiler.ASTSource(fn=triton_per_fused_sum, signature={'in_ptr0': '*fp32', 'out_ptr0': '*fp32'},
+                                      constants={'XBLOCK': 128}), options={
+                                          "cluster_dims": (
+                                              63551,  # tl.cdiv(xnumel, XBLOCK)
+                                              1, 1)
+                                      })
+
+    _, err = capfd.readouterr()
+    assert ("remark: Warning: loading only 1 element per thread."
             in err), "expect performance warning remark:" + err

--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -119,8 +119,11 @@ def test_remark_size_per_thread_equals_one(capfd, fresh_triton_cache):
     with enable_remark_context():
         triton.compile(
             triton.compiler.ASTSource(fn=triton_per_fused_sum, signature={'in_ptr0': '*fp32', 'out_ptr0': '*fp32'},
-                                      constants={'XBLOCK': 128}), options={"cluster_dims": (63551, # tl.cdiv(xnumel, XBLOCK)
-                                       1, 1)})
+                                      constants={'XBLOCK': 128}), options={
+                                          "cluster_dims": (
+                                              63551,  # tl.cdiv(xnumel, XBLOCK)
+                                              1, 1)
+                                      })
 
     _, err = capfd.readouterr()
     assert ("remark: Warning: operation accesses only 1 element per thread."

--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -124,6 +124,7 @@ def test_remark_size_per_thread_equals_one(capfd, fresh_triton_cache):
     _, err = capfd.readouterr()
     assert ("remark: Warning: loading only 1 element per thread."
             in err), "expect performance warning remark:" + err
+    assert ("remark: Warning: vectorization fails" in err), "expect vectorization failure remark"
 
 
 def test_remark_size_per_thread_equals_one_(capfd, fresh_triton_cache):

--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -3,6 +3,16 @@ import triton.language as tl
 import os
 import pytest
 import torch
+from contextlib import contextmanager
+
+
+@contextmanager
+def enable_remark_context():
+    try:
+        os.environ['MLIR_ENABLE_REMARK'] = '1'
+        yield
+    finally:
+        os.environ['MLIR_ENABLE_REMARK'] = '0'
 
 
 def is_perf_warning_enabled():
@@ -84,3 +94,33 @@ def test_remark_vectorization(capfd):
     _, err = capfd.readouterr()
     assert ("remark: Warning: vectorization fails" in err), "expect vectorization failure remark"
     os.environ["MLIR_ENABLE_REMARK"] = "0"
+
+def test_remark_size_per_thread_equals_one(capfd, fresh_triton_cache):
+
+    @triton.jit
+    def triton_per_fused_sum(in_ptr0, out_ptr0, XBLOCK : tl.constexpr):
+        xnumel = 8134407
+        rnumel = 33
+        RBLOCK: tl.constexpr = 64
+        xoffset = tl.program_id(0) * XBLOCK
+        xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+        xmask = xindex < xnumel
+        rindex = tl.arange(0, RBLOCK)[None, :]
+        roffset = 0
+        rmask = rindex < rnumel
+        r1 = rindex
+        x0 = xindex
+        tmp0 = tl.load(in_ptr0 + (r1 + (rnumel*x0)), rmask & xmask, other=0.0)
+        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, RBLOCK])
+        tmp3 = tl.where(rmask & xmask, tmp1, 0)
+        tmp4 = tl.sum(tmp3, 1)[:, None]
+        tl.store(out_ptr0 + (x0), tmp4, xmask)
+
+    with enable_remark_context():
+        triton.compile(
+            triton.compiler.ASTSource(fn=triton_per_fused_sum, signature={'in_ptr0': '*fp32', 'out_ptr0': '*fp32'},
+                                      constants={'XBLOCK': 128}), options={"cluster_dims": (63551, 1, 1)})
+
+    _, err = capfd.readouterr()
+    assert ("remark: Warning: operation accesses only 1 element per thread."
+            in err), "expect performance warning remark:" + err


### PR DESCRIPTION
When each thread computes on only one element, the performance is usually suboptimal. This PR adds a remark when such case happens. The concrete remark is inserted during memory coalesce, which is the last step where the layout could be reorganized. 

Related PR: #4689. Some changes from #4689 can be migrated to this PR or vice versa.

Future works should suppress the remark on failing to vectorize, as this remark provides an earlier catch of the potential performance bug.

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] I have not added any `lit` tests.
