### PR TITLE
Fix use after free in CombineTMEMLoadAndStore

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
@@ -142,7 +142,7 @@ public:
         foundStore = true;
       }
     }
-    if (!found) {
+    if (!foundStore) {
       return failure();
     }
     return success();


### PR DESCRIPTION
The patch fixes use-after-free error in the recently introduced HoistTMEMAlloc.cpp which was detected by the asan build.

We cannot use iterator to the users after erasing the current user of it.
The solution is to wrap the iterator with make_early_inc_range.  

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `the test already exists`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
