### PR TITLE
[AMD][Pipeliner][Draft] Optimize compute logic of pipeliner through unguarding loads in the epilogue

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipelineExpander.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipelineExpander.h
@@ -51,6 +51,8 @@ struct PipeliningOption {
   /// lambda to generate the predicated version of operations.
   bool peelEpilogue = true;
 
+  bool guardEpilogue = true;
+
   /// Control whether the transformation checks that the number of iterations is
   /// greater or equal to the number of stages and skip the transformation if
   /// this is not the case. If the loop is dynamic and this is set to true the

--- a/python/src/passes.h
+++ b/python/src/passes.h
@@ -19,6 +19,11 @@
   m.def(name, [](mlir::PassManager &pm, ty0 val0, ty1 val1, ty2 val2,          \
                  ty3 val3) { pm.addPass(builder(val0, val1, val2, val3)); })
 
+#define ADD_PASS_WRAPPER_5(name, builder, ty0, ty1, ty2, ty3, ty4)             \
+  m.def(name,                                                                  \
+        [](mlir::PassManager &pm, ty0 val0, ty1 val1, ty2 val2, ty3 val3,      \
+           ty4 val4) { pm.addPass(builder(val0, val1, val2, val3, val4)); })
+
 #define ADD_PASS_OPTION_WRAPPER_1(name, builder, ty0)                          \
   m.def(name,                                                                  \
         [](mlir::PassManager &pm, ty0 val0) { pm.addPass(builder({val0})); })

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -246,7 +246,7 @@ class HIPBackend(BaseBackend):
         global_prefetch = int(os.getenv("TRITON_HIP_GLOBAL_PREFETCH", "0"))
         local_prefetch = int(os.getenv("TRITON_HIP_LOCAL_PREFETCH", "0"))
         use_async_copy = int(os.getenv("TRITON_HIP_USE_ASYNC_COPY", "0")) == 1
-        must_guard_epilogue = 1
+        must_guard_epilogue = int(os.getenv("TRITON_HIP_GUARD_EPILOGUE", "1"))
 
         # The `local-prefetch` scheduling variant requires turning on buffer ops.
         if options.schedule_hint == "local-prefetch":

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -246,12 +246,14 @@ class HIPBackend(BaseBackend):
         global_prefetch = int(os.getenv("TRITON_HIP_GLOBAL_PREFETCH", "0"))
         local_prefetch = int(os.getenv("TRITON_HIP_LOCAL_PREFETCH", "0"))
         use_async_copy = int(os.getenv("TRITON_HIP_USE_ASYNC_COPY", "0")) == 1
+        must_guard_epilogue = 1
 
         # The `local-prefetch` scheduling variant requires turning on buffer ops.
         if options.schedule_hint == "local-prefetch":
             global_prefetch = local_prefetch = 1
 
-        amd.passes.ttgpuir.add_stream_pipeline(pm, options.num_stages, global_prefetch, local_prefetch, use_async_copy)
+        amd.passes.ttgpuir.add_stream_pipeline(pm, options.num_stages, global_prefetch, local_prefetch, use_async_copy,
+                                               must_guard_epilogue)
         if use_async_copy:
             amd.passes.ttgpuir.add_coalesce_async_copy(pm, options.arch)
         passes.common.add_canonicalizer(pm)

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -8,10 +8,9 @@
 
 namespace mlir {
 
-std::unique_ptr<Pass>
-createTritonAMDGPUStreamPipelinePass(int numStages = 2, int globalPrefetch = 0,
-                                     int localPrefetch = 0,
-                                     bool useAsyncCopy = false);
+std::unique_ptr<Pass> createTritonAMDGPUStreamPipelinePass(
+    int numStages = 2, int globalPrefetch = 0, int localPrefetch = 0,
+    bool useAsyncCopy = false, bool mustGuardEpilogue = true);
 
 std::unique_ptr<Pass>
 createTritonAMDGPUAccelerateMatmulPass(std::string archGenName = std::string(),

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -28,6 +28,9 @@ def TritonAMDGPUStreamPipeline : Pass<"tritonamdgpu-stream-pipeline", "mlir::Mod
     Option<"useAsyncCopy", "use_async_copy",
            "bool", /*default*/"false",
            "Use AsyncCopyGlobalToLocal to directly load to shared memory">,
+    Option<"mustGuardEpilogue", "must_guard_epilogue",
+	    "bool", /*default*/"true",
+	    "Require conditionalized loads in epiloge of pipelined loop">,
   ];
 }
 

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -78,9 +78,9 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
                      mlir::createTritonAMDGPUFoldTrueCmpIPass);
   ADD_PASS_WRAPPER_1("add_block_pingpong",
                      mlir::createTritonAMDGPUBlockPingpongPass, int32_t);
-  ADD_PASS_WRAPPER_4("add_stream_pipeline",
+  ADD_PASS_WRAPPER_5("add_stream_pipeline",
                      mlir::createTritonAMDGPUStreamPipelinePass, int, int, int,
-                     bool);
+                     bool, bool);
   ADD_PASS_WRAPPER_1("add_coalesce_async_copy",
                      mlir::createTritonAMDGPUCoalesceAsyncCopyPass,
                      std::string);


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/6314 introduced the ability to "unguard" the epilogue in pipelined loops. This should drop the conditional in the epilogue if there is a tl.assume to indicate there is at least one iteration.

This PR extends the ability to unguard the epilogue in pipelined loops without the need for developer annotations for the specific case when: the compute logic in the epilogue depends entirely on global loads that are masked for the zero iteration case. The epilogue can then unconditionalized without side-effects.

Primarily authored by Simon Waters