### PR TITLE
Use `L` integer literal for `int64_t`

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -220,7 +220,7 @@ def make_launcher(constants, signature, ids, warp_size):
             "int8_t": "b",
             "int16_t": "h",
             "int32_t": "i",
-            "int64_t": "l",
+            "int64_t": "L",
             "uint8_t": "B",
             "uint16_t": "H",
             "uint32_t": "I",

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -139,7 +139,7 @@ def make_launcher(constants, signature, ids):
             "int8_t": "b",
             "int16_t": "h",
             "int32_t": "i",
-            "int64_t": "l",
+            "int64_t": "L",
             "uint8_t": "B",
             "uint16_t": "H",
             "uint32_t": "I",


### PR DESCRIPTION
For `uint64_t` the literal `K` is used, which means `unsigned long long` according to https://docs.python.org/3/c-api/arg.html#numbers. It seems logical and correct to use literal `L` for type `int64_t`, which means `long long` C type.