### PR TITLE
[AMD] fix and refactoring `fastPathComputeOffsets` in the AMDGPU backend 

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -394,12 +394,6 @@ public:
                               allocStrides.end());
   }
 
-  // TODO(Keren): deprecate the method once AMD backend has cleaned up
-  Value getCSwizzleOffset(int dim) const {
-    assert(dim >= 0 && dim < offsets.size());
-    return offsets[dim];
-  }
-
 private:
   static SmallVector<unsigned>
   getOrderForShape(ArrayRef<int64_t> shape, ArrayRef<unsigned> layoutOrder) {

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -400,16 +400,6 @@ public:
     return offsets[dim];
   }
 
-  // TODO(Keren): deprecate the method once AMD backend has cleaned up
-  Value getBaseBeforeSlice(int dim, Location loc,
-                           RewriterBase &rewriter) const {
-    auto b = TritonLLVMOpBuilder(loc, rewriter);
-    Value cSwizzleOffset = getCSwizzleOffset(dim);
-    Value offset = b.sub(b.i32_val(0), cSwizzleOffset);
-    Type type = base.getType();
-    return b.gep(type, baseElemType, base, offset);
-  }
-
 private:
   static SmallVector<unsigned>
   getOrderForShape(ArrayRef<int64_t> shape, ArrayRef<unsigned> layoutOrder) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.cpp
@@ -177,17 +177,6 @@ llvm::SmallVector<Value> computeOffsetsAType(
   return aOffsets;
 }
 
-template <typename Container>
-static SmallVector<typename Container::value_type>
-transposeSpatialDims(const Container &vec) {
-  auto rank = vec.size();
-  assert(rank == 2 || rank == 3);
-  SmallVector<typename Container::value_type> res(rank, vec[0]);
-  res[rank - 2] = vec[rank - 1];
-  res[rank - 1] = vec[rank - 2];
-  return res;
-}
-
 llvm::SmallVector<Value> computeOffsetsBType(
     ConversionPatternRewriter &rewriter, Location loc,
     computeTensorElemMappingInBlockT fn, const ArrayRef<int64_t> &elemsPerInstr,
@@ -202,9 +191,10 @@ llvm::SmallVector<Value> computeOffsetsBType(
   auto rank = smemObj.getOffsets().size();
   auto order = srcLayout.getOrder();
   SmallVector<int64_t> tElemsPerInstr{elemsPerInstr[1], elemsPerInstr[0]};
-  SmallVector<int64_t> tReps = transposeSpatialDims(reps);
-  SmallVector<Value> tOffsets = transposeSpatialDims(smemObj.getOffsets());
-  SmallVector<Value> tStrides = transposeSpatialDims(smemStrides);
+  SmallVector<int64_t> tReps = AMD::helper::transposeSpatialDims(reps);
+  SmallVector<Value> tOffsets =
+      AMD::helper::transposeSpatialDims(smemObj.getOffsets());
+  SmallVector<Value> tStrides = AMD::helper::transposeSpatialDims(smemStrides);
 
   int vectorSize = 1;
   if (order[0] == rank - 2) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
@@ -59,6 +59,18 @@ llvm::SmallVector<Value> computeOffsetsBType(
     ArrayRef<int64_t> reps, SharedMemoryObject smemObj, ArrayRef<Value> strides,
     gpu::SwizzledSharedEncodingAttr srcLayout, unsigned nonKDim, unsigned kDim);
 
+namespace helper {
+template <typename Container>
+static SmallVector<typename Container::value_type>
+transposeSpatialDims(const Container &vec) {
+  auto rank = vec.size();
+  assert(rank == 2 || rank == 3);
+  SmallVector<typename Container::value_type> res(rank, vec[0]);
+  res[rank - 2] = vec[rank - 1];
+  res[rank - 1] = vec[rank - 2];
+  return res;
+}
+} // namespace helper
 } // namespace mlir::triton::AMD
 
 #endif // TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUTOLLVM_CONVERTLAYOUTOPTOLLVM_SHAREDTODOTOPERANDHELPER_H_


### PR DESCRIPTION
This PR fixes SMEM/LDS address calculation in the AMDGPU backend. The previous implementation didn't take into account `smem` offsets and `strides` in  `fastPathComputeOffsets`. Everything used to work because `ttg.local_load` was handling the entire tensor tile. However, we found an issue when `memdesc_subview` was applied to another `memdesc_subview` with an offset (with disabled swizzling in LDS). The PR fixes the issue and also cleans the implementation (e.g., reuse of `computeTensorElemMappingInBlock`).

The new implementation was tested with GEMM and FA kernels (including the `refine-ops-pass` and `reschedule-ops-pass` which are still under development in the AMD's fork of Triton).

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because because current tests cover the introduced changes

- Select one of the following.
  - [x] I have not added any `lit` tests.
  