### PR TITLE
[DRAFT][AMD] Introduce OptimizeAtomicLayouts pass

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -57,6 +57,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerOptimizeAMDLDSUsage();
 
   // TritonAMDGPUTransforms passes
+  mlir::registerTritonAMDGPUOptimizeAtomicLayouts();
   mlir::registerTritonAMDGPUAccelerateMatmul();
   mlir::registerTritonAMDGPUOptimizeEpilogue();
   mlir::registerTritonAMDGPUReorderInstructions();

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1300,7 +1300,7 @@ def atom_red_typechecking_impl(ptr: tl.tensor, val: tl.tensor, mask: tl.tensor, 
     element_ty = ptr.type.scalar.element_ty
     if element_ty is tl.float16 and op != 'add':
         raise ValueError("atomic_" + op + " does not support fp16")
-    if element_ty in [tl.int1, tl.int8, tl.int16, tl.bfloat16]:
+    if element_ty in [tl.int1, tl.int8, tl.int16]:
         raise ValueError("atomic_" + op + " does not support " + str(element_ty))
     if ptr.type.is_block():
         if mask is not None:

--- a/test/TritonGPU/amd/optimize-atomic-layouts.mlir
+++ b/test/TritonGPU/amd/optimize-atomic-layouts.mlir
@@ -1,0 +1,31 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-optimize-atomic-layouts='arch-generation-name=gfx942' | FileCheck %s
+
+// CHECK: #[[OLD_LAYOUT:.+]] = #triton_gpu.blocked<{sizePerThread = [1]{{.*}}}>
+// CHECK: #[[NEW_LAYOUT:.+]] = #triton_gpu.blocked<{sizePerThread = [2]{{.*}}}>
+#blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @atomic_add_f16x2(%arg0 : tensor<256x!tt.ptr<f16>, #blocked>, %arg1 : tensor<256xi1, #blocked>, %arg2 : tensor<256xf16, #blocked>) {
+    // CHECK-3: triton_gpu.convert_layout {{.*}}tensor<{{.*}}#[[OLD_LAYOUT]]> -> tensor<{{.*}}#[[NEW_LAYOUT]]>
+    // CHECK: atomic_rmw fadd{{.*}} -> tensor<{{.*}}#[[NEW_LAYOUT]]>
+    %0 = tt.atomic_rmw fadd, relaxed, gpu, %arg0, %arg2, %arg1 : (tensor<256x!tt.ptr<f16>, #blocked>, tensor<256xf16, #blocked>, tensor<256xi1, #blocked>) -> tensor<256xf16, #blocked>
+    // CHECK: triton_gpu.convert_layout {{.*}}tensor<{{.*}} #[[NEW_LAYOUT]]> -> tensor<{{.*}} #[[OLD_LAYOUT]]>
+    tt.store %arg0, %0 : tensor<256x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: #[[OLD_LAYOUT:.+]] = #triton_gpu.blocked<{sizePerThread = [3]{{.*}}}>
+// CHECK: #[[NEW_LAYOUT:.+]] = #triton_gpu.blocked<{sizePerThread = [6]{{.*}}}>
+#blocked = #triton_gpu.blocked<{sizePerThread = [3], threadsPerWarp = [64], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 64 : i32} {
+  tt.func @atomic_add_bf16x6(%arg0 : tensor<256x!tt.ptr<bf16>, #blocked>, %arg1 : tensor<256xi1, #blocked>, %arg2 : tensor<256xbf16, #blocked>) {
+    // CHECK-3: triton_gpu.convert_layout {{.*}}tensor<{{.*}}#[[OLD_LAYOUT]]> -> tensor<{{.*}}#[[NEW_LAYOUT]]>
+    // CHECK: atomic_rmw fadd{{.*}} -> tensor<{{.*}}#[[NEW_LAYOUT]]>
+    %0 = tt.atomic_rmw fadd, relaxed, gpu, %arg0, %arg2, %arg1 : (tensor<256x!tt.ptr<bf16>, #blocked>, tensor<256xbf16, #blocked>, tensor<256xi1, #blocked>) -> tensor<256xbf16, #blocked>
+    // CHECK: triton_gpu.convert_layout {{.*}}tensor<{{.*}} #[[NEW_LAYOUT]]> -> tensor<{{.*}} #[[OLD_LAYOUT]]>
+    tt.store %arg0, %0 : tensor<256x!tt.ptr<bf16>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -210,6 +210,8 @@ class HIPBackend(BaseBackend):
         pm.enable_debug()
         passes.ttgpuir.add_coalesce(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
+        amd.passes.ttgpuir.add_optimize_atomic_layouts(pm, options.arch)
+        passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_optimize_thread_locality(pm)
         amd.passes.ttgpuir.add_accelerate_matmul(pm, options.arch, options.matrix_instr_nonkdim, options.kpack)
         passes.ttgpuir.add_remove_layout_conversions(pm)

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -9,6 +9,9 @@ namespace mlir {
 
 std::unique_ptr<Pass> createTritonAMDGPUStreamPipelineV2Pass(int numStages = 2);
 
+std::unique_ptr<Pass> createTritonAMDGPUOptimizeAtomicLayoutsPass(
+    const std::string archGenName = std::string());
+
 std::unique_ptr<Pass>
 createTritonAMDGPUAccelerateMatmulPass(std::string archGenName = std::string(),
                                        int matrixInstructionSize = 0,

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -22,6 +22,25 @@ def TritonAMDGPUStreamPipelineV2 : Pass<"tritonamdgpu-stream-pipeline-v2", "mlir
   ];
 }
 
+def TritonAMDGPUOptimizeAtomicLayouts : Pass<"tritonamdgpu-optimize-atomic-layouts", "mlir::ModuleOp"> {
+  let summary = "optimize atomic layouts";
+
+  let description = [{
+    TritonAMDGPUOptimizeAtomicLayouts pass is required for rearranging layouts for atomic operations
+    to generate more profitable instructions.
+  }];
+
+  let constructor = "mlir::createTritonAMDGPUOptimizeAtomicLayoutsPass()";
+
+  let dependentDialects = [];
+
+  let options = [
+    Option<"archGenerationName", "arch-generation-name",
+           "std::string", /*default=*/"std::string{}",
+           "GFX generation name of target device.">
+  ];
+}
+
 def TritonAMDGPUAccelerateMatmul : Pass<"tritonamdgpu-accelerate-matmul", "mlir::ModuleOp"> {
   let summary = "accelerate matmul";
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonAMDGPUTransforms
   AccelerateAMDMatmul.cpp
   CanonicalizePointers.cpp
   ConvertToBufferOps.cpp
+  OptimizeAtomicLayouts.cpp
   OptimizeEpilogue.cpp
   ReorderInstructions.cpp
   StreamPipelineV2.cpp

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeAtomicLayouts.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeAtomicLayouts.cpp
@@ -1,0 +1,140 @@
+#include "TritonAMDGPUToLLVM/TargetUtils.h"
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include <memory>
+
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace {
+bool supportedGlobalAtomicPacked(StringRef arch) {
+  if (arch.contains("gfx12"))
+    return true;
+
+  auto isaFamily = tt::AMD::deduceISAFamily(arch);
+  return isaFamily == tt::AMD::ISAFamily::CDNA1 ||
+         isaFamily == tt::AMD::ISAFamily::CDNA2 ||
+         isaFamily == tt::AMD::ISAFamily::CDNA3;
+}
+
+// This rewriter is required to recombine datalayouts for atomicRMW fadd
+// operation to be able to pack 2 16 bit elements and process them by a single
+// instruction.
+class AtomicRmwPackF16 : public OpRewritePattern<tt::AtomicRMWOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  AtomicRmwPackF16(MLIRContext *context)
+      : OpRewritePattern<tt::AtomicRMWOp>(context, /*benefit=*/1) {}
+
+  LogicalResult matchAndRewrite(tt::AtomicRMWOp atomOp,
+                                PatternRewriter &rewriter) const override {
+    auto atomicRmwBinOp = atomOp.getAtomicRmwOp();
+    if (atomicRmwBinOp != RMWOp::FADD)
+      return failure();
+
+    auto ctx = atomOp->getContext();
+
+    Value ptr = atomOp.getPtr();
+    Value val = atomOp.getVal();
+    Value mask = atomOp.getMask();
+
+    Value opResult = atomOp.getResult();
+    auto tensorTy = dyn_cast<RankedTensorType>(opResult.getType());
+    if (!tensorTy)
+      return failure();
+
+    auto oldEncoding = tensorTy.getEncoding();
+    if (!oldEncoding || !isa<ttg::BlockedEncodingAttr>(oldEncoding))
+      return failure();
+
+    Type resElemTy = tensorTy.getElementType();
+    const size_t resElemNbits = resElemTy.getIntOrFloatBitWidth();
+    if (!isa<FloatType>(resElemTy) || resElemNbits != 16)
+      return failure();
+
+    auto order = ttg::getOrder(oldEncoding);
+    auto oldTotalElemsPerThread = ttg::getElemsPerThread(tensorTy);
+    // No need to do anything. Elements already could be collected to pairs
+    if (oldTotalElemsPerThread[order[0]] % 2 == 0)
+      return failure();
+
+    // Just multiply elements per thread by 2. Layout will be built considering
+    // this. There are cases where some threads will be disabled. It is also
+    // better for perf because in the not paired case we have to provide unique
+    // access to each element, this leads to overhead.
+    auto packedElemsPerThread = oldTotalElemsPerThread;
+    packedElemsPerThread[order[0]] *= 2;
+
+    auto mod = atomOp->getParentOfType<ModuleOp>();
+    int numWarps = ttg::TritonGPUDialect::getNumWarps(mod);
+    int numThreads = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
+    int numCTAs = ttg::TritonGPUDialect::getNumCTAs(mod);
+    auto shape = tensorTy.getShape();
+    auto newPackedEncoding = ttg::BlockedEncodingAttr::get(
+        ctx, shape, packedElemsPerThread, order, numWarps, numThreads, numCTAs);
+
+    // Convert val, ptr, mask to packed layout
+    auto newResTensorType =
+        RankedTensorType::get(shape, resElemTy, newPackedEncoding);
+    Value convertedVal = rewriter.create<ttg::ConvertLayoutOp>(
+        val.getLoc(), newResTensorType, val);
+
+    Type ptrElemTy = cast<RankedTensorType>(ptr.getType()).getElementType();
+    auto newPtrTensorType =
+        RankedTensorType::get(shape, ptrElemTy, newPackedEncoding);
+    Value convertedPtr = rewriter.create<ttg::ConvertLayoutOp>(
+        ptr.getLoc(), newPtrTensorType, ptr);
+
+    Type maskElemTy = cast<RankedTensorType>(mask.getType()).getElementType();
+    auto newMaskTensorType =
+        RankedTensorType::get(shape, maskElemTy, newPackedEncoding);
+    Value convertedMask = rewriter.create<ttg::ConvertLayoutOp>(
+        ptr.getLoc(), newMaskTensorType, mask);
+
+    // Create new operation with required operand types
+    auto newAtomicRmw = rewriter.create<tt::AtomicRMWOp>(
+        atomOp.getLoc(), newResTensorType, atomicRmwBinOp, convertedPtr,
+        convertedVal, convertedMask, atomOp.getSem(), atomOp.getScope());
+
+    // Convert result back to the old layout
+    Value convertedRes = rewriter.create<ttg::ConvertLayoutOp>(
+        ptr.getLoc(), tensorTy, newAtomicRmw);
+
+    rewriter.replaceOp(atomOp, convertedRes);
+    return success();
+  }
+};
+} // namespace
+
+#define GEN_PASS_CLASSES
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+
+class TritonAMDGPUOptimizeAtomicLayoutsPass
+    : public TritonAMDGPUOptimizeAtomicLayoutsBase<
+          TritonAMDGPUOptimizeAtomicLayoutsPass> {
+public:
+  TritonAMDGPUOptimizeAtomicLayoutsPass() = default;
+  TritonAMDGPUOptimizeAtomicLayoutsPass(StringRef archGen) {
+    this->archGenerationName = archGen.data();
+  }
+  void runOnOperation() override {
+
+    MLIRContext *context = &getContext();
+    ModuleOp m = getOperation();
+
+    RewritePatternSet patterns(context);
+    if (supportedGlobalAtomicPacked(archGenerationName)) {
+      patterns.add<::AtomicRmwPackF16>(context);
+    }
+    if (applyPatternsAndFoldGreedily(m, std::move(patterns)).failed()) {
+      signalPassFailure();
+    }
+  }
+};
+
+std::unique_ptr<Pass>
+mlir::createTritonAMDGPUOptimizeAtomicLayoutsPass(std::string archGen) {
+  return std::make_unique<TritonAMDGPUOptimizeAtomicLayoutsPass>(archGen);
+}

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -60,6 +60,9 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_2("add_optimize_lds_usage",
                      mlir::triton::AMD::createOptimizeLDSUsagePass,
                      const std::string &, int32_t);
+  ADD_PASS_WRAPPER_1("add_optimize_atomic_layouts",
+                     mlir::createTritonAMDGPUOptimizeAtomicLayoutsPass,
+                     const std::string);
   ADD_PASS_WRAPPER_3("add_accelerate_matmul",
                      mlir::createTritonAMDGPUAccelerateMatmulPass,
                      const std::string, int, int);


### PR DESCRIPTION
The pass is required for rearranging layouts for atomic operations.
Currently only elements packing rewriter is added.
The main purpose of this rewriter to group elements by pairs to utilize
more optimal instructions like global_atomic_pk_fadd_(b)f16.
