### PR TITLE
[BENCH] fix swiglu routing and simplify args

### DIFF
--- a/bench/tests/test_swiglu.py
+++ b/bench/tests/test_swiglu.py
@@ -37,6 +37,6 @@ def test_op(M, N, limit, device, alpha=0.5):
     # initialize data
     x = alloc_rand([n_tokens, N], device=device, dtype=torch.bfloat16)
     precision_config = PrecisionConfig(limit=limit)
-    tri_y = swiglu(x, alpha, precision_config, routing_data, n_expts_tot)
+    tri_y = swiglu(x, alpha, precision_config, routing_data)
     ref_y = swiglu_torch(x, alpha, precision_config)
     assert_close(tri_y, ref_y)

--- a/bench/triton_bench/swiglu_details/_swiglu.py
+++ b/bench/triton_bench/swiglu_details/_swiglu.py
@@ -36,10 +36,10 @@ def swiglu_launch_metadata(grid, kernel, args):
 
 @triton.jit(repr=swiglu_repr, launch_metadata=swiglu_launch_metadata)
 def _swiglu(Out, OutExpectedScale, OutActualScale, OutChecksumScale, A, AScale, alpha, M, N, stride_am, stride_an,
-            stride_outm, stride_outn, limit: tl.constexpr, ExptData, NUM_EXPERTS: tl.constexpr, BLOCK_M: tl.constexpr,
-            BLOCK_N: tl.constexpr, EVEN_N: tl.constexpr, M_BLOCKS, N_BLOCKS, flexpoint_saturate_inf: tl.constexpr):
-    if ExptData is not None:
-        M = tl.load(ExptData + 2 * NUM_EXPERTS)
+            stride_outm, stride_outn, limit: tl.constexpr, NTokens, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+            EVEN_N: tl.constexpr, M_BLOCKS, N_BLOCKS, flexpoint_saturate_inf: tl.constexpr):
+    if NTokens is not None:
+        M = tl.load(NTokens)
         M_BLOCKS = (M + BLOCK_M - 1) // BLOCK_M
 
     local_max = tl.full([tl.extra.cuda.num_threads()], 0.0, tl.float32)


### PR DESCRIPTION
bench_mlp.py was wrong since it did not pass num_experts to the swiglu. This arg defaulted to zero, causing the kernel to load the wrong slot in the expert data.

Fix this, and remove the num_experts arg so this is more foolproof. We can get the number of experts from the routing data.
