### PR TITLE
Fixing external plugin builds.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,9 +5,9 @@ graft include
 graft lib
 graft python/src
 graft python/test
-graft python/triton/backends/amd
-graft python/triton/backends/nvidia
-graft python/triton/tools/extra/cuda
+graft python/triton/backends
+graft python/triton/tools/extra
+graft python/triton/language/extra
 graft test
 graft third_party
 graft unittest


### PR DESCRIPTION
This change reintroduces the symlinking of backends to more setup.py commands. Having the symlinks lets us setup the package dirs in a consistent relative way, which fixes errors when building an external backend with TRITON_PLUGIN_DIRS.

Previously external backends would fail with...

```
error: Error: setup script specifies an absolute path:

       $external_triton_path/backend
```

for the backend and any language/tools extras it provides.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `Fixing build issue`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
