### PR TITLE
[Backend] Reorder return values in `emitHardwareTuple` (NFC)

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -1123,8 +1123,8 @@ emitBaseIndexForLayout(Location loc, RewriterBase &rewriter,
   return idx;
 }
 
-// Emit code to compute the (blockId, warpId, laneId) for the current thread.
-std::tuple</*blockId=*/Value, /*warpId=*/Value, /*laneId=*/Value>
+// Emit code to compute the (laneId, warpId, blockId) for the current thread.
+std::tuple</*laneId=*/Value, /*warpId=*/Value, /*blockId=*/Value>
 emitHardwareTuple(Location loc, RewriterBase &rewriter,
                   const TargetInfoBase &target, bool withCTAOffset,
                   unsigned threadsPerWarp);

--- a/lib/Conversion/TritonGPUToLLVM/GatherOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/GatherOpToLLVM.cpp
@@ -258,7 +258,7 @@ void GatherOpConversion::emitWarpLocalGather(
   SmallVector<Value> idxValues =
       unpackLLElements(loc, adaptor.getIndices(), rewriter);
 
-  auto [blockId, warpId, laneId] =
+  auto [laneId, warpId, blockId] =
       emitHardwareTuple(loc, rewriter, targetInfo, /*withCTAOffset=*/true,
                         srcLayout.getInDimSize(kLane));
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -110,7 +110,7 @@ std::tuple<Value, Value, Value> emitHardwareTuple(Location loc,
   Value warpId = udiv(threadId, threadsPerWarp);
   Value blockId =
       withCTAOffset ? target.getClusterCTAId(rewriter, loc) : i32_val(0);
-  return {blockId, warpId, laneId};
+  return {laneId, warpId, blockId};
 }
 
 SmallVector<SmallVector<Value>>
@@ -130,7 +130,7 @@ emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
   StringAttr kWarp = str_attr("warp");
   StringAttr kBlock = str_attr("block");
 
-  auto [blockId, warpId, laneId] = emitHardwareTuple(
+  auto [laneId, warpId, blockId] = emitHardwareTuple(
       loc, rewriter, target, withCTAOffset, ll->getInDimSize(kLane));
   unsigned rank = shape.size();
   SmallVector<SmallVector<Value>> ret;
@@ -353,7 +353,7 @@ bool emitTransferBetweenRegistersAndShared(
       std::min(regToSharedLayout->getNumConsecutiveInOut(),
                maxVecElems.value_or(std::numeric_limits<int>::max()));
 
-  auto [blockId, warpId, laneId] =
+  auto [laneId, warpId, blockId] =
       emitHardwareTuple(loc, rewriter, target, /*withCTAOffset=*/false,
                         regToSharedLayout->getInDimSize(kLane));
 
@@ -746,7 +746,7 @@ SmallVector<Value> getMultiDimOffset(Attribute layout, Location loc,
     auto instrShape = mmaLayout.getInstrShape();
     SmallVector<Value> mmaColIdx(2);
     SmallVector<Value> mmaRowIdx(2);
-    auto [blockId, warpId, laneId] = emitHardwareTuple(
+    auto [laneId, warpId, blockId] = emitHardwareTuple(
         loc, rewriter, targetInfo, /*withCTAOffset=*/false, 32);
     // TODO: fix the bug in MMAEncodingAttr document
     SmallVector<Value> multiDimWarpId(2);


### PR DESCRIPTION
@lezcano pointed out in another PR that the order is confusing because typically we list the lane ID, warp ID, and blockID in this order.
