### PR TITLE
[TritonGPU] Add a separate pass for optimizing partition num warps

### DIFF
--- a/include/triton/Conversion/TritonToTritonGPU/Passes.td
+++ b/include/triton/Conversion/TritonToTritonGPU/Passes.td
@@ -36,7 +36,10 @@ def ConvertTritonToTritonGPU: Pass<"convert-triton-to-tritongpu", "mlir::ModuleO
               "number of ctas in a cga">,
         Option<"target", "target",
               "std::string", /*default*/"\"\"",
-              "the GPU target, e.g., cuda:80, hip:gfx942">
+              "the GPU target, e.g., cuda:80, hip:gfx942">,
+        Option<"enableSourceRemat", "enable-source-remat",
+               "bool", /*default*/"false",
+               "enable trivial source rematerialization">,
    ];
 }
 

--- a/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
+++ b/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
@@ -18,7 +18,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonToTritonGPUPass();
 // Create the pass with numWarps set explicitly.
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertTritonToTritonGPUPass(const std::string &target, int numWarps,
-                                   int threadsPerWarp = 32, int numCTAs = 1);
+                                   int threadsPerWarp = 32, int numCTAs = 1,
+                                   bool enableSourceRemat = false);
 
 } // namespace triton
 } // namespace mlir

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -155,6 +155,9 @@ def TritonGPUPartitionLoops : Pass<"tritongpu-partition-loops", "mlir::ModuleOp"
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];
 }
 
+def TritonGPUOptimizePartitionWarps : Pass<"tritongpu-optimize-partition-warps", "mlir::ModuleOp"> {
+}
+
 def TritonGPULoadMMASpecialization : Pass<"tritongpu-load-mma-specialization", "mlir::ModuleOp"> {
   let summary = "load MMA specialization";
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -156,6 +156,13 @@ def TritonGPUPartitionLoops : Pass<"tritongpu-partition-loops", "mlir::ModuleOp"
 }
 
 def TritonGPUOptimizePartitionWarps : Pass<"tritongpu-optimize-partition-warps", "mlir::ModuleOp"> {
+  let summary = "optimize the number of warps assigned to partitions";
+
+  let description = [{
+    The `tritongpu-optimize-partition-warps` pass will analyze the partitions
+    of `ttg.warp_specialize` ops and attempts to reduce the number of warps
+    assigned to them and optimize the register usage of the partitions.
+  }];
 }
 
 def TritonGPULoadMMASpecialization : Pass<"tritongpu-load-mma-specialization", "mlir::ModuleOp"> {

--- a/include/triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h
@@ -14,7 +14,7 @@ namespace mlir {
 class TritonGPUTypeConverter : public TypeConverter {
 public:
   TritonGPUTypeConverter(MLIRContext *context, int numWarps, int threadsPerWarp,
-                         int numCTAs);
+                         int numCTAs, bool enableSourceRemat);
   int getNumWarps() const { return numWarps; }
   int getThreadsPerWarp() const { return threadsPerWarp; }
   int getNumCTAs() const { return numCTAs; }

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -136,7 +136,6 @@ private:
       uniqueOffsets.insert({offsets[i], i});
     }
 
-    unsigned srcElems = getTotalElemsPerThread(operandType);
     auto *combineOp = &op.getCombineOp();
     auto srcIndices = emitIndices(op.getLoc(), rewriter, targetInfo,
                                   helper.getSrcLayout(), operandType, true);

--- a/lib/Conversion/TritonToTritonGPU/CMakeLists.txt
+++ b/lib/Conversion/TritonToTritonGPU/CMakeLists.txt
@@ -12,5 +12,4 @@ add_triton_library(TritonToTritonGPU
     TritonIR
     ProtonIR
     TritonGPUIR
-    TritonGPUTransforms
 )

--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -9,6 +9,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 using namespace mlir;
 using namespace mlir::triton::gpu;
@@ -98,7 +99,8 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
 
   addDynamicallyLegalDialect<arith::ArithDialect, math::MathDialect,
                              triton::TritonDialect, cf::ControlFlowDialect,
-                             scf::SCFDialect, ub::UBDialect>(
+                             scf::SCFDialect, ub::UBDialect,
+                             triton::nvidia_gpu::TritonNvidiaGPUDialect>(
       [&](Operation *op) {
         bool hasLegalRegions = true;
         for (auto &region : op->getRegions()) {

--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -19,7 +19,8 @@ using namespace mlir::triton::gpu;
 //
 TritonGPUTypeConverter::TritonGPUTypeConverter(MLIRContext *context,
                                                int numWarps, int threadsPerWarp,
-                                               int numCTAs)
+                                               int numCTAs,
+                                               bool enableSourceRemat)
     : context(context), numWarps(numWarps), threadsPerWarp(threadsPerWarp),
       numCTAs(numCTAs) {
   addConversion([](Type type) { return type; });
@@ -56,9 +57,8 @@ TritonGPUTypeConverter::TritonGPUTypeConverter(MLIRContext *context,
   //
   // This will be called when (newArgType != origArgType)
   // This will create newArg, and map(origArg, newArg)
-  addArgumentMaterialization([&](OpBuilder &builder,
-                                 RankedTensorType tensorType, ValueRange inputs,
-                                 Location loc) -> Value {
+  addArgumentMaterialization([](OpBuilder &builder, RankedTensorType tensorType,
+                                ValueRange inputs, Location loc) -> Value {
     llvm_unreachable("Argument rematerialization should not happen in Triton "
                      "-> TritonGPU conversion");
     return {};
@@ -66,18 +66,19 @@ TritonGPUTypeConverter::TritonGPUTypeConverter(MLIRContext *context,
 
   // If the origValue still has live user(s), use this to
   // convert origValue to newValue
-  addSourceMaterialization([&](OpBuilder &builder, RankedTensorType tensorType,
+  addSourceMaterialization([=](OpBuilder &builder, RankedTensorType tensorType,
                                ValueRange inputs, Location loc) -> Value {
-    llvm_unreachable("Source rematerialization should not happen in Triton -> "
-                     "TritonGPU Conversion");
-    return {};
+    assert(enableSourceRemat && "Source rematerialization should not happen in "
+                                "Triton -> TritonGPU Conversion");
+    return builder.create<UnrealizedConversionCastOp>(loc, tensorType, inputs)
+        .getResult(0);
   });
 
   // This will be called when (desiredType != newOperandType)
   // where, desiredType = typeConverter->convertType(origType)
   // NOTE: only for remapped values.
-  addTargetMaterialization([&](OpBuilder &builder, RankedTensorType tensorType,
-                               ValueRange inputs, Location loc) {
+  addTargetMaterialization([](OpBuilder &builder, RankedTensorType tensorType,
+                              ValueRange inputs, Location loc) {
     auto cast =
         builder.create<triton::gpu::ConvertLayoutOp>(loc, tensorType, inputs);
     return cast.getResult();

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -831,11 +831,13 @@ public:
   ConvertTritonToTritonGPU() = default;
   // constructor with some parameters set explicitly.
   ConvertTritonToTritonGPU(const std::string &target, int numWarps,
-                           int threadsPerWarp, int numCTAs) {
+                           int threadsPerWarp, int numCTAs,
+                           bool enableSourceRemat) {
     this->numWarps = numWarps;
     this->threadsPerWarp = threadsPerWarp;
     this->numCTAs = numCTAs;
     this->target = target;
+    this->enableSourceRemat = enableSourceRemat;
   }
 
   void runOnOperation() override {
@@ -850,7 +852,7 @@ public:
     ModuleOp mod = getOperation();
     // type converter
     TritonGPUTypeConverter typeConverter(context, numWarps, threadsPerWarp,
-                                         numCTAs);
+                                         numCTAs, enableSourceRemat);
     TritonGPUConversionTarget target(*context, typeConverter);
     // rewrite patterns
     RewritePatternSet patterns(context);
@@ -889,9 +891,10 @@ std::unique_ptr<OperationPass<ModuleOp>>
 mlir::triton::createConvertTritonToTritonGPUPass(const std::string &target,
                                                  int numWarps,
                                                  int threadsPerWarp,
-                                                 int numCTAs) {
-  return std::make_unique<::ConvertTritonToTritonGPU>(target, numWarps,
-                                                      threadsPerWarp, numCTAs);
+                                                 int numCTAs,
+                                                 bool enableSourceRemat) {
+  return std::make_unique<::ConvertTritonToTritonGPU>(
+      target, numWarps, threadsPerWarp, numCTAs, enableSourceRemat);
 }
 
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -34,6 +34,7 @@ add_triton_library(TritonGPUTransforms
   Utility.cpp
   WarpSpecialization/AutomaticWarpSpecialization.cpp
   WarpSpecialization/LoadMMASpecialization.cpp
+  WarpSpecialization/OptimizePartitionWarps.cpp
   WarpSpecialization/PartitionLoops.cpp
   WarpSpecialization/RewritePartitionDependencies.cpp
 
@@ -47,5 +48,6 @@ add_triton_library(TritonGPUTransforms
   TritonIR
   TritonGPUIR
   TritonNvidiaGPUIR
+  TritonToTritonGPU
   MLIRTransformUtils
 )

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
@@ -51,4 +51,9 @@ void AutomaticWarpSpecialization::runOnOperation() {
   WarpSpecializeOp::getCanonicalizationPatterns(patterns, &getContext());
   if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
     return signalPassFailure();
+
+  pm.clear();
+  pm.addPass(createTritonGPUOptimizePartitionWarps());
+  if (failed(runPipeline(pm, getOperation())))
+    return signalPassFailure();
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -231,7 +231,6 @@ void OptimizePartitionWarps::runOnOperation() {
   ModuleAxisInfoAnalysis axisInfo(getOperation());
   auto runPipelineFn = [&](OpPassManager &pm, ModuleOp container) {
     getOperation().push_back(container);
-    container.dump();
     auto remove = llvm::make_scope_exit([&] { container->remove(); });
     return runPipeline(pm, container);
   };

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -1,0 +1,245 @@
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "triton/Analysis/AxisInfo.h"
+#include "triton/Conversion/TritonToTritonGPU/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "llvm/ADT/ScopeExit.h"
+
+using namespace mlir;
+using namespace triton;
+using namespace triton::gpu;
+
+//===----------------------------------------------------------------------===//
+// relayoutWarps
+//===----------------------------------------------------------------------===//
+
+using RunPipelineFn = function_ref<LogicalResult(OpPassManager &, ModuleOp)>;
+
+// Take the body of a partition into a new `tt.func`. We can use this to run a
+// full compiler pipeline on the partition.
+static OwningOpRef<ModuleOp> takeIntoFunction(ModuleAxisInfoAnalysis &axisInfo,
+                                              Region *partition) {
+  // Forward the module attributes (target, number of threads per warp, etc.)
+  // onto the container module.
+  ModuleOp mod = axisInfo.getModuleOp();
+  OwningOpRef<ModuleOp> container = ModuleOp::create(mod.getLoc());
+  container.get()->setAttrs(mod->getAttrs());
+  Block *containerBlock = container->getBody();
+
+  auto b = OpBuilder::atBlockBegin(containerBlock);
+  FunctionType funcType = b.getFunctionType(partition->getArgumentTypes(), {});
+  auto containerFunc = b.create<FuncOp>(mod.getLoc(), "container", funcType);
+  containerFunc.getBody().takeBody(*partition);
+
+  // Replace `ttg.warp_return` with `tt.return` to make the IR valid.
+  containerFunc.walk([&](WarpReturnOp op) {
+    b.setInsertionPoint(op);
+    b.create<ReturnOp>(op.getLoc());
+    op.erase();
+  });
+
+  // This should make valid IR.
+  if (failed(mlir::verify(*container)))
+    llvm::report_fatal_error("expected partition region to make valid IR");
+
+  // Attach axis info properties.
+  auto wsOp = partition->getParentOfType<WarpSpecializeOp>();
+  auto *funcInfo =
+      axisInfo.getFuncData(wsOp->getParentOfType<FunctionOpInterface>());
+  assert(funcInfo && "expected to find function axis info");
+  for (auto [i, capture] : llvm::enumerate(wsOp.getExplicitCaptures())) {
+    AxisInfo info = funcInfo->lookup(capture);
+    containerFunc.setArgAttr(i, "tt.contiguity",
+                             b.getI64IntegerAttr(info.getContiguity(0)));
+    containerFunc.setArgAttr(i, "tt.divisibility",
+                             b.getI64IntegerAttr(info.getDivisibility(0)));
+    containerFunc.setArgAttr(i, "tt.constancy",
+                             b.getI64IntegerAttr(info.getConstancy(0)));
+  }
+
+  return container;
+}
+
+// Take the partition body out of the container module and function.
+static void extractPartitionBody(OwningOpRef<ModuleOp> container,
+                                 Region *partition) {
+  auto containerFunc = cast<FuncOp>(container->lookupSymbol("container"));
+
+  // Rewrite the returns.
+  containerFunc.walk([](ReturnOp op) {
+    OpBuilder b(op);
+    b.create<WarpReturnOp>(op.getLoc());
+    op.erase();
+  });
+
+  partition->takeBody(containerFunc.getBody());
+}
+
+// Reset the layouts of operations in a region and re-run layout assignment.
+static LogicalResult relayoutWarps(ModuleAxisInfoAnalysis &axisInfo,
+                                   Region *partition, unsigned numWarps,
+                                   RunPipelineFn runPipeline) {
+  OwningOpRef<ModuleOp> container = takeIntoFunction(axisInfo, partition);
+
+  // Start by removing all tensor encodings.
+  mlir::AttrTypeReplacer replacer;
+  replacer.addReplacement([](RankedTensorType ty) {
+    return RankedTensorType::get(ty.getShape(), ty.getElementType());
+  });
+  // But don't remove them from the tensors inside descriptors.
+  replacer.addReplacement([](TensorDescType ty) -> std::pair<Type, WalkResult> {
+    return {ty, WalkResult::skip()};
+  });
+  replacer.recursivelyReplaceElementsIn(*container, /*replaceAttrs=*/false,
+                                        /*replaceLocs=*/false,
+                                        /*replaceTypes=*/true);
+
+  ModuleOp mod = axisInfo.getModuleOp();
+  auto target = mod->getAttrOfType<StringAttr>(AttrTargetName);
+  if (!target)
+    return mlir::emitError(mod.getLoc(), "module missing target specification");
+  int threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(mod);
+  int numCTAs = TritonGPUDialect::getNumCTAs(mod);
+
+  OpPassManager pm;
+  pm.addPass(createConvertTritonToTritonGPUPass(target.str(), numWarps,
+                                                threadsPerWarp, numCTAs));
+  pm.addPass(createTritonGPUCoalesce());
+  pm.addPass(createTritonGPURemoveLayoutConversions());
+  pm.addPass(createTritonGPUOptimizeThreadLocality());
+  pm.addPass(createTritonGPURemoveLayoutConversions());
+  if (failed(runPipeline(pm, *container)))
+    return failure();
+
+  extractPartitionBody(std::move(container), partition);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// optimizePartitionWarps
+//===----------------------------------------------------------------------===//
+
+// Get the number of i32 registers required to store a tensor, assuming no
+// redundancy in the layout.
+static unsigned getTensorNumI32Regs(RankedTensorType ty) {
+  unsigned elSize =
+      isa<PointerType>(ty.getElementType()) ? 64 : ty.getElementTypeBitWidth();
+  return ty.getNumElements() * (elSize / 32);
+}
+
+static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
+                                               WarpSpecializeOp wsOp,
+                                               RunPipelineFn runPipeline) {
+  // For each partition, get the number of i32 registers used by the largest
+  // tensor value.
+  SmallVector<unsigned> maxTensorRegs;
+  for (Region *partition : wsOp.getPartitionRegions()) {
+    unsigned &tensorRegs = maxTensorRegs.emplace_back(0);
+    partition->walk([&](Operation *op) {
+      for (Type type :
+           llvm::concat<Type>(op->getOperandTypes(), op->getResultTypes())) {
+        if (auto tensor = dyn_cast<RankedTensorType>(type))
+          tensorRegs = std::max(tensorRegs, getTensorNumI32Regs(tensor));
+      }
+    });
+    // Assume that the largest tensor accounts for half of the registers used
+    // by a warpgroup.
+    tensorRegs *= 2;
+  }
+
+  // Reduce the number of warps used by partitions. For partitions with no
+  // tensor computations, always reduce them to 1 warp.
+  //
+  // We can't use `nvvm.setmaxnreg` because this requires a known value for
+  // `maxnreg` on the kernel, which is currently controlled by the frontend.
+  // Thus, assume PTXAS will evenly distribute the total pool of registers
+  // across all warps.
+  constexpr unsigned nCustodialRegs = 32;
+  constexpr unsigned nTotalRegs = 65536; // for Blackwell SMs
+  const unsigned threadsPerWarp =
+      TritonGPUDialect::getThreadsPerWarp(axisInfo.getModuleOp());
+
+  SmallVector<int32_t> partitionNumWarps =
+      llvm::to_vector(wsOp.getPartitionNumWarps());
+
+  // Figure out the number of registers per thread and then how many warps each
+  // partition needs. If this reduces the number of warps, it increases the
+  // number of threads per warp, which can further reduce warps, etc. Iterate
+  // until this converges.
+  bool changed;
+  do {
+    changed = false;
+
+    int32_t totalNumWarps =
+        std::accumulate(partitionNumWarps.begin(), partitionNumWarps.end(), 0);
+    // Given the number of remaining registers per thread, figure out how many
+    // warps are needed to capture the tensor regs. Assume each thread uses a
+    // minimum number of registers for other things.
+    unsigned regsPerThread = (nTotalRegs - totalNumWarps * nCustodialRegs) /
+                             totalNumWarps / threadsPerWarp;
+    for (auto [numWarps, tensorRegs] :
+         llvm::zip(partitionNumWarps, maxTensorRegs)) {
+      int32_t nextNumWarps = 1;
+      if (tensorRegs) {
+        unsigned fittedWarps = llvm::PowerOf2Ceil(llvm::divideCeil(
+            llvm::divideCeil(tensorRegs, regsPerThread), threadsPerWarp));
+        // Never increase the number of warps.
+        nextNumWarps = std::min<int32_t>(numWarps, fittedWarps);
+        assert(nextNumWarps > 0);
+      }
+      changed |= (nextNumWarps != numWarps);
+      numWarps = nextNumWarps;
+    }
+  } while (changed);
+
+  for (auto [partition, newNumWarps, prevNumWarps, tensorRegs] :
+       llvm::zip(wsOp.getPartitionRegions(), partitionNumWarps,
+                 wsOp.getPartitionNumWarps(), maxTensorRegs)) {
+    if (newNumWarps == prevNumWarps || !tensorRegs)
+      continue;
+    // We need to reassign layouts.
+    if (failed(relayoutWarps(axisInfo, partition, newNumWarps, runPipeline)))
+      return failure();
+  }
+  wsOp.setPartitionNumWarps(partitionNumWarps);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Definition
+//===----------------------------------------------------------------------===//
+
+namespace mlir::triton::gpu {
+#define GEN_PASS_DEF_TRITONGPUOPTIMIZEPARTITIONWARPS
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+} // namespace mlir::triton::gpu
+
+namespace {
+struct OptimizePartitionWarps
+    : triton::gpu::impl::TritonGPUOptimizePartitionWarpsBase<
+          OptimizePartitionWarps> {
+  using TritonGPUOptimizePartitionWarpsBase::
+      TritonGPUOptimizePartitionWarpsBase;
+
+  void runOnOperation() override;
+};
+} // namespace
+
+void OptimizePartitionWarps::runOnOperation() {
+  ModuleAxisInfoAnalysis axisInfo(getOperation());
+  auto runPipelineFn = [&](OpPassManager &pm, ModuleOp container) {
+    getOperation().push_back(container);
+    container.dump();
+    auto remove = llvm::make_scope_exit([&] { container->remove(); });
+    return runPipeline(pm, container);
+  };
+  WalkResult result = getOperation().walk([&](WarpSpecializeOp wsOp) {
+    if (failed(optimizePartitionNumWarps(axisInfo, wsOp, runPipelineFn)))
+      return WalkResult::interrupt();
+    return WalkResult::skip();
+  });
+  if (result.wasInterrupted())
+    return signalPassFailure();
+}

--- a/test/TritonGPU/automatic-warp-specialization.mlir
+++ b/test/TritonGPU/automatic-warp-specialization.mlir
@@ -1,6 +1,7 @@
 // RUN: triton-opt %s -allow-unregistered-dialect -tritongpu-automatic-warp-specialization                     | FileCheck %s --check-prefix=CHECK --check-prefix=BASE
 // RUN: triton-opt %s -allow-unregistered-dialect -tritongpu-automatic-warp-specialization -tritongpu-pipeline | FileCheck %s --check-prefix=CHECK --check-prefix=PIPELINE
 
+#indices_layout = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #oper_layout = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
@@ -27,13 +28,16 @@ tt.func @matmul_change_desc_in_prologue(
   // BASE-NOT: tt.make_tensor_descriptor
   // PIPELINE-NOT: tt.experimental_tensormap_create
   // CHECK-LABEL: partition0
+  // CHECK-SAME: num_warps(1)
   // BASE-NOT: tt.make_tensor_descriptor
   // PIPELINE-NOT: tt.experimental_tensormap_create
   // CHECK-LABEL: partition1
+  // CHECK-SAME: num_warps(1)
   // BASE-COUNT-2: tt.make_tensor_descriptor
   // PIPELINE-COUNT-2: ttg.global_scratch_alloc {alignment = 128 : i32, nbytes = 512 : i32}
   // PIPELINE-COUNT-2: tt.experimental_tensormap_create
   // CHECK-LABEL: partition2
+  // CHECK-SAME: num_warps(1)
   // BASE-NOT: tt.make_tensor_descriptor
   // PIPELINE-NOT: tt.experimental_tensormap_create
   scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero, %flag = %true, %a_desc = %a_desc_undef, %b_desc = %b_desc_undef) -> (tensor<128x128xf32, #acc_layout>, i1, !tt.tensordesc<tensor<128x64xf16, #shared>>, !tt.tensordesc<tensor<64x128xf16, #shared>>) : i32 {
@@ -64,6 +68,47 @@ tt.func @matmul_change_desc_in_prologue(
     scf.yield %c, %use_acc, %cur_a_desc, %cur_b_desc : tensor<128x128xf32, #acc_layout>, i1, !tt.tensordesc<tensor<128x64xf16, #shared>>, !tt.tensordesc<tensor<64x128xf16, #shared>>
   } {tt.warp_specialize, tt.disallow_acc_multi_buffer, tt.num_stages = 4 : i32}
 
+  tt.return
+}
+
+// CHECK-LABEL: @matmul_tma_acc_with_conditional_def_and_use
+tt.func @matmul_tma_acc_with_conditional_def_and_use(
+  %a_desc: !tt.tensordesc<tensor<1x64xf16, #shared>>,
+  %b_desc: !tt.tensordesc<tensor<64x128xf16, #shared>>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %false = arith.constant false
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #acc_layout>
+  %k_tiles = arith.constant 32 : i32
+  // CHECK-LABEL: ttg.warp_specialize
+  // CHECK-LABEL: default
+  // CHECK-LABEL: partition0
+  // CHECK-SAME: num_warps(1)
+  // CHECK-LABEL: partition1
+  // CHECK-SAME: num_warps(1)
+  // CHECK: [[INDICES:%.*]] = tt.splat %{{.*}} : i32 -> tensor<128xi32,
+  // CHECK: ttng.async_tma_gather %{{.*}}[[[INDICES]],
+  // CHECK-LABEL: partition2
+  // CHECK-SAME: num_warps(1)
+  scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero, %flag = %true) -> (tensor<128x128xf32, #acc_layout>, i1) : i32 {
+    %off_m, %off_n, %off_k = "get_offsets"(%k) : (i32) -> (i32, i32, i32)
+    %indices = tt.splat %off_m : i32 -> tensor<128xi32, #indices_layout>
+    %a = tt.descriptor_gather %a_desc[%indices, %off_k] : (!tt.tensordesc<tensor<1x64xf16, #shared>>, tensor<128xi32, #indices_layout>, i32) -> tensor<128x64xf16, #oper_layout>
+    %b = tt.descriptor_load %b_desc[%off_n, %off_k] : !tt.tensordesc<tensor<64x128xf16, #shared>> -> tensor<64x128xf16, #oper_layout>
+    %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #oper_layout>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+    %c_tmem = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+    ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem, %flag, %true : (!ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, i1, i1) -> ()
+    %c = ttng.tmem_load %c_tmem : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
+    %do_epilogue = "epilogue_cond"(%k) : (i32) -> i1
+    %use_acc = arith.select %do_epilogue, %false, %true : i1
+    scf.if %do_epilogue {
+      "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
+    }
+    scf.yield %c, %use_acc : tensor<128x128xf32, #acc_layout>, i1
+  } {tt.warp_specialize, tt.disallow_acc_multi_buffer, tt.num_stages = 2 : i32}
   tt.return
 }
 

--- a/test/TritonGPU/load-mma-specialization.mlir
+++ b/test/TritonGPU/load-mma-specialization.mlir
@@ -14,6 +14,8 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // AWS-LABEL: @warp_specialize_tma_matmul
 // AWS: ttg.warp_specialize
+// AWS: num_warps(1)
+// AWS: num_warps(1)
 
 // CHECK: @warp_specialize_tma_matmul
 // CHECK-SAME: [[K_TILES:%arg[0-9]+]]
@@ -263,6 +265,9 @@ tt.func @invalid_acc_reset(
 
 // AWS-LABEL: @matmul_tma_acc_with_unconditional_user
 // AWS: ttg.warp_specialize
+// AWS: num_warps(4)
+// AWS: num_warps(4)
+// AWS: num_warps(4)
 
 // CHECK: @matmul_tma_acc_with_unconditional_user
 // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
@@ -380,6 +385,9 @@ tt.func @matmul_tma_acc_with_unconditional_user(
 
 // AWS-LABEL: @matmul_tma_acc_with_conditional_user
 // AWS: ttg.warp_specialize
+// AWS: num_warps(4)
+// AWS: num_warps(4)
+// AWS: num_warps(4)
 
 // CHECK: @matmul_tma_acc_with_conditional_user
 // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
@@ -474,6 +482,9 @@ tt.func @matmul_tma_acc_with_conditional_user(
 
 // AWS-LABEL: @matmul_tma_acc_with_conditional_def
 // AWS: ttg.warp_specialize
+// AWS: num_warps(4)
+// AWS: num_warps(1)
+// AWS: num_warps(1)
 
 // CHECK: @matmul_tma_acc_with_conditional_def
 // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
@@ -566,6 +577,9 @@ tt.func @matmul_tma_acc_with_conditional_def(
 
 // AWS-LABEL: @matmul_tma_acc_with_conditional_def_and_use
 // AWS: ttg.warp_specialize
+// AWS: num_warps(4)
+// AWS: num_warps(1)
+// AWS: num_warps(1)
 
 // CHECK: @matmul_tma_acc_with_conditional_def_and_use
 // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
@@ -661,6 +675,9 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use(
 
 // AWS-LABEL: @matmul_tma_acc_with_conditional_def_and_use_no_multibuf
 // AWS: ttg.warp_specialize
+// AWS: num_warps(1)
+// AWS: num_warps(1)
+// AWS: num_warps(1)
 
 // CHECK: @matmul_tma_acc_with_conditional_def_and_use_no_multibuf
 // CHECK-SAME: [[A_DESC:%arg[0-9]+]]

--- a/test/TritonGPU/optimize-partition-warps.mlir
+++ b/test/TritonGPU/optimize-partition-warps.mlir
@@ -107,7 +107,7 @@ tt.func @fits_after_shrink(%arg0: i32) {
     ttg.local_store %3, %arg2 : tensor<128x64xf16, #blocked2d_8> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
     ttg.warp_return
   }
-  // CHECK: partition0({{.*}}) num_warps(1)
+  // CHECK: partition1({{.*}}) num_warps(1)
   partition1(%arg1: i32, %arg2: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>) num_warps(8) {
     ttg.warp_return
   } : (i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>) -> ()

--- a/test/TritonGPU/optimize-partition-warps.mlir
+++ b/test/TritonGPU/optimize-partition-warps.mlir
@@ -1,0 +1,94 @@
+// RUN: triton-opt %s -allow-unregistered-dialect -tritongpu-optimize-partition-warps | FileCheck %s
+
+#blocked8 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked4_broadcast = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked2d_4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [0, 1]}>
+#blocked2d_8 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
+#bar_layout = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {ttg.target = "cuda:100", "ttg.num-warps" = 8 : i32} {
+
+// CHECK-LABEL: @no_tensor_computations
+tt.func @no_tensor_computations(%arg0: i32) {
+  ttg.warp_specialize(%arg0)
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(1)
+  partition0(%arg1: i32) num_warps(8) {
+    %0 = arith.addi %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  // CHECK: partition1({{.*}}) num_warps(1)
+  partition1(%arg1: i32) num_warps(4) {
+    %0 = arith.subi %arg1, %arg1 : i32
+    ttg.warp_return
+  } : (i32) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @small_tensor_computation
+tt.func @small_tensor_computation(%arg0: i32) {
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+  ttg.warp_specialize(%arg0, %alloc)
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(1)
+  partition0(%arg1: i32, %arg2: !ttg.memdesc<128xi32, #shared, #smem, mutable>) num_warps(8) {
+    %0 = tt.splat %arg1 : i32 -> tensor<128xi32, #blocked8>
+    ttg.local_store %0, %arg2 : tensor<128xi32, #blocked8> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    ttg.warp_return
+  }
+  // CHECK: partition1({{.*}}) num_warps(1)
+  partition1(%arg1: i32, %arg2: !ttg.memdesc<128xi32, #shared, #smem, mutable>) num_warps(4) {
+    %0 = tt.splat %arg1 : i32 -> tensor<128xi32, #blocked4>
+    %1 = ttg.convert_layout %0 : tensor<128xi32, #blocked4> -> tensor<128xi32, #blocked4_broadcast>
+    ttg.local_store %1, %arg2 : tensor<128xi32, #blocked4_broadcast> -> !ttg.memdesc<128xi32, #shared, #smem, mutable>
+    ttg.warp_return
+  } : (i32, !ttg.memdesc<128xi32, #shared, #smem, mutable>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @large_tensor_computation
+tt.func @large_tensor_computation(%arg0: i32) {
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<128x256xf16, #shared, #smem, mutable>
+  ttg.warp_specialize(%arg0, %alloc)
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(8)
+  partition0(%arg1: i32, %arg2: !ttg.memdesc<128x256xf16, #shared, #smem, mutable>) num_warps(8) {
+    %0 = ttg.local_load %arg2 : !ttg.memdesc<128x256xf16, #shared, #smem, mutable> -> tensor<128x256xf16, #blocked2d_8>
+    %1 = arith.extf %0 : tensor<128x256xf16, #blocked2d_8> to tensor<128x256xf32, #blocked2d_8>
+    %2 = arith.addf %1, %1 : tensor<128x256xf32, #blocked2d_8>
+    %3 = arith.truncf %2 : tensor<128x256xf32, #blocked2d_8> to tensor<128x256xf16, #blocked2d_8>
+    ttg.local_store %3, %arg2 : tensor<128x256xf16, #blocked2d_8> -> !ttg.memdesc<128x256xf16, #shared, #smem, mutable>
+    ttg.warp_return
+  } : (i32, !ttg.memdesc<128x256xf16, #shared, #smem, mutable>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @medium_tensor_computation
+tt.func @medium_tensor_computation(%arg0: i32) {
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+  ttg.warp_specialize(%arg0, %alloc)
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0({{.*}}) num_warps(4)
+  partition0(%arg1: i32, %arg2: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>) num_warps(8) {
+    %0 = ttg.local_load %arg2 : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #blocked2d_8>
+    %1 = arith.extf %0 : tensor<128x64xf16, #blocked2d_8> to tensor<128x64xf32, #blocked2d_8>
+    %2 = arith.addf %1, %1 : tensor<128x64xf32, #blocked2d_8>
+    %3 = arith.truncf %2 : tensor<128x64xf32, #blocked2d_8> to tensor<128x64xf16, #blocked2d_8>
+    ttg.local_store %3, %arg2 : tensor<128x64xf16, #blocked2d_8> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    ttg.warp_return
+  } : (i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>) -> ()
+  tt.return
+}
+
+}

--- a/test/TritonGPU/partition-loops.mlir
+++ b/test/TritonGPU/partition-loops.mlir
@@ -44,7 +44,7 @@ tt.func @two_empty_partitions(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT:   }
   // CHECK-NEXT:   warp_yield
   // CHECK-NEXT: }
-  // CHECK-NEXT: partition0(%arg3: i32, %arg4: i32, %arg5: i32) num_warps(1)
+  // CHECK-NEXT: partition0(%arg3: i32, %arg4: i32, %arg5: i32) num_warps(4)
   // CHECK-NEXT:   scf.for [[I:%.*]] = %arg3 to %arg4 step %arg5
   // CHECK-NEXT:     "op_a"([[I]])
   // CHECK-NEXT:   }
@@ -219,7 +219,7 @@ tt.func @trivial_tensor_captures(%arg0: f16, %lb: i32, %ub: i32, %step: i32) {
 tt.func @dce_before_warp_allocation(%lb: i32, %ub: i32, %step: i32) {
   %cst = arith.constant dense<0> : tensor<128xi32, #blocked>
   // CHECK: ttg.warp_specialize
-  // CHECK: partition0({{.*}}) num_warps(1)
+  // CHECK: partition0({{.*}}) num_warps(4)
   // CHECK: partition1({{.*}}) num_warps(4)
   scf.for %i = %lb to %ub step %step iter_args(%idxs = %cst) -> tensor<128xi32, #blocked> : i32 {
     %do_prologue = "prologue_cond"(%i) : (i32) -> i1


### PR DESCRIPTION
PartitionLoops no longer changes the number of warps of the partitions -- they are always left at the default number. A separate pass runs after the important DCE to analyze the IR and determine the number of warps needed. As before, if there are no tensor computations in the partition, the number of warps is set to 1.

However, the pass will now also look at tensor computations and shrink the number of warps. It does this by doing a very rough estimate of the register usage of the partition and comparing it against the pool of available registers given the number of warps. If it can reduce the number of warps, the algorithm iterates to fixed point. This is important, e.g., for TMA gather or scatter ops that can still use tensor ops, but generally small 1D tensors.

This still assumes uniform register allocation per warp. In the future, we can make the pass much more sophisticated by allowing nonuniform register allocation with setmaxnreg.

The PR implements a pretty major hack to relayout IR by wiping them out and rerunning `convert-triton-to-tritongpu` which sadly breaks layering of TTGIR vs TTIR.