### PR TITLE
[WIP][AMD] Add MFMA and WMMA layouts to LinearEncodingTest

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -1068,18 +1068,24 @@ Row |
     SmallVector<unsigned> getSizePerThreadForOperand(int kWidth, int opIdx) const;
     unsigned getTotalElemsPerThreadForOperand(ArrayRef<int64_t> shape, Type eltTy, int kWidth, int opIdx) const;
     SmallVector<int64_t> getElemsPerInstrForOperands() const;
+    SmallVector<int64_t> getRepTileShapeForOperand(int kWidth, int opIdx) const;
     SmallVector<int64_t> getRepForOperand(ArrayRef<int64_t> operandShape,
                                           Type elemType, int kWidth, int opIdx) const;
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
     SmallVector<unsigned> getThreadsPerWarpForOperand(int opIdx) const;
     static SmallVector<unsigned> getMNKDimPerInstr();
+    static SmallVector<unsigned> getMNKDimPerInstrPerThread(unsigned version);
 
     SmallVector<unsigned> getContigPerThread() {
       auto rank = getWarpsPerCTA().size();
       assert(rank == 2 || rank == 3);
       SmallVector<unsigned> contigPerThread(rank, 1);
       if (getVersion() == 2) {
-        contigPerThread[rank - 2] = 8;
+        if (getIsTransposed()) {
+          contigPerThread[rank - 1] = 8;
+        } else {
+          contigPerThread[rank - 2] = 8;
+        }
       }
       return contigPerThread;
     };
@@ -1339,6 +1345,9 @@ vecIdx (index of the element in the quad; this is always along the k-dim)
         contigPerThread[rank - 1] = kWidth;
       else
         contigPerThread[rank - 2] = kWidth;
+      if (auto wmma = mlir::dyn_cast<AMDWmmaEncodingAttr>(getParent())) {
+        assert(wmma.getVersion() != 1 && "WMMA v1 currently not implemented");
+      }
       return contigPerThread;
     };
   }];

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
@@ -40,23 +40,24 @@ bool isKContig(llvm::ArrayRef<unsigned> order, int opIdx);
 
 using computeTensorElemMappingInBlockT =
     std::function<llvm::SmallVector<llvm::SmallVector<Value>>(
-        ConversionPatternRewriter &, Location, const ArrayRef<int64_t> &, Value,
-        Value, int, ArrayRef<int64_t>, ArrayRef<Value>, int, unsigned,
-        unsigned)>;
+        ConversionPatternRewriter &, Location, Value, Value, int,
+        ArrayRef<int64_t>, ArrayRef<Value>, int, unsigned, unsigned)>;
 
-llvm::SmallVector<Value> computeOffsetsAType(
-    ConversionPatternRewriter &rewriter, Location loc,
-    computeTensorElemMappingInBlockT fn, const ArrayRef<int64_t> &elemsPerInstr,
-    Value warpId, Value laneId, int warpsPerBlock, int numOfElems,
-    ArrayRef<int64_t> reps, SharedMemoryObject smemObj, ArrayRef<Value> strides,
-    gpu::SharedEncodingAttr srcLayout, unsigned nonKDim, unsigned kDim);
+llvm::SmallVector<Value>
+computeOffsetsAType(ConversionPatternRewriter &rewriter, Location loc,
+                    computeTensorElemMappingInBlockT fn, Value warpId,
+                    Value laneId, int warpsPerBlock, int numOfElems,
+                    ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
+                    ArrayRef<Value> strides, gpu::SharedEncodingAttr srcLayout,
+                    unsigned nonKDim, unsigned kDim);
 
-llvm::SmallVector<Value> computeOffsetsBType(
-    ConversionPatternRewriter &rewriter, Location loc,
-    computeTensorElemMappingInBlockT fn, const ArrayRef<int64_t> &elemsPerInstr,
-    Value warpId, Value laneId, int warpsPerBlock, int numOfElems,
-    ArrayRef<int64_t> reps, SharedMemoryObject smemObj, ArrayRef<Value> strides,
-    gpu::SharedEncodingAttr srcLayout, unsigned nonKDim, unsigned kDim);
+llvm::SmallVector<Value>
+computeOffsetsBType(ConversionPatternRewriter &rewriter, Location loc,
+                    computeTensorElemMappingInBlockT fn, Value warpId,
+                    Value laneId, int warpsPerBlock, int numOfElems,
+                    ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
+                    ArrayRef<Value> strides, gpu::SharedEncodingAttr srcLayout,
+                    unsigned nonKDim, unsigned kDim);
 
 } // namespace mlir::triton::AMD
 


### PR DESCRIPTION
This PR adds AMD specific layouts to LinearEncodingTest::DistributedEncodingToLinearEncoding test
and fixes few issues exposed by this test.

This is a followup for https://github.com/triton-lang/triton/pull/5675#pullrequestreview-2571123595

Currently this PR incorporates #5675, I will rebase it after first PR is merged.