### PR TITLE
Pawel/hoist unpipelineable operands

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h
@@ -44,15 +44,13 @@ public:
   // If true, the existing operand loads are all been found and their
   // pipelineability has been determined.
   bool isOperandsStateDetermined = false;
-  SmallVector<Operation *> unpipelineableOperandLoads;
-  SmallVector<Operation *> unpipelineableOperandAllocs;
+  SmallVector<Operation *> unpipelineableOperandDefs;
 
 private:
   MMAv5OpInterface mmaOp;
   scf::ForOp forOp;
   std::function<bool(Operation *)> isLoadToBePipelined;
-  bool isOperandPipelineable(Value v, Operation *&foundLoad,
-                             Operation *&foundAlloc);
+  bool isOperandPipelineable(Value v, Operation *&foundDef);
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h
@@ -38,18 +38,21 @@ public:
       : mmaOp(mmaOp), forOp(forOp), isLoadToBePipelined(isLoadToBePipelined) {
     run();
   }
+  void run();
+
   bool isPipelineable = false;
   // If true, the existing operand loads are all been found and their
   // pipelineability has been determined.
   bool isOperandsStateDetermined = false;
   SmallVector<Operation *> unpipelineableOperandLoads;
+  SmallVector<Operation *> unpipelineableOperandAllocs;
 
 private:
   MMAv5OpInterface mmaOp;
   scf::ForOp forOp;
   std::function<bool(Operation *)> isLoadToBePipelined;
-  bool comesFromLoadOrOutsideLoop(Value v, Operation *&foundLoad);
-  void run();
+  bool isOperandPipelineable(Value v, Operation *&foundLoad,
+                             Operation *&foundAlloc);
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h
@@ -38,7 +38,6 @@ public:
       : mmaOp(mmaOp), forOp(forOp), isLoadToBePipelined(isLoadToBePipelined) {
     run();
   }
-  void run();
 
   bool isPipelineable = false;
   // If true, the existing operand loads are all been found and their
@@ -50,6 +49,7 @@ private:
   MMAv5OpInterface mmaOp;
   scf::ForOp forOp;
   std::function<bool(Operation *)> isLoadToBePipelined;
+  void run();
   bool isOperandPipelineable(Value v, Operation *&foundDef);
 };
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -867,9 +867,6 @@ void createBarrierAndWaitOps(scf::ForOp forOp, CoarseSchedule &schedule,
     }
   }
 
-  // Rerun analysis after hoisting
-  // mmaPipeHelper.run();
-
   if (!mmaPipeHelper.isPipelineable &&
       mmaPipeHelper.isOperandsStateDetermined) {
     // If the operands are not pipelineable, we need to insert a sync point

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -39,9 +39,9 @@ public:
     mod.walk([&](DotOpInterface dotOp) {
       Value a = dotOp.getA();
       Value b = dotOp.getB();
-      bool aDependsOnShared = dependOnCopyRegToShared(a);
-      bool bDependsOnShared = dependOnCopyRegToShared(b);
-      if (!aDependsOnShared && !bDependsOnShared)
+      SmallVector<Operation *> copyRegToSharedOpsA = findCopyRegToSharedOps(a);
+      SmallVector<Operation *> copyRegToSharedOpsB = findCopyRegToSharedOps(b);
+      if (copyRegToSharedOpsA.empty() && copyRegToSharedOpsB.empty())
         return WalkResult::advance();
 
       OpBuilder builder(dotOp);
@@ -50,11 +50,13 @@ public:
       // If there is all the dependencies are outside of the loop try to hoist
       // the fence.
       while (auto loopOp = fence->getParentOfType<LoopLikeOpInterface>()) {
-        if (aDependsOnShared &&
-            loopOp->isAncestor(a.getParentBlock()->getParentOp()))
+        if (!copyRegToSharedOpsA.empty() &&
+            llvm::any_of(copyRegToSharedOpsA,
+                         [&](Operation *op) { return loopOp->isAncestor(op); }))
           break;
-        if (bDependsOnShared &&
-            loopOp->isAncestor(b.getParentBlock()->getParentOp()))
+        if (!copyRegToSharedOpsB.empty() &&
+            llvm::any_of(copyRegToSharedOpsB,
+                         [&](Operation *op) { return loopOp->isAncestor(op); }))
           break;
         loopOp.moveOutOfLoop(fence);
       }
@@ -72,31 +74,47 @@ public:
 
 private:
   // Return true if the operand depends on a copy from register to shared.
-  bool dependOnCopyRegToShared(Value operand) {
+  SmallVector<Operation *> findCopyRegToSharedOps(Value operand) {
     DenseSet<Value> visited;
-    return dependOnCopyRegToShared(operand, visited);
+    llvm::SetVector<Operation *> result;
+    findCopyRegToSharedOps(operand, visited, result);
+    return result.takeVector();
   }
 
-  bool dependOnCopyRegToShared(Value operand, DenseSet<Value> &visited) {
+  void findCopyRegToSharedOps(Value operand, DenseSet<Value> &visited,
+                              llvm::SetVector<Operation *> &result) {
     // If the value has already been visited we can safely return false as we
     // would early return when true.
     if (visited.count(operand))
-      return false;
+      return;
     visited.insert(operand);
     if (!isa<triton::gpu::MemDescType>(operand.getType()))
-      return false;
+      return;
 
     auto op = operand.getDefiningOp();
     if (op) {
       // reach an alloc copying from register, we need a fence.
-      if (isa<ttg::LocalAllocOp>(op) && cast<ttg::LocalAllocOp>(op).getSrc())
-        return true;
+      if (auto localAlloc = dyn_cast<ttg::LocalAllocOp>(op)) {
+        if (localAlloc.getSrc()) {
+          result.insert(op);
+        }
+        // Check if there are local_store ops that write to that buffer.
+        for (auto user : localAlloc.getResult().getUsers()) {
+          while (user->hasOneUse() &&
+                 user->hasTrait<OpTrait::MemDescViewTrait>()) {
+            user = *user->getUsers().begin();
+          }
+          if (isa<ttg::LocalStoreOp>(user)) {
+            result.insert(user);
+            return;
+          }
+        }
+      }
       // if it is not an alloc, iterate over the operands.
       for (auto v : op->getOperands()) {
-        if (dependOnCopyRegToShared(v))
-          return true;
+        findCopyRegToSharedOps(v, visited, result);
       }
-      return false;
+      return;
     }
 
     // reach BlockArgument
@@ -108,22 +126,23 @@ private:
       assert(argNum != 0 && "induction var cannot be memdesc type");
       --argNum;
       // prologue
-      if (dependOnCopyRegToShared(forOp.getInitArgs()[argNum], visited))
-        return true;
+      findCopyRegToSharedOps(forOp.getInitArgs()[argNum], visited, result);
       // yield
       auto yieldOp = forOp.getBody()->getTerminator();
       Value v = yieldOp->getOperand(argNum);
-      return dependOnCopyRegToShared(v, visited);
+      findCopyRegToSharedOps(v, visited, result);
+      return;
     }
 
     // look through `ttg.warp_specialize`.
     if (auto wsOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(argOwner)) {
-      return dependOnCopyRegToShared(
-          wsOp.getParentOp().getExplicitCaptures()[argNum]);
+      findCopyRegToSharedOps(wsOp.getParentOp().getExplicitCaptures()[argNum],
+                             visited, result);
+      return;
     }
 
     // Conservatively return true for other ops
-    return true;
+    result.insert(argOwner);
   }
 };
 

--- a/test/TritonGPU/fence-inserstion.mlir
+++ b/test/TritonGPU/fence-inserstion.mlir
@@ -21,6 +21,27 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 64, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: matmul_like_fence_local_store
+  tt.func public @matmul_like_fence_local_store(%arg0: tensor<128x128xf16, #blocked>, %arg1: tensor<128x64xf16, #blocked2>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #mma>
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared1, #smem, mutable>
+    ttg.local_store %arg0, %0 : tensor<128x128xf16, #blocked> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    // CHECK: ttng.fence_async_shared
+    %2 = ttng.warp_group_dot %0, %1, %cst : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> * !ttg.memdesc<128x64xf16, #shared1, #smem, mutable> -> tensor<128x64xf32, #mma>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 64, 16]}>
@@ -66,6 +87,37 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     scf.for %iv0 = %c0_i32 to %c64_i32 step %c32_i32 : i32 {
       scf.for %iv1 = %c0_i32 to %c64_i32 step %c32_i32 : i32 {
         %2 = ttng.warp_group_dot %0, %1, %cst : !ttg.memdesc<128x128xf16, #shared, #smem> * !ttg.memdesc<128x64xf16, #shared1, #smem> -> tensor<128x64xf32, #mma>
+      }
+    }
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 64, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: fence_store_in_loop
+  tt.func public @fence_store_in_loop(%arg0: tensor<128x128xf16, #blocked>, %arg1: tensor<128x64xf16, #blocked>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #mma>
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %0 = ttg.local_alloc %arg0 : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc %arg1 : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared1, #smem>
+    // CHECK-NOT: ttng.fence_async_shared
+    // CHECK: scf.for
+    // CHECK: ttng.fence_async_shared
+    // CHECK: ttng.warp_group_dot
+    scf.for %iv0 = %c0_i32 to %c64_i32 step %c32_i32 : i32 {
+      scf.for %iv1 = %c0_i32 to %c64_i32 step %c32_i32 : i32 {
+        ttg.local_store %arg0, %0 : tensor<128x128xf16, #blocked> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %2 = ttng.warp_group_dot %0, %1, %cst : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> * !ttg.memdesc<128x64xf16, #shared1, #smem> -> tensor<128x64xf32, #mma>
       }
     }
     tt.return

--- a/test/TritonGPU/loop-pipeline-blackwell.mlir
+++ b/test/TritonGPU/loop-pipeline-blackwell.mlir
@@ -115,8 +115,12 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.targ
                     %B : !tt.ptr<f8E4M3FN> {tt.divisibility = 16 : i32}) -> tensor<128x128xf32, #C> {
 // CHECK-LABEL: tt.func @matmul_loop_cast_load
 // CHECK: scf.for
+// CHECK: ttg.local_load
+// CHECK: tt.fp_to_fp
+// CHECK: ttng.wait_barrier
+// CHECK: ttg.local_store
 // CHECK: ttng.tc_gen5_mma {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}
-// CHECK-NOT: ttng.wait_barrier
+// CHECK: ttg.async_copy_global_to_local
     %a_ptr_splat = tt.splat %A : !tt.ptr<f8E4M3FN> -> tensor<128x32x!tt.ptr<f8E4M3FN>, #AL>
     %a_tmp0 = tt.make_range {end = 32: i32, start = 0: i32} : tensor<32xi32, #ALs0>
     %a_tmp1 = tt.expand_dims %a_tmp0 {axis = 0 : i32} : tensor<32xi32, #ALs0> -> tensor<1x32xi32, #AL>

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -1586,10 +1586,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // Check that wait is pushed to the next stage, right before the tmem_alloc, and after the prologue.
+  // Check that tmem is hoisted out of the loop.
   // CHECK-LABEL: @wait_before_tmem_alloc
+  // CHECK: ttng.tmem_alloc
+  // CHECK: %[[TMEM_BUF:.+]] = ttng.tmem_alloc
   // CHECK: scf.for
   // CHECK: "prologue"() {loop.cluster = 0 : i32, loop.stage = 2 : i32}
-  // CHECK: ttng.tmem_alloc {{.*}} {loop.cluster = 2 : i32, loop.stage = 2 : i32}
+  // CHECK: ttng.tmem_store {{.*}}, %[[TMEM_BUF]], {{.*}} {loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttg.async_copy_global_to_local {{.*}} {loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 1 : i32, loop.stage = 3 : i32}


### PR DESCRIPTION
Hoist tmem and smem allocations for mmav5 operands that may have wait pushed to the next stage despite operands not being pipelined. This is to avoid bug where tmem/smem allocations are being clobbered by allocator due to liveranges being implicitly longer than the allocator is able to see.
To support hoistedproper wait placement in the presence of hoisted allocs (thus having stores instead of allocs in the loop) the `MMAv5PipelineableOperandsHelper` was gneralized a bit to look for any ops that override operand memory, not only load.
Fence insertion pass also had to be generalized a bit to detect that shared memory is being overwritten with stores.