### PR TITLE
[BACKEND] Fix mmav2 for fp8

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -62,7 +62,7 @@ ValueTableV2 getValuesFromDotOperandLayoutStruct(
     ConversionPatternRewriter &rewriter, Value value, int batch, int repOuter,
     int repK, RankedTensorType type) {
   auto elems = unpackLLElements(loc, value, rewriter);
-  auto eltTy = type.getElementType();
+  auto eltTy = typeConverter->convertType(type.getElementType());
   int offset{};
   ValueTableV2 vals;
   auto bitwidth = eltTy.getIntOrFloatBitWidth();


### PR DESCRIPTION
```
within split at ./test.mlir:1 offset :23:10: error: 'llvm.bitcast' op result #0 must be LLVM-compatible non-aggregate type, but got 'f8E5M2'
    %D = tt.dot %AA_DOT, %BB_DOT, %cst0 : tensor<16x16xf8E5M2, #dot_operand_a> * tensor<16x16xf8E5M2, #dot_operand_b> -> tensor<16x16xf32, #mma0>
         ^
```
fp8E5M2 should be converted to i8 in the LLVM backend