### PR TITLE
[PROTON-DEV] Add SamplingStrategy::SELECTIVE for instrumentation

### DIFF
--- a/third_party/proton/dialect/triton_proton.cc
+++ b/third_party/proton/dialect/triton_proton.cc
@@ -27,6 +27,7 @@ void init_triton_proton(py::module &&m) {
   py::enum_<proton::SamplingStrategy>(m, "SAMPLING_STRATEGY",
                                       py::module_local())
       .value("NONE", proton::SamplingStrategy::NONE)
+      .value("SELECTIVE", proton::SamplingStrategy::SELECTIVE)
       .export_values();
 
   // ProtonGPU enums

--- a/third_party/proton/proton/mode.py
+++ b/third_party/proton/proton/mode.py
@@ -18,6 +18,7 @@ buffer_types = {
 
 sampling_strategies = {
     "none": triton_proton.SAMPLING_STRATEGY.NONE,
+    "selective": triton_proton.SAMPLING_STRATEGY.SELECTIVE,
 }
 
 granularities = {


### PR DESCRIPTION
We already have the support for sampling_strategy SELECTIVE in 
ConvertProtonToProtonGPUPass. Here, just I'm adding the link to 
python frontend.