### PR TITLE
[FRONTEND] Remove unused json parse in triton.compile

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -250,7 +250,6 @@ def compile(src, target=None, options=None):
     always_compile = os.environ.get("TRITON_ALWAYS_COMPILE", "0") == "1"
     if not always_compile and metadata_path is not None:
         # cache hit!
-        metadata = json.loads(Path(metadata_path).read_text())
         return CompiledKernel(src, metadata_group, hash)
     # initialize metadata
     metadata = {


### PR DESCRIPTION
This line is somewhat expensive since it reads a file from disk.

As far as I can tell it is a duplicate of this line (which is actually used):
https://github.com/triton-lang/triton/blob/d9facf3a6edbc819c80d58b87e689bc0c2632756/python/triton/compiler/compiler.py#L360
