### PR TITLE
[Refactor] Remove `getVectorSize` and `getContiguity` functions due to incorrect behavior

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -316,7 +316,7 @@ struct BufferLoadOpConversion
         typeConverter->convertType(getElementTypeOrSelf(valueTy));
     Type ptrType = getPointerTypeWithShape(ptr, offset);
     unsigned numElems = getTotalElemsPerThread(ptrType);
-    unsigned vec = getVectorSize(ptr, offset, axisAnalysisPass);
+    unsigned vec = getVectorSize(ptr, axisAnalysisPass);
 
     // Get the offset
     SmallVector<Value> offsetElems = unpackLLElements(loc, llOffset, rewriter);
@@ -404,7 +404,7 @@ struct BufferLoadToLocalOpConversion
     //  2. The mask (if present) has "alignment" N, meaning that each group of N
     //     mask bits are the same.  For example if N=2, the mask must be
     //     [x, x, y, y, ...].
-    unsigned vec = getVectorSize(ptr, offset, axisAnalysisPass);
+    unsigned vec = getVectorSize(ptr, axisAnalysisPass);
     SmallVector<Value> maskElems =
         getMaskElemsAndUpdateVeclen(rewriter, loc, llMask, mask, vec);
 
@@ -753,7 +753,7 @@ struct BufferAtomicRMWOpConversion
     Type ptrType = getPointerTypeWithShape(ptr, offset);
 
     unsigned numElems = getTotalElemsPerThread(ptrType);
-    unsigned vec = getVectorSize(ptr, offset, axisAnalysisPass);
+    unsigned vec = getVectorSize(ptr, axisAnalysisPass);
 
     // v4f16 and v4bf16 variants of buffer atomics do not exist.
     // only v2f16 and v2bf16.
@@ -990,7 +990,7 @@ struct BufferStoreOpConversion
     Type ptrType = getPointerTypeWithShape(ptr, offset);
 
     unsigned numElems = getTotalElemsPerThread(ptrType);
-    unsigned vec = getVectorSize(ptr, offset, axisAnalysisPass);
+    unsigned vec = getVectorSize(ptr, axisAnalysisPass);
 
     // Get the offsets and value
     SmallVector<Value> offsetElems = unpackLLElements(loc, llOffset, rewriter);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -72,16 +72,8 @@ Type getPointerTypeWithShape(Value basePtr, Value offset);
 // Get contiguity for a tensor pointer `ptr`
 unsigned getContiguity(Value ptr, ModuleAxisInfoAnalysis &axisAnalysisPass);
 
-// Get contiguity for a scalar pointer `ptr` and a tensor `offset`
-unsigned getContiguity(Value ptr, Value offset,
-                       ModuleAxisInfoAnalysis &axisAnalysisPass);
-
 // Determine the vector size of a tensor of pointers
 unsigned getVectorSize(Value ptr, ModuleAxisInfoAnalysis &axisAnalysisPass);
-
-// Given a scalar pointer and a tensor of offsets, determine the vector size
-unsigned getVectorSize(Value ptr, Value offset,
-                       ModuleAxisInfoAnalysis &axisAnalysisPass);
 
 Type scaleDotElemTypeToMLIRType(MLIRContext *ctx, triton::ScaleDotElemType t);
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -313,17 +313,19 @@ struct ConvertTritonAtomicRMWOpToBufferAtomicRMW
     // 4. Buffer atomic RMW does not support FP8 ops
     //    easier to just check what we support
     auto checkType = getElementTypeOrSelf(op.getVal());
-    // TODO: F16 and BF16 data types are supported by intrinsics with packed
-    // arithmetic on adjacent addresses, requiring the leading address to be
-    // 4-byte aligned. A runtime check should be implemented to enforce this
-    // requirement and ensure fallback to regular atomic operations when
-    // alignment is not met.
-    bool isSupportedType = checkType.isF32() || checkType.isF64() ||
+    bool isSupportedType = checkType.isF16() || checkType.isBF16() ||
+                           checkType.isF32() || checkType.isF64() ||
                            checkType.isInteger(32) || checkType.isInteger(64);
     if (!isSupportedType) {
       return rewriter.notifyMatchFailure(op, "RMW with unsupported type");
     }
     LDBG("RMW supported type");
+
+    auto vecSize = getVectorSize(ptr, axisAnalysisPass);
+    if (vecSize % 2 != 0 && (checkType.isF16() || checkType.isBF16()))
+      return rewriter.notifyMatchFailure(
+          op, "RMW float 16 dtypes must be aligned by 2");
+    LDBG("RMW passed alignment check");
 
     // 5. Check if the RMWOp is supported
     switch (atomicRmwOp) {
@@ -355,8 +357,7 @@ struct ConvertTritonAtomicRMWOpToBufferAtomicRMW
       // are contiguous we can emit the buffer op. Otherwise, the buffer ops
       // lowering will try to emit individual (unsupported) f16/bf16 ops.
       auto elemBitWidth = tensorType.getElementTypeBitWidth();
-      opBitWidth =
-          getVectorSize(basePtr, tensorOffset, axisAnalysisPass) * elemBitWidth;
+      opBitWidth = vecSize * elemBitWidth;
     } else {
       opBitWidth = opValueType.getIntOrFloatBitWidth();
     }


### PR DESCRIPTION
Removed `getVectorSize` and `getContiguity` functions that take `offset` as a parameter, as they exhibit incorrect behavior.

Issue in getContiguity: Lacks proper analysis of `offset` contents, leading to incorrect behavior in `getVectorSize`.

Misinterpretation of `LinearLayout::getContigPerThread`: It does not indicate the contiguity of elements in the offset tensor but rather the number of elements stored in registers per thread.

Proposed Fix: The `offset` tensor's contents should be analyzed similarly to `axisAnalysis` to ensure correct ordering of elements. Affected Cases: `offset` is not filled with strictly ranged values.

Additionally removed WA for f16 case for buffer atomics.
