### PR TITLE
[AMD]Make AMDGPUAccelerateMatmul depend on TritonAMDGPUDialect

### DIFF
--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -38,7 +38,7 @@ def TritonAMDGPUAccelerateMatmul : Pass<"tritonamdgpu-accelerate-matmul", "mlir:
 
   let constructor = "mlir::createTritonAMDGPUAccelerateMatmulPass()";
 
-  let dependentDialects = [];
+  let dependentDialects = ["mlir::triton::amdgpu::TritonAMDGPUDialect"];
 
   let options = [
     Option<"archGenerationName", "arch-generation-name",


### PR DESCRIPTION
We may emit the UpcastMXFPOp in AMDGPUAccelerateMatmul;
so need to register TritonAMDGPUDialect as a dependency.