### PR TITLE
Add Python ABI tag to the filename of cached C binary

### DIFF
--- a/python/triton/backends/driver.py
+++ b/python/triton/backends/driver.py
@@ -5,10 +5,8 @@ from typing import Callable, List, Protocol, Sequence
 
 @functools.lru_cache()
 def platform_key():
-    import sysconfig
     from platform import machine, system, architecture
-    suffix = sysconfig.get_config_var('EXT_SUFFIX')
-    return ",".join([machine(), system(), *architecture(), suffix])
+    return ",".join([machine(), system(), *architecture()])
 
 
 class Benchmarker(Protocol):

--- a/python/triton/backends/driver.py
+++ b/python/triton/backends/driver.py
@@ -1,5 +1,14 @@
+import functools
 from abc import ABCMeta, abstractmethod
 from typing import Callable, List, Protocol, Sequence
+
+
+@functools.lru_cache()
+def platform_key():
+    import sysconfig
+    from platform import machine, system, architecture
+    suffix = sysconfig.get_config_var('EXT_SUFFIX')
+    return ",".join([machine(), system(), *architecture(), suffix])
 
 
 class Benchmarker(Protocol):

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from triton.runtime.build import _build
 from triton.runtime.cache import get_cache_manager
 from triton.backends.compiler import GPUTarget
-from triton.backends.driver import GPUDriver
+from triton.backends.driver import GPUDriver, platform_key
 
 dirname = os.path.dirname(os.path.realpath(__file__))
 include_dir = [os.path.join(dirname, "include")]
@@ -131,7 +131,7 @@ def _get_path_to_hip_runtime_dylib():
 
 
 def compile_module_from_src(src, name):
-    key = hashlib.sha256(src.encode("utf-8")).hexdigest()
+    key = hashlib.sha256((src + platform_key()).encode("utf-8")).hexdigest()
     cache = get_cache_manager(key)
     cache_path = cache.get_file(f"{name}.so")
     if cache_path is None:

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -2,6 +2,7 @@ import functools
 import os
 import hashlib
 import subprocess
+import sysconfig
 import tempfile
 from pathlib import Path
 from triton.runtime.build import _build
@@ -133,7 +134,8 @@ def _get_path_to_hip_runtime_dylib():
 def compile_module_from_src(src, name):
     key = hashlib.sha256((src + platform_key()).encode("utf-8")).hexdigest()
     cache = get_cache_manager(key)
-    cache_path = cache.get_file(f"{name}.so")
+    suffix = sysconfig.get_config_var("EXT_SUFFIX")
+    cache_path = cache.get_file(f"{name}{suffix}")
     if cache_path is None:
         with tempfile.TemporaryDirectory() as tmpdir:
             src_path = os.path.join(tmpdir, "main.c")
@@ -141,7 +143,7 @@ def compile_module_from_src(src, name):
                 f.write(src)
             so = _build(name, src_path, tmpdir, [], include_dir, [])
             with open(so, "rb") as f:
-                cache_path = cache.put(f.read(), f"{name}.so", binary=True)
+                cache_path = cache.put(f.read(), f"{name}{suffix}", binary=True)
     import importlib.util
     spec = importlib.util.spec_from_file_location(name, cache_path)
     mod = importlib.util.module_from_spec(spec)

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -11,7 +11,7 @@ from triton.runtime.build import _build
 from triton.runtime.cache import get_cache_manager
 from triton.runtime import _allocation
 from triton.backends.compiler import GPUTarget
-from triton.backends.driver import GPUDriver
+from triton.backends.driver import GPUDriver, platform_key
 
 from triton.tools.tensor_descriptor import TensorDescriptor
 
@@ -49,12 +49,6 @@ def libcuda_dirs():
 @functools.lru_cache()
 def library_dirs():
     return [libdevice_dir, *libcuda_dirs()]
-
-
-@functools.lru_cache()
-def platform_key():
-    from platform import machine, system, architecture
-    return ",".join([machine(), system(), *architecture()])
 
 
 def compile_module_from_src(src, name):

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -54,8 +54,8 @@ def library_dirs():
 def compile_module_from_src(src, name):
     key = hashlib.sha256((src + platform_key()).encode("utf-8")).hexdigest()
     cache = get_cache_manager(key)
-    ext = sysconfig.get_config_var("EXT_SUFFIX").split(".")[-1]
-    cache_path = cache.get_file(f"{name}.{ext}")
+    suffix = sysconfig.get_config_var("EXT_SUFFIX")
+    cache_path = cache.get_file(f"{name}{suffix}")
     if cache_path is None:
         with tempfile.TemporaryDirectory() as tmpdir:
             src_path = os.path.join(tmpdir, "main.c")
@@ -63,7 +63,7 @@ def compile_module_from_src(src, name):
                 f.write(src)
             so = _build(name, src_path, tmpdir, library_dirs(), include_dir, libraries)
             with open(so, "rb") as f:
-                cache_path = cache.put(f.read(), f"{name}.{ext}", binary=True)
+                cache_path = cache.put(f.read(), f"{name}{suffix}", binary=True)
     import importlib.util
     spec = importlib.util.spec_from_file_location(name, cache_path)
     mod = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
This is an alternative of #6589, and related to #4809 #6000

We add the Python ABI tag to the filename of each cached C binary, to avoid linking errors when the user switches the Python version.

According to the [comment](https://github.com/triton-lang/triton/pull/4809#issuecomment-2376984522), I move the function `platform_key` to `triton.backends.driver`. The AMD-specific behavior can be implemented on top of this PR if needed.

I think `sysconfig.get_config_var('EXT_SUFFIX')` is the proper way to get the ABI tag. It supports Python 3.9 to 3.13, both Linux and Windows, and many kinds of Python distributions including the embedded and the standalone builds. It also distinguishes cp313 and cp313t ([free-threaded](https://docs.python.org/3/howto/free-threading-python.html)), which we may need in future. It has been used a few times in the codebase.

If I understand correctly, `sysconfig.get_config_var('EXT_SUFFIX')` also covers everything in `machine(), system(), *architecture()`, but for now I leave them as they are.

Note that this PR only focus on the C binaries. As of the current main branch, the cache hashes of CUDA binaries also depend on the Python version, but I think they should not, and we can discuss that later.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because: The test requires two Python versions, which is out of the current scope of pytest. I've tested this locally.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)