### PR TITLE
[CI] Disable build cache step for AMD MI GPU CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -363,32 +363,8 @@ jobs:
             ~/.triton/nvidia
             ~/.triton/json
           key: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ steps.cache-key.outputs.llvm }}-nvidia-${{ steps.cache-key.outputs.nvidia }}-json-${{ steps.cache-key.outputs.json }}
-      - # Cache ~/.triton/cache because the vast majority of unit test time is
-        # spent compiling.  Triton won't (well, should not) use these cached files
-        # if something internal to Triton changes, because Triton's internal
-        # source code is part of the cache key.
-        #
-        # Similarly, cache ~/.cache/ccache to speed up compilation.
-        #
-        # On branch `main` we always start from an empty cache, i.e. we skip the
-        # "restore" step.  This is to prevent the caches from accumulating stale
-        # files over time.
-        name: Restore cache of ccache and Triton compilation artifacts
-        id: restore-build-cache
-        if: github.ref != 'refs/heads/main'
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.triton/cache
-            ~/.ccache
-          # Restore the most recent cache entry.
-          restore-keys: |
-            triton-artifacts-${{ runner.os }}-${{ runner.arch }}-${{ env.RUNNER_TYPE }}-llvm-${{ steps.cache-key.outputs.llvm }}-
-            triton-artifacts-${{ runner.os }}-${{ runner.arch }}-${{ env.RUNNER_TYPE }}-
-          # We expect this cache key never to hit and for us to fall back
-          # unconditionally to the restore-key, so it doesn't actually matter
-          # what we put here (so long as it doesn't hit an existing key).
-          key: triton-artifacts-${{ runner.os }}-${{ runner.arch }}-${{ env.RUNNER_TYPE }}-llvm-${{ steps.cache-key.outputs.llvm }}-${{ steps.cache-key.outputs.datetime }}
+      # Build cache right now takes a long time to restore on MI GPU CI machines. Disabled for now.
+      #- *restore-build-artifacts-step
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton
@@ -463,20 +439,10 @@ jobs:
 
           mkdir -p ~/.ccache
           du -h -d 1 ~/.ccache
-      - # If we're on branch `main`, save the ccache Triton compilation artifacts
-        # to the cache so they can be used by other (non-main) CI runs.
-        #
-        # (It wouldn't be a problem to save the cache on every run, because github
-        # evicts cache entries LRU, but maybe this saves a bit of time in CI.)
-        name: Save ccache and Triton compilation artifacts to cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/.triton/cache
-            ~/.ccache
-          key: triton-artifacts-${{ runner.os }}-${{ runner.arch }}-${{ env.RUNNER_TYPE }}-llvm-${{ steps.cache-key.outputs.llvm }}-${{ steps.cache-key.outputs.datetime }}
-      - name: Clean up caches
+      -
+      # Build cache right now takes a long time to save on MI GPU CI machines. Disabled for now.
+      #- *save-build-artifacts-step
+        name: Clean up caches
         run: |
           rm -rf ~/.triton/cache
   Build-Tests:

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -385,7 +385,8 @@ jobs:
 
       - *compute-cache-keys-step
       - *cache-build-dependencies-step
-      - *restore-build-artifacts-step
+      # Build cache right now takes a long time to restore on MI GPU CI machines. Disabled for now.
+      #- *restore-build-artifacts-step
       - *inspect-cache-directories-step
 
       - name: Update compiler to clang
@@ -439,7 +440,8 @@ jobs:
       - *run-proton-tests-step
       - *run-cpp-unittests-step
       - *inspect-cache-directories-step
-      - *save-build-artifacts-step
+      # Build cache right now takes a long time to save on MI GPU CI machines. Disabled for now.
+      #- *save-build-artifacts-step
 
       - name: Clean up caches
         run: |


### PR DESCRIPTION
Build cache right now takes a long time to restore on MI GPU CI machines. Disabled for now.
