### PR TITLE
[Triton] Remove unused `min/max_element` helpers (NFC)

### DIFF
--- a/include/triton/Dialect/Triton/IR/Utility.h
+++ b/include/triton/Dialect/Triton/IR/Utility.h
@@ -167,27 +167,6 @@ template <typename VecT> bool isConsecutive(const VecT &vec) {
   return isConsecutive(ArrayRef(vec));
 }
 
-// LLVM's STLExtras.h provides a bunch of functions that work over ranges, but
-// it's missing min/max_element until
-// https://github.com/llvm/llvm-project/commit/fab2bb8b makes it into Triton.
-// TODO(jlebar): Remove this once we have the LLVM helpers.
-template <typename R> auto min_element(R &&Range) {
-  return std::min_element(llvm::adl_begin(Range), llvm::adl_end(Range));
-}
-template <typename R, typename Compare>
-auto min_element(R &&Range, Compare &&C) {
-  return std::min_element(llvm::adl_begin(Range), llvm::adl_end(Range),
-                          std::forward<Compare>(C));
-}
-template <typename R> auto max_element(R &&Range) {
-  return std::max_element(llvm::adl_begin(Range), llvm::adl_end(Range));
-}
-template <typename R, typename T, typename Compare>
-auto max_element(R &&Range, Compare &&C) {
-  return std::max_element(llvm::adl_begin(Range), llvm::adl_end(Range),
-                          std::forward<Compare>(C));
-}
-
 } // namespace triton
 } // namespace mlir
 

--- a/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
@@ -115,7 +115,7 @@ CoarseSchedule scheduleKeyOps(scf::ForOp forOp,
   }
 
   auto stages = llvm::make_second_range(opToStage);
-  int maxStage = *std::max_element(stages.begin(), stages.end());
+  int maxStage = *llvm::max_element(stages);
   CoarseSchedule schedule(maxStage + 1);
   SmallVector<CoarseSchedule::Cluster> clusters(maxStage + 1);
   for (int i = 0; i <= maxStage; i++) {

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -257,8 +257,7 @@ DenseMap<Operation *, int> assignLatencies(ModuleOp moduleOp,
 
     // Calculate the stage distance between applicable loads.
     auto vals = llvm::make_second_range(loadOpToIndLevel);
-    int maxIndirectionLevel =
-        vals.empty() ? 0 : *std::max_element(vals.begin(), vals.end());
+    int maxIndirectionLevel = vals.empty() ? 0 : *llvm::max_element(vals);
     unsigned loadLatency = (numStages - 1) / (maxIndirectionLevel + 1);
 
     for (auto [loadOp, dist] : loadOpToIndLevel) {

--- a/lib/Dialect/TritonGPU/Transforms/ReorderInstructions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReorderInstructions.cpp
@@ -51,10 +51,10 @@ public:
       if (Operation *ancestor = op->getBlock()->findAncestorOpInBlock(*user))
         users.push_back(ancestor);
     }
-    auto minOpIt = std::min_element(users.begin(), users.end(),
-                                    [](mlir::Operation *a, mlir::Operation *b) {
-                                      return a->isBeforeInBlock(b);
-                                    });
+    auto minOpIt =
+        llvm::min_element(users, [](mlir::Operation *a, mlir::Operation *b) {
+          return a->isBeforeInBlock(b);
+        });
     return minOpIt != users.end() ? *minOpIt : nullptr;
   }
 


### PR DESCRIPTION
These have been contributed upstream. Also switch a few `std::` usages to `llvm::`.
