### PR TITLE
[PROTON-DEV] Remove redundant lowering code and suppress parser print

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -46,6 +46,7 @@ inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
     "ALLOW_LHS_TMEM_LAYOUT_CONVERSION",
     "TRITON_F32_DEFAULT",
     "TRITON_PREFER_TMEM_16x256_LAYOUT",
+    "PROTON_ENABLE_DEBUG",
     // clang-format on
 };
 

--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -46,14 +46,14 @@ inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
     "ALLOW_LHS_TMEM_LAYOUT_CONVERSION",
     "TRITON_F32_DEFAULT",
     "TRITON_PREFER_TMEM_16x256_LAYOUT",
-    "PROTON_ENABLE_DEBUG",
     // clang-format on
 };
 
 inline const std::set<std::string> CACHE_NEUTRAL_ENV_VARS = {
     // clang-format off
     "TRITON_REPRODUCER_PATH",
-    "TRITON_ENABLE_PYTHON_STACKTRACE"
+    "TRITON_ENABLE_PYTHON_STACKTRACE",
+    "PROTON_ENABLE_DEBUG"
     // clang-format on
 };
 

--- a/third_party/proton/common/include/TraceDataIO/Parser.h
+++ b/third_party/proton/common/include/TraceDataIO/Parser.h
@@ -15,7 +15,7 @@ struct ParserConfig {
   };
 
   // Configure exception message visibility
-  ExceptionPrinting exceptionPrintLevel = ExceptionPrinting::ALL;
+  ExceptionPrinting exceptionPrintLevel = ExceptionPrinting::SILENT;
 };
 
 // Define exception severity levels

--- a/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
+++ b/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
@@ -140,7 +140,7 @@ ScopeMisMatchException::ScopeMisMatchException(const std::string &msg)
     : ParserException(msg, ExceptionSeverity::WARNING) {}
 
 ClockOverflowException::ClockOverflowException(const std::string &msg)
-    : ParserException(msg, ExceptionSeverity::WARNING) {}
+    : ParserException(msg, ExceptionSeverity::ERROR) {}
 
 namespace {
 Device decodeDevice(const uint32_t dev) {

--- a/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
@@ -5,6 +5,7 @@
 #include "Profiler/Instrumentation/CudaRuntime.h"
 #include "Profiler/Instrumentation/HipRuntime.h"
 #include "Utility/String.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
 #include <algorithm>
 #include <limits>
 #include <map>
@@ -186,6 +187,9 @@ void InstrumentationProfiler::exitInstrumentedOp(uint64_t streamId,
   config.uidVec = getUnitIdVector(modeOptions, config.totalUnits);
   config.device = Device();
   config.device.type = runtime->getDeviceType();
+  bool enableDebug = mlir::triton::tools::getBoolEnv("PROTON_ENABLE_DEBUG");
+  if (enableDebug)
+    config.exceptionPrintLevel = ParserConfig::ExceptionPrinting::ALL;
 
   uint32_t timeShiftCost = 0;
   if (modeOptions.count("optimization") &&

--- a/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Utility.h
+++ b/third_party/proton/dialect/include/Conversion/ProtonGPUToLLVM/Utility.h
@@ -1,6 +1,7 @@
 #ifndef PROTONGPU_TO_LLVM_UTILITY_H
 #define PROTONGPU_TO_LLVM_UTILITY_H
 
+#include "Dialect/ProtonGPU/IR/Dialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -25,5 +26,22 @@ struct SegmentObject {
 };
 
 } // namespace mlir::LLVM
+
+namespace mlir::triton {
+namespace proton::gpu {
+
+struct CircularStoreDataPack {
+  Value isWriter;
+  Value record;
+  Value ptr;
+  uint32_t addrSpace;
+};
+
+CircularStoreDataPack
+lowerCircularStoreOpHelper(CircularStoreOp op, Value segmentStruct,
+                           ConversionPatternRewriter &rewriter);
+
+} // namespace proton::gpu
+} // namespace mlir::triton
 
 #endif // PROTONGPU_TO_LLVM_UTILITY_H

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/AMDPatternProtonGPUOpToLLVM.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/AMDPatternProtonGPUOpToLLVM.cpp
@@ -27,39 +27,12 @@ struct CircularStoreOpConversion
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto mod = op.getOperation()->getParentOfType<ModuleOp>();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    const int bytesPerEntry = proton::gpu::getBytesPerClockEntry();
-    const int wordsPerEntry = bytesPerEntry / 4; // 1 word = 4 bytes
-    auto segment = adaptor.getSegment();
-    auto segmentObj = LLVM::SegmentObject::fromStruct(loc, segment, rewriter);
-    Value indexPtr = segmentObj.indexPtr;
-    Value bufferBase = segmentObj.base;
-    Value segmentBase = segmentObj.segmentBase;
-    auto bufferBaseType = bufferBase.getType();
+    auto dataPack =
+        lowerCircularStoreOpHelper(op, adaptor.getSegment(), rewriter);
 
-    Value curIdx = b.load(i32_ty, indexPtr);
-    Value newIdx = b.add(curIdx, b.i32_val(wordsPerEntry));
-    b.store(newIdx, indexPtr);
-
-    int selectedWarpNum = mlir::triton::gpu::lookupNumWarps(mod);
-    auto segmentType = op.getSegment().getType();
-    auto selectedIds = segmentType.getSelectIds();
-    if (!selectedIds.empty())
-      selectedWarpNum = selectedIds.size();
-    const int bufferSizeInBytes = segmentType.getNBytes();
-    const int segmentWordSize = bufferSizeInBytes / selectedWarpNum / 4;
-    Value tagOffset =
-        b.add(segmentBase, b.urem(curIdx, b.i32_val(segmentWordSize)));
-    Value vecPtr = b.gep(bufferBaseType, i32_ty, bufferBase, tagOffset);
-    Value tag = op.getIsStart() ? b.i32_val(op.getScopeId())
-                                : b.i32_val(1 << 31 | op.getScopeId());
-    Value clock = op.getCounter();
-    Value valsVec = packLLVector(loc, {tag, clock}, rewriter);
-
-    uint32_t addrSpace =
-        cast<LLVM::LLVMPointerType>(bufferBaseType).getAddressSpace();
+    uint32_t addrSpace = dataPack.addrSpace;
     if (addrSpace == 1) {
       // TODO(crobeck): see what buffer ops performance looks like here for
       // stack mem (address space 1) compared to predicated ops to shared memory
@@ -67,9 +40,9 @@ struct CircularStoreOpConversion
     } else if (addrSpace == 3) {
       // Setting predicate always true has bank conflicts but it is
       // expected and stable.
-      targetInfo.getTritonTargetInfo().storeDShared(rewriter, loc, vecPtr,
-                                                    std::nullopt, valsVec,
-                                                    /*predicate=*/b.true_val());
+      targetInfo.getTritonTargetInfo().storeDShared(
+          rewriter, loc, dataPack.ptr, std::nullopt, dataPack.record,
+          /*predicate=*/b.true_val());
     } else {
       llvm::report_fatal_error("unsupported address space in circular store");
     }

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/Utility.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/Utility.cpp
@@ -52,3 +52,76 @@ SegmentObject SegmentObject::fromStruct(Location loc, Value segmentStruct,
 }
 
 } // namespace mlir::LLVM
+
+namespace mlir::triton {
+namespace proton::gpu {
+
+CircularStoreDataPack
+lowerCircularStoreOpHelper(CircularStoreOp op, Value segmentStruct,
+                           ConversionPatternRewriter &rewriter) {
+  auto loc = op.getLoc();
+  auto mod = op.getOperation()->getParentOfType<ModuleOp>();
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  const int bytesPerEntry = proton::gpu::getBytesPerClockEntry();
+  const int wordsPerEntry = bytesPerEntry / 4; // 1 word = 4 bytes
+
+  auto segmentObj =
+      LLVM::SegmentObject::fromStruct(loc, segmentStruct, rewriter);
+  Value indexPtr = segmentObj.indexPtr;
+  Value bufferBase = segmentObj.base;
+  Value segmentBase = segmentObj.segmentBase;
+
+  // Update the index (could be register promoted).
+  Value curIdx = b.load(i32_ty, indexPtr);
+  Value newIdx = b.add(curIdx, b.i32_val(wordsPerEntry));
+  b.store(newIdx, indexPtr);
+
+  // Compute the segment size in word (4 bytes).
+  int selectedWarpNum = mlir::triton::gpu::lookupNumWarps(mod);
+  auto segmentType = op.getSegment().getType();
+  auto selectedIds = segmentType.getSelectIds();
+  if (!selectedIds.empty())
+    selectedWarpNum = selectedIds.size();
+  const int bufferSizeInBytes = segmentType.getNBytes();
+  const int segmentWordSize = bufferSizeInBytes / selectedWarpNum / 4;
+
+  // Compute the actual base offset (with urem as circular buffer).
+  Value tagOffset =
+      b.add(segmentBase, b.urem(curIdx, b.i32_val(segmentWordSize)));
+
+  // Store the counter into buffer.
+  auto bufferBaseType = bufferBase.getType();
+  Value vecPtr = b.gep(bufferBaseType, i32_ty, bufferBase, tagOffset);
+  Value tag = op.getIsStart() ? b.i32_val(op.getScopeId())
+                              : b.i32_val(1 << 31 | op.getScopeId());
+  Value clock = op.getCounter();
+  Value valsVec = packLLVector(loc, {tag, clock}, rewriter);
+
+  // Compute the predicate for the writer.
+  const int warpSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
+  Value curThreadId = getThreadId(rewriter, loc);
+  Value isWarpMaster =
+      b.icmp_eq(b.urem(curThreadId, b.i32_val(warpSize)), b.i32_val(0));
+  Value isWriter;
+
+  auto granularity = segmentType.getGranularity();
+  if (selectedIds.empty()) {
+    if (granularity == proton::gpu::Granularity::WARP) {
+      isWriter = isWarpMaster;
+    } else {
+      llvm::report_fatal_error(
+          "segment address specialization not implemented yet");
+    }
+  } else {
+    Value isCurWarpEnabled = b.icmp_ne(segmentBase, b.i32_val(-1));
+    isWriter = b.and_(isCurWarpEnabled, isWarpMaster);
+  }
+
+  uint32_t addrSpace =
+      cast<LLVM::LLVMPointerType>(bufferBaseType).getAddressSpace();
+
+  return {isWriter, valsVec, vecPtr, addrSpace};
+}
+
+} // namespace proton::gpu
+} // namespace mlir::triton


### PR DESCRIPTION
Move the `circular_store` AMD and NV common code into the `utility` and add an ENV for Proton to print debug info.
