### PR TITLE
Add default pre_run hooks as a JITFunction class variable

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -485,6 +485,8 @@ class JITFunction(KernelInterface[T]):
     # Hook to signal that a kernel is done compiling and inspect compiled function.
     # cache_hook will always be called before compilation and compiled_hook after.
     compiled_hook = None
+    # Default run hooks - provide means of overriding run hooks globally
+    default_prerun_hooks = []
 
     def _call_hook(
         self,
@@ -688,7 +690,7 @@ class JITFunction(KernelInterface[T]):
         self.constexprs = [p.num for p in self.params if p.is_constexpr]
 
         # Hooks that will be called prior to executing "run"
-        self.pre_run_hooks = []
+        self.pre_run_hooks = JITFunction.default_prerun_hooks
 
         # reuse docs of wrapped function
         self.__doc__ = fn.__doc__


### PR DESCRIPTION
Add default pre_run hooks as a class variable so that they can be set globally and not per JITFunction instance.

This should allow implementation of statistics, tracing, etc as pre_run hook plugins without touching the core Triton code.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `It is a trivial initialization change`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
