### PR TITLE
[PIPELINE] Limit number of buffers for register operands

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -926,7 +926,7 @@ createAsyncOps(scf::ForOp &forOp,
     // For MMAv3, we need an extra buffer as this is assumed in the wgmma
     // pipelining post-processing. Additionally, SMEM for scales in MMAv5
     // should get the same number of buffers as the operand SMEM.
-    if (info.isMMAv3Shared || info.isMMAv3Registers || info.isMMAv5Scale) {
+    if (info.isMMAv3Shared || info.isMMAv5Scale) {
       ++numBuffers;
     }
     if (isa<tt::ExperimentalDescriptorLoadOp,


### PR DESCRIPTION
If wgmma is using operands in registers, it can't be pipelined (overlapping with mma from previous iteration), as we would end up re-using the same registers while mma is still in-flight. For such cases we don't need to increase number of buffers used by operands of such mma.
This change picks a low hanging fruit by not increasing the number of buffers of the register-based operand. We should go a step further and not increase numBuffers for any operand of such mma.