### PR TITLE
[BACKEND] Support fp64 simt fma for common use and fp64 mma for SM80.

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -216,9 +216,9 @@ unsigned getNumScratchElements(ArrayRef<unsigned> shape);
 
 bool supportWMMA(triton::DotOp op);
 
-bool supportMMA(triton::DotOp op, int version);
+bool supportMMA(triton::DotOp op, int version, bool supportF64mma);
 
-bool supportMMA(Value value, int version);
+bool supportMMA(Value value, int version, bool supportF64mma);
 
 // Conversion from `srcTy` to `dstTy` involving the minimum amount of data
 // transfer provided that both types can be converted to LL (if it can't it'll

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -1442,7 +1442,7 @@ vecIdx (index of the element in the quad; this is always along the k-dim)
         return $_get(context, opIdx, parent, 0);
       // For MMAV2 and V3
       unsigned bitwidth = eltTy.getIntOrFloatBitWidth();
-      unsigned kWidth = 32 / bitwidth;
+      unsigned kWidth = bitwidth < 32 ? 32 / bitwidth : 1;
       return $_get(context, opIdx, parent, kWidth);
     }]>
   ];

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2075,9 +2075,9 @@ NvidiaMmaEncodingAttr::getRepOrderForOperand(int opIdx) const {
 SmallVector<int64_t>
 NvidiaMmaEncodingAttr::getRepForOperand(ArrayRef<int64_t> shape, int bitwidth,
                                         int kWidth, int opIdx) const {
-  assert(
-      kWidth >= 32 / bitwidth &&
-      "kWidth must be >= 32 / bitwidth for this function to be well-defined");
+  assert(kWidth >= (bitwidth < 32 ? 32 / bitwidth : 1) &&
+         "kWidth must be >= max(32 / bitwidth, 1) for this function to be "
+         "well-defined");
   auto rank = shape.size();
   // Broadcast long K
   auto warpsPerCTA = to_vector(getWarpsPerCTA());

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -44,8 +44,12 @@ static int getMMAVersionSafe(int computeCapability, DotOp op) {
   } else {
     assert(false && "computeCapability not supported");
   }
+  bool supportF64mma = false;
+  if (computeCapability == 80) {
+    supportF64mma = true; // TODO: support F64 MMA for SM90
+  }
   for (int baseVersion : versionsSupported) {
-    if (supportMMA(op, baseVersion))
+    if (supportMMA(op, baseVersion, supportF64mma))
       return baseVersion;
     if (baseVersion == 3) {
       auto remark = op.emitRemark()

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1472,10 +1472,10 @@ class TritonSemantic(Generic[TensorTy]):
             # All combinations of supported fp8 x fp8 are permitted
             pass
         else:
-            assert lhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16,
-                                 tl.float32), f"Unsupported lhs dtype {lhs.dtype}"
-            assert rhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16,
-                                 tl.float32), f"Unsupported rhs dtype {rhs.dtype}"
+            assert lhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16, tl.float32,
+                                 tl.float64), f"Unsupported lhs dtype {lhs.dtype}"
+            assert rhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16, tl.float32,
+                                 tl.float64), f"Unsupported rhs dtype {rhs.dtype}"
             assert lhs.dtype == rhs.dtype, f"Both operands must be same dtype. Got {lhs.dtype} and {rhs.dtype}"
 
         if lhs.dtype.is_fp8e4b15() or rhs.dtype.is_fp8e4b15():
@@ -1514,6 +1514,9 @@ class TritonSemantic(Generic[TensorTy]):
         elif lhs.type.scalar.is_fp32() or lhs.type.scalar.is_bf16():
             _0 = self.builder.get_fp32(0)
             ret_scalar_ty = tl.float32
+        elif lhs.type.scalar.is_fp64():
+            _0 = self.builder.get_fp64(0)
+            ret_scalar_ty = tl.float64
         else:
             _0 = self.builder.get_fp16(0) if out_dtype.is_fp16() else self.builder.get_fp32(0)
             ret_scalar_ty = out_dtype

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1873,6 +1873,34 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 // -----
 
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [1, 1], instrShape = [16, 8]}>
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 1, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 2, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {ttg.global_scratch_memory_alignment = 1 : i32, ttg.global_scratch_memory_size = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 4096 : i32, ttg.target = "cuda:80", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @f64_mma_cvt() {
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x16xf64, #shared, #smem, mutable>
+    %1 = ttg.local_alloc {allocation.offset = 2048 : i32} : () -> !ttg.memdesc<16x16xf64, #shared1, #smem, mutable>
+
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf64, #mma>
+
+    %2 = ttg.local_load %0 : !ttg.memdesc<16x16xf64, #shared, #smem, mutable> -> tensor<16x16xf64, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+
+    %3 = ttg.local_load %1 : !ttg.memdesc<16x16xf64, #shared1, #smem, mutable> -> tensor<16x16xf64, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>
+
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m8n8k4.row.col.f64.f64.f64.f64
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: mma.sync.aligned.m8n8k4.row.col.f64.f64.f64.f64
+
+    %out = tt.dot %2, %3, %cst, inputPrecision = tf32 : tensor<16x16xf64, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<16x16xf64, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<16x16xf64, #mma>
+
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
 module attributes {"ttg.target" = "cuda:75", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32} {

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -121,6 +121,21 @@ module attributes {"ttg.target" = "cuda:89", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+// CHECK: #mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:80", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fp64_dot(
+    %arg0: tensor<128x32xf64, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+    %arg1: tensor<32x128xf64, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>) -> tensor<128x128xf64, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf64, #blocked>
+    // CHECK: tt.dot {{.*}} : tensor<128x32xf64, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<32x128xf64, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<128x128xf64, #mma>
+    %d = tt.dot %arg0, %arg1, %cst, inputPrecision = tf32 : tensor<128x32xf64, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<32x128xf64, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf64, #blocked>
+    tt.return %d : tensor<128x128xf64, #blocked>
+  }
+}
+
+// -----
+
 // CHECK-DAG: #[[MMA:.+]] = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 8]}>
 // CHECK-DAG: #[[MMA1:.+]] = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1, 1], instrShape = [1, 16, 8]}>
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -304,7 +304,7 @@ private:
 
     // unpack i32 vectors and cast to native type
     if (bitwidth != 16) {
-      auto numElemsPerVec = 32 / bitwidth;
+      auto numElemsPerVec = bitwidth < 32 ? 32 / bitwidth : 1;
       auto vecTy = vec_ty(llvmElemTy, numElemsPerVec);
       for (int v = 0; v < static_cast<int>(elemsI32.size()); ++v) {
         auto vec = b.bitcast(elemsI32[v], vecTy);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -41,7 +41,9 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
 
     NvidiaMmaEncodingAttr mmaLayout = dyn_cast<NvidiaMmaEncodingAttr>(
         cast<RankedTensorType>(D.getType()).getEncoding());
-    if (!isOuter && mmaLayout && supportMMA(op, mmaLayout.getVersionMajor())) {
+    bool supportF64mma = mmaLayout && mmaLayout.isAmpere();
+    if (!isOuter && mmaLayout &&
+        supportMMA(op, mmaLayout.getVersionMajor(), supportF64mma)) {
       if (mmaLayout.isTuring())
         return convertMMA1688(op, adaptor, getTypeConverter(), rewriter);
       if (mmaLayout.isAmpere())
@@ -80,7 +82,9 @@ struct WarpGroupDotOpConversion
     bool isOuter = K == 1;
 
     auto mmaLayout = cast<NvidiaMmaEncodingAttr>(D.getType().getEncoding());
-    if (!isOuter && supportMMA(op.getOperand(0), mmaLayout.getVersionMajor())) {
+    bool supportF64mma = false;
+    if (!isOuter && supportMMA(op.getOperand(0), mmaLayout.getVersionMajor(),
+                               supportF64mma)) {
       return convertWGMMA(op, adaptor, getTypeConverter(), rewriter,
                           getThreadId(rewriter, loc));
     }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -68,7 +68,8 @@ LogicalResult lowerLdStMatrix(
   std::optional<ColumnAction> maybePermutation;
   LinearLayout tile;
   if (!transpose) {
-    tile = LinearLayout::identity1D(32 / bitwidth, kReg, kOffset) *
+    tile = LinearLayout::identity1D(bitwidth < 32 ? 32 / bitwidth : 1, kReg,
+                                    kOffset) *
            LinearLayout::identity1D(4, kLane, kOffset);
 
     // Find if there is a register permutation that allows us to divideLeft
@@ -129,15 +130,17 @@ LogicalResult lowerLdStMatrix(
   }
 
   // We must have at least 2 register elements to use stmatrix.trans
-  if (transpose && reps.getInDimSizeLog2(kReg) < llvm::Log2_32(32 / bitwidth)) {
+  if (transpose && reps.getInDimSizeLog2(kReg) <
+                       llvm::Log2_32(bitwidth < 32 ? 32 / bitwidth : 1)) {
     return failure();
   }
 
   // Choose up to 4 packs of 32-bit elements indexed by the next (at most) two
   // bases as the vectorisation factor. We don't consider the basis of the tile
   // for vectorisation so we substract them
-  auto vec = std::min<int32_t>(2, reps.getInDimSizeLog2(kReg) -
-                                      llvm::Log2_32(32 / bitwidth));
+  auto vec = std::min<int32_t>(
+      2, reps.getInDimSizeLog2(kReg) -
+             llvm::Log2_32(bitwidth < 32 ? 32 / bitwidth : 1));
 
   // Map from kReg, kLane, kWarp to beginning of each tile
   assert(reps.getOutDimSize(kOffset) == cvt.getOutDimSize(kOffset));
@@ -156,7 +159,7 @@ LogicalResult lowerLdStMatrix(
   //   by the first `vec` reg bases that are not part of the tile
   std::vector<std::vector<int32_t>> laneBases;
   if (!transpose) {
-    auto tileDimSizeReg = llvm::Log2_32(32 / bitwidth);
+    auto tileDimSizeReg = llvm::Log2_32(bitwidth < 32 ? 32 / bitwidth : 1);
     auto tileDimSizeLane = 2;
     for (int i = 0; i < 3; ++i) {
       laneBases.push_back(reps.getBasis(kLane, tileDimSizeLane + i));
@@ -184,14 +187,14 @@ LogicalResult lowerLdStMatrix(
 
   // Elements per op
   auto nVecs = 1 << vec;
-  auto elemsPerVec = 32 / bitwidth;
+  auto elemsPerVec = bitwidth < 32 ? 32 / bitwidth : 1;
   auto step = nVecs * elemsPerVec;
   for (int i = 0; i < cvt.getInDimSize(kReg); i += step) {
     auto regIdx = reps.apply({{kReg, i}, {kLane, 0}, {kWarp, 0}})[0].second;
     Value offset = b.xor_(regBase, b.i32_val(regIdx));
     auto vecAddr = b.gep(smemPtrTy, llvmElemTy, smemBase, offset,
                          LLVM::GEPNoWrapFlags::inbounds);
-    Type packedTy = vec_ty(llvmElemTy, 32 / bitwidth);
+    Type packedTy = vec_ty(llvmElemTy, bitwidth < 32 ? 32 / bitwidth : 1);
     if (isStore) {
       // Pack into vector of i32
       SmallVector<Value> inputs;


### PR DESCRIPTION
This PR add support to fp64 simt fma for common use and fp64 mma for SM80.

- Modify numElemsPerVec's calculation from `32 / bitwidth` to `bitwidth < 32 ? 32 / bitwidth : 1` to support fp64 in many files
- Add func `callMmaAmpereFp64` in MMAv2.cpp to support `TensorCoreType::FP64_FP64_FP64_FP64`, with corresponding logic adjustments.
- Check `supportF64mma` in the MMA selection flow. Currently, fp64 MMA is only enabled for SM80, while SM90 fp64 support will be implemented in the future.
- Add lit tests and python end-to-end test

implements #5483

Performance has been verified on A100.

```bash
python3 python/tutorials/03-matrix-multiplication_fp64.py 
......
✅ Triton and Torch match
matmul-performance-fp16:
         M       N       K     cuBLAS     Triton
0    256.0   256.0   256.0   1.820444   1.638400
1    384.0   384.0   384.0   6.505412   4.253539
2    512.0   512.0   512.0   9.362286   7.489828
3    640.0   640.0   640.0  11.377778  11.906977
4    768.0   768.0   768.0  13.611323  10.532572
5    896.0   896.0   896.0  13.380267  14.483794
6   1024.0  1024.0  1024.0  15.087425  12.052598
7   1152.0  1152.0  1152.0  15.798857  14.782099
8   1280.0  1280.0  1280.0  14.628571  15.937743
9   1408.0  1408.0  1408.0  15.711170  13.494495
10  1536.0  1536.0  1536.0  15.353337  14.593584
11  1664.0  1664.0  1664.0  15.226585  13.717854
12  1792.0  1792.0  1792.0  14.372665  15.438769
13  1920.0  1920.0  1920.0  14.475393  13.768925
14  2048.0  2048.0  2048.0  15.006454  15.087425
15  2176.0  2176.0  2176.0  13.897547  15.073893
16  2304.0  2304.0  2304.0  16.239206  16.429073
17  2432.0  2432.0  2432.0  15.721580  15.153432
18  2560.0  2560.0  2560.0  14.246956  15.442035
19  2688.0  2688.0  2688.0  15.106753  14.657286
20  2816.0  2816.0  2816.0  15.255058  15.568163
21  2944.0  2944.0  2944.0  15.226408  16.206840
22  3072.0  3072.0  3072.0  15.095469  15.315960
23  3200.0  3200.0  3200.0  14.899313  16.004001
24  3328.0  3328.0  3328.0  15.007566  15.432218
25  3456.0  3456.0  3456.0  15.376991  16.040901
26  3584.0  3584.0  3584.0  14.894052  15.296936
27  3712.0  3712.0  3712.0  14.992847  16.001497
28  3840.0  3840.0  3840.0  14.634379  15.624753
29  3968.0  3968.0  3968.0  14.701679  16.282885
30  4096.0  4096.0  4096.0  15.184719  15.823830
```

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
