### PR TITLE
Remove unknown distribution option: `test_suite`

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -729,7 +729,6 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
     ],
-    test_suite="tests",
     extras_require={
         "build": [
             "cmake>=3.20",


### PR DESCRIPTION
Example: 
```bash
  /tmp/pip-build-env-75pviu48/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py:261: UserWarning: Unknown distribution option: 'test_suite'
    warnings.warn(msg)
```

According to https://setuptools.pypa.io/en/latest/references/keywords.html it `Deprecated since version 41.5.0`. I also noticed that triton supports the following versions `setuptools>=40.8.0` and for some versions this parameter should still work, however it is not used in CI and it seems not a very popular way to test via `python setup.py test` command. 