### PR TITLE
[AMD][BACKEND] Refactor shared address calculation for AsyncCopyGlobalToLocal/BufferLoadToLocal

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -547,6 +547,13 @@ emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
     Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
     std::function<void(VectorType, Value /*shmemAddr*/)> perVectorCallback);
 
+[[nodiscard]] bool emitTransferBetweenRegistersAndShared(
+    LinearLayout &regLayout, triton::gpu::MemDescType sharedTy, Type elemLlvmTy,
+    std::optional<int32_t> maxVecElems, const SharedMemoryObject &smemObj,
+    Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
+    Value laneId, Value warpId,
+    std::function<void(VectorType, Value /*shmemAddr*/)> perVectorCallback);
+
 SmallVector<Value> loadSharedToDistributed(triton::gpu::LocalLoadOp localLoadOp,
                                            Type elemLlvmTy,
                                            const SharedMemoryObject &smemObj,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -226,7 +226,8 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
     auto regLayout =
         triton::gpu::toLinearLayout(srcTy.getShape(), srcTy.getEncoding());
 
-    // Using the tid as a scalar improves codegen a lot
+    // The final LDS addr will be a scalar so we compute the warp id based on a
+    // scalar thread id which improves final codegen (reduces register pressure)
     Value tid =
         targetInfo.shuffleIdx(rewriter, loc, getThreadId(rewriter, loc), 0);
     int threadsPerWarp = triton::gpu::lookupThreadsPerWarp(rewriter);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -172,6 +172,7 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
     if (!isSimpleSharedMemoryAccess(
             srcTy.getShape(), dstTy.getAllocShape(),
             cast<SharedEncodingTrait>(dstTy.getEncoding()))) {
+      LDBG(op << " slicing is not support for direct-to-lds loads");
       return failure();
     }
 


### PR DESCRIPTION
On GFX9 direct-to-lds loads write coalesced to LDS and therefore require the start LDS address as a scalar. This PR refactors the address calculation to uniformly compute the start address instead of per lane addresses. This improves final codegen and reduces register usage.
The swizzling computations are now based on the offset instead of the final addresses which further helps codegen.

The lowering can produce incorrect loads in some cases if we store into a sub-view which slices along the two minor dimensions, so pipelining is fine. This was already the case before the refactoring and will be converted to an error in a follow up PR.