### PR TITLE
[PROTON] Correct misuse of `strip`

### DIFF
--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -249,7 +249,7 @@ def parse(metrics, filename, include=None, exclude=None, threshold=None, depth=1
         gf = filter_frames(gf, include, exclude, threshold, metrics[0])
         print(gf.tree(metric_column=metrics, expand_name=True, depth=depth, render_header=False))
         if print_sorted:
-            print("Sorted kernels by metric " + metrics[0].strip("(inc)"))
+            print("Sorted kernels by metric " + metrics[0])
             sorted_df = gf.dataframe.sort_values(by=[metrics[0]], ascending=False)
             for row in range(1, len(sorted_df)):
                 kernel_name = sorted_df.iloc[row]['name'][:100] + "..." if len(


### PR DESCRIPTION
The `strip` method removes characters that match the input argument, but it does not remove substrings that match the full input. For example, previously, `"num_samples (inc)".strip("inc")` would result in `um_samples` because the character `n` is part of the input argument. Instead of using `strip`, the `replace` method can be used. However, in this case, we can simply output the original metric name (i.e., "num_samples (inc)") since it’s more useful to know whether the metric is inclusive or exclusive. 
