### PR TITLE
[CMAKE] Add TritonIR dependency on TritonGPU TypeInterfaces Tablegen

### DIFF
--- a/lib/Dialect/Triton/IR/CMakeLists.txt
+++ b/lib/Dialect/Triton/IR/CMakeLists.txt
@@ -7,6 +7,7 @@ add_triton_library(TritonIR
 
   DEPENDS
   TritonTableGen
+  TritonGPUTypeInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR


### PR DESCRIPTION
https://github.com/triton-lang/triton/commit/133109de1248ddf934fd46409dece99d78ef59d5 added a `TypeInterfaces` tablegen include (`triton/Dialect/TritonGPU/IR/TypeInterfaces.h.inc`) to [include/triton/Dialect/TritonGPU/IR/Types.h](https://github.com/triton-lang/triton/commit/133109de1248ddf934fd46409dece99d78ef59d5#diff-2734cf5b9df131ce772fab2d9564ba76426ed3d3a4f77cf4836569b62d62dcc5). This file is included by https://github.com/triton-lang/triton/blob/main/lib/Dialect/Triton/IR/Traits.cpp#L6 via https://github.com/triton-lang/triton/blob/main/include/triton/Dialect/TritonGPU/IR/Dialect.h which only explicitly depends on the `Triton` Dialect Tablegen. This results in the occasional build failure:
```
2024-12-02T13:21:12.3924074Z   FAILED: lib/Dialect/Triton/IR/CMakeFiles/TritonIR.dir/Traits.cpp.o
2024-12-02T13:21:12.4016048Z   /usr/bin/c++ -DGTEST_HAS_RTTI=0 -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/python/build/cmake.linux-x86_64-cpython-3.9/lib/Dialect/Triton/IR -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/lib/Dialect/Triton/IR -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/include -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/. -I/home/runner/.triton/llvm/llvm-86b69c31-ubuntu-x64/include -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/python/build/cmake.linux-x86_64-cpython-3.9/include -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/third_party -I/runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/python/build/cmake.linux-x86_64-cpython-3.9/third_party -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17 -Werror -Wno-covered-switch-default -fvisibility=hidden -g  -fno-exceptions -funwind-tables -fno-rtti -MD -MT lib/Dialect/Triton/IR/CMakeFiles/TritonIR.dir/Traits.cpp.o -MF lib/Dialect/Triton/IR/CMakeFiles/TritonIR.dir/Traits.cpp.o.d -o lib/Dialect/Triton/IR/CMakeFiles/TritonIR.dir/Traits.cpp.o -c /runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/lib/Dialect/Triton/IR/Traits.cpp
2024-12-02T13:21:12.4044994Z   In file included from /runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/include/triton/Dialect/TritonGPU/IR/Dialect.h:12,
2024-12-02T13:21:12.4047664Z                    from /runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/lib/Dialect/Triton/IR/Traits.cpp:8:
2024-12-02T13:21:12.4050715Z   /runner/_work/intel-xpu-backend-for-triton/intel-xpu-backend-for-triton/include/triton/Dialect/TritonGPU/IR/Types.h:11:10: fatal error: triton/Dialect/TritonGPU/IR/TypeInterfaces.h.inc: No such file or directory
2024-12-02T13:21:12.4054755Z      11 | #include "triton/Dialect/TritonGPU/IR/TypeInterfaces.h.inc"
2024-12-02T13:21:12.4055787Z         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-12-02T13:21:12.4056738Z   compilation terminated.
```

