### PR TITLE
[BUILD] Add instrumentation libs to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ python/triton/language/extra
 # Proton
 python/triton/profiler
 
+# Instrumentation
+python/triton/instrumentation
+
 # Python caches
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Otherwise, we may include `libGPUInstrumentationTestLib.so` into the commit 