### PR TITLE
[Gluon] Add mbarrier

### DIFF
--- a/python/triton/experimental/gluon/language/nvidia/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/__init__.py
@@ -1,3 +1,4 @@
 from . import blackwell
+from . import hopper
 
-__all__ = ["blackwell"]
+__all__ = ["blackwell", "hopper"]

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -5,11 +5,18 @@ from dataclasses import dataclass
 from triton.experimental.gluon.language import _core as ttgl
 from triton.experimental.gluon.language._core import builtin, base_type, base_value, _unwrap_if_constexpr
 
+from ..hopper import mbarrier
+
 if TYPE_CHECKING:
     from triton._C.libtriton.gluon_ir import GluonOpBuilder
     from triton._C.libtriton import gluon_ir as ir
 
-__all__ = ["TensorMemoryLayout", "tensor_memory_descriptor", "allocate_tensor_memory"]
+__all__ = [
+    "TensorMemoryLayout",
+    "tensor_memory_descriptor",
+    "allocate_tensor_memory",
+    "mbarrier",
+]
 
 
 @dataclass(frozen=True, eq=True)

--- a/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
@@ -1,0 +1,3 @@
+from . import mbarrier
+
+__all__ = ["mbarrier"]

--- a/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
@@ -1,0 +1,52 @@
+from triton.experimental.gluon.language._layouts import SwizzledSharedLayout
+import triton.experimental.gluon.language._core as ttgl
+from triton.experimental.gluon.language._core import builtin, _unwrap_if_constexpr
+
+__all__ = ["MBarrierLayout", "init", "invalidate", "expect", "wait", "arrive"]
+
+
+class MBarrierLayout(SwizzledSharedLayout):
+
+    def __init__(self, ctas_per_cga: int = 1, cta_split_num: int = 1):
+        super().__init__(
+            vec=1,
+            per_phase=1,
+            max_phase=1,
+            order=[0],
+            ctas_per_cga=[ctas_per_cga],
+            cta_split_num=[cta_split_num],
+            cta_order=[0],
+        )
+
+
+@builtin
+def init(mbarrier, count, _builder=None):
+    count = _unwrap_if_constexpr(count)
+    _builder.create_mbarrier_init(mbarrier.handle, count)
+
+
+@builtin
+def invalidate(mbarrier, _builder=None):
+    _builder.create_mbarrier_inval(mbarrier.handle)
+
+
+@builtin
+def expect(mbarrier, bytes, pred=True, _builder=None):
+    bytes = _unwrap_if_constexpr(bytes)
+    pred = ttgl.to_tensor(pred, _builder=_builder)
+    _builder.create_mbarrier_expect(mbarrier.handle, bytes, pred.handle)
+
+
+@builtin
+def wait(mbarrier, phase, pred=True, deps=(), _builder=None):
+    phase = ttgl.to_tensor(phase, _builder=_builder)
+    pred = ttgl.to_tensor(pred, _builder=_builder)
+    deps = [x.handle for x in deps]
+    _builder.create_mbarrier_wait(mbarrier.handle, phase.handle, pred.handle, deps)
+
+
+@builtin
+def arrive(mbarrier, count, pred=True, _builder=None):
+    count = _unwrap_if_constexpr(count)
+    pred = ttgl.to_tensor(pred, _builder=_builder)
+    _builder.create_mbarrier_arrive(mbarrier.handle, count, pred.handle)


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. [Gluon] Add mbarrier
    
    This implements:
    - `ttgl.SwizzledSharedLayout`
    - `ttgl.nvidia.hopper.mbarrier.MBarrierLayout` (convenience wrapper for `SwizzledSharedLayout`)
    - `ttgl.nvidia.hopper.mbarrier.init`
    - `ttgl.nvidia.hopper.mbarrier.invalidate`
    - `ttgl.nvidia.hopper.mbarrier.expect`
    - `ttgl.nvidia.hopper.mbarrier.wait`
    - `ttgl.nvidia.hopper.mbarrier.arrive`
    
    plus aliases in `ttgl.nvidia.blackwell.mbarrier`
    
    Note that I'm keeping this API functional to allow interpreting
    any shared allocation as an mbarrier. We can wrap with higher level
    APIs at a later date if desired.
1. Add unsaved changes

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #6997 👈 **YOU ARE HERE**
1. #6998


</git-pr-chain>



