### PR TITLE
[AMD] Fix and enable upcasting fp8e4m3nv to fp16

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -282,7 +282,7 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
             return
     elif is_hip():
         if  src_dtype == 'float8e4nv' and (
-            dst_dtype in ('float32', 'float16') or ((dst_dtype in ('bfloat16')) and not is_hip_mi300())):
+            dst_dtype == 'float32' or ((dst_dtype in ('bfloat16')) and not is_hip_mi300())):
             pytest.skip(f"upcasting {src_dtype} to {dst_dtype} not supported in this architecture")
         if (src_dtype in ('float8e4b15') or
             (src_dtype in ('float8e4b8', 'float8e5b16') and not is_hip_mi300())):

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3538,8 +3538,6 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
         if "e4m3" in (mxfp_type, normal_type):
             if not is_hip_mi300():
                 pytest.skip(f"scaled_dot({mxfp_type}, {normal_type}) only implemented for MI300")
-            if normal_type == "fp16":
-                pytest.skip(f"scaled_dot({mxfp_type}, {normal_type}) not yet implemented for MI300")
         if mma == 16 and K == 64:
             pytest.skip(f"K == {K} too small for mfma {mma} in scaled_dot")
 


### PR DESCRIPTION
This commit fixed and enabled fp8e4m3nv to fp16 upcasting.
In order to properly handle denorms with LUT, this operation is no longer vectorized.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
