### PR TITLE
[AMD] Add MLIR Remark Messages when the Ping Pong Scheduler Succeeds

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -472,7 +472,7 @@ void Pingponger::getDotPingponged() {
     // centric pingpong scheduling.
     if (tileSize <= smallTile && tileSize >= minTile) {
       transformOnePPClusters(builder, loc);
-      LDBG("Successfully performed One Ping Pong Cluster Transformation.");
+      LDBG("Successfully performed one ping pong cluster transformation.");
     }
     // numWarps=4 doesn't need asymmetric sync, return.
     return;
@@ -483,14 +483,14 @@ void Pingponger::getDotPingponged() {
     if (tileSize == mediumTile) {
       if (transformTwoPPClusters(builder, dotOps[0]->getLoc()).failed())
         return;
-      LDBG("Successfully performed Two Ping Pong Cluster Transformation.");
+      LDBG("Successfully performed two ping pong cluster transformation.");
     } else if (tileSize >= largeTile) {
       // Avoid known register spilling. i.e., mfma16x16x16 & largetile & kpack>1
       if (intShape[0] == 16 && intShape[1] == 16 && kWidth == 8)
         return;
       if (transformFourPPClusters(builder, dotOps[0]->getLoc()).failed())
         return;
-      LDBG("Successfully performed Four Ping Pong Cluster Transformation.");
+      LDBG("Successfully performed four ping pong cluster transformation.");
     } else
       return;
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -13,6 +13,7 @@
 #include "TritonAMDGPUTransforms/Passes.h"
 
 #define DEBUG_TYPE "tritonamdgpu-block-pingpong"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 using namespace mlir;
@@ -471,7 +472,7 @@ void Pingponger::getDotPingponged() {
     // centric pingpong scheduling.
     if (tileSize <= smallTile && tileSize >= minTile) {
       transformOnePPClusters(builder, loc);
-      LDBG("Successfully performed One Ping Pong Cluster Transformation.")
+      LDBG("Successfully performed One Ping Pong Cluster Transformation.");
     }
     // numWarps=4 doesn't need asymmetric sync, return.
     return;
@@ -482,14 +483,14 @@ void Pingponger::getDotPingponged() {
     if (tileSize == mediumTile) {
       if (transformTwoPPClusters(builder, dotOps[0]->getLoc()).failed())
         return;
-      LDBG("Successfully performed Two Ping Pong Cluster Transformation.")
+      LDBG("Successfully performed Two Ping Pong Cluster Transformation.");
     } else if (tileSize >= largeTile) {
       // Avoid known register spilling. i.e., mfma16x16x16 & largetile & kpack>1
       if (intShape[0] == 16 && intShape[1] == 16 && kWidth == 8)
         return;
       if (transformFourPPClusters(builder, dotOps[0]->getLoc()).failed())
         return;
-      LDBG("Successfully performed Four Ping Pong Cluster Transformation.")
+      LDBG("Successfully performed Four Ping Pong Cluster Transformation.");
     } else
       return;
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -137,8 +137,9 @@ void Pingponger::transformOnePPClusters(OpBuilder &builder, Location loc) {
 
   // Dot cluster #0
   updateOpInsertion(preDotBar);
-  dotOps[0]->emitRemark() << "Performed one ping pong cluster transformation\n";
   appendOpWithPrio(builder, dotOps[0], loc);
+  // Add a remark for user feedback
+  dotOps[0]->emitRemark() << "Performed one ping pong cluster transformation\n";
 }
 
 void Pingponger::genOffsetConstants(Location loc, OpBuilder &builder,
@@ -273,8 +274,6 @@ LogicalResult Pingponger::transformFourPPClusters(OpBuilder &builder,
   appendClusterBarrier(builder, loc);
 
   // dot0 (1/4)
-  dotSliceOps[0]->emitRemark()
-      << "Performed four ping pong cluster transformation\n";
   appendOpWithPrio(builder, dotSliceOps[0], loc);
   appendClusterBarrier(builder, loc);
 
@@ -304,6 +303,9 @@ LogicalResult Pingponger::transformFourPPClusters(OpBuilder &builder,
   appendOpWithPrio(builder, dotSliceOps[3], loc);
   appendClusterBarrier(builder, loc);
 
+  // Add a remark for user feedback
+  dotSliceOps[0]->emitRemark()
+      << "Performed four ping pong cluster transformation\n";
   return success();
 }
 
@@ -336,8 +338,6 @@ LogicalResult Pingponger::transformTwoPPClusters(OpBuilder &builder,
   appendOp(builder.create<ROCDL::SchedBarrier>(loc, 0));
 
   // dot0 (1/2)
-  dotSliceOps[0]->emitRemark()
-      << "Performed two ping pong cluster transformation\n";
   appendOpWithPrio(builder, dotSliceOps[0], loc);
   appendClusterBarrier(builder, loc);
 
@@ -351,6 +351,9 @@ LogicalResult Pingponger::transformTwoPPClusters(OpBuilder &builder,
   appendOpWithPrio(builder, dotSliceOps[1], loc);
   appendClusterBarrier(builder, loc);
 
+  // Add a remark for user feedback
+  dotSliceOps[0]->emitRemark()
+      << "Performed two ping pong cluster transformation\n";
   return success();
 }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -12,6 +12,7 @@
 #define GEN_PASS_CLASSES
 #include "TritonAMDGPUTransforms/Passes.h"
 
+#define DEBUG_TYPE "tritonamdgpu-block-pingpong"
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 using namespace mlir;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -237,11 +237,11 @@ LogicalResult Pingponger::sliceDot(OpBuilder &builder, Location loc,
 }
 
 // Transform a loop into four Dot - Memory (ping - pong) clusters
-// This transfrom is useful when the original dot tile is too large that there's
-// no enough register to hold data for a Dot cluster. This path slices the dot
+// This transform is useful when the original dot tile is too large that there's
+// not enough registers to hold data for a Dot cluster. This path slices the dot
 // into four pieces and pair with four clusters of reordered memory operations.
 // There are multiple guards at the boundary of each cluster.
-// (1) sched.barrier : with mask0 to prevent compiler backed from reroder
+// (1) sched.barrier : with mask0 to prevent compiler backed from reordering
 //  instructions across the boundary
 // (2) gpu.barrier : ensures asymmetric synchronization at each point
 // (3) setprio (1->0) : in order to avoid incomming warp overtaking resource

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -137,7 +137,7 @@ void Pingponger::transformOnePPClusters(OpBuilder &builder, Location loc) {
 
   // Dot cluster #0
   updateOpInsertion(preDotBar);
-  dotOps[0].emitRemark() << "Performed one ping pong cluster transformation\n";
+  dotOps[0]->emitRemark() << "Performed one ping pong cluster transformation\n";
   appendOpWithPrio(builder, dotOps[0], loc);
 }
 
@@ -273,7 +273,8 @@ LogicalResult Pingponger::transformFourPPClusters(OpBuilder &builder,
   appendClusterBarrier(builder, loc);
 
   // dot0 (1/4)
-  dotSliceOps[0].emitRemark() << "Performed four ping pong cluster transformation\n";
+  dotSliceOps[0]->emitRemark()
+      << "Performed four ping pong cluster transformation\n";
   appendOpWithPrio(builder, dotSliceOps[0], loc);
   appendClusterBarrier(builder, loc);
 
@@ -335,7 +336,8 @@ LogicalResult Pingponger::transformTwoPPClusters(OpBuilder &builder,
   appendOp(builder.create<ROCDL::SchedBarrier>(loc, 0));
 
   // dot0 (1/2)
-  dotSliceOps[0].emitRemark() << "Performed two ping pong cluster transformation\n";
+  dotSliceOps[0]->emitRemark()
+      << "Performed two ping pong cluster transformation\n";
   appendOpWithPrio(builder, dotSliceOps[0], loc);
   appendClusterBarrier(builder, loc);
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

I recently did some benchmarking work where I was investigating the impact of the Ping Pong Scheduler on various Triton kernels. One issue that I hit was determining when the Ping Pong Scheduler was actually running and I found myself needing to check the source code and manually verify the code path (by both manually doing calculations and inserting print statements).

Having a Remark in my logs that could clearly indicate that the which ping pong cluster has occurred would be extremely helpful for validating that I am using the Ping Pong Scheduler.

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because its just a logging message.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
