### PR TITLE
Remove special handling of mmav3 -> dot load. Use ld.shared for lowering.

### DIFF
--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -864,6 +864,30 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 // -----
 
 #blocked0 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#shared0 = #ttg.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = true}>
+#mma0 = #ttg.nvidia_mma<{versionMajor = 2, warpsPerCTA = [1, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1], instrShape = [16, 8]}>
+#dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#mma0, kWidth=2}>
+#dot_operand_b = #ttg.dot_op<{opIdx=1, parent=#mma0, kWidth=2}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  // CHECK-LABEL: convert_dot_mmav3_shared
+  tt.func @convert_dot_mmav3_shared(%A: tensor<64x64xf16, #blocked0>, %B: tensor<64x64xf16, #blocked0>) {
+    %AA = ttg.local_alloc %A : (tensor<64x64xf16, #blocked0>) -> !ttg.memdesc<64x64xf16, #shared0, #smem>
+    %BB = ttg.local_alloc %B : (tensor<64x64xf16, #blocked0>) -> !ttg.memdesc<64x64xf16, #shared0, #smem>
+    // CHECK-NOT: nvgpu.ldmatrix
+    %AA_DOT = ttg.local_load %AA : !ttg.memdesc<64x64xf16, #shared0, #smem> -> tensor<64x64xf16, #dot_operand_a>
+    %BB_DOT = ttg.local_load %BB : !ttg.memdesc<64x64xf16, #shared0, #smem> -> tensor<64x64xf16, #dot_operand_b>
+    %cst0 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma0>
+
+    %D = tt.dot %AA_DOT, %BB_DOT, %cst0 : tensor<64x64xf16, #dot_operand_a> * tensor<64x64xf16, #dot_operand_b> -> tensor<64x64xf32, #mma0>
+
+    tt.return
+  }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 #shared0 = #ttg.shared<{vec = 1, perPhase=2, maxPhase=8, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 #mma0 = #ttg.nvidia_mma<{versionMajor = 2, warpsPerCTA = [1, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1], instrShape = [16, 8]}>
 #dot_operand_a = #ttg.dot_op<{opIdx=0, parent=#mma0, kWidth=4}>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -21,63 +21,12 @@ using namespace mlir;
 using namespace triton;
 using namespace triton::gpu;
 
-// Loading from Hopper shared memory layout to dot operand is not supported. We
-// need to break it down and use a different shared layout. This would mostly
-// happen when TMAs are used with MMAV2 and will cause poor performance.
-class DecomposeLocalLoadToDotOperand
-    : public OpRewritePattern<triton::gpu::LocalLoadOp> {
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(triton::gpu::LocalLoadOp op,
-                                PatternRewriter &rewriter) const override {
-
-    auto dstDotOp = dyn_cast<triton::gpu::DotOperandEncodingAttr>(
-        op.getType().getEncoding());
-    MemDescType srcType = op.getSrc().getType();
-    auto sharedEncoding = cast<SharedEncodingAttr>(srcType.getEncoding());
-    if (!dstDotOp || !sharedEncoding.getHasLeadingOffset())
-      return failure();
-    RankedTensorType type = op.getType();
-    auto parentEnc = dstDotOp.getParent();
-    int numWarps = triton::gpu::getNumWarpsPerCTA(parentEnc);
-    int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(
-        op->getParentOfType<ModuleOp>());
-    int numCTAs = triton::gpu::getNumCTAs(parentEnc);
-    auto blockEncoding = getDefaultBlockedEncoding(
-        op.getContext(), type.getShape(), numWarps, threadsPerWarp, numCTAs);
-    auto tmpType = RankedTensorType::get(type.getShape(), type.getElementType(),
-                                         blockEncoding);
-    Value load =
-        rewriter.create<LocalLoadOp>(op.getLoc(), tmpType, op.getSrc());
-    auto newSharedDescTy = MemDescType::get(
-        type.getShape(), type.getElementType(),
-        triton::gpu::SharedEncodingAttr::get(
-            op.getContext(), dstDotOp, type.getShape(),
-            triton::gpu::getOrder(parentEnc),
-            triton::gpu::getCTALayout(parentEnc), type.getElementType()),
-        srcType.getMemorySpace());
-    auto tmp = rewriter.create<triton::gpu::LocalAllocOp>(
-        op.getLoc(), newSharedDescTy, load);
-    auto newConvert =
-        rewriter.create<triton::gpu::LocalLoadOp>(op.getLoc(), type, tmp);
-    rewriter.replaceOp(op, newConvert);
-    return success();
-  }
-};
-
 struct DecomposeUnsupportedConversions
     : public mlir::triton::impl::DecomposeUnsupportedNVIDIAConversionsBase<
           DecomposeUnsupportedConversions> {
   void runOnOperation() override {
     ModuleOp mod = getOperation();
     triton::gpu::decomposeBlockedToDotLayoutConversion(mod);
-
-    mlir::RewritePatternSet patterns(&getContext());
-    patterns.add<DecomposeLocalLoadToDotOperand>(&getContext());
-    if (mlir::applyPatternsAndFoldGreedily(mod, std::move(patterns)).failed()) {
-      signalPassFailure();
-    }
   }
 };
 } // namespace

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -60,6 +60,7 @@ public:
       canUseLdmatrix &=
           srcTy.getShape()[0] >= 8 &&
           srcTy.getShape()[1] >= 4 * kWidth & dstTy.getRank() <= 2;
+      canUseLdmatrix &= (!shared.getHasLeadingOffset());
       if (canUseLdmatrix) {
         return lowerSharedToDotOperand(op, adaptor, getTypeConverter(),
                                        rewriter);


### PR DESCRIPTION
Get rid of special pattern that was handling previously unsupported load lowering from mmav3 shared layout to dot operand layout.
Fix lowering, so it won't go down unsupported ldmatrix path, until we add support for ldmatrix with mmav3.