### PR TITLE
[NVIDIA] Blackwell: Fix a bug in TritonNvidiaGPU PromoteLHSToTMem pass 

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
@@ -89,11 +89,12 @@ public:
         rewriter.create<ttng::TMEMAllocOp>(loc, lhsMemDescType, src);
     tcGen5MMAOp.getAMutable().assign(tMemAlloc);
     // Check if all users of localAllocResult are WaitBarrierOp
-    if (llvm::all_of(localAllocResult.getUsers(), 
-    [](Operation *user) { return isa<ttng::WaitBarrierOp>(user); })) {
+    if (llvm::all_of(localAllocResult.getUsers(), [](Operation *user) {
+          return isa<ttng::WaitBarrierOp>(user);
+        })) {
       // Replace localAllocResult with tMemAlloc for all users
       rewriter.replaceAllUsesWith(localAllocResult, tMemAlloc);
-    } 
+    }
     return success();
   }
 };


### PR DESCRIPTION
In PromoteLHSToTMem pass, when the lhs localAllocOp is replaced with TMEMAllocOp, the old use of localAllocOp is not replaced. For example, ttng.wait_barrier will wait for old localAllocOp instead of TMEMAllocOp.

This leads to duplicate operations, therefore reduced performance.

One example is here:

```
      %144 = ttg.memdesc_subview %58[%142, %c0_i32, %c0_i32] : !ttg.memdesc<3x128x64xi8, #shared1, #smem, mutable> -> !ttg.memdesc<128x64xi8, #shared1, #smem, mutable, 3x128x64> loc(#loc36)
      %145 = ttg.local_load %144 token %143 : !ttg.memdesc<128x64xi8, #shared1, #smem, mutable, 3x128x64> -> tensor<128x64xi8, #blocked4> loc(#loc36)
      %146 = ttg.local_load %144 token %143 : !ttg.memdesc<128x64xi8, #shared1, #smem, mutable, 3x128x64> -> tensor<128x64xi8, #blocked2> loc(#loc36)
      %147 = ttg.memdesc_subview %59[%142, %c0_i32, %c0_i32] : !ttg.memdesc<3x64x128xbf16, #shared2, #smem, mutable> -> !ttg.memdesc<64x128xbf16, #shared2, #smem, mutable, 3x64x128> loc(#loc37)
      %148 = arith.sitofp %145 : tensor<128x64xi8, #blocked4> to tensor<128x64xbf16, #blocked4> loc(#loc43)
      %149 = arith.sitofp %146 : tensor<128x64xi8, #blocked2> to tensor<128x64xbf16, #blocked2> loc(#loc43)
      %150 = ttg.local_alloc %149 : (tensor<128x64xbf16, #blocked2>) -> !ttg.memdesc<128x64xbf16, #shared3, #smem> loc(#loc43)
      %result_5 = ttng.tmem_alloc %148 : (tensor<128x64xbf16, #blocked4>) -> !ttg.memdesc<128x64xbf16, #tmem1, #ttng.tensor_memory> loc(#loc34)
      ttng.tc_gen5_mma %result_5, %147, %result, %arg12, %true, %56[%true] : !ttg.memdesc<128x64xbf16, #tmem1, #ttng.tensor_memory>, !ttg.memdesc<64x128xbf16, #shared2, #smem, mutable, 3x64x128>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc34)
      ttng.wait_barrier %56, %arg13 deps %150, %147 : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<128x64xbf16, #shared3, #smem>, !ttg.memdesc<64x128xbf16, #shared2, #smem, mutable, 3x64x128> loc(#loc34)
```

This PR fix the bug.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
