### PR TITLE
[BUILD] Ensure parent directory exists before creating symlinks

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -247,6 +247,7 @@ def update_symlink(link_path, source_path):
         shutil.rmtree(link_path)
 
     print(f"creating symlink: {link_path} -> {source_path}", file=sys.stderr)
+    link_path.absolute().parent.mkdir(parents=True, exist_ok=True)  # Ensure link's parent directory exists
     link_path.symlink_to(source_path, target_is_directory=True)
 
 


### PR DESCRIPTION
Fixes #5256
