### PR TITLE
[Frontend] Allow `@_aggregate` types to contain constexprs

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -151,10 +151,10 @@ def add_rhs_constexpr(agg):
 @triton.jit
 def test_aggregate_with_constexpr():
     # CHECK-LABEL: test_aggregate_with_constexpr
-    # CHECK-LITERAL: tt.call @"add_rhs_constexpr____main__.AggregateWithConstexpr[constexpr[42]]<i32S4S>__"
+    # CHECK: tt.call @"add_rhs_constexpr__test_frontend.AggregateWithConstexpr<i32S4S, constexpr[42]>
     agg = AggregateWithConstexpr.create(tl.arange(0, 4))
     add_rhs_constexpr(agg)
 
-    # CHECK-LITERAL: tt.func private @"add_rhs_constexpr____main__.AggregateWithConstexpr[constexpr[42]]<i32S4S>__"
+    # CHECK: tt.func private @"add_rhs_constexpr__test_frontend.AggregateWithConstexpr<i32S4S, constexpr[42]>
     # CHECK: %cst = arith.constant dense<42> : tensor<4xi32>
     # CHECK: arith.addi %arg0, %cst : tensor<4xi32>

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -126,3 +126,35 @@ def test_call_in_loop():
     # CHECK:   call @accumulate
     for i in range(10):
         acc = accumulate(acc, i)
+
+
+@tl.core._aggregate
+class AggregateWithConstexpr:
+    a: tl.tensor
+    b: tl.constexpr
+
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    @staticmethod
+    def create(a):
+        return AggregateWithConstexpr(a, tl.constexpr(42))
+
+
+@triton.jit
+def add_rhs_constexpr(agg):
+    _ = agg.a + agg.b
+
+
+@filecheck_test
+@triton.jit
+def test_aggregate_with_constexpr():
+    # CHECK-LABEL: test_aggregate_with_constexpr
+    # CHECK-LITERAL: tt.call @"add_rhs_constexpr____main__.AggregateWithConstexpr[constexpr[42]]<i32S4S>__"
+    agg = AggregateWithConstexpr.create(tl.arange(0, 4))
+    add_rhs_constexpr(agg)
+
+    # CHECK-LITERAL: tt.func private @"add_rhs_constexpr____main__.AggregateWithConstexpr[constexpr[42]]<i32S4S>__"
+    # CHECK: %cst = arith.constant dense<42> : tensor<4xi32>
+    # CHECK: arith.addi %arg0, %cst : tensor<4xi32>

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1581,7 +1581,7 @@ def _aggregate(cls):
             super().__setattr__(name, value)
 
         def _flatten_ir(self, handles: List[ir.value]) -> None:
-            for name, ty in cls.__annotations__.items():
+            for name in cls.__annotations__.keys():
                 getattr(self, name)._flatten_ir(handles)
 
         @property


### PR DESCRIPTION
Constexpr fields don't have an IR representation and are carried through the type. Also ensure that they are mangled into the type name.

This PR achieves this by adding a `constexpt_type` that contains the constexpr value itself and makes this the type of `constexpr`. Shoutout to @peterbell10 for the suggestion