### PR TITLE
[TEST] Disable unsupported combinations in ensor reduce

### DIFF
--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -1496,6 +1496,9 @@ def test_tensor_descriptor_reduce(kind, descriptor, dtype_str, num_ctas, M_BLOCK
             pytest.skip("Multi-CTA not supported")
         if descriptor == "host":
             pytest.skip("NYI: Host side tensor descriptor fallback")
+        if (dtype_str.startswith("float") or dtype_str.startswith("bfloat")) and \
+                kind in ["min", "max", "and", "or", "xor"]:
+            pytest.skip(f"Incompatible reduce {kind=} and {dtype_str=} combination")
         if is_hip_cdna3() and (kind, dtype_str, M_BLOCK, N_BLOCK) in REDUCE_SKIP_HIP_CDNA3:
             pytest.skip("Broken on rocm")
 


### PR DESCRIPTION
These combinations are actually triggering errors like
"error: Cannot fallback on descriptor atomic op,
unsupported for type bf16".