### PR TITLE
[Gluon] Separate `warp_specialize` default and worker args

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -358,14 +358,14 @@ def test_warp_specialize():
     c = ttgl.arange(0, 4, layout=layout)
     pair = Pair(a, b)
     e: ttgl.constexpr = 42
-    a, b = ttgl.warp_specialize((pair, c, e), warp_specialize_default,
+    a, b = ttgl.warp_specialize((pair, c, e), warp_specialize_default, (pair, c, e),
                                 [warp_specialize_worker0, warp_specialize_worker1], [4, 4], [24, 48])
     anchor(a)
     anchor(b)
 
     # CHECK: ttg.warp_specialize([[A]], [[B]], [[C]])
     # CHECK: (tensor<1xi32, [[BLOCKED]]>, tensor<2xi32, [[BLOCKED]]>, tensor<4xi32, [[BLOCKED]]>) -> ()
-    ttgl.warp_specialize((pair, c, e), warp_specialize_worker0, [warp_specialize_worker1], [4], [48])
+    ttgl.warp_specialize((pair, c, e), warp_specialize_worker0, (pair, c, e), [warp_specialize_worker1], [4], [48])
 
 
 @gluon.jit

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -299,11 +299,11 @@ def allocate_shared_memory(element_ty, shape, layout, value=None, _semantic=None
 
 
 @builtin
-def warp_specialize(args, default_partition, worker_partitions, worker_num_warps, worker_num_regs,  #
+def warp_specialize(default_args, default_partition, worker_args, worker_partitions, worker_num_warps, worker_num_regs,
                     _semantic=None, _generator=None):
     worker_num_warps = [_unwrap_if_constexpr(w) for w in worker_num_warps]
     worker_num_regs = [_unwrap_if_constexpr(r) for r in worker_num_regs]
-    return _semantic.warp_specialize(args, default_partition, worker_partitions, worker_num_warps,  #
+    return _semantic.warp_specialize(default_args, default_partition, worker_args, worker_partitions, worker_num_warps,
                                      worker_num_regs, _generator)
 
 

--- a/python/tutorials/gluon/01-attention-forward.py
+++ b/python/tutorials/gluon/01-attention-forward.py
@@ -589,7 +589,7 @@ class InnerLoopInfo:
 
 @gluon.jit
 def _attn_fwd_load(config,  #
-                   m_is, infos, k_load_ctx, v_load_ctx,  #
+                   infos, k_load_ctx, v_load_ctx,  #
                    STAGE: gl.constexpr):
     prog = config.get_program()
     lo, hi = prog.get_loop_bounds(STAGE)
@@ -609,7 +609,7 @@ def _attn_fwd_load(config,  #
 
 @gluon.jit
 def _attn_fwd_mma(config,  #
-                  m_is, infos, k_load_ctx, v_load_ctx,  #
+                  infos, k_load_ctx, v_load_ctx,  #
                   STAGE: gl.constexpr):
     prog = config.get_program()
     lo, hi = prog.get_loop_bounds(STAGE)
@@ -684,7 +684,7 @@ def _attn_fwd_correction_compute(config, mi_consumer, o_consumer, m_i):
 
 @gluon.jit
 def _attn_fwd_correction(config,  #
-                         m_is, infos, k_load_ctx, v_load_ctx,  #
+                         m_is, infos,  #
                          STAGE: gl.constexpr):
     prog = config.get_program()
     lo, hi = prog.get_loop_bounds(STAGE)
@@ -757,14 +757,14 @@ def _softmax_tile(tile_id: gl.constexpr, config, info, STAGE: gl.constexpr):
 
 @gluon.jit
 def _attn_fwd_softmax0(config,  #
-                       m_is, infos, k_load_ctx, v_load_ctx,  #
+                       infos, k_load_ctx, v_load_ctx,  #
                        STAGE: gl.constexpr):
     _softmax_tile(0, config, infos[0], STAGE)
 
 
 @gluon.jit
 def _attn_fwd_softmax1(config,  #
-                       m_is, infos, k_load_ctx, v_load_ctx,  #
+                       infos, k_load_ctx, v_load_ctx,  #
                        STAGE: gl.constexpr):
     _softmax_tile(1, config, infos[1], STAGE)
 
@@ -781,10 +781,14 @@ def _attn_fwd_inner(config, info0, info1, m_i0, m_i1,  #
         config,
         (m_i0, m_i1),
         (info0, info1),
+        STAGE,
+    ), _attn_fwd_correction, (
+        config,
+        (info0, info1),
         k_load_ctx,
         v_load_ctx,
         STAGE,
-    ), _attn_fwd_correction, [
+    ), [
         _attn_fwd_softmax0,
         _attn_fwd_softmax1,
         _attn_fwd_mma,


### PR DESCRIPTION
This problem was exposed by https://github.com/triton-lang/triton/pull/7225 which verifies the layouts of the call operands.