### PR TITLE
[AMD] [FrontEnd] Optimize is_within_2gb and only enable with buffer ops supported

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -179,7 +179,6 @@ def test_specialize(mode, device, fresh_triton_cache):
     x = torch.empty(1, dtype=torch.int32, device=device)
     function = {'enable': kernel, 'disable': kernel_nospec, 'disable_on_alignment': kernel_nospec_on_alignment}[mode]
     target = {'enable': 3, 'disable': 1, 'disable_on_alignment': 2}[mode]
-    target = {"enable": 3, "disable": 1, "disable_on_alignment": 2}[mode]
     for i in [1, 2, 4, 8, 16, 32]:
         function[(1, )](x, i, BLOCK=512)
     assert counter == target

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -580,7 +580,7 @@ def test_within_2gb(device, fresh_triton_cache) -> None:
             # In warmup we assume that the pointer range is 32 bits
             kernel_add.warmup(torch.float32, grid=(1, ))
             assert pointer_range_32 == pointer_range
-            # Torch tensor > 2GB. This should never hit.
+            # Torch tensor > 2GB
             kernel_add[(1, 0)](torch.empty(2**31, dtype=torch.int8, device=device))
             assert len(pointer_range_32) == 0
             # Torch tensor <= 2GB

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -2,6 +2,7 @@ import importlib.util
 import itertools
 import shutil
 import pathlib
+import os
 
 import pytest
 import torch
@@ -553,28 +554,37 @@ def test_hooks(device, fresh_triton_cache) -> None:
 
 @pytest.mark.skipif(reason="within_2g is a HIP specific optimization", condition=not is_hip())
 def test_within_2gb(device, fresh_triton_cache) -> None:
+    from triton.backends.amd.compiler import use_buffer_ops
+    default_buffer_ops = os.environ.get("AMDGCN_USE_BUFFER_OPS", "0")
+    try:
+        # Set AMDGCN_USE_BUFFER_OPS and invalidate the cache
+        use_buffer_ops.cache_clear()
+        os.environ["AMDGCN_USE_BUFFER_OPS"] = "1"
 
-    @triton.jit
-    def kernel_add(a):
-        tl.load(a)
+        @triton.jit
+        def kernel_add(a):
+            tl.load(a)
 
-    # This is the attribute we want to test
-    pointer_range_32 = None
+        # This is the attribute we want to test
+        pointer_range_32 = None
 
-    def cache_hook(*args, **kwargs):
-        nonlocal pointer_range_32
-        pointer_range_32 = [k for k, v in kwargs["compile"]["configs"][0].items() if ['tt.pointer_range', 32] in v]
+        def cache_hook(*args, **kwargs):
+            nonlocal pointer_range_32
+            pointer_range_32 = [k for k, v in kwargs["compile"]["configs"][0].items() if ['tt.pointer_range', 32] in v]
 
-    JITFunction.cache_hook = cache_hook
-    # In warmup we assume that the pointer range is 32 bits
-    kernel_add.warmup(torch.float32, grid=(1, ))
-    assert pointer_range_32 == [(0, )]
-    # Torch tensor > 2GB
-    kernel_add[(1, 0)](torch.empty(2**31, dtype=torch.int8, device=device))
-    assert len(pointer_range_32) == 0
-    # Torch tensor <= 2GB
-    kernel_add[(1, 0)](torch.empty(2**31 - 1, dtype=torch.int8, device=device))
-    assert pointer_range_32 == [(0, )]
+        JITFunction.cache_hook = cache_hook
+        # In warmup we assume that the pointer range is 32 bits
+        kernel_add.warmup(torch.float32, grid=(1, ))
+        assert pointer_range_32 == [(0, )]
+        # Torch tensor > 2GB
+        kernel_add[(1, 0)](torch.empty(2**31, dtype=torch.int8, device=device))
+        assert len(pointer_range_32) == 0
+        # Torch tensor <= 2GB
+        kernel_add[(1, 0)](torch.empty(2**31 - 1, dtype=torch.int8, device=device))
+        assert pointer_range_32 == [(0, )]
+    finally:
+        use_buffer_ops.cache_clear()
+        os.environ["AMDGCN_USE_BUFFER_OPS"] = default_buffer_ops
 
 
 def test_function_arguments(device):

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -19,7 +19,6 @@ def min_dot_size(target: GPUTarget):
     return lambda lhsType, rhsType: (1, 1, 1)
 
 
-# Disable caching when testing.
 @functools.lru_cache()
 def use_buffer_ops():
     return os.environ.get("AMDGCN_USE_BUFFER_OPS", "0") == "1"

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -9,6 +9,7 @@ import os
 import re
 import subprocess
 import functools
+import sys
 from pathlib import Path
 import torch
 
@@ -18,7 +19,8 @@ def min_dot_size(target: GPUTarget):
     return lambda lhsType, rhsType: (1, 1, 1)
 
 
-@functools.lru_cache()
+# Disable caching when testing.
+@functools.lru_cache(maxsize=0 if "pytest" in sys.modules else 256)
 def use_buffer_ops():
     return os.environ.get("AMDGCN_USE_BUFFER_OPS", "0") == "1"
 

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -1,17 +1,16 @@
-import functools
+from triton.backends.compiler import BaseBackend, GPUTarget
+from triton._C.libtriton import ir, passes, llvm, amd
+from dataclasses import dataclass
+from typing import Any, Dict, Tuple
+from types import ModuleType
 import hashlib
+import tempfile
 import os
 import re
 import subprocess
-import tempfile
-from dataclasses import dataclass
+import functools
 from pathlib import Path
-from types import ModuleType
-from typing import Any, Dict, Tuple
-
 import torch
-from triton._C.libtriton import amd, ir, llvm, passes
-from triton.backends.compiler import BaseBackend, GPUTarget
 
 
 def min_dot_size(target: GPUTarget):
@@ -40,7 +39,7 @@ class HIPOptions:
     kpack: int = 1
     allow_flush_denorm: bool = False
     max_num_imprecise_acc_default: int = 0
-    backend_name: str = "hip"
+    backend_name: str = 'hip'
 
     # The following option provides hints to the AMDGPU backend regarding instruction scheduling
     # for all `tt.dot` operations in a kernel. The "none" variant preserves the default
@@ -59,25 +58,26 @@ class HIPOptions:
     #                 Kernel library. Note, this variant requires the use of buffer load/store ops
     #                 and a special software pipelining style - i.e., 1x LDS and 1x register
     #                 prefetch buffers for each GEMM tile.
-    instruction_sched_variant: str = "none"
+    instruction_sched_variant: str = 'none'
 
     def __post_init__(self):
-        default_libdir = Path(__file__).parent / "lib"
+        default_libdir = Path(__file__).parent / 'lib'
         extern_libs = {} if self.extern_libs is None else dict(self.extern_libs)
         # Ignore user-defined warp size for gfx9
-        warp_size = (32 if "gfx10" in self.arch or "gfx11" in self.arch or "gfx12" in self.arch else 64)
-        object.__setattr__(self, "warp_size", warp_size)
+        warp_size = 32 if 'gfx10' in self.arch or 'gfx11' in self.arch or 'gfx12' in self.arch else 64
+        object.__setattr__(self, 'warp_size', warp_size)
         # Only kpack=1 is supported on gfx950
-        kpack = 1 if self.arch == "gfx950" else self.kpack
-        object.__setattr__(self, "kpack", kpack)
+        kpack = 1 if self.arch == 'gfx950' else self.kpack
+        object.__setattr__(self, 'kpack', kpack)
         libs = ["ocml", "ockl"]
         for lib in libs:
-            extern_libs[lib] = str(default_libdir / f"{lib}.bc")
-        object.__setattr__(self, "extern_libs", tuple(extern_libs.items()))
-        assert (self.num_warps > 0 and (self.num_warps & (self.num_warps - 1)) == 0), "num_warps must be a power of 2"
+            extern_libs[lib] = str(default_libdir / f'{lib}.bc')
+        object.__setattr__(self, 'extern_libs', tuple(extern_libs.items()))
+        assert self.num_warps > 0 and (self.num_warps & (self.num_warps - 1)) == 0, \
+               "num_warps must be a power of 2"
 
     def hash(self):
-        key = "_".join([f"{name}-{val}" for name, val in self.__dict__.items()])
+        key = '_'.join([f'{name}-{val}' for name, val in self.__dict__.items()])
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 
@@ -85,7 +85,7 @@ class HIPBackend(BaseBackend):
 
     @staticmethod
     def supports_target(target: GPUTarget):
-        return target.backend == "hip"
+        return target.backend == 'hip'
 
     def __init__(self, target: GPUTarget) -> None:
         super().__init__(target)
@@ -93,18 +93,18 @@ class HIPBackend(BaseBackend):
         self.binary_ext = "hsaco"
 
     def parse_options(self, opts) -> Any:
-        args = {"arch": os.getenv("TRITON_OVERRIDE_ARCH", self.target.arch)}
+        args = {'arch': os.getenv("TRITON_OVERRIDE_ARCH", self.target.arch)}
 
         # Enable XF32 (TF32) for CDNA3 GPUs
-        if self.target.arch in ("gfx940", "gfx941", "gfx942"):
+        if self.target.arch in ('gfx940', 'gfx941', 'gfx942'):
             allowed_dot_input_precisions = set(HIPOptions.allowed_dot_input_precisions)
-            allowed_dot_input_precisions.update({"tf32"})
+            allowed_dot_input_precisions.update({'tf32'})
             args["allowed_dot_input_precisions"] = tuple(sorted(allowed_dot_input_precisions))
 
         if "supported_fp8_dtypes" not in opts:
             supported_fp8_dtypes = set(HIPOptions.supported_fp8_dtypes)
-            if self.target.arch in ("gfx940", "gfx941", "gfx942", "gfx950"):
-                supported_fp8_dtypes.update({"fp8e4nv", "fp8e4b8", "fp8e5b16"})
+            if self.target.arch in ('gfx940', 'gfx941', 'gfx942', 'gfx950'):
+                supported_fp8_dtypes.update({'fp8e4nv', 'fp8e4b8', 'fp8e5b16'})
             args["supported_fp8_dtypes"] = tuple(sorted(supported_fp8_dtypes))
 
         if "enable_fp_fusion" not in opts:
@@ -204,13 +204,8 @@ class HIPBackend(BaseBackend):
     def make_ttgir(mod, metadata, options):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        passes.ttir.add_convert_to_ttgpuir(
-            pm,
-            f"hip:{options.arch}",
-            options.num_warps,
-            options.warp_size,
-            options.num_ctas,
-        )
+        passes.ttir.add_convert_to_ttgpuir(pm, f"hip:{options.arch}", options.num_warps, options.warp_size,
+                                           options.num_ctas)
         pm.run(mod)
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
@@ -305,9 +300,9 @@ class HIPBackend(BaseBackend):
         context = llvm.context()
         llvm_mod = llvm.to_module(mod, context)
         amd.attach_target_triple(llvm_mod)
-        target_features = ""
+        target_features = ''
         if os.environ.get("TRITON_ENABLE_ASAN", "0") == "1":
-            target_features = "+xnack"
+            target_features = '+xnack'
         llvm.attach_datalayout(llvm_mod, amd.TARGET_TRIPLE, options.arch, target_features)
 
         # Set various control constants on the LLVM module so that device
@@ -344,18 +339,18 @@ class HIPBackend(BaseBackend):
         amd.set_all_fn_arg_inreg(fns[0])
 
         if os.environ.get("TRITON_ENABLE_ASAN", "0") == "1":
-            default_libdir = Path(__file__).parent / "lib"
+            default_libdir = Path(__file__).parent / 'lib'
             paths = [
-                str(default_libdir / "asanrtl.bc"),
+                str(default_libdir / 'asanrtl.bc'),
                 str(default_libdir / "ocml.bc"),
-                str(default_libdir / "ockl.bc"),
+                str(default_libdir / "ockl.bc")
             ]
             llvm.link_extern_libs(llvm_mod, paths)
         elif options.extern_libs:
             paths = [path for (name, path) in options.extern_libs if amd.need_extern_lib(llvm_mod, name)]
             llvm.link_extern_libs(llvm_mod, paths)
 
-        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, options.arch, "", [], options.enable_fp_fusion)
+        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, options.arch, '', [], options.enable_fp_fusion)
 
         # Get some metadata
         metadata["shared"] = src.get_int_attr("ttg.shared")
@@ -375,15 +370,7 @@ class HIPBackend(BaseBackend):
         assert len(names) == 1
         metadata["name"] = names[0]
         # llvm -> hsaco
-        amdgcn = llvm.translate_to_asm(
-            src,
-            amd.TARGET_TRIPLE,
-            options.arch,
-            "",
-            [],
-            options.enable_fp_fusion,
-            False,
-        )
+        amdgcn = llvm.translate_to_asm(src, amd.TARGET_TRIPLE, options.arch, '', [], options.enable_fp_fusion, False)
         if os.environ.get("AMDGCN_ENABLE_DUMP", "0") == "1":
             print("// -----// AMDGCN Dump //----- //")
             print(amdgcn)
@@ -391,26 +378,18 @@ class HIPBackend(BaseBackend):
 
     @staticmethod
     def make_hsaco(src, metadata, options):
-        target_features = ""
+        target_features = ''
         if os.environ.get("TRITON_ENABLE_ASAN", "0") == "1":
-            target_features = "+xnack"
+            target_features = '+xnack'
         hsaco = amd.assemble_amdgcn(src, options.arch, target_features)
 
         rocm_path = HIPBackend.path_to_rocm_lld()
         with tempfile.NamedTemporaryFile() as tmp_out:
             with tempfile.NamedTemporaryFile() as tmp_in:
-                with open(tmp_in.name, "wb") as fd_in:
+                with open(tmp_in.name, 'wb') as fd_in:
                     fd_in.write(hsaco)
-                subprocess.check_call([
-                    rocm_path,
-                    "-flavor",
-                    "gnu",
-                    "-shared",
-                    tmp_in.name,
-                    "-o",
-                    tmp_out.name,
-                ])
-            with open(tmp_out.name, "rb") as fd_out:
+                subprocess.check_call([rocm_path, '-flavor', 'gnu', '-shared', tmp_in.name, '-o', tmp_out.name])
+            with open(tmp_out.name, 'rb') as fd_out:
                 ret = fd_out.read()
         return ret
 
@@ -423,5 +402,5 @@ class HIPBackend(BaseBackend):
 
     @functools.lru_cache()
     def hash(self):
-        version = subprocess.check_output([HIPBackend.path_to_rocm_lld(), "--version"], encoding="utf-8")
-        return f"{version}-{self.target}"
+        version = subprocess.check_output([HIPBackend.path_to_rocm_lld(), "--version"], encoding='utf-8')
+        return f'{version}-{self.target}'

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -10,7 +10,6 @@ import re
 import subprocess
 import functools
 from pathlib import Path
-import torch
 
 
 def min_dot_size(target: GPUTarget):
@@ -141,6 +140,8 @@ class HIPBackend(BaseBackend):
 
     @staticmethod
     def is_within_2gb(arg):
+        import torch
+
         MAX_INT_32 = 2**31 - 1
         if hasattr(arg, "ptr_range"):
             return arg.ptr_range() <= MAX_INT_32
@@ -160,7 +161,7 @@ class HIPBackend(BaseBackend):
         ret = BaseBackend.get_arg_specialization(arg, ty, **kwargs)
         # Only attempt to do buffer ops specialization if buffer ops are enabled.
         # Otherwise the is_within_2gb check is unnecessary overhead.
-        if (HIPBackend.use_buffer_ops() and ty == "tensor" and HIPBackend.is_within_2gb(arg)):
+        if HIPBackend.use_buffer_ops() and ty == "tensor" and HIPBackend.is_within_2gb(arg):
             ret += "S"
         return ret
 

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -140,14 +140,13 @@ class HIPBackend(BaseBackend):
     def load_dialects(self, ctx):
         amd.load_dialects(ctx)
 
-    MAX_INT_32 = 2**31 - 1
-
     @staticmethod
     def is_within_2gb(arg):
+        MAX_INT_32 = 2**31 - 1
         if hasattr(arg, "ptr_range"):
-            return arg.ptr_range() <= HIPBackend.MAX_INT_32
+            return arg.ptr_range() <= MAX_INT_32
         if isinstance(arg, torch.Tensor) and hasattr(arg, "untyped_storage"):
-            return arg.untyped_storage().size() <= HIPBackend.MAX_INT_32
+            return arg.untyped_storage().size() <= MAX_INT_32
         return False
 
     @staticmethod


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

Updates the AMD compiler backend to optimize the implementation of `is_within_2gb` and gate its invocation behind buffer ops being enabled. From internal testing we found that this check can be expensive and since as part of the cache key it will be executed on every kernel invocation. Therefore I believe it makes sense to add a fast path that avoids it when buffer ops related optimizations are disabled.

This also may have an added benefit that if a kernel cannot benefit from the buffer operations then the kernel won't need to be recompiled because we have unnecessarily changed the keys based on the 2GB threshold and therefore caused a cache miss.

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is already covered by existing tests.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
