### PR TITLE
[PROTON] Skip warnings caused by legacy clang compilers

### DIFF
--- a/third_party/proton/CMakeLists.txt
+++ b/third_party/proton/CMakeLists.txt
@@ -26,12 +26,16 @@ function(add_proton_library name)
 
   target_link_libraries(${name} PRIVATE Python3::Module pybind11::headers)
 
+  # Use system to skip warnings caused by legacy clang compilers
+  target_include_directories(${name}
+    SYSTEM PRIVATE
+      "${ROCTRACER_INCLUDE_DIR}"
+  )
+
   target_include_directories(${name}
     PRIVATE
       "${CUPTI_INCLUDE_DIR}"
-      "${ROCTRACER_INCLUDE_DIR}"
       "${JSON_INCLUDE_DIR}"
-      "${PROTON_SRC_DIR}/include"
   )
 
   # If HIP is AMD-based

--- a/third_party/proton/CMakeLists.txt
+++ b/third_party/proton/CMakeLists.txt
@@ -36,6 +36,7 @@ function(add_proton_library name)
     PRIVATE
       "${CUPTI_INCLUDE_DIR}"
       "${JSON_INCLUDE_DIR}"
+      "${PROTON_SRC_DIR}/include"
   )
 
   # If HIP is AMD-based


### PR DESCRIPTION
`error: unknown warning group '-Wreserved-macro-identifier'`, this flag was not defined in `clang-10`