### PR TITLE
[Backend] Update scf.if result uses in RewriteTensorPointer pass

### DIFF
--- a/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
@@ -374,9 +374,7 @@ public:
     unsigned oldResIdx = 0, newResIdx = 0;
     while (oldResIdx < results.size()) {
       if (!triton::isTensorPointerType(results[oldResIdx].getType())) {
-        if (opResults.size() > 0) {
-          opResults[oldResIdx].replaceAllUsesWith(newOp.getResult(newResIdx));
-        }
+        opResults[oldResIdx].replaceAllUsesWith(newOp.getResult(newResIdx));
         oldResIdx++;
         newResIdx++;
       } else {

--- a/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
@@ -370,9 +370,13 @@ public:
     }
 
     // update rewritedInfo
+    auto opResults = op.getResults();
     unsigned oldResIdx = 0, newResIdx = 0;
     while (oldResIdx < results.size()) {
       if (!triton::isTensorPointerType(results[oldResIdx].getType())) {
+        if (opResults.size() > 0) {
+          opResults[oldResIdx].replaceAllUsesWith(newOp.getResult(newResIdx));
+        }
         oldResIdx++;
         newResIdx++;
       } else {

--- a/test/Triton/rewrite-tensor-pointer.mlir
+++ b/test/Triton/rewrite-tensor-pointer.mlir
@@ -182,10 +182,10 @@ tt.func public @rewrite_if(%arg0: !tt.ptr<f16>, %arg1: i1, %arg2: tensor<128x32x
 // CHECK: } else {
 // CHECK:   %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<128x32xf16>
 // CHECK:   scf.yield %[[CST]], %[[EXTSI0]], %[[EXTSI1]] : tensor<128x32xf16>, i64, i64
-// CHECK:   %{{.*}} = tt.splat %[[IF]]#1 : i64 -> tensor<128xi64>
-// CHECK:   %{{.*}} = tt.splat %[[IF]]#2 : i64 -> tensor<32xi64>
-// CHECK:   %{{.*}} = arith.addf %[[IF]]#0, %{{.*}} : tensor<128x32xf16>
 // CHECK: }
+// CHECK: %{{.*}} = tt.splat %[[IF]]#1 : i64 -> tensor<128xi64>
+// CHECK: %{{.*}} = tt.splat %[[IF]]#2 : i64 -> tensor<32xi64>
+// CHECK: %{{.*}} = arith.addf %[[IF]]#0, %{{.*}} : tensor<128x32xf16>
 
 
 // -----


### PR DESCRIPTION
I ran into an error in the RewriteTensorPointer pass when testing the HSTU kernel. In my IR, there's an scf.if that produces a non-pointer result. The rewriteIfOp() created a new scf.if, but the use of scf.if result is still referencing the old one, which caused a compile error. In this patch, I updated all uses of scf.if with the results of the new if-op.