### PR TITLE
[TMA] Avoid in-place modification of TensorDescriptor arguments

### DIFF
--- a/python/tutorials/10-block-scaled-matmul.py
+++ b/python/tutorials/10-block-scaled-matmul.py
@@ -361,6 +361,7 @@ if __name__ == "__main__":
 
         if args.bench:
             proton.start("block_scaled_matmul", hook="triton")
+            proton.deactivate(0)  # Skip argument creation
             for K in range(args.K_range[0], args.K_range[1] + 1, args.K_step):
                 bench_block_scaled(K, reps=10000, block_scale_type=args.format)
             proton.finalize()

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -570,6 +570,7 @@ def make_tensordesc_arg(arg, metadata):
     result = [desc, *shape, *strides]
 
     if fp4_padded:
+        shape = list(shape)
         shape[-1] *= 2
     triton.runtime.driver.active.utils.fill_tma_descriptor(
         desc.tma_desc_cpu_ptr(),


### PR DESCRIPTION
For FP4 padded format, we need to pass double the shape in the last dimension to represent the number of fp4 elements instead of uint8 elements. However, we were doing this update inplace on the `TensorDescriptor` arugment so the last dim would double in size every time you reused the same descriptor.

Also fixed the mxfp benchmark to leave argument initialization out of the recorded trace.