### PR TITLE
avoid mandatory linking of stdc++fs on BSD targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ add_subdirectory(lib)
 # TODO: Figure out which target is sufficient to fix errors; triton is
 # apparently not enough. Currently set linking libstdc++fs for all targets
 # to support some old version GCC compilers like 8.3.0.
-if (NOT WIN32 AND NOT APPLE)
+if (NOT WIN32 AND NOT APPLE AND NOT BSD)
   link_libraries(stdc++fs)
 endif()
 


### PR DESCRIPTION
Sorry for not following the PR template but this is just a trivial change to indicate the problem. I can see there is a TODO here but mandatory linking of `stdc++fs` is very ad hoc and breaks BSD build.