### PR TITLE
Implement `DotOperandEncodingAttr::getSizePerThread` with block layout parent

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2213,10 +2213,11 @@ SmallVector<unsigned> DotOperandEncodingAttr::getSizePerThread() const {
   assert(parentLayout && "DotOperandEncodingAttr must have a parent");
   if (auto parentMmaLayout = mlir::dyn_cast<MmaEncodingTrait>(parentLayout)) {
     return parentMmaLayout.getSizePerThreadForOperand(getKWidth(), getOpIdx());
+  } else if (auto blocked = mlir::dyn_cast<BlockedEncodingAttr>(parentLayout)) {
+    return expandMatrixShapeWithBatch(ArrayRef(blocked.getSizePerThread()));
   } else {
     llvm::report_fatal_error(
-        "DotOperandEncodingAttr non-NvidiaMmaEncodingAttr parent not "
-        "supported yet");
+        "getSizePerThread not implemented for DotOperandEncodingAttr");
     return {};
   }
 }

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2214,7 +2214,7 @@ SmallVector<unsigned> DotOperandEncodingAttr::getSizePerThread() const {
   if (auto parentMmaLayout = mlir::dyn_cast<MmaEncodingTrait>(parentLayout)) {
     return parentMmaLayout.getSizePerThreadForOperand(getKWidth(), getOpIdx());
   } else if (auto blocked = mlir::dyn_cast<BlockedEncodingAttr>(parentLayout)) {
-    return expandMatrixShapeWithBatch(ArrayRef(blocked.getSizePerThread()));
+    return blocked.getSizePerThread();
   } else {
     llvm::report_fatal_error(
         "getSizePerThread not implemented for DotOperandEncodingAttr");


### PR DESCRIPTION
For XPU backend, the logic of the common code is slightly changed and some Triton lit tests encounter the problem of an unimplemented function.