### PR TITLE
[WIP][Remarks][SWP] Emit reasons when no loops are pipelined

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -20,6 +20,26 @@ static const char *kLoopStageAttrName = "loop.stage";
 static const char *kLoopClusterAttrName = "loop.cluster";
 static const char *kScheduledMaxStageAttrName = "tt.scheduled_max_stage";
 
+// Reasons why a loop cannot be pipelined.
+enum class PipelineFailureReason {
+  // No latency is assigned.
+  NoLatencyAssigned,
+  // NumStages is smaller than or equal to 1.
+  NumStagesTooSmall,
+  // The loop has a distance greater than 1.
+  DistanceGreaterThanOne,
+  // The loop is a outer loop.
+  OuterLoop,
+  // The loop contains a BarrierOp.
+  BarrierOp,
+  // An MMAv5 operation happens after the tmem_load.
+  Mmav5AfterTmemLoad,
+};
+
+const char *getFailureReasonString(PipelineFailureReason reason);
+
+using PipelineStatus = std::optional<PipelineFailureReason>;
+
 //===----------------------------------------------------------------------===//
 // Hoisting Utilities
 //===----------------------------------------------------------------------===//

--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -4,6 +4,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipelineExpander.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <list>
 #include <vector>
@@ -14,8 +15,9 @@ namespace triton {
 namespace gpu {
 
 /// Discover operations that should become async and assign latencies to them
-/// based on the numStages value provided by the user.
-void assignLatencies(ModuleOp moduleOp, int numStages);
+/// based on the numStages value provided by the user. Return false if no loops
+/// are assigned with latencies.
+bool assignLatencies(ModuleOp moduleOp, int numStages);
 
 /// Schedule the loops based on the latencies assigned to the operations.
 void scheduleLoops(ModuleOp moduleOp);

--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -17,7 +17,8 @@ namespace gpu {
 /// Discover operations that should become async and assign latencies to them
 /// based on the numStages value provided by the user. Return false if no loops
 /// are assigned with latencies.
-bool assignLatencies(ModuleOp moduleOp, int numStages);
+bool assignLatencies(ModuleOp moduleOp, int numStages,
+                     DenseMap<scf::ForOp, PipelineStatus> &loopPipelineStatus);
 
 /// Schedule the loops based on the latencies assigned to the operations.
 void scheduleLoops(ModuleOp moduleOp);

--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -17,11 +17,15 @@ namespace gpu {
 /// Discover operations that should become async and assign latencies to them
 /// based on the numStages value provided by the user. Return false if no loops
 /// are assigned with latencies.
-bool assignLatencies(ModuleOp moduleOp, int numStages,
-                     DenseMap<scf::ForOp, PipelineStatus> &loopPipelineStatus);
+bool assignLatencies(
+    ModuleOp moduleOp, int numStages,
+    DenseMap<scf::ForOp, PipelineFailureReason> &loopPipelineFailureReasons);
 
 /// Schedule the loops based on the latencies assigned to the operations.
-void scheduleLoops(ModuleOp moduleOp);
+/// Returns false if no loops are scheduled.
+bool scheduleLoops(
+    ModuleOp moduleOp,
+    DenseMap<scf::ForOp, PipelineFailureReason> &loopPipelineFailureReasons);
 
 /// Lower the loops to prepare them for pipeline expansion.
 void lowerLoops(ModuleOp moduleOp);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -59,7 +59,7 @@ class AssignLoadLatencies {
 public:
   AssignLoadLatencies(scf::ForOp forOp, int numStages,
                       DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), numStages(numStages), opLatency(opLatency) {};
+      : forOp(forOp), numStages(numStages), opLatency(opLatency){};
 
   void run() {
     bool pipelineWithoutDot = forOp->hasAttr(mlir::triton::kNumStagesAttrName);
@@ -257,7 +257,7 @@ private:
 class AssignMMALatencies {
 public:
   AssignMMALatencies(scf::ForOp forOp, DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), opLatency(opLatency) {};
+      : forOp(forOp), opLatency(opLatency){};
 
   void run() {
     if (!triton::tools::getBoolEnv("ENABLE_MMA_V5_ATT_PIPELINE")) {
@@ -299,7 +299,8 @@ private:
 // on the requested number of stages assign the latencies in a way that
 // cover all the stages with the sum of latencies in the chain from the first
 // load to the final dot op.
-bool assignLatencies(ModuleOp moduleOp, int defaultNumStages) {
+bool assignLatencies(ModuleOp moduleOp, int defaultNumStages,
+                     DenseMap<scf::ForOp, PipelineStatus> &loopPipelineStatus) {
   SmallVector<scf::ForOp> loops;
   moduleOp->walk([&](scf::ForOp forOp) {
     // Bail out for loops with num_stage <= 1.

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -59,7 +59,7 @@ class AssignLoadLatencies {
 public:
   AssignLoadLatencies(scf::ForOp forOp, int numStages,
                       DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), numStages(numStages), opLatency(opLatency){};
+      : forOp(forOp), numStages(numStages), opLatency(opLatency) {};
 
   void run() {
     bool pipelineWithoutDot = forOp->hasAttr(mlir::triton::kNumStagesAttrName);
@@ -257,7 +257,7 @@ private:
 class AssignMMALatencies {
 public:
   AssignMMALatencies(scf::ForOp forOp, DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), opLatency(opLatency){};
+      : forOp(forOp), opLatency(opLatency) {};
 
   void run() {
     if (!triton::tools::getBoolEnv("ENABLE_MMA_V5_ATT_PIPELINE")) {

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -25,15 +25,15 @@ namespace gpu {
 namespace {
 
 // Return true if the preconditions for pipelining the loop are met.
-bool preCondition(scf::ForOp forOp) {
+PipelineStatus collectPrecondition(scf::ForOp forOp) {
   // Skip loop with distance > 1 for now.
   // TODO: relax the constraint in the expander.
   if (loopHasDistGreaterThanOne(forOp))
-    return false;
+    return std::make_optional(PipelineFailureReason::DistanceGreaterThanOne);
   // Don't pipeline outer loops.
   if (isOuterLoop(forOp))
-    return false;
-  return true;
+    return std::make_optional(PipelineFailureReason::OuterLoop);
+  return std::nullopt;
 }
 
 bool hasLatenciesAssigned(scf::ForOp forOp) {

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -59,7 +59,7 @@ class AssignLoadLatencies {
 public:
   AssignLoadLatencies(scf::ForOp forOp, int numStages,
                       DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), numStages(numStages), opLatency(opLatency) {};
+      : forOp(forOp), numStages(numStages), opLatency(opLatency){};
 
   void run() {
     bool pipelineWithoutDot = forOp->hasAttr(mlir::triton::kNumStagesAttrName);
@@ -257,7 +257,7 @@ private:
 class AssignMMALatencies {
 public:
   AssignMMALatencies(scf::ForOp forOp, DenseMap<Operation *, int> &opLatency)
-      : forOp(forOp), opLatency(opLatency) {};
+      : forOp(forOp), opLatency(opLatency){};
 
   void run() {
     if (!triton::tools::getBoolEnv("ENABLE_MMA_V5_ATT_PIPELINE")) {
@@ -299,7 +299,7 @@ private:
 // on the requested number of stages assign the latencies in a way that
 // cover all the stages with the sum of latencies in the chain from the first
 // load to the final dot op.
-void assignLatencies(ModuleOp moduleOp, int defaultNumStages) {
+bool assignLatencies(ModuleOp moduleOp, int defaultNumStages) {
   SmallVector<scf::ForOp> loops;
   moduleOp->walk([&](scf::ForOp forOp) {
     // Bail out for loops with num_stage <= 1.
@@ -308,7 +308,7 @@ void assignLatencies(ModuleOp moduleOp, int defaultNumStages) {
       loops.push_back(forOp);
   });
   if (loops.empty())
-    return;
+    return false;
 
   DenseMap<Operation *, int> opLatency;
   for (auto forOp : loops) {
@@ -321,6 +321,7 @@ void assignLatencies(ModuleOp moduleOp, int defaultNumStages) {
     AssignMMALatencies(forOp, opLatency).run();
   }
   serializeLatencies(moduleOp, opLatency);
+  return true;
 }
 } // namespace gpu
 } // namespace triton

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -20,6 +20,24 @@ namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
+const char *triton::getFailureReasonString(PipelineFailureReason reason) {
+  switch (reason) {
+  case PipelineFailureReason::NoLatencyAssigned:
+    return "No latency information was assigned to the loop.";
+  case PipelineFailureReason::NumStagesTooSmall:
+    return "NumStages (`num_stages`) is smaller than or equal to 1.";
+  case PipelineFailureReason::DistanceGreaterThanOne:
+    return "The loop has a distance greater than 1.";
+  case PipelineFailureReason::OuterLoop:
+    return "The loop is an outer loop.";
+  case PipelineFailureReason::BarrierOp:
+    return "The loop contains a BarrierOp.";
+  case PipelineFailureReason::Mmav5AfterTmemLoad:
+    return "An MMAv5 operation happens after the tmem_load.";
+  }
+  llvm_unreachable("Unknown failure reason");
+}
+
 //===----------------------------------------------------------------------===//
 // Hoisting Utilities
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -23,17 +23,17 @@ namespace ttng = mlir::triton::nvidia_gpu;
 const char *triton::getFailureReasonString(PipelineFailureReason reason) {
   switch (reason) {
   case PipelineFailureReason::NoLatencyAssigned:
-    return "No latency information was assigned to the loop.";
+    return "no latency information was assigned to the loop.";
   case PipelineFailureReason::NumStagesTooSmall:
     return "NumStages (`num_stages`) is smaller than or equal to 1.";
   case PipelineFailureReason::DistanceGreaterThanOne:
-    return "The loop has a distance greater than 1.";
+    return "the loop has a distance greater than 1.";
   case PipelineFailureReason::OuterLoop:
-    return "The loop is an outer loop.";
+    return "the loop is an outer loop.";
   case PipelineFailureReason::BarrierOp:
-    return "The loop contains a BarrierOp.";
+    return "the loop contains a BarrierOp.";
   case PipelineFailureReason::Mmav5AfterTmemLoad:
-    return "An MMAv5 operation happens after the tmem_load.";
+    return "an MMAv5 operation happens after the tmem_load.";
   }
   llvm_unreachable("Unknown failure reason");
 }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -89,7 +89,8 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
     // numStages) to the them, trying to populate the allowed stages. This
     // step will be at some point extracted to separate pass that will be run
     // only for loops missing the latency information.
-    auto assignedLatency = assignLatencies(moduleOp, numStages);
+    auto assignedLatency =
+        assignLatencies(moduleOp, numStages, loopPipelineStatus);
 
     if (dumpIntermediateSteps) {
       llvm::dbgs() << "// -----// SoftwarePipeliner internal IR Dump After: "
@@ -98,7 +99,7 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
     }
 
     if (!assignedLatency) {
-
+      // no latency assigned. we can print some remarks and bail out.
       return;
     }
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TestPipelineAssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TestPipelineAssignLatencies.cpp
@@ -21,7 +21,10 @@ struct TestPipelineAssignLatencies
   using impl::TritonGPUTestPipelineAssignLatenciesBase<
       TestPipelineAssignLatencies>::TritonGPUTestPipelineAssignLatenciesBase;
 
-  void runOnOperation() override { assignLatencies(getOperation(), numStages); }
+  void runOnOperation() override {
+    DenseMap<scf::ForOp, PipelineFailureReason> loopPipelineFailureReasons;
+    assignLatencies(getOperation(), numStages, loopPipelineFailureReasons);
+  }
 };
 
 } // namespace gpu

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TestPipelineScheduleLoop.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TestPipelineScheduleLoop.cpp
@@ -21,7 +21,10 @@ struct TestPipelineScheduleLoop
   using impl::TritonGPUTestPipelineScheduleLoopBase<
       TestPipelineScheduleLoop>::TritonGPUTestPipelineScheduleLoopBase;
 
-  void runOnOperation() override { scheduleLoops(getOperation()); }
+  void runOnOperation() override {
+    DenseMap<scf::ForOp, PipelineFailureReason> loopPipelineFailureReasons;
+    scheduleLoops(getOperation(), loopPipelineFailureReasons);
+  }
 };
 
 } // namespace gpu


### PR DESCRIPTION
This pull request introduces remarks that provide detailed diagnostic information on why loops within a module fail to be pipelined. Instead of spending extensive hours debugging, developers can now quickly identify the root causes of pipelining failures.

We have identified and categorized all potential root causes that may prevent a loop from being successfully pipelined during the latency assignment or function `scheduleLoops`. These causes are now encapsulated within an enum type.

During the pipelining process, specifically in the latency assignment and `scheduleLoops` stages, the system will collect and report these failure reasons.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
