### PR TITLE
[AMD][BACKEND] Add Alias Information to interleave AsyncLoads and LocalReads in pipelined loops

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -99,7 +99,7 @@ public:
   virtual void storeOpAnnotation(triton::gpu::LocalStoreOp op,
                                  size_t localStoreOpCount, Type type) const {}
   // Helper to add (no)alias information to local loads to help llvm interleave
-  // async operations
+  // with async operations
   virtual void setLocalLoadAsyncAliasInfo(triton::gpu::LocalLoadOp localLoadOp,
                                           Operation *llLoadOp) const {};
 

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -98,10 +98,10 @@ public:
   // llvm.
   virtual void storeOpAnnotation(triton::gpu::LocalStoreOp op,
                                  size_t localStoreOpCount, Type type) const {}
-  // Helper to add (no)alias information to local loads to help llvm interleave
-  // with async operations
-  virtual void setLocalLoadAsyncAliasInfo(triton::gpu::LocalLoadOp localLoadOp,
-                                          Operation *llLoadOp) const {};
+  // Adds alias information to local loads to help llvm interleave with async
+  // operations
+  virtual void setAsyncAliasScopes(triton::gpu::LocalLoadOp localLoadOp,
+                                   Operation *llLoadOp) const {};
 
   virtual ~TargetInfoBase() {}
 };

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -98,6 +98,10 @@ public:
   // llvm.
   virtual void storeOpAnnotation(triton::gpu::LocalStoreOp op,
                                  size_t localStoreOpCount, Type type) const {}
+  // Helper to add (no)alias information to local loads to help llvm interleave
+  // async operations
+  virtual void setLocalLoadAsyncAliasInfo(triton::gpu::LocalLoadOp localLoadOp,
+                                          Operation *llLoadOp) const {};
 
   virtual ~TargetInfoBase() {}
 };

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -100,8 +100,8 @@ public:
                                  size_t localStoreOpCount, Type type) const {}
   // Adds alias information to local loads to help llvm interleave with async
   // operations
-  virtual void setAsyncAliasScopes(triton::gpu::LocalLoadOp localLoadOp,
-                                   Operation *llLoadOp) const {};
+  virtual void localLoadOpAnnotation(triton::gpu::LocalLoadOp localLoadOp,
+                                     Operation *llLoadOp) const {}
 
   virtual ~TargetInfoBase() {}
 };

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -94,12 +94,13 @@ public:
 
   virtual bool supportVectorizedAtomics() const = 0;
 
-  // Helper used by targets to annotate store operations during lowering to
-  // llvm.
-  virtual void storeOpAnnotation(triton::gpu::LocalStoreOp op,
-                                 size_t localStoreOpCount, Type type) const {}
-  // Adds alias information to local loads to help llvm interleave with async
-  // operations
+  // Annotate target specific information to local store operations during
+  // lowering to LLVM.
+  virtual void localStoreOpAnnotation(triton::gpu::LocalStoreOp op,
+                                      size_t localStoreOpCount,
+                                      Type type) const {}
+  // Annotate target specific information to local load operations during
+  // lowering to LLVM. `llLoadOp` is the generated LLVM load op.
   virtual void localLoadOpAnnotation(triton::gpu::LocalLoadOp localLoadOp,
                                      Operation *llLoadOp) const {}
 

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -706,8 +706,7 @@ emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
     Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
     std::function<void(VectorType, Value /*shmemAddr*/)> perVectorCallback);
 
-SmallVector<Value> loadSharedToDistributed(RankedTensorType dstTy,
-                                           triton::gpu::MemDescType srcTy,
+SmallVector<Value> loadSharedToDistributed(triton::gpu::LocalLoadOp localLoadOp,
                                            Type elemLlvmTy,
                                            const SharedMemoryObject &smemObj,
                                            Location loc, RewriterBase &rewriter,

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -140,7 +140,7 @@ private:
     auto elemLlvmTy = typeConverter->convertType(dstTy.getElementType());
 
     SmallVector<Value> outVals = loadSharedToDistributed(
-        dstTy, srcTy, elemLlvmTy, smemObj, loc, rewriter, targetInfo);
+        op, elemLlvmTy, smemObj, loc, rewriter, targetInfo);
 
     Value result = packLLElements(loc, typeConverter, outVals, rewriter, dstTy);
     rewriter.replaceOp(op, result);

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -178,7 +178,8 @@ public:
                              adaptor.getSrc(), smemObj, getTypeConverter(),
                              rewriter, targetInfo, &llvmOpCount);
 
-    targetInfo.storeOpAnnotation(op, llvmOpCount.first, llvmOpCount.second);
+    targetInfo.localStoreOpAnnotation(op, llvmOpCount.first,
+                                      llvmOpCount.second);
 
     rewriter.eraseOp(op);
     return success();

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -508,7 +508,7 @@ SmallVector<Value> loadSharedToDistributed(triton::gpu::LocalLoadOp localLoadOp,
       dstTy, srcTy, elemLlvmTy, /*maxVecElems=*/std::nullopt, smemObj, loc,
       rewriter, target, [&](VectorType vecTy, Value vecAddr) {
         auto vecVal = b.load(vecTy, vecAddr);
-        target.setLocalLoadAsyncAliasInfo(localLoadOp, vecVal);
+        target.setAsyncAliasScopes(localLoadOp, vecVal);
         vecVal.setAlignment(vecTy.getNumElements() *
                             elemLlvmTy.getIntOrFloatBitWidth() / 8);
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -494,18 +494,21 @@ bool emitTransferBetweenRegistersAndShared(
       target, perVectorCallback);
 }
 
-SmallVector<Value> loadSharedToDistributed(RankedTensorType dstTy,
-                                           triton::gpu::MemDescType srcTy,
+SmallVector<Value> loadSharedToDistributed(triton::gpu::LocalLoadOp localLoadOp,
                                            Type elemLlvmTy,
                                            const SharedMemoryObject &smemObj,
                                            Location loc, RewriterBase &rewriter,
                                            const TargetInfoBase &target) {
+  auto srcTy = localLoadOp.getSrc().getType();
+  auto dstTy = localLoadOp.getResult().getType();
+
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   SmallVector<Value> ret;
   bool success = emitTransferBetweenRegistersAndShared(
       dstTy, srcTy, elemLlvmTy, /*maxVecElems=*/std::nullopt, smemObj, loc,
       rewriter, target, [&](VectorType vecTy, Value vecAddr) {
         auto vecVal = b.load(vecTy, vecAddr);
+        target.setLocalLoadAsyncAliasInfo(localLoadOp, vecVal);
         vecVal.setAlignment(vecTy.getNumElements() *
                             elemLlvmTy.getIntOrFloatBitWidth() / 8);
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -508,7 +508,7 @@ SmallVector<Value> loadSharedToDistributed(triton::gpu::LocalLoadOp localLoadOp,
       dstTy, srcTy, elemLlvmTy, /*maxVecElems=*/std::nullopt, smemObj, loc,
       rewriter, target, [&](VectorType vecTy, Value vecAddr) {
         auto vecVal = b.load(vecTy, vecAddr);
-        target.setAsyncAliasScopes(localLoadOp, vecVal);
+        target.localLoadOpAnnotation(localLoadOp, vecVal);
         vecVal.setAlignment(vecTy.getNumElements() *
                             elemLlvmTy.getIntOrFloatBitWidth() / 8);
 

--- a/test/Conversion/amd/async-ops-alias-scopes.mlir
+++ b/test/Conversion/amd/async-ops-alias-scopes.mlir
@@ -1,46 +1,115 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s --check-prefixes=COMMON,GFX950
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 | FileCheck %s --check-prefixes=COMMON,GFX942
 
-// CHECK: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
+// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @local_load_without_no_alias(%arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable>, %arg3: tensor<64x1x!tt.ptr<f16>, #blocked>) {
-    // CHECK: rocdl.global.load.lds {{.*}} {alias_scopes = [[[ASYNC_COPY_SCOPE]]]
-    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<64x1x!tt.ptr<f16>, #blocked> -> <64x1xf16, #shared, #smem, mutable>
-    %1 = ttg.async_commit_group %0
+  tt.func public @async_copy_alias(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                                         %arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable>) {
+    // We need the splat to allow the AxisAnalysis to work during lowering
+    %ptr = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x1x!tt.ptr<f16>, #blocked>
 
-    %3 = ttg.async_wait %1 {num = 1 : i32}
+    // COMMON: rocdl.global.load.lds {{.*}} {alias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    %0 = ttg.async_copy_global_to_local %ptr, %arg1 : tensor<64x1x!tt.ptr<f16>, #blocked> -> <64x1xf16, #shared, #smem, mutable>
 
-    // Both LocalLoads should not have noAlias set to ASYNC_COPY_SCOPE because they do not use a token from ttg.async_wait
-    // CHECK-NOT: [[[ASYNC_COPY_SCOPE]]]
-    %4 = ttg.local_load %arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable> -> tensor<64x1xf16, #blocked>
-    %5 = ttg.local_load %arg1 token %0 : !ttg.memdesc<64x1xf16, #shared, #smem, mutable> -> tensor<64x1xf16, #blocked>
-
-    // CHECK: llvm.return
+    // COMMON: llvm.return
     tt.return
   }
 }
 
 // -----
 
-// CHECK: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
-// CHECK: [[LOCAL_LOAD_SCOPE:#.*]] = #llvm.alias_scope<id = "LocalLoads"
+// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @buffer_load_to_local_alias(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                             %arg1: !tt.ptr<f16>,
+                                             %arg2: tensor<8x64xi32, #blocked>,
+                                             %arg3: !ttg.memdesc<8x64xf16, #shared, #smem, mutable>) {
+    // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}} {alias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    %65 = amdgpu.buffer_load_to_local %arg1[%arg2] into %arg3 {OpIdx = #amdgpu.OpIdx<1>} : <f16>[tensor<8x64xi32, #blocked>] -> <8x64xf16, #shared, #smem, mutable>
+    // COMMON: llvm.return
+    tt.return
+  }
+}
+
+// -----
+
+// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
+// COMMON: [[LOCAL_LOAD_SCOPE:#.*]] = #llvm.alias_scope<id = "LocalLoads"
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
 #smem = #ttg.shared_memory
+#mma = #ttg.amd_mfma<{versionMajor = 4, versionMinor = 0, warpsPerCTA = [1, 4], instrShape = [32, 32], isTransposed = true}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @local_load_with_token_from_async_wait(%arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable>, %arg3: tensor<64x1x!tt.ptr<f16>, #blocked>) {
-    // CHECK: rocdl.global.load.lds {{.*}} {alias_scopes = [[[ASYNC_COPY_SCOPE]]]
-    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<64x1x!tt.ptr<f16>, #blocked> -> <64x1xf16, #shared, #smem, mutable>
+  tt.func public @local_loads_with_token_from_async_wait(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                                         %arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable>,
+                                                         %arg4: !ttg.memdesc<16x16xf16, #shared, #smem, mutable>) {
+    // We need the splat to allow the AxisAnalysis to work during lowering
+    %ptr = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x1x!tt.ptr<f16>, #blocked>
+
+    // COMMON: rocdl.global.load.lds {{.*}} {alias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    %0 = ttg.async_copy_global_to_local %ptr, %arg1 : tensor<64x1x!tt.ptr<f16>, #blocked> -> <64x1xf16, #shared, #smem, mutable>
     %1 = ttg.async_commit_group %0
 
     %3 = ttg.async_wait %1 {num = 1 : i32}
 
-    // CHECK: llvm.load {{.*}} {alias_scopes = [[[LOCAL_LOAD_SCOPE]]], {{.*}}, noalias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    // Check alias information is added for different lowering paths
+
+    // Test lowering path in common MemoryOpToLLVM pattern
+    // COMMON: llvm.load {{.*}} {alias_scopes = [[[LOCAL_LOAD_SCOPE]]], {{.*}}, noalias_scopes = [[[ASYNC_COPY_SCOPE]]]
     %4 = ttg.local_load %arg1 token %3 : !ttg.memdesc<64x1xf16, #shared, #smem, mutable> -> tensor<64x1xf16, #blocked>
 
-    // CHECK: llvm.return
+    // Test lowering path in AMD's MemoryOpToLLVM pattern
+    // GFX942-COUNT-8: llvm.load {{.*}} {alias_scopes = [[[LOCAL_LOAD_SCOPE]]], {{.*}}, noalias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    // GFX950-COUNT-2: rocdl.ds.read.tr16.b64 {{.*}} {alias_scopes = [[[LOCAL_LOAD_SCOPE]]], noalias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    %5 = ttg.local_load %arg4 token %3 : !ttg.memdesc<16x16xf16, #shared, #smem, mutable> -> tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+
+    // COMMON: llvm.return
+    tt.return
+  }
+}
+
+// -----
+
+// Same as above but LocalLoad does not use the token from AsyncWait
+
+// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#mma = #ttg.amd_mfma<{versionMajor = 4, versionMinor = 0, warpsPerCTA = [1, 4], instrShape = [32, 32], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @local_loads_without_token_from_async_wait(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                                            %arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable>,
+                                                            %arg4: !ttg.memdesc<16x16xf16, #shared, #smem, mutable>) {
+    // We need the splat to allow the AxisAnalysis to work during lowering
+    %ptr = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x1x!tt.ptr<f16>, #blocked>
+
+    // COMMON: rocdl.global.load.lds {{.*}} {alias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    %0 = ttg.async_copy_global_to_local %ptr, %arg1 : tensor<64x1x!tt.ptr<f16>, #blocked> -> <64x1xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+
+    %3 = ttg.async_wait %1 {num = 1 : i32}
+
+    // Check alias information is not used at all for different lowering paths
+    // COMMON-NOT: [[ASYNC_COPY_SCOPE]]
+
+    // Test lowering path in common MemoryOpToLLVM pattern
+    %4 = ttg.local_load %arg1 token %0 : !ttg.memdesc<64x1xf16, #shared, #smem, mutable> -> tensor<64x1xf16, #blocked>
+    %5 = ttg.local_load %arg1 : !ttg.memdesc<64x1xf16, #shared, #smem, mutable> -> tensor<64x1xf16, #blocked>
+
+    // Test lowering path in AMD's MemoryOpToLLVM pattern
+    %7 = ttg.local_load %arg4 token %0 : !ttg.memdesc<16x16xf16, #shared, #smem, mutable> -> tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    %8 = ttg.local_load %arg4 : !ttg.memdesc<16x16xf16, #shared, #smem, mutable> -> tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+
+    // COMMON: llvm.return
     tt.return
   }
 }

--- a/test/Conversion/amd/async-ops-alias-scopes.mlir
+++ b/test/Conversion/amd/async-ops-alias-scopes.mlir
@@ -1,0 +1,46 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s
+
+// CHECK: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @local_load_without_no_alias(%arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable>, %arg3: tensor<64x1x!tt.ptr<f16>, #blocked>) {
+    // CHECK: rocdl.global.load.lds {{.*}} {alias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<64x1x!tt.ptr<f16>, #blocked> -> <64x1xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+
+    %3 = ttg.async_wait %1 {num = 1 : i32}
+
+    // Both LocalLoads should not have noAlias set to ASYNC_COPY_SCOPE because they do not use a token from ttg.async_wait
+    // CHECK-NOT: [[[ASYNC_COPY_SCOPE]]]
+    %4 = ttg.local_load %arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable> -> tensor<64x1xf16, #blocked>
+    %5 = ttg.local_load %arg1 token %0 : !ttg.memdesc<64x1xf16, #shared, #smem, mutable> -> tensor<64x1xf16, #blocked>
+
+    // CHECK: llvm.return
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
+// CHECK: [[LOCAL_LOAD_SCOPE:#.*]] = #llvm.alias_scope<id = "LocalLoads"
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @local_load_with_token_from_async_wait(%arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable>, %arg3: tensor<64x1x!tt.ptr<f16>, #blocked>) {
+    // CHECK: rocdl.global.load.lds {{.*}} {alias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<64x1x!tt.ptr<f16>, #blocked> -> <64x1xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group %0
+
+    %3 = ttg.async_wait %1 {num = 1 : i32}
+
+    // CHECK: llvm.load {{.*}} {alias_scopes = [[[LOCAL_LOAD_SCOPE]]], {{.*}}, noalias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    %4 = ttg.local_load %arg1 token %3 : !ttg.memdesc<64x1xf16, #shared, #smem, mutable> -> tensor<64x1xf16, #blocked>
+
+    // CHECK: llvm.return
+    tt.return
+  }
+}

--- a/test/Conversion/amd/async-ops-alias-scopes.mlir
+++ b/test/Conversion/amd/async-ops-alias-scopes.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s --check-prefixes=COMMON,GFX950
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 | FileCheck %s --check-prefixes=COMMON,GFX942
 
-// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
+// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.AsyncCopies"
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
 #smem = #ttg.shared_memory
@@ -21,7 +21,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 
 // -----
 
-// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
+// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.AsyncCopies"
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
@@ -39,8 +39,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
-// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
-// COMMON: [[LOCAL_LOAD_SCOPE:#.*]] = #llvm.alias_scope<id = "LocalLoads"
+// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.AsyncCopies"
+// COMMON: [[LOCAL_LOAD_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.LocalLoads"
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
@@ -79,7 +79,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 
 // Same as above but LocalLoad does not use the token from AsyncWait
 
-// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "AsyncCopies"
+// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.AsyncCopies"
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -104,15 +104,16 @@ Value BufferEmitter::emitLoad(Type type, Value rsrcDesc, Value offset,
   return data;
 }
 
-void BufferEmitter::emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc,
-                                  Value offset, Value dst, Value pred,
-                                  triton::CacheModifier cm) {
+ROCDL::RawPtrBufferLoadLdsOp
+BufferEmitter::emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc,
+                             Value offset, Value dst, Value pred,
+                             triton::CacheModifier cm) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   SmallVector<Value, 6> commonArgs;
   fillCommonArgs(type, rsrcDesc, offset, pred, cm, /*isBufferLoad=*/true,
                  commonArgs);
   Type bufferType = getBufferOpType(type, false);
-  rewriter.create<ROCDL::RawPtrBufferLoadLdsOp>(
+  return rewriter.create<ROCDL::RawPtrBufferLoadLdsOp>(
       loc, TypeRange{},
       ValueRange{
           commonArgs[0], // Buffer descriptor

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.h
@@ -71,8 +71,10 @@ struct BufferEmitter {
                  Value falseVal, CacheModifier cm);
 
   // Emit a predicated rocdl.raw.ptr.buffer.load.lds
-  void emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc, Value offset,
-                     Value dst, Value pred, CacheModifier cm);
+  ROCDL::RawPtrBufferLoadLdsOp emitLoadToLds(Type type, Value byteWidth,
+                                             Value rsrcDesc, Value offset,
+                                             Value dst, Value pred,
+                                             CacheModifier cm);
 
   // Emit a predicated rocdl.raw.ptr.buffer.atomic.* RMWOp
   Value emitAtomicRMW(RMWOp rmwType, Type type, Value rsrcDesc, Value offset,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -297,6 +297,7 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   Value warpIdInBatch = tb.urem(linearWarpId, tb.i32_val(warpsPerBatch));
   elemTy = typeConverter->convertType(elemTy);
 
+  SmallVector<LLVM::LoadOp> llLoads;
   SmallVector<Value> loadedValues;
   SmallVector<Value> offsets;
   Value smemBase;
@@ -377,7 +378,8 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
                                k * loadsPerThread + loadId];
           loadOffset = tb.add(loadOffset, batchOffset);
           Value loadAddress = tb.gep(smemPtrTy, elemTy, smemBase, loadOffset);
-          Value loadedValue = tb.load(loadVecTy, loadAddress);
+          llLoads.push_back(tb.load(loadVecTy, loadAddress));
+          Value loadedValue = llLoads.back();
           for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
             Value elemVal =
                 tb.extract_element(elemTy, loadedValue, tb.i32_val(elemId));
@@ -393,6 +395,10 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
       const size_t numDsReadsCount =
           repB * numRepNonK * numRepK * loadsPerThread;
       setNumGeneratedDsReads(localLoadOp, numDsReadsCount, loadVecTy);
+
+      for (auto llLoad : llLoads) {
+        LLVM::AMD::applyLocalLoadAliasScopes(localLoadOp, llLoad);
+      }
     }
   }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -397,7 +397,7 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
       setNumGeneratedDsReads(localLoadOp, numDsReadsCount, loadVecTy);
 
       for (auto llLoad : llLoads) {
-        LLVM::AMD::applyLocalLoadAliasScopes(localLoadOp, llLoad);
+        LLVM::AMD::addLocalLoadNoAliasScope(localLoadOp, llLoad);
       }
     }
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -597,7 +597,7 @@ struct BufferLoadToLocalOpConversion
       auto bufferLoadToLds = bufferEmitter.emitLoadToLds(
           vecTy, vecBytesVal, rsrcDesc, offsetIn, coalescedShmemAddr[i], pred,
           op.getCache());
-      LLVM::AMD::applyAsyncAliasScopes(bufferLoadToLds);
+      LLVM::AMD::addAsyncCopyAliasScope(bufferLoadToLds);
       if (!otherElems.empty()) {
         Value storeVal = packElementRangeIntoVector(
             rewriter, this->getTypeConverter(), loc, vecTy, otherElems, srcIdx);
@@ -724,7 +724,7 @@ struct AsyncCopyGlobalToLocalOpConversion
             /*size=*/vecBytesVal, /*offset=*/b.i32_val(0),
             /*aux=*/cacheModifiers, /*alias_scopes=*/nullptr,
             /*noalias_scopes=*/nullptr, /*tbaa=*/nullptr);
-        LLVM::AMD::applyAsyncAliasScopes(globalLoadLdsOp);
+        LLVM::AMD::addAsyncCopyAliasScope(globalLoadLdsOp);
         continue;
       }
 
@@ -738,7 +738,7 @@ struct AsyncCopyGlobalToLocalOpConversion
       auto globalLoadLdsOp = rewriter.create<ROCDL::GlobalLoadLDSOp>(
           loc, srcPtr, coalescedShmemAddr[i], vecBytesVal,
           /*offset=*/b.i32_val(0), cacheModifiers, nullptr, nullptr, nullptr);
-      LLVM::AMD::applyAsyncAliasScopes(globalLoadLdsOp);
+      LLVM::AMD::addAsyncCopyAliasScope(globalLoadLdsOp);
 
       rewriter.create<LLVM::BrOp>(loc, afterLoad);
       rewriter.setInsertionPointToStart(afterLoad);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -268,6 +268,7 @@ private:
           if (bitwidth == 16) {
             auto dsReadOp =
                 rewriter.create<ROCDL::ds_read_tr16_b64>(loc, vecTy, vecAddr);
+            LLVM::AMD::applyLocalLoadAliasScopes(op, dsReadOp);
             Value vecVal = dsReadOp.getResult();
             for (int v = 0; v < vecTy.getNumElements(); v++) {
               outVals.push_back(
@@ -281,6 +282,7 @@ private:
 
             auto dsReadOp =
                 rewriter.create<ROCDL::ds_read_tr8_b64>(loc, i32VecTy, vecAddr);
+            LLVM::AMD::applyLocalLoadAliasScopes(op, dsReadOp);
             Value vecVal = dsReadOp.getResult();
             for (auto i = 0; i < numElemsI32; ++i) {
               elemsI32.push_back(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -268,7 +268,7 @@ private:
           if (bitwidth == 16) {
             auto dsReadOp =
                 rewriter.create<ROCDL::ds_read_tr16_b64>(loc, vecTy, vecAddr);
-            LLVM::AMD::applyLocalLoadAliasScopes(op, dsReadOp);
+            LLVM::AMD::addLocalLoadNoAliasScope(op, dsReadOp);
             Value vecVal = dsReadOp.getResult();
             for (int v = 0; v < vecTy.getNumElements(); v++) {
               outVals.push_back(
@@ -282,7 +282,7 @@ private:
 
             auto dsReadOp =
                 rewriter.create<ROCDL::ds_read_tr8_b64>(loc, i32VecTy, vecAddr);
-            LLVM::AMD::applyLocalLoadAliasScopes(op, dsReadOp);
+            LLVM::AMD::addLocalLoadNoAliasScope(op, dsReadOp);
             Value vecVal = dsReadOp.getResult();
             for (auto i = 0; i < numElemsI32; ++i) {
               elemsI32.push_back(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -533,4 +533,10 @@ bool TargetInfo::supportsDirectToLdsLoadBitWidth(int bitWidth) const {
   return false;
 }
 
+void TargetInfo::setLocalLoadAsyncAliasInfo(
+    triton::gpu::LocalLoadOp localLoadOp, Operation *llLoadOp) const {
+  LLVM::AMD::applyLocalLoadAliasScopes(localLoadOp,
+                                       cast<LLVM::LoadOp>(llLoadOp));
+}
+
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -533,8 +533,8 @@ bool TargetInfo::supportsDirectToLdsLoadBitWidth(int bitWidth) const {
   return false;
 }
 
-void TargetInfo::setLocalLoadAsyncAliasInfo(
-    triton::gpu::LocalLoadOp localLoadOp, Operation *llLoadOp) const {
+void TargetInfo::setAsyncAliasScopes(triton::gpu::LocalLoadOp localLoadOp,
+                                     Operation *llLoadOp) const {
   LLVM::AMD::addLocalLoadNoAliasScope(localLoadOp,
                                       cast<LLVM::LoadOp>(llLoadOp));
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -535,8 +535,8 @@ bool TargetInfo::supportsDirectToLdsLoadBitWidth(int bitWidth) const {
 
 void TargetInfo::setLocalLoadAsyncAliasInfo(
     triton::gpu::LocalLoadOp localLoadOp, Operation *llLoadOp) const {
-  LLVM::AMD::applyLocalLoadAliasScopes(localLoadOp,
-                                       cast<LLVM::LoadOp>(llLoadOp));
+  LLVM::AMD::addLocalLoadNoAliasScope(localLoadOp,
+                                      cast<LLVM::LoadOp>(llLoadOp));
 }
 
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -512,8 +512,9 @@ bool TargetInfo::supportVectorizedAtomics() const {
   return true;
 }
 
-void TargetInfo::storeOpAnnotation(triton::gpu::LocalStoreOp op,
-                                   size_t localStoreOpCount, Type type) const {
+void TargetInfo::localStoreOpAnnotation(triton::gpu::LocalStoreOp op,
+                                        size_t localStoreOpCount,
+                                        Type type) const {
   storeOpSchedAnnotations(op, localStoreOpCount, type);
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -533,8 +533,8 @@ bool TargetInfo::supportsDirectToLdsLoadBitWidth(int bitWidth) const {
   return false;
 }
 
-void TargetInfo::setAsyncAliasScopes(triton::gpu::LocalLoadOp localLoadOp,
-                                     Operation *llLoadOp) const {
+void TargetInfo::localLoadOpAnnotation(triton::gpu::LocalLoadOp localLoadOp,
+                                       Operation *llLoadOp) const {
   LLVM::AMD::addLocalLoadNoAliasScope(localLoadOp,
                                       cast<LLVM::LoadOp>(llLoadOp));
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -84,8 +84,8 @@ public:
 
   bool supportsDirectToLdsLoadBitWidth(int bitWidth) const;
 
-  void setLocalLoadAsyncAliasInfo(triton::gpu::LocalLoadOp localLoadOp,
-                                  Operation *llLoadOp) const override;
+  void setAsyncAliasScopes(triton::gpu::LocalLoadOp localLoadOp,
+                           Operation *llLoadOp) const override;
 
 private:
   void printfImpl(Value formatStrStart, int formatStrByteCount, ValueRange args,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -84,6 +84,9 @@ public:
 
   bool supportsDirectToLdsLoadBitWidth(int bitWidth) const;
 
+  void setLocalLoadAsyncAliasInfo(triton::gpu::LocalLoadOp localLoadOp,
+                                  Operation *llLoadOp) const override;
+
 private:
   void printfImpl(Value formatStrStart, int formatStrByteCount, ValueRange args,
                   ArrayRef<bool> isSigned, RewriterBase &rewriter,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -79,8 +79,9 @@ public:
 
   bool supportVectorizedAtomics() const override;
 
-  void storeOpAnnotation(triton::gpu::LocalStoreOp op, size_t localStoreOpCount,
-                         Type type) const override;
+  void localStoreOpAnnotation(triton::gpu::LocalStoreOp op,
+                              size_t localStoreOpCount,
+                              Type type) const override;
 
   bool supportsDirectToLdsLoadBitWidth(int bitWidth) const;
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -84,8 +84,8 @@ public:
 
   bool supportsDirectToLdsLoadBitWidth(int bitWidth) const;
 
-  void setAsyncAliasScopes(triton::gpu::LocalLoadOp localLoadOp,
-                           Operation *llLoadOp) const override;
+  void localLoadOpAnnotation(triton::gpu::LocalLoadOp localLoadOp,
+                             Operation *llLoadOp) const override;
 
 private:
   void printfImpl(Value formatStrStart, int formatStrByteCount, ValueRange args,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -106,6 +106,11 @@ bool isChainDotHead(mlir::triton::DotOpInterface dotOp);
 // Check if the opA of this tl.dot is the result of another tl.dot
 // in the same region
 bool isChainDotTail(mlir::triton::DotOpInterface dotOp);
+
+void applyAsyncAliasScopes(AliasAnalysisOpInterface llLoadDirectToLdsOp);
+void applyLocalLoadAliasScopes(triton::gpu::LocalLoadOp localLoadOp,
+                               AliasAnalysisOpInterface llLoadOp);
+
 } // namespace mlir::LLVM::AMD
 
 #endif // TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUTOLLVM_UTILITY_H_

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -107,9 +107,15 @@ bool isChainDotHead(mlir::triton::DotOpInterface dotOp);
 // in the same region
 bool isChainDotTail(mlir::triton::DotOpInterface dotOp);
 
-void applyAsyncAliasScopes(AliasAnalysisOpInterface llLoadDirectToLdsOp);
+// LLVM is unable to recognize the dependency between AsyncCopy and
+// LocalLoads between warps and generates conservative waits.
+// For LocalLoads consuming an AsyncToken from an AsyncWait we will disable the
+// implicit waits by marking the ops to not alias. All AsyncCopies will be
+// placed in the same alias scope. Manual synchronized LocalLoadOps are marked
+// to not alias with the scope of AsyncCopies
 void applyLocalLoadAliasScopes(triton::gpu::LocalLoadOp localLoadOp,
                                AliasAnalysisOpInterface llLoadOp);
+void applyAsyncLoadAliasScope(AliasAnalysisOpInterface llLoadDirectToLdsOp);
 
 } // namespace mlir::LLVM::AMD
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -113,9 +113,9 @@ bool isChainDotTail(mlir::triton::DotOpInterface dotOp);
 // implicit waits by marking the ops to not alias. All AsyncCopies will be
 // placed in the same alias scope. Manual synchronized LocalLoadOps are marked
 // to not alias with the scope of AsyncCopies
-void applyLocalLoadAliasScopes(triton::gpu::LocalLoadOp localLoadOp,
-                               AliasAnalysisOpInterface llLoadOp);
-void applyAsyncLoadAliasScope(AliasAnalysisOpInterface llLoadDirectToLdsOp);
+void addLocalLoadNoAliasScope(triton::gpu::LocalLoadOp localLoadOp,
+                              AliasAnalysisOpInterface llLoadOp);
+void addAsyncCopyAliasScope(AliasAnalysisOpInterface llLoadDirectToLdsOp);
 
 } // namespace mlir::LLVM::AMD
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -107,14 +107,27 @@ bool isChainDotHead(mlir::triton::DotOpInterface dotOp);
 // in the same region
 bool isChainDotTail(mlir::triton::DotOpInterface dotOp);
 
-// LLVM is unable to recognize the dependency between AsyncCopy and
-// LocalLoads between warps and generates conservative waits.
-// For LocalLoads consuming an AsyncToken from an AsyncWait we will disable the
-// implicit waits by marking the ops to not alias. All AsyncCopies will be
-// placed in the same alias scope. Manual synchronized LocalLoadOps are marked
-// to not alias with the scope of AsyncCopies
+// LLVM is unable to deduce dependencies across warps and loop iterations for
+// AsyncCopy and LocalLoad and will emit conservative wait counts. In triton the
+// dependency is models via AsyncWait, e.g.
+//   %token1 = ttg.async_copy_global_to_local/amdgpu.buffer_load_to_local
+//   %token2 = ttg.async_wait %token1
+//   %1      = ttg.local_load .. token %token2
+// For such cases AsyncWait will emit the correct wait and the conservative
+// waits are redundant and hindering performance/interleaving.
+// To disable the conservative waits two alias scopes are created:
+//   1) "amdgpu.AsyncCopies" will contain all AsyncCopy ops
+//   2) "amdgpu.LocalLoad" will contain all LocalLoads manually synchronized via
+//      AsyncWait
+// ALl manually synchronized LocalLoads will additionally have "AsyncCopies" as
+// a non alias scope to disable the implicit waits from the LLVM backend
+
+// If localLoadOp has a token from an AsyncWait:
+//  - Attaches "amdgpu.LocalLoad" alias scope to llLoadOp
+//  - Attaches "amdgpu.AsyncCopies" as *non* alias scope to llLoadOp
 void addLocalLoadNoAliasScope(triton::gpu::LocalLoadOp localLoadOp,
                               AliasAnalysisOpInterface llLoadOp);
+// Attaches the "AsyncCopies" alias scope to llLoadDirectToLdsOp
 void addAsyncCopyAliasScope(AliasAnalysisOpInterface llLoadDirectToLdsOp);
 
 } // namespace mlir::LLVM::AMD


### PR DESCRIPTION
Add all `AsyncLoads`/`BufferLoadToLocal` to a single alias scope and annotate `LocalLoads` to **not** alias with any `AsyncLoads`/`BufferLoadToLocal` if they depend on an `AsyncToken` from an `AsyncWait`. This tells the LLVM backend to no emit conservative waits before those `LocalLoads` and allows us to manually syncronize via `AsyncWait` enabled by https://github.com/triton-lang/triton/pull/6426. 