### PR TITLE
[BACKEND] Standardize IR print options

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -658,8 +658,11 @@ void init_triton_ir(py::module &&m) {
            })
       .def("create_location_snapshot",
            [](ModuleOp &self, const std::string &fileName) -> void {
-            if (failed(generateLocationsFromIR(fileName, self, {})))
-              throw std::runtime_error("Failed to create location snapshot");
+             auto printingFlags = OpPrintingFlags();
+             printingFlags.elideLargeElementsAttrs(16);
+             printingFlags.enableDebugInfo();
+             if (failed(generateLocationsFromIR(fileName, self, printingFlags)))
+               throw std::runtime_error("Failed to create location snapshot");
            })
       .def("walk",
            [](ModuleOp &self, const std::function<void(Operation *)> &fn) {

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -658,9 +658,8 @@ void init_triton_ir(py::module &&m) {
            })
       .def("create_location_snapshot",
            [](ModuleOp &self, const std::string &fileName) -> void {
-             generateLocationsFromIR(/*raw_ostream=*/llvm::nulls(),
-                                     /*fileName=*/fileName,
-                                     /*op=*/self, /*flags=*/{});
+            if (failed(generateLocationsFromIR(fileName, self, {})))
+              throw std::runtime_error("Failed to create location snapshot");
            })
       .def("walk",
            [](ModuleOp &self, const std::function<void(Operation *)> &fn) {


### PR DESCRIPTION
Previously, when we performed IR relocation, we didn’t output locations of the ModuleOp.

What we printed to the output stream didn’t include locations, but what we stored in the file still did, resulting in mismatches.

Now that we use a single function to control the format of the output IR, we always output locations.