### PR TITLE
Specify in `setup.py` that `setuptools>=40.8.0` is a required dependency

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -711,6 +711,7 @@ setup(
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",
     long_description="",
+    install_requires=["setuptools>=40.8.0"],
     packages=get_packages(),
     entry_points=get_entry_points(),
     package_data=package_data,


### PR DESCRIPTION
Closes #5090

@vancoykendall right that the dependency is used not only during build. However, for now I added it to `setup.py`, since the migration of dependencies to `pyproject.toml` has not yet occurred.