### PR TITLE
[Proton] Rename knobs.proton.cupti_path to knobs.proton.cupti_dir to make clear that it should be the parent directory to .so file

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -450,7 +450,7 @@ class amd_knobs(base_knobs):
 
 
 class proton_knobs(base_knobs):
-    cupti_path: env_opt_str = env_opt_str("TRITON_CUPTI_LIB_PATH")
+    cupti_dir: env_opt_str = env_opt_str("TRITON_CUPTI_LIB_PATH")
 
 
 build = build_knobs()

--- a/third_party/proton/csrc/include/Driver/Dispatch.h
+++ b/third_party/proton/csrc/include/Driver/Dispatch.h
@@ -62,9 +62,7 @@ public:
       // If not found, try to load it from the default path
       auto dir = std::string(ExternLib::defaultDir);
       if (dir.length() > 0) {
-        // When providing a knob a user may set the path directly
-        // to the library.
-        auto fullPath = dir.ends_with(name) ? dir : dir + "/" + name;
+        auto fullPath = dir + "/" + name;
         *lib = dlopen(fullPath.c_str(), RTLD_LOCAL | RTLD_LAZY);
       } else {
         // Only if the default path is not set, we try to load it from the

--- a/third_party/proton/csrc/include/Driver/Dispatch.h
+++ b/third_party/proton/csrc/include/Driver/Dispatch.h
@@ -62,7 +62,9 @@ public:
       // If not found, try to load it from the default path
       auto dir = std::string(ExternLib::defaultDir);
       if (dir.length() > 0) {
-        auto fullPath = dir + "/" + name;
+        // When providing a knob a user may set the path directly
+        // to the library.
+        auto fullPath = dir.ends_with(name) ? dir : dir + "/" + name;
         *lib = dlopen(fullPath.c_str(), RTLD_LOCAL | RTLD_LAZY);
       } else {
         // Only if the default path is not set, we try to load it from the

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -26,14 +26,11 @@ def _get_backend_default_path(backend: str) -> str:
     lib_path = ""
     if backend == "cupti":
         # First try to get the path from the environment variable that overrides the default path
-        lib_path = knobs.proton.cupti_path
+        lib_path = knobs.proton.cupti_dir
         if lib_path is None:
             # Get the default path for the cupti backend,
             # which is the most compatible with the current CUPTI header file triton is compiled with
             lib_path = str(pathlib.Path(__file__).parent.parent.absolute() / "backends" / "nvidia" / "lib" / "cupti")
-        # Proton expects the lib_path to be the directory containing the libcupti.so file, not the actual library.
-        if lib_path.endswith("libcupti.so"):
-            lib_path = str(pathlib.Path(lib_path).parent)
     return lib_path
 
 

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -31,6 +31,9 @@ def _get_backend_default_path(backend: str) -> str:
             # Get the default path for the cupti backend,
             # which is the most compatible with the current CUPTI header file triton is compiled with
             lib_path = str(pathlib.Path(__file__).parent.parent.absolute() / "backends" / "nvidia" / "lib" / "cupti")
+        # Proton expects the lib_path to be the directory containing the libcupti.so file, not the actual library.
+        if lib_path.endswith("libcupti.so"):
+            lib_path = str(pathlib.Path(lib_path).parent)
     return lib_path
 
 


### PR DESCRIPTION
Other knobs with PATH seem to allow referencing the library directly. This name update clarifies that it must be the parent directory.