### PR TITLE
Fix Typos in Comments and Documentation for CUDA Driver and GDC

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -275,7 +275,7 @@ static cuLaunchKernelEx_t getLaunchKernelExHandle() {{
 static void _launch(int gridX, int gridY, int gridZ, int num_warps, int num_ctas, int launch_cooperative_grid, int launch_pdl, int clusterDimX, int clusterDimY, int clusterDimZ, int shared_memory, CUstream stream, CUfunction function, CUdeviceptr global_scratch{', ' + arg_decls if len(arg_decls) > 0 else ''}) {{
   void *params[] = {{ {', '.join(params)} }};
   if (gridX*gridY*gridZ > 0) {{
-    // 4 attributes that we can currently pass maxmimum
+    // 4 attributes that we can currently pass maximum
     CUlaunchAttribute launchAttr[4];
     static cuLaunchKernelEx_t cuLaunchKernelExHandle = NULL;
     if (cuLaunchKernelExHandle == NULL) {{

--- a/third_party/nvidia/language/cuda/gdc.py
+++ b/third_party/nvidia/language/cuda/gdc.py
@@ -16,7 +16,7 @@ def gdc_wait(_builder=None):
     This ensures all memory operations happening before the wait is visible to instructions after it,
     e.g. if the prior kernel writes to address "x" the new values will be visible in this kernel after the wait.
 
-    This instruction is also safe to execute when programatic dependent launch is disabled.
+    This instruction is also safe to execute when programmatic dependent launch is disabled.
 
     See https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-griddepcontrol for more details.
     """
@@ -34,7 +34,7 @@ def gdc_launch_dependents(_builder=None):
     Repeated calls to this function have no effect past the first call, and the first call should be
     treated by the programmer as a hint to the runtime system to launch the next kernel.
 
-    This instruction is also safe to execute when programatic dependent launch is disabled.
+    This instruction is also safe to execute when programmatic dependent launch is disabled.
 
     See https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-griddepcontrol for more details.
     """


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in comments and documentation within the CUDA driver and GDC modules. Specifically, it changes "maximum" to "maximum" in the driver comment and corrects "programatic" to "programmatic" in the GDC documentation. These changes improve code readability and maintain consistency in terminology. No functional code changes are included.