### PR TITLE
[PROTON] Fix multi-session profiling

### DIFF
--- a/third_party/proton/csrc/include/Context/Shadow.h
+++ b/third_party/proton/csrc/include/Context/Shadow.h
@@ -33,8 +33,10 @@ private:
   void initializeThreadContext();
 
   std::vector<Context> *mainContextStack{};
-  static thread_local bool contextInitialized;
-  static thread_local std::vector<Context> threadContextStack;
+  static thread_local std::map<ShadowContextSource *, bool>
+      threadContextInitialized;
+  static thread_local std::map<ShadowContextSource *, std::vector<Context>>
+      threadContextStack;
 };
 
 } // namespace proton

--- a/third_party/proton/csrc/lib/Context/Shadow.cpp
+++ b/third_party/proton/csrc/lib/Context/Shadow.cpp
@@ -7,43 +7,44 @@ namespace proton {
 
 void ShadowContextSource::initializeThreadContext() {
   if (!mainContextStack) {
-    mainContextStack = &threadContextStack;
-    contextInitialized = true;
+    mainContextStack = &threadContextStack[this];
+    threadContextInitialized[this] = false;
   }
-  if (!contextInitialized) {
-    threadContextStack = *mainContextStack;
-    contextInitialized = true;
+  if (!threadContextInitialized[this]) {
+    threadContextStack[this] = *mainContextStack;
+    threadContextInitialized[this] = true;
   }
 }
 
 void ShadowContextSource::enterScope(const Scope &scope) {
   initializeThreadContext();
-  threadContextStack.push_back(scope);
+  threadContextStack[this].push_back(scope);
 }
 
 std::vector<Context> ShadowContextSource::getContextsImpl() {
   initializeThreadContext();
-  return threadContextStack;
+  return threadContextStack[this];
 }
 
 size_t ShadowContextSource::getDepth() {
   initializeThreadContext();
-  return threadContextStack.size();
+  return threadContextStack[this].size();
 }
 
 void ShadowContextSource::exitScope(const Scope &scope) {
-  if (threadContextStack.empty()) {
+  if (threadContextStack[this].empty()) {
     throw std::runtime_error("Context stack is empty");
   }
-  if (threadContextStack.back() != scope) {
+  if (threadContextStack[this].back() != scope) {
     throw std::runtime_error("Context stack is not balanced");
   }
-  threadContextStack.pop_back();
+  threadContextStack[this].pop_back();
 }
 
-/*static*/ thread_local std::vector<Context>
-    ShadowContextSource::threadContextStack;
+/*static*/ thread_local std::map<ShadowContextSource *, bool>
+    ShadowContextSource::threadContextInitialized;
 
-/*static*/ thread_local bool ShadowContextSource::contextInitialized = false;
+/*static*/ thread_local std::map<ShadowContextSource *, std::vector<Context>>
+    ShadowContextSource::threadContextStack;
 
 } // namespace proton

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -298,16 +298,21 @@ def test_multiple_sessions(tmp_path: pathlib.Path):
     temp_file1 = tmp_path / "test_multiple_sessions1.hatchet"
     session_id0 = proton.start(str(temp_file0.with_suffix("")))
     session_id1 = proton.start(str(temp_file1.with_suffix("")))
-    torch.randn((10, 10), device="cuda")
-    torch.randn((10, 10), device="cuda")
+    with proton.scope("scope0"):
+        torch.randn((10, 10), device="cuda")
+        torch.randn((10, 10), device="cuda")
     proton.deactivate(session_id0)
     proton.finalize(session_id0)
-    torch.randn((10, 10), device="cuda")
+    with proton.scope("scope1"):
+        torch.randn((10, 10), device="cuda")
     proton.finalize(session_id1)
-    # kernel has been invokved twice in session 0 and three times in session 1
+    # kernel has been invoked twice in session 0 and three times in session 1
     with temp_file0.open() as f:
         data = json.load(f)
-    assert int(data[0]["children"][0]["metrics"]["count"]) == 2
+    assert data[0]["children"][0]["frame"]["name"] == "scope0"
+    assert int(data[0]["children"][0]["children"][0]["metrics"]["count"]) == 2
     with temp_file1.open() as f:
         data = json.load(f)
-    assert int(data[0]["children"][0]["metrics"]["count"]) == 3
+    scope0_count = int(data[0]["children"][0]["children"][0]["metrics"]["count"])
+    scope1_count = int(data[0]["children"][1]["children"][0]["metrics"]["count"])
+    assert scope0_count + scope1_count == 3


### PR DESCRIPTION
Shadow scopes cannot be shared across sessions. Otherwise, the context source will enter the same scope twice as the thread local stack is registered by two sessions.

Note that concurrent session profiling is important when we want to concatenate profiles from different profilers (e.g., instrumentation & pm sampling).