### PR TITLE
[README] Mention `make dev-install-llvm` for custom LLVM build

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ downloads a prebuilt LLVM, but you can also build LLVM from source and use that.
 LLVM does not have a stable API, so the Triton build will not work at an
 arbitrary LLVM version.
 
+For convenience, you can use the following command to build LLVM at the correct
+version and installs Triton with the custom LLVM build:
+
+```shell
+make dev-install-llvm
+```
+
+<details>
+<summary>
+Alternatively, follow these steps to build LLVM from source manually.
+</summary>
+
 1. Find the version of LLVM that Triton builds against.  Check
 `cmake/llvm-hash.txt` to see the current version. For example, if it says:
        49af6502c6dcb4a7f7520178bd14df396f78240c
@@ -85,6 +97,8 @@ arbitrary LLVM version.
          LLVM_LIBRARY_DIR=$LLVM_BUILD_DIR/lib \
          LLVM_SYSPATH=$LLVM_BUILD_DIR \
          pip install -e .
+
+</details>
 
 # Tips for building
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ downloads a prebuilt LLVM, but you can also build LLVM from source and use that.
 LLVM does not have a stable API, so the Triton build will not work at an
 arbitrary LLVM version.
 
-For convenience, you can use the following command to build LLVM at the correct
-version and installs Triton with the custom LLVM build:
+For convenience, use the following command to build LLVM and install Triton with the custom LLVM:
 
 ```shell
 make dev-install-llvm


### PR DESCRIPTION
The make target `dev-install-llvm` was added in #6709 to streamline the process of building custom LLVM and installing Triton using it. 

While I was building Triton, I encountered the glibc version mismatch issue (e.g., #7088, #6747, #3397), and I found the script super useful to build LLVM from source, so I suppose it would be useful to mention it on README.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because this is a document update.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
