### PR TITLE
[FRONTEND] Fix default values of `tl.range`

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6554,7 +6554,7 @@ def test_static_range(device):
 
 
 @pytest.mark.interpreter
-def test_tl_range(device):
+def test_tl_range_num_stages(device):
     if is_hip():
         pytest.skip("test_tl_range is not supported in HIP")
     M, N, K = 64, 64, 512
@@ -6594,6 +6594,18 @@ def test_tl_range_fuse():
     compiled_kernel = kernel.warmup(10, grid=(1, ))
     assert "tt.flatten" in compiled_kernel.asm["ttir"]
     assert compiled_kernel.asm["ttgir"].count("scf.for") == 1
+
+
+def test_tl_range_option_none():
+
+    @triton.jit
+    def kernel(ub):
+        for i in tl.range(0, ub, num_stages=None, loop_unroll_factor=None):
+            print("i", i)
+
+    compiled_kernel = kernel.warmup(10, grid=(1, ))
+    assert "num_stages" not in compiled_kernel.asm["ttir"]
+    assert "loop_unroll_factor" not in compiled_kernel.asm["ttir"]
 
 
 @triton.jit(noinline=True)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1008,10 +1008,10 @@ class CodeGenerator(ast.NodeVisitor):
             lb = iterator.start
             ub = iterator.end
             step = iterator.step
-            num_stages = iterator.num_stages.value
-            loop_unroll_factor = iterator.loop_unroll_factor.value
-            disallow_acc_multi_buffer = iterator.disallow_acc_multi_buffer.value
-            flatten = iterator.flatten.value
+            num_stages = _unwrap_if_constexpr(iterator.num_stages)
+            loop_unroll_factor = _unwrap_if_constexpr(iterator.loop_unroll_factor)
+            disallow_acc_multi_buffer = _unwrap_if_constexpr(iterator.disallow_acc_multi_buffer)
+            flatten = _unwrap_if_constexpr(iterator.flatten)
         elif IteratorClass is range:
             # visit iterator arguments
             # note: only `range` iterator is supported now

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -999,7 +999,7 @@ class CodeGenerator(ast.NodeVisitor):
         num_stages = None
         loop_unroll_factor = None
         disallow_acc_multi_buffer = False
-        flatten = None
+        flatten = False
         if IteratorClass is language.range:
             iterator = IteratorClass(*iter_args, **iter_kwargs)
             # visit iterator arguments
@@ -1008,10 +1008,10 @@ class CodeGenerator(ast.NodeVisitor):
             lb = iterator.start
             ub = iterator.end
             step = iterator.step
-            num_stages = iterator.num_stages
-            loop_unroll_factor = iterator.loop_unroll_factor
-            disallow_acc_multi_buffer = iterator.disallow_acc_multi_buffer
-            flatten = iterator.flatten
+            num_stages = iterator.num_stages.value
+            loop_unroll_factor = iterator.loop_unroll_factor.value
+            disallow_acc_multi_buffer = iterator.disallow_acc_multi_buffer.value
+            flatten = iterator.flatten.value
         elif IteratorClass is range:
             # visit iterator arguments
             # note: only `range` iterator is supported now

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1008,10 +1008,10 @@ class CodeGenerator(ast.NodeVisitor):
             lb = iterator.start
             ub = iterator.end
             step = iterator.step
-            num_stages = _unwrap_if_constexpr(iterator.num_stages)
-            loop_unroll_factor = _unwrap_if_constexpr(iterator.loop_unroll_factor)
-            disallow_acc_multi_buffer = _unwrap_if_constexpr(iterator.disallow_acc_multi_buffer)
-            flatten = _unwrap_if_constexpr(iterator.flatten)
+            num_stages = iterator.num_stages
+            loop_unroll_factor = iterator.loop_unroll_factor
+            disallow_acc_multi_buffer = iterator.disallow_acc_multi_buffer
+            flatten = iterator.flatten
         elif IteratorClass is range:
             # visit iterator arguments
             # note: only `range` iterator is supported now
@@ -1082,9 +1082,9 @@ class CodeGenerator(ast.NodeVisitor):
             init_handles = [a._flatten_ir() for a in init_args]
             init_handles_spec, init_handles_flat = list_list_flatten(init_handles)
             for_op = self.builder.create_for_op(lb, ub, step, init_handles_flat)
-            if num_stages is not None:
+            if _unwrap_if_constexpr(num_stages) is not None:
                 for_op.set_attr("tt.num_stages", self.builder.get_int32_attr(num_stages))
-            if loop_unroll_factor is not None:
+            if _unwrap_if_constexpr(loop_unroll_factor) is not None:
                 for_op.set_attr("tt.loop_unroll_factor", self.builder.get_int32_attr(loop_unroll_factor))
             if disallow_acc_multi_buffer:
                 for_op.set_attr("tt.disallow_acc_multi_buffer", self.builder.get_unit_attr())

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2884,10 +2884,10 @@ class range:
         else:
             self.start = arg1
             self.end = arg2
-        self.num_stages = constexpr(num_stages)
-        self.loop_unroll_factor = constexpr(loop_unroll_factor)
-        self.disallow_acc_multi_buffer = constexpr(disallow_acc_multi_buffer)
-        self.flatten = constexpr(flatten)
+        self.num_stages = num_stages
+        self.loop_unroll_factor = loop_unroll_factor
+        self.disallow_acc_multi_buffer = disallow_acc_multi_buffer
+        self.flatten = flatten
 
     def __iter__(self):
         raise RuntimeError("tl.range can only be used in @triton.jit'd functions")

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2873,7 +2873,7 @@ class range:
     """
 
     def __init__(self, arg1, arg2=None, step=None, num_stages=None, loop_unroll_factor=None,
-                 disallow_acc_multi_buffer=False, flatten=None):
+                 disallow_acc_multi_buffer=False, flatten=False):
         if step is None:
             self.step = constexpr(1)
         else:
@@ -2884,10 +2884,10 @@ class range:
         else:
             self.start = arg1
             self.end = arg2
-        self.num_stages = num_stages
-        self.loop_unroll_factor = loop_unroll_factor
-        self.disallow_acc_multi_buffer = disallow_acc_multi_buffer
-        self.flatten = flatten
+        self.num_stages = constexpr(num_stages)
+        self.loop_unroll_factor = constexpr(loop_unroll_factor)
+        self.disallow_acc_multi_buffer = constexpr(disallow_acc_multi_buffer)
+        self.flatten = constexpr(flatten)
 
     def __iter__(self):
         raise RuntimeError("tl.range can only be used in @triton.jit'd functions")


### PR DESCRIPTION
`num_stages` and `loop_unroll_factor`'s default values are `constexpr(None)`, so we should unwrap them before checking `if _num_stages is not None`