### PR TITLE
[PROTON-DEV] Option to schedule buffer store

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -106,7 +106,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::proton::gpu::registerConvertProtonAMDGPUToLLVM();
   mlir::triton::proton::gpu::registerAllocateProtonSharedMemoryPass();
   mlir::triton::proton::gpu::registerAllocateProtonGlobalScratchBufferPass();
-  mlir::triton::proton::gpu::registerProtonScheduleBufferStorePass();
+  mlir::triton::proton::gpu::registerScheduleBufferStorePass();
 
   registry.insert<
       mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,

--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -9,6 +9,7 @@
 #include "proton/dialect/include/Conversion/ProtonToProtonGPU/Passes.h"
 #include "proton/dialect/include/Dialect/Proton/IR/Dialect.h"
 #include "proton/dialect/include/Dialect/ProtonGPU/IR/Dialect.h"
+#include "proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -105,6 +106,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::proton::gpu::registerConvertProtonAMDGPUToLLVM();
   mlir::triton::proton::gpu::registerAllocateProtonSharedMemoryPass();
   mlir::triton::proton::gpu::registerAllocateProtonGlobalScratchBufferPass();
+  mlir::triton::proton::gpu::registerMoveProtonStoresToEndPass();
 
   registry.insert<
       mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,

--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -106,7 +106,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::proton::gpu::registerConvertProtonAMDGPUToLLVM();
   mlir::triton::proton::gpu::registerAllocateProtonSharedMemoryPass();
   mlir::triton::proton::gpu::registerAllocateProtonGlobalScratchBufferPass();
-  mlir::triton::proton::gpu::registerMoveProtonStoresToEndPass();
+  mlir::triton::proton::gpu::registerProtonScheduleBufferStorePass();
 
   registry.insert<
       mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,

--- a/test/Proton/protongpu_transforms.mlir
+++ b/test/Proton/protongpu_transforms.mlir
@@ -1,0 +1,20 @@
+// RUN: triton-opt --split-input-file --convert-proton-to-protongpu="max-shared-mem-size=32768" --move-proton-stores-to-end -canonicalize -cse %s | FileCheck %s
+
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: simple_record
+  // CHECK: %[[SCRATCH:.*]] = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+  // CHECK: %[[BUF:.*]] = ttg.local_alloc  : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+  // CHECK: %[[SEGMENT:.*]] = proton_gpu.segment_alloc %[[BUF]]
+  // CHECK: %[[START:.*]] = proton_gpu.read_counter : i32
+  // CHECK: proton_gpu.circular_store start %[[SEGMENT]], %[[START]] {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+  // CHECK: %[[END:.*]] = proton_gpu.read_counter : i32
+  // CHECK: proton_gpu.circular_store end %[[SEGMENT]], %[[END]] {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+  // CHECK: gpu.barrier
+  // CHECK: proton_gpu.finalize %[[SEGMENT]], %[[SCRATCH]] : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+  // CHECK: tt.return
+  tt.func @simple_record() {
+    proton.record start "name0"
+    proton.record end "name0"
+    tt.return
+  }
+}

--- a/test/Proton/protongpu_transforms.mlir
+++ b/test/Proton/protongpu_transforms.mlir
@@ -3,17 +3,44 @@
 module attributes {"ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: simple_record
   // CHECK: %[[SCRATCH:.*]] = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
-  // CHECK: %[[BUF:.*]] = ttg.local_alloc  : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
-  // CHECK: %[[SEGMENT:.*]] = proton_gpu.segment_alloc %[[BUF]]
-  // CHECK: %[[START:.*]] = proton_gpu.read_counter : i32
-  // CHECK: proton_gpu.circular_store start %[[SEGMENT]], %[[START]] {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
-  // CHECK: %[[END:.*]] = proton_gpu.read_counter : i32
-  // CHECK: proton_gpu.circular_store end %[[SEGMENT]], %[[END]] {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
-  // CHECK: gpu.barrier
-  // CHECK: proton_gpu.finalize %[[SEGMENT]], %[[SCRATCH]] : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
-  // CHECK: tt.return
+  // CHECK-NEXT: %[[BUF:.*]] = ttg.local_alloc  : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+  // CHECK-NEXT: %[[SEGMENT:.*]] = proton_gpu.segment_alloc %[[BUF]]
+  // CHECK-NEXT: %[[START:.*]] = proton_gpu.read_counter : i32
+  // CHECK-NEXT: %[[END:.*]] = proton_gpu.read_counter : i32
+  // CHECK-NEXT: proton_gpu.circular_store start %[[SEGMENT]], %[[START]] {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+  // CHECK-NEXT: proton_gpu.circular_store end %[[SEGMENT]], %[[END]] {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+  // CHECK-NEXT: gpu.barrier
+  // CHECK-NEXT: proton_gpu.finalize %[[SEGMENT]], %[[SCRATCH]] : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+  // CHECK-NEXT: tt.return
   tt.func @simple_record() {
     proton.record start "name0"
+    proton.record end "name0"
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: simple_record
+  // CHECK: %[[SCRATCH:.*]] = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 1152 : i32} : !tt.ptr<i32>
+  // CHECK-NEXT: %[[BUF:.*]] = ttg.local_alloc  : () -> !ttg.memdesc<256xi32, #shared, #smem, mutable>
+  // CHECK-NEXT: %[[SEGMENT:.*]] = proton_gpu.segment_alloc %[[BUF]]
+  // CHECK-NEXT: %[[START1:.*]] = proton_gpu.read_counter : i32
+  // CHECK-NEXT: %[[START2:.*]] = proton_gpu.read_counter : i32
+  // CHECK-NEXT: %[[END2:.*]] = proton_gpu.read_counter : i32
+  // CHECK-NEXT: proton_gpu.circular_store start %[[SEGMENT]], %[[START2]] {scopeId = 1 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+  // CHECK-NEXT: proton_gpu.circular_store end %[[SEGMENT]], %[[END2]] {scopeId = 1 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+  // CHECK-NEXT: %[[END1:.*]] = proton_gpu.read_counter : i32
+  // CHECK-NEXT: proton_gpu.circular_store start %[[SEGMENT]], %[[START1]] {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+  // CHECK-NEXT: proton_gpu.circular_store end %[[SEGMENT]], %[[END1]] {scopeId = 0 : i32} : !proton_gpu.segment<1024, #smem, warp>, i32
+  // CHECK-NEXT: gpu.barrier
+  // CHECK-NEXT: proton_gpu.finalize %[[SEGMENT]], %[[SCRATCH]] : !proton_gpu.segment<1024, #smem, warp>, !tt.ptr<i32>
+  // CHECK-NEXT: tt.return
+  tt.func @simple_record() {
+    proton.record start "name0"
+    proton.record start "name1"
+    proton.record end "name1"
     proton.record end "name0"
     tt.return
   }

--- a/test/Proton/protongpu_transforms.mlir
+++ b/test/Proton/protongpu_transforms.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt --split-input-file --convert-proton-to-protongpu="max-shared-mem-size=32768" --move-proton-stores-to-end -canonicalize -cse %s | FileCheck %s
+// RUN: triton-opt --split-input-file -convert-proton-to-protongpu="max-shared-mem-size=32768" -proton-schedule-buffer-store -canonicalize -cse %s | FileCheck %s
 
 module attributes {"ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: simple_record

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/CMakeLists.txt
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/CMakeLists.txt
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls --name ProtonGPU)
+add_public_tablegen_target(ProtonGPUTransformsIncGen)

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.h
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.h
@@ -1,0 +1,17 @@
+#ifndef PROTONGPU_TRANSFORMS_PASSES_H_
+#define PROTONGPU_TRANSFORMS_PASSES_H_
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::triton::proton::gpu {
+
+// Generate the pass class declarations.
+#define GEN_PASS_DECL
+#include "proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.h.inc"
+
+} // namespace mlir::triton::proton::gpu
+
+#endif // PROTONGPU_TRANSFORMS_PASSES_H_

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.td
@@ -3,11 +3,11 @@
 
 include "mlir/Pass/PassBase.td"
 
-def MoveProtonStoresToEndPass: Pass<"move-proton-stores-to-end", "mlir::ModuleOp"> {
-  let summary = "Pass to move all Proton stores to the end of the function";
+def ProtonScheduleBufferStorePass: Pass<"proton-schedule-buffer-store", "mlir::ModuleOp"> {
+  let summary = "Pass to move all Proton buffer stores to the end of the function";
 
   let description = "This pass makes the measurement more accurate by moving the expensive "
-                    "shared memory stores to the end of the measured reagion.";
+                    "shared memory stores to the end of the measured reagion after the measurements.";
 
   let dependentDialects = ["gpu::ProtonGPUDialect"];
 }

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.td
@@ -7,7 +7,7 @@ def ScheduleBufferStorePass: Pass<"proton-schedule-buffer-store", "mlir::ModuleO
   let summary = "Pass to move all Proton buffer stores to the end of the function";
 
   let description = "This pass makes the measurement more accurate by moving the expensive "
-                    "shared memory stores to the end of the measured reagion after the measurements.";
+                    "shared memory stores to the end of the measured region after the measurements.";
 
   let dependentDialects = ["gpu::ProtonGPUDialect"];
 }

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.td
@@ -3,7 +3,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def ProtonScheduleBufferStorePass: Pass<"proton-schedule-buffer-store", "mlir::ModuleOp"> {
+def ScheduleBufferStorePass: Pass<"proton-schedule-buffer-store", "mlir::ModuleOp"> {
   let summary = "Pass to move all Proton buffer stores to the end of the function";
 
   let description = "This pass makes the measurement more accurate by moving the expensive "

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/Transforms/Passes.td
@@ -1,0 +1,15 @@
+#ifndef PROTONGPU_TRANSFORMS_PASSES
+#define PROTONGPU_TRANSFORMS_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def MoveProtonStoresToEndPass: Pass<"move-proton-stores-to-end", "mlir::ModuleOp"> {
+  let summary = "Pass to move all Proton stores to the end of the function";
+
+  let description = "This pass makes the measurement more accurate by moving the expensive "
+                    "shared memory stores to the end of the measured reagion.";
+
+  let dependentDialects = ["gpu::ProtonGPUDialect"];
+}
+
+#endif  // PROTONGPU_TRANSFORMS_PASSES

--- a/third_party/proton/dialect/lib/Dialect/ProtonGPU/CMakeLists.txt
+++ b/third_party/proton/dialect/lib/Dialect/ProtonGPU/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/third_party/proton/dialect/lib/Dialect/ProtonGPU/Transforms/CMakeLists.txt
+++ b/third_party/proton/dialect/lib/Dialect/ProtonGPU/Transforms/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_triton_library(ProtonGPUTransforms
+  ProtonGPUTransformsPass.cpp
+
+  DEPENDS
+  ProtonGPUTransformsIncGen
+  LINK_LIBS PUBLIC
+  ProtonGPUIR
+)

--- a/third_party/proton/dialect/lib/Dialect/ProtonGPU/Transforms/ProtonGPUTransformsPass.cpp
+++ b/third_party/proton/dialect/lib/Dialect/ProtonGPU/Transforms/ProtonGPUTransformsPass.cpp
@@ -23,6 +23,7 @@ struct ProtonScheduleBufferStorePass
     MLIRContext *context = m.getContext();
     OpBuilder builder(context);
 
+    // TODO(srir): Add support for non-inline kernels
     FuncOp func = *m.getOps<triton::FuncOp>().begin();
     auto startStoreList = llvm::SmallVector<CircularStoreOp, 8>();
     auto endStoreMap = llvm::SmallDenseMap<int, CircularStoreOp, 8>();

--- a/third_party/proton/dialect/lib/Dialect/ProtonGPU/Transforms/ProtonGPUTransformsPass.cpp
+++ b/third_party/proton/dialect/lib/Dialect/ProtonGPU/Transforms/ProtonGPUTransformsPass.cpp
@@ -8,15 +8,14 @@
 
 namespace mlir::triton::proton::gpu {
 
-#define GEN_PASS_DEF_PROTONSCHEDULEBUFFERSTOREPASS
+#define GEN_PASS_DEF_SCHEDULEBUFFERSTOREPASS
 #include "Dialect/ProtonGPU/Transforms/Passes.h.inc"
 
-struct ProtonScheduleBufferStorePass
-    : public impl::ProtonScheduleBufferStorePassBase<
-          ProtonScheduleBufferStorePass> {
+struct ScheduleBufferStorePass
+    : public impl::ScheduleBufferStorePassBase<ScheduleBufferStorePass> {
 
-  using impl::ProtonScheduleBufferStorePassBase<
-      ProtonScheduleBufferStorePass>::ProtonScheduleBufferStorePassBase;
+  using impl::ScheduleBufferStorePassBase<
+      ScheduleBufferStorePass>::ScheduleBufferStorePassBase;
 
   void runOnOperation() override {
     ModuleOp m = getOperation();

--- a/third_party/proton/dialect/lib/Dialect/ProtonGPU/Transforms/ProtonGPUTransformsPass.cpp
+++ b/third_party/proton/dialect/lib/Dialect/ProtonGPU/Transforms/ProtonGPUTransformsPass.cpp
@@ -1,0 +1,51 @@
+#include "Dialect/ProtonGPU/Transforms/Passes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+
+#include "Dialect/ProtonGPU/IR/Dialect.h"
+
+namespace mlir::triton::proton::gpu {
+
+#define GEN_PASS_DEF_MOVEPROTONSTORESTOENDPASS
+#include "Dialect/ProtonGPU/Transforms/Passes.h.inc"
+
+struct MoveProtonStoresToEndPass
+    : public impl::MoveProtonStoresToEndPassBase<MoveProtonStoresToEndPass> {
+
+  using impl::MoveProtonStoresToEndPassBase<
+      MoveProtonStoresToEndPass>::MoveProtonStoresToEndPassBase;
+
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+    MLIRContext *context = m.getContext();
+    OpBuilder builder(context);
+
+    FuncOp func = *m.getOps<triton::FuncOp>().begin();
+    auto startStoreList = llvm::SmallVector<CircularStoreOp, 8>();
+    auto endStoreMap = llvm::SmallDenseMap<int, CircularStoreOp, 8>();
+
+    func.walk([&](CircularStoreOp store) {
+      if (store.getIsStart())
+        startStoreList.push_back(store);
+      else
+        endStoreMap[store.getScopeId()] = store;
+    });
+
+    for (auto store : startStoreList) {
+      int scopeId = store.getScopeId();
+      auto endStore = endStoreMap[scopeId];
+      if (!endStore) {
+        mlir::emitError(func.getLoc(), "end store not found");
+        signalPassFailure();
+        return;
+      }
+      builder.setInsertionPoint(endStore);
+      builder.clone(*store);
+      store->erase();
+    }
+  }
+};
+
+} // namespace mlir::triton::proton::gpu

--- a/third_party/proton/dialect/lib/Dialect/ProtonGPU/Transforms/ProtonGPUTransformsPass.cpp
+++ b/third_party/proton/dialect/lib/Dialect/ProtonGPU/Transforms/ProtonGPUTransformsPass.cpp
@@ -8,14 +8,15 @@
 
 namespace mlir::triton::proton::gpu {
 
-#define GEN_PASS_DEF_MOVEPROTONSTORESTOENDPASS
+#define GEN_PASS_DEF_PROTONSCHEDULEBUFFERSTOREPASS
 #include "Dialect/ProtonGPU/Transforms/Passes.h.inc"
 
-struct MoveProtonStoresToEndPass
-    : public impl::MoveProtonStoresToEndPassBase<MoveProtonStoresToEndPass> {
+struct ProtonScheduleBufferStorePass
+    : public impl::ProtonScheduleBufferStorePassBase<
+          ProtonScheduleBufferStorePass> {
 
-  using impl::MoveProtonStoresToEndPassBase<
-      MoveProtonStoresToEndPass>::MoveProtonStoresToEndPassBase;
+  using impl::ProtonScheduleBufferStorePassBase<
+      ProtonScheduleBufferStorePass>::ProtonScheduleBufferStorePassBase;
 
   void runOnOperation() override {
     ModuleOp m = getOperation();
@@ -37,7 +38,7 @@ struct MoveProtonStoresToEndPass
       int scopeId = store.getScopeId();
       auto endStore = endStoreMap[scopeId];
       if (!endStore) {
-        mlir::emitError(func.getLoc(), "end store not found");
+        mlir::emitError(func.getLoc(), "proton end store not found");
         signalPassFailure();
         return;
       }

--- a/third_party/proton/dialect/triton_proton.cc
+++ b/third_party/proton/dialect/triton_proton.cc
@@ -5,6 +5,7 @@
 #include "Conversion/ProtonToProtonGPU/Passes.h"
 #include "Dialect/Proton/IR/Dialect.h"
 #include "Dialect/ProtonGPU/IR/Dialect.h"
+#include "Dialect/ProtonGPU/Transforms/Passes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/Pass/PassManager.h"
 #include "passes.h"
@@ -104,4 +105,6 @@ void init_triton_proton(py::module &&m) {
                      proton::gpu::createAllocateProtonSharedMemoryPass);
   ADD_PASS_WRAPPER_0("add_allocate_proton_global_scratch_buffer",
                      proton::gpu::createAllocateProtonGlobalScratchBufferPass);
+  ADD_PASS_WRAPPER_0("add_move_proton_stores_to_end",
+                     proton::gpu::createMoveProtonStoresToEndPass);
 }

--- a/third_party/proton/dialect/triton_proton.cc
+++ b/third_party/proton/dialect/triton_proton.cc
@@ -106,5 +106,5 @@ void init_triton_proton(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_allocate_proton_global_scratch_buffer",
                      proton::gpu::createAllocateProtonGlobalScratchBufferPass);
   ADD_PASS_WRAPPER_0("add_proton_schedule_buffer_store",
-                     proton::gpu::createProtonScheduleBufferStorePass);
+                     proton::gpu::createScheduleBufferStorePass);
 }

--- a/third_party/proton/dialect/triton_proton.cc
+++ b/third_party/proton/dialect/triton_proton.cc
@@ -105,6 +105,6 @@ void init_triton_proton(py::module &&m) {
                      proton::gpu::createAllocateProtonSharedMemoryPass);
   ADD_PASS_WRAPPER_0("add_allocate_proton_global_scratch_buffer",
                      proton::gpu::createAllocateProtonGlobalScratchBufferPass);
-  ADD_PASS_WRAPPER_0("add_move_proton_stores_to_end",
-                     proton::gpu::createMoveProtonStoresToEndPass);
+  ADD_PASS_WRAPPER_0("add_proton_schedule_buffer_store",
+                     proton::gpu::createProtonScheduleBufferStorePass);
 }

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -159,6 +159,9 @@ class InstrumentationHook(Hook):
                                                           self.mode.buffer_size, max_shared_mem,
                                                           self.profile_buffer_size, self.profile_buffer_alignment)
 
+            if self.mode.optimization == mode.Optimize.SCHED_STORES:
+                triton_proton.add_move_proton_stores_to_end(pm)
+
             triton_proton.add_allocate_proton_shared_memory(pm)
 
         ttgpuir_func = lambda pm: to_ttgpuir_passes(pm)
@@ -174,11 +177,11 @@ class InstrumentationHook(Hook):
 
         original_run = JITFunction.run
 
-        mode = self.mode
+        original_mode = self.mode
 
         @functools.wraps(original_run)
         def instrumented_run(self, *args, **kwargs):
-            kwargs["instrumentation_mode"] = str(mode)
+            kwargs["instrumentation_mode"] = str(original_mode)
             return original_run(self, *args, **kwargs)
 
         JITFunction.run = instrumented_run

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -160,7 +160,7 @@ class InstrumentationHook(Hook):
                                                           self.profile_buffer_size, self.profile_buffer_alignment)
 
             if self.mode.optimization == mode.Optimize.SCHED_STORES:
-                triton_proton.add_move_proton_stores_to_end(pm)
+                triton_proton.add_proton_schedule_buffer_store(pm)
 
             triton_proton.add_allocate_proton_shared_memory(pm)
 

--- a/third_party/proton/proton/mode.py
+++ b/third_party/proton/proton/mode.py
@@ -35,6 +35,7 @@ granularities = {
 class Optimize(Enum):
     NONE = "none"
     TIMESHIFT = "time_shift"
+    SCHED_STORES = "sched_stores"
 
     def __str__(self):
         return self.value


### PR DESCRIPTION
This PR adds a mode to the profiler that allows for more accurate 
measurement of regions using `pl.scope`. Instead of storing the
 clock measurements in shared memory just after reading them. 
This extra pass will schedule the storing of the both the 
measured values (start, end) after the measurement for a 
particular region. The pass `ProtonScheduleBufferStorePass`, 
looks for start stores and moves it after the end of `pl.scope` 
so that the stores don't pollute the measurements.