### PR TITLE
Replace fast methods with Python stable ABI in `driver.c`

### DIFF
--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -305,10 +305,10 @@ static PyObject *fillTMADescriptor(PyObject *self, PyObject *args) {
   blockSizeFast = PySequence_Fast(blockSize, "blockSize must be a sequence");
   if (!blockSizeFast)
     goto cleanup;
-  int rank = PySequence_Fast_GET_SIZE(blockSizeFast);
+  int rank = PySequence_Size(blockSizeFast);
 
   for (int i = 0; i < rank; ++i) {
-    PyObject *item = PySequence_Fast_GET_ITEM(blockSizeFast, i);
+    PyObject *item = PySequence_GetItem(blockSizeFast, i);
     if (!PyLong_Check(item)) {
       PyErr_SetString(PyExc_TypeError, "block size must be an int");
       goto cleanup;
@@ -320,12 +320,12 @@ static PyObject *fillTMADescriptor(PyObject *self, PyObject *args) {
   if (!shapeFast)
     goto cleanup;
 
-  if (rank != PySequence_Fast_GET_SIZE(shapeFast)) {
+  if (rank != PySequence_Size(shapeFast)) {
     PyErr_SetString(PyExc_RuntimeError, "Rank mismatch");
     goto cleanup;
   }
   for (int i = 0; i < rank; ++i) {
-    PyObject *item = PySequence_Fast_GET_ITEM(shapeFast, i);
+    PyObject *item = PySequence_GetItem(shapeFast, i);
     if (!PyLong_Check(item)) {
       PyErr_SetString(PyExc_TypeError, "shape must be an int");
       goto cleanup;
@@ -337,12 +337,12 @@ static PyObject *fillTMADescriptor(PyObject *self, PyObject *args) {
   if (!stridesFast)
     goto cleanup;
 
-  if (rank != PySequence_Fast_GET_SIZE(stridesFast)) {
+  if (rank != PySequence_Size(stridesFast)) {
     PyErr_SetString(PyExc_RuntimeError, "Rank mismatch");
     goto cleanup;
   }
   for (int i = 0; i + 1 < rank; ++i) {
-    PyObject *item = PySequence_Fast_GET_ITEM(stridesFast, i);
+    PyObject *item = PySequence_GetItem(stridesFast, i);
     if (!PyLong_Check(item)) {
       PyErr_SetString(PyExc_TypeError, "shape must be an int");
       goto cleanup;


### PR DESCRIPTION
As previously mentioned in #6151 , I've been using the [Python stable ABI](https://docs.python.org/3/c-api/stable.html) in JIT-compiled binaries (such as `cuda_utils` and `__triton_launcher`) to avoid errors from the cache when the user switches the Python version. This has reduced linking errors reported from users. However, new commits to `driver.c` broke this, and I hope we can maintain this.

Although this means we cannot use the fast methods like `PySequence_Fast_GET_SIZE`, it should not be the performance bottleneck.

If you think this is ok, then we can also proceed to use the stable ABI when calling the compiler on Linux, and on AMD and other backends.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because: The design about using the stable ABI needs discussion, then we can call the compiler with the stable ABI and run the existing unit tests. It has passed the unit tests in my Windows fork.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)