### PR TITLE
[PROTON-DEV] Decouple ProtonGPU RecordOp into two operations

### DIFF
--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
@@ -26,13 +26,14 @@ def PTG_CircularStoreOp : PTG_Op<"circular_store", [
   let summary = "Store the value into a circular buffer";
 
   let description = [{
-    Store a metric counter into a circular buffer backed by the internal memory `data`.
+    Store a metric `counter` into a circular buffer backed by the internal memory `data`.
     The circular buffer indexing `curIndex` is automatically updated and returned as `newIndex`.
     Older metric counter get dropped if the `data` is full.
   }];
   let arguments = (
     ins TTG_MemDescType: $data,
     I32: $curIndex,
+    I32: $counter,
     UnitAttr: $isStart,
     I32Attr: $scopeId,
     DefaultValuedAttr<MetricAttr, "Metric::CYCLE">:$metric,
@@ -44,8 +45,8 @@ def PTG_CircularStoreOp : PTG_Op<"circular_store", [
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    (`start` $isStart^):(`end`)? $data `,` $curIndex attr-dict `:`
-    qualified(type($data)) `,` type($curIndex) `->` type($newIndex)
+    (`start` $isStart^):(`end`)? $data `,` $curIndex `,` $counter attr-dict `:`
+    qualified(type($data)) `,` type($curIndex) `,` type($counter) `->` type($newIndex)
   }];
 }
 

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
@@ -27,7 +27,7 @@ def PTG_CircularStoreOp : PTG_Op<"circular_store", [
 
   let description = [{
     Store a metric counter into a circular buffer backed by the internal memory `data`.
-    The circular buffer indexing `curIndex` is automatically updated and returned as `newIndex`. 
+    The circular buffer indexing `curIndex` is automatically updated and returned as `newIndex`.
     Older metric counter get dropped if the `data` is full.
   }];
   let arguments = (

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
@@ -27,22 +27,25 @@ def PTG_CircularStoreOp : PTG_Op<"circular_store", [
 
   let description = [{
     Store a metric counter into a circular buffer backed by the internal memory `data`.
-    The circular buffer indexing `indexPtr` is automatically maintained. Older events
-    get dropped if the `data` is full.
+    The circular buffer indexing `curIndex` is automatically updated and returned as `newIndex`. 
+    Older metric counter get dropped if the `data` is full.
   }];
   let arguments = (
-    ins UnitAttr: $isStart,
+    ins TTG_MemDescType: $data,
+    I32: $curIndex,
+    UnitAttr: $isStart,
     I32Attr: $scopeId,
-    TTG_MemDescType:$data,
-    TT_PtrLike :$indexPtr,
     DefaultValuedAttr<MetricAttr, "Metric::CYCLE">:$metric,
     DefaultValuedAttr<GranularityAttr, "Granularity::WARPGROUP">:$granularity
   );
+
+  let results = (outs I32 : $newIndex);
+
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    (`start` $isStart^):(`end`)? $data `,` $indexPtr attr-dict `:`
-    qualified(type($data)) `,` type($indexPtr)
+    (`start` $isStart^):(`end`)? $data `,` $curIndex attr-dict `:`
+    qualified(type($data)) `,` type($curIndex) `->` type($newIndex)
   }];
 }
 
@@ -55,15 +58,12 @@ def PTG_ReadCounterOp : PTG_Op<"read_counter", [
     Read a GPU metric counter into a scalar register.
   }];
   let arguments = (
-    ins UnitAttr: $isStart,
-    I32Attr: $scopeId,
-    DefaultValuedAttr<MetricAttr, "Metric::CYCLE">:$metric,
-    DefaultValuedAttr<GranularityAttr, "Granularity::WARPGROUP">:$granularity
+    ins DefaultValuedAttr<MetricAttr, "Metric::CYCLE">:$metric
   );
   let results = (outs I32 : $counter);
 
   let assemblyFormat = [{
-    (`start` $isStart^):(`end`)? attr-dict `:` type($counter)
+    attr-dict `:` type($counter)
   }];
 }
 
@@ -79,27 +79,23 @@ def PTG_FinalizeOp : PTG_Op<"finalize", [
   }];
   let arguments = (
     ins TTG_MemDescType:$data,
-    TT_PtrLike :$indexPtr,
+    I32 :$index,
     TT_PtrLike :$ptr,
     I32Attr :$size
   );
 
-  let assemblyFormat = [{$data `,` $indexPtr `,` $ptr attr-dict `:` qualified(type($data)) `,` type($indexPtr) `,` type($ptr)}];
+  let assemblyFormat = [{$data `,` $index `,` $ptr attr-dict `:` qualified(type($data)) `,` type($index) `,` type($ptr)}];
 }
 
-def PTG_InitOp : PTG_Op<"init", [
-  MemoryEffects<[MemAlloc<GlobalMemory>]>
-]> {
-  let summary = "Initialize the intra kernel profiler";
+def PTG_InitBufferIndexOp : PTG_Op<"init_buffer_index", []> {
+  let summary = "Initialize the internal buffer index";
 
   let description = [{
-      Stack allocation and initialization for the intra kernel profiler.
-      `indexPtr` stores the number of entries proton recorded (zero initialized).
-      We expect `indexPtr` to be register promoted during the LLVM lowering phase.
+      Zero-initialization for the internal buffer index for the intra kernel profiler.
   }];
   let arguments = (ins);
-  let results = (outs TT_PtrLike :$indexPtr);
-  let assemblyFormat = "attr-dict `:` type($indexPtr)";
+  let results = (outs I32 :$index);
+  let assemblyFormat = "attr-dict `:` type($index)";
 }
 
 #endif  // PROTON_GPU_OPS

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
@@ -20,19 +20,19 @@ class PTG_Op<string mnemonic, list<Trait> traits = []> :
   Op<ProtonGPU_Dialect, mnemonic, !listconcat(traits, [])> {
 }
 
-def PTG_CircularRecordOp : PTG_Op<"circular_record", [
+def PTG_CircularStoreOp : PTG_Op<"circular_store", [
   MemoryEffects<[MemRead<DefaultResource>, MemWrite<DefaultResource>]>
 ]> {
-  let summary = "Record a GPU metric event into a circular buffer";
+  let summary = "Store the value into a circular buffer";
 
   let description = [{
-    Records a metric event into a circular buffer backed by the internal memory `data`.
+    Store a metric counter into a circular buffer backed by the internal memory `data`.
     The circular buffer indexing `indexPtr` is automatically maintained. Older events
     get dropped if the `data` is full.
   }];
   let arguments = (
     ins UnitAttr: $isStart,
-    I32: $scopeId,
+    I32Attr: $scopeId,
     TTG_MemDescType:$data,
     TT_PtrLike :$indexPtr,
     DefaultValuedAttr<MetricAttr, "Metric::CYCLE">:$metric,
@@ -41,8 +41,29 @@ def PTG_CircularRecordOp : PTG_Op<"circular_record", [
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    (`start` $isStart^):(`end`)? $scopeId `,` $data `,` $indexPtr attr-dict `:`
+    (`start` $isStart^):(`end`)? $data `,` $indexPtr attr-dict `:`
     qualified(type($data)) `,` type($indexPtr)
+  }];
+}
+
+def PTG_ReadCounterOp : PTG_Op<"read_counter", [
+  MemoryEffects<[MemRead<DefaultResource>, MemWrite<DefaultResource>]>
+]> {
+  let summary = "Read a GPU metric counter into a scalar register";
+
+  let description = [{
+    Read a GPU metric counter into a scalar register.
+  }];
+  let arguments = (
+    ins UnitAttr: $isStart,
+    I32Attr: $scopeId,
+    DefaultValuedAttr<MetricAttr, "Metric::CYCLE">:$metric,
+    DefaultValuedAttr<GranularityAttr, "Granularity::WARPGROUP">:$granularity
+  );
+  let results = (outs I32 : $counter);
+
+  let assemblyFormat = [{
+    (`start` $isStart^):(`end`)? attr-dict `:` type($counter)
   }];
 }
 

--- a/third_party/proton/dialect/lib/Dialect/ProtonGPU/IR/Ops.cpp
+++ b/third_party/proton/dialect/lib/Dialect/ProtonGPU/IR/Ops.cpp
@@ -19,7 +19,7 @@ namespace proton {
 namespace gpu {
 
 // -- CircularRecordOp --
-LogicalResult CircularRecordOp::verify() {
+LogicalResult CircularStoreOp::verify() {
   // TODO(fywkevin): checks the following:
   // 1. circular buffer size power of 2.
   // 2. function's noinline is false.


### PR DESCRIPTION
Decouple the `CircularRecordOp` into two ops: `ReadCounterOp` and `CircularStoreOp`. This allows us to schedule to write operations separately. Note that the `scopeId` is an attribute, which should have been assigned with a value. A `name->id` assignment pass will also happen before lowering `ProtonGPURecordOp`. For example:  
`protongpu.record %name` -> 
`protongpu.record %name` + `proton.init_scope{%name, %id}` -> 
`protongpu.read_counter{%id}` + `protongpu.circular_store{%id}` + `proton.init_scope{%name, %id}`
