### PR TITLE
[Frontend] Enable accessing `fn.__closure__` of `@jit` functions like globals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ python/triton/_C/*.dylib
 python/triton/_C/*.pdb
 python/triton/_C/*.exe
 python/triton/_C/*.ilk
+python/triton/FileCheck
 
 # Backends copied from submodules
 python/triton/backends/*

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -263,19 +263,6 @@ def test_power_of_two_shapes_2():
     assert str(e.value.__cause__) == "Shape element 0 must be a power of 2"
 
 
-def test_captured_var_access():
-
-    CAPTURED = 42
-
-    @triton.jit
-    def kernel():
-        a = CAPTURED  # noqa
-
-    with pytest.raises(CompilationError) as e:
-        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
-    assert "CAPTURED is not defined" in str(e.value)
-
-
 GLOBAL = 42
 
 

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -1,6 +1,6 @@
 import triton
 import triton.language as tl
-from triton._filecheck import filecheck_test
+from triton._filecheck import filecheck_test, run_filecheck_test
 
 # ===-----------------------------------------------------------------------===#
 # Unit Tests
@@ -277,3 +277,89 @@ def test_constexpr_getitem():
     shape: tl.constexpr = make_shape(4, 8)
     sum: tl.constexpr = add_shape_dims(shape[0], shape[1])
     tl.arange(4, sum)
+
+
+@tl.constexpr_function
+def make_constexpr_closure(x):
+    x = tl.constexpr(x)
+
+    @triton.jit
+    def inner(shape: tl.constexpr):
+        return tl.full(shape, x, dtype=tl.int32)
+
+    return inner
+
+
+@filecheck_test
+@triton.jit
+def test_constexpr_closure():
+    # CHECK-LABEL: test_constexpr_closure
+    closure: tl.constexpr = make_constexpr_closure(42)
+
+    # CHECK: arith.constant dense<42> : tensor<128x128xi32>
+    closure((128, 128))
+
+
+@tl.constexpr_function
+def make_constexpr_generator(f):
+    f = tl.constexpr(f)
+
+    @triton.jit
+    def inner(lhs):
+        return lhs + f(lhs.shape, lhs.dtype)
+
+    return inner
+
+
+@triton.jit
+def inner_function(shape: tl.constexpr, dtype: tl.constexpr):
+    return tl.full(shape, 42, dtype)
+
+
+@filecheck_test
+@triton.jit
+def test_constexpr_generator():
+    # CHECK: func public @test_constexpr_generator
+    # CHECK:   [[RANGE:%.*]] = tt.make_range {end = 128 : i32, start = 0 : i32}
+    # CHECK:   call @{{.*}}make_constexpr_generator.<locals>.inner{{.*}}([[RANGE]])
+
+    # CHECK: func private @{{.*}}make_constexpr_generator.<locals>.inner
+    # CHECK:   [[RHS:%.*]] = tt.call @{{.*}}inner_function
+    # CHECK:   [[RESULT:%.*]] = arith.addi %arg0, [[RHS]]
+    # CHECK:   return [[RESULT]]
+
+    # CHECK: func private @{{.*}}inner_function
+    # CHECK:   %cst = arith.constant dense<42> : tensor<128xi32>
+    # CHECK:   return %cst
+    generator: tl.constexpr = make_constexpr_generator(inner_function)
+    lhs = tl.arange(0, 128)
+    generator(lhs)
+
+
+def Box(T):
+
+    @tl.core._aggregate
+    class BoxImpl:
+        value: T
+
+        @triton.jit
+        def create(value):
+            return BoxImpl(value)
+
+        def __init__(self, value):
+            self.value = value
+
+    return BoxImpl
+
+
+def test_late_bound_class_reference():
+    TensorBox = Box(tl.tensor)
+
+    @triton.jit
+    def kernel():
+        # CHECK: [[RANGE:%.*]] = tt.make_range {end = 4 : i32, start = 0 : i32}
+        # CHECK: call @{{.*}}anchor{{.*}}([[RANGE]])
+        value = TensorBox(tl.arange(0, 4))
+        anchor(value)
+
+    run_filecheck_test(kernel)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1212,7 +1212,6 @@ class CodeGenerator(ast.NodeVisitor):
         fn_name = mangle_fn(get_full_name(fn), [arg.type for arg in args_val], args_cst)
         # generate function def if necessary
         if not self.module.has_function(fn_name):
-            gscope = fn.__globals__
             # If the callee is not set, we use the same debug setting as the caller
             file_name, begin_line = get_jit_fn_file_line(fn)
             arg_types = [
@@ -1221,7 +1220,7 @@ class CodeGenerator(ast.NodeVisitor):
                 for arg in args
             ]
             prototype = ASTFunction([], arg_types, args_cst, dict())
-            generator = CodeGenerator(self.context, prototype, gscope, module=self.module, jit_fn=fn,
+            generator = CodeGenerator(self.context, prototype, fn.get_capture_scope(), module=self.module, jit_fn=fn,
                                       function_name=fn_name, function_types=self.function_ret_types,
                                       noinline=fn.noinline, file_name=file_name, begin_line=begin_line,
                                       options=self.builder.options, codegen_fns=self.builder.codegen_fns,
@@ -1478,8 +1477,8 @@ def ast_to_ttir(fn, src, context, options, codegen_fns, module_map, module=None)
     constants = {fn.arg_names[i[0]]: src.constants[i] for i in leaves}
     signature = src.signature
     proxy = namedtuple("SpecializationProxy", ["constants", "signature"])(constants, signature)
-    generator = CodeGenerator(context, prototype, gscope=fn.__globals__.copy(), function_name=fn.repr(proxy), jit_fn=fn,
-                              is_kernel=True, file_name=file_name, begin_line=begin_line, options=options,
+    generator = CodeGenerator(context, prototype, gscope=fn.get_capture_scope(), function_name=fn.repr(proxy),
+                              jit_fn=fn, is_kernel=True, file_name=file_name, begin_line=begin_line, options=options,
                               codegen_fns=codegen_fns, module_map=module_map, module=module)
     generator.visit(fn.parse())
     ret = generator.module

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1356,10 +1356,9 @@ class FunctionRewriter:
         return transformed_ast
 
     def _compile_and_exec(self, transformed_ast):
-        from .jit import JITFunction
         compiled_code = compile(transformed_ast, filename=self.filename, mode='exec')
         local_namespace = {**self.kwargs}
-        fn_globals = JITFunction.get_capture_scope(self.fn)
+        fn_globals = self.fn.__globals__
         for key, value in globals().items():
             if key not in fn_globals:
                 fn_globals[key] = value

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1356,9 +1356,10 @@ class FunctionRewriter:
         return transformed_ast
 
     def _compile_and_exec(self, transformed_ast):
+        from .jit import JITFunction
         compiled_code = compile(transformed_ast, filename=self.filename, mode='exec')
         local_namespace = {**self.kwargs}
-        fn_globals = self.fn.__globals__
+        fn_globals = JITFunction.get_capture_scope(self.fn)
         for key, value in globals().items():
             if key not in fn_globals:
                 fn_globals[key] = value

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations, division
 import ast
+import copy
 import hashlib
 import inspect
 import itertools
@@ -37,13 +38,14 @@ class DependenciesFinder(ast.NodeVisitor):
     otherwise we could recompile).
     """
 
-    def __init__(self, name, globals, src) -> None:
+    def __init__(self, name, globals, nonlocals, src) -> None:
         super().__init__()
         self.name = name
         self.hasher = hashlib.sha256(src.encode("utf-8"))
 
         # This function's __globals__ dict.
         self.globals = globals
+        self.nonlocals = nonlocals
 
         # Python builtins that can be accessed from Triton kernels.
         self.supported_python_builtins = {
@@ -109,7 +111,16 @@ class DependenciesFinder(ast.NodeVisitor):
             # The global name is hidden by the local name.
             return None
 
-        val = self.globals.get(node.id, None)
+        def name_lookup(name):
+            val = self.globals.get(name, None)
+            if val is not None:
+                return val, self.globals
+            val = self.nonlocals.get(name, None)
+            if val is not None:
+                return val, self.nonlocals
+            return None, None
+
+        val, var_dict = name_lookup(node.id)
 
         # Only keep track of "interesting" global variables, that non-evil users
         # might change.  Don't consider functions, modules, builtins, etc.  This
@@ -126,7 +137,7 @@ class DependenciesFinder(ast.NodeVisitor):
                 # `bar` and then someone did `foo = baz`.
                 and not isinstance(val, JITFunction) and not getattr(val, "__triton_builtin__", False)  #
                 and node.id not in self.supported_python_builtins):
-            self.used_global_vals[(node.id, id(self.globals))] = (val, self.globals)
+            self.used_global_vals[(node.id, id(var_dict))] = (copy.copy(val), var_dict)
 
         self._update_hash(val)
         return val
@@ -666,11 +677,16 @@ class JITFunction(KernelInterface[T]):
         self.__globals__ = fn.__globals__
         self.__module__ = fn.__module__
 
+    def get_capture_scope(self):
+        return self.__globals__ | inspect.getclosurevars(self.fn).nonlocals
+
     @property
     def cache_key(self):
         # TODO : hash should be attribute of `self`
         if self.hash is None:
-            dependencies_finder = DependenciesFinder(name=self._fn_name, globals=self.__globals__, src=self.src)
+            nonlocals = inspect.getclosurevars(self.fn).nonlocals
+            dependencies_finder = DependenciesFinder(name=self._fn_name, globals=self.__globals__, nonlocals=nonlocals,
+                                                     src=self.src)
             dependencies_finder.visit(self.parse())
             self.hash = dependencies_finder.ret + str(self.starting_line_number)
             self.used_global_vals = dict(sorted(dependencies_finder.used_global_vals.items()))

--- a/python/triton_kernels/triton_kernels/specialize.py
+++ b/python/triton_kernels/triton_kernels/specialize.py
@@ -78,7 +78,7 @@ def specialize(fn, module, constants, tuples, name=None, do_not_specialize=tuple
             non_specialized_args += new_args
     # add global symbols
     spec_fns = {v.__name__: v for k, v in constants.items() if isinstance(v, triton.runtime.jit.JITFunction)}
-    globals = spec_fns | fn.__globals__
+    globals = spec_fns | fn.get_capture_scope()
     # build new source code and define kernel dynamically
     new_signature = f"def {name}({', '.join(non_specialized_args)}):"
     constexpr_lines = [


### PR DESCRIPTION
This enables the code generator to perform name lookup of captured closure variables like it does for globals. I also made  sure add machinery to the runtime that detects invalid modification of closure captures like for globals.

This allows building Zig-style generics in Triton