### PR TITLE
[TMA] Split large dimensions up into chunks of 256 elements

### DIFF
--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -83,6 +83,17 @@ LinearLayout ensureLayoutNotSmallerThan(
     const LinearLayout &layout,
     const llvm::SmallDenseMap<StringAttr, int64_t> &shape);
 
+inline LinearLayout
+ensureLayoutNotSmallerThan(const LinearLayout &layout,
+                           const llvm::ArrayRef<StringAttr> dimNames,
+                           const llvm::ArrayRef<int64_t> shape) {
+  llvm::SmallDenseMap<StringAttr, int64_t> namedDims;
+  for (auto [dimName, length] : llvm::zip_equal(dimNames, shape))
+    namedDims[dimName] = length;
+  assert(namedDims.size() == shape.size() && "duplicate dimension names given");
+  return ensureLayoutNotSmallerThan(layout, namedDims);
+}
+
 // Return a vector of the standard out dimension names for tensor layouts. These
 // are "dim0", "dim1", etc.
 SmallVector<StringAttr> standardOutDimNames(MLIRContext *ctx, int rank);

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -325,10 +325,12 @@ private:
       bases;
 
   llvm::MapVector<StringAttr, int32_t /*size*/> outDims;
-  bool surjective;
+  bool surjective = true;
 
 public:
   using BasesT = decltype(bases);
+
+  LinearLayout() = default;
 
   // The 0-dimensional layout that maps everything to 0.  This is useful as a
   // starting point when doing something like
@@ -336,12 +338,19 @@ public:
   //   LinearLayout ret = LinearLayout::empty();
   //   for (...) ret *= ...;
   //   return ret;
-  static LinearLayout empty() { return LinearLayout(BasesT{}, {}); }
+  static LinearLayout empty() { return {}; }
+
+  // Creates a 1D -> 1D layout that's the function L(x) = stride * x
+  // for x in [0, size).
+  static LinearLayout strided1D(int32_t size, int32_t stride, StringAttr inDim,
+                                StringAttr outDim);
 
   // Creates a 1D -> 1D layout that's the identity function, i.e. L(x) = x
   // for x in [0, size).
   static LinearLayout identity1D(int32_t size, StringAttr inDim,
-                                 StringAttr outDim);
+                                 StringAttr outDim) {
+    return strided1D(size, /*stride=*/1, inDim, outDim);
+  }
 
   // Creates a 1D -> 1D layout that maps every input value to 0, i.e. L(x) = 0
   // for x in [0, size). By default this creates a surjective layout where

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -6,6 +6,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/StrUtil.h"
@@ -241,7 +242,6 @@ LinearLayout getCoreMatrixLinearLayout(NVMMASharedEncodingAttr shared,
   int tileRows = 8;
   int tileCols = 8 * tileWidthBytes / elemBitWidth;
   bool isFp4Padded = shared.getFp4Padded();
-  int packingFactor = isFp4Padded ? 2 : 1;
 
   std::vector<std::vector<int>> bases2D;
   for (int col = 1; col < tileCols; col *= 2) {
@@ -269,11 +269,7 @@ LinearLayout getCoreMatrixLinearLayout(NVMMASharedEncodingAttr shared,
     }
   }
   auto outDimNames = standardOutDimNames(ctx, 2);
-  auto kRow = outDimNames[1];
-  auto kCol = outDimNames[0];
-  LinearLayout tileLayout =
-      LinearLayout({{S("offset"), bases2D}}, {kRow, kCol});
-  return tileLayout;
+  return LinearLayout({{S("offset"), bases2D}}, outDimNames);
 }
 
 } // namespace
@@ -285,63 +281,62 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
   int rank = shape.size();
   auto shapePerCTA = getShapePerCTA(shared, shape);
   auto kOffset = S("offset");
+  auto tmaShape = triton::nvidia_gpu::getTMABlockShape(shared, shapePerCTA,
+                                                       /*packedSize=*/true);
   if (shared.getSwizzlingByteWidth() == 0) {
     auto outDimNames = standardOutDimNames(ctx, rank);
-    LinearLayout layout = LinearLayout::identity1D(
-        shapePerCTA[rank - 1], kOffset, outDimNames[rank - 1]);
+    LinearLayout layout = LinearLayout::identity1D(tmaShape[rank - 1], kOffset,
+                                                   outDimNames[rank - 1]);
     for (int i = rank - 2; i >= 0; --i) {
-      layout *=
-          LinearLayout::identity1D(shapePerCTA[i], kOffset, outDimNames[i]);
+      layout *= LinearLayout::identity1D(tmaShape[i], kOffset, outDimNames[i]);
     }
+    layout = ensureLayoutNotSmallerThan(layout, outDimNames, shapePerCTA);
     return combineCtaCgaWithShape(layout, shared.getCTALayout(), shape);
   }
   assert(rank >= 2);
 
   // Collapse all the outer dim into one. We will then create a layout for this
   // shape and reshape it to the original shape.
-  std::array<int64_t, 2> collapsedShapePerCTA{1, shapePerCTA.back()};
+  std::array<int64_t, 2> collapsedTmaShape{1, tmaShape.back()};
   for (int i = 0; i + 1 < rank; i++)
-    collapsedShapePerCTA[0] *= shapePerCTA[i];
+    collapsedTmaShape[0] *= tmaShape[i];
   if (shared.getTransposed()) {
-    std::swap(collapsedShapePerCTA[0], collapsedShapePerCTA[1]);
+    std::swap(collapsedTmaShape[0], collapsedTmaShape[1]);
   }
 
   auto tileLayout = getCoreMatrixLinearLayout(shared, disableSwizzle);
   auto outDimNames = standardOutDimNames(ctx, 2);
-  auto kRow = outDimNames[1];
-  auto kCol = outDimNames[0];
+  auto kRow = outDimNames[0];
+  auto kCol = outDimNames[1];
   auto tileRows = tileLayout.getOutDimSize(kRow);
   auto tileCols = tileLayout.getOutDimSize(kCol);
 
   int packingFactor = shared.getFp4Padded() ? 2 : 1;
-  if (collapsedShapePerCTA[1] * packingFactor < tileCols ||
-      collapsedShapePerCTA[0] < tileRows) {
+  if (collapsedTmaShape[1] * packingFactor < tileCols ||
+      collapsedTmaShape[0] < tileRows) {
     llvm::errs() << "Illegal shared layout; expected collapsed shapePerCTA to "
                     "be at least ["
                  << tileRows << ", " << (tileCols / packingFactor)
-                 << "], collapsedShapePerCTA: [" << collapsedShapePerCTA[0]
-                 << ", " << collapsedShapePerCTA[1] << "]\n";
+                 << "], collapsedTmaShape: [" << collapsedTmaShape[0] << ", "
+                 << collapsedTmaShape[1] << "]\n";
     llvm::report_fatal_error("Illegal shared layout");
   }
 
   // Distribute the remaining rows and cols.
-  auto layout = tileLayout;
-  layout *= LinearLayout::identity1D(collapsedShapePerCTA[0] / tileRows,
-                                     kOffset, kRow);
-  layout *= LinearLayout::identity1D(collapsedShapePerCTA[1] / tileCols,
-                                     kOffset, kCol);
+  auto layout =
+      ensureLayoutNotSmallerThan(tileLayout, outDimNames, collapsedTmaShape);
 
   // Reshape the layout to the N-D pre-transposed shape per CTA.
-  SmallVector<int64_t> maybeTransposedShapePerCTA = shapePerCTA;
+  SmallVector<int64_t> maybeTransposedTmaShape = tmaShape;
   if (shared.getTransposed()) {
     // Move the outer dim to the inner position.
     // TODO: we should move back to using `order` instead of transposed to make
     // the order more explicit.
-    std::rotate(maybeTransposedShapePerCTA.begin(),
-                maybeTransposedShapePerCTA.begin() + 1,
-                maybeTransposedShapePerCTA.end());
+    std::rotate(maybeTransposedTmaShape.begin(),
+                maybeTransposedTmaShape.begin() + 1,
+                maybeTransposedTmaShape.end());
   }
-  auto reshapedLayout = reshapeLayout(ctx, layout, maybeTransposedShapePerCTA);
+  auto reshapedLayout = reshapeLayout(ctx, layout, maybeTransposedTmaShape);
 
   if (shared.getTransposed()) {
     SmallVector<int> order = {rank - 1};
@@ -351,6 +346,9 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
     reshapedLayout = transposeLinearLayout(reshapedLayout, order);
   }
 
+  reshapedLayout = ensureLayoutNotSmallerThan(
+      reshapedLayout, standardOutDimNames(ctx, shapePerCTA.size()),
+      shapePerCTA);
   return combineCtaCgaWithShape(reshapedLayout, shared.getCTALayout(), shape);
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -11,6 +11,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
 #include <memory>
 
@@ -149,17 +150,17 @@ static Attribute inferSrcEncodingMemDescReshape(Attribute dstEncoding,
                                                 ArrayRef<int64_t> dstShape) {
   auto mmaEncoding = dyn_cast<NVMMASharedEncodingAttr>(dstEncoding);
   if (!mmaEncoding)
-    return Attribute();
+    return {};
   // TODO: supporting reshape of CTA layouts is non-trivial.
   if (getNumCTAs(mmaEncoding) > 1)
-    return Attribute();
+    return {};
   int innerDimDst =
       mmaEncoding.getTransposed() ? dstShape.front() : dstShape.back();
   int innerDimSrc =
       mmaEncoding.getTransposed() ? srcShape.front() : srcShape.back();
   // For now disallow reshape of the inner dimension.
   if (innerDimDst != innerDimSrc)
-    return Attribute();
+    return {};
 
   // CTALayout can be all 1's because we bailed on multi-CTA layouts above.
   auto CTALayout = CTALayoutAttr::get(
@@ -167,11 +168,18 @@ static Attribute inferSrcEncodingMemDescReshape(Attribute dstEncoding,
       /*CTAsPerCGA=*/SmallVector<unsigned>(srcShape.size(), 1),
       /*CTASplitNum=*/SmallVector<unsigned>(srcShape.size(), 1),
       /*CTAOrder=*/llvm::to_vector(llvm::seq<unsigned>(srcShape.size())));
-  // Check that the second dim is big enough to contain a full swizzle.
-  return NVMMASharedEncodingAttr::get(
+  auto srcEncoding = NVMMASharedEncodingAttr::get(
       dstEncoding.getContext(), mmaEncoding.getSwizzlingByteWidth(),
       mmaEncoding.getTransposed(), mmaEncoding.getElementBitWidth(),
       mmaEncoding.getFp4Padded(), CTALayout);
+  // Big guns, check linear layouts are equivalent
+  auto srcLL = toLinearLayout(srcShape, srcEncoding);
+  auto dstLL = toLinearLayout(dstShape, dstEncoding);
+  auto ctx = dstEncoding.getContext();
+  if (reshapeLayout(ctx, srcLL, dstShape) != dstLL) {
+    return {};
+  }
+  return srcEncoding;
 }
 
 // Rewrite

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -323,12 +323,6 @@ private:
     if (!isInnermostContiguous(scaleType, 512))
       return false;
 
-    auto sharedEnc =
-        dyn_cast<triton::gpu::NVMMASharedEncodingAttr>(scaleType.getEncoding());
-    if (!sharedEnc || sharedEnc.getTransposed() || sharedEnc.getFp4Padded() ||
-        sharedEnc.getSwizzlingByteWidth() != 0)
-      return false;
-
     if (usesTMAload) {
       return true;
     }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
@@ -57,13 +57,6 @@ Attribute findLoadEncodingFromUsers(Operation *op) {
   return {};
 }
 
-ttg::CTALayoutAttr getCtaLayoutFromEncoding(Attribute encoding) {
-  auto layout = cast<ttg::LayoutEncodingTrait>(encoding);
-  auto ctx = encoding.getContext();
-  return ttg::CTALayoutAttr::get(ctx, layout.getCTAsPerCGA(),
-                                 layout.getCTASplitNum(), layout.getCTAOrder());
-}
-
 SmallVector<int64_t> expandToRank(ArrayRef<int64_t> shape, int rank) {
   SmallVector<int64_t> result(rank, 1);
   assert(shape.size() <= rank);

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/SetOperations.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
 
 #define DEBUG_TYPE "linear_layout"
@@ -295,18 +296,20 @@ LinearLayout::LinearLayout(
     ArrayRef<std::pair<StringAttr, int32_t>> outDims, bool requireSurjective)
     : LinearLayout(makeBasesMap(bases), outDims, requireSurjective) {}
 
-/*static*/ LinearLayout LinearLayout::identity1D(int32_t size,
-                                                 StringAttr inDimName,
-                                                 StringAttr outDimName) {
+/*static*/ LinearLayout LinearLayout::strided1D(int32_t size, int32_t stride,
+                                                StringAttr inDimName,
+                                                StringAttr outDimName) {
   if (size == 0)
     return LinearLayout::empty();
 
   assert(llvm::isPowerOf2_32(size));
-  std::vector<std::vector<int32_t>> powersOf2;
+  std::vector<std::vector<int32_t>> bases;
   for (int32_t i = 1; i < size; i *= 2) {
-    powersOf2.emplace_back().push_back(i);
+    bases.emplace_back(std::vector<int32_t>{i * stride});
   }
-  return LinearLayout({{inDimName, std::move(powersOf2)}}, {outDimName});
+  bool requiresSurjective = (stride == 1);
+  return LinearLayout({{inDimName, std::move(bases)}},
+                      {{outDimName, stride * size}}, requiresSurjective);
 }
 
 /*static*/ LinearLayout LinearLayout::zeros1D(int32_t size,
@@ -958,8 +961,14 @@ LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
   const auto &B = *this;
   const auto A = outer.transposeOuts(outDims);
   for (auto dim : outDims) {
-    assert(A.getOutDimSize(dim) == B.getOutDimSize(dim) &&
-           "Convert layout does not change the shape of a tensor");
+    if (A.getOutDimSize(dim) != B.getOutDimSize(dim)) {
+      std::stringstream msg;
+      msg << "A.invertAndCompose(B) called with incompatible output shapes in ";
+      msg << "dim = " << std::string(dim.getValue()) << ": ";
+      msg << "A = " << A.getOutDimSize(dim) << ", ";
+      msg << "B = " << B.getOutDimSize(dim);
+      llvm::report_fatal_error(msg.str().c_str());
+    }
   }
 
   // We'll write A^{-1} to mean the inverse or the pseudo-inverse of A

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -963,7 +963,7 @@ LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
   for (auto dim : outDims) {
     if (A.getOutDimSize(dim) != B.getOutDimSize(dim)) {
       std::stringstream msg;
-      msg << "A.invertAndCompose(B) called with incompatible output shapes in ";
+      msg << "B.invertAndCompose(A) called with incompatible output shapes in ";
       msg << "dim = " << std::string(dim.getValue()) << ": ";
       msg << "A = " << A.getOutDimSize(dim) << ", ";
       msg << "B = " << B.getOutDimSize(dim);

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -259,8 +259,7 @@ py::list getTensorDescMetadata(ModuleOp &mod) {
     auto elemType = ttng::getTMAElementType(nullptr, descTy);
     assert(swizzle.has_value());
     assert(elemType.has_value());
-    auto blockSize = ttg::getShapePerCTA(blockType);
-    blockSize.back() = ttng::getTMAContigDim(blockType);
+    auto blockSize = ttng::getTMABlockShape(blockType, /*packedSize=*/false);
     py::dict metadata;
     metadata["swizzle"] = *swizzle;
     metadata["elem_size"] = descTy.getBlockType().getElementTypeBitWidth() / 8;

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -13,7 +13,7 @@ from triton._internal_testing import is_cuda, is_hip
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
-@pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16), (8, 16), (8, 32), (8, 128)])
+@pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16), (8, 16), (8, 32), (8, 128), (512, 32), (1, 1024)])
 def test_tensor_descriptor_load(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
     if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
         pytest.skip("CTAs is unsupported for these cards")
@@ -57,7 +57,7 @@ def test_tensor_descriptor_load(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
 @pytest.mark.interpreter
 @pytest.mark.parametrize("dtype_str", tma_dtypes)
 @pytest.mark.parametrize("num_ctas", [1, 2])
-@pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16), (8, 16), (8, 32), (8, 128)])
+@pytest.mark.parametrize("M_BLOCK,N_BLOCK", [(2, 16), (8, 16), (8, 32), (8, 128), (512, 32), (1, 1024)])
 def test_tensor_descriptor_store(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
     if num_ctas == 2 and (not is_cuda() or torch.cuda.get_device_capability(0)[0] not in (9, 10)):
         pytest.skip("CTAs is unsupported for these cards")
@@ -87,7 +87,7 @@ def test_tensor_descriptor_store(dtype_str, num_ctas, M_BLOCK, N_BLOCK, device):
         assert desc.block_shape == [M_BLOCK, N_BLOCK]
         desc.store([moffset, noffset], val)
 
-    M, N = 32, 128
+    M, N = M_BLOCK * 2, N_BLOCK * 2
     inp = to_triton(numpy_random((M, N), dtype_str), device=device, dst_type=dtype_str)
     out = inp.new_empty((M, N))
 
@@ -551,7 +551,7 @@ def matmul_kernel_make_tensor_descriptor(a_ptr, b_ptr, c_ptr,  #
 @pytest.mark.parametrize("num_ctas", [1, 2])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K, num_stages", [
     (128, 128, 16, 1),
-    (256, 64, 32, 2),
+    (512, 64, 32, 2),
     (64, 512, 32, 2),
     (128, 128, 16, 4),
     (64, 128, 32, 4),

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -51,7 +51,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 // -----
 
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
-#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_global_to_local
@@ -67,7 +67,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
-#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_local_to_global
@@ -83,7 +83,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
-#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: async_tma_store_wait
   // CHECK: nvvm.cp.async.bulk.wait_group 0 {read}

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -110,9 +110,10 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @scales_in_shmem
+  // FIXME
   // CHECK: %[[A_LA:.*]] = ttg.local_alloc
   // CHECK: %[[B_LA:.*]] = ttg.local_alloc
-  // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_LA]], %[[B_LA]],
+  // CHECK-NOT: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_LA]], %[[B_LA]],
 
   tt.func public @scales_in_shmem(
     %scale: tensor<2x512x!tt.ptr<i8>, #blocked4> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -99,7 +99,7 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
-#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 #blocked4 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked8 = #ttg.blocked<{sizePerThread = [1, 1, 1, 2, 4], threadsPerWarp = [1, 1, 16, 2, 1], warpsPerCTA = [2, 1, 2, 1, 1], order = [4, 3, 2, 1, 0]}>
@@ -110,10 +110,9 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @scales_in_shmem
-  // FIXME
   // CHECK: %[[A_LA:.*]] = ttg.local_alloc
   // CHECK: %[[B_LA:.*]] = ttg.local_alloc
-  // CHECK-NOT: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_LA]], %[[B_LA]],
+  // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[A_LA]], %[[B_LA]],
 
   tt.func public @scales_in_shmem(
     %scale: tensor<2x512x!tt.ptr<i8>, #blocked4> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -19,12 +19,15 @@
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
+#include "triton/Tools/LayoutUtils.h"
 
 #include <cassert>
 
 using namespace mlir;
 using namespace mlir::triton;
+namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
+namespace ttng = mlir::triton::nvidia_gpu;
 
 using ::mlir::LLVM::delinearize;
 using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
@@ -32,8 +35,6 @@ using ::mlir::LLVM::linearize;
 using ::mlir::triton::gpu::getCTALayout;
 using ::mlir::triton::gpu::getTotalElemsPerThread;
 using ::mlir::triton::gpu::NVMMASharedEncodingAttr;
-
-namespace ttg = mlir::triton::gpu;
 
 // Toggle this to work around Cooperative Grid Launch ld.acquire optimized path
 static constexpr bool disableLDAcquireLowering = false;
@@ -1269,26 +1270,32 @@ struct AsyncCopyGlobalToLocalOpConversion
   }
 };
 
-static SmallVector<Value> getCtaOffset(RewriterBase &rewriter, Location loc,
-                                       Attribute encoding,
-                                       ArrayRef<int64_t> shapePerCTA) {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-  auto rank = shapePerCTA.size();
-  auto ctaId = rewriter.create<nvgpu::ClusterCTAIdOp>(loc);
-  auto ctaLayout = getCTALayout(encoding);
-  SmallVector<Value> ctaOffset(rank, Value());
-  Value curVal = ctaId;
-  for (int i = 0; i < rank; i++) {
-    auto dim = ctaLayout.getCTAOrder()[i];
-    auto splits = ctaLayout.getCTASplitNum()[dim];
-    if (splits == 1)
-      continue;
-    auto splitsVal = b.i32_val(splits);
-    auto idx = b.urem(curVal, splitsVal);
-    curVal = b.udiv(curVal, splitsVal);
-    ctaOffset[dim] = b.mul(idx, b.i32_val(shapePerCTA[dim]));
+static LinearLayout getMsgToOffsetLayout(ttg::MemDescType ty) {
+  auto ctx = ty.getContext();
+  auto kMsg = str_attr("msg");
+  auto kBlock = str_attr("block");
+  LinearLayout msgToOffset;
+  bool isFp4Padded =
+      cast<NVMMASharedEncodingAttr>(ty.getEncoding()).getFp4Padded();
+  int packingFactor = isFp4Padded ? 2 : 1;
+
+  auto shapePerCTA = ttg::getShapePerCTA(ty);
+  auto blockShape = ttng::getTMABlockShape(ty, /*packedSize=*/true);
+  int rank = shapePerCTA.size();
+  auto outDimNames = standardOutDimNames(ctx, rank);
+  for (int dim = 0; dim < rank; ++dim) {
+    int dimPackingFactor = (dim == rank - 1) ? packingFactor : 1;
+    auto dimShape = shapePerCTA[dim] * dimPackingFactor;
+    msgToOffset *= LinearLayout::strided1D(
+        dimShape / blockShape[dim], blockShape[dim], kMsg, outDimNames[dim]);
   }
-  return ctaOffset;
+  auto ctaLayout = getCTALayout(ty.getEncoding());
+  for (int i = 0; i < rank; ++i) {
+    auto dim = ctaLayout.getCTAOrder()[i];
+    msgToOffset *= LinearLayout::identity1D(ctaLayout.getCTASplitNum()[dim],
+                                            kBlock, outDimNames[dim]);
+  }
+  return msgToOffset;
 }
 
 struct AsyncTMACopyGlobalToLocalOpConversion
@@ -1329,19 +1336,27 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     // figure out that the op is uniform.
     pred = b.and_(pred, LLVM::NVIDIA::createElectPredicate(loc, rewriter));
 
-    Attribute encoding = op.getResult().getType().getEncoding();
+    auto smemTy = op.getResult().getType();
+    Attribute encoding = smemTy.getEncoding();
     auto mmaEncoding = dyn_cast_or_null<NVMMASharedEncodingAttr>(encoding);
     int elementSizeInBytes =
         op.getResult().getType().getElementType().getIntOrFloatBitWidth() / 8;
     int packingFactor = (mmaEncoding && mmaEncoding.getFp4Padded()) ? 2 : 1;
 
-    auto shapePerCTA = ttg::getShapePerCTA(op.getResult().getType());
-    auto contigDimSize = nvidia_gpu::getTMAContigDim(op.getResult().getType());
-    int numCopies =
-        ceil<int>(shapePerCTA.back() * packingFactor, contigDimSize);
+    auto shapePerCTA = ttg::getShapePerCTA(smemTy);
     int rank = op.getCoord().size();
-    auto ctaOffset = getCtaOffset(rewriter, loc, encoding, shapePerCTA);
-    int elementsPerCTA = product(shapePerCTA) * packingFactor;
+
+    auto msgToOffset = getMsgToOffsetLayout(smemTy);
+    auto smemLayout = ttg::toLinearLayout(smemTy.getShape(), encoding);
+    auto msgToShared = msgToOffset.invertAndCompose(smemLayout);
+    llvm::errs() << msgToOffset << "\n";
+
+    auto ctx = op.getContext();
+    auto kMsg = str_attr("msg");
+    auto kBlock = str_attr("block");
+    const auto numCopies = msgToOffset.getInDimSize(kMsg);
+    auto zero = b.i32_val(0);
+    auto ctaId = rewriter.create<nvgpu::ClusterCTAIdOp>(loc);
 
     // The bounding box inner dimension must be less than or equal to the
     // swizzle size.
@@ -1358,7 +1373,9 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       Type elemPtrTy = ptr_ty(rewriter.getContext(), 3);
       Value copyIdxVal = b.add(warpID, b.i32_val(copyIdx));
       Value shMemOffset =
-          b.mul(copyIdxVal, b.i32_val(elementsPerCTA / numCopies));
+          applyLinearLayout(loc, rewriter, msgToShared,
+                            {{kMsg, copyIdxVal}, {kBlock, zero}})[0]
+              .second;
       Value shMemPtr =
           b.gep(elemPtrTy, llvmElemTy, dstMemObj.getBase(), shMemOffset);
       SmallVector<PTXBuilder::Operand *> operands = {
@@ -1368,15 +1385,14 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       std::string tmaInst =
           "@$0 cp.async.bulk.tensor." + std::to_string(rank) +
           "d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {";
+
+      auto offsets = applyLinearLayout(loc, rewriter, msgToOffset,
+                                       {{kMsg, copyIdxVal}, {kBlock, ctaId}});
       int operandIdx = 3;
       for (int i = 0; i < rank; i++) {
         Value coord = adaptor.getCoord()[rank - i - 1];
-        if (i < ctaOffset.size() && ctaOffset[ctaOffset.size() - i - 1])
-          coord = b.add(coord, ctaOffset[ctaOffset.size() - i - 1]);
-        if (i == 0) {
-          Value offset = b.mul(copyIdxVal, b.i32_val(contigDimSize));
-          coord = b.add(coord, offset);
-        }
+        if (i < offsets.size())
+          coord = b.add(coord, offsets[offsets.size() - i - 1].second);
         operands.push_back(ptxBuilderTMA.newOperand(coord, "r"));
         tmaInst += "$" + std::to_string(operandIdx++);
         if (i != rank - 1)
@@ -1420,11 +1436,18 @@ LogicalResult convertTMAStoreLikeOp(Operation *op,
   auto shapePerCTA = ttg::getShapePerCTA(srcTy);
   int elementsPerCTA = product(shapePerCTA);
 
-  auto contigDimSize = nvidia_gpu::getTMAContigDim(srcTy);
-  int numCopies = shapePerCTA.back() / contigDimSize;
   auto rank = coords.size();
   auto encoding = srcTy.getEncoding();
-  auto ctaOffset = getCtaOffset(rewriter, loc, encoding, shapePerCTA);
+
+  auto msgToOffset = getMsgToOffsetLayout(srcTy);
+  auto smemLayout = ttg::toLinearLayout(srcTy.getShape(), encoding);
+  auto msgToShared = msgToOffset.invertAndCompose(smemLayout);
+  auto ctx = op->getContext();
+  auto kMsg = str_attr("msg");
+  auto kBlock = str_attr("block");
+  auto numCopies = msgToOffset.getInDimSize(kMsg);
+  auto zero = b.i32_val(0);
+  auto ctaId = rewriter.create<nvgpu::ClusterCTAIdOp>(loc);
 
   for (int copyIdx = 0; copyIdx < numCopies; copyIdx += numWarps) {
     int numWarpsToCopy = std::min(numCopies - copyIdx, numWarps);
@@ -1436,21 +1459,22 @@ LogicalResult convertTMAStoreLikeOp(Operation *op,
     Type elemPtrTy = ptr_ty(rewriter.getContext(), 3);
     Value copyIdxVal = b.add(warpID, b.i32_val(copyIdx));
     Value shMemOffset =
-        b.mul(copyIdxVal, b.i32_val(elementsPerCTA / numCopies));
+        applyLinearLayout(loc, rewriter, msgToShared,
+                          {{kMsg, copyIdxVal}, {kBlock, zero}})[0]
+            .second;
     Value shMemPtr =
         b.gep(elemPtrTy, llvmElemTy, dstMemObj.getBase(), shMemOffset);
     SmallVector<PTXBuilder::Operand *> operands = {
         ptxBuilderTMA.newOperand(boxPred, "b"),
         ptxBuilderTMA.newOperand(tmaPtr, "l")};
+
+    auto offsets = applyLinearLayout(loc, rewriter, msgToOffset,
+                                     {{kMsg, copyIdxVal}, {kBlock, ctaId}});
     int operandIdx = 2;
     for (int i = 0; i < rank; i++) {
       Value coord = coords[rank - i - 1];
-      if (i < ctaOffset.size() && ctaOffset[ctaOffset.size() - i - 1])
-        coord = b.add(coord, ctaOffset[ctaOffset.size() - i - 1]);
-      if (i == 0) {
-        Value offset = b.mul(copyIdxVal, b.i32_val(contigDimSize));
-        coord = b.add(coord, offset);
-      }
+      if (i < offsets.size())
+        coord = b.add(coord, offsets[offsets.size() - i - 1].second);
       operands.push_back(ptxBuilderTMA.newOperand(coord, "r"));
     }
     operands.push_back(ptxBuilderTMA.newOperand(shMemPtr, "r"));
@@ -1589,10 +1613,11 @@ static LogicalResult iterateGatherScatterIndices(
   unsigned threadsPerWarp = xCoordsLayout.getInDimSize(kLane);
   unsigned numWarps = xCoordsLayout.getInDimSize(kWarp);
 
-  // Each gather4 instructions reads 128 bytes for 4 rows at a time.
+  // Each gather4 instructions reads contigDimSize columns, 4 rows at a time.
   auto shapePerCTA = ttg::getShapePerCTA(smemType);
+  auto tmaBlockShape = ttng::getTMABlockShape(smemType, /*packedSize=*/true);
   unsigned innerBlockSize = shapePerCTA.back();
-  unsigned contigDimSize = nvidia_gpu::getTMAContigDim(smemType);
+  unsigned contigDimSize = tmaBlockShape.back();
   unsigned numMessagesPerRow = ceil<unsigned>(innerBlockSize, contigDimSize);
 
   // `xCoordsLayout` maps the register ID into dim0. Tile dim1 by adding a new
@@ -1600,15 +1625,11 @@ static LogicalResult iterateGatherScatterIndices(
   assert(innerBlockSize % numMessagesPerRow == 0);
   assert(llvm::isPowerOf2_32(numMessagesPerRow));
   unsigned msgSize = innerBlockSize / numMessagesPerRow;
-  std::vector<std::vector<int>> msgBases;
-  for (unsigned msgId = 1; msgId < numMessagesPerRow; msgId *= 2)
-    msgBases.push_back({int32_t(msgId * msgSize)});
-  LinearLayout msgToCol({{{kMsg, std::move(msgBases)}}},
-                        {{kDim1, innerBlockSize}},
-                        /*requiresSurjective=*/false);
+  LinearLayout msgToCol =
+      LinearLayout::strided1D(numMessagesPerRow, msgSize, kMsg, kDim1);
   LinearLayout msgLayout = xCoordsLayout * msgToCol;
 
-  // `gather4` will put the 128-byte segments of the 4 rows consecutively in
+  // `gather4` will put the segments of the 4 rows consecutively in
   // shared memory. However, if the 4 rows are smaller than the shared memory
   // swizzle tile size, e.g. [4, 32] vs. [8, 32], then, for example, the address
   // of the 0th element of row 4 will not be at the start of the segment.

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -2835,10 +2835,10 @@ TEST_F(LinearLayoutConversionsTest, LeadingOffset_64x4x32_1_8_32b_transposed) {
                       {8, 0, 16},
                       {0, 1, 0},
                       {0, 2, 0},
-                      {16, 0, 0},
-                      {32, 0, 0},
                       {0, 0, 1},
-                      {0, 0, 2}}},
+                      {0, 0, 2},
+                      {16, 0, 0},
+                      {32, 0, 0}}},
                     {S("block"), {}}},
                    {{S("dim0"), 64}, {S("dim1"), 4}, {S("dim2"), 32}},
                    /*requireSurjective=*/true));


### PR DESCRIPTION
This overcomes the hardware limit that no dimension can exceed 256 within the block size of the TMA descriptor.