### PR TITLE
[PROTON] Prefer the default library path when loading profiler backends

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -411,7 +411,7 @@ class CMakeBuild(build_ext):
         if cupti_lib_dir == "":
             cupti_lib_dir = os.path.join(get_base_dir(), "third_party", "nvidia", "backend", "lib", "cupti")
         cmake_args += ["-DCUPTI_LIB_DIR=" + cupti_lib_dir]
-        roctracer_include_dir = get_env_with_keys(["ROCTRACER_INCLUDE_PATH"])
+        roctracer_include_dir = get_env_with_keys(["TRITON_ROCTRACER_INCLUDE_PATH"])
         if roctracer_include_dir == "":
             roctracer_include_dir = os.path.join(get_base_dir(), "third_party", "amd", "backend", "include")
         cmake_args += ["-DROCTRACER_INCLUDE_DIR=" + roctracer_include_dir]

--- a/third_party/proton/csrc/include/Driver/Dispatch.h
+++ b/third_party/proton/csrc/include/Driver/Dispatch.h
@@ -59,25 +59,24 @@ public:
 
   static void init(const char *name, void **lib) {
     if (*lib == nullptr) {
-      // First reuse the existing handle
-      *lib = dlopen(name, RTLD_NOLOAD);
-    }
-    if (*lib == nullptr) {
-      // If not found, try to load it from LD_LIBRARY_PATH
-      *lib = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
-    }
-    if (*lib == nullptr) {
-      // If still not found, try to load it from the default path
+      // If not found, try to load it from the default path
       auto dir = std::string(ExternLib::defaultDir);
       if (dir.length() > 0) {
         auto fullPath = dir + "/" + name;
         *lib = dlopen(fullPath.c_str(), RTLD_LOCAL | RTLD_LAZY);
+      } else {
+        // Only if the default path is not set, we try to load it from the
+        // system.
+        // First reuse the existing handle
+        *lib = dlopen(name, RTLD_NOLOAD);
+        if (*lib == nullptr) {
+          // If not found, try to load it from LD_LIBRARY_PATH
+          *lib = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
+        }
       }
     }
     if (*lib == nullptr) {
-      throw std::runtime_error("Could not find `" + std::string(name) +
-                               "`. Make sure it is in your "
-                               "LD_LIBRARY_PATH.");
+      throw std::runtime_error("Could not load `" + std::string(name) + "`");
     }
   }
 


### PR DESCRIPTION
It will be more consistent since the CUPTI header and library can use the same version.
For roctracer, we don't package the library with triton, so we need to fall back to the system library.
