### PR TITLE
Adding an option to force target nv compute capability for triton

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -33,6 +33,7 @@ inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
     "TRITON_HIP_USE_BLOCK_PINGPONG",
     "TRITON_LLVM_DEBUG_ONLY",
     "TRITON_ENABLE_ASAN",
+    "TRITON_OVERRIDE_NV_CAPABILITY",
     "USE_IR_LOC",
     "NVPTX_ENABLE_DUMP",
     // clang-format on


### PR DESCRIPTION
Adding an option to force NV compute capability for triton. This can be done either with global env flag `TRITON_OVERRIDE_NV_CAPABILITY`, or per-kernel with `override_nv_compute_capability=` launch argument.