### PR TITLE
Disable run on schedule for Manylinux 2014 wheels

### DIFF
--- a/.github/workflows/wheels_v2.yml
+++ b/.github/workflows/wheels_v2.yml
@@ -1,8 +1,6 @@
 name: Wheels Build manylinux2014_x86_64
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "20 2 * * *"
 
 jobs:
 


### PR DESCRIPTION
We want to keep this workflow run only on workflow_dispatch