### PR TITLE
Fix build with clang

### DIFF
--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -9,6 +9,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h"
+#include "llvm/Support/ErrorHandling.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -271,7 +272,7 @@ protected:
     case 4:
       return (ptxAsmBase + ".x4" + suffix).str();
     default:
-      assert(false && "Invalid vector size");
+      llvm_unreachable("Invalid vector size");
     }
   }
 


### PR DESCRIPTION
Trying to build main with clang per the readme currently hits 

`error: non-void function does not return a value in all control paths [-Werror,-Wreturn-type]`

Turning the assert into an llvm_unreachable fixes the error.