### PR TITLE
Fix type hint on Python 3.8

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,7 @@ import json
 from io import BytesIO
 from distutils.command.clean import clean
 from pathlib import Path
-from typing import NamedTuple
+from typing import List, NamedTuple
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
@@ -32,8 +32,8 @@ import pybind11
 @dataclass
 class Backend:
     name: str
-    package_data: list[str]
-    language_package_data: list[str]
+    package_data: List[str]
+    language_package_data: List[str]
     src_dir: str
     backend_dir: str
     language_dir: str

--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -5,7 +5,7 @@ import subprocess
 
 from abc import ABCMeta, abstractmethod, abstractclassmethod
 from dataclasses import dataclass
-from typing import Dict, Union
+from typing import Dict, List, Tuple, Union
 from types import ModuleType
 
 
@@ -146,7 +146,7 @@ class AttrsDescriptor:
         return attrsDescriptor
 
     @staticmethod
-    def from_hints(hints: list[tuple[int, int]]):
+    def from_hints(hints: List[Tuple[int, int]]):
         """
         Create the class from a set of hints that are passed in.
 


### PR DESCRIPTION
Use typing instead on bare Python type to avoid using subscript operation on built-in Python type

Fix "TypeError: 'type' object is not subscriptable" error on Python 3.8

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
