### PR TITLE
[FRONTEND] Fix `__eq__` and `__add__` methods in `tl.tuple`

### DIFF
--- a/python/test/unit/language/test_tuple.py
+++ b/python/test/unit/language/test_tuple.py
@@ -166,12 +166,39 @@ def test_namedtuple(device):
 
 @pytest.mark.interpreter
 def test_eq(device):
+
     @triton.jit
     def fn(ret_ptrs):
-        tl.store(ret_ptrs + 0, (1, 2,) == (1, 2, ))
-        tl.store(ret_ptrs + 1, (1, 2,) == (1, 1, ))
-        tl.store(ret_ptrs + 2, tl.tuple((1, 2,)) == (1, 2, ))
-        tl.store(ret_ptrs + 3, tl.tuple((1, 2,)) == (1, 3,))
+        tl.store(ret_ptrs + 0, (
+            1,
+            2,
+        ) == (
+            1,
+            2,
+        ))
+        tl.store(ret_ptrs + 1, (
+            1,
+            2,
+        ) == (
+            1,
+            1,
+        ))
+        tl.store(ret_ptrs + 2,
+                 tl.tuple((
+                     1,
+                     2,
+                 )) == (
+                     1,
+                     2,
+                 ))
+        tl.store(ret_ptrs + 3,
+                 tl.tuple((
+                     1,
+                     2,
+                 )) == (
+                     1,
+                     3,
+                 ))
 
     rets = torch.zeros((4, ), dtype=torch.int32, device=device)
     fn[(1, )](rets)
@@ -183,15 +210,28 @@ def test_eq(device):
 
 @pytest.mark.interpreter
 def test_add(device):
+
     @triton.jit
     def fn(ret_ptrs):
-        tuple0 = (0, 1,) + (2, 3, )
+        tuple0 = (
+            0,
+            1,
+        ) + (
+            2,
+            3,
+        )
         for i in tl.static_range(4):
             tl.store(ret_ptrs + i, tuple0[i])
-        tuple1 = tl.tuple((4, 5,)) + (6, 7,)
+        tuple1 = tl.tuple((
+            4,
+            5,
+        )) + (
+            6,
+            7,
+        )
         for i in tl.static_range(4):
             tl.store(ret_ptrs + 4 + i, tuple1[i])
 
-    rets = torch.zeros((8,), dtype=torch.int32, device=device)
+    rets = torch.zeros((8, ), dtype=torch.int32, device=device)
     fn[(1, )](rets)
     torch.testing.assert_close(rets.cpu(), torch.arange(8, dtype=torch.int32))

--- a/python/test/unit/language/test_tuple.py
+++ b/python/test/unit/language/test_tuple.py
@@ -162,3 +162,36 @@ def test_namedtuple(device):
     ty = Tensor(y, y.shape, y.stride())
     _namedtuple_kernel[(1, )](function, tx, ty, 64, 64)
     assert torch.allclose(y, x[:16, :16] * a)
+
+
+@pytest.mark.interpreter
+def test_eq(device):
+    @triton.jit
+    def fn(ret_ptrs):
+        tl.store(ret_ptrs + 0, (1, 2,) == (1, 2, ))
+        tl.store(ret_ptrs + 1, (1, 2,) == (1, 1, ))
+        tl.store(ret_ptrs + 2, tl.tuple((1, 2,)) == (1, 2, ))
+        tl.store(ret_ptrs + 3, tl.tuple((1, 2,)) == (1, 3,))
+
+    rets = torch.zeros((4, ), dtype=torch.int32, device=device)
+    fn[(1, )](rets)
+    assert rets[0].item() == 1
+    assert rets[1].item() == 0
+    assert rets[2].item() == 1
+    assert rets[3].item() == 0
+
+
+@pytest.mark.interpreter
+def test_add(device):
+    @triton.jit
+    def fn(ret_ptrs):
+        tuple0 = (0, 1,) + (2, 3, )
+        for i in tl.static_range(4):
+            tl.store(ret_ptrs + i, tuple0[i])
+        tuple1 = tl.tuple((4, 5,)) + (6, 7,)
+        for i in tl.static_range(4):
+            tl.store(ret_ptrs + 4 + i, tuple1[i])
+
+    rets = torch.zeros((8,), dtype=torch.int32, device=device)
+    fn[(1, )](rets)
+    torch.testing.assert_close(rets.cpu(), torch.arange(8, dtype=torch.int32))

--- a/python/test/unit/language/test_tuple.py
+++ b/python/test/unit/language/test_tuple.py
@@ -169,36 +169,10 @@ def test_eq(device):
 
     @triton.jit
     def fn(ret_ptrs):
-        tl.store(ret_ptrs + 0, (
-            1,
-            2,
-        ) == (
-            1,
-            2,
-        ))
-        tl.store(ret_ptrs + 1, (
-            1,
-            2,
-        ) == (
-            1,
-            1,
-        ))
-        tl.store(ret_ptrs + 2,
-                 tl.tuple((
-                     1,
-                     2,
-                 )) == (
-                     1,
-                     2,
-                 ))
-        tl.store(ret_ptrs + 3,
-                 tl.tuple((
-                     1,
-                     2,
-                 )) == (
-                     1,
-                     3,
-                 ))
+        tl.store(ret_ptrs + 0, (1, 2) == (1, 2))
+        tl.store(ret_ptrs + 1, (1, 2) == (1, 1))
+        tl.store(ret_ptrs + 2, tl.tuple((1, 2)) == (1, 2))
+        tl.store(ret_ptrs + 3, tl.tuple((1, 2)) == (1, 3))
 
     rets = torch.zeros((4, ), dtype=torch.int32, device=device)
     fn[(1, )](rets)
@@ -213,22 +187,10 @@ def test_add(device):
 
     @triton.jit
     def fn(ret_ptrs):
-        tuple0 = (
-            0,
-            1,
-        ) + (
-            2,
-            3,
-        )
+        tuple0 = ((0, 1)) + (2, 3)
         for i in tl.static_range(4):
             tl.store(ret_ptrs + i, tuple0[i])
-        tuple1 = tl.tuple((
-            4,
-            5,
-        )) + (
-            6,
-            7,
-        )
+        tuple1 = tl.tuple((4, 5)) + (6, 7)
         for i in tl.static_range(4):
             tl.store(ret_ptrs + 4 + i, tuple1[i])
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -306,6 +306,13 @@ def _unwrap_if_constexpr(o):
     return o.value if isinstance(o, constexpr) else o
 
 
+def _normalize_tuple(t):
+    normalized_tuple = _unwrap_if_constexpr(t)
+    if isinstance(normalized_tuple, (list, builtins.tuple)):
+        normalized_tuple = tuple(normalized_tuple)
+    return normalized_tuple
+
+
 def check_bit_width(value, shift_value):
     if isinstance(value, tensor) and isinstance(shift_value, constexpr):
         bitwidth = value.type.scalar.primitive_bitwidth
@@ -1069,7 +1076,6 @@ class tensor(base_value):
 
     @builtin
     def __getitem__(self, slices, _builder=None):
-        import builtins
         if isinstance(slices, (builtins.slice, slice, constexpr)) or slices is None:
             slices = [slices]
         if isinstance(slices, tuple):
@@ -1237,7 +1243,7 @@ class tensor(base_value):
 
 class tuple(base_value):
 
-    def __init__(self, args: list, type: tuple_type = None):
+    def __init__(self, args: Sequence, type: tuple_type = None):
         self.values = [i for i in args]
 
         def get_type(x):
@@ -1255,7 +1261,6 @@ class tuple(base_value):
         if isinstance(idx, constexpr):
             return self.values[idx]
         else:
-            import builtins
             assert isinstance(idx, (slice, builtins.slice))
             return tuple(self.values[idx.start:idx.stop:idx.step])
 
@@ -1270,8 +1275,7 @@ class tuple(base_value):
         self.values[idx] = value
 
     def __add__(self, other):
-        if isinstance(other, list):
-            other = tuple(other)
+        other = _normalize_tuple(other)
         return tuple(self.values + other.values)
         # return tuple(a + b for a, b in zip(self.values, other.values))
 
@@ -1280,13 +1284,10 @@ class tuple(base_value):
         return tuple(self.values * other.value)
 
     def __eq__(self, other):
-        import builtins
-        if isinstance(other, (list, builtins.tuple)):
-            other = tuple(other)
+        other = _normalize_tuple(other)
         return constexpr(self.values == other.values)
 
     def __hash__(self):
-        import builtins
         return hash(builtins.tuple(self.values))
 
     def __str__(self):

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -498,7 +498,7 @@ def flip(x, dim=None):
 
     # reshape the swap dimension to (2, 2, ..., 2)
     idtype = core.get_int_dtype(bitwidth=x.dtype.primitive_bitwidth, signed=True)
-    y = core.reshape(x.to(idtype, bitcast=True), x.shape[:_dim] + (2,) * steps + x.shape[_dim + 1:])
+    y = core.reshape(x.to(idtype, bitcast=True), x.shape[:_dim] + [2] * steps + x.shape[_dim + 1:])
     for i in core.static_range(steps):
         y = y ^ xor_sum(y, _dim + i, True)
     x = core.reshape(y, x.shape).to(x.dtype, bitcast=True)

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -498,7 +498,7 @@ def flip(x, dim=None):
 
     # reshape the swap dimension to (2, 2, ..., 2)
     idtype = core.get_int_dtype(bitwidth=x.dtype.primitive_bitwidth, signed=True)
-    y = core.reshape(x.to(idtype, bitcast=True), x.shape[:_dim] + core.tuple([2] * steps) + x.shape[_dim + 1:])
+    y = core.reshape(x.to(idtype, bitcast=True), x.shape[:_dim] + (2,) * steps + x.shape[_dim + 1:])
     for i in core.static_range(steps):
         y = y ^ xor_sum(y, _dim + i, True)
     x = core.reshape(y, x.shape).to(x.dtype, bitcast=True)


### PR DESCRIPTION
* Added two `test_eq` and `test_add`
* Introduced a `_normalize_tuple` function to standardize tuple inputs. Otherwise, if `other` is a constexpr, both `__eq__` and `__add__` methods will fail
* Removed redundant imports of `builtins`
* Fixed a tuple construction issue in the `flip` function that previously requires the `core.tuple([2] * steps)` workaround