### PR TITLE
Fix bug in upcast mxfp -> fp16

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3582,8 +3582,6 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
         if cc < (8, 9):
             pytest.skip("float8e4nv not supported on CUDA < 8.9")
     if is_hip():
-        if normal_type == "fp16":
-            pytest.skip("scaled_dot with fp16 input might have bugs on AMD")
         if not is_hip_cdna():
             pytest.skip("scaled_dot only implemented for HIP CDNA")
         if "e4m3" in (mxfp_type, normal_type):

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
@@ -291,7 +291,7 @@ public:
           int index = 32 * i + j;
           xVals[index] = useFp16
                              ? mxfpScaleFp16(rewriter, loc, xVals[index],
-                                             si[j / 16], op.getFastMath())
+                                             si[j / 8], op.getFastMath())
                              : mxfpScaleBf16ViaF32(rewriter, loc, xVals[index],
                                                    si[j / 8], op.getFastMath());
         }


### PR DESCRIPTION
A minor bug used the same logic for sharing scales between threads in both the MFMA16 and MFMA32 paths. Needed a div by 8 for the MFMA16 path instead of 16 (used for the MFMA32 path).

Also enable AMD tests for `test_scaled_dot`.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because I enabled pre-existing tests for AMD. These tests were skipped due to a bug that is fixed in this PR so these tests are now re-enabled.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
