### PR TITLE
[BACKEND] Fix tma lowering crash due to wrong insert point

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -270,9 +270,6 @@ void replaceUsesWithLocalLoad(
       }
     }
   }
-  for (auto alloc : allocsToErase) {
-    alloc.erase();
-  }
 
   // If there are some uses that were not local_allocs, we need to create a
   // local_load for them.
@@ -281,6 +278,9 @@ void replaceUsesWithLocalLoad(
     auto sharedLoad = builder.template create<ttg::LocalLoadOp>(
         loc, old.getType(), alloc, token);
     old.replaceAllUsesWith(sharedLoad.getResult());
+  }
+  for (auto alloc : allocsToErase) {
+    alloc.erase();
   }
 }
 } // namespace mlir::triton


### PR DESCRIPTION
Deleting the alloc op too early maay invalidate the builder insert point. Delay the clean up of the ops.
