### PR TITLE
[BACKEND] Improve subtiling code generation when loading from tmem

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -473,6 +473,27 @@ def TTNG_TMEMAllocOp : TTNG_Op<"tmem_alloc", [DeclareOpInterfaceMethods<MemoryEf
   let hasVerifier = 1;
 }
 
+def TTNG_TMEMSubSliceOp : TTNG_Op<"tmem_subslice", [Pure]> {
+  let summary = "Take a subslice of a tensor memory allocation";
+  let description = [{
+    This operation takes a subslice of a tensor memory allocation and returns a new descriptor
+    containing the address and a view of the subslice.
+    This is similar to ttg.memdesc_subview except the offset needs to be static and we can only
+    slice alog the inner dimension of a 2D memdesc as this is the only one we can do for TMem.
+  }];
+  let arguments = (ins TTG_MemDescType:$src, I32Attr:$N);
+
+  let assemblyFormat = [{
+    $src attr-dict `:` qualified(type($src)) `->` qualified(type($result))
+  }];
+
+  let builders = [
+      OpBuilder<(ins "Value":$alloc, "int":$offset, "int":$size)>,
+    ];
+  let results = (outs TTG_MemDescType:$result);
+  let hasVerifier = 1;
+}
+
 def TTNG_TMEMCopyOp : TTNG_Op<"tmem_copy", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "Initiate an asynchronous copy operation from shared memory to the Tensor Memory.";
 

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h
@@ -60,6 +60,8 @@ std::unique_ptr<Pass> createTritonNvidiaGPUPromoteLHSToTMemPass();
 
 std::unique_ptr<Pass> createTritonNvidiaGPUOptimizeDescriptorEncodingPass();
 
+std::unique_ptr<Pass> createTritonNvidiaGPUOptimizeTMemSubtilingPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #define GEN_PASS_DECL_TRITONNVIDIAGPULEGALIZETMALAYOUTS

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -130,4 +130,16 @@ def TritonNvidiaGPUOptimizeDescriptorEncodingPass : Pass<"triton-nvidia-optimize
                            "mlir::triton::TritonDialect"];
 }
 
+def TritonNvidiaGPUOptimizeTMemSubtilingPass : Pass<"triton-nvidia-optimize-tmem-subtiling", "mlir::ModuleOp"> {
+  let summary = "Optimize subtiling.";
+
+  let description = [{
+    Optimize subtiling by trying to split tmem_load when user splits a tensor.
+  }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+                           "mlir::triton::TritonDialect"];
+}
+
 #endif

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   FenceInsertion.cpp
   MMALowering.cpp
   OptimizeDescriptorEncoding.cpp
+  OptimizeTMemSubtiling.cpp
   PlanCTA.cpp
   PromoteLHSToTMem.cpp
   TensorMemoryAllocation.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemSubtiling.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemSubtiling.cpp
@@ -1,0 +1,207 @@
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
+
+namespace {
+
+using namespace mlir;
+
+namespace ttng = triton::nvidia_gpu;
+namespace ttg = triton::gpu;
+namespace tt = triton;
+
+#define GEN_PASS_CLASSES
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+// If we don't know the effects of the op, we add all possible effects.
+static void addAllValuelessEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Read>());
+  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Write>());
+  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Allocate>());
+  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Free>());
+}
+
+static bool
+collectEffects(Operation *op,
+               SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  // Collect effect instances the operation. Note that the implementation of
+  // getEffects erases all effect instances that have the type other than the
+  // template parameter so we collect them first in a local buffer and then
+  // copy.
+  if (auto iface = dyn_cast<MemoryEffectOpInterface>(op)) {
+    SmallVector<MemoryEffects::EffectInstance> localEffects;
+    iface.getEffects(localEffects);
+    llvm::append_range(effects, localEffects);
+    return true;
+  }
+  if (op->hasTrait<OpTrait::HasRecursiveMemoryEffects>()) {
+    for (auto &region : op->getRegions()) {
+      for (auto &block : region) {
+        for (auto &innerOp : block)
+          if (!collectEffects(&innerOp, effects))
+            return false;
+      }
+    }
+    return true;
+  }
+
+  // We need to be conservative here in case the op doesn't have the interface
+  // and assume it can have any possible effect.
+  addAllValuelessEffects(effects);
+  return false;
+}
+
+// Sink tmem_loads as close to their use as possible to reduce register
+// pressure.
+static void sinkLoad(ttng::TMEMLoadOp load, Operation *cvt) {
+  Operation *insertBefore = nullptr;
+  Operation *next = cvt->getNextNode();
+  while (next && !next->hasTrait<OpTrait::IsTerminator>()) {
+    insertBefore = next;
+    bool dep = false;
+    for (auto operand : next->getOperands()) {
+      if (operand == cvt->getResult(0)) {
+        dep = true;
+        break;
+      }
+    }
+    if (!isMemoryEffectFree(next)) {
+      SmallVector<MemoryEffects::EffectInstance> effects;
+      collectEffects(next, effects);
+      for (auto effect : effects) {
+        if (effect.getEffect() ==
+                MemoryEffects::Effect::get<MemoryEffects::Write>() ||
+            effect.getEffect() ==
+                MemoryEffects::Effect::get<MemoryEffects::Allocate>()) {
+          if (effect.getResource() ==
+                  mlir::SideEffects::DefaultResource::get() ||
+              effect.getResource() ==
+                  mlir::triton::nvidia_gpu::TensorMemory::get()) {
+            dep = true;
+            break;
+          }
+        }
+      }
+    }
+    if (dep)
+      break;
+    next = next->getNextNode();
+  }
+  if (insertBefore) {
+    load->moveBefore(insertBefore);
+    cvt->moveBefore(insertBefore);
+  }
+}
+
+// clang-format off
+// Converts:
+//  %l = ttng.tmem_load %o : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked>
+//  %r = tt.reshape %l : tensor<128x256xf32, #blocked> -> tensor<128x2x128xf32, #blocked4>
+//  %t = tt.trans %r {order = array<i32: 0, 2, 1>} : tensor<128x2x128xf32, #blocked4> -> tensor<128x128x2xf32, #blocked5>
+//  %outLHS, %outRHS = tt.split %t : tensor<128x128x2xf32, #blocked5> -> tensor<128x128xf32, #blocked2>
+// To:
+//  %o0 = ttng.tmem_subslice %o { N = 0 }: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+//  %outLHS = ttng.tmem_load %o0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+//  %o1 = ttng.tmem_subslice %o { N = 128 }: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+//  %outRHS = ttng.tmem_load %o1 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+// clang-format on
+// This will change the layout of the destination tensor to distribute each
+// slice across warps. It currently only supports simple cases where tmem can be
+// sliced easily. This could be extended if needed with more powerful slicing
+// support of tmem.
+class TMemSplitLoadPattern : public OpRewritePattern<tt::SplitOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tt::SplitOp splitOp,
+                                PatternRewriter &rewriter) const override {
+    auto src = splitOp.getSrc();
+    // Skip convert layout ops.
+    while (auto cvt = src.getDefiningOp<ttg::ConvertLayoutOp>()) {
+      src = cvt.getSrc();
+    }
+    // Only support splitting N dimension on the outer most.
+    auto transOp = src.getDefiningOp<tt::TransOp>();
+    if (!transOp || transOp.getOrder() != ArrayRef<int>({0, 2, 1}))
+      return failure();
+    auto reshapeOp = transOp.getSrc().getDefiningOp<tt::ReshapeOp>();
+    if (!reshapeOp)
+      return failure();
+    auto shape = reshapeOp.getResult().getType().getShape();
+    if (shape[0] != reshapeOp.getSrc().getType().getShape()[0])
+      return failure();
+    auto tmemLoad = reshapeOp.getSrc().getDefiningOp<ttng::TMEMLoadOp>();
+    if (!tmemLoad)
+      return failure();
+    // We found a tmem_load that is split on the N dimension. We can split it
+    // into multiple tmem_loads.
+    int mDim = getShapePerCTA(tmemLoad.getSrc().getType())[0];
+    // TODO: enable other M cases. (the layout is a bit more complex).
+    if (mDim != 128)
+      return failure();
+    int splitNSize = shape[2];
+    if (splitNSize < 8)
+      return failure();
+    Value tmem = tmemLoad.getSrc();
+    int numWarps = ttg::lookupNumWarps(tmemLoad);
+    rewriter.setInsertionPoint(tmemLoad);
+    // First slice.
+    Value subSlice0 = rewriter.create<ttng::TMEMSubSliceOp>(
+        tmemLoad.getLoc(), tmem, 0, splitNSize);
+    Attribute distLayout = ttng::getTmemCompatibleLayout(
+        mDim, splitNSize, splitOp.getOutLHS().getType(), numWarps);
+    RankedTensorType newLoadType = RankedTensorType::get(
+        splitOp.getOutLHS().getType().getShape(),
+        splitOp.getOutLHS().getType().getElementType(), distLayout);
+    auto load0 = rewriter.create<ttng::TMEMLoadOp>(tmemLoad.getLoc(),
+                                                   newLoadType, subSlice0);
+    auto cvt0 = rewriter.create<ttg::ConvertLayoutOp>(
+        tmemLoad.getLoc(), splitOp.getOutLHS().getType(), load0);
+    // Second slice.
+    Value subSlice1 = rewriter.create<ttng::TMEMSubSliceOp>(
+        tmemLoad.getLoc(), tmem, splitNSize, splitNSize);
+    auto load1 = rewriter.create<ttng::TMEMLoadOp>(tmemLoad.getLoc(),
+                                                   newLoadType, subSlice1);
+    auto cvt1 = rewriter.create<ttg::ConvertLayoutOp>(
+        tmemLoad.getLoc(), splitOp.getOutRHS().getType(), load1);
+    rewriter.replaceOp(splitOp, {cvt0, cvt1});
+    sinkLoad(load0, cvt0);
+    sinkLoad(load1, cvt1);
+    return success();
+  }
+};
+
+class TritonNvidiaGPUOptimizeTMemSubtilingPass
+    : public TritonNvidiaGPUOptimizeTMemSubtilingPassBase<
+          TritonNvidiaGPUOptimizeTMemSubtilingPass> {
+public:
+  using BaseT = TritonNvidiaGPUOptimizeTMemSubtilingPassBase<
+      TritonNvidiaGPUOptimizeTMemSubtilingPass>;
+  using BaseT::BaseT;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp m = getOperation();
+
+    mlir::RewritePatternSet patterns(context);
+    patterns.add<TMemSplitLoadPattern>(context);
+    if (failed(applyPatternsGreedily(m, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createTritonNvidiaGPUOptimizeTMemSubtilingPass() {
+  return std::make_unique<TritonNvidiaGPUOptimizeTMemSubtilingPass>();
+}

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemSubtiling.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemSubtiling.cpp
@@ -69,7 +69,7 @@ static void sinkLoad(ttng::TMEMLoadOp load, Operation *cvt) {
   while (next && !next->hasTrait<OpTrait::IsTerminator>()) {
     insertBefore = next;
     bool dep = false;
-    for (auto operand : next->getOperands()) {
+    for (auto operand : getNestedOperands(next)) {
       if (operand == cvt->getResult(0)) {
         dep = true;
         break;

--- a/test/TritonNvidiaGPU/tmem_subtiling.mlir
+++ b/test/TritonNvidiaGPU/tmem_subtiling.mlir
@@ -1,0 +1,108 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-optimize-tmem-subtiling --allow-unregistered-dialect | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 2, 1], order = [0, 2, 1]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 64, 1], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 2], order = [0, 1, 2]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @subtile_tmem_load
+  tt.func public @subtile_tmem_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>) {
+    // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
+    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %{{.+}} {N = 64 : i32}
+    // CHECK: %[[L0:.+]] = ttng.tmem_load %[[S0]] : !ttg.memdesc<128x64xf32
+    // CHECK: %[[C0:.+]] = ttg.convert_layout %[[L0]]
+    // CHECK: %[[L1:.+]] = ttng.tmem_load %[[S1]] : !ttg.memdesc<128x64xf32
+    // CHECK: %[[C1:.+]] = ttg.convert_layout %[[L1]]
+    // CHECK: tt.return %[[C0]], %[[C1]]
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+    %1 = tt.reshape %0 : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked2>
+    %2 = tt.trans %1 {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked2> -> tensor<128x64x2xf32, #blocked3>
+    %3 = ttg.convert_layout %2 : tensor<128x64x2xf32, #blocked3> -> tensor<128x64x2xf32, #blocked4>
+    %outLHS, %outRHS = tt.split %3 : tensor<128x64x2xf32, #blocked4> -> tensor<128x64xf32, #blocked>
+    tt.return %outLHS, %outRHS : tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 2, 1], order = [0, 2, 1]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 64, 1], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 2], order = [0, 1, 2]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @subtile_tmem_load_256
+  // CHECK-NOT: ttng.tmem_subslice
+  // CHECK: tt.return
+  tt.func public @subtile_tmem_load_256(%arg0: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<256x64xf32, #blocked>, tensor<256x64xf32, #blocked>) {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x128xf32, #blocked1>
+    %1 = tt.reshape %0 : tensor<256x128xf32, #blocked1> -> tensor<256x2x64xf32, #blocked2>
+    %2 = tt.trans %1 {order = array<i32: 0, 2, 1>} : tensor<256x2x64xf32, #blocked2> -> tensor<256x64x2xf32, #blocked3>
+    %3 = ttg.convert_layout %2 : tensor<256x64x2xf32, #blocked3> -> tensor<256x64x2xf32, #blocked4>
+    %outLHS, %outRHS = tt.split %3 : tensor<256x64x2xf32, #blocked4> -> tensor<256x64xf32, #blocked>
+    tt.return %outLHS, %outRHS : tensor<256x64xf32, #blocked>, tensor<256x64xf32, #blocked>
+  }
+}
+
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 2, 1], order = [0, 2, 1]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 64, 1], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 2], order = [0, 1, 2]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
+  tt.func public @sink_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                            %arg1: tensor<128x128xf16, #blocked>,
+                            %arg2: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>)
+                            -> (tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>) {
+
+    // CHECK: ttg.local_alloc
+    // CHECK: ttng.tmem_load
+    // CHECK: ttg.convert_layout
+    // CHECK: arith.truncf
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+    %1 = tt.reshape %0 : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked2>
+    %2 = tt.trans %1 {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked2> -> tensor<128x64x2xf32, #blocked3>
+    %3 = ttg.convert_layout %2 : tensor<128x64x2xf32, #blocked3> -> tensor<128x64x2xf32, #blocked4>
+    %outLHS, %outRHS = tt.split %3 : tensor<128x64x2xf32, #blocked4> -> tensor<128x64xf32, #blocked>
+
+    // CHECK: ttng.tmem_load
+    // CHECK: ttg.convert_layout
+    // CHECK: ttng.tmem_store
+    // CHECK: arith.truncf
+    %4 = ttg.local_alloc %arg1 : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+    %5 = arith.truncf %outLHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked5>
+    ttng.tmem_store %cst, %arg2, %true : tensor<128x128xf32, #blocked5> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %6 = arith.truncf %outRHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+
+    // CHECK: ttng.tmem_load
+    // CHECK: ttg.convert_layout
+    // CHECK: "unknow_may_side_effect"() : () -> ()
+    // CHECK: arith.truncf
+    %7 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+    %8 = tt.reshape %7 : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked2>
+    %9 = tt.trans %8 {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked2> -> tensor<128x64x2xf32, #blocked3>
+    %10 = ttg.convert_layout %9 : tensor<128x64x2xf32, #blocked3> -> tensor<128x64x2xf32, #blocked4>
+    %outLHS2, %outRHS3 = tt.split %10 : tensor<128x64x2xf32, #blocked4> -> tensor<128x64xf32, #blocked>
+    "unknow_may_side_effect"() : () -> ()
+    %11 = arith.truncf %outLHS2 : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+
+    ttg.local_dealloc %4 : !ttg.memdesc<128x128xf16, #shared, #smem>
+    tt.return %5, %6, %11 : tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -286,6 +286,7 @@ class CUDABackend(BaseBackend):
         passes.ttgpuir.add_prefetch(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm, capability >= 80)
         passes.ttgpuir.add_coalesce_async_copy(pm)
+        nvidia.passes.ttnvgpuir.add_optimize_tmem_subtiling(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_reduce_data_duplication(pm)
         passes.ttgpuir.add_reorder_instructions(pm)

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -46,6 +46,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      mlir::createTritonNvidiaGPUMMALoweringPass);
   ADD_PASS_WRAPPER_0("add_optimize_descriptor_encoding",
                      mlir::createTritonNvidiaGPUOptimizeDescriptorEncodingPass);
+  ADD_PASS_WRAPPER_0("add_optimize_tmem_subtiling",
+                     mlir::createTritonNvidiaGPUOptimizeTMemSubtilingPass);
 }
 
 void init_triton_nvidia_passes_nvws(py::module &&m) {


### PR DESCRIPTION
When loading from tmem we have multiple choices on how to distribute the tensor in registers. If we see that the tensor will be split along N we break up the tmem_load to allow it to be better scheduled.

Also try to sink tmem_load as late as possible to save register pressure. This may need to be tweaked if it causes latency problems.