### PR TITLE
[AMD] Add a tt.pointer_range_32 specialization

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -593,9 +593,9 @@ def test_within_2gb(device, fresh_triton_cache) -> None:
     # In warmup we assume that the pointer range is 32 bits
     kernel_add.warmup(torch.float32, grid=(1, ))
     assert pointer_range_32 == [0]
-    # Torch tensor bigger than 2GB
+    # Torch tensor > 2GB
     kernel_add[(1, 0)](torch.empty(2**31, dtype=torch.int8, device=device))
     assert len(pointer_range_32) == 0
-    # Torch tensor smaller than 2GB
-    kernel_add[(1, 0)](torch.empty(2**30, dtype=torch.int8, device=device))
+    # Torch tensor <= 2GB
+    kernel_add[(1, 0)](torch.empty(2**31 - 1, dtype=torch.int8, device=device))
     assert pointer_range_32 == [0]

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -9,6 +9,7 @@ import torch
 import triton
 import triton.language as tl
 from triton.runtime.jit import JITFunction
+from triton._internal_testing import is_hip
 
 
 @triton.jit
@@ -572,3 +573,29 @@ def test_hooks(device, fresh_triton_cache) -> None:
     assert specialization_data is not None and specialization_data_compiled == specialization_data
     assert is_warmup is True
     assert key in kernel_add.cache[getattr(torch, device).current_device()]
+
+
+@pytest.mark.skipif(reason="within_2g is a HIP specific optimization", condition=not is_hip())
+def test_within_2gb(device, fresh_triton_cache) -> None:
+
+    @triton.jit
+    def kernel_add(a):
+        tl.load(a)
+
+    # This is the attribute we want to test
+    pointer_range_32 = None
+
+    def cache_hook(*args, **kwargs):
+        nonlocal pointer_range_32
+        pointer_range_32 = kwargs["compile"]["configs"][0].pointer_range_32
+
+    JITFunction.cache_hook = cache_hook
+    # In warmup we assume that the pointer range is 32 bits
+    kernel_add.warmup(torch.float32, grid=(1, ))
+    assert pointer_range_32 == [0]
+    # Torch tensor bigger than 2GB
+    kernel_add[(1, 0)](torch.empty(2**31, dtype=torch.int8, device=device))
+    assert len(pointer_range_32) == 0
+    # Torch tensor smaller than 2GB
+    kernel_add[(1, 0)](torch.empty(2**30, dtype=torch.int8, device=device))
+    assert pointer_range_32 == [0]

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -879,6 +879,10 @@ class MockTensor:
     def data_ptr():
         return 0  # optimistically assumes multiple of 16
 
+    @staticmethod
+    def ptr_range():
+        return 0  # optimistically assumes 32 bit pointer range
+
 
 class TensorWrapper:
 

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -6,7 +6,6 @@ from types import ModuleType
 import hashlib
 import tempfile
 import os
-import sys
 import re
 import subprocess
 import functools
@@ -100,7 +99,7 @@ class HIPAttrsDescriptor(AttrsDescriptor):
             return arg.ptr_range() <= 2**31 - 1
         if "torch.Tensor" in str(type(arg)) and hasattr(arg, "untyped_storage"):
             # Please note that 2**31-1 is the max int32 positive limit
-            return sys.getsizeof(arg.untyped_storage()) <= 2**31 - 1
+            return arg.untyped_storage().size() <= 2**31 - 1
         return False
 
     @staticmethod


### PR DESCRIPTION
This is a PR stemming from #4716 . I am adding an attribute in the HIP backend to test for a tensor storage to be within 2GB. This will enable support of buffer operations. 
