### PR TITLE
[pytest] Use knobs to setup fresh cache for testing

### DIFF
--- a/python/test/unit/conftest.py
+++ b/python/test/unit/conftest.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import tempfile
 from typing import Optional, Set
@@ -20,11 +19,10 @@ def device(request):
 @pytest.fixture
 def fresh_triton_cache():
     with tempfile.TemporaryDirectory() as tmpdir:
-        try:
-            os.environ["TRITON_CACHE_DIR"] = tmpdir
+        from triton import knobs
+        with knobs.cache.scope():
+            knobs.cache.dir = tmpdir
             yield tmpdir
-        finally:
-            os.environ.pop("TRITON_CACHE_DIR", None)
 
 
 def _fresh_knobs_impl(monkeypatch, skipped_attr: Optional[Set[str]] = None):


### PR DESCRIPTION
With the new knobs module we have a more pythonic way to setup the cache. Other than being 'pythonic', switching to use knobs ensures the fresh cache will override any previously set cache path (e.g. if you have generic initialization logic which sets up these knobs, which we do have at Meta).