### PR TITLE
Revert "[BE][PIPELINE] Enabling mmav5 pipelining for 2 dots in the loop by default (#6599)"

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -267,7 +267,7 @@ public:
           mmav5Count++;
         }
       }
-      if (mmav5Count > 2)
+      if (mmav5Count > 1)
         return;
     }
     // Check if the load op (mma operand) is pipelineable.

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -1205,7 +1205,7 @@ scf::ForOp lowerMMAs(scf::ForOp forOp, CoarseSchedule &schedule) {
   SmallVector<ttng::MMAv5OpInterface> mmas;
   forOp.walk([&](ttng::MMAv5OpInterface mma) { mmas.push_back(mma); });
   if (!triton::tools::getBoolEnv("ENABLE_MMA_V5_ATT_PIPELINE")) {
-    if (mmas.size() > 2) {
+    if (mmas.size() > 1) {
       return forOp;
     }
   }


### PR DESCRIPTION
This reverts #6599 which caused test failures in our internal workloads.

OAI Ref: https://buildkite.com/organizations/openai-mono/pipelines/monorepo/builds/1350297/jobs/0196866c-f642-4feb-99cd-3cb7653c45cf/log