### PR TITLE
[ANALYSIS] Fixing overflow in AxisInfo.cpp.

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -935,7 +935,7 @@ private:
       // Treat [2^n,2^n+1,...]'s divisibility as 1 instead of 2^n
       lhsDivisibility = 1;
     }
-    return std::max<int64_t>(1, lhsDivisibility / (1 << shift));
+    return std::max<int64_t>(1, lhsDivisibility / (int64_t(1) << shift));
   }
 
   int64_t getConstancy(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,


### PR DESCRIPTION
 UBSan detected that the shift is happening on an int32 variable, but the shift amount could be larger than what int32 supports.

I believe the change is trivial to require a test, but please advice accordingly if you think there is an appropriate way to capture this.