### PR TITLE
[Dialect] Mark Join, Split, and Cat as non speculatable

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -493,7 +493,7 @@ def TT_BroadcastOp : TT_Op<"broadcast", [Pure,
     let hasVerifier = 1;
 }
 
-def TT_CatOp : TT_Op<"cat", [Pure,
+def TT_CatOp : TT_Op<"cat", [NoMemoryEffect,
                              SameTypeOperands,
                              SameOperandsAndResultElementType]> {
     let summary = "concatenate 2 tensors";
@@ -506,7 +506,7 @@ def TT_CatOp : TT_Op<"cat", [Pure,
 }
 
 def TT_JoinOp : TT_Op<"join", [
-    Pure, SameTypeOperands]> {
+    NoMemoryEffect, SameTypeOperands]> {
     let summary = "join two tensors along a new, minor dimension";
     let description = [{
         For example, if the two input tensors are 4x8xf32, returns a tensor of
@@ -526,7 +526,7 @@ def TT_JoinOp : TT_Op<"join", [
 }
 
 def TT_SplitOp : TT_Op<"split", [
-  Pure,
+  NoMemoryEffect,
   InferTypeOpWithLayoutEquivalence,
   TypesMatchWith<"outLHS and outRHS types match",
                   "outLHS", "outRHS", "$_self">,


### PR DESCRIPTION
This fixes bitwise internal determinism tests.
