### PR TITLE
[PIPELINER] Reintroduce epilogue peeling

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(triton-opt PRIVATE
   ${triton_libs}
   # tests
   TritonTestAnalysis
+  TritonTestDialect
   TritonAMDGPUTestAnalysis
   # MLIR core
   MLIROptLib
@@ -31,6 +32,7 @@ target_link_libraries(triton-reduce PRIVATE
   ${triton_libs}
   # tests
   TritonTestAnalysis
+  TritonTestDialect
   TritonAMDGPUTestAnalysis
   # MLIR core
   MLIRReduceLib
@@ -49,6 +51,7 @@ target_link_libraries(triton-lsp PRIVATE
   ${triton_libs}
   # tests
   TritonTestAnalysis
+  TritonTestDialect
   TritonAMDGPUTestAnalysis
   # MLIR core
   MLIRLspServerLib
@@ -85,5 +88,6 @@ target_link_libraries(triton-tensor-layout PRIVATE
   ${conversion_libs}
   ${dialect_libs}
   TritonTestAnalysis
+  TritonTestDialect
   TritonAMDGPUTestAnalysis
   )

--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -37,6 +37,7 @@ void registerTestAllocationPass();
 void registerTestMembarPass();
 void registerTestAMDGPUMembarPass();
 void registerTestTritonAMDGPURangeAnalysis();
+void registerTestLoopPeelingPass();
 } // namespace test
 } // namespace mlir
 
@@ -49,6 +50,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::test::registerTestAlignmentPass();
   mlir::test::registerTestAllocationPass();
   mlir::test::registerTestMembarPass();
+  mlir::test::registerTestLoopPeelingPass();
   mlir::test::registerTestAMDGPUMembarPass();
   mlir::test::registerTestTritonAMDGPURangeAnalysis();
   mlir::triton::registerConvertTritonToTritonGPUPass();

--- a/include/triton/Dialect/Triton/IR/Utility.h
+++ b/include/triton/Dialect/Triton/IR/Utility.h
@@ -177,6 +177,9 @@ template <typename T> auto seq(T start, T end, T step) {
 Value getPredMask(RewriterBase &rewriter, Type typeLike, Value currentMask,
                   Value pred);
 
+// Get the value of the induction variable at the end of the loop.
+Value getLastInductionValue(OpBuilder &b, scf::ForOp loop);
+
 MakeTensorPtrOp getMakeTensorPtrOp(Value v);
 
 } // namespace triton

--- a/include/triton/Dialect/Triton/Transforms/LoopPeeling.h
+++ b/include/triton/Dialect/Triton/Transforms/LoopPeeling.h
@@ -1,0 +1,18 @@
+#ifndef TRITON_DIALECT_TRITON_TRANSFORMS_LOOP_PEELING_H_
+#define TRITON_DIALECT_TRITON_TRANSFORMS_LOOP_PEELING_H_
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+namespace mlir {
+namespace triton {
+
+// Peel the single last iteration of the loop.
+void peelLoopEpilogue(
+    scf::ForOp forOp,
+    function_ref<Operation *(RewriterBase &, Operation *, bool)>
+        processPeeledOp = nullptr);
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_DIALECT_TRITON_TRANSFORMS_LOOP_PEELING_H_

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -337,6 +337,24 @@ def TTG_PredicateStageOp: TTG_Op<"predicate_stage",
   let assemblyFormat = "$iv `,` $ub `,` $step `maxStage` $maxStage `stage` $stage attr-dict `:` type($iv) `->` type($result)";
 }
 
+def TTG_MaskOp: TTG_Op<"mask",
+                       [SingleBlock]> {
+    let summary = "mask op for pipelining";
+    let arguments = (ins I1:$pred);
+    let results = (outs Variadic<AnyType>:$result);
+    let regions = (region SizedRegion<1>:$region);
+    let builders = [
+        OpBuilder<(ins "Value":$pred)>,
+    ];
+}
+
+def TTG_MaskReturnOp: TTG_Op<"mask.return",
+                             [HasParent<"MaskOp">, Pure, Terminator, ReturnLike]> {
+    let summary = "terminator for mask operator";
+    let arguments = (ins Variadic<AnyType>:$result);
+    let assemblyFormat = "$result attr-dict `:` type($result)";
+}
+
 def TTG_Fp4ToFpOp : TTG_Op<"fp4_to_fp", [Pure]> {
   let summary = "Upcast fp4 (e2m1) to fp";
 

--- a/lib/Dialect/Triton/IR/Utility.cpp
+++ b/lib/Dialect/Triton/IR/Utility.cpp
@@ -1,5 +1,6 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 using namespace mlir;
@@ -89,4 +90,16 @@ tt::MakeTensorPtrOp tt::getMakeTensorPtrOp(Value v) {
     return tt::getMakeTensorPtrOp(argOwner->getOperand(argNum));
   }
   llvm_unreachable("Unable to getMakeTensorPtr()");
+}
+
+Value tt::getLastInductionValue(OpBuilder &b, scf::ForOp loop) {
+  Location loc = loop.getLoc();
+  // (ub - lb -1) // step * step + lb
+  Value diff =
+      b.create<arith::SubIOp>(loc, loop.getUpperBound(), loop.getLowerBound());
+  diff = b.create<arith::SubIOp>(
+      loc, diff, b.create<arith::ConstantOp>(loc, b.getI32IntegerAttr(1)));
+  Value ceilStep = b.create<arith::MulIOp>(
+      loc, b.create<arith::DivSIOp>(loc, diff, loop.getStep()), loop.getStep());
+  return b.create<arith::AddIOp>(loc, ceilStep, loop.getLowerBound());
 }

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_triton_library(TritonTransforms
   Combine.cpp
   LoopAwareCSE.cpp
   LoopInvariantCodeMotion.cpp
+  LoopPeeling.cpp
   LoopUnroll.cpp
   ReorderBroadcast.cpp
   RewriteTensorPointer.cpp
@@ -20,5 +21,7 @@ add_triton_library(TritonTransforms
   LINK_LIBS PUBLIC
   MLIRPass
   MLIRTransformUtils
+  MLIRTransforms
+  MLIRSCFToControlFlow
   TritonIR
 )

--- a/lib/Dialect/Triton/Transforms/LoopPeeling.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopPeeling.cpp
@@ -1,0 +1,68 @@
+#include "triton/Dialect/Triton/Transforms/LoopPeeling.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace triton {
+
+void peelLoopEpilogue(
+    scf::ForOp forOp,
+    function_ref<Operation *(RewriterBase &, Operation *, bool)>
+        processPeeledOp) {
+  SmallVector<Operation *> loopBodyOps;
+  IRRewriter rewriter(forOp);
+  Location loc = forOp.getLoc();
+  Type type = forOp.getStep().getType();
+
+  // Fetch loop bounds and step
+  Value lowerBound = forOp.getLowerBound();
+  Value upperBound = forOp.getUpperBound();
+  Value step = forOp.getStep();
+  Value newUpperBound = rewriter.create<arith::SubIOp>(loc, upperBound, step);
+
+  rewriter.setInsertionPointAfter(forOp);
+  Value lastIV = getLastInductionValue(rewriter, forOp);
+
+  auto cond = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,
+                                             lowerBound, upperBound);
+
+  // Create an if op to execute the peeled iteration
+  IRMapping map;
+  map.map(forOp.getRegionIterArgs(), forOp.getResults());
+  map.map(forOp.getInductionVar(), lastIV);
+  auto ifOp = rewriter.create<scf::IfOp>(loc, forOp.getResultTypes(), cond,
+                                         /*hasElse=*/true);
+  ifOp.getThenRegion().front().erase();
+  forOp.getBodyRegion().cloneInto(&ifOp.getThenRegion(), map);
+  rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
+  rewriter.create<scf::YieldOp>(loc, forOp.getResults());
+
+  forOp->replaceUsesWithIf(ifOp, [&](OpOperand &operand) {
+    return !ifOp->isAncestor(operand.getOwner());
+  });
+
+  forOp.getUpperBoundMutable().assign(newUpperBound);
+
+  if (processPeeledOp) {
+    for (auto &op :
+         llvm::make_early_inc_range(forOp.getBody()->without_terminator())) {
+      Operation *newOp = processPeeledOp(rewriter, &op, /*isEpilogue=*/false);
+      if (newOp && newOp != &op) {
+        op.replaceAllUsesWith(newOp);
+      }
+    }
+    for (auto &op : llvm::make_early_inc_range(
+             ifOp.getThenRegion().front().without_terminator())) {
+      Operation *newOp = processPeeledOp(rewriter, &op, /*isEpilogue=*/true);
+      if (newOp && newOp != &op) {
+        op.replaceAllUsesWith(newOp);
+      }
+    }
+  }
+}
+
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -44,6 +44,7 @@ add_triton_library(TritonGPUTransforms
   MLIRTransformUtils
   TritonAnalysis
   TritonIR
+  TritonTransforms
   TritonGPUIR
   TritonNvidiaGPUIR
   TritonToTritonGPU

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -275,10 +275,10 @@ public:
         // place the wait right before the loads.
 
         if (hasSyncDots(forOp)) {
-          // Skip pipelining MMA in the loops where sync dots are used. This is
-          // dirty heuristic for performance drops in kernels where we would
-          // rather want to have last iteration peeled instead of having a full
-          // iteration of masked operations only to execute single wait.
+          // Skip pipelining MMA in the loops where sync dots are used. This
+          // is a dirty heuristic for performance drops in kernels where we
+          // would rather want to have last iteration peeled instead of having a
+          // full iteration of masked operations only to execute single wait.
           continue;
         }
         auto pipeHelper = ttng::MMAv5PipelineableOperandsHelper(

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -1,5 +1,4 @@
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
-
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -160,6 +159,8 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
                                      Value pred) {
   OpBuilder::InsertionGuard guard(rewriter);
   if (mlir::isMemoryEffectFree(op))
+    return op;
+  if (isConstantIntValue(pred, 1))
     return op;
   if (isa<LLVM::AssumeOp, ttng::FenceAsyncSharedOp>(op))
     return op;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -1,4 +1,5 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
@@ -6,6 +7,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/Transforms/LoopPeeling.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipelineExpander.h"
@@ -15,7 +17,6 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/Support/Debug.h"
-
 //===----------------------------------------------------------------------===//
 // This file will create a schedule that will be handed over to the pipeline
 // expander.
@@ -42,6 +43,99 @@ static void pipelineWgmma(ModuleOp moduleOp) {
   }
 }
 
+static Operation *wrapInMaskOp(RewriterBase &rewriter, Operation *op,
+                               Value pred) {
+  auto mask = rewriter.create<MaskOp>(op->getLoc(), op->getResultTypes(), pred);
+  rewriter.createBlock(&mask->getRegion(0));
+  rewriter.setInsertionPointToStart(&mask->getRegion(0).front());
+  auto newOp = rewriter.clone(*op);
+  rewriter.create<MaskReturnOp>(op->getLoc(), newOp->getResults());
+  op->replaceAllUsesWith(mask->getResults());
+  rewriter.eraseOp(op);
+  return mask;
+}
+
+static void resolveMaskOp(ModuleOp moduleOp) {
+  IRRewriter rewriter(moduleOp);
+
+  // Canonicalize the IR to simplify the arithmetic ops defining the mask
+  auto arithDialect =
+      moduleOp.getContext()->getLoadedDialect<arith::ArithDialect>();
+  RewritePatternSet patterns(moduleOp.getContext());
+  arithDialect->getCanonicalizationPatterns(patterns);
+  if (applyPatternsGreedily(moduleOp, std::move(patterns)).failed())
+    return llvm::report_fatal_error("Failed to canonicalize the IR");
+
+  SmallVector<MaskOp> maskOps;
+  moduleOp->walk([&](MaskOp maskOp) { maskOps.push_back(maskOp); });
+  for (auto maskOp : maskOps) {
+    rewriter.setInsertionPoint(maskOp);
+    while (&maskOp.getBody()->front() != maskOp.getBody()->getTerminator()) {
+      Operation *op = &maskOp.getBody()->front();
+      // Statically dead
+      if (isConstantIntValue(maskOp.getPred(), 0)) {
+        if (op->getNumResults() > 0) {
+          SmallVector<Value> results;
+          for (auto result : op->getResults()) {
+            auto poisonOp =
+                rewriter.create<ub::PoisonOp>(op->getLoc(), result.getType());
+            results.push_back(poisonOp);
+          }
+          op->replaceAllUsesWith(results);
+        }
+        op->erase();
+      } else {
+        rewriter.moveOpBefore(op, maskOp);
+        op = triton::predicateOp(rewriter, op, maskOp.getPred());
+      }
+    }
+    maskOp->replaceAllUsesWith(
+        maskOp.getBody()->getTerminator()->getOperands());
+    maskOp->erase();
+  }
+}
+
+static Operation *processPeeledEpilogueOp(RewriterBase &rewriter, Operation *op,
+                                          bool isEpilogue) {
+  if (auto predOp = dyn_cast<triton::gpu::PredicateStageOp>(op)) {
+    if (isEpilogue) {
+      // Return false for the predicate of the peeled iteration
+      return rewriter.create<mlir::arith::ConstantIntOp>(
+          predOp.getLoc(), 0, predOp.getResult().getType());
+    } else {
+      if (predOp.getStage() == predOp.getMaxStage() - 1) {
+        return rewriter.create<mlir::arith::ConstantIntOp>(
+            predOp.getLoc(), 1, predOp.getResult().getType());
+      } else {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPoint(op);
+        return triton::emitPredicateForStage(
+                   rewriter, predOp.getIv(), predOp.getUb(), predOp.getStep(),
+                   predOp.getMaxStage(), predOp.getStage())
+            .getDefiningOp();
+      }
+    }
+  }
+  return op;
+}
+
+static bool hasMMAv5WaitsInLastStage(scf::ForOp forOp,
+                                     CoarseSchedule &schedule) {
+  int maxStage = schedule.getNumStages() - 1;
+  bool hasMMAv5 = false;
+  bool hasWaitInLastStage = false;
+  for (auto &op : forOp.getBody()->without_terminator()) {
+    if (isa<triton::nvidia_gpu::WaitBarrierOp>(op) &&
+        schedule[&op].first == maxStage) {
+      hasWaitInLastStage = true;
+    }
+    if (isa<triton::nvidia_gpu::MMAv5OpInterface>(op)) {
+      hasMMAv5 = true;
+    }
+  }
+  return hasMMAv5 && hasWaitInLastStage;
+}
+
 static void expandLoops(ModuleOp moduleOp) {
   SmallVector<scf::ForOp> loops;
   moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
@@ -56,15 +150,26 @@ static void expandLoops(ModuleOp moduleOp) {
     triton::PipeliningOption options;
     options.supportDynamicLoops = true;
     options.peelEpilogue = false;
-    options.predicateFn = triton::predicateOp;
+    options.predicateFn = wrapInMaskOp;
     options.getScheduleFn =
         [&](scf::ForOp forOp,
             std::vector<std::pair<Operation *, unsigned>> &schedule) {
           schedule = finalSchedule;
         };
+
     // Testing feature: allow for unresolved predicate stage ops
     // in the loop body.
-    if (forOp->hasAttr("__test_keep_predicate_stage")) {
+    bool keepPredicateStage = forOp->hasAttr("__test_keep_predicate_stage");
+    // TODO: Enable epilogue peeling for warp specialized loops
+    // Heuristic: only peel epilogue for MMAv5 loops with waits in the last
+    // stage
+    bool customEpiloguePeeling =
+        hasMMAv5WaitsInLastStage(forOp, schedule) &&
+        !forOp->getParentOfType<triton::gpu::WarpSpecializeOp>() &&
+        !keepPredicateStage; // do not peel if we are testing the stage
+                             // predication
+
+    if (keepPredicateStage || customEpiloguePeeling) {
       options.emitPredicateStageFn =
           [](RewriterBase &rewriter, Value inductionVar, Value upperBound,
              Value step, uint64_t maxStage, uint64_t stage) {
@@ -76,7 +181,18 @@ static void expandLoops(ModuleOp moduleOp) {
     IRRewriter rewriter(forOp);
     FailureOr<scf::ForOp> newForOp =
         triton::pipelineForLoop(rewriter, forOp, options);
+
+    if (failed(newForOp)) {
+      continue;
+    }
+    forOp = *newForOp;
+    if (customEpiloguePeeling) {
+      mlir::triton::peelLoopEpilogue(forOp, processPeeledEpilogueOp);
+    }
   }
+  assert(moduleOp.getOps<triton::gpu::PredicateStageOp>().empty() &&
+         "PredicateStageOp should be resolved after the pipeline expansion");
+  resolveMaskOp(moduleOp);
 }
 
 static void removeAttributes(ModuleOp moduleOp) {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -455,18 +455,6 @@ LogicalResult PipelinedLoadGroup::lowerLoads(WarpSchedule &schedule,
 // MMA Pipelining
 //===----------------------------------------------------------------------===//
 
-static Value getLastInductionValue(PartitionBuilder &b, scf::ForOp loop) {
-  OpBuilder::InsertionGuard guard(b);
-  b.setInsertionPoint(loop);
-  // (ub - lb -1) // step * step + lb
-  Value diff =
-      b.create<arith::SubIOp>(loop.getUpperBound(), loop.getLowerBound());
-  diff = b.create<arith::SubIOp>(diff, b.intCst(1));
-  Value ceilStep = b.create<arith::MulIOp>(
-      b.create<arith::DivSIOp>(diff, loop.getStep()), loop.getStep());
-  return b.create<arith::AddIOp>(ceilStep, loop.getLowerBound());
-}
-
 static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
                                  WarpSchedule &schedule, DominanceInfo &domInfo,
                                  PostDominanceInfo &postDomInfo) {
@@ -587,7 +575,11 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
   Value userPred = b.boolCst(true);
   if (readOp == mmaOp) {
     PartitionBuilder b(mmaOp.getLoc(), mmaOp);
-    Value lastInductionValue = getLastInductionValue(b, loop);
+    Value lastInductionValue = [&]() {
+      OpBuilder::InsertionGuard guard(b);
+      b.setInsertionPoint(loop);
+      return getLastInductionValue(b, loop);
+    }();
     userPred = b.create<arith::CmpIOp>(
         arith::CmpIPredicate::eq, loop.getInductionVar(), lastInductionValue);
     nodes.back().barNext = createBarrierAlloc(loop, /*numBarriers=*/1);

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -375,9 +375,9 @@ def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS
     kernel_kwargs = {}
     if is_hip():
         kernel_kwargs["matrix_instr_nonkdim"] = nonKDim
-    out = mxfp_matmul[grid](a, b, output, a_scale, b_scale, M, N, K, a_scale.stride(0), a.stride(0), a.stride(1),
-                            b.stride(0), b.stride(1), output.stride(0), output.stride(1), BLOCK_M, BLOCK_N, BLOCK_K,
-                            NUM_STAGES=NUM_STAGES, **kernel_kwargs, num_warps=NUM_WARPS)
+    mxfp_matmul[grid](a, b, output, a_scale, b_scale, M, N, K, a_scale.stride(0), a.stride(0), a.stride(1), b.stride(0),
+                      b.stride(1), output.stride(0), output.stride(1), BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES=NUM_STAGES,
+                      **kernel_kwargs, num_warps=NUM_WARPS)
     a_scale_f32 = fp8e8m0_to_float32(a_scale)
     b_scale_f32 = fp8e8m0_to_float32(b_scale)
     a_scale_f32 = a_scale_f32.repeat_interleave(32, dim=1)
@@ -393,11 +393,6 @@ def test_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS
     atol = 0.0001
     rtol = 0.0001
     torch.testing.assert_close(ref_out, output, atol=atol, rtol=rtol)
-
-    if is_cuda() and torch.cuda.get_device_capability()[0] == 10:
-        # Pipelining of dot_scaled requires tmem_copy to be used, which in turn
-        # requires the scales to be in the blocked layout in global memory.
-        assert out.asm["ttgir"].count("ttng.tc_gen5_mma") == 1
 
 
 def _knob_promote_lhs_to_tmem(monkeypatch):

--- a/test/Triton/loop-peeling.mlir
+++ b/test/Triton/loop-peeling.mlir
@@ -1,0 +1,69 @@
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -triton-test-loop-peeling -canonicalize | FileCheck %s
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @simple_loop_i32
+// CHECK: (%[[LB:.*]]: i32, %[[UB:.*]]: i32, %[[STEP:.*]]: i32) -> f32
+// CHECK-DAG: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[ONE:.*]] = arith.constant 1 : i32
+// CHECK: %[[NUB:.*]] = arith.subi %[[UB]], %[[STEP]]
+// CHECK: %[[FOR:.*]] = scf.for %[[IV:.*]] = %[[LB]] to %[[NUB]] step %[[STEP]]
+// CHECK: scf.yield
+// CHECK: %[[RANGE:.*]] = arith.subi %[[UB]], %[[LB]]
+// CHECK: %[[RANGE_M1:.*]] = arith.subi %[[RANGE]], %[[ONE]]
+// CHECK: %[[ITERS_M1:.*]] = arith.divsi %[[RANGE_M1]], %[[STEP]]
+// CHECK: %[[DELTA:.*]] = arith.muli %[[ITERS_M1]], %[[STEP]]
+// CHECK: %[[LAST_IV:.*]] = arith.addi %[[DELTA]], %[[LB]]
+// CHECK: %[[COND:.*]] = arith.cmpi slt, %[[LB]], %[[UB]]
+// CHECK: %[[IF:.*]] = scf.if %[[COND]]
+// CHECK:   %[[DEF:.*]] = "def"(%[[LAST_IV]]) : (i32) -> f32
+// CHECK:   %[[RES:.*]] = arith.addf %[[FOR]], %[[DEF]] : f32
+// CHECK:   scf.yield %[[RES]] : f32
+// CHECK: else
+// CHECK:   scf.yield %[[FOR]] : f32
+// CHECK: tt.return %[[IF]] : f32
+tt.func @simple_loop_i32(%lb : i32, %ub : i32, %step : i32) -> f32 {
+  %init = arith.constant 0.00e+00 : f32
+  %loop = scf.for %iv = %lb to %ub step %step iter_args(%acc = %init) -> (f32) : i32 {
+    %a = "def"(%iv) : (i32) -> f32
+    %res = arith.addf %acc, %a : f32
+    scf.yield %res : f32
+  } {__test_peel_epilogue}
+
+  tt.return %loop#0 : f32
+}
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @simple_loop_i32
+// CHECK: (%[[LB:.*]]: i32, %[[UB:.*]]: i32, %[[STEP:.*]]: i32) -> f32
+// CHECK-DAG: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[ONE:.*]] = arith.constant 1 : i32
+// CHECK: %[[NUB:.*]] = arith.subi %[[UB]], %[[STEP]]
+// CHECK: %[[FOR:.*]] = scf.for %[[IV:.*]] = %[[LB]] to %[[NUB]] step %[[STEP]]
+// CHECK: scf.yield
+// CHECK: %[[RANGE:.*]] = arith.subi %[[UB]], %[[LB]]
+// CHECK: %[[RANGE_M1:.*]] = arith.subi %[[RANGE]], %[[ONE]]
+// CHECK: %[[ITERS_M1:.*]] = arith.divsi %[[RANGE_M1]], %[[STEP]]
+// CHECK: %[[DELTA:.*]] = arith.muli %[[ITERS_M1]], %[[STEP]]
+// CHECK: %[[LAST_IV:.*]] = arith.addi %[[DELTA]], %[[LB]]
+// CHECK: %[[COND:.*]] = arith.cmpi slt, %[[LB]], %[[UB]]
+// CHECK: %[[IF:.*]] = scf.if %[[COND]]
+// CHECK:   %[[DEF:.*]] = "def"(%[[LAST_IV]]) : (i32) -> f32
+// CHECK:   %[[RES:.*]] = arith.addf %[[FOR]], %[[DEF]] : f32
+// CHECK:   scf.yield %[[RES]] : f32
+// CHECK: else
+// CHECK:   scf.yield %[[FOR]] : f32
+// CHECK: tt.return %[[IF]] : f32
+tt.func @simple_loop_i32(%lb : i32, %ub : i32, %step : i32) -> f32 {
+  %init = arith.constant 0.00e+00 : f32
+  %loop = scf.for %iv = %lb to %ub step %step iter_args(%acc = %init) -> (f32) : i32 {
+    %a = "def"(%iv) : (i32) -> f32
+    %res = arith.addf %acc, %a : f32
+    scf.yield %res : f32
+  } {__test_peel_epilogue}
+
+  tt.return %loop#0 : f32
+}
+}

--- a/test/TritonGPU/pipeline-loop-nest.mlir
+++ b/test/TritonGPU/pipeline-loop-nest.mlir
@@ -59,7 +59,8 @@ tt.func public @matmul_kernel_tma_persistent(%arg0: !tt.ptr<i8, 0>, %arg1: !tt.p
       %41 = tt.dot %37, %40, %arg9, inputPrecision = tf32 : tensor<128x64xf16> * tensor<64x128xf16> -> tensor<128x128xf32>
       scf.yield %41 : tensor<128x128xf32>
     }
-    // BLACKWELL-COUNT-1: ttng.tmem_load
+    // Blackwell: expect one tmem_load in the loop, and one in the peeled epilogue
+    // BLACKWELL-COUNT-2: ttng.tmem_load
     // BLACKWELL-NOT: ttng.tmem_load
 
     // HOPPER: ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32}

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Analysis)
+add_subdirectory(Dialect)
 add_subdirectory(Instrumentation)

--- a/test/lib/Dialect/CMakeLists.txt
+++ b/test/lib/Dialect/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_mlir_library(TritonTestDialect
+  TestLoopPeeling.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRPass
+  TritonTransforms
+)

--- a/test/lib/Dialect/TestLoopPeeling.cpp
+++ b/test/lib/Dialect/TestLoopPeeling.cpp
@@ -1,0 +1,38 @@
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/Triton/Transforms/LoopPeeling.h"
+
+using namespace mlir;
+
+namespace {
+
+bool getPeelEpilogue(scf::ForOp forOp) {
+  return forOp->hasAttr("__test_peel_epilogue");
+}
+
+struct TestLoopPeelingPass
+    : public PassWrapper<TestLoopPeelingPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestLoopPeelingPass);
+
+  StringRef getArgument() const final { return "triton-test-loop-peeling"; }
+  StringRef getDescription() const final {
+    return "test the loop peeling pass";
+  }
+
+  void runOnOperation() override {
+    IRRewriter rewriter(getOperation());
+    getOperation().walk([&](scf::ForOp forOp) {
+      if (getPeelEpilogue(forOp)) {
+        mlir::triton::peelLoopEpilogue(forOp);
+      }
+    });
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace test {
+void registerTestLoopPeelingPass() { PassRegistration<TestLoopPeelingPass>(); }
+} // namespace test
+} // namespace mlir


### PR DESCRIPTION
Reintroduce "[PIPELINE] Peel single epilogue iteration after loop expansion #6893"
Fixed the issue that was exposing IMA by using poison values as buffer indices used by speculatively executed async copy.