### PR TITLE
[LinearLayouts] Fix Reduce(LinearEncodingAttr)

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -354,6 +354,15 @@ SmallVector<Value> delinearize(RewriterBase &rewriter, Location loc,
 SmallVector<unsigned> delinearize(unsigned linear, ArrayRef<unsigned> shape,
                                   ArrayRef<unsigned> order);
 
+// Returns a tuple with the delinearized coordinates and a boolean which is true
+// iff the Value is not broadcasted (equivalently, if the value is the "first"
+// lane/thread/etc. that holds the given value). In mathy terms, the boolean is
+// true if the element is the canonical representative of the class.
+std::tuple<SmallVector<Value>, Value>
+delinearize(RewriterBase &rewriter, Location loc,
+            triton::gpu::DistributedEncodingTrait layout,
+            ArrayRef<int64_t> shape, StringAttr dimName, Value linear);
+
 Value linearize(RewriterBase &rewriter, Location loc, ArrayRef<Value> multiDim,
                 ArrayRef<unsigned> shape, ArrayRef<unsigned> order);
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -584,6 +584,19 @@ def LinearEncodingAttr : DistributedEncoding<"LinearEncoding", "linear_encoding"
   let extraClassDeclaration = extraDistributedDeclaration # [{
     SmallVector<unsigned> getContigPerThread() const;
     SmallVector<unsigned> getOrder() const;
+
+    // Generalizes get{Warp,Thread,CTA}Order to linear layouts.
+    // Returns the order of the dimensions `dimName` of the layout.
+    // If more than dimension is of size one, it uses defaultOrder to determine
+    // the order of the dimensions of size one.
+    SmallVector<unsigned> orderPerDim(StringAttr dimName,
+                                      ArrayRef<unsigned> defaultOrder) const;
+
+    // Generalizes getThreadsPerWarp, getWarpsPerCTA, getCTAsPerCGA to linear layouts.
+    // Returns the bases of the dimensions `dimName` of the layout.
+    // If skipBroadcast is false, we count a base zero
+    SmallVector<unsigned> basesPerDim(StringAttr dimName,
+                                      bool skipBroadcast = true) const;
   }];
 
   let genVerifyDecl = 1;

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -63,34 +63,19 @@ SmallVector<unsigned> ReduceOpHelper::getOrderWithAxisAtBeginning() {
 // reduction axis within the warp.
 unsigned ReduceOpHelper::getThreadOffsetOnReductionAxis() {
   auto srcLayout = getSrcLayout();
-
-  // If the reduction axis is the fast axis of the parent layout
-  if (isReductionOnLayoutFastAxis()) {
-    return 1;
-  }
-
-  unsigned threadOffset = 1;
-  SmallVector<int> dimsRemoved;
-  while (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(srcLayout)) {
-    dimsRemoved.push_back(sliceLayout.getDim());
-    srcLayout = sliceLayout.getParent();
-  }
-  // In case of slice layout we want to know the axis dimension relative to the
-  // most inner parent layout. `adjustedAxis` is the matching axis dim in the
-  // parent layout.
-  int adjustedAxis = axis;
-  for (auto dim : dimsRemoved) {
-    if (dim <= adjustedAxis)
-      adjustedAxis++;
-  }
-  auto threadsPerWarp = getThreadsPerWarp(srcLayout);
-  auto order = getThreadOrder(srcLayout);
-  for (unsigned i = 0; i < order.size(); i++) {
-    if (order[i] == adjustedAxis)
+  auto *ctx = srcLayout.getContext();
+  auto linearLayout = *toLinearLayout(getSrcShape(), srcLayout);
+  auto axis = getAxis();
+  auto kLane = mlir::StringAttr::get(ctx, "lane");
+  const auto &bases = linearLayout.getBases();
+  const auto &lanes = bases.find(kLane)->second;
+  auto offset = 1;
+  for (const auto &lane : lanes) {
+    if (lane[axis] != 0)
       break;
-    threadOffset *= threadsPerWarp[order[i]];
+    offset *= 2;
   }
-  return threadOffset;
+  return offset;
 }
 
 // Cases where distributed shared memory is not required in ConvertLayout:
@@ -168,10 +153,11 @@ unsigned ReduceOpHelper::getIntraWarpSizeWithUniqueData() {
 }
 
 unsigned ReduceOpHelper::getThreadsReductionAxis() {
-  auto srcLayout = getSrcLayout();
-  auto srcShape = getSrcShape();
-  return getThreadsPerWarpWithUniqueData(srcLayout, srcShape)[axis] *
-         getWarpsPerCTAWithUniqueData(srcLayout, srcShape)[axis];
+  auto axis = getAxis();
+  auto *ctx = getSrcLayout().getContext();
+  auto ll = LinearEncodingAttr::get(
+      ctx, *toLinearLayout(getSrcShape(), getSrcLayout()));
+  return ll.getThreadsPerWarp()[axis] * ll.getWarpsPerCTA()[axis];
 }
 
 bool ReduceOpHelper::isWarpSynchronous() {

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -2,12 +2,13 @@
 #include "mlir/Support/LLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 
 using namespace mlir;
 using namespace mlir::triton;
 
-using ::mlir::LLVM::delinearize;
 using ::mlir::LLVM::linearize;
+using ::mlir::triton::gpu::DistributedEncodingTrait;
 using ::mlir::triton::gpu::getOrder;
 using ::mlir::triton::gpu::getThreadOrder;
 using ::mlir::triton::gpu::getTotalElemsPerThread;
@@ -160,9 +161,6 @@ private:
     if (success)
       return;
 
-    auto mod = op->getParentOfType<ModuleOp>();
-    unsigned iWarpSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
-
     for (unsigned N = numLaneToReduce / 2; N > 0; N >>= 1) {
       SmallVector<Value> shfl(acc.size());
       for (unsigned i = 0; i < acc.size(); ++i) {
@@ -218,83 +216,6 @@ private:
     rewriter.replaceOp(op, results);
   }
 
-  // For slice layout some ids are duplicated on multiple lanes, so we need to
-  // handle the delinearization of laneId in a special way. We need to
-  // generalize this part of the logic to work on any kind of linear layout
-  // uniformly.
-  SmallVector<Value>
-  getMultiDimLaneId(ReduceOpHelper &helper, Value &laneId, Location &loc,
-                    ConversionPatternRewriter &rewriter) const {
-    auto srcLayout = helper.getSrcLayout();
-    auto srcShape = helper.getSrcShape();
-    auto order = triton::gpu::getThreadOrder(srcLayout);
-    SmallVector<Value> multiDimLaneId;
-
-    if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(srcLayout)) {
-      auto parentLayout = sliceLayout.getParent();
-      SmallVector<unsigned> dims = {sliceLayout.getDim()};
-      while (auto parentSliceLayout =
-                 mlir::dyn_cast<SliceEncodingAttr>(parentLayout)) {
-        dims.push_back(parentSliceLayout.getDim());
-        parentLayout = parentSliceLayout.getParent();
-      }
-
-      auto parentThreadsPerWarps = triton::gpu::getThreadsPerWarp(parentLayout);
-      auto parentOrder = triton::gpu::getThreadOrder(parentLayout);
-      multiDimLaneId = delinearize(rewriter, loc, laneId, parentThreadsPerWarps,
-                                   parentOrder);
-      for (unsigned dim : llvm::reverse(dims)) {
-        multiDimLaneId.erase(multiDimLaneId.begin() + dim);
-      }
-    } else {
-      SmallVector<unsigned> threadsPerWarps =
-          triton::gpu::getThreadsPerWarp(srcLayout);
-      threadsPerWarps[helper.getAxis()] =
-          triton::gpu::getThreadsPerWarpWithUniqueData(
-              srcLayout, srcShape)[helper.getAxis()];
-      multiDimLaneId =
-          delinearize(rewriter, loc, laneId, threadsPerWarps, order);
-    }
-    return multiDimLaneId;
-  }
-
-  SmallVector<Value>
-  getMultiDimWarpId(ReduceOpHelper &helper, Value &warpId, Location &loc,
-                    ConversionPatternRewriter &rewriter) const {
-    auto srcLayout = helper.getSrcLayout();
-    auto srcShape = helper.getSrcShape();
-    auto order = triton::gpu::getWarpOrder(srcLayout);
-    SmallVector<Value> multiDimWarpId;
-
-    // 2x2 warps with slice dim = 0, warpId = 2 ends up writing at the same
-    // address as warpId = 0 since the warpsPerCTA is [1, 2], need to figure out
-    // a way to properly delinearize warpId in the slice case
-    if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(srcLayout)) {
-      auto parentLayout = sliceLayout.getParent();
-      SmallVector<unsigned> dims = {sliceLayout.getDim()};
-      while (auto parentSliceLayout =
-                 mlir::dyn_cast<SliceEncodingAttr>(parentLayout)) {
-        dims.push_back(parentSliceLayout.getDim());
-        parentLayout = parentSliceLayout.getParent();
-      }
-
-      auto parentWarpsPerCTA = triton::gpu::getWarpsPerCTA(parentLayout);
-      auto parentOrder = triton::gpu::getWarpOrder(parentLayout);
-      multiDimWarpId =
-          delinearize(rewriter, loc, warpId, parentWarpsPerCTA, parentOrder);
-      for (unsigned dim : llvm::reverse(dims)) {
-        multiDimWarpId.erase(multiDimWarpId.begin() + dim);
-      }
-    } else {
-      SmallVector<unsigned> warpsPerCTA =
-          triton::gpu::getWarpsPerCTA(srcLayout);
-      warpsPerCTA[helper.getAxis()] = triton::gpu::getWarpsPerCTAWithUniqueData(
-          srcLayout, srcShape)[helper.getAxis()];
-      multiDimWarpId = delinearize(rewriter, loc, warpId, warpsPerCTA, order);
-    }
-    return multiDimWarpId;
-  }
-
   void storeWarpReduceToSharedMemory(
       ReduceOpHelper &helper,
       std::map<SmallVector<unsigned>, SmallVector<Value>> &accs,
@@ -304,22 +225,30 @@ private:
     triton::ReduceOp op = helper.getOperation();
     Location loc = op.getLoc();
     Value threadId = getThreadId(rewriter, loc);
-    auto srcLayout = helper.getSrcLayout();
-    Value warpSize = i32_val(triton::gpu::getWarpSize(srcLayout));
+    auto srcLayout =
+        mlir::cast<DistributedEncodingTrait>(helper.getSrcLayout());
+    auto mod = op.getOperation()->getParentOfType<ModuleOp>();
+    Value warpSize =
+        i32_val(triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod));
     Value warpId = udiv(threadId, warpSize);
     Value laneId = urem(threadId, warpSize);
-    auto srcShape = helper.getSrcShape();
     unsigned axis = op.getAxis();
     auto smemShape = helper.getScratchRepShape();
 
-    SmallVector<Value> multiDimLaneId =
-        getMultiDimLaneId(helper, laneId, loc, rewriter);
-    Value laneIdAxis = multiDimLaneId[axis];
-    Value zero = i32_val(0);
-    Value laneZero = icmp_eq(laneIdAxis, zero);
+    // Lezcano: We should move all the shared memory logic to use LLs natively
+    auto srcShape = helper.getSrcShape();
+    auto kLane = rewriter.getStringAttr("lane");
+    auto [multiDimLaneId, isRepresentativeLane] =
+        delinearize(rewriter, loc, srcLayout, srcShape, kLane, laneId);
+    auto kWarp = rewriter.getStringAttr("warp");
+    auto [multiDimWarpId, isRepresentativeWarp] =
+        delinearize(rewriter, loc, srcLayout, srcShape, kWarp, warpId);
 
-    SmallVector<Value> multiDimWarpId =
-        getMultiDimWarpId(helper, warpId, loc, rewriter);
+    Value laneIdAxis = multiDimLaneId[axis];
+    Value laneZero = icmp_eq(laneIdAxis, i32_val(0));
+    Value write =
+        and_(and_(isRepresentativeLane, isRepresentativeWarp), laneZero);
+
     Value warpIdAxis = multiDimWarpId[axis];
 
     auto smemOrder = helper.getOrderWithAxisAtBeginning();
@@ -335,7 +264,7 @@ private:
         auto elemTy = getElementType(op, i);
         Value writePtr =
             gep(smemBases[i].getType(), elemTy, smemBases[i], writeOffset);
-        targetInfo.storeShared(rewriter, loc, writePtr, acc[i], laneZero);
+        targetInfo.storeShared(rewriter, loc, writePtr, acc[i], write);
       }
     }
   }
@@ -346,21 +275,21 @@ private:
                                    SmallVector<Value> &smemBases,
                                    ConversionPatternRewriter &rewriter) const {
     triton::ReduceOp op = helper.getOperation();
-    auto srcLayout = helper.getSrcLayout();
     auto smemShape = helper.getScratchRepShape();
     unsigned elems = product<unsigned>(smemShape);
     unsigned sizeInterWarps = helper.getInterWarpSizeWithUniqueData();
     Location loc = op.getLoc();
 
+    auto mod = op.getOperation()->getParentOfType<ModuleOp>();
+    int numLanes = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
+    int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
+    int numThreads = numLanes * numWarps;
+
     Value threadId = getThreadId(rewriter, loc);
-    Value warpSize = i32_val(triton::gpu::getWarpSize(srcLayout));
+    Value warpSize = i32_val(numLanes);
     Value laneId = urem(threadId, warpSize);
     Value zero = i32_val(0);
 
-    auto mod = op.getOperation()->getParentOfType<ModuleOp>();
-    unsigned numThreads =
-        product<unsigned>(triton::gpu::getWarpsPerCTA(srcLayout)) *
-        triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
     unsigned elemsPerThread = std::max<unsigned>(elems / numThreads, 1);
     Value threadIsNeeded = icmp_slt(threadId, i32_val(elems));
     Value readOffset = threadId;

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -8,6 +8,17 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "llvm/ADT/STLExtras.h"
 
+#if defined(_MSC_VER) && !defined(__clang__)
+// from https://gist.github.com/pps83/3210a2f980fd02bb2ba2e5a1fc4a2ef0
+#include <intrin.h>
+
+static int __builtin_ctz(unsigned x) {
+  unsigned long r;
+  _BitScanForward(&r, x);
+  return static_cast<int>(r);
+}
+#endif
+
 namespace mlir {
 
 namespace triton::gpu {

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -2,6 +2,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Attributes.h"
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -580,6 +581,53 @@ SmallVector<Value> getStridesFromShapeAndOrder(ArrayRef<int64_t> shape,
     stride *= shape[idx];
   }
   return strides;
+}
+
+// Extract the bits of `a` that are set in `mask`
+Value pext_i32(RewriterBase &rewriter, Location loc, Value a, uint32_t mask) {
+  assert(a.getType() == i32_ty && "a must be i32");
+  // Handle width = 32 to avoid doing 1 << 32
+  if (mask == 0xFFFFFFFF)
+    return a;
+
+  // We implement a blocked algorithm to avoid generating too many instructions
+  Value result = i32_val(0);
+  int resultPos = 0;
+  while (mask) {
+    int start = __builtin_ctz(mask);
+    int width = __builtin_ctz(~(mask >> start));
+    Value shifted = lshr(a, i32_val(start));
+    Value widthMask = i32_val(((1u << width) - 1));
+    Value blockVal = and_(shifted, widthMask);
+    result = or_(result, shl(blockVal, i32_val(resultPos)));
+    resultPos += width;
+    mask &= ~(((1u << width) - 1) << start);
+  }
+  return result;
+}
+
+std::tuple<SmallVector<Value>, Value>
+delinearize(RewriterBase &rewriter, Location loc,
+            triton::gpu::DistributedEncodingTrait layout,
+            ArrayRef<int64_t> shape, StringAttr dimName, Value linear) {
+  auto ll = *triton::gpu::toLinearLayout(shape, layout);
+  auto linearLayout =
+      triton::gpu::LinearEncodingAttr::get(rewriter.getContext(), ll);
+  assert(ll.hasInDim(dimName));
+  int32_t freeVarMask = ll.getFreeVariableMasks()[dimName];
+  auto isRepresentative = true_val();
+  if (freeVarMask != 0) {
+    isRepresentative = icmp_eq(and_(i32_val(freeVarMask), linear), i32_val(0));
+    // We remove the bits of linear that are set to one in freeVarMask
+    int32_t nonFreeVarMask = ~freeVarMask & (ll.getInDimSize(dimName) - 1);
+    linear = pext_i32(rewriter, loc, linear, nonFreeVarMask);
+  }
+
+  auto orderDim = linearLayout.orderPerDim(dimName, linearLayout.getOrder());
+  auto shapeDim = linearLayout.basesPerDim(dimName);
+  auto multiDim = delinearize(rewriter, loc, linear, shapeDim, orderDim);
+
+  return std::make_tuple(std::move(multiDim), isRepresentative);
 }
 
 // Convert an \param index to a multi-dim coordinate given \param shape and

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -216,8 +216,52 @@ class SharedLayout:
         return f"#{GPU_DIALECT}.shared<{{vec={self.vec}, perPhase={self.per_phase}, maxPhase={self.max_phase}, order={self.order}, CTAsPerCGA={self.ctas_per_cga}, CTASplitNum={self.cta_split_num}, CTAOrder={self.cta_order}, hasLeadingOffset={has_leading_offset_str}}}>"
 
 
+class LinearLayout:
+
+    def __init__(self, register, lane, warp, block):
+        self.register = register
+        self.lane = lane
+        self.warp = warp
+        self.block = block
+
+    def __str__(self):
+        return f"#{GPU_DIALECT}.linear<{{register={self.register}, lane={self.lane}, warp={self.warp}, block={self.block}}}>"
+
+
+# Python impl of LinearEncodingAttr::basesPerDim
+def bases_per_dim(layout, dim, rank, skip_broadcast=True):
+    assert isinstance(layout, LinearLayout)
+    bases = getattr(layout, dim)
+    result = [1] * rank
+
+    if not bases:
+        return result
+
+    non_zero_idx = None
+
+    for basis in bases:
+        # Find the first non-zero index in the current basis
+        idx = next((i for i, v in enumerate(basis) if v != 0), None)
+        if idx is not None:
+            non_zero_idx = idx
+            result[idx] *= 2
+        elif not skip_broadcast:
+            # If no non-zero found and we're not skipping broadcasts, use the last found non-zero index
+            assert non_zero_idx is not None
+            result[non_zero_idx] *= 2
+
+    return result
+
+
+def warps_per_cta(layout, shape):
+    if isinstance(layout, LinearLayout):
+        return bases_per_dim(layout, 'warp', len(shape))
+    else:
+        return layout.warps_per_cta
+
+
 def is_layout_applicable(layout) -> bool:
-    if isinstance(layout, (BlockedLayout, SharedLayout)):
+    if isinstance(layout, (BlockedLayout, SharedLayout, LinearLayout)):
         return True
     elif isinstance(layout, SliceLayout):
         return is_layout_applicable(layout.parent)
@@ -2727,6 +2771,9 @@ layouts = [
     WmmaLayout(version=1, warps_per_cta=[2, 2]),
     WmmaLayout(version=1, warps_per_cta=[4, 1]),
     WmmaLayout(version=1, warps_per_cta=[1, 4]),
+    LinearLayout(register=[[0, 16], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], lane=[[0, 0], [0, 1], [0, 2], [0, 4],
+                                                                                    [0, 8]], warp=[[32, 0], [0, 32]],
+                 block=[]),
 ]
 
 
@@ -2772,7 +2819,8 @@ def test_reduce_layouts(M, N, src_layout, axis, epilogue_kind, dtype_str, add_ov
     rdims_2d = f"1x{N}" if axis == 0 else f"{M}x1"
     store_range = "%7" if axis == 0 else "%1"
     blocked = BlockedLayout([1, 1], [32, THREADS_PER_WARP // 32], [4, 1], [0, 1], [1, 1], [1, 1], [0, 1])
-    num_warps = src_layout.warps_per_cta[0] * src_layout.warps_per_cta[1]
+    warps = warps_per_cta(src_layout, [M, N])
+    num_warps = warps[0] * warps[1]
     if num_warps == 8:
         blocked = BlockedLayout([1, 1], [32, THREADS_PER_WARP // 32], [4, 2], [0, 1], [1, 1], [1, 1], [0, 1])
     one_d_layout = BlockedLayout([1], [THREADS_PER_WARP], [num_warps], [0], [1], [1], [0])


### PR DESCRIPTION
To do so, we implemented three things:

- Implement `delinearize` for arbitrary LinearLayouts
- Generalisations of ReduceOpHelper methods
- Use `getNumWarps(mod)` rather than `getWarpSize(srcLayout)`

The first error was already noted in https://github.com/triton-lang/triton/pull/5477#issuecomment-2557720717

The last issue is a bit more problematic. It turns out that the current
implementation of `LinearEncodingAttr::getWarpSize` actually implements
`getWarpsPerCTAWithUniqueData`. Now, this is what we want 99% percent of
the time, so I think this is correct. That being said, after this PR is
merged, I will put up a PR removing `getWarpSize` and
`getNumWarpsPerCTA` in favour of the module-level ops. In the future, we
should simply remove all uses of `.*WithUniqueData` functions in favour
of the vanilla ones.

We also add regression tests.
