### PR TITLE
[PIPELINE] AssignLatencies for mmav5

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -15,7 +15,7 @@ namespace gpu {
 
 /// Discover operations that should become async and assign latencies to them
 /// based on the numStages value provided by the user.
-void assignLatencies(ModuleOp moduleOp, int numStages);
+void assignLatencies(ModuleOp moduleOp, int numStages, bool assignMMA = false);
 
 /// Schedule the loops based on the latencies assigned to the operations.
 void scheduleLoops(ModuleOp moduleOp);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -34,161 +34,6 @@ bool preCondition(scf::ForOp forOp) {
   return true;
 }
 
-bool canHaveSharedEncoding(tt::LoadOp op) {
-  // If used by an user with DotOp encoding, all the uses must be compatible.
-  bool incompatible = false;
-  getSharedEncIfAllUsersAreDotEnc(op.getResult(), incompatible);
-  return !incompatible;
-}
-
-bool isSmallLoad(tt::LoadOp loadOp,
-                 tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
-  assert(!isLoadFromTensorPtr(loadOp) &&
-         "Block ptr should have been lowered before this pass.");
-  auto ptr = loadOp.getPtr();
-  unsigned vec = axisInfoAnalysis.getPtrContiguity(ptr);
-  if (auto mask = loadOp.getMask())
-    vec = std::min<unsigned>(vec, axisInfoAnalysis.getMaskAlignment(mask));
-
-  auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType());
-  if (!tensorTy)
-    return true;
-  auto ty = cast<tt::PointerType>(tensorTy.getElementType()).getPointeeType();
-  unsigned width = vec * ty.getIntOrFloatBitWidth();
-
-  // We do not pipeline all loads for the following reasons:
-  // 1. On nvidia GPUs, cp.async's cp-size can only be 4, 8, or 16.
-  // 2. It's likely that pipling small loads won't offer much performance
-  //    improvement and may even hurt performance by increasing register
-  //    pressure.
-  LDBG("Load " << *loadOp << " has width " << width);
-  return width < 32;
-}
-
-bool isPipeliningBeneficial(Operation *op, Operation *finalUser,
-                            tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
-  if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
-    if (isSmallLoad(loadOp, axisInfoAnalysis)) {
-      LDBG("Load " << *loadOp << " is too small for pipelining");
-      return false;
-    }
-  }
-  if (isa<tt::ExperimentalDescriptorLoadOp, tt::ExperimentalDescriptorGatherOp>(
-          op))
-    return true;
-  if (!canHaveSharedEncoding(cast<tt::LoadOp>(op))) {
-    LDBG("Load " << *op << " cannot have shared encoding");
-    return false;
-  }
-
-  ttg::SharedEncodingTrait localAllocEnc;
-  if (llvm::any_of(op->getUsers(), [&](Operation *user) {
-        return isa<ttg::LocalAllocOp>(user);
-      })) {
-    for (auto user : op->getUsers()) {
-      auto localAlloc = dyn_cast<ttg::LocalAllocOp>(user);
-      if (!localAlloc)
-        continue;
-      auto enc = mlir::cast<ttg::SharedEncodingTrait>(
-          localAlloc.getType().getEncoding());
-      if (!localAllocEnc) {
-        localAllocEnc = enc;
-      }
-      if (enc != localAllocEnc) {
-        // If the load is used by a LocalAllocOp, all the users need to have the
-        // same encoding.
-        return false;
-      }
-    }
-  }
-
-  if (localAllocEnc) {
-    auto registerTy = cast<RankedTensorType>(op->getResultTypes()[0]);
-    auto vecBytes = getCopyVecBytes(registerTy, localAllocEnc);
-    if (vecBytes < 4) {
-      // At least 4 bytes need to be consecutive for cp.async
-      return false;
-    }
-  }
-
-  return true;
-}
-
-// Create a map from load ops to their indirection level and the
-// final use of the load op (another load op, or a dot op).
-// Indirection level is "0" for the load op directly used by the dot op,
-// "1" for the load op used by the load op used by the dot op, and so on.
-llvm::MapVector<Operation *, int>
-loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
-                          tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
-  llvm::MapVector<Operation *, int> loadOpToIndLevel;
-  DenseSet<Operation *> seen;
-  DenseSet<Operation *> excluded;
-
-  std::function<void(Operation *, Operation *, int)> dfs =
-      [&](Operation *op, Operation *finalUser, int distance) {
-        if (!seen.insert(op).second || excluded.count(op))
-          return;
-        if (isa<tt::LoadOp, tt::ExperimentalDescriptorLoadOp,
-                tt::ExperimentalDescriptorGatherOp>(op)) {
-          if (!isPipeliningBeneficial(op, finalUser, axisInfoAnalysis))
-            return;
-          if (loadOpToIndLevel.count(op)) {
-            int level = loadOpToIndLevel[op];
-            if (level != distance) {
-              // If we have multiple uses at different distances, we don't know
-              // which one to pick.
-              LDBG("Load " << *op
-                           << " has multiple uses at different distances:"
-                           << level << " and " << distance);
-              loadOpToIndLevel.erase(op);
-              excluded.insert(op);
-              return;
-            }
-          } else {
-            LDBG("Load " << *op << " considered for pipelining with distance "
-                         << distance);
-            loadOpToIndLevel[op] = distance;
-          }
-          finalUser = op;
-          distance++;
-        }
-        for (Value operand : getNestedOperands(op)) {
-          if (isa<mlir::triton::DotOpInterface>(op)) {
-            // Heuristic: only pipeline A and B operands of the dot op.
-            if (operand == op->getOperand(2))
-              continue;
-          }
-          Value v = operand;
-          Operation *defOp = v.getDefiningOp();
-          if (defOp && defOp->getBlock() == op->getBlock()) {
-            dfs(defOp, finalUser, distance);
-          }
-        }
-      };
-
-  bool seenDot = false;
-  for (Operation &op : forOp.getBody()->without_terminator()) {
-    if (!isa<mlir::triton::DotOpInterface>(op))
-      continue;
-    seenDot = true;
-    seen.clear();
-    dfs(&op, &op, 0);
-  }
-
-  // If the loop has numStages attribute, also consider pipelining other loads
-  // that are not directly used by dot ops.
-  if (pipelineWithoutDot && !seenDot) {
-    for (Operation &op : forOp.getBody()->without_terminator()) {
-      if (!isa<tt::LoadOp, tt::ExperimentalDescriptorLoadOp,
-               tt::ExperimentalDescriptorGatherOp>(op))
-        dfs(&op, &op, 0);
-    }
-  }
-
-  return loadOpToIndLevel;
-}
-
 bool hasLatenciesAssigned(scf::ForOp forOp) {
   for (auto &op : forOp.getBody()->without_terminator()) {
     if (op.hasAttr("tt_latency"))
@@ -206,13 +51,275 @@ void assignUserProvidedLatencies(scf::ForOp forOp,
   }
 }
 
+class AssignLoadLatencies {
+public:
+  AssignLoadLatencies(scf::ForOp forOp, int numStages,
+                      DenseMap<Operation *, int> &opLatency)
+      : forOp(forOp), numStages(numStages), opLatency(opLatency) {};
+
+  void run() {
+    bool pipelineWithoutDot = forOp->hasAttr(mlir::triton::kNumStagesAttrName);
+    ModuleOp moduleOp = forOp->getParentOfType<ModuleOp>();
+    tt::ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
+
+    llvm::MapVector<Operation *, int> loadOpToIndLevel =
+        loadOpsToIndirectionLevel(forOp, pipelineWithoutDot, axisInfoAnalysis);
+    if (loadOpToIndLevel.empty())
+      return;
+
+    // We assume loads with different dist are assigned to different stages.
+    // If numStages is 2, we will have no stage available for indirect loads
+    // with dist >= 1. In general, when dist is equal to numStages - 1, we
+    // should not pipeline it.
+    for (auto iter = loadOpToIndLevel.begin();
+         iter != loadOpToIndLevel.end();) {
+      if (iter->second >= numStages - 1)
+        iter = loadOpToIndLevel.erase(iter);
+      else
+        ++iter;
+    }
+
+    // Calculate the stage distance between applicable loads.
+    auto vals = llvm::make_second_range(loadOpToIndLevel);
+    int maxIndirectionLevel = vals.empty() ? 0 : *llvm::max_element(vals);
+    unsigned loadLatency = (numStages - 1) / (maxIndirectionLevel + 1);
+
+    for (auto [loadOp, dist] : loadOpToIndLevel) {
+      opLatency[loadOp] = loadLatency;
+    }
+  }
+
+private:
+  scf::ForOp forOp;
+  int numStages;
+  DenseMap<Operation *, int> &opLatency;
+
+  bool canHaveSharedEncoding(tt::LoadOp op) {
+    // If used by an user with DotOp encoding, all the uses must be compatible.
+    bool incompatible = false;
+    getSharedEncIfAllUsersAreDotEnc(op.getResult(), incompatible);
+    return !incompatible;
+  }
+
+  bool isSmallLoad(tt::LoadOp loadOp,
+                   tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
+    assert(!isLoadFromTensorPtr(loadOp) &&
+           "Block ptr should have been lowered before this pass.");
+    auto ptr = loadOp.getPtr();
+    unsigned vec = axisInfoAnalysis.getPtrContiguity(ptr);
+    if (auto mask = loadOp.getMask())
+      vec = std::min<unsigned>(vec, axisInfoAnalysis.getMaskAlignment(mask));
+
+    auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType());
+    if (!tensorTy)
+      return true;
+    auto ty = cast<tt::PointerType>(tensorTy.getElementType()).getPointeeType();
+    unsigned width = vec * ty.getIntOrFloatBitWidth();
+
+    // We do not pipeline all loads for the following reasons:
+    // 1. On nvidia GPUs, cp.async's cp-size can only be 4, 8, or 16.
+    // 2. It's likely that pipling small loads won't offer much performance
+    //    improvement and may even hurt performance by increasing register
+    //    pressure.
+    LDBG("Load " << *loadOp << " has width " << width);
+    return width < 32;
+  }
+
+  bool isPipeliningBeneficial(Operation *op, Operation *finalUser,
+                              tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
+    if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
+      if (isSmallLoad(loadOp, axisInfoAnalysis)) {
+        LDBG("Load " << *loadOp << " is too small for pipelining");
+        return false;
+      }
+    }
+    if (isa<tt::ExperimentalDescriptorLoadOp,
+            tt::ExperimentalDescriptorGatherOp>(op))
+      return true;
+    if (!canHaveSharedEncoding(cast<tt::LoadOp>(op))) {
+      LDBG("Load " << *op << " cannot have shared encoding");
+      return false;
+    }
+
+    ttg::SharedEncodingTrait localAllocEnc;
+    if (llvm::any_of(op->getUsers(), [&](Operation *user) {
+          return isa<ttg::LocalAllocOp>(user);
+        })) {
+      for (auto user : op->getUsers()) {
+        auto localAlloc = dyn_cast<ttg::LocalAllocOp>(user);
+        if (!localAlloc)
+          continue;
+        auto enc = mlir::cast<ttg::SharedEncodingTrait>(
+            localAlloc.getType().getEncoding());
+        if (!localAllocEnc) {
+          localAllocEnc = enc;
+        }
+        if (enc != localAllocEnc) {
+          // If the load is used by a LocalAllocOp, all the users need to have
+          // the same encoding.
+          return false;
+        }
+      }
+    }
+
+    if (localAllocEnc) {
+      auto registerTy = cast<RankedTensorType>(op->getResultTypes()[0]);
+      auto vecBytes = getCopyVecBytes(registerTy, localAllocEnc);
+      if (vecBytes < 4) {
+        // At least 4 bytes need to be consecutive for cp.async
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  // Create a map from load ops to their indirection level and the
+  // final use of the load op (another load op, or a dot op).
+  // Indirection level is "0" for the load op directly used by the dot op,
+  // "1" for the load op used by the load op used by the dot op, and so on.
+  llvm::MapVector<Operation *, int>
+  loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
+                            tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
+    llvm::MapVector<Operation *, int> loadOpToIndLevel;
+    DenseSet<Operation *> seen;
+    DenseSet<Operation *> excluded;
+
+    std::function<void(Operation *, Operation *, int)> dfs =
+        [&](Operation *op, Operation *finalUser, int distance) {
+          if (!seen.insert(op).second || excluded.count(op))
+            return;
+          if (isa<tt::LoadOp, tt::ExperimentalDescriptorLoadOp,
+                  tt::ExperimentalDescriptorGatherOp>(op)) {
+            if (!isPipeliningBeneficial(op, finalUser, axisInfoAnalysis))
+              return;
+            if (loadOpToIndLevel.count(op)) {
+              int level = loadOpToIndLevel[op];
+              if (level != distance) {
+                // If we have multiple uses at different distances, we don't
+                // know which one to pick.
+                LDBG("Load " << *op
+                             << " has multiple uses at different distances:"
+                             << level << " and " << distance);
+                loadOpToIndLevel.erase(op);
+                excluded.insert(op);
+                return;
+              }
+            } else {
+              LDBG("Load " << *op << " considered for pipelining with distance "
+                           << distance);
+              loadOpToIndLevel[op] = distance;
+            }
+            finalUser = op;
+            distance++;
+          }
+          for (Value operand : getNestedOperands(op)) {
+            if (isa<mlir::triton::DotOpInterface>(op)) {
+              // Heuristic: only pipeline A and B operands of the dot op.
+              if (operand == op->getOperand(2))
+                continue;
+            }
+            Value v = operand;
+            Operation *defOp = v.getDefiningOp();
+            if (defOp && defOp->getBlock() == op->getBlock()) {
+              dfs(defOp, finalUser, distance);
+            }
+          }
+        };
+
+    bool seenDot = false;
+    for (Operation &op : forOp.getBody()->without_terminator()) {
+      if (!isa<mlir::triton::DotOpInterface>(op))
+        continue;
+      seenDot = true;
+      seen.clear();
+      dfs(&op, &op, 0);
+    }
+
+    // If the loop has numStages attribute, also consider pipelining other loads
+    // that are not directly used by dot ops.
+    if (pipelineWithoutDot && !seenDot) {
+      for (Operation &op : forOp.getBody()->without_terminator()) {
+        if (!isa<tt::LoadOp, tt::ExperimentalDescriptorLoadOp,
+                 tt::ExperimentalDescriptorGatherOp>(op))
+          dfs(&op, &op, 0);
+      }
+    }
+
+    return loadOpToIndLevel;
+  }
+};
+
+class AssignMMALatencies {
+public:
+  AssignMMALatencies(scf::ForOp forOp, DenseMap<Operation *, int> &opLatency)
+      : forOp(forOp), opLatency(opLatency) {};
+
+  void run() {
+    for (auto &op : forOp.getBody()->without_terminator()) {
+      if (isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp>(op) &&
+          isPipeliningOfMMAOpPossible(&op, forOp)) {
+        opLatency[&op] = 1;
+      }
+    }
+  }
+
+private:
+  scf::ForOp forOp;
+  DenseMap<Operation *, int> &opLatency;
+
+  bool isPipeliningOfMMAOpPossible(Operation *op, scf::ForOp forOp) {
+    assert((isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp>(op)) &&
+           "Only MMA ops are supported");
+    // Operands of the MMA op must come from the load, or from outside the loop.
+    auto comesFromLoadOrOutsideLoop = [&](Value v) {
+      if (forOp.isDefinedOutsideOfLoop(v)) {
+        return true;
+      }
+      // Do not walk through the Block Arguments.
+      if (!v.getDefiningOp()) {
+        return false;
+      }
+      if (auto localAlloc = dyn_cast<ttg::LocalAllocOp>(v.getDefiningOp())) {
+        if (!localAlloc.getSrc()) {
+          return false;
+        }
+        return (localAlloc.getSrc().getDefiningOp() &&
+                isa<tt::LoadOp>(localAlloc.getSrc().getDefiningOp())) ||
+               forOp.isDefinedOutsideOfLoop(localAlloc.getSrc());
+      }
+      return false;
+    };
+    if (auto dotOp = dyn_cast<tt::DotOpInterface>(op)) {
+      if (!comesFromLoadOrOutsideLoop(dotOp.getA()) ||
+          !comesFromLoadOrOutsideLoop(dotOp.getB())) {
+        return false;
+      }
+    }
+
+    // For scaled MMA check if the scales are passed through shared memory, and
+    // also coming from load or outside the loop.
+    if (auto scaledOp = dyn_cast<ttng::TCGen5MMAScaledOp>(op)) {
+      if (!isa<ttg::SharedEncodingTrait>(
+              scaledOp.getAScale().getType().getEncoding()) ||
+          !isa<ttg::SharedEncodingTrait>(
+              scaledOp.getBScale().getType().getEncoding()))
+        return false;
+      if (!comesFromLoadOrOutsideLoop(scaledOp.getAScale()) ||
+          !comesFromLoadOrOutsideLoop(scaledOp.getBScale()))
+        return false;
+    }
+    return true;
+  }
+};
+
 } // namespace
 
 // Look for load ops that directly or indirectly feed into dot ops. Based
 // on the requested number of stages assign the latencies in a way that
 // cover all the stages with the sum of latencies in the chain from the first
 // load to the final dot op.
-void assignLatencies(ModuleOp moduleOp, int defaultNumStages) {
+void assignLatencies(ModuleOp moduleOp, int defaultNumStages, bool assignMMA) {
   auto getNumStagesOrDefault = [defaultNumStages](scf::ForOp forOp) -> int {
     // Use the attribute attached to the loop if it exists otherwise use the
     // global control.
@@ -239,34 +346,11 @@ void assignLatencies(ModuleOp moduleOp, int defaultNumStages) {
       continue;
     }
     int numStages = getNumStagesOrDefault(forOp);
-    bool pipelineWithoutDot = forOp->hasAttr(mlir::triton::kNumStagesAttrName);
-    ModuleOp moduleOp = forOp->getParentOfType<ModuleOp>();
-    tt::ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
-
-    llvm::MapVector<Operation *, int> loadOpToIndLevel =
-        loadOpsToIndirectionLevel(forOp, pipelineWithoutDot, axisInfoAnalysis);
-    if (loadOpToIndLevel.empty())
-      continue;
-
-    // We assume loads with different dist are assigned to different stages.
-    // If numStages is 2, we will have no stage available for indirect loads
-    // with dist >= 1. In general, when dist is equal to numStages - 1, we
-    // should not pipeline it.
-    for (auto iter = loadOpToIndLevel.begin();
-         iter != loadOpToIndLevel.end();) {
-      if (iter->second >= numStages - 1)
-        iter = loadOpToIndLevel.erase(iter);
-      else
-        ++iter;
-    }
-
-    // Calculate the stage distance between applicable loads.
-    auto vals = llvm::make_second_range(loadOpToIndLevel);
-    int maxIndirectionLevel = vals.empty() ? 0 : *llvm::max_element(vals);
-    unsigned loadLatency = (numStages - 1) / (maxIndirectionLevel + 1);
-
-    for (auto [loadOp, dist] : loadOpToIndLevel) {
-      opLatency[loadOp] = loadLatency;
+    AssignLoadLatencies assignLoadLatencies(forOp, numStages, opLatency);
+    assignLoadLatencies.run();
+    if (assignMMA) {
+      AssignMMALatencies assignMMALatencies(forOp, opLatency);
+      assignMMALatencies.run();
     }
   }
   serializeLatencies(moduleOp, opLatency);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TestPipelineAssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TestPipelineAssignLatencies.cpp
@@ -21,7 +21,9 @@ struct TestPipelineAssignLatencies
   using impl::TritonGPUTestPipelineAssignLatenciesBase<
       TestPipelineAssignLatencies>::TritonGPUTestPipelineAssignLatenciesBase;
 
-  void runOnOperation() override { assignLatencies(getOperation(), numStages); }
+  void runOnOperation() override {
+    assignLatencies(getOperation(), numStages, /*assignMMA=*/true);
+  }
 };
 
 } // namespace gpu

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -tritongpu-test-pipeline-assign-latencies=num-stages=3 -canonicalize | FileCheck %s
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-test-pipeline-assign-latencies=num-stages=3 -canonicalize | FileCheck %s
 
 #AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #BL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -373,5 +373,319 @@ tt.func @intermediate_use_cust_stages(%lb : index, %ub : index, %step : index,
   } {tt.num_stages = 3 : i32}
   tt.return %loop#2: tensor<128x128xf32, #C>
 }
+}
 
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @tc_gen5_mma
+tt.func @tc_gen5_mma(%lb : index, %ub : index, %step : index,
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>,
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>,
+                  %acc_tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> () {
+  %true = arith.constant true
+  scf.for %iv = %lb to %ub step %step : index {
+    %A = tt.load %A_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %B = tt.load %B_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %A_sh = ttg.local_alloc %A : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    %B_sh = ttg.local_alloc %B : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    // CHECK: ttng.tc_gen5_mma {{.*}} {tt.latency = 1 : i32}
+    ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true : (!ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>, i1, i1) -> ()
+    "use"(%acc_tm) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> ()
+  }
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @tc_gen5_mma
+tt.func @tc_gen5_mma(%lb : index, %ub : index, %step : index,
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>,
+                  %B: tensor<128x128xf16, #blocked1>,
+                  %acc_tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> () {
+  %true = arith.constant true
+  scf.for %iv = %lb to %ub step %step : index {
+    %A = tt.load %A_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %A_sh = ttg.local_alloc %A : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    %B_sh = ttg.local_alloc %B : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    // CHECK: ttng.tc_gen5_mma {{.*}} {tt.latency = 1 : i32}
+    ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true : (!ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>, i1, i1) -> ()
+    "use"(%acc_tm) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> ()
+  }
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @tc_gen5_mma_defined_outside1
+tt.func @tc_gen5_mma_defined_outside1(%lb : index, %ub : index, %step : index,
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>,
+                  %B: tensor<128x128xf16, #blocked1>,
+                  %acc_tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> () {
+  %true = arith.constant true
+  scf.for %iv = %lb to %ub step %step : index {
+    %A = tt.load %A_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %A_sh = ttg.local_alloc %A : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    %B_sh = ttg.local_alloc %B : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    // CHECK: ttng.tc_gen5_mma {{.*}} {tt.latency = 1 : i32}
+    ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true : (!ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>, i1, i1) -> ()
+    "use"(%acc_tm) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> ()
+  }
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @tc_gen5_mma_defined_outside2
+tt.func @tc_gen5_mma_defined_outside2(%lb : index, %ub : index, %step : index,
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>,
+                  %B_sh: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>,
+                  %acc_tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> () {
+  %true = arith.constant true
+  scf.for %iv = %lb to %ub step %step : index {
+    %A = tt.load %A_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %A_sh = ttg.local_alloc %A : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    // CHECK: ttng.tc_gen5_mma {{.*}} {tt.latency = 1 : i32}
+    ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true : (!ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>, i1, i1) -> ()
+    "use"(%acc_tm) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> ()
+  }
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @tc_gen5_mma_non_load_operand1
+tt.func @tc_gen5_mma_non_load_operand1(%lb : index, %ub : index, %step : index,
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>,
+                  %acc_tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> () {
+  %true = arith.constant true
+  scf.for %iv = %lb to %ub step %step : index {
+    %A = tt.load %A_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %A_sh = ttg.local_alloc %A : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    %B = "producer"() : () -> tensor<128x128xf16, #blocked1>
+    %B_sh = ttg.local_alloc %B : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    // CHECK: ttng.tc_gen5_mma
+    // CHECK-NOT: tt.latency
+    ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true : (!ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>, i1, i1) -> ()
+    "use"(%acc_tm) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> ()
+  }
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @tc_gen5_mma_non_load_operand2
+tt.func @tc_gen5_mma_non_load_operand2(%lb : index, %ub : index, %step : index,
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>,
+                  %acc_tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> () {
+  %true = arith.constant true
+  scf.for %iv = %lb to %ub step %step : index {
+    %A = tt.load %A_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %A_sh = ttg.local_alloc %A : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    %B_sh = "producer"() : () -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    // CHECK: ttng.tc_gen5_mma
+    // CHECK-NOT: tt.latency
+    ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true : (!ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>, i1, i1) -> ()
+    "use"(%acc_tm) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> ()
+  }
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 4], threadsPerWarp = [1, 1, 8, 4, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 3, 2, 1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [4, 3, 2, 1, 0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @tc_gen5_mma_scaled
+tt.func @tc_gen5_mma_scaled(%lb : index, %ub : index, %step : index,
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>,
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>,
+                  %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>,
+                  %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>,
+                  %acc_tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> () {
+  %true = arith.constant true
+  scf.for %iv = %lb to %ub step %step : index {
+    %A = tt.load %A_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %A_sh = ttg.local_alloc %A : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    %B = tt.load %B_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %B_sh = ttg.local_alloc %B : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+
+    %A_sc = tt.load %A_sc_ptr : tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>
+    %A_sc_sh = ttg.local_alloc %A_sc : (tensor<1x2x32x4x4xi8, #blocked2>) -> !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>
+
+    %B_sc = tt.load %B_sc_ptr : tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>
+    %B_sc_sh = ttg.local_alloc %B_sc : (tensor<1x2x32x4x4xi8, #blocked2>) -> !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>
+
+    // CHECK: ttng.tc_gen5_mma_scaled {{.*}} {tt.latency = 1 : i32}
+    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %acc_tm, %A_sc_sh, %B_sc_sh, %true, %true lhs = e5m2 rhs = e5m2 : (!ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, i1, i1) -> ()
+    "use"(%acc_tm) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> ()
+  }
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 4], threadsPerWarp = [1, 1, 8, 4, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 3, 2, 1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [4, 3, 2, 1, 0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @tc_gen5_mma_scaled_tmem_scales
+tt.func @tc_gen5_mma_scaled_tmem_scales(%lb : index, %ub : index, %step : index,
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>,
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>,
+                  %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>,
+                  %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>,
+                  %acc_tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> () {
+  %true = arith.constant true
+  scf.for %iv = %lb to %ub step %step : index {
+    %A = tt.load %A_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %A_sh = ttg.local_alloc %A : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+    %B = tt.load %B_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+    %B_sh = ttg.local_alloc %B : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>
+
+    %A_sc = tt.load %A_sc_ptr : tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>
+    %A_sc_sh = ttg.local_alloc %A_sc : (tensor<1x2x32x4x4xi8, #blocked2>) -> !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>
+
+    %B_sc = tt.load %B_sc_ptr : tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>
+    %B_sc_tm = ttng.tmem_alloc %B_sc : (tensor<1x2x32x4x4xi8, #blocked2>) -> !ttg.memdesc<1x2x328x4xi8, #tmem_scales, #ttng.tensor_memory>
+
+    // CHECK: ttng.tc_gen5_mma_scaled {{.*}}
+    // CHECK-NOT: tt.latency
+    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %acc_tm, %A_sc_sh, %B_sc_tm, %true, %true lhs = e5m2 rhs = e5m2 : (!ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, !ttg.memdesc<1x2x328x4xi8, #tmem_scales, #ttng.tensor_memory>, i1, i1) -> ()
+    "use"(%acc_tm) : (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> ()
+  }
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 4], threadsPerWarp = [1, 1, 8, 4, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 3, 2, 1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4]], lane = [[32, 0], [64, 0], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [4, 3, 2, 1, 0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @block_scale_mxfp_matmul
+  tt.func public @block_scale_mxfp_matmul(%lb : index, %ub : index, %step : index, %arg0: !tt.ptr<f8E5M2> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f8E5M2> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<i8> {tt.divisibility = 16 : i32}) -> tensor<128x128xf32, #blocked4> {
+    %true = arith.constant true
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked4>
+    %incr_A = arith.constant dense<4> : tensor<128x256xi32, #blocked>
+    %incr_B = arith.constant dense<4> : tensor<256x128xi32, #blocked1>
+    %incr_scale = arith.constant dense<4> : tensor<1x2x32x4x4xi32, #blocked2>
+
+    %arg0_splat = tt.splat %arg0: !tt.ptr<f8E5M2> -> tensor<128x256x!tt.ptr<f8E5M2>, #blocked>
+    %arg1_splat = tt.splat %arg1: !tt.ptr<f8E5M2> -> tensor<256x128x!tt.ptr<f8E5M2>, #blocked1>
+    %arg3_splat = tt.splat %arg3: !tt.ptr<i8> -> tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>
+    %arg4_splat = tt.splat %arg4: !tt.ptr<i8> -> tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>
+
+    %76 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %77 = tt.expand_dims %76 {axis = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x256xi32, #blocked>
+    %79 = tt.broadcast %77 : tensor<1x256xi32, #blocked> -> tensor<128x256xi32, #blocked>
+    %arg0_init = tt.addptr %arg0_splat, %79 : tensor<128x256x!tt.ptr<f8E5M2>, #blocked>, tensor<128x256xi32, #blocked>
+
+    %83 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
+    %84 = tt.expand_dims %83 {axis = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xi32, #blocked1>
+    %88 = tt.broadcast %84 : tensor<1x128xi32, #blocked1> -> tensor<256x128xi32, #blocked1>
+    %arg1_init = tt.addptr %arg1_splat, %88 : tensor<256x128x!tt.ptr<f8E5M2>, #blocked1>, tensor<256x128xi32, #blocked1>
+
+    %44 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 1, parent = #ttg.slice<{dim = 2, parent = #ttg.slice<{dim = 3, parent = #blocked2}>}>}>}>>
+    %46 = tt.expand_dims %44 {axis = 0 : i32} : tensor<4xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 1, parent = #ttg.slice<{dim = 2, parent = #ttg.slice<{dim = 3, parent = #blocked2}>}>}>}>> -> tensor<1x4xi32, #ttg.slice<{dim = 1, parent = #ttg.slice<{dim = 2, parent = #ttg.slice<{dim = 3, parent = #blocked2}>}>}>>
+    %48 = tt.expand_dims %46 {axis = 1 : i32} : tensor<1x4xi32, #ttg.slice<{dim = 1, parent = #ttg.slice<{dim = 2, parent = #ttg.slice<{dim = 3, parent = #blocked2}>}>}>> -> tensor<1x1x4xi32, #ttg.slice<{dim = 2, parent = #ttg.slice<{dim = 3, parent = #blocked2}>}>>
+    %50 = tt.expand_dims %48 {axis = 2 : i32} : tensor<1x1x4xi32, #ttg.slice<{dim = 2, parent = #ttg.slice<{dim = 3, parent = #blocked2}>}>> -> tensor<1x1x1x4xi32, #ttg.slice<{dim = 3, parent = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 4], threadsPerWarp = [1, 1, 8, 4, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 3, 2, 1, 0]}>}>>
+    %56 = tt.expand_dims %50 {axis = 3 : i32} : tensor<1x1x1x4xi32, #ttg.slice<{dim = 3, parent = #blocked2}>> -> tensor<1x1x1x1x4xi32, #blocked2>
+    %57 = tt.broadcast %56 : tensor<1x1x1x1x4xi32, #blocked2> -> tensor<1x2x32x4x4xi32, #blocked2>
+
+    %arg3_init = tt.addptr %arg3_splat, %57 : tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>, tensor<1x2x32x4x4xi32, #blocked2>
+    %arg4_init = tt.addptr %arg4_splat, %57 : tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>, tensor<1x2x32x4x4xi32, #blocked2>
+
+    %99:5 = scf.for %iv = %lb to %ub step %step iter_args(%arg15 = %cst_1, %arg16 = %arg0_init, %arg17 = %arg1_init, %arg18 = %arg3_init, %arg19 = %arg4_init) -> (tensor<128x128xf32, #blocked4>, tensor<128x256x!tt.ptr<f8E5M2>, #blocked>, tensor<256x128x!tt.ptr<f8E5M2>, #blocked1>, tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>, tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>) {
+      // CHECK: tt.load {{.*}} {tt.latency = 2 : i32}
+      %117 = tt.load %arg16 : tensor<128x256x!tt.ptr<f8E5M2>, #blocked>
+      %118 = ttg.local_alloc %117 : (tensor<128x256xf8E5M2, #blocked>) -> !ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>
+      // CHECK: tt.load {{.*}} {tt.latency = 2 : i32}
+      %119 = tt.load %arg17 : tensor<256x128x!tt.ptr<f8E5M2>, #blocked1>
+      %120 = ttg.local_alloc %119 : (tensor<256x128xf8E5M2, #blocked1>) -> !ttg.memdesc<256x128xf8E5M2, #shared, #ttg.shared_memory>
+      // CHECK: tt.load {{.*}} {tt.latency = 2 : i32}
+      %121 = tt.load %arg18 : tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>
+      // CHECK: tt.load {{.*}} {tt.latency = 2 : i32}
+      %122 = tt.load %arg19 : tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>
+
+      %137 = ttg.local_alloc %121 : (tensor<1x2x32x4x4xi8, #blocked2>) -> !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>
+      %139 = ttg.local_alloc %122 : (tensor<1x2x32x4x4xi8, #blocked2>) -> !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>
+
+      %127 = ttng.tmem_alloc %arg15 : (tensor<128x128xf32, #blocked4>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      // CHECK: ttng.tc_gen5_mma_scaled {{.*}} {tt.latency = 1 : i32}
+      ttng.tc_gen5_mma_scaled %118, %120, %127, %137, %139, %true, %true lhs = e5m2 rhs = e5m2 : (!ttg.memdesc<128x256xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<256x128xf8E5M2, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, i1, i1) -> ()
+      %132 = ttng.tmem_load %127 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked4>
+
+      %133 = tt.addptr %arg16, %incr_A : tensor<128x256x!tt.ptr<f8E5M2>, #blocked>, tensor<128x256xi32, #blocked>
+      %134 = tt.addptr %arg17, %incr_B : tensor<256x128x!tt.ptr<f8E5M2>, #blocked1>, tensor<256x128xi32, #blocked1>
+      %135 = tt.addptr %arg18, %incr_scale : tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>, tensor<1x2x32x4x4xi32, #blocked2>
+      %136 = tt.addptr %arg19, %incr_scale : tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>, tensor<1x2x32x4x4xi32, #blocked2>
+      scf.yield %132, %133, %134, %135, %136 : tensor<128x128xf32, #blocked4>, tensor<128x256x!tt.ptr<f8E5M2>, #blocked>, tensor<256x128x!tt.ptr<f8E5M2>, #blocked1>, tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>, tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>
+    } {tt.num_stages = 3 : i32}
+     tt.return %99#0 : tensor<128x128xf32, #blocked4>
+  }
 }


### PR DESCRIPTION
Implement and test assigning latencies for mmav5 ops (regular and scaled). This PR also features slight refactor of AssignLatencies code with putting load-related and mma-related code in separate classes for maintainability.