### PR TITLE
Update `googletest` version up to `v1.17.0`

### DIFF
--- a/unittest/googletest.cmake
+++ b/unittest/googletest.cmake
@@ -9,7 +9,7 @@ endif()
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG release-1.12.1
+  GIT_TAG v1.17.0
   )
 
 FetchContent_GetProperties(googletest)


### PR DESCRIPTION
To resolve the following warning:
```bash
    CMake Deprecation Warning at build/cmake.linux-x86_64-cpython-3.10/_deps/googletest-src/CMakeLists.txt:4 (cmake_minimum_required):
      Compatibility with CMake < 3.10 will be removed from a future version of
      CMake.

      Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
      to tell CMake that the project requires at least <min> but has been updated
      to work with policies introduced by <max> or earlier.
```

https://github.com/google/googletest/releases/tag/v1.17.0