### PR TITLE
[AMD] Fix rewrite-partition-dependencies lit test

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -252,8 +252,10 @@ struct AsyncRef {
     return createSingleBufferView(b, emptyBars, idx);
   }
   auto getView(ImplicitLocOpBuilder &b, Value idx) const {
-    return std::make_tuple(getValueView(b, idx), getReadyView(b, idx),
-                           getEmptyView(b, idx));
+    auto valView = getValueView(b, idx);
+    auto readyView = getReadyView(b, idx);
+    auto emptyView = getEmptyView(b, idx);
+    return std::make_tuple(valView, readyView, emptyView);
   }
 
   unsigned multiplicitySize;


### PR DESCRIPTION
The reason is unspecified evaluation order.

See also: https://github.com/triton-lang/triton/pull/6175
          https://github.com/triton-lang/triton/pull/5678