### PR TITLE
[Warp Specialization] Allow worker partitions to steal registers from the default partition

### DIFF
--- a/test/Conversion/allocate_warp_groups.mlir
+++ b/test/Conversion/allocate_warp_groups.mlir
@@ -92,3 +92,22 @@ tt.func @setmaxnreg() {
 }
 
 }
+
+// -----
+
+// CHECK: module attributes {ttg.maxnreg = 128 : i32
+module attributes {"ttg.num-warps" = 8 : i32} {
+
+tt.func @steal_from_default() {
+  // CHECK: actualRegisters = array<i32: 64, 192>
+  ttg.warp_specialize() attributes {requestedRegisters = array<i32: 192>}
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(8) {
+    ttg.warp_return
+  } : () -> ()
+  tt.return
+}
+
+}


### PR DESCRIPTION
Previously, register reallocation occurs only if the worker partitions have a positive register deficiency, which redistributes the extra registers to the default partition. This PR enables worker partitions to steal from the default partition, which enables, for example, two softmax partitions to go up to 192 registers by stealing from the default partition.