### PR TITLE
Replace Python 3.10+ union type annotation with typing.Union

### DIFF
--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -179,7 +179,7 @@ def tma_skip_msg(byval_only=False):
 requires_tma = pytest.mark.skipif(not supports_tma(), reason=tma_skip_msg())
 
 
-def unwrap_tensor(t: torch.Tensor | triton.runtime.jit.TensorWrapper):
+def unwrap_tensor(t: Union[torch.Tensor, triton.runtime.jit.TensorWrapper]) -> torch.Tensor:
     if isinstance(t, triton.runtime.jit.TensorWrapper):
         return t.base
     return t


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/6217 reintroduced a python 3.10+ type annotation that causes a python 3.9 wheel to break. This PR re-applies https://github.com/triton-lang/triton/pull/6231 to fix the 3.9 wheel by replacing the `|` type annotation with `typing.Union`.