### PR TITLE
[llvm build script] fetch llvm commit hash before resetting

### DIFF
--- a/scripts/build-llvm-project.sh
+++ b/scripts/build-llvm-project.sh
@@ -42,6 +42,7 @@ if [ ! -e "$LLVM_PROJECT_PATH" ]; then
     git clone "$LLVM_PROJECT_URL" "$LLVM_PROJECT_PATH"
 fi
 echo "Resetting to $LLVM_COMMIT_HASH"
+git -C "$LLVM_PROJECT_PATH" fetch origin "$LLVM_COMMIT_HASH"
 git -C "$LLVM_PROJECT_PATH" reset --hard "$LLVM_COMMIT_HASH"
 echo "Configuring with ${CMAKE_ARGS[@]}"
 cmake "${CMAKE_ARGS[@]}"


### PR DESCRIPTION
Without this step, git can return an error: `fatal: Could not parse object 'e12cbd8339b89563059c2bb2a312579b652560d0'.`.