### PR TITLE
[AMD] Quick fix to the regression with pingpong

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -162,13 +162,9 @@ LogicalResult Pingponger::genLocalSlice(OpBuilder &builder, Value v,
     return failure();
   auto dotOperandEnc = ttg::DotOperandEncodingAttr::get(
       builder.getContext(), opIdx, dotEncoding, kWidth);
-  SmallVector<int64_t> allocShape = llvm::to_vector(type.getAllocShape());
-  for (int i = allocShape.size(); i < 3; ++i)
-    allocShape.insert(allocShape.begin(), 1);
-
   auto subviewDescType = ttg::MemDescType::get(
       shape, elementType, type.getEncoding(), type.getMemorySpace(),
-      type.getMutableMemory(), allocShape);
+      type.getMutableMemory(), type.getAllocShape());
   for (int i = 0; i < numSlices; i++) {
     SmallVector<Value> offsetsVal;
     SmallVector<int64_t> offsets = {0, 0};

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -162,8 +162,13 @@ LogicalResult Pingponger::genLocalSlice(OpBuilder &builder, Value v,
     return failure();
   auto dotOperandEnc = ttg::DotOperandEncodingAttr::get(
       builder.getContext(), opIdx, dotEncoding, kWidth);
+  SmallVector<int64_t> allocShape = llvm::to_vector(type.getAllocShape());
+  for (int i = allocShape.size(); i < 3; ++i)
+    allocShape.insert(allocShape.begin(), 1);
+
   auto subviewDescType = ttg::MemDescType::get(
-      shape, elementType, type.getEncoding(), type.getMemorySpace());
+      shape, elementType, type.getEncoding(), type.getMemorySpace(),
+      type.getMutableMemory(), allocShape);
   for (int i = 0; i < numSlices; i++) {
     SmallVector<Value> offsetsVal;
     SmallVector<int64_t> offsets = {0, 0};


### PR DESCRIPTION
It has been broken since #5625, GEMM generates incorrect result with pingpong enabled.
Fixed by updating the way creating MemDescType for the subviews.
