### PR TITLE
Check for the shared memory limitation when converting ConvertLayoutOp

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -239,6 +239,9 @@ bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy);
 // warps, and possibly blocks.
 bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy);
 
+// Get the potential shared memory usage for a type.
+size_t potentilaSharedMemoryUsage(RankedTensorType Ty);
+
 bool atomicNeedsSharedMemory(Value result);
 
 // Return true if the src and dst layout match.

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -786,6 +786,16 @@ bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
          SmallVector<StringAttr, 2>{kRegister, kLane};
 }
 
+size_t potentilaSharedMemoryUsage(RankedTensorType Ty) {
+  size_t bytes_per_element =
+      (Ty.getElementType().getIntOrFloatBitWidth() + 7) / 8;
+  size_t type_size = bytes_per_element;
+  for (int dim_size : Ty.getShape()) {
+    type_size *= dim_size;
+  }
+  return type_size;
+}
+
 bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy) {
   // TODO(jlebar): Remove these special cases `isMfmaToDotShortcut` once
   // they're fully subsumed by the linear-layout checks.

--- a/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
@@ -44,6 +44,15 @@ public:
         return;
       if (!cvtNeedsSharedMemory(srcType, dstType))
         return;
+      // TODO(Wenqin): we shouldn't hard code here, we should use a limitation
+      // for the current client GPU, there is a python API:
+      // def max_shared_mem(device), an AMD API: int getSharedMemorySize()
+      // TODO(Wenqin): we should maintain a cumulative shared memory usage,
+      // but not just for one OP. Is all shared memory were introduced in
+      // this pass? How to maintain the cumulative SMEM usage?
+      if (potentilaSharedMemoryUsage(dstType) > 96 * 1024) {
+        return;
+      }
       auto order = getOrderForMemory(srcType);
       auto sharedMemorySpace =
           triton::gpu::SharedMemorySpaceAttr::get(srcType.getContext());


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`. If this PR makes sense, I will add a test later.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

# Introduce a new check when converting ConvertLayoutOp
Fix #6446

### Background
When triton is converting a `ConvertLayoutOp` to `LocalLoadOp`, it didn't check for whether this tensor could be load into SMEM or not (like a tensor greater 100KB), this may make some kernel was **not able to be launched**.

### How to do it
This PR would like to add a new check for it to fix this error by elide the conversion for `ConvertLayoutOp` when we found there is a big tensor.

### Next step
If this motivation makes sense to you, we could go further.

This PR is in a very draft states, there are two things in my mind that we still need to do:
1. Introduce an cpp API to get the max shared memory limitation for client's GPU (I just find a API for AMD GPU), the current implement just hard code for 96KB.
2. We may have to maintain a **cumulative** shared memory usage when we're generating `LocalLoadOp`, because the current implement just check for **one single tensor**.
