### PR TITLE
[BENCH][AMD] Enable gfx942 for bench_mlp.py

### DIFF
--- a/bench/bench/bench_mlp.py
+++ b/bench/bench/bench_mlp.py
@@ -27,12 +27,19 @@ def _query_gpu_specs():
     else:
         cmd = ["rocm-smi", "--showproductname", "-d=0", "--csv"]
         output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode().strip()
-        name = output.splitlines()[1].split(",")[1]
+        model = output.splitlines()[1].split(",")[2]
+        if model in ["0x74a9", "0x74a1"]:
+            name = "AMD MI300X"
+        elif model == "0x74a5":
+            name = "AMD MI325X"
+        else:
+            name = "AMD"
 
     gpu_specs = {
         "NVIDIA H100 80GB HBM3": {"MAX_TFLOPS8": 1979, "MAX_TFLOPS16": 989, "MAX_TBPS": 3.35},
         "HGX GB200": {"MAX_TFLOPS8": 4500, "MAX_TFLOPS16": 2250, "MAX_TBPS": 8.0},
-        "AMD Instinct MI300X OAM": {"MAX_TFLOPS8": 2615, "MAX_TFLOPS16": 1307, "MAX_TBPS": 5.3},
+        "AMD Instinct MI300X": {"MAX_TFLOPS8": 2615, "MAX_TFLOPS16": 1307, "MAX_TBPS": 5.3},
+        "AMD Instinct MI325X": {"MAX_TFLOPS8": 2615, "MAX_TFLOPS16": 1307, "MAX_TBPS": 6.0},
     }
     return gpu_specs.get(name)
 

--- a/bench/bench/bench_mlp.py
+++ b/bench/bench/bench_mlp.py
@@ -10,7 +10,6 @@ from triton_bench.numerics import InFlexData
 from triton_bench.routing import routing, simulate_expert_sharded_routing
 from triton_bench.meta import cuda_capability_geq, is_hip, get_cdna_version
 
-
 if torch.cuda.is_available() and not is_hip():
     from triton._C.libtriton import nvidia
     cublas_workspace = torch.empty(32 * 1024 * 1024, device="cuda", dtype=torch.uint8)

--- a/bench/bench/bench_mlp.py
+++ b/bench/bench/bench_mlp.py
@@ -27,7 +27,7 @@ def _query_gpu_specs():
     else:
         cmd = ["rocm-smi", "--showproductname", "-d=0", "--csv"]
         output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode().strip()
-        name = output.splitlines()[1]
+        name = output.splitlines()[1].split(",")[1]
 
     gpu_specs = {
         "NVIDIA H100 80GB HBM3": {"MAX_TFLOPS8": 1979, "MAX_TFLOPS16": 989, "MAX_TBPS": 3.35},
@@ -37,7 +37,7 @@ def _query_gpu_specs():
     return gpu_specs.get(name)
 
 
-SPECS = _query_gpu_specs() if not is_hip() else None
+SPECS = _query_gpu_specs()
 
 
 def quantize(w, dtype, dev, **opt):

--- a/bench/bench/bench_mlp.py
+++ b/bench/bench/bench_mlp.py
@@ -32,7 +32,7 @@ def _query_gpu_specs():
     gpu_specs = {
         "NVIDIA H100 80GB HBM3": {"MAX_TFLOPS8": 1979, "MAX_TFLOPS16": 989, "MAX_TBPS": 3.35},
         "HGX GB200": {"MAX_TFLOPS8": 4500, "MAX_TFLOPS16": 2250, "MAX_TBPS": 8.0},
-        "AMD Instinct MI300X OAM": {"MAX_TFLOPS8": 2615, "MAX_TFLOPS16": 1307 , "MAX_TBPS": 5.3},
+        "AMD Instinct MI300X OAM": {"MAX_TFLOPS8": 2615, "MAX_TFLOPS16": 1307, "MAX_TBPS": 5.3},
     }
     return gpu_specs.get(name)
 

--- a/bench/triton_bench/matmul_ogs_details/opt_flags_amd.py
+++ b/bench/triton_bench/matmul_ogs_details/opt_flags_amd.py
@@ -1,10 +1,7 @@
 import torch
 import triton
 
-
-def is_hip_cdna4():
-    target = triton.runtime.driver.active.get_current_target()
-    return target.backend == 'hip' and target.arch == 'gfx950'
+from triton_bench.meta import get_cdna_version
 
 
 def compute_block_nk(n, block_m, grid_m, num_xcds, lhs_dtype, rhs_dtype, microscaling_ctx):
@@ -23,7 +20,7 @@ def compute_block_nk(n, block_m, grid_m, num_xcds, lhs_dtype, rhs_dtype, microsc
     else:
         block_n = 128
 
-    if is_hip_cdna4() and block_m == 128:
+    if get_cdna_version() == 4 and block_m == 128:
         block_n = 512
 
     # block_k needs to match the cacheline size (128B)

--- a/bench/triton_bench/meta.py
+++ b/bench/triton_bench/meta.py
@@ -91,19 +91,18 @@ def cuda_capability_geq(major, minor=0):
 @constexpr_function
 def get_cdna_version():
     """
-    Get the AMD architecture version, i.e. CDNA3 or CDNA4, currently
+    Gets the AMD architecture version, i.e. CDNA3 or CDNA4, currently
     only supports 3 (gfx942) or 4 (gfx950). Returns -1 if either not AMD
     or unsupported architecture
     """
     target = triton.runtime.driver.active.get_current_target()
     if target.backend != 'hip':
         return -1
-    elif target.arch == 'gfx942':
+    if target.arch == 'gfx942':
         return 3
-    elif target.arch == 'gfx950':
+    if target.arch == 'gfx950':
         return 4
-    else:
-        return -1
+    return -1
 
 
 @constexpr_function

--- a/bench/triton_bench/meta.py
+++ b/bench/triton_bench/meta.py
@@ -87,6 +87,23 @@ def cuda_capability_geq(major, minor=0):
             cached_capabilities["cuda"] = (0, 0)
     return cached_capabilities["cuda"] >= (major, minor)
 
+@constexpr_function
+def get_cdna_version():
+    """
+    Get the AMD architecture version, i.e. CDNA3 or CDNA4, currently
+    only supports 3 (gfx942) or 4 (gfx950). Returns -1 if either not AMD
+    or unsupported architecture
+    """
+    target = triton.runtime.driver.active.get_current_target()
+    if target.backend != 'hip':
+        return -1
+    elif target.arch == 'gfx942':
+        return 3
+    elif target.arch == 'gfx950':
+        return 4
+    else:
+        return -1
+
 
 @constexpr_function
 def num_sms():

--- a/bench/triton_bench/meta.py
+++ b/bench/triton_bench/meta.py
@@ -92,8 +92,8 @@ def cuda_capability_geq(major, minor=0):
 def get_cdna_version():
     """
     Gets the AMD architecture version, i.e. CDNA3 or CDNA4, currently
-    only supports 3 (gfx942) or 4 (gfx950). Returns -1 if either not AMD
-    or unsupported architecture
+    only supports 3 (gfx942) or 4 (gfx950). Returns -1 if it is not AMD
+    hardware or unsupported architecture
     """
     target = triton.runtime.driver.active.get_current_target()
     if target.backend != 'hip':

--- a/bench/triton_bench/meta.py
+++ b/bench/triton_bench/meta.py
@@ -87,6 +87,7 @@ def cuda_capability_geq(major, minor=0):
             cached_capabilities["cuda"] = (0, 0)
     return cached_capabilities["cuda"] >= (major, minor)
 
+
 @constexpr_function
 def get_cdna_version():
     """


### PR DESCRIPTION
This PR fixed the failure of running `bench_mlp.py` on AMD MI300 GPU. 

## Main Fix
The script always uses `torch.float8_e4m3fn` but MI300 uses the special torch.float8_e4m3fnuz` type. 

## Refactoring
Since now we have two different checks to do on the AMD platform since it would have different behaviors depending on it is CDNA3 or CDNA4, I refactored the code slightly to make it cleaner.