### PR TITLE
[Frontend] Support returning tensor descriptor from functions

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ControlFlowOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ControlFlowOpToLLVM.cpp
@@ -92,7 +92,7 @@ private:
       promotedOperands.push_back(base);
     }
 
-    auto opOffsetAttr = caller->getAttrOfType<mlir::IntegerAttr>(
+    auto opOffsetAttr = callOp->getAttrOfType<mlir::IntegerAttr>(
         "ttg.global_scratch_memory_offset");
     Value opOffsetVal;
     if (opOffsetAttr) {

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1,4 +1,4 @@
-﻿#include <optional>
+#include <optional>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -1401,6 +1401,12 @@ void init_triton_ir(py::module &&m) {
               EvictionPolicy evictionPolicy) -> void {
              self.create<StoreOp>(ptrs, val, mask, cacheModifier,
                                   evictionPolicy);
+           })
+      .def("create_tensor_descriptor_type",
+           [](TritonOpBuilder &self, Type blockTy) -> Type {
+             auto ctx = self.getContext();
+             return triton::TensorDescType::get(
+                 ctx, cast<RankedTensorType>(blockTy));
            })
       .def("create_reinterpret_tensor_descriptor",
            [](TritonOpBuilder &self, Value desc_ptr, Type blockTy) -> Value {

--- a/python/test/unit/cuda/test_experimental_tma.py
+++ b/python/test/unit/cuda/test_experimental_tma.py
@@ -613,6 +613,46 @@ def test_tensor_descriptor_in_function():
     torch.testing.assert_close(expect, out)
 
 
+@triton.jit(noinline=True)
+def tensor_descriptor_return_helper(ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+    return tl._experimental_make_tensor_descriptor(
+        ptr,
+        shape=[M, N],
+        strides=[N, 1],
+        block_shape=[M_BLOCK, N_BLOCK],
+    )
+
+
+@requires_tma
+@pytest.mark.interpreter
+def test_tensor_descriptor_return_value():
+
+    @triton.jit
+    def kernel(out_ptr, a_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+        in_desc = tensor_descriptor_return_helper(a_ptr, M, N, M_BLOCK, N_BLOCK)
+        out_desc = tensor_descriptor_return_helper(out_ptr, M, N, M_BLOCK, N_BLOCK)
+        moffset = tl.program_id(0) * M_BLOCK
+        noffset = tl.program_id(1) * N_BLOCK
+        value = in_desc.load([moffset, noffset])
+        out_desc.store([moffset, noffset], value.abs())
+
+    M, N = 32, 128
+    inp = torch.randn((M, N), device="cuda")
+
+    M_BLOCK = 8
+    N_BLOCK = 32
+    out = inp.new_zeros((M, N))
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]) -> torch.Tensor:
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+
+    expect = inp.abs()
+    kernel[(M // M_BLOCK, N // N_BLOCK)](out, inp, M, N, M_BLOCK, N_BLOCK)
+    torch.testing.assert_close(expect, out)
+
+
 @triton.jit
 def matmul_kernel_make_tensor_desciptor(a_ptr, b_ptr, c_ptr,  #
                                         M, N, K,  #

--- a/python/triton/_utils.py
+++ b/python/triton/_utils.py
@@ -1,29 +1,7 @@
-from typing import Tuple, List, Any
-
-# Poor man's PyTree
-
-
-def list_list_flatten(x: List[List[Any]]) -> Tuple[List[int], List[Any]]:
-    spec = []
-    flat = []
-    for l in x:
-        spec.append(len(l))
-        flat.extend(l)
-    return spec, flat
-
-
-def list_list_unflatten(spec: List[int], flat: List[Any]) -> List[List[Any]]:
-    ret = []
-    idx = 0
-    for size in spec:
-        ret.append(flat[idx:idx + size])
-        idx += size
-    assert idx == len(flat)
-    return ret
+from functools import reduce
 
 
 def get_iterable_path(iterable, path):
-    from functools import reduce
     return reduce(lambda a, idx: a[idx], path, iterable)
 
 

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -6,16 +6,16 @@ import os
 import textwrap
 import itertools
 from types import ModuleType
-from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Type, Union, Iterable, List
 
 from .. import language
 from .._C.libtriton import ir
 from ..language import constexpr, semantic, str_to_ty, tensor
-from ..language.core import _unwrap_if_constexpr, nv_tma_desc_type, _value
+from ..language.core import _unwrap_if_constexpr, nv_tma_desc_type, base_value, base_type
 from ..runtime.jit import _normalize_ty, get_jit_fn_file_line
 # ideally we wouldn't need any runtime component
 from ..runtime import JITFunction
-from .._utils import list_list_flatten, list_list_unflatten, find_paths_if, get_iterable_path, set_iterable_path
+from .._utils import find_paths_if, get_iterable_path, set_iterable_path
 
 from .errors import (CompilationError, CompileTimeAssertionFailure, UnsupportedLanguageConstruct)
 
@@ -60,7 +60,7 @@ def mangle_fn(name, arg_tys, constants):
 
 
 def _is_triton_value(o: Any) -> bool:
-    return isinstance(o, _value)
+    return isinstance(o, base_value)
 
 
 def _is_triton_tensor(o: Any) -> bool:
@@ -87,6 +87,21 @@ def _check_fn_args(node, fn, args):
                     fn.src, node,
                     f'Function {fn.__name__} is marked noinline, but was called with non-scalar argument {fn.arg_names[idx]}:{arg}'
                 )
+
+
+def flatten_values_to_ir(values: Iterable[base_value]):
+    handles = []
+    for v in values:
+        v._flatten_ir(handles)
+    return handles
+
+
+def unflatten_ir_values(handles: List[ir.value], types: List[base_type]):
+    cursor = 0
+    for ty in types:
+        value, cursor = ty._unflatten_ir(handles, cursor)
+        yield value
+    assert cursor == len(handles)
 
 
 _condition_types = {bool, int, type(None)}  # Python types accepted for conditionals inside kernels
@@ -209,13 +224,25 @@ class ASTFunction:
         self.constants = constants
         self.attrs = attrs
 
+    def return_types_ir(self, builder: ir.builder):
+        ret_types = []
+        for ret_ty in self.ret_types:
+            if ret_ty is None:
+                continue
+            ir_ty = ret_ty.to_ir(builder)
+            if isinstance(ir_ty, list):
+                ret_types.extend(ir_ty)
+            else:
+                ret_types.append(ir_ty)
+        return ret_types
+
     def serialize(self, builder: ir.builder):
         # fill up IR values in template
         # > build function
         is_val = lambda path, _: path not in self.constants and _ is not None
         val_paths = list(find_paths_if(self.arg_types, is_val))
         arg_types = [get_iterable_path(self.arg_types, path).to_ir(builder) for path in val_paths]
-        ret_types = [ret_type.to_ir(builder) for ret_type in self.ret_types]
+        ret_types = self.return_types_ir(builder)
         return builder.get_function_ty(arg_types, ret_types)
 
     def deserialize(self, fn):
@@ -376,7 +403,7 @@ class CodeGenerator(ast.NodeVisitor):
 
         return name_lookup
 
-    def set_value(self, name: str, value: Union[tensor, constexpr]) -> None:
+    def set_value(self, name: str, value: Union[base_value, constexpr]) -> None:
         ''' This function:
             called by visit_Assign() & visit_FunctionDef() to store left value (lvalue)
         1. record local defined name (FIXME: should consider control flow)
@@ -423,18 +450,24 @@ class CodeGenerator(ast.NodeVisitor):
     # By design, only non-kernel functions can return
     def visit_Return(self, node):
         ret_value = self.visit(node.value)
+        handles = []
+
+        def decay(value):
+            if isinstance(value, language.tuple):
+                return language.tuple([decay(v) for v in value.values])
+            elif isinstance(value, (language.constexpr, int, float)):
+                return semantic.to_tensor(value, self.builder)
+            return value
+
+        ret_value = decay(ret_value)
+
         if ret_value is None:
-            self.builder.ret([])
             ret_ty = language.void
-        elif isinstance(ret_value, language.tuple):
-            ret_values = [semantic.to_tensor(v, self.builder) for v in ret_value.values]
-            ret_types = [v.type for v in ret_values]
-            self.builder.ret([v.handle for v in ret_values])
-            ret_ty = language.tuple_type(ret_types)
         else:
-            ret = semantic.to_tensor(ret_value, self.builder)
-            self.builder.ret([ret.handle])
-            ret_ty = ret.type
+            assert isinstance(ret_value, language.core.base_value)
+            ret_value._flatten_ir(handles)
+            ret_ty = ret_value.type
+        self.builder.ret(handles)
         if self.ret_type is None:
             self.ret_type = ret_ty
         elif self.ret_type != ret_ty:
@@ -497,11 +530,7 @@ class CodeGenerator(ast.NodeVisitor):
             else:
                 self.prototype.ret_types = [self.ret_type]
             self.fn.reset_type(self.prototype.serialize(self.builder))
-            self.builder.ret([
-                self.builder.create_poison(ty.to_ir(self.builder))
-                for ty in self.prototype.ret_types
-                if self.ret_type is not None
-            ])
+            self.builder.ret([self.builder.create_poison(ty) for ty in self.prototype.return_types_ir(self.builder)])
         self.fn.finalize()
 
         if insert_pt:
@@ -693,16 +722,15 @@ class CodeGenerator(ast.NodeVisitor):
             # then terminator
             self.builder.set_insertion_point_to_end(then_block)
             assert not then_block.has_terminator(), f"{then_block}"
-            then_handles = [then_defs[n]._flatten_ir() for n in names]
-            then_handles_spec, then_handles_flat = list_list_flatten(then_handles)
-            self.builder.create_branch(endif_block, then_handles_flat)
+            then_handles = flatten_values_to_ir(then_defs[name] for name in names)
+            self.builder.create_branch(endif_block, then_handles)
             # else terminator
             self.builder.set_insertion_point_to_end(else_block)
             assert not else_block.has_terminator(), f"{else_block}"
-            else_handles = [else_defs[n]._flatten_ir() for n in names]
-            _, else_handles_flat = list_list_flatten(else_handles)
-            self.builder.create_branch(endif_block, else_handles_flat)
-            for then_h, else_h in zip(then_handles_flat, else_handles_flat):
+            else_handles = flatten_values_to_ir(else_defs[name] for name in names)
+            self.builder.create_branch(endif_block, else_handles)
+            assert len(then_handles) == len(else_handles)
+            for then_h, else_h in zip(then_handles, else_handles):
                 ty = then_h.get_type()
                 assert ty == else_h.get_type()
                 endif_block.add_argument(ty)
@@ -710,10 +738,10 @@ class CodeGenerator(ast.NodeVisitor):
         # change block
         self.builder.set_insertion_point_to_start(endif_block)
         # update value
-        res_handles_flat = [endif_block.arg(i) for i in range(len(then_handles_flat))]
-        res_handles = list_list_unflatten(then_handles_spec, res_handles_flat)
-        for name, handles in zip(names, res_handles):
-            new_value = then_defs[name]._unflatten_ir(handles)
+        res_handles = [endif_block.arg(i) for i in range(len(then_handles))]
+        types = [then_defs[name].type for name in names]
+        new_values = unflatten_ir_values(res_handles, types)
+        for name, new_value in zip(names, new_values):
             self.set_value(name, new_value)
 
     # TODO: refactor
@@ -726,28 +754,26 @@ class CodeGenerator(ast.NodeVisitor):
             then_defs, else_defs, then_block, else_block, names = \
                 self.visit_then_else_blocks(node, liveins, then_block, else_block)
             # create if op
-            then_handles = [then_defs[n]._flatten_ir() for n in names]
-            then_handles_spec, then_handles_flat = list_list_flatten(then_handles)
+            then_handles = flatten_values_to_ir(then_defs[name] for name in names)
             self._set_insertion_point_and_loc(ip, last_loc)
-            if_op = self.builder.create_if_op([h.get_type() for h in then_handles_flat], cond.handle, True)
+            if_op = self.builder.create_if_op([h.get_type() for h in then_handles], cond.handle, True)
             then_block.merge_block_before(if_op.get_then_block())
             self.builder.set_insertion_point_to_end(if_op.get_then_block())
             if len(names) > 0:
-                self.builder.create_yield_op(then_handles_flat)
+                self.builder.create_yield_op(then_handles)
             if not node.orelse:
                 else_block = if_op.get_else_block()
             else:
                 else_block.merge_block_before(if_op.get_else_block())
             self.builder.set_insertion_point_to_end(if_op.get_else_block())
             if len(names) > 0:
-                else_handles = [else_defs[n]._flatten_ir() for n in names]
-                _, else_handles_flat = list_list_flatten(else_handles)
-                self.builder.create_yield_op(else_handles_flat)
+                else_handles = flatten_values_to_ir(else_defs[name] for name in names)
+                self.builder.create_yield_op(else_handles)
         # update values
-        res_handles_flat = [if_op.get_result(i) for i in range(len(then_handles_flat))]
-        res_handles = list_list_unflatten(then_handles_spec, res_handles_flat)
-        for name, handles in zip(names, res_handles):
-            new_value = then_defs[name]._unflatten_ir(handles)
+        res_handles = [if_op.get_result(i) for i in range(len(then_handles))]
+        types = [then_defs[name].type for name in names]
+        new_values = unflatten_ir_values(res_handles, types)
+        for name, new_value in zip(names, new_values):
             self.set_value(name, new_value)
 
     def visit_If(self, node):
@@ -909,33 +935,31 @@ class CodeGenerator(ast.NodeVisitor):
                     names.append(name)
                     init_args.append(live_val)
 
-            init_handles = [a._flatten_ir() for a in init_args]
-            init_handles_spec, init_handles_flat = list_list_flatten(init_handles)
-            init_tys_flat = [h.get_type() for h in init_handles_flat]
+            init_handles = flatten_values_to_ir(init_args)
+            init_tys = [h.get_type() for h in init_handles]
+            init_fe_tys = [a.type for a in init_args]
             self._set_insertion_point_and_loc(ip, last_loc)
-            while_op = self.builder.create_while_op(init_tys_flat, init_handles_flat)
+            while_op = self.builder.create_while_op(init_tys, init_handles)
             # merge the condition region
-            before_block = self.builder.create_block_with_parent(while_op.get_before(), init_tys_flat)
+            before_block = self.builder.create_block_with_parent(while_op.get_before(), init_tys)
             self.builder.set_insertion_point_to_start(before_block)
-            block_args_flat = [before_block.arg(i) for i in range(len(init_handles_flat))]
-            block_args = list_list_unflatten(init_handles_spec, block_args_flat)
-            for name, init_val, arg_handles in zip(names, init_args, block_args):
-                val = init_val._unflatten_ir(arg_handles)
+            block_args = [before_block.arg(i) for i in range(len(init_handles))]
+            condition_args = unflatten_ir_values(block_args, init_fe_tys)
+            for name, val in zip(names, condition_args):
                 self.lscope[name] = val
                 self.local_defs[name] = val
             cond = self.visit(node.test)
             self.builder.set_insertion_point_to_end(before_block)
             # create ConditionOp: e.g., scf.condition(%cond) %arg0, %arg1, ...
-            self.builder.create_condition_op(cond.handle, block_args_flat)
+            self.builder.create_condition_op(cond.handle, block_args)
             # merge the loop body
-            after_block = self.builder.create_block_with_parent(while_op.get_after(), init_tys_flat)
+            after_block = self.builder.create_block_with_parent(while_op.get_after(), init_tys)
 
             # generate loop body
             self.builder.set_insertion_point_to_start(after_block)
-            block_args_flat = [after_block.arg(i) for i in range(len(init_handles_flat))]
-            block_args = list_list_unflatten(init_handles_spec, block_args_flat)
-            for name, init_val, arg_handles in zip(names, init_args, block_args):
-                val = init_val._unflatten_ir(arg_handles)
+            body_handles = [after_block.arg(i) for i in range(len(init_handles))]
+            body_args = unflatten_ir_values(body_handles, init_fe_tys)
+            for name, val in zip(names, body_args):
                 self.lscope[name] = val
                 self.local_defs[name] = val
             self.scf_stack.append(node)
@@ -945,16 +969,14 @@ class CodeGenerator(ast.NodeVisitor):
             yields = []
             for name in loop_defs:
                 if name in liveins:
-                    yields.append(loop_defs[name]._flatten_ir())
+                    loop_defs[name]._flatten_ir(yields)
 
-            _, yields_flat = list_list_flatten(yields)
-            self.builder.create_yield_op(yields_flat)
+            self.builder.create_yield_op(yields)
 
         # WhileOp defines new values, update the symbol table (lscope, local_defs)
-        results_flat = [while_op.get_result(i) for i in range(len(init_handles_flat))]
-        results = list_list_unflatten(init_handles_spec, results_flat)
-        for name, init_val, result in zip(names, init_args, results):
-            new_def = init_val._unflatten_ir(result)
+        result_handles = [while_op.get_result(i) for i in range(len(init_handles))]
+        result_vals = unflatten_ir_values(result_handles, init_fe_tys)
+        for name, new_def in zip(names, result_vals):
             self.lscope[name] = new_def
             self.local_defs[name] = new_def
 
@@ -1079,9 +1101,9 @@ class CodeGenerator(ast.NodeVisitor):
 
             # create ForOp
             self._set_insertion_point_and_loc(ip, last_loc)
-            init_handles = [a._flatten_ir() for a in init_args]
-            init_handles_spec, init_handles_flat = list_list_flatten(init_handles)
-            for_op = self.builder.create_for_op(lb, ub, step, init_handles_flat)
+            init_handles = flatten_values_to_ir(init_args)
+            init_tys = [v.type for v in init_args]
+            for_op = self.builder.create_for_op(lb, ub, step, init_handles)
             if _unwrap_if_constexpr(num_stages) is not None:
                 for_op.set_attr("tt.num_stages", self.builder.get_int32_attr(num_stages))
             if _unwrap_if_constexpr(loop_unroll_factor) is not None:
@@ -1097,10 +1119,9 @@ class CodeGenerator(ast.NodeVisitor):
             # reset local scope to not pick up local defs from the previous dry run.
             self.lscope = liveins.copy()
             self.local_defs = {}
-            block_args_flat = [for_op_body.arg(i + 1) for i in range(len(init_handles_flat))]
-            block_args = list_list_unflatten(init_handles_spec, block_args_flat)
-            for name, init_val, arg_handles in zip(names, init_args, block_args):
-                val = init_val._unflatten_ir(arg_handles)
+            block_handles = [for_op_body.arg(i + 1) for i in range(len(init_handles))]
+            block_args = unflatten_ir_values(block_handles, init_tys)
+            for name, val in zip(names, block_args):
                 self.set_value(name, val)
             self.visit_compound_statement(node.body)
             self.scf_stack.pop()
@@ -1114,9 +1135,8 @@ class CodeGenerator(ast.NodeVisitor):
 
             # create YieldOp
             if len(yields) > 0:
-                yield_handles = [y._flatten_ir() for y in yields]
-                _, yield_handles_flat = list_list_flatten(yield_handles)
-                self.builder.create_yield_op(yield_handles_flat)
+                yield_handles = flatten_values_to_ir(yields)
+                self.builder.create_yield_op(yield_handles)
             for_op_region = for_op_body.get_parent()
             assert for_op_region.size() == 1, "We use SCF, so the loop body should only have one block"
 
@@ -1130,10 +1150,9 @@ class CodeGenerator(ast.NodeVisitor):
             self.set_value(node.target.id, language.core.tensor(iv, iv_type))
 
         # update lscope & local_defs (ForOp defines new values)
-        result_handles_flat = [for_op.get_result(i) for i in range(len(init_handles_flat))]
-        result_handles = list_list_unflatten(init_handles_spec, result_handles_flat)
-        for name, init_val, arg_handles in zip(names, init_args, result_handles):
-            val = init_val._unflatten_ir(arg_handles)
+        result_handles = [for_op.get_result(i) for i in range(len(init_handles))]
+        result_values = unflatten_ir_values(result_handles, init_tys)
+        for name, val in zip(names, result_values):
             self.set_value(name, val)
 
         for stmt in node.orelse:
@@ -1198,16 +1217,10 @@ class CodeGenerator(ast.NodeVisitor):
         symbol = self.module.get_function(fn_name)
         args_val = [arg.handle for arg in args_val]
         call_op = self.builder.call(symbol, args_val)
-        if callee_ret_type is None:
+        if callee_ret_type == language.void:
             return None
-        elif call_op.get_num_results() == 1:
-            return tensor(call_op.get_result(0), callee_ret_type)
-        else:
-            # should return a tuple of tl.tensor
-            results = []
-            for i in range(call_op.get_num_results()):
-                results.append(tensor(call_op.get_result(i), callee_ret_type.types[i]))
-            return language.tuple(results)
+        handles = [call_op.get_result(i) for i in range(call_op.get_num_results())]
+        return next(unflatten_ir_values(handles, [callee_ret_type]))
 
     def visit_Call(self, node):
         fn = _unwrap_if_constexpr(self.visit(node.func))

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -283,6 +283,7 @@ def check_bit_width(value, shift_value):
 class base_value:
     """Base class of values that exist in the triton IR (i.e. not constexprs).
     """
+    type: base_type
 
     def _flatten_ir(self, handles: List[ir.value]) -> None:
         """Flatten frontend value into a sequence of mlir handles, which are appended
@@ -662,7 +663,7 @@ class block_type(dtype):
     def get_block_shapes(self) -> List[int]:
         return self.shape
 
-    def __eq__(self, other: block_type) -> bool:
+    def __eq__(self, other) -> bool:
         if not isinstance(other, block_type):
             return False
         return self.element_ty == other.element_ty and self.shape == other.shape
@@ -695,7 +696,7 @@ class tuple_type(base_type):
         return True
 
     def __eq__(self, other):
-        return self.types == other.types
+        return type(self) is type(other) and self.types == other.types and self.fields == other.fields
 
     def _unflatten_ir(self, handles: List[ir.value], cursor: int) -> Tuple[tuple, int]:
         values = []

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1161,20 +1161,20 @@ def validate_descriptor_block(shape, dtype):
 def descriptor_load(desc: tl._experimental_tensor_desciptor_base, offsets, cache_modifier: str, eviction_policy: str,
                     builder: ir.builder) -> tl.tensor:
     assert isinstance(desc, tl._experimental_tensor_descriptor_base)
-    validate_descriptor_block(desc.block_shape, desc.type.element_ty)
+    validate_descriptor_block(desc.block_shape, desc.dtype)
     ndim = len(desc.block_shape)
     assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
 
     offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
     x = builder.create_descriptor_load(desc.handle, offsets, _str_to_load_cache_modifier(cache_modifier),
                                        _str_to_eviction_policy(eviction_policy))
-    return tl.tensor(x, desc.type)
+    return tl.tensor(x, desc.block_type)
 
 
 def descriptor_store(desc: tl._experimental_tensor_descriptor_base, value: tl.tensor, offsets,
                      builder: ir.builder) -> tl.tensor:
     assert isinstance(desc, tl._experimental_tensor_descriptor_base)
-    validate_descriptor_block(desc.block_shape, desc.type.element_ty)
+    validate_descriptor_block(desc.block_shape, desc.dtype)
     ndim = len(desc.block_shape)
     assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
     assert value.shape == desc.block_shape
@@ -1190,18 +1190,18 @@ def descriptor_gather(desc, x_offsets, y_offset, cache_modifier: str, eviction_p
     assert eviction_policy == "", "eviction policy is not supported yet"
 
     # Validate descriptor.
-    assert len(desc.type.shape) == 2, f"descriptor must be 2D, but got {desc.type.shape}"
-    assert desc.type.shape[0] == 1, f"descriptor block must have 1 row, but got {desc.type.shape}"
+    assert len(desc.block_shape) == 2, f"descriptor must be 2D, but got {desc.block_shape}"
+    assert desc.block_shape[0] == 1, f"descriptor block must have 1 row, but got {desc.block_shape}"
 
     # Validate offsets.
-    assert len(x_offsets.shape) == 1, f"x offsets must be 1D, but got {x_offsets.shapae}"
+    assert len(x_offsets.shape) == 1, f"x offsets must be 1D, but got {x_offsets.shape}"
 
     # Validate minimum block size.
     assert x_offsets.shape[0] >= 8, f"descriptor gather must have at least 8 rows, but got {x_offsets.shape}"
-    dtype = desc.type.element_ty
+    dtype = desc.dtype
     min_cols = 32 // dtype.primitive_bitwidth * 8
-    assert desc.type.shape[
-        1] >= min_cols, f"descriptor gather of {dtype} must have at least {min_cols} columns, but got {desc.type.shape[1]}"
+    assert desc.block_shape[
+        1] >= min_cols, f"descriptor gather of {dtype} must have at least {min_cols} columns, but got {desc.block_shape[1]}"
 
     type = tl.block_type(desc.dtype, [x_offsets.shape[0], desc.block_shape[1]])
     y_offset = _convert_to_ir_values(builder, (y_offset, ), require_i64=False)[0]
@@ -1213,8 +1213,8 @@ def descriptor_scatter(desc, value: tl.tensor, x_offsets, y_offset, builder: ir.
     assert isinstance(desc, tl._experimental_tensor_descriptor_base)
 
     # Validate descriptor.
-    assert len(desc.type.shape) == 2, f"descriptor must be 2D, but got {desc.type.shape}"
-    assert desc.type.shape[0] == 1, f"descriptor block must have 1 row, but got {desc.type.shape}"
+    assert len(desc.block_shape) == 2, f"descriptor must be 2D, but got {desc.block_shape}"
+    assert desc.block_shape[0] == 1, f"descriptor block must have 1 row, but got {desc.block_shape}"
 
     # Validate offsets.
     assert len(x_offsets.shape) == 1, f"x offsets must be 1D, but got {x_offsets.shapae}"
@@ -1223,8 +1223,8 @@ def descriptor_scatter(desc, value: tl.tensor, x_offsets, y_offset, builder: ir.
     assert x_offsets.shape[0] >= 8, f"descriptor scatter must have at least 8 rows, but got {x_offsets.shape}"
     dtype = desc.type.element_ty
     min_cols = 32 // dtype.primitive_bitwidth * 8
-    assert desc.type.shape[
-        1] >= min_cols, f"descriptor scatter of {dtype} must have at least {min_cols} columns, but got {desc.type.shape[1]}"
+    assert desc.block_shape[
+        1] >= min_cols, f"descriptor scatter of {dtype} must have at least {min_cols} columns, but got {desc.block_shape[1]}"
 
     y_offset = _convert_to_ir_values(builder, (y_offset, ), require_i64=False)[0]
     builder.create_descriptor_scatter(desc.handle, value.handle, x_offsets.handle, y_offset)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1221,7 +1221,7 @@ def descriptor_scatter(desc, value: tl.tensor, x_offsets, y_offset, builder: ir.
 
     # Validate minimum block size.
     assert x_offsets.shape[0] >= 8, f"descriptor scatter must have at least 8 rows, but got {x_offsets.shape}"
-    dtype = desc.type.element_ty
+    dtype = desc.dtype
     min_cols = 32 // dtype.primitive_bitwidth * 8
     assert desc.block_shape[
         1] >= min_cols, f"descriptor scatter of {dtype} must have at least {min_cols} columns, but got {desc.block_shape[1]}"


### PR DESCRIPTION
Currently the frontend assumes every function returns either tensor, tuple of tensor, or void. This refactors it to operate on a generic `base_value` object. The function return uses `base_value._flatten_ir` to extract the mlir handles and generate the yield expression. The caller then uses `base_type._unflatten_ir` to rebuild a frontend value from a list of mlir handles.

I had started this refactoring before for scf ops, but I needed to change the signatures a bit because previously you called `base_value._unflatten_ir` however the caller here only has the type and not a pre-existing frontend value.
