### PR TITLE
Correct ctad-maybe-unsupported warning

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/FoldTrueCmpIOp.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/FoldTrueCmpIOp.cpp
@@ -18,7 +18,7 @@ struct TritonAMDFoldTrueCmpIOpPass
   void runOnOperation() override {
     DenseMap<Value, SetVector<Operation *>> assumptions =
         AMD::TritonIntegerRangeAnalysis::collectAssumptions(getOperation());
-    std::unique_ptr solver = createDataFlowSolver();
+    std::unique_ptr<DataFlowSolver> solver = createDataFlowSolver();
     solver->load<AMD::TritonIntegerRangeAnalysis>(assumptions);
     if (failed(solver->initializeAndRun(getOperation())))
       return signalPassFailure();


### PR DESCRIPTION
Adding a deduction guide as "std::unique_ptr may not intend to support class template argument deduction"
