### PR TITLE
[BACKEND] Support memdesc_reshape to allow different HBM layout for mmav5

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -9,6 +9,7 @@
 // TritonGPU depends on Triton
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonGPU/IR/Traits.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 
 #include <unordered_map>
@@ -278,6 +279,10 @@ bool areLayoutsEquivalent(ArrayRef<int64_t> shape, Attribute lhs,
 
 // Return true if the innermost numElems are contiguous.
 bool isInnermostContiguous(MemDescType type, unsigned numElems);
+
+LinearLayout inferReshapeLinearLayout(ArrayRef<int64_t> srcShape,
+                                      Attribute srcEnc,
+                                      ArrayRef<int64_t> dstShape);
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_DIALECT_TRITONGPU_IR_DIALECT_H_

--- a/include/triton/Dialect/TritonGPU/IR/Traits.h
+++ b/include/triton/Dialect/TritonGPU/IR/Traits.h
@@ -1,0 +1,22 @@
+#ifndef TRITONGPU_IR_TRAITS_H_
+#define TRITONGPU_IR_TRAITS_H_
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Support/LogicalResult.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+
+namespace mlir {
+namespace OpTrait {
+
+template <typename ConcreteType>
+class MemDescViewTrait
+    : public mlir::OpTrait::TraitBase<ConcreteType, MemDescViewTrait> {
+  // Optional: Add methods or verification logic here
+};
+
+} // namespace OpTrait
+} // namespace mlir
+
+#endif

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -15,6 +15,9 @@ def TritonGPU_AttrTrait : AttrInterface<"TritonGPU_AttrTrait"> {
   ];
 }
 
+def MemDescViewTrait : NativeOpTrait<"MemDescViewTrait">;
+
+
 class TritonGPU_Attr<string name, string attrMnemonic, list<Trait> traits = [],
                      Dialect dialect = TritonGPU_Dialect,
                      string baseCppClass = "::mlir::Attribute">
@@ -395,6 +398,8 @@ def NVMMASharedEncodingAttr :
     This is meant to represent 2d tiled blocked layout.
     The full layout representation is described here:
     https://docs.nvidia.com/cuda/parallel-thread-execution/#asynchronous-warpgroup-level-matrix-shared-memory-layout
+    When the memdesc has more than 2 dimensions the tiling is applied to 8 rows even if the first outer dimension is smaller than 8.
+    In this case `transposed` means that the contiguous dimension is the most outer dimension of the memdesc.
   }];
 
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -198,7 +198,7 @@ def TTG_LocalDeallocOp : TTG_Op<"local_dealloc"> {
   let assemblyFormat = [{$src attr-dict `:` qualified(type($src))}];
 }
 
-def TTG_MemDescSubviewOp : TTG_Op<"memdesc_subview", [Pure]> {
+def TTG_MemDescSubviewOp : TTG_Op<"memdesc_subview", [Pure, MemDescViewTrait]> {
   let summary = "take a subview of the descriptor.";
 
   let description = [{
@@ -224,6 +224,7 @@ def TTG_MemDescSubviewOp : TTG_Op<"memdesc_subview", [Pure]> {
 }
 
 def TTG_MemDescTransOp : TTG_Op<"memdesc_trans", [Pure,
+                                                  MemDescViewTrait,
                                                   TransposeOpInterface,
                                                   InferTypeOpWithLayoutEquivalence,
                                                   SameOperandsAndResultElementType]> {
@@ -246,6 +247,29 @@ def TTG_MemDescTransOp : TTG_Op<"memdesc_trans", [Pure,
   let assemblyFormat = "$src attr-dict `:` qualified(type($src)) `->` qualified(type($result))";
 
   let hasFolder = 1;
+}
+
+def TTG_MemDescReshapeOp : TTG_Op<"memdesc_reshape", [Pure,
+                                                      MemDescViewTrait,
+                                                      SameOperandsAndResultElementType]> {
+  let summary = "creates a descriptor for the new shape";
+
+  let description = [{
+    This operation returns a new descriptor representing a reshaped view of the underlying buffer.
+    This doesn't affect the memory.
+  }];
+
+  let arguments = (ins TTG_MemDescType:$src);
+
+  let arguments = (
+    ins TTG_MemDescType:$src
+  );
+
+  let results = (outs TTG_MemDescType:$result);
+
+  let assemblyFormat = "$src attr-dict `:` qualified(type($src)) `->` qualified(type($result))";
+
+  let hasVerifier = 1;
 }
 
 def TTG_LocalLoadOp : TTG_Op<"local_load"> {

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -104,6 +104,15 @@ LinearLayout identityStandardND(StringAttr inDimName, ArrayRef<unsigned> shape,
 // (e.g. [a, b], [a, c] -> [a, b, c]).
 SmallVector<StringAttr> supremum(const SmallVector<StringAttr> &x,
                                  const SmallVector<StringAttr> &y);
+
+// Return a new layout reshaped to the given shape.
+LinearLayout reshapeLayout(MLIRContext *ctx, LinearLayout layout,
+                           ArrayRef<int64_t> shape);
+
+// Return a new layout with the dimensions transposed according to the given
+// order.
+LinearLayout transposeLinearLayout(LinearLayout layout, ArrayRef<int> order);
+
 } // namespace mlir::triton
 
 #endif // TRITON_TOOLS_LAYOUTUTILS_H

--- a/lib/Analysis/Alias.cpp
+++ b/lib/Analysis/Alias.cpp
@@ -38,8 +38,7 @@ LogicalResult SharedMemoryAliasAnalysis::visitOperation(
   if (isa<triton::gpu::LocalAllocOp>(op)) {
     aliasInfo.insert(result);
     pessimistic = false;
-  } else if (isa<triton::gpu::MemDescSubviewOp, triton::gpu::MemDescTransOp>(
-                 op)) {
+  } else if (op->hasTrait<OpTrait::MemDescViewTrait>()) {
     aliasInfo = AliasInfo(operands[0]->getValue());
     pessimistic = false;
   } else {

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2084,19 +2084,8 @@ struct TritonGPUInferLayoutInterface
       return success();
     }
     auto ll = toLinearLayout(shape, operandEncoding);
-    auto namedBases = ll.getBases();
-    for (auto &bases : llvm::make_second_range(namedBases)) {
-      for (auto &b : bases) {
-        std::vector<int32_t> newB;
-        for (auto i : order) {
-          newB.push_back(b[i]);
-        }
-        b = std::move(newB);
-      }
-    }
-    auto retLl = LinearLayout(std::move(namedBases),
-                              llvm::to_vector(ll.getOutDimNames()));
-    resultEncoding = LinearEncodingAttr::get(ctx, std::move(retLl));
+    auto transposedLl = transposeLinearLayout(ll, order);
+    resultEncoding = LinearEncodingAttr::get(ctx, std::move(transposedLl));
     return success();
   }
 
@@ -3176,18 +3165,7 @@ LinearLayout triton::gpu::inferReshapeLinearLayout(ArrayRef<int64_t> srcShape,
                                                    ArrayRef<int64_t> dstShape) {
   auto *ctx = srcEnc.getContext();
   auto src = toLinearLayout(srcShape, srcEnc);
-
-  auto newRank = dstShape.size();
-
-  auto newOutDims = standardOutDimPairs(ctx, dstShape);
   assert(product(srcShape) == product(dstShape));
-  // reshapeOp assumes minor-to-major, so we need to transpose the out dims
-  // before the reshape
-  auto srcOutDims = to_vector(src.getOutDimNames());
-  std::reverse(srcOutDims.begin(), srcOutDims.end());
-  std::reverse(newOutDims.begin(), newOutDims.end());
-  auto dst = src.transposeOuts(srcOutDims)
-                 .reshapeOuts(newOutDims)
-                 .transposeOuts(standardOutDimNames(ctx, newRank));
+  auto dst = reshapeLayout(ctx, src, dstShape);
   return dst;
 }

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -232,37 +232,6 @@ sharedToLinearLayoutAMDRotating(ArrayRef<int64_t> shape,
 
 } // namespace
 
-static LinearLayout reshapeLayout(MLIRContext *ctx, LinearLayout layout,
-                                  ArrayRef<int64_t> shape) {
-  int rank = shape.size();
-  auto srcOutDims = to_vector(layout.getOutDimNames());
-  std::reverse(srcOutDims.begin(), srcOutDims.end());
-  auto newOutDims = standardOutDimPairs(ctx, shape);
-  std::reverse(newOutDims.begin(), newOutDims.end());
-  return layout.transposeOuts(srcOutDims)
-      .reshapeOuts(newOutDims)
-      .transposeOuts(standardOutDimNames(ctx, rank));
-}
-
-static LinearLayout transposeLinearLayout(LinearLayout layout,
-                                          ArrayRef<int> order) {
-  // Transpose the tile layout.
-  auto namedBases = layout.getBases();
-  // move the most outer dimensions to the inner most position.
-
-  for (auto &bases : llvm::make_second_range(namedBases)) {
-    for (auto &b : bases) {
-      std::vector<int32_t> newB;
-      for (auto i : order) {
-        newB.push_back(b[i]);
-      }
-      b = std::move(newB);
-    }
-  }
-  return LinearLayout(std::move(namedBases),
-                      to_vector(layout.getOutDimNames()));
-}
-
 LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
                                                NVMMASharedEncodingAttr shared,
                                                bool disableSwizzle) {

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -232,19 +232,61 @@ sharedToLinearLayoutAMDRotating(ArrayRef<int64_t> shape,
 
 } // namespace
 
+static LinearLayout reshapeLayout(MLIRContext *ctx, LinearLayout layout,
+                                  ArrayRef<int64_t> shape) {
+  int rank = shape.size();
+  auto srcOutDims = to_vector(layout.getOutDimNames());
+  std::reverse(srcOutDims.begin(), srcOutDims.end());
+  auto newOutDims = standardOutDimPairs(ctx, shape);
+  std::reverse(newOutDims.begin(), newOutDims.end());
+  return layout.transposeOuts(srcOutDims)
+      .reshapeOuts(newOutDims)
+      .transposeOuts(standardOutDimNames(ctx, rank));
+}
+
+static LinearLayout transposeLinearLayout(LinearLayout layout,
+                                          ArrayRef<int> order) {
+  // Transpose the tile layout.
+  auto namedBases = layout.getBases();
+  // move the most outer dimensions to the inner most position.
+
+  for (auto &bases : llvm::make_second_range(namedBases)) {
+    for (auto &b : bases) {
+      std::vector<int32_t> newB;
+      for (auto i : order) {
+        newB.push_back(b[i]);
+      }
+      b = std::move(newB);
+    }
+  }
+  return LinearLayout(std::move(namedBases),
+                      to_vector(layout.getOutDimNames()));
+}
+
 LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
                                                NVMMASharedEncodingAttr shared,
                                                bool disableSwizzle) {
   MLIRContext *ctx = shared.getContext();
-
-  auto shapePerCTA = getShapePerCTA(shared, shape);
-
   int rank = shape.size();
+  auto shapePerCTA = getShapePerCTA(shared, shape);
   if (rank == 1) {
     // TODO: Not sure if this is correct.
     return combineCtaCgaWithShape(
         LinearLayout::identity1D(shapePerCTA[0], S("offset"), S("dim0")),
         shared.getCTALayout(), shape);
+  }
+  // Construct bases for a the layout's 2-dimensional tile.
+  assert(rank >= 2);
+  int batchDims = rank - 2;
+
+  // Collapse all the outer dim into one. We will then create a layout for this
+  // shape and reshape it to the original shape.
+  std::array<int64_t, 2> collapsedShapePerCTA = {shapePerCTA[batchDims],
+                                                 shapePerCTA[batchDims + 1]};
+  for (int i = 0; i < batchDims; i++)
+    collapsedShapePerCTA[0] *= shapePerCTA[i];
+  if (shared.getTransposed()) {
+    std::swap(collapsedShapePerCTA[0], collapsedShapePerCTA[1]);
   }
   int elemBitWidth = shared.getElementBitWidth();
   int tileWidthBytes = shared.getSwizzlingByteWidth();
@@ -261,13 +303,6 @@ LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
     perPhase = 1;
     maxPhase = 8;
   }
-  auto outDimNames = standardOutDimNames(ctx, rank);
-
-  // Construct bases for a the layout's 2-dimensional tile.
-  assert(rank >= 2);
-  int batchDims = rank - 2;
-  int colDim = batchDims + (shared.getTransposed() ? 0 : 1);
-  int rowDim = batchDims + (shared.getTransposed() ? 1 : 0);
 
   int tileRows = 8;
   int tileCols = 8 * tileWidthBytes / elemBitWidth;
@@ -280,17 +315,15 @@ LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
   }
   int packingFactor = isFp4Padded ? 2 : 1;
 
-  if (shapePerCTA[colDim] * packingFactor < tileCols ||
-      shapePerCTA[rowDim] < tileRows) {
-    llvm::errs()
-        << "Illegal shared layout; expected shapePerCTA to be at least ["
-        << tileRows << ", " << tileCols << "], shapePerCTA: ["
-        << shapePerCTA[rowDim] << ", " << shapePerCTA[colDim] << "]\n";
+  if (collapsedShapePerCTA[1] * packingFactor < tileCols ||
+      collapsedShapePerCTA[0] < tileRows) {
+    llvm::errs() << "Illegal shared layout; expected collapsed shapePerCTA to "
+                    "be at least ["
+                 << tileRows << ", " << tileCols << "], collapsedShapePerCTA: ["
+                 << collapsedShapePerCTA[0] << ", " << collapsedShapePerCTA[1]
+                 << "]\n";
     llvm::report_fatal_error("Illegal shared layout");
   }
-
-  StringAttr colDimName = outDimNames[colDim];
-  StringAttr rowDimName = outDimNames[rowDim];
 
   std::vector<std::vector<int>> bases2D;
   for (int logCol = 0; logCol < llvm::Log2_32(tileCols); logCol++) {
@@ -321,16 +354,39 @@ LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
       bases2D.push_back({row, vec * ((row / perPhase) % maxPhase)});
     }
   }
-  LinearLayout tileLayout =
-      LinearLayout({{S("offset"), bases2D}}, {rowDimName, colDimName});
 
-  // Add the remaining dimensions.
-  for (int dim = batchDims - 1; dim >= 0; --dim) {
-    tileLayout *= LinearLayout::identity1D(shapePerCTA[dim], S("offset"),
-                                           outDimNames[dim]);
+  // Then distribute the remaining rows.
+  for (int logRow = llvm::Log2_32(tileRows);
+       logRow < llvm::Log2_32(collapsedShapePerCTA[0]); logRow++) {
+    bases2D.push_back({1 << logRow, 0});
   }
 
-  return combineCtaCgaWithShape(tileLayout, shared.getCTALayout(), shape);
+  auto outDimNames = standardOutDimNames(ctx, 2);
+  std::reverse(outDimNames.begin(), outDimNames.end());
+  LinearLayout tileLayout = LinearLayout({{S("offset"), bases2D}}, outDimNames);
+  // Expand the layout to convert the whole shape per CTA.
+  llvm::SmallDenseMap<StringAttr, int64_t> namedShape;
+  namedShape[outDimNames[0]] = collapsedShapePerCTA[0];
+  namedShape[outDimNames[1]] = collapsedShapePerCTA[1];
+  tileLayout = ensureLayoutNotSmallerThan(tileLayout, namedShape);
+
+  // Reshape the layout to the N-D pre-transposed shape per CTA.
+  SmallVector<int64_t> maybeTransposedShapePerCTA = shapePerCTA;
+  if (shared.getTransposed()) {
+    std::swap(maybeTransposedShapePerCTA[0], maybeTransposedShapePerCTA[1]);
+  }
+  auto reshapedLayout =
+      reshapeLayout(ctx, tileLayout, maybeTransposedShapePerCTA);
+
+  if (shared.getTransposed()) {
+    SmallVector<int> order = {rank - 1};
+    for (int i = 0; i < rank - 1; i++) {
+      order.push_back(i);
+    }
+    reshapedLayout = transposeLinearLayout(reshapedLayout, order);
+  }
+
+  return combineCtaCgaWithShape(reshapedLayout, shared.getCTALayout(), shape);
 }
 
 /// Function to generate lane and warp layout for dot operands.

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -144,6 +144,75 @@ public:
   }
 };
 
+static Attribute inferSrcEncodingMemDescReshape(Attribute dstEncoding,
+                                                ArrayRef<int64_t> srcShape,
+                                                ArrayRef<int64_t> dstShape) {
+  auto mmaEncoding = dyn_cast<NVMMASharedEncodingAttr>(dstEncoding);
+  if (!mmaEncoding)
+    return Attribute();
+  // TODO: supporting reshape of CTA layouts is non-trivial.
+  if (getNumCTAs(mmaEncoding) > 1)
+    return Attribute();
+  int innerDimDst =
+      mmaEncoding.getTransposed() ? dstShape.front() : dstShape.back();
+  int innerDimSrc =
+      mmaEncoding.getTransposed() ? srcShape.front() : srcShape.back();
+  // For now disallow reshape of the inner dimension.
+  if (innerDimDst != innerDimSrc)
+    return Attribute();
+
+  // CTALayout can be all 1's because we bailed on multi-CTA layouts above.
+  auto CTALayout = CTALayoutAttr::get(
+      dstEncoding.getContext(),
+      /*CTAsPerCGA=*/SmallVector<unsigned>(srcShape.size(), 1),
+      /*CTASplitNum=*/SmallVector<unsigned>(srcShape.size(), 1),
+      /*CTAOrder=*/llvm::to_vector(llvm::seq<unsigned>(srcShape.size())));
+  // Check that the second dim is big enough to contain a full swizzle.
+  return NVMMASharedEncodingAttr::get(
+      dstEncoding.getContext(), mmaEncoding.getSwizzlingByteWidth(),
+      mmaEncoding.getTransposed(), mmaEncoding.getElementBitWidth(),
+      mmaEncoding.getFp4Padded(), CTALayout);
+}
+
+// Rewrite
+//
+//   alloc(reshape(), #shared1) ->
+//   memdesc_reshape(alloc() #shared2))
+//
+// if dot is an MMAv3/v5 (because MMAv3/v5 allows us to fold transposes).
+class ReshapeMemDesc : public OpRewritePattern<LocalAllocOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LocalAllocOp allocOp,
+                                PatternRewriter &rewriter) const override {
+    if (!allocOp.getSrc())
+      return failure();
+
+    auto reshapeOp = allocOp.getSrc().getDefiningOp<ReshapeOp>();
+    if (!reshapeOp)
+      return failure();
+
+    MemDescType allocType = allocOp.getType();
+    auto allocEncoding = allocType.getEncoding();
+
+    RankedTensorType srcTy = reshapeOp.getSrc().getType();
+    auto newAllocEncoding = inferSrcEncodingMemDescReshape(
+        allocEncoding, srcTy.getShape(), allocType.getShape());
+    if (!newAllocEncoding)
+      return failure();
+
+    MemDescType innerTy =
+        MemDescType::get(srcTy.getShape(), srcTy.getElementType(),
+                         newAllocEncoding, allocType.getMemorySpace());
+    auto newAlloc = rewriter.create<LocalAllocOp>(allocOp.getLoc(), innerTy,
+                                                  reshapeOp.getSrc());
+    rewriter.replaceOpWithNewOp<MemDescReshapeOp>(allocOp, allocOp.getType(),
+                                                  newAlloc);
+    return success();
+  }
+};
+
 // Inject TMEM copy instructions into IR to efficiently load blocked scales for
 // scaled dot
 class UseShmemForScales
@@ -297,7 +366,7 @@ public:
 
     mlir::RewritePatternSet patterns(context);
     patterns.add<SwizzleShmemConvert>(context);
-    patterns.add<FuseTransMMAV3Plus>(context);
+    patterns.add<FuseTransMMAV3Plus, ReshapeMemDesc>(context);
     patterns.add<UseShmemForScales>(context);
     ConvertLayoutOp::getCanonicalizationPatterns(patterns, context);
     if (failed(applyPatternsGreedily(m, std::move(patterns))))

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -87,7 +87,7 @@ getTopLevelUsersInLoop(Operation *op, scf::ForOp forOp,
     }
     // Don't count view operations as uses. Follow them through to their
     // users.
-    if (isa<ttg::MemDescTransOp, ttg::MemDescSubviewOp>(use->getOwner())) {
+    if (use->getOwner()->hasTrait<OpTrait::MemDescViewTrait>()) {
       for (auto &use : use->getOwner()->getUses())
         q.push_back(&use);
       continue;
@@ -463,7 +463,7 @@ void createTMABarrierAndWait(
 // Check if load requires additional buffer for a mma pipelining
 bool loadRequiresAdditionalBuffer(Operation *loadOp) {
   auto skipViewOps = [](Operation *op) -> Operation * {
-    while (op->hasOneUse() && isa<ttg::MemDescTransOp>(op)) {
+    while (op->hasOneUse() && op->hasTrait<OpTrait::MemDescViewTrait>()) {
       op = *op->getUsers().begin();
     }
     return op;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MMAv5PipelineUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MMAv5PipelineUtility.cpp
@@ -35,7 +35,7 @@ bool ttng::mmaHasPipelineableOperands(
     if (!v.getDefiningOp()) {
       return false;
     }
-    while (isa<ttg::MemDescTransOp>(v.getDefiningOp())) {
+    while (isa<ttg::MemDescTransOp, ttg::MemDescReshapeOp>(v.getDefiningOp())) {
       v = v.getDefiningOp()->getOperand(0);
     }
     if (auto localAlloc = dyn_cast<ttg::LocalAllocOp>(v.getDefiningOp())) {

--- a/python/test/unit/cuda/test_tensor_descriptor.py
+++ b/python/test/unit/cuda/test_tensor_descriptor.py
@@ -1530,3 +1530,118 @@ def test_specialization_after_host_tensordesc():
     desc = TensorDescriptor.from_tensor(A, [128])
     h = kernel.warmup(desc, 16, grid=(1, ))
     assert ", %arg3: i32 {tt.divisibility = 16 : i32}" in h.asm["ttir"]
+
+
+@triton.jit()
+def matmul_kernel_reshape(a_ptr, b_ptr, c_ptr,  #
+                          M, N, K,  #
+                          BLOCK_SIZE_M: tl.constexpr,  #
+                          BLOCK_SIZE_N: tl.constexpr,  #
+                          BLOCK_SIZE_K: tl.constexpr,  #
+                          NUM_SMS: tl.constexpr):  #
+    # Matmul using TMA and device-side descriptor creation
+    GROUP_SIZE_M: tl.constexpr = 8
+    dtype = c_ptr.dtype.element_ty
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    a_desc = tl.make_tensor_descriptor(
+        a_ptr,
+        shape=[2, M // 2, K],
+        strides=[(M // 2) * K, K, 1],
+        block_shape=[2, BLOCK_SIZE_M // 2, BLOCK_SIZE_K],
+    )
+    b_desc = tl.make_tensor_descriptor(
+        b_ptr,
+        shape=[N, K],
+        strides=[K, 1],
+        block_shape=[BLOCK_SIZE_N, BLOCK_SIZE_K],
+    )
+    c_desc = tl.make_tensor_descriptor(
+        c_ptr,
+        shape=[M, N],
+        strides=[N, 1],
+        block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N],
+    )
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
+        offs_am = pid_m * (BLOCK_SIZE_M // 2)
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([0, offs_am, offs_k]).reshape(BLOCK_SIZE_M, BLOCK_SIZE_K)
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m, pid_n = _compute_pid(tile_id_c, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
+        offs_cm = pid_m * BLOCK_SIZE_M
+        offs_cn = pid_n * BLOCK_SIZE_N
+
+        c = accumulator.to(dtype)
+        c_desc.store([offs_cm, offs_cn], c)
+
+
+@requires_tma
+@pytest.mark.parametrize("dtype_str", ["float16", "bfloat16", "float32"])
+def test_tensor_descriptor_reshape_matmul(dtype_str):
+    NUM_SMS = 4
+    M, N, K = 256, 256, 128
+    BLOCK_SIZE_M = 64
+    BLOCK_SIZE_N = 64
+    BLOCK_SIZE_K = 64
+
+    # trunc float32 to avoid large precision differences.
+    def trunc_to_tf32(tensor):
+        int_view = tensor.view(np.uint32)
+        mask = np.uint32(0xFFFFE000)
+        masked_int = int_view & mask
+        tf32_simulated = masked_int.view(np.float32)
+        return tf32_simulated
+
+    # test a layout where block_m is split into two separate chunks.
+    A = numpy_random((M, K), dtype_str)
+    if dtype_str == "float32":
+        A = trunc_to_tf32(A)
+    A_reshaped = (A.reshape(M // BLOCK_SIZE_M, 2, BLOCK_SIZE_M // 2, K).transpose(1, 0, 2, 3).reshape(2, M // 2, K))
+
+    A = to_triton(A, device="cuda", dst_type=dtype_str)
+    A_reshaped = to_triton(A_reshaped, device="cuda", dst_type=dtype_str)
+
+    B = numpy_random((N, K), dtype_str)
+    if dtype_str == "float32":
+        B = trunc_to_tf32(B)
+    B = to_triton(B, device="cuda", dst_type=dtype_str)
+    C = A.new_empty(M, N)
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    kernel = matmul_kernel_reshape[(NUM_SMS, )](
+        A_reshaped,
+        B,
+        C,
+        M,
+        N,
+        K,
+        NUM_SMS=4,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+    )
+
+    actual = unwrap_tensor(C)
+    expect = torch.matmul(A, B.mT)
+    torch.testing.assert_close(expect, actual, atol=1e-1, rtol=1e-4)
+
+    kernel.asm["ttgir"]

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -2775,6 +2775,76 @@ TEST_F(LinearLayoutConversionsTest, LeadingOffset_8x64_1_8_32b) {
                          /*requireSurjective=*/false));
 }
 
+TEST_F(LinearLayoutConversionsTest, LeadingOffset_128x128_1_8_128b_transposed) {
+  EXPECT_EQ(toLinearLayout({128, 128}, nvmmaShared(128, true, 32, {1, 1},
+                                                   {1, 1}, {1, 0}, {1, 0})),
+            LinearLayout({{S("offset"),
+                           {{1, 0},
+                            {2, 0},
+                            {4, 0},
+                            {8, 0},
+                            {16, 0},
+                            {4, 1},
+                            {8, 2},
+                            {16, 4},
+                            {0, 8},
+                            {0, 16},
+                            {0, 32},
+                            {0, 64},
+                            {32, 0},
+                            {64, 0}}},
+                          {S("block"), {}}},
+                         {{S("dim0"), 128}, {S("dim1"), 128}},
+                         /*requireSurjective=*/false));
+}
+
+TEST_F(LinearLayoutConversionsTest, LeadingOffset_32x4x64_1_8_32b) {
+  EXPECT_EQ(
+      toLinearLayout({32, 4, 64}, nvmmaShared(64, false, 32, {1, 1, 1},
+                                              {1, 1, 1}, {2, 1, 0}, {2, 1, 0})),
+      LinearLayout({{S("offset"),
+                     {{0, 0, 1},
+                      {0, 0, 2},
+                      {0, 0, 4},
+                      {0, 0, 8},
+                      {0, 1, 0},
+                      {0, 2, 4},
+                      {1, 0, 8},
+                      {2, 0, 0},
+                      {4, 0, 0},
+                      {8, 0, 0},
+                      {16, 0, 0},
+                      {0, 0, 16},
+                      {0, 0, 32}}},
+                    {S("block"), {}}},
+                   {{S("dim0"), 32}, {S("dim1"), 4}, {S("dim2"), 64}},
+                   /*requireSurjective=*/false));
+}
+
+TEST_F(LinearLayoutConversionsTest, LeadingOffset_64x4x32_1_8_32b_transposed) {
+  EXPECT_EQ(
+      toLinearLayout({64, 4, 32}, nvmmaShared(64, true, 32, {1, 1, 1},
+                                              {1, 1, 1}, {2, 1, 0}, {2, 1, 0})),
+      LinearLayout({{S("offset"),
+                     {{1, 0, 0},
+                      {2, 0, 0},
+                      {4, 0, 0},
+                      {8, 0, 0},
+                      {0, 0, 8},
+                      {4, 0, 16},
+                      {8, 0, 0},
+                      {0, 1, 0},
+                      {0, 2, 0},
+                      {16, 0, 0},
+                      {0, 0, 1},
+                      {0, 0, 2},
+                      {0, 0, 4},
+                      {32, 0, 0}}},
+                    {S("block"), {}}},
+                   {{S("dim0"), 64}, {S("dim1"), 4}, {S("dim2"), 32}},
+                   /*requireSurjective=*/false));
+}
+
 TEST_F(LinearLayoutConversionsTest, Shared1DSwizzle) {
   EXPECT_EQ(
       toLinearLayout({64, 1}, shared(2, 2, 4, {1, 1}, {1, 1}, {1, 0}, {1, 0})),

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -2795,7 +2795,7 @@ TEST_F(LinearLayoutConversionsTest, LeadingOffset_128x128_1_8_128b_transposed) {
                             {64, 0}}},
                           {S("block"), {}}},
                          {{S("dim0"), 128}, {S("dim1"), 128}},
-                         /*requireSurjective=*/false));
+                         /*requireSurjective=*/true));
 }
 
 TEST_F(LinearLayoutConversionsTest, LeadingOffset_32x4x64_1_8_32b) {
@@ -2818,7 +2818,7 @@ TEST_F(LinearLayoutConversionsTest, LeadingOffset_32x4x64_1_8_32b) {
                       {0, 0, 32}}},
                     {S("block"), {}}},
                    {{S("dim0"), 32}, {S("dim1"), 4}, {S("dim2"), 64}},
-                   /*requireSurjective=*/false));
+                   /*requireSurjective=*/true));
 }
 
 TEST_F(LinearLayoutConversionsTest, LeadingOffset_64x4x32_1_8_32b_transposed) {
@@ -2842,7 +2842,7 @@ TEST_F(LinearLayoutConversionsTest, LeadingOffset_64x4x32_1_8_32b_transposed) {
                       {32, 0, 0}}},
                     {S("block"), {}}},
                    {{S("dim0"), 64}, {S("dim1"), 4}, {S("dim2"), 32}},
-                   /*requireSurjective=*/false));
+                   /*requireSurjective=*/true));
 }
 
 TEST_F(LinearLayoutConversionsTest, Shared1DSwizzle) {


### PR DESCRIPTION
Adds an op to reshape memdesc types. This allows to support cases where we want to reshape a value loaded from global to shared without going through register.

This also rework the representation of nvmma layout when the memdesc is greater than 2.
We pick a convention that allows us to reshape the non-contiguous dimension of a memdesc.