### PR TITLE
[Pipelining] make schedule.dump deterministic

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -85,7 +85,7 @@ public:
   using Cluster = ClusterList::iterator;
   using ClusterHash = size_t;
 
-  DenseMap<Operation *, std::pair<int, Cluster>> opToStageAndCluster;
+  llvm::MapVector<Operation *, std::pair<int, Cluster>> opToStageAndCluster;
 
   void setNumStages(int numStages) { this->numStages = numStages; }
   int getNumStages() const { return numStages; }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/Schedule.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/Schedule.cpp
@@ -8,7 +8,6 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
-#include "llvm/ADT/SmallSet.h"
 #include "llvm/Support/Debug.h"
 
 using namespace mlir;
@@ -127,8 +126,8 @@ tt::CoarseSchedule::splitClusterBefore(Operation *op, scf::ForOp forOp) {
 bool tt::CoarseSchedule::isOpBefore(Operation *a, Operation *b) const {
   assert(opToStageAndCluster.count(a) && opToStageAndCluster.count(b) &&
          "Operations must be in the schedule");
-  auto [aStage, aCluster] = opToStageAndCluster.at(a);
-  auto [bStage, bCluster] = opToStageAndCluster.at(b);
+  auto [aStage, aCluster] = opToStageAndCluster.lookup(a);
+  auto [bStage, bCluster] = opToStageAndCluster.lookup(b);
   if (aStage != bStage) {
     return aStage < bStage;
   }
@@ -142,14 +141,15 @@ bool tt::CoarseSchedule::isOpInEarlierCluster(Operation *a,
                                               Operation *b) const {
   assert(opToStageAndCluster.count(a) && opToStageAndCluster.count(b) &&
          "Operations must be in the schedule");
-  return clusters.isBefore(opToStageAndCluster.at(a).second,
-                           opToStageAndCluster.at(b).second);
+  return clusters.isBefore(opToStageAndCluster.lookup(a).second,
+                           opToStageAndCluster.lookup(b).second);
 }
 
 bool tt::CoarseSchedule::isOpInSameCluster(Operation *a, Operation *b) const {
   assert(opToStageAndCluster.count(a) && opToStageAndCluster.count(b) &&
          "Operations must be in the schedule");
-  return opToStageAndCluster.at(a).second == opToStageAndCluster.at(b).second;
+  return opToStageAndCluster.lookup(a).second ==
+         opToStageAndCluster.lookup(b).second;
 }
 
 SmallVector<std::tuple<Operation *, int, tt::CoarseSchedule::Cluster>>
@@ -191,50 +191,15 @@ tt::CoarseSchedule::createFinalSchedule(scf::ForOp forOp) const {
 }
 
 void tt::CoarseSchedule::dump() {
-  auto getOpSortIdent = [](Operation *op) {
-    std::string opStr;
-    llvm::raw_string_ostream os(opStr);
-    if (op->getNumResults()) {
-      op->getResult(0).printAsOperand(os, OpPrintingFlags().assumeVerified());
-    } else if (op->getNumOperands()) {
-      op->getOperand(0).printAsOperand(os, OpPrintingFlags().assumeVerified());
-    } else {
-      opStr = op->getName().getStringRef();
+  assert(numStages > 0 && "Invalid number of stages");
+  for (int i = 0; i < numStages; i++) {
+    llvm::dbgs() << "\n---- Ops in stage " << i << "\n";
+    for (auto &[op, stageAndCluster] : opToStageAndCluster) {
+      if (i == stageAndCluster.first) {
+        llvm::dbgs() << "        cluster: " << *stageAndCluster.second
+                     << ":\n\t" << *op << "\n";
+      }
     }
-    return opStr;
-  };
-
-  SmallVector<std::pair<Operation *, std::pair<int, Cluster>>> ops(
-      opToStageAndCluster.begin(), opToStageAndCluster.end());
-  llvm::sort(ops, [&getOpSortIdent](
-                      std::pair<Operation *, std::pair<int, Cluster>> &one,
-                      std::pair<Operation *, std::pair<int, Cluster>> &two) {
-    auto &[op1, stageAndCluster1] = one;
-    auto &[op2, stageAndCluster2] = two;
-    if (stageAndCluster1.first != stageAndCluster2.first)
-      return stageAndCluster1.first < stageAndCluster2.first;
-
-    if (stageAndCluster1.second._M_node && stageAndCluster2.second._M_node &&
-        *stageAndCluster1.second != *stageAndCluster2.second)
-      return *stageAndCluster1.second < *stageAndCluster2.second;
-    std::string op1Ident = getOpSortIdent(op1);
-    std::string op2Ident = getOpSortIdent(op2);
-    return std::lexicographical_compare(op1Ident.begin(), op1Ident.end(),
-                                        op2Ident.begin(), op2Ident.end());
-  });
-
-  llvm::SmallSet<int, 3> seenStages, seenClusters;
-  for (auto &[op, stageAndCluster] : ops) {
-    if (!seenStages.contains(stageAndCluster.first)) {
-      seenStages.insert(stageAndCluster.first);
-      seenClusters.clear();
-      llvm::dbgs() << "stage: " << stageAndCluster.first << "\n";
-    }
-    if (!seenClusters.contains(*stageAndCluster.second)) {
-      seenClusters.insert(*stageAndCluster.second);
-      llvm::dbgs() << "cluster: " << *stageAndCluster.second << "\n";
-    }
-    llvm::dbgs() << "\t" << *op << "\n";
   }
 }
 


### PR DESCRIPTION
Lately I've been working on AMD's pipelining and I've been looking at schedule dumps. They're great but unfortunately (due to `DenseMap`) not deterministic. This PR makes `opToStageAndCluster` a `MapVector` instead (which produces deterministic dumps).