### PR TITLE
Improve warning about fp8 deprecated format

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -384,10 +384,11 @@ def test_fp8_support(fresh_triton_cache, dtype):
 
     @triton.jit
     def dtype_kernel(dtype: tl.constexpr):
-        _ = tl.full((256, ), 0.0, dtype)
+        a = tl.full((64, 64), 0.0, dtype)
+        tl.dot(a, a)
 
     if dtype in warning_dtypes:
-        ctx = pytest.warns(UserWarning, match=r"fp8e4b15 is deprecated on Hopper+ architectures")
+        ctx = pytest.warns(UserWarning, match=r"the use of fp8e4b15 is deprecated on Hopper and later architectures")
     elif dtype in supported_dtypes:
         ctx = contextlib.nullcontext()
     else:

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -387,7 +387,7 @@ def test_fp8_support(fresh_triton_cache, dtype):
         _ = tl.full((256, ), 0.0, dtype)
 
     if dtype in warning_dtypes:
-        ctx = pytest.warns(UserWarning, match=r"fp8e4b15 is deprecated in this architecture")
+        ctx = pytest.warns(UserWarning, match=r"fp8e4b15 is deprecated on Hopper+ architectures")
     elif dtype in supported_dtypes:
         ctx = contextlib.nullcontext()
     else:

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -570,10 +570,6 @@ class dtype(base_type):
             if self.name not in builder.options.supported_fp8_dtypes:
                 raise ValueError(f'type {self} not supported in this architecture. '
                                  f'The supported fp8 dtypes are {builder.options.supported_fp8_dtypes}')
-            if self.name in builder.options.deprecated_fp8_dtypes:
-                warn(
-                    f"the use of {self.name} is deprecated on Hopper+ architectures and can cause significant slow down. It will be removed in a future triton release"
-                )
 
         if self.name == 'void':
             return builder.get_void_ty()

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -571,7 +571,9 @@ class dtype(base_type):
                 raise ValueError(f'type {self} not supported in this architecture. '
                                  f'The supported fp8 dtypes are {builder.options.supported_fp8_dtypes}')
             if self.name in builder.options.deprecated_fp8_dtypes:
-                warn(f"{self.name} is deprecated in this architecture and will be removed in a future triton release")
+                warn(
+                    f"the use of {self.name} is deprecated on Hopper+ architectures and can cause significant slow down. It will be removed in a future triton release"
+                )
 
         if self.name == 'void':
             return builder.get_void_ty()

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1567,6 +1567,10 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optiona
         assert lhs.dtype == rhs.dtype, f"Both operands must be same dtype. Got {lhs.dtype} and {rhs.dtype}"
 
     if lhs.dtype.is_fp8e4b15() or rhs.dtype.is_fp8e4b15():
+        if "fp8e4b15" in builder.options.deprecated_fp8_dot_operand_dtypes:
+            warnings.warn(
+                "the use of fp8e4b15 is deprecated on Hopper and later architectures and can cause significant slow down. It will be removed in a future triton release"
+            )
         # We upcast because there's no fp8e4b15 type in MLIR
         lhs = cast(lhs, tl.float16, builder)
         rhs = cast(rhs, tl.float16, builder)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -119,7 +119,7 @@ class InterpreterOptions:
     sanitize_overflow: bool = True
     arch: str = None
     supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e5b16", "fp8e4nv", "fp8e4b8", "fp8e4b15")
-    deprecated_fp8_dtypes: Tuple[str] = ()
+    deprecated_fp8_dot_operand_dtypes: Tuple[str] = ()
     default_dot_input_precision: str = "tf32"
     allowed_dot_input_precisions: Tuple[str] = ("tf32", "tf32x3", "ieee")
     max_num_imprecise_acc_default: int = 0

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -38,7 +38,7 @@ class HIPOptions:
     sanitize_overflow: bool = True
     arch: str = None
     supported_fp8_dtypes: Tuple[str] = ("fp8e5", )
-    deprecated_fp8_dtypes: Tuple[str] = ()
+    deprecated_fp8_dot_operand_dtypes: Tuple[str] = ()
     default_dot_input_precision: str = "ieee"
     allowed_dot_input_precisions: Tuple[str] = ("ieee", )
     enable_fp_fusion: bool = True

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -111,7 +111,7 @@ class CUDAOptions:
     launch_cooperative_grid: bool = False
     launch_pdl: bool = False
     supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e4b15")
-    deprecated_fp8_dtypes: Tuple[str] = ()
+    deprecated_fp8_dot_operand_dtypes: Tuple[str] = ()
     default_dot_input_precision: str = "tf32"
     allowed_dot_input_precisions: Tuple[str] = ("tf32", "tf32x3", "ieee")
     max_num_imprecise_acc_default: bool = None
@@ -166,9 +166,9 @@ class CUDABackend(BaseBackend):
                 supported_fp8_dtypes.add("fp8e4nv")
             args["supported_fp8_dtypes"] = tuple(sorted(supported_fp8_dtypes))
 
-        if "deprecated_fp8_dtypes" not in args:
+        if "deprecated_fp8_dot_operand_dtypes" not in args:
             if capability >= 90:
-                args["deprecated_fp8_dtypes"] = ("fp8e4b15", )
+                args["deprecated_fp8_dot_operand_dtypes"] = ("fp8e4b15", )
 
         if "enable_fp_fusion" not in args:
             args["enable_fp_fusion"] = knobs.language.default_fp_fusion


### PR DESCRIPTION
Also move the warning to be emitted only when the fp8 are used in a dot as this is the only case where there are performance problems.