### PR TITLE
Fix: PY_SSIZE_T_CLEAN macro must be defined for '#' formats

### DIFF
--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -1,10 +1,10 @@
+#define PY_SSIZE_T_CLEAN
 #define __HIP_PLATFORM_AMD__
 // clang-format off
 // hip_depreated.h needs definitions from hip_runtime.h.
 #include <hip/hip_runtime.h>
 #include <hip/hip_deprecated.h>
 // clang-format on
-#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <dlfcn.h>
 #include <stdio.h>

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -263,6 +263,7 @@ def make_launcher(constants, signature, warp_size):
     params = [f"&arg{i}" for i, ty in signature.items() if ty != "constexpr"]
     params.append("&global_scratch")
     src = f"""
+#define PY_SSIZE_T_CLEAN
 #define __HIP_PLATFORM_AMD__
 #include <hip/hip_runtime.h>
 #include <Python.h>

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -1,8 +1,8 @@
+#define PY_SSIZE_T_CLEAN
 #include "cuda.h"
+#include <Python.h>
 #include <dlfcn.h>
 #include <stdbool.h>
-#define PY_SSIZE_T_CLEAN
-#include <Python.h>
 
 // Raises a Python exception and returns false if code is not CUDA_SUCCESS.
 static bool gpuAssert(CUresult code, const char *file, int line) {

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -227,6 +227,7 @@ def make_launcher(constants, signature, tensordesc_meta):
     params = [f"&arg{i}" for i, ty in signature.items() if ty != "constexpr"]
     params.append("&global_scratch")
     src = f"""
+#define PY_SSIZE_T_CLEAN
 #include \"cuda.h\"
 #include <stdbool.h>
 #include <Python.h>


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).

Fixes #5919. 

For python 3.12 and older, the macro PY_SSIZE_T_CLEAN must be defined before including Python.h to use all # variants of formats (s#, y#, etc.). 

This PR defines PY_SSIZE_T_CLEAN in the first line for both AMD and NVIDIA backend C and python modules. This fixes `SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats` on python 3.12 and below when `driver.c` file is dynamically loaded and converted into module. 

This change is necessary because as of the date of this PR, fine tuning models with unsloth and vLLM only works with python 3.12 and below.

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because existing builds should continue to succeed .

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
