### PR TITLE
Update `setuptools` supported versions; pin >=65.6.1

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Install pip dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install cython setuptools wheel cmake==3.24 ninja lit
+          python3 -m pip install cython setuptools>=65.6.1 wheel cmake==3.24 ninja lit
       - name: Install Triton
         env:
           CUDA_HOME: "/usr/local/cuda"
@@ -569,7 +569,7 @@ jobs:
           python3 -m venv ~/.venv
           source ~/.venv/bin/activate
           python3 -m pip install --upgrade pip
-          python3 -m pip install cython setuptools wheel cmake==3.24 ninja lit pybind11
+          python3 -m pip install cython setuptools>=65.6.1 wheel cmake==3.24 ninja lit pybind11
       - name: Install Triton
         env:
           TRITON_BUILD_WITH_O1: "true"

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -268,7 +268,7 @@ jobs:
       - name: Install pip dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install cython setuptools wheel cmake==3.24 ninja lit
+          python3 -m pip install cython setuptools>=65.6.1 wheel cmake==3.24 ninja lit
 
       - name: Install Triton
         env:
@@ -481,7 +481,7 @@ jobs:
           python3 -m venv ~/.venv
           source ~/.venv/bin/activate
           python3 -m pip install --upgrade pip
-          python3 -m pip install cython setuptools wheel cmake==3.24 ninja lit pybind11
+          python3 -m pip install cython setuptools>=65.6.1 wheel cmake==3.24 ninja lit pybind11
       - name: Install Triton
         env:
           TRITON_BUILD_WITH_O1: "true"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
+requires = ["setuptools>=65.6.1", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
 
 [tool.yapf]
 based_on_style = "pep8"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1", "pybind11>=2.13.1"]
+requires = ["setuptools>=65.6.1", "wheel", "cmake>=3.18", "ninja>=1.11.1", "pybind11>=2.13.1"]
 
 # We're incrementally switching from autopep8 to ruff.
 [tool.autopep8]

--- a/python/setup.py
+++ b/python/setup.py
@@ -711,7 +711,7 @@ setup(
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",
     long_description="",
-    install_requires=["setuptools>=40.8.0"],
+    install_requires=["setuptools>=65.6.1"],
     packages=get_packages(),
     entry_points=get_entry_points(),
     package_data=package_data,


### PR DESCRIPTION
The reason I want to update to this version is because it has https://github.com/pypa/setuptools/pull/3690: Fixed logging errors: 'underlying buffer has been detached' (issue https://github.com/pypa/setuptools/issues/1631) (https://github.com/pypa/setuptools/blob/main/NEWS.rst#v6561).

With this fix, the logs for Windows builds are no longer littered with messages about the buffer, which increase the logs several times.

I also want to note that the previous pin (https://github.com/pypa/setuptools/tree/v40.8.0) was created about 5 years ago, the new one (https://github.com/pypa/setuptools/tree/v65.6.1) about 2 years ago (it seems that such an update makes sense in any case).
