### PR TITLE
[NFC][Layouts] Cleanup leading offset references + exponential iteration

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -54,9 +54,9 @@ LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout);
 //
 // If `disableSwizzle` is set, then the resulting layout does not include
 // swizzling.
-LinearLayout sharedToLinearLayoutLeadingOffset(ArrayRef<int64_t> shape,
-                                               NVMMASharedEncodingAttr shared,
-                                               bool disableSwizzle = false);
+LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
+                                       NVMMASharedEncodingAttr shared,
+                                       bool disableSwizzle = false);
 
 // Given a linear layout where the input dimensions contain a "block" dimension,
 // this method sets the "block" dimension to 0 and removes the corresponding

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -320,9 +320,8 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
   }
 
   // Then distribute the remaining rows.
-  for (int logRow = llvm::Log2_32(tileRows);
-       logRow < llvm::Log2_32(collapsedShapePerCTA[0]); logRow++) {
-    bases2D.push_back({1 << logRow, 0});
+  for (int row = tileRows; row < collapsedShapePerCTA[0]; row *= 2) {
+    bases2D.push_back({row, 0});
   }
 
   auto outDimNames = standardOutDimNames(ctx, 2);

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -318,8 +318,8 @@ LinearLayout::LinearLayout(
 
   assert(llvm::isPowerOf2_32(size));
   std::vector<std::vector<int32_t>> zeros;
-  for (int i = 0; i < llvm::Log2_32(size); i++) {
-    zeros.emplace_back().push_back(0);
+  for (int i = 1; i < size; i *= 2) {
+    zeros.emplace_back(std::vector<int32_t>{0});
   }
   return LinearLayout({{inDimName, zeros}}, {{outDimName, outDimSize}},
                       /*requiresSurjective=*/outDimSize == 1);
@@ -457,7 +457,7 @@ LinearLayout LinearLayout::reshapeIns(
   int i = 0;
   for (const auto &[inDim, inDimSize] : newInDims) {
     auto &newInDimBases = newBases[inDim];
-    for (int j = 0; j < llvm::Log2_32(inDimSize); j++) {
+    for (int j = 1; j < inDimSize; j *= 2) {
       newInDimBases.push_back(flatBases[i++]);
     }
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1432,7 +1432,7 @@ static LinearLayout getUnswizzledLayout(triton::gpu::MemDescType type) {
     assert(isa<ttg::SwizzledSharedEncodingAttr>(encoding));
     return ttg::toLinearLayout(type.getShape(), encoding);
   }
-  return ttg::sharedToLinearLayoutLeadingOffset(
+  return ttg::nvmmaSharedToLinearLayout(
       type.getShape(), cast<NVMMASharedEncodingAttr>(type.getEncoding()),
       /*disableSwizzle=*/true);
 }

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -758,17 +758,15 @@ TEST_F(LinearLayoutTest, QuotientIdentityMultipleDimensions) {
 LinearLayout getPackedCoordtoPaddedOffset(int M, int KPacked8b, StringAttr row,
                                           StringAttr col, StringAttr offset) {
   std::vector<std::vector<int>> basesRows, basesCols;
-  for (int i = 0; i < llvm::Log2_32(M); ++i) {
-    int row = 1 << i;
+  for (int row = 1; row < M; row *= 2) {
     int col = 0;
     int linearCoord = row * KPacked8b + col;
     int offset = (linearCoord / 8) * 16 + (linearCoord % 8);
     basesRows.push_back({offset});
   }
 
-  for (int j = 0; j < llvm::Log2_32(KPacked8b); ++j) {
+  for (int col = 1; col < KPacked8b; col *= 2) {
     int row = 0;
-    int col = 1 << j;
     int linearCoord = row * KPacked8b + col;
     int offset = (linearCoord / 8) * 16 + (linearCoord % 8);
     basesCols.push_back({offset});
@@ -785,8 +783,7 @@ TEST_F(LinearLayoutTest, BlackwellMixedPrecisionDotScaledSMEM) {
   int KPacked8b = numFp4Elems / M / 2;
   int KPadded8b = numFp4Elems / M;
 
-  for (int i = 0; i < llvm::Log2_32(M * KPadded8b); ++i) {
-    int offset = 1 << i;
+  for (int offset = 1; offset < M * KPadded8b; offset *= 2) {
     int linearCoordPacked = offset / 16 * 8 + offset % 8;
     int row = linearCoordPacked / KPacked8b;
     int col = linearCoordPacked % KPacked8b;
@@ -819,13 +816,11 @@ TEST_F(LinearLayoutTest, BlackwellMixedPrecisionDotScaledSMEMSwizzled) {
   int vec = 16;
 
   std::vector<std::vector<int>> bases2D;
-  for (int logCol = 0; logCol < llvm::Log2_32(tileCols); logCol++) {
-    int colPadded = 1 << logCol;
+  for (int colPadded = 1; colPadded < tileCols; colPadded *= 2) {
     int colPacked = colPadded / 16 * 8 + colPadded % 8;
     bases2D.push_back({0, colPacked});
   }
-  for (int logRow = 0; logRow < llvm::Log2_32(tileRows); logRow++) {
-    int row = 1 << logRow;
+  for (int row = 1; row < tileRows; row *= 2) {
     int perPhase = 1;
     int maxPhase = 8;
     int colPadded = vec * ((row / perPhase) % maxPhase);


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. [NFC][Layouts] Cleanup leading offset references + exponential iteration
    
    This does two things, firstly I cleanup outdated references to
    "LeadingOffset" in favour of NVMMA and Swizzled encodings.
    
    I also clean up iteration in log space + exponentiation e.g.
    ```
    for (int logI = 0; logI < Log2_32(size); logI++) {
        int i = 1 << logI;
    }
    ```
    to exponential iteration
    ```
    for (int i = 1; i < size; i *= 2) {
    }
    ```
1. Cleanup new loop

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #6665 👈 **YOU ARE HERE**


</git-pr-chain>



