### PR TITLE
[AMD][BACKEND] Filter barriers in `Membar` between `LocalLoads` and `AsyncCopy` when pipelining

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -34,6 +34,7 @@ void registerTestAliasPass();
 void registerTestAlignmentPass();
 void registerTestAllocationPass();
 void registerTestMembarPass();
+void registerTestAMDGPUTestMembarPass();
 void registerTestTritonAMDGPURangeAnalysis();
 } // namespace test
 } // namespace mlir
@@ -47,6 +48,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::test::registerTestAlignmentPass();
   mlir::test::registerTestAllocationPass();
   mlir::test::registerTestMembarPass();
+  mlir::test::registerTestAMDGPUTestMembarPass();
   mlir::test::registerTestTritonAMDGPURangeAnalysis();
   mlir::triton::registerConvertTritonToTritonGPUPass();
   mlir::triton::gpu::registerAllocateSharedMemoryPass();

--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -34,7 +34,7 @@ void registerTestAliasPass();
 void registerTestAlignmentPass();
 void registerTestAllocationPass();
 void registerTestMembarPass();
-void registerTestAMDGPUTestMembarPass();
+void registerTestAMDGPUMembarPass();
 void registerTestTritonAMDGPURangeAnalysis();
 } // namespace test
 } // namespace mlir
@@ -48,7 +48,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::test::registerTestAlignmentPass();
   mlir::test::registerTestAllocationPass();
   mlir::test::registerTestMembarPass();
-  mlir::test::registerTestAMDGPUTestMembarPass();
+  mlir::test::registerTestAMDGPUMembarPass();
   mlir::test::registerTestTritonAMDGPURangeAnalysis();
   mlir::triton::registerConvertTritonToTritonGPUPass();
   mlir::triton::gpu::registerAllocateSharedMemoryPass();

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory -test-print-membar | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory -test-tritonamdgpu-membar | FileCheck %s
 
 #AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #sliceAd0 = #ttg.slice<{dim = 0, parent = #AL}>

--- a/test/Conversion/amd/amdgpu_membar.mlir
+++ b/test/Conversion/amd/amdgpu_membar.mlir
@@ -1,0 +1,96 @@
+// RUN: triton-opt %s -split-input-file --convert-scf-to-cf --allocate-shared-memory -test-tritonamdgpu-membar | FileCheck %s
+
+#AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// Check that we only get a single barrier when using AsyncWait
+// CHECK-LABEL: pipelined_async_copy_local_to_global
+tt.func @pipelined_async_copy_local_to_global(%A: !tt.ptr<f16>) {
+  %index_0 = arith.constant 0 : i32
+  %index_1 = arith.constant 1 : i32
+  %a_ptr = tt.splat %A : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #AL>
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %tile_a = ttg.memdesc_subview %alloc[%index_0, %index_0, %index_0] : !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %tile_b = ttg.memdesc_subview %alloc[%index_1, %index_0, %index_0] : !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // Load TileA
+  %1 = ttg.async_copy_global_to_local %a_ptr, %tile_a: tensor<16x16x!tt.ptr<f16>, #AL> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // Wait for TileA
+  %2 = ttg.async_wait %1 {num = 4 : i32}
+  // Read TileA
+  %4 = ttg.local_load %tile_a token %2 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> tensor<16x16xf16, #AL>
+  // Load into TileB
+  %3 = ttg.async_copy_global_to_local %a_ptr, %tile_b : tensor<16x16x!tt.ptr<f16>, #AL> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // There should be a single barrier after async_wait
+  // CHECK-NOT: gpu.barrier
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: gpu.barrier
+  // CHECK-NOT: gpu.barrier
+  // CHECK: tt.return
+  tt.return
+}
+// Same as above but different order of ops
+// CHECK-LABEL: pipelined_async_copy_local_to_global_2
+tt.func @pipelined_async_copy_local_to_global_2(%A: !tt.ptr<f16>) {
+  %index_0 = arith.constant 0 : i32
+  %index_1 = arith.constant 1 : i32
+  %a_ptr = tt.splat %A : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #AL>
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %tile_a = ttg.memdesc_subview %alloc[%index_0, %index_0, %index_0] : !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %tile_b = ttg.memdesc_subview %alloc[%index_1, %index_0, %index_0] : !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // Load Tile
+  %1 = ttg.async_copy_global_to_local %a_ptr, %tile_a: tensor<16x16x!tt.ptr<f16>, #AL> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // Wait for TileA
+  %2 = ttg.async_wait %1 {num = 4 : i32}
+  // Load into TileB
+  %3 = ttg.async_copy_global_to_local %a_ptr, %tile_b : tensor<16x16x!tt.ptr<f16>, #AL> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // Read TileA
+  %4 = ttg.local_load %tile_a token %2 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> tensor<16x16xf16, #AL>
+  // There should be a single barrier after async_wait
+  // CHECK-NOT: gpu.barrier
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: gpu.barrier
+  // CHECK-NOT: gpu.barrier
+  // CHECK: tt.return
+  tt.return
+}
+// Check that AsyncWaits waiting on multiple values produce one barrier
+// CHECK-LABEL: pipelined_async_copy_local_to_global_3
+tt.func @pipelined_async_copy_local_to_global_3(%A: !tt.ptr<f16>, %B: !tt.ptr<f16>) {
+  %index_0 = arith.constant 0 : i32
+  %index_1 = arith.constant 1 : i32
+  %a_ptr = tt.splat %A : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #AL>
+  %b_ptr = tt.splat %B : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #AL>
+
+  %alloc_a = ttg.local_alloc : () -> !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %tile_a_1 = ttg.memdesc_subview %alloc_a[%index_0, %index_0, %index_0] : !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %tile_a_2 = ttg.memdesc_subview %alloc_a[%index_1, %index_0, %index_0] : !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+
+  %alloc_b = ttg.local_alloc : () -> !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %tile_b_1 = ttg.memdesc_subview %alloc_b[%index_0, %index_0, %index_0] : !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %tile_b_2 = ttg.memdesc_subview %alloc_b[%index_1, %index_0, %index_0] : !ttg.memdesc<2x16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+
+  // Load TileA_1
+  %1 = ttg.async_copy_global_to_local %a_ptr, %tile_a_1: tensor<16x16x!tt.ptr<f16>, #AL> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // Load TileB_1
+  %2 = ttg.async_copy_global_to_local %b_ptr, %tile_b_1: tensor<16x16x!tt.ptr<f16>, #AL> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // Wait for TileA
+  %3 = ttg.async_wait %1, %2 {num = 4 : i32}
+  // Read TileA_1
+  %4 = ttg.local_load %tile_a_1 token %3 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> tensor<16x16xf16, #AL>
+  // Read TileB_1
+  %5 = ttg.local_load %tile_b_1 token %3 : !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable> -> tensor<16x16xf16, #AL>
+  // Load into TileA_2
+  %6 = ttg.async_copy_global_to_local %a_ptr, %tile_a_2 : tensor<16x16x!tt.ptr<f16>, #AL> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // Load into TileB_2
+  %7 = ttg.async_copy_global_to_local %b_ptr, %tile_b_2 : tensor<16x16x!tt.ptr<f16>, #AL> -> !ttg.memdesc<16x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+
+  // There should be a single barrier after async_wait
+  // CHECK-NOT: gpu.barrier
+  // CHECK: ttg.async_wait
+  // CHECK-NEXT: gpu.barrier
+  // CHECK-NOT: gpu.barrier
+  // CHECK: tt.return
+  tt.return
+}
+}

--- a/test/Conversion/amd/amdgpu_membar.mlir
+++ b/test/Conversion/amd/amdgpu_membar.mlir
@@ -54,7 +54,7 @@ tt.func @pipelined_async_copy_local_to_global_2(%A: !tt.ptr<f16>) {
   // CHECK: tt.return
   tt.return
 }
-// Check that AsyncWaits waiting on multiple values produce one barrier
+// Check that multiple LocalLoads waiting on the same AsyncWait produce one barrier
 // CHECK-LABEL: pipelined_async_copy_local_to_global_3
 tt.func @pipelined_async_copy_local_to_global_3(%A: !tt.ptr<f16>, %B: !tt.ptr<f16>) {
   %index_0 = arith.constant 0 : i32

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -6,15 +6,15 @@
 namespace mlir::triton::AMD {
 // Filter function used in the AMDGPU backend to filter unnecessary barriers
 // during Membar Analysis. Filters applied by this function:
-// 1) Do not create barriers if one operand is a LocalLoad synced by an
-// AsyncWait. This prevents a redundant barrier between LocalLoad and prefetches
-// because membar cannot see that subviews from the same shared allocation do
-// not alias when pipelining loads. See amdgpu_membar.mlir for examples.
-// This filter can produce wrong IR/assembly if we pipeline with a single buffer
-// in lds because it filters out a required gpu.barrier between the LocalLoad
-// and the prefetches. However the pipeliner will always use at least 2 buffers
-// so this IR cannot be produced. Example membar input IR to produce incorrect
-// results:
+// 1) Do not create barriers between AsyncCopyGlobalToLocal and LocalLoad if the
+// LocalLoad is synced by AsyncWait. This prevents a redundant barrier between
+// LocalLoad and prefetches because membar cannot see that subviews from the
+// same shared allocation do not alias when pipelining loads. See
+// amdgpu_membar.mlir for examples. This filter can produce wrong IR/assembly if
+// we pipeline with a single buffer in lds because it filters out a required
+// gpu.barrier between the LocalLoad and the prefetches. However the pipeliner
+// will always use at least 2 buffers so this IR cannot be produced. Example
+// membar input IR to produce incorrect results:
 //   %tile_a = ttg.memdesc_subview
 //   %1 = AsyncCopyGlobalToLocal %ptr %tile_a
 //   scf.for

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -1,0 +1,10 @@
+#ifndef TRITON_THIRD_PARTY_AMD_INCLUDE_TRITONAMDGPUTOLLVM_MEMBARUTILITY_H_
+#define TRITON_THIRD_PARTY_AMD_INCLUDE_TRITONAMDGPUTOLLVM_MEMBARUTILITY_H_
+
+#include "mlir/IR/Operation.h"
+
+namespace mlir::triton::AMD {
+bool membarFilter(Operation *op1, Operation *op2);
+} // namespace mlir::triton::AMD
+
+#endif

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -4,12 +4,13 @@
 #include "mlir/IR/Operation.h"
 
 namespace mlir::triton::AMD {
-// Should be used to filter barriers during Membar Analysis.
-// There is one filter applied:
+// Filter function used in the AMDGPU backend to filter unnecessary barriers
+// during Membar Analysis. Filters applied by this function:
 // 1) Do not create barriers if one operand is a LocalLoad synced by an
-// AsyncWait. This prevents a redundant barrier because AsyncWait will already
-// create a barrier. (see amdgpu_membar.mlir for examples).
-// This fitler can produce incorrect assembly for the following IR:
+// AsyncWait. This prevents a redundant barrier between LocalLoad and prefetches
+// because membar cannot see that subviews from the same shared allocation do
+// not alias when pipelining loads. See amdgpu_membar.mlir for examples.
+// This filter can produce assembly for the following IR:
 //   %tile_a = ttg.subview
 //   %1 = AsyncCopyGlobalToLocal %ptr %tile_a
 //   scf.for

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -4,6 +4,22 @@
 #include "mlir/IR/Operation.h"
 
 namespace mlir::triton::AMD {
+// Should be used to filter barriers during Membar Analysis.
+// There is one filter applied:
+// 1) Do not create barriers if one operand is a LocalLoad synced by an
+// AsyncWait. This prevents a redundant barrier because AsyncWait will already
+// create a barrier. (see amdgpu_membar.mlir for examples).
+// This fitler can produce incorrect assembly for the following IR:
+//   %tile_a = ttg.subview
+//   %1 = AsyncCopyGlobalToLocal %ptr %tile_a
+//   scf.for
+//     %2 = AsyncWait %1
+//     %3 = LocalLoad %tile_a
+//     %4 = AsyncCopy %ptr_2 %tile_a
+//     scf.yield
+// Because there will be no barrier between %3 and %4 but they read/write to
+// the same location in shared memory. However, the pipeliner does always use at
+// least 2 buffers so this IR cannot be produced.
 bool membarFilter(Operation *op1, Operation *op2);
 } // namespace mlir::triton::AMD
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
@@ -23,6 +23,7 @@ add_triton_library(TritonAMDGPUToLLVM
     SPMDOpToLLVM.cpp
     SchedInstructions.cpp
     UpcastMXFPToLLVM.cpp
+    MembarUtility.cpp
 
     DEPENDS
     TritonAMDGPUConversionPassIncGen

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -1,10 +1,15 @@
 #include "third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h"
+#include "Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace mlir::triton::AMD {
 namespace {
 // Returns true if one of the operands is a LocalLoad synced via AsyncWait.
 bool filterAsyncLocalLoadsDeppendencies(Operation *op1, Operation *op2) {
+  auto isAsyncLoad = [](Operation *op) {
+    return llvm::isa<triton::gpu::AsyncCopyGlobalToLocalOp,
+                     triton::amdgpu::BufferLoadToLocalOp>(op);
+  };
   auto isLocalLoadWithAsyncWaitToken = [](Operation *op) {
     auto localLoad = llvm::dyn_cast<triton::gpu::LocalLoadOp>(op);
     if (!localLoad)
@@ -14,6 +19,11 @@ bool filterAsyncLocalLoadsDeppendencies(Operation *op1, Operation *op2) {
       return false;
     return true;
   };
+
+  // Early return if neither or both operands are an AsyncLoad
+  if (isAsyncLoad(op1) == isAsyncLoad(op2)) {
+    return false;
+  }
 
   return isLocalLoadWithAsyncWaitToken(op1) ||
          isLocalLoadWithAsyncWaitToken(op2);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -1,0 +1,24 @@
+#include "third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+namespace mlir::triton::AMD {
+namespace {
+bool isSyncedByAsyncWait(Operation *op1, Operation *op2) {
+  auto checkForAsyncLocalLoad = [](Operation *op) {
+    auto localLoad = llvm::dyn_cast<triton::gpu::LocalLoadOp>(op);
+    if (!localLoad)
+      return false;
+    auto token = localLoad.getToken();
+    if (!token || !token.getDefiningOp<triton::gpu::AsyncWaitOp>())
+      return false;
+    return true;
+  };
+
+  return checkForAsyncLocalLoad(op1) || checkForAsyncLocalLoad(op2);
+};
+} // namespace
+
+bool membarFilter(Operation *op1, Operation *op2) {
+  return isSyncedByAsyncWait(op1, op2);
+}
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -4,7 +4,7 @@
 namespace mlir::triton::AMD {
 namespace {
 // Returns true if one of the operands is a LocalLoad synced via AsyncWait.
-bool filterAsyncLocalLoads(Operation *op1, Operation *op2) {
+bool filterAsyncLocalLoadsDeppendencies(Operation *op1, Operation *op2) {
   auto isLocalLoadWithAsyncWaitToken = [](Operation *op) {
     auto localLoad = llvm::dyn_cast<triton::gpu::LocalLoadOp>(op);
     if (!localLoad)
@@ -21,6 +21,6 @@ bool filterAsyncLocalLoads(Operation *op1, Operation *op2) {
 } // namespace
 
 bool membarFilter(Operation *op1, Operation *op2) {
-  return filterAsyncLocalLoads(op1, op2);
+  return filterAsyncLocalLoadsDeppendencies(op1, op2);
 }
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -3,6 +3,7 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "SchedInstructions.h"
 #include "TargetInfo.h"
+#include "TritonAMDGPUToLLVM/MembarUtility.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/GPUToNVVM/GPUToNVVMPass.h"
@@ -97,7 +98,9 @@ struct ConvertTritonAMDGPUToLLVM
 
     // Allocate shared memory and set barrier
     ModuleAllocation allocation(mod);
-    ModuleMembarAnalysis membarPass(&allocation);
+
+    ModuleMembarAnalysis membarPass(&allocation,
+                                    mlir::triton::AMD::membarFilter);
     membarPass.run();
 
     // Lower functions

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -308,7 +308,7 @@ bool StreamPipeliner::createAsyncCopy(tt::LoadOp loadOp, Value alloc,
   // If we have a single buffer we would require another barrier after the
   // local_reads so instead we fall back to pipeline with registers
   // Removing this check will create incorrect IR, see
-  // MembarUtility.cpp:isSyncedByAsyncWait
+  // MembarUtility.h:membarFilter
   if (numBuffers == 1)
     return false;
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -307,6 +307,8 @@ bool StreamPipeliner::createAsyncCopy(tt::LoadOp loadOp, Value alloc,
   assert(useAsyncCopy);
   // If we have a single buffer we would require another barrier after the
   // local_reads so instead we fall back to pipeline with registers
+  // Removing this check will create incorrect IR, see
+  // MembarUtility.cpp:isSyncedByAsyncWait
   if (numBuffers == 1)
     return false;
 

--- a/third_party/amd/test/lib/Analysis/CMakeLists.txt
+++ b/third_party/amd/test/lib/Analysis/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_library(TritonAMDGPUTestAnalysis
   TestAMDRangeAnalysis.cpp
+  TestAMDGPUMembar.cpp
 
   DEPENDS
   TritonTableGen

--- a/third_party/amd/test/lib/Analysis/TestAMDGPUMembar.cpp
+++ b/third_party/amd/test/lib/Analysis/TestAMDGPUMembar.cpp
@@ -1,0 +1,39 @@
+#include "TritonAMDGPUToLLVM/MembarUtility.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "triton/Analysis/Allocation.h"
+#include "triton/Analysis/Membar.h"
+
+using namespace mlir;
+
+namespace {
+
+struct TestAMDGPUMembarPass
+    : public PassWrapper<TestAMDGPUMembarPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestAMDGPUMembarPass);
+
+  StringRef getArgument() const final { return "test-tritonamdgpu-membar"; }
+  StringRef getDescription() const final {
+    return "print the result of the membar analysis as run in the amdgpu "
+           "backend";
+  }
+
+  void runOnOperation() override {
+    Operation *operation = getOperation();
+    ModuleOp moduleOp = cast<ModuleOp>(operation);
+    // Print all ops after membar pass
+    ModuleAllocation allocation(moduleOp);
+    ModuleMembarAnalysis membarPass(&allocation,
+                                    mlir::triton::AMD::membarFilter);
+    membarPass.run();
+  }
+};
+
+} // namespace
+
+namespace mlir::test {
+void registerTestAMDGPUTestMembarPass() {
+  PassRegistration<TestAMDGPUMembarPass>();
+}
+} // namespace mlir::test

--- a/third_party/amd/test/lib/Analysis/TestAMDGPUMembar.cpp
+++ b/third_party/amd/test/lib/Analysis/TestAMDGPUMembar.cpp
@@ -20,8 +20,7 @@ struct TestAMDGPUMembarPass
   }
 
   void runOnOperation() override {
-    Operation *operation = getOperation();
-    ModuleOp moduleOp = cast<ModuleOp>(operation);
+    ModuleOp moduleOp = getOperation();
     // Print all ops after membar pass
     ModuleAllocation allocation(moduleOp);
     ModuleMembarAnalysis membarPass(&allocation,
@@ -33,7 +32,7 @@ struct TestAMDGPUMembarPass
 } // namespace
 
 namespace mlir::test {
-void registerTestAMDGPUTestMembarPass() {
+void registerTestAMDGPUMembarPass() {
   PassRegistration<TestAMDGPUMembarPass>();
 }
 } // namespace mlir::test


### PR DESCRIPTION
`Membar` does not deduce that two shared memory sub views do not alias if they are from the same allocation. When pipelining we therefore get barriers between the `LocalLoad` and the prefetch loads (`AsyncCopy/BufferLoadToLocal`) because they read/write into sub views of the same allocation.

This PR adds a filter function to Membar analysis to avoid those barriers by ignoring the dependency of `LocalLoad` if it consumes an `AsyncToken` from an `AsyncWait`. For such cases the barrier of the `AsyncWait` is enough to correctly synchronize the access. 
