### PR TITLE
[BACKEND] Factor out replaceUsesWithLocalLoad and use in TMALowering

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -61,12 +61,6 @@ Value getPredMask(RewriterBase &rewriter, Type typeLike, Value currentMask,
 /// Function to mask operations during scheduling.
 Operation *predicateOp(RewriterBase &rewriter, Operation *op, Value pred);
 
-/// Replace all uses of `oldUse` with `val` and propagate the type if needed.
-/// This is useful when we need to change a memory descriptor from immutable to
-/// mutable.
-void replaceUsesAndPropagateType(OpBuilder &builder, Operation *oldUse,
-                                 Value val);
-
 // Return true if the given ForOp has the attribute
 // `tt.disallow_acc_multi_buffer` set to true.
 bool getDisallowAccMultiBuffer(scf::ForOp forOp);
@@ -123,7 +117,8 @@ int getNumStagesOrDefault(scf::ForOp forOp, int defaultNumStages);
 // Given a result of MemDescSubview, or Alloca, create a MemDescSubview with a
 // single buffer slice (leading dimension equal to 1), at the given index.
 template <typename TBuilder>
-Value createSingleBufferView(TBuilder &builder, Value alloc, Value idx) {
+TypedValue<triton::gpu::MemDescType>
+createSingleBufferView(TBuilder &builder, Value alloc, Value idx) {
   assert(isa<triton::gpu::MemDescType>(alloc.getType()) &&
          "Expected MemDescType");
   auto allocDescType = cast<triton::gpu::MemDescType>(alloc.getType());
@@ -151,7 +146,8 @@ Value createSingleBufferView(TBuilder &builder, Value alloc, Value idx) {
 }
 
 template <typename TBuilder>
-Value createSingleBufferView(TBuilder &builder, Value alloc, int idx) {
+TypedValue<triton::gpu::MemDescType>
+createSingleBufferView(TBuilder &builder, Value alloc, int idx) {
   return createSingleBufferView(
       builder, alloc,
       builder.template create<arith::ConstantIntOp>(alloc.getLoc(), idx, 32));

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -247,7 +247,46 @@ void eraseLoopCarriedValues(scf::ForOp &loop, llvm::BitVector indices);
 // Return true if two value sets may refer to the same allocation.
 bool mayAliasAllocations(const DenseSet<Value> &lhs,
                          const DenseSet<Value> &rhs);
-
 } // namespace mlir
+
+namespace mlir::triton {
+
+/// Replace all uses of `oldUse` with `val` and propagate the type if needed.
+/// This is useful when we need to change a memory descriptor from immutable to
+/// mutable.
+void replaceUsesAndPropagateType(OpBuilder &builder, Operation *oldUse,
+                                 Value val);
+
+template <typename BuilderT>
+void replaceUsesWithLocalLoad(
+    BuilderT &builder, OpResult old, TypedValue<triton::gpu::MemDescType> alloc,
+    TypedValue<triton::gpu::AsyncTokenType> token = {}) {
+  //  Remove redundant local_load -> local_alloc
+  namespace ttg = triton::gpu;
+  using triton::gpu::LocalAllocOp;
+  auto allocTy = alloc.getType();
+  SmallVector<LocalAllocOp> allocsToErase;
+  for (Operation *user : old.getUsers()) {
+    if (auto userAlloc = dyn_cast<LocalAllocOp>(user)) {
+      if (allocTy.getEncoding() == userAlloc.getType().getEncoding()) {
+        replaceUsesAndPropagateType(builder, userAlloc, alloc);
+        allocsToErase.push_back(userAlloc);
+      }
+    }
+  }
+  for (auto alloc : allocsToErase) {
+    alloc.erase();
+  }
+
+  // If there are some uses that were not local_allocs, we need to create a
+  // local_load for them.
+  if (!old.getUsers().empty()) {
+    auto loc = old.getOwner()->getLoc();
+    auto sharedLoad = builder.template create<ttg::LocalLoadOp>(
+        loc, old.getType(), alloc, token);
+    old.replaceAllUsesWith(sharedLoad.getResult());
+  }
+}
+} // namespace mlir::triton
 
 #endif // TRITON_DIALECT_TRITONGPU_TRANSFORMS_UTILITY_H_

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -264,46 +264,24 @@ void createAsyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,
 
   // Create wait and local load
   builder.setStageCluster(schedule[firstUse]);
-  Operation *wait =
-      builder.create<ttg::AsyncWaitOp>(loc, commit->getResult(0), 0);
-  Value viewLoad = createSingleBufferView(builder, alloc, extractIdx);
+  auto wait = builder.create<ttg::AsyncWaitOp>(loc, commit->getResult(0), 0);
+  auto viewLoad = createSingleBufferView(builder, alloc, extractIdx);
 
   if (!loadOp.getOther() || isZeroConst(loadOp.getOther())) {
-    // Remove redundant local_load -> local_alloc, but only if
-    // we are not using the other value. AsyncCopyGlobalToLocalOp does not
-    // support the masking.
-    SmallVector<ttg::LocalAllocOp> allocsToErase;
-    for (Operation *user : loadOp->getUsers()) {
-      if (auto userAlloc = dyn_cast<ttg::LocalAllocOp>(user)) {
-        if (allocTy.getEncoding() == userAlloc.getType().getEncoding()) {
-          tt::replaceUsesAndPropagateType(builder, userAlloc, viewLoad);
-          allocsToErase.push_back(userAlloc);
-        }
-      }
-    }
-    for (auto alloc : allocsToErase) {
-      alloc.erase();
-    }
-  }
-
-  // If there are some uses that were not local_allocs, we need to create a
-  // local_load for them.
-  if (loadOp->use_begin() != loadOp->use_end()) {
+    // If masking isn't required, load directly from shared
+    replaceUsesWithLocalLoad(builder, loadOp->getResult(0), viewLoad,
+                             wait.getResult());
+  } else if (loadOp->use_begin() != loadOp->use_end()) {
+    // Otherwise, create a select for non-zero other values as they are not
+    // handled by AsyncCopyGlobalToLocalOp for now.
     auto sharedLoad = builder.create<ttg::LocalLoadOp>(
-        loc, loadOp.getType(), viewLoad, wait->getResult(0));
-    auto result = sharedLoad->getResults();
-
-    // Create a select for non-zero other values as they are not handled by
-    // AsyncCopyGlobalToLocalOp for now.
-    if (other && !isZeroConst(other)) {
-      auto select = builder.create<arith::SelectOp>(
-          loc, loadOp.getType(),
-          // Use the mask operand from the original load, not the one with a
-          // potentially transformed layout.
-          loadOp.getMask(), sharedLoad.getResult(), other);
-      result = select->getResults();
-    }
-    loadOp->replaceAllUsesWith(result);
+        loc, loadOp.getType(), viewLoad, wait.getResult());
+    auto select = builder.create<arith::SelectOp>(
+        loc, loadOp.getType(),
+        // Use the mask operand from the original load, not the one with a
+        // potentially transformed layout.
+        loadOp.getMask(), sharedLoad.getResult(), other);
+    loadOp->replaceAllUsesWith(select->getResults());
   }
   schedule.erase(loadOp);
   loadOp->erase();
@@ -339,29 +317,9 @@ void createTMAAsyncCopy(
   // Create local load after the wait
   builder.setInsertionPointAfter(waitOp);
   builder.setStageCluster(schedule[firstUse]);
-  Value viewLoad = createSingleBufferView(builder, alloc, extractIdx);
-  //  Remove redundant local_load -> local_alloc
-  SmallVector<ttg::LocalAllocOp> allocsToErase;
-  for (Operation *user : loadOp->getUsers()) {
-    if (auto userAlloc = dyn_cast<ttg::LocalAllocOp>(user)) {
-      if (allocTy.getEncoding() == userAlloc.getType().getEncoding()) {
-        tt::replaceUsesAndPropagateType(builder, userAlloc, viewLoad);
-        allocsToErase.push_back(userAlloc);
-      }
-    }
-  }
-  for (auto alloc : allocsToErase) {
-    alloc.erase();
-  }
+  auto viewLoad = createSingleBufferView(builder, alloc, extractIdx);
+  replaceUsesWithLocalLoad(builder, loadOp->getResult(0), viewLoad);
 
-  // If there are some uses that were not local_allocs, we need to create a
-  // local_load for them.
-  if (loadOp->use_begin() != loadOp->use_end()) {
-    auto sharedLoad = builder.create<ttg::LocalLoadOp>(
-        loc, loadOp->getResultTypes().front(), viewLoad);
-    auto result = sharedLoad->getResults();
-    loadOp->replaceAllUsesWith(result);
-  }
   schedule.erase(loadOp);
   loadOp->erase();
 }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -234,56 +234,6 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
   return op;
 }
 
-void mlir::triton::replaceUsesAndPropagateType(OpBuilder &builder,
-                                               Operation *oldUse, Value val) {
-  SmallVector<Operation *> opsToDelete;
-  SmallVector<OpOperand *> operandsToReplace;
-
-  // Save the operand to replace / delete later (avoid iterator invalidation).
-  // TODO: can we use an early_inc iterator?
-  for (OpOperand &use : oldUse->getUses()) {
-    // Non-subview/trans ops will be replaced by `val`.
-    if (!isa<triton::gpu::MemDescTransOp, triton::gpu::MemDescSubviewOp>(
-            use.getOwner())) {
-      operandsToReplace.push_back(&use);
-      continue;
-    }
-    Operation *user = use.getOwner();
-    // `subview(old_op)` is replaced by a new `subview(val)`.
-    OpBuilder::InsertionGuard g(builder);
-    builder.setInsertionPoint(user);
-    Value newVal;
-    if (auto subview = dyn_cast<triton::gpu::MemDescSubviewOp>(user)) {
-      triton::gpu::MemDescType oldType = subview.getType();
-      bool isMutable =
-          cast<triton::gpu::MemDescType>(val.getType()).getMutableMemory();
-      Type newDstType = triton::gpu::MemDescType::get(
-          oldType.getShape(), oldType.getElementType(), oldType.getEncoding(),
-          oldType.getMemorySpace(), isMutable);
-      newVal = builder.create<triton::gpu::MemDescSubviewOp>(
-          subview.getLoc(), newDstType, val, subview.getOffsets());
-      newVal.getDefiningOp()->setAttrs(user->getAttrs());
-    } else if (auto trans = dyn_cast<triton::gpu::MemDescTransOp>(user)) {
-      newVal = builder.create<triton::gpu::MemDescTransOp>(trans.getLoc(), val,
-                                                           trans.getOrder());
-      newVal.getDefiningOp()->setAttrs(user->getAttrs());
-    }
-    assert(newVal);
-    replaceUsesAndPropagateType(builder, user, newVal);
-    opsToDelete.push_back(use.getOwner());
-  }
-
-  // Perform late replacement.
-  for (OpOperand *operand : operandsToReplace) {
-    Operation *op = operand->getOwner();
-    operand->set(val);
-  }
-
-  // Perform late op erasure.
-  for (Operation *op : opsToDelete)
-    op->erase();
-}
-
 // Return true if the given ForOp has the attribute
 // `tt.disallow_acc_multi_buffer` set to true.
 bool mlir::triton::getDisallowAccMultiBuffer(scf::ForOp forOp) {

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1545,3 +1545,55 @@ bool mayAliasAllocations(const DenseSet<Value> &lhs,
 }
 
 } // namespace mlir
+
+namespace mlir::triton {
+void replaceUsesAndPropagateType(OpBuilder &builder, Operation *oldUse,
+                                 Value val) {
+  SmallVector<Operation *> opsToDelete;
+  SmallVector<OpOperand *> operandsToReplace;
+
+  // Save the operand to replace / delete later (avoid iterator invalidation).
+  // TODO: can we use an early_inc iterator?
+  for (OpOperand &use : oldUse->getUses()) {
+    // Non-subview/trans ops will be replaced by `val`.
+    if (!isa<triton::gpu::MemDescTransOp, triton::gpu::MemDescSubviewOp>(
+            use.getOwner())) {
+      operandsToReplace.push_back(&use);
+      continue;
+    }
+    Operation *user = use.getOwner();
+    // `subview(old_op)` is replaced by a new `subview(val)`.
+    OpBuilder::InsertionGuard g(builder);
+    builder.setInsertionPoint(user);
+    Value newVal;
+    if (auto subview = dyn_cast<triton::gpu::MemDescSubviewOp>(user)) {
+      triton::gpu::MemDescType oldType = subview.getType();
+      bool isMutable =
+          cast<triton::gpu::MemDescType>(val.getType()).getMutableMemory();
+      Type newDstType = triton::gpu::MemDescType::get(
+          oldType.getShape(), oldType.getElementType(), oldType.getEncoding(),
+          oldType.getMemorySpace(), isMutable);
+      newVal = builder.create<triton::gpu::MemDescSubviewOp>(
+          subview.getLoc(), newDstType, val, subview.getOffsets());
+      newVal.getDefiningOp()->setAttrs(user->getAttrs());
+    } else if (auto trans = dyn_cast<triton::gpu::MemDescTransOp>(user)) {
+      newVal = builder.create<triton::gpu::MemDescTransOp>(trans.getLoc(), val,
+                                                           trans.getOrder());
+      newVal.getDefiningOp()->setAttrs(user->getAttrs());
+    }
+    assert(newVal);
+    replaceUsesAndPropagateType(builder, user, newVal);
+    opsToDelete.push_back(use.getOwner());
+  }
+
+  // Perform late replacement.
+  for (OpOperand *operand : operandsToReplace) {
+    Operation *op = operand->getOwner();
+    operand->set(val);
+  }
+
+  // Perform late op erasure.
+  for (Operation *op : opsToDelete)
+    op->erase();
+}
+} // namespace mlir::triton


### PR DESCRIPTION
This helper replaces a tensor with the result of `LocalLoadOp` and looks forward at any downstream `LocalAllocOp` users and tries to elide the allocation if the encodings match.

By using it in TMALowering, we can now avoid taking a round trip through registers before using the loaded value e.g. as an wgmma/tcgen05.mma operand.
