### PR TITLE
[NFC] Make getStackPointer and getGlobalScratchPtr as interface of TargetInfo

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -95,7 +95,14 @@ public:
   // llvm.
   virtual void storeOpAnnotation(triton::gpu::LocalStoreOp op,
                                  size_t localStoreOpCount, Type type) const {}
+  virtual Value
+  getScratchOnSharedMemoryPtr(RewriterBase &rewriter,
+                              FunctionOpInterface funcOp) const = 0;
 
+  virtual Value getScratchOnGlobalMemoryPtr(Location loc,
+                                            RewriterBase &rewriter,
+                                            FunctionOpInterface funcOp,
+                                            Value allocOffset = {}) const = 0;
   virtual ~TargetInfoBase() {}
 };
 } // namespace mlir::triton

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -642,8 +642,8 @@ inline Value getSharedMemoryBase(Location loc, RewriterBase &rewriter,
                       .getZExtValue();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value offVal = b.i32_val(offset);
-  Value base =
-      b.gep(ptrTy, i8_ty, LLVM::getStackPointer(rewriter, func), offVal);
+  Value base = b.gep(
+      ptrTy, i8_ty, target.getScratchOnSharedMemoryPtr(rewriter, func), offVal);
   return base;
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/ControlFlowOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ControlFlowOpToLLVM.cpp
@@ -85,7 +85,7 @@ private:
         callOp.getLoc(), /*opOperands=*/callOp->getOperands(),
         adaptor.getOperands(), rewriter);
     if (!caller->hasAttr("allocation.offset")) {
-      auto base = LLVM::getStackPointer(rewriter, caller);
+      auto base = targetInfo.getScratchOnSharedMemoryPtr(rewriter, caller);
       promotedOperands.push_back(base);
     } else {
       auto base = LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, callOp);
@@ -100,8 +100,8 @@ private:
       opOffsetVal = b.i32_val(opOffset);
     }
 
-    promotedOperands.push_back(
-        LLVM::getGlobalScratchPtr(loc, rewriter, caller, opOffsetVal));
+    promotedOperands.push_back(targetInfo.getScratchOnGlobalMemoryPtr(
+        loc, rewriter, caller, opOffsetVal));
     return promotedOperands;
   }
 

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -32,8 +32,9 @@ void lowerDistributedToShared(
 struct GlobalScratchAllocOpConversion
     : public ConvertOpToLLVMPattern<triton::gpu::GlobalScratchAllocOp> {
   GlobalScratchAllocOpConversion(LLVMTypeConverter &converter,
+                                 const TargetInfoBase &targetInfo,
                                  PatternBenefit benefit)
-      : ConvertOpToLLVMPattern(converter, benefit) {}
+      : ConvertOpToLLVMPattern(converter, benefit), targetInfo(targetInfo) {}
 
   LogicalResult
   matchAndRewrite(triton::gpu::GlobalScratchAllocOp op, OpAdaptor adaptor,
@@ -50,12 +51,15 @@ struct GlobalScratchAllocOpConversion
     if (!funcOp) {
       return failure();
     }
-    Value ptr =
-        LLVM::getGlobalScratchPtr(loc, rewriter, funcOp, b.i32_val(opOffset));
+    Value ptr = targetInfo.getScratchOnGlobalMemoryPtr(loc, rewriter, funcOp,
+                                                       b.i32_val(opOffset));
 
     rewriter.replaceOp(op, ptr);
     return success();
   }
+
+private:
+  const TargetInfoBase &targetInfo;
 };
 
 struct LocalAllocOpConversion
@@ -190,7 +194,8 @@ private:
 void mlir::triton::populateMemoryOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, const TargetInfoBase &targetInfo,
     RewritePatternSet &patterns, PatternBenefit benefit) {
-  patterns.add<GlobalScratchAllocOpConversion>(typeConverter, benefit);
+  patterns.add<GlobalScratchAllocOpConversion>(typeConverter, targetInfo,
+                                               benefit);
   patterns.add<LocalAllocOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<LocalDeallocOpConversion>(typeConverter, benefit);
   patterns.add<LocalLoadOpConversion>(typeConverter, targetInfo, benefit);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -450,4 +450,16 @@ void TargetInfo::storeOpAnnotation(triton::gpu::LocalStoreOp op,
   storeOpSchedAnnotations(op, localStoreOpCount, type);
 }
 
+Value TargetInfo::getScratchOnSharedMemoryPtr(
+    RewriterBase &rewriter, FunctionOpInterface funcOp) const {
+  return LLVM::getStackPointer(rewriter, funcOp);
+}
+
+Value TargetInfo::getScratchOnGlobalMemoryPtr(Location loc,
+                                              RewriterBase &rewriter,
+                                              FunctionOpInterface funcOp,
+                                              Value allocOffset) const {
+  return LLVM::getGlobalScratchPtr(loc, rewriter, funcOp, allocOffset);
+}
+
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -71,6 +71,13 @@ public:
   void storeOpAnnotation(triton::gpu::LocalStoreOp op, size_t localStoreOpCount,
                          Type type) const override;
 
+  Value getScratchOnSharedMemoryPtr(RewriterBase &rewriter,
+                                    FunctionOpInterface funcOp) const override;
+
+  Value getScratchOnGlobalMemoryPtr(Location loc, RewriterBase &rewriter,
+                                    FunctionOpInterface funcOp,
+                                    Value allocOffset = {}) const override;
+
 private:
   void printfImpl(Value formatStrStart, int formatStrByteCount, ValueRange args,
                   RewriterBase &rewriter, bool useStdErr) const;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -623,4 +623,16 @@ bool TargetInfo::supportVectorizedAtomics() const {
   return computeCapability >= 90 && ptxVersion >= 81;
 }
 
+Value TargetInfo::getScratchOnSharedMemoryPtr(
+    RewriterBase &rewriter, FunctionOpInterface funcOp) const {
+  return LLVM::getStackPointer(rewriter, funcOp);
+}
+
+Value TargetInfo::getScratchOnGlobalMemoryPtr(Location loc,
+                                              RewriterBase &rewriter,
+                                              FunctionOpInterface funcOp,
+                                              Value allocOffset) const {
+  return LLVM::getGlobalScratchPtr(loc, rewriter, funcOp, allocOffset);
+}
+
 } // namespace mlir::triton::NVIDIA

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -64,6 +64,13 @@ public:
 
   int getPtxVersion() const { return ptxVersion; }
 
+  Value getScratchOnSharedMemoryPtr(RewriterBase &rewriter,
+                                    FunctionOpInterface funcOp) const override;
+
+  Value getScratchOnGlobalMemoryPtr(Location loc, RewriterBase &rewriter,
+                                    FunctionOpInterface funcOp,
+                                    Value allocOffset = {}) const override;
+
 private:
   int computeCapability;
   int ptxVersion;


### PR DESCRIPTION
This allows XPU backend to have different methods for them.

getStackPointer -> targetInfo.getScratchOnSharedMemoryPtr
getGlobalScratchPtr -> targetInfo.getScratchOnGlobalMemoryPtr