### PR TITLE
topk cleanup

### DIFF
--- a/python/triton_kernels/triton_kernels/routing.py
+++ b/python/triton_kernels/triton_kernels/routing.py
@@ -114,6 +114,7 @@ def routing_torch(logits, n_expts_act, renormalize=True, expt_indx=None):
         # topk of experts
         if expt_indx is None:
             tk_idx = torch.argsort(-vals, dim=1, stable=True)[:, :k]
+            tk_idx, _ = torch.sort(tk_idx, dim=1)
         else:
             tk_idx = expt_indx
         tk_val = torch.take_along_dim(vals, tk_idx, dim=1)

--- a/python/triton_kernels/triton_kernels/topk_details/_topk.py
+++ b/python/triton_kernels/triton_kernels/topk_details/_topk.py
@@ -69,10 +69,10 @@ def streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m, N_EXPTS_PAD: tl.co
 
 
 @triton.jit
-def _rotr(y, right_shift : tl.constexpr):
+def _rotr(y, right_shift: tl.constexpr):
 
-    full_width : tl.constexpr = y.dtype.primitive_bitwidth
-    left_shift : tl.constexpr = full_width - right_shift
+    full_width: tl.constexpr = y.dtype.primitive_bitwidth
+    left_shift: tl.constexpr = full_width - right_shift
     y = (y << left_shift) | (y >> right_shift)
     return y
 

--- a/python/triton_kernels/triton_kernels/topk_details/_topk.py
+++ b/python/triton_kernels/triton_kernels/topk_details/_topk.py
@@ -33,8 +33,13 @@ def streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m, N_EXPTS_PAD: tl.co
                    BLOCK_N: tl.constexpr):
     x_nbits: tl.constexpr = X.dtype.element_ty.primitive_bitwidth
     x_utype: tl.constexpr = tl.dtype(f"uint{x_nbits}")
-    x_ultype: tl.constexpr = tl.dtype(f"uint{2*x_nbits}")
-    x_dbtype: tl.constexpr = tl.dtype(f"fp{2*x_nbits}")
+    if x_nbits < 16:
+        # this ensures that we leave at least 16 bits for expert index
+        # even if the input dtype is smaller than 16 bits:
+        y_nbits: tl.constexpr = 32
+    else:
+        y_nbits: tl.constexpr = x_nbits * 2
+    x_ultype: tl.constexpr = tl.dtype(f"uint{y_nbits}")
 
     # subtract 1 from loop iterations because we peel the first (masked) iteration:
     loop_iterations: tl.constexpr = N_EXPTS_PAD // BLOCK_N - 1
@@ -45,7 +50,7 @@ def streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m, N_EXPTS_PAD: tl.co
     X_ptrs = X + offs_m[:, None] * stride_xm + offs_x_n[None, :]
     x = tl.load(X_ptrs, mask=(mask_m & mask_n), other=float("-inf"))
     x = fpval_to_key(x.to(x_utype, bitcast=True))
-    x = (x.to(x_ultype) << x_nbits) | indx_to_key(offs_x_n, N_EXPTS_PAD)[None, :]
+    x = (x.to(x_ultype) << 16) | indx_to_key(offs_x_n, N_EXPTS_PAD)[None, :]
     acc = tl.topk(x, N_EXPTS_ACT, dim=1)
 
     # subsequent iterations:
@@ -55,14 +60,13 @@ def streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m, N_EXPTS_PAD: tl.co
         offs_x_n -= BLOCK_N
         x = tl.load(X_ptrs, mask=mask_m, other=float("-inf"))
         x = fpval_to_key(x.to(x_utype, bitcast=True))
-        x = (x.to(x_ultype) << x_nbits) | indx_to_key(offs_x_n, N_EXPTS_PAD)[None, :]
+        x = (x.to(x_ultype) << 16) | indx_to_key(offs_x_n, N_EXPTS_PAD)[None, :]
         acc = tl.maximum(acc, tl.topk(x, N_EXPTS_ACT, dim=1))
 
     acc = tl.sort(acc, dim=1, descending=True)
-    acc_values = key_to_fpval((acc >> x_nbits).to(x_utype))
+    acc_values = key_to_fpval((acc >> 16).to(x_utype))
     acc_indices = key_to_indx(acc & 0x0000FFFF, N_EXPTS_PAD)
-    acc = (acc_values.to(x_ultype) << x_nbits) | acc_indices
-    acc = acc.to(x_dbtype, bitcast=True)
+    acc = (acc_values.to(x_ultype) << 16) | acc_indices
 
     return acc
 
@@ -89,7 +93,6 @@ def _topk(X, stride_xm,  # inputs
     x_dtype: tl.constexpr = X.dtype.element_ty
     x_nbits: tl.constexpr = X.dtype.element_ty.primitive_bitwidth
     x_utype: tl.constexpr = tl.dtype(f"uint{x_nbits}")
-    x_ultype: tl.constexpr = tl.dtype(f"uint{2*x_nbits}")
 
     # load logits
     offs_m = pid * BLOCK_M + tl.arange(0, BLOCK_M)
@@ -102,9 +105,8 @@ def _topk(X, stride_xm,  # inputs
         y_values = tl.load(Xv_ptrs, mask=mask_m)
     else:
         y = streaming_topk(X, stride_xm, n_expts_tot, offs_m, mask_m, N_EXPTS_PAD, N_EXPTS_ACT, BLOCK_N)
-        y = y.to(x_ultype, bitcast=True)
-        y_indices = y & 0x0000FFFF
-        y_values = (y >> x_nbits).to(x_utype).to(x_dtype, bitcast=True)
+        y_indices = (y & 0x0000FFFF).to(tl.uint32)
+        y_values = (y >> 16).to(x_utype).to(x_dtype, bitcast=True)
 
     if APPLY_SOFTMAX:
         y_values = tl.softmax(y_values.to(tl.float32), dim=1, keep_dims=True).to(x_dtype)


### PR DESCRIPTION
Ensure that the expert ID always gets 16 bits (even if the inputs to topk are 8-bit floats for example) and avoid the unnecessary bitcasting to and from x_dbtype 