### PR TITLE
[DOCS] fix formatting for dot_scaled

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1647,8 +1647,10 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
 def dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=None, out_dtype=float32, _builder=None):
     """
     Returns the matrix product of two blocks in microscaling format.
+
     lhs and rhs use microscaling formats described here:
     https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
+
     :param lhs: The first tensor to be multiplied.
     :type lhs: 2D tensor representing fp4, fp8 or bf16 elements. Fp4 elements are packed into uint8 inputs with the first element in lower bits. Fp8 are stored as uint8 or the corresponding fp8 type.
     :param lhs_scale: Scale factor for lhs tensor.


### PR DESCRIPTION
Before:

<img width="742" alt="Screenshot 2024-12-06 at 12 35 56 PM" src="https://github.com/user-attachments/assets/c4f8c09f-8471-4dc6-a32a-1a3baa468051">


After:

<img width="738" alt="Screenshot 2024-12-06 at 12 35 51 PM" src="https://github.com/user-attachments/assets/e7dfbc40-833e-49bf-900d-1fc1867a1c72">
