### PR TITLE
[NFC] Fix signed/unsigned comparison.

### DIFF
--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -428,7 +428,8 @@ public:
   ArrayRef<int32_t> getBasis(StringAttr inDim, int32_t pos) const {
     auto it = bases.find(inDim);
     assert(it != bases.end());
-    assert(pos < it->second.size());
+    assert(pos >= 0);
+    assert(static_cast<size_t>(pos) < it->second.size());
     return it->second[pos];
   }
 


### PR DESCRIPTION
Fixing a compiler warning generated from comparison of integers of different signs (int vs size_t)

We build our backend with -Wextra which includes -Wsign-compare, so an accidental include of this header can break our build.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `Fixing a compile time warning and is a non-functional change`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
