### PR TITLE
[AMD] Loosed constraints for MemDescSubviewOp

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -683,15 +683,11 @@ LogicalResult MemDescSubviewOp::verify() {
   //  - We split along at most one dim, but just with constant values
   //  - The values where the split happens must not be within the swizzling
   //  pattern
-  // Check which dimension we are splitting along
-  int dim = -1;
+  // Check which dimensions we are splitting along
+  SetVector<int> splitDims{};
   for (int i = 0; i < srcTy.getRank(); i++) {
     if (srcTy.getDimSize(i) != dstTy.getDimSize(i)) {
-      if (dim != -1) {
-        return emitError(
-            "We don't allow subviews that split along multiple dimensions");
-      }
-      dim = i;
+      splitDims.insert(i);
     }
   }
   SmallVector<int64_t> offsets;
@@ -702,12 +698,12 @@ LogicalResult MemDescSubviewOp::verify() {
     offsets.push_back(value.getSExtValue());
   }
   // Identity subview
-  if (dim == -1) {
+  if (splitDims.empty()) {
     return success();
   }
 
-  for (auto [i, offset] : llvm::enumerate(offsets)) {
-    if (i != dim) {
+  for (auto [dim, offset] : llvm::enumerate(offsets)) {
+    if (!splitDims.contains(dim)) {
       if (offset != 0) {
         return emitError("A non zero offset found in a dimension that is "
                          "not being split");
@@ -718,6 +714,7 @@ LogicalResult MemDescSubviewOp::verify() {
       }
     }
   }
+
   auto ctx = getContext();
   // The order gives us the honest-to-goodness layout rank
   auto srcAllocShape = srcTy.getAllocShape().take_back(getOrder(srcTy).size());
@@ -729,17 +726,19 @@ LogicalResult MemDescSubviewOp::verify() {
   }
 
   auto llInv = ll.invert();
-  auto kDim = mlir::StringAttr::get(ctx, "dim" + llvm::Twine(dim));
-  llvm::SmallVector<std::pair<mlir::StringAttr, int32_t>> namedOffsets;
-  for (auto d : standardOutDimNames(ctx, srcTy.getRank())) {
-    namedOffsets.push_back({d, 0});
-  }
-  for (int dimSize = dstTy.getDimSize(dim); dimSize < srcTy.getDimSize(dim);
-       dimSize *= 2) {
-    namedOffsets[dim] = {kDim, dimSize};
-    if (!llvm::isPowerOf2_32(llInv.apply(namedOffsets)[0].second)) {
-      return emitError(
-          "We don't support splitting along the swizzling pattern");
+  for (auto dim : splitDims) {
+    auto kDim = mlir::StringAttr::get(ctx, "dim" + llvm::Twine(dim));
+    llvm::SmallVector<std::pair<mlir::StringAttr, int32_t>> namedOffsets;
+    for (auto d : standardOutDimNames(ctx, srcTy.getRank())) {
+      namedOffsets.push_back({d, 0});
+    }
+    for (int dimSize = dstTy.getDimSize(dim); dimSize < srcTy.getDimSize(dim);
+         dimSize *= 2) {
+      namedOffsets[dim] = {kDim, dimSize};
+      if (!llvm::isPowerOf2_32(llInv.apply(namedOffsets)[0].second)) {
+        return emitError(
+            "We don't support splitting along the swizzling pattern");
+      }
     }
   }
   return success();

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6310,6 +6310,94 @@ shared_layouts = [
 ]
 
 
+@pytest.mark.parametrize("M, N, M_tile_size, N_tile_size",
+                         [[128, 128, 64, 64], [128, 128, 64, 32], [128, 64, 64, 32], [256, 128, 64, 64]])
+def test_split_subview(M, N, M_tile_size, N_tile_size, device='cuda'):
+    if not is_hip():
+        pytest.skip("the test is temporary disabled for the Nvidia backend.")
+
+    threads_per_warp = 64 if is_hip() else 32
+    num_raws_per_warp = 16 if is_hip() else 8
+    num_repeats_M = int(M / M_tile_size)
+    num_repeats_N = int(N / N_tile_size)
+
+    ir = f"""
+    #blocked = #ttg.blocked<{{sizePerThread=[1, 8], threadsPerWarp=[{num_raws_per_warp}, 4], warpsPerCTA=[4, 1], order=[1, 0], CTAsPerCGA=[1, 1], CTASplitNum=[1, 1], CTAOrder=[0, 1]}}>
+    #shared = #ttg.swizzled_shared<{{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0]}}>
+    #smem = #ttg.shared_memory
+
+    module attributes {{"ttg.num-ctas" = 1, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = {threads_per_warp} : i32}} {{
+    tt.func public @kernel(%arg0: !tt.ptr<f16> {{tt.divisibility = 16 : i32}}) {{
+        %cst = arith.constant dense<{N}> : tensor<{M}x1xi32, #blocked>
+        %cst_n = arith.constant dense<{N_tile_size}> : tensor<{M_tile_size}x1xi32, #blocked>
+        %0 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #ttg.slice<{{dim = 1, parent = #blocked}}>>
+        %1 = tt.make_range {{end = {N} : i32, start = 0 : i32}} : tensor<{N}xi32, #ttg.slice<{{dim = 0, parent = #blocked}}>>
+        %2 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
+        %4 = tt.expand_dims %0 {{axis = 1 : i32}} : tensor<{M}xi32, #ttg.slice<{{dim = 1, parent = #blocked}}>> -> tensor<{M}x1xi32, #blocked>
+        %5 = arith.muli %4, %cst : tensor<{M}x1xi32, #blocked>
+        %6 = tt.expand_dims %1 {{axis = 0 : i32}} : tensor<{N}xi32, #ttg.slice<{{dim = 0, parent = #blocked}}>> -> tensor<1x{N}xi32, #blocked>
+        %7 = tt.broadcast %6 : tensor<1x{N}xi32, #blocked> -> tensor<{M}x{N}xi32, #blocked>
+        %8 = tt.broadcast %5 : tensor<{M}x1xi32, #blocked> -> tensor<{M}x{N}xi32, #blocked>
+        %9 = arith.addi %8, %7 : tensor<{M}x{N}xi32, #blocked>
+        %ptrs = tt.addptr %2, %9 : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>, tensor<{M}x{N}xi32, #blocked>
+        %11 = tt.load %ptrs {{cache = 1 : i32, evict = 1 : i32, isVolatile = false}} : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
+
+        %c0_i32 = arith.constant 0 : i32
+
+        %12 = ttg.local_alloc : () -> !ttg.memdesc<1x{M}x{N}xf16, #shared, #smem, mutable>
+        %13 = ttg.memdesc_subview %12[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x{M}x{N}xf16, #shared, #smem, mutable> -> !ttg.memdesc<{M}x{N}xf16, #shared, #smem, mutable>
+        ttg.local_store %11, %13 : tensor<{M}x{N}xf16, #blocked> -> !ttg.memdesc<{M}x{N}xf16, #shared, #smem, mutable>
+
+    """
+
+    for m in range(num_repeats_M):
+        for n in range(num_repeats_N):
+            linear_idx = n + m * num_repeats_N
+            m_offset = m * M_tile_size
+            n_offset = n * N_tile_size
+            ir += f"""
+        %off0_{m}_{n} = arith.constant {m_offset} : i32
+        %off1_{m}_{n} = arith.constant {n_offset} : i32
+
+        %view{linear_idx} = ttg.memdesc_subview %13[%off0_{m}_{n}, %off1_{m}_{n}] : !ttg.memdesc<{M}x{N}xf16, #shared, #smem, mutable> -> !ttg.memdesc<{M_tile_size}x{N_tile_size}xf16, #shared, #smem, mutable, {M}x{N}>
+        %data{linear_idx} = ttg.local_load %view{linear_idx} : !ttg.memdesc<{M_tile_size}x{N_tile_size}xf16, #shared, #smem, mutable, {M}x{N}> -> tensor<{M_tile_size}x{N_tile_size}xf16, #blocked>
+        %inc{linear_idx} = arith.constant dense<{linear_idx}.0> : tensor<{M_tile_size}x{N_tile_size}xf16, #blocked>
+
+        %res{linear_idx} = arith.addf %data{linear_idx}, %inc{linear_idx} : tensor<{M_tile_size}x{N_tile_size}xf16, #blocked>
+        ttg.local_store %res{linear_idx}, %view{linear_idx} : tensor<{M_tile_size}x{N_tile_size}xf16, #blocked> -> !ttg.memdesc<{M_tile_size}x{N_tile_size}xf16, #shared, #smem, mutable, {M}x{N}>
+        """
+
+    ir += f"""
+        %res = ttg.local_load %13 : !ttg.memdesc<{M}x{N}xf16, #shared, #smem, mutable> -> tensor<{M}x{N}xf16, #blocked>
+        tt.store %ptrs, %res : tensor<{M}x{N}x!tt.ptr<f16>, #blocked>
+        tt.return
+    }}
+    }}
+    """
+
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.ttgir') as f:
+        f.write(ir)
+        f.flush()
+        kernel = triton.compile(f.name)
+
+    triton_result = torch.zeros((M, N), device=device, dtype=torch.float16)
+    kernel[(1, 1, 1)](triton_result.data_ptr())
+
+    rows = []
+    for m in range(num_repeats_M):
+        columns = []
+        for n in range(num_repeats_N):
+            linear_idx = n + m * num_repeats_N
+            tile = float(linear_idx) * torch.ones((M_tile_size, N_tile_size), device=device, dtype=torch.float16)
+            columns.append(tile)
+        rows.append(torch.cat(columns, dim=1))
+    expected_result = torch.cat(rows, dim=0)
+
+    test_result = torch.equal(triton_result, expected_result)
+    assert test_result
+
+
 @pytest.mark.parametrize("M, N", [[16, 32]])
 @pytest.mark.parametrize("dtype", ['float16', 'float8e5', 'float32'])
 @pytest.mark.parametrize("shared_layout", shared_layouts)

--- a/test/TritonGPU/memdesc-subview-split.mlir
+++ b/test/TritonGPU/memdesc-subview-split.mlir
@@ -1,0 +1,39 @@
+// RUN: triton-opt %s | FileCheck %s
+
+
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 2, maxPhase = 8, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: memdesc_subview_spliting
+  tt.func public @memdesc_subview_spliting() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1x256x128xf16, #shared, #smem, mutable>
+    %1 = ttg.memdesc_subview %0[%c0_i32, %c0_i32, %c0_i32] : !ttg.memdesc<1x256x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    %c0_i32_0 = arith.constant 0 : i32
+    %c0_i32_1 = arith.constant 0 : i32
+    %2 = ttg.memdesc_subview %1[%c0_i32_0, %c0_i32_1] : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable, 256x128>
+    %c0_i32_2 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %3 = ttg.memdesc_subview %1[%c0_i32_2, %c32_i32] : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable, 256x128>
+    %c0_i32_3 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %4 = ttg.memdesc_subview %1[%c0_i32_3, %c64_i32] : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable, 256x128>
+    %c0_i32_4 = arith.constant 0 : i32
+    %c96_i32 = arith.constant 96 : i32
+    %5 = ttg.memdesc_subview %1[%c0_i32_4, %c96_i32] : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable, 256x128>
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32_5 = arith.constant 0 : i32
+    %6 = ttg.memdesc_subview %1[%c128_i32, %c0_i32_5] : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable, 256x128>
+    %c128_i32_6 = arith.constant 128 : i32
+    %c32_i32_7 = arith.constant 32 : i32
+    %7 = ttg.memdesc_subview %1[%c128_i32_6, %c32_i32_7] : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable, 256x128>
+    %c128_i32_8 = arith.constant 128 : i32
+    %c64_i32_9 = arith.constant 64 : i32
+    %8 = ttg.memdesc_subview %1[%c128_i32_8, %c64_i32_9] : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable, 256x128>
+    %c128_i32_10 = arith.constant 128 : i32
+    %c96_i32_11 = arith.constant 96 : i32
+    %9 = ttg.memdesc_subview %1[%c128_i32_10, %c96_i32_11] : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable, 256x128>
+    tt.return
+  }
+}


### PR DESCRIPTION
The current implementation allows one to split MemDescSubviewOp along a single dimension which may be not enough in some cases (e.g., ops refinement). We only need to forbid splitting subview along the swizzling pattern.

cc: @lezcano

Closes https://github.com/ROCm/triton-internal/issues/913