### PR TITLE
Support Fp32->Fp16/Bf16 with packed conversion ops in GFX950

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -593,22 +593,19 @@ convertFp32ToFp16RTZ(Location loc, ConversionPatternRewriter &rewriter,
   return ret;
 }
 
-// Fp32->Fp16 (RTNE) in GFX950
+// Fp32->Fp16/Bf16 (RTNE) in GFX950
 static SmallVector<Value>
-convertPkFp32ToFp16(Location loc, ConversionPatternRewriter &rewriter,
-                    arith::TruncFOp op, MultipleOperandsRange operands) {
-  auto outElemTy = getElementType(op.getOut());
-  if (operands.size() == 1)
-    return {rewriter.create<LLVM::FPTruncOp>(loc, outElemTy, operands[0][0])};
+convertFp32ToFp16RTNE(Location loc, ConversionPatternRewriter &rewriter,
+                      const SmallVector<Value> &v, Type outElemTy) {
+  assert(v.size() == 2);
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  auto inElemTy = getElementType(op.getIn());
-  auto inVecTy = vec_ty(inElemTy, 2);
+  auto inVecTy = vec_ty(f32_ty, 2);
   auto retVecTy = vec_ty(outElemTy, 2);
   Value inVec = b.undef(inVecTy);
   auto idx0 = b.i32_val(0);
   auto idx1 = b.i32_val(1);
-  inVec = b.insert_element(inVecTy, inVec, operands[0][0], idx0);
-  inVec = b.insert_element(inVecTy, inVec, operands[1][0], idx1);
+  inVec = b.insert_element(inVecTy, inVec, v[0], idx0);
+  inVec = b.insert_element(inVecTy, inVec, v[1], idx1);
   Value retVec = rewriter.create<LLVM::FPTruncOp>(loc, retVecTy, inVec);
   SmallVector<Value> ret(2);
   ret[0] = b.extract_element(outElemTy, retVec, idx0);
@@ -677,6 +674,29 @@ static Value convertFp32ToBf16(Location loc,
   return b.bitcast(truncated, bf16_ty);
 }
 
+// Fp32_to_F16/Bf16
+static SmallVector<Value>
+Fp32_to_F16(Location loc, ConversionPatternRewriter &rewriter, Type inElemTy,
+            Type outElemTy, MultipleOperandsRange operands,
+            AMD::ISAFamily isaFamily, RoundingMode roundingMode) {
+  if (isaFamily == AMD::ISAFamily::CDNA4 &&
+      roundingMode == RoundingMode::RTNE) {
+    SmallVector<Value> inVals;
+    size_t numElem = std::min(size_t(2), operands.size());
+    inVals.reserve(numElem);
+    for (unsigned i = 0; i < numElem; i++) {
+      inVals.push_back(operands[i][0]);
+    }
+    return convertFp32ToFp16RTNE(loc, rewriter, inVals, outElemTy);
+  }
+
+  if (outElemTy.isBF16()) {
+    assert(inElemTy.isF32() && "unsupported conversion");
+    return {convertFp32ToBf16(loc, rewriter, operands[0][0], roundingMode)};
+  }
+  return {rewriter.create<LLVM::FPTruncOp>(loc, outElemTy, operands[0][0])};
+}
+
 static Value Fp8E5M2FNUZ_to_Fp16_oneValue(Location loc,
                                           ConversionPatternRewriter &rewriter,
                                           Value v) {
@@ -730,8 +750,8 @@ Fp8E5M2FNUZ_to_Fp16_HW(Location loc, ConversionPatternRewriter &rewriter,
       cvtPkF8ToFp32<ROCDL::CvtPkF32Bf8Op>(loc, rewriter, v[0], v[1]);
 
   // Convert fp32 to fp16
-  ret[0] = LLVM::AMD::cvtFp32ToFp16RTNE(loc, rewriter, ret[0]);
-  ret[1] = LLVM::AMD::cvtFp32ToFp16RTNE(loc, rewriter, ret[1]);
+  ret[0] = LLVM::AMD::cvtFp32ToFp16RTNE_oneValue(loc, rewriter, ret[0]);
+  ret[1] = LLVM::AMD::cvtFp32ToFp16RTNE_oneValue(loc, rewriter, ret[1]);
 
   return ret;
 }
@@ -1066,8 +1086,8 @@ Fp8E4M3FNUZ_to_Fp16_HW(Location loc, ConversionPatternRewriter &rewriter,
       cvtPkF8ToFp32<ROCDL::CvtPkF32Fp8Op>(loc, rewriter, v[0], v[1]);
 
   // Convert fp32 to fp16
-  ret[0] = LLVM::AMD::cvtFp32ToFp16RTNE(loc, rewriter, ret[0]);
-  ret[1] = LLVM::AMD::cvtFp32ToFp16RTNE(loc, rewriter, ret[1]);
+  ret[0] = LLVM::AMD::cvtFp32ToFp16RTNE_oneValue(loc, rewriter, ret[0]);
+  ret[1] = LLVM::AMD::cvtFp32ToFp16RTNE_oneValue(loc, rewriter, ret[1]);
 
   return ret;
 }
@@ -1258,28 +1278,19 @@ struct FpToFpOpConversion
     auto dstElementType = getElementType(op.getResult());
 
     auto roundingMode = op.getRounding();
-    if (srcElementType.isF32() && dstElementType.isF16() &&
-        roundingMode.value() == RoundingMode::RTNE) {
+    if (srcElementType.isF32() && dstElementType.isF16()) {
       assert(roundingMode.has_value() &&
              "rounding mode must be specified for fp32->fp16 conversion");
-      SmallVector<Value> outVals;
-      outVals.reserve(operands[0].size());
-      for (Value v : operands[0]) {
-        outVals.push_back(LLVM::AMD::cvtFp32ToFp16RTNE(loc, rewriter, v));
+      if (roundingMode.value() == RoundingMode::RTNE) {
+        return Fp32_to_F16(loc, rewriter, srcElementType, dstElementType,
+                           operands, isaFamily, RoundingMode::RTNE);
       }
-      return outVals;
     }
-
     if (srcElementType.isF32() && dstElementType.isBF16()) {
       assert(roundingMode.has_value() &&
              "rounding mode must be specified for fp32->bf16 conversion");
-      SmallVector<Value> outVals;
-      outVals.reserve(operands[0].size());
-      for (Value v : operands[0]) {
-        outVals.push_back(
-            convertFp32ToBf16(loc, rewriter, v, roundingMode.value()));
-      }
-      return outVals;
+      return Fp32_to_F16(loc, rewriter, srcElementType, dstElementType,
+                         operands, isaFamily, roundingMode.value());
     }
 
     // numElements = 4 for conversions:
@@ -1339,9 +1350,14 @@ struct FpToFpOpConversion
       }
       return outVals;
     }
-    if (useFP16IntermediateSrc)
-      for (Value &v : inVals)
-        v = LLVM::AMD::cvtFp32ToFp16RTNE(loc, rewriter, v);
+    if (useFP16IntermediateSrc) {
+      if (isaFamily == AMD::ISAFamily::CDNA4)
+        inVals = convertFp32ToFp16RTNE(loc, rewriter, inVals, f16_ty);
+      else {
+        for (Value &v : inVals)
+          v = LLVM::AMD::cvtFp32ToFp16RTNE_oneValue(loc, rewriter, v);
+      }
+    }
 
     inVals.resize(numElements, b.undef(typeConverter->convertType(srcType)));
     SmallVector<Value> outVals;
@@ -1591,31 +1607,26 @@ struct TruncFOpConversion
 
   explicit TruncFOpConversion(LLVMTypeConverter &typeConverter,
                               ModuleAxisInfoAnalysis &axisAnalysisPass,
-                              llvm::AMDGPU::GPUKind gpuKind,
+                              AMD::ISAFamily isaFamily,
                               PatternBenefit benefit = patternBenefitDefault)
       : ElementwiseOpConversionBase(typeConverter, axisAnalysisPass, benefit),
-        gpuKind(gpuKind) {}
+        isaFamily(isaFamily) {}
 
   SmallVector<Value> createDestOps(arith::TruncFOp op, OpAdaptor adaptor,
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
     auto outElemTy = getElementType(op.getOut());
-    if (gpuKind == llvm::AMDGPU::GK_GFX950 &&
-        (outElemTy.isBF16() || outElemTy.isF16()))
-      return convertPkFp32ToFp16(loc, rewriter, op, operands);
-    else if (outElemTy.isBF16()) {
-      auto inElemTy = getElementType(op.getIn());
-      assert(inElemTy.isF32() && "unsupported conversion");
-      return {
-          convertFp32ToBf16(loc, rewriter, operands[0][0], RoundingMode::RTNE)};
-    } else {
-      return {rewriter.create<LLVM::FPTruncOp>(loc, elemTy, operands[0][0])};
+    auto inElemTy = getElementType(op.getIn());
+    if (inElemTy.isF32() && (outElemTy.isBF16() || outElemTy.isF16())) {
+      return Fp32_to_F16(loc, rewriter, inElemTy, outElemTy, operands,
+                         isaFamily, RoundingMode::RTNE);
     }
+    return {rewriter.create<LLVM::FPTruncOp>(loc, elemTy, operands[0][0])};
   }
 
 private:
-  llvm::AMDGPU::GPUKind gpuKind;
+  AMD::ISAFamily isaFamily;
 };
 
 struct ExpOpConversionApprox
@@ -1894,7 +1905,7 @@ void populateElementwiseOpToLLVMPatterns(
 
   patterns.add<ExtFOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<TruncFOpConversion>(typeConverter, axisInfoAnalysis,
-                                   targetInfo.getGPUKind(), benefit);
+                                   targetInfo.getISAFamily(), benefit);
   patterns.add<FPToSIOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<SIToFPOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<FpToFpOpConversion>(typeConverter, axisInfoAnalysis,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
@@ -198,7 +198,8 @@ Value mxfpScaleFp16(RewriterBase &rewriter, Location loc, Value v, Value scale,
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value scaleF32 =
       b.bitcast(b.shl(b.zext(i32_ty, scale), b.i32_val(23)), f32_ty);
-  Value scaleF16 = LLVM::AMD::cvtFp32ToFp16RTNE_oneValue(loc, rewriter, scaleF32);
+  Value scaleF16 =
+      LLVM::AMD::cvtFp32ToFp16RTNE_oneValue(loc, rewriter, scaleF32);
   Value mulF16 = b.fmul(v, scaleF16);
   if (fastMath)
     return mulF16;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
@@ -198,7 +198,7 @@ Value mxfpScaleFp16(RewriterBase &rewriter, Location loc, Value v, Value scale,
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value scaleF32 =
       b.bitcast(b.shl(b.zext(i32_ty, scale), b.i32_val(23)), f32_ty);
-  Value scaleF16 = LLVM::AMD::cvtFp32ToFp16RTNE(loc, rewriter, scaleF32);
+  Value scaleF16 = LLVM::AMD::cvtFp32ToFp16RTNE_oneValue(loc, rewriter, scaleF32);
   Value mulF16 = b.fmul(v, scaleF16);
   if (fastMath)
     return mulF16;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -496,10 +496,10 @@ int32_t getCtrlBitsForCacheModifierOnTarget(
   }
 }
 
-Value cvtFp32ToFp16RTNE_oneValue(Location loc, RewriterBase &rewriter, const Value &v) {
+Value cvtFp32ToFp16RTNE_oneValue(Location loc, RewriterBase &rewriter,
+                                 const Value &v) {
   LLVM::RoundingMode rm = LLVM::RoundingMode::NearestTiesToEven;
-  return rewriter.create<LLVM::FPTruncOp>(
-      loc, f16_ty, v);
+  return rewriter.create<LLVM::FPTruncOp>(loc, f16_ty, v);
 }
 
 Type getPointerTypeWithShape(Value basePtr, Value offset) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -496,10 +496,10 @@ int32_t getCtrlBitsForCacheModifierOnTarget(
   }
 }
 
-Value cvtFp32ToFp16RTNE(Location loc, RewriterBase &rewriter, const Value &v) {
+Value cvtFp32ToFp16RTNE_oneValue(Location loc, RewriterBase &rewriter, const Value &v) {
   LLVM::RoundingMode rm = LLVM::RoundingMode::NearestTiesToEven;
-  return rewriter.create<LLVM::ConstrainedFPTruncIntr>(
-      loc, f16_ty, v, rm, LLVM::FPExceptionBehavior::Ignore);
+  return rewriter.create<LLVM::FPTruncOp>(
+      loc, f16_ty, v);
 }
 
 Type getPointerTypeWithShape(Value basePtr, Value offset) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -62,7 +62,7 @@ getCtrlBitsForCacheModifierOnTarget(triton::CacheModifier, bool,
 int32_t getCtrlBitsForBufferAtomicsOnGFX_942_950(bool setSC0, bool setSC1,
                                                  bool setNT);
 
-Value cvtFp32ToFp16RTNE(Location loc, RewriterBase &rewriter, const Value &v);
+Value cvtFp32ToFp16RTNE_oneValue(Location loc, RewriterBase &rewriter, const Value &v);
 
 // Return a tensor of pointers with the same type of `basePtr` and the same
 // shape of `offset`

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -62,7 +62,8 @@ getCtrlBitsForCacheModifierOnTarget(triton::CacheModifier, bool,
 int32_t getCtrlBitsForBufferAtomicsOnGFX_942_950(bool setSC0, bool setSC1,
                                                  bool setNT);
 
-Value cvtFp32ToFp16RTNE_oneValue(Location loc, RewriterBase &rewriter, const Value &v);
+Value cvtFp32ToFp16RTNE_oneValue(Location loc, RewriterBase &rewriter,
+                                 const Value &v);
 
 // Return a tensor of pointers with the same type of `basePtr` and the same
 // shape of `offset`


### PR DESCRIPTION
In GFX950, lower arith::TruncFOp to LLVM::FPTruncOp of vector types in order to generate packed conversion instructions v_cvt_pk_[b]f16_f32. 