### PR TITLE
[PROTON] Emit an error for the roctracer backend if `HIP_VISIBLE_DEVICES` is set

### DIFF
--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -212,4 +212,4 @@ Continuous sampling can allow for more runtime optimizations, but it makes it mo
 
 - Visible devices on AMD GPUs
 
-Environment variables such as `HIP_VISIBLE_DEVICES`, `ROCR_VISIBLE_DEVICES`, or `CUDA_VISIBLE_DEVICES` are not supported on AMD GPUs. Once it's set, we cannot find a valid mapping between the device ID returned by RocTracer and the physical device ID. This issue needs to be addressed by the ROCm team.
+Environment variables such as `HIP_VISIBLE_DEVICES`, `ROCR_VISIBLE_DEVICES`, and `CUDA_VISIBLE_DEVICES` are not supported on AMD GPUs. Once it's set, we cannot find a valid mapping between the device ID returned by RocTracer and the physical device ID. This issue needs to be addressed by the ROCm team.

--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -212,4 +212,4 @@ Continuous sampling can allow for more runtime optimizations, but it makes it mo
 
 - Visible devices on AMD GPUs
 
-Environment variables such as `HIP_VISIBLE_DEVICES`, `ROCR_VISIBLE_DEVICES`, and `CUDA_VISIBLE_DEVICES` are not supported on AMD GPUs. Once it's set, we cannot find a valid mapping between the device ID returned by RocTracer and the physical device ID. This issue needs to be addressed by the ROCm team.
+Environment variables such as `HIP_VISIBLE_DEVICES`, and `CUDA_VISIBLE_DEVICES` are not supported on AMD GPUs. Once it's set, we cannot find a valid mapping between the device ID returned by RocTracer and the physical device ID. Instead, `ROCR_VISIBLE_DEVICES` is recommended to be used.

--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -209,3 +209,7 @@ If you encounter permission related problems when using instruction sampling, yo
 
 The overhead of instruction sampling on NVIDIA GPUs is about 20x using Proton because we haven't enabled continuous sampling yet.
 Continuous sampling can allow for more runtime optimizations, but it makes it more challenging to attribute performance data back to the GPU kernels because: (1) it enables profiling of concurrent kernels, (2) it doesn't allow profiling of time and instruction samples simultaneously, and (3) it works best if we have a separate thread dedicated to attributing instruction samples to the GPU kernels
+
+- Visible devices on AMD GPUs
+
+Environment variables such as `HIP_VISIBLE_DEVICES`, `ROCR_VISIBLE_DEVICES`, or `CUDA_VISIBLE_DEVICES` are not supported on AMD GPUs. Once it's set, we cannot find a valid mapping between the device ID returned by RocTracer and the physical device ID. This issue needs to be addressed by the ROCm team.

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -22,10 +22,12 @@ def _select_backend() -> str:
 
 def _check_env(backend: str) -> None:
     if backend == "roctracer":
-        hip_device_envs = ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"]
+        hip_device_envs = ["HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"]
         for env in hip_device_envs:
             if os.getenv(env, None) is not None:
-                raise ValueError(f"Proton does not work when the environment variable {env} is set. Please unset it.")
+                raise ValueError(
+                    f"Proton does not work when the environment variable {env} is set on AMD GPUs. Please unset it and use `ROCR_VISIBLE_DEVICES` instead"
+                )
 
 
 def start(

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -20,7 +20,7 @@ def _select_backend() -> str:
         raise ValueError("No backend is available for the current target.")
 
 
-def _validate_backend(backend: str) -> None:
+def _check_env(backend: str) -> None:
     if backend == "roctracer":
         hip_device_envs = ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"]
         for env in hip_device_envs:
@@ -75,7 +75,7 @@ def start(
     if backend is None:
         backend = _select_backend()
 
-    _validate_backend(backend)
+    _check_env(backend)
 
     set_profiling_on()
     if hook and hook == "triton":

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -1,5 +1,6 @@
 import functools
 import triton
+import os
 
 from triton._C.libproton import proton as libproton
 from .hook import register_triton_hook, unregister_triton_hook
@@ -17,6 +18,14 @@ def _select_backend() -> str:
         return "roctracer"
     else:
         raise ValueError("No backend is available for the current target.")
+
+
+def _validate_backend(backend: str) -> None:
+    if backend == "hip":
+        hip_device_envs = ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"]
+        for env in hip_device_envs:
+            if os.getenv(env, None) is not None:
+                raise ValueError(f"Proton does not support environment variable {env} is set. Please unset it.")
 
 
 def start(
@@ -65,6 +74,8 @@ def start(
 
     if backend is None:
         backend = _select_backend()
+
+    _validate_backend(backend)
 
     set_profiling_on()
     if hook and hook == "triton":

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -21,11 +21,11 @@ def _select_backend() -> str:
 
 
 def _validate_backend(backend: str) -> None:
-    if backend == "hip":
+    if backend == "roctracer":
         hip_device_envs = ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"]
         for env in hip_device_envs:
             if os.getenv(env, None) is not None:
-                raise ValueError(f"Proton does not support environment variable {env} is set. Please unset it.")
+                raise ValueError(f"Proton does not work when the environment variable {env} is set. Please unset it.")
 
 
 def start(


### PR DESCRIPTION
Based on the feedback from AMD, the device mapping problem has to be addressed by the ROCm team, so we emit an error for now.