### PR TITLE
[Warp Specialization] Fix accidentally assigning ops to default partition

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -269,6 +269,6 @@ void PartitionLoops::runOnOperation() {
 
   for (scf::ForOp loop : loops) {
     if (failed(partitionLoop(loop)))
-      continue;
+      return signalPassFailure();
   }
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -568,6 +568,6 @@ void RewritePartitionDependencies::runOnOperation() {
 
   for (scf::ForOp loop : loops) {
     if (failed(rewritePartitionDependencies(loop)))
-      continue;
+      return signalPassFailure();
   }
 }

--- a/test/TritonGPU/load-mma-specialization.mlir
+++ b/test/TritonGPU/load-mma-specialization.mlir
@@ -722,7 +722,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag(
     %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #oper_layout>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
     %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
 
-    // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi eq, [[K:%.*]], %c0_i32
+    // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi eq, [[K:%.*]], %c0_i32 : i32
     // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], [[FLAG]], %true, {{.*}}, [[ACC_READY_BUF0]][[[DO_EPILOGUE]]] {ttg.partition = 1 : i32}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %flag, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>

--- a/test/TritonGPU/load-mma-specialization.mlir
+++ b/test/TritonGPU/load-mma-specialization.mlir
@@ -172,54 +172,27 @@ tt.func @unsupported_load() {
   // CHECK-NEXT: [[DONE_MBAR0:%.*]] = ttg.memdesc_subview [[DONE_MBAR]][%c0_i32]
   // CHECK-NEXT: ttng.init_barrier [[DONE_MBAR0]], 1
 
-  // CHECK-NEXT: [[A_SHARED:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16,
-  // CHECK-NEXT: [[B_SHARED:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16,
-
-  // CHECK-NEXT: [[OPER_EMPTY_MBAR:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<1xi64
-  // CHECK-NEXT: [[OPER_EMPTY_MBAR0:%.*]] = ttg.memdesc_subview [[OPER_EMPTY_MBAR]][%c0_i32]
-  // CHECK-NEXT: init_barrier [[OPER_EMPTY_MBAR0]], 1
-
-  // CHECK-NEXT: [[OPER_READY_MBAR:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<1xi64
-  // CHECK-NEXT: [[OPER_READY_MBAR0:%.*]] = ttg.memdesc_subview [[OPER_READY_MBAR]][%c0_i32]
-  // CHECK-NEXT: init_barrier [[OPER_READY_MBAR0]], 1
-
-  // CHECK-NEXT: arrive_barrier [[OPER_EMPTY_MBAR]], 1
-
   // CHECK-NEXT: scf.for
   scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero) -> tensor<128x128xf32, #acc_layout> : i32 {
     // CHECK-NEXT: get_ptrs
     %a_ptrs, %b_ptrs = "get_ptrs"(%k) : (i32) -> (tensor<128x64x!tt.ptr<f16>, #oper_layout>, tensor<64x128x!tt.ptr<f16>, #oper_layout>)
-    // CHECK-NEXT: [[A:%.*]] = tt.load
     %a = tt.load %a_ptrs : tensor<128x64x!tt.ptr<f16>, #oper_layout>
-    // CHECK-NEXT: [[B:%.*]] = tt.load
     %b = tt.load %b_ptrs : tensor<64x128x!tt.ptr<f16>, #oper_layout>
 
-    // CHECK-NEXT: wait_barrier [[OPER_EMPTY_MBAR]]
-    // CHECK-NEXT: local_store [[A]], [[A_SHARED]]
     %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
-    // CHECK-NEXT: local_store [[B]], [[B_SHARED]]
     %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #oper_layout>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
-    // CHECK-NEXT: arrive_barrier [[OPER_READY_MBAR]], 1
 
     %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
-    // CHECK-NEXT: [[IS_LAST:%.*]] = arith.cmpi eq, %{{.*}}, %c31_i32
-    // CHECK-NEXT: wait_barrier [[OPER_READY_MBAR]]
-    // CHECK-NEXT: ttng.tc_gen5_mma %{{.*}}, [[ACC]][], %true, %true, [[DONE_MBAR0]][[[IS_LAST]]], [[OPER_EMPTY_MBAR]][%true] {ttg.partition = 1 : i32}
+    // CHECK: [[IS_LAST:%.*]] = arith.cmpi eq, %{{.*}}, %c31_i32
+    // CHECK-NEXT: ttng.tc_gen5_mma %{{.*}}, [[ACC]][], %true, %true, [[DONE_MBAR0]][[[IS_LAST]]] {ttg.partition = 1 : i32}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
-    // CHECK-NEXT: [[NEXT_PHASE:%.*]] = arith.xori
-    // CHECK-NEXT: yield [[NEXT_PHASE]]
-
     scf.yield %c : tensor<128x128xf32, #acc_layout>
-  // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
+  // CHECK: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
   } {tt.warp_specialize}
 
   // CHECK-NEXT: ttng.wait_barrier [[DONE_MBAR0]], %c0_i32
-  // CHECK-NEXT: ttng.inval_barrier [[OPER_READY_MBAR0]]
-  // CHECK-NEXT: ttg.local_dealloc [[OPER_READY_MBAR]]
-  // CHECK-NEXT: ttng.inval_barrier [[OPER_EMPTY_MBAR0]]
-  // CHECK-NEXT: ttg.local_dealloc [[OPER_EMPTY_MBAR]]
   // CHECK-NEXT: ttng.inval_barrier [[DONE_MBAR0]]
   // CHECK-NEXT: ttg.local_dealloc [[DONE_MBAR]]
 

--- a/test/TritonGPU/rewrite-partition-dependencies.mlir
+++ b/test/TritonGPU/rewrite-partition-dependencies.mlir
@@ -1,93 +1,9 @@
-// RUN: triton-opt %s -allow-unregistered-dialect -tritongpu-rewrite-partition-dependencies -verify-diagnostics -canonicalize | FileCheck %s
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-rewrite-partition-dependencies -verify-diagnostics -canonicalize | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 !ty = tensor<1xi32, #blocked>
 
 module attributes {"ttg.num-warps" = 4 : i32} {
-
-tt.func @invalid_attribute(%lb: i32, %ub: i32, %step: i32) {
-  // expected-warning @below {{partition stages attribute 'ttg.partition.stages' has invalid element "a"}}
-  scf.for %i = %lb to %ub step %step : i32 {
-    scf.yield
-  } {ttg.partition.stages = ["a"]}
-  scf.for %j = %lb to %ub step %step : i32 {
-    scf.yield
-  }
-  scf.for %k = %lb to %ub step %step : i32 {
-    // expected-warning @below {{invalid partition index -1}}
-    "op"() {ttg.partition = -1} : () -> ()
-    scf.yield
-  } {ttg.partition.stages = [2, 2]}
-  tt.return
-}
-
-tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
-  // expected-warning @below {{warp schedule contains a cycle}}
-  scf.for %i = %lb to %ub step %step : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> index
-    // expected-note @below {{operation in partition #1 uses value defined in partition #0}}
-    %1 = "op_b"(%0) {ttg.partition = 1} : (index) -> index
-    // expected-note @below {{operation in partition #0 uses value defined in partition #1}}
-    "op_c"(%1) {ttg.partition = 0} : (index) -> ()
-    scf.yield
-  } {ttg.partition.stages = [0, 2]}
-  // expected-warning @below {{warp schedule contains a cycle}}
-  scf.for %j = %lb to %ub step %step : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> index
-    // expected-note @below {{operation in partition #1 uses value defined in partition #0}}
-    %1 = "op_b"(%0) {ttg.partition = 1} : (index) -> index
-    // expected-note @below {{operation in partition #2 uses value defined in partition #1}}
-    %2 = "op_c"(%1) {ttg.partition = 2} : (index) -> index
-    // expected-note @below {{operation in partition #0 uses value defined in partition #2}}
-    "op_c"(%2) {ttg.partition = 0} : (index) -> ()
-    scf.yield
-  } {ttg.partition.stages = [0, 2, 3]}
-  tt.return
-}
-
-tt.func @invalid_root_partition(%lb: i32, %ub: i32, %step: i32) {
-  scf.for %i = %lb to %ub step %step : i32 {
-    // expected-note @below {{operand defined here in partition #0 at distance 0}}
-    %0 = "partition"() {ttg.partition = 0} : () -> index
-    // expected-warning @below {{operation in the root partition depends on a value that originates from a non-root partition through operand #0}}
-    "root"(%0) : (index) -> ()
-    scf.yield
-  } {ttg.partition.stages = [0, 2]}
-
-  %c0 = arith.constant 0 : index
-  scf.for %j = %lb to %ub step %step iter_args(%k = %c0) -> index : i32 {
-    // expected-warning @below {{operation in the root partition depends on a value that originates from a non-root partition through operand #0}}
-    "root"(%k) : (index) -> ()
-    // expected-note @below {{operand defined here in partition #0 at distance 1}}
-    %0 = "partition"() {ttg.partition = 0} : () -> index
-    scf.yield %0 : index
-  } {ttg.partition.stages = [0, 2]}
-  tt.return
-}
-
-tt.func @invalid_partition_stage(%lb: i32, %ub: i32, %step: i32) {
-  // expected-warning @below {{partition #0 has stage 2 but is consumed by partition #1 with stage 0}}
-  scf.for %i = %lb to %ub step %step : i32 {
-    // expected-note @below {{value defined here in partition #0}}
-    %0 = "op_a"() {ttg.partition = 0} : () -> index
-    // expected-note @below {{use of value defined in partition #0}}
-    "op_b"(%0) {ttg.partition = 1} : (index) -> ()
-  } {ttg.partition.stages = [2, 0]}
-  tt.return
-}
-
-tt.func @invalid_future_partition(%lb: i32, %ub: i32, %step: i32) {
-  %c0 = arith.constant 0 : index
-  // expected-warning @below {{partition #1 has stage 2 but is consumed by partition #0 with stage 0 at distance 1}}
-  scf.for %i = %lb to %ub step %step iter_args(%k = %c0) -> index : i32 {
-    // expected-note @below {{use of value defined in partition #1 at 1 iterations in the future}}
-    "op_a"(%k) {ttg.partition = 0} : (index) -> ()
-    // expected-note @below {{value defined here in partition #1}}
-    %0 = "op_b"() {ttg.partition = 1} : () -> index
-    scf.yield %0 : index
-  } {ttg.partition.stages = [0, 2]}
-  tt.return
-}
 
 // CHECK-LABEL: @two_consumers
 tt.func @two_consumers(%lb: i32, %ub: i32, %step: i32) {
@@ -427,6 +343,174 @@ tt.func @no_def_op(%lb: i32, %ub: i32, %step: i32) {
     arith.addi %k, %k : i32
     scf.yield %k : i32
   }
+  tt.return
+}
+
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+!ty = tensor<1xi32, #blocked>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+tt.func @invalid_attribute(%lb: i32, %ub: i32, %step: i32) {
+  // expected-warning @below {{partition stages attribute 'ttg.partition.stages' has invalid element "a"}}
+  scf.for %i = %lb to %ub step %step : i32 {
+    scf.yield
+  } {ttg.partition.stages = ["a"]}
+  scf.for %j = %lb to %ub step %step : i32 {
+    scf.yield
+  }
+  tt.return
+}
+
+}
+
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+!ty = tensor<1xi32, #blocked>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+tt.func @invalid_attribute(%lb: i32, %ub: i32, %step: i32) {
+  scf.for %k = %lb to %ub step %step : i32 {
+    // expected-warning @below {{invalid partition index -1}}
+    "op"() {ttg.partition = -1} : () -> ()
+    scf.yield
+  } {ttg.partition.stages = [2, 2]}
+  tt.return
+}
+
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+!ty = tensor<1xi32, #blocked>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
+  // expected-warning @below {{warp schedule contains a cycle}}
+  scf.for %i = %lb to %ub step %step : i32 {
+    %0 = "op_a"() {ttg.partition = 0} : () -> index
+    // expected-note @below {{operation in partition #1 uses value defined in partition #0}}
+    %1 = "op_b"(%0) {ttg.partition = 1} : (index) -> index
+    // expected-note @below {{operation in partition #0 uses value defined in partition #1}}
+    "op_c"(%1) {ttg.partition = 0} : (index) -> ()
+    scf.yield
+  } {ttg.partition.stages = [0, 2]}
+  tt.return
+}
+
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+!ty = tensor<1xi32, #blocked>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
+  // expected-warning @below {{warp schedule contains a cycle}}
+  scf.for %j = %lb to %ub step %step : i32 {
+    %0 = "op_a"() {ttg.partition = 0} : () -> index
+    // expected-note @below {{operation in partition #1 uses value defined in partition #0}}
+    %1 = "op_b"(%0) {ttg.partition = 1} : (index) -> index
+    // expected-note @below {{operation in partition #2 uses value defined in partition #1}}
+    %2 = "op_c"(%1) {ttg.partition = 2} : (index) -> index
+    // expected-note @below {{operation in partition #0 uses value defined in partition #2}}
+    "op_c"(%2) {ttg.partition = 0} : (index) -> ()
+    scf.yield
+  } {ttg.partition.stages = [0, 2, 3]}
+  tt.return
+}
+
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+!ty = tensor<1xi32, #blocked>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+tt.func @invalid_root_partition(%lb: i32, %ub: i32, %step: i32) {
+  scf.for %i = %lb to %ub step %step : i32 {
+    // expected-note @below {{operand defined here in partition #0 at distance 0}}
+    %0 = "partition"() {ttg.partition = 0} : () -> index
+    // expected-warning @below {{operation in the root partition depends on a value that originates from a non-root partition through operand #0}}
+    "root"(%0) : (index) -> ()
+    scf.yield
+  } {ttg.partition.stages = [0, 2]}
+  tt.return
+}
+
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+!ty = tensor<1xi32, #blocked>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+tt.func @invalid_root_partition(%lb: i32, %ub: i32, %step: i32) {
+  %c0 = arith.constant 0 : index
+  scf.for %j = %lb to %ub step %step iter_args(%k = %c0) -> index : i32 {
+    // expected-warning @below {{operation in the root partition depends on a value that originates from a non-root partition through operand #0}}
+    "root"(%k) : (index) -> ()
+    // expected-note @below {{operand defined here in partition #0 at distance 1}}
+    %0 = "partition"() {ttg.partition = 0} : () -> index
+    scf.yield %0 : index
+  } {ttg.partition.stages = [0, 2]}
+  tt.return
+}
+
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+!ty = tensor<1xi32, #blocked>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+tt.func @invalid_partition_stage(%lb: i32, %ub: i32, %step: i32) {
+  // expected-warning @below {{partition #0 has stage 2 but is consumed by partition #1 with stage 0}}
+  scf.for %i = %lb to %ub step %step : i32 {
+    // expected-note @below {{value defined here in partition #0}}
+    %0 = "op_a"() {ttg.partition = 0} : () -> index
+    // expected-note @below {{use of value defined in partition #0}}
+    "op_b"(%0) {ttg.partition = 1} : (index) -> ()
+  } {ttg.partition.stages = [2, 0]}
+  tt.return
+}
+
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+!ty = tensor<1xi32, #blocked>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+tt.func @invalid_future_partition(%lb: i32, %ub: i32, %step: i32) {
+  %c0 = arith.constant 0 : index
+  // expected-warning @below {{partition #1 has stage 2 but is consumed by partition #0 with stage 0 at distance 1}}
+  scf.for %i = %lb to %ub step %step iter_args(%k = %c0) -> index : i32 {
+    // expected-note @below {{use of value defined in partition #1 at 1 iterations in the future}}
+    "op_a"(%k) {ttg.partition = 0} : (index) -> ()
+    // expected-note @below {{value defined here in partition #1}}
+    %0 = "op_b"() {ttg.partition = 1} : () -> index
+    scf.yield %0 : index
+  } {ttg.partition.stages = [0, 2]}
   tt.return
 }
 


### PR DESCRIPTION
Ops that have no backward dependency on any other partition are expected to be left in the root partition because it's easier to let later passes deal with rematerialization than for higher-level passes to duplicate and assign explicit stages.

Accidentally assigning partitions to these ops will cause later passes to fail. This also changes those passes to a hard fail because the code generated by WS can be invalid if it isn't split. (The code expects to be run concurrently).