### PR TITLE
[PROTON-DEV] Implement ProtonGPU Global Scratch Buffer Alloc Conversion Pass

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -79,6 +79,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::proton::registerConvertProtonToProtonGPU();
   mlir::triton::proton::registerAllocateProtonSharedMemoryPass();
   mlir::triton::proton::registerAddProtonKernelArgPass();
+  mlir::triton::proton::registerAllocateProtonGlobalScratchBufferPass();
 
   // TODO: register Triton & TritonGPU passes
   registry.insert<mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,

--- a/test/Proton/allocate_global_scratch_buffer.mlir
+++ b/test/Proton/allocate_global_scratch_buffer.mlir
@@ -1,0 +1,10 @@
+// RUN: triton-opt --split-input-file -allocate-proton-global-scratch-buffer %s | FileCheck %s
+
+// CHECK: module attributes {proton.global_scratch_memory_alignment = 128 : i32, proton.global_scratch_memory_size = 768 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+  tt.func @test_empty_kernel(%lb : index, %A : !tt.ptr<i8>) {
+    %0 = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 384 : i32} : !tt.ptr<i8>
+    %1 = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 384 : i32} : !tt.ptr<i8>
+    tt.return
+  }
+}

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h
@@ -20,6 +20,8 @@ namespace triton::proton {
 namespace gpu {
 std::unique_ptr<OperationPass<ModuleOp>> createAddProtonKernelArgPass();
 std::unique_ptr<OperationPass<ModuleOp>> createAllocateProtonSharedMemoryPass();
+std::unique_ptr<OperationPass<ModuleOp>>
+createAllocateProtonGlobalScratchBufferPass();
 
 } // namespace gpu
 

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.td
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.td
@@ -13,6 +13,10 @@ def AllocateProtonSharedMemory : Pass<"allocate-proton-shared-memory", "mlir::Mo
     let constructor = "mlir::triton::proton::gpu::createAllocateProtonSharedMemoryPass()";
 }
 
+def AllocateProtonGlobalScratchBuffer : Pass<"allocate-proton-global-scratch-buffer", "mlir::ModuleOp"> {
+    let constructor = "mlir::triton::proton::gpu::createAllocateProtonGlobalScratchBufferPass()";
+}
+
 
 def AddProtonKernelArg : Pass<"add-proton-kernel-arg", "mlir::ModuleOp"> {
 

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonGlobalScratchBuffer.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/AllocateProtonGlobalScratchBuffer.cpp
@@ -1,0 +1,61 @@
+#include "Dialect/ProtonGPU/IR/Dialect.h"
+#include "mlir/Pass/Pass.h"
+#include "third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace mlir {
+namespace triton::proton {
+#define GEN_PASS_DEF_ALLOCATEPROTONGLOBALSCRATCHBUFFER
+#include "proton/dialect/include/Conversion/ProtonGPUToLLVM/Passes.h.inc"
+} // namespace triton::proton
+} // namespace mlir
+
+namespace {
+
+struct AllocateProtonGlobalScratchBuffer
+    : public mlir::triton::proton::impl::AllocateProtonGlobalScratchBufferBase<
+          AllocateProtonGlobalScratchBuffer> {
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    MLIRContext *ctx = &getContext();
+    OpBuilder builder(ctx);
+
+    assert(llvm::range_size(mod.getOps<triton::FuncOp>()) == 1);
+    FuncOp func = *mod.getOps<triton::FuncOp>().begin();
+
+    int32_t totalMemorySize = 0;
+    uint32_t largestAlignment = 1;
+
+    func.walk([&](proton::gpu::GlobalScratchAllocOp op) {
+	  totalMemorySize+=op.getNbytes();
+	  largestAlignment = std::max(largestAlignment, op.getAlignment());
+    });
+  mod->setAttr("proton.global_scratch_memory_size",
+                    builder.getI32IntegerAttr(totalMemorySize));
+  mod->setAttr("proton.global_scratch_memory_alignment",
+                    builder.getI32IntegerAttr(largestAlignment));  
+  }
+};
+
+} // namespace
+
+namespace mlir {
+
+namespace triton::proton {
+
+namespace gpu {
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createAllocateProtonGlobalScratchBufferPass() {
+  return std::make_unique<AllocateProtonGlobalScratchBuffer>();
+}
+
+} // namespace gpu
+
+} // namespace triton::proton
+
+} // namespace mlir

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/CMakeLists.txt
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(ProtonGPUToLLVM
     ProtonGPUToLLVM.cpp
     AllocateProtonSharedMemory.cpp
     AddProtonKernelArg.cpp
+    AllocateProtonGlobalScratchBuffer.cpp
 
     DEPENDS
     ProtonGPUConversionPassIncGen


### PR DESCRIPTION
In this PR, we add the support for the proton's global scratch buffer conversion used for host device transfer of GPU profiling data. This pass happens after ProtonToProtonGPU lowering. We find the total amount of global memory that needs to be allocated from all global scratch alloc ops, set a proton specific function attribute which will be read in the Python backend to do call the actual allocator (e.g. PyTorch or some custom Proton implementation)