### PR TITLE
[BENCH] Remove TMA workaround in swiglu

### DIFF
--- a/bench/tests/test_swiglu.py
+++ b/bench/tests/test_swiglu.py
@@ -5,7 +5,6 @@ import torch
 import pytest
 
 from .test_routing import init_data as init_routing_data
-from .test_routing import ref_expt_data
 
 # ---------------
 # initialize data
@@ -33,8 +32,7 @@ def test_op(M, N, limit, device, alpha=0.5):
     n_expts_act = 2
     logits = init_routing_data(M, n_expts_tot).detach()
     routing_data, _, _ = routing_torch(logits, n_expts_act)
-    expt_data = ref_expt_data(routing_data, M * n_expts_act, block_m=128)
-    n_tokens = expt_data[2 * n_expts_tot].sum()
+    n_tokens = routing_data.expt_hist.sum()
 
     # initialize data
     x = alloc_rand([n_tokens, N], device=device, dtype=torch.bfloat16)


### PR DESCRIPTION
TMA is no longer needed in this kernel after the convert layout cost model added in https://github.com/triton-lang/triton/pull/6699

Also fix test_swiglu.py. It broke after https://github.com/triton-lang/triton/pull/6703

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it already has test coverage.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
