### PR TITLE
Remove wheel version suffix from wheels, set fail-fast to false for wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.config.runs_on }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         config:
         - {runs_on: ['self-hosted', 'CPU'], arch: 'x86_64'}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -63,7 +63,6 @@ jobs:
         run: |
           # Make sure cibuildwheel is updated to latest, this will enable latest python builds
           python3 -m pip install cibuildwheel --upgrade --user
-          export LATEST_DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
           # Pass MAX_JOBS=4 because, at time of writing, the VM "only" has 32GB
           # of RAM and OOMs while building if we give it the default number of
           # workers (2 * NUM_CPUs).

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -68,7 +68,6 @@ jobs:
           # of RAM and OOMs while building if we give it the default number of
           # workers (2 * NUM_CPUs).
           export CIBW_ENVIRONMENT="MAX_JOBS=4 \
-                  TRITON_WHEEL_VERSION_SUFFIX=-$LATEST_DATE \
                   TRITON_BUILD_WITH_CLANG_LLD=1"
 
           # many_linux_2_28 image comes with GCC 12.2.1, but not clang.

--- a/python/setup.py
+++ b/python/setup.py
@@ -746,7 +746,7 @@ def get_git_version_suffix():
 
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.2.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.3.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",


### PR DESCRIPTION
1. TRITON_WHEEL_VERSION_SUFFIX is not needed.
- For Release builds we want to have only version in suffix
- For nightly git sha256 in suffix
2. Set fail-fast true if aarch64 build fails, x86 builds can still continue
3. Update whl version 
