### PR TITLE
[AMD][BACKEND] Enable cache ctrl bits for gfx950

### DIFF
--- a/test/Conversion/amd/async_ops_to_llvm.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm.mlir
@@ -1,5 +1,5 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s --check-prefix=GFX950
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --verify-diagnostics | FileCheck %s --check-prefix=GFX942
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --verify-diagnostics | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
@@ -180,7 +180,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 16 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
-  // GFX942-LABEL: async_copy_cache_mods
+  // CHECK-LABEL: async_copy_cache_mods
   tt.func public @async_copy_cache_mods(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
                                 %arg1: i32 {tt.divisibility = 16 : i32},
                                 %arg2: !ttg.memdesc<32x32xf16, #shared, #smem, mutable>) {
@@ -188,29 +188,29 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 16 : i32, ttg.sha
     %1 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x32x!tt.ptr<f16>, #blocked>
     // Each thread needs to load 1 element and we load 1 (sizePerThread) per global.load.lds
 
-    // GFX942: llvm.getelementptr
-    // GFX942: %[[aux_ca:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // GFX942: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_ca]]
+    // CHECK: llvm.getelementptr
+    // CHECK: %[[aux_ca:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_ca]]
     %2 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = ca: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
-    // GFX942: llvm.getelementptr
-    // GFX942: %[[aux_cg:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // GFX942: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cg]]
+    // CHECK: llvm.getelementptr
+    // CHECK: %[[aux_cg:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cg]]
     %3 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cg: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
-    // GFX942: llvm.getelementptr
-    // GFX942: %[[aux_cs:.*]] = llvm.mlir.constant(3 : i32) : i32
-    // GFX942: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cs]]
+    // CHECK: llvm.getelementptr
+    // CHECK: %[[aux_cs:.*]] = llvm.mlir.constant(3 : i32) : i32
+    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cs]]
     %5 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cs: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
-    // GFX942: llvm.getelementptr
-    // GFX942: %[[aux_cv:.*]] = llvm.mlir.constant(9 : i32) : i32
-    // GFX942: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cv]]
+    // CHECK: llvm.getelementptr
+    // CHECK: %[[aux_cv:.*]] = llvm.mlir.constant(9 : i32) : i32
+    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cv]]
     %6 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cv: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
-    // GFX942: llvm.getelementptr
-    // GFX942: %[[aux_wb:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // GFX942: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_wb]]
+    // CHECK: llvm.getelementptr
+    // CHECK: %[[aux_wb:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_wb]]
     %7 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = wb: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
-    // GFX942: llvm.getelementptr
-    // GFX942: %[[aux_wt:.*]] = llvm.mlir.constant(8 : i32) : i32
-    // GFX942: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_wt]]
+    // CHECK: llvm.getelementptr
+    // CHECK: %[[aux_wt:.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_wt]]
     %8 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = wt: tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
     tt.return
   }

--- a/test/Conversion/amd/buffer_load_store.mlir
+++ b/test/Conversion/amd/buffer_load_store.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=arch=gfx942 | FileCheck %s
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s
 
 #blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -247,10 +247,11 @@ void BufferEmitter::fillCommonArgsAtomics(Type type, Value rsrcDesc,
   // 3. Create the cache modifiers word
   int32_t aux = 0;
   if (hasUsers)
-    aux = getCtrlBitsForBufferAtomicsOnGFX942(/*setSC0*/ true, /*setSC1*/ false,
-                                              /*setNT*/ false);
+    aux = getCtrlBitsForBufferAtomicsOnGFX_942_950(/*setSC0*/ true,
+                                                   /*setSC1*/ false,
+                                                   /*setNT*/ false);
   else
-    aux = getCtrlBitsForBufferAtomicsOnGFX942(
+    aux = getCtrlBitsForBufferAtomicsOnGFX_942_950(
         /*setSC0*/ false, /*setSC1*/ false, /*setNT*/ false);
 
   Value cacheModifiers = b.int_val(32, aux);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -59,8 +59,8 @@ getCtrlBitsForCacheModifierOnTarget(triton::CacheModifier, bool,
                                     const mlir::triton::AMD::TargetInfo &);
 
 // Get cache modifier information for buffer atomics
-int32_t getCtrlBitsForBufferAtomicsOnGFX942(bool setSC0, bool setSC1,
-                                            bool setNT);
+int32_t getCtrlBitsForBufferAtomicsOnGFX_942_950(bool setSC0, bool setSC1,
+                                                 bool setNT);
 
 Value cvtFp32ToFp16(Location loc, RewriterBase &rewriter, const Value &v,
                     triton::RoundingMode rounding);


### PR DESCRIPTION
Enables cache control bits based on Triton's `cacheModifier` on gfx950. They are identical compared to `gfx942`.