### PR TITLE
Deserialize AttrsDescriptor in ASTSource

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -83,6 +83,8 @@ class ASTSource:
                     raise TypeError("Constants keys must be string")
         if self.attrs is None:
             self.attrs = AttrsDescriptor()
+        elif isinstance(self.attrs, dict):
+            self.attrs = AttrsDescriptor.from_dict(self.attrs)
 
     def hash(self):
         sorted_sig = [v for k, v in sorted(self.signature.items())]


### PR DESCRIPTION
PyTorch Inductor writes the contents of `AttrsDescriptor` into the `@triton.heuristics` block in the generated code. When reading this data structure back in, we need to convert back to `AttrsDescriptor` class since we can no longer create the `AttrsDescriptor` from the `__repr__` string. I used the `from_dict` static method here and `to_dict()` when updating PyTorch Inductor. 

@giuseros does this look ok to you? 