### PR TITLE
[Gluon][Tutorial] Optimize attention kernel

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -447,7 +447,7 @@ void init_gluon_ir(py::module &&m) {
           "create_expand_dims",
           [](TritonOpBuilder &self, Value &arg, int axis, Type retTy) -> Value {
             return self.create<tt::ExpandDimsOp>(retTy, arg, axis);
-          })
+           })
       .def("create_warp_return",
            [](GluonOpBuilder &self) -> Operation * {
              return self.create<ttg::WarpReturnOp>();

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -447,7 +447,7 @@ void init_gluon_ir(py::module &&m) {
           "create_expand_dims",
           [](TritonOpBuilder &self, Value &arg, int axis, Type retTy) -> Value {
             return self.create<tt::ExpandDimsOp>(retTy, arg, axis);
-           })
+          })
       .def("create_warp_return",
            [](GluonOpBuilder &self) -> Operation * {
              return self.create<ttg::WarpReturnOp>();

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -155,6 +155,8 @@ class GluonSemantic(TritonSemantic[TensorTy]):
         return ttgl.tensor(handle, ret_ty)
 
     def shared_store(self, mem_desc, value):
+        assert value.shape == mem_desc.shape, f"source shape {value.shape} and destination shape {mem_desc.shape} must match"
+        assert value.dtype == mem_desc.dtype, f"source dtype {value.dtype} and destination dtype {mem_desc.dtype} must match"
         self.builder.create_local_store(mem_desc.handle, value.handle)
 
     def shared_dealloc(self, mem_desc):

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -130,6 +130,8 @@ class tensor_memory_descriptor(base_value):
     def store(self, value, pred=True, _semantic: GluonSemantic = None) -> None:
         pred = _unwrap_if_constexpr(pred)
         pred = _semantic.to_tensor(pred)
+        assert value.shape == self.shape, f"source shape {value.shape} does not match destination shape {self.shape}"
+        assert value.dtype == self.dtype, f"source dtype {value.dtype} does not match destination dtype {self.dtype}"
         _semantic.builder.create_tmem_store(self.handle, value.handle, pred.handle)
 
     @builtin

--- a/python/tutorials/gluon/01-attention-forward.py
+++ b/python/tutorials/gluon/01-attention-forward.py
@@ -418,6 +418,8 @@ class AttentionConfig:
     o_splitn_layout: gl.constexpr
     mi_2d_layout: gl.constexpr
 
+    mi_use_tmem: gl.constexpr
+
     def __init__(self, qk_scale, Z, H, N_CTX, BLOCK_M, BLOCK_N, HEAD_DIM, dtype, num_warps, SPLIT_N_FACTOR):
         self.qk_scale = qk_scale
         self.Z = Z
@@ -451,6 +453,8 @@ class AttentionConfig:
             get_tmem_32x32b_reg_layout((o_instr_shape[0], o_instr_shape[1] // self.SPLIT_N_FACTOR, o_instr_shape[2]),
                                        (self.o_shape[0], self.o_shape[1] // self.SPLIT_N_FACTOR), self.num_warps))
         self.mi_2d_layout = gl.constexpr(gl.BlockedLayout([1, 1], [32, 1], [4, 1], [0, 1]))
+
+        self.mi_use_tmem = gl.constexpr(False)
 
     @gluon.jit
     def get_program(self):
@@ -541,7 +545,7 @@ class InnerLoopInfo:
     qk_mma_ctx: MMAContext
     o_mma_ctx: MMAContext
     p_chnl: TensorMemoryChannel
-    mi_chnl: TensorMemoryChannel
+    mi_chnl: SharedMemoryChannel  # TensorMemoryChannel
     li_smem: gl.shared_memory_descriptor
     q_smem: gl.shared_memory_descriptor
 
@@ -564,9 +568,15 @@ class InnerLoopInfo:
                                              num_consumers=1)
         p_chnl.initialize_for_producer()
 
-        mi_chnl = TensorMemoryChannel._borrow(mi_tmem, [config.SPLIT_M, 1], gl.float32, mi_layout, num_buffers=1)
+        if config.mi_use_tmem:
+            mi_chnl = TensorMemoryChannel._borrow(mi_tmem, [config.SPLIT_M, 1], gl.float32, mi_layout, num_buffers=1)
+            m_i = gl.convert_layout(tile.m_i.expand_dims(1), config.mi_2d_layout)
+        else:
+            mi_chnl = SharedMemoryChannel.create([config.SPLIT_M], gl.float32, gl.constexpr(mbarrier.MBarrierLayout()),
+                                                 num_buffers=1)
+            m_i = tile.m_i
+        mi_chnl.mem.index(0).store(m_i)
         mi_chnl.initialize_for_producer()
-        mi_chnl.mem.index(0).store(gl.convert_layout(tile.m_i.expand_dims(1), config.mi_2d_layout))
 
         li_smem = gl.allocate_shared_memory(gl.float32, [config.SPLIT_M], gl.constexpr(mbarrier.MBarrierLayout()))
         li_smem.store(tile.l_i)
@@ -671,8 +681,12 @@ def _attn_fwd_mma(config,  #
 
 @gluon.jit
 def _attn_fwd_correction_compute(config, mi_consumer, o_consumer, m_i):
-    m_ij, mi_consumer = mi_consumer.get(config.mi_2d_layout)
-    m_ij = gl.convert_layout(m_ij.reshape([config.SPLIT_M]), gl.constexpr(gl.SliceLayout(1, config.o_splitn_layout)))
+    mi_layout: gl.constexpr = gl.SliceLayout(1, config.o_splitn_layout)
+    if config.mi_use_tmem:
+        m_ij, mi_consumer = mi_consumer.get(config.mi_2d_layout)
+        m_ij = gl.convert_layout(m_ij.reshape([config.SPLIT_M]), mi_layout)
+    else:
+        m_ij, mi_consumer = mi_consumer.get(mi_layout)
     alpha = gl.exp2(m_i - m_ij)
 
     o_tmem, o_bar, o_consumer = o_consumer.acquire()
@@ -731,8 +745,11 @@ def _softmax_tile(tile_id: gl.constexpr, config, info, STAGE: gl.constexpr):
     p_producer = info.p_chnl.create_producer()
     mi_producer = info.mi_chnl.create_producer()
 
-    m_i = info.mi_chnl.mem.index(0).load(config.mi_2d_layout)
-    m_i = gl.convert_layout(m_i.reshape([config.SPLIT_M]), qk_slice_dim1)
+    if config.mi_use_tmem:
+        m_i = info.mi_chnl.mem.index(0).load(config.mi_2d_layout)
+        m_i = gl.convert_layout(m_i.reshape([config.SPLIT_M]), qk_slice_dim1)
+    else:
+        m_i = info.mi_chnl.mem.index(0).load(qk_slice_dim1)
     l_i = info.li_smem.load(qk_slice_dim1)
 
     for start_n in range(lo, hi, config.BLOCK_N):
@@ -744,11 +761,17 @@ def _softmax_tile(tile_id: gl.constexpr, config, info, STAGE: gl.constexpr):
             mask = offs_m[:, None] >= (start_n + offs_n[None, :])
             qk = qk * config.qk_scale + gl.where(mask, 0, -1.0e6)
             m_ij = gl.maximum(m_i, gl.max(qk, 1))
-            mi_producer = mi_producer.emplace(gl.convert_layout(m_ij.expand_dims(1), config.mi_2d_layout))
+            if config.mi_use_tmem:
+                mi_producer = mi_producer.emplace(gl.convert_layout(m_ij.expand_dims(1), config.mi_2d_layout))
+            else:
+                mi_producer = mi_producer.emplace(m_ij)
             qk -= m_ij[:, None]
         else:
             m_ij = gl.maximum(m_i, gl.max(qk, 1) * config.qk_scale)
-            mi_producer = mi_producer.emplace(gl.convert_layout(m_ij.expand_dims(1), config.mi_2d_layout))
+            if config.mi_use_tmem:
+                mi_producer = mi_producer.emplace(gl.convert_layout(m_ij.expand_dims(1), config.mi_2d_layout))
+            else:
+                mi_producer = mi_producer.emplace(m_ij)
             qk = qk * config.qk_scale - m_ij[:, None]
 
         p = gl.exp2(qk)
@@ -1007,5 +1030,4 @@ def bench(Z, H, N_CTX, HEAD_DIM, causal, provider):
 
 
 if __name__ == "__main__":
-    test_op(1, 32, 16 * 1024, 64, True, torch.float16)
-    # bench.run(save_path=".", print_data=True)
+    bench.run(save_path=".", print_data=True)


### PR DESCRIPTION
* Pass `m_i` through tensor memory
* Use `FMUL2` instructions in correction partition
* For `DHEAD=128`, subtile `p` production in the softmax partition
  * This allows us to scrounge a few extra registers for the correction partition (200->192)
  * This allows ptxas to overlap the f32 to f16 downcast with the exp
* Reduce the number of instructions needed to apply causal masking
  * Each element is produced with IADD3, conditional, and FSEL