### PR TITLE
[Release Only Changes] Remove git commit hash in wheel name

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -695,7 +695,7 @@ def get_git_commit_hash(length=8):
 
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.2.0" + get_git_commit_hash() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.2.0" + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",


### PR DESCRIPTION
For release we are not looking for something like :
``
pytorch_triton-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
``
not:
``
triton-3.2.0+git35c6c7c6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
``