### PR TITLE
[BACKEND] Deprecate the `strides` field in `SharedMemoryObject`

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -257,9 +257,7 @@ struct SharedMemoryObject {
 
   SharedMemoryObject(Value base, Type baseElemType, ArrayRef<Value> offsets)
       : base(base), baseElemType(baseElemType),
-        offsets(offsets.begin(), offsets.end()) {
-    assert(strides.size() == offsets.size());
-  }
+        offsets(offsets.begin(), offsets.end()) {}
 
   SharedMemoryObject(Value base, Type baseElemType, ArrayRef<int64_t> shape,
                      triton::gpu::SharedEncodingAttr layout, Location loc,

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -283,7 +283,7 @@ public:
         triton::gpu::getShapePerCTA(memDesc.getEncoding(), allocShape);
     auto layoutOrder = triton::gpu::getOrder(memDesc.getEncoding());
     auto allocStrides = SharedMemoryObject::getStridesForShape(
-        allocShape, layoutOrder, loc, rewriter);
+        allocShapePerCTA, layoutOrder, loc, rewriter);
     return SmallVector<Value>(allocStrides.end() - offsets.size(),
                               allocStrides.end());
   }

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -246,36 +246,17 @@ createLLVMIntrinsicCallOp(OpBuilder &builder, Location loc, StringRef intrinsic,
 // Is v an integer or floating-point scalar constant equal to 0?
 bool isConstantZero(Value v);
 
-/// Helper function to get strides from a given shape and its order
-SmallVector<Value> getStridesFromShapeAndOrder(ArrayRef<int64_t> shape,
-                                               ArrayRef<unsigned> order,
-                                               Location loc,
-                                               RewriterBase &rewriter);
 struct SharedMemoryObject {
   Value base; // i32 ptr. The start address of the shared memory object after
               // the initial allocation or the last slicing operation.
   Type baseElemType;
-  // We need to store strides as Values, not integers, because the
-  // extract_slice instruction can take a slice at arbitrary offsets.
-  // Take $a[16:32, 16:32] as an example; though we know the stride of $a[0] is
-  // 32, we need to let the instruction that uses $a be aware of that.
-  // Otherwise, when we use $a, we only know that the shape of $a is 16x16. If
-  // we store strides into an attribute array of integers, the information
-  // cannot pass through block argument assignment because attributes are
-  // associated with operations, not Values.
-  // TODO(Keren): We may need to figure out a way to store strides as integers
-  // if we want to support more optimizations.
-  SmallVector<Value>
-      strides; // i32 int. The strides of the shared memory object.
   SmallVector<Value> offsets; // i32 int.
   // Offsets are applied at the last slicing operation.
   // We can use offsets to recover the previous base.
   // The offsets are zero at the initial allocation.
 
-  SharedMemoryObject(Value base, Type baseElemType, ArrayRef<Value> strides,
-                     ArrayRef<Value> offsets)
+  SharedMemoryObject(Value base, Type baseElemType, ArrayRef<Value> offsets)
       : base(base), baseElemType(baseElemType),
-        strides(strides.begin(), strides.end()),
         offsets(offsets.begin(), offsets.end()) {
     assert(strides.size() == offsets.size());
   }
@@ -295,11 +276,9 @@ struct SharedMemoryObject {
         order[i] = layoutOrder[i] - rankDiff;
     }
     assert(isPermutationOfIota(order) && "Invalid order");
-    strides = getStridesFromShapeAndOrder(shape, order, loc, rewriter);
     offsets.append(order.size(), i32_val(0));
   }
 
-  SmallVector<Value> getStrides() const { return strides; }
   SmallVector<Value> getOffsets() const { return offsets; }
   Value getBase() const { return base; }
   Type getBaseElemType() const { return baseElemType; }
@@ -307,7 +286,6 @@ struct SharedMemoryObject {
   SmallVector<Value> getElems() const {
     SmallVector<Value> elems;
     elems.push_back(base);
-    elems.append(strides.begin(), strides.end());
     elems.append(offsets.begin(), offsets.end());
     return elems;
   }
@@ -315,13 +293,12 @@ struct SharedMemoryObject {
   SmallVector<Type> getTypes() const {
     SmallVector<Type> types;
     types.push_back(base.getType());
-    types.append(strides.size(), IntegerType::get(base.getContext(), 32));
     types.append(offsets.size(), IntegerType::get(base.getContext(), 32));
     return types;
   }
 
   Value getCSwizzleOffset(int dim) const {
-    assert(dim >= 0 && dim < strides.size());
+    assert(dim >= 0 && dim < offsets.size());
     return offsets[dim];
   }
 
@@ -333,6 +310,16 @@ struct SharedMemoryObject {
     return gep(type, baseElemType, base, offset);
   }
 };
+
+/// Helper function to get strides from a given shape and its order
+SmallVector<Value> getStridesFromShapeAndOrder(ArrayRef<int64_t> shape,
+                                               ArrayRef<unsigned> order,
+                                               Location loc,
+                                               RewriterBase &rewriter);
+
+Value getStructFromSharedMemoryObject(Location loc,
+                                      const SharedMemoryObject &smemObj,
+                                      RewriterBase &rewriter);
 
 SharedMemoryObject getSharedMemoryObjectFromStruct(Location loc,
                                                    Value llvmStruct,
@@ -1022,22 +1009,6 @@ void storeDistributedToShared(
     ArrayRef<Value> srcVals, const SharedMemoryObject &smemObj, Location loc,
     RewriterBase &rewriter, const TargetInfoBase &target,
     std::pair<size_t, Type> *const llvmOpCount = nullptr);
-
-inline Value getStructFromSharedMemoryObject(Location loc,
-                                             const SharedMemoryObject &smemObj,
-                                             RewriterBase &rewriter) {
-  auto elems = smemObj.getElems();
-  auto types = smemObj.getTypes();
-  auto structTy =
-      LLVM::LLVMStructType::getLiteral(rewriter.getContext(), types);
-  // pack into struct
-  Value llvmStruct = rewriter.create<LLVM::UndefOp>(loc, structTy);
-  for (const auto &v : llvm::enumerate(elems)) {
-    assert(v.value() && "can not insert null values");
-    llvmStruct = insert_val(structTy, llvmStruct, v.value(), v.index());
-  }
-  return llvmStruct;
-}
 
 inline SmallVector<Value> unpackLLElements(Location loc, Value llvmStruct,
                                            RewriterBase &rewriter) {

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -252,12 +252,10 @@ public:
       : base(base), baseElemType(baseElemType),
         offsets(offsets.begin(), offsets.end()) {}
 
-  SharedMemoryObject(Value base, Type baseElemType, ArrayRef<int64_t> shape,
-                     Attribute layout, Location loc, RewriterBase &rewriter)
+  SharedMemoryObject(Value base, Type baseElemType, int64_t rank, Location loc,
+                     RewriterBase &rewriter)
       : base(base), baseElemType(baseElemType) {
-    auto layoutOrder = ::mlir::triton::gpu::getOrder(layout);
-    auto order = SharedMemoryObject::getOrderForShape(shape, layoutOrder);
-    offsets.append(order.size(), i32_val(0));
+    offsets.append(rank, i32_val(0));
   }
 
   SmallVector<Value> getOffsets() const { return offsets; }
@@ -278,7 +276,7 @@ public:
     return types;
   }
 
-  SmallVector<Value> getStrides(MemDescType memDesc, Location loc,
+  SmallVector<Value> getStrides(triton::gpu::MemDescType memDesc, Location loc,
                                 RewriterBase &rewriter) const {
     auto allocShape = memDesc.getAllocShape();
     auto allocShapePerCTA =

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -283,7 +283,8 @@ public:
                                 RewriterBase &rewriter) const {
     auto allocStrides = SharedMemoryObject::getStridesForShape(
         allocShape, layoutOrder, loc, rewriter);
-    return {allocStrides.end() - offsets.size(), allocStrides.end()};
+    return SmallVector<Value>(allocStrides.end() - offsets.size(),
+                              allocStrides.end());
   }
 
   static SmallVector<unsigned>

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
@@ -231,8 +231,7 @@ Value loadFMAOp(Value srcVal, Value llVal, BlockedEncodingAttr dLayout,
       rewriter);
   auto smem = getExpandedSharedMemoryObject(rewriter, loc, origSmem,
                                             opTensorTy.getShape());
-  auto smemStrides =
-      origSmem.getStrides(opTensorTy.getAllocShape(), opOrder, loc, rewriter);
+  auto smemStrides = origSmem.getStrides(opTensorTy, loc, rewriter);
   int B = opTensorShape[dim.batch];
   int K = opTensorShape[dim.k];
   int NonK = opTensorShape[dim.nonK];

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
@@ -231,7 +231,8 @@ Value loadFMAOp(Value srcVal, Value llVal, BlockedEncodingAttr dLayout,
       rewriter);
   auto smem = getExpandedSharedMemoryObject(rewriter, loc, origSmem,
                                             opTensorTy.getShape());
-  auto strides = smem.strides;
+  auto strides =
+      LLVM::getStridesFromShapeAndOrder(opTensorShape, opOrder, loc, rewriter);
   int B = opTensorShape[dim.batch];
   int K = opTensorShape[dim.k];
   int NonK = opTensorShape[dim.nonK];

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -80,9 +80,8 @@ struct LocalAllocOpConversion
         cast<triton::gpu::SharedEncodingAttr>(resultTy.getEncoding());
 
     auto llvmElemTy = typeConverter->convertType(resultTy.getElementType());
-    auto shapePerCTA = getShapePerCTA(sharedLayout, resultTy.getShape());
-    auto smemObj = SharedMemoryObject(smemBase, llvmElemTy, shapePerCTA,
-                                      sharedLayout, loc, rewriter);
+    auto smemObj = SharedMemoryObject(smemBase, llvmElemTy, resultTy.getRank(),
+                                      loc, rewriter);
     // If there is an initial tensor, store it into the shared memory.
     if (op.getSrc()) {
       lowerDistributedToShared(loc, op.getSrc(), op.getResult(),

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -90,8 +90,8 @@ Type TritonGPUToLLVMTypeConverter::convertTritonTensorType(
     types.push_back(ptrType);
     // shape dims
     auto rank = type.getRank();
-    // offsets + strides
-    for (auto i = 0; i < rank * 2; i++) {
+    // offsets
+    for (auto i = 0; i < rank; i++) {
       types.push_back(IntegerType::get(ctx, 32));
     }
     return LLVM::LLVMStructType::getLiteral(ctx, types);
@@ -114,8 +114,8 @@ Type TritonGPUToLLVMTypeConverter::convertMemDescType(
   types.push_back(ptrType);
   // shape dims
   auto rank = type.getShape().size();
-  // offsets + strides
-  for (auto i = 0; i < rank * 2; i++) {
+  // offsets
+  for (auto i = 0; i < rank; i++) {
     types.push_back(IntegerType::get(ctx, 32));
   }
   return LLVM::LLVMStructType::getLiteral(ctx, types);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -184,6 +184,7 @@ Value getSmemVecAddr(RankedTensorType registerTy,
   StringAttr kLane = str_attr("lane");
   StringAttr kWarp = str_attr("warp");
   auto shape = sharedTy.getShape();
+  auto allocShape = sharedTy.getAllocShape();
   auto rank = shape.size();
   auto sharedEnc =
       dyn_cast<triton::gpu::SharedEncodingAttr>(sharedTy.getEncoding());
@@ -191,8 +192,7 @@ Value getSmemVecAddr(RankedTensorType registerTy,
   auto smemBase = smemObj.getBase();
   auto smemOffsets = smemObj.getOffsets();
   auto smemOrder = sharedEnc.getOrder();
-  auto smemStrides =
-      smemObj.getStrides(sharedTy.getAllocShape(), smemOrder, loc, rewriter);
+  auto smemStrides = smemObj.getStrides(allocShape, smemOrder, loc, rewriter);
   Value smemOffset;
   // When loading or storing to shared memory, we consider two cases for
   // performance reasons:

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -191,7 +191,11 @@ Value getSmemVecAddr(RankedTensorType registerTy,
 
   auto smemBase = smemObj.getBase();
   auto smemOffsets = smemObj.getOffsets();
-  auto smemStrides = getStride auto smemOrder = sharedEnc.getOrder();
+  auto smemOrder = sharedEnc.getOrder();
+  auto allocStrides =
+      LLVM::getStridesFromShapeAndOrder(allocShape, smemOrder, loc, rewriter);
+  auto smemStrides =
+      SmallVector<Value>(allocStrides.end() - rank, allocStrides.end());
   Value smemOffset;
   // When loading or storing to shared memory, we consider two cases for
   // performance reasons:

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -581,28 +581,6 @@ SharedMemoryObject getSharedMemoryObjectFromStruct(Location loc,
           /*offsets=*/{elems.begin() + 1, elems.end()}};
 }
 
-SmallVector<Value> getSmemAllocStrides(ArrayRef<int64_t> allocShape,
-                                       ArrayRef<unsigned> layoutOrder,
-                                       Location loc, RewriterBase &rewriter) {
-  // Default minor-to-major order
-  SmallVector<unsigned> allocOrder(allocShape.size());
-  std::iota(allocOrder.rbegin(), allocOrder.rend(), 0);
-  int rankDiff = layoutOrder.size() - allocShape.size();
-  auto minRank = std::min(allocShape.size(), layoutOrder.size());
-  for (size_t i = 0; i < minRank; ++i)
-    allocOrder[i] = layoutOrder[i] - rankDiff;
-  assert(isPermutationOfIota(allocOrder) && "Invalid order");
-
-  auto rank = allocShape.size();
-  SmallVector<Value> allocStrides(rank);
-  int64_t stride = 1;
-  for (auto idx : allocOrder) {
-    allocStrides[idx] = i32_val(stride);
-    stride *= allocShape[idx];
-  }
-  return allocStrides;
-}
-
 // Convert an \param index to a multi-dim coordinate given \param shape and
 // \param order.
 SmallVector<Value> delinearize(RewriterBase &rewriter, Location loc,

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -576,11 +576,9 @@ SharedMemoryObject getSharedMemoryObjectFromStruct(Location loc,
     Type type = types[i];
     elems[i] = extract_val(type, llvmStruct, i);
   }
-
-  auto rank = (elems.size() - 1) / 2;
   return {/*base=*/elems[0],
           /*baseElemType=*/elemTy,
-          /*offsets=*/{elems.begin() + 1 + rank, elems.end()}};
+          /*offsets=*/{elems.begin() + 1, elems.end()}};
 }
 
 SmallVector<Value> getSmemAllocStrides(ArrayRef<int64_t> allocShape,

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -209,10 +209,8 @@ Value getSmemVecAddr(RankedTensorType registerTy,
 
   auto smemBase = smemObj.getBase();
   auto smemOffsets = smemObj.getOffsets();
+  auto smemStrides = smemObj.getStrides(sharedTy, loc, rewriter);
   auto smemOrder = sharedEnc.getOrder();
-  auto allocShapePerCTA = triton::gpu::getShapePerCTA(sharedEnc, allocShape);
-  auto smemStrides =
-      smemObj.getStrides(allocShapePerCTA, smemOrder, loc, rewriter);
   Value smemOffset;
   // When loading or storing to shared memory, we consider two cases for
   // performance reasons:

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -210,7 +210,9 @@ Value getSmemVecAddr(RankedTensorType registerTy,
   auto smemBase = smemObj.getBase();
   auto smemOffsets = smemObj.getOffsets();
   auto smemOrder = sharedEnc.getOrder();
-  auto smemStrides = smemObj.getStrides(allocShape, smemOrder, loc, rewriter);
+  auto allocShapePerCTA = triton::gpu::getShapePerCTA(sharedEnc, allocShape);
+  auto smemStrides =
+      smemObj.getStrides(allocShapePerCTA, smemOrder, loc, rewriter);
   Value smemOffset;
   // When loading or storing to shared memory, we consider two cases for
   // performance reasons:

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -383,8 +383,9 @@ struct MemDescSubviewOpConversion
     auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
     auto layoutOrder = getOrder(srcTy.getEncoding());
     auto allocShape = srcTy.getAllocShape();
+    auto allocShapePerCTA = getShapePerCTA(srcTy.getEncoding(), allocShape);
     auto allocStrides = SharedMemoryObject::getStridesForShape(
-        allocShape, layoutOrder, loc, rewriter);
+        allocShapePerCTA, layoutOrder, loc, rewriter);
 
     // newBase = base + offset
     auto smemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -284,8 +284,8 @@ struct MemDescTransOpConversion
     auto srcSmemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                       llvmElemTy, rewriter);
     auto dstSmemObj = SharedMemoryObject(
-        srcSmemObj.base, srcSmemObj.baseElemType,
-        /*offsets=*/applyPermutation(srcSmemObj.offsets, op.getOrder()));
+        srcSmemObj.getBase(), srcSmemObj.getBaseElemType(),
+        /*offsets=*/applyPermutation(srcSmemObj.getOffsets(), op.getOrder()));
     auto retVal = getStructFromSharedMemoryObject(loc, dstSmemObj, rewriter);
     rewriter.replaceOp(op, retVal);
     return success();

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -527,6 +527,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-NEXT: llvm.extractvalue
     // CHECK-NEXT: llvm.extractvalue
     // CHECK-NEXT: llvm.extractvalue
+    // CHECK-NEXT: llvm.mlir.constant(1 : i32) : i32
+    // CHECK-NEXT: llvm.mlir.constant(32 : i32) : i32
+    // CHECK-NEXT: llvm.mlir.constant(512 : i32) : i32
     // CHECK-NEXT: llvm.add
     // CHECK-NEXT: llvm.add
     // CHECK-NEXT: llvm.mlir.constant(0 : i32) : i32

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -527,9 +527,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-NEXT: llvm.extractvalue
     // CHECK-NEXT: llvm.extractvalue
     // CHECK-NEXT: llvm.extractvalue
-    // CHECK-NEXT: llvm.extractvalue
-    // CHECK-NEXT: llvm.extractvalue
-    // CHECK-NEXT: llvm.extractvalue
     // CHECK-NEXT: llvm.add
     // CHECK-NEXT: llvm.add
     // CHECK-NEXT: llvm.mlir.constant(0 : i32) : i32

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.cpp
@@ -216,7 +216,7 @@ llvm::SmallVector<Value> computeOffsetsBType(
         Value row = mapping[i][1];
         Value col = add(mapping[i][0], i32_val(blockNonKOffset));
         bOffsets[block * blockSize + i] =
-            computeOffset(rewriter, loc, row, col, smemObj, srcLayout);
+            computeOffset(rewriter, loc, row, col, smemObj, strides, srcLayout);
       }
     }
   } else {
@@ -228,7 +228,7 @@ llvm::SmallVector<Value> computeOffsetsBType(
       Value row = mapping[i][1];
       Value col = mapping[i][0];
       inblockOffset[i] =
-          computeOffset(rewriter, loc, row, col, smemObj, srcLayout);
+          computeOffset(rewriter, loc, row, col, smemObj, strides, srcLayout);
     }
     for (int block = 0; block < numBlocks; ++block) {
       int blockNonKOffset = block * nonKDim * warpsPerBlock;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
@@ -30,10 +30,11 @@ swizzleIndexes(ConversionPatternRewriter &rewriter, Location loc, Value row,
 
 Value computeOffset(ConversionPatternRewriter &rewriter, Location loc,
                     Value row, Value col, SharedMemoryObject smemObj,
-                    gpu::SharedEncodingAttr srcLayout);
+                    ArrayRef<Value> strides, gpu::SharedEncodingAttr srcLayout);
 
 Value computeBasePtr(ConversionPatternRewriter &rewriter, Location loc,
-                     const SharedMemoryObject &smemObj);
+                     const SharedMemoryObject &smemObj,
+                     ArrayRef<Value> strides);
 
 bool isKMajor(llvm::ArrayRef<unsigned> order, int opIdx);
 
@@ -47,14 +48,14 @@ llvm::SmallVector<Value> computeOffsetsAType(
     ConversionPatternRewriter &rewriter, Location loc,
     computeTensorElemMappingInBlockT fn, const ArrayRef<int64_t> &elemsPerInstr,
     Value warpId, Value laneId, int warpsPerBlock, int numOfElems,
-    ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
+    ArrayRef<int64_t> reps, SharedMemoryObject smemObj, ArrayRef<Value> strides,
     gpu::SharedEncodingAttr srcLayout, unsigned nonKDim, unsigned kDim);
 
 llvm::SmallVector<Value> computeOffsetsBType(
     ConversionPatternRewriter &rewriter, Location loc,
     computeTensorElemMappingInBlockT fn, const ArrayRef<int64_t> &elemsPerInstr,
     Value warpId, Value laneId, int warpsPerBlock, int numOfElems,
-    ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
+    ArrayRef<int64_t> reps, SharedMemoryObject smemObj, ArrayRef<Value> strides,
     gpu::SharedEncodingAttr srcLayout, unsigned nonKDim, unsigned kDim);
 
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -274,11 +274,10 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   Value warpIdInBatch = urem(linearWarpId, i32_val(warpsPerBatch));
   elemTy = typeConverter->convertType(elemTy);
 
-  auto smemStrides =
-      smemObj.getStrides(aTensorTy.getAllocShape(), order, loc, rewriter);
   SmallVector<Value> loadedValues;
   SmallVector<Value> offsets;
   Value smemBase;
+  auto smemStrides = smemObj.getStrides(aTensorTy, loc, rewriter);
   bool isFastPath =
       !AMD::isKMajor(order, opIdx) && !hasSwizzleEnabled(sharedLayout);
   if (isFastPath) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
@@ -187,9 +187,8 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
 
   SmallVector<Value> loadedValues;
   SmallVector<Value> offsets;
-  auto smemStrides =
-      smemObj.getStrides(aTensorTy.getAllocShape(), order, loc, rewriter);
   Value smemBase;
+  auto smemStrides = smemObj.getStrides(aTensorTy, loc, rewriter);
   Value spatialWarpId = AMD::getWarpIdInBlock(
       rewriter, loc, linearWaveId, warpsPerCTA, elemsPerInstr[0],
       shape[nonKDimIdx], nonKDimIdx, triton::gpu::getOrder(wmmaLayout));

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
@@ -187,7 +187,7 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
 
   SmallVector<Value> loadedValues;
   SmallVector<Value> offsets;
-  auto strides =
+  auto smemStrides =
       smemObj.getStrides(aTensorTy.getAllocShape(), order, loc, rewriter);
   Value smemBase;
   Value spatialWarpId = AMD::getWarpIdInBlock(
@@ -197,15 +197,15 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
     offsets = AMD::computeOffsetsAType(
         rewriter, loc, computeTensorElemMappingInBlock, elemsPerInstr,
         spatialWarpId, lane, warpsPerBlockNonK, numElemsPerThreadPerRep,
-        numReps, smemObj, strides, sharedLayout, wmmaInstrNonK, wmmaInstrK);
+        numReps, smemObj, smemStrides, sharedLayout, wmmaInstrNonK, wmmaInstrK);
   } else {
     assert(opIdx == 1);
     offsets = AMD::computeOffsetsBType(
         rewriter, loc, computeTensorElemMappingInBlock, elemsPerInstr,
         spatialWarpId, lane, warpsPerBlockNonK, numElemsPerThreadPerRep,
-        numReps, smemObj, strides, sharedLayout, wmmaInstrNonK, wmmaInstrK);
+        numReps, smemObj, smemStrides, sharedLayout, wmmaInstrNonK, wmmaInstrK);
   }
-  smemBase = AMD::computeBasePtr(rewriter, loc, smemObj, strides);
+  smemBase = AMD::computeBasePtr(rewriter, loc, smemObj, smemStrides);
 
   Type resElemTy = typeConverter->convertType(elemTy);
   Type smemPtrTy = ptr_ty(rewriter.getContext(), 3);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
@@ -187,10 +187,8 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
 
   SmallVector<Value> loadedValues;
   SmallVector<Value> offsets;
-  auto allocStrides = LLVM::getStridesFromShapeAndOrder(
-      aTensorTy.getAllocShape(), order, loc, rewriter);
   auto strides =
-      SmallVector<Value>(allocStrides.end() - order.size(), allocStrides.end());
+      smemObj.getStrides(aTensorTy.getAllocShape(), order, loc, rewriter);
   Value smemBase;
   Value spatialWarpId = AMD::getWarpIdInBlock(
       rewriter, loc, linearWaveId, warpsPerCTA, elemsPerInstr[0],

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2OrV3.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2OrV3.cpp
@@ -589,8 +589,7 @@ getLoadMatrixFn(MemDescType descTy, const SharedMemoryObject &smemObj,
   const int mmaElemBytes = 4 / kWidth;
   const bool isHopper = mmaLayout.getVersionMajor() == 3;
   auto order = sharedLayout.getOrder();
-  auto strides = SharedMemoryObject::getStridesForShape(descTy.getAllocShape(),
-                                                        order, loc, rewriter);
+  auto strides = smemObj.getStrides(descTy, loc, rewriter);
 
   int nPerWarp =
       std::max<int>(shapePerCTA[2] / mmaLayout.getWarpsPerCTA()[2], 8);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2OrV3.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2OrV3.cpp
@@ -589,6 +589,10 @@ getLoadMatrixFn(MemDescType descTy, const SharedMemoryObject &smemObj,
   const int mmaElemBytes = 4 / kWidth;
   const bool isHopper = mmaLayout.getVersionMajor() == 3;
   auto order = sharedLayout.getOrder();
+  auto allocStrides = LLVM::getStridesFromShapeAndOrder(descTy.getAllocShape(),
+                                                        order, loc, rewriter);
+  SmallVector<Value> strides = {allocStrides.end() - order.size(),
+                                allocStrides.end()};
 
   int nPerWarp =
       std::max<int>(shapePerCTA[2] / mmaLayout.getWarpsPerCTA()[2], 8);
@@ -596,9 +600,9 @@ getLoadMatrixFn(MemDescType descTy, const SharedMemoryObject &smemObj,
   auto load = [=, &rewriter, &vals](int batch, int a, int b) {
     MMA16816SmemLoader loader(
         nPerWarp, warpsPerTile, order, mmaLayout.getWarpsPerCTA(), kOrder,
-        kWidth, smemObj.strides, shapePerCTA /*tileShape*/, instrShape,
-        matShape, multiDimWarpId, perPhase, maxPhase, elemBytes, mmaElemBytes,
-        isHopper, rewriter, typeConverter, loc);
+        kWidth, strides, shapePerCTA /*tileShape*/, instrShape, matShape,
+        multiDimWarpId, perPhase, maxPhase, elemBytes, mmaElemBytes, isHopper,
+        rewriter, typeConverter, loc);
     // Offset of a slice within the original tensor in shared memory
     Value cSwizzleOffset = smemObj.getCSwizzleOffset(order[0]);
     SmallVector<Value> offs = loader.computeOffsets(lane, cSwizzleOffset);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2OrV3.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2OrV3.cpp
@@ -589,10 +589,8 @@ getLoadMatrixFn(MemDescType descTy, const SharedMemoryObject &smemObj,
   const int mmaElemBytes = 4 / kWidth;
   const bool isHopper = mmaLayout.getVersionMajor() == 3;
   auto order = sharedLayout.getOrder();
-  auto allocStrides = LLVM::getStridesFromShapeAndOrder(descTy.getAllocShape(),
-                                                        order, loc, rewriter);
-  SmallVector<Value> strides = {allocStrides.end() - order.size(),
-                                allocStrides.end()};
+  auto strides =
+      smemObj.getStrides(descTy.getAllocShape(), order, loc, rewriter);
 
   int nPerWarp =
       std::max<int>(shapePerCTA[2] / mmaLayout.getWarpsPerCTA()[2], 8);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2OrV3.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2OrV3.cpp
@@ -589,8 +589,8 @@ getLoadMatrixFn(MemDescType descTy, const SharedMemoryObject &smemObj,
   const int mmaElemBytes = 4 / kWidth;
   const bool isHopper = mmaLayout.getVersionMajor() == 3;
   auto order = sharedLayout.getOrder();
-  auto strides =
-      smemObj.getStrides(descTy.getAllocShape(), order, loc, rewriter);
+  auto strides = SharedMemoryObject::getStridesForShape(descTy.getAllocShape(),
+                                                        order, loc, rewriter);
 
   int nPerWarp =
       std::max<int>(shapePerCTA[2] / mmaLayout.getWarpsPerCTA()[2], 8);
@@ -789,13 +789,16 @@ MemDescType getExpandedDesc(MemDescType descTy) {
 
   auto elTy = descTy.getElementType();
   auto shape = descTy.getShape();
+  auto allocShape = descTy.getAllocShape();
+  auto isMutable = descTy.getMutableMemory();
   auto expandedShape = SmallVector<int64_t>(3, 1);
   expandedShape[1] = shape[0];
   expandedShape[2] = shape[1];
   auto encoding = descTy.getEncoding();
   auto expandedEncoding = getExpandedEncoding(encoding);
-  auto expandedDesc = MemDescType::get(expandedShape, elTy, expandedEncoding,
-                                       descTy.getMemorySpace());
+  auto expandedDesc =
+      MemDescType::get(expandedShape, elTy, expandedEncoding,
+                       descTy.getMemorySpace(), isMutable, allocShape);
   return expandedDesc;
 }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2OrV3.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2OrV3.cpp
@@ -789,11 +789,13 @@ MemDescType getExpandedDesc(MemDescType descTy) {
 
   auto elTy = descTy.getElementType();
   auto shape = descTy.getShape();
-  auto allocShape = descTy.getAllocShape();
   auto isMutable = descTy.getMutableMemory();
   auto expandedShape = SmallVector<int64_t>(3, 1);
   expandedShape[1] = shape[0];
   expandedShape[2] = shape[1];
+  SmallVector<int64_t> allocShape = llvm::to_vector(descTy.getAllocShape());
+  for (int i = allocShape.size(); i < 3; ++i)
+    allocShape.insert(allocShape.begin(), 1);
   auto encoding = descTy.getEncoding();
   auto expandedEncoding = getExpandedEncoding(encoding);
   auto expandedDesc =

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -6,8 +6,6 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
-using ::mlir::triton::gpu::DotOperandEncodingAttr;
 using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -394,11 +394,11 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
         getSharedMemoryObjectFromStruct(
             loc, loadedA,
             typeConverter->convertType(aTensorTy.getElementType()), rewriter)
-            .base;
+            .getBase();
   baseB = getSharedMemoryObjectFromStruct(
               loc, loadedB,
               typeConverter->convertType(bTensorTy.getElementType()), rewriter)
-              .base;
+              .getBase();
   if (aSharedLayout) {
     auto aOrd = aSharedLayout.getOrder();
     transA = aOrd[0] == 0;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -318,9 +318,8 @@ struct LocalAllocOpConversion
     }
 
     auto resultTy = cast<MemDescType>(op.getType());
-    auto shapePerCTA = getShapePerCTA(sharedLayout, resultTy.getShape());
-    auto smemObj = SharedMemoryObject(smemBase, llvmElemTy, shapePerCTA,
-                                      sharedLayout, op.getLoc(), rewriter);
+    auto smemObj = SharedMemoryObject(smemBase, llvmElemTy, resultTy.getRank(),
+                                      op.getLoc(), rewriter);
     auto retVal =
         getStructFromSharedMemoryObject(op.getLoc(), smemObj, rewriter);
     rewriter.replaceOp(op, retVal);


### PR DESCRIPTION
After this PR, we no longer extract strides from llvm struct. Instead, we can get the strides through the `getStrides(memdesc, loc, rewriter)`, which extracts constant numbers from the allocation shape.