### PR TITLE
[AMD] Support FP16 to FP8E4M3NV Conversion

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -330,21 +330,25 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
 ])
 def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
 
-    if src_dtype != 'float32' and is_cuda() and torch.cuda.get_device_capability(0) < (9, 0):
-        pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
+    if is_cuda():
+        if src_dtype != 'float32' and torch.cuda.get_device_capability(0) < (9, 0):
+            pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
 
-    is_fp16_to_fp8e4nv_on_hip_mi300 = is_hip_mi300() and (src_dtype == 'float16') and \
-        (dst_dtype == 'float8e4nv') and (rounding == 'rtne')
+        if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and torch.cuda.get_device_capability(0) < (9, 0):
+            pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
 
-    if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' \
-        and (is_hip() or torch.cuda.get_device_capability(0) < (9, 0)) and not is_fp16_to_fp8e4nv_on_hip_mi300:
-        pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
+        if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne':
+            pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU MI300")
 
-    if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne' and (is_cuda() or not is_hip_mi300()):
-        pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU MI300")
+    if is_hip():
+        if dst_dtype == 'float8e5' and rounding == 'rtne':
+            pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
 
-    if dst_dtype == 'float8e4nv' and is_hip() and not is_fp16_to_fp8e4nv_on_hip_mi300:
-        pytest.skip(f"{dst_dtype} downcast not supported in HIP")
+        if dst_dtype == 'float8e4nv' and not (src_dtype == 'float16' and rounding == 'rtne' and is_hip_mi300()):
+            pytest.skip("float8e4nv downcast tests only supported from float16, with RTNE rounding, and on AMDGPU MI300")
+
+        if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne' and not is_hip_mi300():
+            pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU MI300")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias)
     stuff = {

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -333,13 +333,17 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
     if src_dtype != 'float32' and is_cuda() and torch.cuda.get_device_capability(0) < (9, 0):
         pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
 
-    if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and (is_hip() or torch.cuda.is_available() and torch.cuda.get_device_capability(0) < (9, 0)):
+    is_fp16_to_fp8e4nv_on_hip = is_hip() and (src_dtype == 'float16') and \
+        (dst_dtype == 'float8e4nv') and (rounding == 'rtne')
+
+    if not is_fp16_to_fp8e4nv_on_hip and dst_dtype in ('float8e5', 'float8e4nv') \
+        and rounding == 'rtne' and (is_hip() or torch.cuda.get_device_capability(0) < (9, 0)):
         pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
 
     if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne' and (is_cuda() or not is_hip_mi300()):
         pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU MI300")
 
-    if dst_dtype == 'float8e4nv' and is_hip():
+    if not is_fp16_to_fp8e4nv_on_hip and dst_dtype == 'float8e4nv' and is_hip():
         pytest.skip(f"{dst_dtype} downcast not supported in HIP")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias)

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -333,17 +333,17 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
     if src_dtype != 'float32' and is_cuda() and torch.cuda.get_device_capability(0) < (9, 0):
         pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
 
-    is_fp16_to_fp8e4nv_on_hip = is_hip() and (src_dtype == 'float16') and \
+    is_fp16_to_fp8e4nv_on_hip_mi300 = is_hip_mi300() and (src_dtype == 'float16') and \
         (dst_dtype == 'float8e4nv') and (rounding == 'rtne')
 
     if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' \
-        and (is_hip() or torch.cuda.get_device_capability(0) < (9, 0)) and not is_fp16_to_fp8e4nv_on_hip:
+        and (is_hip() or torch.cuda.get_device_capability(0) < (9, 0)) and not is_fp16_to_fp8e4nv_on_hip_mi300:
         pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
 
     if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne' and (is_cuda() or not is_hip_mi300()):
         pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU MI300")
 
-    if dst_dtype == 'float8e4nv' and is_hip() and not is_fp16_to_fp8e4nv_on_hip:
+    if dst_dtype == 'float8e4nv' and is_hip() and not is_fp16_to_fp8e4nv_on_hip_mi300:
         pytest.skip(f"{dst_dtype} downcast not supported in HIP")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias)

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -336,14 +336,14 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
     is_fp16_to_fp8e4nv_on_hip = is_hip() and (src_dtype == 'float16') and \
         (dst_dtype == 'float8e4nv') and (rounding == 'rtne')
 
-    if not is_fp16_to_fp8e4nv_on_hip and dst_dtype in ('float8e5', 'float8e4nv') \
-        and rounding == 'rtne' and (is_hip() or torch.cuda.get_device_capability(0) < (9, 0)):
+    if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' \
+        and (is_hip() or torch.cuda.get_device_capability(0) < (9, 0)) and not is_fp16_to_fp8e4nv_on_hip:
         pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
 
     if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne' and (is_cuda() or not is_hip_mi300()):
         pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU MI300")
 
-    if not is_fp16_to_fp8e4nv_on_hip and dst_dtype == 'float8e4nv' and is_hip():
+    if dst_dtype == 'float8e4nv' and is_hip() and not is_fp16_to_fp8e4nv_on_hip:
         pytest.skip(f"{dst_dtype} downcast not supported in HIP")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3382,8 +3382,8 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
                     pytest.skip("Only test out_dtype=float16 on devices with sm >=80")
             if capability[0] < 9 and in_dtype == 'float8e4nv':
                 pytest.skip("float8e4nv not supported on sm <= 80")
-        if is_hip() and (in_dtype == 'float8e4nv' or in_dtype == 'float8e5'):
-            pytest.skip("float8e4nv and float8e5 not supported on HIP")
+        if is_hip() and (in_dtype == 'float8e5'):
+            pytest.skip("float8e5 not supported on HIP")
         if is_hip() and (input_precision != "ieee"):
             pytest.skip(f"{input_precision} not supported on HIP")
         if is_hip() and (kpack == 2 and in_dtype == 'int8' and K < 64):

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3382,8 +3382,8 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
                     pytest.skip("Only test out_dtype=float16 on devices with sm >=80")
             if capability[0] < 9 and in_dtype == 'float8e4nv':
                 pytest.skip("float8e4nv not supported on sm <= 80")
-        if is_hip() and (in_dtype == 'float8e5'):
-            pytest.skip("float8e5 not supported on HIP")
+        if is_hip() and (in_dtype == 'float8e4nv' or in_dtype == 'float8e5'):
+            pytest.skip("float8e4nv and float8e5 not supported on HIP")
         if is_hip() and (input_precision != "ieee"):
             pytest.skip(f"{input_precision} not supported on HIP")
         if is_hip() and (kpack == 2 and in_dtype == 'int8' and K < 64):

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -103,13 +103,11 @@ static Value
 Fp16_to_Fp8E4M3FN_RTNE_oneValue(Location loc,
                                 ConversionPatternRewriter &rewriter, Value v) {
   Value vi16 = bitcast(v, i16_ty);
-  Value e = and_(vi16, i16_val(0x7C00));
-  Value m = and_(vi16, i16_val(0x03FF));
 
-  // Check NaNs: S.11111.MMMMMMMMMM(MMMMMMMMMM != 0)
-  Value isExponentAllOnes = icmp_eq(e, i16_val(0x7C00));
-  Value isMantissaNotAllZeros = icmp_ugt(m, i16_val(0));
-  Value isNaN = and_(isExponentAllOnes, isMantissaNotAllZeros);
+  StringRef funcName = "llvm.is.fpclass";
+  Value isNaN = LLVM::createLLVMIntrinsicCallOp(rewriter, loc, funcName, i1_ty,
+                                                {v, i32_val(0x3)})
+                    ->getResult(0);
 
   // Rounding to nearest even
   constexpr uint16_t remainingMantissaLSBMask = 0x0080;
@@ -123,32 +121,34 @@ Fp16_to_Fp8E4M3FN_RTNE_oneValue(Location loc,
   Value vFp8 = add(vi16, roundingBias);
 
   // Reduce mantissa to 3 bits
-  vFp8 = and_(vFp8, i16_val(0x0380)); // 0x0380 === 0.00000.1110000000
+  vFp8 = and_(vFp8, i16_val(0xFF80)); // 0xFF80 === 1.11111.1110000000
 
-  // remove sign bit
+  // Remove sign bit
   vFp8 = and_(vFp8, i16_val(0x7FFF));
 
-  // adjust bias
+  // Round numbers smaller than the smallest normal number in FP8 to 0, 0x2400
+  // is the FP16 representation of 2^{-6}, which is the smallest normal number
+  // in FP8E4M3FN.
+  Value isSubnormal = icmp_ult(vFp8, i16_val(0x2400));
+
+  // S.11111.0000000000 0x5F7F === 0.10111.1101111111 is the largest possible
+  // normal number(including infinity) after rounding in FP8
+  constexpr uint16_t largestPossibleNormal = 0x5F7F;
+  Value isOverflowOrInf = icmp_ugt(vFp8, i16_val(largestPossibleNormal));
+
+  // Adjust exponent bias
   vFp8 = sub(vFp8, i16_val((15 - 7) << 10));
 
-  // shift right and truncate
+  // Shift right and truncate
   vFp8 = lshr(vFp8, i16_val(7)); // 10 - 3
   vFp8 = trunc(i8_ty, vFp8);
 
   // In saturation mode, numbers larger than the max normal number(including
   // infinity) in FP8 after rounding will be replaced with max_E4M3, i.e. 0x7E
   // === 0.1111.110
-  //
-  // S.11111.0000000000 0x5F7F === 0.10111.1101111111 is the largest possible
-  // normal number(including infinity) after rounding in FP8
-  constexpr uint16_t maxPossibleNormal = 0x5F7F;
-  Value isOverflowOrInf = icmp_ugt(vFp8, i16_val(maxPossibleNormal));
   vFp8 = select(isOverflowOrInf, i8_val(0x7E), vFp8);
 
-  // Round numbers smaller than the smallest normal number in FP8 to 0, 0x2400
-  // is the FP16 representation of 2^{-6}, which is the smallest normal number
-  // in FP8E4M3FN.
-  Value isSubnormal = icmp_ult(vFp8, i16_val(0x2400));
+  // Flush subnormals to zeros
   vFp8 = select(isSubnormal, i8_val(0), vFp8);
 
   // NaN remains NaN after conversion
@@ -157,6 +157,7 @@ Fp16_to_Fp8E4M3FN_RTNE_oneValue(Location loc,
   // Set sign bit
   Value sign = and_(vi16, i16_val(0x8000));
   sign = lshr(sign, i16_val(8));
+  sign = trunc(i8_ty, sign);
   vFp8 = or_(vFp8, sign);
 
   return vFp8;


### PR DESCRIPTION
This commit supported FP16 to FP8E4M3NV(FP8E4M3FN) conversion on AMD backend.