### PR TITLE
[AMD] Disable FP8E4M3FN to FP16 upcast

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -282,10 +282,9 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
             return
     elif is_hip():
         if  src_dtype == 'float8e4nv' and (
-            dst_dtype in ('float32', 'float16') or ((dst_dtype in ('bfloat16')) and not is_hip_mi300())):
+            dst_dtype in ('float32', 'float16') or ((dst_dtype in ('bfloat16')) and (not is_hip_mi300()))):
             pytest.skip(f"upcasting {src_dtype} to {dst_dtype} not supported in this architecture")
-        if (src_dtype in ('float8e4b15') or
-            (src_dtype in ('float8e4b8', 'float8e5b16') and not is_hip_mi300())):
+        if src_dtype in ('float8e4b15'):
             # If the dtype should error out in the given device, we assert that and return
             with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
                 launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -273,16 +273,23 @@ def upcast_test(src_dtype, dst_dtype, exponent_bits, mantissa_bits, exponent_bia
 def test_typeconvert_upcast(src_dtype, dst_dtype, device):
 
     # On HIP, fp8e4nv upcasting is only supported to bf16 and fp16, and it's only supported on MI300.
-    if src_dtype == 'float8e4nv' and is_hip() and (dst_dtype != 'bfloat16' or dst_dtype != 'float16' or not is_hip_mi300()):
-        pytest.skip(f"upcasting {src_dtype} to {dst_dtype} not supported in this architecture")
-
-    if ((src_dtype == 'float8e4nv' and is_cuda() and torch.cuda.get_device_capability(0) < (8, 9))
-       or (src_dtype in ('float8e4b15') and is_hip())
-       or (src_dtype in ('float8e4b8', 'float8e5b16') and (is_cuda() or not is_hip_mi300()))):
-        # If the dtype should error out in the given device, we assert that and return
-        with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
-            launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)
-        return
+    if is_cuda():
+        if ((src_dtype == 'float8e4nv' and torch.cuda.get_device_capability(0) < (8, 9))
+            or src_dtype in ('float8e4b8', 'float8e5b16')):
+            # If the dtype should error out in the given device, we assert that and return
+            with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
+                launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)
+            return
+    elif is_hip():
+        if  src_dtype == 'float8e4nv' and (
+            dst_dtype in ('float32', 'float16') or ((dst_dtype in ('bfloat16')) and not is_hip_mi300())):
+            pytest.skip(f"upcasting {src_dtype} to {dst_dtype} not supported in this architecture")
+        if (src_dtype in ('float8e4b15') or
+            (src_dtype in ('float8e4b8', 'float8e5b16') and not is_hip_mi300())):
+            # If the dtype should error out in the given device, we assert that and return
+            with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
+                launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)
+            return
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias, max_repr)
     stuff = {

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -282,9 +282,10 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
             return
     elif is_hip():
         if  src_dtype == 'float8e4nv' and (
-            dst_dtype in ('float32', 'float16') or ((dst_dtype in ('bfloat16')) and (not is_hip_mi300()))):
+            dst_dtype in ('float32', 'float16') or ((dst_dtype in ('bfloat16')) and not is_hip_mi300())):
             pytest.skip(f"upcasting {src_dtype} to {dst_dtype} not supported in this architecture")
-        if src_dtype in ('float8e4b15'):
+        if (src_dtype in ('float8e4b15') or
+            (src_dtype in ('float8e4b8', 'float8e5b16') and not is_hip_mi300())):
             # If the dtype should error out in the given device, we assert that and return
             with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
                 launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -960,7 +960,6 @@ struct FpToFpOpConversion
             // F8 -> F16
             {{F8E4M3FNUZTyID, F16TyID, undefRounding},
              Fp8E4M3FNUZ_to_Fp16(isaFamily)},
-            {{F8E4M3FNTyID, F16TyID, undefRounding}, Fp8E4M3FN_to_Fp16},
             {{F8E5M2FNUZTyID, F16TyID, undefRounding},
              Fp8E5M2FNUZ_to_Fp16(isaFamily)},
             {{F8E5M2TyID, F16TyID, undefRounding}, Fp8E5M2_to_Fp16},


### PR DESCRIPTION
The logic is incorrect; we previously missed it due to test skip conditions disabling the tests. So this commit also restructures the test skip conditions.