### PR TITLE
Added an option to dump IR to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ For detailed instructions on how to debug Triton's frontend, please refer to thi
 - `LLVM_ENABLE_TIMING` dumps the timing information for each LLVM pass.
 - `TRITON_DEFAULT_FP_FUSION` overrides the default behavior of allowing fp fusion (mul+add->fma).
 - `MLIR_ENABLE_REMARK` enables the performance warnings that are emitted as remarks.
+- `MLIR_DUMP_DIR` dumps the IR before and after every MLIR pass Triton runs, for all kernels, into files in the given directory. Works independently of `MLIR_ENABLE_DUMP`.
 
 # Changelog
 

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1629,6 +1629,25 @@ void init_triton_ir(py::module &&m) {
                    printingFlags);
              }
            })
+      .def("enable_debug_to_file_tree",
+           [](PassManager &self, const std::string &dumpPath) {
+             auto *context = self.getContext();
+               context->disableMultithreading();
+               auto printingFlags = OpPrintingFlags();
+               printingFlags.elideLargeElementsAttrs(16);
+               printingFlags.enableDebugInfo();
+               auto printAlways = [](Pass *, Operation *op) -> bool {
+                 return true;
+               };
+                self.enableIRPrintingToFileTree(
+                  /*shouldPrintBeforePass=*/printAlways,
+                  /*shouldPrintAfterPass=*/printAlways,
+                  /*printModuleScope=*/true,
+                  /*printAfterOnlyOnChange=*/false,
+                  /*printAfterOnlyOnFailure*/ false,
+                  /*printTreeDir*/ dumpPath,
+                  /*OpPrintingFlags*/ printingFlags);
+           })
       .def("run", [](PassManager &self, ModuleOp &mod) {
         // TODO: maybe dump module to file and print error for better
         // diagnostics


### PR DESCRIPTION
It's hard to read and compare IR after passes using the terminal. This PR adds a way to dump the IR before and after each pass to its own file. And now the IRs can be compared using file diff