### PR TITLE
[AMD] [Testing] Skip routing tests on AMD

### DIFF
--- a/python/triton_kernels/tests/test_routing.py
+++ b/python/triton_kernels/tests/test_routing.py
@@ -3,6 +3,7 @@ import torch
 from triton_kernels.routing import routing, routing_torch
 from triton_kernels.testing import assert_close
 from triton_kernels.testing import assert_equal
+from triton_kernels.target_info import is_hip
 
 
 def init_data(n_tokens, n_expts_tot, dtype=torch.float32, device="cuda"):
@@ -18,6 +19,7 @@ n_tokens += [(1152, 911)]
 @pytest.mark.parametrize("n_expts_tot, n_expts_act", [(128, 32), (1500, 8)])
 @pytest.mark.parametrize("use_expt_indx", [False, True])
 @pytest.mark.parametrize("sm_first", [True, False])
+@pytest.mark.skipif(is_hip, reason="Tests are currently broken on AMD")
 def test_op(n_tokens_pad, n_tokens_raw, n_expts_tot, n_expts_act, sm_first, use_expt_indx, device):
     torch.manual_seed(2)
     if n_tokens_raw is None:


### PR DESCRIPTION
All of the routing tests are currently broken on AMD. They fail because some of the reference checks are wrong. This disables the tests until someone can fix them.