### PR TITLE
Skip pipelining loops with gpu.barrier

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
@@ -23,6 +23,29 @@ namespace gpu {
 
 namespace {
 
+bool hasGpuBarriers(scf::ForOp forOp) {
+  for (auto &op : forOp.getBody()->without_terminator()) {
+    if (isa<mlir::gpu::BarrierOp>(op))
+      return true;
+  }
+  return false;
+}
+
+// Return true if the preconditions for pipelining the loop are met.
+bool preCondition(scf::ForOp forOp) {
+  // Skip loop with distance > 1 for now.
+  // TODO: relax the constraint in the expander.
+  if (loopHasDistGreaterThanOne(forOp))
+    return false;
+  // Don't pipeline outer loops.
+  if (isOuterLoop(forOp))
+    return false;
+  // Skip loops with barriers.
+  if (hasGpuBarriers(forOp))
+    return false;
+  return true;
+}
+
 bool hasLatenciesAssigned(scf::ForOp forOp,
                           const DenseMap<Operation *, int> &opLatency) {
   for (auto &op : forOp.getBody()->without_terminator()) {
@@ -261,7 +284,7 @@ void scheduleRemainingToLastStage(scf::ForOp forOp, CoarseSchedule &schedule,
 
 void scheduleLoop(scf::ForOp forOp,
                   const DenseMap<Operation *, int> &opLatency) {
-  if (!hasLatenciesAssigned(forOp, opLatency))
+  if (!hasLatenciesAssigned(forOp, opLatency) || !preCondition(forOp))
     return;
   // Based on the latencies, schedule the key ops to the stages.
   CoarseSchedule schedule = scheduleKeyOps(forOp, opLatency);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -33,18 +33,6 @@ namespace gpu {
 #define GEN_PASS_DEF_TRITONGPUPIPELINE
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
 
-// Return true if the preconditions for pipelining the loop are met.
-static bool preCondition(scf::ForOp forOp) {
-  // Skip loop with distance > 1 for now.
-  // TODO: relax the constraint in the expander.
-  if (loopHasDistGreaterThanOne(forOp))
-    return false;
-  // Don't pipeline outer loops.
-  if (isOuterLoop(forOp))
-    return false;
-  return true;
-}
-
 static void tryAndPipelineOuterLoop(scf::ForOp forOp) {
   mlir::triton::PipeliningOption options;
   bool foundSchedule = false;
@@ -60,8 +48,6 @@ static void tryAndPipelineOuterLoop(scf::ForOp forOp) {
 
 static bool pipelineLoop(scf::ForOp forOp, int numStages) {
   mlir::triton::PipeliningOption options;
-  if (!preCondition(forOp))
-    return false;
 
   bool foundSchedule = false;
   foundSchedule = preProcessLoopAndGetSchedule(forOp, numStages, options);


### PR DESCRIPTION
Pipelining loops containing `gpu.barrier` may not always be possible because pipeliner reorders the operations in the loop. It is would be possible to analyze if schedule allows for pipelining that would preserve the order between ops issued before the barrier and ones issued after the barrier, however for now we will simply skip such cases.