### PR TITLE
[FRONTEND] Fix and improve minimum dot size checks

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -382,6 +382,8 @@ def test_fp8_support(dtype):
 @pytest.mark.parametrize("dtype", [tl.float8e5, tl.int8, tl.float16])
 def test_min_dot_size(dtype):
     error_msg = "Input shapes should have "
+    target = triton.runtime.driver.active.get_current_target()
+    print("Target: ", target.arch)
     if is_cuda():
         if dtype.primitive_bitwidth == 8:
             error_msg += "M >= 16, N >= 16 and K >= 32"

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -382,8 +382,6 @@ def test_fp8_support(dtype):
 @pytest.mark.parametrize("dtype", [tl.float8e5, tl.int8, tl.float16])
 def test_min_dot_size(dtype):
     error_msg = "Input shapes should have "
-    target = triton.runtime.driver.active.get_current_target()
-    print("Target: ", target.arch)
     if is_cuda():
         if dtype.primitive_bitwidth == 8:
             error_msg += "M >= 16, N >= 16 and K >= 32"

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1473,6 +1473,7 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optiona
         assert lhs.dtype == rhs.dtype, f"Both operands must be same dtype. Got {lhs.dtype} and {rhs.dtype}"
 
     if lhs.dtype.is_fp8e4b15() or rhs.dtype.is_fp8e4b15():
+        # We upcast because there's no fp8e4b15 type in MLIR
         lhs = cast(lhs, tl.float16, builder)
         rhs = cast(rhs, tl.float16, builder)
 

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -18,7 +18,14 @@ def min_dot_size(target: GPUTarget):
     # CDNA 3.0 supports k==8 in all mfma variants except for int8
     # (where the smallest `k` supported is 16)
     if "gfx94" in arch_str:
-        return lambda lhsType, rhsType: (16, 16, 16) if (lhsType.is_int8() or rhsType.is_int8()) else (16, 16, 8)
+
+        def func(lhsType, rhsType):
+            print(lhsType, rhsType)
+            if lhsType.is_int8() or rhsType.is_int8():
+                return (16, 16, 16)
+            return (16, 16, 8)
+
+        return func
     # CDNA 2.0 always supports `k==8`
     if "gfx9" in arch_str:
         return lambda lhsType, rhsType: (16, 16, 8)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -18,14 +18,8 @@ def min_dot_size(target: GPUTarget):
     # CDNA 3.0 supports k==8 in all mfma variants except for int8
     # (where the smallest `k` supported is 16)
     if "gfx94" in arch_str:
-
-        def func(lhsType, rhsType):
-            print(lhsType, rhsType)
-            if lhsType.is_int8() or rhsType.is_int8():
-                return (16, 16, 16)
-            return (16, 16, 8)
-
-        return func
+        return lambda lhsType, rhsType: (16, 16, 16) if (lhsType.scalar.is_int8() or rhsType.scalar.is_int8()) else (
+            16, 16, 8)
     # CDNA 2.0 always supports `k==8`
     if "gfx9" in arch_str:
         return lambda lhsType, rhsType: (16, 16, 8)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -17,7 +17,17 @@ import sysconfig
 
 
 def min_dot_size(target: GPUTarget):
-    return lambda lhsType, rhsType: (16, 32, 16) if lhsType.is_int8() else (16, 16, 16)
+
+    def check_fp_compatibility(lhs_type, rhs_type) -> Tuple[int, int, int]:  # [m, n, k]
+        lhs_bitwidth = lhs_type.scalar.primitive_bitwidth
+        rhs_bitwidth = rhs_type.scalar.primitive_bitwidth
+        assert lhs_bitwidth == rhs_bitwidth, "lhs and rhs bitwidth must be the same"
+        if lhs_bitwidth == 8:
+            return (16, 16, 32)
+        else:
+            return (16, 16, 16)
+
+    return check_fp_compatibility
 
 
 @functools.lru_cache()

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -18,7 +18,7 @@ import sysconfig
 
 def min_dot_size(target: GPUTarget):
 
-    def check_fp_compatibility(lhs_type, rhs_type) -> Tuple[int, int, int]:  # [m, n, k]
+    def check_dot_compatibility(lhs_type, rhs_type) -> Tuple[int, int, int]:  # [m, n, k]
         lhs_bitwidth = lhs_type.scalar.primitive_bitwidth
         rhs_bitwidth = rhs_type.scalar.primitive_bitwidth
         assert lhs_bitwidth == rhs_bitwidth, "lhs and rhs bitwidth must be the same"
@@ -27,7 +27,7 @@ def min_dot_size(target: GPUTarget):
         else:
             return (16, 16, 16)
 
-    return check_fp_compatibility
+    return check_dot_compatibility
 
 
 @functools.lru_cache()


### PR DESCRIPTION
1. Fix the problem that [m, k, n] but not [m, n, k] is returned on the nvidia backend
2. Check both int8 and float8
3. Add a new compiler error test