### PR TITLE
[TUTORIAL] Restore cublas warmup

### DIFF
--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -721,7 +721,7 @@ def bench(K, dtype, reps=10000, warmup_reps=10000):
     b = b.T.contiguous()
 
     if cublas is not None:
-        bench_fn("cublas", reps, 1, cublas_matmul, a, b)
+        bench_fn("cublas", reps, warmup_reps, cublas_matmul, a, b)
     if dtype == torch.float16:
         bench_fn("torch", reps, warmup_reps, torch_matmul, a, b)
     bench_fn("naive", reps, warmup_reps, matmul, a, b.T)


### PR DESCRIPTION
This was accidentally included in #6374, doesn't seem to change the benchmark numbers too much though, ~20 extra tflops for cublas:

```
├─ 1618.721 849.059 cublas [M=8192, N=8192, K=512]
│  └─ nan 849.059 nvjet_qqhsq_256x256_128x4_2x1_2cta_v_bz_TNT
├─ 1512.257 454.417 matmul_kernel [M=8192, N=8192, K=512]
├─ 1814.302 378.765 matmul_kernel_descriptor_persistent [M=8192, N=8192, K=512]
├─ 1896.133 362.419 matmul_kernel_descriptor_persistent_ws [M=8192, N=8192, K=512]
├─ 1829.098 375.701 matmul_kernel_persistent [M=8192, N=8192, K=512]
├─ 1481.243 463.931 matmul_kernel_tma [M=8192, N=8192, K=512]
├─ 1945.690 353.188 matmul_kernel_tma_persistent [M=8192, N=8192, K=512]
├─ 2074.555 331.249 matmul_kernel_tma_persistent_ws [M=8192, N=8192, K=512]
└─ 1161.908 591.436 matmul_kernel_tma_ws [M=8192, N=8192, K=512]
```