### PR TITLE
[Testing] Update test_compile_stats to allow custom library complier paths

### DIFF
--- a/python/test/unit/conftest.py
+++ b/python/test/unit/conftest.py
@@ -1,6 +1,8 @@
 import os
-import pytest
 import tempfile
+from typing import Optional, Set
+
+import pytest
 
 
 def pytest_configure(config):
@@ -26,20 +28,49 @@ def fresh_triton_cache():
             os.environ.pop("TRITON_CACHE_DIR", None)
 
 
-@pytest.fixture
-def fresh_knobs(request, monkeypatch):
+def _fresh_knobs_impl(monkeypatch, skipped_attr: Optional[Set[str]] = None):
     from triton import knobs
+
+    if skipped_attr is None:
+        skipped_attr = set()
+
     knobs_map = {
         name: knobset
         for name, knobset in knobs.__dict__.items()
-        if isinstance(knobset, knobs.base_knobs) and knobset != knobs.base_knobs
+        if isinstance(knobset, knobs.base_knobs) and knobset != knobs.base_knobs and name not in skipped_attr
     }
-    try:
+
+    def fresh_function():
         for name, knobset in knobs_map.items():
-            setattr(knobs, name, knobset.copy().reset())
             for knob in knobset.knob_descriptors.values():
                 monkeypatch.delenv(knob.key, raising=False)
-        yield knobs
-    finally:
+        return knobs
+
+    def reset_function():
         for name, knobset in knobs_map.items():
             setattr(knobs, name, knobset)
+
+    return fresh_function, reset_function
+
+
+@pytest.fixture
+def fresh_knobs(request, monkeypatch):
+    fresh_function, reset_function = _fresh_knobs_impl(monkeypatch)
+    try:
+        yield fresh_function()
+    finally:
+        reset_function()
+
+
+@pytest.fixture
+def fresh_knobs_except_libraries(fresh_knobs):
+    """
+    A variant of `fresh_knobs` that keeps library path
+    information from the environment as these may be
+    needed to successfully compile kernels.
+    """
+    fresh_function, reset_function = _fresh_knobs_impl({"build", "nvidia", "amd"})
+    try:
+        yield fresh_function()
+    finally:
+        reset_function()

--- a/python/test/unit/conftest.py
+++ b/python/test/unit/conftest.py
@@ -54,7 +54,7 @@ def _fresh_knobs_impl(monkeypatch, skipped_attr: Optional[Set[str]] = None):
 
 
 @pytest.fixture
-def fresh_knobs(request, monkeypatch):
+def fresh_knobs(monkeypatch):
     fresh_function, reset_function = _fresh_knobs_impl(monkeypatch)
     try:
         yield fresh_function()
@@ -63,7 +63,7 @@ def fresh_knobs(request, monkeypatch):
 
 
 @pytest.fixture
-def fresh_knobs_except_libraries(fresh_knobs):
+def fresh_knobs_except_libraries(monkeypatch):
     """
     A variant of `fresh_knobs` that keeps library path
     information from the environment as these may be

--- a/python/test/unit/conftest.py
+++ b/python/test/unit/conftest.py
@@ -42,6 +42,7 @@ def _fresh_knobs_impl(monkeypatch, skipped_attr: Optional[Set[str]] = None):
 
     def fresh_function():
         for name, knobset in knobs_map.items():
+            setattr(knobs, name, knobset.copy().reset())
             for knob in knobset.knob_descriptors.values():
                 monkeypatch.delenv(knob.key, raising=False)
         return knobs

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -45,7 +45,7 @@ class env_base(Generic[SetType, GetType]):
 
     def __get__(self, obj: Optional[object], objclass: Optional[Type[object]]) -> GetType:
         if obj is None:
-            raise AttributeError("Cannot access {type(self)} on non-instance")
+            raise AttributeError(f"Cannot access {type(self)} on non-instance")
 
         if self.name in obj.__dict__:
             return self.transform(obj.__dict__[self.name])


### PR DESCRIPTION
`test_compile_stats` doesn't work in all of our internal testing environments because some of the necessary compile artifacts (e.g. `TRITON_LIBCUDA_PATH`) are at non-default locations and therefore must be read from the environment. This refactors the `fresh_knobs` fixture to introduce a new fixture that doesn't reset any of the knobs required to successfully compile a kernel.