### PR TITLE
[CI] use popd/pushd instead of cd

### DIFF
--- a/.github/workflows/torch-inductor/scripts/install_torchinductor.sh
+++ b/.github/workflows/torch-inductor/scripts/install_torchinductor.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# remember where we started
-ROOT="$(pwd)"
 MODEL_SPEC=$1
 
 # torchinductor venv
@@ -29,15 +27,15 @@ pip3 install --force-reinstall torchtext
 # pytorch nightly
 pip3 install --force-reinstall --pre torch torchvision torchaudio torchrec --extra-index-url https://download.pytorch.org/whl/nightly/cu121
 # pytorch source to get torchbench for dynamo
-cd /tmp || exit
+pushd /tmp || exit
 # cleanup old pytorch
 rm -rf pytorch
 git clone --recursive https://github.com/pytorch/pytorch
-cd pytorch || exit
+pushd pytorch || exit
 # if you are updating an existing checkout
 git submodule sync
 git submodule update --init --recursive
-cd ..
+popd || exit
 
 # required packages
 # https://github.com/pytorch/benchmark/blob/main/docker/gcp-a100-runner-dind.dockerfile#L17
@@ -50,9 +48,9 @@ if [ "$MODEL_SPEC" == "torchbench" ] || [ "$MODEL_SPEC" != "all" ]; then
 	rm -rf benchmark
 	pip3 install pyyaml
 	git clone https://github.com/pytorch/benchmark.git
-	cd benchmark || exit
+	pushd benchmark || exit
 	python3 install.py
-	cd ..
+	popd || exit
 fi
 
 # timm
@@ -60,9 +58,9 @@ if [ "$MODEL_SPEC" == "timm_models" ] || [ "$MODEL_SPEC" != "all" ]; then
 	# clean up old timm
 	rm -rf pytorch-image-models
 	git clone https://github.com/huggingface/pytorch-image-models.git
-	cd pytorch-image-models || exit
+	pushd pytorch-image-models || exit
 	pip3 install -e .
-	cd ..
+	popd || exit
 fi
 
 # clean up cache
@@ -71,4 +69,4 @@ rm -rf ~/.triton/cache
 rm -rf "$TEST_REPORTS_DIR"
 
 # go back to where we started
-cd "$ROOT" || exit
+popd || exit

--- a/.github/workflows/torch-inductor/scripts/install_triton.sh
+++ b/.github/workflows/torch-inductor/scripts/install_triton.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# remember where we started
-ROOT="$(pwd)"
-
 # shellcheck source=/dev/null
 source /tmp/torchinductor_venv/bin/activate
 # shellcheck source=/dev/null
@@ -12,7 +9,7 @@ source ./.github/workflows/torch-inductor/scripts/common.sh
 pip3 install --upgrade cmake ninja lit
 
 # build our own triton and preserve the wheel build for later re-use in this test run.
-cd python || exit
+pushd python || exit
 pip3 uninstall pytorch-triton -y
 rm -rf build dist
 python3 setup.py bdist_wheel
@@ -22,4 +19,4 @@ pip3 install dist/triton*.whl
 rm -rf ~/.triton/cache
 
 # go back to where we started
-cd "$ROOT" || exit
+popd || exit

--- a/.github/workflows/torch-inductor/scripts/run_torchinductor_acc.sh
+++ b/.github/workflows/torch-inductor/scripts/run_torchinductor_acc.sh
@@ -15,7 +15,7 @@ pip3 install --upgrade z3-solver
 
 # Install our own triton.
 pip3 uninstall pytorch-triton -y
-cd $ROOT/python || exit
+pushd python || exit
 if [ -d "./dist" ]; then
   pip3 install dist/triton*.whl
 else
@@ -23,7 +23,7 @@ else
   pip3 install -e .
 fi
 
-cd "$PYTORCH_DIR" || exit
+pushd "$PYTORCH_DIR" || exit
 TEST_REPORTS_DIR=$TEST_REPORTS_DIR/acc
 mkdir -p "$TEST_REPORTS_DIR"
 
@@ -40,7 +40,7 @@ for model in "${MODELS[@]}"; do
     --output "$TEST_REPORTS_DIR"/dynamic_shapes_"$model".csv
 done
 
-cd "$ROOT" || exit
+popd || exit
 for model in "${MODELS[@]}"; do
   if [ "$model" != "$MODEL_SPEC" ] && [ "$MODEL_SPEC" != "all" ]; then
     continue
@@ -52,4 +52,4 @@ for model in "${MODELS[@]}"; do
 done
 
 # go back to where we started
-cd "$ROOT" || exit
+popd || exit

--- a/.github/workflows/torch-inductor/scripts/run_torchinductor_perf.sh
+++ b/.github/workflows/torch-inductor/scripts/run_torchinductor_perf.sh
@@ -14,7 +14,7 @@ source "$INDUCTOR"/scripts/common.sh
 sudo nvidia-smi -i 0 -pm 1
 sudo nvidia-smi -i 0 --lock-gpu-clocks=1350,1350
 
-cd "$PYTORCH_DIR" || exit
+pushd "$PYTORCH_DIR" || exit
 TRITON_TEST_REPORTS_DIR=$TEST_REPORTS_DIR/perf
 BASE_TEST_REPORTS_DIR=$TEST_REPORTS_DIR/acc
 mkdir -p "$TRITON_TEST_REPORTS_DIR"
@@ -50,7 +50,7 @@ done
 # uninstall pytorch-triton
 pip3 uninstall pytorch-triton -y
 
-cd "$ROOT" || exit
+popd || exit
 for model in "${MODELS[@]}"; do
   if [ "$model" != "$MODEL_SPEC" ] && [ "$MODEL_SPEC" != "all" ]; then
     continue
@@ -68,4 +68,4 @@ done
 sudo nvidia-smi -i 0 -rgc
 
 # go back to where we started
-cd "$ROOT" || exit
+popd || exit


### PR DESCRIPTION
Replaced instances of `cd` with `pushd` and `popd` to manage directory changes, ensuring the script maintains a clean and predictable directory state. This change improves readability and maintainability by using directory stack operations, allowing easy return to the original directory after performing tasks in different directories.

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Signed-off-by: Sébastien Han <seb@redhat.com>

- [ ] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it's changing the CI scripts.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
