### PR TITLE
[AMD] [MFMA] [WMMA] Improve Triton GPU to LLVM conversion

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -1009,6 +1009,7 @@ Row |       warp 0                warp 2
   let parameters = (
     ins
     "unsigned": $version,
+    "bool":$isTransposed,
     ArrayRefParameter<"unsigned">:$warpsPerCTA__,
     "CTALayoutAttr":$CTALayout
   );

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1913,8 +1913,8 @@ Attribute AMDWmmaEncodingAttr::parse(AsmParser &parser, Type type) {
 
 void AMDWmmaEncodingAttr::print(AsmPrinter &printer) const {
   printer << "<{"
-          << "version = " << getVersion() << ", isTranspose"
-          << getIsTransposed() << ", warpsPerCTA = ["
+          << "version = " << getVersion()
+          << ", isTranspose = " << getIsTransposed() << ", warpsPerCTA = ["
           << ArrayRef(getWarpsPerCTA()) << "]";
   maybePrintCTALayout(getContext(), printer, getCTALayout(),
                       /*rank=*/getWarpsPerCTA().size());

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -437,60 +437,6 @@ mfmaDotToLinearLayout(DotOperandEncodingAttr dotMfmaLayout,
 }
 
 std::optional<LinearLayout>
-wmmaDotToLinearLayout(DotOperandEncodingAttr dotWmmaLayout,
-                      ArrayRef<int64_t> shape) {
-  auto wmmaLayout = llvm::cast<AMDWmmaEncodingAttr>(dotWmmaLayout.getParent());
-
-  auto rank = shape.size();
-  bool hasBatchDim = rank == 3;
-  int mIndex = 0 + hasBatchDim;
-
-  int32_t kWidth = dotWmmaLayout.getKWidth();
-  auto kDim = dotWmmaLayout.getOpIdx() == 0 ? rank - 1 : rank - 2;
-  int32_t kSize = shape[kDim];
-  auto warpsPerCTA = wmmaLayout.getWarpsPerCTA();
-
-  MLIRContext *ctx = dotWmmaLayout.getContext();
-  SmallVector<StringAttr> outDimNames = standardOutDimNames(ctx, rank);
-
-  StringAttr kRegister = S("register");
-  StringAttr kLane = S("lane");
-  StringAttr kWarp = S("warp");
-
-  // register order
-  // operand A: [1, 0] / [2, 1, 0]
-  // operand B: [0, 1] / [1, 2, 0]
-  // for both cases it is [k, nonk]/[k, nonk, batch]
-  SmallVector<unsigned> order = triton::gpu::getOrder(dotWmmaLayout);
-  // warp order
-  // common for both operand A and B: [0, 1] / [0, 1, 2]
-  // in both cases it is [M dim, N dim]/[batch, M dim, N dim]
-  SmallVector<unsigned> warpOrder = triton::gpu::getWarpOrder(dotWmmaLayout);
-
-  std::vector<std::vector<int32_t>> registerBase = {{1, 0}, {2, 0}, {4, 0}};
-  if (kWidth == 16)
-    registerBase.emplace_back(std::vector<int32_t>{16, 0});
-  std::vector<std::vector<int32_t>> laneBase = {
-      {0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}};
-
-  LinearLayout tileLayout({{kRegister, registerBase}, {kLane, laneBase}},
-                          {outDimNames[order[0]], outDimNames[order[1]]});
-
-  if (hasBatchDim) {
-    assert(order[2] == 0);
-    // Extend the base vector with one value to accomodate for the batch
-    // dimension, which appears at the last.
-    tileLayout *= LinearLayout::identity1D(1, kRegister, outDimNames[order[2]]);
-    tileLayout *= LinearLayout::identity1D(1, kLane, outDimNames[order[2]]);
-  }
-
-  LinearLayout warpLayout = identityStandardND(kWarp, warpsPerCTA, warpOrder);
-  LinearLayout ctaLayout = tileLayout.transposeOuts(outDimNames) *
-                           warpLayout.transposeOuts(outDimNames);
-  return combineCtaCgaWithShape(ctaLayout, wmmaLayout.getCTALayout(), shape);
-}
-
-std::optional<LinearLayout>
 AMDWmmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   int rank = shape.size();
   assert(rank == getWarpsPerCTA().size());
@@ -543,7 +489,7 @@ AMDWmmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   // Please also check explaining comments in TritonGPUAttrDefs.td at the
   // AMDWmmaEncodingAttr section.
   unsigned ver = getVersion();
-  LinearLayout tileLayout;
+  auto tileLayout = LinearLayout::empty();
   switch (ver) {
   case 1:
     tileLayout = LinearLayout(
@@ -552,19 +498,10 @@ AMDWmmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
         {outDimNames[threadOrder[0]], outDimNames[threadOrder[1]]});
     break;
   case 2:
-    if (getIsTransposed()) {
-      tileLayout = LinearLayout(
-          {{kRegister, {{1, 0}, {2, 0}, {4, 0}}},
-           {kLane, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, /*gap*/ {8, 0}}}},
-          {outDimNames[threadOrder[0]], outDimNames[threadOrder[1]]})
-    } else {
-      tileLayout = LinearLayout(
-          {
-              {kLane, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, /*gap*/ {0, 8}}},
-              {kRegister, {{0, 1}, {0, 2}, {0, 4}}},
-          },
-          {outDimNames[threadOrder[0]], outDimNames[threadOrder[1]]});
-    }
+    tileLayout = LinearLayout(
+        {{kRegister, {{0, 1}, {0, 2}, {0, 4}}},
+         {kLane, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, /*gap*/ {0, 8}}}},
+        {outDimNames[threadOrder[0]], outDimNames[threadOrder[1]]});
     break;
   default:
     assert(false && "unexpected wmma layout version");
@@ -752,10 +689,6 @@ DotOperandEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   auto parent = getParent();
   if (auto mfmaLayout = llvm::dyn_cast<AMDMfmaEncodingAttr>(parent)) {
     return mfmaDotToLinearLayout(*this, shape);
-  } else if (auto wmmaLayout = llvm::dyn_cast<AMDWmmaEncodingAttr>(parent)) {
-    if (wmmaLayout.getVersion() == 2) {
-      return wmmaDotToLinearLayout(*this, shape);
-    }
   } else if (auto mma = mlir::dyn_cast<NvidiaMmaEncodingAttr>(parent)) {
     return nvidiaDotToLinearLayout(shape, *this);
   }

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -10,6 +10,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
 
@@ -436,6 +437,60 @@ mfmaDotToLinearLayout(DotOperandEncodingAttr dotMfmaLayout,
 }
 
 std::optional<LinearLayout>
+wmmaDotToLinearLayout(DotOperandEncodingAttr dotWmmaLayout,
+                      ArrayRef<int64_t> shape) {
+  auto wmmaLayout = llvm::cast<AMDWmmaEncodingAttr>(dotWmmaLayout.getParent());
+
+  auto rank = shape.size();
+  bool hasBatchDim = rank == 3;
+  int mIndex = 0 + hasBatchDim;
+
+  int32_t kWidth = dotWmmaLayout.getKWidth();
+  auto kDim = dotWmmaLayout.getOpIdx() == 0 ? rank - 1 : rank - 2;
+  int32_t kSize = shape[kDim];
+  auto warpsPerCTA = wmmaLayout.getWarpsPerCTA();
+
+  MLIRContext *ctx = dotWmmaLayout.getContext();
+  SmallVector<StringAttr> outDimNames = standardOutDimNames(ctx, rank);
+
+  StringAttr kRegister = S("register");
+  StringAttr kLane = S("lane");
+  StringAttr kWarp = S("warp");
+
+  // register order
+  // operand A: [1, 0] / [2, 1, 0]
+  // operand B: [0, 1] / [1, 2, 0]
+  // for both cases it is [k, nonk]/[k, nonk, batch]
+  SmallVector<unsigned> order = triton::gpu::getOrder(dotWmmaLayout);
+  // warp order
+  // common for both operand A and B: [0, 1] / [0, 1, 2]
+  // in both cases it is [M dim, N dim]/[batch, M dim, N dim]
+  SmallVector<unsigned> warpOrder = triton::gpu::getWarpOrder(dotWmmaLayout);
+
+  std::vector<std::vector<int32_t>> registerBase = {{1, 0}, {2, 0}, {4, 0}};
+  if (kWidth == 16)
+    registerBase.emplace_back(std::vector<int32_t>{16, 0});
+  std::vector<std::vector<int32_t>> laneBase = {
+      {0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}};
+
+  LinearLayout tileLayout({{kRegister, registerBase}, {kLane, laneBase}},
+                          {outDimNames[order[0]], outDimNames[order[1]]});
+
+  if (hasBatchDim) {
+    assert(order[2] == 0);
+    // Extend the base vector with one value to accomodate for the batch
+    // dimension, which appears at the last.
+    tileLayout *= LinearLayout::identity1D(1, kRegister, outDimNames[order[2]]);
+    tileLayout *= LinearLayout::identity1D(1, kLane, outDimNames[order[2]]);
+  }
+
+  LinearLayout warpLayout = identityStandardND(kWarp, warpsPerCTA, warpOrder);
+  LinearLayout ctaLayout = tileLayout.transposeOuts(outDimNames) *
+                           warpLayout.transposeOuts(outDimNames);
+  return combineCtaCgaWithShape(ctaLayout, wmmaLayout.getCTALayout(), shape);
+}
+
+std::optional<LinearLayout>
 AMDWmmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   int rank = shape.size();
   assert(rank == getWarpsPerCTA().size());
@@ -488,17 +543,32 @@ AMDWmmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   // Please also check explaining comments in TritonGPUAttrDefs.td at the
   // AMDWmmaEncodingAttr section.
   unsigned ver = getVersion();
-  assert(ver == 1 || ver == 2);
-  LinearLayout tileLayout =
-      ver == 1
-          ? LinearLayout(
-                {{kRegister, {/*gap*/ {0, 2}, {0, 4}, {0, 8}}},
-                 {kLane, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, /*gap*/ {0, 1}}}},
-                {outDimNames[threadOrder[0]], outDimNames[threadOrder[1]]})
-          : LinearLayout(
-                {{kRegister, {{0, 1}, {0, 2}, {0, 4}}},
-                 {kLane, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, /*gap*/ {0, 8}}}},
-                {outDimNames[threadOrder[0]], outDimNames[threadOrder[1]]});
+  LinearLayout tileLayout;
+  switch (ver) {
+  case 1:
+    tileLayout = LinearLayout(
+        {{kRegister, {/*gap*/ {0, 2}, {0, 4}, {0, 8}}},
+         {kLane, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, /*gap*/ {0, 1}}}},
+        {outDimNames[threadOrder[0]], outDimNames[threadOrder[1]]});
+    break;
+  case 2:
+    if (getIsTransposed()) {
+      tileLayout = LinearLayout(
+          {{kRegister, {{1, 0}, {2, 0}, {4, 0}}},
+           {kLane, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, /*gap*/ {8, 0}}}},
+          {outDimNames[threadOrder[0]], outDimNames[threadOrder[1]]})
+    } else {
+      tileLayout = LinearLayout(
+          {
+              {kLane, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, /*gap*/ {0, 8}}},
+              {kRegister, {{0, 1}, {0, 2}, {0, 4}}},
+          },
+          {outDimNames[threadOrder[0]], outDimNames[threadOrder[1]]});
+    }
+    break;
+  default:
+    assert(false && "unexpected wmma layout version");
+  }
 
   if (hasBatchDim) {
     int batchIndex = 0;
@@ -682,6 +752,10 @@ DotOperandEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   auto parent = getParent();
   if (auto mfmaLayout = llvm::dyn_cast<AMDMfmaEncodingAttr>(parent)) {
     return mfmaDotToLinearLayout(*this, shape);
+  } else if (auto wmmaLayout = llvm::dyn_cast<AMDWmmaEncodingAttr>(parent)) {
+    if (wmmaLayout.getVersion() == 2) {
+      return wmmaDotToLinearLayout(*this, shape);
+    }
   } else if (auto mma = mlir::dyn_cast<NvidiaMmaEncodingAttr>(parent)) {
     return nvidiaDotToLinearLayout(shape, *this);
   }

--- a/test/Conversion/amd/tritongpu_wmma_dot_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_wmma_dot_to_llvm.mlir
@@ -4,6 +4,7 @@
 #shared = #ttg.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], hasLeadingOffset = false}>
 #mma1 = #ttg.amd_wmma<{version = 1, warpsPerCTA = [2, 2]}>
 #mma2 = #ttg.amd_wmma<{version = 2, warpsPerCTA = [2, 2]}>
+#mma3 = #ttg.amd_wmma<{version = 2, warpsPerCTA = [2, 2], isTranspose = true}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   //  CHECK-LABEL: wmma1_dot_operand
   tt.func @wmma1_dot_operand(%arg0: !ttg.memdesc<64x64xf16, #shared>) {
@@ -96,6 +97,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-COUNT-8: llvm.extractelement {{.*}} : vector<8xf16>
     // CHECK: llvm.mlir.undef : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
     // CHECK-COUNT-8: llvm.insertvalue {{.*}} : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
+    tt.return
+  }
+
+  // CHECK-LABEL: wmma2_transposed_dot
+  tt.func @wmma2_transposed_dot(%arg0: tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma3, kWidth = 8}>>, %arg1: tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma3, kWidth = 8}>>, %arg2: tensor<16x16xf16, #mma3>) {
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.wmma.f16.16x16x16.f16.v8f16.v8f16"{{.*}} : (vector<8xf16>, vector<8xf16>, vector<8xf16>, i1) -> vector<8xf16>
+    %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma3, kWidth = 8}>> * tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma3, kWidth = 8}>> -> tensor<16x16xf16, #mma3>
     tt.return
   }
 

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen1.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen1.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul='arch-generation-name=gfx1100 matrix-instruction-size=0' | FileCheck %s
 
 // CHECK: #[[DOT_OP_PARENT:.+]] = #ttg.blocked<{{.*}}>
-// CHECK: #[[WMMA_0:.+]] = #ttg.amd_wmma<{version = 1, warpsPerCTA = [1, 4]}>
+// CHECK: #[[WMMA_0:.+]] = #ttg.amd_wmma<{version = 1, isTranspose = false, warpsPerCTA = [1, 4]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_cf32(
@@ -31,7 +31,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // -----
 
 // CHECK: #[[DOT_OP_PARENT:.+]] = #ttg.blocked<{{.*}}>
-// CHECK: #[[WMMA_1:.+]] = #ttg.amd_wmma<{version = 1, warpsPerCTA = [2, 2]}>
+// CHECK: #[[WMMA_1:.+]] = #ttg.amd_wmma<{version = 1, isTranspose = false, warpsPerCTA = [2, 2]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_cf16(
@@ -61,7 +61,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // -----
 
 // CHECK: #[[DOT_OP_PARENT:.+]] = #ttg.blocked<{{.*}}>
-// CHECK: #[[WMMA_0:.+]] = #ttg.amd_wmma<{version = 1, warpsPerCTA = [1, 4]}>
+// CHECK: #[[WMMA_0:.+]] = #ttg.amd_wmma<{version = 1, isTranspose = false, warpsPerCTA = [1, 4]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_ab8_cf16(
@@ -95,7 +95,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // -----
 
 // CHECK: #[[DOT_OP_PARENT:.+]] = #ttg.blocked<{{.*}}>
-// CHECK: #[[WMMA_1:.+]] = #ttg.amd_wmma<{version = 1, warpsPerCTA = [2, 2]}>
+// CHECK: #[[WMMA_1:.+]] = #ttg.amd_wmma<{version = 1, isTranspose = false, warpsPerCTA = [2, 2]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_i8_i32(

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen2.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen2.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul='arch-generation-name=gfx1200 matrix-instruction-size=0' | FileCheck %s
 
 // CHECK: #[[DOT_OP_PARENT:.+]] = #ttg.blocked<{{.*}}>
-// CHECK: #[[WMMA_0:.+]] = #ttg.amd_wmma<{version = 2, warpsPerCTA = [1, 4]}>
+// CHECK: #[[WMMA_0:.+]] = #ttg.amd_wmma<{version = 2, isTranspose = true, warpsPerCTA = [1, 4]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_cf32(
@@ -31,7 +31,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // -----
 
 // CHECK: #[[DOT_OP_PARENT:.+]] = #ttg.blocked<{{.*}}>
-// CHECK: #[[WMMA_1:.+]] = #ttg.amd_wmma<{version = 2, warpsPerCTA = [2, 2]}>
+// CHECK: #[[WMMA_1:.+]] = #ttg.amd_wmma<{version = 2, isTranspose = true, warpsPerCTA = [2, 2]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_cf16(
@@ -61,7 +61,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // -----
 
 // CHECK: #[[DOT_OP_PARENT:.+]] = #ttg.blocked<{{.*}}>
-// CHECK: #[[WMMA_0:.+]] = #ttg.amd_wmma<{version = 2, warpsPerCTA = [1, 4]}>
+// CHECK: #[[WMMA_0:.+]] = #ttg.amd_wmma<{version = 2, isTranspose = true, warpsPerCTA = [1, 4]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_ab8_cf16(
@@ -95,7 +95,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // -----
 
 // CHECK: #[[DOT_OP_PARENT:.+]] = #ttg.blocked<{{.*}}>
-// CHECK: #[[WMMA_1:.+]] = #ttg.amd_wmma<{version = 2, warpsPerCTA = [2, 2]}>
+// CHECK: #[[WMMA_1:.+]] = #ttg.amd_wmma<{version = 2, isTranspose = true, warpsPerCTA = [2, 2]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_i8_i32(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
@@ -6,10 +6,12 @@
 namespace mlir::triton::AMD {
 
 // Get warpId inside block of warps.
-Value getWarpIdInBlock(ConversionPatternRewriter &rewriter, Location loc,
-                       Value warpId, const ArrayRef<unsigned int> &wpt,
-                       int elemPerInstrNonK, int tensorSizeNonK, int nonKIdx,
-                       const ArrayRef<unsigned int> &order);
+// Returns pair<batchId, nonKId>
+std::pair<Value, Value>
+getWarpIdsInBlock(ConversionPatternRewriter &rewriter, Location loc,
+                  Value warpId, const ArrayRef<unsigned int> &wpt,
+                  int elemPerInstrNonK, ArrayRef<int64_t> tensorShape,
+                  int nonKIdx, const ArrayRef<unsigned int> &order);
 
 bool isSwizzled(gpu::SharedEncodingAttr layout);
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -310,9 +310,15 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
                                i32_val(v * paddedOutputElemSize));
         }
         for (size_t k = 0; k < numRepK; k++) {
-          acc = generateWMMAOp(rewriter, loc, wmmaInstrType, ha[{b, m, k}],
-                               hb[{b, n, k}], acc, aTensorTy.getElementType(),
-                               bTensorTy.getElementType(), dstElemTy, wmmaVer);
+          acc = wmmaLayout.getIsTransposed()
+                    ? generateWMMAOp(
+                          rewriter, loc, wmmaInstrType, hb[{b, n, k}],
+                          ha[{b, m, k}], acc, aTensorTy.getElementType(),
+                          bTensorTy.getElementType(), dstElemTy, wmmaVer)
+                    : generateWMMAOp(
+                          rewriter, loc, wmmaInstrType, ha[{b, m, k}],
+                          hb[{b, n, k}], acc, aTensorTy.getElementType(),
+                          bTensorTy.getElementType(), dstElemTy, wmmaVer);
         }
         for (unsigned v = 0; v < dElemsToStorePerThread; ++v) {
           fc[fcThreadOffIdx + v] = extract_element(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
@@ -58,7 +58,8 @@ Attribute createTmpLayout(Attribute layout, ArrayRef<unsigned> warpsPerCTA) {
         src.getCTALayout());
   if (auto src = dyn_cast<triton::gpu::AMDWmmaEncodingAttr>(layout))
     return triton::gpu::AMDWmmaEncodingAttr::get(
-        ctx, /*version=*/1, warpsPerCTA, src.getCTALayout());
+        ctx, /*version=*/1, /*isTranspose=*/false, warpsPerCTA,
+        src.getCTALayout());
   if (auto src = dyn_cast<triton::gpu::BlockedEncodingAttr>(layout))
     return triton::gpu::BlockedEncodingAttr::get(
         ctx, src.getSizePerThread(), src.getThreadsPerWarp(), warpsPerCTA,

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -791,8 +791,9 @@ public:
     auto warpsPerTile = warpsPerTileWMMA(dotOp, retShape, numWarps);
 
     auto CTALayout = ttg::getCTALayout(oldRetEncoding);
-    wmmaEnc = ttg::AMDWmmaEncodingAttr::get(ctx, wmmaVersion, warpsPerTile,
-                                            CTALayout);
+    bool isTransposed = (wmmaVersion == 2);
+    wmmaEnc = ttg::AMDWmmaEncodingAttr::get(ctx, wmmaVersion, isTransposed,
+                                            warpsPerTile, CTALayout);
 
     auto newRetType = RankedTensorType::get(retShape, operandTypes[3], wmmaEnc);
 

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -1499,7 +1499,7 @@ TEST_F(LinearLayoutConversionsTest, WMMA_v2_2x4Warps) {
                          {S("dim0"), S("dim1")}));
   EXPECT_EQ(
       toLinearLayout({64, 128}, layout),
-      LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}, {32, 0}, {0, 64}}},
+      LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}, {0, 64}, {32, 0}}},
                     {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}}},
                     {S("warp"), {{0, 16}, {0, 32}, {16, 0}}},
                     {S("block"), {}}},
@@ -1532,11 +1532,11 @@ TEST_F(LinearLayoutConversionsTest, WMMA_v2_2x2x2Warps) {
             {{0, 1, 0},
              {0, 2, 0},
              {0, 4, 0},
-             {0, 32, 0},
              {0, 0, 32},
+             {0, 32, 0},
              {2, 0, 0}}},
            {S("lane"), {{0, 0, 1}, {0, 0, 2}, {0, 0, 4}, {0, 0, 8}, {0, 8, 0}}},
-           {S("warp"), {{0, 16, 0}, {0, 0, 16}, {1, 0, 0}}},
+           {S("warp"), {{0, 0, 16}, {0, 16, 0}, {1, 0, 0}}},
            {S("block"), {}}},
           {S("dim0"), S("dim1"), S("dim2")}));
 }
@@ -1545,27 +1545,27 @@ TEST_F(LinearLayoutConversionsTest, TWMMA_v2_2x4Warps) {
   auto layout = wmma(/*warps=*/{2, 4}, /*version=*/2, /*transposed=*/true);
 
   EXPECT_EQ(toLinearLayout({16, 16}, layout),
-            LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}}},
-                          {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}}},
+            LinearLayout({{S("register"), {{0, 1}, {0, 2}, {0, 4}}},
+                          {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {0, 8}}},
                           {S("warp"), {{0, 0}, {0, 0}, {0, 0}}},
                           {S("block"), {}}},
                          {S("dim0"), S("dim1")}));
   EXPECT_EQ(toLinearLayout({32, 16}, layout),
-            LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}}},
-                          {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}}},
+            LinearLayout({{S("register"), {{0, 1}, {0, 2}, {0, 4}}},
+                          {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {0, 8}}},
                           {S("warp"), {{0, 0}, {0, 0}, {16, 0}}},
                           {S("block"), {}}},
                          {S("dim0"), S("dim1")}));
   EXPECT_EQ(toLinearLayout({16, 32}, layout),
-            LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}}},
-                          {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}}},
+            LinearLayout({{S("register"), {{0, 1}, {0, 2}, {0, 4}}},
+                          {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {0, 8}}},
                           {S("warp"), {{0, 16}, {0, 0}, {0, 0}}},
                           {S("block"), {}}},
                          {S("dim0"), S("dim1")}));
   EXPECT_EQ(
       toLinearLayout({64, 128}, layout),
-      LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}, {32, 0}, {0, 64}}},
-                    {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}}},
+      LinearLayout({{S("register"), {{0, 1}, {0, 2}, {0, 4}, {0, 64}, {32, 0}}},
+                    {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {0, 8}}},
                     {S("warp"), {{0, 16}, {0, 32}, {16, 0}}},
                     {S("block"), {}}},
                    {S("dim0"), S("dim1")}));
@@ -1577,16 +1577,16 @@ TEST_F(LinearLayoutConversionsTest, TWMMA_v2_2x2x2Warps) {
   EXPECT_EQ(
       toLinearLayout({1, 16, 16}, layout),
       LinearLayout(
-          {{S("register"), {{0, 1, 0}, {0, 2, 0}, {0, 4, 0}}},
-           {S("lane"), {{0, 0, 1}, {0, 0, 2}, {0, 0, 4}, {0, 0, 8}, {0, 8, 0}}},
+          {{S("register"), {{0, 0, 1}, {0, 0, 2}, {0, 0, 4}}},
+           {S("lane"), {{0, 1, 0}, {0, 2, 0}, {0, 4, 0}, {0, 8, 0}, {0, 0, 8}}},
            {S("warp"), {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}}},
            {S("block"), {}}},
           {S("dim0"), S("dim1"), S("dim2")}));
   EXPECT_EQ(
       toLinearLayout({2, 16, 16}, layout),
       LinearLayout(
-          {{S("register"), {{0, 1, 0}, {0, 2, 0}, {0, 4, 0}}},
-           {S("lane"), {{0, 0, 1}, {0, 0, 2}, {0, 0, 4}, {0, 0, 8}, {0, 8, 0}}},
+          {{S("register"), {{0, 0, 1}, {0, 0, 2}, {0, 0, 4}}},
+           {S("lane"), {{0, 1, 0}, {0, 2, 0}, {0, 4, 0}, {0, 8, 0}, {0, 0, 8}}},
            {S("warp"), {{0, 0, 0}, {0, 0, 0}, {1, 0, 0}}},
            {S("block"), {}}},
           {S("dim0"), S("dim1"), S("dim2")}));
@@ -1594,14 +1594,14 @@ TEST_F(LinearLayoutConversionsTest, TWMMA_v2_2x2x2Warps) {
       toLinearLayout({4, 64, 64}, layout),
       LinearLayout(
           {{S("register"),
-            {{0, 1, 0},
-             {0, 2, 0},
-             {0, 4, 0},
-             {0, 32, 0},
+            {{0, 0, 1},
+             {0, 0, 2},
+             {0, 0, 4},
              {0, 0, 32},
+             {0, 32, 0},
              {2, 0, 0}}},
-           {S("lane"), {{0, 0, 1}, {0, 0, 2}, {0, 0, 4}, {0, 0, 8}, {0, 8, 0}}},
-           {S("warp"), {{0, 16, 0}, {0, 0, 16}, {1, 0, 0}}},
+           {S("lane"), {{0, 1, 0}, {0, 2, 0}, {0, 4, 0}, {0, 8, 0}, {0, 0, 8}}},
+           {S("warp"), {{0, 0, 16}, {0, 16, 0}, {1, 0, 0}}},
            {S("block"), {}}},
           {S("dim0"), S("dim1"), S("dim2")}));
 }

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -69,14 +69,13 @@ public:
     return DotOperandEncodingAttr::get(&ctx, opIdx, mfma, kWidth);
   }
 
-  AMDWmmaEncodingAttr wmma(ArrayRef<unsigned> warps) {
+  AMDWmmaEncodingAttr wmma(ArrayRef<unsigned> warps, int version) {
     SmallVector<unsigned> cpg(warps.size(), 1u);
     SmallVector<unsigned> cSplit(warps.size(), 1u);
     SmallVector<unsigned> cOrd(warps.size());
     std::iota(cOrd.begin(), cOrd.end(), 0);
     return AMDWmmaEncodingAttr::get(
-        &ctx, /*version=*/1, warps,
-        CTALayoutAttr::get(&ctx, cpg, cSplit, cOrd));
+        &ctx, version, warps, CTALayoutAttr::get(&ctx, cpg, cSplit, cOrd));
   }
 
   SliceEncodingAttr slice(Attribute parent, int dim) {
@@ -1402,8 +1401,8 @@ TEST_F(LinearLayoutConversionsTest, mfma16_dot_op_rhs_kwidth4) {
             toLinearLayout({16, 16}, mfmaDotOp1_16));
 }
 
-TEST_F(LinearLayoutConversionsTest, WMMA_2x4Warps) {
-  auto legacy = wmma(/*warps=*/{2, 4});
+TEST_F(LinearLayoutConversionsTest, WMMA_v1_2x4Warps) {
+  auto legacy = wmma(/*warps=*/{2, 4}, /*version=*/1);
 
   EXPECT_EQ(toLinearLayout({16, 16}, legacy),
             LinearLayout({{S("register"), {{2, 0}, {4, 0}, {8, 0}}},
@@ -1445,8 +1444,8 @@ TEST_F(LinearLayoutConversionsTest, WMMA_2x4Warps) {
                          {S("dim0"), S("dim1")}));
 }
 
-TEST_F(LinearLayoutConversionsTest, WMMA_2x4x1Warps) {
-  auto legacy = wmma(/*warps=*/{2, 4, 1});
+TEST_F(LinearLayoutConversionsTest, WMMA_v1_2x4x1Warps) {
+  auto legacy = wmma(/*warps=*/{2, 4, 1}, /*version=*/1);
 
   EXPECT_EQ(
       toLinearLayout({1, 16, 16}, legacy),
@@ -1471,6 +1470,71 @@ TEST_F(LinearLayoutConversionsTest, WMMA_2x4x1Warps) {
             {{0, 2, 0}, {0, 4, 0}, {0, 8, 0}, {2, 0, 0}, {4, 0, 0}}},
            {S("lane"), {{0, 0, 1}, {0, 0, 2}, {0, 0, 4}, {0, 0, 8}, {0, 1, 0}}},
            {S("warp"), {{0, 0, 0}, {0, 0, 0}, {1, 0, 0}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1"), S("dim2")}));
+}
+
+TEST_F(LinearLayoutConversionsTest, WMMA_v2_2x4Warps) {
+  auto layout = wmma(/*warps=*/{2, 4}, /*version=*/2);
+
+  EXPECT_EQ(toLinearLayout({16, 16}, layout),
+            LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}}},
+                          {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}}},
+                          {S("warp"), {{0, 0}, {0, 0}, {0, 0}}},
+                          {S("block"), {}}},
+                         {S("dim0"), S("dim1")}));
+  EXPECT_EQ(toLinearLayout({32, 16}, layout),
+            LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}}},
+                          {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}}},
+                          {S("warp"), {{0, 0}, {0, 0}, {16, 0}}},
+                          {S("block"), {}}},
+                         {S("dim0"), S("dim1")}));
+  EXPECT_EQ(toLinearLayout({16, 32}, layout),
+            LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}}},
+                          {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}}},
+                          {S("warp"), {{0, 16}, {0, 0}, {0, 0}}},
+                          {S("block"), {}}},
+                         {S("dim0"), S("dim1")}));
+  EXPECT_EQ(
+      toLinearLayout({64, 128}, layout),
+      LinearLayout({{S("register"), {{1, 0}, {2, 0}, {4, 0}, {32, 0}, {0, 64}}},
+                    {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {8, 0}}},
+                    {S("warp"), {{0, 16}, {0, 32}, {16, 0}}},
+                    {S("block"), {}}},
+                   {S("dim0"), S("dim1")}));
+}
+
+TEST_F(LinearLayoutConversionsTest, WMMA_v2_2x2x2Warps) {
+  auto layout = wmma(/*warps=*/{2, 2, 2}, /*version=*/2);
+
+  EXPECT_EQ(
+      toLinearLayout({1, 16, 16}, layout),
+      LinearLayout(
+          {{S("register"), {{0, 1, 0}, {0, 2, 0}, {0, 4, 0}}},
+           {S("lane"), {{0, 0, 1}, {0, 0, 2}, {0, 0, 4}, {0, 0, 8}, {0, 8, 0}}},
+           {S("warp"), {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1"), S("dim2")}));
+  EXPECT_EQ(
+      toLinearLayout({2, 16, 16}, layout),
+      LinearLayout(
+          {{S("register"), {{0, 1, 0}, {0, 2, 0}, {0, 4, 0}}},
+           {S("lane"), {{0, 0, 1}, {0, 0, 2}, {0, 0, 4}, {0, 0, 8}, {0, 8, 0}}},
+           {S("warp"), {{0, 0, 0}, {0, 0, 0}, {1, 0, 0}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1"), S("dim2")}));
+  EXPECT_EQ(
+      toLinearLayout({4, 64, 64}, layout),
+      LinearLayout(
+          {{S("register"),
+            {{0, 1, 0},
+             {0, 2, 0},
+             {0, 4, 0},
+             {0, 32, 0},
+             {0, 0, 32},
+             {2, 0, 0}}},
+           {S("lane"), {{0, 0, 1}, {0, 0, 2}, {0, 0, 4}, {0, 0, 8}, {0, 8, 0}}},
+           {S("warp"), {{0, 16, 0}, {0, 0, 16}, {1, 0, 0}}},
            {S("block"), {}}},
           {S("dim0"), S("dim1"), S("dim2")}));
 }


### PR DESCRIPTION
This PR
- Replaces calls of generic order function with specific lane/warp/repetition functions
- Fixes wrong warp index computation in legacy shared->mma converter
- Adds basic tests for WMMA v2 layout
- Enables transposed layout for wmma v2