### PR TITLE
[DIALECT] Tighten verifiers of alloc ops

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -142,6 +142,10 @@ def TTG_LocalAllocOp : TTG_Op<"local_alloc", [DeclareOpInterfaceMethods<MemoryEf
     containing the address and a view of the buffer.
 
     Explicitly deallocating a buffer is optional; see local_dealloc.
+
+    The `src` operand is an optional initializer for the allocated buffer. It
+    must have the element type as the buffer. If `src` is not specified, the
+    returned buffer must be mutable.
   }];
   let arguments = (
     ins
@@ -159,9 +163,10 @@ def TTG_LocalAllocOp : TTG_Op<"local_alloc", [DeclareOpInterfaceMethods<MemoryEf
   ];
 
   let extraClassDeclaration = [{
+    static LogicalResult verifyAllocOp(Operation *op, Value src,
+                                       MemDescType dstTy);
     bool isSharedMemoryAlloc() {
-      return getType().getMemorySpace() &&
-             isa<SharedMemorySpaceAttr>(getType().getMemorySpace());
+      return isa_and_nonnull<SharedMemorySpaceAttr>(getType().getMemorySpace());
     }
     int32_t getAlignmentOrDefault();
   }];

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -463,17 +463,13 @@ LogicalResult TMEMLoadOp::verify() {
 
 // -- TMEMAllocOp --
 LogicalResult TMEMAllocOp::verify() {
-  if (!isa<triton::nvidia_gpu::TensorMemorySpaceAttr>(
-          getType().getMemorySpace()))
-    return emitOpError("should create a buffer of tensor memory.");
-  if (!isa<triton::nvidia_gpu::TensorMemoryEncodingAttr,
-           TensorMemoryScalesEncodingAttr>(getType().getEncoding()))
-    return emitOpError("should use tensor memory encoding.");
-  if (!getSrc()) {
-    if (!getType().getMutableMemory())
-      return emitError("uninitialized alloc must have a mutable memdesc type");
-  }
-  return success();
+  if (!isa<TensorMemorySpaceAttr>(getType().getMemorySpace()))
+    return emitOpError("should create a buffer of tensor memory");
+  if (!isa<TensorMemoryEncodingAttr, TensorMemoryScalesEncodingAttr>(
+          getType().getEncoding()))
+    return emitOpError("should use tensor memory encoding");
+
+  return LocalAllocOp::verifyAllocOp(*this, getSrc(), getType());
 }
 
 void TMEMAllocOp::getEffects(

--- a/test/TritonGPU/WGMMAPrefetch.mlir
+++ b/test/TritonGPU/WGMMAPrefetch.mlir
@@ -56,22 +56,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %a_off = arith.constant dense<4> : tensor<128x64xi32, #AL>
     %b_off = arith.constant dense<4> : tensor<64x256xi32, #BL>
 
-    %a_init = ttg.local_alloc : () -> !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable, 1x128x64>
-    %a_ = ttg.async_copy_global_to_local %a_ptr_init, %a_init mask %a_mask other %a_other : tensor<128x64x!tt.ptr<i8>, #AL> -> !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable, 1x128x64>
+    %a_init = ttg.local_alloc : () -> !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable>
+    %a_ = ttg.async_copy_global_to_local %a_ptr_init, %a_init mask %a_mask other %a_other : tensor<128x64x!tt.ptr<i8>, #AL> -> !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable>
     %a_load_commit = ttg.async_commit_group %a_
 
-    %b_init = ttg.local_alloc : () -> !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable, 1x64x256>
-    %b_ = ttg.async_copy_global_to_local %b_ptr_init, %b_init mask %b_mask other %b_other : tensor<64x256x!tt.ptr<bf16>, #BL> -> !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable, 1x64x256>
+    %b_init = ttg.local_alloc : () -> !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable>
+    %b_ = ttg.async_copy_global_to_local %b_ptr_init, %b_init mask %b_mask other %b_other : tensor<64x256x!tt.ptr<bf16>, #BL> -> !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable>
     %b_load_commit = ttg.async_commit_group %b_
 
-    %loop:7 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init, %a_token = %a_load_commit, %b_token = %b_load_commit) -> (tensor<128x64x!tt.ptr<i8>, #AL>, tensor<64x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable, 1x128x64>, !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable, 1x64x256>, tensor<128x256xf32, #C>, !ttg.async.token, !ttg.async.token) {
-        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32] : !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable, 1x128x64> -> !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable, 1x128x64>
-        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable, 1x64x256> -> !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable, 1x64x256>
+    %loop:7 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init, %a_token = %a_load_commit, %b_token = %b_load_commit) -> (tensor<128x64x!tt.ptr<i8>, #AL>, tensor<64x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable>, !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable>, tensor<128x256xf32, #C>, !ttg.async.token, !ttg.async.token) {
+        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32] : !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable> -> !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable>
+        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable> -> !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable>
         %wait_token = ttg.async_wait %a_token, %b_token {num = 0 : i32}
 
-        %a_op_ = ttg.local_load %a_smem_tile token  %wait_token : !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable, 1x128x64> -> tensor<128x64xi8, #A_OP>
+        %a_op_ = ttg.local_load %a_smem_tile token  %wait_token : !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable> -> tensor<128x64xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<128x64xi8, #A_OP> to tensor<128x64xbf16, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<128x64xbf16, #A_OP> * !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable, 1x64x256> -> tensor<128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<128x64xbf16, #A_OP> * !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable> -> tensor<128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<128x256xf32, #C>
 
@@ -80,14 +80,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
         %c_add_constant = arith.addf %c, %constant_init: tensor<128x256xf32, #C>
 
-        %next_a = ttg.local_alloc : () -> !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable, 1x128x64>
-        %next_a_ = ttg.async_copy_global_to_local %next_a_ptr, %next_a mask %a_mask other %a_other : tensor<128x64x!tt.ptr<i8>, #AL> ->  !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable, 1x128x64>
+        %next_a = ttg.local_alloc : () -> !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable>
+        %next_a_ = ttg.async_copy_global_to_local %next_a_ptr, %next_a mask %a_mask other %a_other : tensor<128x64x!tt.ptr<i8>, #AL> ->  !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable>
         %next_a_load_commit = ttg.async_commit_group %next_a_
-        %next_b = ttg.local_alloc : () -> !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable, 1x64x256>
-        %next_b_ = ttg.async_copy_global_to_local %next_b_ptr, %next_b mask %b_mask other %b_other : tensor<64x256x!tt.ptr<bf16>, #BL> -> !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable, 1x64x256>
+        %next_b = ttg.local_alloc : () -> !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable>
+        %next_b_ = ttg.async_copy_global_to_local %next_b_ptr, %next_b mask %b_mask other %b_other : tensor<64x256x!tt.ptr<bf16>, #BL> -> !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable>
         %next_b_load_commit = ttg.async_commit_group %next_b_
 
-        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c_add_constant, %next_a_load_commit, %next_b_load_commit: tensor<128x64x!tt.ptr<i8>, #AL>, tensor<64x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable, 1x128x64>, !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable, 1x64x256>, tensor<128x256xf32, #C>, !ttg.async.token, !ttg.async.token
+        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c_add_constant, %next_a_load_commit, %next_b_load_commit: tensor<128x64x!tt.ptr<i8>, #AL>, tensor<64x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<128x64xi8, #A_SMEM, #smem, mutable>, !ttg.memdesc<64x256xbf16, #B_SMEM, #smem, mutable>, tensor<128x256xf32, #C>, !ttg.async.token, !ttg.async.token
 
     }
     tt.return %loop#4 : tensor<128x256xf32, #C>
@@ -135,16 +135,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %b_off = arith.constant dense<4> : tensor<16x256xi32, #BL>
 
     %a_ = tt.load %a_ptr_init, %a_mask, %a_other : tensor<128x16x!tt.ptr<i8>, #AL>
-    %a_init = ttg.local_alloc %a_ : (tensor<128x16xi8, #AL>) -> !ttg.memdesc<128x16xi8, #A_SMEM, #smem, 1x128x16>
+    %a_init = ttg.local_alloc %a_ : (tensor<128x16xi8, #AL>) -> !ttg.memdesc<128x16xi8, #A_SMEM, #smem>
     %b_ = tt.load %b_ptr_init, %b_mask, %b_other : tensor<16x256x!tt.ptr<bf16>, #BL>
-    %b_init = ttg.local_alloc %b_ : (tensor<16x256xbf16, #BL>) -> !ttg.memdesc<16x256xbf16, #B_SMEM, #smem, 1x16x256>
+    %b_init = ttg.local_alloc %b_ : (tensor<16x256xbf16, #BL>) -> !ttg.memdesc<16x256xbf16, #B_SMEM, #smem>
 
-    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<128x16x!tt.ptr<i8>, #AL>, tensor<16x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<128x16xi8, #A_SMEM, #smem, 1x128x16>, !ttg.memdesc<16x256xbf16, #B_SMEM, #smem, 1x16x256>, tensor<128x256xf32, #C>) {
-        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32] : !ttg.memdesc<128x16xi8, #A_SMEM, #smem, 1x128x16> -> !ttg.memdesc<128x16xi8, #A_SMEM, #smem, 1x128x16>
-        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<16x256xbf16, #B_SMEM, #smem, 1x16x256> -> !ttg.memdesc<16x256xbf16, #B_SMEM, #smem, 1x16x256>
-        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x16xi8, #A_SMEM, #smem, 1x128x16> -> tensor<128x16xi8, #A_OP>
+    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<128x16x!tt.ptr<i8>, #AL>, tensor<16x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<128x16xi8, #A_SMEM, #smem>, !ttg.memdesc<16x256xbf16, #B_SMEM, #smem>, tensor<128x256xf32, #C>) {
+        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32] : !ttg.memdesc<128x16xi8, #A_SMEM, #smem> -> !ttg.memdesc<128x16xi8, #A_SMEM, #smem>
+        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<16x256xbf16, #B_SMEM, #smem> -> !ttg.memdesc<16x256xbf16, #B_SMEM, #smem>
+        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x16xi8, #A_SMEM, #smem> -> tensor<128x16xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<128x16xi8, #A_OP> to tensor<128x16xbf16, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<128x16xbf16, #A_OP> * !ttg.memdesc<16x256xbf16, #B_SMEM, #smem, 1x16x256> -> tensor<128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<128x16xbf16, #A_OP> * !ttg.memdesc<16x256xbf16, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<128x256xf32, #C>
 
@@ -152,11 +152,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %next_b_ptr = tt.addptr %b_ptr, %b_off: tensor<16x256x!tt.ptr<bf16>, #BL>, tensor<16x256xi32, #BL>
 
         %next_a_ = tt.load %next_a_ptr, %a_mask, %a_other : tensor<128x16x!tt.ptr<i8>, #AL>
-        %next_a = ttg.local_alloc %next_a_ : (tensor<128x16xi8, #AL>) -> !ttg.memdesc<128x16xi8, #A_SMEM, #smem, 1x128x16>
+        %next_a = ttg.local_alloc %next_a_ : (tensor<128x16xi8, #AL>) -> !ttg.memdesc<128x16xi8, #A_SMEM, #smem>
         %next_b_ = tt.load %next_b_ptr, %b_mask, %b_other : tensor<16x256x!tt.ptr<bf16>, #BL>
-        %next_b = ttg.local_alloc %next_b_ : (tensor<16x256xbf16, #BL>) -> !ttg.memdesc<16x256xbf16, #B_SMEM, #smem, 1x16x256>
+        %next_b = ttg.local_alloc %next_b_ : (tensor<16x256xbf16, #BL>) -> !ttg.memdesc<16x256xbf16, #B_SMEM, #smem>
 
-        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c: tensor<128x16x!tt.ptr<i8>, #AL>, tensor<16x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<128x16xi8, #A_SMEM, #smem, 1x128x16>, !ttg.memdesc<16x256xbf16, #B_SMEM, #smem, 1x16x256>, tensor<128x256xf32, #C>
+        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c: tensor<128x16x!tt.ptr<i8>, #AL>, tensor<16x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<128x16xi8, #A_SMEM, #smem>, !ttg.memdesc<16x256xbf16, #B_SMEM, #smem>, tensor<128x256xf32, #C>
 
     }
     tt.return %loop#4 : tensor<128x256xf32, #C>
@@ -204,16 +204,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %b_off = arith.constant dense<4> : tensor<8x16x256xi32, #BL>
 
     %a_ = tt.load %a_ptr_init, %a_mask, %a_other : tensor<8x128x16x!tt.ptr<i8>, #AL>
-    %a_init = ttg.local_alloc %a_ : (tensor<8x128x16xi8, #AL>) -> !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem, 1x8x128x16>
+    %a_init = ttg.local_alloc %a_ : (tensor<8x128x16xi8, #AL>) -> !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem>
     %b_ = tt.load %b_ptr_init, %b_mask, %b_other : tensor<8x16x256x!tt.ptr<bf16>, #BL>
-    %b_init = ttg.local_alloc %b_ : (tensor<8x16x256xbf16, #BL>) -> !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem, 1x8x16x256>
+    %b_init = ttg.local_alloc %b_ : (tensor<8x16x256xbf16, #BL>) -> !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem>
 
-    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<8x128x16x!tt.ptr<i8>, #AL>, tensor<8x16x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem, 1x8x128x16>, !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem, 1x8x16x256>, tensor<8x128x256xf32, #C>) {
-        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem, 1x8x128x16> -> !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem, 1x8x128x16>
-        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem, 1x8x16x256> -> !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem, 1x8x16x256>
-        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem, 1x8x128x16> -> tensor<8x128x16xi8, #A_OP>
+    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<8x128x16x!tt.ptr<i8>, #AL>, tensor<8x16x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem>, !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem>, tensor<8x128x256xf32, #C>) {
+        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem> -> !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem>
+        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem> -> !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem>
+        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem> -> tensor<8x128x16xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<8x128x16xi8, #A_OP> to tensor<8x128x16xbf16, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<8x128x16xbf16, #A_OP> * !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem, 1x8x16x256> -> tensor<8x128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<8x128x16xbf16, #A_OP> * !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem> -> tensor<8x128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<8x128x256xf32, #C>
 
@@ -221,11 +221,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %next_b_ptr = tt.addptr %b_ptr, %b_off: tensor<8x16x256x!tt.ptr<bf16>, #BL>, tensor<8x16x256xi32, #BL>
 
         %next_a_ = tt.load %next_a_ptr, %a_mask, %a_other : tensor<8x128x16x!tt.ptr<i8>, #AL>
-        %next_a = ttg.local_alloc %next_a_ : (tensor<8x128x16xi8, #AL>) -> !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem, 1x8x128x16>
+        %next_a = ttg.local_alloc %next_a_ : (tensor<8x128x16xi8, #AL>) -> !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem>
         %next_b_ = tt.load %next_b_ptr, %b_mask, %b_other : tensor<8x16x256x!tt.ptr<bf16>, #BL>
-        %next_b = ttg.local_alloc %next_b_ : (tensor<8x16x256xbf16, #BL>) -> !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem, 1x8x16x256>
+        %next_b = ttg.local_alloc %next_b_ : (tensor<8x16x256xbf16, #BL>) -> !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem>
 
-        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c: tensor<8x128x16x!tt.ptr<i8>, #AL>, tensor<8x16x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem, 1x8x128x16>, !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem, 1x8x16x256>, tensor<8x128x256xf32, #C>
+        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c: tensor<8x128x16x!tt.ptr<i8>, #AL>, tensor<8x16x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<8x128x16xi8, #A_SMEM, #smem>, !ttg.memdesc<8x16x256xbf16, #B_SMEM, #smem>, tensor<8x128x256xf32, #C>
 
     }
     tt.return %loop#4 : tensor<8x128x256xf32, #C>
@@ -288,16 +288,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %b_off = arith.constant dense<4> : tensor<8x64x256xi32, #BL>
 
     %a_ = tt.load %a_ptr_init, %a_mask, %a_other : tensor<8x128x64x!tt.ptr<i8>, #AL>
-    %a_init = ttg.local_alloc %a_ : (tensor<8x128x64xi8, #AL>) -> !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem, 1x8x128x64>
+    %a_init = ttg.local_alloc %a_ : (tensor<8x128x64xi8, #AL>) -> !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem>
     %b_ = tt.load %b_ptr_init, %b_mask, %b_other : tensor<8x64x256x!tt.ptr<bf16>, #BL>
-    %b_init = ttg.local_alloc %b_ : (tensor<8x64x256xbf16, #BL>) -> !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem, 1x8x64x256>
+    %b_init = ttg.local_alloc %b_ : (tensor<8x64x256xbf16, #BL>) -> !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem>
 
-    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<8x128x64x!tt.ptr<i8>, #AL>, tensor<8x64x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem, 1x8x128x64>, !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem, 1x8x64x256>, tensor<8x128x256xf32, #C>) {
-        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem, 1x8x128x64> -> !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem, 1x8x128x64>
-        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem, 1x8x64x256> -> !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem, 1x8x64x256>
-        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem, 1x8x128x64> -> tensor<8x128x64xi8, #A_OP>
+    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<8x128x64x!tt.ptr<i8>, #AL>, tensor<8x64x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem>, !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem>, tensor<8x128x256xf32, #C>) {
+        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem> -> !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem>
+        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem> -> !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem>
+        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem> -> tensor<8x128x64xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<8x128x64xi8, #A_OP> to tensor<8x128x64xbf16, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<8x128x64xbf16, #A_OP> * !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem, 1x8x64x256> -> tensor<8x128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, isAsync = true} : tensor<8x128x64xbf16, #A_OP> * !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem> -> tensor<8x128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<8x128x256xf32, #C>
 
@@ -305,11 +305,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %next_b_ptr = tt.addptr %b_ptr, %b_off: tensor<8x64x256x!tt.ptr<bf16>, #BL>, tensor<8x64x256xi32, #BL>
 
         %next_a_ = tt.load %next_a_ptr, %a_mask, %a_other : tensor<8x128x64x!tt.ptr<i8>, #AL>
-        %next_a = ttg.local_alloc %next_a_ : (tensor<8x128x64xi8, #AL>) -> !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem, 1x8x128x64>
+        %next_a = ttg.local_alloc %next_a_ : (tensor<8x128x64xi8, #AL>) -> !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem>
         %next_b_ = tt.load %next_b_ptr, %b_mask, %b_other : tensor<8x64x256x!tt.ptr<bf16>, #BL>
-        %next_b = ttg.local_alloc %next_b_ : (tensor<8x64x256xbf16, #BL>) -> !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem, 1x8x64x256>
+        %next_b = ttg.local_alloc %next_b_ : (tensor<8x64x256xbf16, #BL>) -> !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem>
 
-        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c: tensor<8x128x64x!tt.ptr<i8>, #AL>, tensor<8x64x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem, 1x8x128x64>, !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem, 1x8x64x256>, tensor<8x128x256xf32, #C>
+        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c: tensor<8x128x64x!tt.ptr<i8>, #AL>, tensor<8x64x256x!tt.ptr<bf16>, #BL>, !ttg.memdesc<8x128x64xi8, #A_SMEM, #smem>, !ttg.memdesc<8x64x256xbf16, #B_SMEM, #smem>, tensor<8x128x256xf32, #C>
 
     }
     tt.return %loop#4 : tensor<8x128x256xf32, #C>
@@ -374,16 +374,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %b_off = arith.constant dense<4> : tensor<128x256xi32, #BL>
 
     %a_ = tt.load %a_ptr_init, %a_mask, %a_other : tensor<128x128x!tt.ptr<i8>, #AL>
-    %a_init = ttg.local_alloc %a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>
+    %a_init = ttg.local_alloc %a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem>
     %b_ = tt.load %b_ptr_init, %b_mask, %b_other : tensor<128x256x!tt.ptr<f8E5M2>, #BL>
-    %b_init = ttg.local_alloc %b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>
+    %b_init = ttg.local_alloc %b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
 
-    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>, tensor<128x256xf32, #C>) {
-        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32] : !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128> -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>
-        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256> -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>
-        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128> -> tensor<128x128xi8, #A_OP>
+    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>, tensor<128x256xf32, #C>) {
+        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32] : !ttg.memdesc<128x128xi8, #A_SMEM, #smem> -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem>
+        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
+        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x128xi8, #A_SMEM, #smem> -> tensor<128x128xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<128x128xi8, #A_OP> to tensor<128x128xf8E5M2, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 129 : i32, isAsync = true} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256> -> tensor<128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 129 : i32, isAsync = true} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<128x256xf32, #C>
 
@@ -393,11 +393,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %c_add_constant = arith.addf %c, %constant_init: tensor<128x256xf32, #C>
 
         %next_a_ = tt.load %next_a_ptr, %a_mask, %a_other : tensor<128x128x!tt.ptr<i8>, #AL>
-        %next_a = ttg.local_alloc %next_a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>
+        %next_a = ttg.local_alloc %next_a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem>
         %next_b_ = tt.load %next_b_ptr, %b_mask, %b_other : tensor<128x256x!tt.ptr<f8E5M2>, #BL>
-        %next_b = ttg.local_alloc %next_b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>
+        %next_b = ttg.local_alloc %next_b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
 
-        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c_add_constant: tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>, tensor<128x256xf32, #C>
+        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c_add_constant: tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>, tensor<128x256xf32, #C>
 
     }
     tt.return %loop#4 : tensor<128x256xf32, #C>
@@ -461,16 +461,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %b_off = arith.constant dense<4> : tensor<128x256xi32, #BL>
 
     %a_ = tt.load %a_ptr_init, %a_mask, %a_other : tensor<128x128x!tt.ptr<i8>, #AL>
-    %a_init = ttg.local_alloc %a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>
+    %a_init = ttg.local_alloc %a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem>
     %b_ = tt.load %b_ptr_init, %b_mask, %b_other : tensor<128x256x!tt.ptr<f8E5M2>, #BL>
-    %b_init = ttg.local_alloc %b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>
+    %b_init = ttg.local_alloc %b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
 
-    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>, tensor<128x256xf32, #C>) {
-        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32] : !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128> -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>
-        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256> -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>
-        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128> -> tensor<128x128xi8, #A_OP>
+    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>, tensor<128x256xf32, #C>) {
+        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32] : !ttg.memdesc<128x128xi8, #A_SMEM, #smem> -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem>
+        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
+        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x128xi8, #A_SMEM, #smem> -> tensor<128x128xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<128x128xi8, #A_OP> to tensor<128x128xf8E5M2, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 128 : i32, isAsync = true} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256> -> tensor<128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 128 : i32, isAsync = true} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<128x256xf32, #C>
 
@@ -480,11 +480,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %c_add_constant = arith.addf %c, %constant_init: tensor<128x256xf32, #C>
 
         %next_a_ = tt.load %next_a_ptr, %a_mask, %a_other : tensor<128x128x!tt.ptr<i8>, #AL>
-        %next_a = ttg.local_alloc %next_a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>
+        %next_a = ttg.local_alloc %next_a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem>
         %next_b_ = tt.load %next_b_ptr, %b_mask, %b_other : tensor<128x256x!tt.ptr<f8E5M2>, #BL>
-        %next_b = ttg.local_alloc %next_b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>
+        %next_b = ttg.local_alloc %next_b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
 
-        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c_add_constant: tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>, tensor<128x256xf32, #C>
+        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c_add_constant: tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>, tensor<128x256xf32, #C>
 
     }
     tt.return %loop#4 : tensor<128x256xf32, #C>
@@ -549,16 +549,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %b_off = arith.constant dense<4> : tensor<128x256xi32, #BL>
 
     %a_ = tt.load %a_ptr_init, %a_mask, %a_other : tensor<128x128x!tt.ptr<i8>, #AL>
-    %a_init = ttg.local_alloc %a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>
+    %a_init = ttg.local_alloc %a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem>
     %b_ = tt.load %b_ptr_init, %b_mask, %b_other : tensor<128x256x!tt.ptr<f8E5M2>, #BL>
-    %b_init = ttg.local_alloc %b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>
+    %b_init = ttg.local_alloc %b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
 
-    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>, tensor<128x256xf32, #C>) {
-        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32] : !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128> -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>
-        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256> -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>
-        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128> -> tensor<128x128xi8, #A_OP>
+    %loop:5 = scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %a = %a_init, %b = %b_init, %prev_c = %c_init) -> (tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>, tensor<128x256xf32, #C>) {
+        %a_smem_tile = ttg.memdesc_subview %a[%c0_i32, %c0_i32] : !ttg.memdesc<128x128xi8, #A_SMEM, #smem> -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem>
+        %b_smem_tile = ttg.memdesc_subview %b[%c0_i32, %c0_i32] : !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
+        %a_op_ = ttg.local_load %a_smem_tile : !ttg.memdesc<128x128xi8, #A_SMEM, #smem> -> tensor<128x128xi8, #A_OP>
         %a_op = arith.sitofp %a_op_ :  tensor<128x128xi8, #A_OP> to tensor<128x128xf8E5M2, #A_OP>
-        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 96 : i32, isAsync = true} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256> -> tensor<128x256xf32, #C>
+        %c_ = ttng.warp_group_dot %a_op, %b_smem_tile, %prev_c  {inputPrecision = 0 : i32, maxNumImpreciseAcc = 96 : i32, isAsync = true} : tensor<128x128xf8E5M2, #A_OP> * !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem> -> tensor<128x256xf32, #C>
 
         %c =  ttng.warp_group_dot_wait %c_ {pendings = 0 : i32}:  tensor<128x256xf32, #C>
 
@@ -568,11 +568,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
         %c_add_constant = arith.addf %c, %constant_init: tensor<128x256xf32, #C>
 
         %next_a_ = tt.load %next_a_ptr, %a_mask, %a_other : tensor<128x128x!tt.ptr<i8>, #AL>
-        %next_a = ttg.local_alloc %next_a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>
+        %next_a = ttg.local_alloc %next_a_ : (tensor<128x128xi8, #AL>) -> !ttg.memdesc<128x128xi8, #A_SMEM, #smem>
         %next_b_ = tt.load %next_b_ptr, %b_mask, %b_other : tensor<128x256x!tt.ptr<f8E5M2>, #BL>
-        %next_b = ttg.local_alloc %next_b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>
+        %next_b = ttg.local_alloc %next_b_ : (tensor<128x256xf8E5M2, #BL>) -> !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>
 
-        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c_add_constant: tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem, 1x128x128>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem, 1x128x256>, tensor<128x256xf32, #C>
+        scf.yield %next_a_ptr, %next_b_ptr, %next_a, %next_b, %c_add_constant: tensor<128x128x!tt.ptr<i8>, #AL>, tensor<128x256x!tt.ptr<f8E5M2>, #BL>, !ttg.memdesc<128x128xi8, #A_SMEM, #smem>, !ttg.memdesc<128x256xf8E5M2, #B_SMEM, #smem>, tensor<128x256xf32, #C>
 
     }
     tt.return %loop#4 : tensor<128x256xf32, #C>

--- a/test/TritonGPU/amd/amd-reorder-instructions.mlir
+++ b/test/TritonGPU/amd/amd-reorder-instructions.mlir
@@ -405,9 +405,9 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32}
     %0 = ttg.local_alloc : () -> !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
     gpu.barrier
     %2 = tt.load %arg0 : tensor<32x32x!tt.ptr<f16>, #blocked>
-    %1 = ttg.local_alloc %2 : (tensor<32x32xf16, #blocked>) -> !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc %2 : (tensor<32x32xf16, #blocked>) -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
     ttg.local_dealloc %0 : !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
-    ttg.local_dealloc %1 : !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
+    ttg.local_dealloc %1 : !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -121,10 +121,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %acc_tm: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>
     ) attributes {noinline = false} {
       %true = arith.constant true
-      %A_la = ttg.local_alloc : () -> !ttg.memdesc<2x512xi8, #shared1, #smem, mutable, 3x2x512>
-      %B_la = ttg.local_alloc : () -> !ttg.memdesc<2x512xi8, #shared1, #smem, mutable, 3x2x512>
-      %A_ll = ttg.local_load %A_la : !ttg.memdesc<2x512xi8, #shared1, #smem, mutable, 3x2x512> -> tensor<2x512xi8, #blocked4>
-      %B_ll = ttg.local_load %B_la : !ttg.memdesc<2x512xi8, #shared1, #smem, mutable, 3x2x512> -> tensor<2x512xi8, #blocked4>
+      %A_la = ttg.local_alloc : () -> !ttg.memdesc<2x512xi8, #shared1, #smem, mutable>
+      %B_la = ttg.local_alloc : () -> !ttg.memdesc<2x512xi8, #shared1, #smem, mutable>
+      %A_ll = ttg.local_load %A_la : !ttg.memdesc<2x512xi8, #shared1, #smem, mutable> -> tensor<2x512xi8, #blocked4>
+      %B_ll = ttg.local_load %B_la : !ttg.memdesc<2x512xi8, #shared1, #smem, mutable> -> tensor<2x512xi8, #blocked4>
       %A_r = tt.reshape %A_ll : tensor<2x512xi8, #blocked4> -> tensor<2x1x32x4x4xi8, #blocked8>
       %B_r = tt.reshape %B_ll : tensor<2x512xi8, #blocked4> -> tensor<2x1x32x4x4xi8, #blocked8>
       %A_tr = tt.trans %A_r {order = array<i32: 0, 3, 2, 1, 4>} : tensor<2x1x32x4x4xi8, #blocked8> -> tensor<2x4x32x1x4xi8, #blocked9>

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -865,12 +865,12 @@ tt.func @tc_gen5_mma_scaled_tmem_scales(%lb : index, %ub : index, %step : index,
     %A_sc_sh = ttg.local_alloc %A_sc : (tensor<1x2x32x4x4xi8, #blocked2>) -> !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>
 
     %B_sc = tt.load %B_sc_ptr : tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2>
-    %B_sc_tm = ttng.tmem_alloc %B_sc : (tensor<1x2x32x4x4xi8, #blocked2>) -> !ttg.memdesc<1x2x328x4xi8, #tmem_scales, #ttng.tensor_memory>
+    %B_sc_tm = ttng.tmem_alloc %B_sc : (tensor<1x2x32x4x4xi8, #blocked2>) -> !ttg.memdesc<1x2x32x4x4xi8, #tmem_scales, #ttng.tensor_memory>
 
     // CHECK: ttng.tc_gen5_mma_scaled {{.*}}
     // CHECK-NOT: tt.latency
     ttng.tmem_store %acc_init, %acc_tm, %true : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %acc_tm, %A_sc_sh, %B_sc_tm, %true, %true lhs = e5m2 rhs = e5m2 : !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, !ttg.memdesc<1x2x328x4xi8, #tmem_scales, #ttng.tensor_memory>
+    ttng.tc_gen5_mma_scaled %A_sh, %B_sh, %acc_tm, %A_sc_sh, %B_sc_tm, %true, %true lhs = e5m2 rhs = e5m2 : !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x2x32x4x4xi8, #shared1, #smem>, !ttg.memdesc<1x2x32x4x4xi8, #tmem_scales, #ttng.tensor_memory>
     %acc_res = ttng.tmem_load %acc_tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
     "use"(%acc_res) : (tensor<128x128xf32, #blocked1>) -> ()
   }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -5,7 +5,7 @@
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @alloc_tensor_memory(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
-    // expected-error @+1 {{op should use tensor memory encoding.}}
+    // expected-error @+1 {{op should use tensor memory encoding}}
     %0 = ttng.tmem_alloc %cst : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #shared, #ttng.tensor_memory, mutable>
     tt.return
   }

--- a/test/TritonNvidiaGPU/test_tensor_memory_allocation.mlir
+++ b/test/TritonNvidiaGPU/test_tensor_memory_allocation.mlir
@@ -16,6 +16,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %cst1 = arith.constant dense<0.000000e+00> : tensor<64x64xf16, #blocked>
     %cst2 = arith.constant dense<0.000000e+00> : tensor<64x256xf16, #blocked>
     %cst3 = arith.constant dense<0> : tensor<64x4xi8, #linear>
+    %cst4 = arith.constant dense<0.000000e+00> : tensor<64x128xf16, #blocked>
 
     // CHECK: ttng.tmem_alloc %{{.+}} {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32}
     %0 = ttng.tmem_alloc %cst : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -32,9 +33,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     ttng.tmem_store %cst, %3, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
 
     // CHECK: ttng.tmem_alloc %{{.+}} {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32}
-    %4 = ttng.tmem_alloc %cst2 : (tensor<64x256xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #tmem2, #ttng.tensor_memory, mutable>
+    %4 = ttng.tmem_alloc %cst4 : (tensor<64x128xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #tmem2, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_alloc %{{.+}} {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 16 : i32}
-    %5 = ttng.tmem_alloc %cst2 : (tensor<64x256xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #tmem2, #ttng.tensor_memory, mutable>
+    %5 = ttng.tmem_alloc %cst4 : (tensor<64x128xf16, #blocked>) -> !ttg.memdesc<64x128xf16, #tmem2, #ttng.tensor_memory, mutable>
     // CHECK: ttng.tmem_alloc %{{.+}} {tensor_memory_col_offset = 128 : i32, tensor_memory_row_offset = 0 : i32}
     %6 = ttng.tmem_alloc %cst : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
 


### PR DESCRIPTION
For both tmem and shared allocs, check that the element types match, the shapes match, and the alloc shape is the same as the initial memdesc shape.
