### PR TITLE
[Frontend] Fix a few things in the frontend

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -196,3 +196,21 @@ def test_aggregate_with_constexpr():
     # CHECK: tt.func private @"test_frontend.add_rhs_constexpr__test_frontend.AggregateWithConstexpr<i32S4S, constexpr[42]>
     # CHECK: %cst = arith.constant dense<42> : tensor<4xi32>
     # CHECK: arith.addi %arg0, %cst : tensor<4xi32>
+
+
+@tl.constexpr_function
+def constexpr_function(x):
+    return x + 1
+
+
+@filecheck_test
+@triton.jit
+def test_constexpr_function_from_jit():
+    # CHECK-LABEL: test_constexpr_function
+    x: tl.constexpr = constexpr_function(7)
+    # CHECK: make_range {end = 8 : i32, start = 0 : i32}
+    tl.arange(0, x)
+
+
+def test_constexpr_function_from_pythin():
+    assert constexpr_function(7) == 8

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -571,8 +571,8 @@ class CodeGenerator(ast.NodeVisitor):
         if isinstance(target, ast.Subscript):
             return self.visit_Subscript_Store(target, value)
         if isinstance(target, ast.Tuple):
-            for i, name in enumerate(target.elts):
-                self.set_value(self.visit(name), value.values[i])
+            for i, target in enumerate(target.elts):
+                self.assignTarget(target, value.values[i])
             return
         if isinstance(target, ast.Attribute):
             base = self.visit(target.value)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -178,6 +178,9 @@ class constexpr_type(base_type):
     def __init__(self, value):
         self.value = value
 
+    def __eq__(self, other):
+        return self.value == other.value
+
     def __repr__(self) -> str:
         return f"constexpr[{self.value}]"
 
@@ -338,7 +341,7 @@ def constexpr_function(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
         # de-constexpr arguments and discard the _builder keyword argument:
-        args = [getattr(x, "value", x) for x in args]
+        args = [_unwrap_if_constexpr(x) for x in args]
         kwargs = {k: getattr(v, "value", v) for (k, v) in kwargs.items() if k != "_builder"}
 
         # call the raw Python function f:


### PR DESCRIPTION
Fix assigning to tuples of other nodes, such as `a.x, b.y = unpack_me()`

Fix `@constexpr_function` so that the functions can still be called from Python.

Add `__eq__` to `constexpr_type` so that the parser can reconcile types of liveouts.