### PR TITLE
[NFC] Remove uses of deprecated `GEN_PASS_CLASSES` for `TritonNvidiaGPU/Transforms`

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -44,7 +44,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerAllPasses();
   mlir::triton::registerTritonPasses();
   mlir::triton::gpu::registerTritonGPUPasses();
-  mlir::registerTritonNvidiaGPUPasses();
+  mlir::triton::nvidia_gpu::registerTritonNvidiaGPUPasses();
   mlir::test::registerTestAliasPass();
   mlir::test::registerTestAlignmentPass();
   mlir::test::registerTestAllocationPass();

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h
@@ -38,6 +38,9 @@ struct ClusterInfo {
   int clusterDimZ;
 };
 
+std::unique_ptr<Pass> createTritonNvidiaGPUPlanCTAPass(
+    mlir::triton::nvidia_gpu::ClusterInfo *clusterInfo = nullptr);
+
 #define GEN_PASS_DECL
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h
@@ -38,38 +38,16 @@ struct ClusterInfo {
   int clusterDimZ;
 };
 
-} // namespace nvidia_gpu
-} // namespace triton
-} // namespace mlir
-
-namespace mlir {
-
-std::unique_ptr<Pass> createTritonNvidiaGPUPlanCTAPass(
-    mlir::triton::nvidia_gpu::ClusterInfo *clusterInfo = nullptr);
-
-std::unique_ptr<Pass>
-createTritonNvidiaGPUFenceInsertionPass(int computeCapability = 90);
-
-std::unique_ptr<Pass> createTritonNvidiaGPUTMALoweringPass();
-
-std::unique_ptr<Pass> createTensorMemoryAllocationPass();
-
-std::unique_ptr<Pass> createTritonNvidiaGPUMMALoweringPass();
-
-std::unique_ptr<Pass> createTritonNvidiaGPUPromoteLHSToTMemPass();
-
-std::unique_ptr<Pass> createTritonNvidiaGPURemoveTMEMTokensPass();
-
-std::unique_ptr<Pass> createTritonNvidiaGPUOptimizeDescriptorEncodingPass();
-
-std::unique_ptr<Pass> createTritonNvidiaGPUOptimizeTMemLayoutsPass();
-
-std::unique_ptr<Pass> createTritonNvidiaGPUInterleaveTMemPass();
+#define GEN_PASS_DECL
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #define GEN_PASS_DECL_TRITONNVIDIAGPULEGALIZETMALAYOUTS
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
+} // namespace nvidia_gpu
+} // namespace triton
 } // namespace mlir
+
 #endif // TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_PASSES_H_

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -32,8 +32,6 @@ def TritonGPUPlanCTAPass : Pass<"triton-nvidia-gpu-plan-cta", "mlir::ModuleOp"> 
     and StoreLikeOps operations.
   }];
 
-  let constructor = "mlir::createTritonNvidiaGPUPlanCTAPass()";
-
   let dependentDialects = [
     "mlir::triton::gpu::TritonGPUDialect",
     "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
@@ -47,8 +45,6 @@ def TritonGPUFenceInsertion : Pass<"triton-nvidia-gpu-fence-insertion", "mlir::M
     This pass is to insert memory fences to ensure that memory operations are
     properly ordered across generic and async operations.
   }];
-
-  let constructor = "mlir::createTritonNvidiaGPUFenceInsertionPass()";
 
   let dependentDialects = [
     "mlir::triton::gpu::TritonGPUDialect",
@@ -69,21 +65,17 @@ def TritonNvidiaGPUTMALoweringPass : Pass<"triton-nvidia-tma-lowering", "mlir::M
     Lower Triton experimental descriptor load to TMA load/store operations in TritonNvidiaGPUDialect.
   }];
 
-  let constructor = "mlir::createTritonNvidiaGPUTMALoweringPass()";
-
   let dependentDialects = [
     "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
   ];
 }
 
-def TritionTensorMemoryAllocationPass : Pass<"triton-tensor-memory-allocation", "mlir::ModuleOp"> {
+def TritonTensorMemoryAllocationPass : Pass<"triton-tensor-memory-allocation", "mlir::ModuleOp"> {
   let summary = "Assign tensor memory allocation";
 
   let description = [{
     Decide on tensor memory allocation and assign attributes to each allocation.
   }];
-
-  let constructor = "mlir::createTensorMemoryAllocationPass()";
 
   let dependentDialects = [
     "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
@@ -97,8 +89,6 @@ def TritonNvidiaGPUMMALoweringPass : Pass<"triton-nvidia-mma-lowering", "mlir::M
     Lower MMA ops to prepare for conversion to LLVM.
   }];
 
-  let constructor = "mlir::createTritonNvidiaGPUMMALoweringPass()";
-
   let dependentDialects = [
     "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
   ];
@@ -110,8 +100,6 @@ def TritonNvidiaGPUPromoteLHSToTMemPass : Pass<"tritongpu-promote-lhs-to-tmem", 
   let description = [{
     Promote LHS operand of MMAv5 op to Tensor Memory.
   }];
-
-  let constructor = "mlir::createTritonNvidiaGPUPromoteLHSToTMemPass()";
 
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
                            "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -32,6 +32,8 @@ def TritonGPUPlanCTAPass : Pass<"triton-nvidia-gpu-plan-cta", "mlir::ModuleOp"> 
     and StoreLikeOps operations.
   }];
 
+  let constructor = "mlir::triton::nvidia_gpu::createTritonNvidiaGPUPlanCTAPass()";
+
   let dependentDialects = [
     "mlir::triton::gpu::TritonGPUDialect",
     "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
@@ -5,17 +5,16 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 
-#include <memory>
+namespace ttg = mlir::triton::gpu;
 
-#define GEN_PASS_CLASSES
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUMMALOWERINGPASS
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 namespace {
-
-using namespace mlir;
-using namespace triton;
-using namespace triton::gpu;
-using namespace triton::nvidia_gpu;
 
 template <typename TCGen5MMAOpTy>
 class SyncMMALowering : public OpRewritePattern<TCGen5MMAOpTy> {
@@ -29,17 +28,17 @@ public:
       return failure();
     MLIRContext *ctx = op.getContext();
     Location loc = op.getLoc();
-    Attribute sharedMemorySpace = SharedMemorySpaceAttr::get(ctx);
-    auto barrierCTALayout = CTALayoutAttr::get(
+    Attribute sharedMemorySpace = ttg::SharedMemorySpaceAttr::get(ctx);
+    auto barrierCTALayout = ttg::CTALayoutAttr::get(
         /*context=*/ctx, /*CTAsPerCGA=*/{1},
         /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
-    auto barrierEncoding =
-        SwizzledSharedEncodingAttr::get(ctx, 1, 1, 1, {0}, barrierCTALayout);
-    MemDescType barrierMemDescType =
-        MemDescType::get({1}, rewriter.getI64Type(), barrierEncoding,
-                         sharedMemorySpace, /*mutableMemory=*/true);
+    auto barrierEncoding = ttg::SwizzledSharedEncodingAttr::get(
+        ctx, 1, 1, 1, {0}, barrierCTALayout);
+    ttg::MemDescType barrierMemDescType =
+        ttg::MemDescType::get({1}, rewriter.getI64Type(), barrierEncoding,
+                              sharedMemorySpace, /*mutableMemory=*/true);
     Value barrierAlloc =
-        rewriter.create<LocalAllocOp>(loc, barrierMemDescType, Value());
+        rewriter.create<ttg::LocalAllocOp>(loc, barrierMemDescType, Value());
     rewriter.create<InitBarrierOp>(loc, barrierAlloc, 1);
     op.addCompletionBarrier(barrierAlloc,
                             rewriter.create<arith::ConstantIntOp>(loc, 1, 1));
@@ -63,18 +62,18 @@ struct TCGen5MMAScaleSharedToTmemConversion
     Location loc = operand.getOwner()->getLoc();
     MLIRContext *context = operand.getOwner()->getContext();
     Attribute tensorMemorySpace = TensorMemorySpaceAttr::get(context);
-    auto oldType = cast<MemDescType>(operand.get().getType());
+    auto oldType = cast<ttg::MemDescType>(operand.get().getType());
     auto numElems = product(oldType.getShape());
     Type elType = oldType.getElementType();
-    CTALayoutAttr CTALayout = getCTALayout(oldType.getEncoding());
+    ttg::CTALayoutAttr CTALayout = ttg::getCTALayout(oldType.getEncoding());
     ArrayRef<unsigned> CTASplitNum = CTALayout.getCTASplitNum();
     // Distribute the scales across the rows of the MMA operation.
     SmallVector<int64_t> shape = {rows, numElems / rows};
     Attribute scaleEncoding = TensorMemoryScalesEncodingAttr::get(
         context, CTASplitNum[0], CTASplitNum[1]);
     Type scaleAType =
-        MemDescType::get(shape, elType, scaleEncoding, tensorMemorySpace,
-                         /*mutableMemory=*/true);
+        ttg::MemDescType::get(shape, elType, scaleEncoding, tensorMemorySpace,
+                              /*mutableMemory=*/true);
     auto tmemAlloc = rewriter.create<TMEMAllocOp>(loc, scaleAType, Value());
     rewriter.create<TMEMCopyOp>(loc, operand.get(), tmemAlloc,
                                 /*barrier*/ Value());
@@ -91,18 +90,20 @@ struct TCGen5MMAScaleSharedToTmemConversion
     int blockM = op.getBlockM();
     int blockN = op.getBlockN();
     bool anyChanged = false;
-    if (isa<SharedMemorySpaceAttr>(aScaleType.getMemorySpace())) {
+    if (isa<ttg::SharedMemorySpaceAttr>(aScaleType.getMemorySpace())) {
       anyChanged = lowerScaleToTmem(op.getAScaleMutable(), rewriter, blockM);
     }
-    if (isa<SharedMemorySpaceAttr>(bScaleType.getMemorySpace())) {
+    if (isa<ttg::SharedMemorySpaceAttr>(bScaleType.getMemorySpace())) {
       anyChanged = lowerScaleToTmem(op.getBScaleMutable(), rewriter, blockN);
     }
     return LogicalResult::success(anyChanged);
   }
 };
 
+} // anonymous namespace
+
 class TritonNvidiaGPUMMALoweringPass
-    : public TritonNvidiaGPUMMALoweringPassBase<
+    : public impl::TritonNvidiaGPUMMALoweringPassBase<
           TritonNvidiaGPUMMALoweringPass> {
 public:
   void runOnOperation() override {
@@ -118,8 +119,6 @@ public:
   }
 };
 
-} // namespace
-
-std::unique_ptr<Pass> mlir::createTritonNvidiaGPUMMALoweringPass() {
-  return std::make_unique<TritonNvidiaGPUMMALoweringPass>();
-}
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
@@ -31,14 +31,16 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/ErrorHandling.h"
 
-#define GEN_PASS_CLASSES
+namespace ttg = mlir::triton::gpu;
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONGPUPLANCTAPASS
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 namespace {
-
-using namespace mlir;
-namespace ttg = ::mlir::triton::gpu;
-namespace ttng = ::mlir::triton::nvidia_gpu;
 
 // TODO: use ConvertLayoutOp
 using CastOp = ::mlir::UnrealizedConversionCastOp;
@@ -83,7 +85,7 @@ replaceCTALayout(ttg::DistributedEncodingTrait layout,
 
 class CTAPlanner {
 public:
-  CTAPlanner(ttng::ClusterInfo *clusterInfo_);
+  CTAPlanner(ClusterInfo *clusterInfo_);
   ~CTAPlanner();
 
   void run(triton::FuncOp &funcOp);
@@ -154,18 +156,18 @@ private:
   // Otherwise, a self-managed ClusterInfo will be created and the ownInfo will
   // be set to true.
   bool ownInfo;
-  ttng::ClusterInfo *clusterInfo;
+  ClusterInfo *clusterInfo;
   bool tiled;
   unsigned step;
   unsigned stepUnchanged;
   std::queue<CastOp> queue;
 };
 
-CTAPlanner::CTAPlanner(ttng::ClusterInfo *clusterInfo_)
+CTAPlanner::CTAPlanner(ClusterInfo *clusterInfo_)
     : ownInfo(false), clusterInfo(clusterInfo_), tiled(false), step(0),
       stepUnchanged(0) {
   if (clusterInfo == nullptr) {
-    clusterInfo = new ttng::ClusterInfo();
+    clusterInfo = new ClusterInfo();
     ownInfo = true;
   }
 }
@@ -1037,10 +1039,11 @@ bool CTAPlanner::processMultiUsersForward(Value castResult, CastOp cast) {
   return true;
 }
 
-struct PlanCTAPass : public TritonGPUPlanCTAPassBase<PlanCTAPass> {
-  PlanCTAPass(ttng::ClusterInfo *clusterInfo_ = nullptr)
-      : clusterInfo(clusterInfo_) {}
+} // anonymous namespace
 
+struct PlanCTAPass : public impl::TritonGPUPlanCTAPassBase<PlanCTAPass> {
+  PlanCTAPass(ClusterInfo *clusterInfo_ = nullptr)
+      : clusterInfo(clusterInfo_) {}
   void runOnOperation() override {
     ModuleOp mod = getOperation();
 
@@ -1062,15 +1065,12 @@ struct PlanCTAPass : public TritonGPUPlanCTAPassBase<PlanCTAPass> {
     });
   }
 
-  ttng::ClusterInfo *clusterInfo;
+  ClusterInfo *clusterInfo;
 };
 
-} // namespace
-
-std::unique_ptr<Pass>
-mlir::createTritonNvidiaGPUPlanCTAPass(ttng::ClusterInfo *clusterInfo) {
-  return std::make_unique<PlanCTAPass>(clusterInfo);
-}
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir
 
 /* TODO
  * - Use ConvertLayoutOp instead of UnrealizedConversionCastOp.

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
@@ -1068,6 +1068,11 @@ struct PlanCTAPass : public impl::TritonGPUPlanCTAPassBase<PlanCTAPass> {
   ClusterInfo *clusterInfo;
 };
 
+std::unique_ptr<Pass>
+createTritonNvidiaGPUPlanCTAPass(ClusterInfo *clusterInfo) {
+  return std::make_unique<PlanCTAPass>(clusterInfo);
+}
+
 } // namespace nvidia_gpu
 } // namespace triton
 } // namespace mlir

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
@@ -7,23 +7,21 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
-#include <memory>
 
-namespace {
+namespace ttg = mlir::triton::gpu;
 
-using namespace mlir;
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
 
-namespace ttng = triton::nvidia_gpu;
-namespace ttg = triton::gpu;
-
-#define GEN_PASS_CLASSES
+#define GEN_PASS_DEF_TRITONNVIDIAGPUPROMOTELHSTOTMEMPASS
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 namespace {
 template <class MMAOpTy>
 Attribute getLHSTMemLayout(MMAOpTy tcGen5MMAOp, RankedTensorType srcType) {
   int numWarps = ttg::lookupNumWarps(tcGen5MMAOp);
-  auto accTmemEncoding = dyn_cast<ttng::TensorMemoryEncodingAttr>(
+  auto accTmemEncoding = dyn_cast<TensorMemoryEncodingAttr>(
       tcGen5MMAOp.getD().getType().getEncoding());
   auto lhs = tcGen5MMAOp.getA();
   auto lhsShape = lhs.getType().getShape();
@@ -31,7 +29,7 @@ Attribute getLHSTMemLayout(MMAOpTy tcGen5MMAOp, RankedTensorType srcType) {
   // N has to follow the number of columns in the LHS.
   int M = accTmemEncoding.getBlockM();
   int N = lhsShape[1];
-  Attribute resLayout = ttng::getTmemCompatibleLayout(M, N, srcType, numWarps);
+  Attribute resLayout = getTmemCompatibleLayout(M, N, srcType, numWarps);
   return resLayout;
 }
 
@@ -53,12 +51,12 @@ public:
     Value src = localAllocOp.getSrc();
     auto srcType = cast<RankedTensorType>(src.getType());
     auto srcLayout = srcType.getEncoding();
-    auto accTMemEncoding = dyn_cast<ttng::TensorMemoryEncodingAttr>(
+    auto accTMemEncoding = dyn_cast<TensorMemoryEncodingAttr>(
         tcGen5MMAOp.getD().getType().getEncoding());
     ArrayRef<unsigned> CTASplitNum =
         triton::gpu::getCTALayout(srcLayout).getCTASplitNum();
     // TMem encoding for A operand is the same as for D (Acc), but packed.
-    auto aTMemEncoding = ttng::TensorMemoryEncodingAttr::get(
+    auto aTMemEncoding = TensorMemoryEncodingAttr::get(
         context, accTMemEncoding.getBlockM(), lhs.getType().getShape()[1],
         /*unpacked=*/false, CTASplitNum[0], CTASplitNum[1]);
     Attribute tensorMemorySpace =
@@ -67,8 +65,8 @@ public:
         lhs.getType().getShape(), lhs.getType().getElementType(), aTMemEncoding,
         tensorMemorySpace,
         /*mutableMemory=*/false);
-    bool layoutTmemCompatible = ttng::isDistributedLayoutTMemCompatible(
-        tcGen5MMAOp, srcType, lhsMemDescType);
+    bool layoutTmemCompatible =
+        isDistributedLayoutTMemCompatible(tcGen5MMAOp, srcType, lhsMemDescType);
     Attribute newLayout = srcLayout;
     if (!layoutTmemCompatible) {
       if (triton::tools::getBoolEnv("ALLOW_LHS_TMEM_LAYOUT_CONVERSION")) {
@@ -84,8 +82,7 @@ public:
           RankedTensorType::get(ty.getShape(), ty.getElementType(), newLayout);
       src = rewriter.create<ttg::ConvertLayoutOp>(loc, newTy, src);
     }
-    Value tMemAlloc =
-        rewriter.create<ttng::TMEMAllocOp>(loc, lhsMemDescType, src);
+    Value tMemAlloc = rewriter.create<TMEMAllocOp>(loc, lhsMemDescType, src);
     tcGen5MMAOp.getAMutable().assign(tMemAlloc);
     return success();
   }
@@ -93,7 +90,7 @@ public:
 } // namespace
 
 class TritonNvidiaGPUPromoteLHSToTMemPass
-    : public TritonNvidiaGPUPromoteLHSToTMemPassBase<
+    : public impl::TritonNvidiaGPUPromoteLHSToTMemPassBase<
           TritonNvidiaGPUPromoteLHSToTMemPass> {
 public:
   using TritonNvidiaGPUPromoteLHSToTMemPassBase<
@@ -105,16 +102,14 @@ public:
     ModuleOp m = getOperation();
 
     RewritePatternSet patterns(context);
-    patterns.add<LHSToTMem<ttng::TCGen5MMAOp>>(context);
-    patterns.add<LHSToTMem<ttng::TCGen5MMAScaledOp>>(context);
+    patterns.add<LHSToTMem<TCGen5MMAOp>>(context);
+    patterns.add<LHSToTMem<TCGen5MMAScaledOp>>(context);
     if (applyPatternsGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();
     }
   }
 };
 
-} // namespace
-
-std::unique_ptr<Pass> mlir::createTritonNvidiaGPUPromoteLHSToTMemPass() {
-  return std::make_unique<TritonNvidiaGPUPromoteLHSToTMemPass>();
-}
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -14,17 +14,14 @@
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "llvm/Support/ErrorHandling.h"
 
-#include <memory>
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
 
-#define GEN_PASS_CLASSES
+#define GEN_PASS_DEF_TRITONNVIDIAGPUTMALOWERINGPASS
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 namespace {
-
-using namespace mlir;
-using namespace triton;
-using namespace triton::gpu;
-using namespace triton::nvidia_gpu;
 
 static Attribute getEncoding(Operation *op, RankedTensorType tensorType,
                              Value desc) {
@@ -36,31 +33,31 @@ static Attribute getEncoding(Operation *op, RankedTensorType tensorType,
     op->emitError() << msg;
     llvm::report_fatal_error(msg);
   }
-  assert(isa<SharedEncodingTrait>(encoding));
+  assert(isa<gpu::SharedEncodingTrait>(encoding));
   if (descBlockType.getShape() == tensorType.getShape())
     return encoding;
 
   // Handle rank reducing loads
   auto ctx = encoding.getContext();
   auto rankDiff = descBlockType.getRank() - tensorType.getRank();
-  if (auto nvmmaEnc = dyn_cast<NVMMASharedEncodingAttr>(encoding)) {
+  if (auto nvmmaEnc = dyn_cast<gpu::NVMMASharedEncodingAttr>(encoding)) {
     auto existingCta = nvmmaEnc.getCTALayout();
-    auto newCtaEnc =
-        CTALayoutAttr::get(ctx, existingCta.getCTAsPerCGA().slice(rankDiff),
-                           existingCta.getCTASplitNum().slice(rankDiff),
-                           existingCta.getCTAOrder().slice(rankDiff));
+    auto newCtaEnc = gpu::CTALayoutAttr::get(
+        ctx, existingCta.getCTAsPerCGA().slice(rankDiff),
+        existingCta.getCTASplitNum().slice(rankDiff),
+        existingCta.getCTAOrder().slice(rankDiff));
 
-    return NVMMASharedEncodingAttr::get(
+    return gpu::NVMMASharedEncodingAttr::get(
         ctx, nvmmaEnc.getSwizzlingByteWidth(), nvmmaEnc.getTransposed(),
         nvmmaEnc.getElementBitWidth(), nvmmaEnc.getFp4Padded(), newCtaEnc);
   }
-  if (auto swizEnc = dyn_cast<SwizzledSharedEncodingAttr>(encoding)) {
+  if (auto swizEnc = dyn_cast<gpu::SwizzledSharedEncodingAttr>(encoding)) {
     auto existingCta = swizEnc.getCTALayout();
-    auto newCtaEnc =
-        CTALayoutAttr::get(ctx, existingCta.getCTAsPerCGA().slice(rankDiff),
-                           existingCta.getCTASplitNum().slice(rankDiff),
-                           existingCta.getCTAOrder().slice(rankDiff));
-    return SwizzledSharedEncodingAttr::get(
+    auto newCtaEnc = gpu::CTALayoutAttr::get(
+        ctx, existingCta.getCTAsPerCGA().slice(rankDiff),
+        existingCta.getCTASplitNum().slice(rankDiff),
+        existingCta.getCTAOrder().slice(rankDiff));
+    return gpu::SwizzledSharedEncodingAttr::get(
         ctx, swizEnc.getVec(), swizEnc.getPerPhase(), swizEnc.getMaxPhase(),
         swizEnc.getOrder().slice(rankDiff), newCtaEnc);
   }
@@ -78,19 +75,20 @@ lowerTMALoad(Operation *op, RankedTensorType tensorType, Value desc,
   Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
   auto loc = op->getLoc();
   auto encoding = getEncodingFromDescriptor(op, tensorType, desc);
-  MemDescType memDescType =
-      MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
-                       encoding, sharedMemorySpace, /*mutableMemory=*/true);
-  auto alloc = rewriter.create<LocalAllocOp>(loc, memDescType).getResult();
-  auto barrierCTALayout = CTALayoutAttr::get(
+  gpu::MemDescType memDescType = gpu::MemDescType::get(
+      tensorType.getShape(), tensorType.getElementType(), encoding,
+      sharedMemorySpace, /*mutableMemory=*/true);
+  auto alloc = rewriter.create<gpu::LocalAllocOp>(loc, memDescType).getResult();
+  auto barrierCTALayout = gpu::CTALayoutAttr::get(
       /*context=*/tensorType.getContext(), /*CTAsPerCGA=*/{1},
       /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
-  auto barrierEncoding = SwizzledSharedEncodingAttr::get(
+  auto barrierEncoding = gpu::SwizzledSharedEncodingAttr::get(
       tensorType.getContext(), 1, 1, 1, {0}, barrierCTALayout);
-  MemDescType barrierMemDescType =
-      MemDescType::get({1}, rewriter.getI64Type(), barrierEncoding,
-                       sharedMemorySpace, /*mutableMemory=*/true);
-  Value barrierAlloc = rewriter.create<LocalAllocOp>(loc, barrierMemDescType);
+  gpu::MemDescType barrierMemDescType =
+      gpu::MemDescType::get({1}, rewriter.getI64Type(), barrierEncoding,
+                            sharedMemorySpace, /*mutableMemory=*/true);
+  Value barrierAlloc =
+      rewriter.create<gpu::LocalAllocOp>(loc, barrierMemDescType);
   rewriter.create<InitBarrierOp>(loc, barrierAlloc, 1);
   auto shapePerCTA = getShapePerCTA(encoding, tensorType.getShape());
   int sizeInBytes = product(shapePerCTA) *
@@ -153,11 +151,11 @@ static void lowerTMAStore(Operation *op, mlir::TypedValue<RankedTensorType> src,
   auto loc = op->getLoc();
   auto tensorType = src.getType();
   auto encoding = getEncodingFromDescriptor(op, src.getType(), desc);
-  assert(isa<SharedEncodingTrait>(encoding));
-  MemDescType memDescType =
-      MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
-                       encoding, sharedMemorySpace, /*mutableMemory=*/true);
-  Value alloc = rewriter.create<LocalAllocOp>(loc, memDescType, src);
+  assert(isa<gpu::SharedEncodingTrait>(encoding));
+  gpu::MemDescType memDescType = gpu::MemDescType::get(
+      tensorType.getShape(), tensorType.getElementType(), encoding,
+      sharedMemorySpace, /*mutableMemory=*/true);
+  Value alloc = rewriter.create<gpu::LocalAllocOp>(loc, memDescType, src);
   rewriter.create<triton::nvidia_gpu::FenceAsyncSharedOp>(loc, false);
   Value tmaPtr =
       rewriter.create<triton::nvidia_gpu::TensorDescToTMAPtrOp>(loc, desc);
@@ -236,8 +234,10 @@ public:
   }
 };
 
+} // anonymous namespace
+
 class TritonNvidiaGPUTMALoweringPass
-    : public TritonNvidiaGPUTMALoweringPassBase<
+    : public impl::TritonNvidiaGPUTMALoweringPassBase<
           TritonNvidiaGPUTMALoweringPass> {
 public:
   void runOnOperation() override {
@@ -253,8 +253,6 @@ public:
   }
 };
 
-} // namespace
-
-std::unique_ptr<Pass> mlir::createTritonNvidiaGPUTMALoweringPass() {
-  return std::make_unique<TritonNvidiaGPUTMALoweringPass>();
-}
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -15,6 +15,7 @@
 #include <pybind11/stl_bind.h>
 
 namespace py = pybind11;
+namespace ttng = mlir::triton::nvidia_gpu;
 
 void init_triton_nvidia_passes_ttgpuir(py::module &&m) {
   using namespace mlir::triton;
@@ -28,30 +29,30 @@ void init_triton_nvidia_passes_ttgpuir(py::module &&m) {
 }
 
 void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
-  ADD_PASS_WRAPPER_1("add_plan_cta", mlir::createTritonNvidiaGPUPlanCTAPass,
-                     mlir::triton::nvidia_gpu::ClusterInfo *);
+  ADD_PASS_WRAPPER_1("add_plan_cta", ttng::createTritonGPUPlanCTAPass,
+                            mlir::triton::nvidia_gpu::ClusterInfo *);
   ADD_PASS_WRAPPER_0("add_fence_insertion",
-                     mlir::createTritonNvidiaGPUFenceInsertionPass);
+                     ttng::createTritonGPUFenceInsertion);
   ADD_PASS_WRAPPER_0("add_tma_lowering",
-                     mlir::createTritonNvidiaGPUTMALoweringPass);
+                     ttng::createTritonNvidiaGPUTMALoweringPass);
   ADD_PASS_WRAPPER_0("add_promote_lhs_to_tmem",
-                     mlir::createTritonNvidiaGPUPromoteLHSToTMemPass);
+                     ttng::createTritonNvidiaGPUPromoteLHSToTMemPass);
   ADD_PASS_WRAPPER_0("add_remove_tmem_tokens",
-                     mlir::createTritonNvidiaGPURemoveTMEMTokensPass);
+                     ttng::createTritonNvidiaGPURemoveTMEMTokensPass);
   ADD_PASS_WRAPPER_0("add_nvgpu_to_llvm",
                      mlir::triton::createConvertNVGPUToLLVMPass);
   ADD_PASS_WRAPPER_0("add_warp_specialize_to_llvm",
                      mlir::triton::createConvertWarpSpecializeToLLVM);
   ADD_PASS_WRAPPER_0("add_allocate_tensor_memory",
-                     mlir::createTensorMemoryAllocationPass);
+                     ttng::createTritonTensorMemoryAllocationPass);
   ADD_PASS_WRAPPER_0("add_lower_mma",
-                     mlir::createTritonNvidiaGPUMMALoweringPass);
+                     ttng::createTritonNvidiaGPUMMALoweringPass);
   ADD_PASS_WRAPPER_0("add_optimize_descriptor_encoding",
-                     mlir::createTritonNvidiaGPUOptimizeDescriptorEncodingPass);
+                     ttng::createTritonNvidiaGPUOptimizeDescriptorEncodingPass);
   ADD_PASS_WRAPPER_0("add_optimize_tmem_layouts",
-                     mlir::createTritonNvidiaGPUOptimizeTMemLayoutsPass);
+                     ttng::createTritonNvidiaGPUOptimizeTMemLayoutsPass);
   ADD_PASS_WRAPPER_0("add_interleave_tmem",
-                     mlir::createTritonNvidiaGPUInterleaveTMemPass);
+                     ttng::createTritonNvidiaGPUInterleaveTMemPass);
 }
 
 void init_triton_nvidia_passes_nvws(py::module &&m) {

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -29,8 +29,8 @@ void init_triton_nvidia_passes_ttgpuir(py::module &&m) {
 }
 
 void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
-  ADD_PASS_WRAPPER_1("add_plan_cta", ttng::createTritonGPUPlanCTAPass,
-                            mlir::triton::nvidia_gpu::ClusterInfo *);
+  ADD_PASS_WRAPPER_1("add_plan_cta", ttng::createTritonNvidiaGPUPlanCTAPass,
+                     mlir::triton::nvidia_gpu::ClusterInfo *);
   ADD_PASS_WRAPPER_0("add_fence_insertion",
                      ttng::createTritonGPUFenceInsertion);
   ADD_PASS_WRAPPER_0("add_tma_lowering",


### PR DESCRIPTION
Continuation of #6785 and #3971