### PR TITLE
[BACKEND] Add a new pass to insert fence.proxy.async for write after read hazard

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -95,7 +95,9 @@ private:
 //===----------------------------------------------------------------------===//
 // Shared Memory Barrier Analysis
 //===----------------------------------------------------------------------===//
-class MembarAnalysis {
+
+// Common class to analyze membar and fence placement.
+class MembarOrFenceAnalysis {
   using VirtualBlock = std::pair<Block *, Block::iterator>;
 
 public:
@@ -113,15 +115,15 @@ public:
   /// a shared memory read. If the temporary storage is written but not read,
   /// it is considered as the problem of the operation itself but not the membar
   /// analysis.
-  MembarAnalysis() = default;
-  explicit MembarAnalysis(Allocation *allocation, MembarFilterFn filter)
+  MembarOrFenceAnalysis() = default;
+  explicit MembarOrFenceAnalysis(Allocation *allocation, MembarFilterFn filter)
       : allocation(allocation), filter(filter) {}
 
   /// Runs the membar analysis to the given operation, inserts a barrier if
   /// necessary.
   void run(FuncBlockInfoMapT &funcBlockInfoMap);
 
-private:
+protected:
   /// Applies the barrier analysis based on the SCF dialect, in which each
   /// region has a single basic block only.
   /// Example:
@@ -139,19 +141,32 @@ private:
   void resolve(FunctionOpInterface funcOp, FuncBlockInfoMapT *funcBlockInfoMap,
                OpBuilder *builder);
 
-  /// Updates the BlockInfo operation based on the operation.
-  void update(Operation *operation, BlockInfo *blockInfo,
-              FuncBlockInfoMapT *funcBlockInfoMap, OpBuilder *builder);
-
   /// Collects the successors of the terminator
   void visitTerminator(Operation *operation,
                        SmallVector<VirtualBlock> &successors);
 
-  void insertBarrier(Operation *operation, OpBuilder *builder);
+  /// Updates the BlockInfo operation based on the operation.
+  virtual void update(Operation *operation, BlockInfo *blockInfo,
+                      FuncBlockInfoMapT *funcBlockInfoMap,
+                      OpBuilder *builder) = 0;
 
-private:
   Allocation *allocation = nullptr;
   MembarFilterFn filter = nullptr;
+};
+
+class MembarAnalysis : public MembarOrFenceAnalysis {
+public:
+  MembarAnalysis() = default;
+  explicit MembarAnalysis(Allocation *allocation, MembarFilterFn filter)
+      : MembarOrFenceAnalysis(allocation, filter) {}
+
+private:
+  /// Updates the BlockInfo operation based on the operation.
+  virtual void update(Operation *operation, BlockInfo *blockInfo,
+                      FuncBlockInfoMapT *funcBlockInfoMap,
+                      OpBuilder *builder) override;
+
+  void insertBarrier(Operation *operation, OpBuilder *builder);
 };
 
 /// Postorder traversal on the callgraph to insert membar instructions
@@ -159,10 +174,11 @@ private:
 /// Each function maintains a BlockInfo map that includes all potential buffers
 /// after returning. This way users do not have to explicitly insert membars
 /// before and after function calls, but might be a bit conservative.
-class ModuleMembarAnalysis : public CallGraph<BlockInfo> {
+template <typename AnalysisType>
+class ModuleMembarOrFenceAnalysis : public CallGraph<BlockInfo> {
 public:
-  ModuleMembarAnalysis(ModuleAllocation *moduleAllocation,
-                       MembarFilterFn filter = nullptr)
+  ModuleMembarOrFenceAnalysis(ModuleAllocation *moduleAllocation,
+                              MembarFilterFn filter = nullptr)
       : CallGraph<BlockInfo>(moduleAllocation->getModuleOp()),
         moduleAllocation(moduleAllocation), filter(filter) {}
 
@@ -175,7 +191,7 @@ public:
           auto *allocation = moduleAllocation->getFuncData(funcOp);
           auto [it, inserted] = funcMap.try_emplace(funcOp, BlockInfo());
           if (inserted) {
-            MembarAnalysis analysis(allocation, filter);
+            AnalysisType analysis(allocation, filter);
             analysis.run(funcMap);
           }
         });
@@ -185,6 +201,8 @@ private:
   ModuleAllocation *moduleAllocation;
   MembarFilterFn filter;
 };
+
+typedef ModuleMembarOrFenceAnalysis<MembarAnalysis> ModuleMembarAnalysis;
 
 } // namespace mlir
 

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -41,6 +41,28 @@ def TritonGPUPlanCTAPass : Pass<"triton-nvidia-gpu-plan-cta", "mlir::ModuleOp"> 
 }
 
 def TritonGPUFenceInsertion : Pass<"triton-nvidia-gpu-fence-insertion", "mlir::ModuleOp"> {
+  let summary = "Insert fences across generic and async proxy.";
+
+  let description = [{
+    This pass is to insert memory fences to ensure that memory operations are
+    properly ordered across generic and async operations.
+    This pass inserts fences at optimized location.
+    There is a pass later to handle all the functional requirements
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+
+  let options = [
+    Option<"computeCapability", "compute-capability",
+           "int32_t", /*default*/"90",
+           "device compute capability">
+  ];
+}
+
+def TritonGPUProxyFenceInsertion : Pass<"triton-nvidia-gpu-proxy-fence-insertion", "mlir::ModuleOp"> {
   let summary = "Insert fences across generic and async proxy";
 
   let description = [{

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -8,16 +8,16 @@
 
 namespace mlir {
 
-void MembarAnalysis::run(FuncBlockInfoMapT &funcBlockInfoMap) {
+void MembarOrFenceAnalysis::run(FuncBlockInfoMapT &funcBlockInfoMap) {
   FunctionOpInterface funcOp =
       dyn_cast<FunctionOpInterface>(allocation->getOperation());
   OpBuilder builder(funcOp.getContext());
   resolve(funcOp, &funcBlockInfoMap, &builder);
 }
 
-void MembarAnalysis::resolve(FunctionOpInterface funcOp,
-                             FuncBlockInfoMapT *funcBlockInfoMap,
-                             OpBuilder *builder) {
+void MembarOrFenceAnalysis::resolve(FunctionOpInterface funcOp,
+                                    FuncBlockInfoMapT *funcBlockInfoMap,
+                                    OpBuilder *builder) {
   // Initialize the blockList. Operations are organized into "virtual blocks",
   // which represent segments of straight-line code analyzed by each iteration
   // of the dataflow analysis. Virtual blocks abstract over both control flow
@@ -103,8 +103,8 @@ void MembarAnalysis::resolve(FunctionOpInterface funcOp,
   });
 }
 
-void MembarAnalysis::visitTerminator(Operation *op,
-                                     SmallVector<VirtualBlock> &successors) {
+void MembarOrFenceAnalysis::visitTerminator(
+    Operation *op, SmallVector<VirtualBlock> &successors) {
   if (isa<BranchOpInterface>(op)) {
     // Collect the block successors of the branch.
     for (Block *successor : op->getSuccessors())

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   OptimizeTMemLayouts.cpp
   PlanCTA.cpp
   PromoteLHSToTMem.cpp
+  ProxFenceInsertion.cpp
   RemoveTMEMTokens.cpp
   TensorMemoryAllocation.cpp
   TMALowering.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxFenceInsertion.cpp
@@ -1,0 +1,196 @@
+#include "triton/Analysis/Allocation.h"
+#include "triton/Analysis/Membar.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+
+//===----------------------------------------------------------------------===//
+//
+// On Hopper+, async proxy is separate from generic proxy, so when shared memory
+// is the generic proxy to the async proxy we need to insert a fence to ensure
+// memory consistency.
+// This pass analyzes dependencies and will conservatively insert fences to
+// avoid race conditions between proxies. Async proxy is defined here:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#async-proxy
+//
+// This pass runs after shared memory allocation, to make sure we insert fences
+// between ops accessing aliasing buffers if needed.
+//
+// We also run a fence insertion pass during optimization phase as it is easier
+// to insert fences at optimial location based on structured control flow.
+//
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONGPUPROXYFENCEINSERTION
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+bool isAsyncProxyWrite(Operation *op) {
+  return isa<triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp,
+             triton::nvidia_gpu::AsyncTMAGatherOp>(op);
+}
+
+Value getSmemDest(Operation *op) {
+  if (auto asyncTMACopyGlobalToLocalOp =
+          dyn_cast<triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp>(op)) {
+    return asyncTMACopyGlobalToLocalOp.getResult();
+  }
+  if (auto asyncTMAGatherOp =
+          dyn_cast<triton::nvidia_gpu::AsyncTMAGatherOp>(op)) {
+    return asyncTMAGatherOp.getResult();
+  }
+  return Value();
+}
+
+bool isAsyncProxyRead(Operation *op) {
+  return isa<triton::nvidia_gpu::WarpGroupDotOp,
+             triton::nvidia_gpu::TCGen5MMAOp,
+             triton::nvidia_gpu::TCGen5MMAScaledOp,
+             triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp,
+             triton::nvidia_gpu::AsyncTMAScatterOp,
+             triton::nvidia_gpu::AsyncTMAReduceOp>(op);
+}
+
+bool ignoreOpForProxyFence(Operation *op) {
+  return isAsyncProxyRead(op) || isAsyncProxyWrite(op) ||
+         isa<triton::nvidia_gpu::ArriveBarrierOp,
+             triton::nvidia_gpu::TMEMCopyOp, triton::nvidia_gpu::WaitBarrierOp,
+             triton::nvidia_gpu::InitBarrierOp,
+             triton::nvidia_gpu::InvalBarrierOp>(op);
+}
+
+bool filterFn(Operation *op, Operation *other) {
+  return ignoreOpForProxyFence(other);
+}
+
+//===----------------------------------------------------------------------===//
+// Proxy Fence Analysis
+//===----------------------------------------------------------------------===//
+class ProxyFenceAnalysis : public MembarOrFenceAnalysis {
+
+public:
+  ProxyFenceAnalysis() = default;
+  explicit ProxyFenceAnalysis(Allocation *allocation, MembarFilterFn filter)
+      : MembarOrFenceAnalysis(allocation, filter) {}
+
+private:
+  /// Updates the BlockInfo operation based on the operation.
+  virtual void update(Operation *operation, BlockInfo *blockInfo,
+                      FuncBlockInfoMapT *funcBlockInfoMap,
+                      OpBuilder *builder) override;
+
+  void insertFence(Operation *operation, OpBuilder *builder);
+};
+
+void ProxyFenceAnalysis::insertFence(Operation *op, OpBuilder *builder) {
+  OpBuilder::InsertionGuard g(*builder);
+  builder->create<triton::nvidia_gpu::FenceAsyncSharedOp>(op->getLoc(), false);
+}
+
+void ProxyFenceAnalysis::update(Operation *op, BlockInfo *blockInfo,
+                                FuncBlockInfoMapT *funcBlockInfoMap,
+                                OpBuilder *builder) {
+  if (isa<triton::nvidia_gpu::FenceAsyncSharedOp>(op)) {
+    // If the current op is a fence, we clear previous reads and writes
+    blockInfo->sync();
+    return;
+  }
+  BlockInfo curBlockInfo;
+  BlockInfo proxyBlockInfo;
+
+  auto scratchBufferId = Allocation::InvalidBufferId;
+  if (isa<triton::CallOp>(op)) {
+    // Inter-function dependencies
+    auto callOpInterface = dyn_cast<CallOpInterface>(op);
+    if (auto callee =
+            dyn_cast<FunctionOpInterface>(callOpInterface.resolveCallable()))
+      curBlockInfo = funcBlockInfoMap->lookup(callee);
+  } else {
+    // Intra-function dependencies
+    if (auto memoryEffectOpInterface = dyn_cast<MemoryEffectOpInterface>(op)) {
+      // Explicit buffer
+      SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>>
+          effectInstances;
+      memoryEffectOpInterface.getEffects(effectInstances);
+      for (auto effectInstance : effectInstances) {
+        if (auto value = effectInstance.getValue()) {
+          for (auto bufferId : allocation->getBufferIds(value)) {
+            if (bufferId != Allocation::InvalidBufferId) {
+              // TODO: handle proxy read cases. Those are currently handled in
+              // FenceInsertionPass where it can generate better placement for
+              // the fence. But we should support a safe fallback here.
+              if (isAsyncProxyWrite(op)) {
+                if (value == getSmemDest(op)) {
+                  proxyBlockInfo
+                      .syncWriteIntervals[allocation->getAllocatedInterval(
+                          bufferId)]
+                      .insert(op);
+                }
+              } else if (isa<MemoryEffects::Write>(
+                             effectInstance.getEffect())) {
+                curBlockInfo
+                    .syncWriteIntervals[allocation->getAllocatedInterval(
+                        bufferId)]
+                    .insert(op);
+              } else if (isa<MemoryEffects::Read>(effectInstance.getEffect())) {
+                curBlockInfo
+                    .syncReadIntervals[allocation->getAllocatedInterval(
+                        bufferId)]
+                    .insert(op);
+              }
+            }
+          }
+        }
+      }
+    }
+    scratchBufferId = allocation->getBufferId(op);
+  }
+
+  // Scratch buffer operations consist of a series of shared memory operations
+  // starting from a shared memory write, followed by a series of shared memory
+  // read/write operations, mark them as a read.
+  if (scratchBufferId != Allocation::InvalidBufferId) {
+    auto interval = allocation->getAllocatedInterval(scratchBufferId);
+    curBlockInfo.syncReadIntervals[interval].insert(op);
+  }
+  if (isAsyncProxyWrite(op) || isAsyncProxyRead(op)) {
+    if (proxyBlockInfo.isIntersected(*blockInfo, filter)) {
+      builder->setInsertionPoint(op);
+      insertFence(op, builder);
+      blockInfo->sync();
+    }
+  }
+
+  // Update the region info, even if barrier is inserted, we have to maintain
+  // the current op's read/write buffers.
+  blockInfo->join(curBlockInfo);
+}
+} // namespace
+
+struct ProxyFenceInsertionPass
+    : public impl::TritonGPUProxyFenceInsertionBase<ProxyFenceInsertionPass> {
+
+public:
+  using impl::TritonGPUProxyFenceInsertionBase<
+      ProxyFenceInsertionPass>::TritonGPUProxyFenceInsertionBase;
+  void runOnOperation() override {
+    // Only insert fences for compute capability 9.0
+    if (computeCapability < 90)
+      return;
+    ModuleOp mod = getOperation();
+    ModuleAllocation allocation(mod);
+    ModuleMembarOrFenceAnalysis<ProxyFenceAnalysis> analysis(&allocation,
+                                                             filterFn);
+    analysis.run();
+  }
+};
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/test/TritonGPU/prox_fence_insertion.mlir
+++ b/test/TritonGPU/prox_fence_insertion.mlir
@@ -1,0 +1,45 @@
+// RUN: triton-opt %s -triton-nvidia-gpu-proxy-fence-insertion --split-input-file -allow-unregistered-dialect | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: fence_write_after_read
+  tt.func @fence_write_after_read(%arg0: !tt.tensordesc<tensor<64x64xf32, #shared>>, %arg1: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) {
+    // CHECK: ttg.local_load
+    // CHECK: ttng.fence_async_shared
+    // CHECK: ttng.async_tma_copy_global_to_local
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %0 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<32x64xf32, #shared, #smem, mutable>
+    %1 = ttg.local_load %0 : !ttg.memdesc<32x64xf32, #shared, #smem, mutable> -> tensor<32x64xf32, #blocked>
+    "test.keep"(%1) : (tensor<32x64xf32, #blocked>) -> ()
+    %2 = ttg.local_alloc {allocation.offset = 32 : i32} : () -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %2, %arg1, %true : !tt.tensordesc<tensor<64x64xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: async_proxy_after_async_proxy
+  tt.func @async_proxy_after_async_proxy(%arg0: !tt.tensordesc<tensor<64x64xf32, #shared>>, %arg1: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) {
+    // CHECK: ttng.async_tma_copy_global_to_local
+    // CHECK-NOT: ttng.fence_async_shared
+    // CHECK: ttng.async_tma_copy_global_to_local
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %0 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %arg1, %true : !tt.tensordesc<tensor<64x64xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    %2 = ttg.local_alloc {allocation.offset = 32 : i32} : () -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %2, %arg1, %true : !tt.tensordesc<tensor<64x64xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<64x64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -291,7 +291,7 @@ class CUDABackend(BaseBackend):
         passes.common.add_symbol_dce(pm)
         if capability // 10 >= 9:
             nvidia.passes.ttnvgpuir.add_tma_lowering(pm)
-            nvidia.passes.ttnvgpuir.add_fence_insertion(pm)
+        nvidia.passes.ttnvgpuir.add_fence_insertion(pm, capability)
         passes.common.add_sccp(pm)
         passes.common.add_canonicalizer(pm)
         pm.run(mod)
@@ -330,6 +330,7 @@ class CUDABackend(BaseBackend):
         passes.ttgpuir.add_allocate_shared_memory(pm)
         nvidia.passes.ttnvgpuir.add_allocate_tensor_memory(pm)
         passes.ttgpuir.add_allocate_global_scratch_memory(pm)
+        nvidia.passes.ttnvgpuir.add_proxy_fence_insertion(pm, capability)
         nvidia.passes.ttgpuir.add_to_llvmir(pm, capability, ptx_version)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -28,11 +28,27 @@ void init_triton_nvidia_passes_ttgpuir(py::module &&m) {
         });
 }
 
+static std::unique_ptr<mlir::Pass>
+createTritonGPUFenceInsertionWrapper(int32_t capability) {
+  ttng::TritonGPUFenceInsertionOptions options;
+  options.computeCapability = capability;
+  return ttng::createTritonGPUFenceInsertion(options);
+}
+
+static std::unique_ptr<mlir::Pass>
+createTritonGPUProxyFenceInsertionWrapper(int32_t capability) {
+  ttng::TritonGPUProxyFenceInsertionOptions options;
+  options.computeCapability = capability;
+  return ttng::createTritonGPUProxyFenceInsertion(options);
+}
+
 void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_1("add_plan_cta", ttng::createTritonNvidiaGPUPlanCTAPass,
                      mlir::triton::nvidia_gpu::ClusterInfo *);
-  ADD_PASS_WRAPPER_0("add_fence_insertion",
-                     ttng::createTritonGPUFenceInsertion);
+  ADD_PASS_WRAPPER_1("add_fence_insertion",
+                     createTritonGPUFenceInsertionWrapper, int32_t);
+  ADD_PASS_WRAPPER_1("add_proxy_fence_insertion",
+                     createTritonGPUProxyFenceInsertionWrapper, int32_t);
   ADD_PASS_WRAPPER_0("add_tma_lowering",
                      ttng::createTritonNvidiaGPUTMALoweringPass);
   ADD_PASS_WRAPPER_0("add_promote_lhs_to_tmem",


### PR DESCRIPTION
When loading data from smem using the generic proxy then writing using the async proxy we need to insert a fence before writing. This case was being missed in our current analysis. This commit hads a new pass to conservatively insert fences in this kind of scenario. We still need the existing insertFence pass as it can be smarter about fence insertion because it runs before lowering of the structured control flow. This pass is meant to be more conservative while the previous pass can optimize better.
Didn't see significant perf regressions so far.
