### PR TITLE
Ensured that dtype subclasses are hashable

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -513,6 +513,11 @@ def test_dtype_codegen():
         assert repr(eval(full_name)) == full_name
 
 
+@pytest.mark.parameterize("dtype", [tl.pointer_type(tl.int8), tl.block_type(tl.int8, [42])])
+def test_dtype_is_hashable(dtype):
+    hash(dtype)
+
+
 # ---------------
 # test binary ops
 # ---------------

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -594,6 +594,8 @@ class pointer_type(dtype):
     def __ne__(self, other: pointer_type) -> bool:
         return not self.__eq__(other)
 
+    __hash__ = dtype.__hash__
+
     @property
     def scalar(self):
         return self
@@ -645,6 +647,8 @@ class block_type(dtype):
 
     def __ne__(self, other: block_type) -> bool:
         return not self.__eq__(other)
+
+    __hash__ = dtype.__hash__
 
     @property
     def scalar(self):


### PR DESCRIPTION
Python data model requires a class to implement both `__eq__` **and**
`__hash__` to be considered hashable. If a class only implements
`__eq__`, it gets an auto-generated `__hash__ = None`, which makes
it non-hashable.

So, as things stand, `tl.pointer_type` and `tl.block_type` instances fail
to hash. The fix is to define `__hash__` explicitly in the class body, as
suggested in [*]:

> If a class that overrides `__eq__` needs to retain the implementation of
> `__hash__` from a parent class, the interpreter must be told this explicitly
> by setting `__hash__ = <ParentClass>.__hash__`.

[*]: https://docs.python.org/3/reference/datamodel.html#object.__hash__

---

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
