### PR TITLE
[frontend] Pretty-print `ptxas` command on failure

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -359,7 +359,7 @@ class CUDABackend(BaseBackend):
 
                 raise RuntimeError(f'{error}\n'
                                    f'`ptxas` stderr:\n{log}\n'
-                                   f'Repro command: {ptxas_cmd}\n')
+                                   f'Repro command: {" ".join(ptxas_cmd)}\n')
 
             with open(fbin, 'rb') as f:
                 cubin = f.read()


### PR DESCRIPTION
Super quick quality-of-life improvement: on `ptxas` failure we were just dumping the repro command as a list, and joining it before printing makes it much easier to copy-and-paste for debugging.