### PR TITLE
Automatic Warp Specialization Optimization (#5622)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,162 @@ Supported Hardware:
   * NVIDIA GPUs (Compute Capability 7.0+)
   * AMD GPUs (ROCm 5.2+)
   * Under development: CPUs
+
+
+
+# Warp Specialization Support
+
+
+Warp specialization enhances kernel performance by utilizing an asynchronous execution model, where different parts of the kernel are handled by separate hardware units. The data communication between these units, via shared memory on the H100, operates with high efficiency. With this in mind, we’ve developed an automatic warp specialization optimization that partitions a user kernel into asynchronous tasks (which map to warp groups on NVIDIA GPU), which naturally execute concurrently, leveraging the hardware’s multitasking warp scheduler. The following sections provide a breakdown of the compiler features developed to enable warp specialization.
+
+
+## Asynchronous Tasks
+
+Warp specialization is built on top of the concept of partitioning the user’s program into asynchronous tasks (referred to as "async tasks" or “tasks” in the following sections). Each async task will be executed by a standalone warp group on the supported hardware, to achieve instruction level parallelism. While optimally and automatically partitioning asynchronous tasks remains a challenge for compilers, our approach to automatic task partitioning has proven effective for kernels similar to typical examples like GEMM and Flash Attention.
+
+To enable warp specialization, user just needs to specify certain autotune flags, i.e., `num_consumer_groups` and `num_buffers_warp_spec`. For example, a warp-specialized GEMM implementation might look like below. You can find a complete example in 09-persistent-matmul.py.
+
+```python
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 256,
+                "BLOCK_SIZE_K": 64,
+                "GROUP_SIZE_M": 8,
+            },
+            num_stages=2,
+            num_warps=4,
+            num_consumer_groups=2,
+            num_buffers_warp_spec=3,
+        ),
+    ],
+    key=["M", "N", "K"],
+)
+@triton.jit
+def matmul_persistent_ws_kernel(
+   a_ptr, b_ptr, c_ptr, M, N, K,
+   stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+   BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+):
+   pid = tl.program_id(axis=0)
+   num_pid_m = tl.cdiv(M, BLOCK_M)
+   num_pid_n = tl.cdiv(N, BLOCK_N)
+   pid_m = pid // num_pid_m
+   pid_n = pid % num_pid_n
+   offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+   offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+   offs_k = tl.arange(0, BLOCK_K)
+   a_ptrs = a_ptr + (offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak)
+   b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn)
+   acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+   for k in range(0, tl.cdiv(K, BLOCK_K)):
+       a = tl.load(a_ptrs)
+       b = tl.load(b_ptrs)
+       acc += tl.dot(a, b)
+       a_ptrs += BLOCK_K * stride_ak
+       b_ptrs += BLOCK_K * stride_bk
+   c = acc.to(tl.float16)
+   c_ptrs = c_ptr + stride_cm * offs_m[:, None] + stride_cn * offs_n[None, :]
+   tl.store(c_ptrs, c)
+```
+
+The compiler automatically determines how to utilize one producer warp group and two consumer warp groups to execute the kernel. It begins by assigning task IDs to certain anchor operations, which influence the task assignments for the remaining operations. Once the anchor tasks are annotated, the compiler assigns the non-anchor operations to tasks as follows:
+
+- Control dependencies exclusive to an anchor operation are included in the same task as the anchor operation.
+- Data dependencies exclusive to an anchor operation are included in the same task as the anchor operation, unless they are another anchor operation.
+- Control or data dependencies shared between tasks are included in all those tasks.
+
+For the GEMM example above, the compiler computes a task scheme and annotates it in the IR using MLIR attributes. To illustrate this more clearly, let's use source code annotations. After task propagation:
+
+
+```python
+@triton.jit
+def matmul_persistent_ws_kernel(
+   a_ptr, b_ptr, c_ptr, M, N, K,
+   stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+   BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+):
+   pid = tl.program_id(axis=0) # async_task 0, 1
+   num_pid_m = tl.cdiv(M, BLOCK_M) # async_task 0, 1
+   num_pid_n = tl.cdiv(N, BLOCK_N) # async_task 0, 1
+   pid_m = pid // num_pid_m # async_task 0, 1
+   pid_n = pid % num_pid_n # async_task 0, 1
+   offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M) # async_task 0, 1
+   offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N) # async_task 0, 1
+   offs_k = tl.arange(0, BLOCK_K) # async_task 0
+   a_ptrs = a_ptr + (offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak) # async_task 0
+   b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn) # async_task 0
+   acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32) # async_task 1
+   for k in range(0, tl.cdiv(K, BLOCK_K)): # async_task 0, 1
+       a = tl.load(a_ptrs)   # async_task 0
+       b = tl.load(b_ptrs)   # async_task 0
+       acc += tl.dot(a, b)   # async_task 1
+       a_ptrs += BLOCK_K * stride_ak # async_task 0
+       b_ptrs += BLOCK_K * stride_bk # async_task 0
+   c = acc.to(tl.float16) # async_task 1
+   c_ptrs = c_ptr + stride_cm * offs_m[:, None] + stride_cn * offs_n[None, :] # async_task 1
+   tl.store(c_ptrs, c) # async_task 1
+```
+
+
+## Data Partitioning
+
+To further improve performance, the compiler will split the same workload across two async tasks  This way, when one task is blocked on a heavy computation (e.g., the dot operation), the other group can execute other operations in parallel. The compiler determines how to divide the work between the two tasks to maximize performance. On the H100 GPU, the compiler will, by default, attempt to split the input tensor A along the M dimension so that each consumer computes half of the output tensor independently. This approach is known as cooperative partitioning. If this split is not advantageous—for instance, if it results in a smaller-than-native `wgmma` instruction—the compiler will instead attempt to split along the N dimension.
+
+The transformed code for the above GEMM kernel with a configured tile size [128, 256, 64] will look like below (using source annotations instead of IR for illustration).
+
+
+```python
+@triton.jit
+def matmul_persistent_ws_kernel(
+   a_ptr, b_ptr, c_ptr, M, N, K,
+   stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+   BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+):
+   pid = tl.program_id(axis=0) # async_task 0, 1, 2
+   num_pid_m = tl.cdiv(M, BLOCK_M) # async_task 0, 1, 2
+   num_pid_n = tl.cdiv(N, BLOCK_N) # async_task 0, 1, 2
+   pid_m = pid // num_pid_m # async_task 0, 1, 2
+   pid_n = pid % num_pid_n # async_task 0, 1, 2
+   offs_m_1 = pid_m * BLOCK_M + tl.arange(0, BLOCK_M // 2) # async_task 0, 1, 2
+   offs_m_2 = pid_m * BLOCK_M + tl.arange(BLOCK_M // 2, BLOCK_M) # async_task 0, 1, 2
+   offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_N) # async_task 0, 1, 2
+   offs_k = tl.arange(0, BLOCK_K) # async_task 0
+   a_ptrs_1 = a_ptr + (offs_m_1[:, None] * stride_am + offs_k[None, :] * stride_ak) # async_task 0
+   a_ptrs_2 = a_ptr + (offs_m_2[:, None] * stride_am + offs_k[None, :] * stride_ak) # async_task 0
+   b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn) # async_task 0
+   acc_1 = tl.zeros((BLOCK_M // 2, BLOCK_N), dtype=tl.float32) # async_task 1
+   acc_1 = tl.zeros((BLOCK_M // 2, BLOCK_N), dtype=tl.float32) # async_task 2
+   for k in range(0, tl.cdiv(K, BLOCK_K)): # async_task 0, 1, 2
+       a_1 = tl.load(a_ptrs_1)   # async_task 0
+       a_2 = tl.load(a_ptrs_2)   # async_task 0
+       b = tl.load(b_ptrs)   # async_task 0
+       acc_1 += tl.dot(a_1, b)   # async_task 1
+       acc_2 += tl.dot(a_2, b)   # async_task 2
+       a_ptrs_1 += BLOCK_K * stride_ak # async_task 0
+       a_ptrs_2 += BLOCK_K * stride_ak # async_task 0
+       b_ptrs += BLOCK_K * stride_bk # async_task 0
+   c_1 = acc_1.to(tl.float16) # async_task 1
+   c_2 = acc_2.to(tl.float16) # async_task 2
+   c_ptrs_1 = c_ptr_1 + stride_cm * offs_m_1[:, None] + stride_cn * offs_n[None, :] # async_task 1
+   c_ptrs_2 = c_ptr_2 + stride_cm * offs_m_2[:, None] + stride_cn * offs_n[None, :] # async_task 2
+   tl.store(c_ptrs_1, c_1) # async_task 1
+   tl.store(c_ptrs_2, c_2) # async_task 2
+```
+
+
+## Code Partitioning
+
+We assume all operations are already marked with a list of taskIds. We first find all communications required between warp groups. Each communication starts from a load operation with a single taskId, and ends at a direct user of the load which belongs to a different taskId. For `ForOps` containing a communication channel, we add additional arguments: `phase` and `bufferIndex`.
+
+We introduce a tuning configuration: `num_buffers_warp_spec`. For each communication channel, if it is within a `forOp`, we use an array of buffers in SMEM to save the results, and size of the array is determined by `num_buffers_warp_spec`. We also use an array of barriers for each communication channel that is inside a `ForOp`. At this pass, four new operations are introduced to correctly synchronize between the producer and the consumer: `ProducerAcquireOp`, `ProducerCommitOp`, `ConsumerWaitOp`, and `ConsumerReleaseOp`. Each of the four new ops take a token, a buffer Index. `ProducerAcquire` and `ConsumerWait` take an additional phase operand.
+
+
+For `ForOps` with multiple task Ids, we clone one copy for each taskId, each copy contains the operations with the specific taskId. In the end, we create multiple `IfOps`, one for each possible taskId. We go through the body of the function, clone the op for each attached task Id and put the cloned op in the right `IfOp`.
+
+To adjust register usage, we introduce two new ops: `RegAllocOp` and `RegDeallocOp`, both taking an integer operand. For each warp group, we decide to insert either `RegAllocOp` or `RegDeallocOp`. The current heuristic is simple: if the task Id is 0, we add `RegDeallocOp`, otherwise we use `RegAllocOp`. The amount of register adjustment can be tuned via `reg_dec_producer` and `reg_inc_consumer`.
+
+This pass also lowers `loadOp`s to `AsyncTMACopyGlobalToLocalOp` or `AsyncCopyGlobalToLocalOp`, so the communication can be expressed via SMEM. For TMA, the producer will become
+`ProducerAcquire` -> `barrier_expect` -> `AsyncTMACopyGlobalToLocalOp`, and the consumer will contain `wait_barrier` -> ops -> `ConsumerRelease`. For non-TMA loads, the producer will become `ProducerAcquire` -> `AsyncCopyGlobalToLocalOp` -> `ProducerCommitOp`, and the consumer will contain `ConsumerWaitOp` -> ops -> `ConsumerRelease`.

--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -186,15 +186,17 @@ private:
     size_t size;
     size_t alignment;
     size_t offset;
+    SetVector<int> regionIds;
+    int sharingGroup; // -1 means not shared
 
     bool operator==(const BufferT &other) const { return id == other.id; }
     bool operator<(const BufferT &other) const { return id < other.id; }
 
     BufferT() : BufferT(BufferKind::Explicit, 0) {}
     BufferT(BufferKind kind, size_t size, size_t alignment = 4,
-            size_t offset = 0)
+            size_t offset = 0, int sharingGroup = -1)
         : kind(kind), id(nextId++), size(size), alignment(alignment),
-          offset(offset) {}
+          offset(offset), sharingGroup(sharingGroup) {}
 
     size_t setOffsetAligned(size_t newOffset) {
       return offset = llvm::alignTo(newOffset, alignment);

--- a/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -104,6 +104,10 @@ void populatePrintOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                   const TargetInfoBase &targetInfo,
                                   PatternBenefit benefit);
 
+void populateRegReallocOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                        RewritePatternSet &patterns,
+                                        PatternBenefit benefit);
+
 } // namespace triton
 } // namespace mlir
 

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -13,6 +13,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/StrUtil.h"
@@ -146,6 +147,23 @@ using namespace mlir::triton;
 
 namespace mlir {
 namespace triton {
+
+static inline void insertBarrier(OpBuilder &builder, Operation *op) {
+  auto barrierOp = builder.create<mlir::gpu::BarrierOp>(op->getLoc());
+  auto asyncTaskIds = getAsyncTaskIds(op);
+  assert(asyncTaskIds.size() <= 1);
+  if (asyncTaskIds.size() == 1) {
+    int asyncTaskId = asyncTaskIds[0];
+    int barId = asyncTaskId + nameBarrierIdBegin;
+    assert(barId < nameBarrierIdEnd);
+    auto mod = op->getParentOfType<ModuleOp>();
+    int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
+    int warpSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
+    int numThreads = numWarps * warpSize;
+    barrierOp->setAttr("bar_id", builder.getI64IntegerAttr(barId));
+    barrierOp->setAttr("num_threads", builder.getI64IntegerAttr(numThreads));
+  }
+}
 
 // Delinearize supposing order is [0, 1, .. , n]
 template <typename T>

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -179,4 +179,90 @@ def TritonGPUOptimizeAccumulatorInit: Pass<"tritongpu-optimize-accumulator-init"
                            "mlir::triton::TritonDialect"];
 }
 
+def TritonGPUWSTaskPartition : Pass<"tritongpu-warp-spec-task-partition", "mlir::ModuleOp"> {
+  let summary = "Warp specialization task partition";
+
+  let description = "This pass computes a warp schedule partition by annoating anchor operations with async task ids";
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"];
+  let options = [
+    Option<"numConsumerGroups", "num-consumer-groups",
+           "int32_t", /*default*/"0",
+           "number of consumer warp groups for warp specialization">
+  ];
+}
+
+def TritonGPUTaskIdPropagate : Pass<"triton-gpu-taskid-propagate", "mlir::ModuleOp"> {
+  let summary = "Propagate async_task_id annotations based on dependencies";
+
+  let description = [{
+    This pass propagates the `async_task_id` annotation to the dependencies
+    of any op that has it set.  This has the functional effect of partitioning
+    the graph into multiple async tasks, based on the initial annotation.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+
+  let options = [
+    Option<"numConsumerGroups", "num-consumer-groups",
+           "int32_t", /*default*/"0",
+           "number of consumer warp groups for warp specialization">
+  ];
+}
+
+def TritonGPUWSCodePartition: Pass<"tritongpu-warp-spec-code-partition", "mlir::ModuleOp"> {
+  let summary = "TritonGPU warp specialization code partition";
+
+  let description = "This pass generates warp specialized code baed on task id attributes.";
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::TritonDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"];
+  let options = [
+    Option<"numBuffers", "num-buffers",
+           "int32_t", /*default*/"0",
+           "number of buffering for producer-consumer">,
+    Option<"numConsumerGroups", "num-consumer-groups",
+           "int32_t", /*default*/"0",
+           "number of consumer warp groups for warp specialization">,
+    Option<"regDecProducer", "producer-reg-dec",
+           "int32_t", /*default*/"40",
+           "register decrement for producer warp group">,
+    Option<"regIncConsumer", "consumer-reg-inc",
+           "int32_t", /*default*/"232",
+           "register indrement for consumer warp group">
+  ];
+}
+
+def TritonGPUWSDataPartition : Pass<"tritongpu-warp-spec-data-partition", "mlir::ModuleOp"> {
+  let summary = "Warp specialization data partition";
+
+  let description = "This pass partitions operations into multiple suboperations which operate on smaller data shapes";
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"];
+  let options = [
+    Option<"numConsumerGroups", "num-consumer-groups",
+           "int32_t", /*default*/"0",
+           "number of consumer warp groups for warp specialization">
+  ];
+}
+
+def TritonGPUWSLowering : Pass<"tritongpu-warp-spec-lowering", "mlir::ModuleOp"> {
+  let summary = "Warp specialization lowering";
+
+  let description = "This pass lowers warp specializtion related operations.";
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"];
+  let options = [
+    Option<"numConsumerGroups", "num-consumer-groups",
+           "int32_t", /*default*/"0",
+           "number of consumer warp groups for warp specialization">
+  ];
+}
 #endif

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -192,6 +192,102 @@ bool isPureUnaryInlineAsm(Operation *op);
 // read the compute capability from the module attributes
 int getNVIDIAComputeCapability(Operation *module);
 
+// 0 is reserved for default sync.
+// TODO: comprehensive mechanism to globally manage namedbarrier.
+static int const nameBarrierIdBegin = 1;
+static int nameBarrierIdEnd = 16;
+
+/// Helper functions for async task
+typedef int AsyncTaskId;
+SmallVector<AsyncTaskId> getAsyncTaskIds(Operation *op);
+bool hasAsyncTaskId(Operation *op, AsyncTaskId asyncTaskId);
+void setAsyncTaskIds(Operation *op, ArrayRef<AsyncTaskId> asyncTaskIds);
+SmallVector<AsyncTaskId> getNestedAsyncTaskIds(Operation *op);
+void addAsyncTaskIds(Operation *op, ArrayRef<int> asyncTasks);
+void removeAsyncTaskId(Operation *op, AsyncTaskId asyncTaskId);
+void removeAsyncTaskIds(Operation *op);
+
+class OpBuilderWithAsyncTaskIds : public OpBuilder {
+public:
+  OpBuilderWithAsyncTaskIds(MLIRContext *context) : OpBuilder(context) {}
+
+  explicit OpBuilderWithAsyncTaskIds(Operation *op) : OpBuilder(op) {
+    setAsyncTaskIdsFromOp(op);
+  }
+
+  void setAsynTaskIdsFromArray(ArrayRef<AsyncTaskId> newAsyncTaskIds) {
+    asyncTaskIds = SmallVector<AsyncTaskId>(newAsyncTaskIds.begin(),
+                                            newAsyncTaskIds.end());
+  }
+
+  void setAsyncTaskIdsFromOp(Operation *op) {
+    setAsynTaskIdsFromArray(getAsyncTaskIds(op));
+  }
+
+  void setAsyncTaskIdsFromValueUsers(Value value) {
+    SetVector<AsyncTaskId> asyncTaskIdSet;
+    for (Operation *user : value.getUsers())
+      for (AsyncTaskId asyncTaskId : getAsyncTaskIds(user))
+        asyncTaskIdSet.insert(asyncTaskId);
+    setAsynTaskIdsFromArray(asyncTaskIdSet.getArrayRef());
+  }
+
+  template <typename OpTy, typename... Args>
+  OpTy createWithAsyncTaskIds(Args &&...args) {
+    OpTy op = create<OpTy>(std::forward<Args>(args)...);
+    if (!asyncTaskIds.empty())
+      setAsyncTaskIds(op, asyncTaskIds);
+    return op;
+  }
+
+private:
+  SmallVector<AsyncTaskId> asyncTaskIds;
+};
+
+class PatternRewriterWithAsyncTaskIds {
+public:
+  PatternRewriterWithAsyncTaskIds(PatternRewriter &rewriter, Operation *op)
+      : rewriter(&rewriter) {
+    setAsyncTaskIdsFromOp(op);
+  }
+
+  void setAsynTaskIdsFromArray(ArrayRef<AsyncTaskId> newAsyncTaskIds) {
+    asyncTaskIds = SmallVector<AsyncTaskId>(newAsyncTaskIds.begin(),
+                                            newAsyncTaskIds.end());
+  }
+
+  void setAsyncTaskIdsFromOp(Operation *op) {
+    setAsynTaskIdsFromArray(getAsyncTaskIds(op));
+  }
+
+  void setAsyncTaskIdsFromValueUsers(Value value) {
+    SetVector<AsyncTaskId> asyncTaskIdSet;
+    for (Operation *user : value.getUsers())
+      for (AsyncTaskId asyncTaskId : getAsyncTaskIds(user))
+        asyncTaskIdSet.insert(asyncTaskId);
+    setAsynTaskIdsFromArray(asyncTaskIdSet.getArrayRef());
+  }
+
+  template <typename OpTy, typename... Args>
+  OpTy create(Location location, Args &&...args) {
+    OpTy op = rewriter->create<OpTy>(location, std::forward<Args>(args)...);
+    if (!asyncTaskIds.empty())
+      setAsyncTaskIds(op, asyncTaskIds);
+    return op;
+  }
+
+  template <typename OpTy, typename... Args>
+  OpTy replaceOpWithNewOp(Operation *op, Args &&...args) {
+    auto newOp =
+        rewriter->replaceOpWithNewOp<OpTy>(op, std::forward<Args>(args)...);
+    return newOp;
+  }
+
+private:
+  PatternRewriter *rewriter;
+  SmallVector<AsyncTaskId> asyncTaskIds;
+};
+
 } // namespace mlir
 
 #endif // TRITON_DIALECT_TRITONGPU_TRANSFORMS_UTILITY_H_

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -43,6 +43,38 @@ class TTNG_Op<string mnemonic, list<Trait> traits = []> :
        !listconcat(traits, [VerifyTensorLayoutsTrait])> {
 }
 
+def TTNG_MBarrierArriveOp : TTNG_Op<"mbarrier_arrive", [AttrSizedOperandSegments,
+                                                      MemoryEffects<[MemWrite<SharedMemory>]>]> {
+  let summary = "mbarrier arrive";
+
+  let description = [{
+    This operation defining the arriving action for a mbarrier.
+    txCount:
+        An optional attribute that set tx-count. This Op will be lowered into
+        mbarrier.arrive.expect_tx if the optional attribute exist.
+    trackAsyncOp:
+        If true, this op will be lowered into cp.async.mbarrier.arrive.noinc.
+    pred:
+        Only perform arrive action when pred is true.
+    remoteCtaId:
+        if set, perform an remote arrive action.
+
+    Example:
+
+    triton_nvidia_gpu.mbarrier_arrive %0 {trackAsyncOp = false} : !tt.ptr<i64>
+
+  }];
+
+  let arguments = (ins TT_MemDescType:$mbarrier,
+                       Optional<I1>:$pred,
+                       Optional<I32>:$remoteCtaId,
+                       I1Attr: $trackAsyncOp,
+                       DefaultValuedAttr<I32Attr, "0">: $txCount
+                  );
+
+  let assemblyFormat = "operands attr-dict `:` type(operands)";
+}
+
 def TTNG_FenceAsyncSharedOp : TTNG_Op<"fence_async_shared"> {
   let arguments = (ins BoolAttr:$bCluster);
 
@@ -55,6 +87,31 @@ def TTNG_FenceAsyncSharedOp : TTNG_Op<"fence_async_shared"> {
       return computeCapability >= 90;
     }
   }];
+}
+
+def TTNG_GetCanonicalWarpIdOp : TTNG_Op<"get_canonical_warp_id", [Pure]> {
+  let description = [{
+    Returns the one dimensional warpId when it's used for producing warp uniform values.
+  }];
+
+  let results = (outs I32:$result);
+  let assemblyFormat = "attr-dict `:` type($result)";
+}
+
+def TTNG_NamedBarrierArriveOp : TTNG_Op<"bar_arrive", []> {
+  let summary = "named barrier arrive";
+
+  let arguments = (ins I32:$bar, I32: $numThreads);
+
+  let assemblyFormat = "$bar `,` $numThreads attr-dict `:` type(operands)";
+}
+
+def TTNG_NamedBarrierWaitOp : TTNG_Op<"bar_wait", []> {
+  let summary = "named barrier wait";
+
+  let arguments = (ins I32:$bar, I32: $numThreads);
+
+  let assemblyFormat = "$bar `,` $numThreads attr-dict `:` type(operands)";
 }
 
 def TTNG_ClusterArriveOp : TTNG_Op<"cluster_arrive", []> {
@@ -247,6 +304,68 @@ def TTNG_TMAStoreWait : TTNG_Op<"async_tma_store_wait"> {
   }];
 
   let assemblyFormat = "attr-dict";
+}
+
+def TTNG_GetAsyncTaskIdOp : TTNG_Op<"get_async_task_id", [Pure]> {
+  let results = (outs I32:$result);
+
+  let builders = [OpBuilder<(ins)>];
+
+  let assemblyFormat = "attr-dict `:` type($result)";
+}
+
+//
+// Token
+//
+
+def TTNG_CreateTokenOp : TTNG_Op<"create_token"> {
+  let results = (outs TensorOf<[TTNG_TokenType]>:$result);
+
+  let arguments = (ins I32Attr:$num);
+
+  let builders = [OpBuilder<(ins "uint32_t":$num)>];
+
+  let assemblyFormat = "attr-dict `:` type($result)";
+}
+
+def TTNG_ProducerAcquireOp : TTNG_Op<"producer_acquire"> {
+  let arguments = (ins TensorOf<[TTNG_TokenType]>:$token, I32:$idx, I1:$phase);
+
+  let assemblyFormat = "$token `,` $idx `,` $phase attr-dict `:` type(operands)";
+}
+
+def TTNG_ProducerCommitOp : TTNG_Op<"producer_commit"> {
+  let arguments = (ins TensorOf<[TTNG_TokenType]>:$token, I32:$idx);
+
+  let assemblyFormat = "$token `,` $idx attr-dict `:` type(operands)";
+}
+
+def TTNG_ConsumerWaitOp : TTNG_Op<"consumer_wait"> {
+  let arguments = (ins TensorOf<[TTNG_TokenType]>:$token, I32:$idx, I1: $phase);
+
+  let assemblyFormat = "$token `,` $idx `,` $phase attr-dict `:` type(operands)";
+}
+
+def TTNG_ConsumerReleaseOp : TTNG_Op<"consumer_release"> {
+  let arguments = (ins TensorOf<[TTNG_TokenType]>:$token, I32:$idx);
+
+  let assemblyFormat = "$token `,` $idx attr-dict `:` type(operands)";
+}
+
+def TTNG_RegAllocOp : TTNG_Op<"reg_alloc", []> {
+  let summary = "register allocation";
+
+  let arguments = (ins I32Attr: $regCount);
+
+  let assemblyFormat = "$regCount attr-dict";
+}
+
+def TTNG_RegDeallocOp : TTNG_Op<"reg_dealloc", []> {
+  let summary = "register deallocation";
+
+  let arguments = (ins I32Attr: $regCount);
+
+  let assemblyFormat = "$regCount attr-dict";
 }
 
 #endif

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include <deque>
 
 namespace mlir {
@@ -94,7 +95,7 @@ void MembarAnalysis::visitTerminator(Operation *op,
 
 void MembarAnalysis::insertBarrier(Operation *op, OpBuilder *builder) {
   OpBuilder::InsertionGuard g(*builder);
-  auto barrierOp = builder->create<gpu::BarrierOp>(op->getLoc());
+  ::insertBarrier(*builder, op);
 }
 
 void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,

--- a/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemory.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemory.cpp
@@ -40,6 +40,8 @@ struct AllocateSharedMemory
         }
         if (offset == -1)
           return;
+        if (op->hasAttr("allocation.offset"))
+          return;
         op->setAttr("allocation.offset",
                     IntegerAttr::get(IntegerType::get(ctx, 32), offset));
       });

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -211,12 +211,12 @@ private:
       auto multiDimRepId =
           getMultiDimIndex<unsigned>(repId, numReplicates, outOrd);
       if (repId != 0) {
-        barrier();
+        insertBarrier(rewriter, op);
       }
       processReplica(loc, rewriter, /*stNotRd*/ true, srcTy, inNumCTAsEachRep,
                      multiDimRepId, inVec, paddedRepShape, origRepShape, outOrd,
                      vals, smemBase);
-      barrier();
+      insertBarrier(rewriter, op);
       processReplica(loc, rewriter, /*stNotRd*/ false, dstTy, outNumCTAsEachRep,
                      multiDimRepId, outVec, paddedRepShape, origRepShape,
                      outOrd, outVals, smemBase);
@@ -605,7 +605,7 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     llvm::MapVector<int, Value> outVals;
     for (int i = 0; i < iterations; i++) {
       if (i != 0)
-        barrier();
+        insertBarrier(rewriter, op);
 
       auto &inRegs = inRegsForIter[i];
       auto &outRegs = outRegsForIter[i];
@@ -629,7 +629,7 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
         }
       }
 
-      barrier();
+      insertBarrier(rewriter, op);
 
       for (int j = 0; j < outSize / iterations; j += scratchConfig.outVec) {
         auto outRegSlice = outRegs[j];

--- a/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
@@ -314,10 +314,14 @@ public:
           loadOp.getLoc(), newPtr, newMask, newOther, loadOp.getCache(),
           loadOp.getEvict(), loadOp.getIsVolatile());
       op->getResult(0).replaceAllUsesWith(newResult);
+      if (op->getAttr("async_task_id"))
+        newResult->setAttr("async_task_id", op->getAttr("async_task_id"));
     } else if (auto storeOp = dyn_cast<triton::StoreOp>(op)) {
-      builder.create<triton::StoreOp>(storeOp.getLoc(), newPtr,
-                                      storeOp.getValue(), newMask,
-                                      storeOp.getCache(), storeOp.getEvict());
+      auto newOp = builder.create<triton::StoreOp>(
+          storeOp.getLoc(), newPtr, storeOp.getValue(), newMask,
+          storeOp.getCache(), storeOp.getEvict());
+      if (op->getAttr("async_task_id"))
+        newOp->setAttr("async_task_id", op->getAttr("async_task_id"));
     }
 
     // Erase the original operation

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2792,8 +2792,9 @@ struct CanonicalizeConvertFromAlloc
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
     if (!convert)
       return failure();
-    rewriter.replaceOpWithNewOp<triton::gpu::LocalAllocOp>(
+    auto newAlloc = rewriter.replaceOpWithNewOp<triton::gpu::LocalAllocOp>(
         op, op->getResult(0).getType(), convert.getSrc());
+    newAlloc->setAttrs(op->getAttrs());
     return mlir::success();
   }
 };
@@ -2809,8 +2810,9 @@ struct CanonicalizeConvertFromLocalStore
     auto convert = op.getSrc().getDefiningOp<ConvertLayoutOp>();
     if (!convert)
       return failure();
-    rewriter.replaceOpWithNewOp<triton::gpu::LocalStoreOp>(op, convert.getSrc(),
-                                                           op.getDst());
+    auto store = rewriter.replaceOpWithNewOp<triton::gpu::LocalStoreOp>(
+        op, convert.getSrc(), op.getDst());
+    store->setAttrs(op->getAttrs());
     return mlir::success();
   }
 };
@@ -2928,8 +2930,10 @@ struct CanonicalizeConvertFromConvert
     // cvt(cvt(x, type1), type2) -> cvt(x, type2)
     if (auto cvt = dyn_cast<ConvertLayoutOp>(arg)) {
       auto srcType = op.getSrc().getType();
-      rewriter.replaceOpWithNewOp<triton::gpu::ConvertLayoutOp>(
+      auto origAttrs = op->getAttrs();
+      auto newOp = rewriter.replaceOpWithNewOp<triton::gpu::ConvertLayoutOp>(
           op, op->getResultTypes().front(), cvt.getSrc());
+      newOp->setAttrs(origAttrs);
       return success();
     }
 

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -18,6 +18,11 @@ add_triton_library(TritonGPUTransforms
   RemoveLayoutConversions.cpp
   ReorderInstructions.cpp
   Utility.cpp
+  TaskIdPropagate.cpp
+  WSTaskPartition.cpp
+  WSDataPartition.cpp
+  WSCodePartition.cpp
+  WSLowering.cpp
 
   DEPENDS
   TritonGPUTransformsIncGen

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -159,6 +159,7 @@ void mlir::triton::replaceUsesAndPropagateType(OpBuilder &builder,
                                                trans.getOrderAttr());
     }
     assert(newVal);
+    newVal.getDefiningOp()->setAttrs(user->getAttrs());
     replaceUsesAndPropagateType(builder, user, newVal);
     opsToDelete.push_back(use.getOwner());
   }

--- a/lib/Dialect/TritonGPU/Transforms/TaskIdPropagate.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/TaskIdPropagate.cpp
@@ -1,0 +1,483 @@
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "triton-gpu-taskid-propagate"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace tt = ::mlir::triton;
+namespace ttg = ::mlir::triton::gpu;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+
+namespace mlir {
+namespace triton {
+namespace gpu {
+
+#define GEN_PASS_DEF_TRITONGPUTASKIDPROPAGATE
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+// Return all Ops that are marked with target task
+void getAsyncTaskOps(triton::FuncOp funcOp, DenseSet<Operation *> &asyncTaskOps,
+                     int asyncTaskId) {
+  funcOp.walk([&](Operation *op) -> void {
+    if (auto attr =
+            op->getAttrOfType<mlir::DenseIntElementsAttr>("async_task_id")) {
+      for (auto val : attr.getValues<int>()) {
+        if (val == asyncTaskId) {
+          asyncTaskOps.insert(op);
+          break;
+        }
+      }
+    }
+  });
+}
+
+void getAllParentOps(DenseSet<Operation *> &parentOps, Operation *targetOp) {
+  auto op = targetOp;
+  while (auto parent = op->getParentOp()) {
+    if (!isa<ModuleOp>(parent) && !isa<triton::FuncOp>(parent)) {
+      parentOps.insert(parent);
+      op = parent;
+    } else {
+      break;
+    }
+  }
+}
+
+void getAllParentOps(triton::FuncOp funcOp, DenseSet<Operation *> &parentOps,
+                     int asyncTaskId) {
+  DenseSet<Operation *> targetOps;
+  getAsyncTaskOps(funcOp, targetOps, asyncTaskId);
+  for (auto op : targetOps) {
+    getAllParentOps(parentOps, op);
+  }
+}
+
+void labelByUsers(Operation *op, ArrayRef<int> allAsyncTasks) {
+  for (Value result : op->getResults()) {
+    for (Operation *userOp : result.getUsers()) {
+      if (!userOp->hasAttr("async_task_id")) {
+        labelByUsers(userOp, allAsyncTasks);
+      }
+      addAsyncTaskIds(op, getAsyncTaskIds(userOp));
+    }
+  }
+  if (!op->hasAttr("async_task_id")) {
+    addAsyncTaskIds(op, allAsyncTasks);
+  }
+}
+
+/// Because we set some special filter rules in populateAsyncTaskRegion,
+/// there may be unlabeled Ops, e.g. YieldOps, some definingOps of ForOps.
+/// or Ops without relations to asyncTaskOps
+void populateUnlabledOpsAtLast(triton::FuncOp funcOp,
+                               ArrayRef<int> allAsyncTasks) {
+  // Label asyncTasks' parentOps
+  for (int i : allAsyncTasks) {
+    DenseSet<Operation *> asyncTaskParentOps;
+    getAllParentOps(funcOp, asyncTaskParentOps, i);
+    for (auto op : asyncTaskParentOps) {
+      addAsyncTaskIds(op, {i});
+    }
+  }
+
+  // Get unlabeled Ops
+  DenseSet<Operation *> unlabeledOps;
+  funcOp.walk([&](Operation *op) -> void {
+    if (isa<ModuleOp>(op) || isa<triton::FuncOp>(op) ||
+        isa<triton::ReturnOp>(op)) {
+      return;
+    }
+    if (!op->hasAttr("async_task_id")) {
+      unlabeledOps.insert(op);
+    }
+  });
+
+  // Label Ops using its parentOp
+  for (auto op : unlabeledOps) {
+    if (auto parent = op->getParentOp()) {
+      if (!isa<triton::FuncOp>(parent)) {
+        if (!parent->hasAttr("async_task_id")) {
+          LLVM_DEBUG({
+            LDBG("op and parent: ");
+            op->dump();
+            parent->dump();
+          });
+          continue;
+        }
+        assert(parent->hasAttr("async_task_id"));
+        auto asyncTasks = getAsyncTaskIds(parent);
+        setAsyncTaskIds(op, asyncTasks);
+        unlabeledOps.erase(op);
+      }
+    }
+  }
+
+  // Label Ops using dependency
+  for (auto op : unlabeledOps) {
+    labelByUsers(op, allAsyncTasks);
+    unlabeledOps.erase(op);
+  }
+  assert(unlabeledOps.size() == 0);
+}
+
+#ifndef NDEBUG
+static bool oneVecCoversTheOther(SmallVector<AsyncTaskId> &one,
+                                 SmallVector<AsyncTaskId> &other) {
+  // Every element of other appears in one.
+  for (AsyncTaskId t : other) {
+    // If t doesn't appear in one, return false.
+    bool found = false;
+    for (AsyncTaskId t2 : one) {
+      if (t2 == t) {
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      return false;
+  }
+  return true;
+}
+
+struct AsyncTaskIdsCompare {
+  static SmallVector<AsyncTaskId> getEmptyKey() {
+    SmallVector<AsyncTaskId> V;
+    V.push_back(reinterpret_cast<AsyncTaskId>(-1));
+    return V;
+  }
+
+  static SmallVector<AsyncTaskId> getTombstoneKey() {
+    SmallVector<AsyncTaskId> V;
+    V.push_back(reinterpret_cast<AsyncTaskId>(-2));
+    return V;
+  }
+
+  static unsigned getHashValue(const SmallVector<AsyncTaskId> &V) {
+    return static_cast<unsigned>(llvm::hash_combine_range(V.begin(), V.end()));
+  }
+
+  static bool isEqual(const SmallVector<AsyncTaskId> &LHS,
+                      const SmallVector<AsyncTaskId> &RHS) {
+    return LHS == RHS;
+  }
+};
+
+// Make sure the def chain contains the right taskId.
+bool verifyTaskId(triton::FuncOp &funcOp,
+                  const llvm::DenseSet<Operation *> &anchorOps) {
+  bool retCode = true;
+  DenseSet<SmallVector<AsyncTaskId>, AsyncTaskIdsCompare> anchorAsyncTasks;
+  for (auto anchorOp : anchorOps) {
+    anchorAsyncTasks.insert(getAsyncTaskIds(anchorOp));
+  }
+
+  funcOp.walk([&](Operation *op) {
+    // Skip control ops
+    if (llvm::isa<ReturnOp, FuncOp, scf::YieldOp, scf::ForOp>(op))
+      return;
+
+    auto asyncTaskIds = getAsyncTaskIds(op);
+    if (asyncTaskIds.empty()) {
+      LLVM_DEBUG({
+        LDBG("Op does not have task id");
+        op->dump();
+      });
+      llvm_unreachable("Op does not have task id");
+    }
+
+    auto partitionShouldBeUsedSpecified = [](Operation *op) {
+      if (isa<StoreOp, ExperimentalDescriptorLoadOp>(op))
+        return true;
+      if (isa<AtomicRMWOp, AtomicCASOp>(op))
+        return true;
+      if (op->hasTrait<OpTrait::DotLike>())
+        return true;
+      return false;
+    };
+
+    if (!anchorAsyncTasks.contains(asyncTaskIds)) {
+      if (partitionShouldBeUsedSpecified(op)) {
+        LLVM_DEBUG({
+          LDBG("async tasks not specified by user");
+          op->dump();
+        });
+        llvm_unreachable("async tasks not specified by user");
+      }
+    }
+
+    assert(!asyncTaskIds.empty() && "Op does not have task id");
+
+    for (Value operand : op->getOperands()) {
+      Operation *defOp = operand.getDefiningOp();
+      if (!defOp)
+        continue;
+      if (llvm::isa<tt::LoadOp, tt::ExperimentalDescriptorLoadOp>(defOp))
+        continue;
+      auto defTaskIds = getAsyncTaskIds(defOp);
+      // Make sure defTaskIds cover asyncTaskIds. Call addAsyncTaskIds if
+      // necessary.
+      LLVM_DEBUG({
+        if (!oneVecCoversTheOther(defTaskIds, asyncTaskIds)) {
+          // print defOp and op
+          LDBG("Def op does not cover op");
+          LDBG("Def op");
+          defOp->dump();
+          LDBG("op");
+          op->dump();
+        }
+      });
+      assert(oneVecCoversTheOther(defTaskIds, asyncTaskIds) &&
+             "defTaskIds should cover asyncTaskIds");
+    }
+  });
+  return retCode;
+}
+#endif
+
+void backwardPropagateTaskIds(Operation *op,
+                              const llvm::DenseSet<Operation *> &anchors) {
+  SmallVector<Value> queue;
+  auto asyncTasks = getAsyncTaskIds(op);
+  for (Value operand : op->getOperands()) {
+    queue.push_back(operand);
+  }
+
+  DenseSet<Value> seen;
+  for (auto anchor : anchors) {
+    if (anchor != op)
+      for (auto result : anchor->getResults())
+        seen.insert(result);
+  }
+
+  while (!queue.empty()) {
+    auto value = queue.pop_back_val();
+    if (!seen.insert(value).second) {
+      continue;
+    }
+
+    // Handle BlockArguments of for loops (i.e. loop carried dependences).
+    if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+      auto parent = blockArg.getOwner()->getParentOp();
+      if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+        // Propagate to the control operands.
+        auto control =
+            forOp.getOperands().take_front(forOp.getNumControlOperands());
+        queue.insert(queue.end(), control.begin(), control.end());
+        // Propagate to the initializer.
+        if (blockArg.getArgNumber() >= forOp.getNumInductionVars()) {
+          queue.push_back(forOp.getTiedLoopInit(blockArg)->get());
+          // Propagate to the yield.
+          auto idx = blockArg.getArgNumber() - forOp.getNumInductionVars();
+          queue.push_back(forOp.getBody()->getTerminator()->getOperand(idx));
+          addAsyncTaskIds(forOp, asyncTasks);
+        }
+      }
+      continue;
+    }
+
+    auto op = value.getDefiningOp();
+    addAsyncTaskIds(op, asyncTasks);
+
+    // Handle for loops.
+    if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+      // Propagate to control operands.
+      auto control =
+          forOp.getOperands().take_front(forOp.getNumControlOperands());
+      queue.insert(queue.end(), control.begin(), control.end());
+      // Propagate to arguments.
+      unsigned idx = cast<OpResult>(value).getResultNumber();
+      queue.push_back(forOp.getOperand(idx + forOp.getNumControlOperands()));
+      // Propagate to yield.
+      queue.push_back(forOp.getBody()->getTerminator()->getOperand(idx));
+      continue;
+    }
+
+    // Handle conditionals.
+    if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+      queue.push_back(ifOp.getCondition());
+      unsigned idx = cast<OpResult>(value).getResultNumber();
+      if (ifOp.elseBlock()) {
+        queue.push_back(ifOp.elseYield()->getOperand(idx));
+      }
+      queue.push_back(ifOp.thenYield()->getOperand(idx));
+      continue;
+    }
+
+    // Handle normal ops.
+    for (Value operand : op->getOperands()) {
+      queue.push_back(operand);
+    }
+  }
+}
+
+void backwardPropagateTaskIds(llvm::DenseSet<Operation *> &rootOps,
+                              llvm::DenseSet<Operation *> &anchorOps) {
+  for (Operation *op : rootOps) {
+    backwardPropagateTaskIds(op, anchorOps);
+  }
+}
+
+void forwardPropagateTaskIds(Operation *root,
+                             const llvm::DenseSet<Operation *> &anchors) {
+  auto asyncTasks = getAsyncTaskIds(root);
+  SmallVector<Value> queue;
+  for (Value result : root->getResults())
+    queue.push_back(result);
+
+  DenseSet<Value> seen;
+  for (auto anchor : anchors) {
+    if (anchor != root)
+      for (auto result : anchor->getResults())
+        seen.insert(result);
+  }
+
+  while (!queue.empty()) {
+    auto v = queue.back();
+    queue.pop_back();
+    if (!seen.insert(v).second)
+      continue;
+
+    for (Operation *depOp : v.getUsers()) {
+      auto depAsyncTasks = getAsyncTaskIds(depOp);
+      // Skip depOp that already has task ids. Those could be either anchorOps
+      // or propagated backward from anchor ops.
+      if (!depAsyncTasks.empty() && depAsyncTasks != asyncTasks)
+        continue;
+      setAsyncTaskIds(depOp, asyncTasks);
+      // Go through yieldOp to propagate task ids to the result of parentOp.
+      if (auto yieldOp = dyn_cast<scf::YieldOp>(depOp)) {
+        auto parentOp = yieldOp->getParentOp();
+        for (OpOperand &operand : yieldOp->getOpOperands()) {
+          if (operand.get() == v) {
+            queue.push_back(parentOp->getResult(operand.getOperandNumber()));
+            break;
+          }
+        }
+      } else {
+        for (Value result : depOp->getResults())
+          queue.push_back(result);
+      }
+    }
+  }
+}
+
+void forwardPropagateTaskIds(llvm::DenseSet<Operation *> &anchorOps) {
+  for (Operation *op : anchorOps) {
+    forwardPropagateTaskIds(op, anchorOps);
+  }
+}
+
+void populateTaskIdsForControlDependencies(
+    llvm::DenseSet<Operation *> &anchorOps) {
+  for (auto op : anchorOps) {
+    auto asyncTaskIds = getAsyncTaskIds(op);
+    if (!asyncTaskIds.empty()) {
+      while (auto parent = op->getParentOp()) {
+        if (!isa<ModuleOp>(parent) && !isa<triton::FuncOp>(parent)) {
+          setAsyncTaskIds(parent, asyncTaskIds);
+          backwardPropagateTaskIds(parent, anchorOps);
+          op = parent;
+        } else {
+          break;
+        }
+      }
+    }
+  }
+}
+
+class TritonGPUTaskIdPropagatePass
+    : public impl::TritonGPUTaskIdPropagateBase<TritonGPUTaskIdPropagatePass> {
+public:
+  using impl::TritonGPUTaskIdPropagateBase<
+      TritonGPUTaskIdPropagatePass>::TritonGPUTaskIdPropagateBase;
+
+  void runOnFuncOp(triton::FuncOp funcOp) {
+    llvm::DenseSet<Operation *> anchorOps;
+    funcOp.walk([&](mlir::Operation *op) {
+      auto asyncTasks = getAsyncTaskIds(op);
+      if (asyncTasks.empty())
+        return;
+      std::sort(asyncTasks.begin(), asyncTasks.end());
+      setAsyncTaskIds(op, asyncTasks);
+      if (!isa<arith::ConstantOp, arith::ConstantIntOp>(op))
+        anchorOps.insert(op);
+    });
+
+    populateTaskIdsForControlDependencies(anchorOps);
+
+    LLVM_DEBUG({
+      LDBG("after populateTaskIdsForControlDependencies ");
+      funcOp->dump();
+    });
+
+    backwardPropagateTaskIds(anchorOps, anchorOps);
+
+    LLVM_DEBUG({
+      LDBG("after backwardPropagateTaskIds ");
+      funcOp->dump();
+    });
+
+    forwardPropagateTaskIds(anchorOps);
+
+    LLVM_DEBUG({
+      LDBG("after forwardPropagateTaskIds ");
+      funcOp->dump();
+    });
+
+    llvm::DenseSet<Operation *> rootOps;
+    funcOp.walk([&](mlir::Operation *op) {
+      auto asyncTasks = getAsyncTaskIds(op);
+      if (!asyncTasks.empty() &&
+          !isa<arith::ConstantOp, arith::ConstantIntOp>(op))
+        rootOps.insert(op);
+    });
+    backwardPropagateTaskIds(rootOps, anchorOps);
+    LLVM_DEBUG({
+      LDBG("after final backwardPropagateTaskIds ");
+      funcOp->dump();
+    });
+
+    DenseSet<int> allAsyncTasks;
+    funcOp->walk([&](Operation *op) {
+      auto asyncTasks = getAsyncTaskIds(op);
+      allAsyncTasks.insert(asyncTasks.begin(), asyncTasks.end());
+    });
+    SmallVector<int> allAsyncTasksVec(allAsyncTasks.begin(),
+                                      allAsyncTasks.end());
+    populateUnlabledOpsAtLast(funcOp, allAsyncTasksVec);
+
+    LLVM_DEBUG({
+      LDBG("after populateUnlabledOpsAtLast ");
+      funcOp->dump();
+    });
+
+#ifndef NDEBUG
+    verifyTaskId(funcOp, anchorOps);
+#endif
+  }
+
+  void runOnOperation() override {
+    if (numConsumerGroups == 0) {
+      getOperation()->walk([&](triton::FuncOp funcOp) {
+        funcOp.walk([&](mlir::Operation *op) {
+          auto asyncTasks = getAsyncTaskIds(op);
+          if (!asyncTasks.empty())
+            op->removeAttr("async_task_id");
+        });
+      });
+      return;
+    }
+    getOperation()->walk([&](triton::FuncOp funcOp) { runOnFuncOp(funcOp); });
+  }
+};
+
+} // namespace gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSCodePartition.cpp
@@ -1,0 +1,2274 @@
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
+#include <list>
+#include <unordered_set>
+
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+namespace mlir {
+namespace triton {
+namespace gpu {
+
+#define GEN_PASS_DEF_TRITONGPUWSCODEPARTITION
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+#define DEBUG_TYPE "tritongpu-warp-spec-code-partition"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+std::pair<int, bool> scanRegUsage(Block *block, AsyncTaskId asyncTaskId,
+                                  int regDecProducer, int regIncConsumer) {
+  // TODO: scan ops to estimate register usage
+  if (asyncTaskId == 0) {
+    // deallocate registers
+    return {regDecProducer == 0 ? 40 : regDecProducer, false};
+  } else {
+    // allocate registers
+    return {regIncConsumer == 0 ? 232 : regIncConsumer, true};
+  }
+}
+
+unsigned getNumBuffersOrDefault(scf::ForOp forOp, unsigned numBuffers) {
+  // Use the attribute attached to the loop if it exists otherwise use the
+  // global control.
+  if (!forOp->hasAttr(mlir::triton::kNumStagesAttrName))
+    return numBuffers;
+  return mlir::cast<IntegerAttr>(
+             forOp->getAttr(mlir::triton::kNumStagesAttrName))
+      .getInt();
+}
+
+// Collect argument indices that are used by the specific taskId.
+static SmallVector<unsigned> collectBlockArgsForTask(scf::ForOp forOp,
+                                                     int asyncTaskId) {
+
+  // Collect argument indices that can be reached along the definition chain.
+  SetVector<unsigned> argIndices;
+  std::function<void(Value, unsigned)> dfs = [&](Value arg, unsigned argIdx) {
+    for (auto user : arg.getUsers()) {
+      // Skip ops that are not in the same async task
+      if (!hasAsyncTaskId(user, asyncTaskId))
+        continue;
+
+      // Skip control flow ops that are shared by all async tasks
+      if (isa<scf::YieldOp>(user))
+        continue;
+
+      // Found a real user, the arg is needed
+      if (user->getNumRegions() == 0) {
+        argIndices.insert(argIdx);
+        return;
+      }
+
+      // Iterate through all regions of the user operation
+      for (auto &region : user->getRegions()) {
+        for (auto regionArg : region.getArguments()) {
+          if (arg == regionArg)
+            dfs(regionArg, argIdx);
+        }
+      }
+    }
+  };
+
+  // check dependency with DFS traversal for loop args and results.
+  mlir::Block &block = forOp.getRegion().front();
+  for (unsigned i = forOp.getNumInductionVars(); i < block.getNumArguments();
+       ++i) {
+    auto arg = block.getArgument(i);
+    dfs(arg, i - forOp.getNumInductionVars());
+  }
+  for (unsigned i = 0; i < forOp.getNumResults(); ++i) {
+    auto result = forOp->getResult(i);
+    dfs(result, i);
+  }
+
+  SmallVector<unsigned> args(argIndices.begin(), argIndices.end());
+  llvm::sort(args);
+  return args;
+}
+
+Operation *SpecializeOp(Operation *op, IRMapping &mapping,
+                        OpBuilderWithAsyncTaskIds &builder,
+                        AsyncTaskId asyncTaskId);
+
+// Return the argument that tracks accumLoopCount if there is an outer
+// ForOp.
+Value getAccumLoopCountArg(scf::ForOp parentForOp) {
+  assert(parentForOp);
+  auto tSize = parentForOp.getBody()->getArguments().size();
+  assert(tSize >= 3); // accum, bufferIdx, phase
+  Value tmpAccumLoopCount = parentForOp.getBody()->getArgument(tSize - 3);
+  return tmpAccumLoopCount;
+}
+
+// Return true if the IfOp contains a ForOp that is in loopWithBufferReuse.
+static bool
+needAccumulatedLoopCnt(scf::IfOp ifOp,
+                       SmallVector<Operation *> &loopWithBufferReuse) {
+  bool needAccum = false;
+  ifOp.walk<WalkOrder::PreOrder>([&](Operation *subOp) {
+    if (auto forOp = dyn_cast<scf::ForOp>(subOp))
+      for (auto tLoop : loopWithBufferReuse)
+        if (forOp.getOperation() == tLoop) {
+          needAccum = true;
+          break;
+        }
+  });
+  return needAccum;
+}
+
+Value updateAccumLoopCount(SmallVector<Operation *> &opList,
+                           unsigned numBuffers,
+                           SmallVector<Operation *> &taskTopOps,
+                           Operation *commonOuterLoop,
+                           SmallVector<Operation *> &loopWithBufferReuse,
+                           Value prevAccum);
+
+scf::ForOp createNewLoopWrapper(scf::ForOp origForOp, unsigned numBuffers,
+                                SmallVector<Operation *> &taskTopOps,
+                                Operation *commonOuterLoop,
+                                SmallVector<Operation *> &loopWithBufferReuse,
+                                Value prevAccum);
+
+// For certain cases, we need to add an additional output for
+// IfOp to track the accumulatedLoopCount, we may need to add
+// a corresponding elseBlock with yieldOp.
+scf::IfOp rewriteIfOp(scf::IfOp ifOp, unsigned numBuffers,
+                      SmallVector<Operation *> &taskTopOps,
+                      Operation *commonOuterLoop,
+                      SmallVector<Operation *> &loopWithBufferReuse,
+                      Value prevAccum) {
+  LLVM_DEBUG({
+    LDBG("rewrite ifOp for smem sharing ");
+    ifOp.dump();
+  });
+
+  OpBuilderWithAsyncTaskIds ifBuilder(ifOp.getContext());
+  ifBuilder.setAsynTaskIdsFromArray(getNestedAsyncTaskIds(ifOp));
+  ifBuilder.setInsertionPoint(ifOp);
+
+  SmallVector<Type> newResultTypes(ifOp->getResultTypes());
+  // Add an output for the IfOp for accumulated loop count.
+  newResultTypes.push_back(ifBuilder.getI64Type());
+  // Create else block if we need to generate accumulated loop count.
+  auto newIfOp = ifBuilder.createWithAsyncTaskIds<scf::IfOp>(
+      ifOp.getLoc(), newResultTypes, ifOp.getCondition(), true, true);
+
+  // Move the existing blocks to the new if.
+  newIfOp.getThenRegion().takeBody(ifOp.getThenRegion());
+
+  ifBuilder.setInsertionPointToEnd(newIfOp.thenBlock());
+  SmallVector<Operation *> opList;
+  for (Operation &op : newIfOp.thenBlock()->getOperations()) {
+    if (auto tOp = dyn_cast<scf::ForOp>(&op))
+      opList.push_back(&op);
+    if (auto tOp = dyn_cast<scf::IfOp>(&op))
+      opList.push_back(&op);
+  }
+
+  // Update yields
+  auto loc = ifOp.getLoc();
+  auto updateYield = [&](scf::YieldOp yield, SmallVector<Value> &operands) {
+    ifBuilder.setInsertionPoint(yield);
+    ifBuilder.createWithAsyncTaskIds<scf::YieldOp>(loc, operands);
+    yield.erase();
+  };
+
+  // Add one more operand to then Yield.
+  Value endAccum =
+      updateAccumLoopCount(opList, numBuffers, taskTopOps, commonOuterLoop,
+                           loopWithBufferReuse, prevAccum);
+
+  SmallVector<Value> ifYieldOperands = newIfOp.thenYield().getOperands();
+  ifYieldOperands.push_back(endAccum);
+  updateYield(newIfOp.thenYield(), ifYieldOperands);
+
+  // Handle elseRegion of the IfOp.
+  if (ifOp.elseBlock()) {
+    ifBuilder.setInsertionPointToEnd(newIfOp.elseBlock());
+    newIfOp.getElseRegion().takeBody(ifOp.getElseRegion());
+    opList.clear();
+    for (Operation &op : newIfOp.elseBlock()->getOperations()) {
+      if (auto tOp = dyn_cast<scf::ForOp>(&op))
+        opList.push_back(&op);
+      if (auto tOp = dyn_cast<scf::IfOp>(&op))
+        opList.push_back(&op);
+    }
+    endAccum =
+        updateAccumLoopCount(opList, numBuffers, taskTopOps, commonOuterLoop,
+                             loopWithBufferReuse, prevAccum);
+  } else {
+    // Create an empty yield
+    auto yieldOp =
+        newIfOp.getElseBodyBuilder().create<scf::YieldOp>(ifOp.getLoc());
+    endAccum = prevAccum;
+  }
+  // Add one more operand to else Yield.
+  SmallVector<Value> elseYieldOperands = newIfOp.elseYield().getOperands();
+  elseYieldOperands.push_back(endAccum);
+  updateYield(newIfOp.elseYield(), elseYieldOperands);
+  int resultIdx = 0;
+  // Replace old if with the new one.
+  for (auto result : ifOp.getResults()) {
+    result.replaceAllUsesWith(newIfOp->getResult(resultIdx++));
+  }
+  ifOp.erase();
+  return newIfOp;
+}
+
+Operation *SpecializeIfOp(scf::IfOp ifOp, IRMapping &mapping,
+                          OpBuilderWithAsyncTaskIds &builder,
+                          AsyncTaskId asyncTaskId) {
+  LLVM_DEBUG({
+    LDBG("specialize ifOp ");
+    ifOp.dump();
+  });
+
+  // It is possible that we need to reduce the results. One example
+  // is that the defining op for the yield operation is not for this
+  // taskId and the defining op is not specialized, thus we should
+  // remove the result.
+  // We need to update the result types correctly here.
+  unsigned resultIdx = 0;
+  SmallVector<unsigned> keptResultVec;
+  if (!ifOp->getResultTypes().empty()) {
+    for (Value yieldV : ifOp.thenYield().getOperands()) {
+      // Check the defining op for the corresponding result.
+      if (Operation *def = yieldV.getDefiningOp()) {
+        bool hasTaskId = hasAsyncTaskId(def, asyncTaskId);
+        if (hasTaskId) {
+          keptResultVec.push_back(resultIdx);
+        }
+      } else {
+        keptResultVec.push_back(resultIdx);
+      }
+      ++resultIdx;
+    }
+  }
+
+  SmallVector<Type> newResultTypes;
+  for (auto idx : keptResultVec) {
+    newResultTypes.push_back(ifOp->getResultTypes()[idx]);
+  }
+  auto newIfOp = builder.createWithAsyncTaskIds<scf::IfOp>(
+      ifOp.getLoc(), newResultTypes, mapping.lookup(ifOp.getCondition()), true,
+      ifOp.elseBlock());
+
+  OpBuilderWithAsyncTaskIds ifBuilder(ifOp.getContext());
+  ifBuilder.setAsynTaskIdsFromArray({asyncTaskId});
+
+  // Handle thenRegion of this IfOp.
+  ifBuilder.setInsertionPointToEnd(newIfOp.thenBlock());
+  for (Operation &thenOp : ifOp.thenBlock()->getOperations()) {
+    SpecializeOp(&thenOp, mapping, ifBuilder, asyncTaskId);
+  }
+
+  // Update yields
+  auto updateYield = [&](scf::YieldOp yield, SmallVector<Value> &operands) {
+    ifBuilder.setInsertionPoint(yield);
+    ifBuilder.createWithAsyncTaskIds<scf::YieldOp>(yield.getLoc(), operands);
+    yield.erase();
+  };
+  if (keptResultVec.size() < ifOp->getResultTypes().size()) {
+    SmallVector<Value> ifYieldOperands;
+    for (auto idx : keptResultVec) {
+      ifYieldOperands.push_back(newIfOp.thenYield().getOperand(idx));
+    }
+    updateYield(newIfOp.thenYield(), ifYieldOperands);
+  }
+
+  // Handle elseRegion of the IfOp.
+  if (ifOp.elseBlock()) {
+    ifBuilder.setInsertionPointToEnd(newIfOp.elseBlock());
+    for (Operation &elseOp : ifOp.elseBlock()->getOperations()) {
+      SpecializeOp(&elseOp, mapping, ifBuilder, asyncTaskId);
+    }
+    if (keptResultVec.size() < ifOp->getResultTypes().size()) {
+      SmallVector<Value> elseYieldOperands;
+      for (auto idx : keptResultVec) {
+        elseYieldOperands.push_back(newIfOp.elseYield().getOperand(idx));
+      }
+      updateYield(newIfOp.elseYield(), elseYieldOperands);
+    }
+  }
+
+  unsigned newResIdx = 0;
+  for (auto idx : keptResultVec) {
+    mapping.map(ifOp.getResult(idx), newIfOp.getResult(newResIdx));
+    ++newResIdx;
+  }
+  return newIfOp;
+}
+
+Operation *SpecializeForOp(scf::ForOp forOp, IRMapping &mapping,
+                           OpBuilderWithAsyncTaskIds &builder,
+                           AsyncTaskId asyncTaskId) {
+  // Create newForOp for each task Id.
+  auto usedArgs = collectBlockArgsForTask(forOp, asyncTaskId);
+
+  // Prepare newLoopArgs.
+  SmallVector<Value> newLoopArgs;
+  for (unsigned argNumber : usedArgs) {
+    auto arg = forOp.getInitArgs()[argNumber];
+    auto newArg = mapping.lookupOrDefault(arg);
+    assert(newArg && "Unexpected missing mapping");
+    newLoopArgs.push_back(newArg);
+  }
+
+  // Prepare loop bounds.
+  auto newLowerBound = mapping.lookupOrDefault(forOp.getLowerBound());
+  auto newUpperBound = mapping.lookupOrDefault(forOp.getUpperBound());
+  auto newStep = mapping.lookupOrDefault(forOp.getStep());
+
+  // Create newForOp.
+  auto newForOp = builder.createWithAsyncTaskIds<scf::ForOp>(
+      forOp.getLoc(), newLowerBound, newUpperBound, newStep, newLoopArgs);
+  if (forOp->getAttr("tt.loop_schedule"))
+    newForOp->setAttr("tt.loop_schedule", forOp->getAttr("tt.loop_schedule"));
+
+  // Initialize Value mapping from forOp to newForOp
+  mapping.map(forOp.getInductionVar(), newForOp.getInductionVar());
+  for (unsigned i = 0; i < usedArgs.size(); ++i) {
+    auto oldArg = forOp.getRegionIterArgs()[usedArgs[i]];
+    auto newArg = newForOp.getRegionIterArgs()[i];
+    mapping.map(oldArg, newArg);
+  }
+
+  // Recursively clone all operations with this asyncTaskId to newForOp.
+  OpBuilderWithAsyncTaskIds forBuilder(forOp.getContext());
+  forBuilder.setAsynTaskIdsFromArray({asyncTaskId});
+  forBuilder.setInsertionPointToStart(newForOp.getBody());
+  for (Operation &op : forOp.getBody()->without_terminator()) {
+    SpecializeOp(&op, mapping, forBuilder, asyncTaskId);
+  }
+
+  // Create YieldOp for newForOp.
+  auto yieldOp = llvm::cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+  SmallVector<Value> newYieldOperands;
+  for (unsigned i : usedArgs)
+    newYieldOperands.push_back(mapping.lookup(yieldOp.getOperand(i)));
+
+  bool createNewYield = true;
+  if (newForOp.getBody()->mightHaveTerminator()) {
+    auto initialYield =
+        llvm::cast<scf::YieldOp>(newForOp.getBody()->getTerminator());
+    if (newYieldOperands.size() == 0) {
+      setAsyncTaskIds(initialYield, {asyncTaskId});
+      createNewYield = false;
+    }
+  }
+  if (createNewYield) {
+    auto newYieldOp =
+        forBuilder.create<scf::YieldOp>(yieldOp.getLoc(), newYieldOperands);
+    setAsyncTaskIds(newYieldOp, {asyncTaskId});
+  }
+
+  // Replace results of forOp with results of newForOp.
+  for (unsigned i = 0; i < usedArgs.size(); ++i) {
+    auto oldResult = forOp.getResult(usedArgs[i]);
+    auto newResult = newForOp.getResult(i);
+    mapping.map(oldResult, newResult);
+  }
+
+  return newForOp;
+}
+
+Operation *SpecializeOp(Operation *op, IRMapping &mapping,
+                        OpBuilderWithAsyncTaskIds &builder,
+                        AsyncTaskId asyncTaskId) {
+  auto taskIds = getAsyncTaskIds(op);
+  // yieldOp are sometimes implict, meaning they do not necessarily have a task
+  // id, but they should be shared by all async tasks.
+  if (!hasAsyncTaskId(op, asyncTaskId) && !isa<scf::YieldOp>(op))
+    return nullptr;
+
+  if (op->getNumRegions() == 0) {
+    Operation *newOp = builder.clone(*op, mapping);
+    setAsyncTaskIds(newOp, asyncTaskId);
+    for (unsigned i = 0; i < op->getNumResults(); ++i)
+      mapping.map(op->getResult(i), newOp->getResult(i));
+    return newOp;
+  } else {
+    if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+      return SpecializeIfOp(ifOp, mapping, builder, asyncTaskId);
+    } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+      return SpecializeForOp(forOp, mapping, builder, asyncTaskId);
+    } else if (auto reduceOp = dyn_cast<ReduceOp>(op)) {
+      Operation *newOp = builder.clone(*op, mapping);
+      // recursively set async task ids for child ops
+      newOp->walk(
+          [&](Operation *childOp) { setAsyncTaskIds(childOp, asyncTaskId); });
+      for (unsigned i = 0; i < op->getNumResults(); ++i)
+        mapping.map(op->getResult(i), newOp->getResult(i));
+      return newOp;
+    } else {
+      llvm_unreachable("Unexpected Op with regions");
+    }
+  }
+
+  return nullptr;
+}
+
+// Create IfOp for each ayncTaskId.
+DenseMap<AsyncTaskId, scf::IfOp> SpecializeRegion(triton::FuncOp funcOp,
+                                                  int regDecProducer,
+                                                  int regIncConsumer) {
+
+  LLVM_DEBUG({
+    LDBG("\n\n");
+    LDBG("Start specializing region");
+  });
+
+  MLIRContext *context = funcOp.getContext();
+  OpBuilder builder(context);
+  auto loc = funcOp.getLoc();
+
+  // Collect original operations
+  SmallVector<Operation *> opList;
+  for (auto &block : funcOp.getBody().getBlocks()) {
+    for (Operation &op : block.getOperations()) {
+      auto taskIds = getAsyncTaskIds(&op);
+      if (!taskIds.empty())
+        opList.push_back(&op);
+    }
+  }
+
+  LLVM_DEBUG({
+    LDBG("ops to be specialized: ");
+    for (Operation *op : opList) {
+      op->dump();
+    }
+  });
+
+  // Create GetAsyncTaskIdOp.
+  Block *lastBlock = &funcOp.getBody().back();
+  auto returnOp = llvm::cast<triton::ReturnOp>(lastBlock->getTerminator());
+  builder.setInsertionPoint(returnOp);
+  Value curAsyncTaskId = builder.create<ttng::GetAsyncTaskIdOp>(loc);
+
+  DenseMap<AsyncTaskId, scf::IfOp> tasksToIfOp;
+
+  // Clone all operations into the corresponding if blocks. If the operation
+  // has multiple taskIds, it will be cloned for multiple if blocks.
+  // If the original code has an IfOp, we should only clone its
+  // body with the right asyncTaskId, instead of cloning the IfOp.
+  for (AsyncTaskId asyncTaskId : getNestedAsyncTaskIds(funcOp)) {
+    // Create IfOp for each asyncTaskId.
+    Value cond = builder.create<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::eq, curAsyncTaskId,
+        builder.create<arith::ConstantIntOp>(loc, asyncTaskId, 32));
+
+    auto ifOp = builder.create<scf::IfOp>(loc, cond);
+    tasksToIfOp[asyncTaskId] = ifOp;
+    setAsyncTaskIds(ifOp, {asyncTaskId});
+
+    OpBuilderWithAsyncTaskIds taskBuilder(context);
+    taskBuilder.setAsynTaskIdsFromArray({asyncTaskId});
+
+    // Set insertion point before yieldOp.
+    auto yieldOp = ifOp.thenYield();
+    setAsyncTaskIds(yieldOp, {asyncTaskId});
+    taskBuilder.setInsertionPoint(yieldOp);
+
+    IRMapping mapping;
+    for (Operation *op : opList) {
+      SpecializeOp(op, mapping, taskBuilder, asyncTaskId);
+    }
+  }
+
+  // Decide if this taskId is a producer or a consumer, and create either
+  // RegAllocOp or RegDeallocOp accordingly.
+  for (auto ifOps : tasksToIfOp) {
+    AsyncTaskId asyncTaskId = ifOps.first;
+    auto ifOp = ifOps.second;
+    OpBuilderWithAsyncTaskIds taskBuilder(ifOp.getContext());
+    taskBuilder.setAsynTaskIdsFromArray({asyncTaskId});
+    auto regAlloc = scanRegUsage(ifOp.thenBlock(), asyncTaskId, regDecProducer,
+                                 regIncConsumer);
+    taskBuilder.setInsertionPointToStart(&(ifOp.getThenRegion().front()));
+    if (regAlloc.second)
+      taskBuilder.create<ttng::RegAllocOp>(
+          loc, taskBuilder.getI32IntegerAttr(regAlloc.first));
+    else
+      taskBuilder.create<ttng::RegDeallocOp>(
+          loc, taskBuilder.getI32IntegerAttr(regAlloc.first));
+  }
+
+  LLVM_DEBUG({
+    LDBG("\n\nWith task Id checks");
+    funcOp.dump();
+  });
+
+  // Remove original operations that have been cloned in reverse order.
+  for (auto it = opList.rbegin(); it != opList.rend(); ++it) {
+    Operation *op = *it;
+    LLVM_DEBUG({
+      LDBG("erasing op ");
+      op->dump();
+    });
+    // For debugging purposes, check to see if the original op is still in use.
+    bool hasUse = false;
+    for (unsigned i = 0; i < op->getNumResults(); ++i) {
+      for (Operation *user : op->getResult(i).getUsers()) {
+        hasUse = true;
+        LLVM_DEBUG({
+          LDBG("op has use ");
+          user->dump();
+        });
+      }
+    }
+    op->erase();
+  }
+  return tasksToIfOp;
+}
+
+struct Channel {
+public:
+  using Relation = std::pair<int, SmallVector<int>>;
+
+  Channel(int producer, SmallVector<int> &consumers, Operation *op,
+          unsigned operandIdx, unsigned numBuffers)
+      : relation(producer, consumers), op(op), operandIdx(operandIdx),
+        numBuffers(numBuffers) {}
+
+  bool operator==(const Channel &c) {
+    return relation == c.relation && operandIdx == c.operandIdx && op == c.op;
+  }
+
+  Operation *getDstOp() { return op; }
+  unsigned getDstOperandIdx() { return operandIdx; }
+  Value getSrcOperand() { return op->getOperand(operandIdx); }
+  Operation *getSrcOp() { return getSrcOperand().getDefiningOp(); }
+
+  Relation relation; // producer task Id, a list of consumer task Ids
+  Operation *op;
+  unsigned operandIdx;
+  unsigned numBuffers;
+};
+
+// Find transitive users of the root op. Track through control flow ops (such as
+// yield) to get to the real users.
+void getTransitiveUsers(Value root,
+                        SetVector<std::pair<Operation *, unsigned>> &users) {
+  for (Operation *userOp : root.getUsers()) {
+    if (auto yieldOp = dyn_cast<scf::YieldOp>(userOp)) {
+      for (OpOperand &operand : yieldOp->getOpOperands()) {
+        if (operand.get() == root) {
+          auto result =
+              yieldOp->getParentOp()->getResult(operand.getOperandNumber());
+          getTransitiveUsers(result, users);
+        }
+      }
+    } else {
+      // find operand index of root
+      unsigned operandIndex = 0;
+      for (OpOperand &operand : userOp->getOpOperands()) {
+        if (operand.get() == root) {
+          break;
+        }
+        operandIndex++;
+      }
+      assert(operandIndex < userOp->getNumOperands() &&
+             "root is not an operand of userOp");
+      users.insert({userOp, operandIndex});
+    }
+  }
+}
+
+// Loads will be in producer warp groups. For now, we only allow a single
+// warp group/task for a producer. For each LoadOp, create a channel from it
+// to any direct user which belongs to a different taskId.
+void collectAsyncChannels(SmallVector<std::unique_ptr<Channel>> &channels,
+                          triton::FuncOp &funcOp, unsigned numBuffers) {
+  funcOp.walk([&](Operation *op) {
+    if (isa<tt::LoadOp, tt::ExperimentalDescriptorLoadOp>(op) ||
+        op->hasTrait<OpTrait::DotLike>()) {
+      auto producerTaskIds = getAsyncTaskIds(op);
+      if (producerTaskIds.empty() || producerTaskIds.size() > 1) {
+        LLVM_DEBUG({
+          LDBG(" ignoring load ops without async task id or with multiple task "
+               "ids: ");
+          op->dump();
+        });
+        return;
+      }
+      auto producerTaskId = producerTaskIds.front();
+      unsigned producerNumBuffers = numBuffers;
+      if (auto forOp = op->getParentOfType<scf::ForOp>()) {
+        producerNumBuffers = getNumBuffersOrDefault(forOp, numBuffers);
+      }
+
+      for (auto result : op->getResults()) {
+        if (result.use_empty()) {
+          continue;
+        }
+
+        SetVector<std::pair<Operation *, unsigned>> users;
+        getTransitiveUsers(result, users);
+        for (auto user : users) {
+          auto userOp = user.first;
+          auto consumerTaskIds = getAsyncTaskIds(userOp);
+          if (consumerTaskIds.empty())
+            continue;
+          // Remove producer task id from consumerTaskIds.
+          auto iter = std::remove(consumerTaskIds.begin(),
+                                  consumerTaskIds.end(), producerTaskId);
+          consumerTaskIds.erase(iter, consumerTaskIds.end());
+          // Add a channel from the single producer task to consumerTaskIds.
+          if (consumerTaskIds.size() > 0) {
+            channels.push_back(std::make_unique<Channel>(
+                producerTaskId, consumerTaskIds, userOp, user.second,
+                producerNumBuffers));
+          }
+        }
+      }
+    }
+  });
+
+  LLVM_DEBUG({
+    LDBG("Async channels:");
+    for (auto &channel : channels) {
+      LDBG("producer op: " << channel->relation.first);
+      channel->getSrcOp()->dump();
+      for (auto &asyncTaskId : channel->relation.second)
+        LDBG("consumer: " << asyncTaskId);
+      channel->getDstOp()->dump();
+      LDBG("numBuffers: " << channel->numBuffers);
+    }
+  });
+}
+
+// Group channels in two ways:
+//  - by producer ops. One producer corresponds to multiple channels. This
+//    grouping will be used to create buffers per shared producer.
+//  - by consumer ops. One consumer corresponds to multiple channels. This
+//  grouping will be used to create barriers per shared consumer.
+// Also compute orderedChannels, which will be keyed by getDstOp() of channels,
+// to enforce deterministic order for map.
+void groupChannels(
+    SmallVector<Channel *> &channels,
+    DenseMap<Channel *, SmallVector<Channel *>> &channelsGroupedByProducers,
+    DenseMap<Channel *, SmallVector<Channel *>> &channelsGroupedByConsumers,
+    SmallVector<Channel *> &orderedChannels) {
+
+  // Group channels by producer op.
+  DenseMap<Operation *, SmallVector<Channel *>> producerChannels;
+  for (auto channel : channels) {
+    producerChannels[channel->getSrcOp()].push_back(channel);
+  }
+
+#ifndef NDEBUG
+  // Some sanity checks.
+  for (auto &item : producerChannels) {
+    auto &channels = item.second;
+    unsigned numBuffers = channels.front()->numBuffers;
+    for (auto c : channels) {
+      assert(c->numBuffers == numBuffers && "Unmatched number of buffers");
+    }
+  }
+#endif
+
+  // Group channels by consumer op.
+  DenseMap<Operation *, SmallVector<Channel *>> consumerChannels;
+
+  // Two channels can be combined if
+  //   src1 and src2 are in the same block and
+  //   (dst1 == dst2 or
+  //    (dst1 and dst2 are in the same block, both have a single user, and
+  //     dst1User == dst2User and dst1User is in the same block as dst1))
+  auto channelCanBeMerged = [](Channel *c1, Channel *c2) -> bool {
+    if (c1->getSrcOp()->getBlock() != c2->getSrcOp()->getBlock())
+      return false;
+    Operation *dst1 = c1->getDstOp(), *dst2 = c2->getDstOp();
+    if (dst1 == dst2)
+      return true;
+    if (dst1->getBlock() != dst2->getBlock() || !dst1->hasOneUse() ||
+        !dst2->hasOneUse())
+      return false;
+    Operation *dst1User = *(dst1->getUsers().begin());
+    Operation *dst2User = *(dst2->getUsers().begin());
+    return dst1User == dst2User && dst1User->getBlock() == dst1->getBlock();
+  };
+  assert(channels.size() > 0 && "channel size is zero");
+  // Compare with existing channels in the consumerChannels to see if
+  // it can be combined.
+  for (auto *c0 : channels) {
+    bool merged = false;
+    for (auto &kv : consumerChannels) {
+      if (kv.second.size() > 0 && channelCanBeMerged(c0, kv.second.front())) {
+        kv.second.push_back(c0);
+        merged = true;
+        break;
+      }
+    }
+    if (!merged) { // Create a new entry.
+      auto *keyOp = c0->getDstOp();
+      if (!consumerChannels.count(keyOp))
+        orderedChannels.push_back(c0);
+      consumerChannels[keyOp].push_back(c0);
+    }
+  }
+
+  // Reorder channels associated with one entry based on program order of the
+  // producers.
+  for (auto &kv : consumerChannels) {
+    if (kv.second.size() > 1) {
+      auto &allOps = kv.second.front()->getSrcOp()->getBlock()->getOperations();
+      std::sort(
+          kv.second.begin(), kv.second.end(), [&](Channel *a, Channel *b) {
+            auto itrA =
+                std::find_if(allOps.begin(), allOps.end(), [&](Operation &op) {
+                  Operation *opPointer = &op;
+                  return opPointer == a->getSrcOp();
+                });
+            auto itrB =
+                std::find_if(allOps.begin(), allOps.end(), [&](Operation &op) {
+                  Operation *opPointer = &op;
+                  return opPointer == b->getSrcOp();
+                });
+            assert(itrA != allOps.end() && itrB != allOps.end());
+            return std::distance(itrA, itrB) < 0;
+          });
+    }
+  }
+
+  // Switch to using channel as the key instead of ops as ops can be volatile.
+  for (auto &kv : producerChannels) {
+    channelsGroupedByProducers[kv.second.front()] = kv.second;
+  }
+  for (auto &kv : consumerChannels) {
+    channelsGroupedByConsumers[kv.second.front()] = kv.second;
+  }
+
+  LLVM_DEBUG({
+    DBGS() << "\n\n";
+    LDBG("Grouped channels by producer:");
+    unsigned i = 0;
+    for (auto &kv : channelsGroupedByProducers) {
+      DBGS() << "Channel  " << ++i << ":\n";
+      DBGS() << "producer:  ";
+      kv.getFirst()->getSrcOp()->dump();
+      for (auto &channel : kv.second) {
+        DBGS() << "consumer: ";
+        channel->getDstOp()->dump();
+        DBGS() << "] ";
+        LDBG("numBuffers: " << channel->numBuffers);
+        DBGS() << "\n";
+      }
+    }
+
+    DBGS() << "\n\n";
+    LDBG("Grouped channels by consumer:");
+    i = 0;
+    for (auto &kv : channelsGroupedByConsumers) {
+      DBGS() << "Channel  " << ++i << ":\n";
+      DBGS() << "consumer:  ";
+      kv.getFirst()->getDstOp()->dump();
+      for (auto &channel : kv.second) {
+        DBGS() << "producer: ";
+        channel->getSrcOp()->dump();
+        for (auto &asyncTaskId : channel->relation.second)
+          DBGS() << asyncTaskId << ", ";
+        DBGS() << "] ";
+        LDBG("numBuffers: " << channel->numBuffers);
+        DBGS() << "\n";
+      }
+      DBGS() << "\n";
+    }
+  });
+}
+
+// Reorder producer ops to unblock consumers interleavingly.
+void reorderProducerOps(SmallVector<Channel *> &channels) {
+  if (channels.size() <= 1)
+    return;
+
+  // Bail out if channels are not in the same block
+  auto block = channels.front()->getSrcOp()->getBlock();
+  for (auto &channel : channels) {
+    if (channel->getSrcOp()->getBlock() != block) {
+      return;
+    }
+  }
+
+  // Group channels by the first consumer taskId of each channel. Smaller taskId
+  // has higher priority.
+  // TODO: consider consumer priority
+  std::map<AsyncTaskId, SmallVector<Channel *>> groupedProducerOps;
+  for (auto &channel : channels) {
+    auto asyncTaskId = channel->relation.second.front();
+    groupedProducerOps[asyncTaskId].push_back(channel);
+  }
+
+  // No need to reorder if all channels are in the same group.
+  if (groupedProducerOps.size() <= 1)
+    return;
+
+  // Sort each group by number of consumers.
+  for (auto &group : groupedProducerOps) {
+    std::sort(group.second.begin(), group.second.end(),
+              [&](Channel *a, Channel *b) {
+                return a->relation.second.size() < b->relation.second.size();
+              });
+  }
+
+  // Start from the first producer in channels. Iterate through the groups
+  // which are ordered by the first consumer taskId. Within each group, channels
+  // are ordered by number of consumers.
+  Operation *currOp = channels.front()->getSrcOp();
+  for (auto &group : groupedProducerOps) {
+    for (auto &channel : group.second) {
+      channel->getSrcOp()->moveAfter(currOp);
+      currOp = channel->getSrcOp();
+    }
+  }
+
+  // Move backward dependency slice close to producer ops.
+  // Start from the last producer op backwards and move backward slice to
+  // before each op. This guarantees that the backward slice of each op is
+  // scheduled as late as possible.
+  for (auto &group : reverse(groupedProducerOps)) {
+    for (auto &channel : reverse(group.second)) {
+      BackwardSliceOptions opt;
+      opt.omitBlockArguments = true;
+      SetVector<Operation *> backwardSlice;
+      getBackwardSlice(channel->getSrcOp(), &backwardSlice, opt);
+      for (auto &op : backwardSlice) {
+        if (op->getBlock() == block)
+          op->moveBefore(channel->getSrcOp());
+      }
+    }
+  }
+
+  LLVM_DEBUG({
+    LDBG("\n");
+    LDBG("after reordering producer ops");
+    currOp->getParentOfType<triton::FuncOp>().dump();
+    LDBG("\n");
+  });
+}
+
+bool isInnermostLoop(scf::ForOp forOp) {
+  bool isInner = true;
+  forOp.walk<WalkOrder::PreOrder>([&](Operation *subOp) {
+    if (subOp != forOp.getOperation())
+      if (auto forOp = dyn_cast<scf::ForOp>(subOp))
+        isInner = false;
+  });
+  return isInner;
+}
+
+// Generate code
+//   numSteps = ((upperBound - lowerBound) + forOpStep - 1) / forOpStep
+Value getNumSteps(scf::ForOp forOp, OpBuilderWithAsyncTaskIds &builder) {
+  auto loc = forOp.getLoc();
+  // numSteps = ((upperBound - lowerBound) + forOpStep - 1) / forOpStep
+  Value numSteps = builder.createWithAsyncTaskIds<arith::SubIOp>(
+      loc, forOp.getUpperBound(), forOp.getLowerBound());
+  numSteps = builder.createWithAsyncTaskIds<arith::AddIOp>(loc, numSteps,
+                                                           forOp.getStep());
+  if (forOp.getStep().getType() != builder.getI64Type())
+    numSteps = builder.createWithAsyncTaskIds<arith::ExtSIOp>(
+        loc, builder.getI64Type(), numSteps);
+
+  Value one = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 64);
+  numSteps = builder.createWithAsyncTaskIds<arith::SubIOp>(loc, numSteps, one);
+  Value innerForStep = forOp.getStep();
+  if (forOp.getStep().getType() != builder.getI64Type())
+    innerForStep = builder.createWithAsyncTaskIds<arith::ExtSIOp>(
+        loc, builder.getI64Type(), forOp.getStep());
+  numSteps = builder.createWithAsyncTaskIds<arith::DivUIOp>(loc, numSteps,
+                                                            innerForStep);
+  return numSteps;
+}
+
+// Add phase and bufferIndex to be used when lowering the producer.
+// When hasParallelReuse is true (i.e this is the innermost loop), we pass in
+// accumulatedLoopCount, which is used to initialize initBufferIdx.
+// When isOuterOfReuse is true, we add an additional arg for accumLoopCount.
+scf::ForOp createNewLoop(scf::ForOp forOp, int numBuffers,
+                         scf::ForOp &parentForOp, Value accumulatedLoopCount,
+                         SmallVector<Operation *> &loopWithBufferReuse,
+                         bool hasParallelReuse, bool isOuterOfReuse) {
+  auto loc = forOp.getLoc();
+  Block *body = forOp.getBody();
+
+  OpBuilderWithAsyncTaskIds builder(forOp.getContext());
+  builder.setAsynTaskIdsFromArray(getNestedAsyncTaskIds(forOp));
+  builder.setInsertionPoint(forOp);
+  if (hasParallelReuse) {
+    LLVM_DEBUG({
+      LDBG("createNewLoop hasParallelReuse: ");
+      accumulatedLoopCount.dump();
+    });
+  }
+
+  Value numBuffersVal =
+      builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, numBuffers, 32);
+
+  // Step 1: Append bufferIdx and phase as forOp arguments.
+  Value tmpAccumLoopCount;
+  if (isOuterOfReuse) {
+    tmpAccumLoopCount = body->insertArgument(body->getNumArguments(),
+                                             builder.getI64Type(), loc);
+  }
+  Value phase =
+      body->insertArgument(body->getNumArguments(), builder.getI1Type(), loc);
+  Value bufferIdx =
+      body->insertArgument(body->getNumArguments(), builder.getI32Type(), loc);
+
+  // Step 2: Generate bufferIdx and phase for next iteration:
+  //   nextBufferIdx = bufferIdx + 1
+  //   nextPhase = ((nextBufferIdx < numBuffers && curPhase) ||
+  //                (nextBufferIdx >= numBuffers && curPhase^1))
+  //   nextBufferIdx = nextBufferIdx >= numBuffers ? 0 : nextBufferIdx
+  auto yieldOp = llvm::cast<scf::YieldOp>(body->getTerminator());
+  builder.setInsertionPoint(yieldOp);
+  Value one = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 32);
+  Value _1_1b = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 1);
+  //   nextBufferIdx = bufferIdx + 1
+  Value nextBufferIdx =
+      builder.createWithAsyncTaskIds<arith::AddIOp>(loc, bufferIdx, one);
+  Value bufferGECond = builder.createWithAsyncTaskIds<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::uge, nextBufferIdx, numBuffersVal);
+  Value bufferLTCond = builder.createWithAsyncTaskIds<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::ult, nextBufferIdx, numBuffersVal);
+  // nextBufferIdx >= numBuffers ? nextBufferIdx - numBuffers : nextBufferIdx
+  Value moduloBufferIdx = builder.createWithAsyncTaskIds<arith::SubIOp>(
+      loc, nextBufferIdx, numBuffersVal);
+  nextBufferIdx = builder.createWithAsyncTaskIds<mlir::arith::SelectOp>(
+      loc, bufferGECond, moduloBufferIdx, nextBufferIdx);
+
+  // nextPhase = ((nextBufferIdx < numBuffers && curPhase) ||
+  //              (nextBufferIdx >= numBuffers && curPhase^1))
+  Value flipPhase =
+      builder.createWithAsyncTaskIds<mlir::arith::XOrIOp>(loc, phase, _1_1b);
+  Value cond0 = builder.createWithAsyncTaskIds<mlir::arith::AndIOp>(
+      loc, bufferGECond, flipPhase);
+  Value cond1 = builder.createWithAsyncTaskIds<mlir::arith::AndIOp>(
+      loc, bufferLTCond, phase);
+  Value nextPhase =
+      builder.createWithAsyncTaskIds<mlir::arith::OrIOp>(loc, cond0, cond1);
+
+  // Step 3: Add nextBufferIdx and nextPhase to yieldOp.
+  if (isOuterOfReuse) {
+    // We have not iterated through the body yet, so do not have the right value
+    // for nextTmpIdx. This will be fixed in the caller.
+    Value nextTmpIdx = tmpAccumLoopCount;
+    yieldOp->insertOperands(yieldOp.getNumOperands(),
+                            {nextTmpIdx, nextPhase, nextBufferIdx});
+  } else
+    yieldOp->insertOperands(yieldOp.getNumOperands(),
+                            {nextPhase, nextBufferIdx});
+
+  // Step 4: Create loop arguments for the new ForOp.
+  SmallVector<Value> newLoopArgs;
+  for (auto operand : forOp.getInitArgs())
+    newLoopArgs.push_back(operand);
+
+  builder.setInsertionPoint(forOp);
+  Value initBufferIdx, initPhase;
+  // Set initial values for bufferIdx and phase.
+  if (parentForOp) {
+    if (hasParallelReuse) {
+      // Handling ForOp with an outer loop, use the passed-in value as initial
+      // value.
+      initBufferIdx = accumulatedLoopCount;
+    } else {
+      // It is possible that parent loop induction variable has different type.
+      // Here we promote to 64 bit.
+      // numSteps = ((upperBound - lowerBound) + forOpStep - 1) / forOpStep
+      Value numSteps = getNumSteps(forOp, builder);
+
+      // TODO: use a global flattened iteration space index for multi-dim loops.
+      // initBufferIdx = (parentInductionVar - parentLowBound) / parentStep *
+      // numSteps
+      Value parentIterIdx = builder.createWithAsyncTaskIds<arith::SubIOp>(
+          loc, parentForOp.getInductionVar(), parentForOp.getLowerBound());
+      parentIterIdx = builder.createWithAsyncTaskIds<arith::DivUIOp>(
+          loc, parentIterIdx, parentForOp.getStep());
+      if (parentForOp.getStep().getType() != builder.getI64Type())
+        parentIterIdx = builder.createWithAsyncTaskIds<arith::ExtSIOp>(
+            loc, builder.getI64Type(), parentIterIdx);
+      initBufferIdx = builder.createWithAsyncTaskIds<arith::MulIOp>(
+          loc, parentIterIdx, numSteps);
+    }
+
+    numBuffersVal = builder.createWithAsyncTaskIds<arith::ExtSIOp>(
+        loc, builder.getI64Type(), numBuffersVal);
+    // Calculate tmpIdx / numBuffers
+    // initBufferIdx = tmpIdx - tmpIdx / numBuffers * numBuffers
+    // initPhase = (tmpIdx / numBuffers) & 1
+    Value bufferIdx = builder.createWithAsyncTaskIds<arith::DivUIOp>(
+        loc, initBufferIdx, numBuffersVal);
+    initBufferIdx = builder.createWithAsyncTaskIds<arith::SubIOp>(
+        loc, initBufferIdx,
+        builder.createWithAsyncTaskIds<arith::MulIOp>(loc, bufferIdx,
+                                                      numBuffersVal));
+    initBufferIdx = builder.createWithAsyncTaskIds<arith::TruncIOp>(
+        loc, builder.getI32Type(), initBufferIdx);
+
+    Value one =
+        builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 64);
+    bufferIdx =
+        builder.createWithAsyncTaskIds<arith::AndIOp>(loc, bufferIdx, one);
+    initPhase = builder.createWithAsyncTaskIds<arith::TruncIOp>(
+        loc, builder.getI1Type(), bufferIdx);
+  } else {
+    if (hasParallelReuse) {
+      // Handling ForOp without outer loop.
+      //   tmpIdx = accumulatedLoopCount
+      initBufferIdx = accumulatedLoopCount;
+      numBuffersVal = builder.createWithAsyncTaskIds<arith::ExtSIOp>(
+          loc, builder.getI64Type(), numBuffersVal);
+      //   bufferIdx = tmpIdx / numBuffers
+      Value bufferIdx = builder.createWithAsyncTaskIds<arith::DivUIOp>(
+          loc, initBufferIdx, numBuffersVal);
+      //   initBufferIdx = tmpIdx - tmpIdx/numBuffers * numBuffers (modulo)
+      initBufferIdx = builder.createWithAsyncTaskIds<arith::SubIOp>(
+          loc, initBufferIdx,
+          builder.createWithAsyncTaskIds<arith::MulIOp>(loc, bufferIdx,
+                                                        numBuffersVal));
+      initBufferIdx = builder.createWithAsyncTaskIds<arith::TruncIOp>(
+          loc, builder.getI32Type(), initBufferIdx);
+
+      Value one =
+          builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 64);
+      //   initPhase = (tmpIdx / numBuffers) & 1
+      bufferIdx =
+          builder.createWithAsyncTaskIds<arith::AndIOp>(loc, bufferIdx, one);
+      initPhase = builder.createWithAsyncTaskIds<arith::TruncIOp>(
+          loc, builder.getI1Type(), bufferIdx);
+    } else {
+      // Set initial phase to false, and initial bufferIdx to 0.
+      initBufferIdx =
+          builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 0, 32);
+      initPhase =
+          builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 0, 1);
+    }
+  }
+  if (isOuterOfReuse) {
+    assert(!hasParallelReuse);
+    Value initTmpIdx =
+        builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 0, 64);
+    newLoopArgs.append({initTmpIdx, initPhase, initBufferIdx});
+  } else
+    newLoopArgs.append({initPhase, initBufferIdx});
+
+  // Step 5: Create newForOp and take the region of the original forOp.
+  auto newForOp = builder.createWithAsyncTaskIds<scf::ForOp>(
+      loc, forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep(),
+      newLoopArgs);
+  if (forOp->getAttr("tt.loop_schedule"))
+    newForOp->setAttr("tt.loop_schedule", forOp->getAttr("tt.loop_schedule"));
+  newForOp.getRegion().takeBody(forOp.getRegion());
+
+  // Step 6: Replace forOp with newForOp.
+  for (unsigned i = 0; i < forOp.getNumResults(); ++i)
+    forOp.getResult(i).replaceAllUsesWith(newForOp.getResult(i));
+  forOp.erase();
+
+  return newForOp;
+}
+
+// Find top-level ops which contain at least one channel. If a channel's
+// getSrcOp() and getDstOp() belong to the inner loop, the outer loop will be
+// part of asyncTaskOps.
+SmallVector<Operation *>
+getTaskTopRegion(triton::FuncOp funcOp,
+                 const SmallVector<Channel *> &channels) {
+  SmallVector<Operation *> asyncTaskOps;
+  auto isAsyncTaskTopOp = [&](Operation *taskTopOp) -> bool {
+    for (auto c : channels) {
+      Operation *producer = c->getSrcOp(), *consumer = c->getDstOp();
+      while (producer && !isa<triton::FuncOp>(producer->getParentOp())) {
+        producer = producer->getParentOp();
+      }
+      while (consumer && !isa<triton::FuncOp>(consumer->getParentOp())) {
+        consumer = consumer->getParentOp();
+      }
+      if (producer == taskTopOp && consumer == taskTopOp)
+        return true;
+    }
+    return false;
+  };
+  for (auto &block : funcOp.getBody().getBlocks()) {
+    for (Operation &bodyOp : block.getOperations()) {
+      Operation *op = &bodyOp;
+      if (op->getNumRegions() <= 0)
+        continue;
+      // If this op does not contain both a producer taskId and a consumer
+      // taskId, continue.
+      if (getAsyncTaskIds(op).size() == 1)
+        continue;
+      if (isAsyncTaskTopOp(op))
+        asyncTaskOps.push_back(op);
+    }
+  }
+
+  LLVM_DEBUG({
+    LDBG("\nTop Task Bodies");
+    for (auto op : asyncTaskOps) {
+      LDBG("\nTask Body:");
+      op->dump();
+    }
+  });
+  return asyncTaskOps;
+}
+
+static unsigned getNumChannelsInLoop(scf::ForOp forOp,
+                                     const SmallVector<Channel *> &channels,
+                                     SmallVector<Channel *> &channelsInLoop) {
+  unsigned num = 0;
+  for (auto *ch : channels) {
+    scf::ForOp srcParent = ch->getSrcOp()->getParentOfType<scf::ForOp>();
+    scf::ForOp dstParent = ch->getSrcOp()->getParentOfType<scf::ForOp>();
+    if (srcParent == forOp && dstParent == forOp) {
+      channelsInLoop.push_back(ch);
+    }
+  }
+  return channelsInLoop.size();
+}
+
+bool reuseBuffers(SmallVector<Operation *> &taskTopOps,
+                  const SmallVector<Channel *> &channels,
+                  DenseMap<Channel *, Channel *> &mapToRepresenting,
+                  SmallVector<Operation *> &loopWithBufferReuse) {
+  // For the case of multiple parallel ForOps with same number of channels,
+  // we can try reusing the buffers across the parallel ForOps.
+  // One case is
+  //   ForOp
+  //   ForOp
+  // The other case is
+  //   ForOp (persistent)
+  //     ForOp
+  //     ForOp
+  // For the case of
+  //   ForOp (persistent)
+  //     ForOp
+  // We update loopWithBufferReuse with the inner loop and use accumLoopCount
+  // via the outer loop to update bufferIdx. This is needed when the loop count
+  // for the inner loop varies with each outer loop iteration.
+  // Assume we handle outer ForOp first, then inner ForOp in program order.
+  SmallVector<scf::ForOp> orderedForOps;
+  SmallVector<Operation *> innerForOps;
+  for (auto &op : taskTopOps) {
+    op->walk<WalkOrder::PreOrder>([&](Operation *subOp) {
+      if (auto forOp = dyn_cast<scf::ForOp>(subOp)) {
+        if (isInnermostLoop(forOp))
+          innerForOps.push_back(forOp.getOperation());
+        orderedForOps.push_back(forOp);
+      }
+    });
+  }
+  LDBG("reuseBuffers number of inner loops: " << innerForOps.size());
+  if (innerForOps.empty())
+    return false;
+  if (innerForOps.size() == 1) {
+    // Persistent with a single inner loop.
+    scf::ForOp parentForOp = innerForOps[0]->getParentOfType<scf::ForOp>();
+    if (parentForOp) {
+      loopWithBufferReuse = innerForOps;
+      LDBG("-- loopWithBufferReuse with size 1");
+    }
+    return false;
+  }
+  // Check to see if the innermost loops are under one parent. And there are no
+  // other loops. Make sure the inner loops have same number of channels.
+  bool firstLoop = true;
+  Operation *outerLoop = nullptr;
+  unsigned numChannels = 0, numBuffers = 0;
+  SmallVector<Channel *> channelsInLoopOne;
+  for (auto &innerLoop : innerForOps) {
+    scf::ForOp parentForOp = innerLoop->getParentOfType<scf::ForOp>();
+    SmallVector<Channel *> channelsInLoop;
+    getNumChannelsInLoop(cast<scf::ForOp>(innerLoop), channels, channelsInLoop);
+    if (firstLoop) {
+      outerLoop = parentForOp.getOperation();
+      numChannels = channelsInLoop.size();
+      channelsInLoopOne = channelsInLoop;
+      numBuffers = channelsInLoop[0]->numBuffers;
+      if (numChannels == 0)
+        return false;
+    } else {
+      if (outerLoop != parentForOp.getOperation())
+        return false;
+      if (numChannels != channelsInLoop.size())
+        return false;
+      if (numBuffers != channelsInLoop[0]->numBuffers)
+        return false;
+      unsigned idx = 0;
+      for (auto *ch : channelsInLoop) {
+        // TODO: sort the channels in the loop according to buffer size.
+        mapToRepresenting[ch] = channelsInLoopOne[idx++];
+      }
+    }
+    firstLoop = false;
+  }
+  LLVM_DEBUG({
+    LDBG("reuseBuffers: ");
+    for (auto &kv : mapToRepresenting) {
+      llvm::dbgs() << "---- from ";
+      kv.first->getDstOp()->dump();
+      llvm::dbgs() << "---- to ";
+      kv.second->getDstOp()->dump();
+    }
+  });
+  loopWithBufferReuse = innerForOps;
+  return true;
+}
+
+// Go through a list of operations under one scope.
+// prevAccum can be null if there is an outer loop for the reuse loops.
+Value updateAccumLoopCount(SmallVector<Operation *> &opList,
+                           unsigned numBuffers,
+                           SmallVector<Operation *> &taskTopOps,
+                           Operation *commonOuterLoop,
+                           SmallVector<Operation *> &loopWithBufferReuse,
+                           Value prevAccum) {
+  for (Operation *op : opList) {
+    if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+      auto newForOp =
+          createNewLoopWrapper(forOp, numBuffers, taskTopOps, commonOuterLoop,
+                               loopWithBufferReuse, prevAccum);
+      // Update prevAccum to be after the loop.
+      // If the loop is in loopWithBufferReuse, generate prevAccum + numSteps.
+      bool hasReuse = false;
+      for (auto tLoop : loopWithBufferReuse)
+        if (newForOp.getOperation() == tLoop) {
+          hasReuse = true;
+          break;
+        }
+      if (hasReuse) {
+        // Update accumLoopCount = prevAccum + numSteps.
+        OpBuilderWithAsyncTaskIds builder(newForOp.getContext());
+        builder.setAsynTaskIdsFromArray(getNestedAsyncTaskIds(newForOp));
+        builder.setInsertionPointAfter(newForOp);
+
+        Value numSteps = getNumSteps(newForOp, builder);
+        prevAccum = builder.createWithAsyncTaskIds<arith::AddIOp>(
+            newForOp.getLoc(), prevAccum, numSteps);
+      }
+      // If the loop is the outer loop for a reuse loop, we are done.
+      // At this point, op is no longer valid.
+    } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+      if (needAccumulatedLoopCnt(ifOp, loopWithBufferReuse)) {
+        auto newIfOp =
+            rewriteIfOp(ifOp, numBuffers, taskTopOps, commonOuterLoop,
+                        loopWithBufferReuse, prevAccum);
+        // update prevAccum to be result of the new IfOp.
+        assert(newIfOp.getNumResults() >= 1);
+        auto numRes = newIfOp.getNumResults();
+        LDBG("update prevAccum with result from IfOp");
+        prevAccum = newIfOp.getResult(numRes - 1); // last result
+      } else {
+        // Still need to process ForOps in pre-order.
+        ifOp->walk<WalkOrder::PreOrder>([&](Operation *subOp) {
+          if (auto forOp = dyn_cast<scf::ForOp>(subOp)) {
+            // Handle forOp.
+            createNewLoopWrapper(forOp, numBuffers, taskTopOps, commonOuterLoop,
+                                 loopWithBufferReuse, prevAccum);
+          }
+        });
+      }
+    }
+  }
+  return prevAccum;
+}
+
+scf::ForOp createNewLoopWrapper(scf::ForOp origForOp, unsigned numBuffers,
+                                SmallVector<Operation *> &taskTopOps,
+                                Operation *commonOuterLoop,
+                                SmallVector<Operation *> &loopWithBufferReuse,
+                                Value prevAccum) {
+  LLVM_DEBUG({
+    LDBG("call createNewLoop on");
+    origForOp.dump();
+  });
+
+  scf::ForOp parentForOp = origForOp->getParentOfType<scf::ForOp>();
+  scf::ForOp newForOp;
+  // for(...) -> for(..., phase, bufferIdx)
+  unsigned loopNumBuffers = getNumBuffersOrDefault(origForOp, numBuffers);
+
+  bool isOuterOfReuse =
+      commonOuterLoop && commonOuterLoop == origForOp.getOperation();
+  bool hasReuse = false;
+  for (auto tLoop : loopWithBufferReuse)
+    if (origForOp.getOperation() == tLoop) {
+      hasReuse = true;
+      break;
+    }
+  // Set accumulatedLoopCount when this is a loop in loopWithBufferReuse. If
+  // this loop has an outer loop, an extra arg for accumLoopCount should have
+  // been added to the outer loop.
+  Value accumulatedLoopCount = prevAccum; // Value();
+  newForOp = createNewLoop(origForOp, loopNumBuffers, parentForOp,
+                           accumulatedLoopCount, loopWithBufferReuse, hasReuse,
+                           isOuterOfReuse);
+  LLVM_DEBUG({
+    LDBG("after createNewLoop ");
+    newForOp.dump();
+  });
+  // origForOp is erased in createNewLoop. If origForOp is a top operation
+  // (i.e in taskTopOps), make sure taskTopOps is updated with the newForOp.
+  auto asyncTaskLoopForItr =
+      std::find(taskTopOps.begin(), taskTopOps.end(), origForOp.getOperation());
+  if (asyncTaskLoopForItr != taskTopOps.end()) {
+    // Update taskTopOps.
+    *asyncTaskLoopForItr = newForOp.getOperation();
+  }
+
+  // origForOp is erased in createNewLoop. If origForOp is in
+  // loopWithBufferReuse, replace.
+  auto tmpIter = std::find(loopWithBufferReuse.begin(),
+                           loopWithBufferReuse.end(), origForOp.getOperation());
+  if (tmpIter != loopWithBufferReuse.end()) {
+    *tmpIter = newForOp.getOperation();
+  }
+
+  // Handle ops in loop body, only IfOps and ForOps.
+  SmallVector<Operation *> opList;
+  for (Operation &op : newForOp.getBody()->without_terminator()) {
+    if (auto tOp = dyn_cast<scf::ForOp>(&op))
+      opList.push_back(&op);
+    if (auto tOp = dyn_cast<scf::IfOp>(&op))
+      opList.push_back(&op);
+  }
+  Value endAccum = updateAccumLoopCount(
+      opList, numBuffers, taskTopOps, commonOuterLoop, loopWithBufferReuse,
+      isOuterOfReuse ? getAccumLoopCountArg(newForOp) : prevAccum);
+
+  // Update yieldOp.
+  if (isOuterOfReuse) {
+    Value arg = getAccumLoopCountArg(newForOp);
+    Operation *yieldOp = newForOp.getBody()->getTerminator();
+    yieldOp->replaceUsesOfWith(arg, endAccum);
+  }
+  return newForOp;
+}
+
+// This function takes a list of channels, a mapping from a channel
+// to its representing channel if the key shares smem space with the
+// representing channel, and a list of loops that are sharing smem spaces. Note
+// that every loop in loopWithBufferReuse either has the same outer loop or has
+// no outer loop.
+// For ForOps in taskTopOps, create new ForOp for each by adding phase,
+// bufferIdx to the arguments. In the case of sharing smem, we need to traverse
+// and update IfOps when necessary. We call updateAccumLoopCount on the list
+// of top level Ops that are ForOps or IfOps enclosing a loop with buffer reuse.
+// updateAccumLoopCount calls createNewLoopWrapper on ForOps, and rewriteIfOp on
+// IfOps. Both will call updateAccumLoopCount on the list of Ops in the ForOp
+// body or the thenBlock, elseBlock for IfOp.
+Value appendBufferIdxArgs(
+    SmallVector<Operation *> &taskTopOps, unsigned numBuffers,
+    const SmallVector<Channel *> &channels,
+    const DenseMap<Channel *, Channel *> &mapToRepresenting,
+    SmallVector<Operation *> &loopWithBufferReuse) {
+  // In order to handle sharing smem for a list of loops, we have two cases,
+  // one is the top-level op containing all loops in loopWithBufferReuse is
+  // a ForOp.
+  bool genAccumLoopCount = !loopWithBufferReuse.empty();
+  Operation *commonOuterLoop = nullptr;
+  if (genAccumLoopCount) {
+    auto oneFor = loopWithBufferReuse[0];
+    scf::ForOp parentForOp = oneFor->getParentOfType<scf::ForOp>();
+    if (parentForOp)
+      commonOuterLoop = parentForOp.getOperation();
+  }
+
+  // When there is no outer loop, we need to create a place holder for
+  // tmpAccumLoopCount. Every forOp in loopWithBufferReuse either has the same
+  // outer loop or has no outer loop.
+  Value tmpAccumLoopCount;
+  if (loopWithBufferReuse.size() > 1 && !commonOuterLoop) {
+    auto oneFor = loopWithBufferReuse[0];
+    // Initialize tmpAccumLoopCount to be 0.
+    OpBuilderWithAsyncTaskIds builder(taskTopOps[0]->getContext());
+    builder.setAsynTaskIdsFromArray(getNestedAsyncTaskIds(oneFor));
+    builder.setInsertionPoint(taskTopOps[0]);
+    tmpAccumLoopCount = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
+        oneFor->getLoc(), 0, 64);
+  }
+
+  SmallVector<Operation *> opList;
+  for (auto &op : taskTopOps) {
+    if (auto origIfOp = dyn_cast<scf::IfOp>(op)) {
+      opList.push_back(op);
+    }
+    if (auto origForOp = dyn_cast<scf::ForOp>(op))
+      opList.push_back(op);
+  }
+  updateAccumLoopCount(opList, numBuffers, taskTopOps, commonOuterLoop,
+                       loopWithBufferReuse, tmpAccumLoopCount);
+
+  return tmpAccumLoopCount;
+}
+
+// Create an allocation to hold the mbarriers.
+static Value createBarrierAlloc(triton::FuncOp funcOp, unsigned distance) {
+  OpBuilder builder(funcOp);
+  builder.setInsertionPointToStart(&(funcOp.getBody().front()));
+  Attribute sharedMemorySpace =
+      triton::gpu::SharedMemorySpaceAttr::get(funcOp.getContext());
+  Location loc = funcOp.getLoc();
+  auto context = funcOp.getContext();
+  auto barrierCTALayout =
+      ttg::CTALayoutAttr::get(context, /*CTAsPerCGA=*/{1},
+                              /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
+  auto barrierEncoding =
+      ttg::SharedEncodingAttr::get(context, 1, 1, 1, {0}, barrierCTALayout);
+  Type barrierMemDescType = tt::MemDescType::get(
+      {distance}, builder.getI64Type(), barrierEncoding, sharedMemorySpace,
+      /*mutableMemory=*/true);
+  Type singleBarrierMemDescType =
+      tt::MemDescType::get({1}, builder.getI64Type(), barrierEncoding,
+                           sharedMemorySpace, /*mutableMemory=*/true);
+  Value barrierAlloc = builder.create<mlir::triton::gpu::LocalAllocOp>(
+      loc, barrierMemDescType, Value());
+  for (unsigned i = 0; i < distance; i++) {
+    Value idx = builder.create<arith::ConstantIntOp>(loc, i, 32);
+    Value barrierView = builder.create<ttg::MemDescSubviewOp>(
+        loc, singleBarrierMemDescType, barrierAlloc, idx);
+    builder.create<ttng::InitBarrierOp>(funcOp->getLoc(), barrierView, 1);
+  }
+  return barrierAlloc;
+}
+
+// channelsGroupedByConsumers: channels are grouped together.
+// Go through each group, check the first channel in the group, create a token
+// for each consumer taskId. Return a map that maps each channel + consumer
+// taskId to a token. Also update barrierAllocMap that maps each channel +
+// consumer taskId to a BarrierAlloc.
+DenseMap<Channel *, DenseMap<int, Value>>
+createToken(const DenseMap<Channel *, SmallVector<Channel *>>
+                &channelsGroupedByConsumers,
+            const SmallVector<Channel *> &orderedChannels,
+            triton::FuncOp funcOp, int numConsumerGroups,
+            DenseMap<Channel *, SmallVector<Channel *>> &channelReuse,
+            DenseMap<Channel *, DenseMap<int, Value>> &barrierAllocMap) {
+  DenseMap<Channel *, DenseMap<int, Value>> ret;
+  OpBuilder builder(funcOp);
+  builder.setInsertionPointToStart(&(funcOp.getBody().front()));
+  for (auto *key : orderedChannels) {
+    auto it = channelsGroupedByConsumers.find(key);
+    Channel *channel = it->second.front();
+    if (!channelReuse.count(channel))
+      continue;
+    for (auto consumerAsyncTaskId : channel->relation.second) {
+      Value v;
+      if (it->second.front()->getSrcOp()->getParentOfType<scf::ForOp>()) {
+        v = builder.create<ttng::CreateTokenOp>(funcOp.getLoc(),
+                                                channel->numBuffers);
+      } else {
+        v = builder.create<ttng::CreateTokenOp>(funcOp.getLoc(), 1);
+      }
+      // Channels in the group share the same set of tokens.
+      for (auto &c : it->second) {
+        ret[c][consumerAsyncTaskId] = v;
+      }
+      for (auto *reuse : channelReuse[channel]) {
+        ret[reuse][consumerAsyncTaskId] = v;
+      }
+
+      auto producerOp = it->second.front()->getSrcOp();
+      if (isa<tt::ExperimentalDescriptorLoadOp>(producerOp)) {
+        Value bAlloc = createBarrierAlloc(funcOp, channel->numBuffers);
+        // Channels in the group share the same set of tokens.
+        for (auto &c : it->second) {
+          ret[c][consumerAsyncTaskId] = v;
+          barrierAllocMap[c][consumerAsyncTaskId] = bAlloc;
+        }
+        for (auto *reuse : channelReuse[channel]) {
+          ret[reuse][consumerAsyncTaskId] = v;
+          barrierAllocMap[reuse][consumerAsyncTaskId] = bAlloc;
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+// Create a buffer array for each producer op, if the producer is in a ForOp,
+// the buffer array will contain numBuffers.
+DenseMap<Channel *, Value> createBuffer(
+    DenseMap<Channel *, SmallVector<Channel *>> &channelsGroupedByProducers,
+    triton::FuncOp funcOp, int numConsumerGroups,
+    DenseMap<Channel *, Channel *> &mapToRepresenting,
+    DenseMap<Channel *, SmallVector<Channel *>> &channelReuse) {
+
+  DenseMap<Channel *, Value> bufferMap;
+  MLIRContext *context = funcOp.getContext();
+  OpBuilder builder(funcOp);
+  builder.setInsertionPointToStart(&(funcOp.getBody().front()));
+  DenseSet<Channel *> visited;
+  for (auto &item : channelsGroupedByProducers) {
+    auto &channels = item.second;
+    for (auto c : channels) {
+      assert(!visited.count(c));
+      visited.insert(c);
+      if (mapToRepresenting.count(c)) {
+        channelReuse[mapToRepresenting[c]].push_back(c);
+        LDBG("update channelReuse key " << mapToRepresenting[c] << " " << c);
+      } else {
+        channelReuse[c].push_back(c);
+        LDBG("update channelReuse key " << c << " " << c);
+      }
+    }
+  }
+  for (auto &item : channelsGroupedByProducers) {
+    auto &channels = item.second;
+    auto srcValue = item.first->getSrcOperand();
+    auto srcOp = item.first->getSrcOp();
+    unsigned numBuffers = channels.front()->numBuffers;
+
+    if (auto tensorType = dyn_cast<RankedTensorType>(srcValue.getType())) {
+      // Get basic information from tensorType
+      auto order = ttg::getOrder(tensorType.getEncoding());
+      auto CTALayout = ttg::getCTALayout(tensorType.getEncoding());
+      auto elemType = tensorType.getElementType();
+
+      // Get shape, layout and type of a slice
+      auto sliceShape = tensorType.getShape();
+      auto sharedLayout = ttg::SharedEncodingAttr::get(
+          context, sliceShape, order, CTALayout, elemType);
+      auto sliceType =
+          RankedTensorType::get(sliceShape, elemType, sharedLayout);
+
+      // Get shape, layout and type of the complete buffer
+      SmallVector<int64_t> bufferShape(sliceShape.begin(), sliceShape.end());
+      if (srcOp->getParentOfType<scf::ForOp>())
+        bufferShape.insert(bufferShape.begin(), numBuffers);
+      else
+        bufferShape.insert(bufferShape.begin(), 1);
+      Attribute sharedMemorySpace =
+          triton::gpu::SharedMemorySpaceAttr::get(context);
+      auto bufferType =
+          RankedTensorType::get(bufferShape, elemType, sharedLayout);
+      Type memdescType =
+          tt::MemDescType::get(bufferShape, elemType, sharedLayout,
+                               sharedMemorySpace, /*mutableMemory*/ true);
+      Value buffer =
+          builder.create<ttg::LocalAllocOp>(funcOp.getLoc(), memdescType);
+
+      // Channels in the group share the same buffer.
+      for (auto c : channels)
+        bufferMap[c] = buffer;
+    } else {
+      llvm_unreachable("Unexpected result type");
+    }
+  }
+  unsigned groupId = 0;
+  for (auto &kv : channelReuse) {
+    if (kv.second.size() <= 1)
+      continue;
+    bufferMap[kv.first].getDefiningOp()->setAttr(
+        "allocation.shareGroup",
+        IntegerAttr::get(IntegerType::get(context, 32), groupId));
+    for (auto *c : kv.second)
+      bufferMap[c].getDefiningOp()->setAttr(
+          "allocation.shareGroup",
+          IntegerAttr::get(IntegerType::get(context, 32), groupId));
+    ++groupId;
+  }
+  return bufferMap;
+}
+
+static Operation *createAsyncCopy(const DenseMap<Channel *, Value> &bufferMap,
+                                  Channel *c, Operation *op,
+                                  SmallVector<AsyncTaskId> &asyncTasksPC,
+                                  Value bufferIdx, Value bufferIdxExtract) {
+  auto loadOp = cast<triton::LoadOp>(op);
+  auto buffer = bufferMap.find(c)->second;
+  MLIRContext *context = loadOp->getContext();
+  OpBuilderWithAsyncTaskIds builder(context);
+  builder.setInsertionPoint(loadOp->getParentOp());
+  builder.setAsynTaskIdsFromArray(asyncTasksPC);
+
+  builder.setInsertionPoint(loadOp);
+  Value loadResult = loadOp.getResult();
+  auto tensorType = dyn_cast<RankedTensorType>(loadResult.getType());
+  if (!tensorType)
+    return nullptr;
+  // Get basic information from tensorType
+  auto order = ttg::getOrder(tensorType.getEncoding());
+  auto CTALayout = ttg::getCTALayout(tensorType.getEncoding());
+  auto elemType = tensorType.getElementType();
+
+  // Get shape, layout and type of a slice
+  auto sliceShape = tensorType.getShape();
+  auto sharedLayout = ttg::SharedEncodingAttr::get(context, sliceShape, order,
+                                                   CTALayout, elemType);
+  auto sliceType = RankedTensorType::get(sliceShape, elemType, sharedLayout);
+
+  Attribute sharedMemorySpace =
+      triton::gpu::SharedMemorySpaceAttr::get(context);
+  tt::MemDescType subviewTy =
+      tt::MemDescType::get(sliceType.getShape(), sliceType.getElementType(),
+                           sliceType.getEncoding(), sharedMemorySpace,
+                           /*mutableMemory=*/true);
+  Value zero = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
+      loadOp.getLoc(), 0, 32);
+  SmallVector<Value> copyOffsets(sliceType.getRank() + 1, zero);
+  copyOffsets[0] = bufferIdx;
+  builder.setAsyncTaskIdsFromOp(loadOp);
+  builder.setInsertionPointAfter(loadOp);
+  auto view = builder.createWithAsyncTaskIds<ttg::MemDescSubviewOp>(
+      loadOp.getLoc(), subviewTy, buffer, copyOffsets);
+  // Create cp.async
+  Operation *copy =
+      builder.createWithAsyncTaskIds<ttg::AsyncCopyGlobalToLocalOp>(
+          loadOp.getLoc(), loadOp.getPtr(), view, loadOp.getMask(),
+          loadOp.getOther(), loadOp.getCache(), loadOp.getEvict(),
+          loadOp.getIsVolatile());
+
+  // Extract part.
+  builder.setAsyncTaskIdsFromValueUsers(loadResult);
+  builder.setInsertionPoint(c->getDstOp());
+  SmallVector<Value> loadOffsets(sliceType.getRank() + 1, zero);
+  loadOffsets[0] = bufferIdxExtract;
+  auto viewLoad = builder.createWithAsyncTaskIds<ttg::MemDescSubviewOp>(
+      loadOp.getLoc(), subviewTy, buffer, loadOffsets);
+  auto sharedLoad = builder.createWithAsyncTaskIds<ttg::LocalLoadOp>(
+      loadOp.getLoc(), loadOp.getType(), viewLoad /*,wait->getResult(0)*/);
+  // Replace all uses of loadResult
+  loadResult.replaceAllUsesWith(sharedLoad.getResult());
+  loadOp.erase();
+  return copy;
+}
+
+// Create a local copy for a channel that is populated by the producer and
+// accessed by the consumer.
+static void createLocalCopy(const DenseMap<Channel *, Value> &bufferMap,
+                            Channel *channel, Value srcBufferIdx,
+                            Value dstBufferIdx) {
+  Operation *srcOp = channel->getSrcOp();
+  Operation *dstOp = channel->getDstOp();
+  MLIRContext *context = srcOp->getContext();
+  auto buffer = bufferMap.find(channel)->second;
+
+  Value srcValue = channel->getSrcOperand();
+  auto tensorType = dyn_cast<RankedTensorType>(srcValue.getType());
+  if (!tensorType)
+    return;
+  // Get basic information from tensorType
+  auto order = ttg::getOrder(tensorType.getEncoding());
+  auto CTALayout = ttg::getCTALayout(tensorType.getEncoding());
+  auto elemType = tensorType.getElementType();
+
+  // Get shape, layout and type of a slice
+  auto sliceShape = tensorType.getShape();
+  auto sharedLayout = ttg::SharedEncodingAttr::get(context, sliceShape, order,
+                                                   CTALayout, elemType);
+  auto sliceType = RankedTensorType::get(sliceShape, elemType, sharedLayout);
+
+  Attribute sharedMemorySpace =
+      triton::gpu::SharedMemorySpaceAttr::get(context);
+  tt::MemDescType subviewTy =
+      tt::MemDescType::get(sliceType.getShape(), sliceType.getElementType(),
+                           sliceType.getEncoding(), sharedMemorySpace,
+                           /*mutableMemory=*/true);
+
+  // Consumer part.
+  OpBuilderWithAsyncTaskIds builder(dstOp);
+  builder.setAsyncTaskIdsFromOp(dstOp);
+  builder.setInsertionPoint(dstOp);
+  Value zero = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
+      dstOp->getLoc(), 0, 32);
+  SmallVector<Value> loadOffsets(sliceType.getRank() + 1, zero);
+  loadOffsets[0] = dstBufferIdx;
+  auto dstView = builder.createWithAsyncTaskIds<ttg::MemDescSubviewOp>(
+      dstOp->getLoc(), subviewTy, buffer, loadOffsets);
+  auto sharedLoad = builder.createWithAsyncTaskIds<ttg::LocalLoadOp>(
+      dstOp->getLoc(), srcValue.getType(), dstView);
+  srcValue.replaceAllUsesWith(sharedLoad.getResult());
+
+  // Producer part. Create local_store for new producers.
+  builder.setAsynTaskIdsFromArray(channel->relation.first);
+  builder.setInsertionPoint(srcOp->getParentOp());
+  zero = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(srcOp->getLoc(),
+                                                              0, 32);
+  SmallVector<Value> storeOffsets(sliceType.getRank() + 1, zero);
+  storeOffsets[0] = srcBufferIdx;
+  builder.setInsertionPointAfter(srcOp);
+  auto srcView = builder.createWithAsyncTaskIds<ttg::MemDescSubviewOp>(
+      srcOp->getLoc(), subviewTy, buffer, storeOffsets);
+  // Create local_alloc
+  Operation *copy = builder.createWithAsyncTaskIds<ttg::LocalStoreOp>(
+      srcOp->getLoc(), srcValue, srcView);
+}
+
+static int getTMALoadSize(tt::ExperimentalDescriptorLoadOp &tmaLoad) {
+  auto tensorTy = cast<RankedTensorType>(tmaLoad->getResult(0).getType());
+  int loadSize = product(tensorTy.getShape());
+  return loadSize * tensorTy.getElementType().getIntOrFloatBitWidth() / 8;
+}
+
+Value getBarrierForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
+                                 Value barrierAlloc, Value bufferIdx) {
+  auto context = barrierAlloc.getContext();
+  Attribute sharedMemorySpace =
+      triton::gpu::SharedMemorySpaceAttr::get(context);
+  tt::MemDescType barrierTy = tt::MemDescType::get(
+      {1}, builder.getI64Type(),
+      cast<tt::MemDescType>(barrierAlloc.getType()).getEncoding(),
+      sharedMemorySpace,
+      /*mutableMemory=*/true);
+
+  // Create barrierForTMA from barrierAlloc.
+  return builder.createWithAsyncTaskIds<ttg::MemDescSubviewOp>(
+      barrierAlloc.getLoc(), barrierTy, barrierAlloc,
+      ArrayRef<Value>({bufferIdx}));
+}
+
+Value getBufferForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
+                                Type loadType, Value buffer, Value bufferIdx,
+                                bool mutableMem) {
+  auto context = buffer.getContext();
+  auto tensorType = dyn_cast<RankedTensorType>(loadType);
+  assert(tensorType);
+
+  auto order = ttg::getOrder(tensorType.getEncoding());
+  auto CTALayout = ttg::getCTALayout(tensorType.getEncoding());
+  auto elemType = tensorType.getElementType();
+
+  // Get shape, layout and type of a slice
+  auto sliceShape = tensorType.getShape();
+  auto sharedLayout = ttg::SharedEncodingAttr::get(context, sliceShape, order,
+                                                   CTALayout, elemType);
+  auto sliceType = RankedTensorType::get(sliceShape, elemType, sharedLayout);
+
+  Attribute sharedMemorySpace =
+      triton::gpu::SharedMemorySpaceAttr::get(context);
+  tt::MemDescType subviewTy =
+      tt::MemDescType::get(sliceType.getShape(), sliceType.getElementType(),
+                           sliceType.getEncoding(), sharedMemorySpace,
+                           /*mutableMemOry=*/mutableMem);
+
+  Value zero = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
+      buffer.getLoc(), 0, 32);
+  SmallVector<Value> copyOffsets(sliceType.getRank() + 1, zero);
+  copyOffsets[0] = bufferIdx;
+
+  return builder.createWithAsyncTaskIds<ttg::MemDescSubviewOp>(
+      buffer.getLoc(), subviewTy, buffer, copyOffsets);
+}
+
+Operation *
+optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
+                 SmallVector<tt::ExperimentalDescriptorLoadOp> &tmaLoads,
+                 SmallVector<Value> &buffers, Value barrierAlloc,
+                 Value bufferIdx, Value bufferIdxExtract, Value phase,
+                 Operation *headProducer, Operation *headConsumer) {
+  auto loc = barrierAlloc.getLoc();
+
+  // Compute the total size of the loads.
+  int sizeInBytes = 0;
+  for (auto &tmaLoad : tmaLoads) {
+    sizeInBytes += getTMALoadSize(tmaLoad);
+  }
+
+  // For each of the following ops, we will operate on a subview of each value
+  // according to the pipeline stage.
+
+  // Create a barrier_expect with the appropriate size and insert it before the
+  // first load.
+  builder.setInsertionPoint(headProducer);
+  builder.setAsyncTaskIdsFromOp(headProducer);
+  auto prodBarrier =
+      getBarrierForPipelineStage(builder, barrierAlloc, bufferIdx);
+  auto pred = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 1);
+  auto expect = builder.createWithAsyncTaskIds<ttng::BarrierExpectOp>(
+      loc, prodBarrier, sizeInBytes, pred);
+
+  // Convert all the producers to async_tma_copy_global_to_local
+  Operation *copy = nullptr;
+  for (auto [tmaLoad, buffer] : zip(tmaLoads, buffers)) {
+    auto pipelineBuffer = getBufferForPipelineStage(builder, tmaLoad.getType(),
+                                                    buffer, bufferIdx, true);
+    copy = builder.createWithAsyncTaskIds<ttng::AsyncTMACopyGlobalToLocalOp>(
+        loc, tmaLoad.getDescPtr(), tmaLoad.getIndices(), prodBarrier,
+        pipelineBuffer, pred);
+  }
+
+  // Create a wait_barrier before the first consumer.
+  builder.setInsertionPoint(headConsumer);
+  builder.setAsyncTaskIdsFromOp(headConsumer);
+  auto consBarrier =
+      getBarrierForPipelineStage(builder, barrierAlloc, bufferIdxExtract);
+  phase = builder.createWithAsyncTaskIds<arith::ExtSIOp>(
+      loc, builder.getI32Type(), phase);
+  auto wait = builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
+      loc, consBarrier, phase);
+
+  // Convert all the consumers to local_load
+  for (auto [tmaLoad, buffer] : zip(tmaLoads, buffers)) {
+    auto pipelineBuffer = getBufferForPipelineStage(
+        builder, tmaLoad.getType(), buffer, bufferIdxExtract, false);
+    auto sharedLoad = builder.createWithAsyncTaskIds<ttg::LocalLoadOp>(
+        loc, tmaLoad.getType(), pipelineBuffer);
+
+    Value loadResult = tmaLoad.getResult();
+    tmaLoad.getResult().replaceAllUsesWith(sharedLoad.getResult());
+    tmaLoad.erase();
+  }
+  return copy;
+}
+
+// Lower producers for channels. Here channels are grouped in
+// "channelsGroupedByConsumers". tokenMap tracks the set of tokens for each
+// channel.
+void insertAsyncComm(
+    triton::FuncOp funcOp,
+    const DenseMap<Channel *, SmallVector<Channel *>>
+        &channelsGroupedByConsumers,
+    const DenseMap<Channel *, DenseMap<int, Value>> &tokenMap,
+    const DenseMap<Channel *, DenseMap<int, Value>> &barrierAllocMap,
+    const DenseMap<Channel *, Value> &bufferMap, int numConsumerGroups) {
+
+  // Find the operation that is along producer's parent chain, and its parent
+  // is the same op as producer's parent. Here p is producer, and c is consumer.
+  auto getSameLevelOp = [](Operation *p, Operation *c) -> Operation * {
+    while (!isa<triton::FuncOp>(c)) {
+      if (c->getParentOp() == p->getParentOp()) {
+        return c;
+      }
+      c = c->getParentOp();
+    }
+    llvm_unreachable("Failed to find consumer's same level Op with producer");
+  };
+
+  auto consumerReleaseHeutistic = [&](Operation *p, Operation *c,
+                                      int consumerAsyncTaskId) -> Operation * {
+    if (c->getBlock() != p->getBlock())
+      return getSameLevelOp(p, c);
+
+    // Find a common place for all users of the consumer, which would be the
+    // common post dominator.
+    mlir::PostDominanceInfo dom(funcOp);
+    std::unordered_set<Operation *> mutuallyNonDominatingUsers;
+    SmallVector<Operation *> users;
+    for (auto user : c->getUsers()) {
+      if (isa<TransOp>(user)) {
+        // TransOp is not a real consumer. It caculates the shared memory
+        // address for the real consumer. Continue to find its transitive users
+        // recursively.
+        DenseSet<Operation *> visited;
+        SmallVector<Operation *> transUsers;
+        transUsers.push_back(user);
+        while (!transUsers.empty()) {
+          auto transUser = transUsers.pop_back_val();
+          visited.insert(transUser);
+          if (isa<TransOp>(transUser)) {
+            for (auto transitiveUser : transUser->getUsers()) {
+              if (!visited.count(transitiveUser))
+                transUsers.push_back(transitiveUser);
+            }
+          } else {
+            users.push_back(transUser);
+          }
+        }
+      } else {
+        users.push_back(user);
+      }
+    }
+
+    for (auto user : users) {
+      auto it = mutuallyNonDominatingUsers.begin();
+      while (it != mutuallyNonDominatingUsers.end()) {
+        if (dom.properlyPostDominates(user, *it)) {
+          it = mutuallyNonDominatingUsers.erase(it);
+        } else if (dom.properlyPostDominates(*it, user)) {
+          break;
+        } else {
+          ++it;
+        }
+      }
+      if (it == mutuallyNonDominatingUsers.end())
+        mutuallyNonDominatingUsers.insert(user);
+    }
+
+    if (mutuallyNonDominatingUsers.size() == 1) {
+      // Find the common parent of this user and c
+      auto user = *mutuallyNonDominatingUsers.begin();
+      while (user && user->getParentOp() != c->getParentOp())
+        user = user->getParentOp();
+      assert(user && "Failed to find common parent of this user and c");
+      return user;
+    }
+
+    for (auto &op : reverse(c->getBlock()->getOperations())) {
+      auto asyncTasks = getAsyncTaskIds(&op);
+      if (asyncTasks.size() == 1 && asyncTasks[0] == consumerAsyncTaskId)
+        return &op;
+    }
+
+    return nullptr;
+  };
+
+  // Go through each channel group.
+  for (auto kv : channelsGroupedByConsumers) {
+    // Find head and tail ops.
+    DenseSet<Operation *> producerOps;
+    DenseSet<Operation *> consumerOps;
+    for (auto &c : kv.second) {
+      producerOps.insert(c->getSrcOp());
+      consumerOps.insert(c->getDstOp());
+    }
+
+    // Find head producer
+    auto producerBlock = kv.second.front()->getSrcOp()->getBlock();
+    Operation *headProducer = nullptr;
+    for (auto &op : producerBlock->getOperations()) {
+      if (producerOps.count(&op)) {
+        headProducer = &op;
+        break;
+      }
+    }
+    // Find tail producer
+    Operation *tailProducer = nullptr;
+    for (auto &op : reverse(producerBlock->getOperations())) {
+      if (producerOps.count(&op)) {
+        tailProducer = &op;
+        break;
+      }
+    }
+
+    // Find head consumer and tail consumer
+    auto consumerBlock = kv.second.front()->getDstOp()->getBlock();
+    Operation *headConsumer = nullptr;
+    for (auto &op : consumerBlock->getOperations()) {
+      if (consumerOps.count(&op)) {
+        headConsumer = &op;
+        break;
+      }
+    }
+    Operation *tailConsumer = nullptr;
+    for (auto &op : reverse(consumerBlock->getOperations())) {
+      if (consumerOps.count(&op)) {
+        tailConsumer = &op;
+        break;
+      }
+    }
+
+    // We have one set of tokens for each channel group.
+    auto tokens = tokenMap.find(kv.second.front())->second;
+    auto masterChannel = kv.getFirst();
+
+    SmallVector<AsyncTaskId> asyncTaskP;
+    asyncTaskP.push_back(masterChannel->relation.first);
+    SmallVector<AsyncTaskId> &asyncTaskC = masterChannel->relation.second;
+    SmallVector<AsyncTaskId> asyncTasksPC = asyncTaskP;
+    asyncTasksPC.insert(asyncTasksPC.end(), asyncTaskC.begin(),
+                        asyncTaskC.end());
+
+    OpBuilderWithAsyncTaskIds builder(headProducer->getContext());
+    if (auto funcOp = dyn_cast<triton::FuncOp>(headProducer->getParentOp())) {
+      builder.setInsertionPointToStart(&(funcOp.getBody().front()));
+    } else {
+      builder.setInsertionPoint(headProducer->getParentOp());
+    }
+    builder.setAsynTaskIdsFromArray(asyncTasksPC);
+
+    Value bufferIdx;
+    Value phase = Value();
+    if (auto forOp = headProducer->getParentOfType<scf::ForOp>()) {
+      // We already added phase, bufferIdx to the ForOp.
+      auto tSize = forOp.getBody()->getArguments().size();
+      assert(tSize >= 2);
+      bufferIdx = forOp.getBody()->getArguments().back();
+      phase = forOp.getBody()->getArgument(tSize - 2); // next to last argument
+    } else {
+      // Producer is not in a ForOp, create phase and bufferIdx here.
+      bufferIdx = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
+          headProducer->getLoc(), 0, 32);
+      phase = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
+          headProducer->getLoc(), 0, 1);
+    }
+
+    builder.setAsynTaskIdsFromArray(masterChannel->relation.first);
+    for (auto token : tokens) {
+      // Insert ProducerAcquireOp before the producer.
+      builder.setInsertionPoint(headProducer);
+      builder.createWithAsyncTaskIds<ttng::ProducerAcquireOp>(
+          headProducer->getLoc(), token.second, bufferIdx, phase);
+
+      // Insert ProducerCommitOp if producer is LoadOp. For TMA, TMA lowering
+      // will handle the ProducerCommit.
+      if (!isa<tt::ExperimentalDescriptorLoadOp>(headProducer)) {
+        builder.setInsertionPointAfter(tailProducer);
+        builder.createWithAsyncTaskIds<ttng::ProducerCommitOp>(
+            tailProducer->getLoc(), token.second, bufferIdx);
+      }
+    }
+
+    for (auto token : tokens) {
+      builder.setAsynTaskIdsFromArray(token.first);
+      // Insert ConsumerWaitOp
+      if (!isa<tt::ExperimentalDescriptorLoadOp>(headProducer)) {
+        auto consumerWaitPoint = getSameLevelOp(headProducer, headConsumer);
+        builder.setInsertionPoint(consumerWaitPoint);
+        builder.createWithAsyncTaskIds<ttng::ConsumerWaitOp>(
+            headConsumer->getLoc(), token.second, bufferIdx, phase);
+      }
+
+      // Insert ConsumerReleaseOp.
+      auto consumerReleasePoint =
+          consumerReleaseHeutistic(tailProducer, tailConsumer, token.first);
+      builder.setInsertionPointAfter(consumerReleasePoint);
+      builder.createWithAsyncTaskIds<ttng::ConsumerReleaseOp>(
+          consumerReleasePoint->getLoc(), token.second, bufferIdx);
+    }
+
+    SmallVector<tt::ExperimentalDescriptorLoadOp> tmaLoads;
+    SmallVector<Value> buffers;
+    DenseMap<Operation *, Operation *> producerCopyMap;
+    // Go through all channels in this channel group.
+    for (auto &c : kv.second) {
+      if (auto tmaLoad =
+              dyn_cast<tt::ExperimentalDescriptorLoadOp>(c->getSrcOp())) {
+        tmaLoads.push_back(tmaLoad);
+        buffers.push_back(bufferMap.find(c)->second);
+      }
+    }
+
+    // Optimize TMA loads.
+    if (tmaLoads.size() > 0) {
+      auto barrierAllocs = barrierAllocMap.find(kv.second.front())->second;
+      // TODO: we created one Alloc for each consumer taskId, but here, we
+      // only use the first Alloc.
+      auto barrierAlloc = barrierAllocs.begin()->second;
+      optimizeTMALoads(builder, tmaLoads, buffers, barrierAlloc, bufferIdx,
+                       bufferIdx, phase, headProducer, headConsumer);
+    }
+  }
+}
+
+// Lower producers for channels. Here channels are grouped in
+// "channelsGroupedByProducers"
+void insertAsyncCopy(triton::FuncOp funcOp,
+                     const DenseMap<Channel *, SmallVector<Channel *>>
+                         &channelsGroupedByProducers,
+                     const DenseMap<Channel *, Value> &bufferMap) {
+  // For each producer op, create a async_copy or local_store from the producer
+  // to the buffer. Create a local_load from the buffer at the dominating
+  // consumer.
+  mlir::DominanceInfo dom(funcOp);
+
+  for (auto kv : channelsGroupedByProducers) {
+    // Finding the dominating channel if possible.
+    std::unordered_set<Channel *> mutuallyNonDominatingChannels;
+    for (auto &c : kv.second) {
+      // check if c is dominating all other previous channels.
+      auto it = mutuallyNonDominatingChannels.begin();
+      while (it != mutuallyNonDominatingChannels.end()) {
+        auto channel = *it;
+        if (dom.properlyDominates(c->getDstOp(), channel->getDstOp())) {
+          it = mutuallyNonDominatingChannels.erase(it);
+        } else if (dom.properlyDominates(channel->getDstOp(), c->getDstOp())) {
+          break;
+        } else {
+          ++it;
+        }
+      }
+      if (it == mutuallyNonDominatingChannels.end())
+        mutuallyNonDominatingChannels.insert(c);
+    }
+
+    auto srcOp = kv.getFirst()->getSrcOp();
+    Value bufferIdx;
+    Value phase = Value();
+    if (auto forOp = srcOp->getParentOfType<scf::ForOp>()) {
+      // We already added phase, bufferIdx to the ForOp.
+      auto tSize = forOp.getBody()->getArguments().size();
+      assert(tSize >= 2);
+      bufferIdx = forOp.getBody()->getArguments().back();
+    } else {
+      // Producer is not in a ForOp, create phase and bufferIdx here which will
+      // be used by both producer and consumers.
+      OpBuilderWithAsyncTaskIds builder(srcOp);
+      SmallVector<AsyncTaskId> asyncTasksPC = getAsyncTaskIds(srcOp);
+      for (auto channel : mutuallyNonDominatingChannels)
+        asyncTasksPC.append(getAsyncTaskIds(channel->getDstOp()));
+      builder.setAsynTaskIdsFromArray(asyncTasksPC);
+      bufferIdx = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
+          srcOp->getLoc(), 0, 32);
+    }
+
+    for (auto channel : mutuallyNonDominatingChannels) {
+      // No need to create async copy for TMA load which is handled in
+      // insertAsyncComm.
+      if (isa<tt::ExperimentalDescriptorLoadOp, ttg::LocalLoadOp>(srcOp)) {
+        continue;
+      }
+      if (isa<triton::LoadOp>(srcOp)) {
+        SmallVector<AsyncTaskId> asyncTasksPC = getAsyncTaskIds(srcOp);
+        asyncTasksPC.append(getAsyncTaskIds(channel->getDstOp()));
+        // After createAsyncCopy, c->getSrcOp()/headProducer are no longer
+        // valid.
+        createAsyncCopy(bufferMap, channel, channel->getSrcOp(), asyncTasksPC,
+                        bufferIdx, bufferIdx);
+      } else {
+        createLocalCopy(bufferMap, channel, bufferIdx, bufferIdx);
+      }
+    }
+  }
+}
+
+void foldLocalLoads(triton::FuncOp funcOp) {
+  // If loadResult has a single use which is LocalAlloc, we can get rid of
+  // sharedLoad and replace all uses of LocalAlloc with viewLoad.
+  DenseMap<Operation *, Value> opsToReplace;
+  funcOp.walk([&](ttg::LocalAllocOp localAlloc) {
+    if (auto src = localAlloc.getSrc()) {
+      if (auto localLoad = dyn_cast<ttg::LocalLoadOp>(src.getDefiningOp())) {
+        // Only fold within the same tasks
+        if (getAsyncTaskIds(localLoad) == getAsyncTaskIds(localAlloc)) {
+          opsToReplace[localAlloc] = localLoad.getSrc();
+        }
+      }
+    }
+  });
+  OpBuilderWithAsyncTaskIds builder(funcOp.getContext());
+  for (auto kv : opsToReplace)
+    replaceUsesAndPropagateType(builder, kv.getFirst(), kv.getSecond());
+}
+
+class TritonGPUWSCodePartitionPass
+    : public impl::TritonGPUWSCodePartitionBase<TritonGPUWSCodePartitionPass> {
+public:
+  using impl::TritonGPUWSCodePartitionBase<
+      TritonGPUWSCodePartitionPass>::TritonGPUWSCodePartitionBase;
+
+  void runOnFuncOp(triton::FuncOp funcOp) {
+    // Disable code partitioning when numBuffers is 0.
+    if (numBuffers == 0)
+      return;
+
+    // Step 1: collect all communications between producers and consumers.
+    SmallVector<std::unique_ptr<Channel>> channelsOrigin;
+    collectAsyncChannels(channelsOrigin, funcOp, numBuffers);
+    SmallVector<Channel *> channels;
+    for (const auto &c : channelsOrigin) {
+      channels.push_back(c.get());
+    }
+    if (channels.empty()) {
+      return;
+    }
+
+    // Step 2: group channels
+    // -  each entry of the channelsGroupedByProducers is keyed by the srcOp.
+    // -  each entry of the channelsGroupedByConsumers is keyed by the dstOp.
+    DenseMap<Channel *, SmallVector<Channel *>> channelsGroupedByProducers;
+    DenseMap<Channel *, SmallVector<Channel *>> channelsGroupedByConsumers;
+    SmallVector<Channel *> orderedChannels;
+    groupChannels(channels, channelsGroupedByProducers,
+                  channelsGroupedByConsumers, orderedChannels);
+
+    // Step 3: reorder producer ops and the backward slices of the producer ops.
+    reorderProducerOps(channels);
+
+    // Step 4: find top-level ops that contain a channel, also create new ForOps
+    // by adding phase and bufferIdx to the original ForOps, erase the original
+    // ForOps.
+    SmallVector<Operation *> asyncTaskTopOps =
+        getTaskTopRegion(funcOp, channels);
+    // Update mapToRepresenting that maps a channel to the representing channel
+    // in the sharing group.
+    DenseMap<Channel *, Channel *> mapToRepresenting;
+    SmallVector<Operation *> loopWithBufferReuse;
+    reuseBuffers(asyncTaskTopOps, channels, mapToRepresenting,
+                 loopWithBufferReuse);
+    // Use and update loopWithBufferReuse.
+    appendBufferIdxArgs(asyncTaskTopOps, numBuffers, channels,
+                        mapToRepresenting, loopWithBufferReuse);
+    LLVM_DEBUG({
+      LDBG("\n\nafter appendBufferIdxArgs");
+      funcOp.dump();
+    });
+
+    // Step 5: Create tokens, and buffers. A set of tokens for each group of
+    // channels and an array of buffers for each channel.
+    // Update channelReuse that maps from a representing channel to the group of
+    // channels that share buffers.
+    DenseMap<Channel *, SmallVector<Channel *>> channelReuse;
+    DenseMap<Channel *, Value> bufferMap =
+        createBuffer(channelsGroupedByProducers, funcOp, numConsumerGroups,
+                     mapToRepresenting, channelReuse);
+    DenseMap<Channel *, DenseMap<int, Value>> barrierAllocMap;
+    DenseMap<Channel *, DenseMap<int, Value>> tokenMap =
+        createToken(channelsGroupedByConsumers, orderedChannels, funcOp,
+                    numConsumerGroups, channelReuse, barrierAllocMap);
+    LLVM_DEBUG({
+      LDBG("\n\nafter createBuffer");
+      funcOp.dump();
+    });
+
+    // Step 6: add async communication ops (ProducerAcquire etc). Also lower the
+    // loads.
+    insertAsyncComm(funcOp, channelsGroupedByConsumers, tokenMap,
+                    barrierAllocMap, bufferMap, numConsumerGroups);
+    LLVM_DEBUG({
+      LDBG("\n\nwith SyncOps");
+      funcOp.dump();
+    });
+
+    // Step 7: Lower the loads. Also add local copy ops for non-load producers.
+    insertAsyncCopy(funcOp, channelsGroupedByProducers, bufferMap);
+    LLVM_DEBUG({
+      LDBG("\n\nwith async copy");
+      funcOp.dump();
+    });
+
+    // If loadResult has a single use which is LocalAlloc, we can get rid of
+    // sharedLoad and replace all uses of LocalAlloc with viewLoad.
+    foldLocalLoads(funcOp);
+    LLVM_DEBUG({
+      LDBG("\n\nsimplify localLoad + localAlloc");
+      funcOp.dump();
+    });
+
+    // Assuming there are no changes to loops in loopWithBufferReuse.
+    auto ret = SpecializeRegion(funcOp, regDecProducer, regIncConsumer);
+    LLVM_DEBUG({
+      LDBG("\n\nwith SpecializeRegion");
+      funcOp.dump();
+    });
+  }
+
+  void runOnOperation() override {
+    getOperation()->walk([&](triton::FuncOp funcOp) { runOnFuncOp(funcOp); });
+    LLVM_DEBUG({
+      LDBG("post pass");
+      getOperation()->dump();
+    });
+    return;
+  }
+};
+
+} // namespace gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSDataPartition.cpp
@@ -1,0 +1,756 @@
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+namespace mlir {
+namespace triton {
+namespace gpu {
+
+#define DEBUG_TYPE "tritongpu-warp-spec-data-partition"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+static bool oneVecCoversTheOther(SmallVector<AsyncTaskId> &one,
+                                 SmallVector<AsyncTaskId> &other) {
+  // Every element of other appears in one.
+  for (AsyncTaskId t : other) {
+    // If t doesn't appear in one, return false.
+    bool found = false;
+    for (AsyncTaskId t2 : one) {
+      if (t2 == t) {
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      return false;
+  }
+  return true;
+}
+
+// Make sure the def chain contains the right taskId.
+void fixTaskId(triton::FuncOp &funcOp) {
+  funcOp.walk([&](Operation *op) {
+    auto asyncTaskIds = getAsyncTaskIds(op);
+    for (Value operand : op->getOperands()) {
+      Operation *defOp = operand.getDefiningOp();
+      if (!defOp)
+        continue;
+      // Do not update loads.
+      if (isa<tt::LoadOp, tt::ExperimentalDescriptorLoadOp>(defOp))
+        continue;
+      auto defTaskIds = getAsyncTaskIds(defOp);
+      // Make sure defTaskIds cover asyncTaskIds. Call addAsyncTaskIds if
+      // necessary.
+      if (!oneVecCoversTheOther(defTaskIds, asyncTaskIds)) {
+        // Const ops with same value but different task ids can be folded.
+        if (isa<arith::ConstantIntOp>(defOp)) {
+          LLVM_DEBUG({
+            LDBG("backward fixing taskId for");
+            defOp->dump();
+          });
+          addAsyncTaskIds(defOp, asyncTaskIds);
+          LLVM_DEBUG({
+            LDBG("resulting");
+            defOp->dump();
+          });
+        }
+      }
+      if (operand.hasOneUse() &&
+          !oneVecCoversTheOther(asyncTaskIds, defTaskIds)) {
+        // YieldOp may lose task attribute during MLIR canonicalization.
+        if (isa<scf::YieldOp>(op)) {
+          LLVM_DEBUG({
+            LDBG("forward fixing taskId for");
+            defOp->dump();
+          });
+          addAsyncTaskIds(op, defTaskIds);
+          LLVM_DEBUG({
+            LDBG("resulting");
+            defOp->dump();
+          });
+        }
+      }
+    }
+  });
+}
+
+static SmallVector<int64_t> getShape(Value v) {
+  auto type = v.getType();
+  if (auto type = dyn_cast<MemDescType>(v.getType())) {
+    return {type.getShape().begin(), type.getShape().end()};
+  } else if (auto type = dyn_cast<RankedTensorType>(v.getType())) {
+    return {type.getShape().begin(), type.getShape().end()};
+  }
+  return {};
+}
+
+bool needToSlice(Value v, int dim, int size) {
+  auto shape = getShape(v);
+  return shape.size() > dim && shape[dim] > size;
+}
+
+void getBackwardSliceToPartition(Value root, unsigned dim, int sliceSize,
+                                 SetVector<Operation *> &backwardSlice) {
+  SmallVector<Value> queue = {root};
+  while (!queue.empty()) {
+    auto v = queue.back();
+    queue.pop_back();
+    if (!needToSlice(v, dim, sliceSize))
+      continue;
+    if (auto op = v.getDefiningOp()) {
+      if (backwardSlice.insert(op)) {
+        if (op->hasTrait<OpTrait::Elementwise>() ||
+            isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
+                arith::ExtFOp, BroadcastOp, ExpandDimsOp, MakeRangeOp, SplatOp,
+                ConvertLayoutOp, triton::gpu::LocalAllocOp, LoadOp,
+                ExperimentalDescriptorLoadOp>(op)) {
+          for (Value operand : op->getOperands())
+            queue.push_back(operand);
+        } else if (auto dotOp = dyn_cast<nvidia_gpu::WarpGroupDotOp>(op)) {
+          queue.push_back(dim == 0 ? dotOp.getA() : dotOp.getB());
+          queue.push_back(dotOp.getC());
+        } else {
+          llvm_unreachable("Unexpected op");
+        }
+      }
+    } else {
+      assert(isa<BlockArgument>(v) && "value is not an operation or block ");
+      auto bbArg = cast<BlockArgument>(v);
+      Operation *bbAargOwner = bbArg.getOwner()->getParentOp();
+      if (auto forOp = dyn_cast<scf::ForOp>(bbAargOwner)) {
+        // track initial value
+        auto initArg = forOp.getInitArgs()[bbArg.getArgNumber() - 1];
+        queue.push_back(initArg);
+        // track yield value
+        auto yieldArg = forOp.getYieldedValues()[bbArg.getArgNumber() - 1];
+        queue.push_back(yieldArg);
+      }
+    }
+  }
+};
+
+void getForwardSliceToPartition(Value root, unsigned dim, int sliceSize,
+                                SetVector<Operation *> &forwardSlice) {
+  SmallVector<Value> queue = {root};
+  llvm::SmallDenseSet<Value> seen;
+  while (!queue.empty()) {
+    auto v = queue.back();
+    queue.pop_back();
+    if (!seen.insert(v).second)
+      continue;
+    if (!needToSlice(v, dim, sliceSize))
+      continue;
+    getForwardSlice(v, &forwardSlice);
+    for (Operation *op : forwardSlice) {
+      if (op->getNumResults() > 0)
+        seen.insert(op->getResult(0));
+      if (auto yieldOp = dyn_cast<scf::YieldOp>(op)) {
+        auto parentOp = yieldOp->getParentOp();
+        for (OpOperand &operand : yieldOp->getOpOperands()) {
+          if (seen.count(operand.get())) {
+            queue.push_back(parentOp->getResult(operand.getOperandNumber()));
+            forwardSlice.insert(parentOp);
+          }
+        }
+      }
+    }
+  }
+};
+
+// Compute a closure of all ops originated from or being dependent on by the
+// root op.
+void getSliceToPartition(Value root, unsigned dim, int sliceSize,
+                         SetVector<Operation *> &slice) {
+  getBackwardSliceToPartition(root, dim, sliceSize, slice);
+  SetVector<Operation *> forwardSlice;
+  getForwardSliceToPartition(root, dim, sliceSize, forwardSlice);
+  slice.insert(forwardSlice.begin(), forwardSlice.end());
+  for (auto op : forwardSlice) {
+    if (op->hasTrait<OpTrait::Elementwise>() ||
+        isa<tt::StoreOp, ExperimentalDescriptorStoreOp>(op)) {
+      for (OpOperand &operand : op->getOpOperands()) {
+        getBackwardSliceToPartition(operand.get(), dim, sliceSize, slice);
+      }
+    } else if (auto dotOp = dyn_cast<nvidia_gpu::WarpGroupDotOp>(op)) {
+      getBackwardSliceToPartition(dim == 0 ? dotOp.getA() : dotOp.getB(), dim,
+                                  sliceSize, slice);
+      getBackwardSliceToPartition(dotOp.getC(), dim, sliceSize, slice);
+    }
+  }
+}
+
+struct DataPartitionScheme {
+  // Which dimension to partition. For dot, dim 0 means along M dimension, 1
+  // means along N dimensiont.
+  unsigned partitionDim = 0;
+  unsigned numPartitions = 0;
+  SetVector<Operation *> ops;
+};
+
+bool computePartitionScheme(triton::FuncOp &funcOp,
+                            DataPartitionScheme &partitionScheme) {
+  // Do not partition producer tasks
+
+  // Use dot to drive the partition
+  SetVector<nvidia_gpu::WarpGroupDotOp> dots;
+
+  // check all dot ops that have more than one async task id
+  funcOp.walk([&](Operation *op) {
+    auto asyncTaskIds = getAsyncTaskIds(op);
+    if (asyncTaskIds.size() > 1) {
+      if (auto dotWaitOp = dyn_cast<nvidia_gpu::WarpGroupDotOp>(op)) {
+        dots.insert(dotWaitOp);
+      }
+    }
+  });
+
+  // Checking if all dots can be partitioned in the same way
+  int numWarps =
+      TritonGPUDialect::getNumWarps(funcOp->getParentOfType<ModuleOp>());
+  for (auto dotOp : dots) {
+    // partition along M first, otherwise along N
+    RankedTensorType dotType = dotOp.getType();
+    LLVM_DEBUG({
+      LDBG("Computing partition scheme for");
+      dotOp.dump();
+      LDBG("\n");
+    });
+    auto shapePerCTA = getShapePerCTA(dotType);
+    if (shapePerCTA.size() != 2) {
+      LDBG("partition not possible: shapePerCTA " << shapePerCTA.size());
+      return false;
+    }
+    auto CTALayout = getCTALayout(dotType.getEncoding());
+    auto asyncTaskIds = getAsyncTaskIds(dotOp);
+    int sliceSizeM = shapePerCTA[0] / asyncTaskIds.size();
+    int sliceSizeN = shapePerCTA[1] / asyncTaskIds.size();
+    int partitionDim, partitionSize;
+    Value partitionOperand;
+
+    if (sliceSizeM >= 64) {
+      LLVM_DEBUG({ LDBG("partition along M\n"); });
+      partitionDim = 0;
+      partitionSize = sliceSizeM;
+      partitionOperand = dotOp.getA();
+    } else if (sliceSizeN >= 256) {
+      LLVM_DEBUG({ LDBG("partition along N\n"); });
+      partitionDim = 1;
+      partitionSize = sliceSizeN;
+      partitionOperand = dotOp.getB();
+    } else {
+      LDBG("partition not possible: " << sliceSizeM << " " << sliceSizeN);
+      return false;
+    }
+
+    if (partitionScheme.numPartitions == 0) {
+      partitionScheme.partitionDim = partitionDim;
+      partitionScheme.numPartitions = asyncTaskIds.size();
+    } else {
+      if (partitionScheme.partitionDim != partitionDim ||
+          partitionScheme.numPartitions != asyncTaskIds.size()) {
+        LDBG("partition not possible, in conflict with previous partition\n");
+        return false;
+      }
+    }
+
+    // Partition the slice closure
+    SetVector<Operation *> &slice = partitionScheme.ops;
+    getSliceToPartition(dotOp.getD(), partitionDim, partitionSize, slice);
+
+    LLVM_DEBUG({
+      partitionOperand.dump();
+      LDBG("\n");
+      LDBG(" slice:");
+      for (auto &op : slice) {
+        op->dump();
+      }
+      LDBG("\n");
+    });
+
+    for (auto op : partitionScheme.ops) {
+      auto opTaskIds = getAsyncTaskIds(op);
+      // skip check for control flow ops
+      if (isa<scf::IfOp, scf::ForOp, scf::YieldOp>(op))
+        continue;
+#if 0
+      if (opTaskIds.size() > partitionScheme.numPartitions) {
+        LLVM_DEBUG({
+          LDBG("partition not possible: numPartitions" << opTaskIds.size() << " " << partitionScheme.numPartitions);
+          op->dump();
+        });
+        return false;
+      }
+#endif
+    }
+  }
+
+  return !partitionScheme.ops.empty();
+}
+
+Operation *sliceOp(Value v, int offset, OpBuilderWithAsyncTaskIds &builder,
+                   IRMapping &mappings, IRMapping &reverseMappings,
+                   DataPartitionScheme &partitionScheme);
+
+Operation *sliceOp(Operation *op, int offset,
+                   OpBuilderWithAsyncTaskIds &builder, IRMapping &mappings,
+                   IRMapping &reverseMappings,
+                   DataPartitionScheme &partitionScheme) {
+  if (!partitionScheme.ops.contains(op))
+    return op;
+  if (mappings.contains(op))
+    return mappings.lookupOrNull(op);
+  if (reverseMappings.contains(op))
+    return op;
+
+  LLVM_DEBUG({
+    LDBG("slicing:");
+    op->dump();
+    LDBG("\n");
+  });
+
+  int dim = partitionScheme.partitionDim;
+  int numOfPartitions = partitionScheme.numPartitions;
+
+  auto asyncTaskIds = getAsyncTaskIds(op);
+  SmallVector<mlir::AsyncTaskId, 3> sliceTaskIds;
+  if (asyncTaskIds.size() == numOfPartitions) {
+    // We are slicing the op for consumer only
+    sliceTaskIds.push_back(asyncTaskIds[offset]);
+  } else if (asyncTaskIds.size() == 1) {
+    // We are slicing the op for producer only
+    sliceTaskIds.push_back(asyncTaskIds.front());
+  } else if (asyncTaskIds.size() > numOfPartitions) {
+    // We are slicing the op for both producer and consumer
+    sliceTaskIds.push_back(asyncTaskIds.front());
+    sliceTaskIds.push_back(asyncTaskIds[offset + 1]);
+  } else {
+    llvm_unreachable("Unexpected asyncTaskIds.size()");
+  }
+
+  builder.setAsynTaskIdsFromArray(sliceTaskIds);
+  auto cloneAndSetResultType = [&](Operation *op) {
+    builder.setInsertionPoint(op);
+    auto newOp = builder.clone(*op, mappings);
+    setAsyncTaskIds(newOp, sliceTaskIds);
+    mappings.map(op, newOp);
+    reverseMappings.map(newOp, op);
+    // set result shape
+    if (!op->getResults().empty()) {
+      auto v = op->getResult(0);
+      auto newV = newOp->getResult(0);
+      if (auto type = dyn_cast<MemDescType>(v.getType())) {
+        SmallVector<int64_t> shape{type.getShape().begin(),
+                                   type.getShape().end()};
+        int sliceSize = shape[dim] / numOfPartitions;
+        shape[dim] = sliceSize;
+        auto newType =
+            MemDescType::get(shape, type.getElementType(), type.getEncoding(),
+                             type.getMemorySpace(), type.getMutableMemory());
+        newV.setType(newType);
+      } else if (auto type = dyn_cast<RankedTensorType>(v.getType())) {
+        SmallVector<int64_t> shape{type.getShape().begin(),
+                                   type.getShape().end()};
+        int sliceSize = shape[dim] / numOfPartitions;
+        shape[dim] = sliceSize;
+        auto newType = RankedTensorType::get(shape, type.getElementType(),
+                                             type.getEncoding());
+        newV.setType(newType);
+      }
+
+      mappings.map(v, newV);
+      reverseMappings.map(newV, v);
+    }
+    return newOp;
+  };
+
+  // slice operands first
+  Operation *newOp;
+  if (op->hasTrait<OpTrait::Elementwise>() ||
+      isa<ConvertLayoutOp, BroadcastOp, SplatOp, ExpandDimsOp, LocalAllocOp>(
+          op)) {
+    for (Value operand : op->getOperands())
+      sliceOp(operand, offset, builder, mappings, reverseMappings,
+              partitionScheme);
+    newOp = cloneAndSetResultType(op);
+  } else if (auto constOp = dyn_cast<arith::ConstantOp>(op)) {
+    builder.setInsertionPoint(op);
+    auto valAttr = cast<DenseElementsAttr>(constOp.getValueAttr());
+    auto valType = cast<ShapedType>(valAttr.getType());
+    SmallVector<int64_t> shape{valType.getShape().begin(),
+                               valType.getShape().end()};
+    int sliceSize = shape[dim] / numOfPartitions;
+    shape[dim] = sliceSize;
+    auto newValType = valType.clone(shape);
+    auto newValAttr = valAttr.resizeSplat(newValType);
+    newOp = builder.createWithAsyncTaskIds<arith::ConstantOp>(op->getLoc(),
+                                                              newValAttr);
+    // Do not drop original task id as constant folding may lose one constant.
+    setAsyncTaskIds(newOp, getAsyncTaskIds(op));
+    auto v = op->getResult(0);
+    auto newV = newOp->getResult(0);
+    mappings.map(v, newV);
+    reverseMappings.map(newV, v);
+  } else if (auto makeRangeOp = dyn_cast<MakeRangeOp>(op)) {
+    builder.setInsertionPoint(op);
+    int newRangeStart = makeRangeOp.getStart();
+    int newRangeEnd = makeRangeOp.getEnd();
+    int sliceSize = (newRangeEnd - newRangeStart) / numOfPartitions;
+    newRangeStart += offset * sliceSize;
+    newRangeEnd = newRangeStart + sliceSize;
+    auto v = op->getResult(0);
+    auto type = cast<RankedTensorType>(v.getType());
+    auto newType = RankedTensorType::get({sliceSize}, builder.getI32Type(),
+                                         type.getEncoding());
+    newOp = builder.createWithAsyncTaskIds<MakeRangeOp>(
+        op->getLoc(), newType, newRangeStart, newRangeEnd);
+    auto newV = newOp->getResult(0);
+    mappings.map(v, newV);
+    reverseMappings.map(newV, v);
+  } else if (isa<StoreOp, LoadOp>(op)) {
+    for (Value operand : op->getOperands())
+      sliceOp(operand, offset, builder, mappings, reverseMappings,
+              partitionScheme);
+    // TODO: slice store base ptr
+    newOp = cloneAndSetResultType(op);
+  } else if (isa<ExperimentalDescriptorLoadOp, ExperimentalDescriptorStoreOp>(
+                 op)) {
+    SmallVector<int64_t> shape;
+    Value coordVal;
+    if (auto loadOp = dyn_cast<ExperimentalDescriptorLoadOp>(op)) {
+      coordVal = loadOp.getIndices()[dim];
+      shape = getShape(loadOp.getResult());
+    } else if (auto storeOp = dyn_cast<ExperimentalDescriptorStoreOp>(op)) {
+      coordVal = storeOp.getIndices()[dim];
+      shape = getShape(storeOp.getSrc());
+    }
+    auto newCoordVal = coordVal;
+    if (offset) {
+      builder.setInsertionPointAfter(coordVal.getDefiningOp());
+      Value offsetVal = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
+          op->getLoc(), offset * shape[dim] / numOfPartitions, 32);
+      newCoordVal = builder.createWithAsyncTaskIds<arith::AddIOp>(
+          op->getLoc(), coordVal, offsetVal);
+      mappings.map(coordVal, newCoordVal);
+      reverseMappings.map(newCoordVal, coordVal);
+    }
+
+    newOp = cloneAndSetResultType(op);
+    if (isa<ExperimentalDescriptorLoadOp>(op)) {
+      // map load result
+      auto v = op->getResult(0);
+      auto newV = newOp->getResult(0);
+      mappings.map(v, newV);
+      reverseMappings.map(newV, v);
+    }
+  } else if (auto dotOp = dyn_cast<nvidia_gpu::WarpGroupDotOp>(op)) {
+    // Only hanlde A and accumulator
+    sliceOp(dim == 0 ? dotOp.getA() : dotOp.getB(), offset, builder, mappings,
+            reverseMappings, partitionScheme);
+    sliceOp(dotOp.getC(), offset, builder, mappings, reverseMappings,
+            partitionScheme);
+    newOp = cloneAndSetResultType(op);
+  } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+    // Add new loop arguments
+    SmallVector<Value> newLoopArgs;
+    for (auto initArg : forOp.getInitArgs())
+      newLoopArgs.push_back(initArg);
+    DenseMap<int, int> newArgIdices;
+    for (unsigned i = 0; i < forOp.getInitArgs().size(); i++) {
+      auto initArg = forOp.getInitArgs()[i];
+      Value newInitArg;
+      auto newInitArgOp = sliceOp(initArg, offset, builder, mappings,
+                                  reverseMappings, partitionScheme);
+      if (auto bbArg = dyn_cast<BlockArgument>(initArg)) {
+        // find the corresponding new block argument
+        Block *parentBlock = bbArg.getOwner();
+        unsigned argIndex = parentBlock->getNumArguments();
+        for (unsigned i = 0; i < parentBlock->getNumArguments(); ++i) {
+          if (parentBlock->getArgument(i) == bbArg) {
+            argIndex = i;
+            break;
+          }
+        }
+        assert(argIndex < parentBlock->getNumArguments() &&
+               "new init argment not found");
+        Region *parentRegion = parentBlock->getParent();
+        Region &newParentRegion =
+            newInitArgOp->getRegion(parentRegion->getRegionNumber());
+        newInitArg = parentRegion->getArgument(argIndex);
+      } else {
+        auto initArgOp = initArg.getDefiningOp();
+        unsigned resultIndex = cast<mlir::OpResult>(initArg).getResultNumber();
+        newInitArg = newInitArgOp->getResult(resultIndex);
+      }
+
+      if (newInitArg != initArg) {
+        newLoopArgs.append({newInitArg});
+        forOp.getBody()->insertArgument(forOp.getBody()->getNumArguments(),
+                                        newInitArg.getType(), forOp.getLoc());
+        newArgIdices[i] = newLoopArgs.size() - 1;
+      }
+    }
+
+    // Create newForOp and take the region of forOp
+    builder.setInsertionPoint(op);
+    auto newForOp = builder.createWithAsyncTaskIds<scf::ForOp>(
+        forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
+        forOp.getStep(), newLoopArgs);
+    assert(newForOp.getRegionIterArgs().size() ==
+           newForOp.getInitArgs().size());
+    newForOp->setAttrs(forOp->getAttrs());
+    partitionScheme.ops.insert(newForOp);
+    newOp = newForOp;
+
+    // Replace forOp with newForOp
+    newForOp.getRegion().takeBody(forOp.getRegion());
+    for (unsigned i = 0; i < forOp.getNumResults(); ++i)
+      forOp.getResult(i).replaceAllUsesWith(newForOp.getResult(i));
+    op->setAttr("to_be_removed", builder.getUnitAttr());
+
+    // Map new loop arguments
+    for (auto argIndex : newArgIdices) {
+      Value v = newForOp.getResult(argIndex.first);
+      Value newV = newForOp.getResult(argIndex.second);
+      mappings.map(v, newV);
+      reverseMappings.map(newV, v);
+
+      auto regionArg = newForOp.getRegionIterArg(argIndex.first);
+      auto newRegionArg = newForOp.getRegionIterArg(argIndex.second);
+      mappings.map(regionArg, newRegionArg);
+      reverseMappings.map(newRegionArg, regionArg);
+    }
+  } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+    // Slice the yield op and update if results
+    auto thenYieldOp = ifOp.thenYield();
+    auto elseYieldOp = ifOp.elseYield();
+    auto newThenYieldOp = sliceOp(thenYieldOp, offset, builder, mappings,
+                                  reverseMappings, partitionScheme);
+    sliceOp(elseYieldOp, offset, builder, mappings, reverseMappings,
+            partitionScheme);
+    assert(newThenYieldOp->getNumOperands() > ifOp->getNumResults() &&
+           "no need to slice if op");
+    // Clone ifOp with updated results but re-use the original regions.
+    builder.setInsertionPoint(op);
+    SmallVector<Type, 4> newResultTypes;
+    for (auto thenResult : thenYieldOp.getResults()) {
+      newResultTypes.push_back(thenResult.getType());
+    }
+    auto newIfOp = builder.create<scf::IfOp>(ifOp.getLoc(), newResultTypes,
+                                             ifOp.getCondition());
+    // Move the original regions to the cloned operation.
+    newIfOp.getThenRegion().takeBody(ifOp.getThenRegion());
+    newIfOp.getElseRegion().takeBody(ifOp.getElseRegion());
+    newOp = newIfOp;
+    newIfOp->setAttrs(ifOp->getAttrs());
+    partitionScheme.ops.insert(newIfOp);
+    ifOp->setAttr("to_be_removed", builder.getUnitAttr());
+
+    // Replace ifOp with newIfOp
+    for (unsigned i = 0; i < ifOp.getNumResults(); ++i)
+      ifOp.getResult(i).replaceAllUsesWith(newIfOp.getResult(i));
+
+    // Map if results based on the mapping for yield
+    for (auto &v : thenYieldOp->getOpOperands()) {
+      auto newV = mappings.lookupOrNull(v.get());
+      if (newV) {
+        int operandIndex = v.getOperandNumber();
+        // find the corresponding operand index of newV in newYieldOp
+        int newOperandIndex = -1;
+        for (int i = 0; i < newThenYieldOp->getNumOperands(); ++i) {
+          if (newThenYieldOp->getOperand(i) == newV) {
+            newOperandIndex = i;
+            break;
+          }
+        }
+        assert(newOperandIndex >= 0 && "newV not found in newYieldOp");
+        auto newResult = newIfOp.getResult(operandIndex);
+        auto newSlicedResult = newIfOp.getResult(newOperandIndex);
+        mappings.map(newResult, newSlicedResult);
+        reverseMappings.map(newSlicedResult, newResult);
+      }
+    }
+  } else if (auto yieldOp = dyn_cast<scf::YieldOp>(op)) {
+    int num = yieldOp.getNumOperands();
+    for (int i = 0; i < num; i++) {
+      auto operand = yieldOp.getOperand(i);
+      sliceOp(operand, offset, builder, mappings, reverseMappings,
+              partitionScheme);
+      if (auto newV = mappings.lookupOrNull(operand))
+        yieldOp->insertOperands(op->getNumOperands(), newV);
+    }
+    newOp = op;
+  } else if (auto reduceOp = dyn_cast<ReduceOp>(op)) {
+    assert(reduceOp.getAxis() != partitionScheme.partitionDim &&
+           "reduce should not happen on the partitioned dimension");
+    for (Value operand : op->getOperands())
+      sliceOp(operand, offset, builder, mappings, reverseMappings,
+              partitionScheme);
+    newOp = cloneAndSetResultType(op);
+    // recursively set async task ids for child ops
+    newOp->walk(
+        [&](Operation *childOp) { setAsyncTaskIds(childOp, sliceTaskIds); });
+  } else {
+    llvm_unreachable("unsupported op type");
+  }
+
+  LLVM_DEBUG({
+    LDBG("resulting");
+    newOp->dump();
+    LDBG("\n");
+  });
+  mappings.map(op, newOp);
+  reverseMappings.map(newOp, op);
+  return newOp;
+}
+
+Operation *sliceOp(Value v, int offset, OpBuilderWithAsyncTaskIds &builder,
+                   IRMapping &mappings, IRMapping &reverseMappings,
+                   DataPartitionScheme &partitionScheme) {
+  if (auto op = v.getDefiningOp()) {
+    return sliceOp(op, offset, builder, mappings, reverseMappings,
+                   partitionScheme);
+  } else {
+    assert(isa<BlockArgument>(v) && "value is not an operation or block ");
+    auto bbArg = cast<BlockArgument>(v);
+    Operation *bbAargOwner = bbArg.getOwner()->getParentOp();
+    return sliceOp(bbAargOwner, offset, builder, mappings, reverseMappings,
+                   partitionScheme);
+  }
+}
+
+void partitionTasks(triton::FuncOp &funcOp) {
+
+  // op -> (partition dim, num of partitions)
+  DataPartitionScheme partitionScheme;
+  if (!computePartitionScheme(funcOp, partitionScheme))
+    return;
+
+  for (int i = 0; i < partitionScheme.numPartitions; i++) {
+    OpBuilderWithAsyncTaskIds builder(funcOp.getContext());
+    IRMapping mappings, reverseMappings;
+
+    LLVM_DEBUG({ LDBG("partitioning op for task " << i << ":\n"); });
+
+    // TODO: compute a topological order for partitionScheme.ops and
+    // slice in that order.
+    int numOps = partitionScheme.ops.size();
+    for (int j = 0; j < numOps; j++) {
+      auto op = partitionScheme.ops[j];
+      sliceOp(op, i, builder, mappings, reverseMappings, partitionScheme);
+    }
+
+    // clean up
+    LLVM_DEBUG({
+      LDBG("prior to clean up:");
+      funcOp.dump();
+    });
+    SmallVector<Operation *> opsToDelete;
+    for (auto op : partitionScheme.ops) {
+      if (op->hasAttr("to_be_removed"))
+        opsToDelete.push_back(op);
+    }
+    for (auto op : opsToDelete) {
+      partitionScheme.ops.remove(op);
+      op->erase();
+    }
+  }
+
+  // clean up
+
+  SmallVector<Operation *> opsToDelete;
+  for (auto op : partitionScheme.ops) {
+    if (isa<scf::YieldOp>(op))
+      continue;
+    bool notUsed = true;
+    for (auto result : op->getResults()) {
+      if (!result.getUsers().empty()) {
+        notUsed = false;
+        break;
+      }
+    }
+    if (notUsed)
+      opsToDelete.push_back(op);
+  }
+
+  LLVM_DEBUG({
+    LDBG("opsToDelete:\n");
+    for (auto op : opsToDelete) {
+      LDBG("op: ");
+      op->dump();
+    }
+    LDBG("\n");
+  });
+  for (auto op : opsToDelete) {
+    partitionScheme.ops.remove(op);
+    op->erase();
+  }
+  LLVM_DEBUG({
+    LDBG("prior to clean up:");
+    funcOp.dump();
+  });
+
+  // delete block arguments
+  RewritePatternSet cleanUpPatterns(funcOp.getContext());
+  populateForOpDeadArgumentElimination(cleanUpPatterns);
+  scf::ForOp::getCanonicalizationPatterns(cleanUpPatterns, funcOp.getContext());
+  scf::IfOp::getCanonicalizationPatterns(cleanUpPatterns, funcOp.getContext());
+  if (applyPatternsAndFoldGreedily(funcOp, std::move(cleanUpPatterns))
+          .failed()) {
+    llvm_unreachable("failed to clean up");
+    // signalPassFailure();
+  }
+
+  // Make sure original ops are not used
+  LLVM_DEBUG({
+    LDBG("after partition");
+    funcOp.dump();
+    LDBG("\n");
+  });
+  fixTaskId(funcOp);
+}
+
+#define GEN_PASS_DEF_TRITONGPUWSDATAPARTITION
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+class TritonGPUWSDataPartitionPass
+    : public impl::TritonGPUWSDataPartitionBase<TritonGPUWSDataPartitionPass> {
+public:
+  using impl::TritonGPUWSDataPartitionBase<
+      TritonGPUWSDataPartitionPass>::TritonGPUWSDataPartitionBase;
+
+  void runOnFuncOp(triton::FuncOp funcOp) {
+    if (numConsumerGroups == 0)
+      return;
+    partitionTasks(funcOp);
+  }
+
+  void runOnOperation() override {
+    getOperation()->walk([&](triton::FuncOp funcOp) { runOnFuncOp(funcOp); });
+  }
+};
+
+} // namespace gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonGPU/Transforms/WSLowering.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSLowering.cpp
@@ -1,0 +1,297 @@
+#include "mlir/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+
+#include <set>
+
+#include "mlir/IR/OperationSupport.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
+
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+namespace mlir {
+namespace triton {
+namespace gpu {
+
+#define DEBUG_TYPE "tritongpu-warp-spec-lowering"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+enum class LoadType {
+  LoadAsyncOp,
+  LoadTMAOp,
+};
+
+static Value createThreadIdOp(OpBuilder &builder, Location loc) {
+  Value threadId = builder.create<::mlir::gpu::ThreadIdOp>(
+      loc, builder.getIndexType(), ::mlir::gpu::Dimension::x);
+  auto cast = builder.create<UnrealizedConversionCastOp>(
+      loc, TypeRange{builder.getIntegerType(32)}, ValueRange{threadId});
+  return cast.getResult(0);
+}
+
+// Lower to use GetCanonicalWarpIdOp.
+// In Hopper, each task is a warpgroup consisting of 4 warps.
+static const int WARPS_PER_TASK = 4;
+static const int THREADS_PER_TASK = 128;
+void lowerGetAsyncTaskIdOp(Operation *parentOp, int numConsumerGroups) {
+  DenseSet<Operation *> eraseOps;
+  parentOp->walk([&](ttng::GetAsyncTaskIdOp op) {
+    auto loc = op.getLoc();
+    OpBuilder builder(op);
+    Value _4 = builder.create<arith::ConstantIntOp>(loc, WARPS_PER_TASK, 32);
+    Value warpId = builder.create<ttng::GetCanonicalWarpIdOp>(loc);
+    Value asyncTaskId = builder.create<arith::DivUIOp>(loc, warpId, _4);
+    op.getResult().replaceAllUsesWith(asyncTaskId);
+
+    LLVM_DEBUG({
+      LDBG("erasing GetAsyncTask");
+      op->dump();
+    });
+    eraseOps.insert(op);
+  });
+  for (Operation *op : eraseOps)
+    op->erase();
+}
+
+//===----------------------------------------------------------------------===//
+// Lower token operations
+//===----------------------------------------------------------------------===//
+
+LoadType scanLoadTypes(ttng::CreateTokenOp createTokenOp) {
+  std::set<LoadType> loadTypes;
+  createTokenOp->getBlock()->walk([&](Operation *op) {
+    if (auto asyncCopy = dyn_cast<ttg::AsyncCopyGlobalToLocalOp>(op)) {
+      loadTypes.insert(LoadType::LoadAsyncOp);
+    } else if (auto asyncCopy =
+                   dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+      loadTypes.insert(LoadType::LoadTMAOp);
+    }
+  });
+  assert(loadTypes.size() > 0 && "no async copy in the block");
+  assert(loadTypes.size() == 1 && "block contains both async copy and tma");
+  return *loadTypes.begin();
+}
+
+Value getMBarrierPhaseBit(OpBuilder &builder, Operation *op,
+                          bool emptyBarrier) {
+  auto loc = op->getLoc();
+  assert(isa<ttng::ProducerAcquireOp>(op) || isa<ttng::ConsumerWaitOp>(op));
+  Value curPhase;
+  if (auto acq = dyn_cast<ttng::ProducerAcquireOp>(op))
+    curPhase = acq.getPhase();
+  else if (auto wait = dyn_cast<ttng::ConsumerWaitOp>(op))
+    curPhase = wait.getPhase();
+  if (emptyBarrier) {
+    // curPhase = curPhase xor True for emptyBarrier.
+    Value _1_1b = builder.create<arith::ConstantIntOp>(loc, 1, 1);
+    curPhase = builder.create<mlir::arith::XOrIOp>(loc, curPhase, _1_1b);
+  }
+  LLVM_DEBUG(curPhase.dump());
+  return curPhase;
+}
+
+void processProducerAcquireOp(OpBuilder &builder, ttng::ProducerAcquireOp op,
+                              Value bufferEmpty) {
+  auto loc = op.getLoc();
+  Value phase = getMBarrierPhaseBit(builder, op, true);
+  auto i32Ty = builder.getIntegerType(32);
+  phase = builder.create<arith::ExtUIOp>(loc, i32Ty, phase);
+  auto waitOp = builder.create<ttng::WaitBarrierOp>(loc, bufferEmpty, phase);
+  assert(op.getOperation()->hasAttr("async_task_id"));
+  setAsyncTaskIds(waitOp, getAsyncTaskIds(op.getOperation()));
+}
+
+void processProducerCommitOp(OpBuilder &builder, ttng::ProducerCommitOp op,
+                             Value bufferFull, LoadType loadType) {
+  auto loc = op.getLoc();
+  int txCnt = 0;
+  ttng::MBarrierArriveOp arriveOp;
+
+  if (loadType == LoadType::LoadAsyncOp) {
+    // Each thread arrives.
+    Value pred = builder.create<arith::ConstantIntOp>(loc, 1, 1);
+    arriveOp = builder.create<ttng::MBarrierArriveOp>(
+        loc, bufferFull, pred, /*remoteCTAId*/ nullptr, /*trackAsyncOp*/ true,
+        txCnt);
+  } else {
+    // Only thread 0 arrives for TMA load.
+    Value _0 = builder.create<arith::ConstantIntOp>(loc, 0, 32);
+    Value threadId = createThreadIdOp(builder, loc);
+    Value pred = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                               threadId, _0);
+    arriveOp = builder.create<ttng::MBarrierArriveOp>(
+        loc, bufferFull, pred, /*remoteCTAId*/ nullptr, /*trackAsyncOp*/ false,
+        txCnt);
+  }
+
+  assert(op.getOperation()->hasAttr("async_task_id"));
+  setAsyncTaskIds(arriveOp, getAsyncTaskIds(op.getOperation()));
+}
+
+void processConsumerWaitOp(OpBuilder &builder, ttng::ConsumerWaitOp op,
+                           Value bufferFull) {
+  auto loc = op.getLoc();
+  Value phase = getMBarrierPhaseBit(builder, op, false);
+  auto i32Ty = builder.getIntegerType(32);
+  phase = builder.create<arith::ExtUIOp>(loc, i32Ty, phase);
+  auto waitOp = builder.create<ttng::WaitBarrierOp>(loc, bufferFull, phase);
+  assert(op.getOperation()->hasAttr("async_task_id"));
+  setAsyncTaskIds(waitOp, getAsyncTaskIds(op.getOperation()));
+}
+
+void processConsumerReleaseOp(OpBuilder &builder, ttng::ConsumerReleaseOp op,
+                              Value bufferEmpty, int numCTAs) {
+  auto loc = op.getLoc();
+  auto arriveOp = builder.create<ttng::MBarrierArriveOp>(
+      loc, bufferEmpty, nullptr, nullptr, false, 0);
+  assert(op.getOperation()->hasAttr("async_task_id"));
+  setAsyncTaskIds(arriveOp, getAsyncTaskIds(op.getOperation()));
+}
+
+void lowerTokenOperations(Operation *parentOp, int numCTAs,
+                          int numConsumerGroups) {
+  SmallVector<Operation *> deprecatedOps;
+  parentOp->walk([&](ttng::CreateTokenOp createTokenOp) {
+    LoadType loadType = scanLoadTypes(createTokenOp);
+    MLIRContext *context = createTokenOp.getContext();
+    OpBuilder builder(createTokenOp);
+    Location loc = createTokenOp.getLoc();
+
+    Attribute sharedMemorySpace =
+        triton::gpu::SharedMemorySpaceAttr::get(context);
+    auto barrierCTALayout =
+        ttg::CTALayoutAttr::get(context, /*CTAsPerCGA=*/{1},
+                                /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
+    auto barrierEncoding =
+        ttg::SharedEncodingAttr::get(context, 1, 1, 1, {0}, barrierCTALayout);
+    Type barrierMemDescType =
+        tt::MemDescType::get({createTokenOp.getNum()}, builder.getI64Type(),
+                             barrierEncoding, sharedMemorySpace,
+                             /*mutableMemory=*/true);
+    Type singleBarrierMemDescType =
+        tt::MemDescType::get({1}, builder.getI64Type(), barrierEncoding,
+                             sharedMemorySpace, /*mutableMemory=*/true);
+    Value bufferFullArray = builder.create<mlir::triton::gpu::LocalAllocOp>(
+        loc, barrierMemDescType, Value());
+    Value bufferEmptyArray = builder.create<mlir::triton::gpu::LocalAllocOp>(
+        loc, barrierMemDescType, Value());
+
+    for (unsigned i = 0; i < createTokenOp.getNum(); i++) {
+      Value idx = builder.create<arith::ConstantIntOp>(loc, i, 32);
+      Value barrierFullView = builder.create<ttg::MemDescSubviewOp>(
+          loc, singleBarrierMemDescType, bufferFullArray, idx);
+      unsigned bufferFullCount =
+          loadType == LoadType::LoadTMAOp ? 1 : THREADS_PER_TASK;
+      builder.create<ttng::InitBarrierOp>(loc, barrierFullView,
+                                          bufferFullCount);
+
+      Value barrierEmptyView = builder.create<ttg::MemDescSubviewOp>(
+          loc, singleBarrierMemDescType, bufferEmptyArray, idx);
+      builder.create<ttng::InitBarrierOp>(loc, barrierEmptyView,
+                                          THREADS_PER_TASK);
+    }
+
+    assert(numCTAs == 1 && "remote CTA is not supported yet");
+    builder.create<mlir::gpu::BarrierOp>(loc);
+
+    // Helper function for extracting one index from bufferFullArray.
+    auto extractBufferFull = [&](Location loc, Value idx) -> Value {
+      return builder.create<ttg::MemDescSubviewOp>(
+          loc, singleBarrierMemDescType, bufferFullArray, idx);
+    };
+
+    // Helper function for extracting one index from bufferEmptyArray.
+    auto extractBufferEmpty = [&](Location loc, Value idx) -> Value {
+      return builder.create<ttg::MemDescSubviewOp>(
+          loc, singleBarrierMemDescType, bufferEmptyArray, idx);
+    };
+
+    // Process token users: ProducerAcquireOp, ProducerCommitOp, ConsumerWaitOp,
+    // and ConsumerReleaseOp.
+    for (Operation *user : createTokenOp.getResult().getUsers()) {
+      auto loc = user->getLoc();
+      builder.setInsertionPoint(user);
+      if (auto op = dyn_cast<ttng::ProducerAcquireOp>(user)) {
+        Value bufferEmpty = extractBufferEmpty(loc, op.getIdx());
+        assert(user->hasAttr("async_task_id"));
+        setAsyncTaskIds(bufferEmpty.getDefiningOp(), getAsyncTaskIds(user));
+        processProducerAcquireOp(builder, op, bufferEmpty);
+      } else if (auto op = dyn_cast<ttng::ProducerCommitOp>(user)) {
+        Value bufferFull = extractBufferFull(loc, op.getIdx());
+        assert(user->hasAttr("async_task_id"));
+        setAsyncTaskIds(bufferFull.getDefiningOp(), getAsyncTaskIds(user));
+        processProducerCommitOp(builder, op, bufferFull, loadType);
+      } else if (auto op = dyn_cast<ttng::ConsumerWaitOp>(user)) {
+        Value bufferFull = extractBufferFull(loc, op.getIdx());
+        assert(user->hasAttr("async_task_id"));
+        setAsyncTaskIds(bufferFull.getDefiningOp(), getAsyncTaskIds(user));
+        processConsumerWaitOp(builder, op, bufferFull);
+      } else if (auto op = dyn_cast<ttng::ConsumerReleaseOp>(user)) {
+        Value bufferEmpty = extractBufferEmpty(loc, op.getIdx());
+        assert(user->hasAttr("async_task_id"));
+        setAsyncTaskIds(bufferEmpty.getDefiningOp(), getAsyncTaskIds(user));
+        processConsumerReleaseOp(builder, op, bufferEmpty, numCTAs);
+      } else {
+        llvm_unreachable("Unexpected user of token");
+      }
+      deprecatedOps.push_back(user);
+    }
+
+    deprecatedOps.push_back(createTokenOp);
+  });
+  for (auto op : deprecatedOps) {
+    op->erase();
+  }
+
+  assert(numCTAs == 1 && "remote CTA is not supported yet");
+}
+
+#define GEN_PASS_DEF_TRITONGPUWSLOWERING
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+// This pass lowers WS-specific operations.
+class TritonGPUWSLowering
+    : public impl::TritonGPUWSLoweringBase<TritonGPUWSLowering> {
+public:
+  using impl::TritonGPUWSLoweringBase<
+      TritonGPUWSLowering>::TritonGPUWSLoweringBase;
+
+  void runOnOperation() override {
+    // Disable WarpSpec if numConsumerGroups is zero.
+    if (numConsumerGroups == 0)
+      return;
+    ModuleOp mod = getOperation();
+    int numCTAs = ttg::TritonGPUDialect::getNumCTAs(mod);
+
+    lowerGetAsyncTaskIdOp(mod, numConsumerGroups);
+    lowerTokenOperations(mod, numCTAs, numConsumerGroups);
+
+    // We assume number of warps per warp group is 4.
+    // With Warp Spec, the effective warps per CTA is
+    // number of warp groups * 4, but within each warp group, layout will use
+    // num_warps of 4, since tensors are not distributed between the groups.
+    //
+    // Loads usually happen in one producer warp groups. num_warps of 4 makes
+    // sense because only the 4 warps from the producer warp group are
+    // participating in the load.
+    //
+    // But at some point (at least when we launch the kernel!) we really do need
+    // to know that the CTA has 8 or 12 warps in it. Attribute
+    // "num-warp-groups-per-cta" can be used to calculate the total number of
+    // warps.
+    auto builder = OpBuilder::atBlockBegin(mod.getBody());
+    mod->setAttr("triton_gpu.num-warp-groups-per-cta",
+                 builder.getI32IntegerAttr(1 + numConsumerGroups));
+  }
+};
+
+} // namespace gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonGPU/Transforms/WSTaskPartition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WSTaskPartition.cpp
@@ -1,0 +1,167 @@
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+namespace mlir {
+namespace triton {
+namespace gpu {
+
+#define DEBUG_TYPE "tritongpu-warp-task-partition"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+#define GEN_PASS_DEF_TRITONGPUWSTASKPARTITION
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+struct TaskSchedule {
+  unsigned numTasks = 0;
+  DenseMap<Operation *, unsigned> opToTaskId;
+};
+
+// Compute a partition schedule for later passes to actually partition the
+// program into async tasks.
+void doPartition(triton::FuncOp &funcOp, unsigned numConsumerGroups) {
+
+  // Bail out in the presence of user annotations.
+  DenseSet<int> allAsyncTasks;
+  funcOp->walk([&](Operation *op) {
+    auto asyncTasks = getAsyncTaskIds(op);
+    allAsyncTasks.insert(asyncTasks.begin(), asyncTasks.end());
+  });
+
+  if (!allAsyncTasks.empty())
+    return;
+
+  SmallVector<scf::ForOp> loops;
+  SmallVector<Operation *> loads;
+  SmallVector<Operation *> dots;
+
+  funcOp.walk([&](Operation *op) {
+    if (scf::ForOp forOp = dyn_cast<scf::ForOp>(op))
+      loops.push_back(forOp);
+    else if (isa<nvidia_gpu::WarpGroupDotOp>(op))
+      dots.push_back(op);
+    else if (isa<triton::LoadOp, ExperimentalDescriptorLoadOp>(op))
+      loads.push_back(op);
+  });
+
+  if (loops.empty() || loads.empty() || dots.empty())
+    return;
+
+  auto getLoopLevel = [&](Operation *op) {
+    // Compute loop depth
+    unsigned depth = 0;
+    Operation *parent = op->getParentOp();
+    while (parent) {
+      if (isa<scf::ForOp>(parent)) {
+        ++depth;
+      }
+      parent = parent->getParentOp();
+    }
+    return depth;
+  };
+
+  // Step 1. Select loads into the first task, which is the producer task by
+  // default. Place dots into the second task, which is the consumer.
+  // Only consider loads that are connected to a dot op in a loop.
+  SmallVector<Operation *> producerOps;
+  SmallVector<Operation *> consumerOps;
+  for (auto op : dots) {
+    if (getLoopLevel(op) == 0)
+      continue;
+    consumerOps.push_back(op);
+    auto dotOp = dyn_cast<nvidia_gpu::WarpGroupDotOp>(op);
+    if (!dotOp)
+      continue;
+    SetVector<Operation *> backwardSlice;
+    getBackwardSlice(dotOp.getA(), &backwardSlice);
+    getBackwardSlice(dotOp.getB(), &backwardSlice);
+
+    for (auto depOp : backwardSlice) {
+      if (isa<triton::LoadOp, ExperimentalDescriptorLoadOp>(depOp)) {
+        producerOps.push_back(depOp);
+      }
+    }
+  }
+
+  LLVM_DEBUG({
+    LDBG("Producer ops:\n");
+    for (auto op : producerOps) {
+      op->dump();
+    }
+
+    LDBG("\n");
+    LDBG("Consumer ops:\n");
+    for (auto op : consumerOps) {
+      op->dump();
+    }
+
+    LDBG("\n");
+  });
+
+  if (consumerOps.empty() || producerOps.empty())
+    return;
+
+  // Annoate the program with task ids
+  SmallVector<AsyncTaskId, 1> producerTaskIds{0};
+  SmallVector<AsyncTaskId, 2> consumerTaskIds;
+  for (unsigned i = 0; i < numConsumerGroups; ++i) {
+    consumerTaskIds.push_back(i + producerTaskIds.size());
+  }
+
+  for (auto op : producerOps) {
+    setAsyncTaskIds(op, producerTaskIds);
+  }
+
+  for (auto op : consumerOps) {
+    setAsyncTaskIds(op, consumerTaskIds);
+  }
+
+  LLVM_DEBUG({
+    LDBG("After task partition");
+    funcOp.dump();
+    LDBG("\n");
+  });
+}
+
+class TritonGPUWSTaskPartitionPass
+    : public impl::TritonGPUWSTaskPartitionBase<TritonGPUWSTaskPartitionPass> {
+public:
+  using impl::TritonGPUWSTaskPartitionBase<
+      TritonGPUWSTaskPartitionPass>::TritonGPUWSTaskPartitionBase;
+
+  void runOnFuncOp(triton::FuncOp funcOp) {
+    if (numConsumerGroups == 0)
+      return;
+    doPartition(funcOp, numConsumerGroups);
+  }
+
+  void runOnOperation() override {
+    getOperation()->walk([&](triton::FuncOp funcOp) { runOnFuncOp(funcOp); });
+  }
+};
+
+} // namespace gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -93,6 +93,19 @@ LogicalResult WarpGroupDotWaitOp::inferReturnTypes(
   return mlir::success();
 }
 
+///--- Async related ops ---
+void GetAsyncTaskIdOp::build(::mlir::OpBuilder &builder,
+                             ::mlir::OperationState &state) {
+  build(builder, state, builder.getI32Type());
+}
+
+void CreateTokenOp::build(::mlir::OpBuilder &builder,
+                          ::mlir::OperationState &state, uint32_t num) {
+  auto tokenType = TokenType::get(builder.getContext());
+  auto resultType = RankedTensorType::get({num}, tokenType);
+  build(builder, state, resultType, num);
+}
+
 static LogicalResult verifyBarrierType(Operation *op, MemDescType barrierType) {
   if (!barrierType.getElementType().isInteger(64) ||
       barrierType.getShape() != ArrayRef<int64_t>({1}))

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   FenceInsertion.cpp
   PlanCTA.cpp
   TMALowering.cpp
+  Utility.cpp
 
   DEPENDS
   TritonNvidiaGPUTransformsIncGen

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
@@ -1,0 +1,88 @@
+
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+#include <fstream>
+
+namespace mlir {
+
+namespace ttg = triton::gpu;
+
+//===----------------------------------------------------------------------===//
+// Helper functions for async task
+//===----------------------------------------------------------------------===//
+
+SmallVector<AsyncTaskId> getAsyncTaskIds(Operation *op) {
+  SmallVector<AsyncTaskId> asyncTaskIds;
+  if (auto attr = op->getAttrOfType<DenseIntElementsAttr>("async_task_id"))
+    for (AsyncTaskId asyncTaskId : attr.getValues<AsyncTaskId>())
+      asyncTaskIds.push_back(asyncTaskId);
+  return asyncTaskIds;
+}
+
+bool hasAsyncTaskId(Operation *op, AsyncTaskId asyncTaskId) {
+  for (AsyncTaskId candidate : getAsyncTaskIds(op))
+    if (candidate == asyncTaskId)
+      return true;
+  return false;
+}
+
+void setAsyncTaskIds(Operation *op, ArrayRef<AsyncTaskId> asyncTaskIds) {
+  SmallVector<AsyncTaskId> sortedAsyncTaskIds(asyncTaskIds.begin(),
+                                              asyncTaskIds.end());
+  sort(sortedAsyncTaskIds);
+  auto i32Ty = IntegerType::get(op->getContext(), 32);
+  auto size = static_cast<int64_t>(sortedAsyncTaskIds.size());
+  auto vecTy = VectorType::get(size, i32Ty);
+  op->setAttr("async_task_id",
+              DenseIntElementsAttr::get(vecTy, sortedAsyncTaskIds));
+}
+
+SmallVector<AsyncTaskId> getNestedAsyncTaskIds(Operation *op) {
+  SetVector<AsyncTaskId> asyncTaskIds;
+  op->walk([&](Operation *curOp) {
+    for (AsyncTaskId asyncTaskId : getAsyncTaskIds(curOp))
+      asyncTaskIds.insert(asyncTaskId);
+  });
+  SmallVector<AsyncTaskId> res(asyncTaskIds.begin(), asyncTaskIds.end());
+  llvm::sort(res);
+  return res;
+}
+
+void addAsyncTaskIds(Operation *op, ArrayRef<int> asyncTasks) {
+  auto asyncTasksVec = getAsyncTaskIds(op);
+  DenseSet<int> asyncTasksSet(asyncTasksVec.begin(), asyncTasksVec.end());
+  for (int a : asyncTasks) {
+    if (!asyncTasksSet.contains(a)) {
+      asyncTasksVec.push_back(a);
+    }
+  }
+  if (asyncTasksVec.size() > 0) {
+    setAsyncTaskIds(op, asyncTasksVec);
+  }
+}
+
+void removeAsyncTaskId(Operation *op, AsyncTaskId asyncTaskId) {
+  auto origAsyncTaskIds = getAsyncTaskIds(op);
+  auto end = std::remove(origAsyncTaskIds.begin(), origAsyncTaskIds.end(),
+                         asyncTaskId);
+  origAsyncTaskIds.erase(end, origAsyncTaskIds.end());
+  if (origAsyncTaskIds.empty())
+    op->removeAttr("async_task_id");
+  else
+    setAsyncTaskIds(op, origAsyncTaskIds);
+}
+
+void removeAsyncTaskIds(Operation *op) { op->removeAttr("async_task_id"); }
+//===----------------------------------------------------------------------===//
+// Implementations for general auto WS
+//===----------------------------------------------------------------------===//
+
+} // namespace mlir

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -68,6 +68,15 @@ void init_triton_passes_ttgpuir(py::module &&m) {
                      createTritonGPUCombineTensorSelectAndIf);
   ADD_PASS_WRAPPER_0("add_optimize_accumulator_init",
                      createTritonGPUOptimizeAccumulatorInit);
+  ADD_PASS_OPTION_WRAPPER_1("add_ws_task_partition",
+                            createTritonGPUWSTaskPartition, int);
+  ADD_PASS_OPTION_WRAPPER_1("add_ws_data_partition",
+                            createTritonGPUWSDataPartition, int);
+  ADD_PASS_OPTION_WRAPPER_1("add_ws_lowering", createTritonGPUWSLowering, int);
+  ADD_PASS_OPTION_WRAPPER_1("add_taskid_propagate",
+                            createTritonGPUTaskIdPropagate, int);
+  ADD_PASS_OPTION_WRAPPER_4("add_ws_code_partition",
+                            createTritonGPUWSCodePartition, int, int, int, int);
 }
 
 void init_triton_passes_convert(py::module &&m) {

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -36,7 +36,10 @@ class Autotuner(KernelInterface):
             'prune_num_stages_by'(optional): a function used to prune num_stages. It takes configs:List[Config] as its input, and returns pruned configs.
         """
         if not configs:
-            self.configs = [Config({}, num_warps=4, num_stages=2, num_ctas=1)]
+            self.configs = [
+                Config({}, num_warps=4, num_stages=2, num_ctas=1, num_buffers_warp_spec=0, num_consumer_groups=0,
+                       reg_dec_producer=0, reg_inc_consumer=0)
+            ]
         else:
             self.configs = configs
         self.keys = key
@@ -259,11 +262,16 @@ class Config:
                     function are args.
     """
 
-    def __init__(self, kwargs, num_warps=4, num_stages=2, num_ctas=1, maxnreg=None, pre_hook=None):
+    def __init__(self, kwargs, num_warps=4, num_stages=2, num_ctas=1, num_buffers_warp_spec=0, num_consumer_groups=0,
+                 reg_dec_producer=0, reg_inc_consumer=0, maxnreg=None, pre_hook=None):
         self.kwargs = kwargs
         self.num_warps = num_warps
         self.num_ctas = num_ctas
         self.num_stages = num_stages
+        self.num_buffers_warp_spec = num_buffers_warp_spec
+        self.num_consumer_groups = num_consumer_groups
+        self.reg_dec_producer = reg_dec_producer
+        self.reg_inc_consumer = reg_inc_consumer
         self.maxnreg = maxnreg
         self.pre_hook = pre_hook
 
@@ -275,6 +283,10 @@ class Config:
                     ("num_warps", self.num_warps),
                     ("num_ctas", self.num_ctas),
                     ("num_stages", self.num_stages),
+                    ("num_buffers_warp_spec", self.num_buffers_warp_spec),
+                    ("num_consumer_groups", self.num_consumer_groups),
+                    ("reg_dec_producer", self.reg_dec_producer),
+                    ("reg_inc_consumer", self.reg_inc_consumer),
                     ("maxnreg", self.maxnreg),
                 ) if v is not None
             }
@@ -287,6 +299,10 @@ class Config:
         res.append(f"num_warps: {self.num_warps}")
         res.append(f"num_ctas: {self.num_ctas}")
         res.append(f"num_stages: {self.num_stages}")
+        res.append(f"num_buffers_warp_spec: {self.num_buffers_warp_spec}")
+        res.append(f"num_consumer_groups: {self.num_consumer_groups}")
+        res.append(f"reg_dec_producer: {self.reg_dec_producer}")
+        res.append(f"reg_inc_consumer: {self.reg_inc_consumer}")
         res.append(f"maxnreg: {self.maxnreg}")
         return ", ".join(res)
 

--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -57,6 +57,75 @@ def _matmul_launch_metadata(grid, kernel, args):
     return ret
 
 
+HAS_TMA_DESC = "nv_tma_desc_type" in dir(tl)
+
+if HAS_TMA_DESC:
+    print("TMA benchmarks will be running with experimental grid constant TMA descriptor.", )
+else:
+    print("TMA benchmarks will be running without grid constant TMA descriptor.", )
+
+
+class TmaAutoTuneHelper:
+
+    # duck typing wrapper to implement the same interface as TmaDescKernelParam in Triton PR #4498
+    class KernelParamWrapper:
+
+        def __init__(self, desc):
+            self.desc = desc
+
+        def tma_desc_cpu_ptr(self):
+            return self.desc.data_ptr()
+
+    TMA_SIZE = 128
+
+    def __init__(self):
+        self.fill_1d_tma_descriptor_inner = (triton.runtime.driver.active.utils.fill_1d_tma_descriptor)
+        self.fill_2d_tma_descriptor_inner = (triton.runtime.driver.active.utils.fill_2d_tma_descriptor)
+        if HAS_TMA_DESC:
+            self.descriptors = {}
+        else:
+            self.cuda_descriptors = {}
+
+    # Call this method outside of the lambda function for grid size
+    def init_tma_descriptor(self, name):
+        if HAS_TMA_DESC:
+            self.descriptors[name] = torch.empty(TmaAutoTuneHelper.TMA_SIZE, device="cpu", dtype=torch.int8)
+        else:
+            self.cuda_descriptors[name] = torch.empty(TmaAutoTuneHelper.TMA_SIZE, device="cuda", dtype=torch.int8)
+
+    # Call this method inside the lambda function for grid size
+    def fill_1d_tma_descriptor(self, name, ptr, dim, block_dim, element_size):
+        if HAS_TMA_DESC:
+            desc_x = self.descriptors[name]
+            assert desc_x.data_ptr() % 64 == 0
+            self.fill_1d_tma_descriptor_inner(ptr, dim, block_dim, element_size, desc_x.data_ptr())
+        else:
+            desc_x = self.cuda_descriptors[name]
+            buf_x = torch.empty_like(desc_x, device="cpu", pin_memory=True)
+            self.fill_1d_tma_descriptor_inner(ptr, dim, block_dim, element_size, buf_x.data_ptr())
+            desc_x.copy_(buf_x, non_blocking=True)
+
+    # Call this method inside the lambda function for grid size
+    def fill_2d_tma_descriptor(self, name, ptr, dim1, dim0, block_dim1, block_dim0, element_size):
+        if HAS_TMA_DESC:
+            desc_x = self.descriptors[name]
+            assert desc_x.data_ptr() % 64 == 0
+            self.fill_2d_tma_descriptor_inner(ptr, dim1, dim0, block_dim1, block_dim0, element_size, desc_x.data_ptr())
+        else:
+            desc_x = self.cuda_descriptors[name]
+            buf_x = torch.empty_like(desc_x, device="cpu", pin_memory=True)
+            self.fill_2d_tma_descriptor_inner(ptr, dim1, dim0, block_dim1, block_dim0, element_size, buf_x.data_ptr())
+            desc_x.copy_(buf_x, non_blocking=True)
+
+    def get_tma_descriptor_kernel_param(self, name):
+        if HAS_TMA_DESC:
+            assert self.descriptors[name] is not None
+            return self.KernelParamWrapper(self.descriptors[name])
+        else:
+            assert self.cuda_descriptors[name] is not None
+            return self.cuda_descriptors[name]
+
+
 @triton.jit(launch_metadata=_matmul_launch_metadata)
 def matmul_kernel(a_ptr, b_ptr, c_ptr,  #
                   M, N, K,  #
@@ -515,6 +584,150 @@ def matmul_device_tma_persistent(a, b, tiles_per_update):
     return c
 
 
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 256,
+                "BLOCK_SIZE_K": 64,
+                "GROUP_SIZE_M": 8,
+                "NUM_CONSUMER_GROUPS": 2,
+            },
+            num_stages=2,
+            num_warps=4,
+            num_consumer_groups=2,
+            num_buffers_warp_spec=3,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 64,
+                "BLOCK_SIZE_N": 64,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 8,
+                "NUM_CONSUMER_GROUPS": 1,
+            },
+            num_stages=3,
+            num_warps=4,
+            num_consumer_groups=0,  # disable warp specialization
+            num_buffers_warp_spec=3,
+        ),
+    ],
+    key=["M", "N", "K"],
+    use_cuda_graph=True,
+)
+@triton.jit(launch_metadata=_matmul_launch_metadata)
+def matmul_persistent_tma_ws_cooperative_kernel(
+    a_desc_ptr,
+    b_desc_ptr,
+    c_desc_ptr,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,  #
+    GROUP_SIZE_M: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    NUM_CONSUMER_GROUPS: tl.constexpr,
+):
+    dtype = tl.float8e4nv if FP8_OUTPUT else tl.float16
+    num_tiles = tl.cdiv(M, BLOCK_SIZE_M) * tl.cdiv(N, BLOCK_SIZE_N)
+    for pid in range(tl.program_id(0), num_tiles, tl.num_programs(0)):
+        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        offs_k = 0
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+            a = tl._experimental_descriptor_load(
+                a_desc_ptr,
+                [offs_am, offs_k],
+                [BLOCK_SIZE_M, BLOCK_SIZE_K],
+                dtype,
+            )
+            b = tl._experimental_descriptor_load(b_desc_ptr, [offs_bn, offs_k], [BLOCK_SIZE_N, BLOCK_SIZE_K], dtype)
+
+            accumulator = tl.dot(a, b.T, accumulator)
+            offs_k += BLOCK_SIZE_K
+
+        c = accumulator.to(dtype)
+        tl._experimental_descriptor_store(c_desc_ptr, c, [offs_am, offs_bn])
+
+
+def matmul_persistent_tma_ws_cooperative(a, b):
+    # Check constraints.
+    assert a.shape[1] == b.shape[1], "Incompatible dimensions"
+    assert a.dtype == b.dtype, "Incompatible dtypes"
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    desc_helper = TmaAutoTuneHelper()
+    desc_helper.init_tma_descriptor("a")
+    desc_helper.init_tma_descriptor("b")
+    desc_helper.init_tma_descriptor("c")
+
+    def grid(META):
+        nonlocal desc_helper
+        desc_helper.fill_2d_tma_descriptor(
+            "a",
+            a.data_ptr(),
+            M,
+            K,
+            META["BLOCK_SIZE_M"] // META["NUM_CONSUMER_GROUPS"],
+            META["BLOCK_SIZE_K"],
+            a.element_size(),
+        )
+
+        desc_helper.fill_2d_tma_descriptor(
+            "b",
+            b.data_ptr(),
+            N,
+            K,
+            META["BLOCK_SIZE_N"],
+            META["BLOCK_SIZE_K"],
+            b.element_size(),
+        )
+        desc_helper.fill_2d_tma_descriptor(
+            "c",
+            c.data_ptr(),
+            M,
+            N,
+            META["BLOCK_SIZE_M"] // META["NUM_CONSUMER_GROUPS"],
+            META["BLOCK_SIZE_N"],
+            c.element_size(),
+        )
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        ), )
+
+    desc_a = desc_helper.get_tma_descriptor_kernel_param("a")
+    desc_b = desc_helper.get_tma_descriptor_kernel_param("b")
+    desc_c = desc_helper.get_tma_descriptor_kernel_param("c")
+
+    matmul_persistent_tma_ws_cooperative_kernel[grid](
+        desc_a, desc_b, desc_c,  #
+        M, N, K,  #
+        FP8_OUTPUT=dtype == torch.float8_e4m3fn,  #
+    )
+    return c
+
+
 def cublas_matmul(a, b):
     # Check constraints.
     assert a.shape[1] == b.shape[1], "Incompatible dimensions"  # b is transposed
@@ -569,6 +782,9 @@ def bench(K, dtype, tiles_per_update, reps=10):
         for _ in range(reps):
             matmul_tma_persistent(a, b)
             time.sleep(0.01)
+        for _ in range(reps):
+            matmul_persistent_tma_ws_cooperative(a, b)
+            time.sleep(0.01)
         with proton.scope(
                 f"matmul_kernel_device_tma_persistent [M={M}, N={N}, K={K}, tiles_per_update={tiles_per_update:02}]"):
             for _ in range(reps):
@@ -589,6 +805,7 @@ def validate(M, N, K, dtype, tiles_per_update):
     persistent_result = matmul_persistent(a, b.T)
     tma_persistent_result = matmul_tma_persistent(a, b) if supports_tma() else None
     device_tma_persistent_result = matmul_device_tma_persistent(a, b, tiles_per_update) if supports_tma() else None
+    matmul_persistent_tma_ws_cooperative_result = matmul_persistent_tma_ws_cooperative(a, b) if supports_tma() else None
 
     if torch_result is not None:
         naive_vs_torch = "✅" if torch.allclose(naive_result.to(torch.float16), torch_result.to(torch.float16),
@@ -604,6 +821,10 @@ def validate(M, N, K, dtype, tiles_per_update):
     if device_tma_persistent_result is not None:
         naive_vs_device_tma_persistent = "✅" if torch.allclose(cublas_result.to(
             torch.float16), device_tma_persistent_result.to(torch.float16), atol=1.0) else "❌"
+    if matmul_persistent_tma_ws_cooperative_result is not None:
+        naive_vs_matmul_persistent_tma_ws_cooperative = "✅" if torch.allclose(
+            cublas_result.to(torch.float16), matmul_persistent_tma_ws_cooperative_result.to(torch.float16),
+            atol=1.0) else "❌"
     print(f"M={M}, N={N}, K={K} verification naive vs: ", end="")
     if torch_result is not None:
         print(f"torch: {naive_vs_torch} ", end="")
@@ -614,6 +835,8 @@ def validate(M, N, K, dtype, tiles_per_update):
         print(f"TMA persistent: {naive_vs_tma_persistent} ", end="")
     if device_tma_persistent_result is not None:
         print(f"Device TMA persistent: {naive_vs_device_tma_persistent} ", end="")
+    if matmul_persistent_tma_ws_cooperative_result is not None:
+        print(f"TMA persistent with warp specialization: {naive_vs_matmul_persistent_tma_ws_cooperative} ", end="")
     print()
 
 

--- a/test/TritonNvidiaGPU/WarpSpecialization/async_propagate.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/async_propagate.mlir
@@ -1,0 +1,63 @@
+// RUN: triton-opt %s -split-input-file --triton-gpu-taskid-propagate=num-consumer-groups=1 | FileCheck %s
+
+// CHECK-LABEL: @async_kernel
+// CHECK: %0 = tt.get_program_id x {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+// CHECK: %5 = tt.splat %arg2 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<1024xi32>
+// CHECK: %9 = tt.load %8, %6 {async_task_id = dense<0> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>
+// CHECK: %10 = tt.splat %arg1 {async_task_id = dense<1> : vector<1xi32>} : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+// CHECK: tt.store %11, %9 {async_task_id = dense<1> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>
+
+module {
+  tt.func public @async_kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32) attributes {noinline = false} {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %3 = tt.splat %1 : i32 -> tensor<1024xi32>
+    %4 = arith.addi %3, %2 : tensor<1024xi32>
+    %5 = tt.splat %arg2 : i32 -> tensor<1024xi32>
+    %6 = arith.cmpi slt, %4, %5 {async_task_id = dense<0> : vector<1xi32>} : tensor<1024xi32>
+    %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %4 {async_task_id = dense<0> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %9 = tt.load %8, %6 {async_task_id = dense<0> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>
+    %10 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+    %11 = tt.addptr %10, %4 {async_task_id = dense<1> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    tt.store %11, %9 {async_task_id = dense<1> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @two_consumers
+// CHECK: tt.get_program_id x {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+// CHECK: tt.splat %arg0 {async_task_id = dense<0> : vector<1xi32>}
+// CHECK: tt.load {{.*}} {async_task_id = dense<0> : vector<1xi32>}
+// CHECK: tt.load {{.*}} {async_task_id = dense<0> : vector<1xi32>}
+// CHECK: tt.splat %arg1 {async_task_id = dense<[1, 2]> : vector<2xi32>}
+// CHECK: tt.store {{.*}} {async_task_id = dense<1> : vector<1xi32>}
+// CHECK: tt.store {{.*}} {async_task_id = dense<2> : vector<1xi32>}
+
+module {
+  tt.func public @two_consumers(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) attributes {noinline = false} {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %3 = tt.make_range {end = 2048 : i32, start = 1024 : i32} : tensor<1024xi32>
+    %4 = tt.splat %1 : i32 -> tensor<1024xi32>
+    %5 = arith.addi %4, %2 : tensor<1024xi32>
+    %6 = arith.addi %4, %3 : tensor<1024xi32>
+    %7 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %5 {async_task_id = dense<0> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %9 = tt.addptr %7, %6 {async_task_id = dense<0> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %10 = tt.load %8 {async_task_id = dense<0> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>
+    %11 = tt.load %9 {async_task_id = dense<0> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>
+    %12 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>>
+    %13 = tt.addptr %12, %5 {async_task_id = dense<1> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %14 = tt.addptr %12, %6 {async_task_id = dense<2> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    tt.store %13, %10 {async_task_id = dense<1> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>
+    tt.store %14, %11 {async_task_id = dense<2> : vector<1xi32>} : tensor<1024x!tt.ptr<f32>>
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/WarpSpecialization/ws_code_partition.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/ws_code_partition.mlir
@@ -1,0 +1,857 @@
+// RUN: triton-opt %s -split-input-file --tritongpu-warp-spec-code-partition=num-buffers=1 | FileCheck %s
+
+// CHECK-LABEL: @matmul_kernel_one_consumer
+// CHECK: %[[#TASKID:]] = triton_nvidia_gpu.get_async_task_id : i32
+// CHECK: %c0_i32 = arith.constant 0 : i32
+// CHECK: %[[#WG0:]] = arith.cmpi eq, %[[#TASKID]], %c0_i32 : i32
+// CHECK: scf.if %[[#WG0]]
+// CHECK: triton_nvidia_gpu.reg_dealloc 40
+// CHECK: scf.for
+// CHECK: triton_nvidia_gpu.producer_acquire
+// CHECK: triton_gpu.async_copy_global_to_local
+// CHECK: triton_gpu.async_copy_global_to_local
+// CHECK: triton_nvidia_gpu.producer_commit
+// CHECK: %c1_i32 = arith.constant 1 : i32
+// CHECK: %[[#WG1:]] = arith.cmpi eq, %[[#TASKID]], %c1_i32 : i32
+// CHECK: scf.if %[[#WG1]]
+// CHECK: triton_nvidia_gpu.reg_alloc 232
+// CHECK: triton_nvidia_gpu.consumer_wait
+// CHECK: triton_gpu.local_load
+// CHECK: triton_gpu.local_load
+// CHECK: tt.dot
+// CHECK: triton_nvidia_gpu.consumer_release
+
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_kernel_one_consumer(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant {async_task_id = dense<1> : vector<1xi32>} dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %c255_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 255 : i32
+    %c127_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 127 : i32
+    %c1_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 1 : i32
+    %c0_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 0 : i32
+    %cst_0 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} dense<0.000000e+00> : tensor<256x128xf16, #blocked1>
+    %cst_1 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} dense<0.000000e+00> : tensor<128x256xf16, #blocked2>
+    %c8_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 8 : i32
+    %c128_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 128 : i32
+    %c256_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 256 : i32
+    %cst_2 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} dense<256> : tensor<128x256xi32, #blocked2>
+    %0 = tt.get_program_id x {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %1 = arith.addi %arg3, %c127_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %2 = arith.divsi %1, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %3 = arith.addi %arg4, %c127_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %4 = arith.divsi %3, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %5 = arith.muli %4, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %6 = arith.divsi %0, %5 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %7 = arith.muli %6, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %8 = arith.subi %2, %7 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %9 = arith.minsi %8, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %10 = arith.remsi %0, %5 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %11 = arith.remsi %10, %9 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %12 = arith.addi %7, %11 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %13 = arith.divsi %10, %9 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %14 = arith.muli %12, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %15 = tt.make_range {async_task_id = dense<[0, 1]> : vector<2xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>>
+    %16 = tt.make_range {async_task_id = dense<1> : vector<1xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %17 = tt.make_range {async_task_id = dense<[0, 1]> : vector<2xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %18 = tt.splat %14 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>>
+    %19 = tt.splat %14 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %20 = arith.addi %18, %15 {async_task_id = dense<[0, 1]> : vector<2xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>>
+    %21 = arith.addi %19, %16 {async_task_id = dense<1> : vector<1xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %22 = tt.splat %arg3 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>>
+    %23 = arith.remsi %20, %22 {async_task_id = dense<[0, 1]> : vector<2xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>>
+    %24 = arith.muli %13, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %25 = tt.splat %24 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %26 = arith.addi %25, %17 {async_task_id = dense<[0, 1]> : vector<2xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %27 = tt.splat %arg4 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %28 = arith.remsi %26, %27 {async_task_id = dense<0> : vector<1xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %29 = tt.expand_dims %23 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked2}>> -> tensor<128x1xi32, #blocked2>
+    %30 = tt.splat %arg6 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<128x1xi32, #blocked2>
+    %31 = arith.muli %29, %30 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x1xi32, #blocked2>
+    %32 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 256 : i32, start = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked2}>>
+    %33 = tt.expand_dims %32 {async_task_id = dense<0> : vector<1xi32>, axis = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked2}>> -> tensor<1x256xi32, #blocked2>
+    %34 = tt.broadcast %31 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x1xi32, #blocked2> -> tensor<128x256xi32, #blocked2>
+    %35 = tt.broadcast %33 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x256xi32, #blocked2> -> tensor<128x256xi32, #blocked2>
+    %36 = arith.addi %34, %35 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x256xi32, #blocked2>
+    %37 = tt.splat %arg0 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<f16> -> tensor<128x256x!tt.ptr<f16>, #blocked2>
+    %38 = tt.addptr %37, %36 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x256x!tt.ptr<f16>, #blocked2>, tensor<128x256xi32, #blocked2>
+    %39 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 256 : i32, start = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %40 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 256 : i32, start = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %41 = tt.expand_dims %39 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> -> tensor<256x1xi32, #blocked1>
+    %42 = tt.expand_dims %40 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> -> tensor<256x1xi32, #blocked1>
+    %43 = tt.splat %arg7 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<256x1xi32, #blocked1>
+    %44 = arith.muli %41, %43 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x1xi32, #blocked1>
+    %45 = tt.expand_dims %28 {async_task_id = dense<0> : vector<1xi32>, axis = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xi32, #blocked1>
+    %46 = tt.broadcast %44 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x1xi32, #blocked1> -> tensor<256x128xi32, #blocked1>
+    %47 = tt.broadcast %45 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x128xi32, #blocked1> -> tensor<256x128xi32, #blocked1>
+    %48 = arith.addi %46, %47 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x128xi32, #blocked1>
+    %49 = tt.splat %arg1 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<f16> -> tensor<256x128x!tt.ptr<f16>, #blocked1>
+    %50 = tt.addptr %49, %48 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x128x!tt.ptr<f16>, #blocked1>, tensor<256x128xi32, #blocked1>
+    %51 = arith.addi %arg5, %c255_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %52 = arith.divsi %51, %c256_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+    %53 = arith.muli %arg7, %c256_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+    %54 = tt.splat %53 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<256x128xi32, #blocked1>
+    %55:3 = scf.for %arg9 = %c0_i32 to %52 step %c1_i32 iter_args(%arg10 = %cst, %arg11 = %38, %arg12 = %50) -> (tensor<128x128xf32, #blocked>, tensor<128x256x!tt.ptr<f16>, #blocked2>, tensor<256x128x!tt.ptr<f16>, #blocked1>)  : i32 {
+      %74 = arith.muli %arg9, %c256_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %75 = arith.subi %arg5, %74 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %76 = tt.splat %75 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<1x256xi32, #blocked2>
+      %77 = arith.cmpi slt, %33, %76 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x256xi32, #blocked2>
+      %78 = tt.broadcast %77 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x256xi1, #blocked2> -> tensor<128x256xi1, #blocked2>
+      %79 = tt.load %arg11, %78, %cst_1 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x256x!tt.ptr<f16>, #blocked2>
+      %80 = tt.splat %75 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<256x1xi32, #blocked1>
+      %81 = arith.cmpi slt, %42, %80 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x1xi32, #blocked1>
+      %82 = tt.broadcast %81 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x1xi1, #blocked1> -> tensor<256x128xi1, #blocked1>
+      %83 = tt.load %arg12, %82, %cst_0 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x128x!tt.ptr<f16>, #blocked1>
+      %84 = triton_gpu.convert_layout %79 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x256xf16, #blocked2> -> tensor<128x256xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>
+      %85 = triton_gpu.convert_layout %83 {async_task_id = dense<1> : vector<1xi32>} : tensor<256x128xf16, #blocked1> -> tensor<256x128xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>
+      %86 = tt.dot %84, %85, %arg10, inputPrecision = tf32 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x256xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<256x128xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
+      %87 = tt.addptr %arg11, %cst_2 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x256x!tt.ptr<f16>, #blocked2>, tensor<128x256xi32, #blocked2>
+      %88 = tt.addptr %arg12, %54 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x128x!tt.ptr<f16>, #blocked1>, tensor<256x128xi32, #blocked1>
+      scf.yield {async_task_id = dense<[0, 1]> : vector<2xi32>} %86, %87, %88 : tensor<128x128xf32, #blocked>, tensor<128x256x!tt.ptr<f16>, #blocked2>, tensor<256x128x!tt.ptr<f16>, #blocked1>
+    } {async_task_id = dense<[0, 1]> : vector<2xi32>}
+    %56 = arith.truncf %55#0 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+    %57 = tt.expand_dims %21 {async_task_id = dense<1> : vector<1xi32>, axis = 1 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> -> tensor<128x1xi32, #blocked1>
+    %58 = tt.splat %arg8 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<128x1xi32, #blocked1>
+    %59 = arith.muli %58, %57 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x1xi32, #blocked1>
+    %60 = tt.splat %arg2 {async_task_id = dense<1> : vector<1xi32>} : !tt.ptr<f16> -> tensor<128x1x!tt.ptr<f16>, #blocked1>
+    %61 = tt.addptr %60, %59 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x1x!tt.ptr<f16>, #blocked1>, tensor<128x1xi32, #blocked1>
+    %62 = tt.expand_dims %26 {async_task_id = dense<1> : vector<1xi32>, axis = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xi32, #blocked1>
+    %63 = tt.broadcast %61 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x1x!tt.ptr<f16>, #blocked1> -> tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %64 = tt.broadcast %62 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x128xi32, #blocked1> -> tensor<128x128xi32, #blocked1>
+    %65 = tt.addptr %63, %64 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x128x!tt.ptr<f16>, #blocked1>, tensor<128x128xi32, #blocked1>
+    %66 = tt.splat %arg3 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<128x1xi32, #blocked1>
+    %67 = arith.cmpi slt, %57, %66 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x1xi32, #blocked1>
+    %68 = tt.splat %arg4 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<1x128xi32, #blocked1>
+    %69 = arith.cmpi slt, %62, %68 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x128xi32, #blocked1>
+    %70 = tt.broadcast %67 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x1xi1, #blocked1> -> tensor<128x128xi1, #blocked1>
+    %71 = tt.broadcast %69 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x128xi1, #blocked1> -> tensor<128x128xi1, #blocked1>
+    %72 = arith.andi %70, %71 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x128xi1, #blocked1>
+    %73 = triton_gpu.convert_layout %56 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x128xf16, #blocked> -> tensor<128x128xf16, #blocked1>
+    tt.store %65, %73, %72 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+
+// CHECK-LABEL: @matmul_kernel_two_consumers
+// CHECK: scf.if
+// CHECK: triton_nvidia_gpu.reg_dealloc 40
+// CHECK: scf.for
+// CHECK: triton_nvidia_gpu.producer_acquire
+// CHECK: triton_gpu.async_copy_global_to_local
+// CHECK: triton_nvidia_gpu.producer_commit
+// CHECK: triton_nvidia_gpu.producer_acquire
+// CHECK: triton_nvidia_gpu.producer_acquire
+// CHECK: triton_gpu.async_copy_global_to_local
+// CHECK: triton_nvidia_gpu.producer_commit
+// CHECK: triton_nvidia_gpu.producer_commit
+// CHECK: scf.if
+// CHECK: triton_nvidia_gpu.reg_alloc 232
+// CHECK: triton_nvidia_gpu.consumer_wait
+// CHECK: triton_nvidia_gpu.consumer_wait
+// CHECK: triton_nvidia_gpu.warp_group_dot
+// CHECK: triton_nvidia_gpu.consumer_release
+// CHECK: triton_nvidia_gpu.consumer_release
+// CHECK: scf.if
+// CHECK: triton_nvidia_gpu.reg_alloc 232
+// CHECK: triton_nvidia_gpu.consumer_wait
+// CHECK: triton_nvidia_gpu.consumer_wait
+// CHECK: triton_nvidia_gpu.warp_group_dot
+// CHECK: triton_nvidia_gpu.consumer_release
+// CHECK: triton_nvidia_gpu.consumer_release
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 16]}>
+#shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = true}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_kernel_two_consumers(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant {async_task_id = dense<0> : vector<1xi32>} dense<64> : tensor<64x64xi32, #blocked>
+    %c64_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 64 : i32
+    %c128_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 128 : i32
+    %c8_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 8 : i32
+    %cst_0 = arith.constant {async_task_id = dense<0> : vector<1xi32>} dense<0.000000e+00> : tensor<64x64xf16, #blocked>
+    %cst_1 = arith.constant {async_task_id = dense<0> : vector<1xi32>} dense<0.000000e+00> : tensor<64x128xf16, #blocked1>
+    %c0_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 0 : i32
+    %c1_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 1 : i32
+    %c127_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 127 : i32
+    %c63_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 63 : i32
+    %cst_2 = arith.constant {async_task_id = dense<[1, 2]> : vector<2xi32>} dense<0.000000e+00> : tensor<64x128xf32, #mma>
+    %0 = tt.get_program_id x {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %1 = arith.addi %arg3, %c127_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %2 = arith.divsi %1, %c128_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %3 = arith.addi %arg4, %c127_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %4 = arith.divsi %3, %c128_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %5 = arith.muli %4, %c8_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %6 = arith.divsi %0, %5 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %7 = arith.muli %6, %c8_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %8 = arith.subi %2, %7 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %9 = arith.minsi %8, %c8_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %10 = arith.remsi %0, %5 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %11 = arith.remsi %10, %9 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %12 = arith.addi %7, %11 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %13 = arith.divsi %10, %9 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %14 = arith.muli %12, %c128_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %15 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %16 = tt.make_range {async_task_id = dense<[0, 1]> : vector<2xi32>, end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %17 = tt.splat %14 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %18 = tt.splat %14 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32 -> tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %19 = arith.addi %17, %15 {async_task_id = dense<0> : vector<1xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %20 = arith.addi %18, %16 {async_task_id = dense<1> : vector<1xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %21 = tt.splat %arg3 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %22 = arith.remsi %19, %21 {async_task_id = dense<0> : vector<1xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %23 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 128 : i32, start = 64 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %24 = tt.make_range {async_task_id = dense<2> : vector<1xi32>, end = 128 : i32, start = 64 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %25 = arith.addi %17, %23 {async_task_id = dense<0> : vector<1xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %26 = arith.addi %18, %24 {async_task_id = dense<2> : vector<1xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %27 = arith.remsi %25, %21 {async_task_id = dense<0> : vector<1xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %28 = arith.muli %13, %c128_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %29 = tt.make_range {async_task_id = dense<[0, 1, 2]> : vector<3xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %30 = tt.splat %28 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %31 = arith.addi %30, %29 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %32 = tt.splat %arg4 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %33 = arith.remsi %31, %32 {async_task_id = dense<0> : vector<1xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %34 = tt.expand_dims %22 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %35 = tt.splat %arg6 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<64x1xi32, #blocked>
+    %36 = arith.muli %34, %35 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi32, #blocked>
+    %37 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+    %38 = tt.expand_dims %37 {async_task_id = dense<0> : vector<1xi32>, axis = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %39 = tt.broadcast %36 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi32, #blocked> -> tensor<64x64xi32, #blocked>
+    %40 = tt.broadcast %38 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x64xi32, #blocked> -> tensor<64x64xi32, #blocked>
+    %41 = arith.addi %39, %40 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x64xi32, #blocked>
+    %42 = tt.splat %arg0 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<f16> -> tensor<64x64x!tt.ptr<f16>, #blocked>
+    %43 = tt.addptr %42, %41 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x64xi32, #blocked>
+    %44 = tt.expand_dims %27 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %45 = arith.muli %44, %35 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi32, #blocked>
+    %46 = tt.broadcast %45 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi32, #blocked> -> tensor<64x64xi32, #blocked>
+    %47 = arith.addi %46, %40 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x64xi32, #blocked>
+    %48 = tt.addptr %42, %47 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x64xi32, #blocked>
+    %49 = tt.expand_dims %16 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> -> tensor<64x1xi32, #blocked1>
+    %50 = tt.splat %arg7 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<64x1xi32, #blocked1>
+    %51 = arith.muli %49, %50 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi32, #blocked1>
+    %52 = tt.expand_dims %33 {async_task_id = dense<0> : vector<1xi32>, axis = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xi32, #blocked1>
+    %53 = tt.broadcast %51 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi32, #blocked1> -> tensor<64x128xi32, #blocked1>
+    %54 = tt.broadcast %52 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x128xi32, #blocked1> -> tensor<64x128xi32, #blocked1>
+    %55 = arith.addi %53, %54 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x128xi32, #blocked1>
+    %56 = tt.splat %arg1 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<f16> -> tensor<64x128x!tt.ptr<f16>, #blocked1>
+    %57 = tt.addptr %56, %55 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x128x!tt.ptr<f16>, #blocked1>, tensor<64x128xi32, #blocked1>
+    %58 = arith.addi %arg5, %c63_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %59 = arith.divsi %58, %c64_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %60 = tt.expand_dims %37 {async_task_id = dense<0> : vector<1xi32>, axis = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %61 = tt.expand_dims %16 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> -> tensor<64x1xi32, #blocked1>
+    %62 = arith.muli %arg7, %c64_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+    %63 = tt.splat %62 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<64x128xi32, #blocked1>
+    %true = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} true
+    %false = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} false
+    %true_3 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} true
+    %false_4 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} false
+    %64:5 = scf.for %arg9 = %c0_i32 to %59 step %c1_i32 iter_args(%arg10 = %cst_2, %arg11 = %cst_2, %arg12 = %43, %arg13 = %57, %arg14 = %48) -> (tensor<64x128xf32, #mma>, tensor<64x128xf32, #mma>, tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x128x!tt.ptr<f16>, #blocked1>, tensor<64x64x!tt.ptr<f16>, #blocked>)  : i32 {
+      %93 = arith.muli %arg9, %c64_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %94 = arith.subi %arg5, %93 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %95 = tt.splat %94 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<1x64xi32, #blocked>
+      %96 = arith.cmpi slt, %60, %95 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x64xi32, #blocked>
+      %97 = tt.broadcast %96 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
+      %98 = tt.load %arg12, %97, %cst_0 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x64x!tt.ptr<f16>, #blocked>
+      %99 = triton_gpu.local_alloc %98 {async_task_id = dense<1> : vector<1xi32>} : (tensor<64x64xf16, #blocked>) -> !tt.memdesc<64x64xf16, #shared, #triton_gpu.shared_memory>
+      %100 = tt.splat %94 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<64x1xi32, #blocked1>
+      %101 = arith.cmpi slt, %61, %100 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi32, #blocked1>
+      %102 = tt.broadcast %101 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi1, #blocked1> -> tensor<64x128xi1, #blocked1>
+      %103 = tt.load %arg13, %102, %cst_1 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x128x!tt.ptr<f16>, #blocked1>
+      %104 = triton_gpu.local_alloc %103 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<64x128xf16, #blocked1>) -> !tt.memdesc<64x128xf16, #shared, #triton_gpu.shared_memory>
+      %105 = tt.load %arg14, %97, %cst_0 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x64x!tt.ptr<f16>, #blocked>
+      %106 = triton_gpu.local_alloc %105 {async_task_id = dense<2> : vector<1xi32>} : (tensor<64x64xf16, #blocked>) -> !tt.memdesc<64x64xf16, #shared, #triton_gpu.shared_memory>
+      %107 = triton_nvidia_gpu.warp_group_dot %99, %104, %arg10 {async_task_id = dense<1> : vector<1xi32>, inputPrecision = 0 : i32} : !tt.memdesc<64x64xf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<64x128xf16, #shared, #triton_gpu.shared_memory> -> tensor<64x128xf32, #mma>
+      %108 = triton_nvidia_gpu.warp_group_dot %106, %104, %arg11 {async_task_id = dense<2> : vector<1xi32>, inputPrecision = 0 : i32} : !tt.memdesc<64x64xf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<64x128xf16, #shared, #triton_gpu.shared_memory> -> tensor<64x128xf32, #mma>
+      %109 = tt.addptr %arg12, %cst {async_task_id = dense<0> : vector<1xi32>} : tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x64xi32, #blocked>
+      %110 = tt.addptr %arg14, %cst {async_task_id = dense<0> : vector<1xi32>} : tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x64xi32, #blocked>
+      %111 = tt.addptr %arg13, %63 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x128x!tt.ptr<f16>, #blocked1>, tensor<64x128xi32, #blocked1>
+      scf.yield {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} %107, %108, %109, %111, %110 : tensor<64x128xf32, #mma>, tensor<64x128xf32, #mma>, tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x128x!tt.ptr<f16>, #blocked1>, tensor<64x64x!tt.ptr<f16>, #blocked>
+    } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>}
+    %65 = arith.truncf %64#0 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xf32, #mma> to tensor<64x128xf16, #mma>
+    %66 = arith.truncf %64#1 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xf32, #mma> to tensor<64x128xf16, #mma>
+    %67 = tt.expand_dims %20 {async_task_id = dense<1> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> -> tensor<64x1xi32, #blocked1>
+    %68 = tt.splat %arg8 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32 -> tensor<64x1xi32, #blocked1>
+    %69 = arith.muli %68, %67 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xi32, #blocked1>
+    %70 = tt.splat %arg2 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<f16> -> tensor<64x1x!tt.ptr<f16>, #blocked1>
+    %71 = tt.addptr %70, %69 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1x!tt.ptr<f16>, #blocked1>, tensor<64x1xi32, #blocked1>
+    %72 = tt.expand_dims %31 {async_task_id = dense<[1, 2]> : vector<2xi32>, axis = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xi32, #blocked1>
+    %73 = tt.broadcast %71 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1x!tt.ptr<f16>, #blocked1> -> tensor<64x128x!tt.ptr<f16>, #blocked1>
+    %74 = tt.broadcast %72 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x128xi32, #blocked1> -> tensor<64x128xi32, #blocked1>
+    %75 = tt.addptr %73, %74 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128x!tt.ptr<f16>, #blocked1>, tensor<64x128xi32, #blocked1>
+    %76 = tt.expand_dims %26 {async_task_id = dense<2> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> -> tensor<64x1xi32, #blocked1>
+    %77 = arith.muli %68, %76 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xi32, #blocked1>
+    %78 = tt.addptr %70, %77 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1x!tt.ptr<f16>, #blocked1>, tensor<64x1xi32, #blocked1>
+    %79 = tt.broadcast %78 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1x!tt.ptr<f16>, #blocked1> -> tensor<64x128x!tt.ptr<f16>, #blocked1>
+    %80 = tt.addptr %79, %74 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128x!tt.ptr<f16>, #blocked1>, tensor<64x128xi32, #blocked1>
+    %81 = tt.splat %arg3 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32 -> tensor<64x1xi32, #blocked1>
+    %82 = arith.cmpi slt, %67, %81 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xi32, #blocked1>
+    %83 = tt.splat %arg4 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32 -> tensor<1x128xi32, #blocked1>
+    %84 = arith.cmpi slt, %72, %83 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x128xi32, #blocked1>
+    %85 = tt.broadcast %82 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xi1, #blocked1> -> tensor<64x128xi1, #blocked1>
+    %86 = tt.broadcast %84 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x128xi1, #blocked1> -> tensor<64x128xi1, #blocked1>
+    %87 = arith.andi %85, %86 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xi1, #blocked1>
+    %88 = arith.cmpi slt, %76, %81 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xi32, #blocked1>
+    %89 = tt.broadcast %88 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xi1, #blocked1> -> tensor<64x128xi1, #blocked1>
+    %90 = arith.andi %89, %86 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xi1, #blocked1>
+    %91 = triton_gpu.convert_layout %65 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xf16, #mma> -> tensor<64x128xf16, #blocked1>
+    tt.store %75, %91, %87 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128x!tt.ptr<f16>, #blocked1>
+    %92 = triton_gpu.convert_layout %66 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xf16, #mma> -> tensor<64x128xf16, #blocked1>
+    tt.store %80, %92, %90 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128x!tt.ptr<f16>, #blocked1>
+    tt.return
+  }
+}
+
+
+// -----
+
+// CHECK-LABEL: @_matmul_layernorm_persistent_one_producer_one_consumer_one_epilog
+// CHECK: %[[#TASKID:]] = triton_nvidia_gpu.get_async_task_id : i32
+// CHECK: %c0_i32_0 = arith.constant 0 : i32
+// CHECK: %[[#WG0:]] = arith.cmpi eq, %[[#TASKID]], %c0_i32_0 : i32
+// CHECK: scf.if %[[#WG0]]
+// CHECK: triton_nvidia_gpu.reg_dealloc 40
+// CHECK: scf.for
+// CHECK: scf.for
+// CHECK: triton_nvidia_gpu.producer_acquire
+// CHECK: triton_nvidia_gpu.barrier_expect
+// CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local
+// CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local
+// CHECK: %c1_i32 = arith.constant 1 : i32
+// CHECK: %[[#WG1:]] = arith.cmpi eq, %[[#TASKID]], %c1_i32 : i32
+// CHECK: scf.if %[[#WG1]]
+// CHECK: triton_nvidia_gpu.reg_alloc 232
+// CHECK: scf.for
+// CHECK: triton_nvidia_gpu.producer_acquire
+// CHECK: scf.for
+// CHECK: triton_nvidia_gpu.wait_barrier
+// CHECK: triton_gpu.local_load
+// CHECK: triton_gpu.local_load
+// CHECK: triton_nvidia_gpu.warp_group_dot
+// CHECK: triton_nvidia_gpu.consumer_release
+// CHECK: triton_gpu.local_store
+// CHECK: triton_nvidia_gpu.producer_commit
+// CHECK: %c2_i32 = arith.constant 2 : i32
+// CHECK: %[[#WG2:]] = arith.cmpi eq, %[[#TASKID]], %c2_i32 : i32
+// CHECK: scf.if %[[#WG2]]
+// CHECK: triton_nvidia_gpu.reg_alloc 232
+// CHECK: scf.for
+// CHECK: scf.for
+// CHECK: triton_gpu.local_load
+// CHECK: triton_nvidia_gpu.consumer_wait
+// CHECK: triton_nvidia_gpu.consumer_release
+// CHECK: tt.experimental_descriptor_store
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked3 = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = true}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @_matmul_layernorm_persistent_one_producer_one_consumer_one_epilog(%arg0: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg1: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg2: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg3: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg4: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: f32) attributes {noinline = false} {
+    %c63_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 63 : i32
+    %c128_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 128 : i32
+    %c0_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 0 : i32
+    %c64_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 64 : i32
+    %c132_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 132 : i32
+    %c1_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 1 : i32
+    %c127_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 127 : i32
+    %c256_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 256 : i32
+    %c255_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 255 : i32
+    %cst = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %cst_0 = arith.constant {async_task_id = dense<2> : vector<1xi32>} dense<1.000000e+00> : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+    %0 = arith.addi %arg7, %c63_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %1 = arith.divsi %0, %c64_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %2 = arith.addi %arg5, %c127_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %3 = arith.divsi %2, %c128_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %4 = arith.addi %arg6, %c255_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %5 = arith.divsi %4, %c256_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %6 = arith.muli %3, %5 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %7 = tt.get_program_id x {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %8 = arith.sitofp %arg6 {async_task_id = dense<2> : vector<1xi32>} : i32 to f32
+    %9 = tt.splat %8 {async_task_id = dense<2> : vector<1xi32>} : f32 -> tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+    %10 = tt.splat %arg11 {async_task_id = dense<2> : vector<1xi32>} : f32 -> tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+    scf.for %arg12 = %7 to %6 step %c132_i32  : i32 {
+      %11 = arith.muli %arg12, %c128_i32 {async_task_id = dense<[0, 2]> : vector<2xi32>} : i32
+      %true = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} true
+      %false = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} false
+      %12 = scf.for %arg13 = %c0_i32 to %1 step %c1_i32 iter_args(%arg14 = %cst) -> (tensor<128x256xf32, #mma>)  : i32 {
+        %45 = arith.muli %arg13, %c64_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+        %46 = tt.experimental_descriptor_load %arg0[%11, %45] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<128x64xf16, #blocked>
+        %47 = triton_gpu.local_alloc %46 {async_task_id = dense<1> : vector<1xi32>} : (tensor<128x64xf16, #blocked>) -> !tt.memdesc<128x64xf16, #shared, #triton_gpu.shared_memory>
+        %48 = tt.experimental_descriptor_load %arg1[%45, %c0_i32] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x256xf16, #blocked1>
+        %49 = triton_gpu.local_alloc %48 {async_task_id = dense<1> : vector<1xi32>} : (tensor<64x256xf16, #blocked1>) -> !tt.memdesc<64x256xf16, #shared, #triton_gpu.shared_memory>
+        %50 = triton_nvidia_gpu.warp_group_dot %47, %49, %arg14 {async_task_id = dense<1> : vector<1xi32>, inputPrecision = 0 : i32} : !tt.memdesc<128x64xf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<64x256xf16, #shared, #triton_gpu.shared_memory> -> tensor<128x256xf32, #mma>
+        scf.yield {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} %50 : tensor<128x256xf32, #mma>
+      } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>}
+      %13 = "tt.reduce"(%12) <{axis = 1 : i32}> ({
+      ^bb0(%arg13: f32, %arg14: f32):
+        %45 = arith.addf %arg13, %arg14 {async_task_id = dense<2> : vector<1xi32>} : f32
+        tt.reduce.return %45 {async_task_id = dense<2> : vector<1xi32>} : f32
+      }) {async_task_id = dense<2> : vector<1xi32>} : (tensor<128x256xf32, #mma>) -> tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+      %14 = arith.divf %13, %9 {async_task_id = dense<2> : vector<1xi32>} : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+      %15 = tt.expand_dims %14 {async_task_id = dense<2> : vector<1xi32>, axis = 1 : i32} : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>> -> tensor<128x1xf32, #mma>
+      %16 = tt.broadcast %15 {async_task_id = dense<2> : vector<1xi32>} : tensor<128x1xf32, #mma> -> tensor<128x256xf32, #mma>
+      %17 = arith.subf %12, %16 {async_task_id = dense<2> : vector<1xi32>} : tensor<128x256xf32, #mma>
+      %18 = arith.mulf %17, %17 {async_task_id = dense<2> : vector<1xi32>} : tensor<128x256xf32, #mma>
+      %19 = "tt.reduce"(%18) <{axis = 1 : i32}> ({
+      ^bb0(%arg13: f32, %arg14: f32):
+        %45 = arith.addf %arg13, %arg14 {async_task_id = dense<2> : vector<1xi32>} : f32
+        tt.reduce.return %45 {async_task_id = dense<2> : vector<1xi32>} : f32
+      }) {async_task_id = dense<2> : vector<1xi32>} : (tensor<128x256xf32, #mma>) -> tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+      %20 = arith.divf %19, %9 {async_task_id = dense<2> : vector<1xi32>} : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+      %21 = arith.addf %20, %10 {async_task_id = dense<2> : vector<1xi32>} : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+      %22 = math.sqrt %21 {async_task_id = dense<2> : vector<1xi32>} : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+      %23 = arith.divf %cst_0, %22 {async_task_id = dense<2> : vector<1xi32>} : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+      %24 = tt.experimental_descriptor_load %arg3[%c0_i32] {async_task_id = dense<2> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<256xf16, #blocked2>
+      %25 = tt.experimental_descriptor_load %arg4[%c0_i32] {async_task_id = dense<2> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<256xf16, #blocked2>
+      %26 = tt.expand_dims %23 {async_task_id = dense<2> : vector<1xi32>, axis = 1 : i32} : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>> -> tensor<128x1xf32, #mma>
+      %27 = tt.broadcast %26 {async_task_id = dense<2> : vector<1xi32>} : tensor<128x1xf32, #mma> -> tensor<128x256xf32, #mma>
+      %28 = arith.mulf %17, %27 {async_task_id = dense<2> : vector<1xi32>} : tensor<128x256xf32, #mma>
+      %29 = triton_gpu.convert_layout %24 {async_task_id = dense<2> : vector<1xi32>} : tensor<256xf16, #blocked2> -> tensor<256xf16, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+      %30 = tt.expand_dims %29 {async_task_id = dense<2> : vector<1xi32>, axis = 0 : i32} : tensor<256xf16, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x256xf16, #blocked1>
+      %31 = triton_gpu.convert_layout %30 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x256xf16, #blocked1> -> tensor<1x256xf16, #blocked3>
+      %32 = arith.extf %31 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x256xf16, #blocked3> to tensor<1x256xf32, #blocked3>
+      %33 = triton_gpu.convert_layout %32 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x256xf32, #blocked3> -> tensor<1x256xf32, #mma>
+      %34 = tt.broadcast %33 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x256xf32, #mma> -> tensor<128x256xf32, #mma>
+      %35 = arith.mulf %28, %34 {async_task_id = dense<2> : vector<1xi32>} : tensor<128x256xf32, #mma>
+      %36 = triton_gpu.convert_layout %25 {async_task_id = dense<2> : vector<1xi32>} : tensor<256xf16, #blocked2> -> tensor<256xf16, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+      %37 = tt.expand_dims %36 {async_task_id = dense<2> : vector<1xi32>, axis = 0 : i32} : tensor<256xf16, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x256xf16, #blocked1>
+      %38 = triton_gpu.convert_layout %37 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x256xf16, #blocked1> -> tensor<1x256xf16, #blocked3>
+      %39 = arith.extf %38 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x256xf16, #blocked3> to tensor<1x256xf32, #blocked3>
+      %40 = triton_gpu.convert_layout %39 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x256xf32, #blocked3> -> tensor<1x256xf32, #mma>
+      %41 = tt.broadcast %40 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x256xf32, #mma> -> tensor<128x256xf32, #mma>
+      %42 = arith.addf %35, %41 {async_task_id = dense<2> : vector<1xi32>} : tensor<128x256xf32, #mma>
+      %43 = arith.truncf %42 {async_task_id = dense<2> : vector<1xi32>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+      %44 = triton_gpu.convert_layout %43 {async_task_id = dense<2> : vector<1xi32>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
+      tt.experimental_descriptor_store %arg2[%11, %c0_i32], %44 {async_task_id = dense<2> : vector<1xi32>} : !tt.ptr<i8, 0>, tensor<128x256xf16, #blocked1>
+    } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>}
+    tt.return
+  }
+}
+
+// -----
+
+// Verify that we can reuse buffers between two for loops
+// CHECK-LABEL: @_attn_bwd_ws
+// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 0 : i32} : () -> !tt.memdesc<2x64x128xbf16
+// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 1 : i32} : () -> !tt.memdesc<2x64x128xbf16
+// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 0 : i32} : () -> !tt.memdesc<2x64x128xbf16
+// CHECK-DAG: triton_gpu.local_alloc  {allocation.shareGroup = 1 : i32} : () -> !tt.memdesc<2x64x128xbf16
+
+// CHECK: %[[TID:.*]] = triton_nvidia_gpu.get_async_task_id : i32
+// CHECK: %[[ZERO:.*]] = arith.constant 0 : i32
+// CHECK: %[[TWG0:.*]] = arith.cmpi eq, %[[TID]], %[[ZERO]] : i32
+// CHECK: scf.if %[[TWG0]]
+// CHECK: triton_nvidia_gpu.reg_dealloc 40
+// CHECK: scf.if
+// CHECK: scf.yield
+
+// CHECK: %[[IF_IDX:.*]] = scf.if
+// CHECK: arith.divui %c0{{.*}}
+// CHECK: arith.subi %c0{{.*}}
+// CHECK: scf.for
+// CHECK: scf.yield
+// CHECK: arith.addi
+// CHECK: %[[NEW_IDX:.*]] = arith.addi %c0
+// CHECK: scf.yield {{.*}} %[[NEW_IDX]]
+// CHECK: scf.yield {{.*}} %c0_
+
+// CHECK: scf.if
+// CHECK: arith.divui %[[IF_IDX]]
+// CHECK: arith.subi %[[IF_IDX]]
+// CHECK: scf.for
+// CHECK: scf.yield
+// CHECK: arith.addi
+// CHECK: %[[NEW_IDX2:.*]] = arith.addi %[[IF_IDX]]
+// CHECK: scf.yield {{.*}} %[[NEW_IDX2]]
+// CHECK: scf.yield {{.*}} %[[IF_IDX]]
+
+// CHECK: %[[ONE:.*]] = arith.constant 1 : i32
+// CHECK: %[[TWG1:.*]] = arith.cmpi eq, %[[TID]], %[[ONE]] : i32
+// CHECK: scf.if %[[TWG1]]
+// CHECK: triton_nvidia_gpu.reg_alloc 232
+// CHECK: scf.if
+// CHECK: scf.yield
+
+// CHECK: %[[IF_IDX_WG1:.*]] = scf.if
+// CHECK: arith.divui %c0{{.*}}
+// CHECK: arith.subi %c0{{.*}}
+// CHECK: scf.for
+// CHECK: scf.yield
+// CHECK: arith.addi
+// CHECK: %[[NEW_IDX_WG1:.*]] = arith.addi %c0
+// CHECK: scf.yield {{.*}} %[[NEW_IDX_WG1]]
+// CHECK: scf.yield {{.*}} %c0_
+
+// CHECK: scf.if
+// CHECK: arith.divui %[[IF_IDX_WG1]]
+// CHECK: arith.subi %[[IF_IDX_WG1]]
+// CHECK: scf.for
+// CHECK: scf.yield
+// CHECK: arith.addi
+// CHECK: %[[NEW_IDX2_WG1:.*]] = arith.addi %[[IF_IDX_WG1]]
+// CHECK: scf.yield {{.*}} %[[NEW_IDX2_WG1]]
+// CHECK: scf.yield {{.*}} %[[IF_IDX_WG1]]
+
+// CHECK: %[[TWO:.*]] = arith.constant 2 : i32
+// CHECK: %[[TWG2:.*]] = arith.cmpi eq, %[[TID]], %[[TWO]] : i32
+// CHECK: scf.if %[[TWG2]]
+// CHECK: triton_nvidia_gpu.reg_alloc 232
+// CHECK: scf.if
+// CHECK: scf.yield
+
+// CHECK: %[[IF_IDX_WG2:.*]] = scf.if
+// CHECK: arith.divui %c0{{.*}}
+// CHECK: arith.subi %c0{{.*}}
+// CHECK: scf.for
+// CHECK: scf.yield
+// CHECK: arith.addi
+// CHECK: %[[NEW_IDX_WG2:.*]] = arith.addi %c0
+// CHECK: scf.yield {{.*}} %[[NEW_IDX_WG2]]
+// CHECK: scf.yield {{.*}} %c0_
+
+// CHECK: scf.if
+// CHECK: arith.divui %[[IF_IDX_WG2]]
+// CHECK: arith.subi %[[IF_IDX_WG2]]
+// CHECK: scf.for
+// CHECK: scf.yield
+// CHECK: arith.addi
+// CHECK: %[[NEW_IDX2_WG2:.*]] = arith.addi %[[IF_IDX_WG2]]
+// CHECK: scf.yield {{.*}} %[[NEW_IDX2_WG2]]
+// CHECK: scf.yield {{.*}} %[[IF_IDX_WG2]]
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked3 = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 64, 16]}>
+#mma1 = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 16]}>
+#shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = true}>
+#shared1 = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [0, 1], hasLeadingOffset = true}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @_attn_bwd_ws(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg5: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg6: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg7: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg8: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg9: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg10: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg11: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg12: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg14: f32, %arg15: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg16: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %arg17: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg18: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg19: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg20: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg21: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg22: i32 {tt.divisibility = 16 : i32}, %arg23: i32 {tt.divisibility = 16 : i32}, %arg24: i32 {tt.divisibility = 16 : i32}, %arg25: i32 {tt.divisibility = 16 : i32}, %arg26: i32 {tt.divisibility = 16 : i32}, %arg27: i32 {tt.divisibility = 16 : i32}, %arg28: i32 {tt.divisibility = 16 : i32}, %arg29: i32, %arg30: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant {async_task_id = dense<[1, 2]> : vector<2xi32>} false
+    %cst = arith.constant {async_task_id = dense<[1, 2]> : vector<2xi32>} dense<0.000000e+00> : tensor<64x64xf32, #mma>
+    %cst_0 = arith.constant {async_task_id = dense<[1, 2]> : vector<2xi32>} dense<128> : tensor<1x128xi32, #blocked>
+    %c0_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 0 : i32
+    %c128_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 128 : i32
+    %c1_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 1 : i32
+    %c64_i64 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 64 : i64
+    %c63_i64 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 63 : i64
+    %c64_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 64 : i32
+    %c0_i64 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 0 : i64
+    %c1_i64 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 1 : i64
+    %cst_1 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} dense<0.000000e+00> : tensor<64x128xf32, #mma1>
+    %cst_2 = arith.constant {async_task_id = dense<[1, 2]> : vector<2xi32>} dense<0.693147182> : tensor<64x128xf32, #mma1>
+    %0 = tt.get_program_id z {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %1 = arith.divsi %0, %arg29 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %2 = arith.remsi %0, %arg29 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %3 = tt.get_program_id x {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %4 = tt.addptr %arg1, %1 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i64>, i32
+    %5 = tt.load %4 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i64>
+    %6 = tt.addptr %4, %c1_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i64>, i32
+    %7 = tt.load %6 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i64>
+    %8 = arith.subi %7, %5 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+    %9 = tt.addptr %arg3, %1 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i64>, i32
+    %10 = tt.load %9 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i64>
+    %11 = tt.addptr %9, %c1_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i64>, i32
+    %12 = tt.load %11 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i64>
+    %13 = arith.subi %12, %10 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+    %14 = arith.muli %3, %c128_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %15 = tt.make_range {async_task_id = dense<1> : vector<1xi32>, end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %16 = tt.make_range {async_task_id = dense<2> : vector<1xi32>, end = 128 : i32, start = 64 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %17 = tt.make_range {async_task_id = dense<1> : vector<1xi32>, end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked1>
+    %18 = tt.make_range {async_task_id = dense<2> : vector<1xi32>, end = 128 : i32, start = 64 : i32} : tensor<64xi32, #blocked1>
+    %19 = arith.extsi %14 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32 to i64
+    %20 = arith.cmpi sle, %19, %13 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+    %21 = arith.cmpi sle, %19, %8 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+    %22 = arith.ori %20, %21 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i1
+    %23:5 = scf.if %22 -> (!tt.ptr<bf16>, !tt.ptr<bf16>, !tt.ptr<bf16>, !tt.ptr<f32>, !tt.ptr<f32>) {
+      %27 = tt.addptr %arg16, %1 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i64>, i32
+      %28 = tt.load %27 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<i64>
+      %29 = arith.extsi %2 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32 to i64
+      %30 = arith.extsi %arg26 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32 to i64
+      %31 = arith.muli %29, %30 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+      %32 = arith.addi %31, %28 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+      %33 = arith.extsi %arg24 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32 to i64
+      %34 = arith.muli %29, %33 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+      %35 = arith.extsi %arg22 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32 to i64
+      %36 = arith.muli %5, %35 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+      %37 = arith.addi %34, %36 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+      %38 = arith.muli %2, %arg25 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %39 = arith.extsi %arg23 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32 to i64
+      %40 = arith.muli %10, %39 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+      %41 = arith.extsi %38 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32 to i64
+      %42 = arith.addi %41, %40 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+      %43 = tt.addptr %arg17, %37 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<bf16>, i64
+      %44 = tt.addptr %arg18, %42 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<bf16>, i64
+      %45 = tt.addptr %arg19, %42 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<bf16>, i64
+      %46 = tt.addptr %arg20, %32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<f32>, i64
+      %47 = tt.addptr %arg21, %32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : !tt.ptr<f32>, i64
+      scf.yield {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} %43, %44, %45, %46, %47 : !tt.ptr<bf16>, !tt.ptr<bf16>, !tt.ptr<bf16>, !tt.ptr<f32>, !tt.ptr<f32>
+    } else {
+      scf.yield {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} %arg17, %arg18, %arg19, %arg20, %arg21 : !tt.ptr<bf16>, !tt.ptr<bf16>, !tt.ptr<bf16>, !tt.ptr<f32>, !tt.ptr<f32>
+    } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>}
+    %24 = arith.extsi %14 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32 to i64
+    %25 = arith.cmpi slt, %24, %13 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+    scf.if %25 {
+      %27 = tt.splat %14 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %28 = tt.splat %14 {async_task_id = dense<2> : vector<1xi32>} : i32 -> tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %29 = arith.addi %27, %15 {async_task_id = dense<1> : vector<1xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %30 = arith.addi %28, %16 {async_task_id = dense<2> : vector<1xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %31 = arith.extsi %14 {async_task_id = dense<0> : vector<1xi32>} : i32 to i64
+      %32 = arith.addi %10, %31 {async_task_id = dense<0> : vector<1xi32>} : i64
+      %33 = arith.trunci %32 {async_task_id = dense<0> : vector<1xi32>} : i64 to i32
+      %34 = arith.addi %33, %c64_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %35 = arith.addi %33, %c64_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %36 = arith.muli %2, %arg25 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %37 = tt.experimental_descriptor_load %arg6[%33, %36] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+      %38 = tt.experimental_descriptor_load %arg6[%35, %36] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+      %39 = triton_gpu.local_alloc %37 {async_task_id = dense<1> : vector<1xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+      %40 = triton_gpu.local_alloc %38 {async_task_id = dense<2> : vector<1xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+      %41 = tt.experimental_descriptor_load %arg7[%33, %36] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+      %42 = tt.experimental_descriptor_load %arg7[%34, %36] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+      %43 = triton_gpu.local_alloc %41 {async_task_id = dense<1> : vector<1xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+      %44 = triton_gpu.local_alloc %42 {async_task_id = dense<2> : vector<1xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+      %45 = arith.addi %8, %c63_i64 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+      %46 = arith.divsi %45, %c64_i64 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+      %47 = arith.extsi %2 {async_task_id = dense<0> : vector<1xi32>} : i32 to i64
+      %48 = tt.make_range {async_task_id = dense<[1, 2]> : vector<2xi32>, end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+      %49 = arith.addi %5, %c64_i64 {async_task_id = dense<0> : vector<1xi32>} : i64
+      %50 = arith.trunci %49 {async_task_id = dense<0> : vector<1xi32>} : i64 to i32
+      %51 = arith.extsi %arg24 {async_task_id = dense<0> : vector<1xi32>} : i32 to i64
+      %52 = arith.muli %47, %51 {async_task_id = dense<0> : vector<1xi32>} : i64
+      %53 = arith.trunci %52 {async_task_id = dense<0> : vector<1xi32>} : i64 to i32
+      %54 = tt.splat %8 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i64 -> tensor<64xi64, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+      %55 = tt.splat %23#3 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+      %56 = tt.splat %arg14 {async_task_id = dense<1> : vector<1xi32>} : f32 -> tensor<64x64xf32, #mma>
+      %57 = tt.splat %arg14 {async_task_id = dense<2> : vector<1xi32>} : f32 -> tensor<64x64xf32, #mma>
+      %58 = tt.splat %23#4 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+      %59:3 = scf.for %arg31 = %c0_i64 to %46 step %c1_i64 iter_args(%arg32 = %c0_i32, %arg33 = %cst_1, %arg35 = %cst_1) -> (i32, tensor<64x128xf32, #mma1>, tensor<64x128xf32, #mma1>)  : i64 {
+        %111 = tt.splat %arg32 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32 -> tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+        %112 = arith.addi %111, %48 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+        %113 = tt.experimental_descriptor_load %arg5[%50, %53] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+        %114 = triton_gpu.local_alloc %113 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+        %115 = tt.trans %114 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory>
+        %116 = arith.extsi %112 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #mma}>> to tensor<64xi64, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+        %117 = arith.cmpi slt, %116, %54 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<64xi64, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+        %118 = tt.addptr %55, %112 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<64x!tt.ptr<f32>, #triton_gpu.slice<{dim = 0, parent = #mma}>>, tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+        %119 = tt.load %118, %117 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<64x!tt.ptr<f32>, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+        %120 = triton_nvidia_gpu.warp_group_dot %39, %115, %cst, %false {async_task_id = dense<1> : vector<1xi32>, inputPrecision = 0 : i32} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<64x64xf32, #mma>
+        %121 = triton_nvidia_gpu.warp_group_dot %40, %115, %cst, %false {async_task_id = dense<2> : vector<1xi32>, inputPrecision = 0 : i32} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<64x64xf32, #mma>
+        %122 = arith.mulf %120, %56 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %123 = arith.mulf %121, %57 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %124 = tt.experimental_descriptor_load %arg8[%50, %53] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+        %125 = triton_gpu.local_alloc %124 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+        %126 = tt.trans %125 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory>
+        %127 = triton_nvidia_gpu.warp_group_dot %43, %126, %cst, %false {async_task_id = dense<1> : vector<1xi32>, inputPrecision = 0 : i32} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<64x64xf32, #mma>
+        %128 = triton_nvidia_gpu.warp_group_dot %44, %126, %cst, %false {async_task_id = dense<2> : vector<1xi32>, inputPrecision = 0 : i32} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<64x64xf32, #mma>
+        %129 = tt.expand_dims %119 {async_task_id = dense<[1, 2]> : vector<2xi32>, axis = 0 : i32} : tensor<64xf32, #triton_gpu.slice<{dim = 0, parent = #mma}>> -> tensor<1x64xf32, #mma>
+        %130 = tt.broadcast %129 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x64xf32, #mma> -> tensor<64x64xf32, #mma>
+        %131 = tt.broadcast %129 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x64xf32, #mma> -> tensor<64x64xf32, #mma>
+        %132 = arith.subf %122, %130 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %133 = arith.subf %123, %131 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %134 = math.exp2 %132 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %135 = math.exp2 %133 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %136 = arith.truncf %134 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #mma> to tensor<64x64xbf16, #mma>
+        %137 = arith.truncf %135 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #mma> to tensor<64x64xbf16, #mma>
+        %138 = tt.addptr %58, %112 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<64x!tt.ptr<f32>, #triton_gpu.slice<{dim = 0, parent = #mma}>>, tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+        %139 = tt.load %138, %117 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<64x!tt.ptr<f32>, #triton_gpu.slice<{dim = 0, parent = #mma}>>
+        %140 = triton_gpu.convert_layout %136 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xbf16, #mma> -> tensor<64x64xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>>
+        %141 = triton_gpu.convert_layout %137 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xbf16, #mma> -> tensor<64x64xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>>
+        %142 = triton_nvidia_gpu.warp_group_dot %140, %125, %arg33 {async_task_id = dense<1> : vector<1xi32>, inputPrecision = 0 : i32} : tensor<64x64xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>> * !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> -> tensor<64x128xf32, #mma1>
+        %143 = triton_nvidia_gpu.warp_group_dot %141, %125, %arg35 {async_task_id = dense<2> : vector<1xi32>, inputPrecision = 0 : i32} : tensor<64x64xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>> * !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> -> tensor<64x128xf32, #mma1>
+        %157 = arith.addi %arg32, %c64_i32 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32
+        scf.yield {async_task_id = dense<[1, 2]> : vector<2xi32>} %157, %142, %143 : i32, tensor<64x128xf32, #mma1>, tensor<64x128xf32, #mma1>
+      } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>, tt.num_stages = 2 : i32}
+      %60 = tt.make_range {async_task_id = dense<[1, 2]> : vector<2xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %61 = tt.expand_dims %60 {async_task_id = dense<[1, 2]> : vector<2xi32>, axis = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x128xi32, #blocked>
+      %62 = arith.cmpi slt, %61, %cst_0 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x128xi32, #blocked>
+      %63 = tt.expand_dims %29 {async_task_id = dense<1> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+      %64 = tt.expand_dims %30 {async_task_id = dense<2> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+      %65 = arith.extsi %63 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xi32, #blocked> to tensor<64x1xi64, #blocked>
+      %66 = arith.extsi %64 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xi32, #blocked> to tensor<64x1xi64, #blocked>
+      %67 = tt.splat %13 {async_task_id = dense<1> : vector<1xi32>} : i64 -> tensor<64x1xi64, #blocked>
+      %68 = tt.splat %13 {async_task_id = dense<2> : vector<1xi32>} : i64 -> tensor<64x1xi64, #blocked>
+      %69 = arith.cmpi slt, %65, %67 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xi64, #blocked>
+      %70 = arith.cmpi slt, %66, %68 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xi64, #blocked>
+      %71 = tt.broadcast %62 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x128xi1, #blocked> -> tensor<64x128xi1, #blocked>
+      %72 = tt.broadcast %62 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x128xi1, #blocked> -> tensor<64x128xi1, #blocked>
+      %73 = tt.broadcast %69 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xi1, #blocked> -> tensor<64x128xi1, #blocked>
+      %74 = tt.broadcast %70 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xi1, #blocked> -> tensor<64x128xi1, #blocked>
+      %75 = arith.andi %71, %73 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xi1, #blocked>
+      %76 = arith.andi %72, %74 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xi1, #blocked>
+      %77 = tt.splat %arg23 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<64x1xi32, #blocked>
+      %78 = tt.splat %arg23 {async_task_id = dense<2> : vector<1xi32>} : i32 -> tensor<64x1xi32, #blocked>
+      %79 = arith.muli %63, %77 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xi32, #blocked>
+      %80 = arith.muli %64, %78 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xi32, #blocked>
+      %81 = tt.splat %23#2 {async_task_id = dense<1> : vector<1xi32>} : !tt.ptr<bf16> -> tensor<64x1x!tt.ptr<bf16>, #blocked>
+      %82 = tt.splat %23#2 {async_task_id = dense<2> : vector<1xi32>} : !tt.ptr<bf16> -> tensor<64x1x!tt.ptr<bf16>, #blocked>
+      %83 = tt.addptr %81, %79 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1x!tt.ptr<bf16>, #blocked>, tensor<64x1xi32, #blocked>
+      %84 = tt.addptr %82, %80 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1x!tt.ptr<bf16>, #blocked>, tensor<64x1xi32, #blocked>
+      %85 = tt.broadcast %83 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1x!tt.ptr<bf16>, #blocked> -> tensor<64x128x!tt.ptr<bf16>, #blocked>
+      %86 = tt.broadcast %84 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1x!tt.ptr<bf16>, #blocked> -> tensor<64x128x!tt.ptr<bf16>, #blocked>
+      %87 = tt.broadcast %61 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x128xi32, #blocked> -> tensor<64x128xi32, #blocked>
+      %88 = tt.broadcast %61 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x128xi32, #blocked> -> tensor<64x128xi32, #blocked>
+      %89 = tt.addptr %85, %87 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128x!tt.ptr<bf16>, #blocked>, tensor<64x128xi32, #blocked>
+      %90 = tt.addptr %86, %88 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128x!tt.ptr<bf16>, #blocked>, tensor<64x128xi32, #blocked>
+      %91 = arith.truncf %59#1 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xf32, #mma1> to tensor<64x128xbf16, #mma1>
+      %92 = arith.truncf %59#2 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xf32, #mma1> to tensor<64x128xbf16, #mma1>
+      %93 = triton_gpu.convert_layout %91 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xbf16, #mma1> -> tensor<64x128xbf16, #blocked>
+      %94 = triton_gpu.convert_layout %92 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xbf16, #mma1> -> tensor<64x128xbf16, #blocked>
+      tt.store %89, %93, %75 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128x!tt.ptr<bf16>, #blocked>
+      tt.store %90, %94, %76 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128x!tt.ptr<bf16>, #blocked>
+    } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>}
+    %26 = arith.cmpi slt, %24, %8 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+    scf.if %26 {
+      %27 = tt.splat %14 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %28 = tt.splat %14 {async_task_id = dense<2> : vector<1xi32>} : i32 -> tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %29 = tt.splat %14 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<64xi32, #blocked1>
+      %30 = tt.splat %14 {async_task_id = dense<2> : vector<1xi32>} : i32 -> tensor<64xi32, #blocked1>
+      %31 = arith.addi %27, %15 {async_task_id = dense<1> : vector<1xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %32 = arith.addi %28, %16 {async_task_id = dense<2> : vector<1xi32>} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %33 = arith.addi %29, %17 {async_task_id = dense<1> : vector<1xi32>} : tensor<64xi32, #blocked1>
+      %34 = arith.addi %30, %18 {async_task_id = dense<2> : vector<1xi32>} : tensor<64xi32, #blocked1>
+      %35 = arith.extsi %2 {async_task_id = dense<0> : vector<1xi32>} : i32 to i64
+      %36 = arith.extsi %14 {async_task_id = dense<0> : vector<1xi32>} : i32 to i64
+      %37 = arith.addi %5, %36 {async_task_id = dense<0> : vector<1xi32>} : i64
+      %38 = arith.trunci %37 {async_task_id = dense<0> : vector<1xi32>} : i64 to i32
+      %39 = arith.addi %38, %c64_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %40 = arith.addi %38, %c64_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %41 = arith.extsi %arg24 {async_task_id = dense<0> : vector<1xi32>} : i32 to i64
+      %42 = arith.muli %35, %41 {async_task_id = dense<0> : vector<1xi32>} : i64
+      %43 = arith.trunci %42 {async_task_id = dense<0> : vector<1xi32>} : i64 to i32
+      %44 = tt.experimental_descriptor_load %arg9[%38, %43] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+      %45 = tt.experimental_descriptor_load %arg9[%40, %43] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+      %46 = triton_gpu.local_alloc %44 {async_task_id = dense<1> : vector<1xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+      %47 = triton_gpu.local_alloc %45 {async_task_id = dense<2> : vector<1xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+      %48 = arith.extsi %arg28 {async_task_id = dense<0> : vector<1xi32>} : i32 to i64
+      %49 = arith.muli %35, %48 {async_task_id = dense<0> : vector<1xi32>} : i64
+      %50 = arith.trunci %49 {async_task_id = dense<0> : vector<1xi32>} : i64 to i32
+      %51 = tt.experimental_descriptor_load %arg12[%38, %50] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+      %52 = tt.experimental_descriptor_load %arg12[%39, %50] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+      %53 = triton_gpu.local_alloc %51 {async_task_id = dense<1> : vector<1xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+      %54 = triton_gpu.local_alloc %52 {async_task_id = dense<2> : vector<1xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+      %55 = arith.extsi %33 {async_task_id = dense<1> : vector<1xi32>} : tensor<64xi32, #blocked1> to tensor<64xi64, #blocked1>
+      %56 = arith.extsi %34 {async_task_id = dense<2> : vector<1xi32>} : tensor<64xi32, #blocked1> to tensor<64xi64, #blocked1>
+      %57 = tt.splat %8 {async_task_id = dense<1> : vector<1xi32>} : i64 -> tensor<64xi64, #blocked1>
+      %58 = tt.splat %8 {async_task_id = dense<2> : vector<1xi32>} : i64 -> tensor<64xi64, #blocked1>
+      %59 = arith.cmpi slt, %55, %57 {async_task_id = dense<1> : vector<1xi32>} : tensor<64xi64, #blocked1>
+      %60 = arith.cmpi slt, %56, %58 {async_task_id = dense<2> : vector<1xi32>} : tensor<64xi64, #blocked1>
+      %61 = tt.splat %23#3 {async_task_id = dense<1> : vector<1xi32>} : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked1>
+      %62 = tt.splat %23#3 {async_task_id = dense<2> : vector<1xi32>} : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked1>
+      %63 = tt.addptr %61, %33 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x!tt.ptr<f32>, #blocked1>, tensor<64xi32, #blocked1>
+      %64 = tt.addptr %62, %34 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x!tt.ptr<f32>, #blocked1>, tensor<64xi32, #blocked1>
+      %65 = tt.load %63, %59 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x!tt.ptr<f32>, #blocked1>
+      %66 = tt.load %64, %60 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x!tt.ptr<f32>, #blocked1>
+      %67 = triton_gpu.convert_layout %65 {async_task_id = dense<1> : vector<1xi32>} : tensor<64xf32, #blocked1> -> tensor<64xf32, #triton_gpu.slice<{dim = 1, parent = #blocked3}>>
+      %68 = triton_gpu.convert_layout %66 {async_task_id = dense<2> : vector<1xi32>} : tensor<64xf32, #blocked1> -> tensor<64xf32, #triton_gpu.slice<{dim = 1, parent = #blocked3}>>
+      %69 = tt.expand_dims %67 {async_task_id = dense<1> : vector<1xi32>, axis = 1 : i32} : tensor<64xf32, #triton_gpu.slice<{dim = 1, parent = #blocked3}>> -> tensor<64x1xf32, #blocked3>
+      %70 = tt.expand_dims %68 {async_task_id = dense<2> : vector<1xi32>, axis = 1 : i32} : tensor<64xf32, #triton_gpu.slice<{dim = 1, parent = #blocked3}>> -> tensor<64x1xf32, #blocked3>
+      %71 = arith.addi %13, %c63_i64 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+      %72 = arith.divsi %71, %c64_i64 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i64
+      %73 = tt.splat %23#4 {async_task_id = dense<1> : vector<1xi32>} : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked1>
+      %74 = tt.splat %23#4 {async_task_id = dense<2> : vector<1xi32>} : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked1>
+      %75 = tt.addptr %73, %33 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x!tt.ptr<f32>, #blocked1>, tensor<64xi32, #blocked1>
+      %76 = tt.addptr %74, %34 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x!tt.ptr<f32>, #blocked1>, tensor<64xi32, #blocked1>
+      %77 = tt.load %75, %59 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x!tt.ptr<f32>, #blocked1>
+      %78 = tt.load %76, %60 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x!tt.ptr<f32>, #blocked1>
+      %79 = arith.trunci %10 {async_task_id = dense<0> : vector<1xi32>} : i64 to i32
+      %80 = arith.muli %2, %arg25 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %81 = tt.splat %arg14 {async_task_id = dense<1> : vector<1xi32>} : f32 -> tensor<64x64xf32, #mma>
+      %82 = tt.splat %arg14 {async_task_id = dense<2> : vector<1xi32>} : f32 -> tensor<64x64xf32, #mma>
+      %83 = tt.broadcast %69 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xf32, #blocked3> -> tensor<64x64xf32, #blocked3>
+      %84 = tt.broadcast %70 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xf32, #blocked3> -> tensor<64x64xf32, #blocked3>
+      %85 = triton_gpu.convert_layout %83 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #blocked3> -> tensor<64x64xf32, #mma>
+      %86 = triton_gpu.convert_layout %84 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #blocked3> -> tensor<64x64xf32, #mma>
+      %87 = triton_gpu.convert_layout %77 {async_task_id = dense<1> : vector<1xi32>} : tensor<64xf32, #blocked1> -> tensor<64xf32, #triton_gpu.slice<{dim = 1, parent = #blocked3}>>
+      %88 = triton_gpu.convert_layout %78 {async_task_id = dense<2> : vector<1xi32>} : tensor<64xf32, #blocked1> -> tensor<64xf32, #triton_gpu.slice<{dim = 1, parent = #blocked3}>>
+      %89 = tt.expand_dims %87 {async_task_id = dense<1> : vector<1xi32>, axis = 1 : i32} : tensor<64xf32, #triton_gpu.slice<{dim = 1, parent = #blocked3}>> -> tensor<64x1xf32, #blocked3>
+      %90 = tt.expand_dims %88 {async_task_id = dense<2> : vector<1xi32>, axis = 1 : i32} : tensor<64xf32, #triton_gpu.slice<{dim = 1, parent = #blocked3}>> -> tensor<64x1xf32, #blocked3>
+      %91 = tt.broadcast %89 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xf32, #blocked3> -> tensor<64x64xf32, #blocked3>
+      %92 = tt.broadcast %90 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xf32, #blocked3> -> tensor<64x64xf32, #blocked3>
+      %93 = triton_gpu.convert_layout %91 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #blocked3> -> tensor<64x64xf32, #mma>
+      %94 = triton_gpu.convert_layout %92 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #blocked3> -> tensor<64x64xf32, #mma>
+      %95 = tt.splat %arg14 {async_task_id = dense<1> : vector<1xi32>} : f32 -> tensor<64x128xf32, #mma1>
+      %96 = tt.splat %arg14 {async_task_id = dense<2> : vector<1xi32>} : f32 -> tensor<64x128xf32, #mma1>
+      %97:2 = scf.for %arg31 = %c0_i64 to %72 step %c1_i64 iter_args(%arg32 = %cst_1, %arg33 = %cst_1) -> (tensor<64x128xf32, #mma1>, tensor<64x128xf32, #mma1>)  : i64 {
+        %135 = tt.experimental_descriptor_load %arg10[%79, %80] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+        %136 = triton_gpu.local_alloc %135 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+        %137 = tt.trans %136 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory>
+        %138 = tt.experimental_descriptor_load %arg11[%79, %80] {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<i8, 0> -> tensor<64x128xbf16, #blocked2>
+        %139 = triton_gpu.local_alloc %138 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<64x128xbf16, #blocked2>) -> !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory>
+        %140 = tt.trans %139 {async_task_id = dense<[1, 2]> : vector<2xi32>, order = array<i32: 1, 0>} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> -> !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory>
+        %141 = triton_nvidia_gpu.warp_group_dot %46, %137, %cst, %false {async_task_id = dense<1> : vector<1xi32>, inputPrecision = 0 : i32} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<64x64xf32, #mma>
+        %142 = triton_nvidia_gpu.warp_group_dot %47, %137, %cst, %false {async_task_id = dense<2> : vector<1xi32>, inputPrecision = 0 : i32} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<64x64xf32, #mma>
+        %143 = arith.mulf %141, %81 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %144 = arith.mulf %142, %82 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %145 = triton_nvidia_gpu.warp_group_dot %53, %140, %cst, %false {async_task_id = dense<1> : vector<1xi32>, inputPrecision = 0 : i32} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<64x64xf32, #mma>
+        %146 = triton_nvidia_gpu.warp_group_dot %54, %140, %cst, %false {async_task_id = dense<2> : vector<1xi32>, inputPrecision = 0 : i32} : !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<128x64xbf16, #shared1, #triton_gpu.shared_memory> -> tensor<64x64xf32, #mma>
+        %147 = arith.subf %143, %85 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %148 = arith.subf %144, %86 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %149 = math.exp2 %147 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %150 = math.exp2 %148 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %151 = arith.subf %145, %93 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %152 = arith.subf %146, %94 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %153 = arith.mulf %149, %151 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %154 = arith.mulf %150, %152 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #mma>
+        %155 = arith.truncf %153 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xf32, #mma> to tensor<64x64xbf16, #mma>
+        %156 = arith.truncf %154 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xf32, #mma> to tensor<64x64xbf16, #mma>
+        %157 = triton_gpu.convert_layout %155 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x64xbf16, #mma> -> tensor<64x64xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>>
+        %158 = triton_gpu.convert_layout %156 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x64xbf16, #mma> -> tensor<64x64xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>>
+        %159 = triton_nvidia_gpu.warp_group_dot %157, %136, %cst_1, %false {async_task_id = dense<1> : vector<1xi32>, inputPrecision = 0 : i32} : tensor<64x64xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>> * !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> -> tensor<64x128xf32, #mma1>
+        %160 = triton_nvidia_gpu.warp_group_dot %158, %136, %cst_1, %false {async_task_id = dense<2> : vector<1xi32>, inputPrecision = 0 : i32} : tensor<64x64xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>> * !tt.memdesc<64x128xbf16, #shared, #triton_gpu.shared_memory> -> tensor<64x128xf32, #mma1>
+        %161 = arith.mulf %159, %95 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xf32, #mma1>
+        %162 = arith.mulf %160, %96 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xf32, #mma1>
+        %163 = arith.addf %arg32, %161 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xf32, #mma1>
+        %164 = arith.addf %arg33, %162 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xf32, #mma1>
+        scf.yield {async_task_id = dense<[1, 2]> : vector<2xi32>} %163, %164 : tensor<64x128xf32, #mma1>, tensor<64x128xf32, #mma1>
+      } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>, tt.num_stages = 2 : i32}
+      %98 = tt.make_range {async_task_id = dense<[1, 2]> : vector<2xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %99 = tt.expand_dims %98 {async_task_id = dense<[1, 2]> : vector<2xi32>, axis = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x128xi32, #blocked>
+      %100 = arith.cmpi slt, %99, %cst_0 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x128xi32, #blocked>
+      %101 = tt.expand_dims %31 {async_task_id = dense<1> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+      %102 = tt.expand_dims %32 {async_task_id = dense<2> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+      %103 = arith.extsi %101 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xi32, #blocked> to tensor<64x1xi64, #blocked>
+      %104 = arith.extsi %102 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xi32, #blocked> to tensor<64x1xi64, #blocked>
+      %105 = tt.splat %8 {async_task_id = dense<1> : vector<1xi32>} : i64 -> tensor<64x1xi64, #blocked>
+      %106 = tt.splat %8 {async_task_id = dense<2> : vector<1xi32>} : i64 -> tensor<64x1xi64, #blocked>
+      %107 = arith.cmpi slt, %103, %105 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xi64, #blocked>
+      %108 = arith.cmpi slt, %104, %106 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xi64, #blocked>
+      %109 = tt.broadcast %100 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x128xi1, #blocked> -> tensor<64x128xi1, #blocked>
+      %110 = tt.broadcast %100 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x128xi1, #blocked> -> tensor<64x128xi1, #blocked>
+      %111 = tt.broadcast %107 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xi1, #blocked> -> tensor<64x128xi1, #blocked>
+      %112 = tt.broadcast %108 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xi1, #blocked> -> tensor<64x128xi1, #blocked>
+      %113 = arith.andi %109, %111 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xi1, #blocked>
+      %114 = arith.andi %110, %112 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xi1, #blocked>
+      %115 = tt.splat %arg22 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<64x1xi32, #blocked>
+      %116 = tt.splat %arg22 {async_task_id = dense<2> : vector<1xi32>} : i32 -> tensor<64x1xi32, #blocked>
+      %117 = arith.muli %101, %115 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1xi32, #blocked>
+      %118 = arith.muli %102, %116 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1xi32, #blocked>
+      %119 = tt.splat %23#0 {async_task_id = dense<1> : vector<1xi32>} : !tt.ptr<bf16> -> tensor<64x1x!tt.ptr<bf16>, #blocked>
+      %120 = tt.splat %23#0 {async_task_id = dense<2> : vector<1xi32>} : !tt.ptr<bf16> -> tensor<64x1x!tt.ptr<bf16>, #blocked>
+      %121 = tt.addptr %119, %117 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1x!tt.ptr<bf16>, #blocked>, tensor<64x1xi32, #blocked>
+      %122 = tt.addptr %120, %118 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1x!tt.ptr<bf16>, #blocked>, tensor<64x1xi32, #blocked>
+      %123 = tt.broadcast %121 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x1x!tt.ptr<bf16>, #blocked> -> tensor<64x128x!tt.ptr<bf16>, #blocked>
+      %124 = tt.broadcast %122 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x1x!tt.ptr<bf16>, #blocked> -> tensor<64x128x!tt.ptr<bf16>, #blocked>
+      %125 = tt.broadcast %99 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x128xi32, #blocked> -> tensor<64x128xi32, #blocked>
+      %126 = tt.broadcast %99 {async_task_id = dense<2> : vector<1xi32>} : tensor<1x128xi32, #blocked> -> tensor<64x128xi32, #blocked>
+      %127 = tt.addptr %123, %125 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128x!tt.ptr<bf16>, #blocked>, tensor<64x128xi32, #blocked>
+      %128 = tt.addptr %124, %126 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128x!tt.ptr<bf16>, #blocked>, tensor<64x128xi32, #blocked>
+      %129 = arith.mulf %97#0, %cst_2 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xf32, #mma1>
+      %130 = arith.mulf %97#1, %cst_2 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xf32, #mma1>
+      %131 = arith.truncf %129 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xf32, #mma1> to tensor<64x128xbf16, #mma1>
+      %132 = arith.truncf %130 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xf32, #mma1> to tensor<64x128xbf16, #mma1>
+      %133 = triton_gpu.convert_layout %131 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128xbf16, #mma1> -> tensor<64x128xbf16, #blocked>
+      %134 = triton_gpu.convert_layout %132 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128xbf16, #mma1> -> tensor<64x128xbf16, #blocked>
+      tt.store %127, %133, %113 {async_task_id = dense<1> : vector<1xi32>} : tensor<64x128x!tt.ptr<bf16>, #blocked>
+      tt.store %128, %134, %114 {async_task_id = dense<2> : vector<1xi32>} : tensor<64x128x!tt.ptr<bf16>, #blocked>
+    } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>}
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/WarpSpecialization/ws_data_partition.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/ws_data_partition.mlir
@@ -1,0 +1,136 @@
+// RUN: triton-opt %s -split-input-file --tritongpu-warp-spec-data-partition=num-consumer-groups=2 | FileCheck %s
+
+// CHECK-LABEL: @matmul_persistent_ws_cooperative_kernel
+// CHECK: %[[#GA1:]] = tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
+// CHECK: %[[#GA2:]] = tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
+// CHECK: %[[#LA1:]] = triton_gpu.local_alloc %[[#GA1]]
+// CHECK: %[[#LA2:]] = triton_gpu.local_alloc %[[#GA2]]
+// CHECK: %[[#GB:]] = tt.load {{.*}} : tensor<64x256x!tt.ptr<f16>
+// CHECK: %[[#LB:]] = triton_gpu.local_alloc %[[#GB]]
+// CHECK: %[[#C1:]] = triton_nvidia_gpu.warp_group_dot %[[#LA1]], %[[#LB]], {{.*}} : !tt.memdesc<64x64xf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<64x256xf16, #shared, #triton_gpu.shared_memory> -> tensor<64x256xf32, #mma>
+// CHECK: %[[#C2:]] = triton_nvidia_gpu.warp_group_dot %[[#LA2]], %[[#LB]], {{.*}} : !tt.memdesc<64x64xf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<64x256xf16, #shared, #triton_gpu.shared_memory> -> tensor<64x256xf32, #mma>
+// CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, #blocked1>
+// CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, #blocked1>
+
+
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = true}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_persistent_ws_cooperative_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant {async_task_id = dense<0> : vector<1xi32>} dense<64> : tensor<128x64xi32, #blocked>
+    %c0_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 0 : i32
+    %c1_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 1 : i32
+    %c255_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 255 : i32
+    %c63_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 63 : i32
+    %c64_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 64 : i32
+    %c256_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 256 : i32
+    %c128_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 128 : i32
+    %c8_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 8 : i32
+    %c127_i32 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} 127 : i32
+    %cst_0 = arith.constant {async_task_id = dense<0> : vector<1xi32>} dense<0.000000e+00> : tensor<128x64xf16, #blocked>
+    %cst_1 = arith.constant {async_task_id = dense<0> : vector<1xi32>} dense<0.000000e+00> : tensor<64x256xf16, #blocked1>
+    %cst_2 = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %0 = arith.addi %arg3, %c127_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %1 = arith.divsi %0, %c128_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %2 = arith.addi %arg4, %c255_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %3 = arith.divsi %2, %c256_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %4 = arith.muli %1, %3 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %5 = tt.get_program_id x {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %6 = tt.get_num_programs x {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %7 = arith.muli %3, %c8_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %8 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %9 = tt.make_range {async_task_id = dense<[1, 2]> : vector<2xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %10 = tt.splat %arg3 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %11 = tt.make_range {async_task_id = dense<[0, 1, 2]> : vector<3xi32>, end = 256 : i32, start = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %12 = tt.splat %arg4 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %13 = tt.splat %arg6 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<128x1xi32, #blocked>
+    %14 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+    %15 = tt.expand_dims %14 {async_task_id = dense<0> : vector<1xi32>, axis = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %16 = tt.broadcast %15 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x64xi32, #blocked> -> tensor<128x64xi32, #blocked>
+    %17 = tt.splat %arg0 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %18 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+    %19 = tt.expand_dims %18 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> -> tensor<64x1xi32, #blocked1>
+    %20 = tt.splat %arg7 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<64x1xi32, #blocked1>
+    %21 = arith.muli %19, %20 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi32, #blocked1>
+    %22 = tt.broadcast %21 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi32, #blocked1> -> tensor<64x256xi32, #blocked1>
+    %23 = tt.splat %arg1 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<f16> -> tensor<64x256x!tt.ptr<f16>, #blocked1>
+    %24 = arith.addi %arg5, %c63_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %25 = arith.divsi %24, %c64_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+    %26 = tt.expand_dims %14 {async_task_id = dense<0> : vector<1xi32>, axis = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %27 = tt.expand_dims %18 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> -> tensor<64x1xi32, #blocked1>
+    %28 = arith.muli %arg7, %c64_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+    %29 = tt.splat %28 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<64x256xi32, #blocked1>
+    %30 = tt.splat %arg8 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32 -> tensor<128x1xi32, #blocked1>
+    %31 = tt.splat %arg2 {async_task_id = dense<[1, 2]> : vector<2xi32>} : !tt.ptr<f16> -> tensor<128x1x!tt.ptr<f16>, #blocked1>
+    %32 = tt.splat %arg3 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32 -> tensor<128x1xi32, #blocked1>
+    %33 = tt.splat %arg4 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32 -> tensor<1x256xi32, #blocked1>
+    scf.for %arg9 = %5 to %4 step %6  : i32 {
+      %34 = arith.divsi %arg9, %7 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %35 = arith.muli %34, %c8_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %36 = arith.subi %1, %35 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %37 = arith.minsi %36, %c8_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %38 = arith.remsi %arg9, %7 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %39 = arith.remsi %38, %37 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %40 = arith.addi %35, %39 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %41 = arith.divsi %38, %37 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %42 = arith.muli %40, %c128_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %43 = tt.splat %42 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %44 = tt.splat %42 {async_task_id = dense<[1, 2]> : vector<2xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %45 = arith.addi %43, %8 {async_task_id = dense<0> : vector<1xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %46 = arith.addi %44, %9 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %47 = arith.remsi %45, %10 {async_task_id = dense<0> : vector<1xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %48 = arith.muli %41, %c256_i32 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32
+      %49 = tt.splat %48 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : i32 -> tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+      %50 = arith.addi %49, %11 {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} : tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+      %51 = arith.remsi %50, %12 {async_task_id = dense<0> : vector<1xi32>} : tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+      %52 = tt.expand_dims %47 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+      %53 = arith.muli %52, %13 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x1xi32, #blocked>
+      %54 = tt.broadcast %53 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x1xi32, #blocked> -> tensor<128x64xi32, #blocked>
+      %55 = arith.addi %54, %16 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x64xi32, #blocked>
+      %56 = tt.addptr %17, %55 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
+      %57 = tt.expand_dims %51 {async_task_id = dense<0> : vector<1xi32>, axis = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x256xi32, #blocked1>
+      %58 = tt.broadcast %57 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x256xi32, #blocked1> -> tensor<64x256xi32, #blocked1>
+      %59 = arith.addi %22, %58 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x256xi32, #blocked1>
+      %60 = tt.addptr %23, %59 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x256x!tt.ptr<f16>, #blocked1>, tensor<64x256xi32, #blocked1>
+      %true = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} true
+      %false = arith.constant {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} false
+      %61:3 = scf.for %arg10 = %c0_i32 to %25 step %c1_i32 iter_args(%arg11 = %cst_2, %arg12 = %56, %arg13 = %60) -> (tensor<128x256xf32, #mma>, tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<64x256x!tt.ptr<f16>, #blocked1>)  : i32 {
+        %76 = arith.muli %arg10, %c64_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+        %77 = arith.subi %arg5, %76 {async_task_id = dense<0> : vector<1xi32>} : i32
+        %78 = tt.splat %77 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<1x64xi32, #blocked>
+        %79 = arith.cmpi slt, %26, %78 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x64xi32, #blocked>
+        %80 = tt.broadcast %79 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x64xi1, #blocked> -> tensor<128x64xi1, #blocked>
+        %81 = tt.load %arg12, %80, %cst_0 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+        %82 = triton_gpu.local_alloc %81 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<128x64xf16, #blocked>) -> !tt.memdesc<128x64xf16, #shared, #triton_gpu.shared_memory>
+        %83 = tt.splat %77 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<64x1xi32, #blocked1>
+        %84 = arith.cmpi slt, %27, %83 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi32, #blocked1>
+        %85 = tt.broadcast %84 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x1xi1, #blocked1> -> tensor<64x256xi1, #blocked1>
+        %86 = tt.load %arg13, %85, %cst_1 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x256x!tt.ptr<f16>, #blocked1>
+        %87 = triton_gpu.local_alloc %86 {async_task_id = dense<[1, 2]> : vector<2xi32>} : (tensor<64x256xf16, #blocked1>) -> !tt.memdesc<64x256xf16, #shared, #triton_gpu.shared_memory>
+        %88 = triton_nvidia_gpu.warp_group_dot %82, %87, %arg11 {async_task_id = dense<[1, 2]> : vector<2xi32>, inputPrecision = 0 : i32} : !tt.memdesc<128x64xf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<64x256xf16, #shared, #triton_gpu.shared_memory> -> tensor<128x256xf32, #mma>
+        %89 = tt.addptr %arg12, %cst {async_task_id = dense<0> : vector<1xi32>} : tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<128x64xi32, #blocked>
+        %90 = tt.addptr %arg13, %29 {async_task_id = dense<0> : vector<1xi32>} : tensor<64x256x!tt.ptr<f16>, #blocked1>, tensor<64x256xi32, #blocked1>
+        scf.yield {async_task_id = dense<[0, 1, 2]> : vector<3xi32>} %88, %89, %90 : tensor<128x256xf32, #mma>, tensor<128x64x!tt.ptr<f16>, #blocked>, tensor<64x256x!tt.ptr<f16>, #blocked1>
+      } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>}
+      %62 = arith.truncf %61#0 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+      %63 = tt.expand_dims %46 {async_task_id = dense<[1, 2]> : vector<2xi32>, axis = 1 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> -> tensor<128x1xi32, #blocked1>
+      %64 = arith.muli %30, %63 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x1xi32, #blocked1>
+      %65 = tt.addptr %31, %64 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x1x!tt.ptr<f16>, #blocked1>, tensor<128x1xi32, #blocked1>
+      %66 = tt.expand_dims %50 {async_task_id = dense<[1, 2]> : vector<2xi32>, axis = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x256xi32, #blocked1>
+      %67 = tt.broadcast %65 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x1x!tt.ptr<f16>, #blocked1> -> tensor<128x256x!tt.ptr<f16>, #blocked1>
+      %68 = tt.broadcast %66 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x256xi32, #blocked1> -> tensor<128x256xi32, #blocked1>
+      %69 = tt.addptr %67, %68 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x256x!tt.ptr<f16>, #blocked1>, tensor<128x256xi32, #blocked1>
+      %70 = arith.cmpi slt, %63, %32 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x1xi32, #blocked1>
+      %71 = arith.cmpi slt, %66, %33 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x256xi32, #blocked1>
+      %72 = tt.broadcast %70 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x1xi1, #blocked1> -> tensor<128x256xi1, #blocked1>
+      %73 = tt.broadcast %71 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<1x256xi1, #blocked1> -> tensor<128x256xi1, #blocked1>
+      %74 = arith.andi %72, %73 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x256xi1, #blocked1>
+      %75 = triton_gpu.convert_layout %62 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
+      tt.store %69, %75, %74 {async_task_id = dense<[1, 2]> : vector<2xi32>} : tensor<128x256x!tt.ptr<f16>, #blocked1>
+    } {async_task_id = dense<[0, 1, 2]> : vector<3xi32>}
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/WarpSpecialization/ws_lowering.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/ws_lowering.mlir
@@ -1,0 +1,237 @@
+// RUN: triton-opt %s -split-input-file --tritongpu-warp-spec-lowering=num-consumer-groups=1 | FileCheck %s
+
+// CHECK:  %[[#PBARRIER:]] = triton_gpu.local_alloc  : () -> !tt.memdesc<1xi64
+// CHECK:  %[[#CBARRIER:]] = triton_gpu.local_alloc  : () -> !tt.memdesc<1xi64
+// CHECK:  %[[#]] = triton_gpu.memdesc_subview %[[#PBARRIER]][%c0_i32]
+// CHECK:  triton_nvidia_gpu.init_barrier %[[#]], 128
+// CHECK:  %[[#]] = triton_gpu.memdesc_subview %[[#CBARRIER]][%c0_i32]
+// CHECK:  triton_nvidia_gpu.init_barrier %[[#]], 1
+// CHECK:  scf.for
+// CHECK:  %[[#]] = triton_gpu.memdesc_subview %[[#CBARRIER]]
+// CHECK:  triton_nvidia_gpu.wait_barrier %[[#]]
+// CHECK:  triton_gpu.async_copy_global_to_local
+// CHECK:  triton_gpu.async_copy_global_to_local
+// CHECK:  %[[#]] = triton_gpu.memdesc_subview %[[#PBARRIER]]
+// CHECK:  triton_nvidia_gpu.mbarrier_arrive %[[#]]
+// CHECK:  scf.for
+// CHECK:  %[[#]] = triton_gpu.memdesc_subview %[[#PBARRIER]]
+// CHECK:  triton_nvidia_gpu.wait_barrier %[[#]]
+// CHECK:  triton_gpu.local_load
+// CHECK:  triton_gpu.local_load
+// CHECK:  tt.dot
+// CHECK:  %[[#]] = triton_gpu.memdesc_subview %[[#CBARRIER]]
+// CHECK:  triton_nvidia_gpu.mbarrier_arrive %[[#]]
+
+
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = true}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %0 = triton_gpu.local_alloc  : () -> !tt.memdesc<1x128x256xf16, #shared, #triton_gpu.shared_memory, mutable>
+    %1 = triton_gpu.local_alloc  : () -> !tt.memdesc<1x256x128xf16, #shared, #triton_gpu.shared_memory, mutable>
+    %2 = triton_nvidia_gpu.create_token {num = 1 : i32} : tensor<1x!triton_nvidia_gpu.token>
+    %3 = triton_nvidia_gpu.get_async_task_id : i32
+    %c0_i32 = arith.constant 0 : i32
+    %4 = arith.cmpi eq, %3, %c0_i32 : i32
+    scf.if %4 {
+      %c255_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 255 : i32
+      %c127_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 127 : i32
+      %c1_i32_0 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 1 : i32
+      %c0_i32_1 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 0 : i32
+      %cst = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} dense<0.000000e+00> : tensor<256x128xf16, #blocked>
+      %cst_2 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} dense<0.000000e+00> : tensor<128x256xf16, #blocked1>
+      %c8_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 8 : i32
+      %c128_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 128 : i32
+      %c256_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 256 : i32
+      %cst_3 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} dense<256> : tensor<128x256xi32, #blocked1>
+      %6 = tt.get_program_id x {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %7 = arith.addi %arg3, %c127_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %8 = arith.divsi %7, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %9 = arith.addi %arg4, %c127_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %10 = arith.divsi %9, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %11 = arith.muli %10, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %12 = arith.divsi %6, %11 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %13 = arith.muli %12, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %14 = arith.subi %8, %13 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %15 = arith.minsi %14, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %16 = arith.remsi %6, %11 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %17 = arith.remsi %16, %15 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %18 = arith.addi %13, %17 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %19 = arith.divsi %16, %15 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %20 = arith.muli %18, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %21 = tt.make_range {async_task_id = dense<[0, 1]> : vector<2xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %22 = tt.make_range {async_task_id = dense<[0, 1]> : vector<2xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %23 = tt.splat %20 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %24 = arith.addi %23, %21 {async_task_id = dense<[0, 1]> : vector<2xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %25 = tt.splat %arg3 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %26 = arith.remsi %24, %25 {async_task_id = dense<[0, 1]> : vector<2xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %27 = arith.muli %19, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %28 = tt.splat %27 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %29 = arith.addi %28, %22 {async_task_id = dense<[0, 1]> : vector<2xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %30 = tt.splat %arg4 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %31 = arith.remsi %29, %30 {async_task_id = dense<0> : vector<1xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %32 = tt.expand_dims %26 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> -> tensor<128x1xi32, #blocked1>
+      %33 = tt.splat %arg6 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<128x1xi32, #blocked1>
+      %34 = arith.muli %32, %33 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x1xi32, #blocked1>
+      %35 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 256 : i32, start = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+      %36 = tt.expand_dims %35 {async_task_id = dense<0> : vector<1xi32>, axis = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x256xi32, #blocked1>
+      %37 = tt.broadcast %34 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x1xi32, #blocked1> -> tensor<128x256xi32, #blocked1>
+      %38 = tt.broadcast %36 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x256xi32, #blocked1> -> tensor<128x256xi32, #blocked1>
+      %39 = arith.addi %37, %38 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x256xi32, #blocked1>
+      %40 = tt.splat %arg0 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<f16> -> tensor<128x256x!tt.ptr<f16>, #blocked1>
+      %41 = tt.addptr %40, %39 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x256x!tt.ptr<f16>, #blocked1>, tensor<128x256xi32, #blocked1>
+      %42 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 256 : i32, start = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %43 = tt.make_range {async_task_id = dense<0> : vector<1xi32>, end = 256 : i32, start = 0 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %44 = tt.expand_dims %42 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<256x1xi32, #blocked>
+      %45 = tt.expand_dims %43 {async_task_id = dense<0> : vector<1xi32>, axis = 1 : i32} : tensor<256xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<256x1xi32, #blocked>
+      %46 = tt.splat %arg7 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<256x1xi32, #blocked>
+      %47 = arith.muli %44, %46 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x1xi32, #blocked>
+      %48 = tt.expand_dims %31 {async_task_id = dense<0> : vector<1xi32>, axis = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x128xi32, #blocked>
+      %49 = tt.broadcast %47 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x1xi32, #blocked> -> tensor<256x128xi32, #blocked>
+      %50 = tt.broadcast %48 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x128xi32, #blocked> -> tensor<256x128xi32, #blocked>
+      %51 = arith.addi %49, %50 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x128xi32, #blocked>
+      %52 = tt.splat %arg1 {async_task_id = dense<0> : vector<1xi32>} : !tt.ptr<f16> -> tensor<256x128x!tt.ptr<f16>, #blocked>
+      %53 = tt.addptr %52, %51 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x128x!tt.ptr<f16>, #blocked>, tensor<256x128xi32, #blocked>
+      %54 = arith.addi %arg5, %c255_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %55 = arith.divsi %54, %c256_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %56 = arith.muli %arg7, %c256_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+      %57 = tt.splat %56 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<256x128xi32, #blocked>
+      %c1_i32_4 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 1 : i32
+      %c0_i32_5 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 0 : i32
+      %false = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} false
+      %58:4 = scf.for %arg9 = %c0_i32_1 to %55 step %c1_i32_0 iter_args(%arg10 = %41, %arg11 = %53, %arg12 = %false, %arg13 = %c0_i32_5) -> (tensor<128x256x!tt.ptr<f16>, #blocked1>, tensor<256x128x!tt.ptr<f16>, #blocked>, i1, i32)  : i32 {
+        %59 = arith.muli %arg9, %c256_i32 {async_task_id = dense<0> : vector<1xi32>} : i32
+        %60 = arith.subi %arg5, %59 {async_task_id = dense<0> : vector<1xi32>} : i32
+        %61 = tt.splat %60 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<1x256xi32, #blocked1>
+        %62 = arith.cmpi slt, %36, %61 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x256xi32, #blocked1>
+        %63 = tt.broadcast %62 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x256xi1, #blocked1> -> tensor<128x256xi1, #blocked1>
+        triton_nvidia_gpu.producer_acquire %2, %arg13, %false {async_task_id = dense<0> : vector<1xi32>} : tensor<1x!triton_nvidia_gpu.token>, i32, i1
+        %c0_i32_6 = arith.constant {async_task_id = dense<0> : vector<1xi32>} 0 : i32
+        %c1_i32_7 = arith.constant {async_task_id = dense<0> : vector<1xi32>} 1 : i32
+        %64 = triton_gpu.memdesc_subview %0[%arg13, %c0_i32_6, %c0_i32_6] {async_task_id = dense<0> : vector<1xi32>} : !tt.memdesc<1x128x256xf16, #shared, #triton_gpu.shared_memory, mutable> -> !tt.memdesc<128x256xf16, #shared, #triton_gpu.shared_memory, mutable>
+        %65 = triton_gpu.async_copy_global_to_local %arg10, %64 mask %63 other %cst_2 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x256x!tt.ptr<f16>, #blocked1> -> <128x256xf16, #shared, #triton_gpu.shared_memory, mutable>
+        %66 = tt.splat %60 {async_task_id = dense<0> : vector<1xi32>} : i32 -> tensor<256x1xi32, #blocked>
+        %67 = arith.cmpi slt, %45, %66 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x1xi32, #blocked>
+        %68 = tt.broadcast %67 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x1xi1, #blocked> -> tensor<256x128xi1, #blocked>
+        %c0_i32_8 = arith.constant {async_task_id = dense<0> : vector<1xi32>} 0 : i32
+        %c1_i32_9 = arith.constant {async_task_id = dense<0> : vector<1xi32>} 1 : i32
+        %69 = triton_gpu.memdesc_subview %1[%arg13, %c0_i32_8, %c0_i32_8] {async_task_id = dense<0> : vector<1xi32>} : !tt.memdesc<1x256x128xf16, #shared, #triton_gpu.shared_memory, mutable> -> !tt.memdesc<256x128xf16, #shared, #triton_gpu.shared_memory, mutable>
+        %70 = triton_gpu.async_copy_global_to_local %arg11, %69 mask %68 other %cst {async_task_id = dense<0> : vector<1xi32>} : tensor<256x128x!tt.ptr<f16>, #blocked> -> <256x128xf16, #shared, #triton_gpu.shared_memory, mutable>
+        triton_nvidia_gpu.producer_commit %2, %arg13 {async_task_id = dense<0> : vector<1xi32>} : tensor<1x!triton_nvidia_gpu.token>, i32
+        %71 = tt.addptr %arg10, %cst_3 {async_task_id = dense<0> : vector<1xi32>} : tensor<128x256x!tt.ptr<f16>, #blocked1>, tensor<128x256xi32, #blocked1>
+        %72 = tt.addptr %arg11, %57 {async_task_id = dense<0> : vector<1xi32>} : tensor<256x128x!tt.ptr<f16>, #blocked>, tensor<256x128xi32, #blocked>
+        %c1_i32_10 = arith.constant {async_task_id = dense<0> : vector<1xi32>} 1 : i32
+        %c0_i32_11 = arith.constant {async_task_id = dense<0> : vector<1xi32>} 0 : i32
+        %true = arith.constant {async_task_id = dense<0> : vector<1xi32>} true
+        %73 = arith.addi %arg13, %c1_i32_10 {async_task_id = dense<0> : vector<1xi32>} : i32
+        %74 = arith.cmpi uge, %73, %c1_i32_4 {async_task_id = dense<0> : vector<1xi32>} : i32
+        %75 = arith.cmpi ult, %73, %c1_i32_4 {async_task_id = dense<0> : vector<1xi32>} : i32
+        %76 = arith.subi %73, %c1_i32_4 {async_task_id = dense<0> : vector<1xi32>} : i32
+        %77 = arith.select %74, %76, %73 {async_task_id = dense<0> : vector<1xi32>} : i32
+        %78 = arith.xori %arg12, %true {async_task_id = dense<0> : vector<1xi32>} : i1
+        %79 = arith.andi %74, %78 {async_task_id = dense<0> : vector<1xi32>} : i1
+        %80 = arith.andi %75, %arg12 {async_task_id = dense<0> : vector<1xi32>} : i1
+        %81 = arith.ori %79, %80 {async_task_id = dense<0> : vector<1xi32>} : i1
+        scf.yield {async_task_id = dense<0> : vector<1xi32>} %71, %72, %81, %77 : tensor<128x256x!tt.ptr<f16>, #blocked1>, tensor<256x128x!tt.ptr<f16>, #blocked>, i1, i32
+      } {async_task_id = dense<0> : vector<1xi32>}
+    } {async_task_id = dense<0> : vector<1xi32>}
+    %c1_i32 = arith.constant 1 : i32
+    %5 = arith.cmpi eq, %3, %c1_i32 : i32
+    scf.if %5 {
+      %cst = arith.constant {async_task_id = dense<1> : vector<1xi32>} dense<0.000000e+00> : tensor<128x128xf32, #blocked2>
+      %c255_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 255 : i32
+      %c127_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 127 : i32
+      %c1_i32_0 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 1 : i32
+      %c0_i32_1 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 0 : i32
+      %cst_2 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} dense<0.000000e+00> : tensor<256x128xf16, #blocked>
+      %cst_3 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} dense<0.000000e+00> : tensor<128x256xf16, #blocked1>
+      %c8_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 8 : i32
+      %c128_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 128 : i32
+      %c256_i32 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 256 : i32
+      %cst_4 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} dense<256> : tensor<128x256xi32, #blocked1>
+      %6 = tt.get_program_id x {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %7 = arith.addi %arg3, %c127_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %8 = arith.divsi %7, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %9 = arith.addi %arg4, %c127_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %10 = arith.divsi %9, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %11 = arith.muli %10, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %12 = arith.divsi %6, %11 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %13 = arith.muli %12, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %14 = arith.subi %8, %13 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %15 = arith.minsi %14, %c8_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %16 = arith.remsi %6, %11 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %17 = arith.remsi %16, %15 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %18 = arith.addi %13, %17 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %19 = arith.divsi %16, %15 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %20 = arith.muli %18, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %21 = tt.make_range {async_task_id = dense<[0, 1]> : vector<2xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %22 = tt.make_range {async_task_id = dense<1> : vector<1xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %23 = tt.make_range {async_task_id = dense<[0, 1]> : vector<2xi32>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %24 = tt.splat %20 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %25 = tt.splat %20 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %26 = arith.addi %24, %21 {async_task_id = dense<[0, 1]> : vector<2xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %27 = arith.addi %25, %22 {async_task_id = dense<1> : vector<1xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+      %28 = tt.splat %arg3 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %29 = arith.remsi %26, %28 {async_task_id = dense<[0, 1]> : vector<2xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
+      %30 = arith.muli %19, %c128_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %31 = tt.splat %30 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32 -> tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %32 = arith.addi %31, %23 {async_task_id = dense<[0, 1]> : vector<2xi32>} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+      %33 = arith.addi %arg5, %c255_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %34 = arith.divsi %33, %c256_i32 {async_task_id = dense<[0, 1]> : vector<2xi32>} : i32
+      %c1_i32_5 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 1 : i32
+      %c0_i32_6 = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} 0 : i32
+      %false = arith.constant {async_task_id = dense<[0, 1]> : vector<2xi32>} false
+      %35:3 = scf.for %arg9 = %c0_i32_1 to %34 step %c1_i32_0 iter_args(%arg10 = %cst, %arg11 = %false, %arg12 = %c0_i32_6) -> (tensor<128x128xf32, #blocked2>, i1, i32)  : i32 {
+        %c0_i32_7 = arith.constant {async_task_id = dense<1> : vector<1xi32>} 0 : i32
+        %c1_i32_8 = arith.constant {async_task_id = dense<1> : vector<1xi32>} 1 : i32
+        %c0_i32_9 = arith.constant {async_task_id = dense<1> : vector<1xi32>} 0 : i32
+        %c1_i32_10 = arith.constant {async_task_id = dense<1> : vector<1xi32>} 1 : i32
+        triton_nvidia_gpu.consumer_wait %2, %arg12, %false {async_task_id = dense<1> : vector<1xi32>} : tensor<1x!triton_nvidia_gpu.token>, i32, i1
+        %54 = triton_gpu.memdesc_subview %0[%arg12, %c0_i32_7, %c0_i32_7] {async_task_id = dense<1> : vector<1xi32>} : !tt.memdesc<1x128x256xf16, #shared, #triton_gpu.shared_memory, mutable> -> !tt.memdesc<128x256xf16, #shared, #triton_gpu.shared_memory, mutable>
+        %55 = triton_gpu.local_load %54 {async_task_id = dense<1> : vector<1xi32>} : !tt.memdesc<128x256xf16, #shared, #triton_gpu.shared_memory, mutable> -> tensor<128x256xf16, #blocked1>
+        %56 = triton_gpu.convert_layout %55 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x256xf16, #blocked1> -> tensor<128x256xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked2}>>
+        %57 = triton_gpu.memdesc_subview %1[%arg12, %c0_i32_9, %c0_i32_9] {async_task_id = dense<1> : vector<1xi32>} : !tt.memdesc<1x256x128xf16, #shared, #triton_gpu.shared_memory, mutable> -> !tt.memdesc<256x128xf16, #shared, #triton_gpu.shared_memory, mutable>
+        %58 = triton_gpu.local_load %57 {async_task_id = dense<1> : vector<1xi32>} : !tt.memdesc<256x128xf16, #shared, #triton_gpu.shared_memory, mutable> -> tensor<256x128xf16, #blocked>
+        %59 = triton_gpu.convert_layout %58 {async_task_id = dense<1> : vector<1xi32>} : tensor<256x128xf16, #blocked> -> tensor<256x128xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked2}>>
+        %60 = tt.dot %56, %59, %arg10, inputPrecision = tf32 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x256xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked2}>> * tensor<256x128xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked2}>> -> tensor<128x128xf32, #blocked2>
+        triton_nvidia_gpu.consumer_release %2, %arg12 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x!triton_nvidia_gpu.token>, i32
+        %c1_i32_11 = arith.constant {async_task_id = dense<1> : vector<1xi32>} 1 : i32
+        %c0_i32_12 = arith.constant {async_task_id = dense<1> : vector<1xi32>} 0 : i32
+        %true = arith.constant {async_task_id = dense<1> : vector<1xi32>} true
+        %61 = arith.addi %arg12, %c1_i32_11 {async_task_id = dense<1> : vector<1xi32>} : i32
+        %62 = arith.cmpi uge, %61, %c1_i32_5 {async_task_id = dense<1> : vector<1xi32>} : i32
+        %63 = arith.cmpi ult, %61, %c1_i32_5 {async_task_id = dense<1> : vector<1xi32>} : i32
+        %64 = arith.subi %61, %c1_i32_5 {async_task_id = dense<1> : vector<1xi32>} : i32
+        %65 = arith.select %62, %64, %61 {async_task_id = dense<1> : vector<1xi32>} : i32
+        %66 = arith.xori %arg11, %true {async_task_id = dense<1> : vector<1xi32>} : i1
+        %67 = arith.andi %62, %66 {async_task_id = dense<1> : vector<1xi32>} : i1
+        %68 = arith.andi %63, %arg11 {async_task_id = dense<1> : vector<1xi32>} : i1
+        %69 = arith.ori %67, %68 {async_task_id = dense<1> : vector<1xi32>} : i1
+        scf.yield {async_task_id = dense<1> : vector<1xi32>} %60, %69, %65 : tensor<128x128xf32, #blocked2>, i1, i32
+      } {async_task_id = dense<1> : vector<1xi32>}
+      %36 = arith.truncf %35#0 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x128xf32, #blocked2> to tensor<128x128xf16, #blocked2>
+      %37 = tt.expand_dims %27 {async_task_id = dense<1> : vector<1xi32>, axis = 1 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+      %38 = tt.splat %arg8 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<128x1xi32, #blocked>
+      %39 = arith.muli %38, %37 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x1xi32, #blocked>
+      %40 = tt.splat %arg2 {async_task_id = dense<1> : vector<1xi32>} : !tt.ptr<f16> -> tensor<128x1x!tt.ptr<f16>, #blocked>
+      %41 = tt.addptr %40, %39 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x1x!tt.ptr<f16>, #blocked>, tensor<128x1xi32, #blocked>
+      %42 = tt.expand_dims %32 {async_task_id = dense<1> : vector<1xi32>, axis = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> -> tensor<1x128xi32, #blocked>
+      %43 = tt.broadcast %41 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x1x!tt.ptr<f16>, #blocked> -> tensor<128x128x!tt.ptr<f16>, #blocked>
+      %44 = tt.broadcast %42 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x128xi32, #blocked> -> tensor<128x128xi32, #blocked>
+      %45 = tt.addptr %43, %44 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x128x!tt.ptr<f16>, #blocked>, tensor<128x128xi32, #blocked>
+      %46 = tt.splat %arg3 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<128x1xi32, #blocked>
+      %47 = arith.cmpi slt, %37, %46 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x1xi32, #blocked>
+      %48 = tt.splat %arg4 {async_task_id = dense<1> : vector<1xi32>} : i32 -> tensor<1x128xi32, #blocked>
+      %49 = arith.cmpi slt, %42, %48 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x128xi32, #blocked>
+      %50 = tt.broadcast %47 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x1xi1, #blocked> -> tensor<128x128xi1, #blocked>
+      %51 = tt.broadcast %49 {async_task_id = dense<1> : vector<1xi32>} : tensor<1x128xi1, #blocked> -> tensor<128x128xi1, #blocked>
+      %52 = arith.andi %50, %51 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x128xi1, #blocked>
+      %53 = triton_gpu.convert_layout %36 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x128xf16, #blocked2> -> tensor<128x128xf16, #blocked>
+      tt.store %45, %53, %52 {async_task_id = dense<1> : vector<1xi32>} : tensor<128x128x!tt.ptr<f16>, #blocked>
+    } {async_task_id = dense<1> : vector<1xi32>}
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/WarpSpecialization/ws_task_partition.mlir
+++ b/test/TritonNvidiaGPU/WarpSpecialization/ws_task_partition.mlir
@@ -1,0 +1,64 @@
+// RUN: triton-opt %s -split-input-file --tritongpu-warp-spec-task-partition=num-consumer-groups=2 | FileCheck %s
+
+// CHECK-LABEL: @matmul_persistent_tma_ws_cooperative_kernel
+// CHECK: %[[#GA:]] = tt.experimental_descriptor_load {{.*}} {async_task_id = dense<0> : vector<1xi32>}
+// CHECK: %[[#LA:]] = triton_gpu.local_alloc %[[#GA]]
+// CHECK: %[[#GB:]] = tt.experimental_descriptor_load {{.*}} {async_task_id = dense<0> : vector<1xi32>}
+// CHECK: %[[#LB:]] = triton_gpu.local_alloc %[[#GB]]
+// CHECK: %[[#C:]] = triton_nvidia_gpu.warp_group_dot %[[#LA]], %[[#LB]], {{.*}} {async_task_id = dense<[1, 2]> : vector<2xi32>
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = true}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_persistent_tma_ws_cooperative_kernel(%arg0: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg1: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg2: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c127_i32 = arith.constant 127 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c256_i32 = arith.constant 256 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c63_i32 = arith.constant 63 : i32
+    %c255_i32 = arith.constant 255 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %0 = arith.addi %arg3, %c127_i32 : i32
+    %1 = arith.divsi %0, %c128_i32 : i32
+    %2 = arith.addi %arg4, %c255_i32 : i32
+    %3 = arith.divsi %2, %c256_i32 : i32
+    %4 = arith.muli %1, %3 : i32
+    %5 = tt.get_program_id x : i32
+    %6 = tt.get_num_programs x : i32
+    %7 = arith.muli %3, %c8_i32 : i32
+    %8 = arith.addi %arg5, %c63_i32 : i32
+    %9 = arith.divsi %8, %c64_i32 : i32
+    scf.for %arg6 = %5 to %4 step %6  : i32 {
+      %10 = arith.divsi %arg6, %7 : i32
+      %11 = arith.muli %10, %c8_i32 : i32
+      %12 = arith.subi %1, %11 : i32
+      %13 = arith.minsi %12, %c8_i32 : i32
+      %14 = arith.remsi %arg6, %7 : i32
+      %15 = arith.remsi %14, %13 : i32
+      %16 = arith.addi %11, %15 : i32
+      %17 = arith.divsi %14, %13 : i32
+      %18 = arith.muli %16, %c128_i32 : i32
+      %19 = arith.muli %17, %c256_i32 : i32
+      %true = arith.constant true
+      %false = arith.constant false
+      %20:2 = scf.for %arg7 = %c0_i32 to %9 step %c1_i32 iter_args(%arg8 = %cst, %arg9 = %c0_i32) -> (tensor<128x256xf32, #mma>, i32)  : i32 {
+        %23 = tt.experimental_descriptor_load %arg0[%18, %arg9] : !tt.ptr<i8, 0> -> tensor<128x64xf16, #blocked>
+        %24 = triton_gpu.local_alloc %23 : (tensor<128x64xf16, #blocked>) -> !tt.memdesc<128x64xf16, #shared, #triton_gpu.shared_memory>
+        %25 = tt.experimental_descriptor_load %arg1[%arg9, %19] : !tt.ptr<i8, 0> -> tensor<64x256xf16, #blocked1>
+        %26 = triton_gpu.local_alloc %25 : (tensor<64x256xf16, #blocked1>) -> !tt.memdesc<64x256xf16, #shared, #triton_gpu.shared_memory>
+        %27 = triton_nvidia_gpu.warp_group_dot %24, %26, %arg8 {inputPrecision = 0 : i32} : !tt.memdesc<128x64xf16, #shared, #triton_gpu.shared_memory> * !tt.memdesc<64x256xf16, #shared, #triton_gpu.shared_memory> -> tensor<128x256xf32, #mma>
+        %28 = arith.addi %arg9, %c64_i32 : i32
+        scf.yield %27, %28 : tensor<128x256xf32, #mma>, i32
+      }
+      %21 = arith.truncf %20#0 : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+      %22 = triton_gpu.convert_layout %21 : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
+      tt.experimental_descriptor_store %arg2[%18, %19], %22 : !tt.ptr<i8, 0>, tensor<128x256xf16, #blocked1>
+    }
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -31,6 +31,10 @@ class HIPOptions:
     waves_per_eu: int = 1
     num_stages: int = 2
     num_ctas: int = 1
+    num_buffers_warp_spec: int = 0
+    num_consumer_groups: int = 0
+    reg_dec_producer: int = 0
+    reg_inc_consumer: int = 0
     extern_libs: dict = None
     cluster_dims: tuple = (1, 1, 1)
     debug: bool = False

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -96,7 +96,7 @@ struct ConvertTritonAMDGPUToLLVM
     int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(mod);
     int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
 
-    // Hack: WSMaterialization may have changed the effective number of warps,
+    // Hack: WSLowering may have changed the effective number of warps,
     // in a way that isn't reflected in triton_gpu.num-warps.  If so, we have to
     // respect that here.
     if (Attribute attr = mod->getAttr("triton_gpu.num-warp-groups-per-cta")) {

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -93,6 +93,10 @@ class CUDAOptions:
     num_warps: int = 4
     num_ctas: int = 1
     num_stages: int = 3
+    num_buffers_warp_spec: int = 0
+    num_consumer_groups: int = 0
+    reg_dec_producer: int = 0
+    reg_inc_consumer: int = 0
     # maxnreg corresponds to the ptx parameter .maxnreg, which controls the
     # maximum number of 32-bit registers used by one thread.
     maxnreg: Optional[int] = None
@@ -227,7 +231,13 @@ class CUDABackend(BaseBackend):
         if capability // 10 >= 8:
             passes.ttgpuir.add_optimize_accumulator_init(pm)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
+            passes.ttgpuir.add_ws_task_partition(pm, opt.num_consumer_groups)
+            passes.ttgpuir.add_taskid_propagate(pm, opt.num_consumer_groups)
+            passes.ttgpuir.add_ws_data_partition(pm, opt.num_consumer_groups)
+            passes.ttgpuir.add_ws_code_partition(pm, opt.num_buffers_warp_spec, opt.num_consumer_groups,
+                                                 opt.reg_dec_producer, opt.reg_inc_consumer)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages)
+            passes.ttgpuir.add_ws_lowering(pm, opt.num_consumer_groups)
         passes.ttgpuir.add_prefetch(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, capability >= 80)
         passes.ttgpuir.add_remove_layout_conversions(pm)

--- a/third_party/nvidia/include/Dialect/NVGPU/IR/NVGPUOps.td
+++ b/third_party/nvidia/include/Dialect/NVGPU/IR/NVGPUOps.td
@@ -39,6 +39,7 @@ def NVGPU_WGMMAFenceOp : NVGPU_Op<"wgmma_fence", []> {
   let assemblyFormat = "attr-dict";
 }
 
+
 def NVGPU_WGMMACommitGroupOp : NVGPU_Op<"wgmma_commit_group", []> {
   let assemblyFormat = "attr-dict";
 }
@@ -50,6 +51,32 @@ def NVGPU_WGMMAWaitGroupOp : NVGPU_Op<"wgmma_wait_group",
   let results = (outs LLVM_AnyStruct:$output);
   let assemblyFormat = "attr-dict";
   let assemblyFormat = "$input attr-dict `:` type($input)";
+}
+
+def MBarrier_ArriveTypeAttr : I32EnumAttr<"MBarriveType",
+    "mbarrier arrive type, either 'normal', 'expect_tx', 'cp_async'",
+    [
+      I32EnumAttrCase<"normal", 0>,
+      I32EnumAttrCase<"cp_async", 1>,
+      I32EnumAttrCase<"expect_tx", 2>,
+      I32EnumAttrCase<"remote", 3>,
+    ]>{
+  let cppNamespace = "::mlir::triton::nvgpu";
+}
+
+def NVGPU_MBarrierArriveOp : NVGPU_Op<"mbarrier_arrive", []> {
+  let arguments = (ins LLVM_PointerShared:$mbarrier, I1:$pred, Optional<I32>:$ctaId, MBarrier_ArriveTypeAttr:$arriveType, DefaultValuedAttr<I32Attr, "0">:$txCount);
+  let assemblyFormat = "$mbarrier `,` $pred (`,` $ctaId^)? attr-dict `:` type($mbarrier)";
+}
+
+def NVGPU_NamedBarrierArriveOp : NVGPU_Op<"bar_arrive", []> {
+  let arguments = (ins I32:$bar, I32:$numThreads);
+  let assemblyFormat = "$bar `,` $numThreads attr-dict `:` type(operands)";
+}
+
+def NVGPU_NamedBarrierWaitOp : NVGPU_Op<"bar_wait", []> {
+  let arguments = (ins I32:$bar, I32:$numThreads);
+  let assemblyFormat = "$bar `,` $numThreads attr-dict `:` type(operands)";
 }
 
 def WGMMA_LayoutAttr : I32EnumAttr<"WGMMALayout",
@@ -109,6 +136,21 @@ def NVGPU_StoreMatrixOp : NVGPU_Op<"stmatrix", [MemoryEffects<[MemWrite]>]> {
 
 def NVGPU_ClusterCTAIdOp : NVGPU_Op<"cluster_id", [Pure]> {
   let results = (outs I32:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+def NVGPU_CanonicalWarpIdOp : NVGPU_Op<"canonical_warp_id", [Pure]> {
+  let results = (outs I32:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+def NVGPU_RegAllocOp : NVGPU_Op<"reg_alloc", []> {
+  let arguments = (ins I32Attr: $regCount);
+  let assemblyFormat = "attr-dict";
+}
+
+def NVGPU_RegDeallocOp : NVGPU_Op<"reg_dealloc", []> {
+  let arguments = (ins I32Attr: $regCount);
   let assemblyFormat = "attr-dict";
 }
 

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -38,6 +38,28 @@ const std::string Cluster_Cta_Id_Op = "{\n"
                                       "mad.lo.u32 a1, a2, a4, a1;     \n"
                                       "mad.lo.u32 $0, a1, a3, a0;     \n"
                                       "}";
+const std::string Reg_Alloc_Op = "setmaxnreg.inc.sync.aligned.u32 #regCount;";
+const std::string Reg_Dealloc_Op = "setmaxnreg.dec.sync.aligned.u32 #regCount;";
+
+const std::string Named_Barrier_Arrive_Op = "bar.arrive $0, $1;";
+const std::string Named_Barrier_Wait_Op = "bar.sync $0, $1;";
+const std::string Canonical_Warp_Id_Op =
+    "{\n"
+    ".reg .u32 a<5>;              \n"
+    "mov.u32 a0, %tid.x;          \n" // x
+    "mov.u32 a1, %tid.y;          \n" // y
+    "mov.u32 a2, %tid.z;          \n" // z
+    "mov.u32 a3, %ntid.x;         \n" // nx
+    "mov.u32 a4, %ntid.y;         \n" // ny
+    "mad.lo.u32 a1, a2, a4, a1;   \n"
+    "mad.lo.u32 a0, a1, a3, a0;   \n"
+    "shr.u32 a0, a0, 5;           \n"
+    ".reg .b32         %tmp<3>;   \n"
+    "mov.u32   %tmp0, -1;         \n"
+    "mov.u32   %tmp1, 31;         \n"
+    "mov.u32   %tmp2, 0;          \n"
+    "shfl.sync.idx.b32         $0, a0, %tmp2, %tmp1, %tmp0;           \n"
+    "}";
 
 bool isNumber(const std::string &s) {
   return !s.empty() && std::find_if(s.begin(), s.end(), [](unsigned char c) {
@@ -278,6 +300,77 @@ public:
   }
 };
 
+class MBarrierArriveOpPattern : public OpRewritePattern<ttn::MBarrierArriveOp> {
+public:
+  using OpRewritePattern<ttn::MBarrierArriveOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttn::MBarrierArriveOp op,
+                                PatternRewriter &rewriter) const override {
+    return rewriteAsPtxAsm(op, rewriter, getPtxAsm(op),
+                           getOperandsAndConstraints(op));
+  }
+
+  OperandsAndConstraints
+  getOperandsAndConstraints(ttn::MBarrierArriveOp op) const {
+    OperandsAndConstraints operandsAndTypes;
+    Value mbarrier = op.getMbarrier();
+    Value pred = op.getPred();
+    Value ctaId = op.getCtaId();
+    auto arriveType = op.getArriveType();
+
+    switch (arriveType) {
+    case ttn::MBarriveType::normal:
+    case ttn::MBarriveType::cp_async:
+    case ttn::MBarriveType::expect_tx:
+      operandsAndTypes.push_back({mbarrier, "r"});
+      operandsAndTypes.push_back({pred, "b"});
+      break;
+    case ttn::MBarriveType::remote:
+      operandsAndTypes.push_back({mbarrier, "r"});
+      operandsAndTypes.push_back({ctaId, "r"});
+      operandsAndTypes.push_back({pred, "b"});
+      break;
+    default:
+      llvm::errs() << "Unsupported mbarrier arrive type " << arriveType << "\n";
+      llvm_unreachable("");
+      break;
+    }
+    return operandsAndTypes;
+  }
+
+  std::string getPtxAsm(ttn::MBarrierArriveOp op) const {
+    Value ctaId = op.getCtaId();
+    auto arriveType = op.getArriveType();
+    uint32_t txCount = op.getTxCount();
+    std::string ptxAsm;
+    switch (arriveType) {
+    case ttn::MBarriveType::normal:
+      ptxAsm = "@$1 mbarrier.arrive.shared.b64 _, [$0];";
+      break;
+    case ttn::MBarriveType::cp_async:
+      ptxAsm = "@$1 cp.async.mbarrier.arrive.noinc.shared.b64 [$0];";
+      break;
+    case ttn::MBarriveType::expect_tx:
+      assert(txCount > 0 && "txCount should be valid");
+      ptxAsm = "@$1 mbarrier.arrive.expect_tx.shared.b64 _, [$0], " +
+               std::to_string(txCount) + ";";
+      break;
+    case ttn::MBarriveType::remote:
+      assert(ctaId && "ctaId should have a valid value");
+      ptxAsm =
+          " { .reg .b32 remAddr32;                                       \n"
+          "  @$2 mapa.shared::cluster.u32  remAddr32, $0, $1;            \n"
+          "  @$2 mbarrier.arrive.shared::cluster.b64  _, [remAddr32]; }  \n";
+      break;
+    default:
+      llvm::errs() << "Unsupported mbarrier arrive type " << arriveType << "\n";
+      llvm_unreachable("");
+      break;
+    }
+    return ptxAsm;
+  }
+};
+
 class WGMMAWaitGroupOpPattern : public OpRewritePattern<ttn::WGMMAWaitGroupOp> {
 public:
   using OpRewritePattern<ttn::WGMMAWaitGroupOp>::OpRewritePattern;
@@ -507,17 +600,25 @@ public:
 #define POPULATE_NVGPU_OP(SRC_OP, ASM)                                         \
   patterns.add<NVGPUOpGenericPattern<SRC_OP>>(context, ASM, Constraints(),     \
                                               Constraints());
+    POPULATE_NVGPU_OP(ttn::RegAllocOp, Reg_Alloc_Op)
     POPULATE_NVGPU_OP(ttn::WGMMAFenceOp, Wgmma_Fence_Op)
     POPULATE_NVGPU_OP(ttn::WGMMACommitGroupOp, Wgmma_Commit_Group_Op)
     POPULATE_NVGPU_OP(ttn::ClusterWaitOp, Cluster_Wait_Op)
+    POPULATE_NVGPU_OP(ttn::RegDeallocOp, Reg_Dealloc_Op)
 #undef POPULATE_NVGPU_OP
+    patterns.add<NVGPUOpGenericPattern<ttn::NamedBarrierArriveOp>>(
+        context, Named_Barrier_Arrive_Op, Constraints(),
+        Constraints({"r", "r"}));
+    patterns.add<NVGPUOpGenericPattern<ttn::NamedBarrierWaitOp>>(
+        context, Named_Barrier_Wait_Op, Constraints(), Constraints({"r", "r"}));
     patterns.add<NVGPUOpGenericPattern<ttn::ClusterCTAIdOp>>(
         context, Cluster_Cta_Id_Op, Constraints({"=r"}), Constraints());
+    patterns.add<NVGPUOpGenericPattern<ttn::CanonicalWarpIdOp>>(
+        context, Canonical_Warp_Id_Op, Constraints({"=r"}), Constraints());
 
-    patterns
-        .add<FenceAsyncSharedOpPattern, StoreMatrixOpPattern,
-             ClusterArriveOpPattern, WGMMAOpPattern, WGMMAWaitGroupOpPattern>(
-            context);
+    patterns.add<FenceAsyncSharedOpPattern, StoreMatrixOpPattern,
+                 MBarrierArriveOpPattern, ClusterArriveOpPattern,
+                 WGMMAOpPattern, WGMMAWaitGroupOpPattern>(context);
 
     if (applyPatternsAndFoldGreedily(mod, std::move(patterns)).failed())
       signalPassFailure();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -55,6 +55,77 @@ struct BarrierOpConversion
   }
 };
 
+// --------------------------------------------------------------------------
+// -- MBarrier related Ops lowering, to be moved to a separate file ---------
+// --------------------------------------------------------------------------
+struct MBarrierArriveOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::MBarrierArriveOp> {
+  using ConvertOpToLLVMPattern<
+      triton::nvidia_gpu::MBarrierArriveOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::MBarrierArriveOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    auto mbarrier = LLVM::getSharedMemoryObjectFromStruct(
+        op.getLoc(), adaptor.getMbarrier(),
+        typeConverter->convertType(op.getMbarrier().getType().getElementType()),
+        rewriter);
+
+    bool trackAsyncOp = op.getTrackAsyncOp();
+    triton::nvgpu::MBarriveType type = triton::nvgpu::MBarriveType::normal;
+    uint32_t txCount = op.getTxCount();
+    auto remoteCtaId = adaptor.getRemoteCtaId();
+    if (trackAsyncOp) {
+      type = triton::nvgpu::MBarriveType::cp_async;
+    } else if (remoteCtaId) {
+      assert(txCount == 0 &&
+             "remote arrive of transaction mbarrier is not implemented yet");
+      type = triton::nvgpu::MBarriveType::remote;
+    } else if (txCount > 0) {
+      type = triton::nvgpu::MBarriveType::expect_tx;
+    }
+    Value pred = adaptor.getPred();
+    if (pred == nullptr) {
+      pred = int_val(/*width*/ 1, 1);
+    }
+    rewriter.replaceOpWithNewOp<triton::nvgpu::MBarrierArriveOp>(
+        op, mbarrier.getBase(), pred, remoteCtaId, type, txCount);
+    return success();
+  }
+};
+
+struct NamedBarrierArriveOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::NamedBarrierArriveOp> {
+  using ConvertOpToLLVMPattern<
+      triton::nvidia_gpu::NamedBarrierArriveOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::NamedBarrierArriveOp op,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    rewriter.replaceOpWithNewOp<triton::nvgpu::NamedBarrierArriveOp>(
+        op, adaptor.getBar(), adaptor.getNumThreads());
+    return success();
+  }
+};
+
+struct NamedBarrierWaitOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::NamedBarrierWaitOp> {
+  using ConvertOpToLLVMPattern<
+      triton::nvidia_gpu::NamedBarrierWaitOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::NamedBarrierWaitOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    rewriter.replaceOpWithNewOp<triton::nvgpu::NamedBarrierWaitOp>(
+        op, adaptor.getBar(), adaptor.getNumThreads());
+    return success();
+  }
+};
+
 struct FenceAsyncSharedOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::FenceAsyncSharedOp> {
   using ConvertOpToLLVMPattern<
@@ -83,8 +154,18 @@ struct InitBarrierOpConversion
         typeConverter->convertType(op.getAlloc().getType().getElementType()),
         rewriter);
 
+    auto asyncTaskIds = getAsyncTaskIds(op);
+    int executingThreadId = 0;
+    if (!asyncTaskIds.empty()) {
+      assert(asyncTaskIds.size() == 1 && "only support single async task");
+      auto mod = op->getParentOfType<ModuleOp>();
+      int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
+      int warpSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
+      executingThreadId = asyncTaskIds[0] * numWarps * warpSize;
+    }
+
     auto id = getThreadId(rewriter, loc);
-    auto pred = icmp_eq(id, i32_val(0));
+    auto pred = icmp_eq(id, i32_val(executingThreadId));
     ::mlir::triton::PTXBuilder ptxBuilder;
     const std::string ptx = "@$0 mbarrier.init.shared::cta.b64 [$1], " +
                             std::to_string(op.getCount()) + ";";
@@ -112,8 +193,17 @@ struct InvalBarrierOpConversion
         typeConverter->convertType(op.getAlloc().getType().getElementType()),
         rewriter);
 
+    auto asyncTaskIds = getAsyncTaskIds(op);
+    int executingThreadId = 0;
+    if (!asyncTaskIds.empty()) {
+      assert(asyncTaskIds.size() == 1 && "only support single async task");
+      auto mod = op->getParentOfType<ModuleOp>();
+      int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
+      int warpSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
+      executingThreadId = asyncTaskIds[0] * numWarps * warpSize;
+    }
     auto id = getThreadId(rewriter, loc);
-    Value pred = icmp_eq(id, i32_val(0));
+    Value pred = icmp_eq(id, i32_val(executingThreadId));
     ::mlir::triton::PTXBuilder ptxBuilder;
     const std::string ptx = "@$0 mbarrier.inval.shared::cta.b64 [$1];";
     auto &barSyncOp = *ptxBuilder.create<>(ptx);
@@ -140,8 +230,17 @@ struct BarrierExpectConversion
         typeConverter->convertType(op.getAlloc().getType().getElementType()),
         rewriter);
 
+    auto asyncTaskIds = getAsyncTaskIds(op);
+    int executingThreadId = 0;
+    if (!asyncTaskIds.empty()) {
+      assert(asyncTaskIds.size() == 1 && "only support single async task");
+      auto mod = op->getParentOfType<ModuleOp>();
+      int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
+      int warpSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
+      executingThreadId = asyncTaskIds[0] * numWarps * warpSize;
+    }
     auto id = getThreadId(rewriter, loc);
-    Value pred = icmp_eq(id, i32_val(0));
+    Value pred = icmp_eq(id, i32_val(executingThreadId));
     pred = and_(pred, adaptor.getPred());
     ::mlir::triton::PTXBuilder ptxBuilder;
     const std::string ptx =
@@ -194,6 +293,9 @@ void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     PatternBenefit benefit) {
   patterns.add<BarrierOpConversion>(typeConverter, benefit);
+  patterns.add<MBarrierArriveOpConversion>(typeConverter, benefit);
+  patterns.add<NamedBarrierArriveOpConversion>(typeConverter, benefit);
+  patterns.add<NamedBarrierWaitOpConversion>(typeConverter, benefit);
   patterns.add<FenceAsyncSharedOpConversion>(typeConverter, benefit);
   patterns.add<InitBarrierOpConversion, InvalBarrierOpConversion>(typeConverter,
                                                                   benefit);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
@@ -19,6 +19,7 @@ add_triton_library(TritonNVIDIAGPUToLLVM
     Utility.cpp
     UpcastMXFPToLLVM.cpp
     TargetInfo.cpp
+    RegReallocOpToLLVM.cpp
 
     DEPENDS
     TritonNVIDIAGPUConversionPassIncGen

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -507,7 +507,7 @@ private:
       auto multiDimRepId =
           getMultiDimIndex<unsigned>(repId, numReplicates, outOrd);
       if (repId != 0) {
-        barrier();
+        insertBarrier(rewriter, op);
       }
 
       if (isLayoutMmaV1(srcLayout))
@@ -519,7 +519,7 @@ private:
                        multiDimRepId, inVec, paddedRepShape, origRepShape,
                        outOrd, vals, smemBase);
 
-      barrier();
+      insertBarrier(rewriter, op);
 
       if (isLayoutMmaV1(dstLayout))
         processReplicaForMMAV1(loc, rewriter, /*stNotRd*/ false, dstTy,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -9,6 +9,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -503,10 +504,11 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
   }
 };
 
-void createBarrier(ConversionPatternRewriter &rewriter, Location loc,
+void createBarrier(ConversionPatternRewriter &rewriter, Operation *op,
                    int numCTAs) {
+  auto loc = op->getLoc();
   if (numCTAs == 1) {
-    barrier();
+    insertBarrier(rewriter, op);
   } else {
     rewriter.create<triton::nvidia_gpu::ClusterArriveOp>(loc, false);
     rewriter.create<triton::nvidia_gpu::ClusterWaitOp>(loc);
@@ -619,7 +621,7 @@ struct AtomicCASOpConversion
         st(dstOprStore, valOprStore).predicate(mask);
         auto ASMReturnTy = void_ty(ctx);
         ptxBuilderStore.launch(rewriter, loc, ASMReturnTy);
-        createBarrier(rewriter, loc, numCTAs);
+        createBarrier(rewriter, op, numCTAs);
         Value ret = load(valueElemTy, atomPtr);
         rewriter.replaceOp(op, {ret});
       }
@@ -857,7 +859,7 @@ struct AtomicRMWOpConversion
         auto *valOpr = ptxBuilderStore.newOperand(old, tyId);
         storeShared(ptrOpr, valOpr).predicate(rmwMask);
         ptxBuilderStore.launch(rewriter, loc, void_ty(ctx));
-        createBarrier(rewriter, loc, numCTAs);
+        createBarrier(rewriter, op, numCTAs);
         Value ret = load(valueElemTy, atomPtr);
         rewriter.replaceOp(op, {ret});
       }
@@ -1067,6 +1069,13 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     if (rank > 1)
       numCopies = ceil<int>(contigDimSizeInByte, 128);
 
+    auto asyncTaskIds = getAsyncTaskIds(op);
+    int firstThreadId = 0;
+    if (!asyncTaskIds.empty()) {
+      assert(asyncTaskIds.size() == 1 && "only support single async task");
+      firstThreadId = asyncTaskIds[0] * numWarps * warpSize;
+    }
+
     // The bounding box inner dimension must be less than or equal to the
     // swizzle size.
     // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html#group__CUDA__TENSOR__MEMORY_1ga7c7d2aaac9e49294304e755e6f341d7
@@ -1076,8 +1085,9 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       int numWarpsToCopy = std::min(numCopies - copyIdx, numWarps);
       if (numWarpsToCopy == 1)
         warpID = i32_val(0);
-      Value boxPred =
-          and_(pred, icmp_ult(id, i32_val(numWarpsToCopy * warpSize)));
+      Value boxPred = and_(
+          pred,
+          icmp_ult(id, i32_val(numWarpsToCopy * warpSize + firstThreadId)));
       ::mlir::triton::PTXBuilder ptxBuilderTMA;
       Type elemPtrTy = ptr_ty(rewriter.getContext(), 3);
       Value copyIdxVal = add(warpID, i32_val(copyIdx));
@@ -1115,6 +1125,14 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     return success();
   }
 };
+
+int getWarpOffset(Operation *op) {
+  auto asyncTaskIds = getAsyncTaskIds(op);
+  if (asyncTaskIds.size() > 0) {
+    return 4 * *std::min_element(asyncTaskIds.begin(), asyncTaskIds.end());
+  }
+  return 0;
+}
 
 struct AsyncTMACopyLocalToGlobalOpConversion
     : public ConvertOpToLLVMPattern<
@@ -1161,6 +1179,9 @@ struct AsyncTMACopyLocalToGlobalOpConversion
       int numWarpsToCopy = std::min(numCopies - copyIdx, numWarps);
       if (numWarpsToCopy == 1)
         warpID = i32_val(0);
+      auto warpOffset = getWarpOffset(op);
+      warpID = sub(warpID, i32_val(warpOffset));
+      id = sub(id, i32_val(warpOffset * warpSize));
       Value boxPred =
           and_(pred, icmp_ult(id, i32_val(numWarpsToCopy * warpSize)));
       ::mlir::triton::PTXBuilder ptxBuilderTMA;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/RegReallocOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/RegReallocOpToLLVM.cpp
@@ -1,0 +1,47 @@
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "nvidia/include/Dialect/NVGPU/IR/Dialect.h"
+#include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+struct RegAllocOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::RegAllocOp> {
+  using ConvertOpToLLVMPattern<
+      triton::nvidia_gpu::RegAllocOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::RegAllocOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    rewriter.replaceOpWithNewOp<triton::nvgpu::RegAllocOp>(
+        op, adaptor.getRegCount());
+    return success();
+  }
+};
+
+struct RegDeallocOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::RegDeallocOp> {
+  using ConvertOpToLLVMPattern<
+      triton::nvidia_gpu::RegDeallocOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::RegDeallocOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    rewriter.replaceOpWithNewOp<triton::nvgpu::RegDeallocOp>(
+        op, adaptor.getRegCount());
+    return success();
+  }
+};
+} // namespace
+
+void mlir::triton::populateRegReallocOpToLLVMPatterns(
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    PatternBenefit benefit) {
+  patterns.add<RegAllocOpConversion>(typeConverter, benefit);
+  patterns.add<RegDeallocOpConversion>(typeConverter, benefit);
+  return;
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/SPMDOpToLLVM.cpp
@@ -1,5 +1,6 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "Utility.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
 namespace {
 
@@ -33,10 +34,25 @@ struct GetNumProgramsOpConversion
   }
 };
 
+struct GetCanonicalWarpIdConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::GetCanonicalWarpIdOp> {
+  using ConvertOpToLLVMPattern<
+      triton::nvidia_gpu::GetCanonicalWarpIdOp>::ConvertOpToLLVMPattern;
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::GetCanonicalWarpIdOp op,
+                  OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto warpIdOp = rewriter.create<triton::nvgpu::CanonicalWarpIdOp>(
+        op->getLoc(), rewriter.getI32Type());
+    rewriter.replaceOp(op, warpIdOp);
+    return success();
+  }
+};
 } // namespace
 
 void mlir::triton::NVIDIA::populateSPMDOpToLLVMPattern(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     PatternBenefit benefit) {
   patterns.add<GetNumProgramsOpConversion>(typeConverter, benefit);
+  patterns.add<GetCanonicalWarpIdConversion>(typeConverter, benefit);
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TMAToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TMAToLLVM.cpp
@@ -206,7 +206,7 @@ struct ExperimentalTensormapFenceproxyAcquireOpConversion
     // We run the fence on a single warp, then use a barrier to synchronize the
     // rest. This ends up being faster than running the fence on each warp.
     // TODO: Ideally we only emit one barrier after all fences are issued
-    rewriter.create<NVVM::Barrier0Op>(loc);
+    insertBarrier(rewriter, op);
 
     rewriter.eraseOp(op);
     return success();


### PR DESCRIPTION
Warp specialization enhances kernel performance by utilizing an asynchronous execution model, where different parts of the kernel are handled by separate hardware units. The data communication between these units, via shared memory on the H100, operates with high efficiency. With this in mind, we’ve developed an automatic warp specialization optimization that partitions a user kernel into asynchronous tasks (which map to warp groups on NVIDIA GPU), which naturally execute concurrently, leveraging the hardware’s multitasking warp scheduler.

To enable warp specialization, user just needs to specify certain autotune flags, i.e., `num_consumer_groups` and `num_buffers_warp_spec`. For example, a warp-specialized GEMM implementation might look like below. You can find a complete example in 09-persistent-matmul.py.

```python
@triton.autotune(
    configs=[
        triton.Config(
            {
                "BLOCK_SIZE_M": 128,
                "BLOCK_SIZE_N": 256,
                "BLOCK_SIZE_K": 64,
                "GROUP_SIZE_M": 8,
            },
            num_stages=2,
            num_warps=4,
            num_consumer_groups=2,
            num_buffers_warp_spec=3,
        ),
    ],
    key=["M", "N", "K"],
)
@triton.jit
def matmul_persistent_ws_kernel(
   a_ptr, b_ptr, c_ptr, M, N, K,
   stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
   BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
):
   pid = tl.program_id(axis=0)
   num_pid_m = tl.cdiv(M, BLOCK_M)
   num_pid_n = tl.cdiv(N, BLOCK_N)
   pid_m = pid // num_pid_m
   pid_n = pid % num_pid_n
   offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
   offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
   offs_k = tl.arange(0, BLOCK_K)
   a_ptrs = a_ptr + (offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak)
   b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn)
   acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
   for k in range(0, tl.cdiv(K, BLOCK_K)):
       a = tl.load(a_ptrs)
       b = tl.load(b_ptrs)
       acc += tl.dot(a, b)
       a_ptrs += BLOCK_K * stride_ak
       b_ptrs += BLOCK_K * stride_bk
   c = acc.to(tl.float16)
   c_ptrs = c_ptr + stride_cm * offs_m[:, None] + stride_cn * offs_n[None, :]
   tl.store(c_ptrs, c)
```

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
