### PR TITLE
[lit][cfg] Declare mlir-translate in lit config

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -58,6 +58,7 @@ for d in tool_dirs:
 tools = [
     'triton-opt',
     'triton-llvm-opt',
+    'mlir-translate',
     ToolSubst('%PYTHON', config.python_executable, unresolved='ignore'),
 ]
 


### PR DESCRIPTION
Internally at Meta we adapt the cmake setup to work with buck. As part of that adaption we rely on this lit cfg file, and in particular rely on the set of tools to be encompassing of all tools that are used by the lit tests. A few tests use `mlir-translate` (see e.g. [`Conversion/gather_to_llvm.mlir`](https://github.com/triton-lang/triton/blob/main/test/Conversion/gather_to_llvm.mlir#L1)), so we need `mlir-translate` in the declared list of tools in the lit cfg file.

N.B. IIUC the cmake setup works because we update `$PATH` to include where `mlir-translate` sits (and buck is a bit persnickety when it comes to `$PATH`)