### PR TITLE
[BACKEND] Don't allocate shmem for warps with repeated data in tt.scan

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -267,7 +267,7 @@ bool ScanLoweringHelper::isSupported() {
 }
 
 unsigned ScanLoweringHelper::getScratchSizeInElems() {
-  unsigned numWarps = lookupNumWarps(scanOp);
+  unsigned numWarps = product(getEncoding().getWarpsPerCTA());
   unsigned numNonAxisElementsPerWarp =
       getNonAxisNumThreadsPerWarp() * getNonAxisNumElementsPerThread();
   unsigned numElements = numWarps * numNonAxisElementsPerWarp *

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -617,13 +617,12 @@ tt.func @call_graph_2(%A : !tt.ptr<f16>, %cond : i1) {
 
 // CHECK-LABEL: scan_alloc
 tt.func @scan_alloc(%x : tensor<8x16xf32, #AL>) {
-  // CHECK: offset = 0, size = 512
+  // CHECK: offset = 0, size = 128
   %a = "tt.scan"(%x) <{axis = 0 : i32, reverse = false}>({
   ^bb0(%arg0: f32, %arg1: f32):
     %add = arith.addf %arg0, %arg1 : f32
     tt.scan.return %add : f32
   }) : (tensor<8x16xf32, #AL>) -> tensor<8x16xf32, #AL>
-  // CHECK-NEXT: virtual offset = 0, size = 1024
   tt.return
 }
 }

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -615,4 +615,15 @@ tt.func @call_graph_2(%A : !tt.ptr<f16>, %cond : i1) {
   // CHECK-NEXT: size = 1024
 }
 
+// CHECK-LABEL: scan_alloc
+tt.func @scan_alloc(%x : tensor<8x16xf32, #AL>) {
+  // CHECK: offset = 0, size = 512
+  %a = "tt.scan"(%x) <{axis = 0 : i32, reverse = false}>({
+  ^bb0(%arg0: f32, %arg1: f32):
+    %add = arith.addf %arg0, %arg1 : f32
+    tt.scan.return %add : f32
+  }) : (tensor<8x16xf32, #AL>) -> tensor<8x16xf32, #AL>
+  // CHECK-NEXT: virtual offset = 0, size = 1024
+  tt.return
+}
 }


### PR DESCRIPTION
It turns out that the previous changes within reduce to support LLs had
already trimmed its shmem memory use to the right size.
