### PR TITLE
[AMD] Add support for scaled_dot(mxfp4, -)

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -391,6 +391,15 @@ inline Value getSharedMemoryBase(Location loc, RewriterBase &rewriter,
   Value base = gep(ptrTy, i8_ty, LLVM::getStackPointer(rewriter, func), offVal);
   return base;
 }
+
+// -----------------------------------------------------------------------
+// MXFP utilities
+// -----------------------------------------------------------------------
+
+// Convert one int8, which contain, 2 packed mxfp4 values, into 2 bf16
+// standalone values and returns them as a pair for (high 4 bits, low 4 bits).
+std::pair<Value, Value> convertMxfp4x2ToBf16x2(RewriterBase &rewriter,
+                                               Location loc, Value v);
 } // namespace LLVM
 
 /* ------------------------------------ */

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3337,7 +3337,7 @@ def test_scaled_dot(M, N, K, col_a, col_b, type_a, type_b, num_warps, mma, kpack
         if cc < (8, 9):
             pytest.skip("float8e4nv not supported on CUDA < 8.9")
     if is_hip():
-        if type_a != "e5m2" or (type_b != "e5m2" and type_b != "bf16"):
+        if (type_a not in ["e2m1", "e5m2"]) or (type_b not in ["e2m1", "e5m2", "bf16"]):
             pytest.skip(f"scaled_dot({type_a}, {type_b}) not yet implemented for HIP")
         if mma == 16 and K == 64:
             pytest.skip(f"K == {K} too small for mfma {mma} in scaled_dot")

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -40,6 +40,11 @@ def is_hip():
     return False if target is None else target.backend == "hip"
 
 
+def is_hip_mi200():
+    target = get_current_target()
+    return target.backend == 'hip' and target.arch == 'gfx90a'
+
+
 def get_arch():
     target = get_current_target()
     return "" if target is None else str(target.arch)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
@@ -146,8 +146,7 @@ public:
 private:
   SmallVector<Value> unpackFP4Elements(Location loc, RewriterBase &rewriter,
                                        ArrayRef<Value> packed) const {
-
-    // Split fp4x8 into 4 bf16x2
+    // Split every fp4x2 into 2 bf16 values.
     llvm::SmallVector<Value> unpacked;
     unpacked.reserve(packed.size() * 2);
     for (Value v : packed) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
@@ -21,10 +21,11 @@ namespace {
 
 Value mxfpScaleBf16(RewriterBase &rewriter, Location loc, Value v,
                     Value scale) {
+  Value vBf16 = bitcast(v, bf16_ty);
   Value nanBf16 = bitcast(i16_val(0x7fff), bf16_ty);
   Value scaleIsNan = icmp_eq(scale, i8_val(0xff));
   Value scaleBf16 = bitcast(shl(zext(i16_ty, scale), i16_val(7)), bf16_ty);
-  Value scaledBf16 = fmul(v, scaleBf16);
+  Value scaledBf16 = fmul(vBf16, scaleBf16);
   // Account for NaN in the scale as per the mxfp specification.
   return select(scaleIsNan, nanBf16, scaledBf16);
 };
@@ -43,7 +44,9 @@ public:
   matchAndRewrite(UpcastMXFPOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto fpType = op.getFpType();
-    if (!(fpType == ScaleDotElemType::E4M3 || fpType == ScaleDotElemType::E5M2))
+    bool isPacked = fpType == ScaleDotElemType::E2M1;
+    if (!(isPacked || fpType == ScaleDotElemType::E4M3 ||
+          fpType == ScaleDotElemType::E5M2))
       return rewriter.notifyMatchFailure(op, "NYI: non-mxfp8 cases");
 
     Location loc = op.getLoc();
@@ -56,7 +59,7 @@ public:
     // warp. MXFP spec mandates 1 scale value for every 32 onsecutive values
     // along the K dimension. So in total each thread should read 32x main
     // element values.
-    if (xVals.size() != scaleVals.size() * 32)
+    if (xVals.size() != scaleVals.size() * (isPacked ? 16 : 32))
       return rewriter.notifyMatchFailure(op, "unsupported problem size");
 
     auto dotEncoding =
@@ -78,6 +81,9 @@ public:
     Value tid = tid_val();
     Value warpId = udiv(tid, warpSize);
     Value laneId = urem(tid, warpSize);
+
+    if (isPacked)
+      xVals = unpackFP4Elements(loc, rewriter, xVals);
 
     // Given that MFMA layout for the A tensor arranges thread in a column-major
     // manner, for the current tid, it's at row (tid % mDim). When we set up
@@ -135,6 +141,21 @@ public:
         packLLElements(loc, getTypeConverter(), xVals, rewriter, op.getType());
     rewriter.replaceOp(op, result);
     return success();
+  }
+
+private:
+  SmallVector<Value> unpackFP4Elements(Location loc, RewriterBase &rewriter,
+                                       ArrayRef<Value> packed) const {
+
+    // Split fp4x8 into 4 bf16x2
+    llvm::SmallVector<Value> unpacked;
+    unpacked.reserve(packed.size() * 2);
+    for (Value v : packed) {
+      auto [e0, e1] = LLVM::convertMxfp4x2ToBf16x2(rewriter, loc, v);
+      unpacked.push_back(e0);
+      unpacked.push_back(e1);
+    }
+    return unpacked;
   }
 };
 } // anonymous namespace

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -529,10 +529,10 @@ public:
     if (failed(mfmaInstr))
       return rewriter.notifyMatchFailure(dotOp, "cannot choose mfma intrinsic");
 
-    const unsigned mDim = mfmaInstr.value().getMDim();
-    const unsigned nDim = mfmaInstr.value().getNDim();
-    const unsigned kDim = mfmaInstr.value().getKDim();
-    const unsigned kBase = mfmaInstr.value().getKBase();
+    unsigned mDim = mfmaInstr.value().getMDim();
+    unsigned nDim = mfmaInstr.value().getNDim();
+    unsigned kDim = mfmaInstr.value().getKDim();
+    unsigned kBase = mfmaInstr.value().getKBase();
 
     // If A tensor contains mxfp4, we pack every two values into one int8 value
     // there. For such cases, we have different initial kWidth for LHS and RHS,


### PR DESCRIPTION
This commit adds support for mxfp4 typed A tensor
for sacled dot in the AMD backend.

We moved the `convertMxfp4x2ToBf16x2` impl
from NVIDIA side to a common path to reuse.