### PR TITLE
[Gluon] Fix warp_specialize with constexprs, add a few APIs

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -299,6 +299,11 @@ void init_gluon_ir(py::module &&m) {
              self.create<ttng::AsyncTMAScatterOp>(descPtr, xOffsets, yOffset,
                                                   src);
            })
+      .def("create_fence_async_shared",
+           [](GluonOpBuilder &self, bool bCluster) -> OpState {
+             return self.create<ttng::FenceAsyncSharedOp>(bCluster);
+           })
+
       .def("create_broadcast",
            [](TritonOpBuilder &self, Value &arg, Type retTy) -> Value {
              return self.create<tt::BroadcastOp>(retTy, arg);

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1425,12 +1425,7 @@ void init_triton_ir(py::module &&m) {
            })
       .def("create_expand_dims",
            [](TritonOpBuilder &self, Value &arg, int axis) -> Value {
-             auto argType = dyn_cast<RankedTensorType>(arg.getType());
-             auto argEltType = argType.getElementType();
-             std::vector<int64_t> retShape = argType.getShape();
-             retShape.insert(retShape.begin() + axis, 1);
-             return self.create<ExpandDimsOp>(
-                 RankedTensorType::get(retShape, argEltType), arg, axis);
+             return self.create<ExpandDimsOp>(arg, axis);
            })
       .def("create_cat",
            [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -49,6 +49,9 @@ _IMPORT_FROM_TRITON: List[str] = [
     "static_assert",  # NOQA: F822
     "store",  # NOQA: F822
     "to_tensor",  # NOQA: F822
+    "where",  # NOQA: F822
+    "maximum",  # NOQA: F822
+    "minimum",  # NOQA: F822
 ]
 
 __all__ = [
@@ -303,6 +306,5 @@ def warp_specialize(args, default_partition, worker_partitions, worker_num_warps
                     _semantic=None, _generator=None):
     worker_num_warps = [_unwrap_if_constexpr(w) for w in worker_num_warps]
     worker_num_regs = [_unwrap_if_constexpr(r) for r in worker_num_regs]
-    args = [_unwrap_if_constexpr(arg) for arg in args]
     return _semantic.warp_specialize(args, default_partition, worker_partitions, worker_num_warps,  #
                                      worker_num_regs, _generator)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1683,7 +1683,7 @@ class TritonSemantic(Generic[TensorTy]):
 
         scan_op = self.builder.create_scan([t.handle for t in inputs], axis, reverse)
         region_builder_fn(scan_op)
-        scan_op.verify()
+        assert scan_op.verify()
 
         return tuple(self.wrap_tensor(scan_op.get_result(i), inputs[i].type.scalar, shape) for i in range(len(inputs)))
 


### PR DESCRIPTION
* where, maximum, minimum
* add gluon_ir builder for fence_async_shared. Not sure what API to use
* fix `ttgl.warp_specialize` passing constexpr arguments
