### PR TITLE
Add LLVM aarch64 Almalinux build

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -6,6 +6,9 @@ on:
       - llvm-head
     paths:
       - cmake/llvm-hash.txt
+  pull_request:
+    paths:
+      - .github/workflows/llvm-build.yml
   workflow_dispatch:
 
 env:

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: true
       matrix:
         config:
-        - {runner: 'AlmaLinux 8 ARM64', runs_on: 'ubuntu-20.04-arm', target-os: 'almalinux', arch: 'arm64'}
+        - {runner: 'AlmaLinux 8 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'almalinux', arch: 'arm64'}
 
     steps:
 

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -26,13 +26,7 @@ jobs:
       fail-fast: true
       matrix:
         config:
-        - {runner: 'Ubuntu 20.04', runs_on: 'ubuntu-20.04', target-os: 'ubuntu', arch: 'x64'}
-        - {runner: 'Ubuntu 20.04 ARM64', runs_on: 'ubuntu-20.04', target-os: 'ubuntu', arch: 'arm64'}
-        - {runner: 'CentOS 7', runs_on: ['self-hosted', 'CPU'], target-os: 'centos', arch: 'x64'}
-        - {runner: 'AlmaLinux 8', runs_on: ['self-hosted', 'CPU'], target-os: 'almalinux', arch: 'x64'}
-        - {runner: 'MacOS X64', runs_on: 'macos-13', target-os: 'macos', arch: 'x64'}
-        - {runner: 'MacOS ARM64', runs_on: 'macos-13', target-os: 'macos', arch: 'arm64'}
-        - {runner: 'Windows Latest', runs_on: 'windows-latest', target-os: 'windows', arch: 'x64'}
+        - {runner: 'AlmaLinux 8 ARM64', runs_on: 'ubuntu-20.04-arm', target-os: 'almalinux', arch: 'arm64'}
 
     steps:
 

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -29,7 +29,14 @@ jobs:
       fail-fast: true
       matrix:
         config:
+        - {runner: 'Ubuntu 20.04', runs_on: 'ubuntu-20.04', target-os: 'ubuntu', arch: 'x64'}
+        - {runner: 'Ubuntu 20.04 ARM64', runs_on: 'ubuntu-20.04', target-os: 'ubuntu', arch: 'arm64'}
+        - {runner: 'CentOS 7', runs_on: ['self-hosted', 'CPU'], target-os: 'centos', arch: 'x64'}
+        - {runner: 'AlmaLinux 8', runs_on: ['self-hosted', 'CPU'], target-os: 'almalinux', arch: 'x64'}
         - {runner: 'AlmaLinux 8 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'almalinux', arch: 'arm64'}
+        - {runner: 'MacOS X64', runs_on: 'macos-13', target-os: 'macos', arch: 'x64'}
+        - {runner: 'MacOS ARM64', runs_on: 'macos-13', target-os: 'macos', arch: 'arm64'}
+        - {runner: 'Windows Latest', runs_on: 'windows-latest', target-os: 'windows', arch: 'x64'}
 
     steps:
 


### PR DESCRIPTION
Builds: ``llvm-a66376b0-almalinux-arm64`` artifact
Test:
```
bin/mlir-tblgen --version
LLVM (http://llvm.org/):
  LLVM version 21.0.0git
  Optimized build with assertions.
```

Failed use case, trying to run ubunu generated aarch64 binary:
```
 ../../llvm-a66376b0-ubuntu-arm64/bin/mlir-tblgen --version
../../llvm-a66376b0-ubuntu-arm64/bin/mlir-tblgen: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by ../../llvm-a66376b0-ubuntu-arm64/bin/mlir-tblgen)
```

This is required in order to build triton aarch64 Manywheel 2.28
Successful run:  https://github.com/triton-lang/triton/actions/runs/13640751105/job/38129853476?pr=6092

This should unlock adding Manyhwheel 2.28 aarch64 builds. Test PR: https://github.com/triton-lang/triton/pull/6089 which is currently failing (since its using ubuntu aarch64 llvm build):
```
        /root/.triton/llvm/llvm-a66376b0-ubuntu-arm64/bin/mlir-tblgen: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by /root/.triton/llvm/llvm-a66376b0-ubuntu-arm64/bin/mlir-tblgen)
```

Please note: The build cancelled because CentOS build finished and was not able to log into the Azure. Hence I restarted the Almalinux aarch64 builds
