### PR TITLE
Fix for factory methods removed from mlir::FloatType.

### DIFF
--- a/include/triton/Conversion/MLIRTypes.h
+++ b/include/triton/Conversion/MLIRTypes.h
@@ -21,10 +21,10 @@ inline Type u1Ty(MLIRContext *ctx) {
 }
 
 // Float types
-inline Type f16Ty(MLIRContext *ctx) { return FloatType::getF16(ctx); }
-inline Type f32Ty(MLIRContext *ctx) { return FloatType::getF32(ctx); }
-inline Type f64Ty(MLIRContext *ctx) { return FloatType::getF64(ctx); }
-inline Type bf16Ty(MLIRContext *ctx) { return FloatType::getBF16(ctx); }
+inline Type f16Ty(MLIRContext *ctx) { return Float16Type::get(ctx); }
+inline Type f32Ty(MLIRContext *ctx) { return Float32Type::get(ctx); }
+inline Type f64Ty(MLIRContext *ctx) { return Float64Type::get(ctx); }
+inline Type bf16Ty(MLIRContext *ctx) { return BFloat16Type::get(ctx); }
 
 inline bool isFloat(Type type) {
   return type.isF32() || type.isF64() || type.isF16() || type.isF128() ||

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -56,9 +56,9 @@ Type getTypeFromConstraint(char constraint, PatternRewriter &rewriter) {
   else if (constraint == 'l')
     ty = IntegerType::get(rewriter.getContext(), 64);
   else if (constraint == 'f')
-    ty = FloatType::getF32(rewriter.getContext());
+    ty = Float32Type::get(rewriter.getContext());
   else if (constraint == 'd')
-    ty = FloatType::getF64(rewriter.getContext());
+    ty = Float64Type::get(rewriter.getContext());
   else {
     assert(false && "Unsupported constraint");
   }

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -272,7 +272,7 @@ public:
     ctx.getOrLoadDialect<TritonGPUDialect>();
     ctaLayout =
         triton::gpu::CTALayoutAttr::get(&ctx, ctaPerCGA, ctaSplit, ctaOrder);
-    f16Ty = FloatType::getF16(&ctx);
+    f16Ty = Float16Type::get(&ctx);
   }
 
   triton::gpu::DotOperandEncodingAttr
@@ -525,7 +525,7 @@ TEST_F(LinearEncodingTest, DistributedEncodingToLinearEncoding) {
       ASSERT_EQ(linearLayout, expandedLL);
 
       // Test that methods of DistributedEncoding return the same values
-      Type eltTy = FloatType::getF32(&ctx);
+      Type eltTy = Float32Type::get(&ctx);
 
       ASSERT_EQ(getOrder(distributedEncoding), linearEncoding.getRepOrder());
       ASSERT_EQ(cast<triton::gpu::TritonGPU_AttrTrait>(distributedEncoding)

--- a/unittest/Dialect/TritonGPU/DumpLayoutTest.cpp
+++ b/unittest/Dialect/TritonGPU/DumpLayoutTest.cpp
@@ -182,7 +182,7 @@ TEST_F(DumpLayoutTest, Simple1DShared) {
                              {1},   /* ord, row-major */
                              {1});  /* cOrd */
 
-  auto elemTy = FloatType::getF16(sharedLayout.getContext());
+  auto elemTy = Float16Type::get(sharedLayout.getContext());
   auto tensorType = RankedTensorType::get({32}, elemTy, sharedLayout);
   std::string layout = getLayoutStr(tensorType, /*useHWPointOfView=*/false);
   assertSameStr(refStr, layout);
@@ -237,7 +237,7 @@ TEST_F(DumpLayoutTest, Larger2DShared) {
                              {1, 0},  /* ord, row-major */
                              {1, 0}); /* cOrd */
 
-  auto elemTy = FloatType::getF16(sharedLayout.getContext());
+  auto elemTy = Float16Type::get(sharedLayout.getContext());
   auto tensorType = RankedTensorType::get({8, 32}, elemTy, sharedLayout);
   std::string layout = getLayoutStr(tensorType, /*useHWPointOfView=*/false);
   assertSameStr(refStr, layout);
@@ -510,7 +510,7 @@ Offset: 255 -> (7,17)
                                {1, 0},  /* ord, row-major */
                                {1, 0}); /* cOrd */
 
-  auto elemTyHW = FloatType::getF16(sharedLayoutHW.getContext());
+  auto elemTyHW = Float16Type::get(sharedLayoutHW.getContext());
   auto tensorTypeHW = RankedTensorType::get({8, 32}, elemTyHW, sharedLayoutHW);
 
   std::string layoutHW = getLayoutStr(tensorTypeHW, /*useHWPointOfView=*/true);


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/commit/f023da12d12635f5fba436e825cbfc999e28e623
