### PR TITLE
[python][amd] Check backend for libamdhip64.so

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -81,6 +81,12 @@ def _get_path_to_hip_runtime_dylib():
 
     paths = []
 
+    # Check backend
+    local_lib = os.path.join(os.path.dirname(__file__), "lib", lib_name)
+    if os.path.exists(local_lib):
+        return local_lib
+    paths.append(local_lib)
+
     import site
     # First search the HIP runtime dynamic library packaged with PyTorch. It's very likely
     # that we run Triton together with PyTorch. This makes sure we use the same dynamic


### PR DESCRIPTION
At Meta, we want to distribute libamdhip64.so alongside the AMD backend, similar to how we already distribute [ptxas](https://github.com/triton-lang/triton/blob/main/third_party/nvidia/backend/compiler.py#L38) and [ld.lld](https://github.com/triton-lang/triton/blob/main/third_party/amd/backend/compiler.py#L196).

This PR implements that change.

cc @njriasan , @zhuhan0 