### PR TITLE
Replace open-coded indirect load elimination loop

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -538,17 +538,14 @@ scheduleLoads(scf::ForOp forOp, tt::CoarseSchedule &schedule,
   if (loadOpToIndLevelAndUse.empty())
     return {};
 
-  for (auto iter = loadOpToIndLevelAndUse.begin();
-       iter != loadOpToIndLevelAndUse.end();) {
-    auto iterNext = iter + 1;
-    if (std::get<1>(*iter) >= numStages - 1)
-      // We assume loads with different dist are assigned to different stages.
-      // If numStages is 2, we will have no stage available for indirect loads
-      // with dist >= 1. In general, when dist is equal to numStages - 1, we
-      // should not pipeline it.
-      loadOpToIndLevelAndUse.erase(iter);
-    iter = iterNext;
-  }
+  // We assume loads with different dist are assigned to different stages.
+  // If numStages is 2, we will have no stage available for indirect loads
+  // with dist >= 1. In general, when dist is equal to numStages - 1, we
+  // should not pipeline it.
+  auto it = llvm::remove_if(loadOpToIndLevelAndUse, [=](auto op) {
+    return std::get<1>(op) >= numStages - 1;
+  });
+  loadOpToIndLevelAndUse.erase(it, loadOpToIndLevelAndUse.end());
 
   // Check which loads are good for pipelining, and assign them
   // memory layouts.


### PR DESCRIPTION
Not only does this have issues with iterator invalidation, it also runs out of bounds if the last element is erased. We should just use the functions for doing this rather than worrying about how to implement it correctly ourselves.

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `I don't actually know how to exercise this code`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
