### PR TITLE
Revert "[FRONTEND] Throw an error when we would downcast an integral constant to a dtype it does not fit in"

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -318,18 +318,6 @@ def test_empty_kernel(dtype_x, device):
     kernel[(1, )](x, SIZE=SIZE, num_warps=4)
 
 
-def test_scalar_overflow(device):
-
-    @triton.jit
-    def kernel():
-        huge_int: tl.constexpr = 0xFFFFFFFFFFFFFF
-        x = tl.full((), 32, dtype=tl.int32)
-        y = x + huge_int
-
-    with pytest.raises(triton.TritonError, match="out of range"):
-        kernel[(1, )]()
-
-
 # generic test functions
 def _test_unary(dtype_x, expr, numpy_expr=None, device='cuda', num_ctas=1):
     check_type_supported(dtype_x, device)  # early return if dtype_x is not supported

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -186,11 +186,6 @@ def binary_op_type_checking_impl(lhs: tl.tensor | numbers.Number, rhs: tl.tensor
                 or rhs_is_scalar and rhs_scalar < 0 and ret_sca_ty.is_int_unsigned()):
             raise ValueError("Cannot perform a binary operation between an unsigned tensor and a negative scalar. "
                              "Perform a explicit cast on one of them.")
-        if ret_sca_ty.is_int():
-            if lhs_is_scalar and not (ret_sca_ty.get_int_min_value() <= lhs_scalar <= ret_sca_ty.get_int_max_value()):
-                raise ValueError(f"Scalar {lhs_scalar} is out of range for type {ret_sca_ty}")
-            if rhs_is_scalar and not (ret_sca_ty.get_int_min_value() <= rhs_scalar <= ret_sca_ty.get_int_max_value()):
-                raise ValueError(f"Scalar {rhs_scalar} is out of range for type {ret_sca_ty}")
         lhs = full(
             (), lhs_scalar, dtype=ret_sca_ty, builder=builder) if lhs_is_scalar else cast(lhs, ret_sca_ty, builder)
         rhs = full(


### PR DESCRIPTION
This breaks backward compatibility a bit too aggressively, we should probably start with a warning.
Reverts triton-lang/triton#5866