### PR TITLE
[AMD] Skip InThreadTransposeOp in scheduleGlobalLoadLocalStore

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -180,6 +180,9 @@ static void scheduleGlobalLoadLocalStore(Operation *parentOp) {
           continue;
         }
 
+        if (isa_and_nonnull<triton::amdgpu::InThreadTransposeOp>(defOp))
+          continue;
+
         // Find uses of the op that are local_store
         for (Operation *op : vals[i].getUsers()) {
           if (auto storeOp = dyn_cast<ttg::LocalStoreOp>(op)) {


### PR DESCRIPTION
When the defOp of a local_store's src is not a loadOp, the while loop in scheduleGlobalLoadLocalStore() becomes an infinite loop. This is because the local_store op is considered as one of the users of the src of this local_store op.
This PR breaks out of the loop when the defOp of a local_store's src is a InThreadTransposeOp.
