### PR TITLE
Disable pipelining when no loop is available.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -82,6 +82,16 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
+    unsigned loopCnt = 0;
+    getOperation()->walk([&](scf::ForOp forOp) {
+      // Bail out for loops with num_stage <= 1.
+      if (getNumStagesOrDefault(forOp, numStages) > 1)
+        loopCnt++;
+    });
+
+    if (loopCnt == 0)
+      return;
+
     // Go over the interesting ops and assign latencies (based on the
     // numStages) to the them, trying to populate the allowed stages. This
     // step will be at some point extracted to separate pass that will be run


### PR DESCRIPTION
Disabling pipelining when no loop is available.

It seems that `num_stages` is used in multiple places in the pipeliner, e.g, `assignLatencies`, but not all places such as `pipelineTC05MMALoops`. I'm disabling the whole pipelining process when no loop wants to be pipelined. 