### PR TITLE
[Triton] Fix exporting test-only module

### DIFF
--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -25,7 +25,6 @@ from .runtime._allocation import set_allocator
 from . import language
 from . import testing
 from . import tools
-from ._filecheck import run_filecheck_test, filecheck_test, run_parser
 
 must_use_result = language.core.must_use_result
 
@@ -52,9 +51,6 @@ __all__ = [
     "TritonError",
     "testing",
     "tools",
-    "run_filecheck_test",
-    "filecheck_test",
-    "run_parser",
 ]
 
 # -------------------------------------


### PR DESCRIPTION
`_internal_testing.py` happens to live in this directory as well, just don't export the symbols in `triton/__init__.py`