### PR TITLE
[BACKEND] Fix wrong K dimension for dot_scaled op

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -511,11 +511,14 @@ struct TCGen5MMAScaledOpConversion
 
     unsigned int M = dTensorTy.getDimSize(0);
     unsigned int N = dTensorTy.getDimSize(1);
-    int numBitsPerElementA = opKindIsMXFP4 ? getFormatBitSize(op.getAType())
-                                           : aTensorTy.getElementTypeBitWidth();
-    int numBitsPerElementB = opKindIsMXFP4 ? getFormatBitSize(op.getBType())
-                                           : bTensorTy.getElementTypeBitWidth();
-    unsigned int K = (aTensorTy.getDimSize(1) * 8) / numBitsPerElementA;
+    int numBitsUnpackedPerElementA = opKindIsMXFP4
+                                         ? getFormatBitSize(op.getAType())
+                                         : aTensorTy.getElementTypeBitWidth();
+    int numBitsUnpackedPerElementB = opKindIsMXFP4
+                                         ? getFormatBitSize(op.getBType())
+                                         : bTensorTy.getElementTypeBitWidth();
+    unsigned int K =
+        (aTensorTy.getDimSize(1) * 8) / getFormatBitSize(op.getAType());
 
     // Get MMA size based on acc layout.
     auto tensorMemAttr = cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
@@ -546,12 +549,12 @@ struct TCGen5MMAScaledOpConversion
     } else {
       aLoader = std::make_unique<DotOpMmaV3SmemLoader>(
           op.getA(), baseA, shapeA, shapeA, zero, 1, transA, aOperandShape,
-          numBitsPerElementA, rewriter, loc);
+          numBitsUnpackedPerElementA, rewriter, loc);
     }
     DotOpMmaV3SmemLoader bLoader =
         DotOpMmaV3SmemLoader(op.getB(), baseB, shapeB, shapeB, zero, 1, transB,
                              {(unsigned)mmaSizeN, (unsigned)mmaSizeK},
-                             numBitsPerElementB, rewriter, loc);
+                             numBitsUnpackedPerElementB, rewriter, loc);
 
     // Only run mma on one thread. We currently use elect as ptxas is not able
     // to detect that tid.x == 0 is true only for 1 thread.


### PR DESCRIPTION
When we have a lhs of 4bits the K dimension calculated was wrong due to ambiguous meaning of some variable.
