### PR TITLE
[Fix] AST parsing fails for float("inf") and float("-inf") in Triton 3.3.0 due to tuple class introduction

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7332,3 +7332,13 @@ def test_dtype_tensor(device, dtype):
         tensor = tl.zeros((1, ), dtype)
 
     dtype_tensor_kernel[(1, )](dtype)
+
+
+@pytest.mark.interpreter
+def test_float_tuple():
+
+    @triton.jit
+    def _namedtuple_float_tuple_kernel():
+        x, y = float('-inf'), float('inf')  # noqa: F841
+
+    _namedtuple_float_tuple_kernel[(1, )]()

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1211,7 +1211,7 @@ class tuple(base_value):
         def get_type(x):
             if isinstance(x, dtype):
                 return dtype
-            if isinstance(x, int):
+            if isinstance(x, (int, float)):
                 return constexpr
             return x.type
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

In Triton 3.2, the AST parser correctly handles expressions like:
```python
float_minus_inf, float_inf = float("-inf"),  float("inf")
```
However, after the introduction of the tuple class in Triton 3.3.0, these expressions fail to parse correctly. This appears to be a regression in the AST parsing logic.

Expected Behavior:
The parser should continue to support float("inf") and float("-inf") expressions as it did in version 3.2.

Actual Behavior:
In Triton 3.3.0, these expressions cause AST parsing failures.

Proposed Solution:
I've prepared a PR that:

Fixes the AST parsing logic to properly handle these float special cases
Adds regression tests to ensure this functionality remains working in future versions
