### PR TITLE
Replace the inline assembly for i32->f32 conversion with LLVM::SIToFpOp

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1906,11 +1906,10 @@ def test_cast(dtype_x, dtype_z, bitcast, size, num_ctas, device):
         check_type_supported(dtype_z, device)
 
     if is_hip():
-        if (not is_hip_cdna3() and not is_hip_cdna4() and 
-           (dtype_x == 'float8_e4m3fn' or dtype_z == 'float8_e4m3fn')):
+        if not is_hip_cdna3() and not is_hip_cdna4() and (dtype_x == 'float8_e4m3fn' or dtype_z == 'float8_e4m3fn'):
             pytest.skip(f'test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA3/CDNA4.')
         if (not is_hip_cdna4()) and ((dtype_x == 'bfloat16' and dtype_z == "float8_e4m3fn") or
-                               (dtype_x == "float8_e4m3fn" and dtype_z == 'bfloat16')):
+                                     (dtype_x == "float8_e4m3fn" and dtype_z == 'bfloat16')):
             pytest.skip(f'test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA4.')
 
     torch.manual_seed(0)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1905,9 +1905,13 @@ def test_cast(dtype_x, dtype_z, bitcast, size, num_ctas, device):
         check_type_supported(dtype_x, device)
         check_type_supported(dtype_z, device)
 
-    if not is_hip_cdna4() and ((dtype_x == 'bfloat16' and dtype_z == "float8_e4m3fn") or
+    if is_hip():
+        if (not is_hip_cdna3() and not is_hip_cdna4() and 
+           (dtype_x == 'float8_e4m3fn' or dtype_z == 'float8_e4m3fn')):
+            pytest.skip(f'test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA3/CDNA4.')
+        if (not is_hip_cdna4()) and ((dtype_x == 'bfloat16' and dtype_z == "float8_e4m3fn") or
                                (dtype_x == "float8_e4m3fn" and dtype_z == 'bfloat16')):
-        pytest.skip(f'test_cast{(dtype_x, dtype_z)} cast to bfloat16 only supported on HIP CDNA4.')
+            pytest.skip(f'test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA4.')
 
     torch.manual_seed(0)
     # This is tricky because numpy doesn't have bfloat, and torch doesn't have uints.

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1905,8 +1905,9 @@ def test_cast(dtype_x, dtype_z, bitcast, size, num_ctas, device):
         check_type_supported(dtype_x, device)
         check_type_supported(dtype_z, device)
 
-    if is_hip() and (dtype_z in ("bfloat16", "float8_e4m3fn") or dtype_x == "float8_e4m3fn"):
-        pytest.skip(f'test_cast{(dtype_x, dtype_z)} cast to bfloat16 not supported on HIP.')
+    if not is_hip_cdna4() and ((dtype_x == 'bfloat16' and dtype_z == "float8_e4m3fn") or
+                               (dtype_x == "float8_e4m3fn" and dtype_z == 'bfloat16')):
+        pytest.skip(f'test_cast{(dtype_x, dtype_z)} cast to bfloat16 only supported on HIP CDNA4.')
 
     torch.manual_seed(0)
     # This is tricky because numpy doesn't have bfloat, and torch doesn't have uints.

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1495,14 +1495,7 @@ static SmallVector<Value> S8_to_Bf16(Location loc,
   SmallVector<Value> outValues = {};
   for (Value inVal : inValues) {
     Value i32Val = b.sext(i32_ty, inVal);
-
-    GCNBuilder builder;
-    auto &cvt = *builder.create("v_cvt_f32_i32");
-    auto res = builder.newOperand("=v");
-    auto operand = builder.newOperand(i32Val, "v");
-    cvt(res, operand);
-    auto f32Val = builder.launch(rewriter, loc, f32_ty, false);
-
+    Value f32Val = rewriter.create<LLVM::SIToFPOp>(loc, f32_ty, i32Val);
     f32Val = b.bitcast(f32Val, i32_ty);
     auto shifted = b.lshr(i32_ty, f32Val, b.i32_val(16));
     auto truncated = b.trunc(i16_ty, shifted);
@@ -1511,7 +1504,6 @@ static SmallVector<Value> S8_to_Bf16(Location loc,
   return outValues;
 }
 
-// Uses inline ptx to convert s8/u8 to bf16, since the
 struct SIToFPOpConversion
     : ElementwiseOpConversionBase<arith::SIToFPOp, SIToFPOpConversion> {
   using ElementwiseOpConversionBase::ElementwiseOpConversionBase;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1494,12 +1494,8 @@ static SmallVector<Value> S8_to_Bf16(Location loc,
   SmallVector<Value> inValues = {v[0], v[1], v[2], v[3]};
   SmallVector<Value> outValues = {};
   for (Value inVal : inValues) {
-    Value i32Val = b.sext(i32_ty, inVal);
-    Value f32Val = rewriter.create<LLVM::SIToFPOp>(loc, f32_ty, i32Val);
-    f32Val = b.bitcast(f32Val, i32_ty);
-    auto shifted = b.lshr(i32_ty, f32Val, b.i32_val(16));
-    auto truncated = b.trunc(i16_ty, shifted);
-    outValues.push_back(b.bitcast(truncated, bf16_ty));
+    Value bf16Val = rewriter.create<LLVM::SIToFPOp>(loc, bf16_ty, inVal);
+    outValues.push_back(bf16Val);
   }
   return outValues;
 }


### PR DESCRIPTION
- Replace the inline assembly for i32->f32 conversion with LLVM::SIToFpOp to allow potential backend optimizations.
- Enable bf16 conversions in test_core.py.