### PR TITLE
[STANDARD] Fix inf handling in tl.flip

### DIFF
--- a/python/test/unit/language/test_standard.py
+++ b/python/test/unit/language/test_standard.py
@@ -75,7 +75,7 @@ def test_flip(M, N, dtype_str, device):
     assert (y == z).all(), (y, z)
 
 
-# @pytest.mark.interpreter
+@pytest.mark.interpreter
 def test_flip_inf(device):
     # Reproducer for https://github.com/triton-lang/triton/issues/5439
 

--- a/python/test/unit/language/test_standard.py
+++ b/python/test/unit/language/test_standard.py
@@ -75,7 +75,7 @@ def test_flip(M, N, dtype_str, device):
     assert (y == z).all(), (y, z)
 
 
-@pytest.mark.interpreter
+# @pytest.mark.interpreter
 def test_flip_inf(device):
     # Reproducer for https://github.com/triton-lang/triton/issues/5439
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -726,10 +726,12 @@ class ReduceScanOpIneterface:
             self.check_axis(arg.shape, self.axis)
 
     def to_tensor(self, ret, dtype):
+        np_dtype = _get_np_dtype(dtype)
         if hasattr(ret, "shape") and ret.shape:
+            ret = ret.astype(np_dtype)
             ret_type = tl.block_type(dtype, list(ret.shape))
         else:
-            ret = np.array([ret]).astype(_get_np_dtype(dtype))
+            ret = np.array([ret], dtype=np_dtype)
             ret_type = dtype
         return tl.core.tensor(TensorHandle(ret, dtype.scalar), ret_type)
 


### PR DESCRIPTION
Fixes #5439

Currently we end up doing `0 * inf = nan`, the fix is to bitcast to int first where `x * 0 == 0` holds.
