### PR TITLE
[FRONTEND] Allow .to(...) on tl.constexpr

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -264,6 +264,13 @@ class constexpr:
     def __call__(self, *args, **kwds):
         return self.value(*args, **kwds)
 
+    @builtin
+    def to(self, dtype: dtype, fp_downcast_rounding: Optional[str] = None, bitcast: bool = False, _builder=None):
+        """
+        Alias for :py:func:`cast`.
+        """
+        return cast(self, dtype, fp_downcast_rounding, bitcast, _builder=_builder)
+
 
 def constexpr_function(f):
     """


### PR DESCRIPTION
`.to(...)` works for `tl.tensor` and scalars but not for `tl.constexpr`. So if we have a kernel like
```python
@triton.jit
def foo(ptr, stride_k, BLOCK: tl.constexpr):
     out_ptr = ptr + stride_k.to(tl.int64) * BLOCK
```
it will compile if `stride_k != 1` but fails to compile if it is `1` because it will create a new specialization where `stride_k` is `tl.constexpr`.
