### PR TITLE
[typehint][knobs] Specify values in metadata_group as str

### DIFF
--- a/python/test/unit/runtime/test_compilation_listener.py
+++ b/python/test/unit/runtime/test_compilation_listener.py
@@ -20,7 +20,7 @@ def cumsum_kernel(ptr):
 def test_compile_stats(device: str, fresh_knobs_except_libraries: Any, fresh_triton_cache: str) -> None:
     captured: Union[tuple[Union[ASTSource, IRSource], dict[str, Any], dict[str, Any], CompileTimes, bool], None] = None
 
-    def compile_listener(src: Union[ASTSource, IRSource], metadata: dict[str, Any], metadata_group: dict[str, Any],
+    def compile_listener(src: Union[ASTSource, IRSource], metadata: dict[str, str], metadata_group: dict[str, Any],
                          times: CompileTimes, cache_hit: bool) -> None:
         nonlocal captured
         assert captured is None

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -253,7 +253,7 @@ class CompileTimes:
 
 class CompilationListener(Protocol):
 
-    def __call__(self, *, src: Union[ASTSource, IRSource], metadata: dict[str, Any], metadata_group: dict[str, Any],
+    def __call__(self, *, src: Union[ASTSource, IRSource], metadata: dict[str, Any], metadata_group: dict[str, str],
                  times: CompileTimes, cache_hit: bool) -> None:
         ...
 


### PR DESCRIPTION
I didn't catch this on https://github.com/triton-lang/triton/pull/6364 -- `Any` is fine, but we know the values are `str` from [`get_group`](https://github.com/triton-lang/triton/blob/b73d59597370a5ea7bd084d0f047516b029d9f4e/python/triton/runtime/cache.py#L26)