### PR TITLE
Fixed `grid` Lambda Function in `LayerNorm` and type anotation of `broadcast_impl_shape` and  `get_block_shapes`

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -660,7 +660,7 @@ class block_type(dtype):
     def is_block(self):
         return True
 
-    def get_block_shapes(self) -> List[int]:
+    def get_block_shapes(self) -> Tuple[int]:
         return self.shape
 
     def __eq__(self, other) -> bool:

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -733,7 +733,7 @@ def permute(input: tl.tensor, dims: Tuple[int], builder: ir.builder) -> tl.tenso
     return tl.tensor(builder.create_trans(input.handle, dims), ret_type)
 
 
-def broadcast_impl_shape(input: tl.tensor, shape: List[int], builder: ir.builder) -> tl.tensor:
+def broadcast_impl_shape(input: tl.tensor, shape: Tuple[int], builder: ir.builder) -> tl.tensor:
     if not input.type.is_block():
         ret_ty = tl.block_type(input.type, shape)
         return tl.tensor(builder.create_splat(input.handle, shape), ret_ty)

--- a/python/tutorials/05-layer-norm.py
+++ b/python/tutorials/05-layer-norm.py
@@ -280,7 +280,7 @@ class LayerNorm(torch.autograd.Function):
             BLOCK_SIZE_N=ctx.BLOCK_SIZE,  #
             GROUP_SIZE_M=GROUP_SIZE_M,  #
             num_warps=ctx.num_warps)
-        grid = lambda meta: (triton.cdiv(N, meta['BLOCK_SIZE_N']),)
+        grid = lambda meta: (triton.cdiv(N, meta['BLOCK_SIZE_N']), )
         # accumulate partial sums in separate kernel
         _layer_norm_bwd_dwdb[grid](
             _dw, _db, dw, db, min(GROUP_SIZE_M, M), N,  #

--- a/python/tutorials/05-layer-norm.py
+++ b/python/tutorials/05-layer-norm.py
@@ -280,7 +280,7 @@ class LayerNorm(torch.autograd.Function):
             BLOCK_SIZE_N=ctx.BLOCK_SIZE,  #
             GROUP_SIZE_M=GROUP_SIZE_M,  #
             num_warps=ctx.num_warps)
-        grid = lambda meta: [triton.cdiv(N, meta['BLOCK_SIZE_N'])]
+        grid = lambda meta: (triton.cdiv(N, meta['BLOCK_SIZE_N']))
         # accumulate partial sums in separate kernel
         _layer_norm_bwd_dwdb[grid](
             _dw, _db, dw, db, min(GROUP_SIZE_M, M), N,  #

--- a/python/tutorials/05-layer-norm.py
+++ b/python/tutorials/05-layer-norm.py
@@ -280,7 +280,7 @@ class LayerNorm(torch.autograd.Function):
             BLOCK_SIZE_N=ctx.BLOCK_SIZE,  #
             GROUP_SIZE_M=GROUP_SIZE_M,  #
             num_warps=ctx.num_warps)
-        grid = lambda meta: (triton.cdiv(N, meta['BLOCK_SIZE_N']))
+        grid = lambda meta: (triton.cdiv(N, meta['BLOCK_SIZE_N']),)
         # accumulate partial sums in separate kernel
         _layer_norm_bwd_dwdb[grid](
             _dw, _db, dw, db, min(GROUP_SIZE_M, M), N,  #


### PR DESCRIPTION
## Changes
1. ​**Fixed `grid` Lambda Function in `LayerNorm`:**
   - Modified the `grid` lambda function in the `LayerNorm` class to return a tuple instead of a list to comply with interpreter requirements.

2. ​**Updated Type Annotations:**
   - Changed input type annotation of `broadcast_impl_shape` from `List[int]` to `Tuple[int]`.
   - Updated return type annotation of `get_block_shapes` from `List[int]` to `Tuple[int]`.

## Context
- The interpreter in `interpter.py` requires the `grid` lambda function to return a tuple, and lists were causing errors.
- The type annotations were updated to better reflect the actual types used in the code.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
- [x] This PR does not need a test because the changes are purely related to type annotations and a minor lambda function fix, which do not affect runtime behavior or logic. The modifications have been manually verified to ensure they align with the interpreter's requirements.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
