### PR TITLE
[AMD] Handling denorms in lowering math.sqrt and math.sqrt_rn

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -45,6 +45,8 @@ using namespace mlir::triton;
 #define fadd(...) rewriter.create<LLVM::FAddOp>(loc, __VA_ARGS__)
 #define mul(...) rewriter.create<LLVM::MulOp>(loc, __VA_ARGS__)
 #define fmul(...) rewriter.create<LLVM::FMulOp>(loc, __VA_ARGS__)
+#define fma(...) rewriter.create<LLVM::FMAOp>(loc, __VA_ARGS__)
+#define neg(...) rewriter.create<LLVM::FNegOp>(loc, __VA_ARGS__)
 #define smax(...) rewriter.create<LLVM::SMaxOp>(loc, __VA_ARGS__)
 #define umax(...) rewriter.create<LLVM::UMaxOp>(loc, __VA_ARGS__)
 #define fmax(...) rewriter.create<LLVM::MaxNumOp>(loc, __VA_ARGS__)

--- a/test/Conversion/amd/math-denorm-handling.mlir
+++ b/test/Conversion/amd/math-denorm-handling.mlir
@@ -1,5 +1,5 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm="arch=gfx942 ftz=True" | FileCheck %s --check-prefix=LLVM_FTZ
-// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm="arch=gfx942 ftz=False" | FileCheck %s --check-prefix=LLVM_NO_FTZ
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm="arch=gfx942 ftz=True" | FileCheck %s --check-prefixes=COMMON,LLVM_FTZ
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm="arch=gfx942 ftz=False" | FileCheck %s --check-prefixes=COMMON,LLVM_NO_FTZ
 
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
@@ -42,7 +42,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @test_sqrt_f32(%arg0: tensor<64xf32, #blocked>) attributes {noinline = false} {
     // LLVM_FTZ-LABEL: test_sqrt_f32
+    // LLVM_FTZ-NOT: llvm.fcmp "ogt"
     // LLVM_FTZ: llvm.amdgcn.sqrt.f32
+    // LLVM_FTZ-NOT: llvm.fmul
+    // LLVM_FTZ-NOT: llvm.select
     //
     // LLVM_NO_FTZ-LABEL: test_sqrt_f32
     // LLVM_NO_FTZ: llvm.fcmp "ogt"
@@ -87,11 +90,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @test_sqrt_rn_f64(%arg0: tensor<64xf64, #blocked>) attributes {noinline = false} {
-    // LLVM_FTZ-LABEL: test_sqrt_rn_f64
-    // LLVM_FTZ: llvm.intr.sqrt
-    //
-    // LLVM_NO_FTZ-LABEL: test_sqrt_rn_f64
-    // LLVM_NO_FTZ: llvm.intr.sqrt
+    // COMMON-LABEL: test_sqrt_rn_f64
+    // COMMON: llvm.intr.sqrt
     %0 = tt.precise_sqrt %arg0 : tensor<64xf64, #blocked>
     tt.return
   }

--- a/test/Conversion/amd/math-denorm-handling.mlir
+++ b/test/Conversion/amd/math-denorm-handling.mlir
@@ -1,5 +1,5 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm="arch=gfx942 ftz=True" --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=LLVM_FTZ
-// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm="arch=gfx942 ftz=False" --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=LLVM_NO_FTZ
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm="arch=gfx942 ftz=True" | FileCheck %s --check-prefix=LLVM_FTZ
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm="arch=gfx942 ftz=False" | FileCheck %s --check-prefix=LLVM_NO_FTZ
 
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
@@ -16,7 +16,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @test_exp2(%arg0: tensor<64xf32, #blocked>) attributes {noinline = false} {
+  tt.func public @test_exp(%arg0: tensor<64xf32, #blocked>) attributes {noinline = false} {
     // LLVM_FTZ: llvm.exp2.f32
     // LLVM_NO_FTZ: llvm.exp2.f32
     %0 = math.exp %arg0 : tensor<64xf32, #blocked>
@@ -32,6 +32,67 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // LLVM_FTZ: llvm.amdgcn.rsq.f32
     // LLVM_NO_FTZ: _ocml_rsqrt_f32
     %0 = math.rsqrt %arg0 : tensor<64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_sqrt_f32(%arg0: tensor<64xf32, #blocked>) attributes {noinline = false} {
+    // LLVM_FTZ-LABEL: test_sqrt_f32
+    // LLVM_FTZ: llvm.amdgcn.sqrt.f32
+    //
+    // LLVM_NO_FTZ-LABEL: test_sqrt_f32
+    // LLVM_NO_FTZ: llvm.fcmp "ogt"
+    // LLVM_NO_FTZ: llvm.fmul
+    // LLVM_NO_FTZ-NEXT: llvm.select
+    // LLVM_NO_FTZ-NEXT: llvm.amdgcn.sqrt.f32
+    // LLVM_NO_FTZ: llvm.fmul
+    // LLVM_NO_FTZ-NEXT: llvm.select
+    %0 = math.sqrt %arg0 : tensor<64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_sqrt_rn_f32(%arg0: tensor<64xf32, #blocked>) attributes {noinline = false} {
+    // LLVM_FTZ-LABEL: test_sqrt_rn_f32
+    // LLVM_FTZ: llvm.amdgcn.rsq.f32
+    // LLVM_FTZ: llvm.fmul
+    // LLVM_FTZ: llvm.fmul
+    // LLVM_FTZ: llvm.fneg
+    // LLVM_FTZ: llvm.intr.fma
+    // LLVM_FTZ-NEXT: llvm.intr.fma
+    // LLVM_FTZ-NEXT: llvm.intr.fma
+    // LLVM_FTZ-NEXT: llvm.fneg
+    // LLVM_FTZ-NEXT: llvm.intr.fma
+    // LLVM_FTZ-NEXT: llvm.intr.fma
+    // LLVM_FTZ-NEXT: llvm.intr.is.fpclass
+    // LLVM_FTZ-NEXT: llvm.select
+    //
+    // LLVM_NO_FTZ-LABEL: test_sqrt_rn_f32
+    // LLVM_NO_FTZ: llvm.intr.sqrt
+    %0 = tt.precise_sqrt %arg0 : tensor<64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @test_sqrt_rn_f64(%arg0: tensor<64xf64, #blocked>) attributes {noinline = false} {
+    // LLVM_FTZ-LABEL: test_sqrt_rn_f64
+    // LLVM_FTZ: llvm.intr.sqrt
+    //
+    // LLVM_NO_FTZ-LABEL: test_sqrt_rn_f64
+    // LLVM_NO_FTZ: llvm.intr.sqrt
+    %0 = tt.precise_sqrt %arg0 : tensor<64xf64, #blocked>
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1413,8 +1413,8 @@ struct SqrtOpConversion
     // Differences in this approach are
     // 1. Refinement iterations following llvm.amdgcn.sqrt.f32 are removed to
     // improve performance.
-    // 2. With ftz disabled, the scaling-up-and-down process is bypassed to
-    // ensure denorms are flushed to zero. flush the denorms to zero.
+    // 2. With ftz enabled, the scaling-up-and-down process is bypassed to
+    // ensure denorms are flushed to zero.
     if (elemTy.getIntOrFloatBitWidth() != 32)
       return {};
 
@@ -1444,8 +1444,8 @@ struct SqrtOpConversion
         LLVM::createLLVMCallOp(rewriter, loc, funcOp, operands[0]).getResult();
 
     if (!ftz) {
-      // In case of non-ftz, we need to calibrate the result by scaling down by
-      // a factor 2^{-16}.
+      // In case of non-ftz, we need to calibrate the results by scaling down by
+      // a factor of 2^{-16}.
       return {scaleDownIfDenorm(rewriter, loc, intrinsicsOutput, needScale,
                                 0x1.0p-16f)};
     } else {


### PR DESCRIPTION
In this commit, we handled the denorm flushing behaviors of math.sqrt and math.sqrt_rn. They read HIP_FTZ to determine whether denorms should be preserved or flushed to zero.

| Backend | sqrt non-ftz                   | sqrt ftz             | sqrt_rn non-ftz | sqrt_rn ftz                            |
| ------- | ------------------------------ | -------------------- | --------------- | -------------------------------------- |
| CUDA    | sqrt.approx.f32                | sqrt.approx.ftz.f32  | sqrt.rn.f32     | sqrt.rn.ftz.f32                        |
| AMD     | scaling + llvm.amdgcn.sqrt.f32 | llvm.amdgcn.sqrt.f32 | llvm.sqrt.f32   | llvm.amdgcn.rsq.f32 + mul + refinement |

`math.sqrt` provides approximation of SQRT. In AMD backend, we use `llvm.amdgcn.sqrt.f32`, which provides direct access to `v_sqrt_f32` and has 1ULP accuracy.

`math.sqrt_rn` provides IEEE-compliant result(round-to-nearest-or-even) of SQRT. Following [the implementation in LLVM](https://github.com/llvm/llvm-project/blob/8820de68ddf02fe3c73def49ec32bbeca54c2754/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp#L5235-L5314), we use extra refinement to get correctly rounded result.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - ✅ `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
