### PR TITLE
Implement TMA store reduction for add, min, max

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
+++ b/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
@@ -134,4 +134,17 @@ def TT_ScaleDotElemTypeAttr : I32EnumAttr<
   let cppNamespace = "::mlir::triton";
 }
 
+// Enum for Reduction operations in ExperimentalStoreOp
+// TODO Add the inc, dec, and, or, xor
+def TT_StoreReduceAttr : I32EnumAttr<
+  "StoreReduceEnum", "",
+  [
+    I32EnumAttrCase<"NONE", 1, "none">,
+    I32EnumAttrCase<"ADD", 2, "add">,
+    I32EnumAttrCase<"MAX", 3, "max">,
+    I32EnumAttrCase<"MIN", 4, "min">
+  ]> {
+  let cppNamespace = "::mlir::triton";
+}
+
 #endif

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -1286,11 +1286,13 @@ def TT_ExperimentalDescriptorStoreOp : TT_Op<"experimental_descriptor_store", [
   let arguments = (ins
     TT_TensorDescType:$desc,
     TT_Tensor:$src,
-    Variadic<I32>:$indices
+    Variadic<I32>:$indices,
+    DefaultValuedAttr<TT_StoreReduceAttr, "::mlir::triton::StoreReduceEnum::NONE">:$store_reduce_attr
   );
 
   let assemblyFormat = [{
     $desc `[` $indices `]` `,` $src
+    oilist(`store_reduce_attr` `=` $store_reduce_attr)
     attr-dict `:` qualified(type($desc)) `,` type($src)
   }];
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -250,10 +250,13 @@ def TTNG_AsyncTMACopyLocalToGlobalOp : TTNG_Op<"async_tma_copy_local_to_global",
   let arguments = (
     ins TT_PtrType:$desc_ptr,
     Variadic<I32>:$coord,
-    TTG_MemDescType:$src);
+    TTG_MemDescType:$src,
+    DefaultValuedAttr<TT_StoreReduceAttr, "::mlir::triton::StoreReduceEnum::NONE">:$store_reduce_attr
+  );
 
   let assemblyFormat = [{
     $desc_ptr `[` $coord `]` $src
+    oilist(`store_reduce_attr` `=` $store_reduce_attr)
     attr-dict `:` qualified(type($desc_ptr)) `,` qualified(type($src))
   }];
 }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -100,7 +100,7 @@ public:
     Value tmaPtr = rewriter.create<triton::nvidia_gpu::TensorDescToTMAPtrOp>(
         loc, op.getDesc());
     rewriter.create<triton::nvidia_gpu::AsyncTMACopyLocalToGlobalOp>(
-        loc, tmaPtr, op.getIndices(), alloc);
+        loc, tmaPtr, op.getIndices(), alloc, op.getStoreReduceAttr());
     rewriter.create<triton::nvidia_gpu::TMAStoreWaitOp>(loc, 0);
     rewriter.eraseOp(op);
     return success();

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -199,6 +199,13 @@ void init_triton_ir(py::module &&m) {
       .value("EVICT_LAST", EvictionPolicy::EVICT_LAST)
       .export_values();
 
+  py::enum_<StoreReduceEnum>(m, "STORE_REDUCE", py::module_local())
+      .value("NONE", StoreReduceEnum::NONE)
+      .value("ADD", StoreReduceEnum::ADD)
+      .value("MAX", StoreReduceEnum::MAX)
+      .value("MIN", StoreReduceEnum::MIN)
+      .export_values();
+
   py::enum_<RMWOp>(m, "ATOMIC_OP", py::module_local())
       .value("ADD", RMWOp::ADD)
       .value("FADD", RMWOp::FADD)
@@ -1347,8 +1354,10 @@ void init_triton_ir(py::module &&m) {
            })
       .def("create_descriptor_store",
            [](TritonOpBuilder &self, Value desc, Value value,
-              std::vector<Value> &indices) -> void {
-             self.create<ExperimentalDescriptorStoreOp>(desc, value, indices);
+              std::vector<Value> &indices,
+              StoreReduceEnum storeReduceEnum) -> void {
+             self.create<ExperimentalDescriptorStoreOp>(desc, value, indices,
+                                                        storeReduceEnum);
            })
       .def("create_tensormap_create",
            [](TritonOpBuilder &self, Value desc_ptr, Value global_address,

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1275,14 +1275,20 @@ class _experimental_tensor_descriptor_base(_value):
         return semantic.descriptor_load(self, offsets, "", "", _builder)
 
     @builtin
-    def store(self, offsets: List[constexpr | tensor], value: tensor, _builder=None) -> tensor:
+    def store(
+        self,
+        offsets: List[constexpr | tensor],
+        value: tensor,
+        store_reduce,
+        _builder=None,
+    ) -> tensor:
         """Store a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be ignored.
 
         :note: Offset must be a multiple of 16-bytes
         """
-        return semantic.descriptor_store(self, value, offsets, _builder)
+        return semantic.descriptor_store(self, value, offsets, store_reduce, _builder)
 
 
 class _experimental_tensor_descriptor(_experimental_tensor_descriptor_base):
@@ -1856,15 +1862,18 @@ def _experimental_descriptor_load(desc_pointer, offsets, shape, dtype, _builder=
 
 
 @builtin
-def _experimental_descriptor_store(desc_pointer, value, offsets, _builder=None):
+def _experimental_descriptor_store(
+    desc_pointer, value, offsets, store_reduce="", _builder=None
+):
     """
     Experimental feature to access TMA descriptors stores. This is an escape hatch to easily exercise TTGIR operations.
     This will be removed in the future and shouldn't be used in production code.
 
     This stores a tensor of data based on the descriptor and offsets.
     """
+    store_reduce = _constexpr_to_value(store_reduce)
     desc = _experimental_reinterpret_tensor_descriptor(desc_pointer, value.shape, value.dtype, _builder=_builder)
-    return desc.store(offsets, value, _builder=_builder)
+    return desc.store(offsets, value, store_reduce, _builder=_builder)
 
 
 @_tensor_member_fn

--- a/python/triton/tools/experimental_descriptor.py
+++ b/python/triton/tools/experimental_descriptor.py
@@ -6,27 +6,35 @@ import triton
 class TmaDescKernelParam:
     TMA_DESC_SIZE = 128
 
-    def __init__(self, ptr, dims, block_dims, element_size):
+    def __init__(self, ptr, dims, block_dims, data_type):
         self.desc = torch.empty(self.TMA_DESC_SIZE, dtype=torch.uint8, device="cpu")
         assert len(dims) == len(block_dims)
         assert 1 <= len(dims) <= 2
         assert self.desc.data_ptr() % 64 == 0
 
         if len(dims) == 1:
-            triton.runtime.driver.active.utils.fill_1d_tma_descriptor(ptr, dims[0], block_dims[0], element_size,
-                                                                      self.desc.data_ptr())
+            triton.runtime.driver.active.utils.fill_1d_tma_descriptor(
+                ptr, dims[0], block_dims[0], data_type, self.desc.data_ptr()
+            )
         else:
-            triton.runtime.driver.active.utils.fill_2d_tma_descriptor(ptr, dims[0], dims[1], block_dims[0],
-                                                                      block_dims[1], element_size, self.desc.data_ptr())
+            triton.runtime.driver.active.utils.fill_2d_tma_descriptor(
+                ptr,
+                dims[0],
+                dims[1],
+                block_dims[0],
+                block_dims[1],
+                data_type,
+                self.desc.data_ptr(),
+            )
 
     # Return a CUtensorMap* pointer in host memory
     def tma_desc_cpu_ptr(self):
         return self.desc.data_ptr()
 
 
-def create_1d_tma_descriptor(ptr, dim, block_dim, element_size):
-    return TmaDescKernelParam(ptr, [dim], [block_dim], element_size)
+def create_1d_tma_descriptor(ptr, dim, block_dim, data_type):
+    return TmaDescKernelParam(ptr, [dim], [block_dim], data_type)
 
 
-def create_2d_tma_descriptor(ptr, dim1, dim0, block_dim1, block_dim0, element_size):
-    return TmaDescKernelParam(ptr, [dim1, dim0], [block_dim1, block_dim0], element_size)
+def create_2d_tma_descriptor(ptr, dim1, dim0, block_dim1, block_dim0, data_type):
+    return TmaDescKernelParam(ptr, [dim1, dim0], [block_dim1, block_dim0], data_type)

--- a/python/tutorials/10-vector-tma-reduce-add.py
+++ b/python/tutorials/10-vector-tma-reduce-add.py
@@ -1,0 +1,132 @@
+import torch
+
+import triton
+import triton.language as tl
+from triton.tools.experimental_descriptor import (
+    create_1d_tma_descriptor,
+)
+
+
+def map_dtype_to_triton(dtype: torch.dtype) -> int:
+    """
+    Maps torch dtype to triton dtype.
+
+    Args:
+        dtype (torch.dtype): input dtype.
+
+    Returns:
+        tl.dtype: triton dtype.
+    """
+    if dtype == torch.float16:
+        return 0
+    elif dtype == torch.bfloat16:
+        return 1
+    elif dtype == torch.float32:
+        return 2
+    elif dtype == torch.int32:
+        return 3
+    else:
+        raise ValueError(f"Unsupported dtype {dtype}")
+
+
+@triton.jit
+def add_kernel(
+    x_ptr,  # *Pointer* to first input vector.
+    x_desc,
+    y_ptr,  # *Pointer* to second input vector.
+    y_desc,
+    output_desc,
+    BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
+):
+    pid = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
+    block_start = pid * BLOCK_SIZE
+    # Load x through TMA.
+    x = tl._experimental_descriptor_load(
+        x_desc, [block_start], [BLOCK_SIZE], x_ptr.dtype.element_ty
+    )
+    # Store x to through TMA.
+    tl._experimental_descriptor_store(output_desc, x, [block_start])
+    # Load y through TMA.
+    y = tl._experimental_descriptor_load(
+        y_desc, [block_start], [BLOCK_SIZE], y_ptr.dtype.element_ty
+    )
+    # Store y to through TMA reduce add.
+    tl._experimental_descriptor_store(output_desc, y, [block_start], store_reduce="add")
+
+
+def add(x: torch.Tensor, y: torch.Tensor):
+    BLOCK_SIZE = 256
+    x_desc = create_1d_tma_descriptor(
+        x.data_ptr(), size, BLOCK_SIZE, map_dtype_to_triton(x.dtype)
+    )
+    y_desc = create_1d_tma_descriptor(
+        y.data_ptr(), size, BLOCK_SIZE, map_dtype_to_triton(y.dtype)
+    )
+    output = torch.empty_like(x)
+    output_desc = create_1d_tma_descriptor(
+        output.data_ptr(), size, BLOCK_SIZE, map_dtype_to_triton(output.dtype)
+    )
+    assert x.is_cuda and y.is_cuda and output.is_cuda
+    n_elements = output.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    add_kernel[grid](x, x_desc, y, y_desc, output_desc, BLOCK_SIZE=BLOCK_SIZE)
+    return output
+
+
+torch.manual_seed(0)
+size = 98432
+x = torch.rand(size, dtype=torch.float32, device="cuda")
+y = torch.rand(size, dtype=torch.float32, device="cuda")
+output_torch = x + y
+output_triton = add(x, y)
+print(output_torch)
+print(output_triton)
+print(
+    f"The maximum difference between torch and triton is "
+    f"{torch.max(torch.abs(output_torch - output_triton))}"
+)
+assert torch.equal(output_torch, output_triton)
+
+# %%
+# Benchmark
+# ---------
+#
+# We can now benchmark our custom op on vectors of increasing sizes to get a sense of how it does relative to PyTorch.
+# To make things easier, Triton has a set of built-in utilities that allow us to concisely plot the performance of our custom ops.
+# for different problem sizes.
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["size"],  # Argument names to use as an x-axis for the plot.
+        x_vals=[
+            2**i for i in range(12, 28, 1)
+        ],  # Different possible values for `x_name`.
+        x_log=True,  # x axis is logarithmic.
+        line_arg="provider",  # Argument name whose value corresponds to a different line in the plot.
+        line_vals=["triton", "torch"],  # Possible values for `line_arg`.
+        line_names=["Triton", "Torch"],  # Label name for the lines.
+        styles=[("blue", "-"), ("green", "-")],  # Line styles.
+        ylabel="GB/s",  # Label name for the y-axis.
+        plot_name="vector-add-float32-performance",  # Name for the plot. Used also as a file name for saving the plot.
+        args={},  # Values for function arguments not in `x_names` and `y_name`.
+    )
+)
+def benchmark(size, provider):
+    x = torch.rand(size, device="cuda", dtype=torch.float32)
+    y = torch.rand(size, device="cuda", dtype=torch.float32)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == "torch":
+        ms, min_ms, max_ms = triton.testing.do_bench(lambda: x + y, quantiles=quantiles)
+    if provider == "triton":
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: add(x, y), quantiles=quantiles
+        )
+    gbps = lambda ms: 3 * x.numel() * x.element_size() * 1e-9 / (ms * 1e-3)
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+
+# # %%
+# # We can now run the decorated function above. Pass `print_data=True` to see the performance number, `show_plots=True` to plot them, and/or
+# # `save_path='/path/to/results/' to save them to disk along with raw CSV data:
+benchmark.run(print_data=True, show_plots=True)

--- a/test/TritonNvidiaGPU/tma_lowering.mlir
+++ b/test/TritonNvidiaGPU/tma_lowering.mlir
@@ -34,6 +34,51 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: tma_store_reduce_add
+//       CHECK: ttg.local_alloc
+//       CHECK: ttng.fence_async_shared {bCluster = false}
+//       CHECK: ttng.tensor_desc_to_tma_ptr
+//       CHECK: ttng.async_tma_copy_local_to_global {{.*}} store_reduce_attr = add
+  tt.func public @tma_store_reduce_add(%arg0: !tt.tensordesc<tensor<128x256xf32>>, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: tensor<128x256xf32, #blocked>) {
+    tt.experimental_descriptor_store %arg0[%arg1, %arg1], %arg2 store_reduce_attr = add : !tt.tensordesc<tensor<128x256xf32>>, tensor<128x256xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: tma_store_reduce_min
+//       CHECK: ttg.local_alloc
+//       CHECK: ttng.fence_async_shared {bCluster = false}
+//       CHECK: ttng.tensor_desc_to_tma_ptr
+//       CHECK: ttng.async_tma_copy_local_to_global {{.*}} store_reduce_attr = min
+  tt.func public @tma_store_reduce_min(%arg0: !tt.tensordesc<tensor<128x256xf32>>, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: tensor<128x256xf32, #blocked>) {
+    tt.experimental_descriptor_store %arg0[%arg1, %arg1], %arg2 store_reduce_attr = min : !tt.tensordesc<tensor<128x256xf32>>, tensor<128x256xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: tma_store_reduce_max
+//       CHECK: ttg.local_alloc
+//       CHECK: ttng.fence_async_shared {bCluster = false}
+//       CHECK: ttng.tensor_desc_to_tma_ptr
+//       CHECK: ttng.async_tma_copy_local_to_global {{.*}} store_reduce_attr = max
+  tt.func public @tma_store_reduce_max(%arg0: !tt.tensordesc<tensor<128x256xf32>>, %arg1: i32 {tt.divisibility = 16 : i32}, %arg2: tensor<128x256xf32, #blocked>) {
+    tt.experimental_descriptor_store %arg0[%arg1, %arg1], %arg2 store_reduce_attr = max : !tt.tensordesc<tensor<128x256xf32>>, tensor<128x256xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: make_tensor_descriptor
   // CHECK: %0 = arith.extsi %arg2 : i32 to i64

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -283,29 +283,37 @@ static PyObject *fill1DTMADescriptor(PyObject *self, PyObject *args) {
   unsigned long long global_address;
   uint64_t dim;
   uint32_t tensorDim;
-  int elementSize;
+  int dataType;
   unsigned long long desc_address;
   if (!PyArg_ParseTuple(args, "KKiiK", &global_address, &dim, &tensorDim,
-                        &elementSize, &desc_address)) {
+                        &dataType, &desc_address)) {
     return NULL;
   }
   uint64_t dims[1] = {dim};
-  uint64_t globalStrides[1] = {dim * elementSize};
+  uint64_t globalStrides[1] = {dim * dataType};
   uint32_t boxDim[1] = {tensorDim};
   uint32_t elementStrides[1] = {1};
   CUtensorMapDataType type;
-  switch (elementSize) {
+  uint elementSize = 0;
+  switch (dataType) {
+  case 0:
+    type = CU_TENSOR_MAP_DATA_TYPE_FLOAT16;
+    elementSize = 2;
+    break;
   case 1:
-    type = CU_TENSOR_MAP_DATA_TYPE_UINT8;
+    type = CU_TENSOR_MAP_DATA_TYPE_BFLOAT16;
+    elementSize = 2;
     break;
   case 2:
-    type = CU_TENSOR_MAP_DATA_TYPE_UINT16;
+    type = CU_TENSOR_MAP_DATA_TYPE_FLOAT32;
+    elementSize = 4;
     break;
-  case 4:
-    type = CU_TENSOR_MAP_DATA_TYPE_UINT32;
+  case 3:
+    type = CU_TENSOR_MAP_DATA_TYPE_INT32;
+    elementSize = 4;
     break;
   default:
-    PyErr_SetString(PyExc_ValueError, "elementSize must be 1, 2, or 4");
+    PyErr_SetString(PyExc_ValueError, "dataType must be 0, 1, 2, or 3");
     return NULL;
   }
   assert((elementSize * tensorDim) >= 32 && "block size too small.");


### PR DESCRIPTION
This change adds support for lowering _experimental_descriptor_store to TMA store reduction instruction **[cp.reduce.async.bulk.tensor](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-reduce-async-bulk-tensor)**.  Performance of reduction operations that can utilize this async instruction should improve. That could be seen in the plot below that's generated from **10-vector-tma-reduce-add.py**. 

![image](https://github.com/user-attachments/assets/013175d6-e020-43b5-8bf0-de7fff6e492a)

During the implementation, we noticed a discrepancy in TMA descriptor generation in **driver.c** that element size needed to be the element type. This is currently fixed for a subset of types for _fill1DTMADescriptor_ and could be improved further. After we decide on a final design, _fill2DTMADescriptor_ should be similarly updated. 

I am also planning to convert the tutorial **10-vector-tma-reduce-add.py** into an end-to-end test. 

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
