### PR TITLE
[backend] Ensure a deterministic allocation order of scratch smem buffers

### DIFF
--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -209,7 +209,7 @@ private:
   };
 
   /// Op -> Scratch Buffer
-  using OpScratchMapT = DenseMap<Operation *, BufferT *>;
+  using OpScratchMapT = llvm::MapVector<Operation *, BufferT *>;
   /// Value -> Explicit Buffer
   using ValueBufferMapT = llvm::MapVector<Value, BufferT *>;
   /// Value -> Alias Buffer


### PR DESCRIPTION
I was seeing non-deterministic SMEM allocation sizes and offsets across compilations with same source and compiler. It seems due to scratch buffers processed in a non-deterministic order, due to the use of `DenseMap`. Using `MapVector` should fix it.