### PR TITLE
[NFC] Add `#include <string>` into `TritonToTritonGPUPass.h`

### DIFF
--- a/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
+++ b/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 
 namespace mlir {
 


### PR DESCRIPTION
This makes the dependence more obvious since `const std::string &target` is used in this file.