### PR TITLE
[AMD]Fix a bug in Fp32->OCP Bf8 conversion with round-to-zero

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1077,7 +1077,8 @@ struct FpToFpOpConversion
 
     // numElements = 4 for conversions:
     // ocp bf8->fp16, ocp bf8->bf16, ocp bf8->fp32 on non-CDNA4
-    // fp16->ocp bf8, bf16->ocp bf8, fp32->ocp bf8 on non-CDNA4
+    // fp16->ocp bf8, bf16->ocp bf8, fp32->ocp bf8(RTNE) on non-CDNA4
+    // fp32->ocp bf8(RTZ)
     size_t numElements = 2;
     if (llvm::isa<Float8E5M2Type>(srcElementType) &&
             !llvm::isa<Float32Type>(dstElementType) ||
@@ -1087,7 +1088,8 @@ struct FpToFpOpConversion
             llvm::isa<Float8E5M2Type>(dstElementType) ||
         llvm::isa<Float32Type>(srcElementType) &&
             llvm::isa<Float8E5M2Type>(dstElementType) &&
-            isaFamily != AMD::ISAFamily::CDNA4) {
+            (roundingMode != RoundingMode::RTNE ||
+            isaFamily != AMD::ISAFamily::CDNA4)) {
       numElements = 4;
     }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1089,7 +1089,7 @@ struct FpToFpOpConversion
         llvm::isa<Float32Type>(srcElementType) &&
             llvm::isa<Float8E5M2Type>(dstElementType) &&
             (roundingMode != RoundingMode::RTNE ||
-            isaFamily != AMD::ISAFamily::CDNA4)) {
+             isaFamily != AMD::ISAFamily::CDNA4)) {
       numElements = 4;
     }
 


### PR DESCRIPTION
Downcasting Fp32 to OCP Bf8 with round-to-zero is done with software conversion which uses numElement = 4 instead of 2.