### PR TITLE
[Pipeliner] Fix a bug that triggers an assertion error on Op's stage larger than numStages

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
@@ -323,7 +323,7 @@ void scheduleLoop(scf::ForOp forOp,
 
   auto newMaxStages = schedule.numStages;
 
-  int64_t oldNumStages = 0;
+  int64_t oldNumStages = -1;
   if (forOp->hasAttr(mlir::triton::kNumStagesAttrName))
   {
     oldNumStages = mlir::cast<IntegerAttr>(
@@ -340,8 +340,9 @@ void scheduleLoop(scf::ForOp forOp,
                    IntegerAttr::get(IntegerType::get(forOp->getContext(),
                                                               32),
                        newMaxStages));
-    LDBG("Updated num_stages attribute to " << newMaxStages);
-    forOp->emitRemark() << "[triton-loop-schedule] Updated num_stages attribute to " << newMaxStages;
+    LDBG("Updated num_stages attribute from" << oldNumStages << " to " << newMaxStages);
+    if (oldNumStages > 0)
+      forOp->emitRemark() << "[triton-loop-schedule] Overwrite num_stages attribute to " << newMaxStages;
   }
   // Write the schedule to the IR
   schedule.serialize(forOp);

--- a/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/LoopScheduling.cpp
@@ -324,11 +324,10 @@ void scheduleLoop(scf::ForOp forOp,
   auto newMaxStages = schedule.numStages;
 
   int64_t oldNumStages = -1;
-  if (forOp->hasAttr(mlir::triton::kNumStagesAttrName))
-  {
+  if (forOp->hasAttr(mlir::triton::kNumStagesAttrName)) {
     oldNumStages = mlir::cast<IntegerAttr>(
-               forOp->getAttr(mlir::triton::kNumStagesAttrName))
-        .getInt();
+                       forOp->getAttr(mlir::triton::kNumStagesAttrName))
+                       .getInt();
   }
 
   LDBG("Old num_stages attribute: " << oldNumStages);
@@ -337,12 +336,14 @@ void scheduleLoop(scf::ForOp forOp,
   // attribute and emit a remark on the loop op
   if (oldNumStages < newMaxStages) {
     forOp->setAttr(mlir::triton::kNumStagesAttrName,
-                   IntegerAttr::get(IntegerType::get(forOp->getContext(),
-                                                              32),
-                       newMaxStages));
-    LDBG("Updated num_stages attribute from" << oldNumStages << " to " << newMaxStages);
+                   IntegerAttr::get(IntegerType::get(forOp->getContext(), 32),
+                                    newMaxStages));
+    LDBG("Updated num_stages attribute from" << oldNumStages << " to "
+                                             << newMaxStages);
     if (oldNumStages > 0)
-      forOp->emitRemark() << "[triton-loop-schedule] Overwrite num_stages attribute to " << newMaxStages;
+      forOp->emitRemark()
+          << "[triton-loop-schedule] Overwrite num_stages attribute to "
+          << newMaxStages;
   }
   // Write the schedule to the IR
   schedule.serialize(forOp);


### PR DESCRIPTION
This fixes https://github.com/pytorch/pytorch/issues/147468, where we have `opToStageAndCluster[&op].first < numStages && "Op with invalid stage!"` triggered. 

We now have two passes for pipelining. In one pass, we compute the stages and annotate on the ops, and pipeline them in another pass. We also support distance > 1, which may result in much more stages. 

The bug is that we didn't annotate the new number of stages on the for loop, and the following pass still reads the number of stages from the loop or use a default value. So I annotate the numStages on the loop as well. Now the assertion error is no longer triggered for the test case.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because I have not yet found a small standalone repro. It may take a while to have a standalone repro.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
