### PR TITLE
[LAYOUTS] Implement generic layout propagation through ReshapeOp

### DIFF
--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -63,6 +63,12 @@ public:
                          ArrayRef<int64_t> dstShape, Attribute &dstEnc,
                          std::optional<Location> loc) const = 0;
 
+  // Check if two layouts are structurally the same, even if their names are
+  // different
+  virtual LogicalResult verifyLayoutsAreEqual(ArrayRef<int64_t> shape,
+                                              Attribute expected, Attribute got,
+                                              Location loc) const = 0;
+
   virtual LogicalResult
   inferJoinOpEncoding(Attribute srcEnc, Attribute &dstEnc,
                       std::optional<Location> loc) const = 0;

--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -55,13 +55,13 @@ public:
 
   // Tries to compute the encoding for the result of a reshape operation that
   // makes the reshape a "nop", i.e. the same GPU threads contain the same
-  // elements as before the reshape.  Note that this is not always possible (in
-  // which case you'd need to choose a different layout for the input to the
-  // reshape).
+  // elements as before the reshape using legacy layouts.  This is not always
+  // possible (in which case we fallback to using LinearLayouts)
+  // In the future we'll always use LinearLayouts
   virtual LogicalResult
-  inferReshapeOpNoReorderEncoding(ArrayRef<int64_t> srcShape, Attribute srcEnc,
-                                  ArrayRef<int64_t> dstShape, Attribute &dstEnc,
-                                  std::optional<Location> loc) const = 0;
+  inferReshapeOpEncoding(ArrayRef<int64_t> srcShape, Attribute srcEnc,
+                         ArrayRef<int64_t> dstShape, Attribute &dstEnc,
+                         std::optional<Location> loc) const = 0;
 
   virtual LogicalResult
   inferJoinOpEncoding(Attribute srcEnc, Attribute &dstEnc,

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2871,6 +2871,22 @@ struct TritonGPUInferLayoutInterface
     return success();
   }
 
+  LogicalResult verifyLayoutsAreEqual(ArrayRef<int64_t> shape,
+                                      Attribute expected, Attribute got,
+                                      Location loc) const override {
+    if (expected == got) {
+      return success();
+    }
+    // Check whether the encodings are structurally the same.
+    auto expectedLL = triton::gpu::toLinearLayout(shape, expected);
+    auto gotLL = triton::gpu::toLinearLayout(shape, got);
+    if (expectedLL != gotLL) {
+      return emitError(loc, "Expected result encoding ")
+             << expected << " but was " << got;
+    }
+    return success();
+  }
+
   LogicalResult
   inferReshapeOpEncoding(ArrayRef<int64_t> srcShape, Attribute srcEnc,
                          ArrayRef<int64_t> dstShape, Attribute &dstEnc,

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2645,10 +2645,10 @@ struct TritonGPUInferLayoutInterface
   // Users of this function require that it is symmetrical: if
   // (srcShape,srcEnc,dstShape) => dstEnc, then (dstShape,dstEnc,srcShape) =>
   // srcEnc.
-  LogicalResult
-  inferReshapeOpLegacyEncoding(ArrayRef<int64_t> srcShape, Attribute srcEnc,
-                               ArrayRef<int64_t> dstShape, Attribute &dstEnc,
-                               std::optional<Location> loc) const {
+  LogicalResult inferReshapeOpLegacyEncoding(ArrayRef<int64_t> srcShape,
+                                             Attribute srcEnc,
+                                             ArrayRef<int64_t> dstShape,
+                                             Attribute &dstEnc) const {
     auto src = mlir::dyn_cast<BlockedEncodingAttr>(srcEnc);
     if (!src) {
       return failure();
@@ -2876,7 +2876,7 @@ struct TritonGPUInferLayoutInterface
                          ArrayRef<int64_t> dstShape, Attribute &dstEnc,
                          std::optional<Location> loc) const override {
     auto result =
-        inferReshapeOpLegacyEncoding(srcShape, srcEnc, dstShape, dstEnc, loc);
+        inferReshapeOpLegacyEncoding(srcShape, srcEnc, dstShape, dstEnc);
     if (succeeded(result)) {
       return result;
     }
@@ -2903,8 +2903,8 @@ struct TritonGPUInferLayoutInterface
       newOutDims.emplace_back(dim, size);
     }
     auto srcOutDims = llvm::to_vector(src->getOutDimNames());
-    // reshapeOp assumes C-order, so we need to transpose the out dims before
-    // the reshape
+    // reshapeOp assumes minor-to-major, so we need to transpose the out dims
+    // before the reshape
     std::reverse(srcOutDims.begin(), srcOutDims.end());
     std::reverse(newOutDims.begin(), newOutDims.end());
     auto dst = src->transposeOuts(srcOutDims)

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1598,11 +1598,12 @@ LinearEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
 
 SmallVector<unsigned>
 LinearEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape, Type) const {
-  // We can relax this assert by calling toLinearLayout rather than
-  // getLinearLayout
-  SmallVector<int32_t> shapeVec(shape.begin(), shape.end());
-  assert(shapeVec == llvm::to_vector(getLinearLayout().getOutDimSizes()));
-  auto ll = getLinearLayout();
+  // When broadcasting the layout the shape changes, otherwise the shape is
+  // the same as the shape of the tensor
+  // We can either have BroadcastOp with SameOperandsAndResultEncoding, or keep
+  // the invariant that the shape of the LL is that of the tensor
+  // We choose the former for BC
+  auto ll = *toLinearLayout(shape);
   return basesPerDim(ll, StringAttr::get(getContext(), "register"));
 }
 
@@ -2623,8 +2624,8 @@ struct TritonGPUInferLayoutInterface
   // contains elements [a,b,c,d] before the reshape, it contains those same
   // elements after the reshape, they're just "renamed".
   //
-  // A dst encoding that satisfies this property does not exist for all inputs.
-  // Here are some positive and negative examples.
+  // Using legacy layouts, a dst encoding that satisfies this property may not
+  // exist.  Here are some positive and negative examples.
   //
   //   - NOT OK: 4x4 order=[0,1] -> 16.  Reshape merges elements so
   //     dim 1 is the fastest-changing in the dst, but the src has the opposite
@@ -2638,17 +2639,19 @@ struct TritonGPUInferLayoutInterface
   //   - OK: 32x4 sizePerThread=[4,4] -> 128.  dst with sizePerThread=[16] will
   //     contain the same elements as before.
   //
+  // With linear layouts, we can always find a dst encoding that satisfies
+  // this property. See inferReshapeOpEncoding.
+  //
   // Users of this function require that it is symmetrical: if
   // (srcShape,srcEnc,dstShape) => dstEnc, then (dstShape,dstEnc,srcShape) =>
   // srcEnc.
   LogicalResult
-  inferReshapeOpNoReorderEncoding(ArrayRef<int64_t> srcShape, Attribute srcEnc,
-                                  ArrayRef<int64_t> dstShape, Attribute &dstEnc,
-                                  std::optional<Location> loc) const override {
+  inferReshapeOpLegacyEncoding(ArrayRef<int64_t> srcShape, Attribute srcEnc,
+                               ArrayRef<int64_t> dstShape, Attribute &dstEnc,
+                               std::optional<Location> loc) const {
     auto src = mlir::dyn_cast<BlockedEncodingAttr>(srcEnc);
     if (!src) {
-      return emitOptionalError(
-          loc, "Non-reordering reshape only supports BlockedEncoding");
+      return failure();
     }
 
     // Nop reshape; we can always infer an encoding.
@@ -2681,9 +2684,7 @@ struct TritonGPUInferLayoutInterface
     // to handle CTASplitNum.
     if (!all_of(src.getCTAsPerCGA(), [](int32_t x) { return x == 1; }) ||
         !all_of(src.getCTASplitNum(), [](int32_t x) { return x == 1; })) {
-      return emitOptionalError(
-          loc, "Non-reordering reshape does not currently support multi-CTA "
-               "layouts other than the default layout.");
+      return failure();
     }
 
     // Cowardly refuse to handle encodings where shape[dim] is not divisible by
@@ -2693,12 +2694,7 @@ struct TritonGPUInferLayoutInterface
       for (int dim = 0; dim < srcShape.size(); dim++) {
         if (srcShape[dim] >= subblock[dim] &&
             srcShape[dim] % subblock[dim] != 0) {
-          return emitOptionalError(loc,
-                                   "Can't do a non-reordering reshape because "
-                                   "the size of dimension ",
-                                   dim, " (", srcShape[dim], ")",
-                                   " is not divisible by ", name, "[", dim, "]",
-                                   " = ", subblock[dim]);
+          return failure();
         }
       }
       return success();
@@ -2723,11 +2719,7 @@ struct TritonGPUInferLayoutInterface
     // physical order, with `a` being the most major.
     for (const auto &[srcDims, dstDims] : decomp) {
       if (!isConsecutive(to_vector(reverse(gather(srcInvOrder, srcDims))))) {
-        return emitOptionalError(loc,
-                                 "Cannot do a non-reordering reshape given "
-                                 "this src encoding order.  Dimensions [",
-                                 join(srcDims),
-                                 "] must be physically consecutive.");
+        return failure();
       }
     }
 
@@ -2774,11 +2766,7 @@ struct TritonGPUInferLayoutInterface
           // Check that more-minor dims all have 1 in shapeRemaining.
           for (int j = i + 1; j < srcDims.size(); j++) {
             if (shapeRemaining[j] != 1) {
-              return emitOptionalError(
-                  loc,
-                  "Invalid src encoding for non-reordering reshape.  Must use "
-                  "up sizePerThread / threadsPerWarp / warpsPerCTA for "
-                  "more-minor dimensions before more major-dims can use them.");
+              return failure();
             }
           }
 
@@ -2793,13 +2781,7 @@ struct TritonGPUInferLayoutInterface
           // only if we're the most-major dimension of the chunk and in all
           // future chunks, only this most-major dim has a non-1 size.
           if (shapeRemaining[i] == 0 && i != 0) {
-            return emitOptionalError(
-                loc,
-                "Invalid src encoding for non-reordering reshape.  Block "
-                "size in dimension ",
-                dim,
-                " is larger than the shape that dimension, but this is only "
-                "allowed for the most-major dimension of a reshape chunk");
+            return failure();
           }
         }
         return success();
@@ -2886,6 +2868,49 @@ struct TritonGPUInferLayoutInterface
                                       dstThreadsPerWarp, dstWarpsPerCTA,
                                       dstOrder, CTALayout);
 
+    return success();
+  }
+
+  LogicalResult
+  inferReshapeOpEncoding(ArrayRef<int64_t> srcShape, Attribute srcEnc,
+                         ArrayRef<int64_t> dstShape, Attribute &dstEnc,
+                         std::optional<Location> loc) const override {
+    auto result =
+        inferReshapeOpLegacyEncoding(srcShape, srcEnc, dstShape, dstEnc, loc);
+    if (succeeded(result)) {
+      return result;
+    }
+
+    // If the legacy encoding failed use LinearLayouts.
+    // Once LinearLayouts are more widely used, we can remove
+    // inferReshapeOpLegacyEncoding and simply use LLs.
+    auto *ctx = getContext();
+    auto src = triton::gpu::toLinearLayout(srcShape, srcEnc);
+    if (!src) {
+      return emitOptionalError(loc,
+                               "src encoding does not support linear layout");
+    }
+
+    if (product(srcShape) != product(dstShape)) {
+      return emitOptionalError(loc, "numel of dst shape does not match "
+                                    "numel of src shape");
+    }
+
+    auto newRank = dstShape.size();
+    SmallVector<std::pair<StringAttr, int32_t>> newOutDims;
+    for (auto [dim, size] :
+         llvm::zip(standardOutDimNames(ctx, newRank), dstShape)) {
+      newOutDims.emplace_back(dim, size);
+    }
+    auto srcOutDims = llvm::to_vector(src->getOutDimNames());
+    // reshapeOp assumes C-order, so we need to transpose the out dims before
+    // the reshape
+    std::reverse(srcOutDims.begin(), srcOutDims.end());
+    std::reverse(newOutDims.begin(), newOutDims.end());
+    auto dst = src->transposeOuts(srcOutDims)
+                   .reshapeOuts(newOutDims)
+                   .transposeOuts(standardOutDimNames(ctx, newRank));
+    dstEnc = LinearEncodingAttr::get(ctx, dst);
     return success();
   }
 

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -40,6 +40,8 @@ struct CanonicalizeConvertFromReshape
   matchAndRewrite(triton::ReshapeOp op,
                   PatternRewriter &rewriter) const override {
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
+    if (!convert)
+      return failure();
     // If the layouts are structurally the same, the convert is trivial
     auto srcType = convert.getSrc().getType();
     auto dstType = convert.getType();
@@ -50,8 +52,6 @@ struct CanonicalizeConvertFromReshape
           op, op.getType(), convert.getSrc(), op.getAllowReorder());
       return mlir::success();
     }
-    if (!convert)
-      return failure();
     if (isExpensiveView(convert.getSrc().getType(), op.getType()))
       return failure();
     if (!op.getAllowReorder() || op.getEfficientLayout())

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -40,6 +40,16 @@ struct CanonicalizeConvertFromReshape
   matchAndRewrite(triton::ReshapeOp op,
                   PatternRewriter &rewriter) const override {
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
+    // If the layouts are structurally the same, the convert is trivial
+    auto srcType = convert.getSrc().getType();
+    auto dstType = convert.getType();
+    auto srcLL = toLinearLayout(srcType.getShape(), srcType.getEncoding());
+    auto dstLL = toLinearLayout(dstType.getShape(), dstType.getEncoding());
+    if (srcLL && dstLL && *srcLL == *dstLL) {
+      rewriter.replaceOpWithNewOp<triton::ReshapeOp>(
+          op, op.getType(), convert.getSrc(), op.getAllowReorder());
+      return mlir::success();
+    }
     if (!convert)
       return failure();
     if (isExpensiveView(convert.getSrc().getType(), op.getType()))

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1025,9 +1025,7 @@ void LayoutRematerialization::backwardRematerialization(
   // we don't handle conversions to DotOperandEncodingAttr
   // this is a heuristic to accommodate fused attention
   RankedTensorType targetType = convertOp.getType();
-  // We stop the rematerialization of linear layouts as we have to be a bit more
-  // careful with the heuristics for both correctness and perf
-  if (isa<DotOperandEncodingAttr, LinearEncodingAttr>(targetType.getEncoding()))
+  if (isa<DotOperandEncodingAttr>(targetType.getEncoding()))
     return;
   Value oldV = convertOp.getSrc();
   LDBG("check backward remat with source " << oldV << " encoding "
@@ -1069,11 +1067,8 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
     ConvertLayoutOp convertOp) {
   // we don't handle conversions to DotOperandEncodingAttr
   // this is a heuristics to accommodate fused attention
-  // We stop the rematerialization of linear layouts as we have to be a bit more
-  // careful with the heuristics for both correctness and perf
   RankedTensorType targetType = convertOp.getType();
-  if (mlir::isa<DotOperandEncodingAttr, LinearEncodingAttr>(
-          targetType.getEncoding()))
+  if (isa<DotOperandEncodingAttr>(targetType.getEncoding()))
     return;
 
   auto isExtOrBroadcastOp = [](Operation *op) {

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -407,14 +407,12 @@ static Attribute inferReshapeOpDstEncoding(ArrayRef<int64_t> srcShape,
     return {};
 
   Attribute dstEnc;
-  if (succeeded(
-          srcEnc.getDialect()
-              .getRegisteredInterface<triton::DialectInferLayoutInterface>()
-              ->inferReshapeOpNoReorderEncoding(
-                  srcShape, srcEnc, dstShape, dstEnc, /*loc=*/std::nullopt))) {
-    return dstEnc;
-  }
-  return {};
+  assert(succeeded(
+      srcEnc.getDialect()
+          .getRegisteredInterface<triton::DialectInferLayoutInterface>()
+          ->inferReshapeOpEncoding(srcShape, srcEnc, dstShape, dstEnc,
+                                   /*loc=*/std::nullopt)));
+  return dstEnc;
 }
 
 static Attribute inferDstEncoding(triton::ReshapeOp op, Attribute encoding) {

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -407,11 +407,12 @@ static Attribute inferReshapeOpDstEncoding(ArrayRef<int64_t> srcShape,
     return {};
 
   Attribute dstEnc;
-  assert(succeeded(
+  auto result =
       srcEnc.getDialect()
           .getRegisteredInterface<triton::DialectInferLayoutInterface>()
           ->inferReshapeOpEncoding(srcShape, srcEnc, dstShape, dstEnc,
-                                   /*loc=*/std::nullopt)));
+                                   /*loc=*/std::nullopt);
+  assert(succeeded(result));
   return dstEnc;
 }
 

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -77,135 +77,6 @@ int64_t getFlatIdx(ArrayRef<unsigned> idx, ArrayRef<unsigned> shape,
   return flatIdx;
 }
 
-// Represents the many indices of one element of a tensor with a
-// BlockedEncoding.
-//
-// The purpose of this class is we can say, if two MultiIdx's have the same
-// flatFoo values before and after a reshape, then the same GPU thread contains
-// the same element (and the reshape is a nop, at least for that element).
-struct MultiIdx {
-  using Vec = SmallVector<unsigned, 5>;
-
-  // Logical index into the tensor.
-  Vec idx;
-
-  // If the tensor's encoding has e.g. numPerThread = [2,2], then idxInThread
-  // tells us which of the four elements per thread this is.  Same for idxInWarp
-  // and idxInCTA.
-  Vec idxInThread;
-  Vec idxInWarp;
-  Vec idxInCTA;
-
-  // If the tensor's encoding defines a block of size [x,y,z], the tensor itself
-  // may be larger than this, comprising multiple blocks.  This tells us which
-  // block we're in.
-  Vec idxOuter;
-
-  // flatIdx is flattened according to the tensor's logical order (i.e. ignoring
-  // the encoding).  The others are flattened according to the tensor's physical
-  // encoding.
-  int64_t flatIdx;
-  int64_t flatIdxInThread;
-  int64_t flatIdxInWarp;
-  int64_t flatIdxInCTA;
-  int64_t flatIdxOuter;
-};
-
-bool sameFlatIdxs(const MultiIdx &a, const MultiIdx &b) {
-  return a.flatIdx == b.flatIdx && //
-         a.flatIdxInThread == b.flatIdxInThread &&
-         a.flatIdxInWarp == b.flatIdxInWarp &&
-         a.flatIdxInCTA == b.flatIdxInCTA && //
-         a.flatIdxOuter == b.flatIdxOuter;
-}
-
-std::string multiIdxsToString(ArrayRef<std::unique_ptr<MultiIdx>> idxs) {
-  std::stringstream ss;
-  for (const auto &idxPtr : idxs) {
-    const MultiIdx &idx = *idxPtr;
-    ss //
-        << "  [" << triton::join(idx.idx, ",") << "] (" << idx.flatIdx << ") "
-        << "elem=[" << triton::join(idx.idxInThread, ",") << "] ("
-        << idx.flatIdxInThread << ") "
-        << "thread=[" << triton::join(idx.idxInWarp, ",") << "] ("
-        << idx.flatIdxInWarp << ") "
-        << "warp=[" << triton::join(idx.idxInCTA, ",") << "] ("
-        << idx.flatIdxInCTA << ") "
-        << "outer=[" << triton::join(idx.idxOuter, ",") << "] ("
-        << idx.flatIdxOuter << ")\n";
-  }
-  return ss.str();
-}
-
-std::vector<std::unique_ptr<MultiIdx>> getMultiIdxs(ArrayRef<unsigned> shape,
-                                                    BlockedEncodingAttr enc) {
-  using Vec = MultiIdx::Vec;
-
-  const unsigned rank = shape.size();
-  auto sizePerThread = enc.getSizePerThread();
-  auto threadsPerWarp = enc.getThreadsPerWarp();
-  auto warpsPerCTA = enc.getWarpsPerCTA();
-  auto order = enc.getOrder();
-
-  Vec numBlocks;
-  for (int i = 0; i < rank; i++) {
-    numBlocks.push_back(ceil<unsigned>(
-        shape[i], sizePerThread[i] * threadsPerWarp[i] * warpsPerCTA[i]));
-  }
-
-  Vec idxInThread(rank, 0);
-  Vec idxInWarp(rank, 0);
-  Vec idxInCTA(rank, 0);
-  Vec idxOuter(rank, 0);
-
-  int64_t nElems = product(sizePerThread) * product(threadsPerWarp) *
-                   product(warpsPerCTA) * product(numBlocks);
-
-  // We eventually sort this array, and if the elements are plain MultiIdx
-  // elements rather than pointers, we have to swap them, which ends up being
-  // expensive.
-  std::vector<std::unique_ptr<MultiIdx>> elems;
-  elems.reserve(nElems);
-
-  for (int64_t i = 0; i < nElems; i++) {
-    auto e = std::make_unique<MultiIdx>();
-    e->idxInThread = idxInThread;
-    e->idxInWarp = idxInWarp;
-    e->idxInCTA = idxInCTA;
-    e->idxOuter = idxOuter;
-
-    for (int i = 0; i < rank; i++) {
-      e->idx.push_back(    //
-          idxInThread[i] + //
-          idxInWarp[i] * sizePerThread[i] +
-          idxInCTA[i] * sizePerThread[i] * threadsPerWarp[i] +
-          idxOuter[i] * sizePerThread[i] * threadsPerWarp[i] * warpsPerCTA[i]);
-    }
-
-    e->flatIdxInThread = getFlatIdx(e->idxInThread, sizePerThread, order);
-    e->flatIdxInWarp = getFlatIdx(e->idxInWarp, threadsPerWarp, order);
-    e->flatIdxInCTA = getFlatIdx(e->idxInCTA, warpsPerCTA, order);
-    e->flatIdxOuter = getFlatIdx(e->idxOuter, numBlocks, order);
-    e->flatIdx = getFlatIdx(e->idx, shape,
-                            llvm::to_vector(llvm::reverse(llvm::seq(rank))));
-
-    elems.push_back(std::move(e));
-
-    if (advance(idxInThread, sizePerThread, order)) {
-      if (advance(idxInWarp, threadsPerWarp, order)) {
-        if (advance(idxInCTA, warpsPerCTA, order)) {
-          advance(idxOuter, numBlocks, order);
-        }
-      }
-    }
-  }
-  llvm::sort(elems, [](const std::unique_ptr<MultiIdx> &a,
-                       const std::unique_ptr<MultiIdx> &b) {
-    return a->flatIdx < b->flatIdx;
-  });
-  return elems;
-}
-
 class InferLayoutTest : public ::testing::Test {
 public:
   InferLayoutTest()
@@ -221,25 +92,12 @@ protected:
 
 /*static*/ MLIRContext InferLayoutTest::ctx;
 
-// The optional outparam couldReshape tells the caller whether the reshape
-// worked.  You might want this to be a return value instead, but gtest ASSERT
-// and FAIL have an implicit `return`, so only work in fns that return void.
 void testReshape(RankedTensorType srcTy, RankedTensorType dstTy,
                  std::optional<BlockedEncodingAttr> expectedDstEnc,
-                 std::optional<bool> expectSuccess,
                  DialectInferLayoutInterface *inferLayout,
-                 bool longErrors = true, bool *couldReshape = nullptr) {
-  std::unique_ptr<bool> couldReshapeStorage;
-  if (!couldReshape) {
-    couldReshapeStorage = std::make_unique<bool>();
-    couldReshape = couldReshapeStorage.get();
-  }
-  *couldReshape = false;
+                 bool longErrors = true) {
 
   MLIRContext *ctx = srcTy.getContext();
-  ASSERT_TRUE(expectSuccess || !dstTy.getEncoding())
-      << "dstTy shouldn't have an expected encoding if we're expecting the "
-         "reshape to be impossible!";
 
   // Capture any errors from calling inferReshapeNoOpReorderEncoding, so we can
   // print them if we expected the reshape to succeed but it failed.
@@ -249,29 +107,17 @@ void testReshape(RankedTensorType srcTy, RankedTensorType dstTy,
   {
     ScopedDiagnosticHandler scopedHandler(
         ctx, [&](Diagnostic &diag) { diags.push_back("  - " + diag.str()); });
-    result = inferLayout->inferReshapeOpNoReorderEncoding(
+    result = inferLayout->inferReshapeOpEncoding(
         srcTy.getShape(), srcTy.getEncoding(), dstTy.getShape(), inferredEnc,
         UnknownLoc::get(ctx));
   }
 
-  if (!expectSuccess.has_value() && !succeeded(result)) {
-    // We didn't know whether or not it was supposed to succeed, and it didn't.
-    // Test passes!
-    return;
-  }
+  // We expect the reshape to succeed as long as the inputs have the same
+  // number of elements
+  EXPECT_TRUE(succeeded(result))
+      << "Expected reshape to succeed, but it didn't!  Error(s):\n"
+      << join(diags, "\n");
 
-  if (expectSuccess.has_value() && !*expectSuccess) {
-    EXPECT_FALSE(succeeded(result))
-        << "Expected reshape to be impossible, but got dst encoding: "
-        << stringifyLLVMType(inferredEnc);
-    *couldReshape = true;
-    return;
-  }
-
-  if (!succeeded(result)) {
-    FAIL() << "Expected reshape to succeed, but it didn't!  Error(s):\n"
-           << join(diags, "\n");
-  }
   if (auto expectedEnc = dstTy.getEncoding()) {
     EXPECT_EQ(inferredEnc, expectedEnc);
   }
@@ -279,12 +125,14 @@ void testReshape(RankedTensorType srcTy, RankedTensorType dstTy,
   // We know that infer(srcShape, srcEnc, dstShape) => dstEnc.  Check that it
   // works the other way around too: infer(dstShape, dstEnc, srcShape) =>
   // srcEnc.  (This is an invariant of the inference function.)
+  // Even more, we check that the inferred encoding is structurally the same as
+  // the src encoding, showing that the inference is consistent.
   {
     std::vector<std::string> diags;
     ScopedDiagnosticHandler scopedHandler(
         ctx, [&](Diagnostic &diag) { diags.push_back("  - " + diag.str()); });
     Attribute inferredSrcEnc;
-    auto result = inferLayout->inferReshapeOpNoReorderEncoding(
+    auto result = inferLayout->inferReshapeOpEncoding(
         dstTy.getShape(), inferredEnc, srcTy.getShape(), inferredSrcEnc,
         UnknownLoc::get(ctx));
     EXPECT_TRUE(succeeded(result))
@@ -292,56 +140,40 @@ void testReshape(RankedTensorType srcTy, RankedTensorType dstTy,
         << " " << stringifyLLVMType(inferredEnc) << " -> "
         << triton::join(srcTy.getShape(), "x") << "failed:\n"
         << join(diags, "\n");
-    if (succeeded(result)) {
-      EXPECT_EQ(inferredSrcEnc, srcTy.getEncoding())
-          << "Inverse encoding inference ("
-          << triton::join(dstTy.getShape(), "x") << " "
-          << stringifyLLVMType(inferredEnc) << " -> "
-          << triton::join(srcTy.getShape(), "x")
-          << " gave the wrong result.  Expected "
-          << stringifyLLVMType(srcTy.getEncoding()) << " but got "
-          << stringifyLLVMType(inferredSrcEnc) << ".\n";
-    }
+    auto srcLinear = toLinearLayout(srcTy.getShape(), srcTy.getEncoding());
+    auto inferredSrcLinear = toLinearLayout(srcTy.getShape(), inferredSrcEnc);
+    EXPECT_EQ(inferredSrcLinear, srcLinear)
+        << "Inverse encoding inference (" << triton::join(dstTy.getShape(), "x")
+        << " " << stringifyLLVMType(inferredEnc) << " -> "
+        << triton::join(srcTy.getShape(), "x")
+        << " gave the wrong result.  Expected " << srcLinear->toString()
+        << " but "
+        << "got " << inferredSrcLinear->toString() << ".\n";
   }
 
-  std::vector<std::unique_ptr<MultiIdx>> srcMultiIdxs =
-      getMultiIdxs(SmallVector<unsigned>(srcTy.getShape()),
-                   mlir::cast<BlockedEncodingAttr>(srcTy.getEncoding()));
-
-  std::vector<std::unique_ptr<MultiIdx>> dstMultiIdxs =
-      getMultiIdxs(SmallVector<unsigned>(dstTy.getShape()),
-                   mlir::cast<BlockedEncodingAttr>(inferredEnc));
-
-  if (srcMultiIdxs.size() != dstMultiIdxs.size() ||
-      !llvm::all_of(llvm::zip_equal(srcMultiIdxs, dstMultiIdxs),
-                    [](const auto &pair) {
-                      const auto &[a, b] = pair;
-                      return sameFlatIdxs(*a, *b);
-                    })) {
-    SCOPED_TRACE(longErrors ? "dst indices:\n" + multiIdxsToString(dstMultiIdxs)
-                            : "");
-    SCOPED_TRACE(longErrors ? "src indices:\n" + multiIdxsToString(srcMultiIdxs)
-                            : "");
-    ADD_FAILURE() << "Reified indices do not match for encodings:\n"
-                  << "  src: [" << triton::join(srcTy.getShape(), "x") << "] "
-                  << stringifyLLVMType(srcTy.getEncoding()) << "\n"
-                  << "  dst: [" << triton::join(dstTy.getShape(), "x") << "] "
-                  << stringifyLLVMType(inferredEnc);
-  } else {
-    *couldReshape = true;
-  }
+  // The funtional characterisation of resize is that, if we have a srcLayout
+  // and a dstLayout, then the flattened layouts are views of the same data
+  // when considered as C-contiguous.
+  auto makeFlattenedCContig = [](ArrayRef<int64_t> shape, Attribute layout) {
+    auto ctx = layout.getContext();
+    auto linear = *toLinearLayout(shape, layout);
+    auto dims = standardOutDimNames(ctx, shape.size());
+    std::reverse(dims.begin(), dims.end());
+    return linear.transposeOuts(dims).reshapeOuts(
+        {{dims.back(), linear.getTotalOutDimSize()}});
+  };
+  EXPECT_EQ(makeFlattenedCContig(srcTy.getShape(), srcTy.getEncoding()),
+            makeFlattenedCContig(dstTy.getShape(), inferredEnc));
 }
 
-class InferReshapeOpNoReorderEncodingTest
+class InferReshapeOpEncodingTest
     : public InferLayoutTest,
       public ::testing::WithParamInterface<
-          std::tuple<std::string /*srcTy*/, std::string /*dstTy*/,
-                     bool /*expectSuccess*/>> {};
+          std::tuple<std::string /*srcTy*/, std::string /*dstTy*/>> {};
 
-TEST_P(InferReshapeOpNoReorderEncodingTest, DoIt) {
+TEST_P(InferReshapeOpEncodingTest, DoIt) {
   std::string srcTyStr = expandTyStr(std::get<0>(GetParam()));
   std::string dstTyStr = expandTyStr(std::get<1>(GetParam()));
-  bool expectSuccess = std::get<2>(GetParam());
 
   auto src = mlir::parseType(srcTyStr, &ctx);
   if (!src)
@@ -357,7 +189,7 @@ TEST_P(InferReshapeOpNoReorderEncodingTest, DoIt) {
   }
 
   testReshape(cast<RankedTensorType>(src), cast<RankedTensorType>(dst),
-              expectedDstEnc, expectSuccess, inferLayout, /*longErrors=*/true);
+              expectedDstEnc, inferLayout, /*longErrors=*/true);
 }
 
 // A testcase of {a, b, c} means:
@@ -368,157 +200,71 @@ TEST_P(InferReshapeOpNoReorderEncodingTest, DoIt) {
 //      encoding that makes the reshape a nop, and
 //    - if b has an encoding, check that the inferred encoding matches b's.
 INSTANTIATE_TEST_SUITE_P(
-    Reshapes, InferReshapeOpNoReorderEncodingTest,
-    ::testing::ValuesIn(std::vector<
-                        std::tuple<std::string /*srcTy*/, std::string /*dstTy*/,
-                                   bool /*expectSuccess*/>>({
+    Reshapes, InferReshapeOpEncodingTest,
+    ::testing::ValuesIn(std::vector<std::tuple<std::string /*srcTy*/,
+                                               std::string /*dstTy*/>>({
         // Use raw strings in here so clang-format doesn't try to wrap them.
         {R"(T<128x64xf32, #B<{spt=[1,1], tpw=[1,32], wpc=[1,1], ord=[1,0]}>>)",
-         R"(T<8192xf32,   #B<{spt=[1],   tpw=[32],   wpc=[1],   ord=[0]}>>)",
-         true},
+         R"(T<8192xf32,   #B<{spt=[1],   tpw=[32],   wpc=[1],   ord=[0]}>>)"},
 
         {R"(T<128xf32,  #B<{spt=[4],   tpw=[32],   wpc=[1],   ord=[0]}>>)",
-         R"(T<32x4xf32, #B<{spt=[1,4], tpw=[32,1], wpc=[1,1], ord=[1,0]}>>)",
-         true},
+         R"(T<32x4xf32, #B<{spt=[1,4], tpw=[32,1], wpc=[1,1], ord=[1,0]}>>)"},
 
         {R"(T<128xf32,  #B<{spt=[4],   tpw=[32],   wpc=[1],   ord=[0]}>>)",
-         R"(T<16x8xf32, #B<{spt=[1,4], tpw=[16,2], wpc=[1,1], ord=[1,0]}>>)",
-         true},
+         R"(T<16x8xf32, #B<{spt=[1,4], tpw=[16,2], wpc=[1,1], ord=[1,0]}>>)"},
 
         {R"(T<32x32xf32, #B<{spt=[2,2], tpw=[32,1], wpc=[1,1], ord=[1,0]}>>)",
-         "T<128xf32>", false},
+         "T<1024xf32>"},
 
         {R"(T<32x4xf32,     #B<{spt=[1,4],     tpw=[32,1],     wpc=[1,1],     ord=[1,0]}>>)",
-         R"(T<2x16x2x2xf32, #B<{spt=[1,1,2,2], tpw=[2,16,1,1], wpc=[1,1,1,1], ord=[3,2,1,0]}>>)",
-         true},
+         R"(T<2x16x2x2xf32, #B<{spt=[1,1,2,2], tpw=[2,16,1,1], wpc=[1,1,1,1], ord=[3,2,1,0]}>>)"},
 
         {R"(T<4x32xf32,     #B<{spt=[4,1],     tpw=[1,32],     wpc=[1,1],     ord=[0,1]}>>)",
-         R"(T<2x2x2x16xf32, #B<{spt=[2,2,1,1], tpw=[1,1,2,16], wpc=[1,1,1,1], ord=[1,0,3,2]}>>)",
-         true},
+         R"(T<2x2x2x16xf32, #B<{spt=[2,2,1,1], tpw=[1,1,2,16], wpc=[1,1,1,1], ord=[1,0,3,2]}>>)"},
 
         {R"(T<32x32xf32,     #B<{spt=[4,4],     tpw=[4,8],     wpc=[1,1],     ord=[1,0]}>>)",
-         R"(T<2x16x2x16xf32, #B<{spt=[1,4,1,4], tpw=[1,4,2,4], wpc=[1,1,1,1], ord=[3,2,1,0]}>>)",
-         true},
+         R"(T<2x16x2x16xf32, #B<{spt=[1,4,1,4], tpw=[1,4,2,4], wpc=[1,1,1,1], ord=[3,2,1,0]}>>)"},
 
         {R"(T<32x32xf32,     #B<{spt=[4,4],     tpw=[4,8],     wpc=[1,1],     ord=[1,0]}>>)",
-         R"(T<16x2x16x2xf32, #B<{spt=[2,2,2,2], tpw=[4,1,8,1], wpc=[1,1,1,1], ord=[3,2,1,0]}>>)",
-         true},
+         R"(T<16x2x16x2xf32, #B<{spt=[2,2,2,2], tpw=[4,1,8,1], wpc=[1,1,1,1], ord=[3,2,1,0]}>>)"},
 
         {R"(T<32x32xf32, #B<{spt=[4,4], tpw=[4,8], wpc=[1,1], ord=[0,1]}>>)",
-         R"(T<16x2x16x2xf32>)", true},
+         R"(T<16x2x16x2xf32>)"},
 
         // nop reshape, but the block size is 2x larger than the tensor.
         {R"(T<4x2x2x4xf32, #B<{spt=[2,1,1,2], tpw=[2,1,1,2], wpc=[2,2,1,1], ord=[0,3,1,2]}>>)",
-         R"(T<4x2x2x4xf32, #B<{spt=[2,1,1,2], tpw=[2,1,1,2], wpc=[2,2,1,1], ord=[0,3,1,2]}>>)",
-         true},
+         R"(T<4x2x2x4xf32, #B<{spt=[2,1,1,2], tpw=[2,1,1,2], wpc=[2,2,1,1], ord=[0,3,1,2]}>>)"},
 
         {R"(T<2x4x2x4xf32, #B<{spt=[1,2,2,1], tpw=[1,2,1,2], wpc=[1,2,2,1], ord=[2,1,0,3]}>>)",
-         R"(T<4x2x2x4xf32>)", false},
+         R"(T<4x2x2x4xf32>)"},
 
         {R"(T<1x2x2x4xf32, #B<{spt=[1,32,4,4], tpw=[4,4,16,16], wpc=[8,8,8,1], ord=[0,1,2,3]}>>)",
-         R"(T<2x2x4x1xf32>)", false},
+         R"(T<2x2x4x1xf32>)"},
 
         {R"(T<2x2x2x2xf32, #B<{spt=[2,2,2,2], tpw=[1,1,1,1], wpc=[1,1,1,1], ord=[1,0,3,2]}>>)",
-         R"(T<4x4xf32>)", true},
+         R"(T<4x4xf32>)"},
 
         {R"(T<16x8xf32, #B<{spt=[1,2], tpw=[2,4], wpc=[2,1], ord=[1,0]}>>)",
-         R"(T<128xf32>)", true},
+         R"(T<128xf32>)"},
 
         {R"(T<16x1x8xf32, #B<{spt=[8,1,1], tpw=[2,1,1], wpc=[1,1,8], ord=[2,1,0]}>>)",
-         R"(T<128x1xf32>)", false},
+         R"(T<128x1xf32>)"},
 
         {R"(T<16x1x8xf32, #B<{spt=[1,1,8], tpw=[2,1,1], wpc=[8,1,1], ord=[2,1,0]}>>)",
-         R"(T<128x1xf32>)", true},
+         R"(T<128x1xf32>)"},
 
         {R"(T<32x32xf32, #B<{spt=[1,2], tpw=[1,8], wpc=[1,1], ord=[1,0]}>>)",
-         R"(T<1024xf32>)", true},
+         R"(T<1024xf32>)"},
 
         {R"(T<4x4xf32, #B<{spt=[1,1], tpw=[2,4], wpc=[2,1], ord=[0,1]}>>)",
-         R"(T<16xf32>)", false},
+         R"(T<16xf32>)"},
 
         {R"(T<32xf32,   #B<{spt=[2],   tpw=[32],   wpc=[2],   ord=[0]}>>)",
-         R"(T<16x2xf32, #B<{spt=[1,2], tpw=[32,1], wpc=[2,1], ord=[1,0]}>>)",
-         true},
+         R"(T<16x2xf32, #B<{spt=[1,2], tpw=[32,1], wpc=[2,1], ord=[1,0]}>>)"},
 
         {R"(T<2x1x2xf32, #B<{spt=[2,1,1], tpw=[2,1,2], wpc=[4,1,8], ord=[2,1,0]}>>)",
-         R"(T<2x2xf32,   #B<{spt=[2,1],   tpw=[2,2],   wpc=[4,8],   ord=[1,0]}>>)",
-         true},
+         R"(T<2x2xf32,   #B<{spt=[2,1],   tpw=[2,2],   wpc=[4,8],   ord=[1,0]}>>)"},
     })));
-
-TEST_F(InferLayoutTest, FuzzReshape) {
-  const int numTests = 1000; // Increase to get more coverage.
-
-  std::minstd_rand rng(/*seed=*/0);
-  auto randPow2Vec = [&](int rank, int maxPow2) {
-    SmallVector<unsigned> ret;
-    for (int i = 0; i < rank; i++) {
-      int pow2 = std::uniform_int_distribution<unsigned>(0, maxPow2)(rng);
-      if (pow2 == maxPow2 && maxPow2 > 0) {
-        maxPow2--;
-      }
-      ret.push_back(1 << pow2);
-    }
-    return ret;
-  };
-
-  int numSuccess = 0;
-  for (int i = 0; i < numTests; i++) {
-    SCOPED_TRACE("iteration " + std::to_string(i));
-    int rank = std::uniform_int_distribution<int>(1, 4)(rng);
-
-    SmallVector<int64_t> srcShape(
-        convertType<int64_t>(randPow2Vec(rank, /*maxPow2=*/4)));
-    SmallVector<int64_t> dstShape = srcShape;
-    std::shuffle(dstShape.begin(), dstShape.end(), rng);
-
-    // Optionally merge some dimensions in dst.
-    for (int i = 1; i < dstShape.size(); i++) {
-      if (std::uniform_real_distribution<float>(0, 1)(rng) > 1.0 / rank) {
-        dstShape[i - 1] *= dstShape[i];
-        dstShape.erase(dstShape.begin() + i);
-        i--;
-      }
-    }
-
-    SmallVector<unsigned> sizePerThread = randPow2Vec(rank, /*maxPow2=*/3);
-    SmallVector<unsigned> threadsPerWarp = randPow2Vec(rank, /*maxPow2=*/3);
-    SmallVector<unsigned> warpsPerCTA = randPow2Vec(rank, /*maxPow2=*/3);
-
-    SmallVector<unsigned> order(llvm::to_vector(llvm::seq<unsigned>(rank)));
-    std::shuffle(order.begin(), order.end(), rng);
-
-    auto ctaLayout = CTALayoutAttr::get(
-        &ctx, SmallVector<unsigned>(rank, 1), SmallVector<unsigned>(rank, 1),
-        llvm::to_vector(llvm::reverse(llvm::seq<unsigned>(rank))));
-
-    auto srcTy = RankedTensorType::get(
-        srcShape, FloatType::getF32(&ctx),
-        BlockedEncodingAttr::get(&ctx, sizePerThread, threadsPerWarp,
-                                 warpsPerCTA, order, ctaLayout));
-    auto dstTy = RankedTensorType::get(dstShape, FloatType::getF32(&ctx));
-
-    bool couldReshape = false;
-    testReshape(srcTy, dstTy, /*expectedDstEnc=*/std::nullopt,
-                /*expectSuccess=*/std::nullopt, inferLayout,
-                /*longErrors=*/false, &couldReshape);
-    if (couldReshape)
-      numSuccess++;
-  }
-
-  // We don't expect or want 100% success, but if only a tiny fraction of tests
-  // actually exercise the successful reshape logic, then that gives us bad
-  // coverage.  I'm currently getting 35% success, which seems good enough,
-  // especially since the successful cases take a lot longer to run because of
-  // the MultiIdx checks (so we're spending most of our time on successful
-  // cases, even if they're only 1/3 of the iterations).
-  //
-  // Run ctest with --verbose to see this output.  For example:
-  //   $ cd python/build/cmake.blah.blah
-  //   $ ninja
-  //   $ $(git rev-parse --show-toplevel)/.venv/bin/ctest --verbose
-  printf("Fuzz success rate: %d/%d = %.2f%%\n", numSuccess, numTests,
-         100.0 * numSuccess / numTests);
-}
 
 class AMDMfmaLayoutTest : public ::testing::Test {
 public:


### PR DESCRIPTION
This PR also:
- Enables backward rematerialisation and hoisting for LLs
- Adds a fold reshape(cvt) -> reshape when the layouts are structurally the same
- Removes an assert that was disallowing the use of LLs across broadcast. When this happens, the LL will not have the same shape as the tensor. We do this to match the legacy behaviour and avoid the proliferation of new layouts
- Removes the layout-specific tests from before and instead we create functional tests that test the axioms for the reshape function. We see that all the legacy layouts pass these tests.
- Temporarily tested that the legacy path and the new path agree in CI in https://github.com/triton-lang/triton/pull/5389/commits/e93638b98409f8dc4c7c41aa644d0501f2630a77

