### PR TITLE
[BW][PIPELINE] Skip waits when scheduling downward dependencies in mmav5 pipelining

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TC05MMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TC05MMAPipeline.cpp
@@ -816,7 +816,9 @@ bool insertUsersOfOp(tt::CoarseSchedule &coarseSchedule, Operation *op,
                      int stage, tt::CoarseSchedule::Cluster cluster) {
   bool changed = false;
   for (auto user : op->getUsers()) {
-    if (coarseSchedule.count(user) == 0) {
+    // Let wait barriers be scheduled based on the stage of async op it waits
+    // for.
+    if (!isa<ttng::WaitBarrierOp>(user) && coarseSchedule.count(user) == 0) {
       changed = true;
       coarseSchedule.insert(user, stage, cluster);
       insertUsersOfOp(coarseSchedule, user, stage, cluster);


### PR DESCRIPTION
Previous approach for scheduling pre-existing `wait_barrier`s in mmav5 pipelining relies on checking which async ops are they waiting for, and scheduling them to the same stage. This however won't work, if we'll schedule wait to some random stage based on the stage it's operands are scheduled to.