### PR TITLE
Docs: Update PyTorch installation for Blackwell 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,43 +25,18 @@ pip install triton
 Binary wheels are available for CPython 3.9-3.13.
 
 # Enabling Blackwell Support
-
 The main branch now features support for NVIDIA Blackwell GPUs using 5th
-generation tensor cores. To enable this, you will need two additional steps:
+generation tensor cores. To enable this, you will need these additional steps:
 
-1. Build a pre-release PyTorch from source with CUDA 12.8
-2. Build triton from the latest source
+1. Ensure you have CUDA 12.8 installed.
+2. Install a PyTorch version compatible with CUDA 12.8 and Blackwell GPUs.
+3. Build triton from the latest source.
 
+To install PyTorch with CUDA 12.8 support for Blackwell :
 
-First, to build pytorch you need to have CUDA 12.8 installed locally. If not,
-follow the [instructions for your platform](https://developer.nvidia.com/cuda-downloads)
 ```bash
-# Clone and checkout pytorch 2.6 release candidate
-git clone https://github.com/pytorch/pytorch
-cd pytorch
-git checkout v2.6.0-rc9
-git submodule sync
-git submodule update --init --recursive -j 8
-
-# Install build dependencies (assumes you already have a system compiler)
-pip install -r requirements.txt
-pip install mkl-static mkl-include wheel
-
-# Build PyTorch (will take a long time)
-export CUDA_HOME=/usr/local/cuda-12.8
-export CUDA_PATH=$CUDA_HOME
-export TORCH_CUDA_ARCH_LIST=Blackwell
-python setup.py develop
-
-# Optional, package build into a wheel to install on other machines.
-python setup.py bdist_wheel
-ls dist  # Wheel should be output in this directory
+pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
 ```
-
-Note that if you use the domain libraries (`torchvision`, `torchtext`,
-`torchaudio`, etc.) these will need to be built from source as well, otherwise
-their custom PyTorch extensions will not work.
-
 Finally, follow the instructions below to install triton from source.
 
 # Install from source

--- a/README.md
+++ b/README.md
@@ -24,21 +24,6 @@ pip install triton
 
 Binary wheels are available for CPython 3.9-3.13.
 
-# Enabling Blackwell Support
-The main branch now features support for NVIDIA Blackwell GPUs using 5th
-generation tensor cores. To enable this, you will need these additional steps:
-
-1. Ensure you have CUDA 12.8 installed.
-2. Install a PyTorch version compatible with CUDA 12.8 and Blackwell GPUs.
-3. Build triton from the latest source.
-
-To install PyTorch with CUDA 12.8 support for Blackwell :
-
-```bash
-pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
-```
-Finally, follow the instructions below to install triton from source.
-
 # Install from source
 
 ```shell


### PR DESCRIPTION
The current README instructions for enabling Blackwell support suggest building PyTorch `2.6.0-rc9` from source with `TORCH_CUDA_ARCH_LIST=Blackwell`.

However, when following these steps, the resulting PyTorch installation did not correctly recognize all Blackwell architectures. For instance, when targeting an sm_120 (NVIDIA 5090) GPU, the available architectures were limited:

```
>>> import torch
>>> print(torch.cuda.get_arch_list())
['sm_100']
```
This PR removes the Blackwell installation process section since torch 2.7.0 is released and supports all the blackwell architectures.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
