### PR TITLE
[AMD] IWYU for RangeAnalysis

### DIFF
--- a/third_party/amd/lib/Analysis/CMakeLists.txt
+++ b/third_party/amd/lib/Analysis/CMakeLists.txt
@@ -3,9 +3,6 @@ add_triton_library(TritonAMDAnalysis
 
   DEPENDS
   TritonTableGen
-  TritonGPUTableGen
-  TritonGPUAttrDefsIncGen
-  TritonGPUTypeInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRAnalysis


### PR DESCRIPTION
Remove unncessary headers which will decouple for required tablegen targets that aren't currently specified (and also removed unnecessary tablegen targets).

cc @danzimm 