### PR TITLE
Create an aggregate `check-triton-unit` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,9 @@ if(NOT WIN32)
 endif()
 
 if(TRITON_BUILD_UT)
+  # This is an aggregate target for all unit tests.
+  add_custom_target(TritonUnitTests)
+  set_target_properties(TritonUnitTests PROPERTIES FOLDER "Triton/Tests")
   include(AddTritonUnitTest)
 endif()
 
@@ -340,4 +343,10 @@ add_subdirectory(test)
 
 if(TRITON_BUILD_UT)
   add_subdirectory(unittest)
+  # This target runs all the unit tests.
+  add_custom_target(check-triton-unit
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+    DEPENDS TritonUnitTests
+    USES_TERMINAL
+  )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,7 +344,7 @@ add_subdirectory(test)
 if(TRITON_BUILD_UT)
   add_subdirectory(unittest)
   # This target runs all the unit tests.
-  add_custom_target(check-triton-unit
+  add_custom_target(check-triton-unit-tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
     DEPENDS TritonUnitTests
     USES_TERMINAL

--- a/cmake/AddTritonUnitTest.cmake
+++ b/cmake/AddTritonUnitTest.cmake
@@ -36,4 +36,7 @@ function(add_triton_ut)
   # laptop.  I think the issue may be that the very first time you run a program
   # it's a bit slow.
   gtest_discover_tests(${__NAME} DISCOVERY_TIMEOUT 60)
+
+  # Add the unit test to the top-level unit test target.
+  add_dependencies(TritonUnitTests ${__NAME})
 endfunction()


### PR DESCRIPTION
This adds a CMake target `check-triton-unit` that builds an runs all Triton unittests written in gtest. This makes it more conveninent to rebuild and run all unittests at once with finer granularity (instead of `ninja; ctest`).
