### PR TITLE
[BACKEND] Emit a better error when predicateOp fails

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -103,7 +103,8 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
     return op;
   }
 
-  assert("don't know how to predicate this op" && false);
+  op->emitError("pipeliner doesn't know how to predicate this op.");
+  llvm::report_fatal_error("Fatal pipeliner error");
   return op;
 }
 


### PR DESCRIPTION
A failure now looks like:
```
/home/peterbell10/test.py:157:8: error: pipeliner doesn't know how to predicate this op.
        tl.debug_barrier()
       ^
/home/peterbell10/test.py:157:8: note: see current operation: "gpu.barrier"() : () -> ()
LLVM ERROR: Fatal pipeliner error
<stack trace>
```

