### PR TITLE
Use `Py_DECREF` after `PyObject_CallObject` call

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -441,6 +441,7 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
     Py_DECREF(args);
     if (!ret)
       return NULL;
+    Py_DECREF(ret);
   }}
 
 
@@ -454,6 +455,7 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
     Py_DECREF(args);
     if (!ret)
       return NULL;
+    Py_DECREF(ret);
   }}
 
   if(PyErr_Occurred()) {{

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -472,6 +472,7 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
     Py_DECREF(args);
     if (!ret)
       return NULL;
+    Py_DECREF(ret);
   }}
 
   CUdeviceptr global_scratch = 0;
@@ -499,7 +500,7 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
     Py_DECREF(args);
     if (!ret)
       return NULL;
-
+    Py_DECREF(ret);
   }}
 
   Py_RETURN_NONE;


### PR DESCRIPTION
`PyObject_CallObject` returns new reference: https://docs.python.org/3/c-api/call.html#c.PyObject_CallObject.