### PR TITLE
[TEST] Assert the return value of torch.allclose in test_unary_math

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5133,7 +5133,7 @@ def test_unary_math(func_str, device):
 
     kernel[(1, )](x, y, BLOCK=shape[0])
     # compare
-    np.testing.assert_allclose(to_numpy(getattr(torch, func_str)(x)), to_numpy(y), rtol=1e-3)
+    torch.testing.assert_close(getattr(torch, func_str)(x), y, rtol=1e-3, atol=1e-5)
 
 
 # -----------------------

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5132,7 +5132,7 @@ def test_unary_math(func_str, device):
     y = torch.zeros(shape, dtype=torch.float32, device=device)
 
     kernel[(1, )](x, y, BLOCK=shape[0])
-    torch.allclose(getattr(torch, func_str)(x), y, rtol=1e-3)
+    assert torch.allclose(getattr(torch, func_str)(x), y, rtol=1e-3)
 
 
 # -----------------------

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5132,7 +5132,8 @@ def test_unary_math(func_str, device):
     y = torch.zeros(shape, dtype=torch.float32, device=device)
 
     kernel[(1, )](x, y, BLOCK=shape[0])
-    assert torch.allclose(getattr(torch, func_str)(x), y, rtol=1e-3)
+    # compare
+    np.testing.assert_allclose(to_numpy(getattr(torch, func_str)(x)), to_numpy(y), rtol=1e-3)
 
 
 # -----------------------


### PR DESCRIPTION
This patch asserts the return value of torch.allclose in test_unary_math. If result y was incorrect, the testcase would fail.

# Problem
torch.allclose() returns a boolean value. it's not an assertion. 

If we comment out the triton kernel call, it's still can pass.
```
-    kernel[(1, )](x, y, BLOCK=shape[0])
+    #kernel[(1, )](x, y, BLOCK=shape[0])

cd python/test/unit; python -m pytest  ./language/test_core.py::test_unary_math
```

The expected behavior: test failed

# Test plan 
cd python/test/unit; python -m pytest  ./language/test_core.py::test_unary_math

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
