### PR TITLE
[BACKEND] Clean up hard code for NV and AMD GPU in the common TritonGPU dialect to support third party GPU extension.

### DIFF
--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -101,6 +101,10 @@ public:
   virtual LogicalResult
   verifyTensorLayout(Attribute layout, RankedTensorType type, Operation *op,
                      function_ref<InFlightDiagnostic()> emitError) const = 0;
+
+  virtual LogicalResult
+  verifyDotOpLayout(Attribute parent, unsigned opIdx, unsigned kWidth,
+                    function_ref<InFlightDiagnostic()> emitError) const = 0;
 };
 
 } // namespace triton

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -680,34 +680,17 @@ LogicalResult DotOperandEncodingAttr::verify(
   if (!parent) {
     return emitError() << "ttg.dot_op parent parameter cannot be null";
   }
-  if (auto parentAttr = mlir::dyn_cast<NvidiaMmaEncodingAttr>(parent)) {
-    if (kWidth != 0 && !(parentAttr.isAmpere() || parentAttr.isHopper()))
-      return emitError() << "ttg.dot_op kWidth parameter can only be "
-                            "non-zero for Ampere or Hopper MMA parent";
-    if (kWidth == 0 && (parentAttr.isAmpere() || parentAttr.isHopper()))
-      return emitError() << "ttg.dot_op kWidth parameter is mandatory for "
-                            "Ampere or Hopper MMA parent";
-    if (opIdx != 0 && parentAttr.isHopper())
-      return emitError()
-             << "ttg.dot_op opIdx parameter must be 0 for "
-                "Hopper MMA parent, since Hopper WGMMA only allows first "
-                "operand to be in registers";
-    return success();
-  }
 
-  if (auto parentAttr = mlir::dyn_cast<AMDWmmaEncodingAttr>(parent)) {
-    if (kWidth != 16 && parentAttr.getVersion() == 1 ||
-        kWidth != 8 && kWidth != 16 && parentAttr.getVersion() == 2)
-      return emitError() << "ttg.dot_op kWidth parameter must be 16 for "
-                            "gfx11 and 8/16 for gfx12";
-    return success();
-  }
-
-  if (auto parentAttr = mlir::dyn_cast<AMDMfmaEncodingAttr>(parent)) {
-    if (kWidth == 0)
-      return emitError() << "ttg.dot_op kWidth parameter is mandatory for "
-                            "MFMA parent";
-    return success();
+  if (isa<MmaEncodingTrait>(parent)) {
+    // The MMA layout can be defined in third party dialect.
+    // Dispatch to the verifier of dialect interface.
+    Dialect &dialect = parent.getDialect();
+    auto verifyLayoutInterface =
+        dyn_cast<mlir::triton::DialectVerifyTensorLayoutInterface>(&dialect);
+    if (verifyLayoutInterface) {
+      return verifyLayoutInterface->verifyDotOpLayout(parent, opIdx, kWidth,
+                                                      emitError);
+    }
   }
 
   if (auto parentAttr = mlir::dyn_cast<BlockedEncodingAttr>(parent)) {
@@ -2726,6 +2709,45 @@ struct TritonGPUVerifyTensorLayoutInterface
     }
 
     return success();
+  }
+
+  LogicalResult verifyDotOpLayout(
+      Attribute parent, unsigned opIdx, unsigned kWidth,
+      function_ref<InFlightDiagnostic()> emitError) const override {
+
+    if (auto parentAttr = mlir::dyn_cast<NvidiaMmaEncodingAttr>(parent)) {
+      if (kWidth != 0 && !(parentAttr.isAmpere() || parentAttr.isHopper()))
+        return emitError() << "ttg.dot_op kWidth parameter can only be "
+                              "non-zero for Ampere or Hopper MMA parent";
+      if (kWidth == 0 && (parentAttr.isAmpere() || parentAttr.isHopper()))
+        return emitError() << "ttg.dot_op kWidth parameter is mandatory for "
+                              "Ampere or Hopper MMA parent";
+      if (opIdx != 0 && parentAttr.isHopper())
+        return emitError()
+               << "ttg.dot_op opIdx parameter must be 0 for "
+                  "Hopper MMA parent, since Hopper WGMMA only allows first "
+                  "operand to be in registers";
+      return success();
+    }
+
+    if (auto parentAttr = mlir::dyn_cast<AMDWmmaEncodingAttr>(parent)) {
+      if (kWidth != 16 && parentAttr.getVersion() == 1 ||
+          kWidth != 8 && kWidth != 16 && parentAttr.getVersion() == 2)
+        return emitError() << "ttg.dot_op kWidth parameter must be 16 for "
+                              "gfx11 and 8/16 for gfx12";
+      return success();
+    }
+
+    if (auto parentAttr = mlir::dyn_cast<AMDMfmaEncodingAttr>(parent)) {
+      if (kWidth == 0)
+        return emitError() << "ttg.dot_op kWidth parameter is mandatory for "
+                              "MFMA parent";
+      return success();
+    }
+
+    return emitError()
+           << "ttg.dot_op unknown parent layout of TritonGPU dialect: "
+           << parent;
   }
 };
 

--- a/unittest/Dialect/TritonGPU/CMakeLists.txt
+++ b/unittest/Dialect/TritonGPU/CMakeLists.txt
@@ -1,3 +1,26 @@
+set(LLVM_TARGET_DEFINITIONS TestDialect.td)
+mlir_tablegen(TestDialect.h.inc -gen-dialect-decls -dialect=tt_test)
+mlir_tablegen(TestDialect.cpp.inc -gen-dialect-defs -dialect=tt_test)
+mlir_tablegen(TestGPUAttrDefs.h.inc -gen-attrdef-decls --attrdefs-dialect=tt_test)
+mlir_tablegen(TestGPUAttrDefs.cpp.inc -gen-attrdef-defs --attrdefs-dialect=tt_test)
+add_public_tablegen_target(TritonTestGPUAttrDefsIncGen)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR}) # Tablegen'd files
+
+add_triton_library(TritonGPUTestIR
+
+    DEPENDS
+    TritonGPUTableGen
+    TritonGPUAttrDefsIncGen
+    TritonGPUTypeInterfacesIncGen
+    TritonTestGPUAttrDefsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRGPUDialect
+    TritonIR
+    TritonTools
+)
+
 add_triton_ut(
   NAME TestSwizzling
   SRCS SwizzleTest.cpp
@@ -12,6 +35,7 @@ add_triton_ut(
   LIBS
     MLIRParser
     TritonGPUIR
+    TritonGPUTestIR
     TritonGPUTransforms
     TritonNvidiaGPUTransforms
 )

--- a/unittest/Dialect/TritonGPU/TestDialect.td
+++ b/unittest/Dialect/TritonGPU/TestDialect.td
@@ -1,0 +1,54 @@
+#ifndef TRITON_GPU_TEST_DIALECT
+#define TRITON_GPU_TEST_DIALECT
+
+include "mlir/IR/OpBase.td"
+include "mlir/IR/AttrTypeBase.td"
+include "triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td"
+
+def TritonTest_Dialect : Dialect {
+  let name = "tt_test";
+}
+
+
+def TestAttr : DistributedEncoding<"TestAttr", "test_attr",
+                                  [MmaEncodingTrait], TritonTest_Dialect> {
+  let mnemonic = "test_mma";
+
+  let parameters = (
+    ins
+    "bool":$fail
+  );
+
+  let assemblyFormat = "`<` `{` struct(params) `}` `>`";
+
+  let extraClassDeclaration = [{
+
+    SmallVector<unsigned> getRepOrder() const {
+      return {1, 0};
+    }
+
+    SmallVector<unsigned> getCTAOrder() const {
+      return {1, 0};
+    }
+
+    SmallVector<unsigned> getCTAsPerCGA() const {
+      return {1, 1};
+    }
+
+    SmallVector<unsigned> getCTASplitNum() const {
+      return {1, 1};
+    }
+
+    SmallVector<unsigned> getRepOrderForOperand(unsigned opIdx) const {
+      return {1, 1};
+    }
+
+    triton::LinearLayout toLinearLayout(ArrayRef<int64_t> shape) const {
+      return triton::LinearLayout{};
+    }
+
+  }];
+}
+
+
+#endif


### PR DESCRIPTION
This PR cleans up specific GPU arch logic in the dot-op layout verifier of common TritonGPU dialect by introducing a new dialect interface method and dispatching layout verification to each dialect’s implementation. It enables the extension to the TritonGPU dialect for third party GPU arch.

- Define `verifyDotOpLayout` in the common `DialectVerifyTensorLayoutInterface` and implement it for NV and AMD MMA layout in the TritonGPU dialects.
- Remove hard-coded checks from `DotOperandEncodingAttr::verify` and replace with trait-based dispatch.
- Add the unit test case for the new interface.
