### PR TITLE
[Release-only] Bump version to 3.3.1 release, turn off publishing to pypi until we needed

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -90,7 +90,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Upload wheels to PyPI
-        if: ${{ matrix.config.arch == 'x86_64' }}
+        if: false
         run: |
           python3 -m pip install twine --upgrade --user
           python3 -m twine upload wheelhouse/* -u __token__ -p ${{ secrets.PYPY_API_TOKEN }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,7 @@ extensions = [
 autosummary_generate = True
 
 # versioning config
-smv_tag_whitelist = r'^(v3.2.0)$'
+smv_tag_whitelist = r'^(v3.3.1)$'
 smv_branch_whitelist = r'^main$'
 smv_remote_whitelist = None
 smv_released_pattern = r'^tags/.*$'

--- a/python/setup.py
+++ b/python/setup.py
@@ -748,7 +748,7 @@ def get_git_version_suffix():
 
 setup(
     name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
-    version="3.3.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
+    version="3.3.1" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = '3.3.0'
+__version__ = '3.3.1'
 
 # ---------------------------------------
 # Note: import order is significant here.


### PR DESCRIPTION
- Bump version to 3.3.1. 
- Disable publishing to pypi step. so that we don't release it untill we are ready