### PR TITLE
Emit remarks for ReduceOp lowering failing to fit within a single warp

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -47,6 +47,10 @@ public:
       return success();
     }
 
+    op->emitRemark()
+      << "Reduction does not fit within a warp boundary and will "
+      << "result in inefficient synchronization through shared memory";
+
     // Compute a shared memory base per operand.
     auto smemShape = helper.getScratchRepShape();
 


### PR DESCRIPTION
When reduce ops fail to fit within a warp, lots of SMEM operations and sync instructions are generated because outside of a warp registers can not be used to accumulate the result of the reduction.

Adding a remark can help Triton devs to catch such inefficient codegen. A really easy way to trigger this is to load odd-sized row lengths that result in a blocked layout that has a `sizePerThread = [1, 1]` rather than something like a `sizePerThread = [1, 8]` and this will result in a wider reduction to be handled that can exceed a warp bound.
