### PR TITLE
Fix F16 -> F8E5M2 RTNE conversion logic on A100.

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -331,14 +331,18 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
 def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
 
     if is_cuda():
-        if src_dtype != 'float32' and torch.cuda.get_device_capability(0) < (9, 0):
-            pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
-
-        if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and torch.cuda.get_device_capability(0) < (9, 0):
-            pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
-
-        if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne':
+        if dst_dtype in ('float8e5b16', 'float8e4b8'):
             pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU MI300")
+        if torch.cuda.get_device_capability(0) < (9, 0):
+            match (src_dtype, dst_dtype, rounding):
+                case ('float16', 'float8e5', 'rtne'):
+                    ...
+                case (_, ty, 'rtne') if ty in ('float8e5', 'float8e4nv'):
+                    pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
+                case (ty, _, _) if ty != 'float32':
+                    pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
+                case _:
+                    ...
 
     if is_hip():
         if dst_dtype == 'float8e5' and rounding == 'rtne':

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -30,10 +30,14 @@ static const Fp8ConversionDesc Fp16_to_Fp8E5M2_RTNE(bool hasNativeFP) {
   if (!hasNativeFP) {
     ret = {"{                            \n"
            ".reg .b32 a<2>;              \n"
-           "and.b32 a0, $1, 0xfffefffe;  \n"   // a0 &= 0xfffefffe
-           "and.b32 a1, $2, 0xfffefffe;  \n"   // (strip lowest bit)
-           "add.u32 a0, a0, 0x00800080;  \n"   // a0 += 0x00800080
-           "add.u32 a1, a1, 0x00800080;  \n"   // (round to nearest)
+           "and.b32 a0, $1, 0x01000100;  \n"   // a0 = $1 & 0x01000100
+           "and.b32 a1, $2, 0x01000100;  \n"   // (least significant result bit)
+           "shr.b32 a0, a0, 8;           \n"   // a0 >>= 8
+           "shr.b32 a1, a1, 8;           \n"   // (shift the lsb)
+           "add.u32 a0, a0, 0x007f007f;  \n"   // a0 += 0x007f007f
+           "add.u32 a1, a1, 0x007f007f;  \n"   // (add rounding base)
+           "add.u32 a0, a0, $1;          \n"   // res = $1 + lsb + 0x7f
+           "add.u32 a1, a1, $2;          \n"   // (round to nearest)
            "prmt.b32 $0, a0, a1, 0x7531; \n\t" // output = a1a0
            "}",
            32, 32, 4};


### PR DESCRIPTION
Prior to this change, Using `tt.fp_to_fp` with `rtne` semantics on A100 to
convert `f16` to `f8e5m2` yields wrong results.

For instance, `9` rounds to `10` instead of the expected `8`. Doing the job of
rounding manually using additional guard-round-sticky bits for convenience, we
have the following representations for 8, 9 and 10 in `f8e5m2`:

```
01001000|000 // 8
01001000|100 // 9
01001001|000 // 10
```

According to round-to-nearest-even semantics, when only the guard bit is set,
we should round to make the last bit of the mantissa even. In this case, this
means rounding down. The bit-twiddling algorithm used for conversion on A100
was therefore wrong.

Fixes issue https://github.com/triton-lang/triton/issues/5925.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] I have not added any `lit` tests.
