### PR TITLE
Add dependency of TritonGPUIR on TritonNvidiaGPUIR table gen'd headers

### DIFF
--- a/lib/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -9,6 +9,10 @@ add_triton_library(TritonGPUIR
   TritonGPUTableGen
   TritonGPUAttrDefsIncGen
   TritonGPUTypeInterfacesIncGen
+  # header only dependency on TritonNvidiaGPU
+  TritonNvidiaGPUTableGen
+  TritonNvidiaGPUAttrDefsIncGen
+  TritonNvidiaGPUOpInterfacesIncGen
 
   LINK_LIBS PUBLIC
   MLIRGPUDialect


### PR DESCRIPTION
# What

Add dependency of TritonGPUIR on TritonNvidiaGPUIR table gen'd headers

# Why

Non-deterministically, for highly parallel builds, I will encounter

```
triton/lib/Dialect/TritonGPU/IR/Dialect.cpp:16:
triton/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h:40:10: fatal error: 'triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.h.inc' file not found
    40 | #include "triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.h.inc"
```

Since CMakeLists.txt for lib TritonGPUIR is missing these tablegen targets, it is possible for them to not yet be available when compiling Dialect.cpp.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it fixes a build stability issue.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
