### PR TITLE
[TMA] Fix assignment of unswizzled layouts from rank-reducing loads

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
@@ -81,8 +81,12 @@ updateEncodingForShape(Operation *op, gpu::SharedEncodingTrait encoding,
       return swizEnc;
 
     auto rank = tensorType.getRank();
-    SmallVector<unsigned> order(
-        swizEnc.getOrder().drop_front(swizEnc.getOrder().size() - rank));
+    auto oldOrder = swizEnc.getOrder();
+    assert(oldOrder.size() <= rank);
+    SmallVector<unsigned> order;
+    for (int i = 0; i + oldOrder.size() < rank; ++i)
+      order.push_back(rank - i - 1);
+    order.append(oldOrder.begin(), oldOrder.end());
     auto newCtaEnc = updateCTALayoutForShape(ctaLayout, tensorType.getShape());
     return gpu::SwizzledSharedEncodingAttr::get(
         ctx, swizEnc.getVec(), swizEnc.getPerPhase(), swizEnc.getMaxPhase(),


### PR DESCRIPTION
The code was expecting that we needed to rank-reduce the layout, but since we're propagating it backward from the load we're actually increasing the rank of the encoding to match the descriptor rank.