### PR TITLE
[BENCH] swiglu improvements

### DIFF
--- a/bench/tests/test_swiglu.py
+++ b/bench/tests/test_swiglu.py
@@ -24,7 +24,6 @@ def alloc_rand(shape, device, dtype, requires_grad=True):
 # ---------------
 
 
-
 @pytest.mark.parametrize("M, N", [(1311, 4352)])
 @pytest.mark.parametrize("limit", [1e-2, 10])
 def test_op(M, N, limit, alpha=0.5):

--- a/bench/tests/test_swiglu.py
+++ b/bench/tests/test_swiglu.py
@@ -1,7 +1,11 @@
+from triton_bench.routing import routing_torch
 from triton_bench.swiglu import swiglu, swiglu_torch, PrecisionConfig
 from triton_bench.testing import assert_close
 import torch
 import pytest
+
+from .test_routing import init_data as init_routing_data
+from .test_routing import ref_expt_data
 
 # ---------------
 # initialize data
@@ -15,13 +19,10 @@ def alloc_rand(shape, device, dtype, requires_grad=True):
     return torch.randn(shape, device=device, dtype=dtype, requires_grad=requires_grad)
 
 
-def alloc_rand_like(x):
-    return alloc_rand(x.shape, x.device, x.dtype, x.requires_grad)
-
-
 # ---------------
 # unit tests
 # ---------------
+
 
 
 @pytest.mark.parametrize("M, N", [(1311, 4352)])
@@ -30,9 +31,17 @@ def test_op(M, N, limit, alpha=0.5):
     torch.manual_seed(2)
     dev = "cuda"
     dtype = torch.bfloat16
+    # initialize expert data
+    n_expts_tot = 6
+    n_expts_act = 2
+    logits = init_routing_data(M, n_expts_tot).detach()
+    routing_data, _, _ = routing_torch(logits, n_expts_act)
+    expt_data = ref_expt_data(routing_data, M * n_expts_act, block_m=128)
+    n_tokens = expt_data[2 * n_expts_tot].sum()
+
     # initialize data
-    x = alloc_rand([M, N], device=dev, dtype=torch.bfloat16)
+    x = alloc_rand([n_tokens, N], device=dev, dtype=dtype)
     precision_config = PrecisionConfig(limit=limit)
-    tri_y = swiglu(x, alpha, precision_config)
+    tri_y = swiglu(x, alpha, precision_config, expt_data, n_expts_tot)
     ref_y = swiglu_torch(x, alpha, precision_config)
     assert_close(tri_y, ref_y)

--- a/bench/triton_bench/swiglu.py
+++ b/bench/triton_bench/swiglu.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
-from triton_bench.numerics import flex_to_float, float_to_flex, update_scale, InFlexData, OutFlexData
-from triton_bench.meta import num_sms, is_hip, threads_per_warp
+from triton_bench.numerics import flex_to_float, float_to_flex, load_scale, update_scale, InFlexData, OutFlexData
+from triton_bench.meta import num_sms, is_hip, threads_per_warp, cuda_capability_geq
 import torch
 import triton
 import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 
 @triton.jit
@@ -38,47 +39,69 @@ def swiglu_launch_metadata(grid, kernel, args):
 
 
 @triton.jit(repr=swiglu_repr, launch_metadata=swiglu_launch_metadata)
-def _swiglu(Out, OutExpectedScale, OutActualScale, A, AScale, alpha, M, N, stride_am, stride_an, stride_outm,
-            stride_outn,
-            # optional PID-indexed arrays for tracking RMS of linear and nonlinear parts
-            limit: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, M_BLOCKS, NUM_THREADS: tl.constexpr,
+def _swiglu(out_desc, Out, OutExpectedScale, OutActualScale, OutChecksumScale, a_desc, A, AScale, alpha, M, N,
+            stride_am, stride_an, stride_outm, stride_outn, limit: tl.constexpr, ExptData, NUM_EXPERTS: tl.constexpr,
+            BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, EVEN_N: tl.constexpr, M_BLOCKS, N_BLOCKS,
             flexpoint_saturate_inf: tl.constexpr):
-    pid_m = tl.program_id(axis=0).to(tl.int64)
-    pid_n = tl.program_id(axis=1).to(tl.int64)
-    # iterate over M blocks until M is reached
-    base_m = pid_m * BLOCK_M
-    local_max = tl.full([NUM_THREADS], 0.0, tl.float32)
-    while base_m < M:
-        off_m = base_m + tl.arange(0, BLOCK_M)
+    if ExptData is not None:
+        M = tl.load(ExptData + 2 * NUM_EXPERTS)
+        M_BLOCKS = (M + BLOCK_M - 1) // BLOCK_M
+
+    local_max = tl.full([tl.extra.cuda.num_threads()], 0.0, tl.float32)
+
+    a_scale = load_scale(AScale)
+    out_expected_scale = load_scale(OutExpectedScale)
+
+    for pid in tl.range(tl.program_id(0), M_BLOCKS * N_BLOCKS, tl.num_programs(0), num_stages=2):
+        pid_m = (pid // N_BLOCKS)
+        pid_n = (pid % N_BLOCKS)
+        off_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
         off_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-        mask = off_m[:, None] < M and off_n[None, :] < N
-        # column offsets
-        off_a_gelu = off_m[:, None] * stride_am + 2 * off_n[None, :] * stride_an
-        off_a_linear = off_m[:, None] * stride_am + 2 * off_n[None, :] * stride_an + 1
+        mask_m = off_m < M
+        mask_n = off_n < N
+        packed_off_n = pid_n * BLOCK_N + tl.arange(0, 2 * BLOCK_N) // 2
+        packed_mask_n = packed_off_n < N
+        packed_mask_n = tl.max_constancy(packed_mask_n, [16])
+        # load a
+        packed_off_n = pid_n * 2 * BLOCK_N + tl.arange(0, 2 * BLOCK_N)
+        packed_offs = off_m[:, None] * stride_am + packed_off_n[None, :] * stride_an
+        if a_desc is not None:
+            a_packed = a_desc.load([pid_m * BLOCK_M, pid_n * 2 * BLOCK_N])
+        if EVEN_N:
+            a_packed = tl.load(A + packed_offs, mask=mask_m[:, None], other=0.)
+        else:
+            if pid_n * BLOCK_N + BLOCK_N <= N:
+                a_packed = tl.load(A + packed_offs, mask=mask_m[:, None], other=0.)
+            else:
+                packed_mask = mask_m[:, None] and packed_mask_n[None, :]
+                a_packed = tl.load(A + packed_offs, mask=packed_mask, other=0.)
+        a_gelu, a_linear = tl.split(tl.reshape(a_packed, (BLOCK_M, BLOCK_N, 2)))
         # a gelu
-        a_gelu = tl.load(A + off_a_gelu, mask=mask, other=0.)
-        a_gelu = flex_to_float(a_gelu, scale_ptr=AScale)
+        a_gelu = a_gelu.to(tl.float32) * a_scale
         if limit is not None:
             a_gelu = clip(a_gelu, limit, clip_lower=False)
         # a linear
-        a_linear = tl.load(A + off_a_linear, mask=mask, other=0.)
-        a_linear = flex_to_float(a_linear, scale_ptr=AScale)
+        a_linear = a_linear.to(tl.float32) * a_scale
         if limit is not None:
             a_linear = clip(a_linear, limit, clip_lower=True)
         # compute output
-        out_gelu = a_gelu / (1 + tl.exp(-alpha * a_gelu))
-        out = out_gelu * (a_linear + 1)
+        s = a_gelu / (1 + tl.exp(-alpha * a_gelu))
+        out = tl.fma(s, a_linear, s)  # (s * (a_linear + 1))
         # update flexpoint stats and divide by scale
         # we don't need masking because of the `other` when loading `A`
         if OutActualScale is not None:
-            absmax = thread_local_absmax(out, BLOCK_M * BLOCK_N, NUM_THREADS)
+            absmax = thread_local_absmax(out, out.numel, tl.extra.cuda.num_threads())
             local_max = tl.maximum(local_max, absmax)
-        out = float_to_flex(out, OutExpectedScale, None, None, Out, None, flexpoint_saturate_inf)
-        # write-back
-        tl.store(Out + off_m[:, None] * stride_outm + off_n[None, :] * stride_outn, out, mask=mask)
-        # increment block base
-        base_m += (M_BLOCKS * BLOCK_M)
-    # reduce flexpoint scale
+        out = float_to_flex(out, out_expected_scale,
+                            None,  # ActualScale: local absmax is tracked and updated after the loop
+                            OutChecksumScale, None, Out, flexpoint_saturate_inf)
+
+        if out_desc is not None:
+            out_desc.store([pid_m * BLOCK_M, pid_n * BLOCK_N], out.to(Out.dtype.element_ty))
+        else:
+            mask = mask_m[:, None] if EVEN_N else mask_m[:, None] and mask_n[None, :]
+            tl.store(Out + off_m[:, None] * stride_outm + off_n[None, :] * stride_outn, out, mask)
+
     update_scale(local_max, OutActualScale, Out)
 
 
@@ -98,7 +121,7 @@ class PrecisionConfig:
 class SwiGLU(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, a, alpha, precision_config):
+    def forward(ctx, a, alpha, precision_config, expt_data, num_experts):
         N = a.shape[-1]
         M = a.numel() // N
         assert a.stride()[-1] == 1
@@ -106,18 +129,40 @@ class SwiGLU(torch.autograd.Function):
         out = torch.empty(size=(M, N // 2), dtype=a.dtype, device=a.device)
         flex_ctx = precision_config.flex_ctx
         # optimization hyperparameters
-        BLOCK_M, BLOCK_N = 8, 128
-        num_warps = 2
-        waves_per_sm = 32 if is_hip() else 128
+        BLOCK_M, BLOCK_N = 32 // a.itemsize, 128
+        num_warps = 4
+        kwargs = {'maxnreg': 64} if not is_hip() else {}
+        # TMA descriptors
+        out_desc = None
+        a_desc = None
+        if cuda_capability_geq(9, 0) and flex_ctx.out_data.actual_scale is not None:
+            # We need TMA to store the outputs otherwise Triton will aggressively removing layout conversions at
+            # the cost of duplicating too much compute. With TMA, the layout conversion gets folded into the TMA store,
+            # and the duplication doesn't occur.
+            assert out.shape[-1] * out.element_size() % 16 == 0
+            out_desc = TensorDescriptor.from_tensor(out, (BLOCK_M, BLOCK_N))
+            assert a.shape[-1] * a.element_size() % 16 == 0
+            a_desc = TensorDescriptor.from_tensor(a, (BLOCK_M, 2 * BLOCK_N))
         # launch semi-persistent kernel
-        num_pid = num_sms() * (waves_per_sm // num_warps)
         N_BLOCKS = triton.cdiv(N // 2, BLOCK_N)
-        M_BLOCKS = max(1, triton.cdiv(num_pid, N_BLOCKS))
-        grid = (M_BLOCKS, N_BLOCKS)
+        if expt_data is not None:
+            waves_per_sm = 32 if is_hip() else 128
+            num_pid = num_sms() * (waves_per_sm // num_warps)
+            M_BLOCKS = max(1, triton.cdiv(num_pid, N_BLOCKS))
+            grid = (min(M_BLOCKS * N_BLOCKS, 4 * num_sms()), )
+        else:
+            M_BLOCKS = triton.cdiv(M, BLOCK_M)
+            if M_BLOCKS * N_BLOCKS >= 8 * num_sms():
+                grid = (8 * num_sms(), )
+            else:
+                grid = (min(M_BLOCKS * N_BLOCKS, 4 * num_sms()), )
         _swiglu[grid](
+            out_desc,
             flex_ctx.out_data.reinterpret(out),
             flex_ctx.out_data.expected_scale,
             flex_ctx.out_data.actual_scale,
+            flex_ctx.out_data.checksum_scale,
+            a_desc,
             flex_ctx.inp_data.reinterpret(a),
             flex_ctx.inp_data.scale,
             alpha,
@@ -128,19 +173,23 @@ class SwiGLU(torch.autograd.Function):
             out.shape[-1],
             1,
             precision_config.limit,
+            expt_data,
+            num_experts,
             BLOCK_M=BLOCK_M,
             BLOCK_N=BLOCK_N,
+            EVEN_N=(N // 2) % 2 == 0,
             M_BLOCKS=M_BLOCKS,
-            NUM_THREADS=num_warps * threads_per_warp(),
+            N_BLOCKS=N_BLOCKS,
             flexpoint_saturate_inf=flex_ctx.saturate_inf,
             num_warps=num_warps,
+            **kwargs,
         )
         out = out.view(a.shape[:-1] + out.shape[-1:])
         return out
 
 
-def swiglu(a, alpha, precision_config):
-    return SwiGLU.apply(a, alpha, precision_config)
+def swiglu(a, alpha, precision_config, expt_data=None, num_experts=0):
+    return SwiGLU.apply(a, alpha, precision_config, expt_data, num_experts)
 
 
 def swiglu_torch(a, alpha, precision_config):


### PR DESCRIPTION
Optimizations, and add support for dynamic number of rows. Existing code was written as a while loop so couldn't pipeline well. By changing to a for loop and explicitly setting num_stages, we increase bandwidth utilization. Dynamic rows will be needed for simulated e sharding.

on H100:
```
-                    "name": "_swiglu_bf16xbf16_8x128 [M = 8192, N = 4096]",
+                    "name": "_swiglu_bf16xbf16_16x128 [M = 8192, N = 4096]",
-                    "time (ns)": 8352191
+                    "time (ns)": 6544317
--
-                    "name": "_swiglu_fp8e4nvxfp8e4nv_8x128 [M = 8192, N = 4096]",
+                    "name": "_swiglu_fp8e4nvxfp8e4nv_32x128 [M = 8192, N = 4096]",
-                    "time (ns)": 8803373
+                    "time (ns)": 4203423
--
-                    "name": "_swiglu_bf16xbf16_8x128 [M = 8192, N = 1024]",
+                    "name": "_swiglu_bf16xbf16_16x128 [M = 8192, N = 1024]",
-                    "time (ns)": 2204914
+                    "time (ns)": 1514706
--
-                    "name": "_swiglu_fp8e4nvxfp8e4nv_8x128 [M = 8192, N = 1024]",
+                    "name": "_swiglu_fp8e4nvxfp8e4nv_32x128 [M = 8192, N = 1024]",
-                    "time (ns)": 2158775
+                    "time (ns)": 1133588
```

on GB200:
```
-                    "name": "_swiglu_fp8e4nvxfp8e4nv_8x128 [M = 8192, N = 4096]",
+                    "name": "_swiglu_fp8e4nvxfp8e4nv_32x128 [M = 8192, N = 4096]",
-                    "time (ns)": 6665739
+                    "time (ns)": 2975619
--
-                    "name": "_swiglu_fp8e4nvxfp8e4nv_8x128 [M = 8192, N = 4096]",
+                    "name": "_swiglu_fp8e4nvxfp8e4nv_32x128 [M = 8192, N = 4096]",
-                    "time (ns)": 7168345
+                    "time (ns)": 3228486
--
-                    "name": "_swiglu_fp8e4nvxfp8e4nv_8x128 [M = 8192, N = 1024]",
+                    "name": "_swiglu_fp8e4nvxfp8e4nv_32x128 [M = 8192, N = 1024]",
-                    "time (ns)": 1872580
+                    "time (ns)": 986370
--
-                    "name": "_swiglu_fp8e4nvxfp8e4nv_8x128 [M = 8192, N = 1024]",
+                    "name": "_swiglu_fp8e4nvxfp8e4nv_32x128 [M = 8192, N = 1024]",
-                    "time (ns)": 1873666
+                    "time (ns)": 984864
```

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
