### PR TITLE
[NFC] Cleanup `flake8` related code as unused

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-# W503 (linebreak occurred before binary operator) seems to be enabled by
-# default, even though it goes against pep8 and is incompatible with W504
-# (linebreak occurred *after* binary operator).  Disable it.
-ignore = E501,E701,E731,W503

--- a/python/setup.py
+++ b/python/setup.py
@@ -762,7 +762,6 @@ setup(
         ],
         "tests": [
             "autopep8",
-            "flake8",
             "isort",
             "numpy",
             "pytest",

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1,4 +1,4 @@
-# flake8: noqa: F821,F841
+# ruff: noqa: F821,F841
 import contextlib
 import itertools
 import re

--- a/third_party/proton/proton/__init__.py
+++ b/third_party/proton/proton/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 from .scope import scope, cpu_timed_scope, enter_scope, exit_scope
 from .state import state, enter_state, exit_state
 from .profile import (


### PR DESCRIPTION
ruff is used insead 