### PR TITLE
[Gluon] Add `local_dealloc` and enable `local_alloc` with no initializer

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -74,6 +74,10 @@ void init_gluon_ir(py::module &&m) {
              return self.create<ttg::ConvertLayoutOp>(resultTy, value);
            })
       .def("create_local_alloc",
+           [](GluonOpBuilder &self, Type resultTy) -> Value {
+             return self.create<ttg::LocalAllocOp>(resultTy);
+           })
+      .def("create_local_alloc",
            [](GluonOpBuilder &self, Type resultTy, Value value) -> Value {
              return self.create<ttg::LocalAllocOp>(resultTy, value);
            })
@@ -84,6 +88,10 @@ void init_gluon_ir(py::module &&m) {
       .def("create_local_load",
            [](GluonOpBuilder &self, Type resultTy, Value memDesc) -> Value {
              return self.create<ttg::LocalLoadOp>(resultTy, memDesc);
+           })
+      .def("create_local_dealloc",
+           [](GluonOpBuilder &self, Value memDesc) -> Operation * {
+             return self.create<ttg::LocalDeallocOp>(memDesc);
            })
 
       .def("create_warp_return",

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -195,6 +195,10 @@ class shared_memory_descriptor(base_value):
     def store(self, value, _builder: GluonOpBuilder) -> None:
         return semantic.shared_store(self, value, _builder)
 
+    @builtin
+    def _keep_alive(self, _builder=None) -> None:
+        return semantic.shared_dealloc(self, _builder)
+
 
 for name in [
         "program_id",

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -32,7 +32,10 @@ def convert_layout(value, layout, builder: GluonOpBuilder):
 
 def allocate_shared(element_ty, shape, layout, value, builder: GluonOpBuilder):
     ty = ttgl.shared_memory_descriptor_type(element_ty, shape, layout, shape)
-    handle = builder.create_local_alloc(ty.to_ir(builder), value.handle)
+    if value is not None:
+        handle = builder.create_local_alloc(ty.to_ir(builder), value.handle)
+    else:
+        handle = builder.create_local_alloc(ty.to_ir(builder))
     return ttgl.shared_memory_descriptor(handle, element_ty, shape, layout, shape)
 
 
@@ -44,6 +47,10 @@ def shared_load(mem_desc, layout, builder: GluonOpBuilder):
 
 def shared_store(mem_desc, value, builder: GluonOpBuilder):
     builder.create_local_store(mem_desc.handle, value.handle)
+
+
+def shared_dealloc(mem_desc, builder: GluonOpBuilder):
+    builder.create_local_dealloc(mem_desc.handle)
 
 
 def warp_specialize(args, default_partition, worker_partitions, worker_num_warps: Sequence[int],


### PR DESCRIPTION
`local_dealloc` is an unfortunate necessity because the compiler doesn't correctly reason about the liveranges of shared memory used by async operations. For now, users will need to manually keep shared memory alive using `smem._keep_alive()`.
