### PR TITLE
[SWP] Fix a bug in SWP that did not correctly compute the number of loop iterations

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipelineExpander.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipelineExpander.h
@@ -57,6 +57,10 @@ struct PipeliningOption {
   /// pipeliner will have to predicate operations in the the prologue/epilogue.
   bool supportDynamicLoops = false;
 
+  /// The number of stages to use for the pipelining. Generally, it comes from
+  /// ``tt.num_stages``.
+  int numStages = 0;
+
   // Callback to predicate operations when the prologue or epilogue are not
   // peeled. This takes the original operation, an i1 predicate value and the
   // pattern rewriter. It is expected to replace the given operation with

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -1132,6 +1132,7 @@ bool mlir::triton::preProcessLoopAndGetSchedule(
   options.peelEpilogue = false;
   options.predicateFn = tt::predicateOp;
   options.supportDynamicLoops = true;
+  options.numStages = numStages;
   options.annotateFn = [](Operation *op,
                           mlir::triton::PipeliningOption::PipelinerPart part,
                           unsigned iteration) {};

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
@@ -127,7 +127,6 @@ bool LoopPipelinerInternal::initializeLoopInfo(
       // Not defined by a ConstantOp
       return std::nullopt;
     }
-    // return constantOp.getValue().dyn_cast<mlir::IntegerAttr>();
     return mlir::cast<mlir::IntegerAttr>(constantOp.getValue());
   };
   auto upperBoundCst = getIntegerAttrFromValue(ub);


### PR DESCRIPTION
This PR is picked from #4689 for clarity. Prior to this PR, the loop lower and outer bound for `tl.range` was incorrect. Now it correctly casts to the data type that holds the bounds in `tl.range`. Also, prior to this PR, the `maxStage` was set to zero, and we correctly set it to the value come from `num_stages` in `tl.range`.

It is likely that it's directly inherited from the MLIR upstream pipelining algorithm: https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/SCF/Transforms/LoopPipelining.cpp#L110. However, seems Triton uses different data types from the MLIR upstream algorithm.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] I have not added any `lit` tests.