### PR TITLE
[Blackwell] Support mxfp with 8 warps

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -275,6 +275,9 @@ chooseScaledMfmaOperandLayout(AMDMfmaEncodingAttr mfmaEnc, int kWidth,
                               int dotOperandIdx, ScaleDotElemType elemType,
                               llvm::ArrayRef<int64_t> dotOperandShape);
 
+LinearLayout getScaleTMEMStoreLinearLayout(RankedTensorType scaleType,
+                                           int numWarps);
+
 // Create LinearLayout for scale in scaled mfma.
 LinearLayout chooseScaledMfmaScaleLayout(
     MLIRContext *ctx, int dotOperandIdx,

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1503,18 +1503,23 @@ LinearLayout getScaleTMEMStoreLinearLayout(RankedTensorType scaleType,
   int64_t N = scaleType.getDimSize(1);
   auto CTALayout = getCTALayout(scaleType.getEncoding());
   basisT regBase;
-  for (int i = 1; i < N; i = i << 1) {
-    regBase.push_back({0, i});
+
+  for (int i = 1; i < 4; i = i << 1) {
+    if (i >= N)
+      regBase.push_back({0, 0});
+    else
+      regBase.push_back({0, i});
   }
-  // For N < 4, duplicate the scales up to 4 elements.
-  for (int i = N; i < 4; i = i << 1) {
-    regBase.push_back({0, 0});
-  }
+
   basisT laneBase = {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}};
   basisT warpBase = {{0, 0}, {0, 0}};
   for (int i = 32; i < M; i = i << 1) {
     regBase.push_back({i, 0});
   }
+  for (int i = 4; i < N; i = i << 1) {
+    regBase.push_back({0, i});
+  }
+
   SmallVector<StringAttr> outDimNames = standardOutDimNames(ctx, 2);
   auto regLanes =
       LinearLayout({{kRegister, regBase}, {kLane, laneBase}, {kWarp, warpBase}},

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1492,6 +1492,7 @@ LinearLayout chooseScaledMfmaScaleLayout(
 
 LinearLayout getScaleTMEMStoreLinearLayout(RankedTensorType scaleType,
                                            int numWarps) {
+  assert(numWarps == 4 || numWarps == 8);
   MLIRContext *ctx = scaleType.getContext();
 
   using basisT = std::vector<std::vector<int32_t>>;
@@ -1518,6 +1519,10 @@ LinearLayout getScaleTMEMStoreLinearLayout(RankedTensorType scaleType,
   }
   for (int i = 4; i < N; i = i << 1) {
     regBase.push_back({0, i});
+  }
+  if (numWarps == 8) {
+    warpBase.push_back(regBase.back());
+    regBase.pop_back();
   }
 
   SmallVector<StringAttr> outDimNames = standardOutDimNames(ctx, 2);

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -396,7 +396,6 @@ public:
 // Pick the layout to match MXFP scales layout in register so that it can be
 // copied directly using tmem st.
 static Attribute getTmemScales(RankedTensorType type, unsigned numWarps) {
-  assert(numWarps == 4 || numWarps == 8);
   return triton::gpu::LinearEncodingAttr::get(
       type.getContext(), getScaleTMEMStoreLinearLayout(type, numWarps));
 }

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -396,6 +396,7 @@ public:
 // Pick the layout to match MXFP scales layout in register so that it can be
 // copied directly using tmem st.
 static Attribute getTmemScales(RankedTensorType type, unsigned numWarps) {
+  assert(numWarps == 4 || numWarps == 8);
   return triton::gpu::LinearEncodingAttr::get(
       type.getContext(), getScaleTMEMStoreLinearLayout(type, numWarps));
 }

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -164,9 +164,10 @@ bool isDistributedLayoutTMemCompatible(Operation *op,
     assert(isa<triton::nvidia_gpu::TensorMemoryScalesEncodingAttr>(
                memType.getEncoding()) &&
            "Expecting a tensor memory encoding attribute");
-    blockM = 128;
-    blockN = 32;
-    scalesEncoding = true;
+    return tensorType.getEncoding() ==
+           triton::gpu::LinearEncodingAttr::get(
+               tensorType.getContext(),
+               getScaleTMEMStoreLinearLayout(tensorType, numWarps));
   }
   auto shapePerCTA = mlir::triton::gpu::getShapePerCTA(tensorType);
   int numElements = product(shapePerCTA);
@@ -185,7 +186,7 @@ bool isDistributedLayoutTMemCompatible(Operation *op,
   if (order.size() != 2)
     return false;
 
-  if (!scalesEncoding && (order[0] != 0 || order[1] != 1))
+  if (order[0] != 0 || order[1] != 1)
     return false;
 
   if (useStridedMessage) {

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -313,7 +313,7 @@ def fp8e8m0_to_float32(scale):
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 128), (256, 128, 128), (128, 256, 128),
                                                        (128, 256, 256), (128, 128, 64), (128, 64, 128)])
 @pytest.mark.parametrize("NUM_STAGES", [1, 3])
-@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else []))
+@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else [0]))
 def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, device):
     if is_cuda() and torch.cuda.get_device_capability()[0] < 10:
         pytest.skip("Requires compute capability >= 10")
@@ -736,7 +736,7 @@ def block_scale_fp4_matmul(  #
 @pytest.mark.parametrize("with_b_scale", [True, False])
 @pytest.mark.parametrize(("scale_type", "VEC_SIZE"), [("float8_e8m0fnu", 32), ("float8_e4m3fn", 16)],
                          ids=["mxfp4", "nvfp4"])
-@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else []))
+@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else [0]))
 def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, with_a_scale, with_b_scale, scale_type, nonKDim,
                          device):
     if is_cuda():
@@ -876,7 +876,7 @@ def mxfp8_mxfp4_matmul(  #
 @pytest.mark.parametrize("B_DATA_TYPE", ["float8e5", "float8e4nv", "float4"])
 @pytest.mark.parametrize("WITH_A_SCALE", [True, False])
 @pytest.mark.parametrize("WITH_B_SCALE", [True, False])
-@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else []))
+@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else [0]))
 def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TRANS, CONST_SCALE, A_DATA_TYPE,
                             B_DATA_TYPE, WITH_A_SCALE, WITH_B_SCALE, nonKDim, device):
     if is_cuda():

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -313,8 +313,9 @@ def fp8e8m0_to_float32(scale):
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 128), (256, 128, 128), (128, 256, 128),
                                                        (128, 256, 256), (128, 128, 64), (128, 64, 128)])
 @pytest.mark.parametrize("NUM_STAGES", [1, 3])
+@pytest.mark.parametrize("NUM_WARPS", [4, 8])
 @pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else [0]))
-def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, device):
+def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS, device):
     if is_cuda() and torch.cuda.get_device_capability()[0] < 10:
         pytest.skip("Requires compute capability >= 10")
     elif is_hip():
@@ -345,7 +346,7 @@ def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, device):
         kernel_kwargs["matrix_instr_nonkdim"] = nonKDim
     out = mxfp_matmul[grid](a, b, output, a_scale, b_scale, M, N, K, a_scale.stride(0), a.stride(0), a.stride(1),
                             b.stride(0), b.stride(1), output.stride(0), output.stride(1), BLOCK_M, BLOCK_N, BLOCK_K,
-                            NUM_STAGES=NUM_STAGES, **kernel_kwargs)
+                            NUM_STAGES=NUM_STAGES, **kernel_kwargs, num_warps=NUM_WARPS)
     a_scale_f32 = fp8e8m0_to_float32(a_scale)
     b_scale_f32 = fp8e8m0_to_float32(b_scale)
     a_scale_f32 = a_scale_f32.repeat_interleave(32, dim=1)


### PR DESCRIPTION
Relax restriction on gen05_scaled_dot op to support 8 warps.

Move the layout used for the storing into tmem to use linear for more flexibility.