### PR TITLE
[AMD] incorporate `tl.assume` into RangeAnalysis and support more ops

### DIFF
--- a/third_party/amd/lib/Analysis/RangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/RangeAnalysis.cpp
@@ -127,7 +127,7 @@ std::optional<ConstantIntRanges> maybeGetAssumedRange(Operation *assumption,
     emitRemark(assumption->getLoc(),
                "unsigned arithmetic not currently supported");
     return {};
-  default:;
+  default:
     break;
   }
   bool isSigned = true;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -85,7 +85,7 @@ bool verifyNonNegativeExpr(Value expr, const DenseSet<Value> &assumptions,
   LDBG("Determing if non-negative: " << expr);
 
   if (!llvm::isa<mlir::BlockArgument>(expr) &&
-      succeeded(AMD::staticallyNonNegative(*solver, expr))) {
+      succeeded(dataflow::staticallyNonNegative(*solver, expr))) {
     return true;
   }
 
@@ -491,8 +491,9 @@ public:
     // Collect assumptions in the function
     DenseSet<Value> assumptions;
     mod.walk([&](LLVM::AssumeOp op) {
-      if (op->getOperand(0).getDefiningOp<arith::CmpIOp>())
-        assumptions.insert(op->getOperand(0));
+      auto oper = op->getOperand(0);
+      if (oper.getDefiningOp<arith::CmpIOp>())
+        assumptions.insert(oper);
     });
     LLVM_DEBUG({
       DBGS() << "Number of assumptions found: " << assumptions.size() << "\n";


### PR DESCRIPTION
This PR implements initializing lattice ranges using assumptions, ie things like `tl.assume(K < 128)` initializing K to have integer range `[-smax, 128]`.

Additionally it adds support for range inference for various `tt`/`ttg` ops.