### PR TITLE
[AMD] Fix loop trip count for scf.while in ConvertToBufferOps

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -47,8 +47,9 @@ std::optional<int64_t> maybeGetTripCount(LoopLikeOpInterface loop) {
   std::optional<OpFoldResult> lowerBound = loop.getSingleLowerBound();
   std::optional<OpFoldResult> upperBound = loop.getSingleUpperBound();
   std::optional<OpFoldResult> step = loop.getSingleStep();
-  assert(lowerBound && upperBound && step);
-  return constantTripCount(*lowerBound, *upperBound, *step);
+  if (lowerBound && upperBound && step)
+    return constantTripCount(*lowerBound, *upperBound, *step);
+  return {};
 }
 
 void getEnclosingLoops(Operation &op, SmallVector<LoopLikeOpInterface> &ops) {


### PR DESCRIPTION
If the LoopLikeOpInterface op doesn't have start/stop/step (e.g. `scf.while`) don't assert false, just don't return a trip count.