### PR TITLE
[AMD] MI350 support for ds_read_b64_tr_b16  instruction

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -256,6 +256,11 @@ LinearLayout chooseStMatrixLayout(MLIRContext *ctx, RankedTensorType tensorTy,
 // tensor into shared memory using the `ldmatrix` instruction.
 LinearLayout chooseLdMatrixLayout(Attribute enc, ArrayRef<int64_t> shape,
                                   bool needTrans, int32_t elemBitWidth);
+
+// The primary goal of this function is to efficiently load 2D tiles of a
+// tensor from shared memory using the `ds_read_tr` instruction for AMD GPUs.
+LinearLayout chooseLDSTransLayout(Attribute enc, ArrayRef<int64_t> shape,
+                                  int32_t elemBitWidth);
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_DIALECT_TRITONGPU_IR_LINEARLAYOUTCONVERSIONS_H

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -259,8 +259,8 @@ LinearLayout chooseLdMatrixLayout(Attribute enc, ArrayRef<int64_t> shape,
 
 // The primary goal of this function is to efficiently load 2D tiles of a
 // tensor from shared memory using the `ds_read_tr` instruction for AMD GPUs.
-LinearLayout chooseLDSTransLayout(Attribute enc, ArrayRef<int64_t> shape,
-                                  int32_t elemBitWidth);
+LinearLayout chooseDsReadB64Tr16Layout(Attribute enc, ArrayRef<int64_t> shape,
+                                       int32_t elemBitWidth);
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_DIALECT_TRITONGPU_IR_LINEARLAYOUTCONVERSIONS_H

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -431,7 +431,7 @@ LinearLayout chooseDotLDSTransLayout(DotOperandEncodingAttr dotMfmaLayout,
   // The MFMA selection logic prioritizes double-rate MFMA instructions whenever
   // possible. Specifically:
   // - For MFMA operations that are non-K = 16, when blockK > 16, mfma16x16x32
-  // is selected; otherwise (blockK ≤ 16), mfma16x16x32 remains the choice.
+  // is selected; otherwise (blockK ≤ 16), mfma16x16x16 remains the choice.
   // - For MFMA operations that are non-K = 32, when blockK > 8, mfma32x32x16 is
   // selected; otherwise (blockK ≤ 8), mfma32x32x8 is used.
   //
@@ -516,7 +516,7 @@ LinearLayout chooseDotLDSTransLayout(DotOperandEncodingAttr dotMfmaLayout,
                            warpLayout.transposeOuts(outDimNames);
   auto finalLayout =
       combineCtaCgaWithShape(ctaLayout, mfmaLayout.getCTALayout(), shape);
-  // llvm::outs() << finalLayout;
+
   return finalLayout;
 }
 

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -401,8 +401,7 @@ LinearLayout chooseDotDsReadB64Tr16Layout(DotOperandEncodingAttr dotMfmaLayout,
   bool hasBatchDim = rank == 3;
   int32_t kWidthDot = dotMfmaLayout.getKWidth();
   // Number of bits loaded by an LDS read. ds_read_tr primarily supports 64-bit
-  // loads for most element sizes (16b, 8b, 4b), except for 6b elements. Here,
-  // we assume 6b elements will not be used.
+  // loads for most element sizes (16b, 8b, 4b).
   const int32_t ldsReadWidth = 64;
   int32_t kWidthTransRead = ldsReadWidth / elemBitWidth;
   auto kDim = dotMfmaLayout.getOpIdx() == 0 ? rank - 1 : rank - 2;

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -390,6 +390,136 @@ AMDMfmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   return combineCtaCgaWithShape(ctaLayout, getCTALayout(), shape);
 }
 
+LinearLayout chooseDotLDSTransLayout(DotOperandEncodingAttr dotMfmaLayout,
+                                     ArrayRef<int64_t> shape,
+                                     int32_t elemBitWidth) {
+  auto mfmaLayout = llvm::cast<AMDMfmaEncodingAttr>(dotMfmaLayout.getParent());
+  assert(mfmaLayout.getMDim() == 16 || mfmaLayout.getNDim() == 32);
+  assert(elemBitWidth == 16);
+
+  auto rank = shape.size();
+  bool hasBatchDim = rank == 3;
+  int mIndex = 0 + hasBatchDim;
+  int32_t kWidthDot = dotMfmaLayout.getKWidth();
+  int32_t kWidthTransRead = 64 / elemBitWidth;
+  auto kDim = dotMfmaLayout.getOpIdx() == 0 ? rank - 1 : rank - 2;
+
+  int32_t kSize = shape[kDim];
+  auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
+
+  MLIRContext *ctx = dotMfmaLayout.getContext();
+  SmallVector<StringAttr> outDimNames = standardOutDimNames(ctx, rank);
+
+  StringAttr kRegister = S("register");
+  StringAttr kLane = S("lane");
+  StringAttr kWarp = S("warp");
+
+  // register order
+  // operand A: [1, 0] / [2, 1, 0]
+  // operand B: [0, 1] / [1, 2, 0]
+  // Regular dot mfma order for both cases is [k, nonk]/[k, nonk, batch]
+  // For LDS transpose layout swap order to [nonk, k]/[nonk, k, batch]
+  SmallVector<unsigned> order = triton::gpu::getOrder(dotMfmaLayout);
+  std::swap(order[0], order[1]);
+
+  // In the LDS transpose logic, each thread accesses 64 bits (8 bytes) of data.
+  // The smallest unit for transposing is a 4x4 sub-tile of threads, where each
+  // thread reads 4 16-bit elements along the non-K dimension, resulting in a
+  // [non-K, K] = {16, 4}  sub-tile of elements. Because of transposing
+  // mechanism, thread ends up with 4 16-bit elements along K dim.
+  //
+  // The MFMA selection logic prioritizes double-rate MFMA instructions whenever
+  // possible. Specifically:
+  // - For MFMA operations that are non-K = 16, when blockK > 16, mfma16x16x32
+  // is selected; otherwise (blockK ≤ 16), mfma16x16x32 remains the choice.
+  // - For MFMA operations that are non-K = 32, when blockK > 8, mfma32x32x16 is
+  // selected; otherwise (blockK ≤ 8), mfma32x32x8 is used.
+  //
+  // In double-rate MFMA instructions, each thread holds 8 elements along the K
+  // dimension.
+  // - The first 4 elements belong to the first sub-tile.
+  // - The next 4 elements belong to the second sub-tile.
+  //
+  // We then group these into larger tiles, each consisting of 8 of these 16x4
+  // sub-tiles. These tiles correspond to data for one mfma instruction. The
+  // shapes of these tiles depend on the MFMA instruction used:
+  // 1. For mfma32x32x16, the tile shape is [non-K, K] = {32, 16}.
+  // 2. For mfma16x16x32, the tile shape is [non-K, K] = {16, 32}.
+  //
+  // For single-rate mfma instructions, each thread holds 4 elements along K
+  // dimension. This means larger tile (that corresponds to one mfma
+  // instruction) consists of 4 16x4 sub-tiles.
+  std::vector<std::vector<int32_t>> registerBase = {{1, 0},
+                                                    {2, 0}}; // first sub-tile
+  std::vector<std::vector<int32_t>> laneBase = {{kWidthTransRead, 0},
+                                                {2 * kWidthTransRead, 0},
+                                                {0, 1},
+                                                {0, 2}}; // first sub-tile
+
+  // Extend register base for multiple tiles in K dimension (corresponding to
+  // multiple mfma instructions accross k dim).
+  auto populateRegisterBase = [&](int kTileSize) {
+    const int regsPerTile = 8;
+    int numRegs = (kSize / kTileSize) * regsPerTile;
+    for (int reg = regsPerTile; reg < numRegs; reg *= 2) {
+      registerBase.push_back({0, (reg / regsPerTile) * kTileSize});
+    }
+  };
+
+  const bool isMfma32 = (mfmaLayout.getMDim() == 32);
+  const bool isMfma16 = (mfmaLayout.getMDim() == 16);
+  assert(isMfma32 || isMfma16);
+
+  const int kTileSize = isMfma32 ? 16 : 32;
+  const int kThreshold = isMfma32 ? 8 : 16;
+
+  if (kSize > kThreshold) {
+    // Handles mfma32x32x16 and mfma16x16x32 cases
+    assert(kWidthDot == 8);
+    registerBase.push_back({0, 4}); // second sub-tile
+    populateRegisterBase(kTileSize);
+    auto laneBaseExt = isMfma32
+                           ? std::vector<std::vector<int32_t>>{{16, 0}, {0, 8}}
+                           : std::vector<std::vector<int32_t>>{{0, 8}, {0, 16}};
+    laneBase.insert(laneBase.end(), laneBaseExt.begin(), laneBaseExt.end());
+  } else {
+    // Handles mfma32x32x8 and mfma16x16x16 cases
+    assert(kWidthDot == 4);
+    auto laneBaseExt = isMfma32
+                           ? std::vector<std::vector<int32_t>>{{16, 0}, {0, 4}}
+                           : std::vector<std::vector<int32_t>>{{0, 4}, {0, 8}};
+    laneBase.insert(laneBase.end(), laneBaseExt.begin(), laneBaseExt.end());
+  }
+
+  // Base vectors above are defined in a fixed order [non-k-dim, k-dim].
+  // To assign them to actual matrix dimensions `order` array is used.
+  // For operand A: non-k-dim -> dim0, k-dim -> dim1
+  // For operand B: non-k-dim -> dim1, k-dim -> dim0
+  LinearLayout tileLayout({{kRegister, registerBase}, {kLane, laneBase}},
+                          {outDimNames[order[0]], outDimNames[order[1]]});
+
+  if (hasBatchDim) {
+    assert(order[2] == 0);
+    // Extend the base vector with one value to accommodate for the batch
+    // dimension, which appears at the last.
+    tileLayout *= LinearLayout::identity1D(1, kRegister, outDimNames[order[2]]);
+    tileLayout *= LinearLayout::identity1D(1, kLane, outDimNames[order[2]]);
+  }
+
+  // warp order
+  // common for both operand A and B: [0, 1] / [0, 1, 2]
+  // in both cases it is [M dim, N dim]/[batch, M dim, N dim]
+  SmallVector<unsigned> warpOrder = triton::gpu::getWarpOrder(dotMfmaLayout);
+  LinearLayout warpLayout = identityStandardND(kWarp, warpsPerCTA, warpOrder);
+
+  LinearLayout ctaLayout = tileLayout.transposeOuts(outDimNames) *
+                           warpLayout.transposeOuts(outDimNames);
+  auto finalLayout =
+      combineCtaCgaWithShape(ctaLayout, mfmaLayout.getCTALayout(), shape);
+  // llvm::outs() << finalLayout;
+  return finalLayout;
+}
+
 LinearLayout mfmaDotToLinearLayout(DotOperandEncodingAttr dotMfmaLayout,
                                    ArrayRef<int64_t> shape) {
 
@@ -1198,6 +1328,12 @@ LinearLayout chooseLdMatrixLayout(Attribute enc, ArrayRef<int64_t> shape,
                                   bool needTrans, int32_t elemBitWidth) {
   auto dot = cast<DotOperandEncodingAttr>(enc);
   return chooseDotLdMatrixLayout(dot, shape, needTrans, elemBitWidth);
+}
+
+LinearLayout chooseLDSTransLayout(Attribute enc, ArrayRef<int64_t> shape,
+                                  int32_t elemBitWidth) {
+  auto dot = cast<DotOperandEncodingAttr>(enc);
+  return chooseDotLDSTransLayout(dot, shape, elemBitWidth);
 }
 
 } // namespace mlir::triton::gpu

--- a/test/Conversion/amd/ds_transpose.mlir
+++ b/test/Conversion/amd/ds_transpose.mlir
@@ -1,0 +1,77 @@
+// RUN: triton-opt %s --split-input-file --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s
+
+#mma16 = #ttg.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 16], isTransposed = true}>
+#mma32 = #ttg.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [32, 32], isTransposed = true}>
+#shared = #ttg.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1], hasLeadingOffset = false}>
+#shared1 = #ttg.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], hasLeadingOffset = false}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  //  CHECK-LABEL: ds_transpose_n_t_fp16_mfma_16
+  tt.func @ds_transpose_n_t_fp16_mfma_16(%arg0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf16, #shared1, #smem, mutable>) {
+    // CHECK-COUNT-32: rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 8}>>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf16, #shared1, #smem, mutable> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 8}>>
+    tt.return
+  }
+
+  //  CHECK-LABEL: ds_transpose_t_t_fp16_mfma_16
+  tt.func @ds_transpose_t_t_fp16_mfma_16(%arg0: !ttg.memdesc<128x64xf16, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf16, #shared1, #smem, mutable>) {
+    // CHECK-COUNT-8: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<8xf16>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf16, #shared1, #smem, mutable> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 8}>>
+    // CHECK-COUNT-16: rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf16, #shared1, #smem, mutable> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 8}>>
+    tt.return
+  }
+
+  //  CHECK-LABEL: ds_transpose_n_n_fp16_mfma_16
+  tt.func @ds_transpose_n_n_fp16_mfma_16(%arg0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf16, #shared, #smem, mutable>) {
+    // CHECK-COUNT-16: rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 8}>>
+    // CHECK-COUNT-8: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<8xf16>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 8}>>
+    tt.return
+  }
+
+  //  CHECK-LABEL: ds_transpose_t_n_fp16_mfma_16
+  tt.func @ds_transpose_t_n_fp16_mfma_16(%arg0: !ttg.memdesc<128x64xf16, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf16, #shared, #smem, mutable>) {
+    // CHECK-NOT: rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf16, #shared1, #smem, mutable> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 8}>>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 8}>>
+    tt.return
+  }
+
+  //  CHECK-LABEL: ds_transpose_n_t_fp16_mfma32
+  tt.func @ds_transpose_n_t_fp16_mfma32(%arg0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf16, #shared1, #smem, mutable>) {
+    // CHECK-COUNT-32: rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 8}>>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf16, #shared1, #smem, mutable> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 8}>>
+    tt.return
+  }
+
+  //  CHECK-LABEL: ds_transpose_t_t_fp16_mfma32
+  tt.func @ds_transpose_t_t_fp16_mfma32(%arg0: !ttg.memdesc<128x64xf16, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf16, #shared1, #smem, mutable>) {
+    // CHECK-COUNT-8: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<8xf16>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf16, #shared1, #smem, mutable> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 8}>>
+    // CHECK-COUNT-16: rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf16, #shared1, #smem, mutable> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 8}>>
+    tt.return
+  }
+
+  //  CHECK-LABEL: ds_transpose_n_n_fp16_mfma32
+  tt.func @ds_transpose_n_n_fp16_mfma32(%arg0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf16, #shared, #smem, mutable>) {
+    // CHECK-COUNT-16: rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 8}>>
+    // CHECK-COUNT-8: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<8xf16>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 8}>>
+    tt.return
+  }
+
+  //  CHECK-LABEL: ds_transpose_t_n_fp16_mfma32
+  tt.func @ds_transpose_t_n_fp16_mfma32(%arg0: !ttg.memdesc<128x64xf16, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf16, #shared, #smem, mutable>) {
+    // CHECK-NOT: rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf16, #shared1, #smem, mutable> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 8}>>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 8}>>
+    tt.return
+  }
+}

--- a/test/Conversion/amd/ds_transpose.mlir
+++ b/test/Conversion/amd/ds_transpose.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt %s --split-input-file --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s
 
-#mma16 = #ttg.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 16], isTransposed = true}>
-#mma32 = #ttg.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [32, 32], isTransposed = true}>
+#mma16 = #ttg.amd_mfma<{versionMajor = 4, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 16], isTransposed = true}>
+#mma32 = #ttg.amd_mfma<{versionMajor = 4, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [32, 32], isTransposed = true}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory

--- a/test/Conversion/amd/ds_transpose.mlir
+++ b/test/Conversion/amd/ds_transpose.mlir
@@ -2,8 +2,8 @@
 
 #mma16 = #ttg.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 16], isTransposed = true}>
 #mma32 = #ttg.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [32, 32], isTransposed = true}>
-#shared = #ttg.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1], hasLeadingOffset = false}>
-#shared1 = #ttg.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], hasLeadingOffset = false}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -14,6 +14,7 @@ void populateConvertLayoutOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
 
 void populateMemoryOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                     RewritePatternSet &patterns,
+                                    const TargetInfo &targetInfo,
                                     PatternBenefit benefit);
 
 void populateDotOpToLLVMPatterns(LLVMTypeConverter &typeConverter,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -101,6 +101,10 @@ bool TargetInfo::canUseStMatrix(RankedTensorType tensorTy,
   return false;
 }
 
+bool TargetInfo::canUseLDSTransLoad(int bitwidth) const {
+  return arch == "gfx950" && llvm::is_contained({16, 8, 4, 6}, bitwidth);
+}
+
 void TargetInfo::storeMatrixShared(RewriterBase &rewriter, Location loc,
                                    Value ptr, Value val) const {
   llvm::report_fatal_error("AMDGPU does not support stmatrix");

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -30,6 +30,7 @@ public:
   Value loadDShared(RewriterBase &rewriter, Location loc, Value ptr,
                     std::optional<Value> ctaId, Type elemTy,
                     Value pred) const override;
+  bool canUseLDSTransLoad(int bitwidth) const;
 
   bool canUseStMatrix(RankedTensorType tensorTy, ArrayRef<unsigned> repShape,
                       ArrayRef<unsigned> paddedRepShape,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -195,7 +195,8 @@ struct ConvertTritonAMDGPUToLLVM
     populatePatterns7(mlir::triton::populateGatherOpToLLVMPatterns,
                       commonBenefit);
 
-    AMD::populateMemoryOpToLLVMPatterns(typeConverter, patterns, AMDBenefit);
+    AMD::populateMemoryOpToLLVMPatterns(typeConverter, patterns, targetInfo,
+                                        AMDBenefit);
     mlir::triton::populateMemoryOpToLLVMPatterns(typeConverter, targetInfo,
                                                  patterns, commonBenefit);
     mlir::triton::populateMakeRangeOpToLLVMPattern(typeConverter, targetInfo,

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -1523,6 +1523,225 @@ TEST_F(LinearLayoutConversionsTest, mfma16_dot_op_rhs_kwidth4) {
             toLinearLayout({16, 16}, mfmaDotOp1_16));
 }
 
+TEST_F(LinearLayoutConversionsTest, mfma16_dot_op_lhs_trans) {
+  auto parentMfma16 = mfma(/*warps=*/{2, 4}, /*mDim=*/16, /*nDim=*/16,
+                           /*isTransposed=*/false);
+  auto mfmaDotOp0_kwidth_8 = mfmaDotOp(parentMfma16, /*opIdx=*/0, /*kWidth=*/8);
+  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {128, 128},
+                                 /*elemBitWidth=*/16),
+            LinearLayout(
+                {{S("register"),
+                  {{1, 0}, {2, 0}, {0, 4}, {0, 32}, {0, 64}, {32, 0}, {64, 0}}},
+                 {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {0, 8}, {0, 16}}},
+                 {S("warp"), {{0, 0}, {0, 0}, {16, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+  EXPECT_EQ(
+      chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {32, 64}, /*elemBitWidth=*/16),
+      LinearLayout(
+          {{S("register"), {{1, 0}, {2, 0}, {0, 4}, {0, 32}}},
+           {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {0, 8}, {0, 16}}},
+           {S("warp"), {{0, 0}, {0, 0}, {16, 0}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+
+  auto mfmaDotOp0_kwidth_4 = mfmaDotOp(parentMfma16, /*opIdx=*/0, /*kWidth=*/4);
+  EXPECT_EQ(
+      chooseLDSTransLayout(mfmaDotOp0_kwidth_4, {16, 16}, /*elemBitWidth=*/16),
+      LinearLayout(
+          {{S("register"), {{1, 0}, {2, 0}}},
+           {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {0, 4}, {0, 8}}},
+           {S("warp"), {{0, 0}, {0, 0}, {0, 0}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+
+  // Dot operand for LDS transpose load on transposed mfma layout has same
+  // layout as ordinary
+  auto parentTMfma16 = mfma(/*warps=*/{2, 4}, /*mDim=*/16, /*nDim=*/16,
+                            /*isTransposed=*/true);
+  auto tmfmaDotOp0_kwidth_8 =
+      mfmaDotOp(parentTMfma16, /*opIdx=*/0, /*kWidth=*/8);
+  auto tmfmaDotOp0_kwidth_4 =
+      mfmaDotOp(parentTMfma16, /*opIdx=*/0, /*kWidth=*/4);
+
+  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp0_kwidth_8, {128, 128},
+                                 /*elemBitWidth=*/16),
+            chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {128, 128},
+                                 /*elemBitWidth=*/16));
+  EXPECT_EQ(
+      chooseLDSTransLayout(tmfmaDotOp0_kwidth_8, {64, 32}, /*elemBitWidth=*/16),
+      chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {64, 32}, /*elemBitWidth=*/16));
+  EXPECT_EQ(
+      chooseLDSTransLayout(tmfmaDotOp0_kwidth_4, {16, 16}, /*elemBitWidth=*/16),
+      chooseLDSTransLayout(mfmaDotOp0_kwidth_4, {16, 16}, /*elemBitWidth=*/16));
+}
+
+TEST_F(LinearLayoutConversionsTest, mfma16_dot_op_rhs_trans) {
+  auto parentMfma16 = mfma(/*warps=*/{2, 4}, /*mDim=*/16, /*nDim=*/16,
+                           /*isTransposed=*/false);
+  auto mfmaDotOp1_kwidth_8 = mfmaDotOp(parentMfma16, /*opIdx=*/1, /*kWidth=*/8);
+  EXPECT_EQ(
+      chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {128, 128},
+                           /*elemBitWidth=*/16),
+      LinearLayout(
+          {{S("register"), {{0, 1}, {0, 2}, {4, 0}, {32, 0}, {64, 0}, {0, 64}}},
+           {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {8, 0}, {16, 0}}},
+           {S("warp"), {{0, 16}, {0, 32}, {0, 0}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {32, 64},
+                                 /*elemBitWidth=*/16),
+            LinearLayout(
+                {{S("register"), {{0, 1}, {0, 2}, {4, 0}}},
+                 {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {8, 0}, {16, 0}}},
+                 {S("warp"), {{0, 16}, {0, 32}, {0, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+
+  auto mfmaDotOp1_kwidth_4 = mfmaDotOp(parentMfma16, /*opIdx=*/1, /*kWidth=*/4);
+  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp1_kwidth_4, {16, 16},
+                                 /*elemBitWidth=*/16),
+            LinearLayout(
+                {{S("register"), {{0, 1}, {0, 2}}},
+                 {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {4, 0}, {8, 0}}},
+                 {S("warp"), {{0, 0}, {0, 0}, {0, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+
+  // Dot operand for LDS transpose load based on transposed mfma layout has
+  // same  layout as ordinary.
+  auto parentTMfma16 = mfma(/*warps=*/{2, 4}, /*mDim=*/16, /*nDim=*/16,
+                            /*isTransposed=*/true);
+  auto tmfmaDotOp1_kwidth_8 =
+      mfmaDotOp(parentTMfma16, /*opIdx=*/1, /*kWidth=*/8);
+  auto tmfmaDotOp1_kwidth_4 =
+      mfmaDotOp(parentTMfma16, /*opIdx=*/1, /*kWidth=*/4);
+
+  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_8, {128, 128},
+                                 /*elemBitWidth=*/16),
+            chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {128, 128},
+                                 /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_8, {64, 32},
+                                 /*elemBitWidth=*/16),
+            chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {64, 32},
+                                 /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_4, {16, 16},
+                                 /*elemBitWidth=*/16),
+            chooseLDSTransLayout(mfmaDotOp1_kwidth_4, {16, 16},
+                                 /*elemBitWidth=*/16));
+}
+
+TEST_F(LinearLayoutConversionsTest, mfma32_dot_op_lhs_trans) {
+  auto parentMfma32 = mfma(/*warps=*/{2, 4}, /*mDim=*/32, /*nDim=*/32,
+                           /*isTransposed=*/false);
+  auto mfmaDotOp0_kwidth_8 = mfmaDotOp(parentMfma32, /*opIdx=*/0, /*kWidth=*/8);
+  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {128, 128},
+                                 /*elemBitWidth=*/16),
+            LinearLayout(
+                {{S("register"),
+                  {{1, 0}, {2, 0}, {0, 4}, {0, 16}, {0, 32}, {0, 64}, {64, 0}}},
+                 {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {16, 0}, {0, 8}}},
+                 {S("warp"), {{0, 0}, {0, 0}, {32, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {32, 64},
+                                 /*elemBitWidth=*/16),
+            LinearLayout(
+                {{S("register"), {{1, 0}, {2, 0}, {0, 4}, {0, 16}, {0, 32}}},
+                 {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {16, 0}, {0, 8}}},
+                 {S("warp"), {{0, 0}, {0, 0}, {0, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+
+  auto mfmaDotOp0_kwidth_4 = mfmaDotOp(parentMfma32, /*opIdx=*/0,
+                                       /*kWidth=*/4);
+  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp0_kwidth_4, {32, 8},
+                                 /*elemBitWidth=*/16),
+            LinearLayout(
+                {{S("register"), {{1, 0}, {2, 0}}},
+                 {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {16, 0}, {0, 4}}},
+                 {S("warp"), {{0, 0}, {0, 0}, {0, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+
+  // Dot operand for LDS transpose load based on transposed mfma layout has
+  // same  layout as ordinary.
+  auto parentTMfma32 = mfma(/*warps=*/{2, 4}, /*mDim=*/32, /*nDim=*/32,
+                            /*isTransposed=*/true);
+  auto tmfmaDotOp0_kwidth_8 =
+      mfmaDotOp(parentTMfma32, /*opIdx=*/0, /*kWidth=*/8);
+  auto tmfmaDotOp0_kwidth_4 =
+      mfmaDotOp(parentTMfma32, /*opIdx=*/0, /*kWidth=*/4);
+
+  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp0_kwidth_8, {128, 128},
+                                 /*elemBitWidth=*/16),
+            chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {128, 128},
+                                 /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp0_kwidth_8, {64, 32},
+                                 /*elemBitWidth=*/16),
+            chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {64, 32},
+                                 /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp0_kwidth_4, {32, 8},
+                                 /*elemBitWidth=*/16),
+            chooseLDSTransLayout(mfmaDotOp0_kwidth_4, {32, 8},
+                                 /*elemBitWidth=*/16));
+}
+
+TEST_F(LinearLayoutConversionsTest, mfma32_dot_op_rhs_trans) {
+  auto parentMfma16 = mfma(/*warps=*/{2, 4}, /*mDim=*/32, /*nDim=*/32,
+                           /*isTransposed=*/false);
+  auto mfmaDotOp1_kwidth_8 = mfmaDotOp(parentMfma16, /*opIdx=*/1, /*kWidth=*/8);
+  EXPECT_EQ(
+      chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {128, 128},
+                           /*elemBitWidth=*/16),
+      LinearLayout(
+          {{S("register"), {{0, 1}, {0, 2}, {4, 0}, {16, 0}, {32, 0}, {64, 0}}},
+           {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {0, 16}, {8, 0}}},
+           {S("warp"), {{0, 32}, {0, 64}, {0, 0}}},
+           {S("block"), {}}},
+          {S("dim0"), S("dim1")}));
+  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {32, 64},
+                                 /*elemBitWidth=*/16),
+            LinearLayout(
+                {{S("register"), {{0, 1}, {0, 2}, {4, 0}, {16, 0}}},
+                 {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {0, 16}, {8, 0}}},
+                 {S("warp"), {{0, 32}, {0, 0}, {0, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+
+  auto mfmaDotOp1_kwidth_4 = mfmaDotOp(parentMfma16, /*opIdx=*/1, /*kWidth=*/4);
+  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp1_kwidth_4, {8, 32},
+                                 /*elemBitWidth=*/16),
+            LinearLayout(
+                {{S("register"), {{0, 1}, {0, 2}}},
+                 {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {0, 16}, {4, 0}}},
+                 {S("warp"), {{0, 0}, {0, 0}, {0, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+
+  // Dot operand for LDS transpose load based on transposed mfma layout has
+  // same  layout as ordinary.
+  auto parentTMfma16 = mfma(/*warps=*/{2, 4}, /*mDim=*/32, /*nDim=*/32,
+                            /*isTransposed=*/true);
+  auto tmfmaDotOp1_kwidth_8 =
+      mfmaDotOp(parentTMfma16, /*opIdx=*/1, /*kWidth=*/8);
+  auto tmfmaDotOp1_kwidth_4 =
+      mfmaDotOp(parentTMfma16, /*opIdx=*/1, /*kWidth=*/4);
+
+  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_8, {128, 128},
+                                 /*elemBitWidth=*/16),
+            chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {128, 128},
+                                 /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_8, {64, 32},
+                                 /*elemBitWidth=*/16),
+            chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {64, 32},
+                                 /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_4, {8, 32},
+                                 /*elemBitWidth=*/16),
+            chooseLDSTransLayout(mfmaDotOp1_kwidth_4, {8, 32},
+                                 /*elemBitWidth=*/16));
+}
+
 TEST_F(LinearLayoutConversionsTest, WMMA_v1_2x4Warps) {
   auto legacy = wmma(/*warps=*/{2, 4}, /*version=*/1, /*transposed=*/false);
 

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -1527,8 +1527,8 @@ TEST_F(LinearLayoutConversionsTest, mfma16_dot_op_lhs_trans) {
   auto parentMfma16 = mfma(/*warps=*/{2, 4}, /*mDim=*/16, /*nDim=*/16,
                            /*isTransposed=*/false);
   auto mfmaDotOp0_kwidth_8 = mfmaDotOp(parentMfma16, /*opIdx=*/0, /*kWidth=*/8);
-  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {128, 128},
-                                 /*elemBitWidth=*/16),
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_8, {128, 128},
+                                      /*elemBitWidth=*/16),
             LinearLayout(
                 {{S("register"),
                   {{1, 0}, {2, 0}, {0, 4}, {0, 32}, {0, 64}, {32, 0}, {64, 0}}},
@@ -1536,24 +1536,24 @@ TEST_F(LinearLayoutConversionsTest, mfma16_dot_op_lhs_trans) {
                  {S("warp"), {{0, 0}, {0, 0}, {16, 0}}},
                  {S("block"), {}}},
                 {S("dim0"), S("dim1")}));
-  EXPECT_EQ(
-      chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {32, 64}, /*elemBitWidth=*/16),
-      LinearLayout(
-          {{S("register"), {{1, 0}, {2, 0}, {0, 4}, {0, 32}}},
-           {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {0, 8}, {0, 16}}},
-           {S("warp"), {{0, 0}, {0, 0}, {16, 0}}},
-           {S("block"), {}}},
-          {S("dim0"), S("dim1")}));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_8, {32, 64},
+                                      /*elemBitWidth=*/16),
+            LinearLayout(
+                {{S("register"), {{1, 0}, {2, 0}, {0, 4}, {0, 32}}},
+                 {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {0, 8}, {0, 16}}},
+                 {S("warp"), {{0, 0}, {0, 0}, {16, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
 
   auto mfmaDotOp0_kwidth_4 = mfmaDotOp(parentMfma16, /*opIdx=*/0, /*kWidth=*/4);
-  EXPECT_EQ(
-      chooseLDSTransLayout(mfmaDotOp0_kwidth_4, {16, 16}, /*elemBitWidth=*/16),
-      LinearLayout(
-          {{S("register"), {{1, 0}, {2, 0}}},
-           {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {0, 4}, {0, 8}}},
-           {S("warp"), {{0, 0}, {0, 0}, {0, 0}}},
-           {S("block"), {}}},
-          {S("dim0"), S("dim1")}));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_4, {16, 16},
+                                      /*elemBitWidth=*/16),
+            LinearLayout(
+                {{S("register"), {{1, 0}, {2, 0}}},
+                 {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {0, 4}, {0, 8}}},
+                 {S("warp"), {{0, 0}, {0, 0}, {0, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
 
   // Dot operand for LDS transpose load on transposed mfma layout has same
   // layout as ordinary
@@ -1564,16 +1564,18 @@ TEST_F(LinearLayoutConversionsTest, mfma16_dot_op_lhs_trans) {
   auto tmfmaDotOp0_kwidth_4 =
       mfmaDotOp(parentTMfma16, /*opIdx=*/0, /*kWidth=*/4);
 
-  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp0_kwidth_8, {128, 128},
-                                 /*elemBitWidth=*/16),
-            chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {128, 128},
-                                 /*elemBitWidth=*/16));
-  EXPECT_EQ(
-      chooseLDSTransLayout(tmfmaDotOp0_kwidth_8, {64, 32}, /*elemBitWidth=*/16),
-      chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {64, 32}, /*elemBitWidth=*/16));
-  EXPECT_EQ(
-      chooseLDSTransLayout(tmfmaDotOp0_kwidth_4, {16, 16}, /*elemBitWidth=*/16),
-      chooseLDSTransLayout(mfmaDotOp0_kwidth_4, {16, 16}, /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp0_kwidth_8, {128, 128},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_8, {128, 128},
+                                      /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp0_kwidth_8, {64, 32},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_8, {64, 32},
+                                      /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp0_kwidth_4, {16, 16},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_4, {16, 16},
+                                      /*elemBitWidth=*/16));
 }
 
 TEST_F(LinearLayoutConversionsTest, mfma16_dot_op_rhs_trans) {
@@ -1581,16 +1583,16 @@ TEST_F(LinearLayoutConversionsTest, mfma16_dot_op_rhs_trans) {
                            /*isTransposed=*/false);
   auto mfmaDotOp1_kwidth_8 = mfmaDotOp(parentMfma16, /*opIdx=*/1, /*kWidth=*/8);
   EXPECT_EQ(
-      chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {128, 128},
-                           /*elemBitWidth=*/16),
+      chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_8, {128, 128},
+                                /*elemBitWidth=*/16),
       LinearLayout(
           {{S("register"), {{0, 1}, {0, 2}, {4, 0}, {32, 0}, {64, 0}, {0, 64}}},
            {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {8, 0}, {16, 0}}},
            {S("warp"), {{0, 16}, {0, 32}, {0, 0}}},
            {S("block"), {}}},
           {S("dim0"), S("dim1")}));
-  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {32, 64},
-                                 /*elemBitWidth=*/16),
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_8, {32, 64},
+                                      /*elemBitWidth=*/16),
             LinearLayout(
                 {{S("register"), {{0, 1}, {0, 2}, {4, 0}}},
                  {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {8, 0}, {16, 0}}},
@@ -1599,8 +1601,8 @@ TEST_F(LinearLayoutConversionsTest, mfma16_dot_op_rhs_trans) {
                 {S("dim0"), S("dim1")}));
 
   auto mfmaDotOp1_kwidth_4 = mfmaDotOp(parentMfma16, /*opIdx=*/1, /*kWidth=*/4);
-  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp1_kwidth_4, {16, 16},
-                                 /*elemBitWidth=*/16),
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_4, {16, 16},
+                                      /*elemBitWidth=*/16),
             LinearLayout(
                 {{S("register"), {{0, 1}, {0, 2}}},
                  {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {4, 0}, {8, 0}}},
@@ -1617,26 +1619,26 @@ TEST_F(LinearLayoutConversionsTest, mfma16_dot_op_rhs_trans) {
   auto tmfmaDotOp1_kwidth_4 =
       mfmaDotOp(parentTMfma16, /*opIdx=*/1, /*kWidth=*/4);
 
-  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_8, {128, 128},
-                                 /*elemBitWidth=*/16),
-            chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {128, 128},
-                                 /*elemBitWidth=*/16));
-  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_8, {64, 32},
-                                 /*elemBitWidth=*/16),
-            chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {64, 32},
-                                 /*elemBitWidth=*/16));
-  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_4, {16, 16},
-                                 /*elemBitWidth=*/16),
-            chooseLDSTransLayout(mfmaDotOp1_kwidth_4, {16, 16},
-                                 /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp1_kwidth_8, {128, 128},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_8, {128, 128},
+                                      /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp1_kwidth_8, {64, 32},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_8, {64, 32},
+                                      /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp1_kwidth_4, {16, 16},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_4, {16, 16},
+                                      /*elemBitWidth=*/16));
 }
 
 TEST_F(LinearLayoutConversionsTest, mfma32_dot_op_lhs_trans) {
   auto parentMfma32 = mfma(/*warps=*/{2, 4}, /*mDim=*/32, /*nDim=*/32,
                            /*isTransposed=*/false);
   auto mfmaDotOp0_kwidth_8 = mfmaDotOp(parentMfma32, /*opIdx=*/0, /*kWidth=*/8);
-  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {128, 128},
-                                 /*elemBitWidth=*/16),
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_8, {128, 128},
+                                      /*elemBitWidth=*/16),
             LinearLayout(
                 {{S("register"),
                   {{1, 0}, {2, 0}, {0, 4}, {0, 16}, {0, 32}, {0, 64}, {64, 0}}},
@@ -1644,8 +1646,8 @@ TEST_F(LinearLayoutConversionsTest, mfma32_dot_op_lhs_trans) {
                  {S("warp"), {{0, 0}, {0, 0}, {32, 0}}},
                  {S("block"), {}}},
                 {S("dim0"), S("dim1")}));
-  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {32, 64},
-                                 /*elemBitWidth=*/16),
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_8, {32, 64},
+                                      /*elemBitWidth=*/16),
             LinearLayout(
                 {{S("register"), {{1, 0}, {2, 0}, {0, 4}, {0, 16}, {0, 32}}},
                  {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {16, 0}, {0, 8}}},
@@ -1655,8 +1657,8 @@ TEST_F(LinearLayoutConversionsTest, mfma32_dot_op_lhs_trans) {
 
   auto mfmaDotOp0_kwidth_4 = mfmaDotOp(parentMfma32, /*opIdx=*/0,
                                        /*kWidth=*/4);
-  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp0_kwidth_4, {32, 8},
-                                 /*elemBitWidth=*/16),
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_4, {32, 8},
+                                      /*elemBitWidth=*/16),
             LinearLayout(
                 {{S("register"), {{1, 0}, {2, 0}}},
                  {S("lane"), {{4, 0}, {8, 0}, {0, 1}, {0, 2}, {16, 0}, {0, 4}}},
@@ -1673,18 +1675,18 @@ TEST_F(LinearLayoutConversionsTest, mfma32_dot_op_lhs_trans) {
   auto tmfmaDotOp0_kwidth_4 =
       mfmaDotOp(parentTMfma32, /*opIdx=*/0, /*kWidth=*/4);
 
-  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp0_kwidth_8, {128, 128},
-                                 /*elemBitWidth=*/16),
-            chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {128, 128},
-                                 /*elemBitWidth=*/16));
-  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp0_kwidth_8, {64, 32},
-                                 /*elemBitWidth=*/16),
-            chooseLDSTransLayout(mfmaDotOp0_kwidth_8, {64, 32},
-                                 /*elemBitWidth=*/16));
-  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp0_kwidth_4, {32, 8},
-                                 /*elemBitWidth=*/16),
-            chooseLDSTransLayout(mfmaDotOp0_kwidth_4, {32, 8},
-                                 /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp0_kwidth_8, {128, 128},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_8, {128, 128},
+                                      /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp0_kwidth_8, {64, 32},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_8, {64, 32},
+                                      /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp0_kwidth_4, {32, 8},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp0_kwidth_4, {32, 8},
+                                      /*elemBitWidth=*/16));
 }
 
 TEST_F(LinearLayoutConversionsTest, mfma32_dot_op_rhs_trans) {
@@ -1692,16 +1694,16 @@ TEST_F(LinearLayoutConversionsTest, mfma32_dot_op_rhs_trans) {
                            /*isTransposed=*/false);
   auto mfmaDotOp1_kwidth_8 = mfmaDotOp(parentMfma16, /*opIdx=*/1, /*kWidth=*/8);
   EXPECT_EQ(
-      chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {128, 128},
-                           /*elemBitWidth=*/16),
+      chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_8, {128, 128},
+                                /*elemBitWidth=*/16),
       LinearLayout(
           {{S("register"), {{0, 1}, {0, 2}, {4, 0}, {16, 0}, {32, 0}, {64, 0}}},
            {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {0, 16}, {8, 0}}},
            {S("warp"), {{0, 32}, {0, 64}, {0, 0}}},
            {S("block"), {}}},
           {S("dim0"), S("dim1")}));
-  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {32, 64},
-                                 /*elemBitWidth=*/16),
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_8, {32, 64},
+                                      /*elemBitWidth=*/16),
             LinearLayout(
                 {{S("register"), {{0, 1}, {0, 2}, {4, 0}, {16, 0}}},
                  {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {0, 16}, {8, 0}}},
@@ -1710,8 +1712,8 @@ TEST_F(LinearLayoutConversionsTest, mfma32_dot_op_rhs_trans) {
                 {S("dim0"), S("dim1")}));
 
   auto mfmaDotOp1_kwidth_4 = mfmaDotOp(parentMfma16, /*opIdx=*/1, /*kWidth=*/4);
-  EXPECT_EQ(chooseLDSTransLayout(mfmaDotOp1_kwidth_4, {8, 32},
-                                 /*elemBitWidth=*/16),
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_4, {8, 32},
+                                      /*elemBitWidth=*/16),
             LinearLayout(
                 {{S("register"), {{0, 1}, {0, 2}}},
                  {S("lane"), {{0, 4}, {0, 8}, {1, 0}, {2, 0}, {0, 16}, {4, 0}}},
@@ -1728,18 +1730,18 @@ TEST_F(LinearLayoutConversionsTest, mfma32_dot_op_rhs_trans) {
   auto tmfmaDotOp1_kwidth_4 =
       mfmaDotOp(parentTMfma16, /*opIdx=*/1, /*kWidth=*/4);
 
-  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_8, {128, 128},
-                                 /*elemBitWidth=*/16),
-            chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {128, 128},
-                                 /*elemBitWidth=*/16));
-  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_8, {64, 32},
-                                 /*elemBitWidth=*/16),
-            chooseLDSTransLayout(mfmaDotOp1_kwidth_8, {64, 32},
-                                 /*elemBitWidth=*/16));
-  EXPECT_EQ(chooseLDSTransLayout(tmfmaDotOp1_kwidth_4, {8, 32},
-                                 /*elemBitWidth=*/16),
-            chooseLDSTransLayout(mfmaDotOp1_kwidth_4, {8, 32},
-                                 /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp1_kwidth_8, {128, 128},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_8, {128, 128},
+                                      /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp1_kwidth_8, {64, 32},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_8, {64, 32},
+                                      /*elemBitWidth=*/16));
+  EXPECT_EQ(chooseDsReadB64Tr16Layout(tmfmaDotOp1_kwidth_4, {8, 32},
+                                      /*elemBitWidth=*/16),
+            chooseDsReadB64Tr16Layout(mfmaDotOp1_kwidth_4, {8, 32},
+                                      /*elemBitWidth=*/16));
 }
 
 TEST_F(LinearLayoutConversionsTest, WMMA_v1_2x4Warps) {


### PR DESCRIPTION
This PR introduces initial support for using LDS transposed load intrinsics in Triton. It implements selection of ds_read_b64_tr_b16 instruction for mi350 architecture. These intrinsics are designed to handle tensors that are non-k contiguous in LDS, enabling efficient loading in a transposed manner. 

LDS transposed loading only works if:
1. The hardware supports transposed LDS load instructions.
2. The tensor we’re loading is contiguous along the non-K dimension in LDS.

How the compiler handles LDS transpose loads (like the intrinsics and LL we use) depends on two things:
1. The type of data we’re working with.
2. The type of MFMA instruction.

Currently, we only support transpose loads for 16-bit data on gfx950.
TODO: Add support for other data types (e.g., 8-bit types).
TODO : Support transpose loading on swizzled data to avoid bank conflicts.