### PR TITLE
[AMD][Buffer Ops] Leverage MLIR infra for errors in more places

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -581,7 +581,8 @@ struct BufferAtomicRMWOpConversion
     switch (memScope) {
     // System scope is not supported yet
     case MemSyncScope::SYSTEM:
-      return failure();
+      return rewriter.notifyMatchFailure(
+          op, "System memory scope is not supported for Buffer Atomic RMW");
     case MemSyncScope::GPU:
       scopeStr = "agent";
       break;
@@ -589,7 +590,8 @@ struct BufferAtomicRMWOpConversion
       scopeStr = "workgroup";
       break;
     default:
-      return failure();
+      return rewriter.notifyMatchFailure(
+          op, "Unsupported memory scope for Buffer Atomic RMW");
     }
 
     StringAttr scope = mlir::StringAttr::get(loc.getContext(), scopeStr);
@@ -815,7 +817,7 @@ struct AtomicCASOpConversion
     auto scope = op.getScope();
     auto scopeStr = getAMDGPUMemScopeStr(scope);
     if (!scopeStr)
-      return failure();
+      return rewriter.notifyMatchFailure(op, "Unknown AMDGPU memory scope");
 
     // deal with tensor or scalar
     auto valueTy = op.getResult().getType();
@@ -1143,7 +1145,7 @@ struct AtomicRMWOpConversion
 
     auto scopeStr = getAMDGPUMemScopeStr(scope);
     if (!scopeStr)
-      return failure();
+      return rewriter.notifyMatchFailure(op, "Unknown AMDGPU memory scope");
 
     auto vecTy = vec_ty(valueElemTy, vec);
     auto retType = vec == 1 ? valueElemTy : vecTy;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -422,8 +422,9 @@ struct ConvertTritonLoadToBufferLoad
       rewriter.replaceOp(op, bufferLoadOp);
       return success();
     }
+
     LDBG("Failed to convert: " << op);
-    return failure();
+    return rewriter.notifyMatchFailure(op, "Failed to convert LoadOp");
   }
 
 private:
@@ -462,7 +463,7 @@ struct ConvertTritonStoreToBufferStore
       return success();
     }
     LDBG("Failed to convert: " << op);
-    return failure();
+    return rewriter.notifyMatchFailure(op, "Failed to convert StoreOp");
   }
 
 private:


### PR DESCRIPTION
# Overview

This is a minor change, when implementing PR #5549 I used: ```rewriter.notifyMatchFailure``` in place of ```return failure();``` as per suggestions to leverage MLIR infra for errors.

We should probably be consistent throughout the file and use the MLIR infra for the other buffer ops.

# Testing

I don't think this should impact anything and doesn't require any added tests

================================================================================

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `minor change to error reporting`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
