### PR TITLE
[NVWS] Add initial version of Aref Lowering

### DIFF
--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -40,7 +40,7 @@ class NVWS_Op<string mnemonic, list<Trait> traits = []> :
 
 def NVWS_ArefCreateOp : NVWS_Op<"aref.create", [
     RangedTypesMatchWith<"input types match Aref output type",
-                        "result", "operands", "::llvm::cast<ArefType>($_self).getBaseType()">]> {
+                        "result", "operands", "::llvm::cast<ArefType>($_self).getBaseType()">, Pure]> {
   let summary = "Create an asynchronous reference.";
   let description = [{
     Create an asynchronous reference.
@@ -56,6 +56,7 @@ def NVWS_ArefCreateOp : NVWS_Op<"aref.create", [
   let results = (outs NVWS_ArefType:$result);
 
   let assemblyFormat = [{$operands attr-dict `:` type($result)}];
+  let hasVerifier = 1;
 }
 
 def NVWS_ArefGetOp : NVWS_Op<"aref.get", []> {

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -67,7 +67,8 @@ def NVWS_ArefGetOp : NVWS_Op<"aref.get", []> {
     If indexes is empty, the op will return the entire underlying value(s).
     If the indexes is size 1, the op will ensure that the underlying
     value is Tensor-Like (i.e, has a shape parameter) with rank at least 1,
-    and index into the first dimension.
+    and index into the first dimension in a circular fashion, by wrapping the
+    index around the boundaries of that dimension.
     Similarly, if indexes is size 2, the op will index into the first 2 dimensions
     etc.
 
@@ -99,7 +100,8 @@ def NVWS_ArefPutOp : NVWS_Op<"aref.put", [SameVariadicOperandSize]> {
     If indexes is empty, the op will return the entire underlying value(s).
     If the indexes is size 1, the op will ensure that the underlying
     value is Tensor-Like (i.e, has a shape parameter) with rank at least 1,
-    and index into the first dimension.
+    and index into the first dimension in a circular fashion, by wrapping the
+    index around the boundaries of that dimension.
     Similarly, if indexes is size 2, the op will index into the first 2 dimensions
     etc.
 

--- a/third_party/nvidia/include/Dialect/NVWS/Transforms/Passes.h
+++ b/third_party/nvidia/include/Dialect/NVWS/Transforms/Passes.h
@@ -30,6 +30,8 @@ namespace mlir {
 
 std::unique_ptr<Pass> createNVWSLowerWarpGroupPass();
 
+std::unique_ptr<Pass> createNVWSLowerArefPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "nvidia/include/Dialect/NVWS/Transforms/Passes.h.inc"

--- a/third_party/nvidia/include/Dialect/NVWS/Transforms/Passes.td
+++ b/third_party/nvidia/include/Dialect/NVWS/Transforms/Passes.td
@@ -45,4 +45,27 @@ def NVWSLowerWarpGroup : Pass<"nvws-lower-warp-group", "mlir::ModuleOp"> {
   ];
 }
 
+def NVWSLowerAref : Pass<"nvws-lower-aref", "mlir::ModuleOp"> {
+  let summary = "Convert nvws.aref.* to ttng.*barrier* ops.";
+
+  let description = [{
+    Convert nvws.aref.* to ttng.*barrier* ops.
+
+    The pass will convert each aref to a matched value and barrier set,
+    and will determined appropriate waits/signalling for values being
+    "empty" or "full" from the use/def chain of aref get/put.
+
+    This lowering may yield non-ideal parallelism in certain cases,
+    which will be optimized by follow up peephole passes.
+  }];
+
+  let constructor = "mlir::createNVWSLowerArefPass()";
+
+  let dependentDialects = [
+    "mlir::triton::nvws::NVWSDialect",
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect"
+  ];
+}
+
 #endif // NVWS_PASSES

--- a/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
@@ -13,6 +13,29 @@
 
 namespace mlir::triton::nvws {
 
+LogicalResult ArefCreateOp::verify() {
+  auto rank = getResult().getType().getNumBatchAxes();
+  if (!rank)
+    return success();
+  for (size_t i = 0, e = *rank; i < e; i++) {
+    SmallVector<int> dims;
+    for (auto operand : getOperands()) {
+      auto type = operand.getType();
+      if (auto mType = dyn_cast<gpu::MemDescType>(type)) {
+        dims.push_back(mType.getShape()[i]);
+      } else if (auto rType = dyn_cast<RankedTensorType>(type)) {
+        dims.push_back(rType.getShape()[i]);
+      } else {
+        return emitError("Aref is sliced, but input type isn't supported.");
+      }
+      if (!llvm::all_equal(dims)) {
+        return emitError("Leading dims of sliced aref inputs don't match.");
+      }
+    }
+  }
+  return success();
+}
+
 template <typename T>
 static std::optional<Twine> verifySlice(T &origType, T &newType, size_t rank) {
   if (!origType || !newType)

--- a/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
@@ -21,8 +21,8 @@ LogicalResult ArefCreateOp::verify() {
     for (auto operand : getOperands()) {
       SmallVector<Operation *> users(operand.user_begin(), operand.user_end());
       if (users.size() != 1)
-        return emitError(
-            "Aref buffer is used elsewhere, Aref cannot garuntee async safety");
+        return emitError("Aref buffer is used elsewhere, Aref cannot guarantee "
+                         "async safety");
       auto type = operand.getType();
       if (auto mType = dyn_cast<gpu::MemDescType>(type)) {
         dims.push_back(mType.getShape()[i]);

--- a/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
@@ -1,7 +1,6 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
-#include "triton/Conversion/MLIRTypes.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
@@ -20,6 +19,10 @@ LogicalResult ArefCreateOp::verify() {
   for (size_t i = 0, e = *rank; i < e; i++) {
     SmallVector<int> dims;
     for (auto operand : getOperands()) {
+      SmallVector<Operation *> users(operand.user_begin(), operand.user_end());
+      if (users.size() != 1)
+        return emitError(
+            "Aref buffer is used elsewhere, Aref cannot garuntee async safety");
       auto type = operand.getType();
       if (auto mType = dyn_cast<gpu::MemDescType>(type)) {
         dims.push_back(mType.getShape()[i]);

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_triton_library(NVWSTransforms
+  LowerAref.cpp
   LowerWarpGroup.cpp
 
   DEPENDS

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2025 NVIDIA Corporation & Affiliates. All rights reserved.
  *
@@ -23,20 +22,25 @@
  */
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/IR/AttrTypeSubElements.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "nvidia/include/Dialect/NVWS/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
 
 #include <memory>
 #include <optional>
@@ -61,11 +65,14 @@ struct ArefUseNode {
   ArefUseNode *parent;
   Operation *op;
   SmallVector<ArefUseNode *> subOps;
+  bool containsAsync = false;
 };
 
 struct ArefValue {
   Value emptyMbars;
+  Value emptyPhase;
   Value fullMbars;
+  Value fullPhase;
   int depth;
 };
 
@@ -75,17 +82,21 @@ struct ArefUseGraph {
   SmallVector<ArefUseNode *> topLevelUses;
 };
 
-static MemDescType getBarrierMemDesc(MLIRContext *ctx,
-                                     PatternRewriter &rewriter,
-                                     llvm::ArrayRef<int64_t> shape) {
+static MemDescType getMemDesc(MLIRContext *ctx, PatternRewriter &rewriter,
+                              llvm::ArrayRef<int64_t> shape, Type intType) {
   Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
   auto barrierCTALayout = CTALayoutAttr::get(
       /*context=*/ctx, /*CTAsPerCGA=*/{1},
       /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
   auto barrierEncoding =
       SwizzledSharedEncodingAttr::get(ctx, 1, 1, 1, {0}, barrierCTALayout);
-  return MemDescType::get(shape, rewriter.getI64Type(), barrierEncoding,
-                          sharedMemorySpace, /*mutableMemory=*/true);
+  return MemDescType::get(shape, intType, barrierEncoding, sharedMemorySpace,
+                          /*mutableMemory=*/true);
+}
+static MemDescType getBarrierMemDesc(MLIRContext *ctx,
+                                     PatternRewriter &rewriter,
+                                     llvm::ArrayRef<int64_t> shape) {
+  return getMemDesc(ctx, rewriter, shape, rewriter.getI64Type());
 }
 
 static Value getBarrierAt(MLIRContext *ctx, Location loc,
@@ -99,12 +110,34 @@ static Value getStageIndex(PatternRewriter &rewriter, Location loc, Value idx,
                            int depth) {
   Value stageIdx = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
   if (depth > 1) {
-    auto stage = rewriter.create<arith::RemSIOp>(
-        loc, idx, rewriter.create<arith::ConstantIntOp>(loc, depth, 32));
+    Value depthVal = rewriter.create<arith::ConstantIntOp>(loc, depth, 32);
+    Value stage = rewriter.create<arith::RemSIOp>(loc, idx, depthVal);
     stageIdx = rewriter.create<arith::IndexCastOp>(
         loc, rewriter.getIntegerType(32), stage);
   }
   return stageIdx;
+}
+
+static Value getPhase(Value k, Value phase, int depth, Location loc,
+                      PatternRewriter &rewriter) {
+  // parity = (k % numStage) % 2 == 0 ? parity : parity ^ 1
+  Value D = rewriter.create<arith::ConstantIntOp>(loc, depth, 32);
+  Value one = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
+  Value two = rewriter.create<arith::ConstantIntOp>(loc, 2, 32);
+  Value kmodD = rewriter.create<arith::RemSIOp>(loc, k, D);
+  Value kmodDmod2 = rewriter.create<arith::RemSIOp>(loc, k, two);
+  Value pred = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::eq, kmodDmod2,
+      rewriter.create<arith::ConstantIntOp>(loc, 0, 32));
+  Value parityXor = rewriter.create<arith::XOrIOp>(loc, phase, one);
+  return rewriter.create<arith::SelectOp>(loc, pred, phase, parityXor);
+}
+
+static Value updatePhaseCalculation(Operation *op, Value tmaIdx, Value phase,
+                                    int depth, PatternRewriter &rewriter) {
+  rewriter.setInsertionPointAfter(op);
+  auto loc = op->getLoc();
+  return getPhase(tmaIdx, phase, depth, loc, rewriter);
 }
 
 class LowerArefCreate : public OpRewritePattern<ArefCreateOp> {
@@ -125,11 +158,16 @@ public:
     auto loc = op.getLoc();
     auto ctx = op.getContext();
     auto uses = op.getResult().getUses();
-    auto rank = op.getResult().getType().getNumBatchAxes();
-    if (rank && *rank > 1)
+    auto numBatches = op.getResult().getType().getNumBatchAxes();
+
+    int rank = 0;
+    if (numBatches)
+      rank = *numBatches;
+    if (rank > 1)
       op.emitError("TODO: Implement multi-axis slicing");
+
     int depth = 1;
-    if (rank) {
+    if (rank == 1) {
       if (auto mType = dyn_cast<MemDescType>(op.getOperand(0).getType()))
         depth = mType.getShape()[0];
       if (auto rType = dyn_cast<RankedTensorType>(op.getOperand(0).getType()))
@@ -146,12 +184,20 @@ public:
     auto barrierType = MemDescType::get(
         SmallVector<int64_t>{depth}, rewriter.getI64Type(), barrierEncoding,
         sharedMemorySpace, /*mutableMemory=*/true);
+    auto phaseType = MemDescType::get(
+        SmallVector<int64_t>{depth}, rewriter.getI32Type(), barrierEncoding,
+        sharedMemorySpace, /*mutableMemory=*/true);
     // Create two mbarriers
     auto emptyMbars = rewriter.create<LocalAllocOp>(loc, barrierType, Value());
     emptyMbars->setAttr("aref_empty_mbarriers", rewriter.getUnitAttr());
-    auto fullMbars = rewriter.create<LocalAllocOp>(loc, barrierType, Value());
+    auto emptyPhases = rewriter.create<LocalAllocOp>(loc, phaseType, Value());
+    emptyMbars->setAttr("aref_empty_phases", rewriter.getUnitAttr());
 
+    auto fullMbars = rewriter.create<LocalAllocOp>(loc, barrierType, Value());
     fullMbars->setAttr("aref_full_mbarriers", rewriter.getUnitAttr());
+    auto fullPhases = rewriter.create<LocalAllocOp>(loc, phaseType, Value());
+    fullPhases->setAttr("aref_full_phases", rewriter.getUnitAttr());
+
     auto lb = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
     auto ub = rewriter.create<arith::ConstantIntOp>(loc, depth, 32);
     auto step = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
@@ -168,6 +214,16 @@ public:
       rewriter.create<InitBarrierOp>(loc, singleBarrier, count);
     }
 
+    for (int i = 0; i < 2; ++i) {
+      auto memDesc = geMemDesc(ctx, rewriter, {1}, rewriter.getI32Type());
+      auto singleBarrier = rewriter.create<triton::gpu::MemDescSubviewOp>(
+          loc, memDesc, i == 0 ? emptyMbars.getResult() : fullMbars.getResult(),
+          SmallVector<Value>{dLoop.getInductionVar()});
+
+      int count = i == 0 ? 0 : 1;
+      rewriter.create<InitBarrierOp>(loc, singleBarrier, count);
+    }
+
     graph.arefs[op] =
         ArefValue{emptyMbars.getResult(), fullMbars.getResult(), depth};
 
@@ -175,9 +231,15 @@ public:
   }
 };
 
-template <int full = 0, typename T>
+template <bool put, bool manualWait = false, typename T>
 LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
                           ArefUseGraph &graph) {
+  // Lowering rules for Put/Get
+  // 1) they wait on empty/full barriers respectively at start
+  // 2) if full/empty barriers are signaled by enclosed ops, they will
+  // have already been lowered, so we can skip arrives. If not, add an arrive
+  // j3) If a Get op encloses a Put op, the get op's empty barrier depends
+  // on the put op's full barrier
   auto ctx = op.getContext();
   auto loc = op.getLoc();
   auto aref = op.getOperand();
@@ -197,14 +259,16 @@ LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
     idx = op.getIndexes()[0];
 
   rewriter.setInsertionPoint(op);
-
   auto stageIdx = getStageIndex(rewriter, loc, idx, depth);
 
-  auto fullBarrier =
-      getBarrierAt(ctx, loc, rewriter, full ? fullMbars : emptyMbars, stageIdx);
-  // wait on full. Use a default phase for now, will rewrite later
-  auto waitOp =
-      rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(loc, fullBarrier, one);
+  auto barrier =
+      getBarrierAt(ctx, loc, rewriter, put ? emptyMbars : fullMbars, stageIdx);
+  auto waitPhase = getPhase(idx, put ? one : zero, depth, loc, rewriter);
+  if constexpr (!manualWait) {
+    // wait on empty/full
+    auto waitOp = rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
+        loc, barrier, waitPhase);
+  }
 
   SmallVector<Value> views;
 
@@ -212,7 +276,6 @@ LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
   if (depth > 1) {
     for (auto value :
          aref.template getDefiningOp<ArefCreateOp>().getOperands()) {
-      llvm::errs() << value << '\n';
       if (auto mType = dyn_cast<MemDescType>(value.getType())) {
         auto shape = mType.getShape();
         SmallVector<int64_t> tensorShape(shape.begin() + 1, shape.end());
@@ -242,15 +305,23 @@ LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
   for (auto [arg, view] : zip(putOpBody->getArguments(), views)) {
     arg.replaceAllUsesWith(view);
   }
+
+  for (auto [ret, val] :
+       llvm::zip(op.getResults(), putOpBody->back().getOperands()))
+    ret.replaceAllUsesWith(val);
+
   for (auto &bodyOp :
        llvm::make_early_inc_range(putOpBody->without_terminator()))
     bodyOp.moveBefore(op);
 
-  // arrive on full mbar. To be rewritten later.
-  auto emptyBarrier = getBarrierAt(ctx, loc, rewriter, emptyMbars, stageIdx);
-  // wait on empty. Use a default phase for now, will rewrite later
-  rewriter.create<triton::nvidia_gpu::ArriveBarrierOp>(
-      loc, full ? emptyBarrier : fullBarrier, 1);
+  if (!graph.nodes[op].containsAsync) {
+    // And a barrier arrive to signal completion of the region if none of the
+    // underlying ops are already async. Phase To be rewritten later.
+    barrier = getBarrierAt(ctx, loc, rewriter, put ? fullMbars : emptyMbars,
+                           stageIdx);
+    // wait on empty. Use a default phase for now, will rewrite later
+    rewriter.create<triton::nvidia_gpu::ArriveBarrierOp>(loc, barrier, 1);
+  }
 
   rewriter.eraseOp(op);
 
@@ -268,7 +339,7 @@ public:
 
   LogicalResult matchAndRewrite(ArefGetOp op,
                                 PatternRewriter &rewriter) const override {
-    return lowerRegion<1, ArefGetOp>(op, rewriter, graph);
+    return lowerRegion<0>(op, rewriter, graph);
   }
 };
 
@@ -283,8 +354,241 @@ public:
 
   LogicalResult matchAndRewrite(ArefPutOp op,
                                 PatternRewriter &rewriter) const override {
+    return lowerRegion<1>(op, rewriter, graph);
+  }
+};
 
-    return lowerRegion<1, ArefPutOp>(op, rewriter, graph);
+class TMAStoreLowering : public OpRewritePattern<DescriptorStoreOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(DescriptorStoreOp op,
+                                PatternRewriter &rewriter) const override {
+    MLIRContext *ctx = op.getContext();
+    Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
+    auto loc = op.getLoc();
+    auto tensorType = op.getSrc().getType();
+    auto order = getOrder(tensorType);
+    auto ctaLayout = getCTALayout(tensorType.getEncoding());
+    auto m = op->getParentOfType<ModuleOp>();
+    auto numWarps =
+        mlir::cast<mlir::IntegerAttr>(m->getAttr("ttg.num-warps")).getInt();
+    Attribute encoding = SwizzledSharedEncodingAttr::get(
+        tensorType.getContext(), 1, 1, 1, order, ctaLayout);
+    if (tensorType.getRank() > 1) {
+      encoding = NVMMASharedEncodingAttr::get(
+          tensorType.getContext(), tensorType.getShape(), order, ctaLayout,
+          tensorType.getElementType(), false);
+    }
+    MemDescType memDescType =
+        MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
+                         encoding, sharedMemorySpace, /*mutableMemory=*/true);
+    Value alloc = rewriter.create<LocalAllocOp>(loc, memDescType, op.getSrc());
+    rewriter.create<triton::nvidia_gpu::FenceAsyncSharedOp>(loc, false);
+    // use id 2 for named barrier
+    auto barId = rewriter.create<arith::ConstantIntOp>(op.getLoc(), 2, 32);
+    auto numThreads =
+        rewriter.create<arith::ConstantIntOp>(op.getLoc(), numWarps * 32, 32);
+    rewriter.create<NVVM::BarrierOp>(op.getLoc(), barId, numThreads);
+    auto tensorOp =
+        dyn_cast<ReinterpretTensorDescOp>(op.getDesc().getDefiningOp());
+    rewriter.create<triton::nvidia_gpu::AsyncTMACopyLocalToGlobalOp>(
+        loc, tensorOp.getRawDesc(), op.getIndices(), alloc);
+    rewriter.create<triton::nvidia_gpu::TMAStoreWaitOp>(loc, 0);
+    // Ensure all threads arrive at this point to avoid race conditions between
+    // two TMA stores in Blackwell tests with sub-tiling enabled. Without this
+    // barrier, TMAStoreWaitOp might be executed by another warp that is
+    // slightly ahead of the warp issuing AsyncTMACopyLocalToGlobal. The barrier
+    // ensures that all warps proceed simultaneously after the data is copied.
+    rewriter.create<NVVM::BarrierOp>(op.getLoc(), barId, numThreads);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+class ParallelizeDescriptorLoad : public OpRewritePattern<DescriptorLoadOp> {
+  ArefUseGraph &graph;
+
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  ParallelizeDescriptorLoad(mlir::MLIRContext *context, ArefUseGraph &graph)
+      : OpRewritePattern<DescriptorLoadOp>(context), graph(graph) {}
+
+  LogicalResult matchAndRewrite(DescriptorLoadOp op,
+                                PatternRewriter &rewriter) const override {
+
+    auto ctx = op.getContext();
+    auto loc = op.getLoc();
+    SmallVector<Operation *> users(op->user_begin(), op->user_end());
+    if (users.size() != 1)
+      return failure();
+    if (!isa<LocalStoreOp>(users[0]))
+      return failure();
+
+    auto putOp = dyn_cast<ArefPutOp>(op->getBlock()->getParentOp());
+    if (!putOp)
+      return failure();
+
+    auto aref = putOp.getOperand();
+    if (!graph.arefs.contains(aref))
+      return failure();
+    auto descOp =
+        dyn_cast<ReinterpretTensorDescOp>(op.getDesc().getDefiningOp());
+    if (!descOp)
+      return failure();
+    auto stageIdx = getStageIndex(rewriter, loc, putOp.getIndexes()[0],
+                                  graph.arefs[aref].depth);
+    auto fullBarrier =
+        getBarrierAt(ctx, loc, rewriter, graph.arefs[aref].fullMbars, stageIdx);
+
+    auto buf = users[0]->getOperand(1);
+    Value pred = rewriter.create<arith::ConstantIntOp>(loc, 1, 1);
+    rewriter.create<triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp>(
+        loc, descOp.getRawDesc(), op.getIndices(), fullBarrier, buf, pred);
+    int sizeInBytes = 0;
+    auto memDesc = cast<MemDescType>(buf.getType());
+    auto bufShape = memDesc.getShape();
+    auto elementType = memDesc.getElementType();
+    SmallVector<int64_t> tensorShape(bufShape.begin() + 1, bufShape.end());
+    sizeInBytes +=
+        product(tensorShape) * elementType.getIntOrFloatBitWidth() / 8;
+
+    rewriter.create<triton::nvidia_gpu::BarrierExpectOp>(loc, fullBarrier,
+                                                         sizeInBytes, pred);
+    graph.nodes[putOp].containsAsync = true;
+
+    rewriter.eraseOp(users[0]);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+class ParallelizeTCGen5MMA : public OpRewritePattern<TCGen5MMAOp> {
+  ArefUseGraph &graph;
+
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  ParallelizeTCGen5MMA(mlir::MLIRContext *context, ArefUseGraph &graph)
+      : OpRewritePattern<TCGen5MMAOp>(context), graph(graph) {}
+
+  LogicalResult matchAndRewrite(TCGen5MMAOp op,
+                                PatternRewriter &rewriter) const override {
+    auto ctx = op.getContext();
+    auto loc = op.getLoc();
+    SmallVector<Operation *> users(op->user_begin(), op->user_end());
+    // if (users.size() != 1)
+    //   return failure();
+    // if (!isa<LocalStoreOp>(users[0]))
+    //   return failure();
+
+    auto putOp = dyn_cast<ArefPutOp>(op->getBlock()->getParentOp());
+    if (!putOp)
+      return failure();
+
+    auto getOp = dyn_cast<ArefGetOp>(putOp->getBlock()->getParentOp());
+    if (!getOp)
+      return failure();
+
+    auto putAref = putOp.getOperand();
+    auto getAref = getOp.getOperand();
+    if (!graph.arefs.contains(putAref) || !graph.arefs.contains(getAref))
+      return failure();
+
+    auto getArefValue = graph.arefs[getAref];
+    auto putArefValue = graph.arefs[putAref];
+
+    if (op.getBarrier())
+      return failure(); // Can't paralleize an already parallel mma
+
+    if (putAref.getType().getBaseType().size() != 1)
+      return failure(
+          "TODO: support putting into more than one tmem_buffer at a time");
+    if (putOp.getRegion().getArguments()[0] != op.getD())
+      return failure("This mma isn't accumulating to the put argument");
+
+    graph.nodes[putOp].containsAsync = true;
+    graph.nodes[getOp].containsAsync = true;
+
+    if (failed(lowerRegion<true, true>(putOp, rewriter, graph)))
+      return failure();
+
+    rewriter.setInsertionPoint(op);
+    auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
+    auto one = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
+
+    auto getBarrier = [&](const ArefValue &aref, const Value &idx,
+                          Value mbars) {
+      auto stageIdx = getStageIndex(rewriter, loc, idx, aref.depth);
+      return getBarrierAt(ctx, loc, rewriter, mbars, stageIdx);
+    };
+
+    // This assumes inputs to an mma are both from a single aref get. Need to
+    // relax that to allow nested aref gets for attention
+    Value getIdx = getArefValue.depth > 1 ? getOp.getIndexes()[0] : zero;
+    auto getEmptyBarrier =
+        getBarrier(getArefValue, getIdx, getArefValue.emptyMbars);
+    op.setBarrier(getEmptyBarrier);
+
+    int loopCarried = -1;
+    if (isa<BlockArgument>(getIdx)) {
+      // the index is a loop carried variable
+      int i = -1;
+      for (auto arg : getIdx.getParentBlock()->getArguments()) {
+        if (arg == getIdx)
+          loopCarried = i;
+        i += 1;
+      }
+    }
+    if (loopCarried < 0)
+      return failure();
+
+    auto mmaFor = dyn_cast<scf::ForOp>(getOp->getParentOp());
+    for (auto user : putAref.getUsers()) {
+      auto tmpOp = dyn_cast<ArefGetOp>(user);
+      if (!tmpOp)
+        continue;
+      for (auto arg : tmpOp.getRegion().getArguments()) {
+        for (auto getArgUser : arg.getUsers()) {
+          if (!isa<TMEMLoadOp>(getArgUser))
+            continue;
+          if (mmaFor) {
+            // Otherwise wait outside the loop.
+            rewriter.setInsertionPoint(mmaFor);
+            Value putIdx =
+                putArefValue.depth > 1
+                    ? putOp.getIndexes()[0]
+                    : rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
+            auto putEmptyBarrier =
+                getBarrier(putArefValue, putIdx, putArefValue.emptyMbars);
+
+            rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
+                loc, putEmptyBarrier,
+                getPhase(putIdx, one, putArefValue.depth, loc, rewriter));
+            rewriter.setInsertionPointAfter(mmaFor);
+
+            Value idx = mmaFor.getResult(loopCarried);
+            Value finalMMABarrier =
+                getBarrier(getArefValue, idx, getArefValue.emptyMbars);
+            Value finalPhase =
+                getPhase(idx, rewriter.create<arith::ConstantIntOp>(loc, 0, 32),
+                         getArefValue.depth, loc, rewriter);
+            rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
+                loc, finalMMABarrier, finalPhase);
+            // signal full.
+            auto putFullBarrier =
+                getBarrier(putArefValue, putIdx, putArefValue.fullMbars);
+            rewriter.create<triton::nvidia_gpu::ArriveBarrierOp>(
+                loc, putFullBarrier, 1);
+          } else {
+            return failure();
+          }
+        }
+      }
+    }
+
+    return success();
   }
 };
 
@@ -337,10 +641,25 @@ public:
     ArefUseGraph graph = analyzeArefUseDef(m);
 
     mlir::RewritePatternSet patterns(context);
-    patterns.add<LowerArefCreate, LowerArefGet, LowerArefPut>(context, graph);
+    patterns
+        .add<LowerArefCreate, ParallelizeDescriptorLoad, ParallelizeTCGen5MMA>(
+            context, graph);
     GreedyRewriteConfig config;
 
     if (applyPatternsGreedily(m, std::move(patterns), config).failed())
+      signalPassFailure();
+
+    OpPassManager pm;
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(mlir::createCSEPass());
+    if (failed(runPipeline(pm, m)))
+      return signalPassFailure();
+
+    mlir::RewritePatternSet patterns2(context);
+    patterns2.add<LowerArefGet, LowerArefPut>(context, graph);
+    GreedyRewriteConfig config2;
+
+    if (applyPatternsGreedily(m, std::move(patterns2), config2).failed())
       signalPassFailure();
   }
 };

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -1,0 +1,352 @@
+
+/*
+ * Copyright (c) 2025 NVIDIA Corporation & Affiliates. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/AttrTypeSubElements.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
+#include "nvidia/include/Dialect/NVWS/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/ADT/STLExtras.h"
+
+#include <memory>
+#include <optional>
+
+#define GEN_PASS_CLASSES
+#include "nvidia/include/Dialect/NVWS/Transforms/Passes.h.inc"
+
+#define DEBUG_TYPE "nvws-lower-aref"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace {
+
+using namespace mlir;
+using namespace triton;
+using namespace triton::gpu;
+using namespace triton::nvidia_gpu;
+using namespace triton::nvws;
+
+struct ArefUseNode {
+  SmallVector<ArefUseNode *> inputs;
+  ArefUseNode *parent;
+  Operation *op;
+  SmallVector<ArefUseNode *> subOps;
+};
+
+struct ArefValue {
+  Value emptyMbars;
+  Value fullMbars;
+  int depth;
+};
+
+struct ArefUseGraph {
+  llvm::MapVector<Operation *, ArefUseNode> nodes;
+  llvm::MapVector<Value, ArefValue> arefs;
+  SmallVector<ArefUseNode *> topLevelUses;
+};
+
+static MemDescType getBarrierMemDesc(MLIRContext *ctx,
+                                     PatternRewriter &rewriter,
+                                     llvm::ArrayRef<int64_t> shape) {
+  Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
+  auto barrierCTALayout = CTALayoutAttr::get(
+      /*context=*/ctx, /*CTAsPerCGA=*/{1},
+      /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
+  auto barrierEncoding =
+      SwizzledSharedEncodingAttr::get(ctx, 1, 1, 1, {0}, barrierCTALayout);
+  return MemDescType::get(shape, rewriter.getI64Type(), barrierEncoding,
+                          sharedMemorySpace, /*mutableMemory=*/true);
+}
+
+static Value getBarrierAt(MLIRContext *ctx, Location loc,
+                          PatternRewriter &rewriter, Value mbars, Value idx) {
+  auto memDesc = getBarrierMemDesc(ctx, rewriter, {1});
+  return rewriter.create<triton::gpu::MemDescSubviewOp>(
+      loc, memDesc, mbars, SmallVector<Value>{idx});
+}
+
+static Value getStageIndex(PatternRewriter &rewriter, Location loc, Value idx,
+                           int depth) {
+  Value stageIdx = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
+  if (depth > 1) {
+    auto stage = rewriter.create<arith::RemSIOp>(
+        loc, idx, rewriter.create<arith::ConstantIntOp>(loc, depth, 32));
+    stageIdx = rewriter.create<arith::IndexCastOp>(
+        loc, rewriter.getIntegerType(32), stage);
+  }
+  return stageIdx;
+}
+
+class LowerArefCreate : public OpRewritePattern<ArefCreateOp> {
+  ArefUseGraph &graph;
+
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LowerArefCreate(mlir::MLIRContext *context, ArefUseGraph &graph)
+      : OpRewritePattern<ArefCreateOp>(context), graph(graph) {}
+
+  LogicalResult matchAndRewrite(ArefCreateOp op,
+                                PatternRewriter &rewriter) const override {
+    if (graph.arefs.contains(op.getResult())) {
+      // We've already added the barriers for this op
+      return failure();
+    }
+    auto loc = op.getLoc();
+    auto ctx = op.getContext();
+    auto uses = op.getResult().getUses();
+    auto rank = op.getResult().getType().getNumBatchAxes();
+    if (rank && *rank > 1)
+      op.emitError("TODO: Implement multi-axis slicing");
+    int depth = 1;
+    if (rank) {
+      if (auto mType = dyn_cast<MemDescType>(op.getOperand(0).getType()))
+        depth = mType.getShape()[0];
+      if (auto rType = dyn_cast<RankedTensorType>(op.getOperand(0).getType()))
+        depth = rType.getShape()[0];
+    }
+
+    rewriter.setInsertionPointAfter(op);
+    Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
+    auto barrierCTALayout = CTALayoutAttr::get(
+        /*context=*/ctx, /*CTAsPerCGA=*/{1},
+        /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
+    auto barrierEncoding =
+        SwizzledSharedEncodingAttr::get(ctx, 1, 1, 1, {0}, barrierCTALayout);
+    auto barrierType = MemDescType::get(
+        SmallVector<int64_t>{depth}, rewriter.getI64Type(), barrierEncoding,
+        sharedMemorySpace, /*mutableMemory=*/true);
+    // Create two mbarriers
+    auto emptyMbars = rewriter.create<LocalAllocOp>(loc, barrierType, Value());
+    emptyMbars->setAttr("aref_empty_mbarriers", rewriter.getUnitAttr());
+    auto fullMbars = rewriter.create<LocalAllocOp>(loc, barrierType, Value());
+
+    fullMbars->setAttr("aref_full_mbarriers", rewriter.getUnitAttr());
+    auto lb = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
+    auto ub = rewriter.create<arith::ConstantIntOp>(loc, depth, 32);
+    auto step = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
+    auto dLoop = rewriter.create<scf::ForOp>(loc, lb, ub, step);
+    rewriter.setInsertionPointToStart(dLoop.getBody());
+
+    for (int i = 0; i < 2; ++i) {
+      auto memDesc = getBarrierMemDesc(ctx, rewriter, {1});
+      auto singleBarrier = rewriter.create<triton::gpu::MemDescSubviewOp>(
+          loc, memDesc, i == 0 ? emptyMbars.getResult() : fullMbars.getResult(),
+          SmallVector<Value>{dLoop.getInductionVar()});
+
+      int count = i == 0 ? 0 : 1;
+      rewriter.create<InitBarrierOp>(loc, singleBarrier, count);
+    }
+
+    graph.arefs[op] =
+        ArefValue{emptyMbars.getResult(), fullMbars.getResult(), depth};
+
+    return success();
+  }
+};
+
+template <int full = 0, typename T>
+LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
+                          ArefUseGraph &graph) {
+  auto ctx = op.getContext();
+  auto loc = op.getLoc();
+  auto aref = op.getOperand();
+  if (!graph.arefs.contains(aref)) {
+    // we don't have barriers yet
+    return failure();
+  }
+  auto emptyMbars = graph.arefs[aref].emptyMbars;
+  auto fullMbars = graph.arefs[aref].fullMbars;
+  auto depth = graph.arefs[aref].depth;
+
+  auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
+  auto one = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
+
+  Value idx = zero;
+  if (depth > 1)
+    idx = op.getIndexes()[0];
+
+  rewriter.setInsertionPoint(op);
+
+  auto stageIdx = getStageIndex(rewriter, loc, idx, depth);
+
+  auto fullBarrier =
+      getBarrierAt(ctx, loc, rewriter, full ? fullMbars : emptyMbars, stageIdx);
+  // wait on full. Use a default phase for now, will rewrite later
+  auto waitOp =
+      rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(loc, fullBarrier, one);
+
+  SmallVector<Value> views;
+
+  // slice aref values
+  if (depth > 1) {
+    for (auto value :
+         aref.template getDefiningOp<ArefCreateOp>().getOperands()) {
+      llvm::errs() << value << '\n';
+      if (auto mType = dyn_cast<MemDescType>(value.getType())) {
+        auto shape = mType.getShape();
+        SmallVector<int64_t> tensorShape(shape.begin() + 1, shape.end());
+        auto memDescTypeNew =
+            MemDescType::get(tensorShape, mType.getElementType(),
+                             mType.getEncoding(), mType.getMemorySpace(), true);
+        SmallVector<Value> offsets(mType.getShape().size(), zero);
+        offsets[0] = stageIdx;
+        Value singleBuffer = rewriter.create<triton::gpu::MemDescSubviewOp>(
+            loc, memDescTypeNew, value, offsets);
+        views.push_back(singleBuffer);
+      } else if (auto rType = dyn_cast<RankedTensorType>(value.getType())) {
+        return op.emitError("FIXME: In-register Tensors not yet supported");
+      } else {
+        return op.emitError("Aref input type not supported for slicing");
+      }
+    }
+  } else {
+    for (auto value : aref.template getDefiningOp<ArefCreateOp>().getOperands())
+      views.push_back(value);
+  }
+
+  auto putOpBody = &op->getRegion(0).front();
+  if (putOpBody->getArguments().size() != views.size()) {
+    return op.emitError("number of views and arguments mismatch.");
+  };
+  for (auto [arg, view] : zip(putOpBody->getArguments(), views)) {
+    arg.replaceAllUsesWith(view);
+  }
+  for (auto &bodyOp :
+       llvm::make_early_inc_range(putOpBody->without_terminator()))
+    bodyOp.moveBefore(op);
+
+  // arrive on full mbar. To be rewritten later.
+  auto emptyBarrier = getBarrierAt(ctx, loc, rewriter, emptyMbars, stageIdx);
+  // wait on empty. Use a default phase for now, will rewrite later
+  rewriter.create<triton::nvidia_gpu::ArriveBarrierOp>(
+      loc, full ? emptyBarrier : fullBarrier, 1);
+
+  rewriter.eraseOp(op);
+
+  return success();
+}
+
+class LowerArefGet : public OpRewritePattern<ArefGetOp> {
+  ArefUseGraph &graph;
+
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LowerArefGet(mlir::MLIRContext *context, ArefUseGraph &graph)
+      : OpRewritePattern<ArefGetOp>(context), graph(graph) {}
+
+  LogicalResult matchAndRewrite(ArefGetOp op,
+                                PatternRewriter &rewriter) const override {
+    return lowerRegion<1, ArefGetOp>(op, rewriter, graph);
+  }
+};
+
+class LowerArefPut : public OpRewritePattern<ArefPutOp> {
+  ArefUseGraph &graph;
+
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LowerArefPut(mlir::MLIRContext *context, ArefUseGraph &graph)
+      : OpRewritePattern<ArefPutOp>(context), graph(graph) {}
+
+  LogicalResult matchAndRewrite(ArefPutOp op,
+                                PatternRewriter &rewriter) const override {
+
+    return lowerRegion<1, ArefPutOp>(op, rewriter, graph);
+  }
+};
+
+static ArefUseGraph analyzeArefUseDef(ModuleOp m) {
+  ArefUseGraph graph;
+  DenseSet<Operation *> seen;
+
+  ArefUseNode *parent = nullptr;
+  std::function<void(Operation * op)> createGraph;
+  // Psuedo recursion to get the dependency graph
+  createGraph = [&](Operation *op) {
+    if (seen.contains(op))
+      return;
+    ArefUseNode node;
+    node.parent = parent;
+    node.op = op;
+    if (isa<ArefCreateOp>(op)) {
+      graph.nodes[op] = node;
+    } else if (auto get = dyn_cast<ArefGetOp>(op)) {
+      graph.nodes[op] = node;
+      auto old_parent = parent;
+      parent = &node;
+      get.getRegion().walk(createGraph);
+      parent = old_parent;
+    } else if (auto put = dyn_cast<ArefPutOp>(op)) {
+      graph.nodes[op] = node;
+      auto old_parent = parent;
+      parent = &graph.nodes[op];
+      put.getRegion().walk(createGraph);
+      parent = old_parent;
+    } else {
+      return;
+    }
+    if (parent)
+      graph.nodes[parent->op].subOps.push_back(&graph.nodes[op]);
+    seen.insert(op);
+  };
+
+  m.walk(createGraph);
+
+  return graph;
+}
+
+class NVWSLowerAref : public NVWSLowerArefBase<NVWSLowerAref> {
+public:
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    mlir::ModuleOp m = getOperation();
+
+    ArefUseGraph graph = analyzeArefUseDef(m);
+
+    mlir::RewritePatternSet patterns(context);
+    patterns.add<LowerArefCreate, LowerArefGet, LowerArefPut>(context, graph);
+    GreedyRewriteConfig config;
+
+    if (applyPatternsGreedily(m, std::move(patterns), config).failed())
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createNVWSLowerArefPass() {
+  return std::make_unique<NVWSLowerAref>();
+}

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -42,7 +42,6 @@
 #include "llvm/ADT/STLExtras.h"
 
 #include <memory>
-#include <optional>
 
 #define GEN_PASS_CLASSES
 #include "nvidia/include/Dialect/NVWS/Transforms/Passes.h.inc"
@@ -95,7 +94,8 @@ static MemDescType getBarrierMemDesc(PatternRewriter &rewriter,
   return getMemDesc(rewriter, shape, rewriter.getI64Type());
 }
 
-static Value getBarrierAt(PatternRewriter &rewriter, Location loc, Value mbars, Value idx) {
+static Value getBarrierAt(PatternRewriter &rewriter, Location loc, Value mbars,
+                          Value idx) {
   auto memDesc = getBarrierMemDesc(rewriter, {1});
   return rewriter.create<triton::gpu::MemDescSubviewOp>(
       loc, memDesc, mbars, SmallVector<Value>{idx});
@@ -113,7 +113,8 @@ static Value getStageIndex(PatternRewriter &rewriter, Location loc, Value idx,
   return stageIdx;
 }
 
-static Value getPhase(PatternRewriter &rewriter, Location loc, Value k, Value phase, int depth) {
+static Value getPhase(PatternRewriter &rewriter, Location loc, Value k,
+                      Value phase, int depth) {
   // parity = (k % numStage) % 2 == 0 ? parity : parity ^ 1
   Value D = rewriter.create<arith::ConstantIntOp>(loc, depth, 32);
   Value one = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
@@ -125,6 +126,32 @@ static Value getPhase(PatternRewriter &rewriter, Location loc, Value k, Value ph
       rewriter.create<arith::ConstantIntOp>(loc, 0, 32));
   Value parityXor = rewriter.create<arith::XOrIOp>(loc, phase, one);
   return rewriter.create<arith::SelectOp>(loc, pred, phase, parityXor);
+}
+
+static Value getBarrier(PatternRewriter &rewriter, Location loc, Value mBars,
+                        Value idx, int depth) {
+  auto stageIdx = getStageIndex(rewriter, loc, idx, depth);
+  return getBarrierAt(rewriter, loc, mBars, stageIdx);
+}
+
+static void waitOnMbar(PatternRewriter &rewriter, Location loc, Value mBars,
+                       Value idx, Value phase0, int depth) {
+  auto ctx = rewriter.getContext();
+  auto barrier = getBarrier(rewriter, loc, mBars, idx, depth);
+  auto waitPhase = getPhase(rewriter, loc, idx, phase0, depth);
+  // wait on empty/full
+  auto waitOp = rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(loc, barrier,
+                                                                   waitPhase);
+}
+
+static void signalArrival(PatternRewriter &rewriter, Location loc, Value mBars,
+                          Value idx, int depth) {
+  // And a barrier arrive to signal completion of the region if none of the
+  // underlying ops are already async.
+  auto stageIdx = getStageIndex(rewriter, loc, idx, depth);
+  auto barrier = getBarrierAt(rewriter, loc, mBars, stageIdx);
+  // wait on empty. Use a default phase for now, will rewrite later
+  rewriter.create<triton::nvidia_gpu::ArriveBarrierOp>(loc, barrier, 1);
 }
 
 class LowerArefCreate : public OpRewritePattern<ArefCreateOp> {
@@ -203,32 +230,7 @@ public:
   }
 };
 
-static void waitOnMbar(PatternRewriter &rewriter, Location loc, Value mBars, Value idx, Value phase0, int depth) {
-  auto ctx = rewriter.getContext();
-  auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
-  auto one = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
-
-  auto stageIdx = getStageIndex(rewriter, loc, idx, depth);
-
-  auto barrier =
-      getBarrierAt(rewriter, loc, mBars, stageIdx);
-  auto waitPhase = getPhase(rewriter, loc, idx, phase0, depth);
-  // wait on empty/full
-  auto waitOp = rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
-      loc, barrier, waitPhase);
-}
-
-static void signalArrival(PatternRewriter& rewriter, Location loc, Value mBars, Value idx, int depth) {
-    // And a barrier arrive to signal completion of the region if none of the
-    // underlying ops are already async.
-    auto stageIdx = getStageIndex(rewriter, loc, idx, depth);
-    auto barrier = getBarrierAt(rewriter, loc, mBars,
-                           stageIdx);
-    // wait on empty. Use a default phase for now, will rewrite later
-    rewriter.create<triton::nvidia_gpu::ArriveBarrierOp>(loc, barrier, 1);
-}
-
-template <bool put, bool manualWait = false, typename T>
+template <bool put, typename T>
 LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
                           ArefUseGraph &graph) {
   // Lowering rules for Put/Get
@@ -256,8 +258,8 @@ LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
 
   auto stageIdx = getStageIndex(rewriter, loc, idx, depth);
 
-  if constexpr (!manualWait)
-    waitOnMbar(rewriter, loc, put ? emptyMbars : fullMbars, idx, put ? one : zero, depth);
+  waitOnMbar(rewriter, loc, put ? emptyMbars : fullMbars, idx, put ? one : zero,
+             depth);
 
   SmallVector<Value> views;
 
@@ -291,10 +293,8 @@ LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
   if (putOpBody->getArguments().size() != views.size())
     return op.emitError("number of views and arguments mismatch.");
 
-
   for (auto [arg, view] : zip(putOpBody->getArguments(), views))
     arg.replaceAllUsesWith(view);
-
 
   for (auto [ret, val] :
        llvm::zip(op.getResults(), putOpBody->back().getOperands()))
@@ -422,10 +422,10 @@ public:
         dyn_cast<ReinterpretTensorDescOp>(op.getDesc().getDefiningOp());
     if (!descOp)
       return failure();
-    auto stageIdx = getStageIndex(rewriter, loc, putOp.getIndexes()[0],
-                                  graph.arefs[aref].depth);
+
     auto fullBarrier =
-        getBarrierAt(ctx, loc, rewriter, graph.arefs[aref].fullMbars, stageIdx);
+        getBarrier(rewriter, loc, graph.arefs[aref].fullMbars,
+                   putOp.getIndexes()[0], graph.arefs[aref].depth);
 
     auto buf = users[0]->getOperand(1);
     Value pred = rewriter.create<arith::ConstantIntOp>(loc, 1, 1);
@@ -491,84 +491,51 @@ public:
     if (putOp.getRegion().getArguments()[0] != op.getD())
       return failure("This mma isn't accumulating to the put argument");
 
-    graph.nodes[putOp].containsAsync = true;
-    graph.nodes[getOp].containsAsync = true;
-
     rewriter.setInsertionPoint(op);
-    auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
-    auto one = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
-
-    auto getBarrier = [&](const ArefValue &aref, const Value &idx,
-                          Value mbars) {
-      auto stageIdx = getStageIndex(rewriter, loc, idx, aref.depth);
-      return getBarrierAt(ctx, loc, rewriter, mbars, stageIdx);
-    };
 
     // This assumes inputs to an mma are both from a single aref get. Need to
     // relax that to allow nested aref gets for attention
-    Value getIdx = getArefValue.depth > 1 ? getOp.getIndexes()[0] : zero;
-    auto getEmptyBarrier =
-        getBarrier(getArefValue, getIdx, getArefValue.emptyMbars);
+    Value getIdx = getArefValue.depth > 1
+                       ? getOp.getIndexes()[0]
+                       : rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
+    auto getEmptyBarrier = getBarrier(rewriter, loc, getArefValue.emptyMbars,
+                                      getIdx, getArefValue.depth);
     op.setBarrier(getEmptyBarrier);
 
+    // Lowering the Put op will tell the get op that reads the mma accumulator
+    // to that the mma loop is done, but we need to wait on the last mma
+    // operation inside the get.
     if (putArefValue.depth == 1) {
-      // not peristent
+      // not peristent, wait immediately after k loop
       rewriter.setInsertionPointAfter(kLoop);
-      // TODO: relax the assumption about which position the loop-carried iteration count is in
+      // TODO: relax the assumption about which position the loop-carried
+      // iteration count is in
       Value idx = kLoop.getResult(0);
-      Value finalMMABarrier =
-          getBarrier(getArefValue, idx, getArefValue.emptyMbars);
-      Value finalPhase =
-          getPhase(idx, rewriter.create<arith::ConstantIntOp>(loc, 0, 32),
-                   getArefValue.depth, loc, rewriter);
-      rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
-          loc, finalMMABarrier, finalPhase);
-
-
+      waitOnMbar(rewriter, loc, getArefValue.emptyMbars,
+                 rewriter.create<arith::ConstantIntOp>(loc, 0, 32), idx,
+                 getArefValue.depth);
     } else {
-      // persistent. This should be cleaner, need to leverage the graph
-      ArefGetOp arefOp;
-      TMEMLoadOp load;
-      auto findLoad = [&]() -> TMEMLoadOp {
-        if (!arefOp)
-          return nullptr;
-        for (auto arg : arefOp.getRegion().getArguments()) {
-          for (auto getArgUser : arg.getUsers()) {
-            load = dyn_cast<TMEMLoadOp>(getArgUser);
-            if (load)
-              return load;
-          }
-        }
-        return nullptr;
-      };
-
-      for (auto user : putAref.getUsers()) {
-        arefOp = dyn_cast<ArefGetOp>(user);
-        if (!arefOp)
+      // persistent.
+      for (auto user : putArefValue.users) {
+        auto mmaGetOp = dyn_cast<ArefGetOp>(user->op);
+        if (!mmaGetOp)
           continue;
-        load = findLoad();
-        if (load)
-          break;
+        rewriter.setInsertionPoint(&mmaGetOp.getRegion().front().front());
+        // Get should be inside of a for loop
+        auto forOp = dyn_cast<scf::ForOp>(mmaGetOp->getBlock()->getParentOp());
+        if (!forOp)
+          return failure();
+        // TODO: relax the assumption about which position the loop-carried
+        // iteration count is in
+        Value idx = forOp.getOperand(1);
+        waitOnMbar(rewriter, loc, getArefValue.emptyMbars,
+                   rewriter.create<arith::ConstantIntOp>(loc, 0, 32), idx,
+                   getArefValue.depth);
       }
-
-      if (load)
-        rewriter.setInsertionPoint(load);
-      else
-        return failure();
-
-      auto forOp = dyn_cast<scf::ForOp>(arefOp->getBlock()->getParentOp());
-      if (!forOp)
-        return failure();
-      // TODO: relax the assumption about which position the loop-carried iteration count is in
-      Value idx = forOp.getOperand(1);
-      Value finalMMABarrier =
-          getBarrier(getArefValue, idx, getArefValue.emptyMbars);
-      Value finalPhase =
-          getPhase(idx, rewriter.create<arith::ConstantIntOp>(loc, 0, 32),
-                   getArefValue.depth, loc, rewriter);
-      rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
-          loc, finalMMABarrier, finalPhase);
     }
+    // Since we are signalling the inputs to the mma are done with the mma
+    // barrier, we don't need to add an arrival when lowering the get.
+    graph.nodes[getOp].containsAsync = true;
 
     return success();
   }

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -70,9 +70,7 @@ struct ArefUseNode {
 
 struct ArefValue {
   Value emptyMbars;
-  Value emptyPhase;
   Value fullMbars;
-  Value fullPhase;
   int depth;
 };
 
@@ -184,19 +182,12 @@ public:
     auto barrierType = MemDescType::get(
         SmallVector<int64_t>{depth}, rewriter.getI64Type(), barrierEncoding,
         sharedMemorySpace, /*mutableMemory=*/true);
-    auto phaseType = MemDescType::get(
-        SmallVector<int64_t>{depth}, rewriter.getI32Type(), barrierEncoding,
-        sharedMemorySpace, /*mutableMemory=*/true);
     // Create two mbarriers
     auto emptyMbars = rewriter.create<LocalAllocOp>(loc, barrierType, Value());
     emptyMbars->setAttr("aref_empty_mbarriers", rewriter.getUnitAttr());
-    auto emptyPhases = rewriter.create<LocalAllocOp>(loc, phaseType, Value());
-    emptyMbars->setAttr("aref_empty_phases", rewriter.getUnitAttr());
 
     auto fullMbars = rewriter.create<LocalAllocOp>(loc, barrierType, Value());
     fullMbars->setAttr("aref_full_mbarriers", rewriter.getUnitAttr());
-    auto fullPhases = rewriter.create<LocalAllocOp>(loc, phaseType, Value());
-    fullPhases->setAttr("aref_full_phases", rewriter.getUnitAttr());
 
     auto lb = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
     auto ub = rewriter.create<arith::ConstantIntOp>(loc, depth, 32);
@@ -206,16 +197,6 @@ public:
 
     for (int i = 0; i < 2; ++i) {
       auto memDesc = getBarrierMemDesc(ctx, rewriter, {1});
-      auto singleBarrier = rewriter.create<triton::gpu::MemDescSubviewOp>(
-          loc, memDesc, i == 0 ? emptyMbars.getResult() : fullMbars.getResult(),
-          SmallVector<Value>{dLoop.getInductionVar()});
-
-      int count = i == 0 ? 0 : 1;
-      rewriter.create<InitBarrierOp>(loc, singleBarrier, count);
-    }
-
-    for (int i = 0; i < 2; ++i) {
-      auto memDesc = geMemDesc(ctx, rewriter, {1}, rewriter.getI32Type());
       auto singleBarrier = rewriter.create<triton::gpu::MemDescSubviewOp>(
           loc, memDesc, i == 0 ? emptyMbars.getResult() : fullMbars.getResult(),
           SmallVector<Value>{dLoop.getInductionVar()});
@@ -478,17 +459,13 @@ public:
     auto ctx = op.getContext();
     auto loc = op.getLoc();
     SmallVector<Operation *> users(op->user_begin(), op->user_end());
-    // if (users.size() != 1)
-    //   return failure();
-    // if (!isa<LocalStoreOp>(users[0]))
-    //   return failure();
 
-    auto putOp = dyn_cast<ArefPutOp>(op->getBlock()->getParentOp());
-    if (!putOp)
+    auto getOp = dyn_cast<ArefGetOp>(op->getBlock()->getParentOp());
+    if (!getOp)
       return failure();
 
-    auto getOp = dyn_cast<ArefGetOp>(putOp->getBlock()->getParentOp());
-    if (!getOp)
+    auto putOp = dyn_cast<ArefPutOp>(getOp->getBlock()->getParentOp());
+    if (!putOp)
       return failure();
 
     auto putAref = putOp.getOperand();
@@ -511,7 +488,7 @@ public:
     graph.nodes[putOp].containsAsync = true;
     graph.nodes[getOp].containsAsync = true;
 
-    if (failed(lowerRegion<true, true>(putOp, rewriter, graph)))
+    if (failed(lowerRegion<true, true>(getOp, rewriter, graph)))
       return failure();
 
     rewriter.setInsertionPoint(op);
@@ -530,19 +507,6 @@ public:
     auto getEmptyBarrier =
         getBarrier(getArefValue, getIdx, getArefValue.emptyMbars);
     op.setBarrier(getEmptyBarrier);
-
-    int loopCarried = -1;
-    if (isa<BlockArgument>(getIdx)) {
-      // the index is a loop carried variable
-      int i = -1;
-      for (auto arg : getIdx.getParentBlock()->getArguments()) {
-        if (arg == getIdx)
-          loopCarried = i;
-        i += 1;
-      }
-    }
-    if (loopCarried < 0)
-      return failure();
 
     auto mmaFor = dyn_cast<scf::ForOp>(getOp->getParentOp());
     for (auto user : putAref.getUsers()) {

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -40,7 +40,6 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/Sequence.h"
 
 #include <memory>
 #include <optional>
@@ -61,7 +60,6 @@ using namespace triton::nvidia_gpu;
 using namespace triton::nvws;
 
 struct ArefUseNode {
-  SmallVector<ArefUseNode *> inputs;
   ArefUseNode *parent;
   Operation *op;
   SmallVector<ArefUseNode *> subOps;
@@ -72,16 +70,17 @@ struct ArefValue {
   Value emptyMbars;
   Value fullMbars;
   int depth;
+  SmallVector<ArefUseNode *> users;
 };
 
 struct ArefUseGraph {
   llvm::MapVector<Operation *, ArefUseNode> nodes;
   llvm::MapVector<Value, ArefValue> arefs;
-  SmallVector<ArefUseNode *> topLevelUses;
 };
 
-static MemDescType getMemDesc(MLIRContext *ctx, PatternRewriter &rewriter,
+static MemDescType getMemDesc(PatternRewriter &rewriter,
                               llvm::ArrayRef<int64_t> shape, Type intType) {
+  auto ctx = rewriter.getContext();
   Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
   auto barrierCTALayout = CTALayoutAttr::get(
       /*context=*/ctx, /*CTAsPerCGA=*/{1},
@@ -91,15 +90,13 @@ static MemDescType getMemDesc(MLIRContext *ctx, PatternRewriter &rewriter,
   return MemDescType::get(shape, intType, barrierEncoding, sharedMemorySpace,
                           /*mutableMemory=*/true);
 }
-static MemDescType getBarrierMemDesc(MLIRContext *ctx,
-                                     PatternRewriter &rewriter,
+static MemDescType getBarrierMemDesc(PatternRewriter &rewriter,
                                      llvm::ArrayRef<int64_t> shape) {
-  return getMemDesc(ctx, rewriter, shape, rewriter.getI64Type());
+  return getMemDesc(rewriter, shape, rewriter.getI64Type());
 }
 
-static Value getBarrierAt(MLIRContext *ctx, Location loc,
-                          PatternRewriter &rewriter, Value mbars, Value idx) {
-  auto memDesc = getBarrierMemDesc(ctx, rewriter, {1});
+static Value getBarrierAt(PatternRewriter &rewriter, Location loc, Value mbars, Value idx) {
+  auto memDesc = getBarrierMemDesc(rewriter, {1});
   return rewriter.create<triton::gpu::MemDescSubviewOp>(
       loc, memDesc, mbars, SmallVector<Value>{idx});
 }
@@ -116,8 +113,7 @@ static Value getStageIndex(PatternRewriter &rewriter, Location loc, Value idx,
   return stageIdx;
 }
 
-static Value getPhase(Value k, Value phase, int depth, Location loc,
-                      PatternRewriter &rewriter) {
+static Value getPhase(PatternRewriter &rewriter, Location loc, Value k, Value phase, int depth) {
   // parity = (k % numStage) % 2 == 0 ? parity : parity ^ 1
   Value D = rewriter.create<arith::ConstantIntOp>(loc, depth, 32);
   Value one = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
@@ -129,13 +125,6 @@ static Value getPhase(Value k, Value phase, int depth, Location loc,
       rewriter.create<arith::ConstantIntOp>(loc, 0, 32));
   Value parityXor = rewriter.create<arith::XOrIOp>(loc, phase, one);
   return rewriter.create<arith::SelectOp>(loc, pred, phase, parityXor);
-}
-
-static Value updatePhaseCalculation(Operation *op, Value tmaIdx, Value phase,
-                                    int depth, PatternRewriter &rewriter) {
-  rewriter.setInsertionPointAfter(op);
-  auto loc = op->getLoc();
-  return getPhase(tmaIdx, phase, depth, loc, rewriter);
 }
 
 class LowerArefCreate : public OpRewritePattern<ArefCreateOp> {
@@ -196,7 +185,7 @@ public:
     rewriter.setInsertionPointToStart(dLoop.getBody());
 
     for (int i = 0; i < 2; ++i) {
-      auto memDesc = getBarrierMemDesc(ctx, rewriter, {1});
+      auto memDesc = getBarrierMemDesc(rewriter, {1});
       auto singleBarrier = rewriter.create<triton::gpu::MemDescSubviewOp>(
           loc, memDesc, i == 0 ? emptyMbars.getResult() : fullMbars.getResult(),
           SmallVector<Value>{dLoop.getInductionVar()});
@@ -207,10 +196,37 @@ public:
 
     graph.arefs[op] =
         ArefValue{emptyMbars.getResult(), fullMbars.getResult(), depth};
+    for (auto user : op.getResult().getUsers())
+      graph.arefs[op].users.push_back(&graph.nodes[user]);
 
     return success();
   }
 };
+
+static void waitOnMbar(PatternRewriter &rewriter, Location loc, Value mBars, Value idx, Value phase0, int depth) {
+  auto ctx = rewriter.getContext();
+  auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
+  auto one = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
+
+  auto stageIdx = getStageIndex(rewriter, loc, idx, depth);
+
+  auto barrier =
+      getBarrierAt(rewriter, loc, mBars, stageIdx);
+  auto waitPhase = getPhase(rewriter, loc, idx, phase0, depth);
+  // wait on empty/full
+  auto waitOp = rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
+      loc, barrier, waitPhase);
+}
+
+static void signalArrival(PatternRewriter& rewriter, Location loc, Value mBars, Value idx, int depth) {
+    // And a barrier arrive to signal completion of the region if none of the
+    // underlying ops are already async.
+    auto stageIdx = getStageIndex(rewriter, loc, idx, depth);
+    auto barrier = getBarrierAt(rewriter, loc, mBars,
+                           stageIdx);
+    // wait on empty. Use a default phase for now, will rewrite later
+    rewriter.create<triton::nvidia_gpu::ArriveBarrierOp>(loc, barrier, 1);
+}
 
 template <bool put, bool manualWait = false, typename T>
 LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
@@ -232,24 +248,16 @@ LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
   auto fullMbars = graph.arefs[aref].fullMbars;
   auto depth = graph.arefs[aref].depth;
 
+  rewriter.setInsertionPoint(op);
+
   auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
   auto one = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
+  Value idx = depth > 1 ? op.getIndexes()[0] : zero;
 
-  Value idx = zero;
-  if (depth > 1)
-    idx = op.getIndexes()[0];
-
-  rewriter.setInsertionPoint(op);
   auto stageIdx = getStageIndex(rewriter, loc, idx, depth);
 
-  auto barrier =
-      getBarrierAt(ctx, loc, rewriter, put ? emptyMbars : fullMbars, stageIdx);
-  auto waitPhase = getPhase(idx, put ? one : zero, depth, loc, rewriter);
-  if constexpr (!manualWait) {
-    // wait on empty/full
-    auto waitOp = rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
-        loc, barrier, waitPhase);
-  }
+  if constexpr (!manualWait)
+    waitOnMbar(rewriter, loc, put ? emptyMbars : fullMbars, idx, put ? one : zero, depth);
 
   SmallVector<Value> views;
 
@@ -280,12 +288,13 @@ LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
   }
 
   auto putOpBody = &op->getRegion(0).front();
-  if (putOpBody->getArguments().size() != views.size()) {
+  if (putOpBody->getArguments().size() != views.size())
     return op.emitError("number of views and arguments mismatch.");
-  };
-  for (auto [arg, view] : zip(putOpBody->getArguments(), views)) {
+
+
+  for (auto [arg, view] : zip(putOpBody->getArguments(), views))
     arg.replaceAllUsesWith(view);
-  }
+
 
   for (auto [ret, val] :
        llvm::zip(op.getResults(), putOpBody->back().getOperands()))
@@ -296,12 +305,7 @@ LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
     bodyOp.moveBefore(op);
 
   if (!graph.nodes[op].containsAsync) {
-    // And a barrier arrive to signal completion of the region if none of the
-    // underlying ops are already async. Phase To be rewritten later.
-    barrier = getBarrierAt(ctx, loc, rewriter, put ? fullMbars : emptyMbars,
-                           stageIdx);
-    // wait on empty. Use a default phase for now, will rewrite later
-    rewriter.create<triton::nvidia_gpu::ArriveBarrierOp>(loc, barrier, 1);
+    signalArrival(rewriter, loc, put ? fullMbars : emptyMbars, idx, depth);
   }
 
   rewriter.eraseOp(op);
@@ -458,13 +462,15 @@ public:
                                 PatternRewriter &rewriter) const override {
     auto ctx = op.getContext();
     auto loc = op.getLoc();
-    SmallVector<Operation *> users(op->user_begin(), op->user_end());
-
     auto getOp = dyn_cast<ArefGetOp>(op->getBlock()->getParentOp());
     if (!getOp)
       return failure();
 
-    auto putOp = dyn_cast<ArefPutOp>(getOp->getBlock()->getParentOp());
+    auto kLoop = dyn_cast<scf::ForOp>(getOp->getBlock()->getParentOp());
+    if (!kLoop)
+      return failure();
+
+    auto putOp = dyn_cast<ArefPutOp>(kLoop->getBlock()->getParentOp());
     if (!putOp)
       return failure();
 
@@ -488,9 +494,6 @@ public:
     graph.nodes[putOp].containsAsync = true;
     graph.nodes[getOp].containsAsync = true;
 
-    if (failed(lowerRegion<true, true>(getOp, rewriter, graph)))
-      return failure();
-
     rewriter.setInsertionPoint(op);
     auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
     auto one = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
@@ -508,48 +511,63 @@ public:
         getBarrier(getArefValue, getIdx, getArefValue.emptyMbars);
     op.setBarrier(getEmptyBarrier);
 
-    auto mmaFor = dyn_cast<scf::ForOp>(getOp->getParentOp());
-    for (auto user : putAref.getUsers()) {
-      auto tmpOp = dyn_cast<ArefGetOp>(user);
-      if (!tmpOp)
-        continue;
-      for (auto arg : tmpOp.getRegion().getArguments()) {
-        for (auto getArgUser : arg.getUsers()) {
-          if (!isa<TMEMLoadOp>(getArgUser))
-            continue;
-          if (mmaFor) {
-            // Otherwise wait outside the loop.
-            rewriter.setInsertionPoint(mmaFor);
-            Value putIdx =
-                putArefValue.depth > 1
-                    ? putOp.getIndexes()[0]
-                    : rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
-            auto putEmptyBarrier =
-                getBarrier(putArefValue, putIdx, putArefValue.emptyMbars);
+    if (putArefValue.depth == 1) {
+      // not peristent
+      rewriter.setInsertionPointAfter(kLoop);
+      // TODO: relax the assumption about which position the loop-carried iteration count is in
+      Value idx = kLoop.getResult(0);
+      Value finalMMABarrier =
+          getBarrier(getArefValue, idx, getArefValue.emptyMbars);
+      Value finalPhase =
+          getPhase(idx, rewriter.create<arith::ConstantIntOp>(loc, 0, 32),
+                   getArefValue.depth, loc, rewriter);
+      rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
+          loc, finalMMABarrier, finalPhase);
 
-            rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
-                loc, putEmptyBarrier,
-                getPhase(putIdx, one, putArefValue.depth, loc, rewriter));
-            rewriter.setInsertionPointAfter(mmaFor);
 
-            Value idx = mmaFor.getResult(loopCarried);
-            Value finalMMABarrier =
-                getBarrier(getArefValue, idx, getArefValue.emptyMbars);
-            Value finalPhase =
-                getPhase(idx, rewriter.create<arith::ConstantIntOp>(loc, 0, 32),
-                         getArefValue.depth, loc, rewriter);
-            rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
-                loc, finalMMABarrier, finalPhase);
-            // signal full.
-            auto putFullBarrier =
-                getBarrier(putArefValue, putIdx, putArefValue.fullMbars);
-            rewriter.create<triton::nvidia_gpu::ArriveBarrierOp>(
-                loc, putFullBarrier, 1);
-          } else {
-            return failure();
+    } else {
+      // persistent. This should be cleaner, need to leverage the graph
+      ArefGetOp arefOp;
+      TMEMLoadOp load;
+      auto findLoad = [&]() -> TMEMLoadOp {
+        if (!arefOp)
+          return nullptr;
+        for (auto arg : arefOp.getRegion().getArguments()) {
+          for (auto getArgUser : arg.getUsers()) {
+            load = dyn_cast<TMEMLoadOp>(getArgUser);
+            if (load)
+              return load;
           }
         }
+        return nullptr;
+      };
+
+      for (auto user : putAref.getUsers()) {
+        arefOp = dyn_cast<ArefGetOp>(user);
+        if (!arefOp)
+          continue;
+        load = findLoad();
+        if (load)
+          break;
       }
+
+      if (load)
+        rewriter.setInsertionPoint(load);
+      else
+        return failure();
+
+      auto forOp = dyn_cast<scf::ForOp>(arefOp->getBlock()->getParentOp());
+      if (!forOp)
+        return failure();
+      // TODO: relax the assumption about which position the loop-carried iteration count is in
+      Value idx = forOp.getOperand(1);
+      Value finalMMABarrier =
+          getBarrier(getArefValue, idx, getArefValue.emptyMbars);
+      Value finalPhase =
+          getPhase(idx, rewriter.create<arith::ConstantIntOp>(loc, 0, 32),
+                   getArefValue.depth, loc, rewriter);
+      rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(
+          loc, finalMMABarrier, finalPhase);
     }
 
     return success();

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -23,6 +23,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/AttrTypeSubElements.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -70,6 +71,7 @@ struct ArefValue {
   Value fullMbars;
   int depth;
   SmallVector<ArefUseNode *> users;
+  SmallVector<Value> updatedValues;
 };
 
 struct ArefUseGraph {
@@ -250,6 +252,9 @@ LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
   auto fullMbars = graph.arefs[aref].fullMbars;
   auto depth = graph.arefs[aref].depth;
 
+  if (put)
+    graph.arefs[aref].updatedValues.clear();
+
   rewriter.setInsertionPoint(op);
 
   auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
@@ -285,23 +290,34 @@ LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
       }
     }
   } else {
-    for (auto value : aref.template getDefiningOp<ArefCreateOp>().getOperands())
-      views.push_back(value);
+    if (graph.arefs[aref].updatedValues.size() > 0) {
+      views.append(graph.arefs[aref].updatedValues.begin(),
+                   graph.arefs[aref].updatedValues.end());
+    } else {
+      for (auto value :
+           aref.template getDefiningOp<ArefCreateOp>().getOperands())
+        views.push_back(value);
+    }
   }
 
-  auto putOpBody = &op->getRegion(0).front();
-  if (putOpBody->getArguments().size() != views.size())
+  auto opBody = &op->getRegion(0).front();
+  if (opBody->getArguments().size() != views.size())
     return op.emitError("number of views and arguments mismatch.");
-
-  for (auto [arg, view] : zip(putOpBody->getArguments(), views))
+  for (auto [arg, view] : zip(opBody->getArguments(), views))
     arg.replaceAllUsesWith(view);
 
   for (auto [ret, val] :
-       llvm::zip(op.getResults(), putOpBody->back().getOperands()))
+       llvm::zip(op.getResults(), opBody->back().getOperands())) {
     ret.replaceAllUsesWith(val);
+  }
 
-  for (auto &bodyOp :
-       llvm::make_early_inc_range(putOpBody->without_terminator()))
+  if (put) {
+    for (auto result : opBody->back().getOperands())
+      if (isa<RankedTensorType>(result.getType()))
+        graph.arefs[op.getOperand()].updatedValues.push_back(result);
+  }
+
+  for (auto &bodyOp : llvm::make_early_inc_range(opBody->without_terminator()))
     bodyOp.moveBefore(op);
 
   if (!graph.nodes[op].containsAsync) {
@@ -309,7 +325,6 @@ LogicalResult lowerRegion(T op, PatternRewriter &rewriter,
   }
 
   rewriter.eraseOp(op);
-
   return success();
 }
 
@@ -540,6 +555,99 @@ public:
   }
 };
 
+class ParallelizeWarpGroupDot : public OpRewritePattern<WarpGroupDotOp> {
+  ArefUseGraph &graph;
+
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  ParallelizeWarpGroupDot(mlir::MLIRContext *context, ArefUseGraph &graph)
+      : OpRewritePattern<WarpGroupDotOp>(context), graph(graph) {}
+
+  LogicalResult matchAndRewrite(WarpGroupDotOp op,
+                                PatternRewriter &rewriter) const override {
+    auto ctx = op.getContext();
+    auto loc = op.getLoc();
+    auto getOp = dyn_cast<ArefGetOp>(op->getBlock()->getParentOp());
+    if (!getOp)
+      return failure();
+
+    auto kLoop = dyn_cast<scf::ForOp>(getOp->getBlock()->getParentOp());
+    if (!kLoop)
+      return failure();
+
+    auto putOp = dyn_cast<ArefPutOp>(kLoop->getBlock()->getParentOp());
+    if (!putOp)
+      return failure();
+
+    auto putAref = putOp.getOperand();
+    auto getAref = getOp.getOperand();
+    if (!graph.arefs.contains(putAref) || !graph.arefs.contains(getAref))
+      return failure();
+
+    auto getArefValue = graph.arefs[getAref];
+    auto putArefValue = graph.arefs[putAref];
+
+    if (putAref.getType().getBaseType().size() != 1)
+      return failure(
+          "TODO: support putting into more than one accumulator at a time");
+
+    SmallVector<Operation *> users(op->user_begin(), op->user_end());
+    if (users.size() != 1)
+      return failure();
+    auto wait = dyn_cast<WarpGroupDotWaitOp>(users[0]);
+    if (!wait)
+      return failure();
+
+    if (wait.getPendings() == (getArefValue.depth - 1))
+      return failure(); // we've already processed this
+
+    wait.setPendings(getArefValue.depth - 1);
+    rewriter.setInsertionPointAfter(wait);
+
+    // This assumes inputs to an mma are both from a single aref get. Need to
+    // relax that to allow nested aref gets for attention
+    Value getIdx = getArefValue.depth > 1
+                       ? getOp.getIndexes()[0]
+                       : rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
+    auto depthVal =
+        rewriter.create<arith::ConstantIntOp>(loc, getArefValue.depth - 1, 32);
+    Value idx = rewriter.create<arith::SubIOp>(loc, getIdx, depthVal);
+    auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
+    Value cond = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge,
+                                                idx, zero);
+    auto ifOp = rewriter.create<scf::IfOp>(loc, SmallVector<Type>(), cond);
+    rewriter.setInsertionPointToStart(&ifOp.getThenRegion().emplaceBlock());
+    signalArrival(rewriter, loc, getArefValue.emptyMbars, idx,
+                  getArefValue.depth);
+    rewriter.create<scf::YieldOp>(loc);
+
+    // Lowering the Put op will tell the get op that reads the mma accumulator
+    // to that the mma loop is done, but we need to wait on the last mma
+    // operation inside the get.
+    for (auto user : putArefValue.users) {
+      Value idx;
+      auto mmaGetOp = dyn_cast<ArefGetOp>(user->op);
+      if (!mmaGetOp)
+        continue;
+      // TODO: relax the assumption about which position the loop-carried
+      // iteration count is in
+      idx = kLoop.getResult(1);
+      rewriter.setInsertionPoint(&mmaGetOp.getRegion().front().front());
+      rewriter.create<WarpGroupDotWaitOp>(
+          loc, mmaGetOp.getRegion().front().getArgument(0), 0);
+    }
+    // Since manually signaled the that the barriers are empty,
+    // we don't need to automatically do it
+    graph.nodes[getOp].containsAsync = true;
+
+    // Since we're returning a register tensor from a put op, we need to lower
+    // it now to ensure the value gets updated for the get.
+    // TODO: This feels gross, think of a better solution
+    return lowerRegion<1>(putOp, rewriter, graph);
+  }
+};
+
 static ArefUseGraph analyzeArefUseDef(ModuleOp m) {
   ArefUseGraph graph;
   DenseSet<Operation *> seen;
@@ -589,9 +697,8 @@ public:
     ArefUseGraph graph = analyzeArefUseDef(m);
 
     mlir::RewritePatternSet patterns(context);
-    patterns
-        .add<LowerArefCreate, ParallelizeDescriptorLoad, ParallelizeTCGen5MMA>(
-            context, graph);
+    patterns.add<LowerArefCreate, ParallelizeDescriptorLoad,
+                 ParallelizeTCGen5MMA, ParallelizeWarpGroupDot>(context, graph);
     GreedyRewriteConfig config;
 
     if (applyPatternsGreedily(m, std::move(patterns), config).failed())
@@ -604,7 +711,7 @@ public:
       return signalPassFailure();
 
     mlir::RewritePatternSet patterns2(context);
-    patterns2.add<LowerArefGet, LowerArefPut>(context, graph);
+    patterns2.add<LowerArefPut, LowerArefGet>(context, graph);
     GreedyRewriteConfig config2;
 
     if (applyPatternsGreedily(m, std::move(patterns2), config2).failed())

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -505,34 +505,33 @@ public:
     // Lowering the Put op will tell the get op that reads the mma accumulator
     // to that the mma loop is done, but we need to wait on the last mma
     // operation inside the get.
-    if (putArefValue.depth == 1) {
-      // not peristent, wait immediately after k loop
-      rewriter.setInsertionPointAfter(kLoop);
-      // TODO: relax the assumption about which position the loop-carried
-      // iteration count is in
-      Value idx = kLoop.getResult(0);
-      waitOnMbar(rewriter, loc, getArefValue.emptyMbars,
-                 rewriter.create<arith::ConstantIntOp>(loc, 0, 32), idx,
-                 getArefValue.depth);
-    } else {
-      // persistent.
-      for (auto user : putArefValue.users) {
-        auto mmaGetOp = dyn_cast<ArefGetOp>(user->op);
-        if (!mmaGetOp)
-          continue;
-        rewriter.setInsertionPoint(&mmaGetOp.getRegion().front().front());
+    for (auto user : putArefValue.users) {
+      Value idx;
+      auto mmaGetOp = dyn_cast<ArefGetOp>(user->op);
+      if (!mmaGetOp)
+        continue;
+      if (putArefValue.depth == 1) {
+        // not peristent, use the kLoop return
+        // TODO: relax the assumption about which position the loop-carried
+        // iteration count is in
+        idx = kLoop.getResult(0);
+        rewriter.setInsertionPointAfter(kLoop);
+      } else {
+        // persistent
         // Get should be inside of a for loop
         auto forOp = dyn_cast<scf::ForOp>(mmaGetOp->getBlock()->getParentOp());
         if (!forOp)
           return failure();
         // TODO: relax the assumption about which position the loop-carried
         // iteration count is in
-        Value idx = forOp.getOperand(1);
-        waitOnMbar(rewriter, loc, getArefValue.emptyMbars,
-                   rewriter.create<arith::ConstantIntOp>(loc, 0, 32), idx,
-                   getArefValue.depth);
+        idx = forOp.getOperand(1);
+        rewriter.setInsertionPoint(&mmaGetOp.getRegion().front().front());
       }
+      waitOnMbar(rewriter, loc, getArefValue.emptyMbars,
+                 rewriter.create<arith::ConstantIntOp>(loc, 0, 32), idx,
+                 getArefValue.depth);
     }
+
     // Since we are signalling the inputs to the mma are done with the mma
     // barrier, we don't need to add an arrival when lowering the get.
     graph.nodes[getOp].containsAsync = true;

--- a/third_party/nvidia/test/NVWS/invalid.mlir
+++ b/third_party/nvidia/test/NVWS/invalid.mlir
@@ -3,8 +3,36 @@
 #shared0 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @aref_get_single(%d : !ttg.memdesc<1x64x16xf16, #shared0, #smem>, %e : !ttg.memdesc<2x16x32xf16, #shared0, #smem>) {
+    %c0_i32 = arith.constant 0 : i32
+    // expected-error @below {{Leading dims of sliced aref inputs don't match}}
+    %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<2x16x32xf16, #shared0, #smem>], 1>
+    tt.return
+  }
+}
+
+// -----
+
+#shared0 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @aref_get_single(%d : !ttg.memdesc<1x64x16xf16, #shared0, #smem>, %e : !ttg.memdesc<2x16x32xf16, #shared0, #smem>) {
+    %c0_i32 = arith.constant 0 : i32
+    // expected-error @below {{Aref buffer is used elsewhere, Aref cannot guarantee async safety}}
+    %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<2x16x32xf16, #shared0, #smem>], 1>
+    %1 = ttng.tmem_alloc %d : (!ttg.memdesc<1x64x16xf16, #shared0, #smem>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared0 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func @aref_get_single(%d : !ttg.memdesc<1x64x16xf16, #shared0, #smem>, %e : !ttg.memdesc<1x16x32xf16, #shared0, #smem>) {
-    %c0_i32 = arith.constant {ttg.partition = [0, 1]} 0 : i32
+    %c0_i32 = arith.constant 0 : i32
     %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>], 1>
     // expected-error @below {{Number of Batch axes on the aref type does not match the number of indexes}}
     %1 = nvws.aref.get %0 as (%b0 : !ttg.memdesc<1x64x16xf16, #shared0, #smem>, %b1 : !ttg.memdesc<1x16x32xf16, #shared0, #smem>) {
@@ -35,7 +63,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 #smem = #ttg.shared_memory
 module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func @aref_get_batch(%d : !ttg.memdesc<1x64x16xf16, #shared0, #smem>, %e : !ttg.memdesc<1x16x32xf16, #shared0, #smem>) {
-    %c0_i32 = arith.constant {ttg.partition = [0, 1]} 0 : i32
+    %c0_i32 = arith.constant 0 : i32
     %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
     // expected-error @below {{Number of Batch axes on the aref type does not match the number of indexes}}
     %1 = nvws.aref.get %0[%c0_i32] as (%b0 : !ttg.memdesc<64x16xf16, #shared0, #smem>, %b1 : !ttg.memdesc<16x32xf16, #shared0, #smem>) {
@@ -51,7 +79,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 #smem = #ttg.shared_memory
 module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func @aref_put_batch(%d : !ttg.memdesc<1x64x16xf16, #shared0, #smem>, %e : !ttg.memdesc<1x16x32xf16, #shared0, #smem>) {
-    %c0_i32 = arith.constant {ttg.partition = [0, 1]} 0 : i32
+    %c0_i32 = arith.constant 0 : i32
     %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>], 1>
     // expected-error @below {{Dimensions don't match}}
     nvws.aref.put %0[%c0_i32] as (%b0 : !ttg.memdesc<64x16xf16, #shared0, #smem>, %b1 : !ttg.memdesc<32x32xf16, #shared0, #smem>) {
@@ -67,7 +95,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 #smem = #ttg.shared_memory
 module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func @aref_put_batch(%d : !ttg.memdesc<1x64x16xf16, #shared0, #smem>, %e : !ttg.memdesc<1x16x32xf16, #shared0, #smem>) {
-    %c0_i32 = arith.constant {ttg.partition = [0, 1]} 0 : i32
+    %c0_i32 = arith.constant 0 : i32
     %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>], 1>
     // expected-error @below {{MLIR Types don't match}}
     nvws.aref.put %0[%c0_i32] as (%b0 : tensor<64x16xf16>, %b1 : tensor<16x32xf16>) {
@@ -101,7 +129,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
   // CHECK-LABEL: aref_put_tensor_wrong_type
   // CHECK: nvws.aref.put
   tt.func @aref_put_tensor_wrong_type(%d : tensor<1x64x16xf16>, %e : tensor<1x16x32xf16>) {
-    %c0_i32 = arith.constant {ttg.partition = [0, 1]} 0 : i32
+    %c0_i32 = arith.constant 0 : i32
     %0 = nvws.aref.create %d, %e : !nvws.aref<[tensor<1x64x16xf16>, tensor<1x16x32xf16>], 1>
     nvws.aref.put %0[%c0_i32] as (%b0 : tensor<64x16xf16>, %b1 : tensor<16x32xf16>) {
       %1 = math.exp %b0 : tensor<64x16xf16>
@@ -119,7 +147,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
   // CHECK-LABEL: aref_put_tensor_wrong_num_outputs
   // CHECK: nvws.aref.put
   tt.func @aref_put_tensor_wrong_num_outputs(%d : tensor<1x64x16xf16>, %e : tensor<1x16x32xf16>) {
-    %c0_i32 = arith.constant {ttg.partition = [0, 1]} 0 : i32
+    %c0_i32 = arith.constant 0 : i32
     %0 = nvws.aref.create %d, %e : !nvws.aref<[tensor<1x64x16xf16>, tensor<1x16x32xf16>], 1>
     nvws.aref.put %0[%c0_i32] as (%b0 : tensor<64x16xf16>, %b1 : tensor<16x32xf16>) {
       %1 = math.exp %b0 : tensor<64x16xf16>
@@ -139,7 +167,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
   // CHECK-LABEL: aref_get_dot
   // CHECK: nvws.aref.get
   tt.func @aref_get_dot(%d : !ttg.memdesc<1x64x16xf16, #shared0, #smem>, %e : !ttg.memdesc<1x16x32xf16, #shared0, #smem>) {
-    %c0_i32 = arith.constant {ttg.partition = [0, 1]} 0 : i32
+    %c0_i32 = arith.constant 0 : i32
     %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>], 1>
     %1 = nvws.aref.get %0[%c0_i32] as (%b0 : !ttg.memdesc<64x16xf16, #shared0, #smem>, %b1 : !ttg.memdesc<16x32xf16, #shared0, #smem>) {
       %1 = ttg.local_load %b0 : !ttg.memdesc<64x16xf16, #shared0, #smem> -> tensor<64x16xf16>

--- a/third_party/nvidia/test/NVWS/lower_aref.mlir
+++ b/third_party/nvidia/test/NVWS/lower_aref.mlir
@@ -42,6 +42,7 @@ module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 4 : i32}, nvws.
     %13 = arith.muli %4, %c8_i32 : i32
     %14 = arith.muli %6, %11 : i32
     %15 = ttng.tmem_alloc %cst {} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %tmem_aref = nvws.aref.create %15 : !nvws.aref<[!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>
     %16 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>
     %17 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>
     %18 = nvws.aref.create %16, %17 : !nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>
@@ -94,8 +95,11 @@ module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 4 : i32}, nvws.
       %22:3 = scf.for %arg6 = %c0_i32 to %14 step %c1_i32 iter_args(%arg7 = %c-1_i32, %arg8 = %false, %arg9 = %c0_i32) -> (i32, i1, i32)  : i32 {
         nvws.aref.get %18[%arg9] as (%arg10 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>,
                                      %arg11: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>) {
-          %24 = ttg.memdesc_trans %arg11 {order=array<i32: 1,0>} : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>
-          ttng.tc_gen5_mma %arg10, %24, %15, %arg8, %true : (!ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1, i1) -> ()
+          nvws.aref.put %tmem_aref as (%arg12 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+            %24 = ttg.memdesc_trans %arg11 {order=array<i32: 1,0>} : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>
+            ttng.tc_gen5_mma %arg10, %24, %arg12, %arg8, %true : (!ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1, i1) -> ()
+            nvws.aref.return
+          } : (!nvws.aref<[!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>) -> ()
           nvws.aref.return
         } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
         %25 = arith.subi %6, %c1_i32 {} : i32
@@ -119,7 +123,10 @@ module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 4 : i32}, nvws.
           %43 = arith.divsi %42, %39 : i32
           %44 = arith.muli %41, %c128_i32 {tt.divisibility = dense<128> : tensor<1xi32>} : i32
           %45 = arith.muli %43, %c128_i32 {tt.divisibility = dense<128> : tensor<1xi32>} : i32
-          %46 = ttng.tmem_load %15 {} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+          %46 = nvws.aref.get %tmem_aref as (%arg12 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+            %acc = ttng.tmem_load %arg12 {} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+            nvws.aref.return %acc : tensor<128x128xf32, #blocked>
+          } : (!nvws.aref<[!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>) -> (tensor<128x128xf32, #blocked>)
           %47 = tt.fp_to_fp %46, rounding = rtne : tensor<128x128xf32, #blocked> -> tensor<128x128xf8E4M3FN, #blocked>
           %48 = ttg.convert_layout %47 : tensor<128x128xf8E4M3FN, #blocked> -> tensor<128x128xf8E4M3FN, #blocked2>
           %49 = tt.reinterpret_tensor_descriptor %arg2 : !tt.ptr<f32> to !tt.tensordesc<tensor<128x128xf8E4M3FN>>
@@ -162,6 +169,7 @@ module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 0 : i32}, nvws.
     %7 = arith.addi %arg5, %c63_i32 : i32
     %8 = arith.divsi %7, %c64_i32 : i32
     %9 = ttng.tmem_alloc %cst {} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %tmem_aref = nvws.aref.create %9 : !nvws.aref<[!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>
     %10 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>
     %11 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>
     %12 = nvws.aref.create %10, %11 : !nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>
@@ -194,14 +202,20 @@ module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 0 : i32}, nvws.
       %16 = scf.for %arg7 = %c0_i32 to %8 step %c1_i32 iter_args(%arg8 = %c0_i32) -> (i32)  : i32 {
         nvws.aref.get %12[%arg8] as (%arg9 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>,
                                      %arg10 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>) {
-          %36 = ttg.memdesc_trans %arg10 {order=array<i32: 1,0>} : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>
-          ttng.tc_gen5_mma %arg9, %36, %9, %true, %true {} : (!ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1, i1) -> ()
+          nvws.aref.put %tmem_aref as (%arg11 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+            %36 = ttg.memdesc_trans %arg10 {order=array<i32: 1,0>} : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>
+            ttng.tc_gen5_mma %arg9, %36, %arg11, %true, %true {} : (!ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1, i1) -> ()
+            nvws.aref.return
+          } : (!nvws.aref<[!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>) -> ()
           nvws.aref.return
         } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
         %37 = arith.addi %arg8, %c1_i32 {} : i32
         scf.yield {} %37 : i32
       }
-      %17 = ttng.tmem_load %9 {} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      %17 = nvws.aref.get %tmem_aref as (%arg11 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+        %acc = ttng.tmem_load %arg11 {} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+        nvws.aref.return %acc : tensor<128x128xf32, #blocked>
+      } : (!nvws.aref<[!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>) -> (tensor<128x128xf32, #blocked>)
       %18 = tt.fp_to_fp %17 {}, rounding = rtne : tensor<128x128xf32, #blocked> -> tensor<128x128xf8E4M3FN, #blocked>
       %19 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>>
       %20 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked2}>>

--- a/third_party/nvidia/test/NVWS/lower_aref.mlir
+++ b/third_party/nvidia/test/NVWS/lower_aref.mlir
@@ -2,148 +2,6 @@
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
-#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
-#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
-#smem = #ttg.shared_memory
-#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
-module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 4 : i32}, nvws.tma_load = {num_warps = 4 : i32, start_warp = 0 : i32}, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.warp-specialized" = true} {
-  tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
-    %false = arith.constant false
-    %true = arith.constant true
-    %c148_i32 = arith.constant 148 : i32
-    %c1_i32 = arith.constant 1 : i32
-    %c-1_i32 = arith.constant -1 : i32
-    %c0_i32 = arith.constant 0 : i32
-    %c8_i32 = arith.constant 8 : i32
-    %c128_i32 = arith.constant 128 : i32
-    %c64_i32 = arith.constant 64 : i32
-    %c127_i32 = arith.constant 127 : i32
-    %c63_i32 = arith.constant 63 : i32
-    %cst = arith.constant {} dense<0.000000e+00> : tensor<128x128xf32, #blocked>
-    %0 = tt.get_program_id x : i32
-    %1 = arith.addi %arg3, %c127_i32 : i32
-    %2 = arith.divsi %1, %c128_i32 : i32
-    %3 = arith.addi %arg4, %c127_i32 : i32
-    %4 = arith.divsi %3, %c128_i32 : i32
-    %5 = arith.addi %arg5, %c63_i32 : i32
-    %6 = arith.divsi %5, %c64_i32 : i32
-    %7 = arith.muli %2, %4 : i32
-    %8 = arith.divsi %7, %c148_i32 : i32
-    %9 = arith.remsi %7, %c148_i32 : i32
-    %10 = arith.cmpi slt, %0, %9 : i32
-    %11 = scf.if %10 -> (i32) {
-      %22 = arith.addi %8, %c1_i32 : i32
-      scf.yield %22 : i32
-    } else {
-      scf.yield %8 : i32
-    }
-    %12 = arith.subi %0, %c148_i32 : i32
-    %13 = arith.muli %4, %c8_i32 : i32
-    %14 = arith.muli %6, %11 : i32
-    %15 = ttng.tmem_alloc %cst {} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    %tmem_aref = nvws.aref.create %15 : !nvws.aref<[!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>
-    %16 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>
-    %17 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>
-    %18 = nvws.aref.create %16, %17 : !nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>
-    %19 = nvvm.read.ptx.sreg.tid.x : i32
-    %20 = arith.divsi %19, %c128_i32 : i32
-    %21 = arith.cmpi eq, %20, %c0_i32 : i32
-    nvvm.barrier0
-    nvws.warp_group
-    partition0 num_warps(4) {
-      nvvm.setmaxregister  decrease 40
-      %22:5 = scf.for %arg6 = %c0_i32 to %14 step %c1_i32 iter_args(%arg7 = %c-1_i32, %arg8 = %12, %arg9 = %c0_i32, %arg10 = %c0_i32, %arg11 = %c0_i32) -> (i32, i32, i32, i32, i32) : i32 {
-        %23 = arith.subi %6, %c1_i32 {} : i32
-        %24 = arith.cmpi eq, %arg7, %23 {} : i32
-        %25 = arith.addi %arg7, %c1_i32 {} : i32
-        %26 = arith.select %24, %c0_i32, %25 {} : i32
-        %27 = arith.cmpi eq, %26, %c0_i32 {} : i32
-        %28:3 = scf.if %27 -> (i32, i32, i32) {
-          %33 = arith.addi %arg8, %c148_i32 {} : i32
-          %34 = arith.divsi %33, %13 {} : i32
-          %35 = arith.muli %34, %c8_i32 {} : i32
-          %36 = arith.subi %2, %35 {} : i32
-          %37 = arith.minsi %36, %c8_i32 {} : i32
-          %38 = arith.remsi %33, %37 {} : i32
-          %39 = arith.addi %35, %38 {} : i32
-          %40 = arith.remsi %33, %13 {} : i32
-          %41 = arith.divsi %40, %37 {} : i32
-          %42 = arith.muli %39, %c128_i32 {} : i32
-          %43 = arith.muli %41, %c128_i32 {} : i32
-          scf.yield %33, %42, %43 : i32, i32, i32
-        } else {
-          scf.yield %arg8, %arg9, %arg10 : i32, i32, i32
-        }
-        %29 = arith.muli %26, %c64_i32 {} : i32
-        %30 = tt.reinterpret_tensor_descriptor %arg0 {} : !tt.ptr<f32> to !tt.tensordesc<tensor<128x64xf8E4M3FN>>
-        %31 = tt.reinterpret_tensor_descriptor %arg1 {} : !tt.ptr<f32> to !tt.tensordesc<tensor<128x64xf8E4M3FN>>
-        nvws.aref.put %18[%arg11] as (%arg12: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>,
-                                      %arg13: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>) {
-          %33 = tt.descriptor_load %30[%28#1, %29] {} : !tt.tensordesc<tensor<128x64xf8E4M3FN>> -> tensor<128x64xf8E4M3FN, #blocked1>
-          ttg.local_store %33, %arg12 : tensor<128x64xf8E4M3FN, #blocked1> -> !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>
-          %34 = tt.descriptor_load %31[%28#2, %29] {} : !tt.tensordesc<tensor<128x64xf8E4M3FN>> -> tensor<128x64xf8E4M3FN, #blocked1>
-          ttg.local_store %34, %arg13 : tensor<128x64xf8E4M3FN, #blocked1> -> !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>
-          nvws.aref.return
-        } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
-        %32 = arith.addi %arg11, %c1_i32 {} : i32
-        scf.yield {} %26, %28#0, %28#1, %28#2, %32 : i32, i32, i32, i32, i32
-      }
-      nvws.warp_group.return
-    } partition1 num_warps(4) {
-      nvvm.setmaxregister  increase 232
-      %22:3 = scf.for %arg6 = %c0_i32 to %14 step %c1_i32 iter_args(%arg7 = %c-1_i32, %arg8 = %false, %arg9 = %c0_i32) -> (i32, i1, i32)  : i32 {
-        nvws.aref.get %18[%arg9] as (%arg10 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>,
-                                     %arg11: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>) {
-          nvws.aref.put %tmem_aref as (%arg12 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
-            %24 = ttg.memdesc_trans %arg11 {order=array<i32: 1,0>} : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>
-            ttng.tc_gen5_mma %arg10, %24, %arg12, %arg8, %true : (!ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1, i1) -> ()
-            nvws.aref.return
-          } : (!nvws.aref<[!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>) -> ()
-          nvws.aref.return
-        } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
-        %25 = arith.subi %6, %c1_i32 {} : i32
-        %26 = arith.cmpi eq, %arg7, %25 {} : i32
-        %27 = arith.addi %arg7, %c1_i32 {} : i32
-        %28 = arith.select %26, %c0_i32, %27 {} : i32
-        %29 = arith.cmpi eq, %28, %25 {} : i32
-        %30 = arith.cmpi ne, %28, %25 {} : i32
-        scf.if %29 {
-          %32 = arith.addi %arg6, %c1_i32 : i32
-          %33 = arith.divsi %32, %6 : i32
-          %34 = arith.muli %33, %c148_i32 : i32
-          %35 = arith.addi %12, %34 : i32
-          %36 = arith.divsi %35, %13 : i32
-          %37 = arith.muli %36, %c8_i32 : i32
-          %38 = arith.subi %2, %37 : i32
-          %39 = arith.minsi %38, %c8_i32 : i32
-          %40 = arith.remsi %35, %39 : i32
-          %41 = arith.addi %37, %40 : i32
-          %42 = arith.remsi %35, %13 : i32
-          %43 = arith.divsi %42, %39 : i32
-          %44 = arith.muli %41, %c128_i32 {tt.divisibility = dense<128> : tensor<1xi32>} : i32
-          %45 = arith.muli %43, %c128_i32 {tt.divisibility = dense<128> : tensor<1xi32>} : i32
-          %46 = nvws.aref.get %tmem_aref as (%arg12 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
-            %acc = ttng.tmem_load %arg12 {} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
-            nvws.aref.return %acc : tensor<128x128xf32, #blocked>
-          } : (!nvws.aref<[!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>) -> (tensor<128x128xf32, #blocked>)
-          %47 = tt.fp_to_fp %46, rounding = rtne : tensor<128x128xf32, #blocked> -> tensor<128x128xf8E4M3FN, #blocked>
-          %48 = ttg.convert_layout %47 : tensor<128x128xf8E4M3FN, #blocked> -> tensor<128x128xf8E4M3FN, #blocked2>
-          %49 = tt.reinterpret_tensor_descriptor %arg2 : !tt.ptr<f32> to !tt.tensordesc<tensor<128x128xf8E4M3FN>>
-          tt.descriptor_store %49[%44, %45], %48 {} : !tt.tensordesc<tensor<128x128xf8E4M3FN>>, tensor<128x128xf8E4M3FN, #blocked2>
-        }
-        %31 = arith.addi %arg9, %c1_i32 {} : i32
-        scf.yield {} %28, %30, %31 : i32, i1, i32
-      }
-      nvws.warp_group.return
-    }
-    tt.return
-  }
-}
-
-// -----
-#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
@@ -156,6 +14,7 @@ module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 0 : i32}, nvws.
     %c0_i32 = arith.constant 0 : i32
     %c64_i32 = arith.constant 64 : i32
     %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
     %c127_i32 = arith.constant {} 127 : i32
     %c63_i32 = arith.constant 63 : i32
     %cst = arith.constant {} dense<0.000000e+00> : tensor<128x128xf32, #blocked>
@@ -199,19 +58,19 @@ module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 0 : i32}, nvws.
     }
     partition1 num_warps(4) {
       nvvm.setmaxregister  increase 232
-      %16 = scf.for %arg7 = %c0_i32 to %8 step %c1_i32 iter_args(%arg8 = %c0_i32) -> (i32)  : i32 {
-        nvws.aref.get %12[%arg8] as (%arg9 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>,
-                                     %arg10 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>) {
-          nvws.aref.put %tmem_aref as (%arg11 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+      nvws.aref.put %tmem_aref as (%arg11 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+        %16 = scf.for %arg7 = %c0_i32 to %8 step %c1_i32 iter_args(%arg8 = %c0_i32) -> (i32)  : i32 {
+          nvws.aref.get %12[%arg8] as (%arg9 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>,
+                                       %arg10 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>) {
             %36 = ttg.memdesc_trans %arg10 {order=array<i32: 1,0>} : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>
             ttng.tc_gen5_mma %arg9, %36, %arg11, %true, %true {} : (!ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1, i1) -> ()
             nvws.aref.return
-          } : (!nvws.aref<[!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>) -> ()
-          nvws.aref.return
-        } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
-        %37 = arith.addi %arg8, %c1_i32 {} : i32
-        scf.yield {} %37 : i32
-      }
+          } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
+          %37 = arith.addi %arg8, %c1_i32 {} : i32
+          scf.yield %37 : i32
+        }
+        nvws.aref.return
+      } : (!nvws.aref<[!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>) -> ()
       %17 = nvws.aref.get %tmem_aref as (%arg11 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
         %acc = ttng.tmem_load %arg11 {} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
         nvws.aref.return %acc : tensor<128x128xf32, #blocked>
@@ -234,6 +93,127 @@ module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 0 : i32}, nvws.
       %33 = tt.addptr %31, %32 {} : tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked2>, tensor<128x128xi32, #blocked2>
       %34 = ttg.convert_layout %18 : tensor<128x128xf8E4M3FN, #blocked> -> tensor<128x128xf8E4M3FN, #blocked2>
       tt.store %33, %34 {} : tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked2>
+      nvws.warp_group.return
+    }
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [2, 1, 128], threadsPerWarp = [1, 32, 1], warpsPerCTA = [1, 4, 1], order = [0, 1, 2]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 0 : i32}, nvws.tma_load = {num_warps = 4 : i32, start_warp = 4 : i32}, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.warp-specialized" = true} {
+  tt.func public @matmul_kernel_tma_persistent_nested(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %true = arith.constant {} true
+    %c8_i32 = arith.constant {} 8 : i32
+    %c128_i32 = arith.constant {} 128 : i32
+    %c0_i32 = arith.constant {} 0 : i32
+    %c1_i32 = arith.constant {} 1 : i32
+    %c2_i32 = arith.constant {} 2 : i32
+    %c127_i32 = arith.constant {} 127 : i32
+    %cst = arith.constant {} dense<0.000000e+00> : tensor<2x128x128xf32, #blocked2>
+    %0 = tt.get_program_id x {} : i32
+    %1 = arith.addi %arg3, %c127_i32 {} : i32
+    %2 = arith.divsi %1, %c128_i32 {} : i32
+    %3 = arith.addi %arg4, %c127_i32 {} : i32
+    %4 = arith.divsi %3, %c128_i32 {} : i32
+    %5 = arith.addi %arg5, %c127_i32 {} : i32
+    %6 = arith.divsi %5, %c128_i32 {} : i32
+    %7 = arith.muli %2, %4 {} : i32
+    %8 = arith.muli %4, %c8_i32 {} : i32
+    %9 = tt.get_num_programs x {} : i32
+    %10 = nvvm.read.ptx.sreg.tid.x : i32
+    %11 = arith.divsi %10, %c128_i32 : i32
+    %12 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x128xf8E4M3FN, #shared, #smem, mutable>
+    %13 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x128xf8E4M3FN, #shared, #smem, mutable>
+    %14 = nvws.aref.create %12, %13 : !nvws.aref<[!ttg.memdesc<3x128x128xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x128xf8E4M3FN, #shared, #smem, mutable>], 1>
+    %15 = ttng.tmem_alloc %cst : (tensor<2x128x128xf32, #blocked2>) -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %16 = nvws.aref.create %15 : !nvws.aref<[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>], 1>
+    nvvm.barrier0 {init_barrier_sync}
+    nvws.warp_group
+    partition0 num_warps(4) {
+      %20 = scf.for %arg6 = %0 to %7 step %9 iter_args(%arg7 = %c0_i32) -> (i32)  : i32 {
+        %21 = arith.divsi %arg6, %8 {} : i32
+        %22 = arith.muli %21, %c8_i32 {} : i32
+        %23 = arith.subi %2, %22 {} : i32
+        %24 = arith.minsi %23, %c8_i32 {} : i32
+        %25 = arith.remsi %arg6, %24 {} : i32
+        %26 = arith.addi %22, %25 {} : i32
+        %27 = arith.remsi %arg6, %8 {} : i32
+        %28 = arith.divsi %27, %24 {} : i32
+        %29 = arith.muli %26, %c128_i32 {} : i32
+        %30 = arith.muli %28, %c128_i32 {} : i32
+        %31:2 = scf.for %arg8 = %c0_i32 to %6 step %c1_i32 iter_args(%arg9 = %c0_i32, %arg10 = %arg7) -> (i32, i32)  : i32 {
+          %32 = tt.reinterpret_tensor_descriptor %arg0 {} : !tt.ptr<f32> to !tt.tensordesc<tensor<128x128xf8E4M3FN>>
+          %33 = tt.reinterpret_tensor_descriptor %arg1 {} : !tt.ptr<f32> to !tt.tensordesc<tensor<128x128xf8E4M3FN>>
+          nvws.aref.put %14[%arg10] as (%arg11: !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>, %arg12: !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>) {
+            %36 = tt.descriptor_load %32[%29, %arg9] {} : !tt.tensordesc<tensor<128x128xf8E4M3FN>> -> tensor<128x128xf8E4M3FN, #blocked1>
+            ttg.local_store %36, %arg11 : tensor<128x128xf8E4M3FN, #blocked1> -> !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>
+            %37 = tt.descriptor_load %33[%30, %arg9] {} : !tt.tensordesc<tensor<128x128xf8E4M3FN>> -> tensor<128x128xf8E4M3FN, #blocked1>
+            ttg.local_store %37, %arg12 : tensor<128x128xf8E4M3FN, #blocked1> -> !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>
+            nvws.aref.return
+          }: (!nvws.aref<[!ttg.memdesc<3x128x128xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x128xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
+          %34 = arith.addi %arg9, %c128_i32 {} : i32
+          %35 = arith.addi %arg10, %c1_i32 {} : i32
+          scf.yield {} %34, %35 : i32, i32
+        }
+        scf.yield {} %31#1 : i32
+      }
+      nvws.warp_group.return
+    }
+    partition1 num_warps(4) {
+      %20 = scf.for %arg6 = %0 to %7 step %9 iter_args(%arg7 = %c0_i32) -> (i32)  : i32 {
+        %21 = arith.remsi %arg6, %c2_i32 : i32
+        nvws.aref.put %16[%21] as (%arg11 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+          %31:2 = scf.for %arg8 = %c0_i32 to %6 step %c1_i32 iter_args(%arg9 = %false, %arg10 = %arg7) -> (i1, i32)  : i32 {
+            nvws.aref.get %14[%arg10] as (%arg12 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>, %arg13 : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>) {
+              %37 = ttg.memdesc_trans %arg13 {order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable>
+              ttng.tc_gen5_mma %arg12, %37, %arg11, %arg9, %true : (!ttg.memdesc<128x128xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<128x128xf8E4M3FN, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1, i1) -> ()
+              nvws.aref.return
+            } : (!nvws.aref<[!ttg.memdesc<3x128x128xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x128xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
+            %38 = arith.addi %arg10, %c1_i32  : i32
+            scf.yield {} %true, %38 : i1, i32
+          }
+          nvws.aref.return
+        } : (!nvws.aref<[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>], 1>, i32) -> ()
+        %31 = arith.addi %arg7, %6 : i32
+        scf.yield {} %31 : i32
+      }
+      nvws.warp_group.return
+    }
+    partition2 num_warps(4) {
+      %20 = scf.for %arg6 = %0 to %7 step %9 iter_args(%arg7 = %c0_i32) -> (i32)  : i32 {
+        %21 = arith.divsi %arg6, %8 {} : i32
+        %22 = arith.muli %21, %c8_i32 {} : i32
+        %23 = arith.subi %2, %22 {} : i32
+        %24 = arith.minsi %23, %c8_i32 {} : i32
+        %25 = arith.remsi %arg6, %24 {} : i32
+        %26 = arith.addi %22, %25 {} : i32
+        %27 = arith.remsi %arg6, %8 {} : i32
+        %28 = arith.divsi %27, %24 {} : i32
+        %29 = arith.muli %26, %c128_i32 : i32
+        %30 = arith.muli %28, %c128_i32 : i32
+        %31 = arith.addi %arg7, %6 : i32
+        %stage = arith.remsi %arg6, %c2_i32 : i32
+        %32 = nvws.aref.get %16[%stage] as (%arg8 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
+          %32 = ttng.tmem_load %arg8 {} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+          // need to zero out the tmem here
+          nvws.aref.return %32 : tensor<128x128xf32, #blocked>
+        } : (!nvws.aref<[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>], 1>, i32) -> (tensor<128x128xf32, #blocked>)
+        %33 = tt.fp_to_fp %32 {}, rounding = rtne : tensor<128x128xf32, #blocked> -> tensor<128x128xf8E4M3FN, #blocked>
+        %34 = ttg.convert_layout %33 : tensor<128x128xf8E4M3FN, #blocked> -> tensor<128x128xf8E4M3FN, #blocked1>
+        %35 = tt.reinterpret_tensor_descriptor %arg2 {} : !tt.ptr<f32> to !tt.tensordesc<tensor<128x128xf8E4M3FN>>
+        tt.descriptor_store %35[%29, %30], %34 {} : !tt.tensordesc<tensor<128x128xf8E4M3FN>>, tensor<128x128xf8E4M3FN, #blocked1>
+        scf.yield {} %31 : i32
+      }
       nvws.warp_group.return
     }
     tt.return

--- a/third_party/nvidia/test/NVWS/lower_aref.mlir
+++ b/third_party/nvidia/test/NVWS/lower_aref.mlir
@@ -218,3 +218,93 @@ module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 0 : i32}, nvws.
     tt.return
   }
 }
+
+// -----
+
+module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 0 : i32}, nvws.tma_load = {num_warps = 4 : i32, start_warp = 4 : i32}, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32, "ttg.warp-specialized" = true} {
+  tt.func public @matmul_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f8E4M3FN> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c127_i32 = arith.constant {} 127 : i32
+    %c63_i32 = arith.constant {} 63 : i32
+    %cst = arith.constant {} dense<0.000000e+00> : tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>
+    %0 = tt.get_program_id x {} : i32
+    %1 = arith.addi %arg3, %c127_i32 {} : i32
+    %2 = arith.divsi %1, %c128_i32 {} : i32
+    %3 = arith.remsi %0, %2 {} : i32
+    %4 = arith.divsi %0, %2 {} : i32
+    %5 = arith.muli %3, %c128_i32 {} : i32
+    %6 = arith.muli %4, %c128_i32 {} : i32
+    %7 = arith.addi %arg5, %c63_i32 {} : i32
+    %8 = arith.divsi %7, %c64_i32 {} : i32
+    %9 = nvvm.read.ptx.sreg.tid.x : i32
+    %10 = arith.divsi %9, %c128_i32 : i32
+    %11 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>
+    %12 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>
+    %13 = nvws.aref.create %11, %12 : !nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>], 1>
+    %acc = nvws.aref.create %cst : !nvws.aref<[tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>]>
+    nvvm.barrier0 {init_barrier_sync}
+    %14 = arith.cmpi eq, %10, %c1_i32 {} : i32
+    nvws.warp_group
+    partition0 num_warps(4) {
+      nvvm.setmaxregister  decrease 40 {}
+      %18:2 = scf.for %arg7 = %c0_i32 to %8 step %c1_i32 iter_args(%arg8 = %c0_i32, %arg9 = %c0_i32) -> (i32, i32)  : i32 {
+        %19 = tt.reinterpret_tensor_descriptor %arg0 {} : !tt.ptr<f32> to !tt.tensordesc<tensor<128x64xf8E4M3FN>>
+        %20 = tt.reinterpret_tensor_descriptor %arg1 {} : !tt.ptr<f32> to !tt.tensordesc<tensor<128x64xf8E4M3FN>>
+        nvws.aref.put %13[%arg9] as (%arg10: !ttg.memdesc<128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>, %arg11: !ttg.memdesc<128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>) {
+          %23 = tt.descriptor_load %19[%5, %arg8] {} : !tt.tensordesc<tensor<128x64xf8E4M3FN>> -> tensor<128x64xf8E4M3FN, #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>
+          ttg.local_store %23, %arg10 : tensor<128x64xf8E4M3FN, #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>> -> !ttg.memdesc<128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>
+          %24 = tt.descriptor_load %20[%6, %arg8] {} : !tt.tensordesc<tensor<128x64xf8E4M3FN>> -> tensor<128x64xf8E4M3FN, #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>
+          ttg.local_store %24, %arg11 : tensor<128x64xf8E4M3FN, #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>> -> !ttg.memdesc<128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>
+          nvws.aref.return
+        } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>], 1>, i32) -> ()
+        %21 = arith.addi %arg8, %c64_i32 {} : i32
+        %22 = arith.addi %arg9, %c1_i32 {} : i32
+        scf.yield {} %21, %22 : i32, i32
+      }
+      nvws.warp_group.return
+    } partition1 num_warps(4) {
+      nvvm.setmaxregister  increase 232 {}
+      nvws.aref.put %acc as (%arg10 : tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>) {
+        %18:2 = scf.for %arg7 = %c0_i32 to %8 step %c1_i32 iter_args(%arg8 = %cst, %arg9 = %c0_i32) -> (tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>, i32)  : i32 {
+          %40 = nvws.aref.get %13[%arg9] as (%arg11 :!ttg.memdesc<128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>, %arg12 : !ttg.memdesc<128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>) {
+            %38 = ttg.memdesc_trans %arg12 {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable> -> !ttg.memdesc<64x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>, #ttg.shared_memory, mutable>
+            ttng.fence_async_shared {bCluster = false}
+            %39 = ttng.warp_group_dot %arg11, %38, %arg8 : !ttg.memdesc<128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable> * !ttg.memdesc<64x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>, #ttg.shared_memory, mutable> -> tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>
+            %40 = ttng.warp_group_dot_wait %39 {pendings = 0 : i32} : tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>
+            nvws.aref.return %40 : tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>
+          } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory, mutable>], 1>, i32) -> (tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>)
+          %41 = arith.subi %arg9, %c1_i32 : i32
+          %42 = arith.addi %arg9, %c1_i32  : i32
+          scf.yield %40, %42 : tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>, i32
+        }
+        nvws.aref.return %18#0 : tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>
+      } : (!nvws.aref<[tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>]>) -> ()
+      %20 = nvws.aref.get %acc as (%arg10: tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>) {
+        %20 = tt.fp_to_fp %arg10 {}, rounding = rtne : tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>> -> tensor<128x128xf8E4M3FN, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>
+        nvws.aref.return %20 : tensor<128x128xf8E4M3FN, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>
+      } : (!nvws.aref<[tensor<128x128xf32, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>]>) -> (tensor<128x128xf8E4M3FN, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>>)
+      %21 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>}>>
+      %22 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>}>>
+      %23 = tt.splat %5 {} : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>}>>
+      %24 = arith.addi %23, %21 {} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>}>>
+      %25 = tt.splat %6 {} : i32 -> tensor<128xi32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>}>>
+      %26 = arith.addi %25, %22 {} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>}>>
+      %27 = tt.expand_dims %24 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>}>> -> tensor<128x1xi32, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      %28 = tt.splat %arg6  : i32 -> tensor<128x1xi32, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      %29 = arith.muli %28, %27  : tensor<128x1xi32, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      %30 = tt.splat %arg2  : !tt.ptr<f8E4M3FN> -> tensor<128x1x!tt.ptr<f8E4M3FN>, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      %31 = tt.addptr %30, %29  : tensor<128x1x!tt.ptr<f8E4M3FN>, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>, tensor<128x1xi32, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      %32 = tt.expand_dims %26 {axis = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>}>> -> tensor<1x128xi32, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      %33 = tt.broadcast %31  : tensor<128x1x!tt.ptr<f8E4M3FN>, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>> -> tensor<128x128x!tt.ptr<f8E4M3FN>, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      %34 = tt.broadcast %32 : tensor<1x128xi32, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>> -> tensor<128x128xi32, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      %35 = tt.addptr %33, %34 : tensor<128x128x!tt.ptr<f8E4M3FN>, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>, tensor<128x128xi32, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      %36 = ttg.convert_layout %20 : tensor<128x128xf8E4M3FN, #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 32]}>> -> tensor<128x128xf8E4M3FN, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      tt.store %35, %36 : tensor<128x128x!tt.ptr<f8E4M3FN>, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      nvws.warp_group.return
+    }
+    tt.return
+  }
+}

--- a/third_party/nvidia/test/NVWS/lower_aref.mlir
+++ b/third_party/nvidia/test/NVWS/lower_aref.mlir
@@ -205,7 +205,6 @@ module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 0 : i32}, nvws.
         %stage = arith.remsi %arg6, %c2_i32 : i32
         %32 = nvws.aref.get %16[%stage] as (%arg8 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) {
           %32 = ttng.tmem_load %arg8 {} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
-          // need to zero out the tmem here
           nvws.aref.return %32 : tensor<128x128xf32, #blocked>
         } : (!nvws.aref<[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>], 1>, i32) -> (tensor<128x128xf32, #blocked>)
         %33 = tt.fp_to_fp %32 {}, rounding = rtne : tensor<128x128xf32, #blocked> -> tensor<128x128xf8E4M3FN, #blocked>

--- a/third_party/nvidia/test/NVWS/lower_aref.mlir
+++ b/third_party/nvidia/test/NVWS/lower_aref.mlir
@@ -1,0 +1,227 @@
+// RUN: triton-opt %s -split-input-file --nvws-lower-aref | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 4 : i32}, nvws.tma_load = {num_warps = 4 : i32, start_warp = 0 : i32}, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.warp-specialized" = true} {
+  tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %true = arith.constant true
+    %c148_i32 = arith.constant 148 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c-1_i32 = arith.constant -1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c63_i32 = arith.constant 63 : i32
+    %cst = arith.constant {} dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %0 = tt.get_program_id x : i32
+    %1 = arith.addi %arg3, %c127_i32 : i32
+    %2 = arith.divsi %1, %c128_i32 : i32
+    %3 = arith.addi %arg4, %c127_i32 : i32
+    %4 = arith.divsi %3, %c128_i32 : i32
+    %5 = arith.addi %arg5, %c63_i32 : i32
+    %6 = arith.divsi %5, %c64_i32 : i32
+    %7 = arith.muli %2, %4 : i32
+    %8 = arith.divsi %7, %c148_i32 : i32
+    %9 = arith.remsi %7, %c148_i32 : i32
+    %10 = arith.cmpi slt, %0, %9 : i32
+    %11 = scf.if %10 -> (i32) {
+      %22 = arith.addi %8, %c1_i32 : i32
+      scf.yield %22 : i32
+    } else {
+      scf.yield %8 : i32
+    }
+    %12 = arith.subi %0, %c148_i32 : i32
+    %13 = arith.muli %4, %c8_i32 : i32
+    %14 = arith.muli %6, %11 : i32
+    %15 = ttng.tmem_alloc %cst {} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %16 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>
+    %17 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>
+    %18 = nvws.aref.create %16, %17 : !nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>
+    %19 = nvvm.read.ptx.sreg.tid.x : i32
+    %20 = arith.divsi %19, %c128_i32 : i32
+    %21 = arith.cmpi eq, %20, %c0_i32 : i32
+    nvvm.barrier0
+    nvws.warp_group
+    partition0 num_warps(4) {
+      nvvm.setmaxregister  decrease 40
+      %22:5 = scf.for %arg6 = %c0_i32 to %14 step %c1_i32 iter_args(%arg7 = %c-1_i32, %arg8 = %12, %arg9 = %c0_i32, %arg10 = %c0_i32, %arg11 = %c0_i32) -> (i32, i32, i32, i32, i32) : i32 {
+        %23 = arith.subi %6, %c1_i32 {} : i32
+        %24 = arith.cmpi eq, %arg7, %23 {} : i32
+        %25 = arith.addi %arg7, %c1_i32 {} : i32
+        %26 = arith.select %24, %c0_i32, %25 {} : i32
+        %27 = arith.cmpi eq, %26, %c0_i32 {} : i32
+        %28:3 = scf.if %27 -> (i32, i32, i32) {
+          %33 = arith.addi %arg8, %c148_i32 {} : i32
+          %34 = arith.divsi %33, %13 {} : i32
+          %35 = arith.muli %34, %c8_i32 {} : i32
+          %36 = arith.subi %2, %35 {} : i32
+          %37 = arith.minsi %36, %c8_i32 {} : i32
+          %38 = arith.remsi %33, %37 {} : i32
+          %39 = arith.addi %35, %38 {} : i32
+          %40 = arith.remsi %33, %13 {} : i32
+          %41 = arith.divsi %40, %37 {} : i32
+          %42 = arith.muli %39, %c128_i32 {} : i32
+          %43 = arith.muli %41, %c128_i32 {} : i32
+          scf.yield %33, %42, %43 : i32, i32, i32
+        } else {
+          scf.yield %arg8, %arg9, %arg10 : i32, i32, i32
+        }
+        %29 = arith.muli %26, %c64_i32 {} : i32
+        %30 = tt.reinterpret_tensor_descriptor %arg0 {} : !tt.ptr<f32> to !tt.tensordesc<tensor<128x64xf8E4M3FN>>
+        %31 = tt.reinterpret_tensor_descriptor %arg1 {} : !tt.ptr<f32> to !tt.tensordesc<tensor<128x64xf8E4M3FN>>
+        nvws.aref.put %18[%arg11] as (%arg12: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>,
+                                      %arg13: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>) {
+          %33 = tt.descriptor_load %30[%28#1, %29] {} : !tt.tensordesc<tensor<128x64xf8E4M3FN>> -> tensor<128x64xf8E4M3FN, #blocked1>
+          ttg.local_store %33, %arg12 : tensor<128x64xf8E4M3FN, #blocked1> -> !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>
+          %34 = tt.descriptor_load %31[%28#2, %29] {} : !tt.tensordesc<tensor<128x64xf8E4M3FN>> -> tensor<128x64xf8E4M3FN, #blocked1>
+          ttg.local_store %34, %arg13 : tensor<128x64xf8E4M3FN, #blocked1> -> !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>
+          nvws.aref.return
+        } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
+        %32 = arith.addi %arg11, %c1_i32 {} : i32
+        scf.yield {} %26, %28#0, %28#1, %28#2, %32 : i32, i32, i32, i32, i32
+      }
+      nvws.warp_group.return
+    } partition1 num_warps(4) {
+      nvvm.setmaxregister  increase 232
+      %22:3 = scf.for %arg6 = %c0_i32 to %14 step %c1_i32 iter_args(%arg7 = %c-1_i32, %arg8 = %false, %arg9 = %c0_i32) -> (i32, i1, i32)  : i32 {
+        nvws.aref.get %18[%arg9] as (%arg10 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>,
+                                     %arg11: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>) {
+          %24 = ttg.memdesc_trans %arg11 {order=array<i32: 1,0>} : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>
+          ttng.tc_gen5_mma %arg10, %24, %15, %arg8, %true : (!ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1, i1) -> ()
+          nvws.aref.return
+        } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
+        %25 = arith.subi %6, %c1_i32 {} : i32
+        %26 = arith.cmpi eq, %arg7, %25 {} : i32
+        %27 = arith.addi %arg7, %c1_i32 {} : i32
+        %28 = arith.select %26, %c0_i32, %27 {} : i32
+        %29 = arith.cmpi eq, %28, %25 {} : i32
+        %30 = arith.cmpi ne, %28, %25 {} : i32
+        scf.if %29 {
+          %32 = arith.addi %arg6, %c1_i32 : i32
+          %33 = arith.divsi %32, %6 : i32
+          %34 = arith.muli %33, %c148_i32 : i32
+          %35 = arith.addi %12, %34 : i32
+          %36 = arith.divsi %35, %13 : i32
+          %37 = arith.muli %36, %c8_i32 : i32
+          %38 = arith.subi %2, %37 : i32
+          %39 = arith.minsi %38, %c8_i32 : i32
+          %40 = arith.remsi %35, %39 : i32
+          %41 = arith.addi %37, %40 : i32
+          %42 = arith.remsi %35, %13 : i32
+          %43 = arith.divsi %42, %39 : i32
+          %44 = arith.muli %41, %c128_i32 {tt.divisibility = dense<128> : tensor<1xi32>} : i32
+          %45 = arith.muli %43, %c128_i32 {tt.divisibility = dense<128> : tensor<1xi32>} : i32
+          %46 = ttng.tmem_load %15 {} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+          %47 = tt.fp_to_fp %46, rounding = rtne : tensor<128x128xf32, #blocked> -> tensor<128x128xf8E4M3FN, #blocked>
+          %48 = ttg.convert_layout %47 : tensor<128x128xf8E4M3FN, #blocked> -> tensor<128x128xf8E4M3FN, #blocked2>
+          %49 = tt.reinterpret_tensor_descriptor %arg2 : !tt.ptr<f32> to !tt.tensordesc<tensor<128x128xf8E4M3FN>>
+          tt.descriptor_store %49[%44, %45], %48 {} : !tt.tensordesc<tensor<128x128xf8E4M3FN>>, tensor<128x128xf8E4M3FN, #blocked2>
+        }
+        %31 = arith.addi %arg9, %c1_i32 {} : i32
+        scf.yield {} %28, %30, %31 : i32, i1, i32
+      }
+      nvws.warp_group.return
+    }
+    tt.return
+  }
+}
+
+// -----
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+module attributes {nvws.mma = {num_warps = 4 : i32, start_warp = 0 : i32}, nvws.tma_load = {num_warps = 4 : i32, start_warp = 4 : i32}, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.warp-specialized" = true} {
+  tt.func public @matmul_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f8E4M3FN> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %true = arith.constant true
+    %c128_i32 = arith.constant {} 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c127_i32 = arith.constant {} 127 : i32
+    %c63_i32 = arith.constant 63 : i32
+    %cst = arith.constant {} dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %0 = tt.get_program_id x {} : i32
+    %1 = arith.addi %arg3, %c127_i32 {} : i32
+    %2 = arith.divsi %1, %c128_i32 {} : i32
+    %3 = arith.remsi %0, %2 {} : i32
+    %4 = arith.divsi %0, %2 {} : i32
+    %5 = arith.muli %3, %c128_i32 {} : i32
+    %6 = arith.muli %4, %c128_i32 {} : i32
+    %7 = arith.addi %arg5, %c63_i32 : i32
+    %8 = arith.divsi %7, %c64_i32 : i32
+    %9 = ttng.tmem_alloc %cst {} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %10 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>
+    %11 = ttg.local_alloc  {aref_buffer} : () -> !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>
+    %12 = nvws.aref.create %10, %11 : !nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>
+    %13 = nvvm.read.ptx.sreg.tid.x : i32
+    %14 = arith.divsi %13, %c128_i32 : i32
+    %15 = arith.cmpi eq, %14, %c1_i32 : i32
+    nvvm.barrier0
+    nvws.warp_group
+    partition0 num_warps(4) {
+      nvvm.setmaxregister  decrease 40
+      %16:2 = scf.for %arg7 = %c0_i32 to %8 step %c1_i32 iter_args(%arg8 = %c0_i32, %arg9 = %c0_i32) -> (i32, i32)  : i32 {
+        %17 = tt.reinterpret_tensor_descriptor %arg0 {} : !tt.ptr<f32> to !tt.tensordesc<tensor<128x64xf8E4M3FN>>
+        %18 = tt.reinterpret_tensor_descriptor %arg1 {} : !tt.ptr<f32> to !tt.tensordesc<tensor<128x64xf8E4M3FN>>
+        nvws.aref.put %12[%arg9] as (%arg10: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>,
+                                     %arg11: !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>) {
+          %21 = tt.descriptor_load %17[%5, %arg8] {} : !tt.tensordesc<tensor<128x64xf8E4M3FN>> -> tensor<128x64xf8E4M3FN, #blocked1>
+          ttg.local_store %21, %arg10 : tensor<128x64xf8E4M3FN, #blocked1> -> !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>
+          %22 = tt.descriptor_load %18[%6, %arg8] {} : !tt.tensordesc<tensor<128x64xf8E4M3FN>> -> tensor<128x64xf8E4M3FN, #blocked1>
+          ttg.local_store %22, %arg11 : tensor<128x64xf8E4M3FN, #blocked1> -> !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>
+          nvws.aref.return
+        } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
+        %19 = arith.addi %arg8, %c64_i32 {} : i32
+        %20 = arith.addi %arg9, %c1_i32 {} : i32
+        scf.yield {} %19, %20 : i32, i32
+      }
+      nvws.warp_group.return
+    }
+    partition1 num_warps(4) {
+      nvvm.setmaxregister  increase 232
+      %16 = scf.for %arg7 = %c0_i32 to %8 step %c1_i32 iter_args(%arg8 = %c0_i32) -> (i32)  : i32 {
+        nvws.aref.get %12[%arg8] as (%arg9 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>,
+                                     %arg10 : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>) {
+          %36 = ttg.memdesc_trans %arg10 {order=array<i32: 1,0>} : !ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>
+          ttng.tc_gen5_mma %arg9, %36, %9, %true, %true {} : (!ttg.memdesc<128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<64x128xf8E4M3FN, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, i1, i1) -> ()
+          nvws.aref.return
+        } : (!nvws.aref<[!ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf8E4M3FN, #shared, #smem, mutable>], 1>, i32) -> ()
+        %37 = arith.addi %arg8, %c1_i32 {} : i32
+        scf.yield {} %37 : i32
+      }
+      %17 = ttng.tmem_load %9 {} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      %18 = tt.fp_to_fp %17 {}, rounding = rtne : tensor<128x128xf32, #blocked> -> tensor<128x128xf8E4M3FN, #blocked>
+      %19 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>>
+      %20 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked2}>>
+      %21 = tt.splat %5 {} : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>>
+      %22 = arith.addi %21, %19 {} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>>
+      %23 = tt.splat %6 {} : i32 -> tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked2}>>
+      %24 = arith.addi %23, %20 {} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked2}>>
+      %25 = tt.expand_dims %22 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked2}>> -> tensor<128x1xi32, #blocked2>
+      %26 = tt.splat %arg6 {} : i32 -> tensor<128x1xi32, #blocked2>
+      %27 = arith.muli %26, %25 {} : tensor<128x1xi32, #blocked2>
+      %28 = tt.splat %arg2 {} : !tt.ptr<f8E4M3FN> -> tensor<128x1x!tt.ptr<f8E4M3FN>, #blocked2>
+      %29 = tt.addptr %28, %27 {} : tensor<128x1x!tt.ptr<f8E4M3FN>, #blocked2>, tensor<128x1xi32, #blocked2>
+      %30 = tt.expand_dims %24 {axis = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked2}>> -> tensor<1x128xi32, #blocked2>
+      %31 = tt.broadcast %29 {} : tensor<128x1x!tt.ptr<f8E4M3FN>, #blocked2> -> tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked2>
+      %32 = tt.broadcast %30 {} : tensor<1x128xi32, #blocked2> -> tensor<128x128xi32, #blocked2>
+      %33 = tt.addptr %31, %32 {} : tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked2>, tensor<128x128xi32, #blocked2>
+      %34 = ttg.convert_layout %18 : tensor<128x128xf8E4M3FN, #blocked> -> tensor<128x128xf8E4M3FN, #blocked2>
+      tt.store %33, %34 {} : tensor<128x128x!tt.ptr<f8E4M3FN>, #blocked2>
+      nvws.warp_group.return
+    }
+    tt.return
+  }
+}


### PR DESCRIPTION
Supports regular and persistent matmuls on Hopper/Blackwell. Doesn't yet support attention. 

Also includes a verifier/lit tests for nvws.aref.create.

Marking as draft until I can add `// Check` commands to the lit test. 