### PR TITLE
[Pipeliner] Fix a dangling insertion point issue.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -270,6 +270,7 @@ createTMAAsyncCopy(scf::ForOp &forOp, tt::ExperimentalDescriptorLoadOp loadOp,
       alloc.erase();
     }
 
+    builder.setInsertionPointAfter(viewLoad);
     auto sharedLoad = builder.createWithStage<ttg::LocalLoadOp>(
         loc, stage, clusterId, loadOp.getType(),
         viewLoad /*,wait->getResult(0)*/);


### PR DESCRIPTION
The insertion point for a `LocalLoadOp` after a `LocalAllocOp` op is erased could be invalid. Setting it explicitly right after the new `MemDescSubviewOp`.