### PR TITLE
Refactor CompilationListener handling in compilation knobs

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -299,13 +299,15 @@ def compile(src, target=None, options=None):
         # cache hit!
         res = CompiledKernel(src, metadata_group, hash)
         if compilation_listener:
-            compilation_listener(
-                src=src,
-                metadata=res.metadata._asdict(),
-                metadata_group=metadata_group,
-                times=timer.end(),
-                cache_hit=True,
-            )
+            listeners = compilation_listener if isinstance(compilation_listener, list) else [compilation_listener]
+            for listener in listeners:
+                listener(
+                    src=src,
+                    metadata=res.metadata._asdict(),
+                    metadata_group=metadata_group,
+                    times=timer.end(),
+                    cache_hit=True,
+                )
         return res
 
     # initialize metadata
@@ -382,8 +384,9 @@ def compile(src, target=None, options=None):
 
     # notify any listener
     if compilation_listener:
-        compilation_listener(src=src, metadata=metadata, metadata_group=metadata_group, times=timer.end(),
-                             cache_hit=False)
+        listeners = compilation_listener if isinstance(compilation_listener, list) else [compilation_listener]
+        for listener in listeners:
+            listener(src=src, metadata=metadata, metadata_group=metadata_group, times=timer.end(), cache_hit=False)
     # return handle to compiled kernel
     return CompiledKernel(src, metadata_group, hash)
 

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -8,7 +8,7 @@ import sysconfig
 
 from dataclasses import dataclass
 from contextlib import contextmanager
-from typing import cast, Any, Callable, Generator, Generic, Optional, Protocol, Type, TypeVar, TypedDict, TYPE_CHECKING, Union
+from typing import cast, Any, Callable, Generator, Generic, List, Optional, Protocol, Type, TypeVar, TypedDict, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from .runtime.cache import CacheManager, RemoteCacheBackend
@@ -358,7 +358,7 @@ class compilation_knobs(base_knobs):
     disable_line_info: env_bool = env_bool("TRITON_DISABLE_LINE_INFO")
     front_end_debugging: env_bool = env_bool("TRITON_FRONT_END_DEBUGGING")
     allow_non_constexpr_globals: env_bool = env_bool("TRITON_ALLOW_NON_CONSTEXPR_GLOBALS")
-    listener: Union[CompilationListener, None] = None
+    listener: Union[CompilationListener, List[CompilationListener], None] = None
 
 
 class autotuning_knobs(base_knobs):


### PR DESCRIPTION
This PR updates `compilation_knobs.listener` to support multiple listeners. The changes include:
Modified compilation_knobs.listener to accept a single listener function, a list of listeners, or None.
Refactored the listener calling code:
- First convert any listener to a list form
- Then use a simple loop to invoke each listener with the same parameters

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
