### PR TITLE
Update `FetchContent_Populate` -> `FetchContent_MakeAvailable` in `googletest.cmake`

### DIFF
--- a/unittest/googletest.cmake
+++ b/unittest/googletest.cmake
@@ -15,9 +15,8 @@ FetchContent_Declare(
 FetchContent_GetProperties(googletest)
 
 if(NOT googletest_POPULATED)
-  FetchContent_Populate(googletest)
+  FetchContent_MakeAvailable(googletest)
   if (MSVC)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   endif()
-  add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()


### PR DESCRIPTION
To fix:
```bash
    CMake Warning (dev) at /home/runner/.local/lib/python3.10/site-packages/cmake/data/share/cmake-3.31/Modules/FetchContent.cmake:1953 (message):
      Calling FetchContent_Populate(googletest) is deprecated, call
      FetchContent_MakeAvailable(googletest) instead.  Policy CMP0169 can be set
      to OLD to allow FetchContent_Populate(googletest) to be called directly for
      now, but the ability to call it with declared details will be removed
      completely in a future version.
    Call Stack (most recent call first):
      unittest/googletest.cmake:18 (FetchContent_Populate)
      cmake/AddTritonUnitTest.cmake:1 (include)
      CMakeLists.txt:81 (include)
```