### PR TITLE
[NFC] Use `get_config_var('EXT_SUFFIX')` instead of using `so` directly

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import re
 import functools
 import os
+import sysconfig
 
 # - ^\s*tt\.func\s+ : match the start of the string, any leading whitespace, the keyword func,
 #    and any following whitespace
@@ -151,7 +152,8 @@ def triton_key():
 
     # backend
     libtriton_hash = hashlib.sha256()
-    with open(os.path.join(TRITON_PATH, "_C/libtriton.so"), "rb") as f:
+    ext = sysconfig.get_config_var("EXT_SUFFIX").split(".")[-1]
+    with open(os.path.join(TRITON_PATH, f"_C/libtriton.{ext}"), "rb") as f:
         while True:
             chunk = f.read(1024**2)
             if not chunk:

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import sysconfig
 import hashlib
 import subprocess
 import tempfile
@@ -48,7 +49,8 @@ def library_dirs():
 def compile_module_from_src(src, name):
     key = hashlib.sha256(src.encode("utf-8")).hexdigest()
     cache = get_cache_manager(key)
-    cache_path = cache.get_file(f"{name}.so")
+    ext = sysconfig.get_config_var("EXT_SUFFIX").split(".")[-1]
+    cache_path = cache.get_file(f"{name}.{ext}")
     if cache_path is None:
         with tempfile.TemporaryDirectory() as tmpdir:
             src_path = os.path.join(tmpdir, "main.c")
@@ -56,7 +58,7 @@ def compile_module_from_src(src, name):
                 f.write(src)
             so = _build(name, src_path, tmpdir, library_dirs(), include_dir, libraries)
             with open(so, "rb") as f:
-                cache_path = cache.put(f.read(), f"{name}.so", binary=True)
+                cache_path = cache.put(f.read(), f"{name}.{ext}", binary=True)
     import importlib.util
     spec = importlib.util.spec_from_file_location(name, cache_path)
     mod = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
Change to improve platform independence.

How it works?

On Windows:
```python
>>> import sysconfig
>>> sysconfig.get_config_var("EXT_SUFFIX")
'.cp310-win_amd64.pyd'
>>> sysconfig.get_config_var("EXT_SUFFIX").split(".")[-1]
'pyd'
```

On Linux:
```python
>>> import sysconfig
>>> sysconfig.get_config_var("EXT_SUFFIX")
'.cpython-310-x86_64-linux-gnu.so'
>>> sysconfig.get_config_var("EXT_SUFFIX").split(".")[-1]
'so'
```