### PR TITLE
[AMD] Fix crash in OptimizeLDSUsage on Linear encoding

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUsage.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUsage.cpp
@@ -132,11 +132,14 @@ class OptimizeAMDLDSUsage
     SmallVector<Attribute> tmpLayouts;
     for (int i = 0; i < factorizedNumWarps.size(); i++) {
       auto warpsPerCTA = factorizedNumWarps[i];
-      tmpLayouts.push_back(
-          mlir::triton::AMD::createTmpLayout(srcEnc, warpsPerCTA));
-      tmpLayouts.push_back(
-          mlir::triton::AMD::createTmpLayout(dstEnc, warpsPerCTA));
-      tmpLayouts.push_back(
+      auto pushNotNull = [&](Attribute enc) {
+        if (enc)
+          tmpLayouts.push_back(enc);
+      };
+
+      pushNotNull(mlir::triton::AMD::createTmpLayout(srcEnc, warpsPerCTA));
+      pushNotNull(mlir::triton::AMD::createTmpLayout(dstEnc, warpsPerCTA));
+      pushNotNull(
           mlir::triton::AMD::createTmpLayout(baseFallbackLayout, warpsPerCTA));
     }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
@@ -79,7 +79,10 @@ createTmpLayout(triton::gpu::DistributedEncodingTrait layout,
     return triton::gpu::SliceEncodingAttr::get(
         ctx, src.getDim(), createTmpLayout(src.getParent(), parentWarpsPerCTA));
   }
-  assert("Encountered unsupported layout");
+  // TODO: support linear layout if needed.
+  if (isa<triton::gpu::LinearEncodingAttr>(layout))
+    return {};
+  assert(false && "Encountered unsupported layout");
   return {};
 }
 


### PR DESCRIPTION
This PR fixes crash of OptimizeLDSUsage pass on layout convert involving LinearEncodingAttr.
