### PR TITLE
[BACKEND] Implement generic swizzling when lowering `convert_layout`

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -96,6 +96,7 @@ public:
 
   virtual bool supportLdMatrix() const { return false; }
   virtual bool supportStMatrix() const { return false; }
+  virtual bool isCuda() const { return false; }
 
   // Annotate target specific information to local store operations during
   // lowering to LLVM.

--- a/include/triton/Tools/GenericSwizzling.h
+++ b/include/triton/Tools/GenericSwizzling.h
@@ -1,0 +1,17 @@
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include <cstdint>
+
+namespace mlir::triton {
+class LinearLayout;
+}
+
+namespace mlir::triton::gpu {
+LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
+                              int32_t bitwidth);
+
+// Compute a basis of span(b1) ∩ span(b2)
+llvm::SmallVector<int32_t> intersectionBasis(llvm::ArrayRef<int32_t> b1,
+                                             llvm::ArrayRef<int32_t> b2,
+                                             int32_t rank);
+} // namespace mlir::triton::gpu

--- a/include/triton/Tools/GenericSwizzling.h
+++ b/include/triton/Tools/GenericSwizzling.h
@@ -10,6 +10,11 @@ namespace mlir::triton::gpu {
 LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
                               int32_t bitwidth);
 
+std::pair<int, int> logBankConflicts(const LinearLayout &src,
+                                     const LinearLayout &dst,
+                                     const LinearLayout &smem,
+                                     int32_t bitwidth);
+
 // Compute a basis of span(b1) ∩ span(b2)
 llvm::SmallVector<int32_t> intersectionBasis(llvm::ArrayRef<int32_t> b1,
                                              llvm::ArrayRef<int32_t> b2,

--- a/include/triton/Tools/GenericSwizzling.h
+++ b/include/triton/Tools/GenericSwizzling.h
@@ -1,3 +1,6 @@
+#ifndef TRITON_GENERIC_SWIZZLING_H
+#define TRITON_GENERIC_SWIZZLING_H
+
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include <cstdint>
@@ -14,9 +17,6 @@ std::pair<int, int> logBankConflicts(const LinearLayout &src,
                                      const LinearLayout &dst,
                                      const LinearLayout &smem,
                                      int32_t bitwidth);
-
-// Compute a basis of span(b1) ∩ span(b2)
-llvm::SmallVector<int32_t> intersectionBasis(llvm::ArrayRef<int32_t> b1,
-                                             llvm::ArrayRef<int32_t> b2,
-                                             int32_t rank);
 } // namespace mlir::triton::gpu
+
+#endif // TRITON_GENERIC_SWIZZLING_H

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -118,8 +118,8 @@ LinearLayout zerosLike(const LinearLayout &layout);
 // It's not always true that the action returned by this function will
 // allow us to divideLeft, but it is true that if it if there exists one, it is
 // the one returned by this function.
-std::optional<ColumnAction> regPermForDivideLeft(const LinearLayout &A,
-                                                 const LinearLayout &B);
+std::optional<ColumnAction> regPermForDivide(const LinearLayout &A,
+                                             const LinearLayout &B, bool left);
 
 // For a layout A with A.hasInDim(kReg), find a permutation of registers action
 // such that action.apply(A) has the broadcasted registers removed
@@ -129,11 +129,6 @@ ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout);
 // the same broadcasting as layout
 SmallVector<Value> broadcastAs(const SmallVector<Value> &values,
                                const LinearLayout &layout);
-
-// Given a smem layout returned by `optimalSwizzling`, move the registers
-// associated with smem[kReps] to the back of the layout[kReg] bases
-ColumnAction actionMoveRepsToBack(const LinearLayout &layout,
-                                  const LinearLayout &smem);
 
 // Compute the supremum of two lists.
 // Error out if the supremum does not exist (e.g. [a, b] and [b, a]).

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -130,6 +130,11 @@ ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout);
 SmallVector<Value> broadcastAs(const SmallVector<Value> &values,
                                const LinearLayout &layout);
 
+// Given a smem layout returned by `optimalSwizzling`, move the registers
+// associated with smem[kReps] to the back of the layout[kReg] bases
+ColumnAction actionMoveRepsToBack(const LinearLayout &layout,
+                                  const LinearLayout &smem);
+
 // Compute the supremum of two lists.
 // Error out if the supremum does not exist (e.g. [a, b] and [b, a]).
 // If the supremum is not unique, we return the first list first

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -116,8 +116,8 @@ LinearLayout zerosLike(const LinearLayout &layout);
 // For a layout A with A.hasInDim(kReg), find a permutation of registers action
 // such that action.apply(A) may be divisible by B
 // It's not always true that the action returned by this function will
-// allow us to divideLeft, but it is true that if it if there exists one, it is
-// the one returned by this function.
+// allow us to divideLeft (resp. divideRight), but it is true that if it if
+// there exists one, it is the one returned by this function.
 std::optional<ColumnAction> regPermForDivide(const LinearLayout &A,
                                              const LinearLayout &B, bool left);
 

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -125,6 +125,9 @@ std::optional<ColumnAction> regPermForDivide(const LinearLayout &A,
 // such that action.apply(A) has the broadcasted registers removed
 ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout);
 
+std::pair<int64_t, ColumnAction>
+actionAdditiveStrides(const LinearLayout &layout);
+
 // For a layout A with A.hasInDim(kReg), repeat the values so that they have
 // the same broadcasting as layout
 SmallVector<Value> broadcastAs(const SmallVector<Value> &values,

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -625,6 +625,7 @@ public:
 
   // Compute a C such that A = B * C if it exists.
   // In other words, C = B^{-1} * A.
+  // For divideRight, we compute A = C * B, that is, C = A * B^{-1}.
   // Note that such a C exists iff (every pair of input/output dim of) A is
   // of the form
   // [[B, 0],
@@ -638,6 +639,8 @@ public:
   // same dimensions as A ensures that C is well-defined.
   friend std::optional<LinearLayout> divideLeft(const LinearLayout &A,
                                                 const LinearLayout &B);
+  friend std::optional<LinearLayout> divideRight(const LinearLayout &A,
+                                                 const LinearLayout &B);
 
   // Returns true if this layout acts trivially (as the identity) on the given
   // dimensions. This means that it's the identity on those dimensions, and it

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -453,6 +453,11 @@ public:
   auto getOutDimNames() const { return llvm::make_first_range(outDims); }
   auto getOutDimSizes() const { return llvm::make_second_range(outDims); }
 
+  // Relevant for reshaping
+  SmallVector<std::pair<StringAttr, int32_t>> getOutDims() const {
+    return to_vector(outDims);
+  }
+
   // Gets the position that this outDim occupies in getOutDimNames().  Asserts
   // if the dim is not present.
   int32_t getOutDimIndex(StringAttr outDim) const;

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -806,9 +806,10 @@ private:
   SmallVector<size_t> action;
   StringAttr inDim;
   size_t inSizeLog2;
-  bool isIdentity;
+  bool isIdentity = true;
 
 public:
+  ColumnAction() = default;
   ColumnAction(ArrayRef<size_t> action, StringAttr inDim, size_t inSizeLog2)
       : action(action), inDim(inDim), inSizeLog2(inSizeLog2) {
     auto it = llvm::max_element(action);

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -48,8 +48,8 @@ static unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
   dstLayout = actionRemoveBroadcastedRegs(dstLayout).apply(dstLayout);
   auto bitwidth = getBitwidth(srcTy);
   auto smem = gpu::optimalSwizzling(srcLayout, dstLayout, bitwidth);
-  auto reps = smem.getOutDimSize(StringAttr::get(ctx, "reps"));
-  return smem.getTotalOutDimSize() / reps;
+  auto reps = smem.getInDimSize(StringAttr::get(ctx, "reps"));
+  return smem.getTotalInDimSize() / reps;
 }
 
 static unsigned getNumScratchElemsPaddedCvt(RankedTensorType srcTy,

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -203,22 +203,11 @@ unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
     auto dstTy = cvtLayout.getType();
     if (!cvtNeedsSharedMemory(srcTy, dstTy))
       return 0;
-    // Hack
-    auto bitwidth = getBitwidth(srcTy);
-    if (bitwidth < 32) {
-      auto has32BContig = [bitwidth](RankedTensorType ty) {
-        auto layout = gpu::toLinearLayout(ty.getShape(), ty.getEncoding());
-        return layout.getNumConsecutiveInOut() * bitwidth >= 32;
-      };
-      if (!has32BContig(srcTy) || !has32BContig(dstTy)) {
-        return getNumScratchElemsPaddedCvt(srcTy, dstTy) * bitwidth / 8;
-      }
-    }
-
     // Pesimistically take the max. We will revisit later
     auto elems = std::max(getNumScratchElemsSwizzledCvt(srcTy, dstTy),
                           getNumScratchElemsPaddedCvt(srcTy, dstTy));
-    return elems * bitwidth / 8;
+
+    return elems * getBitwidth(srcTy) / 8;
   }
   if (isa<AtomicRMWOp, AtomicCASOp>(op)) {
     auto value = op->getOperand(0);

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -248,10 +248,14 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
 
     // The permutation exists by construction of the reps dimension in
     // optimalSwizzling
-    auto permRead = *regPermForDivide(totalReadCvt, reps, /*left=*/false);
+    auto maybePermRead = regPermForDivide(totalReadCvt, reps, /*left=*/false);
+    assert(maybePermRead.has_value());
+    auto permRead = *maybePermRead;
     totalReadCvt = permRead.apply(totalReadCvt);
     inVals = permRead.apply(inVals);
-    auto permWrite = *regPermForDivide(totalWriteCvt, reps, /*left=*/false);
+    auto maybePermWrite = regPermForDivide(totalWriteCvt, reps, /*left=*/false);
+    assert(maybePermWrite.has_value());
+    auto permWrite = *maybePermWrite;
     totalWriteCvt = permWrite.apply(totalWriteCvt);
 
     // Remove the reps and flatten into offset

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -204,6 +204,8 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
                         : srcTy.getElementTypeBitWidth();
 
     // Handle sub-byte elements like i1
+    auto inVals = unpackLLElements(loc, src, rewriter);
+
     bool isSubByte = bitwidth < 8;
     auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
     if (isSubByte) {
@@ -236,8 +238,6 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
                                     to_vector(srcLayout.getOutDimNames()));
     dstLayout = dstLayout.sublayout({kRegister, kLane, kWarp},
                                     to_vector(dstLayout.getOutDimNames()));
-
-    auto inVals = unpackLLElements(loc, src, rewriter);
 
     // Remove register broadcast from src and dst and input values
     auto removeBroadcastSrc = actionRemoveBroadcastedRegs(srcLayout);

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -227,11 +227,9 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
 
     auto smem = optimalSwizzling(srcLayout, dstLayout, bitwidth);
 
-    // Handle sub-byte elements
+    // Handle sub-byte elements like i1
     bool isSubByte = bitwidth * smem.getInDimSize(str_attr("vector")) < 8;
-    // Is the isSubByte case dead?
     auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
-    assert(!isSubByte);
     if (isSubByte) {
       // Upcast to i8
       auto llvmElemTy = i8_ty;

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -114,6 +114,32 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     return success();
   }
 
+  std::pair<int, ColumnAction> largestVectorisation(MLIRContext *ctx,
+                                                    const LinearLayout &cvt,
+                                                    int bitwidth) const {
+    // Find the largest vectorisation we can use:
+    StringAttr kReg = str_attr("register");
+    StringAttr kOffset = str_attr("offset");
+    LinearLayout quot;
+    LinearLayout tile;
+    ColumnAction permutation;
+    for (int v = 128 / bitwidth; v >= 1; v /= 2) {
+      tile = LinearLayout::identity1D(v, kReg, kOffset);
+      auto maybePerm = regPermForDivide(cvt, tile, /*left=*/true);
+      if (!maybePerm) {
+        continue;
+      }
+      permutation = *maybePerm;
+      auto newCvt = permutation.apply(cvt);
+      auto maybeQuot = divideLeft(newCvt, tile);
+      if (!maybeQuot) {
+        continue;
+      }
+      return {v, permutation};
+    }
+    llvm_unreachable("No vectorisation found");
+  }
+
   // Close cousin of lowerLdStMatrix in MemoryOpToLLVM.cpp
   // We might want to merge them at some point, but having to support
   // ldmatrix.trans makes the code in lowerLdStMatrix a bit specific
@@ -133,19 +159,19 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     auto kLane = str_attr("lane");
     auto kWarp = str_attr("warp");
     auto kOffset = str_attr("offset");
+    auto bitwidth = llvmElemTy.getIntOrFloatBitWidth();
 
-    // Form the map from value to offset
-    auto tile = LinearLayout::identity1D(elemsPerVec, kReg, kOffset);
-    // By construction, there is a register permutation that allows us to
-    // divideLeft
-    auto permutation = *regPermForDivide(cvt, tile, /*left=*/true);
+    auto [vec, permutation] = largestVectorisation(ctx, cvt, bitwidth);
+    assert(vec >= elemsPerVec);
+    elemsPerVec = vec;
+
     cvt = permutation.apply(cvt);
     if (isStore) {
       vals = permutation.apply(vals);
     }
 
-    // By construction of the smemLl, we can divideLeft
-    LinearLayout quot = *divideLeft(cvt, tile);
+    auto tile = LinearLayout::identity1D(vec, kReg, kOffset);
+    auto quot = *divideLeft(cvt, tile);
     LinearLayout reps = zerosLike(tile) * quot;
 
     auto [nAdditive, permStrides] = actionAdditiveStrides(reps);
@@ -158,7 +184,6 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     // If we don't perform the computations in i8, the compiler would
     // have to divide the computation by bitwdith / 8 and then lift this
     // shl, which often it's not able to do.
-    auto bitwidth = llvmElemTy.getIntOrFloatBitWidth();
     auto i8Tile =
         zerosLike(LinearLayout::identity1D(bitwidth / 8, kReg, kOffset));
     auto i8Reps = i8Tile * reps;
@@ -297,12 +322,6 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
       if (totalLoadCvt.getBasis(kReg, i, kVec) != (1 << i)) {
         return failure();
       }
-    }
-
-    // FIXME(Lezcano): Return when there's broadcasting
-    if (srcLayout.getFreeVariableMasks()[kLane] != 0 ||
-        dstLayout.getFreeVariableMasks()[kLane] != 0) {
-      return failure();
     }
 
     // The permutation exists by construction of the reps dimension in

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -246,6 +246,10 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     dstLayout = actionRemoveBroadcastedRegs(dstLayout).apply(dstLayout);
 
     auto smem = optimalSwizzling(srcLayout, dstLayout, bitwidth);
+    auto [r, w] = logBankConflicts(srcLayout, dstLayout, smem, bitwidth);
+    // If there are bank conflicts, we fallback to padding for now
+    if (r > 0 || w > 0)
+      return failure();
 
     // Extract reps from smem
     auto kReg = str_attr("register");

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -252,8 +252,8 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     auto smem = optimalSwizzling(srcLayout, dstLayout, bitwidth);
     auto [r, w] = logBankConflicts(srcLayout, dstLayout, smem, bitwidth);
     // If there are bank conflicts, we fallback to padding for now
-    if (r > 0 || w > 0)
-      return failure();
+    // if (r > 0 || w > 0)
+    //   return failure();
 
     // Extract reps from smem
     auto kReg = str_attr("register");

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -302,7 +302,6 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
 
     // Extract reps from smem
     auto kReg = str_attr("register");
-    auto kVec = str_attr("vector");
     auto kReps = str_attr("reps");
     auto nReps = smem.getInDimSize(kReps);
     auto reps = LinearLayout::identity1D(nReps, kReg, kReps);
@@ -311,18 +310,6 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     auto totalLoadCvt = dstLayout.invertAndCompose(smem);
 
     // FIXME(Lezcano): The legacy path also creates PRMT, so we should revisit
-    // If the vectorization up to 32 bits is not contiguous, the current
-    // algorithm creates a ton of PRMTs that often kill performance
-    auto vecUntilB32 = std::min<int>(llvm::Log2_32(32 / bitwidth),
-                                     smem.getInDimSizeLog2(kVec));
-    for (int i = 0; i < vecUntilB32; i++) {
-      if (totalStoreCvt.getBasis(kReg, i, kVec) != (1 << i)) {
-        return failure();
-      }
-      if (totalLoadCvt.getBasis(kReg, i, kVec) != (1 << i)) {
-        return failure();
-      }
-    }
 
     // The permutation exists by construction of the reps dimension in
     // optimalSwizzling

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -125,7 +125,6 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
                   ArrayRef<Value> valsArray, // Input for store, output for load
                   Type llvmElemTy, Value smemBase,
                   ConversionPatternRewriter &rewriter) const {
-    // Local copy of vals_ to avoid modifying the original vector
     auto vals = to_vector(valsArray);
     bool isStore = !vals.empty();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -275,10 +274,6 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     dstLayout = actionRemoveBroadcastedRegs(dstLayout).apply(dstLayout);
 
     auto smem = optimalSwizzling(srcLayout, dstLayout, bitwidth);
-    auto [r, w] = logBankConflicts(srcLayout, dstLayout, smem, bitwidth);
-    // If there are bank conflicts, we fallback to padding for now
-    // if (r > 0 || w > 0)
-    //   return failure();
 
     // Extract reps from smem
     auto kReg = str_attr("register");
@@ -287,43 +282,44 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     auto nReps = smem.getInDimSize(kReps);
     auto reps = LinearLayout::identity1D(nReps, kReg, kReps);
 
-    auto totalLoadCvt = srcLayout.invertAndCompose(smem);
-    auto totalStoreCvt = dstLayout.invertAndCompose(smem);
+    auto totalStoreCvt = srcLayout.invertAndCompose(smem);
+    auto totalLoadCvt = dstLayout.invertAndCompose(smem);
 
+    // FIXME(Lezcano): The legacy path also creates PRMT, so we should revisit
     // If the vectorization up to 32 bits is not contiguous, the current
     // algorithm creates a ton of PRMTs that often kill performance
     auto vecUntilB32 = std::min<int>(llvm::Log2_32(32 / bitwidth),
                                      smem.getInDimSizeLog2(kVec));
     for (int i = 0; i < vecUntilB32; i++) {
-      if (totalLoadCvt.getBasis(kReg, i, kVec) != (1 << i)) {
+      if (totalStoreCvt.getBasis(kReg, i, kVec) != (1 << i)) {
         return failure();
       }
-      if (totalStoreCvt.getBasis(kReg, i, kVec) != (1 << i)) {
+      if (totalLoadCvt.getBasis(kReg, i, kVec) != (1 << i)) {
         return failure();
       }
     }
 
     // The permutation exists by construction of the reps dimension in
     // optimalSwizzling
-    auto permLoad =
-        regPermForDivide(totalLoadCvt, reps, /*left=*/false).value();
-    totalLoadCvt = permLoad.apply(totalLoadCvt);
-    inVals = permLoad.apply(inVals);
     auto permStore =
         regPermForDivide(totalStoreCvt, reps, /*left=*/false).value();
     totalStoreCvt = permStore.apply(totalStoreCvt);
+    inVals = permStore.apply(inVals);
+    auto permLoad =
+        regPermForDivide(totalLoadCvt, reps, /*left=*/false).value();
+    totalLoadCvt = permLoad.apply(totalLoadCvt);
 
     // Remove the reps and flatten into offset
-    auto loadCvt = *divideRight(totalLoadCvt, reps);
     auto storeCvt = *divideRight(totalStoreCvt, reps);
+    auto loadCvt = *divideRight(totalLoadCvt, reps);
     auto kOffset = str_attr("offset");
-    loadCvt = loadCvt.reshapeOuts({{kOffset, loadCvt.getTotalOutDimSize()}});
     storeCvt = storeCvt.reshapeOuts({{kOffset, storeCvt.getTotalOutDimSize()}});
+    loadCvt = loadCvt.reshapeOuts({{kOffset, loadCvt.getTotalOutDimSize()}});
 
     Value smemBase =
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
 
-    auto tileSize = loadCvt.getInDimSize(kReg);
+    auto tileSize = storeCvt.getInDimSize(kReg);
 
     assert(inVals.size() == tileSize * nReps);
     SmallVector<Value> outVals;
@@ -334,17 +330,17 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
 
       auto tileInVals = ArrayRef<Value>(inVals).slice(i * tileSize, tileSize);
       // Store
-      lowerLdStShared(loc, ctx, loadCvt, elemsPerVec, tileInVals, llvmElemTy,
+      lowerLdStShared(loc, ctx, storeCvt, elemsPerVec, tileInVals, llvmElemTy,
                       smemBase, rewriter);
       b.barrier();
       // Load
       SmallVector<Value> tileOutVals = lowerLdStShared(
-          loc, ctx, storeCvt, elemsPerVec, {}, llvmElemTy, smemBase, rewriter);
+          loc, ctx, loadCvt, elemsPerVec, {}, llvmElemTy, smemBase, rewriter);
       llvm::append_range(outVals, tileOutVals);
     }
 
-    // Undo the permStore used to divideRight
-    outVals = permStore.inverse().apply(outVals);
+    // Undo the permLoad used to divideRight
+    outVals = permLoad.inverse().apply(outVals);
 
     // Unwrap sub-byte elements if necessary
     if (isSubByte) {

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -174,9 +174,8 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
                            LLVM::GEPNoWrapFlags::inbounds);
       // Lezcano: Do we want to use getFreeVariableMasks for pred or nah?
       if (isStore) {
-        Value valsVec = packLLVector(
-            loc, ArrayRef<Value>(vals.begin() + i, vals.begin() + i + step),
-            rewriter);
+        Value valsVec =
+            packLLVector(loc, ArrayRef<Value>(vals).slice(i, step), rewriter);
         targetInfo.storeDShared(rewriter, loc, vecAddr, std::nullopt, valsVec,
                                 /*pred=*/b.true_val());
       } else {

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -299,6 +299,12 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
       }
     }
 
+    // FIXME(Lezcano): Return when there's broadcasting
+    if (srcLayout.getFreeVariableMasks()[kLane] != 0 ||
+        dstLayout.getFreeVariableMasks()[kLane] != 0) {
+      return failure();
+    }
+
     // The permutation exists by construction of the reps dimension in
     // optimalSwizzling
     auto permStore =

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -392,8 +392,9 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     assert(cvtNeedsSharedMemory(srcTy, dstTy));
 
     // Try to use swizzling to implement the conversion
-    if (succeeded(
-            transferWithinBlockSwizzling(op, adaptor.getSrc(), rewriter))) {
+    // HACK Remove once AMD tests pass for the swizzling path
+    if (targetInfo.isCuda() && succeeded(transferWithinBlockSwizzling(
+                                   op, adaptor.getSrc(), rewriter))) {
       return success();
     }
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -683,7 +683,7 @@ void ConvertLayoutOpUsingLinearLayoutsConversion::transferWithinWarp(
     // At the same time, for each register, P1 returns the source value index
     // to provide as the shuffle value.
     auto out = applyLinearLayout(loc, rewriter, P1,
-                                 {{kLane, laneId}, {kRegister, b.i32_val(i)}});
+                                 {{kRegister, b.i32_val(i)}, {kLane, laneId}});
     assert(out.size() == 1);
     Value srcRegIdx = out.front().second;
     // The size of the input lane dimension is the number of selects to emit.
@@ -698,7 +698,7 @@ void ConvertLayoutOpUsingLinearLayoutsConversion::transferWithinWarp(
     }
 
     out = applyLinearLayout(loc, rewriter, Cp,
-                            {{kLane, laneId}, {kRegister, b.i32_val(i)}});
+                            {{kRegister, b.i32_val(i)}, {kLane, laneId}});
     assert(out.size() == 1);
     Value shflIdx = out.front().second;
     shflOuts[i] = targetInfo.shuffleIdx(rewriter, loc, shflSrc, shflIdx);
@@ -712,7 +712,7 @@ void ConvertLayoutOpUsingLinearLayoutsConversion::transferWithinWarp(
     Value result = b.undef(srcValues.front().getType());
 
     auto out = applyLinearLayout(loc, rewriter, P2inv,
-                                 {{kLane, laneId}, {kRegister, b.i32_val(i)}});
+                                 {{kRegister, b.i32_val(i)}, {kLane, laneId}});
     Value resultIdx = out.front().second;
     for (int j : llvm::seq(reducedP2.getInDimSize(kLane))) {
       int32_t check =

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -150,9 +150,7 @@ applyLinearLayout(Location loc, RewriterBase &rewriter,
                   ArrayRef<std::pair<StringAttr, Value>> indices) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   assert(layout.getNumInDims() == indices.size());
-  for (auto [inDimName, idx] : indices) {
-    assert(layout.hasInDim(inDimName) && "Invalid inDimName");
-  }
+  assert(llvm::equal(layout.getInDimNames(), llvm::make_first_range(indices)));
 
   // This function can emit a lot of MLIR code, which ultimately makes
   // compilation slow.  (We think this shouldn't be the case -- it's not *that*

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -191,14 +191,10 @@ applyLinearLayout(Location loc, RewriterBase &rewriter,
     // Concatenate input
     Value x = b.i32_val(0);
     int shift = 0;
-    for (auto orderedName : layout.getInDimNames()) {
-      for (auto [inDimName, idx] : nonConstantIns) {
-        if (orderedName == inDimName) {
-          inDimNames.push_back(inDimName);
-          x = b.or_(x, b.shl(idx, b.i32_val(shift)));
-          shift += layout.getInDimSizeLog2(inDimName);
-        }
-      }
+    for (auto [inDimName, idx] : nonConstantIns) {
+      inDimNames.push_back(inDimName);
+      x = b.or_(x, b.shl(idx, b.i32_val(shift)));
+      shift += layout.getInDimSizeLog2(inDimName);
     }
     // Flatten ins
     auto matrix = layout.sublayout(inDimNames, outIndices[0].first);

--- a/lib/Tools/CMakeLists.txt
+++ b/lib/Tools/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_triton_library(TritonTools
+  GenericSwizzling.cpp
   LayoutUtils.cpp
   LinearLayout.cpp
 

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -1,0 +1,256 @@
+#include "triton/Tools/GenericSwizzling.h"
+
+#include "third_party/f2reduce/f2reduce.h"
+#include "triton/Tools/LayoutUtils.h"
+#include "triton/Tools/LinearLayout.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
+
+#define DEBUG_TYPE "generic-swizzling"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+
+#if defined(_MSC_VER) && !defined(__clang__)
+// from https://gist.github.com/pps83/3210a2f980fd02bb2ba2e5a1fc4a2ef0
+#include <intrin.h>
+
+static int __builtin_ctzll(unsigned long long x) {
+  unsigned long r;
+  _BitScanForward64(&r, x);
+  return static_cast<int>(r);
+}
+
+#endif
+
+void printBasis(const llvm::SmallVector<int32_t> &basis,
+                const std::string &name) {
+  llvm::errs() << name << ": ";
+  for (int32_t b : basis)
+    llvm::errs() << b << " ";
+  llvm::errs() << "\n";
+}
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+// Compute the nullspace basis of `vectors`
+SmallVector<int32_t> nullspaceBasis(ArrayRef<int32_t> vectors, int32_t rank) {
+  // Solve A^T x = 0, where A is the matrix of vectors
+  // To do this, we form a matrix where each vector is a row
+  const int32_t nRows = vectors.size();
+  auto mat = std::make_unique<uint64_t[]>(nRows);
+  for (int i = 0; i < nRows; ++i)
+    mat[i] = static_cast<uint64_t>(vectors[i]);
+  f2reduce::inplace_rref_strided(mat.get(), /*rows=*/nRows, /*cols=*/rank,
+                                 /*stride=*/1);
+
+  // Collect pivot columns.
+  llvm::SmallDenseSet<int32_t> pivotCols;
+  for (int32_t r = 0; r < nRows; ++r)
+    if (mat[r])
+      pivotCols.insert(__builtin_ctzll(mat[r]));
+
+  // Free columns are range(rank) - pivotCols.
+  SmallVector<int32_t> basis;
+  for (int32_t freeCol = 0; freeCol < rank; ++freeCol) {
+    if (!pivotCols.contains(freeCol)) {
+      uint64_t vec = 1ull << freeCol; // start with e_free
+      for (int32_t r = 0; r < nRows; ++r)
+        if (mat[r] & (1ull << freeCol)) {
+          const int32_t pivot = __builtin_ctzll(mat[r]);
+          vec ^= (1ull << pivot);
+        }
+      basis.push_back(static_cast<int32_t>(vec));
+    }
+  }
+  return basis;
+}
+
+// Helper used by findGoodSmemLayoutFasto – matches ll.py::compute_segment.
+SmallVector<int32_t> computeSegment(const SmallVector<int32_t> &bankSrc,
+                                    const SmallVector<int32_t> &bankDst,
+                                    int32_t rank, int32_t lenSegment) {
+  llvm::SmallDenseSet<int32_t> setSrc(bankSrc.begin(), bankSrc.end());
+  llvm::SmallDenseSet<int32_t> setDst(bankDst.begin(), bankDst.end());
+  // Remove the 0 as it's not a basis
+  setSrc.erase(0);
+  setDst.erase(0);
+
+  SmallVector<int32_t> segment;
+  for (int32_t b = 0; b < rank; ++b)
+    if (!setSrc.contains(1 << b) && !setDst.contains(1 << b))
+      segment.push_back(1 << b);
+  if (segment.size() >= lenSegment) {
+    segment.resize(lenSegment);
+    return segment;
+  }
+  printBasis(bankSrc, "bankSrc");
+  printBasis(bankDst, "bankDst");
+  printBasis(segment, "segment");
+
+  // A and B are the difference sets
+  SmallVector<int32_t> A, B;
+  for (int32_t v : setSrc)
+    if (!setDst.contains(v))
+      A.push_back(v);
+  for (int32_t v : setDst)
+    if (!setSrc.contains(v))
+      B.push_back(v);
+  if (A.size() > B.size()) {
+    std::swap(A, B);
+  }
+  llvm::sort(A);
+  llvm::sort(B);
+  // A is the smaller set now
+  auto logBankConflicts = std::min<int32_t>(
+      std::max<int32_t>(0, lenSegment - A.size() - segment.size()), A.size());
+  // Conflict-free
+  for (int i = logBankConflicts; i < A.size(); ++i)
+    segment.push_back(A[i] ^ B[i]);
+  // Write conflicts
+  segment.append(A.begin(), A.begin() + logBankConflicts);
+  // Read conflicts
+  segment.append(B.begin(), B.begin() + logBankConflicts);
+
+  if (segment.size() > lenSegment)
+    segment.resize(lenSegment);
+  return segment;
+}
+
+SmallVector<int32_t> complementBasis(ArrayRef<int32_t> basis, int32_t rank) {
+  const int32_t nRows = basis.size();
+  // Build an nRows × rank matrix: each row is one of your 'basis' vectors.
+  auto mat = std::make_unique<uint64_t[]>(nRows);
+  for (int r = 0; r < nRows; ++r)
+    mat[r] = static_cast<uint64_t>(basis[r]);
+
+  // RREF that, with 'rows = nRows' and 'cols = rank'.
+  f2reduce::inplace_rref_strided(mat.get(), /*rows=*/nRows,
+                                 /*cols=*/rank, /*stride=*/1);
+
+  // Collect which coordinate-columns have pivots.
+  llvm::SmallDenseSet<int32_t> pivotCols;
+  for (int r = 0; r < nRows; ++r) {
+    if (mat[r]) {
+      pivotCols.insert(__builtin_ctzll(mat[r])); // leading-1 position
+    }
+  }
+
+  // Now any coordinate i ∈ [0,rank) that *isn’t* in pivotCols is free,
+  // so the unit-vector (1<<i) belongs in your complement.
+  SmallVector<int32_t> comp;
+  for (int i = 0; i < rank; ++i)
+    if (!pivotCols.contains(i))
+      comp.push_back(1 << i);
+
+  return comp;
+}
+} // anonymous namespace
+
+namespace mlir::triton::gpu {
+
+SmallVector<int32_t> intersectionBasis(ArrayRef<int32_t> b1,
+                                       ArrayRef<int32_t> b2, int32_t rank) {
+  auto ns1 = nullspaceBasis(b1, rank);
+  auto ns2 = nullspaceBasis(b2, rank);
+  auto joint = llvm::to_vector(llvm::concat<int32_t>(ns1, ns2));
+  auto result = nullspaceBasis(joint, rank);
+  return result;
+}
+
+LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
+                              int32_t bitwidth) {
+  assert(llvm::equal(src.getInDimNames(), dst.getInDimNames()) &&
+         "src and dst must have identical in dims");
+  assert(llvm::equal(src.getOutDims(), dst.getOutDims()) &&
+         "src and dst must have identical out dims and shape");
+  assert((bitwidth > 0) && llvm::isPowerOf2_32(bitwidth) &&
+         "bitwidth must be a power of two");
+  assert(bitwidth <= 32 && "NYI: support for larger bitwidths");
+
+  const int32_t rank = src.getTotalOutDimSizeLog2();
+
+  // We work on the flattened tensors as the tensor dimensions are not relevant
+  // here
+  const LinearLayout srcFlat = src.flattenOuts();
+  const LinearLayout dstFlat = dst.flattenOuts();
+  const StringAttr out1D = *srcFlat.getOutDimNames().begin(); // single dim
+  auto *ctx = out1D.getContext();
+  auto kReg = StringAttr::get(ctx, "register");
+  auto kLane = StringAttr::get(ctx, "lane");
+
+  // Goes from bases of the form [[1], [2], [4], [8]] to [1, 2, 4, 8]
+  auto flatten = [&](const LinearLayout &ll, StringAttr dim) {
+    SmallVector<int32_t> vec;
+    for (int i = 0; i < ll.getInDimSizeLog2(dim); ++i)
+      vec.push_back(ll.getBasis(dim, i, out1D));
+    return vec;
+  };
+
+  auto regSrc = flatten(srcFlat, kReg);
+  auto regDst = flatten(dstFlat, kReg);
+  auto laneSrc = flatten(srcFlat, kLane);
+  auto laneDst = flatten(dstFlat, kLane);
+
+  // Compute the vectorisation we can use
+  SmallVector<int32_t> vbasis = intersectionBasis(regSrc, regDst, rank);
+  // Restrict the vectorisation to the maximum we can use
+  auto maxVecBases = llvm::Log2_32(128 / bitwidth);
+  if (vbasis.size() > maxVecBases) {
+    vbasis.resize(maxVecBases);
+  }
+
+  // Bits in a bank segment: 32 banks x 32 bits
+  constexpr int32_t bankBits = 32 * 32;
+  // Bases needed to cover a whole bank segment
+  // FIXME: Handle small converts
+  assert(bankBits >= (1 << vbasis.size()) * bitwidth && "cvt too small");
+  const int32_t lenBbasis =
+      llvm::Log2_32(bankBits / ((1 << vbasis.size()) * bitwidth));
+  // Bases to cover all the tensor
+  const int32_t lenSbasis = rank - lenBbasis - vbasis.size();
+
+  llvm::errs() << "MaxVect: " << maxVecBases << " == " << vbasis.size() << "\n";
+  printBasis(regSrc, "regSrc");
+  printBasis(regDst, "regDst");
+  printBasis(laneSrc, "laneSrc");
+  printBasis(laneDst, "laneDst");
+  printBasis(vbasis, "vbasis");
+
+  auto bankSrc = llvm::to_vector(llvm::concat<int32_t>(vbasis, laneSrc));
+  auto bankDst = llvm::to_vector(llvm::concat<int32_t>(vbasis, laneDst));
+  auto sbasis = computeSegment(bankSrc, bankDst, rank, lenSbasis);
+  printBasis(sbasis, "sbasis");
+
+  // The bank is the complement of the union of the vector and the start of the
+  // segments
+  auto unionBasis = llvm::to_vector(llvm::concat<int32_t>(vbasis, sbasis));
+  SmallVector<int32_t> bbasis = complementBasis(unionBasis, rank);
+  assert(bbasis.size() == lenBbasis + (lenSbasis - sbasis.size()) &&
+         "bbasis size mismatch");
+  printBasis(bbasis, "bbasis");
+
+  // Build the 1D result layout
+  StringAttr vecAttr = StringAttr::get(ctx, "vector");
+  StringAttr bankAttr = StringAttr::get(ctx, "bank");
+  StringAttr segAttr = StringAttr::get(ctx, "segment");
+
+  auto unflatten = [&](const SmallVector<int32_t> &basis)
+      -> std::vector<std::vector<int32_t>> {
+    std::vector<std::vector<int32_t>> unflattened;
+    for (int32_t b : basis)
+      unflattened.push_back({b});
+    return unflattened;
+  };
+
+  LinearLayout basis1D({{vecAttr, unflatten(vbasis)},
+                        {bankAttr, unflatten(bbasis)},
+                        {segAttr, unflatten(sbasis)}},
+                       srcFlat.getOutDims(), /*requireSurjective=*/true);
+
+  return basis1D.reshapeOuts(src.getOutDims());
+}
+} // namespace mlir::triton::gpu

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -252,7 +252,6 @@ LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
          "src and dst must have identical out dims and shape");
   assert((bitwidth > 0) && llvm::isPowerOf2_32(bitwidth) &&
          "bitwidth must be a power of two");
-  assert(bitwidth <= 32 && "NYI: support for larger bitwidths");
 
   const int32_t rank = src.getTotalOutDimSizeLog2();
   assert(src.getNumInDims() != 0);

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -100,19 +100,14 @@ LinearLayout buildReps(MLIRContext *ctx, const LinearLayout &src,
   auto kReg = StringAttr::get(ctx, "register");
   // A basis is a rep if:
   // 1) It is in registers in both src and dst
-  // 2) It is not swizzled
-  // 3) It is not vectorised
-  // After a moment's reflection, it should be clear that the
-  // set of basis that can be reps is exactly the set of elements
-  // that are in src[kReg] \cup dst[kReg], but are not in smem[kVec].
-  // This is because the swizzled elements are xors of elements that
-  // are in the src[kLane] \cup dst[kLane], which is disjoint to this set
+  // 2) It is in the segment of smem (i.e., is not part of just one
+  //    load/store)
   SetVector<int32_t> srcRegs(llvm::from_range_t{}, flatten(src, kReg));
   SetVector<int32_t> dstRegs(llvm::from_range_t{}, flatten(dst, kReg));
-  SetVector<int32_t> smemVecs(llvm::from_range_t{}, flatten(smem, kVec));
+  SetVector<int32_t> smemSegment(llvm::from_range_t{}, flatten(smem, kSegment));
   SetVector<int32_t> reps;
   for (int32_t b : srcRegs) {
-    if (dstRegs.contains(b) && !smemVecs.contains(b)) {
+    if (dstRegs.contains(b) && smemSegment.contains(b)) {
       reps.insert(b);
     }
   }

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -118,11 +118,12 @@ LinearLayout buildReps(MLIRContext *ctx, const LinearLayout &src,
   }
   // Split segment into segment and reps
   SetVector<int32_t> segment;
-  for (int32_t b : smemVecs) {
+  for (int32_t b : flatten(smem, kSegment)) {
     if (!reps.contains(b)) {
       segment.insert(b);
     }
   }
+
   auto smemReps = LinearLayout({{kVec, smem.getBases().lookup(kVec)},
                                 {kBank, smem.getBases().lookup(kBank)},
                                 {kSegment, unflatten(to_vector(segment))},

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -291,8 +291,10 @@ LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
   // Bits in a bank segment: 32 banks x 32 bits
   constexpr int32_t bankBits = 32 * 32;
   // Bases needed to cover a whole bank segment
-  // FIXME: Handle small converts
-  assert(bankBits >= (1 << vbasis.size()) * bitwidth && "cvt too small");
+  // FIXME: Make small cvts performant:
+  //    if (1 << vbasis.size()) * bitwidth < 32, we could use
+  //    32 when computing lenBbasis, and then upcast values to a b32
+  //    to cover at least one bank per element
   const int32_t lenBbasis =
       llvm::Log2_32(bankBits / ((1 << vbasis.size()) * bitwidth));
   // Bases to cover all the tensor

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -87,9 +87,6 @@ SmallVector<int32_t> computeSegment(const SmallVector<int32_t> &bankSrc,
     segment.resize(lenSegment);
     return segment;
   }
-  printBasis(bankSrc, "bankSrc");
-  printBasis(bankDst, "bankDst");
-  printBasis(segment, "segment");
 
   // A and B are the difference sets
   SmallVector<int32_t> A, B;
@@ -213,17 +210,9 @@ LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
   // Bases to cover all the tensor
   const int32_t lenSbasis = rank - lenBbasis - vbasis.size();
 
-  llvm::errs() << "MaxVect: " << maxVecBases << " == " << vbasis.size() << "\n";
-  printBasis(regSrc, "regSrc");
-  printBasis(regDst, "regDst");
-  printBasis(laneSrc, "laneSrc");
-  printBasis(laneDst, "laneDst");
-  printBasis(vbasis, "vbasis");
-
   auto bankSrc = llvm::to_vector(llvm::concat<int32_t>(vbasis, laneSrc));
   auto bankDst = llvm::to_vector(llvm::concat<int32_t>(vbasis, laneDst));
   auto sbasis = computeSegment(bankSrc, bankDst, rank, lenSbasis);
-  printBasis(sbasis, "sbasis");
 
   // The bank is the complement of the union of the vector and the start of the
   // segments
@@ -231,7 +220,6 @@ LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
   SmallVector<int32_t> bbasis = complementBasis(unionBasis, rank);
   assert(bbasis.size() == lenBbasis + (lenSbasis - sbasis.size()) &&
          "bbasis size mismatch");
-  printBasis(bbasis, "bbasis");
 
   // Build the 1D result layout
   StringAttr vecAttr = StringAttr::get(ctx, "vector");

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -343,10 +343,10 @@ LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
     SmallVector<int32_t> banksInRegSrc;
     SmallVector<int32_t> banksInRegDst;
     for (auto r : bbasis) {
-      if (llvm::any_of(regSrc, [r](int32_t b) { return b == r; })) {
+      if (llvm::is_contained(regSrc, r)) {
         banksInRegSrc.push_back(r);
       }
-      if (llvm::any_of(regDst, [r](int32_t b) { return b == r; })) {
+      if (llvm::is_contained(regDst, r)) {
         banksInRegDst.push_back(r);
       }
     }
@@ -357,7 +357,7 @@ LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
                          : std::move(banksInRegDst);
     SmallVector<int32_t> others;
     for (auto b : bbasis) {
-      if (!llvm::any_of(newBbasis, [b](int32_t b2) { return b2 == b; })) {
+      if (!llvm::is_contained(newBbasis, b)) {
         others.push_back(b);
       }
     }

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -229,6 +229,8 @@ std::optional<ColumnAction> regPermForDivide(const LinearLayout &A,
   for (StringAttr out : A.getOutDimNames()) {
     log2QuotSize[out] =
         A.getOutDimSizeLog2(out) - BBroadcast.getOutDimSizeLog2(out);
+    if (log2QuotSize[out] < 0)
+      return std::nullopt;
   }
 
   auto multiplyByTileSize =

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -35,7 +35,7 @@ tt.func @empty(%A : !tt.ptr<f16>) {
 }
 
 // expected-remark @below {{matmul_loop}}
-// expected-remark @below {{size = 8192}}
+// expected-remark @below {{size = 4608}}
 tt.func @matmul_loop(%lb : index, %ub : index, %step : index, %A : !tt.ptr<f16>, %B : !tt.ptr<f16>) {
   %a_ptr_init = tt.splat %A : !tt.ptr<f16> -> tensor<128x32x!tt.ptr<f16>, #AL>
   %b_ptr_init = tt.splat %B : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>, #BL>
@@ -51,10 +51,10 @@ tt.func @matmul_loop(%lb : index, %ub : index, %step : index, %A : !tt.ptr<f16>,
 
   scf.for %iv = %lb to %ub step %step iter_args(%a_ptr = %a_ptr_init, %b_ptr = %b_ptr_init, %prev_c = %c_init) -> (tensor<128x32x!tt.ptr<f16>, #AL>, tensor<32x128x!tt.ptr<f16>, #BL>, tensor<128x128xf32, #C>) {
     %a_ = tt.load %a_ptr, %a_mask, %a_other : tensor<128x32x!tt.ptr<f16>, #AL>
-    // expected-remark @below {{scratch offset = 0, size = 8192}}
+    // expected-remark @below {{scratch offset = 0, size = 4608}}
     %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A_DOT>
     %b_ = tt.load %b_ptr, %b_mask, %b_other : tensor<32x128x!tt.ptr<f16>, #BL>
-    // expected-remark @below {{scratch offset = 0, size = 8192}}
+    // expected-remark @below {{scratch offset = 0, size = 2304}}
     %b = ttg.convert_layout %b_ : tensor<32x128xf16, #BL> -> tensor<32x128xf16, #B_DOT>
 
     %c = tt.dot %a, %b, %prev_c : tensor<128x32xf16, #A_DOT> * tensor<32x128xf16, #B_DOT> -> tensor<128x128xf32, #C>
@@ -68,7 +68,7 @@ tt.func @matmul_loop(%lb : index, %ub : index, %step : index, %A : !tt.ptr<f16>,
 
 // Shared memory is available after a tensor's liveness range ends
 // expected-remark @below {{reusable}}
-// expected-remark @below {{size = 8192}}
+// expected-remark @below {{size = 4608}}
 tt.func @reusable(%A : !tt.ptr<f16>) {
   %cst1 = arith.constant dense<true> : tensor<128x32xi1, #AL>
   %cst2 = arith.constant dense<0.000000e+00> : tensor<128x32xf16, #AL>
@@ -79,17 +79,17 @@ tt.func @reusable(%A : !tt.ptr<f16>) {
   %a_ptr = tt.splat %A : !tt.ptr<f16> -> tensor<128x32x!tt.ptr<f16>, #AL>
   %b_ptr = tt.splat %A : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>, #AL>
   %a1_ = tt.load %a_ptr, %cst1, %cst2 : tensor<128x32x!tt.ptr<f16>, #AL>
-  // expected-remark @below {{scratch offset = 0, size = 8192}}
+  // expected-remark @below {{scratch offset = 0, size = 4608}}
   %a1 = ttg.convert_layout %a1_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A_DOT>
   %a2_ = tt.load %b_ptr, %cst3, %cst4 : tensor<32x128x!tt.ptr<f16>, #AL>
-  // expected-remark @below {{scratch offset = 0, size = 8192}}
+  // expected-remark @below {{scratch offset = 0, size = 1088}}
   %a2 = ttg.convert_layout %a2_ : tensor<32x128xf16, #AL> -> tensor<32x128xf16, #B_DOT>
   %a3_ = tt.load %a_ptr, %cst1, %cst2 : tensor<128x32x!tt.ptr<f16>, #AL>
-  // expected-remark @below {{scratch offset = 0, size = 8192}}
+  // expected-remark @below {{scratch offset = 0, size = 4608}}
   %a3 = ttg.convert_layout %a3_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A_DOT>
   %c = tt.dot %a1, %a2, %c_init : tensor<128x32xf16, #A_DOT> * tensor<32x128xf16, #B_DOT> -> tensor<128x128xf32, #C>
   %a4_ = tt.load %b_ptr, %cst3, %cst4 : tensor<32x128x!tt.ptr<f16>, #AL>
-  // expected-remark @below {{scratch offset = 0, size = 8192}}
+  // expected-remark @below {{scratch offset = 0, size = 1088}}
   %a4 = ttg.convert_layout %a4_ : tensor<32x128xf16, #AL> -> tensor<32x128xf16, #B_DOT>
   %c1 = tt.dot %a3, %a4, %c : tensor<128x32xf16, #A_DOT> * tensor<32x128xf16, #B_DOT> -> tensor<128x128xf32, #C>
   tt.return

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1215,10 +1215,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK: llvm.mlir.global external @global_smem
   // CHECK-LABEL: convert_layout_mmav3_transpose
   tt.func @convert_layout_mmav3_transpose(%arg0: tensor<128x256xf8E5M2, #mma>) {
-    // CHECK-COUNT-16:
-    // CHECK-COUNT-8: llvm.store {{.*}} : vector<4xb32>
+    // CHECK-COUNT-8: llvm.store {{.*}} : vector<4xi32>
     // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
     %0 = ttg.convert_layout %arg0 : tensor<128x256xf8E5M2, #mma> -> tensor<128x256xf8E5M2, #blocked>
     tt.return
   }
@@ -1248,7 +1246,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // CHECK-LABEL: convert_blocked1d_to_slice0
   tt.func @convert_blocked1d_to_slice0(%src:tensor<32xi32, #blocked0>) {
-    // CHECK: st.shared.b32
+    // CHECK: llvm.store {{.*}} : vector<1xi32>
     // CHECK: nvvm.barrier0
     // CHECK-COUNT-4: llvm.load {{.*}} -> i32
     %cvt = ttg.convert_layout %src : tensor<32xi32, #blocked0> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1248,7 +1248,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   tt.func @convert_blocked1d_to_slice0(%src:tensor<32xi32, #blocked0>) {
     // CHECK: llvm.store {{.*}} : vector<1xi32>
     // CHECK: nvvm.barrier0
-    // CHECK-COUNT-4: llvm.load {{.*}} -> i32
+    // CHECK-COUNT-1: llvm.load {{.*}} -> vector<4xi32>
     %cvt = ttg.convert_layout %src : tensor<32xi32, #blocked0> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
     tt.return
   }
@@ -1261,7 +1261,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // CHECK-LABEL: convert_blocked1d_to_slice1
   tt.func @convert_blocked1d_to_slice1(%src:tensor<32xi32, #blocked0>) {
-    // CHECK-COUNT-8: llvm.load {{.*}} -> i32
+    // CHECK-COUNT-2: llvm.load {{.*}} -> vector<4xi32>
     %cvt = ttg.convert_layout %src : tensor<32xi32, #blocked0> -> tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked1}>>
     tt.return
   }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1215,30 +1215,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK: llvm.mlir.global external @global_smem
   // CHECK-LABEL: convert_layout_mmav3_transpose
   tt.func @convert_layout_mmav3_transpose(%arg0: tensor<128x256xf8E5M2, #mma>) {
-        // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
+    // CHECK-COUNT-8: llvm.store {{.*}} : vector<4xi32>
     // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
     %0 = ttg.convert_layout %arg0 : tensor<128x256xf8E5M2, #mma> -> tensor<128x256xf8E5M2, #blocked>
     tt.return
   }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1270,7 +1270,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   tt.func @convert_blocked1d_to_slice0(%src:tensor<32xi32, #blocked0>) {
     // CHECK: llvm.store {{.*}} : vector<1xi32>
     // CHECK: nvvm.barrier0
-    // CHECK-COUNT-4: llvm.load {{.*}} -> i32
+    // CHECK-COUNT-1: llvm.load {{.*}} -> vector<4xi32>
     %cvt = ttg.convert_layout %src : tensor<32xi32, #blocked0> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
     tt.return
   }
@@ -1283,7 +1283,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // CHECK-LABEL: convert_blocked1d_to_slice1
   tt.func @convert_blocked1d_to_slice1(%src:tensor<32xi32, #blocked0>) {
-    // CHECK-COUNT-8: llvm.load {{.*}} -> i32
+    // CHECK-COUNT-2: llvm.load {{.*}} -> vector<4xi32>
     %cvt = ttg.convert_layout %src : tensor<32xi32, #blocked0> -> tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked1}>>
     tt.return
   }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1215,28 +1215,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK: llvm.mlir.global external @global_smem
   // CHECK-LABEL: convert_layout_mmav3_transpose
   tt.func @convert_layout_mmav3_transpose(%arg0: tensor<128x256xf8E5M2, #mma>) {
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
-    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
+    // CHECK-COUNT-16:
+    // CHECK-COUNT-8: llvm.store {{.*}} : vector<4xb32>
     // CHECK: nvvm.barrier0
     // CHECK: llvm.load {{.*}} -> vector<4xi32>
     %0 = ttg.convert_layout %arg0 : tensor<128x256xf8E5M2, #mma> -> tensor<128x256xf8E5M2, #blocked>
@@ -1268,7 +1248,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // CHECK-LABEL: convert_blocked1d_to_slice0
   tt.func @convert_blocked1d_to_slice0(%src:tensor<32xi32, #blocked0>) {
-    // CHECK: llvm.load {{.*}} -> vector<4xi32>
+    // CHECK: st.shared.b32
+    // CHECK: nvvm.barrier0
+    // CHECK-COUNT-4: llvm.load {{.*}} -> i32
     %cvt = ttg.convert_layout %src : tensor<32xi32, #blocked0> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
     tt.return
   }
@@ -1313,13 +1295,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: linear_layout_with_multiple_iterations
   tt.func @linear_layout_with_multiple_iterations(%src: tensor<8x4xbf16, #linear>) {
     %cvt = ttg.convert_layout %src : tensor<8x4xbf16, #linear> -> tensor<8x4xbf16, #linear1>
-    // CHECK: llvm.store {{.*}} : vector<2xi16>
+    // CHECK-COUNT-2: llvm.store {{.*}} : vector<2xi16>
     // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> i16
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.store {{.*}} : vector<2xi16>
-    // CHECK: nvvm.barrier0
-    // CHECK: llvm.load {{.*}} -> i16
+    // CHECK-COUNT: llvm.load{{.*}}->vector<2xi16>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1215,8 +1215,30 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK: llvm.mlir.global external @global_smem
   // CHECK-LABEL: convert_layout_mmav3_transpose
   tt.func @convert_layout_mmav3_transpose(%arg0: tensor<128x256xf8E5M2, #mma>) {
-    // CHECK-COUNT-8: llvm.store {{.*}} : vector<4xi32>
+        // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
     // CHECK: nvvm.barrier0
+    // CHECK: llvm.load {{.*}} -> vector<4xi32>
+    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
+    // CHECK: nvvm.barrier0
+    // CHECK: llvm.load {{.*}} -> vector<4xi32>
+    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
+    // CHECK: nvvm.barrier0
+    // CHECK: llvm.load {{.*}} -> vector<4xi32>
+    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
+    // CHECK: nvvm.barrier0
+    // CHECK: llvm.load {{.*}} -> vector<4xi32>
+    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
+    // CHECK: nvvm.barrier0
+    // CHECK: llvm.load {{.*}} -> vector<4xi32>
+    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
+    // CHECK: nvvm.barrier0
+    // CHECK: llvm.load {{.*}} -> vector<4xi32>
+    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
+    // CHECK: nvvm.barrier0
+    // CHECK: llvm.load {{.*}} -> vector<4xi32>
+    // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xi8>
+    // CHECK: nvvm.barrier0
+    // CHECK: llvm.load {{.*}} -> vector<4xi32>
     %0 = ttg.convert_layout %arg0 : tensor<128x256xf8E5M2, #mma> -> tensor<128x256xf8E5M2, #blocked>
     tt.return
   }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1248,7 +1248,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   tt.func @convert_blocked1d_to_slice0(%src:tensor<32xi32, #blocked0>) {
     // CHECK: llvm.store {{.*}} : vector<1xi32>
     // CHECK: nvvm.barrier0
-    // CHECK-COUNT-1: llvm.load {{.*}} -> vector<4xi32>
+    // CHECK-COUNT-4: llvm.load {{.*}} -> i32
     %cvt = ttg.convert_layout %src : tensor<32xi32, #blocked0> -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
     tt.return
   }
@@ -1261,7 +1261,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // CHECK-LABEL: convert_blocked1d_to_slice1
   tt.func @convert_blocked1d_to_slice1(%src:tensor<32xi32, #blocked0>) {
-    // CHECK-COUNT-2: llvm.load {{.*}} -> vector<4xi32>
+    // CHECK-COUNT-8: llvm.load {{.*}} -> i32
     %cvt = ttg.convert_layout %src : tensor<32xi32, #blocked0> -> tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked1}>>
     tt.return
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1678,11 +1678,11 @@ static LogicalResult iterateGatherScatterIndices(
       Value msgIdVal = b.i32_val(msgId);
 
       auto result = applyLinearLayout(loc, rewriter, msgToShared,
-                                      {{kMsg, msgIdVal},
-                                       {kRegister, regIdVal},
+                                      {{kRegister, regIdVal},
                                        {kLane, laneId},
                                        {kWarp, warpId},
-                                       {kBlock, blockId}});
+                                       {kBlock, blockId},
+                                       {kMsg, msgIdVal}});
       assert(result.size() == 2 && result.front().first == "offset" &&
              result.back().first == "block");
       Value shMemOffset = result.front().second;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -73,7 +73,7 @@ LogicalResult lowerLdStMatrix(
 
     // Find if there is a register permutation that allows us to divideLeft
     // We need to pass the map from regs to offsets, as is cvt
-    maybePermutation = regPermForDivideLeft(cvt, tile);
+    maybePermutation = regPermForDivide(cvt, tile, /*left=*/true);
     if (!maybePermutation.has_value()) {
       return failure();
     }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -73,6 +73,8 @@ public:
 
   int getPtxVersion() const { return ptxVersion; }
 
+  bool isCuda() const override { return true; }
+
 private:
   int computeCapability;
   int ptxVersion;

--- a/unittest/Dialect/TritonGPU/CMakeLists.txt
+++ b/unittest/Dialect/TritonGPU/CMakeLists.txt
@@ -2,9 +2,9 @@ add_triton_ut(
   NAME TestSwizzling
   SRCS SwizzleTest.cpp
   LIBS
-    TritonGPUIR
-    TritonGPUTransforms
-    TritonNvidiaGPUTransforms
+    TritonTools
+    LLVMSupport
+    MLIRSupport
 )
 add_triton_ut(
   NAME Dialect

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -1,66 +1,148 @@
-#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Tools/GenericSwizzling.h"
+#include "triton/Tools/LayoutUtils.h"
+#include "triton/Tools/LinearLayout.h"
+
+#include "mlir/Support/LLVM.h"
 #include "llvm/Support/Signals.h"
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using namespace mlir;
-using mlir::triton::gpu::SwizzledSharedEncodingAttr;
+using namespace mlir::triton;
+
+using mlir::triton::gpu::intersectionBasis;
+using mlir::triton::gpu::optimalSwizzling;
 
 namespace {
 
-struct swizzleParams {
-  int vec;
-  int perPhase;
-  int maxPhase;
-};
+SmallVector<int32_t> flatten(const LinearLayout &ll, StringAttr dim) {
+  assert(ll.hasInDim(dim) && "in dim must exist");
+  SmallVector<int32_t> vec;
+  for (const auto &basis : ll.getBases().lookup(dim)) {
+    assert(basis.size() == 1 && "basis must be a single int32_t");
+    vec.push_back(basis[0]);
+  }
+  return vec;
+}
+class SwizzleTest : public ::testing::Test {
+public:
+  StringAttr S(StringRef str) { return StringAttr::get(&ctx, str); }
 
-struct ParamT {
-  std::array<int64_t, 2> shape;
-  int opIdx;
-  int typeWidth;
-  swizzleParams refSwizzle;
-};
+  std::pair<int, int> logBankConflicts(const LinearLayout &src,
+                                       const LinearLayout &dst,
+                                       const LinearLayout &smem) {
+    // build vector + segment basis
+    auto srcFlat = src.flattenOuts();
+    auto dstFlat = dst.flattenOuts();
+    auto smemFlat = smem.flattenOuts();
+    auto vecBasis = flatten(smemFlat, S("vector"));
+    auto segBasis = flatten(smemFlat, S("segment"));
+    auto bank0 = llvm::to_vector(llvm::concat<int32_t>(vecBasis, segBasis));
+    int32_t rank = smem.getTotalOutDimSizeLog2();
+    // compute conflicts
+    int read =
+        intersectionBasis(bank0, flatten(dstFlat, S("lane")), rank).size();
+    int write =
+        intersectionBasis(bank0, flatten(srcFlat, S("lane")), rank).size();
+    return {read, write};
+  }
 
-class SwizzleDotOperandTestFixture : public ::testing::TestWithParam<ParamT> {
+  int32_t logWavefronts(const LinearLayout &ll, int32_t bitwidth) {
+    // Returns the log of the wavefronts used by the read and write operations
+    // In other words:
+    // LDS.32, STS.32 -> Return 0
+    // LDS.64, STS.64 -> Return 1
+    // LDS.128, STS.128 -> Return 2
+    auto bitsPerThread = ll.getInDimSize(S("vector")) * bitwidth;
+    assert(bitsPerThread >= 32 && "each thread must write at least 32 bits");
+    return llvm::Log2_32(bitsPerThread / 32);
+  }
+
 protected:
-  ParamType param;
+  MLIRContext ctx;
 };
 
-TEST_P(SwizzleDotOperandTestFixture, DotOperands) {
-  auto params = GetParam();
-  // init context
-  MLIRContext ctx;
-  ctx.loadDialect<triton::gpu::TritonGPUDialect>();
+// computes (read, write) bank‐conflicts exactly as in ll.py
 
-  auto CTALayout =
-      triton::gpu::CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {0, 1});
+// ——— Tests ———
 
-  // create encoding
-  auto parent = triton::gpu::NvidiaMmaEncodingAttr::get(
-      &ctx, 2, 0, {1, 1}, CTALayout, {16, 64, 16});
-  auto encoding = triton::gpu::DotOperandEncodingAttr::get(
-      &ctx, params.opIdx, parent, 32 / params.typeWidth);
+TEST_F(SwizzleTest, Test128x128Float8Transpose) {
+  // 128x128 float8 matrix transpose
+  LinearLayout matrix(
+      {{S("register"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {1, 0}, {2, 0}}},
+       {S("lane"), {{0, 16}, {0, 32}, {0, 64}, {4, 0}, {8, 0}}},
+       {S("warp"), {{16, 0}, {32, 0}, {64, 0}}}},
+      {{S("dim0"), 128}, {S("dim1"), 128}}, /*requireSurjective=*/true);
+  auto matrix_t = transposeLinearLayout(matrix, {1, 0});
 
-  // create element type
-  Type eltType = IntegerType::get(&ctx, params.typeWidth);
-  auto layout = SwizzledSharedEncodingAttr::get(&ctx, encoding, params.shape,
-                                                {1, 0}, CTALayout, eltType);
-
-  ASSERT_EQ(layout.getVec(), params.refSwizzle.vec);
-  ASSERT_EQ(layout.getPerPhase(), params.refSwizzle.perPhase);
-  ASSERT_EQ(layout.getMaxPhase(), params.refSwizzle.maxPhase);
+  auto smem = optimalSwizzling(matrix, matrix_t, /*bitwidth=*/8);
+  auto [r, w] = logBankConflicts(matrix, matrix_t, smem);
+  auto logWf = logWavefronts(smem, 8);
+  EXPECT_EQ(r, logWf);
+  EXPECT_EQ(w, logWf);
 }
 
-INSTANTIATE_TEST_SUITE_P(TestDotOperands, SwizzleDotOperandTestFixture,
-                         ::testing::Values(ParamT{{128, 64}, 0, 16, {8, 1, 8}},
-                                           ParamT{{64, 256}, 1, 16, {8, 1, 8}},
-                                           ParamT{{128, 32}, 0, 16, {8, 2, 4}},
-                                           ParamT{{32, 128}, 1, 16, {8, 1, 8}},
-                                           ParamT{{32, 32}, 0, 16, {8, 2, 4}},
-                                           ParamT{{32, 32}, 1, 16, {8, 2, 4}},
-                                           ParamT{{16, 16}, 0, 16, {8, 4, 2}},
-                                           ParamT{{16, 16}, 1, 16, {8, 4, 2}}));
+TEST_F(SwizzleTest, Test16x16Bf16BlockedMma) {
+  // 16×16 bf16 MMA
+  LinearLayout blocked({{S("register"), {{0, 1}, {0, 2}, {0, 4}}},
+                        {S("lane"), {{0, 8}, {1, 0}, {2, 0}, {4, 0}, {8, 0}}},
+                        {S("warp"), {}}},
+                       {{S("dim0"), 16}, {S("dim1"), 16}},
+                       /*requireSurjective=*/true);
+  LinearLayout mma({{S("register"), {{0, 1}, {8, 0}, {0, 8}}},
+                    {S("lane"), {{0, 2}, {0, 4}, {1, 0}, {2, 0}, {4, 0}}},
+                    {S("warp"), {}}},
+                   {{S("dim0"), 16}, {S("dim1"), 16}},
+                   /*requireSurjective=*/true);
 
-} // anonymous namespace
+  auto smem = optimalSwizzling(blocked, mma, /*bitwidth=*/16);
+  auto [r, w] = logBankConflicts(blocked, mma, smem);
+  auto logWf = logWavefronts(smem, 16);
+  EXPECT_EQ(r, logWf);
+  EXPECT_EQ(w, logWf);
+}
+
+TEST_F(SwizzleTest, Test16x256U4Mma) {
+  // 16×256 u4 MMA
+  LinearLayout blocked(
+      {{S("register"),
+        {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {4, 0}, {8, 0}}},
+       {S("lane"), {{0, 32}, {0, 64}, {0, 128}, {1, 0}, {2, 0}}},
+       {S("warp"), {}}},
+      {{S("dim0"), 16}, {S("dim1"), 256}}, /*requireSurjective=*/true);
+  LinearLayout mma(
+      {{S("register"),
+        {{0, 1}, {0, 2}, {0, 4}, {8, 0}, {0, 32}, {0, 64}, {0, 128}}},
+       {S("lane"), {{0, 8}, {0, 16}, {1, 0}, {2, 0}, {4, 0}}},
+       {S("warp"), {}}},
+      {{S("dim0"), 16}, {S("dim1"), 256}}, /*requireSurjective=*/true);
+
+  auto smem = optimalSwizzling(blocked, mma, /*bitwidth=*/4);
+  auto [r, w] = logBankConflicts(blocked, mma, smem);
+  auto logWf = logWavefronts(smem, 4);
+  EXPECT_EQ(r, logWf);
+  EXPECT_EQ(w, logWf);
+}
+
+TEST_F(SwizzleTest, Test32x16F32Transpose) {
+  // 32×16 f32 transpose
+  LinearLayout matrix({{S("register"), {{4, 0}, {8, 0}, {16, 0}}},
+                       {S("lane"), {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {1, 0}}},
+                       {S("warp"), {{2, 0}}}},
+                      {{S("dim0"), 32}, {S("dim1"), 16}},
+                      /*requireSurjective=*/true);
+  LinearLayout matrix_t({{S("register"), {{0, 2}, {0, 4}, {0, 8}}},
+                         {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}}},
+                         {S("warp"), {{0, 1}}}},
+                        {{S("dim0"), 32}, {S("dim1"), 16}},
+                        /*requireSurjective=*/true);
+  auto smem = optimalSwizzling(matrix, matrix_t, /*bitwidth=*/32);
+  auto [r, w] = logBankConflicts(matrix, matrix_t, smem);
+  auto logWf = logWavefronts(smem, 32);
+  EXPECT_EQ(r, logWf);
+  EXPECT_EQ(w, logWf);
+}
+} // namespace
 
 int main(int argc, char *argv[]) {
   llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -10,7 +10,7 @@
 using namespace mlir;
 using namespace mlir::triton;
 
-using mlir::triton::gpu::intersectionBasis;
+using mlir::triton::gpu::logBankConflicts;
 using mlir::triton::gpu::optimalSwizzling;
 
 namespace {
@@ -27,36 +27,6 @@ SmallVector<int32_t> flatten(const LinearLayout &ll, StringAttr dim) {
 class SwizzleTest : public ::testing::Test {
 public:
   StringAttr S(StringRef str) { return StringAttr::get(&ctx, str); }
-
-  std::pair<int, int> logBankConflicts(const LinearLayout &src,
-                                       const LinearLayout &dst,
-                                       const LinearLayout &smem) {
-    // build vector + segment basis
-    auto srcFlat = src.flattenOuts();
-    auto dstFlat = dst.flattenOuts();
-    auto smemFlat = smem.flattenOuts();
-    auto vecBasis = flatten(smemFlat, S("vector"));
-    auto segBasis = flatten(smemFlat, S("segment"));
-    auto bank0 = llvm::to_vector(llvm::concat<int32_t>(vecBasis, segBasis));
-    int32_t rank = smem.getTotalOutDimSizeLog2();
-    // compute conflicts
-    int read =
-        intersectionBasis(bank0, flatten(dstFlat, S("lane")), rank).size();
-    int write =
-        intersectionBasis(bank0, flatten(srcFlat, S("lane")), rank).size();
-    return {read, write};
-  }
-
-  int32_t logWavefronts(const LinearLayout &ll, int32_t bitwidth) {
-    // Returns the log of the wavefronts used by the read and write operations
-    // In other words:
-    // LDS.32, STS.32 -> Return 0
-    // LDS.64, STS.64 -> Return 1
-    // LDS.128, STS.128 -> Return 2
-    auto bitsPerThread = ll.getInDimSize(S("vector")) * bitwidth;
-    assert(bitsPerThread >= 32 && "each thread must write at least 32 bits");
-    return llvm::Log2_32(bitsPerThread / 32);
-  }
 
 protected:
   MLIRContext ctx;
@@ -76,10 +46,9 @@ TEST_F(SwizzleTest, Test128x128Float8Transpose) {
   auto matrix_t = transposeLinearLayout(matrix, {1, 0});
 
   auto smem = optimalSwizzling(matrix, matrix_t, /*bitwidth=*/8);
-  auto [r, w] = logBankConflicts(matrix, matrix_t, smem);
-  auto logWf = logWavefronts(smem, 8);
-  EXPECT_EQ(r, logWf);
-  EXPECT_EQ(w, logWf);
+  auto [r, w] = logBankConflicts(matrix, matrix_t, smem, /*bitwidth=*/8);
+  EXPECT_EQ(r, 0);
+  EXPECT_EQ(w, 0);
 }
 
 TEST_F(SwizzleTest, Test16x16Bf16BlockedMma) {
@@ -96,10 +65,9 @@ TEST_F(SwizzleTest, Test16x16Bf16BlockedMma) {
                    /*requireSurjective=*/true);
 
   auto smem = optimalSwizzling(blocked, mma, /*bitwidth=*/16);
-  auto [r, w] = logBankConflicts(blocked, mma, smem);
-  auto logWf = logWavefronts(smem, 16);
-  EXPECT_EQ(r, logWf);
-  EXPECT_EQ(w, logWf);
+  auto [r, w] = logBankConflicts(blocked, mma, smem, /*bitwidth=*/16);
+  EXPECT_EQ(r, 0);
+  EXPECT_EQ(w, 0);
 }
 
 TEST_F(SwizzleTest, Test16x256U4Mma) {
@@ -118,10 +86,9 @@ TEST_F(SwizzleTest, Test16x256U4Mma) {
       {{S("dim0"), 16}, {S("dim1"), 256}}, /*requireSurjective=*/true);
 
   auto smem = optimalSwizzling(blocked, mma, /*bitwidth=*/4);
-  auto [r, w] = logBankConflicts(blocked, mma, smem);
-  auto logWf = logWavefronts(smem, 4);
-  EXPECT_EQ(r, logWf);
-  EXPECT_EQ(w, logWf);
+  auto [r, w] = logBankConflicts(blocked, mma, smem, /*bitwidth=*/4);
+  EXPECT_EQ(r, 0);
+  EXPECT_EQ(w, 0);
 }
 
 TEST_F(SwizzleTest, Test32x16F32Transpose) {
@@ -137,10 +104,9 @@ TEST_F(SwizzleTest, Test32x16F32Transpose) {
                         {{S("dim0"), 32}, {S("dim1"), 16}},
                         /*requireSurjective=*/true);
   auto smem = optimalSwizzling(matrix, matrix_t, /*bitwidth=*/32);
-  auto [r, w] = logBankConflicts(matrix, matrix_t, smem);
-  auto logWf = logWavefronts(smem, 32);
-  EXPECT_EQ(r, logWf);
-  EXPECT_EQ(w, logWf);
+  auto [r, w] = logBankConflicts(matrix, matrix_t, smem, /*bitwidth=*/32);
+  EXPECT_EQ(r, 0);
+  EXPECT_EQ(w, 0);
 }
 } // namespace
 


### PR DESCRIPTION
We implement a generic swizzling algorithm by @apgoucher that, given two linear layouts, finds the optimal shared memory layout that maximises read/write vectorisation and, provided that, minimises bank conflicts.

We also implement an algorithm to find the minimum tile size necessary to perform the `convert_layout` given the restrictions above, and we use it to perform the `convert_layout` iteratively.

This PR does not yet implement a lowering to ldmatrix/stmatrix, we'll do that in a future PR.