### PR TITLE
Release Only - Enable pypi promotion for 3.2.x release

### DIFF
--- a/.github/workflows/wheels_v2.yml
+++ b/.github/workflows/wheels_v2.yml
@@ -3,9 +3,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "20 2 * * *"
-  pull_request:
-    paths:
-      - .github/workflows/wheels_v2.yml
 
 jobs:
 

--- a/.github/workflows/wheels_v2.yml
+++ b/.github/workflows/wheels_v2.yml
@@ -77,6 +77,5 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Upload wheels to PyPI
-        if: false # Disable Upload to PyPI until ready for release
         run: |
           python3 -m twine upload wheelhouse/* -u __token__ -p ${{ secrets.PYPY_API_TOKEN }}

--- a/.github/workflows/wheels_v2.yml
+++ b/.github/workflows/wheels_v2.yml
@@ -1,8 +1,6 @@
 name: Wheels Build manylinux2014_x86_64
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "20 2 * * *"
 
 jobs:
 


### PR DESCRIPTION
We are ready for release 3.2.x hence enable promotion to pypi