### PR TITLE
[PROTON-DEV] Support passing a list of optimizations in mode

### DIFF
--- a/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
@@ -211,9 +211,11 @@ void InstrumentationProfiler::exitInstrumentedOp(uint64_t streamId,
   }
 
   uint32_t timeShiftCost = 0;
-  if (modeOptions.count("optimization") &&
-      modeOptions.at("optimization") == "time_shift") {
-    timeShiftCost = getTimeShiftCost(*circularLayoutConfig);
+  if (modeOptions.count("optimizations")) {
+    auto optimizations = proton::split(modeOptions.at("optimizations"), ",");
+    if (std::find(optimizations.begin(), optimizations.end(), "time_shift") !=
+        optimizations.end())
+      timeShiftCost = getTimeShiftCost(*circularLayoutConfig);
   }
 
   auto &scopeIdContexts = functionScopeIdContexts[functionId];

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -100,7 +100,11 @@ def _interpret_mode(mode_obj: Union[str, mode.InstrumentationMode]) -> mode.Inst
     options["granularity"] = get_option_value("granularity", mode.granularities)
     options["sampling_strategy"] = get_option_value("sampling_strategy", mode.sampling_strategies)
 
-    values = [value.strip() for value in options["optimizations"].split(",")]
+    values = (
+        [value.strip() for value in options["optimizations"].split(",")]
+        if len(options["optimizations"]) > 0
+        else []
+    )
     for value in values:
         if value not in mode.optimizations:
             raise ValueError(f"Unknown optimization: {value}")

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -162,7 +162,7 @@ class InstrumentationHook(Hook):
                                                           self.mode.buffer_size, max_shared_mem,
                                                           self.profile_buffer_size, self.profile_buffer_alignment)
 
-            if mode.Optimize.SCHED_STORES in (self.mode.optimizations or []):
+            if mode.Optimize.SCHED_STORES in self.mode.optimizations:
                 triton_proton.add_schedule_buffer_store(pm)
 
             triton_proton.add_allocate_proton_shared_memory(pm)

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -83,7 +83,7 @@ def _interpret_mode(mode_obj: Union[str, mode.InstrumentationMode]) -> mode.Inst
         "metric_type": opts.get("metric_type", "cycle"), "buffer_type": opts.get("buffer_type", "shared"),
         "buffer_strategy": opts.get("buffer_strategy", "circular"), "buffer_size": int(opts.get("buffer_size", "0")),
         "granularity": opts.get("granularity", "warp"), "sampling_strategy": opts.get("sampling_strategy", "none"),
-        "sampling_options": opts.get("sampling_options", ""), "optimization": opts.get("optimization", "none")
+        "sampling_options": opts.get("sampling_options", ""), "optimizations": opts.get("optimizations", "")
     }
 
     # Helper function to validate and map options to their enum values
@@ -99,6 +99,12 @@ def _interpret_mode(mode_obj: Union[str, mode.InstrumentationMode]) -> mode.Inst
     options["buffer_strategy"] = get_option_value("buffer_strategy", mode.buffer_strategies)
     options["granularity"] = get_option_value("granularity", mode.granularities)
     options["sampling_strategy"] = get_option_value("sampling_strategy", mode.sampling_strategies)
+
+    values = [value.strip() for value in options["optimizations"].split(",")]
+    for value in values:
+        if value not in mode.optimizations:
+            raise ValueError(f"Unknown optimization: {value}")
+    options["optimizations"] = [mode.optimizations[value] for value in values]
 
     # Create the appropriate mode instance
     if mode_name == "default":
@@ -159,7 +165,7 @@ class InstrumentationHook(Hook):
                                                           self.mode.buffer_size, max_shared_mem,
                                                           self.profile_buffer_size, self.profile_buffer_alignment)
 
-            if self.mode.optimization == mode.Optimize.SCHED_STORES:
+            if mode.Optimize.SCHED_STORES in (self.mode.optimizations or []):
                 triton_proton.add_proton_schedule_buffer_store(pm)
 
             triton_proton.add_allocate_proton_shared_memory(pm)

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -100,11 +100,8 @@ def _interpret_mode(mode_obj: Union[str, mode.InstrumentationMode]) -> mode.Inst
     options["granularity"] = get_option_value("granularity", mode.granularities)
     options["sampling_strategy"] = get_option_value("sampling_strategy", mode.sampling_strategies)
 
-    values = (
-        [value.strip() for value in options["optimizations"].split(",")]
-        if len(options["optimizations"]) > 0
-        else []
-    )
+    values = ([value.strip()
+               for value in options["optimizations"].split(",")] if len(options["optimizations"]) > 0 else [])
     for value in values:
         if value not in mode.optimizations:
             raise ValueError(f"Unknown optimization: {value}")

--- a/third_party/proton/proton/mode.py
+++ b/third_party/proton/proton/mode.py
@@ -101,7 +101,6 @@ class InstrumentationMode(BaseMode):
                     raise ValueError(f"Unknown optimization: {value}")
             object.__setattr__(self, "optimizations", [optimizations[value] for value in values])
 
-
     def __str__(self):
         optimizations_str = ",".join([str(opt) for opt in self.optimizations or []])
         return (f"{self.name}:metric_type={self.metric_type}:sampling_strategy={self.sampling_strategy}"

--- a/third_party/proton/proton/mode.py
+++ b/third_party/proton/proton/mode.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from triton._C.libtriton import proton as triton_proton
+from typing import List, Optional
 from enum import Enum
 
 metric_types = {"cycle": triton_proton.METRIC_TYPE.CYCLE}
@@ -33,12 +34,17 @@ granularities = {
 
 
 class Optimize(Enum):
-    NONE = "none"
     TIMESHIFT = "time_shift"
     SCHED_STORES = "sched_stores"
 
     def __str__(self):
         return self.value
+
+
+optimizations = {
+    "time_shift": Optimize.TIMESHIFT,
+    "sched_stores": Optimize.SCHED_STORES,
+}
 
 
 @dataclass(frozen=True)
@@ -69,7 +75,7 @@ class InstrumentationMode(BaseMode):
     buffer_strategy: triton_proton.BUFFER_STRATEGY = triton_proton.BUFFER_STRATEGY.CIRCULAR
     buffer_type: triton_proton.BUFFER_TYPE = triton_proton.BUFFER_TYPE.SHARED
     buffer_size: int = 0
-    optimization: Optimize = Optimize.NONE
+    optimizations: Optional[List[Optimize]] = None
 
     def __post_init__(self):
         # automatically map string inputs to enums using the global lookup dicts
@@ -87,11 +93,21 @@ class InstrumentationMode(BaseMode):
                     raise ValueError(f"Unknown {field_name}: {value}")
                 object.__setattr__(self, field_name, lookup[value])
 
+        values_str = getattr(self, "optimizations")
+        if isinstance(values_str, str):
+            values = [value.strip() for value in values_str.split(",")] if len(values_str) > 0 else []
+            for value in values:
+                if value not in optimizations:
+                    raise ValueError(f"Unknown optimization: {value}")
+            object.__setattr__(self, "optimizations", [optimizations[value] for value in values])
+
+
     def __str__(self):
+        optimizations_str = ",".join([str(opt) for opt in self.optimizations or []])
         return (f"{self.name}:metric_type={self.metric_type}:sampling_strategy={self.sampling_strategy}"
                 f":sampling_options={self.sampling_options}:granularity={self.granularity}"
                 f":buffer_strategy={self.buffer_strategy}:buffer_type={self.buffer_type}"
-                f":buffer_size={self.buffer_size}:optimization={self.optimization}")
+                f":buffer_size={self.buffer_size}:optimizations={optimizations_str}")
 
 
 @dataclass(frozen=True)

--- a/third_party/proton/proton/mode.py
+++ b/third_party/proton/proton/mode.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from triton._C.libtriton import proton as triton_proton
-from typing import List, Optional
+from typing import List
 from enum import Enum
 
 metric_types = {"cycle": triton_proton.METRIC_TYPE.CYCLE}
@@ -75,7 +75,7 @@ class InstrumentationMode(BaseMode):
     buffer_strategy: triton_proton.BUFFER_STRATEGY = triton_proton.BUFFER_STRATEGY.CIRCULAR
     buffer_type: triton_proton.BUFFER_TYPE = triton_proton.BUFFER_TYPE.SHARED
     buffer_size: int = 0
-    optimizations: Optional[List[Optimize]] = None
+    optimizations: List[Optimize] = field(default_factory=list)
 
     def __post_init__(self):
         # automatically map string inputs to enums using the global lookup dicts
@@ -102,7 +102,7 @@ class InstrumentationMode(BaseMode):
             object.__setattr__(self, "optimizations", [optimizations[value] for value in values])
 
     def __str__(self):
-        optimizations_str = ",".join([str(opt) for opt in self.optimizations or []])
+        optimizations_str = ",".join([str(opt) for opt in self.optimizations])
         return (f"{self.name}:metric_type={self.metric_type}:sampling_strategy={self.sampling_strategy}"
                 f":sampling_options={self.sampling_options}:granularity={self.granularity}"
                 f":buffer_strategy={self.buffer_strategy}:buffer_type={self.buffer_type}"

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -347,7 +347,7 @@ def test_trace(tmp_path: pathlib.Path):
 
 def test_timeline(tmp_path: pathlib.Path):
     temp_file = tmp_path / "test_timeline.chrome_trace"
-    mode = proton.mode.Default(metric_type="cycle", optimization="time_shift")
+    mode = proton.mode.Default(metric_type="cycle", optimizations="time_shift")
     proton.start(str(temp_file.with_suffix("")), data="trace", backend="instrumentation", mode=mode)
 
     @triton.jit


### PR DESCRIPTION
This PR adds the ability to provide a comma separated list of 
optimizations to mode. We have just `TIME_SHIFT` and `SCHED_STORES`
optimizations for now. `TIME_SHIFT` optimization doesn't support 
handling SCHED_STORES in the current state but can be extended 
to support it. This is being added so that in future when we have more 
such optimizations we can allow users to specify multiple of them 
instead of just one.

Tested this locally with a test script by using different combinations of 
`time_shift` and `sched_stores` in optimizations. Even though using them 
together will produce inconsistent results it was useful to test that the 
ability to provide a list of options.