### PR TITLE
[BACKEND] Use some linear layout tricks in emitTransferBetweenRegistersAndShared

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -235,13 +235,7 @@ bool emitTransferBetweenRegistersAndShared(
   SmallVector<Value> ret;
 
   // Flatten regToSharedLayout out dims into linear smem index
-  auto sharedOrder = triton::gpu::getOrder(sharedTy.getEncoding());
-  SmallVector<StringAttr> permutedDims;
-  for (int iDim : sharedOrder) {
-    permutedDims.push_back(str_attr("offset" + Twine(iDim)));
-  }
-  auto flatLayout =
-      regToSharedLayout->transposeOuts(permutedDims).flattenOuts();
+  auto flatLayout = regToSharedLayout->flattenOuts();
 
   // Precompute common smem offset for this thread
   auto threadSmemOffset = applyLinearLayout(loc, rewriter, flatLayout,

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -237,24 +237,14 @@ bool emitTransferBetweenRegistersAndShared(
   // Flatten regToSharedLayout out dims into linear smem index
   auto flatLayout = regToSharedLayout->flattenOuts();
 
-  // Precompute common smem offset for this thread
-  auto threadSmemOffset = applyLinearLayout(loc, rewriter, flatLayout,
-                                            {{kRegister, i32_val(0)},
-                                             {kLane, laneId},
-                                             {kWarp, warpId},
-                                             {kBlock, zero}})[0]
-                              .second;
-
   for (int i = 0; i < numElems / vecElems; i++) {
     // Get the address to load/store.
-    auto regOffset = applyLinearLayout(loc, rewriter, flatLayout,
-                                       {{kRegister, i32_val(i * vecElems)},
-                                        {kLane, zero},
-                                        {kWarp, zero},
-                                        {kBlock, zero}})[0]
-                         .second;
-
-    Value shmemOffset = xor_(threadSmemOffset, regOffset);
+    auto shmemOffset = applyLinearLayout(loc, rewriter, flatLayout,
+                                         {{kRegister, i32_val(i * vecElems)},
+                                          {kLane, laneId},
+                                          {kWarp, warpId},
+                                          {kBlock, zero}})[0]
+                           .second;
 
     auto vecAddr = gep(ptrTy, elemLlvmTy, shmemBase, shmemOffset);
     vecAddr.setInbounds(true);


### PR DESCRIPTION
This makes two changes:
1. Instead of applying the layout to get a multi-dim index and using striding math, I flatten the linear layout to produce a linear index directly.
2. Instead of re-evaluating the full linear layout for each register, I pre-compute for the zeroth register and use the linear property to offset in the register dimension.