### PR TITLE
[BUILD] Speedup unittests linking

### DIFF
--- a/cmake/AddTritonUnitTest.cmake
+++ b/cmake/AddTritonUnitTest.cmake
@@ -9,10 +9,6 @@ function(add_triton_ut)
   set(multiValueArgs SRCS LIBS DEFS)
   cmake_parse_arguments(_ "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-  get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-  get_property(triton_libs GLOBAL PROPERTY TRITON_LIBS)
-
   add_test(NAME ${__NAME}
           COMMAND ${__NAME})
   add_executable(
@@ -22,9 +18,6 @@ function(add_triton_ut)
           ${__NAME}
           PRIVATE
           GTest::gtest_main
-          ${triton_libs}
-          ${dialect_libs}
-          ${conversion_libs}
           gmock
           ${__LIBS})
 

--- a/third_party/amd/unittest/Conversion/CMakeLists.txt
+++ b/third_party/amd/unittest/Conversion/CMakeLists.txt
@@ -1,6 +1,14 @@
-add_triton_ut(NAME TestOptimizeLDS
-SRCS OptimizeLDSTest.cpp
-LIBS
-  TritonAnalysis
-  TritonIR
-  TritonGPUIR)
+add_triton_ut(
+  NAME TestOptimizeLDS
+  SRCS OptimizeLDSTest.cpp
+  LIBS
+    TritonAnalysis
+    TritonIR
+    TritonGPUIR
+    TritonAMDGPUToLLVM
+    MLIRUBToLLVM
+    TritonAMDUtils
+    TritonAMDAnalysis
+    TritonAMDGPUTransforms
+    TritonAMDGPUDialectToLLVM
+)

--- a/third_party/nvidia/unittest/Conversion/TritonGPUToLLVM/CMakeLists.txt
+++ b/third_party/nvidia/unittest/Conversion/TritonGPUToLLVM/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_triton_ut(
-	NAME TestPtxAsmFormat
-	SRCS PTXAsmFormatTest.cpp
-	LIBS TritonGPUToLLVM TritonNVIDIAGPUToLLVM
+  NAME TestPtxAsmFormat
+  SRCS PTXAsmFormatTest.cpp
+  LIBS
+    TritonGPUToLLVM
+    TritonNVIDIAGPUToLLVM
+    NVGPUIR MLIRUBToLLVM
 )

--- a/unittest/Analysis/CMakeLists.txt
+++ b/unittest/Analysis/CMakeLists.txt
@@ -5,4 +5,6 @@ add_triton_ut(
     TritonAnalysis
     TritonIR
     TritonGPUIR
+    TritonGPUTransforms
+    TritonNvidiaGPUTransforms
 )

--- a/unittest/Dialect/TritonGPU/CMakeLists.txt
+++ b/unittest/Dialect/TritonGPU/CMakeLists.txt
@@ -1,21 +1,34 @@
 add_triton_ut(
-	NAME TestSwizzling
-	SRCS SwizzleTest.cpp
-	LIBS TritonGPUIR TritonNvidiaGPUIR
+  NAME TestSwizzling
+  SRCS SwizzleTest.cpp
+  LIBS
+    TritonGPUIR
+    TritonGPUTransforms
+    TritonNvidiaGPUTransforms
 )
 add_triton_ut(
-	NAME Dialect
-	SRCS DialectTest.cpp
-	LIBS TritonGPUIR
+  NAME Dialect
+  SRCS DialectTest.cpp
+  LIBS
+    MLIRParser
+    TritonGPUIR
+    TritonGPUTransforms
+    TritonNvidiaGPUTransforms
 )
 add_triton_ut(
-	NAME LinearLayoutConversions
-	SRCS LinearLayoutConversionsTest.cpp
-	LIBS TritonGPUIR
+  NAME LinearLayoutConversions
+  SRCS LinearLayoutConversionsTest.cpp
+  LIBS
+    TritonGPUIR
+    TritonGPUTransforms
+    TritonNvidiaGPUTransforms
 )
 
 add_triton_ut(
-	NAME DumpLayoutTest
-	SRCS DumpLayoutTest.cpp
-	LIBS TritonGPUIR
+  NAME DumpLayoutTest
+  SRCS DumpLayoutTest.cpp
+  LIBS
+    TritonGPUIR
+    TritonGPUTransforms
+    TritonNvidiaGPUTransforms
 )

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -1,10 +1,8 @@
 #include <algorithm>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <random>
 
 #include "mlir/AsmParser/AsmParser.h"
-#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/StrUtil.h"

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -5,6 +5,8 @@
 using namespace mlir;
 using mlir::triton::gpu::SwizzledSharedEncodingAttr;
 
+namespace {
+
 struct swizzleParams {
   int vec;
   int perPhase;
@@ -57,6 +59,8 @@ INSTANTIATE_TEST_SUITE_P(TestDotOperands, SwizzleDotOperandTestFixture,
                                            ParamT{{32, 32}, 1, 16, {8, 2, 4}},
                                            ParamT{{16, 16}, 0, 16, {8, 4, 2}},
                                            ParamT{{16, 16}, 1, 16, {8, 4, 2}}));
+
+} // anonymous namespace
 
 int main(int argc, char *argv[]) {
   llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);


### PR DESCRIPTION
Comparison of the sizes of build artifacts:
Old:
```bash
ls build/cmake.linux-x86_64-cpython-3.10/unittest/Dialect/TritonGPU/ -lh
total 1.8G
drwxr-sr-x 6 jovyan users 4.0K May 11 13:29  CMakeFiles
-rw-r--r-- 1 jovyan users 3.3K May 12 21:16  CTestTestfile.cmake
-rwxr-xr-x 1 jovyan users 440M May 12 21:18  Dialect
-rw-r--r-- 1 jovyan users  387 May 12 21:16 'Dialect[1]_include.cmake'
-rw-r--r-- 1 jovyan users  18K May 12 21:18 'Dialect[1]_tests.cmake'
-rwxr-xr-x 1 jovyan users 438M May 12 21:18  DumpLayoutTest
-rw-r--r-- 1 jovyan users  415 May 12 21:16 'DumpLayoutTest[1]_include.cmake'
-rw-r--r-- 1 jovyan users 2.3K May 12 21:18 'DumpLayoutTest[1]_tests.cmake'
-rwxr-xr-x 1 jovyan users 446M May 12 21:18  LinearLayoutConversions
-rw-r--r-- 1 jovyan users  451 May 12 21:16 'LinearLayoutConversions[1]_include.cmake'
-rw-r--r-- 1 jovyan users  60K May 12 21:18 'LinearLayoutConversions[1]_tests.cmake'
-rwxr-xr-x 1 jovyan users 439M May 12 21:18  TestSwizzling
-rw-r--r-- 1 jovyan users  411 May 12 21:16 'TestSwizzling[1]_include.cmake'
-rw-r--r-- 1 jovyan users 8.6K May 12 21:18 'TestSwizzling[1]_tests.cmake'
-rw-r--r-- 1 jovyan users 1.7K May 12 21:16  cmake_install.cmake
```

New:
```bash
ls build/cmake.linux-x86_64-cpython-3.10/unittest/Dialect/TritonGPU/ -lh
total 853M
drwxr-sr-x 6 jovyan users 4.0K May 11 13:29  CMakeFiles
-rw-r--r-- 1 jovyan users 3.3K May 12 21:39  CTestTestfile.cmake
-rwxr-xr-x 1 jovyan users 217M May 12 21:39  Dialect
-rw-r--r-- 1 jovyan users  387 May 12 21:39 'Dialect[1]_include.cmake'
-rw-r--r-- 1 jovyan users  18K May 12 21:39 'Dialect[1]_tests.cmake'
-rwxr-xr-x 1 jovyan users 210M May 12 21:39  DumpLayoutTest
-rw-r--r-- 1 jovyan users  415 May 12 21:39 'DumpLayoutTest[1]_include.cmake'
-rw-r--r-- 1 jovyan users 2.3K May 12 21:39 'DumpLayoutTest[1]_tests.cmake'
-rwxr-xr-x 1 jovyan users 217M May 12 21:39  LinearLayoutConversions
-rw-r--r-- 1 jovyan users  451 May 12 21:39 'LinearLayoutConversions[1]_include.cmake'
-rw-r--r-- 1 jovyan users  60K May 12 21:39 'LinearLayoutConversions[1]_tests.cmake'
-rwxr-xr-x 1 jovyan users 210M May 12 21:39  TestSwizzling
-rw-r--r-- 1 jovyan users  411 May 12 21:39 'TestSwizzling[1]_include.cmake'
-rw-r--r-- 1 jovyan users 8.6K May 12 21:39 'TestSwizzling[1]_tests.cmake'
-rw-r--r-- 1 jovyan users 1.7K May 12 21:39  cmake_install.cmake

```