### PR TITLE
[PROTON-DEV] Chrome Trace Writer

### DIFF
--- a/third_party/proton/common/include/TraceDataIO/ByteSpan.h
+++ b/third_party/proton/common/include/TraceDataIO/ByteSpan.h
@@ -1,5 +1,5 @@
-#ifndef PROTON_DATA_BYTE_SPAN_H_
-#define PROTON_DATA_BYTE_SPAN_H_
+#ifndef PROTON_COMMON_BYTE_SPAN_H_
+#define PROTON_COMMON_BYTE_SPAN_H_
 
 #include <cstdint>
 #include <stdexcept>
@@ -48,4 +48,4 @@ private:
 
 } // namespace proton
 
-#endif // PROTON_DATA_BYTE_SPAN_H_
+#endif // PROTON_COMMON_BYTE_SPAN_H_

--- a/third_party/proton/common/include/TraceDataIO/CircularLayoutParser.h
+++ b/third_party/proton/common/include/TraceDataIO/CircularLayoutParser.h
@@ -1,5 +1,5 @@
-#ifndef PROTON_DATA_CIRCULAR_LAYOUT_PARSER_H_
-#define PROTON_DATA_CIRCULAR_LAYOUT_PARSER_H_
+#ifndef PROTON_COMMON_CIRCULAR_LAYOUT_PARSER_H_
+#define PROTON_COMMON_CIRCULAR_LAYOUT_PARSER_H_
 
 #include "Device.h"
 #include "Parser.h"
@@ -93,4 +93,4 @@ void timeShift(const CircularLayoutParserConfig &config,
 
 } // namespace proton
 
-#endif // PROTON_DATA_CIRCULAR_LAYOUT_PARSER_H_
+#endif // PROTON_COMMON_CIRCULAR_LAYOUT_PARSER_H_

--- a/third_party/proton/common/include/TraceDataIO/EntryDecoder.h
+++ b/third_party/proton/common/include/TraceDataIO/EntryDecoder.h
@@ -1,5 +1,5 @@
-#ifndef PROTON_DATA_ENTRY_DECODER_H_
-#define PROTON_DATA_ENTRY_DECODER_H_
+#ifndef PROTON_COMMON_ENTRY_DECODER_H_
+#define PROTON_COMMON_ENTRY_DECODER_H_
 
 #include "ByteSpan.h"
 #include <cstdint>
@@ -64,4 +64,4 @@ template <> void decodeFn<CycleEntry>(ByteSpan &buffer, CycleEntry &entry);
 
 } // namespace proton
 
-#endif // PROTON_DATA_ENTRY_DECODER_H_
+#endif // PROTON_COMMON_ENTRY_DECODER_H_

--- a/third_party/proton/common/include/TraceDataIO/Parser.h
+++ b/third_party/proton/common/include/TraceDataIO/Parser.h
@@ -1,5 +1,5 @@
-#ifndef PROTON_DATA_PARSER_H_
-#define PROTON_DATA_PARSER_H_
+#ifndef PROTON_COMMON_PARSER_H_
+#define PROTON_COMMON_PARSER_H_
 
 #include "ByteSpan.h"
 #include "EntryDecoder.h"
@@ -49,4 +49,4 @@ protected:
 
 } // namespace proton
 
-#endif // PROTON_DATA_PARSER_H_
+#endif // PROTON_COMMON_PARSER_H_

--- a/third_party/proton/common/include/TraceDataIO/TraceWriter.h
+++ b/third_party/proton/common/include/TraceDataIO/TraceWriter.h
@@ -1,0 +1,64 @@
+#ifndef PROTON_COMMON_TRACE_WRITER_H_
+#define PROTON_COMMON_TRACE_WRITER_H_
+
+#include "CircularLayoutParser.h"
+#include <cstdint>
+#include <fstream>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace proton {
+
+const uint32_t kKernelTimeGap = 10000000;
+
+struct KernelMetadata {
+  std::map<int, std::string> scopeName;
+  std::string kernelName;
+};
+
+using KernelTrace = std::pair<CircularLayoutParserResult *, KernelMetadata *>;
+
+class StreamTraceWriter {
+public:
+  explicit StreamTraceWriter(const std::vector<KernelTrace> &streamTrace,
+                             const std::string &path);
+
+  virtual ~StreamTraceWriter() = default;
+
+  void dump();
+
+protected:
+  virtual void write(std::ofstream &outfile) = 0;
+
+  const std::string path;
+  const std::vector<KernelTrace> &streamTrace;
+};
+
+class StreamChromeTraceWriter : public StreamTraceWriter {
+public:
+  explicit StreamChromeTraceWriter(const std::vector<KernelTrace> &streamTrace,
+                                   const std::string &path);
+
+private:
+  void write(std::ofstream &outfile) override final;
+  void writeKernel(std::stringstream &outstream, const KernelTrace &kernelTrace,
+                   uint32_t kernelTimeStart);
+
+  const std::vector<std::string> kChromeColor = {"cq_build_passed",
+                                                 "cq_build_failed",
+                                                 "thread_state_iowait",
+                                                 "thread_state_running",
+                                                 "thread_state_runnable",
+                                                 "thread_state_unknown",
+                                                 "rail_response",
+                                                 "rail_idle",
+                                                 "rail_load",
+                                                 "cq_build_attempt_passed",
+                                                 "cq_build_attempt_failed"};
+};
+
+} // namespace proton
+
+#endif // PROTON_COMMON_TRACE_WRITER_H_

--- a/third_party/proton/common/include/TraceDataIO/TraceWriter.h
+++ b/third_party/proton/common/include/TraceDataIO/TraceWriter.h
@@ -11,6 +11,8 @@
 
 namespace proton {
 
+// TODO(fywkevin): this time gap to offset multiple kernels is not needed after
+// we have the global time.
 const uint32_t kKernelTimeGap = 10000000;
 
 struct KernelMetadata {
@@ -20,6 +22,11 @@ struct KernelMetadata {
 
 using KernelTrace = std::pair<CircularLayoutParserResult *, KernelMetadata *>;
 
+// StreamTraceWriter handles trace dumping for a single cuda stream.
+// If we have multiple stream, simply having a for loop to write to multiple
+// files (one for each stream). Other types of per-stream trace writers could
+// subclass the StreamTraceWriter such as StreamPerfettoTraceWriter that
+// produces a protobuf format trace.
 class StreamTraceWriter {
 public:
   explicit StreamTraceWriter(const std::vector<KernelTrace> &streamTrace,

--- a/third_party/proton/common/lib/TraceDataIO/CMakeLists.txt
+++ b/third_party/proton/common/lib/TraceDataIO/CMakeLists.txt
@@ -3,4 +3,5 @@ add_proton_library(ProtonTraceDataIO
 	EntryDecoder.cpp
 	Parser.cpp
 	CircularLayoutParser.cpp
+	TraceWriter.cpp
 )

--- a/third_party/proton/common/lib/TraceDataIO/TraceWriter.cpp
+++ b/third_party/proton/common/lib/TraceDataIO/TraceWriter.cpp
@@ -1,0 +1,214 @@
+#include "TraceDataIO/TraceWriter.h"
+#include <algorithm>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+
+using namespace proton;
+
+StreamTraceWriter::StreamTraceWriter(
+    const std::vector<KernelTrace> &streamTrace, const std::string &path)
+    : streamTrace(streamTrace), path(path) {}
+
+void StreamTraceWriter::dump() {
+  std::ofstream outfile;
+  outfile.open(path);
+  if (!outfile.is_open()) {
+    std::cerr << "Failed to open trace file: " << path << std::endl;
+    return;
+  }
+
+  write(outfile);
+
+  outfile.close();
+}
+
+StreamChromeTraceWriter::StreamChromeTraceWriter(
+    const std::vector<KernelTrace> &streamTrace, const std::string &path)
+    : StreamTraceWriter(streamTrace, path) {}
+
+void StreamChromeTraceWriter::write(std::ofstream &outfile) {
+  outfile << "{\n\"traceEvents\": [\n";
+
+  std::stringstream ss;
+  int totalKernelNum = streamTrace.size();
+  for (int i = 0; i < totalKernelNum; i++) {
+    writeKernel(ss, streamTrace[i], kKernelTimeGap * i);
+  }
+  std::string fullTraceStr = ss.str();
+  // Remove the last comma
+  fullTraceStr.pop_back();
+  fullTraceStr.pop_back();
+
+  outfile << fullTraceStr;
+  outfile << "],\n";
+  outfile << "\"displayTimeUnit\": \"ns\"\n";
+  outfile << "}\n";
+}
+
+namespace {
+using BlockTraceVec =
+    std::vector<const CircularLayoutParserResult::BlockTrace *>;
+
+void populateTraceInfo(const CircularLayoutParserResult &result,
+                       uint32_t kernelTimeStart,
+                       std::map<int, int64_t> &cycleAdjust,
+                       std::map<int, BlockTraceVec> &procToBlockTraces) {
+  uint32_t minStartTime;
+  for (auto &bt : result.blockTraces) {
+    minStartTime = std::numeric_limits<uint32_t>::max();
+    for (auto &trace : bt.traces)
+      for (auto &event : trace.profileEvents)
+        if (event.first->cycle < minStartTime)
+          minStartTime = event.first->cycle;
+
+    cycleAdjust[bt.blockId] = static_cast<int64_t>(kernelTimeStart) -
+                              static_cast<int64_t>(minStartTime);
+    int procId = bt.procId;
+    if (!procToBlockTraces.count(procId)) {
+      procToBlockTraces[procId] = {};
+    }
+    procToBlockTraces[procId].push_back(&bt);
+  }
+}
+
+std::vector<int> assignLineIds(
+    const std::vector<CircularLayoutParserResult::ProfileEvent> &trace) {
+
+  std::vector<int> result(trace.size());
+
+  if (trace.empty()) {
+    return result;
+  }
+
+  // Create indexed events and sort by start time
+  std::vector<std::pair<size_t, CircularLayoutParserResult::ProfileEvent>>
+      indexedEvents;
+  indexedEvents.reserve(trace.size());
+
+  for (size_t i = 0; i < trace.size(); ++i) {
+    indexedEvents.push_back({i, trace[i]});
+  }
+
+  std::sort(indexedEvents.begin(), indexedEvents.end(),
+            [](const auto &a, const auto &b) {
+              return a.second.first->cycle < b.second.first->cycle;
+            });
+
+  // For each line, store all the intervals
+  std::vector<std::vector<std::pair<uint32_t, uint32_t>>> lines;
+
+  for (const auto &[originalIdx, event] : indexedEvents) {
+    uint32_t startTime = event.first->cycle;
+    uint32_t endTime = event.second->cycle;
+
+    // Find the first line where this event can be placed
+    int lineIdx = 0;
+    bool foundLine = false;
+
+    for (; lineIdx < lines.size(); ++lineIdx) {
+      const auto &lineIntervals = lines[lineIdx];
+      bool canPlace = true;
+
+      // Check for overlap with any interval on this line
+      for (const auto &[intervalStart, intervalEnd] : lineIntervals) {
+        // Check if there's any overlap
+        if (startTime < intervalEnd && endTime > intervalStart) {
+          canPlace = false;
+          break;
+        }
+      }
+
+      if (canPlace) {
+        foundLine = true;
+        break;
+      }
+    }
+
+    // If no suitable line found, create a new one
+    if (!foundLine) {
+      lineIdx = lines.size();
+      lines.push_back({});
+    }
+
+    // Add the event to the line
+    lines[lineIdx].push_back({startTime, endTime});
+    result[originalIdx] = lineIdx;
+  }
+
+  return result;
+}
+
+} // namespace
+
+void StreamChromeTraceWriter::writeKernel(std::stringstream &outstream,
+                                          const KernelTrace &kernelTrace,
+                                          uint32_t kernelTimeStart) {
+  auto &result = *kernelTrace.first;
+  auto &metadata = *kernelTrace.second;
+
+  int curColorIndex = 0;
+  // scope id -> color index in chrome color
+  std::map<int, int> scopeColor;
+  // block id -> cycle adjust
+  std::map<int, int64_t> cycleAdjust;
+  // proc id -> block traces
+  std::map<int, BlockTraceVec> procToBlockTraces;
+
+  populateTraceInfo(result, kernelTimeStart, cycleAdjust, procToBlockTraces);
+
+  std::string name;
+  std::string pid;
+  std::string category;
+  std::string tid;
+  for (auto &[procId, blockVec] : procToBlockTraces) {
+    for (auto *bt : blockVec) {
+      int ctaId = bt->blockId;
+      for (auto &trace : bt->traces) {
+        int warpId = trace.uid;
+        auto lineInfo = assignLineIds(trace.profileEvents);
+        int eventIdx = 0;
+        for (auto &event : trace.profileEvents) {
+          int lineId = lineInfo[eventIdx];
+          int scopeId = event.first->scopeId;
+          if (!scopeColor.count(scopeId)) {
+            scopeColor[scopeId] = curColorIndex;
+            curColorIndex = (curColorIndex + 1) % kChromeColor.size();
+          }
+          const std::string &color = kChromeColor[scopeColor[scopeId]];
+          pid = metadata.kernelName + " Core" + std::to_string(procId) +
+                " CTA" + std::to_string(ctaId) +
+                " [measure in clock cycle (assume 1GHz)]";
+          tid = "warp " + std::to_string(warpId) + " (line " +
+                std::to_string(lineId) + ")";
+          category = metadata.kernelName;
+          if (!metadata.scopeName.count(scopeId))
+            name = "scope_" + std::to_string(scopeId);
+          else
+            name = metadata.scopeName.at(scopeId);
+
+          uint32_t ts = static_cast<uint32_t>(
+              static_cast<int64_t>(event.first->cycle) + cycleAdjust[ctaId]);
+          uint32_t dur = event.second->cycle - event.first->cycle;
+
+          outstream << "{";
+          outstream << "\"cname\": \"" << color << "\",";
+          outstream << "\"name\": \"" << name << "\",";
+          outstream << "\"cat\": \"" << category << "\",";
+          outstream << "\"ph\": \"X\",";
+          outstream << "\"pid\": \"" << pid << "\",";
+          outstream << "\"tid\": \"" << tid << "\",";
+          outstream << "\"ts\": \"" << static_cast<float>(ts) / 1000.0 << "\",";
+          outstream << "\"dur\": \"" << static_cast<float>(dur) / 1000.0
+                    << "\",";
+          outstream << "\"args\": {\"Unit\": \"GPU cycle\", \"Kernel Gap\": \""
+                    << kKernelTimeGap << "cycle(ns)\"}";
+          outstream << "},\n";
+
+          eventIdx++;
+        }
+      }
+    }
+  }
+}

--- a/third_party/proton/common/lib/TraceDataIO/TraceWriter.cpp
+++ b/third_party/proton/common/lib/TraceDataIO/TraceWriter.cpp
@@ -29,6 +29,11 @@ StreamChromeTraceWriter::StreamChromeTraceWriter(
     : StreamTraceWriter(streamTrace, path) {}
 
 void StreamChromeTraceWriter::write(std::ofstream &outfile) {
+  if (streamTrace.empty()) {
+    std::cerr << "Failed to write the trace file: empty trace!" << std::endl;
+    return;
+  }
+
   outfile << "{\n\"traceEvents\": [\n";
 
   std::stringstream ss;

--- a/third_party/proton/test/unittest/TraceDataIO/CMakeLists.txt
+++ b/third_party/proton/test/unittest/TraceDataIO/CMakeLists.txt
@@ -3,7 +3,7 @@ add_compile_definitions(PROTON_TEST_UTIL_PATH="${PROTON_TEST_UTIL_PATH}")
 
 add_triton_ut(
 	NAME TraceDataIO
-	SRCS ByteSpanTest.cpp DecoderTest.cpp CircularLayoutParserTest.cpp
+	SRCS ByteSpanTest.cpp DecoderTest.cpp CircularLayoutParserTest.cpp ChromeTraceWriterTest.cpp
 	LIBS ProtonTraceDataIO
 )
 

--- a/third_party/proton/test/unittest/TraceDataIO/ChromeTraceWriterTest.cpp
+++ b/third_party/proton/test/unittest/TraceDataIO/ChromeTraceWriterTest.cpp
@@ -1,0 +1,212 @@
+#include "TraceDataIO/EntryDecoder.h"
+#include "TraceDataIO/TraceWriter.h"
+#include "nlohmann/json.hpp"
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <vector>
+
+using json = nlohmann::json;
+using namespace proton;
+
+class ChromeTraceWriterTest : public ::testing::Test {
+public:
+  void SetUp() override {}
+
+  void TearDown() override {
+    try {
+      std::filesystem::remove_all(chromeTracePath);
+    } catch (const std::filesystem::filesystem_error &e) {
+      std::cerr << "Error cleaning up test trace files: " << e.what()
+                << std::endl;
+    }
+  }
+
+  void printJsonTrace(json data) { std::cout << data.dump(4) << std::endl; }
+
+  json readJsonTrace(const std::string &path) {
+    std::ifstream file(path);
+
+    if (!file.is_open()) {
+      std::cerr << "Failed to open chrome trace file!" << std::endl;
+      return json();
+    }
+
+    json data;
+    try {
+      data = json::parse(file);
+    } catch (json::parse_error &e) {
+      std::cerr << "Error parsing JSON: " << e.what() << std::endl;
+      data = json();
+    }
+    file.close();
+    return data;
+  }
+
+  CircularLayoutParserResult createDefaultResult(int numBlocks, int numTraces,
+                                                 int numEvents) {
+    CircularLayoutParserResult result;
+    result.blockTraces.resize(numBlocks);
+    for (int i = 0; i < numBlocks; i++) {
+      result.blockTraces[i].traces.resize(numTraces);
+      for (int j = 0; j < numTraces; j++) {
+        result.blockTraces[i].traces[j].profileEvents.resize(numEvents);
+        for (int k = 0; k < numEvents; k++) {
+          result.blockTraces[i].traces[j].profileEvents[k].first =
+              std::make_shared<CycleEntry>();
+          result.blockTraces[i].traces[j].profileEvents[k].second =
+              std::make_shared<CycleEntry>();
+        }
+      }
+    }
+    return result;
+  }
+
+protected:
+  std::string chromeTracePath = "chrome_trace.json";
+};
+
+TEST_F(ChromeTraceWriterTest, SingleBlock) {
+  KernelMetadata metadata;
+  metadata.kernelName = "kernel1";
+  metadata.scopeName = {{1, "s1"}, {2, "s2"}};
+
+  auto result = createDefaultResult(1, 1, metadata.scopeName.size());
+  result.blockTraces[0].blockId = 1;
+  result.blockTraces[0].procId = 120;
+  result.blockTraces[0].traces[0].uid = 2;
+  result.blockTraces[0].traces[0].profileEvents[0].first->cycle = 122;
+  result.blockTraces[0].traces[0].profileEvents[0].second->cycle = 162;
+  result.blockTraces[0].traces[0].profileEvents[0].first->scopeId = 1;
+  result.blockTraces[0].traces[0].profileEvents[0].second->scopeId = 1;
+  result.blockTraces[0].traces[0].profileEvents[1].first->cycle = 222;
+  result.blockTraces[0].traces[0].profileEvents[1].second->cycle = 262;
+  result.blockTraces[0].traces[0].profileEvents[1].first->scopeId = 7;
+  result.blockTraces[0].traces[0].profileEvents[1].second->scopeId = 7;
+  std::vector<KernelTrace> kerneltrace = {std::make_pair(&result, &metadata)};
+  auto writer = StreamChromeTraceWriter(kerneltrace, chromeTracePath);
+  writer.dump();
+
+  auto data = readJsonTrace(chromeTracePath);
+  EXPECT_EQ(data.empty(), false);
+  EXPECT_EQ(data["displayTimeUnit"], "ns");
+  EXPECT_EQ(data["traceEvents"].size(), 2);
+  EXPECT_EQ(data["traceEvents"][0]["name"], "s1");
+  EXPECT_EQ(data["traceEvents"][1]["name"], "scope_7");
+  EXPECT_EQ(data["traceEvents"][0]["ts"], "0");
+  EXPECT_EQ(data["traceEvents"][1]["ts"], "0.1");
+}
+
+TEST_F(ChromeTraceWriterTest, MultiBlockMultiWarp) {
+  KernelMetadata metadata;
+  metadata.kernelName = "kernel2";
+  metadata.scopeName = {{1, "s1"}, {2, "s2"}, {3, "s3"}, {4, "s4"}};
+
+  auto result = createDefaultResult(2, 3, metadata.scopeName.size());
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 2; j++) {
+      result.blockTraces[j].blockId = 1 + j;
+      result.blockTraces[j].procId = 120 + j;
+      result.blockTraces[j].traces[i].uid = i;
+      result.blockTraces[j].traces[i].profileEvents[0].first->cycle = 122;
+      result.blockTraces[j].traces[i].profileEvents[0].second->cycle = 162;
+      result.blockTraces[j].traces[i].profileEvents[0].first->scopeId = 1;
+      result.blockTraces[j].traces[i].profileEvents[0].second->scopeId = 1;
+      result.blockTraces[j].traces[i].profileEvents[1].first->cycle = 142;
+      result.blockTraces[j].traces[i].profileEvents[1].second->cycle = 182;
+      result.blockTraces[j].traces[i].profileEvents[1].first->scopeId = 2;
+      result.blockTraces[j].traces[i].profileEvents[1].second->scopeId = 2;
+      result.blockTraces[j].traces[i].profileEvents[2].first->cycle = 172;
+      result.blockTraces[j].traces[i].profileEvents[2].second->cycle = 200;
+      result.blockTraces[j].traces[i].profileEvents[2].first->scopeId = 3;
+      result.blockTraces[j].traces[i].profileEvents[2].second->scopeId = 3;
+      result.blockTraces[j].traces[i].profileEvents[3].first->cycle = 183;
+      result.blockTraces[j].traces[i].profileEvents[3].second->cycle = 210;
+      result.blockTraces[j].traces[i].profileEvents[3].first->scopeId = 4;
+      result.blockTraces[j].traces[i].profileEvents[3].second->scopeId = 4;
+    }
+  }
+  std::vector<KernelTrace> kerneltrace = {std::make_pair(&result, &metadata)};
+  auto writer = StreamChromeTraceWriter(kerneltrace, chromeTracePath);
+  writer.dump();
+
+  auto data = readJsonTrace(chromeTracePath);
+
+  EXPECT_EQ(data.empty(), false);
+  EXPECT_EQ(data["traceEvents"].size(), 24);
+  std::map<std::string, int> pidCount;
+  std::map<std::string, int> tidCount;
+  for (int i = 0; i < 24; i++) {
+    pidCount[data["traceEvents"][i]["pid"]] += 1;
+    tidCount[data["traceEvents"][i]["tid"]] += 1;
+  }
+  EXPECT_EQ(
+      pidCount["kernel2 Core121 CTA2 [measure in clock cycle (assume 1GHz)]"],
+      12);
+  EXPECT_EQ(
+      pidCount["kernel2 Core120 CTA1 [measure in clock cycle (assume 1GHz)]"],
+      12);
+  EXPECT_EQ(tidCount["warp 0 (line 0)"], 4);
+  EXPECT_EQ(tidCount["warp 0 (line 1)"], 4);
+  EXPECT_EQ(tidCount["warp 1 (line 0)"], 4);
+  EXPECT_EQ(tidCount["warp 1 (line 1)"], 4);
+  EXPECT_EQ(tidCount["warp 2 (line 0)"], 4);
+  EXPECT_EQ(tidCount["warp 2 (line 1)"], 4);
+}
+
+TEST_F(ChromeTraceWriterTest, MultiKernel) {
+  KernelMetadata metadata1;
+  metadata1.kernelName = "kernel1";
+  metadata1.scopeName = {{1, "s1"}};
+  auto result1 = createDefaultResult(1, 2, metadata1.scopeName.size());
+
+  for (int i = 0; i < 2; i++) {
+    for (int j = 0; j < 1; j++) {
+      result1.blockTraces[j].blockId = j;
+      result1.blockTraces[j].procId = j;
+      result1.blockTraces[j].traces[i].uid = i;
+      result1.blockTraces[j].traces[i].profileEvents[0].first->cycle = 1220000;
+      result1.blockTraces[j].traces[i].profileEvents[0].second->cycle = 1620000;
+      result1.blockTraces[j].traces[i].profileEvents[0].first->scopeId = 1;
+      result1.blockTraces[j].traces[i].profileEvents[0].second->scopeId = 1;
+    }
+  }
+
+  KernelMetadata metadata2;
+  metadata2.kernelName = "kernel2";
+  metadata2.scopeName = {{1, "s1"}};
+  auto result2 = createDefaultResult(2, 1, metadata2.scopeName.size());
+
+  for (int i = 0; i < 1; i++) {
+    for (int j = 0; j < 2; j++) {
+      result2.blockTraces[j].blockId = j;
+      result2.blockTraces[j].procId = j;
+      result2.blockTraces[j].traces[i].uid = i;
+      result2.blockTraces[j].traces[i].profileEvents[0].first->cycle =
+          2 * kKernelTimeGap + 1220000;
+      result2.blockTraces[j].traces[i].profileEvents[0].second->cycle =
+          2 * kKernelTimeGap + 1620000;
+      result2.blockTraces[j].traces[i].profileEvents[0].first->scopeId = 1;
+      result2.blockTraces[j].traces[i].profileEvents[0].second->scopeId = 1;
+    }
+  }
+  std::vector<KernelTrace> kerneltrace = {std::make_pair(&result1, &metadata1),
+                                          std::make_pair(&result2, &metadata2)};
+  auto writer = StreamChromeTraceWriter(kerneltrace, chromeTracePath);
+  writer.dump();
+
+  auto data = readJsonTrace(chromeTracePath);
+
+  EXPECT_EQ(data.empty(), false);
+  EXPECT_EQ(data["traceEvents"][0]["cat"], "kernel1");
+  EXPECT_EQ(data["traceEvents"][0]["ts"], "0");
+  EXPECT_EQ(data["traceEvents"][0]["dur"], "400");
+  EXPECT_EQ(data["traceEvents"][1]["cat"], "kernel1");
+  EXPECT_EQ(data["traceEvents"][2]["cat"], "kernel2");
+  EXPECT_EQ(data["traceEvents"][2]["ts"], "10000");
+  EXPECT_EQ(data["traceEvents"][2]["dur"], "400");
+}


### PR DESCRIPTION
This PR adds the trace writer utilities for the chrome tracing. Specifically, it supports dumping a json trace in chrome trace format for a single stream with multiple kernels. Each kernels has a constant gap `kKernelTimeGap`. Due to the limitation of chrome trace, each pid line is a CTA triplet (kernel name, Processor ID, CTA ID). Inside PID,  each TID is a portion of warp events recorded. Here we say portion because we apply a line splitting to avoid chrome tracing corrupts overlapping events. Any overlapping events in the same warp would be placed in a separate TID line. In this implementation, each CTA applies an independent start event offset. As a result, it is only safe to compare events within the same CTA.
