### PR TITLE
[AMD] Fix warp starting order in the block ping-pong #5018

### DIFF
--- a/test/TritonGPU/amd/amd-block-pingpong.mlir
+++ b/test/TritonGPU/amd/amd-block-pingpong.mlir
@@ -79,8 +79,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: gpu.barrier
 // CHECK: %[[IDX:.+]] = rocdl.workitem.id.x
 // CHECK: %[[XDIV:.+]] = arith.divsi %[[IDX]]
-// CHECK: %[[WARPLOW:.+]] = arith.cmpi ne, %[[XDIV]]
-// CHECK: %[[WARPHIGH:.+]] = arith.cmpi eq, %[[XDIV]]
+// CHECK: %[[WARPLOW:.+]] = arith.cmpi eq, %[[XDIV]]
+// CHECK: %[[WARPHIGH:.+]] = arith.cmpi ne, %[[XDIV]]
 // CHECK: amdgpu.cond_barrier %[[WARPHIGH]]
 // CHECK: scf.for
 // CHECK: tt.load

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -301,9 +301,9 @@ void Pingponger::addAsymmetricSyncToLoop(OpBuilder &builder, Location loc) {
   auto constZero = builder.create<arith::ConstantIntOp>(loc, 0, 32);
   auto constWarpSize = builder.create<arith::ConstantIntOp>(loc, 256, 32);
   auto warpIDX = builder.create<arith::DivSIOp>(loc, workIDX, constWarpSize);
-  auto warpLow = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne,
+  auto warpLow = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
                                                warpIDX, constZero);
-  auto warpHigh = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+  auto warpHigh = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne,
                                                 warpIDX, constZero);
   auto condBarrierHigh =
       builder.create<tt::amdgpu::CondBarrierOp>(loc, warpHigh);


### PR DESCRIPTION
Start pingpong from the first warp.
The original PR mistakenly filed with the experiment that second warp enters into the pingpong status first. That doesn't break any functionality but performance is slightly better with starting from the first warp since it's already prioritized by default and likely to be advancing.
