### PR TITLE
[AMD][BACKEND] Refactor Membar filter for LocalLoads synced via AsyncWait

### DIFF
--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -3,12 +3,14 @@
 
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace mlir::triton::AMD {
 
 // Annotates LocalLoadOps with ttg.amdgpu.syncedByAsyncWait if they consume an
 // AsyncToken from an AsyncWait.
-void markLocalLoadsSyncedViaAsyncWait(ModuleOp mod);
+void annotateLocalLoadsSyncedViaAsyncWait(ModuleOp mod);
+bool isSyncedViaAsyncWait(triton::gpu::LocalLoadOp localLoadOp);
 
 // Filter function used in the AMDGPU backend to filter unnecessary barriers
 // during Membar Analysis. Filters applied by this function:

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -7,9 +7,11 @@
 
 namespace mlir::triton::AMD {
 
-// Annotates LocalLoadOps with ttg.amdgpu.syncedByAsyncWait if they consume an
-// AsyncToken from an AsyncWait.
+// Annotates LocalLoadOps with ttg.amdgpu.syncedByAsyncWait=true if they are
+// synced by an AsyncWait.
 void annotateLocalLoadsSyncedViaAsyncWait(ModuleOp mod);
+
+// Getter for the annotation applied by annotateLocalLoadsSyncedViaAsyncWait
 bool isSyncedViaAsyncWait(triton::gpu::LocalLoadOp localLoadOp);
 
 // Filter function used in the AMDGPU backend to filter unnecessary barriers

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -1,9 +1,15 @@
 #ifndef TRITON_THIRD_PARTY_AMD_INCLUDE_TRITONAMDGPUTOLLVM_MEMBARUTILITY_H_
 #define TRITON_THIRD_PARTY_AMD_INCLUDE_TRITONAMDGPUTOLLVM_MEMBARUTILITY_H_
 
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 
 namespace mlir::triton::AMD {
+
+// Annotates LocalLoadOps with ttg.amdgpu.syncedByAsyncWait if they consume an
+// AsyncToken from an AsyncWait.
+void markLocalLoadsSyncedViaAsyncWait(ModuleOp mod);
+
 // Filter function used in the AMDGPU backend to filter unnecessary barriers
 // during Membar Analysis. Filters applied by this function:
 // 1) Do not create barriers between AsyncCopyGlobalToLocal and LocalLoad if the

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -77,7 +77,7 @@ void annotateLocalLoadsSyncedViaAsyncWait(ModuleOp mod) {
   auto *ctx = mod->getContext();
   for (auto &loadOp : localLoads) {
     auto token = loadOp.getToken();
-    bool isSyncedViaAsyncWait = token && AMD::comesFromAsyncWait(token);
+    bool isSyncedViaAsyncWait = token && comesFromAsyncWait(token);
     loadOp->setAttr(syncedViaAsyncWaitAttrName,
                     BoolAttr::get(ctx, isSyncedViaAsyncWait));
   }
@@ -85,11 +85,10 @@ void annotateLocalLoadsSyncedViaAsyncWait(ModuleOp mod) {
 
 bool isSyncedViaAsyncWait(triton::gpu::LocalLoadOp localLoadOp) {
   auto attr = localLoadOp->getAttr(syncedViaAsyncWaitAttrName);
-  // If the attribute is missing we output a remark instead of error because it
-  // only affects performance
   if (!attr) {
-    localLoadOp.emitRemark("has no async sync information attached to it. "
-                           "Run annotateLocalLoadSyncedViaAsyncWait first");
+    localLoadOp.emitRemark("has no async sync information attached to it which "
+                           "might negatively affect performance. Run "
+                           "annotateLocalLoadSyncedViaAsyncWait first");
     return false;
   }
   return cast<BoolAttr>(attr).getValue();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -100,6 +100,7 @@ struct ConvertTritonAMDGPUToLLVM
     // Allocate shared memory and set barrier
     ModuleAllocation allocation(mod);
 
+    AMD::markLocalLoadsSyncedViaAsyncWait(mod);
     ModuleMembarAnalysis membarPass(&allocation,
                                     mlir::triton::AMD::membarFilter);
     membarPass.run();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -100,7 +100,7 @@ struct ConvertTritonAMDGPUToLLVM
     // Allocate shared memory and set barrier
     ModuleAllocation allocation(mod);
 
-    AMD::markLocalLoadsSyncedViaAsyncWait(mod);
+    AMD::annotateLocalLoadsSyncedViaAsyncWait(mod);
     ModuleMembarAnalysis membarPass(&allocation,
                                     mlir::triton::AMD::membarFilter);
     membarPass.run();

--- a/third_party/amd/test/lib/Analysis/TestAMDGPUMembar.cpp
+++ b/third_party/amd/test/lib/Analysis/TestAMDGPUMembar.cpp
@@ -21,10 +21,10 @@ struct TestAMDGPUMembarPass
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
+    triton::AMD::markLocalLoadsSyncedViaAsyncWait(moduleOp);
     // Print all ops after membar pass
     ModuleAllocation allocation(moduleOp);
-    ModuleMembarAnalysis membarPass(&allocation,
-                                    mlir::triton::AMD::membarFilter);
+    ModuleMembarAnalysis membarPass(&allocation, triton::AMD::membarFilter);
     membarPass.run();
   }
 };

--- a/third_party/amd/test/lib/Analysis/TestAMDGPUMembar.cpp
+++ b/third_party/amd/test/lib/Analysis/TestAMDGPUMembar.cpp
@@ -21,7 +21,7 @@ struct TestAMDGPUMembarPass
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
-    triton::AMD::markLocalLoadsSyncedViaAsyncWait(moduleOp);
+    triton::AMD::annotateLocalLoadsSyncedViaAsyncWait(moduleOp);
     // Print all ops after membar pass
     ModuleAllocation allocation(moduleOp);
     ModuleMembarAnalysis membarPass(&allocation, triton::AMD::membarFilter);


### PR DESCRIPTION
Instead of walking the def-chain of the `AsyncToken` inside the membar filter we do it once before running membar analysis. Also makes the branch handling more generic by using `BranchOpInterface` instead of the specific branch instructions.

This also allows us to reuse the information when adding alias information while lowering `LocalLoads` which will be enabled in a follow up PR.