### PR TITLE
Avoid calling self.knobs during reset

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -258,7 +258,7 @@ class base_knobs:
         return res
 
     def reset(self: knobs_type) -> knobs_type:
-        for knob in self.knobs.keys():
+        for knob in self.knob_descriptors.keys():
             delattr(self, knob)
         return self
 


### PR DESCRIPTION
When calling reset (which is implicitly done by `fresh_knobs`) the base_knobs class invokes `knobs`, which in turn invokes the `getattr` implementation. The base implementation for this calls `self.transform`, which is problematic when running these tests on an AMD machine because the `env_nvidia_tool` will call transform and may produce a RuntimeError.

This updates reset to just get the keys from `knob_descriptors`, which avoids this issue.