### PR TITLE
[release-only] Update twine for release 3.3.x

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -92,4 +92,5 @@ jobs:
       - name: Upload wheels to PyPI
         if: ${{ matrix.config.arch == 'x86_64' }}
         run: |
+          python3 -m pip install twine --upgrade --user
           python3 -m twine upload wheelhouse/* -u __token__ -p ${{ secrets.PYPY_API_TOKEN }}


### PR DESCRIPTION
Seeing following error:
https://github.com/triton-lang/triton/actions/runs/14364110492/job/40272734561

```
Uploading distributions to https://upload.pypi.org/legacy/
ERROR    InvalidDistribution: Metadata is missing required fields: Name,        
         Version.                                                               
         Make sure the distribution includes the files where those fields are   
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,   
         2.0, 2.1, 2.2, 2.3.    
```

twine needs to be updated.