### PR TITLE
[LAYOUTS] Implement LL conversion for DotOperand(Hopper)

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1017,7 +1017,8 @@ SmallVector<unsigned> DotOperandEncodingAttr::getCTASplitNum() const {
   assert(rank == 2 || rank == 3 && "Invalid dotLayout");
 
   // Do not split CTA in K dimension
-  getOpIdx() == 0 ? res[rank - 1] = 1 : res[rank - 2] = 1;
+  auto kDim = getOpIdx() == 0 ? rank - 1 : rank - 2;
+  res[kDim] = 1;
   return res;
 }
 SmallVector<unsigned> DotOperandEncodingAttr::getWarpsPerCTA() const {

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -41,10 +41,16 @@ public:
         CTALayoutAttr::get(&ctx, cpg, cSplit, cOrd), instrShape);
   }
 
-  DotOperandEncodingAttr dotMMAv2(int idx, int kWidth,
-                                  ArrayRef<unsigned> warps) {
-    auto mmaLayout = mma(2, 0, {16, 8}, warps, {1, 1}, {1, 1}, {1, 0});
-    return DotOperandEncodingAttr::get(&ctx, idx, mmaLayout, /*kWidth=*/kWidth);
+  NvidiaMmaEncodingAttr mma(unsigned versionMaj, unsigned versionMin,
+                            ArrayRef<unsigned> instrShape,
+                            ArrayRef<unsigned> numWarps) {
+    auto ctaLayout = CTALayoutAttr::getDefault(&ctx, numWarps.size());
+    return NvidiaMmaEncodingAttr::get(&ctx, versionMaj, versionMin, numWarps,
+                                      std::move(ctaLayout), instrShape);
+  }
+
+  DotOperandEncodingAttr dot(Attribute parent, int idx, int kWidth) {
+    return DotOperandEncodingAttr::get(&ctx, idx, parent, /*kWidth=*/kWidth);
   }
 
   AMDMfmaEncodingAttr mfma(ArrayRef<unsigned> warps, unsigned mDim,
@@ -391,8 +397,7 @@ TEST_F(LinearLayoutConversionsTest, MMAv2_Small3D) {
 }
 
 TEST_F(LinearLayoutConversionsTest, MMAv3_64x16) {
-  SmallVector<SmallVector<unsigned>, 4> instrShapes = {
-      {16, 16, 8}, {16, 16, 8}, {16, 8, 8}};
+  SmallVector<SmallVector<unsigned>, 2> instrShapes = {{16, 16, 8}, {16, 8, 8}};
   for (auto instrShape : instrShapes) {
     SCOPED_TRACE(triton::join(instrShape, ","));
     EXPECT_EQ(toLinearLayout({64, 16}, mma(3, 0, instrShape, {4, 1}, {1, 1},
@@ -515,7 +520,8 @@ TEST_F(LinearLayoutConversionsTest, MMAv3_4x4Warps) {
 }
 
 TEST_F(LinearLayoutConversionsTest, DotMMAv2_tile_kwidth8) {
-  EXPECT_EQ(toLinearLayout({16, 64}, dotMMAv2(0, 8, {1, 1})),
+  auto parent = mma(2, 0, {16, 8}, {1, 1});
+  EXPECT_EQ(toLinearLayout({16, 64}, dot(parent, 0, 8)),
             LinearLayout(
                 {
                     {S("register"), {{0, 1}, {0, 2}, {0, 4}, {8, 0}, {0, 32}}},
@@ -524,7 +530,7 @@ TEST_F(LinearLayoutConversionsTest, DotMMAv2_tile_kwidth8) {
                     {S("block"), {}},
                 },
                 {S("dim0"), S("dim1")}));
-  EXPECT_EQ(toLinearLayout({64, 8}, dotMMAv2(1, 8, {1, 1})),
+  EXPECT_EQ(toLinearLayout({64, 8}, dot(parent, 1, 8)),
             LinearLayout(
                 {
                     {S("register"), {{1, 0}, {2, 0}, {4, 0}, {32, 0}}},
@@ -536,8 +542,9 @@ TEST_F(LinearLayoutConversionsTest, DotMMAv2_tile_kwidth8) {
 }
 
 TEST_F(LinearLayoutConversionsTest, DotMMAv2_large_warp4_kwidth8) {
+  auto parent = mma(2, 0, {16, 8}, {4, 1});
   EXPECT_EQ(
-      toLinearLayout({128, 128}, dotMMAv2(0, 8, {4, 1})),
+      toLinearLayout({128, 128}, dot(parent, 0, 8)),
       LinearLayout(
           {
               {S("register"),
@@ -547,7 +554,7 @@ TEST_F(LinearLayoutConversionsTest, DotMMAv2_large_warp4_kwidth8) {
               {S("block"), {}},
           },
           {S("dim0"), S("dim1")}));
-  EXPECT_EQ(toLinearLayout({128, 64}, dotMMAv2(1, 8, {4, 1})),
+  EXPECT_EQ(toLinearLayout({128, 64}, dot(parent, 1, 8)),
             LinearLayout(
                 {
                     {S("register"),
@@ -567,7 +574,7 @@ TEST_F(LinearLayoutConversionsTest, DotMMAv2_large_warp4_kwidth8) {
                     {S("block"), {}},
                 },
                 {S("dim0"), S("dim1")}));
-  EXPECT_EQ(toLinearLayout({64, 128}, dotMMAv2(1, 8, {4, 1})),
+  EXPECT_EQ(toLinearLayout({64, 128}, dot(parent, 1, 8)),
             LinearLayout(
                 {
                     {S("register"),
@@ -589,22 +596,75 @@ TEST_F(LinearLayoutConversionsTest, DotMMAv2_large_warp4_kwidth8) {
                 {S("dim0"), S("dim1")}));
 }
 
+TEST_F(LinearLayoutConversionsTest, DotMMAv3_warp4_kwidth2) {
+  auto parent = mma(3, 0, {16, 16, 8}, {4, 1});
+  auto dotOp = dot(parent, 0, 2);
+
+  EXPECT_EQ(toLinearLayout({64, 16}, dotOp),
+            LinearLayout(
+                {
+                    {S("register"), {{0, 1}, {8, 0}, {0, 8}}},
+                    {S("lane"), {{0, 2}, {0, 4}, {1, 0}, {2, 0}, {4, 0}}},
+                    {S("warp"), {{16, 0}, {32, 0}}},
+                    {S("block"), {}},
+                },
+                {S("dim0"), S("dim1")}));
+
+  EXPECT_EQ(toLinearLayout({128, 16}, dotOp),
+            LinearLayout(
+                {
+                    {S("register"), {{0, 1}, {8, 0}, {0, 8}, {64, 0}}},
+                    {S("lane"), {{0, 2}, {0, 4}, {1, 0}, {2, 0}, {4, 0}}},
+                    {S("warp"), {{16, 0}, {32, 0}}},
+                    {S("block"), {}},
+                },
+                {S("dim0"), S("dim1")}));
+
+  EXPECT_EQ(toLinearLayout({128, 32}, dotOp),
+            LinearLayout(
+                {
+                    {S("register"), {{0, 1}, {8, 0}, {0, 8}, {0, 16}, {64, 0}}},
+                    {S("lane"), {{0, 2}, {0, 4}, {1, 0}, {2, 0}, {4, 0}}},
+                    {S("warp"), {{16, 0}, {32, 0}}},
+                    {S("block"), {}},
+                },
+                {S("dim0"), S("dim1")}));
+}
+
+TEST_F(LinearLayoutConversionsTest, DotMMAv3_mixed_warp_kwidth4) {
+  // Testing dot with MMAv3 encoding for opIdx = 0 and kWidth = 4
+  auto parent = mma(3, 0, {16, 16, 8}, {4, 2});
+  auto dotOp = dot(parent, 0, 4);
+
+  EXPECT_EQ(toLinearLayout({128, 64}, dotOp),
+            LinearLayout(
+                {
+                    {S("register"),
+                     {{0, 1}, {0, 2}, {8, 0}, {0, 16}, {0, 32}, {64, 0}}},
+                    {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {4, 0}}},
+                    {S("warp"), {{16, 0}, {32, 0}, {0, 0}}},
+                    {S("block"), {}},
+                },
+                {S("dim0"), S("dim1")}));
+}
+
 TEST_F(LinearLayoutConversionsTest, DotMMAv2_split_warp_kwidth8) {
+  auto parent = mma(2, 0, {16, 8}, {2, 2});
   EXPECT_EQ(
-      toLinearLayout({32, 64}, dotMMAv2(0, 8, {2, 2})),
+      toLinearLayout({32, 64}, dot(parent, 0, 8)),
       LinearLayout({{S("register"), {{0, 1}, {0, 2}, {0, 4}, {8, 0}, {0, 32}}},
                     {S("lane"), {{0, 8}, {0, 16}, {1, 0}, {2, 0}, {4, 0}}},
                     {S("warp"), {{0, 0}, {16, 0}}},
                     {S("block"), {}}},
                    {S("dim0"), S("dim1")}));
   EXPECT_EQ(
-      toLinearLayout({64, 16}, dotMMAv2(1, 8, {2, 2})),
+      toLinearLayout({64, 16}, dot(parent, 1, 8)),
       LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}, {32, 0}}},
                     {S("lane"), {{8, 0}, {16, 0}, {0, 1}, {0, 2}, {0, 4}}},
                     {S("warp"), {{0, 8}, {0, 0}}},
                     {S("block"), {}}},
                    {S("dim0"), S("dim1")}));
-  EXPECT_EQ(toLinearLayout({64, 128}, dotMMAv2(0, 8, {2, 2})),
+  EXPECT_EQ(toLinearLayout({64, 128}, dot(parent, 0, 8)),
             LinearLayout(
                 {{S("register"),
                   {{0, 1}, {0, 2}, {0, 4}, {8, 0}, {0, 32}, {0, 64}, {32, 0}}},
@@ -613,7 +673,7 @@ TEST_F(LinearLayoutConversionsTest, DotMMAv2_split_warp_kwidth8) {
                  {S("block"), {}}},
                 {S("dim0"), S("dim1")}));
   EXPECT_EQ(
-      toLinearLayout({128, 32}, dotMMAv2(1, 8, {2, 2})),
+      toLinearLayout({128, 32}, dot(parent, 1, 8)),
       LinearLayout(
           {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {32, 0}, {64, 0}, {0, 16}}},
            {S("lane"), {{8, 0}, {16, 0}, {0, 1}, {0, 2}, {0, 4}}},


### PR DESCRIPTION
We also rewrite the way we implement DotOperand(Ampere) and mma Ampere
to promote code reusing. I also started using what I believe is a rather
compact pattern to write these things, where you first call `identiyND`
with the `repOrder`, which gives you an LL with the dims in the correct
order, and then you construct the final layout by specifying the tiles
by multiplying `identity1D` maps. Using this allowed me to heavily
simplify the handling of the `warps` of `DotOperand` which used to be a
tad messy.
