### PR TITLE
[Backend] Improve how dynamic register reallocation is implemented

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -25,6 +25,7 @@ namespace {
 using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
+namespace ttng = triton::nvidia_gpu;
 
 // pass named attrs (e.g., tt.contiguity) from Triton to Triton
 static void addNamedAttrs(Operation *op, DictionaryAttr dictAttrs) {
@@ -466,6 +467,72 @@ struct GatherScatterOpPattern : public OpConversionPattern<OpT> {
   }
 };
 
+// Given a tensor and its representation in tensor memory, determine its
+// distributed layout.
+static RankedTensorType getTMEMTensorLayout(const TypeConverter *tc,
+                                            RankedTensorType type,
+                                            MemDescType memdesc,
+                                            unsigned numWarps) {
+  Attribute encoding;
+  type = cast<RankedTensorType>(tc->convertType(type));
+  if (isa<ttng::TensorMemoryScalesEncodingAttr>(memdesc.getEncoding())) {
+    encoding = LinearEncodingAttr::get(
+        type.getContext(), getScaleTMEMStoreLinearLayout(type, numWarps));
+  } else {
+    auto tmemEnc = cast<ttng::TensorMemoryEncodingAttr>(memdesc.getEncoding());
+    encoding = ttng::getTmemCompatibleLayout(
+        tmemEnc.getBlockM(), tmemEnc.getBlockN(), type, numWarps);
+  }
+  return RankedTensorType::get(type.getShape(), type.getElementType(),
+                               encoding);
+}
+
+struct TMEMLoadOpPattern : public OpConversionPattern<ttng::TMEMLoadOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttng::TMEMLoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    RankedTensorType type = getTMEMTensorLayout(
+        typeConverter, op.getType(), op.getSrc().getType(), lookupNumWarps(op));
+    rewriter.modifyOpInPlace(op, [&] { op.getResult().setType(type); });
+    return success();
+  }
+};
+
+struct TMEMStoreOpPattern : public OpConversionPattern<ttng::TMEMStoreOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttng::TMEMStoreOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    RankedTensorType type =
+        getTMEMTensorLayout(typeConverter, op.getSrc().getType(),
+                            op.getDst().getType(), lookupNumWarps(op));
+    Value src =
+        rewriter.create<ConvertLayoutOp>(op.getLoc(), type, adaptor.getSrc());
+    rewriter.modifyOpInPlace(op, [&] { op.getSrcMutable().assign(src); });
+    return success();
+  }
+};
+
+struct TMEMAllocOpPattern : public OpConversionPattern<ttng::TMEMAllocOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttng::TMEMAllocOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!op.getSrc())
+      return success();
+    RankedTensorType type = getTMEMTensorLayout(
+        typeConverter, op.getSrc().getType(), op.getType(), lookupNumWarps(op));
+    Value src =
+        rewriter.create<ConvertLayoutOp>(op.getLoc(), type, adaptor.getSrc());
+    rewriter.modifyOpInPlace(op, [&] { op.getSrcMutable().assign(src); });
+    return success();
+  }
+};
+
 struct TritonTransPattern : public OpConversionPattern<TransOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -592,40 +659,61 @@ void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
   MLIRContext *context = patterns.getContext();
   patterns.insert< // TODO: view should have custom pattern that views the
                    // layout
+      // clang-format off
       GenericOpPattern<triton::AdvanceOp>,
       GenericOpPattern<triton::MakeTensorPtrOp>,
-      GenericOpPattern<triton::ReshapeOp>, GenericOpPattern<triton::BitcastOp>,
-      GenericOpPattern<triton::FpToFpOp>, GenericOpPattern<triton::IntToPtrOp>,
-      GenericOpPattern<triton::PtrToIntOp>, GenericOpPattern<triton::SplatOp>,
-      TritonBroadcastPattern, GenericOpPattern<triton::AddPtrOp>,
-      TritonCatPattern, TritonJoinOpPattern, TritonSplitOpPattern,
+      GenericOpPattern<triton::ReshapeOp>,
+      GenericOpPattern<triton::BitcastOp>,
+      GenericOpPattern<triton::FpToFpOp>,
+      GenericOpPattern<triton::IntToPtrOp>,
+      GenericOpPattern<triton::PtrToIntOp>,
+      GenericOpPattern<triton::SplatOp>,
+      GenericOpPattern<triton::AddPtrOp>,
+      TritonBroadcastPattern,
+      TritonCatPattern,
+      TritonJoinOpPattern,
+      TritonSplitOpPattern,
       GenericOpPattern<triton::ClampFOp>,
       GenericOpPattern<triton::PreciseSqrtOp>,
       GenericOpPattern<triton::PreciseDivFOp>,
       GenericOpPattern<triton::MulhiUIOp>,
-      GenericOpPattern<triton::ElementwiseInlineAsmOp>, TritonReducePattern,
-      GenericOpPattern<triton::ReduceReturnOp>, TritonScanPattern,
+      GenericOpPattern<triton::ElementwiseInlineAsmOp>,
+      TritonReducePattern,
+      GenericOpPattern<triton::ReduceReturnOp>,
+      TritonScanPattern,
       GenericOpPattern<triton::ScanReturnOp>,
-      GenericOpPattern<triton::MakeRangeOp>, TritonExpandDimsPattern,
-      TritonTransPattern, TritonDotPattern,
+      GenericOpPattern<triton::MakeRangeOp>,
+      TritonExpandDimsPattern,
+      TritonTransPattern,
+      TritonDotPattern,
       GatherScatterOpPattern<DescriptorGatherOp>,
       GatherScatterOpPattern<DescriptorScatterOp>,
-      GatherScatterOpPattern<triton::nvidia_gpu::AsyncTMAGatherOp>,
-      GatherScatterOpPattern<triton::nvidia_gpu::AsyncTMAScatterOp>,
-      GenericOpPattern<triton::LoadOp>, GenericOpPattern<triton::StoreOp>,
-      GenericOpPattern<triton::HistogramOp>, GenericOpPattern<triton::GatherOp>,
+      GatherScatterOpPattern<ttng::AsyncTMAGatherOp>,
+      GatherScatterOpPattern<ttng::AsyncTMAScatterOp>,
+      TMEMLoadOpPattern,
+      TMEMStoreOpPattern,
+      TMEMAllocOpPattern,
+      GenericOpPattern<triton::LoadOp>,
+      GenericOpPattern<triton::StoreOp>,
+      GenericOpPattern<triton::HistogramOp>,
+      GenericOpPattern<triton::GatherOp>,
       GenericOpPattern<triton::ExternElementwiseOp>,
-      GenericOpPattern<triton::PrintOp>, GenericOpPattern<triton::AssertOp>,
+      GenericOpPattern<triton::PrintOp>,
+      GenericOpPattern<triton::AssertOp>,
       GenericOpPattern<triton::AtomicCASOp>,
-      GenericOpPattern<triton::AtomicRMWOp>, GenericOpPattern<ReturnOp>,
+      GenericOpPattern<triton::AtomicRMWOp>,
       GenericOpPattern<triton::DescriptorLoadOp>,
       GenericOpPattern<triton::DescriptorStoreOp>,
       GenericOpPattern<triton::DescriptorReduceOp>,
       GenericOpPattern<triton::ExperimentalTensormapCreateOp>,
       GenericOpPattern<triton::ExperimentalTensormapFenceproxyAcquireOp>,
       // this assumes the right layout will be set later for dot scaled.
-      GenericOpPattern<triton::DotScaledOp>, GenericOpPattern<triton::CallOp>,
-      TritonFuncOpPattern>(typeConverter, context);
+      GenericOpPattern<triton::DotScaledOp>,
+      GenericOpPattern<triton::CallOp>,
+      GenericOpPattern<ReturnOp>,
+      TritonFuncOpPattern
+      // clang-format on
+      >(typeConverter, context);
 }
 // Proton patterns
 // NOTE: Because Proton's inputs are scalars and not tensors this conversion

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -213,10 +213,8 @@ static WarpSchedule getInitialSchedule(const PartitionScheme &scheme) {
       userPartition->insert(userOp);
     // Place the epilogue partition in the default warpgroup. The MMA and load
     // partitions shouldn't have tensor computations in them, which means they
-    // will get assigned just 1 warp each. Add an extra partition to pad the
-    // number of warps to the nearest warpgroup.
-    schedule.addPartition(0);
-    schedule.reorderPartitions({2, 1, 0, 3});
+    // will get assigned just 1 warp each.
+    schedule.reorderPartitions({2, 1, 0});
   }
 
   schedule.updatePartitions();

--- a/test/Conversion/allocate_warp_groups.mlir
+++ b/test/Conversion/allocate_warp_groups.mlir
@@ -6,11 +6,11 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 
 // -----
 
-// CHECK: module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 17 : i32}
+// CHECK: module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 20 : i32}
 module attributes {"ttg.num-warps" = 4 : i32} {
 
 tt.func @kernel() {
-  // CHECK: ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 16, 4, 12>}
+  // CHECK: ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 18, 4, 12, 16, 19>}
   ttg.warp_specialize()
   default {
     ttg.warp_yield
@@ -24,6 +24,8 @@ tt.func @kernel() {
   partition2() num_warps(4) {
     ttg.warp_return
   } : () -> ()
+  // CHECK: partition3() num_warps(2)
+  // CHECK: partition4() num_warps(1)
   tt.return
 }
 
@@ -31,11 +33,11 @@ tt.func @kernel() {
 
 // -----
 
-// CHECK: module attributes {"ttg.num-warps" = 2 : i32, "ttg.total-num-warps" = 11 : i32}
-module attributes {"ttg.num-warps" = 2 : i32} {
+// CHECK: module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 16 : i32}
+module attributes {"ttg.num-warps" = 4 : i32} {
 
 tt.func @two_warp_specialize() {
-  // CHECK: ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 2, 4>}
+  // CHECK: ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 12, 14, 4, 15>}
   ttg.warp_specialize()
   default {
     ttg.warp_yield
@@ -46,8 +48,10 @@ tt.func @two_warp_specialize() {
   partition1() num_warps(1) {
     ttg.warp_return
   } : () -> ()
+  // CHECK: partition2() num_warps(8)
+  // CHECK: partition3() num_warps(1)
 
-  // CHECK: ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 10, 2>}
+  // CHECK: ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 14, 4, 12, 15>}
   ttg.warp_specialize()
   default {
     ttg.warp_yield

--- a/test/Conversion/triton_to_tritongpu.mlir
+++ b/test/Conversion/triton_to_tritongpu.mlir
@@ -175,25 +175,3 @@ tt.func @ub_poison() {
   %0 = ub.poison : tensor<128x64xf16>
   tt.return
 }
-
-// -----
-
-#blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [2], order = [0]}>
-
-module attributes {"ttg.num-warps" = 4 : i32} {
-
-// CHECK-LABEL: @partition_axis_info
-tt.func @partition_axis_info(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
-  ttg.warp_specialize(%arg0)
-  default {
-    ttg.warp_yield
-  }
-  partition0(%arg2: !tt.ptr<i32>) num_warps(2) {
-    %splatted = tt.splat %arg2 : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>, #blocked2>
-    %input = tt.load %splatted : tensor<256x!tt.ptr<i32>, #blocked2>
-    ttg.warp_return
-  } : (!tt.ptr<i32>) -> ()
-  tt.return
-}
-
-}

--- a/test/Conversion/triton_to_tritongpu_4_warps.mlir
+++ b/test/Conversion/triton_to_tritongpu_4_warps.mlir
@@ -1,0 +1,42 @@
+// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=cuda:100 num-warps=4' | FileCheck %s
+
+#tmem0 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, unpacked = true>
+#tmem2 = #ttng.tensor_memory_encoding<blockM = 256, blockN = 64, unpacked = true>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+
+// CHECK-DAG: [[BLOCKN64:#.*]] = #ttg.blocked<{sizePerThread = [1, 64]
+// CHECK-DAG: [[BLOCKN128:#.*]] = #ttg.blocked<{sizePerThread = [1, 128]
+// CHECK-DAG: [[SCALES:#.*]] = #ttg.linear<{register = {{\[\[}}0, 1], [0, 2], [32, 0], [64, 0], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64{{]]}}, lane = {{\[\[}}1, 0], [2, 0], [4, 0], [8, 0], [16, 0{{]]}}, warp = {{\[\[}}0, 0], [0, 0{{]]}}, block = []}>
+
+// CHECK: @tmem_alloc
+tt.func @tmem_alloc() {
+  %cst = arith.constant dense<1.0> : tensor<128x128xf32>
+  // CHECK: ttng.tmem_alloc {{.*}} (tensor<128x128xf32, [[BLOCKN128]]>) ->
+  %result = ttng.tmem_alloc %cst : (tensor<128x128xf32>) -> !ttg.memdesc<128x128xf32, #tmem0, #ttng.tensor_memory>
+  tt.return
+}
+
+// CHECK: @tmem_load
+tt.func @tmem_load(%desc: !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory>) {
+  // CHECK: ttng.tmem_load {{.*}} -> tensor<128x64xf32, [[BLOCKN64]]>
+  %result = ttng.tmem_load %desc : !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory> -> tensor<128x64xf32>
+  tt.return
+}
+
+// CHECK: @tmem_store
+tt.func @tmem_store(%desc: !ttg.memdesc<256x64xf32, #tmem2, #ttng.tensor_memory, mutable>) {
+  %cst = arith.constant dense<1.0> : tensor<256x64xf32>
+  %true = arith.constant true
+  // CHECK: ttng.tmem_store {{.*}} tensor<256x64xf32, [[BLOCKN64]]> ->
+  ttng.tmem_store %cst, %desc, %true : tensor<256x64xf32> -> !ttg.memdesc<256x64xf32, #tmem2, #ttng.tensor_memory, mutable>
+  tt.return
+}
+
+// CHECK: @tmem_scales_layout
+tt.func @tmem_scales_layout() {
+  %cst = arith.constant dense<0> : tensor<128x128xi8>
+  // CHECK: ttng.tmem_alloc {{.*}} (tensor<128x128xi8, [[SCALES]]>) ->
+  %result = ttng.tmem_alloc %cst : (tensor<128x128xi8>) -> !ttg.memdesc<128x128xi8, #tmem_scales, #ttng.tensor_memory>
+  tt.return
+}

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -2409,3 +2409,25 @@ tt.func private @tensor_desc_to_tma_ptr(%arg0: !tt.tensordesc<tensor<128x64xf16,
 }
 
 }
+
+// -----
+
+#blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [2], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+// CHECK-LABEL: @partition_axis_info
+tt.func @partition_axis_info(%arg0: !tt.ptr<i32>, %arg1: !tt.ptr<i32>) {
+  ttg.warp_specialize(%arg0)
+  default {
+    ttg.warp_yield
+  }
+  partition0(%arg2: !tt.ptr<i32>) num_warps(2) {
+    %splatted = tt.splat %arg2 : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>, #blocked2>
+    %input = tt.load %splatted : tensor<256x!tt.ptr<i32>, #blocked2>
+    ttg.warp_return
+  } : (!tt.ptr<i32>) -> ()
+  tt.return
+}
+
+}

--- a/test/TritonGPU/automatic-warp-specialization.mlir
+++ b/test/TritonGPU/automatic-warp-specialization.mlir
@@ -36,10 +36,7 @@ tt.func @matmul_change_desc_in_prologue(
   // BASE-COUNT-2: tt.make_tensor_descriptor
   // PIPELINE-COUNT-2: ttg.global_scratch_alloc {alignment = 128 : i32, nbytes = 512 : i32}
   // PIPELINE-COUNT-2: tt.experimental_tensormap_create
-  // CHECK-LABEL: partition2
-  // CHECK-SAME: num_warps(1)
-  // BASE-NOT: tt.make_tensor_descriptor
-  // PIPELINE-NOT: tt.experimental_tensormap_create
+  // CHECK-NOT: partition2
   scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero, %flag = %true, %a_desc = %a_desc_undef, %b_desc = %b_desc_undef) -> (tensor<128x128xf32, #acc_layout>, i1, !tt.tensordesc<tensor<128x64xf16, #shared>>, !tt.tensordesc<tensor<64x128xf16, #shared>>) : i32 {
     %do_prologue = "prologue_cond"(%k) : (i32) -> i1
     %cur_a_desc, %cur_b_desc = scf.if %do_prologue -> (!tt.tensordesc<tensor<128x64xf16, #shared>>, !tt.tensordesc<tensor<64x128xf16, #shared>>) {
@@ -90,8 +87,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use(
   // CHECK-SAME: num_warps(2)
   // CHECK: [[INDICES:%.*]] = tt.splat %{{.*}} : i32 -> tensor<128xi32,
   // CHECK: ttng.async_tma_gather %{{.*}}[[[INDICES]],
-  // CHECK-LABEL: partition2
-  // CHECK-SAME: num_warps(1)
+  // CHECK-NOT: partition2
   scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero, %flag = %true) -> (tensor<128x128xf32, #acc_layout>, i1) : i32 {
     %off_m, %off_n, %off_k = "get_offsets"(%k) : (i32) -> (i32, i32, i32)
     %indices = tt.splat %off_m : i32 -> tensor<128xi32, #indices_layout>

--- a/test/TritonGPU/load-mma-specialization.mlir
+++ b/test/TritonGPU/load-mma-specialization.mlir
@@ -20,6 +20,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // AWS: ttg.warp_specialize
 // AWS: num_warps(1)
+// AWS-NOT: num_warps(
 
 // CHECK: @warp_specialize_tma_matmul
 // CHECK-SAME: [[K_TILES:%arg[0-9]+]]
@@ -276,7 +277,7 @@ tt.func @invalid_acc_reset(
 // AWS: ttg.warp_specialize
 // AWS: num_warps(4)
 // AWS: num_warps(4)
-// AWS: num_warps(4)
+// AWS-NOT: num_warps(
 
 // CHECK-LABEL: @matmul_tma_acc_with_unconditional_user
 // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
@@ -369,7 +370,7 @@ tt.func @matmul_tma_acc_with_unconditional_user(
 
     // CHECK: scf.yield %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_NEXT_INDEX]], [[ACC_NEXT_PHASE]]
     scf.yield %acc_reset : tensor<128x128xf32, #acc_layout>
-  // CHECK-NEXT: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32, 0 : i32]
+  // CHECK-NEXT: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32]
   } {tt.warp_specialize, tt.num_stages = 2 : i32}
 
   tt.return
@@ -383,7 +384,7 @@ tt.func @matmul_tma_acc_with_unconditional_user(
 // AWS: ttg.warp_specialize
 // AWS: num_warps(4)
 // AWS: num_warps(4)
-// AWS: num_warps(4)
+// AWS-NOT: num_warps(
 
 // CHECK-LABEL: @matmul_tma_acc_with_conditional_user
 // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
@@ -464,7 +465,7 @@ tt.func @matmul_tma_acc_with_conditional_user(
 
     // CHECK: scf.yield %{{[0-9]+}}, %{{[0-9]+}}, [[EPILOGUE_ACC_NEXT_INDEX]], [[EPILOGUE_ACC_NEXT_PHASE]]
     scf.yield %acc_reset : tensor<128x128xf32, #acc_layout>
-  // CHECK-NEXT: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32, 0 : i32]
+  // CHECK-NEXT: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32]
   } {tt.warp_specialize, tt.num_stages = 2 : i32}
 
   tt.return
@@ -478,7 +479,7 @@ tt.func @matmul_tma_acc_with_conditional_user(
 // AWS: ttg.warp_specialize
 // AWS: num_warps(4)
 // AWS: num_warps(2)
-// AWS: num_warps(1)
+// AWS-NOT: num_warps(
 
 // CHECK-LABEL: @matmul_tma_acc_with_conditional_def
 // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
@@ -556,7 +557,7 @@ tt.func @matmul_tma_acc_with_conditional_def(
 
     // CHECK: scf.yield {{.*}} [[ACC_NEXT_INDEX]], [[ACC_NEXT_PHASE]]
     scf.yield %acc_reset : tensor<128x128xf32, #acc_layout>
-  // CHECK-NEXT: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32, 0 : i32]
+  // CHECK-NEXT: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32]
   } {tt.warp_specialize, tt.num_stages = 2 : i32}
 
   tt.return
@@ -570,7 +571,7 @@ tt.func @matmul_tma_acc_with_conditional_def(
 // AWS: ttg.warp_specialize
 // AWS: num_warps(4)
 // AWS: num_warps(2)
-// AWS: num_warps(1)
+// AWS-NOT: num_warps(
 
 // CHECK-LABEL: @matmul_tma_acc_with_conditional_def_and_use
 // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
@@ -652,7 +653,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use(
 
     // CHECK: scf.yield {{.*}} [[EPILOGUE_ACC_NEXT_INDEX]], [[EPILOGUE_ACC_NEXT_PHASE]]
     scf.yield %acc_reset : tensor<128x128xf32, #acc_layout>
-  // CHECK-NEXT: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32, 0 : i32]
+  // CHECK-NEXT: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32]
   } {tt.warp_specialize, tt.num_stages = 2 : i32}
 
   tt.return
@@ -666,7 +667,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use(
 // AWS: ttg.warp_specialize
 // AWS: num_warps(1)
 // AWS: num_warps(2)
-// AWS: num_warps(1)
+// AWS-NOT: num_warps(
 
 // CHECK-LABEL: @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag
 // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
@@ -751,12 +752,13 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag(
     // CHECK: scf.yield [[NEXT_FLAG]], %{{[0-9]+}}, %{{[0-9]+}}, [[EPILOGUE_ACC_NEXT_PHASE]]
     scf.yield %c, %use_acc : tensor<128x128xf32, #acc_layout>, i1
   // CHECK-NEXT: tt.scheduled_max_stage = 2 : i32
-  // CHECK-SAME: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32, 0 : i32]
+  // CHECK-SAME: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32]
   } {tt.warp_specialize, tt.disallow_acc_multi_buffer, tt.num_stages = 2 : i32}
 
   tt.return
 }
 
+// FUNC-LABEL: @matmul_scaled_rhs_scales_tma
 // CHECK-LABEL: @matmul_scaled_rhs_scales_tma
 tt.func @matmul_scaled_rhs_scales_tma(
   %k_tiles: i32,
@@ -1007,7 +1009,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_flag(
     // CHECK: scf.yield [[NEXT_FLAG]], %{{[0-9]+}}, %{{[0-9]+}}, [[EPILOGUE_ACC_NEXT_INDEX]], [[EPILOGUE_ACC_NEXT_PHASE]]
     scf.yield %c, %use_acc : tensor<128x128xf32, #acc_layout>, i1
   // CHECK-NEXT: tt.scheduled_max_stage = 4 : i32
-  // CHECK-SAME: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32, 0 : i32]
+  // CHECK-SAME: ttg.partition.stages = [2 : i32, 1 : i32, 0 : i32]
   } {tt.warp_specialize, tt.num_stages = 4 : i32}
 
   tt.return

--- a/test/TritonGPU/optimize-partition-warps.mlir
+++ b/test/TritonGPU/optimize-partition-warps.mlir
@@ -5,8 +5,11 @@
 #blocked4_broadcast = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #blocked2d_4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 2], order = [0, 1]}>
 #blocked2d_8 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
+#blocked2d_16 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 4], order = [0, 1]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
 #bar_layout = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, unpacked = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, unpacked = true>
 #smem = #ttg.shared_memory
 
 module attributes {ttg.target = "cuda:100", "ttg.num-warps" = 8 : i32} {
@@ -111,6 +114,75 @@ tt.func @fits_after_shrink(%arg0: i32) {
   partition1(%arg1: i32, %arg2: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>) num_warps(8) {
     ttg.warp_return
   } : (i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @register_use_heuristic
+tt.func @register_use_heuristic() {
+  // CHECK: requestedRegisters = array<i32: 24, 72>
+  ttg.warp_specialize()
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(1) {
+    ttg.warp_return
+  }
+  partition1() num_warps(4) {
+    %cst = arith.constant dense<0> : tensor<128x64xi32, #blocked2d_4>
+    ttg.warp_return
+  } : () -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @tmem_min_4_warps
+tt.func @tmem_min_4_warps(%tensor_desc: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>) {
+  ttg.warp_specialize(%tensor_desc)
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0{{.*}} num_warps(4)
+  partition0(%desc: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(8) {
+    %result = ttng.tmem_load %desc : !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x64xf32, #blocked2d_8>
+    "use"(%result) : (tensor<64x64xf32, #blocked2d_8>) -> ()
+    ttg.warp_return
+  }
+  // CHECK: partition1{{.*}} num_warps(4)
+  partition1(%desc: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(8) {
+    %cst = arith.constant dense<0> : tensor<64x64xi32, #blocked2d_8>
+    %true = arith.constant true
+    ttng.tmem_store %cst, %desc, %true : tensor<64x64xi32, #blocked2d_8> -> !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttg.warp_return
+  }
+  // CHECK: partition2{{.*}} num_warps(4)
+  partition2(%desc: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(8) {
+    %cst = arith.constant dense<0.0> : tensor<64x64xf32, #blocked2d_8>
+    %result = ttng.tmem_alloc %cst : (tensor<64x64xf32, #blocked2d_8>) -> !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory>
+    "use"(%result) : (!ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory>) -> ()
+    ttg.warp_return
+  } : (!ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>) -> ()
+  tt.return
+}
+
+tt.func @tmem_split_m_layout(%tensor_desc: !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable>) {
+  ttg.warp_specialize(%tensor_desc)
+  default {
+    ttg.warp_yield
+  }
+  // CHECK: partition0{{.*}} num_warps(8)
+  partition0(%desc: !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable>) num_warps(16) {
+    // CHECK: ttng.tmem_load {{.*}} -> tensor<128x64xf32, #linear>
+    %0 = ttng.tmem_load %desc : !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked2d_16>
+
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%arg2: f32, %arg3: f32):
+      %2 = arith.addf %arg2, %arg3 : f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<128x64xf32, #blocked2d_16>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked2d_16}>>
+
+    %cst = arith.constant dense<0.0> : tensor<128x128xf32, #blocked2d_16>
+    "use"(%1, %cst) : (tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked2d_16}>>, tensor<128x128xf32, #blocked2d_16>) -> ()
+    ttg.warp_return
+  } : (!ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable>) -> ()
   tt.return
 }
 


### PR DESCRIPTION
This PR generally improves how the compiler handles dynamic register reallocation for warp specialization.

* Codegen generates `setmaxnreg` both at the entry and exit of the partition regions, even when the number of registers does not change. This somehow makes `ptxas` behave much better, allowing the registers allocated to the load and MMA partitions to drop to `24` as they should be. This should improve register pressure across the board for warp specialized kernels.
* The maximum number of warpgroups is computed across the whole program and each `ttg.warp_specialize` is padded to it. This ensures all warps are always present to surrender registers. This primarily improves the layering between partitioning in the middle end (no longer need the "extra empty warp" hack).
* Handle TMEM ops when relayout'ing the IR (they require a minimum of 4 warps). Thankfully, the TMEM compatible distributed layout can always be inferred for these ops.