### PR TITLE
[Triton] Change `xor_sum` to use `@jit` (NFC)

### DIFF
--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -280,8 +280,6 @@ def _xor_combine(a, b):
 @core._add_reduction_docstr("xor sum")
 def xor_sum(input, axis=None, keep_dims=False):
     core.static_assert(input.type.scalar.is_int(), "xor_sum only supported for integers")
-
-    input = core._promote_bfloat16_to_float32(input)
     return core.reduce(input, axis, _xor_combine, keep_dims=keep_dims)
 
 

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -276,15 +276,13 @@ def _xor_combine(a, b):
 
 
 @core._tensor_member_fn
-@core.builtin
+@jit
 @core._add_reduction_docstr("xor sum")
-def xor_sum(input, axis=None, keep_dims=False, _builder=None, _generator=None):
-    scalar_ty = input.type.scalar
-    if not scalar_ty.is_int():
-        raise ValueError("xor_sum only supported for integers")
+def xor_sum(input, axis=None, keep_dims=False):
+    core.static_assert(input.type.scalar.is_int(), "xor_sum only supported for integers")
 
-    input = core._promote_bfloat16_to_float32(input, _builder=_builder)
-    return core.reduce(input, axis, _xor_combine, keep_dims=keep_dims, _builder=_builder, _generator=_generator)
+    input = core._promote_bfloat16_to_float32(input)
+    return core.reduce(input, axis, _xor_combine, keep_dims=keep_dims)
 
 
 # cumsum


### PR DESCRIPTION
The interpreter doesn't support the `_generator` special argument at the moment.
