### PR TITLE
[Blackwell] Relax the condition to pipeline tc_gen5_mma_scaled

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TC05MMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TC05MMAPipeline.cpp
@@ -575,15 +575,22 @@ bool isSafeToPipeline(ttng::TCGen5MMAScaledOp scaledDot, scf::ForOp forOp) {
   // when its scales in TMEM are stored by the TMEMCopy op (tcgen05.cp).
   // That condition is equivalent to scale arguments of
   // ttng::TCGen5MMAScaledOp being in SMEM during SWP in our convention.
-  auto isCopiedByTMEMCopy = [&](Value scale) {
+  auto isInvariantOrCopiedByTMEMCopy = [&](Value scale) {
+    if (forOp.isDefinedOutsideOfLoop(scale))
+      return true;
+    if (auto tmemAlloc = scale.getDefiningOp<ttng::TMEMAllocOp>()) {
+      Value tmemAllocSrc = tmemAlloc.getSrc();
+      if (tmemAllocSrc && forOp.isDefinedOutsideOfLoop(tmemAllocSrc))
+        return true;
+    }
     auto scaleAlloc = findShmemAlloc(scale);
     if (!scaleAlloc || !forOp.isDefinedOutsideOfLoop(scaleAlloc))
       return false;
     return true;
   };
 
-  return isCopiedByTMEMCopy(scaledDot.getAScale()) &&
-         isCopiedByTMEMCopy(scaledDot.getBScale());
+  return isInvariantOrCopiedByTMEMCopy(scaledDot.getAScale()) &&
+         isInvariantOrCopiedByTMEMCopy(scaledDot.getBScale());
 }
 
 // Find MMAs eligible for pipelining and lower them by:

--- a/test/TritonGPU/mma-pipeline-blackwell.mlir
+++ b/test/TritonGPU/mma-pipeline-blackwell.mlir
@@ -5,10 +5,12 @@
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked3 =  #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 #tmem1 = #ttng.tensor_memory_scales_encoding<>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LOWER-LABEL: @chained_dot_no_multibuf_acc
@@ -958,6 +960,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    %cst_1 = arith.constant dense<127> : tensor<128x4xi8, #blocked4>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<2x128x128xf16, #shared, #ttg.shared_memory, mutable>
     %2 = ttg.local_alloc : () -> !ttg.memdesc<2x128x128xf16, #shared, #ttg.shared_memory, mutable>
     %scale_A_SMEM = ttg.local_alloc : () -> !ttg.memdesc<2x1x512xi8, #shared1, #ttg.shared_memory, mutable>
@@ -992,8 +995,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %22 = ttg.memdesc_subview %2[%19, %c0_i32, %c0_i32] : !ttg.memdesc<2x128x128xf16, #shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>
 
       %tmem = ttng.tmem_alloc %acc : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-
-      ttng.tc_gen5_mma_scaled %20, %22, %tmem, %arg8, %arg9, %true, %true lhs = e5m2 rhs = e5m2: (!ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x512xi8, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<1x512xi8, #shared1, #ttg.shared_memory, mutable>, i1, i1) -> ()
+      %cst_scale = ttng.tmem_alloc %cst_1 : (tensor<128x4xi8, #blocked4>) -> !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>
+      ttng.tc_gen5_mma_scaled %20, %22, %tmem, %arg8, %cst_scale, %true, %true lhs = e5m2 rhs = e5m2: (!ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x512xi8, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>, i1, i1) -> ()
       %acc_res = ttng.tmem_load %tmem : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
       %23 = arith.addi %arg4, %c1_i32 : i32
       %24 = arith.cmpi slt, %23, %c2_i32 : i32


### PR DESCRIPTION
When the scales are from tmem they can still be pipelined as long as the scales are invariant.
