### PR TITLE
[Blackwell] Support narrower TMEM messages and shapes

### DIFF
--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1975,7 +1975,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_st
   // CHECK: nvgpu.tensor_memory_base
-  // CHECK: tcgen05.st.sync.aligned.32x32b.x32.b32
+  // CHECK: tcgen05.st.sync.aligned.32x32b.x128.b32
   // CHECK: tcgen05.wait::st.sync.aligned
   tt.func public @tensor_memory_st(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1975,7 +1975,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_st
   // CHECK: nvgpu.tensor_memory_base
-  // CHECK: tcgen05.st.sync.aligned.32x32b.x128.b32
+  // CHECK: tcgen05.st.sync.aligned.32x32b.x32.b32
   // CHECK: tcgen05.wait::st.sync.aligned
   tt.func public @tensor_memory_st(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -121,9 +121,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_ld
   // CHECK: nvgpu.tensor_memory_base
-  // CHECK: tcgen05.st.sync.aligned.32x32b.x128.b32
+  // CHECK: tcgen05.st.sync.aligned.32x32b.x32.b32
   // CHECK: tcgen05.wait::st.sync.aligned
-  // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "tcgen05.ld.sync.aligned.32x32b.x128.b32 {$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, $66, $67, $68, $69, $70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, $86, $87, $88, $89, $90, $91, $92, $93, $94, $95, $96, $97, $98, $99, $100, $101, $102, $103, $104, $105, $106, $107, $108, $109, $110, $111, $112, $113, $114, $115, $116, $117, $118, $119, $120, $121, $122, $123, $124, $125, $126, $127}, [$128];", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,r" %{{.*}} : (i32) -> !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+  // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "tcgen05.ld.sync.aligned.32x32b.x32.b32 {$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31}, [$32];", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,r" %285 : (i32) -> !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
   // CHECK: tcgen05.wait::ld.sync.aligned
   tt.func public @tensor_memory_ld(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -153,11 +153,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_ld_m64
   // CHECK: nvgpu.tensor_memory_base
-  // CHECK: tcgen05.st.sync.aligned.16x32bx2.x64.b32
-  // CHECK: tcgen05.st.sync.aligned.16x32bx2.x64.b32
+  // CHECK: tcgen05.st.sync.aligned.16x32bx2.x32.b32
+  // CHECK: tcgen05.st.sync.aligned.16x32bx2.x32.b32
   // CHECK: tcgen05.wait::st.sync.aligned
-  // CHECK: tcgen05.ld.sync.aligned.16x32bx2.x64.b32
-  // CHECK: tcgen05.ld.sync.aligned.16x32bx2.x64.b32
+  // CHECK: tcgen05.ld.sync.aligned.16x32bx2.x32.b32
+  // CHECK: tcgen05.ld.sync.aligned.16x32bx2.x32.b32
   // CHECK: tcgen05.wait::ld.sync.aligned
   tt.func public @tensor_memory_ld_m64(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -175,9 +175,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_unpack_f16
   // CHECK: nvgpu.tensor_memory_base
-  // CHECK: tcgen05.st.sync.aligned.32x32b.x64.unpack::16b.b32
+  // CHECK: tcgen05.st.sync.aligned.32x32b.x32.unpack::16b.b32
   // CHECK: tcgen05.wait::st.sync.aligned
-  // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "tcgen05.ld.sync.aligned.32x32b.x64.pack::16b.b32 {$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63}, [$64];", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,r" %{{.*}} : (i32) -> !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+  // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "tcgen05.ld.sync.aligned.32x32b.x32.pack::16b.b32 {$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31}, [$32];", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,r" %{{.*}} : (i32) -> !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
   // CHECK: tcgen05.wait::ld.sync.aligned
   tt.func public @tensor_memory_unpack_f16() {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #blocked1>

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -121,9 +121,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_ld
   // CHECK: nvgpu.tensor_memory_base
-  // CHECK: tcgen05.st.sync.aligned.32x32b.x32.b32
+  // CHECK: tcgen05.st.sync.aligned.32x32b.x128.b32
   // CHECK: tcgen05.wait::st.sync.aligned
-  // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "tcgen05.ld.sync.aligned.32x32b.x32.b32 {$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31}, [$32];", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,r" %285 : (i32) -> !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+  // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "tcgen05.ld.sync.aligned.32x32b.x128.b32 {$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, $66, $67, $68, $69, $70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, $86, $87, $88, $89, $90, $91, $92, $93, $94, $95, $96, $97, $98, $99, $100, $101, $102, $103, $104, $105, $106, $107, $108, $109, $110, $111, $112, $113, $114, $115, $116, $117, $118, $119, $120, $121, $122, $123, $124, $125, $126, $127}, [$128];", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,r" %{{.*}} : (i32) -> !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
   // CHECK: tcgen05.wait::ld.sync.aligned
   tt.func public @tensor_memory_ld(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -153,11 +153,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_ld_m64
   // CHECK: nvgpu.tensor_memory_base
-  // CHECK: tcgen05.st.sync.aligned.16x32bx2.x32.b32
-  // CHECK: tcgen05.st.sync.aligned.16x32bx2.x32.b32
+  // CHECK: tcgen05.st.sync.aligned.16x32bx2.x64.b32
+  // CHECK: tcgen05.st.sync.aligned.16x32bx2.x64.b32
   // CHECK: tcgen05.wait::st.sync.aligned
-  // CHECK: tcgen05.ld.sync.aligned.16x32bx2.x32.b32
-  // CHECK: tcgen05.ld.sync.aligned.16x32bx2.x32.b32
+  // CHECK: tcgen05.ld.sync.aligned.16x32bx2.x64.b32
+  // CHECK: tcgen05.ld.sync.aligned.16x32bx2.x64.b32
   // CHECK: tcgen05.wait::ld.sync.aligned
   tt.func public @tensor_memory_ld_m64(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -175,9 +175,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_unpack_f16
   // CHECK: nvgpu.tensor_memory_base
-  // CHECK: tcgen05.st.sync.aligned.32x32b.x32.unpack::16b.b32
+  // CHECK: tcgen05.st.sync.aligned.32x32b.x64.unpack::16b.b32
   // CHECK: tcgen05.wait::st.sync.aligned
-  // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "tcgen05.ld.sync.aligned.32x32b.x32.pack::16b.b32 {$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31}, [$32];", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,r" %{{.*}} : (i32) -> !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
+  // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "tcgen05.ld.sync.aligned.32x32b.x64.pack::16b.b32 {$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63}, [$64];", "=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,=r,r" %{{.*}} : (i32) -> !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>
   // CHECK: tcgen05.wait::ld.sync.aligned
   tt.func public @tensor_memory_unpack_f16() {
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #blocked1>
@@ -338,6 +338,33 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     i1,
     i1,
     !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 256], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, unpacked = true>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tensor_memory_ld_128x256
+  // CHECK: tcgen05.st.sync.aligned.32x32b.x64.b32
+  // CHECK: tcgen05.st.sync.aligned.32x32b.x64.b32
+  // CHECK: tcgen05.st.sync.aligned.32x32b.x64.b32
+  // CHECK: tcgen05.st.sync.aligned.32x32b.x64.b32
+  // CHECK: tcgen05.wait::st.sync.aligned
+  // CHECK: tcgen05.ld.sync.aligned.32x32b.x64.b32
+  // CHECK: tcgen05.ld.sync.aligned.32x32b.x64.b32
+  // CHECK: tcgen05.ld.sync.aligned.32x32b.x64.b32
+  // CHECK: tcgen05.ld.sync.aligned.32x32b.x64.b32
+  // CHECK: tcgen05.wait::ld.sync.aligned
+  tt.func public @tensor_memory_ld_128x256(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked1>
+    %0 = ttng.tmem_alloc %cst_0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x256xf32, #blocked1>) -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+    %20 = ttng.tmem_load %0 : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked1>
     tt.return
   }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -12,8 +12,61 @@ using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
 
-static const int largestTmemLoadStore = 128;
+// The maximum number of registers that can be accessed by a single message
+// regardless of shape or repetitions
+static constexpr int largestTmemLoadStore = 128;
+// Factor used to intentionally narrow contiguous tmem access down from
+// the maximum message width to avoid register pressure
+static constexpr int narrowingFactor = 4;
+
 namespace {
+
+// Tensor memory access traits, currently only 32b is used
+template <bool IsStrided> struct TMemAccess32b {
+  static constexpr int opBitWidth = 32;
+  static constexpr int colsPerThread = 1;
+  static constexpr int rowsPerThread = 1;
+  static constexpr const char *opShape = IsStrided ? "16x32bx2" : "32x32b";
+  static constexpr bool usesSecondHalfOffset = IsStrided;
+};
+
+struct TMemAccess256b {
+  static constexpr int opBitWidth = 256;
+  static constexpr int colsPerThread = 2;
+  static constexpr int rowsPerThread = 2;
+  static constexpr char opShape[] = "16x256b";
+};
+
+template <typename TMemAccess> struct TMemMessage {
+  using traits = TMemAccess;
+  static constexpr int opBitWidth = TMemAccess::opBitWidth;
+  static constexpr int colsPerThread = TMemAccess::colsPerThread;
+  static constexpr int rowsPerThread = TMemAccess::rowsPerThread;
+  static constexpr int numThreadsPerWarp = 32;
+  static constexpr int maxNumRepeats =
+      largestTmemLoadStore / (colsPerThread * rowsPerThread);
+  static constexpr int maxColsPerMessage = (opBitWidth / 32) * maxNumRepeats;
+  static constexpr int rowsPerMessage = numThreadsPerWarp / rowsPerThread;
+  static constexpr int colsPerMessage = maxColsPerMessage / narrowingFactor;
+};
+
+struct TMemRuntimeInfo {
+  static constexpr int numRowsPerWarp = 32;
+  int numWarps;
+  int numWarpGroups;
+  int numElementsPer32B;
+  int numElements;
+  int numCols;
+  int blockM;
+  int blockN;
+  bool unpackedb16;
+  bool useStridedMessage;
+  int numBlocks;
+  int numWarpGroupsPerBlock;
+  bool blocksInterleaved;
+  int numColsPerBlock;
+  int colsPerWarpGroup;
+};
 
 SmallVector<Value> packToI32(const SmallVector<Value> &values, Location loc,
                              ConversionPatternRewriter &rewriter) {
@@ -38,143 +91,170 @@ SmallVector<Value> packToI32(const SmallVector<Value> &values, Location loc,
   return packedValues;
 }
 
-// Helper to compute how many registers are needed to load/store `numCols` Tmem
-// coloumns.
-int getNum32BRegs(int rowsPerMessage, bool unpackedb16, int numElementsPer32B,
-                  int numCols) {
+int getNum32BRegs(bool unpackedb16, int numElementsPer32B, int numCols) {
   int numRegPerMessage = numCols;
-  if (rowsPerMessage == 16)
-    numRegPerMessage = numRegPerMessage / 2;
   if (unpackedb16)
     numRegPerMessage = numRegPerMessage / numElementsPer32B;
   return numRegPerMessage;
 }
 
-// Map the distributed layout onto the tmem. Calculate the address and emit one
-// or more tmem messages.
-void calculateAddressAndEmitTmemMessage(
-    Location loc, Operation *op, Value baseAddress, RankedTensorType tensorType,
-    MemDescType memType, ConversionPatternRewriter &rewriter,
-    const std::function<void(Value /*startAddress*/,
-                             int /*secondHalfColOffset*/, bool /*unpackedb16*/,
-                             int /*regsPerMessage*/,
-                             bool /*useStridedMessage*/)> &createMemoryOp) {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-  const int numRowsPerWarp = 32;
-
+TMemRuntimeInfo getTMemRuntimeInfo(Operation *op, RankedTensorType tensorType,
+                                   MemDescType memType) {
+  TMemRuntimeInfo info;
+  static_assert(TMemRuntimeInfo::numRowsPerWarp == 32,
+                "A single warp must access exactly 32 rows of tmem");
   assert(
       nvidia_gpu::isDistributedLayoutTMemCompatible(op, tensorType, memType) &&
       "unsupported distributed layout for tensor memory");
 
-  int numWarps = triton::gpu::lookupNumWarps(op);
-  assert(numWarps % 4 == 0);
-  int numWarpGroups = numWarps / 4;
-  int numElementsPer32B = 32 / tensorType.getElementTypeBitWidth();
+  info.numWarps = triton::gpu::lookupNumWarps(op);
+  assert(info.numWarps % 4 == 0 && "Unexpected number of warps");
+  info.numWarpGroups = info.numWarps / 4;
+  info.numElementsPer32B = 32 / tensorType.getElementTypeBitWidth();
   auto shapePerCTA = mlir::triton::gpu::getShapePerCTA(tensorType);
-  int numElements = product(shapePerCTA);
+  info.numElements = product(shapePerCTA);
+
   triton::nvidia_gpu::TMemAllocation tmemAlloc =
       triton::nvidia_gpu::getTmemAllocSizes(memType);
-  int numCols = tmemAlloc.numCols;
-  int blockM = 0;
-  int blockN = 0;
-  bool unpackedb16 = false;
+  info.numCols = tmemAlloc.numCols;
+
+  info.blockM = 0;
+  info.blockN = 0;
+  info.unpackedb16 = false;
   if (auto attr = dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
           memType.getEncoding())) {
-    blockM = attr.getBlockM();
-    blockN = attr.getBlockN();
-    assert((!attr.getUnpacked() || numElementsPer32B <= 2) &&
+    info.blockM = attr.getBlockM();
+    info.blockN = attr.getBlockN();
+    assert((!attr.getUnpacked() || info.numElementsPer32B <= 2) &&
            "unsupported unpacked layout");
-    unpackedb16 = attr.getUnpacked() && numElementsPer32B == 2;
+    info.unpackedb16 = attr.getUnpacked() && (info.numElementsPer32B == 2);
   } else {
     assert(isa<triton::nvidia_gpu::TensorMemoryScalesEncodingAttr>(
                memType.getEncoding()) &&
            "Expecting a tensor memory encoding attribute");
-    blockM = 128;
-    blockN = 32;
+    info.blockM = 128;
+    info.blockN = 32;
   }
 
-  int numBlocks = ceil<int>(numElements, blockM * blockN);
-  bool useStridedMessage = blockM == 64;
-  int numWarpGroupsPerBlock = ceil<int>(numWarpGroups, numBlocks);
+  info.useStridedMessage = (info.blockM == 64);
 
-  bool blocksInterleaved = numBlocks > 1 && blockM == 64;
-  int numColsPerBlock = numCols / numBlocks;
-  if (blocksInterleaved)
-    // We pack two blocks in the same column group of tmem.
-    numColsPerBlock *= 2;
+  info.numBlocks = ceil<int>(info.numElements, info.blockM * info.blockN);
+  info.numWarpGroupsPerBlock = ceil<int>(info.numWarpGroups, info.numBlocks);
+  info.blocksInterleaved = (info.numBlocks > 1 && info.useStridedMessage);
+  info.numColsPerBlock = info.numCols / info.numBlocks;
+  info.colsPerWarpGroup = info.numCols / info.numWarpGroups;
+  // If more than one warp group processes the same block,
+  // then fewer columns must be processed per message per warp group
+  info.numColsPerBlock /= info.numWarpGroupsPerBlock;
 
+  if (info.blocksInterleaved) {
+    info.numColsPerBlock *= 2;
+  }
+
+  return info;
+}
+
+template <typename TMemMsgT>
+void calculateAddressAndEmitTmemMessage(
+    Location loc, Value baseAddress, TMemRuntimeInfo info,
+    ConversionPatternRewriter &rewriter,
+    const std::function<void(Value, int, bool, int, bool, int)>
+        &createMemoryOp) {
+
+  TritonLLVMOpBuilder b(loc, rewriter);
   Value warpId = rewriter.create<nvgpu::WarpIdOp>(loc);
   Value warpIdInGroup = b.urem(warpId, b.i32_val(4));
   Value warpGroupId = b.udiv(warpId, b.i32_val(4));
-  Value rowId = b.mul(warpIdInGroup, b.i32_val(numRowsPerWarp));
 
-  int colsPerWarpGroup = numColsPerBlock / numWarpGroupsPerBlock;
+  int numRegs = getNum32BRegs(info.unpackedb16, info.numElementsPer32B,
+                              info.colsPerWarpGroup);
+  if (info.useStridedMessage)
+    numRegs /= 2;
 
-  int rowsPerMessage = blockM == 64 ? 16 : 32;
-  int numRegs = getNum32BRegs(rowsPerMessage, unpackedb16, numElementsPer32B,
-                              colsPerWarpGroup);
+  // If the workload runtime requires fewer registers than the default message
+  // width, use a message width that matches the workload
+  int colsPerMessage = TMemMsgT::colsPerMessage;
+  int numRepeats = colsPerMessage / (TMemMsgT::opBitWidth / 32);
+  int numRegsPerMsg =
+      TMemMsgT::colsPerThread * TMemMsgT::rowsPerThread * numRepeats;
+  numRegsPerMsg = std::min(numRegsPerMsg, numRegs);
+  // Invert the above formulas to calculate the effective runtime message width
+  colsPerMessage = (numRegsPerMsg * (TMemMsgT::opBitWidth / 32)) /
+                   (TMemMsgT::colsPerThread * TMemMsgT::rowsPerThread);
 
-  int numRegsPerMessage = std::min(largestTmemLoadStore, numRegs);
-  int numColsPerMessage = (numColsPerBlock * numRegsPerMessage) / numRegs;
-  if (blockM == 64 && numColsPerMessage > blockN) {
-    numColsPerMessage = blockN;
-    numRegsPerMessage = (numColsPerMessage * numRegs) / numColsPerBlock;
-  }
-
-  for (int block = 0; block < numBlocks; block += numWarpGroups) {
+  // Half as many registers are needed for 16-bit packed elements,
+  // so twice as many columns are accessed per message.
+  colsPerMessage *= info.numElementsPer32B;
+  for (int block = 0; block < info.numBlocks; block += info.numWarpGroups) {
     Value address = b.ptrtoint(i32_ty, baseAddress);
     Value blockId =
         b.add(b.i32_val(block),
-              b.udiv(warpGroupId, b.i32_val(numWarpGroupsPerBlock)));
-    Value blockRowId = rowId;
+              b.udiv(warpGroupId, b.i32_val(info.numWarpGroupsPerBlock)));
     Value warpGroupIdInBlock =
-        b.urem(warpGroupId, b.i32_val(numWarpGroupsPerBlock));
+        b.urem(warpGroupId, b.i32_val(info.numWarpGroupsPerBlock));
     Value startColumnId =
-        b.mul(warpGroupIdInBlock, b.i32_val(colsPerWarpGroup));
-    if (blocksInterleaved) {
+        b.mul(warpGroupIdInBlock, b.i32_val(info.colsPerWarpGroup));
+    Value blockRowId =
+        b.mul(warpIdInGroup, b.i32_val(TMemRuntimeInfo::numRowsPerWarp));
+
+    if (info.blocksInterleaved) {
       Value blockIdIsOdd = b.urem(blockId, b.i32_val(2));
       Value blockIdPrevEven = b.sub(blockId, blockIdIsOdd);
       blockRowId = b.add(blockRowId, b.mul(blockIdIsOdd, b.i32_val(16)));
       startColumnId =
           b.add(startColumnId,
-                b.mul(blockIdPrevEven, b.i32_val(numColsPerBlock / 2)));
+                b.mul(blockIdPrevEven, b.i32_val(info.numColsPerBlock / 2)));
     } else {
       startColumnId =
-          b.add(startColumnId, b.mul(blockId, b.i32_val(numColsPerBlock)));
+          b.add(startColumnId, b.mul(blockId, b.i32_val(info.numColsPerBlock)));
     }
-    address =
-        b.add(b.add(address, b.shl(blockRowId, b.i32_val(16))), startColumnId);
 
-    for (int colStart = 0; colStart < numColsPerBlock;
-         colStart += numColsPerMessage) {
-      Value startAddress = b.add(address, b.i32_val(colStart));
+    // A strided message accesses twice as many columns per message,
+    // thus half as many messages are required
+    int numColumns = info.useStridedMessage ? info.numColsPerBlock / 2
+                                            : info.numColsPerBlock;
+    for (int colStart = 0; colStart < numColumns; colStart += colsPerMessage) {
+      // For messages that span only 16 rows (e.g. 16x256b), multiple messages
+      // are required to cover the entire set of rows per warp.
+      for (int rowStart = 0; rowStart < TMemRuntimeInfo::numRowsPerWarp;
+           rowStart += TMemMsgT::rowsPerMessage) {
+        Value rowOffset = b.add(blockRowId, b.i32_val(rowStart));
+        Value warpGroupAddress =
+            b.add(address, b.shl(rowOffset, b.i32_val(16)));
+        warpGroupAddress = b.add(warpGroupAddress, startColumnId);
 
-      // Column offset of second half of the message in case of 16x32bx2
-      // message.
-      int secondHalfColOffset = useStridedMessage ? colsPerWarpGroup / 2 : 0;
-      createMemoryOp(startAddress, secondHalfColOffset, unpackedb16,
-                     numRegsPerMessage, useStridedMessage);
+        Value msgAddress = b.add(warpGroupAddress, b.i32_val(colStart));
+        int secondHalfColOffset = 0;
+        if (info.useStridedMessage) {
+          // Offset to half way through the set of columns for this warpgroup.
+          secondHalfColOffset = numColumns;
+        }
+        createMemoryOp(msgAddress, secondHalfColOffset, info.unpackedb16,
+                       numRegsPerMsg, info.useStridedMessage,
+                       TMemMsgT::opBitWidth);
+      }
     }
   }
 }
 
-static void createTensorMemoryStore(Location loc, Value address,
-                                    SmallVector<Value> &srcs,
-                                    bool stridedMessage, int secondHalfOffset,
-                                    Value pred, bool unpacked,
-                                    ConversionPatternRewriter &rewriter) {
+template <typename TMemMsgT>
+static void
+createTensorMemoryStore(Location loc, Value address, SmallVector<Value> &srcs,
+                        int secondHalfOffset, Value pred, bool unpacked,
+                        ConversionPatternRewriter &rewriter) {
   PTXBuilder ptxBuilder;
   std::string opcode;
   std::string packedStr = unpacked ? ".unpack::16b" : "";
-  if (stridedMessage) {
-    opcode = "@$0 tcgen05.st.sync.aligned.16x32bx2.x" +
-             std::to_string(srcs.size()) + packedStr + ".b32 [$1], " +
-             std::to_string(secondHalfOffset) + ", {";
+  unsigned numRepeats = srcs.size() / (TMemMsgT::traits::rowsPerThread *
+                                       TMemMsgT::traits::colsPerThread);
+  opcode = "@$0 tcgen05.st.sync.aligned." +
+           std::string(TMemMsgT::traits::opShape) + ".x" +
+           std::to_string(numRepeats) + packedStr;
+  if (secondHalfOffset)
+    opcode += ".b32 [$1], " + std::to_string(secondHalfOffset) + ", {";
+  else
+    opcode += ".b32 [$1], {";
 
-  } else {
-    opcode = "@$0 tcgen05.st.sync.aligned.32x32b.x" +
-             std::to_string(srcs.size()) + packedStr + ".b32 [$1], {";
-  }
   SmallVector<PTXInstr::Operand *> operands;
   operands.push_back(ptxBuilder.newOperand(pred, "b"));
   operands.push_back(ptxBuilder.newOperand(address, "r"));
@@ -183,7 +263,7 @@ static void createTensorMemoryStore(Location loc, Value address,
     auto *resultOp = ptxBuilder.newOperand(srcs[i], "r");
     operands.push_back(resultOp);
     if (i < srcs.size() - 1)
-      opcode = opcode + ", ";
+      opcode += ", ";
   }
   opcode += "};";
 
@@ -219,6 +299,13 @@ static void reorderScales(SmallVector<Value> &srcValues, int64_t k) {
   srcValues = std::move(reorderedValues);
 }
 
+template <typename Fn> void emitMemoryOp(bool isStrided, Fn &&emitMemoryOpFn) {
+  if (isStrided)
+    emitMemoryOpFn(std::integral_constant<bool, true>{});
+  else
+    emitMemoryOpFn(std::integral_constant<bool, false>{});
+}
+
 static void lowerStoreToTensorMemory(Location loc, Operation *op, Value src,
                                      Value dest, Value llSrc, Value pred,
                                      Value tmemBase,
@@ -233,21 +320,25 @@ static void lowerStoreToTensorMemory(Location loc, Operation *op, Value src,
     // along K are stored separately.
     reorderScales(srcValues, dstType.getShape().back());
   }
-  int regIdx = 0;
-  calculateAddressAndEmitTmemMessage(
-      loc, op, tmemBase, cast<RankedTensorType>(src.getType()),
-      cast<MemDescType>(dest.getType()), rewriter,
-      [&](Value startAddress, int secondHalfColOffset, bool unpackedb16,
-          int regsPerMessage, bool useStridedMessage) {
-        SmallVector<Value> srcValuesSlice(srcValues.begin() + regIdx,
-                                          srcValues.begin() + regIdx +
-                                              regsPerMessage);
-        regIdx += regsPerMessage;
-        createTensorMemoryStore(loc, startAddress, srcValuesSlice,
-                                useStridedMessage, secondHalfColOffset, pred,
-                                unpackedb16, rewriter);
-      });
 
+  auto tmemInfo = getTMemRuntimeInfo(op, cast<RankedTensorType>(src.getType()),
+                                     cast<MemDescType>(dest.getType()));
+  int regIdx = 0;
+  emitMemoryOp(tmemInfo.useStridedMessage, [&](auto isStrided) {
+    using MsgT = TMemMessage<TMemAccess32b<decltype(isStrided)::value>>;
+    calculateAddressAndEmitTmemMessage<MsgT>(
+        loc, tmemBase, tmemInfo, rewriter,
+        [&](Value startAddress, int secondHalfColOffset, bool unpackedb16,
+            int regsPerMsg, bool useStridedMessage, int opBitWidth) {
+          SmallVector<Value> srcValuesSlice(srcValues.begin() + regIdx,
+                                            srcValues.begin() + regIdx +
+                                                regsPerMsg);
+          regIdx += regsPerMsg;
+          createTensorMemoryStore<MsgT>(loc, startAddress, srcValuesSlice,
+                                        secondHalfColOffset, pred, unpackedb16,
+                                        rewriter);
+        });
+  });
   createWaitOpSt(loc, rewriter);
 
   // Emit a barrier to ensure all threads have finished writing to tensor memory
@@ -292,35 +383,32 @@ struct TensorMemoryAllocOpConversion
   }
 };
 
+template <typename TMemMsgT>
 static Value createTensorMemoryLoad(Location loc,
                                     triton::nvidia_gpu::TMEMLoadOp op,
                                     Value address, int secondHalfOffset,
                                     bool unpacked, int numRegPerMessage,
-                                    bool stridedMessage,
                                     ConversionPatternRewriter &rewriter) {
   PTXBuilder ptxBuilder;
   std::string opcode;
   // If the memory is unpacked we need to pack on the fly when loading.
   std::string packedStr = unpacked ? ".pack::16b" : "";
-  if (stridedMessage) {
-    opcode = "tcgen05.ld.sync.aligned.16x32bx2.x" +
-             std::to_string(numRegPerMessage) + packedStr + ".b32 {";
-  } else {
-    opcode = "tcgen05.ld.sync.aligned.32x32b.x" +
-             std::to_string(numRegPerMessage) + packedStr + ".b32 {";
-  }
+  unsigned numRepeats = numRegPerMessage / (TMemMsgT::traits::rowsPerThread *
+                                            TMemMsgT::traits::colsPerThread);
+  opcode = "tcgen05.ld.sync.aligned." + std::string(TMemMsgT::traits::opShape) +
+           ".x" + std::to_string(numRepeats) + packedStr + ".b32 {";
+
   SmallVector<PTXInstr::Operand *> operands;
   for (int i = 0; i < numRegPerMessage; i++) {
     opcode += "$" + std::to_string(i);
     auto *resultOp = ptxBuilder.newOperand("=r");
     operands.push_back(resultOp);
     if (i < numRegPerMessage - 1)
-      opcode = opcode + ", ";
+      opcode += ", ";
   }
   opcode += "}, [$" + std::to_string(numRegPerMessage) + "]";
-  if (stridedMessage) {
+  if (secondHalfOffset)
     opcode += ", " + std::to_string(secondHalfOffset);
-  }
   opcode += ";";
   operands.push_back(ptxBuilder.newOperand(address, "r"));
   auto &ld = *ptxBuilder.create<PTXInstr>(opcode);
@@ -376,20 +464,25 @@ struct TensorMemoryLoadOpConversion
         getTypeConverter()->convertType(op.getSrc().getType().getElementType());
     auto tmemBase = adaptor.getSrc();
 
+    auto tmemInfo =
+        getTMemRuntimeInfo(op, cast<RankedTensorType>(op.getType()),
+                           cast<MemDescType>(op.getSrc().getType()));
     SmallVector<Value> resultVals;
-    calculateAddressAndEmitTmemMessage(
-        loc, op, tmemBase, op.getType(), op.getSrc().getType(), rewriter,
-        [&](Value startAddress, int secondHalfColOffset, bool unpackedb16,
-            int regsPerMessage, bool useStridedMessage) {
-          Value packedValues = createTensorMemoryLoad(
-              loc, op, startAddress, secondHalfColOffset, unpackedb16,
-              regsPerMessage, useStridedMessage, rewriter);
-          auto results =
-              unpackResults(packedValues, op.getType().getElementType(),
-                            regsPerMessage, loc, rewriter);
-          resultVals.append(results.begin(), results.end());
-        });
-
+    emitMemoryOp(tmemInfo.useStridedMessage, [&](auto isStrided) {
+      using MsgT = TMemMessage<TMemAccess32b<decltype(isStrided)::value>>;
+      calculateAddressAndEmitTmemMessage<MsgT>(
+          loc, tmemBase, tmemInfo, rewriter,
+          [&](Value startAddress, int secondHalfColOffset, bool unpackedb16,
+              int regsPerMessage, bool useStridedMessage, int opBitWidth) {
+            Value packedValues = createTensorMemoryLoad<MsgT>(
+                loc, op, startAddress, secondHalfColOffset, unpackedb16,
+                regsPerMessage, rewriter);
+            auto results =
+                unpackResults(packedValues, op.getType().getElementType(),
+                              regsPerMessage, loc, rewriter);
+            resultVals.append(results.begin(), results.end());
+          });
+    });
     Type structTy = getTypeConverter()->convertType(op.getType());
     Value resultStruct =
         packLLElements(loc, getTypeConverter(), resultVals, rewriter, structTy);


### PR DESCRIPTION
Refactors tensor memory message emission to support narrower message widths to alleviate register pressure. 

For example, I found that when using the on device TMA descriptors the additional registers they require was sufficient to push the already very tight register budget over the edge for for fp4 kernels where BLOCK_N=256 is optimal. For BLOCK_N = 256, the epilogue currently emits two tcgen05.ld..32x32b.x128 which each require 128 registers and then spills these to thread local memory in order to cast and pack them into fewer output registers. The result is that the on device TMA descriptor creation runtime is about 40-50% slower than when using host TMA descriptors.

With this PR we emit messages each with a smaller width (fewer repeats), with very little performance degredation. In that case the same number of registers are required by the epilogue, but the ptxas backend is better able to interleave these loads with casting and packing instructions that alleviate the pressure and effectively avoid any spills. In this case, the fp4 runtime with on device TMA descriptors is only ~10% slower than the host side equivalent. 

The PR also makes the message emission generic over the instruction shape and adds a new specialization to support `tcgen05.st/ld..16x256b`. With subsequent work this can pair with downstream stmatrix ops for lower latency epilogues.

I updated the corresponding lit tests to match the narrowed tensor memory loads and stores. 

cc @pawelszczerbuk @ThomasRaoux 