### PR TITLE
[BE][PIPELINE] Enabling mmav5 pipelining for 2 dots in the loop by default

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -267,7 +267,7 @@ public:
           mmav5Count++;
         }
       }
-      if (mmav5Count > 1)
+      if (mmav5Count > 2)
         return;
     }
     // Check if the load op (mma operand) is pipelineable.

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -1234,7 +1234,7 @@ scf::ForOp lowerMMAs(scf::ForOp forOp, CoarseSchedule &schedule) {
   SmallVector<ttng::MMAv5OpInterface> mmas;
   forOp.walk([&](ttng::MMAv5OpInterface mma) { mmas.push_back(mma); });
   if (!triton::tools::getBoolEnv("ENABLE_MMA_V5_ATT_PIPELINE")) {
-    if (mmas.size() > 1) {
+    if (mmas.size() > 2) {
       return forOp;
     }
   }


### PR DESCRIPTION
This change enables MMAv5 pipelining for loops with 2 dot ops. This unblocks pipelining of attention forward kernels. MMAv5 pipelining for attention backward (which have more than 2 dots) is still disabled, as there are still cases that regress in performance.