### PR TITLE
[WIP] Optimize Autotuner with Parallel Compilation

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -8,7 +8,7 @@ from typing import Dict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .jit import KernelInterface
-from .errors import OutOfResources
+from .errors import OutOfResources, PTXASError
 from .driver import driver
 
 
@@ -45,36 +45,40 @@ class Autotuner(KernelInterface):
         self.arg_names = arg_names
 
         # Reset to zero or restore values
-        self.reset_idx = []
+        self.reset_to_zero = []
         if reset_to_zero is not None:
-            self.reset_idx = [arg_names.index(k) for k in reset_to_zero]
-        self.restore_idx = []
+            self.reset_to_zero = list(reset_to_zero)
+        self.restore_value = []
         if restore_value is not None:
-            self.restore_idx = [arg_names.index(k) for k in restore_value]
+            self.restore_value = list(restore_value)
 
         # Hook to reset or restore for required tensors
-        self.pre_hook = lambda args, reset_only=False: 0
-        self.post_hook = lambda args, exception: 0
+        self.pre_hook = lambda kwargs, reset_only=False: 0
+        self.post_hook = lambda kwargs, exception: 0
+        self.user_defined_pre_hook = False
+        self.user_defined_post_hook = False
         if pre_hook:
             self.pre_hook = pre_hook
-        elif (len(self.reset_idx) > 0 or len(self.restore_idx) > 0):
+            self.user_defined_pre_hook = True
+        elif (len(self.reset_to_zero) > 0 or len(self.restore_value) > 0):
 
-            def _pre_hook(args, reset_only=False):
-                for i in self.reset_idx:
-                    args[i].zero_()
+            def _pre_hook(kwargs, reset_only=False):
+                for name in self.reset_to_zero:
+                    kwargs[name].zero_()
                 if not reset_only:
-                    self.restore_copies = [args[i].clone() for i in self.restore_idx]
+                    self.restore_copies = {name: kwargs[name].clone() for name in self.restore_value}
 
             self.pre_hook = _pre_hook
 
         if post_hook:
             self.post_hook = post_hook
-        elif len(self.restore_idx) > 0:
+            self.user_defined_post_hook = True
+        elif len(self.restore_value) > 0:
 
-            def _post_hook(args, exception):
-                for i, j in enumerate(self.restore_idx):
-                    args[j].copy_(self.restore_copies[i])
-                self.restore_copies = []
+            def _post_hook(kwargs, exception):
+                for name in self.restore_value:
+                    kwargs[name].copy_(self.restore_copies[name])
+                self.restore_copies = {}
 
             self.post_hook = _post_hook
 
@@ -90,6 +94,10 @@ class Autotuner(KernelInterface):
         self.base_fn = fn
         while not inspect.isfunction(self.base_fn):
             self.base_fn = self.base_fn.fn
+
+        self.num_warmups = warmup
+        self.num_reps = rep
+        self.use_cuda_graph = use_cuda_graph
 
         # If we got explicitly called via the old interface, raise a warning
         # and proceed with the old behavior.
@@ -146,6 +154,10 @@ class Autotuner(KernelInterface):
     def _bench(self, *args, config, **meta):
         from ..compiler.errors import CompileTimeAssertionFailure
 
+        verbose = os.environ.get("TRITON_PRINT_AUTOTUNING", None) == "1"
+        if verbose:
+            print(f"Autotuning kernel {self.base_fn.__name__} with config {config}")
+
         # check for conflicts, i.e. meta-parameters both provided
         # as kwargs and by the autotuner
         conflicts = meta.keys() & config.kwargs.keys()
@@ -159,21 +171,26 @@ class Autotuner(KernelInterface):
         def kernel_call():
             if config.pre_hook:
                 config.pre_hook(full_nargs)
-            self.pre_hook(args)
+            self.pre_hook(full_nargs)
             try:
-                self.fn.run(*args, **current)
+                self.fn.run(
+                    *args,
+                    **current,
+                )
             except Exception as e:
                 try:
-                    self.post_hook(args, exception=e)
+                    self.post_hook(full_nargs, exception=e)
                 finally:
-                    # Throw exception raised by self.fn.run
+                    # Throw exception raised by `self.fn.run`
                     raise
 
-            self.post_hook(args, exception=None)
+            self.post_hook(full_nargs, exception=None)
 
         try:
             return self.do_bench(kernel_call, quantiles=(0.5, 0.2, 0.8))
-        except (OutOfResources, CompileTimeAssertionFailure):
+        except (OutOfResources, CompileTimeAssertionFailure, PTXASError) as e:
+            if verbose:
+                print(f"Autotuning failed with {e}")
             return [float("inf"), float("inf"), float("inf")]
 
     def run(self, *args, **kwargs):
@@ -188,8 +205,8 @@ class Autotuner(KernelInterface):
                     key.append(str(arg.dtype))
             key = tuple(key)
             if key not in self.cache:
+                # prune configs
                 used_cached_result = False
-
                 # Step 1: Parallel compilation
                 pruned_configs = self.prune_configs(kwargs)
                 compile_start = time.time()
@@ -217,19 +234,21 @@ class Autotuner(KernelInterface):
 
                 # Cache the best configuration
                 self.cache[key] = builtins.min(timings, key=timings.get)
-                self.pre_hook(args, reset_only=True)
+
+                full_nargs = {**self.nargs, **kwargs, **self.cache[key].all_kwargs()}
+                self.pre_hook(full_nargs, reset_only=True)
                 self.configs_timings = timings
             config = self.cache[key]
         else:
             config = self.configs[0]
-
         self.best_config = config
         if os.getenv("TRITON_PRINT_AUTOTUNING", None) == "1" and not used_cached_result:
             print(f"Triton autotuning for function {self.base_fn.__name__} finished after "
                   f"{self.compile_time:.2f}s (compilation) + {self.bench_time:.2f}s (benchmarking); "
                   f"best config selected: {self.best_config};")
         if config.pre_hook is not None:
-            config.pre_hook({**self.nargs, **kwargs, **config.all_kwargs()})
+            full_nargs = {**self.nargs, **kwargs, **config.all_kwargs()}
+            config.pre_hook(full_nargs)
         ret = self.fn.run(
             *args,
             **kwargs,
@@ -365,12 +384,12 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_va
     :type restore_value: list[str]
     :param pre_hook: a function that will be called before the kernel is called.
         This overrides the default pre_hook used for 'reset_to_zero' and 'restore_value'.
-        'args': a list of arguments passed to the kernel.
+        'kwargs': a dict of all arguments passed to the kernel.
         'reset_only': a boolean indicating whether the pre_hook is called to reset the values only, without a corresponding post_hook.
     :type pre_hook: lambda args, reset_only
     :param post_hook: a function that will be called after the kernel is called.
         This overrides the default post_hook used for 'restore_value'.
-        'args': a list of arguments passed to the kernel.
+        'kwargs': a dict of all arguments passed to the kernel.
         'exception': the exception raised by the kernel in case of a compilation or runtime error.
     :type post_hook: lambda args, exception
     :param warmup: warmup time (in ms) to pass to benchmarking (deprecated).

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -137,7 +137,6 @@ class Autotuner(KernelInterface):
             raise ValueError(f"Conflicting meta-parameters: {', '.join(conflicts)}."
                              " Make sure that you don't re-define auto-tuned symbols.")
         current = dict(meta, **config.all_kwargs())
-        full_nargs = {**self.nargs, **current}
 
         try:
             # Attempt to execute the kernel with all arguments

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -210,7 +210,7 @@ class Autotuner(KernelInterface):
                 pruned_configs = self.prune_configs(kwargs)
                 compile_start = time.time()
                 compiled_configs = []
-                with ThreadPoolExecutor() as executor:
+                with ThreadPoolExecutor(max_workers=max_workers) as executor:
                     futures = {
                         executor.submit(self._compile, *args, config=config, **kwargs): config
                         for config in pruned_configs

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -8,7 +8,6 @@ import inspect
 from typing import Dict, Tuple, List, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-
 from .jit import KernelInterface
 from .errors import OutOfResources, PTXASError
 from .driver import driver
@@ -45,7 +44,7 @@ class Autotuner(KernelInterface):
         else:
             self.configs = configs
         self.keys = key
-        self.cache: Dict[Tuple, Config] = {} = {
+        self.cache: Dict[Tuple, Config] = {}
         self.arg_names = arg_names
         self.max_workers = max_workers
 

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -223,9 +223,7 @@ class Autotuner(KernelInterface):
 
                 # Step 2: Linear benchmarking
                 bench_start = time.time()
-                timings = {}
-                for config in compiled_configs:
-                    timings[config] = self._bench(*args, config=config, **kwargs)
+                timings = {config: self._bench(*args, config=config, **kwargs) for config in compiled_configs}
                 bench_end = time.time()
 
                 self.compile_time = compile_end - compile_start


### PR DESCRIPTION
Autotuning takes a while and for us most of that time is actually spent compiling the JIT kernel for each configuration rather than running the code. Since this process happens on the host CPU and should not affect timings it would be nice if it could be run in parallel and then once that is done all the configurations could be tested on the GPU linearly. ([Issue#4806](https://github.com/triton-lang/triton/issues/4806))

# Changes Made
1. Added _compile Method for Standalone Kernel Compilation: Introduced a _compile method in autotuner.py that allows kernels to be compiled independently of execution by leveraging the warmup argument.
Note: The warmup argument is currently marked as deprecated, and guidance on how to proceed without relying on this argument would be highly appreciated.
2. Implemented Parallel Kernel Compilation: Leveraged ThreadPoolExecutor to enable parallel compilation of configurations during the autotuning process. Compilation results are collected asynchronously, and only successful configurations are retained for subsequent benchmarking.
3. Separated Timing for Compilation and Benchmarking: Introduced separate timers for the compilation and benchmarking phases to provide more granular insights into the autotuning process. Compilation and benchmarking times are printed when the TRITON_PRINT_AUTOTUNING environment variable is set.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because:The separation of compilation and execution does not alter the behavior of existing functionality. All current test cases for kernel execution remain valid and ensure correctness.
This change focuses on improving internal performance and does not introduce new user-facing APIs or features that require additional testing.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

# Future work
- Replace the deprecated warmup argument if a recommended alternative becomes available.
- Add benchmarking data to this PR to demonstrate performance improvements with parallel compilation.
