### PR TITLE
#6304 Fix setup.py initial max_jobs variable too aggressive

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,7 @@ def setup(app):
     import sphinx
 
     app.connect("autodoc-process-signature", process_sig)
-    max_jobs = os.getenv("MAX_JOBS", str(2 * os.cpu_count()))
+    max_jobs = os.getenv("MAX_JOBS", str(os.cpu_count()))
     print(f"Installing Triton Python package using {max_jobs} threads")
     subprocess.run("pip install -e ../python", shell=True, env=os.environ.copy())
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -458,7 +458,7 @@ class CMakeBuild(build_ext):
         if platform.system() == "Windows":
             cmake_args += [f"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"]
         else:
-            max_jobs = os.getenv("MAX_JOBS", str(2 * os.cpu_count()))
+            max_jobs = os.getenv("MAX_JOBS", str(os.cpu_count()))
             build_args += ['-j' + max_jobs]
 
         if check_env_flag("TRITON_BUILD_WITH_CLANG_LLD"):


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ x] I am not making a trivial change, such as fixing a typo in a comment.

- [ x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

Issue #6304: 
Why:
The initial value of max_jobs in setup.py is set to an overly aggressive value of 2 * os.cpu_count(), which could lead to suboptimal performance or resource contention.

What:
This PR adjusts the max_jobs variable to be based directly on os.cpu_count(), providing a more balanced and appropriate setting.
