### PR TITLE
[BE] Fix tmem shape for MMAv5 scales

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
@@ -55,7 +55,8 @@ struct TCGen5MMAScaleSharedToTmemConversion
     : public OpRewritePattern<TCGen5MMAScaledOp> {
   using OpRewritePattern<TCGen5MMAScaledOp>::OpRewritePattern;
 
-  bool lowerScaleToTmem(OpOperand &operand, PatternRewriter &rewriter) const {
+  bool lowerScaleToTmem(OpOperand &operand, PatternRewriter &rewriter, int rows,
+                        int cols) const {
     Location loc = operand.getOwner()->getLoc();
     MLIRContext *context = operand.getOwner()->getContext();
     Attribute tensorMemorySpace = TensorMemorySpaceAttr::get(context);
@@ -65,7 +66,7 @@ struct TCGen5MMAScaleSharedToTmemConversion
         cast<SwizzledSharedEncodingAttr>(oldType.getEncoding());
     CTALayoutAttr CTALayout = getCTALayout(oldEncoding);
     ArrayRef<unsigned> CTASplitNum = CTALayout.getCTASplitNum();
-    ArrayRef<int64_t> shape = oldType.getShape();
+    SmallVector<int64_t> shape = {rows, cols / 32};
     Attribute scaleEncoding = TensorMemoryScalesEncodingAttr::get(
         context, CTASplitNum[0], CTASplitNum[1]);
     Type scaleAType =
@@ -84,12 +85,23 @@ struct TCGen5MMAScaleSharedToTmemConversion
     MLIRContext *context = op->getContext();
     auto aScaleType = op.getAScale().getType();
     auto bScaleType = op.getBScale().getType();
+    int blockM = op.getA()
+                     .getType()
+                     .getShape()[op.getA().getType().getShape().size() - 2];
+    int blockN = op.getB()
+                     .getType()
+                     .getShape()[op.getB().getType().getShape().size() - 2];
+    int blockK = op.getA()
+                     .getType()
+                     .getShape()[op.getA().getType().getShape().size() - 1];
     bool anyChanged = false;
     if (isa<SwizzledSharedEncodingAttr>(aScaleType.getEncoding())) {
-      anyChanged = lowerScaleToTmem(op.getAScaleMutable(), rewriter);
+      anyChanged =
+          lowerScaleToTmem(op.getAScaleMutable(), rewriter, blockM, blockK);
     }
     if (isa<SwizzledSharedEncodingAttr>(bScaleType.getEncoding())) {
-      anyChanged = lowerScaleToTmem(op.getBScaleMutable(), rewriter);
+      anyChanged =
+          lowerScaleToTmem(op.getBScaleMutable(), rewriter, blockN, blockK);
     }
     return LogicalResult::success(anyChanged);
   }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
@@ -90,7 +90,7 @@ struct TCGen5MMAScaleSharedToTmemConversion
                      .getShape()[op.getA().getType().getShape().size() - 2];
     int blockN = op.getB()
                      .getType()
-                     .getShape()[op.getB().getType().getShape().size() - 2];
+                     .getShape()[op.getB().getType().getShape().size() - 1];
     int blockK = op.getA()
                      .getType()
                      .getShape()[op.getA().getType().getShape().size() - 1];

--- a/test/TritonNvidiaGPU/mma_lowering.mlir
+++ b/test/TritonNvidiaGPU/mma_lowering.mlir
@@ -10,8 +10,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-LABEL: gen5_mma_scaled_shmem_to_tmem
   tt.func public @gen5_mma_scaled_shmem_to_tmem(
     %A_sh: !ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>,
-    %B_sh: !ttg.memdesc<256x128xf8E5M2, #shared, #ttg.shared_memory>,
-    %C_tmem: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %B_sh: !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>,
+    %C_tmem: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>,
     %A_scale_sh: !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>,
     %B_scale_sh: !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>,
     %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>) {
@@ -20,10 +20,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Verify that the scale in tmem has the shape of (LHS) BlockM x BlockK / 32, (RHS) BlockN x BlockK / 32
     // CHECK: %[[A_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_copy {{.*}}, %[[A_SC_TMEM]]
-    // CHECK: %[[B_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<256x8xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    // CHECK: %[[B_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<64x8xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_copy {{.*}}, %[[B_SC_TMEM]]
     // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_SC_TMEM]], %[[B_SC_TMEM]]
-    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %C_tmem, %A_scale_sh, %B_scale_sh, %true, %true lhs = e5m2 rhs = e5m2, %barrier : (!ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<256x128xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, i1, i1, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>) -> ()
+    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %C_tmem, %A_scale_sh, %B_scale_sh, %true, %true lhs = e5m2 rhs = e5m2, %barrier : (!ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<256x64xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, i1, i1, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>) -> ()
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/mma_lowering.mlir
+++ b/test/TritonNvidiaGPU/mma_lowering.mlir
@@ -17,9 +17,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>) {
 
     %true = arith.constant true
-    // CHECK: %[[A_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<1x2x32x4x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    // Verify that the scale in tmem has the shape of (LHS) BlockM x BlockK / 32, (RHS) BlockN x BlockK / 32
+    // CHECK: %[[A_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_copy {{.*}}, %[[A_SC_TMEM]]
-    // CHECK: %[[B_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<1x2x32x4x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    // CHECK: %[[B_SC_TMEM:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<256x8xi8, #tmem_scales, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_copy {{.*}}, %[[B_SC_TMEM]]
     // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_SC_TMEM]], %[[B_SC_TMEM]]
     ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %C_tmem, %A_scale_sh, %B_scale_sh, %true, %true lhs = e5m2 rhs = e5m2, %barrier : (!ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<256x128xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, i1, i1, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>) -> ()


### PR DESCRIPTION
Commit https://github.com/triton-lang/triton/commit/5c051063f10a27a98b14d119c3fa7235a623ec17 introduced a bug in scaled mma lowering, where we pick wrong shape for the scale blocks in the tensor memory. This change fixes it.