### PR TITLE
[TMA] Use NVMMA to represent unswizzled case

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -435,7 +435,10 @@ def NVMMASharedEncodingAttr :
         } else if (contigDimSizeInByte >= 32 && contigDimSizeInByte % 32 == 0) {
           swizzlingByteWidth = 32;
         } else {
-          llvm_unreachable("unsupported NVMMA layout (MMAv3 or TMA)");
+          swizzlingByteWidth = 0;
+        }
+        if (shapePerCTA.size() < 2 || shapePerCTA[order[1]] < 8) {
+          swizzlingByteWidth = 0;
         }
         bool transposed = order[0] == 0;
         return $_get(context, swizzlingByteWidth, transposed, eleBitWidth, fp4Padded, CTALayout);
@@ -447,9 +450,9 @@ def NVMMASharedEncodingAttr :
     SmallVector<unsigned> getCTAsPerCGA() const;
     SmallVector<unsigned> getCTAOrder() const;
     SmallVector<unsigned> getCTASplitNum() const;
-    SmallVector<unsigned> getOrder() const {
-      return getTransposed() ? SmallVector<unsigned>({0, 1}) : SmallVector<unsigned>({1, 0});
-    }
+    int getPerPhase() const;
+    int getMaxPhase() const;
+    int getVec() const;
   }];
   let hasCustomAssemblyFormat = 1;
 }

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -441,13 +441,13 @@ struct MemDescSubviewOpConversion
     for (int i = rankReduced; i < opOffsetVals.size(); i++) {
       offsetVals.push_back(b.add(opOffsetVals[i], smemObj.getOffsets()[i]));
     }
-    Value offset = b.undef(i32_ty);
+    Value offset;
     auto allocShape = srcTy.getAllocShape();
+    auto nvmmaEnc = dyn_cast<NVMMASharedEncodingAttr>(enc);
     bool isSimpleSubview =
-        allocShape.take_back(destRank) == destTy.getShape() ||
-        !isa<NVMMASharedEncodingAttr>(enc);
+        (!nvmmaEnc || allocShape.take_back(destRank) == destTy.getShape() ||
+         nvmmaEnc.getSwizzlingByteWidth() == 0);
     if (!isSimpleSubview) {
-      auto nvmmaEnc = cast<NVMMASharedEncodingAttr>(enc);
       assert(destRank >= 2 &&
              "Shape size should be >= 2 when using NVMMAShared encoding");
       auto swizzleStride = b.i32_val((nvmmaEnc.getSwizzlingByteWidth() * 8) /

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
@@ -252,15 +252,6 @@ Attribute getFallbackSharedEncoding(RankedTensorType tensorType,
   else if (ctaLayout.getRank() != tensorType.getRank())
     ctaLayout = ttng::updateCTALayoutForShape(ctaLayout, shape);
 
-  auto elemTy = tensorType.getElementType();
-  auto shapePerCTA = ttg::getShapePerCTA(ctaLayout.getCTASplitNum(), shape);
-  unsigned eleBitWidth = tensorType.getElementType().getIntOrFloatBitWidth();
-
-  auto contigDimSizeInBytes = shapePerCTA.back() * eleBitWidth / 8;
-  auto rank = tensorType.getRank();
-  if (rank == 1 || contigDimSizeInBytes < 32 || shapePerCTA[rank - 2] < 8) {
-    return ttg::SwizzledSharedEncodingAttr::get(ctx, 1, 1, 1, order, ctaLayout);
-  }
   return ttg::NVMMASharedEncodingAttr::get(ctx, shape, order, ctaLayout,
                                            tensorType.getElementType(),
                                            /*fp4Padded*/ false);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
@@ -109,7 +109,7 @@ int64_t getTMAContigDim(Attribute encoding, ArrayRef<int64_t> shape) {
   // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html#group__CUDA__TENSOR__MEMORY_1ga7c7d2aaac9e49294304e755e6f341d7
   // We clamp the block size and the codegen will emit multiple copy
   // operations.
-  if (mmaEncoding) {
+  if (mmaEncoding && mmaEncoding.getSwizzlingByteWidth() != 0) {
     auto elemSize = mmaEncoding.getElementBitWidth() / 8;
     return mmaEncoding.getSwizzlingByteWidth() / elemSize;
   }
@@ -143,6 +143,8 @@ std::optional<int> getTMASwizzleMode(Operation *op, TensorDescType ty) {
     swizzleMode = 2;
   } else if (swizzleBytes == 32) {
     swizzleMode = 1;
+  } else {
+    assert(swizzleBytes == 0);
   }
   return swizzleMode;
 }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -561,7 +561,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-NEXT: llvm.mlir.constant(512 : i32) : i32
     // CHECK-NEXT: llvm.add
     // CHECK-NEXT: llvm.add
-    // CHECK-NEXT: llvm.mlir.undef
     // CHECK-NEXT: llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT: llvm.mul
     // CHECK-NEXT: llvm.add
@@ -587,8 +586,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: nvmma_subview
   tt.func @nvmma_subview() {
     // CHECK: llvm.mlir.addressof @global_smem
-    // CHECK: llvm.mlir.undef : i32
-    // CHECK-NEXT: llvm.mlir.constant(32 : i32) : i32
+    // CHECK: llvm.mlir.constant(32 : i32) : i32
     // CHECK-NEXT: llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT: llvm.mlir.constant(16 : i32) : i32
     // CHECK-NEXT: llvm.mul


### PR DESCRIPTION
<git-pr-chain>


[TMA] Use NVMMA to represent unswizzled case

Currently this is used to ensure the smem allocation is properly aligned. Soon this will also be needed so we can break up the unswizzled case into multiple tma messages to overcome tma's 256 maximum block dimension size.

Closes #6723

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #6725 👈 **YOU ARE HERE**


</git-pr-chain>



