### PR TITLE
[AMD][WMMA] Disable dot wmma configurations that use f16 as accumulator

### DIFF
--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen1.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen1.mlir
@@ -42,17 +42,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
    %2: tensor<32x32x!tt.ptr<f16>, #blocked>) {
     // CHECK: %[[DOT1_ARG_C:.+]] = arith.constant dense<0.000000e+00> : tensor<32x32xf16, #[[DOT_OP_PARENT]]>
     // CHECK: %[[DOT1_OP_C:.+]] = ttg.convert_layout %[[DOT1_ARG_C]]
-    // CHECK-SAME: -> tensor<32x32xf16, #[[WMMA_1]]
+    // CHECK-SAME: -> tensor<32x32xf16, #[[WMMA_1]]>
+    // CHECK: %[[DOT1_OP_C_EXT:.+]] = arith.extf %[[DOT1_OP_C]]
+    // CHECK-SAME: to tensor<32x32xf32, #[[WMMA_1]]>
     %3 = arith.constant dense<0.000000e+00> : tensor<32x32xf16, #blocked>
     // CHECK: %[[DOT1_OP_A:.+]] = ttg.convert_layout %[[DOT1_ARG_A]]
     // CHECK-SAME: -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[WMMA_1]]
     // CHECK: %[[DOT1_OP_B:.+]] = ttg.convert_layout %[[DOT1_ARG_B]]
     // CHECK-SAME: -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 1, parent = #[[WMMA_1]]
-    // CHECK: %[[DOT1_WMMA_RES:.+]] = tt.dot %[[DOT1_OP_A]], %[[DOT1_OP_B]], %[[DOT1_OP_C]]
-    // CHECK-SAME: -> tensor<32x32xf16, #[[WMMA_1]]
+    // CHECK: %[[DOT1_WMMA_RES:.+]] = tt.dot %[[DOT1_OP_A]], %[[DOT1_OP_B]], %[[DOT1_OP_C_EXT]]
+    // CHECK-SAME: -> tensor<32x32xf32, #[[WMMA_1]]
     %4 = tt.dot %0, %1, %3 : tensor<32x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x32xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x32xf16, #blocked>
-    // CHECK: ttg.convert_layout %[[DOT1_WMMA_RES]]
-    // CHECK-SAME: -> tensor<32x32xf16, #[[DOT_OP_PARENT]]>
+    // CHECK: %[[CONVERTED_RES:.+]] = ttg.convert_layout %[[DOT1_WMMA_RES]]
+    // CHECK-SAME: -> tensor<32x32xf32, #[[DOT_OP_PARENT]]>
+    // CHECK: arith.truncf %[[CONVERTED_RES]]
+    // CHECK-SAME: to tensor<32x32xf16, #[[DOT_OP_PARENT]]>
     tt.store %2, %4 : tensor<32x32x!tt.ptr<f16>, #blocked>
     tt.return
   }
@@ -72,7 +76,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
    %2: tensor<32x64x!tt.ptr<f16>, #blocked>) {
     // CHECK: %[[DOT2_ARG_C:.+]] = arith.constant dense<0.000000e+00> : tensor<32x64xf16, #[[DOT_OP_PARENT]]>
     // CHECK: %[[DOT2_OP_C:.+]] = ttg.convert_layout %[[DOT2_ARG_C]]
-    // CHECK-SAME: -> tensor<32x64xf16, #[[WMMA_0]]
+    // CHECK-SAME: -> tensor<32x64xf16, #[[WMMA_0]]>
+    // CHECK: %[[DOT2_OP_C_EXT:.+]] = arith.extf %[[DOT2_OP_C]]
+    // CHECK-SAME: to tensor<32x64xf32, #[[WMMA_0]]>
     %3 = arith.constant dense<0.000000e+00> : tensor<32x64xf16, #blocked>
     // CHECK: %[[DOT2_OP_A_F8:.+]] = ttg.convert_layout %[[DOT2_ARG_A]]
     // CHECK-SAME: -> tensor<32x128xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #[[WMMA_0]]
@@ -82,13 +88,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-SAME: -> tensor<128x64xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #[[WMMA_0]]
     // CHECK: %[[DOT2_OP_B_F16:.+]] = tt.fp_to_fp %[[DOT2_OP_B_F8]]
     // CHECK-SAME: -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #[[WMMA_0]], kWidth = 16}>>
-    // CHECK: %[[DOT2_WMMA_RES:.+]] = tt.dot %[[DOT2_OP_A_F16]], %[[DOT2_OP_B_F16]], %[[DOT2_OP_C]]
-    // CHECK-SAME: -> tensor<32x64xf16, #[[WMMA_0]]
+    // CHECK: %[[DOT2_WMMA_RES:.+]] = tt.dot %[[DOT2_OP_A_F16]], %[[DOT2_OP_B_F16]], %[[DOT2_OP_C_EXT]]
+    // CHECK-SAME: -> tensor<32x64xf32, #[[WMMA_0]]
     %4 = tt.dot %0, %1, %3 : tensor<32x128xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x64xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x64xf16, #blocked>
-    // CHECK: ttg.convert_layout %[[DOT2_WMMA_RES]]
-    // CHECK-SAME: -> tensor<32x64xf16, #[[DOT_OP_PARENT]]>
+    // CHECK: %[[CONVERTED_RES:.+]] = ttg.convert_layout %[[DOT2_WMMA_RES]]
+    // CHECK-SAME: -> tensor<32x64xf32, #[[DOT_OP_PARENT]]>
+    // CHECK: arith.truncf %[[CONVERTED_RES]]
+    // CHECK-SAME: to tensor<32x64xf16, #[[DOT_OP_PARENT]]>
     tt.store %2, %4 : tensor<32x64x!tt.ptr<f16>, #blocked>
-        tt.return
+    tt.return
   }
 }
 

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen2.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen2.mlir
@@ -42,17 +42,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
    %2: tensor<32x32x!tt.ptr<f16>, #blocked>) {
     // CHECK: %[[DOT1_ARG_C:.+]] = arith.constant dense<0.000000e+00> : tensor<32x32xf16, #[[DOT_OP_PARENT]]>
     // CHECK: %[[DOT1_OP_C:.+]] = ttg.convert_layout %[[DOT1_ARG_C]]
-    // CHECK-SAME: -> tensor<32x32xf16, #[[WMMA_1]]
+    // CHECK-SAME: -> tensor<32x32xf16, #[[WMMA_1]]>
+    // CHECK: %[[DOT1_OP_C_EXT:.+]] = arith.extf %[[DOT1_OP_C]]
+    // CHECK-SAME: to tensor<32x32xf32, #[[WMMA_1]]>
     %3 = arith.constant dense<0.000000e+00> : tensor<32x32xf16, #blocked>
     // CHECK: %[[DOT1_OP_A:.+]] = ttg.convert_layout %[[DOT1_ARG_A]]
     // CHECK-SAME: -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 0, parent = #[[WMMA_1]]
     // CHECK: %[[DOT1_OP_B:.+]] = ttg.convert_layout %[[DOT1_ARG_B]]
     // CHECK-SAME: -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 1, parent = #[[WMMA_1]]
-    // CHECK: %[[DOT1_WMMA_RES:.+]] = tt.dot %[[DOT1_OP_A]], %[[DOT1_OP_B]], %[[DOT1_OP_C]]
-    // CHECK-SAME: -> tensor<32x32xf16, #[[WMMA_1]]
+    // CHECK: %[[DOT1_WMMA_RES:.+]] = tt.dot %[[DOT1_OP_A]], %[[DOT1_OP_B]], %[[DOT1_OP_C_EXT]]
+    // CHECK-SAME: -> tensor<32x32xf32, #[[WMMA_1]]
     %4 = tt.dot %0, %1, %3 : tensor<32x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x32xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x32xf16, #blocked>
-    // CHECK: ttg.convert_layout %[[DOT1_WMMA_RES]]
-    // CHECK-SAME: -> tensor<32x32xf16, #[[DOT_OP_PARENT]]>
+    // CHECK: %[[CONVERTED_RES:.+]] = ttg.convert_layout %[[DOT1_WMMA_RES]]
+    // CHECK-SAME: -> tensor<32x32xf32, #[[DOT_OP_PARENT]]>
+    // CHECK: arith.truncf %[[CONVERTED_RES]]
+    // CHECK-SAME: to tensor<32x32xf16, #[[DOT_OP_PARENT]]>
     tt.store %2, %4 : tensor<32x32x!tt.ptr<f16>, #blocked>
     tt.return
   }
@@ -72,7 +76,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
    %2: tensor<32x64x!tt.ptr<f16>, #blocked>) {
     // CHECK: %[[DOT2_ARG_C:.+]] = arith.constant dense<0.000000e+00> : tensor<32x64xf16, #[[DOT_OP_PARENT]]>
     // CHECK: %[[DOT2_OP_C:.+]] = ttg.convert_layout %[[DOT2_ARG_C]]
-    // CHECK-SAME: -> tensor<32x64xf16, #[[WMMA_0]]
+    // CHECK-SAME: -> tensor<32x64xf16, #[[WMMA_0]]>
+    // CHECK: %[[DOT2_OP_C_EXT:.+]] = arith.extf %[[DOT2_OP_C]]
+    // CHECK-SAME: to tensor<32x64xf32, #[[WMMA_0]]>
     %3 = arith.constant dense<0.000000e+00> : tensor<32x64xf16, #blocked>
     // CHECK: %[[DOT2_OP_A_F8:.+]] = ttg.convert_layout %[[DOT2_ARG_A]]
     // CHECK-SAME: -> tensor<32x128xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #[[WMMA_0]]
@@ -82,11 +88,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-SAME: -> tensor<128x64xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #[[WMMA_0]]
     // CHECK: %[[DOT2_OP_B_F16:.+]] = tt.fp_to_fp %[[DOT2_OP_B_F8]]
     // CHECK-SAME: -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 1, parent = #[[WMMA_0]], kWidth = 8}>>
-    // CHECK: %[[DOT2_WMMA_RES:.+]] = tt.dot %[[DOT2_OP_A_F16]], %[[DOT2_OP_B_F16]], %[[DOT2_OP_C]]
-    // CHECK-SAME: -> tensor<32x64xf16, #[[WMMA_0]]
+    // CHECK: %[[DOT2_WMMA_RES:.+]] = tt.dot %[[DOT2_OP_A_F16]], %[[DOT2_OP_B_F16]], %[[DOT2_OP_C_EXT]]
+    // CHECK-SAME: -> tensor<32x64xf32, #[[WMMA_0]]
     %4 = tt.dot %0, %1, %3 : tensor<32x128xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x64xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x64xf16, #blocked>
-    // CHECK: ttg.convert_layout %[[DOT2_WMMA_RES]]
-    // CHECK-SAME: -> tensor<32x64xf16, #[[DOT_OP_PARENT]]>
+    // CHECK: %[[CONVERTED_RES:.+]] = ttg.convert_layout %[[DOT2_WMMA_RES]]
+    // CHECK-SAME: -> tensor<32x64xf32, #[[DOT_OP_PARENT]]>
+    // CHECK: arith.truncf %[[CONVERTED_RES]]
+    // CHECK-SAME: to tensor<32x64xf16, #[[DOT_OP_PARENT]]>
     tt.store %2, %4 : tensor<32x64x!tt.ptr<f16>, #blocked>
         tt.return
   }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -291,11 +291,11 @@ OperandTypesVector getOperandTypesForWmmaOp(PatternRewriter &rewriter,
   SmallVector<OperandTypesVector> applicableTypes = {
       // clang-format off
       {f16, f16, f32, f32},
-      {f16, f16, f16, f16},
       {bf16, bf16, f32, f32},
-      {bf16, bf16, bf16, bf16},
       {i8, i8, i32, i32},
-      // i4, i4, i32, i32 - is supported configuration
+      // {f16, f16, f16, f16},
+      // {bf16, bf16, bf16, bf16},
+      // {i4, i4, i32, i32} - are supported configurations
       // by WMMA instruction, but not supported by triton
       // clang-format on
   };


### PR DESCRIPTION
Although wmma supports configurations like
{f16, f16, f16, f16} and {bf16, bf16, bf16, bf16}, use f32 accumulators and results, and convert the result to f16 if required.

This change is needed to provide equivalent behavior across different targets.

fixed gfx11/12:
test_matmul.py::test_simple_matmul[False-4-1-128-128-16-4-float16-float16] test_matmul.py::test_simple_matmul[False-4-1-64-128-32-4-float16-float16] test_matmul.py::test_simple_matmul[False-4-1-32-32-32-4-float16-float16] test_matmul.py::test_simple_matmul[False-4-1-64-16-16-4-float16-float16] test_matmul.py::test_simple_matmul[False-8-1-128-128-16-4-float16-float16] test_matmul.py::test_simple_matmul[False-8-1-64-128-32-4-float16-float16] test_matmul.py::test_simple_matmul[False-8-1-32-32-32-4-float16-float16] test_matmul.py::test_simple_matmul[False-8-1-64-16-16-4-float16-float16]
