### PR TITLE
[LAYOUTS] Implement divideLeft

### DIFF
--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -610,6 +610,22 @@ public:
     return *this;
   }
 
+  // Compute a C such that A = B * C if it exists.
+  // In other words, C = B^{-1} * A.
+  // Note that such a C exists iff (every pair of input/output dim of) A is
+  // of the form
+  // [[B, 0],
+  //  [0, C]]
+  // as a matrix, whenever those dimensions are present in B.
+  //
+  // C will always have the same input/output dimensions as A.
+  // When there are dimensions of size 1 there is some ambiguity in the
+  // division, as in `operator*` we treat missing dimensions as dimensions
+  // of size 1 whenever it makes sense to do so. The rule that C has the
+  // same dimensions as A ensures that C is well-defined.
+  friend std::optional<LinearLayout> divideLeft(const LinearLayout &A,
+                                                const LinearLayout &B);
+
   // Returns true if this layout acts trivially (as the identity) on the given
   // dimensions. This means that it's the identity on those dimensions, and it
   // does not map other dimensions onto those or these onto other dimensions.


### PR DESCRIPTION
Finally got around to implement `divideLeft`. I rescued and adapted the
`divideRight` tests from https://github.com/triton-lang/triton/pull/5170
and added a few more.

As discussed in the inline comment, there is some ambiguity when it
comes to define the quotient if the quotient has dimensions of size one.
You can basically keep them or remove them and both of them would give
you a LinearLayout such that `A = B * C`. We choose to keep them, as
removing them would make the behaviour too unpredictable. The invariant
here is that the dimensions of the result of `leftDivide` are the same
as the dimensions of the left input. The right input may have less
dimensions than the right input tho.
