### PR TITLE
[AMD][Backend, Atomics] Remove old comment regarding buffer atomics

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -905,8 +905,6 @@ struct AtomicRMWOpConversion
 
       rewriter.setInsertionPointToEnd(atomicBlock);
       auto maybeKind = matchAtomicOp(atomicRmwAttr);
-      // TODO: use rocdl.raw.buffer.atomic from ROCDL dialect to use efficient
-      // atomics for MI-* series of AMD GPU.
       Value atom =
           rewriter
               .create<LLVM::AtomicRMWOp>(loc, *maybeKind, rmwPtr, operand,


### PR DESCRIPTION
# Overview

I spent a day investigating an old comment in the AMD backend regarding buffer atomics (specifically buffer atomic RMW) which suggested that buffer atomics perform better on MI-* series GPUs. The branch I worked on is available [here for reference](https://github.com/SamGinzburg/triton/tree/PR-BufferAtomicRMW).

I think that (today, maybe this was different in the past) as far as I can tell the only benefit that buffer atomics (on their own) offer is the same hardware masking benefits that other buffer ops have (i.e., atomics out of bounds are dropped). This depends on how the buffer atomics are synchronized though, and this is where I'm less sure of whats correct:

With full barriers (identical performance to "normal" atomics):
```python
buffer_wbl2 sc1
s_waitcnt lgkmcnt(0)
atomicRMWop()
s_waitcnt vmcnt(0) 
buffer_inv sc1
buffer_wbl2 sc1
s_waitcnt lgkmcnt(0)
atomicRMWop()
s_waitcnt vmcnt(0) 
buffer_inv sc1
```

With some assumptions specific to gfx942 (This can improve latency in bw-bound Split-K for some but not all shapes, it seems [this is what CK does](https://github.com/ROCm/composable_kernel/blob/6df5fe2ad8fb6ff054a3e75250ccef7c878c3455/include/ck_tile/core/arch/amd_buffer_addressing.hpp#L619)):
```python
buffer_wbl2 sc1
s_waitcnt lgkmcnt(0)
atomicRMWop()
s_waitcnt vmcnt(0) # AMDGCN specific cross-CU synchronization primitive
atomicRMWop()
s_waitcnt vmcnt(0) 
buffer_inv sc1
```

If there is interest, I can file a PR to add experimental support for buffer atomic RMW ops. The only major difference with my implementation is that I added support for CTA-scope (atomics in the AMD backend today only support agent scope as far as I can tell I think).



==================================================================
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ x] This PR does not need a test because `just removing a comment`.

- Select one of the following.
  - [ x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
