### PR TITLE
Only include backend's directories as python packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -606,20 +606,16 @@ def get_package_dirs():
             # Install the contents of each backend's `language` directory into
             # `triton.language.extra`.
             for x in os.listdir(backend.language_dir):
-                ### TRITON-SHARED ###
                 full_path = os.path.join(backend.language_dir, x)
                 if os.path.isdir(full_path):
-                ### TRITON-SHARED ###
                     yield (f"triton.language.extra.{x}", os.path.join(backend.language_dir, x))
 
         if backend.tools_dir:
             # Install the contents of each backend's `tools` directory into
             # `triton.tools.extra`.
             for x in os.listdir(backend.tools_dir):
-                ### TRITON-SHARED ###
                 full_path = os.path.join(backend.tools_dir, x)
                 if os.path.isdir(full_path):
-                ### TRITON-SHARED ###
                     yield (f"triton.tools.extra.{x}", os.path.join(backend.tools_dir, x))
 
     if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
@@ -636,20 +632,16 @@ def get_packages():
             # Install the contents of each backend's `language` directory into
             # `triton.language.extra`.
             for x in os.listdir(backend.language_dir):
-                ### TRITON-SHARED ###
                 full_path = os.path.join(backend.language_dir, x)
                 if os.path.isdir(full_path):
-                ### TRITON-SHARED ###
                     yield f"triton.language.extra.{x}"
 
         if backend.tools_dir:
             # Install the contents of each backend's `tools` directory into
             # `triton.tools.extra`.
             for x in os.listdir(backend.tools_dir):
-                ### TRITON-SHARED ###
                 full_path = os.path.join(backend.tools_dir, x)
                 if os.path.isdir(full_path):
-                ### TRITON-SHARED ###
                     yield f"triton.tools.extra.{x}"
 
     if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON

--- a/setup.py
+++ b/setup.py
@@ -606,13 +606,21 @@ def get_package_dirs():
             # Install the contents of each backend's `language` directory into
             # `triton.language.extra`.
             for x in os.listdir(backend.language_dir):
-                yield (f"triton.language.extra.{x}", os.path.join(backend.language_dir, x))
+                ### TRITON-SHARED ###
+                full_path = os.path.join(backend.language_dir, x)
+                if os.path.isdir(full_path):
+                ### TRITON-SHARED ###
+                    yield (f"triton.language.extra.{x}", os.path.join(backend.language_dir, x))
 
         if backend.tools_dir:
             # Install the contents of each backend's `tools` directory into
             # `triton.tools.extra`.
             for x in os.listdir(backend.tools_dir):
-                yield (f"triton.tools.extra.{x}", os.path.join(backend.tools_dir, x))
+                ### TRITON-SHARED ###
+                full_path = os.path.join(backend.tools_dir, x)
+                if os.path.isdir(full_path):
+                ### TRITON-SHARED ###
+                    yield (f"triton.tools.extra.{x}", os.path.join(backend.tools_dir, x))
 
     if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
         yield ("triton.profiler", "third_party/proton/proton")
@@ -628,13 +636,21 @@ def get_packages():
             # Install the contents of each backend's `language` directory into
             # `triton.language.extra`.
             for x in os.listdir(backend.language_dir):
-                yield f"triton.language.extra.{x}"
+                ### TRITON-SHARED ###
+                full_path = os.path.join(backend.language_dir, x)
+                if os.path.isdir(full_path):
+                ### TRITON-SHARED ###
+                    yield f"triton.language.extra.{x}"
 
         if backend.tools_dir:
             # Install the contents of each backend's `tools` directory into
             # `triton.tools.extra`.
             for x in os.listdir(backend.tools_dir):
-                yield f"triton.tools.extra.{x}"
+                ### TRITON-SHARED ###
+                full_path = os.path.join(backend.tools_dir, x)
+                if os.path.isdir(full_path):
+                ### TRITON-SHARED ###
+                    yield f"triton.tools.extra.{x}"
 
     if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
         yield "triton.profiler"


### PR DESCRIPTION
Fix a bug in setup.py where the list of packages included files (not just directories) from the `$TRITON_PLUGINS_DIR/language` and `$TRITON_PLUGINS_DIR/tools` directories.

Example: the failure happens when `$TRITON_PLUGINS_DIR/tools` contains a file, such as CMakeLists.txt. The failure was that `.../tools/extra/CMakeLists/txt` did not exist.

This change makes `get_package_dirs`/`get_packages` include only directories in the list of package names.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is a change to setup.py for out-of-tree backends.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
