### PR TITLE
[AMD] Enhance non-negative proof for buffer ops

### DIFF
--- a/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
@@ -122,3 +122,256 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32}  {
     tt.return %10 : tensor<1024xf32, #blocked>
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: assume_eq_non_neg
+  tt.func @assume_eq_non_neg(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2: i32) {
+    %c10_i32 = arith.constant 10 : i32
+    %0 = arith.cmpi eq, %arg2, %c10_i32 : i32
+    llvm.intr.assume %0 : i1
+    // CHECK: %[[range:.*]] = tt.make_range
+    %1 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #blocked>
+    // CHECK: %[[ptr:.*]] = tt.addptr %arg0, %arg2
+    %2 = tt.addptr %arg0, %arg2: !tt.ptr<bf16>, i32
+    %3 = tt.splat %2 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>, #blocked>
+    %4 = tt.addptr %3, %1 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
+    %5 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>, #blocked>
+    %6 = tt.addptr %5, %1 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
+    // CHECK: %[[loaded:.*]] = amdgpu.buffer_load %arg1[%1]
+    %7 = tt.load %6 : tensor<16x!tt.ptr<bf16>, #blocked>
+    // CHECK: amdgpu.buffer_store %[[loaded]], %[[ptr]][%[[range]]]
+    tt.store %4, %7 : tensor<16x!tt.ptr<bf16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: assume_nonneg_less
+  tt.func @assume_nonneg_less(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2: i32) {
+    %c10_i32 = arith.constant 5 : i32
+    %0 = arith.cmpi slt, %c10_i32, %arg2 : i32
+    llvm.intr.assume %0 : i1
+    // CHECK: %[[range:.*]] = tt.make_range
+    %1 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #blocked>
+    // CHECK: %[[ptr:.*]] = tt.addptr %arg0, %arg2
+    %2 = tt.addptr %arg0, %arg2: !tt.ptr<bf16>, i32
+    %3 = tt.splat %2 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>, #blocked>
+    %4 = tt.addptr %3, %1 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
+    %5 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>, #blocked>
+    %6 = tt.addptr %5, %1 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
+    // CHECK: %[[loaded:.*]] = amdgpu.buffer_load %arg1[%1]
+    %7 = tt.load %6 : tensor<16x!tt.ptr<bf16>, #blocked>
+    // CHECK: amdgpu.buffer_store %[[loaded]], %[[ptr]][%[[range]]]
+    tt.store %4, %7 : tensor<16x!tt.ptr<bf16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: assume_cmp_non_const
+  tt.func @assume_cmp_non_const(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2: i32, %arg3 : i32, %arg4 : i32, %arg5 : i32, %arg6 : i32) {
+    %0 = arith.cmpi sgt, %arg2, %arg3 : i32
+    llvm.intr.assume %0 : i1
+    %1 = arith.subi %arg2, %arg3 : i32
+    %2 = arith.cmpi sge, %1, %arg4 : i32
+    llvm.intr.assume %2 : i1
+    %3 = arith.subi %1, %arg4 : i32
+    %4 = arith.cmpi slt, %3, %arg5 : i32
+    llvm.intr.assume %4 : i1
+    %5 = arith.subi %arg5, %3 : i32
+    %6 = arith.cmpi sle, %5, %arg6 : i32
+    llvm.intr.assume %6 : i1
+    %7 = arith.subi %arg6, %5 : i32
+    %8 = arith.minsi %1, %3 : i32
+    %9 = arith.minsi %8, %5 : i32
+    %10 = arith.minsi %9, %7 : i32
+    // CHECK: %[[range:.*]] = tt.make_range
+    %11 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #blocked>
+    %12 = tt.splat %10 : i32 -> tensor<16xi32, #blocked>
+    // CHECK: %[[offsets:.*]] = arith.addi
+    %offsets = arith.addi %11, %12 : tensor<16xi32, #blocked>
+    %13 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>, #blocked>
+    %14 = tt.addptr %13, %11 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
+    %15 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>, #blocked>
+    %16 = tt.addptr %15, %offsets : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
+    // CHECK: %[[loaded:.*]] = amdgpu.buffer_load %arg1[%[[offsets]]]
+    %17 = tt.load %16 : tensor<16x!tt.ptr<bf16>, #blocked>
+    // CHECK: amdgpu.buffer_store %[[loaded]], %arg0[%[[range]]]
+    tt.store %14, %17 : tensor<16x!tt.ptr<bf16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blockedtrans = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.slice<{dim=0, parent=#blocked}>
+#blocked2 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: unary_triton_ops_transitive_nonneg
+  tt.func @unary_triton_ops_transitive_nonneg(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
+    %c10_i32 = arith.constant 5 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #blocked1>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32, #blocked1> -> tensor<1x16xi32, #blocked>
+    %2 = tt.reshape %1 allow_reorder : tensor<1x16xi32, #blocked> -> tensor<8x2xi32, #blocked>
+    %3 = tt.reshape %1 allow_reorder : tensor<1x16xi32, #blocked> -> tensor<2x8xi32, #blocked>
+    %4 = tt.trans %3 {order = array<i32: 1, 0>} : tensor<2x8xi32, #blocked> -> tensor<8x2xi32, #blockedtrans>
+    %5 = ttg.convert_layout %4 : tensor<8x2xi32, #blockedtrans> -> tensor<8x2xi32, #blocked>
+    %6 = arith.addi %5, %2 : tensor<8x2xi32, #blocked>
+    %7 = tt.make_range {end = 10 : i32, start = 2 : i32} : tensor<8xi32, #blocked2>
+    %8 = ttg.convert_layout %7 : tensor<8xi32, #blocked2> -> tensor<8xi32, #blocked1>
+    %9 = tt.expand_dims %8 {axis = 0 : i32} : tensor<8xi32, #blocked1> -> tensor<1x8xi32, #blocked>
+    %10 = tt.broadcast %9 : tensor<1x8xi32, #blocked> -> tensor<2x8xi32, #blocked>
+    %11 = tt.reshape %10 allow_reorder : tensor<2x8xi32, #blocked> -> tensor<8x2xi32, #blocked>
+    %12 = tt.splat %c10_i32 : i32 -> tensor<8x2xi32, #blocked>
+    %13 = arith.addi %11, %12 : tensor<8x2xi32, #blocked>
+    %14 = arith.minsi %13, %5 : tensor<8x2xi32, #blocked>
+    // CHECK: %[[lhs:.*]], %[[rhs:.*]] = tt.split
+    %15, %16 = tt.split %11: tensor<8x2xi32, #blocked> -> tensor<8xi32, #blocked2>
+    %17 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked2>
+    %18 = tt.addptr %17, %15 : tensor<8x!tt.ptr<bf16>, #blocked2>, tensor<8xi32, #blocked2>
+    // CHECK: %[[loaded:.*]] = amdgpu.buffer_load %arg0[%[[lhs]]]
+    %19 = tt.load %18 : tensor<8x!tt.ptr<bf16>, #blocked2>
+    %20 = tt.addptr %17, %16 : tensor<8x!tt.ptr<bf16>, #blocked2>, tensor<8xi32, #blocked2>
+    // CHECK: %[[loaded2:.*]] = amdgpu.buffer_load %arg0[%[[rhs]]]
+    %21 = tt.load %20 : tensor<8x!tt.ptr<bf16>, #blocked2>
+    // CHECK: %[[added:.*]] = arith.addf %[[loaded]], %[[loaded2]]
+    %22 = arith.addf %19, %21 : tensor<8xbf16, #blocked2>
+    %23 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked2>
+    %24 = tt.addptr %23, %7 : tensor<8x!tt.ptr<bf16>, #blocked2>, tensor<8xi32, #blocked2>
+    // CHECK: amdgpu.buffer_store %[[added]], %arg1[%{{.*}}]
+    tt.store %24, %22 : tensor<8x!tt.ptr<bf16>, #blocked2>
+    tt.return
+  }
+}
+
+// -----
+
+
+#blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: join_cat_transitive_nonneg
+  tt.func @join_cat_transitive_nonneg(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
+    %0 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32, #blocked1>
+    %1 = tt.make_range {end = 10 : i32, start = 2 : i32} : tensor<8xi32, #blocked1>
+    %2 = tt.join %0, %1 : tensor<8xi32, #blocked1> -> tensor<8x2xi32, #blocked>
+    %3 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32, #blocked1>
+    %4 = tt.make_range {end = 8 : i32, start = 4 : i32} : tensor<4xi32, #blocked1>
+    %5 = tt.join %3, %4 : tensor<4xi32, #blocked1> -> tensor<4x2xi32, #blocked>
+    %6 = tt.cat %5, %5 : tensor<4x2xi32, #blocked> -> tensor<8x2xi32, #blocked>
+    %7 = arith.addi %2, %6 : tensor<8x2xi32, #blocked>
+    %zeros = arith.constant dense<0> : tensor<8x1xi32, #blocked>
+    %ones = arith.constant dense<1> : tensor<8x1xi32, #blocked>
+    %8 = tt.gather %7[%zeros] {axis = 1 : i32} : (tensor<8x2xi32, #blocked>, tensor<8x1xi32, #blocked>) -> tensor<8x1xi32, #blocked>
+    %9 = tt.gather %7[%ones] {axis = 1 : i32} : (tensor<8x2xi32, #blocked>, tensor<8x1xi32, #blocked>) -> tensor<8x1xi32, #blocked>
+    %10 = arith.addi %8, %9 : tensor<8x1xi32, #blocked>
+    %11 = tt.reshape %10 allow_reorder : tensor<8x1xi32, #blocked> -> tensor<8xi32, #blocked1>
+    %12 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked1>
+    %14 = tt.addptr %12, %11 : tensor<8x!tt.ptr<bf16>, #blocked1>, tensor<8xi32, #blocked1>
+    // CHECK: %[[loaded:.*]] = amdgpu.buffer_load %arg0[%{{.*}}]
+    %15 = tt.load %14 : tensor<8x!tt.ptr<bf16>, #blocked1>
+    %16 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked1>
+    %17 = tt.addptr %16, %0 : tensor<8x!tt.ptr<bf16>, #blocked1>, tensor<8xi32, #blocked1>
+    // CHECK: amdgpu.buffer_store %[[loaded]], %arg1[%{{.*}}]
+    tt.store %17, %15 : tensor<8x!tt.ptr<bf16>, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: histo_nonneg
+  tt.func @histo_nonneg(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2 : tensor<256xi32, #blocked>) {
+    /// Purposely specify %arg2 so that we can't statically determine the input
+    /// data is nonneg.
+    // CHECK: tt.histogram
+    %0 = tt.histogram %arg2 : tensor<256xi32, #blocked> -> tensor<8xi32, #blocked>
+    %1 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32, #blocked>
+    %2 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked>
+    %3 = tt.addptr %2, %0 : tensor<8x!tt.ptr<bf16>, #blocked>, tensor<8xi32, #blocked>
+    // CHECK: %[[loaded:.*]] = amdgpu.buffer_load %arg0[%{{.*}}]
+    %4 = tt.load %3 : tensor<8x!tt.ptr<bf16>, #blocked>
+    %5 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked>
+    %6 = tt.addptr %5, %1 : tensor<8x!tt.ptr<bf16>, #blocked>, tensor<8xi32, #blocked>
+    // CHECK: amdgpu.buffer_store %[[loaded]], %arg1[%{{.*}}]
+    tt.store %6, %4 : tensor<8x!tt.ptr<bf16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: get_num_prog_nonneg
+  tt.func @get_num_prog_nonneg(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2 : i32) {
+    %0 = tt.get_num_programs x : i32
+    %1 = tt.get_num_programs y : i32
+    %2 = tt.get_num_programs z : i32
+    %3 = arith.minsi %0, %1 : i32
+    %4 = arith.minsi %2, %3 : i32
+    %5 = arith.maxsi %arg2, %4 : i32
+    %6 = tt.splat %5 : i32 -> tensor<8xi32, #blocked>
+    %7 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32, #blocked>
+    %8 = arith.addi %6, %7 : tensor<8xi32, #blocked>
+    %9 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked>
+    %10 = tt.addptr %9, %8 : tensor<8x!tt.ptr<bf16>, #blocked>, tensor<8xi32, #blocked>
+    // CHECK: %[[loaded:.*]] = amdgpu.buffer_load %arg0[%{{.*}}]
+    %11 = tt.load %10 : tensor<8x!tt.ptr<bf16>, #blocked>
+    %12 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked>
+    %13 = tt.addptr %12, %7 : tensor<8x!tt.ptr<bf16>, #blocked>, tensor<8xi32, #blocked>
+    // CHECK: amdgpu.buffer_store %[[loaded]], %arg1[%{{.*}}]
+    tt.store %13, %11 : tensor<8x!tt.ptr<bf16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: unsigned_ops
+  tt.func @unsigned_ops(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2 : i32, %arg3 : i32, %arg4 : f32, %arg5 : index) {
+    %c5_i32 = arith.constant 5 : i32
+    %0 = arith.ceildivui %arg2, %c5_i32 : i32
+    %1 = arith.divui %arg3, %c5_i32 : i32
+    %2 = arith.fptoui %arg4 : f32 to i32
+    %3 = arith.index_castui %arg5 : index to i32
+    %4 = arith.maxui %arg2, %arg3 : i32
+    %5 = arith.minui %arg2, %arg3 : i32
+    %6 = arith.remui %arg2, %c5_i32 : i32
+    %7 = arith.shrui %arg3, %c5_i32 : i32
+    %8 = arith.addi %0, %1 : i32
+    %9 = arith.addi %2, %3 : i32
+    %10 = arith.addi %4, %5 : i32
+    %11 = arith.addi %6, %7 : i32
+    %12 = arith.addi %8, %9 : i32
+    %13 = arith.addi %10, %11 : i32
+    %14 = arith.addi %12, %13 : i32
+    %15 = tt.splat %14 : i32 -> tensor<8xi32, #blocked>
+    %16 = tt.make_range {end = 8 : i32, start = 0 : i32} : tensor<8xi32, #blocked>
+    %17 = arith.addi %15, %16 : tensor<8xi32, #blocked>
+    %18 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked>
+    %19 = tt.addptr %18, %17 : tensor<8x!tt.ptr<bf16>, #blocked>, tensor<8xi32, #blocked>
+    // CHECK: %[[loaded:.*]] = amdgpu.buffer_load %arg0[%{{.*}}]
+    %20 = tt.load %19 : tensor<8x!tt.ptr<bf16>, #blocked>
+    %21 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<8x!tt.ptr<bf16>, #blocked>
+    %22 = tt.addptr %21, %16 : tensor<8x!tt.ptr<bf16>, #blocked>, tensor<8xi32, #blocked>
+    // CHECK: amdgpu.buffer_store %[[loaded]], %arg1[%{{.*}}]
+    tt.store %22, %20 : tensor<8x!tt.ptr<bf16>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -110,7 +110,7 @@ bool verifyNonNegativeExpr(Value expr, const DenseSet<Value> &assumptions) {
             return verifyNonNegativeExpr(joinOp.getLhs(), assumptions) &&
                    verifyNonNegativeExpr(joinOp.getRhs(), assumptions);
           })
-          // Returns a tensor representing histogram: historgrams only conatin
+          // Returns a tensor representing histogram: historgrams only contain
           // buckets of non-negative values.
           .Case<triton::HistogramOp>([&](auto) { return true; })
           .Case<triton::MakeRangeOp>([&](auto makeRangeOp) {


### PR DESCRIPTION
Hello AMD triton friends! I want to emphasize that this is an RFC. I understand the work wasn't discussed ahead of time, so it may or may not align with what you folks are doing/planning.

## Context
Buffer ops have an obvious advantage of reducing register pressure, as well as various other improvements over stanard load/store ops.

We want to start using them over at Meta. We found that the current implementation in triton is very strict, and because of this weren't able to use buffer ops without *heavy* usage of `tl.assume`.

## Working Example: Matmul

We were able to improve the situation by expanding `verifyNonNegativeExpr` to be less conservative (eliding details on the exact changes here in favor of conversation over code). With the changes in the PR we're able to (more often) successfully convert to buffer ops. For example, we were able to convert some of the loads/stores in the matmul in the tutorial.

Specifically, working off a copy of the matmul tutorial (https://gist.github.com/danzimm/8ce3cdb52e9630986a71542a239090cd) we're able to successfully convert some loads/stores to buffer ops: https://gist.github.com/danzimm/cdda36a68d3940cf407f403d3af72627 .

## Tests

As this is an RFC I didn't write any tests. If the idea is accepted I'll write lit tests.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `This is an RFC. If the idea is accepted I'll write tests`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
