### PR TITLE
[frontend] Remove Complex Regex for MLIR Parsing

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -492,13 +492,13 @@ void init_triton_ir(py::module &&m) {
            })
       .def("get_first_func_name",
            [](ModuleOp &self) -> std::string {
-              std::string str;
-              for (auto &op : self.getOps()) {
-                if (auto func = dyn_cast<FuncOp>(op)) {
-                  return func.getName().str();
-                }
-              }
-              return str;
+             std::string str;
+             for (auto &op : self.getOps()) {
+               if (auto func = dyn_cast<FuncOp>(op)) {
+                 return func.getName().str();
+               }
+             }
+             return str;
            })
       .def("has_function",
            [](ModuleOp &self, std::string &funcName) -> bool {
@@ -517,46 +517,46 @@ void init_triton_ir(py::module &&m) {
 
       .def("get_function_signature",
            [](ModuleOp &self, FuncOp &func) -> std::vector<std::string> {
-              std::vector<std::string> strVec;
+             std::vector<std::string> strVec;
 
-              auto findTMA = [](ArrayRef<NamedAttribute> dictVals) {
-                for (auto attr : dictVals) {
-                  if (auto intAttr = dyn_cast<IntegerAttr>(attr.getValue())) {
-                    if (intAttr.getInt() == 1)
-                      return true;
-                  }
-                }
-                return false;
-              };
+             auto findTMA = [](ArrayRef<NamedAttribute> dictVals) {
+               for (auto attr : dictVals) {
+                 if (auto intAttr = dyn_cast<IntegerAttr>(attr.getValue())) {
+                   if (intAttr.getInt() == 1)
+                     return true;
+                 }
+               }
+               return false;
+             };
 
-              auto type = func.getFunctionType();
-              unsigned numArgs = type.getNumInputs();
-              for (unsigned i = 0; i != numArgs; ++i) {
-                std::string tempType;
-                llvm::raw_string_ostream os(tempType);
+             auto type = func.getFunctionType();
+             unsigned numArgs = type.getNumInputs();
+             for (unsigned i = 0; i != numArgs; ++i) {
+               std::string tempType;
+               llvm::raw_string_ostream os(tempType);
 
-                auto ty = type.getInput(i);
-                if (auto attributes = func.getCallableArgAttrs()) {
-                  Attribute attr = attributes[i];
-                  // Check for tt.nv_tma_desc = 1
-                  if (auto dAttr = dyn_cast<DictionaryAttr>(attr)) {
-                    ArrayRef<NamedAttribute> dictVals = dAttr.getValue();
-                    if (findTMA(dictVals)) {
-                      strVec.push_back("nvTmaDesc");
-                      continue;
-                    }
-                  }
-                }
-                if (auto ptrType = dyn_cast<PointerType>(ty)) {
-                  auto pType = ptrType.getPointeeType();
-                  os << "*";
-                  pType.print(os);
-                } else {
-                  ty.print(os);
-                }
-                strVec.push_back(tempType);
-              }
-              return strVec;
+               auto ty = type.getInput(i);
+               if (auto attributes = func.getCallableArgAttrs()) {
+                 Attribute attr = attributes[i];
+                 // Check for tt.nv_tma_desc = 1
+                 if (auto dAttr = dyn_cast<DictionaryAttr>(attr)) {
+                   ArrayRef<NamedAttribute> dictVals = dAttr.getValue();
+                   if (findTMA(dictVals)) {
+                     strVec.push_back("nvTmaDesc");
+                     continue;
+                   }
+                 }
+               }
+               if (auto ptrType = dyn_cast<PointerType>(ty)) {
+                 auto pType = ptrType.getPointeeType();
+                 os << "*";
+                 pType.print(os);
+               } else {
+                 ty.print(os);
+               }
+               strVec.push_back(tempType);
+             }
+             return strVec;
            })
       .def("get_int_attr",
            [](ModuleOp &self, std::string name) -> py::object {

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -1,10 +1,12 @@
 import multiprocessing
 import shutil
+import tempfile
 
 import triton
 import triton.language as tl
 from triton.backends.compiler import AttrsDescriptor
-from triton.compiler import ASTSource
+from triton.compiler import ASTSource, IRSource
+from triton._C.libtriton import ir
 
 target = triton.runtime.driver.active.get_current_target()
 
@@ -104,3 +106,53 @@ def test_compile_in_forked_subproc_with_forced_gc(fresh_triton_cache) -> None:
     if old_gc_state:
         gc.enable()
     assert proc.exitcode == 0
+
+
+def test_mlir_attribute_parsing() -> None:
+    '''
+    Tests that MLIR attributes are parsed correctly from input ttir/ttgir.
+
+    Checks for the following:
+    1. Name and type signature are parsed correctly
+    2. _get_num_warps_from_ir_str() works
+    3. tt.nv_tma_desc attribute is parsed correctly
+    '''
+
+    sample_ttgir = r"""
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>
+#shared = #triton_gpu.shared<{vec = 4, perPhase = 2, maxPhase = 4, order = [1, 0], hasLeadingOffset = false}>
+#shared1 = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [1, 0], hasLeadingOffset = false}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 8 : i32, triton_gpu.target = "cuda:80", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                                %arg3: i32 {tt.divisibility = 16 : i32},
+                                %arg4: i32 {tt.divisibility = 16 : i32},
+                                %arg5: i32 {tt.divisibility = 16 : i32},
+                                %arg6: i32 {tt.divisibility = 16 : i32},
+                                %arg7: i32 {tt.divisibility = 16 : i32},
+                                %arg8: i32 {tt.divisibility = 16 : i32},
+                                %desc: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}) attributes {noinline = false} {
+    tt.return
+  }
+}
+"""
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.ttgir') as f:
+        f.write(sample_ttgir)
+        f.flush()
+        context = ir.context()
+        ir.load_dialects(context)
+        src = IRSource(f.name, context)
+
+        # check name and type signature
+        # should match ty_to_cpp(...)
+        assert  src.signature == \
+                    {0: "*f32", 1: "*f32", 2: "*f32", 3: "i32", \
+                           4: "i32", 5: "i32", 6: "i32", 7: "i32", 8: "i32", 9: "nvTmaDesc"}
+        assert src.name == "@matmul_kernel"
+
+        # check num warps
+        assert src.parse_options()['num_warps'] == 8

--- a/python/triton/compiler/__init__.py
+++ b/python/triton/compiler/__init__.py
@@ -1,4 +1,4 @@
-from .compiler import CompiledKernel, ASTSource, compile, make_backend, LazyDict
+from .compiler import CompiledKernel, ASTSource, IRSource, compile, make_backend, LazyDict
 from .errors import CompilationError
 
-__all__ = ["compile", "make_backend", "ASTSource", "AttrsDescriptor", "CompiledKernel", "CompilationError", "LazyDict"]
+__all__ = ["compile", "make_backend", "ASTSource", "IRSource", "AttrsDescriptor", "CompiledKernel", "CompilationError", "LazyDict"]

--- a/python/triton/compiler/__init__.py
+++ b/python/triton/compiler/__init__.py
@@ -1,4 +1,7 @@
 from .compiler import CompiledKernel, ASTSource, IRSource, compile, make_backend, LazyDict
 from .errors import CompilationError
 
-__all__ = ["compile", "make_backend", "ASTSource", "IRSource", "AttrsDescriptor", "CompiledKernel", "CompilationError", "LazyDict"]
+__all__ = [
+    "compile", "make_backend", "ASTSource", "IRSource", "AttrsDescriptor", "CompiledKernel", "CompilationError",
+    "LazyDict"
+]

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -106,34 +106,23 @@ class ASTSource:
 
 class IRSource:
 
-    def __init__(self, path):
+    def __init__(self, path, context):
         self.path = path
         path = Path(path)
         self.ext = path.suffix[1:]
         self.src = path.read_text()
-        print ("IRSource.__init__(...)", self.ext, flush=True)
         match = re.search(prototype_pattern[self.ext], self.src, re.MULTILINE)
-        self.name = match.group(1)
-        context = ir.context()
-        ir.load_dialects(context)
         module = ir.parse_mlir_module(self.path, context)
-        #print (module)
         fn_name = module.get_first_func_name()
-        print (fn_name)
-        funcop = module.get_function(fn_name)
-        func_ty = module.get_function_signature(funcop)
-        print (func_ty)
-        signature = match.group(2)
-        print ("signature", signature)
-        types = re.findall(arg_type_pattern[self.ext], signature)
-        print (types)
-        self.signature = {k: convert_type_repr(ty) for k, ty in enumerate(types)}
+        self.name = "@" + fn_name
+        funcOp = module.get_function(fn_name)
+        func_ty = module.get_function_signature(funcOp)
+        self.signature = {k: ty for k, ty in enumerate(func_ty)}
 
     def hash(self):
         return hashlib.sha256(self.src.encode("utf-8")).hexdigest()
 
     def make_ir(self, options, codegen_fns, module_map, context):
-        print ("IRSource.make_ir(...)", flush=True)
         module = ir.parse_mlir_module(self.path, context)
         module.context = context
 
@@ -237,8 +226,10 @@ def compile(src, target=None, options=None):
     # create backend
     if ir_source:
         assert isinstance(src, str), "source must be either AST or a filepath"
-        print ("compile(...)")
-        src = IRSource(src)
+        # Do an early init, since we use the MLIR parser which needs the context
+        context = ir.context()
+        ir.load_dialects(context)
+        src = IRSource(src, context)
 
     extra_options = src.parse_options()
     options = backend.parse_options(dict(options or dict(), **extra_options))
@@ -263,8 +254,6 @@ def compile(src, target=None, options=None):
     metadata_path = metadata_group.get(metadata_filename)
     always_compile = os.environ.get("TRITON_ALWAYS_COMPILE", "0") == "1"
     if not always_compile and metadata_path is not None:
-        print ("src cache hit", ir_source == True)
-
         # cache hit!
         metadata = json.loads(Path(metadata_path).read_text())
         return CompiledKernel(src, metadata_group, hash)
@@ -282,17 +271,17 @@ def compile(src, target=None, options=None):
     # when the source is an IR file, don't apply the passes related to this stage. This makes it easier to write IR level tests.
     if ir_source:
         first_stage += 1
-    context = ir.context()
-    ir.load_dialects(context)
+
+    # We initialize these
+    if not ir_source:
+        context = ir.context()
+        ir.load_dialects(context)
     backend.load_dialects(context)
     codegen_fns = backend.get_codegen_implementation()
     module_map = backend.get_module_map()
     try:
-        print ("src.make_ir(...)", type(src), src.ext, ir_source == True)
         module = src.make_ir(options, codegen_fns, module_map, context)
-        print ("src.make_ir(...) finished")
     except Exception as e:
-        print ("exception in src.make_ir(...)", flush=True)
         filter_traceback(e)
         raise
     use_ir_loc = os.environ.get("USE_IR_LOC", None)

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -34,6 +34,7 @@ arg_type_pattern = {
     "ptx": ptx_arg_type_pattern,
 }
 
+
 def convert_type_repr(x):
     # Currently we only capture the pointer type and assume the pointer is on global memory.
     # TODO: Capture and support shared memory space
@@ -45,6 +46,7 @@ def convert_type_repr(x):
     if match is not None:
         return '*' + convert_type_repr(match.group(1))
     return x
+
 
 class ASTSource:
 


### PR DESCRIPTION
There were a number of complex regexes used for parsing MLIR in the python frontend. For maintainability reasons, it is likely better to just expose the MLIR bindings to python and use those instead.

The PTX regex is left in place because we don't have an easy way to parse PTX (for now).

========================================================================
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [ x] I am not making a trivial change, such as fixing a typo in a comment.

- [ x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
