### PR TITLE
[DEV] Unify Makefile and cuda CI commands

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,6 +26,7 @@ env:
   TRITON_USE_ASSERT_ENABLED_LLVM: "TRUE"
   TRITON_DISABLE_LINE_INFO: 1
   PROTON_SKIP_PC_SAMPLING_TEST: 1
+  PYTHON: "python3"
   CCACHE_COMPRESS: "true"
 jobs:
   Runner-Preparation:
@@ -233,18 +234,13 @@ jobs:
       - name: Update PATH
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - name: Install pip dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install cython setuptools wheel cmake==3.24 ninja lit
       - name: Install Triton
         env:
           CUDA_HOME: "/usr/local/cuda"
         run: |
           echo "PATH is '$PATH'"
           ccache --zero-stats
-          python3 -m pip install -r python/requirements.txt
-          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
+          make dev-install
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
@@ -371,8 +367,7 @@ jobs:
           echo "PATH is '$PATH'"
           pip uninstall -y triton pytorch-triton-rocm
           ccache --zero-stats
-          python3 -m pip install -r python/requirements.txt
-          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
+          make dev-install
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
@@ -528,12 +523,11 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
-      - name: Install pip dependencies
+      - name: Create venv
         run: |
           python3 -m venv ~/.venv
           source ~/.venv/bin/activate
           python3 -m pip install --upgrade pip
-          python3 -m pip install cython setuptools wheel cmake==3.24 ninja lit pybind11
       - name: Install Triton
         env:
           TRITON_BUILD_WITH_O1: "true"
@@ -544,8 +538,7 @@ jobs:
           source ~/.venv/bin/activate
           echo "PATH is '$PATH'"
           ccache --zero-stats
-          python3 -m pip install -r python/requirements.txt
-          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
+          make dev-install
       - name: CCache Stats
         run: ccache --print-stats
       - name: Inspect cache directories

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -247,18 +247,18 @@ jobs:
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
-        run: make test-lit PYTHON=python3
+        run: make test-lit
       - name: Run python tests on CUDA
-        run: make test-unit PYTHON=python3
+        run: make test-unit
       - name: Run interpreter tests
         if: ${{ matrix.runner[0] == 'h100-runner-set' }}
-        run: make test-intrepet PYTHON=python3
+        run: make test-intrepet
       - name: Run regression tests
-        run: make test-regression PYTHON=python3
+        run: make test-regression
       - name: Run C++ unittests
-        run: make test-cpp PYTHON=python3
+        run: make test-cpp
       - name: Run Proton tests
-        run: make test-proton PYTHON=python3
+        run: make test-proton
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton
@@ -374,7 +374,7 @@ jobs:
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
-        run: make test-lit PYTHON=python3
+        run: make test-lit
       - name: Run python tests on HIP
         run: |
           INSTRUMENTATION_LIB_DIR="${GITHUB_WORKSPACE}/python/triton/instrumentation"
@@ -412,9 +412,9 @@ jobs:
           cd python/test/regression
           python3 -m pytest -s -n 8 ./test_cast_matmul.py
       - name: Run Proton tests
-        run: make test-proton PYTHON=python3
+        run: make test-proton
       - name: Run C++ unittests
-        run: make test-cpp PYTHON=python3
+        run: make test-cpp
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -248,7 +248,7 @@ jobs:
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
-        run: make test-lit
+        run: make test-lit PYTHON=python3
       - name: Run python tests on CUDA
         run: make test-unit PYTHON=python3
       - name: Run interpreter tests
@@ -257,7 +257,7 @@ jobs:
       - name: Run regression tests
         run: make test-regression PYTHON=python3
       - name: Run C++ unittests
-        run: make test-cpp
+        run: make test-cpp PYTHON=python3
       - name: Run Proton tests
         run: make test-proton PYTHON=python3
       - name: Inspect cache directories
@@ -376,7 +376,7 @@ jobs:
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
-        run: make test-lit
+        run: make test-lit PYTHON=python3
       - name: Run python tests on HIP
         run: |
           INSTRUMENTATION_LIB_DIR="${GITHUB_WORKSPACE}/python/triton/instrumentation"
@@ -416,7 +416,7 @@ jobs:
       - name: Run Proton tests
         run: make test-proton PYTHON=python3
       - name: Run C++ unittests
-        run: make test-cpp
+        run: make test-cpp PYTHON=python3
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -249,7 +249,7 @@ jobs:
         run: make test-unit
       - name: Run interpreter tests
         if: ${{ matrix.runner[0] == 'h100-runner-set' }}
-        run: make test-intrepet
+        run: make test-interpret
       - name: Run regression tests
         run: make test-regression
       - name: Run C++ unittests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -248,53 +248,18 @@ jobs:
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
-        run: |
-          cd python
-          LIT_TEST_DIR="build/$(ls build | grep -i cmake)/test"
-          if [ ! -d "${LIT_TEST_DIR}" ]; then
-            echo "Could not find '${LIT_TEST_DIR}'" ; exit -1
-          fi
-          lit -v "${LIT_TEST_DIR}"
+        run: make test-lit
       - name: Run python tests on CUDA
-        run: |
-          INSTRUMENTATION_LIB_DIR="${GITHUB_WORKSPACE}/python/build/$(ls python/build | grep -i lib)/triton/instrumentation"
-          if [ ! -d "${INSTRUMENTATION_LIB_DIR}" ]; then
-            echo "Could not find '${INSTRUMENTATION_LIB_DIR}'" ; exit -1
-          fi
-          cd python/test/unit
-          python3 -m pytest -s -n 8 --ignore=cuda/test_flashattention.py --ignore=language/test_line_info.py --ignore=language/test_subprocess.py --ignore=test_debug.py
-          python3 -m pytest -s -n 8 language/test_subprocess.py
-          python3 -m pytest -s -n 8 test_debug.py --forked
-          # Run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
-          TRITON_DISABLE_LINE_INFO=0 python3 -m pytest -s language/test_line_info.py
-          # Run cuda/test_flashattention.py separately to avoid out of gpu memory
-          python3 -m pytest -s cuda/test_flashattention.py
-          TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${INSTRUMENTATION_LIB_DIR}/libGPUInstrumentationTestLib.so \
-          python3 -m pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
+        run: make test-unit PYTHON=python3
       - name: Run interpreter tests
         if: ${{ matrix.runner[0] == 'h100-runner-set' }}
-        env:
-          TRITON_INTERPRET: "1"
-        run: |
-          cd python/test/unit
-          python3 -m pytest -s -n 16 -m interpreter language/test_core.py language/test_standard.py \
-           language/test_random.py language/test_block_pointer.py language/test_subprocess.py language/test_line_info.py \
-           runtime/test_autotuner.py::test_kwargs[False]\
-           ../../tutorials/06-fused-attention.py::test_op --device cpu
+        run: make test-intrepet PYTHON=python3
       - name: Run regression tests
-        run: |
-          cd python/test/regression
-          python3 -m pytest -s -n 8 .
+        run: make test-regression PYTHON=python3
       - name: Run C++ unittests
-        run: |
-          cd python
-          cd "build/$(ls build | grep -i cmake)"
-          ctest -j32
+        run: make test-cpp
       - name: Run Proton tests
-        run: |
-          cd third_party/proton/test
-          python3 -m pytest -s .
-          cd ..
+        run: make test-proton PYTHON=python3
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton
@@ -411,13 +376,7 @@ jobs:
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
-        run: |
-          cd python
-          LIT_TEST_DIR="build/$(ls build | grep -i cmake)/test"
-          if [ ! -d "${LIT_TEST_DIR}" ]; then
-            echo "Could not find '${LIT_TEST_DIR}'" ; exit -1
-          fi
-          lit -v "${LIT_TEST_DIR}"
+        run: make test-lit
       - name: Run python tests on HIP
         run: |
           INSTRUMENTATION_LIB_DIR="${GITHUB_WORKSPACE}/python/triton/instrumentation"
@@ -455,15 +414,9 @@ jobs:
           cd python/test/regression
           python3 -m pytest -s -n 8 ./test_cast_matmul.py
       - name: Run Proton tests
-        run: |
-          cd third_party/proton/test
-          python3 -m pytest -s .
-          cd ..
+        run: make test-proton PYTHON=python3
       - name: Run C++ unittests
-        run: |
-          cd python
-          cd "build/$(ls build | grep -i cmake)"
-          ctest -j32
+        run: make test-cpp
       - name: Inspect cache directories
         run: |
           mkdir -p ~/.triton

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -244,7 +244,7 @@ jobs:
           echo "PATH is '$PATH'"
           cd python
           ccache --zero-stats
-          python3 -m pip install -v '.[tests]'
+          python3 -m pip install -v '.[tests]' --no-build-isolation
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
@@ -372,7 +372,7 @@ jobs:
           pip uninstall -y triton pytorch-triton-rocm
           cd python
           ccache --zero-stats
-          pip install -v -e '.[tests]'
+          pip install -v -e '.[tests]' --no-build-isolation
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -243,7 +243,8 @@ jobs:
         run: |
           echo "PATH is '$PATH'"
           ccache --zero-stats
-          make dev-install
+          python3 -m pip install -r python/requirements.txt
+          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
@@ -370,7 +371,8 @@ jobs:
           echo "PATH is '$PATH'"
           pip uninstall -y triton pytorch-triton-rocm
           ccache --zero-stats
-          make dev-install
+          python3 -m pip install -r python/requirements.txt
+          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
@@ -542,7 +544,8 @@ jobs:
           source ~/.venv/bin/activate
           echo "PATH is '$PATH'"
           ccache --zero-stats
-          make dev-install
+          python3 -m pip install -r python/requirements.txt
+          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
       - name: CCache Stats
         run: ccache --print-stats
       - name: Inspect cache directories

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -242,9 +242,8 @@ jobs:
           CUDA_HOME: "/usr/local/cuda"
         run: |
           echo "PATH is '$PATH'"
-          cd python
           ccache --zero-stats
-          python3 -m pip install -v '.[tests]' --no-build-isolation
+          make dev-install
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
@@ -370,9 +369,8 @@ jobs:
         run: |
           echo "PATH is '$PATH'"
           pip uninstall -y triton pytorch-triton-rocm
-          cd python
           ccache --zero-stats
-          pip install -v -e '.[tests]' --no-build-isolation
+          make dev-install
       - name: CCache Stats
         run: ccache --print-stats
       - name: Run lit tests
@@ -543,9 +541,8 @@ jobs:
         run: |
           source ~/.venv/bin/activate
           echo "PATH is '$PATH'"
-          cd python
           ccache --zero-stats
-          python3 -m pip install -v --no-build-isolation .
+          make dev-install
       - name: CCache Stats
         run: ccache --print-stats
       - name: Inspect cache directories

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -276,7 +276,8 @@ jobs:
         run: |
           echo "PATH is '$PATH'"
           ccache --zero-stats
-          make dev-install
+          python3 -m pip install -r python/requirements.txt
+          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
 
       - &print-ccache-stats
         name: CCache Stats
@@ -363,7 +364,8 @@ jobs:
           echo "PATH is '$PATH'"
           pip uninstall -y triton pytorch-triton-rocm
           ccache --zero-stats
-          make dev-install
+          python3 -m pip install -r python/requirements.txt
+          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
 
       - *print-ccache-stats
       - *run-lit-tests-step
@@ -464,7 +466,8 @@ jobs:
           source ~/.venv/bin/activate
           echo "PATH is '$PATH'"
           ccache --zero-stats
-          make dev-install
+          python3 -m pip install -r python/requirements.txt
+          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
 
       - *print-ccache-stats
       - *inspect-cache-directories-step

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -287,7 +287,7 @@ jobs:
 
       - name: Run interpreter tests
         if: ${{ matrix.runner[0] == 'h100-runner-set' }}
-        run: make test-intrepet
+        run: make test-interpret
 
       - name: Run regression tests
         run: make test-regression

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -285,59 +285,25 @@ jobs:
 
       - &run-lit-tests-step
         name: Run lit tests
-        run: |
-          cd python
-          LIT_TEST_DIR="build/$(ls build | grep -i cmake)/test"
-          if [ ! -d "${LIT_TEST_DIR}" ]; then
-            echo "Could not find '${LIT_TEST_DIR}'" ; exit -1
-          fi
-          lit -v "${LIT_TEST_DIR}"
+        run: make test-lit
 
       - name: Run python tests on CUDA
-        run: |
-          INSTRUMENTATION_LIB_DIR="${GITHUB_WORKSPACE}/python/build/$(ls python/build | grep -i lib)/triton/instrumentation"
-          if [ ! -d "${INSTRUMENTATION_LIB_DIR}" ]; then
-            echo "Could not find '${INSTRUMENTATION_LIB_DIR}'" ; exit -1
-          fi
-          cd python/test/unit
-          python3 -m pytest -s -n 8 --ignore=cuda/test_flashattention.py --ignore=language/test_line_info.py --ignore=language/test_subprocess.py --ignore=test_debug.py
-          python3 -m pytest -s -n 8 language/test_subprocess.py
-          python3 -m pytest -s -n 8 test_debug.py --forked
-          # Run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
-          TRITON_DISABLE_LINE_INFO=0 python3 -m pytest -s language/test_line_info.py
-          # Run cuda/test_flashattention.py separately to avoid out of gpu memory
-          python3 -m pytest -s cuda/test_flashattention.py
-          TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=${INSTRUMENTATION_LIB_DIR}/libGPUInstrumentationTestLib.so \
-          python3 -m pytest --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
+        run: make test-unit PYTHON=python3
+
       - name: Run interpreter tests
         if: ${{ matrix.runner[0] == 'h100-runner-set' }}
-        env:
-          TRITON_INTERPRET: "1"
-        run: |
-          cd python/test/unit
-          python3 -m pytest -s -n 16 -m interpreter language/test_core.py language/test_standard.py \
-           language/test_random.py language/test_block_pointer.py language/test_subprocess.py language/test_line_info.py \
-           runtime/test_autotuner.py::test_kwargs[False]\
-           ../../tutorials/06-fused-attention.py::test_op --device cpu
+        run: make test-intrepet PYTHON=python3
 
       - name: Run regression tests
-        run: |
-          cd python/test/regression
-          python3 -m pytest -s -n 8 .
+        run: make test-regression PYTHON=python3
 
       - &run-cpp-unittests-step
         name: Run C++ unittests
-        run: |
-          cd python
-          cd "build/$(ls build | grep -i cmake)"
-          ctest -j32
+        run: make test-cpp
 
       - &run-proton-tests-step
         name: Run Proton tests
-        run: |
-          cd third_party/proton/test
-          python3 -m pytest -s .
-          cd ..
+        run: make test-proton PYTHON=python3
 
       - *inspect-cache-directories-step
 

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -285,7 +285,7 @@ jobs:
 
       - &run-lit-tests-step
         name: Run lit tests
-        run: make test-lit
+        run: make test-lit PYTHON=python3
 
       - name: Run python tests on CUDA
         run: make test-unit PYTHON=python3
@@ -299,7 +299,7 @@ jobs:
 
       - &run-cpp-unittests-step
         name: Run C++ unittests
-        run: make test-cpp
+        run: make test-cpp PYTHON=python3
 
       - &run-proton-tests-step
         name: Run Proton tests

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -284,25 +284,25 @@ jobs:
 
       - &run-lit-tests-step
         name: Run lit tests
-        run: make test-lit PYTHON=python3
+        run: make test-lit
 
       - name: Run python tests on CUDA
-        run: make test-unit PYTHON=python3
+        run: make test-unit
 
       - name: Run interpreter tests
         if: ${{ matrix.runner[0] == 'h100-runner-set' }}
-        run: make test-intrepet PYTHON=python3
+        run: make test-intrepet
 
       - name: Run regression tests
-        run: make test-regression PYTHON=python3
+        run: make test-regression
 
       - &run-cpp-unittests-step
         name: Run C++ unittests
-        run: make test-cpp PYTHON=python3
+        run: make test-cpp
 
       - &run-proton-tests-step
         name: Run Proton tests
-        run: make test-proton PYTHON=python3
+        run: make test-proton
 
       - *inspect-cache-directories-step
 

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -28,6 +28,7 @@ env:
   TRITON_USE_ASSERT_ENABLED_LLVM: "TRUE"
   TRITON_DISABLE_LINE_INFO: 1
   PROTON_SKIP_PC_SAMPLING_TEST: 1
+  PYTHON: "python3"
   CCACHE_COMPRESS: "true"
 
 jobs:
@@ -265,19 +266,13 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Install pip dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install cython setuptools wheel cmake==3.24 ninja lit
-
       - name: Install Triton
         env:
           CUDA_HOME: "/usr/local/cuda"
         run: |
           echo "PATH is '$PATH'"
           ccache --zero-stats
-          python3 -m pip install -r python/requirements.txt
-          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
+          make dev-install
 
       - &print-ccache-stats
         name: CCache Stats
@@ -364,8 +359,7 @@ jobs:
           echo "PATH is '$PATH'"
           pip uninstall -y triton pytorch-triton-rocm
           ccache --zero-stats
-          python3 -m pip install -r python/requirements.txt
-          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
+          make dev-install
 
       - *print-ccache-stats
       - *run-lit-tests-step
@@ -450,12 +444,11 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
-      - name: Install pip dependencies
+      - name: Create venv
         run: |
           python3 -m venv ~/.venv
           source ~/.venv/bin/activate
           python3 -m pip install --upgrade pip
-          python3 -m pip install cython setuptools wheel cmake==3.24 ninja lit pybind11
       - name: Install Triton
         env:
           TRITON_BUILD_WITH_O1: "true"
@@ -466,8 +459,7 @@ jobs:
           source ~/.venv/bin/activate
           echo "PATH is '$PATH'"
           ccache --zero-stats
-          python3 -m pip install -r python/requirements.txt
-          python3 -m pip install -e 'python[tests]' --no-build-isolation -v
+          make dev-install
 
       - *print-ccache-stats
       - *inspect-cache-directories-step

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -275,9 +275,8 @@ jobs:
           CUDA_HOME: "/usr/local/cuda"
         run: |
           echo "PATH is '$PATH'"
-          cd python
           ccache --zero-stats
-          python3 -m pip install -v '.[tests]' --no-build-isolation
+          make dev-install
 
       - &print-ccache-stats
         name: CCache Stats
@@ -363,9 +362,8 @@ jobs:
         run: |
           echo "PATH is '$PATH'"
           pip uninstall -y triton pytorch-triton-rocm
-          cd python
           ccache --zero-stats
-          pip install -v -e '.[tests]' --no-build-isolation
+          make dev-install
 
       - *print-ccache-stats
       - *run-lit-tests-step
@@ -465,9 +463,8 @@ jobs:
         run: |
           source ~/.venv/bin/activate
           echo "PATH is '$PATH'"
-          cd python
           ccache --zero-stats
-          python3 -m pip install -v --no-build-isolation .
+          make dev-install
 
       - *print-ccache-stats
       - *inspect-cache-directories-step

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -277,7 +277,7 @@ jobs:
           echo "PATH is '$PATH'"
           cd python
           ccache --zero-stats
-          python3 -m pip install -v '.[tests]'
+          python3 -m pip install -v '.[tests]' --no-build-isolation
 
       - &print-ccache-stats
         name: CCache Stats
@@ -365,7 +365,7 @@ jobs:
           pip uninstall -y triton pytorch-triton-rocm
           cd python
           ccache --zero-stats
-          pip install -v -e '.[tests]'
+          pip install -v -e '.[tests]' --no-build-isolation
 
       - *print-ccache-stats
       - *run-lit-tests-step

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,9 @@ test: test-lit test-cpp test-python
 .PHONY: dev-install
 dev-install:
 	# build-time dependencies
-	$(PYTHON) -m pip install ninja cmake wheel pybind11 llnl-hatchet
+	$(PYTHON) -m pip install ninja cmake wheel pybind11
 	# test dependencies
-	$(PYTHON) -m pip install scipy numpy torch pytest lit pandas matplotlib
+	$(PYTHON) -m pip install scipy numpy torch pytest lit pandas matplotlib llnl-hatchet
 	$(PYTHON) -m pip install -e python --no-build-isolation -v
 
 .PHONY: golden-samples

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Make sure to first initialize the build system with:
 #     make dev-install
 
-PYTHON := python
+PYTHON := python3
 BUILD_DIR := $(shell cd python; $(PYTHON) -c 'from build_helpers import get_cmake_dir; print(get_cmake_dir())')
 TRITON_OPT := $(BUILD_DIR)/bin/triton-opt
 PYTEST := $(PYTHON) -m pytest

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,11 @@ test: test-lit test-cpp test-python
 
 .PHONY: dev-install
 dev-install:
+	cd python
 	# build-time dependencies
-	$(PYTHON) -m pip install ninja cmake wheel pybind11 setuptools
-	# test dependencies
-	$(PYTHON) -m pip install torch lit
+	$(PYTHON) -m pip install python/requirements.txt
+	# runtime dependencies
+	$(PYTHON) -m pip install torch
 	$(PYTHON) -m pip uninstall triton pytorch-triton -y
 	$(PYTHON) -m pip install -e 'python[tests]' --no-build-isolation -v
 

--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,11 @@ test: test-lit test-cpp test-python
 .PHONY: dev-install
 dev-install:
 	# build-time dependencies
-	$(PYTHON) -m pip install ninja cmake wheel pybind11
+	$(PYTHON) -m pip install ninja cmake wheel pybind11 setuptools
 	# test dependencies
-	$(PYTHON) -m pip install scipy numpy torch pytest lit pandas matplotlib llnl-hatchet
-	$(PYTHON) -m pip install -e python --no-build-isolation -v
+	$(PYTHON) -m pip install torch lit
+	$(PYTHON) -m pip uninstall triton pytorch-triton -y
+	$(PYTHON) -m pip install -e 'python[tests]' --no-build-isolation -v
 
 .PHONY: golden-samples
 golden-samples: triton-opt

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test-unit: all
 	$(PYTEST) -s -n 8 --ignore=cuda/test_flashattention.py --ignore=language/test_line_info.py --ignore=language/test_subprocess.py --ignore=test_debug.py
 	$(PYTEST) -s -n 8 language/test_subprocess.py
 	$(PYTEST) -s -n 8 test_debug.py --forked
-	# TRITON_DISABLE_LINE_INFO=0 $(PYTEST) -s language/test_line_info.py
+	TRITON_DISABLE_LINE_INFO=0 $(PYTEST) -s language/test_line_info.py
 	# Run cuda/test_flashattention.py separately to avoid out of gpu memory
 	$(PYTEST) -s cuda/test_flashattention.py
 	TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=../../triton/instrumentation/libGPUInstrumentationTestLib.so \

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ test-unit: all
 	$(PYTEST) -s -n 8 --ignore=cuda/test_flashattention.py --ignore=language/test_line_info.py --ignore=language/test_subprocess.py --ignore=test_debug.py
 	$(PYTEST) -s -n 8 language/test_subprocess.py
 	$(PYTEST) -s -n 8 test_debug.py --forked
-	TRITON_DISABLE_LINE_INFO=0 $(PYTEST) -s language/test_line_info.py
+	# TRITON_DISABLE_LINE_INFO=0 $(PYTEST) -s language/test_line_info.py
 	# Run cuda/test_flashattention.py separately to avoid out of gpu memory
 	$(PYTEST) -s cuda/test_flashattention.py
-	TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=$(BUILD_DIR)/triton/instrumentation/libGPUInstrumentationTestLib.so \
+	TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=../../triton/instrumentation/libGPUInstrumentationTestLib.so \
 		$(PYTEST) --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
 
 .PHONY: test-regression

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ test-cpp:
 	ninja -C $(BUILD_DIR) check-triton-unit-tests
 
 .PHONY: test-python
+.ONESHELL:
 test-unit: all
 	cd python/test/unit
 	$(PYTEST) -s -n 8 --ignore=cuda/test_flashattention.py --ignore=language/test_line_info.py --ignore=language/test_subprocess.py --ignore=test_debug.py
@@ -44,6 +45,7 @@ test-regression: all
 	$(PYTEST) -s -n 8 python/test/regression
 
 .PHONY: test-interpret
+.ONESHELL:
 test-interpret: all
 	cd python/test/unit
 	TRITON_INTERPRET=1 $(PYTEST) -s -n 16 -m interpreter language/test_core.py language/test_standard.py \

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 PYTHON := python
 BUILD_DIR := $(shell cd python; $(PYTHON) -c 'from build_helpers import get_cmake_dir; print(get_cmake_dir())')
 TRITON_OPT := $(BUILD_DIR)/bin/triton-opt
+PYTEST := $(PYTHON) -m pytest
 
 .PHONY: all
 all:
@@ -23,8 +24,38 @@ test-cpp:
 	ninja -C $(BUILD_DIR) check-triton-unit-tests
 
 .PHONY: test-python
-test-python: all
-	$(PYTHON) -m pytest python/test/unit
+test-unit: all
+	cd python/test/unit
+	$(PYTEST) -s -n 8 --ignore=cuda/test_flashattention.py --ignore=language/test_line_info.py --ignore=language/test_subprocess.py --ignore=test_debug.py
+	$(PYTEST) -s -n 8 language/test_subprocess.py
+	$(PYTEST) -s -n 8 test_debug.py --forked
+	TRITON_DISABLE_LINE_INFO=0 $(PYTEST) -s language/test_line_info.py
+	# Run cuda/test_flashattention.py separately to avoid out of gpu memory
+	$(PYTEST) -s cuda/test_flashattention.py
+	TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=$(BUILD_DIR)/triton/instrumentation/libGPUInstrumentationTestLib.so \
+		$(PYTEST) --capture=tee-sys -rfs -vvv instrumentation/test_gpuhello.py
+
+.PHONY: test-regression
+test-regression: all
+	$(PYTEST) -s -n 8 python/test/regression
+
+.PHONY: test-interpret
+test-interpret: all
+	cd python/test/unit
+	TRITON_INTERPRET=1 $(PYTEST) -s -n 16 -m interpreter language/test_core.py language/test_standard.py \
+		language/test_random.py language/test_block_pointer.py language/test_subprocess.py language/test_line_info.py \
+		runtime/test_autotuner.py::test_kwargs[False] \
+		../../tutorials/06-fused-attention.py::test_op --device=cpu
+
+.PHONY: test-proton
+test-proton: all
+	$(PYTEST) -s third_party/proton/test
+
+.PHONY: test-python
+test-python: test-unit test-regression test-interpret test-proton
+
+.PHONY: test-nogpu
+test-nogpu: test-lit test-cpp
 
 .PHONY: test
 test: test-lit test-cpp test-python
@@ -32,7 +63,7 @@ test: test-lit test-cpp test-python
 .PHONY: dev-install
 dev-install:
 	# build-time dependencies
-	$(PYTHON) -m pip install ninja cmake wheel pybind11
+	$(PYTHON) -m pip install ninja cmake wheel pybind11 llnl-hatchet
 	# test dependencies
 	$(PYTHON) -m pip install scipy numpy torch pytest lit pandas matplotlib
 	$(PYTHON) -m pip install -e python --no-build-isolation -v

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ $ make dev-install
 $ make test
 
 # Or, to run tests without a gpu
-$ make test-cpp test-lit
+$ make test-nogpu
 ```
 
 # Tips for hacking

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,8 @@
+ninja
+cmake
+setuptools>=40.8.0
+wheel
+cmake>=3.18
+ninja>=1.11.1
+pybind11>=2.13.1
+lit

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -1,0 +1,8 @@
+autopep8
+isort
+numpy
+pytest
+pytest-forked
+pytest-xdist
+scipy>=1.7.1
+llnl-hatchet

--- a/third_party/proton/test/instrument.py
+++ b/third_party/proton/test/instrument.py
@@ -50,10 +50,7 @@ def matmul(a, b, activation=""):
     c = torch.empty((M, N), device=a.device, dtype=a.dtype)
 
     # 1D launch kernel where each block gets its own program.
-    def grid():
-        return (1, )
-
-    matmul_kernel[grid](
+    matmul_kernel[(1, )](
         a, b, c,  #
         M, N, K,  #
         a.stride(0), a.stride(1),  #

--- a/third_party/proton/test/test_cmd.py
+++ b/third_party/proton/test/test_cmd.py
@@ -38,8 +38,8 @@ def test_exec(mode, tmp_path: pathlib.Path):
 def test_instrument_exec():
 
     try:
-        out = subprocess.Popen(["proton", "--instrument=print-mem-spaces", "instrument.py"], stderr=subprocess.PIPE,
-                               stdout=subprocess.PIPE)
+        out = subprocess.Popen(["proton", "--instrument=print-mem-spaces", "instrument.py"],
+                               cwd=pathlib.Path(__file__).parent, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
     except Exception as e:
         print(f"An error occurred while executing proton: {e}")
 


### PR DESCRIPTION
Now `make test` runs the exact commands used in CI, so there should be no spurious local failures due to the specific `pytest` command used.