### PR TITLE
[AMD] Added an extra test to mfma to linear layout conversion

### DIFF
--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -859,6 +859,20 @@ TEST_F(LinearLayoutConversionsTest, SliceDot) {
                 {S("dim0")}));
 }
 
+TEST_F(LinearLayoutConversionsTest, MFMA32_Skinny_Tensor) {
+  auto mfmaT = mfma(/*warps=*/{4, 1}, /*mDim=*/32, /*nDim=*/32,
+                    /*isTransposed=*/true);
+  auto testLinearLayout = toLinearLayout({128, 8}, mfmaT);
+
+  EXPECT_EQ(testLinearLayout,
+            LinearLayout(
+                {{S("register"), {{0, 1}, {0, 2}}},
+                 {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}, {0, 4}}},
+                 {S("warp"), {{32, 0}, {64, 0}}},
+                 {S("block"), {}}},
+                {S("dim0"), S("dim1")}));
+}
+
 TEST_F(LinearLayoutConversionsTest, MFMA32_2x4Warps) {
   auto mfmaNT = mfma(/*warps=*/{2, 4}, /*mDim=*/32, /*nDim=*/32,
                      /*isTransposed=*/false);


### PR DESCRIPTION
Conversion from `amd_mfma` to linear layout doesn't work as expected. It becomes noticeable when we extract a slice of a tensor with at least one dim smaller than a given MFMA instruction width. The reproducible example is given below:

```bash
> cat  ./extract-slice.mlir
// RUN: triton-opt %s -split-input-file -convert-triton-amdgpu-to-llvm='arch=gfx942' | FileCheck %s

#mma = #ttg.amd_mfma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [32, 32], isTransposed = true}>

module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 16384 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
  tt.func public @kernel(%arg0: tensor<128x64xf16, #mma>) attributes {noinline = false} { 
    %0 = amdgpu.extract_slice %arg0 [0,0] : tensor<128x64xf16, #mma> to tensor<128x8xf16, #mma>
    tt.return
  }
}
```