### PR TITLE
Fix enable_debug's handling of false value boolean env vars

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1,4 +1,4 @@
-﻿#include <optional>
+#include <optional>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -1774,7 +1774,9 @@ void init_triton_ir(py::module &&m) {
              std::string funcToDump;
              if (!haveDump) {
                funcToDump = triton::tools::getStrEnv("MLIR_ENABLE_DUMP");
-               if (!funcToDump.empty())
+               bool isEnvValueBool =
+                   triton::tools::isEnvValueBool(funcToDump).has_value();
+               if (!funcToDump.empty() && !isEnvValueBool)
                  haveDump = true;
              }
              if (haveDump) {


### PR DESCRIPTION
Right now, running a Triton kernel with MLIR_ENABLE_DUMP=0 results in the software pipeliner pass printing spurious output due to the dumpIntermediateSteps flag that is set when MLIR_ENABLE_DUMP is neither true nor a function value. This fix checks that the result of isEnvValueBool's tri-state does in fact indicate that the value is not a boolean before setting haveDump to true.

