### PR TITLE
[BACKEND] Correctly print unsigned types

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -70,7 +70,8 @@ public:
   // the format string global variable; |args| are the arguments to fill
   // placeholders in the format string.
   virtual void printf(RewriterBase &rewriter, Value formatStrStart,
-                      int formatStrByteCount, ValueRange args) const = 0;
+                      int formatStrByteCount, ValueRange args,
+                      ArrayRef<bool> isSigned = {}) const = 0;
 
   // Emits LLVM code with |rewriter| to print a message, particularly useful for
   // backend debug. |msg| is the message to print, |args| are the arguments to
@@ -78,8 +79,8 @@ public:
   // NOTE: This function is used for backend debug. DO NOT DELETE.
   // Example use: targetInfo.printf(rewriter,"index: %d, value: %f", {index,
   // value});
-  virtual void printf(RewriterBase &rewriter, StringRef msg,
-                      ValueRange args) const = 0;
+  virtual void printf(RewriterBase &rewriter, StringRef msg, ValueRange args,
+                      ArrayRef<bool> isSigned = {}) const = 0;
 
   // Emits LLVM code with |rewriter| to perform assertion failure with the given
   // |message| from the given |func| in |file|.

--- a/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
@@ -39,7 +39,7 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
       os << "pid (" << getFormatSubstr(pid[0]) << ", "
          << getFormatSubstr(pid[1]) << ", " << getFormatSubstr(pid[2]) << ")"
          << op.getPrefix();
-      llPrintf(formatStr, {pid[0], pid[1], pid[2]}, rewriter);
+      llPrintf(formatStr, {pid[0], pid[1], pid[2]}, {}, rewriter);
       rewriter.eraseOp(op);
       return success();
     }
@@ -162,12 +162,12 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
       // construct the format string at the same time as we populate
       // printfOperands.  But we don't want to create BLOCK_SIZE duplicate
       // strings, so we cache the Value.
+      auto isSignedOperands =
+          llvm::SmallVector<bool>(printfOperands.size(), isSigned);
       if (i == 0) {
-        formatStrValue =
-            llPrintf(formatStr, printfOperands, rewriter, &formatStrByteCount);
+        formatStrValue = llPrintf(formatStr, printfOperands, isSignedOperands,
+                                  rewriter, &formatStrByteCount);
       } else {
-        auto isSignedOperands =
-            llvm::SmallVector<bool>(printfOperands.size(), isSigned);
         targetInfo.printf(rewriter, formatStrValue, formatStrByteCount,
                           printfOperands, isSignedOperands);
       }
@@ -214,7 +214,7 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
 
   // Returns a Value for the format string, which you can reuse. Writes the byte
   // count for the string to |formatStrByteCount| if not null.
-  Value llPrintf(StringRef msg, ValueRange args,
+  Value llPrintf(StringRef msg, ValueRange args, ArrayRef<bool> isSigned,
                  ConversionPatternRewriter &rewriter,
                  int *formatStrByteCount = nullptr) const {
     assert(!msg.empty() && "printf with empty string not supported");
@@ -224,7 +224,8 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
     Value msgValue =
         LLVM::addStringToModule(UnknownLoc::get(rewriter.getContext()),
                                 rewriter, "printfFormat_", msgNewline);
-    targetInfo.printf(rewriter, msgValue, msgNewline.size_in_bytes(), args);
+    targetInfo.printf(rewriter, msgValue, msgNewline.size_in_bytes(), args,
+                      isSigned);
     if (formatStrByteCount)
       *formatStrByteCount = msgNewline.size_in_bytes();
     return msgValue;

--- a/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
@@ -166,8 +166,10 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
         formatStrValue =
             llPrintf(formatStr, printfOperands, rewriter, &formatStrByteCount);
       } else {
+        auto isSignedOperands =
+            llvm::SmallVector<bool>(printfOperands.size(), isSigned);
         targetInfo.printf(rewriter, formatStrValue, formatStrByteCount,
-                          printfOperands);
+                          printfOperands, isSignedOperands);
       }
     }
   }

--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -153,9 +153,12 @@ def test_print(func: str, data_type: str, device: str):
     else:
         assert f"Unknown kernel: {func}"
 
-    if func != "print_no_arg" and func != "no_arg_print" and func != "device_print_large" and \
-       func != "print_multiple_args" and func != "device_print_multiple_args" and \
-       func != "device_print_pointer" and func != "device_print_scalar" and func != "device_print_2d_tensor":
+    excluded_funcs = {
+        "print_no_arg", "no_arg_print", "device_print_large", "print_multiple_args",
+        "device_print_multiple_args", "device_print_pointer", "device_print_scalar",
+        "device_print_2d_tensor", "device_print_uint_cast"
+    }
+    if func not in excluded_funcs:
         assert_close(y, x)
 
     # Wait until driver complete all the jobs for the device_print, especially test_subprocess

--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -125,7 +125,7 @@ def test_print(func: str, data_type: str, device: str):
         x = torch.arange((1 << 31), (1 << 31) + N, device=device).to(getattr(torch, data_type))
         kernel_device_print[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "device_print_uint_cast":
-        kernel_device_print_cast[(1, )](num_warps=num_warps)
+        kernel_device_print_cast[(1, )](num_warps=num_warps, BLOCK=N)
     elif func == "print":
         kernel_print[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "device_print_large":

--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -154,9 +154,8 @@ def test_print(func: str, data_type: str, device: str):
         assert f"Unknown kernel: {func}"
 
     excluded_funcs = {
-        "print_no_arg", "no_arg_print", "device_print_large", "print_multiple_args",
-        "device_print_multiple_args", "device_print_pointer", "device_print_scalar",
-        "device_print_2d_tensor", "device_print_uint_cast"
+        "print_no_arg", "no_arg_print", "device_print_large", "print_multiple_args", "device_print_multiple_args",
+        "device_print_pointer", "device_print_scalar", "device_print_2d_tensor", "device_print_uint_cast"
     }
     if func not in excluded_funcs:
         assert_close(y, x)

--- a/python/test/unit/language/print_helper.py
+++ b/python/test/unit/language/print_helper.py
@@ -20,6 +20,12 @@ def kernel_device_print(X, Y, BLOCK: tl.constexpr):
 
 
 @triton.jit
+def kernel_device_print_cast(BLOCK: tl.constexpr):
+    x = tl.arange(0, BLOCK) + 128
+    tl.device_print("x: ", x.to(tl.uint8))
+
+
+@triton.jit
 def kernel_device_print_hex(X, Y, BLOCK: tl.constexpr):
     x = tl.load(X + tl.arange(0, BLOCK))
     tl.device_print("x: ", x, hex=True)
@@ -118,6 +124,8 @@ def test_print(func: str, data_type: str, device: str):
     elif func == "device_print_uint":
         x = torch.arange((1 << 31), (1 << 31) + N, device=device).to(getattr(torch, data_type))
         kernel_device_print[(1, )](x, y, num_warps=num_warps, BLOCK=N)
+    elif func == "device_print_uint_cast":
+        kernel_device_print_cast[(1, )](num_warps=num_warps)
     elif func == "print":
         kernel_print[(1, )](x, y, num_warps=num_warps, BLOCK=N)
     elif func == "device_print_large":

--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -37,6 +37,7 @@ def is_interpreter():
                                                       ("device_print_pointer", "int32"),
                                                       ("device_print_negative", "int32"),
                                                       ("device_print_uint", "uint32"),
+                                                      ("device_print_uint_cast", "uint8")
                                                       ("device_print_2d_tensor", "int32"),
                                                   ])
 def test_print(func_type: str, data_type: str, device: str):
@@ -62,9 +63,13 @@ def test_print(func_type: str, data_type: str, device: str):
     # Format is
     #   pid (<x>, <y>, <z>) idx (<i1>, <i2>, ...) <prefix> (operand <n>) <elem>
     expected_lines = Counter()
-    if func_type in ("print", "device_print", "device_print_uint"):
+    if func_type in ("print", "device_print", "device_print_uint", "device_print_uint_cast"):
         for i in range(N):
-            offset = (1 << 31) if data_type == "uint32" else 0
+            offset = 0
+            if data_type == "uint8":
+                offset = 1 << 7
+            elif data_type == "uint32":
+                offset = (1 << 31)
             line = f"pid (0, 0, 0) idx ({i:3}) x: {i + offset}"
             if data_type.startswith("float"):
                 line += ".000000"

--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -68,7 +68,7 @@ def test_print(func_type: str, data_type: str, device: str):
             offset = 0
             if data_type == "device_print_uint_cast":
                 offset = 1 << 7
-            elif func_type == "device_print_uint_cast":
+            elif func_type == "device_print_uint":
                 offset = (1 << 31)
             line = f"pid (0, 0, 0) idx ({i:3}) x: {i + offset}"
             if data_type.startswith("float"):

--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -37,7 +37,7 @@ def is_interpreter():
                                                       ("device_print_pointer", "int32"),
                                                       ("device_print_negative", "int32"),
                                                       ("device_print_uint", "uint32"),
-                                                      ("device_print_uint_cast", "uint8")
+                                                      ("device_print_uint_cast", "uint8"),
                                                       ("device_print_2d_tensor", "int32"),
                                                   ])
 def test_print(func_type: str, data_type: str, device: str):

--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -66,9 +66,9 @@ def test_print(func_type: str, data_type: str, device: str):
     if func_type in ("print", "device_print", "device_print_uint", "device_print_uint_cast"):
         for i in range(N):
             offset = 0
-            if data_type == "uint8":
+            if data_type == "device_print_uint_cast":
                 offset = 1 << 7
-            elif data_type == "uint32":
+            elif func_type == "device_print_uint_cast":
                 offset = (1 << 31)
             line = f"pid (0, 0, 0) idx ({i:3}) x: {i + offset}"
             if data_type.startswith("float"):

--- a/python/test/unit/language/test_subprocess.py
+++ b/python/test/unit/language/test_subprocess.py
@@ -66,7 +66,7 @@ def test_print(func_type: str, data_type: str, device: str):
     if func_type in ("print", "device_print", "device_print_uint", "device_print_uint_cast"):
         for i in range(N):
             offset = 0
-            if data_type == "device_print_uint_cast":
+            if func_type == "device_print_uint_cast":
                 offset = 1 << 7
             elif func_type == "device_print_uint":
                 offset = (1 << 31)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -411,12 +411,13 @@ std::string TargetInfo::getMulhiFuncName(Type resultElementTy) const {
 void TargetInfo::printf(RewriterBase &rewriter, Value formatStrStart,
                         int formatStrByteCount, ValueRange args,
                         ArrayRef<bool> isSigned) const {
-  return printfImpl(formatStrStart, formatStrByteCount, args, isSigned, rewriter,
+  return printfImpl(formatStrStart, formatStrByteCount, args, isSigned,
+                    rewriter,
                     /*useStdError=*/false);
 }
 
-void TargetInfo::printf(RewriterBase &rewriter, StringRef msg,
-                        ValueRange args, ArrayRef<bool> isSigned) const {
+void TargetInfo::printf(RewriterBase &rewriter, StringRef msg, ValueRange args,
+                        ArrayRef<bool> isSigned) const {
   assert(!msg.empty() && "printf with empty string not supported");
   llvm::SmallString<64> msgNewline(msg);
   msgNewline.push_back('\n');

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -26,7 +26,7 @@ LLVM::LLVMFuncOp getOrInsertFunction(T &moduleOp, const Location loc,
 }
 
 // Extend all values to 64-bit per printf call requirements.
-Value printfPromoteValue(RewriterBase &rewriter, Value value) {
+Value printfPromoteValue(RewriterBase &rewriter, Value value, bool isSigned) {
   auto *context = rewriter.getContext();
   auto loc = UnknownLoc::get(context);
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -48,12 +48,13 @@ Value printfPromoteValue(RewriterBase &rewriter, Value value) {
 
   assert(type.isIntOrIndex());
   if (type.getIntOrFloatBitWidth() < 64) {
-    if (type.isUnsignedInteger())
-      return b.zext(ui64_ty, value);
-    if (type.isSignedInteger())
+    if (isSigned) {
       return b.sext(i64_ty, value);
-    // Signless integers are printed using unsigned integer formats.
-    return b.zext(i64_ty, value);
+    } else {
+      // Signless and unsigned integers are printed using unsigned integer
+      // formats.
+      return b.zext(i64_ty, value);
+    }
   }
 
   return value;
@@ -334,8 +335,8 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
 }
 
 void TargetInfo::printfImpl(Value formatStrStart, int formatStrByteCount,
-                            ValueRange args, RewriterBase &rewriter,
-                            bool useStdErr) const {
+                            ValueRange args, ArrayRef<bool> isSigned,
+                            RewriterBase &rewriter, bool useStdErr) const {
   auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
   auto *ctx = rewriter.getContext();
   mlir::Location loc = UnknownLoc::get(ctx);
@@ -387,7 +388,8 @@ void TargetInfo::printfImpl(Value formatStrStart, int formatStrByteCount,
     arguments.push_back(message);
     arguments.push_back(b.i32_val(numArgs));
     for (size_t i = group; i < bound; ++i) {
-      arguments.push_back(printfPromoteValue(rewriter, args[i]));
+      arguments.push_back(printfPromoteValue(
+          rewriter, args[i], isSigned.empty() ? true : isSigned[i]));
     }
     // Pad out to 7 arguments since the function always needs 7 args.
     for (size_t extra = numArgs; extra < kArgsPerGroup; ++extra) {
@@ -407,13 +409,14 @@ std::string TargetInfo::getMulhiFuncName(Type resultElementTy) const {
 }
 
 void TargetInfo::printf(RewriterBase &rewriter, Value formatStrStart,
-                        int formatStrByteCount, ValueRange args) const {
-  return printfImpl(formatStrStart, formatStrByteCount, args, rewriter,
+                        int formatStrByteCount, ValueRange args,
+                        ArrayRef<bool> isSigned) const {
+  return printfImpl(formatStrStart, formatStrByteCount, args, isSigned, rewriter,
                     /*useStdError=*/false);
 }
 
 void TargetInfo::printf(RewriterBase &rewriter, StringRef msg,
-                        ValueRange args) const {
+                        ValueRange args, ArrayRef<bool> isSigned) const {
   assert(!msg.empty() && "printf with empty string not supported");
   llvm::SmallString<64> msgNewline(msg);
   msgNewline.push_back('\n');
@@ -421,7 +424,7 @@ void TargetInfo::printf(RewriterBase &rewriter, StringRef msg,
   Value msgValue =
       LLVM::addStringToModule(UnknownLoc::get(rewriter.getContext()), rewriter,
                               "printfFormat_", msgNewline);
-  printf(rewriter, msgValue, msgNewline.size_in_bytes(), args);
+  printf(rewriter, msgValue, msgNewline.size_in_bytes(), args, isSigned);
 }
 
 void TargetInfo::assertFail(RewriterBase &rewriter, Location loc,
@@ -436,9 +439,9 @@ void TargetInfo::assertFail(RewriterBase &rewriter, Location loc,
   Value msgValue =
       LLVM::addStringToModule(loc, rewriter, "printfFormat_", msgBuffer);
   printfImpl(msgValue, msgBuffer.size_in_bytes(), /*args=*/ValueRange(),
-             rewriter, /*useStdError=*/true);
+             /*isSigned=*/{}, rewriter, /*useStdError=*/true);
 
-  // Set block barrrier before aborting kernel, give a chance for all
+  // Set block barrier before aborting kernel, give a chance for all
   // the threads in a block to check/print the assert failure.
   b.barrier();
   // Perform the trap to abort the kernel.

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -58,10 +58,11 @@ public:
   std::string getMulhiFuncName(Type resultElementTy) const override;
 
   void printf(RewriterBase &rewriter, Value formatStrStart,
-              int formatStrByteCount, ValueRange args) const override;
+              int formatStrByteCount, ValueRange args,
+              ArrayRef<bool> isSigned = {}) const override;
 
-  void printf(RewriterBase &rewriter, StringRef msg,
-              ValueRange args) const override;
+  void printf(RewriterBase &rewriter, StringRef msg, ValueRange args,
+              ArrayRef<bool> isSigned = {}) const override;
 
   void assertFail(RewriterBase &rewriter, Location loc, StringRef message,
                   StringRef file, StringRef func, int line) const override;
@@ -77,7 +78,8 @@ public:
 
 private:
   void printfImpl(Value formatStrStart, int formatStrByteCount, ValueRange args,
-                  RewriterBase &rewriter, bool useStdErr) const;
+                  ArrayRef<bool> isSigned, RewriterBase &rewriter,
+                  bool useStdErr) const;
 
   std::string arch;
 };

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -33,7 +33,8 @@ LLVM::LLVMFuncOp getVprintfDeclaration(RewriterBase &rewriter) {
 
 // extend integer to int32, extend float to float64
 // this comes from vprintf alignment requirements.
-std::pair<Type, Value> printfPromoteValue(RewriterBase &rewriter, Value value, bool isSigned) {
+std::pair<Type, Value> printfPromoteValue(RewriterBase &rewriter, Value value,
+                                          bool isSigned) {
   auto *context = rewriter.getContext();
   auto type = value.getType();
   Value newOp = value;
@@ -579,8 +580,8 @@ void TargetInfo::printf(RewriterBase &rewriter, Value formatStrStart,
   b.call(funcOp, operands);
 }
 
-void TargetInfo::printf(RewriterBase &rewriter, StringRef msg,
-                        ValueRange args, ArrayRef<bool> isSigned) const {
+void TargetInfo::printf(RewriterBase &rewriter, StringRef msg, ValueRange args,
+                        ArrayRef<bool> isSigned) const {
   assert(!msg.empty() && "printf with empty string not supported");
   llvm::SmallString<64> msgNewline(msg);
   msgNewline.push_back('\n');

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -41,13 +41,11 @@ std::pair<Type, Value> printfPromoteValue(RewriterBase &rewriter, Value value, b
   auto loc = UnknownLoc::get(context);
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-  bool isUnsigned = type.isUnsignedInteger();
   if (type.isIntOrIndex() && type.getIntOrFloatBitWidth() < 32) {
+    newType = i32_ty;
     if (isSigned) {
-      newType = i32_ty;
       newOp = b.sext(newType, value);
     } else {
-      newType = ui32_ty;
       newOp = b.zext(newType, value);
     }
   } else if (type.isBF16() || type.isF16() || type.isF32()) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -51,10 +51,12 @@ public:
   std::string getMulhiFuncName(Type resultElementTy) const override;
 
   void printf(RewriterBase &rewriter, Value formatStrStart,
-              int formatStrByteCount, ValueRange args) const override;
+              int formatStrByteCount, ValueRange args,
+              ArrayRef<bool> isSigned = {}) const override;
 
-  void printf(RewriterBase &rewriter, StringRef msg,
-              ValueRange args) const override;
+  void printf(RewriterBase &rewriter, StringRef msg, ValueRange args,
+
+              ArrayRef<bool> isSigned = {}) const override;
 
   void assertFail(RewriterBase &rewriter, Location loc, StringRef message,
                   StringRef file, StringRef func, int line) const override;


### PR DESCRIPTION
We have to pass along the `isSigned` flag from the conversion to target info because triton int types are defined as signless. 