### PR TITLE
[BACKEND] Preserve DiscardableAttrs in AddPtr combine and canonicalize

### DIFF
--- a/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
+++ b/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
@@ -6,7 +6,10 @@
 
 namespace mlir::triton {
 
-SmallVector<NamedAttribute> getAllowedDiscardableAttrs(triton::AddPtrOp op);
+// Filter out attributes from the given operation that are not present in
+// the allowList.
+[[nodiscard]] SmallVector<NamedAttribute>
+filterDiscardableAttrs(Operation *op, ArrayRef<StringRef> allowList);
 
 } // namespace mlir::triton
 #endif // TRITON_DIALECT_TRITON_IR_DISCARDABLE_ATTRIBUTES_H_

--- a/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
+++ b/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
@@ -1,0 +1,12 @@
+#ifndef TRITON_DIALECT_TRITON_IR_DISCARDABLE_ATTRIBUTES_H_
+#define TRITON_DIALECT_TRITON_IR_DISCARDABLE_ATTRIBUTES_H_
+
+#include "mlir/Support/LLVM.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir::triton {
+
+SmallVector<NamedAttribute> getAllowedDiscardableAttrs(triton::AddPtrOp op);
+
+} // namespace mlir::triton
+#endif // TRITON_DIALECT_TRITON_IR_DISCARDABLE_ATTRIBUTES_H_

--- a/lib/Dialect/Triton/IR/CMakeLists.txt
+++ b/lib/Dialect/Triton/IR/CMakeLists.txt
@@ -4,6 +4,7 @@ add_public_tablegen_target(TritonCanonicalizeIncGen)
 
 add_triton_library(TritonIR
   Dialect.cpp
+  DiscardableAttributes.cpp
   Ops.cpp
   Traits.cpp
   Types.cpp

--- a/lib/Dialect/Triton/IR/DiscardableAttributes.cpp
+++ b/lib/Dialect/Triton/IR/DiscardableAttributes.cpp
@@ -3,9 +3,8 @@
 
 namespace mlir::triton {
 
-SmallVector<NamedAttribute> getAllowedDiscardableAttrs(triton::AddPtrOp op) {
-  std::array<StringRef, 3> allowList{"tt.divisibility", "tt.contiguity",
-                                     "tt.constancy"};
+SmallVector<NamedAttribute>
+filterDiscardableAttrs(Operation *op, ArrayRef<StringRef> allowList) {
   SmallVector<NamedAttribute> propagatedAttrs;
   for (auto attrName : allowList) {
     Attribute attr = op->getDiscardableAttr(attrName);

--- a/lib/Dialect/Triton/IR/DiscardableAttributes.cpp
+++ b/lib/Dialect/Triton/IR/DiscardableAttributes.cpp
@@ -1,0 +1,18 @@
+#include "mlir/Support/LLVM.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir::triton {
+
+SmallVector<NamedAttribute> getAllowedDiscardableAttrs(triton::AddPtrOp op) {
+  std::array<StringRef, 3> allowList{"tt.divisibility", "tt.contiguity",
+                                     "tt.constancy"};
+  SmallVector<NamedAttribute> propagatedAttrs;
+  for (auto attrName : allowList) {
+    Attribute attr = op->getDiscardableAttr(attrName);
+    if (attr)
+      propagatedAttrs.emplace_back(attrName, attr);
+  }
+  return propagatedAttrs;
+}
+
+} // namespace mlir::triton

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
 
 namespace mlir::triton {
@@ -58,19 +59,6 @@ bool isAddPtrOffsetCombinable(Value first, Value second) {
     }
   }
   return false;
-}
-
-SmallVector<NamedAttribute> getAllowedDiscardableAttrs(triton::AddPtrOp op) {
-  // Query all discardable attributes that we want to preserve
-  std::array<StringRef, 3> allowList{"tt.divisibility", "tt.contiguity",
-                                     "tt.constancy"};
-  SmallVector<NamedAttribute> propagatedAttrs;
-  for (auto attrName : allowList) {
-    Attribute attr = op->getDiscardableAttr(attrName);
-    if (attr)
-      propagatedAttrs.emplace_back(attrName, attr);
-  }
-  return propagatedAttrs;
 }
 
 // TODO(csigg): remove after next LLVM integrate.

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -60,6 +60,19 @@ bool isAddPtrOffsetCombinable(Value first, Value second) {
   return false;
 }
 
+SmallVector<NamedAttribute> getAllowedDiscardableAttrs(triton::AddPtrOp op) {
+  // Query all discardable attributes that we want to preserve
+  std::array<StringRef, 3> allowList{"tt.divisibility", "tt.contiguity",
+                                     "tt.constancy"};
+  SmallVector<NamedAttribute> propagatedAttrs;
+  for (auto attrName : allowList) {
+    Attribute attr = op->getDiscardableAttr(attrName);
+    if (attr)
+      propagatedAttrs.emplace_back(attrName, attr);
+  }
+  return propagatedAttrs;
+}
+
 // TODO(csigg): remove after next LLVM integrate.
 using FastMathFlags = arith::FastMathFlags;
 

--- a/lib/Dialect/Triton/Transforms/Combine.td
+++ b/lib/Dialect/Triton/Transforms/Combine.td
@@ -41,7 +41,8 @@ def CombineDotAddFRevPattern : Pat<
 defvar DefOverflow = ConstantEnumCase<Arith_IntegerOverflowAttr, "none">;
 
 def CopyDiscardableAttrs: NativeCodeCallVoid<
-        "$1.getOwner()->setDiscardableAttrs($0.getOwner()->getDiscardableAttrDictionary())">;
+        "$1.getOwner()->setDiscardableAttrs(getAllowedDiscardableAttrs("
+        "::llvm::cast<::mlir::triton::AddPtrOp>($0.getOwner())))">;
 
 def CombineAddPtrPattern : Pat<
         (TT_AddPtrOp:$src (TT_AddPtrOp $ptr, $idx0), $idx1),

--- a/lib/Dialect/Triton/Transforms/Combine.td
+++ b/lib/Dialect/Triton/Transforms/Combine.td
@@ -39,9 +39,14 @@ def CombineDotAddFRevPattern : Pat<
 //   Note: leave (sub %c0, %c0) canceling to ArithDialect
 //         (ref: ArithCanonicalization.td)
 defvar DefOverflow = ConstantEnumCase<Arith_IntegerOverflowAttr, "none">;
+
+def CopyDiscardableAttrs: NativeCodeCallVoid<
+        "$1.getOwner()->setDiscardableAttrs($0.getOwner()->getDiscardableAttrDictionary())">;
+
 def CombineAddPtrPattern : Pat<
-        (TT_AddPtrOp (TT_AddPtrOp $ptr, $idx0), $idx1),
-        (TT_AddPtrOp $ptr, (Arith_AddIOp $idx0, $idx1, DefOverflow)),
-        [(Constraint<CPred<"isAddPtrOffsetCombinable($0, $1)">> $idx0, $idx1)]>;
+        (TT_AddPtrOp:$src (TT_AddPtrOp $ptr, $idx0), $idx1),
+        (TT_AddPtrOp:$dest $ptr, (Arith_AddIOp $idx0, $idx1, DefOverflow)),
+        [(Constraint<CPred<"isAddPtrOffsetCombinable($0, $1)">> $idx0, $idx1)],
+        [(CopyDiscardableAttrs $src, $dest)]>;
 
 #endif

--- a/lib/Dialect/Triton/Transforms/Combine.td
+++ b/lib/Dialect/Triton/Transforms/Combine.td
@@ -41,8 +41,8 @@ def CombineDotAddFRevPattern : Pat<
 defvar DefOverflow = ConstantEnumCase<Arith_IntegerOverflowAttr, "none">;
 
 def CopyDiscardableAttrs: NativeCodeCallVoid<
-        "$1.getOwner()->setDiscardableAttrs(getAllowedDiscardableAttrs("
-        "::llvm::cast<::mlir::triton::AddPtrOp>($0.getOwner())))">;
+        "$1.getOwner()->setDiscardableAttrs(triton::filterDiscardableAttrs($0.getOwner(), "
+        "{\"tt.divisibility\", \"tt.contiguity\", \"tt.constancy\"}))">;
 
 def CombineAddPtrPattern : Pat<
         (TT_AddPtrOp:$src (TT_AddPtrOp $ptr, $idx0), $idx1),

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -84,18 +84,29 @@ tt.func @test_combine_addptr_pattern(%base: !tt.ptr<f32>) -> tensor<8x!tt.ptr<f3
     tt.return %ptr1 : tensor<8x!tt.ptr<f32>>
 }
 
-// CHECK-LABEL: @test_combine_addptr_pattern_divisibility
-tt.func @test_combine_addptr_pattern_divisibility(%base: !tt.ptr<f32>) -> !tt.ptr<f32> {
+// CHECK-LABEL: @test_combine_addptr_pattern_discardableattrs
+tt.func @test_combine_addptr_pattern_discardableattrs(%base: !tt.ptr<f32>) -> !tt.ptr<f32> {
+    %off0 = arith.constant 8 : i32
+    %off1 = arith.constant 4 : i32
+    // CHECK-NEXT: %[[cst:.*]] = arith.constant 12 : i32
+    // CHECK-NEXT: %0 = tt.addptr %{{.*}}, %[[cst]] {tt.constancy = 8 : i32, tt.contiguity = 512 : i32, tt.divisibility = 16 : i32} : !tt.ptr<f32>, i32
+    %ptr0 = tt.addptr %base, %off0 : !tt.ptr<f32>, i32
+    %ptr1 = tt.addptr %ptr0, %off1 {tt.divisibility = 16 : i32, tt.constancy = 8 : i32, tt.contiguity = 512 : i32} : !tt.ptr<f32>, i32
+
+    tt.return %ptr1 : !tt.ptr<f32>
+}
+
+// CHECK-LABEL: @test_combine_addptr_pattern_discardableattrs_disallowed
+tt.func @test_combine_addptr_pattern_discardableattrs_disallowed(%base: !tt.ptr<f32>) -> !tt.ptr<f32> {
     %off0 = arith.constant 8 : i32
     %off1 = arith.constant 4 : i32
     // CHECK-NEXT: %[[cst:.*]] = arith.constant 12 : i32
     // CHECK-NEXT: %0 = tt.addptr %{{.*}}, %[[cst]] {tt.divisibility = 16 : i32} : !tt.ptr<f32>, i32
     %ptr0 = tt.addptr %base, %off0 : !tt.ptr<f32>, i32
-    %ptr1 = tt.addptr %ptr0, %off1 {tt.divisibility = 16 : i32} : !tt.ptr<f32>, i32
+    %ptr1 = tt.addptr %ptr0, %off1 {tt.divisibility = 16 : i32, tt.disallowed = 8 : i32} : !tt.ptr<f32>, i32
 
     tt.return %ptr1 : !tt.ptr<f32>
 }
-
 // CHECK-LABEL: @test_combine_addptr_pattern_i64
 tt.func @test_combine_addptr_pattern_i64(%base: !tt.ptr<f32>) -> tensor<8x!tt.ptr<f32>> {
     %off0 = arith.constant 10 : i64

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -84,6 +84,18 @@ tt.func @test_combine_addptr_pattern(%base: !tt.ptr<f32>) -> tensor<8x!tt.ptr<f3
     tt.return %ptr1 : tensor<8x!tt.ptr<f32>>
 }
 
+// CHECK-LABEL: @test_combine_addptr_pattern_divisibility
+tt.func @test_combine_addptr_pattern_divisibility(%base: !tt.ptr<f32>) -> !tt.ptr<f32> {
+    %off0 = arith.constant 8 : i32
+    %off1 = arith.constant 4 : i32
+    // CHECK-NEXT: %[[cst:.*]] = arith.constant 12 : i32
+    // CHECK-NEXT: %0 = tt.addptr %{{.*}}, %[[cst]] {tt.divisibility = 16 : i32} : !tt.ptr<f32>, i32
+    %ptr0 = tt.addptr %base, %off0 : !tt.ptr<f32>, i32
+    %ptr1 = tt.addptr %ptr0, %off1 {tt.divisibility = 16 : i32} : !tt.ptr<f32>, i32
+
+    tt.return %ptr1 : !tt.ptr<f32>
+}
+
 // CHECK-LABEL: @test_combine_addptr_pattern_i64
 tt.func @test_combine_addptr_pattern_i64(%base: !tt.ptr<f32>) -> tensor<8x!tt.ptr<f32>> {
     %off0 = arith.constant 10 : i64

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -567,6 +567,9 @@ public:
              "expected offset to be integer type");
       auto newAddPtrOp = rewriter.create<tt::AddPtrOp>(
           curLoc, fatPtrBase.getType(), fatPtrBase, origOffset);
+      newAddPtrOp.getOperation()->setDiscardableAttrs(
+          addPtrOp->getDiscardableAttrDictionary());
+
       rewriter.replaceOpWithMultiple(addPtrOp, {{newAddPtrOp, fatPtrOffset}});
       fatPtrs[{newAddPtrOp, fatPtrOffset}] =
           fatPtrs.at({fatPtrBase, fatPtrOffset});
@@ -581,6 +584,9 @@ public:
             maybeGetOrCreateScalarConstant(rewriter, curLoc, origOffset)) {
       tt::AddPtrOp newAddPtrOp = rewriter.create<tt::AddPtrOp>(
           curLoc, fatPtrBase.getType(), fatPtrBase, *scalarConst);
+      newAddPtrOp.getOperation()->setDiscardableAttrs(
+          addPtrOp->getDiscardableAttrDictionary());
+
       rewriter.replaceOpWithMultiple(addPtrOp, {{newAddPtrOp, fatPtrOffset}});
       // If we are updating the tensor pointer with a constant value, we can
       // propagate the attributes of the tensor pointer to the fat pointer.
@@ -596,6 +602,8 @@ public:
 
     auto newAddPtrOp = rewriter.create<tt::AddPtrOp>(
         curLoc, fatPtrBase.getType(), fatPtrBase, uniformOffset);
+    newAddPtrOp.getOperation()->setDiscardableAttrs(
+        addPtrOp->getDiscardableAttrDictionary());
 
     // Vector offset update (if any): bump the tensor offset
     bool canNarrow = fatPtrs.at({fatPtrBase, fatPtrOffset}).canNarrow;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -574,7 +574,7 @@ public:
              "expected offset to be integer type");
       auto newAddPtrOp = rewriter.create<tt::AddPtrOp>(
           curLoc, fatPtrBase.getType(), fatPtrBase, origOffset);
-      newAddPtrOp.getOperation()->setDiscardableAttrs(propagatedAttrs);
+      newAddPtrOp->setDiscardableAttrs(propagatedAttrs);
 
       rewriter.replaceOpWithMultiple(addPtrOp, {{newAddPtrOp, fatPtrOffset}});
       fatPtrs[{newAddPtrOp, fatPtrOffset}] =
@@ -590,7 +590,7 @@ public:
             maybeGetOrCreateScalarConstant(rewriter, curLoc, origOffset)) {
       tt::AddPtrOp newAddPtrOp = rewriter.create<tt::AddPtrOp>(
           curLoc, fatPtrBase.getType(), fatPtrBase, *scalarConst);
-      newAddPtrOp.getOperation()->setDiscardableAttrs(propagatedAttrs);
+      newAddPtrOp->setDiscardableAttrs(propagatedAttrs);
 
       rewriter.replaceOpWithMultiple(addPtrOp, {{newAddPtrOp, fatPtrOffset}});
       // If we are updating the tensor pointer with a constant value, we can
@@ -607,7 +607,7 @@ public:
 
     auto newAddPtrOp = rewriter.create<tt::AddPtrOp>(
         curLoc, fatPtrBase.getType(), fatPtrBase, uniformOffset);
-    newAddPtrOp.getOperation()->setDiscardableAttrs(propagatedAttrs);
+    newAddPtrOp->setDiscardableAttrs(propagatedAttrs);
 
     // Vector offset update (if any): bump the tensor offset
     bool canNarrow = fatPtrs.at({fatPtrBase, fatPtrOffset}).canNarrow;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -563,8 +563,10 @@ public:
     rewriter.setInsertionPoint(addPtrOp);
 
     // Query all discardable attributes that we want to preserve
+    std::array<StringRef, 3> propagateList{"tt.divisibility", "tt.contiguity",
+                                           "tt.constancy"};
     SmallVector<NamedAttribute> propagatedAttrs =
-        getAllowedDiscardableAttrs(addPtrOp);
+        tt::filterDiscardableAttrs(addPtrOp.getOperation(), propagateList);
 
     // If it is a scalar pointer update, simply bump the base pointer
     if (llvm::isa<tt::PointerType>(addPtrOp.getPtr().getType())) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "llvm/ADT/STLExtras.h"
@@ -562,14 +563,8 @@ public:
     rewriter.setInsertionPoint(addPtrOp);
 
     // Query all discardable attributes that we want to preserve
-    std::array<StringRef, 3> allowList{"tt.divisibility", "tt.contiguity",
-                                       "tt.constancy"};
-    SmallVector<NamedAttribute> propagatedAttrs;
-    for (auto attrName : allowList) {
-      Attribute attr = addPtrOp->getDiscardableAttr(attrName);
-      if (attr)
-        propagatedAttrs.emplace_back(attrName, attr);
-    }
+    SmallVector<NamedAttribute> propagatedAttrs =
+        getAllowedDiscardableAttrs(addPtrOp);
 
     // If it is a scalar pointer update, simply bump the base pointer
     if (llvm::isa<tt::PointerType>(addPtrOp.getPtr().getType())) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -561,14 +561,23 @@ public:
     RewriterBase::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(addPtrOp);
 
+    // Query all discardable attributes that we want to preserve
+    std::array<StringRef, 3> allowList{"tt.divisibility", "tt.contiguity",
+                                       "tt.constancy"};
+    SmallVector<NamedAttribute> propagatedAttrs;
+    for (auto attrName : allowList) {
+      Attribute attr = addPtrOp->getDiscardableAttr(attrName);
+      if (attr)
+        propagatedAttrs.emplace_back(attrName, attr);
+    }
+
     // If it is a scalar pointer update, simply bump the base pointer
     if (llvm::isa<tt::PointerType>(addPtrOp.getPtr().getType())) {
       assert(llvm::isa<IntegerType>(origOffset.getType()) &&
              "expected offset to be integer type");
       auto newAddPtrOp = rewriter.create<tt::AddPtrOp>(
           curLoc, fatPtrBase.getType(), fatPtrBase, origOffset);
-      newAddPtrOp.getOperation()->setDiscardableAttrs(
-          addPtrOp->getDiscardableAttrDictionary());
+      newAddPtrOp.getOperation()->setDiscardableAttrs(propagatedAttrs);
 
       rewriter.replaceOpWithMultiple(addPtrOp, {{newAddPtrOp, fatPtrOffset}});
       fatPtrs[{newAddPtrOp, fatPtrOffset}] =
@@ -584,8 +593,7 @@ public:
             maybeGetOrCreateScalarConstant(rewriter, curLoc, origOffset)) {
       tt::AddPtrOp newAddPtrOp = rewriter.create<tt::AddPtrOp>(
           curLoc, fatPtrBase.getType(), fatPtrBase, *scalarConst);
-      newAddPtrOp.getOperation()->setDiscardableAttrs(
-          addPtrOp->getDiscardableAttrDictionary());
+      newAddPtrOp.getOperation()->setDiscardableAttrs(propagatedAttrs);
 
       rewriter.replaceOpWithMultiple(addPtrOp, {{newAddPtrOp, fatPtrOffset}});
       // If we are updating the tensor pointer with a constant value, we can
@@ -602,8 +610,7 @@ public:
 
     auto newAddPtrOp = rewriter.create<tt::AddPtrOp>(
         curLoc, fatPtrBase.getType(), fatPtrBase, uniformOffset);
-    newAddPtrOp.getOperation()->setDiscardableAttrs(
-        addPtrOp->getDiscardableAttrDictionary());
+    newAddPtrOp.getOperation()->setDiscardableAttrs(propagatedAttrs);
 
     // Vector offset update (if any): bump the tensor offset
     bool canNarrow = fatPtrs.at({fatPtrBase, fatPtrOffset}).canNarrow;


### PR DESCRIPTION
Combine and canonicalize remove the attributes that relate to alignment so we don't get vectorization of stores in some cases, this allows them to keep it.
These two attributes are important to keep :tt.contiguity tt.divisibility. This PR will also possibly copy more, do we want a allowlist instead?

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
