### PR TITLE
Add `TRITON_IGNORE_LIBTRITON_HASH` for hash stability between Python versions

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -144,7 +144,10 @@ def triton_key():
             with open(lib.module_finder.find_spec(lib.name).origin, "rb") as f:
                 contents += [hashlib.sha256(f.read()).hexdigest()]
 
-    if os.environ.get("TRITON_IGNORE_LIBTRITON_HASH", "0") == "0":
+    if os.environ.get("TRITON_IGNORE_LIBTRITON_HASH", "0") == "1":
+        import importlib
+        contents.append(importlib.metadata.version("triton"))
+    else:
         # backend
         libtriton_hash = hashlib.sha256()
         ext = sysconfig.get_config_var("EXT_SUFFIX").split(".")[-1]

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -144,7 +144,7 @@ def triton_key():
             with open(lib.module_finder.find_spec(lib.name).origin, "rb") as f:
                 contents += [hashlib.sha256(f.read()).hexdigest()]
 
-    if os.environ.get("TRITON_IGNORE_LIBTRITON_HASH", "0") == "1":
+    if config.cache.ignore_libtriton_hash:
         import importlib
         contents.append(importlib.metadata.version("triton"))
     else:

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -144,16 +144,18 @@ def triton_key():
             with open(lib.module_finder.find_spec(lib.name).origin, "rb") as f:
                 contents += [hashlib.sha256(f.read()).hexdigest()]
 
-    # backend
-    libtriton_hash = hashlib.sha256()
-    ext = sysconfig.get_config_var("EXT_SUFFIX").split(".")[-1]
-    with open(os.path.join(TRITON_PATH, "_C", f"libtriton.{ext}"), "rb") as f:
-        while True:
-            chunk = f.read(1024**2)
-            if not chunk:
-                break
-            libtriton_hash.update(chunk)
-    contents.append(libtriton_hash.hexdigest())
+    if os.environ.get("TRITON_IGNORE_LIBTRITON_HASH", "0") == "0":
+        # backend
+        libtriton_hash = hashlib.sha256()
+        ext = sysconfig.get_config_var("EXT_SUFFIX").split(".")[-1]
+        with open(os.path.join(TRITON_PATH, "_C", f"libtriton.{ext}"), "rb") as f:
+            while True:
+                chunk = f.read(1024**2)
+                if not chunk:
+                    break
+                libtriton_hash.update(chunk)
+        contents.append(libtriton_hash.hexdigest())
+
     # language
     language_path = os.path.join(TRITON_PATH, 'language')
     for lib in pkgutil.walk_packages([language_path], prefix="triton.language."):

--- a/python/triton/config.py
+++ b/python/triton/config.py
@@ -269,6 +269,8 @@ class cache_config(base_config):
     manager_class: env_class[CacheManager] = env_class("TRITON_CACHE_MANAGER", "CacheManager")
     remote_manager_class: env_class[RemoteCacheBackend] = env_class("TRITON_REMOTE_CACHE_BACKEND", "RemoteCacheBackend")
 
+    ignore_libtriton_hash: env_bool = env_bool("TRITON_IGNORE_LIBTRITON_HASH")
+
     def get_triton_dir(self, dirname: str) -> str:
         return os.path.join(self.home_dir, ".triton", dirname)
 


### PR DESCRIPTION
This is for reducing the disk usage of the JIT-compiled CUDA binaries (such as `add_kernel.cubin`). For example, when running a large AI model such as Wan with torch.compile autotune, the cached binaries can take 500 MB of disk space, and I would like to avoid recompiling them when switching the Python version.

Conceptually, the CUDA binaries generated by Triton should not depend on the Python version (they don't involve any C-Python binding), and I've tested that their binary contents are actually the same between Python versions. However, in the current implementation, the cache folder hash depends on libtriton, which involves the C-Python binding. Also, the binary content of libtriton can depend on some debug infomation such as the tmp path where it's compiled.

I propose to add the environment variable `TRITON_IGNORE_LIBTRITON_HASH`, which can opt in to ignore this dependency. Then the cache can be reused between Python versions, and the user is responsible for clearing the cache if they somehow updated the functionality of libtriton without changing the rest Python code in the package.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because: The test requires two Python versions, which is out of the current scope of pytest. I've tested locally.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
