### PR TITLE
[AMD][BACKEND] Fix addresses for other stores from BufferLoadToLocal

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -562,8 +562,7 @@ struct BufferLoadToLocalOpConversion
         llStore(rewriter, loc,
                 hasSwizzling ? swizzledShmemAddr[i] : coalescedShmemAddr[i],
                 storeVal, b.icmp_ne(maskElems[srcIdx], b.true_val()),
-                op.getCache(),
-                /*forceNoAliasAsyncLoads=*/true);
+                op.getCache(), /*forceNoAliasAsyncLoads=*/true);
       }
     }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -561,7 +561,8 @@ struct BufferLoadToLocalOpConversion
             rewriter, this->getTypeConverter(), loc, vecTy, otherElems, srcIdx);
         llStore(rewriter, loc,
                 hasSwizzling ? swizzledShmemAddr[i] : coalescedShmemAddr[i],
-                storeVal, b.icmp_ne(pred, b.true_val()), op.getCache(),
+                storeVal, b.icmp_ne(maskElems[srcIdx], b.true_val()),
+                op.getCache(),
                 /*forceNoAliasAsyncLoads=*/true);
       }
     }


### PR DESCRIPTION
We need to predicate the `llStore` for the other value based on the initial mask or otherwise we would need to shuffle the other value as well.

`AsyncCopyGlobalToLocal` does this already correctly.