### PR TITLE
Expose max_threads_per_block to avoid launch failures and improve autotune robustness

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -224,4 +224,5 @@ def test_exceed_threads(device):
 
     add_kernel[grid](x, y, output, x.numel(), BLOCK_SIZE=128)
 
-    assert exception_out_of_resource is not None and "out of resource: threads, Required: 4096" in str(exception_out_of_resource)
+    assert exception_out_of_resource is not None and "out of resource: threads, Required: 4096" in str(
+        exception_out_of_resource)

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -186,3 +186,42 @@ def test_exceed_tmem(device):
     assert exception_out_of_resource is not None and str(
         exception_out_of_resource
     ) == "out of resource: tensor memory, Required: 640, Hardware limit: 512. Reducing block sizes or `num_stages` may help."
+
+
+def test_exceed_threads(device):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    x = torch.empty(1024, device=device, dtype=torch.float32)
+    y = torch.empty_like(x)
+    output = torch.empty_like(x)
+
+    configs = [
+        triton.Config({}, num_warps=128),
+        triton.Config({}, num_warps=4),
+    ]
+
+    exception_out_of_resource = None
+
+    def _post_hook(*args, exception):
+        nonlocal exception_out_of_resource
+        if exception is not None:
+            exception_out_of_resource = exception
+
+    @triton.autotune(configs=configs, key=['BLOCK_SIZE'], do_bench=do_bench, post_hook=_post_hook)
+    @triton.jit
+    def add_kernel(x_ptr, y_ptr, output_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+        pid = tl.program_id(0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(x_ptr + offsets, mask=mask)
+        y = tl.load(y_ptr + offsets, mask=mask)
+        output = x + y
+        tl.store(output_ptr + offsets, output, mask=mask)
+
+    def grid(meta):
+        return (triton.cdiv(x.numel(), meta['BLOCK_SIZE']), )
+
+    add_kernel[grid](x, y, output, x.numel(), BLOCK_SIZE=128)
+
+    assert exception_out_of_resource is not None and "out of resource: threads, Required: 4096" in str(exception_out_of_resource)

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -224,5 +224,6 @@ def test_exceed_threads(device):
 
     add_kernel[grid](x, y, output, x.numel(), BLOCK_SIZE=128)
 
-    assert exception_out_of_resource is not None and "out of resource: threads, Required: 4096" in str(
+    warp_size = triton.runtime.driver.active.get_current_target().warp_size
+    assert exception_out_of_resource is not None and f"out of resource: threads, Required: {128 * warp_size}" in str(
         exception_out_of_resource)

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -415,11 +415,11 @@ class CompiledKernel:
             if self.metadata.tmem_size > max_tmem_size:
                 raise OutOfResources(self.metadata.tmem_size, max_tmem_size, "tensor memory")
         # TODO: n_regs, n_spills should be metadata generated when calling `ptxas`
-        self.module, self.function, self.n_regs, self.n_spills, self.n_threads = driver.active.utils.load_binary(
+        self.module, self.function, self.n_regs, self.n_spills, self.n_max_threads = driver.active.utils.load_binary(
             self.name, self.kernel, self.metadata.shared, device)
         warp_size = driver.active.get_current_target().warp_size
-        if self.metadata.num_warps * warp_size > self.n_threads:
-            raise OutOfResources(self.metadata.num_warps * warp_size, self.n_threads, "threads")
+        if self.metadata.num_warps * warp_size > self.n_max_threads:
+            raise OutOfResources(self.metadata.num_warps * warp_size, self.n_max_threads, "threads")
 
     def __getattribute__(self, name):
         if name == 'run':

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -417,8 +417,9 @@ class CompiledKernel:
         # TODO: n_regs, n_spills should be metadata generated when calling `ptxas`
         self.module, self.function, self.n_regs, self.n_spills, self.n_threads = driver.active.utils.load_binary(
             self.name, self.kernel, self.metadata.shared, device)
-        if self.metadata.num_warps * 32 > self.n_threads:
-            raise OutOfResources(self.metadata.num_warps * 32, self.n_threads, "threads")
+        warp_size = driver.active.get_current_target().warp_size
+        if self.metadata.num_warps * warp_size > self.n_threads:
+            raise OutOfResources(self.metadata.num_warps * warp_size, self.n_threads, "threads")
 
     def __getattribute__(self, name):
         if name == 'run':

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -415,8 +415,10 @@ class CompiledKernel:
             if self.metadata.tmem_size > max_tmem_size:
                 raise OutOfResources(self.metadata.tmem_size, max_tmem_size, "tensor memory")
         # TODO: n_regs, n_spills should be metadata generated when calling `ptxas`
-        self.module, self.function, self.n_regs, self.n_spills = driver.active.utils.load_binary(
+        self.module, self.function, self.n_regs, self.n_spills, self.n_threads = driver.active.utils.load_binary(
             self.name, self.kernel, self.metadata.shared, device)
+        if self.metadata.num_warps * 32 > self.n_threads:
+            raise OutOfResources(self.metadata.num_warps * 32, self.n_threads, "threads")
 
     def __getattribute__(self, name):
         if name == 'run':

--- a/python/triton/runtime/errors.py
+++ b/python/triton/runtime/errors.py
@@ -19,7 +19,7 @@ class OutOfResources(TritonError):
         self.name = name
 
     def __str__(self) -> str:
-        return f"out of resource: {self.name}, Required: {self.required}, Hardware limit: {self.limit}. Reducing block sizes, `num_stages` or `num_warps` may help."
+        return f"out of resource: {self.name}, Required: {self.required}, Hardware limit: {self.limit}. Reducing block sizes or `num_stages` may help."
 
     def __reduce__(self):
         # this is necessary to make CompilationError picklable

--- a/python/triton/runtime/errors.py
+++ b/python/triton/runtime/errors.py
@@ -19,7 +19,7 @@ class OutOfResources(TritonError):
         self.name = name
 
     def __str__(self) -> str:
-        return f"out of resource: {self.name}, Required: {self.required}, Hardware limit: {self.limit}. Reducing block sizes or `num_stages` may help."
+        return f"out of resource: {self.name}, Required: {self.required}, Hardware limit: {self.limit}. Reducing block sizes, `num_stages` or `num_warps` may help."
 
     def __reduce__(self):
         # this is necessary to make CompilationError picklable

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -1,6 +1,5 @@
 from triton.backends.compiler import BaseBackend, GPUTarget
 from triton._C.libtriton import ir, passes, llvm, amd
-from triton.runtime.errors import OutOfResources
 from dataclasses import dataclass
 from typing import Any, Dict, Tuple
 from types import ModuleType
@@ -73,13 +72,6 @@ class HIPOptions:
         gfx_major = int(self.arch[3:-2])  # Drop "gfx" prefix and minor/patch number
         warp_size = 32 if gfx_major >= 10 else 64
         object.__setattr__(self, 'warp_size', warp_size)
-
-        # Error out if max threads per block is exceeded.
-        # This is theoretically architecture specific but in reality they are all 1024.
-        max_threads = 1024
-        if self.num_warps * warp_size > max_threads:
-            raise OutOfResources(self.num_warps * warp_size, max_threads, "threads")
-
         assert self.num_warps > 0 and (self.num_warps & (self.num_warps - 1)) == 0, \
                "num_warps must be a power of 2"
 

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -172,15 +172,18 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   // get allocated registers and spilled registers from the function
   int n_regs = 0;
   int n_spills = 0;
+  int32_t n_threads = 0;
   hipSymbolTable.hipFuncGetAttribute(&n_regs, HIP_FUNC_ATTRIBUTE_NUM_REGS, fun);
   hipSymbolTable.hipFuncGetAttribute(&n_spills,
                                      HIP_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, fun);
+  hipSymbolTable.hipFuncGetAttribute(
+      &n_threads, HIP_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, fun);
   n_spills /= 4;
   if (PyErr_Occurred()) {
     return NULL;
   }
-  return Py_BuildValue("(KKii)", (uint64_t)mod, (uint64_t)fun, n_regs,
-                       n_spills);
+  return Py_BuildValue("(KKiii)", (uint64_t)mod, (uint64_t)fun, n_regs,
+                       n_spills, n_threads);
 }
 
 static PyMethodDef ModuleMethods[] = {

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -172,18 +172,18 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   // get allocated registers and spilled registers from the function
   int n_regs = 0;
   int n_spills = 0;
-  int32_t n_threads = 0;
+  int32_t n_max_threads = 0;
   hipSymbolTable.hipFuncGetAttribute(&n_regs, HIP_FUNC_ATTRIBUTE_NUM_REGS, fun);
   hipSymbolTable.hipFuncGetAttribute(&n_spills,
                                      HIP_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, fun);
   hipSymbolTable.hipFuncGetAttribute(
-      &n_threads, HIP_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, fun);
+      &n_max_threads, HIP_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, fun);
   n_spills /= 4;
   if (PyErr_Occurred()) {
     return NULL;
   }
   return Py_BuildValue("(KKiii)", (uint64_t)mod, (uint64_t)fun, n_regs,
-                       n_spills, n_threads);
+                       n_spills, n_max_threads);
 }
 
 static PyMethodDef ModuleMethods[] = {

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -103,7 +103,7 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   CUmodule mod;
   int32_t n_regs = 0;
   int32_t n_spills = 0;
-  int32_t n_threads = 0;
+  int32_t n_max_threads = 0;
   // create driver handles
   CUcontext pctx = 0;
 
@@ -125,7 +125,7 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
       cuFuncGetAttribute(&n_spills, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, fun));
   n_spills /= 4;
   CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuFuncGetAttribute(
-      &n_threads, CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, fun));
+      &n_max_threads, CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, fun));
   // set dynamic shared memory if necessary
   int shared_optin;
   CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuDeviceGetAttribute(
@@ -150,7 +150,7 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
     return NULL;
   }
   return Py_BuildValue("(KKiii)", (uint64_t)mod, (uint64_t)fun, n_regs,
-                       n_spills, n_threads);
+                       n_spills, n_max_threads);
 }
 
 typedef CUresult (*cuOccupancyMaxActiveClusters_t)(

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -102,8 +102,8 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   CUfunction fun;
   CUmodule mod;
   int32_t n_regs = 0;
-  int32_t n_threads = 0;
   int32_t n_spills = 0;
+  int32_t n_threads = 0;
   // create driver handles
   CUcontext pctx = 0;
 
@@ -124,8 +124,8 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
       cuFuncGetAttribute(&n_spills, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, fun));
   n_spills /= 4;
-  CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
-      cuFuncGetAttribute(&n_threads, CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, fun));
+  CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuFuncGetAttribute(
+      &n_threads, CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, fun));
   // set dynamic shared memory if necessary
   int shared_optin;
   CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuDeviceGetAttribute(

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -102,6 +102,7 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   CUfunction fun;
   CUmodule mod;
   int32_t n_regs = 0;
+  int32_t n_threads = 0;
   int32_t n_spills = 0;
   // create driver handles
   CUcontext pctx = 0;
@@ -123,6 +124,8 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
       cuFuncGetAttribute(&n_spills, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, fun));
   n_spills /= 4;
+  CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
+      cuFuncGetAttribute(&n_threads, CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, fun));
   // set dynamic shared memory if necessary
   int shared_optin;
   CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuDeviceGetAttribute(
@@ -146,8 +149,8 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   if (PyErr_Occurred()) {
     return NULL;
   }
-  return Py_BuildValue("(KKii)", (uint64_t)mod, (uint64_t)fun, n_regs,
-                       n_spills);
+  return Py_BuildValue("(KKiii)", (uint64_t)mod, (uint64_t)fun, n_regs,
+                       n_spills, n_threads);
 }
 
 typedef CUresult (*cuOccupancyMaxActiveClusters_t)(


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
Expose CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK to Python as `n_threads` during kernel loading. This allows runtime to check whether num_warps * 32 exceeds the kernel's thread block limit,  making autotune more robust by skipping invalid configs with a clear `OutOfResources` error.

Before this change, the following autotune example failed immediately with RuntimeError: `RuntimeError: Triton Error [CUDA]: invalid argument`:
```python
import torch
import triton
import triton.language as tl

def test_exceed_threads(device):
    x = torch.empty(1024, device=device, dtype=torch.float32)
    y = torch.empty_like(x)
    output = torch.empty_like(x)

    configs = [
        triton.Config({}, num_warps=128),
        triton.Config({}, num_warps=4),
    ]

    @triton.autotune(configs=configs, key=['BLOCK_SIZE'])
    @triton.jit
    def add_kernel(x_ptr, y_ptr, output_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
        pid = tl.program_id(0)
        block_start = pid * BLOCK_SIZE
        offsets = block_start + tl.arange(0, BLOCK_SIZE)
        mask = offsets < n_elements
        x = tl.load(x_ptr + offsets, mask=mask)
        y = tl.load(y_ptr + offsets, mask=mask)
        output = x + y
        tl.store(output_ptr + offsets, output, mask=mask)

    def grid(meta):
        return (triton.cdiv(x.numel(), meta['BLOCK_SIZE']), )

    add_kernel[grid](x, y, output, x.numel(), BLOCK_SIZE=128)

test_exceed_threads("cuda")
```
After this change, autotune could finish successfully.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
