### PR TITLE
[Docs] add doc for `tl.assume`

### DIFF
--- a/docs/python-api/triton.language.rst
+++ b/docs/python-api/triton.language.rst
@@ -205,6 +205,7 @@ Compiler Hint Ops
     :toctree: generated
     :nosignatures:
 
+    assume
     debug_barrier
     max_constancy
     max_contiguous


### PR DESCRIPTION
add docs for `tl.assume` as described in title.
the relative code is in `python/triton/language/core.py`  line: 2435