### PR TITLE
[FRONTEND] Insert zext prior to addptr with unsigned offset

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -232,7 +232,7 @@ def add(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, sa
     if input_scalar_ty.is_ptr():
         other_handle = other.handle
         if other.dtype.is_int_unsigned() and other.dtype.int_bitwidth < 64:
-            # We want to zext when the offset is smaller than pointer size (64bit)
+            # addptr treats offset as signed. Zero-extend unsigned offsets to ensure they're positive
             if other.type.is_block():
                 i64_ty = tl.block_type(tl.int64, other.type.get_block_shapes()).to_ir(builder)
             else:


### PR DESCRIPTION
Hi triton friends ! This is my first PR here: I've tried to be thoughtful in my presentation and implementation. If I'm doing anything clearly inappropriate don't hesitate to mention so. This PR originally approached solving the problem listed below differently than it does now. Have a look at the posts edit history for the original idea.

## Context (What)
Currently the frontend lowers arguments to signless types regardless of the signedness the user provides (see e.g. [`dtype.to_ir`](https://github.com/triton-lang/triton/blob/main/python/triton/language/core.py#L507-L508)). I'm reading a little bit between the lines here, but this seems like a conscious design decision to align with how LLVM handles integers.

While the signedness of the arguments does affect how certain operations are lowered (e.g. [`floordiv`](https://github.com/triton-lang/triton/blob/main/python/triton/language/semantic.py#L312-L315) generates either `udiv/sdiv`), not every instruction has signed vs. unsigned variants, in particular `tt.addptr` does not, so whether or not a value is signed is not passed on when creating this instruction.

### A (Very) Contrived Example
```
import triton
import triton.language as tl
import torch
@triton.jit
def tst(x_ptr, y_ptr, Q: tl.uint32, K: tl.constexpr):
    tl.store(x_ptr + tl.arange(0, K) + Q, tl.load(y_ptr + tl.arange(0, K)))
x = torch.randn(32, dtype=torch.bfloat16, device='cuda:0')
y = torch.randn(16, dtype=torch.bfloat16, device='cuda:0')
tst[(1,)](x, y, 10, 16)
```
This lowers to
```
  tt.func public @tst(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32} loc(), %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32} loc(), %arg2: i32 loc()) attributes {noinline = false} {
    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32> loc(#loc1)
    %1 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>> loc(#loc2)
    %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<bf16>>, tensor<16xi32> loc(#loc2)
    %3 = tt.splat %arg2 : i32 -> tensor<16xi32> loc(#loc3)
    %4 = tt.addptr %2, %3 : tensor<16x!tt.ptr<bf16>>, tensor<16xi32> loc(#loc3)
    %5 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>> loc(#loc4)
    %6 = tt.addptr %5, %0 : tensor<16x!tt.ptr<bf16>>, tensor<16xi32> loc(#loc4)
    %7 = tt.load %6 : tensor<16x!tt.ptr<bf16>> loc(#loc5)
    tt.store %4, %7 : tensor<16x!tt.ptr<bf16>> loc(#loc6)
    tt.return loc(#loc7)
  } loc(#loc)
```
There is not a way to statically determine `%arg2` was declared unsigned. After this PR the above lowers to
```
  tt.func public @tst(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32} loc("/home/danzimm/tross/triton/dz/tst.py":6:0), %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32} loc("/home/danzimm/tross/triton/dz/tst.py":6:0), %arg2: i32 loc("/home/danzimm/tross/triton/dz/tst.py":6:0)) attributes {noinline = false} {
    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #blocked> loc(#loc1)
    %1 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>, #blocked> loc(#loc2)
    %2 = tt.addptr %1, %0 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked> loc(#loc2)
    %3 = arith.extui %arg2 : i32 to i64 loc(#loc3)
    %4 = tt.splat %3 : i64 -> tensor<16xi64, #blocked> loc(#loc3)
    %5 = tt.addptr %2, %4 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi64, #blocked> loc(#loc3)
    %6 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>, #blocked> loc(#loc4)
    %7 = tt.addptr %6, %0 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked> loc(#loc4)
    %8 = tt.load %7 : tensor<16x!tt.ptr<bf16>, #blocked> loc(#loc5)
    tt.store %5, %8 : tensor<16x!tt.ptr<bf16>, #blocked> loc(#loc6)
    tt.return loc(#loc7)
  } loc(#loc)
```
The only difference is the introduction of `arith.extui %arg2` which indicates `%arg2` was unsigned. This behavior matches clang's: https://godbolt.org/z/ah1oKMa43

## Motivation (Why)
In the AMD backend buffered load/store ops require non-negative offsets (see [`ConvertToBufferOps.cpp`](https://github.com/triton-lang/triton/blob/main/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp#L65)). Right now the only way to enable these operations is by inserting `tl.assume` statements manually. This is awkward, especially when there're several parameters, and isn't "standard" for kernel developers.

On the other hand, typing is fairly standard, so it seems fitting to translate unsigned types to assume statements.

This information could be useful for e.g. elision of `math.abs` or `scf.if` 'negative' branches.

## Other Solutions Considered
- Lower to signed types: this would break the "signless by default" paradigm, so seems not a good path forward
- Introduce additional signed/unsigned instructions, e.g. `splats` and `splatu`: seems confusing/anti-paradigm since we would be encoding signedness into instructions that really don't care about signedness
- Introduce `tt.addptru`: see discussion for below for why we opted to insert `zext` instead
    - Though I don't know for a fact NV *can't* optimize better if it knows its offsets are non-negative, my brief research doesn't indicate that it can't
- Force users to specify `tl.assume` everywhere: this is viable but non-ideal since using `assume` isn't common for kernel developers

## Open Questions
-  How should we handle python typehints type checking?
    - Punting this to another PR (if there is actually an issue)

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
```
> pre-commit run --from-ref origin/main --to-ref HEAD
check for broken symlinks............................(no files to check)Skipped
detect destroyed symlinks................................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check python ast.........................................................Passed
check for added large files..............................................Passed
check for merge conflicts................................................Passed
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable..........................Passed
detect private key.......................................................Passed
debug statements (python)................................................Passed
ruff.....................................................................Passed
yapf.....................................................................Passed
clang-format.........................................(no files to check)Skipped
Expand YAML anchors..................................(no files to check)Skipped
```

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `N/A`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

.