### PR TITLE
[Frontend] Treat JITFunction as constexpr type

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -48,7 +48,7 @@ def _is_triton_tensor(o: Any) -> bool:
 
 
 def _is_constexpr(o: Any) -> bool:
-    return o is None or isinstance(o, (constexpr, language.core.dtype))
+    return o is None or isinstance(o, (constexpr, language.core.dtype, JITFunction))
 
 
 def _is_non_scalar_tensor(o: Any) -> bool:

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1576,6 +1576,7 @@ def _aggregate(cls):
     aggregate_value.__name__ = cls.__name__
     aggregate_value.__module__ = cls.__module__
     aggregate_value.__qualname__ = cls.__qualname__
+    aggregate_value.__doc__ = cls.__doc__
 
     return aggregate_value
 

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -711,6 +711,11 @@ class JITFunction(KernelInterface[T]):
             self.used_global_vals = dict(sorted(dependencies_finder.used_global_vals.items()))
         return self.hash
 
+    @property
+    def type(self):
+        from triton.language.core import constexpr
+        return constexpr
+
     def warmup(self, *args, grid, **kwargs):
         return self.run(grid=grid, warmup=True, *map(MockTensor.wrap_dtype, args), **kwargs)
 


### PR DESCRIPTION
📚 Stack PRs 📚

1. ➡️ https://github.com/triton-lang/triton/pull/6988
2. https://github.com/triton-lang/triton/pull/6989

This teaches a few more places in the frontend to treat JITFunction as constexprs. This allows, for example, passing lists of functions as constexprs.
