### PR TITLE
[AMD]Lower fp8 tl.dot to scaled mfma on gfx950

### DIFF
--- a/test/TritonGPU/amd/accelerate-amd-matmul-mfma-gfx950.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-mfma-gfx950.mlir
@@ -1,6 +1,8 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-accelerate-matmul='arch-generation-name=gfx950 matrix-instruction-size=0' | FileCheck %s --check-prefixes CHECK
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK{LITERAL}: #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 32], [64, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 16]], warp = [[0, 0], [32, 0]], block = []}>
 // CHECK{LITERAL}: #linear1 = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [32, 0], [0, 64]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [16, 0]], warp = [[0, 32], [0, 0]], block = []}>
 // CHECK{LITERAL}: #linear2 = #ttg.linear<{register = [[0, 2], [64, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 1]], warp = [[0, 0], [32, 0]], block = []}>
@@ -8,96 +10,104 @@
 // CHECK-LABEL: mfma_dot_scaled_mxfp4_mxfp4
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @mfma_dot_scaled_mxfp4_mxfp4(
-      %arg0: tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
-      %arg1: tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
-      %arg2: tensor<128x4xi8>,
-      %arg3: tensor<128x4xi8>,
-      %arg4: tensor<128x128x!tt.ptr<f32>, #blocked>
+      %arg0: tensor<128x64xi8, #blocked>,
+      %arg1: tensor<64x128xi8, #blocked1>,
+      %arg2: tensor<128x4xi8, #blocked2>,
+      %arg3: tensor<128x4xi8, #blocked2>,
+      %arg4: tensor<128x128x!tt.ptr<f32>, #blocked1>
       ) {
     // CHECK-NOT: arith.constant dense<127> : tensor<128x4xi8, #linear>
     // CHECK-NOT: arith.constant dense<127> : tensor<128x4xi8, #linear1>
     // CHECK-NOT: tt.fp_to_fp
-    // CHECK: %[[C:.+]] = ttg.convert_layout {{.*}} : tensor<128x128xf32, #blocked> -> tensor<128x128xf32, #mma>
-    // CHECK: %[[A:.+]] = ttg.convert_layout {{.*}} : tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<128x64xi8, #linear>
-    // CHECK: %[[B:.+]] = ttg.convert_layout {{.*}} : tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x128xi8, #linear1>
-    // CHECK: %[[SCALE0:.+]] = ttg.convert_layout {{.*}} : {{.*}} -> tensor<128x4xi8, #linear2>
-    // CHECK: %[[SCALE1:.+]] = ttg.convert_layout {{.*}} : {{.*}} -> tensor<128x4xi8, #linear3>
+    // CHECK: %[[C:.+]] = ttg.convert_layout {{.*}} : tensor<128x128xf32, #blocked1> -> tensor<128x128xf32, #mma>
+    // CHECK: %[[A:.+]] = ttg.convert_layout {{.*}} : tensor<128x64xi8, #blocked> -> tensor<128x64xi8, #linear>
+    // CHECK: %[[B:.+]] = ttg.convert_layout {{.*}} : tensor<64x128xi8, #blocked1> -> tensor<64x128xi8, #linear1>
+    // CHECK: %[[SCALE0:.+]] = ttg.convert_layout {{.*}} : tensor<128x4xi8, #blocked2> -> tensor<128x4xi8, #linear2>
+    // CHECK: %[[SCALE1:.+]] = ttg.convert_layout {{.*}} : tensor<128x4xi8, #blocked2> -> tensor<128x4xi8, #linear3>
     // CHECK: tt.dot_scaled %[[A]] scale %[[SCALE0]], %[[B]] scale %[[SCALE1]], %[[C]] lhs = e2m1 rhs = e2m1
-    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
-    %1 = tt.dot_scaled %arg0 scale %arg2, %arg1 scale %arg3, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, tensor<128x4xi8> * tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, tensor<128x4xi8> -> tensor<128x128xf32, #blocked>
-    tt.store %arg4, %1 : tensor<128x128x!tt.ptr<f32>, #blocked>
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    // %1 = tt.dot_scaled %arg0 scale %arg2, %arg1 scale %arg3, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #linear>, tensor<128x4xi8, #linear2> * tensor<64x128xi8, #linear1>, tensor<128x4xi8, #linear3> -> tensor<128x128xf32, #mma>
+    %1 = tt.dot_scaled %arg0 scale %arg2, %arg1 scale %arg3, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #blocked>, tensor<128x4xi8, #blocked2> * tensor<64x128xi8, #blocked1>, tensor<128x4xi8, #blocked2> -> tensor<128x128xf32, #blocked1>
+    tt.store %arg4, %1 : tensor<128x128x!tt.ptr<f32>, #blocked1>
     tt.return
   }
 }
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK-LABEL: mfma_dot_scaled_mxfp4_fp4
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @mfma_dot_scaled_mxfp4_fp4(
-      %arg0: tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
-      %arg1: tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
-      %arg2: tensor<128x4xi8>,
-      %arg3: tensor<128x128x!tt.ptr<f32>, #blocked>
+      %arg0: tensor<128x64xi8, #blocked>,
+      %arg1: tensor<64x128xi8, #blocked1>,
+      %arg2: tensor<128x4xi8, #blocked2>,
+      %arg3: tensor<128x128x!tt.ptr<f32>, #blocked1>
       ) {
     // CHECK-NOT: tt.fp_to_fp
     // CHECK: %[[CST1:.+]] = arith.constant dense<127> : tensor<128x4xi8, #linear>
-    // CHECK: %[[SCALE0:.+]] = ttg.convert_layout {{.*}} : {{.*}} -> tensor<128x4xi8, #linear3>
+    // CHECK: %[[SCALE0:.+]] = ttg.convert_layout {{.*}} : tensor<128x4xi8, #blocked2> -> tensor<128x4xi8, #linear3>
     // CHECK: tt.dot_scaled {{.*}} scale %[[SCALE0]], {{.*}} scale %[[CST1]], {{.*}} lhs = e2m1 rhs = e2m1
-    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
-    %1 = tt.dot_scaled %arg0 scale %arg2, %arg1, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, tensor<128x4xi8> * tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
-    tt.store %arg3, %1 : tensor<128x128x!tt.ptr<f32>, #blocked>
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    %1 = tt.dot_scaled %arg0 scale %arg2, %arg1, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #blocked>, tensor<128x4xi8, #blocked2> * tensor<64x128xi8, #blocked1> -> tensor<128x128xf32, #blocked1>
+    tt.store %arg3, %1 : tensor<128x128x!tt.ptr<f32>, #blocked1>
     tt.return
   }
 }
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK-LABEL: mfma_dot_scaled_fp4_mxfp4
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @mfma_dot_scaled_fp4_mxfp4(
-      %arg0: tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
-      %arg1: tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
-      %arg2: tensor<128x4xi8>,
-      %arg3: tensor<128x128x!tt.ptr<f32>, #blocked>
+      %arg0: tensor<128x64xi8, #blocked>,
+      %arg1: tensor<64x128xi8, #blocked1>,
+      %arg2: tensor<128x4xi8, #blocked2>,
+      %arg3: tensor<128x128x!tt.ptr<f32>, #blocked1>
       ) {
     // CHECK-NOT: tt.fp_to_fp
     // CHECK: %[[CST0:.+]] = arith.constant dense<127> : tensor<128x4xi8, #linear>
-    // CHECK: %[[SCALE1:.+]] = ttg.convert_layout {{.*}} : {{.*}} -> tensor<128x4xi8, #linear3>
+    // CHECK: %[[SCALE1:.+]] = ttg.convert_layout {{.*}} : tensor<128x4xi8, #blocked2> -> tensor<128x4xi8, #linear3>
     // CHECK: tt.dot_scaled {{.*}} scale %[[CST0]], {{.*}} scale %[[SCALE1]], {{.*}} lhs = e2m1 rhs = e2m1
-    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
-    %1 = tt.dot_scaled %arg0, %arg1 scale %arg2, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, tensor<128x4xi8> -> tensor<128x128xf32, #blocked>
-    tt.store %arg3, %1 : tensor<128x128x!tt.ptr<f32>, #blocked>
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    %1 = tt.dot_scaled %arg0, %arg1 scale %arg2, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #blocked> * tensor<64x128xi8, #blocked1>, tensor<128x4xi8, #blocked2> -> tensor<128x128xf32, #blocked1>
+    tt.store %arg3, %1 : tensor<128x128x!tt.ptr<f32>, #blocked1>
     tt.return
   }
 }
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0]}>
+// #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK-LABEL: mfma_dot_scaled_fp4_fp4
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @mfma_dot_scaled_fp4_fp4(
-      %arg0: tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
-      %arg1: tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
-      %arg2: tensor<128x128x!tt.ptr<f32>, #blocked>
+      %arg0: tensor<128x64xi8, #blocked>,
+      %arg1: tensor<64x128xi8, #blocked1>,
+      %arg2: tensor<128x128x!tt.ptr<f32>, #blocked1>
       ) {
     // CHECK-NOT: tt.fp_to_fp
     // CHECK-DAG: %[[CST0:.+]] = arith.constant dense<127> : tensor<128x4xi8, #linear>
     // CHECK-DAG: %[[CST1:.+]] = arith.constant dense<127> : tensor<128x4xi8, #linear1>
     // CHECK: tt.dot_scaled {{.*}} scale %[[CST1]], {{.*}} scale %[[CST0]], {{.*}} lhs = e2m1 rhs = e2m1
-    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
-    %1 = tt.dot_scaled %arg0, %arg1, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
-    tt.store %arg2, %1 : tensor<128x128x!tt.ptr<f32>, #blocked>
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    %1 = tt.dot_scaled %arg0, %arg1, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #blocked> * tensor<64x128xi8, #blocked1> -> tensor<128x128xf32, #blocked1>
+    tt.store %arg2, %1 : tensor<128x128x!tt.ptr<f32>, #blocked1>
     tt.return
   }
 }
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK{LITERAL}: #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 32], [0, 64], [64, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 16]], warp = [[0, 0], [32, 0]], block = []}>
 // CHECK{LITERAL}: #linear1 = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [32, 0], [64, 0], [0, 64]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [16, 0]], warp = [[0, 32], [0, 0]], block = []}>
 // CHECK{LITERAL}: #linear2 = #ttg.linear<{register = [[0, 2], [64, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 1]], warp = [[0, 0], [32, 0]], block = []}>
@@ -105,23 +115,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: mfma_dot_scaled_mxfp8e4_mxfp8e4
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @mfma_dot_scaled_mxfp8e4_mxfp8e4(
-      %arg0: tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
-      %arg1: tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
-      %arg2: tensor<128x4xi8>,
-      %arg3: tensor<128x4xi8>,
+      %arg0: tensor<128x128xf8E4M3FN, #blocked>,
+      %arg1: tensor<128x128xf8E4M3FN, #blocked>,
+      %arg2: tensor<128x4xi8, #blocked1>,
+      %arg3: tensor<128x4xi8, #blocked1>,
       %arg4: tensor<128x128x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK-NOT: arith.constant dense<127> : tensor<128x4xi8, #linear>
     // CHECK-NOT: arith.constant dense<127> : tensor<128x4xi8, #linear1>
     // CHECK-NOT: tt.fp_to_fp
     // CHECK: %[[C:.+]] = ttg.convert_layout {{.*}} : tensor<128x128xf32, #blocked> -> tensor<128x128xf32, #mma>
-    // CHECK: %[[A:.+]] = ttg.convert_layout {{.*}} : tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<128x128xf8E4M3FN, #linear>
-    // CHECK: %[[B:.+]] = ttg.convert_layout {{.*}} : tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf8E4M3FN, #linear1>
-    // CHECK: %[[SCALE0:.+]] = ttg.convert_layout {{.*}} : {{.*}} -> tensor<128x4xi8, #linear2>
-    // CHECK: %[[SCALE1:.+]] = ttg.convert_layout {{.*}} : {{.*}} -> tensor<128x4xi8, #linear3>
+    // CHECK: %[[A:.+]] = ttg.convert_layout {{.*}} : tensor<128x128xf8E4M3FN, #blocked> -> tensor<128x128xf8E4M3FN, #linear>
+    // CHECK: %[[B:.+]] = ttg.convert_layout {{.*}} : tensor<128x128xf8E4M3FN, #blocked> -> tensor<128x128xf8E4M3FN, #linear1>
+    // CHECK: %[[SCALE0:.+]] = ttg.convert_layout {{.*}} : tensor<128x4xi8, #blocked1> -> tensor<128x4xi8, #linear2>
+    // CHECK: %[[SCALE1:.+]] = ttg.convert_layout {{.*}} : tensor<128x4xi8, #blocked1> -> tensor<128x4xi8, #linear3>
     // CHECK: tt.dot_scaled %[[A]] scale %[[SCALE0]], %[[B]] scale %[[SCALE1]], %[[C]] lhs = e4m3 rhs = e4m3
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
-    %1 = tt.dot_scaled %arg0 scale %arg2, %arg1 scale %arg3, %cst lhs = e4m3 rhs = e4m3 {fastMath = false} : tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, tensor<128x4xi8> * tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, tensor<128x4xi8> -> tensor<128x128xf32, #blocked>
+    %1 = tt.dot_scaled %arg0 scale %arg2, %arg1 scale %arg3, %cst lhs = e4m3 rhs = e4m3 {fastMath = false} : tensor<128x128xf8E4M3FN, #blocked>, tensor<128x4xi8, #blocked1> * tensor<128x128xf8E4M3FN, #blocked>, tensor<128x4xi8, #blocked1> -> tensor<128x128xf32, #blocked>
     tt.store %arg4, %1 : tensor<128x128x!tt.ptr<f32>, #blocked>
     tt.return
   }
@@ -129,21 +139,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK-LABEL: mfma_dot_scaled_fp8e4_mxfp4
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @mfma_dot_scaled_fp8e4_mxfp4(
-      %arg0: tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
-      %arg1: tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
-      %arg2: tensor<128x4xi8>,
+      %arg0: tensor<128x128xf8E4M3FN, #blocked>,
+      %arg1: tensor<64x128xi8, #blocked>,
+      %arg2: tensor<128x4xi8, #blocked1>,
       %arg3: tensor<128x128x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK-NOT: tt.fp_to_fp
     // CHECK: %[[CST0:.+]] = arith.constant dense<127> : tensor<128x4xi8, #linear>
-    // CHECK: %[[SCALE1:.+]] = ttg.convert_layout {{.*}} : {{.*}} -> tensor<128x4xi8, #linear3>
+    // CHECK: %[[SCALE1:.+]] = ttg.convert_layout {{.*}} : tensor<128x4xi8, #blocked1> -> tensor<128x4xi8, #linear3>
     // CHECK: tt.dot_scaled {{.*}} scale %[[CST0]], {{.*}} scale %[[SCALE1]], {{.*}} lhs = e4m3 rhs = e2m1
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
-    %1 = tt.dot_scaled %arg0, %arg1 scale %arg2, %cst lhs = e4m3 rhs = e2m1 {fastMath = false} : tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x128xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, tensor<128x4xi8> -> tensor<128x128xf32, #blocked>
+    %1 = tt.dot_scaled %arg0, %arg1 scale %arg2, %cst lhs = e4m3 rhs = e2m1 {fastMath = false} : tensor<128x128xf8E4M3FN, #blocked> * tensor<64x128xi8, #blocked>, tensor<128x4xi8, #blocked1> -> tensor<128x128xf32, #blocked>
     tt.store %arg3, %1 : tensor<128x128x!tt.ptr<f32>, #blocked>
     tt.return
   }
@@ -151,21 +162,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK-LABEL: mfma_dot_scaled_mxfp4_fp8e5
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @mfma_dot_scaled_mxfp4_fp8e5(
-      %arg0: tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
-      %arg1: tensor<128x128xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
-      %arg2: tensor<128x4xi8>,
+      %arg0: tensor<128x64xi8, #blocked>,
+      %arg1: tensor<128x128xf8E5M2, #blocked>,
+      %arg2: tensor<128x4xi8, #blocked1>,
       %arg3: tensor<128x128x!tt.ptr<f32>, #blocked>
       ) {
     // CHECK-NOT: tt.fp_to_fp
     // CHECK: %[[CST1:.+]] = arith.constant dense<127> : tensor<128x4xi8, #linear>
-    // CHECK: %[[SCALE0:.+]] = ttg.convert_layout {{.*}} : {{.*}} -> tensor<128x4xi8, #linear3>
+    // CHECK: %[[SCALE0:.+]] = ttg.convert_layout {{.*}} : tensor<128x4xi8, #blocked1> -> tensor<128x4xi8, #linear3>
     // CHECK: tt.dot_scaled {{.*}} scale %[[SCALE0]], {{.*}} scale %[[CST1]], {{.*}} lhs = e2m1 rhs = e5m2
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
-    %1 = tt.dot_scaled %arg0 scale %arg2, %arg1, %cst lhs = e2m1 rhs = e5m2 {fastMath = false} : tensor<128x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, tensor<128x4xi8> * tensor<128x128xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
+    %1 = tt.dot_scaled %arg0 scale %arg2, %arg1, %cst lhs = e2m1 rhs = e5m2 {fastMath = false} : tensor<128x64xi8, #blocked>, tensor<128x4xi8, #blocked1> * tensor<128x128xf8E5M2, #blocked> -> tensor<128x128xf32, #blocked>
     tt.store %arg3, %1 : tensor<128x128x!tt.ptr<f32>, #blocked>
     tt.return
   }

--- a/test/TritonGPU/amd/accelerate-amd-matmul-mfma-gfx950.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-mfma-gfx950.mlir
@@ -26,7 +26,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: %[[SCALE1:.+]] = ttg.convert_layout {{.*}} : tensor<128x4xi8, #blocked2> -> tensor<128x4xi8, #linear3>
     // CHECK: tt.dot_scaled %[[A]] scale %[[SCALE0]], %[[B]] scale %[[SCALE1]], %[[C]] lhs = e2m1 rhs = e2m1
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
-    // %1 = tt.dot_scaled %arg0 scale %arg2, %arg1 scale %arg3, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #linear>, tensor<128x4xi8, #linear2> * tensor<64x128xi8, #linear1>, tensor<128x4xi8, #linear3> -> tensor<128x128xf32, #mma>
     %1 = tt.dot_scaled %arg0 scale %arg2, %arg1 scale %arg3, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #blocked>, tensor<128x4xi8, #blocked2> * tensor<64x128xi8, #blocked1>, tensor<128x4xi8, #blocked2> -> tensor<128x128xf32, #blocked1>
     tt.store %arg4, %1 : tensor<128x128x!tt.ptr<f32>, #blocked1>
     tt.return
@@ -179,6 +178,54 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %1 = tt.dot_scaled %arg0 scale %arg2, %arg1, %cst lhs = e2m1 rhs = e5m2 {fastMath = false} : tensor<128x64xi8, #blocked>, tensor<128x4xi8, #blocked1> * tensor<128x128xf8E5M2, #blocked> -> tensor<128x128xf32, #blocked>
     tt.store %arg3, %1 : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_op_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_op_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+// CHECK-LABEL: mfma_bf8_dot_to_dot_scaled
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mfma_bf8_dot_to_dot_scaled(
+      %arg0: tensor<128x64xf8E5M2, #dot_op_a>,
+      %arg1: tensor<64x128xf8E5M2, #dot_op_b>,
+      %arg2: tensor<128x128x!tt.ptr<f32>, #blocked>
+      ) {
+    // CHECK-NOT: tt.fp_to_fp
+    // CHECK-NOT: tt.dot {{.*}}, {{.*}}, {{.*}}
+    // CHECK-DAG: %[[A:.+]] = ttg.convert_layout {{.*}} : tensor<128x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<128x64xf8E5M2, #linear>
+    // CHECK-DAG: %[[B:.+]] = ttg.convert_layout {{.*}} : tensor<64x128xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x128xf8E5M2, #linear1>
+    // CHECK: tt.dot_scaled %[[A]], %[[B]], {{.*}} lhs = e5m2 rhs = e5m2 {fastMath = false} : tensor<128x64xf8E5M2, #linear> * tensor<64x128xf8E5M2, #linear1> -> tensor<128x128xf32, #mma>
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<128x64xf8E5M2, #dot_op_a> * tensor<64x128xf8E5M2, #dot_op_b> -> tensor<128x128xf32, #blocked>
+    tt.store %arg2, %1 : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_op_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_op_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+// CHECK-LABEL: mfma_fp16_dot_to_dot
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mfma_fp16_dot_to_dot(
+      %arg0: tensor<128x64xf16, #dot_op_a>,
+      %arg1: tensor<64x128xf16, #dot_op_b>,
+      %arg2: tensor<128x128x!tt.ptr<f32>, #blocked>
+      ) {
+    // CHECK-NOT: tt.fp_to_fp
+    // CHECK-NOT: tt.dot_scaled
+    // CHECK-DAG: %[[A:.+]] = ttg.convert_layout {{.*}} : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    // CHECK-DAG: %[[B:.+]] = ttg.convert_layout {{.*}} : tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    // CHECK: tt.dot %[[A]], %[[B]], {{.*}} : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<128x128xf32, #mma>
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %1 = tt.dot %arg0, %arg1, %cst : tensor<128x64xf16, #dot_op_a> * tensor<64x128xf16, #dot_op_b> -> tensor<128x128xf32, #blocked>
+    tt.store %arg2, %1 : tensor<128x128x!tt.ptr<f32>, #blocked>
     tt.return
   }
 }

--- a/third_party/amd/include/TritonAMDGPUTransforms/MfmaGroup.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/MfmaGroup.h
@@ -1,10 +1,16 @@
 #ifndef TRITON_THIRD_PARTY_AMD_INCLUDE_TRITONAMDGPUTRANSFORMS_MFMAGROUP_H_
 #define TRITON_THIRD_PARTY_AMD_INCLUDE_TRITONAMDGPUTRANSFORMS_MFMAGROUP_H_
 
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace mlir {
+// Returns true if the given type is an OCP FP8/FP6/FP6 type.
+inline bool isF8F6F4(mlir::Type type) {
+  return llvm::isa<Float8E4M3FNType, Float8E5M2Type, Float6E3M2FNType,
+                   Float6E2M3FNType, Float4E2M1FNType>(type);
+}
 
 struct MfmaIntrinsic {
   // Chooses a suitable mfma instrinsic for the given input case.
@@ -19,6 +25,8 @@ struct MfmaIntrinsic {
         bElementType(bET) {}
   MfmaIntrinsic(const MfmaIntrinsic &other) = default;
   MfmaIntrinsic(MfmaIntrinsic &&other) = default;
+  MfmaIntrinsic() = default;
+  MfmaIntrinsic &operator=(MfmaIntrinsic &&other) = default;
 
   llvm::StringRef name;
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -491,6 +491,23 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
       : DotOpMFMAConversionHelper(mfmaLayout, rewriter, typeConverter, loc) {}
 
   Value generateScaledMFMAOp(StringRef intrinsicName, Value valA, Value valB,
+                             Value valC, Type elemTypeA, Type elemTypeB) const {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto resType = valC.getType();
+    Value zeroFlag = b.i32_val(0);
+    OperationState loweredOp(loc, intrinsicName);
+    int32_t cbsz = getMfmaF8F6F4MatrixFormat(elemTypeA);
+    int32_t blgp = getMfmaF8F6F4MatrixFormat(elemTypeB);
+    assert((cbsz != -1) && (blgp != -1));
+    loweredOp.addTypes(resType);
+    // If both scales are constant 0, the LLVM backend will use V_MFMA_*_F8F6F4
+    // instructions instead of V_MFMA_SCALE_*_F8F6F4 to reduce memory access.
+    loweredOp.addOperands({valA, valB, valC, b.i32_val(cbsz), b.i32_val(blgp),
+                           zeroFlag, zeroFlag, zeroFlag, zeroFlag});
+    return rewriter.create(loweredOp)->getResult(0);
+  }
+
+  Value generateScaledMFMAOp(StringRef intrinsicName, Value valA, Value valB,
                              Value valC, Value valScaleA, Value valScaleB,
                              Type elemTypeA, Type elemTypeB) const {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -522,8 +539,13 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
     Value b = op.getB();
     Value aScale = op.getAScale();
     Value bScale = op.getBScale();
-    bool isAScaleConstant = aScale.getDefiningOp<arith::ConstantOp>();
-    bool isBScaleConstant = bScale.getDefiningOp<arith::ConstantOp>();
+    if ((aScale && !bScale) || (!aScale && bScale)) {
+      llvm::report_fatal_error("Single scale is not supported\n");
+    }
+
+    bool existBothScales = aScale && bScale;
+    bool isAScaleConstant = aScale && aScale.getDefiningOp<arith::ConstantOp>();
+    bool isBScaleConstant = bScale && bScale.getDefiningOp<arith::ConstantOp>();
     Value d = op.getD();
     auto aTensorTy = cast<RankedTensorType>(a.getType());
     auto bTensorTy = cast<RankedTensorType>(b.getType());
@@ -572,9 +594,6 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
     auto repB = mfmaLayout.getRepForOperand(bTensorTy.getShape(), bKWidth, 1);
     assert(repA[2] == repB[1]);
 
-    auto aScaleTensorTy = cast<RankedTensorType>(aScale.getType());
-    auto bScaleTensorTy = cast<RankedTensorType>(bScale.getType());
-
     // For fp4 scaled mfma, each thread takes 1 element from scale. Will have
     // better way to get it when adapting other data types. Similar to
     // scaleKBase
@@ -602,14 +621,21 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
 
     // Scales have the same replica distributions as their corresponding
     // operands.
-    auto operandAScale = getValuesFromDotOperandLayoutStruct(
-        loadedAScale, numRepB, numRepM, numRepK, scaleKWidth, scaleKBase,
-        aScaleTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false,
-        isAScaleConstant);
-    auto operandBScale = getValuesFromDotOperandLayoutStruct(
-        loadedBScale, numRepB, numRepN, numRepK, scaleKWidth, scaleKBase,
-        bScaleTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false,
-        isBScaleConstant);
+    SmallVector<ValueTable> operandAScale;
+    SmallVector<ValueTable> operandBScale;
+    if (existBothScales) {
+      auto aScaleTensorTy = cast<RankedTensorType>(aScale.getType());
+      operandAScale = getValuesFromDotOperandLayoutStruct(
+          loadedAScale, numRepB, numRepM, numRepK, scaleKWidth, scaleKBase,
+          aScaleTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false,
+          isAScaleConstant);
+
+      auto bScaleTensorTy = cast<RankedTensorType>(bScale.getType());
+      operandBScale = getValuesFromDotOperandLayoutStruct(
+          loadedBScale, numRepB, numRepN, numRepK, scaleKWidth, scaleKBase,
+          bScaleTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false,
+          isBScaleConstant);
+    }
 
     auto dstElemTy = dTensorTy.getElementType();
     auto fc = unpackLLElements(loc, loadedC, rewriter);
@@ -638,22 +664,38 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
           acc = zeroAuxiliarBlocks(subBlocks, acc);
           for (int k = 0; k < numRepK; k++) {
             for (int kPack = 0; kPack < aKWidth / aKBase; ++kPack) {
-              if (mfmaLayout.getIsTransposed()) {
-                acc = generateScaledMFMAOp(intrinsicName,
-                                           operandB[kPack][{b, n, k}],
-                                           operandA[kPack][{b, m, k}], acc,
-                                           operandBScale[kPack][{b, n, k}],
-                                           operandAScale[kPack][{b, m, k}],
-                                           maybeMfmaIntrinsic->bElementType,
-                                           maybeMfmaIntrinsic->aElementType);
+              if (existBothScales) {
+                if (mfmaLayout.getIsTransposed()) {
+                  acc = generateScaledMFMAOp(intrinsicName,
+                                             operandB[kPack][{b, n, k}],
+                                             operandA[kPack][{b, m, k}], acc,
+                                             operandBScale[kPack][{b, n, k}],
+                                             operandAScale[kPack][{b, m, k}],
+                                             maybeMfmaIntrinsic->bElementType,
+                                             maybeMfmaIntrinsic->aElementType);
+                } else {
+                  acc = generateScaledMFMAOp(intrinsicName,
+                                             operandA[kPack][{b, m, k}],
+                                             operandB[kPack][{b, n, k}], acc,
+                                             operandAScale[kPack][{b, m, k}],
+                                             operandBScale[kPack][{b, n, k}],
+                                             maybeMfmaIntrinsic->aElementType,
+                                             maybeMfmaIntrinsic->bElementType);
+                }
               } else {
-                acc = generateScaledMFMAOp(intrinsicName,
-                                           operandA[kPack][{b, m, k}],
-                                           operandB[kPack][{b, n, k}], acc,
-                                           operandAScale[kPack][{b, m, k}],
-                                           operandBScale[kPack][{b, n, k}],
-                                           maybeMfmaIntrinsic->aElementType,
-                                           maybeMfmaIntrinsic->bElementType);
+                if (mfmaLayout.getIsTransposed()) {
+                  acc = generateScaledMFMAOp(intrinsicName,
+                                             operandB[kPack][{b, n, k}],
+                                             operandA[kPack][{b, m, k}], acc,
+                                             maybeMfmaIntrinsic->bElementType,
+                                             maybeMfmaIntrinsic->aElementType);
+                } else {
+                  acc = generateScaledMFMAOp(intrinsicName,
+                                             operandA[kPack][{b, m, k}],
+                                             operandB[kPack][{b, n, k}], acc,
+                                             maybeMfmaIntrinsic->aElementType,
+                                             maybeMfmaIntrinsic->bElementType);
+                }
               }
               if (!firstMfma)
                 firstMfma = acc;
@@ -724,9 +766,18 @@ LogicalResult convertScaledMFMA(triton::DotScaledOp op,
          isa<LinearEncodingAttr>(op.getB().getType().getEncoding()) &&
          "Both lhs and rhs should be linear layout.");
 
-  assert(isa<LinearEncodingAttr>(op.getAScale().getType().getEncoding()) &&
-         isa<LinearEncodingAttr>(op.getBScale().getType().getEncoding()) &&
-         "Both LhsScale and RhsScale should be linear layout.");
+  auto aScale = op.getAScale();
+  auto bScale = op.getBScale();
+
+  assert(((aScale && bScale) || (!aScale && !bScale)) &&
+         "Single scale is not supported");
+
+  if (aScale && bScale) {
+    assert(
+        isa<LinearEncodingAttr>(aScale.getType().getEncoding()) &&
+        isa<LinearEncodingAttr>(bScale.getType().getEncoding()) &&
+        "If scales exist, both LhsScale and RhsScale should be linear layout.");
+  }
 
   auto cTensorTy = op.getC().getType();
   auto dTensorTy = op.getD().getType();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -9,6 +9,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include <memory>
 
 using namespace mlir;
@@ -43,6 +44,16 @@ int getWmmaVersion(StringRef archGen) {
   if (archGen.contains("gfx12"))
     return 2;
   return 0;
+}
+
+FailureOr<ScaleDotElemType> mlirTypeToScaledElemType(Type type) {
+  return llvm::TypeSwitch<Type, FailureOr<ScaleDotElemType>>(type)
+      .Case<Float8E4M3FNType>([](Type) { return ScaleDotElemType::E4M3; })
+      .Case<Float8E5M2Type>([](Type) { return ScaleDotElemType::E5M2; })
+      .Case<Float6E3M2FNType>([](Type) { return ScaleDotElemType::E3M2; })
+      .Case<Float6E2M3FNType>([](Type) { return ScaleDotElemType::E2M3; })
+      .Case<Float4E2M1FNType>([](Type) { return ScaleDotElemType::E2M1; })
+      .Default([](Type) { return failure(); });
 }
 
 // Check if the result of this tl.dot is used as opA of another tl.dot
@@ -213,14 +224,15 @@ chooseMfmaInstruction(int mfmaVersion, RankedTensorType cType, Type aElemType,
 }
 
 FailureOr<MfmaIntrinsic> chooseMfmaInstruction(tt::DotOp dot, int mfmaVersion,
-                                               int nonKDim) {
+                                               int nonKDim,
+                                               bool withScale = false) {
   RankedTensorType aType = dot.getA().getType();
   bool allowXF32 =
       dot.getInputPrecision() == InputPrecision::TF32 && mfmaVersion == 3;
   return chooseMfmaInstruction(
       mfmaVersion, dot.getC().getType(), aType.getElementType(),
       dot.getB().getType().getElementType(), aType.getShape().back(), nonKDim,
-      /*withScale=*/false, allowXF32);
+      withScale, allowXF32);
 }
 
 FailureOr<MfmaIntrinsic> chooseMfmaInstruction(tt::DotScaledOp dot,
@@ -450,15 +462,37 @@ public:
     auto oldBType = cast<RankedTensorType>(b.getType());
     auto ctx = oldAType.getContext();
 
-    ttg::AMDMfmaEncodingAttr mfmaEnc;
+    Type aElemType = oldAType.getElementType();
+    Type bElemType = oldBType.getElementType();
+    bool withScale =
+        mfmaVersion == 4 && isF8F6F4(aElemType) && isF8F6F4(bElemType);
 
-    auto mfmaInstr = chooseMfmaInstruction(dotOp, mfmaVersion, nonKDim);
-    if (failed(mfmaInstr))
-      return failure();
-    auto mDim = mfmaInstr->mDim;
-    auto nDim = mfmaInstr->nDim;
-    auto kDim = mfmaInstr->kDim;
-    auto kBase = mfmaInstr->kBase;
+    // If mfmaVersion == 4 and both inputs are of F8F6F4 types, we will try to
+    // use the V_MFMA_*_F8F6F4 instructions since it has higher bandwidth. If we
+    // can't find a proper instruction, we will fall back to select from normal
+    // mfma instructions.
+    MfmaIntrinsic mfmaInstr;
+    FailureOr<MfmaIntrinsic> maybeMfmaInstr =
+        chooseMfmaInstruction(dotOp, mfmaVersion, nonKDim, withScale);
+    if (failed(maybeMfmaInstr)) {
+      if (!withScale) {
+        return failure();
+      }
+      auto maybeMfmaInstr =
+          chooseMfmaInstruction(dotOp, mfmaVersion, nonKDim, false);
+      if (failed(maybeMfmaInstr))
+        return failure();
+
+      mfmaInstr = std::move(maybeMfmaInstr.value());
+      withScale = false;
+    } else {
+      mfmaInstr = std::move(maybeMfmaInstr.value());
+    }
+
+    auto mDim = mfmaInstr.mDim;
+    auto nDim = mfmaInstr.nDim;
+    auto kDim = mfmaInstr.kDim;
+    auto kBase = mfmaInstr.kBase;
 
     auto warpsPerTile =
         warpsPerTileMFMA(dotOp, retShape, numWarps, {mDim, nDim});
@@ -466,12 +500,12 @@ public:
     // Use transposed mfma layout to enable larger vectorization for global
     // store instructions, except for fp8 matmul kernels due to regression
     // TODO (lixun): investigate the regression and enable this feature again
-    auto aElemTy = mfmaInstr->aElementType;
+    auto aElemTy = mfmaInstr.aElementType;
     bool isFP8 = llvm::isa<Float8E5M2FNUZType, Float8E4M3FNUZType,
                            Float8E4M3FNType, Float8E5M2Type>(aElemTy);
     bool isTransposed =
         isChainDotHead(dotOp) || isChainDotTail(dotOp) || !isFP8;
-    mfmaEnc = ttg::AMDMfmaEncodingAttr::get(
+    ttg::AMDMfmaEncodingAttr mfmaEnc = ttg::AMDMfmaEncodingAttr::get(
         oldRetType.getContext(),
         /*versionMajor*/ mfmaVersion, /*versionMinor*/ 0, warpsPerTile,
         /*instrShape*/ mDim, nDim, isTransposed, CTALayout);
@@ -526,17 +560,47 @@ public:
     if (!isChainDotTail(dotOp))
       kWidth *= kPack;
 
-    auto newAEncoding =
-        ttg::DotOperandEncodingAttr::get(ctx, 0, mfmaEnc, kWidth);
-    auto newBEncoding =
-        ttg::DotOperandEncodingAttr::get(ctx, 1, mfmaEnc, kWidth);
-    a = convertAndCastTensor(rewriter, a, newAEncoding,
-                             mfmaInstr->aElementType);
-    b = convertAndCastTensor(rewriter, b, newBEncoding,
-                             mfmaInstr->bElementType);
-    auto newDot = rewriter.create<tt::DotOp>(
-        dotOp.getLoc(), newAcc.getType(), a, b, newAcc,
-        dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc());
+    Value newDot;
+    if (withScale) {
+      // If a scaled mfma instruction is chosen, we will rewrite the DotOp to a
+      // DotScaledOp.
+      auto aScaledElemTy = mlirTypeToScaledElemType(aElemType);
+      if (failed(aScaledElemTy))
+        return failure();
+      auto bScaledElemTy = mlirTypeToScaledElemType(bElemType);
+      if (failed(bScaledElemTy))
+        return failure();
+
+      auto aEncLL = chooseScaledMfmaOperandLayout(
+          mfmaEnc, kWidth, /*dotOperandIdx=*/0, aScaledElemTy.value(),
+          oldAType.getShape());
+      auto bEncLL = chooseScaledMfmaOperandLayout(
+          mfmaEnc, kWidth, /*dotOperandIdx=*/1, bScaledElemTy.value(),
+          oldBType.getShape());
+      auto newAEncoding = ttg::LinearEncodingAttr::get(ctx, aEncLL);
+      auto newBEncoding = ttg::LinearEncodingAttr::get(ctx, bEncLL);
+
+      a = convertAndCastTensor(rewriter, a, newAEncoding,
+                               mfmaInstr.aElementType);
+      b = convertAndCastTensor(rewriter, b, newBEncoding,
+                               mfmaInstr.bElementType);
+      newDot = rewriter.create<triton::DotScaledOp>(
+          dotOp.getLoc(), newAcc.getType(), a, b, newAcc, Value(), Value(),
+          aScaledElemTy.value(), bScaledElemTy.value(), /*fastMath=*/false);
+    } else {
+      auto newAEncoding =
+          ttg::DotOperandEncodingAttr::get(ctx, 0, mfmaEnc, kWidth);
+      auto newBEncoding =
+          ttg::DotOperandEncodingAttr::get(ctx, 1, mfmaEnc, kWidth);
+      a = convertAndCastTensor(rewriter, a, newAEncoding,
+                               mfmaInstr.aElementType);
+      b = convertAndCastTensor(rewriter, b, newBEncoding,
+                               mfmaInstr.bElementType);
+      newDot = rewriter.create<tt::DotOp>(dotOp.getLoc(), newAcc.getType(), a,
+                                          b, newAcc, dotOp.getInputPrecision(),
+                                          dotOp.getMaxNumImpreciseAcc());
+    }
+
     Value dotOutput =
         convertAndCastTensor(rewriter, newDot, oldRetType.getEncoding(),
                              oldRetType.getElementType());
@@ -805,11 +869,6 @@ public:
     auto newAcc = rewriter.create<ttg::ConvertLayoutOp>(
         dotOp.getC().getLoc(), newRetType, dotOp.getC());
 
-    StringAttr kRegister = StringAttr::get(ctx, "register");
-    StringAttr kLane = StringAttr::get(ctx, "lane");
-    StringAttr kWarp = StringAttr::get(ctx, "warp");
-    StringAttr kBlock = StringAttr::get(ctx, "block");
-
     auto order = ttg::getMatrixOrder(rank, /*rowMajor=*/true);
     auto standardOutDims = standardOutDimNames(ctx, rank);
 
@@ -838,6 +897,7 @@ public:
     a = convertInputLayout(a, aEncLL);
     b = convertInputLayout(b, bEncLL);
 
+    StringAttr kWarp = StringAttr::get(ctx, "warp");
     auto convertScaleLayout = [&](TensorValue scale,
                                   llvm::ArrayRef<int64_t> valShape,
                                   LinearLayout dotLL, int idx) -> Value {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/MfmaGroup.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/MfmaGroup.cpp
@@ -11,12 +11,6 @@ namespace {
 // MFMA intrinsic query key
 //===----------------------------------------------------------------------===//
 
-// Returns true if the given type is an OCP FP8/FP6/FP6 type.
-inline bool isF8F6F4(mlir::Type type) {
-  return llvm::isa<Float8E4M3FNType, Float8E5M2Type, Float6E3M2FNType,
-                   Float6E2M3FNType, Float4E2M1FNType>(type);
-}
-
 // The tuple used as key to query MFMA intrinsic map.
 using MfmaKey =
     std::tuple<unsigned /*version*/, unsigned /*mDim*/, unsigned /*nDim*/,


### PR DESCRIPTION
Try to lower fp8 tl.dot to the new scaled mfma on gfx950. Although we only have access to the fused mfma_scale instruction, there're optimization passes to rewrite mfma_scale to normal mfma if both scales are 0.

If we can't select a proper scaled mfma instruction, it will fall back to normal mfma instructions.