### PR TITLE
[PROTON-DEV] Implement Proton GlobalScratchAllocOp To LLVM Conversion Passes

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -2,6 +2,7 @@
 #include "amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "amd/include/TritonAMDGPUTransforms/Passes.h"
 #include "third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h"
+#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h"
 #include "third_party/proton/dialect/include/Conversion/ProtonToProtonGPU/Passes.h"
 #include "third_party/proton/dialect/include/Dialect/Proton/IR/Dialect.h"
 #include "third_party/proton/dialect/include/Dialect/ProtonGPU/IR/Dialect.h"
@@ -76,6 +77,8 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();
   mlir::triton::proton::registerConvertProtonToProtonGPU();
+  mlir::triton::proton::registerAllocateProtonSharedMemoryPass();
+  mlir::triton::proton::registerAddProtonKernelArgPass();
 
   // TODO: register Triton & TritonGPU passes
   registry.insert<mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,

--- a/test/Proton/allocate_shared_memory.mlir
+++ b/test/Proton/allocate_shared_memory.mlir
@@ -1,0 +1,50 @@
+// RUN: triton-opt --split-input-file -allocate-shared-memory -convert-proton-to-protongpu="max-shared-mem=4096" -allocate-proton-shared-memory %s | FileCheck %s
+
+#A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+// CHECK: ttg.shared = 3584 : i32
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: allocate_aligned
+  tt.func @allocate_aligned(%A : !tt.ptr<f16>) {
+  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record start "name0"
+  %cst1 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %cst2 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst0 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst1 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record end "name0"
+  ttg.local_dealloc %cst2 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // CHECK: ttg.local_alloc  {allocation.offset = 1536 : i32}
+  tt.return
+  }
+}
+
+// -----
+
+#A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+// CHECK: ttg.shared = 2064 : i32
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: allocate_unaligned
+  tt.func @allocate_unaligned(%A : !tt.ptr<f16>) {
+  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<1x6xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record start "name0"
+  ttg.local_dealloc %cst0 : !ttg.memdesc<1x6xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record end "name0"
+  // CHECK: ttg.local_alloc  {allocation.offset = 16 : i32}
+  tt.return
+  }
+}
+
+// -----
+
+#A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+// CHECK: ttg.shared = 50 : i32
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: no_proton
+  tt.func @no_proton(%A : !tt.ptr<f16>) {
+  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<1x25xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst0 : !ttg.memdesc<1x25xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // CHECK: ttg.local_alloc
+  // CHECK-NOT: ttg.local_alloc
+  tt.return
+  }
+}

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/CMakeLists.txt
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls --name ProtonGPUToLLVM)
+add_public_tablegen_target(ProtonGPUConversionPassIncGen)

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h
@@ -1,0 +1,33 @@
+#ifndef PROTONGPU_CONVERSION_PROTONGPUTOLLVM_PASSES_H
+#define PROTONGPU_CONVERSION_PROTONGPUTOLLVM_PASSES_H
+
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include <memory>
+
+namespace mlir {
+
+class ModuleOp;
+template <typename T> class OperationPass;
+
+namespace triton::proton {
+
+#define GEN_PASS_DECL
+#include "proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h.inc"
+
+namespace gpu {
+std::unique_ptr<OperationPass<ModuleOp>> createAddProtonKernelArgPass();
+std::unique_ptr<OperationPass<ModuleOp>> createAllocateProtonSharedMemoryPass();
+
+} // namespace gpu
+
+#define GEN_PASS_REGISTRATION
+#include "proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h.inc"
+
+} // namespace triton::proton
+
+} // namespace mlir
+
+#endif

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.td
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.td
@@ -1,0 +1,24 @@
+#ifndef PROTONCOMMONGPU_CONVERSION_PASSES
+#define PROTONCOMMONGPU_CONVERSION_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def AllocateProtonSharedMemory : Pass<"allocate-proton-shared-memory", "mlir::ModuleOp"> {
+    let summary = "Update metadata for proton shared memory allocation";
+    let description = [{
+      This pass updates the amount of shared/local memory used due to
+      proton intra kernel profiling.
+     }];
+
+    let constructor = "mlir::triton::proton::gpu::createAllocateProtonSharedMemoryPass()";
+}
+
+
+def AddProtonKernelArg : Pass<"add-proton-kernel-arg", "mlir::ModuleOp"> {
+
+    let constructor = "mlir::triton::proton::gpu::createAddProtonKernelArgPass()";
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect"
+  ];
+}
+#endif

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/PatternProtonOpToLLVM.h
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/PatternProtonOpToLLVM.h
@@ -12,6 +12,11 @@ void populateRecordOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                    const TargetInfoBase &targetInfo,
                                    PatternBenefit benefit);
 
+void populateGlobalScratchAllocOpToLLVMPattern(LLVMTypeConverter &typeConverter,
+                                               RewritePatternSet &patterns,
+                                               const TargetInfoBase &targetInfo,
+                                               PatternBenefit benefit);
+
 void populateProtonOpPatterns(LLVMTypeConverter &typeConverter,
                               RewritePatternSet &patterns,
                               const TargetInfoBase &targetInfo,

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Utility.h
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Utility.h
@@ -1,0 +1,37 @@
+#ifndef TRITON_CONVERSION_PROTONGPU_TO_LLVM_UTILITY_H
+#define TRITON_CONVERSION_PROTONGPU_TO_LLVM_UTILITY_H
+
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Conversion/MLIRTypes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace mlir {
+namespace triton {
+namespace proton {
+namespace gpu {
+
+static Value getGlobalScratchPtr(Location loc, RewriterBase &rewriter,
+                                 FunctionOpInterface funcOp,
+                                 Value allocOffset = {}) {
+  auto gmemBase = funcOp.getArgument(funcOp.getNumArguments() - 1);
+  ModuleOp mod = funcOp.getOperation()->getParentOfType<ModuleOp>();
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto *ctx = rewriter.getContext();
+  Value bufferPtr = b.gep(mlir::LLVM::LLVMPointerType::get(ctx, 1), i8_ty,
+                          gmemBase, allocOffset);
+  return bufferPtr;
+}
+} // namespace gpu
+} // namespace proton
+} // namespace triton
+} // namespace mlir
+#endif

--- a/third_party/proton/dialect/include/Dialect/ProtonGPUToLLVM/Passes.h
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPUToLLVM/Passes.h
@@ -1,0 +1,33 @@
+#ifndef TRITON_THIRD_PARTY_PROTON_INCLUDE_TRITONPROTONGPUTOLLVM_PASSES_H_
+#define TRITON_THIRD_PARTY_PROTON_INCLUDE_TRITONPROTONGPUTOLLVM_PASSES_H_
+
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+
+class ModuleOp;
+template <typename T> class OperationPass;
+
+} // namespace mlir
+
+namespace mlir::triton {
+
+#define GEN_PASS_DECL
+#include "third_party/proton/dialect/include/Dialect/ProtonGPUToLLVM/Passes.h"
+
+} // namespace mlir::triton
+
+
+namespace mlir::triton {
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertProtonGPUToLLVMPass(StringRef targetArch);
+
+#define GEN_PASS_REGISTRATION
+#include "third_party/proton/dialect/include/Dialect/ProtonGPUToLLVM/Passes.h"
+} // namespace mlir::triton
+
+#endif // TRITON_THIRD_PARTY_PROTON_INCLUDE_TRITONPROTONGPUTOLLVM_PASSES_H_

--- a/third_party/proton/dialect/include/Dialect/ProtonGPUToLLVM/Passes.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPUToLLVM/Passes.td
@@ -1,0 +1,21 @@
+#ifndef PROTONGPU_CONVERSION_PASSES
+#define PROTONGPU_CONVERSION_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+
+def ConvertProtonGPUToLLVM : Pass<"convert-proton-gpu-to-llvm", "mlir::ModuleOp"> {
+    let summary = "Convert ProtonGPU to LLVM";
+    let constructor = "mlir::triton::createConvertProtonGPUToLLVMPass(\"\")";
+
+    let dependentDialects = ["mlir::LLVM::LLVMDialect",
+                             "mlir::triton::TritonDialect",
+                             "mlir::triton::gpu::TritonGPUDialect"];
+
+    let options = [
+        Option<"arch", "arch", "std::string", /*default*/"\"\"",
+               "target device architecture, e.g., gfx942">,
+    ];
+}
+
+#endif

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/AddProtonKernelArg.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/AddProtonKernelArg.cpp
@@ -12,14 +12,8 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
-#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/PatternProtonOpToLLVM.h"
-#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Utility.h"
 #include "third_party/proton/dialect/include/Dialect/Proton/IR/Dialect.h"
 #include "third_party/proton/dialect/include/Dialect/ProtonGPU/IR/Dialect.h"
-
-#include "llvm/Support/FormatVariadic.h"
-
-
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -32,439 +26,49 @@ namespace triton::proton {
 } // namespace mlir
 
 namespace {
-// The following convertFuncOpToLLVMFuncOp is copied and modified from
-// https://github.com/llvm/llvm-project/blob/main/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
-static constexpr StringRef varargsAttrName = "func.varargs";
-static constexpr StringRef linkageAttrName = "llvm.linkage";
-static constexpr StringRef barePtrAttrName = "llvm.bareptr";
 
-/// Return `true` if the `op` should use bare pointer calling convention.
-static bool shouldUseBarePtrCallConv(Operation *op,
-                                     const LLVMTypeConverter *typeConverter) {
-  return (op && op->hasAttr(barePtrAttrName)) ||
-         typeConverter->getOptions().useBarePtrCallConv;
-}
-
-/// Only retain those attributes that are not constructed by
-/// `LLVMFuncOp::build`.
-static void filterFuncAttributes(FunctionOpInterface func,
+static void filterFuncAttributes(triton::FuncOp op, bool filterArgAttrs,
                                  SmallVectorImpl<NamedAttribute> &result) {
-  for (const NamedAttribute &attr : func->getDiscardableAttrs()) {
-    if (attr.getName() == linkageAttrName ||
-        attr.getName() == varargsAttrName ||
-        attr.getName() == LLVM::LLVMDialect::getReadnoneAttrName())
+
+  for (const auto &attr : op->getAttrs()) {
+    if (attr.getName() == SymbolTable::getSymbolAttrName() ||
+        attr.getName() == op.getFunctionTypeAttrName() ||
+        attr.getName() == "std.varargs" ||
+        (filterArgAttrs && attr.getName() == op.getArgAttrsAttrName()))
       continue;
     result.push_back(attr);
   }
 }
 
-/// Propagate argument/results attributes.
-static void propagateArgResAttrs(OpBuilder &builder, bool resultStructType,
-                                 FunctionOpInterface funcOp,
-                                 LLVM::LLVMFuncOp wrapperFuncOp) {
-  auto argAttrs = funcOp.getAllArgAttrs();
-  if (!resultStructType) {
-    if (auto resAttrs = funcOp.getAllResultAttrs())
-      wrapperFuncOp.setAllResultAttrs(resAttrs);
-    if (argAttrs)
-      wrapperFuncOp.setAllArgAttrs(argAttrs);
-  } else {
-    SmallVector<Attribute> argAttributes;
-    // Only modify the argument and result attributes when the result is now
-    // an argument.
-    if (argAttrs) {
-      argAttributes.push_back(builder.getDictionaryAttr({}));
-      argAttributes.append(argAttrs.begin(), argAttrs.end());
-      wrapperFuncOp.setAllArgAttrs(argAttributes);
-    }
-  }
-  cast<FunctionOpInterface>(wrapperFuncOp.getOperation())
-      .setVisibility(funcOp.getVisibility());
-}
-
-/// Creates an auxiliary function with pointer-to-memref-descriptor-struct
-/// arguments instead of unpacked arguments. This function can be called from C
-/// by passing a pointer to a C struct corresponding to a memref descriptor.
-/// Similarly, returned memrefs are passed via pointers to a C struct that is
-/// passed as additional argument.
-/// Internally, the auxiliary function unpacks the descriptor into individual
-/// components and forwards them to `newFuncOp` and forwards the results to
-/// the extra arguments.
-static void wrapForExternalCallers(OpBuilder &rewriter, Location loc,
-                                   const LLVMTypeConverter &typeConverter,
-                                   FunctionOpInterface funcOp,
-                                   LLVM::LLVMFuncOp newFuncOp) {
-  auto type = cast<FunctionType>(funcOp.getFunctionType());
-  auto [wrapperFuncType, resultStructType] =
-      typeConverter.convertFunctionTypeCWrapper(type);
-
-  SmallVector<NamedAttribute> attributes;
-  filterFuncAttributes(funcOp, attributes);
-
-  auto wrapperFuncOp = rewriter.create<LLVM::LLVMFuncOp>(
-      loc, llvm::formatv("_mlir_ciface_{0}", funcOp.getName()).str(),
-      wrapperFuncType, LLVM::Linkage::External, /*dsoLocal=*/false,
-      /*cconv=*/LLVM::CConv::C, /*comdat=*/nullptr, attributes);
-  propagateArgResAttrs(rewriter, !!resultStructType, funcOp, wrapperFuncOp);
-
-  OpBuilder::InsertionGuard guard(rewriter);
-  rewriter.setInsertionPointToStart(wrapperFuncOp.addEntryBlock(rewriter));
-
-  SmallVector<Value, 8> args;
-  size_t argOffset = resultStructType ? 1 : 0;
-  for (auto [index, argType] : llvm::enumerate(type.getInputs())) {
-    Value arg = wrapperFuncOp.getArgument(index + argOffset);
-    if (auto memrefType = dyn_cast<MemRefType>(argType)) {
-      Value loaded = rewriter.create<LLVM::LoadOp>(
-          loc, typeConverter.convertType(memrefType), arg);
-      MemRefDescriptor::unpack(rewriter, loc, loaded, memrefType, args);
-      continue;
-    }
-    if (isa<UnrankedMemRefType>(argType)) {
-      Value loaded = rewriter.create<LLVM::LoadOp>(
-          loc, typeConverter.convertType(argType), arg);
-      UnrankedMemRefDescriptor::unpack(rewriter, loc, loaded, args);
-      continue;
-    }
-
-    args.push_back(arg);
-  }
-
-  auto call = rewriter.create<LLVM::CallOp>(loc, newFuncOp, args);
-
-  if (resultStructType) {
-    rewriter.create<LLVM::StoreOp>(loc, call.getResult(),
-                                   wrapperFuncOp.getArgument(0));
-    rewriter.create<LLVM::ReturnOp>(loc, ValueRange{});
-  } else {
-    rewriter.create<LLVM::ReturnOp>(loc, call.getResults());
-  }
-}
-
-/// Creates an auxiliary function with pointer-to-memref-descriptor-struct
-/// arguments instead of unpacked arguments. Creates a body for the (external)
-/// `newFuncOp` that allocates a memref descriptor on stack, packs the
-/// individual arguments into this descriptor and passes a pointer to it into
-/// the auxiliary function. If the result of the function cannot be directly
-/// returned, we write it to a special first argument that provides a pointer
-/// to a corresponding struct. This auxiliary external function is now
-/// compatible with functions defined in C using pointers to C structs
-/// corresponding to a memref descriptor.
-static void wrapExternalFunction(OpBuilder &builder, Location loc,
-                                 const LLVMTypeConverter &typeConverter,
-                                 FunctionOpInterface funcOp,
-                                 LLVM::LLVMFuncOp newFuncOp) {
-  OpBuilder::InsertionGuard guard(builder);
-
-  auto [wrapperType, resultStructType] =
-      typeConverter.convertFunctionTypeCWrapper(
-          cast<FunctionType>(funcOp.getFunctionType()));
-  // This conversion can only fail if it could not convert one of the argument
-  // types. But since it has been applied to a non-wrapper function before, it
-  // should have failed earlier and not reach this point at all.
-  assert(wrapperType && "unexpected type conversion failure");
-
-  SmallVector<NamedAttribute, 4> attributes;
-  filterFuncAttributes(funcOp, attributes);
-
-  // Create the auxiliary function.
-  auto wrapperFunc = builder.create<LLVM::LLVMFuncOp>(
-      loc, llvm::formatv("_mlir_ciface_{0}", funcOp.getName()).str(),
-      wrapperType, LLVM::Linkage::External, /*dsoLocal=*/false,
-      /*cconv=*/LLVM::CConv::C, /*comdat=*/nullptr, attributes);
-  propagateArgResAttrs(builder, !!resultStructType, funcOp, wrapperFunc);
-
-  // The wrapper that we synthetize here should only be visible in this module.
-  newFuncOp.setLinkage(LLVM::Linkage::Private);
-  builder.setInsertionPointToStart(newFuncOp.addEntryBlock(builder));
-
-  // Get a ValueRange containing arguments.
-  FunctionType type = cast<FunctionType>(funcOp.getFunctionType());
-  SmallVector<Value, 8> args;
-  args.reserve(type.getNumInputs());
-  ValueRange wrapperArgsRange(newFuncOp.getArguments());
-
-  if (resultStructType) {
-    // Allocate the struct on the stack and pass the pointer.
-    Type resultType = cast<LLVM::LLVMFunctionType>(wrapperType).getParamType(0);
-    Value one = builder.create<LLVM::ConstantOp>(
-        loc, typeConverter.convertType(builder.getIndexType()),
-        builder.getIntegerAttr(builder.getIndexType(), 1));
-    Value result =
-        builder.create<LLVM::AllocaOp>(loc, resultType, resultStructType, one);
-    args.push_back(result);
-  }
-
-  // Iterate over the inputs of the original function and pack values into
-  // memref descriptors if the original type is a memref.
-  for (Type input : type.getInputs()) {
-    Value arg;
-    int numToDrop = 1;
-    auto memRefType = dyn_cast<MemRefType>(input);
-    auto unrankedMemRefType = dyn_cast<UnrankedMemRefType>(input);
-    if (memRefType || unrankedMemRefType) {
-      numToDrop = memRefType
-                      ? MemRefDescriptor::getNumUnpackedValues(memRefType)
-                      : UnrankedMemRefDescriptor::getNumUnpackedValues();
-      Value packed =
-          memRefType
-              ? MemRefDescriptor::pack(builder, loc, typeConverter, memRefType,
-                                       wrapperArgsRange.take_front(numToDrop))
-              : UnrankedMemRefDescriptor::pack(
-                    builder, loc, typeConverter, unrankedMemRefType,
-                    wrapperArgsRange.take_front(numToDrop));
-
-      auto ptrTy = LLVM::LLVMPointerType::get(builder.getContext());
-      Value one = builder.create<LLVM::ConstantOp>(
-          loc, typeConverter.convertType(builder.getIndexType()),
-          builder.getIntegerAttr(builder.getIndexType(), 1));
-      Value allocated = builder.create<LLVM::AllocaOp>(
-          loc, ptrTy, packed.getType(), one, /*alignment=*/0);
-      builder.create<LLVM::StoreOp>(loc, packed, allocated);
-      arg = allocated;
-    } else {
-      arg = wrapperArgsRange[0];
-    }
-
-    args.push_back(arg);
-    wrapperArgsRange = wrapperArgsRange.drop_front(numToDrop);
-  }
-  assert(wrapperArgsRange.empty() && "did not map some of the arguments");
-
-  auto call = builder.create<LLVM::CallOp>(loc, wrapperFunc, args);
-
-  if (resultStructType) {
-    Value result =
-        builder.create<LLVM::LoadOp>(loc, resultStructType, args.front());
-    builder.create<LLVM::ReturnOp>(loc, result);
-  } else {
-    builder.create<LLVM::ReturnOp>(loc, call.getResults());
-  }
-}
-
-/// Inserts `llvm.load` ops in the function body to restore the expected pointee
-/// value from `llvm.byval`/`llvm.byref` function arguments that were converted
-/// to LLVM pointer types.
-static void restoreByValRefArgumentType(
-    ConversionPatternRewriter &rewriter, const LLVMTypeConverter &typeConverter,
-    ArrayRef<std::optional<NamedAttribute>> byValRefNonPtrAttrs,
-    ArrayRef<BlockArgument> oldBlockArgs, LLVM::LLVMFuncOp funcOp) {
-  // Nothing to do for function declarations.
-  if (funcOp.isExternal())
-    return;
-
-  ConversionPatternRewriter::InsertionGuard guard(rewriter);
-  rewriter.setInsertionPointToStart(&funcOp.getFunctionBody().front());
-
-  for (const auto &[arg, oldArg, byValRefAttr] :
-       llvm::zip(funcOp.getArguments(), oldBlockArgs, byValRefNonPtrAttrs)) {
-    // Skip argument if no `llvm.byval` or `llvm.byref` attribute.
-    if (!byValRefAttr)
-      continue;
-
-    // Insert load to retrieve the actual argument passed by value/reference.
-    assert(isa<LLVM::LLVMPointerType>(arg.getType()) &&
-           "Expected LLVM pointer type for argument with "
-           "`llvm.byval`/`llvm.byref` attribute");
-    Type resTy = typeConverter.convertType(
-        cast<TypeAttr>(byValRefAttr->getValue()).getValue());
-
-    auto valueArg = rewriter.create<LLVM::LoadOp>(arg.getLoc(), resTy, arg);
-    rewriter.replaceUsesOfBlockArgument(oldArg, valueArg);
-  }
-}	
-
-FailureOr<LLVM::LLVMFuncOp>
-convertFuncOpToLLVMFuncOp(FunctionOpInterface funcOp,
-                                ConversionPatternRewriter &rewriter,
-                                const LLVMTypeConverter &converter) {
-  // Check the funcOp has `FunctionType`.
-  auto funcTy = dyn_cast<FunctionType>(funcOp.getFunctionType());
-  if (!funcTy)
-    return rewriter.notifyMatchFailure(
-        funcOp, "Only support FunctionOpInterface with FunctionType");
-
-  // Keep track of the entry block arguments. They will be needed later.
-  SmallVector<BlockArgument> oldBlockArgs =
-      llvm::to_vector(funcOp.getArguments());
-
-  // Convert the original function arguments. They are converted using the
-  // LLVMTypeConverter provided to this legalization pattern.
-  auto varargsAttr = funcOp->getAttrOfType<BoolAttr>(varargsAttrName);
-  // Gather `llvm.byval` and `llvm.byref` arguments whose type convertion was
-  // overriden with an LLVM pointer type for later processing.
-  SmallVector<std::optional<NamedAttribute>> byValRefNonPtrAttrs;
-  TypeConverter::SignatureConversion result(funcOp.getNumArguments());
-  auto llvmType = converter.convertFunctionSignature(
-      funcOp, varargsAttr && varargsAttr.getValue(),
-      shouldUseBarePtrCallConv(funcOp, &converter), result,
-      byValRefNonPtrAttrs);
-  if (!llvmType)
-    return rewriter.notifyMatchFailure(funcOp, "signature conversion failed");
-
-  // Create an LLVM function, use external linkage by default until MLIR
-  // functions have linkage.
-  LLVM::Linkage linkage = LLVM::Linkage::External;
-  if (funcOp->hasAttr(linkageAttrName)) {
-    auto attr =
-        dyn_cast<mlir::LLVM::LinkageAttr>(funcOp->getAttr(linkageAttrName));
-    if (!attr) {
-      funcOp->emitError() << "Contains " << linkageAttrName
-                          << " attribute not of type LLVM::LinkageAttr";
-      return rewriter.notifyMatchFailure(
-          funcOp, "Contains linkage attribute not of type LLVM::LinkageAttr");
-    }
-    linkage = attr.getLinkage();
-  }
-
-  SmallVector<NamedAttribute, 4> attributes;
-  filterFuncAttributes(funcOp, attributes);
-  auto newFuncOp = rewriter.create<LLVM::LLVMFuncOp>(
-      funcOp.getLoc(), funcOp.getName(), llvmType, linkage,
-      /*dsoLocal=*/false, /*cconv=*/LLVM::CConv::C, /*comdat=*/nullptr,
-      attributes);
-  cast<FunctionOpInterface>(newFuncOp.getOperation())
-      .setVisibility(funcOp.getVisibility());
-
-  // Create a memory effect attribute corresponding to readnone.
-  StringRef readnoneAttrName = LLVM::LLVMDialect::getReadnoneAttrName();
-  if (funcOp->hasAttr(readnoneAttrName)) {
-    auto attr = funcOp->getAttrOfType<UnitAttr>(readnoneAttrName);
-    if (!attr) {
-      funcOp->emitError() << "Contains " << readnoneAttrName
-                          << " attribute not of type UnitAttr";
-      return rewriter.notifyMatchFailure(
-          funcOp, "Contains readnone attribute not of type UnitAttr");
-    }
-    auto memoryAttr = LLVM::MemoryEffectsAttr::get(
-        rewriter.getContext(),
-        {LLVM::ModRefInfo::NoModRef, LLVM::ModRefInfo::NoModRef,
-         LLVM::ModRefInfo::NoModRef});
-    newFuncOp.setMemoryEffectsAttr(memoryAttr);
-  }
-
-  // Propagate argument/result attributes to all converted arguments/result
-  // obtained after converting a given original argument/result.
-  if (ArrayAttr resAttrDicts = funcOp.getAllResultAttrs()) {
-    assert(!resAttrDicts.empty() && "expected array to be non-empty");
-    if (funcOp.getNumResults() == 1)
-      newFuncOp.setAllResultAttrs(resAttrDicts);
-  }
-  if (ArrayAttr argAttrDicts = funcOp.getAllArgAttrs()) {
-    SmallVector<Attribute> newArgAttrs(
-        cast<LLVM::LLVMFunctionType>(llvmType).getNumParams());
-    for (unsigned i = 0, e = funcOp.getNumArguments(); i < e; ++i) {
-      // Some LLVM IR attribute have a type attached to them. During FuncOp ->
-      // LLVMFuncOp conversion these types may have changed. Account for that
-      // change by converting attributes' types as well.
-      SmallVector<NamedAttribute, 4> convertedAttrs;
-      auto attrsDict = cast<DictionaryAttr>(argAttrDicts[i]);
-      convertedAttrs.reserve(attrsDict.size());
-      for (const NamedAttribute &attr : attrsDict) {
-        const auto convert = [&](const NamedAttribute &attr) {
-          return TypeAttr::get(converter.convertType(
-              cast<TypeAttr>(attr.getValue()).getValue()));
-        };
-        if (attr.getName().getValue() ==
-            LLVM::LLVMDialect::getByValAttrName()) {
-          convertedAttrs.push_back(rewriter.getNamedAttr(
-              LLVM::LLVMDialect::getByValAttrName(), convert(attr)));
-        } else if (attr.getName().getValue() ==
-                   LLVM::LLVMDialect::getByRefAttrName()) {
-          convertedAttrs.push_back(rewriter.getNamedAttr(
-              LLVM::LLVMDialect::getByRefAttrName(), convert(attr)));
-        } else if (attr.getName().getValue() ==
-                   LLVM::LLVMDialect::getStructRetAttrName()) {
-          convertedAttrs.push_back(rewriter.getNamedAttr(
-              LLVM::LLVMDialect::getStructRetAttrName(), convert(attr)));
-        } else if (attr.getName().getValue() ==
-                   LLVM::LLVMDialect::getInAllocaAttrName()) {
-          convertedAttrs.push_back(rewriter.getNamedAttr(
-              LLVM::LLVMDialect::getInAllocaAttrName(), convert(attr)));
-        } else {
-          convertedAttrs.push_back(attr);
-        }
-      }
-      auto mapping = result.getInputMapping(i);
-      assert(mapping && "unexpected deletion of function argument");
-      // Only attach the new argument attributes if there is a one-to-one
-      // mapping from old to new types. Otherwise, attributes might be
-      // attached to types that they do not support.
-      if (mapping->size == 1) {
-        newArgAttrs[mapping->inputNo] =
-            DictionaryAttr::get(rewriter.getContext(), convertedAttrs);
-        continue;
-      }
-      // TODO: Implement custom handling for types that expand to multiple
-      // function arguments.
-      for (size_t j = 0; j < mapping->size; ++j)
-        newArgAttrs[mapping->inputNo + j] =
-            DictionaryAttr::get(rewriter.getContext(), {});
-    }
-    if (!newArgAttrs.empty())
-      newFuncOp.setAllArgAttrs(rewriter.getArrayAttr(newArgAttrs));
-  }
-
-  rewriter.inlineRegionBefore(funcOp.getFunctionBody(), newFuncOp.getBody(),
-                              newFuncOp.end());
-  // Convert just the entry block. The remaining unstructured control flow is
-  // converted by ControlFlowToLLVM.
-  if (!newFuncOp.getBody().empty())
-    rewriter.applySignatureConversion(&newFuncOp.getBody().front(), result,
-                                      &converter);
-
-  // Fix the type mismatch between the materialized `llvm.ptr` and the expected
-  // pointee type in the function body when converting `llvm.byval`/`llvm.byref`
-  // function arguments.
-  restoreByValRefArgumentType(rewriter, converter, byValRefNonPtrAttrs,
-                              oldBlockArgs, newFuncOp);
-
-  if (!shouldUseBarePtrCallConv(funcOp, &converter)) {
-    if (funcOp->getAttrOfType<UnitAttr>(
-            LLVM::LLVMDialect::getEmitCWrapperAttrName())) {
-      if (newFuncOp.isVarArg())
-        return funcOp.emitError("C interface for variadic functions is not "
-                                "supported yet.");
-
-      if (newFuncOp.isExternal())
-        wrapExternalFunction(rewriter, funcOp->getLoc(), converter, funcOp,
-                             newFuncOp);
-      else
-        wrapForExternalCallers(rewriter, funcOp->getLoc(), converter, funcOp,
-                               newFuncOp);
-    }
-  }
-
-  return newFuncOp;
-}
-
-triton::FuncOp amendFuncOp(LLVM::LLVMFuncOp funcOp,
-                           ConversionPatternRewriter &rewriter){
+triton::FuncOp insertAmendedFuncOp(triton::FuncOp funcOp,
+                                   IRRewriter &rewriter) {
   auto moduleOp = funcOp->getParentOfType<ModuleOp>();
   Location loc = moduleOp->getLoc();
   auto ctx = funcOp->getContext();
-  auto globalPtrTy = LLVM::LLVMPointerType::get(ctx, 1);
   auto funcTy = funcOp.getFunctionType();
-  auto amendedInputTy = llvm::to_vector(funcOp.getArgumentTypes());
-  unsigned oldNumArgs = amendedInputTy.size();
+  SmallVector<Type> amendedInputTy(funcTy.getInputs());
+  Type globalPtrTy = triton::PointerType::get(rewriter.getI8Type(), 1);
+
   amendedInputTy.push_back(globalPtrTy);
   auto amendedFuncTy =
-      FunctionType::get(ctx, amendedInputTy, funcOp.getResultTypes());
+      FunctionType::get(ctx, amendedInputTy, funcTy.getResults());
+  SmallVector<NamedAttribute> amendedAttrs;
+  filterFuncAttributes(funcOp, /*filterArgAttrs=*/true, amendedAttrs);
+  if (auto argAttrs = funcOp.getAllArgAttrs()) {
+    llvm::SmallVector<mlir::Attribute> amendedArgAttrs(argAttrs.begin(),
+                                                       argAttrs.end());
+    while (amendedArgAttrs.size() < amendedInputTy.size()) {
+      amendedArgAttrs.emplace_back(DictionaryAttr::get(ctx));
+    }
+    amendedAttrs.push_back(rewriter.getNamedAttr(
+        funcOp.getArgAttrsAttrName(), rewriter.getArrayAttr(amendedArgAttrs)));
+  }
   auto amendedFuncOp = rewriter.create<triton::FuncOp>(
-      funcOp.getLoc(), funcOp.getName(), amendedFuncTy);
+      funcOp.getLoc(), funcOp.getName(), amendedFuncTy, amendedAttrs);
   auto &region = funcOp.getBody();
-  region.addArgument(globalPtrTy, amendedFuncOp.getLoc());
+  region.addArgument(globalPtrTy, loc);
   rewriter.inlineRegionBefore(region, amendedFuncOp.getBody(),
                               amendedFuncOp.end());
-  IRMapping mapper;
-  if (auto argAttrs = funcOp.getAllArgAttrs()) {
-    SmallVector<Attribute> newArgAttrs;
-    newArgAttrs.reserve(amendedInputTy.size());
-    for (unsigned i = 0; i != oldNumArgs; ++i)
-      if (!mapper.contains(funcOp.getArgument(i)))
-        newArgAttrs.push_back(argAttrs[i]);
-    amendedFuncOp.setAllArgAttrs(newArgAttrs);
-  }
   return amendedFuncOp;
 }
 
@@ -476,24 +80,23 @@ struct AddProtonKernelArg
     MLIRContext *ctx = &getContext();
 
     bool hasProtonGlobalScratchAllocOp = false;
-    moduleOp.walk([&](LLVM::LLVMFuncOp funcOp) {
+    moduleOp.walk([&](triton::FuncOp funcOp) {
       funcOp.walk([&](proton::gpu::GlobalScratchAllocOp op) {
         hasProtonGlobalScratchAllocOp = true;
-        auto funcTy = funcOp.getFunctionType();		    
-	llvm::errs() << funcTy << "\n";
       });
-    });    
+    });
 
-    if (!hasProtonGlobalScratchAllocOp)
-      return;
-
-    assert(llvm::range_size(moduleOp.getOps<LLVM::LLVMFuncOp>()) == 1);
-    LLVM::LLVMFuncOp funcOp = *moduleOp.getOps<LLVM::LLVMFuncOp>().begin();
+    assert(hasProtonGlobalScratchAllocOp &&
+           "Proton scratch alloc op not found");
+    // TODO(crobeck): add support for multiple kernels
+    assert(llvm::range_size(moduleOp.getOps<triton::FuncOp>()) == 1);
+    triton::FuncOp funcOp = *moduleOp.getOps<triton::FuncOp>().begin();
 
     IRRewriter rewriter(ctx);
     rewriter.setInsertionPointToStart(moduleOp.getBody());
-//    auto amendedFuncOp = amendFuncOp(funcOp, rewriter);
-
+    auto amendedFuncOp = insertAmendedFuncOp(funcOp, rewriter);
+    rewriter.eraseOp(funcOp);
+    return;
   }
 };
 
@@ -505,8 +108,7 @@ namespace triton::proton {
 
 namespace gpu {
 
-std::unique_ptr<OperationPass<ModuleOp>>
-createAddProtonKernelArgPass() {
+std::unique_ptr<OperationPass<ModuleOp>> createAddProtonKernelArgPass() {
   return std::make_unique<AddProtonKernelArg>();
 }
 
@@ -514,4 +116,4 @@ createAddProtonKernelArgPass() {
 
 } // namespace triton::proton
 
-} // namespace mlir    
+} // namespace mlir

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/AddProtonKernelArg.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/AddProtonKernelArg.cpp
@@ -1,0 +1,517 @@
+#include "Dialect/ProtonGPU/IR/Dialect.h"
+#include "mlir/Pass/Pass.h"
+#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h"
+
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+#include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/PatternProtonOpToLLVM.h"
+#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Utility.h"
+#include "third_party/proton/dialect/include/Dialect/Proton/IR/Dialect.h"
+#include "third_party/proton/dialect/include/Dialect/ProtonGPU/IR/Dialect.h"
+
+#include "llvm/Support/FormatVariadic.h"
+
+
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace mlir {
+namespace triton::proton {
+#define GEN_PASS_DEF_ADDPROTONKERNELARG
+#include "proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h.inc"
+} // namespace triton::proton
+} // namespace mlir
+
+namespace {
+// The following convertFuncOpToLLVMFuncOp is copied and modified from
+// https://github.com/llvm/llvm-project/blob/main/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
+static constexpr StringRef varargsAttrName = "func.varargs";
+static constexpr StringRef linkageAttrName = "llvm.linkage";
+static constexpr StringRef barePtrAttrName = "llvm.bareptr";
+
+/// Return `true` if the `op` should use bare pointer calling convention.
+static bool shouldUseBarePtrCallConv(Operation *op,
+                                     const LLVMTypeConverter *typeConverter) {
+  return (op && op->hasAttr(barePtrAttrName)) ||
+         typeConverter->getOptions().useBarePtrCallConv;
+}
+
+/// Only retain those attributes that are not constructed by
+/// `LLVMFuncOp::build`.
+static void filterFuncAttributes(FunctionOpInterface func,
+                                 SmallVectorImpl<NamedAttribute> &result) {
+  for (const NamedAttribute &attr : func->getDiscardableAttrs()) {
+    if (attr.getName() == linkageAttrName ||
+        attr.getName() == varargsAttrName ||
+        attr.getName() == LLVM::LLVMDialect::getReadnoneAttrName())
+      continue;
+    result.push_back(attr);
+  }
+}
+
+/// Propagate argument/results attributes.
+static void propagateArgResAttrs(OpBuilder &builder, bool resultStructType,
+                                 FunctionOpInterface funcOp,
+                                 LLVM::LLVMFuncOp wrapperFuncOp) {
+  auto argAttrs = funcOp.getAllArgAttrs();
+  if (!resultStructType) {
+    if (auto resAttrs = funcOp.getAllResultAttrs())
+      wrapperFuncOp.setAllResultAttrs(resAttrs);
+    if (argAttrs)
+      wrapperFuncOp.setAllArgAttrs(argAttrs);
+  } else {
+    SmallVector<Attribute> argAttributes;
+    // Only modify the argument and result attributes when the result is now
+    // an argument.
+    if (argAttrs) {
+      argAttributes.push_back(builder.getDictionaryAttr({}));
+      argAttributes.append(argAttrs.begin(), argAttrs.end());
+      wrapperFuncOp.setAllArgAttrs(argAttributes);
+    }
+  }
+  cast<FunctionOpInterface>(wrapperFuncOp.getOperation())
+      .setVisibility(funcOp.getVisibility());
+}
+
+/// Creates an auxiliary function with pointer-to-memref-descriptor-struct
+/// arguments instead of unpacked arguments. This function can be called from C
+/// by passing a pointer to a C struct corresponding to a memref descriptor.
+/// Similarly, returned memrefs are passed via pointers to a C struct that is
+/// passed as additional argument.
+/// Internally, the auxiliary function unpacks the descriptor into individual
+/// components and forwards them to `newFuncOp` and forwards the results to
+/// the extra arguments.
+static void wrapForExternalCallers(OpBuilder &rewriter, Location loc,
+                                   const LLVMTypeConverter &typeConverter,
+                                   FunctionOpInterface funcOp,
+                                   LLVM::LLVMFuncOp newFuncOp) {
+  auto type = cast<FunctionType>(funcOp.getFunctionType());
+  auto [wrapperFuncType, resultStructType] =
+      typeConverter.convertFunctionTypeCWrapper(type);
+
+  SmallVector<NamedAttribute> attributes;
+  filterFuncAttributes(funcOp, attributes);
+
+  auto wrapperFuncOp = rewriter.create<LLVM::LLVMFuncOp>(
+      loc, llvm::formatv("_mlir_ciface_{0}", funcOp.getName()).str(),
+      wrapperFuncType, LLVM::Linkage::External, /*dsoLocal=*/false,
+      /*cconv=*/LLVM::CConv::C, /*comdat=*/nullptr, attributes);
+  propagateArgResAttrs(rewriter, !!resultStructType, funcOp, wrapperFuncOp);
+
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(wrapperFuncOp.addEntryBlock(rewriter));
+
+  SmallVector<Value, 8> args;
+  size_t argOffset = resultStructType ? 1 : 0;
+  for (auto [index, argType] : llvm::enumerate(type.getInputs())) {
+    Value arg = wrapperFuncOp.getArgument(index + argOffset);
+    if (auto memrefType = dyn_cast<MemRefType>(argType)) {
+      Value loaded = rewriter.create<LLVM::LoadOp>(
+          loc, typeConverter.convertType(memrefType), arg);
+      MemRefDescriptor::unpack(rewriter, loc, loaded, memrefType, args);
+      continue;
+    }
+    if (isa<UnrankedMemRefType>(argType)) {
+      Value loaded = rewriter.create<LLVM::LoadOp>(
+          loc, typeConverter.convertType(argType), arg);
+      UnrankedMemRefDescriptor::unpack(rewriter, loc, loaded, args);
+      continue;
+    }
+
+    args.push_back(arg);
+  }
+
+  auto call = rewriter.create<LLVM::CallOp>(loc, newFuncOp, args);
+
+  if (resultStructType) {
+    rewriter.create<LLVM::StoreOp>(loc, call.getResult(),
+                                   wrapperFuncOp.getArgument(0));
+    rewriter.create<LLVM::ReturnOp>(loc, ValueRange{});
+  } else {
+    rewriter.create<LLVM::ReturnOp>(loc, call.getResults());
+  }
+}
+
+/// Creates an auxiliary function with pointer-to-memref-descriptor-struct
+/// arguments instead of unpacked arguments. Creates a body for the (external)
+/// `newFuncOp` that allocates a memref descriptor on stack, packs the
+/// individual arguments into this descriptor and passes a pointer to it into
+/// the auxiliary function. If the result of the function cannot be directly
+/// returned, we write it to a special first argument that provides a pointer
+/// to a corresponding struct. This auxiliary external function is now
+/// compatible with functions defined in C using pointers to C structs
+/// corresponding to a memref descriptor.
+static void wrapExternalFunction(OpBuilder &builder, Location loc,
+                                 const LLVMTypeConverter &typeConverter,
+                                 FunctionOpInterface funcOp,
+                                 LLVM::LLVMFuncOp newFuncOp) {
+  OpBuilder::InsertionGuard guard(builder);
+
+  auto [wrapperType, resultStructType] =
+      typeConverter.convertFunctionTypeCWrapper(
+          cast<FunctionType>(funcOp.getFunctionType()));
+  // This conversion can only fail if it could not convert one of the argument
+  // types. But since it has been applied to a non-wrapper function before, it
+  // should have failed earlier and not reach this point at all.
+  assert(wrapperType && "unexpected type conversion failure");
+
+  SmallVector<NamedAttribute, 4> attributes;
+  filterFuncAttributes(funcOp, attributes);
+
+  // Create the auxiliary function.
+  auto wrapperFunc = builder.create<LLVM::LLVMFuncOp>(
+      loc, llvm::formatv("_mlir_ciface_{0}", funcOp.getName()).str(),
+      wrapperType, LLVM::Linkage::External, /*dsoLocal=*/false,
+      /*cconv=*/LLVM::CConv::C, /*comdat=*/nullptr, attributes);
+  propagateArgResAttrs(builder, !!resultStructType, funcOp, wrapperFunc);
+
+  // The wrapper that we synthetize here should only be visible in this module.
+  newFuncOp.setLinkage(LLVM::Linkage::Private);
+  builder.setInsertionPointToStart(newFuncOp.addEntryBlock(builder));
+
+  // Get a ValueRange containing arguments.
+  FunctionType type = cast<FunctionType>(funcOp.getFunctionType());
+  SmallVector<Value, 8> args;
+  args.reserve(type.getNumInputs());
+  ValueRange wrapperArgsRange(newFuncOp.getArguments());
+
+  if (resultStructType) {
+    // Allocate the struct on the stack and pass the pointer.
+    Type resultType = cast<LLVM::LLVMFunctionType>(wrapperType).getParamType(0);
+    Value one = builder.create<LLVM::ConstantOp>(
+        loc, typeConverter.convertType(builder.getIndexType()),
+        builder.getIntegerAttr(builder.getIndexType(), 1));
+    Value result =
+        builder.create<LLVM::AllocaOp>(loc, resultType, resultStructType, one);
+    args.push_back(result);
+  }
+
+  // Iterate over the inputs of the original function and pack values into
+  // memref descriptors if the original type is a memref.
+  for (Type input : type.getInputs()) {
+    Value arg;
+    int numToDrop = 1;
+    auto memRefType = dyn_cast<MemRefType>(input);
+    auto unrankedMemRefType = dyn_cast<UnrankedMemRefType>(input);
+    if (memRefType || unrankedMemRefType) {
+      numToDrop = memRefType
+                      ? MemRefDescriptor::getNumUnpackedValues(memRefType)
+                      : UnrankedMemRefDescriptor::getNumUnpackedValues();
+      Value packed =
+          memRefType
+              ? MemRefDescriptor::pack(builder, loc, typeConverter, memRefType,
+                                       wrapperArgsRange.take_front(numToDrop))
+              : UnrankedMemRefDescriptor::pack(
+                    builder, loc, typeConverter, unrankedMemRefType,
+                    wrapperArgsRange.take_front(numToDrop));
+
+      auto ptrTy = LLVM::LLVMPointerType::get(builder.getContext());
+      Value one = builder.create<LLVM::ConstantOp>(
+          loc, typeConverter.convertType(builder.getIndexType()),
+          builder.getIntegerAttr(builder.getIndexType(), 1));
+      Value allocated = builder.create<LLVM::AllocaOp>(
+          loc, ptrTy, packed.getType(), one, /*alignment=*/0);
+      builder.create<LLVM::StoreOp>(loc, packed, allocated);
+      arg = allocated;
+    } else {
+      arg = wrapperArgsRange[0];
+    }
+
+    args.push_back(arg);
+    wrapperArgsRange = wrapperArgsRange.drop_front(numToDrop);
+  }
+  assert(wrapperArgsRange.empty() && "did not map some of the arguments");
+
+  auto call = builder.create<LLVM::CallOp>(loc, wrapperFunc, args);
+
+  if (resultStructType) {
+    Value result =
+        builder.create<LLVM::LoadOp>(loc, resultStructType, args.front());
+    builder.create<LLVM::ReturnOp>(loc, result);
+  } else {
+    builder.create<LLVM::ReturnOp>(loc, call.getResults());
+  }
+}
+
+/// Inserts `llvm.load` ops in the function body to restore the expected pointee
+/// value from `llvm.byval`/`llvm.byref` function arguments that were converted
+/// to LLVM pointer types.
+static void restoreByValRefArgumentType(
+    ConversionPatternRewriter &rewriter, const LLVMTypeConverter &typeConverter,
+    ArrayRef<std::optional<NamedAttribute>> byValRefNonPtrAttrs,
+    ArrayRef<BlockArgument> oldBlockArgs, LLVM::LLVMFuncOp funcOp) {
+  // Nothing to do for function declarations.
+  if (funcOp.isExternal())
+    return;
+
+  ConversionPatternRewriter::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(&funcOp.getFunctionBody().front());
+
+  for (const auto &[arg, oldArg, byValRefAttr] :
+       llvm::zip(funcOp.getArguments(), oldBlockArgs, byValRefNonPtrAttrs)) {
+    // Skip argument if no `llvm.byval` or `llvm.byref` attribute.
+    if (!byValRefAttr)
+      continue;
+
+    // Insert load to retrieve the actual argument passed by value/reference.
+    assert(isa<LLVM::LLVMPointerType>(arg.getType()) &&
+           "Expected LLVM pointer type for argument with "
+           "`llvm.byval`/`llvm.byref` attribute");
+    Type resTy = typeConverter.convertType(
+        cast<TypeAttr>(byValRefAttr->getValue()).getValue());
+
+    auto valueArg = rewriter.create<LLVM::LoadOp>(arg.getLoc(), resTy, arg);
+    rewriter.replaceUsesOfBlockArgument(oldArg, valueArg);
+  }
+}	
+
+FailureOr<LLVM::LLVMFuncOp>
+convertFuncOpToLLVMFuncOp(FunctionOpInterface funcOp,
+                                ConversionPatternRewriter &rewriter,
+                                const LLVMTypeConverter &converter) {
+  // Check the funcOp has `FunctionType`.
+  auto funcTy = dyn_cast<FunctionType>(funcOp.getFunctionType());
+  if (!funcTy)
+    return rewriter.notifyMatchFailure(
+        funcOp, "Only support FunctionOpInterface with FunctionType");
+
+  // Keep track of the entry block arguments. They will be needed later.
+  SmallVector<BlockArgument> oldBlockArgs =
+      llvm::to_vector(funcOp.getArguments());
+
+  // Convert the original function arguments. They are converted using the
+  // LLVMTypeConverter provided to this legalization pattern.
+  auto varargsAttr = funcOp->getAttrOfType<BoolAttr>(varargsAttrName);
+  // Gather `llvm.byval` and `llvm.byref` arguments whose type convertion was
+  // overriden with an LLVM pointer type for later processing.
+  SmallVector<std::optional<NamedAttribute>> byValRefNonPtrAttrs;
+  TypeConverter::SignatureConversion result(funcOp.getNumArguments());
+  auto llvmType = converter.convertFunctionSignature(
+      funcOp, varargsAttr && varargsAttr.getValue(),
+      shouldUseBarePtrCallConv(funcOp, &converter), result,
+      byValRefNonPtrAttrs);
+  if (!llvmType)
+    return rewriter.notifyMatchFailure(funcOp, "signature conversion failed");
+
+  // Create an LLVM function, use external linkage by default until MLIR
+  // functions have linkage.
+  LLVM::Linkage linkage = LLVM::Linkage::External;
+  if (funcOp->hasAttr(linkageAttrName)) {
+    auto attr =
+        dyn_cast<mlir::LLVM::LinkageAttr>(funcOp->getAttr(linkageAttrName));
+    if (!attr) {
+      funcOp->emitError() << "Contains " << linkageAttrName
+                          << " attribute not of type LLVM::LinkageAttr";
+      return rewriter.notifyMatchFailure(
+          funcOp, "Contains linkage attribute not of type LLVM::LinkageAttr");
+    }
+    linkage = attr.getLinkage();
+  }
+
+  SmallVector<NamedAttribute, 4> attributes;
+  filterFuncAttributes(funcOp, attributes);
+  auto newFuncOp = rewriter.create<LLVM::LLVMFuncOp>(
+      funcOp.getLoc(), funcOp.getName(), llvmType, linkage,
+      /*dsoLocal=*/false, /*cconv=*/LLVM::CConv::C, /*comdat=*/nullptr,
+      attributes);
+  cast<FunctionOpInterface>(newFuncOp.getOperation())
+      .setVisibility(funcOp.getVisibility());
+
+  // Create a memory effect attribute corresponding to readnone.
+  StringRef readnoneAttrName = LLVM::LLVMDialect::getReadnoneAttrName();
+  if (funcOp->hasAttr(readnoneAttrName)) {
+    auto attr = funcOp->getAttrOfType<UnitAttr>(readnoneAttrName);
+    if (!attr) {
+      funcOp->emitError() << "Contains " << readnoneAttrName
+                          << " attribute not of type UnitAttr";
+      return rewriter.notifyMatchFailure(
+          funcOp, "Contains readnone attribute not of type UnitAttr");
+    }
+    auto memoryAttr = LLVM::MemoryEffectsAttr::get(
+        rewriter.getContext(),
+        {LLVM::ModRefInfo::NoModRef, LLVM::ModRefInfo::NoModRef,
+         LLVM::ModRefInfo::NoModRef});
+    newFuncOp.setMemoryEffectsAttr(memoryAttr);
+  }
+
+  // Propagate argument/result attributes to all converted arguments/result
+  // obtained after converting a given original argument/result.
+  if (ArrayAttr resAttrDicts = funcOp.getAllResultAttrs()) {
+    assert(!resAttrDicts.empty() && "expected array to be non-empty");
+    if (funcOp.getNumResults() == 1)
+      newFuncOp.setAllResultAttrs(resAttrDicts);
+  }
+  if (ArrayAttr argAttrDicts = funcOp.getAllArgAttrs()) {
+    SmallVector<Attribute> newArgAttrs(
+        cast<LLVM::LLVMFunctionType>(llvmType).getNumParams());
+    for (unsigned i = 0, e = funcOp.getNumArguments(); i < e; ++i) {
+      // Some LLVM IR attribute have a type attached to them. During FuncOp ->
+      // LLVMFuncOp conversion these types may have changed. Account for that
+      // change by converting attributes' types as well.
+      SmallVector<NamedAttribute, 4> convertedAttrs;
+      auto attrsDict = cast<DictionaryAttr>(argAttrDicts[i]);
+      convertedAttrs.reserve(attrsDict.size());
+      for (const NamedAttribute &attr : attrsDict) {
+        const auto convert = [&](const NamedAttribute &attr) {
+          return TypeAttr::get(converter.convertType(
+              cast<TypeAttr>(attr.getValue()).getValue()));
+        };
+        if (attr.getName().getValue() ==
+            LLVM::LLVMDialect::getByValAttrName()) {
+          convertedAttrs.push_back(rewriter.getNamedAttr(
+              LLVM::LLVMDialect::getByValAttrName(), convert(attr)));
+        } else if (attr.getName().getValue() ==
+                   LLVM::LLVMDialect::getByRefAttrName()) {
+          convertedAttrs.push_back(rewriter.getNamedAttr(
+              LLVM::LLVMDialect::getByRefAttrName(), convert(attr)));
+        } else if (attr.getName().getValue() ==
+                   LLVM::LLVMDialect::getStructRetAttrName()) {
+          convertedAttrs.push_back(rewriter.getNamedAttr(
+              LLVM::LLVMDialect::getStructRetAttrName(), convert(attr)));
+        } else if (attr.getName().getValue() ==
+                   LLVM::LLVMDialect::getInAllocaAttrName()) {
+          convertedAttrs.push_back(rewriter.getNamedAttr(
+              LLVM::LLVMDialect::getInAllocaAttrName(), convert(attr)));
+        } else {
+          convertedAttrs.push_back(attr);
+        }
+      }
+      auto mapping = result.getInputMapping(i);
+      assert(mapping && "unexpected deletion of function argument");
+      // Only attach the new argument attributes if there is a one-to-one
+      // mapping from old to new types. Otherwise, attributes might be
+      // attached to types that they do not support.
+      if (mapping->size == 1) {
+        newArgAttrs[mapping->inputNo] =
+            DictionaryAttr::get(rewriter.getContext(), convertedAttrs);
+        continue;
+      }
+      // TODO: Implement custom handling for types that expand to multiple
+      // function arguments.
+      for (size_t j = 0; j < mapping->size; ++j)
+        newArgAttrs[mapping->inputNo + j] =
+            DictionaryAttr::get(rewriter.getContext(), {});
+    }
+    if (!newArgAttrs.empty())
+      newFuncOp.setAllArgAttrs(rewriter.getArrayAttr(newArgAttrs));
+  }
+
+  rewriter.inlineRegionBefore(funcOp.getFunctionBody(), newFuncOp.getBody(),
+                              newFuncOp.end());
+  // Convert just the entry block. The remaining unstructured control flow is
+  // converted by ControlFlowToLLVM.
+  if (!newFuncOp.getBody().empty())
+    rewriter.applySignatureConversion(&newFuncOp.getBody().front(), result,
+                                      &converter);
+
+  // Fix the type mismatch between the materialized `llvm.ptr` and the expected
+  // pointee type in the function body when converting `llvm.byval`/`llvm.byref`
+  // function arguments.
+  restoreByValRefArgumentType(rewriter, converter, byValRefNonPtrAttrs,
+                              oldBlockArgs, newFuncOp);
+
+  if (!shouldUseBarePtrCallConv(funcOp, &converter)) {
+    if (funcOp->getAttrOfType<UnitAttr>(
+            LLVM::LLVMDialect::getEmitCWrapperAttrName())) {
+      if (newFuncOp.isVarArg())
+        return funcOp.emitError("C interface for variadic functions is not "
+                                "supported yet.");
+
+      if (newFuncOp.isExternal())
+        wrapExternalFunction(rewriter, funcOp->getLoc(), converter, funcOp,
+                             newFuncOp);
+      else
+        wrapForExternalCallers(rewriter, funcOp->getLoc(), converter, funcOp,
+                               newFuncOp);
+    }
+  }
+
+  return newFuncOp;
+}
+
+triton::FuncOp amendFuncOp(LLVM::LLVMFuncOp funcOp,
+                           ConversionPatternRewriter &rewriter){
+  auto moduleOp = funcOp->getParentOfType<ModuleOp>();
+  Location loc = moduleOp->getLoc();
+  auto ctx = funcOp->getContext();
+  auto globalPtrTy = LLVM::LLVMPointerType::get(ctx, 1);
+  auto funcTy = funcOp.getFunctionType();
+  auto amendedInputTy = llvm::to_vector(funcOp.getArgumentTypes());
+  unsigned oldNumArgs = amendedInputTy.size();
+  amendedInputTy.push_back(globalPtrTy);
+  auto amendedFuncTy =
+      FunctionType::get(ctx, amendedInputTy, funcOp.getResultTypes());
+  auto amendedFuncOp = rewriter.create<triton::FuncOp>(
+      funcOp.getLoc(), funcOp.getName(), amendedFuncTy);
+  auto &region = funcOp.getBody();
+  region.addArgument(globalPtrTy, amendedFuncOp.getLoc());
+  rewriter.inlineRegionBefore(region, amendedFuncOp.getBody(),
+                              amendedFuncOp.end());
+  IRMapping mapper;
+  if (auto argAttrs = funcOp.getAllArgAttrs()) {
+    SmallVector<Attribute> newArgAttrs;
+    newArgAttrs.reserve(amendedInputTy.size());
+    for (unsigned i = 0; i != oldNumArgs; ++i)
+      if (!mapper.contains(funcOp.getArgument(i)))
+        newArgAttrs.push_back(argAttrs[i]);
+    amendedFuncOp.setAllArgAttrs(newArgAttrs);
+  }
+  return amendedFuncOp;
+}
+
+struct AddProtonKernelArg
+    : public mlir::triton::proton::impl::AddProtonKernelArgBase<
+          AddProtonKernelArg> {
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    MLIRContext *ctx = &getContext();
+
+    bool hasProtonGlobalScratchAllocOp = false;
+    moduleOp.walk([&](LLVM::LLVMFuncOp funcOp) {
+      funcOp.walk([&](proton::gpu::GlobalScratchAllocOp op) {
+        hasProtonGlobalScratchAllocOp = true;
+        auto funcTy = funcOp.getFunctionType();		    
+	llvm::errs() << funcTy << "\n";
+      });
+    });    
+
+    if (!hasProtonGlobalScratchAllocOp)
+      return;
+
+    assert(llvm::range_size(moduleOp.getOps<LLVM::LLVMFuncOp>()) == 1);
+    LLVM::LLVMFuncOp funcOp = *moduleOp.getOps<LLVM::LLVMFuncOp>().begin();
+
+    IRRewriter rewriter(ctx);
+    rewriter.setInsertionPointToStart(moduleOp.getBody());
+//    auto amendedFuncOp = amendFuncOp(funcOp, rewriter);
+
+  }
+};
+
+} // namespace
+
+namespace mlir {
+
+namespace triton::proton {
+
+namespace gpu {
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createAddProtonKernelArgPass() {
+  return std::make_unique<AddProtonKernelArg>();
+}
+
+} // namespace gpu
+
+} // namespace triton::proton
+
+} // namespace mlir    

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonSharedMemory.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonSharedMemory.cpp
@@ -1,0 +1,84 @@
+#include "Dialect/ProtonGPU/IR/Dialect.h"
+#include "mlir/Pass/Pass.h"
+#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/Support/MathExtras.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace mlir {
+namespace triton::proton {
+#define GEN_PASS_DEF_ALLOCATEPROTONSHAREDMEMORY
+#include "proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h.inc"
+} // namespace triton::proton
+} // namespace mlir
+
+namespace {
+
+struct AllocateProtonSharedMemory
+    : public mlir::triton::proton::impl::AllocateProtonSharedMemoryBase<
+          AllocateProtonSharedMemory> {
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    MLIRContext *ctx = &getContext();
+
+    int sharedMemUsed = 0;
+    if (mod->hasAttr("ttg.shared"))
+      sharedMemUsed =
+          mod->getAttrOfType<mlir::IntegerAttr>("ttg.shared").getInt();
+
+    assert(llvm::range_size(mod.getOps<triton::FuncOp>()) == 1);
+    FuncOp func = *mod.getOps<triton::FuncOp>().begin();
+
+    int totalSharedMemSize = 0;
+    int count = 0;
+    func.walk([&](triton::gpu::LocalAllocOp alloc) {
+      // We ignore the shared memory allocations that have been allocated by the
+      // triton conversion pass.
+      if (!alloc->hasAttr("allocation.offset")) {
+        int offset =
+            llvm::alignTo(sharedMemUsed, proton::gpu::getBytesPerClockEntry());
+        alloc->setAttr("allocation.offset",
+                       IntegerAttr::get(IntegerType::get(ctx, 32), offset));
+        // Compute the proton buffer size in bytes.
+        auto memDescTy =
+            mlir::cast<triton::gpu::MemDescType>(alloc.getResult().getType());
+        int bufferSizeInBytes =
+            mlir::ShapedType::getNumElements(memDescTy.getShape()) *
+            memDescTy.getElementType().getIntOrFloatBitWidth() / 8;
+
+        totalSharedMemSize = offset + bufferSizeInBytes;
+        count++;
+      }
+    });
+
+    if (count == 0) {
+      totalSharedMemSize = sharedMemUsed;
+    }
+
+    mod->setAttr("ttg.shared",
+                 mlir::IntegerAttr::get(mlir::IntegerType::get(ctx, 32),
+                                        totalSharedMemSize));
+  }
+};
+
+} // namespace
+
+namespace mlir {
+
+namespace triton::proton {
+
+namespace gpu {
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createAllocateProtonSharedMemoryPass() {
+  return std::make_unique<AllocateProtonSharedMemory>();
+}
+
+} // namespace gpu
+
+} // namespace triton::proton
+
+} // namespace mlir

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/CMakeLists.txt
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_triton_library(ProtonGPUToLLVM
     RecordOpToLLVM.cpp
     ProtonGPUToLLVM.cpp
-    GlobalScratchAllocOpToLLVM.cpp
     AllocateProtonSharedMemory.cpp
     AddProtonKernelArg.cpp
+    GlobalScratchAllocOpToLLVM.cpp
 
     DEPENDS
     ProtonGPUConversionPassIncGen

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/CMakeLists.txt
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/CMakeLists.txt
@@ -1,6 +1,12 @@
 add_triton_library(ProtonGPUToLLVM
     RecordOpToLLVM.cpp
     ProtonGPUToLLVM.cpp
+    GlobalScratchAllocOpToLLVM.cpp
+    AllocateProtonSharedMemory.cpp
+    AddProtonKernelArg.cpp
+
+    DEPENDS
+    ProtonGPUConversionPassIncGen
 
     LINK_LIBS PUBLIC
     ProtonIR

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/GlobalScratchAllocOpToLLVM.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/GlobalScratchAllocOpToLLVM.cpp
@@ -1,0 +1,56 @@
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+#include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+
+#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/PatternProtonOpToLLVM.h"
+#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Utility.h"
+#include "third_party/proton/dialect/include/Dialect/Proton/IR/Dialect.h"
+#include "third_party/proton/dialect/include/Dialect/ProtonGPU/IR/Dialect.h"
+
+namespace {
+using namespace mlir;
+using namespace mlir::triton;
+
+struct GlobalScratchAllocOpConversion
+    : public ConvertOpToLLVMPattern<proton::gpu::GlobalScratchAllocOp> {
+  explicit GlobalScratchAllocOpConversion(LLVMTypeConverter &typeConverter,
+                                          const TargetInfoBase &targetInfo,
+                                          PatternBenefit benefit)
+      : mlir::ConvertOpToLLVMPattern<proton::gpu::GlobalScratchAllocOp>(
+            typeConverter, benefit),
+        targetInfo(targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(proton::gpu::GlobalScratchAllocOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    rewriter.eraseOp(op);
+    auto funcOp = op->getParentOfType<LLVM::LLVMFuncOp>();
+    auto ctx = funcOp->getContext();
+    auto loc = funcOp.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto gmemBase = funcOp.getArgument(funcOp.getNumArguments() - 1);
+    // TODO: implement this offset value
+    auto opOffset = 0;
+    auto llvmPointerType = LLVM::LLVMPointerType::get(ctx);
+    rewriter.create<LLVM::GEPOp>(loc, llvmPointerType, llvmPointerType,
+                                 gmemBase, b.i32_val(opOffset));
+    return success();
+  }
+
+protected:
+  const TargetInfoBase &targetInfo;
+};
+
+} // namespace
+
+void mlir::triton::proton::populateGlobalScratchAllocOpToLLVMPattern(
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    const TargetInfoBase &targetInfo, PatternBenefit benefit) {
+  patterns.add<GlobalScratchAllocOpConversion>(typeConverter, targetInfo,
+                                               benefit);
+}

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/ProtonGPUToLLVM.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/ProtonGPUToLLVM.cpp
@@ -15,6 +15,8 @@ void populateProtonOpPatterns(LLVMTypeConverter &typeConverter,
                               RewritePatternSet &patterns,
                               const TargetInfoBase &targetInfo,
                               PatternBenefit benefit) {
+  populateGlobalScratchAllocOpToLLVMPattern(typeConverter, patterns, targetInfo,
+                                            benefit);
   populateRecordOpToLLVMPattern(typeConverter, patterns, targetInfo, benefit);
 }
 

--- a/third_party/proton/dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
+++ b/third_party/proton/dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
@@ -102,8 +102,13 @@ public:
     const int circularHeaderSize = 16;           // byte size
     // TODO(fywkevin): we should consider the WS support for shared memory
     // allocation.
+
+    // We take any available shared memory left to allocate the circular buffer.
+    // The buffer size must be power of 2.
     int sharedSlots =
-        llvm::PowerOf2Ceil((maxSharedMem - sharedMemUsed) / bytesPerEntry);
+        llvm::NextPowerOf2(
+            (maxSharedMem - llvm::alignTo(sharedMemUsed, bytesPerEntry))) /
+        (2 * bytesPerEntry);
     int allocSharedMemSize = sharedSlots * bytesPerEntry;
     int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
     int allocBufferSize = bufferSize > 0 ? bufferSize : allocSharedMemSize;


### PR DESCRIPTION
This pass implements the Proton Dialect GlobalScratchAllocOp to LLVM conversion. This takes the proton global scratch alloc operation and rewrites with a a gep to the kernel arg ptr for device to host transfers of performance data collected on the GPU.