### PR TITLE
[Warp Specialization] Add support for tensor captures into partitioned loops

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -106,7 +106,7 @@ Value createScalarAlloc(ImplicitLocOpBuilder &rewriter, Type type,
 Value createBarrierAlloc(scf::ForOp forOp, int numBarriers,
                          int arriveCount = 1);
 // Create an allocation that can hold distance number of tensor shapes.
-Value createAlloc(scf::ForOp forOp, RankedTensorType ty, Location loc,
+Value createAlloc(Operation *scope, RankedTensorType ty, Location loc,
                   gpu::SharedEncodingTrait sharedEnc, unsigned distance);
 
 // Determine if the operation is a TMA load.

--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -20,6 +20,7 @@ static const char *kLoopStageAttrName = "loop.stage";
 static const char *kLoopClusterAttrName = "loop.cluster";
 static const char *kScheduledMaxStageAttrName = "tt.scheduled_max_stage";
 static const char *kAssignedStageAttrName = "ttg.assigned_stage";
+static const char *kAssignedClusterAttrName = "ttg.assigned_cluster";
 
 //===----------------------------------------------------------------------===//
 // Hoisting Utilities

--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -107,7 +107,7 @@ Value createScalarAlloc(ImplicitLocOpBuilder &rewriter, Type type,
 Value createBarrierAlloc(scf::ForOp forOp, int numBarriers,
                          int arriveCount = 1);
 // Create an allocation that can hold distance number of tensor shapes.
-Value createAlloc(Operation *scope, RankedTensorType ty, Location loc,
+Value createAlloc(Operation *insertBefore, RankedTensorType ty, Location loc,
                   gpu::SharedEncodingTrait sharedEnc, unsigned distance);
 
 // Determine if the operation is a TMA load.

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -380,13 +380,13 @@ Value mlir::triton::createBarrierAlloc(scf::ForOp forOp, int numBarriers,
   return barrierAlloc;
 }
 
-Value mlir::triton::createAlloc(scf::ForOp forOp, RankedTensorType ty,
+Value mlir::triton::createAlloc(Operation *scope, RankedTensorType ty,
                                 Location loc,
                                 gpu::SharedEncodingTrait sharedEnc,
                                 unsigned distance) {
-  OpBuilder builder(forOp);
+  OpBuilder builder(scope);
   Attribute sharedMemorySpace =
-      ttg::SharedMemorySpaceAttr::get(forOp.getContext());
+      ttg::SharedMemorySpaceAttr::get(scope->getContext());
   SmallVector<int64_t> bufferShape(ty.getShape().begin(), ty.getShape().end());
   bufferShape.insert(bufferShape.begin(), distance);
   Type memdescType = ttg::MemDescType::get(bufferShape, ty.getElementType(),
@@ -394,8 +394,8 @@ Value mlir::triton::createAlloc(scf::ForOp forOp, RankedTensorType ty,
                                            /*mutableMemory=*/true);
   Value alloc = builder.create<ttg::LocalAllocOp>(loc, memdescType);
 
-  builder.setInsertionPointAfter(forOp);
-  builder.create<ttg::LocalDeallocOp>(forOp.getLoc(), alloc);
+  builder.setInsertionPointAfter(scope);
+  builder.create<ttg::LocalDeallocOp>(scope->getLoc(), alloc);
   return alloc;
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -380,13 +380,13 @@ Value mlir::triton::createBarrierAlloc(scf::ForOp forOp, int numBarriers,
   return barrierAlloc;
 }
 
-Value mlir::triton::createAlloc(Operation *scope, RankedTensorType ty,
+Value mlir::triton::createAlloc(Operation *insertBefore, RankedTensorType ty,
                                 Location loc,
                                 gpu::SharedEncodingTrait sharedEnc,
                                 unsigned distance) {
-  OpBuilder builder(scope);
+  OpBuilder builder(insertBefore);
   Attribute sharedMemorySpace =
-      ttg::SharedMemorySpaceAttr::get(scope->getContext());
+      ttg::SharedMemorySpaceAttr::get(insertBefore->getContext());
   SmallVector<int64_t> bufferShape(ty.getShape().begin(), ty.getShape().end());
   bufferShape.insert(bufferShape.begin(), distance);
   Type memdescType = ttg::MemDescType::get(bufferShape, ty.getElementType(),
@@ -394,8 +394,8 @@ Value mlir::triton::createAlloc(Operation *scope, RankedTensorType ty,
                                            /*mutableMemory=*/true);
   Value alloc = builder.create<ttg::LocalAllocOp>(loc, memdescType);
 
-  builder.setInsertionPointAfter(scope);
-  builder.create<ttg::LocalDeallocOp>(scope->getLoc(), alloc);
+  builder.setInsertionPointAfter(insertBefore);
+  builder.create<ttg::LocalDeallocOp>(insertBefore->getLoc(), alloc);
   return alloc;
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -190,26 +190,6 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
   SetVector<Value> captures;
   getUsedValuesDefinedAbove(wsOp.getPartitionOpHolder(), captures);
 
-  // Deal with tensor captures by passing them over shared memory.
-  for (Value capture : captures) {
-    auto tensorTy = dyn_cast<RankedTensorType>(capture.getType());
-    if (!tensorTy)
-      continue;
-    SharedEncodingTrait sharedEnc = getSharedEncoding(tensorTy);
-    ImplicitLocOpBuilder b(capture.getLoc(), wsOp);
-    auto memdescTy = MemDescType::get(
-        tensorTy.getShape(), tensorTy.getElementType(), sharedEnc,
-        SharedMemorySpaceAttr::get(tensorTy.getContext()));
-    auto alloc = b.create<LocalAllocOp>(memdescTy, capture);
-    for (Region *region : wsOp.getPartitionRegions()) {
-      b.setInsertionPointToStart(&region->front());
-      Value value = b.create<LocalLoadOp>(tensorTy, alloc);
-      replaceAllUsesInRegionWith(capture, value, *region);
-    }
-  }
-  captures.clear();
-  getUsedValuesDefinedAbove(wsOp.getPartitionOpHolder(), captures);
-
   // Find the subgraph that should be cloned into the partition regions. The
   // explicit captures are the leaves of the subgraph.
   SetVector<Operation *> opsToClone;
@@ -228,11 +208,23 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
       continue;
     }
 
-    if (isa<RankedTensorType>(capture.getType())) {
-      return mlir::emitWarning(capture.getLoc(),
-                               "FIXME: capturing tensor values into warp "
-                               "partitions is not supported");
+    // Explicitly pass tensor captures through shared memory.
+    auto tensorTy = dyn_cast<RankedTensorType>(capture.getType());
+    if (tensorTy) {
+      SharedEncodingTrait sharedEnc = getSharedEncoding(tensorTy);
+      ImplicitLocOpBuilder b(capture.getLoc(), wsOp);
+      auto memdescTy = MemDescType::get(
+          tensorTy.getShape(), tensorTy.getElementType(), sharedEnc,
+          SharedMemorySpaceAttr::get(tensorTy.getContext()));
+      auto alloc = b.create<LocalAllocOp>(memdescTy, capture);
+      for (Region *region : wsOp.getPartitionRegions()) {
+        b.setInsertionPointToStart(&region->front());
+        Value value = b.create<LocalLoadOp>(tensorTy, alloc);
+        replaceAllUsesInRegionWith(capture, value, *region);
+      }
+      capture = alloc;
     }
+
     explicitCaptures.push_back(capture);
   }
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -190,6 +190,26 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
   SetVector<Value> captures;
   getUsedValuesDefinedAbove(wsOp.getPartitionOpHolder(), captures);
 
+  // Deal with tensor captures by passing them over shared memory.
+  for (Value capture : captures) {
+    auto tensorTy = dyn_cast<RankedTensorType>(capture.getType());
+    if (!tensorTy)
+      continue;
+    SharedEncodingTrait sharedEnc = getSharedEncoding(tensorTy);
+    ImplicitLocOpBuilder b(capture.getLoc(), wsOp);
+    auto memdescTy = MemDescType::get(
+        tensorTy.getShape(), tensorTy.getElementType(), sharedEnc,
+        SharedMemorySpaceAttr::get(tensorTy.getContext()));
+    auto alloc = b.create<LocalAllocOp>(memdescTy, capture);
+    for (Region *region : wsOp.getPartitionRegions()) {
+      b.setInsertionPointToStart(&region->front());
+      Value value = b.create<LocalLoadOp>(tensorTy, alloc);
+      replaceAllUsesInRegionWith(capture, value, *region);
+    }
+  }
+  captures.clear();
+  getUsedValuesDefinedAbove(wsOp.getPartitionOpHolder(), captures);
+
   // Find the subgraph that should be cloned into the partition regions. The
   // explicit captures are the leaves of the subgraph.
   SetVector<Operation *> opsToClone;


### PR DESCRIPTION
This is to support forward attention when the row maxes for each subtile need to be passed from the first pair of softmax partitions to the second pair.