### PR TITLE
Allow tl.make_tensor_descriptor to produce 1D tensor descriptors

### DIFF
--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -133,7 +133,8 @@ sharedToLinearLayoutNoLeadingOffset(ArrayRef<int64_t> shape,
   int rank = shape.size();
   if (rank == 1) {
     return combineCtaCgaWithShape(
-        LinearLayout::identity1D(shape[0], S("offset"), S("dim0")),
+        LinearLayout::identity1D(shape[0] / shared.getCTASplitNum()[0],
+                                 S("offset"), S("dim0")),
         shared.getCTALayout(), shape);
   }
 
@@ -181,7 +182,8 @@ sharedToLinearLayoutAMDRotating(ArrayRef<int64_t> shape,
   int rank = shape.size();
   if (rank == 1) {
     return combineCtaCgaWithShape(
-        LinearLayout::identity1D(shape[0], S("offset"), S("dim0")),
+        LinearLayout::identity1D(shape[0] / shared.getCTASplitNum()[0],
+                                 S("offset"), S("dim0")),
         shared.getCTALayout(), shape);
   }
 
@@ -235,7 +237,8 @@ LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
   if (rank == 1) {
     // TODO: Not sure if this is correct.
     return combineCtaCgaWithShape(
-        LinearLayout::identity1D(shape[0], S("offset"), S("dim0")),
+        LinearLayout::identity1D(shape[0] / shared.getCTASplitNum()[0],
+                                 S("offset"), S("dim0")),
         shared.getCTALayout(), shape);
   }
   int elemBitWidth = shared.getElementBitWidth();

--- a/python/test/unit/cuda/test_tensor_descriptor.py
+++ b/python/test/unit/cuda/test_tensor_descriptor.py
@@ -254,7 +254,7 @@ def test_tensor_descriptor_store3d(dtype_str, K_BLOCK):
 @requires_tma
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
-@pytest.mark.parametrize("ndim", [2, 3, 4, 5])
+@pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
 @pytest.mark.parametrize("INNER_BLOCK", [16, 32, 64, 128])
 def test_tensor_descriptor_load_nd(dtype_str, num_ctas, ndim, INNER_BLOCK):
 
@@ -318,7 +318,7 @@ def test_tensor_descriptor_load_nd(dtype_str, num_ctas, ndim, INNER_BLOCK):
 @requires_tma
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
-@pytest.mark.parametrize("ndim", [2, 3, 4, 5])
+@pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
 @pytest.mark.parametrize("INNER_BLOCK", [16, 32, 64, 128])
 def test_tensor_descriptor_store_nd(dtype_str, num_ctas, ndim, INNER_BLOCK):
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1922,8 +1922,8 @@ def make_tensor_descriptor(
     builder: ir.builder,
 ) -> tl.tensor_descriptor:
     ndim = len(shape)
-    if not (2 <= ndim <= 5):
-        raise ValueError(f"Expected 2 <= ndim <= 5 but got {ndim} dimensions")
+    if not (1 <= ndim <= 5):
+        raise ValueError(f"Expected 1 <= ndim <= 5 but got {ndim} dimensions")
     if len(strides) != ndim:
         raise ValueError(f"Expected {ndim} strides but got {len(strides)}")
     if len(block_shape) != ndim:


### PR DESCRIPTION
This change relaxes the constraint on `tl.make_tensor_descriptor` to allow it to produce 1 dimensional tensor descriptors.

Currently this is supported in block pointers but is restricted for tensor descriptors. This generalises tensor descriptors so they can cover more of the block pointer use cases. This would help with deprecating block pointers but also makes tensor descriptors more flexible for other backends to make use of.

Adding the tests revealed a small bug for simple 1D layouts which weren't taking in to account the number of CTAs resulting in a shape mismatch during compilation.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
