### PR TITLE
Update kernel name to include the constexprs names and vals

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -522,6 +522,19 @@ class JITFunction(KernelInterface[T]):
         binder = create_function_from_signature(self.signature, self.params, backend)
         return {}, target, backend, binder
 
+    def _update_fn_name(self, constexpr_params):
+        for key, val in constexpr_params.items():
+            strkey = str(key)
+            strval = str(val)
+            spchars = re.compile("[-@!#$%^&*()<>?/|\\{}~:.]")
+
+            if spchars.search(strkey):
+                raise ValueError(f"constrexpr param {strkey} has a special character")
+            if spchars.search(strval):
+                raise ValueError(f"constrexpr param {strval} has a special character")
+
+            self._fn_name += "_" + strkey + "_" + strval
+
     def run(self, *args, grid, warmup, **kwargs):
         kwargs["debug"] = kwargs.get("debug", self.debug) or os.environ.get("TRITON_DEBUG", "0") == "1"
 
@@ -558,6 +571,13 @@ class JITFunction(KernelInterface[T]):
             # constexprs
             constexprs = find_paths_if(sigvals, lambda _, val: val == "constexpr")
             constexprs = {path: get_iterable_path(list(bound_args.values()), path) for path in constexprs}
+            constexpr_params = {
+                p.name: v
+                for (v, p) in zip(tuple(bound_args.values()), self.params)
+                if p.is_constexpr
+            }
+            _fn_orig_name = self._fn_name
+            self._update_fn_name(constexpr_params)
             # attributes
             attrvals = [x[1] for x in specialization]
             attrs = find_paths_if(attrvals, lambda _, x: isinstance(x, str))
@@ -569,6 +589,7 @@ class JITFunction(KernelInterface[T]):
             kernel = self.compile(src, target=target, options=options.__dict__)
             kernel_cache[key] = kernel
             self._call_hook(key, signature, device, constexprs, options, [attrs], warmup, before=False)
+            self._fn_name = _fn_orig_name
 
         # Check that used global values have not changed.
         not_present = object()

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -571,11 +571,7 @@ class JITFunction(KernelInterface[T]):
             # constexprs
             constexprs = find_paths_if(sigvals, lambda _, val: val == "constexpr")
             constexprs = {path: get_iterable_path(list(bound_args.values()), path) for path in constexprs}
-            constexpr_params = {
-                p.name: v
-                for (v, p) in zip(tuple(bound_args.values()), self.params)
-                if p.is_constexpr
-            }
+            constexpr_params = {p.name: v for (v, p) in zip(tuple(bound_args.values()), self.params) if p.is_constexpr}
             _fn_orig_name = self._fn_name
             self._update_fn_name(constexpr_params)
             # attributes


### PR DESCRIPTION
When using autotune configs, which allow varying constexpr params during a single run, the kernel keeps getting replaced since the name remains the same. This way the kernels will have different names each time we use a varying constexpr param.

For example, running python/tutorials/06-fused-attention.py will generate these kernels:
```
_attn_bwd
_attn_bwd_preprocess
_attn_fwd
```

But these have updating constexpr vals (using autotune) during the run which updates the kernels, but the kernel keeps getting replaced since the kernel name remains the same. Using this change, the kernel names can be captured in the following way:
```
_attn_bwd_BLOCK_M1_32_BLOCK_N1_128_BLOCK_M2_128_BLOCK_N2_32_BLK_SLICE_FACTOR_2_HEAD_DIM_64
_attn_bwd_preprocess_BLOCK_M_128_HEAD_DIM_64
_attn_fwd_HEAD_DIM_64_BLOCK_M_128_BLOCK_N_32_STAGE_3
_attn_fwd_HEAD_DIM_64_BLOCK_M_128_BLOCK_N_64_STAGE_3
_attn_fwd_HEAD_DIM_64_BLOCK_M_64_BLOCK_N_32_STAGE_3
_attn_fwd_HEAD_DIM_64_BLOCK_M_64_BLOCK_N_64_STAGE_3
```

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
