### PR TITLE
Fix thirdparty builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -586,8 +586,10 @@ backends = [*BackendInstaller.copy(["nvidia", "amd"]), *BackendInstaller.copy_ex
 def language_extras_install_path():
     return os.path.abspath(os.path.join(os.path.dirname(__file__), "python", "triton", "language", "extra"))
 
+
 def tools_extra_install_path():
     return os.path.abspath(os.path.join(os.path.dirname(__file__), "python", "triton", "tools", "extra"))
+
 
 def get_package_dirs():
     yield ("", "python")


### PR DESCRIPTION
This change tweaks the paths generated by `get_package_dirs` so they're relative to their respective package.

Thirdparty backends specified via `TRITON_PLUGIN_DIRS` were using absolute paths, which causes setup.py to fail with..

```
error: Error: setup script specifies an absolute path:

       $external_triton_path/backend
```

For each external backend/language/tool.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `setup.py build fix `.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
