### PR TITLE
[TritonNvidiaGPU] Tighten WGMMA verifier; improve FenceInsertion

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -72,32 +72,40 @@ def TTNG_ClusterWaitOp : TTNG_Op<"cluster_wait", []> {
 //
 // WarpGroupDot Op
 //
-def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [DeclareOpInterfaceMethods<InferTypeOpInterface>,
-                                                     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                                                     DeclareOpInterfaceMethods<DotOpInterface>,
-                                                     TypesMatchWith<"result's type matches accumulator's type",
-                                                                     "d", "c", "$_self">]> {
-    let summary = "warp group dot";
+def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [
+  DeclareOpInterfaceMethods<InferTypeOpInterface>,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+  DeclareOpInterfaceMethods<DotOpInterface>,
+  TypesMatchWith<"result's type matches accumulator's type", "d", "c", "$_self">
+]> {
+  let summary = "warp group dot";
 
-    let description = [{
-        $d = matrix_multiply($a, $b) + $c. For docs on InputPrecisionAttr, see TT_DotOp
-    }];
+  let description = [{
+    $d = matrix_multiply($a, $b) + $c. For docs on InputPrecisionAttr, see TT_DotOp
+  }];
 
-    let arguments = (ins TTG_TensorOrMemDesc:$a,
-                         TTG_TensorOrMemDesc:$b,
-                         TT_FpIntTensor:$c,
-                         Optional<I1>:$useC,
-                         DefaultValuedAttr<TT_InputPrecisionAttr, "::mlir::triton::InputPrecision::IEEE">:$inputPrecision,
-                         DefaultValuedAttr<I32Attr, "0">:$maxNumImpreciseAcc,
-                         DefaultValuedAttr<BoolAttr, "false">:$isAsync);
+  let arguments = (ins
+    TTG_TensorOrMemDesc:$a,
+    TTG_TensorOrMemDesc:$b,
+    TT_FpIntTensor:$c,
+    Optional<I1>:$useC,
+    DefaultValuedAttr<TT_InputPrecisionAttr, "::mlir::triton::InputPrecision::IEEE">:$inputPrecision,
+    DefaultValuedAttr<I32Attr, "0">:$maxNumImpreciseAcc,
+    DefaultValuedAttr<BoolAttr, "false">:$isAsync
+  );
 
-    let results = (outs TT_FpIntTensor:$d);
+  let results = (outs TT_FpIntTensor:$d);
 
-    let assemblyFormat = "$a`,` $b`,` $c (`,` $useC^)? attr-dict `:` type($a) `*` type($b) `->` type($d)";
+  let assemblyFormat = [{
+    $a`,` $b`,` $c (`,` $useC^)? attr-dict
+    `:` type($a) `*` type($b) `->` type($d)
+  }];
 
-    let extraClassDeclaration = [{
-      bool needsPartialAccumulator();
-    }];
+  let extraClassDeclaration = [{
+    bool needsPartialAccumulator();
+  }];
+
+  let hasVerifier = 1;
 }
 
 def TTNG_WarpGroupDotWaitOp : TTNG_Op<"warp_group_dot_wait", [DeclareOpInterfaceMethods<InferTypeOpInterface>,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -48,8 +48,8 @@ public:
         return WalkResult::advance();
 
       OpBuilder builder(dotOp);
-      Operation *fence = builder.create<ttng::FenceAsyncSharedOp>(
-          dotOp.getLoc(), /*bCluster=*/false);
+      auto fence = builder.create<ttng::FenceAsyncSharedOp>(dotOp.getLoc(),
+                                                            /*bCluster=*/false);
       // If there is all the dependencies are outside of the loop try to hoist
       // the fence.
       while (auto loopOp = fence->getParentOfType<LoopLikeOpInterface>()) {
@@ -61,6 +61,14 @@ public:
           break;
         loopOp.moveOutOfLoop(fence);
       }
+
+      // If the previous op is already a fence, this one isn't needed.
+      if (auto lastFence = dyn_cast_or_null<ttng::FenceAsyncSharedOp>(
+              fence->getPrevNode())) {
+        if (lastFence.getBCluster() == fence.getBCluster())
+          fence.erase();
+      }
+
       return WalkResult::advance();
     });
   }
@@ -80,6 +88,7 @@ private:
     visited.insert(operand);
     if (!isa<triton::gpu::MemDescType>(operand.getType()))
       return false;
+
     auto op = operand.getDefiningOp();
     if (op) {
       // reach an alloc copying from register, we need a fence.
@@ -92,26 +101,30 @@ private:
       }
       return false;
     }
+
     // reach BlockArgument
     BlockArgument arg = cast<BlockArgument>(operand);
     unsigned argNum = arg.getArgNumber();
     Operation *argOwner = arg.getOwner()->getParentOp();
-    // support ForOp only
+    // look through ForOp iter argument
     if (auto forOp = dyn_cast<scf::ForOp>(argOwner)) {
+      assert(argNum != 0 && "induction var cannot be memdesc type");
+      --argNum;
       // prologue
-      auto iterOperands = forOp.getInitArgs();
-      if (argNum == 0)
-        return false;
-      if (dependOnCopyRegToShared(iterOperands[argNum - 1], visited))
+      if (dependOnCopyRegToShared(forOp.getInitArgs()[argNum], visited))
         return true;
       // yield
       auto yieldOp = forOp.getBody()->getTerminator();
-      Value v = yieldOp->getOperand(argNum - 1);
-      auto entry = std::make_pair<Operation *, unsigned>(std::move(yieldOp),
-                                                         std::move(argNum));
-      if (dependOnCopyRegToShared(v, visited))
-        return true;
+      Value v = yieldOp->getOperand(argNum);
+      return dependOnCopyRegToShared(v, visited);
     }
+
+    // look through `ttg.warp_specialize`.
+    if (auto wsOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(argOwner)) {
+      return dependOnCopyRegToShared(
+          wsOp.getParentOp().getExplicitCaptures()[argNum]);
+    }
+
     // Conservatively return true for other ops
     return true;
   }


### PR DESCRIPTION
* verify that WarpGroupDotOp's result encoding is always NVMMA Hopper encoding
* clean up some code with this
* teach FenceInsertion to look through WarpSpecializeOp
* deduplicate fences (e.g. two dots in a loop with captured reg->shared operands)