### PR TITLE
[OPTIMIZER] Fix insertion location in HoistLayoutConversion pattern

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -285,6 +285,7 @@ public:
     if (!foundInitializer)
       return failure();
 
+    rewriter.setInsertionPointAfter(src);
     SmallVector<ConvertLayoutOp> newOperands;
     for (auto operand : src->getOperands()) {
       // We checked earlier that all operands are ranked tensors.

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -340,6 +340,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: tt.func @propagate_dot_op_to_constant_above_for()
   // CHECK: arith.constant dense<1.000000e+00> : tensor<32x128xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>
+  // CHECK: tt.elementwise_inline_asm
+  // CHECK: scf.for
+  // CHECK: tt.dot
   tt.func @propagate_dot_op_to_constant_above_for() -> tensor<32x128xf32, #mma> {
     %cst = arith.constant dense<1.000000e+00> : tensor<32x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
     %cst_0 = arith.constant dense<1.000000e+00> : tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>
@@ -347,8 +350,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
     %c32_i32 = arith.constant 32 : i32
     %c128_i32 = arith.constant 128 : i32
+    %0 = tt.elementwise_inline_asm "cvt.rna.tf32.f32 $0, $1;" {constraints = "=r,r", packed_element = 1 : i32, pure = true} %cst : tensor<32x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
     %loop:1 = scf.for %arg2 = %c0_i32 to %c128_i32 step %c32_i32 iter_args(%arg0 = %cst_1) -> (tensor<32x128xf32, #mma>)  : i32 {
-      %0 = tt.elementwise_inline_asm "cvt.rna.tf32.f32 $0, $1;" {constraints = "=r,r", packed_element = 1 : i32, pure = true} %cst : tensor<32x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>
       %1 = ttg.convert_layout %0 : tensor<32x128xf32, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x128xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>
       %2 = ttg.convert_layout %cst_0 : tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
       %3 = tt.dot %2, %1, %arg0, inputPrecision = tf32 : tensor<32x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<32x128xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<32x128xf32, #mma>


### PR DESCRIPTION
When rewriting `convert_layout(src)` to `src(convert_layout)` we should be hoisting `convert_layout` to appear in the program before `src`. However, in the current implementation the insertion point was set to `convert_layout`, so we effectively ended up pulling `src` to the location after `convert_layout`.

This didn't really make a difference before #5349 as we didn't allow hoisting outside of blocks, but with that change it could mean that we pull `src` into a different block than it was originally in. (For example, this caused issues in our internal attention kernel, where an op was accidentally pulled into a loop, which then prevented a subsequent ReorderInstructions pass to hoist a dependent `local_alloc` out of the loop, causing increased register pressure, spills to local memory, and 25% perf regression.)

This change fixes this by setting the insertion point to the location of `src`, making sure that op is kept in a fixed location.
