### PR TITLE
[AMD] Added support for multiple `tt.DotOps` in a `scf::ForOp` region

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -67,6 +67,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUCanonicalizePointers();
   mlir::registerTritonAMDGPUConvertToBufferOps();
   mlir::triton::registerTritonAMDGPUInsertInstructionSchedHints();
+  mlir::triton::registerTritonAMDGPUInsertInstructionSchedGuards();
   mlir::triton::registerTritonAMDGPULowerInstructionSchedHints();
 
   // TODO: register Triton & TritonGPU passes

--- a/include/triton/Dialect/Triton/IR/Traits.h
+++ b/include/triton/Dialect/Triton/IR/Traits.h
@@ -104,6 +104,12 @@ public:
   }
 };
 
+template <class ConcreteType>
+class TritonMetaDataOp : public TraitBase<ConcreteType, TritonMetaDataOp> {
+public:
+  static LogicalResult verifyTrait(Operation *op) { return success(); }
+};
+
 template <typename ConcreteType>
 class SameOperandsAndResultEncoding
     : public TraitBase<ConcreteType, SameOperandsAndResultEncoding> {

--- a/include/triton/Dialect/Triton/IR/TritonInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonInterfaces.td
@@ -12,5 +12,6 @@ def SameLoadStoreOperandsShape : NativeOpTrait<"SameLoadStoreOperandsShape">;
 def SameLoadStoreOperandsAndResultShape : NativeOpTrait<"SameLoadStoreOperandsAndResultShape">;
 def SameLoadStoreOperandsEncoding : NativeOpTrait<"SameLoadStoreOperandsEncoding">;
 def SameLoadStoreOperandsAndResultEncoding : NativeOpTrait<"SameLoadStoreOperandsAndResultEncoding">;
+def TritonMetaDataOp : NativeOpTrait<"TritonMetaDataOp">;
 
 #endif // TRITON_INTERFACES

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -102,10 +102,12 @@ struct CanonicalizeMaskedLoadPattern : public OpRewritePattern<LoadOp> {
 
     if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
       // mask = splat(1)
-      rewriter.replaceOpWithNewOp<LoadOp>(
+      DictionaryAttr notPropertiesAttrs = loadOp->getRawDictionaryAttrs();
+      auto newLoadOp = rewriter.replaceOpWithNewOp<LoadOp>(
           loadOp, loadOp.getType(), loadOp.getPtr(), Value(), Value(),
           loadOp.getBoundaryCheckAttr(), loadOp.getPaddingAttr(),
           loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
+      newLoadOp->setAttrs(notPropertiesAttrs);
     } else {
       // mask = splat(0)
 

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -225,9 +225,10 @@ struct CanonicalizeConvertFromConvert
       // We insert at the point of the original op as there could be ops with
       // memory side-effects between the LocalLoad op and the ConvertLayout op
       rewriter.setInsertionPoint(arg);
-      rewriter.replaceOpWithNewOp<LocalLoadOp>(op, op->getResult(0).getType(),
-                                               sharedLoad.getSrc());
-
+      auto attrs = sharedLoad->getAttrDictionary();
+      auto newSharedLoad = rewriter.replaceOpWithNewOp<LocalLoadOp>(
+          op, op->getResult(0).getType(), sharedLoad.getSrc());
+      newSharedLoad->setAttrs(attrs);
       return success();
     }
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -49,6 +49,9 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
   OpBuilder::InsertionGuard guard(rewriter);
   if (mlir::isMemoryEffectFree(op))
     return op;
+  if (op->hasTrait<OpTrait::TritonMetaDataOp>())
+    return op;
+
   if (isa<ttg::AsyncCommitGroupOp, ttg::AsyncWaitOp>(op))
     return op;
   if (isa<ttg::LocalLoadOp, ttg::LocalStoreOp>(op))

--- a/test/TritonGPU/amd/amd-instruction-sched.mlir
+++ b/test/TritonGPU/amd/amd-instruction-sched.mlir
@@ -1,10 +1,9 @@
 // RUN: triton-opt %s -split-input-file -triton-amdgpu-insert-instruction-sched-hints -triton-amdgpu-lower-insert-instruction-sched-hints='variant=llvm_iglp_0' -verify-diagnostics | FileCheck %s -check-prefix=INSERT_IGLP0
 // RUN: triton-opt %s -split-input-file -triton-amdgpu-insert-instruction-sched-hints -triton-amdgpu-lower-insert-instruction-sched-hints='variant=llvm_iglp_1' -verify-diagnostics | FileCheck %s -check-prefix=INSERT_IGLP1
-// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=hip:gfx942 num-ctas=1 num-warps=4 threads-per-warp=64' -tritongpu-coalesce -tritonamdgpu-accelerate-matmul='arch-generation-name=gfx942 matrix-instruction-size=32 kPack=1' -tritongpu-remove-layout-conversions -tritonamdgpu-stream-pipeline='num_stages=1' -triton-amdgpu-insert-instruction-sched-hints -decompose-unsupported-amd-conversions   -optimize-amd-lds-usage='target-arch=gfx942' -convert-scf-to-cf -convert-index-to-llvm -allocate-shared-memory -convert-triton-amdgpu-to-llvm='arch=gfx942' -verify-diagnostics | FileCheck %s -check-prefix=INSTR_COUNT_NS1
-// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=hip:gfx942 num-ctas=1 num-warps=4 threads-per-warp=64' -tritongpu-coalesce -tritonamdgpu-accelerate-matmul='arch-generation-name=gfx942 matrix-instruction-size=32 kPack=1' -tritongpu-remove-layout-conversions -tritonamdgpu-stream-pipeline='num_stages=2' -triton-amdgpu-insert-instruction-sched-hints -decompose-unsupported-amd-conversions   -optimize-amd-lds-usage='target-arch=gfx942' -convert-scf-to-cf -convert-index-to-llvm -allocate-shared-memory -convert-triton-amdgpu-to-llvm='arch=gfx942' -verify-diagnostics | FileCheck %s -check-prefix=INSTR_COUNT_NS2
-// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=hip:gfx942 num-ctas=1 num-warps=4 threads-per-warp=64' -tritongpu-coalesce -tritonamdgpu-accelerate-matmul='arch-generation-name=gfx942 matrix-instruction-size=16 kPack=1' -tritongpu-remove-layout-conversions -tritonamdgpu-stream-pipeline='num_stages=2' -triton-amdgpu-insert-instruction-sched-hints -decompose-unsupported-amd-conversions   -optimize-amd-lds-usage='target-arch=gfx942' -convert-scf-to-cf -convert-index-to-llvm -allocate-shared-memory -convert-triton-amdgpu-to-llvm='arch=gfx942' -triton-amdgpu-lower-insert-instruction-sched-hints='variant=local_prefetch arch=gfx942 num_stages=2' -debug-only='lower-insert-instruction-sched-hints' -verify-diagnostics 2>&1 | FileCheck %s -check-prefix=USE_LOCAL_PREFETCH_GLOBAL_LOAD
-// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=hip:gfx942 num-ctas=1 num-warps=4 threads-per-warp=64' -tritongpu-coalesce -tritongpu-remove-layout-conversions -tritonamdgpu-stream-pipeline='num_stages=1' | FileCheck %s -check-prefix=LABELING_PS_1
-// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=hip:gfx942 num-ctas=1 num-warps=4 threads-per-warp=64' -tritongpu-coalesce -tritongpu-remove-layout-conversions -tritonamdgpu-stream-pipeline='num_stages=2' | FileCheck %s -check-prefix=LABELING_PS_2
+// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=hip:gfx942 num-ctas=1 num-warps=4 threads-per-warp=64' -tritongpu-coalesce -tritonamdgpu-accelerate-matmul='arch-generation-name=gfx942 matrix-instruction-size=32 kPack=1' -tritongpu-remove-layout-conversions -triton-amdgpu-insert-instruction-sched-hints -tritonamdgpu-stream-pipeline='num_stages=2' -triton-amdgpu-insert-instruction-sched-guards -canonicalize -decompose-unsupported-amd-conversions -optimize-amd-lds-usage='target-arch=gfx942' -convert-scf-to-cf -convert-index-to-llvm -allocate-shared-memory -convert-triton-amdgpu-to-llvm='arch=gfx942' -verify-diagnostics | FileCheck %s -check-prefix=INSTR_COUNT_NS2
+// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=hip:gfx942 num-ctas=1 num-warps=4 threads-per-warp=64' -tritongpu-coalesce -tritonamdgpu-accelerate-matmul='arch-generation-name=gfx942 matrix-instruction-size=16 kPack=1' -tritongpu-remove-layout-conversions -triton-amdgpu-insert-instruction-sched-hints -tritonamdgpu-stream-pipeline='num_stages=2' -triton-amdgpu-insert-instruction-sched-guards -canonicalize -decompose-unsupported-amd-conversions -optimize-amd-lds-usage='target-arch=gfx942' -convert-scf-to-cf -convert-index-to-llvm -allocate-shared-memory -convert-triton-amdgpu-to-llvm='arch=gfx942' -triton-amdgpu-lower-insert-instruction-sched-hints='variant=local_prefetch arch=gfx942 num_stages=2' -debug-only='lower-insert-instruction-sched-hints' -verify-diagnostics 2>&1 | FileCheck %s -check-prefix=USE_LOCAL_PREFETCH_GLOBAL_LOAD
+// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=hip:gfx942 num-ctas=1 num-warps=4 threads-per-warp=64' -tritongpu-coalesce -tritongpu-remove-layout-conversions -triton-amdgpu-insert-instruction-sched-hints -tritonamdgpu-stream-pipeline='num_stages=1' | FileCheck %s -check-prefix=LABELING_PS_1
+// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=hip:gfx942 num-ctas=1 num-warps=4 threads-per-warp=64' -tritongpu-coalesce -tritongpu-remove-layout-conversions -triton-amdgpu-insert-instruction-sched-hints -tritonamdgpu-stream-pipeline='num_stages=2' | FileCheck %s -check-prefix=LABELING_PS_2
 
 module {
   // INSERT_IGLP0-LABEL: @test_dot_op
@@ -48,6 +47,7 @@ module {
     // INSERT_IGLP1: rocdl.iglp.opt 1
 
     // INSTR_COUNT_NS1: amdgpu.instruction_sched_hint
+    // INSTR_COUNT_NS1: SchedRegionIdx = #amdgpu.SchedRegionIdx<0>
     // INSTR_COUNT_NS1-SAME: isBufferLoadsAEnabled = false
     // INSTR_COUNT_NS1-SAME: isBufferLoadsBEnabled = false
     // INSTR_COUNT_NS1-SAME: numDsReadsA = #amdgpu.InstCounter<8, vector<4xf16>>
@@ -59,6 +59,7 @@ module {
     // INSTR_COUNT_NS1-SAME: numMMAs = #amdgpu.InstCounter<16, tensor<32x32x8xf16>>
 
     // INSTR_COUNT_NS2: amdgpu.instruction_sched_hint
+    // INSTR_COUNT_NS2: SchedRegionIdx = #amdgpu.SchedRegionIdx<0>
     // INSTR_COUNT_NS2-SAME: isBufferLoadsAEnabled = false
     // INSTR_COUNT_NS2-SAME: isBufferLoadsBEnabled = false
     // INSTR_COUNT_NS2-SAME: numDsReadsA = #amdgpu.InstCounter<8, vector<4xf16>>
@@ -138,17 +139,17 @@ module {
 
 
     // LABELING_PS_1: scf.for
-    // LABELING_PS_1: %[[REG0_OP0:.+]] = tt.load {{.*}} {OpIdx = #amdgpu.OpIdx<0>}
-    // LABELING_PS_1: %[[REG0_OP1:.+]] = tt.load {{.*}} {OpIdx = #amdgpu.OpIdx<1>}
+    // LABELING_PS_1: %[[REG0_OP0:.+]] = tt.load {{.*}} {OpIdx = #amdgpu.OpIdx<0>, SchedRegionIdx = #amdgpu.SchedRegionIdx<0>}
+    // LABELING_PS_1: %[[REG0_OP1:.+]] = tt.load {{.*}} {OpIdx = #amdgpu.OpIdx<1>, SchedRegionIdx = #amdgpu.SchedRegionIdx<0>}
     // LABELING_PS_1: %[[REG1_OP0:.+]] = ttg.convert_layout %[[REG0_OP0]]
     // LABELING_PS_1: %[[REG1_OP1:.+]] = ttg.convert_layout %[[REG0_OP1]]
     // LABELING_PS_1: tt.dot %[[REG1_OP0]], %[[REG1_OP1]], {{.*}}
 
     // LABELING_PS_2: scf.for
-    // LABELING_PS_2: %[[REG0_OP0:.+]] = tt.load {{.*}} {OpIdx = #amdgpu.OpIdx<0>}
-    // LABELING_PS_2: %[[REG0_OP1:.+]] = tt.load {{.*}} {OpIdx = #amdgpu.OpIdx<1>}
-    // LABELING_PS_2: ttg.local_store %[[REG0_OP0]], %{{.*}} {OpIdx = #amdgpu.OpIdx<0>}
-    // LABELING_PS_2: ttg.local_store %[[REG0_OP1]], %{{.*}} {OpIdx = #amdgpu.OpIdx<1>}
+    // LABELING_PS_2: %[[REG0_OP0:.+]] = tt.load {{.*}} {OpIdx = #amdgpu.OpIdx<0>, SchedRegionIdx = #amdgpu.SchedRegionIdx<0>}
+    // LABELING_PS_2: %[[REG0_OP1:.+]] = tt.load {{.*}} {OpIdx = #amdgpu.OpIdx<1>, SchedRegionIdx = #amdgpu.SchedRegionIdx<0>}
+    // LABELING_PS_2: ttg.local_store %[[REG0_OP0]], %{{.*}} {OpIdx = #amdgpu.OpIdx<0>, SchedRegionIdx = #amdgpu.SchedRegionIdx<0>}
+    // LABELING_PS_2: ttg.local_store %[[REG0_OP1]], %{{.*}} {OpIdx = #amdgpu.OpIdx<1>, SchedRegionIdx = #amdgpu.SchedRegionIdx<0>}
 
     %c = tt.dot %a, %b, %prev_c : tensor<128x32xf16> * tensor<32x128xf16> -> tensor<128x128xf32>
     %next_a_ptr = tt.addptr %a_ptr, %a_off : tensor<128x32x!tt.ptr<f16>>, tensor<128x32xi32>

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h
@@ -29,7 +29,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/PatternMatch.h"
-#include "triton/Dialect/Triton/IR/Traits.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 
 // clang-format off
 #include "amd/include/Dialect/TritonAMDGPU/IR/Dialect.h.inc"

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUAttrDefs.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUAttrDefs.td
@@ -46,6 +46,18 @@ def TritonAMDGPU_OpIdxAttr : TritonAMDGPU_Attr<"OpIdx"> {
   let assemblyFormat = "`<` $value `>`";
 }
 
+def TritonAMDGPU_SchedRegionIdxAttr : TritonAMDGPU_Attr<"SchedRegionIdx"> {
+  let cppNamespace = "::mlir::triton::amdgpu";
+  let mnemonic = "SchedRegionIdx";
+  let summary = "A scheduling region index attribute.";
+  let description = [{
+    The attribute is a way to describe a scheduling region.
+  }];
+
+  let parameters = (ins "uint32_t":$value);
+  let assemblyFormat = "`<` $value `>`";
+}
+
 def TritonAMDGPU_InstCounter : TritonAMDGPU_Attr<"InstCounter"> {
   let cppNamespace = "::mlir::triton::amdgpu";
   let mnemonic = "InstCounter";
@@ -74,13 +86,17 @@ class TritonAMDGPU_I32EnumAttr<string mnemonic, TritonAMDGPU_I32Enum enumInfo> :
 def SchedHintCaseNone : I32EnumAttrCase<"none", 0>;
 def SchedHintCaseLLVMIglp0 : I32EnumAttrCase<"llvm_iglp_0", 1>;
 def SchedHintCaseLLVMIglp1 : I32EnumAttrCase<"llvm_iglp_1", 2>;
-def SchedHintCaseLocalPrefetch : I32EnumAttrCase<"local_prefetch", 3>;
+def SchedHintCaseLLVMIglp2 : I32EnumAttrCase<"llvm_iglp_2", 3>;
+def SchedHintCaseLLVMIglp3 : I32EnumAttrCase<"llvm_iglp_3", 4>;
+def SchedHintCaseLocalPrefetch : I32EnumAttrCase<"local_prefetch", 5>;
 
 def TritonAMDGPU_SchedHintsEnum : TritonAMDGPU_I32Enum<
   "SchedHint", "Instruction Scheduling Hints for AMD GPUs", [
     SchedHintCaseNone,
     SchedHintCaseLLVMIglp0,
     SchedHintCaseLLVMIglp1,
+    SchedHintCaseLLVMIglp2,
+    SchedHintCaseLLVMIglp3,
     SchedHintCaseLocalPrefetch,
   ]>;
 

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -114,7 +114,7 @@ def ExtractSliceOp
   let hasVerifier = 1;
 }
 
-def InstructionSchedHint : TT_AMDGPU_Op<"instruction_sched_hint", []> {
+def InstructionSchedHint : TT_AMDGPU_Op<"instruction_sched_hint", [TritonMetaDataOp]> {
   let summary = "A placeholder op for instruction scheduling hints within a basic block";
   let description = [{
     A placeholder op for instruction scheduling hints applied to instructions within

--- a/third_party/amd/include/Dialect/TritonAMDGPU/utility/CommonUtils.h
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/utility/CommonUtils.h
@@ -1,0 +1,11 @@
+#ifndef TRITON_THIRD_PARTY_AMD_INCLUDE_DIALECT_TRITONAMDGPU_UTILITY_COMMONUTILS_H_
+#define TRITON_THIRD_PARTY_AMD_INCLUDE_DIALECT_TRITONAMDGPU_UTILITY_COMMONUTILS_H_
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir::triton::AMD {
+SmallVector<scf::ForOp> getLeafForOps(triton::FuncOp funcOp);
+} // namespace mlir::triton::AMD
+
+#endif // TRITON_THIRD_PARTY_AMD_INCLUDE_DIALECT_TRITONAMDGPU_UTILITY_COMMONUTILS_H_

--- a/third_party/amd/include/TritonAMDGPUToLLVM/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/Passes.h
@@ -44,6 +44,8 @@ createConvertBuiltinFuncToLLVMPass(bool ftz);
 std::unique_ptr<OperationPass<ModuleOp>>
 createTritonAMDGPUInsertInstructionSchedHintsPass();
 std::unique_ptr<OperationPass<ModuleOp>>
+createTritonAMDGPUInsertInstructionSchedGuardsPass();
+std::unique_ptr<OperationPass<ModuleOp>>
 createTritonAMDGPULowerInstructionSchedHintsPass(StringRef arch,
                                                  int32_t numStages,
                                                  StringRef variant);

--- a/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
@@ -66,6 +66,15 @@ def TritonAMDGPUInsertInstructionSchedHints : Pass<"triton-amdgpu-insert-instruc
                              "mlir::triton::amdgpu::TritonAMDGPUDialect"];
 }
 
+def TritonAMDGPUInsertInstructionSchedGuards : Pass<"triton-amdgpu-insert-instruction-sched-guards", "mlir::ModuleOp"> {
+    let summary = "Insert instruction scheduling guards after the dot ops in the main loop";
+    let constructor = "mlir::triton::createTritonAMDGPUInsertInstructionSchedGuardsPass()";
+
+    let dependentDialects = ["mlir::LLVM::LLVMDialect",
+                             "mlir::ROCDL::ROCDLDialect",
+                             "mlir::triton::amdgpu::TritonAMDGPUDialect"];
+}
+
 def TritonAMDGPULowerInstructionSchedHints : Pass<"triton-amdgpu-lower-insert-instruction-sched-hints", "mlir::ModuleOp"> {
     let summary = "Lower instruction scheduling hints to LLVM intrinsics";
     let constructor = "mlir::triton::createTritonAMDGPULowerInstructionSchedHintsPass(/*arch=*/\"\",/*numStages=*/2, /*variant=*/\"\")";

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/CMakeLists.txt
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(utility)

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/utility/CMakeLists.txt
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/utility/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_triton_library(TritonAMDUtils
+  CommonUtils.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRLLVMDialect
+  TritonIR
+  TritonGPUIR
+)

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/utility/CommonUtils.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/utility/CommonUtils.cpp
@@ -1,0 +1,17 @@
+#include "third_party/amd/include/Dialect/TritonAMDGPU/utility/CommonUtils.h"
+
+namespace mlir::triton::AMD {
+SmallVector<scf::ForOp> getLeafForOps(triton::FuncOp funcOp) {
+  SmallVector<scf::ForOp> allOps;
+  funcOp->walk([&](scf::ForOp forOp) { allOps.push_back(forOp); });
+
+  SmallVector<scf::ForOp> leafOps;
+  for (scf::ForOp forOp : allOps) {
+    auto searchResult = forOp.getBody()->walk(
+        [](scf::ForOp) { return WalkResult::interrupt(); });
+    if (!searchResult.wasInterrupted())
+      leafOps.push_back(forOp);
+  }
+  return leafOps;
+}
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
@@ -30,4 +30,5 @@ add_triton_library(TritonAMDGPUToLLVM
     TritonGPUToLLVM
     TritonAMDGPUIR
     TritonProtonToLLVM
+    TritonAMDUtils
 )

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
@@ -5,10 +5,12 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Pass/Pass.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/utility/CommonUtils.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
 namespace mlir::triton {
 #define GEN_PASS_DEF_TRITONAMDGPUINSERTINSTRUCTIONSCHEDHINTS
+#define GEN_PASS_DEF_TRITONAMDGPUINSERTINSTRUCTIONSCHEDGUARDS
 #define GEN_PASS_DEF_TRITONAMDGPULOWERINSTRUCTIONSCHEDHINTS
 #include "TritonAMDGPUToLLVM/Passes.h.inc"
 } // namespace mlir::triton
@@ -19,6 +21,7 @@ namespace mlir::triton {
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 using namespace mlir;
+using namespace triton::amdgpu;
 
 // TODO: The following passes/algorithms are applicable only for a single
 // `tt.dot` op in a `scf.for` block -i.e., a single schedule hint op per block.
@@ -26,14 +29,27 @@ using namespace mlir;
 // implementation.
 
 namespace mlir::triton {
-void setNumGeneratedMMAs(DotOp op, size_t mmaCount, unsigned m, unsigned n,
-                         unsigned k, Type elementType) {
-  auto *ctx = op->getContext();
-  auto mmaType = RankedTensorType::get({m, n, k}, elementType);
-  auto counterAttr =
-      triton::amdgpu::InstCounterAttr::get(ctx, mmaCount, mmaType);
+bool isSameSchedRegion(Operation *op0, Operation *op1) {
+  auto regionIdxOp0 =
+      op0->getAttrOfType<SchedRegionIdxAttr>(SchedRegionIdxAttr::getMnemonic());
 
-  op->getBlock()->walk([&](triton::amdgpu::InstructionSchedHint schedHint) {
+  auto regionIdxOp1 =
+      op1->getAttrOfType<SchedRegionIdxAttr>(SchedRegionIdxAttr::getMnemonic());
+
+  if (regionIdxOp0 && regionIdxOp1)
+    return regionIdxOp0.getValue() == regionIdxOp1.getValue();
+  return false;
+}
+
+void setNumGeneratedMMAs(DotOp dotOp, size_t mmaCount, unsigned m, unsigned n,
+                         unsigned k, Type elementType) {
+  auto *ctx = dotOp->getContext();
+  auto mmaType = RankedTensorType::get({m, n, k}, elementType);
+  auto counterAttr = InstCounterAttr::get(ctx, mmaCount, mmaType);
+
+  dotOp->getBlock()->walk([&](InstructionSchedHint schedHint) {
+    if (!isSameSchedRegion(dotOp, schedHint))
+      return;
     schedHint.setNumMMAsAttr(counterAttr);
   });
 }
@@ -42,15 +58,16 @@ template <typename LoadOpType>
 void setNumGeneratedGlobalLoads(LoadOpType op, size_t globalLoadsCount,
                                 Type type) {
   MLIRContext *ctx = op->getContext();
-  auto counterAttr =
-      triton::amdgpu::InstCounterAttr::get(ctx, globalLoadsCount, type);
+  auto counterAttr = InstCounterAttr::get(ctx, globalLoadsCount, type);
 
-  op->getBlock()->walk([&](triton::amdgpu::InstructionSchedHint schedHint) {
-    if (auto opIdxAttr = op->template getAttrOfType<triton::amdgpu::OpIdxAttr>(
-            triton::amdgpu::OpIdxAttr::getMnemonic())) {
+  op->getBlock()->walk([&](InstructionSchedHint schedHint) {
+    if (!isSameSchedRegion(op, schedHint))
+      return;
+
+    if (auto opIdxAttr =
+            op->template getAttrOfType<OpIdxAttr>(OpIdxAttr::getMnemonic())) {
       assert(opIdxAttr.getValue() < 2);
-      const bool isBufferLoadOp =
-          std::is_same_v<LoadOpType, triton::amdgpu::BufferLoadOp>;
+      const bool isBufferLoadOp = std::is_same_v<LoadOpType, BufferLoadOp>;
       if (opIdxAttr.getValue() == 0) {
         schedHint.setNumGlobalLoadsAAttr(counterAttr);
         schedHint.setIsBufferLoadsAEnabled(isBufferLoadOp);
@@ -61,7 +78,7 @@ void setNumGeneratedGlobalLoads(LoadOpType op, size_t globalLoadsCount,
     }
   });
 }
-template void setNumGeneratedGlobalLoads(triton::amdgpu::BufferLoadOp op,
+template void setNumGeneratedGlobalLoads(BufferLoadOp op,
                                          size_t globalLoadsCount, Type type);
 template void setNumGeneratedGlobalLoads(triton::LoadOp op,
                                          size_t globalLoadsCount, Type type);
@@ -69,10 +86,12 @@ template void setNumGeneratedGlobalLoads(triton::LoadOp op,
 void setNumGeneratedDsReads(gpu::LocalLoadOp op, size_t dsReadsCount,
                             Type type) {
   auto *ctx = op->getContext();
-  auto counterAttr =
-      triton::amdgpu::InstCounterAttr::get(ctx, dsReadsCount, type);
+  auto counterAttr = InstCounterAttr::get(ctx, dsReadsCount, type);
 
-  op->getBlock()->walk([&](triton::amdgpu::InstructionSchedHint schedHint) {
+  op->getBlock()->walk([&](InstructionSchedHint schedHint) {
+    if (!isSameSchedRegion(op, schedHint))
+      return;
+
     Value dst = op.getResult();
     auto dstTensorTy = cast<RankedTensorType>(dst.getType());
     auto dotOperandLayout =
@@ -89,12 +108,13 @@ void setNumGeneratedDsReads(gpu::LocalLoadOp op, size_t dsReadsCount,
 void storeOpConversionCallback(triton::gpu::LocalStoreOp op,
                                size_t localStoreOpCount, Type type) {
   MLIRContext *ctx = op->getContext();
-  auto counterAttr =
-      triton::amdgpu::InstCounterAttr::get(ctx, localStoreOpCount, type);
+  auto counterAttr = InstCounterAttr::get(ctx, localStoreOpCount, type);
 
-  op->getBlock()->walk([&](triton::amdgpu::InstructionSchedHint schedHint) {
-    if (auto opIdxAttr = op->getAttrOfType<triton::amdgpu::OpIdxAttr>(
-            triton::amdgpu::OpIdxAttr::getMnemonic())) {
+  op->getBlock()->walk([&](InstructionSchedHint schedHint) {
+    if (!isSameSchedRegion(op, schedHint))
+      return;
+    if (auto opIdxAttr =
+            op->getAttrOfType<OpIdxAttr>(OpIdxAttr::getMnemonic())) {
       assert(opIdxAttr.getValue() < 2);
       if (opIdxAttr.getValue() == 0)
         schedHint.setNumDsWritesAAttr(counterAttr);
@@ -145,7 +165,7 @@ namespace {
 
 // Create an intrinsic to control how different instruction kinds should
 // interleave for better ILP.
-void createSchedGroupBarrier(PatternRewriter &rewriter, Location loc,
+void createSchedGroupBarrier(OpBuilder &rewriter, Location loc,
                              mlir::amdgpu::sched_barrier_opt_enum maskValue,
                              int sizeValue, int groupIdValue) {
   if (sizeValue < 1)
@@ -161,7 +181,7 @@ void createSchedGroupBarrier(PatternRewriter &rewriter, Location loc,
 
 // Insert intrinsic that controls the types of instructions that may be
 // allowed to cross the intrinsic during instruction scheduling.
-Operation *createSchedBarrier(PatternRewriter &rewriter, Location loc,
+Operation *createSchedBarrier(OpBuilder &rewriter, Location loc,
                               mlir::amdgpu::sched_barrier_opt_enum maskValue) {
   IntegerAttr mask =
       rewriter.getI32IntegerAttr(static_cast<int32_t>(maskValue));
@@ -170,7 +190,7 @@ Operation *createSchedBarrier(PatternRewriter &rewriter, Location loc,
 
 // Insert an experimental intrinsic for instruction group level parallelism.
 // The intrinsic takes a value that specifies the strategy.
-Operation *createIglpOpt(PatternRewriter &rewriter, Location loc, int value) {
+Operation *createIglpOpt(OpBuilder &rewriter, Location loc, int value) {
   IntegerAttr iglpValue =
       rewriter.getI32IntegerAttr(static_cast<int32_t>(value));
   return rewriter.create<ROCDL::IglpOpt>(loc, iglpValue);
@@ -238,238 +258,124 @@ std::unique_ptr<MachineDescr> MachineDescr::get(StringRef arch) {
   return nullptr;
 }
 
-struct InstructionSchedHintsRewriter
-    : public OpRewritePattern<triton::amdgpu::InstructionSchedHint> {
+// The following is inspired by ROCm Composable Kernel library's V3 pipelining
+// (see ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops_v3.hpp).
+// This scheduling requires 1x register and 1x LDS buffers combined with the
+// local (LDS to registers) and global (HBM to registers) data prefetching.
+void createLocalPrefetchSchedule(OpBuilder &rewriter, Location loc,
+                                 InstructionSchedHint schedHint,
+                                 std::unique_ptr<MachineDescr> &machineDescr) {
 
-  InstructionSchedHintsRewriter(MLIRContext *ctx, StringRef arch,
-                                int32_t numStages, std::string variant)
-      : OpRewritePattern(ctx), numStages(numStages) {
-
-    this->machineDescr = MachineDescr::get(arch);
-
-    this->schedHint = mlir::triton::amdgpu::SchedHint::none;
-    if (this->numStages < 2) {
-      LDBG("ignoring instruction scheduling due to a very low num. "
-           "stages value. Must be >= 2");
-      return;
-    }
-
-    std::transform(variant.begin(), variant.end(), variant.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
-    if (auto maybeSchedHint = triton::amdgpu::symbolizeSchedHint(variant))
-      this->schedHint = maybeSchedHint.value();
-    else
-      LDBG("ignoring instruction scheduling because "
-           "unknown instruction scheduling variant has been provided");
+  if (!machineDescr) {
+    schedHint.emitError("unknown target architecture detected");
+    return;
   }
 
-  // The following is inspired by ROCm Composable Kernel library's V3 pipelining
-  // (see ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops_v3.hpp).
-  // This scheduling requires 1x register and 1x LDS buffers combined with the
-  // local (LDS to registers) and global (HBM to registers) data prefetching.
-  void createLocalPrefetchSchedule(
-      PatternRewriter &rewriter, Location loc,
-      triton::amdgpu::InstructionSchedHint schedHint) const {
+  const uint32_t numDsReadInstA = schedHint.getNumDsReadsA().getValue();
+  const uint32_t numDsReadInstB = schedHint.getNumDsReadsB().getValue();
+  const uint32_t numDsWriteInstA = schedHint.getNumDsWritesA().getValue();
+  const uint32_t numDsWriteInstB = schedHint.getNumDsWritesB().getValue();
+  const uint32_t numBufferLoadInstA = schedHint.getNumGlobalLoadsA().getValue();
+  const uint32_t numBufferLoadInstB = schedHint.getNumGlobalLoadsB().getValue();
+  if (numBufferLoadInstA == 0) {
+    schedHint.emitError("buffer load count for tile A must be initialized");
+    return;
+  }
+  if (numBufferLoadInstB == 0) {
+    schedHint.emitError("buffer load count for tile B must be initialized");
+    return;
+  }
+  const uint32_t numMmaInst = schedHint.getNumMMAs().getValue();
+  auto mmaType = cast<RankedTensorType>(schedHint.getNumMMAs().getType());
+  auto maybeMmaExecCycle = machineDescr->getMmaExecCycle(mmaType.getShape());
+  if (llvm::failed(maybeMmaExecCycle)) {
+    schedHint.emitError("unknown mma instruction type");
+    return;
+  }
+  const uint32_t mmaExecCycle = maybeMmaExecCycle.value();
+  auto dsReadsAType = cast<VectorType>(schedHint.getNumDsReadsA().getType());
+  auto dsReadsBType = cast<VectorType>(schedHint.getNumDsReadsB().getType());
+  const uint32_t dsReadAIssueCycle =
+      machineDescr->getDsReadIssueCycle(dsReadsAType.getShape()[0]);
+  const uint32_t dsReadBIssueCycle =
+      machineDescr->getDsReadIssueCycle(dsReadsBType.getShape()[0]);
+  const uint32_t mmaIssueCycle = machineDescr->getMmaIssueCycle();
+  const uint32_t numLdsDataPaths = machineDescr->getNumLdsDataPaths();
+  const auto dsReadAMmaRate =
+      (mmaExecCycle - mmaIssueCycle + numLdsDataPaths * dsReadAIssueCycle - 1) /
+      (numLdsDataPaths * dsReadAIssueCycle);
+  const auto dsReadBMmaRate =
+      (mmaExecCycle - mmaIssueCycle + numLdsDataPaths * dsReadBIssueCycle - 1) /
+      (numLdsDataPaths * dsReadBIssueCycle);
+  const auto numDsreadAMma =
+      (numDsReadInstA + dsReadAMmaRate - 1) / dsReadAMmaRate;
+  const auto numDsreadBMma =
+      (numDsReadInstB + dsReadBMmaRate - 1) / dsReadBMmaRate;
+  // stage 1
+  const auto numMmaStage1 = numMmaInst - (numDsreadAMma + numDsreadBMma);
+  const auto numMmaPerIssue =
+      numMmaStage1 / (numBufferLoadInstA + numBufferLoadInstB);
+  const auto numDswritePerIssueA = numDsWriteInstA / numBufferLoadInstA;
+  const auto numDswritePerIssueB = numDsWriteInstB / numBufferLoadInstB;
 
-    if (!machineDescr) {
-      schedHint.emitError("unknown target architecture detected");
-      return;
-    }
+  rewriter.setInsertionPoint(schedHint);
 
-    const uint32_t numDsReadInstA = schedHint.getNumDsReadsA().getValue();
-    const uint32_t numDsReadInstB = schedHint.getNumDsReadsB().getValue();
-
-    const uint32_t numDsWriteInstA = schedHint.getNumDsWritesA().getValue();
-    const uint32_t numDsWriteInstB = schedHint.getNumDsWritesB().getValue();
-
-    const uint32_t numBufferLoadInstA =
-        schedHint.getNumGlobalLoadsA().getValue();
-    const uint32_t numBufferLoadInstB =
-        schedHint.getNumGlobalLoadsB().getValue();
-
-    if (numBufferLoadInstA == 0) {
-      schedHint.emitError(
-          "global/buffer load count for tile A must be initialized");
-      return;
-    }
-
-    if (numBufferLoadInstB == 0) {
-      schedHint.emitError(
-          "global/buffer load count for tile B must be initialized");
-      return;
-    }
-
-    const uint32_t numMmaInst = schedHint.getNumMMAs().getValue();
-
-    auto mmaType = cast<RankedTensorType>(schedHint.getNumMMAs().getType());
-    auto maybeMmaExecCycle = machineDescr->getMmaExecCycle(mmaType.getShape());
-    if (llvm::failed(maybeMmaExecCycle)) {
-      schedHint.emitError("unknown mma instruction type");
-      return;
-    }
-    const uint32_t mmaExecCycle = maybeMmaExecCycle.value();
-
-    auto dsReadsAType = cast<VectorType>(schedHint.getNumDsReadsA().getType());
-    auto dsReadsBType = cast<VectorType>(schedHint.getNumDsReadsB().getType());
-
-    const uint32_t dsReadAIssueCycle =
-        machineDescr->getDsReadIssueCycle(dsReadsAType.getShape()[0]);
-    const uint32_t dsReadBIssueCycle =
-        machineDescr->getDsReadIssueCycle(dsReadsBType.getShape()[0]);
-
-    const uint32_t mmaIssueCycle = this->machineDescr->getMmaIssueCycle();
-    const uint32_t numLdsDataPaths = this->machineDescr->getNumLdsDataPaths();
-
-    // Compute how many ds_reads from tile A we can put between to adjacent
-    // MFMAs
-    const auto dsReadAMmaRate = (mmaExecCycle - mmaIssueCycle +
-                                 numLdsDataPaths * dsReadAIssueCycle - 1) /
-                                (numLdsDataPaths * dsReadAIssueCycle);
-
-    // Compute how many ds_reads from tile B we can put between to adjacent
-    // MFMAs
-    const auto dsReadBMmaRate = (mmaExecCycle - mmaIssueCycle +
-                                 numLdsDataPaths * dsReadBIssueCycle - 1) /
-                                (numLdsDataPaths * dsReadBIssueCycle);
-
-    // Compute how many (MFMA [ds_read]+) clusters we can get from tile A
-    const auto numDsreadAMma =
-        (numDsReadInstA + dsReadAMmaRate - 1) / dsReadAMmaRate;
-
-    // Compute how many (MFMA [ds_read]+) clusters we can get from tile B
-    const auto numDsreadBMma =
-        (numDsReadInstB + dsReadBMmaRate - 1) / dsReadBMmaRate;
-
-    // Stage 1
-    // Compute how many MFMAs we have left for stage 1 - i.e., clusters with
-    // ds_writes, global/buffer_loads, MFMAs
-    const auto numMmaStage1 = numMmaInst - (numDsreadAMma + numDsreadBMma);
-    const auto numMmaPerIssue =
-        numMmaStage1 / (numBufferLoadInstA + numBufferLoadInstB);
-
-    // Compute how many ds_writes we have per global/buffer load resulting from
-    // tile A
-    const auto numDswritePerIssueA = numDsWriteInstA / numBufferLoadInstA;
-
-    // Compute how many ds_writes we have per global/buffer load resulting from
-    // tile B
-    const auto numDswritePerIssueB = numDsWriteInstB / numBufferLoadInstB;
-
-    for (size_t i = 0; i < numBufferLoadInstA; ++i) {
-      for (size_t idswrite = 0; idswrite < numDswritePerIssueA; ++idswrite) {
-        createSchedGroupBarrier(rewriter, loc,
-                                mlir::amdgpu::sched_barrier_opt_enum::ds_write,
-                                1, 0);
-        createSchedGroupBarrier(rewriter, loc,
-                                mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma,
-                                1, 0);
-      }
+  for (size_t i = 0; i < numBufferLoadInstA; ++i) {
+    for (size_t idswrite = 0; idswrite < numDswritePerIssueA; ++idswrite) {
       createSchedGroupBarrier(
-          rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::vmem_read, 1, 0);
-      createSchedGroupBarrier(rewriter, loc,
-                              mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma,
-                              numMmaPerIssue - numDswritePerIssueA, 0);
-    }
-
-    for (size_t i = 0; i < numBufferLoadInstB; ++i) {
-      for (size_t idswrite = 0; idswrite < numDswritePerIssueB; ++idswrite) {
-        createSchedGroupBarrier(rewriter, loc,
-                                mlir::amdgpu::sched_barrier_opt_enum::ds_write,
-                                1, 0);
-        createSchedGroupBarrier(rewriter, loc,
-                                mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma,
-                                1, 0);
-      }
-      createSchedGroupBarrier(
-          rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::vmem_read, 1, 0);
-      createSchedGroupBarrier(rewriter, loc,
-                              mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma,
-                              numMmaPerIssue - numDswritePerIssueB, 0);
-    }
-
-    // stage 2
-    for (size_t i = 0; i < numDsreadAMma; ++i) {
-      if ((numDsReadInstA - (i + 1) * dsReadAMmaRate) >= dsReadAMmaRate) {
-        createSchedGroupBarrier(rewriter, loc,
-                                mlir::amdgpu::sched_barrier_opt_enum::ds_read,
-                                dsReadAMmaRate, 0);
-      } else {
-        createSchedGroupBarrier(
-            rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::ds_read,
-            numDsReadInstA - (numDsreadAMma - 1) * dsReadAMmaRate, 0);
-      }
+          rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::ds_write, 1, 0);
       createSchedGroupBarrier(
           rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma, 1, 0);
     }
-
-    for (size_t i = 0; i < numDsreadBMma; ++i) {
-      if ((numDsReadInstB - (i + 1) * dsReadBMmaRate) >= dsReadBMmaRate) {
-        createSchedGroupBarrier(rewriter, loc,
-                                mlir::amdgpu::sched_barrier_opt_enum::ds_read,
-                                dsReadBMmaRate, 0);
-      } else {
-        createSchedGroupBarrier(
-            rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::ds_read,
-            numDsReadInstB - (numDsreadBMma - 1) * dsReadBMmaRate, 0);
-      }
+    createSchedGroupBarrier(
+        rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::vmem_read, 1, 0);
+    createSchedGroupBarrier(rewriter, loc,
+                            mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma,
+                            numMmaPerIssue - numDswritePerIssueA, 0);
+  }
+  for (size_t i = 0; i < numBufferLoadInstB; ++i) {
+    for (size_t idswrite = 0; idswrite < numDswritePerIssueB; ++idswrite) {
+      createSchedGroupBarrier(
+          rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::ds_write, 1, 0);
       createSchedGroupBarrier(
           rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma, 1, 0);
     }
-
-    disableInstructionFolding(schedHint);
+    createSchedGroupBarrier(
+        rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::vmem_read, 1, 0);
+    createSchedGroupBarrier(rewriter, loc,
+                            mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma,
+                            numMmaPerIssue - numDswritePerIssueB, 0);
+  }
+  // stage 2
+  for (size_t i = 0; i < numDsreadAMma; ++i) {
+    if ((numDsReadInstA - (i + 1) * dsReadAMmaRate) >= dsReadAMmaRate) {
+      createSchedGroupBarrier(rewriter, loc,
+                              mlir::amdgpu::sched_barrier_opt_enum::ds_read,
+                              dsReadAMmaRate, 0);
+    } else {
+      createSchedGroupBarrier(
+          rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::ds_read,
+          numDsReadInstA - (numDsreadAMma - 1) * dsReadAMmaRate, 0);
+    }
+    createSchedGroupBarrier(
+        rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma, 1, 0);
+  }
+  for (size_t i = 0; i < numDsreadBMma; ++i) {
+    if ((numDsReadInstB - (i + 1) * dsReadBMmaRate) >= dsReadBMmaRate) {
+      createSchedGroupBarrier(rewriter, loc,
+                              mlir::amdgpu::sched_barrier_opt_enum::ds_read,
+                              dsReadBMmaRate, 0);
+    } else {
+      createSchedGroupBarrier(
+          rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::ds_read,
+          numDsReadInstB - (numDsreadBMma - 1) * dsReadBMmaRate, 0);
+    }
+    createSchedGroupBarrier(
+        rewriter, loc, mlir::amdgpu::sched_barrier_opt_enum::mfma_wmma, 1, 0);
   }
 
-  LogicalResult
-  matchAndRewrite(triton::amdgpu::InstructionSchedHint instructionSchedHint,
-                  PatternRewriter &rewriter) const override {
-    if (this->schedHint == mlir::triton::amdgpu::SchedHint::none) {
-      rewriter.eraseOp(instructionSchedHint);
-      return success();
-    }
-
-    // The switch controls whether instructions are allowed to cross the basic
-    // block boundaries at the very top and at the very bottom. Note, this is
-    // not supposed to be used together with IGLP OPT according to the AMDGPU
-    // backend documentation.
-    const bool limitSchedulingRange =
-        this->schedHint == mlir::triton::amdgpu::SchedHint::local_prefetch;
-    ;
-    Location loc = instructionSchedHint->getLoc();
-    Block *block = instructionSchedHint->getBlock();
-    if (limitSchedulingRange) {
-      rewriter.setInsertionPointToStart(block);
-      createSchedBarrier(rewriter, loc,
-                         mlir::amdgpu::sched_barrier_opt_enum::none);
-    }
-
-    rewriter.setInsertionPoint(block, std::prev(block->end()));
-
-    switch (this->schedHint) {
-    case mlir::triton::amdgpu::SchedHint::llvm_iglp_0:
-    case mlir::triton::amdgpu::SchedHint::llvm_iglp_1:
-      createIglpOpt(rewriter, loc, static_cast<int>(this->schedHint) - 1);
-      break;
-    case mlir::triton::amdgpu::SchedHint::local_prefetch:
-      createLocalPrefetchSchedule(rewriter, loc, instructionSchedHint);
-      break;
-    case mlir::triton::amdgpu::SchedHint::none:
-    default:
-      break;
-    }
-
-    if (limitSchedulingRange)
-      createSchedBarrier(rewriter, loc,
-                         mlir::amdgpu::sched_barrier_opt_enum::none);
-
-    rewriter.eraseOp(instructionSchedHint);
-    return success();
-  }
-
-private:
-  int32_t numStages;
-  mlir::triton::amdgpu::SchedHint schedHint;
-  std::unique_ptr<MachineDescr> machineDescr;
-};
+  disableInstructionFolding(schedHint);
+}
 
 struct TritonAMDGPULowerInstructionSchedHints
     : public triton::impl::TritonAMDGPULowerInstructionSchedHintsBase<
@@ -487,23 +393,59 @@ struct TritonAMDGPULowerInstructionSchedHints
     MLIRContext *ctx = &getContext();
     ModuleOp mod = getOperation();
 
-    ConversionTarget target(*ctx);
-    target.addLegalDialect<LLVM::LLVMDialect>();
-    target.addIllegalOp<triton::amdgpu::InstructionSchedHint>();
-    target.addLegalOp<ROCDL::SchedBarrier>();
-    target.addLegalOp<ROCDL::IglpOpt>();
-    target.addLegalOp<ROCDL::SchedGroupBarrier>();
+    OpBuilder rewriter(ctx);
 
     RewritePatternSet patterns(ctx);
-
-    patterns.add<InstructionSchedHintsRewriter>(ctx, this->arch,
-                                                this->numStages, this->variant);
-
-    if (failed(applyPartialConversion(getOperation(), target,
-                                      std::move(patterns)))) {
-
-      signalPassFailure();
+    SchedHint schedHint = SchedHint::none;
+    if (this->numStages < 2) {
+      LDBG("ignoring instruction scheduling due to a very low num. "
+           "stages value. Must be >= 2");
     }
+
+    std::transform(variant.begin(), variant.end(), variant.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (auto maybeSchedHint = symbolizeSchedHint(variant)) {
+      schedHint = maybeSchedHint.value();
+    } else {
+      LDBG("ignoring instruction scheduling because "
+           "unknown instruction scheduling variant has been provided");
+    }
+
+    bool cleanUp = schedHint != SchedHint::local_prefetch;
+    llvm::SmallVector<Operation *> deletees;
+    if (cleanUp) {
+      mod.walk([&](Operation *op) {
+        if (llvm::dyn_cast<InstructionSchedHint>(op)) {
+          rewriter.setInsertionPoint(op->getBlock(), --Block::iterator(op));
+          deletees.push_back(op);
+        }
+        if (llvm::dyn_cast<ROCDL::SchedBarrier>(op))
+          deletees.push_back(op);
+      });
+    }
+
+    auto loc = UnknownLoc::get(ctx);
+
+    switch (schedHint) {
+    case SchedHint::llvm_iglp_0:
+    case SchedHint::llvm_iglp_1:
+    case SchedHint::llvm_iglp_2:
+    case SchedHint::llvm_iglp_3:
+      createIglpOpt(rewriter, loc, static_cast<int>(schedHint) - 1);
+      break;
+    case SchedHint::local_prefetch: {
+      auto machineDescr = MachineDescr::get(arch);
+      mod->walk([&](InstructionSchedHint schedHint) {
+        createLocalPrefetchSchedule(rewriter, loc, schedHint, machineDescr);
+        deletees.push_back(schedHint);
+      });
+    } break;
+    default:
+      break;
+    }
+
+    for (auto op : deletees)
+      op->erase();
   }
 };
 
@@ -515,16 +457,75 @@ struct TritonAMDGPUInsertInstructionSchedHints
     MLIRContext *ctx = &getContext();
     ModuleOp mod = getOperation();
 
-    mod.walk([this, ctx](scf::ForOp forOp) {
-      // Note, instruction schedule barriers are inserted only in the case of
-      // a single `tt.dot` op in a `scf::ForOp` scope in the current
-      // implementation.
-      if (auto dotOp = getSingleDotOpIfExists(forOp)) {
-        OpBuilder rewriter(ctx);
-        rewriter.setInsertionPointAfter(dotOp);
-        rewriter.create<triton::amdgpu::InstructionSchedHint>(dotOp->getLoc());
+    constexpr llvm::StringLiteral schedRegionIdxAttrName =
+        SchedRegionIdxAttr::getMnemonic();
+    static size_t globalCounter = 0;
+    mod.walk([&](triton::FuncOp funcOp) {
+      auto forOps = AMD::getLeafForOps(funcOp);
+      for (auto forOp : forOps) {
+        forOp->walk([&](triton::DotOp dotOp) {
+          OpBuilder rewriter(ctx);
+          rewriter.setInsertionPointAfter(dotOp);
+          auto hintOp = rewriter.create<InstructionSchedHint>(dotOp->getLoc());
+
+          auto regionIdx = SchedRegionIdxAttr::get(ctx, globalCounter);
+          dotOp->setAttr(schedRegionIdxAttrName, regionIdx);
+          hintOp->setAttr(schedRegionIdxAttrName, regionIdx);
+          ++globalCounter;
+        });
       }
     });
+  }
+};
+
+struct TritonAMDGPUInsertInstructionSchedGuards
+    : public triton::impl::TritonAMDGPUInsertInstructionSchedGuardsBase<
+          TritonAMDGPUInsertInstructionSchedGuards> {
+
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    ModuleOp mod = getOperation();
+
+    llvm::SmallVector<scf::ForOp> forOps;
+    mod.walk([&](scf::ForOp forOp) {
+      auto result = forOp->walk(
+          [](InstructionSchedHint) { return WalkResult::interrupt(); });
+      if (result.wasInterrupted())
+        forOps.push_back(forOp);
+    });
+
+    for (auto forOp : forOps) {
+      OpBuilder rewriter(ctx);
+      int32_t prevSchedRegionIdx = -1;
+      auto body = forOp.getBody();
+      for (auto op = body->begin(); op != body->end(); ++op) {
+        if (auto currRegionIdx = op->getAttrOfType<SchedRegionIdxAttr>(
+                SchedRegionIdxAttr::getMnemonic())) {
+          if (currRegionIdx.getValue() != prevSchedRegionIdx) {
+            if (op == body->begin()) {
+              rewriter.setInsertionPointToStart(body);
+            } else {
+              rewriter.setInsertionPointAfter(&(*(std::prev(op))));
+            }
+            createSchedBarrier(rewriter, op->getLoc(),
+                               mlir::amdgpu::sched_barrier_opt_enum::none);
+            prevSchedRegionIdx = currRegionIdx.getValue();
+          }
+        }
+      }
+      prevSchedRegionIdx = -1;
+      for (auto op = body->rbegin(); op != body->rend(); ++op) {
+        if (auto currRegionIdx = op->getAttrOfType<SchedRegionIdxAttr>(
+                SchedRegionIdxAttr::getMnemonic())) {
+          if (currRegionIdx.getValue() != prevSchedRegionIdx) {
+            rewriter.setInsertionPointAfter(&(*op));
+            createSchedBarrier(rewriter, op->getLoc(),
+                               mlir::amdgpu::sched_barrier_opt_enum::none);
+            prevSchedRegionIdx = currRegionIdx.getValue();
+          }
+        }
+      }
+    }
   }
 };
 } // namespace
@@ -541,5 +542,10 @@ createTritonAMDGPULowerInstructionSchedHintsPass(StringRef arch,
 std::unique_ptr<OperationPass<ModuleOp>>
 createTritonAMDGPUInsertInstructionSchedHintsPass() {
   return std::make_unique<TritonAMDGPUInsertInstructionSchedHints>();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createTritonAMDGPUInsertInstructionSchedGuardsPass() {
+  return std::make_unique<TritonAMDGPUInsertInstructionSchedGuards>();
 }
 } // namespace mlir::triton

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_triton_library(TritonAMDGPUTransforms
   TritonAMDGPUIR
   TritonAMDGPUTransformsIncGen
   TritonGPUIR
+  TritonAMDUtils
 )
 
 target_include_directories(TritonAMDGPUTransforms PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../include)

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -269,6 +269,12 @@ struct ConvertTritonLoadToBufferLoad
         bufferLoadOp->setAttr(triton::amdgpu::OpIdxAttr::getMnemonic(),
                               opIdxAttr);
       }
+      if (auto regionIdxAttr =
+              op->getAttrOfType<triton::amdgpu::SchedRegionIdxAttr>(
+                  triton::amdgpu::SchedRegionIdxAttr::getMnemonic())) {
+        bufferLoadOp->setAttr(triton::amdgpu::SchedRegionIdxAttr::getMnemonic(),
+                              regionIdxAttr);
+      }
       rewriter.replaceOp(op, bufferLoadOp);
 
       return success();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -4,6 +4,7 @@
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Pass/PassManager.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/utility/CommonUtils.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -15,20 +16,6 @@ namespace ttg = mlir::triton::gpu;
 //===----------------------------------------------------------------------===//
 // Utility functions
 //===----------------------------------------------------------------------===//
-
-static SmallVector<scf::ForOp> getLeafForOps(triton::FuncOp funcOp) {
-  SmallVector<scf::ForOp> allOps;
-  funcOp->walk([&](scf::ForOp forOp) { allOps.push_back(forOp); });
-
-  SmallVector<scf::ForOp> leafOps;
-  for (scf::ForOp forOp : allOps) {
-    auto searchResult = forOp.getBody()->walk(
-        [](scf::ForOp) { return WalkResult::interrupt(); });
-    if (!searchResult.wasInterrupted())
-      leafOps.push_back(forOp);
-  }
-  return leafOps;
-}
 
 // Return true if the given funcOp is a pure matmul problem; i.e.,
 // a single main loop with a single dot.
@@ -85,7 +72,7 @@ findEarlyInsertionPoint(Block *block, Operation *move) {
       if (isa<triton::AtomicRMWOp, triton::AtomicCASOp>(wop))
         ipnt = bi;
       // Break at barrier
-      if (isa<gpu::BarrierOp>(wop))
+      if (isa<mlir::gpu::BarrierOp>(wop))
         ipnt = bi;
       // Break at loops.
       if (isa<scf::ForOp, scf::WhileOp>(wop))
@@ -425,7 +412,8 @@ struct TritonAMDGPUReorderInstructionsPass
         scheduleGlobalLoadLocalStore(funcOp);
         funcOp.walk([&](scf::ForOp forOp) -> void { sinkSecondLoad(forOp); });
       } else {
-        SmallVector<scf::ForOp> leafForOps = getLeafForOps(funcOp);
+        SmallVector<scf::ForOp> leafForOps =
+            mlir::triton::AMD::getLeafForOps(funcOp);
         for (auto forOp : leafForOps) {
           if (isPureMatmulLoop(forOp)) {
             scheduleGlobalLoadLocalStore(forOp);

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -47,6 +47,9 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
   m.def("insert_instruction_sched_hints", [](mlir::PassManager &pm) {
     pm.addPass(createTritonAMDGPUInsertInstructionSchedHintsPass());
   });
+  m.def("insert_instruction_sched_guards", [](mlir::PassManager &pm) {
+    pm.addPass(createTritonAMDGPUInsertInstructionSchedGuardsPass());
+  });
   m.def("lower_instruction_sched_hints",
         [](mlir::PassManager &pm, const std::string &arch, int32_t numStages,
            const std::string &variant) {


### PR DESCRIPTION
This PR extends the current instruction scheduling implementation by adding support for multiple `tt.DotOp` in a `scf::ForOp` region. This allows one to apply IGLP version 3 and 4 to the FA-like kernels.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.
