### PR TITLE
Disable dot transpose optimization due to perf regressions

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -338,20 +338,6 @@ public:
     bool bFromLoad = comesFromLoadOrBlockArg(dotOp.getB());
     bool transpose = false;
     auto origDotOp = dotOp;
-    if (aFromLoad && !bFromLoad) {
-      // If the lhs is not a load and the rhs is, we transpose the inputs
-      // and the result provided this allows us to use mmav3
-      // We transpose the result at the end of the rewrite
-      DotOp transDot = transposeDotOp(rewriter, dotOp);
-      if (getMMAVersionSafe(computeCapability, transDot) == 3) {
-        dotOp = transDot;
-        versionMajor = 3;
-        transpose = true;
-      }
-      std::swap(aFromLoad, bFromLoad);
-    }
-    // If !aFromLoad && !bFromLoad, we just accept a shmem roundtrip
-    // for versionMajor == 3
 
     Value a = dotOp.getA();
     Value b = dotOp.getB();


### PR DESCRIPTION
There are cases where transposing the dot op may cause performance problems. For example, if the accumulator is being used in something like:
```
 %206 = ttg.convert_layout %205 : tensor<128x64xf16, #mma> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> loc(#loc216)
```
transposing it makes the conversion expensive. This is likely to happen in attention kernels.