### PR TITLE
Cast bf16 to fp32 for sum/reduce

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2641,7 +2641,7 @@ def test_sum_dtype(device):
 
     @triton.jit
     def kernel_default_float(out_ptr):
-        x = tl.full((32, 32), 1.0, dtype=tl.bfloat16)
+        x = tl.full((32, 32), 0.0001, dtype=tl.bfloat16)
         x = tl.sum(x)
         tl.store(out_ptr, x)
 
@@ -2663,7 +2663,7 @@ def test_sum_dtype(device):
 
     out = torch.empty(1, dtype=torch.bfloat16, device=device)
     kernel_default_float[(1, )](out)
-    torch.testing.assert_close(out[0], torch.tensor(32 * 32, dtype=torch.bfloat16, device=device))
+    torch.testing.assert_close(out[0], torch.tensor(32 * 32 * 0.0001, dtype=torch.bfloat16, device=device))
 
 
 @triton.jit

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -275,8 +275,8 @@ def _pick_sum_dtype(in_dtype: core.constexpr, dtype: core.constexpr):
         out_dtype = core.int32 if in_dtype.int_bitwidth < 32 else None
     elif in_dtype.is_int_unsigned():
         out_dtype = core.uint32 if in_dtype.int_bitwidth < 32 else None
-    elif in_dtype.is_floating() and in_dtype.primitive_bitwidth < 32:
-        out_dtype = core.float32
+    elif in_dtype.is_floating():
+        out_dtype = core.float32 if in_dtype.primitive_bitwidth < 32 else None
     return out_dtype
 
 

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -275,6 +275,8 @@ def _pick_sum_dtype(in_dtype: core.constexpr, dtype: core.constexpr):
         out_dtype = core.int32 if in_dtype.int_bitwidth < 32 else None
     elif in_dtype.is_int_unsigned():
         out_dtype = core.uint32 if in_dtype.int_bitwidth < 32 else None
+    elif in_dtype.is_floating() and in_dtype.primitive_bitwidth < 32:
+        out_dtype = core.float32
     return out_dtype
 
 


### PR DESCRIPTION
There used to be this behavior but got stopped by https://github.com/triton-lang/triton/commit/f9ad25edcea3533d16bb1d63da7c95383e3b2d1b#diff-7935be9afb58d190ea8fd7a849bdc375fa48f75aff33c7bb152428feaa6860f4 by @Mogball 

By reading the PR summary, it seems unintentional to stop promoting bf16 to fp32. 

> To reduce this footgun, this PR adds a `dtype` argument to `tl.sum` (and
`tl.reduce`) which optionally casts the input to that dtype before
computing the operation. For `tl.sum`, the default dtype is set to
`tl.int32` for integers smaller than that and `tl.float32` for floats
smaller than that.