### PR TITLE
[AMD] Moved membar analysis to its dedicated pass

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -58,6 +58,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerOptimizeAMDLDSUsage();
 
   // TritonAMDGPUTransforms passes
+  mlir::registerTritonAMDGPUMembarAnalysis();
   mlir::registerTritonAMDGPUAccelerateMatmul();
   mlir::registerTritonAMDGPUOptimizeEpilogue();
   mlir::registerTritonAMDGPUReorderInstructions();

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -258,6 +258,7 @@ class HIPBackend(BaseBackend):
         passes.convert.add_index_to_llvmir(pm)
 
         passes.ttgpuir.add_allocate_shared_memory(pm)
+        amd.passes.ttgpuir.add_membar_analysis(pm)
         ## __HIP_FTZ is used to control the denorm flushing behavior of exp2 op as follows:
         ## 1. If __HIP_FTZ = 1, exp2 flushes denorms in input and output regardless
         ##    of the value of kernel arg `allow_flush_denorm`.

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -31,6 +31,8 @@ std::unique_ptr<Pass> createTritonAMDGPUConvertToBufferOpsPass(
 
 std::unique_ptr<Pass> createTritonAMDGPUBlockPingpongPass();
 
+std::unique_ptr<Pass> createTritonAMDGPUMembarAnalysisPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "TritonAMDGPUTransforms/Passes.h.inc"

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -145,4 +145,13 @@ def TritonAMDGPUBlockPingpong: Pass<"tritonamdgpu-block-pingpong", "mlir::Module
   let dependentDialects = ["mlir::ROCDL::ROCDLDialect, mlir::triton::amdgpu::TritonAMDGPUDialect"];
 }
 
+def TritonAMDGPUMembarAnalysis : Pass<"triton-amdgpu-membar-analysis", "mlir::ModuleOp"> {
+    let summary = "Perform the memory-barrier analysis";
+    let description = [{
+      This pass allocates shared memory and set barriers.
+     }];
+
+    let constructor = "mlir::createTritonAMDGPUMembarAnalysisPass()";
+}
+
 #endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -2,7 +2,6 @@
 #include "Utility.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "triton/Analysis/Allocation.h"
 #include "triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -1549,8 +1548,8 @@ private:
 namespace mlir::triton::AMD {
 void populateElementwiseOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns, bool ftz,
-    ModuleAxisInfoAnalysis &axisInfoAnalysis, ModuleAllocation &allocation,
-    const TargetInfo &targetInfo, PatternBenefit benefit) {
+    ModuleAxisInfoAnalysis &axisInfoAnalysis, const TargetInfo &targetInfo,
+    PatternBenefit benefit) {
 
   // fmin (return NaN if either op is NaN)
   patterns.add<ElementwiseOpConversion<arith::MinimumFOp, LLVM::MinimumOp>>(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -22,8 +22,8 @@ void populateDotOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                  PatternBenefit benefit);
 void populateElementwiseOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns, bool ftz,
-    ModuleAxisInfoAnalysis &axisInfoAnalysis, ModuleAllocation &allocation,
-    const TargetInfo &targetInfo, PatternBenefit benefit);
+    ModuleAxisInfoAnalysis &axisInfoAnalysis, const TargetInfo &targetInfo,
+    PatternBenefit benefit);
 void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                        const TargetInfo &targetInfo,
                                        RewritePatternSet &patterns,

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_triton_library(TritonAMDGPUTransforms
   ReorderInstructions.cpp
   StreamPipeline.cpp
   MfmaGroup.cpp
+  MembarAnalysis.cpp
 
   DEPENDS
   TritonAMDGPUIR

--- a/third_party/amd/lib/TritonAMDGPUTransforms/MembarAnalysis.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/MembarAnalysis.cpp
@@ -1,0 +1,37 @@
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
+// #include "mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h"
+// #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/Pass/Pass.h"
+// #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+// #include "third_party/amd/include/TritonAMDGPUTransforms/MfmaGroup.h"
+// #include "third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h"
+// #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+// #include "triton/Dialect/Triton/IR/Dialect.h"
+// #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+// #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Analysis/Allocation.h"
+#include "triton/Analysis/Membar.h"
+
+#define GEN_PASS_CLASSES
+#include "TritonAMDGPUTransforms/Passes.h"
+
+namespace {
+struct TritonAMDGPUMembarAnalysis
+    : public mlir::TritonAMDGPUMembarAnalysisBase<TritonAMDGPUMembarAnalysis> {
+
+  void runOnOperation() override {
+    mlir::ModuleOp mod = getOperation();
+
+    // Allocate shared memory and set barrier
+    mlir::ModuleAllocation allocation(mod);
+    mlir::ModuleMembarAnalysis membarPass(&allocation);
+    membarPass.run();
+  }
+};
+} // namespace
+
+namespace mlir {
+std::unique_ptr<Pass> createTritonAMDGPUMembarAnalysisPass() {
+  return std::make_unique<TritonAMDGPUMembarAnalysis>();
+}
+} // namespace mlir

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -37,6 +37,9 @@ const char *const amdTargetTriple = "amdgcn-amd-amdhsa";
 
 void init_triton_amd_passes_ttgpuir(py::module &&m) {
   using namespace mlir::triton;
+  m.def("add_membar_analysis", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::createTritonAMDGPUMembarAnalysisPass());
+  });
   m.def("add_to_llvmir",
         [](mlir::PassManager &pm, const std::string &arch, bool ftz) {
           pm.addPass(createConvertTritonAMDGPUToLLVMPass(arch, ftz));


### PR DESCRIPTION
`TritonGPUToLLVM` is a huge pass containing many rewrite patterns. The goal of this pass is supposed to be only lowering TTGIR to LLVM IR. However, it performs the membar analysis as its first step. It seems that some rewrite patterns used to use `allocations` returned by the membar analysis. This probably explained why the analysis was a part of the `TritonGPUToLLVM` pass. However, it turns out that none of the rewrite patterns in `TritonGPUToLLVM`  uses `allocations`. Therefore, I extracted the membar analysis own pass which runs after `scf_to_cf` and `allocate_shared_memory` passes. Note, `allocate_shared_memory` used to be inside the `TritonGPUToLLVM` pass as well.

Note, the membar analysis is generic and its shared between all backends (AMD and Nvidia). The changes in this PR allows one to add some transformations or analysis-passes at the TTGIR level after the membar analysis - i.e., before lowering TTGIR to llvm. 