### PR TITLE
[SWP] Print recurring dependencies when reporting scheduling conflicts

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipelineErrorReporter.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipelineErrorReporter.h
@@ -1,0 +1,64 @@
+#ifndef TRITON_TRITONGPU_TRANSFORMS_PIPELINER_PIPELINE_ERROR_REPORTER_H_
+#define TRITON_TRITONGPU_TRANSFORMS_PIPELINER_PIPELINE_ERROR_REPORTER_H_
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Operation.h"
+#include <cstdint>
+#include <optional>
+
+using namespace mlir;
+using namespace mlir::scf;
+
+/// This class is used to report the scheduling error. It is used by
+/// the pipeline expander.
+class PipelineErrorReporter {
+protected:
+  ForOp forOp;
+
+  unsigned numStages = 0;
+  const DenseMap<Operation *, unsigned int> &stages;
+
+  /// Collect the root defining ops in IfOps. There could be multiple root
+  /// defining ops in IfOps, as there are then branches and else branches.
+  DenseSet<Operation *> rootDefiningOps;
+
+  /// Recursively find the root defining op of the value in IfOps by traversing
+  /// back the index of an OpResult and yielded values.
+  void findRootDefiningOp(Operation *op, unsigned int resultNumber);
+
+  DenseSet<Operation *> rootUserOps;
+
+  void findRootUserOp(Operation *op, const DenseSet<Operation *> &userOps);
+
+  std::optional<unsigned int> findStage(Operation *op);
+
+  /// Get the operand from the yield operation of the loop, which is the real
+  /// value of the loop-carried dependency.
+  std::optional<Value> getBlockArgYieldValueFromForLoop(BlockArgument arg);
+
+  /// Find the loop-carried dependency that really causes the scheduling error,
+  /// going into nested operations of IfOps.
+  void findRootSchedulingErrorLoopCarryDep(Operation *consumer,
+                                           Operation *producer, Value operand);
+
+public:
+  explicit PipelineErrorReporter(
+      ForOp forOp, unsigned numStages,
+      const DenseMap<Operation *, unsigned int> &stages)
+      : forOp(forOp), numStages(numStages), stages(stages) {}
+  PipelineErrorReporter(const PipelineErrorReporter &) = delete;
+  PipelineErrorReporter &operator=(const PipelineErrorReporter &) = delete;
+  PipelineErrorReporter(PipelineErrorReporter &&) = delete;
+  PipelineErrorReporter &operator=(PipelineErrorReporter &&) = delete;
+
+  /// Print the scheduling error message using MLIR's diagnostic engine.
+  /// Depending on whether it is a loop-carried dependency, we print different
+  /// messages. When distance is 0, it means the consumer and producer are in
+  /// the same iteration. We are not supposed to have scheduling error in this
+  /// case, as we have addressed the potential data dependency conflicts.
+  ///
+  /// When distance is 1, we find the root scheduling error, and print the
+  /// diagnostic message.
+  void printSchedulingError(int64_t distance, Operation *consumer,
+                            Operation *producer, Value operand);
+};
+#endif // TRITON_TRITONGPU_TRANSFORMS_PIPELINER_PIPELINE_ERROR_REPORTER_H_

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -13,6 +13,7 @@ add_triton_library(TritonGPUTransforms
   Pipeliner/AssignLatencies.cpp
   Pipeliner/MatmulLoopPipeline.cpp
   Pipeliner/PipelineExpander.cpp
+  Pipeliner/PipelineErrorReporter.cpp
   Pipeliner/TestPipelineAssignLatencies.cpp
   Pipeliner/TestPipelineScheduleLoop.cpp
   Pipeliner/SoftwarePipeliner.cpp

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineErrorReporter.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineErrorReporter.cpp
@@ -1,0 +1,223 @@
+// Reporting error messages for scheduling errors.
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/Support/Debug.h"
+#include <cstdint>
+
+#include "triton/Dialect/TritonGPU/Transforms/PipelineErrorReporter.h"
+
+#define DEBUG_TYPE "triton-pipeline-error-reporter"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+using namespace mlir::scf;
+
+void PipelineErrorReporter::findRootDefiningOp(Operation *op,
+                                               unsigned int resultNumber) {
+  LDBG("findRootDefiningOp: " << *op << "\n from its " << resultNumber
+                              << "th result\n");
+
+  if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+    // then branch.
+    {
+      auto operandFromThenBranch = ifOp.thenYield()->getOperand(resultNumber);
+      LDBG("operandFromThenBranch: " << operandFromThenBranch);
+      if (auto opResult = dyn_cast<OpResult>(operandFromThenBranch)) {
+        findRootDefiningOp(operandFromThenBranch.getDefiningOp(),
+                           opResult.getResultNumber());
+      } else if (!dyn_cast<BlockArgument>(operandFromThenBranch)) {
+        rootDefiningOps.insert(operandFromThenBranch.getDefiningOp());
+      }
+    }
+    // else branch.
+    {
+      auto operandFromElseBranch = ifOp.elseYield()->getOperand(resultNumber);
+      LDBG("operandFromElseBranch: " << operandFromElseBranch);
+      if (auto opResult = dyn_cast<OpResult>(operandFromElseBranch)) {
+        findRootDefiningOp(opResult.getDefiningOp(),
+                           opResult.getResultNumber());
+      } else if (!dyn_cast<BlockArgument>(operandFromElseBranch)) {
+        rootDefiningOps.insert(operandFromElseBranch.getDefiningOp());
+      }
+    }
+  } else {
+    rootDefiningOps.insert(op);
+  }
+}
+
+std::optional<Value>
+PipelineErrorReporter::getBlockArgYieldValueFromForLoop(BlockArgument arg) {
+  if (arg.getOwner() != forOp.getBody())
+    return std::nullopt;
+  // Ignore induction variable.
+  if (arg.getArgNumber() == 0)
+    return std::nullopt;
+  return forOp.getBody()->getTerminator()->getOperand(arg.getArgNumber() - 1);
+}
+
+DenseSet<Operation *> findUsersInBlockHierarchy(BlockArgument arg,
+                                                Operation *consumerOp) {
+
+  DenseSet<Operation *> usersInBlockHierarchy;
+
+  for (Operation *user : arg.getUsers()) {
+    Operation *currentOp = user;
+    while (currentOp) {
+      if (currentOp == consumerOp) {
+        usersInBlockHierarchy.insert(user);
+        break;
+      }
+      currentOp = currentOp->getParentOp();
+    }
+  }
+
+  return usersInBlockHierarchy;
+}
+
+void PipelineErrorReporter::findRootSchedulingErrorLoopCarryDep(
+    Operation *consumer, Operation *producer, Value operand) {
+  LDBG("findRootSchedulingErrorLoopCarryDep: this operand is not ready at "
+       "the consumer: "
+       << operand << "\n");
+
+  if (auto arg = dyn_cast<BlockArgument>(operand)) {
+
+    // This is a loop-carried dependency. Find which value yields the arg.
+    auto yieldValue = getBlockArgYieldValueFromForLoop(arg);
+    if (!yieldValue) {
+      LDBG("no yield value for arg " << arg << " -> BAIL");
+      return;
+    }
+
+    // first find the root consumer.
+    rootUserOps = std::move(findUsersInBlockHierarchy(arg, consumer));
+
+    assert(producer == yieldValue->getDefiningOp() &&
+           "producer should be the def of the yield value of operand");
+    // We repeat the process of computing the producer, because we need to
+    // know the result number of the producer, which is only available in the
+    // yield value.
+    LDBG("yield value (loop-carry): " << *yieldValue << "\n");
+    if (auto opResult = dyn_cast<OpResult>(*yieldValue)) {
+      findRootDefiningOp(producer, opResult.getResultNumber());
+    } else
+      rootDefiningOps.insert(producer);
+  }
+}
+
+std::optional<unsigned int> PipelineErrorReporter::findStage(Operation *op) {
+  auto it = stages.find(op);
+  if (it != stages.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
+void printImplicitUse(Operation *op, InFlightDiagnostic &mainError) {
+  auto parentOpLoc = op->getParentOp()->getLoc();
+  if (isa<IfOp>(op->getParentOp())) {
+    // When an if branch yields a value, the original value is used implicitly
+    // when the condition is false. In this case, we don't have the source
+    // location of the implicit use. We can only attach a note to the if
+    // operation.
+    // TODO: we can report the location of the yield value in the if branch.
+    mainError.attachNote(parentOpLoc)
+        << "Value is implicitly used here when the condition is false in "
+           "TTIR, because the variable is updated when the condition is "
+           "true.";
+  } else {
+    mainError.attachNote(parentOpLoc) << "Value is implicitly used here. ";
+  }
+}
+
+// Comparator for sorting FileLineColLoc operations
+bool compareFileLineColLoc(Operation *a, Operation *b) {
+  auto locA = a->getLoc();
+  auto locB = b->getLoc();
+  if (!isa<FileLineColLoc>(locA))
+    return false;
+  if (!isa<FileLineColLoc>(locB))
+    return true;
+  auto fileLineLocA = dyn_cast<FileLineColLoc>(a->getLoc());
+  auto fileLineLocB = dyn_cast<FileLineColLoc>(b->getLoc());
+  if (!fileLineLocA || !fileLineLocB)
+    return false; // Should not happen if used correctly
+  if (fileLineLocA.getLine() != fileLineLocB.getLine())
+    return fileLineLocA.getLine() < fileLineLocB.getLine();
+  return fileLineLocA.getColumn() < fileLineLocB.getColumn();
+}
+
+void PipelineErrorReporter::printSchedulingError(int64_t distance,
+                                                 Operation *consumer,
+                                                 Operation *producer,
+                                                 Value operand) {
+  LDBG("printSchedulingError: distance: " << distance << "\n");
+  const char *errorMessage =
+      "The software pipeliner failed due to a dependency conflict, resulting "
+      "in suboptimal loop performance.";
+  const char *likelyBuggyMessage = "This is likely to be a bug. Please "
+                                   "report it.";
+  // We only find the root defining ops for loop-carried dependencies.
+  // When distance is 0, we let the set of root defining ops to be empty.
+  if (distance > 0) {
+    findRootSchedulingErrorLoopCarryDep(consumer, producer, operand);
+  }
+  if (rootDefiningOps.empty()) {
+    // We failed to find the root defining ops. Whether the disntance is 0 or
+    // not, an empty set means we have some bugs in the pipeline expander. We
+    // should let the user help report the bug.
+    consumer->emitError() << errorMessage << " " << likelyBuggyMessage;
+    return;
+  }
+  // find the stage of the consumer and the producer.
+  auto consumerStage = findStage(consumer);
+  auto producerStage = findStage(producer);
+  if (!consumerStage || !producerStage) {
+    // We failed to find the stage of the consumer or the producer. This is
+    // likely to be a bug. We should let the user help report the bug.
+    consumer->emitError() << errorMessage << " " << likelyBuggyMessage;
+    return;
+  }
+  InFlightDiagnostic mainError = forOp->emitError() << errorMessage;
+  mainError.attachNote()
+      << "The loop body is divided into " << numStages
+      << " stages to optimize GPU I/O and computation resources. Different "
+         "parts of the loop body are computed in different iterations. "
+      << "In iteration i, the update of the following variable is rescheduled "
+         "to execute in iteration i + "
+      << *producerStage - *consumerStage
+      << ". However, it must be updated before its use in iteration i.";
+  auto firstRootDefiningOp = *rootDefiningOps.begin();
+  auto firstRootDefiningOpName = firstRootDefiningOp->getName().getStringRef();
+
+  for (auto op : rootDefiningOps) {
+    mainError.attachNote(op->getLoc())
+        << "The variable is updated here:";
+  }
+
+  auto firstRootUserOp = *rootUserOps.begin();
+  auto firstRootUserOpName = firstRootUserOp->getName().getStringRef();
+
+  // Sort rootUserOps using the custom comparator
+  std::vector<Operation *> sortedRootUserOps(rootUserOps.begin(),
+                                             rootUserOps.end());
+  std::sort(sortedRootUserOps.begin(), sortedRootUserOps.end(),
+            compareFileLineColLoc);
+  // Print sorted operations
+  for (auto op : sortedRootUserOps) {
+    auto loc = op->getLoc();
+    if (isa<UnknownLoc>(loc)) {
+      printImplicitUse(op, mainError);
+    } else {
+      // TODO: we can't find the variable name in the source code. Once we use
+      // FileLineColRange instead of FileLineColLoc, we can find the variable
+      // name and provide more detailed debug information.
+      mainError.attachNote(op->getLoc())
+          << "The variable is used here:";
+    }
+  }
+  // TODO: we can also add more detailed debug information for more advanced
+  // users.
+}

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineErrorReporter.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineErrorReporter.cpp
@@ -193,8 +193,7 @@ void PipelineErrorReporter::printSchedulingError(int64_t distance,
   auto firstRootDefiningOpName = firstRootDefiningOp->getName().getStringRef();
 
   for (auto op : rootDefiningOps) {
-    mainError.attachNote(op->getLoc())
-        << "The variable is updated here:";
+    mainError.attachNote(op->getLoc()) << "The variable is updated here:";
   }
 
   auto firstRootUserOp = *rootUserOps.begin();
@@ -214,8 +213,7 @@ void PipelineErrorReporter::printSchedulingError(int64_t distance,
       // TODO: we can't find the variable name in the source code. Once we use
       // FileLineColRange instead of FileLineColLoc, we can find the variable
       // name and provide more detailed debug information.
-      mainError.attachNote(op->getLoc())
-          << "The variable is used here:";
+      mainError.attachNote(op->getLoc()) << "The variable is used here:";
     }
   }
   // TODO: we can also add more detailed debug information for more advanced

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineErrorReporter.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineErrorReporter.cpp
@@ -168,7 +168,7 @@ void PipelineErrorReporter::printSchedulingError(int64_t distance,
     // We failed to find the root defining ops. Whether the disntance is 0 or
     // not, an empty set means we have some bugs in the pipeline expander. We
     // should let the user help report the bug.
-    consumer->emitError() << errorMessage << " " << likelyBuggyMessage;
+    consumer->emitWarning() << errorMessage << " " << likelyBuggyMessage;
     return;
   }
   // find the stage of the consumer and the producer.
@@ -177,10 +177,10 @@ void PipelineErrorReporter::printSchedulingError(int64_t distance,
   if (!consumerStage || !producerStage) {
     // We failed to find the stage of the consumer or the producer. This is
     // likely to be a bug. We should let the user help report the bug.
-    consumer->emitError() << errorMessage << " " << likelyBuggyMessage;
+    consumer->emitWarning() << errorMessage << " " << likelyBuggyMessage;
     return;
   }
-  InFlightDiagnostic mainError = forOp->emitError() << errorMessage;
+  InFlightDiagnostic mainError = forOp->emitWarning() << errorMessage;
   mainError.attachNote()
       << "The loop body is divided into " << numStages
       << " stages to optimize GPU I/O and computation resources. Different "

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineErrorReporter.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineErrorReporter.cpp
@@ -25,7 +25,7 @@ void PipelineErrorReporter::findRootDefiningOp(Operation *op,
       auto operandFromThenBranch = ifOp.thenYield()->getOperand(resultNumber);
       LDBG("operandFromThenBranch: " << operandFromThenBranch);
       if (auto opResult = dyn_cast<OpResult>(operandFromThenBranch)) {
-        findRootDefiningOp(operandFromThenBranch.getDefiningOp(),
+        findRootDefiningOp(opResult.getDefiningOp(),
                            opResult.getResultNumber());
       } else if (!dyn_cast<BlockArgument>(operandFromThenBranch)) {
         rootDefiningOps.insert(operandFromThenBranch.getDefiningOp());

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineErrorReporter.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineErrorReporter.cpp
@@ -165,7 +165,7 @@ void PipelineErrorReporter::printSchedulingError(int64_t distance,
     findRootSchedulingErrorLoopCarryDep(consumer, producer, operand);
   }
   if (rootDefiningOps.empty()) {
-    // We failed to find the root defining ops. Whether the disntance is 0 or
+    // We failed to find the root defining ops. Whether the distance is 0 or
     // not, an empty set means we have some bugs in the pipeline expander. We
     // should let the user help report the bug.
     consumer->emitWarning() << errorMessage << " " << likelyBuggyMessage;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
@@ -34,6 +34,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MathExtras.h"
 
+#include "triton/Dialect/TritonGPU/Transforms/PipelineErrorReporter.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipelineExpander.h"
 
 // FIXME: PipelineExpander should not depend on Triton-specific headers!
@@ -264,6 +265,9 @@ bool LoopPipelinerInternal::verifySchedule() {
         diag.attachNote(producer->getLoc())
             .append("operand defined here: ")
             .appendOp(*producer, OpPrintingFlags().printGenericOpForm());
+        PipelineErrorReporter errorReporter(forOp, maxStage + 1, stages);
+        errorReporter.printSchedulingError(distance, consumer, producer,
+                                           operand);
         return false;
       }
     }

--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -186,3 +186,155 @@ def test_remark_swp_op_before_operands(capfd, fresh_triton_cache):
     i = torch.empty(64 * 64, dtype=torch.float32).cuda()
     o = torch.empty(64 * 64, dtype=torch.float32).cuda()
     kernel_pipe_error[(1, )](i, o)
+
+
+def test_remark_swp_op_before_operands_persistent_matmul(capfd, fresh_triton_cache):
+
+    # this example is from https://github.com/triton-lang/triton/issues/5172
+    @triton.jit
+    def matmul_kernel_persistent(a_ptr, b_ptr, c_ptr,  #
+                                 M, N, K,  #
+                                 stride_am, stride_ak,  #
+                                 stride_bk, stride_bn,  #
+                                 stride_cm, stride_cn,  #
+                                 BLOCK_SIZE_M: tl.constexpr,  #
+                                 BLOCK_SIZE_N: tl.constexpr,  #
+                                 BLOCK_SIZE_K: tl.constexpr,  #
+                                 GROUP_SIZE_M: tl.constexpr,  #
+                                 NUM_SMS: tl.constexpr,  #
+                                 ):
+        start_pid = tl.program_id(axis=0)
+        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+        num_tiles = num_pid_m * num_pid_n
+
+        tiles_per_SM = num_tiles // NUM_SMS
+        if start_pid < num_tiles % NUM_SMS:
+            tiles_per_SM += 1
+
+        # tile_id = start_pid - NUM_SMS
+        tile_id = start_pid
+
+        ki = -1
+
+        offs_k_for_mask = tl.arange(0, BLOCK_SIZE_K)
+
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+        pid_m = 0
+        pid_n = 0
+        offs_am = tl.arange(0, BLOCK_SIZE_M)
+        offs_bn = tl.arange(0, BLOCK_SIZE_N)
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+        for _ in range(0, k_tiles * tiles_per_SM):
+            ki = tl.where(ki == k_tiles - 1, 0, ki + 1)
+            if ki == 0:
+                # tile_id += NUM_SMS
+                group_id = tile_id // num_pid_in_group
+                first_pid_m = group_id * GROUP_SIZE_M
+                group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+                pid_m = first_pid_m + (tile_id % group_size_m)
+                pid_n = (tile_id % num_pid_in_group) // group_size_m
+
+                start_m = pid_m * BLOCK_SIZE_M
+                start_n = pid_n * BLOCK_SIZE_N
+                offs_am = start_m + tl.arange(0, BLOCK_SIZE_M)
+                offs_bn = start_n + tl.arange(0, BLOCK_SIZE_N)
+                offs_am = tl.where(offs_am < M, offs_am, 0)
+                offs_bn = tl.where(offs_bn < N, offs_bn, 0)
+                offs_am = tl.max_contiguous(tl.multiple_of(offs_am, BLOCK_SIZE_M), BLOCK_SIZE_M)
+                offs_bn = tl.max_contiguous(tl.multiple_of(offs_bn, BLOCK_SIZE_N), BLOCK_SIZE_N)
+            offs_k = ki * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+            a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+            b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+            a = tl.load(a_ptrs, mask=offs_k_for_mask[None, :] < K - ki * BLOCK_SIZE_K, other=0.0)
+            b = tl.load(b_ptrs, mask=offs_k_for_mask[:, None] < K - ki * BLOCK_SIZE_K, other=0.0)
+            accumulator = tl.dot(a, b, accumulator)
+
+            if ki == k_tiles - 1:
+                offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+                offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+                c_ptrs = (c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :])
+                c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+                if c_ptr.dtype.element_ty == tl.float8e4nv:
+                    c = accumulator.to(tl.float8e4nv)
+                else:
+                    c = accumulator.to(tl.float16)
+                tl.store(c_ptrs, c, mask=c_mask)
+                accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+                tile_id += NUM_SMS  # this line is newly added
+
+    # We don't need any envirnoment variables to test this remark, as it reports as an error
+    with enable_diagnostics_context(''):
+        dtype = torch.float16
+
+        M = 8192
+        N = 8192
+        K = 512
+        a = torch.randn((M, K), device="cuda", dtype=torch.float16).to(dtype)
+        b = torch.randn((K, N), device="cuda", dtype=torch.float16).to(dtype)
+
+        b = b.T.contiguous().T
+
+        # Check constraints.
+        assert a.shape[1] == b.shape[0], "Incompatible dimensions"
+        assert a.dtype == b.dtype, "Incompatible dtypes"
+
+        # equals to 132 on H100
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+        M, K = a.shape
+        K, N = b.shape
+        dtype = a.dtype
+        # Allocates output.
+        c = torch.empty((M, N), device=a.device, dtype=dtype)
+        # 1D launch kernel where each block gets its own program.
+        grid = lambda META: (min(NUM_SMS,
+                                 triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"])), )
+        matmul_kernel_persistent[grid](
+            a, b, c,  #
+            M, N, K,  #
+            a.stride(0), a.stride(1),  #
+            b.stride(0), b.stride(1),  #
+            c.stride(0), c.stride(1),  #
+            BLOCK_SIZE_M=128,  #
+            BLOCK_SIZE_N=256,  #
+            BLOCK_SIZE_K=64,  #
+            GROUP_SIZE_M=8,  #
+            NUM_SMS=NUM_SMS,  #
+            num_stages=3,  #
+            num_warps=8,  #
+        )
+
+    _, err = capfd.readouterr()
+    # Split the output into lines for easier processing
+    lines = err.splitlines()
+    # Define the expected strings in order
+    expected_strings = [
+        "error: The software pipeliner failed due to a dependency conflict", "for _ in range",
+        "note: The loop body is divided into 3 stages to optimize GPU I/O and computation resources.",
+        "tile_id += NUM_SMS", "group_id = tile_id", "pid_m = first_pid_m + (tile_id % group_size_m)",
+        "pid_n = (tile_id % num_pid_in_group)"
+    ]
+    # Initialize an index to track the position in expected_strings
+    index = 0
+    # Iterate over each line in the output
+    for line in lines:
+        # Check if the current expected string is in the line
+        if expected_strings[index] in line:
+            # Move to the next expected string
+            index += 1
+            # If all expected strings have been found, break out of the loop
+            if index == len(expected_strings):
+                break
+        else:
+            print("line: ", line)
+            print("expected strings: ", expected_strings[index])
+    # Check if all expected strings were found
+    if index != len(expected_strings):
+        missing_string = expected_strings[index]
+        raise AssertionError(f"Missing expected string: '{missing_string}' from {err}")

--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -268,8 +268,7 @@ def test_remark_swp_op_before_operands_persistent_matmul(capfd, fresh_triton_cac
                 accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
                 tile_id += NUM_SMS  # this line is newly added
 
-    # We don't need any envirnoment variables to test this remark, as it reports as an error
-    with enable_diagnostics_context(''):
+    with enable_diagnostics_context('warnings'):
         dtype = torch.float16
 
         M = 8192
@@ -315,10 +314,219 @@ def test_remark_swp_op_before_operands_persistent_matmul(capfd, fresh_triton_cac
     lines = err.splitlines()
     # Define the expected strings in order
     expected_strings = [
-        "error: The software pipeliner failed due to a dependency conflict", "for _ in range",
+        "warning: The software pipeliner failed due to a dependency conflict", "for _ in range",
         "note: The loop body is divided into 3 stages to optimize GPU I/O and computation resources.",
         "tile_id += NUM_SMS", "group_id = tile_id", "pid_m = first_pid_m + (tile_id % group_size_m)",
         "pid_n = (tile_id % num_pid_in_group)"
+    ]
+    # Initialize an index to track the position in expected_strings
+    index = 0
+    # Iterate over each line in the output
+    for line in lines:
+        # Check if the current expected string is in the line
+        if expected_strings[index] in line:
+            # Move to the next expected string
+            index += 1
+            # If all expected strings have been found, break out of the loop
+            if index == len(expected_strings):
+                break
+        else:
+            print("line: ", line)
+            print("expected strings: ", expected_strings[index])
+    # Check if all expected strings were found
+    if index != len(expected_strings):
+        missing_string = expected_strings[index]
+        raise AssertionError(f"Missing expected string: '{missing_string}' from {err}")
+
+def test_remark_swp_op_before_operands_fused_matmul(capfd, fresh_triton_cache):
+
+    @triton.jit()
+    def fused_matmul_kernel(
+        a_ptr,
+        b_left_ptr,
+        b_right_ptr,
+        bias_left_ptr,
+        bias_right_ptr,
+        c_ptr,
+        M,
+        N: tl.constexpr,
+        K: tl.constexpr,
+        stride_am,
+        stride_ak,
+        stride_bk,
+        stride_bn,
+        stride_cm,
+        stride_cn,
+        BLOCK_SIZE_M: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+        BLOCK_SIZE_K: tl.constexpr,
+        GROUP_SIZE_M: tl.constexpr,
+        NUM_SMS: tl.constexpr,
+    ):
+        start_pid = tl.program_id(axis=0)
+        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+        num_tiles = num_pid_m * num_pid_n
+
+        tiles_per_SM = num_tiles // NUM_SMS
+        if start_pid < num_tiles % NUM_SMS:
+            tiles_per_SM += 1
+
+        tile_id = start_pid - NUM_SMS
+        ki = -1
+
+        offs_k_for_mask = tl.arange(0, BLOCK_SIZE_K)
+
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+        pid_m = 0
+        pid_n = 0
+        offs_am = tl.arange(0, BLOCK_SIZE_M)
+        offs_bn = tl.arange(0, BLOCK_SIZE_N)
+
+        acc_left = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        acc_right = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+        for _ in range(0, k_tiles * tiles_per_SM):
+            ki = tl.where(ki == k_tiles - 1, 0, ki + 1)
+            if ki == 0:
+                tile_id += NUM_SMS
+                group_id = tile_id // num_pid_in_group
+                first_pid_m = group_id * GROUP_SIZE_M
+                group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+                pid_m = first_pid_m + (tile_id % group_size_m)
+                pid_n = (tile_id % num_pid_in_group) // group_size_m
+
+                start_m = pid_m * BLOCK_SIZE_M
+                start_n = pid_n * BLOCK_SIZE_N
+                offs_am = start_m + tl.arange(0, BLOCK_SIZE_M)
+                offs_bn = start_n + tl.arange(0, BLOCK_SIZE_N)
+                offs_am = tl.where(offs_am < M, offs_am, 0)
+                offs_bn = tl.where(offs_bn < N, offs_bn, 0)
+                offs_am = tl.max_contiguous(
+                    tl.multiple_of(offs_am, BLOCK_SIZE_M), BLOCK_SIZE_M
+                )
+                offs_bn = tl.max_contiguous(
+                    tl.multiple_of(offs_bn, BLOCK_SIZE_N), BLOCK_SIZE_N
+                )
+                bias_left_ptrs = bias_left_ptr + offs_bn[None, :]
+                bias_right_ptrs = bias_right_ptr + offs_bn[None, :]
+                bias_left = tl.load(bias_left_ptrs).to(tl.float32)
+                bias_right = tl.load(bias_right_ptrs).to(tl.float32)
+                acc_left = bias_left.broadcast_to(BLOCK_SIZE_M, BLOCK_SIZE_N) # num_stage = 0
+                acc_right = bias_right.broadcast_to(BLOCK_SIZE_M, BLOCK_SIZE_N)
+            # else:
+                # we implicit yield acc_left and acc_right from the previous iteration. This causes conflicts in scheduling.
+
+            offs_k = ki * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+            a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+            b_left_ptrs = b_left_ptr + (
+                offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+            )
+            b_right_ptrs = b_right_ptr + (
+                offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+            )
+
+            a = tl.load(
+                a_ptrs, mask=offs_k_for_mask[None, :] < K - ki * BLOCK_SIZE_K, other=0.0
+            )
+            b_left = tl.load(
+                b_left_ptrs,
+                mask=offs_k_for_mask[:, None] < K - ki * BLOCK_SIZE_K,
+                other=0.0,
+            )
+            b_right = tl.load(
+                b_right_ptrs,
+                mask=offs_k_for_mask[:, None] < K - ki * BLOCK_SIZE_K,
+                other=0.0,
+            )
+
+            acc_left = tl.dot(a, b_left, acc_left) # num_stage = 2
+            acc_right = tl.dot(a, b_right, acc_right)
+
+            if ki == k_tiles - 1:
+                offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+                offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+                c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+                c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+                c = (acc_left * tl.sigmoid(acc_right)).to(c_ptr.dtype.element_ty)
+                tl.store(c_ptrs, c, mask=c_mask)
+
+    with enable_diagnostics_context('warnings'):
+
+        # Define constants
+        NUM_ROWS = 291840
+        D_IN = 384
+        D_OUT = 384
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+        # Define matrix dimensions
+        M = NUM_ROWS
+        N = D_OUT * 2
+        K = D_IN
+        # Generate input tensors
+        a = torch.randn((M, K), device=device, dtype=dtype, requires_grad=True)
+        w = torch.randn((K, N), dtype=dtype, device=device)
+        b = torch.randn((N,), dtype=dtype, device=device)
+        # Split the b matrix in half column-wise
+        N_half = N // 2
+        b_left, b_right = w.split(N_half, dim=-1)
+        bias_left, bias_right = b.split(N_half)
+        # Allocate output tensor
+        c = torch.empty((M, N_half), device=device, dtype=dtype)
+        # Get the number of streaming multiprocessors
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        # Define kernel configuration
+        config = {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_stages": 3,
+            "num_warps": 8,
+        }
+        # Define grid size
+        grid = lambda META: (
+            min(
+                NUM_SMS,
+                triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N_half, META["BLOCK_SIZE_N"]),
+            ),
+        )
+        # Launch the kernel
+        fused_matmul_kernel[grid](
+            a,
+            b_left,
+            b_right,
+            bias_left,
+            bias_right,
+            c,
+            M,
+            N_half,
+            K,
+            a.stride(0),
+            a.stride(1),
+            w.stride(0),
+            w.stride(1),
+            c.stride(0),
+            c.stride(1),
+            BLOCK_SIZE_M=config["BLOCK_SIZE_M"],
+            BLOCK_SIZE_N=config["BLOCK_SIZE_N"],
+            BLOCK_SIZE_K=config["BLOCK_SIZE_K"],
+            GROUP_SIZE_M=config["GROUP_SIZE_M"],
+            NUM_SMS=NUM_SMS,
+            num_stages=config["num_stages"],
+            num_warps=config["num_warps"],
+        )
+
+    _, err = capfd.readouterr()
+    # Split the output into lines for easier processing
+    lines = err.splitlines()
+    # Define the expected strings in order
+    expected_strings = [
+        "warning: The software pipeliner failed due to a dependency conflict", "for _ in range",
+        "note: The loop body is divided into",
+        "acc_left = tl.dot(a, b_left, acc_left)", "if ki == 0:"
     ]
     # Initialize an index to track the position in expected_strings
     index = 0

--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -529,7 +529,8 @@ def test_remark_swp_op_before_operands_fused_matmul(capfd, fresh_triton_cache):
     expected_strings = [
         "warning: The software pipeliner failed due to a dependency conflict", "for _ in range",
         "note: The loop body is divided into",
-        "acc_left = tl.dot(a, b_left, acc_left)", "if ki == 0:"
+        "acc_left = tl.dot(a, b_left, acc_left)",
+        "if ki == 0:" #implicit use from the else branch
     ]
     # Initialize an index to track the position in expected_strings
     index = 0


### PR DESCRIPTION
This PR enhances error messaging for scheduling conflicts in software pipelining, providing clearer guidance for debugging issues. Users will now receive prompts to reposition the producer earlier in the loop body to facilitate pipelining.

Previously, error messages only indicated that a consumer was scheduled before its producer, which was insufficient for effective debugging. Additionally, the location of the producer's definition was unclear, especially when the actual producer is inside an SCF IfOp.

This PR improves error tracing by backtracking the data flow into nested MLIR blocks of IfOps to identify the root definition of the producer and the root user of the consumer.  This is especially useful for persistent kernels, as demonstrated in #5172, which is now included as a unit test. Another example involving a fused persistent matmul is also included as a test. Many users adapt persistent kernels from the official tutorial for their implementations, and this PR is useful for debugging.

This PR currently tracks only IfOps. We leave other cases as future work.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
