### PR TITLE
Revert "[LAYOUTS] Move order to LinearEncoding implementation (#6181)"

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -137,44 +137,17 @@ getWarpsPerCTAWithUniqueData(Attribute layout, ArrayRef<int64_t> tensorShape);
 // is contiguous in shared memory.
 SmallVector<unsigned> getOrder(DistributedEncodingTrait layout,
                                ArrayRef<int64_t> shape);
-inline SmallVector<unsigned> getOrder(RankedTensorType type) {
-  return getOrder(cast<DistributedEncodingTrait>(type.getEncoding()),
-                  type.getShape());
-}
+SmallVector<unsigned> getOrder(RankedTensorType type);
 
 SmallVector<unsigned> getOrder(SharedEncodingTrait layout,
                                ArrayRef<int64_t> shape);
-inline SmallVector<unsigned> getOrder(MemDescType type) {
-  return getOrder(cast<SharedEncodingTrait>(type.getEncoding()),
-                  type.getShape());
-}
-inline SmallVector<unsigned> getOrder(TensorOrMemDesc type) {
-  if (auto memDesc = dyn_cast<MemDescType>(type)) {
-    return getOrder(memDesc);
-  } else {
-    auto tensorTy = cast<RankedTensorType>(type);
-    return getOrder(tensorTy);
-  }
-}
+SmallVector<unsigned> getOrder(MemDescType type);
+SmallVector<unsigned> getOrder(TensorOrMemDesc type);
 
-// To be removed once we implement arbitrary swizzled layouts
-// It chooses heuristically an order for the memory layout in which to save
-// a distributed layout taking into account the order of the elements
-// and the threads.
-SmallVector<unsigned> getOrderForMemory(DistributedEncodingTrait layout,
-                                        ArrayRef<int64_t> shape);
-inline SmallVector<unsigned> getOrderForMemory(RankedTensorType type) {
-  return getOrderForMemory(cast<DistributedEncodingTrait>(type.getEncoding()),
-                           type.getShape());
-}
-inline SmallVector<unsigned> getOrderForMemory(TensorOrMemDesc type) {
-  if (auto memDesc = dyn_cast<MemDescType>(type)) {
-    return getOrder(memDesc);
-  } else {
-    auto tensorTy = cast<RankedTensorType>(type);
-    return getOrderForMemory(tensorTy);
-  }
-}
+// Order of the elements in the shared memory as defined at layout creation
+// If this layout is associated with a MemDesc with a different shape
+// it may return a different order than the actual order of the elements
+SmallVector<unsigned> getDefaultOrder(SharedEncodingTrait layout);
 
 // Returns the dimensions along which warpId's are distributed.
 // warpsPerCTA only tells the warp layout in the CTA, e.g. warpsPerCTA = [2, 4]
@@ -185,20 +158,14 @@ inline SmallVector<unsigned> getOrderForMemory(TensorOrMemDesc type) {
 // [warp1  warp3  warp5 warp7]
 SmallVector<unsigned> getWarpOrder(DistributedEncodingTrait layout,
                                    ArrayRef<int64_t> shape);
-inline SmallVector<unsigned> getWarpOrder(RankedTensorType type) {
-  return getWarpOrder(cast<DistributedEncodingTrait>(type.getEncoding()),
-                      type.getShape());
-}
+SmallVector<unsigned> getWarpOrder(RankedTensorType type);
 
 // Returns the dimensions along which threadId's are distributed.
 // Similar to warpOrder, threadOrder is necessary to tell the specific thread
 // distribution in the warp.
 SmallVector<unsigned> getThreadOrder(DistributedEncodingTrait layout,
                                      ArrayRef<int64_t> shape);
-inline SmallVector<unsigned> getThreadOrder(RankedTensorType type) {
-  return getThreadOrder(cast<DistributedEncodingTrait>(type.getEncoding()),
-                        type.getShape());
-}
+SmallVector<unsigned> getThreadOrder(RankedTensorType type);
 
 CTALayoutAttr getCTALayout(Attribute layout);
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -606,6 +606,21 @@ We call each individual tile "rep".
                     "LinearLayout",
                     "toLinearLayout",
                     (ins "ArrayRef<int64_t>":$shape)>,
+
+    // Legacy methods: They do not take into account the shape of the tensor
+    // that is, the fact that we use them to tile the tensor.
+    InterfaceMethod<"Get the default order of the registers per warp. The fastest-changing axis first",
+                    "SmallVector<unsigned>",
+                    "getDefaultOrder">,
+
+    InterfaceMethod<"Get the default order of the threads per warp. The fastest-changing axis first",
+                    "SmallVector<unsigned>",
+                    "getDefaultThreadOrder">,
+
+    InterfaceMethod<"Get the default order of the warps per CTA. The fastest-changing axis first",
+                    "SmallVector<unsigned>",
+                    "getDefaultWarpOrder">
+
   ];
 }
 
@@ -647,7 +662,6 @@ L(T) = [ {0,8} , {1,9} , {2,10}, {3,11}, {0,8} , {1, 9} , {2, 10}, {3, 11},
   }];
 
   code extraDistributedDeclaration  = extraBaseClassDeclaration # [{
-    unsigned getRank() const { return getCTAOrder().size(); }
     // Implemented in subclasses
     SmallVector<unsigned> getRepOrder() const;
     SmallVector<unsigned> getCTAsPerCGA() const;
@@ -656,6 +670,11 @@ L(T) = [ {0,8} , {1,9} , {2,10}, {3,11}, {0,8} , {1, 9} , {2, 10}, {3, 11},
     SmallVector<unsigned> getWarpsPerCTA() const;
 
     LinearLayout toLinearLayout(ArrayRef<int64_t> shape) const;
+
+    // Legacy methods: They do not take into account the shape of the tensor
+    SmallVector<unsigned> getDefaultWarpOrder() const;
+    SmallVector<unsigned> getDefaultThreadOrder() const;
+    SmallVector<unsigned> getDefaultOrder() const;
   }];
 }
 

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -121,7 +121,7 @@ ScratchConfig getScratchConfigForCvt(RankedTensorType srcTy,
   Attribute dstLayout = dstTy.getEncoding();
 
   assert(cvtNeedsSharedMemory(srcTy, dstTy));
-  auto outOrd = gpu::getOrder(dstTy);
+  auto outOrd = gpu::toLinearEncoding(dstLayout, dstTy.getShape()).getOrder();
   scratchConfig.order = outOrd;
 
   std::tie(scratchConfig.inVec, scratchConfig.outVec) =

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -198,39 +198,61 @@ SmallVector<unsigned> getOrder(SharedEncodingTrait layout,
   return {};
 }
 
+// Convenience functions
+SmallVector<unsigned> getOrder(TensorOrMemDesc type) {
+  if (auto memDesc = dyn_cast<MemDescType>(type)) {
+    return getOrder(memDesc);
+  } else {
+    auto tensorTy = cast<RankedTensorType>(type);
+    return getOrder(tensorTy);
+  }
+}
+
+SmallVector<unsigned> getOrder(MemDescType type) {
+  return getOrder(cast<SharedEncodingTrait>(type.getEncoding()),
+                  type.getShape());
+}
+
+// Legacy impl for now
 SmallVector<unsigned> getOrder(DistributedEncodingTrait layout,
                                ArrayRef<int64_t> shape) {
-  return toLinearEncoding(layout, shape).getOrder();
+  return layout.getDefaultOrder();
 }
 
-SmallVector<unsigned> getOrderForMemory(DistributedEncodingTrait layout,
-                                        ArrayRef<int64_t> shape) {
-  auto linear = toLinearEncoding(layout, shape);
-  auto order = linear.getOrder();
-  auto threadOrder = linear.getThreadOrder();
-  if (order == threadOrder) {
-    return order;
-  }
-  // Heuristic:
-  // If the element contiguity does not align with the thread order
-  // because the thread order dimension has contiguity of 1---meaning that
-  // the order position of this dimension is irrelevant---we prefer
-  // to use the thread order for the memory layout
-  auto contig = linear.getElemsPerThread(shape);
-  if (contig[threadOrder[0]] == 1) {
-    return threadOrder;
-  }
-  return order;
+// Convenience function
+SmallVector<unsigned> getOrder(RankedTensorType type) {
+  return getOrder(cast<DistributedEncodingTrait>(type.getEncoding()),
+                  type.getShape());
 }
 
+SmallVector<unsigned> getDefaultMmaOrder(MmaEncodingTrait layout) {
+  auto distributedLayout = cast<DistributedEncodingTrait>(layout);
+  auto rank = distributedLayout.getWarpsPerCTA().size();
+  return getMatrixOrder(rank, /*rowMajor*/ true);
+}
+
+// Legacy impl for now
 SmallVector<unsigned> getThreadOrder(DistributedEncodingTrait layout,
                                      ArrayRef<int64_t> shape) {
-  return toLinearEncoding(layout, shape).getThreadOrder();
+  return layout.getDefaultThreadOrder();
 }
 
+// Convenience function
+SmallVector<unsigned> getThreadOrder(RankedTensorType type) {
+  return getThreadOrder(cast<DistributedEncodingTrait>(type.getEncoding()),
+                        type.getShape());
+}
+
+// Legacy impl for now
 SmallVector<unsigned> getWarpOrder(DistributedEncodingTrait layout,
                                    ArrayRef<int64_t> shape) {
-  return toLinearEncoding(layout, shape).getWarpOrder();
+  return layout.getDefaultWarpOrder();
+}
+
+// Convenience function
+SmallVector<unsigned> getWarpOrder(RankedTensorType type) {
+  return getWarpOrder(cast<DistributedEncodingTrait>(type.getEncoding()),
+                      type.getShape());
 }
 
 CTALayoutAttr getCTALayout(Attribute layout) {
@@ -567,7 +589,7 @@ static void maybePrintCTALayout(mlir::MLIRContext *context,
 // But we need to have a consistent interface with e.g. SliceEncodingAttr, which
 // computes some of these fields.
 SmallVector<unsigned> BlockedEncodingAttr::getRepOrder() const {
-  return SmallVector<unsigned>(getOrder());
+  return SmallVector<unsigned>(getDefaultOrder());
 }
 SmallVector<unsigned> BlockedEncodingAttr::getCTAsPerCGA() const {
   return SmallVector<unsigned>(getCTALayout().getCTAsPerCGA());
@@ -578,8 +600,17 @@ SmallVector<unsigned> BlockedEncodingAttr::getCTAOrder() const {
 SmallVector<unsigned> BlockedEncodingAttr::getCTASplitNum() const {
   return SmallVector<unsigned>(getCTALayout().getCTASplitNum());
 }
+SmallVector<unsigned> BlockedEncodingAttr::getDefaultOrder() const {
+  return SmallVector<unsigned>(getOrder());
+}
 SmallVector<unsigned> BlockedEncodingAttr::getWarpsPerCTA() const {
   return SmallVector<unsigned>(getWarpsPerCTA__());
+}
+SmallVector<unsigned> BlockedEncodingAttr::getDefaultWarpOrder() const {
+  return SmallVector<unsigned>(getDefaultOrder());
+}
+SmallVector<unsigned> BlockedEncodingAttr::getDefaultThreadOrder() const {
+  return SmallVector<unsigned>(getDefaultOrder());
 }
 
 template <class T>
@@ -646,6 +677,26 @@ SmallVector<unsigned> SliceEncodingAttr::getWarpsPerCTA() const {
   warpsPerCTA[nextDim] *= parentWarpsPerCTA[getDim()];
   return warpsPerCTA;
 }
+SmallVector<unsigned> SliceEncodingAttr::getDefaultWarpOrder() const {
+  auto parentWarpOrder = getParent().getDefaultWarpOrder();
+  return eraseOrder(parentWarpOrder, getDim());
+}
+SmallVector<unsigned> SliceEncodingAttr::getDefaultThreadOrder() const {
+  auto parentThreadOrder = getParent().getDefaultThreadOrder();
+  return eraseOrder(parentThreadOrder, getDim());
+}
+SmallVector<unsigned> SliceEncodingAttr::getDefaultOrder() const {
+  SmallVector<unsigned> parentOrder = getParent().getDefaultOrder();
+  unsigned dim = getDim();
+  SmallVector<unsigned> order;
+  for (unsigned d : parentOrder) {
+    if (d != dim)
+      order.push_back(d > dim ? d - 1 : d);
+  }
+  return order;
+}
+
+//
 
 // Wmma encoding
 
@@ -708,6 +759,24 @@ SmallVector<unsigned> DotOperandEncodingAttr::getWarpsPerCTA() const {
   auto kDim = getOpIdx() == 0 ? rank - 1 : rank - 2;
   warps[kDim] = 1;
   return warps;
+}
+SmallVector<unsigned> DotOperandEncodingAttr::getDefaultOrder() const {
+  auto rank = getWarpsPerCTA().size();
+  return getOrderForDotOperand(getOpIdx(), rank, /*kContig*/ true);
+}
+SmallVector<unsigned> DotOperandEncodingAttr::getDefaultWarpOrder() const {
+  // FIXME(Lezcano): Preexisting. Do we want to have this path at all?
+  if (mlir::isa<AMDMfmaEncodingAttr, AMDWmmaEncodingAttr>(getParent())) {
+    return mlir::cast<DistributedEncodingTrait>(getParent())
+        .getDefaultWarpOrder();
+  }
+  llvm::report_fatal_error(
+      "DotOperandEncoding::getDefaultWarpOrder not implemented");
+  return {};
+}
+SmallVector<unsigned> DotOperandEncodingAttr::getDefaultThreadOrder() const {
+  return getOrderForDotOperand(getOpIdx(), getWarpsPerCTA().size(),
+                               /*kContig*/ true);
 }
 
 LogicalResult DotOperandEncodingAttr::verify(
@@ -1097,14 +1166,20 @@ SmallVector<unsigned> LinearEncodingAttr::getCTASplitNum() const {
 SmallVector<unsigned> LinearEncodingAttr::getWarpsPerCTA() const {
   return basesPerDim(StringAttr::get(getContext(), "warp"));
 }
+SmallVector<unsigned> LinearEncodingAttr::getDefaultWarpOrder() const {
+  return getWarpOrder();
+}
 SmallVector<unsigned> LinearEncodingAttr::getWarpOrder() const {
   return orderPerDim(StringAttr::get(getContext(), "warp"), getOrder());
 }
 SmallVector<unsigned> LinearEncodingAttr::getThreadsPerWarp() const {
   return basesPerDim(StringAttr::get(getContext(), "lane"));
 }
+SmallVector<unsigned> LinearEncodingAttr::getDefaultThreadOrder() const {
+  return getThreadOrder();
+}
 SmallVector<unsigned> LinearEncodingAttr::getThreadOrder() const {
-  return orderPerDim(StringAttr::get(getContext(), "lane"), getOrder());
+  return orderPerDim(StringAttr::get(getContext(), "lane"), getDefaultOrder());
 }
 SmallVector<unsigned> LinearEncodingAttr::getSizePerThread() const {
   auto rank = getOrder().size();
@@ -1154,6 +1229,10 @@ SmallVector<unsigned> LinearEncodingAttr::getShapePerCTATile() const {
     shape.push_back(size * thread * warp);
   }
   return shape;
+}
+
+SmallVector<unsigned> LinearEncodingAttr::getDefaultOrder() const {
+  return getOrder();
 }
 
 SmallVector<unsigned> LinearEncodingAttr::getOrder() const {
@@ -1724,6 +1803,18 @@ SmallVector<unsigned> AMDMfmaEncodingAttr::getCTASplitNum() const {
 SmallVector<unsigned> AMDMfmaEncodingAttr::getWarpsPerCTA() const {
   return SmallVector<unsigned>(getWarpsPerCTA__());
 }
+SmallVector<unsigned> AMDMfmaEncodingAttr::getDefaultOrder() const {
+  return getDefaultMmaOrder(*this);
+}
+SmallVector<unsigned> AMDMfmaEncodingAttr::getDefaultWarpOrder() const {
+  return getDefaultOrder();
+}
+SmallVector<unsigned> AMDMfmaEncodingAttr::getDefaultThreadOrder() const {
+  auto order = getDefaultOrder();
+  if (getIsTransposed())
+    std::swap(order[0], order[1]);
+  return order;
+}
 
 SmallVector<int64_t>
 AMDMfmaEncodingAttr::getInstrShapeForOperand(int kWidth, int opIdx) const {
@@ -1746,12 +1837,14 @@ AMDMfmaEncodingAttr::getInstrShapeForOperand(int kWidth, int opIdx) const {
 }
 
 SmallVector<unsigned> AMDMfmaEncodingAttr::getRepOrder() const {
-  return getMatrixOrder(getRank(), /*rowMajor*/ true);
+  auto rank = getDefaultOrder().size();
+  return getMatrixOrder(rank, /*rowMajor*/ true);
 }
 
 SmallVector<unsigned>
 AMDMfmaEncodingAttr::getRepOrderForOperand(int opIdx) const {
-  return getOrderForDotOperand(opIdx, getRank(), /*kContig*/ true);
+  auto rank = getDefaultOrder().size();
+  return getOrderForDotOperand(opIdx, rank, /*kContig*/ true);
 }
 
 SmallVector<int64_t>
@@ -1825,12 +1918,14 @@ SwizzledSharedEncodingAttr AMDMfmaEncodingAttr::composeSharedLayoutForOperand(
 //===----------------------------------------------------------------------===//
 
 SmallVector<unsigned> AMDWmmaEncodingAttr::getRepOrder() const {
-  return getMatrixOrder(getRank(), /*rowMajor*/ true);
+  auto rank = getWarpsPerCTA().size();
+  return getMatrixOrder(rank, /*rowMajor*/ true);
 }
 
 SmallVector<unsigned>
 AMDWmmaEncodingAttr::getRepOrderForOperand(int opIdx) const {
-  return getOrderForDotOperand(opIdx, getRank(), /*kContig*/ true);
+  auto rank = getDefaultOrder().size();
+  return getOrderForDotOperand(opIdx, rank, /*kContig*/ true);
 }
 
 SmallVector<unsigned> AMDWmmaEncodingAttr::getCTAsPerCGA() const {
@@ -1844,6 +1939,18 @@ SmallVector<unsigned> AMDWmmaEncodingAttr::getCTASplitNum() const {
 }
 SmallVector<unsigned> AMDWmmaEncodingAttr::getWarpsPerCTA() const {
   return SmallVector<unsigned>(getWarpsPerCTA__());
+}
+SmallVector<unsigned> AMDWmmaEncodingAttr::getDefaultOrder() const {
+  return getDefaultMmaOrder(*this);
+}
+SmallVector<unsigned> AMDWmmaEncodingAttr::getDefaultWarpOrder() const {
+  return getDefaultOrder();
+}
+SmallVector<unsigned> AMDWmmaEncodingAttr::getDefaultThreadOrder() const {
+  auto order = getDefaultOrder();
+  if (getIsTransposed())
+    std::swap(order[0], order[1]);
+  return order;
 }
 
 SmallVector<int64_t> AMDWmmaEncodingAttr::getElemsPerInstrForOperands() const {
@@ -1883,7 +1990,8 @@ SmallVector<unsigned> AMDWmmaEncodingAttr::getMNKDimPerInstr() {
 }
 
 unsigned AMDWmmaEncodingAttr::getKWidthForOperands() const {
-  SmallVector<unsigned> sizePerThread(getRank(), 1);
+  auto rank = getWarpsPerCTA().size();
+  SmallVector<unsigned> sizePerThread(rank, 1);
   auto numReplicated = getVersion() == 1 ? 2 : 1;
   auto elemsPerInstr =
       numReplicated * product(getElemsPerInstrForOperands()) / 32;
@@ -1905,7 +2013,8 @@ bool NvidiaMmaEncodingAttr::isAmpere() const { return getVersionMajor() == 2; }
 bool NvidiaMmaEncodingAttr::isHopper() const { return getVersionMajor() == 3; }
 
 SmallVector<unsigned> NvidiaMmaEncodingAttr::getRepOrder() const {
-  return getMatrixOrder(getRank(), /*rowMajor*/ true);
+  auto rank = getDefaultOrder().size();
+  return getMatrixOrder(rank, /*rowMajor*/ true);
 }
 SmallVector<unsigned> NvidiaMmaEncodingAttr::getCTAsPerCGA() const {
   return SmallVector<unsigned>(getCTALayout().getCTAsPerCGA());
@@ -1919,10 +2028,25 @@ SmallVector<unsigned> NvidiaMmaEncodingAttr::getCTASplitNum() const {
 SmallVector<unsigned> NvidiaMmaEncodingAttr::getWarpsPerCTA() const {
   return SmallVector<unsigned>(getWarpsPerCTA__());
 }
+SmallVector<unsigned> NvidiaMmaEncodingAttr::getDefaultOrder() const {
+  return getDefaultMmaOrder(*this);
+}
+SmallVector<unsigned> NvidiaMmaEncodingAttr::getDefaultWarpOrder() const {
+  auto rank = getDefaultOrder().size();
+  // Hopper (wgmma) uses column-major as this is embedded in the instruction
+  // For Ampere we can choose either row-major or column-major.
+  // We choose row-major as the legacy path did so
+  return getMatrixOrder(rank, /*rowMajor*/ !isHopper());
+}
+SmallVector<unsigned> NvidiaMmaEncodingAttr::getDefaultThreadOrder() const {
+  auto rank = getDefaultOrder().size();
+  return getMatrixOrder(rank, /*rowMajor*/ true);
+}
 
 SmallVector<unsigned>
 NvidiaMmaEncodingAttr::getRepOrderForOperand(int opIdx) const {
-  return getOrderForDotOperand(opIdx, getRank(), /*kContig*/ true);
+  auto rank = getDefaultOrder().size();
+  return getOrderForDotOperand(opIdx, rank, /*kContig*/ true);
 }
 
 SmallVector<int64_t>
@@ -2639,11 +2763,12 @@ struct TritonGPUInferLayoutInterface
     // We implement two legacy layout propagations
     // Once we fully migrate to LinearLayouts, we can remove these.
     auto *ctx = getContext();
+    auto rank = shape.size();
     // The output encoding will only be a legacy encoding if the axis is the
     // fastest running dimension.
     // FIXME: We should make sure that there are enough elements along the axis
     // axis whenever fwdInference is false
-    if (getOrder(cast<DistributedEncodingTrait>(inEnc), shape)[axis] == 0) {
+    if (cast<DistributedEncodingTrait>(inEnc).getDefaultOrder()[axis] == 0) {
       // Dot operand: double kWidth if kDim == axis.
       if (auto dotEnc = mlir::dyn_cast<DotOperandEncodingAttr>(inEnc)) {
         auto kWidth = dotEnc.getKWidth();
@@ -2715,8 +2840,9 @@ struct TritonGPUVerifyTensorLayoutInterface
       // A different verifier should have checked that the layout itself is
       // valid, including that threads-per-warp has the same rank as
       // warps-per-block etc.
-      if (blocked.getRank() != rankedTy.getRank()) {
-        return makeErr() << layout << ".\nLayout has rank " << blocked.getRank()
+      auto layoutRank = blocked.getThreadsPerWarp().size();
+      if (layoutRank != rankedTy.getRank()) {
+        return makeErr() << layout << ".\nLayout has rank " << layoutRank
                          << ", but the tensor it's attached to has rank "
                          << rankedTy.getRank() << ".";
       }

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -58,7 +58,7 @@ public:
     // swizzling code.
     auto newInnerCvtEnc = SwizzledSharedEncodingAttr::get(
         getContext(), cvtEncoding, srcTy.getShape(),
-        /*order=*/getOrderForMemory(srcTy),
+        /*order=*/getOrder(srcTy),
         triton::gpu::getCTALayout(srcTy.getEncoding()), srcTy.getElementType(),
         /*needTrans=*/true);
     if (newInnerCvtEnc == cvtEncoding)
@@ -107,9 +107,9 @@ public:
 
     // MMAv3 with transpose only supports f16 and bf16.  Fall back to MMAv3
     // without transpose for other data types.)
-    auto newInnerCvtOrder = getOrderForMemory(srcTy);
+    auto newInnerCvtOrder = getOrder(srcTy);
     if (auto cvt = trans.getSrc().getDefiningOp<ConvertLayoutOp>()) {
-      newInnerCvtOrder = getOrderForMemory(cvt.getSrc().getType());
+      newInnerCvtOrder = getOrder(cvt.getSrc().getType());
     }
     auto srcElemTy = allocType.getElementType();
     if (!srcElemTy.isF16() && !srcElemTy.isBF16()) {

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -8,7 +8,6 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
-#include "triton/Tools/StrUtil.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -176,6 +175,7 @@ ttg::SharedEncodingTrait getSharedEncoding(Operation *op) {
 
   auto ty = cast<RankedTensorType>(op->getResultTypes()[0]);
   auto ctaLayout = ttg::getCTALayout(ty.getEncoding());
+  auto order = ttg::getOrder(ty);
   if (isTMALoad(op)) {
     // TMA encoding is set on the descriptor type
     TypedValue<tt::TensorDescType> desc;
@@ -202,7 +202,6 @@ ttg::SharedEncodingTrait getSharedEncoding(Operation *op) {
   if (localAllocEnc)
     return localAllocEnc;
 
-  auto order = getOrderForMemory(ty);
   // Use generic layout. This won't be optimal for 2D tensors.
   return ttg::SwizzledSharedEncodingAttr::get(ty.getContext(), 1, 1, 1, order,
                                               ctaLayout);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
@@ -37,8 +37,7 @@ static SmallVector<TMAStore> getTMAStores(scf::ForOp forOp) {
 static Value createAlloc(scf::ForOp &forOp, const TMAStore &store) {
   OpBuilder builder(forOp);
   RankedTensorType ty = store.src.getType();
-  // Is this one correct or should it always be [2, 1, 0]?
-  auto order = triton::gpu::getOrderForMemory(ty);
+  auto order = ttg::getOrder(ty);
   auto ctaLayout = ttg::getCTALayout(ty.getEncoding());
   Attribute encoding = ttg::SwizzledSharedEncodingAttr::get(
       ty.getContext(), 1, 1, 1, order, ctaLayout);
@@ -62,6 +61,7 @@ static void createTMAAsyncCopy(scf::ForOp forOp, const TMAStore &store,
   OpBuilder builder(store.op);
   Location loc = store.op->getLoc();
   RankedTensorType ty = store.src.getType();
+  auto order = ttg::getOrder(ty);
   auto ctaLayout = ttg::getCTALayout(ty.getEncoding());
 
   // Put wait before the local_store make the store truly async. We know

--- a/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
@@ -44,13 +44,24 @@ public:
         return;
       if (!cvtNeedsSharedMemory(srcType, dstType))
         return;
-      auto order = getOrderForMemory(srcType);
+      auto srcOrder = triton::gpu::getOrder(srcType);
+      auto rank = srcOrder.size();
+      SmallVector<unsigned> sharedOrder;
+      if (rank == 3) {
+        // add all elements except the element that is zero
+        for (unsigned i = 0; i < rank; ++i)
+          if (srcOrder[i] != 0)
+            sharedOrder.emplace_back(srcOrder[i]);
+        sharedOrder.emplace_back(0);
+      } else {
+        sharedOrder = srcOrder;
+      }
       auto sharedMemorySpace =
           triton::gpu::SharedMemorySpaceAttr::get(srcType.getContext());
       auto tmpType = triton::gpu::MemDescType::get(
           dstType.getShape(), dstType.getElementType(),
           triton::gpu::SwizzledSharedEncodingAttr::get(
-              mod.getContext(), dstDotOp, srcType.getShape(), order,
+              mod.getContext(), dstDotOp, srcType.getShape(), sharedOrder,
               triton::gpu::getCTALayout(srcEncoding), srcType.getElementType()),
           sharedMemorySpace);
       auto tmp = builder.create<triton::gpu::LocalAllocOp>(

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1066,7 +1066,7 @@ getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible) {
         return std::nullopt;
       auto srcTy = cast<triton::gpu::TensorOrMemDesc>(val.getType());
       auto CTALayout = ttg::getCTALayout(srcTy.getEncoding());
-      auto order = getOrderForMemory(srcTy);
+      auto order = ttg::getOrder(srcTy);
       unsigned bitWidth = srcTy.getElementType().getIntOrFloatBitWidth();
       tempAttr = ttg::SwizzledSharedEncodingAttr::get(
           val.getContext(), dotOpEnc, srcTy.getShape(), order, CTALayout,

--- a/test/TritonGPU/optimize-locality.mlir
+++ b/test/TritonGPU/optimize-locality.mlir
@@ -705,7 +705,7 @@ tt.func @set_warp_shuffle_layout_warp_broadcast(%arg0: tensor<64x64xf32, #blocke
 
 #blocked = #ttg.blocked<{sizePerThread = [2, 2, 1], threadsPerWarp = [16, 2, 1], warpsPerCTA = [2, 1, 2], order = [1, 0, 2]}>
 
-// CHECK: [[LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [2, 2, 1], order = [2, 0, 1]}>
+// CHECK: [[LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [2, 2, 1], order = [2, 1, 0]}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -269,11 +269,9 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   Value linearWarpId = tb.udiv(thread, warpSize);
   Value lane = tb.urem(thread, warpSize);
 
-  auto warpOrder = triton::gpu::getMatrixOrder(rank, /*rowMajor*/ true);
-
   Value spatialWarpId = AMD::getWarpIdInBlock(
       rewriter, loc, linearWarpId, warpsPerCTA, mfmaInstrNonK,
-      shape[nonKDimIdx], nonKDimIdx, warpOrder);
+      shape[nonKDimIdx], nonKDimIdx, mfmaLayout.getDefaultOrder());
 
   // number of duplicates of elements in warp
   // In case of 64x4 x 4x4 multiplication, 4x4 B operand is duplicated 16 times

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
@@ -190,10 +190,9 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   SmallVector<Value> offsets;
   Value smemBase;
   auto smemStrides = smemObj.getStrides(aTensorTy, loc, rewriter);
-  auto warpOrder = triton::gpu::getMatrixOrder(rank, /*rowMajor*/ true);
   Value spatialWarpId = AMD::getWarpIdInBlock(
       rewriter, loc, linearWaveId, warpsPerCTA, elemsPerInstr[0],
-      shape[nonKDimIdx], nonKDimIdx, warpOrder);
+      shape[nonKDimIdx], nonKDimIdx, wmmaLayout.getDefaultOrder());
   if (opIdx == 0) {
     offsets = AMD::computeOffsetsAType(
         rewriter, loc, computeTensorElemMappingInBlock, elemsPerInstr,

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -852,6 +852,7 @@ public:
     auto mfmaEnc = ttg::AMDMfmaEncodingAttr::get(
         ctx, /*versionMajor=*/mfmaVersion, /*versionMinor=*/0, warpsPerTile,
         /*instrShape=*/mDim, nDim, /*isTransposed=*/true, ctaLayout);
+    auto warpOrder = mfmaEnc.getDefaultWarpOrder();
 
     auto newRetType =
         RankedTensorType::get(oldShape, oldRetType.getElementType(), mfmaEnc);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -399,7 +399,7 @@ getSharedEncIfAllUsersAreDotEnc(Value loadedValue) {
 
       auto srcTy = cast<ttg::TensorOrMemDesc>(loadedValue.getType());
       auto ctaLayout = ttg::getCTALayout(srcTy.getEncoding());
-      auto order = getOrderForMemory(srcTy);
+      auto order = ttg::getOrder(srcTy);
       unsigned bitWidth = srcTy.getElementType().getIntOrFloatBitWidth();
       SmallVector<unsigned> sharedOrder;
       int rank = order.size();
@@ -430,8 +430,8 @@ getSharedEncIfAllUsersAreDotEnc(Value loadedValue) {
           unsigned vecSize = llEnc.getLinearLayout().getNumConsecutiveInOut();
           LDBG("deduced opIdx: " << opIdx << "; deduced vecSize: " << vecSize);
           tempAttr = dotEnc.composeSharedLayoutForOperand(
-              ctaLayout, opIdx, srcTy.getShape(), order, vecSize, bitWidth,
-              /*needTrans=*/false);
+              ctaLayout, opIdx, srcTy.getShape(), sharedOrder, vecSize,
+              bitWidth, /*needTrans=*/false);
         }
       }
     }

--- a/third_party/amd/python/test/test_extract_slice.py
+++ b/third_party/amd/python/test/test_extract_slice.py
@@ -39,8 +39,7 @@ extract_layout = [
     BlockedLayout([2, 2], [64, 1], [2, 2], [1, 0], [1, 1], [1, 1], [0, 1]),
     BlockedLayout([2, 2], [16, 4], [4, 1], [0, 1], [1, 1], [1, 1], [0, 1]),
     BlockedLayout([1, 8], [16, 4], [4, 1], [1, 0], [1, 1], [1, 1], [0, 1]),
-    # FIXME(Lezcano): This layout errors out
-    #BlockedLayout([1, 8], [16, 4], [4, 1], [0, 1], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([1, 8], [16, 4], [4, 1], [0, 1], [1, 1], [1, 1], [0, 1]),
 ]
 blocked_layout = [
     BlockedLayout([1, 8], [16, 4], [4, 1], [1, 0], [1, 1], [1, 1], [0, 1]),

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -486,6 +486,150 @@ public:
   }
 };
 
+class AMDWmmaLayoutTest : public AMDLayoutTest {
+public:
+  AMDWmmaLayoutTest() = default;
+
+  triton::gpu::AMDWmmaEncodingAttr
+  createWMMAv1(ArrayRef<unsigned> warpsPerCTA) {
+    return triton::gpu::AMDWmmaEncodingAttr::get(
+        &ctx, /*version=*/1, /*isTransposed=*/false, warpsPerCTA, ctaLayout);
+  }
+
+  triton::gpu::AMDWmmaEncodingAttr
+  createWMMAv2(bool isTransposed, ArrayRef<unsigned> warpsPerCTA) {
+    return triton::gpu::AMDWmmaEncodingAttr::get(
+        &ctx, /*version=*/2, isTransposed, warpsPerCTA, ctaLayout);
+  }
+};
+
+TEST_F(AMDMfmaLayoutTest, mfma32) {
+  auto mfma2d = createMFMA(32, 32, {2, 4});
+  ASSERT_THAT(mfma2d.getDefaultThreadOrder(), testing::ElementsAre(1u, 0u));
+  ASSERT_THAT(mfma2d.getDefaultWarpOrder(), testing::ElementsAre(1u, 0u));
+
+  auto tmfma2d = createTransposedMFMA(32, 32, {2, 4});
+  ASSERT_THAT(tmfma2d.getDefaultThreadOrder(), testing::ElementsAre(0u, 1u));
+  ASSERT_THAT(tmfma2d.getDefaultWarpOrder(), testing::ElementsAre(1u, 0u));
+
+  auto mfma3d = createMFMA(32, 32, {2, 4, 1});
+  ASSERT_THAT(mfma3d.getDefaultThreadOrder(), testing::ElementsAre(2u, 1u, 0u));
+  ASSERT_THAT(mfma3d.getDefaultWarpOrder(), testing::ElementsAre(2u, 1u, 0u));
+
+  auto tmfma3d = createTransposedMFMA(32, 32, {2, 4, 1});
+  ASSERT_THAT(tmfma3d.getDefaultThreadOrder(),
+              testing::ElementsAre(1u, 2u, 0u));
+  ASSERT_THAT(tmfma3d.getDefaultWarpOrder(), testing::ElementsAre(2u, 1u, 0u));
+}
+
+TEST_F(AMDMfmaLayoutTest, mfma16) {
+  auto mfma2d = createMFMA(16, 16, {2, 4});
+  ASSERT_THAT(mfma2d.getDefaultThreadOrder(), testing::ElementsAre(1u, 0u));
+  ASSERT_THAT(mfma2d.getDefaultWarpOrder(), testing::ElementsAre(1u, 0u));
+
+  auto tmfma2d = createTransposedMFMA(16, 16, {2, 4});
+  ASSERT_THAT(tmfma2d.getDefaultThreadOrder(), testing::ElementsAre(0u, 1u));
+  ASSERT_THAT(tmfma2d.getDefaultWarpOrder(), testing::ElementsAre(1u, 0u));
+
+  auto mfma3d = createMFMA(16, 16, {2, 4, 1});
+  ASSERT_THAT(mfma3d.getDefaultThreadOrder(), testing::ElementsAre(2u, 1u, 0u));
+  ASSERT_THAT(mfma3d.getDefaultWarpOrder(), testing::ElementsAre(2u, 1u, 0u));
+
+  auto tmfma3d = createTransposedMFMA(16, 16, {2, 4, 1});
+  ASSERT_THAT(tmfma3d.getDefaultThreadOrder(),
+              testing::ElementsAre(1u, 2u, 0u));
+  ASSERT_THAT(tmfma3d.getDefaultWarpOrder(), testing::ElementsAre(2u, 1u, 0u));
+}
+
+TEST_F(AMDMfmaLayoutTest, mfma_dot_op) {
+  auto mfma2d = createMFMA(32, 32, {2, 4});
+  auto dot2dOp0 = createDotOperand(0, mfma2d, 4);
+  auto dot2dOp1 = createDotOperand(1, mfma2d, 4);
+  ASSERT_THAT(dot2dOp0.getDefaultWarpOrder(), mfma2d.getDefaultWarpOrder());
+  ASSERT_THAT(dot2dOp1.getDefaultWarpOrder(), mfma2d.getDefaultWarpOrder());
+
+  auto tmfma2d = createTransposedMFMA(32, 32, {2, 4});
+  auto tdot2dOp0 = createDotOperand(0, tmfma2d, 4);
+  auto tdot2dOp1 = createDotOperand(1, tmfma2d, 4);
+  ASSERT_THAT(tdot2dOp0.getDefaultWarpOrder(), tmfma2d.getDefaultWarpOrder());
+  ASSERT_THAT(tdot2dOp1.getDefaultWarpOrder(), tmfma2d.getDefaultWarpOrder());
+
+  auto mfma3d = createMFMA(32, 32, {2, 4, 1});
+  auto dot3dOp0 = createDotOperand(0, mfma3d, 4);
+  auto dot3dOp1 = createDotOperand(1, mfma3d, 4);
+  ASSERT_THAT(dot3dOp0.getDefaultWarpOrder(), mfma3d.getDefaultWarpOrder());
+  ASSERT_THAT(dot3dOp1.getDefaultWarpOrder(), mfma3d.getDefaultWarpOrder());
+
+  auto tmfma3d = createTransposedMFMA(32, 32, {2, 4, 1});
+  auto tdot3dOp0 = createDotOperand(0, tmfma3d, 4);
+  auto tdot3dOp1 = createDotOperand(1, tmfma3d, 4);
+  ASSERT_THAT(tdot3dOp0.getDefaultWarpOrder(), tmfma3d.getDefaultWarpOrder());
+  ASSERT_THAT(tdot3dOp1.getDefaultWarpOrder(), tmfma3d.getDefaultWarpOrder());
+}
+
+TEST_F(AMDWmmaLayoutTest, wmmaV1) {
+  auto wmma2d = createWMMAv1({2, 4});
+  ASSERT_THAT(wmma2d.getDefaultThreadOrder(), testing::ElementsAre(1u, 0u));
+  ASSERT_THAT(wmma2d.getDefaultWarpOrder(), testing::ElementsAre(1u, 0u));
+
+  auto wmma3d = createWMMAv1({2, 4, 1});
+  ASSERT_THAT(wmma3d.getDefaultThreadOrder(), testing::ElementsAre(2u, 1u, 0u));
+  ASSERT_THAT(wmma3d.getDefaultWarpOrder(), testing::ElementsAre(2u, 1u, 0u));
+}
+
+TEST_F(AMDWmmaLayoutTest, wmmaV2) {
+  auto wmma2d = createWMMAv2(false, {2, 4});
+  ASSERT_THAT(wmma2d.getDefaultThreadOrder(), testing::ElementsAre(1u, 0u));
+  ASSERT_THAT(wmma2d.getDefaultWarpOrder(), testing::ElementsAre(1u, 0u));
+
+  auto wmma3d = createWMMAv2(false, {2, 4, 1});
+  ASSERT_THAT(wmma3d.getDefaultThreadOrder(), testing::ElementsAre(2u, 1u, 0u));
+  ASSERT_THAT(wmma3d.getDefaultWarpOrder(), testing::ElementsAre(2u, 1u, 0u));
+
+  auto twmma2d = createWMMAv2(true, {2, 4});
+  ASSERT_THAT(twmma2d.getDefaultThreadOrder(), testing::ElementsAre(0u, 1u));
+  ASSERT_THAT(twmma2d.getDefaultWarpOrder(), testing::ElementsAre(1u, 0u));
+
+  auto twmma3d = createWMMAv2(true, {2, 4, 1});
+  ASSERT_THAT(twmma3d.getDefaultThreadOrder(),
+              testing::ElementsAre(1u, 2u, 0u));
+  ASSERT_THAT(twmma3d.getDefaultWarpOrder(), testing::ElementsAre(2u, 1u, 0u));
+}
+
+TEST_F(AMDWmmaLayoutTest, wmma_dot_op) {
+  auto wmma2dVer1 = createWMMAv1({2, 4});
+  auto dot2dVer1Op0 = createDotOperand(0, wmma2dVer1, 16);
+  auto dot2dVer1Op1 = createDotOperand(1, wmma2dVer1, 16);
+  ASSERT_THAT(dot2dVer1Op0.getDefaultWarpOrder(),
+              wmma2dVer1.getDefaultWarpOrder());
+  ASSERT_THAT(dot2dVer1Op1.getDefaultWarpOrder(),
+              wmma2dVer1.getDefaultWarpOrder());
+
+  auto wmma3dVer1 = createWMMAv1({2, 4, 1});
+  auto dot3dVer1Op0 = createDotOperand(0, wmma3dVer1, 16);
+  auto dot3dVer1Op1 = createDotOperand(1, wmma3dVer1, 16);
+  ASSERT_THAT(dot3dVer1Op0.getDefaultWarpOrder(),
+              wmma3dVer1.getDefaultWarpOrder());
+  ASSERT_THAT(dot3dVer1Op1.getDefaultWarpOrder(),
+              wmma3dVer1.getDefaultWarpOrder());
+
+  auto wmma2dVer2 = createWMMAv2(false, {2, 4});
+  auto dot2dVer2Op0 = createDotOperand(0, wmma2dVer2, 16);
+  auto dot2dVer2Op1 = createDotOperand(1, wmma2dVer2, 16);
+  ASSERT_THAT(dot2dVer2Op0.getDefaultWarpOrder(),
+              wmma2dVer2.getDefaultWarpOrder());
+  ASSERT_THAT(dot2dVer2Op1.getDefaultWarpOrder(),
+              wmma2dVer2.getDefaultWarpOrder());
+
+  auto wmma3dVer2 = createWMMAv2(false, {2, 4, 1});
+  auto dot3dVer2Op0 = createDotOperand(0, wmma3dVer2, 16);
+  auto dot3dVer2Op1 = createDotOperand(1, wmma3dVer2, 16);
+  ASSERT_THAT(dot3dVer2Op0.getDefaultWarpOrder(),
+              wmma3dVer2.getDefaultWarpOrder());
+  ASSERT_THAT(dot3dVer2Op1.getDefaultWarpOrder(),
+              wmma3dVer2.getDefaultWarpOrder());
+}
+
 class LinearEncodingTest : public ::testing::Test {
 public:
   LinearEncodingTest() { ctx.getOrLoadDialect<TritonGPUDialect>(); }
@@ -545,6 +689,15 @@ TEST_F(LinearEncodingTest, DistributedEncodingToLinearEncoding) {
       if (!is_dot_op_with_block_parent(distributedEncoding)) {
         ASSERT_EQ(distributedEncoding.getRepOrder(),
                   linearEncoding.getRepOrder());
+      }
+      // DotOperandEncodingAttr::getDefaultWarpOrder() is not defined
+      if (!isa<triton::gpu::DotOperandEncodingAttr>(distributedEncoding)) {
+        ASSERT_EQ(distributedEncoding.getDefaultWarpOrder(),
+                  linearEncoding.getWarpOrder());
+      }
+      if (!is_dot_op_with_block_parent(distributedEncoding)) {
+        ASSERT_EQ(distributedEncoding.getDefaultThreadOrder(),
+                  linearEncoding.getThreadOrder());
       }
       // For slice these do not equal the total number of lines / warps
       // See [Note. Divergence of methods wrt. legacy layouts]


### PR DESCRIPTION
This reverts commit 1217ffc9140c5d10929e07c151a6516d5a2c049e.

We observed some regressions on BW.
