### PR TITLE
[TMA] Correctly get TMA Block Shape for SwizzledShared Blocks

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
@@ -39,6 +39,17 @@ SmallVector<int64_t> getTMABlockShape(ArrayRef<int64_t> shapePerCTA,
 inline SmallVector<int64_t> getTMABlockShape(Attribute encoding,
                                              ArrayRef<int64_t> shapePerCTA,
                                              bool packedSize) {
+  auto swizzledEnc =
+      llvm::dyn_cast_or_null<gpu::SwizzledSharedEncodingAttr>(encoding);
+  if (swizzledEnc) {
+    SmallVector<int64_t> blockShape(shapePerCTA);
+    constexpr int64_t dimMax = 256;
+    for (auto &size : blockShape)
+      size = std::min(size, dimMax);
+
+    return blockShape;
+  }
+
   auto mmaEnc = cast<gpu::NVMMASharedEncodingAttr>(encoding);
   return getTMABlockShape(shapePerCTA, mmaEnc.getElementBitWidth(),
                           mmaEnc.getSwizzlingByteWidth(), mmaEnc.getFp4Padded(),


### PR DESCRIPTION
When calculating the TMA Block Shape, we previously assumed the encoding was always an `NVMMASharedEncodingAttr`. However, when the inner dimension is less than 8, the actual encoding is a `SwizzledSharedEncodingAttr`. Under our old assumption, casting to `NVMMASharedEncodingAttr` would result in reading garbage values for fields like `elementBitWidth`, `swizzleBytes`, `fp4Padded`, `transposed`, and `packedSize`. In practice, this often led to `fp4Padded` being incorrectly interpreted as `True`, causing the calculated Block Shape to be multiplied by 2. In certain cases, this results in unpredictable behavior during TMA load/store operations.

When we have a `SwizzledSharedEncodingAttr`, the only modification necessary to calculate the Block Shape is to limit each dimension to 256, the max size for a TMA block pointer.

We also need to fix something similar when calculating the unpacked offset layout.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because the changes should already be covered under `test_tensor_descriptor_store` and `test_make_tensor_descriptor_matmul` in test/unit/language/test_tensor_descriptor.py. And by `test_tensor_descriptor_reduce`, `test_tma_gather`, `test_tma_scatter`, `test_host_tensor_descriptor_load`, and `test_host_tensor_descriptor_matmul` in test/unit/cuda/test_tensor_descriptor.py

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
