### PR TITLE
Pipeline scale_dot

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -404,6 +404,22 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
         }
         return true;
       }
+      if (auto dotOperand = dyn_cast<DotOperandEncodingAttr>(layout)) {
+        if (auto nvidiaMma =
+                dyn_cast<NvidiaMmaEncodingAttr>(dotOperand.getParent())) {
+          if (product(getCTAsPerCGA(nvidiaMma)) > 1) {
+            return false;
+          }
+          if (useLegacyMMAConversion) {
+            return false;
+          }
+          // FIXME [Dot LL]
+          // Enabling LL path for buggy kWidth path
+          bool largeKWidth =
+              dotOperand.getKWidth() * dstTy.getElementTypeBitWidth() > 64;
+          return largeKWidth && nvidiaMma.isAmpere();
+        }
+      }
       if (isa<BlockedEncodingAttr>(layout)) {
         return true;
       }
@@ -458,6 +474,22 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
       } else if (isPtr) {
         outVals[it.index()] = inttoptr(llvmElemTyOrig, it.value());
       }
+    }
+
+    // FIXME [Dot LL]
+    // We know it's just for largeKWidth case in Ampere
+    // In this case, we need to pack the outputs into i32
+    if (isa<DotOperandEncodingAttr>(dstTy.getEncoding())) {
+      auto concat = [&](Value a, Value b) {
+        return or_(zext(i32_ty, bitcast(a, i16_ty)),
+                   shl(zext(i32_ty, bitcast(b, i16_ty)), i32_val(16)));
+      };
+
+      SmallVector<Value> outVals32(outVals.size() / 2);
+      for (int i = 0; i < outVals32.size(); ++i) {
+        outVals32[i] = concat(outVals[2 * i], outVals[2 * i + 1]);
+      }
+      outVals = outVals32;
     }
 
     Value result = packLLElements(loc, getTypeConverter(), outVals, rewriter,

--- a/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -90,16 +90,6 @@ void decomposeBlockedToDotLayoutConversion(ModuleOp module) {
     auto dstDotOp =
         dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
     if (srcBlocked && dstDotOp) {
-      // FIXME [Dot LL]
-      // We support this one via LLs, as the LocalLoad path is buggy
-      if (auto mma = dyn_cast<NvidiaMmaEncodingAttr>(dstDotOp.getParent())) {
-        bool largeKWidth =
-            dstDotOp.getKWidth() * dstType.getElementTypeBitWidth() > 64;
-        if (mma.isAmpere() && largeKWidth) {
-          return;
-        }
-      }
-
       Attribute sharedMemorySpace =
           triton::gpu::SharedMemorySpaceAttr::get(srcType.getContext());
       auto tmpType = MemDescType::get(

--- a/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
@@ -44,13 +44,6 @@ public:
         return;
       if (!cvtNeedsSharedMemory(srcType, dstType))
         return;
-      // FIXME [Dot LL]
-      // We support this one via LLs, as the LocalLoad path is buggy
-      bool largeKWidth =
-          dstDotOp.getKWidth() * dstType.getElementTypeBitWidth() > 64;
-      if (largeKWidth) {
-        return;
-      }
       auto srcOrder = triton::gpu::getOrder(srcEncoding);
       auto rank = srcOrder.size();
       SmallVector<unsigned> sharedOrder;

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3315,16 +3315,12 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
             assert 'wgmma.mma_async.sync.aligned.m64n128k32.f32.e4m3.e4m3' in ptx
 
 
-@pytest.mark.parametrize("M, N, K, col_a, col_b, type_a, type_b, num_warps", [
-    (M, N, K, col_a, col_b, type_a, type_b, 4)
-    for M, N, K in itertools.product([32, 64, 128], [32, 64, 128], [64, 128])
-    for col_a, col_b in itertools.product([True, False], repeat=2)
-    # We don't test e5m2 as its range + the uniform sampling overflows easily
-    # Tested locally and it works fine other than for ~10 entries out of 10_000
-    # which are of the size of 10**30
-    for type_a in ["e2m1", "e4m3"]
-    for type_b in ["e4m3"]
-])
+@pytest.mark.parametrize("M, N, K, col_a, col_b, type_a, type_b, num_warps",
+                         [(M, N, K, col_a, col_b, type_a, type_b, 4)
+                          for M, N, K in itertools.product([32, 64, 128], [32, 64, 128], [64, 128])
+                          for col_a, col_b in itertools.product([True, False], repeat=2)
+                          for type_a in ["e2m1", "e4m3", "e5m2"]
+                          for type_b in ["e4m3", "e5m2"]])
 def test_scaled_dot(M, N, K, col_a, col_b, type_a, type_b, num_warps, device):
     if not is_cuda():
         pytest.skip("scaled_dot only supported on CUDA")
@@ -3355,7 +3351,7 @@ def test_scaled_dot(M, N, K, col_a, col_b, type_a, type_b, num_warps, device):
         a_scale = tl.load(scale_a_ptr)
         c = tl.dot_scaled(a, a_scale, type_a, b, None, type_b)
         out_ptr = out + tl.arange(0, BLOCK_M)[:, None] * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
-        tl.store(out_ptr, c)
+        tl.store(out_ptr, c.to(tl.bfloat16))
 
     @triton.jit
     def mxfp_to_bf16_kernel(
@@ -3431,7 +3427,6 @@ def test_scaled_dot(M, N, K, col_a, col_b, type_a, type_b, num_warps, device):
         type_fp8_y = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}[type_y]
 
         comp_dtype = torch.bfloat16
-        out_dtype = torch.float32
 
         x = x.contiguous()
         x_upcast = x.new_empty(scale.shape[:-1] + (32 * scale.shape[-1], ), dtype=comp_dtype)
@@ -3440,16 +3435,28 @@ def test_scaled_dot(M, N, K, col_a, col_b, type_a, type_b, num_warps, device):
         BLOCK_SIZE = 512
         grid = ((N + BLOCK_SIZE - 1) // BLOCK_SIZE, )
         mxfp_to_bf16_kernel[grid](x, scale, x_upcast, scale.numel(), e_bits, m_bits, BLOCK_SIZE, num_warps=num_warps)
+        assert x_upcast.isfinite().all()
 
         y_upcast = y.view(type_fp8_y).to(comp_dtype)
-        return torch.matmul(x_upcast.to(out_dtype), y_upcast.to(out_dtype))
+
+        class AccumulateInFp32:
+
+            def __enter__(self):
+                self.prev_value = torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
+                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = self.prev_value
+
+        with AccumulateInFp32():
+            return torch.matmul(x_upcast.to(comp_dtype), y_upcast.to(comp_dtype))
 
     torch.manual_seed(0)
 
-    def create_uint8(shape, col_major=False):
+    def create_uint8(shape, col_major=False, max_val=255):
         if col_major:
             shape = shape[:-2] + (shape[-1], shape[-2])
-        ret = torch.randint(1 << 8, shape, dtype=torch.uint8, device=device)
+        ret = torch.randint(max_val + 1, shape, dtype=torch.uint8, device=device)
         if col_major:
             ret = ret.mT
         return ret
@@ -3457,25 +3464,36 @@ def test_scaled_dot(M, N, K, col_a, col_b, type_a, type_b, num_warps, device):
     DIV_FACTOR = 2 if type_a == "e2m1" else 1
     x = create_uint8((M, K // DIV_FACTOR), col_major=col_a)
     y = create_uint8((K, N), col_major=col_b)
-    scale_x = create_uint8((M, K // 32))
 
-    z = x.new_empty((M, N), dtype=torch.float32)
+    # sample scales that don't overflow as otherwise it's implementation defined (underflowing is alright)
+    # We substract a reasonably high number (64) so that the sum of all the mxfp elements does not overflow
+    m_bytes = int(type_a[1])
+    bias_type_a = 1 << (m_bytes - 1) - 1
+    max_exponent_type_a = (1 << m_bytes) - 1 - bias_type_a
+    scale_x = create_uint8((M, K // 32), max_val=255 - max_exponent_type_a - 64)
+
+    def make_finite(x, dtype):
+        # e5m2 has too many non-finite values when sampled uniformly (1 / 32) and
+        # Fp8E5M2_to_Bf16 doesn't preserve NaNs (fixme)
+        if dtype not in ("e5m2", "e4m3"):
+            return x
+        mask = 0x7C if dtype == "e5m2" else 0x7F
+        finite = torch.arange(x.numel(), device=device, dtype=torch.uint8).reshape_as(x) % mask
+        x_finite = torch.where(x & mask == mask, finite | (0x80 & x), x)
+        x.copy_(x_finite)
+        return x
+
+    x = make_finite(x, type_a)
+    y = make_finite(y, type_b)
+
+    z = x.new_empty((M, N), dtype=torch.bfloat16)
     pgm = dot_scale_kernel[(1, )](x, *x.stride(), scale_x, y, *y.stride(), z, M, N, K, type_a, type_b,
                                   num_warps=num_warps)
 
     z_ref = dot_scale_ref(x, scale_x, y, type_a, type_b)
 
-    # dot_scale_ref computes the result in higher precision
-    # so we equalise all the non-finite values
-    # This also fixes a bug in our upcasting from e5m2 to bf16 where inf is not preserved
-    non_finite_z = ~z.isfinite()
-    z_ref[non_finite_z] = z[non_finite_z]
-    non_finite_ref = ~z_ref.isfinite()
-    z[non_finite_ref] = z_ref[non_finite_ref]
-
-    # generous rtol set because the ref is more precise than the fused
-    # (computes in higher dtype) and we are sampling the whole range of floats
-    torch.testing.assert_close(z, z_ref, equal_nan=True, atol=1e-5, rtol=1e-2)
+    # generous rtol as we are sampling the whole range of floats
+    torch.testing.assert_close(z, z_ref, atol=1e-5, rtol=1e-2)
 
     # make sure ld/st are vectorized
     ptx = pgm.asm['ptx']

--- a/python/test/unit/language/test_pipeliner.py
+++ b/python/test/unit/language/test_pipeliner.py
@@ -11,7 +11,7 @@ def is_cuda():
     return triton.runtime.driver.active.get_current_target().backend == "cuda"
 
 
-def is_cuda_tma_available():
+def is_hopper():
     return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
 
 
@@ -33,32 +33,51 @@ def check_capabilities():
 
 @triton.jit
 def matmul_kernel(  #
-        a_ptr, b_ptr, output_ptr,  #
+        a_ptr, scale_ptr, b_ptr, output_ptr,  #
         M, N, K,  #
         stride_am, stride_ak,  #
+        stride_sm, stride_sk,  #
         stride_bk, stride_bn,  #
         stride_cm, stride_cn,  #
         BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,  #
-        NUM_STAGES: tl.constexpr):
+        NUM_STAGES: tl.constexpr, a_type: tl.constexpr, b_type: tl.constexpr):
     pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_M)
     pid_m = pid % num_pid_m
     pid_n = pid // num_pid_m
     offs_am = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)) % M
     offs_bn = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)) % N
+    IS_SCALED: tl.constexpr = a_type is not None and b_type is not None
+    DIV_FACTOR: tl.constexpr = 2 if IS_SCALED and a_type == "e2m1" else 1
+    KA: tl.constexpr = BLOCK_K // DIV_FACTOR
+    BLOCK_AK: tl.constexpr = BLOCK_K // DIV_FACTOR
     offs_k = tl.arange(0, BLOCK_K)
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    offs_ak = tl.arange(0, BLOCK_AK)
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak)
     b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    if IS_SCALED:
+        BLOCK_SK: tl.constexpr = BLOCK_K // 32
+        offs_sk = tl.arange(0, BLOCK_SK)
+        scale_ptrs = scale_ptr + (offs_am[:, None] * stride_sm + offs_sk[None, :] * stride_sk)
     accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
     for k in tl.range(0, tl.cdiv(K, BLOCK_K), num_stages=NUM_STAGES):
-        mask_a = (offs_am[:, None] < M) & (offs_k[None, :] + k * BLOCK_K < K)
+        mask_a = (offs_am[:, None] < M) & (offs_ak[None, :] + k * BLOCK_AK < KA)
         mask_b = ((offs_k[:, None] + k * BLOCK_K) < K) & (offs_bn[None, :] < N)
         a = tl.load(a_ptrs, mask=mask_a, other=0)
         b = tl.load(b_ptrs, mask=mask_b, other=0)
-        accumulator = tl.dot(a, b, acc=accumulator)
-        a_ptrs += BLOCK_K * stride_ak
+        if IS_SCALED:
+            # Adapted scale indexing and dot_scaled operation
+            mask_scale = (offs_am[:, None] < M) & (offs_sk[None, :] + k * BLOCK_SK < K // 32)
+            a_scale = tl.load(scale_ptrs, mask=mask_scale, other=0)
+            accumulator = tl.dot_scaled(a, a_scale, a_type, b, None, b_type, acc=accumulator)
+        else:
+            accumulator = tl.dot(a, b, acc=accumulator)
+        a_ptrs += BLOCK_AK * stride_ak
         b_ptrs += BLOCK_K * stride_bk
-    accumulator = accumulator.to(tl.float16)
+        if IS_SCALED:
+            scale_ptrs += BLOCK_SK * stride_sk
+    OUT_DTYPE = tl.bfloat16 if IS_SCALED else tl.float16
+    accumulator = accumulator.to(OUT_DTYPE)
     offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
@@ -105,16 +124,142 @@ def vecadd_kernel(a_ptr, b_ptr, output_ptr, n_elements, num_blocks, BLOCK_SIZE: 
         offsets += BLOCK_SIZE
 
 
-def test_pipeline_matmul(device):
+@triton.jit
+def mxfp_to_bf16_kernel(
+    x_ptr,
+    scale_ptr,
+    mxfp_ptr,
+    N,
+    e_bits: tl.constexpr,
+    m_bits: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    # x.shape ==     (N, 32) for fp8 or (N, 16) for fp4
+    # scale.shape == (N,)
+    # out.shape   == (N, 32)
+    is_fp8: tl.constexpr = e_bits + m_bits == 7
+    # fp8: BLOCK_SIZE -> BLOCK_SIZE // 32, 32
+    # fp4: BLOCK_SIZE // 2 -> BLOCK_SIZE // 32 , 16
+    PARALLEL_DIM: tl.constexpr = BLOCK_SIZE // 32
+    LAST_DIM: tl.constexpr = 32 if is_fp8 else 16
+    LOAD_SIZE: tl.constexpr = LAST_DIM * PARALLEL_DIM
+
+    offsets = (tl.program_id(0) * LOAD_SIZE + tl.arange(0, PARALLEL_DIM)[:, None] * LAST_DIM +
+               tl.arange(0, LAST_DIM)[None, :])
+    x = tl.load(x_ptr + offsets, mask=offsets < N * LAST_DIM)
+
+    offsets = tl.program_id(0) * PARALLEL_DIM + tl.arange(0, PARALLEL_DIM)[:, None]
+    scale = tl.load(scale_ptr + offsets, mask=offsets < N)
+    tl.static_assert(scale.dtype == tl.uint8)
+    tl.static_assert(x.dtype == tl.uint8)
+
+    scale_bf16 = (scale.to(tl.uint16) << 7).to(tl.bfloat16, bitcast=True)
+    if is_fp8:
+        if e_bits == 5 and m_bits == 2:
+            x_f8 = x.to(tl.float8e5, bitcast=True)
+            x_bf16 = x_f8.to(tl.bfloat16)
+            # Preserve infs and nans. FIXME Fp8E5M2_to_Bf16 doesn't preserve them!
+            non_finite_mask: tl.constexpr = ((1 << e_bits) - 1) << m_bits
+            non_finite_mask_bf16: tl.constexpr = ((1 << 8) - 1) << 7
+            x_bf16 = tl.where(
+                x & non_finite_mask == non_finite_mask,
+                (x_bf16.to(tl.uint16, bitcast=True) | non_finite_mask_bf16).to(tl.bfloat16, bitcast=True),
+                x_bf16,
+            )
+        else:
+            tl.static_assert(e_bits == 4 and m_bits == 3)
+            x_f8 = x.to(tl.float8e4nv, bitcast=True)
+            x_bf16 = x_f8.to(tl.bfloat16)
+    else:
+        # e2m1
+        em0 = x & 0x70
+        em1 = x & 0x7
+        x0 = (em0.to(tl.uint16) << 2) | ((x & 0x80).to(tl.uint16) << 8)
+        x1 = (em1.to(tl.uint16) << (2 + 4)) | ((x & 0x8).to(tl.uint16) << (8 + 4))
+        # Three cases:
+        # 1) x is normal and non-zero: Correct bias
+        x0 = tl.where((em0 & 0x60) != 0, x0 + ((127 - 1) << 7), x0)
+        x1 = tl.where((em1 & 0x6) != 0, x1 + ((127 - 1) << 7), x1)
+        # 2) x is subnormal (x == 0bs001 where s is the sign): Map to +-0.5 in bf16
+        x0 = tl.where(em0 == 0x10, 16128 | (x0 & 0x8000), x0)
+        x1 = tl.where(em1 == 0x1, 16128 | (x1 & 0x8000), x1)
+        # 3) x is zero, do nothing
+        x_bf16 = tl.interleave(x0, x1).to(tl.bfloat16, bitcast=True)
+    # Multiplication preserves infs and NaNs in x_bf16
+    mxfp = x_bf16 * scale_bf16
+    # If scale is NaN, we encode it as an bf16 inf, so we need to correct for that
+    mxfp = tl.where(scale == 0xFF, float("nan"), mxfp)
+
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    tl.store(mxfp_ptr + offsets, tl.ravel(mxfp), mask=offsets < N * 32)
+
+
+def dot_scale_ref(x, scale, y, type_x, type_y):
+    e_bits, m_bits = {"e2m1": (2, 1), "e4m3": (4, 3), "e5m2": (5, 2)}[type_x]
+    type_fp8_y = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}[type_y]
+
+    comp_dtype = torch.float32
+    out_dtype = torch.bfloat16
+
+    x = x.contiguous()
+    x_upcast = x.new_empty(scale.shape[:-1] + (32 * scale.shape[-1], ), dtype=comp_dtype)
+
+    N = x_upcast.numel()
+    BLOCK_SIZE = 512
+    grid = ((N + BLOCK_SIZE - 1) // BLOCK_SIZE, )
+    mxfp_to_bf16_kernel[grid](x, scale, x_upcast, scale.numel(), e_bits, m_bits, BLOCK_SIZE, num_warps=4)
+    y_upcast = y.view(type_fp8_y)
+
+    class AccumulateInFp32:
+
+        def __enter__(self):
+            self.prev_value = torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
+            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = self.prev_value
+
+    with AccumulateInFp32():
+        return torch.matmul(x_upcast.to(out_dtype), y_upcast.to(out_dtype))
+
+
+@pytest.mark.parametrize("scale", [True, False])
+def test_pipeline_matmul(scale, device):
     check_capabilities()
+    if scale and not is_cuda():
+        pytest.skip("NYI: scale_dot just implemented in CUDA")
     M, N, K = 512, 512, 128
     BLOCK_M, BLOCK_N, BLOCK_K = 64, 64, 32
     NUM_STAGES = 4
-    a = torch.randn(M, K, device=device, dtype=torch.float16)
-    b = torch.randn(K, N, device=device, dtype=torch.float16)
-    output = torch.empty((M, N), dtype=torch.float16, device=device)
+
+    if scale:
+        # TODO Use e5m2 for Ampere, as it does not support fp_to_fp conversions for fp8e4m3
+        BLOCK_K = 64  # 32 NYI
+        K = BLOCK_K * NUM_STAGES
+        a_type = "e2m1"
+        DIV_FACTOR = 2 if a_type == "e2m1" else 1
+        a = torch.randint(256, (M, K // DIV_FACTOR), device=device, dtype=torch.uint8)
+        # Sample small-ish scales to avoid overflow
+        scale_a = torch.randint(74, (M, K // 32), device=device, dtype=torch.uint8)
+        # Ampere does not support fp8e4m3
+        b_type = "e4m3" if is_hopper() else "e5m2"
+        b = torch.randint(256, (K, N), device=device, dtype=torch.uint8)
+        # e5m2 has too many non-finite values when sampled uniformly (1 / 32) and
+        # Fp8E5M2_to_Bf16 doesn't preserve NaNs (fixme)
+        if b_type == "e5m2":
+            finite = torch.arange(K * N, device=device, dtype=torch.uint8).reshape(K, N) % 0x7C
+            b = torch.where(b & 0x7C == 0x7C, finite | (0x80 & b), b)
+        output = torch.empty((M, N), dtype=torch.bfloat16, device=device)
+    else:
+        a = torch.randn(M, K, device=device, dtype=torch.float16)
+        b = torch.randn(K, N, device=device, dtype=torch.float16)
+        scale_a = None
+        a_type, b_type = None, None
+        output = torch.empty((M, N), dtype=torch.float16, device=device)
     grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), 1)
-    if is_cuda_tma_available():
+    use_tma = not scale and is_hopper()
+
+    if use_tma:
         a_tma = triton.tools.experimental_descriptor.create_2d_tma_descriptor(a.data_ptr(), M, K, BLOCK_M, BLOCK_K,
                                                                               a.element_size())
         b_tma = triton.tools.experimental_descriptor.create_2d_tma_descriptor(b.data_ptr(), K, N, BLOCK_K, BLOCK_N,
@@ -124,19 +269,23 @@ def test_pipeline_matmul(device):
         handler = matmul_kernel_tma[grid](a_tma, b_tma, output_tma, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K,
                                           NUM_STAGES=NUM_STAGES)
     else:
-        handler = matmul_kernel[grid](a, b, output, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1),
-                                      output.stride(0), output.stride(1), BLOCK_M, BLOCK_N, BLOCK_K,
-                                      NUM_STAGES=NUM_STAGES)
-    ref_out = torch.matmul(a, b)
-    atol = 1e-2 if is_hip_mi200() else None
+        stride_sm, stride_sk = scale_a.stride() if scale else (0, 0)
+        handler = matmul_kernel[grid](a, scale_a, b, output, M, N, K, a.stride(0), a.stride(1), stride_sm, stride_sk,
+                                      b.stride(0), b.stride(1), output.stride(0), output.stride(1), BLOCK_M, BLOCK_N,
+                                      BLOCK_K, NUM_STAGES=NUM_STAGES, a_type=a_type, b_type=b_type)
+    if scale:
+        ref_out = dot_scale_ref(a, scale_a, b, a_type, b_type)
+    else:
+        ref_out = torch.matmul(a, b)
     # Bigger tolerance for AMD MI200 devices.
     # MI200 devices use reduced precision fp16 and bf16 and flush input and
     # output denormal values to zero. Detailed info is at: https://pytorch.org/docs/stable/notes/numerical_accuracy.html#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices
-    rtol = 1e-2 if is_hip_mi200() else None
-    torch.testing.assert_close(ref_out, output, atol=atol, rtol=rtol)
+    atol = 1e-2 if is_hip_mi200() or scale else None
+    rtol = 1e-2 if is_hip_mi200() or scale else None
+    torch.testing.assert_close(ref_out, output, atol=atol, rtol=rtol, equal_nan=scale)
     if is_cuda():
         ttgir = handler.asm["ttgir"]
-        if is_cuda_tma_available():
+        if use_tma:
             assert ttgir.count("triton_nvidia_gpu.async_tma_copy_global_to_local") != 0, "async tma copy not found"
             assert ttgir.count(f"num = {NUM_STAGES} : i32") == 0, "num_stages not match"
             # a_tma, b_tma, output_tma, barriar


### PR DESCRIPTION
We allow DotOperand within MemoryOpToLLVM in the buggy ampere case via
LLs. This allows us to remove two workarounds that we added in a previous PR.

We add tests in test_pipeliner.py

We also remove some implementation-defined behaviour (overflows / NaNs)
in test_core.py, thus making the tests more resilient and realistic.
