### PR TITLE
[BACKEND] Support the conversion of nested layout "#slice->#dot->#third_party_mma" to LinearLayout

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -83,6 +83,15 @@ unsigned getTotalElemsPerThread(Type type) {
   if (type.isIntOrIndexOrFloat() || isa<triton::PointerType>(type))
     return 1;
   auto tensorType = cast<RankedTensorType>(type);
+
+  std::optional<LinearLayout> ll = triton::gpu::toLinearLayout(
+      tensorType.getShape(), tensorType.getEncoding());
+  if (ll.has_value()) {
+    MLIRContext *ctx = tensorType.getContext();
+    auto kRegister = StringAttr::get(ctx, "register");
+    return ll->getInDimSize(kRegister);
+  }
+  // fallback to legacy layout interface.
   return getTotalElemsPerThread(tensorType.getEncoding(), tensorType.getShape(),
                                 tensorType.getElementType());
 }


### PR DESCRIPTION
The method `DotOperandEncodingAttr::getElemsPerThread` is used when converting the nested layout: #slice->#dot->#mma to the LinearLayout.
But the implementation only supports the MMA layout of the in-tree GPU dialect which blocks the third party extensions.

Use the interface `DistributedEncodingTrait::getSizePerThread` to replace the `getTotalElemsPerThread` in the `SliceEncodingAttr::toLinearLayout`. Because the `DotOperandEncodingAttr::getSizePerThread` is implemented based on `MmaTraits` interface, we can support the nested slice layout for the third party extension as well.

The changes has been covered by the existing LinearLayout conversion unittest.
