### PR TITLE
[TensorDescriptor] Support ndim > 2 loads and stores

### DIFF
--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1236,15 +1236,15 @@ LogicalResult ExperimentalDescriptorStoreOp::verify() {
 LogicalResult ExperimentalTensormapCreateOp::verify() {
   auto rank = getBoxDim().size();
   if (getGlobalDim().size() != rank) {
-    return emitError("Rank mismatch for global dim. Got")
+    return emitError("Rank mismatch for global dim. Got ")
            << getGlobalDim().size() << " but expected " << rank;
   }
   if (getGlobalStride().size() + 1 != rank) {
-    return emitError("Rank mismatch for global stride. Got")
+    return emitError("Rank mismatch for global stride. Got ")
            << getGlobalStride().size() << " but expected " << rank - 1;
   }
   if (getElementStride().size() != rank) {
-    return emitError("Rank mismatch for element stride. Got")
+    return emitError("Rank mismatch for element stride. Got ")
            << getElementStride().size() << " but expected " << rank;
   }
   return success();

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -196,9 +196,10 @@ LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
   auto outDimNames = standardOutDimNames(ctx, rank);
 
   // Construct bases for a the layout's 2-dimensional tile.
-  assert(shape.size() >= 2);
-  int colDim = shared.getTransposed() ? 0 : 1;
-  int rowDim = shared.getTransposed() ? 1 : 0;
+  assert(rank >= 2);
+  int batchDims = rank - 2;
+  int colDim = batchDims + (shared.getTransposed() ? 0 : 1);
+  int rowDim = batchDims + (shared.getTransposed() ? 1 : 0);
 
   int tileRows = 8;
   int tileCols = 8 * tileWidthBytes / elemBitWidth;
@@ -229,8 +230,7 @@ LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
       LinearLayout({{S("offset"), bases2D}}, {rowDimName, colDimName});
 
   // Add the remaining dimensions.
-  for (int i = 2; i < rank; i++) {
-    int dim = shared.getTransposed() ? i : 1 - i;
+  for (int dim = batchDims - 1; dim >= 0; --dim) {
     tileLayout *=
         LinearLayout::identity1D(shape[dim], S("offset"), outDimNames[dim]);
   }

--- a/python/test/unit/cuda/test_experimental_tma.py
+++ b/python/test/unit/cuda/test_experimental_tma.py
@@ -783,11 +783,11 @@ def test_experimental_make_tensor_descriptor_loop_carried():
 
 
 @triton.jit
-def batched_gemm_kernel(a_ptr, b_ptr, c_ptr,  #
-                        B, M, N, K,  #
-                        dtype: tl.constexpr,  #
-                        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,  #
-                        NUM_SMS: tl.constexpr):
+def batched_gemm_2d_tma_kernel(a_ptr, b_ptr, c_ptr,  #
+                               B, M, N, K,  #
+                               dtype: tl.constexpr,  #
+                               BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,  #
+                               NUM_SMS: tl.constexpr):
     start_pid = tl.program_id(axis=0)
     num_tiles_m = tl.cdiv(M, BLOCK_M)
     num_tiles_n = tl.cdiv(N, BLOCK_N)
@@ -850,7 +850,7 @@ def batched_gemm_kernel(a_ptr, b_ptr, c_ptr,  #
 
 @requires_tma
 @pytest.mark.interpreter
-def test_tensor_descriptor_batched_gemm():
+def test_tensor_descriptor_batched_gemm_2d_tma():
     device = "cuda"
     BLOCK_M, BLOCK_N, BLOCK_K = 128, 256, 64
     if is_interpreter():
@@ -877,7 +877,7 @@ def test_tensor_descriptor_batched_gemm():
 
     triton.set_allocator(alloc_fn)
 
-    batched_gemm_kernel[grid](
+    batched_gemm_2d_tma_kernel[grid](
         a, b, c,  #
         B, M, N, K,  #
         tl.float16,  #
@@ -885,6 +885,109 @@ def test_tensor_descriptor_batched_gemm():
         NUM_SMS,  #
         num_stages=num_stages, num_warps=8)
     torch.cuda.synchronize()
+
+    torch.testing.assert_close(c, expect, rtol=1e-3, atol=1e-3)
+
+
+@triton.jit
+def batched_gemm_3d_tma_kernel(a_ptr, b_ptr, c_ptr,  #
+                               B, M, N, K,  #
+                               dtype: tl.constexpr,  #
+                               BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,  #
+                               NUM_SMS: tl.constexpr):
+    start_pid = tl.program_id(axis=0)
+    num_tiles_m = tl.cdiv(M, BLOCK_M)
+    num_tiles_n = tl.cdiv(N, BLOCK_N)
+    k_tiles = tl.cdiv(K, BLOCK_K)
+    num_tiles_per_batch = num_tiles_m * num_tiles_n
+    num_tiles = B * num_tiles_per_batch
+
+    tiles_per_SM = num_tiles // NUM_SMS
+    if start_pid < num_tiles % NUM_SMS:
+        tiles_per_SM += 1
+
+    tile_id = start_pid - NUM_SMS
+    ki = -1
+
+    tile_m = 0
+    tile_n = 0
+    tile_b = 0
+
+    offs_m = 0
+    offs_n = 0
+    offs_b = 0
+
+    a_desc = tl._experimental_make_tensor_descriptor(a_ptr, [B, M, K], [K * M, K, 1], [1, BLOCK_M, BLOCK_K])
+    b_desc = tl._experimental_make_tensor_descriptor(b_ptr, [B, N, K], [N * K, K, 1], [1, BLOCK_N, BLOCK_K])
+    c_desc = tl._experimental_make_tensor_descriptor(c_ptr, [B, M, N], [M * N, N, 1], [1, BLOCK_M, BLOCK_N])
+
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for _ in range(k_tiles * tiles_per_SM):
+        ki = tl.where(ki == k_tiles - 1, 0, ki + 1)
+        if ki == 0:
+            tile_id += NUM_SMS
+            tile_b = tile_id // num_tiles_per_batch
+            tile_m = (tile_id // num_tiles_n) % num_tiles_m
+            tile_n = tile_id % num_tiles_n
+
+            offs_b = tile_b
+            offs_m = tile_m * BLOCK_M
+            offs_n = tile_n * BLOCK_N
+
+        offs_k = ki * BLOCK_K
+
+        a = a_desc.load([offs_b, offs_m, offs_k]).reshape([BLOCK_M, BLOCK_K])
+        b = b_desc.load([offs_b, offs_n, offs_k]).reshape([BLOCK_N, BLOCK_K])
+        accumulator = tl.dot(a, b.T, accumulator)
+
+        if ki == k_tiles - 1:
+            c = accumulator.to(dtype)
+
+            c_desc.store([offs_b, offs_m, offs_n], c.reshape((1, BLOCK_M, BLOCK_N)))
+            accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+
+@requires_tma
+@pytest.mark.interpreter
+def test_tensor_descriptor_batched_gemm_3d_tma():
+    device = "cuda"
+    BLOCK_M, BLOCK_N, BLOCK_K = 128, 256, 64
+    if is_interpreter():
+        B, M, N, K = 2, BLOCK_M, BLOCK_N, BLOCK_K
+    else:
+        B, M, N, K = 2, 1024, 1024, 128
+    NUM_SMS = 96
+    num_stages = 3
+
+    grid = (min(NUM_SMS, B * triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)), )
+
+    a = torch.randn((B, M, K), device=device, dtype=torch.float16)
+    b = torch.randn((B, N, K), device=device, dtype=torch.float16)
+    c = torch.empty((B, M, N), device=device, dtype=torch.float16)
+
+    expect = torch.bmm(a, b.mT)
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        # TODO: should only need num_stages * 3 descriptors per SM
+        assert size == 128 * 3 * grid[0]
+        assert align == 128
+        assert stream == 0
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+
+    h = batched_gemm_3d_tma_kernel[grid](
+        a, b, c,  #
+        B, M, N, K,  #
+        tl.float16,  #
+        BLOCK_M, BLOCK_N, BLOCK_K,  #
+        NUM_SMS,  #
+        num_stages=num_stages, num_warps=8)
+    torch.cuda.synchronize()
+
+    if not is_interpreter():
+        assert "warp_group_dot" in h.asm["ttgir"]
 
     torch.testing.assert_close(c, expect, rtol=1e-3, atol=1e-3)
 

--- a/python/test/unit/cuda/test_experimental_tma.py
+++ b/python/test/unit/cuda/test_experimental_tma.py
@@ -987,7 +987,9 @@ def test_tensor_descriptor_batched_gemm_3d_tma():
     torch.cuda.synchronize()
 
     if not is_interpreter():
-        assert "warp_group_dot" in h.asm["ttgir"]
+        capability = torch.cuda.get_device_capability(0)[0]
+        dot_op = {9: "warp_group_dot", 10: "tc_gen5_mma"}
+        assert dot_op[capability] in h.asm["ttgir"]
 
     torch.testing.assert_close(c, expect, rtol=1e-3, atol=1e-3)
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1265,7 +1265,7 @@ class _experimental_tensor_descriptor_base(_value):
         return f"tensor_descriptor<{self.type}>"
 
     @builtin
-    def load(self, offsets: List[constexpr | tensor], _builder=None) -> tensor:
+    def load(self, offsets: Sequence[constexpr | tensor], _builder=None) -> tensor:
         """Load a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be filled with zeros.
@@ -1275,7 +1275,7 @@ class _experimental_tensor_descriptor_base(_value):
         return semantic.descriptor_load(self, offsets, "", "", _builder)
 
     @builtin
-    def store(self, offsets: List[constexpr | tensor], value: tensor, _builder=None) -> tensor:
+    def store(self, offsets: Sequence[constexpr | tensor], value: tensor, _builder=None) -> tensor:
         """Store a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be ignored.
@@ -1982,7 +1982,7 @@ def _experimental_make_tensor_descriptor(
     On NVIDIA GPUs with TMA support, this will result in a TMA descriptor object
     and loads and stores from the descriptor will be backed by the TMA hardware.
 
-    Currently only 2d tensors are supported.
+    Currently only 2-5 dimensional tensors are supported.
 
     Example
     *******

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1162,6 +1162,8 @@ def descriptor_load(desc: tl._experimental_tensor_desciptor_base, offsets, cache
                     builder: ir.builder) -> tl.tensor:
     assert isinstance(desc, tl._experimental_tensor_descriptor_base)
     validate_descriptor_block(desc.block_shape, desc.type.element_ty)
+    ndim = len(desc.block_shape)
+    assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
 
     offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
     x = builder.create_descriptor_load(desc.handle, offsets, _str_to_load_cache_modifier(cache_modifier),
@@ -1173,6 +1175,9 @@ def descriptor_store(desc: tl._experimental_tensor_descriptor_base, value: tl.te
                      builder: ir.builder) -> tl.tensor:
     assert isinstance(desc, tl._experimental_tensor_descriptor_base)
     validate_descriptor_block(desc.block_shape, desc.type.element_ty)
+    ndim = len(desc.block_shape)
+    assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
+    assert value.shape == desc.block_shape
 
     offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
     return tl.tensor(builder.create_descriptor_store(desc.handle, value.handle, offsets), tl.void)
@@ -1916,8 +1921,8 @@ def make_tensor_descriptor(
     builder: ir.builder,
 ) -> tl._experimental_tensor_descriptor:
     ndim = len(shape)
-    if ndim != 2:
-        raise ValueError("Only two dimensional tensor descriptors are supported at the moment")
+    if not (2 <= ndim <= 5):
+        raise ValueError(f"Expected 2 <= ndim <= 5 but got {ndim} dimensions")
     if len(strides) != ndim:
         raise ValueError(f"Expected {ndim} strides but got {len(strides)}")
     if len(block_shape) != ndim:

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -842,8 +842,8 @@ class TensorWrapper:
     def data_ptr(self):
         return self.base.data_ptr()
 
-    def stride(self, i):
-        return self.base.stride(i)
+    def stride(self, *args):
+        return self.base.stride(*args)
 
     def __str__(self) -> str:
         return f"TensorWrapper[{self.dtype}]({self.base})"


### PR DESCRIPTION
This adds support for 3, 4 and 5 dimensional tensor descriptors with tests that load and store work correctly. It was surprisingly easy as most of the code was already written generically, there were only a few changes needed to the TMA creation lowering, and a bug-fix for LL conversion of NVMMA encoding with >2 dims.