### PR TITLE
[AMD] Remove f8 dtypes in type checking for gfx12

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -113,6 +113,9 @@ class HIPBackend(BaseBackend):
                 supported_fp8_dtypes.update({'fp8e4nv', 'fp8e4b8', 'fp8e5b16'})
             elif self.target.arch == 'gfx950':
                 supported_fp8_dtypes.update({'fp8e4nv', 'fp8e5'})
+            elif 'gfx12' in self.target.arch:
+                # Triton does not support f8 dtypes for gfx12 target yet.
+                supported_fp8_dtypes.update({})
             args["supported_fp8_dtypes"] = tuple(sorted(supported_fp8_dtypes))
 
         if "enable_fp_fusion" not in opts:


### PR DESCRIPTION
Currently Triton does not support f8 dtypes for gfx12. As a stub, remove all f8 in type checking to make failure message clearer
