### PR TITLE
[BACKEND] Add optimization for local_load -> tmem_store layout

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
@@ -223,6 +223,75 @@ public:
   }
 };
 
+// Optimize local_load -> tmem_store when the layout 16x256b allows better
+// code generation for local_load lowering.
+class TMemFromSharedMemPattern : public OpRewritePattern<TMEMStoreOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(TMEMStoreOp tmemStoreOp,
+                                PatternRewriter &rewriter) const override {
+    auto tmemEnc = dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
+        tmemStoreOp.getDst().getType().getEncoding());
+    if (!tmemEnc)
+      return failure();
+    int M = tmemEnc.getBlockM();
+    int N = tmemEnc.getBlockN();
+    int numWarps = ttg::lookupNumWarps(tmemStoreOp);
+    // Compute the alternative layout.
+    std::optional<LinearLayout> ll = gpu::getTmemLoadStoreLayout16x256(
+        M, N, tmemStoreOp.getSrc().getType(), numWarps);
+    if (!ll)
+      return failure();
+    Attribute newEncoding =
+        gpu::LinearEncodingAttr::get(tmemStoreOp.getContext(), *ll);
+    auto newType = RankedTensorType::get(
+        tmemStoreOp.getSrc().getType().getShape(),
+        tmemStoreOp.getSrc().getType().getElementType(), newEncoding);
+    if (newType == tmemStoreOp.getSrc().getType())
+      return failure();
+
+    SetVector<Value> slice;
+    DenseMap<Value, Attribute> layoutMap;
+    // Check how it may propagate up the SSA chain.
+    LogicalResult result = getConvertBackwardSlice(
+        tmemStoreOp.getSrcMutable(), slice, newEncoding, layoutMap);
+    if (result.failed())
+      return failure();
+    bool foundImprovedLoad = false;
+    for (Value v : slice) {
+      auto localLoad = v.getDefiningOp<gpu::LocalLoadOp>();
+      if (!localLoad)
+        continue;
+      // 16x256b is optimized for 16bits load.
+      if (localLoad.getType().getElementType().getIntOrFloatBitWidth() != 16)
+        return failure();
+      LinearLayout regLayout = gpu::toLinearLayout(
+          localLoad.getType().getShape(), localLoad.getType().getEncoding());
+      LinearLayout smemLayout =
+          gpu::toLinearLayout(localLoad.getSrc().getType().getShape(),
+                              localLoad.getSrc().getType().getEncoding());
+      int vecDim =
+          regLayout.invertAndCompose(smemLayout).getNumConsecutiveInOut();
+      // If we find a 16bits load that cannot be vectorized use the alternative
+      // layout.
+      if (vecDim != 1)
+        return failure();
+      foundImprovedLoad = true;
+    }
+    if (!foundImprovedLoad)
+      return failure();
+    // Use the new layout and rely on RemoveLayoutConversions pass to propagate
+    // the convert_layout.
+    auto cvt = rewriter.create<ttg::ConvertLayoutOp>(
+        tmemStoreOp.getLoc(), newType, tmemStoreOp.getSrc());
+    rewriter.modifyOpInPlace(tmemStoreOp, [&]() {
+      tmemStoreOp.getSrcMutable().assign(cvt.getResult());
+    });
+    return success();
+  }
+};
+
 } // anonymous namespace
 
 class TritonNvidiaGPUOptimizeTMemLayoutsPass
@@ -238,9 +307,8 @@ public:
     ModuleOp m = getOperation();
 
     mlir::RewritePatternSet patterns(context);
-    patterns
-        .add<TMemSplitLoadPattern, TMemStoreJoinPattern, TMemLoadReducePattern>(
-            context);
+    patterns.add<TMemSplitLoadPattern, TMemStoreJoinPattern,
+                 TMemLoadReducePattern, TMemFromSharedMemPattern>(context);
     if (failed(applyPatternsGreedily(m, std::move(patterns))))
       signalPassFailure();
   }

--- a/test/TritonNvidiaGPU/tmem_layouts.mlir
+++ b/test/TritonNvidiaGPU/tmem_layouts.mlir
@@ -104,3 +104,49 @@ tt.func public @tmem_load_reduce(%arg0: !ttg.memdesc<128x64xf32, #tmem, #ttng.te
 }
 
 }
+
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [64, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, unpacked = true>
+// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[0, 1], [8, 0], [0, 8], [0, 16], [0, 32], [16, 0]], lane = [[0, 2], [0, 4], [1, 0], [2, 0], [4, 0]], warp = [[32, 0], [64, 0]], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABLE: test_tmem_store_dist_layout
+  tt.func public @test_tmem_store_dist_layout(%arg0: f32, %arg1: !ttg.memdesc<64x128xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %true = arith.constant true
+    %0 = tt.splat %arg0 : f32 -> tensor<64x128xf32, #blocked>
+    %1 = ttg.local_load %arg1 : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    %2 = arith.extf %1 : tensor<64x128xf16, #blocked> to tensor<64x128xf32, #blocked>
+    %3 = arith.mulf %2, %0 : tensor<64x128xf32, #blocked>
+    %4 = tt.trans %3 {order = array<i32: 1, 0>} : tensor<64x128xf32, #blocked> -> tensor<128x64xf32, #blocked1>
+    // CHECK: %[[C:.+]] = ttg.convert_layout %{{.+}} : tensor<128x64xf32, #{{.+}}> -> tensor<128x64xf32, #linear>
+    // CHECK: ttng.tmem_store %[[C]], %{{.+}}, %{{.+}} : tensor<128x64xf32, #linear> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %4, %arg2, %true : tensor<128x64xf32, #blocked1> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [64, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, unpacked = true>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABLE: test_tmem_store_dist_layout_negative
+  tt.func public @test_tmem_store_dist_layout_negative(%arg0: f32, %arg1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %true = arith.constant true
+    %1 = ttg.local_load %arg1 : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #blocked1>
+    %2 = arith.extf %1 : tensor<128x64xf16, #blocked1> to tensor<128x64xf32, #blocked1>
+    // CHECK: %[[C:.+]] = arith.extf
+    // CHECK: ttng.tmem_store %[[C]]
+    ttng.tmem_store %2, %arg2, %true : tensor<128x64xf32, #blocked1> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}


### PR DESCRIPTION
When the src of a tmem_store comes from a local_load try to pick 16x256 message layout in case we cannot vectorize with existing layout.
