### PR TITLE
[python][compiler] Add triton_key knob for custom key calculation

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -129,6 +129,8 @@ class IRSource:
 
 @functools.lru_cache()
 def triton_key():
+    if triton_key_hook := knobs.compilation.triton_key:
+        return triton_key_hook()
     import pkgutil
     TRITON_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     contents = []

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -319,6 +319,10 @@ class compilation_knobs(base_knobs):
     front_end_debugging: env_bool = env_bool("TRITON_FRONT_END_DEBUGGING")
     allow_non_constexpr_globals: env_bool = env_bool("TRITON_ALLOW_NON_CONSTEXPR_GLOBALS")
     listener: Optional[CompilationListener] = None
+
+    # WARNING: Use this hook at your own risk. Overriding this with a callback
+    # that does not correctly invalidate caches may cause over compilation, or
+    # worse mis-compilation.
     triton_key: Optional[Callable[[], str]] = None
 
 

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -318,7 +318,8 @@ class compilation_knobs(base_knobs):
     disable_line_info: env_bool = env_bool("TRITON_DISABLE_LINE_INFO")
     front_end_debugging: env_bool = env_bool("TRITON_FRONT_END_DEBUGGING")
     allow_non_constexpr_globals: env_bool = env_bool("TRITON_ALLOW_NON_CONSTEXPR_GLOBALS")
-    listener: Union[CompilationListener, None] = None
+    listener: Optional[CompilationListener] = None
+    triton_key: Optional[Callable[[], str]] = None
 
 
 class autotuning_knobs(base_knobs):


### PR DESCRIPTION
At Meta we pre-compute the triton_key at build time and currently maintain a patch on the function to read that precomputed value. It looks like custom `triton_key` implementation might be desirable to more than just us, see https://github.com/triton-lang/triton/pull/6617

Since this is opt-in it should be a NFC to anyone who doesn't configure the new knob.

cc @woct0rdho