### PR TITLE
[AMD] Fix test_matmul.py num_stage with large block

### DIFF
--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -889,7 +889,7 @@ def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TR
         if (A_DATA_TYPE == 'float4' and not WITH_A_SCALE) or (B_DATA_TYPE == 'float4' and not WITH_B_SCALE):
             pytest.skip("Float4 without scale is tested in test_block_scale_fp4")
 
-    if not is_hip() and BLOCK_N == 256 and BLOCK_K == 256:
+    if BLOCK_N == 256 and BLOCK_K == 256:
         NUM_STAGES = 2
 
     torch.manual_seed(42)


### PR DESCRIPTION
In test_mxfp8_mxfp4_matmul, large block sizes can exceed shared memory limitation with num_stages=3.
Found from internal test.