### PR TITLE
[DIALECT] Clean up memory effect definitions (NFC)

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -77,7 +77,6 @@ def TTG_AsyncCommitGroupOp : TTG_Op<"async_commit_group"> {
 
 def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
   AttrSizedOperandSegments,
-  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
   TypesMatchWith<"infer mask type from src type",
                  "src", "mask", "getI1SameShape($_self)",
                  "($_op.getOperands().size() <= 3) || std::equal_to<>()">,
@@ -95,9 +94,9 @@ def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
     operands are the same as tt.load.
   }];
 
-  let arguments = (
-    ins TT_PtrTensor:$src,
-    TTG_MemDescType:$result,
+  let arguments = (ins
+    Arg<TT_PtrTensor, "", [MemRead<GlobalMemory>]>:$src,
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$result,
     Optional<I1Tensor>:$mask,
     Optional<TT_Type>:$other,
     DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache,
@@ -251,13 +250,16 @@ def TTG_MemDescTransOp : TTG_Op<"memdesc_trans", [Pure,
   let hasFolder = 1;
 }
 
-def TTG_LocalLoadOp : TTG_Op<"local_load", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTG_LocalLoadOp : TTG_Op<"local_load"> {
   let summary = "Load a buffer from local memory into a distributed tensor";
 
   let description = [{
     Load a tensor from the local memory descriptor into a distributed tensor.
   }];
-  let arguments = (ins TTG_MemDescType:$src, Optional<TTG_AsyncToken> :$token);
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
+    Optional<TTG_AsyncToken>:$token
+  );
 
   let builders = [
       OpBuilder<(ins "Type":$retType, "Value":$src),
@@ -271,13 +273,16 @@ def TTG_LocalLoadOp : TTG_Op<"local_load", [DeclareOpInterfaceMethods<MemoryEffe
   let results = (outs TT_Tensor:$result);
 }
 
-def TTG_LocalStoreOp : TTG_Op<"local_store", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTG_LocalStoreOp : TTG_Op<"local_store"> {
   let summary = "Store a distributed tensor into a buffer in local memory";
 
   let description = [{
     Store a distributed tensor into a buffer in local memory.
   }];
-  let arguments = (ins TT_Tensor:$src, TTG_MemDescType:$dst);
+  let arguments = (ins
+    TT_Tensor:$src,
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst
+  );
 
   let hasVerifier = 1;
   // Use qualified() otherwise "!ttg.memdesc<X>" is printed as "<X>".

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -39,6 +39,7 @@ include "mlir/Interfaces/ViewLikeInterface.td"
 
 def GlobalMemory : Resource<"::mlir::triton::GlobalMemory">;
 def SharedMemory : Resource<"::mlir::triton::gpu::SharedMemory">;
+def TensorMemory : Resource<"::mlir::triton::nvidia_gpu::TensorMemory">;
 
 class TTNG_Op<string mnemonic, list<Trait> traits = []> :
     Op<TritonNvidiaGPU_Dialect, mnemonic,
@@ -115,39 +116,41 @@ def TTNG_WarpGroupDotWaitOp : TTNG_Op<"warp_group_dot_wait", [DeclareOpInterface
   let assemblyFormat = "$inputs attr-dict `:` type($inputs)";
 }
 
-def TTNG_InitBarrierOp : TTNG_Op<"init_barrier", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-    let summary = "Initialize a barrier in the given shared memory allocation.";
+def TTNG_InitBarrierOp : TTNG_Op<"init_barrier"> {
+  let summary = "Initialize a barrier in the given shared memory allocation.";
 
-    let description = [{
-        Initializes a shared memory allocation with mbarrier information.
-        `alloc` is a descriptor to the shared memory allocation. `count` is the
-        number of arrives expected by the barrier.
+  let description = [{
+      Initializes a shared memory allocation with mbarrier information.
+      `alloc` is a descriptor to the shared memory allocation. `count` is the
+      number of arrives expected by the barrier.
 
-        This lowers to PTX mbarrier.init.shared::cta.b64.
-    }];
+      This lowers to PTX mbarrier.init.shared::cta.b64.
+  }];
 
-    let hasVerifier = 1;
-    let arguments = (ins TTG_MemDescType:$alloc,
-                         I32Attr:$count);
-    let assemblyFormat = "$alloc `,` $count attr-dict `:` qualified(type($alloc))";
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$alloc,
+    I32Attr:$count
+  );
+  let assemblyFormat = "$alloc `,` $count attr-dict `:` qualified(type($alloc))";
+  let hasVerifier = 1;
 }
 
-def TTNG_InvalBarrierOp : TTNG_Op<"inval_barrier", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-    let summary = "Invalidate a barrier allocation.";
+def TTNG_InvalBarrierOp : TTNG_Op<"inval_barrier"> {
+  let summary = "Invalidate a barrier allocation.";
 
-    let description = [{
-      Invalidate a barrier allocation so that it can be re-used. According to PTX
-      spec this has to be done before any reuse of the memory used by mbarrier.
+  let description = [{
+    Invalidate a barrier allocation so that it can be re-used. According to PTX
+    spec this has to be done before any reuse of the memory used by mbarrier.
 
-      https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-inval
-    }];
+    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-inval
+  }];
 
-    let hasVerifier = 1;
-    let arguments = (ins TTG_MemDescType:$alloc);
-    let assemblyFormat = "$alloc attr-dict `:` qualified(type($alloc))";
+  let hasVerifier = 1;
+  let arguments = (ins Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$alloc);
+  let assemblyFormat = "$alloc attr-dict `:` qualified(type($alloc))";
 }
 
-def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect"> {
   let summary = "Signal a barrier of an expected number of bytes to be copied.";
 
   let description = [{
@@ -156,8 +159,8 @@ def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [DeclareOpInterfaceMethods<
   }];
 
   let hasVerifier = 1;
-  let arguments = (
-    ins TTG_MemDescType:$alloc,
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$alloc,
     I32Attr:$size,
     I1:$pred
   );
@@ -167,48 +170,53 @@ def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [DeclareOpInterfaceMethods<
   }];
 }
 
-def TTNG_WaitBarrierOp : TTNG_Op<"wait_barrier", [
-      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-      AttrSizedOperandSegments]> {
-    let summary = "wait until the mbarrier phase completes.";
+def TTNG_WaitBarrierOp : TTNG_Op<"wait_barrier", [AttrSizedOperandSegments]> {
+  let summary = "wait until the mbarrier phase completes.";
 
-    let description = [{
-      Blocks the program progress until the mbarrier object in `alloc` completes
-      its current phase.
+  let description = [{
+    Blocks the program progress until the mbarrier object in `alloc` completes
+    its current phase.
 
-      This lowers a waitloop using PTX instruction
-      mbarrier.try_wait.parity.shared.b64.
+    This lowers a waitloop using PTX instruction
+    mbarrier.try_wait.parity.shared.b64.
 
-      Accepts optional list of memory. If present, it is assumed that any of the
-      dependencies may be accessed until the barrier completes.
+    Accepts optional list of memory. If present, it is assumed that any of the
+    dependencies may be accessed until the barrier completes.
 
-      The barrier behavior is described here:
-      https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-asynchronous-copy-completion-mechanisms
-    }];
+    The barrier behavior is described here:
+    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-asynchronous-copy-completion-mechanisms
+  }];
 
-    let hasVerifier = 1;
-    let arguments = (ins TTG_MemDescType:$alloc,
-                         I32:$phase,
-                         Optional<I1>:$pred,
-                         Variadic<TTG_MemDescType>:$deps);
-    let builders = [
-      OpBuilder<(ins "Value":$alloc, "Value":$phase),
-      [{
-      build($_builder, $_state, alloc, phase, /*pred=*/static_cast<mlir::Value>(nullptr), /*deps=*/{});
-      }]>,
-      OpBuilder<(ins "Value":$alloc, "Value":$phase, "Value":$pred),
-      [{
-      build($_builder, $_state, alloc, phase, pred, /*deps=*/{});
-      }]>,
-      OpBuilder<(ins "Value":$alloc, "Value":$phase, "ValueRange":$deps),
-      [{
-      build($_builder, $_state, alloc, phase, /*pred=*/static_cast<mlir::Value>(nullptr), deps);
-      }]>,
-    ];
-    let assemblyFormat = "$alloc `,` $phase (`,` $pred^)? (`deps` $deps^)? attr-dict `:` qualified(type($alloc)) (`,` type($deps)^)?";
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$alloc,
+    I32:$phase,
+    Optional<I1>:$pred,
+    Variadic<TTG_MemDescType>:$deps
+  );
+
+  let builders = [
+    OpBuilder<(ins "Value":$alloc, "Value":$phase),
+    [{
+    build($_builder, $_state, alloc, phase, /*pred=*/static_cast<mlir::Value>(nullptr), /*deps=*/{});
+    }]>,
+    OpBuilder<(ins "Value":$alloc, "Value":$phase, "Value":$pred),
+    [{
+    build($_builder, $_state, alloc, phase, pred, /*deps=*/{});
+    }]>,
+    OpBuilder<(ins "Value":$alloc, "Value":$phase, "ValueRange":$deps),
+    [{
+    build($_builder, $_state, alloc, phase, /*pred=*/static_cast<mlir::Value>(nullptr), deps);
+    }]>,
+  ];
+
+  let assemblyFormat = [{
+    $alloc `,` $phase (`,` $pred^)? (`deps` $deps^)?
+    attr-dict `:` qualified(type($alloc)) (`,` type($deps)^)?
+  }];
+  let hasVerifier = 1;
 }
 
-def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier"> {
   let summary = "perform the arrive operation on an mbarrier";
   let description = [{
     The `ttng.arrive_barrier` operation performs the "arrive" operation on an
@@ -227,7 +235,7 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier", [DeclareOpInterfaceMethods<
   }];
 
   let arguments = (ins
-    TTG_MemDescType:$alloc,
+    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$alloc,
     I32Attr:$count,
     Optional<I1>:$pred
   );
@@ -266,7 +274,7 @@ def TTNG_TensorDescToTMAPtrOp : TTNG_Op<"tensor_desc_to_tma_ptr", [Pure]> {
 }
 
 
-def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local"> {
   let summary = "copy data based on descriptor from global memory to local memory asynchronously";
 
   let description = [{
@@ -278,11 +286,11 @@ def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local",
   }];
 
   let hasVerifier = 1;
-  let arguments = (
-    ins TT_PtrType:$desc_ptr,
+  let arguments = (ins
+    Arg<TT_PtrType, "", [MemRead<GlobalMemory>]>:$desc_ptr,
     Variadic<I32>:$coord,
-    TTG_MemDescType:$barrier,
-    TTG_MemDescType:$result,
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$barrier,
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$result,
     I1:$pred,
     DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache,
     DefaultValuedAttr<TT_EvictionPolicyAttr, "triton::EvictionPolicy::NORMAL">:$evict,
@@ -296,7 +304,7 @@ def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local",
   }];
 }
 
-def TTNG_AsyncTMACopyLocalToGlobalOp : TTNG_Op<"async_tma_copy_local_to_global", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTNG_AsyncTMACopyLocalToGlobalOp : TTNG_Op<"async_tma_copy_local_to_global"> {
   let summary = "copy data based on descriptor from local memory to global memory asynchronously";
 
   let description = [{
@@ -307,10 +315,11 @@ def TTNG_AsyncTMACopyLocalToGlobalOp : TTNG_Op<"async_tma_copy_local_to_global",
     by `desc_ptr`.
   }];
 
-  let arguments = (
-    ins TT_PtrType:$desc_ptr,
+  let arguments = (ins
+    Arg<TT_PtrType, "", [MemWrite<GlobalMemory>]>:$desc_ptr,
     Variadic<I32>:$coord,
-    TTG_MemDescType:$src);
+    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src
+  );
 
   let assemblyFormat = [{
     $desc_ptr `[` $coord `]` $src
@@ -318,7 +327,7 @@ def TTNG_AsyncTMACopyLocalToGlobalOp : TTNG_Op<"async_tma_copy_local_to_global",
   }];
 }
 
-def TTNG_AsyncTMAGatherOp : TTNG_Op<"async_tma_gather", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTNG_AsyncTMAGatherOp : TTNG_Op<"async_tma_gather"> {
   let summary = "gather data based on descriptor from global memory to local memory asynchronously";
 
   let description = [{
@@ -328,11 +337,11 @@ def TTNG_AsyncTMAGatherOp : TTNG_Op<"async_tma_gather", [DeclareOpInterfaceMetho
   }];
 
   let arguments = (ins
-    TT_PtrType:$desc_ptr,
+    Arg<TT_PtrType, "", [MemRead<GlobalMemory>]>:$desc_ptr,
     RankedTensorOf<[I32]>:$x_offsets,
     I32:$y_offset,
-    TTG_MemDescType:$barrier,
-    TTG_MemDescType:$result,
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$barrier,
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$result,
     I1:$pred
   );
 
@@ -344,7 +353,7 @@ def TTNG_AsyncTMAGatherOp : TTNG_Op<"async_tma_gather", [DeclareOpInterfaceMetho
   let hasVerifier = 1;
 }
 
-def TTNG_AsyncTMAScatterOp : TTNG_Op<"async_tma_scatter", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTNG_AsyncTMAScatterOp : TTNG_Op<"async_tma_scatter"> {
   let summary = "scatter data from local memory into global memory based on a descriptor asynchronously";
 
   let description = [{
@@ -356,10 +365,10 @@ def TTNG_AsyncTMAScatterOp : TTNG_Op<"async_tma_scatter", [DeclareOpInterfaceMet
   }];
 
   let arguments = (ins
-    TT_PtrType:$desc_ptr,
+    Arg<TT_PtrType, "", [MemWrite<GlobalMemory>]>:$desc_ptr,
     RankedTensorOf<[I32]>:$x_offsets,
     I32:$y_offset,
-    TTG_MemDescType:$src
+    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src
   );
 
   let assemblyFormat = [{
@@ -545,7 +554,7 @@ def TTNG_TMEMSubSliceOp : TTNG_Op<"tmem_subslice", [Pure]> {
   let hasVerifier = 1;
 }
 
-def TTNG_TMEMCopyOp : TTNG_Op<"tmem_copy", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTNG_TMEMCopyOp : TTNG_Op<"tmem_copy", [MemoryEffects<[MemWrite<TensorMemory>]>]> {
   let summary = "Initiate an asynchronous copy operation from shared memory to the Tensor Memory.";
 
   let description = [{
@@ -589,7 +598,11 @@ def TTNG_TMEMCopyOp : TTNG_Op<"tmem_copy", [DeclareOpInterfaceMethods<MemoryEffe
     In the absence of such operations on memdesc, we resort to implicitly encoding the reshape/transpose semantics in tmem_copy.
 
   }];
-  let arguments = (ins TTG_MemDescType:$src, TTG_MemDescType:$dst, Optional<TTG_MemDescType>:$barrier);
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
+    TTG_MemDescType:$dst,
+    Optional<TTG_MemDescType>:$barrier
+  );
 
   let assemblyFormat = [{$src `,` $dst `,` $barrier attr-dict `:` functional-type(operands, results)}];
   let hasVerifier = 1;

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -17,10 +17,9 @@ void LoadOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   effects.emplace_back(MemoryEffects::Read::get(), &getPtrMutable(),
-                       triton::GlobalMemory::get());
+                       GlobalMemory::get());
   if (getIsVolatile())
-    effects.emplace_back(MemoryEffects::Write::get(),
-                         SideEffects::DefaultResource::get());
+    effects.emplace_back(MemoryEffects::Write::get());
 }
 
 } // namespace triton
@@ -1177,10 +1176,8 @@ void ElementwiseInlineAsmOp::getEffects(
         &effects) {
   if (getPure())
     return;
-  effects.emplace_back(MemoryEffects::Write::get(),
-                       SideEffects::DefaultResource::get());
-  effects.emplace_back(MemoryEffects::Read::get(),
-                       SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Write::get());
+  effects.emplace_back(MemoryEffects::Read::get());
 }
 
 Speculation::Speculatability ElementwiseInlineAsmOp::getSpeculatability() {
@@ -1209,10 +1206,8 @@ void ExternElementwiseOp::getEffects(
         &effects) {
   if (getPure())
     return;
-  effects.emplace_back(MemoryEffects::Write::get(),
-                       SideEffects::DefaultResource::get());
-  effects.emplace_back(MemoryEffects::Read::get(),
-                       SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Write::get());
+  effects.emplace_back(MemoryEffects::Read::get());
 }
 
 Speculation::Speculatability ExternElementwiseOp::getSpeculatability() {

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -452,12 +452,10 @@ void LocalAllocOp::getEffects(
   // op.
   if (!getType().getMutableMemory() && !op->hasAttr("allocation.offset"))
     return;
-  effects.emplace_back(MemoryEffects::Allocate::get(),
-                       mlir::triton::gpu::SharedMemory::get());
+  effects.emplace_back(MemoryEffects::Allocate::get(), SharedMemory::get());
   if (getSrc())
     effects.emplace_back(MemoryEffects::Write::get(),
-                         getOperation()->getOpResult(0),
-                         mlir::triton::gpu::SharedMemory::get());
+                         getOperation()->getOpResult(0), SharedMemory::get());
 }
 
 OpFoldResult LocalAllocOp::fold(FoldAdaptor adaptor) {
@@ -490,14 +488,6 @@ LogicalResult LocalAllocOp::verify() {
   return success();
 }
 
-// LocalLoadOp
-void LocalLoadOp::getEffects(
-    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
-        &effects) {
-  effects.emplace_back(MemoryEffects::Read::get(), &getSrcMutable(),
-                       mlir::triton::gpu::SharedMemory::get());
-}
-
 // LocalStoreOp
 LogicalResult LocalStoreOp::verify() {
   if (!getDst().getType().getMutableMemory())
@@ -505,27 +495,11 @@ LogicalResult LocalStoreOp::verify() {
   return success();
 }
 
-void LocalStoreOp::getEffects(
-    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
-        &effects) {
-  effects.emplace_back(MemoryEffects::Write::get(), &getDstMutable(),
-                       mlir::triton::gpu::SharedMemory::get());
-}
-
 // AsyncCopyGlobalToLocalOp
 LogicalResult AsyncCopyGlobalToLocalOp::verify() {
   if (!getResult().getType().getMutableMemory())
     return emitOpError("Cannot store into immutable memory");
   return success();
-}
-
-void AsyncCopyGlobalToLocalOp::getEffects(
-    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
-        &effects) {
-  effects.emplace_back(MemoryEffects::Read::get(), &getSrcMutable(),
-                       mlir::triton::GlobalMemory::get());
-  effects.emplace_back(MemoryEffects::Write::get(), &getResultMutable(),
-                       mlir::triton::gpu::SharedMemory::get());
 }
 
 LogicalResult MemDescSubviewOp::verify() {

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -423,7 +423,6 @@ LogicalResult TMEMStoreOp::verify() {
 }
 
 // -- TMEMLoadOp --
-// -- TMEMLoadOp --
 LogicalResult TMEMLoadOp::verify() {
   if (!isa<triton::nvidia_gpu::TensorMemorySpaceAttr>(
           getSrc().getType().getMemorySpace()))


### PR DESCRIPTION
This is an NFC reland of #6476. I am splitting out the functional changes so that we can narrow done the commit that is causing a bitwise equivalence problem in an internal test.
