### PR TITLE
[NVIDIA] Add compiler-controlled host side tensor descriptor API

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
@@ -184,19 +184,23 @@ inline std::optional<int> getTMAElementType(Operation *op, TensorDescType ty) {
   bool fp4Padded = mmaEncoding && mmaEncoding.getFp4Padded();
 
   if (fp4Padded)
-    return 14;  // .b4x16_p64
+    return 14; // .b4x16_p64
 
   auto elemSize = ty.getBlockType().getElementTypeBitWidth() / 8;
   switch (elemSize) {
-    case 1: return 0;
-    case 2: return 1;
-    case 4: return 2;
-    default: break;
+  case 1:
+    return 0;
+  case 2:
+    return 1;
+  case 4:
+    return 2;
+  default:
+    break;
   }
   if (op) {
     op->emitError()
-          << "Tensor descriptor element type must have size 1, 2, or 4 but got "
-          << elemSize;
+        << "Tensor descriptor element type must have size 1, 2, or 4 but got "
+        << elemSize;
   }
   return std::nullopt;
 }

--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -67,6 +67,13 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     auto funcTy = funcOp.getFunctionType();
     auto amendedInputTy = llvm::to_vector<4>(funcTy.getInputs());
     bool isKernel = LLVM::isKernel(funcOp);
+    if (isKernel) {
+      for (auto i : llvm::seq(amendedInputTy.size())) {
+        if (isa<TensorDescType>(amendedInputTy[i])) {
+          funcOp.setArgAttr(i, "tt.nv_tma_desc", mlir::IntegerAttr::get(i32_ty, 1));
+        }
+      }
+    }
     if (!isKernel) {
       amendedInputTy.push_back(sharedPtrTy);
     }

--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -70,7 +70,8 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     if (isKernel) {
       for (auto i : llvm::seq(amendedInputTy.size())) {
         if (isa<TensorDescType>(amendedInputTy[i])) {
-          funcOp.setArgAttr(i, "tt.nv_tma_desc", mlir::IntegerAttr::get(i32_ty, 1));
+          funcOp.setArgAttr(i, "tt.nv_tma_desc",
+                            mlir::IntegerAttr::get(i32_ty, 1));
         }
       }
     }

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -25,7 +25,7 @@ TritonGPUToLLVMTypeConverter::TritonGPUToLLVMTypeConverter(
     return LLVM::LLVMPointerType::get(ctx, type.getAddressSpace());
   });
   addConversion([ctx](TensorDescType type) -> std::optional<Type> {
-    return LLVM::LLVMPointerType::get(ctx, 1);
+    return LLVM::LLVMPointerType::get(ctx, 0);
   });
   addConversion([&](RankedTensorType type) -> std::optional<Type> {
     return convertTritonTensorType(type, targetInfo);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
@@ -313,8 +313,8 @@ void assignMemoryLayouts(tt::FuncOp &func) {
     }
   };
 
-  // 1. Set seed values from either TMA ops, or device function boundaries for which
-  // we fallback to default encoding
+  // 1. Set seed values from either TMA ops, or device function boundaries for
+  // which we fallback to default encoding
   auto isKernel = LLVM::isKernel(func);
   for (auto blockArg : func.getBlocks().front().getArguments())
     if (auto desc = dyn_cast<TypedValue<tt::TensorDescType>>(blockArg))

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
@@ -1,5 +1,6 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Pass/PassManager.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
@@ -312,12 +313,13 @@ void assignMemoryLayouts(tt::FuncOp &func) {
     }
   };
 
-  // 1. Set seed values from either TMA ops, or function boundary ops which we
-  // fallback to default encoding
+  // 1. Set seed values from either TMA ops, or device function boundaries for which
+  // we fallback to default encoding
+  auto isKernel = LLVM::isKernel(func);
   for (auto blockArg : func.getBlocks().front().getArguments())
     if (auto desc = dyn_cast<TypedValue<tt::TensorDescType>>(blockArg))
       updateEncoding({desc},
-                     EncodingInfo{{}, {}, {}, /*forcedToDefault=*/true});
+                     EncodingInfo{{}, {}, {}, /*forcedToDefault=*/!isKernel});
 
   func.walk([&](Operation *op) {
     if (auto info = getUseInfo(op)) {
@@ -397,15 +399,8 @@ void assignMemoryLayouts(tt::FuncOp &func) {
                                                newEncoding));
   }
 
-  SmallVector<Type> argTys(func.getArgumentTypes());
+  SmallVector<Type> argTys(func.getBlocks().front().getArgumentTypes());
   SmallVector<Type> resultTys(func.getResultTypes());
-  for (auto [i, argTy] : llvm::enumerate(argTys)) {
-    if (auto descTy = dyn_cast<tt::TensorDescType>(argTy)) {
-      auto encoding = getFallbackSharedEncoding(descTy.getBlockType(), {}, {});
-      argTys[i] = getTensorDescTypeWithEncoding(nullptr, descTy.getBlockType(),
-                                                encoding);
-    }
-  }
   for (auto [i, resultTy] : llvm::enumerate(resultTys)) {
     if (auto descTy = dyn_cast<tt::TensorDescType>(resultTy)) {
       auto encoding = getFallbackSharedEncoding(descTy.getBlockType(), {}, {});

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1,4 +1,5 @@
 #include <optional>
+#include <pybind11/cast.h>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -28,6 +29,7 @@
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/SourceMgr.h"
@@ -39,6 +41,9 @@ namespace {
 namespace py = pybind11;
 using namespace mlir;
 using namespace triton;
+namespace tt = triton;
+namespace ttg = triton::gpu;
+namespace ttng = triton::nvidia_gpu;
 
 llvm::raw_fd_ostream &mlir_dumps() {
   std::error_code EC;
@@ -228,6 +233,43 @@ OpPrintingFlags getOpPrintingFlags() {
   auto printingFlags = OpPrintingFlags();
   printingFlags.enableDebugInfo();
   return printingFlags;
+}
+
+py::list getTensorDescMetadata(ModuleOp &mod) {
+  py::list result;
+  triton::FuncOp kernelFunc;
+  mod.walk([&](triton::FuncOp func) {
+    if (LLVM::isKernel(func)) {
+      kernelFunc = func;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::skip();
+  });
+  assert(kernelFunc);
+
+  for (auto [i, argTy] : llvm::enumerate(kernelFunc.getArgumentTypes())) {
+    auto descTy = dyn_cast<TensorDescType>(argTy);
+    if (!descTy)
+      continue;
+
+    auto blockType = descTy.getBlockType();
+    auto encoding = blockType.getEncoding();
+    auto mmaEncoding = dyn_cast<triton::gpu::NVMMASharedEncodingAttr>(encoding);
+    auto swizzle = ttng::getTMASwizzleMode(nullptr, descTy);
+    auto elemType = ttng::getTMAElementType(nullptr, descTy);
+    assert(swizzle.has_value());
+    assert(elemType.has_value());
+    auto blockSize = ttg::getShapePerCTA(blockType);
+    blockSize.back() = ttng::getTMAContigDim(blockType);
+    py::dict metadata;
+    metadata["swizzle"] = *swizzle;
+    metadata["elem_size"] = descTy.getBlockType().getElementTypeBitWidth() / 8;
+    metadata["elem_type"] = *elemType;
+    metadata["block_size"] = std::vector<int>(blockSize.begin(), blockSize.end());
+    metadata["fp4_padded"] = mmaEncoding && mmaEncoding.getFp4Padded();
+    result.append(std::move(metadata));
+  }
+  return result;
 }
 
 } // anonymous namespace
@@ -660,6 +702,7 @@ void init_triton_ir(py::module &&m) {
                return py::none();
              return py::int_(ret.getInt());
            })
+      .def("get_tensordesc_metadata", getTensorDescMetadata)
       .def("create_location_snapshot",
            [](ModuleOp &self, const std::string &fileName) -> void {
              auto printingFlags = getOpPrintingFlags();

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -265,7 +265,8 @@ py::list getTensorDescMetadata(ModuleOp &mod) {
     metadata["swizzle"] = *swizzle;
     metadata["elem_size"] = descTy.getBlockType().getElementTypeBitWidth() / 8;
     metadata["elem_type"] = *elemType;
-    metadata["block_size"] = std::vector<int>(blockSize.begin(), blockSize.end());
+    metadata["block_size"] =
+        std::vector<int>(blockSize.begin(), blockSize.end());
     metadata["fp4_padded"] = mmaEncoding && mmaEncoding.getFp4Padded();
     result.append(std::move(metadata));
   }

--- a/python/test/unit/cuda/test_tensor_descriptor.py
+++ b/python/test/unit/cuda/test_tensor_descriptor.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 from triton._internal_testing import is_interpreter, numpy_random, to_triton, requires_tma, unwrap_tensor, tma_dtypes
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
+from triton.tools.experimental_descriptor import TensorDescriptor
 from typing import Optional
 
 
@@ -505,7 +506,7 @@ def test_tensor_descriptor_argument():
 
 
 @triton.jit
-def matmul_kernel_make_tensor_desciptor(a_ptr, b_ptr, c_ptr,  #
+def matmul_kernel_make_tensor_descriptor(a_ptr, b_ptr, c_ptr,  #
                                         M, N, K,  #
                                         BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
                                         BLOCK_SIZE_K: tl.constexpr,  #
@@ -577,7 +578,7 @@ def test_make_tensor_descriptor_matmul(num_stages, num_ctas, BLOCK_M, BLOCK_N, B
 
     triton.set_allocator(alloc_fn)
 
-    kernel = matmul_kernel_make_tensor_desciptor[grid](
+    kernel = matmul_kernel_make_tensor_descriptor[grid](
         A,
         B,
         C,
@@ -604,7 +605,7 @@ def test_make_tensor_descriptor_matmul(num_stages, num_ctas, BLOCK_M, BLOCK_N, B
 
 
 @triton.jit
-def kernel_make_tensor_desciptor_loop_carried(a_ptr, M, N, MBLOCK: tl.constexpr, NBLOCK: tl.constexpr):
+def kernel_make_tensor_descriptor_loop_carried(a_ptr, M, N, MBLOCK: tl.constexpr, NBLOCK: tl.constexpr):
     # Test that descriptors work with
     pid = tl.program_id(0)
     moffset = MBLOCK * pid
@@ -667,7 +668,7 @@ def test_make_tensor_descriptor_loop_carried():
     triton.set_allocator(alloc_fn)
 
     ref_out = A + 15
-    kernel = kernel_make_tensor_desciptor_loop_carried[grid](
+    kernel = kernel_make_tensor_descriptor_loop_carried[grid](
         A,
         M,
         N,
@@ -1302,3 +1303,100 @@ def test_mxfp8_mxfp4_matmul_tma(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, 
     ref_out = torch.matmul(a_ref * a_scale_ref, b_ref * b_scale_ref)
 
     torch.testing.assert_close(ref_out, output, atol=1e-3, rtol=1e-3)
+
+
+@requires_tma
+@pytest.mark.interpreter
+@pytest.mark.parametrize("dtype_str", tma_dtypes)
+@pytest.mark.parametrize("num_ctas", [1, 2])
+@pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16), (8, 16), (8, 32), (8, 128)])
+def test_host_tensor_descriptor_load(dtype_str, num_ctas, M_BLOCK, N_BLOCK):
+
+    @triton.jit(debug=True)
+    def kernel(out_ptr, desc, M, N, M_BLOCK: tl.constexpr, N_BLOCK: tl.constexpr):
+        assert desc.shape[0] == M
+        assert desc.shape[1] == N
+        assert desc.strides[0] == N
+        assert desc.strides[1] == 1
+        assert desc.block_shape == [M_BLOCK, N_BLOCK]
+        block = desc.load([M_BLOCK, 2 * N_BLOCK])
+        idx = tl.arange(0, M_BLOCK)[:, None] * N_BLOCK + tl.arange(0, N_BLOCK)[None, :]
+        tl.store(out_ptr + idx, block)
+
+    M, N = M_BLOCK * 3, N_BLOCK * 4
+    inp = to_triton(numpy_random((M, N), dtype_str), device="cuda", dst_type=dtype_str)
+    out = inp.new_empty((M_BLOCK, N_BLOCK))
+
+    inp_desc = TensorDescriptor(inp, shape=inp.shape, strides=inp.stride(), block_shape=[M_BLOCK, N_BLOCK])
+    kernel[(1, )](out, inp_desc, M, N, M_BLOCK, N_BLOCK, num_ctas=num_ctas)
+
+    expect = unwrap_tensor(inp)[1 * M_BLOCK:2 * M_BLOCK, 2 * N_BLOCK:3 * N_BLOCK]
+    torch.testing.assert_close(expect, unwrap_tensor(out))
+
+
+@triton.jit
+def matmul_kernel_host_tensor_descriptor(a_desc, b_desc, c_desc):
+    K = a_desc.shape[1]
+    BLOCK_M: tl.constexpr = a_desc.block_shape[0]
+    BLOCK_K: tl.constexpr = a_desc.block_shape[1]
+    BLOCK_N: tl.constexpr = b_desc.block_shape[1]
+
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    offs_am = pid_m * BLOCK_M
+    offs_bn = pid_n * BLOCK_N
+    offs_k = 0
+
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_K)):
+        a = a_desc.load([offs_am, offs_k])
+        b = b_desc.load([offs_k, offs_bn])
+        accumulator = tl.dot(a, b, acc=accumulator)
+        offs_k += BLOCK_K
+    accumulator = accumulator.to(a_desc.dtype)
+    c_desc.store([offs_am, offs_bn], accumulator)
+
+
+@requires_tma
+@pytest.mark.interpreter
+@pytest.mark.parametrize("num_ctas", [1, 2])
+@pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K, num_stages", [
+    (128, 128, 16, 1),
+    (256, 64, 32, 2),
+    (64, 512, 32, 2),
+    (128, 128, 16, 4),
+    (64, 128, 32, 4),
+    (32, 32, 32, 4),
+    (256, 128, 32, 4),
+])
+def test_host_tensor_descriptor_matmul(num_stages, num_ctas, BLOCK_M, BLOCK_N, BLOCK_K):
+    device = "cuda"
+    if is_interpreter():
+        M, N, K = BLOCK_M, BLOCK_N, BLOCK_K
+    else:
+        M, N, K = 1024, 512, 256
+    torch.manual_seed(42)
+    A = torch.randn((M, K), dtype=torch.float16, device=device)
+    B = torch.randn((K, N), dtype=torch.float16, device=device)
+    C = torch.empty((M, N), dtype=torch.float16, device=device)
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N), 1)
+
+    A_desc = TensorDescriptor(A, A.shape, A.stride(), [BLOCK_M, BLOCK_K])
+    B_desc = TensorDescriptor(B, B.shape, B.stride(), [BLOCK_K, BLOCK_N])
+    C_desc = TensorDescriptor(C, C.shape, C.stride(), [BLOCK_M, BLOCK_N])
+
+    kernel = matmul_kernel_host_tensor_descriptor[grid](
+        A_desc, B_desc, C_desc, #
+        num_warps=8,
+        num_stages=num_stages,
+        num_ctas=num_ctas,
+    )
+    ref_out = torch.matmul(A.to(torch.float32), B.to(torch.float32)).to(torch.float16)
+    torch.testing.assert_close(ref_out, C, rtol=1e-3, atol=1e-3)
+    if is_interpreter():
+        return
+
+    if BLOCK_M >= 64 * num_ctas and BLOCK_N >= 64 and torch.cuda.get_device_capability()[0] == 9:
+        # TODO: The use of stmatrix for Blackwell is currently not supported.
+        # Only a subset of TMEM and stmatrix layout pairs are compatible, for example 16x256bx2 and m8n8x4.
+        assert "stmatrix.sync.aligned.m8n8.x4.shared.b16" in kernel.asm["ptx"]

--- a/python/test/unit/cuda/test_tensor_descriptor.py
+++ b/python/test/unit/cuda/test_tensor_descriptor.py
@@ -507,10 +507,10 @@ def test_tensor_descriptor_argument():
 
 @triton.jit
 def matmul_kernel_make_tensor_descriptor(a_ptr, b_ptr, c_ptr,  #
-                                        M, N, K,  #
-                                        BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
-                                        BLOCK_SIZE_K: tl.constexpr,  #
-                                        ):
+                                         M, N, K,  #
+                                         BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
+                                         BLOCK_SIZE_K: tl.constexpr,  #
+                                         ):
     pid_m = tl.program_id(axis=0)
     pid_n = tl.program_id(axis=1)
     offs_am = pid_m * BLOCK_SIZE_M
@@ -1386,7 +1386,9 @@ def test_host_tensor_descriptor_matmul(num_stages, num_ctas, BLOCK_M, BLOCK_N, B
     C_desc = TensorDescriptor(C, C.shape, C.stride(), [BLOCK_M, BLOCK_N])
 
     kernel = matmul_kernel_host_tensor_descriptor[grid](
-        A_desc, B_desc, C_desc, #
+        A_desc,
+        B_desc,
+        C_desc,  #
         num_warps=8,
         num_stages=num_stages,
         num_ctas=num_ctas,

--- a/python/test/unit/cuda/test_tensor_descriptor.py
+++ b/python/test/unit/cuda/test_tensor_descriptor.py
@@ -1306,7 +1306,6 @@ def test_mxfp8_mxfp4_matmul_tma(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, 
 
 
 @requires_tma
-@pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
 @pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16), (8, 16), (8, 32), (8, 128)])
@@ -1358,7 +1357,6 @@ def matmul_kernel_host_tensor_descriptor(a_desc, b_desc, c_desc):
 
 
 @requires_tma
-@pytest.mark.interpreter
 @pytest.mark.parametrize("num_ctas", [1, 2])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K, num_stages", [
     (128, 128, 16, 1),

--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -33,6 +33,7 @@ from .core import (
     make_tensor_descriptor,
     _experimental_reinterpret_tensor_descriptor,
     tensor_descriptor,
+    tensor_descriptor_type,
     add,
     advance,
     arange,
@@ -283,6 +284,18 @@ def str_to_ty(name):
             const = True
         ty = str_to_ty(name)
         return pointer_type(element_ty=ty, const=const)
+
+    if name.startswith("tensordesc"):
+        inner = name.split("<")[1].rstrip(">")
+        dtype, block_shape = inner.split("[")
+        block_shape = [int(s.strip()) for s in block_shape.rstrip("]").split(",")]
+        dtype = str_to_ty(dtype)
+        ndim = len(block_shape)
+        shape_type = tuple_type([int32] * ndim)
+        # FIXME: Last dim stride should be constexpr(1)
+        stride_type = tuple_type(([int64] * ndim))
+        block = block_type(dtype, block_shape)
+        return tensor_descriptor_type(block, shape_type, stride_type)
 
     if name == "nvTmaDesc":
         return nv_tma_desc_type()

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -9,6 +9,8 @@ import textwrap
 from collections import defaultdict
 from functools import cached_property
 from typing import Callable, Generic, Iterable, Optional, TypeVar, Union, overload, Dict, Any, Tuple
+
+from triton.tools.experimental_descriptor import TensorDescriptor
 from ..runtime.driver import driver
 from types import ModuleType
 from .._utils import find_paths_if, get_iterable_path
@@ -343,6 +345,10 @@ def create_specialize_impl(specialize_extra):
             tys = make_tuple([x[0] for x in spec])
             keys = make_tuple([x[1] for x in spec])
             return (tys, keys)
+        elif isinstance(arg, TensorDescriptor):
+            assert hasattr(arg.base, "data_ptr")
+            inner = type_canonicalisation_dict[str(arg.base.dtype).split('.')[-1]]
+            return (f"tensordesc<{inner}{list(arg.block_shape)}>", None)
         else:
             raise TypeError("Unsupported type: %s" % type(arg))
 

--- a/python/triton/tools/experimental_descriptor.py
+++ b/python/triton/tools/experimental_descriptor.py
@@ -1,4 +1,6 @@
 import torch
+from dataclasses import dataclass
+from typing import List, Any
 
 import triton
 
@@ -6,8 +8,10 @@ import triton
 class TmaDescKernelParam:
     TMA_DESC_SIZE = 128
 
-    def __init__(self, ptr, dims, block_dims, element_size):
-        self.desc = torch.empty(self.TMA_DESC_SIZE, dtype=torch.uint8, device="cpu")
+    def __init__(self):
+        self.desc = torch.zeros(self.TMA_DESC_SIZE, dtype=torch.uint8, device="cpu")
+
+    def fill_(self, ptr, dims, block_dims, element_size):
         assert len(dims) == len(block_dims)
         assert 1 <= len(dims) <= 2
         assert self.desc.data_ptr() % 64 == 0
@@ -25,8 +29,20 @@ class TmaDescKernelParam:
 
 
 def create_1d_tma_descriptor(ptr, dim, block_dim, element_size):
-    return TmaDescKernelParam(ptr, [dim], [block_dim], element_size)
+    desc = TmaDescKernelParam()
+    desc.fill_(ptr, [dim], [block_dim], element_size)
+    return desc
 
 
 def create_2d_tma_descriptor(ptr, dim1, dim0, block_dim1, block_dim0, element_size):
-    return TmaDescKernelParam(ptr, [dim1, dim0], [block_dim1, block_dim0], element_size)
+    desc = TmaDescKernelParam()
+    desc.fill_(ptr, [dim1, dim0], [block_dim1, block_dim0], element_size)
+    return desc
+
+
+@dataclass
+class TensorDescriptor:
+    base: Any
+    shape: List[int]
+    strides: List[int]
+    block_shape: List[int]

--- a/python/triton/tools/experimental_descriptor.py
+++ b/python/triton/tools/experimental_descriptor.py
@@ -9,7 +9,7 @@ class TmaDescKernelParam:
     TMA_DESC_SIZE = 128
 
     def __init__(self):
-        self.desc = torch.zeros(self.TMA_DESC_SIZE, dtype=torch.uint8, device="cpu")
+        self.desc = torch.empty(self.TMA_DESC_SIZE, dtype=torch.uint8, device="cpu")
 
     def fill_(self, ptr, dims, block_dims, element_size):
         assert len(dims) == len(block_dims)

--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -27,6 +27,7 @@ import triton
 import triton.language as tl
 import triton.tools.experimental_descriptor
 import triton.profiler as proton
+from triton.tools.experimental_descriptor import TensorDescriptor
 from contextlib import contextmanager
 
 from typing import Optional
@@ -65,54 +66,14 @@ def _matmul_launch_metadata(grid, kernel, args):
     return ret
 
 
-HAS_TMA_DESC = supports_tma() and hasattr(tl, "nv_tma_desc_type")
 HAS_TENSOR_DESC = supports_tma() and hasattr(tl, "make_tensor_descriptor")
+HAS_HOST_TENSOR_DESC = supports_tma() and hasattr(triton.tools.experimental_descriptor, "TensorDescriptor")
 HAS_WARP_SPECIALIZE = supports_ws() and HAS_TENSOR_DESC
 
 
-# TmaAutoTuneHelper used in htyu's PR #5622
-class TmaAutoTuneHelper:
-
-    # duck typing wrapper to implement the same interface as TmaDescKernelParam in Triton PR #4498
-    class KernelParamWrapper:
-
-        def __init__(self, desc):
-            self.desc = desc
-
-        def tma_desc_cpu_ptr(self):
-            return self.desc.data_ptr()
-
-    TMA_SIZE = 128
-
-    def __init__(self):
-        self.fill_1d_tma_descriptor_inner = (triton.runtime.driver.active.utils.fill_1d_tma_descriptor)
-        self.fill_2d_tma_descriptor_inner = (triton.runtime.driver.active.utils.fill_2d_tma_descriptor)
-        self.descriptors = {}
-
-    # Call this method outside of the lambda function for grid size
-    def init_tma_descriptor(self, name):
-        self.descriptors[name] = torch.empty(TmaAutoTuneHelper.TMA_SIZE, device="cpu", dtype=torch.int8)
-
-    # Call this method inside the lambda function for grid size
-    def fill_1d_tma_descriptor(self, name, ptr, dim, block_dim, element_size):
-        desc_x = self.descriptors[name]
-        assert desc_x.data_ptr() % 64 == 0
-        self.fill_1d_tma_descriptor_inner(ptr, dim, block_dim, element_size, desc_x.data_ptr())
-
-    # Call this method inside the lambda function for grid size
-    def fill_2d_tma_descriptor(self, name, ptr, dim1, dim0, block_dim1, block_dim0, element_size):
-        desc_x = self.descriptors[name]
-        assert desc_x.data_ptr() % 64 == 0
-        self.fill_2d_tma_descriptor_inner(ptr, dim1, dim0, block_dim1, block_dim0, element_size, desc_x.data_ptr())
-
-    def get_tma_descriptor_kernel_param(self, name):
-        assert self.descriptors[name] is not None
-        return self.KernelParamWrapper(self.descriptors[name])
-
-
-def matmul_get_configs():
+def matmul_get_configs(pre_hook=None):
     return [
-        triton.Config({'BLOCK_SIZE_M': BM, 'BLOCK_SIZE_N': BN, "BLOCK_SIZE_K" : BK, "GROUP_SIZE_M" : 8}, num_stages=s, num_warps=w) \
+        triton.Config({'BLOCK_SIZE_M': BM, 'BLOCK_SIZE_N': BN, "BLOCK_SIZE_K" : BK, "GROUP_SIZE_M" : 8}, num_stages=s, num_warps=w, pre_hook=pre_hook) \
         for BM in [128] \
         for BN in [128, 256] \
         for BK in [64,128] \
@@ -202,12 +163,25 @@ def matmul(a, b):
     return c
 
 
+def matmul_tma_set_block_size_hook(nargs):
+    EPILOGUE_SUBTILE = nargs.get("EPILOGUE_SUBTILE", False)
+    BLOCK_M = nargs["BLOCK_SIZE_M"]
+    BLOCK_N = nargs["BLOCK_SIZE_N"]
+    BLOCK_K = nargs["BLOCK_SIZE_K"]
+    nargs["a_desc"].block_shape = [BLOCK_M, BLOCK_K]
+    nargs["b_desc"].block_shape = [BLOCK_N, BLOCK_K]
+    if EPILOGUE_SUBTILE:
+        nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N // 2]
+    else:
+        nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N]
+
+
 @triton.autotune(
-    configs=matmul_get_configs(),
+    configs=matmul_get_configs(pre_hook=matmul_tma_set_block_size_hook),
     key=["M", "N", "K", "WARP_SPECIALIZE"],
 )
 @triton.jit(launch_metadata=_matmul_launch_metadata)
-def matmul_kernel_tma(a_desc_ptr, b_desc_ptr, c_desc_ptr,  #
+def matmul_kernel_tma(a_desc, b_desc, c_desc,  #
                       M, N, K,  #
                       BLOCK_SIZE_M: tl.constexpr,  #
                       BLOCK_SIZE_N: tl.constexpr,  #
@@ -237,15 +211,15 @@ def matmul_kernel_tma(a_desc_ptr, b_desc_ptr, c_desc_ptr,  #
 
     for k in tl.range(k_tiles, warp_specialize=WARP_SPECIALIZE):
         offs_k = k * BLOCK_SIZE_K
-        a = tl._experimental_descriptor_load(a_desc_ptr, [offs_am, offs_k], [BLOCK_SIZE_M, BLOCK_SIZE_K], dtype)
-        b = tl._experimental_descriptor_load(b_desc_ptr, [offs_bn, offs_k], [BLOCK_SIZE_N, BLOCK_SIZE_K], dtype)
+        a = a_desc.load([offs_am, offs_k])
+        b = b_desc.load([offs_bn, offs_k])
         accumulator = tl.dot(a, b.T, accumulator)
 
     c = accumulator.to(dtype)
 
     offs_cm = pid_m * BLOCK_SIZE_M
     offs_cn = pid_n * BLOCK_SIZE_N
-    tl._experimental_descriptor_store(c_desc_ptr, c, [offs_cm, offs_cn])
+    c_desc.store([offs_cm, offs_cn], c)
 
 
 def matmul_tma(a, b, warp_specialize: bool):
@@ -259,53 +233,19 @@ def matmul_tma(a, b, warp_specialize: bool):
 
     c = torch.empty((M, N), device=a.device, dtype=dtype)
 
-    desc_helper = TmaAutoTuneHelper()
-    desc_helper.init_tma_descriptor("a")
-    desc_helper.init_tma_descriptor("b")
-    desc_helper.init_tma_descriptor("c")
+    # A dummy block value that will be overwritten when we have the real block size
+    dummy_block = [1, 1]
+    a_desc = TensorDescriptor(a, a.shape, a.stride(), dummy_block)
+    b_desc = TensorDescriptor(b, b.shape, b.stride(), dummy_block)
+    c_desc = TensorDescriptor(c, c.shape, c.stride(), dummy_block)
 
     def grid(META):
-        nonlocal desc_helper
-        desc_helper.fill_2d_tma_descriptor(
-            "a",
-            a.data_ptr(),
-            M,
-            K,
-            META["BLOCK_SIZE_M"],
-            META["BLOCK_SIZE_K"],
-            a.element_size(),
-        )
-
-        desc_helper.fill_2d_tma_descriptor(
-            "b",
-            b.data_ptr(),
-            N,
-            K,
-            META["BLOCK_SIZE_N"],
-            META["BLOCK_SIZE_K"],
-            b.element_size(),
-        )
-
-        store_block_n = META["BLOCK_SIZE_N"]
-
-        desc_helper.fill_2d_tma_descriptor(
-            "c",
-            c.data_ptr(),
-            M,
-            N,
-            META["BLOCK_SIZE_M"],
-            store_block_n,
-            c.element_size(),
-        )
-
-        return (triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]), )
-
-    desc_a = desc_helper.get_tma_descriptor_kernel_param("a")
-    desc_b = desc_helper.get_tma_descriptor_kernel_param("b")
-    desc_c = desc_helper.get_tma_descriptor_kernel_param("c")
+        BLOCK_M = META["BLOCK_SIZE_M"]
+        BLOCK_N = META["BLOCK_SIZE_N"]
+        return (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), )
 
     matmul_kernel_tma[grid](
-        desc_a, desc_b, desc_c,  #
+        a_desc, b_desc, c_desc,  #
         M, N, K,  #
         FP8_OUTPUT=dtype == torch.float8_e4m3fn,  #
         WARP_SPECIALIZE=warp_specialize,  #
@@ -409,13 +349,13 @@ def matmul_persistent(a, b):
     return c
 
 
-def matmul_tma_persistent_get_configs():
+def matmul_tma_persistent_get_configs(pre_hook=None):
     return [
         triton.Config(
             {
                 'BLOCK_SIZE_M': BM, 'BLOCK_SIZE_N': BN, "BLOCK_SIZE_K": BK, "GROUP_SIZE_M": 8, "EPILOGUE_SUBTILE":
                 SUBTILE
-            }, num_stages=s, num_warps=w)  #
+            }, num_stages=s, num_warps=w, pre_hook=pre_hook)  #
         for BM in [128]  #
         for BN in [128, 256]  #
         for BK in [64, 128]  #
@@ -426,11 +366,11 @@ def matmul_tma_persistent_get_configs():
 
 
 @triton.autotune(
-    configs=matmul_tma_persistent_get_configs(),
+    configs=matmul_tma_persistent_get_configs(pre_hook=matmul_tma_set_block_size_hook),
     key=["M", "N", "K", "WARP_SPECIALIZE"],
 )
 @triton.jit(launch_metadata=_matmul_launch_metadata)
-def matmul_kernel_tma_persistent(a_desc_ptr, b_desc_ptr, c_desc_ptr,  #
+def matmul_kernel_tma_persistent(a_desc, b_desc, c_desc,  #
                                  M, N, K,  #
                                  BLOCK_SIZE_M: tl.constexpr,  #
                                  BLOCK_SIZE_N: tl.constexpr,  #
@@ -462,8 +402,8 @@ def matmul_kernel_tma_persistent(a_desc_ptr, b_desc_ptr, c_desc_ptr,  #
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
         for ki in range(k_tiles):
             offs_k = ki * BLOCK_SIZE_K
-            a = tl._experimental_descriptor_load(a_desc_ptr, [offs_am, offs_k], [BLOCK_SIZE_M, BLOCK_SIZE_K], dtype)
-            b = tl._experimental_descriptor_load(b_desc_ptr, [offs_bn, offs_k], [BLOCK_SIZE_N, BLOCK_SIZE_K], dtype)
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
             accumulator = tl.dot(a, b.T, accumulator)
 
         tile_id_c += NUM_SMS
@@ -480,12 +420,12 @@ def matmul_kernel_tma_persistent(a_desc_ptr, b_desc_ptr, c_desc_ptr,  #
             acc = tl.permute(acc, (0, 2, 1))
             acc0, acc1 = tl.split(acc)
             c0 = acc0.to(dtype)
-            tl._experimental_descriptor_store(c_desc_ptr, c0, [offs_am_c, offs_bn_c])
+            c_desc.store([offs_am_c, offs_bn_c], c0)
             c1 = acc1.to(dtype)
-            tl._experimental_descriptor_store(c_desc_ptr, c1, [offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
         else:
             accumulator = accumulator.to(dtype)
-            tl._experimental_descriptor_store(c_desc_ptr, accumulator, [offs_am_c, offs_bn_c])
+            c_desc.store([offs_am_c, offs_bn_c], accumulator)
 
 
 def matmul_tma_persistent(a, b, warp_specialize: bool):
@@ -499,61 +439,25 @@ def matmul_tma_persistent(a, b, warp_specialize: bool):
 
     c = torch.empty((M, N), device=a.device, dtype=dtype)
 
-    desc_helper = TmaAutoTuneHelper()
-    desc_helper.init_tma_descriptor("a")
-    desc_helper.init_tma_descriptor("b")
-    desc_helper.init_tma_descriptor("c")
-
     NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
 
+    # A dummy block value that will be overwritten when we have the real block size
+    dummy_block = [1, 1]
+    a_desc = TensorDescriptor(a, a.shape, a.stride(), dummy_block)
+    b_desc = TensorDescriptor(b, b.shape, b.stride(), dummy_block)
+    c_desc = TensorDescriptor(c, c.shape, c.stride(), dummy_block)
+
     def grid(META):
-        nonlocal desc_helper
-        desc_helper.fill_2d_tma_descriptor(
-            "a",
-            a.data_ptr(),
-            M,
-            K,
-            META["BLOCK_SIZE_M"],
-            META["BLOCK_SIZE_K"],
-            a.element_size(),
-        )
-
-        desc_helper.fill_2d_tma_descriptor(
-            "b",
-            b.data_ptr(),
-            N,
-            K,
-            META["BLOCK_SIZE_N"],
-            META["BLOCK_SIZE_K"],
-            b.element_size(),
-        )
-
-        store_block_n = META["BLOCK_SIZE_N"]
-
-        if META["EPILOGUE_SUBTILE"]:
-            store_block_n = store_block_n // 2
-
-        desc_helper.fill_2d_tma_descriptor(
-            "c",
-            c.data_ptr(),
-            M,
-            N,
-            META["BLOCK_SIZE_M"],
-            store_block_n,
-            c.element_size(),
-        )
-
+        nonlocal a_desc, b_desc, c_desc
+        BLOCK_M = META["BLOCK_SIZE_M"]
+        BLOCK_N = META["BLOCK_SIZE_N"]
         return (min(
             NUM_SMS,
-            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+            triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N),
         ), )
 
-    desc_a = desc_helper.get_tma_descriptor_kernel_param("a")
-    desc_b = desc_helper.get_tma_descriptor_kernel_param("b")
-    desc_c = desc_helper.get_tma_descriptor_kernel_param("c")
-
     matmul_kernel_tma_persistent[grid](
-        desc_a, desc_b, desc_c,  #
+        a_desc, b_desc, c_desc,  #
         M, N, K,  #
         FP8_OUTPUT=dtype == torch.float8_e4m3fn,  #
         NUM_SMS=NUM_SMS,  #
@@ -729,7 +633,7 @@ def bench(K, dtype, reps=10000, warmup_reps=10000):
     warp_specialize = [False, True] if HAS_WARP_SPECIALIZE else [False]
     for ws in warp_specialize:
         ws_str = "_ws" if ws else ""
-        if HAS_TMA_DESC:
+        if HAS_HOST_TENSOR_DESC:
             bench_fn(f"tma_persistent{ws_str}", reps, warmup_reps, lambda a, b: matmul_tma_persistent(a, b, ws), a, b)
             bench_fn(f"tma{ws_str}", reps, warmup_reps, lambda a, b: matmul_tma(a, b, ws), a, b)
         if HAS_TENSOR_DESC:
@@ -760,8 +664,8 @@ def validate(M, N, K, dtype):
     run_test(naive_result, matmul_persistent, a, b.T, "Persistent")
 
     kernels = [
-        (matmul_tma, "TMA", HAS_TMA_DESC),
-        (matmul_tma_persistent, "TMA Persistent", HAS_TMA_DESC),
+        (matmul_tma, "TMA", HAS_HOST_TENSOR_DESC),
+        (matmul_tma_persistent, "TMA Persistent", HAS_HOST_TENSOR_DESC),
         (matmul_descriptor_persistent, "Tensor Descriptor Persistent", HAS_TENSOR_DESC),
     ]
     warp_specialize = [False, True] if HAS_WARP_SPECIALIZE else [False]

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -2396,22 +2396,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // CHECK-LABEL: @reinterpret_tensor_descriptor
 tt.func private @reinterpret_tensor_descriptor(%arg0: !tt.ptr<i8, 0>) -> !tt.tensordesc<tensor<128x64xf16, #shared>> {
-  // CHECK-NEXT: llvm.addrspacecast %arg0 : !llvm.ptr to !llvm.ptr<1>
+  // CHECK-NEXT: llvm.addrspacecast %arg0 : !llvm.ptr to !llvm.ptr
   %0 = tt.reinterpret_tensor_descriptor %arg0 : !tt.ptr<i8, 0> to !tt.tensordesc<tensor<128x64xf16, #shared>>
   tt.return %0 : !tt.tensordesc<tensor<128x64xf16, #shared>>
 }
 
 // CHECK-LABEL: @tensor_desc_to_tma_ptr
 tt.func private @tensor_desc_to_tma_ptr(%arg0: !tt.tensordesc<tensor<128x64xf16, #shared>>) -> !tt.ptr<i8, 0> {
-  // CHECK-NEXT: llvm.addrspacecast %arg0 : !llvm.ptr<1> to !llvm.ptr
-  %0 = ttng.tensor_desc_to_tma_ptr %arg0 : !tt.tensordesc<tensor<128x64xf16, #shared>> to !tt.ptr<i8, 0>
-  tt.return %0 : !tt.ptr<i8, 0>
-}
-
-// CHECK-LABEL: @tensor_desc_kernel_arg
-// CHECK-SAME: %arg0: !llvm.ptr<0>
-tt.func public @tensor_desc_kernel_arg(%arg0: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}) -> !tt.ptr<i8, 0> {
-  // CHECK-NEXT: llvm.addrspacecast %arg0 : !llvm.ptr<1> to !llvm.ptr
+  // CHECK-NEXT: llvm.addrspacecast %arg0 : !llvm.ptr to !llvm.ptr
   %0 = ttng.tensor_desc_to_tma_ptr %arg0 : !tt.tensordesc<tensor<128x64xf16, #shared>> to !tt.ptr<i8, 0>
   tt.return %0 : !tt.ptr<i8, 0>
 }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -2408,4 +2408,12 @@ tt.func private @tensor_desc_to_tma_ptr(%arg0: !tt.tensordesc<tensor<128x64xf16,
   tt.return %0 : !tt.ptr<i8, 0>
 }
 
+// CHECK-LABEL: @tensor_desc_kernel_arg
+// CHECK-SAME: %arg0: !llvm.ptr<0>
+tt.func public @tensor_desc_kernel_arg(%arg0: !tt.ptr<i8, 0> {tt.nv_tma_desc = 1 : i32}) -> !tt.ptr<i8, 0> {
+  // CHECK-NEXT: llvm.addrspacecast %arg0 : !llvm.ptr<1> to !llvm.ptr
+  %0 = ttng.tensor_desc_to_tma_ptr %arg0 : !tt.tensordesc<tensor<128x64xf16, #shared>> to !tt.ptr<i8, 0>
+  tt.return %0 : !tt.ptr<i8, 0>
+}
+
 }

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -63,3 +63,23 @@ tt.func public @tma_scatter(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32, %arg3: 
   tt.return
 }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+// CHECK-DAG: #[[BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK-DAG: #[[NVMMA_128:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+tt.func public @descriptor_kernel_arg(%arg0: !tt.tensordesc<tensor<64x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64) {
+  // CHECK: %arg0: !tt.tensordesc<tensor<64x64xf16, #[[NVMMA_128]]>>
+  // CHECK: %[[LOAD:.*]] = tt.descriptor_load %arg0[{{.*}}] : !tt.tensordesc<tensor<64x64xf16, #[[NVMMA_128]]>> -> tensor<64x64xf16, #[[BLOCKED]]>
+  // CHECK: ttg.local_alloc %[[LOAD]] : (tensor<64x64xf16, #[[BLOCKED]]>) -> !ttg.memdesc<64x64xf16, #[[NVMMA_128]], #smem>
+  %c1_i32 = arith.constant 1 : i32
+  %1 = tt.descriptor_load %arg0[%c1_i32, %c1_i32] : !tt.tensordesc<tensor<64x64xf16>> -> tensor<64x64xf16, #blocked>
+  %2 = ttg.local_alloc %1 : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
+  tt.return
+}
+}

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -67,16 +67,16 @@ tt.func public @tma_scatter(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32, %arg3: 
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK-DAG: #[[BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-// CHECK-DAG: #[[NVMMA_128:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+// CHECK-DAG: #[[NVMMA_64:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
 tt.func public @descriptor_kernel_arg(%arg0: !tt.tensordesc<tensor<64x64xf16>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64) {
-  // CHECK: %arg0: !tt.tensordesc<tensor<64x64xf16, #[[NVMMA_128]]>>
-  // CHECK: %[[LOAD:.*]] = tt.descriptor_load %arg0[{{.*}}] : !tt.tensordesc<tensor<64x64xf16, #[[NVMMA_128]]>> -> tensor<64x64xf16, #[[BLOCKED]]>
-  // CHECK: ttg.local_alloc %[[LOAD]] : (tensor<64x64xf16, #[[BLOCKED]]>) -> !ttg.memdesc<64x64xf16, #[[NVMMA_128]], #smem>
+  // CHECK: %arg0: !tt.tensordesc<tensor<64x64xf16, #[[NVMMA_64]]>>
+  // CHECK: %[[LOAD:.*]] = tt.descriptor_load %arg0[{{.*}}] : !tt.tensordesc<tensor<64x64xf16, #[[NVMMA_64]]>> -> tensor<64x64xf16, #[[BLOCKED]]>
+  // CHECK: ttg.local_alloc %[[LOAD]] : (tensor<64x64xf16, #[[BLOCKED]]>) -> !ttg.memdesc<64x64xf16, #[[NVMMA_64]], #smem>
   %c1_i32 = arith.constant 1 : i32
   %1 = tt.descriptor_load %arg0[%c1_i32, %c1_i32] : !tt.tensordesc<tensor<64x64xf16>> -> tensor<64x64xf16, #blocked>
   %2 = ttg.local_alloc %1 : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -298,6 +298,8 @@ class CUDABackend(BaseBackend):
         passes.common.add_canonicalizer(pm)
         pm.run(mod)
         metadata["cluster_dims"] = (cluster_info.clusterDimX, cluster_info.clusterDimY, cluster_info.clusterDimZ)
+        tensordesc_meta = mod.get_tensordesc_metadata()
+        metadata["tensordesc_meta"] = tensordesc_meta
         return mod
 
     def make_llir(self, src, metadata, options, capability):

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -365,8 +365,8 @@ static PyObject *fillTMADescriptor(PyObject *self, PyObject *args) {
   CUDA_CHECK_AND_RETURN_NULL(cuTensorMapEncodeTiled(
       (CUtensorMap *)desc_address, elemType, rank, (void *)global_address,
       shapeInt, stridesLL, blockSizeInt, elementStrides,
-      CU_TENSOR_MAP_INTERLEAVE_NONE, swizzle, CU_TENSOR_MAP_L2_PROMOTION_NONE,
-      CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE));
+      CU_TENSOR_MAP_INTERLEAVE_NONE, swizzle,
+      CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE));
   Py_RETURN_NONE;
 
 cleanup:

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -109,7 +109,7 @@ def ty_to_cpp(ty):
     if ty[0] == '*':
         return "CUdeviceptr"
     if ty.startswith("tensordesc"):
-        return "CUtensorMap";
+        return "CUtensorMap"
     return {
         "i1": "int32_t",
         "i8": "int8_t",
@@ -582,8 +582,6 @@ def wrap_handle_tensordesc(launcher, tensordesc_meta):
         return launcher(*meta_args, *final_args)
 
     return inner
-
-
 
 
 class CudaLauncher(object):

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -596,7 +596,6 @@ class CudaLauncher(object):
         arg_idx = lambda x: (src.fn.arg_names.index(x), ) if isinstance(x, str) else x
         constants = {arg_idx(idx): value for idx, value in constants.items()}
         signature = {idx: value for idx, value in src.signature.items()}
-
         src = make_launcher(constants, signature)
         mod = compile_module_from_src(src, "__triton_launcher")
         self.num_ctas = functools.reduce(operator.mul, metadata.cluster_dims, 1)


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. [NVIDIA] Add compiler-controlled host side tensor descriptor API
    
    This adds a new `TensorDescriptor` kernel argument which doesn't rely on
    convention, and instead choses the descriptor parameters at compile time
    and communicates this to the launcher via the kernel signature in the
    ttgir (this is later serialized in the kernel metadata in the cache).
    
    The real `CuTensorMap` object is then created at the last second in the
    kernel launcher. We can revisit this with caching if needed to reduce
    launch overhead. I was however careful to not introduce any additional
    overhead for kernels not using `TensorDescriptor`.
    
    Benchmarks show we achieve the same performance benefits as the previous
    host side API (descriptor=device side, tma=host side):
    ```
    1690.079 3659.446 ROOT
    ├─ 1598.967 429.774 cublas [M=8192, N=8192, K=512]
    │  └─ nan 429.774 nvjet_qqhsq_256x256_128x4_2x1_2cta_v_bz_TNT
    ├─ 1491.274 460.810 matmul_kernel [M=8192, N=8192, K=512]
    ├─ 1778.448 386.401 matmul_kernel_persistent [M=8192, N=8192, K=512]
    ├─ 1887.893 364.001 matmul_kernel_descriptor_persistent [M=8192, N=8192, K=512]
    ├─ 2178.427 315.455 matmul_kernel_descriptor_persistent_ws [M=8192, N=8192, K=512]
    ├─ 1972.040 348.469 matmul_kernel_tma_persistent [M=8192, N=8192, K=512]
    ├─ 2359.637 291.229 matmul_kernel_tma_persistent_ws [M=8192, N=8192, K=512]
    ```
    
    Will follow up with lots of juicy clean up PRs.
1. Lint
1. Fix lit
1. More fixes
1. Fix nested tuple handling
1. Skip interpreter tests for now
1. Cleanup

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #6463 👈 **YOU ARE HERE**
1. #6464
1. #6465


</git-pr-chain>
