### PR TITLE
[Tests] Replace block_ptr with tensor_descriptor

### DIFF
--- a/python/test/unit/conftest.py
+++ b/python/test/unit/conftest.py
@@ -88,3 +88,16 @@ def fresh_knobs_except_libraries(monkeypatch):
         yield fresh_function()
     finally:
         reset_function()
+
+
+@pytest.fixture
+def with_allocator():
+    import triton
+    from triton.runtime._allocation import NullAllocator
+    from triton._internal_testing import default_alloc_fn
+
+    triton.set_allocator(default_alloc_fn)
+    try:
+        yield
+    finally:
+        triton.set_allocator(NullAllocator())

--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -32,40 +32,31 @@ def test_mma_remark(capfd, fresh_triton_cache):
         N,
         K,
         stride_am,
-        stride_ak,
-        stride_bk,
         stride_bn,
         stride_cm,
-        stride_cn,
     ):
-        a_block_ptr = tl.make_block_ptr(
+        a_desc = tl.make_tensor_descriptor(
             base=a_ptr,
-            shape=(M, K),
-            strides=(stride_am, stride_ak),
-            offsets=(0, 0),
-            block_shape=(32, 128),
-            order=(1, 0),
+            shape=[M, K],
+            strides=[stride_am, 1],
+            block_shape=[32, 128],
         )
-        b_block_ptr = tl.make_block_ptr(
+        b_desc = tl.make_tensor_descriptor(
             base=b_ptr,
-            shape=(K, N),
-            strides=(stride_bk, stride_bn),
-            offsets=(0, 0),
-            block_shape=(128, 32),
-            order=(0, 1),
+            shape=[K, N],
+            strides=[stride_bn, 1],
+            block_shape=[32, 128],
         )
-        c_block_ptr = tl.make_block_ptr(
+        c_desc = tl.make_tensor_descriptor(
             base=c_ptr,
-            shape=(M, N),
-            strides=(stride_cm, stride_cn),
-            offsets=(0, 0),
-            block_shape=(32, 32),
-            order=(1, 0),
+            shape=[M, N],
+            strides=[stride_cm, 1],
+            block_shape=[32, 32],
         )
-        a = tl.load(a_block_ptr)
-        b = tl.load(b_block_ptr)
+        a = a_desc.load([0, 0])
+        b = b_desc.load([0, 0]).T
         c = tl.dot(a, b)
-        tl.store(c_block_ptr, c)
+        c_desc.store([0, 0], c)
 
     signature = {
         "a_ptr": "*fp32",
@@ -75,11 +66,8 @@ def test_mma_remark(capfd, fresh_triton_cache):
         "N": "i32",
         "K": "i32",
         "stride_am": "i32",
-        "stride_ak": "i32",
-        "stride_bk": "i32",
         "stride_bn": "i32",
         "stride_cm": "i32",
-        "stride_cn": "i32",
     }
     with enable_diagnostics_context('remarks'):
         triton.compile(triton.compiler.ASTSource(

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -179,6 +179,10 @@ def tma_skip_msg(byval_only=False):
 requires_tma = pytest.mark.skipif(not supports_tma(), reason=tma_skip_msg())
 
 
+def default_alloc_fn(size: int, align: int, _):
+    return torch.empty(size, dtype=torch.int8, device="cuda")
+
+
 def unwrap_tensor(t: Union[torch.Tensor, triton.runtime.jit.TensorWrapper]) -> torch.Tensor:
     if isinstance(t, triton.runtime.jit.TensorWrapper):
         return t.base


### PR DESCRIPTION
<git-pr-chain>


[Tests] Replace block_ptr with tensor_descriptor

This changes tests that aren't specifically testing block_ptr to use
tensor_descriptor instead.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #6846 👈 **YOU ARE HERE**
1. #6847
1. #6848


</git-pr-chain>





