### PR TITLE
[FRONTEND] Fix handling of `from m import x as y` in CodeGenerator

### DIFF
--- a/python/test/unit/language/test_libdevice.py
+++ b/python/test/unit/language/test_libdevice.py
@@ -1,0 +1,23 @@
+import torch
+
+import triton
+import triton.language as tl
+
+from triton.language.extra.libdevice import fast_dividef as my_fast_dividef
+
+
+def test_libdevice_rename(device):
+    # mark the import as used by this test
+    _ = my_fast_dividef
+
+    @triton.jit
+    def triton_copy(in_ptr, out_ptr, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.arange(0, BLOCK_SIZE)
+        data = tl.load(in_ptr + offsets)
+        tl.store(out_ptr + offsets, data)
+
+    BLOCK_SIZE = 256
+    inp = torch.randn(BLOCK_SIZE, device=device)
+    out = torch.empty_like(inp)
+
+    triton_copy[(1, )](inp, out, BLOCK_SIZE)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -218,7 +218,7 @@ class CodeGenerator(ast.NodeVisitor):
 
             module_name = getattr(v, "__module__", "")
             if module_name in module_map:
-                self.gscope[k] = getattr(module_map[module_name], k)
+                self.gscope[k] = getattr(module_map[module_name], v.__name__)
             else:
                 self.gscope[k] = v
 


### PR DESCRIPTION
Context: in `CodeGenerator.__init__`, globals for a given triton function are modified to handle remapping the libdevice module to cuda or hip (from https://github.com/triton-lang/triton/pull/4539). In particular, this logic:

```python
for k, v in gscope.items():  # gscope is a dict of fn.__globals__
  ...
  self.gscope[k] = getattr(module_map[module_name], k)
```

was failing if you do this in the global scope: `from triton.language.extras.libdevice import fast_dividef as my_fast_dividef`.