### PR TITLE
Fix RelWithDebInfo build

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -57,12 +57,14 @@ inline const std::set<std::string> CACHE_NEUTRAL_ENV_VARS = {
 namespace tools {
 
 inline void assertIsRecognized(const std::string &env) {
-  bool is_invalidating = CACHE_INVALIDATING_ENV_VARS.find(env.c_str()) !=
-                         CACHE_INVALIDATING_ENV_VARS.end();
-  bool is_neutral =
+  [[maybe_unused]] bool is_invalidating =
+      CACHE_INVALIDATING_ENV_VARS.find(env.c_str()) !=
+      CACHE_INVALIDATING_ENV_VARS.end();
+  [[maybe_unused]] bool is_neutral =
       CACHE_NEUTRAL_ENV_VARS.find(env.c_str()) != CACHE_NEUTRAL_ENV_VARS.end();
-  std::string errmsg = env + "is not recognized. "
-                             "Please add it to triton/tools/sys/getenv.hpp";
+  [[maybe_unused]] std::string errmsg =
+      env + "is not recognized. "
+            "Please add it to triton/tools/sys/getenv.hpp";
   assert((is_invalidating || is_neutral) && errmsg.c_str());
 }
 


### PR DESCRIPTION
This change adds the `[[maybe_unused]]` type alias to the variables defined and used in `assertIsRecognized` in `GetEnv.hpp`. This fixes `-Wunused-variable` errors raised when building with `REL_WITH_DEB_INFO` enabled, as we build our backend with `-Wunused`.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `this just fixes a build issue`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)