### PR TITLE
[BENCH] Implement value and scale swizzling for Hopper bf16xmxfp4

### DIFF
--- a/python/triton_kernels/tests/test_mxfp.py
+++ b/python/triton_kernels/tests/test_mxfp.py
@@ -1,0 +1,266 @@
+import math
+
+import pytest
+import torch
+
+import triton
+from triton_kernels.numerics_details.mxfp import (
+    DequantScaleRoundingMode,
+    SwizzlingType,
+    downcast_to_mxfp,
+    downcast_to_mxfp_torch,
+    get_max_quant_val,
+    perm_tensor_from_contig,
+    perm_tuple_to_contig,
+    swizzle_mx_scale_bw,
+    swizzle_mxfp4_scale_hopper,
+    swizzle_mxfp4_value_hopper,
+    unswizzle_mx_scale_bw_torch,
+    unswizzle_mxfp4_scale_hopper_torch,
+    unswizzle_mxfp4_value_hopper_torch,
+    upcast_from_mxfp,
+    upcast_from_mxfp_torch,
+)
+from triton_kernels.testing import assert_close, assert_equal
+
+
+def dtype_str_to_torch(dtype_str: str) -> torch.dtype:
+    return torch.uint8 if dtype_str == "float4_e2m1" else getattr(torch, dtype_str)
+
+
+@pytest.mark.parametrize("dst_dtype", ["float16", "bfloat16"])
+def test_mxfp4_rounding_cases(dst_dtype):
+    dst_dtype = dtype_str_to_torch(dst_dtype)
+    x = torch.tensor([6, 0, 0.24, 0.25, 0.75, 0.99, 1.2, 1.3]).cuda().bfloat16().view(1, -1, 1)
+    quant, scale, _ = downcast_to_mxfp(x, torch.uint8, axis=1)
+    dequant = upcast_from_mxfp(quant, scale, dst_dtype, axis=1)
+    assert dequant.flatten().tolist() == [6, 0, 0, 0.5, 1.0, 1.0, 1.0, 1.5], f"{dequant=}"
+
+    quant_torch, scale_torch = downcast_to_mxfp_torch(x, torch.uint8, axis=1)
+    assert_equal(quant_torch, quant)
+    assert_equal(scale_torch, scale)
+
+    dequant_torch = upcast_from_mxfp_torch(quant_torch, scale_torch, dst_dtype, axis=1)
+    assert_equal(dequant_torch, dequant)
+
+
+@pytest.mark.parametrize("src_dtype", ["float4_e2m1", "float8_e5m2", "float8_e4m3fn"])
+@pytest.mark.parametrize("dst_dtype", ["float16", "bfloat16"])
+def test_mxfp_quant_dequant(src_dtype, dst_dtype):
+    if "float8" in src_dtype and torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("Float8 not tested on A100")
+    limit_range = src_dtype == "float8_e5m2" and dst_dtype == "float16"
+
+    # This test checks that quantization and dequantization kernels produce the exact values for some inputs
+    # that can be represented exactly in the quantized format.
+    src_dtype = dtype_str_to_torch(src_dtype)
+    dst_dtype = dtype_str_to_torch(dst_dtype)
+    max_val = get_max_quant_val(src_dtype)
+    if limit_range:
+        # FP16 can't represent the full range of MXFP8, so we limit the max value here
+        max_val = 128
+
+    # These are all the valid mxfp4 positive values.
+    pos_vals = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, max_val], device="cuda", dtype=dst_dtype)
+    neg_vals = -pos_vals
+    k_dim = torch.cat([pos_vals, neg_vals])
+    k_dim = k_dim.reshape([k_dim.shape[0], 1])
+
+    # We pick power of 2 scales since both the scales and their inverse only require exponent bits to be exactly
+    # represented. This means we can store the scales exactly in the e8m0 format.
+    powers = torch.arange(-8, 8, device="cuda", dtype=dst_dtype)
+    scales = 2**powers
+    scales = scales.reshape([1, powers.shape[0]])
+    weight = k_dim * scales
+    weight = weight.repeat((9, 32))  # Repeat the dimensions to test multi block launches.
+    weight = weight.reshape([1, weight.shape[0], weight.shape[1]])
+    weight = weight.mT.contiguous().mT
+    quant, scale, _ = downcast_to_mxfp(weight, src_dtype, axis=1)
+    dequant = upcast_from_mxfp(quant, scale, dst_dtype, axis=1)
+    assert_equal(weight, dequant)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (3, 4096, 1024),
+        (10, 254, 60),
+        (1, 320, 160),
+        (2, 16, 512),
+        (3, 2, 36),
+    ],
+)
+def test_mxfp_swizzle(shape: tuple[int, ...]):
+    """
+    Test that unswizzle is the inverse of swizzle, after removing padding.
+    """
+    x = torch.randn(shape, device="cuda")
+    assert_equal(x, unswizzle_mx_scale_bw_torch(swizzle_mx_scale_bw(x))[..., :shape[-2], :shape[-1]])
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "shape, axis, swizzle_axis, block_out_dim, block_quant_dim, quant_dtype, rounding_mode",
+    [
+        ((3, 4096, 1024), 1, -1, 128, 32, "float4_e2m1", DequantScaleRoundingMode.ROUND_UP),
+        ((10, 254, 60), 0, 1, 128, 32, "float4_e2m1", DequantScaleRoundingMode.ROUND_DOWN),
+        ((1, 320, 160), 2, 1, 128, 32, "float8_e5m2", DequantScaleRoundingMode.ROUND_UP),
+        ((2, 16, 512), -1, 0, 128, 32, "float8_e4m3fn", DequantScaleRoundingMode.ROUND_DOWN),
+    ],
+)
+# fmt: on
+@pytest.mark.parametrize("user_allocated_output", [False, True])
+@pytest.mark.parametrize("dequant_dtype", ["float16", "bfloat16"])
+@pytest.mark.parametrize("swizzle_value, swizzle_scale", [(None, None), (SwizzlingType.HOPPER, None),
+                                                          (None, SwizzlingType.HOPPER),
+                                                          (SwizzlingType.HOPPER, SwizzlingType.HOPPER),
+                                                          (None, SwizzlingType.BLACKWELL)])
+def test_mxfp_casting(
+    shape: tuple[int, ...],
+    axis: int,
+    swizzle_axis: int | None,
+    swizzle_value: SwizzlingType | None,
+    swizzle_scale: SwizzlingType | None,
+    block_out_dim,
+    block_quant_dim,
+    quant_dtype: str,
+    dequant_dtype: str,
+    rounding_mode: DequantScaleRoundingMode,
+    user_allocated_output: bool,
+):
+    if "float8" in quant_dtype and torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("Float8 not tested on A100")
+    if swizzle_value == SwizzlingType.HOPPER:
+        if "float4" not in quant_dtype:
+            pytest.skip("NYI. Hopper swizzle just implemented for mxfp4")
+        if shape[axis] % 64 != 0 or shape[swizzle_axis] % 128 != 0:
+            # Automatic padding not implemented for Hopper swizzle
+            pytest.skip("Hopper swizzle not supported for tile not multiple of 64x128")
+    if swizzle_scale == SwizzlingType.HOPPER:
+        if shape[axis] % 64 != 0 or shape[swizzle_axis] % 128 != 0:
+            # Automatic padding not implemented for Hopper swizzle
+            pytest.skip("Hopper swizzle not supported for tile not multiple of 64x128")
+    if user_allocated_output and any([swizzle_value, swizzle_scale]):
+        pytest.skip("User-allocated output not supported together with swizzling")
+
+    swizzle_axis = swizzle_axis if (swizzle_value or swizzle_scale) else None
+    quant_torch_type = dtype_str_to_torch(quant_dtype)
+    dequant_torch_type = dtype_str_to_torch(dequant_dtype)
+    # Generate random input tensor that is contiguous once axis is the last dimension
+    # and swizzle_axis is the second to last dimension.
+    x = torch.randn(shape, device="cuda", dtype=dequant_torch_type)
+
+    # Allocate output tensor if needed
+    if user_allocated_output:
+        shape_list = list(perm_tuple_to_contig(shape, axis, swizzle_axis))
+        scale_shape_list = list(shape_list)
+        scale_shape_list[-1] = triton.cdiv(scale_shape_list[-1], 32)
+        if "float4" in quant_dtype:
+            shape_list[-1] //= 2
+
+        out_tensor = torch.empty(shape_list, device="cuda", dtype=quant_torch_type)
+        out_tensor_scale = torch.empty(scale_shape_list, device="cuda", dtype=torch.uint8)
+
+        out_tensor = perm_tensor_from_contig(out_tensor, axis, swizzle_axis)
+        out_tensor_scale = perm_tensor_from_contig(out_tensor_scale, axis, swizzle_axis)
+    else:
+        out_tensor = None
+        out_tensor_scale = None
+
+    # Quantize and check equivalence
+    quant, scale, _ = downcast_to_mxfp(
+        x,
+        quant_torch_type,
+        axis,
+        swizzle_axis,
+        swizzle_value=swizzle_value,
+        swizzle_scale=swizzle_scale,
+        out_quant_tensor=out_tensor,
+        out_scale=out_tensor_scale,
+        DEQUANT_SCALE_ROUNDING_MODE=rounding_mode,
+        BLOCK_OUT_DIM=block_out_dim,
+        BLOCK_QUANT_DIM=block_quant_dim,
+    )
+    if out_tensor is not None:
+        assert_equal(out_tensor, quant)
+    if out_tensor_scale is not None:
+        assert_equal(out_tensor_scale, scale)
+
+    quant_torch, scale_torch = downcast_to_mxfp_torch(
+        x,
+        quant_torch_type,
+        axis,
+        swizzle_axis,
+        swizzle_value=swizzle_value,
+        swizzle_scale=swizzle_scale,
+        out_quant_tensor=out_tensor,
+        out_scale=out_tensor_scale,
+        DEQUANT_SCALE_ROUNDING_MODE=rounding_mode,
+    )
+    if out_tensor is not None:
+        assert_equal(out_tensor, quant_torch)
+    if out_tensor_scale is not None:
+        assert_equal(out_tensor_scale, scale_torch)
+
+    assert_equal(quant_torch, quant)
+    assert_equal(scale_torch, scale)
+    assert_equal(1, quant.stride(axis))
+    assert_equal(1, quant_torch.stride(axis))
+
+    # Dequantize and check equivalence
+    dequant = upcast_from_mxfp(
+        quant,
+        scale,
+        dequant_torch_type,
+        axis,
+        swizzle_axis,
+        swizzle_value=swizzle_value,
+        swizzle_scale=swizzle_scale,
+        BLOCK_OUT_DIM=block_out_dim,
+        BLOCK_QUANT_DIM=block_quant_dim,
+    )
+    dequant_torch = upcast_from_mxfp_torch(quant_torch, scale_torch, dequant_torch_type, axis, swizzle_axis,
+                                           swizzle_value, swizzle_scale)
+    assert_equal(dequant, dequant_torch)
+
+    # Dequantized result should be close to the original, though tolerance is large due to the precision loss.
+    assert_close(x, dequant, maxtol=0.5, rmstol=0.15)
+
+
+def test_unswizzle_mxfp4_value_golden_value():
+    shape = (16, 32)
+    x = torch.arange(math.prod(shape)).view(shape).to(torch.uint8)
+    x = x.mT
+    res = swizzle_mxfp4_value_hopper(x, op_idx=1, mma_version=3)
+    # res = res.mT.view(torch.uint32).mT
+    # Thread 0
+    assert res[0:16, 0].tolist() == [0, 0, 4, 4, 8, 8, 12, 12, 16, 16, 20, 20, 24, 24, 28, 28]
+    # Thread 1
+    assert res[16:32, 0].tolist() == [1, 1, 5, 5, 9, 9, 13, 13, 17, 17, 21, 21, 25, 25, 29, 29]
+
+
+@pytest.mark.parametrize("shape", [(16, 32), (16, 64), (32, 32), (32, 64), (64, 128), (128, 128)])
+@pytest.mark.parametrize("trans", [False, True])
+@pytest.mark.parametrize("op_idx", [0, 1])
+@pytest.mark.parametrize("mma_version", [2, 3])
+def test_swizzle_mxfp4_value(shape, trans, op_idx, mma_version):
+    x = torch.randint(0, 256, shape, dtype=torch.uint8, device="cuda")
+    if trans:
+        x = x.mT
+    k_dim = 1 - op_idx
+    if x.shape[k_dim] < 32:
+        pytest.skip("Not enough elements along K")
+
+    # PyTorch implementation of unswizzle_mxfp4_value
+    res = swizzle_mxfp4_value_hopper(x, op_idx, mma_version)
+    res = unswizzle_mxfp4_value_hopper_torch(res, op_idx, mma_version)
+    assert (res == x).all()
+
+
+@pytest.mark.parametrize("num_warps", [4, 8])
+@pytest.mark.parametrize("shape", [(256, 64), (256, 128), (256, 256)])
+def test_swizzle_mxfp4_scale(shape, num_warps):
+    x = torch.randint(0, 256, shape, dtype=torch.uint8, device="cuda")
+    res = swizzle_mxfp4_scale_hopper(x, num_warps=num_warps)
+    res = unswizzle_mxfp4_scale_hopper_torch(res, num_warps=num_warps)
+    assert (res == x).all()

--- a/python/triton_kernels/triton_kernels/matmul_ogs.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs.py
@@ -15,6 +15,7 @@ from .matmul_ogs_details._finalize_matmul import _finalize_matmul
 from .matmul_ogs_details.opt_flags import make_opt_flags
 from .matmul_ogs_details.metadata import compute_metadata
 from .matmul_ogs_details.fast_contiguous import fast_contiguous
+from .numerics_details.mxfp import SwizzlingType
 from .specialize import specialize
 
 
@@ -89,7 +90,12 @@ class MicroscalingCtx:
     act_scale: torch.Tensor | None = None
     weight_scale: torch.Tensor | None = None
 
-    swizzle_mx: bool = False  # Whether the weight scales are stored in swizzled 5D layout
+    swizzle_value: SwizzlingType | None = (
+        None  # Whether the weight values are stored in swizzled layout
+    )
+    swizzle_scale: SwizzlingType | None = (
+        None  # Whether the weight scales are stored in swizzled layout
+    )
     actual_weight_scale_shape: tuple | None = None  # Actual weight scales shape, without padding
 
     def __post_init__(self):
@@ -111,6 +117,9 @@ class MicroscalingCtx:
             )
 
     def check_inputs(self, weights: torch.Tensor) -> None:
+        if self.swizzle_value and self.swizzle_value != SwizzlingType.HOPPER:
+            raise ValueError(f"Only Hopper swizzling is supported. Got {self.swizzle_value}")
+
         if self.weight_scale is None:
             return
 
@@ -122,17 +131,28 @@ class MicroscalingCtx:
         # Validate weights tensor dimensions
         if weights.ndim != 3:
             raise ValueError(f"Weights must be 3D (experts, in_dim, out_dim). Got {weights.shape}")
+        weights_shape = self.get_packed_tensor_logical_shape(weights)
 
         # Validate shapes
         weight_scale_shape = self.actual_weight_scale_shape
-        if weights.shape[0] != weight_scale_shape[0] or weights.shape[2] != weight_scale_shape[2]:
+        if weights_shape[0] != weight_scale_shape[0] or weights_shape[2] != weight_scale_shape[2]:
             raise ValueError(
                 f"Weights and scale must have the same number of experts and output dimensions. "
-                f"Got weights experts: {weights.shape[0]}, scale experts: {weight_scale_shape[0]}, "
-                f"weights out_dim: {weights.shape[2]}, scale out_dim: {weight_scale_shape[2]}"
+                f"Got weights experts: {weights_shape[0]}, scale experts: {weight_scale_shape[0]}, "
+                f"weights out_dim: {weights_shape[2]}, scale out_dim: {weight_scale_shape[2]}"
             )
+        if self.swizzle_value == SwizzlingType.HOPPER:
+            if weights_shape[1] % 64 != 0 or weights_shape[2] % 16 != 0:
+                raise ValueError(
+                    f"Hopper scale swizzling acts on a 64x16 tile (4x1 mma tiles). Got {weights_shape=}"
+                )
+        if self.swizzle_scale == SwizzlingType.HOPPER:
+            if weights_shape[1] % 64 != 0 or weights_shape[2] % 64 != 0:
+                raise ValueError(
+                    f"Hopper scale swizzling acts on a 64x64 tile (4x4 mma tiles). Got {weights_shape=}"
+                )
 
-        k_dim = self.get_packed_tensor_logical_shape(weights)[1]
+        k_dim = weights_shape[1]
         rounded_k_dim = (k_dim + 31) // 32 * 32
         block_size = rounded_k_dim // weight_scale_shape[1]
         if block_size != 32:
@@ -141,7 +161,7 @@ class MicroscalingCtx:
     def compute_strides(self):
         if self.weight_scale is not None:
             # Check expected properties of the weights.
-            if self.swizzle_mx:
+            if self.swizzle_scale == SwizzlingType.BLACKWELL:
                 mxE, mxK, mxN = self.weight_scale.shape
 
                 # Compute strides of the 5D swizzled tensor.
@@ -161,11 +181,14 @@ class MicroscalingCtx:
 
 
     def get_packed_tensor_logical_shape(self, tensor: torch.Tensor):
-        k_dim = tensor.shape[1]
+        shape = list(tensor.shape)
         if tensor.dtype == torch.uint8:
             # Assume 2 fp4s packed into a byte
-            k_dim *= 2
-        return tensor.shape[0], k_dim, tensor.shape[2]
+            shape[1] *= 2
+        if self.swizzle_value == SwizzlingType.HOPPER:
+            shape[1] //= 4
+            shape[2] *= 4
+        return tuple(shape)
 
 @dataclass(frozen=True)
 class FlexCtx:
@@ -194,15 +217,17 @@ def mx_can_use_tma(mx_ctx: MicroscalingCtx):
     if mx_scale_stride_e * mx_ctx.weight_scale.element_size() % 16 != 0:
         return False
 
-    if mx_ctx.swizzle_mx:
-        # CHeck stride in bytes are multiples of 16.
+    if mx_ctx.swizzle_scale == SwizzlingType.BLACKWELL:
+        # Check stride in bytes are multiples of 16.
         return mx_scale_stride_n * mx_ctx.weight_scale.element_size() % 16 == 0 and mx_scale_stride_k * mx_ctx.weight_scale.element_size() % 16 == 0
-    else:
+    elif mx_ctx.swizzle_scale is None:
         # Check MX is either transposed or non-transposed, and with required stride.
         return (
             (mx_scale_stride_n * mx_ctx.weight_scale.element_size() % 16 == 0 and mx_scale_stride_k == 1) or
             (mx_scale_stride_k * mx_ctx.weight_scale.element_size() % 16 == 0 and mx_scale_stride_n == 1)
         )
+    else:
+        return False
 
 def can_use_persistent_tma(x, w, gather_indx, precision_config):
     mx_ctx = precision_config.mx_ctx
@@ -225,6 +250,8 @@ def can_use_persistent_tma(x, w, gather_indx, precision_config):
         )
         # compiler crash ?
         and (x.dtype.itemsize <= 1 or w.dtype != torch.uint8)
+        # NYI
+        and mx_ctx.swizzle_value is None
     )
 
 def can_use_fused_scatter(scatter_indx):
@@ -589,7 +616,8 @@ def matmul_ogs(x, w, bias,
                    opt_flags.block_k,
                    opt_flags.group_m,
                    XCD_SWIZZLE=opt_flags.xcd_swizzle,
-                   SWIZZLE_MX=mx_ctx.swizzle_mx,
+                   SWIZZLE_MX_VALUE=mx_ctx.swizzle_value.name if mx_ctx.swizzle_value else None,
+                   SWIZZLE_MX_SCALE=mx_ctx.swizzle_scale.name if mx_ctx.swizzle_scale else None,
                    EPILOGUE_SUBTILE=opt_flags.epilogue_subtile,
                    SPLIT_K=opt_flags.split_k,
                    EVEN_K=K % opt_flags.block_k == 0,

--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/_matmul_ogs.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/_matmul_ogs.py
@@ -1,6 +1,12 @@
 import triton
 import triton.language as tl
-from triton_kernels.numerics_details.mxfp import _unswizzle_mx_block, get_scaled_dot_format_string
+from triton_kernels.numerics_details.mxfp import (
+    get_scaled_dot_format_string,
+    unswizzle_mx_scale_bw,
+    unswizzle_mxfp4_scale_hopper,
+    unswizzle_mxfp4_value_hopper,
+)
+
 from triton_kernels.numerics_details.flexpoint import float_to_flex, load_scale
 from ._common import make_matmul_repr, matmul_launch_metadata, swizzle2d, xcd_swizzle
 
@@ -54,7 +60,11 @@ def _matmul_ogs(
              PER_BATCH_SCALE: tl.constexpr,
              # optimization config
              BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
-             GROUP_M: tl.constexpr, XCD_SWIZZLE: tl.constexpr, SWIZZLE_MX: tl.constexpr,
+             GROUP_M: tl.constexpr, XCD_SWIZZLE: tl.constexpr,
+             # One of ["HOPPER", "BLACKWELL", None]
+             SWIZZLE_MX_VALUE: tl.constexpr,
+             # One of ["HOPPER", "BLACKWELL", None]
+             SWIZZLE_MX_SCALE: tl.constexpr,
              EPILOGUE_SUBTILE: tl.constexpr,
              EVEN_K: tl.constexpr, SPLIT_K: tl.constexpr,
              W_CACHE_MODIFIER: tl.constexpr,
@@ -69,10 +79,15 @@ def _matmul_ogs(
     MX_PACK_DIVISOR: tl.constexpr = 32
     if is_microscaled_format:
         w_type: tl.constexpr = W.dtype.element_ty
+        is_mxfp4: tl.constexpr = w_type == tl.uint8
         tl.static_assert(w_type == tl.uint8 or (w_type == tl.float8e4nv or w_type == tl.float8e5),
                          "mx_weight_ptr must be uint8")
         tl.static_assert(MxScale.dtype.element_ty == tl.uint8, "mx_scale_ptr must be uint8")
         tl.static_assert(BLOCK_K % MX_PACK_DIVISOR == 0, "BLOCK_K must be a multiple of MX_PACK_DIVISOR")
+        tl.static_assert(SWIZZLE_MX_VALUE == "HOPPER" or SWIZZLE_MX_VALUE is None, "Only Hopper swizzling is supported for values")
+    else:
+        tl.static_assert(SWIZZLE_MX_VALUE is None)
+        tl.static_assert(SWIZZLE_MX_SCALE is None)
 
     pid = tl.program_id(0)
     if ExptOffsSum is not None and XCD_SWIZZLE > 1:
@@ -141,39 +156,61 @@ def _matmul_ogs(
         offs_x_m = tl.load(GatherIndx + offs_x_m) // N_EXPTS_ACT
     offs_k = BLOCK_K * pid_k + tl.arange(0, BLOCK_K)
     XPtrs = X + offs_x_m.to(index_type)[:, None] * stride_x_m + offs_k.to(index_type)[None, :] * stride_x_k
-    # B pointers
-    offs_w_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    offs_w_n = tl.max_contiguous(tl.multiple_of(offs_w_n % N, BLOCK_N), BLOCK_N)
 
     # TODO: refactor if/else when triton front end improves
     if is_microscaled_format:
-        # We have pack 2 fp4 values in a  byte
-        W_PACK_DIVISOR: tl.constexpr = 2 if W.dtype.element_ty == tl.uint8 else 1
-        PACKED_BLOCK_K_W: tl.constexpr = BLOCK_K // W_PACK_DIVISOR
+        if SWIZZLE_MX_VALUE == "HOPPER":
+            x_type: tl.constexpr = X.dtype.element_ty
+            tl.static_assert(x_type == tl.bfloat16 or x_type == tl.float16, "Only bfloat16 or float16 is supported for HOPPER swizzling")
+            tl.static_assert(is_mxfp4, "Only mxfp4 is supported for HOPPER swizzling")
+            # We have pack 2 fp4 values in a byte but we divide the dimension by 2
+            # when swizzling
+            W_K_DIVISOR: tl.constexpr = 1
+            W_K_MULTIPLIER: tl.constexpr = 2
+            W_N_DIVISOR: tl.constexpr = 4
+        else:
+            # We have pack 2 fp4 values in a  byte
+            W_K_DIVISOR: tl.constexpr = 2 if is_mxfp4 else 1
+            W_K_MULTIPLIER: tl.constexpr = 1
+            W_N_DIVISOR: tl.constexpr = 1
+
+        PACKED_BLOCK_K_W: tl.constexpr = (BLOCK_K // W_K_DIVISOR) * W_K_MULTIPLIER
+        PACKED_BLOCK_N_W: tl.constexpr = BLOCK_N // W_N_DIVISOR
         MX_SCALE_BLOCK_K: tl.constexpr = BLOCK_K // MX_PACK_DIVISOR
 
         MxScale += expt_id * stride_mx_e
 
-        if SWIZZLE_MX:
+        if SWIZZLE_MX_SCALE == "BLACKWELL":
             tl.static_assert(BLOCK_N % 128 == 0)
             tl.static_assert(MX_SCALE_BLOCK_K % 4 == 0)
             PACKED_MX_BLOCK: tl.constexpr = (MX_SCALE_BLOCK_K // 4) * 32 * 4 * 4
-            offs_inner = PACKED_MX_BLOCK * pid_k + tl.arange(0, PACKED_MX_BLOCK)
-            offs_n_scale = (pid_n * (BLOCK_N // 128) + tl.arange(0, BLOCK_N // 128)) % N
-            offs_n_scale = tl.max_contiguous(tl.multiple_of(offs_n_scale, BLOCK_N // 128), BLOCK_N // 128)
-
-            MxScalePtrs = MxScale + offs_n_scale.to(index_type)[:, None] * stride_mx_n + offs_inner[None, :]
+            SCALE_BLOCK_N: tl.constexpr = BLOCK_N // 128
+        elif SWIZZLE_MX_SCALE == "HOPPER":
+            n_warps: tl.constexpr = tl.extra.cuda.num_warps()
+            tl.static_assert(BLOCK_N % (2 * n_warps * 2 * 8) == 0)
+            tl.static_assert(MX_SCALE_BLOCK_K % 2 == 0)
+            PACKED_MX_BLOCK: tl.constexpr = MX_SCALE_BLOCK_K * 32
+            SCALE_BLOCK_N: tl.constexpr = BLOCK_N // 32
         else:
-            offs_k_scale = MX_SCALE_BLOCK_K * pid_k + tl.arange(0, MX_SCALE_BLOCK_K)
-            offs_n_scale = offs_w_n
-            # K dimension must be the last dimension for the scales
-            MxScalePtrs = MxScale + offs_k_scale.to(index_type)[None, :] * stride_mx_k + offs_n_scale.to(index_type)[:, None] * stride_mx_n
+            PACKED_MX_BLOCK: tl.constexpr = MX_SCALE_BLOCK_K
+            SCALE_BLOCK_N: tl.constexpr = BLOCK_N
+        offs_n_scale = (pid_n * SCALE_BLOCK_N + tl.arange(0, SCALE_BLOCK_N)) % N
+        offs_n_scale = tl.max_contiguous(tl.multiple_of(offs_n_scale, SCALE_BLOCK_N), SCALE_BLOCK_N)
+        # K dimension must be the last dimension for the scales
+        offs_k_scale = PACKED_MX_BLOCK * pid_k + tl.arange(0, PACKED_MX_BLOCK)
+        MxScalePtrs = MxScale + offs_k_scale.to(index_type)[None, :] * stride_mx_k + offs_n_scale.to(index_type)[:, None] * stride_mx_n
     else:
         MxScalePtrs = None
         offs_k_scale = None
-        W_PACK_DIVISOR: tl.constexpr = 1
-        MX_SCALE_BLOCK_K: tl.constexpr = 1
+        W_K_DIVISOR: tl.constexpr = 1
+        W_K_MULTIPLIER: tl.constexpr = 1
+        W_N_DIVISOR: tl.constexpr = 1
         PACKED_BLOCK_K_W: tl.constexpr = BLOCK_K
+        PACKED_BLOCK_N_W: tl.constexpr = BLOCK_N
+
+    # B pointers
+    offs_w_n = pid_n * PACKED_BLOCK_N_W + tl.arange(0, PACKED_BLOCK_N_W)
+    offs_w_n = tl.max_contiguous(tl.multiple_of(offs_w_n % (N // W_N_DIVISOR), PACKED_BLOCK_N_W), PACKED_BLOCK_N_W)
 
     offs_w_k = PACKED_BLOCK_K_W * pid_k + tl.arange(0, PACKED_BLOCK_K_W)
     W += expt_id * stride_w_e
@@ -184,11 +221,12 @@ def _matmul_ogs(
         if EVEN_K:
             mask_k = tl.full([BLOCK_K], True, dtype=tl.int1)
             mask_k_w = tl.full([PACKED_BLOCK_K_W], True, dtype=tl.int1)
-            mask_k_scale = tl.full([MX_SCALE_BLOCK_K], True, dtype=tl.int1)
+            if is_microscaled_format:
+                mask_k_scale = tl.full([PACKED_MX_BLOCK], True, dtype=tl.int1)
         else:
             mask_k = offs_k < k
-            mask_k_w = offs_w_k < tl.cdiv(k, W_PACK_DIVISOR)
-            if is_microscaled_format and not SWIZZLE_MX:
+            mask_k_w = offs_w_k < (tl.cdiv(k, W_K_DIVISOR) * W_K_MULTIPLIER)
+            if is_microscaled_format and SWIZZLE_MX_SCALE is None:
                 mask_k_scale = offs_k_scale < tl.cdiv(k, MX_PACK_DIVISOR)
 
         x = tl.load(XPtrs, mask=mask_k[None, :], other=0.0)
@@ -201,15 +239,27 @@ def _matmul_ogs(
             else:
                 # Scale of 1 in E8M0 format
                 x_scales = tl.full((BLOCK_M, BLOCK_K // MX_PACK_DIVISOR), 127, dtype=tl.uint8)
-            if SWIZZLE_MX:
-                w_scales = _unswizzle_mx_block(tl.load(MxScalePtrs))
+
+            if SWIZZLE_MX_SCALE == "BLACKWELL":
+                w_scales = unswizzle_mx_scale_bw(tl.load(MxScalePtrs))
+            elif SWIZZLE_MX_SCALE == "HOPPER":
+                # Handshake with the swizzling code
+                tl.static_assert(tl.extra.cuda.num_warps() == 8, "Only 8 warps are supported for Hopper swizzling. Got %d" % tl.extra.cuda.num_warps())
+                w_scales = unswizzle_mxfp4_scale_hopper(tl.load(MxScalePtrs), num_warps=8)
             else:
                 w_scales = tl.load(MxScalePtrs, mask=mask_k_scale[None, :], other=0.0)
+
+            if SWIZZLE_MX_VALUE == "HOPPER":
+                # Handshake with the swizzling code
+                w = unswizzle_mxfp4_value_hopper(w, op_idx=1, mma_version=3)
+                mma_version: tl.constexpr = 3 if w.shape[1] >= 64 else 2
+                tl.static_assert(mma_version == 3, "Only mma_version 3 is supported for Hopper swizzling")
+
             acc = tl.dot_scaled(x, x_scales, x_format, w, w_scales, mx_format, acc=acc, fast_math=True)
-            if SWIZZLE_MX:
+            if SWIZZLE_MX_SCALE == "BLACKWELL":
                 MxScalePtrs += (MX_SCALE_BLOCK_K // 4 * SPLIT_K) * stride_mx_k
             else:
-                MxScalePtrs += (MX_SCALE_BLOCK_K * SPLIT_K) * stride_mx_k
+                MxScalePtrs += (PACKED_MX_BLOCK * SPLIT_K) * stride_mx_k
         else:
             acc = tl.dot(x, w, acc, max_num_imprecise_acc=MAX_NUM_IMPRECISE_ACC, allow_tf32=ALLOW_TF32)
         XPtrs += (BLOCK_K * SPLIT_K) * stride_x_k

--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags_nvidia.py
@@ -13,10 +13,10 @@ def compute_grid_size(routing_data, m, n, block_m, block_n):
 
 
 def compute_block_n(n: int, arch, precision_config):
-    capability = torch.cuda.get_device_capability()[0] if arch is None else int(arch[2:-1])
     # block_n:
     block_n = max(16, min(128, triton.next_power_of_2(n)))
-    if capability >= 9 and precision_config.max_num_imprecise_acc is None and n > 128:
+    # On Ampere and Hopper, handshake with swizzle_mxfp4_scale_hopper
+    if precision_config.max_num_imprecise_acc is None and n > 128:
         block_n = 256
     return block_n
 


### PR DESCRIPTION
This improves utilisation from 28% to 37%.
Edit with https://github.com/triton-lang/triton/pull/6812 we hit 49% util.

We don't try to optimise the upcasting sequence yet but we could do that
if we are willing to add a global scale via a packing/unpacking sequence
by Scott Gray in a future PR.

We also add tests for quantisation in general.
