### PR TITLE
Remove import-time dependency on PyTorch in nvidia driver.py

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -6,7 +6,6 @@ import hashlib
 import subprocess
 import tempfile
 import triton
-import torch
 from pathlib import Path
 from triton.runtime.build import _build
 from triton.runtime.cache import get_cache_manager
@@ -539,6 +538,7 @@ class TmaDescKernelParam:
     TMA_DESC_SIZE = 128
 
     def __init__(self):
+        import torch
         self.desc = torch.empty(self.TMA_DESC_SIZE, dtype=torch.uint8, device="cpu")
 
     # Return a CUtensorMap* pointer in host memory


### PR DESCRIPTION
This change was introduced in https://github.com/triton-lang/triton/commit/053f98b79076f3e819eb637e61c3b6b1014ad8fe.