### PR TITLE
Optimize reduce(reshape_1D)

### DIFF
--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -187,6 +187,29 @@ public:
   }
 };
 
+// When reducing a 1D tensor the order of elements of the tensor doesn't matter.
+// Therefore we can relax the reshape to allow it to re-order elements.
+class CombineReshapeReducePatterns : public mlir::OpRewritePattern<ReshapeOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(triton::ReshapeOp reshapeOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (reshapeOp.getAllowReorder())
+      return failure();
+    if (reshapeOp.getType().getRank() != 1)
+      return failure();
+    for (Operation *user : reshapeOp->getUsers()) {
+      if (!isa<triton::ReduceOp>(user))
+        return failure();
+    }
+    rewriter.modifyOpInPlace(reshapeOp,
+                             [&]() { reshapeOp.setAllowReorder(true); });
+    return success();
+  }
+};
+
 class CombineOpsPass : public TritonCombineOpsBase<CombineOpsPass> {
 public:
   void runOnOperation() override {
@@ -203,6 +226,7 @@ public:
     patterns.add<CombineSelectMaskedLoadPattern>(context);
     patterns.add<CombineAddPtrPattern>(context);
     patterns.add<CombineBroadcastMulReducePattern>(context);
+    patterns.add<CombineReshapeReducePatterns>(context);
 
     if (applyPatternsGreedily(m, std::move(patterns)).failed())
       signalPassFailure();

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -201,7 +201,7 @@ public:
     if (reshapeOp.getType().getRank() != 1)
       return failure();
     for (Operation *user : reshapeOp->getUsers()) {
-      if (!isa<triton::ReduceOp>(user))
+      if (!isa<triton::ReduceOp, triton::HistogramOp>(user))
         return failure();
     }
     rewriter.modifyOpInPlace(reshapeOp,

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -347,7 +347,7 @@ tt.func @test_nested_transpose(%arg0: tensor<2x4x8xf32>) -> (tensor<8x2x4xf32>) 
 }
 
 // CHECK-LABEL: test_reshape_reduce
-tt.func @test_reshape_reduce(%0: tensor<32x4x2xi32>) -> i32 {
+tt.func @test_reshape_reduce(%0: tensor<32x4x2xi32>) -> (i32, tensor<16xi32>) {
   // CHECK: tt.reshape %{{.+}} allow_reorder : tensor<32x4x2xi32> -> tensor<256xi32>
   %1 = tt.reshape %0 : tensor<32x4x2xi32> -> tensor<256xi32>
   %2 = "tt.reduce" (%1) ({
@@ -355,5 +355,6 @@ tt.func @test_reshape_reduce(%0: tensor<32x4x2xi32>) -> i32 {
       %add = arith.addi %arg7, %arg8 : i32
       tt.reduce.return %add : i32
     }) {axis = 0 : i32} : (tensor<256xi32>) -> i32
-  tt.return %2 : i32
+  %3 = tt.histogram %1 : tensor<256xi32> -> tensor<16xi32>
+  tt.return %2, %3 : i32, tensor<16xi32>
 }

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -345,3 +345,15 @@ tt.func @test_nested_transpose(%arg0: tensor<2x4x8xf32>) -> (tensor<8x2x4xf32>) 
     // CHECK: tt.return %[[res]]
     tt.return %b : tensor<8x2x4xf32>
 }
+
+// CHECK-LABEL: test_reshape_reduce
+tt.func @test_reshape_reduce(%0: tensor<32x4x2xi32>) -> i32 {
+  // CHECK: tt.reshape %{{.+}} allow_reorder : tensor<32x4x2xi32> -> tensor<256xi32>
+  %1 = tt.reshape %0 : tensor<32x4x2xi32> -> tensor<256xi32>
+  %2 = "tt.reduce" (%1) ({
+    ^bb0(%arg7: i32, %arg8: i32):
+      %add = arith.addi %arg7, %arg8 : i32
+      tt.reduce.return %add : i32
+    }) {axis = 0 : i32} : (tensor<256xi32>) -> i32
+  tt.return %2 : i32
+}


### PR DESCRIPTION
When reducing a 1D tensor the order of elements doesn't matter. This allows us to use a more relaxed version of reshape.
