### PR TITLE
[AMD] Generalize matmul detection in reorder instructions pass

### DIFF
--- a/test/TritonGPU/amd/amd-sched-2nd-load.mlir
+++ b/test/TritonGPU/amd/amd-sched-2nd-load.mlir
@@ -61,6 +61,48 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32}
 #dotOp1 = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>
 #smem = #ttg.shared_memory
 
+// Should apply: tile size 256x256x128 with nested single dot
+// CHECK-LABEL: nested_sink_2nd_load_256x256x128
+//       CHECK: %[[tileA:.*]] = tt.load
+//  CHECK-NEXT: local_load
+//  CHECK-NEXT: local_load
+//  CHECK-NEXT: %[[tileB:.*]] = tt.load
+//  CHECK-NEXT: tt.dot
+//  CHECK-NEXT: ttg.local_store %[[tileA]]
+//  CHECK-NEXT: ttg.local_store %[[tileB]]
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @nested_sink_2nd_load_256x256x128(%A_ptr: tensor<256x128x!tt.ptr<f16>, #blocked>, %B_ptr: tensor<128x256x!tt.ptr<f16>, #blocked1>, %C_ptr: tensor<256x256x!tt.ptr<f32>, #mma>, %A_LDS: !ttg.memdesc<256x128xf16, #shared, #smem, mutable>, %B_LDS: !ttg.memdesc<128x256xf16, #shared1, #smem, mutable>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x256xf32, #mma>
+    scf.for %arg2 = %c0 to %c1 step %c1  : i32 {
+      %0:1 = scf.for %arg0 = %c0 to %c1 step %c1 iter_args(%arg1 = %cst) -> (tensor<256x256xf32, #mma>)  : i32 {
+        %4 = tt.load %A_ptr : tensor<256x128x!tt.ptr<f16>, #blocked>
+        %1 = ttg.local_load %A_LDS : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #dotOp0>
+        %5 = tt.load %B_ptr : tensor<128x256x!tt.ptr<f16>, #blocked1>
+        %2 = ttg.local_load %B_LDS : !ttg.memdesc<128x256xf16, #shared1, #smem, mutable> -> tensor<128x256xf16, #dotOp1>
+        %3 = tt.dot %1, %2, %arg1 : tensor<256x128xf16, #dotOp0> * tensor<128x256xf16, #dotOp1> -> tensor<256x256xf32, #mma>
+        ttg.local_store %4, %A_LDS : tensor<256x128xf16, #blocked> -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+        ttg.local_store %5, %B_LDS : tensor<128x256xf16, #blocked1> -> !ttg.memdesc<128x256xf16, #shared1, #smem, mutable>
+        scf.yield %3 : tensor<256x256xf32, #mma>
+      }
+      tt.store %C_ptr, %0#0: tensor<256x256x!tt.ptr<f32>, #mma>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [0, 1]}>
+#mma = #ttg.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [1, 1], instrShape = [16, 16], isTransposed = true}>
+#shared = #ttg.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = false}>
+#shared1 = #ttg.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [0, 1], hasLeadingOffset = false}>
+#dotOp0 = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>
+#dotOp1 = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>
+#smem = #ttg.shared_memory
+
 // Should apply: tile size 256x256x64 with single dot
 // CHECK-LABEL: sink_2nd_load_256x256x64
 //       CHECK: %[[tileA:.*]] = tt.load

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -227,10 +227,35 @@ static void moveUpTranspose(triton::FuncOp funcOp) {
 // Schedule global load and local store ops for better GEMM performance.
 static void scheduleGlobalLoadLocalStore(scf::ForOp forOp) {
   SmallVector<Operation *> moveOps;
-  // Move global loads early to prefetch. This may increase register pressure
+  // Search through the forOp initArgs to find global loads and local stores for a GEMM
+  // that the pipeliner may have peeled into a loop prologue.
+  SmallVector<Value> vals = forOp.getInitArgs();
+  while (!vals.empty()) {
+    SmallVector<Value> nextVals; // next set of values to search via BFS.
+    for (size_t i = 0; i < vals.size(); ++i) {
+      Operation* defOp = vals[i].getDefiningOp();
+      if (defOp != nullptr && isa<triton::LoadOp>(defOp)) {
+        moveOps.push_back(defOp);
+      } else {
+        for (Operation* op : vals[i].getUsers()) {
+          // find uses of the op that are local_store
+          if (isa<ttg::LocalStoreOp>(op)) {
+            moveOps.push_back(op);
+            // Recurse on operands of the local_store (to find a global load).
+            for (Value operand : op->getOperands()) {
+              if (operand == vals[i]) continue;
+              nextVals.push_back(operand);
+            }
+          }
+        }
+      }
+    }
+    vals = std::move(nextVals);
+  }
+  // Move global loads inside the loop early to prefetch. This may increase register pressure
   // but it enables issuing global loads early.
   forOp.walk([&](triton::LoadOp op) { moveOps.push_back(op); });
-  // Move local_stores early if dependence distance greater than one iteration.
+  // Move local_stores inside the loop early if dependence distance greater than one iteration.
   // Best perf on GEMM when these precede global loads.
   forOp.walk([&](ttg::LocalStoreOp op) { moveOps.push_back(op); });
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -222,7 +222,7 @@ static void moveUpTranspose(triton::FuncOp funcOp) {
 }
 
 // Schedule global load and local store ops for better GEMM performance.
-static void scheduleGlobalLoadLocalStore(Operation* parentOp) {
+static void scheduleGlobalLoadLocalStore(Operation *parentOp) {
   SmallVector<Operation *> moveOps;
   // Move local_stores inside the loop early if dependence distance greater than
   // one iteration. Best perf on GEMM when these precede global loads.

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -222,7 +222,7 @@ static void moveUpTranspose(triton::FuncOp funcOp) {
 }
 
 // Schedule global load and local store ops for better GEMM performance.
-static void scheduleGlobalLoadLocalStore(Operation *parentOp) {
+static void scheduleGlobalLoadLocalStore(Operation* parentOp) {
   SmallVector<Operation *> moveOps;
   // Move local_stores inside the loop early if dependence distance greater than
   // one iteration. Best perf on GEMM when these precede global loads.

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -222,39 +222,14 @@ static void moveUpTranspose(triton::FuncOp funcOp) {
 }
 
 // Schedule global load and local store ops for better GEMM performance.
-static void scheduleGlobalLoadLocalStore(scf::ForOp forOp) {
+static void scheduleGlobalLoadLocalStore(Operation* parentOp) {
   SmallVector<Operation *> moveOps;
-
-  // Search through the forOp initArgs to find global loads for a GEMM that
-  // the pipeliner may have peeled into a loop prologue.
-  SmallVector<Value> vals = forOp.getInitArgs();
-  while (!vals.empty()) {
-    SmallVector<Value> nextVals; // Next set of values to search via BFS.
-    for (size_t i = 0; i < vals.size(); ++i) {
-      Operation *defOp = vals[i].getDefiningOp();
-      if (isa_and_nonnull<triton::LoadOp>(defOp)) {
-        moveOps.push_back(defOp);
-        continue;
-      }
-
-      // Find uses of the op that are local_store
-      for (Operation *op : vals[i].getUsers()) {
-        if (auto storeOp = dyn_cast<ttg::LocalStoreOp>(op)) {
-          // Recurse on operands of the local_store (to find a global_load).
-          nextVals.push_back(storeOp.getSrc());
-        }
-      }
-    }
-    vals.swap(nextVals);
-  }
-
-  // Move local_store ops inside the loop early if dependence distance greater
-  // than one iteration (i.e., num_stages > 2). For such case, better perf on
-  // GEMM when local_store ops precede global loads.
-  forOp.walk([&](ttg::LocalStoreOp op) { moveOps.push_back(op); });
-  // Move global_load ops inside the loop early to prefetch. This may increase
+  // Move local_stores inside the loop early if dependence distance greater than
+  // one iteration. Best perf on GEMM when these precede global loads.
+  parentOp->walk([&](ttg::LocalStoreOp op) { moveOps.push_back(op); });
+  // Move global loads inside the loop early to prefetch. This may increase
   // register pressure but it enables issuing global loads early.
-  forOp.walk([&](triton::LoadOp op) { moveOps.push_back(op); });
+  parentOp->walk([&](triton::LoadOp op) { moveOps.push_back(op); });
 
   for (auto op : llvm::reverse(moveOps)) {
     // Gather use-def chain in block.
@@ -411,7 +386,7 @@ struct TritonAMDGPUReorderInstructionsPass
       SmallVector<scf::ForOp> leafForOps = getLeafForOps(funcOp);
       for (auto forOp : leafForOps) {
         if (isPureMatmulProblem(forOp)) {
-          scheduleGlobalLoadLocalStore(forOp);
+          scheduleGlobalLoadLocalStore(forOp->getParentOp());
           sinkSecondLoad(forOp);
         }
       }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -17,18 +17,29 @@ namespace ttg = mlir::triton::gpu;
 // Utility functions
 //===----------------------------------------------------------------------===//
 
-// Return true if the given moduleOp contains a pure matmul problem; i.e.,
-// single dot in the main loop.
-static bool isPureMatmulProblem(triton::FuncOp funcOp) {
-  bool isMatmul = true;
-  bool foundLoop = false;
-  funcOp.walk([&](scf::ForOp forOp) -> void {
+// Walk innermost for loops that have a single dot inside.
+template <typename Fn>
+static void walkPureMatmul(triton::FuncOp funcOp, Fn fn) {
+  funcOp.walk([&](scf::ForOp loop) -> void {
+    // Check if this loop contains any nested loops.
+    bool hasNestedLoops = false;
+    loop.walk([&](scf::ForOp nestedLoop) {
+      if (nestedLoop != loop) {
+        hasNestedLoops = true;
+      }
+    });
+
+    // Early-out if this is an outer loop.
+    if (hasNestedLoops)
+      return;
+
+    // Count dot operations in the inner loop.
     int counter = 0;
-    forOp.walk([&counter](triton::DotOp dotOp) { ++counter; });
-    isMatmul = (isMatmul && (counter == 1));
-    foundLoop = true;
+    loop.walk([&counter](triton::DotOp dotOp) { ++counter; });
+    if (counter == 1) {
+      fn(loop);
+    }
   });
-  return foundLoop && isMatmul;
 }
 
 // Search through block to find earliest insertion point for move op. This can
@@ -214,14 +225,14 @@ static void moveUpTranspose(triton::FuncOp funcOp) {
 }
 
 // Schedule global load and local store ops for better GEMM performance.
-static void scheduleGlobalLoadLocalStore(triton::FuncOp funcOp) {
+static void scheduleGlobalLoadLocalStore(scf::ForOp forOp) {
   SmallVector<Operation *> moveOps;
-  // Move local_stores early if dependence distance greater than one iteration.
-  // Best perf on GEMM when these precede global loads.
-  funcOp.walk([&](ttg::LocalStoreOp op) { moveOps.push_back(op); });
   // Move global loads early to prefetch. This may increase register pressure
   // but it enables issuing global loads early.
-  funcOp.walk([&](triton::LoadOp op) { moveOps.push_back(op); });
+  forOp.walk([&](triton::LoadOp op) { moveOps.push_back(op); });
+  // Move local_stores early if dependence distance greater than one iteration.
+  // Best perf on GEMM when these precede global loads.
+  forOp.walk([&](ttg::LocalStoreOp op) { moveOps.push_back(op); });
 
   for (auto op : llvm::reverse(moveOps)) {
     // Gather use-def chain in block.
@@ -322,38 +333,36 @@ static void scheduleGlobalLoadLocalStore(triton::FuncOp funcOp) {
 // are experimenting how to better control instruction scheduling and enable
 // such optimizations.
 //===-------------------------------------------------------------------===//
-static void sinkSecondLoad(triton::FuncOp funcOp) {
-  funcOp.walk([&](scf::ForOp forOp) -> void {
-    SetVector<triton::LoadOp> loadOps;
-    triton::DotOp dotOp;
-    for (Operation &op : forOp) {
-      if (auto loadOp = dyn_cast<triton::LoadOp>(&op))
-        loadOps.insert(loadOp);
-      if (auto curOp = dyn_cast<triton::DotOp>(&op))
-        dotOp = curOp;
-    }
-    // Only apply the optimization when there are 2 load's in the loop
-    if (loadOps.size() != 2)
-      return;
-    // Only apply the optimization when tile size is large enough
-    // 1. nonKDim >= 128
-    // 2. kDim >= 64
-    auto ldAOp = loadOps[0];
-    auto tileAShape = cast<RankedTensorType>(ldAOp.getType()).getShape();
-    auto ldBOp = loadOps[1];
-    auto tileBShape = cast<RankedTensorType>(ldBOp.getType()).getShape();
-    if (!(tileAShape[0] >= 128 && tileAShape[1] >= 64 && tileBShape[1] >= 128))
-      return;
-    // Only apply the optimization when the moving is legal
-    // 1. Make sure the 2nd loadOp is before the dot
-    // 2. Make sure the first user of the 2nd loadOp is after the dot.
-    bool isBeforeDotOp = ldBOp->isBeforeInBlock(dotOp);
-    auto firstUser = *ldBOp.getResult().getUsers().begin();
-    bool firstUserAfterDotOp = dotOp->isBeforeInBlock(firstUser);
-    if (isBeforeDotOp && firstUserAfterDotOp)
-      // move ldBOp right before tt.dot
-      ldBOp->moveBefore(dotOp);
-  });
+static void sinkSecondLoad(scf::ForOp forOp) {
+  SetVector<triton::LoadOp> loadOps;
+  triton::DotOp dotOp;
+  for (Operation &op : forOp) {
+    if (auto loadOp = dyn_cast<triton::LoadOp>(&op))
+      loadOps.insert(loadOp);
+    if (auto curOp = dyn_cast<triton::DotOp>(&op))
+      dotOp = curOp;
+  }
+  // Only apply the optimization when there are 2 load's in the loop
+  if (loadOps.size() != 2)
+    return;
+  // Only apply the optimization when tile size is large enough
+  // 1. nonKDim >= 128
+  // 2. kDim >= 64
+  auto ldAOp = loadOps[0];
+  auto tileAShape = cast<RankedTensorType>(ldAOp.getType()).getShape();
+  auto ldBOp = loadOps[1];
+  auto tileBShape = cast<RankedTensorType>(ldBOp.getType()).getShape();
+  if (!(tileAShape[0] >= 128 && tileAShape[1] >= 64 && tileBShape[1] >= 128))
+    return;
+  // Only apply the optimization when the moving is legal
+  // 1. Make sure the 2nd loadOp is before the dot
+  // 2. Make sure the first user of the 2nd loadOp is after the dot.
+  bool isBeforeDotOp = ldBOp->isBeforeInBlock(dotOp);
+  auto firstUser = *ldBOp.getResult().getUsers().begin();
+  bool firstUserAfterDotOp = dotOp->isBeforeInBlock(firstUser);
+  if (isBeforeDotOp && firstUserAfterDotOp)
+    // move ldBOp right before tt.dot
+    ldBOp->moveBefore(dotOp);
 }
 
 //===----------------------------------------------------------------------===//
@@ -377,10 +386,10 @@ struct TritonAMDGPUReorderInstructionsPass
 
       moveUpTranspose(funcOp);
 
-      if (isPureMatmulProblem(funcOp)) {
-        scheduleGlobalLoadLocalStore(funcOp);
-        sinkSecondLoad(funcOp);
-      }
+      walkPureMatmul(funcOp, [&](scf::ForOp forOp) -> void {
+        scheduleGlobalLoadLocalStore(forOp);
+        sinkSecondLoad(forOp);
+      });
     }
   }
 };

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -227,23 +227,24 @@ static void moveUpTranspose(triton::FuncOp funcOp) {
 // Schedule global load and local store ops for better GEMM performance.
 static void scheduleGlobalLoadLocalStore(scf::ForOp forOp) {
   SmallVector<Operation *> moveOps;
-  // Search through the forOp initArgs to find global loads and local stores for a GEMM
-  // that the pipeliner may have peeled into a loop prologue.
+  // Search through the forOp initArgs to find global loads and local stores for
+  // a GEMM that the pipeliner may have peeled into a loop prologue.
   SmallVector<Value> vals = forOp.getInitArgs();
   while (!vals.empty()) {
     SmallVector<Value> nextVals; // next set of values to search via BFS.
     for (size_t i = 0; i < vals.size(); ++i) {
-      Operation* defOp = vals[i].getDefiningOp();
+      Operation *defOp = vals[i].getDefiningOp();
       if (defOp != nullptr && isa<triton::LoadOp>(defOp)) {
         moveOps.push_back(defOp);
       } else {
-        for (Operation* op : vals[i].getUsers()) {
+        for (Operation *op : vals[i].getUsers()) {
           // find uses of the op that are local_store
           if (isa<ttg::LocalStoreOp>(op)) {
             moveOps.push_back(op);
             // Recurse on operands of the local_store (to find a global load).
             for (Value operand : op->getOperands()) {
-              if (operand == vals[i]) continue;
+              if (operand == vals[i])
+                continue;
               nextVals.push_back(operand);
             }
           }
@@ -252,11 +253,11 @@ static void scheduleGlobalLoadLocalStore(scf::ForOp forOp) {
     }
     vals = std::move(nextVals);
   }
-  // Move global loads inside the loop early to prefetch. This may increase register pressure
-  // but it enables issuing global loads early.
+  // Move global loads inside the loop early to prefetch. This may increase
+  // register pressure but it enables issuing global loads early.
   forOp.walk([&](triton::LoadOp op) { moveOps.push_back(op); });
-  // Move local_stores inside the loop early if dependence distance greater than one iteration.
-  // Best perf on GEMM when these precede global loads.
+  // Move local_stores inside the loop early if dependence distance greater than
+  // one iteration. Best perf on GEMM when these precede global loads.
   forOp.walk([&](ttg::LocalStoreOp op) { moveOps.push_back(op); });
 
   for (auto op : llvm::reverse(moveOps)) {


### PR DESCRIPTION
Previously the pass required a single for loop with a single dot. This doesn't work well for nested loops used for example in persistent matmul kernels.

The pass is updated to search for for-loops without other for-loops contained inside, and that contain a single tl.dot operation. Then, the transformation is applied to matching loops. The scheduleGlobalLoadLocalStore operates on the parent of the for op. This ensures it captures both the loop body and global loads that have been peeled out into a loop prologue by the pipeliner.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
