### PR TITLE
[Blackwell] Subtile TMEM stores and improve TMEM interleaving

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -29,6 +29,7 @@ include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "triton/Dialect/Triton/IR/TritonAttrDefs.td"
 include "triton/Dialect/Triton/IR/TritonInterfaces.td"
 include "triton/Dialect/Triton/IR/TritonOpInterfaces.td"
+include "triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypes.td"
 include "triton/Dialect/TritonGPU/IR/TritonGPUTypeInterfaces.td"
 include "mlir/IR/OpBase.td"
@@ -583,6 +584,12 @@ def TTNG_TMEMStoreOp : TTNG_Op<"tmem_store"> {
     I1:$pred
   );
   let results = (outs Optional<TTG_AsyncToken>:$token);
+
+  let builders = [
+    OpBuilder<(ins "Value":$dst, "Value":$src, "Value":$pred), [{
+      build($_builder, $_state, Type(), dst, Value(), src, pred);
+    }]>
+  ];
 
   let assemblyFormat = [{
     $src `,` $dst `` custom<Token>($dep, type($token)) `,` $pred

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h
@@ -64,6 +64,8 @@ std::unique_ptr<Pass> createTritonNvidiaGPUOptimizeDescriptorEncodingPass();
 
 std::unique_ptr<Pass> createTritonNvidiaGPUOptimizeTMemLayoutsPass();
 
+std::unique_ptr<Pass> createTritonNvidiaGPUInterleaveTMemPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #define GEN_PASS_DECL_TRITONNVIDIAGPULEGALIZETMALAYOUTS

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -143,6 +143,16 @@ def TritonNvidiaGPUOptimizeTMemLayoutsPass : Pass<"triton-nvidia-optimize-tmem-l
                            "mlir::triton::TritonDialect"];
 }
 
+def TritonNvidiaGPUInterleaveTMemPass : Pass<"triton-nvidia-interleave-tmem", "mlir::ModuleOp"> {
+  let summary = "Interleave TMEM loads/stores.";
+
+  let description = [{
+    The `triton-nvidia-interleave-tmem` pass attempts to sink TMEM loads and
+    hoist TMEM stores, and potentially interleave them, to reduce register
+    pressure.
+  }];
+}
+
 def TritonNvidiaGPURemoveTMEMTokensPass : Pass<"triton-nvidia-gpu-remove-tmem-tokens", "mlir::ModuleOp"> {
   let summary = "remove TMEM tokens";
 

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -445,9 +445,17 @@ MemDescTransOp::inferReturnTypes(MLIRContext *context,
 // MemDescReshapeOp
 
 LogicalResult MemDescReshapeOp::verify() {
-  // Infer the dst layout from the source and verify that it is equivalent.
   MemDescType dstType = getResult().getType();
   MemDescType srcType = getSrc().getType();
+  if (product(dstType.getShape()) != product(srcType.getShape())) {
+    return emitError(
+        "number of src and dst elements of reshape must be the same");
+  }
+  if (dstType.getElementType() != srcType.getElementType()) {
+    return emitError("result element type must match src element type");
+  }
+
+  // Infer the dst layout from the source and verify that it is equivalent.
   auto srcEncoding = srcType.getEncoding();
   Attribute inferedDstEncoding;
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_triton_library(TritonNvidiaGPUTransforms
   FenceInsertion.cpp
+  InterleaveTMem.cpp
   MMALowering.cpp
   OptimizeDescriptorEncoding.cpp
   OptimizeTMemLayouts.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -241,6 +241,7 @@ struct TritonNvidiaGPUInterleaveTMemPass
     m.walk([&](ttng::TMEMLoadOp load) { loads.push_back(load); });
     for (ttng::TMEMLoadOp load : loads) {
       while (trySinkLoad(load)) {
+        // Keep trying to sink loads and their users.
       }
     }
   }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -1,0 +1,260 @@
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+#include "llvm/ADT/AddressRanges.h"
+
+namespace {
+
+using namespace mlir;
+
+namespace ttng = triton::nvidia_gpu;
+namespace ttg = triton::gpu;
+namespace tt = triton;
+
+#define GEN_PASS_CLASSES
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+// If we don't know the effects of the op, we add all possible effects.
+void addAllValuelessEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Read>());
+  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Write>());
+  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Allocate>());
+  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Free>());
+}
+
+bool collectEffects(Operation *op,
+                    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  // Collect effect instances the operation. Note that the implementation of
+  // getEffects erases all effect instances that have the type other than the
+  // template parameter so we collect them first in a local buffer and then
+  // copy.
+  if (auto iface = dyn_cast<MemoryEffectOpInterface>(op)) {
+    SmallVector<MemoryEffects::EffectInstance> localEffects;
+    iface.getEffects(localEffects);
+    llvm::append_range(effects, localEffects);
+    return true;
+  }
+  if (op->hasTrait<OpTrait::HasRecursiveMemoryEffects>()) {
+    for (auto &region : op->getRegions()) {
+      for (auto &block : region) {
+        for (auto &innerOp : block)
+          if (!collectEffects(&innerOp, effects))
+            return false;
+      }
+    }
+    return true;
+  }
+
+  // We need to be conservative here in case the op doesn't have the interface
+  // and assume it can have any possible effect.
+  addAllValuelessEffects(effects);
+  return false;
+}
+
+struct AccessRange {
+  SmallVector<std::optional<llvm::AddressRange>> ranges;
+  unsigned rankOffset = 0;
+};
+
+// Simple local alias analysis that looks for a single underlying allocation and
+// an access subrange.
+std::pair<Value, AccessRange> findBufferAccess(Value a) {
+  // Handle block arguments.
+  if (auto arg = dyn_cast<BlockArgument>(a)) {
+    Operation *parentOp = arg.getOwner()->getParentOp();
+
+    // Look through `ttg.warp_specialize` explicit captures.
+    if (auto wsOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(parentOp)) {
+      return findBufferAccess(
+          wsOp.getParentOp().getExplicitCaptures()[arg.getArgNumber()]);
+    }
+
+    // Unknown block argument.
+    return {};
+  }
+
+  Operation *defOp = a.getDefiningOp();
+  // Accessing the alloc accesses the whole buffer.
+  if (auto alloc = dyn_cast<ttng::TMEMAllocOp>(defOp)) {
+    AccessRange access;
+    for (uint64_t dim : alloc.getType().getShape())
+      access.ranges.push_back({{0, dim}});
+    return {a, std::move(access)};
+  }
+
+  // Trans and Reshape views don't change the access size.
+  if (isa<ttg::MemDescTransOp, ttg::MemDescReshapeOp>(defOp)) {
+    return findBufferAccess(defOp->getOperand(0));
+  }
+
+  // Subviews can reduce the access sizes.
+  if (auto subview = dyn_cast<ttg::MemDescSubviewOp>(defOp)) {
+    auto [alloc, parentAccess] = findBufferAccess(subview.getSrc());
+    if (!alloc)
+      return {};
+    // Handle subview of a subview. The first `rankOffset` access sizes are
+    // the same as in the parent access.
+    AccessRange childAccess;
+    for (auto i : llvm::seq(parentAccess.rankOffset))
+      childAccess.ranges.push_back(parentAccess.ranges[i]);
+
+    // The subview may have a smaller rank, in which case its access size is
+    // just 1 for the higher dims.
+    childAccess.rankOffset =
+        subview.getSrc().getType().getRank() - subview.getType().getRank();
+    for (auto [i, offset] : llvm::enumerate(subview.getOffsets())) {
+      auto parentRange = parentAccess.ranges[i + parentAccess.rankOffset];
+      if (!parentRange) {
+        childAccess.ranges.push_back({});
+        continue;
+      }
+
+      // If the offset is not known, then the entire dim may be accessed.
+      APInt value;
+      if (!matchPattern(offset, m_ConstantInt(&value))) {
+        childAccess.ranges.push_back({});
+        continue;
+      }
+
+      uint64_t accessStart = parentRange->start() + value.getSExtValue();
+      uint64_t accessSize = 1;
+      if (i >= childAccess.rankOffset)
+        accessSize = subview.getType().getShape()[i - childAccess.rankOffset];
+      childAccess.ranges.push_back({{accessStart, accessStart + accessSize}});
+    }
+    return {alloc, std::move(childAccess)};
+  }
+
+  // Subslice is a subview only on the N dimension.
+  if (auto subslice = dyn_cast<ttng::TMEMSubSliceOp>(defOp)) {
+    auto [alloc, parentAccess] = findBufferAccess(subslice.getSrc());
+    if (!alloc)
+      return {};
+    if (!parentAccess.ranges[1])
+      return {alloc, parentAccess};
+    uint64_t mStart = parentAccess.ranges[1]->start() + subslice.getN();
+    uint64_t mSize = subslice.getType().getShape()[1];
+    AccessRange childAccess = parentAccess;
+    childAccess.ranges[1] = {{mStart, mStart + mSize}};
+    return {alloc, std::move(childAccess)};
+  }
+
+  // Unknown defining op.
+  return {};
+}
+
+bool tmemMayAlias(Value a, Value b) {
+  auto [aAlloc, aRanges] = findBufferAccess(a);
+  auto [bAlloc, bRanges] = findBufferAccess(b);
+  // If the underlying buffer was not identified, assume mayalias.
+  if (!aAlloc || !bAlloc)
+    return true;
+  // If the buffers are different, they don't alias.
+  if (aAlloc != bAlloc)
+    return false;
+  // If the access ranges along any dimension are known to not overlap, then the
+  // accesses don't alias.
+  for (auto [aRange, bRange] : llvm::zip(aRanges.ranges, bRanges.ranges)) {
+    // If either access range at this dim is unknown, we can't determine if they
+    // don't overlap.
+    if (!aRange || !bRange)
+      continue;
+    // The access ranges are known and don't overlap.
+    if (!aRange->intersects(*bRange))
+      return false;
+  }
+  return true;
+}
+
+// Sink tmem_loads as close to their use as possible to reduce register
+// pressure.
+bool sinkLoad(ttng::TMEMLoadOp load, ArrayRef<Operation *> useChain) {
+  Operation *insertBefore = nullptr;
+  Operation *next = useChain.back()->getNextNode();
+  while (next && !next->hasTrait<OpTrait::IsTerminator>()) {
+    insertBefore = next;
+    bool dep = false;
+    for (auto operand : getNestedOperands(next)) {
+      if (llvm::any_of(useChain, [&](Operation *op) {
+            return llvm::is_contained(op->getResults(), operand);
+          })) {
+        dep = true;
+        break;
+      }
+    }
+    if (isa<ttng::ArriveBarrierOp>(next))
+      break;
+    if (!isMemoryEffectFree(next)) {
+      SmallVector<MemoryEffects::EffectInstance> effects;
+      collectEffects(next, effects);
+      for (auto effect : effects) {
+        // Look for potentially aliasing write or free effects.
+        if (!isa<MemoryEffects::Write, MemoryEffects::Free>(effect.getEffect()))
+          continue;
+        if (isa<SideEffects::DefaultResource>(effect.getResource())) {
+          dep = true;
+          break;
+        }
+        if (isa<ttng::TensorMemory>(effect.getResource()) &&
+            (!effect.getValue() ||
+             tmemMayAlias(effect.getValue(), load.getSrc()))) {
+          dep = true;
+          break;
+        }
+      }
+    }
+    if (dep)
+      break;
+    next = next->getNextNode();
+  }
+  if (insertBefore && insertBefore != useChain.back()->getNextNode()) {
+    for (Operation *op : useChain)
+      op->moveBefore(insertBefore);
+    return true;
+  }
+  return false;
+}
+
+struct SinkLoadPattern : public OpRewritePattern<ttng::TMEMLoadOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttng::TMEMLoadOp load,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<Operation *> useChain{load};
+    while (useChain.back()->hasOneUse() &&
+           isPure(*useChain.back()->user_begin()) &&
+           useChain.back()->getNextNode() == *useChain.back()->user_begin()) {
+      useChain.push_back(*useChain.back()->user_begin());
+    }
+    if (sinkLoad(load, useChain))
+      return success();
+    return failure();
+  }
+};
+
+struct TritonNvidiaGPUInterleaveTMemPass
+    : public TritonNvidiaGPUInterleaveTMemPassBase<
+          TritonNvidiaGPUInterleaveTMemPass> {
+  using TritonNvidiaGPUInterleaveTMemPassBase::
+      TritonNvidiaGPUInterleaveTMemPassBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp m = getOperation();
+
+    mlir::RewritePatternSet patterns(context);
+    patterns.add<SinkLoadPattern>(context);
+    GreedyRewriteConfig config;
+    config.setMaxIterations(1024);
+    if (failed(applyPatternsGreedily(m, std::move(patterns), config)))
+      llvm::report_fatal_error("InterleaveTMem pass failed to converge");
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createTritonNvidiaGPUInterleaveTMemPass() {
+  return std::make_unique<TritonNvidiaGPUInterleaveTMemPass>();
+}

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -217,22 +217,16 @@ bool sinkLoad(ttng::TMEMLoadOp load, ArrayRef<Operation *> useChain) {
   return false;
 }
 
-struct SinkLoadPattern : public OpRewritePattern<ttng::TMEMLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ttng::TMEMLoadOp load,
-                                PatternRewriter &rewriter) const override {
-    SmallVector<Operation *> useChain{load};
-    while (useChain.back()->hasOneUse() &&
-           isPure(*useChain.back()->user_begin()) &&
-           useChain.back()->getNextNode() == *useChain.back()->user_begin()) {
-      useChain.push_back(*useChain.back()->user_begin());
-    }
-    if (sinkLoad(load, useChain))
-      return success();
-    return failure();
+// Try to sink a load and a collection of its users.
+bool trySinkLoad(ttng::TMEMLoadOp load) {
+  SmallVector<Operation *> useChain{load};
+  while (useChain.back()->hasOneUse() &&
+         isPure(*useChain.back()->user_begin()) &&
+         useChain.back()->getNextNode() == *useChain.back()->user_begin()) {
+    useChain.push_back(*useChain.back()->user_begin());
   }
-};
+  return sinkLoad(load, useChain);
+}
 
 struct TritonNvidiaGPUInterleaveTMemPass
     : public TritonNvidiaGPUInterleaveTMemPassBase<
@@ -243,13 +237,12 @@ struct TritonNvidiaGPUInterleaveTMemPass
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
-
-    mlir::RewritePatternSet patterns(context);
-    patterns.add<SinkLoadPattern>(context);
-    GreedyRewriteConfig config;
-    config.setMaxIterations(1024);
-    if (failed(applyPatternsGreedily(m, std::move(patterns), config)))
-      llvm::report_fatal_error("InterleaveTMem pass failed to converge");
+    SmallVector<ttng::TMEMLoadOp> loads;
+    m.walk([&](ttng::TMEMLoadOp load) { loads.push_back(load); });
+    for (ttng::TMEMLoadOp load : loads) {
+      while (trySinkLoad(load)) {
+      }
+    }
   }
 };
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
@@ -1,18 +1,13 @@
 #include "mlir/Analysis/SliceAnalysis.h"
-#include "mlir/IR/TypeUtilities.h"
-#include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
-#include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
-#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
-#include "llvm/ADT/AddressRanges.h"
 
 namespace {
 
@@ -24,247 +19,6 @@ namespace tt = triton;
 
 #define GEN_PASS_CLASSES
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
-
-// If we don't know the effects of the op, we add all possible effects.
-static void addAllValuelessEffects(
-    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Read>());
-  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Write>());
-  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Allocate>());
-  effects.emplace_back(MemoryEffects::Effect::get<MemoryEffects::Free>());
-}
-
-static bool
-collectEffects(Operation *op,
-               SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  // Collect effect instances the operation. Note that the implementation of
-  // getEffects erases all effect instances that have the type other than the
-  // template parameter so we collect them first in a local buffer and then
-  // copy.
-  if (auto iface = dyn_cast<MemoryEffectOpInterface>(op)) {
-    SmallVector<MemoryEffects::EffectInstance> localEffects;
-    iface.getEffects(localEffects);
-    llvm::append_range(effects, localEffects);
-    return true;
-  }
-  if (op->hasTrait<OpTrait::HasRecursiveMemoryEffects>()) {
-    for (auto &region : op->getRegions()) {
-      for (auto &block : region) {
-        for (auto &innerOp : block)
-          if (!collectEffects(&innerOp, effects))
-            return false;
-      }
-    }
-    return true;
-  }
-
-  // We need to be conservative here in case the op doesn't have the interface
-  // and assume it can have any possible effect.
-  addAllValuelessEffects(effects);
-  return false;
-}
-
-struct AccessRange {
-  SmallVector<std::optional<llvm::AddressRange>> ranges;
-  unsigned rankOffset = 0;
-};
-
-// Simple local alias analysis that looks for a single underlying allocation and
-// an access subrange.
-static std::pair<Value, AccessRange> findBufferAccess(Value a) {
-  // Handle block arguments.
-  if (auto arg = dyn_cast<BlockArgument>(a)) {
-    Operation *parentOp = arg.getOwner()->getParentOp();
-
-    // Look through `ttg.warp_specialize` explicit captures.
-    if (auto wsOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(parentOp)) {
-      return findBufferAccess(
-          wsOp.getParentOp().getExplicitCaptures()[arg.getArgNumber()]);
-    }
-
-    // Unknown block argument.
-    return {};
-  }
-
-  Operation *defOp = a.getDefiningOp();
-  // Accessing the alloc accesses the whole buffer.
-  if (auto alloc = dyn_cast<ttng::TMEMAllocOp>(defOp)) {
-    AccessRange access;
-    for (uint64_t dim : alloc.getType().getShape())
-      access.ranges.push_back({{0, dim}});
-    return {a, std::move(access)};
-  }
-
-  // Trans and Reshape views don't change the access size.
-  if (isa<ttg::MemDescTransOp, ttg::MemDescReshapeOp>(defOp)) {
-    return findBufferAccess(defOp->getOperand(0));
-  }
-
-  // Subviews can reduce the access sizes.
-  if (auto subview = dyn_cast<ttg::MemDescSubviewOp>(defOp)) {
-    auto [alloc, parentAccess] = findBufferAccess(subview.getSrc());
-    if (!alloc)
-      return {};
-    // Handle subview of a subview. The first `rankOffset` access sizes are
-    // the same as in the parent access.
-    AccessRange childAccess;
-    for (auto i : llvm::seq(parentAccess.rankOffset))
-      childAccess.ranges.push_back(parentAccess.ranges[i]);
-
-    // The subview may have a smaller rank, in which case its access size is
-    // just 1 for the higher dims.
-    childAccess.rankOffset =
-        subview.getSrc().getType().getRank() - subview.getType().getRank();
-    for (auto [i, offset] : llvm::enumerate(subview.getOffsets())) {
-      auto parentRange = parentAccess.ranges[i + parentAccess.rankOffset];
-      if (!parentRange) {
-        childAccess.ranges.push_back({});
-        continue;
-      }
-
-      // If the offset is not known, then the entire dim may be accessed.
-      APInt value;
-      if (!matchPattern(offset, m_ConstantInt(&value))) {
-        childAccess.ranges.push_back({});
-        continue;
-      }
-
-      uint64_t accessStart = parentRange->start() + value.getSExtValue();
-      uint64_t accessSize = 1;
-      if (i >= childAccess.rankOffset)
-        accessSize = subview.getType().getShape()[i - childAccess.rankOffset];
-      childAccess.ranges.push_back({{accessStart, accessStart + accessSize}});
-    }
-    return {alloc, std::move(childAccess)};
-  }
-
-  // Subslice is a subview only on the N dimension.
-  if (auto subslice = dyn_cast<ttng::TMEMSubSliceOp>(defOp)) {
-    auto [alloc, parentAccess] = findBufferAccess(subslice.getSrc());
-    if (!alloc)
-      return {};
-    if (!parentAccess.ranges[1])
-      return {alloc, parentAccess};
-    uint64_t mStart = parentAccess.ranges[1]->start() + subslice.getN();
-    uint64_t mSize = subslice.getType().getShape()[1];
-    AccessRange childAccess = parentAccess;
-    childAccess.ranges[1] = {{mStart, mStart + mSize}};
-    return {alloc, std::move(childAccess)};
-  }
-
-  // Unknown defining op.
-  return {};
-}
-
-static bool tmemMayAlias(Value a, Value b) {
-  auto [aAlloc, aRanges] = findBufferAccess(a);
-  auto [bAlloc, bRanges] = findBufferAccess(b);
-  // If the underlying buffer was not identified, assume mayalias.
-  if (!aAlloc || !bAlloc)
-    return true;
-  // If the buffers are different, they don't alias.
-  if (aAlloc != bAlloc)
-    return false;
-  // If the access ranges along any dimension are known to not overlap, then the
-  // accesses don't alias.
-  for (auto [aRange, bRange] : llvm::zip(aRanges.ranges, bRanges.ranges)) {
-    // If either access range at this dim is unknown, we can't determine if they
-    // don't overlap.
-    if (!aRange || !bRange)
-      continue;
-    // The access ranges are known and don't overlap.
-    if (!aRange->intersects(*bRange))
-      return false;
-  }
-  return true;
-}
-
-// Sink tmem_loads as close to their use as possible to reduce register
-// pressure.
-static void sinkLoad(ttng::TMEMLoadOp load, ttg::ConvertLayoutOp cvt) {
-  Operation *insertBefore = nullptr;
-  Operation *next = cvt->getNextNode();
-  while (next && !next->hasTrait<OpTrait::IsTerminator>()) {
-    insertBefore = next;
-    bool dep = false;
-    for (auto operand : getNestedOperands(next)) {
-      if (operand == cvt.getResult()) {
-        dep = true;
-        break;
-      }
-    }
-    if (!isMemoryEffectFree(next)) {
-      SmallVector<MemoryEffects::EffectInstance> effects;
-      collectEffects(next, effects);
-      for (auto effect : effects) {
-        // Look for potentially aliasing write or free effects.
-        if (!isa<MemoryEffects::Write, MemoryEffects::Free>(effect.getEffect()))
-          continue;
-        if (isa<SideEffects::DefaultResource>(effect.getResource())) {
-          dep = true;
-          break;
-        }
-        if (isa<ttng::TensorMemory>(effect.getResource()) &&
-            (!effect.getValue() ||
-             tmemMayAlias(effect.getValue(), load.getSrc()))) {
-          dep = true;
-          break;
-        }
-      }
-    }
-    if (dep)
-      break;
-    next = next->getNextNode();
-  }
-  if (insertBefore) {
-    load->moveBefore(insertBefore);
-    cvt->moveBefore(insertBefore);
-  }
-}
-
-static void hoistStore(ttng::TMEMStoreOp store, ttg::ConvertLayoutOp cvt,
-                       ttng::TMEMSubSliceOp subSlice) {
-  Operation *insertAfter = nullptr;
-  Operation *prev = subSlice->getPrevNode();
-  while (prev) {
-    insertAfter = prev;
-    bool dep = false;
-    for (Value result : prev->getResults()) {
-      if (result == cvt.getSrc() || result == subSlice.getSrc()) {
-        dep = true;
-        break;
-      }
-    }
-    if (!isMemoryEffectFree(prev)) {
-      SmallVector<MemoryEffects::EffectInstance> effects;
-      collectEffects(prev, effects);
-      for (auto effect : effects) {
-        // Look for potentially aliasing read or alloc effects.
-        if (!isa<MemoryEffects::Read, MemoryEffects::Allocate>(
-                effect.getEffect()))
-          continue;
-        if (isa<SideEffects::DefaultResource>(effect.getResource())) {
-          dep = true;
-          break;
-        }
-        if (isa<ttng::TensorMemory>(effect.getResource()) &&
-            (!effect.getValue() ||
-             tmemMayAlias(effect.getValue(), store.getDst()))) {
-          dep = true;
-          break;
-        }
-      }
-    }
-    if (dep)
-      break;
-    prev = prev->getPrevNode();
-  }
-  if (insertAfter) {
-    store->moveAfter(insertAfter);
-    cvt->moveAfter(insertAfter);
-    subSlice->moveAfter(insertAfter);
-  }
-}
 
 // clang-format off
 // Converts:
@@ -338,8 +92,6 @@ public:
     auto cvt1 = rewriter.create<ttg::ConvertLayoutOp>(
         tmemLoad.getLoc(), splitOp.getOutRHS().getType(), load1);
     rewriter.replaceOp(splitOp, {cvt0, cvt1});
-    sinkLoad(load0, cvt0);
-    sinkLoad(load1, cvt1);
     return success();
   }
 };
@@ -404,9 +156,6 @@ public:
         b.create<ttg::ConvertLayoutOp>(loc, newStoreType, joinOp.getRhs());
     auto store1 =
         b.create<ttng::TMEMStoreOp>(loc, subSlice1, cvt1.getResult(), truePred);
-
-    hoistStore(store0, cvt0, subSlice0);
-    hoistStore(store1, cvt1, subSlice1);
     b.eraseOp(storeOp);
     return success();
   }

--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -1,0 +1,52 @@
+
+// RUN: triton-opt %s -split-input-file --triton-nvidia-interleave-tmem --allow-unregistered-dialect | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
+#subtile_layout = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
+  tt.func public @sink_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                            %arg1: tensor<128x128xf16, #blocked>,
+                            %arg2: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>)
+                            -> (tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>) {
+
+    // CHECK: ttg.local_alloc
+    // CHECK: ttng.tmem_load
+    // CHECK: ttg.convert_layout
+    // CHECK: arith.truncf
+    %subslice0 = ttng.tmem_subslice %arg0 {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    %subtile0 = ttng.tmem_load %subslice0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #subtile_layout>
+    %outLHS = ttg.convert_layout %subtile0 : tensor<128x64xf32, #subtile_layout> -> tensor<128x64xf32, #blocked>
+    %subslice1 = ttng.tmem_subslice %arg0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    %subtile1 = ttng.tmem_load %subslice1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #subtile_layout>
+    %outRHS = ttg.convert_layout %subtile1 : tensor<128x64xf32, #subtile_layout> -> tensor<128x64xf32, #blocked>
+
+    // CHECK: ttng.tmem_load
+    // CHECK: ttg.convert_layout
+    // CHECK: ttng.tmem_store
+    // CHECK: arith.truncf
+    %4 = ttg.local_alloc %arg1 : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+    %5 = arith.truncf %outLHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    ttng.tmem_store %cst, %arg2, %true : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %6 = arith.truncf %outRHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+
+    // CHECK: ttng.tmem_load
+    // CHECK: ttg.convert_layout
+    // CHECK: "unknow_may_side_effect"() : () -> ()
+    // CHECK: arith.truncf
+    %7 = ttng.tmem_load %arg2 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+    %8 = ttg.convert_layout %7 : tensor<128x128xf32, #blocked1> -> tensor<128x128xf32, #blocked>
+    "unknow_may_side_effect"() : () -> ()
+    %9 = arith.truncf %8 : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+
+    ttg.local_dealloc %4 : !ttg.memdesc<128x128xf16, #shared, #smem>
+    tt.return %5, %6, %9 : tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>
+  }
+}

--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -1,5 +1,4 @@
-
-// RUN: triton-opt %s -split-input-file --triton-nvidia-interleave-tmem --allow-unregistered-dialect | FileCheck %s
+// RUN: triton-opt %s --triton-nvidia-interleave-tmem --allow-unregistered-dialect | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
@@ -8,45 +7,94 @@
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
-  tt.func public @sink_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
-                            %arg1: tensor<128x128xf16, #blocked>,
-                            %arg2: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>)
-                            -> (tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>) {
 
-    // CHECK: ttg.local_alloc
-    // CHECK: ttng.tmem_load
-    // CHECK: ttg.convert_layout
-    // CHECK: arith.truncf
-    %subslice0 = ttng.tmem_subslice %arg0 {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
-    %subtile0 = ttng.tmem_load %subslice0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #subtile_layout>
-    %outLHS = ttg.convert_layout %subtile0 : tensor<128x64xf32, #subtile_layout> -> tensor<128x64xf32, #blocked>
-    %subslice1 = ttng.tmem_subslice %arg0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
-    %subtile1 = ttng.tmem_load %subslice1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #subtile_layout>
-    %outRHS = ttg.convert_layout %subtile1 : tensor<128x64xf32, #subtile_layout> -> tensor<128x64xf32, #blocked>
+tt.func public @sink_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                          %arg1: tensor<128x128xf16, #blocked>,
+                          %arg2: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>)
+                          -> (tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>) {
 
-    // CHECK: ttng.tmem_load
-    // CHECK: ttg.convert_layout
-    // CHECK: ttng.tmem_store
-    // CHECK: arith.truncf
-    %4 = ttg.local_alloc %arg1 : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
-    %5 = arith.truncf %outLHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+  // CHECK: ttg.local_alloc
+  // CHECK: ttng.tmem_load
+  // CHECK: ttg.convert_layout
+  // CHECK: arith.truncf
+  %subslice0 = ttng.tmem_subslice %arg0 {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+  %subtile0 = ttng.tmem_load %subslice0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #subtile_layout>
+  %outLHS = ttg.convert_layout %subtile0 : tensor<128x64xf32, #subtile_layout> -> tensor<128x64xf32, #blocked>
+  %subslice1 = ttng.tmem_subslice %arg0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+  %subtile1 = ttng.tmem_load %subslice1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #subtile_layout>
+  %outRHS = ttg.convert_layout %subtile1 : tensor<128x64xf32, #subtile_layout> -> tensor<128x64xf32, #blocked>
 
-    %true = arith.constant true
-    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
-    ttng.tmem_store %cst, %arg2, %true : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    %6 = arith.truncf %outRHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+  // CHECK: ttng.tmem_load
+  // CHECK: ttg.convert_layout
+  // CHECK: ttng.tmem_store
+  // CHECK: arith.truncf
+  %4 = ttg.local_alloc %arg1 : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+  %5 = arith.truncf %outLHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
 
-    // CHECK: ttng.tmem_load
-    // CHECK: ttg.convert_layout
-    // CHECK: "unknow_may_side_effect"() : () -> ()
-    // CHECK: arith.truncf
-    %7 = ttng.tmem_load %arg2 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
-    %8 = ttg.convert_layout %7 : tensor<128x128xf32, #blocked1> -> tensor<128x128xf32, #blocked>
-    "unknow_may_side_effect"() : () -> ()
-    %9 = arith.truncf %8 : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+  %true = arith.constant true
+  %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+  ttng.tmem_store %cst, %arg2, %true : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %6 = arith.truncf %outRHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
 
-    ttg.local_dealloc %4 : !ttg.memdesc<128x128xf16, #shared, #smem>
-    tt.return %5, %6, %9 : tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>
+  // CHECK: ttng.tmem_load
+  // CHECK: ttg.convert_layout
+  // CHECK: "unknow_may_side_effect"() : () -> ()
+  // CHECK: arith.truncf
+  %7 = ttng.tmem_load %arg2 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+  %8 = ttg.convert_layout %7 : tensor<128x128xf32, #blocked1> -> tensor<128x128xf32, #blocked>
+  "unknow_may_side_effect"() : () -> ()
+  %9 = arith.truncf %8 : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+
+  ttg.local_dealloc %4 : !ttg.memdesc<128x128xf16, #shared, #smem>
+  tt.return %5, %6, %9 : tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>
+}
+
+// CHECK-LABEL: @interleave_load_store_ws
+tt.func @interleave_load_store_ws() {
+  %0 = ttng.tmem_alloc : () -> (!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>)
+  ttg.warp_specialize(%0)
+  default{
+    ttg.warp_yield
   }
+  // CHECK: partition0
+  partition0(%arg0: !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) num_warps(8) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c32 = arith.constant 32 : i32
+    %alpha = arith.constant dense<0.5> : tensor<128x64xf32, #blocked>
+    %true = arith.constant true
+
+    // CHECK: scf.for
+    scf.for %i = %c0 to %c32 step %c1 : i32 {
+      // CHECK: memdesc_subview
+      %cur_acc = ttg.memdesc_subview %arg0[%i, %c0, %c0] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+      // CHECK-NEXT: [[S0:%.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
+      // CHECK-NEXT: [[S1:%.+]] = ttng.tmem_subslice %{{.+}} {N = 64 : i32}
+
+      // CHECK-NEXT: [[L0:%.+]] = ttng.tmem_load [[S0]]
+      // CHECK-NEXT: [[M0:%.+]] = arith.mulf [[L0]]
+      // CHECK-NEXT: ttng.tmem_store [[M0]], [[S0]]
+      %slice0 = ttng.tmem_subslice %cur_acc {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+      %val0 = ttng.tmem_load %slice0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+      %mul0 = arith.mulf %val0, %alpha : tensor<128x64xf32, #blocked>
+
+      // CHECK-NEXT: [[L1:%.+]] = ttng.tmem_load [[S1]]
+      // CHECK-NEXT: [[M1:%.+]] = arith.mulf [[L1]]
+      // CHECK-NEXT: ttng.tmem_store [[M1]], [[S1]]
+      %slice1 = ttng.tmem_subslice %cur_acc {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+      %val1 = ttng.tmem_load %slice1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+      %mul1 = arith.mulf %val1, %alpha : tensor<128x64xf32, #blocked>
+
+      ttng.tmem_store %mul0, %slice0, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+      ttng.tmem_store %mul1, %slice1, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    }
+    ttg.warp_return
+  } : (!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> ()
+  tt.return
+}
+
 }

--- a/test/TritonNvidiaGPU/tmem_layouts.mlir
+++ b/test/TritonNvidiaGPU/tmem_layouts.mlir
@@ -11,9 +11,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
   // CHECK-LABEL: @subtile_tmem_load
   tt.func public @subtile_tmem_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>) {
     // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
-    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %{{.+}} {N = 64 : i32}
     // CHECK: %[[L0:.+]] = ttng.tmem_load %[[S0]] : !ttg.memdesc<128x64xf32
     // CHECK: %[[C0:.+]] = ttg.convert_layout %[[L0]]
+    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %{{.+}} {N = 64 : i32}
     // CHECK: %[[L1:.+]] = ttng.tmem_load %[[S1]] : !ttg.memdesc<128x64xf32
     // CHECK: %[[C1:.+]] = ttg.convert_layout %[[L1]]
     // CHECK: tt.return %[[C0]], %[[C1]]
@@ -46,64 +46,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %3 = ttg.convert_layout %2 : tensor<256x64x2xf32, #blocked3> -> tensor<256x64x2xf32, #blocked4>
     %outLHS, %outRHS = tt.split %3 : tensor<256x64x2xf32, #blocked4> -> tensor<256x64xf32, #blocked>
     tt.return %outLHS, %outRHS : tensor<256x64xf32, #blocked>, tensor<256x64xf32, #blocked>
-  }
-}
-
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
-#blocked2 = #ttg.blocked<{sizePerThread = [1, 1, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 2, 1], order = [0, 2, 1]}>
-#blocked3 = #ttg.blocked<{sizePerThread = [1, 64, 1], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 2], order = [0, 1, 2]}>
-#blocked4 = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
-#blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
-
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
-#smem = #ttg.shared_memory
-#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
-  tt.func public @sink_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
-                            %arg1: tensor<128x128xf16, #blocked>,
-                            %arg2: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>)
-                            -> (tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>) {
-
-    // CHECK: ttg.local_alloc
-    // CHECK: ttng.tmem_load
-    // CHECK: ttg.convert_layout
-    // CHECK: arith.truncf
-    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
-    %1 = tt.reshape %0 : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked2>
-    %2 = tt.trans %1 {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked2> -> tensor<128x64x2xf32, #blocked3>
-    %3 = ttg.convert_layout %2 : tensor<128x64x2xf32, #blocked3> -> tensor<128x64x2xf32, #blocked4>
-    %outLHS, %outRHS = tt.split %3 : tensor<128x64x2xf32, #blocked4> -> tensor<128x64xf32, #blocked>
-
-    // CHECK: ttng.tmem_load
-    // CHECK: ttg.convert_layout
-    // CHECK: ttng.tmem_store
-    // CHECK: arith.truncf
-    %4 = ttg.local_alloc %arg1 : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
-    %5 = arith.truncf %outLHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
-
-    %true = arith.constant true
-    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked5>
-    ttng.tmem_store %cst, %arg2, %true : tensor<128x128xf32, #blocked5> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    %6 = arith.truncf %outRHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
-
-    // CHECK: ttng.tmem_load
-    // CHECK: ttg.convert_layout
-    // CHECK: "unknow_may_side_effect"() : () -> ()
-    // CHECK: arith.truncf
-    %7 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
-    %8 = tt.reshape %7 : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked2>
-    %9 = tt.trans %8 {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked2> -> tensor<128x64x2xf32, #blocked3>
-    %10 = ttg.convert_layout %9 : tensor<128x64x2xf32, #blocked3> -> tensor<128x64x2xf32, #blocked4>
-    %outLHS2, %outRHS3 = tt.split %10 : tensor<128x64x2xf32, #blocked4> -> tensor<128x64xf32, #blocked>
-    "unknow_may_side_effect"() : () -> ()
-    %11 = arith.truncf %outLHS2 : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
-
-    ttg.local_dealloc %4 : !ttg.memdesc<128x128xf16, #shared, #smem>
-    tt.return %5, %6, %11 : tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>
   }
 }
 

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -272,6 +272,7 @@ class CUDABackend(BaseBackend):
         passes.ttgpuir.add_coalesce_async_copy(pm)
         nvidia.passes.ttnvgpuir.add_optimize_tmem_layouts(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
+        nvidia.passes.ttnvgpuir.add_interleave_tmem(pm)
         passes.ttgpuir.add_reduce_data_duplication(pm)
         passes.ttgpuir.add_reorder_instructions(pm)
         passes.common.add_cse(pm)

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -50,6 +50,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      mlir::createTritonNvidiaGPUOptimizeDescriptorEncodingPass);
   ADD_PASS_WRAPPER_0("add_optimize_tmem_layouts",
                      mlir::createTritonNvidiaGPUOptimizeTMemLayoutsPass);
+  ADD_PASS_WRAPPER_0("add_interleave_tmem",
+                     mlir::createTritonNvidiaGPUInterleaveTMemPass);
 }
 
 void init_triton_nvidia_passes_nvws(py::module &&m) {


### PR DESCRIPTION
This PR introduces a similar trick as `split(tmem_load)` to `tmem_store(join)` by propagating the store through the join. This also splits out the TMEM load sinking into a separate pass and makes it more powerful.

* It has more nuanced alias analysis. This allows interleaving RMW of values in TMEM
* It will try to iteratively sink multiple pure user ops

This reduces register pressure a lot in certain cases, because ptxas is quite ineffective at sinking LDTM ops.