### PR TITLE
[pipeliner] do not optimize the pending number of AsyncWaitOp without…

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -112,7 +112,7 @@ static int minNumInterleavedCommitOps(Operation *waitOp) {
   };
 
   if (waitOp->getNumOperands() != 1)
-    return 0;
+    return cast<ttg::AsyncWaitOp>(waitOp).getNum();
   Value val = waitOp->getOperand(0);
   // If the value resides in a region other than the region of the wait op, then
   // the wait op must be in some nested region. Measure the number of commits


### PR DESCRIPTION
For an `AsyncWaitOp` op that does not come in with a valid token, the pipeliner could kick in optimizing its pending wait count to 0. This is problematic if the original op has a different pending count, even for loops with num_stages=0. I'm disabling the optimization. Not sure it is the right fix though.

The problem is exposed by user-written pipelined code (such as using TLX). I'm not sure how Gluon works around it.  