### PR TITLE
[NVWS] Add nvws.warp_group IR

### DIFF
--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSAttrDefs.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSAttrDefs.td
@@ -31,5 +31,6 @@ class NVWS_Attr<string name, list<Trait> traits = [],
 }
 
 def NVWS_TypeArray : ArrayOfAttr<NVWS_Dialect, "TypeArray", "type_array", "Type"> {}
+def NVWS_IntArray : ArrayOfAttr<NVWS_Dialect, "IntArray", "int_array", "int"> {}
 
 #endif

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -141,7 +141,7 @@ def NVWS_WarpGroupOp : NVWS_Op<"warp_group", [
   let description = [{
     Higher level container for Warp Specialization Analysis.
 
-    Contains a variadic number warp groups, a startWarp number, and
+    Contains a variadic number warp groups, with
     the number of warps in each group, plus a region to hold the
     computation for that warp group.
 
@@ -152,9 +152,7 @@ def NVWS_WarpGroupOp : NVWS_Op<"warp_group", [
     before execution.
   }];
 
-  let arguments = (ins
-    I32Attr:$startWarp,
-    NVWS_IntArray:$numWarps);
+  let arguments = (ins DenseI32ArrayAttr:$numWarps);
 
   let regions = (region VariadicRegion<MinSizedRegion<1>>:$partitionRegions);
   let hasVerifier=1;

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -134,4 +134,44 @@ def NVWS_ArefReturnOp: NVWS_Op<"aref.return",
   let hasVerifier = 1;
 }
 
+def NVWS_WarpGroupOp : NVWS_Op<"warp_group", [
+  RecursiveMemoryEffects, RecursivelySpeculatable,
+]> {
+  let summary = "Container Op for Warp Specialization";
+  let description = [{
+    Higher level container for Warp Specialization Analysis.
+
+    Contains a variadic number warp groups, a startWarp number, and
+    the number of warps in each group, plus a region to hold the
+    computation for that warp group.
+
+    Regions are not Isolated from Above to aid in analysis,
+    and take inputs purely by reference.
+
+    nvws.warp_group should be lowered to ttg.warp_specialize
+    before execution.
+  }];
+
+  let arguments = (ins
+    I32Attr:$startWarp,
+    NVWS_IntArray:$numWarps);
+
+  let regions = (region VariadicRegion<MinSizedRegion<1>>:$partitionRegions);
+  let hasVerifier=1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+def NVWS_WarpGroupReturnOp : NVWS_Op<"warp_group.return", [
+  Pure, Terminator, HasParent<"WarpGroupOp">
+]> {
+  let summary = "Terminator for a warp group region";
+  let description = [{
+    Warp groups are expected to return values via referential modification
+    of their inputs. Thus, the warp_group.return op takes no values to
+    return from the warp group.
+  }];
+
+  let assemblyFormat = "attr-dict";
+}
+
 #endif

--- a/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
@@ -1,9 +1,11 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
+#include "triton/Conversion/MLIRTypes.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 
 #define GET_OP_CLASSES
@@ -186,6 +188,58 @@ LogicalResult ArefReturnOp::verify() {
     }
   }
   return success();
+}
+
+LogicalResult WarpGroupOp::verify() {
+  auto numWarps = getNumWarps();
+  auto regions = getRegions();
+  if (numWarps.size() != regions.size())
+    return emitError("Must supply numWarps for each Warp Group");
+  return success();
+}
+
+ParseResult WarpGroupOp::parse(OpAsmParser &p, OperationState &result) {
+  auto ctx = p.getBuilder().getContext();
+
+  int32_t startWarp;
+  SMLoc operandLoc = p.getCurrentLocation();
+  if (p.parseKeyword("start_warp") || p.parseLParen() ||
+      p.parseInteger(startWarp) || p.parseRParen() ||
+      p.parseOptionalAttrDictWithKeyword(result.attributes))
+    return failure();
+
+  result.addAttribute(
+      getStartWarpAttrName(result.name),
+      p.getBuilder().getIntegerAttr(type::i32Ty(ctx), startWarp));
+  SmallVector<int32_t> partitionNumWarps;
+  while (succeeded(p.parseOptionalKeyword(
+      ("partition" + Twine(partitionNumWarps.size()).str())))) {
+    SMLoc regionLoc = p.getCurrentLocation();
+    if (p.parseKeyword("num_warps") || p.parseLParen() ||
+        p.parseInteger(partitionNumWarps.emplace_back()) || p.parseRParen() ||
+        p.parseRegion(*result.addRegion()))
+      return failure();
+  }
+
+  result.addAttribute(getNumWarpsAttrName(result.name),
+                      IntArrayAttr::get(ctx, partitionNumWarps));
+
+  return success();
+}
+
+void WarpGroupOp::print(OpAsmPrinter &p) {
+  p << " start_warp(" << getStartWarp() << ") ";
+  p.printOptionalAttrDictWithKeyword(
+      getOperation()->getAttrs(),
+      {getStartWarpAttrName(), getNumWarpsAttrName()});
+
+  for (auto [i, region, numWarps] :
+       llvm::enumerate(getPartitionRegions(), getNumWarps())) {
+    p.printNewline();
+    p << "partition" << i;
+    p << " num_warps(" << numWarps << ") ";
+    p.printRegion(region, /*printEntryBlockArgs=*/false);
+  }
 }
 
 } // namespace mlir::triton::nvws

--- a/third_party/nvidia/test/NVWS/ops.mlir
+++ b/third_party/nvidia/test/NVWS/ops.mlir
@@ -115,15 +115,15 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
 // CHECK-LABEL: @warp_group_nothing
 tt.func @warp_group_nothing() {
-  // CHECK-NEXT: nvws.warp_group start_warp(0)
-  nvws.warp_group start_warp(0)
+  // CHECK-NEXT: nvws.warp_group
+  nvws.warp_group
   tt.return
 }
 
 // CHECK-LABEL: @warp_1_partition
 tt.func @warp_1_partition() {
-  // CHECK-NEXT: nvws.warp_group start_warp(0)
-  nvws.warp_group start_warp(0)
+  // CHECK-NEXT: nvws.warp_group
+  nvws.warp_group
   // CHECK-NEXT:  num_warps(4) {
   partition0  num_warps(4) {
   // CHECK-NEXT: nvws.warp_group.return
@@ -135,8 +135,8 @@ tt.func @warp_1_partition() {
 
 // CHECK-LABEL: @warp_2_partition
 tt.func @warp_2_partition() {
-  // CHECK-NEXT: nvws.warp_group start_warp(2)
-  nvws.warp_group start_warp(2)
+  // CHECK-NEXT: nvws.warp_group
+  nvws.warp_group
   // CHECK-NEXT: partition0  num_warps(8) {
   partition0  num_warps(8) {
   // CHECK-NEXT: nvws.warp_group.return

--- a/third_party/nvidia/test/NVWS/ops.mlir
+++ b/third_party/nvidia/test/NVWS/ops.mlir
@@ -109,3 +109,45 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     tt.return
   }
 }
+
+// -----
+
+
+// CHECK-LABEL: @warp_group_nothing
+tt.func @warp_group_nothing() {
+  // CHECK-NEXT: nvws.warp_group start_warp(0)
+  nvws.warp_group start_warp(0)
+  tt.return
+}
+
+// CHECK-LABEL: @warp_1_partition
+tt.func @warp_1_partition() {
+  // CHECK-NEXT: nvws.warp_group start_warp(0)
+  nvws.warp_group start_warp(0)
+  // CHECK-NEXT:  num_warps(4) {
+  partition0  num_warps(4) {
+  // CHECK-NEXT: nvws.warp_group.return
+    nvws.warp_group.return
+  // CHECK-NEXT: }
+  }
+  tt.return
+}
+
+// CHECK-LABEL: @warp_2_partition
+tt.func @warp_2_partition() {
+  // CHECK-NEXT: nvws.warp_group start_warp(2)
+  nvws.warp_group start_warp(2)
+  // CHECK-NEXT: partition0  num_warps(8) {
+  partition0  num_warps(8) {
+  // CHECK-NEXT: nvws.warp_group.return
+    nvws.warp_group.return
+  // CHECK-NEXT: }
+  }
+  // CHECK-NEXT: partition1 num_warps(4) {
+  partition1 num_warps(4) {
+  // CHECK-NEXT:   nvws.warp_group.return
+    nvws.warp_group.return
+  // CHECK-NEXT: }
+  }
+  tt.return
+}


### PR DESCRIPTION
This is a fairly simple container op for warp specialization analysis and progressive lowering.

Since it's so simple, the only invalid ir I could come up with were standard parser errors, and it's impossible to hit the the validation error via textual IR, so only valid lit tests this time.
