### PR TITLE
[PROTON-DEV] protongpu shared memory buffer conversion pass

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -2,6 +2,7 @@
 #include "amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "amd/include/TritonAMDGPUTransforms/Passes.h"
 #include "third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h"
+#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h"
 #include "third_party/proton/dialect/include/Conversion/ProtonToProtonGPU/Passes.h"
 #include "third_party/proton/dialect/include/Dialect/Proton/IR/Dialect.h"
 #include "third_party/proton/dialect/include/Dialect/ProtonGPU/IR/Dialect.h"
@@ -76,6 +77,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   // Proton passes
   mlir::test::proton::registerTestScopeIdAllocationPass();
   mlir::triton::proton::registerConvertProtonToProtonGPU();
+  mlir::triton::proton::registerAllocateProtonSharedMemoryPass();
 
   // TODO: register Triton & TritonGPU passes
   registry.insert<mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,

--- a/test/Proton/allocate_shared_memory.mlir
+++ b/test/Proton/allocate_shared_memory.mlir
@@ -1,0 +1,35 @@
+// RUN: triton-opt --split-input-file -allocate-shared-memory -convert-proton-to-protongpu="max-shared-mem=4096" -allocate-proton-shared-memory -canonicalize -cse %s | FileCheck %s
+
+#A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+
+// CHECK: ttg.shared = 5632 : i32
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: allocate_aligned
+  tt.func @allocate_aligned(%A : !tt.ptr<f16>) {
+  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record start "name0"
+  %cst1 = ttg.local_alloc : () -> !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %cst2 = ttg.local_alloc : () -> !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst0 : !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst1 : !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record end "name0"
+  ttg.local_dealloc %cst2 : !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // CHECK: ttg.local_alloc  {allocation.offset = 1536 : i32}
+  tt.return
+  }
+}
+
+// -----
+
+// CHECK: module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5632 : i32}
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: allocate_unaligned
+  tt.func @allocate_unaligned(%A : !tt.ptr<f16>) {
+  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<15xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record start "name0"
+  ttg.local_dealloc %cst0 : !ttg.memdesc<15xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  proton.record end "name0"
+  // CHECK: ttg.local_alloc  {allocation.offset = 1536 : i32} : () -> !ttg.memdesc<1024xi32, #shared, #smem, mutable>
+  tt.return
+  }
+}

--- a/test/Proton/allocate_shared_memory.mlir
+++ b/test/Proton/allocate_shared_memory.mlir
@@ -1,19 +1,18 @@
-// RUN: triton-opt --split-input-file -allocate-shared-memory -convert-proton-to-protongpu="max-shared-mem=4096" -allocate-proton-shared-memory -canonicalize -cse %s | FileCheck %s
+// RUN: triton-opt --split-input-file -allocate-shared-memory -convert-proton-to-protongpu="max-shared-mem=4096" -allocate-proton-shared-memory %s | FileCheck %s
 
 #A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
-
-// CHECK: ttg.shared = 5632 : i32
+// CHECK: ttg.shared = 3584 : i32
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
   // CHECK-LABEL: allocate_aligned
   tt.func @allocate_aligned(%A : !tt.ptr<f16>) {
-  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
   proton.record start "name0"
-  %cst1 = ttg.local_alloc : () -> !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
-  %cst2 = ttg.local_alloc : () -> !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
-  ttg.local_dealloc %cst0 : !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
-  ttg.local_dealloc %cst1 : !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %cst1 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %cst2 = ttg.local_alloc : () -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst0 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst1 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
   proton.record end "name0"
-  ttg.local_dealloc %cst2 : !ttg.memdesc<1x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst2 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
   // CHECK: ttg.local_alloc  {allocation.offset = 1536 : i32}
   tt.return
   }
@@ -21,15 +20,31 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 
 // -----
 
-// CHECK: module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5632 : i32}
+#A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+// CHECK: ttg.shared = 2064 : i32
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
   // CHECK-LABEL: allocate_unaligned
   tt.func @allocate_unaligned(%A : !tt.ptr<f16>) {
-  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<15xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<1x6xf16, #A_SHARED, #ttg.shared_memory, mutable>
   proton.record start "name0"
-  ttg.local_dealloc %cst0 : !ttg.memdesc<15xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst0 : !ttg.memdesc<1x6xf16, #A_SHARED, #ttg.shared_memory, mutable>
   proton.record end "name0"
-  // CHECK: ttg.local_alloc  {allocation.offset = 1536 : i32} : () -> !ttg.memdesc<1024xi32, #shared, #smem, mutable>
+  // CHECK: ttg.local_alloc  {allocation.offset = 16 : i32}
+  tt.return
+  }
+}
+
+// -----
+
+#A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+// CHECK: ttg.shared = 50 : i32
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: no_proton
+  tt.func @no_proton(%A : !tt.ptr<f16>) {
+  %cst0 = ttg.local_alloc : () -> !ttg.memdesc<1x25xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %cst0 : !ttg.memdesc<1x25xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // CHECK: ttg.local_alloc
+  // CHECK-NOT: ttg.local_alloc
   tt.return
   }
 }

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/CMakeLists.txt
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls --name ProtonGPUToLLVM)
+add_public_tablegen_target(ProtonGPUConversionPassIncGen)

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h
@@ -1,0 +1,32 @@
+#ifndef PROTONGPU_CONVERSION_PROTONGPUTOLLVM_PASSES_H
+#define PROTONGPU_CONVERSION_PROTONGPUTOLLVM_PASSES_H
+
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include <memory>
+
+namespace mlir {
+
+class ModuleOp;
+template <typename T> class OperationPass;
+
+namespace triton::proton {
+
+#define GEN_PASS_DECL
+#include "proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h.inc"
+
+namespace gpu {
+std::unique_ptr<OperationPass<ModuleOp>> createAllocateProtonSharedMemoryPass();
+
+} // namespace gpu
+
+#define GEN_PASS_REGISTRATION
+#include "proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h.inc"
+
+} // namespace triton::proton
+
+} // namespace mlir
+
+#endif

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.td
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.td
@@ -1,0 +1,16 @@
+#ifndef PROTONCOMMONGPU_CONVERSION_PASSES
+#define PROTONCOMMONGPU_CONVERSION_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def AllocateProtonSharedMemory : Pass<"allocate-proton-shared-memory", "mlir::ModuleOp"> {
+    let summary = "Update metadata for proton shared memory allocation";
+    let description = [{
+      This pass updates the amount of shared/local memory used due to 
+      proton intra kernel profiling.
+     }];
+
+    let constructor = "mlir::triton::proton::gpu::createAllocateProtonSharedMemoryPass()";
+}
+
+#endif

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.td
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.td
@@ -6,7 +6,7 @@ include "mlir/Pass/PassBase.td"
 def AllocateProtonSharedMemory : Pass<"allocate-proton-shared-memory", "mlir::ModuleOp"> {
     let summary = "Update metadata for proton shared memory allocation";
     let description = [{
-      This pass updates the amount of shared/local memory used due to 
+      This pass updates the amount of shared/local memory used due to
       proton intra kernel profiling.
      }];
 

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonSharedMemory.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonSharedMemory.cpp
@@ -45,7 +45,9 @@ struct AllocateProtonSharedMemory
         // Compute the proton buffer size in bytes.
         auto memDescTy =
             mlir::cast<triton::gpu::MemDescType>(alloc.getResult().getType());
-        int bufferSizeInBytes = memDescTy.getShape()[0] * 4;
+        int bufferSizeInBytes =
+            mlir::ShapedType::getNumElements(memDescTy.getShape()) *
+            memDescTy.getElementType().getIntOrFloatBitWidth() / 8;
 
         totalSharedMemSize = offset + bufferSizeInBytes;
         count++;

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonSharedMemory.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonSharedMemory.cpp
@@ -52,13 +52,7 @@ struct AllocateProtonSharedMemory
       }
     });
 
-    if (count > 1) {
-      mlir::emitError(
-          func.getLoc(),
-          "we expect proton allocates a single shared memory buffer");
-      signalPassFailure();
-      return;
-    } else if (count == 0) {
+    if (count == 0) {
       totalSharedMemSize = sharedMemUsed;
     }
 

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonSharedMemory.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonSharedMemory.cpp
@@ -42,8 +42,7 @@ struct AllocateProtonSharedMemory
             llvm::alignTo(sharedMemUsed, proton::gpu::getBytesPerClockEntry());
         alloc->setAttr("allocation.offset",
                        IntegerAttr::get(IntegerType::get(ctx, 32), offset));
-        // Compute the proton buffer size in bytes: the shape, for example is
-        // something like <1024xi32>
+        // Compute the proton buffer size in bytes.
         auto memDescTy =
             mlir::cast<triton::gpu::MemDescType>(alloc.getResult().getType());
         int bufferSizeInBytes = memDescTy.getShape()[0] * 4;
@@ -59,6 +58,8 @@ struct AllocateProtonSharedMemory
           "we expect proton allocates a single shared memory buffer");
       signalPassFailure();
       return;
+    } else if (count == 0) {
+      totalSharedMemSize = sharedMemUsed;
     }
 
     mod->setAttr("ttg.shared",

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonSharedMemory.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonSharedMemory.cpp
@@ -1,0 +1,87 @@
+#include "Dialect/ProtonGPU/IR/Dialect.h"
+#include "mlir/Pass/Pass.h"
+#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/Support/MathExtras.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace mlir {
+namespace triton::proton {
+#define GEN_PASS_DEF_ALLOCATEPROTONSHAREDMEMORY
+#include "proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h.inc"
+} // namespace triton::proton
+} // namespace mlir
+
+namespace {
+
+struct AllocateProtonSharedMemory
+    : public mlir::triton::proton::impl::AllocateProtonSharedMemoryBase<
+          AllocateProtonSharedMemory> {
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    MLIRContext *ctx = &getContext();
+
+    int sharedMemUsed = 0;
+    if (mod->hasAttr("ttg.shared"))
+      sharedMemUsed =
+          mod->getAttrOfType<mlir::IntegerAttr>("ttg.shared").getInt();
+
+    assert(llvm::range_size(mod.getOps<triton::FuncOp>()) == 1);
+    FuncOp func = *mod.getOps<triton::FuncOp>().begin();
+
+    int totalSharedMemSize = 0;
+    int count = 0;
+    func.walk([&](triton::gpu::LocalAllocOp alloc) {
+      // We ignore the shared memory allocations that have been allocated by the
+      // triton conversion pass.
+      if (!alloc->hasAttr("allocation.offset")) {
+        int offset =
+            llvm::alignTo(sharedMemUsed, proton::gpu::getBytesPerClockEntry());
+        alloc->setAttr("allocation.offset",
+                       IntegerAttr::get(IntegerType::get(ctx, 32), offset));
+        // Compute the proton buffer size in bytes: the shape, for example is
+        // something like <1024xi32>
+        auto memDescTy =
+            mlir::cast<triton::gpu::MemDescType>(alloc.getResult().getType());
+        int bufferSizeInBytes = memDescTy.getShape()[0] * 4;
+
+        totalSharedMemSize = offset + bufferSizeInBytes;
+        count++;
+      }
+    });
+
+    if (count > 1) {
+      mlir::emitError(
+          func.getLoc(),
+          "we expect proton allocates a single shared memory buffer");
+      signalPassFailure();
+      return;
+    }
+
+    mod->setAttr("ttg.shared",
+                 mlir::IntegerAttr::get(mlir::IntegerType::get(ctx, 32),
+                                        totalSharedMemSize));
+  }
+};
+
+} // namespace
+
+namespace mlir {
+
+namespace triton::proton {
+
+namespace gpu {
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createAllocateProtonSharedMemoryPass() {
+  return std::make_unique<AllocateProtonSharedMemory>();
+}
+
+} // namespace gpu
+
+} // namespace triton::proton
+
+} // namespace mlir

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/CMakeLists.txt
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_triton_library(ProtonGPUToLLVM
     RecordOpToLLVM.cpp
     ProtonGPUToLLVM.cpp
+    AllocateProtonSharedMemory.cpp
+
+    DEPENDS
+    ProtonGPUConversionPassIncGen
 
     LINK_LIBS PUBLIC
     ProtonIR

--- a/third_party/proton/dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
+++ b/third_party/proton/dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
@@ -102,9 +102,12 @@ public:
     const int circularHeaderSize = 16;           // byte size
     // TODO(fywkevin): we should consider the WS support for shared memory
     // allocation.
-    int sharedSlots =
-        llvm::PowerOf2Ceil((maxSharedMem - sharedMemUsed) / bytesPerEntry);
+    // TODO: considers to align of offset 8 bytes.
+    int sharedSlots = llvm::NextPowerOf2((maxSharedMem - sharedMemUsed)) /
+                      (2 * bytesPerEntry);
     int allocSharedMemSize = sharedSlots * bytesPerEntry;
+    llvm::outs() << "sharedMemUsed: " << sharedMemUsed << "\n";
+    llvm::outs() << "sharedSlots: " << sharedSlots << "\n";
     int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
     int allocBufferSize = bufferSize > 0 ? bufferSize : allocSharedMemSize;
     if (!allocBufferSize) {

--- a/third_party/proton/dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
+++ b/third_party/proton/dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
@@ -102,12 +102,14 @@ public:
     const int circularHeaderSize = 16;           // byte size
     // TODO(fywkevin): we should consider the WS support for shared memory
     // allocation.
-    // TODO: considers to align of offset 8 bytes.
-    int sharedSlots = llvm::NextPowerOf2((maxSharedMem - sharedMemUsed)) /
-                      (2 * bytesPerEntry);
+
+    // We take any available shared memory left to allocate the circular buffer.
+    // The buffer size must be power of 2.
+    int sharedSlots =
+        llvm::NextPowerOf2(
+            (maxSharedMem - llvm::alignTo(sharedMemUsed, bytesPerEntry))) /
+        (2 * bytesPerEntry);
     int allocSharedMemSize = sharedSlots * bytesPerEntry;
-    llvm::outs() << "sharedMemUsed: " << sharedMemUsed << "\n";
-    llvm::outs() << "sharedSlots: " << sharedSlots << "\n";
     int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
     int allocBufferSize = bufferSize > 0 ? bufferSize : allocSharedMemSize;
     if (!allocBufferSize) {


### PR DESCRIPTION
In this PR, we add the support for proton's internal SMEM profiling buffer conversion. This pass happens after `proton-to-protongpu` lowering and after the general triton's `shared-memory-alloc` pass. We basically override the `ttg.shared` attributes and annotate the shared memory alloc op proton inserted.