### PR TITLE
[Hopper][WS] Update pipeline to get GEMM/FA working

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -223,6 +223,14 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
+    SmallVector<scf::ForOp> loops;
+    getOperation()->walk([&](scf::ForOp forOp) {
+      // Bail out for loops with num_stage < 1.
+      if (getNumStagesOrDefault(forOp, numStages) >= 1)
+        loops.push_back(forOp);
+    });
+    if (loops.empty())
+      return;
 
     // Transform the loop by introducing async operations to prepare it for
     // pipeline expansion.

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -33,12 +33,13 @@ namespace gpu {
 #define GEN_PASS_DEF_TRITONGPUPIPELINE
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
 
-static void pipelineWgmma(ModuleOp moduleOp) {
+static void pipelineWgmma(ModuleOp moduleOp, unsigned numStages) {
   SmallVector<scf::ForOp> loops;
   moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
 
   for (scf::ForOp forOp : loops) {
-    mlir::triton::asyncLaunchDots(forOp);
+    if (getNumStagesOrDefault(forOp, numStages) >= 1)
+      mlir::triton::asyncLaunchDots(forOp);
   }
 }
 
@@ -223,15 +224,6 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
-    SmallVector<scf::ForOp> loops;
-    getOperation()->walk([&](scf::ForOp forOp) {
-      // Bail out for loops with num_stage < 1.
-      if (getNumStagesOrDefault(forOp, numStages) >= 1)
-        loops.push_back(forOp);
-    });
-    if (loops.empty())
-      return;
-
     // Transform the loop by introducing async operations to prepare it for
     // pipeline expansion.
     lowerLoops(moduleOp);
@@ -252,7 +244,7 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
     // Cleanup the IR from the pipeline attributes.
     removeAttributes(moduleOp);
 
-    pipelineWgmma(moduleOp);
+    pipelineWgmma(moduleOp, numStages);
 
     // schedule the waits
     mlir::triton::updateWaits(getOperation());

--- a/python/tutorials/09-persistent-matmul.py
+++ b/python/tutorials/09-persistent-matmul.py
@@ -570,6 +570,136 @@ def matmul_descriptor_persistent(a, b, warp_specialize: bool):
     return c
 
 
+def matmul_tma_ws_cooperative_get_configs(pre_hook=None):
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 256,
+                "BLOCK_SIZE_K": 64,
+                "GROUP_SIZE_M": 8,
+                "EPILOGUE_SUBTILE": False,
+            },
+            num_stages=2,
+            num_warps=4,
+            pre_hook=pre_hook,
+        ),
+    ]
+
+
+@triton.autotune(
+    configs=matmul_tma_ws_cooperative_get_configs(),
+    key=["M", "N", "K"],
+    use_cuda_graph=True,
+)
+@triton.jit(launch_metadata=_matmul_launch_metadata)
+def matmul_kernel_persistent_tma_ws_cooperative(a_ptr, b_ptr, c_ptr, M, N, K, BLOCK_SIZE_M: tl.constexpr,
+                                                BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,  #
+                                                GROUP_SIZE_M: tl.constexpr,  #
+                                                FP8_OUTPUT: tl.constexpr,  #
+                                                NUM_SMS: tl.constexpr,  #
+                                                EPILOGUE_SUBTILE: tl.constexpr,  #
+                                                ):
+    dtype = tl.float8e4nv if FP8_OUTPUT else tl.float16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    a_desc = tl.make_tensor_descriptor(
+        a_ptr,
+        shape=[M, K],
+        strides=[K, 1],
+        block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
+    )
+    b_desc = tl.make_tensor_descriptor(
+        b_ptr,
+        shape=[N, K],
+        strides=[K, 1],
+        block_shape=[BLOCK_SIZE_N, BLOCK_SIZE_K],
+    )
+    c_desc = tl.make_tensor_descriptor(
+        c_ptr,
+        shape=[M, N],
+        strides=[N, 1],
+        block_shape=[
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N if not EPILOGUE_SUBTILE else BLOCK_SIZE_N // 2,
+        ],
+    )
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    # Enable warp specialization to leverage async warp scheduling in the GPU.
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, warp_specialize=True):
+        pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m, pid_n = _compute_pid(tile_id_c, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        # Epilogue subtiling is a technique to break our computation and stores into multiple pieces
+        # By subtiling we can reduce shared memory consumption by the epilogue and instead use that
+        # memory to increase our stage count.
+        # In this case we partition the accumulator into 2 BLOCK_SIZE_M x BLOCK_SIZE_N // 2 tensors
+        if EPILOGUE_SUBTILE:
+            acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+            acc = tl.permute(acc, (0, 2, 1))
+            acc0, acc1 = tl.split(acc)
+            c0 = acc0.to(dtype)
+            c_desc.store([offs_am_c, offs_bn_c], c0)
+            c1 = acc1.to(dtype)
+            c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        else:
+            accumulator = accumulator.to(dtype)
+            c_desc.store([offs_am_c, offs_bn_c], accumulator)
+
+
+def matmul_persistent_tma_ws_cooperative(a, b):
+    # Check constraints.
+    assert a.shape[1] == b.shape[1], "Incompatible dimensions"  # b is transposed
+    assert a.dtype == b.dtype, "Incompatible dtypes"
+
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    # TMA descriptors require a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    grid = lambda META: (min(
+        NUM_SMS,
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+    ), )
+
+    matmul_kernel_persistent_tma_ws_cooperative[grid](
+        a, b, c,  #
+        M, N, K,  #
+        FP8_OUTPUT=dtype == torch.float8_e4m3fn,  #
+        NUM_SMS=NUM_SMS,  #
+    )
+    return c
+
+
 def cublas_matmul(a, b):
     # Check constraints.
     assert a.shape[1] == b.shape[1], "Incompatible dimensions"  # b is transposed
@@ -638,6 +768,7 @@ def bench(K, dtype, reps=10000, warmup_reps=10000):
         if HAS_TENSOR_DESC:
             bench_fn(f"descriptor_persistent{ws_str}", reps, warmup_reps,
                      lambda a, b: matmul_descriptor_persistent(a, b, ws), a, b)
+    bench_fn("WS cooperative", reps, warmup_reps, matmul_persistent_tma_ws_cooperative, a, b)
 
 
 def run_test(expect, fn, a, b, label, enabled=True):
@@ -661,6 +792,7 @@ def validate(M, N, K, dtype):
     run_test(naive_result, torch_matmul, a, b, "Torch", enabled=dtype == torch.float16)
     run_test(naive_result, cublas_matmul, a, b, "cuBLAS", enabled=cublas is not None)
     run_test(naive_result, matmul_persistent, a, b.T, "Persistent")
+    run_test(naive_result, matmul_persistent_tma_ws_cooperative, a, b, "WS Cooperative")
 
     kernels = [
         (matmul_tma, "TMA", HAS_HOST_TENSOR_DESC),

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -259,6 +259,7 @@ class CUDABackend(BaseBackend):
             passes.ttir.add_triton_licm(pm)
             passes.common.add_canonicalizer(pm)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
+            nvidia.passes.hopperws.add_hopper_warpspec(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_assign_latencies(pm, opt.num_stages)
             passes.ttgpuir.add_schedule_loops(pm)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -259,7 +259,7 @@ class CUDABackend(BaseBackend):
             passes.ttir.add_triton_licm(pm)
             passes.common.add_canonicalizer(pm)
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
-            nvidia.passes.hopperws.add_hopper_warpspec(pm, opt.num_stages, dump_enabled)
+            nvidia.passes.hopper.add_hopper_warpspec(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_assign_latencies(pm, opt.num_stages)
             passes.ttgpuir.add_schedule_loops(pm)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -14,9 +14,12 @@ def NVGPUWarpSpecialization : Pass<"nvgpu-warp-specialization", "mlir::ModuleOp"
 
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];
   let options = [
-    Option<"numWarpGroups", "num-warp-groups",
+    Option<"numStages", "num-stages",
            "int32_t", /*default*/"0",
-           "number of warp groups for warp specialization">
+           "number of buffers for warp specialization">,
+    Option<"dumpIntermediateSteps", "dump-intermediate-steps",
+           "bool", /*default*/"false",
+           "Dump intermediate steps">
   ];
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_triton_library(NVHopperTransforms
   WarpSpecialization/WSCodePartition.cpp
   WarpSpecialization/WSDataPartition.cpp
   WarpSpecialization/WSLowerMem.cpp
+  WarpSpecialization/WSLowerToken.cpp
   WarpSpecialization/WSSpecialize.cpp
   WarpSpecialization/WSTaskIdPropagate.cpp
   WarpSpecialization/WSTaskPartition.cpp

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -34,6 +34,11 @@ public:
     });
     if (loops.empty())
       return;
+
+    int numWarps = mlir::triton::gpu::lookupNumWarps(funcOp);
+    if (numWarps != 4)
+      return;
+
     // FIXME: skip warpspec if there is else block. Need to improve
     // CodePartitioning to correctly handle channels in else block.
     bool hasElse = false;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -34,7 +34,8 @@ public:
     });
     if (loops.empty())
       return;
-    // FIXME: skip warpspec if there is else block.
+    // FIXME: skip warpspec if there is else block. Need to improve
+    // CodePartitioning to correctly handle channels in else block.
     bool hasElse = false;
     funcOp->walk([&](scf::IfOp ifOp) {
       if (ifOp.elseBlock()) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -3,6 +3,7 @@
 #include "mlir/Transforms/Passes.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 
 #define DEBUG_TYPE "nvgpu-warp-specialization"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -11,7 +12,10 @@
 namespace mlir {
 
 void doTaskPartition(triton::FuncOp &funcOp, unsigned numWarpGroups);
+int doTaskIdPropagate(triton::FuncOp &funcOp);
 bool doDataPartition(triton::FuncOp &funcOp, unsigned numConsumerGroups);
+void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers);
+void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups);
 
 #define GEN_PASS_DEF_NVGPUWARPSPECIALIZATION
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"
@@ -23,15 +27,63 @@ public:
       NVGPUWarpSpecializationPass>::NVGPUWarpSpecializationBase;
 
   void runOnFuncOp(triton::FuncOp funcOp) {
-    if (numWarpGroups <= 1)
+    SmallVector<scf::ForOp> loops;
+    funcOp->walk([&](scf::ForOp forOp) {
+      if (forOp->hasAttr(mlir::triton::kWarpSpecializeAttrName))
+        loops.push_back(forOp);
+    });
+    if (loops.empty())
       return;
 
-    // Partition key ops into multiple async tasks.
-    doTaskPartition(funcOp, numWarpGroups);
+    OpBuilder builder(funcOp);
+    auto moduleOp = funcOp->getParentOfType<ModuleOp>();
+    unsigned numWarpGroups = 3;
+    bool success = false;
+    for (; numWarpGroups >= 2; numWarpGroups--) {
+      // Partition key ops into multiple async tasks.
+      doTaskPartition(funcOp, numWarpGroups);
+      if (dumpIntermediateSteps) {
+        llvm::dbgs()
+            << "// -----// WarpSpec internal IR Dump After: doTaskPartition\n"
+            << moduleOp << "\n\n\n";
+      }
+      // Propagate taskId.
+      int retCode = doTaskIdPropagate(funcOp);
+      if (retCode == -1)
+        continue;
+      if (dumpIntermediateSteps) {
+        llvm::dbgs()
+            << "// -----// WarpSpec internal IR Dump After: doTaskIdPropagate\n"
+            << moduleOp << "\n\n\n";
+      }
 
-    // Partition ops into parallel sub ops.
-    if (!doDataPartition(funcOp, numWarpGroups - 1))
+      // Partition ops into parallel sub ops.
+      if (doDataPartition(funcOp, numWarpGroups - 1)) {
+        if (dumpIntermediateSteps) {
+          llvm::dbgs()
+              << "// -----// WarpSpec internal IR Dump After: doDataPartition\n"
+              << moduleOp << "\n\n\n";
+        }
+        success = true;
+        break;
+      }
+      // Clear async_task.
+    }
+    if (!success)
       signalPassFailure();
+
+    doCodePartition(funcOp, numStages);
+    if (dumpIntermediateSteps) {
+      llvm::dbgs()
+          << "// -----// WarpSpec internal IR Dump After: doCodePartition\n"
+          << moduleOp << "\n\n\n";
+    }
+    doTokenLowering(funcOp, numWarpGroups - 1);
+    // Clear num_stages to disable SWP.
+    funcOp->walk([&](scf::ForOp forOp) {
+      forOp->setAttr(mlir::triton::kNumStagesAttrName,
+                     builder.getI32IntegerAttr(0));
+    });
   }
 
   void runOnOperation() override {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TaskIdPropagation.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TaskIdPropagation.h
@@ -91,6 +91,9 @@ public:
 
   void propagateToYield(scf::YieldOp yieldOp, SmallVector<TaskId> &lattices);
 
+  void propagateToTerminator(Operation *op,
+                             ArrayRef<const TaskIdLattice *> &lattices);
+
   void propagateToParent(Operation *op, const TaskId &taskId);
 };
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1178,8 +1178,7 @@ void foldLocalLoads(triton::FuncOp funcOp) {
                                               kv.getSecond());
 }
 
-void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers,
-                     unsigned requestedRegisters) {
+void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
   // Step 1: collect all communications between producers and consumers.
   SmallVector<std::unique_ptr<Channel>> channelsOrigin;
   collectAsyncChannels(channelsOrigin, funcOp, numBuffers);
@@ -1269,7 +1268,7 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers,
     funcOp.dump();
   });
 
-  specializeRegion(funcOp, requestedRegisters);
+  specializeRegion(funcOp, 0 /*requestedRegisters*/);
   LLVM_DEBUG({
     LDBG("\n\nwith specializeRegion");
     funcOp.dump();
@@ -1288,7 +1287,7 @@ public:
   void runOnFuncOp(triton::FuncOp funcOp) {
     // Disable code partitioning when numBuffers is 0.
     if (numBuffers > 0)
-      doCodePartition(funcOp, numBuffers, requestedRegisters);
+      doCodePartition(funcOp, numBuffers);
   }
   void runOnOperation() override {
     getOperation()->walk([&](triton::FuncOp funcOp) { runOnFuncOp(funcOp); });

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -47,6 +47,9 @@ static void fixTaskId(triton::FuncOp &funcOp) {
         auto defTaskIds = getAsyncTaskIds(defOp);
         // Backward propagation: ensure def covers op's task IDs.
         if (!containsAll(defTaskIds, asyncTaskIds)) {
+          // Skip control flow ops.
+          if (isa<scf::YieldOp, scf::ForOp, scf::IfOp>(op))
+            continue;
           // Only propagate backward to arithmetic ops (e.g. constants).
           // Const ops with same value but different task ids can be folded.
           if (defOp->getDialect()->getNamespace() == "arith") {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -1,0 +1,353 @@
+#include "Utility.h"
+#include "mlir/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+
+#include <set>
+
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+namespace ttnvws = ::mlir::triton::nvws;
+namespace mlir {
+
+#define DEBUG_TYPE "tritongpu-warp-spec-lowering"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+static Value createThreadIdOp(OpBuilder &builder, Location loc) {
+  Value threadId = builder.create<::mlir::gpu::ThreadIdOp>(
+      loc, builder.getIndexType(), ::mlir::gpu::Dimension::x);
+  auto cast = builder.create<UnrealizedConversionCastOp>(
+      loc, TypeRange{builder.getIntegerType(32)}, ValueRange{threadId});
+  return cast.getResult(0);
+}
+
+// Lower to use GetCanonicalWarpIdOp.
+// In Hopper, each task is a warpgroup consisting of 4 warps.
+static const int WARPS_PER_TASK = 4;
+static const int THREADS_PER_TASK = 128;
+#if 0
+void lowerGetAsyncTaskIdOp(Operation *parentOp, int numConsumerGroups) {
+  DenseSet<Operation *> eraseOps;
+  parentOp->walk([&](ttng::GetAsyncTaskIdOp op) {
+    auto loc = op.getLoc();
+    OpBuilder builder(op);
+    Value _4 = builder.create<arith::ConstantIntOp>(loc, WARPS_PER_TASK, 32);
+    Value warpId = builder.create<ttng::GetCanonicalWarpIdOp>(loc);
+    Value asyncTaskId = builder.create<arith::DivUIOp>(loc, warpId, _4);
+    op.getResult().replaceAllUsesWith(asyncTaskId);
+
+    LLVM_DEBUG({
+      LDBG("erasing GetAsyncTask");
+      op->dump();
+    });
+    eraseOps.insert(op);
+  });
+  for (Operation *op : eraseOps)
+    op->erase();
+}
+#endif
+
+Value getMBarrierPhaseBit(OpBuilder &builder, Operation *op,
+                          bool emptyBarrier) {
+  auto loc = op->getLoc();
+  assert(isa<ttnvws::ProducerAcquireOp>(op) || isa<ttnvws::ConsumerWaitOp>(op));
+  Value curPhase;
+  if (auto acq = dyn_cast<ttnvws::ProducerAcquireOp>(op))
+    curPhase = acq.getPhase();
+  else if (auto wait = dyn_cast<ttnvws::ConsumerWaitOp>(op))
+    curPhase = wait.getPhase();
+  if (emptyBarrier) {
+    // curPhase = curPhase xor True for emptyBarrier.
+    Value _1_1b = builder.create<arith::ConstantIntOp>(loc, 1, 1);
+    curPhase = builder.create<mlir::arith::XOrIOp>(loc, curPhase, _1_1b);
+  }
+  LLVM_DEBUG(curPhase.dump());
+  return curPhase;
+}
+
+void processProducerAcquireOp(OpBuilder &builder, ttnvws::ProducerAcquireOp op,
+                              Value bufferEmpty) {
+  auto loc = op.getLoc();
+  Value phase = getMBarrierPhaseBit(builder, op, true);
+  auto i32Ty = builder.getIntegerType(32);
+  phase = builder.create<arith::ExtUIOp>(loc, i32Ty, phase);
+  auto waitOp = builder.create<ttng::WaitBarrierOp>(loc, bufferEmpty, phase);
+  assert(op.getOperation()->hasAttr("async_task_id"));
+  setAsyncTaskIds(waitOp, getAsyncTaskIds(op.getOperation()));
+}
+
+void processProducerCommitOp(OpBuilder &builder, ttnvws::ProducerCommitOp op,
+                             Value bufferFull, ttnvws::TokenLoadType loadType,
+                             unsigned fullCnt) {
+  auto loc = op.getLoc();
+  ttng::ArriveBarrierOp arriveOp;
+
+  if (loadType == ttnvws::TokenLoadType::TMALoadOp) {
+    // Only thread 0 arrives for TMA load.
+    Value _0 = builder.create<arith::ConstantIntOp>(loc, 0, 32);
+    Value threadId = createThreadIdOp(builder, loc);
+    Value pred = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                               threadId, _0);
+    // Get the count from the barriers: trace the local_alloc for the barrier
+    // then find the count from init_barrier
+    arriveOp =
+        builder.create<ttng::ArriveBarrierOp>(loc, bufferFull, fullCnt, pred);
+  } else {
+#if 0
+    // Each thread arrives.
+    Value pred = builder.create<arith::ConstantIntOp>(loc, 1, 1);
+    arriveOp = builder.create<ttng::MBarrierArriveOp>(
+        loc, bufferFull, pred, /*remoteCTAId*/ nullptr, /*trackAsyncOp*/ true,
+        txCnt);
+#else
+    assert(false);
+#endif
+  }
+
+  assert(op.getOperation()->hasAttr("async_task_id"));
+  setAsyncTaskIds(arriveOp, getAsyncTaskIds(op.getOperation()));
+}
+
+void processConsumerWaitOp(OpBuilder &builder, ttnvws::ConsumerWaitOp op,
+                           Value bufferFull) {
+  auto loc = op.getLoc();
+  Value phase = getMBarrierPhaseBit(builder, op, false);
+  auto i32Ty = builder.getIntegerType(32);
+  phase = builder.create<arith::ExtUIOp>(loc, i32Ty, phase);
+  auto waitOp = builder.create<ttng::WaitBarrierOp>(loc, bufferFull, phase);
+  assert(op.getOperation()->hasAttr("async_task_id"));
+  setAsyncTaskIds(waitOp, getAsyncTaskIds(op.getOperation()));
+}
+
+void processConsumerReleaseOp(OpBuilder &builder, ttnvws::ConsumerReleaseOp op,
+                              Value bufferEmpty, int numCTAs,
+                              unsigned emptyCnt) {
+  auto loc = op.getLoc();
+  auto arriveOp =
+      builder.create<ttng::ArriveBarrierOp>(loc, bufferEmpty, emptyCnt);
+  assert(op.getOperation()->hasAttr("async_task_id"));
+  setAsyncTaskIds(arriveOp, getAsyncTaskIds(op.getOperation()));
+}
+
+void lowerTokenOperations(Operation *parentOp, int numCTAs,
+                          int numConsumerGroups) {
+  SmallVector<Operation *> deprecatedOps;
+  SmallVector<Operation *> deprecatedTokenOps;
+  DenseSet<Operation *> warpSpecOps;
+  DenseMap<Operation *, Value> tokenToFull;
+  DenseMap<Operation *, Value> tokenToEmpty;
+  parentOp->walk([&](ttnvws::CreateTokenOp createTokenOp) {
+    ttnvws::TokenLoadType loadType = createTokenOp.getLoadType();
+    MLIRContext *context = createTokenOp.getContext();
+    OpBuilder builder(createTokenOp);
+    Location loc = createTokenOp.getLoc();
+
+    Attribute sharedMemorySpace =
+        triton::gpu::SharedMemorySpaceAttr::get(context);
+    auto barrierCTALayout =
+        ttg::CTALayoutAttr::get(context, /*CTAsPerCGA=*/{1},
+                                /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
+    auto barrierEncoding = ttg::SwizzledSharedEncodingAttr::get(
+        context, 1, 1, 1, {0}, barrierCTALayout);
+    Type barrierMemDescType = ttg::MemDescType::get(
+        {createTokenOp.getNumBuffers()}, builder.getI64Type(), barrierEncoding,
+        sharedMemorySpace,
+        /*mutableMemory=*/true);
+    Type singleBarrierMemDescType =
+        ttg::MemDescType::get({1}, builder.getI64Type(), barrierEncoding,
+                              sharedMemorySpace, /*mutableMemory=*/true);
+    // These are created prior to warp_specialize.
+    Value bufferFullArray = builder.create<mlir::triton::gpu::LocalAllocOp>(
+        loc, barrierMemDescType, Value());
+    Value bufferEmptyArray = builder.create<mlir::triton::gpu::LocalAllocOp>(
+        loc, barrierMemDescType, Value());
+    tokenToFull[createTokenOp.getOperation()] = bufferFullArray;
+    tokenToEmpty[createTokenOp.getOperation()] = bufferEmptyArray;
+
+    unsigned bufferFullCount =
+        loadType == ttnvws::TokenLoadType::TMALoadOp ? 1 : THREADS_PER_TASK;
+    unsigned bufferEmptyCount = THREADS_PER_TASK;
+    for (unsigned i = 0; i < createTokenOp.getNumBuffers(); i++) {
+      Value idx = builder.create<arith::ConstantIntOp>(loc, i, 32);
+      Value barrierFullView = builder.create<ttg::MemDescSubviewOp>(
+          loc, singleBarrierMemDescType, bufferFullArray, idx);
+      // EmptyView is used for ConsumerRelease and ProducerAcquire.
+      // FullView is for ConsumerWait and ProducerCommit.
+      builder.create<ttng::InitBarrierOp>(loc, barrierFullView,
+                                          bufferFullCount);
+
+      Value barrierEmptyView = builder.create<ttg::MemDescSubviewOp>(
+          loc, singleBarrierMemDescType, bufferEmptyArray, idx);
+      builder.create<ttng::InitBarrierOp>(loc, barrierEmptyView,
+                                          bufferEmptyCount);
+    }
+
+    assert(numCTAs == 1 && "remote CTA is not supported yet");
+    builder.create<mlir::gpu::BarrierOp>(loc);
+
+    // Helper function for extracting one index from bufferFullArray.
+    auto extractBufferFull = [&](Location loc, Value idx) -> Value {
+      return builder.create<ttg::MemDescSubviewOp>(
+          loc, singleBarrierMemDescType, bufferFullArray, idx);
+    };
+
+    // Helper function for extracting one index from bufferEmptyArray.
+    auto extractBufferEmpty = [&](Location loc, Value idx) -> Value {
+      return builder.create<ttg::MemDescSubviewOp>(
+          loc, singleBarrierMemDescType, bufferEmptyArray, idx);
+    };
+    auto handleOneUser = [&](Operation *user) -> bool {
+      // Here builder is at the user, make sure usage of values outside of
+      // warp_specialize is via capture if user is in a partition region.
+      // We need bufferFullArray and bufferEmptyArray.
+      if (auto op = dyn_cast<ttnvws::ProducerAcquireOp>(user)) {
+        Value bufferEmpty = extractBufferEmpty(loc, op.getIdx());
+        auto pOp = user->getParentOp();
+        assert(user->hasAttr("async_task_id"));
+        setAsyncTaskIds(bufferEmpty.getDefiningOp(), getAsyncTaskIds(user));
+        processProducerAcquireOp(builder, op, bufferEmpty);
+        deprecatedOps.push_back(user);
+        return true;
+      } else if (auto op = dyn_cast<ttnvws::ProducerCommitOp>(user)) {
+        Value bufferFull = extractBufferFull(loc, op.getIdx());
+        assert(user->hasAttr("async_task_id"));
+        setAsyncTaskIds(bufferFull.getDefiningOp(), getAsyncTaskIds(user));
+        processProducerCommitOp(builder, op, bufferFull, loadType,
+                                bufferFullCount);
+        deprecatedOps.push_back(user);
+        return true;
+      } else if (auto op = dyn_cast<ttnvws::ConsumerWaitOp>(user)) {
+        Value bufferFull = extractBufferFull(loc, op.getIdx());
+        assert(user->hasAttr("async_task_id"));
+        setAsyncTaskIds(bufferFull.getDefiningOp(), getAsyncTaskIds(user));
+        processConsumerWaitOp(builder, op, bufferFull);
+        deprecatedOps.push_back(user);
+        return true;
+      } else if (auto op = dyn_cast<ttnvws::ConsumerReleaseOp>(user)) {
+        Value bufferEmpty = extractBufferEmpty(loc, op.getIdx());
+        assert(user->hasAttr("async_task_id"));
+        setAsyncTaskIds(bufferEmpty.getDefiningOp(), getAsyncTaskIds(user));
+        processConsumerReleaseOp(builder, op, bufferEmpty, numCTAs,
+                                 bufferEmptyCount);
+        deprecatedOps.push_back(user);
+        return true;
+      }
+      return false;
+    };
+
+    // Process token users: ProducerAcquireOp, ProducerCommitOp, ConsumerWaitOp,
+    // and ConsumerReleaseOp.
+    for (OpOperand &use : createTokenOp.getResult().getUses()) {
+      Operation *user = use.getOwner();
+      auto loc = user->getLoc();
+      builder.setInsertionPoint(user);
+      bool handled = handleOneUser(user);
+      if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+        unsigned opndNum = use.getOperandNumber();
+        // Handle the regions. Trace uses of the argument corresponding to the
+        // captured value.
+        for (Region *region : wsOp.getPartitionRegions()) {
+          LDBG("-- region " << region->getNumArguments());
+          auto tArg = region->getArgument(opndNum);
+          for (Operation *tUser : tArg.getUsers()) {
+            builder.setInsertionPoint(tUser);
+            // Use of TokenOp via capture of warp_specialize.
+            handleOneUser(tUser);
+          }
+        }
+        warpSpecOps.insert(user);
+      } else if (!handled) {
+        llvm_unreachable("Unexpected user of token");
+      }
+    }
+
+    deprecatedTokenOps.push_back(createTokenOp);
+  });
+  for (auto op : deprecatedOps) {
+    LLVM_DEBUG({
+      LDBG("erasing deprecatedOps");
+      op->dump();
+    });
+    op->erase();
+  }
+  unsigned tokenRemoval = 0;
+  // Map from tokenOp to bufferFullArray, bufferEmptyArray.
+  // If a tokenOp is used by warp_specialize, remove it and add
+  // buffer[Full|Empty]Array.
+
+  for (auto op : deprecatedTokenOps) {
+    LLVM_DEBUG({
+      LDBG("erasing deprecatedOps");
+      op->dump();
+    });
+    ++tokenRemoval;
+    if (auto tokenOp = dyn_cast<ttnvws::CreateTokenOp>(op)) {
+      // Check to see if it is used by warpSpec. If yes, eraseOperand and
+      // eraseArgument.
+      for (OpOperand &use : tokenOp->getUses()) {
+        Operation *user = use.getOwner();
+        if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+          unsigned opndNum = use.getOperandNumber();
+          LDBG("wsOp user numOperands: " << wsOp->getNumOperands() << " idx "
+                                         << opndNum);
+
+          LLVM_DEBUG({
+            LDBG("prior to erasing " << tokenRemoval);
+            parentOp->dump();
+          });
+          wsOp->eraseOperand(opndNum);
+          Value empty = tokenToEmpty[op];
+          Value full = tokenToFull[op];
+          wsOp->insertOperands(wsOp.getNumOperands(), full);
+          wsOp->insertOperands(wsOp.getNumOperands(), empty);
+          // Handle the regions.
+          for (Region *region : wsOp.getPartitionRegions()) {
+            LDBG("-- region " << region->getNumArguments());
+            auto tArg = region->getArgument(opndNum);
+            for (Operation *tUser : tArg.getUsers()) {
+              LLVM_DEBUG({
+                LDBG("user for arg");
+                tUser->dump();
+              });
+            }
+            region->eraseArgument(opndNum);
+            BlockArgument arg =
+                region->addArgument(full.getType(), full.getLoc());
+            replaceAllUsesInRegionWith(full, arg, *region);
+            BlockArgument arg2 =
+                region->addArgument(empty.getType(), empty.getLoc());
+            replaceAllUsesInRegionWith(empty, arg2, *region);
+          }
+        }
+      }
+    }
+    op->erase();
+  }
+
+  assert(numCTAs == 1 && "remote CTA is not supported yet");
+  LLVM_DEBUG({
+    LDBG("after lowering");
+    parentOp->dump();
+  });
+}
+
+void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups) {
+  ModuleOp mod = funcOp.getOperation()->getParentOfType<ModuleOp>();
+  int numCTAs = ttg::TritonGPUDialect::getNumCTAs(mod);
+
+  // lowerGetAsyncTaskIdOp(mod, numConsumerGroups);
+  lowerTokenOperations(mod, numCTAs, numConsumerGroups);
+}
+
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -36,27 +36,6 @@ static Value createThreadIdOp(OpBuilder &builder, Location loc) {
 // In Hopper, each task is a warpgroup consisting of 4 warps.
 static const int WARPS_PER_TASK = 4;
 static const int THREADS_PER_TASK = 128;
-#if 0
-void lowerGetAsyncTaskIdOp(Operation *parentOp, int numConsumerGroups) {
-  DenseSet<Operation *> eraseOps;
-  parentOp->walk([&](ttng::GetAsyncTaskIdOp op) {
-    auto loc = op.getLoc();
-    OpBuilder builder(op);
-    Value _4 = builder.create<arith::ConstantIntOp>(loc, WARPS_PER_TASK, 32);
-    Value warpId = builder.create<ttng::GetCanonicalWarpIdOp>(loc);
-    Value asyncTaskId = builder.create<arith::DivUIOp>(loc, warpId, _4);
-    op.getResult().replaceAllUsesWith(asyncTaskId);
-
-    LLVM_DEBUG({
-      LDBG("erasing GetAsyncTask");
-      op->dump();
-    });
-    eraseOps.insert(op);
-  });
-  for (Operation *op : eraseOps)
-    op->erase();
-}
-#endif
 
 Value getMBarrierPhaseBit(OpBuilder &builder, Operation *op,
                           bool emptyBarrier) {
@@ -104,15 +83,7 @@ void processProducerCommitOp(OpBuilder &builder, ttnvws::ProducerCommitOp op,
     arriveOp =
         builder.create<ttng::ArriveBarrierOp>(loc, bufferFull, fullCnt, pred);
   } else {
-#if 0
-    // Each thread arrives.
-    Value pred = builder.create<arith::ConstantIntOp>(loc, 1, 1);
-    arriveOp = builder.create<ttng::MBarrierArriveOp>(
-        loc, bufferFull, pred, /*remoteCTAId*/ nullptr, /*trackAsyncOp*/ true,
-        txCnt);
-#else
     assert(false);
-#endif
   }
 
   assert(op.getOperation()->hasAttr("async_task_id"));

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -5,6 +5,7 @@
 #include "cublas_instance.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
 #include "nvidia/include/Dialect/NVWS/Transforms/Passes.h"
 #include "passes.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -61,11 +62,18 @@ void init_triton_nvidia_passes_nvws(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_lower_aref", mlir::triton::createNVWSLowerAref);
 }
 
+void init_triton_hopper_passes(py::module &&m) {
+  // Meta's autoWS
+  ADD_PASS_OPTION_WRAPPER_2("add_hopper_warpspec",
+                            mlir::createNVGPUWarpSpecialization, int, bool);
+}
+
 void init_triton_nvidia(py::module &&m) {
   auto passes = m.def_submodule("passes");
   init_triton_nvidia_passes_nvws(passes.def_submodule("nvws"));
   init_triton_nvidia_passes_ttgpuir(passes.def_submodule("ttgpuir"));
   init_triton_nvidia_passes_ttnvgpuir(passes.def_submodule("ttnvgpuir"));
+  init_triton_hopper_passes(passes.def_submodule("hopperws"));
 
   // cluster info
   py::class_<mlir::triton::nvidia_gpu::ClusterInfo>(m, "ClusterInfo")

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -73,7 +73,7 @@ void init_triton_nvidia(py::module &&m) {
   init_triton_nvidia_passes_nvws(passes.def_submodule("nvws"));
   init_triton_nvidia_passes_ttgpuir(passes.def_submodule("ttgpuir"));
   init_triton_nvidia_passes_ttnvgpuir(passes.def_submodule("ttnvgpuir"));
-  init_triton_hopper_passes(passes.def_submodule("hopperws"));
+  init_triton_hopper_passes(passes.def_submodule("hopper"));
 
   // cluster info
   py::class_<mlir::triton::nvidia_gpu::ClusterInfo>(m, "ClusterInfo")


### PR DESCRIPTION
Builds and runs for GEMM with matmul_kernel_persistent_tma_ws_cooperative (i.e 2 consumer groups doing computation + epilogue, one producer group doing loads).
Performance will be tuned in a followup diff.

We set num_stages to 0 after WarpSpec to disable SWP. Also SWP is updated to bail out if there is no loop with num_stages >= 1.