### PR TITLE
[kernels] restore old behavior that output for tokens routed to zero experts should be zero-initialized

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_ogs.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs.py
@@ -145,10 +145,16 @@ class TensorDescriptorBuilder:
                                                                                 block_n], transpose=transpose)
 
     @staticmethod
+    def squeeze_after_dim(x, dim=2):
+        shape = list(x.shape)
+        new_shape = [s for s in shape[:dim - 1] if s != 1] + shape[dim - 1:]
+        return x.view(*new_shape)
+
+    @staticmethod
     def create_input_descriptor_gather(x_tensor: torch.Tensor, K: int, x_stride_1: int, x_stride_2: int,
                                        block_k: int) -> TensorDescriptor:
         """Create a tensor descriptor for input matrix X via TMA gather"""
-        x_desc = x_tensor.squeeze()
+        x_desc = TensorDescriptorBuilder.squeeze_after_dim(x_tensor)
         assert x_desc.ndim == 2, "TMA gather descriptor requires 2D input"
         INT_MAX = 2147483647
         return TensorDescriptor(base=x_desc, shape=[INT_MAX, K], strides=[x_stride_1, x_stride_2],
@@ -158,7 +164,7 @@ class TensorDescriptorBuilder:
     def create_input_descriptor_load(x_tensor: torch.Tensor, K: int, x_stride_1: int, x_stride_2: int, block_m: int,
                                      block_k: int) -> TensorDescriptor:
         """Create a tensor descriptor for input matrix X via TMA"""
-        x_desc = x_tensor.squeeze()
+        x_desc = TensorDescriptorBuilder.squeeze_after_dim(x_tensor)
         assert x_desc.ndim in [2, 3], "LHS input TMA descriptor builder expects 2D or 3D input"
         return TensorDescriptor(base=x_desc, shape=[x_desc.shape[0], K], strides=[x_stride_1, x_stride_2],
                                 block_shape=[block_m, block_k])

--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/_finalize_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/_finalize_matmul.py
@@ -291,7 +291,7 @@ def _finalize_matmul(
                         if src_idx != -1:
                             As = A + src_idx.to(tl.int64) * stride_a_m + offs_n
                             for ki in tl.static_range(K):
-                                acc += tl.load(As, mask=n_mask, other=0.0)
+                                acc += tl.load(As, mask=(src_idxs != -1)[:, None] & n_mask[None, :], other=0.0)
                                 As += stride_a_k
                 else:
                     As = A + src_idxs.to(tl.int64)[:, None] * stride_a_m + offs_n[None, :]

--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/_matmul_ogs.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/_matmul_ogs.py
@@ -387,7 +387,7 @@ def _compute_writeback_idx(
     is_src_active = (src_idxs != -1).to(tl.int32)
     num_src_active = tl.sum(is_src_active, axis=1)
 
-    need_finalize_scatter = mask_m & (num_src_active > 1)
+    need_finalize_scatter = mask_m & (num_src_active != 1)
     finalize_scatter_count = tl.sum(need_finalize_scatter.to(tl.int32))
     if finalize_scatter_count == 0:
         return


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/7140 introduced a subtle change in the semantics of `matmul_ogs`. We actually care that the output of rows that have scatter_indx==-1 be zero-initialized because some expert parallelism code may reduce them

also found some missing mask in the AMD implementation, which most likely explains the test failure.