### PR TITLE
[Build] Remove unnecessary `NVGPUIR` from `TritonGPUToLLVM`

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
@@ -34,5 +34,4 @@ add_triton_library(TritonGPUToLLVM
     TritonGPUIR
     TritonGPUTransforms
     TritonNvidiaGPUTransforms
-    NVGPUIR
 )


### PR DESCRIPTION
Note, there are no uses of `nvgpu::` in this lib. Unblocks building `*-opt` tools with "custom" LLVM that was built with `-DLLVM_TARGETS_TO_BUILD="host;AMDGPU"` (i.e., no `NVPTX`).