### PR TITLE
[Bug fix] tl.dot(a, b, None)

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2034,6 +2034,7 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
     input_precision = _unwrap_if_constexpr(input_precision)
     out_dtype = _unwrap_if_constexpr(out_dtype)
     max_num_imprecise_acc = _unwrap_if_constexpr(max_num_imprecise_acc)
+    acc = _unwrap_if_constexpr(acc)
     return _semantic.dot(input, other, acc, input_precision, max_num_imprecise_acc, out_dtype)
 
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1523,7 +1523,7 @@ class TritonSemantic(Generic[TensorTy]):
         K = lhs.type.shape[-1]
         B = lhs.type.shape[0] if lhs_rank == 3 else None
         ret_ty = tl.block_type(ret_scalar_ty, [B, M, N] if B else [M, N])
-        if acc is None:
+        if tl._unwrap_if_constexpr(acc) is None:
             acc_handle = self.builder.create_splat(ret_ty.to_ir(self.builder), _0)
         else:
             acc_handle = acc.handle

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1523,7 +1523,7 @@ class TritonSemantic(Generic[TensorTy]):
         K = lhs.type.shape[-1]
         B = lhs.type.shape[0] if lhs_rank == 3 else None
         ret_ty = tl.block_type(ret_scalar_ty, [B, M, N] if B else [M, N])
-        if tl._unwrap_if_constexpr(acc) is None:
+        if acc is None:
             acc_handle = self.builder.create_splat(ret_ty.to_ir(self.builder), _0)
         else:
             acc_handle = acc.handle


### PR DESCRIPTION
If user passes None explicitly to `acc` in tl.dot, it will fail when accessing acc.handle from a constexpr[None].

```
        if acc is None:
            acc_handle = builder.create_splat(ret_ty.to_ir(builder), _0)
        else:
>           acc_handle = acc.handle
E           AttributeError: 'constexpr' object has no attribute 'handle'
```

Test plan:
1. randomly pick a unit test `pytest python/test/unit/language/test_core.py::test_dot[1-32-32-32-4-False-False-add-cols-ieee-float16-float16-1-None]`
2. add None to tl.dot