### PR TITLE
[Blackwell] Optimize MMAv5 lowering to reduce register usage

### DIFF
--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -41,21 +41,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 #tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, unpacked = true>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_multi_m_n
-  // CHECK-DAG: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
-  // CHECK-DAG: %[[C0:.+]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK-DAG: %[[C64:.+]] = llvm.mlir.constant(64 : i32) : i32
-  // CHECK-DAG: %[[T0:.+]] = llvm.add %[[TMEM_BASE]], %[[C0]] : i32
-  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[T0]]
-  // CHECK: %[[T1:.+]] = llvm.add %[[TMEM_BASE]], %[[C64]] : i32
-  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[T1]]
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
+  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]]
+  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 64 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]]
   // 1048576 = row << 16 + col = 16 << 16 + 0
-  // CHECK: %[[C1048576:.+]] = llvm.mlir.constant(1048576 : i32) : i32
-  // CHECK: %[[T2:.+]] = llvm.add %[[TMEM_BASE]], %[[C1048576]] : i32
-  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[T2]]
+  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 1048576 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]]
   // 1048640 = row << 16 + col = 16 << 16 + 64
-  // CHECK: %[[C1048640:.+]] = llvm.mlir.constant(1048640 : i32) : i32
-  // CHECK: %[[T3:.+]] = llvm.add %[[TMEM_BASE]], %[[C1048640]] : i32
-  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[T3]]
+  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 1048640 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]]
 
   tt.func @tc_gen5_mma_multi_m_n(%a: !ttg.memdesc<128x16xf16, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
@@ -82,21 +74,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 #tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, unpacked = true, CTASplitN = 2>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_multi_ctas
-  // CHECK-DAG: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
-  // CHECK-DAG: %[[C0:.+]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK-DAG: %[[C32:.+]] = llvm.mlir.constant(32 : i32) : i32
-  // CHECK-DAG: %[[T0:.+]] = llvm.add %[[TMEM_BASE]], %[[C0]] : i32
-  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[T0]]
-  // CHECK: %[[T1:.+]] = llvm.add %[[TMEM_BASE]], %[[C32]] : i32
-  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[T1]]
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
+  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]]
+  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 32 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]]
   // 1048576 = row << 16 + col = 16 << 16 + 0
-  // CHECK: %[[C1048576:.+]] = llvm.mlir.constant(1048576 : i32) : i32
-  // CHECK: %[[T2:.+]] = llvm.add %[[TMEM_BASE]], %[[C1048576]] : i32
-  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[T2]]
+  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 1048576 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]]
   // 1048640 = row << 16 + col = 16 << 16 + 32
-  // CHECK: %[[C1048608:.+]] = llvm.mlir.constant(1048608 : i32) : i32
-  // CHECK: %[[T3:.+]] = llvm.add %[[TMEM_BASE]], %[[C1048608]] : i32
-  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[T3]]
+  // CHECK: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 1048608 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_BASE]]
 
   tt.func @tc_gen5_mma_multi_ctas(%a: !ttg.memdesc<128x16xf16, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
@@ -203,12 +187,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: %[[P0:.+]] = llvm.icmp "eq" %[[WID]], %[[C0]] : i32
   // CHECK: %[[P1:.+]] = llvm.and %{{.*}}, %[[P0]]  : i1
   // CHECK: llvm.cond_br %[[P1]]
-  // CHECK: %[[T0:.+]] = llvm.add %[[TMEM_BASE]], %[[C0]] : i32
   // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(144708608 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[T0]], %{{.+}}, %{{.+}}, %[[DESC0]], %{{.+}}, %{{.+}}, %arg5
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]], %{{.+}}, %{{.+}}, %arg5
   // CHECK: %[[TRUE:.+]] = llvm.mlir.constant(true) : i1
   // CHECK: %[[DESC1:.+]] = llvm.mlir.constant(681579536 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[T0]], %{{.+}}, %{{.+}}, %[[DESC1]], %{{.+}}, %{{.+}}, %[[TRUE]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC1]], %{{.+}}, %{{.+}}, %[[TRUE]]
   tt.func @tc_gen5_mma_block_scale(%a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<32x128xi8, #shared1, #ttg.shared_memory>,
                        %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
@@ -320,12 +303,10 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.thr
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_nvfp4
-  // CHECK-DAG: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
-  // CHECK-DAG: %[[C0:.+]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK: %[[T0:.+]] = llvm.add %[[TMEM_BASE]], %[[C0]] : i32
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
   // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(138413184 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[T0]], %{{.+}}, %{{.+}}, %[[DESC0]]
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[T0]], %{{.+}}, %{{.+}}, %[[DESC0]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
   tt.func @tc_gen5_mma_block_scale_nvfp4(%a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<64x256xi8, #shared1, #ttg.shared_memory>,
                        %c: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>,
@@ -356,12 +337,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_mxfp4
   // CHECK-DAG: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
-  // CHECK-DAG: %[[C0:.+]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK: %[[T0:.+]] = llvm.add %[[TMEM_BASE]], %[[C0]] : i32
   // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(146801792 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[T0]], %{{.+}}, %{{.+}}, %[[DESC0]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
   // CHECK: %[[DESC1:.+]] = llvm.mlir.constant(1220543648 : i32) : i32
-  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[T0]], %{{.+}}, %{{.+}}, %[[DESC1]]
+  // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC1]]
   tt.func @tc_gen5_mma_block_scale_mxfp4(%a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<64x256xi8, #shared1, #ttg.shared_memory>,
                        %c: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -23,12 +23,18 @@ union SMEMDescriptor {
   };
 };
 
+struct MemDescOperand {
+  Value base;
+  std::optional<int> offset;
+};
+
 // Abstract class to calculate the address of a shared or tensor memory slice.
 class DotOpMmaMemLoader {
 public:
   virtual ~DotOpMmaMemLoader() = default;
-  virtual Value memLoad(int a, int b, ConversionPatternRewriter &rewriter,
-                        Location loc) const = 0;
+  virtual MemDescOperand memLoad(int a, int b,
+                                 ConversionPatternRewriter &rewriter,
+                                 Location loc) const = 0;
 };
 
 // Helper class to load shared memory slices following MMAv3 layout.
@@ -46,9 +52,9 @@ public:
   Value smemLoad(int a, int b, ConversionPatternRewriter &rewriter,
                  Location loc) const;
 
-  Value memLoad(int a, int b, ConversionPatternRewriter &rewriter,
-                Location loc) const override {
-    return smemLoad(a, b, rewriter, loc);
+  MemDescOperand memLoad(int a, int b, ConversionPatternRewriter &rewriter,
+                         Location loc) const override {
+    return {smemLoad(a, b, rewriter, loc), std::nullopt};
   }
 
 private:
@@ -73,11 +79,11 @@ public:
   DotOpMmaV5TmemLoader(Value tensor, Value base,
                        SmallVector<unsigned int> instrShape, bool interleaved,
                        bool trans);
-  Value tmemLoad(int a, int b, ConversionPatternRewriter &rewriter,
-                 Location loc) const;
+  MemDescOperand tmemLoad(int a, int b, ConversionPatternRewriter &rewriter,
+                          Location loc) const;
 
-  Value memLoad(int a, int b, ConversionPatternRewriter &rewriter,
-                Location loc) const override {
+  MemDescOperand memLoad(int a, int b, ConversionPatternRewriter &rewriter,
+                         Location loc) const override {
     return tmemLoad(a, b, rewriter, loc);
   }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -32,27 +32,28 @@ mlir::triton::NVIDIA::DotOpMmaV5TmemLoader::DotOpMmaV5TmemLoader(
   numRepM = ceil<unsigned>(shapePerCTA[0], instrShape[0]);
 }
 
-Value mlir::triton::NVIDIA::DotOpMmaV5TmemLoader::tmemLoad(
+MemDescOperand mlir::triton::NVIDIA::DotOpMmaV5TmemLoader::tmemLoad(
     int a, int b, ConversionPatternRewriter &rewriter, Location loc) const {
-  auto tb = TritonLLVMOpBuilder(loc, rewriter);
   int numRows = 64;
   if (interleaved || instrShape[0] >= 128)
     numRows = 128;
   int numColPerBlock =
       ((instrShape[0] * instrShape[1]) / numRows) / numElementsPer32b;
-  Value address = base;
   int blockId = a + b * numRepM;
-  address = tb.ptrtoint(i32_ty, address);
+  int offset;
   if (!interleaved) {
-    address = tb.add(address, tb.i32_val(numColPerBlock * blockId));
+    offset = numColPerBlock * blockId;
+    // address = tb.add(address, tb.i32_val(numColPerBlock * blockId));
   } else {
     int blockIdIsOdd = blockId & 1;
     int blockIdPrevEven = blockId - blockIdIsOdd;
-    Value offset = tb.i32_val(numColPerBlock * blockIdPrevEven +
-                              ((16 * blockIdIsOdd) << 16));
-    address = tb.add(address, offset);
+    offset = numColPerBlock * blockIdPrevEven + ((16 * blockIdIsOdd) << 16);
+    // address = tb.add(address, offset);
   }
-  return address;
+
+  auto tb = TritonLLVMOpBuilder(loc, rewriter);
+  Value address = tb.ptrtoint(i32_ty, base);
+  return {address, offset};
 }
 
 //===----------------------------------------------------------------------===//
@@ -229,9 +230,9 @@ static Value createScaleInstDescriptor(ConversionPatternRewriter &rewriter,
 //===----------------------------------------------------------------------===//
 
 static void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
-                          ttng::TCGen5MMAOp op, Value a, Value b, Value d,
-                          Value pred, Value instDescriptor, Value useInitAcc,
-                          bool aInTMem, bool twoCTAs) {
+                          ttng::TCGen5MMAOp op, MemDescOperand a, Value b,
+                          MemDescOperand d, Value pred, Value instDescriptor,
+                          Value useInitAcc, bool aInTMem, bool twoCTAs) {
   PTXBuilder ptxBuilder;
   std::string opcode =
       "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
@@ -244,9 +245,10 @@ static void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
     opcode += "f8f6f4";
   else
     assert(0 && "Unsupported type.");
-  auto *accOp = ptxBuilder.newAddrOperand(d, "r");
-  auto *aOp = aInTMem ? ptxBuilder.newAddrOperand(a, "r")
-                      : ptxBuilder.newOperand(a, "l");
+  auto *accOp = ptxBuilder.newAddrOperand(d.base, "r", *d.offset);
+  assert(a.offset.has_value() == aInTMem);
+  auto *aOp = aInTMem ? ptxBuilder.newAddrOperand(a.base, "r", *a.offset)
+                      : ptxBuilder.newOperand(a.base, "l");
   auto *bOp = ptxBuilder.newOperand(b, "l");
   auto *instDescOp = ptxBuilder.newOperand(instDescriptor, "r");
   auto *useInitAccOp = ptxBuilder.newOperand(useInitAcc, "b");
@@ -257,10 +259,10 @@ static void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
 
 static void createScaledGen5MMA(ConversionPatternRewriter &rewriter,
                                 Location loc, ttng::TCGen5MMAScaledOp op,
-                                Value a, Value b, Value d, Value scaleA,
-                                Value scaleB, Value pred, Value instDescriptor,
-                                Value useInitAcc, bool aInTmem,
-                                mxfpKind mxfpInstKind) {
+                                MemDescOperand a, Value b, MemDescOperand d,
+                                Value scaleA, Value scaleB, Value pred,
+                                Value instDescriptor, Value useInitAcc,
+                                bool aInTmem, mxfpKind mxfpInstKind) {
   PTXBuilder ptxBuilder;
   std::string opcode;
   if (mxfpInstKind == mxfpKind::mxf8f6f4) {
@@ -274,9 +276,10 @@ static void createScaledGen5MMA(ConversionPatternRewriter &rewriter,
   } else {
     assert(0 && "Unsupported mxfp kind.");
   }
-  auto *accOp = ptxBuilder.newAddrOperand(d, "r");
-  auto *aOp = aInTmem ? ptxBuilder.newAddrOperand(a, "r")
-                      : ptxBuilder.newOperand(a, "l");
+  auto *accOp = ptxBuilder.newAddrOperand(d.base, "r", *d.offset);
+  assert(aInTmem == a.offset.has_value());
+  auto *aOp = aInTmem ? ptxBuilder.newAddrOperand(a.base, "r", *a.offset)
+                      : ptxBuilder.newOperand(a.base, "l");
   auto *bOp = ptxBuilder.newOperand(b, "l");
   auto *instDescOp = ptxBuilder.newOperand(instDescriptor, "r");
   auto *scaleAOp = ptxBuilder.newAddrOperand(scaleA, "r");
@@ -335,11 +338,11 @@ struct DotConversion {
     bool aInTmem;
   };
 
-  using GetAccAddressFn = std::function<Value(
+  using GetAccAddressFn = std::function<MemDescOperand(
       ConversionPatternRewriter &, Location, int, int, const InstDesc &)>;
-  using CreateMMAInstFn =
-      std::function<void(ConversionPatternRewriter &, Location, Value, Value,
-                         Value, Value, Value, const InstDesc &, int, int, int)>;
+  using CreateMMAInstFn = std::function<void(
+      ConversionPatternRewriter &, Location, MemDescOperand, MemDescOperand,
+      Value, Value, Value, const InstDesc &, int, int, int)>;
 
   struct {
     unsigned M;
@@ -456,9 +459,9 @@ void convertDotImpl(const LLVMTypeConverter &typeConverter,
   for (int m = 0; m < numRepM; m++) {
     for (int n = 0; n < numRepN; n++) {
       Value useInitAcc = useDFlag;
-      Value accAddress = op.getAccAddress(rewriter, loc, m, n, desc);
+      MemDescOperand accAddress = op.getAccAddress(rewriter, loc, m, n, desc);
       for (int k = 0; k < numRepK; k++) {
-        Value a = aLoader->memLoad(m, k, rewriter, loc);
+        MemDescOperand a = aLoader->memLoad(m, k, rewriter, loc);
         Value b = bLoader.smemLoad(n, k, rewriter, loc);
         op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
                          desc, m, n, k);
@@ -506,9 +509,10 @@ void convertDot(const LLVMTypeConverter &typeConverter,
   };
 
   dot.createMMAInst = [&](ConversionPatternRewriter &rewriter, Location loc,
-                          Value accAddress, Value a, Value b, Value pred,
-                          Value useInitAcc, const DotConversion::InstDesc &desc,
-                          int m, int n, int k) {
+                          MemDescOperand accAddress, MemDescOperand a, Value b,
+                          Value pred, Value useInitAcc,
+                          const DotConversion::InstDesc &desc, int m, int n,
+                          int k) {
     Value instDescriptor = createInstDescriptor(
         rewriter, op, twoCTAs ? desc.mmaSizeM * 2 : desc.mmaSizeM,
         desc.mmaSizeN, desc.transA, desc.transB);
@@ -598,13 +602,14 @@ void convertScaledDot(const LLVMTypeConverter &typeConverter,
                                        dTensorTy.getElementTypeBitWidth(),
                                    numRows * colSizeInBits);
     int blockId = m + n * desc.repShape.numRepM;
-    return tb.add(baseD, tb.i32_val(numColPerBlock * blockId));
+    return MemDescOperand{baseD, numColPerBlock * blockId};
   };
 
   dot.createMMAInst = [&](ConversionPatternRewriter &rewriter, Location loc,
-                          Value accAddress, Value a, Value b, Value pred,
-                          Value useInitAcc, const DotConversion::InstDesc &desc,
-                          int m, int n, int k) {
+                          MemDescOperand accAddress, MemDescOperand a, Value b,
+                          Value pred, Value useInitAcc,
+                          const DotConversion::InstDesc &desc, int m, int n,
+                          int k) {
     auto [numRepM, numRepN, numRepK] = desc.repShape;
     int scaleFactorColsPerSet = getScaleFactorColsPerSet(mxfpInstKind);
     int numColPerScaleBlockA = ceil<int>(

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -43,12 +43,10 @@ MemDescOperand mlir::triton::NVIDIA::DotOpMmaV5TmemLoader::tmemLoad(
   int offset;
   if (!interleaved) {
     offset = numColPerBlock * blockId;
-    // address = tb.add(address, tb.i32_val(numColPerBlock * blockId));
   } else {
     int blockIdIsOdd = blockId & 1;
     int blockIdPrevEven = blockId - blockIdIsOdd;
     offset = numColPerBlock * blockIdPrevEven + ((16 * blockIdIsOdd) << 16);
-    // address = tb.add(address, offset);
   }
 
   auto tb = TritonLLVMOpBuilder(loc, rewriter);


### PR DESCRIPTION
The MMAv5 instruction supports constant offsets encoded directly in the instruction for TMEM memory descriptors, such as for the `d` operand or if `a` is in TMEM. Using constant offsets reduces register pressure because each new offset doesn't require a register. It also helps a lot when there are pipelined MMAv5 instructions or multiple in the same loop because LLVM will CSE and hoist all the offsets out of the loop and PTXAS will keep them live for the whole loop instead of rematerializing them. This means each `ttng.tc_gen5_mma` can end up using up to 15-20 registers each in the loop because of all the offsets.