### PR TITLE
[python][backends] Setup sys.modules with any loaded backend

### DIFF
--- a/python/triton/backends/__init__.py
+++ b/python/triton/backends/__init__.py
@@ -1,6 +1,7 @@
-import os
 import importlib.util
 import inspect
+import os
+import sys
 from dataclasses import dataclass
 from .driver import DriverBase
 from .compiler import BaseBackend
@@ -9,6 +10,7 @@ from .compiler import BaseBackend
 def _load_module(name, path):
     spec = importlib.util.spec_from_file_location(name, path)
     module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -40,8 +42,8 @@ def _discover_backends():
             continue
         if name.startswith('__'):
             continue
-        compiler = _load_module(name, os.path.join(root, name, 'compiler.py'))
-        driver = _load_module(name, os.path.join(root, name, 'driver.py'))
+        compiler = _load_module(f"triton.backends.{name}.compiler", os.path.join(root, name, 'compiler.py'))
+        driver = _load_module(f"triton.backends.{name}.driver", os.path.join(root, name, 'driver.py'))
         backends[name] = Backend(_find_concrete_subclasses(compiler, BaseBackend),
                                  _find_concrete_subclasses(driver, DriverBase))
     return backends


### PR DESCRIPTION
From [importlib's docs](https://docs.python.org/3.13/library/importlib.html#importing-a-source-file-directly) you're supposed to setup `sys.modules` with the imported module after you import it, and the name should be the fully qualified import path.

Besides following the docs, this enables any external user to access/reference a backend module (otherwise there's no easy way-- meaning without traversing the `gc`-- to access those modules).

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `the test would be trivial-- I can add it if requested`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
