### PR TITLE
[TritonGPU] Fix crash in Accelerate matmul

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -241,9 +241,11 @@ static int computeOrigBitWidth(Value x) {
   int origBitWidth = getElementTypeOrSelf(x).getIntOrFloatBitWidth();
   for (auto op : slice) {
     if (isa<LoadOp, ExperimentalDescriptorLoadOp>(op)) {
-      origBitWidth = std::min<int>(
-          origBitWidth, cast<RankedTensorType>(op->getResult(0).getType())
-                            .getElementTypeBitWidth());
+      if (auto tensorTy =
+              dyn_cast<RankedTensorType>(op->getResultTypes().front())) {
+        origBitWidth =
+            std::min<int>(origBitWidth, tensorTy.getElementTypeBitWidth());
+      }
     }
   }
   return origBitWidth;


### PR DESCRIPTION
Not all loads are tensor loads. Check for scalar loads to avoid crashing.
