### PR TITLE
Mark dot' output `bfloat16` type as unsupported only for `cuda` and `hip` backends

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1496,8 +1496,13 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optiona
         _0 = builder.get_int32(0)
         ret_scalar_ty = tl.int32
     elif out_dtype.is_bf16():
-        raise ValueError(
-            "out_dtype=bfloat16 is unsupported. Please use out_dtype=float32/float16 and cast with `.to(tl.bfloat16)`")
+        if builder.options.backend_name in ('cuda', 'hip'):
+            raise ValueError(
+                "out_dtype=bfloat16 is unsupported. Please use out_dtype=float32/float16 and cast with `.to(tl.bfloat16)`"
+            )
+        else:
+            _0 = builder.get_bf16(0)
+            ret_scalar_ty = tl.bfloat16
     elif lhs.type.scalar.is_fp32() or lhs.type.scalar.is_bf16():
         _0 = builder.get_fp32(0)
         ret_scalar_ty = tl.float32


### PR DESCRIPTION
Considering the plugin structure of the repository, I think it is possible to clearly indicate which backends are not supported, since `xpu` does.