### PR TITLE
[BUILD] Add language extras to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ python/triton/backends/
 !python/triton/backends/compiler.py
 !python/triton/backends/driver.py
 
+# Language extras
+python/triton/language/extra
+
 # Proton
 python/triton/profiler
 


### PR DESCRIPTION
Address an issue caused by https://github.com/triton-lang/triton/commit/53166efa2494764e11734d57de681cc4d2486981 after which we will see extra libraries after building from source each time, such as `python/triton/language/extra/cuda`.