### PR TITLE
[AMD][BACKEND] Clamp vmcnt instead of erroring out in AsyncWait lowering

### DIFF
--- a/test/Conversion/amd/async_ops_to_llvm.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm.mlir
@@ -95,6 +95,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: rocdl.s.waitcnt -1
     // CHECK: rocdl.barrier
     ttg.async_wait {num = 63 : i32}
+    // Check that we clamp values > 63
+    // CHECK: rocdl.s.waitcnt -1
+    // CHECK: rocdl.barrier
+    ttg.async_wait {num = 64 : i32}
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1531,10 +1531,8 @@ struct AsyncWaitOpConversion : public ConvertOpToLLVMPattern<AsyncWaitOp> {
     // 15:14. We have to set all other bits in v to 1 to signal we are not
     // interested in those.
 
-    int vmCnt = op.getNum();
-    if (vmCnt >= 64) {
-      return emitError(loc, "AsyncWait does not support values >= 64");
-    }
+    // Clamp vmcnt to 6bits; a lower vmcnt will produce a conservative wait
+    unsigned vmCnt = std::min(63u, op.getNum());
 
     // Extract low and high bits and combine while setting all other bits to 1
     unsigned lowBits = vmCnt & 0xF;


### PR DESCRIPTION
Emit a conservative load instead of erroring out if the `vmcnt` is larger than 6 bits (hardware limit).