### PR TITLE
Update forOp's num stages based on calculated schedule

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
@@ -29,6 +29,15 @@ bool hasGpuBarriers(scf::ForOp forOp) {
   return result.wasInterrupted();
 }
 
+// This is required only until we refactor the pipeline lowering to calculate
+// the num stages based on the ops in the loop.
+void updateForOpNumStages(scf::ForOp forOp, int numStages) {
+  forOp->setAttr(
+      kNumStagesAttrName,
+      mlir::IntegerAttr::get(mlir::IntegerType::get(forOp->getContext(), 32),
+                             numStages));
+}
+
 // Return true if the preconditions for pipelining the loop are met.
 bool isSafeToPipeline(scf::ForOp forOp) {
   // Skip loop with distance > 1 for now.
@@ -292,6 +301,10 @@ void scheduleLoop(scf::ForOp forOp,
     LDBG("Initial coarse schedule:");
     schedule.dump();
   });
+  // This is required only until we refactor the pipeline lowering to calculate
+  // the num stages based on the ops in the loop.
+  updateForOpNumStages(forOp, schedule.numStages);
+
   // Schedule the dependencies
   CoarseSchedule::Cluster afterPrologue =
       schedulePrologueAndEpilogue(forOp, schedule);


### PR DESCRIPTION
For some kernels the loop scheduling may actually change number of stages of loop. Until we change pipeline lowering to figure out number of stages based on op stage assignments, override for's num_stages attribute to reflect scheduler output.