### PR TITLE
[PROTON-DEV] Better profiler buffer default size and opt mode

### DIFF
--- a/test/Proton/allocate_shared_memory.mlir
+++ b/test/Proton/allocate_shared_memory.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt --split-input-file -allocate-shared-memory -convert-proton-to-protongpu="max-shared-mem-size=4096" -allocate-proton-shared-memory %s | FileCheck %s
 
 #A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
-// CHECK: ttg.shared = 3584 : i32
+// CHECK: ttg.shared = 1664 : i32
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
   // CHECK-LABEL: allocate_aligned
   tt.func @allocate_aligned(%A : !tt.ptr<f16>) {
@@ -21,7 +21,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // -----
 
 #A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
-// CHECK: ttg.shared = 2064 : i32
+// CHECK: ttg.shared = 144 : i32
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
   // CHECK-LABEL: allocate_unaligned
   tt.func @allocate_unaligned(%A : !tt.ptr<f16>) {

--- a/test/Proton/proton_to_protongpu.mlir
+++ b/test/Proton/proton_to_protongpu.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt --split-input-file -convert-proton-to-protongpu="max-shared-mem-size=1024" -canonicalize -cse %s | FileCheck %s
+// RUN: triton-opt --split-input-file -convert-proton-to-protongpu="max-shared-mem-size=32768" -canonicalize -cse %s | FileCheck %s
 
 module {
   // CHECK-LABEL: no_record

--- a/third_party/proton/common/include/TraceDataIO/TraceWriter.h
+++ b/third_party/proton/common/include/TraceDataIO/TraceWriter.h
@@ -2,6 +2,7 @@
 #define PROTON_COMMON_TRACE_WRITER_H_
 
 #include "CircularLayoutParser.h"
+#include "nlohmann/json.hpp"
 #include <cstdint>
 #include <fstream>
 #include <map>
@@ -50,7 +51,7 @@ public:
 
 private:
   void write(std::ofstream &outfile) override final;
-  void writeKernel(std::stringstream &outstream, const KernelTrace &kernelTrace,
+  void writeKernel(nlohmann::json &object, const KernelTrace &kernelTrace,
                    uint32_t kernelTimeStart);
 
   const std::vector<std::string> kChromeColor = {"cq_build_passed",

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -82,14 +82,10 @@ def _interpret_mode(mode_obj: Union[str, mode.InstrumentationMode]) -> mode.Inst
 
     # Get option values or empty strings
     options = {
-        "metric_type": opts.get("metric_type", "cycle"),
-        "buffer_type": opts.get("buffer_type", "shared"),
-        "buffer_strategy": opts.get("buffer_strategy", "circular"),
-        "buffer_size": int(opts.get("buffer_size", "0")),
-        "granularity": opts.get("granularity", "warp"),
-        "sampling_strategy": opts.get("sampling_strategy", "none"),
-        "sampling_options": opts.get("sampling_options", ""),
-        "optimization": opts.get("optimization", "none")
+        "metric_type": opts.get("metric_type", "cycle"), "buffer_type": opts.get("buffer_type", "shared"),
+        "buffer_strategy": opts.get("buffer_strategy", "circular"), "buffer_size": int(opts.get("buffer_size", "0")),
+        "granularity": opts.get("granularity", "warp"), "sampling_strategy": opts.get("sampling_strategy", "none"),
+        "sampling_options": opts.get("sampling_options", ""), "optimization": opts.get("optimization", "none")
     }
 
     # Helper function to validate and map options to their enum values

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -89,6 +89,7 @@ def _interpret_mode(mode_obj: Union[str, mode.InstrumentationMode]) -> mode.Inst
         "granularity": opts.get("granularity", "warp"),
         "sampling_strategy": opts.get("sampling_strategy", "none"),
         "sampling_options": opts.get("sampling_options", ""),
+        "optimization": opts.get("optimization", "none")
     }
 
     # Helper function to validate and map options to their enum values

--- a/third_party/proton/proton/mode.py
+++ b/third_party/proton/proton/mode.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass, field
 from triton._C.libtriton import proton as triton_proton
 from enum import Enum
 
-
 metric_types = {"cycle": triton_proton.METRIC_TYPE.CYCLE}
 
 buffer_strategies = {

--- a/third_party/proton/proton/mode.py
+++ b/third_party/proton/proton/mode.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 from triton._C.libtriton import proton as triton_proton
+from enum import Enum
+
 
 metric_types = {"cycle": triton_proton.METRIC_TYPE.CYCLE}
 
@@ -31,6 +33,14 @@ granularities = {
 }
 
 
+class Optimize(Enum):
+    NONE = "none"
+    TIMESHIFT = "time_shift"
+
+    def __str__(self):
+        return self.value
+
+
 @dataclass(frozen=True)
 class BaseMode:
     name: str
@@ -59,6 +69,7 @@ class InstrumentationMode(BaseMode):
     buffer_strategy: triton_proton.BUFFER_STRATEGY = triton_proton.BUFFER_STRATEGY.CIRCULAR
     buffer_type: triton_proton.BUFFER_TYPE = triton_proton.BUFFER_TYPE.SHARED
     buffer_size: int = 0
+    optimization: Optimize = Optimize.NONE
 
     def __post_init__(self):
         # automatically map string inputs to enums using the global lookup dicts
@@ -80,7 +91,7 @@ class InstrumentationMode(BaseMode):
         return (f"{self.name}:metric_type={self.metric_type}:sampling_strategy={self.sampling_strategy}"
                 f":sampling_options={self.sampling_options}:granularity={self.granularity}"
                 f":buffer_strategy={self.buffer_strategy}:buffer_type={self.buffer_type}"
-                f":buffer_size={self.buffer_size}")
+                f":buffer_size={self.buffer_size}:optimization={self.optimization}")
 
 
 @dataclass(frozen=True)

--- a/third_party/proton/test/unittest/TraceDataIO/ChromeTraceWriterTest.cpp
+++ b/third_party/proton/test/unittest/TraceDataIO/ChromeTraceWriterTest.cpp
@@ -96,8 +96,8 @@ TEST_F(ChromeTraceWriterTest, SingleBlock) {
   EXPECT_EQ(data["traceEvents"].size(), 2);
   EXPECT_EQ(data["traceEvents"][0]["name"], "s1");
   EXPECT_EQ(data["traceEvents"][1]["name"], "scope_7");
-  EXPECT_EQ(data["traceEvents"][0]["ts"], "0");
-  EXPECT_EQ(data["traceEvents"][1]["ts"], "0.1");
+  EXPECT_EQ(data["traceEvents"][0]["ts"], 0.0);
+  EXPECT_EQ(data["traceEvents"][1]["ts"], 0.1);
 }
 
 TEST_F(ChromeTraceWriterTest, MultiBlockMultiWarp) {
@@ -203,10 +203,10 @@ TEST_F(ChromeTraceWriterTest, MultiKernel) {
 
   EXPECT_EQ(data.empty(), false);
   EXPECT_EQ(data["traceEvents"][0]["cat"], "kernel1");
-  EXPECT_EQ(data["traceEvents"][0]["ts"], "0");
-  EXPECT_EQ(data["traceEvents"][0]["dur"], "400");
+  EXPECT_EQ(data["traceEvents"][0]["ts"], 0.0);
+  EXPECT_EQ(data["traceEvents"][0]["dur"], 400.0);
   EXPECT_EQ(data["traceEvents"][1]["cat"], "kernel1");
   EXPECT_EQ(data["traceEvents"][2]["cat"], "kernel2");
-  EXPECT_EQ(data["traceEvents"][2]["ts"], "10000");
-  EXPECT_EQ(data["traceEvents"][2]["dur"], "400");
+  EXPECT_EQ(data["traceEvents"][2]["ts"], 10000.0);
+  EXPECT_EQ(data["traceEvents"][2]["dur"], 400.0);
 }


### PR DESCRIPTION
This PR adds: 
1. hard cap of default profiler shared memory buffer size: at most 4% of total smem size when estimated occupancy > 1 
2. the optimization mode in `instrumentation.py`. That optimization mode is intended to be the knobs outside the compiler (e.g., trace post processing).
3. change string concat to using json object in the `ChromeTraceWriter`