### PR TITLE
[AMD][BACKEND] Add alias information to `other` stores from `AsyncCopy/BufferLoadToLocal`

### DIFF
--- a/test/Conversion/amd/async-ops-alias-scopes.mlir
+++ b/test/Conversion/amd/async-ops-alias-scopes.mlir
@@ -1,18 +1,24 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s --check-prefixes=COMMON,GFX950
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 | FileCheck %s --check-prefixes=COMMON,GFX942
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 --convert-builtin-func-to-llvm | FileCheck %s --check-prefixes=COMMON,GFX950
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --convert-builtin-func-to-llvm | FileCheck %s --check-prefixes=COMMON,GFX942
 
 // COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.AsyncCopies"
+// COMMON: [[LOCAL_LOAD_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.LocalLoads"
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @async_copy_alias(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
-                                                         %arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable>) {
+                                                         %arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable>,
+                                                         %maskVal: i1,
+                                                         %other: tensor<64x1xf16, #blocked>) {
     // We need the splat to allow the AxisAnalysis to work during lowering
     %ptr = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x1x!tt.ptr<f16>, #blocked>
+    %mask = tt.splat %maskVal : i1 -> tensor<64x1xi1, #blocked>
 
     // COMMON: rocdl.global.load.lds {{.*}} {alias_scopes = [[[ASYNC_COPY_SCOPE]]]
-    %0 = ttg.async_copy_global_to_local %ptr, %arg1 : tensor<64x1x!tt.ptr<f16>, #blocked> -> <64x1xf16, #shared, #smem, mutable>
+    // Check that store for 'other' has alias information set
+    // COMMON: llvm.store {{.*}} {alias_scopes = [[[LOCAL_LOAD_SCOPE]]], noalias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    %0 = ttg.async_copy_global_to_local %ptr, %arg1 mask %mask other %other : tensor<64x1x!tt.ptr<f16>, #blocked> -> <64x1xf16, #shared, #smem, mutable>
 
     // COMMON: llvm.return
     tt.return
@@ -26,12 +32,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @buffer_load_to_local_alias(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+  tt.func public @buffer_load_to_local_alias(%maskVal: i1,
                                              %arg1: !tt.ptr<f16>,
                                              %arg2: tensor<8x64xi32, #blocked>,
                                              %arg3: !ttg.memdesc<8x64xf16, #shared, #smem, mutable>) {
+    %mask = tt.splat %maskVal : i1 -> tensor<8x64xi1, #blocked>
+    %cst_1 = arith.constant dense<1.000000e+00> : tensor<8x64xf16, #blocked>
+
     // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}} {alias_scopes = [[[ASYNC_COPY_SCOPE]]]
-    %65 = amdgpu.buffer_load_to_local %arg1[%arg2] into %arg3 {OpIdx = #amdgpu.OpIdx<1>} : <f16>[tensor<8x64xi32, #blocked>] -> <8x64xf16, #shared, #smem, mutable>
+    // Check that store for 'other' has alias information set
+    // COMMON: llvm.store {{.*}} {alias_scopes = [[[LOCAL_LOAD_SCOPE]]], noalias_scopes = [[[ASYNC_COPY_SCOPE]]]
+    %65 = amdgpu.buffer_load_to_local %arg1[%arg2] mask=%mask other=%cst_1 into %arg3 {OpIdx = #amdgpu.OpIdx<1>} : <f16>[tensor<8x64xi32, #blocked>] tensor<8x64xf16, #blocked> -> <8x64xf16, #shared, #smem, mutable>
+
     // COMMON: llvm.return
     tt.return
   }
@@ -39,8 +51,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
-// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.AsyncCopies"
 // COMMON: [[LOCAL_LOAD_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.LocalLoads"
+// COMMON: [[ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.AsyncCopies"
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
 #shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
@@ -49,15 +61,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @local_loads_with_token_from_async_wait(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
                                                          %arg1: !ttg.memdesc<64x1xf16, #shared, #smem, mutable>,
-                                                         %arg4: !ttg.memdesc<16x16xf16, #shared, #smem, mutable>) {
-    // We need the splat to allow the AxisAnalysis to work during lowering
-    %ptr = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x1x!tt.ptr<f16>, #blocked>
-
-    // COMMON: rocdl.global.load.lds {{.*}} {alias_scopes = [[[ASYNC_COPY_SCOPE]]]
-    %0 = ttg.async_copy_global_to_local %ptr, %arg1 : tensor<64x1x!tt.ptr<f16>, #blocked> -> <64x1xf16, #shared, #smem, mutable>
-    %1 = ttg.async_commit_group %0
-
-    %3 = ttg.async_wait %1 {num = 1 : i32}
+                                                         %arg2: !ttg.memdesc<16x16xf16, #shared, #smem, mutable>) {
+    %3 = ttg.async_wait {num = 1 : i32}
 
     // Check alias information is added for different lowering paths
 
@@ -68,7 +73,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // Test lowering path in AMD's MemoryOpToLLVM pattern
     // GFX942-COUNT-8: llvm.load {{.*}} {alias_scopes = [[[LOCAL_LOAD_SCOPE]]], {{.*}}, noalias_scopes = [[[ASYNC_COPY_SCOPE]]]
     // GFX950-COUNT-2: rocdl.ds.read.tr16.b64 {{.*}} {alias_scopes = [[[LOCAL_LOAD_SCOPE]]], noalias_scopes = [[[ASYNC_COPY_SCOPE]]]
-    %5 = ttg.local_load %arg4 token %3 : !ttg.memdesc<16x16xf16, #shared, #smem, mutable> -> tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    %5 = ttg.local_load %arg2 token %3 : !ttg.memdesc<16x16xf16, #shared, #smem, mutable> -> tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+
+    // Stores to keep the local_loads
+    %ptr = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x1x!tt.ptr<f16>, #blocked>
+    tt.store %ptr, %4 : tensor<64x1x!tt.ptr<f16>, #blocked>
+    %ptr2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    tt.store %ptr2, %5 : tensor<16x16x!tt.ptr<f16>, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
 
     // COMMON: llvm.return
     tt.return

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
@@ -77,6 +77,11 @@ private:
         mlir::LLVM::AMD::getCacheModifierFlagsForPredicatedCall(callOp);
     auto storeOp = rewriter.create<LLVM::StoreOp>(
         loc, val, ptr, /*alignment=*/0, volatileFlag, nonTmpFlag);
+    bool addAsyncNoAliasInfo =
+        callOp.getCallee().value().contains(mlir::LLVM::AMD::noAliasAsyncLoads);
+    if (addAsyncNoAliasInfo) {
+      LLVM::AMD::addLocalLoadNoAliasScope(storeOp);
+    }
     rewriter.create<LLVM::BrOp>(loc, afterStore);
     rewriter.setInsertionPointToStart(afterStore);
     rewriter.eraseOp(callOp);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
@@ -77,9 +77,9 @@ private:
         mlir::LLVM::AMD::getCacheModifierFlagsForPredicatedCall(callOp);
     auto storeOp = rewriter.create<LLVM::StoreOp>(
         loc, val, ptr, /*alignment=*/0, volatileFlag, nonTmpFlag);
-    bool addAsyncNoAliasInfo =
+    bool addAsyncAliasScopes =
         callOp.getCallee().value().contains(mlir::LLVM::AMD::noAliasAsyncLoads);
-    if (addAsyncNoAliasInfo) {
+    if (addAsyncAliasScopes) {
       LLVM::AMD::addLocalLoadNoAliasScope(storeOp);
     }
     rewriter.create<LLVM::BrOp>(loc, afterStore);
@@ -117,6 +117,11 @@ private:
         mlir::LLVM::AMD::getCacheModifierFlagsForPredicatedCall(callOp);
     auto loadOp = rewriter.create<LLVM::LoadOp>(
         loc, elemTy, ptr, /*alignment=*/0, volatileFlag, nonTmpFlag);
+    bool addAsyncNoAliasInfo =
+        callOp.getCallee().value().contains(mlir::LLVM::AMD::noAliasAsyncLoads);
+    if (addAsyncNoAliasInfo) {
+      LLVM::AMD::addLocalLoadNoAliasScope(loadOp);
+    }
     rewriter.create<LLVM::BrOp>(loc, loadOp->getResult(0), afterLoad);
     rewriter.setInsertionPointToStart(falseBlock);
     rewriter.create<LLVM::BrOp>(loc, falseVal, afterLoad);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -603,7 +603,8 @@ struct BufferLoadToLocalOpConversion
             rewriter, this->getTypeConverter(), loc, vecTy, otherElems, srcIdx);
         llStore(rewriter, loc,
                 hasSwizzling ? swizzledShmemAddr[i] : coalescedShmemAddr[i],
-                storeVal, b.icmp_ne(pred, b.true_val()), op.getCache());
+                storeVal, b.icmp_ne(pred, b.true_val()), op.getCache(),
+                /*aliasAsyncLoads=*/false);
       }
     }
 
@@ -748,7 +749,7 @@ struct AsyncCopyGlobalToLocalOpConversion
         llStore(rewriter, loc,
                 hasSwizzling ? swizzledShmemAddr[i] : coalescedShmemAddr[i],
                 storeVal, b.icmp_ne(maskElems[srcIdx], b.true_val()),
-                op.getCache());
+                op.getCache(), /*aliasAsyncLoads=*/false);
       }
     }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -604,7 +604,7 @@ struct BufferLoadToLocalOpConversion
         llStore(rewriter, loc,
                 hasSwizzling ? swizzledShmemAddr[i] : coalescedShmemAddr[i],
                 storeVal, b.icmp_ne(pred, b.true_val()), op.getCache(),
-                /*aliasAsyncLoads=*/false);
+                /*forceNoAliasAsyncLoads=*/true);
       }
     }
 
@@ -749,7 +749,7 @@ struct AsyncCopyGlobalToLocalOpConversion
         llStore(rewriter, loc,
                 hasSwizzling ? swizzledShmemAddr[i] : coalescedShmemAddr[i],
                 storeVal, b.icmp_ne(maskElems[srcIdx], b.true_val()),
-                op.getCache(), /*aliasAsyncLoads=*/false);
+                op.getCache(), /*forceNoAliasAsyncLoads=*/true);
       }
     }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -316,29 +316,35 @@ Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
 }
 
 void llStore(RewriterBase &rewriter, Location loc, Value ptr, Value val,
-             Value pred, triton::CacheModifier cm) {
+             Value pred, triton::CacheModifier cm, bool aliasAsyncLoad) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
   auto ctx = ptr.getContext();
   Type funcType = getFunctionType(void_ty(ctx), ValueRange({ptr, val, pred}));
   auto parent = ptr.getParentRegion()->getParentOfType<LLVM::LLVMFuncOp>();
-  auto getStoreNameRaw = [](triton::CacheModifier cm) {
-    switch (cm) {
-    case triton::CacheModifier::WT:
-      return predicatedStoreWT;
-    case triton::CacheModifier::CG:
-      return predicatedStoreCG;
-    case triton::CacheModifier::CS:
-      return predicatedStoreCS;
-    default:
-      // Do not fail in compile time in the case of unsupported modifier.
-      // Just apply default config.
-      return predicatedStore;
-    }
-  };
-  auto funcName = mangleFunc(getStoreNameRaw(cm), funcType);
+
+  std::string funcName;
+  switch (cm) {
+  case triton::CacheModifier::NONE:
+    funcName += predicatedStore;
+  case triton::CacheModifier::WT:
+    funcName += predicatedStoreWT;
+  case triton::CacheModifier::CG:
+    funcName += predicatedStoreCG;
+  case triton::CacheModifier::CS:
+    funcName += predicatedStoreCS;
+  default:
+    // Do not fail in compile time in the case of unsupported modifier.
+    // Just apply default config.
+    funcName += predicatedStore;
+    // TODO proper error handling
+  }
+  if (!aliasAsyncLoad) {
+    funcName += noAliasAsyncLoads;
+  }
+  auto mangledName = mangleFunc(funcName, funcType);
   LLVM::LLVMFuncOp funcOp =
-      appendOrGetExternFuncOp(rewriter, parent, funcName, funcType);
+      appendOrGetExternFuncOp(rewriter, parent, mangledName, funcType);
   LLVM::createLLVMCallOp(rewriter, loc, funcOp, ValueRange({ptr, val, pred}));
 }
 
@@ -728,11 +734,13 @@ void addAsyncCopyAliasScope(AliasAnalysisOpInterface directToLdsOp) {
 void addLocalLoadNoAliasScope(triton::gpu::LocalLoadOp localLoadOp,
                               AliasAnalysisOpInterface llLoadOp) {
   auto token = localLoadOp.getToken();
-  if (!token)
-    return;
-  if (!token.getDefiningOp<tt::gpu::AsyncWaitOp>())
+  if (!token || !token.getDefiningOp<tt::gpu::AsyncWaitOp>())
     return;
 
+  return addLocalLoadNoAliasScope(llLoadOp);
+}
+
+void addLocalLoadNoAliasScope(AliasAnalysisOpInterface llLoadOp) {
   auto ctx = llLoadOp->getContext();
 
   // Do not alias with AsyncCopies

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -49,7 +49,7 @@ Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
 // Stores to shared or global memory with predication.
 void llStore(RewriterBase &rewriter, Location loc, Value ptr, Value val,
              Value pred, triton::CacheModifier cm = triton::CacheModifier::NONE,
-             bool aliasAsyncLoads = true);
+             bool forceNoAliasAsyncLoads = false);
 
 // Get cache modifier information for creating load or store instruction
 // Get flags <volatile, nontemporal> for a predicated Load or Store

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -22,6 +22,7 @@ const char predicatedStore[] = "__predicated_store";
 const char predicatedStoreCG[] = "__predicated_store_CG";
 const char predicatedStoreCS[] = "__predicated_store_CS";
 const char predicatedStoreWT[] = "__predicated_store_WT";
+const char noAliasAsyncLoads[] = "__no_alias_async_loads";
 
 Value shuffleXor(Location loc, RewriterBase &rewriter, Value val, int i,
                  mlir::triton::AMD::ISAFamily isaFamily =
@@ -47,8 +48,8 @@ Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
 
 // Stores to shared or global memory with predication.
 void llStore(RewriterBase &rewriter, Location loc, Value ptr, Value val,
-             Value pred,
-             triton::CacheModifier cm = triton::CacheModifier::NONE);
+             Value pred, triton::CacheModifier cm = triton::CacheModifier::NONE,
+             bool aliasAsyncLoads = true);
 
 // Get cache modifier information for creating load or store instruction
 // Get flags <volatile, nontemporal> for a predicated Load or Store
@@ -128,6 +129,8 @@ bool isChainDotTail(mlir::triton::DotOpInterface dotOp);
 //  - Attaches "amdgpu.AsyncCopies" as *non* alias scope to llLoadOp
 void addLocalLoadNoAliasScope(triton::gpu::LocalLoadOp localLoadOp,
                               AliasAnalysisOpInterface llLoadOp);
+// Overload from above without checking the AsyncToken
+void addLocalLoadNoAliasScope(AliasAnalysisOpInterface llLoadOp);
 // Attaches the "AsyncCopies" alias scope to llLoadDirectToLdsOp
 void addAsyncCopyAliasScope(AliasAnalysisOpInterface llLoadDirectToLdsOp);
 


### PR DESCRIPTION
This PR adds noAlias information to stores into LDS for `other` values from `AsyncCopy/BufferLoadToLocal`. Without this change LLVM will add conservative waits before the `ds_writes` because it cannot see that the `direct-to-lds` loads and `ds_writes` do not alias.

Similar to https://github.com/triton-lang/triton/pull/6450 which did it for `LocalLoads`.