### PR TITLE
[DOC] Fix documentation pipeline

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   Build-Documentation:
-    runs-on: [a100-runner-set]
+    runs-on: [nvidia-a100]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Build docs
         run: |
-          rm -rf build
-          rm -rf python/build
           cd docs
           export PATH=$(python3 -c "import cmake; print(cmake.CMAKE_BIN_DIR)"):$PATH
           # Limit the number of threads to reduce CPU memory usage

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Build docs
         run: |
+          rm -rf build
+          rm -rf python/build
           cd docs
           export PATH=$(python3 -c "import cmake; print(cmake.CMAKE_BIN_DIR)"):$PATH
           # Limit the number of threads to reduce CPU memory usage

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ def get_cmake_dir():
     plat_name = sysconfig.get_platform()
     python_version = sysconfig.get_python_version()
     dir_name = f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"
-    cmake_dir = Path("../") / dir_name
+    cmake_dir = Path("../build") / dir_name
     return cmake_dir
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ def get_cmake_dir():
     plat_name = sysconfig.get_platform()
     python_version = sysconfig.get_python_version()
     dir_name = f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"
-    cmake_dir = Path("../python") / "build" / dir_name
+    cmake_dir = Path("../") / "build" / dir_name
     return cmake_dir
 
 
@@ -100,7 +100,7 @@ def setup(app):
     app.connect("autodoc-process-signature", process_sig)
     max_jobs = os.getenv("MAX_JOBS", str(2 * os.cpu_count()))
     print(f"Installing Triton Python package using {max_jobs} threads")
-    subprocess.run("pip install -e ../python", shell=True, env=os.environ.copy())
+    subprocess.run("pip install -e ../", shell=True, env=os.environ.copy())
 
     setup_generated_mlir_docs()
 
@@ -131,7 +131,7 @@ def setup(app):
 
 # Auto Doc
 
-sys.path.insert(0, os.path.abspath('../python/'))
+sys.path.insert(0, os.path.abspath('../'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
@@ -156,7 +156,7 @@ smv_prefer_remote_refs = False
 extensions += ['sphinx_gallery.gen_gallery']
 
 sphinx_gallery_conf = {
-    'examples_dirs': '../python/tutorials/',
+    'examples_dirs': '../tutorials/',
     'gallery_dirs': 'getting-started/tutorials',
     'filename_pattern': '',
     'ignore_pattern': r'(__init__\.py|11.*.py)',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ def get_cmake_dir():
     plat_name = sysconfig.get_platform()
     python_version = sysconfig.get_python_version()
     dir_name = f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"
-    cmake_dir = Path("../") / "build" / dir_name
+    cmake_dir = Path("../") / dir_name
     return cmake_dir
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,7 @@ def setup(app):
 
 # Auto Doc
 
-sys.path.insert(0, os.path.abspath('../python'))
+sys.path.insert(0, os.path.abspath('../python/'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,7 @@ def setup(app):
 
 # Auto Doc
 
-sys.path.insert(0, os.path.abspath('../'))
+sys.path.insert(0, os.path.abspath('../python'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,7 +156,7 @@ smv_prefer_remote_refs = False
 extensions += ['sphinx_gallery.gen_gallery']
 
 sphinx_gallery_conf = {
-    'examples_dirs': '../tutorials/',
+    'examples_dirs': '../python/tutorials/',
     'gallery_dirs': 'getting-started/tutorials',
     'filename_pattern': '',
     'ignore_pattern': r'(__init__\.py|11.*.py)',

--- a/python/tutorials/08-grouped-gemm.py
+++ b/python/tutorials/08-grouped-gemm.py
@@ -392,12 +392,12 @@ for i in range(group_size):
 tri_out = group_gemm_fn(group_A, group_B)
 ref_out = [torch.matmul(a, b) for a, b in zip(group_A, group_B)]
 for i in range(group_size):
-    assert torch.allclose(ref_out[i], tri_out[i], atol=1e-2, rtol=0)
+    assert torch.allclose(ref_out[i], tri_out[i], atol=1e-2, rtol=1e-2)
 
 if supports_tma():
     tri_tma_out = group_gemm_tma_fn(group_A, group_B_T)
     for i in range(group_size):
-        assert torch.allclose(ref_out[i], tri_tma_out[i], atol=1e-2, rtol=0)
+        assert torch.allclose(ref_out[i], tri_tma_out[i], atol=1e-2, rtol=1e-2)
 
 
 # only launch the kernel, no tensor preparation here to remove all overhead


### PR DESCRIPTION
1. Change the default build directory from `python/` to the root of triton.
2. Update on the CI runners.
3. Increase the relative tolerance of 08-group-gemm tutorial due to its failure on some GPUs using mmav2.
Tested https://github.com/triton-lang/triton/actions/runs/14816446953