### PR TITLE
Revert "[LAYOUTS] Use divideLeft on layout inference (#6577)"

### DIFF
--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -503,7 +503,7 @@ public:
   // This only works across the first (i.e. the most-minor) dimension of in/out.
   // If you want it to work across more dimensions, flatten the layout.
   //
-  // TODO: Replace the uses with flattenIns/Outs + divideLeft.
+  // TODO(jlebar): Replace with divideLeft.
   int32_t getNumConsecutiveInOut() const;
 
   // Reorders the in/out dimensions of the layout.  This is mostly cosmetic

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -426,12 +426,28 @@ LogicalResult tryJoinOnAxis(MLIRContext *ctx, const LinearLayout &inLl,
                             std::optional<Location> loc) {
   auto kRegister = StringAttr::get(ctx, "register");
   auto outDims = llvm::to_vector(inLl.getOutDimNames());
-  auto split = LinearLayout::identity1D(2, kRegister, outDims[axis]);
   if (fwdInference) {
+    auto split = LinearLayout::identity1D(2, kRegister, outDims[axis]);
     outLl = split * inLl;
   } else {
-    if (auto div = divideLeft(inLl, split)) {
-      outLl = *div;
+    // TODO This requires a division algorithm!
+    // Implement manually ll.divideLeft(split)
+    auto contiguousElems =
+        LinearEncodingAttr::get(ctx, inLl).getContigPerThread();
+    if (contiguousElems[axis] > 1) {
+      LinearLayout::BasesT newBases;
+      for (const auto &basesDim : inLl.getBases()) {
+        std::vector<std::vector<int32_t>> newBasesDim;
+        for (auto base : basesDim.second) {
+          if (base[axis] == 1) {
+            continue;
+          }
+          base[axis] /= 2;
+          newBasesDim.push_back(std::move(base));
+        }
+        newBases.insert({basesDim.first, std::move(newBasesDim)});
+      }
+      outLl = LinearLayout(std::move(newBases), std::move(outDims));
     } else {
       return emitOptionalError(loc,
                                "Fp4ToFpOp/SplitOp requires at least 2 elements "


### PR DESCRIPTION
There is a bug in layout inference. Will send a fix in a bit.
Reverting to keep main clean

This reverts commit 2cca24be0350f53770d53536d907d3a263f40f34.
