### PR TITLE
[WIP][Backend] Optimize TMA gather and scatter codegen

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -3,7 +3,6 @@
 
 #include <set>
 
-#include "triton/Tools/STLExtras.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -19,6 +18,7 @@
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LinearLayout.h"
+#include "triton/Tools/STLExtras.h"
 #include "triton/Tools/StrUtil.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/ADT/STLExtras.h"

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -1340,9 +1340,10 @@ def TT_DescriptorGatherOp : TT_Op<"descriptor_gather", [MemoryEffects<[MemRead<G
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    // TMA gathers have resstrictions on the minimum size of the gather result.
+    // TMA gathers have restrictions on the minimum size of the gather result.
     // This function verifies the result type.
-    static LogicalResult verifyResultType(Operation *op, mlir::ShapedType type);
+    static LogicalResult verifyResultType(Operation *op, ShapedType resultType,
+                                          RankedTensorType indicesType);
   }];
 }
 
@@ -1360,6 +1361,8 @@ def TT_DescriptorScatterOp : TT_Op<"descriptor_scatter", [
     $desc `[` $x_offsets `,` $y_offset `]` `,` $src
     attr-dict `:` type(operands)
   }];
+
+  let hasVerifier = 1;
 }
 
 def TT_ExperimentalTensormapCreateOp: TT_Op<

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -366,6 +366,8 @@ def TTNG_AsyncTMAScatterOp : TTNG_Op<"async_tma_scatter", [DeclareOpInterfaceMet
     $desc_ptr `[` $x_offsets `,` $y_offset `]` $src
     attr-dict `:` type(operands)
   }];
+
+  let hasVerifier = 1;
 }
 
 def TTNG_TMAStoreWaitOp : TTNG_Op<"async_tma_store_wait"> {

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -436,6 +436,9 @@ public:
     return getBasis(inDim, pos)[getOutDimIndex(outDim)];
   }
 
+  // Get the map of the output dimensions.
+  auto &getOutDims() const { return outDims; }
+
   // These are in minor-to-major order, although if you don't flatten the dims
   // (e.g. by reshaping) then the order doesn't really affect anything.
   auto getInDimNames() const { return llvm::make_first_range(bases); }

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -436,9 +436,6 @@ public:
     return getBasis(inDim, pos)[getOutDimIndex(outDim)];
   }
 
-  // Get the map of the output dimensions.
-  auto &getOutDims() const { return outDims; }
-
   // These are in minor-to-major order, although if you don't flatten the dims
   // (e.g. by reshaping) then the order doesn't really affect anything.
   auto getInDimNames() const { return llvm::make_first_range(bases); }

--- a/include/triton/Tools/STLExtras.h
+++ b/include/triton/Tools/STLExtras.h
@@ -1,0 +1,17 @@
+#ifndef TRITON_TOOLS_STLEXTRAS_H
+#define TRITON_TOOLS_STLEXTRAS_H
+
+#include <tuple>
+
+namespace mlir::triton {
+// Iterate over a parameter pack with an index.
+template <typename F, typename... Args>
+auto for_each_with_index(F f, Args &&...args) {
+  size_t index = 0;
+  return std::make_tuple(([&]() {
+    return f(index++, std::forward<Args>(args));
+  }())...);
+}
+} // namespace mlir::triton
+
+#endif // TRITON_TOOLS_STLEXTRAS_H

--- a/include/triton/Tools/STLExtras.h
+++ b/include/triton/Tools/STLExtras.h
@@ -1,6 +1,7 @@
 #ifndef TRITON_TOOLS_STLEXTRAS_H
 #define TRITON_TOOLS_STLEXTRAS_H
 
+#include <cstddef>
 #include <tuple>
 
 namespace mlir::triton {
@@ -8,9 +9,8 @@ namespace mlir::triton {
 template <typename F, typename... Args>
 auto for_each_with_index(F f, Args &&...args) {
   size_t index = 0;
-  return std::make_tuple(([&]() {
-    return f(index++, std::forward<Args>(args));
-  }())...);
+  return std::make_tuple(
+      ([&]() { return f(index++, std::forward<Args>(args)); }())...);
 }
 } // namespace mlir::triton
 

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1245,67 +1245,82 @@ LogicalResult GatherOp::inferReturnTypes(
 }
 
 // -- DescriptorGatherOp
-LogicalResult DescriptorGatherOp::verifyResultType(Operation *op,
-                                                   mlir::ShapedType type) {
-  if (type.getRank() != 2)
-    return op->emitOpError("result must be a 2D tensor, but got ") << type;
+LogicalResult
+DescriptorGatherOp::verifyResultType(Operation *op, ShapedType resultType,
+                                     RankedTensorType indicesType) {
+  if (indicesType.getRank() != 1)
+    return op->emitOpError("x offsets must be a 1D tensor, but got ")
+           << indicesType;
+  if (resultType.getRank() != 2)
+    return op->emitOpError("result must be a 2D tensor, but got ")
+           << resultType;
 
   // The swizzling of TMA accesses matches that of the MMAv3 shared memory
   // layouts. However, these have minimum size requirements.
   // TODO: We can support smaller gather sizes by padding the `local_alloc` this
   // lowers to to the nearest minimum tile size.
-  if (unsigned rows = type.getShape()[0]; rows < 8) {
+  if (unsigned rows = resultType.getShape()[0]; rows < 8) {
     return op->emitOpError("gather must have at least 8 rows, but got ")
            << rows;
   }
 
-  Type dtype = type.getElementType();
+  Type dtype = resultType.getElementType();
   if (dtype.getIntOrFloatBitWidth() > 32)
     return op->emitOpError("TMA dtype cannot be greater than 32 bits");
 
   unsigned minCols = 32 / dtype.getIntOrFloatBitWidth() * 8;
-  if (unsigned cols = type.getShape()[1]; cols < minCols) {
+  if (unsigned cols = resultType.getShape()[1]; cols < minCols) {
     return op->emitOpError("gather of ")
            << dtype << " must have at least " << minCols << " columns, but got "
            << cols;
+  }
+
+  if (resultType.getShape()[0] != indicesType.getShape()[0]) {
+    return op->emitOpError("result tensor must have as many rows as indices (")
+           << indicesType.getShape()[0] << "), but got " << resultType;
+  }
+
+  return success();
+}
+
+static LogicalResult verifyGatherScatterOp(Operation *op,
+                                           RankedTensorType blockType,
+                                           RankedTensorType resultType,
+                                           RankedTensorType indicesType) {
+  // Gather from `!tt.tensordesc<tensor<1xMxdtype>>`.
+  if (blockType.getRank() != 2) {
+    return op->emitOpError("block must be a 2D tensor, but got ") << blockType;
+  }
+  if (blockType.getShape()[0] != 1) {
+    return op->emitOpError("block must have exactly 1 row, but got ")
+           << blockType;
+  }
+
+  // With x offsets `tensor<Nxinttype>` into `tensor<NxMxdtype>`.
+  if (failed(DescriptorGatherOp::verifyResultType(op, resultType, indicesType)))
+    return failure();
+
+  if (resultType.getShape()[1] != blockType.getShape()[1]) {
+    return op->emitOpError("result tensor number of columns must match block (")
+           << blockType.getShape()[1] << "), but got " << resultType;
+  }
+  if (resultType.getElementType() != blockType.getElementType()) {
+    return op->emitOpError("result tensor element type must match block (")
+           << blockType.getElementType() << "), but got " << resultType;
   }
 
   return success();
 }
 
 LogicalResult DescriptorGatherOp::verify() {
-  RankedTensorType blockType = getDesc().getType().getBlockType();
-  // Gather from `!tt.tensordesc<tensor<1xMxdtype>>`.
-  if (blockType.getRank() != 2)
-    return emitOpError("block must be a 2D tensor, but got ") << blockType;
-  if (blockType.getShape()[0] != 1)
-    return emitOpError("block must have exactly 1 row, but got ") << blockType;
+  return verifyGatherScatterOp(*this, getDesc().getType().getBlockType(),
+                               getResult().getType(), getXOffsets().getType());
+}
 
-  // With x offsets `tensor<Nxinttype>`.
-  RankedTensorType indicesType = getXOffsets().getType();
-  if (indicesType.getRank() != 1)
-    return emitOpError("x offsets must be a 1D tensor, but got ")
-           << indicesType;
-
-  // Into `tensor<NxMxdtype>`.
-  RankedTensorType resultType = getType();
-  if (failed(verifyResultType(*this, resultType)))
-    return failure();
-
-  if (resultType.getShape()[0] != indicesType.getShape()[0]) {
-    return emitOpError("result tensor must have as many rows as indices (")
-           << indicesType.getShape()[0] << "), but got " << resultType;
-  }
-  if (resultType.getShape()[1] != blockType.getShape()[1]) {
-    return emitOpError("result tensor number of columns must match block (")
-           << blockType.getShape()[1] << "), but got " << resultType;
-  }
-  if (resultType.getElementType() != blockType.getElementType()) {
-    return emitOpError("result tensor element type must match block (")
-           << blockType.getElementType() << "), but got " << resultType;
-  }
-
-  return success();
+// -- DescriptorScatterOp --
+LogicalResult DescriptorScatterOp::verify() {
+  return verifyGatherScatterOp(*this, getDesc().getType().getBlockType(),
+                               getSrc().getType(), getXOffsets().getType());
 }
 
 // -- DescriptorLoadOp --

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -244,7 +244,8 @@ LogicalResult AsyncTMAGatherOp::verify() {
   triton::gpu::MemDescType resultType = getResult().getType();
   if (!resultType.getMutableMemory())
     return emitOpError("cannot store into immutable memory");
-  return DescriptorGatherOp::verifyResultType(*this, resultType);
+  return DescriptorGatherOp::verifyResultType(*this, resultType,
+                                              getXOffsets().getType());
 }
 
 void AsyncTMAGatherOp::getEffects(
@@ -259,6 +260,11 @@ void AsyncTMAGatherOp::getEffects(
 }
 
 // -- AsyncTMAScatter --
+LogicalResult AsyncTMAScatterOp::verify() {
+  return DescriptorGatherOp::verifyResultType(*this, getSrc().getType(),
+                                              getXOffsets().getType());
+}
+
 void AsyncTMAScatterOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -185,6 +185,14 @@ LinearLayout identityStandardND(StringAttr inDimName, ArrayRef<unsigned> shape,
   return ret;
 }
 
+LinearLayout createScalarQuotientLayout(int32_t divisor, unsigned dimSize,
+                                        StringAttr inDim, StringAttr outDim) {
+  std::vector<std::vector<int>> bases;
+  for (unsigned x = 1; x < dimSize; x *= 2)
+    bases.push_back({int32_t(x / divisor)});
+  return LinearLayout({{inDim, std::move(bases)}}, outDim);
+}
+
 // Compute the supremum of two lists.
 // If the supremum is not unique, we return the first list first
 // Error out if the supremum does not exist

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -787,12 +787,14 @@ tt.func @tma_special_cases(%arg1: !tt.ptr<i8, 0>) -> (tensor<256x64xf16, #blocke
   ttng.async_tma_copy_global_to_local %arg1[%c0, %c0] %alloc, %barrier, %true : !tt.ptr<i8, 0>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable> -> !ttg.memdesc<256x64xf16, #shared, #ttg.shared_memory, mutable>
   ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
 
+  // CHECK-NEXT: memdesc_subview
   // CHECK-NEXT: ttng.barrier_expect
   // CHECK-NEXT: ttng.async_tma_gather
   // CHECK-NEXT: gpu.barrier
   // CHECK-NEXT: ttng.wait_barrier
+  %view = ttg.memdesc_subview %alloc[%c0, %c0] : !ttg.memdesc<256x64xf16, #shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<32x64xf16, #shared, #ttg.shared_memory, mutable>
   ttng.barrier_expect %barrier, 49152, %true : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
-  ttng.async_tma_gather %arg1[%cx, %c0] %alloc, %barrier, %true : !tt.ptr<i8, 0>, tensor<32xi32>, i32, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<256x64xf16, #shared, #ttg.shared_memory, mutable>, i1
+  ttng.async_tma_gather %arg1[%cx, %c0] %view, %barrier, %true : !tt.ptr<i8, 0>, tensor<32xi32>, i32, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<32x64xf16, #shared, #ttg.shared_memory, mutable>, i1
   ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>
 
   // CHECK-NEXT: gpu.barrier

--- a/test/Conversion/tma_to_llvm.mlir
+++ b/test/Conversion/tma_to_llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --convert-triton-gpu-to-llvm --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | not FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>

--- a/test/Conversion/tma_to_llvm_8_warps.mlir
+++ b/test/Conversion/tma_to_llvm_8_warps.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --convert-triton-gpu-to-llvm --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | not FileCheck %s
 
 #bar_layout = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem_layout = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>

--- a/test/Conversion/tma_to_llvm_8_warps.mlir
+++ b/test/Conversion/tma_to_llvm_8_warps.mlir
@@ -1,0 +1,138 @@
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
+
+#bar_layout = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem_layout = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+
+#blocked_indices_8 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#blocked_indices_4 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @tma_gather_large_tile_complex
+tt.func @tma_gather_large_tile_complex(
+  %arg0: !tt.ptr<i8>,
+  %arg1: !ttg.memdesc<1xi64, #bar_layout, #smem, mutable>,
+  %arg2: tensor<512xi32, #blocked_indices_8>,
+  %arg3: i32,
+  %arg4: !ttg.memdesc<512x512xf32, #smem_layout, #smem, mutable>,
+  %arg5: i1
+) {
+  // CHECK-COUNT-256: cp.async.bulk.tensor
+  ttng.async_tma_gather %arg0[%arg2, %arg3] %arg4, %arg1, %arg5 :
+    !tt.ptr<i8>,
+    tensor<512xi32, #blocked_indices_8>,
+    i32,
+    !ttg.memdesc<1xi64, #bar_layout, #smem, mutable>,
+    !ttg.memdesc<512x512xf32, #smem_layout, #smem, mutable>, i1
+  // CHECK-NEXT: ret void
+  tt.return
+}
+
+tt.func @tma_gather_small_tile_simple(
+  %arg0: !tt.ptr<i8>,
+  %arg1: !ttg.memdesc<1xi64, #bar_layout, #smem, mutable>,
+  %arg2: tensor<64xi32, #blocked_indices_4>,
+  %arg3: i32,
+  %arg4: !ttg.memdesc<64x64xf32, #smem_layout, #smem, mutable>,
+  %arg5: i1
+) {
+  // CHECK: [[TID:%.*]] = tail call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+  // CHECK: [[LANE_ID:%.*]] = and i32 [[TID]], 31
+  // CHECK: [[WARP_ID:%.*]] = tail call i32 @llvm.nvvm.shfl.sync
+
+  // CHECK: [[IDX0:%.*]] = extractvalue {{.*}} 0
+  // CHECK: [[IDX1:%.*]] = extractvalue {{.*}} 1
+  // CHECK: [[IDX2:%.*]] = extractvalue {{.*}} 2
+  // CHECK: [[IDX3:%.*]] = extractvalue {{.*}} 3
+
+  // CHECK: [[ACTIVE_LANE0:%.*]] = and i32 [[WARP_ID]], 7
+  // CHECK: [[WARP_OFFSET:%.*]] = shl i32 [[WARP_ID]], 7
+  // CHECK: [[CLAMP_WARP_OFFSET:%.*]] = and i32 [[WARP_OFFSET]], 896
+  // CHECK: [[PRED0_LANE:%.*]] = icmp eq i32 [[LANE_ID]], [[ACTIVE_LANE0]]
+  // CHECK: [[PRED0:%.*]] = and i1 %5, [[PRED0_LANE]]
+  // CHECK: [[OFFSET_i64:%.*]] = zext nneg i32 [[CLAMP_WARP_OFFSET]]
+  // CHECK: [[PTR:%.*]] = getelementptr {{.*}} [[OFFSET_i64]]
+  // CHECK-NEXT: cp.async.bulk.tensor
+  // CHECK-SAME: (i1 [[PRED0]], ptr addrspace(3) [[PTR]], ptr addrspace(1) %0, i32 %3, i32 [[IDX0]], i32 [[IDX1]], i32 [[IDX2]], i32 [[IDX3]]
+
+  // CHECK: [[ACTIVE_LANE1:%.*]] = or disjoint i32 [[ACTIVE_LANE0]], 8
+  // CHECK: [[OFFSET:%.*]] = or disjoint i32 [[CLAMP_WARP_OFFSET]], 1024
+  // CHECK: [[PRED1_LANE:%.*]] = icmp eq i32 [[LANE_ID]], [[ACTIVE_LANE1]]
+  // CHECK: [[PRED1:%.*]] = and i1 %5, [[PRED1_LANE]]
+  // CHECK: [[OFFSET_i64:%.*]] = zext nneg i32 [[OFFSET]]
+  // CHECK: [[PTR:%.*]] = getelementptr {{.*}} [[OFFSET_i64]]
+  // CHECK-NEXT: cp.async.bulk.tensor
+  // CHECK-SAME: (i1 [[PRED1]], ptr addrspace(3) [[PTR]], ptr addrspace(1) %0, i32 %3, i32 [[IDX0]], i32 [[IDX1]], i32 [[IDX2]], i32 [[IDX3]]
+
+  // CHECK: [[OFFSET:%.*]] = or disjoint i32 [[CLAMP_WARP_OFFSET]], 2048
+  // CHECK: [[Y1:%.*]] = add i32 %3, 32
+  // CHECK: [[OFFSET_i64:%.*]] = zext nneg i32 [[OFFSET]]
+  // CHECK: [[PTR:%.*]] = getelementptr {{.*}} [[OFFSET_i64]]
+  // CHECK-NEXT: cp.async.bulk.tensor
+  // CHECK-SAME: (i1 [[PRED0]], ptr addrspace(3) [[PTR]], ptr addrspace(1) %0, i32 [[Y1]], i32 [[IDX0]], i32 [[IDX1]], i32 [[IDX2]], i32 [[IDX3]]
+
+  // CHECK: [[OFFSET:%.*]] = or disjoint i32 [[CLAMP_WARP_OFFSET]], 3072
+  // CHECK: [[OFFSET_i64:%.*]] = zext nneg i32 [[OFFSET]]
+  // CHECK: [[PTR:%.*]] = getelementptr {{.*}} [[OFFSET_i64]]
+  // CHECK-NEXT: cp.async.bulk.tensor
+  // CHECK-SAME: (i1 [[PRED1]], ptr addrspace(3) [[PTR]], ptr addrspace(1) %0, i32 [[Y1]], i32 [[IDX0]], i32 [[IDX1]], i32 [[IDX2]], i32 [[IDX3]]
+  ttng.async_tma_gather %arg0[%arg2, %arg3] %arg4, %arg1, %arg5 :
+    !tt.ptr<i8>,
+    tensor<64xi32, #blocked_indices_4>,
+    i32,
+    !ttg.memdesc<1xi64, #bar_layout, #smem, mutable>,
+    !ttg.memdesc<64x64xf32, #smem_layout, #smem, mutable>, i1
+
+  // CHECK-NEXT: ret void
+  tt.return
+}
+
+// CHECK-LABEL: @tma_gather_tiny_tile
+tt.func @tma_gather_tiny_tile(
+  %arg0: !tt.ptr<i8>,
+  %arg1: !ttg.memdesc<1xi64, #bar_layout, #smem, mutable>,
+  %arg2: tensor<8xi32, #blocked_indices_4>,
+  %arg3: i32,
+  %arg4: !ttg.memdesc<8x32xf32, #smem_layout, #smem, mutable>,
+  %arg5: i1
+) {
+  // CHECK: [[TID:%.*]] = tail call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+  // CHECK: [[LANE_ID:%.*]] = and i32 [[TID]], 31
+  // CHECK: [[WARP_ID:%.*]] = tail call i32 @llvm.nvvm.shfl.sync
+
+  // Only warps 0 and 1 are active.
+
+  // CHECK: [[WARP_SELECT:%.*]] = and i32 [[WARP_ID]], 6
+  // CHECK: [[WARP_PRED:%.*]] = icmp eq i32 [[WARP_SELECT]], 0
+  // CHECK: [[PRED:%.*]] = and i1 %5, [[WARP_PRED]]
+
+  // CHECK: [[IDX0:%.*]] = extractvalue {{.*}} 0
+  // CHECK: [[IDX1:%.*]] = extractvalue {{.*}} 1
+  // CHECK: [[IDX2:%.*]] = extractvalue {{.*}} 2
+  // CHECK: [[IDX3:%.*]] = extractvalue {{.*}} 3
+
+  // offset = (warpId & 1) * 128
+
+  // CHECK: [[WID_LSB:%.*]] = and i32 [[WARP_ID]], 1
+  // CHECK: [[OFFSET:%.*]] = shl nuw nsw i32 [[WID_LSB]], 7
+
+  // Lane 0 in warp 0 and lane 1 in warp 1 are active.
+
+  // CHECK: [[LANE_PRED:%.*]] = icmp eq i32 [[LANE_ID]], [[WID_LSB]]
+  // CHECK: [[CUR_PRED:%.*]] = and i1 [[LANE_PRED]], [[PRED]]
+
+  // CHECK: [[OFFSET_i64:%.*]] = zext nneg i32 [[OFFSET]]
+  // CHECK: [[PTR:%.*]] = getelementptr {{.*}} [[OFFSET_i64]]
+  // CHECK: (i1 [[CUR_PRED]], ptr addrspace(3) [[PTR]], ptr addrspace(1) %0, i32 %3, i32 [[IDX0]], i32 [[IDX1]], i32 [[IDX2]], i32 [[IDX3]]
+  ttng.async_tma_gather %arg0[%arg2, %arg3] %arg4, %arg1, %arg5 :
+    !tt.ptr<i8>,
+    tensor<8xi32, #blocked_indices_4>,
+    i32,
+    !ttg.memdesc<1xi64, #bar_layout, #smem, mutable>,
+    !ttg.memdesc<8x32xf32, #smem_layout, #smem, mutable>, i1
+  // CHECK-NEXT: ret void
+  tt.return
+}
+
+}

--- a/test/Conversion/triton_to_tritongpu.mlir
+++ b/test/Conversion/triton_to_tritongpu.mlir
@@ -125,12 +125,12 @@ tt.func @gather_op() {
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
 #bar_layout = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
 
-// CHECK: [[SLICE_PARENT:#.*]] = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 2], order = [1, 0]}>
+// CHECK: [[IDX_LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [2], order = [0]}>
 
 // CHECK: @gather4_layout
 tt.func @gather4_layout(%arg0: !tt.tensordesc<tensor<1x128xf32>>, %arg1: i32, %arg2: !tt.ptr<f32>) {
   %cst = arith.constant dense<1> : tensor<32xi32>
-  // CHECK: [[IDX:%.*]] = ttg.convert_layout %cst : tensor<32xi32, #{{.*}}> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = [[SLICE_PARENT]]}>>
+  // CHECK: [[IDX:%.*]] = ttg.convert_layout %cst : tensor<32xi32, #{{.*}}> -> tensor<32xi32, [[IDX_LAYOUT]]>
   %0 = tt.descriptor_gather %arg0[%cst, %arg1] : (!tt.tensordesc<tensor<1x128xf32>>, tensor<32xi32>, i32) -> tensor<32x128xf32>
   %1 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<32x128x!tt.ptr<f32>>
   tt.store %1, %0 : tensor<32x128x!tt.ptr<f32>>
@@ -142,7 +142,7 @@ tt.func @scatter4_layout(%arg0: !tt.tensordesc<tensor<1x128xf32>>, %arg1: i32, %
   %cst = arith.constant dense<1> : tensor<32xi32>
   %0 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<32x128x!tt.ptr<f32>>
   %1 = tt.load %0 : tensor<32x128x!tt.ptr<f32>>
-  // CHECK: [[IDX:%.*]] = ttg.convert_layout %cst : tensor<32xi32, #{{.*}}> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = [[SLICE_PARENT]]}>>
+  // CHECK: [[IDX:%.*]] = ttg.convert_layout %cst : tensor<32xi32, #{{.*}}> -> tensor<32xi32, [[IDX_LAYOUT]]>
   tt.descriptor_scatter %arg0[%cst, %arg1], %1 : !tt.tensordesc<tensor<1x128xf32>>, tensor<32xi32>, i32, tensor<32x128xf32>
   tt.return
 }
@@ -153,7 +153,7 @@ tt.func @async_tma_gather(%desc: !tt.ptr<i8>, %y_offset: i32,
                           %result: !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>,
                           %pred: i1) {
   %x_offsets = arith.constant dense<1> : tensor<32xi32>
-  // CHECK: [[IDX:%.*]] = ttg.convert_layout %cst : tensor<32xi32, #{{.*}}> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = [[SLICE_PARENT]]}>>
+  // CHECK: [[IDX:%.*]] = ttg.convert_layout %cst : tensor<32xi32, #{{.*}}> -> tensor<32xi32, [[IDX_LAYOUT]]>
   ttng.async_tma_gather %desc[%x_offsets, %y_offset] %result, %bar, %pred : !tt.ptr<i8>, tensor<32xi32>, i32, !ttg.memdesc<1xi64, #bar_layout, #ttg.shared_memory, mutable>, !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>, i1
   tt.return
 }
@@ -162,7 +162,7 @@ tt.func @async_tma_gather(%desc: !tt.ptr<i8>, %y_offset: i32,
 tt.func @async_tma_scatter(%desc: !tt.ptr<i8>, %y_offset: i32,
                            %src: !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>) {
   %x_offsets = arith.constant dense<1> : tensor<32xi32>
-  // CHECK: [[IDX:%.*]] = ttg.convert_layout %cst : tensor<32xi32, #{{.*}}> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = [[SLICE_PARENT]]}>>
+  // CHECK: [[IDX:%.*]] = ttg.convert_layout %cst : tensor<32xi32, #{{.*}}> -> tensor<32xi32, [[IDX_LAYOUT]]>
   ttng.async_tma_scatter %desc[%x_offsets, %y_offset] %src : !tt.ptr<i8>, tensor<32xi32>, i32, !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>
   tt.return
 }


### PR DESCRIPTION
This PR reworks the codegen for TMA gather and scatter to reduce register pressure. Because TMA gather/scatter issues a memory transaction for 4 consecutive rows of the result tensor, the indices along the dimension must be consecutive as well. Previously, this was implemented by broadcasting elements of the index tensor across each warp.

This means a `tensor<128xi32>` with 4 warps is using 32 registers per thread, or 128 when compressed into a single warp such as during warp specialization. This PR relaxes the lowering to accept any layout as long as four registers are consecutive per thread, i.e. `sizePerThread=[4]`. This cuts the register usage to 4 per thread for `tensor<128xi32>` (4x redundancy instead of 32x).

Because the threads now have different data, the codegen needs to figure out, given the specific subtile, which lane in that warp actually has the right offsets and dynmically predicate each instruction based on that. 

This PR implements an additional optimization that leverages redundancy in the warp dimension to reduce the number of emitted instructions: instead of being masked out, the redundant warps will issue transactions for other tiles. In other words, we subtile the TMA messages into the zero warp bases.

I also added verifiers for TMA scatter ops.