### PR TITLE
[AMD] [BACKEND] Update the is_active check to comply with PyTorch docs 

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -515,7 +515,7 @@ class HIPDriver(GPUDriver):
     def is_active():
         try:
             import torch
-            return torch.version.hip is not None
+            return torch.cuda.is_available() and (torch.version.hip is not None)
         except ImportError:
             return False
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

Per [the pytorch docs](https://github.com/pytorch/pytorch/blob/21b0ef520d651ed67f6978ac37c8a8a4093819ee/docs/source/notes/hip.rst#checking-for-hip) we should be checking `torch.cuda.is_available()` to verify the driver is active. This is also consistent with the [Nvidia backend](https://github.com/njriasan/triton/blob/e5e5f573a203747f1421944b8fd8cf77dbad83f7/third_party/nvidia/backend/driver.py#L657).