### PR TITLE
[proton] NFC: Make header file self-contained

### DIFF
--- a/third_party/proton/dialect/include/TritonProtonToLLVM/PatternTritonProtonOpToLLVM.h
+++ b/third_party/proton/dialect/include/TritonProtonToLLVM/PatternTritonProtonOpToLLVM.h
@@ -3,18 +3,14 @@
 
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 
-using namespace mlir;
-using namespace mlir::triton;
-
-namespace mlir {
-namespace triton {
+namespace mlir::triton {
+class TargetInfoBase;
 namespace proton {
 void populateRecordOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                    RewritePatternSet &patterns,
                                    const TargetInfoBase &targetInfo,
                                    PatternBenefit benefit);
 } // namespace proton
-} // namespace triton
-} // namespace mlir
+} // namespace mlir::triton
 
 #endif


### PR DESCRIPTION
Forward-declare TargetInfoBase so that header is self-contained.
