### PR TITLE
[AMD] expose core pipeliner utilities and integrate in AMD pipeliner

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -23,7 +23,7 @@ bool isSafeToPipeline(scf::ForOp forOp);
 llvm::MapVector<Operation *, std::pair<int, Operation *>>
 loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
                           triton::ModuleAxisInfoAnalysis &axisInfoAnalysis,
-                          int numStages);
+                          int numStages, bool filterSmall = true);
 
 }; // namespace gpu
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -4,6 +4,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Support/LLVM.h"
+#include "triton/Analysis/AxisInfo.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipelineExpander.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <list>
@@ -16,6 +17,13 @@ namespace gpu {
 
 /// Lower the loops to prepare them for pipeline expansion.
 void lowerLoops(ModuleOp moduleOp);
+
+bool hasGpuBarriers(scf::ForOp forOp);
+bool isSafeToPipeline(scf::ForOp forOp);
+llvm::MapVector<Operation *, std::pair<int, Operation *>>
+loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
+                          triton::ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                          int numStages);
 
 }; // namespace gpu
 
@@ -190,6 +198,13 @@ private:
   std::optional<CoarseSchedule::Cluster> cluster;
   CoarseSchedule &schedule;
 };
+
+namespace gpu {
+void scheduleDistanceOneDependencies(scf::ForOp forOp,
+                                     CoarseSchedule &schedule);
+void scheduleRemainingToLastStage(scf::ForOp forOp, CoarseSchedule &schedule,
+                                  CoarseSchedule::Cluster afterPrologue);
+} // namespace gpu
 
 } // namespace triton
 } // namespace mlir

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -147,97 +147,7 @@ public:
     return true;
   }
 };
-} // namespace
 
-// Create a map from load ops to their indirection level and the
-// final use of the load op (another load op, or a dot op).
-// Indirection level is "0" for the load op directly used by the dot op,
-// "1" for the load op used by the load op used by the dot op, and so on.
-llvm::MapVector<Operation *, std::pair<int, Operation *>>
-loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
-                          tt::ModuleAxisInfoAnalysis &axisInfoAnalysis,
-                          int numStages, bool filterSmall) {
-  llvm::MapVector<Operation *, std::pair<int, Operation *>> loadOpToIndLevel;
-  DenseSet<Operation *> seen;
-  DenseSet<Operation *> excluded;
-
-  std::function<void(Operation *, Operation *, int)> dfs =
-      [&](Operation *op, Operation *finalUser, int distance) {
-        if (!seen.insert(op).second || excluded.count(op))
-          return;
-        if (isa<tt::LoadOp, tt::DescriptorLoadOp, tt::DescriptorGatherOp>(op)) {
-          if (!AssignLoadLatencies::isPipeliningBeneficial(
-                  op, finalUser, axisInfoAnalysis, filterSmall))
-            return;
-          if (loadOpToIndLevel.count(op)) {
-            int level = loadOpToIndLevel[op].first;
-            if (level != distance) {
-              // If we have multiple uses at different distances, we don't
-              // know which one to pick.
-              LDBG("Load " << *op
-                           << " has multiple uses at different distances:"
-                           << level << " and " << distance);
-              loadOpToIndLevel.erase(op);
-              excluded.insert(op);
-              return;
-            }
-          } else {
-            LDBG("Load " << *op << " considered for pipelining with distance "
-                         << distance);
-            loadOpToIndLevel[op] = {distance, finalUser};
-          }
-          finalUser = op;
-          distance++;
-        }
-        for (Value operand : getNestedOperands(op)) {
-          if (isa<mlir::triton::DotOpInterface>(op)) {
-            // Heuristic: only pipeline A and B operands of the dot op.
-            if (operand == op->getOperand(2))
-              continue;
-          }
-          Value v = operand;
-          Operation *defOp = v.getDefiningOp();
-          if (defOp && defOp->getBlock() == op->getBlock()) {
-            dfs(defOp, finalUser, distance);
-          }
-        }
-      };
-
-  bool seenDot = false;
-  for (Operation &op : forOp.getBody()->without_terminator()) {
-    // Arbitrary heuristic. TMEMStoreOp is included to keep logic consistent
-    // with legacy code when we weren't hoisting tmem allocas.
-    if (!isa<mlir::triton::DotOpInterface, ttng::TMEMStoreOp>(op))
-      continue;
-    seenDot = true;
-    seen.clear();
-    dfs(&op, &op, 0);
-  }
-
-  // If the loop has numStages attribute, also consider pipelining other loads
-  // that are not directly used by dot ops.
-  if (pipelineWithoutDot && !seenDot) {
-    for (Operation &op : forOp.getBody()->without_terminator()) {
-      if (!isa<tt::LoadOp, tt::DescriptorLoadOp, tt::DescriptorGatherOp>(op))
-        dfs(&op, &op, 0);
-    }
-  }
-
-  // We assume loads with different dist are assigned to different stages.
-  // If numStages is 2, we will have no stage available for indirect loads
-  // with dist >= 1. In general, when dist is equal to numStages - 1, we
-  // should not pipeline it.
-  for (auto iter = loadOpToIndLevel.begin(); iter != loadOpToIndLevel.end();) {
-    if (iter->second.first >= numStages - 1)
-      iter = loadOpToIndLevel.erase(iter);
-    else
-      ++iter;
-  }
-
-  return loadOpToIndLevel;
-}
-
-namespace {
 class AssignMMALatencies {
 public:
   AssignMMALatencies(scf::ForOp forOp, DenseMap<Operation *, int> &opLatency)
@@ -341,6 +251,94 @@ void assignLatencies(ModuleOp moduleOp, int defaultNumStages) {
 }
 
 } // namespace
+
+// Create a map from load ops to their indirection level and the
+// final use of the load op (another load op, or a dot op).
+// Indirection level is "0" for the load op directly used by the dot op,
+// "1" for the load op used by the load op used by the dot op, and so on.
+llvm::MapVector<Operation *, std::pair<int, Operation *>>
+loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
+                          tt::ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                          int numStages, bool filterSmall) {
+  llvm::MapVector<Operation *, std::pair<int, Operation *>> loadOpToIndLevel;
+  DenseSet<Operation *> seen;
+  DenseSet<Operation *> excluded;
+
+  std::function<void(Operation *, Operation *, int)> dfs =
+      [&](Operation *op, Operation *finalUser, int distance) {
+        if (!seen.insert(op).second || excluded.count(op))
+          return;
+        if (isa<tt::LoadOp, tt::DescriptorLoadOp, tt::DescriptorGatherOp>(op)) {
+          if (!AssignLoadLatencies::isPipeliningBeneficial(
+                  op, finalUser, axisInfoAnalysis, filterSmall))
+            return;
+          if (loadOpToIndLevel.count(op)) {
+            int level = loadOpToIndLevel[op].first;
+            if (level != distance) {
+              // If we have multiple uses at different distances, we don't
+              // know which one to pick.
+              LDBG("Load " << *op
+                           << " has multiple uses at different distances:"
+                           << level << " and " << distance);
+              loadOpToIndLevel.erase(op);
+              excluded.insert(op);
+              return;
+            }
+          } else {
+            LDBG("Load " << *op << " considered for pipelining with distance "
+                         << distance);
+            loadOpToIndLevel[op] = {distance, finalUser};
+          }
+          finalUser = op;
+          distance++;
+        }
+        for (Value operand : getNestedOperands(op)) {
+          if (isa<mlir::triton::DotOpInterface>(op)) {
+            // Heuristic: only pipeline A and B operands of the dot op.
+            if (operand == op->getOperand(2))
+              continue;
+          }
+          Value v = operand;
+          Operation *defOp = v.getDefiningOp();
+          if (defOp && defOp->getBlock() == op->getBlock()) {
+            dfs(defOp, finalUser, distance);
+          }
+        }
+      };
+
+  bool seenDot = false;
+  for (Operation &op : forOp.getBody()->without_terminator()) {
+    // Arbitrary heuristic. TMEMStoreOp is included to keep logic consistent
+    // with legacy code when we weren't hoisting tmem allocas.
+    if (!isa<mlir::triton::DotOpInterface, ttng::TMEMStoreOp>(op))
+      continue;
+    seenDot = true;
+    seen.clear();
+    dfs(&op, &op, 0);
+  }
+
+  // If the loop has numStages attribute, also consider pipelining other loads
+  // that are not directly used by dot ops.
+  if (pipelineWithoutDot && !seenDot) {
+    for (Operation &op : forOp.getBody()->without_terminator()) {
+      if (!isa<tt::LoadOp, tt::DescriptorLoadOp, tt::DescriptorGatherOp>(op))
+        dfs(&op, &op, 0);
+    }
+  }
+
+  // We assume loads with different dist are assigned to different stages.
+  // If numStages is 2, we will have no stage available for indirect loads
+  // with dist >= 1. In general, when dist is equal to numStages - 1, we
+  // should not pipeline it.
+  for (auto iter = loadOpToIndLevel.begin(); iter != loadOpToIndLevel.end();) {
+    if (iter->second.first >= numStages - 1)
+      iter = loadOpToIndLevel.erase(iter);
+    else
+      ++iter;
+  }
+
+  return loadOpToIndLevel;
+}
 
 //===----------------------------------------------------------------------===//
 // Pass Definition

--- a/test/TritonGPU/loop-pipeline-hip.mlir
+++ b/test/TritonGPU/loop-pipeline-hip.mlir
@@ -363,14 +363,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 //         COMMON:   tt.dot_scaled
 //         COMMON:   scf.yield
 
-// fails here because some of the loads are too small and thus loadOpsToIndirectionLevel->isPipeliningBeneficial->canBeConvertedToAsyncLoad returns False
 // Epilogue
-// XXXXXXXXXXXXXXXXXXX: ttg.async_wait
-// XXXXXXXXXXXXXXXXXXX: ttg.local_load
-// XXXXXXXXXXXXXXXXXXX: scf.if
-// XXXXXXXXXXXXXXXXXXX:   tt.dot_scaled
-// XXXXXXXXXXXXXXXXXXX:   scf.yield
-// XXXXXXXXXXXXXXXXXXX: ttg.local_dealloc
+//          ASYNC: ttg.async_wait
+// COMMON-COUNT-3: ttg.local_load
+//         COMMON: scf.if
+//         COMMON:   tt.dot_scaled
+// COMMON-COUNT-2:   scf.yield
+// COMMON-COUNT-3: ttg.local_dealloc
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [64, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -565,17 +564,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // Prologue
 // COMMON-COUNT-4: tt.load
 
-// fails here because some of the loads are too small and thus loadOpsToIndirectionLevel->isPipeliningBeneficial->canBeConvertedToAsyncLoad returns False
 // Main loop
-// XXXXXXXXXXXXXX: scf.for
-// XXXXXXXXXXXXXX:   tt.load
-// XXXXXXXXXXXXXX:   tt.dot_scaled
-// XXXXXXXXXXXXXX:   scf.yield
+//         COMMON: scf.for
+// COMMON-COUNT-4:   tt.load
+//         COMMON:   tt.dot_scaled
+//         COMMON:   scf.yield
 
 // Epilogue
-// XXXXXXXXXXXXXX: scf.if
-// XXXXXXXXXXXXXX:   tt.dot_scaled
-// XXXXXXXXXXXXXX:   scf.yield
+//         COMMON: scf.if
+//         COMMON:   tt.dot_scaled
+//         COMMON:   scf.yield
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>

--- a/test/TritonGPU/loop-pipeline-hip.mlir
+++ b/test/TritonGPU/loop-pipeline-hip.mlir
@@ -363,13 +363,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 //         COMMON:   tt.dot_scaled
 //         COMMON:   scf.yield
 
+// fails here because some of the loads are too small and thus loadOpsToIndirectionLevel->isPipeliningBeneficial->canBeConvertedToAsyncLoad returns False
 // Epilogue
-//          ASYNC: ttg.async_wait
-// COMMON-COUNT-3: ttg.local_load
-//         COMMON: scf.if
-//         COMMON:   tt.dot_scaled
-// COMMON-COUNT-2:   scf.yield
-// COMMON-COUNT-3: ttg.local_dealloc
+// XXXXXXXXXXXXXXXXXXX: ttg.async_wait
+// XXXXXXXXXXXXXXXXXXX: ttg.local_load
+// XXXXXXXXXXXXXXXXXXX: scf.if
+// XXXXXXXXXXXXXXXXXXX:   tt.dot_scaled
+// XXXXXXXXXXXXXXXXXXX:   scf.yield
+// XXXXXXXXXXXXXXXXXXX: ttg.local_dealloc
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [64, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -564,16 +565,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // Prologue
 // COMMON-COUNT-4: tt.load
 
+// fails here because some of the loads are too small and thus loadOpsToIndirectionLevel->isPipeliningBeneficial->canBeConvertedToAsyncLoad returns False
 // Main loop
-//         COMMON: scf.for
-// COMMON-COUNT-4:   tt.load
-//         COMMON:   tt.dot_scaled
-//         COMMON:   scf.yield
+// XXXXXXXXXXXXXX: scf.for
+// XXXXXXXXXXXXXX:   tt.load
+// XXXXXXXXXXXXXX:   tt.dot_scaled
+// XXXXXXXXXXXXXX:   scf.yield
 
 // Epilogue
-//         COMMON: scf.if
-//         COMMON:   tt.dot_scaled
-//         COMMON:   scf.yield
+// XXXXXXXXXXXXXX: scf.if
+// XXXXXXXXXXXXXX:   tt.dot_scaled
+// XXXXXXXXXXXXXX:   scf.yield
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -920,8 +920,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
       %25 = ttg.memdesc_trans %24 {order=array<i32: 1,0>} : !ttg.memdesc<64x16xf16, #shared, #smem> -> !ttg.memdesc<16x64xf16, #shared1, #smem>
       %26 = ttg.local_load %25 : !ttg.memdesc<16x64xf16, #shared1, #smem> -> tensor<16x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
       %27 = tt.dot %23, %26, %arg4 : tensor<128x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<16x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x64xf32, #mma>
+      // COMMON: scf.yield
       scf.yield %21, %27 : tensor<128x16xf32, #mma>, tensor<128x64xf32, #mma>
     }
+    // COMMON-NOT: alloc
     tt.return %17#0, %17#1 : tensor<128x16xf32, #mma>, tensor<128x64xf32, #mma>
   }
 }


### PR DESCRIPTION
This PR exposes (via header) core pipelining utilities/helpers:

```c++
bool hasGpuBarriers(scf::ForOp forOp);
bool isSafeToPipeline(scf::ForOp forOp);
llvm::MapVector<Operation *, std::pair<int, Operation *>>
loadOpsToIndirectionLevel(scf::ForOp forOp, bool pipelineWithoutDot,
                          triton::ModuleAxisInfoAnalysis &axisInfoAnalysis,
                          int numStages, bool filterSmall = true);
void scheduleDistanceOneDependencies(scf::ForOp forOp,
                                     CoarseSchedule &schedule);
void scheduleRemainingToLastStage(scf::ForOp forOp, CoarseSchedule &schedule,
                                  CoarseSchedule::Cluster afterPrologue);
```

They are directly useable by AMD's pipeliner. 

Note, this is basically NFC for AMD because AMD's pipeliner simply had copy-paste of the same functions from ~last year (specifically somewhere around prior to this [PR](https://github.com/triton-lang/triton/pull/5176)).

A couple of minor notes/call-outs:

1. The PR is "wacky" in order minimize line-noise and enable reviewers to review changes. By funky I mean I have endeavoured to move the code around as little as possible in core and instead opted to instead insert `namespace` etc. After the PR is approved I will re-org so that no new `namespace` scopes are created.
2. `loadOpsToIndirectionLevel` is currently a member of `AssignLoadLatencies` (i.e., prior to this PR). In this PR I expose it as a free function but this necessitates exposing `canHaveSharedEncoding` and `isPipeliningBeneficial`) as static members of `AssignLoadLatencies`. Post approval I will move these out as free functions (but not exposed in a header).
   - currently the code-formatting check fails - this is because I have kept `loadOpsToIndirectionLevel` indented as if it were a member so that highlighting here focuses on the small API change (see next bullets).

Small API changes:

3. On NV we do not pipeline small loads (vec width < 32b). On AMD we do. The choice is made inside `isPipeliningBeneficial` inside `loadOpsToIndirectionLevel`. To support AMD I have added a flag `filterSmall`.
4. On AMD the load `use`s (computed as a matter of course in `loadOpsToIndirectionLevel`) are used (no pun intended) whereas on NV they are not. To support AMD I keep those `use`s in the `llvm::MapVector<Operation *, std::pair<int, Operation *>>` return from `loadOpsToIndirectionLevel`.

These two small changes are the only "non-NFC" changes.
