### PR TITLE
Eliminate Ambiguous Function Evaluation Order in ConvertWarpSpecializeToLLVM

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -328,7 +328,8 @@ static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
     b.setInsertionPointToEnd(before);
     Value statePtr = LLVM::getSharedMemoryBase(b.getLoc(), b, targetInfo, func);
     for (auto [i, state] : llvm::enumerate(stateMap)) {
-      b.store(b.i8_val(state), b.gep(ptrTy, i8_ty, statePtr, LLVM::GEPArg(i)));
+      Value stateVal = b.i8_val(state);
+      b.store(stateVal, b.gep(ptrTy, i8_ty, statePtr, LLVM::GEPArg(i)));
     }
 
     // Store the captures if there are any.


### PR DESCRIPTION
This PR eliminated the ambiguous evaluation order in the ConvertWarpSpecializeToLLVM pass, which leads to a failure in lit tests if the compiler is clang 20.