### PR TITLE
[Frontend][NFC] Make semantic a language-specific class

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -25,7 +25,7 @@ class Pair:
     def get_first(self):
         return self.first
 
-    def get_second(self, _builder=None):
+    def get_second(self, _semantic=None):
         return self.second
 
     @triton.jit
@@ -82,10 +82,10 @@ def test_jit_method():
 class TypeWithBuiltinInitializer:
     value: tl.tensor
 
-    def __init__(self, _builder=None):
-        self.value = tl.arange(0, 4, _builder=_builder)
+    def __init__(self, _semantic=None):
+        self.value = tl.arange(0, 4, _semantic=_semantic)
 
-    def modify(self, value, _builder=None):
+    def modify(self, value, _semantic=None):
         self.value = value
 
 

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Type, Union, Iterable, 
 
 from .. import knobs, language
 from .._C.libtriton import ir, gluon_ir
-from ..language import constexpr, semantic, str_to_ty, tensor
+from ..language import constexpr, str_to_ty, tensor
 from ..language.core import _unwrap_if_constexpr, base_value, base_type
 from ..runtime.jit import get_jit_fn_file_line, get_full_name
 # ideally we wouldn't need any runtime component
@@ -284,7 +284,14 @@ class CodeGenerator(ast.NodeVisitor):
                  module=None, is_kernel=False, function_types: Optional[Dict] = None, noinline=False,
                  file_name: Optional[str] = None, begin_line=0):
         self.context = context
-        self.builder = ir.builder(context) if not jit_fn.is_gluon() else gluon_ir.GluonOpBuilder(context)
+        if jit_fn.is_gluon():
+            from triton.experimental.gluon.language._semantic import GluonSemantic
+            self.builder = gluon_ir.GluonOpBuilder(context)
+            self.semantic = GluonSemantic(self.builder)
+        else:
+            from triton.language.semantic import TritonSemantic
+            self.builder = ir.builder(context)
+            self.semantic = TritonSemantic(self.builder)
         self.file_name = file_name
         # node.lineno starts from 1, so we need to subtract 1
         self.begin_line = begin_line - 1
@@ -459,7 +466,7 @@ class CodeGenerator(ast.NodeVisitor):
             if isinstance(value, language.tuple):
                 return _apply_to_tuple_values(value, decay)
             elif isinstance(value, (language.constexpr, int, float)):
-                return semantic.to_tensor(value, self.builder)
+                return self.semantic.to_tensor(value)
             return value
 
         ret_value = decay(ret_value)
@@ -591,7 +598,7 @@ class CodeGenerator(ast.NodeVisitor):
             if value is not None and \
                 not _is_triton_value(value) and \
                 not isinstance(value, native_nontensor_types):
-                value = semantic.to_tensor(value, self.builder)
+                value = self.semantic.to_tensor(value)
             return value
 
         values = _sanitize_value(self.visit(node.value))
@@ -625,10 +632,10 @@ class CodeGenerator(ast.NodeVisitor):
     def _apply_binary_method(self, method_name, lhs, rhs):
         # TODO: raise something meaningful if getattr fails below, esp for reverse method
         if _is_triton_tensor(lhs):
-            return getattr(lhs, method_name)(rhs, _builder=self.builder)
+            return getattr(lhs, method_name)(rhs, _semantic=self.semantic)
         if _is_triton_tensor(rhs):
             reverse_method_name = re.sub(r"__(.*)__", r"__r\1__", method_name)
-            return getattr(rhs, reverse_method_name)(lhs, _builder=self.builder)
+            return getattr(rhs, reverse_method_name)(lhs, _semantic=self.semantic)
         return getattr(lhs, method_name)(rhs)
 
     def visit_BinOp(self, node):
@@ -787,8 +794,8 @@ class CodeGenerator(ast.NodeVisitor):
                 warnings.warn(
                     "If conditional called with multidimensional Tensor instead of scalar; please use \"if (%s).item()\" instead"
                     % ast.unparse(node.test))
-                cond = language.core._unsplat(cond, _builder=self.builder, _generator=self)
-            cond = cond.to(language.int1, _builder=self.builder)
+                cond = language.core._unsplat(cond, _semantic=self.semantic, _generator=self)
+            cond = cond.to(language.int1, _semantic=self.semantic)
             contains_return = ContainsReturnChecker(self.gscope).visit(node)
             if contains_return:
                 if self.scf_stack:
@@ -814,21 +821,21 @@ class CodeGenerator(ast.NodeVisitor):
     def visit_IfExp(self, node):
         cond = self.visit(node.test)
         if _is_triton_tensor(cond):
-            cond = cond.to(language.int1, _builder=self.builder)
+            cond = cond.to(language.int1, _semantic=self.semantic)
             # TODO: Deal w/ more complicated return types (e.g tuple)
             with enter_sub_region(self):
                 ip, last_loc = self._get_insertion_point_and_loc()
 
                 then_block = self.builder.create_block()
                 self.builder.set_insertion_point_to_start(then_block)
-                then_val = semantic.to_tensor(self.visit(node.body), self.builder)
+                then_val = self.semantic.to_tensor(self.visit(node.body))
                 then_block = self.builder.get_insertion_block()
 
                 else_block = self.builder.create_block()
                 self.builder.set_insertion_point_to_start(else_block)
                 # do not need to reset lscope since
                 # ternary expressions cannot define new variables
-                else_val = semantic.to_tensor(self.visit(node.orelse), self.builder)
+                else_val = self.semantic.to_tensor(self.visit(node.orelse))
                 else_block = self.builder.get_insertion_block()
 
                 self._set_insertion_point_and_loc(ip, last_loc)
@@ -894,7 +901,7 @@ class CodeGenerator(ast.NodeVisitor):
         if fn is None:
             raise self._unsupported(node, f"AST unary operator '{node.op.__name__}' is not (currently) implemented.")
         if _is_triton_tensor(operand):
-            return getattr(operand, fn)(_builder=self.builder)
+            return getattr(operand, fn)(_semantic=self.semantic)
         try:
             return getattr(operand, fn)()
         except AttributeError:
@@ -999,7 +1006,7 @@ class CodeGenerator(ast.NodeVisitor):
         lhs = self.visit(node.value)
         slices = self.visit(node.slice)
         if _is_triton_tensor(lhs):
-            return lhs.__getitem__(slices, _builder=self.builder)
+            return lhs.__getitem__(slices, _semantic=self.semantic)
         return lhs[slices]
 
     def visit_Subscript_Store(self, node, value):
@@ -1061,14 +1068,14 @@ class CodeGenerator(ast.NodeVisitor):
             step = constexpr(-step.value)
             negative_step = True
             lb, ub = ub, lb
-        lb = semantic.to_tensor(lb, self.builder)
-        ub = semantic.to_tensor(ub, self.builder)
-        step = semantic.to_tensor(step, self.builder)
+        lb = self.semantic.to_tensor(lb)
+        ub = self.semantic.to_tensor(ub)
+        step = self.semantic.to_tensor(step)
         # induction variable type
         if not lb.dtype.is_int() or not ub.dtype.is_int() or not step.dtype.is_int():
             raise TypeError(f"For loop bounds and step must all be ints, are ({lb.dtype}, {ub.dtype}, {step.dtype})")
-        iv_type = semantic.integer_promote_impl(lb.dtype, ub.dtype)
-        iv_type = semantic.integer_promote_impl(iv_type, step.dtype)
+        iv_type = self.semantic.integer_promote_impl(lb.dtype, ub.dtype)
+        iv_type = self.semantic.integer_promote_impl(iv_type, step.dtype)
         iv_ir_type = iv_type.to_ir(self.builder)
         iv_is_signed = iv_type.int_signedness == language.core.dtype.SIGNEDNESS.SIGNED
         # lb/ub/step might be constexpr, we need to cast them to tensor
@@ -1144,7 +1151,7 @@ class CodeGenerator(ast.NodeVisitor):
                 if name in liveins:
                     local = self.local_defs[name]
                     if isinstance(local, constexpr):
-                        local = semantic.to_tensor(local, self.builder)
+                        local = self.semantic.to_tensor(local)
                     yields.append(local)
 
             # create YieldOp
@@ -1188,7 +1195,7 @@ class CodeGenerator(ast.NodeVisitor):
     def visit_Assert(self, node) -> Any:
         test = self.visit(node.test)
         msg = self.visit(node.msg) if node.msg is not None else ""
-        return language.core.device_assert(test, msg, _builder=self.builder)
+        return language.core.device_assert(test, msg, _semantic=self.semantic)
 
     def call_JitFunction(self, fn: JITFunction, args, kwargs):
         args = inspect.getcallargs(fn.fn, *args, **kwargs)
@@ -1261,7 +1268,7 @@ class CodeGenerator(ast.NodeVisitor):
             _check_fn_args(node, fn, args)
             return self.call_JitFunction(fn, args, kws)
         if (hasattr(fn, '__self__') and _is_triton_value(fn.__self__)) or language.core.is_builtin(fn):
-            extra_kwargs = {"_builder": self.builder}
+            extra_kwargs = {"_semantic": self.semantic}
             sig = inspect.signature(fn)
             if '_generator' in sig.parameters:
                 extra_kwargs['_generator'] = self
@@ -1347,7 +1354,7 @@ class CodeGenerator(ast.NodeVisitor):
     def visit_Attribute(self, node):
         lhs = self.visit(node.value)
         if _is_triton_tensor(lhs) and node.attr == "T":
-            return semantic.permute(lhs, (1, 0), builder=self.builder)
+            return self.semantic.permute(lhs, (1, 0))
         # NOTE: special case ".value" for BC
         if isinstance(lhs, constexpr) and node.attr != "value":
             lhs = lhs.value

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -4,6 +4,7 @@ from functools import wraps
 
 if TYPE_CHECKING:
     from triton._C.libtriton.gluon_ir import GluonOpBuilder
+    from ._semantic import GluonSemantic
 
 from ._layouts import SharedLayout, DistributedLayout
 from triton._C.libtriton import ir
@@ -39,7 +40,6 @@ from triton.language.core import (
     _unwrap_shape,
     tensor,
 )
-from . import _semantic as semantic
 
 _IMPORT_FROM_TRITON: List[str] = [
     "program_id",  # NOQA: F822
@@ -122,9 +122,9 @@ def builtin(fn: T) -> T:
 
     @wraps(fn)
     def wrapper(*args, **kwargs):
-        if "_builder" not in kwargs or kwargs["_builder"] is None:
+        if "_semantic" not in kwargs or kwargs["_semantic"] is None:
             raise ValueError("Did you forget to add @triton.gluon.jit ? "
-                             "(`_builder` argument must be provided outside of JIT functions.)")
+                             "(`_semantic` argument must be provided outside of JIT functions.)")
         return fn(*args, **kwargs)
 
     setattr(wrapper, GLUON_BUILTIN, True)
@@ -196,16 +196,16 @@ class shared_memory_descriptor(base_value):
         return str(self.type)
 
     @builtin
-    def load(self, layout, _builder: GluonOpBuilder) -> tensor:
+    def load(self, layout, _semantic: GluonSemantic) -> tensor:
         layout = _unwrap_if_constexpr(layout)
-        return semantic.shared_load(self, layout, _builder)
+        return _semantic.shared_load(self, layout)
 
     @builtin
-    def store(self, value, _builder: GluonOpBuilder) -> None:
-        return semantic.shared_store(self, value, _builder)
+    def store(self, value, _semantic: GluonSemantic) -> None:
+        return _semantic.shared_store(self, value)
 
     @builtin
-    def split(self, offset, size, dim=None, layout=None, _builder: GluonOpBuilder = None) -> shared_memory_descriptor:
+    def split(self, offset, size, dim=None, layout=None, _semantic: GluonSemantic = None) -> shared_memory_descriptor:
         if layout is None:
             layout = self.type.layout
         if dim is None:
@@ -216,10 +216,10 @@ class shared_memory_descriptor(base_value):
         dim = _unwrap_if_constexpr(dim)
         layout = _unwrap_if_constexpr(layout)
 
-        return semantic.memdesc_split(self, offset, size, dim, layout, _builder)
+        return _semantic.memdesc_split(self, offset, size, dim, layout)
 
     @builtin
-    def subslice(self, index, shape=None, layout=None, _builder: GluonOpBuilder = None) -> shared_memory_descriptor:
+    def subslice(self, index, shape=None, layout=None, _semantic: GluonSemantic = None) -> shared_memory_descriptor:
         if layout is None:
             layout = self.type.layout
         if shape is None:
@@ -229,33 +229,33 @@ class shared_memory_descriptor(base_value):
         shape = [_unwrap_if_constexpr(s) for s in shape]
         layout = _unwrap_if_constexpr(layout)
 
-        return semantic.memdesc_slice(self, index, shape, layout, _builder)
+        return _semantic.memdesc_slice(self, index, shape, layout)
 
     @builtin
-    def permute(self, order, layout, _builder: GluonOpBuilder) -> shared_memory_descriptor:
+    def permute(self, order, layout, _semantic: GluonSemantic) -> shared_memory_descriptor:
         order = [_unwrap_if_constexpr(o) for o in order]
         layout = _unwrap_if_constexpr(layout)
 
-        return semantic.memdesc_trans(self, order, layout, _builder)
+        return _semantic.memdesc_trans(self, order, layout)
 
     @builtin
-    def reshape(self, shape, layout, _builder: GluonOpBuilder) -> shared_memory_descriptor:
+    def reshape(self, shape, layout, _semantic: GluonSemantic) -> shared_memory_descriptor:
         shape = [_unwrap_if_constexpr(s) for s in shape]
         layout = _unwrap_if_constexpr(layout)
 
-        return semantic.memdesc_reshape(self, shape, layout, _builder)
+        return _semantic.memdesc_reshape(self, shape, layout)
 
     @builtin
-    def _reinterpret(self, dtype, shape, layout, _builder: GluonOpBuilder = None) -> shared_memory_descriptor:
+    def _reinterpret(self, dtype, shape, layout, _semantic: GluonSemantic = None) -> shared_memory_descriptor:
         dtype = _unwrap_if_constexpr(dtype)
         shape = [_unwrap_if_constexpr(s) for s in shape]
         layout = _unwrap_if_constexpr(layout)
 
-        return semantic.memdesc_reinterpret(self, dtype, shape, layout, _builder)
+        return _semantic.memdesc_reinterpret(self, dtype, shape, layout)
 
     @builtin
-    def _keep_alive(self, _builder: GluonOpBuilder = None) -> None:
-        return semantic.shared_dealloc(self, _builder)
+    def _keep_alive(self, _semantic: GluonSemantic = None) -> None:
+        return _semantic.shared_dealloc(self)
 
 
 for name in _IMPORT_FROM_TRITON:
@@ -264,42 +264,42 @@ for name in _IMPORT_FROM_TRITON:
 
 
 @builtin
-def arange(start, end, layout, _builder=None):
+def arange(start, end, layout, _semantic=None):
     start = _unwrap_if_constexpr(start)
     end = _unwrap_if_constexpr(end)
     layout = _unwrap_if_constexpr(layout)
-    return semantic.arange(start, end, layout, _builder)
+    return _semantic.arange(start, end, layout)
 
 
 @builtin
-def convert_layout(value, layout, _builder=None):
+def convert_layout(value, layout, _semantic=None):
     layout = _unwrap_if_constexpr(layout)
-    return semantic.convert_layout(value, layout, _builder)
+    return _semantic.convert_layout(value, layout)
 
 
 @builtin
-def full(shape, value, dtype, layout, _builder=None):
+def full(shape, value, dtype, layout, _semantic=None):
     shape = _unwrap_shape(shape)
     value = _unwrap_if_constexpr(value)
     dtype = _unwrap_if_constexpr(dtype)
     layout = _unwrap_if_constexpr(layout)
-    return semantic.full(shape, value, dtype, layout, _builder)
+    return _semantic.full(shape, value, dtype, layout)
 
 
 @builtin
-def allocate_shared_memory(element_ty, shape, layout, value=None, _builder=None):
+def allocate_shared_memory(element_ty, shape, layout, value=None, _semantic=None):
     element_ty = _unwrap_if_constexpr(element_ty)
     shape = _unwrap_if_constexpr(shape)
     shape = [_unwrap_if_constexpr(s) for s in shape]
     layout = _unwrap_if_constexpr(layout)
-    return semantic.allocate_shared(element_ty, shape, layout, value, _builder)
+    return _semantic.allocate_shared(element_ty, shape, layout, value)
 
 
 @builtin
 def warp_specialize(args, default_partition, worker_partitions, worker_num_warps, worker_num_regs,  #
-                    _builder=None, _generator=None):
+                    _semantic=None, _generator=None):
     worker_num_warps = [_unwrap_if_constexpr(w) for w in worker_num_warps]
     worker_num_regs = [_unwrap_if_constexpr(r) for r in worker_num_regs]
     args = [_unwrap_if_constexpr(arg) for arg in args]
-    return semantic.warp_specialize(args, default_partition, worker_partitions, worker_num_warps,  #
-                                    worker_num_regs, _builder, _generator)
+    return _semantic.warp_specialize(args, default_partition, worker_partitions, worker_num_warps,  #
+                                     worker_num_regs, _generator)

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -1,142 +1,142 @@
 from typing import Sequence
-from triton.language import semantic as tl_semantic
+from triton.language.semantic import TritonSemantic
 from . import _core as ttgl
 from triton._C.libtriton.gluon_ir import GluonOpBuilder
 from triton.compiler.code_generator import flatten_values_to_ir, unflatten_ir_values
 
 
-def arange(start, end, layout, builder: GluonOpBuilder):
-    shape = [end - start]
-    ret_ty = ttgl.distributed_type(ttgl.int32, shape, layout)
-    return tl_semantic.arange(start, end, builder, ret_ty=ret_ty)
+class GluonSemantic(TritonSemantic[ttgl.tensor]):
+    tensor = ttgl.tensor
+    lang = ttgl
 
+    builder: GluonOpBuilder
 
-def splat(value, shape, layout, builder: GluonOpBuilder):
-    ret_ty = ttgl.distributed_type(value.dtype, shape, layout)
-    handle = builder.create_splat(ret_ty.to_ir(builder), value.handle)
-    return ttgl.tensor(handle, ret_ty)
+    def __init__(self, builder: GluonOpBuilder):
+        self.builder = builder
 
+    def arange(self, start, end, layout):
+        shape = [end - start]
+        ret_ty = ttgl.distributed_type(ttgl.int32, shape, layout)
+        return super().arange(start, end, ret_ty=ret_ty)
 
-def full(shape, value, dtype, layout, builder: GluonOpBuilder):
-    scalar = tl_semantic.full([], value, dtype, builder)
-    return splat(scalar, shape, layout, builder)
+    def splat(self, value, shape, layout):
+        ret_ty = ttgl.distributed_type(value.dtype, shape, layout)
+        handle = self.builder.create_splat(ret_ty.to_ir(self.builder), value.handle)
+        return ttgl.tensor(handle, ret_ty)
 
+    def full(self, shape, value, dtype, layout):
+        scalar = super().full([], value, dtype)
+        return self.splat(scalar, shape, layout)
 
-def convert_layout(value, layout, builder: GluonOpBuilder):
-    ty = value.type
-    assert isinstance(ty, ttgl.distributed_type)
-    ret_ty = ttgl.distributed_type(ty.element_ty, ty.shape, layout)
-    handle = builder.create_convert_layout(ret_ty.to_ir(builder), value.handle)
-    return ttgl.tensor(handle, ret_ty)
+    def convert_layout(self, value, layout):
+        ty = value.type
+        assert isinstance(ty, ttgl.distributed_type)
+        ret_ty = ttgl.distributed_type(ty.element_ty, ty.shape, layout)
+        handle = self.builder.create_convert_layout(ret_ty.to_ir(self.builder), value.handle)
+        return ttgl.tensor(handle, ret_ty)
 
+    def allocate_shared(self, element_ty, shape, layout, value):
+        ty = ttgl.shared_memory_descriptor_type(element_ty, shape, layout, shape)
+        if value is not None:
+            handle = self.builder.create_local_alloc(ty.to_ir(self.builder), value.handle)
+        else:
+            handle = self.builder.create_local_alloc(ty.to_ir(self.builder))
+        return ttgl.shared_memory_descriptor(handle, element_ty, shape, layout, shape)
 
-def allocate_shared(element_ty, shape, layout, value, builder: GluonOpBuilder):
-    ty = ttgl.shared_memory_descriptor_type(element_ty, shape, layout, shape)
-    if value is not None:
-        handle = builder.create_local_alloc(ty.to_ir(builder), value.handle)
-    else:
-        handle = builder.create_local_alloc(ty.to_ir(builder))
-    return ttgl.shared_memory_descriptor(handle, element_ty, shape, layout, shape)
+    def shared_load(self, mem_desc, layout):
+        ret_ty = ttgl.distributed_type(mem_desc.dtype, mem_desc.shape, layout)
+        handle = self.builder.create_local_load(ret_ty.to_ir(self.builder), mem_desc.handle)
+        return ttgl.tensor(handle, ret_ty)
 
+    def shared_store(self, mem_desc, value):
+        self.builder.create_local_store(mem_desc.handle, value.handle)
 
-def shared_load(mem_desc, layout, builder: GluonOpBuilder):
-    ret_ty = ttgl.distributed_type(mem_desc.dtype, mem_desc.shape, layout)
-    handle = builder.create_local_load(ret_ty.to_ir(builder), mem_desc.handle)
-    return ttgl.tensor(handle, ret_ty)
+    def shared_dealloc(self, mem_desc):
+        self.builder.create_local_dealloc(mem_desc.handle)
 
+    def _memdesc_subview(self, mem_desc, offsets, shape, layout):
+        ty = ttgl.shared_memory_descriptor_type(mem_desc.dtype, shape, layout, mem_desc.type.alloc_shape)
+        builder = self.builder
+        handle = builder.create_memdesc_subview(ty.to_ir(builder), mem_desc.handle, offsets)
+        return ttgl.shared_memory_descriptor(handle, **ty.__dict__)
 
-def shared_store(mem_desc, value, builder: GluonOpBuilder):
-    builder.create_local_store(mem_desc.handle, value.handle)
+    def memdesc_split(self, mem_desc, offset, size, dim, layout):
+        offsets = [self.builder.get_int32(0)] * mem_desc.rank
+        offsets[dim] = self.builder.get_int32(offset)
+        shape = list(mem_desc.shape)
+        shape[dim] = size
+        return self._memdesc_subview(mem_desc, offsets, shape, layout)
 
+    def memdesc_slice(self, mem_desc, index, shape, layout):
+        assert mem_desc.rank > len(
+            shape), f"source rank ({mem_desc.rank}) must be greater than result rank ({len(shape)})"
 
-def shared_dealloc(mem_desc, builder: GluonOpBuilder):
-    builder.create_local_dealloc(mem_desc.handle)
+        offsets = [self.builder.get_int32(0)] * mem_desc.rank
+        offsets[0] = self._convert_elem_to_ir_value(index, require_i64=False)
+        return self._memdesc_subview(mem_desc, offsets, shape, layout)
 
+    def memdesc_trans(self, mem_desc, order, layout):
+        assert len(order) == len(
+            mem_desc.shape), f"source rank ({mem_desc.rank}) and order length ({len(order)}) must match"
 
-def _memdesc_subview(mem_desc, offsets, shape, layout, builder: GluonOpBuilder):
-    ty = ttgl.shared_memory_descriptor_type(mem_desc.dtype, shape, layout, mem_desc.type.alloc_shape)
-    handle = builder.create_memdesc_subview(ty.to_ir(builder), mem_desc.handle, offsets)
-    return ttgl.shared_memory_descriptor(handle, **ty.__dict__)
+        shape = [mem_desc.shape[i] for i in order]
+        alloc_shape = mem_desc.type.alloc_shape
+        new_alloc_shape = alloc_shape[:len(alloc_shape) - mem_desc.rank]
+        new_alloc_shape += [alloc_shape[:mem_desc.rank][i] for i in order]
 
+        ty = ttgl.shared_memory_descriptor_type(mem_desc.dtype, shape, layout, new_alloc_shape)
+        handle = self.builder.create_memdesc_trans(ty.to_ir(self.builder), mem_desc.handle, order)
+        return ttgl.shared_memory_descriptor(handle, **ty.__dict__)
 
-def memdesc_split(mem_desc, offset, size, dim, layout, builder: GluonOpBuilder):
-    offsets = [builder.get_int32(0)] * mem_desc.rank
-    offsets[dim] = builder.get_int32(offset)
-    shape = list(mem_desc.shape)
-    shape[dim] = size
-    return _memdesc_subview(mem_desc, offsets, shape, layout, builder)
+    def memdesc_reshape(self, mem_desc, shape, layout):
+        ty = ttgl.shared_memory_descriptor_type(mem_desc.dtype, shape, layout, mem_desc.type.alloc_shape)
+        handle = self.builder.create_memdesc_reshape(ty.to_ir(self.builder), mem_desc.handle)
+        return ttgl.shared_memory_descriptor(handle, **ty.__dict__)
 
+    def memdesc_reinterpret(self, mem_desc, dtype, shape, layout):
+        ty = ttgl.shared_memory_descriptor_type(dtype, shape, layout, shape)
+        handle = self.builder.create_memdesc_reinterpret(ty.to_ir(self.builder), mem_desc.handle)
+        return ttgl.shared_memory_descriptor(handle, **ty.__dict__)
 
-def memdesc_slice(mem_desc, index, shape, layout, builder: GluonOpBuilder):
-    assert mem_desc.rank > len(shape), f"source rank ({mem_desc.rank}) must be greater than result rank ({len(shape)})"
+    def warp_specialize(self, args, default_partition, worker_partitions, worker_num_warps: Sequence[int],
+                        worker_num_regs: Sequence[int], generator):
+        num_partitions = len(worker_partitions)
+        assert num_partitions == len(
+            worker_num_warps
+        ), f"warp specialize got {num_partitions} partitions but {len(worker_num_warps)} warp counts"
+        assert num_partitions == len(
+            worker_num_regs
+        ), f"warp specialize got {num_partitions} partitions but {len(worker_num_regs)} register counts"
 
-    offsets = [builder.get_int32(0)] * mem_desc.rank
-    offsets[0] = tl_semantic._convert_elem_to_ir_value(builder, index, require_i64=False)
-    return _memdesc_subview(mem_desc, offsets, shape, layout, builder)
+        builder = self.builder
+        insert_pt = builder.get_insertion_point()
 
+        # Emit the default partition to get the result types.
+        default_block = builder.new_block()
+        builder.set_insertion_point_to_start(default_block)
+        default_results = generator.call_JitFunction(default_partition, args, kwargs={})
+        mlir_results = flatten_values_to_ir(default_results)
+        builder.create_warp_yield(mlir_results)
+        result_types = [r.get_type() for r in mlir_results]
 
-def memdesc_trans(mem_desc, order, layout, builder: GluonOpBuilder):
-    assert len(order) == len(
-        mem_desc.shape), f"source rank ({mem_desc.rank}) and order length ({len(order)}) must match"
+        # Create the warp specialize op.
+        builder.restore_insertion_point(insert_pt)
+        mlir_args = flatten_values_to_ir(args)
+        ws_op = builder.create_warp_specialize(result_types, mlir_args, worker_num_warps)
+        ws_op.get_default_region().push_back(default_block)
+        ws_op.set_requested_registers(worker_num_regs)
 
-    shape = [mem_desc.shape[i] for i in order]
-    alloc_shape = mem_desc.type.alloc_shape
-    new_alloc_shape = alloc_shape[:len(alloc_shape) - mem_desc.rank]
-    new_alloc_shape += [alloc_shape[:mem_desc.rank][i] for i in order]
+        # Emit the partition regions.
+        builder.create_block_with_parent(ws_op.get_partition_op_holder(), [])
+        partitions_op = builder.create_warp_specialize_partitions(num_partitions)
+        arg_types = [arg.get_type() for arg in mlir_args]
+        for i in range(num_partitions):
+            block = builder.create_block_with_parent(partitions_op.get_region(i), arg_types)
+            block_args = [block.get_argument(j) for j in range(len(mlir_args))]
+            block_args = unflatten_ir_values(block_args, [arg.type for arg in args])
+            generator.call_JitFunction(worker_partitions[i], block_args, kwargs={})
+            builder.create_warp_return()
 
-    ty = ttgl.shared_memory_descriptor_type(mem_desc.dtype, shape, layout, new_alloc_shape)
-    handle = builder.create_memdesc_trans(ty.to_ir(builder), mem_desc.handle, order)
-    return ttgl.shared_memory_descriptor(handle, **ty.__dict__)
-
-
-def memdesc_reshape(mem_desc, shape, layout, builder: GluonOpBuilder):
-    ty = ttgl.shared_memory_descriptor_type(mem_desc.dtype, shape, layout, mem_desc.type.alloc_shape)
-    handle = builder.create_memdesc_reshape(ty.to_ir(builder), mem_desc.handle)
-    return ttgl.shared_memory_descriptor(handle, **ty.__dict__)
-
-
-def memdesc_reinterpret(mem_desc, dtype, shape, layout, builder: GluonOpBuilder):
-    ty = ttgl.shared_memory_descriptor_type(dtype, shape, layout, shape)
-    handle = builder.create_memdesc_reinterpret(ty.to_ir(builder), mem_desc.handle)
-    return ttgl.shared_memory_descriptor(handle, **ty.__dict__)
-
-
-def warp_specialize(args, default_partition, worker_partitions, worker_num_warps: Sequence[int],
-                    worker_num_regs: Sequence[int], builder: GluonOpBuilder, generator):
-    num_partitions = len(worker_partitions)
-    assert num_partitions == len(
-        worker_num_warps), f"warp specialize got {num_partitions} partitions but {len(worker_num_warps)} warp counts"
-    assert num_partitions == len(
-        worker_num_regs), f"warp specialize got {num_partitions} partitions but {len(worker_num_regs)} register counts"
-
-    insert_pt = builder.get_insertion_point()
-
-    # Emit the default partition to get the result types.
-    default_block = builder.new_block()
-    builder.set_insertion_point_to_start(default_block)
-    default_results = generator.call_JitFunction(default_partition, args, kwargs={})
-    mlir_results = flatten_values_to_ir(default_results)
-    builder.create_warp_yield(mlir_results)
-    result_types = [r.get_type() for r in mlir_results]
-
-    # Create the warp specialize op.
-    builder.restore_insertion_point(insert_pt)
-    mlir_args = flatten_values_to_ir(args)
-    ws_op = builder.create_warp_specialize(result_types, mlir_args, worker_num_warps)
-    ws_op.get_default_region().push_back(default_block)
-    ws_op.set_requested_registers(worker_num_regs)
-
-    # Emit the partition regions.
-    builder.create_block_with_parent(ws_op.get_partition_op_holder(), [])
-    partitions_op = builder.create_warp_specialize_partitions(num_partitions)
-    arg_types = [arg.get_type() for arg in mlir_args]
-    for i in range(num_partitions):
-        block = builder.create_block_with_parent(partitions_op.get_region(i), arg_types)
-        block_args = [block.get_argument(j) for j in range(len(mlir_args))]
-        block_args = unflatten_ir_values(block_args, [arg.type for arg in args])
-        generator.call_JitFunction(worker_partitions[i], block_args, kwargs={})
-        builder.create_warp_return()
-
-    builder.set_insertion_point_after(ws_op.get_operation())
-    mlir_results = [ws_op.get_result(i) for i in range(len(result_types))]
-    return tuple(unflatten_ir_values(mlir_results, [r.type for r in default_results]))
+        builder.set_insertion_point_after(ws_op.get_operation())
+        mlir_results = [ws_op.get_result(i) for i in range(len(result_types))]
+        return tuple(unflatten_ir_values(mlir_results, [r.type for r in default_results]))

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -25,7 +25,7 @@ class GluonSemantic(TritonSemantic[ttgl.tensor]):
         return ttgl.tensor(handle, ret_ty)
 
     def full(self, shape, value, dtype, layout):
-        scalar = super().full([], value, dtype)
+        scalar = self.make_scalar(value, dtype)
         return self.splat(scalar, shape, layout)
 
     def convert_layout(self, value, layout):

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from typing import Optional, Tuple, List, TYPE_CHECKING
 
 from dataclasses import dataclass
-from triton.language.semantic import _convert_elem_to_ir_value, _convert_to_ir_values
 from triton.experimental.gluon.language import _core as ttgl
 from triton.experimental.gluon.language._core import builtin, base_type, base_value, _unwrap_if_constexpr
 
@@ -12,6 +11,7 @@ from ..hopper import mbarrier
 if TYPE_CHECKING:
     from triton._C.libtriton.gluon_ir import GluonOpBuilder
     from triton._C.libtriton import gluon_ir as ir
+    from ..._semantic import GluonSemantic
 
 __all__ = [
     "TensorMemoryLayout",
@@ -111,63 +111,67 @@ class tensor_memory_descriptor(base_value):
         return str(self.type)
 
     @builtin
-    def load(self, layout, _builder: GluonOpBuilder) -> ttgl.tensor:
+    def load(self, layout, _semantic: GluonSemantic) -> ttgl.tensor:
         layout = _unwrap_if_constexpr(layout)
         ret_ty = ttgl.distributed_type(self.dtype, self.shape, layout)
-        handle = _builder.create_tmem_load(ret_ty.to_ir(_builder), self.handle)
+        builder = _semantic.builder
+        handle = builder.create_tmem_load(ret_ty.to_ir(builder), self.handle)
         return ttgl.tensor(handle, ret_ty)
 
     @builtin
-    def store(self, value, pred=True, _builder: GluonOpBuilder = None) -> None:
+    def store(self, value, pred=True, _semantic: GluonSemantic = None) -> None:
         pred = _unwrap_if_constexpr(pred)
-        pred = ttgl.to_tensor(pred, _builder=_builder)
-        _builder.create_tmem_store(self.handle, value.handle, pred.handle)
+        pred = _semantic.to_tensor(pred)
+        _semantic.builder.create_tmem_store(self.handle, value.handle, pred.handle)
 
     @builtin
-    def split(self, start, length, _builder: GluonOpBuilder) -> None:
+    def split(self, start, length, _semantic: GluonSemantic) -> None:
         start = _unwrap_if_constexpr(start)
         length = _unwrap_if_constexpr(length)
         assert isinstance(start, int)
         assert isinstance(length, int)
         shape = [self.shape[0], length]
         ret = tensor_memory_descriptor(None, self.dtype, shape, self.type.layout, self.type.alloc_shape)
-        ret.handle = _builder.create_tmem_subslice(ret.type.to_ir(_builder), self.handle, start)
+        builder = _semantic.builder
+        ret.handle = builder.create_tmem_subslice(ret.type.to_ir(builder), self.handle, start)
         return ret
 
     @builtin
-    def subslice(self, index, shape=None, layout=None, _builder: GluonOpBuilder = None) -> tensor_memory_descriptor:
+    def subslice(self, index, shape=None, layout=None, _semantic: GluonSemantic = None) -> tensor_memory_descriptor:
         if layout is None:
             layout = self.type.layout
         if shape is None:
             shape = self.shape[1:]
 
-        index = _convert_elem_to_ir_value(_builder, index, require_i64=False)
+        index = _semantic._convert_elem_to_ir_value(index, require_i64=False)
         shape = [_unwrap_if_constexpr(s) for s in shape]
         layout = _unwrap_if_constexpr(layout)
 
-        offsets = [_builder.get_int32(0)] * self.rank
+        builder = _semantic.builder
+        offsets = [builder.get_int32(0)] * self.rank
         offsets[0] = index
         ret = tensor_memory_descriptor(None, self.dtype, shape, layout, self.type.alloc_shape)
-        ret.handle = _builder.create_memdesc_subview(ret.type.to_ir(_builder), self.handle, offsets)
+        ret.handle = builder.create_memdesc_subview(ret.type.to_ir(builder), self.handle, offsets)
         return ret
 
 
 @builtin
-def allocate_tensor_memory(element_ty, shape, layout, value=None, _builder=None):
+def allocate_tensor_memory(element_ty, shape, layout, value=None, _semantic=None):
     element_ty = _unwrap_if_constexpr(element_ty)
     shape = _unwrap_if_constexpr(shape)
     layout = _unwrap_if_constexpr(layout)
     value = value.handle if value is not None else None
 
     ty = tensor_memory_descriptor_type(element_ty, shape, layout, shape)
-    handle = _builder.create_tmem_alloc(ty.to_ir(_builder), value)
+    builder = _semantic.builder
+    handle = builder.create_tmem_alloc(ty.to_ir(builder), value)
     return tensor_memory_descriptor(handle, element_ty, shape, layout, shape)
 
 
 @builtin
-def tcgen05_mma(a, b, acc, *, use_acc=True, pred=True, mbarriers=None, mbarrier_preds=None, _builder=None):
-    use_acc = ttgl.to_tensor(use_acc, _builder=_builder)
-    pred = ttgl.to_tensor(pred, _builder=_builder)
+def tcgen05_mma(a, b, acc, *, use_acc=True, pred=True, mbarriers=None, mbarrier_preds=None, _semantic=None):
+    use_acc = _semantic.to_tensor(use_acc)
+    pred = _semantic.to_tensor(pred)
 
     if mbarriers is None:
         assert mbarrier_preds is None
@@ -176,9 +180,10 @@ def tcgen05_mma(a, b, acc, *, use_acc=True, pred=True, mbarriers=None, mbarrier_
     else:
         mbarriers = [bar.handle for bar in mbarriers]
         if mbarrier_preds is None:
-            true = ttgl.to_tensor(True, _builder=_builder)
+            true = _semantic.to_tensor(True)
             mbarrier_preds = [true] * len(mbarriers)
         else:
-            mbarrier_preds = _convert_to_ir_values(_builder, mbarrier_preds, require_i64=False)
+            mbarrier_preds = _semantic._convert_to_ir_values(mbarrier_preds, require_i64=False)
 
-    _builder.create_tcgen05_mma(a.handle, b.handle, acc.handle, use_acc.handle, pred.handle, mbarriers, mbarrier_preds)
+    _semantic.builder.create_tcgen05_mma(a.handle, b.handle, acc.handle, use_acc.handle, pred.handle, mbarriers,
+                                         mbarrier_preds)

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
@@ -25,4 +25,4 @@ def async_gather(tensor_desc, x_offsets, y_offset, barrier, result, pred=True, _
 @builtin
 def async_scatter(tensor_desc, x_offsets, y_offset, src, _semantic=None):
     y_offset = _semantic.to_tensor(y_offset)
-    _semantic.create_async_tma_scatter(tensor_desc.handle, x_offsets.handle, y_offset.handle, src.handle)
+    _semantic.builder.create_async_tma_scatter(tensor_desc.handle, x_offsets.handle, y_offset.handle, src.handle)

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
@@ -1,5 +1,4 @@
 from triton.experimental.gluon.language._core import builtin
-import triton.experimental.gluon.language._core as ttgl
 from triton.experimental.gluon.language.nvidia.hopper.tma import (
     async_copy_global_to_shared,
     async_copy_shared_to_global,
@@ -16,14 +15,14 @@ __all__ = [
 
 
 @builtin
-def async_gather(tensor_desc, x_offsets, y_offset, barrier, result, pred=True, _builder=None):
-    pred = ttgl.to_tensor(pred, _builder=_builder)
-    y_offset = ttgl.to_tensor(y_offset, _builder=_builder)
-    _builder.create_async_tma_gather(tensor_desc.handle, x_offsets.handle, y_offset.handle, barrier.handle,
-                                     result.handle, pred.handle)
+def async_gather(tensor_desc, x_offsets, y_offset, barrier, result, pred=True, _semantic=None):
+    pred = _semantic.to_tensor(pred)
+    y_offset = _semantic.to_tensor(y_offset)
+    _semantic.builder.create_async_tma_gather(tensor_desc.handle, x_offsets.handle, y_offset.handle, barrier.handle,
+                                              result.handle, pred.handle)
 
 
 @builtin
-def async_scatter(tensor_desc, x_offsets, y_offset, src, _builder=None):
-    y_offset = ttgl.to_tensor(y_offset, _builder=_builder)
-    _builder.create_async_tma_scatter(tensor_desc.handle, x_offsets.handle, y_offset.handle, src.handle)
+def async_scatter(tensor_desc, x_offsets, y_offset, src, _semantic=None):
+    y_offset = _semantic.to_tensor(y_offset)
+    _semantic.create_async_tma_scatter(tensor_desc.handle, x_offsets.handle, y_offset.handle, src.handle)

--- a/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
@@ -1,5 +1,4 @@
 from triton.experimental.gluon.language._layouts import SwizzledSharedLayout
-import triton.experimental.gluon.language._core as ttgl
 from triton.experimental.gluon.language._core import builtin, _unwrap_if_constexpr
 
 __all__ = ["MBarrierLayout", "init", "invalidate", "expect", "wait", "arrive"]
@@ -20,33 +19,33 @@ class MBarrierLayout(SwizzledSharedLayout):
 
 
 @builtin
-def init(mbarrier, count, _builder=None):
+def init(mbarrier, count, _semantic=None):
     count = _unwrap_if_constexpr(count)
-    _builder.create_mbarrier_init(mbarrier.handle, count)
+    _semantic.builder.create_mbarrier_init(mbarrier.handle, count)
 
 
 @builtin
-def invalidate(mbarrier, _builder=None):
-    _builder.create_mbarrier_inval(mbarrier.handle)
+def invalidate(mbarrier, _semantic=None):
+    _semantic.builder.create_mbarrier_inval(mbarrier.handle)
 
 
 @builtin
-def expect(mbarrier, bytes, pred=True, _builder=None):
+def expect(mbarrier, bytes, pred=True, _semantic=None):
     bytes = _unwrap_if_constexpr(bytes)
-    pred = ttgl.to_tensor(pred, _builder=_builder)
-    _builder.create_mbarrier_expect(mbarrier.handle, bytes, pred.handle)
+    pred = _semantic.to_tensor(pred)
+    _semantic.builder.create_mbarrier_expect(mbarrier.handle, bytes, pred.handle)
 
 
 @builtin
-def wait(mbarrier, phase, pred=True, deps=(), _builder=None):
-    phase = ttgl.to_tensor(phase, _builder=_builder)
-    pred = ttgl.to_tensor(pred, _builder=_builder)
+def wait(mbarrier, phase, pred=True, deps=(), _semantic=None):
+    phase = _semantic.to_tensor(phase)
+    pred = _semantic.to_tensor(pred)
     deps = [x.handle for x in deps]
-    _builder.create_mbarrier_wait(mbarrier.handle, phase.handle, pred.handle, deps)
+    _semantic.builder.create_mbarrier_wait(mbarrier.handle, phase.handle, pred.handle, deps)
 
 
 @builtin
-def arrive(mbarrier, count, pred=True, _builder=None):
+def arrive(mbarrier, count, pred=True, _semantic=None):
     count = _unwrap_if_constexpr(count)
-    pred = ttgl.to_tensor(pred, _builder=_builder)
-    _builder.create_mbarrier_arrive(mbarrier.handle, count, pred.handle)
+    pred = _semantic.to_tensor(pred)
+    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, pred.handle)

--- a/python/triton/experimental/gluon/language/nvidia/hopper/tma.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/tma.py
@@ -1,25 +1,23 @@
-from triton.language.semantic import _convert_to_ir_values
 from triton.experimental.gluon.language._core import builtin, _unwrap_if_constexpr
-import triton.experimental.gluon.language._core as ttgl
 
 __all__ = ["async_copy_global_to_shared", "async_copy_shared_to_global", "store_wait"]
 
 
 @builtin
-def async_copy_global_to_shared(tensor_desc, coord, barrier, result, pred=True, _builder=None):
-    coord = _convert_to_ir_values(_builder, coord, require_i64=False)
-    pred = ttgl.to_tensor(pred, _builder=_builder)
-    _builder.create_async_tma_copy_global_to_local(tensor_desc.handle, coord, barrier.handle, result.handle,
-                                                   pred.handle)
+def async_copy_global_to_shared(tensor_desc, coord, barrier, result, pred=True, _semantic=None):
+    coord = _semantic._convert_to_ir_values(coord, require_i64=False)
+    pred = _semantic.to_tensor(pred)
+    _semantic.builder.create_async_tma_copy_global_to_local(tensor_desc.handle, coord, barrier.handle, result.handle,
+                                                            pred.handle)
 
 
 @builtin
-def async_copy_shared_to_global(tensor_desc, coord, src, _builder=None):
-    coord = _convert_to_ir_values(_builder, coord, require_i64=False)
-    _builder.create_async_tma_copy_local_to_global(tensor_desc.handle, coord, src.handle)
+def async_copy_shared_to_global(tensor_desc, coord, src, _semantic=None):
+    coord = _semantic._convert_to_ir_values(coord, require_i64=False)
+    _semantic.builder.create_async_tma_copy_local_to_global(tensor_desc.handle, coord, src.handle)
 
 
 @builtin
-def store_wait(pendings, _builder=None):
+def store_wait(pendings, _semantic=None):
     pendings = _unwrap_if_constexpr(pendings)
-    _builder.create_async_tma_store_wait(pendings)
+    _semantic.builder.create_async_tma_store_wait(pendings)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -13,7 +13,6 @@ from ..runtime.jit import jit, JITFunction
 import inspect
 
 from .._C.libtriton import ir
-from . import semantic
 from .._utils import TRITON_MAX_TENSOR_NUMEL, validate_block_shape, get_primitive_bitwidth
 
 T = TypeVar('T')
@@ -37,9 +36,9 @@ def builtin(fn: T) -> T:
 
     @wraps(fn)
     def wrapper(*args, **kwargs):
-        if "_builder" not in kwargs or kwargs["_builder"] is None:
+        if "_semantic" not in kwargs or kwargs["_semantic"] is None:
             raise ValueError("Did you forget to add @triton.jit ? "
-                             "(`_builder` argument must be provided outside of JIT functions.)")
+                             "(`_semantic` argument must be provided outside of JIT functions.)")
         return fn(*args, **kwargs)
 
     setattr(wrapper, TRITON_BUILTIN, True)
@@ -62,8 +61,8 @@ def _tensor_member_fn(fn: T) -> T:
     """
     assert callable(fn)
     orig_sig = inspect.signature(fn)
-    # Does fn take args other than _builder, _generator, and the tensor itself?
-    has_args = len(orig_sig.parameters.keys() - {"_builder", "_generator"}) > 1
+    # Does fn take args other than _semantic, _generator, and the tensor itself?
+    has_args = len(orig_sig.parameters.keys() - {"_semantic", "_generator"}) > 1
 
     if not fn.__doc__:
         fn.__doc__ = ""
@@ -119,8 +118,8 @@ def is_builtin(fn) -> bool:
 
 
 @builtin
-def to_tensor(x, _builder=None):
-    return semantic.to_tensor(x, _builder)
+def to_tensor(x, _semantic=None):
+    return _semantic.to_tensor(x)
 
 
 # -----------------------
@@ -339,10 +338,10 @@ def constexpr_function(f):
     """
 
     @wraps(f)
-    def wrapper(*args, **kwargs):
-        # de-constexpr arguments and discard the _builder keyword argument:
+    def wrapper(*args, **kwargs, _semantic):
+        # de-constexpr arguments and discard the _semantic keyword argument:
         args = [_unwrap_if_constexpr(x) for x in args]
-        kwargs = {k: getattr(v, "value", v) for (k, v) in kwargs.items() if k != "_builder"}
+        kwargs = {k: _unwrap_if_constexpr(v) for (k, v) in kwargs.items()}
 
         # call the raw Python function f:
         res = f(*args, **kwargs)
@@ -886,213 +885,213 @@ class tensor(base_value):
         return str(self.dtype) + '[' + ', '.join(str(s) for s in self.shape) + ']'
 
     @builtin
-    def __add__(self, other, _builder=None):
-        return add(self, other, sanitize_overflow=True, _builder=_builder)
+    def __add__(self, other, _semantic=None):
+        return add(self, other, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
-    def __radd__(self, other, _builder=None):
-        return add(other, self, sanitize_overflow=True, _builder=_builder)
+    def __radd__(self, other, _semantic=None):
+        return add(other, self, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
-    def __sub__(self, other, _builder=None):
-        return sub(self, other, sanitize_overflow=True, _builder=_builder)
+    def __sub__(self, other, _semantic=None):
+        return sub(self, other, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
-    def __rsub__(self, other, _builder=None):
-        return sub(other, self, sanitize_overflow=True, _builder=_builder)
+    def __rsub__(self, other, _semantic=None):
+        return sub(other, self, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
-    def __mul__(self, other, _builder=None):
-        return mul(self, other, sanitize_overflow=True, _builder=_builder)
+    def __mul__(self, other, _semantic=None):
+        return mul(self, other, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
-    def __rmul__(self, other, _builder=None):
-        return mul(other, self, sanitize_overflow=True, _builder=_builder)
+    def __rmul__(self, other, _semantic=None):
+        return mul(other, self, sanitize_overflow=True, _semantic=_semantic)
 
     @builtin
-    def __truediv__(self, other, _builder=None):
+    def __truediv__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.truediv(self, other, _builder)
+        return _semantic.truediv(self, other)
 
     @builtin
-    def __rtruediv__(self, other, _builder=None):
+    def __rtruediv__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.truediv(other, self, _builder)
+        return _semantic.truediv(other, self)
 
     @builtin
-    def __floordiv__(self, other, _builder=None):
+    def __floordiv__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.floordiv(self, other, _builder)
+        return _semantic.floordiv(self, other)
 
     @builtin
-    def __rfloordiv__(self, other, _builder=None):
+    def __rfloordiv__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.floordiv(other, self, _builder)
+        return _semantic.floordiv(other, self)
 
     @builtin
-    def __mod__(self, other, _builder=None):
+    def __mod__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.mod(self, other, _builder)
+        return _semantic.mod(self, other)
 
     @builtin
-    def __rmod__(self, other, _builder=None):
+    def __rmod__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.mod(other, self, _builder)
+        return _semantic.mod(other, self)
 
     # unary operators
     @builtin
-    def __neg__(self, _builder=None):
-        return semantic.minus(self, _builder)
+    def __neg__(self, _semantic=None):
+        return _semantic.minus(self)
 
     @builtin
-    def __invert__(self, _builder=None):
-        return semantic.invert(self, _builder)
+    def __invert__(self, _semantic=None):
+        return _semantic.invert(self)
 
     # bitwise operators
 
     @builtin
-    def __and__(self, other, _builder=None):
+    def __and__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.and_(self, other, _builder)
+        return _semantic.and_(self, other)
 
     @builtin
-    def __rand__(self, other, _builder=None):
+    def __rand__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.and_(other, self, _builder)
+        return _semantic.and_(other, self)
 
     @builtin
-    def __or__(self, other, _builder=None):
+    def __or__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.or_(self, other, _builder)
+        return _semantic.or_(self, other)
 
     @builtin
-    def __ror__(self, other, _builder=None):
+    def __ror__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.or_(other, self, _builder)
+        return _semantic.or_(other, self)
 
     @builtin
-    def __xor__(self, other, _builder=None):
+    def __xor__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.xor_(self, other, _builder)
+        return _semantic.xor_(self, other)
 
     @builtin
-    def __rxor__(self, other, _builder=None):
+    def __rxor__(self, other, _semantic=None):
         other = _unwrap_if_constexpr(other)
-        return semantic.xor_(other, self, _builder)
+        return _semantic.xor_(other, self)
 
     @builtin
-    def __lshift__(self, other, _builder=None):
+    def __lshift__(self, other, _semantic=None):
         check_bit_width(self, other)
         other = _unwrap_if_constexpr(other)
-        return semantic.shl(self, other, _builder)
+        return _semantic.shl(self, other)
 
     @builtin
-    def __rlshift__(self, other, _builder=None):
+    def __rlshift__(self, other, _semantic=None):
         check_bit_width(other, self)
         other = _unwrap_if_constexpr(other)
-        return semantic.shl(other, self, _builder)
+        return _semantic.shl(other, self)
 
     @builtin
-    def __rshift__(self, other, _builder=None):
+    def __rshift__(self, other, _semantic=None):
         check_bit_width(self, other)
         other = _unwrap_if_constexpr(other)
         if self.dtype.is_int_signed():
-            return semantic.ashr(self, other, _builder)
+            return _semantic.ashr(self, other)
         else:
-            return semantic.lshr(self, other, _builder)
+            return _semantic.lshr(self, other)
 
     @builtin
-    def __rrshift__(self, other, _builder=None):
+    def __rrshift__(self, other, _semantic=None):
         check_bit_width(other, self)
         other = _unwrap_if_constexpr(other)
         if self.dtype.is_int_signed():
-            return semantic.ashr(other, self, _builder)
+            return _semantic.ashr(other, self)
         else:
-            return semantic.lshr(other, self, _builder)
+            return _semantic.lshr(other, self)
 
     # >
     @builtin
-    def __gt__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.greater_than(self, other, _builder)
+    def __gt__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.greater_than(self, other)
 
     @builtin
-    def __rgt__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.greater_than(other, self, _builder)
+    def __rgt__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.greater_than(other, self)
 
     # >=
     @builtin
-    def __ge__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.greater_equal(self, other, _builder)
+    def __ge__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.greater_equal(self, other)
 
     @builtin
-    def __rge__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.greater_equal(other, self, _builder)
+    def __rge__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.greater_equal(other, self)
 
     # <
     @builtin
-    def __lt__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.less_than(self, other, _builder)
+    def __lt__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.less_than(self, other)
 
     @builtin
-    def __rlt__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.less_than(other, self, _builder)
+    def __rlt__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.less_than(other, self)
 
     # <=
     @builtin
-    def __le__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.less_equal(self, other, _builder)
+    def __le__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.less_equal(self, other)
 
     @builtin
-    def __rle__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.less_equal(other, self, _builder)
+    def __rle__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.less_equal(other, self)
 
     # ==
     @builtin
-    def __eq__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.equal(self, other, _builder)
+    def __eq__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.equal(self, other)
 
     @builtin
-    def __req__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.equal(other, self, _builder)
+    def __req__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.equal(other, self)
 
     @builtin
-    def __ne__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.not_equal(self, other, _builder)
+    def __ne__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.not_equal(self, other)
 
     @builtin
-    def __rne__(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.not_equal(other, self, _builder)
+    def __rne__(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.not_equal(other, self)
 
     @builtin
-    def logical_and(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.logical_and(self, other, _builder)
+    def logical_and(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.logical_and(self, other)
 
     @builtin
-    def logical_or(self, other, _builder=None):
-        other = semantic.to_tensor(other, _builder)
-        return semantic.logical_or(self, other, _builder)
+    def logical_or(self, other, _semantic=None):
+        other = _semantic.to_tensor(other)
+        return _semantic.logical_or(self, other)
 
     # note: __not__ isn't actually a magic method in python
     # but it's ok because our ASTVisitor handles it
     @builtin
-    def __not__(self, _builder=None):
-        return semantic.not_(self, _builder)
+    def __not__(self, _semantic=None):
+        return _semantic.not_(self)
 
     @builtin
-    def __getitem__(self, slices, _builder=None):
+    def __getitem__(self, slices, _semantic=None):
         if isinstance(slices, (builtins.slice, slice, constexpr)) or slices is None:
             slices = [slices]
         if isinstance(slices, tuple):
@@ -1100,7 +1099,7 @@ class tensor(base_value):
         ret = self
         for dim, sl in enumerate(slices):
             if _unwrap_if_constexpr(sl) is None:
-                ret = semantic.expand_dims(ret, dim, _builder)
+                ret = _semantic.expand_dims(ret, dim)
             elif isinstance(sl, (builtins.slice, slice)) and all(
                     _unwrap_if_constexpr(arg) is None for arg in (sl.start, sl.stop, sl.step)):
                 pass  # an unsqueeze
@@ -1114,11 +1113,11 @@ class tensor(base_value):
         assert False, "Transposition must be created by the AST Visitor"
 
     @builtin
-    def to(self, dtype: dtype, fp_downcast_rounding: Optional[str] = None, bitcast: bool = False, _builder=None):
+    def to(self, dtype: dtype, fp_downcast_rounding: Optional[str] = None, bitcast: bool = False, _semantic=None):
         """
         Alias for :py:func:`tensor.cast`.
         """
-        return cast(self, dtype, fp_downcast_rounding, bitcast, _builder=_builder)
+        return cast(self, dtype, fp_downcast_rounding, bitcast, _semantic=_semantic)
 
     # Type stubs for functions added by the _tensor_member_fn decorator.
     # (Unfortunately these can't be created automatically.)
@@ -1393,64 +1392,64 @@ class tensor_descriptor_base(base_value):
         return str(self.type)
 
     @builtin
-    def load(self, offsets: Sequence[constexpr | tensor], _builder=None) -> tensor:
+    def load(self, offsets: Sequence[constexpr | tensor], _semantic=None) -> tensor:
         """Load a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be filled with zeros.
 
         :note: Offset must be a multiple of 16-bytes
         """
-        return semantic.descriptor_load(self, offsets, "", "", _builder)
+        return _semantic.descriptor_load(self, offsets, "", "")
 
     @builtin
-    def store(self, offsets: Sequence[constexpr | tensor], value: tensor, _builder=None) -> tensor:
+    def store(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:
         """Store a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be ignored.
 
         :note: Offset must be a multiple of 16-bytes
         """
-        return semantic.descriptor_store(self, value, offsets, _builder)
+        return _semantic.descriptor_store(self, value, offsets)
 
     @builtin
-    def atomic_add(self, offsets: Sequence[constexpr | tensor], value: tensor, _builder=None) -> tensor:
-        return semantic.descriptor_atomic_add(self, value, offsets, _builder)
+    def atomic_add(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:
+        return _semantic.descriptor_atomic_add(self, value, offsets)
 
     @builtin
-    def atomic_min(self, offsets: Sequence[constexpr | tensor], value: tensor, _builder=None) -> tensor:
-        return semantic.descriptor_atomic_min(self, value, offsets, _builder)
+    def atomic_min(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:
+        return _semantic.descriptor_atomic_min(self, value, offsets)
 
     @builtin
-    def atomic_max(self, offsets: Sequence[constexpr | tensor], value: tensor, _builder=None) -> tensor:
-        return semantic.descriptor_atomic_max(self, value, offsets, _builder)
+    def atomic_max(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:
+        return _semantic.descriptor_atomic_max(self, value, offsets)
 
     @builtin
-    def atomic_and(self, offsets: Sequence[constexpr | tensor], value: tensor, _builder=None) -> tensor:
-        return semantic.descriptor_atomic_and(self, value, offsets, _builder)
+    def atomic_and(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:
+        return _semantic.descriptor_atomic_and(self, value, offsets)
 
     @builtin
-    def atomic_or(self, offsets: Sequence[constexpr | tensor], value: tensor, _builder=None) -> tensor:
-        return semantic.descriptor_atomic_or(self, value, offsets, _builder)
+    def atomic_or(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:
+        return _semantic.descriptor_atomic_or(self, value, offsets)
 
     @builtin
-    def atomic_xor(self, offsets: Sequence[constexpr | tensor], value: tensor, _builder=None) -> tensor:
-        return semantic.descriptor_atomic_xor(self, value, offsets, _builder)
+    def atomic_xor(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:
+        return _semantic.descriptor_atomic_xor(self, value, offsets)
 
     @builtin
-    def gather(self, *args, _builder=None) -> tensor:
+    def gather(self, *args, _semantic=None) -> tensor:
         """Gather multiple descriptors worth of data"""
         assert len(args) == 2, f"descriptor gather only supports 2D indexing, but got {len(args)}"
         x_offsets = args[0]
         y_offset = args[1]
-        return semantic.descriptor_gather(self, x_offsets, y_offset, "", "", _builder)
+        return _semantic.descriptor_gather(self, x_offsets, y_offset, "", "")
 
     @builtin
-    def scatter(self, value, *args, _builder=None) -> tensor:
+    def scatter(self, value, *args, _semantic=None) -> tensor:
         """Scatter multiple descriptors worth of data"""
         assert len(args) == 2, f"descriptor scatter only supports 2D indexing, but got {len(args)}"
         x_offsets = args[0]
         y_offset = args[1]
-        return semantic.descriptor_scatter(self, value, x_offsets, y_offset, _builder)
+        return _semantic.descriptor_scatter(self, value, x_offsets, y_offset)
 
 
 class tensor_descriptor_type(tensor_descriptor_base_type):
@@ -1547,14 +1546,14 @@ def _aggregate(cls):
         def _get_instance(this_cls):
             return super().__new__(this_cls)
 
-        def __new__(this_cls, *args, _builder=None, _generator=None, **kwargs):
+        def __new__(this_cls, *args, _semantic=None, _generator=None, **kwargs):
             # Call into the user-defined constructor.
             instance = this_cls._get_instance()
             if isinstance(cls.__init__, JITFunction):
                 raise ValueError(f"{cls.__name__}.__init__ cannot be a @triton.jit function")
             extra_kwargs = {}
-            if "_builder" in inspect.signature(cls.__init__).parameters:
-                extra_kwargs["_builder"] = _builder
+            if "_semantic" in inspect.signature(cls.__init__).parameters:
+                extra_kwargs["_semantic"] = _semantic
             if "_generator" in inspect.signature(cls.__init__).parameters:
                 extra_kwargs["_generator"] = _generator
             cls.__init__(instance, *args, **extra_kwargs, **kwargs)
@@ -1602,7 +1601,7 @@ def _aggregate(cls):
 
 
 @builtin
-def program_id(axis, _builder=None):
+def program_id(axis, _semantic=None):
     """
     Returns the id of the current program instance along the given :code:`axis`.
 
@@ -1610,18 +1609,18 @@ def program_id(axis, _builder=None):
     :type axis: int
     """
     # if axis == -1:
-    #     pid0 = program_id(0, _builder)
-    #     pid1 = program_id(1, _builder)
-    #     pid2 = program_id(2, _builder)
-    #     npg0 = num_programs(0, _builder)
-    #     npg1 = num_programs(1, _builder)
+    #     pid0 = _semantic.program_id(0)
+    #     pid1 = _semantic.program_id(1)
+    #     pid2 = _semantic.program_id(2)
+    #     npg0 = _semantic.num_programs(0)
+    #     npg1 = _semantic.num_programs(1)
     #     return pid0 + pid1*npg0 + pid2*npg0*npg1
     axis = _unwrap_if_constexpr(axis)
-    return semantic.program_id(axis, _builder)
+    return _semantic.program_id(axis)
 
 
 @builtin
-def num_programs(axis, _builder=None):
+def num_programs(axis, _semantic=None):
     """
     Returns the number of program instances launched along the given :code:`axis`.
 
@@ -1629,7 +1628,7 @@ def num_programs(axis, _builder=None):
     :type axis: int
     """
     axis = _unwrap_if_constexpr(axis)
-    return semantic.num_programs(axis, _builder)
+    return _semantic.num_programs(axis)
 
 
 # -----------------------
@@ -1638,10 +1637,10 @@ def num_programs(axis, _builder=None):
 
 
 @builtin
-def arange(start, end, _builder=None):
+def arange(start, end, _semantic=None):
     start = _unwrap_if_constexpr(start)
     end = _unwrap_if_constexpr(end)
-    return semantic.arange(start, end, _builder)
+    return _semantic.arange(start, end)
 
 
 arange.__doc__ = f"""
@@ -1669,7 +1668,7 @@ def _shape_check_impl(shape):
 
 
 @builtin
-def full(shape, value, dtype, _builder=None):
+def full(shape, value, dtype, _semantic=None):
     """
     Returns a tensor filled with the scalar value for the given :code:`shape` and :code:`dtype`.
 
@@ -1683,7 +1682,7 @@ def full(shape, value, dtype, _builder=None):
     shape = _shape_check_impl(shape)
     value = _unwrap_if_constexpr(value)
     dtype = _unwrap_if_constexpr(dtype)
-    return semantic.full(shape, value, dtype, _builder)
+    return _semantic.full(shape, value, dtype)
 
 
 # -----------------------
@@ -1692,7 +1691,7 @@ def full(shape, value, dtype, _builder=None):
 
 
 @builtin
-def broadcast(input, other, _builder=None):
+def broadcast(input, other, _semantic=None):
     """
     Tries to broadcast the two given blocks to a common compatible shape.
 
@@ -1701,12 +1700,12 @@ def broadcast(input, other, _builder=None):
     :param other: The second input tensor.
     :type other: Block
     """
-    return semantic.broadcast_impl_value(input, other, _builder)
+    return _semantic.broadcast_impl_value(input, other)
 
 
 @_tensor_member_fn
 @builtin
-def broadcast_to(input, *shape, _builder=None):
+def broadcast_to(input, *shape, _semantic=None):
     """
     Tries to broadcast the given tensor to a new :code:`shape`.
 
@@ -1722,12 +1721,12 @@ def broadcast_to(input, *shape, _builder=None):
         broadcast_to(x, 32, 32)
     """
     shape = _shape_check_impl(_unwrap_iterable(shape))
-    return semantic.broadcast_impl_shape(input, shape, _builder)
+    return _semantic.broadcast_impl_shape(input, shape)
 
 
 @_tensor_member_fn
 @builtin
-def trans(input: tensor, *dims, _builder=None):
+def trans(input: tensor, *dims, _semantic=None):
     """
     Permutes the dimensions of a tensor.
 
@@ -1750,12 +1749,12 @@ def trans(input: tensor, *dims, _builder=None):
     dims = _unwrap_iterable(dims)
     if not dims:
         dims = (1, 0)
-    return semantic.permute(input, dims, _builder)
+    return _semantic.permute(input, dims)
 
 
 @_tensor_member_fn
 @builtin
-def permute(input, *dims, _builder=None):
+def permute(input, *dims, _semantic=None):
     """
     Permutes the dimensions of a tensor.
 
@@ -1774,11 +1773,11 @@ def permute(input, *dims, _builder=None):
     :code:`dims` is empty, it tries to do a (1,0) permutation.
     """
     dims = _unwrap_iterable(dims)
-    return semantic.permute(input, dims, _builder)
+    return _semantic.permute(input, dims)
 
 
 @builtin
-def cat(input, other, can_reorder=False, _builder=None):
+def cat(input, other, can_reorder=False, _semantic=None):
     """
     Concatenate the given blocks
 
@@ -1791,11 +1790,11 @@ def cat(input, other, can_reorder=False, _builder=None):
         order does not matter (e.g., result is only used in reduction ops).
         Current implementation of `cat` supports only can_reorder=True.
     """
-    return semantic.cat(input, other, can_reorder, _builder)
+    return _semantic.cat(input, other, can_reorder)
 
 
 @builtin
-def join(a, b, _builder=None):
+def join(a, b, _semantic=None):
     """
     Join the given tensors in a new, minor dimension.
 
@@ -1815,7 +1814,7 @@ def join(a, b, _builder=None):
     :param b: The second input tensor.
     :type b: Tensor
     """
-    return semantic.join(a, b, _builder)
+    return _semantic.join(a, b)
 
 
 @jit
@@ -1823,7 +1822,7 @@ def _take_first(a, b):
     return a
 
 
-def _unsplat(x, _builder=None, _generator=None):
+def _unsplat(x, _semantic=None, _generator=None):
     """
     Convert a single-element tensor to a scalar.
     """
@@ -1834,14 +1833,14 @@ def _unsplat(x, _builder=None, _generator=None):
         numel *= d
     assert numel == 1, "can only unsplat single-element tensors"
     if len(x.shape) >= 2:
-        x = semantic.reshape(x, [1], builder=_builder)
-    x = typing.cast(tensor, reduce(x, 0, _take_first, _builder=_builder, _generator=_generator))
+        x = _semantic.reshape(x, [1])
+    x = typing.cast(tensor, reduce(x, 0, _take_first, _semantic=_semantic, _generator=_generator))
     return x
 
 
 @_tensor_member_fn
 @builtin
-def split(a, _builder=None, _generator=None) -> tuple[tensor, tensor]:
+def split(a, _semantic=None, _generator=None) -> tuple[tensor, tensor]:
     """
     Split a tensor in two along its last dim, which must have size 2.
 
@@ -1858,25 +1857,25 @@ def split(a, _builder=None, _generator=None) -> tuple[tensor, tensor]:
     :type a: Tensor
     """
     # If len(a.shape) == 1, i.e. a.shape == [2], we should return two scalars.
-    # But semantic.split can only handle returning tensors.  Work around this by
+    # But _semantic.split can only handle returning tensors.  Work around this by
     # expanding the input to shape [1,2] and then reducing the result.
     was_rank_1 = len(a.shape) == 1
     if was_rank_1:
-        a = semantic.expand_dims(a, 0, _builder)
+        a = _semantic.expand_dims(a, 0)
 
-    out_lhs, out_rhs = semantic.split(a, _builder)
+    out_lhs, out_rhs = _semantic.split(a)
 
     if was_rank_1:
         # Currently `reduce` is the best way to convert a tensor of shape [1] to a scalar.
-        out_lhs = _unsplat(out_lhs, _builder, _generator)
-        out_rhs = _unsplat(out_rhs, _builder, _generator)
+        out_lhs = _unsplat(out_lhs, _semantic=_semantic, _generator=_generator)
+        out_rhs = _unsplat(out_rhs, _semantic=_semantic, _generator=_generator)
 
     return out_lhs, out_rhs
 
 
 @_tensor_member_fn
 @builtin
-def view(input, *shape, _builder=None):
+def view(input, *shape, _semantic=None):
     """
     Returns a tensor with the same elements as `input` but a different shape.
     The order of the elements may not be preserved.
@@ -1893,21 +1892,21 @@ def view(input, *shape, _builder=None):
     """
     warn("view is deprecated, please use reshape with can_reorder being true.")
     shape = _shape_check_impl(_unwrap_iterable(shape))
-    return semantic.reshape(input, shape, can_reorder=True, builder=_builder)
+    return _semantic.reshape(input, shape, can_reorder=True)
 
 
 @_tensor_member_fn
 @builtin
-def item(input, _builder=None, _generator=None):
+def item(input, _semantic=None, _generator=None):
     """
     Converts a single-element tensor into a scalar.
     """
-    return _unsplat(input, _builder=_builder, _generator=_generator)
+    return _unsplat(input, _semantic=_semantic, _generator=_generator)
 
 
 @_tensor_member_fn
 @builtin
-def reshape(input, *shape, can_reorder=False, _builder=None, _generator=None):
+def reshape(input, *shape, can_reorder=False, _semantic=None, _generator=None):
     """
     Returns a tensor with the same number of elements as input but with the
     provided shape.
@@ -1924,8 +1923,8 @@ def reshape(input, *shape, can_reorder=False, _builder=None, _generator=None):
     """
     shape = _shape_check_impl(_unwrap_iterable(shape))
     if len(shape) == 0:
-        return _unsplat(input, _builder=_builder, _generator=_generator)
-    return semantic.reshape(input, shape, can_reorder, _builder)
+        return _unsplat(input, _semantic=_semantic, _generator=_generator)
+    return _semantic.reshape(input, shape, can_reorder)
 
 
 def _wrap_axis(axis, ndim):
@@ -1937,7 +1936,7 @@ def _wrap_axis(axis, ndim):
 
 @_tensor_member_fn
 @builtin
-def expand_dims(input, axis, _builder=None):
+def expand_dims(input, axis, _semantic=None):
     """
     Expand the shape of a tensor, by inserting new length-1 dimensions.
 
@@ -1950,7 +1949,7 @@ def expand_dims(input, axis, _builder=None):
     :type axis: int | Sequence[int]
 
     """
-    input = semantic.to_tensor(input, _builder)
+    input = _semantic.to_tensor(input)
     axis = _unwrap_if_constexpr(axis)
     axes = list(axis) if isinstance(axis, (Sequence, tuple)) else [axis]
     new_ndim = len(input.shape) + len(axes)
@@ -1961,13 +1960,13 @@ def expand_dims(input, axis, _builder=None):
 
     ret = input
     for a in sorted(axes):
-        ret = semantic.expand_dims(ret, a, _builder)
+        ret = _semantic.expand_dims(ret, a)
     return ret
 
 
 @_tensor_member_fn
 @builtin
-def cast(input, dtype: dtype, fp_downcast_rounding: Optional[str] = None, bitcast: bool = False, _builder=None):
+def cast(input, dtype: dtype, fp_downcast_rounding: Optional[str] = None, bitcast: bool = False, _semantic=None):
     """
     Casts a tensor to the given :code:`dtype`.
 
@@ -1983,13 +1982,13 @@ def cast(input, dtype: dtype, fp_downcast_rounding: Optional[str] = None, bitcas
         :code:`dtype`, instead of being numerically casted.
     :type bitcast: bool, optional
     """
-    input = semantic.to_tensor(input, _builder)
+    input = _semantic.to_tensor(input)
     dtype = _unwrap_if_constexpr(dtype)
     fp_downcast_rounding = _unwrap_if_constexpr(fp_downcast_rounding)
     bitcast = _unwrap_if_constexpr(bitcast)
     if bitcast:
-        return semantic.bitcast(input, dtype, _builder)
-    return semantic.cast(input, dtype, _builder, fp_downcast_rounding)
+        return _semantic.bitcast(input, dtype)
+    return _semantic.cast(input, dtype, fp_downcast_rounding)
 
 
 # -----------------------
@@ -1999,7 +1998,7 @@ def cast(input, dtype: dtype, fp_downcast_rounding: Optional[str] = None, bitcas
 
 @builtin
 def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_imprecise_acc=None, out_dtype=float32,
-        _builder=None):
+        _semantic=None):
     """
     Returns the matrix product of two blocks.
 
@@ -2024,19 +2023,19 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
     """
     assert input_precision is None or allow_tf32 is None, "Only one of input_precision and allow_tf32 can be specified"
     if input_precision is None:
-        supports_tf32 = _builder and "tf32" in _builder.options.allowed_dot_input_precisions
+        supports_tf32 = "tf32" in _semantic.builder.options.allowed_dot_input_precisions
         input_precision = knobs.language.fp32_default or ("tf32" if (supports_tf32 and
                                                                      (allow_tf32 or allow_tf32 is None)) else "ieee")
 
     input_precision = _unwrap_if_constexpr(input_precision)
     out_dtype = _unwrap_if_constexpr(out_dtype)
     max_num_imprecise_acc = _unwrap_if_constexpr(max_num_imprecise_acc)
-    return semantic.dot(input, other, acc, input_precision, max_num_imprecise_acc, out_dtype, _builder)
+    return _semantic.dot(input, other, acc, input_precision, max_num_imprecise_acc, out_dtype)
 
 
 @builtin
 def dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=None, fast_math=False, lhs_k_pack=True,
-               rhs_k_pack=True, out_dtype=float32, _builder=None):
+               rhs_k_pack=True, out_dtype=float32, _semantic=None):
     """
     Returns the matrix product of two blocks in microscaling format.
 
@@ -2070,8 +2069,8 @@ def dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=None,
     """
     out_dtype = _unwrap_if_constexpr(out_dtype)
     assert out_dtype == float32, "Only float32 is supported for out_dtype at the moment"
-    return semantic.dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc, fast_math, lhs_k_pack,
-                               rhs_k_pack, out_dtype, _builder)
+    return _semantic.dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc, fast_math, lhs_k_pack,
+                                rhs_k_pack, out_dtype)
 
 
 # -----------------------
@@ -2081,7 +2080,7 @@ def dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=None,
 
 @builtin
 def load(pointer, mask=None, other=None, boundary_check=(), padding_option="", cache_modifier="", eviction_policy="",
-         volatile=False, _builder=None):
+         volatile=False, _semantic=None):
     """
     Return a tensor of data whose values are loaded from memory at location defined by `pointer`:
 
@@ -2129,34 +2128,34 @@ def load(pointer, mask=None, other=None, boundary_check=(), padding_option="", c
     mask = _unwrap_if_constexpr(mask)
     other = _unwrap_if_constexpr(other)
     if mask is not None:
-        mask = semantic.to_tensor(mask, _builder)
+        mask = _semantic.to_tensor(mask)
     if other is not None:
-        other = semantic.to_tensor(other, _builder)
+        other = _semantic.to_tensor(other)
     padding_option = _unwrap_if_constexpr(padding_option)
     cache_modifier = _unwrap_if_constexpr(cache_modifier)
     eviction_policy = _unwrap_if_constexpr(eviction_policy)
     volatile = _unwrap_if_constexpr(volatile)
-    return semantic.load(pointer, mask, other, boundary_check, padding_option, cache_modifier, eviction_policy,
-                         volatile, _builder)
+    return _semantic.load(pointer, mask, other, boundary_check, padding_option, cache_modifier, eviction_policy,
+                          volatile)
 
 
 @builtin
 def load_tensor_descriptor(desc: tensor_descriptor_base, offsets: Sequence[constexpr | tensor],
-                           _builder=None) -> tensor:
+                           _semantic=None) -> tensor:
     """Load a block of data from a tensor descriptor."""
-    return desc.load(offsets, _builder=_builder)
+    return desc.load(offsets, _semantic=_semantic)
 
 
 @builtin
 def store_tensor_descriptor(desc: tensor_descriptor_base, offsets: Sequence[constexpr | tensor], value: tensor,
-                            _builder=None) -> tensor:
+                            _semantic=None) -> tensor:
     """Store a block of data to a tensor descriptor."""
-    return desc.store(offsets, value, _builder=_builder)
+    return desc.store(offsets, value, _semantic=_semantic)
 
 
 @_tensor_member_fn
 @builtin
-def store(pointer, value, mask=None, boundary_check=(), cache_modifier="", eviction_policy="", _builder=None):
+def store(pointer, value, mask=None, boundary_check=(), cache_modifier="", eviction_policy="", _semantic=None):
     """
     Store a tensor of data into memory locations defined by `pointer`.
 
@@ -2196,17 +2195,17 @@ def store(pointer, value, mask=None, boundary_check=(), cache_modifier="", evict
     :type eviction_policy: str, optional, should be one of {"", "evict_first", "evict_last"}
     """
     # `value` can be constexpr
-    value = semantic.to_tensor(value, _builder)
+    value = _semantic.to_tensor(value)
     mask = _unwrap_if_constexpr(mask)
     if mask is not None:
-        mask = semantic.to_tensor(mask, _builder)
+        mask = _semantic.to_tensor(mask)
     cache_modifier = _unwrap_if_constexpr(cache_modifier)
     eviction_policy = _unwrap_if_constexpr(eviction_policy)
-    return semantic.store(pointer, value, mask, boundary_check, cache_modifier, eviction_policy, _builder)
+    return _semantic.store(pointer, value, mask, boundary_check, cache_modifier, eviction_policy)
 
 
 @builtin
-def make_block_ptr(base: tensor, shape, strides, offsets, block_shape, order, _builder=None):
+def make_block_ptr(base: tensor, shape, strides, offsets, block_shape, order, _semantic=None):
     """
     Returns a pointer to a block in a parent tensor
 
@@ -2217,7 +2216,7 @@ def make_block_ptr(base: tensor, shape, strides, offsets, block_shape, order, _b
     :param block_shape: The shape of the block
     :param order: The order of the original data format
     """
-    return semantic.make_block_ptr(base, shape, strides, offsets, block_shape, order, _builder)
+    return _semantic.make_block_ptr(base, shape, strides, offsets, block_shape, order)
 
 
 @must_use_result(
@@ -2225,14 +2224,14 @@ def make_block_ptr(base: tensor, shape, strides, offsets, block_shape, order, _b
 )
 @_tensor_member_fn
 @builtin
-def advance(base, offsets, _builder=None):
+def advance(base, offsets, _semantic=None):
     """
     Advance a block pointer
 
     :param base: the block pointer to advance
     :param offsets: the offsets to advance, a tuple by dimension
     """
-    return semantic.advance(base, offsets, _builder)
+    return _semantic.advance(base, offsets)
 
 
 @builtin
@@ -2241,7 +2240,7 @@ def make_tensor_descriptor(
     shape: List[tensor],
     strides: List[tensor],
     block_shape: List[constexpr],
-    _builder=None,
+    _semantic=None,
 ) -> tensor_descriptor:
     """Make a tensor descriptor object
 
@@ -2290,7 +2289,7 @@ def make_tensor_descriptor(
         inplace_abs[grid](x, M, N, M_BLOCK, N_BLOCK)
 
     """
-    return semantic.make_tensor_descriptor(base, shape, strides, block_shape, _builder)
+    return _semantic.make_tensor_descriptor(base, shape, strides, block_shape)
 
 
 # -----------------------
@@ -2332,89 +2331,89 @@ def _add_atomic_docstr(name: str, has_cmp: bool = False) -> Callable[[T], T]:
 @_tensor_member_fn
 @builtin
 @_add_atomic_docstr("compare-and-swap", has_cmp=True)
-def atomic_cas(pointer, cmp, val, sem=None, scope=None, _builder=None):
-    cmp = semantic.to_tensor(cmp, _builder)
-    val = semantic.to_tensor(val, _builder)
+def atomic_cas(pointer, cmp, val, sem=None, scope=None, _semantic=None):
+    cmp = _semantic.to_tensor(cmp)
+    val = _semantic.to_tensor(val)
     sem = _unwrap_if_constexpr(sem)
     scope = _unwrap_if_constexpr(scope)
-    return semantic.atomic_cas(pointer, cmp, val, sem, scope, _builder)
+    return _semantic.atomic_cas(pointer, cmp, val, sem, scope)
 
 
 @_tensor_member_fn
 @builtin
 @_add_atomic_docstr("exchange")
-def atomic_xchg(pointer, val, mask=None, sem=None, scope=None, _builder=None):
-    val = semantic.to_tensor(val, _builder)
+def atomic_xchg(pointer, val, mask=None, sem=None, scope=None, _semantic=None):
+    val = _semantic.to_tensor(val)
     sem = _unwrap_if_constexpr(sem)
     scope = _unwrap_if_constexpr(scope)
     mask = _unwrap_if_constexpr(mask)
-    return semantic.atomic_xchg(pointer, val, mask, sem, scope, _builder)
+    return _semantic.atomic_xchg(pointer, val, mask, sem, scope)
 
 
 @_tensor_member_fn
 @builtin
 @_add_atomic_docstr("add")
-def atomic_add(pointer, val, mask=None, sem=None, scope=None, _builder=None):
-    val = semantic.to_tensor(val, _builder)
+def atomic_add(pointer, val, mask=None, sem=None, scope=None, _semantic=None):
+    val = _semantic.to_tensor(val)
     sem = _unwrap_if_constexpr(sem)
     scope = _unwrap_if_constexpr(scope)
     mask = _unwrap_if_constexpr(mask)
-    return semantic.atomic_add(pointer, val, mask, sem, scope, _builder)
+    return _semantic.atomic_add(pointer, val, mask, sem, scope)
 
 
 @_tensor_member_fn
 @builtin
 @_add_atomic_docstr("max")
-def atomic_max(pointer, val, mask=None, sem=None, scope=None, _builder=None):
-    val = semantic.to_tensor(val, _builder)
+def atomic_max(pointer, val, mask=None, sem=None, scope=None, _semantic=None):
+    val = _semantic.to_tensor(val)
     sem = _unwrap_if_constexpr(sem)
     scope = _unwrap_if_constexpr(scope)
     mask = _unwrap_if_constexpr(mask)
-    return semantic.atomic_max(pointer, val, mask, sem, scope, _builder)
+    return _semantic.atomic_max(pointer, val, mask, sem, scope)
 
 
 @_tensor_member_fn
 @builtin
 @_add_atomic_docstr("min")
-def atomic_min(pointer, val, mask=None, sem=None, scope=None, _builder=None):
-    val = semantic.to_tensor(val, _builder)
+def atomic_min(pointer, val, mask=None, sem=None, scope=None, _semantic=None):
+    val = _semantic.to_tensor(val)
     sem = _unwrap_if_constexpr(sem)
     scope = _unwrap_if_constexpr(scope)
     mask = _unwrap_if_constexpr(mask)
-    return semantic.atomic_min(pointer, val, mask, sem, scope, _builder)
+    return _semantic.atomic_min(pointer, val, mask, sem, scope)
 
 
 @_tensor_member_fn
 @builtin
 @_add_atomic_docstr("logical and")
-def atomic_and(pointer, val, mask=None, sem=None, scope=None, _builder=None):
-    val = semantic.to_tensor(val, _builder)
+def atomic_and(pointer, val, mask=None, sem=None, scope=None, _semantic=None):
+    val = _semantic.to_tensor(val)
     sem = _unwrap_if_constexpr(sem)
     scope = _unwrap_if_constexpr(scope)
     mask = _unwrap_if_constexpr(mask)
-    return semantic.atomic_and(pointer, val, mask, sem, scope, _builder)
+    return _semantic.atomic_and(pointer, val, mask, sem, scope)
 
 
 @_tensor_member_fn
 @builtin
 @_add_atomic_docstr("logical or")
-def atomic_or(pointer, val, mask=None, sem=None, scope=None, _builder=None):
-    val = semantic.to_tensor(val, _builder)
+def atomic_or(pointer, val, mask=None, sem=None, scope=None, _semantic=None):
+    val = _semantic.to_tensor(val)
     sem = _unwrap_if_constexpr(sem)
     scope = _unwrap_if_constexpr(scope)
     mask = _unwrap_if_constexpr(mask)
-    return semantic.atomic_or(pointer, val, mask, sem, scope, _builder)
+    return _semantic.atomic_or(pointer, val, mask, sem, scope)
 
 
 @_tensor_member_fn
 @builtin
 @_add_atomic_docstr("logical xor")
-def atomic_xor(pointer, val, mask=None, sem=None, scope=None, _builder=None):
-    val = semantic.to_tensor(val, _builder)
+def atomic_xor(pointer, val, mask=None, sem=None, scope=None, _semantic=None):
+    val = _semantic.to_tensor(val)
     sem = _unwrap_if_constexpr(sem)
     scope = _unwrap_if_constexpr(scope)
     mask = _unwrap_if_constexpr(mask)
-    return semantic.atomic_xor(pointer, val, mask, sem, scope, _builder)
+    return _semantic.atomic_xor(pointer, val, mask, sem, scope)
 
 
 # -----------------------
@@ -2423,7 +2422,7 @@ def atomic_xor(pointer, val, mask=None, sem=None, scope=None, _builder=None):
 
 
 @builtin
-def where(condition, x, y, _builder=None):
+def where(condition, x, y, _semantic=None):
     """
     Returns a tensor of elements from either :code:`x` or :code:`y`, depending on :code:`condition`.
 
@@ -2439,10 +2438,10 @@ def where(condition, x, y, _builder=None):
     :param x: values selected at indices where condition is True.
     :param y: values selected at indices where condition is False.
     """
-    condition = semantic.to_tensor(condition, _builder)
+    condition = _semantic.to_tensor(condition)
     x = _unwrap_if_constexpr(x)
     y = _unwrap_if_constexpr(y)
-    return semantic.where(condition, x, y, _builder)
+    return _semantic.where(condition, x, y)
 
 
 # -----------------------
@@ -2451,28 +2450,28 @@ def where(condition, x, y, _builder=None):
 
 
 @builtin
-def add(x, y, sanitize_overflow: constexpr = True, _builder=None):
+def add(x, y, sanitize_overflow: constexpr = True, _semantic=None):
     x = _unwrap_if_constexpr(x)
     y = _unwrap_if_constexpr(y)
-    return semantic.add(x, y, sanitize_overflow, _builder)
+    return _semantic.add(x, y, sanitize_overflow)
 
 
 @builtin
-def sub(x, y, sanitize_overflow: constexpr = True, _builder=None):
+def sub(x, y, sanitize_overflow: constexpr = True, _semantic=None):
     x = _unwrap_if_constexpr(x)
     y = _unwrap_if_constexpr(y)
-    return semantic.sub(x, y, sanitize_overflow, _builder)
+    return _semantic.sub(x, y, sanitize_overflow)
 
 
 @builtin
-def mul(x, y, sanitize_overflow: constexpr = True, _builder=None):
+def mul(x, y, sanitize_overflow: constexpr = True, _semantic=None):
     x = _unwrap_if_constexpr(x)
     y = _unwrap_if_constexpr(y)
-    return semantic.mul(x, y, sanitize_overflow, _builder)
+    return _semantic.mul(x, y, sanitize_overflow)
 
 
 @builtin
-def minimum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _builder=None):
+def minimum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _semantic=None):
     """
     Computes the element-wise minimum of :code:`x` and :code:`y`.
 
@@ -2485,16 +2484,16 @@ def minimum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _builder=None):
 
     .. seealso:: :class:`tl.PropagateNan`
     """
-    x = semantic.to_tensor(x, _builder)
-    y = semantic.to_tensor(y, _builder)
-    x = _promote_bfloat16_to_float32(x, _builder=_builder)
-    y = _promote_bfloat16_to_float32(y, _builder=_builder)
+    x = _semantic.to_tensor(x)
+    y = _semantic.to_tensor(y)
+    x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
+    y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
-    return semantic.minimum(x, y, propagate_nan, _builder)
+    return _semantic.minimum(x, y, propagate_nan)
 
 
 @builtin
-def maximum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _builder=None):
+def maximum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _semantic=None):
     """
     Computes the element-wise maximum of :code:`x` and :code:`y`.
 
@@ -2507,16 +2506,16 @@ def maximum(x, y, propagate_nan: constexpr = PropagateNan.NONE, _builder=None):
 
     .. seealso:: :class:`tl.PropagateNan`
     """
-    x = semantic.to_tensor(x, _builder)
-    y = semantic.to_tensor(y, _builder)
-    x = _promote_bfloat16_to_float32(x, _builder=_builder)
-    y = _promote_bfloat16_to_float32(y, _builder=_builder)
+    x = _semantic.to_tensor(x)
+    y = _semantic.to_tensor(y)
+    x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
+    y = _promote_bfloat16_to_float32(y, _semantic=_semantic)
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
-    return semantic.maximum(x, y, propagate_nan, _builder)
+    return _semantic.maximum(x, y, propagate_nan)
 
 
 @builtin
-def clamp(x, min, max, propagate_nan: constexpr = PropagateNan.NONE, _builder=None):
+def clamp(x, min, max, propagate_nan: constexpr = PropagateNan.NONE, _semantic=None):
     """
     Clamps the input tensor :code:`x` within the range [min, max].
     Behavior when :code:`min` > :code:`max` is undefined.
@@ -2533,16 +2532,16 @@ def clamp(x, min, max, propagate_nan: constexpr = PropagateNan.NONE, _builder=No
 
     .. seealso:: :class:`tl.PropagateNan`
     """
-    x = semantic.to_tensor(x, _builder)
-    min = semantic.to_tensor(min, _builder)
-    max = semantic.to_tensor(max, _builder)
-    x = _promote_bfloat16_to_float32(x, _builder=_builder)
-    min = _promote_bfloat16_to_float32(min, _builder=_builder)
-    max = _promote_bfloat16_to_float32(max, _builder=_builder)
+    x = _semantic.to_tensor(x)
+    min = _semantic.to_tensor(min)
+    max = _semantic.to_tensor(max)
+    x = _promote_bfloat16_to_float32(x, _semantic=_semantic)
+    min = _promote_bfloat16_to_float32(min, _semantic=_semantic)
+    max = _promote_bfloat16_to_float32(max, _semantic=_semantic)
 
     propagate_nan = _unwrap_if_constexpr(propagate_nan)
 
-    return semantic.clamp(x, min, max, propagate_nan, _builder)
+    return _semantic.clamp(x, min, max, propagate_nan)
 
 
 # -----------------------
@@ -2591,7 +2590,7 @@ def _insertion_guard(builder):
 
 @_tensor_member_fn
 @builtin
-def reduce(input, axis, combine_fn, keep_dims=False, _builder=None, _generator=None):
+def reduce(input, axis, combine_fn, keep_dims=False, _semantic=None, _generator=None):
     """Applies the combine_fn to all elements in :code:`input` tensors along the provided :code:`axis`
 
     :param input: the input tensor, or tuple of tensors
@@ -2605,64 +2604,65 @@ def reduce(input, axis, combine_fn, keep_dims=False, _builder=None, _generator=N
 
     """
     if isinstance(input, tensor):
-        return reduce((input, ), axis, combine_fn, keep_dims=keep_dims, _builder=_builder, _generator=_generator)[0]
+        return reduce((input, ), axis, combine_fn, keep_dims=keep_dims, _semantic=_semantic, _generator=_generator)[0]
 
     def make_combine_region(reduce_op):
         param_types = [t.type.scalar for t in input] * 2
         region = reduce_op.get_region(0)
-        with _insertion_guard(_builder):
-            to_ir = lambda T: T.to_ir(_builder)
-            block = _builder.create_block_with_parent(region, list(map(to_ir, param_types)))
+        builder = _semantic.builder
+        with _insertion_guard(builder):
+            to_ir = lambda T: T.to_ir(builder)
+            block = builder.create_block_with_parent(region, list(map(to_ir, param_types)))
             args = [tensor(block.arg(i), ty) for i, ty in enumerate(param_types)]
             results = _generator.call_JitFunction(combine_fn, args, kwargs={})
             if isinstance(results, tensor):
                 handles = [results.handle]
             else:
                 handles = [r.handle for r in results]
-            _builder.create_reduce_ret(*handles)
+            builder.create_reduce_ret(*handles)
 
     def expand_ndims(t, ndims):
         for _ in builtins.range(ndims):
-            t = expand_dims(t, 0, _builder=_builder)
+            t = expand_dims(t, 0, _semantic=_semantic)
         return t
 
     axis = _unwrap_if_constexpr(axis)
     keep_dims = _unwrap_if_constexpr(keep_dims)
     if axis is not None:
         axis = _wrap_axis(axis, len(input[0].shape))
-    ret = semantic.reduction(input, axis, make_combine_region, _builder)
+    ret = _semantic.reduction(input, axis, make_combine_region)
     if keep_dims:
         if axis is not None:
-            ret = tuple(expand_dims(t, axis, _builder=_builder) for t in ret)
+            ret = tuple(expand_dims(t, axis, _semantic=_semantic) for t in ret)
         else:
             ret = tuple(expand_ndims(t, len(input[0].shape)) for t in ret)
     return ret
 
 
 @builtin
-def _promote_bfloat16_to_float32(t, _builder=None):
+def _promote_bfloat16_to_float32(t, _semantic=None):
     scalar_ty = t.type.scalar
 
     # hardware doesn't support FMAX, FMIN, CMP for bfloat16
     if scalar_ty is bfloat16:
-        return t.to(float32, _builder=_builder)
+        return t.to(float32, _semantic=_semantic)
     return t
 
 
 @builtin
-def _reduce_with_indices(input, axis, combine_fn, keep_dims=False, _builder=None, _generator=None):
+def _reduce_with_indices(input, axis, combine_fn, keep_dims=False, _semantic=None, _generator=None):
     axis = _unwrap_if_constexpr(axis)
     n = input.shape[axis]
-    index = arange(0, n, _builder=_builder)
+    index = arange(0, n, _semantic=_semantic)
 
     if len(input.shape) > 1:
         # Broadcast index across the non-reduced axes
         axes_to_expand = [constexpr(d) for d in builtins.range(len(input.shape))]
         del axes_to_expand[axis]
-        index = expand_dims(index, axes_to_expand, _builder=_builder)
-        index = broadcast_to(index, input.shape, _builder=_builder)
+        index = expand_dims(index, axes_to_expand, _semantic=_semantic)
+        index = broadcast_to(index, input.shape, _semantic=_semantic)
 
-    rvalue, rindices = reduce((input, index), axis, combine_fn, keep_dims=keep_dims, _builder=_builder,
+    rvalue, rindices = reduce((input, index), axis, combine_fn, keep_dims=keep_dims, _semantic=_semantic,
                               _generator=_generator)
     return rvalue, rindices
 
@@ -2698,7 +2698,7 @@ def _add_scan_docstr(name: str, dtype_arg: str = None) -> Callable[[T], T]:
 
 @_tensor_member_fn
 @builtin
-def associative_scan(input, axis, combine_fn, reverse=False, _builder=None, _generator=None):
+def associative_scan(input, axis, combine_fn, reverse=False, _semantic=None, _generator=None):
     """Applies the combine_fn to each elements with a carry in :code:`input` tensors along the provided :code:`axis` and update the carry
 
     :param input: the input tensor, or tuple of tensors
@@ -2712,31 +2712,32 @@ def associative_scan(input, axis, combine_fn, reverse=False, _builder=None, _gen
 
     """
     if isinstance(input, tensor):
-        return associative_scan((input, ), axis, combine_fn, reverse, _builder=_builder, _generator=_generator)[0]
+        return associative_scan((input, ), axis, combine_fn, reverse, _semantic=_semantic, _generator=_generator)[0]
 
     def make_combine_region(scan_op):
         param_types = [t.type.scalar for t in input] * 2
         region = scan_op.get_region(0)
-        with _insertion_guard(_builder):
-            to_ir = lambda T: T.to_ir(_builder)
-            block = _builder.create_block_with_parent(region, list(map(to_ir, param_types)))
+        builder = _semantic.builder
+        with _insertion_guard(builder):
+            to_ir = lambda T: T.to_ir(builder)
+            block = builder.create_block_with_parent(region, list(map(to_ir, param_types)))
             args = [tensor(block.arg(i), ty) for i, ty in enumerate(param_types)]
             results = _generator.call_JitFunction(combine_fn, args, kwargs={})
             if isinstance(results, tensor):
                 handles = [results.handle]
             else:
                 handles = [r.handle for r in results]
-            _builder.create_scan_ret(*handles)
+            builder.create_scan_ret(*handles)
 
     axis = _unwrap_if_constexpr(axis)
     if axis is not None:
         axis = _wrap_axis(axis, len(input[0].shape))
-    return semantic.associative_scan(input, axis, make_combine_region, reverse, _builder)
+    return _semantic.associative_scan(input, axis, make_combine_region, reverse)
 
 
 @_tensor_member_fn
 @builtin
-def histogram(input, num_bins, mask=None, _builder=None, _generator=None):
+def histogram(input, num_bins, mask=None, _semantic=None, _generator=None):
     """computes an histogram based on input tensor with num_bins bins, the bins have a width of 1 and start at 0.
 
     :param input: the input tensor
@@ -2750,13 +2751,13 @@ def histogram(input, num_bins, mask=None, _builder=None, _generator=None):
     num_bins = _unwrap_if_constexpr(num_bins)
     mask = _unwrap_if_constexpr(mask)
     if mask is not None:
-        mask = semantic.to_tensor(mask, _builder)
-    return semantic.histogram(input, num_bins, mask, _builder)
+        mask = _semantic.to_tensor(mask)
+    return _semantic.histogram(input, num_bins, mask)
 
 
 @_tensor_member_fn
 @builtin
-def gather(src, index, axis, _builder=None):
+def gather(src, index, axis, _semantic=None):
     """Gather from a tensor along a given dimension.
 
     :param src: the source tensor
@@ -2768,7 +2769,7 @@ def gather(src, index, axis, _builder=None):
 
     """
     axis = _unwrap_if_constexpr(axis)
-    return semantic.gather(src, index, axis, _builder)
+    return _semantic.gather(src, index, axis)
 
 
 # -----------------------
@@ -2777,15 +2778,15 @@ def gather(src, index, axis, _builder=None):
 
 
 @builtin
-def debug_barrier(_builder=None):
+def debug_barrier(_semantic=None):
     '''
     Insert a barrier to synchronize all threads in a block.
     '''
-    return semantic.debug_barrier(_builder)
+    return _semantic.debug_barrier()
 
 
 @builtin
-def multiple_of(input, values, _builder=None):
+def multiple_of(input, values, _semantic=None):
     """
     Let the compiler know that the values in :code:`input` are all multiples of :code:`value`.
     """
@@ -2797,11 +2798,11 @@ def multiple_of(input, values, _builder=None):
         if not isinstance(d.value, int):
             raise TypeError(f"values element {i} must have type `constexpr[int]`, got `constexpr[{type(d.value)}]")
     values = [x.value for x in values]
-    return semantic.multiple_of(input, values)
+    return _semantic.multiple_of(input, values)
 
 
 @builtin
-def max_contiguous(input, values, _builder=None):
+def max_contiguous(input, values, _semantic=None):
     """
     Let the compiler know that the `value` first values in :code:`input` are contiguous.
     """
@@ -2813,11 +2814,11 @@ def max_contiguous(input, values, _builder=None):
         if not isinstance(d.value, int):
             raise TypeError(f"values element {i} must have type `constexpr[int]`, got `constexpr[{type(d.value)}]")
     values = [x.value for x in values]
-    return semantic.max_contiguous(input, values)
+    return _semantic.max_contiguous(input, values)
 
 
 @builtin
-def max_constancy(input, values, _builder=None):
+def max_constancy(input, values, _semantic=None):
     """
     Let the compiler know that the `value` first values in :code:`input` are constant.
 
@@ -2832,15 +2833,15 @@ def max_constancy(input, values, _builder=None):
         if not isinstance(d.value, int):
             raise TypeError(f"values element {i} must have type `constexpr[int]`, got `constexpr[{type(d.value)}]")
     values = [x.value for x in values]
-    return semantic.max_constancy(input, values)
+    return _semantic.max_constancy(input, values)
 
 
 @builtin
-def assume(cond, _builder=None):
+def assume(cond, _semantic=None):
     '''
     Allow compiler to assume the :code:`cond` is True.
     '''
-    return semantic.assume(semantic.to_tensor(cond, _builder), _builder)
+    return _semantic.assume(_semantic.to_tensor(cond))
 
 
 # -----------------------
@@ -2849,7 +2850,7 @@ def assume(cond, _builder=None):
 
 
 @builtin
-def static_print(*values, sep: str = " ", end: str = "\n", file=None, flush=False, _builder=None):
+def static_print(*values, sep: str = " ", end: str = "\n", file=None, flush=False, _semantic=None):
     '''
     Print the values at compile time.  The parameters are the same as the builtin :code:`print`.
 
@@ -2865,7 +2866,7 @@ def static_print(*values, sep: str = " ", end: str = "\n", file=None, flush=Fals
 
 
 @builtin
-def static_assert(cond, msg="", _builder=None):
+def static_assert(cond, msg="", _semantic=None):
     '''
     Assert the condition at compile time.  Does not require that the :code:`TRITON_DEBUG` environment variable
     is set.
@@ -2879,7 +2880,7 @@ def static_assert(cond, msg="", _builder=None):
 
 
 @builtin
-def device_print(prefix, *args, hex=False, _builder=None):
+def device_print(prefix, *args, hex=False, _semantic=None):
     '''
     Print the values at runtime from the device.  String formatting does not work for runtime values, so you should
     provide the values you want to print as arguments.  The first value must be a string, all following values must
@@ -2923,12 +2924,12 @@ def device_print(prefix, *args, hex=False, _builder=None):
     assert b_ascii, f"{prefix} is not an ascii string"
     new_args = []
     for arg in args:
-        new_args.append(semantic.to_tensor(arg, _builder))
-    return semantic.device_print(prefix, new_args, hex, _builder)
+        new_args.append(_semantic.to_tensor(arg))
+    return _semantic.device_print(prefix, new_args, hex)
 
 
 @builtin
-def device_assert(cond, msg="", _builder=None):
+def device_assert(cond, msg="", _semantic=None):
     '''
     Assert the condition at runtime from the device.  Requires that the environment variable :code:`TRITON_DEBUG`
     is set to a value besides :code:`0` in order for this to have any effect.
@@ -2947,12 +2948,12 @@ def device_assert(cond, msg="", _builder=None):
     :param msg: the message to print if the assertion fails. This is required to be a string literal.
     '''
     msg = _unwrap_if_constexpr(msg)
-    return semantic.device_assert(semantic.to_tensor(cond, _builder), msg, _builder)
+    return _semantic.device_assert(_semantic.to_tensor(cond), msg)
 
 
 @builtin
 def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Union[dtype, Sequence[dtype]],
-                           is_pure: bool, pack: int, _builder=None):
+                           is_pure: bool, pack: int, _semantic=None):
     '''
         Execute inline assembly over a tensor.  Essentially, this is :code:`map`
         where the function is inline assembly.
@@ -3037,7 +3038,6 @@ def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Un
         :param dtype: the element type(s) of the returned tensor(s)
         :param is_pure: if true, the compiler assumes the asm block has no side-effects
         :param pack: the number of elements to be processed by one instance of inline assembly
-        :param _builder: the builder
         :return: one tensor or a tuple of tensors of the given dtypes
     '''
     asm = _unwrap_if_constexpr(asm)
@@ -3056,10 +3056,9 @@ def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Un
     dtype = typing.cast(Sequence[_DtypeClass], dtype)
 
     res_tys = dtype
-    if dispatch_args := [semantic.to_tensor(arg, _builder) for arg in args]:
+    if dispatch_args := [_semantic.to_tensor(arg) for arg in args]:
         bin_op_type_checking = partial(
-            semantic.binary_op_type_checking_impl,
-            builder=_builder,
+            _semantic.binary_op_type_checking_impl,
             arithmetic_check=False,
             allow_lhs_ptr=True,
             allow_rhs_ptr=True,
@@ -3074,7 +3073,8 @@ def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Un
                 dispatch_args[i], _ = bin_op_type_checking(item, broadcast_arg)
             res_tys = [block_type(dt, broadcast_arg.shape) for dt in dtype]
     handles = [t.handle for t in dispatch_args]
-    call = _builder.create_inline_asm(asm, constraints, handles, [ty.to_ir(_builder) for ty in res_tys], is_pure, pack)
+    builder = _semantic.builder
+    call = builder.create_inline_asm(asm, constraints, handles, [ty.to_ir(builder) for ty in res_tys], is_pure, pack)
 
     if not has_multiple_outputs:
         return tensor(call.get_result(0), res_tys[0])
@@ -3198,7 +3198,7 @@ class range:
 
 
 def dispatch(func, lib_name: str, lib_path: str, args: list, arg_type_symbol_dict: dict, ret_shape: tuple,
-             is_pure: bool, _builder=None):
+             is_pure: bool, _semantic):
     '''
         Dispatch a function to a library
         :param func: the function to dispatch
@@ -3207,7 +3207,6 @@ def dispatch(func, lib_name: str, lib_path: str, args: list, arg_type_symbol_dic
         :param args: the arguments of the function
         :param arg_type_symbol_dict: the type of the arguments
         :param ret_shape: the shape of the return value
-        :param _builder: the builder
         :return: the return value of the function
     '''
     if len(arg_type_symbol_dict) == 0:
@@ -3237,12 +3236,13 @@ def dispatch(func, lib_name: str, lib_path: str, args: list, arg_type_symbol_dic
         ret_type = arg_type_symbol_dict[arg_types][1]
         if ret_shape:
             ret_type = block_type(ret_type, ret_shape)
-        return tensor(func(lib_name, lib_path, symbol, arg_list, ret_type.to_ir(_builder), is_pure), ret_type)
+        builder = _semantic.builder
+        return tensor(func(lib_name, lib_path, symbol, arg_list, ret_type.to_ir(builder), is_pure), ret_type)
 
 
 @builtin
 def extern_elementwise(lib_name: str, lib_path: str, args: list, arg_type_symbol_dict: dict, is_pure: bool,
-                       _builder=None):
+                       _semantic=None):
     '''
         Dispatch an elementwise function to a library
         :param lib_name: the name of the library
@@ -3250,7 +3250,6 @@ def extern_elementwise(lib_name: str, lib_path: str, args: list, arg_type_symbol
         :param args: the arguments of the function
         :param arg_type_symbol_dict: the type of the arguments
         :param is_pure: whether the function is pure
-        :param _builder: the builder
         :return: the return value of the function
     '''
     dispatch_args = args.copy()
@@ -3258,7 +3257,7 @@ def extern_elementwise(lib_name: str, lib_path: str, args: list, arg_type_symbol
     ret_shape = None
     arg_types = []
     for i in builtins.range(len(dispatch_args)):
-        dispatch_args[i] = semantic.to_tensor(dispatch_args[i], _builder)
+        dispatch_args[i] = _semantic.to_tensor(dispatch_args[i])
         arg_types.append(dispatch_args[i].dtype)
         if dispatch_args[i].type.is_block():
             all_scalar = False
@@ -3271,26 +3270,26 @@ def extern_elementwise(lib_name: str, lib_path: str, args: list, arg_type_symbol
         broadcast_arg = dispatch_args[0]
         # Get the broadcast shape over all the arguments
         for item in dispatch_args:
-            _, broadcast_arg = semantic.binary_op_type_checking_impl(item, broadcast_arg, _builder,
-                                                                     arithmetic_check=arithmetic_check)
+            _, broadcast_arg = _semantic.binary_op_type_checking_impl(item, broadcast_arg,
+                                                                      arithmetic_check=arithmetic_check)
         # Change the shape of each argument based on the broadcast shape
         for i in builtins.range(len(dispatch_args)):
-            dispatch_args[i], _ = semantic.binary_op_type_checking_impl(dispatch_args[i], broadcast_arg, _builder,
-                                                                        arithmetic_check=arithmetic_check)
+            dispatch_args[i], _ = _semantic.binary_op_type_checking_impl(dispatch_args[i], broadcast_arg,
+                                                                         arithmetic_check=arithmetic_check)
         if not all_scalar:
             ret_shape = broadcast_arg.shape
-    func = _builder.create_extern_elementwise
-    return dispatch(func, lib_name, lib_path, dispatch_args, arg_type_symbol_dict, ret_shape, is_pure, _builder)
+    func = _semantic.builder.create_extern_elementwise
+    return dispatch(func, lib_name, lib_path, dispatch_args, arg_type_symbol_dict, ret_shape, is_pure, _semantic)
 
 
-def binary_op_type_legalization(lhs, rhs, builder):
+def binary_op_type_legalization(lhs, rhs, semantic):
     '''
         Convert both operands to a single common type
         :param lhs: the left operand
         :param rhs: the right operand
         :param builder: the builder
     '''
-    return semantic.binary_op_type_checking_impl(lhs, rhs, builder)
+    return semantic.binary_op_type_checking_impl(lhs, rhs)
 
 
 def extern(fn):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1487,19 +1487,19 @@ class tensor_descriptor(tensor_descriptor_base):
         """Not called by user code."""
         # IR handle
         super().__init__(handle, block_type)
+        # Global shape
+        self.shape = tuple(shape)
+        self.strides = tuple(strides)
         self.type = tensor_descriptor_type(
             block_type,
-            shape_type=tuple_type([s.type for s in shape]),
-            strides_type=tuple_type([s.type for s in strides]),
+            shape_type=self.shape.type,
+            strides_type=self.strides.type,
         )
-        # Global shape
-        self.shape = shape
-        self.strides = strides
 
     def _flatten_ir(self, handles: List[ir.value]) -> None:
         handles.append(self.handle)
-        handles.extend(s.handle for s in self.shape)
-        handles.extend(s.handle for s in self.strides)
+        self.shape._flatten_ir(handles)
+        self.strides._flatten_ir(handles)
 
 
 # -----------------------

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -338,7 +338,7 @@ def constexpr_function(f):
     """
 
     @wraps(f)
-    def wrapper(*args, **kwargs, _semantic):
+    def wrapper(*args, _semantic=None, **kwargs):
         # de-constexpr arguments and discard the _semantic keyword argument:
         args = [_unwrap_if_constexpr(x) for x in args]
         kwargs = {k: _unwrap_if_constexpr(v) for (k, v) in kwargs.items()}

--- a/python/triton/language/math.py
+++ b/python/triton/language/math.py
@@ -1,5 +1,4 @@
 from . import core
-from . import semantic
 from functools import wraps
 from typing import List
 
@@ -85,107 +84,107 @@ def _add_math_3arg_docstr(name: str) -> core.Callable[[T], T]:
 @core.builtin
 @_check_dtype(dtypes=["int32", "int64", "uint32", "uint64"])
 @_add_math_2arg_docstr("most significant N bits of the 2N-bit product")
-def umulhi(x, y, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    y = semantic.to_tensor(y, _builder)
-    x, y = core.binary_op_type_legalization(x, y, _builder)
-    return core.tensor(_builder.create_umulhi(x.handle, y.handle), x.type)
+def umulhi(x, y, _semantic=None):
+    x = _semantic.to_tensor(x)
+    y = _semantic.to_tensor(y)
+    x, y = core.binary_op_type_legalization(x, y, _semantic)
+    return core.tensor(_semantic.builder.create_umulhi(x.handle, y.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("exponential")
 @core._tensor_member_fn
-def exp(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_exp(x.handle), x.type)
+def exp(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_exp(x.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("exponential (base 2)")
 @core._tensor_member_fn
-def exp2(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_exp2(x.handle), x.type)
+def exp2(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_exp2(x.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("natural logarithm")
 @core._tensor_member_fn
-def log(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_log(x.handle), x.type)
+def log(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_log(x.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("logarithm (base 2)")
 @core._tensor_member_fn
-def log2(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_log2(x.handle), x.type)
+def log2(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_log2(x.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("cosine")
 @core._tensor_member_fn
-def cos(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_cos(x.handle), x.type)
+def cos(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_cos(x.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("sine")
 @core._tensor_member_fn
-def sin(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_sin(x.handle), x.type)
+def sin(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_sin(x.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("fast square root")
 @core._tensor_member_fn
-def sqrt(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_sqrt(x.handle), x.type)
+def sqrt(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_sqrt(x.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32"])
 @_add_math_1arg_docstr("precise square root (rounding to nearest wrt the IEEE standard)")
 @core._tensor_member_fn
-def sqrt_rn(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_precise_sqrt(x.handle), x.type)
+def sqrt_rn(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_precise_sqrt(x.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("inverse square root")
 @core._tensor_member_fn
-def rsqrt(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_rsqrt(x.handle), x.type)
+def rsqrt(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_rsqrt(x.handle), x.type)
 
 
 @core._tensor_member_fn
 @core.builtin
 @_add_math_1arg_docstr("absolute value")
-def abs(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
+def abs(x, _semantic=None):
+    x = _semantic.to_tensor(x)
     dtype = x.dtype
     if dtype.is_fp8e4b15():
-        mask = core.full(x.shape, 0x7F, core.int8, _builder=_builder)
-        return core.tensor(_builder.create_and(x.handle, mask.handle), x.type)
+        mask = core.full(x.shape, 0x7F, core.int8, _semantic=_semantic)
+        return core.tensor(_semantic.builder.create_and(x.handle, mask.handle), x.type)
     elif dtype.is_floating():
-        return core.tensor(_builder.create_fabs(x.handle), x.type)
+        return core.tensor(_semantic.builder.create_fabs(x.handle), x.type)
     elif dtype.is_int_signed():
-        return core.tensor(_builder.create_iabs(x.handle), x.type)
+        return core.tensor(_semantic.builder.create_iabs(x.handle), x.type)
     elif dtype.is_int_unsigned():
         return x  # no-op
     else:
@@ -194,57 +193,57 @@ def abs(x, _builder=None):
 
 @core.builtin
 @_add_math_2arg_docstr("fast division")
-def fdiv(x, y, ieee_rounding=False, _builder=None):
+def fdiv(x, y, ieee_rounding=False, _semantic=None):
     ieee_rounding = core._unwrap_if_constexpr(ieee_rounding)
-    x = semantic.to_tensor(x, _builder)
-    y = semantic.to_tensor(y, _builder)
-    return semantic.fdiv(x, y, ieee_rounding, _builder)
+    x = _semantic.to_tensor(x)
+    y = _semantic.to_tensor(y)
+    return _semantic.fdiv(x, y, ieee_rounding)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32"])
 @_add_math_2arg_docstr("precise division (rounding to nearest wrt the IEEE standard)")
-def div_rn(x, y, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    y = semantic.to_tensor(y, _builder)
-    x, y = core.binary_op_type_legalization(x, y, _builder)
-    return core.tensor(_builder.create_precise_divf(x.handle, y.handle), x.type)
+def div_rn(x, y, _semantic=None):
+    x = _semantic.to_tensor(x)
+    y = _semantic.to_tensor(y)
+    x, y = core.binary_op_type_legalization(x, y, _semantic)
+    return core.tensor(_semantic.builder.create_precise_divf(x.handle, y.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("error function")
 @core._tensor_member_fn
-def erf(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_erf(x.handle), x.type)
+def erf(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_erf(x.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("floor")
 @core._tensor_member_fn
-def floor(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_floor(x.handle), x.type)
+def floor(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_floor(x.handle), x.type)
 
 
 @core.builtin
 @_check_dtype(dtypes=["fp32", "fp64"])
 @_add_math_1arg_docstr("ceil")
 @core._tensor_member_fn
-def ceil(x, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    return core.tensor(_builder.create_ceil(x.handle), x.type)
+def ceil(x, _semantic=None):
+    x = _semantic.to_tensor(x)
+    return core.tensor(_semantic.builder.create_ceil(x.handle), x.type)
 
 
 @core.builtin
 @_add_math_3arg_docstr("fused multiply-add")
-def fma(x, y, z, _builder=None):
-    x = semantic.to_tensor(x, _builder)
-    y = semantic.to_tensor(y, _builder)
-    z = semantic.to_tensor(z, _builder)
-    x, y = core.binary_op_type_legalization(x, y, _builder)
-    z, x = core.binary_op_type_legalization(z, x, _builder)
-    z, y = core.binary_op_type_legalization(z, y, _builder)
-    return core.tensor(_builder.create_fma(x.handle, y.handle, z.handle), x.type)
+def fma(x, y, z, _semantic=None):
+    x = _semantic.to_tensor(x)
+    y = _semantic.to_tensor(y)
+    z = _semantic.to_tensor(z)
+    x, y = core.binary_op_type_legalization(x, y, _semantic)
+    z, x = core.binary_op_type_legalization(z, x, _semantic)
+    z, y = core.binary_op_type_legalization(z, y, _semantic)
+    return core.tensor(_semantic.builder.create_fma(x.handle, y.handle, z.handle), x.type)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1,7 +1,7 @@
 from __future__ import annotations  # remove after python 3.11
 import warnings
 
-from typing import List, Optional, Sequence, Tuple, TypeVar
+from typing import List, Optional, Sequence, Tuple, TypeVar, Generic, Type
 import numbers
 
 from triton.runtime import driver
@@ -10,6 +10,7 @@ from .._C.libtriton import ir
 from . import core as tl
 
 T = TypeVar('T')
+TensorTy = TypeVar('TensorTy')
 
 
 class IncompatibleTypeErrorImpl(Exception):
@@ -21,1967 +22,1862 @@ class IncompatibleTypeErrorImpl(Exception):
         super(IncompatibleTypeErrorImpl, self).__init__(self.message)
 
 
+class TritonSemantic(Generic[TensorTy]):
+    tensor: Type[TensorTy] = tl.tensor
+    lang = tl
+
+    builder: ir.builder
+
+    def __init__(self, builder):
+        self.builder = builder
+
 # ===----------------------------------------------------------------------===##
 # Programming Model
 # ===----------------------------------------------------------------------===##
 
+    def program_id(self, axis: int) -> TensorTy:
+        if axis not in (0, 1, 2):
+            raise ValueError(f"program_id axis must be 0, 1, or 2 but got {axis}")
+        return self.tensor(self.builder.create_get_program_id(axis), tl.int32)
 
-def program_id(axis: int, builder: ir.builder) -> tl.tensor:
-    if axis not in (0, 1, 2):
-        raise ValueError(f"program_id axis must be 0, 1, or 2 but got {axis}")
-    return tl.tensor(builder.create_get_program_id(axis), tl.int32)
-
-
-def num_programs(axis: int, builder: ir.builder) -> tl.tensor:
-    if axis not in (0, 1, 2):
-        raise ValueError(f"num_programs axis must be 0, 1, or 2 but got {axis}")
-    return tl.tensor(builder.create_get_num_programs(axis), tl.int32)
-
+    def num_programs(self, axis: int) -> TensorTy:
+        if axis not in (0, 1, 2):
+            raise ValueError(f"num_programs axis must be 0, 1, or 2 but got {axis}")
+        return self.tensor(self.builder.create_get_num_programs(axis), tl.int32)
 
 # ===----------------------------------------------------------------------===//
 #                               Implicit Casting Utilities
 # ===----------------------------------------------------------------------===//
 
+    def integer_promote_impl(self, a_ty: tl.dtype, b_ty: tl.dtype) -> tl.dtype:
+        a_rank = a_ty.int_bitwidth
+        b_rank = b_ty.int_bitwidth
+        a_sn = a_ty.int_signedness
+        b_sn = b_ty.int_signedness
+        # Rules for signedness taken from "Usual arithmetic conversions" on
+        # https://en.cppreference.com/w/c/language/conversion.
+        if a_sn == b_sn:
+            return a_ty if a_rank > b_rank else b_ty
+        elif a_sn == tl.dtype.SIGNEDNESS.UNSIGNED:
+            return a_ty if a_rank >= b_rank else b_ty
+        elif b_sn == tl.dtype.SIGNEDNESS.UNSIGNED:
+            return b_ty if b_rank >= a_rank else a_ty
+        raise TypeError(f"unexpected signedness {a_sn} and {b_sn}")
 
-def integer_promote_impl(a_ty: tl.dtype, b_ty: tl.dtype) -> tl.dtype:
-    a_rank = a_ty.int_bitwidth
-    b_rank = b_ty.int_bitwidth
-    a_sn = a_ty.int_signedness
-    b_sn = b_ty.int_signedness
-    # Rules for signedness taken from "Usual arithmetic conversions" on
-    # https://en.cppreference.com/w/c/language/conversion.
-    if a_sn == b_sn:
-        return a_ty if a_rank > b_rank else b_ty
-    elif a_sn == tl.dtype.SIGNEDNESS.UNSIGNED:
-        return a_ty if a_rank >= b_rank else b_ty
-    elif b_sn == tl.dtype.SIGNEDNESS.UNSIGNED:
-        return b_ty if b_rank >= a_rank else a_ty
-    raise TypeError(f"unexpected signedness {a_sn} and {b_sn}")
+    def computation_type_impl(self, a_ty: tl.dtype, a_is_scalar: bool, b_ty: tl.dtype, b_is_scalar: bool,
+                              div_or_mod: bool) -> tl.dtype:
+        # 0) For scalars we follow semantics similar to PyTorch, namely:
+        # - If the scalar is of a lower or equal kind (bool < uint < int < fp),
+        #   it doesn't participate in the promotion
+        if a_is_scalar != b_is_scalar:
+            scalar_ty, tensor_ty = (a_ty, b_ty) if a_is_scalar else (b_ty, a_ty)
+            if scalar_ty.kind().value <= tensor_ty.kind().value:
+                # Upcast because of 3) and 4) below!
+                if div_or_mod and (tensor_ty in (tl.float16, tl.bfloat16)):
+                    return tl.float32
+                return tensor_ty
 
-
-def computation_type_impl(a_ty: tl.dtype, a_is_scalar: bool, b_ty: tl.dtype, b_is_scalar: bool,
-                          div_or_mod: bool) -> tl.dtype:
-    # 0) For scalars we follow semantics similar to PyTorch, namely:
-    # - If the scalar is of a lower or equal kind (bool < uint < int < fp),
-    #   it doesn't participate in the promotion
-    if a_is_scalar != b_is_scalar:
-        scalar_ty, tensor_ty = (a_ty, b_ty) if a_is_scalar else (b_ty, a_ty)
-        if scalar_ty.kind().value <= tensor_ty.kind().value:
-            # Upcast because of 3) and 4) below!
-            if div_or_mod and (tensor_ty in (tl.float16, tl.bfloat16)):
+        # 1) if one operand is double, the other is implicitly
+        #    converted to double
+        if a_ty.is_fp64() or b_ty.is_fp64():
+            return tl.float64
+        # 2) if one operand is float, the other is implicitly
+        #    converted to float
+        if a_ty.is_fp32() or b_ty.is_fp32():
+            return tl.float32
+        # 3 ) if one operand is half, the other is implicitly converted to half
+        #     unless we're doing / or %, which do not exist natively in PTX for fp16.
+        #     Supported PTX op: add, sub, mul, fma, neg, abs, min, max, tanh, ex2, setp
+        if a_ty.is_fp16() or b_ty.is_fp16():
+            if div_or_mod:
                 return tl.float32
-            return tensor_ty
-
-    # 1) if one operand is double, the other is implicitly
-    #    converted to double
-    if a_ty.is_fp64() or b_ty.is_fp64():
-        return tl.float64
-    # 2) if one operand is float, the other is implicitly
-    #    converted to float
-    if a_ty.is_fp32() or b_ty.is_fp32():
-        return tl.float32
-    # 3 ) if one operand is half, the other is implicitly converted to half
-    #     unless we're doing / or %, which do not exist natively in PTX for fp16.
-    #     Supported PTX op: add, sub, mul, fma, neg, abs, min, max, tanh, ex2, setp
-    if a_ty.is_fp16() or b_ty.is_fp16():
-        if div_or_mod:
+            else:
+                return tl.float16
+        # 4) return bf16 only if both operands are of bf16
+        if a_ty.is_bf16() and b_ty.is_bf16():
+            if div_or_mod:
+                return tl.float32
+            else:
+                return tl.bfloat16
+        if a_ty.is_bf16() or b_ty.is_bf16():
             return tl.float32
-        else:
-            return tl.float16
-    # 4) return bf16 only if both operands are of bf16
-    if a_ty.is_bf16() and b_ty.is_bf16():
-        if div_or_mod:
-            return tl.float32
-        else:
-            return tl.bfloat16
-    if a_ty.is_bf16() or b_ty.is_bf16():
-        return tl.float32
-    # 5) return fp16 if operands are different fp8
-    if a_ty.is_fp8() and b_ty.is_fp8():
-        return a_ty if a_ty == b_ty else tl.float16
-    if not a_ty.is_int() or not b_ty.is_int():
-        raise TypeError(f"unexpected type {a_ty} and {b_ty}")
-    # 6 ) both operands are integer and undergo
-    #    integer promotion
-    if div_or_mod and a_ty.int_signedness != b_ty.int_signedness:
-        raise TypeError("Cannot use /, #, or % with " + a_ty.__repr__() + " and " + b_ty.__repr__() +
-                        " because they have different signedness;"
-                        "this is unlikely to result in a useful answer. Cast them to the same signedness.")
-    return integer_promote_impl(a_ty, b_ty)
+        # 5) return fp16 if operands are different fp8
+        if a_ty.is_fp8() and b_ty.is_fp8():
+            return a_ty if a_ty == b_ty else tl.float16
+        if not a_ty.is_int() or not b_ty.is_int():
+            raise TypeError(f"unexpected type {a_ty} and {b_ty}")
+        # 6 ) both operands are integer and undergo
+        #    integer promotion
+        if div_or_mod and a_ty.int_signedness != b_ty.int_signedness:
+            raise TypeError("Cannot use /, #, or % with " + a_ty.__repr__() + " and " + b_ty.__repr__() +
+                            " because they have different signedness;"
+                            "this is unlikely to result in a useful answer. Cast them to the same signedness.")
+        return self.integer_promote_impl(a_ty, b_ty)
 
+    def to_tensor(self, x, check_type: bool = True):
+        if isinstance(x, bool):
+            return self.tensor(self.builder.get_int1(x), tl.int1)
+        # Note: compile-time const integers are represented by unsigned values
+        elif isinstance(x, int):
+            if -2**31 <= x < 2**31:
+                dtype = tl.int32
+            elif 2**31 <= x < 2**32:
+                dtype = tl.uint32
+            elif -2**63 <= x < 2**63:
+                dtype = tl.int64
+            elif 2**63 <= x < 2**64:
+                dtype = tl.uint64
+            else:
+                raise ValueError(f'Nonrepresentable integer {x}.')
+            return self.full((), x, dtype=dtype)
+        elif isinstance(x, float):
+            min_float32 = 2**-126
+            max_float32 = (2 - 2**-23) * 2**127
+            abs_x = __builtins__['abs'](x)
+            if abs_x == float("inf") or\
+               abs_x == 0.0 or \
+               x != x or \
+               min_float32 <= abs_x <= max_float32:
+                dtype = tl.float32
+            else:
+                dtype = tl.float64
+            return self.full((), x, dtype=dtype)
 
-def to_tensor(x, builder, check_type: bool = True):
-    if isinstance(x, bool):
-        return tl.tensor(builder.get_int1(x), tl.int1)
-    # Note: compile-time const integers are represented by unsigned values
-    elif isinstance(x, int):
-        if -2**31 <= x < 2**31:
-            dtype = tl.int32
-        elif 2**31 <= x < 2**32:
-            dtype = tl.uint32
-        elif -2**63 <= x < 2**63:
-            dtype = tl.int64
-        elif 2**63 <= x < 2**64:
-            dtype = tl.uint64
-        else:
-            raise ValueError(f'Nonrepresentable integer {x}.')
-        return full((), x, dtype=dtype, builder=builder)
-    elif isinstance(x, float):
-        min_float32 = 2**-126
-        max_float32 = (2 - 2**-23) * 2**127
-        abs_x = __builtins__['abs'](x)
-        if abs_x == float("inf") or\
-           abs_x == 0.0 or \
-           x != x or \
-           min_float32 <= abs_x <= max_float32:
-            dtype = tl.float32
-        else:
-            dtype = tl.float64
-        return full((), x, dtype=dtype, builder=builder)
-
-    elif isinstance(x, tl.constexpr):
-        return to_tensor(x.value, builder)
-    elif isinstance(x, tl.tensor):
+        elif isinstance(x, tl.constexpr):
+            return self.to_tensor(x.value)
+        elif isinstance(x, self.tensor):
+            return x
+        if check_type:
+            raise TypeError(f"cannot convert {x} of type {type(x)} to tensor")
         return x
-    if check_type:
-        raise TypeError(f"cannot convert {x} of type {type(x)} to tensor")
-    return x
-
 
 # ===----------------------------------------------------------------------===//
 #                               Binary Operators
 # ===----------------------------------------------------------------------===//
 
+    def check_ptr_type_impl(self, type_a: tl.dtype, type_b: tl.dtype, allow_ptr_a: bool) -> None:
+        if type_a.is_ptr():
+            if not allow_ptr_a:
+                raise IncompatibleTypeErrorImpl(type_a, type_b)
+            # T* + U* with T != U
+            if type_b.is_ptr() and (type_a != type_b):
+                raise IncompatibleTypeErrorImpl(type_a, type_b)
+            # T* + float
+            if type_b.is_floating():
+                raise IncompatibleTypeErrorImpl(type_a, type_b)
 
-def check_ptr_type_impl(type_a: tl.dtype, type_b: tl.dtype, allow_ptr_a: bool) -> None:
-    if type_a.is_ptr():
-        if not allow_ptr_a:
-            raise IncompatibleTypeErrorImpl(type_a, type_b)
-        # T* + U* with T != U
-        if type_b.is_ptr() and (type_a != type_b):
-            raise IncompatibleTypeErrorImpl(type_a, type_b)
-        # T* + float
-        if type_b.is_floating():
-            raise IncompatibleTypeErrorImpl(type_a, type_b)
+    def binary_op_type_checking_impl(self, lhs: TensorTy | numbers.Number, rhs: TensorTy | numbers.Number,
+                                     allow_lhs_ptr=False, allow_rhs_ptr=False, arithmetic_check=True,
+                                     div_or_mod=False) -> Tuple[TensorTy, TensorTy]:
+        lhs_is_scalar = isinstance(lhs, numbers.Number)
+        rhs_is_scalar = isinstance(rhs, numbers.Number)
+        if lhs_is_scalar:
+            lhs_scalar = lhs
+            lhs = self.to_tensor(lhs)
+        if rhs_is_scalar:
+            rhs_scalar = rhs
+            rhs = self.to_tensor(rhs)
 
+        # implicit typecasting
+        lhs_sca_ty = lhs.type.scalar
+        rhs_sca_ty = rhs.type.scalar
+        self.check_ptr_type_impl(lhs_sca_ty, rhs_sca_ty, allow_lhs_ptr)
+        self.check_ptr_type_impl(rhs_sca_ty, lhs_sca_ty, allow_rhs_ptr)
+        if arithmetic_check and not lhs_sca_ty.is_ptr() and not rhs_sca_ty.is_ptr():
+            ret_sca_ty = self.computation_type_impl(lhs_sca_ty, lhs_is_scalar, rhs_sca_ty, rhs_is_scalar, div_or_mod)
+            if (lhs_is_scalar and lhs_scalar < 0 and ret_sca_ty.is_int_unsigned()
+                    or rhs_is_scalar and rhs_scalar < 0 and ret_sca_ty.is_int_unsigned()):
+                raise ValueError("Cannot perform a binary operation between an unsigned tensor and a negative scalar. "
+                                 "Perform a explicit cast on one of them.")
+            if ret_sca_ty.is_int():
+                if lhs_is_scalar and not (ret_sca_ty.get_int_min_value() <= lhs_scalar <=
+                                          ret_sca_ty.get_int_max_value()):
+                    raise ValueError(f"Scalar {lhs_scalar} is out of range for type {ret_sca_ty}")
+                if rhs_is_scalar and not (ret_sca_ty.get_int_min_value() <= rhs_scalar <=
+                                          ret_sca_ty.get_int_max_value()):
+                    raise ValueError(f"Scalar {rhs_scalar} is out of range for type {ret_sca_ty}")
+            lhs = self.full((), lhs_scalar, dtype=ret_sca_ty) if lhs_is_scalar else self.cast(lhs, ret_sca_ty)
+            rhs = self.full((), rhs_scalar, dtype=ret_sca_ty) if rhs_is_scalar else self.cast(rhs, ret_sca_ty)
 
-def binary_op_type_checking_impl(lhs: tl.tensor | numbers.Number, rhs: tl.tensor | numbers.Number, builder: ir.builder,
-                                 allow_lhs_ptr=False, allow_rhs_ptr=False, arithmetic_check=True,
-                                 div_or_mod=False) -> Tuple[tl.tensor, tl.tensor]:
-    lhs_is_scalar = isinstance(lhs, numbers.Number)
-    rhs_is_scalar = isinstance(rhs, numbers.Number)
-    if lhs_is_scalar:
-        lhs_scalar = lhs
-        lhs = to_tensor(lhs, builder)
-    if rhs_is_scalar:
-        rhs_scalar = rhs
-        rhs = to_tensor(rhs, builder)
+        # implicit broadcasting
+        lhs, rhs = self.broadcast_impl_value(lhs, rhs)
+        return lhs, rhs
 
-    # implicit typecasting
-    lhs_sca_ty = lhs.type.scalar
-    rhs_sca_ty = rhs.type.scalar
-    check_ptr_type_impl(lhs_sca_ty, rhs_sca_ty, allow_lhs_ptr)
-    check_ptr_type_impl(rhs_sca_ty, lhs_sca_ty, allow_rhs_ptr)
-    if arithmetic_check and not lhs_sca_ty.is_ptr() and not rhs_sca_ty.is_ptr():
-        ret_sca_ty = computation_type_impl(lhs_sca_ty, lhs_is_scalar, rhs_sca_ty, rhs_is_scalar, div_or_mod)
-        if (lhs_is_scalar and lhs_scalar < 0 and ret_sca_ty.is_int_unsigned()
-                or rhs_is_scalar and rhs_scalar < 0 and ret_sca_ty.is_int_unsigned()):
-            raise ValueError("Cannot perform a binary operation between an unsigned tensor and a negative scalar. "
-                             "Perform a explicit cast on one of them.")
-        if ret_sca_ty.is_int():
-            if lhs_is_scalar and not (ret_sca_ty.get_int_min_value() <= lhs_scalar <= ret_sca_ty.get_int_max_value()):
-                raise ValueError(f"Scalar {lhs_scalar} is out of range for type {ret_sca_ty}")
-            if rhs_is_scalar and not (ret_sca_ty.get_int_min_value() <= rhs_scalar <= ret_sca_ty.get_int_max_value()):
-                raise ValueError(f"Scalar {rhs_scalar} is out of range for type {ret_sca_ty}")
-        lhs = full(
-            (), lhs_scalar, dtype=ret_sca_ty, builder=builder) if lhs_is_scalar else cast(lhs, ret_sca_ty, builder)
-        rhs = full(
-            (), rhs_scalar, dtype=ret_sca_ty, builder=builder) if rhs_is_scalar else cast(rhs, ret_sca_ty, builder)
+    def binary_op_sanitize_overflow_impl(self, lhs: TensorTy, rhs: TensorTy, binary_op: callable):
+        if lhs.type.scalar.int_bitwidth >= 64 or not self.builder.options.sanitize_overflow:
+            return
+        lhs_sca_ty = lhs.type.scalar
+        rhs_sca_ty = rhs.type.scalar
+        assert lhs_sca_ty == rhs_sca_ty
+        assert lhs_sca_ty.is_int()
+        lhs = self.cast(lhs, tl.int64)
+        rhs = self.cast(rhs, tl.int64)
+        ret = binary_op(lhs, rhs, False)
+        max_value = lhs_sca_ty.get_int_max_value()
+        max_value = self.full([], max_value, tl.int64)
+        min_value = lhs_sca_ty.get_int_min_value()
+        min_value = self.full([], min_value, tl.int64)
+        cond = self.and_(self.less_equal(ret, max_value), self.greater_equal(ret, min_value))
+        msg = f"int{lhs_sca_ty.int_bitwidth} overflow detected for operation {binary_op.__name__}"
+        self.device_assert(cond, msg)
 
-    # implicit broadcasting
-    lhs, rhs = broadcast_impl_value(lhs, rhs, builder)
-    return lhs, rhs
-
-
-def binary_op_sanitize_overflow_impl(lhs: tl.tensor, rhs: tl.tensor, builder: ir.builder, binary_op: callable):
-    if lhs.type.scalar.int_bitwidth >= 64 or not builder.options.sanitize_overflow:
-        return
-    lhs_sca_ty = lhs.type.scalar
-    rhs_sca_ty = rhs.type.scalar
-    assert lhs_sca_ty == rhs_sca_ty
-    assert lhs_sca_ty.is_int()
-    lhs = cast(lhs, tl.int64, builder)
-    rhs = cast(rhs, tl.int64, builder)
-    ret = binary_op(lhs, rhs, False, builder)
-    max_value = lhs_sca_ty.get_int_max_value()
-    max_value = tl.tensor(builder.get_int64(max_value), tl.int64)
-    min_value = lhs_sca_ty.get_int_min_value()
-    min_value = tl.tensor(builder.get_int64(min_value), tl.int64)
-    cond = and_(less_equal(ret, max_value, builder), greater_equal(ret, min_value, builder), builder)
-    msg = f"int{lhs_sca_ty.int_bitwidth} overflow detected for operation {binary_op.__name__}"
-    device_assert(cond, msg, builder)
-
-
-def add(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, sanitize_overflow: bool,
-        builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder, True, True)
-    input_scalar_ty = input.type.scalar
-    other_scalar_ty = other.type.scalar
-    if input_scalar_ty.is_ptr() and other_scalar_ty.is_ptr():
-        raise TypeError("cannot add pointers together")
-
-    # offset + ptr
-    # ptr + offset
-    if other_scalar_ty.is_ptr() and not input_scalar_ty.is_ptr():
-        input, other = other, input
+    def add(self, input: TensorTy | numbers.Number, other: TensorTy | numbers.Number,
+            sanitize_overflow: bool) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other, True, True)
         input_scalar_ty = input.type.scalar
         other_scalar_ty = other.type.scalar
-    if input_scalar_ty.is_ptr():
-        other_handle = other.handle
-        if other.dtype.is_int_unsigned() and other.dtype.int_bitwidth < 64:
-            # addptr treats offset as signed. Zero-extend unsigned offsets to ensure they're positive
-            i64_ty = other.type.with_element_ty(tl.int64).to_ir(builder)
-            other_handle = builder.create_int_cast(other.handle, i64_ty, False)
-        return tl.tensor(builder.create_addptr(input.handle, other_handle), input.type)
-    # float + float
-    elif input_scalar_ty.is_floating():
-        return tl.tensor(builder.create_fadd(input.handle, other.handle), input.type)
-    # int + int
-    elif input_scalar_ty.is_int():
-        if sanitize_overflow:
-            binary_op_sanitize_overflow_impl(input, other, builder, add)
-        return tl.tensor(builder.create_add(input.handle, other.handle), input.type)
-    raise TypeError(f"unexpected type {input_scalar_ty}")
+        if input_scalar_ty.is_ptr() and other_scalar_ty.is_ptr():
+            raise TypeError("cannot add pointers together")
 
-
-def sub(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, sanitize_overflow: bool,
-        builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder, True, False)
-    scalar_ty = input.type.scalar
-    # ptr - offset
-    if scalar_ty.is_ptr():
-        return tl.tensor(builder.create_addptr(input.handle, minus(other, builder).handle), input.type)
-    # float - float
-    if scalar_ty.is_floating():
-        return tl.tensor(builder.create_fsub(input.handle, other.handle), input.type)
-    # int - int
-    elif scalar_ty.is_int():
-        if sanitize_overflow:
-            binary_op_sanitize_overflow_impl(input, other, builder, sub)
-        return tl.tensor(builder.create_sub(input.handle, other.handle), input.type)
-    raise TypeError(f"unexpected type {scalar_ty}")
-
-
-def mul(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, sanitize_overflow: bool,
-        builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder)
-    scalar_ty = input.type.scalar
-    # float * float
-    if scalar_ty.is_floating():
-        return tl.tensor(builder.create_fmul(input.handle, other.handle), input.type)
-    # int * int
-    elif scalar_ty.is_int():
-        if sanitize_overflow:
-            binary_op_sanitize_overflow_impl(input, other, builder, mul)
-        return tl.tensor(builder.create_mul(input.handle, other.handle), input.type)
-    raise TypeError(f"unexpected type {scalar_ty}")
-
-
-def truediv(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder, False, False, True, True)
-    input_scalar_ty = input.type.scalar
-    other_scalar_ty = other.type.scalar
-    # float / int
-    if input_scalar_ty.is_floating() and other_scalar_ty.is_int():
-        other = cast(other, input_scalar_ty, builder)
-    # int / float
-    elif input_scalar_ty.is_int() and other_scalar_ty.is_floating():
-        input = cast(input, other_scalar_ty, builder)
-    # int / int (cast to tl.float32)
-    elif input_scalar_ty.is_int() and other_scalar_ty.is_int():
-        input = cast(input, tl.float32, builder)
-        other = cast(other, tl.float32, builder)
-    # float / float (cast to the highest exponent type)
-    elif input_scalar_ty.is_floating() and other_scalar_ty.is_floating():
-        if input_scalar_ty.fp_mantissa_width > other_scalar_ty.fp_mantissa_width:
-            other = cast(other, input_scalar_ty, builder)
-        else:
-            input = cast(input, other_scalar_ty, builder)
-    # unreachable
-    else:
+        # offset + ptr
+        # ptr + offset
+        if other_scalar_ty.is_ptr() and not input_scalar_ty.is_ptr():
+            input, other = other, input
+            input_scalar_ty = input.type.scalar
+            other_scalar_ty = other.type.scalar
+        if input_scalar_ty.is_ptr():
+            other_handle = other.handle
+            if other.dtype.is_int_unsigned() and other.dtype.int_bitwidth < 64:
+                # addptr treats offset as signed. Zero-extend unsigned offsets to ensure they're positive
+                i64_ty = other.type.with_element_ty(tl.int64).to_ir(self.builder)
+                other_handle = self.builder.create_int_cast(other.handle, i64_ty, False)
+            return self.tensor(self.builder.create_addptr(input.handle, other_handle), input.type)
+        # float + float
+        elif input_scalar_ty.is_floating():
+            return self.tensor(self.builder.create_fadd(input.handle, other.handle), input.type)
+        # int + int
+        elif input_scalar_ty.is_int():
+            if sanitize_overflow:
+                self.binary_op_sanitize_overflow_impl(input, other, self.add)
+            return self.tensor(self.builder.create_add(input.handle, other.handle), input.type)
         raise TypeError(f"unexpected type {input_scalar_ty}")
-    return tl.tensor(builder.create_fdiv(input.handle, other.handle), input.type)
 
+    def sub(self, input: TensorTy | numbers.Number, other: TensorTy | numbers.Number,
+            sanitize_overflow: bool) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other, True, False)
+        scalar_ty = input.type.scalar
+        # ptr - offset
+        if scalar_ty.is_ptr():
+            return self.add(input, self.minus(other), sanitize_overflow=False)
+        # float - float
+        if scalar_ty.is_floating():
+            return self.tensor(self.builder.create_fsub(input.handle, other.handle), input.type)
+        # int - int
+        elif scalar_ty.is_int():
+            if sanitize_overflow:
+                self.binary_op_sanitize_overflow_impl(input, other, self.sub)
+            return self.tensor(self.builder.create_sub(input.handle, other.handle), input.type)
+        raise TypeError(f"unexpected type {scalar_ty}")
 
-def floordiv(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder, False, False, True, True)
-    input_scalar_ty = input.type.scalar
-    other_scalar_ty = other.type.scalar
-    if input_scalar_ty.is_int() and other_scalar_ty.is_int():
-        ret_ty = integer_promote_impl(input_scalar_ty, other_scalar_ty)
-        input = cast(input, ret_ty, builder)
-        other = cast(other, ret_ty, builder)
-        if ret_ty.is_int_signed():
-            return tl.tensor(builder.create_sdiv(input.handle, other.handle), input.type)
+    def mul(self, input: TensorTy | numbers.Number, other: TensorTy | numbers.Number,
+            sanitize_overflow: bool) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other)
+        scalar_ty = input.type.scalar
+        # float * float
+        if scalar_ty.is_floating():
+            return self.tensor(self.builder.create_fmul(input.handle, other.handle), input.type)
+        # int * int
+        elif scalar_ty.is_int():
+            if sanitize_overflow:
+                self.binary_op_sanitize_overflow_impl(input, other, self.mul)
+            return self.tensor(self.builder.create_mul(input.handle, other.handle), input.type)
+        raise TypeError(f"unexpected type {scalar_ty}")
+
+    def truediv(self, input: TensorTy | numbers.Number, other: TensorTy | numbers.Number) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other, False, False, True, True)
+        input_scalar_ty = input.type.scalar
+        other_scalar_ty = other.type.scalar
+        # float / int
+        if input_scalar_ty.is_floating() and other_scalar_ty.is_int():
+            other = self.cast(other, input_scalar_ty)
+        # int / float
+        elif input_scalar_ty.is_int() and other_scalar_ty.is_floating():
+            input = self.cast(input, other_scalar_ty)
+        # int / int (cast to tl.float32)
+        elif input_scalar_ty.is_int() and other_scalar_ty.is_int():
+            input = self.cast(input, tl.float32)
+            other = self.cast(other, tl.float32)
+        # float / float (cast to the highest exponent type)
+        elif input_scalar_ty.is_floating() and other_scalar_ty.is_floating():
+            if input_scalar_ty.fp_mantissa_width > other_scalar_ty.fp_mantissa_width:
+                other = self.cast(other, input_scalar_ty)
+            else:
+                input = self.cast(input, other_scalar_ty)
+        # unreachable
         else:
-            return tl.tensor(builder.create_udiv(input.handle, other.handle), input.type)
-    raise TypeError(f"unexpected type {input_scalar_ty}")
+            raise TypeError(f"unexpected type {input_scalar_ty}")
+        return self.tensor(self.builder.create_fdiv(input.handle, other.handle), input.type)
 
+    def floordiv(self, input: TensorTy | numbers.Number, other: TensorTy | numbers.Number) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other, False, False, True, True)
+        input_scalar_ty = input.type.scalar
+        other_scalar_ty = other.type.scalar
+        if input_scalar_ty.is_int() and other_scalar_ty.is_int():
+            ret_ty = self.integer_promote_impl(input_scalar_ty, other_scalar_ty)
+            input = self.cast(input, ret_ty)
+            other = self.cast(other, ret_ty)
+            if ret_ty.is_int_signed():
+                return self.tensor(self.builder.create_sdiv(input.handle, other.handle), input.type)
+            else:
+                return self.tensor(self.builder.create_udiv(input.handle, other.handle), input.type)
+        raise TypeError(f"unexpected type {input_scalar_ty}")
 
-def fdiv(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, ieee_rounding: bool,
-         builder: ir.builder) -> tl.tensor:
-    input_scalar_ty = input.type.scalar
-    other_scalar_ty = other.type.scalar
-    if not input_scalar_ty.is_floating() or not other_scalar_ty.is_floating():
-        raise TypeError("both operands of fdiv must have floating scalar type")
-    input, other = binary_op_type_checking_impl(input, other, builder, False, False, False, True)
-    ret = builder.create_fdiv(input.handle, other.handle)
-    return tl.tensor(ret, input.type)
+    def fdiv(self, input: TensorTy | numbers.Number, other: TensorTy | numbers.Number, ieee_rounding: bool) -> TensorTy:
+        input_scalar_ty = input.type.scalar
+        other_scalar_ty = other.type.scalar
+        if not input_scalar_ty.is_floating() or not other_scalar_ty.is_floating():
+            raise TypeError("both operands of fdiv must have floating scalar type")
+        input, other = self.binary_op_type_checking_impl(input, other, False, False, False, True)
+        ret = self.builder.create_fdiv(input.handle, other.handle)
+        return self.tensor(ret, input.type)
 
-
-def mod(input: tl.tensor | numbers.Number, other: tl.tensor | numbers.Number, builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder, False, False, True, True)
-    scalar_ty = input.type.scalar
-    other_scalar_ty = other.type.scalar
-    # float % float
-    if scalar_ty.is_floating():
-        return tl.tensor(builder.create_frem(input.handle, other.handle), input.type)
-    # % int
-    elif scalar_ty.is_int():
-        if scalar_ty.int_signedness != other_scalar_ty.int_signedness:
-            raise TypeError("Cannot mod " + scalar_ty.__repr__() + " by " + other_scalar_ty.__repr__() + " "
-                            "because they have different signedness;"
-                            "this is unlikely to result in a useful answer. Cast them to the same signedness.")
-        if scalar_ty.is_int_signed():
-            return tl.tensor(builder.create_srem(input.handle, other.handle), input.type)
-        else:
-            return tl.tensor(builder.create_urem(input.handle, other.handle), input.type)
-    raise TypeError(f"unexpected type {scalar_ty}")
-
+    def mod(self, input: TensorTy | numbers.Number, other: TensorTy | numbers.Number) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other, False, False, True, True)
+        scalar_ty = input.type.scalar
+        other_scalar_ty = other.type.scalar
+        # float % float
+        if scalar_ty.is_floating():
+            return self.tensor(self.builder.create_frem(input.handle, other.handle), input.type)
+        # % int
+        elif scalar_ty.is_int():
+            if scalar_ty.int_signedness != other_scalar_ty.int_signedness:
+                raise TypeError("Cannot mod " + scalar_ty.__repr__() + " by " + other_scalar_ty.__repr__() + " "
+                                "because they have different signedness;"
+                                "this is unlikely to result in a useful answer. Cast them to the same signedness.")
+            if scalar_ty.is_int_signed():
+                return self.tensor(self.builder.create_srem(input.handle, other.handle), input.type)
+            else:
+                return self.tensor(self.builder.create_urem(input.handle, other.handle), input.type)
+        raise TypeError(f"unexpected type {scalar_ty}")
 
 ##############
 # other arithmetic ops
 ##############
 
-
-def minimum(x: tl.tensor, y: tl.tensor, propagate_nan: tl.PropagateNan, builder: ir.builder):
-    x, y = binary_op_type_checking_impl(x, y, builder)
-    dtype = x.dtype
-    if dtype.is_floating():
-        if propagate_nan == tl.PropagateNan.ALL:
-            return tl.tensor(builder.create_minimumf(x.handle, y.handle), x.type)
-        elif propagate_nan == tl.PropagateNan.NONE:
-            return tl.tensor(builder.create_minnumf(x.handle, y.handle), x.type)
+    def minimum(self, x: TensorTy, y: TensorTy, propagate_nan: tl.PropagateNan):
+        x, y = self.binary_op_type_checking_impl(x, y)
+        dtype = x.dtype
+        if dtype.is_floating():
+            if propagate_nan == tl.PropagateNan.ALL:
+                return self.tensor(self.builder.create_minimumf(x.handle, y.handle), x.type)
+            elif propagate_nan == tl.PropagateNan.NONE:
+                return self.tensor(self.builder.create_minnumf(x.handle, y.handle), x.type)
+            else:
+                raise ValueError(f"Unexpected propagate_nan {propagate_nan}")
+        elif dtype.is_int_signed():
+            return self.tensor(self.builder.create_minsi(x.handle, y.handle), x.type)
+        elif dtype.is_int_unsigned():
+            return self.tensor(self.builder.create_minui(x.handle, y.handle), x.type)
         else:
-            raise ValueError(f"Unexpected propagate_nan {propagate_nan}")
-    elif dtype.is_int_signed():
-        return tl.tensor(builder.create_minsi(x.handle, y.handle), x.type)
-    elif dtype.is_int_unsigned():
-        return tl.tensor(builder.create_minui(x.handle, y.handle), x.type)
-    else:
-        raise TypeError(f"Unexpected dtype {dtype}")
+            raise TypeError(f"Unexpected dtype {dtype}")
 
-
-def maximum(x: tl.tensor, y: tl.tensor, propagate_nan: tl.PropagateNan, builder: ir.builder):
-    x, y = binary_op_type_checking_impl(x, y, builder)
-    dtype = x.dtype
-    if dtype.is_floating():
-        if propagate_nan == tl.PropagateNan.ALL:
-            return tl.tensor(builder.create_maximumf(x.handle, y.handle), x.type)
-        elif propagate_nan == tl.PropagateNan.NONE:
-            return tl.tensor(builder.create_maxnumf(x.handle, y.handle), x.type)
+    def maximum(self, x: TensorTy, y: TensorTy, propagate_nan: tl.PropagateNan):
+        x, y = self.binary_op_type_checking_impl(x, y)
+        dtype = x.dtype
+        if dtype.is_floating():
+            if propagate_nan == tl.PropagateNan.ALL:
+                return self.tensor(self.builder.create_maximumf(x.handle, y.handle), x.type)
+            elif propagate_nan == tl.PropagateNan.NONE:
+                return self.tensor(self.builder.create_maxnumf(x.handle, y.handle), x.type)
+            else:
+                raise ValueError(f"Unexpected propagate_nan {propagate_nan}")
+        elif dtype.is_int_signed():
+            return self.tensor(self.builder.create_maxsi(x.handle, y.handle), x.type)
+        elif dtype.is_int_unsigned():
+            return self.tensor(self.builder.create_maxui(x.handle, y.handle), x.type)
         else:
-            raise ValueError(f"Unexpected propagate_nan {propagate_nan}")
-    elif dtype.is_int_signed():
-        return tl.tensor(builder.create_maxsi(x.handle, y.handle), x.type)
-    elif dtype.is_int_unsigned():
-        return tl.tensor(builder.create_maxui(x.handle, y.handle), x.type)
-    else:
-        raise TypeError(f"Unexpected dtype {dtype}")
+            raise TypeError(f"Unexpected dtype {dtype}")
 
+    def clamp(self, x: TensorTy, min: TensorTy, max: TensorTy, propagate_nan: tl.PropagateNan):
+        min, max = self.binary_op_type_checking_impl(min, max)
+        x, min = self.binary_op_type_checking_impl(x, min)
+        x, max = self.binary_op_type_checking_impl(x, max)
 
-def clamp(x: tl.tensor, min: tl.tensor, max: tl.tensor, propagate_nan: tl.PropagateNan, builder: ir.builder):
-    min, max = binary_op_type_checking_impl(min, max, builder)
-    x, min = binary_op_type_checking_impl(x, min, builder)
-    x, max = binary_op_type_checking_impl(x, max, builder)
-
-    dtype = x.dtype
-    if dtype.is_floating():
-        return tl.tensor(builder.create_clampf(x.handle, min.handle, max.handle, propagate_nan), x.type)
-    else:
-        raise TypeError(f"Unexpected dtype {dtype}. Only floating point clamp is supported")
-
+        dtype = x.dtype
+        if dtype.is_floating():
+            return self.tensor(self.builder.create_clampf(x.handle, min.handle, max.handle, propagate_nan), x.type)
+        else:
+            raise TypeError(f"Unexpected dtype {dtype}. Only floating point clamp is supported")
 
 ##############
 # bitwise ops
 ##############
 
+    def bitwise_op_type_checking_impl(self, input: TensorTy, other: TensorTy) -> Tuple[TensorTy, TensorTy]:
+        input, other = self.binary_op_type_checking_impl(input, other)
+        input_sca_ty = input.type.scalar
+        other_sca_ty = other.type.scalar
+        if not input_sca_ty.is_int() or not other_sca_ty.is_int():
+            raise IncompatibleTypeErrorImpl(input_sca_ty, other_sca_ty)
+        ret_sca_ty = self.integer_promote_impl(input_sca_ty, other_sca_ty)
+        if ret_sca_ty != input_sca_ty:
+            input = self.cast(input, ret_sca_ty)
+        if ret_sca_ty != other_sca_ty:
+            other = self.cast(other, ret_sca_ty)
+        return input, other
 
-def bitwise_op_type_checking_impl(input: tl.tensor, other: tl.tensor,
-                                  builder: ir.builder) -> Tuple[tl.tensor, tl.tensor]:
-    input, other = binary_op_type_checking_impl(input, other, builder)
-    input_sca_ty = input.type.scalar
-    other_sca_ty = other.type.scalar
-    if not input_sca_ty.is_int() or not other_sca_ty.is_int():
-        raise IncompatibleTypeErrorImpl(input_sca_ty, other_sca_ty)
-    ret_sca_ty = integer_promote_impl(input_sca_ty, other_sca_ty)
-    if ret_sca_ty != input_sca_ty:
-        input = cast(input, ret_sca_ty, builder)
-    if ret_sca_ty != other_sca_ty:
-        other = cast(other, ret_sca_ty, builder)
-    return input, other
+    def and_(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.bitwise_op_type_checking_impl(input, other)
+        return self.tensor(self.builder.create_and(input.handle, other.handle), input.type)
 
+    def or_(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.bitwise_op_type_checking_impl(input, other)
+        return self.tensor(self.builder.create_or(input.handle, other.handle), input.type)
 
-def and_(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = bitwise_op_type_checking_impl(input, other, builder)
-    return tl.tensor(builder.create_and(input.handle, other.handle), input.type)
+    def xor_(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.bitwise_op_type_checking_impl(input, other)
+        return self.tensor(self.builder.create_xor(input.handle, other.handle), input.type)
 
+    def logical_and(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        if not input.type.is_int1():
+            input = self.bitcast(input, tl.int1)
+        if not other.type.is_int1():
+            other = self.bitcast(other, tl.int1)
+        return self.and_(input, other)
 
-def or_(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = bitwise_op_type_checking_impl(input, other, builder)
-    return tl.tensor(builder.create_or(input.handle, other.handle), input.type)
+    def logical_or(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        if not input.type.is_int1():
+            input = self.bitcast(input, tl.int1)
+        if not other.type.is_int1():
+            other = self.bitcast(other, tl.int1)
+        return self.or_(input, other)
 
+    def not_(self, input: TensorTy):
+        if not input.type.is_int1():
+            input = self.bitcast(input, tl.int1)
+        return self.invert(input)
 
-def xor_(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = bitwise_op_type_checking_impl(input, other, builder)
-    return tl.tensor(builder.create_xor(input.handle, other.handle), input.type)
+    def lshr(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.bitwise_op_type_checking_impl(input, other)
+        return self.tensor(self.builder.create_lshr(input.handle, other.handle), input.type)
 
+    def ashr(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.bitwise_op_type_checking_impl(input, other)
+        return self.tensor(self.builder.create_ashr(input.handle, other.handle), input.type)
 
-def logical_and(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    if not input.type.is_int1():
-        input = bitcast(input, tl.dtype("int1"), builder)
-    if not other.type.is_int1():
-        other = bitcast(other, tl.dtype("int1"), builder)
-    return and_(input, other, builder)
-
-
-def logical_or(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    if not input.type.is_int1():
-        input = bitcast(input, tl.dtype("int1"), builder)
-    if not other.type.is_int1():
-        other = bitcast(other, tl.dtype("int1"), builder)
-    return or_(input, other, builder)
-
-
-def not_(input: tl.tensor, builder: ir.builder):
-    if not input.type.is_int1():
-        input = bitcast(input, tl.dtype("int1"), builder)
-    return invert(input, builder)
-
-
-def lshr(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = bitwise_op_type_checking_impl(input, other, builder)
-    return tl.tensor(builder.create_lshr(input.handle, other.handle), input.type)
-
-
-def ashr(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = bitwise_op_type_checking_impl(input, other, builder)
-    return tl.tensor(builder.create_ashr(input.handle, other.handle), input.type)
-
-
-def shl(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = bitwise_op_type_checking_impl(input, other, builder)
-    return tl.tensor(builder.create_shl(input.handle, other.handle), input.type)
-
+    def shl(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.bitwise_op_type_checking_impl(input, other)
+        return self.tensor(self.builder.create_shl(input.handle, other.handle), input.type)
 
 # ===----------------------------------------------------------------------===//
 #                               Unary Operators
 # ===----------------------------------------------------------------------===//
 
+    def plus(self, input: TensorTy) -> TensorTy:
+        return input
 
-def plus(input: tl.tensor) -> tl.tensor:
-    return input
+    def minus(self, input: TensorTy) -> TensorTy:
+        input_sca_ty = input.type.scalar
+        if input_sca_ty.is_ptr():
+            raise ValueError("wrong type argument to unary minus (" + input_sca_ty.__repr__() + ")")
+        _0 = self.tensor(self.builder.get_null_value(input_sca_ty.to_ir(self.builder)), input_sca_ty)
+        return self.sub(_0, input, True)
 
-
-def minus(input: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input_sca_ty = input.type.scalar
-    if input_sca_ty.is_ptr():
-        raise ValueError("wrong type argument to unary minus (" + input_sca_ty.__repr__() + ")")
-    _0 = tl.tensor(builder.get_null_value(input_sca_ty.to_ir(builder)), input_sca_ty)
-    return sub(_0, input, True, builder)
-
-
-def invert(input: tl.tensor, builder: tl.tensor) -> tl.tensor:
-    input_sca_ty = input.type.scalar
-    if input_sca_ty.is_ptr() or input_sca_ty.is_floating():
-        raise ValueError("wrong type argument to unary invert (" + input_sca_ty.__repr__() + ")")
-    _1 = tl.tensor(builder.get_all_ones_value(input_sca_ty.to_ir(builder)), input_sca_ty)
-    return xor_(input, _1, builder)
-
+    def invert(self, input: TensorTy) -> TensorTy:
+        input_sca_ty = input.type.scalar
+        if input_sca_ty.is_ptr() or input_sca_ty.is_floating():
+            raise ValueError("wrong type argument to unary invert (" + input_sca_ty.__repr__() + ")")
+        _1 = self.tensor(self.builder.get_all_ones_value(input_sca_ty.to_ir(self.builder)), input_sca_ty)
+        return self.xor_(input, _1)
 
 # ===----------------------------------------------------------------------===//
 #                               Comparison Operators
 # ===----------------------------------------------------------------------===//
-def _bool_like(v: tl.tensor) -> tl.block_type:
-    return v.type.with_element_ty(tl.int1)
 
+    def _bool_like(self, v: TensorTy) -> tl.block_type:
+        return v.type.with_element_ty(tl.int1)
 
-def greater_than(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder)
-    scalar_ty = input.type.scalar
-    # float > float
-    if scalar_ty.is_floating():
-        return tl.tensor(builder.create_fcmpOGT(input.handle, other.handle), _bool_like(input))
-    # > int
-    elif scalar_ty.is_int():
-        if scalar_ty.is_int_signed():
-            return tl.tensor(builder.create_icmpSGT(input.handle, other.handle), _bool_like(input))
-        else:
-            return tl.tensor(builder.create_icmpUGT(input.handle, other.handle), _bool_like(input))
-    raise TypeError(f"unexpected type {scalar_ty}")
+    def greater_than(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other)
+        scalar_ty = input.type.scalar
+        # float > float
+        if scalar_ty.is_floating():
+            return self.tensor(self.builder.create_fcmpOGT(input.handle, other.handle), self._bool_like(input))
+        # > int
+        elif scalar_ty.is_int():
+            if scalar_ty.is_int_signed():
+                return self.tensor(self.builder.create_icmpSGT(input.handle, other.handle), self._bool_like(input))
+            else:
+                return self.tensor(self.builder.create_icmpUGT(input.handle, other.handle), self._bool_like(input))
+        raise TypeError(f"unexpected type {scalar_ty}")
 
+    def greater_equal(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other)
+        scalar_ty = input.type.scalar
+        # float >= float
+        if scalar_ty.is_floating():
+            return self.tensor(self.builder.create_fcmpOGE(input.handle, other.handle), self._bool_like(input))
+        # >= int
+        elif scalar_ty.is_int():
+            if scalar_ty.is_int_signed():
+                return self.tensor(self.builder.create_icmpSGE(input.handle, other.handle), self._bool_like(input))
+            else:
+                return self.tensor(self.builder.create_icmpUGE(input.handle, other.handle), self._bool_like(input))
+        raise TypeError(f"unexpected type {scalar_ty}")
 
-def greater_equal(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder)
-    scalar_ty = input.type.scalar
-    # float >= float
-    if scalar_ty.is_floating():
-        return tl.tensor(builder.create_fcmpOGE(input.handle, other.handle), _bool_like(input))
-    # >= int
-    elif scalar_ty.is_int():
-        if scalar_ty.is_int_signed():
-            return tl.tensor(builder.create_icmpSGE(input.handle, other.handle), _bool_like(input))
-        else:
-            return tl.tensor(builder.create_icmpUGE(input.handle, other.handle), _bool_like(input))
-    raise TypeError(f"unexpected type {scalar_ty}")
+    def less_than(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other)
+        scalar_ty = input.type.scalar
+        # float < float
+        if scalar_ty.is_floating():
+            return self.tensor(self.builder.create_fcmpOLT(input.handle, other.handle), self._bool_like(input))
+        # < int
+        elif scalar_ty.is_int():
+            if scalar_ty.is_int_signed():
+                return self.tensor(self.builder.create_icmpSLT(input.handle, other.handle), self._bool_like(input))
+            else:
+                return self.tensor(self.builder.create_icmpULT(input.handle, other.handle), self._bool_like(input))
+        raise TypeError(f"unexpected type {scalar_ty}")
 
+    def less_equal(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other)
+        scalar_ty = input.type.scalar
+        # float < float
+        if scalar_ty.is_floating():
+            return self.tensor(self.builder.create_fcmpOLE(input.handle, other.handle), self._bool_like(input))
+        # < int
+        elif scalar_ty.is_int():
+            if scalar_ty.is_int_signed():
+                return self.tensor(self.builder.create_icmpSLE(input.handle, other.handle), self._bool_like(input))
+            else:
+                return self.tensor(self.builder.create_icmpULE(input.handle, other.handle), self._bool_like(input))
+        raise TypeError(f"unexpected type {scalar_ty}")
 
-def less_than(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder)
-    scalar_ty = input.type.scalar
-    # float < float
-    if scalar_ty.is_floating():
-        return tl.tensor(builder.create_fcmpOLT(input.handle, other.handle), _bool_like(input))
-    # < int
-    elif scalar_ty.is_int():
-        if scalar_ty.is_int_signed():
-            return tl.tensor(builder.create_icmpSLT(input.handle, other.handle), _bool_like(input))
-        else:
-            return tl.tensor(builder.create_icmpULT(input.handle, other.handle), _bool_like(input))
-    raise TypeError(f"unexpected type {scalar_ty}")
+    def equal(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other)
+        scalar_ty = input.type.scalar
+        # float == float
+        if scalar_ty.is_floating():
+            return self.tensor(self.builder.create_fcmpOEQ(input.handle, other.handle), self._bool_like(input))
+        # == int
+        elif scalar_ty.is_int():
+            return self.tensor(self.builder.create_icmpEQ(input.handle, other.handle), self._bool_like(input))
+        raise TypeError(f"unexpected type {scalar_ty}")
 
-
-def less_equal(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder)
-    scalar_ty = input.type.scalar
-    # float < float
-    if scalar_ty.is_floating():
-        return tl.tensor(builder.create_fcmpOLE(input.handle, other.handle), _bool_like(input))
-    # < int
-    elif scalar_ty.is_int():
-        if scalar_ty.is_int_signed():
-            return tl.tensor(builder.create_icmpSLE(input.handle, other.handle), _bool_like(input))
-        else:
-            return tl.tensor(builder.create_icmpULE(input.handle, other.handle), _bool_like(input))
-    raise TypeError(f"unexpected type {scalar_ty}")
-
-
-def equal(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder)
-    scalar_ty = input.type.scalar
-    # float == float
-    if scalar_ty.is_floating():
-        return tl.tensor(builder.create_fcmpOEQ(input.handle, other.handle), _bool_like(input))
-    # == int
-    elif scalar_ty.is_int():
-        return tl.tensor(builder.create_icmpEQ(input.handle, other.handle), _bool_like(input))
-    raise TypeError(f"unexpected type {scalar_ty}")
-
-
-def not_equal(input: tl.tensor, other: tl.tensor, builder: ir.builder) -> tl.tensor:
-    input, other = binary_op_type_checking_impl(input, other, builder)
-    scalar_ty = input.type.scalar
-    # float == float
-    if scalar_ty.is_floating():
-        return tl.tensor(builder.create_fcmpUNE(input.handle, other.handle), _bool_like(input))
-    # == int
-    elif scalar_ty.is_int():
-        return tl.tensor(builder.create_icmpNE(input.handle, other.handle), _bool_like(input))
-    raise TypeError(f"unexpected type {scalar_ty}")
-
+    def not_equal(self, input: TensorTy, other: TensorTy) -> TensorTy:
+        input, other = self.binary_op_type_checking_impl(input, other)
+        scalar_ty = input.type.scalar
+        # float == float
+        if scalar_ty.is_floating():
+            return self.tensor(self.builder.create_fcmpUNE(input.handle, other.handle), self._bool_like(input))
+        # == int
+        elif scalar_ty.is_int():
+            return self.tensor(self.builder.create_icmpNE(input.handle, other.handle), self._bool_like(input))
+        raise TypeError(f"unexpected type {scalar_ty}")
 
 # ===----------------------------------------------------------------------===//
 #                               Block Creation
 # ===----------------------------------------------------------------------===//
 
+    def arange(self, start: int, end: int, *, ret_ty: tl.block_type = None) -> TensorTy:
+        if not isinstance(start, int) or not isinstance(end, int):
+            raise ValueError("arange's arguments must be of type tl.constexpr")
+        is_start_int64 = bool(start >> 32)
+        is_end_int64 = bool(end >> 32)
+        if is_start_int64 or is_end_int64:
+            raise ValueError("arange must fit in int32")
+        if end <= start:
+            raise ValueError("arange's end argument must be greater than the start argument")
+        range = end - start
+        if (range & (range - 1)) != 0:
+            raise ValueError("arange's range must be a power of 2")
+        shape = [range]
+        if ret_ty is None:
+            ret_ty = tl.block_type(tl.int32, shape)
+        ret_ty_ir = ret_ty.to_ir(self.builder)
+        return self.tensor(self.builder.create_make_range(ret_ty_ir, start, end), ret_ty)
 
-def arange(start: int, end: int, builder: ir.builder, *, ret_ty: tl.block_type = None) -> tl.tensor:
-    if not isinstance(start, int) or not isinstance(end, int):
-        raise ValueError("arange's arguments must be of type tl.constexpr")
-    is_start_int64 = bool(start >> 32)
-    is_end_int64 = bool(end >> 32)
-    if is_start_int64 or is_end_int64:
-        raise ValueError("arange must fit in int32")
-    if end <= start:
-        raise ValueError("arange's end argument must be greater than the start argument")
-    range = end - start
-    if (range & (range - 1)) != 0:
-        raise ValueError("arange's range must be a power of 2")
-    shape = [range]
-    if ret_ty is None:
-        ret_ty = tl.block_type(tl.int32, shape)
-    ret_ty_ir = ret_ty.to_ir(builder)
-    return tl.tensor(builder.create_make_range(ret_ty_ir, start, end), ret_ty)
-
-
-def full(shape: List[int], value, dtype: tl.dtype, builder: ir.builder) -> tl.tensor:
-    if isinstance(value, tl.tensor):
-        assert value.numel.value == 1, "only accepts size-1 tensor"
-        value = cast(value, dtype, builder)
-    else:
-        # scalar
-        if dtype is None:
-            raise ValueError("dtype must be specified when value is not a tensor")
-        if value == 0:
-            value = builder.get_null_value(dtype.to_ir(builder))
+    def full(self, shape: List[int], value, dtype: tl.dtype) -> TensorTy:
+        if isinstance(value, tl.tensor):
+            assert value.numel.value == 1, "only accepts size-1 tensor"
+            value = self.cast(value, dtype)
         else:
-            get_value_fn = getattr(builder, f"get_{dtype.name}")
-            value = get_value_fn(value)
-        value = tl.tensor(value, dtype)
+            # scalar
+            if dtype is None:
+                raise ValueError("dtype must be specified when value is not a tensor")
+            if value == 0:
+                value = self.builder.get_null_value(dtype.to_ir(self.builder))
+            else:
+                get_value_fn = getattr(self.builder, f"get_{dtype.name}")
+                value = get_value_fn(value)
+            value = self.tensor(value, dtype)
 
-    return splat(value, shape, builder)
-
+        return self.splat(value, shape)
 
 # ===----------------------------------------------------------------------===//
 #                               Shape Manipulation
 # ===----------------------------------------------------------------------===//
 
+    def splat(self, value: TensorTy, shape: List[int]) -> TensorTy:
+        assert not value.type.is_block(), "Cannot splat a block tensor"
+        if len(shape) == 0:
+            return value
+        ret_ty = tl.block_type(value.dtype, shape)
+        return self.tensor(self.builder.create_splat(ret_ty.to_ir(self.builder), value.handle), ret_ty)
 
-def splat(value: tl.tensor, shape: List[int], builder: ir.builder) -> tl.tensor:
-    assert not value.type.is_block(), "Cannot splat a block tensor"
-    if len(shape) == 0:
-        return value
-    ret_ty = tl.block_type(value.dtype, shape)
-    return tl.tensor(builder.create_splat(ret_ty.to_ir(builder), value.handle), ret_ty)
+    def reshape(self, input: TensorTy, dst_shape: List[int], can_reorder: bool) -> TensorTy:
+        numel = 1
+        for s in dst_shape:
+            numel *= s
+        if input.type.numel != numel:
+            raise ValueError("reshape() cannot change total number of elements in tensor")
+        ret_ty = tl.block_type(input.type.scalar, dst_shape)
+        return self.tensor(self.builder.create_reshape(input.handle, dst_shape, can_reorder), ret_ty)
 
+    def expand_dims(self, input: TensorTy, axis: int) -> TensorTy:
+        dst_shape = [tl._unwrap_if_constexpr(x) for x in input.shape]
+        dst_shape.insert(axis, 1)
 
-def reshape(input: tl.tensor, dst_shape: List[int], can_reorder: bool, builder: ir.builder) -> tl.tensor:
-    numel = 1
-    for s in dst_shape:
-        numel *= s
-    if input.type.numel != numel:
-        raise ValueError("reshape() cannot change total number of elements in tensor")
-    ret_ty = tl.block_type(input.type.scalar, dst_shape)
-    return tl.tensor(builder.create_reshape(input.handle, dst_shape, can_reorder), ret_ty)
+        if not input.type.is_block():
+            return self.splat(input, shape=dst_shape)
 
+        ret_ty = tl.block_type(input.type.scalar, dst_shape)
+        return self.tensor(self.builder.create_expand_dims(input.handle, axis), ret_ty)
 
-def expand_dims(input: tl.tensor, axis: int, builder: ir.builder) -> tl.tensor:
-    dst_shape = [tl._unwrap_if_constexpr(x) for x in input.shape]
-    dst_shape.insert(axis, 1)
+    def cat(self, lhs: TensorTy, rhs: TensorTy, can_reorder: bool) -> TensorTy:
+        assert can_reorder, "current implementation of `cat` always may reorder elements"
+        assert len(lhs.shape) == 1
+        ret_type = tl.block_type(lhs.type.scalar, [lhs.shape[0] + rhs.shape[0]])
+        return self.tensor(self.builder.create_cat(lhs.handle, rhs.handle), ret_type)
 
-    if not input.type.is_block():
-        return splat(input, shape=dst_shape, builder=builder)
+    def join(self, a: TensorTy, b: TensorTy) -> TensorTy:
+        a, b = self.broadcast_impl_value(a, b)
 
-    ret_ty = tl.block_type(input.type.scalar, dst_shape)
-    return tl.tensor(builder.create_expand_dims(input.handle, axis), ret_ty)
+        # The IR can't handle joining two scalars, so upcast them to 1D tensors,
+        # then downcast the result.
+        was_rank_1 = a.shape == []
+        if was_rank_1:
+            a = self.expand_dims(a, 0)
+            b = self.expand_dims(b, 0)
 
+        if isinstance(a.shape[-1], tl.constexpr):
+            two = tl.constexpr(2)
+        else:
+            two = 2
+        new_shape = a.shape + [two]
 
-def cat(lhs: tl.tensor, rhs: tl.tensor, can_reorder: bool, builder: ir.builder) -> tl.tensor:
-    assert can_reorder, "current implementation of `cat` always may reorder elements"
-    assert len(lhs.shape) == 1
-    ret_type = tl.block_type(lhs.type.scalar, [lhs.shape[0] + rhs.shape[0]])
-    return tl.tensor(builder.create_cat(lhs.handle, rhs.handle), ret_type)
+        ret_type = tl.block_type(a.type.scalar, new_shape)
+        ret = self.tensor(self.builder.create_join(a.handle, b.handle), ret_type)
 
+        if was_rank_1:
+            ret = self.reshape(ret, [2], can_reorder=False)
 
-def join(a: tl.tensor, b: tl.tensor, builder: ir.builder) -> tl.tensor:
-    a, b = broadcast_impl_value(a, b, builder)
+        return ret
 
-    # The IR can't handle joining two scalars, so upcast them to 1D tensors,
-    # then downcast the result.
-    was_rank_1 = a.shape == []
-    if was_rank_1:
-        a = expand_dims(a, 0, builder)
-        b = expand_dims(b, 0, builder)
+    def split(self, a: TensorTy) -> Tuple[TensorTy, TensorTy]:
+        assert (len(a.shape) > 0)
+        assert (tl._unwrap_if_constexpr(a.shape[-1]) == 2)
 
-    if isinstance(a.shape[-1], tl.constexpr):
-        two = tl.constexpr(2)
-    else:
-        two = 2
-    new_shape = a.shape + [two]
+        new_shape = a.shape[:-1]
+        ret_type = tl.block_type(a.type.scalar, new_shape)
+        outLHS, outRHS = self.builder.create_split(a.handle)
+        return (
+            self.tensor(outLHS, ret_type),
+            self.tensor(outRHS, ret_type),
+        )
 
-    ret_type = tl.block_type(a.type.scalar, new_shape)
-    ret = tl.tensor(builder.create_join(a.handle, b.handle), ret_type)
+    def permute(self, input: TensorTy, dims: Tuple[int]) -> TensorTy:
+        if len(input.shape) != len(dims):
+            raise ValueError("permute dims must have the same length as input shape")
+        if sorted(tl._unwrap_if_constexpr(d) for d in dims) != list(range(len(dims))):
+            raise ValueError(f"permute dims must be a permutation of 0, 1, ..., n-1, but were {dims}")
 
-    if was_rank_1:
-        ret = reshape(ret, [2], can_reorder=False, builder=builder)
+        ret_type = tl.block_type(input.type.scalar, [input.shape[d] for d in dims])
+        return self.tensor(self.builder.create_trans(input.handle, dims), ret_type)
 
-    return ret
+    def broadcast_impl_shape(self, input: TensorTy, shape: Tuple[int]) -> TensorTy:
+        if not input.type.is_block():
+            return self.splat(input, shape)
+        src_shape = input.type.get_block_shapes()
+        if len(src_shape) != len(shape):
+            raise ValueError(f"Cannot broadcast, rank mismatch: {src_shape}, {shape}")
+        if shape == src_shape:
+            return input
+        for i, item in enumerate(src_shape):
+            if shape[i] != item and item != 1:
+                raise ValueError(f"Cannot broadcast, the expanded size of the tensor ({shape[i]})"
+                                 f" must match the existing size ({item}) at non-singleton dimension"
+                                 f" {i}: {src_shape}, {shape}")
+        ret_ty = tl.block_type(input.type.scalar, shape)
+        return self.tensor(self.builder.create_broadcast(input.handle, shape), ret_ty)
 
+    def broadcast_impl_value(self, lhs: TensorTy, rhs: TensorTy) -> TensorTy:
+        lhs_ty = lhs.type
+        rhs_ty = rhs.type
 
-def split(a: tl.tensor, builder: ir.builder) -> Tuple[tl.tensor, tl.tensor]:
-    assert (len(a.shape) > 0)
-    assert (tl._unwrap_if_constexpr(a.shape[-1]) == 2)
+        # make_shape_compatible(block, scalar)
+        if lhs_ty.is_block() and not rhs_ty.is_block():
+            rhs_ty = lhs_ty.with_element_ty(rhs_ty.scalar)
+            rhs = self.tensor(self.builder.create_splat(rhs_ty.to_ir(self.builder), rhs.handle), rhs_ty)
+        # make_shape_compatible(scalar, block)
+        elif not lhs_ty.is_block() and rhs_ty.is_block():
+            lhs_ty = rhs_ty.with_element_ty(lhs_ty.scalar)
+            lhs = self.tensor(self.builder.create_splat(lhs_ty.to_ir(self.builder), lhs.handle), lhs_ty)
+        # make_shape_compatible(block, block)
+        elif lhs_ty.is_block() and rhs_ty.is_block():
+            lhs_shape = lhs_ty.get_block_shapes()
+            rhs_shape = rhs_ty.get_block_shapes()
 
-    new_shape = a.shape[:-1]
-    ret_type = tl.block_type(a.type.scalar, new_shape)
-    outLHS, outRHS = builder.create_split(a.handle)
-    return (
-        tl.tensor(outLHS, ret_type),
-        tl.tensor(outRHS, ret_type),
-    )
+            if len(lhs_shape) < len(rhs_shape):
+                # Add new axes to lhs
+                for _ in range(len(lhs_shape), len(rhs_shape)):
+                    lhs = self.tensor(self.builder.create_expand_dims(lhs.handle, 0),
+                                      tl.block_type(lhs_ty.scalar, [1] + lhs_shape.values))
+                    lhs_ty = lhs.type
+                    lhs_shape = lhs_ty.get_block_shapes()
+            elif len(rhs_shape) < len(lhs_shape):
+                # Add new axes to rhs
+                for _ in range(len(rhs_shape), len(lhs_shape)):
+                    rhs = self.tensor(self.builder.create_expand_dims(rhs.handle, 0),
+                                      tl.block_type(rhs_ty.scalar, [1] + rhs_shape.values))
+                    rhs_ty = rhs.type
+                    rhs_shape = rhs_ty.get_block_shapes()
+            assert len(rhs_shape) == len(lhs_shape)
 
-
-def permute(input: tl.tensor, dims: Tuple[int], builder: ir.builder) -> tl.tensor:
-    if len(input.shape) != len(dims):
-        raise ValueError("permute dims must have the same length as input shape")
-    if sorted(tl._unwrap_if_constexpr(d) for d in dims) != list(range(len(dims))):
-        raise ValueError(f"permute dims must be a permutation of 0, 1, ..., n-1, but were {dims}")
-
-    ret_type = tl.block_type(input.type.scalar, [input.shape[d] for d in dims])
-    return tl.tensor(builder.create_trans(input.handle, dims), ret_type)
-
-
-def broadcast_impl_shape(input: tl.tensor, shape: Tuple[int], builder: ir.builder) -> tl.tensor:
-    if not input.type.is_block():
-        return splat(input, shape, builder)
-    src_shape = input.type.get_block_shapes()
-    if len(src_shape) != len(shape):
-        raise ValueError(f"Cannot broadcast, rank mismatch: {src_shape}, {shape}")
-    if shape == src_shape:
-        return input
-    for i, item in enumerate(src_shape):
-        if shape[i] != item and item != 1:
-            raise ValueError(f"Cannot broadcast, the expanded size of the tensor ({shape[i]})"
-                             f" must match the existing size ({item}) at non-singleton dimension"
-                             f" {i}: {src_shape}, {shape}")
-    ret_ty = tl.block_type(input.type.scalar, shape)
-    return tl.tensor(builder.create_broadcast(input.handle, shape), ret_ty)
-
-
-def broadcast_impl_value(lhs: tl.tensor, rhs: tl.tensor, builder: ir.builder) -> tl.tensor:
-    lhs_ty = lhs.type
-    rhs_ty = rhs.type
-
-    # make_shape_compatible(block, scalar)
-    if lhs_ty.is_block() and not rhs_ty.is_block():
-        rhs_ty = lhs_ty.with_element_ty(rhs_ty.scalar)
-        rhs = tl.tensor(builder.create_splat(rhs_ty.to_ir(builder), rhs.handle), rhs_ty)
-    # make_shape_compatible(scalar, block)
-    elif not lhs_ty.is_block() and rhs_ty.is_block():
-        lhs_ty = rhs_ty.with_element_ty(lhs_ty.scalar)
-        lhs = tl.tensor(builder.create_splat(lhs_ty.to_ir(builder), lhs.handle), lhs_ty)
-    # make_shape_compatible(block, block)
-    elif lhs_ty.is_block() and rhs_ty.is_block():
-        lhs_shape = lhs_ty.get_block_shapes()
-        rhs_shape = rhs_ty.get_block_shapes()
-
-        if len(lhs_shape) < len(rhs_shape):
-            # Add new axes to lhs
-            for _ in range(len(lhs_shape), len(rhs_shape)):
-                lhs = tl.tensor(builder.create_expand_dims(lhs.handle, 0),
-                                tl.block_type(lhs_ty.scalar, [1] + lhs_shape.values))
-                lhs_ty = lhs.type
-                lhs_shape = lhs_ty.get_block_shapes()
-        elif len(rhs_shape) < len(lhs_shape):
-            # Add new axes to rhs
-            for _ in range(len(rhs_shape), len(lhs_shape)):
-                rhs = tl.tensor(builder.create_expand_dims(rhs.handle, 0),
-                                tl.block_type(rhs_ty.scalar, [1] + rhs_shape.values))
-                rhs_ty = rhs.type
-                rhs_shape = rhs_ty.get_block_shapes()
-        assert len(rhs_shape) == len(lhs_shape)
-
-        ret_shape = []
-        for i, left in enumerate(lhs_shape):
-            right = rhs_shape[i]
-            if left == 1:
-                ret_shape.append(right)
-            elif (right == 1) or (right == left):
-                ret_shape.append(left)
-            else:
-                raise ValueError("Cannot make_shape_compatible: incompatible dimensions "
-                                 "at index " + str(i) + ": " + str(left) + " and " + str(right))
-        if lhs_shape != ret_shape:
-            ret_ty = tl.block_type(lhs_ty.scalar, ret_shape)
-            lhs = tl.tensor(builder.create_broadcast(lhs.handle, ret_shape), ret_ty)
-        if rhs_shape != ret_shape:
-            ret_ty = tl.block_type(rhs_ty.scalar, ret_shape)
-            rhs = tl.tensor(builder.create_broadcast(rhs.handle, ret_shape), ret_ty)
-    # (scalar, scalar) => returns original blocks
-    return lhs, rhs
-
+            ret_shape = []
+            for i, left in enumerate(lhs_shape):
+                right = rhs_shape[i]
+                if left == 1:
+                    ret_shape.append(right)
+                elif (right == 1) or (right == left):
+                    ret_shape.append(left)
+                else:
+                    raise ValueError("Cannot make_shape_compatible: incompatible dimensions "
+                                     "at index " + str(i) + ": " + str(left) + " and " + str(right))
+            if lhs_shape != ret_shape:
+                ret_ty = tl.block_type(lhs_ty.scalar, ret_shape)
+                lhs = self.tensor(self.builder.create_broadcast(lhs.handle, ret_shape), ret_ty)
+            if rhs_shape != ret_shape:
+                ret_ty = tl.block_type(rhs_ty.scalar, ret_shape)
+                rhs = self.tensor(self.builder.create_broadcast(rhs.handle, ret_shape), ret_ty)
+        # (scalar, scalar) => returns original blocks
+        return lhs, rhs
 
 #######
 # cast
 #######
 
+    def _str_to_rounding_mode(self, rounding_mode: Optional[str]):
+        if rounding_mode is None:
+            return None
+        if rounding_mode == 'rtne':
+            return ir.ROUNDING_MODE.RTNE
+        if rounding_mode == 'rtz':
+            return ir.ROUNDING_MODE.RTZ
+        raise ValueError(f"Invalid rounding mode: {rounding_mode}. Supported rounding modes are 'rtne' and 'rtz'.")
 
-def _str_to_rounding_mode(rounding_mode: Optional[str]):
-    if rounding_mode is None:
-        return None
-    if rounding_mode == 'rtne':
-        return ir.ROUNDING_MODE.RTNE
-    if rounding_mode == 'rtz':
-        return ir.ROUNDING_MODE.RTZ
-    raise ValueError(f"Invalid rounding mode: {rounding_mode}. Supported rounding modes are 'rtne' and 'rtz'.")
+    def bitcast(self, input: TensorTy, dst_ty: tl.dtype) -> TensorTy:
+        src_ty = input.type
+        if src_ty.is_block():
+            dst_ty = src_ty.with_element_ty(dst_ty.scalar)
+        if src_ty == dst_ty:
+            return input
+        src_sca_ty = src_ty.scalar
+        dst_sca_ty = dst_ty.scalar
+        if src_sca_ty.is_ptr() or dst_sca_ty.is_ptr():
+            return self.cast(input, dst_ty)
+        # Bitcast
+        src_bits = src_sca_ty.primitive_bitwidth
+        dst_bits = dst_sca_ty.primitive_bitwidth
+        if src_bits != dst_bits:
+            raise ValueError("Cannot bitcast data-type of size " + str(src_bits) + " to "
+                             "data-type of size " + str(dst_bits))
+        return self.tensor(self.builder.create_bitcast(input.handle, dst_ty.to_ir(self.builder)), dst_ty)
 
+    def cast(self, input: TensorTy, dst_ty: tl.dtype, fp_downcast_rounding: Optional[str] = None) -> TensorTy:
+        src_ty = input.type
+        src_sca_ty = src_ty.scalar
+        dst_sca_ty = dst_ty.scalar
+        if src_sca_ty == dst_sca_ty:
+            return input
+        if src_ty.is_block():
+            dst_ty = src_ty.with_element_ty(dst_sca_ty)
 
-def bitcast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder) -> tl.tensor:
-    src_ty = input.type
-    if src_ty.is_block():
-        dst_ty = src_ty.with_element_ty(dst_ty.scalar)
-    if src_ty == dst_ty:
-        return input
-    src_sca_ty = src_ty.scalar
-    dst_sca_ty = dst_ty.scalar
-    if src_sca_ty.is_ptr() or dst_sca_ty.is_ptr():
-        return cast(input, dst_ty, builder)
-    # Bitcast
-    src_bits = src_sca_ty.primitive_bitwidth
-    dst_bits = dst_sca_ty.primitive_bitwidth
-    if src_bits != dst_bits:
-        raise ValueError("Cannot bitcast data-type of size " + str(src_bits) + " to "
-                         "data-type of size " + str(dst_bits))
-    return tl.tensor(builder.create_bitcast(input.handle, dst_ty.to_ir(builder)), dst_ty)
-
-
-def cast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder,
-         fp_downcast_rounding: Optional[str] = None) -> tl.tensor:
-    src_ty = input.type
-    src_sca_ty = src_ty.scalar
-    dst_sca_ty = dst_ty.scalar
-    if src_sca_ty == dst_sca_ty:
-        return input
-    if src_ty.is_block():
-        dst_ty = src_ty.with_element_ty(dst_sca_ty)
-
-    # For fp downcasting default rounding mode should be RTNE, for all other conversions it should
-    # not be set
-    fp_downcast_rounding = _str_to_rounding_mode(fp_downcast_rounding)
-    use_custom_rounding = False
-    if dst_sca_ty.is_floating() and src_sca_ty.is_floating(
-    ) and dst_sca_ty.primitive_bitwidth < src_sca_ty.primitive_bitwidth:
-        if fp_downcast_rounding is None: fp_downcast_rounding = ir.ROUNDING_MODE.RTNE
-        elif fp_downcast_rounding != ir.ROUNDING_MODE.RTNE: use_custom_rounding = True
-    else:
-        if fp_downcast_rounding is not None:
-            raise ValueError("fp_downcast_rounding should be set only for truncating fp conversions. "
-                             "Source scalar type is " + str(src_sca_ty) + " and destination type is " + str(dst_sca_ty))
-
-    if (src_sca_ty.is_fp8e4b15() or dst_sca_ty.is_fp8e4b15()):
-        assert builder.codegen_fns.get(
-            "convert_custom_types") is not None, "target doesn't provide conversion for this type."
-        return builder.codegen_fns["convert_custom_types"](input, dst_ty, fp_downcast_rounding, _builder=builder)
-    # Casting with customized floating types involved: fp8 <=> bf16, fp16, fp32, fp64
-    # and non-default rounding modes for downcasting
-    if (src_sca_ty.is_fp8() and dst_sca_ty.is_floating()) or \
-       (src_sca_ty.is_floating() and dst_sca_ty.is_fp8()) or \
-       use_custom_rounding:
-        return tl.tensor(builder.create_fp_to_fp(input.handle, dst_ty.to_ir(builder), fp_downcast_rounding), dst_ty)
-
-    # bf16 <=> (not fp32)
-    if (src_sca_ty.is_fp16() and not dst_sca_ty.is_fp32()) or \
-       (src_sca_ty.is_bf16() and not dst_sca_ty.is_fp32()):
-        return cast(cast(input, tl.float32, builder), dst_sca_ty, builder)
-
-    # Standard floating types' casting: truncation
-    #   fp64 => fp32, fp16, bf16
-    #   fp32 => fp16, bf16
-    truncate_fp = src_sca_ty.is_floating() and \
-        dst_sca_ty.is_floating() and \
-        src_sca_ty.primitive_bitwidth > dst_sca_ty.primitive_bitwidth
-    if truncate_fp:
-        return tl.tensor(builder.create_fp_trunc(input.handle, dst_ty.to_ir(builder)), dst_ty)
-
-    # Standard floating types' casting: extension
-    #   fp32 => fp64
-    #   fp16 => fp32, fp64
-    #   bf16 => fp32, fp64
-    ext_fp = src_sca_ty.is_floating() and \
-        dst_sca_ty.is_floating() and \
-        src_sca_ty.primitive_bitwidth < dst_sca_ty.primitive_bitwidth
-    if ext_fp:
-        return tl.tensor(builder.create_fp_ext(input.handle, dst_ty.to_ir(builder)), dst_ty)
-
-    # Casting between integer types
-    if src_sca_ty.is_int() and dst_sca_ty.is_int() and \
-       (src_sca_ty.int_bitwidth != dst_sca_ty.int_bitwidth or src_sca_ty.int_signedness != dst_sca_ty.int_signedness):
-        sign_extend = src_sca_ty.is_int_signed() and not src_sca_ty.is_bool()
-        if dst_sca_ty.is_bool():
-            ty = input.dtype.to_ir(builder)
-            _0 = tl.tensor(builder.get_null_value(ty), input.dtype)
-            return not_equal(input, _0, builder)
+        # For fp downcasting default rounding mode should be RTNE, for all other conversions it should
+        # not be set
+        fp_downcast_rounding = self._str_to_rounding_mode(fp_downcast_rounding)
+        use_custom_rounding = False
+        if dst_sca_ty.is_floating() and src_sca_ty.is_floating(
+        ) and dst_sca_ty.primitive_bitwidth < src_sca_ty.primitive_bitwidth:
+            if fp_downcast_rounding is None: fp_downcast_rounding = ir.ROUNDING_MODE.RTNE
+            elif fp_downcast_rounding != ir.ROUNDING_MODE.RTNE: use_custom_rounding = True
         else:
-            return tl.tensor(builder.create_int_cast(input.handle, dst_ty.to_ir(builder), sign_extend), dst_ty)
+            if fp_downcast_rounding is not None:
+                raise ValueError("fp_downcast_rounding should be set only for truncating fp conversions. "
+                                 "Source scalar type is " + str(src_sca_ty) + " and destination type is " +
+                                 str(dst_sca_ty))
 
-    # Casting standard floating types to integer types
-    if src_sca_ty.is_standard_floating() and dst_sca_ty.is_int():
-        if dst_sca_ty.is_bool():
-            ty = input.dtype.to_ir(builder)
-            _0 = tl.tensor(builder.get_null_value(ty), input.dtype)
-            return not_equal(input, _0, builder)
-        elif dst_sca_ty.is_int_signed():
-            return tl.tensor(builder.create_fp_to_si(input.handle, dst_ty.to_ir(builder)), dst_ty)
-        else:
-            return tl.tensor(builder.create_fp_to_ui(input.handle, dst_ty.to_ir(builder)), dst_ty)
+        if (src_sca_ty.is_fp8e4b15() or dst_sca_ty.is_fp8e4b15()):
+            assert self.builder.codegen_fns.get(
+                "convert_custom_types") is not None, "target doesn't provide conversion for this type."
+            return self.builder.codegen_fns["convert_custom_types"](input, dst_ty, fp_downcast_rounding, _semantic=self)
+        # Casting with customized floating types involved: fp8 <=> bf16, fp16, fp32, fp64
+        # and non-default rounding modes for downcasting
+        if (src_sca_ty.is_fp8() and dst_sca_ty.is_floating()) or \
+           (src_sca_ty.is_floating() and dst_sca_ty.is_fp8()) or \
+           use_custom_rounding:
+            return self.tensor(
+                self.builder.create_fp_to_fp(input.handle, dst_ty.to_ir(self.builder), fp_downcast_rounding), dst_ty)
 
-    # Casting integer types to standard floating types
-    if src_sca_ty.is_int() and dst_sca_ty.is_standard_floating():
-        if src_sca_ty.is_bool() or not src_sca_ty.is_int_signed():
-            return tl.tensor(builder.create_ui_to_fp(input.handle, dst_ty.to_ir(builder)), dst_ty)
-        else:
-            return tl.tensor(builder.create_si_to_fp(input.handle, dst_ty.to_ir(builder)), dst_ty)
+        # bf16 <=> (not fp32)
+        if (src_sca_ty.is_fp16() and not dst_sca_ty.is_fp32()) or \
+           (src_sca_ty.is_bf16() and not dst_sca_ty.is_fp32()):
+            return self.cast(self.cast(input, tl.float32), dst_sca_ty)
 
-    # Casting pointer types to integer types
-    if src_sca_ty.is_ptr() and dst_sca_ty.is_int():
-        bitwidth = dst_sca_ty.int_bitwidth
-        if bitwidth == 64:
-            return tl.tensor(builder.create_ptr_to_int(input.handle, dst_ty.to_ir(builder)), dst_ty)
-        if bitwidth == 1:
-            return not_equal(cast(input, tl.int64, builder), tl.tensor(builder.get_int64(0), tl.int64), builder)
+        # Standard floating types' casting: truncation
+        #   fp64 => fp32, fp16, bf16
+        #   fp32 => fp16, bf16
+        truncate_fp = src_sca_ty.is_floating() and \
+            dst_sca_ty.is_floating() and \
+            src_sca_ty.primitive_bitwidth > dst_sca_ty.primitive_bitwidth
+        if truncate_fp:
+            return self.tensor(self.builder.create_fp_trunc(input.handle, dst_ty.to_ir(self.builder)), dst_ty)
 
-    # Casting integer types to pointer types
-    if src_sca_ty.is_int() and dst_sca_ty.is_ptr():
-        return tl.tensor(builder.create_int_to_ptr(input.handle, dst_ty.to_ir(builder)), dst_ty)
+        # Standard floating types' casting: extension
+        #   fp32 => fp64
+        #   fp16 => fp32, fp64
+        #   bf16 => fp32, fp64
+        ext_fp = src_sca_ty.is_floating() and \
+            dst_sca_ty.is_floating() and \
+            src_sca_ty.primitive_bitwidth < dst_sca_ty.primitive_bitwidth
+        if ext_fp:
+            return self.tensor(self.builder.create_fp_ext(input.handle, dst_ty.to_ir(self.builder)), dst_ty)
 
-    # Casting pointer types to pointer types
-    if src_sca_ty.is_ptr() and dst_sca_ty.is_ptr():
-        return tl.tensor(builder.create_bitcast(input.handle, dst_ty.to_ir(builder)), dst_ty)
+        # Casting between integer types
+        if src_sca_ty.is_int() and dst_sca_ty.is_int() and \
+           (src_sca_ty.int_bitwidth != dst_sca_ty.int_bitwidth or src_sca_ty.int_signedness != dst_sca_ty.int_signedness):
+            sign_extend = src_sca_ty.is_int_signed() and not src_sca_ty.is_bool()
+            if dst_sca_ty.is_bool():
+                ty = input.dtype.to_ir(self.builder)
+                _0 = self.tensor(self.builder.get_null_value(ty), input.dtype)
+                return self.not_equal(input, _0)
+            else:
+                return self.tensor(self.builder.create_int_cast(input.handle, dst_ty.to_ir(self.builder), sign_extend),
+                                   dst_ty)
 
-    assert False, f'cannot cast {input} to {dst_ty}'
+        # Casting standard floating types to integer types
+        if src_sca_ty.is_standard_floating() and dst_sca_ty.is_int():
+            if dst_sca_ty.is_bool():
+                ty = input.dtype.to_ir(self.builder)
+                _0 = self.tensor(self.builder.get_null_value(ty), input.dtype)
+                return self.not_equal(input, _0)
+            elif dst_sca_ty.is_int_signed():
+                return self.tensor(self.builder.create_fp_to_si(input.handle, dst_ty.to_ir(self.builder)), dst_ty)
+            else:
+                return self.tensor(self.builder.create_fp_to_ui(input.handle, dst_ty.to_ir(self.builder)), dst_ty)
 
+        # Casting integer types to standard floating types
+        if src_sca_ty.is_int() and dst_sca_ty.is_standard_floating():
+            if src_sca_ty.is_bool() or not src_sca_ty.is_int_signed():
+                return self.tensor(self.builder.create_ui_to_fp(input.handle, dst_ty.to_ir(self.builder)), dst_ty)
+            else:
+                return self.tensor(self.builder.create_si_to_fp(input.handle, dst_ty.to_ir(self.builder)), dst_ty)
+
+        # Casting pointer types to integer types
+        if src_sca_ty.is_ptr() and dst_sca_ty.is_int():
+            bitwidth = dst_sca_ty.int_bitwidth
+            if bitwidth == 64:
+                return self.tensor(self.builder.create_ptr_to_int(input.handle, dst_ty.to_ir(self.builder)), dst_ty)
+            if bitwidth == 1:
+                return self.not_equal(self.cast(input, tl.int64), self.tensor(self.builder.get_int64(0), tl.int64))
+
+        # Casting integer types to pointer types
+        if src_sca_ty.is_int() and dst_sca_ty.is_ptr():
+            return self.tensor(self.builder.create_int_to_ptr(input.handle, dst_ty.to_ir(self.builder)), dst_ty)
+
+        # Casting pointer types to pointer types
+        if src_sca_ty.is_ptr() and dst_sca_ty.is_ptr():
+            return self.tensor(self.builder.create_bitcast(input.handle, dst_ty.to_ir(self.builder)), dst_ty)
+
+        assert False, f'cannot cast {input} to {dst_ty}'
 
 # ===----------------------------------------------------------------------===//
 #                               Memory Operators
 # ===----------------------------------------------------------------------===//
 
+    def _str_to_load_cache_modifier(self, cache_modifier):
+        cache = ir.CACHE_MODIFIER.NONE  # default
+        if cache_modifier:
+            if cache_modifier == ".ca":
+                cache = ir.CACHE_MODIFIER.CA
+            elif cache_modifier == ".cg":
+                cache = ir.CACHE_MODIFIER.CG
+            elif cache_modifier == ".cv":
+                cache = ir.CACHE_MODIFIER.CV
+            else:
+                raise ValueError(f"Cache modifier {cache_modifier} not supported")
+        return cache
 
-def _str_to_load_cache_modifier(cache_modifier):
-    cache = ir.CACHE_MODIFIER.NONE  # default
-    if cache_modifier:
-        if cache_modifier == ".ca":
-            cache = ir.CACHE_MODIFIER.CA
-        elif cache_modifier == ".cg":
-            cache = ir.CACHE_MODIFIER.CG
-        elif cache_modifier == ".cv":
-            cache = ir.CACHE_MODIFIER.CV
-        else:
-            raise ValueError(f"Cache modifier {cache_modifier} not supported")
-    return cache
+    def _str_to_store_cache_modifier(self, cache_modifier):
+        cache = ir.CACHE_MODIFIER.NONE  # default
+        if cache_modifier:
+            if cache_modifier == ".wb":
+                cache = ir.CACHE_MODIFIER.WB
+            elif cache_modifier == ".cg":
+                cache = ir.CACHE_MODIFIER.CG
+            elif cache_modifier == ".cs":
+                cache = ir.CACHE_MODIFIER.CS
+            elif cache_modifier == ".wt":
+                cache = ir.CACHE_MODIFIER.WT
+            else:
+                raise ValueError(f"Cache modifier {cache_modifier} not supported")
+        return cache
 
+    def _str_to_eviction_policy(self, eviction_policy):
+        eviction = ir.EVICTION_POLICY.NORMAL  # default
+        if eviction_policy:
+            if eviction_policy == "evict_last":
+                eviction = ir.EVICTION_POLICY.EVICT_LAST
+            elif eviction_policy == "evict_first":
+                eviction = ir.EVICTION_POLICY.EVICT_FIRST
+            else:
+                raise ValueError(f"Eviction policy {eviction_policy} not supported")
+        return eviction
 
-def _str_to_store_cache_modifier(cache_modifier):
-    cache = ir.CACHE_MODIFIER.NONE  # default
-    if cache_modifier:
-        if cache_modifier == ".wb":
-            cache = ir.CACHE_MODIFIER.WB
-        elif cache_modifier == ".cg":
-            cache = ir.CACHE_MODIFIER.CG
-        elif cache_modifier == ".cs":
-            cache = ir.CACHE_MODIFIER.CS
-        elif cache_modifier == ".wt":
-            cache = ir.CACHE_MODIFIER.WT
-        else:
-            raise ValueError(f"Cache modifier {cache_modifier} not supported")
-    return cache
+    def _str_to_padding_option(self, padding_option):
+        padding = None  # default
+        if padding_option:
+            if padding_option == "zero":
+                padding = ir.PADDING_OPTION.PAD_ZERO
+            elif padding_option == "nan":
+                padding = ir.PADDING_OPTION.PAD_NAN
+            else:
+                raise ValueError(f"Padding option {padding_option} not supported")
+        return padding
 
+    def _str_to_sem(self, sem_option):
+        sem = ir.MEM_SEMANTIC.ACQUIRE_RELEASE
+        if sem_option:
+            if sem_option == "acquire":
+                sem = ir.MEM_SEMANTIC.ACQUIRE
+            elif sem_option == "release":
+                sem = ir.MEM_SEMANTIC.RELEASE
+            elif sem_option == "acq_rel":
+                sem = ir.MEM_SEMANTIC.ACQUIRE_RELEASE
+            elif sem_option == "relaxed":
+                sem = ir.MEM_SEMANTIC.RELAXED
+            else:
+                raise ValueError(f"Memory semantic {sem_option} not supported")
+        return sem
 
-def _str_to_eviction_policy(eviction_policy):
-    eviction = ir.EVICTION_POLICY.NORMAL  # default
-    if eviction_policy:
-        if eviction_policy == "evict_last":
-            eviction = ir.EVICTION_POLICY.EVICT_LAST
-        elif eviction_policy == "evict_first":
-            eviction = ir.EVICTION_POLICY.EVICT_FIRST
-        else:
-            raise ValueError(f"Eviction policy {eviction_policy} not supported")
-    return eviction
+    def _str_to_scope(self, scope_option):
+        scope = ir.MEM_SYNC_SCOPE.GPU
+        if scope_option:
+            if scope_option == "gpu":
+                scope = ir.MEM_SYNC_SCOPE.GPU
+            elif scope_option == "cta":
+                scope = ir.MEM_SYNC_SCOPE.CTA
+            elif scope_option == "sys":
+                scope = ir.MEM_SYNC_SCOPE.SYSTEM
+            else:
+                raise ValueError(f"Memory semantic {scope_option} not supported")
+        return scope
 
+    def _canonicalize_boundary_check(self, boundary_check, block_shape):
+        if boundary_check:
+            if not hasattr(boundary_check, "__iter__"):
+                boundary_check = [boundary_check]
+            boundary_check = [elem.value if isinstance(elem, tl.constexpr) else elem for elem in boundary_check]
+            for dim in boundary_check:
+                assert isinstance(dim, int) and 0 <= dim < len(block_shape)
+            assert len(boundary_check) > 0
+            assert len(boundary_check) == len(set(boundary_check)), "Duplicate dimension in `boundary_check`"
+            return sorted(boundary_check)
+        return ()
 
-def _str_to_padding_option(padding_option):
-    padding = None  # default
-    if padding_option:
-        if padding_option == "zero":
-            padding = ir.PADDING_OPTION.PAD_ZERO
-        elif padding_option == "nan":
-            padding = ir.PADDING_OPTION.PAD_NAN
-        else:
-            raise ValueError(f"Padding option {padding_option} not supported")
-    return padding
-
-
-def _str_to_sem(sem_option):
-    sem = ir.MEM_SEMANTIC.ACQUIRE_RELEASE
-    if sem_option:
-        if sem_option == "acquire":
-            sem = ir.MEM_SEMANTIC.ACQUIRE
-        elif sem_option == "release":
-            sem = ir.MEM_SEMANTIC.RELEASE
-        elif sem_option == "acq_rel":
-            sem = ir.MEM_SEMANTIC.ACQUIRE_RELEASE
-        elif sem_option == "relaxed":
-            sem = ir.MEM_SEMANTIC.RELAXED
-        else:
-            raise ValueError(f"Memory semantic {sem_option} not supported")
-    return sem
-
-
-def _str_to_scope(scope_option):
-    scope = ir.MEM_SYNC_SCOPE.GPU
-    if scope_option:
-        if scope_option == "gpu":
-            scope = ir.MEM_SYNC_SCOPE.GPU
-        elif scope_option == "cta":
-            scope = ir.MEM_SYNC_SCOPE.CTA
-        elif scope_option == "sys":
-            scope = ir.MEM_SYNC_SCOPE.SYSTEM
-        else:
-            raise ValueError(f"Memory semantic {scope_option} not supported")
-    return scope
-
-
-def _canonicalize_boundary_check(boundary_check, block_shape):
-    if boundary_check:
-        if not hasattr(boundary_check, "__iter__"):
-            boundary_check = [boundary_check]
-        boundary_check = [elem.value if isinstance(elem, tl.constexpr) else elem for elem in boundary_check]
-        for dim in boundary_check:
-            assert isinstance(dim, int) and 0 <= dim < len(block_shape)
-        assert len(boundary_check) > 0
-        assert len(boundary_check) == len(set(boundary_check)), "Duplicate dimension in `boundary_check`"
-        return sorted(boundary_check)
-    return ()
-
-
-def _load_block_pointer(ptr, mask, other, boundary_check, padding, cache, eviction, is_volatile, builder):
-    # Load by a block pointer: `pointer_type<block_type<>>`
-    # Block pointer can not have `mask` and `other` arguments
-    if mask is not None or other is not None:
-        raise ValueError("`mask` and `other` arguments cannot be specified for loading block pointers")
-
-    elt_ty = ptr.type.element_ty.element_ty
-    assert elt_ty != tl.int1, "`tl.int1` should be rewritten in `tl.make_block_ptr`"
-    if elt_ty.is_int() and padding == ir.PADDING_OPTION.PAD_NAN:
-        raise ValueError("Padding option `nan` is not supported for integer block pointers")
-
-    # `dst_ty` is de-referenced type of the pointer type
-    dst_ty = ptr.type.element_ty
-
-    # Check `boundary_check` argument
-    boundary_check = _canonicalize_boundary_check(boundary_check, dst_ty.get_block_shapes())
-
-    # Build IR
-    return tl.tensor(
-        builder.create_tensor_pointer_load(ptr.handle, boundary_check, padding, cache, eviction, is_volatile), dst_ty)
-
-
-def _load_legacy(ptr, mask, other, boundary_check, padding, cache, eviction, is_volatile, builder):
-    # Load by a tensor of pointers or a pointer of scalar: `block_type<pointer_type<>>` or `pointer_type<>`
-    if not ptr.type.scalar.is_ptr():
-        raise ValueError(f"Unsupported ptr type {ptr.type.__repr__()} in `tl.load`")
-
-    # Check `mask`, `other`, `boundary_check`, and `padding` arguments
-    if mask is None and other is not None:
-        raise ValueError("`other` cannot be provided without `mask`")
-    if padding or boundary_check:
-        raise ValueError("`padding_option` or `boundary_check` argument is not supported for loading a tensor of"
-                         "pointers or loading a scalar. Because the compiler does not know the boundary; please "
-                         "use block pointers (defined by `make_block_ptr`) instead")
-
-    # For a pointer of scalar, check the type of `mask` and `other`
-    if not ptr.type.is_block():
-        if mask and mask.type.is_block():
-            raise ValueError("Mask argument cannot be block type if pointer argument is not a block")
-        if other and other.type.is_block():
-            raise ValueError("Other argument cannot be block type if pointer argument is not a block")
-
-    # Make `mask` and `other` into the same shape as `ptr`
-    if ptr.type.is_block():
-        if mask is not None:
-            mask = broadcast_impl_shape(mask, ptr.type.get_block_shapes(), builder)
-        if other is not None:
-            other = broadcast_impl_shape(other, ptr.type.get_block_shapes(), builder)
-
-    # Get `pointer_type<elt_ty>` and `elt_ty`
-    ptr_ty = ptr.type.scalar
-    elt_ty = ptr_ty.element_ty
-
-    # Treat `pointer_type<tl.int1>` as `pointer_type<tl.int8>`
-    is_bool = elt_ty == tl.int1
-    if is_bool:
-        elt_ty = tl.int8
-        ptr_ty = tl.pointer_type(elt_ty, ptr_ty.address_space)
-        ptr = cast(ptr, ptr_ty, builder)
-
-    # Cast `other` into `elt_ty` type
-    if other is not None:
-        other = cast(other, elt_ty, builder)
-
-    # Create loaded result type `dst_ty`
-    if ptr.type.is_block():
-        shape = ptr.type.get_block_shapes()
-        dst_ty = tl.block_type(elt_ty, shape)
-    else:
-        # Load by de-referencing the pointer of scalar
-        dst_ty = elt_ty
-
-    # Build IR
-    if mask is None:
-        ret = tl.tensor(builder.create_load(ptr.handle, cache, eviction, is_volatile), dst_ty)
-    else:
-        ret = tl.tensor(
-            builder.create_masked_load(ptr.handle, mask.handle, other.handle if other else None, cache, eviction,
-                                       is_volatile), dst_ty)
-    if is_bool:
-        ret = cast(ret, tl.int1, builder)
-    return ret
-
-
-def load(ptr: tl.tensor, mask: Optional[tl.tensor], other: Optional[tl.tensor], boundary_check: Tuple,
-         padding_option: str, cache_modifier: str, eviction_policy: str, is_volatile: bool,
-         builder: ir.builder) -> tl.tensor:
-    # Cache, eviction and padding options
-    cache = _str_to_load_cache_modifier(cache_modifier)
-    eviction = _str_to_eviction_policy(eviction_policy)
-    padding = _str_to_padding_option(padding_option)
-
-    if ptr.type.is_ptr() and ptr.type.element_ty.is_block():
+    def _load_block_pointer(self, ptr, mask, other, boundary_check, padding, cache, eviction, is_volatile):
         # Load by a block pointer: `pointer_type<block_type<>>`
-        return _load_block_pointer(ptr, mask, other, boundary_check, padding, cache, eviction, is_volatile, builder)
-    else:
+        # Block pointer can not have `mask` and `other` arguments
+        if mask is not None or other is not None:
+            raise ValueError("`mask` and `other` arguments cannot be specified for loading block pointers")
+
+        elt_ty = ptr.type.element_ty.element_ty
+        assert elt_ty != tl.int1, "`tl.int1` should be rewritten in `tl.make_block_ptr`"
+        if elt_ty.is_int() and padding == ir.PADDING_OPTION.PAD_NAN:
+            raise ValueError("Padding option `nan` is not supported for integer block pointers")
+
+        # `dst_ty` is de-referenced type of the pointer type
+        dst_ty = ptr.type.element_ty
+
+        # Check `boundary_check` argument
+        boundary_check = self._canonicalize_boundary_check(boundary_check, dst_ty.get_block_shapes())
+
+        # Build IR
+        return self.tensor(
+            self.builder.create_tensor_pointer_load(ptr.handle, boundary_check, padding, cache, eviction, is_volatile),
+            dst_ty)
+
+    def _load_legacy(self, ptr, mask, other, boundary_check, padding, cache, eviction, is_volatile):
         # Load by a tensor of pointers or a pointer of scalar: `block_type<pointer_type<>>` or `pointer_type<>`
-        return _load_legacy(ptr, mask, other, boundary_check, padding, cache, eviction, is_volatile, builder)
+        if not ptr.type.scalar.is_ptr():
+            raise ValueError(f"Unsupported ptr type {ptr.type.__repr__()} in `tl.load`")
 
+        # Check `mask`, `other`, `boundary_check`, and `padding` arguments
+        if mask is None and other is not None:
+            raise ValueError("`other` cannot be provided without `mask`")
+        if padding or boundary_check:
+            raise ValueError("`padding_option` or `boundary_check` argument is not supported for loading a tensor of"
+                             "pointers or loading a scalar. Because the compiler does not know the boundary; please "
+                             "use block pointers (defined by `make_block_ptr`) instead")
 
-def descriptor_load(desc: tl.tensor_descriptor_base, offsets, cache_modifier: str, eviction_policy: str,
-                    builder: ir.builder) -> tl.tensor:
-    assert isinstance(desc, tl.tensor_descriptor_base)
-    ndim = len(desc.block_shape)
-    assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
+        # For a pointer of scalar, check the type of `mask` and `other`
+        if not ptr.type.is_block():
+            if mask and mask.type.is_block():
+                raise ValueError("Mask argument cannot be block type if pointer argument is not a block")
+            if other and other.type.is_block():
+                raise ValueError("Other argument cannot be block type if pointer argument is not a block")
 
-    offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
-    x = builder.create_descriptor_load(desc.handle, offsets, _str_to_load_cache_modifier(cache_modifier),
-                                       _str_to_eviction_policy(eviction_policy))
-    return tl.tensor(x, desc.block_type)
+        # Make `mask` and `other` into the same shape as `ptr`
+        if ptr.type.is_block():
+            if mask is not None:
+                mask = self.broadcast_impl_shape(mask, ptr.type.get_block_shapes())
+            if other is not None:
+                other = self.broadcast_impl_shape(other, ptr.type.get_block_shapes())
 
+        # Get `pointer_type<elt_ty>` and `elt_ty`
+        ptr_ty = ptr.type.scalar
+        elt_ty = ptr_ty.element_ty
 
-def validate_store_like(desc: tl.tensor_descriptor_base, value: tl.tensor, offsets) -> None:
-    assert isinstance(desc, tl.tensor_descriptor_base)
-    ndim = len(desc.block_shape)
-    assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
-    assert value.shape == desc.block_shape
+        # Treat `pointer_type<tl.int1>` as `pointer_type<tl.int8>`
+        is_bool = elt_ty == tl.int1
+        if is_bool:
+            elt_ty = tl.int8
+            ptr_ty = tl.pointer_type(elt_ty, ptr_ty.address_space)
+            ptr = self.cast(ptr, ptr_ty)
 
+        # Cast `other` into `elt_ty` type
+        if other is not None:
+            other = self.cast(other, elt_ty)
 
-def descriptor_store(desc: tl.tensor_descriptor_base, value: tl.tensor, offsets, builder: ir.builder) -> tl.tensor:
-    validate_store_like(desc, value, offsets)
-    offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
-    return tl.tensor(builder.create_descriptor_store(desc.handle, value.handle, offsets), tl.void)
+        # Create loaded result type `dst_ty`
+        if ptr.type.is_block():
+            shape = ptr.type.get_block_shapes()
+            dst_ty = tl.block_type(elt_ty, shape)
+        else:
+            # Load by de-referencing the pointer of scalar
+            dst_ty = elt_ty
 
+        # Build IR
+        if mask is None:
+            ret = self.tensor(self.builder.create_load(ptr.handle, cache, eviction, is_volatile), dst_ty)
+        else:
+            ret = self.tensor(
+                self.builder.create_masked_load(ptr.handle, mask.handle, other.handle if other else None, cache,
+                                                eviction, is_volatile), dst_ty)
+        if is_bool:
+            ret = self.cast(ret, tl.int1)
+        return ret
 
-def descriptor_atomic_add(desc: tl.tensor_descriptor_base, value: tl.tensor, offsets, builder: ir.builder) -> tl.tensor:
-    validate_store_like(desc, value, offsets)
-    assert desc.dtype in {tl.uint32, tl.int32, tl.uint64, tl.float32, tl.float16, tl.bfloat16}, "Unsupported dtype"
-    offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
-    kind = ir.DESCRIPTOR_REDUCE_KIND.ADD
-    return tl.tensor(builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
+    def load(self, ptr: TensorTy, mask: Optional[TensorTy], other: Optional[TensorTy], boundary_check: Tuple,
+             padding_option: str, cache_modifier: str, eviction_policy: str, is_volatile: bool) -> TensorTy:
+        # Cache, eviction and padding options
+        cache = self._str_to_load_cache_modifier(cache_modifier)
+        eviction = self._str_to_eviction_policy(eviction_policy)
+        padding = self._str_to_padding_option(padding_option)
 
+        if ptr.type.is_ptr() and ptr.type.element_ty.is_block():
+            # Load by a block pointer: `pointer_type<block_type<>>`
+            return self._load_block_pointer(ptr, mask, other, boundary_check, padding, cache, eviction, is_volatile)
+        else:
+            # Load by a tensor of pointers or a pointer of scalar: `block_type<pointer_type<>>` or `pointer_type<>`
+            return self._load_legacy(ptr, mask, other, boundary_check, padding, cache, eviction, is_volatile)
 
-def _has_native_tma():
-    target = driver.active.get_current_target()
-    return (target.backend == "cuda" and target.arch >= 90)
+    def descriptor_load(self, desc: tl.tensor_descriptor_base, offsets, cache_modifier: str,
+                        eviction_policy: str) -> TensorTy:
+        assert isinstance(desc, tl.tensor_descriptor_base)
+        ndim = len(desc.block_shape)
+        assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
 
+        offsets = self._convert_to_ir_values(offsets, require_i64=False)
+        x = self.builder.create_descriptor_load(desc.handle, offsets, self._str_to_load_cache_modifier(cache_modifier),
+                                                self._str_to_eviction_policy(eviction_policy))
+        return self.tensor(x, desc.block_type)
 
-def _descriptor_atomic_min_max_supported(dtype):
-    assert dtype in {tl.uint32, tl.int32, tl.uint64, tl.int64, tl.float16, tl.bfloat16}, "Unsupported dtype"
-    if dtype in {tl.float16, tl.bfloat16}:
-        assert _has_native_tma(), "16-bit float types require native tma support"
+    def validate_store_like(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> None:
+        assert isinstance(desc, tl.tensor_descriptor_base)
+        ndim = len(desc.block_shape)
+        assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
+        assert value.shape == desc.block_shape
 
+    def descriptor_store(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> TensorTy:
+        self.validate_store_like(desc, value, offsets)
+        offsets = self._convert_to_ir_values(offsets, require_i64=False)
+        return self.tensor(self.builder.create_descriptor_store(desc.handle, value.handle, offsets), tl.void)
 
-def descriptor_atomic_min(desc: tl.tensor_descriptor_base, value: tl.tensor, offsets, builder: ir.builder) -> tl.tensor:
-    validate_store_like(desc, value, offsets)
-    _descriptor_atomic_min_max_supported(desc.dtype)
-    offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
-    kind = ir.DESCRIPTOR_REDUCE_KIND.MIN
-    return tl.tensor(builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
+    def descriptor_atomic_add(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> TensorTy:
+        self.validate_store_like(desc, value, offsets)
+        assert desc.dtype in {tl.uint32, tl.int32, tl.uint64, tl.float32, tl.float16, tl.bfloat16}, "Unsupported dtype"
+        offsets = self._convert_to_ir_values(offsets, require_i64=False)
+        kind = ir.DESCRIPTOR_REDUCE_KIND.ADD
+        return self.tensor(self.builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
 
+    def _has_native_tma(self, ):
+        target = driver.active.get_current_target()
+        return (target.backend == "cuda" and target.arch >= 90)
 
-def descriptor_atomic_max(desc: tl.tensor_descriptor_base, value: tl.tensor, offsets, builder: ir.builder) -> tl.tensor:
-    validate_store_like(desc, value, offsets)
-    _descriptor_atomic_min_max_supported(desc.dtype)
-    offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
-    kind = ir.DESCRIPTOR_REDUCE_KIND.MAX
-    return tl.tensor(builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
+    def _descriptor_atomic_min_max_supported(self, dtype):
+        assert dtype in {tl.uint32, tl.int32, tl.uint64, tl.int64, tl.float16, tl.bfloat16}, "Unsupported dtype"
+        if dtype in {tl.float16, tl.bfloat16}:
+            assert self._has_native_tma(), "16-bit float types require native tma support"
 
+    def descriptor_atomic_min(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> TensorTy:
+        self.validate_store_like(desc, value, offsets)
+        self._descriptor_atomic_min_max_supported(desc.dtype)
+        offsets = self._convert_to_ir_values(offsets, require_i64=False)
+        kind = ir.DESCRIPTOR_REDUCE_KIND.MIN
+        return self.tensor(self.builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
 
-def descriptor_atomic_and(desc: tl.tensor_descriptor_base, value: tl.tensor, offsets, builder: ir.builder) -> tl.tensor:
-    validate_store_like(desc, value, offsets)
-    assert desc.dtype in {tl.uint32, tl.int32, tl.uint64, tl.int64}, "Unsupported dtype"
-    offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
-    kind = ir.DESCRIPTOR_REDUCE_KIND.AND
-    return tl.tensor(builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
+    def descriptor_atomic_max(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> TensorTy:
+        self.validate_store_like(desc, value, offsets)
+        self._descriptor_atomic_min_max_supported(desc.dtype)
+        offsets = self._convert_to_ir_values(offsets, require_i64=False)
+        kind = ir.DESCRIPTOR_REDUCE_KIND.MAX
+        return self.tensor(self.builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
 
+    def descriptor_atomic_and(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> TensorTy:
+        self.validate_store_like(desc, value, offsets)
+        assert desc.dtype in {tl.uint32, tl.int32, tl.uint64, tl.int64}, "Unsupported dtype"
+        offsets = self._convert_to_ir_values(offsets, require_i64=False)
+        kind = ir.DESCRIPTOR_REDUCE_KIND.AND
+        return self.tensor(self.builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
 
-def descriptor_atomic_or(desc: tl.tensor_descriptor_base, value: tl.tensor, offsets, builder: ir.builder) -> tl.tensor:
-    validate_store_like(desc, value, offsets)
-    assert desc.dtype in {tl.uint32, tl.int32, tl.uint64, tl.int64}, "Unsupported dtype"
-    offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
-    kind = ir.DESCRIPTOR_REDUCE_KIND.OR
-    return tl.tensor(builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
+    def descriptor_atomic_or(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> TensorTy:
+        self.validate_store_like(desc, value, offsets)
+        assert desc.dtype in {tl.uint32, tl.int32, tl.uint64, tl.int64}, "Unsupported dtype"
+        offsets = self._convert_to_ir_values(offsets, require_i64=False)
+        kind = ir.DESCRIPTOR_REDUCE_KIND.OR
+        return self.tensor(self.builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
 
+    def descriptor_atomic_xor(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> TensorTy:
+        self.validate_store_like(desc, value, offsets)
+        assert desc.dtype in {tl.uint32, tl.int32, tl.uint64, tl.int64}, "Unsupported dtype"
+        offsets = self._convert_to_ir_values(offsets, require_i64=False)
+        kind = ir.DESCRIPTOR_REDUCE_KIND.XOR
+        return self.tensor(self.builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
 
-def descriptor_atomic_xor(desc: tl.tensor_descriptor_base, value: tl.tensor, offsets, builder: ir.builder) -> tl.tensor:
-    validate_store_like(desc, value, offsets)
-    assert desc.dtype in {tl.uint32, tl.int32, tl.uint64, tl.int64}, "Unsupported dtype"
-    offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
-    kind = ir.DESCRIPTOR_REDUCE_KIND.XOR
-    return tl.tensor(builder.create_descriptor_reduce(kind, desc.handle, value.handle, offsets), tl.void)
+    def descriptor_gather(self, desc, x_offsets, y_offset, cache_modifier: str, eviction_policy: str) -> TensorTy:
+        assert isinstance(desc, tl.tensor_descriptor_base)
+        assert cache_modifier == "", "cache modifier is not supported yet"
+        assert eviction_policy == "", "eviction policy is not supported yet"
 
+        # Validate descriptor.
+        assert len(desc.block_shape) == 2, f"descriptor must be 2D, but got {desc.block_shape}"
+        assert desc.block_shape[0] == 1, f"descriptor block must have 1 row, but got {desc.block_shape}"
 
-def descriptor_gather(desc, x_offsets, y_offset, cache_modifier: str, eviction_policy: str,
-                      builder: ir.builder) -> tl.tensor:
-    assert isinstance(desc, tl.tensor_descriptor_base)
-    assert cache_modifier == "", "cache modifier is not supported yet"
-    assert eviction_policy == "", "eviction policy is not supported yet"
+        # Validate offsets.
+        assert len(x_offsets.shape) == 1, f"x offsets must be 1D, but got {x_offsets.shape}"
 
-    # Validate descriptor.
-    assert len(desc.block_shape) == 2, f"descriptor must be 2D, but got {desc.block_shape}"
-    assert desc.block_shape[0] == 1, f"descriptor block must have 1 row, but got {desc.block_shape}"
+        # Validate minimum block size.
+        assert x_offsets.shape[0] >= 8, f"descriptor gather must have at least 8 rows, but got {x_offsets.shape}"
+        dtype = desc.dtype
+        min_cols = 32 // dtype.primitive_bitwidth * 8
+        assert desc.block_shape[
+            1] >= min_cols, f"descriptor gather of {dtype} must have at least {min_cols} columns, but got {desc.block_shape[1]}"
 
-    # Validate offsets.
-    assert len(x_offsets.shape) == 1, f"x offsets must be 1D, but got {x_offsets.shape}"
+        type = tl.block_type(desc.dtype, [x_offsets.shape[0], desc.block_shape[1]])
+        y_offset = self._convert_to_ir_values((y_offset, ), require_i64=False)[0]
+        x = self.builder.create_descriptor_gather(desc.handle, x_offsets.handle, y_offset, type.to_ir(self.builder))
+        return self.tensor(x, type)
 
-    # Validate minimum block size.
-    assert x_offsets.shape[0] >= 8, f"descriptor gather must have at least 8 rows, but got {x_offsets.shape}"
-    dtype = desc.dtype
-    min_cols = 32 // dtype.primitive_bitwidth * 8
-    assert desc.block_shape[
-        1] >= min_cols, f"descriptor gather of {dtype} must have at least {min_cols} columns, but got {desc.block_shape[1]}"
+    def descriptor_scatter(self, desc, value: TensorTy, x_offsets, y_offset) -> TensorTy:
+        assert isinstance(desc, tl.tensor_descriptor_base)
 
-    type = tl.block_type(desc.dtype, [x_offsets.shape[0], desc.block_shape[1]])
-    y_offset = _convert_to_ir_values(builder, (y_offset, ), require_i64=False)[0]
-    x = builder.create_descriptor_gather(desc.handle, x_offsets.handle, y_offset, type.to_ir(builder))
-    return tl.tensor(x, type)
+        # Validate descriptor.
+        assert len(desc.block_shape) == 2, f"descriptor must be 2D, but got {desc.block_shape}"
+        assert desc.block_shape[0] == 1, f"descriptor block must have 1 row, but got {desc.block_shape}"
 
+        # Validate offsets.
+        assert len(x_offsets.shape) == 1, f"x offsets must be 1D, but got {x_offsets.shapae}"
 
-def descriptor_scatter(desc, value: tl.tensor, x_offsets, y_offset, builder: ir.builder) -> tl.tensor:
-    assert isinstance(desc, tl.tensor_descriptor_base)
+        # Validate minimum block size.
+        assert x_offsets.shape[0] >= 8, f"descriptor scatter must have at least 8 rows, but got {x_offsets.shape}"
+        dtype = desc.dtype
+        min_cols = 32 // dtype.primitive_bitwidth * 8
+        assert desc.block_shape[
+            1] >= min_cols, f"descriptor scatter of {dtype} must have at least {min_cols} columns, but got {desc.block_shape[1]}"
 
-    # Validate descriptor.
-    assert len(desc.block_shape) == 2, f"descriptor must be 2D, but got {desc.block_shape}"
-    assert desc.block_shape[0] == 1, f"descriptor block must have 1 row, but got {desc.block_shape}"
+        y_offset = self._convert_to_ir_values((y_offset, ), require_i64=False)[0]
+        self.builder.create_descriptor_scatter(desc.handle, value.handle, x_offsets.handle, y_offset)
+        return self.tensor(None, tl.void)
 
-    # Validate offsets.
-    assert len(x_offsets.shape) == 1, f"x offsets must be 1D, but got {x_offsets.shapae}"
-
-    # Validate minimum block size.
-    assert x_offsets.shape[0] >= 8, f"descriptor scatter must have at least 8 rows, but got {x_offsets.shape}"
-    dtype = desc.dtype
-    min_cols = 32 // dtype.primitive_bitwidth * 8
-    assert desc.block_shape[
-        1] >= min_cols, f"descriptor scatter of {dtype} must have at least {min_cols} columns, but got {desc.block_shape[1]}"
-
-    y_offset = _convert_to_ir_values(builder, (y_offset, ), require_i64=False)[0]
-    builder.create_descriptor_scatter(desc.handle, value.handle, x_offsets.handle, y_offset)
-    return tl.tensor(None, tl.void)
-
-
-def _store_block_pointer(ptr, val, mask, boundary_check, cache, eviction, builder):
-    # Store by a block pointer: `pointer_type<block_type<>>`
-    # Block pointers can not have the `mask` argument
-    if mask is not None:
-        raise ValueError("`mask` and `other` arguments cannot be specified for loading block pointers")
-
-    # Check same shape and element type
-    block_shape = ptr.type.element_ty.get_block_shapes()
-    if not val.type.is_block():
-        val = broadcast_impl_shape(val, block_shape, builder)
-    assert val.type.is_block(), "Value argument must be block type or a scalar"
-    assert block_shape == val.type.get_block_shapes(
-    ), f"Block shape({block_shape}) and value shape({val.type.get_block_shapes()}) mismatch"
-    assert ptr.type.element_ty.element_ty == val.type.element_ty, f"Block element type({ptr.type.element_ty.element_ty}) and value element type({val.type.element_ty}) mismatch"
-
-    elt_ty = ptr.type.element_ty.element_ty
-    assert elt_ty != tl.int1, "`tl.int1` should be rewritten in `tl.make_block_ptr`"
-
-    # Check `boundary_check` argument
-    boundary_check = _canonicalize_boundary_check(boundary_check, block_shape)
-
-    # Cast to target data type
-    val = cast(val, elt_ty, builder)
-
-    # Build IR
-    return tl.tensor(builder.create_tensor_pointer_store(ptr.handle, val.handle, boundary_check, cache, eviction),
-                     tl.void)
-
-
-def _store_legacy(ptr, val, mask, boundary_check, cache, eviction, builder):
-    # Store by a tensor of pointers or a pointer of scalar: `block_type<pointer_type<>>` or `pointer_type<>`
-    if not ptr.type.scalar.is_ptr():
-        raise ValueError(f"Unsupported ptr type {ptr.type.__repr__()} in `tl.store`")
-
-    # Check `boundary_check` argument
-    if boundary_check:
-        raise ValueError("`boundary_check` argument is not supported for storing a tensor of pointers or storing a "
-                         "scalar. Because the compiler does not know the boundary; please use block pointers "
-                         "(defined by `make_block_ptr`) instead")
-
-    # For a pointer of scalar, check the type of `val` and `mask`
-    if not ptr.type.is_block():
-        if val.type.is_block():
-            raise ValueError("Value argument cannot be block type if pointer argument is not a block")
-        if mask and mask.type.is_block():
-            raise ValueError("Mask argument cannot be block type if pointer argument is not a block")
-
-    # Make `mask` and `val` into the same shape as `ptr`
-    if ptr.type.is_block():
-        val = broadcast_impl_shape(val, ptr.type.get_block_shapes(), builder)
-        if mask is not None:
-            mask = broadcast_impl_shape(mask, ptr.type.get_block_shapes(), builder)
-
-    ptr_ty = ptr.type.scalar
-    elt_ty = ptr_ty.element_ty
-
-    # Treat `pointer_type<tl.int1>` as `pointer_type<tl.int8>`
-    if elt_ty == tl.int1:
-        elt_ty = tl.int8
-        ptr_ty = tl.pointer_type(elt_ty, ptr_ty.address_space)
-        ptr = cast(ptr, ptr_ty, builder)
-
-    # Cast to target data type
-    val = cast(val, elt_ty, builder)
-
-    # Build IR
-    if mask is None:
-        return tl.tensor(builder.create_store(ptr.handle, val.handle, cache, eviction), tl.void)
-    if not mask.type.scalar.is_bool():
-        raise ValueError("Mask must have boolean scalar type")
-    return tl.tensor(builder.create_masked_store(ptr.handle, val.handle, mask.handle, cache, eviction), tl.void)
-
-
-def store(ptr: tl.tensor, val: tl.tensor, mask: Optional[tl.tensor], boundary_check, cache_modifier: str,
-          eviction_policy: str, builder: ir.builder) -> tl.tensor:
-    # Cache and eviction options
-    cache = _str_to_store_cache_modifier(cache_modifier)
-    eviction = _str_to_eviction_policy(eviction_policy)
-
-    if ptr.type.is_const() or ptr.type.scalar.is_const():
-        raise ValueError("Cannot store to a constant pointer")
-
-    if ptr.type.is_ptr() and ptr.type.element_ty.is_block():
+    def _store_block_pointer(self, ptr, val, mask, boundary_check, cache, eviction):
         # Store by a block pointer: `pointer_type<block_type<>>`
-        return _store_block_pointer(ptr, val, mask, boundary_check, cache, eviction, builder)
-    else:
-        # Store by a tensor of pointers or a pointer of scalar: `block_type<pointer_type<>>` or `pointer_type<>`
-        return _store_legacy(ptr, val, mask, boundary_check, cache, eviction, builder)
+        # Block pointers can not have the `mask` argument
+        if mask is not None:
+            raise ValueError("`mask` and `other` arguments cannot be specified for loading block pointers")
 
+        # Check same shape and element type
+        block_shape = ptr.type.element_ty.get_block_shapes()
+        if not val.type.is_block():
+            val = self.broadcast_impl_shape(val, block_shape)
+        assert val.type.is_block(), "Value argument must be block type or a scalar"
+        assert block_shape == val.type.get_block_shapes(
+        ), f"Block shape({block_shape}) and value shape({val.type.get_block_shapes()}) mismatch"
+        assert ptr.type.element_ty.element_ty == val.type.element_ty, f"Block element type({ptr.type.element_ty.element_ty}) and value element type({val.type.element_ty}) mismatch"
+
+        elt_ty = ptr.type.element_ty.element_ty
+        assert elt_ty != tl.int1, "`tl.int1` should be rewritten in `tl.make_block_ptr`"
+
+        # Check `boundary_check` argument
+        boundary_check = self._canonicalize_boundary_check(boundary_check, block_shape)
+
+        # Cast to target data type
+        val = self.cast(val, elt_ty)
+
+        # Build IR
+        return self.tensor(
+            self.builder.create_tensor_pointer_store(ptr.handle, val.handle, boundary_check, cache, eviction), tl.void)
+
+    def _store_legacy(self, ptr, val, mask, boundary_check, cache, eviction):
+        # Store by a tensor of pointers or a pointer of scalar: `block_type<pointer_type<>>` or `pointer_type<>`
+        if not ptr.type.scalar.is_ptr():
+            raise ValueError(f"Unsupported ptr type {ptr.type.__repr__()} in `tl.store`")
+
+        # Check `boundary_check` argument
+        if boundary_check:
+            raise ValueError("`boundary_check` argument is not supported for storing a tensor of pointers or storing a "
+                             "scalar. Because the compiler does not know the boundary; please use block pointers "
+                             "(defined by `make_block_ptr`) instead")
+
+        # For a pointer of scalar, check the type of `val` and `mask`
+        if not ptr.type.is_block():
+            if val.type.is_block():
+                raise ValueError("Value argument cannot be block type if pointer argument is not a block")
+            if mask and mask.type.is_block():
+                raise ValueError("Mask argument cannot be block type if pointer argument is not a block")
+
+        # Make `mask` and `val` into the same shape as `ptr`
+        if ptr.type.is_block():
+            val = self.broadcast_impl_shape(val, ptr.type.get_block_shapes())
+            if mask is not None:
+                mask = self.broadcast_impl_shape(mask, ptr.type.get_block_shapes())
+
+        ptr_ty = ptr.type.scalar
+        elt_ty = ptr_ty.element_ty
+
+        # Treat `pointer_type<tl.int1>` as `pointer_type<tl.int8>`
+        if elt_ty == tl.int1:
+            elt_ty = tl.int8
+            ptr_ty = tl.pointer_type(elt_ty, ptr_ty.address_space)
+            ptr = self.cast(ptr, ptr_ty)
+
+        # Cast to target data type
+        val = self.cast(val, elt_ty)
+
+        # Build IR
+        if mask is None:
+            return self.tensor(self.builder.create_store(ptr.handle, val.handle, cache, eviction), tl.void)
+        if not mask.type.scalar.is_bool():
+            raise ValueError("Mask must have boolean scalar type")
+        return self.tensor(self.builder.create_masked_store(ptr.handle, val.handle, mask.handle, cache, eviction),
+                           tl.void)
+
+    def store(self, ptr: TensorTy, val: TensorTy, mask: Optional[TensorTy], boundary_check, cache_modifier: str,
+              eviction_policy: str) -> TensorTy:
+        # Cache and eviction options
+        cache = self._str_to_store_cache_modifier(cache_modifier)
+        eviction = self._str_to_eviction_policy(eviction_policy)
+
+        if ptr.type.is_const() or ptr.type.scalar.is_const():
+            raise ValueError("Cannot store to a constant pointer")
+
+        if ptr.type.is_ptr() and ptr.type.element_ty.is_block():
+            # Store by a block pointer: `pointer_type<block_type<>>`
+            return self._store_block_pointer(ptr, val, mask, boundary_check, cache, eviction)
+        else:
+            # Store by a tensor of pointers or a pointer of scalar: `block_type<pointer_type<>>` or `pointer_type<>`
+            return self._store_legacy(ptr, val, mask, boundary_check, cache, eviction)
 
 #########
 # atomic
 #########
 
+    def atomic_cas(self, ptr: TensorTy, cmp: TensorTy, val: TensorTy, sem: str, scope: str) -> TensorTy:
+        sem = self._str_to_sem(sem)
+        scope = self._str_to_scope(scope)
+        element_ty = ptr.type.scalar.element_ty
+        if element_ty.primitive_bitwidth not in [16, 32, 64]:
+            raise ValueError("atomic_cas only supports elements with width {16, 32, 64}")
+        return self.tensor(self.builder.create_atomic_cas(ptr.handle, cmp.handle, val.handle, sem, scope), val.type)
 
-def atomic_cas(ptr: tl.tensor, cmp: tl.tensor, val: tl.tensor, sem: str, scope: str, builder: ir.builder) -> tl.tensor:
-    sem = _str_to_sem(sem)
-    scope = _str_to_scope(scope)
-    element_ty = ptr.type.scalar.element_ty
-    if element_ty.primitive_bitwidth not in [16, 32, 64]:
-        raise ValueError("atomic_cas only supports elements with width {16, 32, 64}")
-    return tl.tensor(builder.create_atomic_cas(ptr.handle, cmp.handle, val.handle, sem, scope), val.type)
-
-
-def atom_red_typechecking_impl(ptr: tl.tensor, val: tl.tensor, mask: tl.tensor, op: str,
-                               builder: ir.builder) -> Tuple[tl.tensor, tl.tensor, tl.tensor]:
-    if not ptr.type.scalar.is_ptr():
-        raise ValueError("Pointer argument of store instruction is " + ptr.type.__repr__())
-    if ptr.type.is_const() or ptr.type.element_ty.is_const():
-        raise ValueError("Cannot store to a constant pointer")
-    element_ty = ptr.type.scalar.element_ty
-    if element_ty is tl.float16 and op != 'add':
-        raise ValueError("atomic_" + op + " does not support fp16")
-    if element_ty is tl.bfloat16 and op != 'add':
-        raise ValueError("atomic_" + op + " does not support bf16")
-    if element_ty in [tl.int16, tl.uint16] or element_ty.primitive_bitwidth < 16:
-        raise ValueError("atomic_" + op + " does not support " + str(element_ty))
-    if ptr.type.is_block():
-        if mask is not None:
-            mask = broadcast_impl_shape(mask, ptr.type.get_block_shapes(), builder)
-        if val is not None:
-            val = broadcast_impl_shape(val, ptr.type.get_block_shapes(), builder)
-    val = cast(val, ptr.type.scalar.element_ty, builder)
-    if mask is None:
-        mask_ir = builder.get_int1(True)
-        mask_ty = tl.int1
+    def atom_red_typechecking_impl(self, ptr: TensorTy, val: TensorTy, mask: TensorTy,
+                                   op: str) -> Tuple[TensorTy, TensorTy, TensorTy]:
+        if not ptr.type.scalar.is_ptr():
+            raise ValueError("Pointer argument of store instruction is " + ptr.type.__repr__())
+        if ptr.type.is_const() or ptr.type.element_ty.is_const():
+            raise ValueError("Cannot store to a constant pointer")
+        element_ty = ptr.type.scalar.element_ty
+        if element_ty is tl.float16 and op != 'add':
+            raise ValueError("atomic_" + op + " does not support fp16")
+        if element_ty is tl.bfloat16 and op != 'add':
+            raise ValueError("atomic_" + op + " does not support bf16")
+        if element_ty in [tl.int16, tl.uint16] or element_ty.primitive_bitwidth < 16:
+            raise ValueError("atomic_" + op + " does not support " + str(element_ty))
         if ptr.type.is_block():
-            mask_ty = ptr.type.with_element_ty(tl.int1)
-            mask_ir = builder.create_splat(mask_ty.to_ir(builder), mask_ir)
-        mask = tl.tensor(mask_ir, mask_ty)
-    return ptr, val, mask
+            if mask is not None:
+                mask = self.broadcast_impl_shape(mask, ptr.type.get_block_shapes())
+            if val is not None:
+                val = self.broadcast_impl_shape(val, ptr.type.get_block_shapes())
+        val = self.cast(val, ptr.type.scalar.element_ty)
+        if mask is None:
+            mask_ir = self.builder.get_int1(True)
+            mask_ty = tl.int1
+            if ptr.type.is_block():
+                mask_ty = ptr.type.with_element_ty(tl.int1)
+                mask_ir = self.builder.create_splat(mask_ty.to_ir(self.builder), mask_ir)
+            mask = self.tensor(mask_ir, mask_ty)
+        return ptr, val, mask
 
+    def _signbit(self, x: TensorTy) -> TensorTy:
+        bitwidth = x.dtype.primitive_bitwidth
+        idtype = tl.get_int_dtype(bitwidth=bitwidth, signed=False)
+        ix = self.bitcast(x, idtype)
+        signbit = self.lshr(ix, bitwidth - 1)
+        return self.cast(signbit, tl.int1)
 
-def _signbit(x: tl.tensor, builder: ir.builder) -> tl.tensor:
-    bitwidth = x.dtype.primitive_bitwidth
-    idtype = tl.get_int_dtype(bitwidth=bitwidth, signed=False)
-    ix = x.to(idtype, bitcast=True, _builder=builder)
-    signbit = lshr(ix, bitwidth - 1, builder)
-    return signbit.to(tl.int1, _builder=builder)
+    def atomic_max(self, ptr: TensorTy, val: TensorTy, mask: TensorTy, sem: str, scope: str) -> TensorTy:
+        ptr, val, mask = self.atom_red_typechecking_impl(ptr, val, mask, 'max')
+        sem = self._str_to_sem(sem)
+        scope = self._str_to_scope(scope)
+        sca_ty = val.type.scalar
+        # direct call to atomic_max for integers
+        if sca_ty.is_int():
+            if sca_ty.is_int_signed():
+                return self.tensor(
+                    self.builder.create_atomic_rmw(ir.ATOMIC_OP.MAX, ptr.handle, val.handle, mask.handle, sem, scope),
+                    val.type)
+            else:
+                return self.tensor(
+                    self.builder.create_atomic_rmw(ir.ATOMIC_OP.UMAX, ptr.handle, val.handle, mask.handle, sem, scope),
+                    val.type)
+        # for float
+        # return atomic_smax(i_ptr, i_val) if val >= 0
+        # return atomic_umin(i_ptr, i_val) if val < 0
+        if sca_ty not in {tl.float32, tl.float64}:
+            raise TypeError(f"atomic_max not supported for dtype {sca_ty}")
 
+        i_type = tl.int32 if sca_ty == tl.float32 else tl.int64
+        i_val = self.bitcast(val, i_type)
+        i_ptr = self.bitcast(ptr, tl.pointer_type(i_type, 1))
+        ui_type = tl.uint32 if sca_ty == tl.float32 else tl.uint64
+        ui_val = self.bitcast(val, ui_type)
+        ui_ptr = self.bitcast(ptr, tl.pointer_type(ui_type, 1))
+        neg = self._signbit(val)
+        pos = self.not_(neg)
+        pos_ret = self.tensor(
+            self.builder.create_atomic_rmw(ir.ATOMIC_OP.MAX, i_ptr.handle, i_val.handle,
+                                           self.and_(mask, pos).handle, sem, scope), i_val.type)
+        neg_ret = self.tensor(
+            self.builder.create_atomic_rmw(ir.ATOMIC_OP.UMIN, ui_ptr.handle, ui_val.handle,
+                                           self.and_(mask, neg).handle, sem, scope), ui_val.type)
+        ret = self.where(pos, pos_ret, neg_ret)
+        return self.bitcast(ret, sca_ty)
 
-def atomic_max(ptr: tl.tensor, val: tl.tensor, mask: tl.tensor, sem: str, scope: str, builder: ir.builder) -> tl.tensor:
-    ptr, val, mask = atom_red_typechecking_impl(ptr, val, mask, 'max', builder)
-    sem = _str_to_sem(sem)
-    scope = _str_to_scope(scope)
-    sca_ty = val.type.scalar
-    # direct call to atomic_max for integers
-    if sca_ty.is_int():
-        if sca_ty.is_int_signed():
-            return tl.tensor(
-                builder.create_atomic_rmw(ir.ATOMIC_OP.MAX, ptr.handle, val.handle, mask.handle, sem, scope), val.type)
-        else:
-            return tl.tensor(
-                builder.create_atomic_rmw(ir.ATOMIC_OP.UMAX, ptr.handle, val.handle, mask.handle, sem, scope), val.type)
-    # for float
-    # return atomic_smax(i_ptr, i_val) if val >= 0
-    # return atomic_umin(i_ptr, i_val) if val < 0
-    if sca_ty not in {tl.float32, tl.float64}:
-        raise TypeError(f"atomic_max not supported for dtype {sca_ty}")
+    def atomic_min(self, ptr: TensorTy, val: TensorTy, mask: TensorTy, sem: str, scope: str) -> TensorTy:
+        ptr, val, mask = self.atom_red_typechecking_impl(ptr, val, mask, 'min')
+        sem = self._str_to_sem(sem)
+        scope = self._str_to_scope(scope)
+        sca_ty = val.type.scalar
+        # direct call to atomic_min for integers
+        if sca_ty.is_int():
+            if sca_ty.is_int_signed():
+                return self.tensor(
+                    self.builder.create_atomic_rmw(ir.ATOMIC_OP.MIN, ptr.handle, val.handle, mask.handle, sem, scope),
+                    val.type)
+            else:
+                return self.tensor(
+                    self.builder.create_atomic_rmw(ir.ATOMIC_OP.UMIN, ptr.handle, val.handle, mask.handle, sem, scope),
+                    val.type)
+        # for float
+        # return atomic_smin(i_ptr, i_val) if val >= 0
+        # return atomic_umax(i_ptr, i_val) if val < 0
+        if sca_ty not in {tl.float32, tl.float64}:
+            raise TypeError(f"atomic_min not supported for dtype {sca_ty}")
 
-    i_type = tl.int32 if sca_ty == tl.float32 else tl.int64
-    i_val = bitcast(val, i_type, builder)
-    i_ptr = bitcast(ptr, tl.pointer_type(i_type, 1), builder)
-    ui_type = tl.uint32 if sca_ty == tl.float32 else tl.uint64
-    ui_val = bitcast(val, ui_type, builder)
-    ui_ptr = bitcast(ptr, tl.pointer_type(ui_type, 1), builder)
-    neg = _signbit(val, builder)
-    pos = not_(neg, builder)
-    pos_ret = tl.tensor(
-        builder.create_atomic_rmw(ir.ATOMIC_OP.MAX, i_ptr.handle, i_val.handle,
-                                  and_(mask, pos, builder).handle, sem, scope), i_val.type)
-    neg_ret = tl.tensor(
-        builder.create_atomic_rmw(ir.ATOMIC_OP.UMIN, ui_ptr.handle, ui_val.handle,
-                                  and_(mask, neg, builder).handle, sem, scope), ui_val.type)
-    ret = where(pos, pos_ret, neg_ret, builder)
-    return bitcast(ret, sca_ty, builder)
+        i_type = tl.int32 if sca_ty == tl.float32 else tl.int64
+        i_val = self.bitcast(val, i_type)
+        i_ptr = self.bitcast(ptr, tl.pointer_type(i_type, 1))
+        ui_type = tl.uint32 if sca_ty == tl.float32 else tl.uint64
+        ui_val = self.bitcast(val, ui_type)
+        ui_ptr = self.bitcast(ptr, tl.pointer_type(ui_type, 1))
+        neg = self._signbit(val)
+        pos = self.not_(neg)
+        pos_ret = self.tensor(
+            self.builder.create_atomic_rmw(ir.ATOMIC_OP.MIN, i_ptr.handle, i_val.handle,
+                                           self.and_(mask, pos).handle, sem, scope), i_val.type)
+        neg_ret = self.tensor(
+            self.builder.create_atomic_rmw(ir.ATOMIC_OP.UMAX, ui_ptr.handle, ui_val.handle,
+                                           self.and_(mask, neg).handle, sem, scope), ui_ptr.type)
+        ret = self.where(pos, pos_ret, neg_ret)
+        return self.bitcast(ret, sca_ty)
 
+    def atomic_add(self, ptr: TensorTy, val: TensorTy, mask: TensorTy, sem: str, scope: str) -> TensorTy:
+        ptr, val, mask = self.atom_red_typechecking_impl(ptr, val, mask, 'add')
+        sem = self._str_to_sem(sem)
+        scope = self._str_to_scope(scope)
+        sca_ty = val.type.scalar
+        op = ir.ATOMIC_OP.FADD if sca_ty.is_floating() else ir.ATOMIC_OP.ADD
+        return self.tensor(self.builder.create_atomic_rmw(op, ptr.handle, val.handle, mask.handle, sem, scope),
+                           val.type)
 
-def atomic_min(ptr: tl.tensor, val: tl.tensor, mask: tl.tensor, sem: str, scope: str, builder: ir.builder) -> tl.tensor:
-    ptr, val, mask = atom_red_typechecking_impl(ptr, val, mask, 'min', builder)
-    sem = _str_to_sem(sem)
-    scope = _str_to_scope(scope)
-    sca_ty = val.type.scalar
-    # direct call to atomic_min for integers
-    if sca_ty.is_int():
-        if sca_ty.is_int_signed():
-            return tl.tensor(
-                builder.create_atomic_rmw(ir.ATOMIC_OP.MIN, ptr.handle, val.handle, mask.handle, sem, scope), val.type)
-        else:
-            return tl.tensor(
-                builder.create_atomic_rmw(ir.ATOMIC_OP.UMIN, ptr.handle, val.handle, mask.handle, sem, scope), val.type)
-    # for float
-    # return atomic_smin(i_ptr, i_val) if val >= 0
-    # return atomic_umax(i_ptr, i_val) if val < 0
-    if sca_ty not in {tl.float32, tl.float64}:
-        raise TypeError(f"atomic_min not supported for dtype {sca_ty}")
+    def atomic_and(self, ptr: TensorTy, val: TensorTy, mask: TensorTy, sem: str, scope: str) -> TensorTy:
+        ptr, val, mask = self.atom_red_typechecking_impl(ptr, val, mask, 'and')
+        sem = self._str_to_sem(sem)
+        scope = self._str_to_scope(scope)
+        return self.tensor(
+            self.builder.create_atomic_rmw(ir.ATOMIC_OP.AND, ptr.handle, val.handle, mask.handle, sem, scope), val.type)
 
-    i_type = tl.int32 if sca_ty == tl.float32 else tl.int64
-    i_val = bitcast(val, i_type, builder)
-    i_ptr = bitcast(ptr, tl.pointer_type(i_type, 1), builder)
-    ui_type = tl.uint32 if sca_ty == tl.float32 else tl.uint64
-    ui_val = bitcast(val, ui_type, builder)
-    ui_ptr = bitcast(ptr, tl.pointer_type(ui_type, 1), builder)
-    neg = _signbit(val, builder)
-    pos = not_(neg, builder)
-    pos_ret = tl.tensor(
-        builder.create_atomic_rmw(ir.ATOMIC_OP.MIN, i_ptr.handle, i_val.handle,
-                                  and_(mask, pos, builder).handle, sem, scope), i_val.type)
-    neg_ret = tl.tensor(
-        builder.create_atomic_rmw(ir.ATOMIC_OP.UMAX, ui_ptr.handle, ui_val.handle,
-                                  and_(mask, neg, builder).handle, sem, scope), ui_ptr.type)
-    ret = where(pos, pos_ret, neg_ret, builder)
-    return bitcast(ret, sca_ty, builder)
+    def atomic_or(self, ptr: TensorTy, val: TensorTy, mask: TensorTy, sem: str, scope: str) -> TensorTy:
+        ptr, val, mask = self.atom_red_typechecking_impl(ptr, val, mask, 'or')
+        sem = self._str_to_sem(sem)
+        scope = self._str_to_scope(scope)
+        return self.tensor(
+            self.builder.create_atomic_rmw(ir.ATOMIC_OP.OR, ptr.handle, val.handle, mask.handle, sem, scope), val.type)
 
+    def atomic_xor(self, ptr: TensorTy, val: TensorTy, mask: TensorTy, sem: str, scope: str) -> TensorTy:
+        ptr, val, mask = self.atom_red_typechecking_impl(ptr, val, mask, 'xor')
+        sem = self._str_to_sem(sem)
+        scope = self._str_to_scope(scope)
+        return self.tensor(
+            self.builder.create_atomic_rmw(ir.ATOMIC_OP.XOR, ptr.handle, val.handle, mask.handle, sem, scope), val.type)
 
-def atomic_add(ptr: tl.tensor, val: tl.tensor, mask: tl.tensor, sem: str, scope: str, builder: ir.builder) -> tl.tensor:
-    ptr, val, mask = atom_red_typechecking_impl(ptr, val, mask, 'add', builder)
-    sem = _str_to_sem(sem)
-    scope = _str_to_scope(scope)
-    sca_ty = val.type.scalar
-    op = ir.ATOMIC_OP.FADD if sca_ty.is_floating() else ir.ATOMIC_OP.ADD
-    return tl.tensor(builder.create_atomic_rmw(op, ptr.handle, val.handle, mask.handle, sem, scope), val.type)
-
-
-def atomic_and(ptr: tl.tensor, val: tl.tensor, mask: tl.tensor, sem: str, scope: str, builder: ir.builder) -> tl.tensor:
-    ptr, val, mask = atom_red_typechecking_impl(ptr, val, mask, 'and', builder)
-    sem = _str_to_sem(sem)
-    scope = _str_to_scope(scope)
-    return tl.tensor(builder.create_atomic_rmw(ir.ATOMIC_OP.AND, ptr.handle, val.handle, mask.handle, sem, scope),
-                     val.type)
-
-
-def atomic_or(ptr: tl.tensor, val: tl.tensor, mask: tl.tensor, sem: str, scope: str, builder: ir.builder) -> tl.tensor:
-    ptr, val, mask = atom_red_typechecking_impl(ptr, val, mask, 'or', builder)
-    sem = _str_to_sem(sem)
-    scope = _str_to_scope(scope)
-    return tl.tensor(builder.create_atomic_rmw(ir.ATOMIC_OP.OR, ptr.handle, val.handle, mask.handle, sem, scope),
-                     val.type)
-
-
-def atomic_xor(ptr: tl.tensor, val: tl.tensor, mask: tl.tensor, sem: str, scope: str, builder: ir.builder) -> tl.tensor:
-    ptr, val, mask = atom_red_typechecking_impl(ptr, val, mask, 'xor', builder)
-    sem = _str_to_sem(sem)
-    scope = _str_to_scope(scope)
-    return tl.tensor(builder.create_atomic_rmw(ir.ATOMIC_OP.XOR, ptr.handle, val.handle, mask.handle, sem, scope),
-                     val.type)
-
-
-def atomic_xchg(ptr: tl.tensor, val: tl.tensor, mask: tl.tensor, sem: str, scope: str,
-                builder: ir.builder) -> tl.tensor:
-    ptr, val, mask = atom_red_typechecking_impl(ptr, val, mask, 'xchg', builder)
-    sem = _str_to_sem(sem)
-    scope = _str_to_scope(scope)
-    return tl.tensor(builder.create_atomic_rmw(ir.ATOMIC_OP.XCHG, ptr.handle, val.handle, mask.handle, sem, scope),
-                     val.type)
-
+    def atomic_xchg(self, ptr: TensorTy, val: TensorTy, mask: TensorTy, sem: str, scope: str) -> TensorTy:
+        ptr, val, mask = self.atom_red_typechecking_impl(ptr, val, mask, 'xchg')
+        sem = self._str_to_sem(sem)
+        scope = self._str_to_scope(scope)
+        return self.tensor(
+            self.builder.create_atomic_rmw(ir.ATOMIC_OP.XCHG, ptr.handle, val.handle, mask.handle, sem, scope),
+            val.type)
 
 # ===----------------------------------------------------------------------===//
 #                               Linear Algebra
 # ===----------------------------------------------------------------------===//
 
+    def _str_to_dot_input_precision(self, input_precision):
+        assert input_precision.lower() in self.builder.options.allowed_dot_input_precisions, \
+            f"input_precision must be one of {self.builder.options.allowed_dot_input_precisions}. Got {input_precision}"
+        input_precision = input_precision.upper()
+        if input_precision == "TF32X3":
+            input_precision = "TF32x3"
+        return getattr(ir.INPUT_PRECISION, input_precision)
 
-def _str_to_dot_input_precision(input_precision, builder):
-    assert input_precision.lower() in builder.options.allowed_dot_input_precisions, \
-        f"input_precision must be one of {builder.options.allowed_dot_input_precisions}. Got {input_precision}"
-    input_precision = input_precision.upper()
-    if input_precision == "TF32X3":
-        input_precision = "TF32x3"
-    return getattr(ir.INPUT_PRECISION, input_precision)
+    def dot(self, lhs: TensorTy, rhs: TensorTy, acc: TensorTy, input_precision: Optional[str],
+            max_num_imprecise_acc: int, out_dtype: tl.dtype) -> TensorTy:
+        assert lhs.type.is_block() and rhs.type.is_block()
 
-
-def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, input_precision: Optional[str], max_num_imprecise_acc: int,
-        out_dtype: tl.dtype, builder: ir.builder) -> tl.tensor:
-    assert lhs.type.is_block() and rhs.type.is_block()
-
-    if lhs.dtype.is_fp8() and rhs.dtype.is_fp8():
-        # All combinations of supported fp8 x fp8 are permitted
-        pass
-    else:
-        assert lhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16,
-                             tl.float32), f"Unsupported lhs dtype {lhs.dtype}"
-        assert rhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16,
-                             tl.float32), f"Unsupported rhs dtype {rhs.dtype}"
-        assert lhs.dtype == rhs.dtype, f"Both operands must be same dtype. Got {lhs.dtype} and {rhs.dtype}"
-
-    if lhs.dtype.is_fp8e4b15() or rhs.dtype.is_fp8e4b15():
-        if "fp8e4b15" in builder.options.deprecated_fp8_dot_operand_dtypes:
-            warnings.warn(
-                "the use of fp8e4b15 is deprecated on Hopper and later architectures and can cause significant slow down. It will be removed in a future triton release"
-            )
-        # We upcast because there's no fp8e4b15 type in MLIR
-        lhs = cast(lhs, tl.float16, builder)
-        rhs = cast(rhs, tl.float16, builder)
-
-    if input_precision is None:
-        input_precision = builder.options.default_dot_input_precision
-
-    input_precision = _str_to_dot_input_precision(input_precision, builder)
-
-    lhs_rank = len(lhs.shape)
-    rhs_rank = len(rhs.shape)
-    assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
-    assert lhs.shape[-1].value == rhs.shape[
-        -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
-    assert builder.codegen_fns.get("min_dot_size") is not None, "target doesn't provide lower shape bounds for dot."
-    min_dot_size = builder.codegen_fns["min_dot_size"](lhs.type, rhs.type)
-    assert lhs.shape[-2].value >= min_dot_size[0] and lhs.shape[-1].value >= min_dot_size[2] \
-        and rhs.shape[-1].value >= min_dot_size[1], \
-            f"Input shapes should have M >= {min_dot_size[0]}, N >= {min_dot_size[1]} and K >= {min_dot_size[2]}"
-    if lhs.type.scalar.is_int():
-        assert lhs.type.scalar == tl.int8, "only int8 supported!"
-        _0 = builder.get_int32(0)
-        ret_scalar_ty = tl.int32
-    elif out_dtype.is_bf16():
-        raise ValueError(
-            "out_dtype=bfloat16 is unsupported. Please use out_dtype=float32/float16 and cast with `.to(tl.bfloat16)`")
-    elif lhs.type.scalar.is_fp32() or lhs.type.scalar.is_bf16():
-        _0 = builder.get_fp32(0)
-        ret_scalar_ty = tl.float32
-    else:
-        _0 = builder.get_fp16(0) if out_dtype.is_fp16() else builder.get_fp32(0)
-        ret_scalar_ty = out_dtype
-
-    M = lhs.type.shape[-2]
-    N = rhs.type.shape[-1]
-    K = lhs.type.shape[-1]
-    B = lhs.type.shape[0] if lhs_rank == 3 else None
-    ret_ty = tl.block_type(ret_scalar_ty, [B, M, N] if B else [M, N])
-    if acc is None:
-        acc_handle = builder.create_splat(ret_ty.to_ir(builder), _0)
-    else:
-        acc_handle = acc.handle
-        assert acc.type == ret_ty
-
-    # max_num_imprecise_acc only applies to fp8 -> fp32 dot on sm_90
-    if max_num_imprecise_acc is None:
         if lhs.dtype.is_fp8() and rhs.dtype.is_fp8():
-            max_num_imprecise_acc = builder.options.max_num_imprecise_acc_default
+            # All combinations of supported fp8 x fp8 are permitted
+            pass
         else:
-            max_num_imprecise_acc = 0
-    else:
-        if lhs.dtype.is_fp8() and rhs.dtype.is_fp8() and max_num_imprecise_acc > K:
-            raise ValueError(f"max_num_imprecise_acc ({max_num_imprecise_acc}) must be <= K ({K})")
+            assert lhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16,
+                                 tl.float32), f"Unsupported lhs dtype {lhs.dtype}"
+            assert rhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16,
+                                 tl.float32), f"Unsupported rhs dtype {rhs.dtype}"
+            assert lhs.dtype == rhs.dtype, f"Both operands must be same dtype. Got {lhs.dtype} and {rhs.dtype}"
 
-    return tl.tensor(builder.create_dot(lhs.handle, rhs.handle, acc_handle, input_precision, max_num_imprecise_acc),
-                     ret_ty)
+        if lhs.dtype.is_fp8e4b15() or rhs.dtype.is_fp8e4b15():
+            if "fp8e4b15" in self.builder.options.deprecated_fp8_dot_operand_dtypes:
+                warnings.warn(
+                    "the use of fp8e4b15 is deprecated on Hopper and later architectures and can cause significant slow down. It will be removed in a future triton release"
+                )
+            # We upcast because there's no fp8e4b15 type in MLIR
+            lhs = self.cast(lhs, tl.float16)
+            rhs = self.cast(rhs, tl.float16)
 
+        if input_precision is None:
+            input_precision = self.builder.options.default_dot_input_precision
 
-def _str_to_fp_type(float_format: str):
-    ty_enum = getattr(ir.ScaleDotElemTypeTY, float_format.upper(), None)
-    if ty_enum is None:
-        raise ValueError(f"Invalid float format: {float_format}.")
-    return ty_enum
+        input_precision = self._str_to_dot_input_precision(input_precision)
 
+        lhs_rank = len(lhs.shape)
+        rhs_rank = len(rhs.shape)
+        assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
+        assert lhs.shape[-1].value == rhs.shape[
+            -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
+        assert self.builder.codegen_fns.get(
+            "min_dot_size") is not None, "target doesn't provide lower shape bounds for dot."
+        min_dot_size = self.builder.codegen_fns["min_dot_size"](lhs.type, rhs.type)
+        assert lhs.shape[-2].value >= min_dot_size[0] and lhs.shape[-1].value >= min_dot_size[2] \
+            and rhs.shape[-1].value >= min_dot_size[1], \
+                f"Input shapes should have M >= {min_dot_size[0]}, N >= {min_dot_size[1]} and K >= {min_dot_size[2]}"
+        if lhs.type.scalar.is_int():
+            assert lhs.type.scalar == tl.int8, "only int8 supported!"
+            _0 = self.builder.get_int32(0)
+            ret_scalar_ty = tl.int32
+        elif out_dtype.is_bf16():
+            raise ValueError(
+                "out_dtype=bfloat16 is unsupported. Please use out_dtype=float32/float16 and cast with `.to(tl.bfloat16)`"
+            )
+        elif lhs.type.scalar.is_fp32() or lhs.type.scalar.is_bf16():
+            _0 = self.builder.get_fp32(0)
+            ret_scalar_ty = tl.float32
+        else:
+            _0 = self.builder.get_fp16(0) if out_dtype.is_fp16() else self.builder.get_fp32(0)
+            ret_scalar_ty = out_dtype
 
-def _bitcast_to_fp_type(val: tl.tensor, float_format: str, builder: ir.builder):
-    """
-    If float_format is subbyte, make sure it's packed as uint8 and return it.
-    Otherwise, return a tensor (perhaps bitcasting) of the specified float format.
-    """
-    triton_ty = {"e5m2": tl.float8e5, "e4m3": tl.float8e4nv, "bf16": tl.bfloat16, "fp16": tl.float16}.get(float_format)
-    if triton_ty is None:
-        assert float_format == "e2m1", f"Internal Error: Unexpected float format: {float_format}"
-        assert val.dtype == tl.uint8, f"e2m1 format must be packed as uint8. Got {val.dtype}"
-        return val
-    if val.dtype == triton_ty:
-        return val
-    else:
-        unsigned_ty = {"e5m2": tl.uint8, "e4m3": tl.uint8, "bf16": tl.uint16, "fp16": tl.uint16}[float_format]
-        assert val.dtype == unsigned_ty, f"Unexpected dtype for {float_format}. Got {val.dtype}"
-        return bitcast(val, triton_ty, builder)
+        M = lhs.type.shape[-2]
+        N = rhs.type.shape[-1]
+        K = lhs.type.shape[-1]
+        B = lhs.type.shape[0] if lhs_rank == 3 else None
+        ret_ty = tl.block_type(ret_scalar_ty, [B, M, N] if B else [M, N])
+        if acc is None:
+            acc_handle = self.builder.create_splat(ret_ty.to_ir(self.builder), _0)
+        else:
+            acc_handle = acc.handle
+            assert acc.type == ret_ty
 
+        # max_num_imprecise_acc only applies to fp8 -> fp32 dot on sm_90
+        if max_num_imprecise_acc is None:
+            if lhs.dtype.is_fp8() and rhs.dtype.is_fp8():
+                max_num_imprecise_acc = self.builder.options.max_num_imprecise_acc_default
+            else:
+                max_num_imprecise_acc = 0
+        else:
+            if lhs.dtype.is_fp8() and rhs.dtype.is_fp8() and max_num_imprecise_acc > K:
+                raise ValueError(f"max_num_imprecise_acc ({max_num_imprecise_acc}) must be <= K ({K})")
 
-def dot_scaled(lhs: tl.tensor, lhs_scale: tl.tensor, lhs_format: str, rhs: tl.tensor, rhs_scale: Optional[tl.tensor],
-               rhs_format: str, acc: tl.tensor | None, fast_math: bool, lhs_k_pack: bool, rhs_k_pack: bool,
-               out_dtype: tl.dtype, builder: ir.builder) -> tl.tensor:
-    assert lhs.type.is_block() and rhs.type.is_block()
-    #TODO: validate types.
-    lhs_rank = len(lhs.shape)
-    rhs_rank = len(rhs.shape)
-    assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
-    lhs_format: str = lhs_format.value
-    rhs_format: str = rhs_format.value
-    lhs_format_enum = _str_to_fp_type(lhs_format)
-    rhs_format_enum = _str_to_fp_type(rhs_format)
-    allowed_formats = {"e2m1", "e4m3", "e5m2", "bf16", "fp16"}
-    assert lhs_format in allowed_formats, f"NYI: lhs_format {lhs_format}"
-    assert rhs_format in allowed_formats, f"NYI: rhs_format {rhs_format}"
-    rhs_scale_is_none = rhs_scale is None or (isinstance(rhs_scale, tl.constexpr) and rhs_scale.value is None)
-    lhs_scale_is_none = lhs_scale is None or (isinstance(lhs_scale, tl.constexpr) and lhs_scale.value is None)
-    lhs = _bitcast_to_fp_type(lhs, lhs_format, builder)
-    rhs = _bitcast_to_fp_type(rhs, rhs_format, builder)
+        return self.tensor(
+            self.builder.create_dot(lhs.handle, rhs.handle, acc_handle, input_precision, max_num_imprecise_acc), ret_ty)
 
-    assert lhs_k_pack or lhs_format == "e2m1", "only mxfp4 inputs can be packed along a dimension different than K"
-    assert rhs_k_pack or rhs_format == "e2m1", "only mxfp4 inputs can be packed along a dimension different than K"
-    M, K_LHS = lhs.type.shape[-2:]
-    K_RHS, N = rhs.type.shape[-2:]
-    PACKED_A = 2 if lhs_format == "e2m1" else 1
-    PACKED_B = 2 if rhs_format == "e2m1" else 1
-    PACKED_A_DIM = PACKED_A * K_LHS if lhs_k_pack else K_LHS
-    PACKED_B_DIM = PACKED_B * K_RHS if rhs_k_pack else K_RHS
-    assert PACKED_B_DIM == PACKED_A_DIM, f"Reduction dimension should pack the same number of elements; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
-    #assert K * PACKED_B >= 64, f"scaled_dot NYI for K < 64. Got {K=}"
-    B = lhs.type.shape[0] if lhs_rank == 3 else None
-    if not lhs_k_pack:
-        M = M * PACKED_A
-    if not rhs_k_pack:
-        N = N * PACKED_B
-    ret_ty = tl.block_type(out_dtype, [B, M, N] if B else [M, N])
-    _0 = builder.get_fp32(0)
-    if acc is None:
-        acc_handle = builder.create_splat(ret_ty.to_ir(builder), _0)
-    else:
-        acc_handle = acc.handle
-        assert acc.type == ret_ty
-    rhs_scale_handle = None if rhs_scale_is_none else rhs_scale.handle
-    lhs_scale_handle = None if lhs_scale_is_none else lhs_scale.handle
-    return tl.tensor(
-        builder.create_dot_scaled(lhs.handle, lhs_scale_handle, lhs_format_enum, rhs.handle, rhs_scale_handle,
-                                  rhs_format_enum, fast_math, lhs_k_pack, rhs_k_pack, acc_handle), ret_ty)
+    def _str_to_fp_type(self, float_format: str):
+        ty_enum = getattr(ir.ScaleDotElemTypeTY, float_format.upper(), None)
+        if ty_enum is None:
+            raise ValueError(f"Invalid float format: {float_format}.")
+        return ty_enum
 
+    def _bitcast_to_fp_type(self, val: TensorTy, float_format: str):
+        """
+        If float_format is subbyte, make sure it's packed as uint8 and return it.
+        Otherwise, return a tensor (perhaps bitcasting) of the specified float format.
+        """
+        triton_ty = {"e5m2": tl.float8e5, "e4m3": tl.float8e4nv, "bf16": tl.bfloat16, "fp16":
+                     tl.float16}.get(float_format)
+        if triton_ty is None:
+            assert float_format == "e2m1", f"Internal Error: Unexpected float format: {float_format}"
+            assert val.dtype == tl.uint8, f"e2m1 format must be packed as uint8. Got {val.dtype}"
+            return val
+        if val.dtype == triton_ty:
+            return val
+        else:
+            unsigned_ty = {"e5m2": tl.uint8, "e4m3": tl.uint8, "bf16": tl.uint16, "fp16": tl.uint16}[float_format]
+            assert val.dtype == unsigned_ty, f"Unexpected dtype for {float_format}. Got {val.dtype}"
+            return self.bitcast(val, triton_ty)
+
+    def dot_scaled(self, lhs: TensorTy, lhs_scale: TensorTy, lhs_format: str, rhs: TensorTy,
+                   rhs_scale: Optional[TensorTy], rhs_format: str, acc: TensorTy | None, fast_math: bool,
+                   lhs_k_pack: bool, rhs_k_pack: bool, out_dtype: tl.dtype) -> TensorTy:
+        assert lhs.type.is_block() and rhs.type.is_block()
+        #TODO: validate types.
+        lhs_rank = len(lhs.shape)
+        rhs_rank = len(rhs.shape)
+        assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
+        lhs_format: str = lhs_format.value
+        rhs_format: str = rhs_format.value
+        lhs_format_enum = self._str_to_fp_type(lhs_format)
+        rhs_format_enum = self._str_to_fp_type(rhs_format)
+        allowed_formats = {"e2m1", "e4m3", "e5m2", "bf16", "fp16"}
+        assert lhs_format in allowed_formats, f"NYI: lhs_format {lhs_format}"
+        assert rhs_format in allowed_formats, f"NYI: rhs_format {rhs_format}"
+        rhs_scale_is_none = rhs_scale is None or (isinstance(rhs_scale, tl.constexpr) and rhs_scale.value is None)
+        lhs_scale_is_none = lhs_scale is None or (isinstance(lhs_scale, tl.constexpr) and lhs_scale.value is None)
+        lhs = self._bitcast_to_fp_type(lhs, lhs_format)
+        rhs = self._bitcast_to_fp_type(rhs, rhs_format)
+
+        assert lhs_k_pack or lhs_format == "e2m1", "only mxfp4 inputs can be packed along a dimension different than K"
+        assert rhs_k_pack or rhs_format == "e2m1", "only mxfp4 inputs can be packed along a dimension different than K"
+        M, K_LHS = lhs.type.shape[-2:]
+        K_RHS, N = rhs.type.shape[-2:]
+        PACKED_A = 2 if lhs_format == "e2m1" else 1
+        PACKED_B = 2 if rhs_format == "e2m1" else 1
+        PACKED_A_DIM = PACKED_A * K_LHS if lhs_k_pack else K_LHS
+        PACKED_B_DIM = PACKED_B * K_RHS if rhs_k_pack else K_RHS
+        assert PACKED_B_DIM == PACKED_A_DIM, f"Reduction dimension should pack the same number of elements; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
+        #assert K * PACKED_B >= 64, f"scaled_dot NYI for K < 64. Got {K=}"
+        B = lhs.type.shape[0] if lhs_rank == 3 else None
+        if not lhs_k_pack:
+            M = M * PACKED_A
+        if not rhs_k_pack:
+            N = N * PACKED_B
+        ret_ty = tl.block_type(out_dtype, [B, M, N] if B else [M, N])
+        _0 = self.builder.get_fp32(0)
+        if acc is None:
+            acc_handle = self.builder.create_splat(ret_ty.to_ir(self.builder), _0)
+        else:
+            acc_handle = acc.handle
+            assert acc.type == ret_ty
+        rhs_scale_handle = None if rhs_scale_is_none else rhs_scale.handle
+        lhs_scale_handle = None if lhs_scale_is_none else lhs_scale.handle
+        return self.tensor(
+            self.builder.create_dot_scaled(lhs.handle, lhs_scale_handle, lhs_format_enum, rhs.handle, rhs_scale_handle,
+                                           rhs_format_enum, fast_math, lhs_k_pack, rhs_k_pack, acc_handle), ret_ty)
 
 # ===----------------------------------------------------------------------===//
 #                               Indexing
 # ===----------------------------------------------------------------------===//
 
-
-def where(condition: tl.tensor, x: tl.tensor, y: tl.tensor, builder: ir.builder) -> tl.tensor:
-    if condition.dtype != tl.int1:
-        warnings.warn(
-            f"tl.where with a non-boolean condition is deprecated and will error out in a future triton release. Got {condition.dtype}"
-        )
-    condition = cast(condition, tl.int1, builder)
-    x, y = binary_op_type_checking_impl(x, y, builder, True, True)
-    # x, y are broadcasted
-    if condition.type.is_block():
-        condition, x = broadcast_impl_value(condition, x, builder)
-        x, y = broadcast_impl_value(x, y, builder)
-    else:
-        condition, _ = broadcast_impl_value(condition, x, builder)
-    ret_ty = x.type
-    return tl.tensor(builder.create_select(condition.handle, x.handle, y.handle), ret_ty)
-
+    def where(self, condition: TensorTy, x: TensorTy, y: TensorTy) -> TensorTy:
+        if condition.dtype != tl.int1:
+            warnings.warn(
+                f"tl.where with a non-boolean condition is deprecated and will error out in a future triton release. Got {condition.dtype}"
+            )
+        condition = self.cast(condition, tl.int1)
+        x, y = self.binary_op_type_checking_impl(x, y, True, True)
+        # x, y are broadcasted
+        if condition.type.is_block():
+            condition, x = self.broadcast_impl_value(condition, x)
+            x, y = self.broadcast_impl_value(x, y)
+        else:
+            condition, _ = self.broadcast_impl_value(condition, x)
+        ret_ty = x.type
+        return self.tensor(self.builder.create_select(condition.handle, x.handle, y.handle), ret_ty)
 
 # ===----------------------------------------------------------------------===//
 #                               Reduction
 # ===----------------------------------------------------------------------===
 
+    def wrap_tensor(self, x, scalar_ty, ret_shape):
+        if ret_shape:
+            res_ty = tl.block_type(scalar_ty, ret_shape)
+        else:
+            # 0d-tensor -> scalar
+            res_ty = scalar_ty
+        return self.tensor(x, res_ty)
 
-def wrap_tensor(x, scalar_ty, ret_shape):
-    if ret_shape:
-        res_ty = tl.block_type(scalar_ty, ret_shape)
-    else:
-        # 0d-tensor -> scalar
-        res_ty = scalar_ty
-    return tl.tensor(x, res_ty)
+    def reduction(self, inputs: Sequence[TensorTy], axis: int, region_builder_fn) -> Tuple[TensorTy, ...]:
+        if axis is None:
+            inputs = tuple(self.reshape(t, [t.numel.value], can_reorder=True) for t in inputs)
+            axis = 0
+        # get result shape
+        shape = inputs[0].type.shape
+        rank = len(shape)
+        assert axis < rank, f"reduction axis must be < inputs rank ({rank})"
+        ret_shape = [s for i, s in enumerate(shape) if i != axis]
+        assert all(t.type.shape == shape for t in inputs), "all reduction inputs must have the same shape"
 
+        reduce_op = self.builder.create_reduce([t.handle for t in inputs], axis)
+        region_builder_fn(reduce_op)
+        reduce_op.verify()
 
-def reduction(inputs: Sequence[tl.tensor], axis: int, region_builder_fn, builder: ir.builder) -> Tuple[tl.tensor, ...]:
-    if axis is None:
-        inputs = tuple(reshape(t, [t.numel.value], can_reorder=True, builder=builder) for t in inputs)
-        axis = 0
-    # get result shape
-    shape = inputs[0].type.shape
-    rank = len(shape)
-    assert axis < rank, f"reduction axis must be < inputs rank ({rank})"
-    ret_shape = [s for i, s in enumerate(shape) if i != axis]
-    assert all(t.type.shape == shape for t in inputs), "all reduction inputs must have the same shape"
-
-    reduce_op = builder.create_reduce([t.handle for t in inputs], axis)
-    region_builder_fn(reduce_op)
-    reduce_op.verify()
-
-    return tuple(wrap_tensor(reduce_op.get_result(i), inputs[i].type.scalar, ret_shape) for i in range(len(inputs)))
-
+        return tuple(
+            self.wrap_tensor(reduce_op.get_result(i), inputs[i].type.scalar, ret_shape) for i in range(len(inputs)))
 
 # ===----------------------------------------------------------------------===
 #                               Associative Scan
 # ===----------------------------------------------------------------------===
 
+    def associative_scan(self, inputs: Sequence[TensorTy], axis: int, region_builder_fn,
+                         reverse: bool) -> Tuple[TensorTy, ...]:
+        shape = inputs[0].type.shape
+        rank = len(shape)
 
-def associative_scan(inputs: Sequence[tl.tensor], axis: int, region_builder_fn, reverse: bool,
-                     builder: ir.builder) -> Tuple[tl.tensor, ...]:
-    shape = inputs[0].type.shape
-    rank = len(shape)
+        assert -rank <= axis < rank, f"scan axis {axis} must be < inputs rank ({rank})"
 
-    assert -rank <= axis < rank, f"scan axis {axis} must be < inputs rank ({rank})"
+        if axis < 0:
+            axis += rank
 
-    if axis < 0:
-        axis += rank
+        for t in inputs:
+            assert t.type.shape == shape, "all scan inputs must have the same shape"
 
-    for t in inputs:
-        assert t.type.shape == shape, "all scan inputs must have the same shape"
+        scan_op = self.builder.create_scan([t.handle for t in inputs], axis, reverse)
+        region_builder_fn(scan_op)
+        scan_op.verify()
 
-    scan_op = builder.create_scan([t.handle for t in inputs], axis, reverse)
-    region_builder_fn(scan_op)
-    scan_op.verify()
-
-    return tuple(wrap_tensor(scan_op.get_result(i), inputs[i].type.scalar, shape) for i in range(len(inputs)))
-
+        return tuple(self.wrap_tensor(scan_op.get_result(i), inputs[i].type.scalar, shape) for i in range(len(inputs)))
 
 # ===----------------------------------------------------------------------===
 #                               Gather
 # ===----------------------------------------------------------------------===
 
+    def gather(self, src: TensorTy, index: TensorTy, axis: int) -> TensorTy:
+        assert index.dtype.is_int(), "index must be an integer tensor"
 
-def gather(src: tl.tensor, index: tl.tensor, axis: int, builder: ir.builder) -> tl.tensor:
-    assert index.dtype.is_int(), "index must be an integer tensor"
+        rank = len(src.type.shape)
+        assert len(index.type.shape) == rank, "source and index tensors must have the same rank"
 
-    rank = len(src.type.shape)
-    assert len(index.type.shape) == rank, "source and index tensors must have the same rank"
+        assert -rank <= axis < rank, f"gather axis {axis} must be < source rank ({rank})"
+        if axis < 0:
+            axis += rank
 
-    assert -rank <= axis < rank, f"gather axis {axis} must be < source rank ({rank})"
-    if axis < 0:
-        axis += rank
+        for d in range(rank):
+            if d == axis:
+                continue
+            assert index.type.shape[d] == src.type.shape[d], f"index dim {axis} must match the corresponding source dim"
 
-    for d in range(rank):
-        if d == axis:
-            continue
-        assert index.type.shape[d] == src.type.shape[d], f"index dim {axis} must match the corresponding source dim"
-
-    gather = builder.create_gather(src.handle, index.handle, axis)
-    return wrap_tensor(gather, src.type.scalar, index.type.shape)
+        gather = self.builder.create_gather(src.handle, index.handle, axis)
+        return self.wrap_tensor(gather, src.type.scalar, index.type.shape)
 
 
 # ===----------------------------------------------------------------------===
 #                               Histogram
 # ===----------------------------------------------------------------------===
 
+    def histogram(self, input: TensorTy, num_bins: int, mask: Optional[TensorTy]) -> TensorTy:
+        assert len(input.shape) == 1, "histogram only supports 1D input"
+        assert input.dtype.is_int(), "histogram only supports integer input"
+        if mask is not None:
+            mask = self.broadcast_impl_shape(mask, input.shape)
+            if not mask.type.scalar.is_bool():
+                raise ValueError("Mask must have boolean scalar type")
+            mask = mask.handle
+        return self.tensor(self.builder.create_histogram(input.handle, num_bins, mask),
+                           tl.block_type(tl.int32, [num_bins]))
 
-def histogram(input: tl.tensor, num_bins: int, mask: Optional[tl.tensor], builder: ir.builder) -> tl.tensor:
-    assert len(input.shape) == 1, "histogram only supports 1D input"
-    assert input.dtype.is_int(), "histogram only supports integer input"
-    if mask is not None:
-        mask = broadcast_impl_shape(mask, input.shape, builder)
-        if not mask.type.scalar.is_bool():
-            raise ValueError("Mask must have boolean scalar type")
-        mask = mask.handle
-    return tl.tensor(builder.create_histogram(input.handle, num_bins, mask), tl.block_type(tl.int32, [num_bins]))
+    def multiple_of(self, x: TensorTy, values: List[int]) -> TensorTy:
+        if max(1, len(x.shape)) != len(values):
+            raise ValueError("Shape of input to multiple_of does not match the length of values")
+        x.handle.set_attr("tt.divisibility", ir.make_attr(values, x.handle.get_context()))
+        return x
 
+    def max_contiguous(self, x: TensorTy, values: List[int]) -> TensorTy:
+        if len(x.shape) != len(values):
+            raise ValueError("Shape of input to max_contiguous does not match the length of values")
+        x.handle.set_attr("tt.contiguity", ir.make_attr(values, x.handle.get_context()))
+        return x
 
-def multiple_of(x: tl.tensor, values: List[int]) -> tl.tensor:
-    if max(1, len(x.shape)) != len(values):
-        raise ValueError("Shape of input to multiple_of does not match the length of values")
-    x.handle.set_attr("tt.divisibility", ir.make_attr(values, x.handle.get_context()))
-    return x
+    def max_constancy(self, x: TensorTy, values: List[int]) -> TensorTy:
+        if len(x.shape) != len(values):
+            raise ValueError("Shape of input to max_constancy does not match the length of values")
+        x.handle.set_attr("tt.constancy", ir.make_attr(values, x.handle.get_context()))
+        return x
 
+    def debug_barrier(self) -> TensorTy:
+        return self.tensor(self.builder.create_barrier(), tl.void)
 
-def max_contiguous(x: tl.tensor, values: List[int]) -> tl.tensor:
-    if len(x.shape) != len(values):
-        raise ValueError("Shape of input to max_contiguous does not match the length of values")
-    x.handle.set_attr("tt.contiguity", ir.make_attr(values, x.handle.get_context()))
-    return x
+    def device_print(self, prefix: str, args: List[TensorTy], hex: bool) -> TensorTy:
+        # It makes sense visually for prefix to end in ": "; make it so.  Also,
+        # non-empty prefixes should start with " ".
+        if not prefix.endswith(" ") and args:
+            prefix += " "
+        if not prefix.endswith(": ") and args:
+            prefix = prefix[:-1] + ": "
+        if len(prefix) > 2 and not prefix.startswith(" "):
+            prefix = " " + prefix
 
+        new_args = [arg.handle for arg in args]
+        is_signed = [arg.dtype.is_int_signed() for arg in args]
+        return self.tensor(self.builder.create_print(prefix, hex, new_args, is_signed), tl.void)
 
-def max_constancy(x: tl.tensor, values: List[int]) -> tl.tensor:
-    if len(x.shape) != len(values):
-        raise ValueError("Shape of input to max_constancy does not match the length of values")
-    x.handle.set_attr("tt.constancy", ir.make_attr(values, x.handle.get_context()))
-    return x
+    def device_assert(self, cond: TensorTy, msg: str) -> TensorTy:
+        if not self.builder.options.debug:
+            return
+        return self.tensor(self.builder.create_assert(cond.handle, msg), tl.void)
 
+    def assume(self, cond) -> TensorTy:
+        return self.tensor(self.builder.create_assume(cond.handle), tl.void)
 
-def debug_barrier(builder: ir.builder) -> tl.tensor:
-    return tl.tensor(builder.create_barrier(), tl.void)
+    def _convert_elem_to_ir_value(self, elem, require_i64):
+        if isinstance(elem, int):
+            elem = tl.constexpr(elem)
+        if isinstance(elem, tl.constexpr):
+            if isinstance(elem.value, bool):
+                return self.builder.get_int1(elem.value)
+            if require_i64:
+                assert -2**63 <= elem.value < 2**63, f"Block pointers only support 64 bit `shape/strides`, " \
+                    f"got a value {elem.value} which is out of the range"
+                return self.builder.get_int64(elem.value)
+            else:
+                assert -2**31 <= elem.value < 2**31, f"Block pointers only support 32 bit `offsets/block_shape`, " \
+                    f"got a value {elem.value} which is out of the range"
+                return self.builder.get_int32(elem.value)
+        elif isinstance(elem, tl.tensor):
+            assert elem.numel.value == 1, "Expected a scalar in shape/strides/offsets"
+            assert elem.dtype.is_int(), "Expected an integer scalar type in shape/strides/offsets"
+            if elem.dtype != tl.int64 and require_i64:
+                return self.builder.create_int_cast(elem.handle, self.builder.get_int64_ty(),
+                                                    elem.dtype.is_int_signed())
+            elif elem.dtype != tl.int32 and not require_i64:
+                assert False, "Block pointers only support 32 bit `offsets/block_shape`, " \
+                    "add a `.to(tl.int32)` or use regular indexing for 64 bit support"
+            return elem.handle
+        assert False, f"Unsupported element type in shape/strides/offsets: {type(elem)}"
 
+    def _convert_to_ir_values(self, list_like, require_i64=True):
+        if hasattr(list_like, "__iter__"):
+            return [self._convert_elem_to_ir_value(elem, require_i64) for elem in list_like]
+        return [self._convert_elem_to_ir_value(list_like, require_i64)]
 
-def device_print(prefix: str, args: List[tl.tensor], hex: bool, builder: ir.builder) -> tl.tensor:
-    # It makes sense visually for prefix to end in ": "; make it so.  Also,
-    # non-empty prefixes should start with " ".
-    if not prefix.endswith(" ") and args:
-        prefix += " "
-    if not prefix.endswith(": ") and args:
-        prefix = prefix[:-1] + ": "
-    if len(prefix) > 2 and not prefix.startswith(" "):
-        prefix = " " + prefix
+    def make_block_ptr(self, base: TensorTy, shape, strides, offsets, block_shape, order) -> TensorTy:
+        # Convert dynamic arguments to IR values
+        # NOTES(Chenggang): current `shape/strides` are `int64_t`, while `offsets/block_shape` are `int32_t`
+        shape = self._convert_to_ir_values(shape)
+        strides = self._convert_to_ir_values(strides)
+        offsets = self._convert_to_ir_values(offsets, require_i64=False)
 
-    new_args = [arg.handle for arg in args]
-    is_signed = [arg.dtype.is_int_signed() for arg in args]
-    return tl.tensor(builder.create_print(prefix, hex, new_args, is_signed), tl.void)
+        # Check `base` type
+        if not base.type.is_ptr() or base.type.element_ty.is_block():
+            raise ValueError("Expected `base` to be a pointer type (but not a block pointer type or others)")
 
+        # Treat `pointer_type<tl.int1>` as `pointer_type<tl.int8>`
+        if base.type.element_ty == tl.int1:
+            base = self.cast(base, tl.pointer_type(tl.int8, base.type.address_space))
 
-def device_assert(cond: tl.tensor, msg: str, builder: ir.builder) -> tl.tensor:
-    if not builder.options.debug:
-        return
-    return tl.tensor(builder.create_assert(cond.handle, msg), tl.void)
+        # Check whether `block_shape` is static
+        if not hasattr(block_shape, "__iter__"):
+            block_shape = [block_shape]
+        block_shape = [elem.value if isinstance(elem, tl.constexpr) else elem for elem in block_shape]
+        assert all(isinstance(elem, int) and -2**31 <= elem < 2**31 for elem in block_shape), \
+            "Expected a list of constant integers (`int32_t` range) in `block_shape`"
 
+        # Check `order`
+        if not hasattr(order, "__iter__"):
+            order = [order]
+        order = [elem.value if isinstance(elem, tl.constexpr) else elem for elem in order]
+        assert sorted(order) == list(range(len(order))), "Expected a permutation of (0, 1, ..., len(order)-1) in order"
 
-def assume(cond, builder: ir.builder) -> tl.tensor:
-    return tl.tensor(builder.create_assume(cond.handle), tl.void)
+        # Must have same length
+        assert all(len(block_shape) == len(list_like) for list_like in [shape, strides, offsets, order]), \
+            "Expected shape/strides/offsets/block_shape to have the same length"
 
+        # Build value, the type is:
+        #   `pointer_type<blocked<shape, element_type>>` in Python
+        #   `tt.ptr<tensor<shape, element_type>>` in MLIR
+        handle = self.builder.create_make_block_ptr(base.handle, shape, strides, offsets, block_shape, order)
+        return self.tensor(handle, tl.pointer_type(tl.block_type(base.type.element_ty, block_shape)))
 
-def _convert_elem_to_ir_value(builder, elem, require_i64):
-    if isinstance(elem, int):
-        elem = tl.constexpr(elem)
-    if isinstance(elem, tl.constexpr):
-        if isinstance(elem.value, bool):
-            return builder.get_int1(elem.value)
-        if require_i64:
-            assert -2**63 <= elem.value < 2**63, f"Block pointers only support 64 bit `shape/strides`, " \
-                f"got a value {elem.value} which is out of the range"
-            return builder.get_int64(elem.value)
-        else:
-            assert -2**31 <= elem.value < 2**31, f"Block pointers only support 32 bit `offsets/block_shape`, " \
-                f"got a value {elem.value} which is out of the range"
-            return builder.get_int32(elem.value)
-    elif isinstance(elem, tl.tensor):
-        assert elem.numel.value == 1, "Expected a scalar in shape/strides/offsets"
-        assert elem.dtype.is_int(), "Expected an integer scalar type in shape/strides/offsets"
-        if elem.dtype != tl.int64 and require_i64:
-            return builder.create_int_cast(elem.handle, builder.get_int64_ty(), elem.dtype.is_int_signed())
-        elif elem.dtype != tl.int32 and not require_i64:
-            assert False, "Block pointers only support 32 bit `offsets/block_shape`, " \
-                "add a `.to(tl.int32)` or use regular indexing for 64 bit support"
-        return elem.handle
-    assert False, f"Unsupported element type in shape/strides/offsets: {type(elem)}"
+    def advance(self, base: TensorTy, offsets) -> TensorTy:
+        # Convert dynamic offsets to IR values
+        offsets = self._convert_to_ir_values(offsets, require_i64=False)
 
+        # Advanced block pointer type is the same as before
+        return self.tensor(self.builder.create_advance(base.handle, offsets), base.type)
 
-def _convert_to_ir_values(builder, list_like, require_i64=True):
-    if hasattr(list_like, "__iter__"):
-        return [_convert_elem_to_ir_value(builder, elem, require_i64) for elem in list_like]
-    return [_convert_elem_to_ir_value(builder, list_like, require_i64)]
+    def make_tensor_descriptor(
+        self,
+        base: TensorTy,
+        shape: List[TensorTy],
+        strides: List[TensorTy],
+        block_shape: List[tl.constexpr],
+    ) -> tl.tensor_descriptor:
+        ndim = len(shape)
+        if not (1 <= ndim <= 5):
+            raise ValueError(f"Expected 1 <= ndim <= 5 but got {ndim} dimensions")
+        if len(strides) != ndim:
+            raise ValueError(f"Expected {ndim} strides but got {len(strides)}")
+        if len(block_shape) != ndim:
+            raise ValueError(f"Expected block_shape to have {ndim} dimensions but got {len(strides)}")
+        assert isinstance(base.dtype, tl.pointer_type)
+        elem_size = base.dtype.element_ty.primitive_bitwidth // 8
+        contig_dim_size = tl._unwrap_if_constexpr(block_shape[-1])
+        if contig_dim_size * elem_size < 16:
+            raise ValueError(
+                f"Descriptor block shape must have at least 16 bytes in the last dimension, but got {contig_dim_size} * {elem_size} = {contig_dim_size * elem_size} bytes"
+            )
 
+        strides[-1] = tl._unwrap_if_constexpr(strides[-1])
+        if strides[-1] != 1:
+            raise ValueError(f"Tensor descriptor last dim must be 1 but got {strides[-1]}")
 
-def make_block_ptr(base: tl.tensor, shape, strides, offsets, block_shape, order, builder: ir.builder) -> tl.tensor:
-    # Convert dynamic arguments to IR values
-    # NOTES(Chenggang): current `shape/strides` are `int64_t`, while `offsets/block_shape` are `int32_t`
-    shape = _convert_to_ir_values(builder, shape)
-    strides = _convert_to_ir_values(builder, strides)
-    offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
+        shape = [self.full([], x, tl.int32) for x in shape]
+        strides = [self.full([], x, tl.int64) for x in strides]
 
-    # Check `base` type
-    if not base.type.is_ptr() or base.type.element_ty.is_block():
-        raise ValueError("Expected `base` to be a pointer type (but not a block pointer type or others)")
+        # Check whether `block_shape` is static
+        block_shape = tl._unwrap_shape(block_shape)
 
-    # Treat `pointer_type<tl.int1>` as `pointer_type<tl.int8>`
-    if base.type.element_ty == tl.int1:
-        base = cast(base, tl.pointer_type(tl.int8, base.type.address_space), builder)
+        assert isinstance(base.type, tl.pointer_type)
+        type = tl.block_type(base.type.element_ty, block_shape)
+        base_handle = base.handle
+        is_signed_int = base.type.element_ty.is_int_signed()
 
-    # Check whether `block_shape` is static
-    if not hasattr(block_shape, "__iter__"):
-        block_shape = [block_shape]
-    block_shape = [elem.value if isinstance(elem, tl.constexpr) else elem for elem in block_shape]
-    assert all(isinstance(elem, int) and -2**31 <= elem < 2**31 for elem in block_shape), \
-        "Expected a list of constant integers (`int32_t` range) in `block_shape`"
-
-    # Check `order`
-    if not hasattr(order, "__iter__"):
-        order = [order]
-    order = [elem.value if isinstance(elem, tl.constexpr) else elem for elem in order]
-    assert sorted(order) == list(range(len(order))), "Expected a permutation of (0, 1, ..., len(order)-1) in order"
-
-    # Must have same length
-    assert all(len(block_shape) == len(list_like) for list_like in [shape, strides, offsets, order]), \
-        "Expected shape/strides/offsets/block_shape to have the same length"
-
-    # Build value, the type is:
-    #   `pointer_type<blocked<shape, element_type>>` in Python
-    #   `tt.ptr<tensor<shape, element_type>>` in MLIR
-    handle = builder.create_make_block_ptr(base.handle, shape, strides, offsets, block_shape, order)
-    return tl.tensor(handle, tl.pointer_type(tl.block_type(base.type.element_ty, block_shape)))
-
-
-def advance(base: tl.tensor, offsets, builder: ir.builder) -> tl.tensor:
-    # Convert dynamic offsets to IR values
-    offsets = _convert_to_ir_values(builder, offsets, require_i64=False)
-
-    # Advanced block pointer type is the same as before
-    return tl.tensor(builder.create_advance(base.handle, offsets), base.type)
-
-
-def make_tensor_descriptor(
-    base: tl.tensor,
-    shape: List[tl.tensor],
-    strides: List[tl.tensor],
-    block_shape: List[tl.constexpr],
-    builder: ir.builder,
-) -> tl.tensor_descriptor:
-    ndim = len(shape)
-    if not (1 <= ndim <= 5):
-        raise ValueError(f"Expected 1 <= ndim <= 5 but got {ndim} dimensions")
-    if len(strides) != ndim:
-        raise ValueError(f"Expected {ndim} strides but got {len(strides)}")
-    if len(block_shape) != ndim:
-        raise ValueError(f"Expected block_shape to have {ndim} dimensions but got {len(strides)}")
-    assert isinstance(base.dtype, tl.pointer_type)
-    elem_size = base.dtype.element_ty.primitive_bitwidth // 8
-    contig_dim_size = tl._unwrap_if_constexpr(block_shape[-1])
-    if contig_dim_size * elem_size < 16:
-        raise ValueError(
-            f"Descriptor block shape must have at least 16 bytes in the last dimension, but got {contig_dim_size} * {elem_size} = {contig_dim_size * elem_size} bytes"
-        )
-
-    strides[-1] = tl._unwrap_if_constexpr(strides[-1])
-    if strides[-1] != 1:
-        raise ValueError(f"Tensor descriptor last dim must be 1 but got {strides[-1]}")
-
-    shape = [to_tensor(x, builder) for x in shape]
-    strides = [to_tensor(x, builder).to(tl.int64, _builder=builder) for x in strides]
-
-    # Check whether `block_shape` is static
-    block_shape = tl._unwrap_shape(block_shape)
-
-    assert isinstance(base.type, tl.pointer_type)
-    type = tl.block_type(base.type.element_ty, block_shape)
-    base_handle = base.handle
-    is_signed_int = base.type.element_ty.is_int_signed()
-
-    handle = builder.create_make_tensor_descriptor(base_handle, [s.handle for s in shape], [s.handle for s in strides],
-                                                   block_shape, is_signed_int)
-    return tl.tensor_descriptor(handle, shape, strides, type)
+        handle = self.builder.create_make_tensor_descriptor(base_handle, [s.handle for s in shape],
+                                                            [s.handle for s in strides], block_shape, is_signed_int)
+        return tl.tensor_descriptor(handle, shape, strides, type)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -12,7 +12,7 @@ import triton.language as tl
 import dataclasses
 from dataclasses import dataclass
 
-from triton.language import semantic
+from triton.language.semantic import TritonSemantic
 from triton.tools.tensor_descriptor import TensorDescriptor
 from .errors import InterpreterError
 from functools import partial
@@ -253,8 +253,8 @@ np_umulhi_u64 = np.vectorize(_umulhi_64, otypes=[np.uint64])
 class ExtraFunctions:
 
     @staticmethod
-    def _convert_custom_types(input, dst_ty, fp_downcast_rounding, _builder):
-        return tl.tensor(_builder.create_fp_to_fp(input.handle, dst_ty, fp_downcast_rounding), dst_ty)
+    def _convert_custom_types(input, dst_ty, fp_downcast_rounding, _semantic):
+        return tl.tensor(_semantic.builder.create_fp_to_fp(input.handle, dst_ty, fp_downcast_rounding), dst_ty)
 
 
 class InterpreterBuilder:
@@ -777,10 +777,11 @@ class InterpreterBuilder:
 
 
 def _patch_attr(obj, name, member, builder):
+    semantic = TritonSemantic(builder)
     new_member = lambda *args, member=member, **kwargs: (member(*args, **
                                                                 {k: v
                                                                  for k, v in kwargs.items()
-                                                                 if k != "_builder"}, _builder=builder))
+                                                                 if k != "_semantic"}, _semantic=semantic))
     setattr(obj, name, new_member)
 
 
@@ -1148,17 +1149,18 @@ def _implicit_cvt(arg):
         strides = [_implicit_cvt(s) for s in arg.strides]
         assert arg.strides[-1] == 1
         strides[-1] = tl.constexpr(1)
+        semantic = TritonSemantic(InterpreterBuilder())
         return semantic.make_tensor_descriptor(
             base=_implicit_cvt(arg.base),
             shape=[_implicit_cvt(s) for s in arg.shape],
             strides=strides,
             block_shape=[tl.constexpr(b) for b in arg.block_shape],
-            builder=InterpreterBuilder(),
         )
     return arg
 
 
 interpreter_builder = InterpreterBuilder()
+interpreter_semantic = TritonSemantic(interpreter_builder)
 
 
 def _unwrap_tensor(t):
@@ -1272,6 +1274,8 @@ class GridExecutor:
                         interpreter_builder.set_grid_idx(x, y, z)
                         self.fn(**args)
         except Exception as e:
+            if triton.knobs.compilation.front_end_debugging:
+                raise
             raise InterpreterError(repr(e)) from e
         # copy arguments back to propagate side-effects
         self._restore_args_dev(args_dev, args_hst, kwargs, kwargs_hst)
@@ -1286,14 +1290,10 @@ class ASTTransformer(ast.NodeTransformer):
         if len(names) > 1:
             raise ValueError("Multiple assignments are not supported")
         # Modify the assignment x = value to
-        # triton.language.semantic.to_tensor(value, interpreter_builder, False)
+        # interpreter_semantic.to_tensor(value, False)
         node.value = ast.Call(
-            func=ast.Attribute(
-                value=ast.Attribute(
-                    value=ast.Attribute(value=ast.Name(id='triton', ctx=ast.Load()), attr='language', ctx=ast.Load()),
-                    attr='semantic', ctx=ast.Load()), attr='to_tensor', ctx=ast.Load()),
-            args=[node.value, ast.Name(id='interpreter_builder', ctx=ast.Load()),
-                  ast.Constant(value=False)], keywords=[])
+            func=ast.Attribute(value=ast.Name(id="interpreter_semantic", ctx=ast.Load()), attr="to_tensor",
+                               ctx=ast.Load()), args=[node.value, ast.Constant(value=False)], keywords=[])
         return node
 
 

--- a/third_party/amd/language/hip/libdevice.py
+++ b/third_party/amd/language/hip/libdevice.py
@@ -2,474 +2,474 @@ from triton.language import core
 
 
 @core.extern
-def abs(arg0, _builder=None):
+def abs(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("int32"), ): ("__triton_hip_iabs", core.dtype("int32")),
             (core.dtype("int64"), ): ("__triton_hip_iabs", core.dtype("int64")),
             (core.dtype("fp32"), ): ("__triton_hip_fabs", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__triton_hip_fabs", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def floor(arg0, _builder=None):
+def floor(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_floor_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_floor_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rsqrt(arg0, _builder=None):
+def rsqrt(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_rsqrt_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_rsqrt_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ceil(arg0, _builder=None):
+def ceil(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_ceil_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_ceil_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def trunc(arg0, _builder=None):
+def trunc(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_trunc_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_trunc_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def exp2(arg0, _builder=None):
+def exp2(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_exp2_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_exp2_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def exp(arg0, _builder=None):
+def exp(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_exp_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_exp_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_expf(arg0, _builder=None):
+def fast_expf(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__triton_hip_fast_expf", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_dividef(arg0, arg1, _builder=None):
+def fast_dividef(arg0, arg1, _semantic=None):
     return core.extern_elementwise("", "", [arg0, arg1], {
         (core.dtype("fp32"), core.dtype("fp32")): ("__triton_hip_fast_fdividef", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sqrt(arg0, _builder=None):
+def sqrt(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_sqrt_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_sqrt_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def llrint(arg0, _builder=None):
+def llrint(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__triton_hip_llrint", core.dtype("int64")),
             (core.dtype("fp64"), ): ("__triton_hip_llrint", core.dtype("int64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def nearbyint(arg0, _builder=None):
+def nearbyint(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [
             arg0,
         ], {
             (core.dtype("fp32"), ): ("__ocml_nearbyint_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_nearbyint_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def isnan(arg0, _builder=None):
+def isnan(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [
             arg0,
         ], {
             (core.dtype("fp32"), ): ("__ocml_isnan_f32", core.dtype("int32")),
             (core.dtype("fp64"), ): ("__ocml_isnan_f64", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder).to(core.int1, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic).to(core.int1, _semantic=_semantic)
 
 
 @core.extern
-def signbit(arg0, _builder=None):
+def signbit(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [
             arg0,
         ], {
             (core.dtype("fp32"), ): ("__ocml_signbit_f32", core.dtype("int32")),
             (core.dtype("fp64"), ): ("__ocml_signbit_f64", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def copysign(arg0, arg1, _builder=None):
+def copysign(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_copysign_f32", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__ocml_copysign_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def isinf(arg0, _builder=None):
+def isinf(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_isinf_f32", core.dtype("int32")),
             (core.dtype("fp64"), ): ("__ocml_isinf_f64", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder).to(core.int1, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic).to(core.int1, _semantic=_semantic)
 
 
 @core.extern
-def nextafter(arg0, arg1, _builder=None):
+def nextafter(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_nextafter_f32", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__ocml_nextafter_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sin(arg0, _builder=None):
+def sin(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_sin_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_sin_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def cos(arg0, _builder=None):
+def cos(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_cos_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_cos_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def tan(arg0, _builder=None):
+def tan(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_tan_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_tan_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def log2(arg0, _builder=None):
+def log2(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_log2_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_log2_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def cosh(arg0, _builder=None):
+def cosh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_cosh_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_cosh_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sinh(arg0, _builder=None):
+def sinh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_sinh_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_sinh_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def tanh(arg0, _builder=None):
+def tanh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_tanh_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_tanh_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def atan2(arg0, arg1, _builder=None):
+def atan2(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_atan2_f32", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__ocml_atan2_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def atan(arg0, _builder=None):
+def atan(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_atan_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_atan_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def asin(arg0, _builder=None):
+def asin(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_asin_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_asin_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def acos(arg0, _builder=None):
+def acos(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_acos_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_acos_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def log(arg0, _builder=None):
+def log(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_log_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_log_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def log10(arg0, _builder=None):
+def log10(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_log10_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_log10_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def log1p(arg0, _builder=None):
+def log1p(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_log1p_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_log1p_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def acosh(arg0, _builder=None):
+def acosh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_acosh_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_acosh_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def asinh(arg0, _builder=None):
+def asinh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_asinh_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_asinh_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def atanh(arg0, _builder=None):
+def atanh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_atanh_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_atanh_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def expm1(arg0, _builder=None):
+def expm1(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_expm1_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_expm1_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def hypot(arg0, arg1, _builder=None):
+def hypot(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_hypot_f32", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__ocml_hypot_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def j0(arg0, _builder=None):
+def j0(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_j0_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_j0_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def j1(arg0, _builder=None):
+def j1(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_j1_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_j1_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def y0(arg0, _builder=None):
+def y0(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_y0_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_y0_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def y1(arg0, _builder=None):
+def y1(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_y1_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_y1_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def cyl_bessel_i0(arg0, _builder=None):
+def cyl_bessel_i0(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_i0_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_i0_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def cyl_bessel_i1(arg0, _builder=None):
+def cyl_bessel_i1(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_i1_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_i1_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def erf(arg0, _builder=None):
+def erf(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_erf_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_erf_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def erfinv(arg0, _builder=None):
+def erfinv(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_erfinv_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_erfinv_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def erfc(arg0, _builder=None):
+def erfc(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_erfc_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_erfc_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def erfcx(arg0, _builder=None):
+def erfcx(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_erfcx_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_erfcx_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def lgamma(arg0, _builder=None):
+def lgamma(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_lgamma_f32", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__ocml_lgamma_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ldexp(arg0, arg1, _builder=None):
+def ldexp(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("int32")): ("__ocml_ldexp_f32", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("int32")): ("__ocml_ldexp_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fmod(arg0, arg1, _builder=None):
+def fmod(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_fmod_f32", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__ocml_fmod_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fma(arg0, arg1, arg2, _builder=None):
+def fma(arg0, arg1, arg2, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2], {
             (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__ocml_fma_f32", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__ocml_fma_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def pow(arg0, arg1, _builder=None):
+def pow(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("int32")): ("__ocml_pown_f32", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("int32")): ("__ocml_pown_f64", core.dtype("fp64")),
             (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_pow_f32", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__ocml_pow_f64", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ilogb(arg0, _builder=None):
+def ilogb(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__ocml_ilogb_f32", core.dtype("int32")),
             (core.dtype("fp64"), ): ("__ocml_ilogb_f64", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)

--- a/third_party/nvidia/language/cuda/libdevice.py
+++ b/third_party/nvidia/language/cuda/libdevice.py
@@ -2,363 +2,363 @@ from triton.language import core
 
 
 @core.extern
-def clz(arg0, _builder=None):
+def clz(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("int32"), ): ("__nv_clz", core.dtype("int32")),
             (core.dtype("int64"), ): ("__nv_clzll", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def popc(arg0, _builder=None):
+def popc(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("int32"), ): ("__nv_popc", core.dtype("int32")),
             (core.dtype("int64"), ): ("__nv_popcll", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def byte_perm(arg0, arg1, arg2, _builder=None):
+def byte_perm(arg0, arg1, arg2, _semantic=None):
     return core.extern_elementwise("", "", [arg0, arg1, arg2], {
         (core.dtype("int32"), core.dtype("int32"), core.dtype("int32")): ("__nv_byte_perm", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def mulhi(arg0, arg1, _builder=None):
+def mulhi(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("int32"), core.dtype("int32")): ("__nv_mulhi", core.dtype("int32")),
             (core.dtype("uint32"), core.dtype("uint32")): ("__nv_umulhi", core.dtype("uint32")),
             (core.dtype("int64"), core.dtype("int64")): ("__nv_mul64hi", core.dtype("int64")),
             (core.dtype("uint64"), core.dtype("uint64")): ("__nv_umul64hi", core.dtype("uint64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def mul24(arg0, arg1, _builder=None):
+def mul24(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("int32"), core.dtype("int32")): ("__nv_mul24", core.dtype("int32")),
             (core.dtype("uint32"), core.dtype("uint32")): ("__nv_umul24", core.dtype("uint32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def brev(arg0, _builder=None):
+def brev(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("int32"), ): ("__nv_brev", core.dtype("int32")),
             (core.dtype("int64"), ): ("__nv_brevll", core.dtype("int64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sad(arg0, arg1, arg2, _builder=None):
+def sad(arg0, arg1, arg2, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2], {
             (core.dtype("int32"), core.dtype("int32"), core.dtype("uint32")): ("__nv_sad", core.dtype("int32")),
             (core.dtype("uint32"), core.dtype("uint32"), core.dtype("uint32")): ("__nv_usad", core.dtype("uint32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def abs(arg0, _builder=None):
+def abs(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("int32"), ): ("__nv_abs", core.dtype("int32")),
             (core.dtype("int64"), ): ("__nv_llabs", core.dtype("int64")),
             (core.dtype("fp32"), ): ("__nv_fabsf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_fabs", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def floor(arg0, _builder=None):
+def floor(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_floorf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_floor", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rcp64h(arg0, _builder=None):
+def rcp64h(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_rcp64h", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rsqrt(arg0, _builder=None):
+def rsqrt(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_rsqrtf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_rsqrt", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ceil(arg0, _builder=None):
+def ceil(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp64"), ): ("__nv_ceil", core.dtype("fp64")),
             (core.dtype("fp32"), ): ("__nv_ceilf", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def trunc(arg0, _builder=None):
+def trunc(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp64"), ): ("__nv_trunc", core.dtype("fp64")),
             (core.dtype("fp32"), ): ("__nv_truncf", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def exp2(arg0, _builder=None):
+def exp2(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_exp2f", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_exp2", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def saturatef(arg0, _builder=None):
+def saturatef(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_saturatef", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fma_rn(arg0, arg1, arg2, _builder=None):
+def fma_rn(arg0, arg1, arg2, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2], {
             (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__nv_fmaf_rn", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__nv_fma_rn", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fma_rz(arg0, arg1, arg2, _builder=None):
+def fma_rz(arg0, arg1, arg2, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2], {
             (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__nv_fmaf_rz", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__nv_fma_rz", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fma_rd(arg0, arg1, arg2, _builder=None):
+def fma_rd(arg0, arg1, arg2, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2], {
             (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__nv_fmaf_rd", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__nv_fma_rd", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fma_ru(arg0, arg1, arg2, _builder=None):
+def fma_ru(arg0, arg1, arg2, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2], {
             (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__nv_fmaf_ru", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__nv_fma_ru", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_dividef(arg0, arg1, _builder=None):
+def fast_dividef(arg0, arg1, _semantic=None):
     return core.extern_elementwise("", "", [arg0, arg1], {
         (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fast_fdividef", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def div_rn(arg0, arg1, _builder=None):
+def div_rn(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fdiv_rn", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_ddiv_rn", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def div_rz(arg0, arg1, _builder=None):
+def div_rz(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fdiv_rz", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_ddiv_rz", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def div_rd(arg0, arg1, _builder=None):
+def div_rd(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fdiv_rd", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_ddiv_rd", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def div_ru(arg0, arg1, _builder=None):
+def div_ru(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fdiv_ru", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_ddiv_ru", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rcp_rn(arg0, _builder=None):
+def rcp_rn(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_frcp_rn", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_drcp_rn", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rcp_rz(arg0, _builder=None):
+def rcp_rz(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_frcp_rz", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_drcp_rz", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rcp_rd(arg0, _builder=None):
+def rcp_rd(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_frcp_rd", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_drcp_rd", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rcp_ru(arg0, _builder=None):
+def rcp_ru(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_frcp_ru", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_drcp_ru", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sqrt_rn(arg0, _builder=None):
+def sqrt_rn(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_fsqrt_rn", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_dsqrt_rn", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sqrt_rz(arg0, _builder=None):
+def sqrt_rz(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_fsqrt_rz", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_dsqrt_rz", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sqrt_rd(arg0, _builder=None):
+def sqrt_rd(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_fsqrt_rd", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_dsqrt_rd", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sqrt_ru(arg0, _builder=None):
+def sqrt_ru(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_fsqrt_ru", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_dsqrt_ru", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sqrt(arg0, _builder=None):
+def sqrt(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_sqrtf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_sqrt", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def add_rn(arg0, arg1, _builder=None):
+def add_rn(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_dadd_rn", core.dtype("fp64")),
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fadd_rn", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def add_rz(arg0, arg1, _builder=None):
+def add_rz(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_dadd_rz", core.dtype("fp64")),
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fadd_rz", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def add_rd(arg0, arg1, _builder=None):
+def add_rd(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_dadd_rd", core.dtype("fp64")),
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fadd_rd", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def add_ru(arg0, arg1, _builder=None):
+def add_ru(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_dadd_ru", core.dtype("fp64")),
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fadd_ru", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def mul_rn(arg0, arg1, _builder=None):
+def mul_rn(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_dmul_rn", core.dtype("fp64")),
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fmul_rn", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def mul_rz(arg0, arg1, _builder=None):
+def mul_rz(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_dmul_rz", core.dtype("fp64")),
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fmul_rz", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def mul_rd(arg0, arg1, _builder=None):
+def mul_rd(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_dmul_rd", core.dtype("fp64")),
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fmul_rd", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def mul_ru(arg0, arg1, _builder=None):
+def mul_ru(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [
             arg0,
@@ -372,1258 +372,1258 @@ def mul_ru(arg0, arg1, _builder=None):
                 core.dtype("fp32"),
                 core.dtype("fp32"),
             ): ("__nv_fmul_ru", core.dtype("fp32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2float_rn(arg0, _builder=None):
+def double2float_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2float_rn", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2float_rz(arg0, _builder=None):
+def double2float_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2float_rz", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2float_rd(arg0, _builder=None):
+def double2float_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2float_rd", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2float_ru(arg0, _builder=None):
+def double2float_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2float_ru", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2int_rn(arg0, _builder=None):
+def double2int_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2int_rn", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2int_rz(arg0, _builder=None):
+def double2int_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2int_rz", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2int_rd(arg0, _builder=None):
+def double2int_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2int_rd", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2int_ru(arg0, _builder=None):
+def double2int_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2int_ru", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2uint_rn(arg0, _builder=None):
+def double2uint_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2uint_rn", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2uint_rz(arg0, _builder=None):
+def double2uint_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2uint_rz", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2uint_rd(arg0, _builder=None):
+def double2uint_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2uint_rd", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2uint_ru(arg0, _builder=None):
+def double2uint_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2uint_ru", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def int2double_rn(arg0, _builder=None):
+def int2double_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int32"), ): ("__nv_int2double_rn", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def uint2double_rn(arg0, _builder=None):
+def uint2double_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint32"), ): ("__nv_uint2double_rn", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2int_rn(arg0, _builder=None):
+def float2int_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2int_rn", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2int_rz(arg0, _builder=None):
+def float2int_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2int_rz", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2int_rd(arg0, _builder=None):
+def float2int_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2int_rd", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2int_ru(arg0, _builder=None):
+def float2int_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2int_ru", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2uint_rn(arg0, _builder=None):
+def float2uint_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2uint_rn", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2uint_rz(arg0, _builder=None):
+def float2uint_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2uint_rz", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2uint_rd(arg0, _builder=None):
+def float2uint_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2uint_rd", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2uint_ru(arg0, _builder=None):
+def float2uint_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2uint_ru", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def int2float_rn(arg0, _builder=None):
+def int2float_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int32"), ): ("__nv_int2float_rn", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def int2float_rz(arg0, _builder=None):
+def int2float_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int32"), ): ("__nv_int2float_rz", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def int2float_rd(arg0, _builder=None):
+def int2float_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int32"), ): ("__nv_int2float_rd", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def int2float_ru(arg0, _builder=None):
+def int2float_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int32"), ): ("__nv_int2float_ru", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def uint2float_rn(arg0, _builder=None):
+def uint2float_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint32"), ): ("__nv_uint2float_rn", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def uint2float_rz(arg0, _builder=None):
+def uint2float_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint32"), ): ("__nv_uint2float_rz", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def uint2float_rd(arg0, _builder=None):
+def uint2float_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint32"), ): ("__nv_uint2float_rd", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def uint2float_ru(arg0, _builder=None):
+def uint2float_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint32"), ): ("__nv_uint2float_ru", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def hiloint2double(arg0, arg1, _builder=None):
+def hiloint2double(arg0, arg1, _semantic=None):
     return core.extern_elementwise("", "", [arg0, arg1], {
         (core.dtype("int32"), core.dtype("int32")): ("__nv_hiloint2double", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2loint(arg0, _builder=None):
+def double2loint(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2loint", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2hiint(arg0, _builder=None):
+def double2hiint(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2hiint", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2ll_rn(arg0, _builder=None):
+def float2ll_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2ll_rn", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2ll_rz(arg0, _builder=None):
+def float2ll_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2ll_rz", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2ll_rd(arg0, _builder=None):
+def float2ll_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2ll_rd", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2ll_ru(arg0, _builder=None):
+def float2ll_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2ll_ru", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2ull_rn(arg0, _builder=None):
+def float2ull_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2ull_rn", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2ull_rz(arg0, _builder=None):
+def float2ull_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2ull_rz", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2ull_rd(arg0, _builder=None):
+def float2ull_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2ull_rd", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float2ull_ru(arg0, _builder=None):
+def float2ull_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float2ull_ru", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2ll_rn(arg0, _builder=None):
+def double2ll_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2ll_rn", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2ll_rz(arg0, _builder=None):
+def double2ll_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2ll_rz", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2ll_rd(arg0, _builder=None):
+def double2ll_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2ll_rd", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2ll_ru(arg0, _builder=None):
+def double2ll_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2ll_ru", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2ull_rn(arg0, _builder=None):
+def double2ull_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2ull_rn", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2ull_rz(arg0, _builder=None):
+def double2ull_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2ull_rz", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2ull_rd(arg0, _builder=None):
+def double2ull_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2ull_rd", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double2ull_ru(arg0, _builder=None):
+def double2ull_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double2ull_ru", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ll2float_rn(arg0, _builder=None):
+def ll2float_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int64"), ): ("__nv_ll2float_rn", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ll2float_rz(arg0, _builder=None):
+def ll2float_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int64"), ): ("__nv_ll2float_rz", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ll2float_rd(arg0, _builder=None):
+def ll2float_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int64"), ): ("__nv_ll2float_rd", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ll2float_ru(arg0, _builder=None):
+def ll2float_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int64"), ): ("__nv_ll2float_ru", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ull2float_rn(arg0, _builder=None):
+def ull2float_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint64"), ): ("__nv_ull2float_rn", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ull2float_rz(arg0, _builder=None):
+def ull2float_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint64"), ): ("__nv_ull2float_rz", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ull2float_rd(arg0, _builder=None):
+def ull2float_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint64"), ): ("__nv_ull2float_rd", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ull2float_ru(arg0, _builder=None):
+def ull2float_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint64"), ): ("__nv_ull2float_ru", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ll2double_rn(arg0, _builder=None):
+def ll2double_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int64"), ): ("__nv_ll2double_rn", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ll2double_rz(arg0, _builder=None):
+def ll2double_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int64"), ): ("__nv_ll2double_rz", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ll2double_rd(arg0, _builder=None):
+def ll2double_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int64"), ): ("__nv_ll2double_rd", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ll2double_ru(arg0, _builder=None):
+def ll2double_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int64"), ): ("__nv_ll2double_ru", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ull2double_rn(arg0, _builder=None):
+def ull2double_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint64"), ): ("__nv_ull2double_rn", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ull2double_rz(arg0, _builder=None):
+def ull2double_rz(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint64"), ): ("__nv_ull2double_rz", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ull2double_rd(arg0, _builder=None):
+def ull2double_rd(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint64"), ): ("__nv_ull2double_rd", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ull2double_ru(arg0, _builder=None):
+def ull2double_ru(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint64"), ): ("__nv_ull2double_ru", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def int_as_float(arg0, _builder=None):
+def int_as_float(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int32"), ): ("__nv_int_as_float", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float_as_int(arg0, _builder=None):
+def float_as_int(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float_as_int", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def uint_as_float(arg0, _builder=None):
+def uint_as_float(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("uint32"), ): ("__nv_uint_as_float", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def float_as_uint(arg0, _builder=None):
+def float_as_uint(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_float_as_uint", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def longlong_as_double(arg0, _builder=None):
+def longlong_as_double(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("int64"), ): ("__nv_longlong_as_double", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def double_as_longlong(arg0, _builder=None):
+def double_as_longlong(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_double_as_longlong", core.dtype("int64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_sinf(arg0, _builder=None):
+def fast_sinf(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_fast_sinf", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_cosf(arg0, _builder=None):
+def fast_cosf(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_fast_cosf", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_log2f(arg0, _builder=None):
+def fast_log2f(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_fast_log2f", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_logf(arg0, _builder=None):
+def fast_logf(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_fast_logf", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_expf(arg0, _builder=None):
+def fast_expf(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_fast_expf", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_tanf(arg0, _builder=None):
+def fast_tanf(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_fast_tanf", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_exp10f(arg0, _builder=None):
+def fast_exp10f(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_fast_exp10f", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_log10f(arg0, _builder=None):
+def fast_log10f(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_fast_log10f", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fast_powf(arg0, arg1, _builder=None):
+def fast_powf(arg0, arg1, _semantic=None):
     return core.extern_elementwise("", "", [arg0, arg1], {
         (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fast_powf", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def hadd(arg0, arg1, _builder=None):
+def hadd(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("int32"), core.dtype("int32")): ("__nv_hadd", core.dtype("int32")),
             (core.dtype("uint32"), core.dtype("uint32")): ("__nv_uhadd", core.dtype("uint32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rhadd(arg0, arg1, _builder=None):
+def rhadd(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("int32"), core.dtype("int32")): ("__nv_rhadd", core.dtype("int32")),
             (core.dtype("uint32"), core.dtype("uint32")): ("__nv_urhadd", core.dtype("uint32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sub_rn(arg0, arg1, _builder=None):
+def sub_rn(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fsub_rn", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_dsub_rn", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sub_rz(arg0, arg1, _builder=None):
+def sub_rz(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fsub_rz", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_dsub_rz", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sub_rd(arg0, arg1, _builder=None):
+def sub_rd(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fsub_rd", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_dsub_rd", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sub_ru(arg0, arg1, _builder=None):
+def sub_ru(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fsub_ru", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_dsub_ru", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rsqrt_rn(arg0, _builder=None):
+def rsqrt_rn(arg0, _semantic=None):
     return core.extern_elementwise("", "", [
         arg0,
     ], {
         (core.dtype("fp32"), ): ("__nv_frsqrt_rn", core.dtype("fp32")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ffs(arg0, _builder=None):
+def ffs(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [
             arg0,
         ], {
             (core.dtype("int32"), ): ("__nv_ffs", core.dtype("int32")),
             (core.dtype("int64"), ): ("__nv_ffsll", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rint(arg0, _builder=None):
+def rint(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [
             arg0,
         ], {
             (core.dtype("fp32"), ): ("__nv_rintf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_rint", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def llrint(arg0, _builder=None):
+def llrint(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [
             arg0,
         ], {
             (core.dtype("fp32"), ): ("__nv_llrintf", core.dtype("int64")),
             (core.dtype("fp64"), ): ("__nv_llrint", core.dtype("int64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def nearbyint(arg0, _builder=None):
+def nearbyint(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [
             arg0,
         ], {
             (core.dtype("fp32"), ): ("__nv_nearbyintf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_nearbyint", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def isnan(arg0, _builder=None):
+def isnan(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [
             arg0,
         ], {
             (core.dtype("fp32"), ): ("__nv_isnanf", core.dtype("int32")),
             (core.dtype("fp64"), ): ("__nv_isnand", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder).to(core.int1, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic).to(core.int1, _semantic=_semantic)
 
 
 @core.extern
-def signbit(arg0, _builder=None):
+def signbit(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [
             arg0,
         ], {
             (core.dtype("fp32"), ): ("__nv_signbitf", core.dtype("int32")),
             (core.dtype("fp64"), ): ("__nv_signbitd", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def copysign(arg0, arg1, _builder=None):
+def copysign(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_copysignf", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_copysign", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def finitef(arg0, _builder=None):
+def finitef(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_finitef", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder).to(core.int1, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic).to(core.int1, _semantic=_semantic)
 
 
 @core.extern
-def isinf(arg0, _builder=None):
+def isinf(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_isinff", core.dtype("int32")),
             (core.dtype("fp64"), ): ("__nv_isinfd", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder).to(core.int1, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic).to(core.int1, _semantic=_semantic)
 
 
 @core.extern
-def nextafter(arg0, arg1, _builder=None):
+def nextafter(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_nextafterf", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_nextafter", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sin(arg0, _builder=None):
+def sin(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_sinf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_sin", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def cos(arg0, _builder=None):
+def cos(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_cosf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_cos", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sinpi(arg0, _builder=None):
+def sinpi(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_sinpif", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_sinpi", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def cospi(arg0, _builder=None):
+def cospi(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_cospif", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_cospi", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def tan(arg0, _builder=None):
+def tan(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_tanf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_tan", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def log2(arg0, _builder=None):
+def log2(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_log2f", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_log2", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def exp(arg0, _builder=None):
+def exp(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_expf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_exp", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def exp10(arg0, _builder=None):
+def exp10(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_exp10f", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_exp10", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def cosh(arg0, _builder=None):
+def cosh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_coshf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_cosh", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def sinh(arg0, _builder=None):
+def sinh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_sinhf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_sinh", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def tanh(arg0, _builder=None):
+def tanh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_tanhf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_tanh", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def atan2(arg0, arg1, _builder=None):
+def atan2(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_atan2f", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_atan2", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def atan(arg0, _builder=None):
+def atan(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_atanf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_atan", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def asin(arg0, _builder=None):
+def asin(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_asinf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_asin", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def acos(arg0, _builder=None):
+def acos(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_acosf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_acos", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def log(arg0, _builder=None):
+def log(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_logf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_log", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def log10(arg0, _builder=None):
+def log10(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_log10f", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_log10", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def log1p(arg0, _builder=None):
+def log1p(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_log1pf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_log1p", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def acosh(arg0, _builder=None):
+def acosh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_acoshf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_acosh", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def asinh(arg0, _builder=None):
+def asinh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_asinhf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_asinh", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def atanh(arg0, _builder=None):
+def atanh(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_atanhf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_atanh", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def expm1(arg0, _builder=None):
+def expm1(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_expm1f", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_expm1", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def hypot(arg0, arg1, _builder=None):
+def hypot(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_hypotf", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_hypot", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rhypot(arg0, arg1, _builder=None):
+def rhypot(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_rhypotf", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_rhypot", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def norm3d(arg0, arg1, arg2, _builder=None):
+def norm3d(arg0, arg1, arg2, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2], {
             (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__nv_norm3df", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__nv_norm3d", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rnorm3d(arg0, arg1, arg2, _builder=None):
+def rnorm3d(arg0, arg1, arg2, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2], {
             (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__nv_rnorm3df", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__nv_rnorm3d", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def norm4d(arg0, arg1, arg2, arg3, _builder=None):
+def norm4d(arg0, arg1, arg2, arg3, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2, arg3], {
             (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")):
             ("__nv_norm4df", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")):
             ("__nv_norm4d", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rnorm4d(arg0, arg1, arg2, arg3, _builder=None):
+def rnorm4d(arg0, arg1, arg2, arg3, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2, arg3], {
             (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")):
             ("__nv_rnorm4df", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")):
             ("__nv_rnorm4d", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def cbrt(arg0, _builder=None):
+def cbrt(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_cbrtf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_cbrt", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def rcbrt(arg0, _builder=None):
+def rcbrt(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_rcbrtf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_rcbrt", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def j0(arg0, _builder=None):
+def j0(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_j0f", core.dtype("fp32")),
         (core.dtype("fp64"), ): ("__nv_j0", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def j1(arg0, _builder=None):
+def j1(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_j1f", core.dtype("fp32")),
         (core.dtype("fp64"), ): ("__nv_j1", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def y0(arg0, _builder=None):
+def y0(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_y0f", core.dtype("fp32")),
         (core.dtype("fp64"), ): ("__nv_y0", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def y1(arg0, _builder=None):
+def y1(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp32"), ): ("__nv_y1f", core.dtype("fp32")),
         (core.dtype("fp64"), ): ("__nv_y1", core.dtype("fp64")),
-    }, is_pure=True, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def yn(arg0, arg1, _builder=None):
+def yn(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("int32"), core.dtype("fp32")): ("__nv_ynf", core.dtype("fp32")),
             (core.dtype("int32"), core.dtype("fp64")): ("__nv_yn", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def jn(arg0, arg1, _builder=None):
+def jn(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("int32"), core.dtype("fp32")): ("__nv_jnf", core.dtype("fp32")),
             (core.dtype("int32"), core.dtype("fp64")): ("__nv_jn", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def cyl_bessel_i0(arg0, _builder=None):
+def cyl_bessel_i0(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_cyl_bessel_i0f", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_cyl_bessel_i0", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def cyl_bessel_i1(arg0, _builder=None):
+def cyl_bessel_i1(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_cyl_bessel_i1f", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_cyl_bessel_i1", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def erf(arg0, _builder=None):
+def erf(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_erff", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_erf", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def erfinv(arg0, _builder=None):
+def erfinv(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_erfinvf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_erfinv", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def erfc(arg0, _builder=None):
+def erfc(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_erfcf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_erfc", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def erfcx(arg0, _builder=None):
+def erfcx(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_erfcxf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_erfcx", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def erfcinv(arg0, _builder=None):
+def erfcinv(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_erfcinvf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_erfcinv", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def normcdfinv(arg0, _builder=None):
+def normcdfinv(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_normcdfinvf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_normcdfinv", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def normcdf(arg0, _builder=None):
+def normcdf(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_normcdff", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_normcdf", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def lgamma(arg0, _builder=None):
+def lgamma(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_lgammaf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_lgamma", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ldexp(arg0, arg1, _builder=None):
+def ldexp(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("int32")): ("__nv_ldexpf", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("int32")): ("__nv_ldexp", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def scalbn(arg0, arg1, _builder=None):
+def scalbn(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("int32")): ("__nv_scalbnf", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("int32")): ("__nv_scalbn", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fmod(arg0, arg1, _builder=None):
+def fmod(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fmodf", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_fmod", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def remainder(arg0, arg1, _builder=None):
+def remainder(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_remainderf", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_remainder", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fma(arg0, arg1, arg2, _builder=None):
+def fma(arg0, arg1, arg2, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1, arg2], {
             (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__nv_fmaf", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__nv_fma", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def pow(arg0, arg1, _builder=None):
+def pow(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("int32")): ("__nv_powif", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("int32")): ("__nv_powi", core.dtype("fp64")),
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_powf", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_pow", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def tgamma(arg0, _builder=None):
+def tgamma(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_tgammaf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_tgamma", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def round(arg0, _builder=None):
+def round(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_roundf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_round", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def llround(arg0, _builder=None):
+def llround(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_llroundf", core.dtype("int64")),
             (core.dtype("fp64"), ): ("__nv_llround", core.dtype("int64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def fdim(arg0, arg1, _builder=None):
+def fdim(arg0, arg1, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0, arg1], {
             (core.dtype("fp32"), core.dtype("fp32")): ("__nv_fdimf", core.dtype("fp32")),
             (core.dtype("fp64"), core.dtype("fp64")): ("__nv_fdim", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def ilogb(arg0, _builder=None):
+def ilogb(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_ilogbf", core.dtype("int32")),
             (core.dtype("fp64"), ): ("__nv_ilogb", core.dtype("int32")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def logb(arg0, _builder=None):
+def logb(arg0, _semantic=None):
     return core.extern_elementwise(
         "", "", [arg0], {
             (core.dtype("fp32"), ): ("__nv_logbf", core.dtype("fp32")),
             (core.dtype("fp64"), ): ("__nv_logb", core.dtype("fp64")),
-        }, is_pure=True, _builder=_builder)
+        }, is_pure=True, _semantic=_semantic)
 
 
 @core.extern
-def isfinited(arg0, _builder=None):
+def isfinited(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__nv_isfinited", core.dtype("int32")),
-    }, is_pure=True, _builder=_builder).to(core.int1, _builder=_builder)
+    }, is_pure=True, _semantic=_semantic).to(core.int1, _semantic=_semantic)

--- a/third_party/proton/proton/language.py
+++ b/third_party/proton/proton/language.py
@@ -4,8 +4,8 @@ import warnings
 
 
 @builtin
-def record(isStart: bool, regionId: int, _builder=None):
+def record(isStart: bool, regionId: int, _semantic=None):
     warnings.warn(
         "\nWarning the proton language module within Proton contains under development features that are not intended to be used outside of the core development team"
     )
-    return tl.tensor(_builder.create_proton_record(isStart, regionId), tl.void)
+    return tl.tensor(_semantic.builder.create_proton_record(isStart, regionId), tl.void)


### PR DESCRIPTION
This changes the builtin calling convention to pass a `_semantic` value instead of `_builder`. So instead of:
```python
def add(x, y, _builder=None):
    return semantic.add(x, y, _builder)
```
we now have
```python
def add(x, y, _semantic=None):
    return _semantic.add(x, y)
```
The advantage being that `GluonSemantic` can inherit from `TritonSemantic` and share most of the implementation, but override some specifics e.g. broadcasting.

I recommend to view the diff ignoring whitespace changes.
