### PR TITLE
[BACKEND] Cleaning up tmem_copy references in pipeliner code

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -165,16 +165,6 @@ loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
             dfs(defOp, finalUser, distance);
           }
         }
-        if (auto tmemAlloc = dyn_cast<nvidia_gpu::TMEMAllocOp>(op)) {
-          if (!tmemAlloc.getSrc()) {
-            for (auto user : tmemAlloc.getResult().getUsers()) {
-              if (auto tmemCopy = dyn_cast<nvidia_gpu::TMEMCopyOp>(user)) {
-                dfs(tmemCopy.getSrc().getDefiningOp(), finalUser, distance);
-                break;
-              }
-            }
-          }
-        }
       };
 
   bool seenDot = false;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -54,7 +54,7 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
     return op;
   if (isa<ttg::LocalLoadOp, ttg::LocalStoreOp>(op))
     return op;
-  if (isa<ttng::TMEMAllocOp, ttng::TMEMCopyOp>(op))
+  if (isa<ttng::TMEMAllocOp>(op))
     return op;
   if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
     rewriter.setInsertionPoint(op);


### PR DESCRIPTION
Cleaning up the code after https://github.com/triton-lang/triton/pull/6019

Tested with test_matmul.py and 10-block-scaled-matmul.py