### PR TITLE
[NFC] Remove dependency to cuda headers in Triton build

### DIFF
--- a/third_party/nvidia/include/cublas_types.h
+++ b/third_party/nvidia/include/cublas_types.h
@@ -3,9 +3,6 @@
 
 // Forward declarations of cuBLAS types and functions.
 
-#include "backend/include/cuda.h"
-#include "backend/include/driver_types.h"
-
 /* CUBLAS status type returns */
 typedef enum {
   CUBLAS_STATUS_SUCCESS = 0,
@@ -148,5 +145,7 @@ struct cublasContext;
 typedef struct cublasLtContext *cublasLtHandle_t;
 struct cublasLtMatmulDescOpaque_t;
 typedef cublasLtMatmulDescOpaque_t *cublasLtMatmulDesc_t;
+struct CUstream_st;
+typedef struct CUstream_st *cudaStream_t;
 
 #endif // TRITON_CUBLAS_TYPES_H


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
https://github.com/triton-lang/triton/pull/4085 now makes it impossible to build Triton without downloading cuda libraries (see https://github.com/triton-lang/triton/issues/5449). This PR adds dummy cuda headers (not vendoring the actual ones for legal reasons), making it possible to build a functional Triton without downloading cuda for backends that don't require cuda at runtime (e.g. amd, cpu).

Note that `setup.py`'s `download_and_copy` will replace the dummy headers with downloaded headers in a normal build.

https://github.com/triton-lang/triton/blob/c1166e537552e73392d26b055ea1b505277ca242/python/setup.py#L297-L330

Fixes https://github.com/triton-lang/triton/issues/5449. See also https://github.com/triton-lang/triton-cpu/issues/202, https://github.com/triton-lang/triton-cpu/pull/203.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because build system change.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
