### PR TITLE
Disable test_nvidia_tool for AMD and simplify default ptxas check

### DIFF
--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -1,9 +1,11 @@
 import os
-import pytest
 import shutil
-import triton
 
 from pathlib import Path
+
+import pytest
+import triton
+from triton._internal_testing import is_hip
 
 
 def test_knobs_utils() -> None:
@@ -102,8 +104,18 @@ def test_knobs_scope(fresh_knobs, monkeypatch):
     assert fresh_knobs.amd.use_buffer_ops
 
 
-@pytest.mark.parametrize("truthy, falsey", [("1", "0"), ("true", "false"), ("True", "False"), ("TRUE", "FALSE"),
-                                            ("y", "n"), ("YES", "NO"), ("ON", "OFF")])
+@pytest.mark.parametrize(
+    "truthy, falsey",
+    [
+        ("1", "0"),
+        ("true", "false"),
+        ("True", "False"),
+        ("TRUE", "FALSE"),
+        ("y", "n"),
+        ("YES", "NO"),
+        ("ON", "OFF"),
+    ],
+)
 def test_read_env(truthy, falsey, fresh_knobs, monkeypatch):
     # bool defaulting to False
     assert not fresh_knobs.runtime.debug
@@ -136,6 +148,7 @@ def test_read_env(truthy, falsey, fresh_knobs, monkeypatch):
     assert fresh_knobs.cache.override_dir == "/tmp/triton_home/.triton/override"
 
     from triton.runtime.cache import FileCacheManager
+
     assert fresh_knobs.cache.manager_class == FileCacheManager
 
     assert fresh_knobs.build.backend_dirs == {"/tmp/cuda/crt", "/tmp/cuda/rt"}
@@ -216,10 +229,15 @@ def test_set_knob_directly(fresh_knobs, monkeypatch):
     assert fresh_knobs.cache.manager_class == FileCacheManager
 
 
+@pytest.mark.skipif(
+    is_hip() or "TRITON_PTXAS_PATH" in os.environ,
+    reason="Only default ptxas Nvidia installations are supported.",
+)
 def test_nvidia_tool(fresh_knobs, tmp_path, monkeypatch):
     triton_root = Path(__file__).parent.parent.parent / "triton"
     default_ptxas = triton_root / "backends/nvidia/bin/ptxas"
 
+    assert default_ptxas.exists()
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
 
     tmp_ptxas = tmp_path / "ptxas-special"

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -230,11 +230,11 @@ def test_set_knob_directly(fresh_knobs, monkeypatch):
 
 
 @pytest.mark.skipif(
-    is_hip() or "TRITON_PTXAS_PATH" in os.environ,
-    reason="Only default ptxas Nvidia installations are supported.",
+    is_hip(),
+    reason="PTXAS is not installed on AMD",
 )
 def test_nvidia_tool(fresh_knobs, tmp_path, monkeypatch):
-    triton_root = Path(__file__).parent.parent.parent / "triton"
+    triton_root = Path(fresh_knobs.__file__).parent
     default_ptxas = triton_root / "backends/nvidia/bin/ptxas"
 
     assert default_ptxas.exists()

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -220,7 +220,6 @@ def test_nvidia_tool(fresh_knobs, tmp_path, monkeypatch):
     triton_root = Path(__file__).parent.parent.parent / "triton"
     default_ptxas = triton_root / "backends/nvidia/bin/ptxas"
 
-    assert default_ptxas.exists()
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
 
     tmp_ptxas = tmp_path / "ptxas-special"


### PR DESCRIPTION
At meta our build process can remap certain files to their import location. As a result, the parent mapping from the test file is inconsistent with the default PTXAS pass on knobs. This updates the test to always use the parent of the knobs file (which should be a more accurate test because it checks the same location that is actually set by default).

This also disables the test for AMD since ptxas shouldn't need to be installed.