### PR TITLE
Introduce an interface for SMEM encoding

### DIFF
--- a/bin/triton-tensor-layout.cpp
+++ b/bin/triton-tensor-layout.cpp
@@ -84,7 +84,7 @@ LogicalResult layoutPrint(RankedTensorType tensorType, raw_ostream &os) {
   // toLinearLayout interface.
   mlir::Attribute layout = tensorType.getEncoding();
   if (isa<mlir::triton::gpu::DistributedEncodingTrait,
-          mlir::triton::gpu::SharedEncodingAttr>(layout)) {
+          mlir::triton::gpu::SharedEncodingTrait>(layout)) {
     os << triton::gpu::getLayoutStr(tensorType, UseHWPointOfView);
     return success();
   }

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -1288,7 +1288,7 @@ inline Value packLLVector(Location loc, ValueRange vals,
 inline bool
 isSimpleSharedMemoryAccess(ArrayRef<int64_t> shape,
                            ArrayRef<int64_t> allocShape,
-                           triton::gpu::SharedEncodingAttr sharedEnc) {
+                           triton::gpu::SharedEncodingTrait sharedEnc) {
   auto rank = shape.size();
   return /*no swizzling*/ sharedEnc.getMaxPhase() == 1 ||
          /*swizzling but same shape*/ shape == allocShape ||

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -9,7 +9,7 @@
 #include "triton/Tools/LinearLayout.h"
 
 namespace mlir::triton::gpu {
-class SharedEncodingAttr;
+class SharedEncodingTrait;
 
 // - BlockedEncodingAttrs have the following input dimensions.
 //
@@ -48,7 +48,7 @@ LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout,
 // If `disableSwizzle` is set, then the resulting layout does not include
 // swizzling.
 LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
-                                               SharedEncodingAttr shared,
+                                               SharedEncodingTrait shared,
                                                int32_t elemBitWidth,
                                                bool disableSwizzle = false);
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -156,6 +156,24 @@ def SharedEncodingTrait : AttrInterface<"SharedEncodingTrait"> {
   }];
 
   let methods = [
+    InterfaceMethod<"",
+                    "unsigned",
+                    "getVec">,
+    InterfaceMethod<"",
+                    "unsigned",
+                    "getPerPhase">,
+    InterfaceMethod<"",
+                    "unsigned",
+                    "getMaxPhase">,
+    InterfaceMethod<"",
+                    "ArrayRef<unsigned>",
+                    "getOrder">,
+    // InterfaceMethod<"",
+    //                 "CTALayoutAttr",
+    //                 "getCTALayout">,
+    InterfaceMethod<"",
+                    "bool",
+                    "getHasLeadingOffset">
   ];
 }
 
@@ -164,6 +182,15 @@ class SharedEncoding<list<Trait> traits = [],
   : TritonGPU_Attr<"SharedEncoding", "shared_encoding", !listconcat([SharedEncodingTrait], traits), dialect> {
 
   let description = [{
+  }];
+
+  code extraSharedEncodingDeclaration = extraBaseClassDeclaration # [{
+     unsigned getVec() const;
+     unsigned getPerPhase() const;
+     unsigned getMaxPhase() const;
+     ArrayRef<unsigned> getOrder() const;
+     // CTALayoutAttr getCTALayout();
+     bool getHasLeadingOffset() const;
   }];
 }
 
@@ -257,12 +284,12 @@ compared to 1*64 when the hasLeadingOffset is false.
   // order: the fastest-changing axis first
   let parameters = (
     ins
-    "unsigned":$vec,
-    "unsigned":$perPhase,
-    "unsigned":$maxPhase,
-    ArrayRefParameter<"unsigned">:$order,
+    "unsigned":$vec__,
+    "unsigned":$perPhase__,
+    "unsigned":$maxPhase__,
+     ArrayRefParameter<"unsigned">:$order__,
     "CTALayoutAttr":$CTALayout,
-    "bool":$hasLeadingOffset
+    "bool":$hasLeadingOffset__
   );
 
   let builders = [
@@ -450,7 +477,8 @@ compared to 1*64 when the hasLeadingOffset is false.
     }]>
   ];
 
-  let extraClassDeclaration = extraBaseClassDeclaration # [{
+  let extraClassDeclaration = extraSharedEncodingDeclaration # [{
+    // TODO: Should this be part of the interface?
     int32_t getAlignment() const;
   }];
   let hasCustomAssemblyFormat = 1;

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -178,6 +178,9 @@ def SharedEncodingTrait : AttrInterface<"SharedEncodingTrait"> {
                     "SmallVector<unsigned>",
                     "getCTAOrder">,
     InterfaceMethod<"",
+                    "int32_t",
+                    "getAlignment">,
+    InterfaceMethod<"",
                     "bool",
                     "getHasLeadingOffset">
   ];
@@ -199,6 +202,7 @@ class SharedEncoding<list<Trait> traits = [],
      SmallVector<unsigned> getCTASplitNum() const;
      SmallVector<unsigned> getCTAOrder() const;
      bool getHasLeadingOffset() const;
+     int32_t getAlignment() const;
   }];
 }
 
@@ -485,10 +489,7 @@ compared to 1*64 when the hasLeadingOffset is false.
     }]>
   ];
 
-  let extraClassDeclaration = extraSharedEncodingDeclaration # [{
-    // TODO: Should this be part of the interface?
-    int32_t getAlignment() const;
-  }];
+  let extraClassDeclaration = extraSharedEncodingDeclaration;
   let hasCustomAssemblyFormat = 1;
 }
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -182,7 +182,7 @@ def SharedEncodingTrait : AttrInterface<"SharedEncodingTrait"> {
                     "getAlignment">,
     InterfaceMethod<"",
                     "bool",
-                    "getHasLeadingOffset">
+                    "hasLeadingOffset">
   ];
 }
 
@@ -201,7 +201,7 @@ class SharedEncoding<list<Trait> traits = [],
      SmallVector<unsigned> getCTAsPerCGA() const;
      SmallVector<unsigned> getCTASplitNum() const;
      SmallVector<unsigned> getCTAOrder() const;
-     bool getHasLeadingOffset() const;
+     bool hasLeadingOffset() const;
      int32_t getAlignment() const;
   }];
 }

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -149,8 +149,26 @@ addition, if there's only one CTA per CGA, then Triton canonicalizes CTAOrder to
 //===----------------------------------------------------------------------===//
 // Shared Layout Encoding
 //===----------------------------------------------------------------------===//
+def SharedEncodingTrait : AttrInterface<"SharedEncodingTrait"> {
+  let cppNamespace = "::mlir::triton::gpu";
 
-def SharedEncodingAttr : TritonGPU_Attr<"SharedEncoding", "shared_encoding"> {
+  let description = [{
+  }];
+
+  let methods = [
+  ];
+}
+
+class SharedEncoding<list<Trait> traits = [],
+                     Dialect dialect = TritonGPU_Dialect>
+  : TritonGPU_Attr<"SharedEncoding", "shared_encoding", !listconcat([SharedEncodingTrait], traits), dialect> {
+
+  let description = [{
+  }];
+}
+
+// def SharedEncodingAttr : TritonGPU_Attr<"SharedEncoding", "shared_encoding"> {
+def SharedEncodingAttr : SharedEncoding {
   let mnemonic = "shared";
 
   let description = [{

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -166,7 +166,7 @@ def SharedEncodingTrait : AttrInterface<"SharedEncodingTrait"> {
                     "unsigned",
                     "getMaxPhase">,
     InterfaceMethod<"",
-                    "ArrayRef<unsigned>",
+                    "SmallVector<unsigned>",
                     "getOrder">,
     InterfaceMethod<"Get the shape of the CTAs per CGA.",
                     "SmallVector<unsigned>",
@@ -194,8 +194,7 @@ class SharedEncoding<list<Trait> traits = [],
      unsigned getVec() const;
      unsigned getPerPhase() const;
      unsigned getMaxPhase() const;
-     // TODO: make ArrayRef vs SmallVector consistent
-     ArrayRef<unsigned> getOrder() const;
+     SmallVector<unsigned> getOrder() const;
      SmallVector<unsigned> getCTAsPerCGA() const;
      SmallVector<unsigned> getCTASplitNum() const;
      SmallVector<unsigned> getCTAOrder() const;

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -153,63 +153,6 @@ def SharedEncodingTrait : AttrInterface<"SharedEncodingTrait"> {
   let cppNamespace = "::mlir::triton::gpu";
 
   let description = [{
-  }];
-
-  let methods = [
-    InterfaceMethod<"",
-                    "unsigned",
-                    "getVec">,
-    InterfaceMethod<"",
-                    "unsigned",
-                    "getPerPhase">,
-    InterfaceMethod<"",
-                    "unsigned",
-                    "getMaxPhase">,
-    InterfaceMethod<"",
-                    "SmallVector<unsigned>",
-                    "getOrder">,
-    InterfaceMethod<"Get the shape of the CTAs per CGA.",
-                    "SmallVector<unsigned>",
-                    "getCTAsPerCGA">,
-    InterfaceMethod<"Each CTA processes 1/CTASplitNum of the tensor.",
-                    "SmallVector<unsigned>",
-                    "getCTASplitNum">,
-    InterfaceMethod<"Get the order of the CTAs per CGA. The fastest-changing axis first",
-                    "SmallVector<unsigned>",
-                    "getCTAOrder">,
-    InterfaceMethod<"",
-                    "int32_t",
-                    "getAlignment">,
-    InterfaceMethod<"",
-                    "bool",
-                    "hasLeadingOffset">
-  ];
-}
-
-class SharedEncoding<string name, string attrMnemonic, list<Trait> traits = [],
-                     Dialect dialect = TritonGPU_Dialect>
-  : TritonGPU_Attr<name, attrMnemonic, !listconcat([SharedEncodingTrait], traits), dialect> {
-
-  let description = [{
-  }];
-
-  code extraSharedEncodingDeclaration = extraBaseClassDeclaration # [{
-     unsigned getVec() const;
-     unsigned getPerPhase() const;
-     unsigned getMaxPhase() const;
-     SmallVector<unsigned> getOrder() const;
-     SmallVector<unsigned> getCTAsPerCGA() const;
-     SmallVector<unsigned> getCTASplitNum() const;
-     SmallVector<unsigned> getCTAOrder() const;
-     bool hasLeadingOffset() const;
-     int32_t getAlignment() const;
-  }];
-}
-
-def SharedEncodingAttr : SharedEncoding<"SharedEncoding", "shared_encoding"> {
-  let mnemonic = "shared";
-
-  let description = [{
 An encoding for tensors whose elements may be simultaneously accessed by
 different cuda threads in the programs, via shared memory. In other words,
 for all indices i \in Z^d, \mathcal{L}(i) = {0, 1, ..., 32*num_warps - 1}.
@@ -289,6 +232,65 @@ only in the stride dimension, but also in the leading dimension. For example,
 a matrix of size 16x128 and data type I8 is stored in the shared memory with
 64B-swizzle mode. The offset of the element with index (0, 64) will be 16*64,
 compared to 1*64 when the hasLeadingOffset is false.
+  }];
+
+  let methods = [
+    InterfaceMethod<"Get 'vec', one of properties of swizzling.",
+                    "unsigned",
+                    "getVec">,
+    InterfaceMethod<"Get 'per phase', one of properties of swizzling.",
+                    "unsigned",
+                    "getPerPhase">,
+    InterfaceMethod<"Get 'max phase', one of properties of swizzling.",
+                    "unsigned",
+                    "getMaxPhase">,
+    InterfaceMethod<"Get the order of this SMEM encoding.",
+                    "SmallVector<unsigned>",
+                    "getOrder">,
+    InterfaceMethod<"Get the shape of the CTAs per CGA.",
+                    "SmallVector<unsigned>",
+                    "getCTAsPerCGA">,
+    InterfaceMethod<"Each CTA processes 1/CTASplitNum of the tensor.",
+                    "SmallVector<unsigned>",
+                    "getCTASplitNum">,
+    InterfaceMethod<"Get the order of the CTAs per CGA. The fastest-changing axis first",
+                    "SmallVector<unsigned>",
+                    "getCTAOrder">,
+    InterfaceMethod<"Get the size of the address alignment in bytes.",
+                    "int32_t",
+                    "getAlignment">,
+    InterfaceMethod<"True if the SMEM layout is in the core-matrices format.",
+                    "bool",
+                    "hasLeadingOffset">
+  ];
+}
+
+class SharedEncoding<string name, string attrMnemonic, list<Trait> traits = [],
+                     Dialect dialect = TritonGPU_Dialect>
+  : TritonGPU_Attr<name, attrMnemonic, !listconcat([SharedEncodingTrait], traits), dialect> {
+
+  let description = [{
+The interface which can be inherited by various representations of an SMEM encoding.
+  }];
+
+  code extraSharedEncodingDeclaration = extraBaseClassDeclaration # [{
+     unsigned getVec() const;
+     unsigned getPerPhase() const;
+     unsigned getMaxPhase() const;
+     SmallVector<unsigned> getOrder() const;
+     SmallVector<unsigned> getCTAsPerCGA() const;
+     SmallVector<unsigned> getCTASplitNum() const;
+     SmallVector<unsigned> getCTAOrder() const;
+     bool hasLeadingOffset() const;
+     int32_t getAlignment() const;
+  }];
+}
+
+def SharedEncodingAttr : SharedEncoding<"SharedEncoding", "shared_encoding"> {
+  let mnemonic = "shared";
+
+  let description = [{
+The concrete attribute class for an SMEM encoding, used by multiple GPU backends.
   }];
 
   // swizzle info: vec, perPhase, maxPhase

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -186,9 +186,9 @@ def SharedEncodingTrait : AttrInterface<"SharedEncodingTrait"> {
   ];
 }
 
-class SharedEncoding<list<Trait> traits = [],
+class SharedEncoding<string name, string attrMnemonic, list<Trait> traits = [],
                      Dialect dialect = TritonGPU_Dialect>
-  : TritonGPU_Attr<"SharedEncoding", "shared_encoding", !listconcat([SharedEncodingTrait], traits), dialect> {
+  : TritonGPU_Attr<name, attrMnemonic, !listconcat([SharedEncodingTrait], traits), dialect> {
 
   let description = [{
   }];
@@ -206,8 +206,7 @@ class SharedEncoding<list<Trait> traits = [],
   }];
 }
 
-// def SharedEncodingAttr : TritonGPU_Attr<"SharedEncoding", "shared_encoding"> {
-def SharedEncodingAttr : SharedEncoding {
+def SharedEncodingAttr : SharedEncoding<"SharedEncoding", "shared_encoding"> {
   let mnemonic = "shared";
 
   let description = [{

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -168,9 +168,15 @@ def SharedEncodingTrait : AttrInterface<"SharedEncodingTrait"> {
     InterfaceMethod<"",
                     "ArrayRef<unsigned>",
                     "getOrder">,
-    // InterfaceMethod<"",
-    //                 "CTALayoutAttr",
-    //                 "getCTALayout">,
+    InterfaceMethod<"Get the shape of the CTAs per CGA.",
+                    "SmallVector<unsigned>",
+                    "getCTAsPerCGA">,
+    InterfaceMethod<"Each CTA processes 1/CTASplitNum of the tensor.",
+                    "SmallVector<unsigned>",
+                    "getCTASplitNum">,
+    InterfaceMethod<"Get the order of the CTAs per CGA. The fastest-changing axis first",
+                    "SmallVector<unsigned>",
+                    "getCTAOrder">,
     InterfaceMethod<"",
                     "bool",
                     "getHasLeadingOffset">
@@ -188,8 +194,11 @@ class SharedEncoding<list<Trait> traits = [],
      unsigned getVec() const;
      unsigned getPerPhase() const;
      unsigned getMaxPhase() const;
+     // TODO: make ArrayRef vs SmallVector consistent
      ArrayRef<unsigned> getOrder() const;
-     // CTALayoutAttr getCTALayout();
+     SmallVector<unsigned> getCTAsPerCGA() const;
+     SmallVector<unsigned> getCTASplitNum() const;
+     SmallVector<unsigned> getCTAOrder() const;
      bool getHasLeadingOffset() const;
   }];
 }

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -194,7 +194,7 @@ bool isPureUnaryInlineAsm(Operation *op);
 // read the compute capability from the module attributes
 int getNVIDIAComputeCapability(Operation *module);
 
-std::optional<mlir::triton::gpu::SharedEncodingAttr>
+std::optional<mlir::triton::gpu::SharedEncodingTrait>
 getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible);
 
 enum class MMALoadType {

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -165,8 +165,8 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
     auto dstTy = cvtLayout.getType();
     auto srcEncoding = srcTy.getEncoding();
     auto dstEncoding = dstTy.getEncoding();
-    if (mlir::isa<gpu::SharedEncodingAttr>(srcEncoding) ||
-        mlir::isa<gpu::SharedEncodingAttr>(dstEncoding)) {
+    if (mlir::isa<gpu::SharedEncodingTrait>(srcEncoding) ||
+        mlir::isa<gpu::SharedEncodingTrait>(dstEncoding)) {
       // Conversions from/to shared memory do not need scratch memory.
       return 0;
     }

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
@@ -32,7 +32,9 @@ Value getStructFromValueTable(ArrayRef<Value> vals,
   return packLLElements(loc, typeConverter, elems, rewriter, structTy);
 }
 
-bool isSwizzled(SharedEncodingTrait layout) { return layout.getMaxPhase() != 1; }
+bool isSwizzled(SharedEncodingTrait layout) {
+  return layout.getMaxPhase() != 1;
+}
 
 SmallVector<Value> swizzleIndices(ConversionPatternRewriter &rewriter,
                                   Location loc, SmallVector<Value> rawIndices,

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
@@ -15,7 +15,7 @@ using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::getSizePerThread;
 using ::mlir::triton::gpu::getTotalElemsPerThread;
 using ::mlir::triton::gpu::MemDescType;
-using ::mlir::triton::gpu::SharedEncodingAttr;
+using ::mlir::triton::gpu::SharedEncodingTrait;
 
 Value getStructFromValueTable(ArrayRef<Value> vals,
                               ConversionPatternRewriter &rewriter, Location loc,
@@ -32,11 +32,11 @@ Value getStructFromValueTable(ArrayRef<Value> vals,
   return packLLElements(loc, typeConverter, elems, rewriter, structTy);
 }
 
-bool isSwizzled(SharedEncodingAttr layout) { return layout.getMaxPhase() != 1; }
+bool isSwizzled(SharedEncodingTrait layout) { return layout.getMaxPhase() != 1; }
 
 SmallVector<Value> swizzleIndices(ConversionPatternRewriter &rewriter,
                                   Location loc, SmallVector<Value> rawIndices,
-                                  SharedEncodingAttr layout) {
+                                  SharedEncodingTrait layout) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   const auto &order = layout.getOrder();
   auto rank = order.size();
@@ -154,7 +154,7 @@ Value computeSwizzledOffset(ConversionPatternRewriter &rewriter, Location loc,
                             Value bTileOffset, Value nonKTileOffset,
                             unsigned shapePerCTABTile,
                             unsigned shapePerCTANonKTile,
-                            SharedEncodingAttr sharedLayout,
+                            SharedEncodingTrait sharedLayout,
                             ArrayRef<int64_t> opTensorShape,
                             ArrayRef<Value> strides) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -229,7 +229,7 @@ Value loadFMAOp(Value srcVal, Value llVal, BlockedEncodingAttr dLayout,
   dim.nonK = dotOpNo == 0 ? 1 : 2;
   auto opTensorTy = cast<MemDescType>(srcVal.getType());
   auto opTensorShape = expandMatrixShapeWithBatch(opTensorTy.getShape());
-  auto sharedLayout = cast<SharedEncodingAttr>(opTensorTy.getEncoding());
+  auto sharedLayout = cast<SharedEncodingTrait>(opTensorTy.getEncoding());
 
   auto opOrder = expandMatrixOrderWithBatch(dLayout.getOrder());
 

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -76,8 +76,6 @@ struct LocalAllocOpConversion
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
     auto resultTy = cast<MemDescType>(op.getType());
     auto typeConverter = getTypeConverter();
-    auto sharedLayout =
-        cast<triton::gpu::SharedEncodingAttr>(resultTy.getEncoding());
 
     auto llvmElemTy = typeConverter->convertType(resultTy.getElementType());
     auto smemObj = SharedMemoryObject(smemBase, llvmElemTy, resultTy.getRank(),

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -10,7 +10,6 @@ using namespace mlir::triton;
 
 using ::mlir::triton::gpu::getTotalElemsPerThread;
 using ::mlir::triton::gpu::MemDescType;
-using ::mlir::triton::gpu::SharedEncodingAttr;
 
 TritonGPUToLLVMTypeConverter::TritonGPUToLLVMTypeConverter(
     MLIRContext *ctx, LowerToLLVMOptions &options,

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -253,7 +253,7 @@ Value getSmemVecAddr(const LinearLayout &regLayout,
                      .second;
   } else { // Case 2 -> rank-reduced swizzling
     assert(rank >= 2 && "Swizzling only applies to tensors with rank >= 2");
-    assert(!sharedEnc.getHasLeadingOffset() &&
+    assert(!sharedEnc.hasLeadingOffset() &&
            "Leading offsets are not supported for sliced tensors");
     // We define both tensor offsets and shared memory offsets:
     //

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -208,7 +208,7 @@ Value getSmemVecAddr(const LinearLayout &regLayout,
   auto allocShape = sharedTy.getAllocShape();
   auto rank = shape.size();
   auto sharedEnc =
-      dyn_cast<triton::gpu::SharedEncodingAttr>(sharedTy.getEncoding());
+      dyn_cast<triton::gpu::SharedEncodingTrait>(sharedTy.getEncoding());
 
   auto smemBase = smemObj.getBase();
   auto smemOffsets = smemObj.getOffsets();

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -279,7 +279,6 @@ struct MemDescTransOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     auto resultTy = cast<TensorOrMemDesc>(op.getType());
-    auto enc = cast<SharedEncodingAttr>(resultTy.getEncoding());
     auto llvmElemTy =
         getTypeConverter()->convertType(resultTy.getElementType());
     auto srcSmemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2587,7 +2587,7 @@ struct TritonGPUInferLayoutInterface
     auto mmaRetEncoding = mlir::dyn_cast<NvidiaMmaEncodingAttr>(retEncoding);
     if (mmaRetEncoding && mmaRetEncoding.isHopper()) {
       auto dotOpEnc = mlir::dyn_cast<DotOperandEncodingAttr>(operandEncoding);
-      if (!mlir::isa<SharedEncodingAttr>(operandEncoding) &&
+      if (!mlir::isa<SharedEncodingTrait>(operandEncoding) &&
           !(opIdx == 0 && dotOpEnc && dotOpEnc.getOpIdx() == 0 &&
             mlir::isa<NvidiaMmaEncodingAttr>(dotOpEnc.getParent()))) {
         return emitOptionalError(
@@ -3023,7 +3023,7 @@ struct TritonGPUVerifyTensorLayoutInterface
   LogicalResult verifyTensorLayout(
       Attribute layout, RankedTensorType rankedTy, ModuleOp module,
       function_ref<InFlightDiagnostic()> makeErr) const override {
-    if (isa<triton::gpu::SharedEncodingAttr>(layout))
+    if (isa<triton::gpu::SharedEncodingTrait>(layout))
       return makeErr() << "Shared layout is not allowed on tensor type.";
     // TODO(jlebar): Currently this only checks blocked layouts, but other
     // layouts also have invariants!

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -909,12 +909,12 @@ SmallVector<unsigned> SharedEncodingAttr::getCTASplitNum() const {
   return SmallVector<unsigned>(getCTALayout().getCTASplitNum());
 }
 
-bool SharedEncodingAttr::getHasLeadingOffset() const {
+bool SharedEncodingAttr::hasLeadingOffset() const {
   return getHasLeadingOffset__();
 }
 
 int32_t SharedEncodingAttr::getAlignment() const {
-  if (getHasLeadingOffset())
+  if (hasLeadingOffset())
     return 128 * getMaxPhase();
   return 16;
 }
@@ -1903,7 +1903,7 @@ void SharedEncodingAttr::print(AsmPrinter &printer) const {
           << ", order = [" << ArrayRef<unsigned>(getOrder()) << "]";
   maybePrintCTALayout(getContext(), printer, getCTALayout(),
                       /*rank=*/getOrder().size());
-  printer << ", hasLeadingOffset = " << getHasLeadingOffset() << "}>";
+  printer << ", hasLeadingOffset = " << hasLeadingOffset() << "}>";
 }
 
 //===----------------------------------------------------------------------===//
@@ -2529,7 +2529,7 @@ struct TritonGPUInferLayoutInterface
         resultEncoding = SharedEncodingAttr::get(
             ctx, enc.getVec(), enc.getPerPhase(), enc.getMaxPhase(),
             applyPermutation(invOrderUnsigned, enc.getOrder()), *ctaLayout,
-            enc.getHasLeadingOffset());
+            enc.hasLeadingOffset());
       } else {
         llvm_unreachable("Unsupported shared encoding");
       }

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -892,7 +892,10 @@ unsigned SharedEncodingAttr::getTotalElemsPerThread(ArrayRef<int64_t> shape,
 unsigned SharedEncodingAttr::getVec() const { return getVec__(); }
 unsigned SharedEncodingAttr::getPerPhase() const { return getPerPhase__(); }
 unsigned SharedEncodingAttr::getMaxPhase() const { return getMaxPhase__(); }
-ArrayRef<unsigned> SharedEncodingAttr::getOrder() const { return getOrder__(); }
+
+SmallVector<unsigned> SharedEncodingAttr::getOrder() const {
+  return SmallVector<unsigned>(getOrder__());
+}
 
 SmallVector<unsigned> SharedEncodingAttr::getCTAsPerCGA() const {
   return SmallVector<unsigned>(getCTALayout().getCTAsPerCGA());

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3387,10 +3387,9 @@ std::string mlir::triton::gpu::getLayoutStr(RankedTensorType tensorType,
 
   // tensorType is needed later on (e.g., getDimSize(j)), so we still have to
   // pass it as a param
-  if (auto sharedLayout = mlir::dyn_cast<SharedEncodingAttr>(layout)) {
+  if (isa<SharedEncodingTrait>(layout)) {
     return getSharedLayoutStr(tensorType, useHWPointOfView);
-  } else if (auto distributedLayout =
-                 mlir::dyn_cast<DistributedEncodingTrait>(layout)) {
+  } else if (isa<DistributedEncodingTrait>(layout)) {
     return getDistributedLayoutStr(tensorType, useHWPointOfView);
   }
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -362,7 +362,7 @@ SmallVector<unsigned> getCTAOrder(Attribute layout) {
   } else {
     llvm::report_fatal_error("Unimplemented usage of getCTAOrder");
   }
-  llvm_unreachable("Unhandled case");
+  llvm_unreachable("Unhandled case in getCTAOrder");
 }
 
 SmallVector<int64_t> getShapePerCTA(ArrayRef<unsigned> CTASplitNum,
@@ -2424,7 +2424,8 @@ public:
       os << "shared";
       return AliasResult::FinalAlias;
     } else if (auto sharedAttr = mlir::dyn_cast<SharedEncodingTrait>(attr)) {
-      llvm_unreachable("Unsupported shared encoding");
+      llvm_unreachable(
+          "Unsupported shared encoding in TritonGPUOpAsmInterface::getAlias");
     } else if (auto blockedAttr = mlir::dyn_cast<BlockedEncodingAttr>(attr)) {
       os << "blocked";
       return AliasResult::FinalAlias;
@@ -2531,7 +2532,8 @@ struct TritonGPUInferLayoutInterface
             applyPermutation(invOrderUnsigned, enc.getOrder()), *ctaLayout,
             enc.hasLeadingOffset());
       } else {
-        llvm_unreachable("Unsupported shared encoding");
+        llvm_unreachable("Unsupported shared encoding in "
+                         "TritonGPUInferLayoutInterface::inferTransOpEncoding");
       }
       return success();
     }

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -18,6 +18,7 @@
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/StrUtil.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 // Include TableGen'erated code
@@ -885,6 +886,16 @@ unsigned SharedEncodingAttr::getTotalElemsPerThread(ArrayRef<int64_t> shape,
   llvm_unreachable("getElemsPerThread is not supported for shared layout");
   return 0;
 }
+
+unsigned SharedEncodingAttr::getVec() const { return getVec__(); }
+unsigned SharedEncodingAttr::getPerPhase() const { return getPerPhase__(); }
+unsigned SharedEncodingAttr::getMaxPhase() const { return getMaxPhase__(); }
+ArrayRef<unsigned> SharedEncodingAttr::getOrder() const { return getOrder__(); }
+
+bool SharedEncodingAttr::getHasLeadingOffset() const {
+  return getHasLeadingOffset__();
+}
+
 int32_t SharedEncodingAttr::getAlignment() const {
   if (getHasLeadingOffset())
     return 128 * getMaxPhase();
@@ -1872,7 +1883,7 @@ void SharedEncodingAttr::print(AsmPrinter &printer) const {
           << "vec = " << getVec() //
           << ", perPhase = " << getPerPhase()
           << ", maxPhase = " << getMaxPhase() //
-          << ", order = [" << getOrder() << "]";
+          << ", order = [" << ArrayRef<unsigned>(getOrder()) << "]";
   maybePrintCTALayout(getContext(), printer, getCTALayout(),
                       /*rank=*/getOrder().size());
   printer << ", hasLeadingOffset = " << getHasLeadingOffset() << "}>";

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -127,7 +127,7 @@ LinearLayout sharedToLinearLayoutNoLeadingOffset(ArrayRef<int64_t> shape,
   if (rank == 1) {
     return combineCtaCgaWithShape(
         LinearLayout::identity1D(shape[0], S("offset"), S("dim0")),
-        shared.getCTALayout(), shape);
+        getCTALayout(shared), shape);
   }
 
   auto outDimNames = standardOutDimNames(ctx, rank);
@@ -163,7 +163,7 @@ LinearLayout sharedToLinearLayoutNoLeadingOffset(ArrayRef<int64_t> shape,
         LinearLayout::identity1D(shape[dim], S("offset"), outDimNames[dim]);
   }
 
-  return combineCtaCgaWithShape(ctaLayout, shared.getCTALayout(), shape);
+  return combineCtaCgaWithShape(ctaLayout, getCTALayout(shared), shape);
 }
 
 } // namespace
@@ -180,7 +180,7 @@ LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
     // TODO: Not sure if this is correct.
     return combineCtaCgaWithShape(
         LinearLayout::identity1D(shape[0], S("offset"), S("dim0")),
-        shared.getCTALayout(), shape);
+        getCTALayout(shared), shape);
   }
 
   int tileWidthBytes;
@@ -244,7 +244,7 @@ LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
         LinearLayout::identity1D(shape[dim], S("offset"), outDimNames[dim]);
   }
 
-  return combineCtaCgaWithShape(tileLayout, shared.getCTALayout(), shape);
+  return combineCtaCgaWithShape(tileLayout, getCTALayout(shared), shape);
 }
 
 /// Function to generate lane and warp layout for dot operands.

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -120,7 +120,7 @@ LinearLayout combineCtaCgaWithShape(LinearLayout ctaLayout,
 
 LinearLayout sharedToLinearLayoutNoLeadingOffset(ArrayRef<int64_t> shape,
                                                  SharedEncodingTrait shared) {
-  assert(!shared.getHasLeadingOffset());
+  assert(!shared.hasLeadingOffset());
 
   MLIRContext *ctx = shared.getContext();
   int rank = shape.size();
@@ -172,7 +172,7 @@ LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
                                                SharedEncodingTrait shared,
                                                int32_t elemBitWidth,
                                                bool disableSwizzle) {
-  assert(shared.getHasLeadingOffset());
+  assert(shared.hasLeadingOffset());
 
   MLIRContext *ctx = shared.getContext();
   int rank = shape.size();
@@ -889,7 +889,7 @@ TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape, Attribute layout,
     result = distributed.toLinearLayout(shape);
   } else {
     auto shared = dyn_cast<SharedEncodingTrait>(layout);
-    if (shared.getHasLeadingOffset()) {
+    if (shared.hasLeadingOffset()) {
       assert(elemBitWidth.has_value());
       result = sharedToLinearLayoutLeadingOffset(shape, shared, *elemBitWidth);
     } else {

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -119,7 +119,7 @@ LinearLayout combineCtaCgaWithShape(LinearLayout ctaLayout,
 }
 
 LinearLayout sharedToLinearLayoutNoLeadingOffset(ArrayRef<int64_t> shape,
-                                                 SharedEncodingAttr shared) {
+                                                 SharedEncodingTrait shared) {
   assert(!shared.getHasLeadingOffset());
 
   MLIRContext *ctx = shared.getContext();
@@ -169,7 +169,7 @@ LinearLayout sharedToLinearLayoutNoLeadingOffset(ArrayRef<int64_t> shape,
 } // namespace
 
 LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
-                                               SharedEncodingAttr shared,
+                                               SharedEncodingTrait shared,
                                                int32_t elemBitWidth,
                                                bool disableSwizzle) {
   assert(shared.getHasLeadingOffset());
@@ -888,7 +888,7 @@ TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape, Attribute layout,
   if (auto distributed = dyn_cast<DistributedEncodingTrait>(layout)) {
     result = distributed.toLinearLayout(shape);
   } else {
-    auto shared = dyn_cast<SharedEncodingAttr>(layout);
+    auto shared = dyn_cast<SharedEncodingTrait>(layout);
     if (shared.getHasLeadingOffset()) {
       assert(elemBitWidth.has_value());
       result = sharedToLinearLayoutLeadingOffset(shape, shared, *elemBitWidth);

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -654,7 +654,7 @@ int32_t LocalAllocOp::getAlignmentOrDefault() {
   }
 
   auto ty = getType();
-  auto enc = dyn_cast<SharedEncodingAttr>(ty.getEncoding());
+  auto enc = dyn_cast<SharedEncodingTrait>(ty.getEncoding());
   return enc ? enc.getAlignment() : 16;
 }
 

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -608,11 +608,11 @@ LogicalResult MemDescSubviewOp::verify() {
 
   if (!isa<SharedEncodingTrait>(srcEnc) &&
       !isa<triton::nvidia_gpu::TensorMemoryEncodingAttr>(srcEnc)) {
-    return emitError("src encoding must be SharedEncodingAttr");
+    return emitError("src encoding must be SharedEncodingTrait");
   }
   if (!isa<SharedEncodingTrait>(dstEnc) &&
       !isa<triton::nvidia_gpu::TensorMemoryEncodingAttr>(srcEnc)) {
-    return emitError("result encoding must be SharedEncodingAttr");
+    return emitError("result encoding must be SharedEncodingTrait");
   }
 
   if (isa<triton::nvidia_gpu::TensorMemoryEncodingAttr>(srcEnc)) {

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -218,7 +218,7 @@ struct CanonicalizeConvertFromConvert
       return failure();
 
     // for hopper MMAv3
-    if (mlir::isa<SharedEncodingAttr>(dstType.getEncoding()) &&
+    if (mlir::isa<SharedEncodingTrait>(dstType.getEncoding()) &&
         mlir::isa<NvidiaMmaEncodingAttr>(srcType.getEncoding()) &&
         llvm::any_of(op.getResult().getUsers(), [](Operation *dot) {
           return dot->hasTrait<OpTrait::DotLike>();
@@ -606,11 +606,11 @@ LogicalResult MemDescSubviewOp::verify() {
     return emitError("src and result must both have or not have an encoding");
   }
 
-  if (!isa<SharedEncodingAttr>(srcEnc) &&
+  if (!isa<SharedEncodingTrait>(srcEnc) &&
       !isa<triton::nvidia_gpu::TensorMemoryEncodingAttr>(srcEnc)) {
     return emitError("src encoding must be SharedEncodingAttr");
   }
-  if (!isa<SharedEncodingAttr>(dstEnc) &&
+  if (!isa<SharedEncodingTrait>(dstEnc) &&
       !isa<triton::nvidia_gpu::TensorMemoryEncodingAttr>(srcEnc)) {
     return emitError("result encoding must be SharedEncodingAttr");
   }

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -120,7 +120,7 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
     for (auto operand : op->getOperands()) {
       auto tensorType = dyn_cast<RankedTensorType>(operand.getType());
       if (tensorType &&
-          !isa<triton::gpu::SharedEncodingAttr>(tensorType.getEncoding())) {
+          !isa<triton::gpu::SharedEncodingTrait>(tensorType.getEncoding())) {
         Type newType = getNewType(tensorType, encoding);
         newArgs.push_back(builder.create<triton::gpu::ConvertLayoutOp>(
             op->getLoc(), newType, operand));

--- a/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
@@ -45,7 +45,7 @@ struct ClipAsyncCopySizePerThread
     if (!blockedEnc)
       return rewriter.notifyMatchFailure(copyOp,
                                          "src must be of blocked encoding");
-    auto sharedEnc = cast<SharedEncodingAttr>(dstTy.getEncoding());
+    auto sharedEnc = cast<SharedEncodingTrait>(dstTy.getEncoding());
     auto sharedVec = sharedEnc.getVec();
 
     // obtain max contiguous copy size

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -385,7 +385,7 @@ struct MMAV3UseRegOperand
       return cast<TensorOrMemDesc>(v.getType()).getEncoding();
     };
 
-    if (!isa<SharedEncodingAttr>(getEncoding(dotOp.getOperand(0))))
+    if (!isa<SharedEncodingTrait>(getEncoding(dotOp.getOperand(0))))
       return failure();
     auto srcEnc = dyn_cast<NvidiaMmaEncodingAttr>(getEncoding(alloc.getSrc()));
     auto dstEnc =
@@ -444,7 +444,7 @@ struct MMAV3HoistLayoutConversion
       return cast<TensorOrMemDesc>(v.getType()).getEncoding();
     };
 
-    if (!isa<SharedEncodingAttr>(getEncoding(dotOp.getOperand(0))))
+    if (!isa<SharedEncodingTrait>(getEncoding(dotOp.getOperand(0))))
       return rewriter.notifyMatchFailure(
           dotOp, "requires Shared encoding for operand A");
 

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -359,7 +359,7 @@ public:
           getContext(), srcTy.getShape(), newInnerCvtOrder,
           allocEncoding.getCTALayout(), srcTy.getElementType());
     } else {
-      llvm_unreachable("Unsupported shared encoding");
+      llvm_unreachable("Unsupported shared encoding in FuseTransMMAV3Plus");
     }
 
     MemDescType innerTy =

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -45,12 +45,12 @@ bool canHaveSharedEncoding(tt::LoadOp op) {
   if (llvm::any_of(op->getUsers(), [&](Operation *user) {
         return isa<ttg::LocalAllocOp>(user);
       })) {
-    ttg::SharedEncodingAttr localAllocEnc;
+    ttg::SharedEncodingTrait localAllocEnc;
     for (auto user : op->getUsers()) {
       auto localAlloc = dyn_cast<ttg::LocalAllocOp>(user);
       if (!localAlloc)
         continue;
-      auto enc = mlir::cast<ttg::SharedEncodingAttr>(
+      auto enc = mlir::cast<ttg::SharedEncodingTrait>(
           localAlloc.getType().getEncoding());
       if (!localAllocEnc) {
         localAllocEnc = enc;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -554,7 +554,8 @@ assignMemoryLayouts(scf::ForOp &forOp,
 
 // Create an allocation that can hold distance number of loadOp shapes.
 static Value createAlloc(scf::ForOp &forOp, Operation *loadOp,
-                         ttg::SharedEncodingTrait sharedEnc, unsigned distance) {
+                         ttg::SharedEncodingTrait sharedEnc,
+                         unsigned distance) {
   OpBuilder builder(forOp);
   Attribute sharedMemorySpace =
       ttg::SharedMemorySpaceAttr::get(forOp.getContext());

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -37,7 +37,7 @@ namespace {
 
 struct LoadInfo {
   // Layout of the data in shared memory.
-  ttg::SharedEncodingAttr sharedEncoding = nullptr;
+  ttg::SharedEncodingTrait sharedEncoding = nullptr;
   // Blocked encoding is used for loads not used by the dot.
   ttg::BlockedEncodingAttr blockedEncoding = nullptr;
   bool isMMAv3Shared = false;
@@ -578,7 +578,7 @@ assignMemoryLayouts(scf::ForOp &forOp,
 
 // Create an allocation that can hold distance number of loadOp shapes.
 static Value createAlloc(scf::ForOp &forOp, Operation *loadOp,
-                         ttg::SharedEncodingAttr sharedEnc, unsigned distance) {
+                         ttg::SharedEncodingTrait sharedEnc, unsigned distance) {
   OpBuilder builder(forOp);
   Attribute sharedMemorySpace =
       ttg::SharedMemorySpaceAttr::get(forOp.getContext());

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -402,30 +402,6 @@ getSharedEncoding(Operation *loadOp, bool isTMALoad) {
                                       ctaLayout);
 }
 
-static bool hasSharedEncodingHelper(Operation *loadOp) {
-  // If the load is used by a LocalAllocOp, use the same encoding as the allocs.
-  // If the allocs don't all have the same encoding, bail.
-  if (llvm::any_of(loadOp->getUsers(), [&](Operation *user) {
-        return isa<ttg::LocalAllocOp>(user);
-      })) {
-    ttg::SharedEncodingAttr localAllocEnc;
-    for (auto user : loadOp->getUsers()) {
-      auto localAlloc = dyn_cast<ttg::LocalAllocOp>(user);
-      if (!localAlloc)
-        continue;
-      auto enc = mlir::cast<ttg::SharedEncodingAttr>(
-          localAlloc.getType().getEncoding());
-      if (!localAllocEnc) {
-        localAllocEnc = enc;
-      }
-      if (enc != localAllocEnc)
-        return false;
-    }
-    return true;
-  }
-  return true;
-}
-
 static llvm::SmallVector<Operation *> getDirectUserInBlock(Operation *loadOp) {
   llvm::SmallVector<Operation *> users;
   DenseSet<Operation *> seen;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -1429,7 +1429,7 @@ static std::optional<int> dotCanBeProperlyAsync(ttng::WarpGroupDotOp dotOp,
 
   // Rule 1: All shmem operands are multi-buffered.
   auto checkOperand = [&](Value operand) {
-    if (!isa<ttg::SharedEncodingAttr>(
+    if (!isa<ttg::SharedEncodingTrait>(
             cast<ttg::TensorOrMemDesc>(operand.getType()).getEncoding())) {
       // Rule 1a: Register operands must not be modified within the loop.
       // First, check for chained WGMMA as an exception.

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -351,7 +351,7 @@ getBlockedEncoding(tt::LoadOp loadOp, tt::ModuleAxisInfoAnalysis &axisInfo) {
                                        threadsPerWarp, ctaLayout);
 }
 
-static std::optional<ttg::SharedEncodingAttr>
+static std::optional<ttg::SharedEncodingTrait>
 getSharedEncoding(Operation *loadOp, bool isTMALoad) {
   auto ty = cast<RankedTensorType>(loadOp->getResultTypes()[0]);
   auto ctaLayout = ttg::getCTALayout(ty.getEncoding());
@@ -380,12 +380,12 @@ getSharedEncoding(Operation *loadOp, bool isTMALoad) {
   if (llvm::any_of(loadOp->getUsers(), [&](Operation *user) {
         return isa<ttg::LocalAllocOp>(user);
       })) {
-    ttg::SharedEncodingAttr localAllocEnc;
+    ttg::SharedEncodingTrait localAllocEnc;
     for (auto user : loadOp->getUsers()) {
       auto localAlloc = dyn_cast<ttg::LocalAllocOp>(user);
       if (!localAlloc)
         continue;
-      auto enc = mlir::cast<ttg::SharedEncodingAttr>(
+      auto enc = mlir::cast<ttg::SharedEncodingTrait>(
           localAlloc.getType().getEncoding());
       if (!localAllocEnc) {
         localAllocEnc = enc;

--- a/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
@@ -36,7 +36,7 @@ public:
       auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
       auto dstType = cast<RankedTensorType>(cvtOp.getType());
       auto srcEncoding = srcType.getEncoding();
-      if (isa<triton::gpu::SharedEncodingAttr>(srcEncoding))
+      if (isa<triton::gpu::SharedEncodingTrait>(srcEncoding))
         return;
       auto dstDotOp =
           dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -985,7 +985,7 @@ int getNVIDIAComputeCapability(Operation *module) {
 // the same dot operand encoding, return the shared encoding that needs to be
 // used to be compatible with users' layouts. If there are incompatible shared
 // encodings, set incompatible to true.
-std::optional<ttg::SharedEncodingAttr>
+std::optional<ttg::SharedEncodingTrait>
 getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible) {
   ttg::SharedEncodingAttr attr;
   incompatible = false;

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -284,7 +284,7 @@ std::string GraphLayoutMarker::getColor(const Type &type) const {
       return "lightslateblue";
     else if (isa<triton::gpu::DotOperandEncodingAttr>(layout))
       return "orange";
-    else if (isa<triton::gpu::SharedEncodingAttr>(layout))
+    else if (isa<triton::gpu::SharedEncodingTrait>(layout))
       return "orangered";
     else {
       llvm::report_fatal_error("Unrecognized layout");

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -987,17 +987,17 @@ int getNVIDIAComputeCapability(Operation *module) {
 // encodings, set incompatible to true.
 std::optional<ttg::SharedEncodingTrait>
 getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible) {
-  ttg::SharedEncodingAttr attr;
+  ttg::SharedEncodingTrait attr;
   incompatible = false;
   for (Operation *user : val.getUsers()) {
-    ttg::SharedEncodingAttr tempAttr;
+    ttg::SharedEncodingTrait tempAttr;
     if (user->getNumResults() != 1)
       return std::nullopt;
     if (auto memDesc =
             dyn_cast<triton::gpu::MemDescType>(user->getResult(0).getType())) {
       // First time we find a shared encoding in the chain, save it and try to
       // use it if it is compatible with the other users.
-      tempAttr = cast<ttg::SharedEncodingAttr>(memDesc.getEncoding());
+      tempAttr = cast<ttg::SharedEncodingTrait>(memDesc.getEncoding());
       if (!getSharedEncIfAllUsersAreDotEnc(user->getResult(0), incompatible)
                .has_value())
         return std::nullopt;

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1033,7 +1033,7 @@ MMALoadType getMMALoadType(Operation *loadOp) {
 
   if (auto alloc = dyn_cast<ttg::LocalAllocOp>(*loadOp->getUsers().begin())) {
     auto sharedEnc =
-        cast<ttg::SharedEncodingAttr>(alloc.getType().getEncoding());
+        cast<ttg::SharedEncodingTrait>(alloc.getType().getEncoding());
 
     if (!sharedEnc.hasLeadingOffset())
       return MMALoadType::DoNotPipeline;

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1035,7 +1035,7 @@ MMALoadType getMMALoadType(Operation *loadOp) {
     auto sharedEnc =
         cast<ttg::SharedEncodingAttr>(alloc.getType().getEncoding());
 
-    if (!sharedEnc.getHasLeadingOffset())
+    if (!sharedEnc.hasLeadingOffset())
       return MMALoadType::DoNotPipeline;
 
     // MMA V3 case.

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -21,8 +21,6 @@ namespace ttng = ::mlir::triton::nvidia_gpu;
 #define GEN_PASS_CLASSES
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
-using ::mlir::triton::gpu::SharedEncodingAttr;
-
 namespace {
 
 struct FenceInsertionPass

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -8,7 +8,6 @@ using ::mlir::triton::gpu::AMDMfmaEncodingAttr;
 using ::mlir::triton::gpu::AMDWmmaEncodingAttr;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;
 using ::mlir::triton::gpu::MemDescType;
-using ::mlir::triton::gpu::SharedEncodingAttr;
 
 namespace SharedToDotOperandMFMA {
 Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -8,7 +8,6 @@ using ::mlir::triton::gpu::AMDMfmaEncodingAttr;
 using ::mlir::triton::gpu::AMDWmmaEncodingAttr;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;
 using ::mlir::triton::gpu::MemDescType;
-using ::mlir::triton::gpu::SharedEncodingAttr;
 
 namespace SharedToDotOperandMFMA {
 Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -61,7 +61,8 @@ public:
           triton::gpu::getOrder(parentEnc),
           triton::gpu::getCTALayout(parentEnc), type.getElementType());
     } else {
-      llvm_unreachable("Unsupporeted shared encoding");
+      llvm_unreachable(
+          "Unsupporeted shared encoding in DecomposeLocalLoadToDotOperand");
     }
     auto newSharedDescTy =
         MemDescType::get(type.getShape(), type.getElementType(), newSharedEnc,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -39,7 +39,7 @@ public:
         op.getType().getEncoding());
     MemDescType srcType = op.getSrc().getType();
     auto sharedEncoding = dyn_cast<SharedEncodingTrait>(srcType.getEncoding());
-    if (!dstDotOp || !sharedEncoding || !sharedEncoding.getHasLeadingOffset())
+    if (!dstDotOp || !sharedEncoding || !sharedEncoding.hasLeadingOffset())
       return failure();
     RankedTensorType type = op.getType();
     auto parentEnc = dstDotOp.getParent();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -58,7 +58,7 @@ private:
   bool trans;
   Value elemsPerSwizzlingRowVal;
   SmallVector<unsigned int> instrShape;
-  ArrayRef<unsigned> ord;
+  SmallVector<unsigned> ord;
   int elemsPerSwizzlingRow;
   int64_t elemBits;
   Value descriptor;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -435,10 +435,10 @@ struct TCGen5MMAOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto AEnc = op.getA().getType().getEncoding();
     auto BEnc = op.getB().getType().getEncoding();
-    assert(mlir::isa<SharedEncodingAttr>(AEnc) ||
+    assert(mlir::isa<SharedEncodingTrait>(AEnc) ||
            mlir::isa<triton::nvidia_gpu::TensorMemoryEncodingAttr>(AEnc) &&
                "Operand A should use Shared or Tensor memory layout.");
-    assert(mlir::isa<SharedEncodingAttr>(BEnc) &&
+    assert(mlir::isa<SharedEncodingTrait>(BEnc) &&
            "Operand B should use Shared layout.");
     assert(op.getBarrier() &&
            "tensorcore op should have a barrier at this point.");

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -14,7 +14,7 @@ using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
 using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::getShapePerCTATile;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
-using ::mlir::triton::gpu::SharedEncodingAttr;
+using ::mlir::triton::gpu::SharedEncodingTrait;
 
 mlir::triton::NVIDIA::DotOpMmaV5TmemLoader::DotOpMmaV5TmemLoader(
     Value tensor, Value base, SmallVector<unsigned int> instrShape,
@@ -344,12 +344,12 @@ void convertDot(const LLVMTypeConverter *typeConverter,
   bool aInTmem = true;
   bool transA = false;
   if (auto aSharedLayout =
-          dyn_cast<SharedEncodingAttr>(aTensorTy.getEncoding())) {
+          dyn_cast<SharedEncodingTrait>(aTensorTy.getEncoding())) {
     auto aOrd = aSharedLayout.getOrder();
     transA = aOrd[0] == 0;
     aInTmem = false;
   }
-  auto bSharedLayout = cast<SharedEncodingAttr>(bTensorTy.getEncoding());
+  auto bSharedLayout = cast<SharedEncodingTrait>(bTensorTy.getEncoding());
   auto bOrd = bSharedLayout.getOrder();
   bool transB = bOrd[0] == 1;
   Value baseA =
@@ -491,12 +491,12 @@ struct TCGen5MMAScaledOpConversion
     bool aInTmem = true;
     bool transA = false;
     if (auto aSharedLayout =
-            dyn_cast<SharedEncodingAttr>(aTensorTy.getEncoding())) {
+            dyn_cast<SharedEncodingTrait>(aTensorTy.getEncoding())) {
       auto aOrd = aSharedLayout.getOrder();
       transA = aOrd[0] == 0;
       aInTmem = false;
     }
-    auto bSharedLayout = cast<SharedEncodingAttr>(bTensorTy.getEncoding());
+    auto bSharedLayout = cast<SharedEncodingTrait>(bTensorTy.getEncoding());
     auto bOrd = bSharedLayout.getOrder();
     bool transB = bOrd[0] == 1;
     Value baseA =

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1412,7 +1412,7 @@ static LogicalResult iterateGatherScatterIndices(
     return op->emitError("memdesc shape must match alloc shape");
   // `hasLeadingOffset` means the core matrix tiles are placed next to each
   // other in shared memory, which lines up with how `gather4` loads data.
-  if (!cast<SharedEncodingTrait>(smemType.getEncoding()).getHasLeadingOffset())
+  if (!cast<SharedEncodingTrait>(smemType.getEncoding()).hasLeadingOffset())
     return op->emitError("requires dst encoding with `hasLeadingOffset=true`");
   Type llvmElemTy = typeConverter.convertType(smemType.getElementType());
   Type elemPtrTy = ptr_ty(ctx, /*addrspace=*/3);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -30,7 +30,7 @@ using ::mlir::LLVM::linearize;
 using ::mlir::triton::gpu::getCTALayout;
 using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::getTotalElemsPerThread;
-using ::mlir::triton::gpu::SharedEncodingAttr;
+using ::mlir::triton::gpu::SharedEncodingTrait;
 
 namespace ttg = mlir::triton::gpu;
 
@@ -1047,7 +1047,7 @@ struct AsyncCopyGlobalToLocalOpConversion
     auto srcLayout = srcTy.getEncoding();
     assert((isa<BlockedEncodingAttr, SliceEncodingAttr>(srcLayout) &&
             "Unexpected srcLayout in AsyncCopyGlobalToLocalOpConversion"));
-    auto resSharedLayout = cast<SharedEncodingAttr>(dstTy.getEncoding());
+    auto resSharedLayout = cast<SharedEncodingTrait>(dstTy.getEncoding());
 
     Value llDst = adaptor.getResult();
     Value llSrc = adaptor.getSrc();
@@ -1361,7 +1361,7 @@ struct AsyncTMACopyLocalToGlobalOpConversion
 
 static LinearLayout getUnswizzledLayout(triton::gpu::MemDescType type) {
   return triton::gpu::sharedToLinearLayoutLeadingOffset(
-      type.getShape(), cast<SharedEncodingAttr>(type.getEncoding()),
+      type.getShape(), cast<SharedEncodingTrait>(type.getEncoding()),
       type.getElementTypeBitWidth(), /*disableSwizzle=*/true);
 }
 
@@ -1412,7 +1412,7 @@ static LogicalResult iterateGatherScatterIndices(
     return op->emitError("memdesc shape must match alloc shape");
   // `hasLeadingOffset` means the core matrix tiles are placed next to each
   // other in shared memory, which lines up with how `gather4` loads data.
-  if (!cast<SharedEncodingAttr>(smemType.getEncoding()).getHasLeadingOffset())
+  if (!cast<SharedEncodingTrait>(smemType.getEncoding()).getHasLeadingOffset())
     return op->emitError("requires dst encoding with `hasLeadingOffset=true`");
   Type llvmElemTy = typeConverter.convertType(smemType.getElementType());
   Type elemPtrTy = ptr_ty(ctx, /*addrspace=*/3);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -47,7 +47,7 @@ public:
       // Limitation 1 [TODO: remove]: Check LL bases to verify register and
       // address alignment
       auto canUseLdmatrix =
-          (kWidth == vecWidth) && (!sharedEnc.getHasLeadingOffset());
+          (kWidth == vecWidth) && (!sharedEnc.hasLeadingOffset());
       canUseLdmatrix &= (sharedEnc.getMaxPhase() == 1) ||
                         (sharedEnc.getVec() * bitwidth >= 8 * 16);
       auto shape = srcTy.getShape();
@@ -147,7 +147,7 @@ LogicalResult lowerDistributedToSharedStmatrix(
     return failure();
   auto sharedLayout =
       cast<triton::gpu::SharedEncodingTrait>(memDescType.getEncoding());
-  if (!sharedLayout.getHasLeadingOffset())
+  if (!sharedLayout.hasLeadingOffset())
     return failure();
   int swizzleByteSize = 0;
   if (sharedLayout.getPerPhase() == 4 && sharedLayout.getMaxPhase() == 2)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -36,7 +36,7 @@ public:
             cast<DotOperandEncodingAttr>(dstLayout).getParent())) {
       auto dotEnc = cast<DotOperandEncodingAttr>(dstLayout);
       auto mmaEnc = cast<NvidiaMmaEncodingAttr>(dotEnc.getParent());
-      auto sharedEnc = cast<SharedEncodingAttr>(srcLayout);
+      auto sharedEnc = cast<SharedEncodingTrait>(srcLayout);
       auto bitwidth = dstTy.getElementTypeBitWidth();
       auto vecWidth = 32 / bitwidth;
       auto kWidth = dotEnc.getKWidth();
@@ -77,7 +77,7 @@ private:
     auto dstTy = cast<RankedTensorType>(op.getType());
     auto srcTy = cast<MemDescType>(op.getSrc().getType());
     auto dotEnc = cast<DotOperandEncodingAttr>(dstTy.getEncoding());
-    auto sharedEnc = cast<SharedEncodingAttr>(srcTy.getEncoding());
+    auto sharedEnc = cast<SharedEncodingTrait>(srcTy.getEncoding());
     auto shape = dstTy.getShape();
     auto rank = dstTy.getRank();
     auto kOrder = dotEnc.getOpIdx() == 0 ? rank - 1 : rank - 2;
@@ -146,7 +146,7 @@ LogicalResult lowerDistributedToSharedStmatrix(
   if (!mmaEncoding)
     return failure();
   auto sharedLayout =
-      cast<triton::gpu::SharedEncodingAttr>(memDescType.getEncoding());
+      cast<triton::gpu::SharedEncodingTrait>(memDescType.getEncoding());
   if (!sharedLayout.getHasLeadingOffset())
     return failure();
   int swizzleByteSize = 0;
@@ -223,7 +223,7 @@ struct LocalAllocOpConversion
       return failure();
     MemDescType memDescType = op.getType();
     auto sharedLayout =
-        cast<triton::gpu::SharedEncodingAttr>(memDescType.getEncoding());
+        cast<triton::gpu::SharedEncodingTrait>(memDescType.getEncoding());
     RankedTensorType srcTy = op.getSrc().getType();
     Type llvmElemTy = typeConverter->convertType(srcTy.getElementType());
     Value smemBase =

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -481,7 +481,7 @@ struct TensorMemoryCopyOpConversion
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto srcTy = cast<MemDescType>(op.getSrc().getType());
     assert(isa<triton::gpu::SharedMemorySpaceAttr>(srcTy.getMemorySpace()));
-    assert(isa<triton::gpu::SharedEncodingAttr>(srcTy.getEncoding()));
+    assert(isa<triton::gpu::SharedEncodingTrait>(srcTy.getEncoding()));
 
     auto sharedEnc = cast<triton::gpu::SharedEncodingAttr>(srcTy.getEncoding());
     assert(


### PR DESCRIPTION
To prepare for a follow-up PR which will introduce a new SMEM encoding representing the FP4 padded layout for Blackwell mixed-precision scaled dot. The layout is described in https://docs.nvidia.com/cuda/parallel-thread-execution/#packing-format-used-for-matrix-a-and-b-by-kind-mxf8f6f4-in-shared-memory

We agreed to implement the new encoding as a separate class from the existing `SharedEncodingAttr`, rather than adding a new field or subclassing it. But we want the rest of the code to work generically with both SMEM encoding types, so I'm introducing an SMEM encoding interface which is inherited by both encodings.

The PR is mostly mechanical changes:

* Follows the design of `DistributedEncoding` (use of `Trait` etc)
* The interface consists of methods which used to be an accessor method on `SharedEncodingAttr` (getMaxPhase etc). Whether or not `hasLeadingOffset` should be part of the interface is debatable, since this is NV-specific, but for now it is.
* Change `isa<SharedEncodingAttr>`, `cast<SharedEncodingAttr>` etc, and `ShardEncodingAttr` in function arguments to work with `SharedEncodingTrait` instead.
* AMD code is untouched. But given the discussion in https://github.com/triton-lang/triton/pull/5720 I'm curious if this could be useful there too cc @binarman 

cc @ThomasRaoux @lezcano I hope I'm on the right track with this one
