### PR TITLE
Add generalization for DotLike operations

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -44,7 +44,7 @@ public:
       return;
     ModuleOp mod = getOperation();
     mod.walk([&](Operation *op) {
-      if (!isa<ttng::WarpGroupDotOp>(op))
+      if (!op->hasTrait<OpTrait::DotLike>())
         return WalkResult::advance();
       OpBuilder builder(op);
       auto a = op->getOperand(0);


### PR DESCRIPTION
This PR allows other dot-like operations to be built on top of Triton instead of requiring ops to be DotOp exactly.

We are using this internally in order to support SparseDotOp (which has DotLike trait implemented).