### PR TITLE
[workflow] Add dev-install-llvm target for building LLVM from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 build/
 build-*/
 
+llvm-project/
+llvm-project-*/
+.llvm-project/
+
 # Triton Python module builds
 python/build/
 python/dist/

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PYTHON ?= python
 BUILD_DIR := $(shell cd python; $(PYTHON) -c 'from build_helpers import get_cmake_dir; print(get_cmake_dir())')
 TRITON_OPT := $(BUILD_DIR)/bin/triton-opt
 PYTEST := $(PYTHON) -m pytest
+LLVM_BUILD_PATH ?= ".llvm-project/build"
 
 # Incremental builds
 
@@ -84,6 +85,16 @@ dev-install-triton:
 .PHONY: dev-install
 .NOPARALLEL: dev-install
 dev-install: dev-install-requires dev-install-triton
+
+.PHONY: dev-install-llvm
+.NOPARALLEL: dev-install-llvm
+dev-install-llvm:
+	LLVM_BUILD_PATH=$(LLVM_BUILD_PATH) scripts/build-llvm-project.sh
+	TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_BUILD_WITH_CCACHE=0 \
+		LLVM_INCLUDE_DIRS=$(LLVM_BUILD_PATH)/include \
+		LLVM_LIBRARY_DIR=$(LLVM_BUILD_PATH)/lib \
+		LLVM_SYSPATH=$(LLVM_BUILD_PATH) \
+	$(MAKE) dev-install
 
 # Updating lit tests
 

--- a/scripts/build-llvm-project.sh
+++ b/scripts/build-llvm-project.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+LLVM_TARGETS=${LLVM_TARGETS:-Native;NVPTX;AMDGPU}
+LLVM_PROJECTS=${LLVM_PROJECTS:-mlir;llvm}
+LLVM_BUILD_TYPE=${LLVM_BUILD_TYPE:-Debug}
+LLVM_COMMIT_HASH=${LLVM_COMMIT_HASH:-$(cat "$REPO_ROOT/cmake/llvm-hash.txt")}
+LLVM_PROJECT_PATH=${LLVM_PROJECT_PATH:-"$REPO_ROOT/llvm-project"}
+LLVM_BUILD_PATH=${LLVM_BUILD_PATH:-"$LLVM_PROJECT_PATH/build"}
+LLVM_INSTALL_PATH=${LLVM_INSTALL_PATH:-"$LLVM_PROJECT_PATH/install"}
+LLVM_PROJECT_URL=${LLVM_PROJECT_URL:-"https://github.com/llvm/llvm-project"}
+
+if [ -z "$CMAKE_ARGS" ]; then
+    if [ "$#" -eq 0 ]; then
+        CMAKE_ARGS=(
+            -G Ninja
+              -DCMAKE_BUILD_TYPE="$LLVM_BUILD_TYPE"
+              -DLLVM_CCACHE_BUILD=OFF
+              -DLLVM_ENABLE_ASSERTIONS=ON
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_CXX_COMPILER=clang++
+              -DLLVM_ENABLE_LLD=ON
+              -DLLVM_OPTIMIZED_TABLEGEN=ON
+              -DLLVM_TARGETS_TO_BUILD="$LLVM_TARGETS"
+              -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+              -DLLVM_ENABLE_PROJECTS="$LLVM_PROJECTS"
+              -DCMAKE_INSTALL_PREFIX="$LLVM_INSTALL_PATH"
+              -B"$LLVM_BUILD_PATH" "$LLVM_PROJECT_PATH/llvm"
+        )
+    else
+        CMAKE_ARGS=("$@")
+    fi
+fi
+
+if [ -n "$LLVM_CLEAN" ] && [ -e "$LLVM_PROJECT_PATH" ]; then
+    rm -rf "$LLVM_PROJECT_PATH"
+fi
+
+if [ ! -e "$LLVM_PROJECT_PATH" ]; then
+    echo "Cloning from $LLVM_PROJECT_URL"
+    git clone "$LLVM_PROJECT_URL" "$LLVM_PROJECT_PATH"
+fi
+echo "Resetting to $LLVM_COMMIT_HASH"
+git -C "$LLVM_PROJECT_PATH" reset --hard "$LLVM_COMMIT_HASH"
+echo "Configuring with ${CMAKE_ARGS[@]}"
+cmake "${CMAKE_ARGS[@]}"
+echo "Building LLVM"
+ninja -C "$LLVM_BUILD_PATH"


### PR DESCRIPTION
I've found using the make commands an absolute delight, but are missing support for building LLVM from source, hence this PR.

In the future we might consider moving the logic in the LLVM workflow into the new script (so that it's KISS to repro a workflow build locally), but that's probably not necessary for now.

cc @plotfi whose build script was a huge inspiration for this