### PR TITLE
[AMD][WMMA] Fail in wmma convertor and use linear convertor instead

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
@@ -156,8 +156,11 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   ArrayRef<int64_t> shape = aTensorTy.getShape();
   auto sharedLayout = cast<SwizzledSharedEncodingAttr>(aTensorTy.getEncoding());
   auto order = sharedLayout.getOrder();
-  assert((rank == 2 || order[2] == 0) &&
-         "expect batch to be the slowest dimension");
+
+  // Rely on the linear layout conversion logic in this case, since only slowest
+  // dimension for batch is supported here
+  if (rank != 2 && order.back() != 0)
+    return Value();
 
   auto elemTy = aTensorTy.getElementType();
   int kWidth = encoding.getKWidth();


### PR DESCRIPTION
In the case of batch dimension is not slowest, return empty value and provoke failure. Linear layout convertor should deal with this case.

Fixed: test_core.py::test_dot3d[8-1-64-64-64-32-32-float16-float32]
