### PR TITLE
[Warp Specialization] Don't pipeline loops where latency ops are in the same stage

### DIFF
--- a/test/TritonGPU/automatic-warp-specialization.mlir
+++ b/test/TritonGPU/automatic-warp-specialization.mlir
@@ -31,11 +31,16 @@ tt.func @matmul_change_desc_in_prologue(
   // CHECK-SAME: num_warps(1)
   // BASE-NOT: tt.make_tensor_descriptor
   // PIPELINE-NOT: tt.experimental_tensormap_create
+  // PIPELINE-COUNT-1: tc_gen5_mma
+  // PIPELINE-NOT: tc_gen5_mma
   // CHECK-LABEL: partition1
   // CHECK-SAME: num_warps(2)
   // BASE-COUNT-2: tt.make_tensor_descriptor
   // PIPELINE-COUNT-2: ttg.global_scratch_alloc {alignment = 128 : i32, nbytes = 512 : i32}
   // PIPELINE-COUNT-2: tt.experimental_tensormap_create
+  // PIPELINE-NOT: tt.experimental_tensormap_create
+  // PIPELINE-COUNT-2: async_tma_copy_global_to_local
+  // PIPELINE-NOT: async_tma_copy_global_to_local
   // CHECK-NOT: partition2
   scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero, %flag = %true, %a_desc = %a_desc_undef, %b_desc = %b_desc_undef) -> (tensor<128x128xf32, #acc_layout>, i1, !tt.tensordesc<tensor<128x64xf16, #shared>>, !tt.tensordesc<tensor<64x128xf16, #shared>>) : i32 {
     %do_prologue = "prologue_cond"(%k) : (i32) -> i1


### PR DESCRIPTION
Loop scheduling on the full loop (pre-partitioning) can result in ops in the backward slices of latency ops being placed in a different stage than the latency op. If after loop splitting, all the latency ops are in the same stage but some ops in the backward slice are in a different stage, the loop gets software pipelined. This can result in a performance regression due to extra register pressure and worse instruction scheduling if no overlap is actually introduced.

This PR adds a small trick to detect when all latency ops are in the same stage and when that happens, it doesn't schedule the loop.