### PR TITLE
[AMD] fix CanonicalizePointers FatPtrAttrs (SmallDenseMap -> DenseMap)

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -230,7 +230,6 @@ class HIPBackend(BaseBackend):
                 amd.passes.ttgpuir.add_block_pingpong(pm)
 
         use_buffer_ops = os.environ.get("AMDGCN_USE_BUFFER_OPS", "0") == "1"
-        use_buffer_ops = True
         if use_buffer_ops:
             amd.passes.ttgpuir.add_canonicalize_pointers(pm)
             passes.common.add_canonicalizer(pm)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -230,6 +230,7 @@ class HIPBackend(BaseBackend):
                 amd.passes.ttgpuir.add_block_pingpong(pm)
 
         use_buffer_ops = os.environ.get("AMDGCN_USE_BUFFER_OPS", "0") == "1"
+        use_buffer_ops = True
         if use_buffer_ops:
             amd.passes.ttgpuir.add_canonicalize_pointers(pm)
             passes.common.add_canonicalizer(pm)

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -296,7 +296,7 @@ struct FatPointers {
       return !(lhs == rhs);
     }
 
-    llvm::SmallDenseMap<StringRef, Attribute> attributes;
+    llvm::DenseMap<StringRef, Attribute> attributes;
     bool canNarrow = false;
   };
 


### PR DESCRIPTION
This PR fixes an assert thrown in [DenseMap::copyFrom](https://github.com/llvm/llvm-project/blob/390b82dd4c485ec64cf8a6c52fb73e391792262e/llvm/include/llvm/ADT/DenseMap.h#L435) that looks like this:

```
... Assertion `getNumBuckets() == other.getNumBuckets()' failed.
```

The call to `copyFrom` is via `SmallDenseMap`s copy ctor which fires in our code in the default ctor of [`CanonicalizePointers::FatPointers::FatPtrAttrs`](https://github.com/triton-lang/triton/blob/083731a28defcf54c53f4a16836af3a277f2437e/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp#L287) since `FatPtrAttrs` wraps a `llvm::SmallDenseMap<StringRef, Attribute> attributes`.

I have locally verified the fix resolves the issue using @jungpark-mlir reproducer but note, this is a non-deterministic bug. I wasn't able to root cause (i.e., it's not clear to me under which conditions [`other.getNumBuckets() <= InlineBuckets`](https://github.com/llvm/llvm-project/blob/390b82dd4c485ec64cf8a6c52fb73e391792262e/llvm/include/llvm/ADT/DenseMap.h#L1027)) but the design decision to use `llvm::SmallDenseMap<StringRef, Attribute> attributes` instead of `llvm::DenseMap<StringRef, Attribute> attributes` was a mistake left over from when I/we were debating whether we were going to propagate all pointer attributes or only a "small" subset (so this change to "large" `DenseMap` makes sense on first principles irrespective of the bug).

Note, also I have temporarily enabled buffer ops by default to "stress test" the patch and I will restore before landing.