### PR TITLE
Fix when trying to convert an mma<!tt.ptr<f32>> into blocked

### DIFF
--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -997,6 +997,8 @@ bool canUseStMatrix(RankedTensorType tensorTy, ArrayRef<unsigned> repShape,
       mlir::dyn_cast<NvidiaMmaEncodingAttr>(tensorTy.getEncoding());
   if (!mmaLayout || !mmaLayout.isHopper())
     return false;
+  if (isa<PointerType>(tensorTy.getElementType()))
+    return false;
   if (tensorTy.getElementType().getIntOrFloatBitWidth() != 16)
     return false;
   if (order[0] != 1)


### PR DESCRIPTION
Hit by @apgoucher. Putting this up to unblock him, but I find absolutely
bizarre that we end up with a tensor of pointers in mma format. I
haven't investigated where this is created though. We should probably
look into it.
