### PR TITLE
[Backend] Reject volatile TMA load in LLVM codegen

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1082,10 +1082,13 @@ struct AsyncTMACopyGlobalToLocalOpConversion
   matchAndRewrite(triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp op,
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    assert(op.getCache() == triton::CacheModifier::NONE &&
-           "cache modifiers not supported yet.");
-    assert(op.getEvict() == triton::EvictionPolicy::NORMAL &&
-           "eviction policy not supported yet.");
+    if (op.getCache() != triton::CacheModifier::NONE)
+      return op.emitError("cache modifiers not supported yet");
+    if (op.getEvict() != triton::EvictionPolicy::NORMAL)
+      return op.emitError("eviction policy not supported yet");
+    if (op.getIsVolatile())
+      return op.emitError("volatile not supported yet");
+
     auto loc = op.getLoc();
     Type llvmElemTy =
         typeConverter->convertType(op.getResult().getType().getElementType());


### PR DESCRIPTION
This isn't supported by the lowering, so reject it properly. Also, switch from using asserts to emitting an MLIR error.
