### PR TITLE
Fix pipelining of mixed WGMMA and non-WGMMA usage

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -458,23 +458,44 @@ void createTMABarrierAndWait(
 }
 
 // Check if load requires additional buffer for a mma pipelining
-bool loadRequiresAdditionalBuffer(Operation *loadOp) {
-  auto skipViewOps = [](Operation *op) -> Operation * {
-    while (op->hasOneUse() && op->hasTrait<OpTrait::MemDescViewTrait>()) {
-      op = *op->getUsers().begin();
-    }
-    return op;
+bool loadRequiresAdditionalBuffer(Operation *op) {
+  static bool (*hasWGMMAUser)(Operation *) = [](Operation *op) -> bool {
+    if (isa<ttng::WarpGroupDotOp>(op))
+      return true;
+
+    return op->hasTrait<OpTrait::MemDescViewTrait>() &&
+           llvm::any_of(op->getUsers(),
+                        [](Operation *op) { return hasWGMMAUser(op); });
   };
+
+  if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
+    // AsyncCopyGlobalToLocalOp does not support the non-zero "other" value.
+    // With consumer consuming directly the shared memory, there would be no way
+    // to replace masked values with the "other" value.
+    if (loadOp.getOther() && !isZeroConst(loadOp.getOther()))
+      return false;
+  }
+
+  Attribute loadEncoding;
+  if (auto descLoad = dyn_cast<DescriptorLoadOp>(op)) {
+    loadEncoding = nvidia_gpu::getEncodingFromDescriptor(op, descLoad.getType(),
+                                                         descLoad.getDesc());
+  } else if (auto descGather = dyn_cast<DescriptorGatherOp>(op)) {
+    loadEncoding = nvidia_gpu::getEncodingFromDescriptor(
+        op, descGather.getType(), descGather.getDesc());
+  }
+
   // Pattern match the op sequence used for loading mmav3 operands
-  if (!mustLoadToRegisters(loadOp)) {
-    assert(loadOp->hasOneUse());
-    ttg::LocalAllocOp alloc =
-        dyn_cast<ttg::LocalAllocOp>(*loadOp->getUsers().begin());
-    if (alloc) {
-      return llvm::any_of(alloc->getUsers(), [&](Operation *op) {
-        return isa<ttng::WarpGroupDotOp>(skipViewOps(op));
-      });
-    }
+  for (auto user : op->getUsers()) {
+    ttg::LocalAllocOp alloc = dyn_cast<ttg::LocalAllocOp>(user);
+    if (!alloc)
+      continue;
+
+    if (loadEncoding && (loadEncoding != alloc.getType().getEncoding()))
+      return false;
+
+    if (llvm::any_of(alloc->getUsers(), hasWGMMAUser))
+      return true;
   }
   return false;
 }


### PR DESCRIPTION
Currently, if a load operation has a WGMMA user and another non-WGMMA user, the pipeliner code bails out on adjusting stageDiff counter. As a result, local_alloc operation is created with a single buffer. However, later code is generated with the assumption that double buffer has been allocated leading to incorrect result. This fix updates the loadRequiresAdditionalBuffer function to handle this use-case. Now it correctly increments the stageDiff counter which in turn results in the correct number of buffers to pipeline a load operation. Fixes #6691.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
