### PR TITLE
[FRONTEND] Better handling of boolean operators and scalars

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7457,18 +7457,19 @@ def test_short_circuiting(device):
 
     @triton.jit
     def short_circuiting_kernel(x):
-        if (x is not None) and hasattr(x, "dtype") and isinstance(x.dtype, tl.pointer_type) and (x.dtype.element_ty == tl.int32) and (tl.load(x) > 42):
+        if (x is not None) and hasattr(x, "dtype") and isinstance(
+                x.dtype, tl.pointer_type) and (x.dtype.element_ty == tl.int32) and (tl.load(x) > 42):
             tl.store(x, 42)
 
     def f(x):
-        short_circuiting_kernel[(1,)](x, num_warps=1)
+        short_circuiting_kernel[(1, )](x, num_warps=1)
 
-    f(None) # should succeed with NoneType
-    f(1) # should succeed with tl.constexpr type
-    f(2) # should succeed with integer type
+    f(None)  # should succeed with NoneType
+    f(1)  # should succeed with tl.constexpr type
+    f(2)  # should succeed with integer type
 
     def g(y, dtype):
-        x = torch.full((1,), y, device=device, dtype=dtype)
+        x = torch.full((1, ), y, device=device, dtype=dtype)
         f(x)
         return x.item()
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7540,3 +7540,25 @@ def test_unsplat(device):
     assert g(43, False) == 42
     assert g(41, True) == 41
     assert g(43, True) == 42
+
+
+@pytest.mark.interpreter
+def test_tuple_logic():
+
+    @triton.jit
+    def tuple_logic_kernel():
+
+        # arity-2 BoolOps:
+        tl.static_assert(((3, 4) or (5, 6)) == (3, 4))
+        tl.static_assert(((3, 4) and (5, 6)) == (5, 6))
+        tl.static_assert(((3, 4) and ()) == ())
+        tl.static_assert((() or (5, 6)) == (5, 6))
+
+        # arity-3 BoolOps:
+        tl.static_assert(((1, 2) and (3, 4) and (5, 6)) == (5, 6))
+        tl.static_assert(((1, 2) or (3, 4) or (5, 6)) == (1, 2))
+
+        # constexpr short-circuiting over dynamic argument:
+        tl.static_assert((() and tl.program_id(0)) == ())
+
+    tuple_logic_kernel[(1, )]()

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7484,7 +7484,7 @@ def test_short_circuiting(device):
 def test_unsplat(device):
 
     @triton.jit
-    def unsplat_kernel(x, explicit : tl.constexpr):
+    def unsplat_kernel(x, explicit: tl.constexpr):
 
         # this is a single-element tensor:
         condition = tl.load(x + tl.arange(0, 1)) > 42

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -324,7 +324,7 @@ class CodeGenerator(ast.NodeVisitor):
         # special handling.
         self.visiting_arg_default_value = False
 
-    builtin_namespace: Dict[str, Any] = {_.__name__: _ for _ in (len, list, range, float, int, isinstance, getattr)}
+    builtin_namespace: Dict[str, Any] = {_.__name__: _ for _ in (len, list, range, float, int, isinstance, getattr, hasattr)}
     builtin_namespace.update((
         ('print', language.core.device_print),
         ('min', language.minimum),
@@ -876,6 +876,8 @@ class CodeGenerator(ast.NodeVisitor):
         try:
             return getattr(operand, fn)()
         except AttributeError:
+            if fn == "__not__":
+                return constexpr(not operand)
             raise self._unsupported(
                 node, f"AST unary operator '{fn}' is not (currently) implemented on type {type(operand).__name__}")
 

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -772,7 +772,9 @@ class CodeGenerator(ast.NodeVisitor):
             if _is_non_scalar_tensor(cond):
                 raise self._unsupported(node, "Boolean value of Tensor with more than one value is ambiguous")
             if cond.type.is_block():
-                warnings.warn("If conditional called with multidimensional Tensor instead of scalar; please use \"if (%s).reshape([])\" instead" % ast.unparse(node.test))
+                warnings.warn(
+                    "If conditional called with multidimensional Tensor instead of scalar; please use \"if (%s).reshape([])\" instead"
+                    % ast.unparse(node.test))
                 cond = language.core._unsplat(cond, _builder=self.builder, _generator=self)
             cond = cond.to(language.int1, _builder=self.builder)
             contains_return = ContainsReturnChecker(self.gscope).visit(node)
@@ -1291,7 +1293,9 @@ class CodeGenerator(ast.NodeVisitor):
                 # expression so we do not append it to nontrivial_values.
             else:
                 if value.type.is_block():
-                    warnings.warn("Logical operators 'and' and 'or' are deprecated for non-scalar tensors; please use '&' or '|' instead")
+                    warnings.warn(
+                        "Logical operators 'and' and 'or' are deprecated for non-scalar tensors; please use '&' or '|' instead"
+                    )
                 # not a constexpr so we must append it:
                 nontrivial_values.append(value)
 

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -324,7 +324,10 @@ class CodeGenerator(ast.NodeVisitor):
         # special handling.
         self.visiting_arg_default_value = False
 
-    builtin_namespace: Dict[str, Any] = {_.__name__: _ for _ in (len, list, range, float, int, isinstance, getattr, hasattr)}
+    builtin_namespace: Dict[str, Any] = {
+        _.__name__: _
+        for _ in (len, list, range, float, int, isinstance, getattr, hasattr)
+    }
     builtin_namespace.update((
         ('print', language.core.device_print),
         ('min', language.minimum),


### PR DESCRIPTION
This commit contains the following frontend enhancements:

1. `tl.reshape(x, [])` works for single-element tensors and returns a scalar. Previously, it was very difficult to produce scalars, and `tl.reshape(x, [])` would throw an error.
2. `if`-statements correctly throw frontend errors if used on multiple-element tensors, and if a multidimensional single-element tensor is provided then we raise a warning (recommending `tl.reshape(x, [])`) and unsplat it to a scalar. Before, the backend would crash in both cases with an inscrutable MLIR error.
3. chained boolean operations such as `(P or Q or R)` are supported, whereas before they would throw frontend errors.
4. in boolean operations, operands with constexpr truth values are handled specially:
   - if we are in a conjunction and encounter a constexpr falsey operand, we short-circuit and return it;
   - if we are in a disjunction and encounter a constexpr truthy operand, we short-circuit and return it;
   - other constexpr operands are ignored completely (they do not participate in the result);

The last of these enhancements allows one to write things such as:

```
    if (x is not None) and (x.dtype == tl.int32):
        ...
```

which would previously have failed as Triton would have tried to compute both operands (the latter yielding an error) before taking their conjunction.