### PR TITLE
[FRONTEND] add support for function arguments ; enforce use of `_unsafe_update_src` to modify the source-code of a JITFunction

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -89,7 +89,7 @@ def patch_kernel(template, to_replace):
     else:
         kernel = triton.JITFunction(template.fn)
         for key, value in to_replace.items():
-            kernel.src = kernel.src.replace(key, value)
+            kernel._unsafe_update_src(kernel.src.replace(key, value))
         return kernel
 
 

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -378,27 +378,6 @@ def test_no_cache_callable():
     assert not kernel.used_global_vals
 
 
-def test_constexpr_not_callable(device) -> None:
-
-    @triton.jit
-    def kernel(X, c: tl.constexpr):
-        tl.store(X, 2)
-
-    x = torch.empty(1, dtype=torch.int32, device=device)
-    error = False
-    try:
-        kernel[(1, )](x, c="str")
-    except BaseException:
-        error = True
-    assert error is False
-    # try and catch
-    try:
-        kernel[(1, )](x, c=tl.abs)
-    except BaseException:
-        error = True
-    assert error is True
-
-
 def test_jit_warmup_cache(device) -> None:
 
     @triton.jit

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -72,9 +72,9 @@ def apply_src_change(target, old, new, to_modify):
     function_0.hash = None
     function_1.hash = None
     function_2.hash = None
-    to_modify.src = to_modify.src.replace(old, new)
+    to_modify._unsafe_update_src(to_modify.src.replace(old, new))
     ret = target.cache_key
-    to_modify.src = to_modify.src.replace(new, old)
+    to_modify._unsafe_update_src(to_modify.src.replace(new, old))
     return ret
 
 

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -114,16 +114,13 @@ def test_combine_fn_change():
         ["tl.reduce", "tl.associative_scan"],
         ["a + b", "a * b"],
     ):
-        combine_fn.src = orig_combine_fn_src.replace("COMBINE_OP", combine_op)
-        kernel_with_combine_fn.src = orig_kernel_src.replace("REDUCE_OR_SCAN", reduce_or_scan)
+        combine_fn._unsafe_update_src(orig_combine_fn_src.replace("COMBINE_OP", combine_op))
+        kernel_with_combine_fn._unsafe_update_src(orig_kernel_src.replace("REDUCE_OR_SCAN", reduce_or_scan))
         try:
             key = kernel_with_combine_fn.cache_key
         finally:
-            combine_fn.src = orig_combine_fn_src
-            kernel_with_combine_fn.src = orig_kernel_src
-
-            kernel_with_combine_fn.hash = None
-            combine_fn.hash = None
+            combine_fn._unsafe_update_src(orig_combine_fn_src)
+            kernel_with_combine_fn._unsafe_update_src(orig_kernel_src)
 
         assert key not in seen_keys
         seen_keys.add(key)

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -620,6 +620,8 @@ def test_function_arguments():
     def kernel(Y, fn: tl.constexpr, fn_args):
         tl.store(Y, fn(*fn_args))
 
+    JITFunction.cache_hook = None
+    JITFunction.compiled_hook = None
     y = torch.zeros((5, ), dtype=torch.int32, device="cuda")
     kernel[(1, )](y[0], func1, tuple())
     kernel[(1, )](y[1], func2, tuple())

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -76,8 +76,9 @@ class ASTSource:
         sorted_sig = [v for k, v in sorted(self.signature.items())]
         # Note - we stringify the keys here to allow sorting to work for cases
         # where constants have mixed int/str keys.
-        sorted_constants = sorted((str(k), v) for k, v in self.constexprs.items())
-        key = f"{self.fn.cache_key}-{self.attrs.hash()}-{sorted_sig}-{sorted_constants}"
+        get_key = lambda x: x.cache_key if hasattr(x, 'cache_key') else str(x)
+        constexprs_key = '-'.join([get_key(v) for k, v in sorted(self.constexprs.items())])
+        key = f"{self.fn.cache_key}-{self.attrs.hash()}-{sorted_sig}-{constexprs_key}"
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
     def make_ir(self, options, codegen_fns, module_map, context):


### PR DESCRIPTION
caveat: not serializable - i.e. doesn't work with `preload`