### PR TITLE
[BACKEND] Remove mma->dot decomposition from NVIDIA backend

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Patterns.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Patterns.h
@@ -13,13 +13,6 @@ namespace triton::gpu {
 /// |module| op because the codegen doesn't handle `blocked -> dot_op` directly.
 void decomposeBlockedToDotLayoutConversion(ModuleOp module);
 
-/// Replaces `mma/mfma -> dot_op` with `mma/mfma -> blocked -> dot_op` in the
-/// given |module| op, but bypass the decomposition if |shortcutFn| returns
-/// true.
-using ShortcutFn = std::function<bool(RankedTensorType, RankedTensorType)>;
-void decomposeTensorCoreToDotLayoutConversion(ModuleOp module,
-                                              ShortcutFn shortcutFn);
-
 } // namespace triton::gpu
 
 } // namespace mlir

--- a/include/triton/Conversion/TritonGPUToLLVM/Patterns.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Patterns.h
@@ -13,6 +13,13 @@ namespace triton::gpu {
 /// |module| op because the codegen doesn't handle `blocked -> dot_op` directly.
 void decomposeBlockedToDotLayoutConversion(ModuleOp module);
 
+/// Replaces `mfma -> dot_op` with `mfma -> blocked -> dot_op` in the
+/// given |module| op, but bypass the decomposition if |shortcutFn| returns
+/// true.
+using ShortcutFn = std::function<bool(RankedTensorType, RankedTensorType)>;
+void decomposeTensorCoreToDotLayoutConversion(ModuleOp module,
+                                              ShortcutFn shortcutFn);
+
 } // namespace triton::gpu
 
 } // namespace mlir

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -789,6 +789,11 @@ def MmaEncodingTrait : AttrInterface<"MmaEncodingTrait"> {
                     (ins "int":$opIdx,
                          "int":$kWidth)>,
 
+    InterfaceMethod<"Return the number of threads per warp for dot operands.",
+                    "SmallVector<unsigned>",
+                    "getThreadsPerWarpForOperand",
+                    (ins "int":$opIdx)>,
+
     InterfaceMethod<"Get the order of reps (tiles of this layout that tile the whole tensor). The fastest-changing axis first",
                     "SmallVector<unsigned>",
                     "getRepOrderForOperand",
@@ -915,6 +920,7 @@ V [ 0,4,8...60   1,5...61     2,6...62     3,7...63    ]   [ 128,132...188  129,
     SmallVector<int64_t> getInstrShapeForOperand(int kWidth, int opIdx) const;
     SmallVector<int64_t> getRepForOperand(ArrayRef<int64_t> operandShape, int kWidth, int opIdx) const;
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
+    SmallVector<unsigned> getThreadsPerWarpForOperand(int opIdx) const;
 
     SmallVector<unsigned> getContigPerThread() {
       auto rank = getWarpsPerCTA().size();
@@ -1023,6 +1029,7 @@ Row |       warp 0                warp 2
     SmallVector<int64_t> getRepForOperand(ArrayRef<int64_t> operandShape,
                                           Type elemType, int kWidth, int opIdx) const;
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
+    SmallVector<unsigned> getThreadsPerWarpForOperand(int opIdx) const;
     static SmallVector<unsigned> getMNKDimPerInstr();
 
     SmallVector<unsigned> getContigPerThread() {
@@ -1141,6 +1148,7 @@ For example, the matrix L corresponding to blockTileSize=[32,16] is:
                                           int bitwidth, int kWidth,
                                           int opIdx) const;
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
+    SmallVector<unsigned> getThreadsPerWarpForOperand(int opIdx) const;
 
     bool supportReduction() const {
       if (isAmpere() || isHopper()) {

--- a/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -18,6 +18,37 @@ static void addAttrs(Operation *op, ArrayRef<mlir::NamedAttribute> attrs) {
 
 namespace mlir::triton::gpu {
 
+void decomposeTensorCoreToDotLayoutConversion(ModuleOp module,
+                                              ShortcutFn shortcutFn) {
+  int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(module);
+  int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(module);
+  int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(module);
+
+  module.walk([&](triton::gpu::ConvertLayoutOp cvtOp) -> void {
+    OpBuilder builder(cvtOp);
+    auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
+    auto dstType = cast<RankedTensorType>(cvtOp.getType());
+    auto srcMma = dyn_cast<MmaEncodingTrait>(srcType.getEncoding());
+    auto dstDotOp =
+        dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
+    if (srcMma && dstDotOp && !shortcutFn(srcType, dstType)) {
+      auto tmpType = RankedTensorType::get(
+          dstType.getShape(), dstType.getElementType(),
+          triton::gpu::BlockedEncodingAttr::get(
+              module.getContext(), srcType.getShape(), getSizePerThread(srcMma),
+              getOrder(srcMma), numWarps, threadsPerWarp, numCTAs));
+      auto tmp = builder.create<triton::gpu::ConvertLayoutOp>(
+          cvtOp.getLoc(), tmpType, cvtOp.getSrc());
+      addAttrs(tmp, cvtOp->getAttrs());
+      auto newConvert = builder.create<triton::gpu::ConvertLayoutOp>(
+          cvtOp.getLoc(), dstType, tmp);
+      addAttrs(newConvert, cvtOp->getAttrs());
+      cvtOp.replaceAllUsesWith(newConvert.getResult());
+      cvtOp.erase();
+    }
+  });
+}
+
 void decomposeBlockedToDotLayoutConversion(ModuleOp module) {
   int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(module);
   int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(module);

--- a/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -18,37 +18,6 @@ static void addAttrs(Operation *op, ArrayRef<mlir::NamedAttribute> attrs) {
 
 namespace mlir::triton::gpu {
 
-void decomposeTensorCoreToDotLayoutConversion(ModuleOp module,
-                                              ShortcutFn shortcutFn) {
-  int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(module);
-  int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(module);
-  int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(module);
-
-  module.walk([&](triton::gpu::ConvertLayoutOp cvtOp) -> void {
-    OpBuilder builder(cvtOp);
-    auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
-    auto dstType = cast<RankedTensorType>(cvtOp.getType());
-    auto srcMma = dyn_cast<MmaEncodingTrait>(srcType.getEncoding());
-    auto dstDotOp =
-        dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
-    if (srcMma && dstDotOp && !shortcutFn(srcType, dstType)) {
-      auto tmpType = RankedTensorType::get(
-          dstType.getShape(), dstType.getElementType(),
-          triton::gpu::BlockedEncodingAttr::get(
-              module.getContext(), srcType.getShape(), getSizePerThread(srcMma),
-              getOrder(srcMma), numWarps, threadsPerWarp, numCTAs));
-      auto tmp = builder.create<triton::gpu::ConvertLayoutOp>(
-          cvtOp.getLoc(), tmpType, cvtOp.getSrc());
-      addAttrs(tmp, cvtOp->getAttrs());
-      auto newConvert = builder.create<triton::gpu::ConvertLayoutOp>(
-          cvtOp.getLoc(), dstType, tmp);
-      addAttrs(newConvert, cvtOp->getAttrs());
-      cvtOp.replaceAllUsesWith(newConvert.getResult());
-      cvtOp.erase();
-    }
-  });
-}
-
 void decomposeBlockedToDotLayoutConversion(ModuleOp module) {
   int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(module);
   int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(module);

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2085,7 +2085,8 @@ AMDMfmaEncodingAttr::getRepOrderForOperand(int opIdx) const {
 
 SmallVector<unsigned>
 AMDMfmaEncodingAttr::getThreadsPerWarpForOperand(int opIdx) const {
-  llvm::report_fatal_error("Not implemented");
+  llvm::report_fatal_error(
+      "getThreadsPerWarpForOperand not implemented for AMDMfmaEncodingAttr");
   return {};
 }
 
@@ -2152,7 +2153,8 @@ AMDWmmaEncodingAttr::getRepOrderForOperand(int opIdx) const {
 
 SmallVector<unsigned>
 AMDWmmaEncodingAttr::getThreadsPerWarpForOperand(int opIdx) const {
-  llvm::report_fatal_error("Not implemented");
+  llvm::report_fatal_error("getThreadsPerWarpForOperand not implemented for "
+                           "AMDWmmaEncodingAttr");
   return {};
 }
 
@@ -2414,7 +2416,7 @@ SmallVector<unsigned> DotOperandEncodingAttr::getThreadsPerWarp() const {
     return mma.getThreadsPerWarpForOperand(getOpIdx());
   }
   llvm::report_fatal_error(
-      "getRepOrder not implemented for DotOperandEncodingAttr");
+      "getThreadsPerWarp not implemented for DotOperandEncodingAttr");
   return {};
 }
 SmallVector<unsigned> DotOperandEncodingAttr::getSizePerThread() const {

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2083,6 +2083,12 @@ AMDMfmaEncodingAttr::getRepOrderForOperand(int opIdx) const {
   return getOrderForDotOperand(opIdx, rank, /*kMajor*/ true);
 }
 
+SmallVector<unsigned>
+AMDMfmaEncodingAttr::getThreadsPerWarpForOperand(int opIdx) const {
+  llvm::report_fatal_error("Not implemented");
+  return {};
+}
+
 SmallVector<int64_t>
 AMDMfmaEncodingAttr::getRepForOperand(ArrayRef<int64_t> operandShape,
                                       int kWidth, int opIdx) const {
@@ -2142,6 +2148,12 @@ SmallVector<unsigned>
 AMDWmmaEncodingAttr::getRepOrderForOperand(int opIdx) const {
   auto rank = getWarpsPerCTA().size();
   return getOrderForDotOperand(opIdx, rank, /*kMajor*/ true);
+}
+
+SmallVector<unsigned>
+AMDWmmaEncodingAttr::getThreadsPerWarpForOperand(int opIdx) const {
+  llvm::report_fatal_error("Not implemented");
+  return {};
 }
 
 SmallVector<unsigned> AMDWmmaEncodingAttr::getCTAsPerCGA() const {
@@ -2321,6 +2333,15 @@ NvidiaMmaEncodingAttr::getRepOrderForOperand(int opIdx) const {
   return getOrderForDotOperand(opIdx, rank, /*kMajor*/ true);
 }
 
+SmallVector<unsigned>
+NvidiaMmaEncodingAttr::getThreadsPerWarpForOperand(int opIdx) const {
+  auto threadsPerWarp = getThreadsPerWarp();
+  auto rank = threadsPerWarp.size();
+  if (opIdx == 1)
+    std::swap(threadsPerWarp[rank - 2], threadsPerWarp[rank - 1]);
+  return threadsPerWarp;
+}
+
 SmallVector<int64_t>
 NvidiaMmaEncodingAttr::getRepForOperand(ArrayRef<int64_t> shape, int bitwidth,
                                         int kWidth, int opIdx) const {
@@ -2389,16 +2410,12 @@ SmallVector<unsigned> DotOperandEncodingAttr::getRepOrder() const {
 }
 
 SmallVector<unsigned> DotOperandEncodingAttr::getThreadsPerWarp() const {
-  auto parent = getParent();
-  if (auto mma = mlir::dyn_cast<NvidiaMmaEncodingAttr>(parent)) {
-    auto threadsPerWarp = mma.getThreadsPerWarp();
-    auto rank = threadsPerWarp.size();
-    if (getOpIdx() == 1)
-      std::swap(threadsPerWarp[rank - 2], threadsPerWarp[rank - 1]);
-    return threadsPerWarp;
+  if (auto mma = mlir::dyn_cast<MmaEncodingTrait>(getParent())) {
+    return mma.getThreadsPerWarpForOperand(getOpIdx());
   }
   llvm::report_fatal_error(
-      "getThreadsPerWarp not implemented for DotOperandEncodingAttr");
+      "getRepOrder not implemented for DotOperandEncodingAttr");
+  return {};
 }
 SmallVector<unsigned> DotOperandEncodingAttr::getSizePerThread() const {
   auto parentLayout = getParent();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -34,34 +34,6 @@ struct DecomposeUnsupportedAMDConversions
     int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(mod);
     int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
 
-    auto isShortcut =
-        mlir::triton::gpu::ShortcutFn(std::not_fn(cvtNeedsSharedMemory));
-
-    triton::gpu::decomposeTensorCoreToDotLayoutConversion(mod, isShortcut);
-
-    // Replace `wmma -> dot_op` with `wmma -> blocked -> dot_op`
-    mod.walk([&](triton::gpu::ConvertLayoutOp cvtOp) -> void {
-      OpBuilder builder(cvtOp);
-      auto srcType = cvtOp.getSrc().getType();
-      auto dstType = cvtOp.getType();
-      auto srcWmma =
-          dyn_cast<triton::gpu::AMDWmmaEncodingAttr>(srcType.getEncoding());
-      auto dstDotOp =
-          dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
-      if (srcWmma && dstDotOp) {
-        auto tmpType = RankedTensorType::get(
-            dstType.getShape(), dstType.getElementType(),
-            triton::gpu::BlockedEncodingAttr::get(
-                mod.getContext(), srcType.getShape(), getSizePerThread(srcWmma),
-                getOrder(srcWmma), numWarps, threadsPerWarp, numCTAs));
-        auto tmp = builder.create<triton::gpu::ConvertLayoutOp>(
-            cvtOp.getLoc(), tmpType, cvtOp.getOperand());
-        auto newConvert = builder.create<triton::gpu::ConvertLayoutOp>(
-            cvtOp.getLoc(), dstType, tmp);
-        cvtOp.replaceAllUsesWith(newConvert.getResult());
-        cvtOp.erase();
-      }
-    });
     // Try to reduce LDS usage of cvt(mfma->blocked) op by changing the shape of
     // WarpsPerCta attribute in mfma layout. The implicit LDS usage of
     // cvt(mfma->blocked) op depends on the number of warps per CTA that mfma

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -70,14 +70,7 @@ struct DecomposeUnsupportedConversions
     : public mlir::triton::impl::DecomposeUnsupportedNVIDIAConversionsBase<
           DecomposeUnsupportedConversions> {
   void runOnOperation() override {
-    // FIXME [Dot LL]
-    // Remove the decomposeTensorCoreToDotLayoutConversion class entirely after
-    // we have enabled the new layout conversion for all the cases.
-    auto nvidiaShortCutFn = [&](RankedTensorType srcTy,
-                                RankedTensorType dstTy) { return true; };
     ModuleOp mod = getOperation();
-    triton::gpu::decomposeTensorCoreToDotLayoutConversion(mod,
-                                                          nvidiaShortCutFn);
     triton::gpu::decomposeBlockedToDotLayoutConversion(mod);
 
     mlir::RewritePatternSet patterns(&getContext());


### PR DESCRIPTION
Also create the `getThreadsPerWarpForOperand` interface.

This PR doesn't completely remove the decompose method because `getThreadsPerWarpForOperand` hasn't been implemented yet for some AMD specific encodings