### PR TITLE
[TEST] Skip poison when checking llvm ir for xpu

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -32,6 +32,7 @@ from triton._internal_testing import (
     is_hip_cdna,
     is_hip_mi200,
     is_hip_mi300,
+    is_xpu,
     get_arch,
     torch_float8_dtypes,
     torch_dtypes,
@@ -5181,7 +5182,9 @@ def test_poison_return(device):
     a = torch.empty((), device=device, dtype=torch.int32)
     h = kernel[(1, )](a)
     assert "ub.poison" in h.asm["ttir"], h.asm["ttir"]
-    assert "poison" in h.asm["llir"], h.asm["llir"]
+    # xpu uses llvm.store, which in this case is removed by the optimizer
+    if not is_xpu():
+        assert "poison" in h.asm["llir"], h.asm["llir"]
 
 
 # -----------------------

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -59,6 +59,11 @@ def is_hip_cdna():
     return is_hip_mi200() or is_hip_mi300()
 
 
+def is_xpu():
+    target = get_current_target()
+    return False if target is None else target.backend == "xpu"
+
+
 def get_arch():
     target = get_current_target()
     return "" if target is None else str(target.arch)


### PR DESCRIPTION
Cuda converts `tt.store` to `inline_asm` command, and xpu converts it to `llvm.store`. Then the LLVM optimizer for the SROA function removes `llvm.store` with the poison value, but ignores the cuda assembly instruction.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
