### PR TITLE
[LAYOUTS] Make operator* associative and dimension-order-preserving

### DIFF
--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -93,6 +93,12 @@ SmallVector<StringAttr> standardOutDimNames(MLIRContext *ctx, int rank);
 LinearLayout identityStandardND(StringAttr inDimName, ArrayRef<unsigned> shape,
                                 ArrayRef<unsigned> order);
 
+// Compute the supremum of two lists.
+// Error out if the supremum does not exist (e.g. [a, b] and [b, a]).
+// If the supremum is not unique, we return the first list first
+// (e.g. [a, b], [a, c] -> [a, b, c]).
+SmallVector<StringAttr> supremum(const SmallVector<StringAttr> &x,
+                                 const SmallVector<StringAttr> &y);
 } // namespace mlir::triton
 
 #endif // TRITON_TOOLS_LAYOUTUTILS_H

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -550,9 +550,13 @@ public:
   // from a larger one.
   [[nodiscard]] LinearLayout concatOuts(const LinearLayout &other) const;
 
-  // Creates a new layout which, roughly speaking, is equivalent to one where
-  // every element of the `outer` layout is replaced by a full instance of the
-  // `inner` layout.
+  // Computes the direct sum of two layouts.
+  // https://en.wikipedia.org/wiki/Direct_sum#Direct_sum_of_matrices
+  //
+  // Roughly speaking, the first layout acts on the first part of the input
+  // dimensions, and the second layout acts on the second part.
+  // In other words, it's the generalisation of concatenation of the inputs
+  // to linear maps.
   //
   // Examples:
   //
@@ -572,19 +576,27 @@ public:
   //
   //    - identity1D(4, "i", "o") * identity1D(2, "i", "o") ==
   //      identity1D(8, "i", "o")
+  //      The output matrix is [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
   //
   //    - identity1D(4, "i", "o") * zeros1D(2, "i", "o") => L(x) = x % 4
   //      for x in [0,8).
+  //      The output matrix is [[1, 0, 0], [0, 1, 0], [0, 0, 0]]
   //
   //    - zeros1D(2, "i", "o") * identity1D(4, "i", "o") => L(x) = x / 2
   //      for x in [0,8).
-  //
+  //      The output matrix is [[0, 0, 0], [0, 1, 0], [0, 0, 1]]
+
   //    - identity1D(4, "i", "o1") * identity1D(8, "i", "o2") =>
   //      L(x) = (x % 4, x / 4) for x in [0,32).
+  //      The output dims are ("o1", "o2") in that order.
   //
-  // Notice that this operation is not commutative.  It's also not associative.
-  // TODO(jlebar): Can I modify the definition to make it associative?  Pretty
-  // confusing if not.  If I can't, add an example.
+  // If the input (or output) dims of the layouts are not the same, we take
+  // the supremum of the two ordered lists with the inclusion, respecting the
+  // order. If multiple suprema exist, we bias towards the first list.
+  // e.g. sup([a, b], [a, c]) = [a, b, c], sup([a, b], [b, c]) = [a, b, c]
+  //      sup([a, b], [b, a]) = error! Supremum does not exist.
+  //
+  // Notice that this operation is not commutative, but it is associative.
   //
   // Requires: Any in/out dimensions which are in both outer and inner appear in
   // the same relative order.

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2880,9 +2880,6 @@ struct TritonGPUInferLayoutInterface
     if (fwdInference) {
       auto split = LinearLayout::identity1D(2, kRegister, outDims[axis]);
       newLl = split * ll;
-      // FIXME!!!!
-      // operator* transposes the output dimensions??!! WTF
-      newLl = newLl.transposeOuts(outDims);
     } else {
       // TODO This requires a division algorithm!
       // Implement manually ll.divideLeft(split)


### PR DESCRIPTION
To do so, we compute the supremum on the POSET of ordered strings 
without repetition ordered via the inclusion and 
error out if it does not exist. We break ties to the left.

We do this as this is the natural order for the output dims.
