### PR TITLE
Add implicit downcast in TMA descriptor store

### DIFF
--- a/python/test/unit/cuda/test_experimental_tma.py
+++ b/python/test/unit/cuda/test_experimental_tma.py
@@ -227,3 +227,45 @@ def test_device_tensormap1d(dtype_str):
     # Check results are correct
     torch.testing.assert_close(unwrap_tensor(inp), unwrap_tensor(out))
     torch.testing.assert_close(unwrap_tensor(inp), unwrap_tensor(inp_copy))
+
+
+"""
+Regression test: descriptor store should implicitly downcast values to match
+descriptor element type. For float16/bfloat16 descriptors, storing a float32
+block should succeed and round-trip downcast.
+"""
+
+
+@requires_tma
+@pytest.mark.interpreter
+@pytest.mark.parametrize("dtype_str", ["float16", "bfloat16"])
+def test_tensor_descriptor_store_downcast(dtype_str):
+
+    @triton.jit
+    def kernel(out_ptr, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+        moffset = tl.program_id(0) * M_BLOCK
+        noffset = tl.program_id(1) * N_BLOCK
+        midx = moffset + tl.arange(0, M_BLOCK)[:, None]
+        nidx = noffset + tl.arange(0, N_BLOCK)[None, :]
+        # Generate a float32 block based on linear indices.
+        val_f32 = (midx * N + nidx).to(tl.float32)
+        desc = tl._experimental_make_tensor_descriptor(
+            out_ptr,
+            shape=[M, N],
+            strides=[N, 1],
+            block_shape=[M_BLOCK, N_BLOCK],
+        )
+        desc.store([moffset, noffset], val_f32)
+
+    M, N = 32, 128
+    # baseline pattern 0..M*N-1 in the target dtype
+    torch_dtype = getattr(torch, dtype_str)
+    baseline = torch.arange(M * N, dtype=torch.float32).reshape(M, N).to(torch_dtype)
+    M_BLOCK = 8
+    N_BLOCK = 32
+    out = torch.empty((M, N), dtype=torch_dtype, device="cuda")
+    grid_m = M // M_BLOCK
+    grid_n = N // N_BLOCK
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        assert size == 128 * (grid_m * grid_n)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1182,7 +1182,9 @@ def descriptor_store(desc: tl.tensor_descriptor_base, value: tl.tensor, offsets,
     ndim = len(desc.block_shape)
     assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
     assert value.shape == desc.block_shape
-
+    # Ensure we store a block value with the correct element type for this descriptor
+    # (e.g., implicitly downcast values whose element type is wider than the descriptor's)
+    value = cast(value, desc.dtype, builder)
     offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
     return tl.tensor(builder.create_descriptor_store(desc.handle, value.handle, offsets), tl.void)
 


### PR DESCRIPTION
#### Description
This fixes a missing implicit downcast when storing blocks through TMA descriptors. Previously, attempting to widen the result of a descriptor load (e.g. from `float16` to `float32`) and then store it back via the descriptor would result in an MLIR verification error because the block types no longer matched:
```python
# ptr.element_ty is tl.float16
desc = tl._experimental_make_tensor_descriptor(ptr, shape=.., strides=..., block_shape=...)
value = desc.load([off_x, off_y]).to(tl.float32)
# 'tt.experimental_descriptor_store' op tensor desciptor block and tensor types must match
desc.store([off_x, off_y], value)
```
The pointer/`tl.store` path already cast values to the target element type; descriptor stores should behave the same.
#### Changes
* Updated `descriptor_store` in `python/triton/language/semantic.py` to cast the incoming tensor to the descriptor's element type before emitting the `create_descriptor_store` IR node.
* Added a regression test `test_tensor_descriptor_store_downcast` to `python/test/unit/cuda/test_experimental_tma.py` which widens a `float16`/`bfloat16` block to `float32` and stores it back via the descriptor.
* Ran `pre-commit` hooks to keep formatting consistent.
A quick check under `TRITON_INTERPRET=1` shows the new downcast path works:
```
True  # torch.equal(a, out) when storing a widened float16 block
True  # bfloat16 as well
```
#### Checklist
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests under `python/test`.
- [x] I have not added any `lit` tests.
---
This fix aligns descriptor stores with pointer store semantics and avoids an IR verifier failure when the stored block's element type is wider than the descriptor’s element type.