### PR TITLE
[CI] Fix `du` failling if cache restore fails

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -221,12 +221,10 @@ jobs:
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton
-          ls -alh ~/.triton
-          du -sh ~/.triton/**
+          du -h -d 1 ~/.triton
 
           mkdir -p ~/.ccache
-          ls -alh ~/.ccache
-          du -sh ~/.ccache
+          du -h -d 1 ~/.ccache
       - name: Update PATH
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -295,12 +293,10 @@ jobs:
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton
-          ls -alh ~/.triton
-          du -sh ~/.triton/**
+          du -h -d 1 ~/.triton
 
           mkdir -p ~/.ccache
-          ls -alh ~/.ccache
-          du -sh ~/.ccache
+          du -h -d 1 ~/.ccache
       - # If we're on branch `main`, save the ccache Triton compilation artifacts
         # to the cache so they can be used by other (non-main) CI runs.
         #
@@ -391,12 +387,10 @@ jobs:
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton
-          ls -alh ~/.triton
-          du -sh ~/.triton/**
+          du -h -d 1 ~/.triton
 
           mkdir -p ~/.ccache
-          ls -alh ~/.ccache
-          du -sh ~/.ccache
+          du -h -d 1 ~/.ccache
       - name: Update PATH
         run: |
           echo "/opt/rocm/llvm/bin" >> $GITHUB_PATH
@@ -467,12 +461,10 @@ jobs:
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton
-          ls -alh ~/.triton
-          du -sh ~/.triton/**
+          du -h -d 1 ~/.triton
 
           mkdir -p ~/.ccache
-          ls -alh ~/.ccache
-          du -sh ~/.ccache
+          du -h -d 1 ~/.ccache
       - # If we're on branch `main`, save the ccache Triton compilation artifacts
         # to the cache so they can be used by other (non-main) CI runs.
         #
@@ -566,12 +558,10 @@ jobs:
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton
-          ls -alh ~/.triton
-          du -sh ~/.triton/**
+          du -h -d 1 ~/.triton
 
           mkdir -p ~/.ccache
-          ls -alh ~/.ccache
-          du -sh ~/.ccache
+          du -h -d 1 ~/.ccache
       - name: Update PATH
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -599,12 +589,10 @@ jobs:
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton
-          ls -alh ~/.triton
-          du -sh ~/.triton/**
+          du -h -d 1 ~/.triton
 
           mkdir -p ~/.ccache
-          ls -alh ~/.ccache
-          du -sh ~/.ccache
+          du -h -d 1 ~/.ccache
       - # If we're on branch `main`, save the ccache Triton compilation artifacts
         # to the cache so they can be used by other (non-main) CI runs.
         #

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -250,12 +250,10 @@ jobs:
         name: Inspect cache directories
         run: |
           mkdir -p ~/.triton
-          ls -alh ~/.triton
-          du -sh ~/.triton/**
+          du -h -d 1 ~/.triton
 
           mkdir -p ~/.ccache
-          ls -alh ~/.ccache
-          du -sh ~/.ccache
+          du -h -d 1 ~/.ccache
 
       - name: Update PATH
         run: |


### PR DESCRIPTION
Follow up to #5202

It's currently failing with the error
```
du: /Users/runner/.triton/**: No such file or directory
Error: Process completed with exit code 1.
```
which happens because even though the `.triton` directory exists, it is empty. This instead uses du on `.triton` with a depth of 1.