### PR TITLE
[AMD][BACKEND] Count vmcnt instructions for AsyncWait to emit correct vmcnt

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -73,6 +73,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUConvertToBufferOps();
   mlir::registerTritonAMDGPUInThreadTranspose();
   mlir::registerTritonAMDGPUCoalesceAsyncCopy();
+  mlir::registerTritonAMDGPUUpdateAsyncWaitCount();
   mlir::triton::registerTritonAMDGPUInsertInstructionSchedHints();
   mlir::triton::registerTritonAMDGPULowerInstructionSchedHints();
   mlir::registerTritonAMDFoldTrueCmpI();

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -17,11 +17,39 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %3 = ttg.async_commit_group %2
 
     // Do not wait on the second async_copy => waitcnt 2
-    //CHECK: ttg.async_wait {{.*}} {num = 2
+    // CHECK: ttg.async_wait {{.*}} {num = 2
     %9 = ttg.async_wait %1 {num = 0 : i32}
     // No async_copies in between => waitcnt 0
-    //CHECK: ttg.async_wait {{.*}} {num = 0
+    // CHECK: ttg.async_wait {{.*}} {num = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Same as simple_waitcnt but swapped async_waits
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @simple_waitcnt(%arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
+    // Emits 1 direct to lds instruction
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+    // Emits 2 direct to lds instructions
+    %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %3 = ttg.async_commit_group %2
+
+    // Do not wait on the second async_copy => waitcnt 2
+    // CHECK: ttg.async_wait {{.*}} {num = 0
+    %9 = ttg.async_wait %3 {num = 0 : i32}
+    // No async_copies in between => waitcnt 0
+    // CHECK: ttg.async_wait {{.*}} {num = 2
+    %10 = ttg.async_wait %1 {num = 0 : i32}
     tt.return
   }
 }
@@ -46,9 +74,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     %4 = tt.load %arg3 : tensor<128x16x!tt.ptr<f16>, #blocked>
 
-    //CHECK: ttg.async_wait {{.*}} {num = 2
+    // CHECK: ttg.async_wait {{.*}} {num = 2
     %9 = ttg.async_wait %1 {num = 0 : i32}
-    //CHECK: ttg.async_wait {{.*}} {num = 0
+    // CHECK: ttg.async_wait {{.*}} {num = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
   }
@@ -74,7 +102,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group %2
     %8:2 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %3) -> (!ttg.async.token, !ttg.async.token)  : i32 {
-      //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+      // CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
       %10 = ttg.async_wait %arg15, %arg16 {num = 2 : i32}
       %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       %12 = ttg.async_commit_group %11
@@ -82,7 +110,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %14 = ttg.async_commit_group %13
       scf.yield %12, %14: !ttg.async.token, !ttg.async.token
     }
-    //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+    // CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
     %9 = ttg.async_wait %8#0, %8#1 {num = 0 : i32}
     tt.return
   }
@@ -112,7 +140,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %7 = ttg.async_commit_group %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
-      //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 3
+      // CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 3
       %10 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
       %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       %12 = ttg.async_commit_group %11
@@ -120,7 +148,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %14 = ttg.async_commit_group %13
       scf.yield %arg16, %12, %arg18, %14 : !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
     }
-    //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+    // CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
     %9 = ttg.async_wait %8#0, %8#1, %8#2, %8#3 {num = 0 : i32}
     tt.return
   }
@@ -151,12 +179,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token) : i32 {
       %103 = scf.if %cond -> (!ttg.async.token) {
         // We wait on both tokens so we interleave with one iteration => 3
-        //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 3
+        // CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 3
         %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
         scf.yield %token1 : !ttg.async.token
       } else {
         // We only wait on the token of the first load so we can interleave one more load => 3 + 2
-        //CHECK: ttg.async_wait {{.*}} {num = 5
+        // CHECK: ttg.async_wait {{.*}} {num = 5
         %token2 = ttg.async_wait %arg15 {num = 1 : i32}
         scf.yield %token2 : !ttg.async.token
       }
@@ -166,7 +194,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %14 = ttg.async_commit_group %13
       scf.yield %arg16, %12, %arg18, %14 : !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
     }
-    //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+    // CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
     %9 = ttg.async_wait %8#0, %8#1, %8#2, %8#3 {num = 0 : i32}
     tt.return
   }
@@ -200,7 +228,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         %cond_load = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
         %cond_load_commit = ttg.async_commit_group %cond_load
         // We wait on both tokens (3) and additionally we should count the load inside our block (+2) => 5
-        //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 5
+        // CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 5
         %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
         scf.yield %token1 : !ttg.async.token
       } else {
@@ -212,7 +240,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %14 = ttg.async_commit_group %13
       scf.yield %arg16, %12, %arg18, %14 : !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
     }
-    //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+    // CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
     %9 = ttg.async_wait %8#0, %8#1, %8#2, %8#3 {num = 0 : i32}
     tt.return
   }
@@ -243,7 +271,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %7 = ttg.async_commit_group %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
       // The then block contains 3 instructions and the else 1 so we expect the count to be 3 (1 + 2) because there are also 2 instructions outside the scf.if in the loop body
-      //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 3
+      // CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 3
       %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
 
       %103 = scf.if %cond -> (!ttg.async.token) {
@@ -260,8 +288,74 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %14 = ttg.async_commit_group %13
       scf.yield %arg16, %103, %arg18, %14 : !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
     }
-    //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+    // CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
     %9 = ttg.async_wait %8#0, %8#1, %8#2, %8#3 {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Test for dynamic loop in def chain
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @double_buffering(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    // Emits 1 direct to lds instruction
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+    // Emits 1 direct to lds instruction
+    %6 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %7 = ttg.async_commit_group %6
+    // Loop with 4 iterations => 4 instructions
+    %30 = scf.for %arg21 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg30 = %6) -> (!ttg.async.token) : i32 {
+      // CHECK: ttg.async_wait {{.*}} {num = 0
+      %31 = ttg.async_wait %arg30 {num = 1 : i32}
+      // Emits 1 direct to lds instruction
+      %32 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+      %33 = ttg.async_commit_group %32
+      scf.yield %33 : !ttg.async.token
+    }
+    // CHECK: ttg.async_wait {{.*}} {num = 1
+    %10 = ttg.async_wait %1 {num = 1 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Test loop in def chain with constant iteration count
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @double_buffering(%arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    // Emits 1 direct to lds instruction
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+    // Emits 1 direct to lds instruction
+    %6 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %7 = ttg.async_commit_group %6
+    // Loop with 4 iterations => 4 instructions
+    %30 = scf.for %arg21 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg30 = %6) -> (!ttg.async.token) : i32 {
+      // CHECK: ttg.async_wait {{.*}} {num = 0
+      %31 = ttg.async_wait %arg30 {num = 1 : i32}
+      // Emits 1 direct to lds instruction
+      %32 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+      %33 = ttg.async_commit_group %32
+      scf.yield %33 : !ttg.async.token
+    }
+    // CHECK: ttg.async_wait {{.*}} {num = 5
+    %10 = ttg.async_wait %1 {num = 1 : i32}
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -8,10 +8,8 @@
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @simple_waitcnt(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
-    %c0_i32 = arith.constant 0 : i32
-    %c1_i32 = arith.constant 1 : i32
-    // Emits 1 direct to lds instructions
+  tt.func public @simple_waitcnt(%arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
+    // Emits 1 direct to lds instruction
     %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %1 = ttg.async_commit_group %0
     // Emits 2 direct to lds instructions
@@ -38,10 +36,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @simple_waitcnt_with_tt_load(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
-    %c0_i32 = arith.constant 0 : i32
-    %c1_i32 = arith.constant 1 : i32
-    // Emits 1 direct to lds instructions
+  tt.func public @simple_waitcnt_with_tt_load(%arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
+    // Emits 1 direct to lds instruction
     %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %1 = ttg.async_commit_group %0
     // Emits 2 direct to lds instructions
@@ -68,10 +64,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @for_loop(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  tt.func public @for_loop(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
-    // Emits 1 direct to lds instructions
+    // Emits 1 direct to lds instruction
     %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %1 = ttg.async_commit_group %0
     // Emits 2 direct to lds instructions
@@ -102,10 +98,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @double_buffering(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  tt.func public @double_buffering(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
-    // Emits 1 direct to lds instructions
+    // Emits 1 direct to lds instruction
     %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %1 = ttg.async_commit_group %0
     // Emits 2 direct to lds instructions
@@ -139,10 +135,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @double_buffering_wait_in_if(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  tt.func public @double_buffering_wait_in_if(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
-    // Emits 1 direct to lds instructions
+    // Emits 1 direct to lds instruction
     %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %1 = ttg.async_commit_group %0
     // Emits 2 direct to lds instructions
@@ -152,7 +148,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %5 = ttg.async_commit_group %4
     %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %7 = ttg.async_commit_group %6
-    %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+    %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token) : i32 {
       %103 = scf.if %cond -> (!ttg.async.token) {
         // We wait on both tokens so we interleave with one iteration => 3
         //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 3
@@ -186,10 +182,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @doube_buffering_wait_loads_in_if(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  tt.func public @doube_buffering_wait_loads_in_if(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
-    // Emits 1 direct to lds instructions
+    // Emits 1 direct to lds instruction
     %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %1 = ttg.async_commit_group %0
     // Emits 2 direct to lds instructions
@@ -201,9 +197,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %7 = ttg.async_commit_group %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
       %103 = scf.if %cond -> (!ttg.async.token) {
-        %dummy_load = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
-        %dummy_group = ttg.async_commit_group %dummy_load
-        // We wait on both tokens (3) and additionally we should count the dummy loads inside our block (+2) => 5
+        %cond_load = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+        %cond_load_commit = ttg.async_commit_group %cond_load
+        // We wait on both tokens (3) and additionally we should count the load inside our block (+2) => 5
         //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 5
         %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
         scf.yield %token1 : !ttg.async.token
@@ -232,10 +228,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @double_buffering_uneven_then_else(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  tt.func public @double_buffering_uneven_then_else(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
-    // Emits 1 direct to lds instructions
+    // Emits 1 direct to lds instruction
     %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %1 = ttg.async_commit_group %0
     // Emits 2 direct to lds instructions
@@ -246,7 +242,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %7 = ttg.async_commit_group %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
-      // The then block contains 3 instruction and the else 1 so we expect the count to be 3 because there are 2 instructions outside the scf.if in the loop body
+      // The then block contains 3 instructions and the else 1 so we expect the count to be 3 (1 + 2) because there are also 2 instructions outside the scf.if in the loop body
       //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 3
       %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
 

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -1,0 +1,271 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx950 | FileCheck %s
+
+// Simple case without any branching
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @simple_waitcnt(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    // Emits 1 direct to lds instructions
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+    // Emits 2 direct to lds instructions
+    %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %3 = ttg.async_commit_group %2
+
+    // Do not wait on the second async_copy => waitcnt 2
+    //CHECK: ttg.async_wait {{.*}} {num = 2
+    %9 = ttg.async_wait %1 {num = 0 : i32}
+    // No async_copies in between => waitcnt 0
+    //CHECK: ttg.async_wait {{.*}} {num = 0
+    %10 = ttg.async_wait %3 {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// We should ignore tt.loads when counting
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @simple_waitcnt_with_tt_load(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    // Emits 1 direct to lds instructions
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+    // Emits 2 direct to lds instructions
+    %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %3 = ttg.async_commit_group %2
+
+    %4 = tt.load %arg3 : tensor<128x16x!tt.ptr<f16>, #blocked>
+
+    //CHECK: ttg.async_wait {{.*}} {num = 2
+    %9 = ttg.async_wait %1 {num = 0 : i32}
+    //CHECK: ttg.async_wait {{.*}} {num = 0
+    %10 = ttg.async_wait %3 {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Simple loop without any interleaving loads so we expect waitcnt 0
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @for_loop(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    // Emits 1 direct to lds instructions
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+    // Emits 2 direct to lds instructions
+    %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %3 = ttg.async_commit_group %2
+    %8:2 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %3) -> (!ttg.async.token, !ttg.async.token)  : i32 {
+      //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+      %10 = ttg.async_wait %arg15, %arg16 {num = 2 : i32}
+      %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+      %12 = ttg.async_commit_group %11
+      %13 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+      %14 = ttg.async_commit_group %13
+      scf.yield %12, %14: !ttg.async.token, !ttg.async.token
+    }
+    //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+    %9 = ttg.async_wait %8#0, %8#1 {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Double buffering for 2 loads where the first one will emit 2 instructions and the second 1 instruction so we expect waitcnt 3 inside the loop and 0 in the epilogue
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @double_buffering(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    // Emits 1 direct to lds instructions
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+    // Emits 2 direct to lds instructions
+    %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %3 = ttg.async_commit_group %2
+    %4 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %5 = ttg.async_commit_group %4
+    %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %7 = ttg.async_commit_group %6
+    %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+      //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 3
+      %10 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
+      %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+      %12 = ttg.async_commit_group %11
+      %13 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+      %14 = ttg.async_commit_group %13
+      scf.yield %arg16, %12, %arg18, %14 : !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+    }
+    //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+    %9 = ttg.async_wait %8#0, %8#1, %8#2, %8#3 {num = 0 : i32}
+    tt.return
+  }
+}
+// -----
+
+// Double buffering with async_wait inside scf.if
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @double_buffering_wait_in_if(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    // Emits 1 direct to lds instructions
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+    // Emits 2 direct to lds instructions
+    %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %3 = ttg.async_commit_group %2
+    %4 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %5 = ttg.async_commit_group %4
+    %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %7 = ttg.async_commit_group %6
+    %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+      %103 = scf.if %cond -> (!ttg.async.token) {
+        // We wait on both tokens so we interleave with one iteration => 3
+        //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 3
+        %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
+        scf.yield %token1 : !ttg.async.token
+      } else {
+        // We only wait on the token of the first load so we can interleave one more load => 3 + 2
+        //CHECK: ttg.async_wait {{.*}} {num = 5
+        %token2 = ttg.async_wait %arg15 {num = 1 : i32}
+        scf.yield %token2 : !ttg.async.token
+      }
+      %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+      %12 = ttg.async_commit_group %11
+      %13 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+      %14 = ttg.async_commit_group %13
+      scf.yield %arg16, %12, %arg18, %14 : !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+    }
+    //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+    %9 = ttg.async_wait %8#0, %8#1, %8#2, %8#3 {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Double buffering with async_wait and additional async_loads inside the scf.if
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @doube_buffering_wait_loads_in_if(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    // Emits 1 direct to lds instructions
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+    // Emits 2 direct to lds instructions
+    %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %3 = ttg.async_commit_group %2
+    %4 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %5 = ttg.async_commit_group %4
+    %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %7 = ttg.async_commit_group %6
+    %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+      %103 = scf.if %cond -> (!ttg.async.token) {
+        %dummy_load = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+        %dummy_group = ttg.async_commit_group %dummy_load
+        // We wait on both tokens (3) and additionally we should count the dummy loads inside our block (+2) => 5
+        //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 5
+        %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
+        scf.yield %token1 : !ttg.async.token
+      } else {
+        scf.yield %arg15 : !ttg.async.token
+      }
+      %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+      %12 = ttg.async_commit_group %11
+      %13 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+      %14 = ttg.async_commit_group %13
+      scf.yield %arg16, %12, %arg18, %14 : !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+    }
+    //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+    %9 = ttg.async_wait %8#0, %8#1, %8#2, %8#3 {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Double buffering with different number of async_copies inside scf.if then and else block. Check that we take the lower number from both blocks
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @double_buffering_uneven_then_else(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>, %arg5: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg7: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}, %arg10: i32 {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    // Emits 1 direct to lds instructions
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+    // Emits 2 direct to lds instructions
+    %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %3 = ttg.async_commit_group %2
+    %4 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %5 = ttg.async_commit_group %4
+    %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+    %7 = ttg.async_commit_group %6
+    %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+      // The then block contains 3 instruction and the else 1 so we expect the count to be 3 because there are 2 instructions outside the scf.if in the loop body
+      //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 3
+      %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
+
+      %103 = scf.if %cond -> (!ttg.async.token) {
+        %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+        %110 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+        %12 = ttg.async_commit_group %11, %110
+        scf.yield %12 : !ttg.async.token
+      } else {
+        %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+        %12 = ttg.async_commit_group %11
+        scf.yield %12 : !ttg.async.token
+      }
+      %13 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
+      %14 = ttg.async_commit_group %13
+      scf.yield %arg16, %103, %arg18, %14 : !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+    }
+    //CHECK: ttg.async_wait {{.*}}, {{.*}} {num = 0
+    %9 = ttg.async_wait %8#0, %8#1, %8#2, %8#3 {num = 0 : i32}
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -8,6 +8,7 @@
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: simple_waitcnt
   tt.func public @simple_waitcnt(%arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     // Emits 1 direct to lds instruction
     %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
@@ -36,7 +37,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @simple_waitcnt(%arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
+  // CHECK-LABEL: simple_waitcnt_reversed
+  tt.func public @simple_waitcnt_reversed(%arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     // Emits 1 direct to lds instruction
     %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %1 = ttg.async_commit_group %0
@@ -64,6 +66,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: simple_waitcnt_with_tt_load
   tt.func public @simple_waitcnt_with_tt_load(%arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     // Emits 1 direct to lds instruction
     %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
@@ -92,7 +95,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @for_loop(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
+  // CHECK-LABEL wait_in_for_loop
+  tt.func public @wait_in_for_loop(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
     // Emits 1 direct to lds instruction
@@ -126,6 +130,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL double_buffering
   tt.func public @double_buffering(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -163,6 +168,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: double_buffering_wait_in_if
   tt.func public @double_buffering_wait_in_if(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -210,6 +216,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: doube_buffering_wait_loads_in_if
   tt.func public @doube_buffering_wait_loads_in_if(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -256,6 +263,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: double_buffering_uneven_then_else
   tt.func public @double_buffering_uneven_then_else(%cond: i1, %arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<16x256xf16, #shared1, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>, %arg4: tensor<16x256x!tt.ptr<f16>, #blocked1>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -302,7 +310,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @double_buffering(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>) {
+  // CHECK-LABEL: dynamic_loop_in_def_chain
+  tt.func public @dynamic_loop_in_def_chain(%arg0: i32, %arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
     %c4_i32 = arith.constant 4 : i32
@@ -312,7 +321,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Emits 1 direct to lds instruction
     %6 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %7 = ttg.async_commit_group %6
-    // Loop with 4 iterations => 4 instructions
+    // Dynamic iteration count so we should not count its body
     %30 = scf.for %arg21 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg30 = %6) -> (!ttg.async.token) : i32 {
       // CHECK: ttg.async_wait {{.*}} {num = 0
       %31 = ttg.async_wait %arg30 {num = 1 : i32}
@@ -335,7 +344,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @double_buffering(%arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>) {
+  // CHECK-LABEL: constant_loop_in_def_chain
+  tt.func public @constant_loop_in_def_chain(%arg1: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg3: tensor<128x16x!tt.ptr<f16>, #blocked>) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
     %c4_i32 = arith.constant 4 : i32

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -278,7 +278,7 @@ class HIPBackend(BaseBackend):
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
         if use_async_copy:
-            amd.passes.ttgpuir.add_update_async_wait_count(pm)
+            amd.passes.ttgpuir.add_update_async_wait_count(pm, options.arch)
         pm.run(mod)
         return mod
 

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -277,6 +277,8 @@ class HIPBackend(BaseBackend):
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
+        if use_async_copy:
+            amd.passes.ttgpuir.add_update_async_wait_count(pm)
         pm.run(mod)
         return mod
 

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -41,6 +41,9 @@ std::unique_ptr<Pass> createTritonAMDGPUInThreadTransposePass();
 std::unique_ptr<Pass>
 createTritonAMDGPUCoalesceAsyncCopyPass(std::string archGenName = {});
 
+std::unique_ptr<Pass>
+createTritonAMDGPUUpdateAsyncWaitCountPass(std::string archGenName = {});
+
 std::unique_ptr<Pass> createTritonAMDGPUFoldTrueCmpIPass();
 
 /// Generate the code for registering passes.

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -248,6 +248,26 @@ def TritonAMDGPUCoalesceAsyncCopy: Pass<"tritonamdgpu-coalesce-async-copy", "mli
   ];
 }
 
+def TritonAMDGPUUpdateAsyncWaitCount: Pass<"tritonamdgpu-update-async-wait-count", "mlir::ModuleOp"> {
+  let summary = "Adjust async wait count to allow prefetching over multiple loop iterations";
+
+  let description = [{
+    GFX9:
+      LLVM cannot see the dependency across loop iterations between AsyncCopy and local_reads. So we
+      compute the number of interleaving global memory instructions to emit the correct waitcnt during lowering.
+  }];
+
+  let constructor = "mlir::createTritonAMDGPUUpdateAsyncWaitCountPass()";
+
+  let dependentDialects = [];
+
+  let options = [
+    Option<"archGenerationName", "arch-generation-name",
+           "std::string", /*default=*/"std::string{}",
+           "GFX generation name of target device.">,
+  ];
+}
+
 def TritonAMDFoldTrueCmpI: Pass<"tritonamdgpu-fold-true-cmpi", "mlir::ModuleOp"> {
   let summary = "Fold true arith.cmpi to %true";
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_triton_library(TritonAMDGPUTransforms
   InThreadTranspose.cpp
   FoldTrueCmpIOp.cpp
   UpdateAsyncWaitCount.cpp
+  Utility.cpp
 
   DEPENDS
   TritonAMDGPUIR

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_triton_library(TritonAMDGPUTransforms
   MfmaGroup.cpp
   InThreadTranspose.cpp
   FoldTrueCmpIOp.cpp
+  UpdateAsyncWaitCount.cpp
 
   DEPENDS
   TritonAMDGPUIR

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -351,6 +351,9 @@ bool StreamPipeliner::createAsyncCopy(tt::LoadOp loadOp, Value alloc,
   // create a barrier to ensure all warps are finished reading the shared buffer
   // we will write into. This is done by scheduling it as a local_store.
   scheduleOp(newLoadOp, SCHED_LOCAL_STORE);
+  // Place Commit next to async_load so UpdateAsyncWaitCount can deduce better
+  // waitcnts
+  scheduleOp(commit, SCHED_LOCAL_STORE);
 
   // Create local load which consumes the async token from the AsyncWait
   auto sharedLoad =

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -346,13 +346,12 @@ bool StreamPipeliner::createAsyncCopy(tt::LoadOp loadOp, Value alloc,
       builder.create<ttg::AsyncCommitGroupOp>(loc, newLoadOp->getResult(0));
   ttg::AsyncWaitOp wait =
       builder.create<ttg::AsyncWaitOp>(loc, commit->getResult(0), 0);
-
   // We need to place the prefetches (AsyncCopy) after the AsyncWaits which
   // create a barrier to ensure all warps are finished reading the shared buffer
   // we will write into. This is done by scheduling it as a local_store.
   scheduleOp(newLoadOp, SCHED_LOCAL_STORE);
-  // Place Commit next to async_load so UpdateAsyncWaitCount can deduce better
-  // waitcnts
+  // Place ttg.async_commit_group op next to async load so the later
+  // UpdateAsyncWaitCount pass can deduce better waitcnts
   scheduleOp(commit, SCHED_LOCAL_STORE);
 
   // Create local load which consumes the async token from the AsyncWait

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -1,4 +1,3 @@
-
 #include "amd/lib/TritonAMDGPUToLLVM/Utility.h"
 #include "amd/lib/TritonAMDGPUTransforms/Utility.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -7,18 +6,14 @@
 #define GEN_PASS_CLASSES
 #include "TritonAMDGPUTransforms/Passes.h"
 
-#undef DEBUG_TYPE
-#define DEBUG_TYPE "tritonamdgpu-update-async-wait-count"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
-#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
-
 using namespace mlir;
+namespace tt = triton;
 namespace ttg = triton::gpu;
 
 // LLVM cannot infer the dependency between direct to lds (async) loads and the
 // local reads between warps in a workgroup. As a workaround we update the
 // waitcnt to represent the number of hardware instructions we are interleaving
-// with. This allows us to manually emit the waitcnt when lowering.
+// with. This allows us to manually emit the waitcnt during lowering.
 struct UpdateAsyncWaitCount : public OpRewritePattern<ttg::AsyncWaitOp> {
   UpdateAsyncWaitCount(MLIRContext *ctx) : OpRewritePattern(ctx) {}
 
@@ -26,13 +21,13 @@ struct UpdateAsyncWaitCount : public OpRewritePattern<ttg::AsyncWaitOp> {
                                 PatternRewriter &rewriter) const override {
     int waitCnt = std::numeric_limits<int>::max();
 
-    // AsyncWait can wait on multiple tokens we have to use the minimum as our
-    // waitcnt
+    // AsyncWait can await multiple tokens so we get the minimum from all
+    // tokens
     for (auto token : waitOp.getOperands()) {
       // Traverse def chain from waitOp to the producer of the token and count
       // the minumum number of vmcnt instructions
       auto tokenWaitCnt =
-          findMinCountInDefChain(token, waitOp, [this](Operation *op) {
+          findMinPathCountInDefChain(token, waitOp, [this](Operation *op) {
             return getNumberOfLoadInstructions(op);
           });
       waitCnt = std::min(waitCnt, tokenWaitCnt);
@@ -46,58 +41,54 @@ struct UpdateAsyncWaitCount : public OpRewritePattern<ttg::AsyncWaitOp> {
     return success();
   }
 
-  // Computes (conservatively) the number of vmcnt instructions the op will
-  // produce
+  // To count AsyncLoads we have two options:
+  // 1) Count the AsyncLoads directly but we the overall producer of the token
+  //    might be an AsyncCommitGroup in which case we would miss the loads of
+  //    this CommitGroup.
+  // 2) Count based on the Operands of encountered CommitGroups. This ensures we
+  //    include the loads of the CommitGroup producing the token. We might miss
+  //    AsyncLoads if their commit group is scheduled very late.
+  // The second case is implemented because the scheduling will place the
+  // CommitGroup right after the AsyncCopy hence we will never miss AsyncCopies
   int getNumberOfLoadInstructions(Operation *op) const {
     if (isa<ttg::AsyncCommitGroupOp>(op)) {
-      Value token = op->getOperand(0);
-      auto defToken = token.getDefiningOp();
-      if (defToken) {
-        return llvm::TypeSwitch<Operation *, unsigned>(defToken)
-            .Case([&](ttg::AsyncCopyGlobalToLocalOp copyOp) {
-              return getNumberOfLoadInstructions(getContext(),
-                                                 copyOp.getSrc().getType(),
-                                                 copyOp.getResult().getType());
-            })
-            .Case([&](amdgpu::BufferLoadToLocalOp copyOp) {
-              RankedTensorType srcTy =
-                  cast<RankedTensorType>(LLVM::AMD::getPointerTypeWithShape(
-                      copyOp.getPtr(), copyOp.getOffsets()));
-              return getNumberOfLoadInstructions(getContext(), srcTy,
-                                                 copyOp.getDest().getType());
-            })
-            .Case([&](triton::StoreOp loadOp) {
-              // We do not control the vectorSize for global
-              // stores so just return 0 which will always be
-              // correct
-              LDBG("Global store between async waits. We will "
-                   "conservatively set the vmcnt which might "
-                   "impact performance.");
-              return 0;
-            })
-            .Case([&](triton::LoadOp loadOp) {
-              // We do not control the vectorSize for global
-              // loads so just return 0 which will always be
-              // correct
-              LDBG("Global load between async waits. We will "
-                   "conservatively set the vmcnt which might "
-                   "impact performance.");
-              return 0;
-            })
-            .Default([&](auto) { return 0; });
+      int count = 0;
+      for (auto token : op->getOperands()) {
+        auto defOp = token.getDefiningOp();
+        if (!defOp)
+          continue;
+        count += llvm::TypeSwitch<Operation *, int>(defOp)
+                     .Case([&](ttg::AsyncCopyGlobalToLocalOp copyOp) {
+                       return getNumberOfLoadInstructions(
+                           getContext(), copyOp.getSrc().getType(),
+                           copyOp.getResult().getType());
+                     })
+                     .Case([&](amdgpu::BufferLoadToLocalOp copyOp) {
+                       RankedTensorType srcTy = cast<RankedTensorType>(
+                           LLVM::AMD::getPointerTypeWithShape(
+                               copyOp.getPtr(), copyOp.getOffsets()));
+                       return getNumberOfLoadInstructions(
+                           getContext(), srcTy, copyOp.getDest().getType());
+                     })
+                     .Default([&](auto) { return 0; });
       }
+      return count;
+    } else if (isa<tt::LoadOp, tt::StoreOp>(op)) {
+      op->emitRemark("Global memory instruction between async wait and "
+                     "async_loads. This will hinder the interleaving of memory "
+                     "operations and might impact performance.");
     }
     return 0;
   }
 
-  // Overload to get the number of loads from direct to lds loads
+  // Overload to get the number of loads from direct to lds memory layouts
   int getNumberOfLoadInstructions(MLIRContext *context, RankedTensorType srcTy,
                                   ttg::MemDescType dstTy) const {
     auto shape = srcTy.getShape();
     LinearLayout srcLayout =
-        triton::gpu::toLinearLayout(shape, srcTy.getEncoding());
+        tt::gpu::toLinearLayout(shape, srcTy.getEncoding());
     LinearLayout sharedLayout =
-        triton::gpu::toLinearLayout(shape, dstTy.getEncoding());
+        tt::gpu::toLinearLayout(shape, dstTy.getEncoding());
     LinearLayout srcToSharedLayout = srcLayout.invertAndCompose(sharedLayout);
 
     // On GFX9 we cannot split direct to lds loads into multiple ones because we
@@ -106,9 +97,7 @@ struct UpdateAsyncWaitCount : public OpRewritePattern<ttg::AsyncWaitOp> {
     unsigned contig = srcToSharedLayout.getNumConsecutiveInOut();
     unsigned numberOfRegisters =
         srcToSharedLayout.getInDimSize(StringAttr::get(context, "register"));
-
     unsigned loadInstructionCount = numberOfRegisters / contig;
-
     return loadInstructionCount;
   }
 };
@@ -125,12 +114,12 @@ public:
     ModuleOp m = getOperation();
     MLIRContext *context = &getContext();
 
-    triton::AMD::TargetInfo targetInfo(archGenerationName);
+    tt::AMD::TargetInfo targetInfo(archGenerationName);
     switch (targetInfo.getISAFamily()) {
-    case triton::AMD::ISAFamily::CDNA1:
-    case triton::AMD::ISAFamily::CDNA2:
-    case triton::AMD::ISAFamily::CDNA3:
-    case triton::AMD::ISAFamily::CDNA4: {
+    case tt::AMD::ISAFamily::CDNA1:
+    case tt::AMD::ISAFamily::CDNA2:
+    case tt::AMD::ISAFamily::CDNA3:
+    case tt::AMD::ISAFamily::CDNA4: {
       break;
     }
     default:
@@ -138,9 +127,7 @@ public:
     }
 
     mlir::RewritePatternSet patterns(context);
-
     patterns.add<UpdateAsyncWaitCount>(context);
-
     if (applyPatternsGreedily(m, std::move(patterns)).failed())
       signalPassFailure();
   }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -6,130 +6,126 @@
 #define GEN_PASS_CLASSES
 #include "TritonAMDGPUTransforms/Passes.h"
 
+// This pass updates the waitCount of `AsyncWait` Ops to represent the number of
+// inflight async load operation between the async_wait and the definition of
+// the async_tokens. This value can then be used to wait only on the dependent
+// async loads before accessing the data allowing loads issues after to complete
+// in the future. This also means we should never overestimate the value to
+// ensure correctness wherease underestimating only affects performance.
+// So for each async_wait we need to compute the minimum across all async_token
+// operands.
+// For each token the minimum number of async transaction along it's def chain
+// is deduced. Note that a token can have multiple producers, e.g. if it's loop
+// carried (prologue and loop body). Therefore all paths to all producers of the
+// async_token have to be analyzed.
+// Note that we do not exit early if we encounter another async_wait along the
+// def chain because the pipeliner will merge redundant waits for us already
+
 using namespace mlir;
 namespace tt = triton;
 namespace ttg = triton::gpu;
 
-// LLVM cannot infer the dependency between direct to lds (async) loads and the
-// local reads between warps in a workgroup. As a workaround we update the
-// waitcnt to represent the number of hardware instructions we are interleaving
-// with. This allows us to manually emit the waitcnt during lowering.
-struct UpdateAsyncWaitCount : public OpRewritePattern<ttg::AsyncWaitOp> {
-  UpdateAsyncWaitCount(MLIRContext *ctx) : OpRewritePattern(ctx) {}
+// Overload to get the number of loads from direct to lds memory layouts
+int getNumberOfLoadInstructions(RankedTensorType srcTy,
+                                ttg::MemDescType dstTy) {
+  auto shape = srcTy.getShape();
+  LinearLayout srcLayout = tt::gpu::toLinearLayout(shape, srcTy.getEncoding());
+  LinearLayout sharedLayout =
+      tt::gpu::toLinearLayout(shape, dstTy.getEncoding());
+  LinearLayout srcToSharedLayout = srcLayout.invertAndCompose(sharedLayout);
 
-  LogicalResult matchAndRewrite(ttg::AsyncWaitOp waitOp,
-                                PatternRewriter &rewriter) const override {
-    int waitCnt = std::numeric_limits<int>::max();
+  // On GFX9 we cannot split direct to lds loads into multiple ones because we
+  // need coalesced writes. So we can divide the number of registers by the
+  // contiguity to get the number of load instructions.
+  int contig = srcToSharedLayout.getNumConsecutiveInOut();
+  int numberOfRegisters = srcToSharedLayout.getInDimSize(
+      StringAttr::get(srcTy.getContext(), "register"));
+  int loadInstructionCount = std::max(1, numberOfRegisters / contig);
+  return loadInstructionCount;
+}
 
-    // AsyncWait can await multiple tokens so we get the minimum from all
-    // tokens
-    for (auto token : waitOp.getOperands()) {
-      // Traverse def chain from waitOp to the producer of the token and count
-      // the minumum number of vmcnt instructions
-      auto tokenWaitCnt =
-          findMinPathCountInDefChain(token, waitOp, [this](Operation *op) {
-            return getNumberOfLoadInstructions(op);
-          });
-      waitCnt = std::min(waitCnt, tokenWaitCnt);
-    }
-
-    if (waitCnt == std::numeric_limits<int>::max() ||
-        waitOp.getNum() == waitCnt)
-      return failure();
-
-    rewriter.modifyOpInPlace(waitOp, [&]() { waitOp.setNum(waitCnt); });
-    return success();
-  }
-
-  // To count AsyncLoads we have two options:
-  // 1) Count the AsyncLoads directly but we the overall producer of the token
-  //    might be an AsyncCommitGroup in which case we would miss the loads of
-  //    this CommitGroup.
-  // 2) Count based on the Operands of encountered CommitGroups. This ensures we
-  //    include the loads of the CommitGroup producing the token. We might miss
-  //    AsyncLoads if their commit group is scheduled very late.
-  // The second case is implemented because the scheduling will place the
-  // CommitGroup right after the AsyncCopy hence we will never miss AsyncCopies
-  int getNumberOfLoadInstructions(Operation *op) const {
-    if (isa<ttg::AsyncCommitGroupOp>(op)) {
-      int count = 0;
-      for (auto token : op->getOperands()) {
-        auto defOp = token.getDefiningOp();
-        if (!defOp)
-          continue;
-        count += llvm::TypeSwitch<Operation *, int>(defOp)
-                     .Case([&](ttg::AsyncCopyGlobalToLocalOp copyOp) {
-                       return getNumberOfLoadInstructions(
-                           getContext(), copyOp.getSrc().getType(),
-                           copyOp.getResult().getType());
-                     })
-                     .Case([&](amdgpu::BufferLoadToLocalOp copyOp) {
-                       RankedTensorType srcTy = cast<RankedTensorType>(
-                           LLVM::AMD::getPointerTypeWithShape(
-                               copyOp.getPtr(), copyOp.getOffsets()));
-                       return getNumberOfLoadInstructions(
-                           getContext(), srcTy, copyOp.getDest().getType());
-                     })
-                     .Default([&](auto) { return 0; });
+// The pipeliner always insert ops following an order of ttg.async_load ->
+// [token] -> ttg.async_commit_group -> [token] -> ttg.async_wait. So here we
+// scan the operands of ttg.async_commit_group to count the number of issued
+// async load intrinsics.
+int getNumberOfLoadInstructions(Operation *op) {
+  if (isa<ttg::AsyncCommitGroupOp>(op)) {
+    int count = 0;
+    for (auto token : op->getOperands()) {
+      auto defOp = token.getDefiningOp();
+      if (!defOp)
+        continue;
+      if (auto copyOp = llvm::dyn_cast<ttg::AsyncCopyGlobalToLocalOp>(defOp)) {
+        count += getNumberOfLoadInstructions(copyOp.getSrc().getType(),
+                                             copyOp.getResult().getType());
+      } else if (auto copyOp =
+                     llvm::dyn_cast<amdgpu::BufferLoadToLocalOp>(defOp)) {
+        auto srcTy = cast<RankedTensorType>(LLVM::AMD::getPointerTypeWithShape(
+            copyOp.getPtr(), copyOp.getOffsets()));
+        count += getNumberOfLoadInstructions(srcTy, copyOp.getDest().getType());
       }
-      return count;
-    } else if (isa<tt::LoadOp, tt::StoreOp>(op)) {
-      op->emitRemark("Global memory instruction between async wait and "
-                     "async_loads. This will hinder the interleaving of memory "
-                     "operations and might impact performance.");
     }
-    return 0;
+    return count;
+  }
+  if (isa<tt::LoadOp, tt::StoreOp, amdgpu::BufferLoadToLocalOp,
+          amdgpu::BufferStoreOp, tt::AtomicRMWOp, tt::AtomicCASOp,
+          amdgpu::BufferAtomicRMWOp>(op)) {
+    op->emitRemark("Global memory operation between async wait and "
+                   "async_loads. This will hinder the interleaving of memory "
+                   "operations and might impact performance.");
+  }
+  return 0;
+}
+
+// LLVM cannot infer the dependency between direct to lds (async) loads and
+// the local reads between warps in a workgroup. As a workaround we update the
+// waitcnt to represent the number of hardware instructions we are
+// interleaving with. This allows us to manually emit the waitcnt during
+// lowering.
+void updateWaitCount(ttg::AsyncWaitOp waitOp, RewriterBase &rewriter) {
+  int waitCnt = std::numeric_limits<int>::max();
+
+  // AsyncWait can await multiple tokens so we get the minimum from all
+  // tokens
+  for (auto token : waitOp.getOperands()) {
+    // Traverse def chain from waitOp to the producer of the token and count
+    // the minumum number of vmcnt instructions
+    auto tokenWaitCnt =
+        deduceMinCountOnDefChain(token, waitOp, [](Operation *op) {
+          return getNumberOfLoadInstructions(op);
+        });
+    waitCnt = std::min(waitCnt, tokenWaitCnt);
   }
 
-  // Overload to get the number of loads from direct to lds memory layouts
-  int getNumberOfLoadInstructions(MLIRContext *context, RankedTensorType srcTy,
-                                  ttg::MemDescType dstTy) const {
-    auto shape = srcTy.getShape();
-    LinearLayout srcLayout =
-        tt::gpu::toLinearLayout(shape, srcTy.getEncoding());
-    LinearLayout sharedLayout =
-        tt::gpu::toLinearLayout(shape, dstTy.getEncoding());
-    LinearLayout srcToSharedLayout = srcLayout.invertAndCompose(sharedLayout);
+  if (waitCnt == std::numeric_limits<int>::max() || waitOp.getNum() == waitCnt)
+    return;
 
-    // On GFX9 we cannot split direct to lds loads into multiple ones because we
-    // need coalesced writes. So we can divide the number of registers by the
-    // contiguity to get the number of load instructions.
-    unsigned contig = srcToSharedLayout.getNumConsecutiveInOut();
-    unsigned numberOfRegisters =
-        srcToSharedLayout.getInDimSize(StringAttr::get(context, "register"));
-    unsigned loadInstructionCount = numberOfRegisters / contig;
-    return loadInstructionCount;
-  }
-};
+  rewriter.modifyOpInPlace(waitOp, [&]() { waitOp.setNum(waitCnt); });
+}
 
-class TritonAMDGPUUpdateAsyncWaitCountPass
+struct TritonAMDGPUUpdateAsyncWaitCountPass
     : public TritonAMDGPUUpdateAsyncWaitCountBase<
           TritonAMDGPUUpdateAsyncWaitCountPass> {
-public:
   TritonAMDGPUUpdateAsyncWaitCountPass(StringRef archGenName) {
     this->archGenerationName = archGenName.str();
   }
 
   void runOnOperation() override {
-    ModuleOp m = getOperation();
-    MLIRContext *context = &getContext();
-
     tt::AMD::TargetInfo targetInfo(archGenerationName);
-    switch (targetInfo.getISAFamily()) {
-    case tt::AMD::ISAFamily::CDNA1:
-    case tt::AMD::ISAFamily::CDNA2:
-    case tt::AMD::ISAFamily::CDNA3:
-    case tt::AMD::ISAFamily::CDNA4: {
-      break;
-    }
-    default:
+    if (!targetInfo.isCDNA()) {
       return;
     }
 
-    mlir::RewritePatternSet patterns(context);
-    patterns.add<UpdateAsyncWaitCount>(context);
-    if (applyPatternsGreedily(m, std::move(patterns)).failed())
-      signalPassFailure();
+    ModuleOp m = getOperation();
+
+    SmallVector<ttg::AsyncWaitOp> waitOps;
+    getOperation()->walk(
+        [&](ttg::AsyncWaitOp waitOp) { waitOps.push_back(waitOp); });
+
+    for (auto waitOp : waitOps) {
+      IRRewriter builder(waitOp->getContext());
+      updateWaitCount(waitOp, builder);
+    }
   }
 };
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -1,0 +1,210 @@
+
+#include "amd/lib/TritonAMDGPUToLLVM/Utility.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#define GEN_PASS_CLASSES
+#include "TritonAMDGPUTransforms/Passes.h"
+
+#undef DEBUG_TYPE
+#define DEBUG_TYPE "tritonamdgpu-update-async-wait-count"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+using namespace mlir;
+namespace ttg = triton::gpu;
+
+unsigned countLoadInstructions(MLIRContext *context, RankedTensorType srcTy,
+                               ttg::MemDescType dstTy) {
+  auto shape = srcTy.getShape();
+  LinearLayout srcLayout =
+      triton::gpu::toLinearLayout(shape, srcTy.getEncoding());
+  LinearLayout sharedLayout =
+      triton::gpu::toLinearLayout(shape, dstTy.getEncoding());
+  LinearLayout srcToSharedLayout = srcLayout.invertAndCompose(sharedLayout);
+
+  // On GFX9 we cannot split direct to lds loads into multiple ones because we
+  // need coalesced writes. So we can divide the number of registers by the
+  // contiguity to get the number of load instructions.
+  unsigned contig = srcToSharedLayout.getNumConsecutiveInOut();
+  unsigned numberOfRegisters =
+      srcToSharedLayout.getInDimSize(StringAttr::get(context, "register"));
+
+  unsigned loadInstructionCount = numberOfRegisters / contig;
+
+  return loadInstructionCount;
+}
+
+unsigned countLoadInstructions(MLIRContext *context,
+                               ttg::AsyncCopyGlobalToLocalOp copyOp) {
+  return countLoadInstructions(context, copyOp.getSrc().getType(),
+                               copyOp.getResult().getType());
+}
+
+unsigned countLoadInstructions(MLIRContext *context,
+                               amdgpu::BufferLoadToLocalOp copyOp) {
+  RankedTensorType srcTy = cast<RankedTensorType>(
+      LLVM::AMD::getPointerTypeWithShape(copyOp.getPtr(), copyOp.getOffsets()));
+  return countLoadInstructions(context, srcTy, copyOp.getDest().getType());
+}
+
+// LLVM cannot infer the dependency between direct to lds (async) loads and the
+// local reads between warps in a workgroup. As a workaround we can count the
+// instructions of load and store instruction and emit the correct waitcnt
+// ourselfs. It is important to never overestimate or else we will see
+// correctness issues.
+struct UpdateAsyncWaitCount : public OpRewritePattern<ttg::AsyncWaitOp> {
+  UpdateAsyncWaitCount(MLIRContext *ctx) : OpRewritePattern(ctx) {}
+
+  LogicalResult matchAndRewrite(ttg::AsyncWaitOp waitOp,
+                                PatternRewriter &rewriter) const override {
+    int minCommitNumber = INT_MAX;
+
+    if (waitOp->getNumOperands() < 1) {
+      return failure();
+    }
+
+    int waitCnt = std::numeric_limits<int>::max();
+
+    for (auto operand : waitOp.getOperands()) {
+      // If the value resides in a region other than the region of the wait op,
+      // then the wait op must be in some nested region. Measure the number of
+      // commits between the definition value and the parent op.
+      // TODO: We could measure commits in nested regions along the path if
+      // necessary.
+      Operation *waitOpPtr = waitOp;
+      while (waitOp->getParentRegion() != operand.getParentRegion())
+        waitOpPtr = waitOp->getParentOp();
+      waitCnt = std::min(waitCnt, findMinCountInDefChain(operand, waitOpPtr));
+    }
+
+    if (waitCnt == std::numeric_limits<int>::max() ||
+        waitOp.getNum() == waitCnt)
+      return failure();
+
+    rewriter.modifyOpInPlace(waitOp, [&]() { waitOp.setNum(waitCnt); });
+    return success();
+  }
+
+  // DFS the def chain of val from sinkOp and call countOp on all operation
+  // ranges spanned by the def chain. Returns the minimum count found in all def
+  // chain paths
+  // TODO: merge with minNumInterleavedCommitOps
+  int findMinCountInDefChain(
+      Value val, Operation *sinkOp, int pathSum = 0,
+      int foundMin = std::numeric_limits<int>::max()) const {
+    if (Operation *defOp = val.getDefiningOp()) {
+      pathSum += countVMCntInstructionBetween(defOp->getNextNode(), sinkOp);
+      foundMin = std::min(foundMin, pathSum);
+      return foundMin;
+    }
+    if (auto arg = mlir::dyn_cast<BlockArgument>(val)) {
+      Block *block = arg.getOwner();
+      auto forOp = dyn_cast<scf::ForOp>(block->getParentOp());
+
+      // Failed to track, return 0 conservatively.
+      if (!forOp)
+        return 0;
+
+      Operation *firstForInst = &*forOp.getBody()->begin();
+      int insertsBetween = countVMCntInstructionBetween(firstForInst, sinkOp);
+      pathSum += insertsBetween;
+      if (pathSum >= foundMin)
+        return foundMin;
+
+      // get the value assigned to the argument coming from outside the loop
+      Value incomingVal = forOp.getInitArgs()[arg.getArgNumber() - 1];
+      int min1 = findMinCountInDefChain(incomingVal, forOp, pathSum, foundMin);
+
+      // get the value assigned to the argument coming from the previous
+      // iteration
+      Operation *yieldOp = block->getTerminator();
+      Value prevVal = yieldOp->getOperand(arg.getArgNumber() - 1);
+      int min2 = findMinCountInDefChain(prevVal, yieldOp, pathSum, foundMin);
+      return std::min(std::min(min1, min2), foundMin);
+    }
+    // Failed to track, return 0 conservatively.
+    return 0;
+  }
+
+  int countVMCntInstructionBetween(Operation *op1, Operation *op2) const {
+    auto *ctx = getContext();
+    int count = 0;
+    for (auto op = op1; op != op2; op = op->getNextNode()) {
+      if (isa<ttg::AsyncCommitGroupOp>(op)) {
+        Value token = op->getOperand(0);
+        auto defToken = token.getDefiningOp();
+        if (defToken) {
+          count += llvm::TypeSwitch<Operation *, unsigned>(defToken)
+                       .Case([&](ttg::AsyncCopyGlobalToLocalOp copyOp) {
+                         return countLoadInstructions(ctx, copyOp);
+                       })
+                       .Case([&](amdgpu::BufferLoadToLocalOp copyOp) {
+                         return countLoadInstructions(ctx, copyOp);
+                       })
+                       .Case([&](triton::StoreOp loadOp) {
+                         // We do not control the vectorSize for global
+                         // stores so just return 0 which will always be
+                         // correct
+                         LDBG("Global store between async waits. We will "
+                              "conservatively set the vmcnt which might "
+                              "impact performance.");
+                         return 0;
+                       })
+                       .Case([&](triton::LoadOp loadOp) {
+                         // We do not control the vectorSize for global
+                         // loads so just return 0 which will always be
+                         // correct
+                         LDBG("Global load between async waits. We will "
+                              "conservatively set the vmcnt which might "
+                              "impact performance.");
+                         return 0;
+                       })
+                       .Default([&](auto) { return 0; });
+        }
+      }
+    }
+    return count;
+  };
+};
+
+class TritonAMDGPUUpdateAsyncWaitCountPass
+    : public TritonAMDGPUUpdateAsyncWaitCountBase<
+          TritonAMDGPUUpdateAsyncWaitCountPass> {
+public:
+  TritonAMDGPUUpdateAsyncWaitCountPass(StringRef archGenName) {
+    this->archGenerationName = archGenName.str();
+  }
+
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+    MLIRContext *context = &getContext();
+
+    triton::AMD::TargetInfo targetInfo(archGenerationName);
+    switch (targetInfo.getISAFamily()) {
+    case triton::AMD::ISAFamily::CDNA1:
+    case triton::AMD::ISAFamily::CDNA2:
+    case triton::AMD::ISAFamily::CDNA3:
+    case triton::AMD::ISAFamily::CDNA4: {
+      break;
+    }
+    default:
+      return;
+    }
+
+    mlir::RewritePatternSet patterns(context);
+
+    // Precompute the contiguity of all AsyncCopy ops based on the src and
+    // mask contiguity/alignment to avoid rebuilding ModuleAxisInfoAnalysis
+    // after every IR change.
+    patterns.add<UpdateAsyncWaitCount>(context);
+
+    if (applyPatternsGreedily(m, std::move(patterns)).failed())
+      signalPassFailure();
+  }
+};
+
+std::unique_ptr<Pass>
+mlir::createTritonAMDGPUUpdateAsyncWaitCountPass(std::string archGenName) {
+  return std::make_unique<TritonAMDGPUUpdateAsyncWaitCountPass>(archGenName);
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -37,9 +37,9 @@ int findMinInBlock(Block &block,
 }
 } // namespace findMin
 
-int findMinCountInDefChain(Value value, Operation *consumerOp,
-                           const std::function<int(Operation *)> &countFunc,
-                           int pathSum, int foundMin) {
+int findMinPathCountInDefChain(Value value, Operation *consumerOp,
+                               const std::function<int(Operation *)> &countFunc,
+                               int pathSum, int foundMin) {
 
   // If the value is not defined in the same region as the consumer we need to
   // peel the parent region of consumer until we arrive at value's region
@@ -80,12 +80,14 @@ int findMinCountInDefChain(Value value, Operation *consumerOp,
     // Split the path and traverse the value assigned to the initial loop
     // iteration and the yield from the previous iteation recursively.
     Value incomingVal = forOp.getInitArgs()[arg.getArgNumber() - 1];
-    int countLoopInit = findMinCountInDefChain(incomingVal, forOp, countFunc,
-                                               pathSum, foundMin);
+    int countLoopInit = findMinPathCountInDefChain(
+        incomingVal, forOp, countFunc, pathSum, foundMin);
+
     Operation *yieldOp = block->getTerminator();
     Value prevVal = yieldOp->getOperand(arg.getArgNumber() - 1);
-    int countPreviousIter =
-        findMinCountInDefChain(prevVal, yieldOp, countFunc, pathSum, foundMin);
+    int countPreviousIter = findMinPathCountInDefChain(
+        prevVal, yieldOp, countFunc, pathSum, foundMin);
+
     return std::min(std::min(countLoopInit, countPreviousIter), foundMin);
   }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -1,0 +1,94 @@
+#include "Utility.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+namespace findMin {
+int findMinInBlock(Block &block,
+                   const std::function<int(Operation *)> &countFunc);
+
+// Returns the minimum found when accumulating countFunc(op) for all paths
+// between op1 and op2
+int findMinBetweenOps(Operation *op1, Operation *op2,
+                      const std::function<int(Operation *)> &countFunc) {
+  assert(op1 && op2);
+  int count = 0;
+  for (auto op = op1; op != op2; op = op->getNextNode()) {
+    if (auto ifOp = llvm::dyn_cast<scf::IfOp>(op)) {
+      assert(!ifOp.getThenRegion().empty() && !ifOp.getElseRegion().empty());
+      auto minThen = findMinInBlock(ifOp.getThenRegion().front(), countFunc);
+      auto minElse = findMinInBlock(ifOp.getElseRegion().front(), countFunc);
+      count += std::min(minThen, minElse);
+    } else if (auto forOp = llvm::dyn_cast<scf::ForOp>(op)) {
+      count += findMinInBlock(*forOp.getBody(), countFunc);
+    } else {
+      count += countFunc(op);
+    }
+  }
+  return count;
+}
+
+// Returns the minimum found when accumulating countFunc(op) for all paths
+// between the block's start and end op
+int findMinInBlock(Block &block,
+                   const std::function<int(Operation *)> &countFunc) {
+  if (block.empty())
+    return 0;
+  return findMinBetweenOps(&block.front(), &block.back(), countFunc);
+}
+} // namespace findMin
+
+int findMinCountInDefChain(Value value, Operation *consumerOp,
+                           const std::function<int(Operation *)> &countFunc,
+                           int pathSum, int foundMin) {
+
+  // If the value is not defined in the same region as the consumer we need to
+  // peel the parent region of consumer until we arrive at value's region
+  while (consumerOp->getParentRegion() != value.getParentRegion()) {
+    assert(!consumerOp->getParentRegion()->empty());
+    assert(!consumerOp->getParentRegion()->front().empty());
+    pathSum += findMin::findMinBetweenOps(
+        &consumerOp->getParentRegion()->front().front(), consumerOp, countFunc);
+    consumerOp = consumerOp->getParentOp();
+  }
+
+  // Break recursion if we arrive at the producer updating the path based on the
+  // ops between producer and consumer
+  if (Operation *defOp = value.getDefiningOp()) {
+    pathSum +=
+        findMin::findMinBetweenOps(defOp->getNextNode(), consumerOp, countFunc);
+    foundMin = std::min(foundMin, pathSum);
+    return foundMin;
+  }
+  // If value is a loop carried value (BlockArgument) we need to look at initial
+  // argumets of the loop and the previous iteration to find all producers
+  if (auto arg = mlir::dyn_cast<BlockArgument>(value)) {
+    Block *block = arg.getOwner();
+    auto forOp = dyn_cast<scf::ForOp>(block->getParentOp());
+
+    // Failed to track, return 0 conservatively.
+    if (!forOp || forOp.getBody()->empty()) {
+      return 0;
+    }
+
+    Operation *firstForOp = &*forOp.getBody()->begin();
+    pathSum += findMin::findMinBetweenOps(firstForOp, consumerOp, countFunc);
+
+    // Break recursion early if we exceed previous min
+    if (pathSum >= foundMin)
+      return foundMin;
+
+    // Split the path and traverse the value assigned to the initial loop
+    // iteration and the yield from the previous iteation recursively.
+    Value incomingVal = forOp.getInitArgs()[arg.getArgNumber() - 1];
+    int countLoopInit = findMinCountInDefChain(incomingVal, forOp, countFunc,
+                                               pathSum, foundMin);
+    Operation *yieldOp = block->getTerminator();
+    Value prevVal = yieldOp->getOperand(arg.getArgNumber() - 1);
+    int countPreviousIter =
+        findMinCountInDefChain(prevVal, yieldOp, countFunc, pathSum, foundMin);
+    return std::min(std::min(countLoopInit, countPreviousIter), foundMin);
+  }
+
+  // Unsupported value, return 0 conservatively.
+  return 0;
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
@@ -9,16 +9,14 @@
 
 using namespace mlir;
 
-// DFS the def chain of 'value' starting from 'consumer' and will return the
+// DFS the def chain of 'defValue' starting from 'consumer' and will return the
 // minimum found when accumulating countFunc(op) for all non control flow ops
 // between value and the consumer. This function will traverse through for loop
 // iterations and to the outside of the loop to find all its producers.
 //    CountOp(Operation*) should return the value to accumulate for the
 //    operation
 // Returns 0 if there is an error traversing the def chain
-int findMinPathCountInDefChain(Value value, Operation *consumerOp,
-                               const std::function<int(Operation *)> &countFunc,
-                               int pathSum = 0,
-                               int foundMin = std::numeric_limits<int>::max());
+int deduceMinCountOnDefChain(Value defValue, Operation *consumerOp,
+                             const std::function<int(Operation *)> &countFunc);
 
 #endif

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
@@ -1,0 +1,24 @@
+#ifndef TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUTRANSFORMS_UTILITY_H_
+#define TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUTRANSFORMS_UTILITY_H_
+
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+
+#include <functional>
+#include <limits>
+
+using namespace mlir;
+
+// DFS the def chain of 'value' starting from 'consumer' and will return the
+// minimum found when accumulating countFunc(op) for all non control flow ops
+// between value and the consumer. This function will traverse through for loop
+// iterations and to the outside of the loop to find all its producers.
+//    CountOp(Operation*) should return the value to accumulate for the
+//    operation
+// Returns 0 if there is an error traversing the def chain
+int findMinCountInDefChain(Value value, Operation *consumerOp,
+                           const std::function<int(Operation *)> &countFunc,
+                           int pathSum = 0,
+                           int foundMin = std::numeric_limits<int>::max());
+
+#endif

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
@@ -4,9 +4,6 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
 
-#include <functional>
-#include <limits>
-
 using namespace mlir;
 
 // DFS the def chain of 'defValue' starting from 'consumer' and will return the
@@ -17,6 +14,6 @@ using namespace mlir;
 //    operation
 // Returns 0 if there is an error traversing the def chain
 int deduceMinCountOnDefChain(Value defValue, Operation *consumerOp,
-                             const std::function<int(Operation *)> &countFunc);
+                             llvm::function_ref<int(Operation *)> countFunc);
 
 #endif

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
@@ -16,9 +16,9 @@ using namespace mlir;
 //    CountOp(Operation*) should return the value to accumulate for the
 //    operation
 // Returns 0 if there is an error traversing the def chain
-int findMinCountInDefChain(Value value, Operation *consumerOp,
-                           const std::function<int(Operation *)> &countFunc,
-                           int pathSum = 0,
-                           int foundMin = std::numeric_limits<int>::max());
+int findMinPathCountInDefChain(Value value, Operation *consumerOp,
+                               const std::function<int(Operation *)> &countFunc,
+                               int pathSum = 0,
+                               int foundMin = std::numeric_limits<int>::max());
 
 #endif

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -84,6 +84,9 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_1("add_coalesce_async_copy",
                      mlir::createTritonAMDGPUCoalesceAsyncCopyPass,
                      std::string);
+  ADD_PASS_WRAPPER_1("add_update_async_wait_count",
+                     mlir::createTritonAMDGPUUpdateAsyncWaitCountPass,
+                     std::string);
   m.def("add_in_thread_transpose", [](mlir::PassManager &pm) {
     pm.addNestedPass<mlir::triton::FuncOp>(
         mlir::createTritonAMDGPUInThreadTransposePass());


### PR DESCRIPTION
Adds `UpdateAsyncWaitCountPass` to adjusts the wait counts of `AsyncWait` ops to reflect the number of interleaved direct to lds assembly instructions. The LLVM backend cannot infer the dependency between the `AsyncCopies` and the `local_reads` so we emit it from Triton as we have the dependency information via tracing the `AsyncToken`.

The pass ignores global/buffer loads because the actual number of assembly instructions is determined by the LLVM backend. Note that an underestimation does only affect performance but not correctness.

`findMinPathCountInDefChain` is in separate file because we might reuse it for combining `AsyncWaits` in the `StreamPipeliner`.