### PR TITLE
Add string representation for AttrsDescriptor

### DIFF
--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -210,6 +210,9 @@ class AttrsDescriptor:
             return "1"
         return "N"
 
+    def __repr__(self):
+        return f"AttrsDescriptor.from_dict({self.to_dict()})"
+
 
 @dataclass(frozen=True)
 class GPUTarget(object):

--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -211,7 +211,7 @@ class AttrsDescriptor:
         return "N"
 
     def __repr__(self):
-        return f"AttrsDescriptor.from_dict({self.to_dict()})"
+        return f"AttrsDescriptor.from_dict({self.to_dict()!r})"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
The string representation allows PyTorch Inductor to serialize/derserialize the `AttrsDescriptor` to the `@triton.heuristics` block in the generated code.