### PR TITLE
Remove git commit hash in wheel name when building from release branch

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -719,6 +719,7 @@ def get_git_commit_hash(length=8):
     except Exception:
         return ""
 
+
 def get_git_branch():
     try:
         cmd = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
@@ -726,13 +727,15 @@ def get_git_branch():
     except Exception:
         return ""
 
+
 def git_git_version_suffix():
     branch = get_git_branch()
     if branch.startswith("release"):
         return ""
     else:
         return get_git_commit_hash()
-    
+
+
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
     version="3.2.0" + git_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),

--- a/python/setup.py
+++ b/python/setup.py
@@ -728,7 +728,7 @@ def get_git_branch():
         return ""
 
 
-def git_git_version_suffix():
+def get_git_version_suffix():
     branch = get_git_branch()
     if branch.startswith("release"):
         return ""
@@ -738,7 +738,7 @@ def git_git_version_suffix():
 
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.2.0" + git_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.2.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",

--- a/python/setup.py
+++ b/python/setup.py
@@ -719,10 +719,23 @@ def get_git_commit_hash(length=8):
     except Exception:
         return ""
 
+def get_git_branch():
+    try:
+        cmd = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
+        return subprocess.check_output(cmd).strip().decode('utf-8')
+    except Exception:
+        return ""
 
+def git_git_version_suffix():
+    branch = get_git_branch()
+    if branch.startswith("release"):
+        return ""
+    else:
+        return get_git_commit_hash()
+    
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.2.0" + get_git_commit_hash() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.2.0" + git_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",


### PR DESCRIPTION
See release changes: https://github.com/triton-lang/triton/pull/5405

For release we are not looking for something like :
``
pytorch_triton-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
``
not:
``
triton-3.2.0+git35c6c7c6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
``