### PR TITLE
[FRONTEND] allow assigning a tensor.shape to a variable

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -591,12 +591,12 @@ class CodeGenerator(ast.NodeVisitor):
         def _sanitize_value(value):
             if isinstance(value, language.tuple):
                 return _apply_to_tuple_values(value, _sanitize_value)
-            native_nontensor_types = (language.dtype, language.tuple)
-            value = _unwrap_if_constexpr(value)
+            native_nontensor_types = (language.dtype, language.tuple, int, float, bool)
+            non_constexpr_value = _unwrap_if_constexpr(value)
             if value is not None and \
-                not _is_triton_value(value) and \
-                not isinstance(value, native_nontensor_types):
-                value = semantic.to_tensor(value, self.builder)
+                not _is_triton_value(non_constexpr_value) and \
+                not isinstance(non_constexpr_value, native_nontensor_types):
+                value = semantic.to_tensor(non_constexpr_value, self.builder)
             return value
 
         values = _sanitize_value(self.visit(node.value))


### PR DESCRIPTION
Allow `TENSOR_SHAPE = tensor.shape`.

Previously, if you did this, the `_sanitize_value` logic would convert the shape from `tuple[constexpr[int], ...]` to `tuple[tl.tensor, ...]`. This changes the `_sanitize_value` logic to accept ints, floats, and bools as "native" triton types.

(Use case: found this when writing https://github.com/pytorch/pytorch/pull/148769 - I wanted to assign `BLOCK_SHAPE = values.shape` and then reuse `BLOCK_SHAPE`, but ran into this issue)