### PR TITLE
[CI] Run CI on all PRs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,7 @@ name: Integration Tests
 on:
   workflow_dispatch:
   pull_request:
+    branches-ignore: ['llvm-**']
   merge_group:
     branches: [main, 'dev-**']
     types: [checks_requested]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,8 +10,6 @@ name: Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    # You can name your branch dev-foo to get CI runs.
-    branches: [main, 'dev-**']
   merge_group:
     branches: [main, 'dev-**']
     types: [checks_requested]

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -9,6 +9,7 @@ name: Integration Tests
 on:
   workflow_dispatch:
   pull_request:
+    branches-ignore: ['llvm-**']
   merge_group:
     branches: [main, 'dev-**']
     types: [checks_requested]

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -9,8 +9,6 @@ name: Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    # You can name your branch dev-foo to get CI runs.
-    branches: [main, 'dev-**']
   merge_group:
     branches: [main, 'dev-**']
     types: [checks_requested]


### PR DESCRIPTION
Currently PRs only get CI when the base branch is main or starts with `dev-` but this changes it to run on all PRs which works better for when using `git-pr-chain` where the base branch usually isn't main.

