### PR TITLE
[PIPELINER] Allow to create async RS mmav3

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -54,6 +54,10 @@ getNumElementsPerThread(Operation *op, SmallVector<unsigned> order,
 // Returns whether the op is a "view op", i.e. doesn't move any data
 bool isView(Operation *op);
 
+// Returns whether the op is a "noop op", i.e. has one input and one output
+// and lowers to llvm as the identity function (returns the input)
+bool isNoop(Operation *op);
+
 /* Dump Triton IR in graphviz dot format.
  *
  * You can override `onValue` and `onOperation` in a subclass to mark

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -149,6 +149,17 @@ bool isView(Operation *op) {
   return isa<ExpandDimsOp, ReshapeOp, TransOp, JoinOp, SplitOp>(op);
 }
 
+bool isNoop(Operation *op) {
+  if (isa<ReshapeOp, TransOp>(op))
+    return true;
+  if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+    // The conversion op is a noop if the conversion layout is trivial
+    return minimalCvtLayout(cvt.getSrc().getType(),
+                            cvt.getResult().getType()) == LinearLayout::empty();
+  }
+  return false;
+}
+
 //===----------------------------------------------------------------------===//
 // GraphDumper
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TritonGPU/Transforms/WGMMAPrefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WGMMAPrefetch.cpp
@@ -197,7 +197,10 @@ LogicalResult WGMMAPrefetcher::initialize() {
   }
 
   // Early exit conditions
-  if (dotsInFor.empty() || dotsInFor.size() > 1) {
+  if (dotsInFor.size() != 1) {
+    return failure();
+  }
+  if (dotsInFor.front().getIsAsync()) {
     return failure();
   }
 

--- a/python/test/regression/test_cast_matmul.py
+++ b/python/test/regression/test_cast_matmul.py
@@ -35,8 +35,7 @@ def matmul_kernel(A, B, C, M, N, K,  #
                   stride_am, stride_ak,  #
                   stride_bk, stride_bn,  #
                   stride_cm, stride_cn,  #
-                  dot_out_dtype: tl.constexpr,  #
-                  BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,  #
+                  compute_dtype: tl.constexpr, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,  #
                   BLOCK_K: tl.constexpr, GROUP_M: tl.constexpr):
     # matrix multiplication
     pid = tl.program_id(0)
@@ -57,15 +56,14 @@ def matmul_kernel(A, B, C, M, N, K,  #
     # pointers
     A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
     B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
-    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=dot_out_dtype)
+    acc_dtype = tl.float16 if compute_dtype == tl.float16 and C.dtype.element_ty == tl.float16 else tl.float32
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=acc_dtype)
     for k in range(0, tl.cdiv(K, BLOCK_K)):
         k_remaining = K - k * BLOCK_K
-        _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
+        _0 = tl.zeros((1, 1), dtype=compute_dtype)
         a = tl.load(A, mask=rk[None, :] < k_remaining, other=_0)
         b = tl.load(B, mask=rk[:, None] < k_remaining, other=_0)
-        a = a.to(C.dtype.element_ty)
-        b = b.to(C.dtype.element_ty)
-        acc += tl.dot(a, b, out_dtype=dot_out_dtype)
+        acc += tl.dot(a.to(compute_dtype), b.to(compute_dtype), out_dtype=acc_dtype)
         A += BLOCK_K * stride_ak
         B += BLOCK_K * stride_bk
     acc = acc.to(C.dtype.element_ty)
@@ -100,30 +98,44 @@ def test_cast_matmul(M, K, N, BLOCK_K, BLOCK_M, BLOCK_N, w_dtype, x_dtype, out_d
         else:
             return torch.randn(shape, device=device, dtype=dtype)
 
+    def compute_dtype(a_dtype, b_dtype):
+        # a holds the larger dtype
+        if a_dtype.itemsize < b_dtype.itemsize:
+            a_dtype, b_dtype = b_dtype, a_dtype
+        # float64 matmul is not supported by triton
+        if a_dtype == torch.float64:
+            return torch.float32
+        # If they are both 1 byte or float16 and (1 byte or float16)
+        if a_dtype.itemsize == 1 or (a_dtype == torch.float16 and b_dtype != torch.bfloat16):
+            return torch.float16
+        else:
+            return torch.float32
+
+    # nasty hack
+    def get_triton_dtype(dtype):
+        return getattr(tl, str(dtype).removeprefix("torch."))
+
     torch.manual_seed(42)
     a = init_tensor(w_dtype, (M, K))
     b = init_tensor(x_dtype, (K, N))
 
     torch_dtype = getattr(torch, out_dtype)
-    triton_dtype = getattr(tl, out_dtype)  # <- here force dot_out_dtype
     out_torch = torch.matmul(a.to(torch_dtype), b.to(torch_dtype))
     out_triton = torch.empty((M, N), device=device, dtype=torch_dtype)
+    compute_triton = get_triton_dtype(compute_dtype(w_dtype, x_dtype))
 
     # launch kernel
     block_m, block_n, block_k = BLOCK_M, BLOCK_N, BLOCK_K
     grid = ((triton.cdiv(M, block_m) * triton.cdiv(N, block_n)), 1)
 
-    ker = matmul_kernel[grid](
+    matmul_kernel[grid](
         a, b, out_triton, M, N, K,  #
         a.stride(0), a.stride(1),  #
         b.stride(0), b.stride(1),  #
-        out_triton.stride(0), out_triton.stride(1), dot_out_dtype=triton_dtype,  #
-        GROUP_M=8,  #
+        out_triton.stride(0), out_triton.stride(1),  #
+        compute_triton, GROUP_M=8,  #
         BLOCK_M=block_m,  #
         BLOCK_N=block_n,  #
         BLOCK_K=block_k)
-    print(ker.asm["sass"])
-    diff = (out_torch - out_triton).abs() > 0.3 + 0.01 * out_torch.abs()
-    print(torch.nonzero(diff)[:30])
 
     torch.testing.assert_close(out_torch, out_triton, atol=0.3, rtol=0.01)

--- a/test/TritonGPU/WGMMAPrefetch.mlir
+++ b/test/TritonGPU/WGMMAPrefetch.mlir
@@ -71,7 +71,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
         %a_op_ = ttg.local_load %a_smem_tile token  %wait_token : !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable> -> tensor<128x64xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<128x64xi8, #A_OP> to tensor<128x64xbf16, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<128x64xbf16, #A_OP> * !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable> -> tensor<128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32} : tensor<128x64xbf16, #A_OP> * !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable> -> tensor<128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<128x256xf32, #C>
 
@@ -144,7 +144,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<16x256xbf16, #B_SMEM, #smem> -> !ttg.memdesc<16x256xbf16, #B_SMEM, #smem>
         %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x16xi8, #A_SMEM, #smem> -> tensor<128x16xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<128x16xi8, #A_OP> to tensor<128x16xbf16, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<128x16xbf16, #A_OP> * !ttg.memdesc<16x256xbf16, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32} : tensor<128x16xbf16, #A_OP> * !ttg.memdesc<16x256xbf16, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<128x256xf32, #C>
 
@@ -213,7 +213,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem> -> !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem>
         %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem> -> tensor<8x128x16xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<8x128x16xi8, #A_OP> to tensor<8x128x16xbf16, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<8x128x16xbf16, #A_OP> * !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem> -> tensor<8x128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32} : tensor<8x128x16xbf16, #A_OP> * !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem> -> tensor<8x128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<8x128x256xf32, #C>
 
@@ -297,7 +297,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem> -> !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem>
         %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem> -> tensor<8x128x64xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<8x128x64xi8, #A_OP> to tensor<8x128x64xbf16, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<8x128x64xbf16, #A_OP> * !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem> -> tensor<8x128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32} : tensor<8x128x64xbf16, #A_OP> * !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem> -> tensor<8x128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<8x128x256xf32, #C>
 
@@ -345,13 +345,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK:       %[[A_SUBTILE_4_SMEM:.*]] = ttg.memdesc_subview %[[A_TILE_SMEM]][%[[C0]], %[[C96]]]
 // CHECK:       %[[A_SUBITLE_4_REG:.*]] = ttg.local_load %[[A_SUBTILE_4_SMEM]]
 // CHECK:       %[[A_SUBITLE_1_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_1_REG]]
-// CHECK:       %[[D_1:.*]] = ttng.warp_group_dot %[[A_SUBITLE_1_REG_CVT]], %[[B_SUBTILE_1_SMEM:.*]], %[[D_arg]] {{{.*}}, {{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
+// CHECK:       %[[D_1:.*]] = ttng.warp_group_dot %[[A_SUBITLE_1_REG_CVT]], %[[B_SUBTILE_1_SMEM:.*]], %[[D_arg]] {{{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
 // CHECK:       %[[A_SUBITLE_2_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_2_REG]]
-// CHECK:       %[[D_2:.*]] = ttng.warp_group_dot %[[A_SUBITLE_2_REG_CVT]], %[[B_SUBTILE_2_SMEM:.*]], %[[D_1]], %[[TRUE]] {{{.*}}, {{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
+// CHECK:       %[[D_2:.*]] = ttng.warp_group_dot %[[A_SUBITLE_2_REG_CVT]], %[[B_SUBTILE_2_SMEM:.*]], %[[D_1]], %[[TRUE]] {{{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
 // CHECK:       %[[A_SUBITLE_3_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_3_REG]]
-// CHECK:       %[[D_3:.*]] = ttng.warp_group_dot %[[A_SUBITLE_3_REG_CVT]], %[[B_SUBTILE_3_SMEM:.*]], %[[D_2]], %[[TRUE]] {{{.*}}, {{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
+// CHECK:       %[[D_3:.*]] = ttng.warp_group_dot %[[A_SUBITLE_3_REG_CVT]], %[[B_SUBTILE_3_SMEM:.*]], %[[D_2]], %[[TRUE]] {{{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
 // CHECK:       %[[A_SUBITLE_4_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_4_REG]]
-// CHECK:       %[[D_4:.*]] = ttng.warp_group_dot %[[A_SUBITLE_4_REG_CVT]], %[[B_SUBTILE_4_SMEM:.*]], %[[D_3]], %[[TRUE]] {{{.*}}, {{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
+// CHECK:       %[[D_4:.*]] = ttng.warp_group_dot %[[A_SUBITLE_4_REG_CVT]], %[[B_SUBTILE_4_SMEM:.*]], %[[D_3]], %[[TRUE]] {{{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
 // CHECK-DAG:   %[[D:.*]] = ttng.warp_group_dot_wait %[[D_4]]
 // CHECK-NEXT:  %[[D_ADD_CONSTANT:.*]] = arith.addf %[[D]]
 // CHECK:       scf.yield {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[D_ADD_CONSTANT]]
@@ -383,7 +383,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
         %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x128xi8, #A_SMEM, #smem> -> tensor<128x128xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<128x128xi8, #A_OP> to tensor<128x128xf8E5M2, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 129 : i32, isAsync = true} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 129 : i32} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<128x256xf32, #C>
 
@@ -432,13 +432,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK:       %[[A_SUBTILE_4_SMEM:.*]] = ttg.memdesc_subview %[[A_TILE_SMEM]][%[[C0]], %[[C96]]]
 // CHECK:       %[[A_SUBITLE_4_REG:.*]] = ttg.local_load %[[A_SUBTILE_4_SMEM]]
 // CHECK:       %[[A_SUBITLE_1_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_1_REG]]
-// CHECK:       %[[D_1:.*]] = ttng.warp_group_dot %[[A_SUBITLE_1_REG_CVT]], %[[B_SUBTILE_1_SMEM:.*]], %[[D_arg]] {{{.*}}, {{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
+// CHECK:       %[[D_1:.*]] = ttng.warp_group_dot %[[A_SUBITLE_1_REG_CVT]], %[[B_SUBTILE_1_SMEM:.*]], %[[D_arg]] {{{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
 // CHECK:       %[[A_SUBITLE_2_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_2_REG]]
-// CHECK:       %[[D_2:.*]] = ttng.warp_group_dot %[[A_SUBITLE_2_REG_CVT]], %[[B_SUBTILE_2_SMEM:.*]], %[[D_1]], %[[TRUE]] {{{.*}}, {{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
+// CHECK:       %[[D_2:.*]] = ttng.warp_group_dot %[[A_SUBITLE_2_REG_CVT]], %[[B_SUBTILE_2_SMEM:.*]], %[[D_1]], %[[TRUE]] {{{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
 // CHECK:       %[[A_SUBITLE_3_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_3_REG]]
-// CHECK:       %[[D_3:.*]] = ttng.warp_group_dot %[[A_SUBITLE_3_REG_CVT]], %[[B_SUBTILE_3_SMEM:.*]], %[[D_2]], %[[TRUE]] {{{.*}}, {{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
+// CHECK:       %[[D_3:.*]] = ttng.warp_group_dot %[[A_SUBITLE_3_REG_CVT]], %[[B_SUBTILE_3_SMEM:.*]], %[[D_2]], %[[TRUE]] {{{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
 // CHECK:       %[[A_SUBITLE_4_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_4_REG]]
-// CHECK:       %[[D_4:.*]] = ttng.warp_group_dot %[[A_SUBITLE_4_REG_CVT]], %[[B_SUBTILE_4_SMEM:.*]], %[[D_3]], %[[TRUE]] {{{.*}}, {{.*}}, maxNumImpreciseAcc = 32 : i32}
+// CHECK:       %[[D_4:.*]] = ttng.warp_group_dot %[[A_SUBITLE_4_REG_CVT]], %[[B_SUBTILE_4_SMEM:.*]], %[[D_3]], %[[TRUE]] {{{.*}}, maxNumImpreciseAcc = 32 : i32}
 // CHECK-DAG:   %[[D:.*]] = ttng.warp_group_dot_wait %[[D_4]]
 // CHECK-NEXT:  %[[D_ADD_CONSTANT:.*]] = arith.addf %[[D]]
 // CHECK:       scf.yield {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[D_ADD_CONSTANT]]
@@ -470,7 +470,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
         %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x128xi8, #A_SMEM, #smem> -> tensor<128x128xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<128x128xi8, #A_OP> to tensor<128x128xf8E5M2, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 128 : i32, isAsync = true} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 128 : i32} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<128x256xf32, #C>
 
@@ -520,11 +520,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK:       %[[A_SUBTILE_4_SMEM:.*]] = ttg.memdesc_subview %[[A_TILE_SMEM]][%[[C0]], %[[C96]]]
 // CHECK:       %[[A_SUBITLE_4_REG:.*]] = ttg.local_load %[[A_SUBTILE_4_SMEM]]
 // CHECK:       %[[A_SUBITLE_1_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_1_REG]]
-// CHECK:       %[[D_1:.*]] = ttng.warp_group_dot %[[A_SUBITLE_1_REG_CVT]], %[[B_SUBTILE_1_SMEM:.*]], %[[D_arg]] {{{.*}}, {{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
+// CHECK:       %[[D_1:.*]] = ttng.warp_group_dot %[[A_SUBITLE_1_REG_CVT]], %[[B_SUBTILE_1_SMEM:.*]], %[[D_arg]] {{{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
 // CHECK:       %[[A_SUBITLE_2_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_2_REG]]
-// CHECK:       %[[D_2:.*]] = ttng.warp_group_dot %[[A_SUBITLE_2_REG_CVT]], %[[B_SUBTILE_2_SMEM:.*]], %[[D_1]], %[[TRUE]] {{{.*}}, {{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
+// CHECK:       %[[D_2:.*]] = ttng.warp_group_dot %[[A_SUBITLE_2_REG_CVT]], %[[B_SUBTILE_2_SMEM:.*]], %[[D_1]], %[[TRUE]] {{{.*}}, maxNumImpreciseAcc = 1073741824 : i32}
 // CHECK:       %[[A_SUBITLE_3_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_3_REG]]
-// CHECK:       %[[D_3:.*]] = ttng.warp_group_dot %[[A_SUBITLE_3_REG_CVT]], %[[B_SUBTILE_3_SMEM:.*]], %[[D_2]], %[[TRUE]] {{{.*}}, {{.*}}, maxNumImpreciseAcc = 32 : i32}
+// CHECK:       %[[D_3:.*]] = ttng.warp_group_dot %[[A_SUBITLE_3_REG_CVT]], %[[B_SUBTILE_3_SMEM:.*]], %[[D_2]], %[[TRUE]] {{{.*}}, maxNumImpreciseAcc = 32 : i32}
 // CHECK:       %[[A_SUBITLE_4_REG_CVT:.*]] = arith.sitofp %[[A_SUBITLE_4_REG]]
 // CHECK:       %[[D_4:.*]] = ttng.warp_group_dot %[[A_SUBITLE_4_REG_CVT]], %[[B_SUBTILE_4_SMEM:.*]], %[[D_3]], %[[TRUE]] {{{.*}}, {{.*}}}
 // CHECK-DAG:   %[[D:.*]] = ttng.warp_group_dot_wait %[[D_4]]
@@ -558,7 +558,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
         %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x128xi8, #A_SMEM, #smem> -> tensor<128x128xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<128x128xi8, #A_OP> to tensor<128x128xf8E5M2, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 96 : i32, isAsync = true} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 96 : i32} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<128x256xf32, #C>
 

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -759,7 +759,6 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     // CHECK:   ttg.async_wait {{.*}} {num = 2 : i32}
     // CHECK:   ttg.local_load
     // CHECK:   ttng.warp_group_dot
-    // CHECK-NEXT: ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32}
     // CHECK:   ttg.async_copy_global_to_local
     // CHECK:   ttg.async_commit_group
     // CHECK:   ttg.async_copy_global_to_local
@@ -778,6 +777,75 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
       scf.yield %21, %25, %26 : tensor<128x16xf32, #mma>, tensor<128x64x!tt.ptr<f16>, #blocked1>, tensor<64x16x!tt.ptr<f16>, #blocked>
     }
     tt.return %17#0 : tensor<128x16xf32, #mma>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[1, 0], [0, 8], [8, 0]], lane = [[2, 0], [4, 0], [0, 1], [0, 2], [0, 4]], warp = [[0, 16], [0, 32]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1], [8, 0], [0, 8]], lane = [[0, 2], [0, 4], [1, 0], [2, 0], [4, 0]], warp = [[16, 0], [32, 0]], block = []}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: dot_lhs_registers_noops_acc
+  tt.func @dot_lhs_registers_noops_acc(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) -> tensor<16x128xf32, #linear> {
+    %cst = arith.constant dense<0> : tensor<64x16xi32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %cst_0 = arith.constant dense<0> : tensor<1x16xi32, #blocked>
+    %cst_1 = arith.constant dense<0> : tensor<128x1xi32, #blocked1>
+    %c0_i64 = arith.constant 0 : i64
+    %cst_2 = arith.constant dense<0.000000e+00> : tensor<16x128xf32, #linear>
+    %cst_3 = arith.constant dense<0> : tensor<128x64xi32, #blocked1>
+    %cst_4 = arith.constant dense<2.0> : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = tt.addptr %arg0, %c0_i64 : !tt.ptr<f16>, i64
+    %1 = tt.addptr %arg1, %c0_i64 : !tt.ptr<f16>, i64
+    %2 = tt.splat %1 : !tt.ptr<f16> -> tensor<128x1x!tt.ptr<f16>, #blocked1>
+    %3 = tt.addptr %2, %cst_1 : tensor<128x1x!tt.ptr<f16>, #blocked1>, tensor<128x1xi32, #blocked1>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x64xi32, #blocked1>
+    %6 = tt.broadcast %3 : tensor<128x1x!tt.ptr<f16>, #blocked1> -> tensor<128x64x!tt.ptr<f16>, #blocked1>
+    %7 = tt.broadcast %5 : tensor<1x64xi32, #blocked1> -> tensor<128x64xi32, #blocked1>
+    %8 = tt.addptr %6, %7 : tensor<128x64x!tt.ptr<f16>, #blocked1>, tensor<128x64xi32, #blocked1>
+    %9 = tt.load %8 : tensor<128x64x!tt.ptr<f16>, #blocked1>
+    %10 = tt.splat %0 : !tt.ptr<f16> -> tensor<1x16x!tt.ptr<f16>, #blocked>
+    %11 = tt.addptr %10, %cst_0 : tensor<1x16x!tt.ptr<f16>, #blocked>, tensor<1x16xi32, #blocked>
+    %12 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %13 = tt.expand_dims %12 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %14 = tt.broadcast %11 : tensor<1x16x!tt.ptr<f16>, #blocked> -> tensor<64x16x!tt.ptr<f16>, #blocked>
+    %15 = tt.broadcast %13 : tensor<64x1xi32, #blocked> -> tensor<64x16xi32, #blocked>
+    %16 = tt.addptr %14, %15 : tensor<64x16x!tt.ptr<f16>, #blocked>, tensor<64x16xi32, #blocked>
+    // CHECK: scf.for
+    // CHECK:   ttg.async_wait {{.*}} {num = 2 : i32}
+    // CHECK:   ttg.local_load
+    // CHECK:   ttng.warp_group_dot
+    // CHECK:   ttg.async_copy_global_to_local
+    // CHECK:   ttg.async_commit_group
+    // CHECK:   ttg.async_copy_global_to_local
+    // CHECK:   ttg.async_commit_group
+    // CHECK:   scf.yield
+    // CHECK:   ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32}
+    %17:3 = scf.for %arg3 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg4 = %cst_2, %arg5 = %8, %arg6 = %16) -> (tensor<16x128xf32, #linear>, tensor<128x64x!tt.ptr<f16>, #blocked1>,
+        tensor<64x16x!tt.ptr<f16>, #blocked>)  : i32 {
+      %a_block = tt.load %arg5 : tensor<128x64x!tt.ptr<f16>, #blocked1>
+      %b_block = tt.load %arg6 : tensor<64x16x!tt.ptr<f16>, #blocked>
+      %a_dotop = ttg.convert_layout %a_block : tensor<128x64xf16, #blocked1> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+      %a_dotop_mul = arith.mulf %a_dotop, %cst_4 : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+      %b_smem = ttg.local_alloc %b_block : (tensor<64x16xf16, #blocked>) -> !ttg.memdesc<64x16xf16, #shared1, #smem>
+      %acc_linear = tt.trans %arg4 {order = array<i32: 1, 0>} : tensor<16x128xf32, #linear> -> tensor<128x16xf32, #linear1>
+      %acc = ttg.convert_layout %acc_linear : tensor<128x16xf32, #linear1> -> tensor<128x16xf32, #mma>
+      %21 = ttng.warp_group_dot %a_dotop_mul, %b_smem, %acc : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * !ttg.memdesc<64x16xf16, #shared1, #smem> -> tensor<128x16xf32, #mma>
+      %acc_t = tt.trans %21 {order = array<i32: 1, 0>} : tensor<128x16xf32, #mma> -> tensor<16x128xf32, #linear>
+      %25 = tt.addptr %arg5, %cst_3 : tensor<128x64x!tt.ptr<f16>, #blocked1>, tensor<128x64xi32, #blocked1>
+      %26 = tt.addptr %arg6, %cst : tensor<64x16x!tt.ptr<f16>, #blocked>, tensor<64x16xi32, #blocked>
+      scf.yield %acc_t, %25, %26 : tensor<16x128xf32, #linear>, tensor<128x64x!tt.ptr<f16>, #blocked1>, tensor<64x16x!tt.ptr<f16>, #blocked>
+    }
+    tt.return %17#0 : tensor<16x128xf32, #linear>
   }
 }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -451,7 +451,6 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
           llvm::SmallVector<Value> regA =
               loadReg(rewriter, loc, structA, (m * numRepK + k) * regASize,
                       regASize, startSequence);
-
           auto regATy = LLVM::LLVMStructType::getLiteral(
               rewriter.getContext(),
               SmallVector<Type>(regA.size(), regA[0].getType()));


### PR DESCRIPTION
We allow it when the RHS is multibuffered. In that case, we add
`wgmma_wait(repK-1)` in the LLVM lowering rather than adding explicit
waits at the TTGIR level. We might change this bit in the future.
