### PR TITLE
[python][config] Add cache.home_dir config

### DIFF
--- a/python/test/unit/conftest.py
+++ b/python/test/unit/conftest.py
@@ -27,7 +27,7 @@ def fresh_triton_cache():
 
 
 @pytest.fixture
-def fresh_config(request):
+def fresh_config(request, monkeypatch):
     from triton import config
     config_map = {
         name: conf
@@ -37,6 +37,8 @@ def fresh_config(request):
     try:
         for name, conf in config_map.items():
             setattr(config, name, conf.copy().reset())
+            for knob in conf.knob_descriptors.values():
+                monkeypatch.delenv(knob.key, raising=False)
         yield config
     finally:
         for name, conf in config_map.items():

--- a/python/test/unit/test_config.py
+++ b/python/test/unit/test_config.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import shutil
 import triton
@@ -129,6 +130,7 @@ def test_read_env(truthy, falsey, fresh_config, monkeypatch):
     assert fresh_config.runtime.debug
     assert not fresh_config.language.default_fp_fusion
     assert fresh_config.compilation.use_ir_loc == "ttir"
+    assert fresh_config.cache.home_dir == "/tmp/triton_home"
     assert fresh_config.cache.dir == "/tmp/triton_cache"
     assert fresh_config.cache.dump_dir == "/tmp/triton_home/.triton/dump"
     assert fresh_config.cache.override_dir == "/tmp/triton_home/.triton/override"
@@ -137,6 +139,24 @@ def test_read_env(truthy, falsey, fresh_config, monkeypatch):
     assert fresh_config.cache.manager_class == FileCacheManager
 
     assert fresh_config.build.backend_dirs == {"/tmp/cuda/crt", "/tmp/cuda/rt"}
+
+
+def test_triton_home(fresh_config, monkeypatch):
+    initial_home = fresh_config.cache.home_dir
+    assert initial_home == os.path.expanduser("~/")
+    assert fresh_config.cache.dir == os.path.join(initial_home, ".triton/cache")
+    assert fresh_config.cache.dump_dir == os.path.join(initial_home, ".triton/dump")
+    assert fresh_config.cache.override_dir == os.path.join(initial_home, ".triton/override")
+
+    monkeypatch.setenv("TRITON_HOME", "/tmp/triton_home")
+    assert fresh_config.cache.dir == "/tmp/triton_home/.triton/cache"
+    assert fresh_config.cache.dump_dir == "/tmp/triton_home/.triton/dump"
+    assert fresh_config.cache.override_dir == "/tmp/triton_home/.triton/override"
+
+    fresh_config.cache.home_dir = "/tmp/user/triton_home"
+    assert fresh_config.cache.dir == "/tmp/user/triton_home/.triton/cache"
+    assert fresh_config.cache.dump_dir == "/tmp/user/triton_home/.triton/dump"
+    assert fresh_config.cache.override_dir == "/tmp/user/triton_home/.triton/override"
 
 
 def test_set_config_directly(fresh_config, monkeypatch):

--- a/python/triton/config.py
+++ b/python/triton/config.py
@@ -199,14 +199,6 @@ class env_opt_bool(env_opt_base[bool, bool], env_bool):
     pass
 
 
-def get_triton_dir(dirname: str) -> str:
-    return os.path.join(
-        getenv("TRITON_HOME") or os.path.expanduser("~/"),
-        ".triton",
-        dirname,
-    )
-
-
 config_type = TypeVar("config_type", bound='base_config')
 
 
@@ -260,13 +252,21 @@ class redis_config(base_config):
     port: env_int = env_int("TRITON_REDIS_PORT", 6379)
 
 
+cache: cache_config
+
+
 class cache_config(base_config):
-    dump_dir: env_str = env_str("TRITON_DUMP_DIR", lambda: get_triton_dir("dump"))
-    override_dir: env_str = env_str("TRITON_OVERRIDE_DIR", lambda: get_triton_dir("override"))
-    dir: env_str = env_str("TRITON_CACHE_DIR", lambda: get_triton_dir("cache"))
+    home_dir: env_str = env_str("TRITON_HOME", lambda: os.path.expanduser("~/"))
+
+    dump_dir: env_str = env_str("TRITON_DUMP_DIR", lambda: cache.get_triton_dir("dump"))
+    override_dir: env_str = env_str("TRITON_OVERRIDE_DIR", lambda: cache.get_triton_dir("override"))
+    dir: env_str = env_str("TRITON_CACHE_DIR", lambda: cache.get_triton_dir("cache"))
 
     manager_class: env_class[CacheManager] = env_class("TRITON_CACHE_MANAGER", "CacheManager")
     remote_manager_class: env_class[RemoteCacheBackend] = env_class("TRITON_REMOTE_CACHE_BACKEND", "RemoteCacheBackend")
+
+    def get_triton_dir(self, dirname: str) -> str:
+        return os.path.join(self.home_dir, ".triton", dirname)
 
 
 class compilation_config(base_config):

--- a/python/triton/config.py
+++ b/python/triton/config.py
@@ -205,13 +205,17 @@ config_type = TypeVar("config_type", bound='base_config')
 class base_config:
 
     @property
-    def knobs(self) -> dict[str, Any]:
+    def knob_descriptors(self) -> dict[str, env_base]:
         return {
-            k: getattr(self, k)
+            k: v
             # data descriptors live on the class object
             for k, v in type(self).__dict__.items()
             if isinstance(v, env_base)
         }
+
+    @property
+    def knobs(self) -> dict[str, Any]:
+        return {k: getattr(self, k) for k in self.knob_descriptors.keys()}
 
     def copy(self: config_type) -> config_type:
         res = type(self)()


### PR DESCRIPTION
In https://github.com/triton-lang/triton/pull/6467 I didn't expose `TRITON_HOME` as its own knob, which meant if you wanted to programmatically override it you'd need to override all the `cache.*dir` knobs directly. I've exposed a new `cache.home_dir` knob so that you can programmatically customize all those directories at once.