### PR TITLE
Refactor convertLayoutOp by expanding dot operands of 2d tensors to 3d

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -478,6 +478,7 @@ using ::mlir::LLVM::SharedMemoryObject;
 using ::mlir::triton::gpu::AMDMfmaEncodingAttr;
 using ::mlir::triton::gpu::AMDWmmaEncodingAttr;
 using ::mlir::triton::gpu::BlockedEncodingAttr;
+using ::mlir::triton::gpu::SharedEncodingAttr;
 using ::mlir::triton::gpu::CTALayoutAttr;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
@@ -493,6 +494,41 @@ inline Value dot(RewriterBase &rewriter, Location loc, ArrayRef<Value> offsets,
   return ret;
 }
 
+template <typename T>
+SmallVector<T> insertValue(ArrayRef<T> vec, unsigned index, T value) {
+  SmallVector<T> res(vec.begin(), vec.end());
+  res.insert(res.begin() + index, value);
+  return res;
+}
+template <typename T>
+SmallVector<T> insertValue(const SmallVector<T> &vec, unsigned index, T value) {
+  SmallVector<T> res(vec.begin(), vec.end());
+  res.insert(res.begin() + index, value);
+  return res;
+}
+
+/// Extend 2d shared object to 3d.
+///
+/// If tensor has 3 dimensions, returns original shared object.
+/// If tensor shape is [M, N], return shared object describing shape [1, M, N]
+///
+/// This Function is used to simplify processing of 2d and 3d dot operands,
+/// particularly in the conversion of local_load operation.
+///
+/// \param rewriter
+/// \param loc
+/// \param smemObj
+/// \param shape shape of a tensor represented by smemObj
+/// \returns shared object describing 3d tensor
+SharedMemoryObject
+getExpandedSharedMemoryObject(ConversionPatternRewriter &rewriter, Location loc,
+                              SharedMemoryObject smemObj,
+                              ArrayRef<int64_t> shape);
+
+CTALayoutAttr getExpandedCTALayout(MLIRContext *ctx,
+                                   CTALayoutAttr ctaLayoutAttr);
+
+Attribute getExpandedSharedEncoding(SharedEncodingAttr SharedEncoding);
 // -----------------------------------------------------------------------
 // Blocked layout indices
 // -----------------------------------------------------------------------

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -907,4 +907,58 @@ Value mxfpScaleBf16(RewriterBase &rewriter, Location loc, Value v,
 };
 
 } // namespace LLVM
+
+SharedMemoryObject
+getExpandedSharedMemoryObject(ConversionPatternRewriter &rewriter, Location loc,
+                              SharedMemoryObject smemObj,
+                              ArrayRef<int64_t> shape) {
+  auto strides = smemObj.getStrides();
+  auto offsets = smemObj.getOffsets();
+  auto rank = strides.size();
+  if (rank == 3)
+    return smemObj;
+  auto expandedStrides = insertValue(strides, 0, i32_val(shape[0] * shape[1]));
+  auto expandedOffsets = insertValue(offsets, 0, i32_val(0));
+  auto expandedSmemObj =
+      SharedMemoryObject(smemObj.getBase(), smemObj.getBaseElemType(),
+                         expandedStrides, expandedOffsets);
+  return expandedSmemObj;
+}
+
+CTALayoutAttr getExpandedCTALayout(MLIRContext *ctx,
+                                   CTALayoutAttr ctaLayoutAttr) {
+  auto rank = ctaLayoutAttr.getCTAsPerCGA().size();
+  if (rank == 3) {
+    return ctaLayoutAttr;
+  }
+
+  auto ctasPerCGA3d =
+      insertValue<unsigned>(ctaLayoutAttr.getCTAsPerCGA(), rank, 1);
+  auto ctasSplitNum3d =
+      insertValue<unsigned>(ctaLayoutAttr.getCTASplitNum(), rank, 1);
+  auto ctaOrder3d =
+      insertValue<unsigned>(ctaLayoutAttr.getCTAOrder(), rank, rank);
+  auto expandedCTALayout = triton::gpu::CTALayoutAttr::get(
+      ctx, ctasPerCGA3d, ctasSplitNum3d, ctaOrder3d);
+  return expandedCTALayout;
+}
+
+Attribute getExpandedSharedEncoding(SharedEncodingAttr sharedEncoding) {
+  auto ctx = sharedEncoding.getContext();
+  auto order = sharedEncoding.getOrder();
+  auto rank = order.size();
+  if (rank == 3) {
+    return sharedEncoding;
+  }
+  auto expandedOrder = SmallVector<unsigned>(3, 0);
+  expandedOrder[0] = order[0] + 1;
+  expandedOrder[1] = order[1] + 1;
+  ArrayRef<unsigned> expandedOrderArr(expandedOrder);
+  auto expandedEncoding = triton::gpu::SharedEncodingAttr::get(
+      ctx, sharedEncoding.getVec(), sharedEncoding.getPerPhase(),
+      sharedEncoding.getMaxPhase(), expandedOrderArr,
+      getExpandedCTALayout(ctx, sharedEncoding.getCTALayout()),
+      sharedEncoding.getHasLeadingOffset());
+  return expandedEncoding;
+}
 } // namespace mlir


### PR DESCRIPTION
This patch eliminates rank checks in convertLayoutOp implementations by expanding a 2D tensor to a 3D tensor.