### PR TITLE
Add missing include header

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -11,6 +11,8 @@
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 
+#include <unordered_map>
+
 // LinearLayoutCache Utils
 using CacheKey =
     std::tuple<std::vector<int64_t>, mlir::Attribute, std::optional<int32_t>>;


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/5542/files introduced a dependency on an unordered_map without requiring the unordered_map include path.

This works on some systems currently if other headers include unordered map, but fails on others.
