### PR TITLE
[Triton] Add canonicalization patterns for `tt.reduce`

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -723,6 +723,7 @@ def TT_ReduceOp: TT_Op<"reduce",
     ];
     let hasVerifier = 1;
     let hasRegionVerifier = 1;
+    let hasCanonicalizer = 1;
     let extraClassDeclaration = [{
       llvm::SmallVector<RankedTensorType> getInputTypes();
       llvm::SmallVector<Type> getElementTypes();


### PR DESCRIPTION
Add canonicalization pattern replacing `tt.reduce` with axis of size 1 with a `tt.reshape` operation.

This may enable further optimizations and simplifications.
