### PR TITLE
[Build] Pin cmake < 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Finally, follow the instructions below to install triton from source.
 git clone https://github.com/triton-lang/triton.git
 cd triton
 
-pip install ninja cmake wheel pybind11 # build-time dependencies
+pip install -r python/requirements.txt # build-time dependencies
 pip install -e python
 ```
 
@@ -83,7 +83,7 @@ cd triton
 python -m venv .venv --prompt triton
 source .venv/bin/activate
 
-pip install ninja cmake wheel pybind11 # build-time dependencies
+pip install -r python/requirements.txt # build-time dependencies
 pip install -e python
 ```
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,7 +2,7 @@ ninja
 cmake
 setuptools>=40.8.0
 wheel
-cmake>=3.18
+cmake>=3.18,<4.0
 ninja>=1.11.1
 pybind11>=2.13.1
 lit


### PR DESCRIPTION
CMake was updated to 4.0 yesterday and it's breaking our macos builds:
https://pypi.org/project/cmake/#history