### PR TITLE
[AMD-Pipeline] Add multi-stage global/local prefetch

### DIFF
--- a/test/TritonGPU/amd/amd-stream-prefetch.mlir
+++ b/test/TritonGPU/amd/amd-stream-prefetch.mlir
@@ -1,0 +1,104 @@
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-stream-pipeline="num_stages=2 global_prefetch=1" -canonicalize | FileCheck %s --check-prefixes=GLOBAL_1
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-stream-pipeline="num_stages=2 global_prefetch=2" -canonicalize | FileCheck %s --check-prefixes=GLOBAL_2
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-stream-pipeline="num_stages=2 local_prefetch=1 global_prefetch=1" -canonicalize | FileCheck %s --check-prefixes=GLOBAL_LOCAL_1
+
+// matmul: 128x32 @ 32x128 -> 128x128
+#AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#BL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#ALs0 = #ttg.slice<{parent=#AL, dim=0}>
+#BLs0 = #ttg.slice<{parent=#BL, dim=0}>
+#BLs1 = #ttg.slice<{parent=#BL, dim=1}>
+#C = #ttg.nvidia_mma<{versionMajor = 2, warpsPerCTA = [4, 1]}>
+#A = #ttg.dot_op<{opIdx = 0, parent = #C, kWidth=2}>
+#B = #ttg.dot_op<{opIdx = 1, parent = #C, kWidth=2}>
+
+// An extra register buffer for global loads.
+// GLOBAL_1-LABEL: tt.func @matmul_loop
+// GLOBAL_1-COUNT-4: tt.load
+// GLOBAL_1-COUNT-2: ttg.local_store
+// GLOBAL_1: scf.for
+// GLOBAL_1: tt.load
+// GLOBAL_1: ttg.local_load
+// GLOBAL_1: tt.load
+// GLOBAL_1: ttg.local_load
+// GLOBAL_1: tt.dot
+// GLOBAL_1-COUNT-2: ttg.local_store
+// GLOBAL_1: scf.yield
+// GLOBAL_1-COUNT-2: tt.dot
+// GLOBAL_LOCAL_1-NOT: tt.dot
+
+// Two extra register buffers for global loads.
+// GLOBAL_2-LABEL: tt.func @matmul_loop
+// GLOBAL_2-COUNT-6: tt.load
+// GLOBAL_2-COUNT-2: ttg.local_store
+// GLOBAL_2: scf.for
+// GLOBAL_2: tt.load
+// GLOBAL_2: ttg.local_load
+// GLOBAL_2: tt.load
+// GLOBAL_2: ttg.local_load
+// GLOBAL_2: tt.dot
+// GLOBAL_2-COUNT-2: ttg.local_store
+// GLOBAL_2: scf.yield
+// GLOBAL_2-COUNT-3: tt.dot
+// GLOBAL_LOCAL_1-NOT: tt.dot
+
+// An extra register buffer for global loads and an extra register buffer for local_loads.
+// GLOBAL_LOCAL_1-LABEL: tt.func @matmul_loop
+// GLOBAL_LOCAL_1-COUNT-4: tt.load
+// GLOBAL_LOCAL_1-COUNT-2: ttg.local_store
+// GLOBAL_LOCAL_1-COUNT-2: tt.load
+// GLOBAL_LOCAL_1-COUNT-2: ttg.local_load
+// GLOBAL_LOCAL_1: scf.for
+// GLOBAL_LOCAL_1-COUNT-2: ttg.local_store
+// GLOBAL_LOCAL_1-COUNT-2: tt.load
+// GLOBAL_LOCAL_1: tt.dot
+// GLOBAL_LOCAL_1-COUNT-2: ttg.local_load
+// GLOBAL_LOCAL_1: scf.yield
+// GLOBAL_LOCAL_1-COUNT-3: tt.dot
+// GLOBAL_LOCAL_1-NOT: tt.dot
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @matmul_loop(%lb : index, %ub : index, %step : index,
+                  %A : !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                  %B : !tt.ptr<f16> {tt.divisibility = 16 : i32}) -> tensor<128x128xf32, #C> {
+  // A ptrs
+  %a_ptr_splat = tt.splat %A : !tt.ptr<f16> -> tensor<128x32x!tt.ptr<f16>, #AL>
+  %a_tmp0 = tt.make_range {end = 32: i32, start = 0: i32} : tensor<32xi32, #ALs0>
+  %a_tmp1 = tt.expand_dims %a_tmp0 {axis = 0 : i32} : tensor<32xi32, #ALs0> -> tensor<1x32xi32, #AL>
+  %a_offs = tt.broadcast %a_tmp1 : tensor<1x32xi32, #AL> -> tensor<128x32xi32, #AL>
+  %a_ptr_init = tt.addptr %a_ptr_splat, %a_offs : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+  // B ptrs
+  %b_ptr_splat = tt.splat %B : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>, #BL>
+  %b_tmp0 = tt.make_range {end = 128: i32, start = 0: i32} : tensor<128xi32, #BLs0>
+  %b_tmp1 = tt.expand_dims %b_tmp0 {axis = 0 : i32} : tensor<128xi32, #BLs0> -> tensor<1x128xi32, #BL>
+  %b_offs = tt.broadcast %b_tmp1 : tensor<1x128xi32, #BL> -> tensor<32x128xi32, #BL>
+  %b_ptr_init = tt.addptr %b_ptr_splat, %b_offs : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
+
+
+  %a_mask = arith.constant dense<true> : tensor<128x32xi1, #AL>
+  %a_other = arith.constant dense<0.00e+00> : tensor<128x32xf16, #AL>
+  %b_mask = arith.constant dense<true> : tensor<32x128xi1, #BL>
+  %b_other = arith.constant dense<0.00e+00> : tensor<32x128xf16, #BL>
+  %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
+
+  %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
+  %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
+
+  %b_scale = arith.constant dense<4.> : tensor<32x128xf16, #B>
+
+  %loop:3 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %prev_c = %c_init) -> (tensor<128x32x!tt.ptr<f16>, #AL>, tensor<32x128x!tt.ptr<f16>, #BL>, tensor<128x128xf32, #C>) {
+    %a_ = tt.load %a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
+    %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A>
+    %b__ = tt.load %b_ptr, %b_mask, %b_other : tensor<32x128x!tt.ptr<f16>, #BL>
+    %b_ = ttg.convert_layout %b__ : tensor<32x128xf16, #BL> -> tensor<32x128xf16, #B>
+    %b = arith.mulf %b_, %b_scale: tensor<32x128xf16, #B>
+
+    %c = tt.dot %a, %b, %prev_c : tensor<128x32xf16, #A> * tensor<32x128xf16, #B> -> tensor<128x128xf32, #C>
+
+    %next_a_ptr = tt.addptr %a_ptr, %a_off : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+    %next_b_ptr = tt.addptr %b_ptr, %b_off : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
+    scf.yield %next_a_ptr, %next_b_ptr, %c : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<32x128x!tt.ptr<f16>, #BL>, tensor<128x128xf32, #C>
+  }
+  tt.return %loop#2: tensor<128x128xf32, #C>
+}
+}

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -1,6 +1,6 @@
 // RUN: triton-opt %s -split-input-file -tritongpu-loop-scheduling=num-stages=3 -tritongpu-pipeline=num-stages=3 -canonicalize | FileCheck %s --check-prefixes=COMMON,CHECK
 // RUN: triton-opt %s -split-input-file -tritonamdgpu-stream-pipeline=num_stages=2 -canonicalize | FileCheck %s --check-prefixes=COMMON,AMD
-// RUN: triton-opt %s -split-input-file -tritonamdgpu-stream-pipeline="num_stages=2 prefetch=1" -canonicalize | FileCheck %s --check-prefixes=COMMON,AMD_PREFETCH
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-stream-pipeline="num_stages=2 local_prefetch=1" -canonicalize | FileCheck %s --check-prefixes=COMMON,AMD_PREFETCH
 
 // 4 warps
 // matmul: 128x32 @ 32x128 -> 128x128
@@ -504,16 +504,22 @@ tt.func @matmul_loop_single_pipeline(%lb : index, %ub : index, %step : index,
 //       AMD_PREFETCH:   tt.load
 //       AMD_PREFETCH:   tt.load
 //       AMD_PREFETCH:   tt.load
+//       AMD_PREFETCH:   ttg.local_store
+//       AMD_PREFETCH:   ttg.local_store
+//       AMD_PREFETCH:   tt.load
 //       AMD_PREFETCH:   ttg.local_load
+//       AMD_PREFETCH:   tt.load
+//       AMD_PREFETCH:   tt.load
 //       AMD_PREFETCH:   ttg.local_load
 //       AMD_PREFETCH:   scf.for
 //       AMD_PREFETCH:     ttg.local_store
 //       AMD_PREFETCH:     ttg.local_store
 //       AMD_PREFETCH:     tt.load
-//       AMD_PREFETCH:     tt.load
-//       AMD_PREFETCH:     tt.load
-//       AMD_PREFETCH:     tt.dot
 //       AMD_PREFETCH:     ttg.local_load
+//       AMD_PREFETCH:     tt.load
+//       AMD_PREFETCH:     tt.load
+//       AMD_PREFETCH:     ttg.local_load
+//       AMD_PREFETCH:     tt.dot
 //       AMD_PREFETCH:     scf.yield
 //       AMD_PREFETCH:   tt.dot
 //       AMD_PREFETCH:   tt.dot

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -228,12 +228,14 @@ class HIPBackend(BaseBackend):
         amd.passes.ttgpuir.add_optimize_epilogue(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, True)
 
-        stream_prefetch = os.getenv("TRITON_HIP_STREAM_PREFETCH", "0") == "1"
+        local_prefetch = int(os.getenv("TRITON_HIP_STREAM_PREFETCH", "0"))
         use_buffer_ops = os.environ.get("AMDGCN_USE_BUFFER_OPS", "0") == "1"
 
         # The `local-prefetch` scheduling variant requires turning on buffer ops.
         if options.instruction_sched_variant == "local-prefetch":
-            stream_prefetch = use_buffer_ops = True
+            if local_prefetch == 0:
+                local_prefetch = 1
+            use_buffer_ops = True
 
         if amd.has_matrix_core_feature(options.arch):
             assert options.num_stages != 0, ("Triton AMD backend pipeliner has been updated. "
@@ -241,7 +243,8 @@ class HIPBackend(BaseBackend):
                                              "num_stages == 0. Now it will not happen anymore; "
                                              "please update to use num_stages == 2 for "
                                              "equivalent behavior in the past.")
-            amd.passes.ttgpuir.add_stream_pipeline(pm, options.num_stages, stream_prefetch)
+            global_prefetch = int(os.getenv("TRITON_HIP_STREAM_GLOBAL_PREFETCH", "0"))
+            amd.passes.ttgpuir.add_stream_pipeline(pm, options.num_stages, global_prefetch, local_prefetch)
             passes.common.add_canonicalizer(pm)
         amd.passes.ttgpuir.insert_instruction_sched_hints(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, True)

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -7,8 +7,9 @@
 
 namespace mlir {
 
-std::unique_ptr<Pass> createTritonAMDGPUStreamPipelinePass(int numStages = 2,
-                                                           int prefetch = 0);
+std::unique_ptr<Pass>
+createTritonAMDGPUStreamPipelinePass(int numStages = 2, int globalPrefetch = 0,
+                                     int localPrefetch = 0);
 
 std::unique_ptr<Pass>
 createTritonAMDGPUAccelerateMatmulPass(std::string archGenName = std::string(),

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -19,7 +19,10 @@ def TritonAMDGPUStreamPipeline : Pass<"tritonamdgpu-stream-pipeline", "mlir::Mod
     Option<"numStages", "num_stages",
            "int32_t", /*default*/"2",
            "Number of Pipeline stages">,
-    Option<"prefetch", "prefetch",
+    Option<"globalPrefetch", "global_prefetch",
+           "int32_t", /*default*/"0",
+           "Enable prefetch from global memory">,
+    Option<"localPrefetch", "local_prefetch",
            "int32_t", /*default*/"0",
            "Enable prefetch from shared memory">
   ];

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -72,8 +72,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
                      mlir::createTritonAMDGPUConvertToBufferOpsPass);
   ADD_PASS_WRAPPER_0("add_reorder_instructions",
                      mlir::createTritonAMDGPUReorderInstructionsPass);
-  ADD_PASS_WRAPPER_2("add_stream_pipeline",
-                     mlir::createTritonAMDGPUStreamPipelinePass, int, int);
+  ADD_PASS_WRAPPER_3("add_stream_pipeline",
+                     mlir::createTritonAMDGPUStreamPipelinePass, int, int, int);
 }
 
 void addControlConstant(llvm::Module *module, const char *name,


### PR DESCRIPTION
  * Setting global_prefetch = <n> will insert <n> stages after the last global_load and before the local_store.
  * Setting local_prefetch = <n> will insert <n> stages after the local_load and before the compute.

Global prefetch is enabled with TRITON_HIP_STREAM_GLOBAL_PREFETCH=<n> environment variable.

Local prefetch is enabled with TRITON_HIP_STREAM_PREFETCH=<n> or with `instruction_sched_variant = local_prefetch`, where <n> = 1 if the environment variable is not set.