### PR TITLE
Auto import backends in `triton.language.extra`

### DIFF
--- a/python/triton/language/extra/__init__.py
+++ b/python/triton/language/extra/__init__.py
@@ -1,0 +1,26 @@
+import pkgutil
+from importlib.util import module_from_spec
+from sys import modules
+
+_backends = []
+for module_finder, module_name, is_pkg in pkgutil.iter_modules(
+        __path__,
+        prefix=__name__ + ".",
+):
+    # skip .py files (like libdevice.py)
+    if not is_pkg:
+        continue
+
+    # import backends (like cuda and hip) that are included during setup.py
+    spec = module_finder.find_spec(module_name)
+    if spec is None or spec.loader is None:
+        continue
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    _backends.append(module_name)
+    modules[module_name] = module
+
+__all__ = _backends
+
+del _backends


### PR DESCRIPTION
Before 53166efa2494764e11734d57de681cc4d2486981, `importing triton/language/extra/__init__.py` used to import `cuda` and `hip`: https://github.com/triton-lang/triton/commit/53166efa2494764e11734d57de681cc4d2486981#diff-20c816668bef8f6f25f90585e3cf909d86c209cbb2281c49938de1a2e6729c5dL1-L4

After the commit it no longer imports them because submodules in triton.language.extra are moved to /third_party and copied during setup.py. This change breaks code that relies on such behavior:

```python
# Before commit
from triton.language import extra
extra.cuda
>>> <cuda submodule>

# After commit
from triton.language import extra
extra.cuda

>>> Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'triton.language.extra' has no attribute 'cuda'
```

To keep the compatibility, this commit is to dynamically import submodules in `triton.language.extra`.

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is about module structure.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
