### PR TITLE
[Blackwell][Clean up] Remove use of SharedMemoryObject on TMEM

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -11,9 +11,7 @@ using namespace mlir::triton::gpu;
 using namespace mlir::triton::NVIDIA;
 
 using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
-using ::mlir::triton::gpu::getShapePerCTA;
-using ::mlir::triton::gpu::getShapePerCTATile;
-using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
+using ::mlir::LLVM::NVIDIA::getTensorMemoryBase;
 using ::mlir::triton::gpu::NVMMASharedEncodingAttr;
 
 mlir::triton::NVIDIA::DotOpMmaV5TmemLoader::DotOpMmaV5TmemLoader(
@@ -360,11 +358,7 @@ void convertDot(const LLVMTypeConverter *typeConverter,
           loc, loadedB, typeConverter->convertType(bTensorTy.getElementType()),
           rewriter)
           .getBase();
-  Value baseD =
-      getSharedMemoryObjectFromStruct(
-          loc, loadedD, typeConverter->convertType(dTensorTy.getElementType()),
-          rewriter)
-          .getBase();
+  Value baseD = getTensorMemoryBase(loc, loadedD, rewriter);
 
   SmallVector<int64_t> dstPerCTA = triton::gpu::getShapePerCTA(dTensorTy);
   unsigned int M = dstPerCTA[0];
@@ -505,18 +499,10 @@ struct TCGen5MMAScaledOpConversion
             loc, adaptor.getB(),
             typeConverter->convertType(bTensorTy.getElementType()), rewriter)
             .getBase();
-    Value baseD =
-        getSharedMemoryObjectFromStruct(
-            loc, adaptor.getD(),
-            typeConverter->convertType(dTensorTy.getElementType()), rewriter)
-            .getBase();
+    Value baseD = getTensorMemoryBase(loc, adaptor.getD(), rewriter);
     baseD = tb.ptrtoint(i32_ty, baseD);
-    Value baseScaleA = getSharedMemoryObjectFromStruct(loc, adaptor.getAScale(),
-                                                       i8_ty, rewriter)
-                           .getBase();
-    Value baseScaleB = getSharedMemoryObjectFromStruct(loc, adaptor.getBScale(),
-                                                       i8_ty, rewriter)
-                           .getBase();
+    Value baseScaleA = getTensorMemoryBase(loc, adaptor.getAScale(), rewriter);
+    Value baseScaleB = getTensorMemoryBase(loc, adaptor.getBScale(), rewriter);
     baseScaleA = tb.ptrtoint(i32_ty, baseScaleA);
     baseScaleB = tb.ptrtoint(i32_ty, baseScaleB);
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -132,6 +132,14 @@ Value createElectPredicateWarp0(Location loc, RewriterBase &rewriter) {
   return b.and_(warp0, createElectPredicate(loc, rewriter));
 }
 
+Value getTensorMemoryBase(Location loc, Value llvmStruct,
+                          RewriterBase &rewriter) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  ArrayRef<Type> types =
+      cast<LLVM::LLVMStructType>(llvmStruct.getType()).getBody();
+  return b.extract_val(types[0], llvmStruct, 0);
+}
+
 } // namespace NVIDIA
 } // namespace LLVM
 } // namespace mlir

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
@@ -43,6 +43,11 @@ Value createElectPredicateWarp0(Location loc, RewriterBase &rewriter);
 // Create bar.warp.sync
 void createSyncWarp(Location loc, OpBuilder &builder);
 
+// Similar to getSharedMemoryObjectFromStruct, but only for getting the base
+// address of TMEM
+Value getTensorMemoryBase(Location loc, Value llvmStruct,
+                          RewriterBase &rewriter);
+
 } // namespace NVIDIA
 } // namespace LLVM
 


### PR DESCRIPTION
Using `getSharedMemoryObjectFromStruct` etc on TMEM is very confusing for new readers, so I'm introducing simpler alternatives for TMEM. In practice, we only need the base address of TMEM.

@ThomasRaoux 