### PR TITLE
Cache importing contexpr

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -7,7 +7,7 @@ import os
 import re
 import textwrap
 from collections import defaultdict
-from functools import cached_property
+from functools import cached_property, cache
 from typing import Callable, Generic, Iterable, Optional, TypeVar, Union, overload, Dict, Any, Tuple
 from ..runtime.driver import driver
 from types import ModuleType
@@ -279,8 +279,13 @@ class KernelParam:
 dtype2str = {}
 
 
-def specialize_impl(arg, specialize_extra, is_const=False, specialize_value=True, align=True):
+def cached_constexpr():
     from ..language import constexpr
+    return constexpr
+
+
+def specialize_impl(arg, specialize_extra, is_const=False, specialize_value=True, align=True):
+    constexpr = cached_constexpr()
     if arg is None:
         return ("constexpr", None)
     elif isinstance(arg, JITFunction):


### PR DESCRIPTION
A large portion of kernel launch overhead is this import. Caching the import was roughly a ~50% win in our tests.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is not a change in behavior.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
