### PR TITLE
[mlir][dialect] Refactor DotLike trait into a DotOpInterface + Enable verification of scaled_dot

### DIFF
--- a/include/triton/Dialect/Triton/IR/OpInterfaces.h
+++ b/include/triton/Dialect/Triton/IR/OpInterfaces.h
@@ -11,6 +11,8 @@ namespace impl {
 
 LogicalResult verifyTransposeOpInterface(Operation *op);
 
+LogicalResult verifyDotOpInterface(Operation *op);
+
 } // namespace impl
 
 } // namespace triton

--- a/include/triton/Dialect/Triton/IR/Traits.h
+++ b/include/triton/Dialect/Triton/IR/Traits.h
@@ -58,55 +58,6 @@ public:
   }
 };
 
-// Verify if the op is a dot-like operation.
-// A dot-like operation should have three operands.
-// The first two operands should share a common dimension, and the result
-// should have the dimensions of the two operands that are not shared.
-// A dot-like operation can be either 2d or 3d.
-// In the 3d case, the first dimension of operands is the batch dimension.
-/*
-template <class ConcreteType>
-class DotLike : public TraitBase<ConcreteType, DotLike> {
-public:
-  static LogicalResult verifyTrait(Operation *op) {
-    if (op->getNumOperands() < 3)
-      return op->emitOpError("expected at least 3 operands");
-    auto aTy = cast<ShapedType>(op->getOperand(0).getType());
-    auto bTy = cast<ShapedType>(op->getOperand(1).getType());
-    auto cTy = cast<ShapedType>(op->getOperand(2).getType());
-    auto aShape = aTy.getShape();
-    auto bShape = bTy.getShape();
-    auto cShape = cTy.getShape();
-    // Check if all 3d or all 2d
-    if (aShape.size() != 2 && aShape.size() != 3)
-      return op->emitOpError("expected operands to be 2d or 3d");
-    if (aShape.size() != bShape.size() || aShape.size() != cShape.size())
-      return op->emitOpError("expected all operands to have the same rank");
-    // Check if the first two operands share a common dimension
-    // TODO: enable back with an interface to support scaled dot.
-    // if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
-    //   return op->emitOpError("expected the last dimension of the first
-    //   operand "
-    //                          "to be equal to the second-to-last dimension of
-    //                          " "the second operand");
-    // Check the batch dimension
-    if (aShape.size() == 3 &&
-        (aShape[0] != cShape[0] || bShape[0] != cShape[0]))
-      return op->emitOpError("expected the first dimension of the first "
-                             "operand to be equal to the first dimension of "
-                             "the result");
-    // Check the output shape
-    if (cShape[cShape.size() - 2] != aShape[aShape.size() - 2] ||
-        cShape[cShape.size() - 1] != bShape[aShape.size() - 1])
-      return op->emitOpError(
-          "expected the output shape to be the concatenation of the last "
-          "dimension of the first operand and the last dimension of the "
-          "second ");
-    return success();
-  }
-};
-*/
-
 template <typename ConcreteType>
 class SameOperandsAndResultEncoding
     : public TraitBase<ConcreteType, SameOperandsAndResultEncoding> {

--- a/include/triton/Dialect/Triton/IR/Traits.h
+++ b/include/triton/Dialect/Triton/IR/Traits.h
@@ -64,6 +64,7 @@ public:
 // should have the dimensions of the two operands that are not shared.
 // A dot-like operation can be either 2d or 3d.
 // In the 3d case, the first dimension of operands is the batch dimension.
+/*
 template <class ConcreteType>
 class DotLike : public TraitBase<ConcreteType, DotLike> {
 public:
@@ -104,6 +105,7 @@ public:
     return success();
   }
 };
+*/
 
 template <typename ConcreteType>
 class SameOperandsAndResultEncoding

--- a/include/triton/Dialect/Triton/IR/TritonInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonInterfaces.td
@@ -6,7 +6,6 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 
 def TensorSizeTrait : NativeOpTrait<"TensorSizeTrait">;
 def VerifyTensorLayoutsTrait : NativeOpTrait<"VerifyTensorLayoutsTrait">;
-def DotLike : NativeOpTrait<"DotLike">;
 def SameOperandsEncoding : NativeOpTrait<"SameOperandsEncoding">;
 def SameOperandsAndResultEncoding : NativeOpTrait<"SameOperandsAndResultEncoding">;
 def SameLoadStoreOperandsShape : NativeOpTrait<"SameLoadStoreOperandsShape">;

--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -29,7 +29,19 @@ def TransposeOpInterface : OpInterface<"TransposeOpInterface"> {
 			/*args=*/(ins)>
   ];
 
-	let verify = [{ return ::mlir::triton::impl::verifyTransposeOpInterface($_op); }];
+  let verify = [{ return ::mlir::triton::impl::verifyTransposeOpInterface($_op); }];
+}
+
+def DotOpInterface : OpInterface<"DotOpInterface"> {
+  let description = [{
+	TODO: This interface is implemented by operations that perform a dot product.
+  }];
+
+  let cppNamespace = "::mlir::triton";
+
+  let methods = [];
+
+  let verify = [{ return ::mlir::triton::impl::verifyDotOpInterface($_op); }];
 }
 
 

--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -34,7 +34,7 @@ def TransposeOpInterface : OpInterface<"TransposeOpInterface"> {
 
 def DotOpInterface : OpInterface<"DotOpInterface"> {
   let description = [{
-	TODO: This interface is implemented by operations that perform a dot product.
+	This interface is implemented by operations that perform a dot product.
   }];
 
   let cppNamespace = "::mlir::triton";
@@ -42,7 +42,7 @@ def DotOpInterface : OpInterface<"DotOpInterface"> {
   let methods = [
 	InterfaceMethod<
 			/*desc=*/[{
-			  Verifies the dimensions of DotOp operands.
+			  Verifies the dimensions of the A and B DotOp operands.
 		  }],
 			/*retType=*/"bool",
 			/*methodName=*/"verifyDims",

--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -39,7 +39,15 @@ def DotOpInterface : OpInterface<"DotOpInterface"> {
 
   let cppNamespace = "::mlir::triton";
 
-  let methods = [];
+  let methods = [
+	InterfaceMethod<
+			/*desc=*/[{
+			  Verifies the dimensions of DotOp operands.
+		  }],
+			/*retType=*/"::mlir::LogicalResult",
+			/*methodName=*/"verifyDims",
+			/*args=*/(ins "Operation*":$op)>
+	];
 
   let verify = [{ return ::mlir::triton::impl::verifyDotOpInterface($_op); }];
 }

--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -44,9 +44,9 @@ def DotOpInterface : OpInterface<"DotOpInterface"> {
 			/*desc=*/[{
 			  Verifies the dimensions of DotOp operands.
 		  }],
-			/*retType=*/"::mlir::LogicalResult",
+			/*retType=*/"bool",
 			/*methodName=*/"verifyDims",
-			/*args=*/(ins "Operation*":$op)>
+			/*args=*/(ins)>
 	];
 
   let verify = [{ return ::mlir::triton::impl::verifyDotOpInterface($_op); }];

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -655,6 +655,11 @@ def TT_DotOp : TT_Op<"dot", [Pure,
 
     let results = (outs TT_FpIntTensor:$d);
 
+
+    let extraClassDeclaration = [{
+      LogicalResult verifyDims(Operation*) { return success(); }
+    }];
+
     // attr-dict prints enums as integers.  To get inputPrecision printed as a
     // string, we need to specify it explicitly.
     let assemblyFormat = [{
@@ -695,6 +700,10 @@ def TT_DotScaledOp : TT_Op<"dot_scaled", [Pure,
     );
 
     let results = (outs TT_FloatTensor:$d);
+
+    let extraClassDeclaration = [{
+      LogicalResult verifyDims(Operation*) { return success(); }
+    }];
 
     let assemblyFormat = [{
       $lhs (`scale` $lhs_scale^)? `,` $rhs (`scale` $rhs_scale^)? `,` $c `lhs` `=` $lhs_type `rhs` `=` $rhs_type attr-dict

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -630,7 +630,7 @@ def TT_GetNumProgramsOp : TT_Op<"get_num_programs", [Pure]> {
 //
 def TT_DotOp : TT_Op<"dot", [Pure,
                              DeclareOpInterfaceMethods<InferTypeOpInterface>,
-                             DotOpInterface,
+                             DeclareOpInterfaceMethods<DotOpInterface>,
                              TypesMatchWith<"result's type matches accumulator's type",
                                             "d", "c", "$_self">]> {
     let summary = "dot";
@@ -655,18 +655,6 @@ def TT_DotOp : TT_Op<"dot", [Pure,
 
     let results = (outs TT_FpIntTensor:$d);
 
-
-    let extraClassDeclaration = [{
-      bool verifyDims() {
-        auto aShape = this->getA().getType().getShape();
-        auto bShape = this->getB().getType().getShape();
-
-        if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
-           return false;
-        return true;
-      }
-    }];
-
     // attr-dict prints enums as integers.  To get inputPrecision printed as a
     // string, we need to specify it explicitly.
     let assemblyFormat = [{
@@ -682,7 +670,7 @@ def TT_DotOp : TT_Op<"dot", [Pure,
 //
 def TT_DotScaledOp : TT_Op<"dot_scaled", [Pure,
                              AttrSizedOperandSegments,
-                             DotOpInterface,
+                             DeclareOpInterfaceMethods<DotOpInterface>,
                              TypesMatchWith<"result's type matches accumulator's type",
                                             "d", "c", "$_self">]> {
     let summary = "dot_scaled";
@@ -707,24 +695,6 @@ def TT_DotScaledOp : TT_Op<"dot_scaled", [Pure,
     );
 
     let results = (outs TT_FloatTensor:$d);
-
-    let extraClassDeclaration = [{
-      bool verifyDims() {
-        auto aShape = this->getLhs().getType().getShape();
-        auto bShape = this->getRhs().getType().getShape();
-
-        auto aKdim = aShape[aShape.size() - 1];
-        auto bKdim = bShape[aShape.size() - 2];
-        if (this->getLhsType() == ScaleDotElemType::E2M1)
-            aKdim *= 2;
-        if (this->getRhsType() == ScaleDotElemType::E2M1)
-            bKdim *= 2;
-
-        if (aKdim != bKdim)
-           return false;
-        return true;
-      }
-    }];
 
     let assemblyFormat = [{
       $lhs (`scale` $lhs_scale^)? `,` $rhs (`scale` $rhs_scale^)? `,` $c `lhs` `=` $lhs_type `rhs` `=` $rhs_type attr-dict

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -658,8 +658,9 @@ def TT_DotOp : TT_Op<"dot", [Pure,
 
     let extraClassDeclaration = [{
       bool verifyDims() {
-        auto aShape = cast<RankedTensorType>(this->getOperand(0).getType()).getShape();
-        auto bShape = cast<RankedTensorType>(this->getOperand(1).getType()).getShape();
+        auto aShape = this->getA().getType().getShape();
+        auto bShape = this->getB().getType().getShape();
+
         if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
            return false;
         return true;
@@ -709,9 +710,17 @@ def TT_DotScaledOp : TT_Op<"dot_scaled", [Pure,
 
     let extraClassDeclaration = [{
       bool verifyDims() {
-        auto aShape = cast<RankedTensorType>(this->getOperand(0).getType()).getShape();
-        auto bShape = cast<RankedTensorType>(this->getOperand(1).getType()).getShape();
-        if (aShape[aShape.size() - 1] * 2 != bShape[aShape.size() - 2])
+        auto aShape = this->getLhs().getType().getShape();
+        auto bShape = this->getRhs().getType().getShape();
+
+        auto aKdim = aShape[aShape.size() - 1];
+        auto bKdim = bShape[aShape.size() - 2];
+        if (this->getLhsType() == ScaleDotElemType::E2M1)
+            aKdim *= 2;
+        if (this->getRhsType() == ScaleDotElemType::E2M1)
+            bKdim *= 2;
+
+        if (aKdim != bKdim)
            return false;
         return true;
       }

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -657,7 +657,13 @@ def TT_DotOp : TT_Op<"dot", [Pure,
 
 
     let extraClassDeclaration = [{
-      LogicalResult verifyDims(Operation*) { return success(); }
+      bool verifyDims() {
+        auto aShape = cast<RankedTensorType>(this->getOperand(0).getType()).getShape();
+        auto bShape = cast<RankedTensorType>(this->getOperand(1).getType()).getShape();
+        if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
+           return false;
+        return true;
+      }
     }];
 
     // attr-dict prints enums as integers.  To get inputPrecision printed as a
@@ -702,7 +708,13 @@ def TT_DotScaledOp : TT_Op<"dot_scaled", [Pure,
     let results = (outs TT_FloatTensor:$d);
 
     let extraClassDeclaration = [{
-      LogicalResult verifyDims(Operation*) { return success(); }
+      bool verifyDims() {
+        auto aShape = cast<RankedTensorType>(this->getOperand(0).getType()).getShape();
+        auto bShape = cast<RankedTensorType>(this->getOperand(1).getType()).getShape();
+        if (aShape[aShape.size() - 1] * 2 != bShape[aShape.size() - 2])
+           return false;
+        return true;
+      }
     }];
 
     let assemblyFormat = [{

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -630,7 +630,7 @@ def TT_GetNumProgramsOp : TT_Op<"get_num_programs", [Pure]> {
 //
 def TT_DotOp : TT_Op<"dot", [Pure,
                              DeclareOpInterfaceMethods<InferTypeOpInterface>,
-                             DotLike,
+                             DotOpInterface,
                              TypesMatchWith<"result's type matches accumulator's type",
                                             "d", "c", "$_self">]> {
     let summary = "dot";
@@ -670,7 +670,7 @@ def TT_DotOp : TT_Op<"dot", [Pure,
 //
 def TT_DotScaledOp : TT_Op<"dot_scaled", [Pure,
                              AttrSizedOperandSegments,
-                             DotLike,
+                             DotOpInterface,
                              TypesMatchWith<"result's type matches accumulator's type",
                                             "d", "c", "$_self">]> {
     let summary = "dot_scaled";

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -72,7 +72,7 @@ def TTNG_ClusterWaitOp : TTNG_Op<"cluster_wait", []> {
 //
 def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [DeclareOpInterfaceMethods<InferTypeOpInterface>,
                                                      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                                                     DotOpInterface,
+                                                     DeclareOpInterfaceMethods<DotOpInterface>,
                                                      TypesMatchWith<"result's type matches accumulator's type",
                                                                      "d", "c", "$_self">]> {
     let summary = "warp group dot";
@@ -94,14 +94,6 @@ def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [DeclareOpInterfaceMethods<I
     let assemblyFormat = "$a`,` $b`,` $c (`,` $useC^)? attr-dict `:` type($a) `*` type($b) `->` type($d)";
 
     let extraClassDeclaration = [{
-       bool verifyDims() {
-        auto aShape = this->getA().getType().getShape();
-        auto bShape = this->getB().getType().getShape();
-
-        if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
-           return false;
-        return true;
-      }
       bool needsPartialAccumulator();
     }];
 }
@@ -334,7 +326,7 @@ def TTNG_TMAStoreWaitOp : TTNG_Op<"async_tma_store_wait"> {
   let assemblyFormat = "attr-dict";
 }
 
-def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, DotOpInterface]> {
+def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, DeclareOpInterfaceMethods<DotOpInterface>]> {
     let summary = "block level op mapping to tensorcore gen5 mma";
 
     let description = [{
@@ -353,22 +345,11 @@ def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [DeclareOpInterfaceMethods<MemoryE
                          Optional<TTG_MemDescType>:$barrier,
                          OptionalAttr<UnitAttr>:$two_ctas);
 
-    let extraClassDeclaration = [{
-      bool verifyDims() {
-        auto aShape = this->getA().getType().getShape();
-        auto bShape = this->getB().getType().getShape();
-
-        if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
-           return false;
-        return true;
-      }
-    }];
-
     // TODO: improve printing format.
     let assemblyFormat = "$a`,` $b`,` $d`,` $useD`,` $pred (`,` $barrier^)? attr-dict `:` functional-type(operands, results)";
 }
 
-def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, DotOpInterface]> {
+def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, DeclareOpInterfaceMethods<DotOpInterface>]> {
     let summary = "block level op mapping to tensorcore gen5 mma";
 
     let description = [{
@@ -387,24 +368,6 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [DeclareOpInterfaceMe
                          I1:$useD,
                          I1:$pred,
                          Optional<TTG_MemDescType>:$barrier);
-
-    let extraClassDeclaration = [{
-      bool verifyDims() {
-        auto aShape = this->getA().getType().getShape();
-        auto bShape = this->getB().getType().getShape();
-
-        auto aKdim = aShape[aShape.size() - 1];
-        auto bKdim = bShape[aShape.size() - 2];
-        if (this->getAType() == ScaleDotElemType::E2M1)
-            aKdim *= 2;
-        if (this->getBType() == ScaleDotElemType::E2M1)
-            bKdim *= 2;
-
-        if (aKdim != bKdim)
-           return false;
-        return true;
-      }
-    }];
 
     // TODO: improve printing format.
     let assemblyFormat = "$a `,` $b `,` $d `,` $a_scale `,` $b_scale `,` $useD`,` $pred `lhs` `=` $a_type `rhs` `=` $b_type (`,` $barrier^)? attr-dict `:` functional-type(operands, results)";

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -94,9 +94,10 @@ def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [DeclareOpInterfaceMethods<I
     let assemblyFormat = "$a`,` $b`,` $c (`,` $useC^)? attr-dict `:` type($a) `*` type($b) `->` type($d)";
 
     let extraClassDeclaration = [{
-      bool verifyDims() {
-        auto aShape = cast<RankedTensorType>(this->getOperand(0).getType()).getShape();
-        auto bShape = cast<RankedTensorType>(this->getOperand(1).getType()).getShape();
+       bool verifyDims() {
+        auto aShape = this->getA().getType().getShape();
+        auto bShape = this->getB().getType().getShape();
+
         if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
            return false;
         return true;
@@ -353,9 +354,10 @@ def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [DeclareOpInterfaceMethods<MemoryE
                          OptionalAttr<UnitAttr>:$two_ctas);
 
     let extraClassDeclaration = [{
-       bool verifyDims() {
-        auto aShape = cast<RankedTensorType>(this->getOperand(0).getType()).getShape();
-        auto bShape = cast<RankedTensorType>(this->getOperand(1).getType()).getShape();
+      bool verifyDims() {
+        auto aShape = this->getA().getType().getShape();
+        auto bShape = this->getB().getType().getShape();
+
         if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
            return false;
         return true;
@@ -388,9 +390,17 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [DeclareOpInterfaceMe
 
     let extraClassDeclaration = [{
       bool verifyDims() {
-        auto aShape = cast<RankedTensorType>(this->getOperand(0).getType()).getShape();
-        auto bShape = cast<RankedTensorType>(this->getOperand(1).getType()).getShape();
-        if (aShape[aShape.size() - 1] * 2 != bShape[aShape.size() - 2])
+        auto aShape = this->getA().getType().getShape();
+        auto bShape = this->getB().getType().getShape();
+
+        auto aKdim = aShape[aShape.size() - 1];
+        auto bKdim = bShape[aShape.size() - 2];
+        if (this->getAType() == ScaleDotElemType::E2M1)
+            aKdim *= 2;
+        if (this->getBType() == ScaleDotElemType::E2M1)
+            bKdim *= 2;
+
+        if (aKdim != bKdim)
            return false;
         return true;
       }

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -94,6 +94,7 @@ def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [DeclareOpInterfaceMethods<I
     let assemblyFormat = "$a`,` $b`,` $c (`,` $useC^)? attr-dict `:` type($a) `*` type($b) `->` type($d)";
 
     let extraClassDeclaration = [{
+      LogicalResult verifyDims(Operation*) { return success(); }
       bool needsPartialAccumulator();
     }];
 }
@@ -344,6 +345,11 @@ def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [DeclareOpInterfaceMethods<MemoryE
                          I1:$pred,
                          Optional<TTG_MemDescType>:$barrier,
                          OptionalAttr<UnitAttr>:$two_ctas);
+
+    let extraClassDeclaration = [{
+      LogicalResult verifyDims(Operation*) { return success(); }
+    }];
+
     // TODO: improve printing format.
     let assemblyFormat = "$a`,` $b`,` $d`,` $useD`,` $pred (`,` $barrier^)? attr-dict `:` functional-type(operands, results)";
 }
@@ -367,6 +373,11 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [DeclareOpInterfaceMe
                          I1:$useD,
                          I1:$pred,
                          Optional<TTG_MemDescType>:$barrier);
+
+    let extraClassDeclaration = [{
+      LogicalResult verifyDims(Operation*) { return success(); }
+    }];
+
     // TODO: improve printing format.
     let assemblyFormat = "$a `,` $b `,` $d `,` $a_scale `,` $b_scale `,` $useD`,` $pred `lhs` `=` $a_type `rhs` `=` $b_type (`,` $barrier^)? attr-dict `:` functional-type(operands, results)";
 }

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -27,6 +27,7 @@ include "mlir/Dialect/Arith/IR/ArithBase.td"
 include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "triton/Dialect/Triton/IR/TritonAttrDefs.td"
 include "triton/Dialect/Triton/IR/TritonInterfaces.td"
+include "triton/Dialect/Triton/IR/TritonOpInterfaces.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypes.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypeInterfaces.td"
 include "mlir/IR/OpBase.td"
@@ -71,7 +72,7 @@ def TTNG_ClusterWaitOp : TTNG_Op<"cluster_wait", []> {
 //
 def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [DeclareOpInterfaceMethods<InferTypeOpInterface>,
                                                      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                                                     DotLike,
+                                                     DotOpInterface,
                                                      TypesMatchWith<"result's type matches accumulator's type",
                                                                      "d", "c", "$_self">]> {
     let summary = "warp group dot";
@@ -325,7 +326,7 @@ def TTNG_TMAStoreWaitOp : TTNG_Op<"async_tma_store_wait"> {
   let assemblyFormat = "attr-dict";
 }
 
-def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, DotLike]> {
+def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, DotOpInterface]> {
     let summary = "block level op mapping to tensorcore gen5 mma";
 
     let description = [{
@@ -347,7 +348,7 @@ def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [DeclareOpInterfaceMethods<MemoryE
     let assemblyFormat = "$a`,` $b`,` $d`,` $useD`,` $pred (`,` $barrier^)? attr-dict `:` functional-type(operands, results)";
 }
 
-def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, DotLike]> {
+def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, DotOpInterface]> {
     let summary = "block level op mapping to tensorcore gen5 mma";
 
     let description = [{

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -94,7 +94,13 @@ def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [DeclareOpInterfaceMethods<I
     let assemblyFormat = "$a`,` $b`,` $c (`,` $useC^)? attr-dict `:` type($a) `*` type($b) `->` type($d)";
 
     let extraClassDeclaration = [{
-      LogicalResult verifyDims(Operation*) { return success(); }
+      bool verifyDims() {
+        auto aShape = cast<RankedTensorType>(this->getOperand(0).getType()).getShape();
+        auto bShape = cast<RankedTensorType>(this->getOperand(1).getType()).getShape();
+        if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
+           return false;
+        return true;
+      }
       bool needsPartialAccumulator();
     }];
 }
@@ -347,7 +353,13 @@ def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [DeclareOpInterfaceMethods<MemoryE
                          OptionalAttr<UnitAttr>:$two_ctas);
 
     let extraClassDeclaration = [{
-      LogicalResult verifyDims(Operation*) { return success(); }
+       bool verifyDims() {
+        auto aShape = cast<RankedTensorType>(this->getOperand(0).getType()).getShape();
+        auto bShape = cast<RankedTensorType>(this->getOperand(1).getType()).getShape();
+        if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
+           return false;
+        return true;
+      }
     }];
 
     // TODO: improve printing format.
@@ -375,7 +387,13 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [DeclareOpInterfaceMe
                          Optional<TTG_MemDescType>:$barrier);
 
     let extraClassDeclaration = [{
-      LogicalResult verifyDims(Operation*) { return success(); }
+      bool verifyDims() {
+        auto aShape = cast<RankedTensorType>(this->getOperand(0).getType()).getShape();
+        auto bShape = cast<RankedTensorType>(this->getOperand(1).getType()).getShape();
+        if (aShape[aShape.size() - 1] * 2 != bShape[aShape.size() - 2])
+           return false;
+        return true;
+      }
     }];
 
     // TODO: improve printing format.

--- a/lib/Dialect/Triton/IR/OpInterfaces.cpp
+++ b/lib/Dialect/Triton/IR/OpInterfaces.cpp
@@ -29,7 +29,6 @@ LogicalResult verifyTransposeOpInterface(Operation *op) {
   return success();
 }
 
-// Verify if the op is a dot-like operation.
 // A DotOpInterface operation should have three operands.
 // The first two operands should share a common dimension, and the result
 // should have the dimensions of the two operands that are not shared.
@@ -52,8 +51,7 @@ LogicalResult verifyDotOpInterface(Operation *op) {
   if (aShape.size() != bShape.size() || aShape.size() != cShape.size())
     return dotOp->emitOpError("expected all operands to have the same rank");
 
-  // Check if the first two operands share a common dimension
-
+  // Check for valid A, B input shapes for dot
   if (!dotOp.verifyDims())
     return dotOp->emitOpError(
         "expected the last dimension of the first operand "

--- a/lib/Dialect/Triton/IR/OpInterfaces.cpp
+++ b/lib/Dialect/Triton/IR/OpInterfaces.cpp
@@ -29,6 +29,55 @@ LogicalResult verifyTransposeOpInterface(Operation *op) {
   return success();
 }
 
+// Verify if the op is a dot-like operation.
+// A DotOpInterface operation should have three operands.
+// The first two operands should share a common dimension, and the result
+// should have the dimensions of the two operands that are not shared.
+// A DotOpInterface operation can be either 2d or 3d.
+// In the 3d case, the first dimension of operands is the batch dimension.
+LogicalResult verifyDotOpInterface(Operation *op) {
+  DotOpInterface dotOp = cast<mlir::triton::DotOpInterface>(op);
+
+  if (dotOp->getNumOperands() < 3)
+    return dotOp->emitOpError("expected at least 3 operands");
+  auto aTy = cast<ShapedType>(dotOp->getOperand(0).getType());
+  auto bTy = cast<ShapedType>(dotOp->getOperand(1).getType());
+  auto cTy = cast<ShapedType>(dotOp->getOperand(2).getType());
+  auto aShape = aTy.getShape();
+  auto bShape = bTy.getShape();
+  auto cShape = cTy.getShape();
+  // Check if all 3d or all 2d
+  if (aShape.size() != 2 && aShape.size() != 3)
+    return dotOp->emitOpError("expected operands to be 2d or 3d");
+  if (aShape.size() != bShape.size() || aShape.size() != cShape.size())
+    return dotOp->emitOpError("expected all operands to have the same rank");
+
+  // Check if the first two operands share a common dimension
+
+  /*
+  auto scaledDotOp = dyn_cast<triton::ScaledDotOp>(dotOp);
+  if (!scaledDotOp && aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
+    return dotOp->emitOpError(
+        "expected the last dimension of thae first operand "
+        "to be equal to the second-to-last dimension of "
+        "the second operand");
+    */
+
+  // Check the batch dimension
+  if (aShape.size() == 3 && (aShape[0] != cShape[0] || bShape[0] != cShape[0]))
+    return dotOp->emitOpError("expected the first dimension of the first "
+                              "operand to be equal to the first dimension of "
+                              "the result");
+  // Check the output shape
+  if (cShape[cShape.size() - 2] != aShape[aShape.size() - 2] ||
+      cShape[cShape.size() - 1] != bShape[aShape.size() - 1])
+    return dotOp->emitOpError(
+        "expected the output shape to be the concatenation of the last "
+        "dimension of the first operand and the last dimension of the "
+        "second ");
+  return success();
+}
+
 } // namespace impl
 } // namespace triton
 } // namespace mlir

--- a/lib/Dialect/Triton/IR/OpInterfaces.cpp
+++ b/lib/Dialect/Triton/IR/OpInterfaces.cpp
@@ -29,7 +29,7 @@ LogicalResult verifyTransposeOpInterface(Operation *op) {
   return success();
 }
 
-// A DotOpInterface operation should have three operands.
+// A DotOpInterface operation should have at least three operands.
 // The first two operands should share a common dimension, and the result
 // should have the dimensions of the two operands that are not shared.
 // A DotOpInterface operation can be either 2d or 3d.

--- a/lib/Dialect/Triton/IR/OpInterfaces.cpp
+++ b/lib/Dialect/Triton/IR/OpInterfaces.cpp
@@ -54,9 +54,13 @@ LogicalResult verifyDotOpInterface(Operation *op) {
 
   // Check if the first two operands share a common dimension
 
+  if (!dotOp.verifyDims())
+    return dotOp->emitOpError(
+        "expected the last dimension of thae first operand "
+        "to be equal to the second-to-last dimension of "
+        "the second operand");
   /*
-  auto scaledDotOp = dyn_cast<triton::ScaledDotOp>(dotOp);
-  if (!scaledDotOp && aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
+  if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
     return dotOp->emitOpError(
         "expected the last dimension of thae first operand "
         "to be equal to the second-to-last dimension of "

--- a/lib/Dialect/Triton/IR/OpInterfaces.cpp
+++ b/lib/Dialect/Triton/IR/OpInterfaces.cpp
@@ -56,16 +56,9 @@ LogicalResult verifyDotOpInterface(Operation *op) {
 
   if (!dotOp.verifyDims())
     return dotOp->emitOpError(
-        "expected the last dimension of thae first operand "
+        "expected the last dimension of the first operand "
         "to be equal to the second-to-last dimension of "
         "the second operand");
-  /*
-  if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
-    return dotOp->emitOpError(
-        "expected the last dimension of thae first operand "
-        "to be equal to the second-to-last dimension of "
-        "the second operand");
-    */
 
   // Check the batch dimension
   if (aShape.size() == 3 && (aShape[0] != cShape[0] || bShape[0] != cShape[0]))

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -286,6 +286,32 @@ LogicalResult DotOp::verify() {
                                                      bEncoding);
 }
 
+bool DotOp::verifyDims() {
+  auto aShape = this->getA().getType().getShape();
+  auto bShape = this->getB().getType().getShape();
+
+  if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
+    return false;
+  return true;
+}
+
+//-- DotScaledOp --
+bool DotScaledOp::verifyDims() {
+  auto aShape = this->getLhs().getType().getShape();
+  auto bShape = this->getRhs().getType().getShape();
+
+  auto aKdim = aShape[aShape.size() - 1];
+  auto bKdim = bShape[aShape.size() - 2];
+  if (this->getLhsType() == ScaleDotElemType::E2M1)
+    aKdim *= 2;
+  if (this->getRhsType() == ScaleDotElemType::E2M1)
+    bKdim *= 2;
+
+  if (aKdim != bKdim)
+    return false;
+  return true;
+}
+
 //-- MakeRangeOp --
 OpFoldResult MakeRangeOp::fold(FoldAdaptor adaptor) {
   // make_range(start, start + 1) -> constant(start)

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -290,9 +290,7 @@ bool DotOp::verifyDims() {
   auto aShape = this->getA().getType().getShape();
   auto bShape = this->getB().getType().getShape();
 
-  if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
-    return false;
-  return true;
+  return aShape[aShape.size() - 1] == bShape[aShape.size() - 2];
 }
 
 //-- DotScaledOp --
@@ -307,9 +305,7 @@ bool DotScaledOp::verifyDims() {
   if (this->getRhsType() == ScaleDotElemType::E2M1)
     bKdim *= 2;
 
-  if (aKdim != bKdim)
-    return false;
-  return true;
+  return aKdim == bKdim;
 }
 
 //-- MakeRangeOp --

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -120,9 +120,7 @@ warpsPerTileV3(DotOp dotOp, const ArrayRef<int64_t> shape, int numWarps,
   // to facilitate use cases like flash attention, allowing reductions within
   // the same warp.
   if (llvm::find_if(slices, [](Operation *op) {
-        if (dyn_cast<mlir::triton::DotOpInterface>(op))
-          return true;
-        return false;
+        return dyn_cast<mlir::triton::DotOpInterface>(op) != nullptr;
       }) != slices.end())
     return {(unsigned)numWarps, 1};
 

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -120,7 +120,7 @@ warpsPerTileV3(DotOp dotOp, const ArrayRef<int64_t> shape, int numWarps,
   // to facilitate use cases like flash attention, allowing reductions within
   // the same warp.
   if (llvm::find_if(slices, [](Operation *op) {
-        return dyn_cast<mlir::triton::DotOpInterface>(op) != nullptr;
+        return isa<mlir::triton::DotOpInterface>(op);
       }) != slices.end())
     return {(unsigned)numWarps, 1};
 

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -120,7 +120,9 @@ warpsPerTileV3(DotOp dotOp, const ArrayRef<int64_t> shape, int numWarps,
   // to facilitate use cases like flash attention, allowing reductions within
   // the same warp.
   if (llvm::find_if(slices, [](Operation *op) {
-        return op->hasTrait<OpTrait::DotLike>();
+        if (dyn_cast<mlir::triton::DotOpInterface>(op))
+          return true;
+        return false;
       }) != slices.end())
     return {(unsigned)numWarps, 1};
 

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
@@ -55,7 +55,7 @@ public:
 };
 
 bool dotSupportsAccInitFlag(Operation *op) {
-  assert(dyn_cast<DotOpInterface>(op) &&
+  assert(isa<DotOpInterface>(op) &&
          "Expected an op which implements a DotOpInterface");
 
   if (auto wgDotOp = dyn_cast<triton::nvidia_gpu::WarpGroupDotOp>(op)) {
@@ -70,7 +70,7 @@ bool dotSupportsAccInitFlag(Operation *op) {
 }
 
 std::pair<Value, Operation *> getAccumulatorUseAndDef(Operation *op) {
-  assert(dyn_cast<DotOpInterface>(op) &&
+  assert(isa<DotOpInterface>(op) &&
          "Expected an op which implements a DotOpInterface");
 
   if (auto wgDotOp = dyn_cast<triton::nvidia_gpu::WarpGroupDotOp>(op)) {
@@ -99,7 +99,7 @@ std::pair<Value, Operation *> getAccumulatorUseAndDef(Operation *op) {
 }
 
 void setUseAccFlag(Operation *op, Value useAcc) {
-  assert(dyn_cast<DotOpInterface>(op) &&
+  assert(isa<DotOpInterface>(op) &&
          "Expected an op which implements a DotOpInterface");
 
   if (auto wgDotOp = dyn_cast<triton::nvidia_gpu::WarpGroupDotOp>(op)) {

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
@@ -56,7 +56,7 @@ public:
 
 bool dotSupportsAccInitFlag(Operation *op) {
   if (!dyn_cast<DotOpInterface>(op))
-    assert("Expected a dot-like operation");
+    assert("Expected an op which implements a DotOpInterface");
 
   if (auto wgDotOp = dyn_cast<triton::nvidia_gpu::WarpGroupDotOp>(op)) {
     // Partial accumulation would require a select op to handle the
@@ -71,7 +71,7 @@ bool dotSupportsAccInitFlag(Operation *op) {
 
 std::pair<Value, Operation *> getAccumulatorUseAndDef(Operation *op) {
   if (!dyn_cast<DotOpInterface>(op))
-    assert("Expected a dot-like operation");
+    assert("Expected an op which implements a DotOpInterface");
 
   if (auto wgDotOp = dyn_cast<triton::nvidia_gpu::WarpGroupDotOp>(op)) {
     return std::make_pair(wgDotOp.getC(), wgDotOp);
@@ -94,20 +94,20 @@ std::pair<Value, Operation *> getAccumulatorUseAndDef(Operation *op) {
       return std::make_pair(nullptr, nullptr);
     return std::make_pair(tmemAlloc.getSrc(), tmemLoad);
   }
-  assert(false && "Unexpected dot-like operation");
+  assert(false && "Unexpected op which implements a DotOpInterface");
   return std::make_pair(nullptr, nullptr);
 }
 
 void setUseAccFlag(Operation *op, Value useAcc) {
   if (!dyn_cast<DotOpInterface>(op))
-    assert("Expected a dot-like operation");
+    assert("Expected an op which implements a DotOpInterface");
 
   if (auto wgDotOp = dyn_cast<triton::nvidia_gpu::WarpGroupDotOp>(op)) {
     wgDotOp.getUseCMutable().assign(useAcc);
   } else if (auto tc05MmaOp = dyn_cast<triton::nvidia_gpu::TCGen5MMAOp>(op)) {
     tc05MmaOp.getUseDMutable().assign(useAcc);
   } else {
-    assert(false && "Unexpected dot-like operation");
+    assert(false && "Unexpected op which implements a DotOpInterface");
   }
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
@@ -55,8 +55,8 @@ public:
 };
 
 bool dotSupportsAccInitFlag(Operation *op) {
-  if (!dyn_cast<DotOpInterface>(op))
-    assert("Expected an op which implements a DotOpInterface");
+  assert(dyn_cast<DotOpInterface>(op) &&
+         "Expected an op which implements a DotOpInterface");
 
   if (auto wgDotOp = dyn_cast<triton::nvidia_gpu::WarpGroupDotOp>(op)) {
     // Partial accumulation would require a select op to handle the
@@ -70,8 +70,8 @@ bool dotSupportsAccInitFlag(Operation *op) {
 }
 
 std::pair<Value, Operation *> getAccumulatorUseAndDef(Operation *op) {
-  if (!dyn_cast<DotOpInterface>(op))
-    assert("Expected an op which implements a DotOpInterface");
+  assert(dyn_cast<DotOpInterface>(op) &&
+         "Expected an op which implements a DotOpInterface");
 
   if (auto wgDotOp = dyn_cast<triton::nvidia_gpu::WarpGroupDotOp>(op)) {
     return std::make_pair(wgDotOp.getC(), wgDotOp);
@@ -99,8 +99,8 @@ std::pair<Value, Operation *> getAccumulatorUseAndDef(Operation *op) {
 }
 
 void setUseAccFlag(Operation *op, Value useAcc) {
-  if (!dyn_cast<DotOpInterface>(op))
-    assert("Expected an op which implements a DotOpInterface");
+  assert(dyn_cast<DotOpInterface>(op) &&
+         "Expected an op which implements a DotOpInterface");
 
   if (auto wgDotOp = dyn_cast<triton::nvidia_gpu::WarpGroupDotOp>(op)) {
     wgDotOp.getUseCMutable().assign(useAcc);
@@ -165,10 +165,8 @@ public:
     ModuleOp m = getOperation();
     SmallVector<Operation *> mmaOps;
     m.walk([&](Operation *op) {
-      auto dotOp = dyn_cast<DotOpInterface>(op);
-      if (dotOp && dotSupportsAccInitFlag(dotOp)) {
-        mmaOps.push_back(dotOp);
-      }
+      if (isa<DotOpInterface>(op) && dotSupportsAccInitFlag(op))
+        mmaOps.push_back(op);
     });
 
     // for each mma op, find where the accumulator is initialized with zero

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -151,9 +151,9 @@ loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
           distance++;
         }
         for (Value operand : op->getOperands()) {
-          if (auto dotOp = dyn_cast<mlir::triton::DotOpInterface>(op)) {
+          if (isa<mlir::triton::DotOpInterface>(op)) {
             // Heuristic: only pipeline A and B operands of the dot op.
-            if (operand == dotOp->getOperand(2))
+            if (operand == op->getOperand(2))
               continue;
           }
           Value v = operand;
@@ -166,7 +166,7 @@ loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
 
   bool seenDot = false;
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    if (!dyn_cast<mlir::triton::DotOpInterface>(op))
+    if (!isa<mlir::triton::DotOpInterface>(op))
       continue;
     seenDot = true;
     seen.clear();

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -166,11 +166,11 @@ loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
 
   bool seenDot = false;
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    if (dyn_cast<mlir::triton::DotOpInterface>(op)) {
-      seenDot = true;
-      seen.clear();
-      dfs(&op, &op, 0);
-    }
+    if (!dyn_cast<mlir::triton::DotOpInterface>(op))
+      continue;
+    seenDot = true;
+    seen.clear();
+    dfs(&op, &op, 0);
   }
 
   // If the loop has numStages attribute, also consider pipelining other loads

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -151,9 +151,9 @@ loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
           distance++;
         }
         for (Value operand : op->getOperands()) {
-          if (op->hasTrait<OpTrait::DotLike>()) {
+          if (auto dotOp = dyn_cast<mlir::triton::DotOpInterface>(op)) {
             // Heuristic: only pipeline A and B operands of the dot op.
-            if (operand == op->getOperand(2))
+            if (operand == dotOp->getOperand(2))
               continue;
           }
           Value v = operand;
@@ -166,11 +166,11 @@ loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
 
   bool seenDot = false;
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    if (!op.hasTrait<OpTrait::DotLike>())
-      continue;
-    seenDot = true;
-    seen.clear();
-    dfs(&op, &op, 0);
+    if (dyn_cast<mlir::triton::DotOpInterface>(op)) {
+      seenDot = true;
+      seen.clear();
+      dfs(&op, &op, 0);
+    }
   }
 
   // If the loop has numStages attribute, also consider pipelining other loads

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -89,9 +89,7 @@ bool WarpGroupDotOp::verifyDims() {
   auto aShape = this->getA().getType().getShape();
   auto bShape = this->getB().getType().getShape();
 
-  if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
-    return false;
-  return true;
+  return aShape[aShape.size() - 1] == bShape[aShape.size() - 2];
 }
 
 // -- WarpGroupDotWaitOp --
@@ -272,9 +270,7 @@ bool TCGen5MMAOp::verifyDims() {
   auto aShape = this->getA().getType().getShape();
   auto bShape = this->getB().getType().getShape();
 
-  if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
-    return false;
-  return true;
+  return aShape[aShape.size() - 1] == bShape[aShape.size() - 2];
 }
 
 // -- TMEMStoreOp --
@@ -318,9 +314,7 @@ bool TCGen5MMAScaledOp::verifyDims() {
   if (this->getBType() == ScaleDotElemType::E2M1)
     bKdim *= 2;
 
-  if (aKdim != bKdim)
-    return false;
-  return true;
+  return aKdim == bKdim;
 }
 
 // -- TMEMLoadOp --

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -85,6 +85,15 @@ bool WarpGroupDotOp::needsPartialAccumulator() {
   return isFP8 && accFP32 && maxNumImpreciseAcc <= aTensorTy.getShape()[1];
 }
 
+bool WarpGroupDotOp::verifyDims() {
+  auto aShape = this->getA().getType().getShape();
+  auto bShape = this->getB().getType().getShape();
+
+  if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
+    return false;
+  return true;
+}
+
 // -- WarpGroupDotWaitOp --
 LogicalResult WarpGroupDotWaitOp::inferReturnTypes(
     ::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location,
@@ -259,6 +268,15 @@ void TCGen5MMAOp::getEffects(
                        mlir::triton::gpu::SharedMemory::get());
 }
 
+bool TCGen5MMAOp::verifyDims() {
+  auto aShape = this->getA().getType().getShape();
+  auto bShape = this->getB().getType().getShape();
+
+  if (aShape[aShape.size() - 1] != bShape[aShape.size() - 2])
+    return false;
+  return true;
+}
+
 // -- TMEMStoreOp --
 LogicalResult TMEMStoreOp::verify() {
   if (!isa<triton::nvidia_gpu::TensorMemorySpaceAttr>(
@@ -287,6 +305,22 @@ void TCGen5MMAScaledOp::getEffects(
   }
   effects.emplace_back(MemoryEffects::Read::get(), &getBMutable(),
                        mlir::triton::gpu::SharedMemory::get());
+}
+
+bool TCGen5MMAScaledOp::verifyDims() {
+  auto aShape = this->getA().getType().getShape();
+  auto bShape = this->getB().getType().getShape();
+
+  auto aKdim = aShape[aShape.size() - 1];
+  auto bKdim = bShape[aShape.size() - 2];
+  if (this->getAType() == ScaleDotElemType::E2M1)
+    aKdim *= 2;
+  if (this->getBType() == ScaleDotElemType::E2M1)
+    bKdim *= 2;
+
+  if (aKdim != bKdim)
+    return false;
+  return true;
 }
 
 // -- TMEMLoadOp --

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -77,7 +77,7 @@ private:
     static DenseSet<std::pair<Operation *, unsigned>> trace;
     auto op = operand.getDefiningOp();
     // avoid redundant insertion
-    if (op && op->hasTrait<OpTrait::DotLike>())
+    if (op && isa<mlir::triton::DotOpInterface>(op))
       return false;
     // reach convertlayout
     if (op && isa<ttg::LocalAllocOp>(op) &&

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -55,9 +55,10 @@ warpsPerTile(Operation *dotOp, ArrayRef<int64_t> shape, int numWarps,
   bwdOpt.omitBlockArguments = true;
   bwdOpt.filter = filter;
   auto slices = getSlice(dotOp, bwdOpt, fwdOpt);
-  for (Operation *op : slices)
-    if (op->hasTrait<OpTrait::DotLike>() && (op != dotOp))
+  for (Operation *op : slices) {
+    if (dyn_cast<mlir::triton::DotOpInterface>(op) && (op != dotOp))
       return {(unsigned)numWarps, 1};
+  }
 
   SmallVector<int64_t, 2> tensorShape = {shape[0], shape[1]};
   SmallVector<unsigned, 3> ret = {1, 1};

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -56,7 +56,7 @@ warpsPerTile(Operation *dotOp, ArrayRef<int64_t> shape, int numWarps,
   bwdOpt.filter = filter;
   auto slices = getSlice(dotOp, bwdOpt, fwdOpt);
   for (Operation *op : slices) {
-    if (dyn_cast<mlir::triton::DotOpInterface>(op) && (op != dotOp))
+    if (isa<mlir::triton::DotOpInterface>(op) && (op != dotOp))
       return {(unsigned)numWarps, 1};
   }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -404,10 +404,10 @@ void StreamPipeliner::computeLoadOpsToIndirectionLevelAndUse() {
       };
 
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    if (!op.hasTrait<OpTrait::DotLike>())
-      continue;
-    seen.clear();
-    dfs(&op, 0, &op);
+    if (dyn_cast<mlir::triton::DotOpInterface>(op)) {
+      seen.clear();
+      dfs(&op, 0, &op);
+    }
   }
 
   // If the loop has numStages attribute, also consider pipelining other loads
@@ -454,7 +454,7 @@ void StreamPipeliner::assignMemoryLayouts() {
       continue;
     }
 
-    if (use->hasTrait<OpTrait::DotLike>()) {
+    if (dyn_cast<mlir::triton::DotOpInterface>(use)) {
       // Only use shared memory when feeding into a dot op.
       loadInfo.usedByDot = true;
       loadInfo.sharedEncoding =

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -404,10 +404,10 @@ void StreamPipeliner::computeLoadOpsToIndirectionLevelAndUse() {
       };
 
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    if (dyn_cast<mlir::triton::DotOpInterface>(op)) {
-      seen.clear();
-      dfs(&op, 0, &op);
-    }
+    if (!dyn_cast<mlir::triton::DotOpInterface>(op))
+      continue;
+    seen.clear();
+    dfs(&op, 0, &op);
   }
 
   // If the loop has numStages attribute, also consider pipelining other loads

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -404,7 +404,7 @@ void StreamPipeliner::computeLoadOpsToIndirectionLevelAndUse() {
       };
 
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    if (!dyn_cast<mlir::triton::DotOpInterface>(op))
+    if (!isa<mlir::triton::DotOpInterface>(op))
       continue;
     seen.clear();
     dfs(&op, 0, &op);
@@ -454,7 +454,7 @@ void StreamPipeliner::assignMemoryLayouts() {
       continue;
     }
 
-    if (dyn_cast<mlir::triton::DotOpInterface>(use)) {
+    if (isa<mlir::triton::DotOpInterface>(use)) {
       // Only use shared memory when feeding into a dot op.
       loadInfo.usedByDot = true;
       loadInfo.sharedEncoding =


### PR DESCRIPTION
# Overview

The Triton MLIR dialect presently has a `DotLike` trait which DotOps have.

The problem with this trait is the way it is currently implemented prevents `scaled_dot` from being verified properly (dimensions are not properly checked at the moment: "TODO: enable back with an interface to support scaled dot.").

This PR refactors the "DotLike" trait into an interface which implements a "verifyDims" function that checks if the dims for the A and B operands are compatible (e.g., something like MxK1 and K2xN; k1==k2; in the simple case).

# How

The initial implementation of DotOpInterface is similar to the prior `DotLike` trait with the exception that it includes the `verifyDims` function which all DotOps must implement---this function just checks whether the dimensions of the A, B inputs match.

In the future this interface can be extended to include more functionality.

# Testing

I think since this enables the verifier for `scaled_dot`, that the existing scaled dot tests should cover any changes made in the PR---but if this is wrong I will add additional tests.

================================================================
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `I think this should be covered by existing tests`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
