### PR TITLE
[AMD]Optimize tt.dot_scaled whose both scales are None on gfx950

### DIFF
--- a/test/TritonGPU/amd/accelerate-amd-matmul-mfma-gfx950.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-mfma-gfx950.mlir
@@ -93,9 +93,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %arg2: tensor<128x128x!tt.ptr<f32>, #blocked1>
       ) {
     // CHECK-NOT: tt.fp_to_fp
-    // CHECK-DAG: %[[CST0:.+]] = arith.constant dense<127> : tensor<128x4xi8, #linear>
-    // CHECK-DAG: %[[CST1:.+]] = arith.constant dense<127> : tensor<128x4xi8, #linear1>
-    // CHECK: tt.dot_scaled {{.*}} scale %[[CST1]], {{.*}} scale %[[CST0]], {{.*}} lhs = e2m1 rhs = e2m1
+    // CHECK: tt.dot_scaled {{.*}}, {{.*}}, {{.*}} lhs = e2m1 rhs = e2m1
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %1 = tt.dot_scaled %arg0, %arg1, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #blocked> * tensor<64x128xi8, #blocked1> -> tensor<128x128xf32, #blocked1>
     tt.store %arg2, %1 : tensor<128x128x!tt.ptr<f32>, #blocked1>

--- a/test/TritonGPU/amd/accelerate-amd-matmul-mfma-gfx950.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-mfma-gfx950.mlir
@@ -93,7 +93,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %arg2: tensor<128x128x!tt.ptr<f32>, #blocked1>
       ) {
     // CHECK-NOT: tt.fp_to_fp
-    // CHECK: tt.dot_scaled {{.*}}, {{.*}}, {{.*}} lhs = e2m1 rhs = e2m1
+    // CHECK: tt.dot_scaled {{[^ ]+}}, {{[^ ]+}}, {{[^ ]+}} lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #linear> * tensor<64x128xi8, #linear1> -> tensor<128x128xf32, #mma>
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %1 = tt.dot_scaled %arg0, %arg1, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x64xi8, #blocked> * tensor<64x128xi8, #blocked1> -> tensor<128x128xf32, #blocked1>
     tt.store %arg2, %1 : tensor<128x128x!tt.ptr<f32>, #blocked1>

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -778,7 +778,9 @@ LogicalResult convertScaledMFMA(triton::DotScaledOp op,
   // If the tt.dot_scaled is not from a tt.dot but native, we support 0, 1, 2
   // scales and treat them in different ways:
   //
-  // 1. #scales = 0, 1: The upstream transform guarantees to create constant
+  // 1. #scales = 0: Just like those transformed from tt.dot, both scales remain
+  // None.
+  // 2. #scales = 1: The upstream transform guarantees to create constant
   // scales for the absent.
   // 2. #scales = 2: Both scales should exist.
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -825,6 +825,8 @@ public:
       return rewriter.notifyMatchFailure(dotOp, "NYI: mxfp6");
     }
 
+    bool bothScalesAbsent = !aScale && !bScale;
+
     MLIRContext *ctx = dotOp.getContext();
 
     ttg::CTALayoutAttr ctaLayout = ttg::getCTALayout(oldRetType.getEncoding());
@@ -894,6 +896,9 @@ public:
     auto convertScaleLayout = [&](TensorValue scale,
                                   llvm::ArrayRef<int64_t> valShape,
                                   LinearLayout dotLL, int idx) -> Value {
+      if (bothScalesAbsent)
+        return Value();
+
       LinearLayout::BasesT scaleBases = dotLL.getBases();
       auto &warpBases = scaleBases[kWarp];
 


### PR DESCRIPTION
This PR optimized the tt.dot_scaled whose both scales are None on gfx950 in a way same as https://github.com/triton-lang/triton/pull/6038.