### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -12,7 +12,7 @@ class OpBuilder;
 
 /// Callback to allow backend to provide more information on whether a barrier
 /// is needed between two operations. Even though two operations access the same
-/// shared memory thay may not require a barrier in between them.
+/// shared memory they may not require a barrier in between them.
 using MembarFilterFn = std::function<bool(Operation *, Operation *)>;
 
 struct BlockInfo {

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -854,7 +854,7 @@ def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [
 // Histogram Op
 //
 def TT_HistogramOp : TT_Op<"histogram", [Pure]> {
-  let summary = "return a histgram of the inputs.";
+  let summary = "return a histogram of the inputs.";
   let description = [{
     Return the histogram of the input tensor. The number of bins is equal to
     the dimension of the output tensor. Each bins has a width of 1 and bins

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -950,7 +950,7 @@ available on AMD Radeon GPUs of RDNA architectures.
   - 1: gfx11
   - 2: gfx12
 - A `warpsPerCTA` parameter characterizes data distribution between warps.
-  An important limitation of WMMA for layout is a shape for tiles proccessed
+  An important limitation of WMMA for layout is a shape for tiles processed
   by a single warp. It is [16, 16].
   This encoding assumes specific access to matrix elements by threads.
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -90,7 +90,7 @@ def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
   let description = [{
     This operation copies data from global memory to local memory asynchronously.
     This is analogue to tt.load except the data are copied to local memory pointed
-    by by the memory descriptor instread of a distributed tensor. The rest of the
+    by by the memory descriptor instead of a distributed tensor. The rest of the
     operands are the same as tt.load.
   }];
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -202,7 +202,7 @@ def TritonGPUReduceDataDuplication: Pass<"tritongpu-reduce-data-duplication", "m
 def TritonGPUCombineTensorSelectAndIf: Pass<"tritongpu-combine-tensor-select-and-if", "mlir::ModuleOp"> {
   let summary = "Combine tensor select and if";
 
-  let description = "For select instruction that uses the same condidtion as the if instruction in the same block "
+  let description = "For select instruction that uses the same condition as the if instruction in the same block "
                     "this pass combines the select into the if instruction, making the select operands returned by the "
                     "then/else yields.";
 
@@ -211,7 +211,7 @@ def TritonGPUCombineTensorSelectAndIf: Pass<"tritongpu-combine-tensor-select-and
 }
 
 def TritonGPUOptimizeAccumulatorInit: Pass<"tritongpu-optimize-accumulator-init", "mlir::ModuleOp"> {
-  let summary = "Replace accumulater zero-initialization with the flag indicating first use of the accumulator";
+  let summary = "Replace accumulator zero-initialization with the flag indicating first use of the accumulator";
 
   let description = "For the dot operations that support accumulator-use flag this pass replaces the zero-initialization "
                     "of the accumulator with the flag indicating the first use of the accumulator.";

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -136,7 +136,7 @@ def TTNG_InvalBarrierOp : TTNG_Op<"inval_barrier", [DeclareOpInterfaceMethods<Me
 
     let description = [{
       Invalidate a barrier allocation so that it can be re-used. According to PTX
-      spec this has to be done before any re-use of the memory used by mbarrier.
+      spec this has to be done before any reuse of the memory used by mbarrier.
 
       https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-inval
     }];
@@ -213,7 +213,7 @@ def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local",
   let description = [{
     This operation copies data from global memory to local memory
     asynchronously.  This is analogue to tt.load except the data are copied to
-    local memory pointed by the memory descriptor instread of a distributed
+    local memory pointed by the memory descriptor instead of a distributed
     tensor. The data copied depends on the global memory descriptor pointed to
     by `desc_ptr`.
   }];
@@ -243,7 +243,7 @@ def TTNG_AsyncTMACopyLocalToGlobalOp : TTNG_Op<"async_tma_copy_local_to_global",
   let description = [{
     This operation copies data from local memory to global memory
     asynchronously.  This is analogue to tt.store except the data are copied from
-    local memory pointed by the memory descriptor instread of a distributed
+    local memory pointed by the memory descriptor instead of a distributed
     tensor. The data copied depends on the global memory descriptor pointed to
     by `desc_ptr`.
   }];

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
@@ -158,7 +158,7 @@ Value computeSwizzledOffset(ConversionPatternRewriter &rewriter, Location loc,
                             ArrayRef<int64_t> opTensorShape,
                             ArrayRef<Value> strides) {
   Value offset = i32_val(0);
-  // Compute unswizzled multi dim coordinates in shared memmory object
+  // Compute unswizzled multi dim coordinates in shared memory object
   SmallVector<Value> elemMultiDimIndices(3);
   elemMultiDimIndices[dim.batch] =
       add(bTileOffset, i32_val(i.bTile * shapePerCTABTile + i.b));
@@ -309,7 +309,7 @@ Value loadFMAOp(Value srcVal, Value llVal, BlockedEncodingAttr dLayout,
                               sizeNonKPerThread);
 
   // In swizzled memory case basePtr stores pointer to the beginning of shared
-  // memmory object.
+  // memory object.
   //
   // If memory is not swizzled, algorithm breaks element offset pointer into
   // constant and non-constant part. Non-constant (depends on thread id) part is

--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -17,7 +17,7 @@ using namespace mlir::triton;
 // NOTE: [Additional Function Arguments]
 // To support use of shared memory and global scratch memory inside of a
 // function, the caller allocates a single large block of the relevant memory
-// and calls the funciton with these extra arguments at the end.
+// and calls the function with these extra arguments at the end.
 // Specifically, the last argument is the global scratch memory allocation and
 // the second to last is the shared memory allocation.
 //

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -127,7 +127,7 @@ private:
         emitOffsetForLayout(helper.getSrcLayout(), operandType);
 
     // Thread X might hold the same input value in two registers.  Get the
-    // indices in `offsets` that hold unique values, and only accumualte over
+    // indices in `offsets` that hold unique values, and only accumulate over
     // those.
     llvm::MapVector<ArrayRef<unsigned>, int> uniqueOffsets;
     for (int i = 0; i < offsets.size(); ++i) {
@@ -221,7 +221,7 @@ private:
   // For slice layout some ids are duplicated on multiple lanes, so we need to
   // handle the delinearization of laneId in a special way. We need to
   // generalize this part of the logic to work on any kind of linear layout
-  // uniformely.
+  // uniformly.
   SmallVector<Value>
   getMultiDimLaneId(ReduceOpHelper &helper, Value &laneId, Location &loc,
                     ConversionPatternRewriter &rewriter) const {

--- a/lib/Conversion/TritonGPUToLLVM/ReduceScanCommon.h
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceScanCommon.h
@@ -51,7 +51,7 @@ inline SmallVector<Value> applyCombineOp(Location loc,
                                          ConversionPatternRewriter &rewriter,
                                          Region &combineOp, ValueRange acc,
                                          ValueRange cur, Value pred = {}) {
-  // Allows for passing an unitialized acc and use cur as the neutral element
+  // Allows for passing an uninitialized acc and use cur as the neutral element
   if (acc.size() == 0) {
     return cur;
   }

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -173,7 +173,7 @@ struct SplitOpConversion : public ConvertOpToLLVMPattern<SplitOp> {
     // verifier):
     //
     // - The op has a blocked encoding.
-    // - The last dimension (the one we're spliting) has sizePerThread=2,
+    // - The last dimension (the one we're splitting) has sizePerThread=2,
     // threadPerWarp=1 and warpPerBlock=1.
     //
     // With these invariants, split is trivial: We can count how many contiguous

--- a/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
@@ -395,7 +395,7 @@ public:
 
   Operation *rewriteForOp(OpBuilder &builder, scf::ForOp op,
                           std::stack<Operation *> &eraser) {
-    // Generate new iteration operands and set rewrited information
+    // Generate new iteration operands and set rewritten information
     SmallVector<Value> oldIterOperands = llvm::to_vector(op.getInitArgs());
     SmallVector<Value> newIterOperands = llvm::to_vector(op.getInitArgs());
     for (unsigned i = 0, oldI = 0, size = op.getInitArgs().size(); i < size;
@@ -425,7 +425,7 @@ public:
          ++i, ++oldI) {
       auto oldRegionIterArg = op.getRegionIterArg(oldI);
       if (triton::isTensorPointerType(oldRegionIterArg.getType())) {
-        // Pass rewrited info inside
+        // Pass rewritten info inside
         assert(rewritedInfo.count(oldIterOperands[oldI]));
         auto info = rewritedInfo[oldIterOperands[oldI]];
         mapping.map(oldRegionIterArg, oldRegionIterArg);
@@ -450,7 +450,7 @@ public:
     for (unsigned i = 0, oldI = 0; oldI < op.getNumResults(); ++i, ++oldI) {
       auto oldResult = op.getResult(oldI);
       if (triton::isTensorPointerType(oldResult.getType())) {
-        // Pack new offsets into rewrited info
+        // Pack new offsets into rewritten info
         assert(rewritedInfo.count(oldIterOperands[oldI]));
         auto info = rewritedInfo[oldIterOperands[oldI]];
         for (unsigned j = 0; j < info.length(); ++j)

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1135,11 +1135,11 @@ LogicalResult DotOperandEncodingAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
     unsigned opIdx, Attribute parent, unsigned kWidth) {
   if (opIdx != 0 && opIdx != 1) {
-    return emitError() << "ttg.dot_op opIdx paramenter can be 0 or 1, got: "
+    return emitError() << "ttg.dot_op opIdx parameter can be 0 or 1, got: "
                        << opIdx;
   }
   if (!parent) {
-    return emitError() << "ttg.dot_op parent paramenter cannot be null";
+    return emitError() << "ttg.dot_op parent parameter cannot be null";
   }
   if (auto parentAttr = mlir::dyn_cast<NvidiaMmaEncodingAttr>(parent)) {
     if (kWidth != 0 && !(parentAttr.isAmpere() || parentAttr.isHopper()))
@@ -2315,7 +2315,7 @@ SmallVector<unsigned> NvidiaMmaEncodingAttr::getWarpsPerCTA() const {
 }
 SmallVector<unsigned> NvidiaMmaEncodingAttr::getWarpOrder() const {
   auto rank = getWarpsPerCTA().size();
-  // Hopper (wgmma) uses column-major as this is embeded in the instruction
+  // Hopper (wgmma) uses column-major as this is embedded in the instruction
   // For Ampere we can choose either row-major or column-major.
   // We choose row-major as the legacy path did so
   return getMatrixOrder(rank, /*rowMajor*/ !isHopper());

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -352,13 +352,13 @@ AMDMfmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   }
   if (hasBatchDim) {
     assert(order[2] == 0);
-    // Extend the base vector with one value to accomodate for the batch
+    // Extend the base vector with one value to accommodate for the batch
     // dimension, which appears at the last.
     tileLayout *= LinearLayout::identity1D(1, kRegister, outDimNames[order[2]]);
     tileLayout *= LinearLayout::identity1D(1, kLane, outDimNames[order[2]]);
   }
 
-  // And each warp takes the same register and lane sub-layout. So mulitply with
+  // And each warp takes the same register and lane sub-layout. So multiply with
   // an identity layout for the warp.
   LinearLayout warpLayout =
       identityStandardND(S("warp"), getWarpsPerCTA(), order);
@@ -435,7 +435,7 @@ mfmaDotToLinearLayout(DotOperandEncodingAttr dotMfmaLayout,
 
   if (mfmaLayout.getMDim() == 32) {
     // Canonical MFMA linear layout handles 4 consecutive elements along
-    // the register dimension. Dot operand handles varaible kWidth consecutive
+    // the register dimension. Dot operand handles variable kWidth consecutive
     // elements. For lane dim, since the MFMA thread arrangement is {K, N} = {2,
     // 32}, this means that mapping of first 5 base (up to thread 16) vectors
     // will be an identity along N dim. Thread 32 will be mapped to element
@@ -465,7 +465,7 @@ mfmaDotToLinearLayout(DotOperandEncodingAttr dotMfmaLayout,
 
   if (hasBatchDim) {
     assert(order[2] == 0);
-    // Extend the base vector with one value to accomodate for the batch
+    // Extend the base vector with one value to accommodate for the batch
     // dimension, which appears at the last.
     tileLayout *= LinearLayout::identity1D(1, kRegister, outDimNames[order[2]]);
     tileLayout *= LinearLayout::identity1D(1, kLane, outDimNames[order[2]]);
@@ -546,14 +546,14 @@ AMDWmmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
 
   if (hasBatchDim) {
     int batchIndex = 0;
-    // Extend the base vector with one value to accomodate for the batch
+    // Extend the base vector with one value to accommodate for the batch
     // dimension, which appears at the last.
     tileLayout *=
         LinearLayout::identity1D(1, kRegister, outDimNames[batchIndex]);
     tileLayout *= LinearLayout::identity1D(1, kLane, outDimNames[batchIndex]);
   }
 
-  // And each warp takes the same register and lane sub-layout. So mulitply with
+  // And each warp takes the same register and lane sub-layout. So multiply with
   // an identity layout for the warp.
   auto warpOrder = getWarpOrder();
   LinearLayout warpLayout =
@@ -612,7 +612,7 @@ wmmaDotOperandToLinearLayout(DotOperandEncodingAttr dotWmmaLayout,
       {outDimNames[laneOrder[0]], outDimNames[laneOrder[1]]});
   if (hasBatchDim) {
     assert(laneOrder[2] == 0);
-    // Extend the base vector with one value to accomodate for the batch
+    // Extend the base vector with one value to accommodate for the batch
     // dimension, which appears at the last.
     tileLayout *=
         LinearLayout::identity1D(1, kRegister, outDimNames[laneOrder[2]]);

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -96,7 +96,7 @@ SmallVector<unsigned> warpsPerTileV2(DotOp dotOp, const ArrayRef<int64_t> shape,
     if (reps[0] >= reps[1]) {
       warps[0] *= 2;
       // Too many warps for this mma (repM == repN == 1).
-      // We allocate the remainin warps to the left (arbitrary choice)
+      // We allocate the remaining warps to the left (arbitrary choice)
       if (reps[0] != 1) {
         reps[0] /= 2;
       }
@@ -287,7 +287,7 @@ public:
     Operation *newDot = nullptr;
     if (versionMajor == 3) {
       auto eltType = dotOp.getA().getType().getElementType();
-      // In MMAV3 tranpose is only supported for f16 and bf16.
+      // In MMAV3 transpose is only supported for f16 and bf16.
       bool allowTranspose = eltType.isF16() || eltType.isBF16();
       a = getSharedMemoryMMAOperand(a, rewriter, 0, allowTranspose);
       b = getSharedMemoryMMAOperand(b, rewriter, 1, allowTranspose);

--- a/lib/Dialect/TritonGPU/Transforms/F32DotTC.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/F32DotTC.cpp
@@ -11,7 +11,7 @@ namespace gpu {
 
 namespace {
 
-// nb. We call the trick TF32x3 as C++ disallows varaibles starting with numbers
+// nb. We call the trick TF32x3 as C++ disallows variables starting with numbers
 // Implement 3xTF32 trick https://github.com/NVIDIA/cutlass/discussions/385
 // For a, b f32
 // dot(a, b, inputPrecision="tf32x3") ->

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -101,7 +101,7 @@ static RankedTensorType replaceEncoding(RankedTensorType oldType,
                                newEncoding);
 }
 
-// This function considers a gather op in isolation and attemps to determine
+// This function considers a gather op in isolation and attempts to determine
 // whether an optimized layout can be applied to the source and index tensors.
 static void setOptimizedGatherLayout(GatherOp op, mlir::RewriterBase &b) {
   RankedTensorType srcType = op.getSrc().getType();

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -171,7 +171,7 @@ static int createAsyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,
   Operation *copy = builder.createWithStage<ttg::AsyncCopyGlobalToLocalOp>(
       loc, stage, clusterId, src, view, mask, other, loadOp.getCache(),
       loadOp.getEvict(), loadOp.getIsVolatile());
-  Operation *commmit = builder.createWithStage<ttg::AsyncCommitGroupOp>(
+  Operation *commit = builder.createWithStage<ttg::AsyncCommitGroupOp>(
       loc, stage, clusterId, copy->getResult(0));
   Operation *wait = builder.createWithStage<ttg::AsyncWaitOp>(
       loc, stageForFirstUse, clusterForFirstUse, commmit->getResult(0), 0);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -174,7 +174,7 @@ static int createAsyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,
   Operation *commit = builder.createWithStage<ttg::AsyncCommitGroupOp>(
       loc, stage, clusterId, copy->getResult(0));
   Operation *wait = builder.createWithStage<ttg::AsyncWaitOp>(
-      loc, stageForFirstUse, clusterForFirstUse, commmit->getResult(0), 0);
+      loc, stageForFirstUse, clusterForFirstUse, commit->getResult(0), 0);
 
   auto loadIsMMAv3Shared = loadToInfo[loadOp].isMMAv3Shared;
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
@@ -83,7 +83,7 @@ bool mlir::triton::pipelineTMAStores(scf::ForOp forOp) {
     // Reuse allocations for stores of the same shape and types. This allows
     // saving shared memory usage. It is valid since we have a wait 0 before
     // every local_store. We could pipeline more aggressively if we didn't
-    // re-use but there is a tradeoff with shared memory usage.
+    // reuse but there is a tradeoff with shared memory usage.
     auto key = std::make_pair(op.getSrc().getType().getShape(),
                               op.getSrc().getType().getElementType());
     auto it = allocs.find(key);

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -950,7 +950,7 @@ LogicalResult LayoutRematerialization::getRematerializableSlice(
     DenseMap<Value, Attribute> &layout,
     std::function<bool(Operation *)> stopPropagation) {
   // Allow re-using existing conversions for a value. Check dominance of any
-  // re-usable materializations against the root value. This is sufficient
+  // reusable materializations against the root value. This is sufficient
   // because the conversions are processed in post-order.
   auto getExistingConversion = [&](OpOperand &value, Attribute encoding) {
     Value remat = getRematValue(value.get(), encoding);
@@ -996,7 +996,7 @@ void LayoutRematerialization::backwardRematerialization() {
   for (ConvertLayoutOp convertOp : convertOps) {
     backwardRematerialization(convertOp);
     if (!opToDelete.contains(convertOp)) {
-      // If the conversion didn't get removed, consider it for re-use in future
+      // If the conversion didn't get removed, consider it for reuse in future
       // backward slices.
       addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
                     convertOp.getResult());
@@ -1012,7 +1012,7 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast() {
   for (ConvertLayoutOp convertOp : convertOps) {
     hoistConvertOnTopOfExtOrBroadcast(convertOp);
     if (!opToDelete.contains(convertOp)) {
-      // If the conversion didn't get removed, consider it for re-use in future
+      // If the conversion didn't get removed, consider it for reuse in future
       // backward slices.
       addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
                     convertOp.getResult());

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -970,7 +970,7 @@ int getNVIDIAComputeCapability(Operation *module) {
 
 // If all the transitive uses of the given value have are used by a convert to
 // the same dot operand encoding, return the shared encoding that needs to be
-// used to be compatible with users' layouts. If there are imcompatible shared
+// used to be compatible with users' layouts. If there are incompatible shared
 // encodings, set incompatible to true.
 std::optional<ttg::SharedEncodingAttr>
 getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible) {

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -348,7 +348,7 @@ void init_triton_llvm(py::module &&m) {
         // level plugins. LLVM IR level plugin passes typically want to insert
         // calls to externally generated code (i.e. precompile a Cuda/Hip kernel
         // with Clang and then insert a call to it within an instrumentation
-        // pass) setting the targetMachine value here can can cause a mis-match
+        // pass) setting the targetMachine value here can can cause a mismatch
         // in the target machine between the MLIR and Clang generated kernels
         // and break the lowering of some target specific intrinsics.
         std::unique_ptr<TargetMachine> targetMachine = nullptr;

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2404,7 +2404,7 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
     check_type_supported(dtype_str, device)
     if dtype_str == 'bfloat16':
         if op == 'cummax':
-            pytest.skip("bfloat16 compare not suppoted before sm90")
+            pytest.skip("bfloat16 compare not supported before sm90")
         if op == 'linear_recurrence':
             pytest.skip("Skipping linear_recurrence scan on bfloat16 due to accuracy issues")
     numpy_dtype_str = 'float32' if dtype_str == 'bfloat16' else dtype_str
@@ -6190,7 +6190,7 @@ def test_temp_var_in_loop(device):
                 acc = temp
             else:
                 acc += tl.full((BLOCK, ), 1, dtype=tl.int32)
-            # re-use the temp variable and make sure to check that it isn't creating incorrect IR.
+            # reuse the temp variable and make sure to check that it isn't creating incorrect IR.
             temp = tl.full((BLOCK, ), 1, dtype=tl.int32)
             acc += temp
         z = Z + tl.arange(0, BLOCK)

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -86,7 +86,7 @@ def test_hooks(device):
     _kernel[(1, )](src, N)
 
     # On NVIDIA GPUs:
-    # The tunning knob `num_stages` can be set by users.
+    # The tuning knob `num_stages` can be set by users.
     # This will cause out of resources when N_STAGES = 100
     # shared memory bytes = N_STAGES * BLOCK_SIZE * sizeof(float)
     # On AMD GPUs:

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -61,7 +61,7 @@ def computation_type_impl(a_ty: tl.dtype, a_is_scalar: bool, b_ty: tl.dtype, b_i
                           div_or_mod: bool) -> tl.dtype:
     # 0) For scalars we follow semantics similar to PyTorch, namely:
     # - If the scalar is of a lower or equal kind (bool < uint < int < fp),
-    #   it doesn't participate in the pomotion
+    #   it doesn't participate in the promotion
     if a_is_scalar != b_is_scalar:
         scalar_ty, tensor_ty = (a_ty, b_ty) if a_is_scalar else (b_ty, a_ty)
         if scalar_ty.kind().value <= tensor_ty.kind().value:
@@ -1049,7 +1049,7 @@ def _load_block_pointer(ptr, mask, other, boundary_check, padding, cache, evicti
         raise ValueError("`mask` and `other` arguments cannot be specified for loading block pointers")
 
     elt_ty = ptr.type.element_ty.element_ty
-    assert elt_ty != tl.int1, "`tl.int1` should be rewrited in `tl.make_block_ptr`"
+    assert elt_ty != tl.int1, "`tl.int1` should be rewritten in `tl.make_block_ptr`"
     if elt_ty.is_int() and padding == ir.PADDING_OPTION.PAD_NAN:
         raise ValueError("Padding option `nan` is not supported for integer block pointers")
 
@@ -1213,7 +1213,7 @@ def _store_block_pointer(ptr, val, mask, boundary_check, cache, eviction, builde
     assert ptr.type.element_ty.element_ty == val.type.element_ty, f"Block element type({ptr.type.element_ty.element_ty}) and value element type({val.type.element_ty}) mismatch"
 
     elt_ty = ptr.type.element_ty.element_ty
-    assert elt_ty != tl.int1, "`tl.int1` should be rewrited in `tl.make_block_ptr`"
+    assert elt_ty != tl.int1, "`tl.int1` should be rewritten in `tl.make_block_ptr`"
 
     # Check `boundary_check` argument
     boundary_check = _canonicalize_boundary_check(boundary_check, block_shape)

--- a/test/TritonGPU/invalid-attributes.mlir
+++ b/test/TritonGPU/invalid-attributes.mlir
@@ -1,6 +1,6 @@
 // RUN: triton-opt %s -split-input-file -verify-diagnostics
 
-// expected-error@+2 {{ttg.dot_op opIdx paramenter can be 0 or 1, got: 2}}
+// expected-error@+2 {{ttg.dot_op opIdx parameter can be 0 or 1, got: 2}}
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #dot_op = #ttg.dot_op<{opIdx = 2, parent = #blocked, kWidth = 2}>
 

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -1543,7 +1543,7 @@ TEST_F(LinearLayoutConversionsTest, WMMA_v1_2x4Warps) {
   // For 128x128, we need 8x8 WMMA instances. Given that we have 2x4 warps, each
   // warp handles 4x2 instances. So for both the warp M and N dimension, we
   // distribute. The register dimension will handle (8 x 4x2 =) 64 values--those
-  // additonal base vectors after the intrinsic shape are next power of two
+  // additional base vectors after the intrinsic shape are next power of two
   // values following the warp dimension, given that we are tiling cyclically
   // among warps.
   EXPECT_EQ(toLinearLayout({128, 128}, legacy),

--- a/utils/generate-test-checks.py
+++ b/utils/generate-test-checks.py
@@ -261,8 +261,8 @@ def main():
     parser.add_argument(
         "--source",
         type=str,
-        help="Print each CHECK chunk before each delimeter line in the source"
-        "file, respectively. The delimeter lines are identified by "
+        help="Print each CHECK chunk before each delimiter line in the source"
+        "file, respectively. The delimiter lines are identified by "
         "--source_delim_regex.",
     )
     parser.add_argument("--source_delim_regex", type=str, default="func @")


### PR DESCRIPTION
```
codespell --ignore-words-list=ans,conver,destop,dout,interm,latops,nd,olt,repid,subtile,valu \
          --skip="./third_party/*,*.mlir,*.pdf"
```
https://pypi.org/project/codespell

`conver` should be removed from the `ignore-words-list` and the following line should be cleaned up:
https://github.com/triton-lang/triton/blob/25732f0a063f025a4eb6f01a2e0939ef43a8afc7/include/triton/Dialect/TritonGPU/Transforms/Passes.td#L122

Should codespell be added to pre-commit and/or GitHub Actions?

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not add a test but this could be easily added to pre-commit and/or GitHub Actions if desired.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
