### PR TITLE
Fix order

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -37,6 +37,11 @@ bool isLoadFromTensorPtr(triton::LoadOp op);
 // order (so that result[i] is the index of the i-th largest element of 'arr')
 SmallVector<unsigned, 4> argSort(const SmallVector<int64_t> &arr);
 
+// Gets the order of a tensor from its contiguity. Places the dimensions the largest
+// contiguity as the inner most dimension. If the contiguity is all ones, returns the
+// order {dim - 1, dim - 2, ..., 0}
+SmallVector<unsigned, 4> getOrderFromContiguity(const SmallVector<int64_t> &contiguity);
+
 // Return the operand used to access the memory in the operation
 Value getMemAccessPtr(Operation *op);
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -37,10 +37,11 @@ bool isLoadFromTensorPtr(triton::LoadOp op);
 // order (so that result[i] is the index of the i-th largest element of 'arr')
 SmallVector<unsigned, 4> argSort(const SmallVector<int64_t> &arr);
 
-// Gets the order of a tensor from its contiguity. Places the dimensions the largest
-// contiguity as the inner most dimension. If the contiguity is all ones, returns the
-// order {dim - 1, dim - 2, ..., 0}
-SmallVector<unsigned, 4> getOrderFromContiguity(const SmallVector<int64_t> &contiguity);
+// Gets the order of a tensor from its contiguity. Places the dimensions the
+// largest contiguity as the inner most dimension. If the contiguity is all
+// ones, returns the order {dim - 1, dim - 2, ..., 0}
+SmallVector<unsigned, 4>
+getOrderFromContiguity(const SmallVector<int64_t> &contiguity);
 
 // Return the operand used to access the memory in the operation
 Value getMemAccessPtr(Operation *op);

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -38,7 +38,7 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
     });
 
     auto contiguity = axisInfoAnalysis.getAxisInfo(ptr)->getContiguity();
-    SmallVector<unsigned> order = argSort(contiguity);
+    SmallVector<unsigned> order = getOrderFromContiguity(contiguity);
     LDBG("order=[" << triton::join(order, ", ") << "]");
 
     auto matchesShape = [&refTensorType](const Value &val) {
@@ -56,7 +56,7 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
         if (!val || !matchesShape(val) || memAccessesSameOrder.contains(use))
           continue;
         auto currOrder =
-            argSort(axisInfoAnalysis.getAxisInfo(val)->getContiguity());
+            getOrderFromContiguity(axisInfoAnalysis.getAxisInfo(val)->getContiguity());
         if (order == currOrder) {
           LDBG("multi-root-slice: insert to memAccessesSameOrder " << *use);
           memAccessesSameOrder.insert(use);

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -55,8 +55,8 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
         Value val = getMemAccessPtr(use);
         if (!val || !matchesShape(val) || memAccessesSameOrder.contains(use))
           continue;
-        auto currOrder =
-            getOrderFromContiguity(axisInfoAnalysis.getAxisInfo(val)->getContiguity());
+        auto currOrder = getOrderFromContiguity(
+            axisInfoAnalysis.getAxisInfo(val)->getContiguity());
         if (order == currOrder) {
           LDBG("multi-root-slice: insert to memAccessesSameOrder " << *use);
           memAccessesSameOrder.insert(use);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -268,7 +268,7 @@ getBlockedEncoding(tt::LoadOp loadOp, tt::ModuleAxisInfoAnalysis &axisInfo) {
   int threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
   tt::AxisInfo::DimVectorT contiguity =
       axisInfo.getAxisInfo(src)->getContiguity();
-  SmallVector<unsigned> order = argSort(contiguity);
+  SmallVector<unsigned> order = getOrderFromContiguity(contiguity);
   unsigned currPerThread = getNumElementsPerThread(loadOp, order, axisInfo);
   SmallVector<unsigned> sizePerThread(order.size(), 1);
   sizePerThread[order[0]] = currPerThread;

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -86,7 +86,8 @@ SmallVector<unsigned, 4> argSort(const SmallVector<int64_t> &arr) {
   return ret;
 }
 
-SmallVector<unsigned, 4> getOrderFromContiguity(const SmallVector<int64_t> &arr) {
+SmallVector<unsigned, 4>
+getOrderFromContiguity(const SmallVector<int64_t> &arr) {
   SmallVector<unsigned, 4> ret(arr.size());
   std::iota(ret.begin(), ret.end(), 0);
   std::reverse(ret.begin(), ret.end());

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -86,6 +86,15 @@ SmallVector<unsigned, 4> argSort(const SmallVector<int64_t> &arr) {
   return ret;
 }
 
+SmallVector<unsigned, 4> getOrderFromContiguity(const SmallVector<int64_t> &arr) {
+  SmallVector<unsigned, 4> ret(arr.size());
+  std::iota(ret.begin(), ret.end(), 0);
+  std::reverse(ret.begin(), ret.end());
+  std::stable_sort(ret.begin(), ret.end(),
+                   [&](unsigned x, unsigned y) { return arr[x] > arr[y]; });
+  return ret;
+}
+
 Value getMemAccessPtr(Operation *op) {
   if (auto ld = dyn_cast<triton::LoadOp>(op))
     return ld.getPtr();


### PR DESCRIPTION
Makes the default order from contiguity row-major. It used to be tranposed by default, which could lead to some unnecessary convert layouts in the final TTGIR if the contiguity in all dimensions was equal.

Adds a new `getOrderFromContiguity` function to handle the default case differently, since the order reversal would be surprising from a call to `argsort`.

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
