### PR TITLE
[AMD] Improve shared layout for Wmma's operands

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -286,34 +286,10 @@ When vec=2, elements are swizzled in pairs of 2.  In other words, the element at
         }
 
         // ---- begin WMMA ----
-        if (mlir::isa<AMDWmmaEncodingAttr>(dotOpEnc.getParent())) {
-          int kDimIndex = dotOpEnc.getOpIdx() == 0 ? 1 : 0;
-          bool isKContig = order[0] == kDimIndex;
-
-          if (!isKContig) {
-            // Do not swizzle. In this case accesses will go in different banks even
-            // without swizzling.
-            return get(context, 1, 1, 1, order, CTALayout);
-          }
-
-          // kWidth: the number of elements each thread loads from shared memory in
-          // preparation for wmma instructions.
-          auto kWidth = dotOpEnc.getKWidth();
-          // max vectorization size for ds_load is 128 bits
-          int vectorSize = std::min(kWidth * typeWidthInBit, 128u) / typeWidthInBit;
-
-          const int numBanks = 32;
-          const int bankBitWidth = 32;
-          const int simdWidth = 16;
-
-          // Number of inner dimension rows per one pattern repeat
-          int innerDimLength = shape[order[0]];
-          int elemsPerOneBanksRow = (numBanks * bankBitWidth) / typeWidthInBit;
-
-          int perPhase = std::max(1, elemsPerOneBanksRow / innerDimLength);
-          int maxPhase = std::max(std::min(simdWidth / perPhase, innerDimLength / vectorSize), 1);
-
-          return get(context, vectorSize, perPhase, maxPhase, order, CTALayout);
+        if (auto wmmaEnc = mlir::dyn_cast<AMDWmmaEncodingAttr>(dotOpEnc.getParent())) {
+          return wmmaEnc.composeSharedLayoutForOperand(
+              CTALayout, dotOpEnc.getOpIdx(), shape, order, dotOpEnc.getKWidth(),
+              typeWidthInBit, needTrans);
         }
 
 
@@ -1239,6 +1215,13 @@ Row |
                                           Type elemType, int kWidth, int kDim, int opIdx) const;
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
     static SmallVector<unsigned> getMNKDimPerInstr();
+
+    // Returns a swizzled shared layout matching this WMMA layout for the
+    // dot operand at the given |operandIdx| with |operandShape|.
+    SwizzledSharedEncodingAttr composeSharedLayoutForOperand(
+        CTALayoutAttr ctaLayout, int operandIdx, ArrayRef<int64_t> operandShape,
+        ArrayRef<unsigned> sharedOrder, unsigned kWidth,
+        unsigned elemBitWidth, bool needTrans) const;
   }];
 }
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -287,24 +287,33 @@ When vec=2, elements are swizzled in pairs of 2.  In other words, the element at
 
         // ---- begin WMMA ----
         if (mlir::isa<AMDWmmaEncodingAttr>(dotOpEnc.getParent())) {
-          if (dotOpEnc.getOpIdx() == 0) {
-            const int numBanks = 32;
-            const int bankBitWidth = 32;
+          int kDimIndex = dotOpEnc.getOpIdx() == 0 ? 1 : 0;
+          bool isKContig = order[0] == kDimIndex;
 
-            // number of inner dimension rows per one pattern repeat
-            int innerDimLength = shape[order[0]];
-            int elemsPerOneBanksRow = (numBanks * bankBitWidth) / typeWidthInBit;
-
-            int perPhase = std::max(1, elemsPerOneBanksRow / innerDimLength);
-            int vecSize = ((typeWidthInBit == 16) ? 64 : 32 ) / typeWidthInBit;
-            int maxPhase = 16 / perPhase;
-
-            return get(context, vecSize, perPhase, maxPhase, order, CTALayout);
-          } else {
-            // Do not swizzle in case k dimension is not innermost.
-            // In this case accesses will go in different banks even without swizzling.
+          if (!isKContig) {
+            // Do not swizzle. In this case accesses will go in different banks even
+            // without swizzling.
             return get(context, 1, 1, 1, order, CTALayout);
           }
+
+          // kWidth: the number of elements each thread loads from shared memory in
+          // preparation for wmma instructions.
+          auto kWidth = dotOpEnc.getKWidth();
+          // max vectorization size for ds_load is 128 bits
+          int vectorSize = std::min(kWidth * typeWidthInBit, 128u) / typeWidthInBit;
+
+          const int numBanks = 32;
+          const int bankBitWidth = 32;
+          const int simdWidth = 16;
+
+          // Number of inner dimension rows per one pattern repeat
+          int innerDimLength = shape[order[0]];
+          int elemsPerOneBanksRow = (numBanks * bankBitWidth) / typeWidthInBit;
+
+          int perPhase = std::max(1, elemsPerOneBanksRow / innerDimLength);
+          int maxPhase = std::max(std::min(simdWidth / perPhase, innerDimLength / vectorSize), 1);
+
+          return get(context, vectorSize, perPhase, maxPhase, order, CTALayout);
         }
 
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2059,15 +2059,18 @@ SwizzledSharedEncodingAttr AMDWmmaEncodingAttr::composeSharedLayoutForOperand(
 
   const int numBanks = 32;
   const int bankBitWidth = 32;
-  const int simdWidth = 16;
 
   // Number of inner dimension rows per one pattern repeat
   int innerDimLength = operandShape[sharedOrder[0]];
   int elemsPerOneBanksRow = (numBanks * bankBitWidth) / elemBitWidth;
 
   int perPhase = std::max(1, elemsPerOneBanksRow / innerDimLength);
+  // for both RDNA3 and RDNA4, the M/N dimension of wmma is 16
+  // This represents the max number of rows that can be accessed
+  // at the same time
+  int mDim = getMNKDimPerInstr()[0];
   int maxPhase =
-      std::max(std::min(simdWidth / perPhase, innerDimLength / vectorSize), 1);
+      std::max(std::min(mDim / perPhase, innerDimLength / vectorSize), 1);
 
   return SwizzledSharedEncodingAttr::get(getContext(), vectorSize, perPhase,
                                          maxPhase, sharedOrder, ctaLayout);

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2040,6 +2040,39 @@ SmallVector<unsigned> AMDWmmaEncodingAttr::getMNKDimPerInstr() {
   return {16, 16, 16};
 }
 
+SwizzledSharedEncodingAttr AMDWmmaEncodingAttr::composeSharedLayoutForOperand(
+    CTALayoutAttr ctaLayout, int operandIdx, ArrayRef<int64_t> operandShape,
+    ArrayRef<unsigned> sharedOrder, unsigned kWidth, unsigned elemBitWidth,
+    bool needTrans) const {
+  int kDimIndex = operandIdx == 0 ? 1 : 0;
+  bool isKContig = sharedOrder[0] == kDimIndex;
+
+  if (!isKContig) {
+    // Do not swizzle. In this case accesses will go in different banks even
+    // without swizzling.
+    return SwizzledSharedEncodingAttr::get(getContext(), 1, 1, 1, sharedOrder,
+                                           ctaLayout);
+  }
+
+  // max vectorization size for ds_load is 128 bits
+  int vectorSize = std::min(kWidth * elemBitWidth, 128u) / elemBitWidth;
+
+  const int numBanks = 32;
+  const int bankBitWidth = 32;
+  const int simdWidth = 16;
+
+  // Number of inner dimension rows per one pattern repeat
+  int innerDimLength = operandShape[sharedOrder[0]];
+  int elemsPerOneBanksRow = (numBanks * bankBitWidth) / elemBitWidth;
+
+  int perPhase = std::max(1, elemsPerOneBanksRow / innerDimLength);
+  int maxPhase =
+      std::max(std::min(simdWidth / perPhase, innerDimLength / vectorSize), 1);
+
+  return SwizzledSharedEncodingAttr::get(getContext(), vectorSize, perPhase,
+                                         maxPhase, sharedOrder, ctaLayout);
+}
+
 //===----------------------------------------------------------------------===//
 // Mma encoding
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Swizzling is always disabled for Wmma's B operand, it should be disabled only when k dimension is not contiguous.

Both vectorSize, perPhase and maxPhase are now determined using a heuristic approach.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because this PR only updates the shared layout for Wmma's operand, and it's applicable across various cases.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
