### PR TITLE
[LAYOUTS] Add ConvertLayoutOp::fold and remove stale heuristic

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -36,6 +36,8 @@ def TTG_ConvertLayoutOp : TTG_Op<"convert_layout",
 
   let results = (outs TT_Tensor:$result);
 
+  let hasFolder = 1;
+
   let hasCanonicalizer = 1;
 
   let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";


### PR DESCRIPTION
After https://github.com/triton-lang/triton/pull/5044 this should not be needed
