### PR TITLE
Enable python 3.13 wheels, remove python 3.8

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -63,8 +63,10 @@ jobs:
           # many_linux_2_28 image comes with GCC 12.2.1, but not clang.
           # With this install, it gets clang 16.0.6.
           export CIBW_BEFORE_ALL="dnf install clang lld -y";
-          export CIBW_SKIP="cp{35,36,37}-*"
-          export CIBW_BUILD="cp3*-manylinux_x86_64"
+          export CIBW_SKIP="cp{35,36,37,38}-*"
+          export CIBW_BUILD="cp3{9,10,11,12,13,13t}-manylinux_x86_64"
+          export CIBW_FREE_THREADED_SUPPORT=1
+
           python3 -m cibuildwheel python --output-dir wheelhouse
 
       - name: Install Azure CLI

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -50,6 +50,8 @@ jobs:
       - name: Build wheels
         if: ${{ steps.check-version.outputs.new_commit == 'true' }}
         run: |
+          # Make sure cibuildwheel is updated to latest, this will enable latest python builds
+          python3 -m pip install cibuildwheel --upgrade --user
           export LATEST_DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
           # Pass MAX_JOBS=4 because, at time of writing, the VM "only" has 32GB
           # of RAM and OOMs while building if we give it the default number of

--- a/python/setup.py
+++ b/python/setup.py
@@ -735,11 +735,11 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     test_suite="tests",
     extras_require={


### PR DESCRIPTION
This should enable python 3.13 and 3.13t wheels and disable building python 3.8 wheels.

Related to: https://github.com/pytorch/pytorch/issues/143654

cc @ptillet @Jokeren @albanD @malfet 