### PR TITLE
Add correct guardian for disabling wgmma prefetching when needsPartialAccumulator

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WGMMAPrefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WGMMAPrefetch.cpp
@@ -243,11 +243,11 @@ LogicalResult WGMMAPrefetcher::initialize() {
   };
 
   for (ttng::WarpGroupDotOp dotOp : dotsInFor) {
-    // If getMaxNumImpreciseAcc > 0, WGMMA.cpp will have
+    // If needsPartialAccumulator, WGMMA.cpp will have
     // extra treatment for dotOp (e.g., add accumulator).
     // Therefore, we disable the optimization here
-    // when getMaxNumImpreciseAcc > 0;
-    if (dotOp.getMaxNumImpreciseAcc() > 0) {
+    // when needsPartialAccumulator() == true;
+    if (dotOp.needsPartialAccumulator()) {
       return failure();
     }
 


### PR DESCRIPTION
In WGMMA prefetch pass, we disable the optimization when  getMaxNumImpreciseAcc > 0.
However, there is some rare cases that getMaxNumImpreciseAcc > 0 does not cover.
The correct guardian should be needsPartialAccumulator()




<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
