### PR TITLE
Fix TRITON_PRINT_AUTOTUNING crash on disk‑cache hits

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -167,7 +167,7 @@ class Autotuner(KernelInterface):
         # We can't serialize prehooks, so just give up and run the benchmarks.
         if not tuning_key or any(cfg.pre_hook for cfg in configs):
             bench_fn()
-            return
+            return False
 
         from triton._C.libtriton import get_cache_invalidating_env_vars
         from triton.compiler.compiler import make_backend, triton_key
@@ -196,7 +196,7 @@ class Autotuner(KernelInterface):
                 timings = {Config(**config): timing for config, timing in timings}
                 self.cache[tuning_key] = builtins.min(timings, key=timings.get)
                 self.configs_timings = timings
-            return
+            return True
 
         bench_fn()
         cache.put(
@@ -206,6 +206,7 @@ class Autotuner(KernelInterface):
                 "configs_timings":
                 [(config.__dict__, timings) for config, timings in self.configs_timings.items() if not config.pre_hook],
             }), file_name, binary=False)
+        return False
 
     def run(self, *args, **kwargs):
         self.nargs = dict(zip(self.arg_names, args))
@@ -233,7 +234,7 @@ class Autotuner(KernelInterface):
                     self.configs_timings = timings
 
                 if self.cache_results:
-                    self.check_disk_cache(key, pruned_configs, benchmark)
+                    used_cached_result = self.check_disk_cache(key, pruned_configs, benchmark)
                 else:
                     benchmark()
 


### PR DESCRIPTION
When `TRITON_PRINT_AUTOTUNING=1`, we expect `self.bench_time` to be populated if we did not used a cached result for the benchmarking results. There was a codepath that used cached results from the disk, but did not update the flag saying we used cached results, leading to a crash when `self.bench_time` was unset.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it should be handled by existing tests.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
