### PR TITLE
[Frontend][Cache] Include platform information in the key

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -47,8 +47,14 @@ def library_dirs():
     return [libdevice_dir, *libcuda_dirs()]
 
 
+@functools.lru_cache()
+def platform_key():
+    from platform import machine, system, architecture
+    return ",".join([machine(), system(), *architecture()])
+
+
 def compile_module_from_src(src, name):
-    key = hashlib.sha256(src.encode("utf-8")).hexdigest()
+    key = hashlib.sha256((src + platform_key()).encode("utf-8")).hexdigest()
     cache = get_cache_manager(key)
     ext = sysconfig.get_config_var("EXT_SUFFIX").split(".")[-1]
     cache_path = cache.get_file(f"{name}.{ext}")


### PR DESCRIPTION
Note: This patch is an upstream version of what we use internally at Meta with the goal of reducing our internal patches.

This PR adds platform specific information to the caching backend in order to make sure cached data does not get used incorrectly on a different platform.

While one may say that on-disk local cache is only for that one machine, it is not uncommon that these files get transferred between machines either on purpose or accidental. 