### PR TITLE
[AMD][Atomic] Introduce runtime LDS reduction algorithm for atomicRmwOp

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -56,6 +56,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerConvertTritonAMDGPUToLLVM();
   mlir::triton::registerConvertBuiltinFuncToLLVM();
   mlir::triton::registerDecomposeUnsupportedAMDConversions();
+  mlir::triton::registerSetSpecificAllocationSize();
   mlir::triton::registerOptimizeAMDLDSUsage();
 
   // TritonAMDGPUTransforms passes

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -117,6 +117,9 @@ ScratchConfig getScratchConfigForCvt(RankedTensorType srcTy,
 }
 
 unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
+  if (op->hasAttr("allocation.size")) {
+    return op->getAttrOfType<mlir::IntegerAttr>("allocation.size").getInt();
+  }
   if (auto reduceOp = dyn_cast<ReduceOp>(op)) {
     ReduceOpHelper helper(reduceOp);
     return helper.getScratchSizeInBytes();

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1451,7 +1451,7 @@ def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
         tl.static_assert(old.dtype == x.dtype)
 
     sem_arg = sem if sem is None else f'"{sem}"'
-    kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'tl.atomic_{op}(Z, x, sem={sem_arg})'})
+    kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'tl.atomic_{op}(Z, x, sem={sem_arg} )'})
     numpy_op = {'add': np.sum, 'max': np.max, 'min': np.min}[op]
     max_neutral = float('-inf') if dtype_x_str in float_dtypes else np.iinfo(getattr(np, dtype_x_str)).min
     min_neutral = float('inf') if dtype_x_str in float_dtypes else np.iinfo(getattr(np, dtype_x_str)).max
@@ -1505,18 +1505,20 @@ def test_atomic_rmw_predicate(num_ctas, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("shape, axis, num_ctas, dtype_x_str",
-                         [(shape, axis, num_ctas, dtype_x_str)
+@pytest.mark.parametrize("shape, axis, num_ctas, dtype_x_str, check_return_val",
+                         [(shape, axis, num_ctas, dtype_x_str, check_return_val)
                           for shape in [(2, 2), (2, 8), (8, 2), (8, 8), (32, 32), (64, 64)]
                           for axis in [0, 1]
                           for num_ctas in num_ctas_list
-                          for dtype_x_str in ['float16', 'float32', 'uint64', 'int64', 'float64']])
-def test_tensor_atomic_rmw(shape, axis, num_ctas, dtype_x_str, device):
+                          for dtype_x_str in ['float16', 'float32', 'uint64', 'int64', 'float64']
+                          for check_return_val in ([True, False] if "gfx94" in get_arch() else [True])])
+def test_tensor_atomic_rmw(shape, axis, num_ctas, dtype_x_str, check_return_val, device):
     shape0, shape1 = shape
     # triton kernel
 
     @triton.jit
-    def kernel(Z, X, OLD, AXIS: tl.constexpr, SHAPE0: tl.constexpr, SHAPE1: tl.constexpr, DTYPE: tl.constexpr):
+    def kernel(Z, X, OLD, AXIS: tl.constexpr, SHAPE0: tl.constexpr, SHAPE1: tl.constexpr, DTYPE: tl.constexpr,
+               RETURN_VAL: tl.constexpr):
         off0 = tl.arange(0, SHAPE0)
         off1 = tl.arange(0, SHAPE1)
         x = tl.load(X + off0[:, None] * SHAPE1 + off1[None, :])
@@ -1533,10 +1535,12 @@ def test_tensor_atomic_rmw(shape, axis, num_ctas, dtype_x_str, device):
 
         if AXIS == 1:
             old = tl.atomic_add(Z + off0, z)
-            tl.store(OLD + off0, old)
+            if RETURN_VAL:
+                tl.store(OLD + off0, old)
         else:
             old = tl.atomic_add(Z + off1, z)
-            tl.store(OLD + off1, old)
+            if RETURN_VAL:
+                tl.store(OLD + off1, old)
 
     rs = RandomState(17)
     x = numpy_random((shape0, shape1), dtype_str=dtype_x_str, rs=rs)
@@ -1560,9 +1564,11 @@ def test_tensor_atomic_rmw(shape, axis, num_ctas, dtype_x_str, device):
             return tl.float16
         return None
 
-    kernel[(1, )](z_tri, x_tri, old_tri, axis, shape0, shape1, torch_to_triton_dtype(x_tri.dtype), num_ctas=num_ctas)
+    kernel[(1, )](z_tri, x_tri, old_tri, axis, shape0, shape1, torch_to_triton_dtype(x_tri.dtype), check_return_val,
+                  num_ctas=num_ctas)
     np.testing.assert_allclose(z_ref, to_numpy(z_tri), rtol=1e-4)
-    np.testing.assert_equal(old_ref, to_numpy(old_tri))
+    if check_return_val:
+        np.testing.assert_equal(old_ref, to_numpy(old_tri))
 
 
 @pytest.mark.interpreter

--- a/test/Conversion/amd/set-specific-allocation-size.mlir
+++ b/test/Conversion/amd/set-specific-allocation-size.mlir
@@ -1,0 +1,11 @@
+// RUN: triton-opt %s --split-input-file --set-specific-allocation-size=arch=gfx942 | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [2], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: atomic_lds_reduction
+  tt.func @atomic_lds_reduction(%arg0 : tensor<128x!tt.ptr<f32>, #blocked>, %arg2 : tensor<128xf32, #blocked>) {
+    // CHECK: tt.atomic_rmw fadd, relaxed, gpu{{.*}}allocation.size = 512 : i32
+    %0 = tt.atomic_rmw fadd, relaxed, gpu, %arg0, %arg2 : (tensor<128x!tt.ptr<f32>, #blocked>, tensor<128xf32, #blocked>) -> tensor<128xf32, #blocked>
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -292,6 +292,7 @@ class HIPBackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         amd.passes.ttgpuir.add_decompose_unsupported_conversions(pm, options.arch)
+        amd.passes.ttgpuir.add_set_specific_allocation_size(pm, options.arch)
         # custom_lds_size is an experimental parameter that defines amount of LDS available
         # for one thread block. Measured in bytes.
         #

--- a/third_party/amd/include/TritonAMDGPUToLLVM/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/Passes.h
@@ -26,6 +26,9 @@ namespace mlir::triton::AMD {
 std::unique_ptr<OperationPass<ModuleOp>>
 createDecomposeUnsupportedConversionsPass(StringRef targetArch);
 
+std::unique_ptr<OperationPass<ModuleOp>>
+createSetSpecificAllocationSizePass(StringRef targetArch);
+
 /// @brief Creates pass that keep LDS consumption within specified limits.
 /// @param arch target architecture name, for example "gfx940"
 /// @param customLDSLimit defines LDS size available for one thread block

--- a/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
@@ -13,6 +13,16 @@ def DecomposeUnsupportedAMDConversions : Pass<"decompose-unsupported-amd-convers
     ];
 }
 
+def SetSpecificAllocationSize : Pass<"set-specific-allocation-size", "mlir::ModuleOp"> {
+    let summary = "Set `allocation.size` attribute to make a hint to allocator that operation requires LDS.";
+    let constructor = "mlir::triton::AMD::createSetSpecificAllocationSizePass(\"\")";
+
+    let options = [
+        Option<"arch", "arch", "std::string", /*default*/"\"\"",
+               "gfx target device architecture, e.g., gfx942">,
+    ];
+}
+
 def OptimizeAMDLDSUsage : Pass<"optimize-amd-lds-usage", "mlir::ModuleOp"> {
     let summary = "Minimize LDS usage";
     let constructor = "mlir::triton::AMD::createOptimizeLDSUsagePass(\"\")";

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
@@ -17,6 +17,7 @@ add_triton_library(TritonAMDGPUToLLVM
     TargetInfo.cpp
     TargetUtils.cpp
     DecomposeUnsupportedConversions.cpp
+    SetSpecificAllocationSize.cpp
     OptimizeLDSUsage.cpp
     OptimizeLDSUtility.cpp
     SPMDOpToLLVM.cpp

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/SetSpecificAllocationSize.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/SetSpecificAllocationSize.cpp
@@ -1,0 +1,62 @@
+#include "TargetInfo.h"
+#include "TritonAMDGPUToLLVM/Passes.h"
+#include "Utility.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Conversion/TritonGPUToLLVM/Patterns.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include <numeric>
+
+using namespace mlir;
+namespace mlir::triton {
+#define GEN_PASS_DEF_SETSPECIFICALLOCATIONSIZE
+#include "TritonAMDGPUToLLVM/Passes.h.inc"
+} // namespace mlir::triton
+
+namespace {
+
+using namespace mlir;
+using namespace mlir::triton;
+
+struct SetSpecificAllocationSize
+    : public mlir::triton::impl::SetSpecificAllocationSizeBase<
+          SetSpecificAllocationSize> {
+  explicit SetSpecificAllocationSize(StringRef targetArch) {
+    this->arch = targetArch.str();
+  }
+
+  void runOnOperation() override {
+    triton::AMD::TargetInfo targetInfo(this->arch.getValue());
+    ModuleOp mod = getOperation();
+    mod.walk([&](triton::AtomicRMWOp atomOp) -> void {
+      Value res = atomOp.getResult();
+      Value value = atomOp.getVal();
+      auto tensorTy = dyn_cast<RankedTensorType>(value.getType());
+      Type elemTy = tensorTy ? tensorTy.getElementType() : value.getType();
+      size_t elemSize = elemTy.getIntOrFloatBitWidth();
+      if (!LLVM::AMD::isRuntimeLdsReductionforAtomicApplicable(
+              atomOp, targetInfo.getISAFamily()))
+        return;
+
+      auto layout = dyn_cast<RankedTensorType>(res.getType()).getEncoding();
+      size_t elemsToAlloc = triton::gpu::getWarpSize(layout) *
+                            triton::gpu::getNumWarpsPerCTA(layout);
+      size_t size = elemsToAlloc * std::max<int>(8, elemSize) / 8;
+      atomOp->setAttr(
+          "allocation.size",
+          IntegerAttr::get(IntegerType::get(atomOp.getContext(), 32), size));
+    });
+  }
+};
+
+} // namespace
+
+namespace mlir::triton::AMD {
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createSetSpecificAllocationSizePass(StringRef targetArch) {
+  return std::make_unique<SetSpecificAllocationSize>(targetArch);
+}
+
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -47,6 +47,10 @@ Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
 void llStore(RewriterBase &rewriter, Location loc, Value ptr, Value val,
              Value pred, int64_t alignmentBytes = 0,
              triton::CacheModifier cm = triton::CacheModifier::NONE);
+
+// Checks if runtime LDS reduction for atomic applicable or not
+bool isRuntimeLdsReductionforAtomicApplicable(
+    triton::AtomicRMWOp atomOp, mlir::triton::AMD::ISAFamily isaFamily);
 } // namespace mlir::LLVM::AMD
 
 #endif // TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUTOLLVM_UTILITY_H_

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -58,6 +58,10 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
     pm.addPass(
         mlir::triton::AMD::createDecomposeUnsupportedConversionsPass(arch));
   });
+  m.def("add_set_specific_allocation_size", [](mlir::PassManager &pm,
+                                               const std::string &arch) {
+    pm.addPass(mlir::triton::AMD::createSetSpecificAllocationSizePass(arch));
+  });
   ADD_PASS_WRAPPER_2("add_optimize_lds_usage",
                      mlir::triton::AMD::createOptimizeLDSUsagePass,
                      const std::string &, int32_t);


### PR DESCRIPTION
Algorithm description:
1. Sort {ptr, operand} among the threads within the warp
   via bitonic sort based on DPP and Permute operations;
2. Distribute threads between groups defined by pointers,
   define a group for each thread by analizing neighbours
   with DPP instructions;
3. Select master thread for each group using exec mask;
4. Collect partial sum in LDS for each group via
   DS_ADD-like instructions
5. Utilize global atomic operation for each group by
   master thread

Added lit test for checking algorithm highlights.

As far as described algoritm requires additional memory, size calculating
should be done in the target dependent code.
For this purpose `SetSpecificAllocationSize` pass was introduced, it sets
`allocation.size` attribute for required operation. This attribute has
highest priority during LDS size calculation in Allocation analysis.

Added a lit teest for `SetSpecificAllocationSize`.

Also extended `test_core.py::test_tensor_atomic_rmw` to be able to test cases
of interest.