### PR TITLE
Remove is within_2gb check for specialization

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -143,17 +143,6 @@ class HIPBackend(BaseBackend):
         amd.load_dialects(ctx)
 
     @staticmethod
-    def is_within_2gb(arg):
-        import torch
-
-        MAX_INT_32 = 2**31 - 1
-        if hasattr(arg, "ptr_range"):
-            return arg.ptr_range() <= MAX_INT_32
-        if isinstance(arg, torch.Tensor) and hasattr(arg, "untyped_storage"):
-            return arg.untyped_storage().size() <= MAX_INT_32
-        return False
-
-    @staticmethod
     def parse_attr(desc):
         ret = BaseBackend.parse_attr(desc)
         if "S" in desc:
@@ -164,8 +153,7 @@ class HIPBackend(BaseBackend):
     def get_arg_specialization(arg, ty, **kwargs):
         ret = BaseBackend.get_arg_specialization(arg, ty, **kwargs)
         # Only attempt to do buffer ops specialization if buffer ops are enabled.
-        # Otherwise the is_within_2gb check is unnecessary overhead.
-        if knobs.amd.use_buffer_ops and ty == "tensor" and HIPBackend.is_within_2gb(arg):
+        if knobs.amd.use_buffer_ops and ty == "tensor":
             ret += "S"
         return ret
 


### PR DESCRIPTION
BufferOps are constructed by requiring that a base pointer be added to a tensor of int32 values that are non-negative. As a result, it should not be necessary to check the tensor fits within 2GB. This check is under specified because the only requirement should be the offsets using a 32-bit integer. If for example we were to add a scalar value to the base pointer, it doesn't seem like there should be any requirement the tensor couldn't be padded with additional memory. 

I want to remove this `is_within_2gb` check for 2 reasons.
1. The existing BufferOps implementation already does a better job of specifying this requirement.
2. This can add additional overhead to check with inference kernels that likely see minimal benefit from BufferOps.