### PR TITLE
Fix version when using source tarballs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -756,6 +756,8 @@ def get_git_branch():
 
 
 def get_git_version_suffix():
+    if not os.path.isdir(os.path.join(os.path.dirname(__file__), '.git')):
+        return ""  # Not a git checkout
     branch = get_git_branch()
     if branch.startswith("release"):
         return ""

--- a/setup.py
+++ b/setup.py
@@ -756,7 +756,7 @@ def get_git_branch():
 
 
 def get_git_version_suffix():
-    if not os.path.isdir(os.path.join(os.path.dirname(__file__), '.git')):
+    if not (Path(__file__).parent / ".git").is_dir():
         return ""  # Not a git checkout
     branch = get_git_branch()
     if branch.startswith("release"):


### PR DESCRIPTION
In tarballs there is not git information and `git` would check every parent folder potentially returning unrelated information.

Verify that `setup.py` is run from a git checkout and bail out otherwise.   
The existence of the `.git` folder should be a good enough indicator for that.


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] This PR does not need a test because it changes the setup.py file only

- Select one of the following.
  - [x] I have not added any `lit` tests.
