### PR TITLE
[BUILD] Skip installing test related python packages

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -581,7 +581,7 @@ jobs:
           echo "PATH is '$PATH'"
           cd python
           ccache --zero-stats
-          python3 -m pip install -v --no-build-isolation .[tests]
+          python3 -m pip install -v --no-build-isolation .
       - name: CCache Stats
         run: ccache --print-stats
       - name: Inspect cache directories

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -493,7 +493,7 @@ jobs:
           echo "PATH is '$PATH'"
           cd python
           ccache --zero-stats
-          python3 -m pip install -v --no-build-isolation .[tests]
+          python3 -m pip install -v --no-build-isolation .
 
       - *print-ccache-stats
       - *inspect-cache-directories-step


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/5292 failed because of macOS build. Since we don’t run any tests on macOS anyway, it’s fine to simply skip them.