### PR TITLE
[AMD] Fix `fuse-nested-loops` lit test

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -671,10 +671,11 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
     b.setInsertionPointAfter(prologueIf);
     Value innerEndT = b.create<arith::AddIOp>(
         loc, innerStartT, castIntIfNecessary(b, loc, lenInners[k], intTy));
-    Value bodyCond = b.create<arith::AndIOp>(
-        loc,
-        b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge, T, innerStartT),
-        b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt, T, innerEndT));
+    Value ge =
+        b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge, T, innerStartT);
+    Value lt =
+        b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt, T, innerEndT);
+    Value bodyCond = b.create<arith::AndIOp>(loc, ge, lt);
 
     // The outputs will be the outputs of the inner loop body and the next jk.
     SmallVector<Type> bodyOutTypes{jk.getType()};


### PR DESCRIPTION
The order of evaluating of function arguments unspecified according the standard.
It caused a lit test failure on my local and all AMD machines I tried.
Create `cmpi sge` and `cmpi slt` operation separatly to determine the order of them.
Fixed `fuse-nested-loops:multiple_loops` lit test.