### PR TITLE
Add a default-off option to promote bf16 to fp32 for accumulation in tl.sum

### DIFF
--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -281,12 +281,17 @@ def _pick_sum_dtype(in_dtype: core.constexpr, dtype: core.constexpr):
 @core._tensor_member_fn
 @jit
 @core._add_reduction_docstr("sum", dtype_arg="dtype")
-def sum(input, axis=None, keep_dims=False, dtype: core.constexpr = None):
+def sum(input, axis=None, keep_dims=False, promote_bfloat16_to_float32=False, dtype: core.constexpr = None):
     # Pick a default dtype for the reduction if one was not specified.
     out_dtype: core.constexpr = _pick_sum_dtype(input.dtype, dtype)
 
     if out_dtype is not None:
         input = input.to(out_dtype)
+
+    # Provide an option to keep consistent behavior with torch.sum()
+    # where bf16 are casted to fp32 before reduce
+    if promote_bfloat16_to_float32:
+        input = core._promote_bfloat16_to_float32(input)
     return core.reduce(input, axis, _sum_combine, keep_dims=keep_dims)
 
 


### PR DESCRIPTION
Provide an option (default-off) to users with needs on numerical parity against `torch.sum` (especially in prod environment with high sensitivity for numeric issues).

According to [https://github.com/.../native/cuda/ReduceSumProdKernel.cu](https://github.com/pytorch/pytorch/blob/a84d8c4a1cc515db274366537afd0b1492800c2d/aten/src/ATen/native/cuda/ReduceSumProdKernel.cu)

`torch.sum()` on bf16 will go to the branch at L178 where acc_t is float when template sum_functor is instantiated at L14 which takes a lambda doing addition (at L31) between fp32 instead of bf16.