### PR TITLE
[AMD] Fix test_simple_matmul for gfx950

### DIFF
--- a/test/Conversion/amd/ds_transpose.mlir
+++ b/test/Conversion/amd/ds_transpose.mlir
@@ -144,70 +144,70 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   }
 
   //  CHECK-LABEL: ds_transpose_n_t_fp8_mfma_16
-  tt.func @ds_transpose_n_t_fp8_mfma_16(%arg0: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>) {
-    // CHECK-COUNT-16: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
-    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 16}>>
-    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 16}>>
+  tt.func @ds_transpose_n_t_fp8_mfma_16(%arg0: !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>, %arg1: !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable>) {
+    // CHECK-COUNT-32: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 16}>>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 16}>>
     tt.return
   }
 
   //  CHECK-LABEL: ds_transpose_t_t_fp8_mfma_16
-  tt.func @ds_transpose_t_t_fp8_mfma_16(%arg0: !ttg.memdesc<128x64xf8E4M3FN, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>) {
-    // CHECK-COUNT-4: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<16xi8>
-    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 16}>>
-    // CHECK-COUNT-8: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
-    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 16}>>
+  tt.func @ds_transpose_t_t_fp8_mfma_16(%arg0: !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable>) {
+    // CHECK-COUNT-8: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<16xi8>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 16}>>
+    // CHECK-COUNT-16: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 16}>>
     tt.return
   }
 
   //  CHECK-LABEL: ds_transpose_n_n_fp8_mfma_16
-  tt.func @ds_transpose_n_n_fp8_mfma_16(%arg0: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf8E4M3FN, #shared, #smem, mutable>) {
-    // CHECK-COUNT-8: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
-    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 16}>>
-    // CHECK-COUNT-4: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<16xi8>
-    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 16}>>
+  tt.func @ds_transpose_n_n_fp8_mfma_16(%arg0: !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>, %arg1: !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>) {
+    // CHECK-COUNT-16: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 16}>>
+    // CHECK-COUNT-8: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<16xi8>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 16}>>
     tt.return
   }
 
   //  CHECK-LABEL: ds_transpose_t_n_fp8_mfma_16
-  tt.func @ds_transpose_t_n_fp8_mfma_16(%arg0: !ttg.memdesc<128x64xf8E4M3FN, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf8E4M3FN, #shared, #smem, mutable>) {
+  tt.func @ds_transpose_t_n_fp8_mfma_16(%arg0: !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>) {
     // CHECK-NOT: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
-    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 16}>>
-    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 16}>>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma16, kWidth = 16}>>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma16, kWidth = 16}>>
     tt.return
   }
 
   //  CHECK-LABEL: ds_transpose_n_t_fp8_mfma32
-  tt.func @ds_transpose_n_t_fp8_mfma32(%arg0: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>) {
-    // CHECK-COUNT-16: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
-    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 16}>>
-    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 16}>>
+  tt.func @ds_transpose_n_t_fp8_mfma32(%arg0: !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>, %arg1: !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable>) {
+    // CHECK-COUNT-32: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 16}>>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 16}>>
     tt.return
   }
 
   //  CHECK-LABEL: ds_transpose_t_t_fp8_mfma32
-  tt.func @ds_transpose_t_t_fp8_mfma32(%arg0: !ttg.memdesc<128x64xf8E4M3FN, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>) {
-    // CHECK-COUNT-4: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<16xi8>
-    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 16}>>
-    // CHECK-COUNT-6: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
-    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 16}>>
+  tt.func @ds_transpose_t_t_fp8_mfma32(%arg0: !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable>) {
+    // CHECK-COUNT-8: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<16xi8>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 16}>>
+    // CHECK-COUNT-12: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 16}>>
     tt.return
   }
 
   //  CHECK-LABEL: ds_transpose_n_n_fp8_mfma32
-  tt.func @ds_transpose_n_n_fp8_mfma32(%arg0: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf8E4M3FN, #shared, #smem, mutable>) {
-    // CHECK-COUNT-8: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
-    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 16}>>
-    // CHECK-COUNT-4: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<16xi8>
-    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 16}>>
+  tt.func @ds_transpose_n_n_fp8_mfma32(%arg0: !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>, %arg1: !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>) {
+    // CHECK-COUNT-16: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 16}>>
+    // CHECK-COUNT-8: llvm.load %{{.*}} : !llvm.ptr<3> -> vector<16xi8>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 16}>>
     tt.return
   }
 
   //  CHECK-LABEL: ds_transpose_t_n_fp8_mfma32
-  tt.func @ds_transpose_t_n_fp8_mfma32(%arg0: !ttg.memdesc<128x64xf8E4M3FN, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<64x128xf8E4M3FN, #shared, #smem, mutable>) {
+  tt.func @ds_transpose_t_n_fp8_mfma32(%arg0: !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable>, %arg1: !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>) {
     // CHECK-NOT: rocdl.ds.read.tr8.b64 %{{.*}} : <3> -> vector<2xi32>
-    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 16}>>
-    %2 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<64x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 16}>>
+    %1 = ttg.local_load %arg0 : !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma32, kWidth = 16}>>
+    %2 = ttg.local_load %arg1 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable> -> tensor<128x128xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma32, kWidth = 16}>>
     tt.return
   }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -184,7 +184,7 @@ private:
         (mDim == 32) ? kSizeSingleRateMfma32 : kSizeSingleRateMfma16;
 
     // For FP8, wider MFMA instructions (scaled MFMA) have a k-dimension
-    // that is four times larger than regular MFMA instructions.
+    // that is four times of regular MFMA instructions.
     if (dstTy.getElementType().isFloat() && bitwidth == 8) {
       largeTileThreshold *= 2;
     }


### PR DESCRIPTION
This PR fixes calculation for largeTileThreshold during LDS transpose instruction lowering. 
For fp8, wider MFMA instructions (scaled MFMA) have a k-dimension that is four times of regular MFMA instructions. For fp16/int8 types k-dimension is two times of wider MFMA instructions.
