### PR TITLE
[FRONTEND] Fix atomic min/max for float with negative zero

### DIFF
--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -756,6 +756,8 @@ class InterpreterBuilder:
         np_type = _get_np_dtype(type)
         if "int" in np_type.name:
             return TensorHandle(np.full(1, -1, dtype=np_type), type.scalar)
+        elif np_type == np.bool_:
+            return TensorHandle(np.full(1, True, dtype=np_type), type.scalar)
         else:
             raise TypeError(f"unsupported type {type}")
 


### PR DESCRIPTION
Fixes #6376

The software emulation of atomic min/max uses `x >= 0` to test the signbit, which breaks down when `x` is `-0.0` which equals zero but does have the sign bit set .

I fix this by looking at the bit representation of the float and extracting the sign bit directly.

I also fix not_ raising an error in the interpreter from `get_all_ones_value` since `np.bool` doesn't have "int" in the name.