### PR TITLE
Cache autotune timings to disk

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -162,7 +162,7 @@ class Autotuner(KernelInterface):
 
     def check_disk_cache(self, tuning_key, configs, bench_fn):
         # We can't serialize prehooks, so just give up and run the benchmarks.
-        if any(cfg.pre_hook for cfg in configs):
+        if not tuning_key or any(cfg.pre_hook for cfg in configs):
             bench_fn()
             return
 

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -178,11 +178,16 @@ class Autotuner(KernelInterface):
             bench_fn()
             return
 
-        from triton.compiler.compiler import triton_key
+        from triton.compiler.compiler import make_backend, triton_key
         from triton.runtime.cache import get_cache_manager
+        from triton._C.libtriton import get_cache_invalidating_env_vars
+
+        env_vars = get_cache_invalidating_env_vars()
         cache_key = [
             triton_key(),
+            make_backend(driver.active.get_current_target()).hash(),
             self.fn.cache_key,
+            str(sorted(env_vars.items())),
             str(tuning_key),
         ] + [str(c) for c in configs]
         cache_key = hashlib.sha256("-".join(cache_key).encode("utf-8")).hexdigest()

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -221,8 +221,11 @@ class Autotuner(KernelInterface):
                     timings = {}
                     bench_start = time.time()
                     new_timings = False
-                    # we want to skip benchmarking configs that aren't in the cache; but we don't
-                    # want to select any cached configs that aren't in the pruned set
+                    # We want to find timings for any config in the pruned set; we can't
+                    # just return the cached set of configs, because the user may have
+                    # changed the config set or the pruning function.  But if the cache
+                    # already has a timing for a given config, use that instead of
+                    # re-running the benchmark.
                     for config in pruned_configs:
                         if config in cached_timings:
                             timings[config] = cached_timings[config]

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -222,13 +222,12 @@ class Autotuner(KernelInterface):
                 pruned_configs = self.prune_configs(kwargs)
 
                 def benchmark():
-                    # prune configs
-                    bench_start = time.time()
                     # We want to find timings for any config in the pruned set; we can't
                     # just return the cached set of configs, because the user may have
                     # changed the config set or the pruning function.  But if the cache
                     # already has a timing for a given config, use that instead of
                     # re-running the benchmark.
+                    bench_start = time.time()
                     timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
                     bench_end = time.time()
                     self.bench_time = bench_end - bench_start

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -347,30 +347,15 @@ class Config:
         return ", ".join(res)
 
     def __hash__(self):
-        return hash((
-            *self.kwargs.items(),
-            self.num_warps,
-            self.num_ctas,
-            self.num_stages,
-            self.maxnreg,
-            self.pre_hook,
-        ))
+        return hash((*self.all_kwargs().items(), self.pre_hook))
 
     def __eq__(self, other):
         self_tuple = tuple((
-            *self.kwargs.items(),
-            self.num_warps,
-            self.num_ctas,
-            self.num_stages,
-            self.maxnreg,
+            *self.all_kwargs().items(),
             self.pre_hook,
         ))
         other_tuple = tuple((
-            *other.kwargs.items(),
-            other.num_warps,
-            other.num_ctas,
-            other.num_stages,
-            other.maxnreg,
+            *other.all_kwargs().items(),
             other.pre_hook,
         ))
         return self_tuple == other_tuple

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -227,11 +227,6 @@ class Autotuner(KernelInterface):
                 pruned_configs = self.prune_configs(kwargs)
 
                 def benchmark():
-                    # We want to find timings for any config in the pruned set; we can't
-                    # just return the cached set of configs, because the user may have
-                    # changed the config set or the pruning function.  But if the cache
-                    # already has a timing for a given config, use that instead of
-                    # re-running the benchmark.
                     bench_start = time.time()
                     timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
                     bench_end = time.time()


### PR DESCRIPTION
Some users had expressed a desire to cache autotune results, both to speed up local iteration, and to avoid re-tuning when scaling up to large numbers of GPUs.

This PR caches tuning timings in Triton's cache dir.  Running locally on 03-matrix-multiplication.py, the time of later runs is greatly reduced:
```
% time python ./03-matrix-multiplication.py
...
real    1m59.055s

% time python ./03-matrix-multiplication.py
...
real    0m13.794s
```

The cache key consists of:
* system information (triton source, target info, env vars)
* kernel source code (with dependences)
* the values of the tuning keys (e.g. M/N/K in the matmul example)
* the set of configs requested for tuning (so that we'll re-tune if the user changes tunings)

If any configs have `pre_hook`s defined, we don't try caching at all, since the results could depend on arbitrary python code.

A sampling of one of the cache entries (from the matmul tutorial) is:
```
% jq . $TRITON_CACHE_DIR/X5O...Q/matmul_kernel.autotune.json
{
  "key": [
    3968,
    3968,
    3968,
    "torch.float8_e5m2",
    "torch.float8_e5m2",
    "torch.float16"
  ],
  "configs_timings": [
    [
      {
        "kwargs": {
          "BLOCK_SIZE_M": 128,
          "BLOCK_SIZE_N": 256,
          "BLOCK_SIZE_K": 64,
          "GROUP_SIZE_M": 8
        },
        "num_warps": 8,
        "num_ctas": 1,
        "num_stages": 3,
        "maxnreg": null,
        "pre_hook": null
      },
      [
        0.14316800236701965,
        0.1420159935951233,
        0.14431999623775482
      ]
    ],
    ...                                                                                                                                                                                                                                                                                                                                                                                                                    
```

It's not strictly necessary to encode the key, since it's part of the hashed path, but I think it makes it easier to understand the cache contents for any dev who needs to do so.

I considered a few different designs here:
* storing just the best config versus all timings (I like having the raw data available in the cache from a dev perspective, but I could relent on this, it's an easy change)
* allowing new configs to be added while re-using older cached ones (I got cold feet at the thought of mutating the cache)
* storing all key+config+timings in a single cache file (convenient for analysis, but also requires mutating the cache)

