### PR TITLE
[CI] Fix Nightly Builds Failing Due to Metadata Validation Issues

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Publish wheels to Azure DevOps
         if: ${{ steps.check-version.outputs.new_commit == 'true' }}
         run: |
-          python3 -m pip install twine
+          python3 -m pip install twine pkginfo --upgrade
           python3 -m twine upload -r Triton-Nightly -u TritonArtifactsSP -p ${{ steps.generate-token.outputs.access_token }} --config-file utils/nightly.pypirc --non-interactive --verbose wheelhouse/*
 
       - name: Azure Logout


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `No ci permissions`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)




The Triton nightly builds have been failing for some time with the error:
InvalidDistribution: Metadata is missing required fields: Name, Version

This appears to be related to a known packaging toolchain issue where outdated pkginfo versions fail to properly validate wheel metadata. A similar case was documented where:

https://github.com/pypa/twine/issues/1059#issuecomment-2003615442

Verification Needed:
While this solution worked in other projects experiencing identical symptoms, I cannot fully verify it for Triton because:

Local LLVM prebuilt downloads are prohibitively slow
My fork lacks CI trigger permissions
Request:
Could the Triton maintainers please:

Review this straightforward dependency update
Trigger test builds to verify nightly pipeline restoration
The nightly builds are critical infrastructure for many users, and this appears to be a low-risk fix addressing a known toolchain compatibility issue.


Thank you for your fantastic work! :)
