### PR TITLE
Revert "[PIPELINE] Relax requirements for wgmma operand register pipelining (#5810)"

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -200,7 +200,13 @@ StringRef getAMDArch(Operation *module);
 std::optional<mlir::triton::gpu::SwizzledSharedEncodingAttr>
 getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible);
 
-bool canUseMMAv3Pipelining(Operation *loadOp);
+enum class MMALoadType {
+  SharedV3,
+  Registers,     // may be v2 or v3
+  DoNotPipeline, // could be a valid shared/registers MMA operand, but skip
+                 // pipelining
+};
+MMALoadType getMMALoadType(Operation *loadOp);
 
 // Convert \param op operands and results to layout \param encoding.
 void convertOpEncoding(Attribute encoding, Operation *op);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -87,6 +87,11 @@ bool isPipeliningBeneficial(Operation *op, Operation *finalUser,
   if (isa<tt::ExperimentalDescriptorLoadOp, tt::ExperimentalDescriptorGatherOp>(
           op))
     return true;
+  if (isa<ttng::WarpGroupDotOp>(finalUser) &&
+      getMMALoadType(op) == MMALoadType::DoNotPipeline) {
+    LDBG("Load " << *op << " used by WarpGroupDotOp with incompatible layout");
+    return false;
+  }
   if (!canHaveSharedEncoding(cast<tt::LoadOp>(op))) {
     LDBG("Load " << *op << " cannot have shared encoding");
     return false;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -41,6 +41,7 @@ struct LoadInfo {
   // Blocked encoding is used for loads not used by the dot.
   ttg::BlockedEncodingAttr blockedEncoding = nullptr;
   bool isMMAv3Shared = false;
+  bool isMMAv3Registers = false;
   bool isMMAv5Scale = false;
   int distToUse = 0;
   bool usedByDot = false;
@@ -517,22 +518,21 @@ assignMemoryLayouts(scf::ForOp &forOp,
     loadsToPipeline.insert(&op);
     LoadInfo loadInfo;
     for (auto use : users) {
-      // By default we will try pipelining with load to registers at the end.
-      // For mmav3 we can try leaving the operands in shared memory.
-      bool mmav3Shmem = false;
       if (isa<mlir::triton::DotOpInterface>(use)) {
         LDBG("set shared encoding with dot user: " << *use);
+        auto mmaLoadType = getMMALoadType(&op);
         auto dot = dyn_cast<tt::DotOp>(use);
         auto warpGroupDot = dyn_cast<ttng::WarpGroupDotOp>(use);
-        mmav3Shmem = canUseMMAv3Pipelining(&op) && warpGroupDot;
 
         loadInfo.usedByDot = true;
-        loadInfo.isMMAv3Shared = mmav3Shmem;
+        loadInfo.isMMAv3Shared = mmaLoadType == MMALoadType::SharedV3;
+        loadInfo.isMMAv3Registers =
+            (mmaLoadType == MMALoadType::Registers) && warpGroupDot;
 
-        if (mmav3Shmem || isTMALoad) {
+        if (loadInfo.isMMAv3Shared || isTMALoad) {
           loadInfo.sharedEncoding =
               getSharedEncoding(&op, isTMALoad).value_or(nullptr);
-        } else if (!mmav3Shmem || dot) {
+        } else if (loadInfo.isMMAv3Registers || dot) {
           bool incompatible = false;
 
           loadInfo.sharedEncoding =
@@ -543,9 +543,7 @@ assignMemoryLayouts(scf::ForOp &forOp,
 
       // If we still don't have a shared encoding, try a "generic" shared
       // encoding.
-      if (!loadInfo.sharedEncoding) {
-        assert(!loadInfo.isMMAv3Shared &&
-               "For MMAv3 pipelining we should have shared encoding");
+      if (!loadInfo.sharedEncoding && !isa<ttng::WarpGroupDotOp>(use)) {
         LDBG("try generic shared encoding");
         loadInfo.sharedEncoding =
             getSharedEncoding(&op, isTMALoad).value_or(nullptr);

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4089,7 +4089,13 @@ def test_dot_mulbroadcasted(in_dtype, device):
     if not is_cuda():
         return
     assert "tt.dot" in h.asm['ttir']
-    assert re.search(r"ttg.async_wait %.* {num = 2 : i32}", h.asm["ttgir"]) is not None
+    # When using MMAv3, we will not pipeline the load op for Y, as the loaded
+    # value is in rowmajor. But MMAv3 requires its second operand is in colmajor
+    # because transpose is not supported for MMAv3 with float32 input.
+    if capability[0] == 9:
+        assert re.search(r"ttg.async_wait %.* {num = 1 : i32}", h.asm["ttgir"]) is not None
+    else:
+        assert re.search(r"ttg.async_wait %.* {num = 2 : i32}", h.asm["ttgir"]) is not None
 
 
 @pytest.mark.interpreter

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -88,8 +88,8 @@ tt.func @load_into_shared(%lb : index, %ub : index, %step : index,
   tt.return %loop#2: tensor<128x128xf32, #mma>
 }
 
-// CHECK-LABEL: @load_into_lt_4b
-tt.func @load_into_lt_4b(%lb : index, %ub : index, %step : index,
+// CHECK-LABEL: @load_into_shared_incompat_layout
+tt.func @load_into_shared_incompat_layout(%lb : index, %ub : index, %step : index,
                   %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
                   %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x128xf32, #mma> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #mma>
@@ -100,7 +100,6 @@ tt.func @load_into_lt_4b(%lb : index, %ub : index, %step : index,
     // CHECK: tt.load {{.*}} {tt.latency = 2 : i32}
     %a_ = tt.load %a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
     %a = ttg.local_alloc %a_ : (tensor<128x32xf16, #AL>) -> !ttg.memdesc<128x32xf16, #shared, #ttg.shared_memory>
-    // Do not pipeline if cp.async would read less than 4 consecutive bytes
     // CHECK: tt.load
     // CHECK-NOT: {tt.latency = 2 : i32}
     %b_ = tt.load %b_ptr : tensor<32x128x!tt.ptr<f16>, #BL>


### PR DESCRIPTION
This reverts #5810, which broke `test_gemm.py` on blackwell.