### PR TITLE
[AMD] Enable swizzling for m/n contig tensors on GFX950

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -271,14 +271,20 @@ When vec=2, elements are swizzled in pairs of 2.  In other words, the element at
                      "unsigned":$typeWidthInBit,
                      "bool":$needTrans), [{
 
-        // ---- begin GFX908/GFX90A ----
+        // ---- begin GFX908/GFX90A/GFX950 ----
         if (auto mfmaEnc = mlir::dyn_cast<AMDMfmaEncodingAttr>(dotOpEnc.getParent())) {
           int kDimNum = dotOpEnc.getOpIdx() == 0 ? 1 : 0;
           if (needTrans)
             kDimNum = 1 - kDimNum;
           bool isKDimInner = (order[0] == kDimNum);
-          if (isKDimInner) {
-            const int numBanks = 32;
+
+          // GFX950 supports LDS transpose load instructions, so we need
+          // swizzling even when K dimension is not innermost.
+          const int versionMajor = mfmaEnc.getVersionMajor();
+          bool isGFX950 = versionMajor == 4;
+          bool swizzleNonKDimInner = isGFX950 && (typeWidthInBit == 8 || typeWidthInBit == 16);
+          if (isKDimInner || swizzleNonKDimInner) {
+            const int numBanks = isGFX950 ? 64 : 32;
             const int bankBitWidth = 32;
             const int SIMDWidth = 16;
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -271,7 +271,7 @@ When vec=2, elements are swizzled in pairs of 2.  In other words, the element at
                      "unsigned":$typeWidthInBit,
                      "bool":$needTrans), [{
 
-        // ---- begin GFX908/GFX90A/GFX950 ----
+        // ---- begin MFMA ----
         if (auto mfmaEnc = mlir::dyn_cast<AMDMfmaEncodingAttr>(dotOpEnc.getParent())) {
           int kDimNum = dotOpEnc.getOpIdx() == 0 ? 1 : 0;
           if (needTrans)
@@ -309,7 +309,7 @@ When vec=2, elements are swizzled in pairs of 2.  In other words, the element at
           }
         }
 
-        // ---- begin GFX11 ----
+        // ---- begin WMMA ----
         if (mlir::isa<AMDWmmaEncodingAttr>(dotOpEnc.getParent())) {
           if (dotOpEnc.getOpIdx() == 0) {
             const int numBanks = 32;


### PR DESCRIPTION
GFX950 supports LDS transpose load instructions, so we need swizzling even when K dimension is not innermost. Also, this PR changes number of banks to 64 for swizzling on GFX950 arch.
Swizzling enabled in this PR is realized trough existing SwizzledSharedEncodingAttr.
This pattern can't resolve (but need to confirm this) all bank conflicts for 64b LDS transpose instructions, so likely we will eventually need to switch to custom swizzling pattern.
