### PR TITLE
[BACKEND] Fix opt level

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -285,7 +285,7 @@ void init_triton_llvm(py::module &&m) {
 
   m.def(
       "optimize_module",
-      [](llvm::Module *mod, const llvm::OptimizationLevel &opt,
+      [](llvm::Module *mod, const llvm::OptimizationLevel opt,
          std::string arch, std::string features, std::vector<std::string> flags,
          bool enable_fp_fusion) {
         if (mlir::triton::tools::getBoolEnv("DISABLE_LLVM_OPT"))


### PR DESCRIPTION
opt level was passed as const pointer, which means its data can be modified or erased. This was causing the backend compiled with wrong opt level.
Fixed by removing reference so it can use the copy that remains constant.
