### PR TITLE
[AMD][Atomic] Implement intrawave reduction algorithm for atomic operation

### DIFF
--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -252,3 +252,45 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 }
+
+// -----
+
+#blocked5 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: atomic_runtime_lds_reduction
+  tt.func @atomic_runtime_lds_reduction(%arg0 : tensor<64x!tt.ptr<f32>, #blocked5>, %arg2 : tensor<64xf32, #blocked5>) {
+    // CHECK: ptrtoint
+
+    // loop body:
+    // CHECK: llvm.bitcast
+    // CHECK-COUNT-2: llvm.amdgcn.readfirstlane
+    // CHECK: llvm.bitcast
+    // CHECK: llvm.amdgcn.ballot
+    // CHECK: rocdl.mbcnt.lo
+    // CHECK: rocdl.mbcnt.hi
+
+    // share info:
+    // 1. address
+    // CHECK: llvm.bitcast
+    // CHECK-COUNT-2: llvm.amdgcn.ds.permute
+    // CHECK: llvm.bitcast
+    // 2. value
+    // CHECK: llvm.bitcast
+    // CHECK: llvm.amdgcn.ds.permute
+    // CHECK: llvm.bitcast
+    // 3. packed methadata
+    // CHECK: llvm.bitcast
+    // CHECK: llvm.amdgcn.ds.permute
+    // CHECK: llvm.bitcast
+
+    // CHECK: llvm.amdgcn.ballot
+
+    // reduction:
+    // CHECK-COUNT-6: llvm.amdgcn.ds.bpermute
+
+    // CHECK: inttoptr
+    // CHECK: llvm.atomicrmw
+    %0 = tt.atomic_rmw fadd, relaxed, gpu, %arg0, %arg2 {allocation.offset = 0 : i32} : (tensor<64x!tt.ptr<f32>, #blocked5>, tensor<64xf32, #blocked5>) -> tensor<64xf32, #blocked5>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -955,6 +955,67 @@ Value shiftRightI32ByDpp(PatternRewriter &rewriter, Value val) {
   return generateI32DppMove(rewriter, val, 0x111); // shift right 1 lane
 }
 
+Value generatePopcount64(PatternRewriter &rewriter, Value val) {
+  auto loc = val.getLoc();
+  Value m1 = i64_val(0x5555555555555555); // binary: 0101 0101..
+  Value m2 = i64_val(0x3333333333333333); // binary: 0011 0011..
+  Value m4 = i64_val(0x0f0f0f0f0f0f0f0f); // binary: 0000 1111..
+  // binary: 0000 0001 0000 0001..
+  Value h01 = i64_val(0x0101010101010101);
+  // put count of each 2 bits into those 2 bits
+  val = sub(val, and_(m1, lshr(val, i64_val(1))));
+  // put count of each 4 bits into those 4 bits
+  val = add(and_(val, m2), and_(lshr(val, i64_val(2)), m2));
+  // put count of each 8 bits into those 8 bits
+  val = and_(add(val, lshr(val, i64_val(4))), m4);
+  // left 8 bits of x + (x<<8) + (x<<16) + (x<<24) + ...
+  return lshr(mul(val, h01), i64_val(56));
+}
+
+Value genReadFirstLane(PatternRewriter &rewriter, Value v) {
+  auto loc = v.getLoc();
+  std::string intrinsic = "llvm.amdgcn.readfirstlane";
+  return LLVM::createLLVMIntrinsicCallOp(rewriter, loc, intrinsic, i32_ty, v)
+      ->getResult(0);
+}
+
+Value genPermute(PatternRewriter &rewriter, Value v, Value dst) {
+  auto loc = v.getLoc();
+  std::string intrinsic = "llvm.amdgcn.ds.permute";
+  return LLVM::createLLVMIntrinsicCallOp(rewriter, loc, intrinsic, i32_ty,
+                                         ValueRange{dst, v})
+      ->getResult(0);
+}
+
+Value genBPermute(PatternRewriter &rewriter, Value v, Value dst) {
+  auto loc = v.getLoc();
+  std::string intrinsic = "llvm.amdgcn.ds.bpermute";
+  return LLVM::createLLVMIntrinsicCallOp(rewriter, loc, intrinsic, i32_ty,
+                                         ValueRange{dst, v})
+      ->getResult(0);
+}
+
+template <typename Generator, typename... Values>
+Value genI32TiledOp(PatternRewriter &rewriter, Generator genCall,
+                    Value argToSplit, Values... args) {
+  auto loc = argToSplit.getLoc();
+  Type ty = argToSplit.getType();
+  size_t tySize = ty.getIntOrFloatBitWidth();
+  size_t i32Size = i32_ty.getIntOrFloatBitWidth();
+  size_t count = tySize / i32Size;
+  assert(tySize % i32Size == 0 && count > 0 &&
+         "Unalligned types are not supported yet.");
+  Type i32VecValTy = vec_ty(i32_ty, count);
+  Value vec = undef(i32VecValTy);
+  Value valCasted = bitcast(argToSplit, i32VecValTy);
+  for (int i = 0; i < count; i++) {
+    Value subVal = extract_element(i32_ty, valCasted, i32_val(i));
+    Value result = genCall(rewriter, subVal, args...);
+    vec = insert_element(i32VecValTy, vec, result, i32_val(i));
+  }
+  return bitcast(vec, ty);
+}
+
 struct AtomicRMWOpConversion
     : public ConvertOpToLLVMPattern<triton::AtomicRMWOp>,
       public LoadStoreConversionBase {
@@ -1027,6 +1088,16 @@ struct AtomicRMWOpConversion
     auto vec = getVectorSize(ptr, axisAnalysisPass);
     int numElems = 1;
     Type packF16Ty = vec_ty(valueElemTy, 2);
+
+    // CDNA3 arch allows to accelerate its atomics with LDS reduction algorithm,
+    // which is only applicable for atomics with no return. Otherwise we have to
+    // deal with an additional overhead.
+    bool enableIntraWaveReduce =
+        targetInfo.getISAFamily() == triton::AMD::ISAFamily::CDNA3 &&
+        tensorTy && opResult.use_empty();
+
+    // TODO: support data types less than 32 bits
+    enableIntraWaveReduce &= valueElemNbits >= 32;
 
     // In the case of unpaired f16 elements utilize dpp instructions to
     // accelerate atomics. Here is an algorithm of lowering
@@ -1125,12 +1196,17 @@ struct AtomicRMWOpConversion
 
       rewriter.setInsertionPointToEnd(atomicBlock);
       auto maybeKind = matchAtomicOp(atomicRmwAttr);
-
-      Value atom = rewriter
-                       .create<LLVM::AtomicRMWOp>(loc, *maybeKind, rmwPtr,
-                                                  operand, atomicMemOrdering,
-                                                  StringRef(scopeStr.value()))
-                       .getResult();
+      Value atom;
+      if (enableIntraWaveReduce) {
+        atom = atomicIntraWaveReduce(rewriter, rmwPtr, operand, *maybeKind,
+                                     atomicMemOrdering, scopeStr.value());
+      } else {
+        atom = rewriter
+                   .create<LLVM::AtomicRMWOp>(loc, *maybeKind, rmwPtr, operand,
+                                              atomicMemOrdering,
+                                              StringRef(scopeStr.value()))
+                   .getResult();
+      }
 
       if (!tensorTy) {
         if (atomicNeedsSharedMemory(op.getResult())) {
@@ -1183,6 +1259,182 @@ struct AtomicRMWOpConversion
       rewriter.replaceOp(op, {resultStruct});
     }
     return success();
+  }
+
+private:
+  Value atomicIntraWaveReduce(PatternRewriter &rewriter, Value rmwPtr,
+                              Value operand, LLVM::AtomicBinOp opKind,
+                              LLVM::AtomicOrdering memOrdering,
+                              StringRef scope) const {
+    // This approach minimizes intra-warp thread contention when accessing
+    // global memory pointers. It is particularly advantageous for certain ISA
+    // families, such as CDNA3. The algorithm follows these steps:
+    // 1. Analyze thread groups and their relative positions:
+    // 1.1. Consider groups of threads sharing identical pointers using
+    //      `readfirstlane` and ballot `intrinsics`.
+    // 1.2. Compute parameters to form contiguous groups and further optimize
+    //      them.
+    // 1.3. Disable threads that have already been processed.
+    // 1.4. If thread was not considered, jump to `1.1.`.
+    // 2. Form contiguous groups:
+    //    Use `permute` instructions to organize threads within the wavefront
+    //    into continuous groups.
+    // 4. Reduce Groups to Leader threads:
+    //    Apply `bpermute` and operation-specific arithmetic based on the opKind
+    //    to consolidate group data into leader threads.
+    // 5. Perform global atomic operations by leader threads.
+    auto loc = operand.getLoc();
+    Type operandElemType = operand.getType();
+    Type origPtrType = rmwPtr.getType();
+
+    rmwPtr = ptrtoint(i64_ty, rmwPtr);
+
+    auto *curBlock = rewriter.getInsertionBlock();
+    auto *afterLoopBlock = curBlock->splitBlock(rewriter.getInsertionPoint());
+    afterLoopBlock->addArgument(i32_ty, loc);    // idx
+    afterLoopBlock->addArgument(i32_ty, loc);    // cnt
+    afterLoopBlock->addArgument(int_ty(1), loc); // isLeader
+    auto *loopBody = rewriter.createBlock(
+        curBlock->getParent(), std::next(Region::iterator(curBlock)));
+    loopBody->addArgument(i32_ty, loc); // base
+    rewriter.setInsertionPointToEnd(curBlock);
+    rewriter.create<LLVM::BrOp>(loc, i32_val(0), loopBody);
+
+    // Greed search of same addr within wavefront. Also collect auxiliary
+    // information about relative position:
+    // - idx in a group + base laneId. This param is required to form continuous
+    //   groups further;
+    // - cnt of remaining threads in a group after current thread;
+    // - leadership status of the current thread.
+    rewriter.setInsertionPointToEnd(loopBody);
+    // `readfirstlane` considers only enabled threads
+    Value chosen = genI32TiledOp(rewriter, genReadFirstLane, rmwPtr);
+    // this flag is required to disable thread if we have already checked its
+    // pointer
+    Value done = icmp_eq(chosen, rmwPtr);
+    Value mask = targetInfo.ballot(rewriter, loc, i64_ty, done);
+    Value start = loopBody->getArgument(0);
+    Value cnt = trunc(i32_ty, generatePopcount64(rewriter, mask));
+    Value mbcntLoRes = rewriter
+                           .create<ROCDL::MbcntLoOp>(
+                               loc, i32_ty, trunc(i32_ty, mask), i32_val(0))
+                           ->getResult(0);
+    Value idx = rewriter.create<ROCDL::MbcntHiOp>(
+        loc, i32_ty, trunc(i32_ty, lshr(mask, i64_val(32))), mbcntLoRes);
+    Value base = add(start, cnt);
+    Value leader = icmp_eq(idx, i32_val(0));
+    cnt = sub(cnt, idx);
+    idx = add(idx, start);
+    rewriter.create<LLVM::CondBrOp>(loc, done, afterLoopBlock,
+                                    ValueRange({idx, cnt, leader}), loopBody,
+                                    ValueRange({base}));
+
+    rewriter.setInsertionPointToEnd(afterLoopBlock);
+
+    Value idxRes = afterLoopBlock->getArgument(0);
+    Value cntRes = afterLoopBlock->getArgument(1);
+    Value leaderRes = afterLoopBlock->getArgument(2);
+    Value idxScaledForPermute = mul(idxRes, i32_val(4));
+
+    // Make groups continuous
+    rmwPtr = genI32TiledOp(rewriter, genPermute, rmwPtr, idxScaledForPermute);
+    operand = genI32TiledOp(rewriter, genPermute, operand, idxScaledForPermute);
+    // Actualize auxiliary info as well
+    Value packedRoleInfo =
+        genI32TiledOp(rewriter, genPermute,
+                      or_(zext(i32_ty, leaderRes),
+                          or_(idxScaledForPermute, shl(cntRes, i32_val(8)))),
+                      idxScaledForPermute);
+    idxScaledForPermute = packedRoleInfo;
+    cntRes = and_(lshr(packedRoleInfo, i32_val(8)), i32_val(0xff));
+    leaderRes = icmp_ne(and_(packedRoleInfo, i32_val(1)), i32_val(0));
+
+    auto *afterRedBlock =
+        afterLoopBlock->splitBlock(rewriter.getInsertionPoint());
+    afterRedBlock->addArgument(operandElemType, loc);
+    auto *partialReductionBlock =
+        rewriter.createBlock(afterLoopBlock->getParent(),
+                             std::next(Region::iterator(afterLoopBlock)));
+    rewriter.setInsertionPointToEnd(afterLoopBlock);
+    Value reductionCond = icmp_ne(
+        targetInfo.ballot(rewriter, loc, i64_ty, icmp_ne(cntRes, i32_val(1))),
+        i64_val(0));
+    rewriter.create<LLVM::CondBrOp>(loc, reductionCond, partialReductionBlock,
+                                    afterRedBlock, operand);
+    rewriter.setInsertionPointToEnd(partialReductionBlock);
+
+    auto performOpIfCond = [&](Value res, Value v, Value cond) -> Value {
+      Type ty = v.getType();
+      assert(ty == res.getType());
+      Value notCond = icmp_eq(cond, false_val());
+      switch (opKind) {
+      case LLVM::AtomicBinOp::_and:
+        // res &= cond ? v : 1111..
+        return and_(res, or_(v, sub(int_val(ty.getIntOrFloatBitWidth(), 0),
+                                    zext(ty, notCond))));
+      case LLVM::AtomicBinOp::_or:
+        // res |= cond ? v : 0
+        return or_(res, mul(v, zext(ty, cond)));
+      case LLVM::AtomicBinOp::_xor:
+        // res ^= cond ? v : 0
+        return xor_(res, mul(v, zext(ty, cond)));
+      case LLVM::AtomicBinOp::add:
+        // res += cond ? v : 0
+        return add(res, mul(v, zext(ty, cond)));
+      case LLVM::AtomicBinOp::fadd:
+        // res += cond ? v : 0
+        return fadd(
+            res, fmul(v, inttofloat(ty, zext(int_ty(ty.getIntOrFloatBitWidth()),
+                                             cond))));
+      case LLVM::AtomicBinOp::max:
+      case LLVM::AtomicBinOp::umax:
+        // res = cond ? umax(v, res) : res
+        return or_(mul(res, zext(ty, notCond)),
+                   mul(umax(v, res), zext(ty, cond)));
+      case LLVM::AtomicBinOp::min:
+      case LLVM::AtomicBinOp::umin:
+        // res = cond ? umin(v, res) : res
+        return or_(mul(res, zext(ty, notCond)),
+                   mul(umin(v, res), zext(ty, cond)));
+      case LLVM::AtomicBinOp::xchg:
+        // res = cond ? v : res
+        return or_(mul(res, zext(ty, notCond)), mul(v, zext(ty, cond)));
+      default:
+        llvm_unreachable("Unsupported atomic binary operation.");
+      }
+    };
+    Value acc = operand;
+    // Reduce to leader thread
+    for (int i = 32; i != 0; i /= 2) {
+      Value tmp = genI32TiledOp(rewriter, genBPermute, acc,
+                                add(idxScaledForPermute, i32_val(i * 4)));
+      acc = performOpIfCond(acc, tmp, icmp_ult(i32_val(i), cntRes));
+    }
+
+    rewriter.create<LLVM::BrOp>(loc, acc, afterRedBlock);
+    rewriter.setInsertionPointToEnd(afterRedBlock);
+
+    auto *endBlock = afterRedBlock->splitBlock(rewriter.getInsertionPoint());
+    endBlock->addArgument(operandElemType, loc);
+    auto *leaderBlock = rewriter.createBlock(
+        afterRedBlock->getParent(), std::next(Region::iterator(afterRedBlock)));
+    rewriter.setInsertionPointToEnd(afterRedBlock);
+    Value leaderCond = leaderRes;
+    Value defaultRes = undef(operandElemType);
+    rewriter.create<LLVM::CondBrOp>(loc, leaderCond, leaderBlock, endBlock,
+                                    defaultRes);
+    rewriter.setInsertionPointToEnd(leaderBlock);
+    // Utilize global atomic only by leader threads
+    rmwPtr = inttoptr(origPtrType, rmwPtr);
+    Value atom = rewriter
+                     .create<LLVM::AtomicRMWOp>(loc, opKind, rmwPtr,
+                                                afterRedBlock->getArgument(0),
+                                                memOrdering, scope)
+                     .getResult();
+    rewriter.create<LLVM::BrOp>(loc, atom, endBlock);
+    rewriter.setInsertionPointToStart(endBlock);
+
+    return endBlock->getArgument(0);
   }
 };
 } // namespace


### PR DESCRIPTION
- Does not require shared memory
- Grouping is done using O(n) algorithm

Algorithm description:
1. Detect groups and gather additional info related to relative position within the group
   in a greedy maner within a single wavefront
2. Rearange data between threads to form continuous groups using `permute` instructions
3. Reduce groups to their leading threads via `bpermute` instructions
4. Leading threads perform global atomic operation