### PR TITLE
[TEST] Use a fresh triton cache dir for warning tests

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -7,7 +7,7 @@ import triton
 import triton.language as tl
 from triton.compiler.errors import CompilationError, CompileTimeAssertionFailure
 import traceback
-from triton._internal_testing import is_interpreter, is_cuda, is_hip, is_hip_mi300
+from triton._internal_testing import is_cuda, is_hip, is_hip_mi300
 
 
 def format_exception(type, value, tb):
@@ -362,7 +362,7 @@ def test_where_warning(fresh_triton_cache):
 
 
 @pytest.mark.parametrize("dtype", [tl.float8e5, tl.float8e5b16, tl.float8e4nv, tl.float8e4b8, tl.float8e4b15])
-def test_fp8_support(dtype):
+def test_fp8_support(fresh_triton_cache, dtype):
     warning_dtypes = []
     supported_dtypes = [tl.float8e5]
     if is_cuda():
@@ -375,8 +375,6 @@ def test_fp8_support(dtype):
     elif is_hip():
         if is_hip_mi300():
             supported_dtypes += [tl.float8e4nv, tl.float8e4b8, tl.float8e5b16]
-    elif is_interpreter():
-        supported_dtypes = [tl.float8e5, tl.float8e5b16, tl.float8e4nv, tl.float8e4b8, tl.float8e4b15]
 
     @triton.jit
     def dtype_kernel(dtype: tl.constexpr):


### PR DESCRIPTION
If we expect a warning, we need to use a fresh cache dir; otherwise, no warning will be thrown when the cache is hit.
Also take out interpreter related code from this file.