### PR TITLE
[Triton][Allocation] Enable `getScratchValueSize` specialization

### DIFF
--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -20,9 +20,11 @@ class AllocationAnalysis;
 
 constexpr inline unsigned invalidAllocationSize = -1;
 
-/// Callback to allow backends to specify target-specific scratch sizes for some
-/// operations.
+/// Callback to allow backends to specify target-specific scratch sizes for
+/// some operations.
 using AllocationAnalysisScratchSizeFn = std::function<unsigned(Operation *)>;
+
+unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op);
 
 // To convert a tensor from one layout to another, we need to allocate a
 // temporary buffer (i.e., scratch buffer) in shared memory. The conversion may
@@ -257,9 +259,9 @@ class ModuleAllocation : public CallGraph<Allocation> {
 public:
   using FuncOffsetMapT = DenseMap<FunctionOpInterface, Value>;
 
-  ModuleAllocation(
-      ModuleOp moduleOp,
-      triton::AllocationAnalysisScratchSizeFn scratchSizeGetter = nullptr)
+  ModuleAllocation(ModuleOp moduleOp,
+                   triton::AllocationAnalysisScratchSizeFn scratchSizeGetter =
+                       triton::defaultAllocationAnalysisScratchSizeFn)
       : CallGraph<Allocation>(moduleOp) {
     walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
         // Pre-order edge walk callback

--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -18,8 +18,6 @@ namespace mlir {
 namespace triton {
 class AllocationAnalysis;
 
-constexpr inline unsigned invalidAllocationSize = -1;
-
 /// Callback to allow backends to specify target-specific scratch sizes for
 /// some operations.
 using AllocationAnalysisScratchSizeFn = std::function<unsigned(Operation *)>;

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -254,16 +254,6 @@ private:
       return;
     }
     unsigned bytes = scratchSizeGetter(op);
-    if (bytes == invalidAllocationSize) {
-      assert(
-          scratchSizeGetter
-                  .target<decltype(defaultAllocationAnalysisScratchSizeFn)>() !=
-              defaultAllocationAnalysisScratchSizeFn &&
-          "Default implementation should return a valid value");
-      bytes = defaultAllocationAnalysisScratchSizeFn(op);
-    }
-    assert(bytes != invalidAllocationSize &&
-           "Default implementation should return a valid value");
     maybeAddScratchBuffer<BufferT::BufferKind::Scratch>(op, bytes,
                                                         scratchAlignment);
   }

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -1,6 +1,5 @@
 // RUN: triton-opt %s -split-input-file --mlir-disable-threading -test-print-allocation 2>&1 | FileCheck %s
 // RUN: triton-opt %s -split-input-file --mlir-disable-threading -test-print-allocation="get-scratch-size-function=ValidConstant" 2>&1 | FileCheck %s --check-prefix=CHECK-128
-// RUN: triton-opt %s -split-input-file --mlir-disable-threading -test-print-allocation="get-scratch-size-function=Invalid" 2>&1 | FileCheck %s
 
 // Check there are no lines with a size different to 128 and we have at least a line with size 128.
 

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -1,4 +1,12 @@
 // RUN: triton-opt %s -split-input-file --mlir-disable-threading -test-print-allocation 2>&1 | FileCheck %s
+// RUN: triton-opt %s -split-input-file --mlir-disable-threading -test-print-allocation="get-scratch-size-function=ValidConstant" 2>&1 | FileCheck %s --check-prefix=CHECK-128
+// RUN: triton-opt %s -split-input-file --mlir-disable-threading -test-print-allocation="get-scratch-size-function=Invalid" 2>&1 | FileCheck %s
+
+// Check there are no lines with a size different to 128 and we have at least a line with size 128.
+
+// CHECK-128-NOT: scratch offset = {{.*}}, size = {{^(128)}}
+// CHECK-128: scratch offset = {{.*}}, size = 128
+// CHECK-128-NOT: scratch offset = {{.*}}, size = {{^(128)}}
 
 #AL = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #sliceAd0 = #triton_gpu.slice<{dim = 0, parent = #AL}>

--- a/test/lib/Analysis/TestAllocation.cpp
+++ b/test/lib/Analysis/TestAllocation.cpp
@@ -6,14 +6,10 @@ using namespace mlir;
 namespace {
 
 unsigned getScratchSize128(Operation *) { return 128; }
-unsigned getScratchSizeInvalid(Operation *) {
-  return mlir::triton::invalidAllocationSize;
-}
 
 enum class GetScratchSizeFunction {
   None,
   ValidConstant,
-  Invalid,
 };
 
 struct TestAllocationPass
@@ -36,8 +32,6 @@ struct TestAllocationPass
       return {getOperation()};
     case GetScratchSizeFunction::ValidConstant:
       return {getOperation(), getScratchSize128};
-    case GetScratchSizeFunction::Invalid:
-      return {getOperation(), getScratchSizeInvalid};
     }
     llvm_unreachable("Unhandled case");
   }
@@ -83,8 +77,7 @@ struct TestAllocationPass
       llvm::cl::values(
           clEnumValN(GetScratchSizeFunction::None, "None", "None (default)"),
           clEnumValN(GetScratchSizeFunction::ValidConstant, "ValidConstant",
-                     "ValidConstant"),
-          clEnumValN(GetScratchSizeFunction::Invalid, "Invalid", "Invalid"))};
+                     "ValidConstant"))};
 };
 
 } // namespace

--- a/test/lib/Analysis/TestAllocation.cpp
+++ b/test/lib/Analysis/TestAllocation.cpp
@@ -5,21 +5,48 @@ using namespace mlir;
 
 namespace {
 
+unsigned getScratchSize128(Operation *) { return 128; }
+unsigned getScratchSizeInvalid(Operation *) {
+  return mlir::triton::invalidAllocationSize;
+}
+
+enum class GetScratchSizeFunction {
+  None,
+  ValidConstant,
+  Invalid,
+};
+
 struct TestAllocationPass
     : public PassWrapper<TestAllocationPass, OperationPass<ModuleOp>> {
 
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestAllocationPass);
+
+  TestAllocationPass() = default;
+  TestAllocationPass(const TestAllocationPass &other)
+      : PassWrapper<TestAllocationPass, OperationPass<ModuleOp>>(other) {}
 
   StringRef getArgument() const final { return "test-print-allocation"; }
   StringRef getDescription() const final {
     return "print the result of the allocation pass";
   }
 
+  ModuleAllocation getModuleAllocation() {
+    switch (getScratchSizeFunction) {
+    case GetScratchSizeFunction::None:
+      return {getOperation()};
+    case GetScratchSizeFunction::ValidConstant:
+      return {getOperation(), getScratchSize128};
+    case GetScratchSizeFunction::Invalid:
+      return {getOperation(), getScratchSizeInvalid};
+    }
+    llvm_unreachable("Unhandled case");
+  }
+
   void runOnOperation() override {
     auto &os = llvm::errs();
     ModuleOp moduleOp = getOperation();
     // Convert to std::string can remove quotes from opName
-    ModuleAllocation moduleAllocation(moduleOp);
+    ModuleAllocation moduleAllocation = getModuleAllocation();
     moduleOp.walk([&](triton::FuncOp funcOp) {
       auto opName = SymbolTable::getSymbolName(funcOp).getValue().str();
       os << opName << "\n";
@@ -48,6 +75,16 @@ struct TestAllocationPass
       os << "size = " << allocation->getSharedMemorySize() << "\n";
     });
   }
+
+  Option<GetScratchSizeFunction> getScratchSizeFunction{
+      *this, "get-scratch-size-function",
+      llvm::cl::desc("Custom scratch size function to use"),
+      llvm::cl::init(GetScratchSizeFunction::None),
+      llvm::cl::values(
+          clEnumValN(GetScratchSizeFunction::None, "None", "None (default)"),
+          clEnumValN(GetScratchSizeFunction::ValidConstant, "ValidConstant",
+                     "ValidConstant"),
+          clEnumValN(GetScratchSizeFunction::Invalid, "Invalid", "Invalid"))};
 };
 
 } // namespace


### PR DESCRIPTION
Allow passing a functor to `ModuleAllocation` constructor to override
`getScratchValueSize` in the allocation analysis. This parameter will
be a default implementation by default.

The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because it isn't modifying compiler functionality, just enabling new memory allocation analysis implementations to be used while keeping the same interface.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
