### PR TITLE
[Blackwell] Fix TMEM message size selection heuristic

### DIFF
--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -384,34 +384,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 256], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 256], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, unpacked = true>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_ld_128x256
-  // CHECK: tcgen05.st.sync.aligned.32x32b.x64.b32
-  // CHECK: tcgen05.st.sync.aligned.32x32b.x64.b32
-  // CHECK: tcgen05.st.sync.aligned.32x32b.x64.b32
-  // CHECK: tcgen05.st.sync.aligned.32x32b.x64.b32
+  // CHECK-COUNT-2: tcgen05.st.sync.aligned.32x32b.x128.b32
+  // CHECK-NOT: tcgen05.st
   // CHECK: tcgen05.wait::st.sync.aligned
-  // CHECK: tcgen05.ld.sync.aligned.32x32b.x64.b32
-  // CHECK: tcgen05.ld.sync.aligned.32x32b.x64.b32
-  // CHECK: tcgen05.ld.sync.aligned.32x32b.x64.b32
-  // CHECK: tcgen05.ld.sync.aligned.32x32b.x64.b32
+  // CHECK-COUNT-2: tcgen05.ld.sync.aligned.32x32b.x128.b32
+  // CHECK-NOT: tcgen05.ld
   // CHECK: tcgen05.wait::ld.sync.aligned
   tt.func public @tensor_memory_ld_128x256(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) {
-    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked1>
-    %0 = ttng.tmem_alloc %cst_0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x256xf32, #blocked1>) -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
-    %20 = ttng.tmem_load %0 : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked1>
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked>
+    %0 = ttng.tmem_alloc %cst_0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x256xf32, #blocked>) -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+    %20 = ttng.tmem_load %0 : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked>
     tt.return
   }
 }
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 4], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, unpacked = true>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
@@ -421,9 +415,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
   // CHECK: tcgen05.ld.sync.aligned.32x32b.x128.b32
   // CHECK: tcgen05.wait::ld.sync.aligned
   tt.func public @tensor_memory_ld_128x256_8_warps(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) {
-    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked1>
-    %0 = ttng.tmem_alloc %cst_0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x256xf32, #blocked1>) -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
-    %20 = ttng.tmem_load %0 : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked1>
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #blocked>
+    %0 = ttng.tmem_alloc %cst_0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x256xf32, #blocked>) -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
+    %20 = ttng.tmem_load %0 : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked>
     tt.return
   }
 }
@@ -486,6 +480,66 @@ module attributes {"ttg.num-warps" = 8 : i32} {
     %result = ttng.tmem_load %tmem : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #linear>
     tt.return
   }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, unpacked = true>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.maxnreg = 80 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32} {
+
+// CHECK-LABEL: @tmem_message_maxnreg_80
+tt.func public @tmem_message_maxnreg_80(%desc: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory>) {
+  // CHECK-COUNT-2: tcgen05.ld.sync.aligned.32x32b.x32.b32
+  // CHECK-NOT: tcgen05.ld
+  ttng.tmem_load %desc : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory> -> tensor<128x64xf32, #blocked>
+  tt.return
+}
+
+tt.func public @module_constraint_supercedes_local(%desc: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory>) {
+  ttg.warp_specialize(%desc) attributes {actualRegisters = array<i32: 256, 256>}
+  default {
+    // CHECK-COUNT-2: tcgen05.ld.sync.aligned.32x32b.x32.b32
+    // CHECK-NOT: tcgen05.ld
+    // CHECK: ttg.warp_yield
+    ttng.tmem_load %desc : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory> -> tensor<128x64xf32, #blocked>
+    ttg.warp_yield
+  }
+  partition0(%arg0: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory>) num_warps(4) {
+    // CHECK-COUNT-2: tcgen05.ld.sync.aligned.32x32b.x32.b32
+    // CHECK-NOT: tcgen05.ld
+    // CHECK: ttg.warp_return
+    ttng.tmem_load %arg0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory> -> tensor<128x64xf32, #blocked>
+    ttg.warp_return
+  } : (!ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory>) -> ()
+  tt.return
+}
+
+}
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.maxnreg = 256 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32} {
+
+// CHECK-LABEL: @tmem_message_local_constraint
+tt.func public @tmem_message_local_constraint(%desc: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory>) {
+  ttg.warp_specialize(%desc) attributes {actualRegisters = array<i32: 80, 48>}
+  default {
+    // CHECK-COUNT-2: tcgen05.ld.sync.aligned.32x32b.x32.b32
+    // CHECK-NOT: tcgen05.ld
+    // CHECK: ttg.warp_yield
+    ttng.tmem_load %desc : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory> -> tensor<128x64xf32, #blocked>
+    ttg.warp_yield
+  }
+  partition0(%arg0: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory>) num_warps(4) {
+    // CHECK-COUNT-4: tcgen05.ld.sync.aligned.32x32b.x16.b32
+    // CHECK-NOT: tcgen05.ld
+    // CHECK: ttg.warp_return
+    ttng.tmem_load %arg0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory> -> tensor<128x64xf32, #blocked>
+    ttg.warp_return
+  } : (!ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory>) -> ()
+  tt.return
+}
+
 }
 
 // -----

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -137,11 +137,11 @@ TMemMessageTraits getTMemMessageFromAtom(const TMemAccessAtom &atom,
 // Only allows half of the thread registers to be used for tensor memory access
 // to avoid register pressure. This ensures the largest tmem message width is
 // used for the workload without inducing spills.
-int getTMemMessageNarrowingFactor(int workloadThreadRegs, int maxnreg) {
+int getTMemMessageNarrowingFactor(const TMemAccessAtom &atom, int maxnreg) {
   const int allowedRegUsage = maxnreg / 2;
   int narrowingFactor = 1;
-  while (workloadThreadRegs > allowedRegUsage) {
-    workloadThreadRegs /= 2;
+  while (getTMemMessageFromAtom(atom, narrowingFactor).numRegs >
+         allowedRegUsage) {
     narrowingFactor *= 2;
   }
   return narrowingFactor;
@@ -381,10 +381,7 @@ void createWaitOpSt(Location loc, ConversionPatternRewriter &rewriter) {
 TMemMessageTraits selectTMemMessage(const TMemRuntimeInfo &info, int maxnreg) {
   auto atom = info.useStridedMessage ? TMemAccess16x32bx2 : TMemAccess32x32b;
 
-  int totalRegsNeeded =
-      getEffectiveRegs(info.unpackedb16, info.useStridedMessage,
-                       info.numCols / info.numWarpGroups);
-  int narrowingFactor = getTMemMessageNarrowingFactor(totalRegsNeeded, maxnreg);
+  int narrowingFactor = getTMemMessageNarrowingFactor(atom, maxnreg);
   auto narrowedMessage = getTMemMessageFromAtom(atom, narrowingFactor);
   narrowedMessage = constrainMessageFromWorkload(narrowedMessage, info,
                                                  narrowedMessage.numRegs);
@@ -396,32 +393,54 @@ TMemMessageTraits selectTMemMessage(const TMemRuntimeInfo &info, int maxnreg) {
 }
 
 // Get the maximum number of registers per thread based on the context. This is
-// by default 256, but it can be overridden by `ttg.maxnreg` set on the module.
-// Alternatively, warp groups within warp specialized regions can have a
-// different number of registers allocated.
+// by default 256, but it can be overridden by `ttg.maxnreg` set on the module
+// or a contextual register limit set by the compiler on partitions.
 static int getContextualMaxNReg(Operation *op) {
-  if (auto mod = dyn_cast<ModuleOp>(op)) {
-    // Check for a maxnreg attribute.
-    if (auto attr = op->getAttrOfType<IntegerAttr>(AttrMaxRegistersName))
-      return std::max<int>(maxRegisters, attr.getInt());
+  // Check the immediate parent op to see if it places a register constraint.
+  auto getFromParent = [](Operation *op) -> std::optional<int> {
+    Operation *parent = op->getParentOp();
+    if (auto mod = dyn_cast<ModuleOp>(parent)) {
+      if (auto attr = mod->getAttrOfType<IntegerAttr>(AttrMaxRegistersName))
+        return attr.getInt();
+      return {};
+    }
 
-  } else if (auto partitions =
-                 dyn_cast<WarpSpecializePartitionsOp>(op->getParentOp())) {
-    // Check if the partition has reduced registers.
-    unsigned idx = op->getParentRegion()->getRegionNumber();
-    if (auto actRegisters = partitions.getParentOp().getActualRegisters())
-      return std::max<int>(maxRegisters, (*actRegisters)[1 + idx]);
-    return getContextualMaxNReg(partitions.getParentOp());
+    if (auto partitions = dyn_cast<WarpSpecializePartitionsOp>(parent)) {
+      // Check if the partition has reduced registers.
+      unsigned idx = op->getParentRegion()->getRegionNumber();
+      if (auto actRegisters = partitions.getParentOp().getActualRegisters())
+        return (*actRegisters)[1 + idx];
+      return {};
+    }
 
-  } else if (auto wsOp = dyn_cast<WarpSpecializeOp>(op->getParentOp())) {
-    // Check the register usage of the default warpgroup.
-    if (auto actRegisters = wsOp.getActualRegisters())
-      return std::max<int>(maxRegisters, actRegisters->front());
+    if (auto wsOp = dyn_cast<WarpSpecializeOp>(op->getParentOp())) {
+      // Check the register usage of the default warpgroup.
+      if (auto actRegisters = wsOp.getActualRegisters())
+        return actRegisters->front();
+      return {};
+    }
+
+    return {};
+  };
+
+  // PTXAS validates the register usage of `tcgen05.ld` and `tcgen05.st`
+  // instructions based on the static number of registers set on the module, not
+  // the dynamic allocation. This just means the register limit used for the
+  // purpose of subtiling TMEM messages cannot be higher than the module's.
+  auto mod = op->getParentOfType<ModuleOp>();
+  int maxnreg = maxRegisters;
+
+  for (; op != mod; op = op->getParentOp()) {
+    if (std::optional<int> limit = getFromParent(op)) {
+      maxnreg = std::min(maxnreg, *limit);
+      break;
+    }
   }
 
-  if (Operation *parent = op->getParentOp())
-    return getContextualMaxNReg(parent);
-  return maxRegisters;
+  if (auto maxnregAttr = mod->getAttrOfType<IntegerAttr>(AttrMaxRegistersName))
+    maxnreg = std::min<int>(maxnreg, maxnregAttr.getInt());
+
+  return maxnreg;
 }
 
 static void lowerStoreToTensorMemory(Location loc, Operation *op, Value src,


### PR DESCRIPTION
The goal of the heuristic here is to never use more than half of the available registers for a TMEM instruction, since each instruction requires all registers to be live at once.

The register use of each message was being calculated incorrectly, sometimes resulting in a larger or smaller narrowing factor. This PR fixes that. It also fixes `getContextualMaxNReg` to return values other than 256...

Also, PTXAS will fail compilation if it detects that TMEM instruction whose register usage plus a fudge factor (seem to be 18 regs) is larger than the `maxnreg` set on the module, not based on dynamic reallocation, so that has to be taken into account.
