### PR TITLE
Annotations for elementary dtypes and pointers

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -444,7 +444,7 @@ type_canonicalisation_dict = {
     "bool": "u1",
     "int1": "u1",
     "uint1": "u1",
-    "i1" : "u1",
+    "i1": "u1",
     # floating-point dtypes:
     "float8e4nv": "fp8e4nv",
     "float8e5": "fp8e5",

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -224,17 +224,17 @@ def _normalize_ty(ty) -> str:
     import triton.language.core as core
     if isinstance(ty, str):
         ty = ty.strip()
+        if ty.startswith("const "):
+            ty = ty.removeprefix("const")
+            ty = _normalize_ty(ty)
+            assert ty.startswith("*")
+            return "*k" + ty[1:]
         if ty.endswith("*"):
             return "*" + _normalize_ty(ty[:-1])
         if ty.startswith("*"):
             return "*" + _normalize_ty(ty[1:])
         if ty.startswith("tl."):
             return _normalize_ty(ty.removeprefix("tl."))
-        if ty.startswith("const "):
-            ty = ty.removeprefix("const")
-            ty = _normalize_ty(ty)
-            assert ty.startswith("*")
-            return "*k" + ty[1:]
     elif isinstance(ty, type):
         ty = ty.__name__
     elif isinstance(ty, core.dtype):

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -402,7 +402,7 @@ def create_function_from_signature(sig, kparams, backend):
             ret = f"specialize_impl({name}, {is_const}, {specialize}, {align})"
             if kp.annotation_type:
                 if isinstance(kp.annotation_type, str):
-                    if kp.annotation_type[:2] in ["fp", "bf", "i1", "u1"]:
+                    if kp.annotation_type == "i1" or kp.annotation_type[:2] in ["fp", "bf"]:
                         # we do not specialize non-constexpr floats and bools:
                         specialize = False
                 if specialize:

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -242,7 +242,7 @@ def _normalize_ty(ty) -> str:
         return f"*{_normalize_ty(ty.element_ty)}"
     else:
         ty = str(ty)
-    return type_canonicalization_dict.get(ty, ty)
+    return type_canonicalisation_dict.get(ty, ty)
 
 
 class KernelParam:
@@ -272,7 +272,7 @@ class KernelParam:
             a = a[2:]
         elif a.startswith("*"):
             a = a[1:]
-        if a in set(type_canonicalization_dict.values()):
+        if a in set(type_canonicalisation_dict.values()):
             return self.annotation
         return ""
 

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -221,6 +221,7 @@ class DependenciesFinder(ast.NodeVisitor):
 
 
 def _normalize_ty(ty) -> str:
+    import triton.language.core as core
     if isinstance(ty, str):
         ty = ty.strip()
         if ty.endswith("*"):

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -235,12 +235,12 @@ def _normalize_ty(ty) -> str:
             return "*" + _normalize_ty(ty[1:])
         if ty.startswith("tl."):
             return _normalize_ty(ty.removeprefix("tl."))
-    elif isinstance(ty, type):
-        ty = ty.__name__
-    elif isinstance(ty, core.dtype):
-        ty = ty.name
     elif isinstance(ty, core.pointer_type):
         return f"*{_normalize_ty(ty.element_ty)}"
+    elif isinstance(ty, core.dtype):
+        ty = ty.name
+    elif isinstance(ty, type):
+        ty = ty.__name__
     else:
         ty = str(ty)
     return type_canonicalisation_dict.get(ty, ty)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -243,7 +243,7 @@ def _normalize_ty(ty) -> str:
         ty = ty.__name__
     else:
         ty = str(ty)
-    return type_canonicalisation_dict.get(ty, ty)
+    return type_canonicalisation_dict.get(ty.replace("_t", ""), ty)
 
 
 class KernelParam:
@@ -455,13 +455,17 @@ type_canonicalisation_dict = {
     "float8_e5m2": "fp8e5",
     "float8e5b16": "fp8e5b16",
     "float8_e5m2fnuz": "fp8e5b16",
+    "half": "fp16",
     "float16": "fp16",
     "bfloat16": "bf16",
+    "float": "fp32",
     "float32": "fp32",
+    "double": "fp64",
     "float64": "fp64",
     # signed integers:
     "int8": "i8",
     "int16": "i16",
+    "int": "i32",
     "int32": "i32",
     "int64": "i64",
     # unsigned integers:

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -309,7 +309,7 @@ def create_specialize_impl(specialize_extra):
         if arg is None:
             return ("constexpr", None)
         elif isinstance(arg, bool):
-            return ("i1", None)
+            return ("u1", None)
         elif isinstance(arg, int):
             key = specialize_extra(arg, "int", align=align) if specialize_value else None
             if arg == 1 and specialize_value:
@@ -402,7 +402,7 @@ def create_function_from_signature(sig, kparams, backend):
             ret = f"specialize_impl({name}, {is_const}, {specialize}, {align})"
             if kp.annotation_type:
                 if isinstance(kp.annotation_type, str):
-                    if kp.annotation_type == "i1" or kp.annotation_type[:2] in ["fp", "bf"]:
+                    if kp.annotation_type == "u1" or kp.annotation_type[:2] in ["fp", "bf"]:
                         # we do not specialize non-constexpr floats and bools:
                         specialize = False
                 if specialize:
@@ -440,7 +440,12 @@ def dynamic_func({", ".join(list(map(arg, sig.parameters.items())) + ["**options
 
 
 type_canonicalisation_dict = {
-    "bool": "i1",
+    # we canonicalise all bools to be unsigned:
+    "bool": "u1",
+    "int1": "u1",
+    "uint1": "u1",
+    "i1" : "u1",
+    # floating-point dtypes:
     "float8e4nv": "fp8e4nv",
     "float8e5": "fp8e5",
     "float8e4b15": "fp8e4b15",
@@ -454,10 +459,12 @@ type_canonicalisation_dict = {
     "bfloat16": "bf16",
     "float32": "fp32",
     "float64": "fp64",
+    # signed integers:
     "int8": "i8",
     "int16": "i16",
     "int32": "i32",
     "int64": "i64",
+    # unsigned integers:
     "uint8": "u8",
     "uint16": "u16",
     "uint32": "u32",

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -282,7 +282,9 @@ class KernelParam:
 
     @cached_property
     def is_const(self):
-        return "const" in self.annotation and not self.is_constexpr
+        if self.is_constexpr:
+            return False
+        return "const" in self.annotation or self.annotation.startswith("*k")
 
     @property
     def default(self):


### PR DESCRIPTION
This introduces thorough support for annotations of elementary dtypes and pointers. Annotated kernel arguments can under certain circumstances skip `specialize_impl` leading to faster launch times. This is inspired by the patch provided by @saagarjha in the comments in https://github.com/triton-lang/triton/issues/6064 but we go further by doing the logic statically -- when constructing `dynamic_func` -- rather than at runtime.

We also take this opportunity to do some general code simplification and cleanup, including consistently using "u1" rather than "i1" to denote booleans in the specialisation key.