### PR TITLE
Support computation pipelining after SWP refactoring

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
@@ -418,6 +418,27 @@ scheduleRemainingToLastStage(scf::ForOp forOp, tt::CoarseSchedule &schedule,
   }
 }
 
+static const char *kLoopScheduleAttrName = "tt.loop_schedule";
+std::string getLoopScheduleOrDefault(scf::ForOp forOp) {
+  if (!forOp->hasAttr(kLoopScheduleAttrName))
+    return "default";
+  return (cast<StringAttr>(forOp->getAttr(kLoopScheduleAttrName))).str();
+}
+
+static bool isHeavyComputation(Operation *op) {
+  // include exp2, mulf, addf 1D. Somehow we don't go through reduction
+  // when checking dependencies
+  if (!isa<arith::MulFOp>(op) && !isa<math::Exp2Op>(op) &&
+      !isa<arith::AddFOp>(op))
+    return false;
+  auto tensorTy = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  if (!tensorTy)
+    return false;
+  if (tensorTy.getRank() < 1)
+    return false;
+  return true;
+}
+
 #define GEN_PASS_DEF_TRITONGPULOOPSCHEDULING
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
 
@@ -437,6 +458,155 @@ public:
         .getInt();
   }
 
+  bool
+  isFlashAttention(scf::ForOp forOp,
+                   llvm::SmallVector<std::tuple<Operation *, int, Operation *>>
+                       &loadOpToIndLevelAndUse,
+                   SmallVector<Operation *> &keyOps,
+                   DenseSet<Operation *> &heavyCompOps) {
+    SmallVector<Operation *> loads;
+    SmallVector<Operation *> dots;
+    for (Operation &op : forOp.getBody()->without_terminator()) {
+      // Check for loop-carried dependencies.
+      // We have two loadOps, one feeding the first dot, and the other feeding
+      // the second dot.
+      if (isa<tt::LoadOp, tt::ExperimentalDescriptorLoadOp>(op)) {
+        loads.push_back(&op);
+      }
+      if (op.hasTrait<OpTrait::DotLike>()) {
+        dots.push_back(&op);
+      }
+    }
+    if (dots.size() != 2 || loads.size() != 2)
+      return false;
+
+    Operation *secondDot = dots[1];
+    DenseSet<Operation *> seen;
+    DenseSet<Operation *> tracedDots;
+    // Make sure there is a dependency path from firstDot to secondDot.
+    // This means we need to do computation pipelining to break the dependency.
+    std::function<void(Operation * op)> dfs = [&](Operation *op) {
+      if (!seen.insert(op).second)
+        return;
+      for (Value operand : op->getOperands()) {
+        Value v = operand;
+        Operation *defOp = v.getDefiningOp();
+        if (defOp && defOp->getBlock() == op->getBlock()) {
+          if (defOp->hasTrait<OpTrait::DotLike>()) {
+            // Stop tracing when hitting a dot.
+            tracedDots.insert(defOp);
+          } else {
+            if (isHeavyComputation(defOp))
+              heavyCompOps.insert(defOp);
+            dfs(defOp);
+          }
+        }
+      }
+    };
+    dfs(secondDot);
+    if (tracedDots.size() != 1)
+      return false;
+
+    for (auto [loadOp, dist, use] : loadOpToIndLevelAndUse) {
+      if (dist != 0)
+        return false;
+    }
+
+    keyOps.push_back(loads[0]); // FIXME
+    keyOps.push_back(loads[1]);
+    keyOps.push_back(dots[0]);
+    keyOps.push_back(secondDot);
+    return true;
+  }
+
+  void getFAFirstDotSchedule(scf::ForOp forOp, tt::CoarseSchedule &schedule,
+                             int numStages) {
+    llvm::SmallVector<std::tuple<Operation *, int, Operation *>>
+        loadOpToIndLevelAndUse = loadOpsToIndirectionLevelAndUse(forOp);
+    LLVM_DEBUG({
+      LDBG("Found " << loadOpToIndLevelAndUse.size() << " loads to pipeline:");
+      for (const auto &[l, i, u] : loadOpToIndLevelAndUse) {
+        LDBG("  - load: " << *l);
+        LDBG("    at indirection level: " << i);
+        LDBG("    used by op: " << *u);
+      }
+    });
+    if (loadOpToIndLevelAndUse.empty())
+      return;
+
+    // Check to see if the for loop matches the pattern for flash attention.
+    // If yes, move the first dot to its own stage (numStages - 2), the
+    // rest of the computation will be in stage (numStages - 1). The two loads
+    // will be in stage 0 and 1.
+    SmallVector<Operation *> keyOps;
+    DenseSet<Operation *> heavyCompOps;
+    if (!isFlashAttention(forOp, loadOpToIndLevelAndUse, keyOps,
+                          heavyCompOps)) {
+      LDBG("isFlashAttention returns false");
+      return;
+    }
+    // firstLoad: keyOps[0]
+    tt::CoarseSchedule::Cluster rootUsersCluster =
+        schedule.clusters.newAtFront();
+    tt::CoarseSchedule::Cluster loadCluster = schedule.clusters.newAtBack();
+    schedule.insert(keyOps[0], 0, loadCluster);
+    schedule.insert(keyOps[1], 1, loadCluster);
+    schedule.insert(keyOps[2], numStages - 2, rootUsersCluster);
+    schedule.insert(keyOps[3], numStages - 1, rootUsersCluster);
+    return;
+  }
+
+  void getFASecondDotSchedule(scf::ForOp forOp, tt::CoarseSchedule &schedule,
+                              int numStages) {
+    llvm::SmallVector<std::tuple<Operation *, int, Operation *>>
+        loadOpToIndLevelAndUse = loadOpsToIndirectionLevelAndUse(forOp);
+    LLVM_DEBUG({
+      LDBG("Found " << loadOpToIndLevelAndUse.size() << " loads to pipeline:");
+      for (const auto &[l, i, u] : loadOpToIndLevelAndUse) {
+        LDBG("  - load: " << *l);
+        LDBG("    at indirection level: " << i);
+        LDBG("    used by op: " << *u);
+      }
+    });
+    if (loadOpToIndLevelAndUse.empty())
+      return;
+
+    // Check to see if the for loop matches the pattern for flash attention.
+    // If yes, move the second dot to its own stage (numStages - 1), the
+    // rest of the computation will be in stage (numStages - 2). The two loads
+    // will be in stage 0 and 1.
+    SmallVector<Operation *> keyOps;
+    DenseSet<Operation *> heavyCompOps;
+    if (!isFlashAttention(forOp, loadOpToIndLevelAndUse, keyOps,
+                          heavyCompOps)) {
+      LDBG("isFlashAttention returns false");
+      return;
+    }
+    // Go through loop body
+    for (Operation &op : forOp.getBody()->without_terminator()) {
+      if (isHeavyComputation(&op))
+        heavyCompOps.insert(&op);
+    }
+    // keyOps: load0, load1, dot0, dot1
+    //   Dot0(i+1)
+    //   Dot1(i)
+    //   Softmax(i+1): includes MUL0(i+1)
+    //   MUL1(i+1)
+    tt::CoarseSchedule::Cluster rootUsersCluster =
+        schedule.clusters.newAtFront();
+    tt::CoarseSchedule::Cluster nextCluster = schedule.clusters.newAtBack();
+    tt::CoarseSchedule::Cluster nextNextCluster = schedule.clusters.newAtBack();
+    tt::CoarseSchedule::Cluster loadCluster = schedule.clusters.newAtBack();
+    schedule.insert(keyOps[0], 0, loadCluster);
+    schedule.insert(keyOps[1], 1, loadCluster);
+    schedule.insert(keyOps[2], numStages - 2, rootUsersCluster);
+    schedule.insert(keyOps[3], numStages - 1, nextCluster);
+    // Softmax(i+1), MUL1(i+1) in nextNextCluster
+    for (auto *heavyOp : heavyCompOps)
+      schedule.insert(heavyOp, numStages - 2, nextNextCluster);
+    return;
+  }
+
   void runOnOperation() override {
     SmallVector<scf::ForOp> loops;
     getOperation()->walk([&](scf::ForOp forOp) {
@@ -451,7 +621,16 @@ public:
       int loopNumStages = getNumStagesOrDefault(forOp);
       DenseSet<Operation *> rootUsers;
       tt::CoarseSchedule coarseSchedule(loopNumStages);
-      scheduleLoads(forOp, coarseSchedule, rootUsers, loopNumStages);
+      std::string loopSchedule = getLoopScheduleOrDefault(forOp);
+      if (loopSchedule == "default") {
+        scheduleLoads(forOp, coarseSchedule, rootUsers, loopNumStages);
+      } else if (loopSchedule == "FA_firstDot") {
+        getFAFirstDotSchedule(forOp, coarseSchedule, loopNumStages);
+      } else if (loopSchedule == "FA_secondDot") {
+        getFASecondDotSchedule(forOp, coarseSchedule, loopNumStages);
+      } else {
+        assert(false && "unrecognized loop schedule");
+      }
       if (coarseSchedule.opToStageAndCluster.size() == 0)
         continue;
       tt::CoarseSchedule::Cluster afterPrologue = schedulePrologueAndEpilogue(

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -80,6 +80,15 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
     storeOp.getMaskMutable().assign(mask);
     return op;
   }
+  if (isa<ttng::WarpGroupDotOp>(op))
+    return op;
+  if (auto wait = dyn_cast<ttng::WaitBarrierOp>(op)) {
+    rewriter.setInsertionPoint(wait);
+    auto ifOp =
+        rewriter.create<scf::IfOp>(wait->getLoc(), pred, /*else=*/false);
+    rewriter.moveOpBefore(wait, ifOp.thenBlock(), ifOp.thenBlock()->begin());
+    return ifOp;
+  }
 
   assert("don't know how to predicate this op" && false);
   return op;

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -385,6 +385,7 @@ void init_triton_ir(py::module &&m) {
   py::class_<Attribute>(m, "attribute", py::module_local());
   py::class_<IntegerAttr, Attribute>(m, "integer_attr", py::module_local());
   py::class_<BoolAttr, Attribute>(m, "bool_attr", py::module_local());
+  py::class_<StringAttr, Attribute>(m, "string_attr", py::module_local());
 
   // Ops
   py::class_<OpState>(m, "OpState", py::module_local())
@@ -683,6 +684,10 @@ void init_triton_ir(py::module &&m) {
       .def("get_int32_attr",
            [](TritonOpBuilder &self, int32_t value) {
              return self.getBuilder().getI32IntegerAttr(value);
+           })
+      .def("get_string_attr",
+           [](TritonOpBuilder &self, const std::string &value) {
+             return self.getBuilder().getStringAttr(value);
            })
       // Use arith.ConstantOp to create constants
       // Constants

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -930,6 +930,7 @@ class CodeGenerator(ast.NodeVisitor):
             return
         num_stages = None
         loop_unroll_factor = None
+        loop_schedule = None
         if IteratorClass is language.range:
             iterator = IteratorClass(*iter_args, **iter_kwargs)
             # visit iterator arguments
@@ -940,6 +941,7 @@ class CodeGenerator(ast.NodeVisitor):
             step = iterator.step
             num_stages = iterator.num_stages
             loop_unroll_factor = iterator.loop_unroll_factor
+            loop_schedule = iterator.loop_schedule
         elif IteratorClass is range:
             # visit iterator arguments
             # note: only `range` iterator is supported now
@@ -1014,6 +1016,8 @@ class CodeGenerator(ast.NodeVisitor):
                 for_op.set_attr("tt.num_stages", self.builder.get_int32_attr(num_stages))
             if loop_unroll_factor is not None:
                 for_op.set_attr("tt.loop_unroll_factor", self.builder.get_int32_attr(loop_unroll_factor))
+            if loop_schedule is not None:
+                for_op.set_attr("tt.loop_schedule", self.builder.get_string_attr(loop_schedule.value))
 
             self.scf_stack.append(node)
             for_op_body = for_op.get_body(0)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2685,7 +2685,7 @@ class range:
 
         @triton.jit
         def kernel(...):
-            for i in tl.range(10, num_stages=3):
+            for i in tl.range(10, num_stages=3, loop_schedule="Default"):
                 ...
     :note: This is a special iterator used to implement similar semantics to Python's :code:`range` in the context of
         :code:`triton.jit` functions. In addition, it allows user to pass extra attributes to the compiler.
@@ -2702,9 +2702,10 @@ class range:
     :param loop_unroll_factor: Tells the Triton IR level loop unroller how many
         times to unroll a for loop that this range is used with. Less than 2 for
         this value implies no unrolling.
+    :param loop_schedule: specify a scheduling policy for the loop.
     """
 
-    def __init__(self, arg1, arg2=None, step=None, num_stages=None, loop_unroll_factor=None):
+    def __init__(self, arg1, arg2=None, step=None, num_stages=None, loop_unroll_factor=None, loop_schedule=None):
         if step is None:
             self.step = constexpr(1)
         else:
@@ -2717,6 +2718,7 @@ class range:
             self.end = arg2
         self.num_stages = num_stages
         self.loop_unroll_factor = loop_unroll_factor
+        self.loop_schedule = loop_schedule
 
     def __iter__(self):
         raise RuntimeError("tl.range can only be used in @triton.jit'd functions")


### PR DESCRIPTION
With the recent SWP refactoring, it is much easier to support arbitrary stage assignments where computations can be separated into different stages. Computation pipelining is basically splitting computations to different stages. Take flash attention as an example:
Currently the two loads are in stage 0 (S0), all other ops are in the last stage (stage 2). The loop body will look like
MMA0(i)
Softmax(i)
MUL(i)
MMA1(i)
LoadV(i+2)
LoadK(i+2)

This patch defines two different pipeline schedule for attention-like kernels:
1> putting first dot in S2, other computations in S3, loadK in stage 0, loadV in stage 1
MMA0(i+1)    
Softmax(i)
MUL(i)
MMA1(i)
loadK(i+3) 
loadV(i+2)
2> putting second dot in S3, other computations in S2, loadK in stage 0, loadV in stage 1
MMA0(i+1)      
MMA1(i)       
Softmax(i+1)   
MUL(i+1)           
loadK(i+3)       
loadV(i+2)

Preliminary performance number on H100 for flash attention:
  (Batch, Heads, SeqLen, Dhead)    triton_tutorial_flash_v2_opt-tflops    triton_tutorial_flash_v2_tma-tflops    triton_tutorial_flash_v2-tflops
--------------------------  --------------------------------  --------------------------------  ----------------------------
             (8, 16, 8192, 128)                                517.528                                504.565                            481.402

The implementation and the frontend is preliminary for discussion.             