### PR TITLE
[Test] [AMD] Fix triton_kernels tests to support constraints on AMD

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -215,6 +215,7 @@ class Case:
 ])
 @pytest.mark.parametrize("has_y_gammas", [False, True])
 @pytest.mark.parametrize("is_persistent", [False, True])
+@pytest.mark.skipif(is_hip(), reason="AMD doesn't support constraints yet")
 def test_op(m, n, k, split_k, do_gather, do_scatter, fused_scatter, has_y_gammas, is_persistent, n_expts_tot,
             n_expts_act, n_expt_shards, mode, act_dtype_str, weight_dtype_str, block_m, hbm_swizzling, epilogue_subtile,
             device):

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -215,7 +215,6 @@ class Case:
 ])
 @pytest.mark.parametrize("has_y_gammas", [False, True])
 @pytest.mark.parametrize("is_persistent", [False, True])
-@pytest.mark.skipif(is_hip(), reason="AMD doesn't support constraints yet")
 def test_op(m, n, k, split_k, do_gather, do_scatter, fused_scatter, has_y_gammas, is_persistent, n_expts_tot,
             n_expts_act, n_expt_shards, mode, act_dtype_str, weight_dtype_str, block_m, hbm_swizzling, epilogue_subtile,
             device):

--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
@@ -1,6 +1,4 @@
 from dataclasses import dataclass
-
-import torch
 import triton
 from triton_kernels.numerics_details.mxfp import SwizzlingType
 import torch
@@ -111,7 +109,7 @@ def make_default_opt_flags_amd(
         epilogue_subtile = False
     # AMD-specific
     target_kernel_kwargs = {"waves_per_eu": 0, "matrix_instr_nonkdim": 16, "kpack": 1}
-    return OptFlags(
+    ret = OptFlags(
         block_m=block_m,
         block_n=block_n,
         block_k=block_k,
@@ -127,6 +125,9 @@ def make_default_opt_flags_amd(
         arch=None,
         target_kernel_kwargs=target_kernel_kwargs,
     )
+    # check constraints
+    assert all(getattr(ret, ck) == cv for ck, cv in constraints.items() if cv is not None), f"{ret} != {constraints}"
+    return ret
 
 def make_default_opt_flags_nvidia(
     out_dtype,

--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+
+import torch
 import triton
 from triton_kernels.numerics_details.mxfp import SwizzlingType
 import torch
@@ -46,7 +48,8 @@ def make_default_opt_flags_amd(
     has_expensive_epilogue,
     constraints,
 ):
-    assert not constraints, "flags constraints not supported on AMD"
+    constraints_supported = ["block_m", "block_k", "split_k", "fused_scatter", "is_persistent", "epilogue_subtile"]
+    assert not any([c not in constraints_supported for c in constraints]), constraints.keys()
     # tokens per expert
     if routing_data is None:
         tokens_per_expt = m
@@ -76,19 +79,36 @@ def make_default_opt_flags_amd(
     block_n, block_k = opt_flags_amd.compute_block_nk(
         n, block_m, grid_m, num_xcds, lhs_dtype, rhs_dtype, microscaling_ctx
     )
+    # Replace block_k if provided in constraints.
+    # TODO: Does opt_flags_amd.compute_block_nk need to be refactored?
+    if constraints.get("block_k", None) is not None:
+        block_k = constraints["block_k"]
+    if constraints.get("is_persistent", None) is not None:
+        is_persistent = constraints["is_persistent"]
+    else:
+        is_persistent = False
     # split_k:
-    grid_size = grid_m * ((n + block_n - 1) // block_n)
-    n_cu = torch.cuda.get_device_properties(0).multi_processor_count
-    if enforce_bitwise_invariance:
+    if constraints.get("split_k", None) is not None:
+        split_k = constraints["split_k"]
+    elif is_persistent or enforce_bitwise_invariance:
         split_k = 1
     else:
+        grid_size = grid_m * ((n + block_n - 1) // block_n)
+        n_cu = torch.cuda.get_device_properties(0).multi_processor_count
         split_k = max(1, n_cu // grid_size)
     # w_cache_modifier:
     w_cache_modifier = ".cg" if block_m <= 32 else None
     # num_warps, num_stages
     num_warps = 2 if (m is not None and m <= 16) else 8
     num_stages = 2
-    is_persistent = False
+    if constraints.get("fused_scatter", None) is not None:
+        fused_scatter = constraints["fused_scatter"]
+    else:
+        fused_scatter = False
+    if constraints.get("epilogue_subtile", None) is not None:
+        epilogue_subtile = constraints["epilogue_subtile"]
+    else:
+        epilogue_subtile = False
     # AMD-specific
     target_kernel_kwargs = {"waves_per_eu": 0, "matrix_instr_nonkdim": 16, "kpack": 1}
     return OptFlags(
@@ -101,9 +121,9 @@ def make_default_opt_flags_amd(
         xcd_swizzle=xcd_swizzle,
         w_cache_modifier=w_cache_modifier,
         split_k=split_k,
-        fused_scatter=False,
+        fused_scatter=fused_scatter,
         is_persistent=is_persistent,
-        epilogue_subtile=False,
+        epilogue_subtile=epilogue_subtile,
         arch=None,
         target_kernel_kwargs=target_kernel_kwargs,
     )


### PR DESCRIPTION
`test_op` sets constraints when calling `matmul_ogs`, which fails because `make_default_opt_flags_amd` requires constrains not to be passed in. This updates `make_default_opt_flags_amd` to accept the constraints without modify the logic for the default behavior.