### PR TITLE
[LLVM] Pass NVPTX triple to LibaryAnalysis

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -316,6 +316,11 @@ void init_triton_llvm(py::module &&m) {
         CGSCCAnalysisManager cgam;
         ModuleAnalysisManager mam;
 
+        llvm::TargetLibraryInfoImpl TLII{Triple("nvptx64", "nvidia", "cuda")};
+        fam.registerPass([TLII = std::move(TLII)] {
+          return llvm::TargetLibraryAnalysis(TLII);
+        });
+
         PassInstrumentationCallbacks *instrCbPtr = nullptr;
         PassInstrumentationCallbacks passInstrCb;
         StandardInstrumentations standardInstr(mod->getContext(),

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -316,10 +316,12 @@ void init_triton_llvm(py::module &&m) {
         CGSCCAnalysisManager cgam;
         ModuleAnalysisManager mam;
 
-        llvm::TargetLibraryInfoImpl TLII{Triple("nvptx64", "nvidia", "cuda")};
-        fam.registerPass([TLII = std::move(TLII)] {
-          return llvm::TargetLibraryAnalysis(TLII);
-        });
+        if (arch.empty()) {
+          llvm::TargetLibraryInfoImpl TLII{Triple("nvptx64", "nvidia", "cuda")};
+          fam.registerPass([TLII = std::move(TLII)] {
+            return llvm::TargetLibraryAnalysis(TLII);
+          });
+        }
 
         PassInstrumentationCallbacks *instrCbPtr = nullptr;
         PassInstrumentationCallbacks passInstrCb;

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -317,7 +317,8 @@ void init_triton_llvm(py::module &&m) {
         ModuleAnalysisManager mam;
 
         if (arch.empty()) {
-          llvm::TargetLibraryInfoImpl TLII{Triple("nvptx64", "nvidia", "cuda")};
+          llvm::TargetLibraryInfoImpl TLII;
+          TLII.disableAllFunctions();
           fam.registerPass([TLII = std::move(TLII)] {
             return llvm::TargetLibraryAnalysis(TLII);
           });


### PR DESCRIPTION
NVPTX has some suboptimal lowerings like that memset. By doing this, we avoid
hitting these lowerings.
