### PR TITLE
[LAYOUTS] Cache LinearEncoding creation

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -55,9 +55,9 @@ std::optional<int> maybeLookupNumWarps(Operation *op);
 // Utility to find the number of threads per warp
 int lookupThreadsPerWarp(OpBuilder &rewriter);
 
-class LinearLayoutCache {
+template <typename Key, typename Value> class Cache {
 public:
-  std::optional<LinearLayout> get(const CacheKey &key) {
+  std::optional<Value> get(const Key &key) {
     std::shared_lock lock(mutex);
     auto it = cache.find(key);
     if (it != cache.end()) {
@@ -66,15 +66,18 @@ public:
     return std::nullopt;
   }
 
-  void set(CacheKey key, LinearLayout result) {
+  void set(Key key, Value result) {
     std::scoped_lock lock(mutex);
     cache.emplace(std::move(key), std::move(result));
   }
 
 private:
-  std::unordered_map<CacheKey, LinearLayout> cache;
+  std::unordered_map<Key, Value> cache;
   llvm::sys::SmartRWMutex<true> mutex;
 };
+
+using LinearLayoutCache = Cache<CacheKey, LinearLayout>;
+using LinearEncodingCache = Cache<CacheKey, LinearEncodingAttr>;
 } // namespace mlir::triton::gpu
 
 #define GET_OP_CLASSES

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
@@ -23,12 +23,14 @@ def TritonGPU_Dialect : Dialect {
     void registerTypes();
 
     LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout);
+    LinearEncodingAttr toLinearEncoding(ArrayRef<int64_t> shape, Attribute layout);
 
     static int getNumCTAs(ModuleOp mod);
     static int getThreadsPerWarp(ModuleOp mod);
 
     private:
       LinearLayoutCache llCache;
+      LinearEncodingCache leCache;
   }];
 
   let useDefaultTypePrinterParser = 1;


### PR DESCRIPTION
Linear Encodings are going to be queried a ton. Now, we would now want
to copy a LinearLayout from the LL cache and create a new LinearEncoding
each time we want to query the number of elements or warps. As such, we
cache them.
