### PR TITLE
[BC Breaking] Add output dtype to `tl.sum` with default

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2464,9 +2464,9 @@ def test_sum_dtype():
     kernel_default_int[(1, )](out)
     assert out[0] == 32 * 32
 
-    out = torch.empty(1, dtype=torch.float32, device='cuda')
+    out = torch.empty(1, dtype=torch.bfloat16, device='cuda')
     kernel_default_float[(1, )](out)
-    torch.testing.assert_close(out[0], torch.tensor(32 * 32, dtype=torch.float32, device='cuda'))
+    torch.testing.assert_close(out[0], torch.tensor(32 * 32, dtype=torch.bfloat16, device='cuda'))
 
 
 @triton.jit

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2429,6 +2429,7 @@ negative_config = [('cumsum', 'float32', (32, 32), -1, False, 4)]
 
 
 def test_sum_dtype():
+
     @triton.jit
     def kernel(out_ptr):
         x = tl.full((32, 32), 1, dtype=tl.int1)
@@ -2436,7 +2437,7 @@ def test_sum_dtype():
         tl.store(out_ptr, x.to(tl.int32))
 
     out = torch.empty(1, dtype=torch.int32, device='cuda')
-    kernel[(1,)](out)
+    kernel[(1, )](out)
     assert out[0] == 32 * 32
 
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2428,6 +2428,18 @@ scan_configs = [(op, type, shape, axis, reverse, num_warps)
 negative_config = [('cumsum', 'float32', (32, 32), -1, False, 4)]
 
 
+def test_sum_dtype():
+    @triton.jit
+    def kernel(out_ptr):
+        x = tl.full((32, 32), 1, dtype=tl.int1)
+        x = tl.sum(x)
+        tl.store(out_ptr, x.to(tl.int32))
+
+    out = torch.empty(1, dtype=torch.int32, device='cuda')
+    kernel[(1,)](out)
+    assert out[0] == 32 * 32
+
+
 @triton.jit
 # trivial associative but not commutative function
 def get_first_element(a, b):

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2458,6 +2458,9 @@ def test_sum_dtype():
     kernel_dtype[(1, )](out, init=7, in_dtype=tl.int8, out_dtype=tl.int8)
     assert out[0] == (7 * 32 * 32) % 256
 
+    kernel_dtype[(1, )](out, init=1, in_dtype=tl.int32, out_dtype=None)
+    assert out[0] == 32 * 32
+
     kernel_default_int[(1, )](out)
     assert out[0] == 32 * 32
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2431,14 +2431,39 @@ negative_config = [('cumsum', 'float32', (32, 32), -1, False, 4)]
 def test_sum_dtype():
 
     @triton.jit
-    def kernel(out_ptr):
-        x = tl.full((32, 32), 1, dtype=tl.int1)
-        x = tl.sum(x)
+    def kernel_dtype(out_ptr, init, in_dtype: tl.constexpr, out_dtype: tl.constexpr):
+        x = tl.full((32, 32), init, dtype=in_dtype)
+        x = tl.sum(x, dtype=out_dtype)
         tl.store(out_ptr, x.to(tl.int32))
 
+    @triton.jit
+    def kernel_default_int(out_ptr):
+        x = tl.full((32, 32), 1, dtype=tl.int1)
+        x = tl.sum(x)
+        tl.store(out_ptr, x)
+
+    @triton.jit
+    def kernel_default_float(out_ptr):
+        x = tl.full((32, 32), 1.0, dtype=tl.bfloat16)
+        x = tl.sum(x)
+        tl.store(out_ptr, x)
+
     out = torch.empty(1, dtype=torch.int32, device='cuda')
-    kernel[(1, )](out)
+    kernel_dtype[(1, )](out, init=1, in_dtype=tl.int1, out_dtype=None)
     assert out[0] == 32 * 32
+
+    kernel_dtype[(1, )](out, init=1, in_dtype=tl.int1, out_dtype=tl.int1)
+    assert out[0] == 0
+
+    kernel_dtype[(1, )](out, init=7, in_dtype=tl.int8, out_dtype=tl.int8)
+    assert out[0] == (7 * 32 * 32) % 256
+
+    kernel_default_int[(1, )](out)
+    assert out[0] == 32 * 32
+
+    out = torch.empty(1, dtype=torch.float32, device='cuda')
+    kernel_default_float[(1, )](out)
+    torch.testing.assert_close(out[0], torch.tensor(32 * 32, dtype=torch.float32, device='cuda'))
 
 
 @triton.jit

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2276,7 +2276,8 @@ def clamp(x, min, max, propagate_nan: constexpr = PropagateNan.NONE, _builder=No
 # -----------------------
 
 
-def _add_reduction_docstr(name: str, return_indices_arg: str = None, tie_break_arg: str = None, dtype_arg: str = None) -> Callable[[T], T]:
+def _add_reduction_docstr(name: str, return_indices_arg: str = None, tie_break_arg: str = None,
+                          dtype_arg: str = None) -> Callable[[T], T]:
 
     def _decorator(func: T) -> T:
         docstr = """
@@ -2331,7 +2332,8 @@ def reduce(input, axis, combine_fn, keep_dims=False, dtype=None, _builder=None, 
 
     """
     if isinstance(input, tensor):
-        return reduce((input, ), axis, combine_fn, keep_dims=keep_dims, dtype=dtype, _builder=_builder, _generator=_generator)[0]
+        return reduce((input, ), axis, combine_fn, keep_dims=keep_dims, dtype=dtype, _builder=_builder,
+                      _generator=_generator)[0]
 
     def make_combine_region(reduce_op):
         param_types = [t.type.scalar for t in input] * 2

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1107,7 +1107,7 @@ class tensor(_value):
     def abs(self) -> tensor:
         ...
 
-    def reduce(self, axis, combine_fn, keep_dims=False) -> tensor:
+    def reduce(self, axis, combine_fn, keep_dims=False, dtype=None) -> tensor:
         ...
 
     def associative_scan(self, axis, combine_fn, reverse=False) -> tensor:
@@ -1143,7 +1143,7 @@ class tensor(_value):
     def argmin(self, axis, tie_break_left=True, keep_dims=False) -> tensor:
         ...
 
-    def sum(self, axis=None, keep_dims=False) -> tensor:
+    def sum(self, axis=None, keep_dims=False, dtype=None) -> tensor:
         ...
 
     def xor_sum(self, axis=None, keep_dims=False) -> tensor:
@@ -2276,7 +2276,7 @@ def clamp(x, min, max, propagate_nan: constexpr = PropagateNan.NONE, _builder=No
 # -----------------------
 
 
-def _add_reduction_docstr(name: str, return_indices_arg: str = None, tie_break_arg: str = None) -> Callable[[T], T]:
+def _add_reduction_docstr(name: str, return_indices_arg: str = None, tie_break_arg: str = None, dtype_arg: str = None) -> Callable[[T], T]:
 
     def _decorator(func: T) -> T:
         docstr = """
@@ -2296,6 +2296,10 @@ def _add_reduction_docstr(name: str, return_indices_arg: str = None, tie_break_a
             docstr += f"""
     :param {tie_break_arg}: if true, in case of a tie (i.e., multiple elements have the same {name} value), return the left-most index for values that aren't NaN
     :type {tie_break_arg}: bool"""
+        if dtype_arg is not None:
+            docstr += f"""
+    :param {dtype_arg}: the desired data type of the returned tensor. If specified, the input tensor is casted to :code:`{dtype_arg}` before the operation is performed. This is useful for preventing data overflows. If not specified, integer and bool dtypes are upcasted to :code:`tl.int32` and float dtypes are upcasted to at least :code:`tl.float32`.
+    :type {dtype_arg}: tl.dtype"""
 
         func.__doc__ = docstr.format(name=name)
         return func
@@ -2312,7 +2316,7 @@ def _insertion_guard(builder):
 
 @_tensor_member_fn
 @builtin
-def reduce(input, axis, combine_fn, keep_dims=False, _builder=None, _generator=None):
+def reduce(input, axis, combine_fn, keep_dims=False, dtype=None, _builder=None, _generator=None):
     """Applies the combine_fn to all elements in :code:`input` tensors along the provided :code:`axis`
 
     :param input: the input tensor, or tuple of tensors
@@ -2323,6 +2327,7 @@ def reduce(input, axis, combine_fn, keep_dims=False, _builder=None, _generator=N
     :type combine_fn: Callable
     :param keep_dims: if true, keep the reduced dimensions with length 1
     :type keep_dims: bool
+    :param dtype: the desired data type of the returned tensor. If specified, the input tensor is casted to :code:`dtype` before the operation. This is useful for preventing data overflows.
 
     """
     if isinstance(input, tensor):
@@ -2351,6 +2356,8 @@ def reduce(input, axis, combine_fn, keep_dims=False, _builder=None, _generator=N
     keep_dims = _constexpr_to_value(keep_dims)
     if axis is not None:
         axis = _wrap_axis(axis, len(input[0].shape))
+    if dtype is not None:
+        input = input.to(dtype)
     ret = semantic.reduction(input, axis, make_combine_region, _builder)
     if keep_dims:
         if axis is not None:

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2331,7 +2331,7 @@ def reduce(input, axis, combine_fn, keep_dims=False, dtype=None, _builder=None, 
 
     """
     if isinstance(input, tensor):
-        return reduce((input, ), axis, combine_fn, keep_dims=keep_dims, _builder=_builder, _generator=_generator)[0]
+        return reduce((input, ), axis, combine_fn, keep_dims=keep_dims, dtype=dtype, _builder=_builder, _generator=_generator)[0]
 
     def make_combine_region(reduce_op):
         param_types = [t.type.scalar for t in input] * 2
@@ -2357,7 +2357,7 @@ def reduce(input, axis, combine_fn, keep_dims=False, dtype=None, _builder=None, 
     if axis is not None:
         axis = _wrap_axis(axis, len(input[0].shape))
     if dtype is not None:
-        input = input.to(dtype)
+        input = tuple(t.to(dtype, _builder=_builder) for t in input)
     ret = semantic.reduction(input, axis, make_combine_region, _builder)
     if keep_dims:
         if axis is not None:

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -277,7 +277,8 @@ def sum(input, axis=None, keep_dims=False, dtype: core.constexpr = None, _builde
         elif input.dtype.is_floating():
             dtype = core.float32 if input.dtype.primitive_bitwidth < 32 else None
 
-    input = input.to(dtype, _builder=_builder)
+    if dtype is not None:
+        input = input.to(dtype, _builder=_builder)
     return core.reduce(input, axis, _sum_combine, keep_dims=keep_dims, _builder=_builder, _generator=_generator)
 
 

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -262,8 +262,9 @@ def _sum_combine(a, b):
 @core._tensor_member_fn
 @core.builtin
 @core._add_reduction_docstr("sum", dtype_arg="dtype")
-def sum(input, axis=None, keep_dims=False, dtype=None, _builder=None, _generator=None):
+def sum(input, axis=None, keep_dims=False, dtype: core.constexpr = None, _builder=None, _generator=None):
     # Pick a default dtype for the reduction if one was not specified.
+    dtype = core._unwrap_if_constexpr(dtype)
     if dtype is None:
         # For integer bitwidths less than 32, pick int32 with the same sign to
         # avoid overflow.
@@ -276,9 +277,8 @@ def sum(input, axis=None, keep_dims=False, dtype=None, _builder=None, _generator
         elif input.dtype.is_floating():
             dtype = core.float32 if input.dtype.primitive_bitwidth < 32 else None
 
-    input = core._promote_bfloat16_to_float32(input, _builder=_builder)
-    return core.reduce(input, axis, _sum_combine, keep_dims=keep_dims, dtype=dtype, _builder=_builder,
-                       _generator=_generator)
+    input = input.to(dtype, _builder=_builder)
+    return core.reduce(input, axis, _sum_combine, keep_dims=keep_dims, _builder=_builder, _generator=_generator)
 
 
 @jit

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -261,8 +261,8 @@ def _sum_combine(a, b):
 
 def _pick_sum_dtype(in_dtype: core.constexpr, dtype: core.constexpr):
     # FIXME: Workaround the interpreter not wrapping constexpr args.
-    is_wrapped = isinstance(dtype, core.constexpr)
-    if (is_wrapped and dtype.value is not None) or (not is_wrapped and dtype is not None):
+    dtype = core._unwrap_if_constexpr(dtype)
+    if dtype is not None:
         return dtype
 
     # For integer bitwidths less than 32, pick int32 with the same sign to
@@ -277,7 +277,7 @@ def _pick_sum_dtype(in_dtype: core.constexpr, dtype: core.constexpr):
     elif in_dtype.is_floating():
         out_dtype = core.float32 if in_dtype.primitive_bitwidth < 32 else None
 
-    return core.constexpr(out_dtype) if is_wrapped else out_dtype
+    return out_dtype
 
 
 @core._tensor_member_fn

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -277,7 +277,8 @@ def sum(input, axis=None, keep_dims=False, dtype=None, _builder=None, _generator
             dtype = core.float32 if input.dtype.primitive_bitwidth < 32 else None
 
     input = core._promote_bfloat16_to_float32(input, _builder=_builder)
-    return core.reduce(input, axis, _sum_combine, keep_dims=keep_dims, dtype=dtype, _builder=_builder, _generator=_generator)
+    return core.reduce(input, axis, _sum_combine, keep_dims=keep_dims, dtype=dtype, _builder=_builder,
+                       _generator=_generator)
 
 
 @jit

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -260,7 +260,9 @@ def _sum_combine(a, b):
 
 
 def _pick_sum_dtype(in_dtype: core.constexpr, dtype: core.constexpr):
-    if dtype.value is not None:
+    # FIXME: Workaround the interpreter not wrapping constexpr args.
+    is_wrapped = isinstance(dtype, core.constexpr)
+    if (is_wrapped and dtype.value is not None) or (not is_wrapped and dtype is not None):
         return dtype
 
     # For integer bitwidths less than 32, pick int32 with the same sign to
@@ -275,7 +277,7 @@ def _pick_sum_dtype(in_dtype: core.constexpr, dtype: core.constexpr):
     elif in_dtype.is_floating():
         out_dtype = core.float32 if in_dtype.primitive_bitwidth < 32 else None
 
-    return core.constexpr(out_dtype)
+    return core.constexpr(out_dtype) if is_wrapped else out_dtype
 
 
 @core._tensor_member_fn

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -262,7 +262,7 @@ def _sum_combine(a, b):
 @core._tensor_member_fn
 @core.builtin
 @core._add_reduction_docstr("sum", dtype_arg="dtype")
-def sum(input, axis=None, keep_dims=False, dtype: core.constexpr = None, _builder=None, _generator=None):
+def sum(input, axis=None, keep_dims=False, dtype: core.constexpr = None, _builder=None):
     # Pick a default dtype for the reduction if one was not specified.
     dtype = core._unwrap_if_constexpr(dtype)
     if dtype is None:
@@ -279,7 +279,7 @@ def sum(input, axis=None, keep_dims=False, dtype: core.constexpr = None, _builde
 
     if dtype is not None:
         input = input.to(dtype, _builder=_builder)
-    return core.reduce(input, axis, _sum_combine, keep_dims=keep_dims, _builder=_builder, _generator=_generator)
+    return core.reduce(input, axis, _sum_combine, keep_dims=keep_dims, _builder=_builder, _generator=None)
 
 
 @jit
@@ -441,7 +441,7 @@ def flip(x, dim=None):
         for j in core.static_range(0, steps + 1):
             if j != i and j != i + 1:
                 flip2 = core.expand_dims(flip2, j)
-        y = sum(y * flip2, i + 1, keep_dims=True)
+        y = sum(y * flip2, i + 1, keep_dims=True, dtype=y.dtype)
     x = core.reshape(y, x.shape).to(x.dtype, bitcast=True)
     return x
 

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -262,7 +262,7 @@ def _sum_combine(a, b):
 @core._tensor_member_fn
 @core.builtin
 @core._add_reduction_docstr("sum", dtype_arg="dtype")
-def sum(input, axis=None, keep_dims=False, dtype: core.constexpr = None, _builder=None):
+def sum(input, axis=None, keep_dims=False, dtype: core.constexpr = None, _builder=None, _generator=None):
     # Pick a default dtype for the reduction if one was not specified.
     dtype = core._unwrap_if_constexpr(dtype)
     if dtype is None:
@@ -279,7 +279,7 @@ def sum(input, axis=None, keep_dims=False, dtype: core.constexpr = None, _builde
 
     if dtype is not None:
         input = input.to(dtype, _builder=_builder)
-    return core.reduce(input, axis, _sum_combine, keep_dims=keep_dims, _builder=_builder, _generator=None)
+    return core.reduce(input, axis, _sum_combine, keep_dims=keep_dims, _builder=_builder, _generator=_generator)
 
 
 @jit

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -260,7 +260,6 @@ def _sum_combine(a, b):
 
 
 def _pick_sum_dtype(in_dtype: core.constexpr, dtype: core.constexpr):
-    # FIXME: Workaround the interpreter not wrapping constexpr args.
     dtype = core._unwrap_if_constexpr(dtype)
     if dtype is not None:
         return dtype
@@ -272,11 +271,6 @@ def _pick_sum_dtype(in_dtype: core.constexpr, dtype: core.constexpr):
         out_dtype = core.int32 if in_dtype.int_bitwidth < 32 else None
     elif in_dtype.is_int_unsigned():
         out_dtype = core.uint32 if in_dtype.int_bitwidth < 32 else None
-    # For float bitwidths less than 32, pick float32 to avoid overflow or
-    # precision loss.
-    elif in_dtype.is_floating():
-        out_dtype = core.float32 if in_dtype.primitive_bitwidth < 32 else None
-
     return out_dtype
 
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -750,10 +750,9 @@ class ReduceScanOpInterface:
 
 class ReduceOps(ReduceScanOpInterface):
 
-    def __init__(self, axis, combine_fn, keep_dims, dtype):
+    def __init__(self, axis, combine_fn, keep_dims):
         super().__init__(axis, combine_fn)
         self.keep_dims = keep_dims
-        self.dtype = dtype
 
     def unravel(self, input, axis):
         ret = []
@@ -830,9 +829,6 @@ class ReduceOps(ReduceScanOpInterface):
         return self.to_tensor(np.sum(input.handle.data, axis=self.axis, keepdims=self.keep_dims), input.dtype)
 
     def apply_impl(self, input):
-        if self.dtype is not None:
-            input = input.astype(getattr(np, str(self.dtype)))
-
         if self.combine_fn == tl.standard._argmin_combine_tie_break_left:
             return self.min_max(input[0], val_reduce_op=np.min, idx_reduce_op=np.argmin)
         elif self.combine_fn == tl.standard._argmax_combine_tie_break_left:

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -910,8 +910,8 @@ def _patch_reduce_scan():
     # Because interpreter doesn't support region_builder_fn, we cannot patch the builder
     # to use the new reduce and scan functions.
     # Instead, we need to patch reduce and reduce functions in tl and tl.core
-    def _new_reduce(input, axis, combine_fn, keep_dims=False, dtype=None, **kwargs):
-        return ReduceOps(axis, combine_fn, keep_dims, dtype).apply(input)
+    def _new_reduce(input, axis, combine_fn, keep_dims=False, **kwargs):
+        return ReduceOps(axis, combine_fn, keep_dims).apply(input)
 
     def _new_scan(input, axis, combine_fn, reverse=False, **kwargs):
         return ScanOps(axis, combine_fn, reverse).apply(input)


### PR DESCRIPTION
`tl.sum` can have surprising behaviour when invoked on lower-precision floating point or low bitwidth integer types, such as `tl.sum(i1)` actually computing xor reduce.

To reduce this footgun, this PR adds a `dtype` argument to `tl.sum` (and `tl.reduce`) which optionally casts the input to that dtype before computing the operation. For `tl.sum`, the default dtype is set to `tl.int32` for integers smaller than that and `tl.float32` for floats smaller than that.