### PR TITLE
[TUTORIAL] Deactivate proton before warmup

### DIFF
--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -808,6 +808,7 @@ if __name__ == "__main__":
         validate(8192, 8192, args.K_range[0], dtype)
 
         proton.start("matmul", hook="triton")
+        proton.deactivate()
         for K in range(args.K_range[0], args.K_range[1] + 1, args.K_step):
             bench(K, dtype)
         proton.finalize()


### PR DESCRIPTION
Doesn't seem to make any difference to the performance numbers, but does remove some torch kernels from the trace so that's nice.

```
1658.978 3728.050 ROOT
├─ 1615.049 425.495 cublas [M=8192, N=8192, K=512]
│  └─ nan 425.495 nvjet_qqhsq_256x256_128x4_2x1_2cta_v_bz_TNT
├─ 1506.697 456.093 matmul_kernel [M=8192, N=8192, K=512]
├─ 1827.475 376.035 matmul_kernel_descriptor_persistent [M=8192, N=8192, K=512]
├─ 1905.893 360.563 matmul_kernel_descriptor_persistent_ws [M=8192, N=8192, K=512]
├─ 1831.274 375.255 matmul_kernel_persistent [M=8192, N=8192, K=512]
├─ 1483.875 463.108 matmul_kernel_tma [M=8192, N=8192, K=512]
├─ 1955.301 351.452 matmul_kernel_tma_persistent [M=8192, N=8192, K=512]
├─ 2098.157 327.523 matmul_kernel_tma_persistent_ws [M=8192, N=8192, K=512]
└─ 1159.774 592.524 matmul_kernel_tma_ws [M=8192, N=8192, K=512]
```