### PR TITLE
[GLUON] Docstrings for public functions

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -485,13 +485,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 @gluon.jit
 def warpgroup_mma_wait_kernel():
     layout: ttgl.constexpr = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=[4, 1], instr_shape=[16, 32, 16])
-<<<<<<< HEAD
     acc = ttgl.full([128, 128], 0, dtype=ttgl.float16, layout=layout)
     hopper.warpgroup_mma_wait(num_outstanding=1, deps=[acc])
-=======
-    acc = ttgl.zeros([128, 128], dtype=ttgl.float16, layout=layout)
-    hopper.warpgroup_mma_wait([acc], 1)
->>>>>>> 31f072cbd (Added wgmma wait, working on tests)
 
 
 @pytest.mark.skipif(not is_hopper(), reason="Requires Hopper WGMMA")
@@ -499,7 +494,6 @@ def test_warpgroup_mma_wait(fresh_knobs):
     knobs.compilation.disable_line_info = True
 
     h = warpgroup_mma_wait_kernel.warmup(grid=(1, ))
-<<<<<<< HEAD
     expecttest.assert_expected_inline(
         anonymize_ir(h.asm["source"]), """\
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 32, 16]}>
@@ -513,9 +507,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 } loc(#loc)
 #loc = loc(unknown)
 """)
-=======
-    print(h.asm["source"])
->>>>>>> 31f072cbd (Added wgmma wait, working on tests)
 
 
 @gluon.jit

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -485,8 +485,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 @gluon.jit
 def warpgroup_mma_wait_kernel():
     layout: ttgl.constexpr = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=[4, 1], instr_shape=[16, 32, 16])
+<<<<<<< HEAD
     acc = ttgl.full([128, 128], 0, dtype=ttgl.float16, layout=layout)
     hopper.warpgroup_mma_wait(num_outstanding=1, deps=[acc])
+=======
+    acc = ttgl.zeros([128, 128], dtype=ttgl.float16, layout=layout)
+    hopper.warpgroup_mma_wait([acc], 1)
+>>>>>>> 31f072cbd (Added wgmma wait, working on tests)
 
 
 @pytest.mark.skipif(not is_hopper(), reason="Requires Hopper WGMMA")
@@ -494,6 +499,7 @@ def test_warpgroup_mma_wait(fresh_knobs):
     knobs.compilation.disable_line_info = True
 
     h = warpgroup_mma_wait_kernel.warmup(grid=(1, ))
+<<<<<<< HEAD
     expecttest.assert_expected_inline(
         anonymize_ir(h.asm["source"]), """\
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 32, 16]}>
@@ -507,6 +513,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 } loc(#loc)
 #loc = loc(unknown)
 """)
+=======
+    print(h.asm["source"])
+>>>>>>> 31f072cbd (Added wgmma wait, working on tests)
 
 
 @gluon.jit

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -191,6 +191,20 @@ class shared_memory_descriptor_type(base_type):
 
 
 class shared_memory_descriptor(base_value):
+    """
+    Represents a handle to a shared memory allocation in Gluon IR.
+
+    This value wraps an IR handle to shared memory along with its type
+    metadata and provides methods for loading, storing, and reshaping
+    the shared memory region.
+
+    Args:
+        handle (ir.Value): The IR value representing the allocation handle.
+        element_ty (dtype): The data type of each element.
+        shape (List[int]): The dimensions of the descriptor.
+        layout (SharedLayout): The layout of the shared memory.
+        alloc_shape (List[int]): The actual allocation shape.
+    """
 
     def __init__(self, handle, element_ty, shape, layout, alloc_shape):
         self.handle = handle
@@ -220,15 +234,41 @@ class shared_memory_descriptor(base_value):
 
     @builtin
     def load(self, layout, _semantic: GluonSemantic) -> tensor:
+        """
+        Load a tensor from shared memory.
+
+        Args:
+            layout (DistributedLayout): The destination layout of the tensor.
+
+        Returns:
+            tensor: A Gluon tensor containing the loaded data.
+        """
         layout = _unwrap_if_constexpr(layout)
         return _semantic.shared_load(self, layout)
 
     @builtin
     def store(self, value, _semantic: GluonSemantic) -> None:
+        """
+        Store a tensor into shared memory.
+
+        Args:
+            value (tensor): The tensor whose contents to store.
+        """
         return _semantic.shared_store(self, value)
 
     @builtin
     def slice(self, start, length, dim=0, _semantic: GluonSemantic = None) -> shared_memory_descriptor:
+        """
+        Create a subview of shared memory by slicing along a given dimension.
+
+        Args:
+            start (int): The starting index of the slice.
+            length (int): The length of the slice.
+            dim (int): The dimension to slice (default: 0).
+
+        Returns:
+            shared_memory_descriptor: Descriptor for the sliced subview.
+        """
         start = _unwrap_if_constexpr(start)
         length = _unwrap_if_constexpr(length)
         dim = _unwrap_if_constexpr(dim)
@@ -236,16 +276,44 @@ class shared_memory_descriptor(base_value):
 
     @builtin
     def index(self, index, _semantic: GluonSemantic = None) -> shared_memory_descriptor:
+        """
+        Create a subview of shared memory by indexing along the first dimension.
+
+        Args:
+            index (int): The index at which to take the subview.
+
+        Returns:
+            shared_memory_descriptor: Descriptor for the indexed subview.
+        """
         index = _unwrap_if_constexpr(index)
         return _semantic.memdesc_index(self, index)
 
     @builtin
     def permute(self, order, _semantic: GluonSemantic) -> shared_memory_descriptor:
+        """
+        Permute the dimensions of the shared memory descriptor.
+
+        Args:
+            order (List[int]): The new ordering of dimensions.
+
+        Returns:
+            shared_memory_descriptor: Descriptor with permuted dimensions.
+        """
         order = [_unwrap_if_constexpr(o) for o in order]
         return _semantic.memdesc_trans(self, order)
 
     @builtin
     def reshape(self, shape, layout, _semantic: GluonSemantic) -> shared_memory_descriptor:
+        """
+        Reshape the shared memory descriptor to a new shape and layout.
+
+        Args:
+            shape (List[int]): The target shape.
+            layout (SharedLayout): The new layout for the descriptor.
+
+        Returns:
+            shared_memory_descriptor: Descriptor with the new shape and layout.
+        """
         shape = [_unwrap_if_constexpr(s) for s in shape]
         layout = _unwrap_if_constexpr(layout)
 
@@ -253,6 +321,17 @@ class shared_memory_descriptor(base_value):
 
     @builtin
     def _reinterpret(self, dtype, shape, layout, _semantic: GluonSemantic = None) -> shared_memory_descriptor:
+        """
+        Reinterpret the shared memory descriptor as a different dtype, shape, or layout.
+
+        Args:
+            dtype (dtype): The new data type.
+            shape (List[int]): The new shape.
+            layout (SharedLayout): The new layout.
+
+        Returns:
+            shared_memory_descriptor: Descriptor with updated type and layout.
+        """
         dtype = _unwrap_if_constexpr(dtype)
         shape = [_unwrap_if_constexpr(s) for s in shape]
         layout = _unwrap_if_constexpr(layout)
@@ -261,6 +340,9 @@ class shared_memory_descriptor(base_value):
 
     @builtin
     def _keep_alive(self, _semantic: GluonSemantic = None) -> None:
+        """
+        Dummy use to keep the shared memory descriptor alive.
+        """
         return _semantic.shared_dealloc(self)
 
 
@@ -271,6 +353,17 @@ for name in _IMPORT_FROM_TRITON:
 
 @builtin
 def arange(start, end, layout, _semantic=None):
+    """
+    Generate a sequence tensor with values in [start, end) using a specified layout.
+
+    Args:
+        start (int): Inclusive start of the sequence.
+        end (int): Exclusive end of the sequence.
+        layout (DistributedLayout): The layout of the output tensor.
+
+    Returns:
+        tensor: A 1D tensor containing sequential values.
+    """
     start = _unwrap_if_constexpr(start)
     end = _unwrap_if_constexpr(end)
     layout = _unwrap_if_constexpr(layout)
@@ -279,12 +372,34 @@ def arange(start, end, layout, _semantic=None):
 
 @builtin
 def convert_layout(value, layout, _semantic=None):
+    """
+    Convert a tensor to a different distributed layout.
+
+    Args:
+        value (tensor): The input tensor.
+        layout (DistributedLayout): The target layout.
+
+    Returns:
+        tensor: The tensor with the new layout.
+    """
     layout = _unwrap_if_constexpr(layout)
     return _semantic.convert_layout(value, layout)
 
 
 @builtin
 def full(shape, value, dtype, layout, _semantic=None):
+    """
+    Create a tensor filled with a scalar value, with specified shape, dtype, and layout.
+
+    Args:
+        shape (Sequence[int]): The shape of the tensor.
+        value (int or float): The fill value.
+        dtype (dtype): The data type for the tensor.
+        layout (DistributedLayout): The layout of the output tensor.
+
+    Returns:
+        tensor: A tensor where every element equals value.
+    """
     shape = _unwrap_shape(shape)
     value = _unwrap_if_constexpr(value)
     dtype = _unwrap_if_constexpr(dtype)
@@ -294,6 +409,18 @@ def full(shape, value, dtype, layout, _semantic=None):
 
 @builtin
 def allocate_shared_memory(element_ty, shape, layout, value=None, _semantic=None):
+    """
+    Allocate shared memory for a tensor with the given element type, shape, and layout.
+
+    Args:
+        element_ty (dtype): The element data type.
+        shape (Sequence[int]): The dimensions of the shared memory.
+        layout (SharedLayout): The shared memory layout.
+        value (tensor, optional): Initial value to copy into shared memory.
+
+    Returns:
+        shared_memory_descriptor: Descriptor for the allocated memory.
+    """
     element_ty = _unwrap_if_constexpr(element_ty)
     shape = _unwrap_if_constexpr(shape)
     shape = [_unwrap_if_constexpr(s) for s in shape]
@@ -304,6 +431,20 @@ def allocate_shared_memory(element_ty, shape, layout, value=None, _semantic=None
 @builtin
 def warp_specialize(default_args, default_partition, worker_args, worker_partitions, worker_num_warps, worker_num_regs,
                     _semantic=None, _generator=None):
+    """
+    Create a warp-specialized execution region, partitioning work across warps.
+
+    Args:
+        default_args (List[Any]): Arguments for the default region.
+        default_partition (callable): Function to build the default execution region.
+        worker_args (List[Any]): Arguments for each warp partition.
+        worker_partitions (List[callable]): Functions for each warp partition.
+        worker_num_warps (List[int]): Number of warps per partition.
+        worker_num_regs (List[int]): Number of registers per partition.
+
+    Returns:
+        Tuple[Any, ...]: Results from the warp-specialized regions.
+    """
     worker_num_warps = [_unwrap_if_constexpr(w) for w in worker_num_warps]
     worker_num_regs = [_unwrap_if_constexpr(r) for r in worker_num_regs]
     return _semantic.warp_specialize(default_args, default_partition, worker_args, worker_partitions, worker_num_warps,
@@ -312,4 +453,7 @@ def warp_specialize(default_args, default_partition, worker_args, worker_partiti
 
 @builtin
 def thread_barrier(_semantic=None):
+    """
+    Insert a barrier to synchronize threads within a CTA.
+    """
     return _semantic.debug_barrier()

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -193,17 +193,6 @@ class shared_memory_descriptor_type(base_type):
 class shared_memory_descriptor(base_value):
     """
     Represents a handle to a shared memory allocation in Gluon IR.
-
-    This value wraps an IR handle to shared memory along with its type
-    metadata and provides methods for loading, storing, and reshaping
-    the shared memory region.
-
-    Args:
-        handle (ir.Value): The IR value representing the allocation handle.
-        element_ty (dtype): The data type of each element.
-        shape (List[int]): The dimensions of the descriptor.
-        layout (SharedLayout): The layout of the shared memory.
-        alloc_shape (List[int]): The actual allocation shape.
     """
 
     def __init__(self, handle, element_ty, shape, layout, alloc_shape):
@@ -443,7 +432,7 @@ def warp_specialize(default_args, default_partition, worker_args, worker_partiti
         worker_num_regs (List[int]): Number of registers per partition.
 
     Returns:
-        Tuple[Any, ...]: Results from the warp-specialized regions.
+        Tuple[Any, ...]: Results from the default region.
     """
     worker_num_warps = [_unwrap_if_constexpr(w) for w in worker_num_warps]
     worker_num_regs = [_unwrap_if_constexpr(r) for r in worker_num_regs]

--- a/python/triton/experimental/gluon/language/_layouts.py
+++ b/python/triton/experimental/gluon/language/_layouts.py
@@ -22,11 +22,26 @@ def _realize_cta_layout(layout, rank):
 
 
 class DistributedLayout:
+    """
+    Base class for distributed memory layouts in Gluon IR.
+    """
     pass
 
 
 @dataclass(frozen=True)
 class BlockedLayout(DistributedLayout):
+    """
+    Represents a blocked layout, partitioning a tensor across threads, warps, and CTAs.
+
+    Args:
+        size_per_thread (List[int]): Number of elements per thread per dimension.
+        threads_per_warp (List[int]): Number of threads per warp per dimension.
+        warps_per_cta (List[int]): Number of warps per CTA per dimension.
+        order (List[int]): The ordering of dimensions for partitioning.
+        ctas_per_cga (Optional[List[int]]): CTAs per CGA grouping.
+        cta_split_num (Optional[List[int]]): Split factors for CTAs.
+        cta_order (Optional[List[int]]): Ordering for CTAs.
+    """
     size_per_thread: List[int]
     threads_per_warp: List[int]
     warps_per_cta: List[int]
@@ -83,6 +98,13 @@ class BlockedLayout(DistributedLayout):
 
 @dataclass(frozen=True)
 class SliceLayout(DistributedLayout):
+    """
+    Represents a layout corresponding to slicing a distributed tensor along one dimension.
+
+    Args:
+        dim (int): The dimension index to slice.
+        parent (DistributedLayout): The parent layout before slicing.
+    """
     dim: int
     parent: DistributedLayout
 
@@ -102,6 +124,17 @@ class SliceLayout(DistributedLayout):
 
 @dataclass(frozen=True)
 class DistributedLinearLayout(DistributedLayout):
+    """
+    Represents a linear distributed layout with explicit bases at register, lane, warp, and block levels.
+    See: https://arxiv.org/abs/2505.23819 for reference.
+
+    Args:
+        reg_bases (List[List[int]]): Bases for register-level distribution.
+        lane_bases (List[List[int]]): Bases for lane-level distribution.
+        warp_bases (List[List[int]]): Bases for warp-level distribution.
+        block_bases (List[List[int]]): Bases for block-level distribution.
+        shape (List[int]): The tensor global shape.
+    """
     reg_bases: List[List[int]]
     lane_bases: List[List[int]]
     warp_bases: List[List[int]]
@@ -136,6 +169,17 @@ class DistributedLinearLayout(DistributedLayout):
 
 @dataclass(frozen=True)
 class NVMMADistributedLayout(DistributedLayout):
+    """
+    Represents a layout for NVIDIA MMA (tensor core) operations.
+
+    Args:
+        version (List[int]): Version identifier for the MMA instruction.
+        warps_per_cta (List[int]): Number of warps per CTA.
+        instr_shape (List[int]): Instruction shape for MMA.
+        ctas_per_cga (Optional[List[int]]): CTAs per CGA grouping.
+        cta_split_num (Optional[List[int]]): Split factors for CTAs.
+        cta_order (Optional[List[int]]): CTA ordering.
+    """
     version: List[int]
     warps_per_cta: List[int]
     instr_shape: List[int]
@@ -166,11 +210,27 @@ class NVMMADistributedLayout(DistributedLayout):
 
 
 class SharedLayout:
+    """
+    Base class for shared memory layouts in Gluon IR.
+    """
     pass
 
 
 @dataclass(frozen=True)
 class NVMMASharedLayout(SharedLayout):
+    """
+    Represents a layout for shared memory suitable for NVIDIA MMA operations.
+
+    Args:
+        swizzle_byte_width (int): Width in bytes for swizzling.
+        element_bitwidth (int): Bitwidth of element type.
+        rank (int): Rank of the tensor.
+        transposed (bool): Whether the layout is transposed.
+        fp4_padded (bool): Whether FP4 padding is used.
+        ctas_per_cga (Optional[List[int]]): CTAs per CGA grouping.
+        cta_split_num (Optional[List[int]]): Split factors for CTAs.
+        cta_order (Optional[List[int]]): CTA ordering.
+    """
     swizzle_byte_width: int
     element_bitwidth: int
     rank: int
@@ -215,6 +275,18 @@ class NVMMASharedLayout(SharedLayout):
 
 @dataclass(frozen=True, eq=True)
 class SwizzledSharedLayout(SharedLayout):
+    """
+    Represents a generic swizzled shared memory layout.
+
+    Args:
+        vec (int): Vector width for swizzling.
+        per_phase (int): Elements per swizzle phase.
+        max_phase (int): Maximum number of swizzle phases.
+        order (List[int]): Dimension ordering for swizzling.
+        ctas_per_cga (Optional[List[int]]): CTAs per CGA grouping.
+        cta_split_num (Optional[List[int]]): Split factors for CTAs.
+        cta_order (Optional[List[int]]): CTA ordering.
+    """
     vec: int
     per_phase: int
     max_phase: int

--- a/python/triton/experimental/gluon/language/_standard.py
+++ b/python/triton/experimental/gluon/language/_standard.py
@@ -24,16 +24,43 @@ for name in _IMPORT_FROM_TRITON:
     # Convert JITFunction -> GluonJitFunction
     fn = getattr(tl_standard, name)
     assert knobs.runtime.interpret or isinstance(fn, triton.runtime.JITFunction)
-    globals()[name] = jit(fn.fn)
+    # Wrap the function and preserve its original docstring
+    gluon_fn = jit(fn.fn)
+    gluon_fn.__doc__ = fn.__doc__
+    globals()[name] = gluon_fn
 
 
 @jit
 def zeros(shape, dtype, layout):
+    """
+    Create a tensor filled with zeros.
+
+    Args:
+        shape (Sequence[int]): The shape of the tensor.
+        dtype (dtype): The data type for the tensor.
+        layout (DistributedLayout): The distributed layout of the tensor.
+
+    Returns:
+        tensor: A tensor where every element is zero.
+    """
     return ttgl.full(shape, 0, dtype, layout)
 
 
 @jit
 def full_like(input, value, shape=None, dtype=None, layout=None):
+    """
+    Create a tensor with the same properties as a given tensor, filled with a specified value.
+
+    Args:
+        input (tensor): Reference tensor to infer default shape, dtype, and layout.
+        value (int or float): The fill value.
+        shape (Sequence[int], optional): Target shape. Defaults to input.shape.
+        dtype (dtype, optional): Target data type. Defaults to input.dtype.
+        layout (DistributedLayout, optional): Target layout. Defaults to input.layout.
+
+    Returns:
+        tensor: A tensor where every element equals value.
+    """
     return ttgl.full(
         input.shape if shape is None else shape,
         value,
@@ -44,4 +71,16 @@ def full_like(input, value, shape=None, dtype=None, layout=None):
 
 @jit
 def zeros_like(input, shape=None, dtype=None, layout=None):
+    """
+    Create a tensor with the same properties as a given tensor, filled with zeros.
+
+    Args:
+        input (tensor): Reference tensor to infer default shape, dtype, and layout.
+        shape (Sequence[int], optional): Target shape. Defaults to input.shape.
+        dtype (dtype, optional): Target data type. Defaults to input.dtype.
+        layout (DistributedLayout, optional): Target layout. Defaults to input.layout.
+
+    Returns:
+        tensor: A tensor where every element is zero.
+    """
     return full_like(input, 0, shape=shape, dtype=dtype, layout=layout)

--- a/python/triton/experimental/gluon/language/nvidia/ampere/async_copy.py
+++ b/python/triton/experimental/gluon/language/nvidia/ampere/async_copy.py
@@ -13,6 +13,17 @@ __all__ = [
 @builtin
 def async_copy_global_to_shared(smem, pointer, mask=None, cache_modifier="", eviction_policy="", volatile=False,
                                 _semantic=None):
+    """
+    Asynchronously copy elements from global memory to shared memory.
+
+    Args:
+        smem (shared_memory_descriptor): Destination shared memory descriptor.
+        pointer (tensor): Source pointer tensor.
+        mask (tensor, optional): Mask tensor for predicated loads. Defaults to None.
+        cache_modifier (str): Cache modifier specifier. Defaults to "".
+        eviction_policy (str): Eviction policy specifier. Defaults to "".
+        volatile (bool): Whether the load is volatile. Defaults to False.
+    """
     mask = _unwrap_if_constexpr(mask)
     cache_modifier = _semantic._str_to_load_cache_modifier(cache_modifier)
     eviction_policy = _semantic._str_to_eviction_policy(eviction_policy)
@@ -30,7 +41,12 @@ def async_copy_global_to_shared(smem, pointer, mask=None, cache_modifier="", evi
 
 @builtin
 def mbarrier_arrive(mbarrier, increment_count=True, _semantic=None):
-    """Arrive on the mbarrier once all outstanding async copies are complete.
+    """
+    Arrive on an mbarrier after completing outstanding async copies.
+
+    Args:
+        mbarrier (shared_memory_descriptor): Barrier object to arrive on.
+        increment_count (bool): Whether to increment the arrival count. Defaults to True.
     """
     increment_count = _unwrap_if_constexpr(increment_count)
     _semantic.builder.create_async_copy_mbarrier_arrive(mbarrier.handle, increment_count)
@@ -38,10 +54,21 @@ def mbarrier_arrive(mbarrier, increment_count=True, _semantic=None):
 
 @builtin
 def commit_group(_semantic=None):
+    """
+    Commit the current asynchronous copy group.
+
+    This finalizes a set of asynchronous copy operations.
+    """
     _semantic.builder.create_async_commit_group()
 
 
 @builtin
 def wait_group(num_outstanding=0, _semantic=None):
+    """
+    Wait for outstanding asynchronous copy group operations.
+
+    Args:
+        num_outstanding (int): Number of outstanding copies to wait for. Defaults to 0.
+    """
     num_outstanding = _unwrap_if_constexpr(num_outstanding)
     _semantic.builder.create_async_wait_group(num_outstanding)

--- a/python/triton/experimental/gluon/language/nvidia/ampere/async_copy.py
+++ b/python/triton/experimental/gluon/language/nvidia/ampere/async_copy.py
@@ -42,7 +42,7 @@ def async_copy_global_to_shared(smem, pointer, mask=None, cache_modifier="", evi
 @builtin
 def mbarrier_arrive(mbarrier, increment_count=True, _semantic=None):
     """
-    Arrive on an mbarrier after completing outstanding async copies.
+    Arrive on the mbarrier once all outstanding async copies are complete.
 
     Args:
         mbarrier (shared_memory_descriptor): Barrier object to arrive on.
@@ -68,7 +68,7 @@ def wait_group(num_outstanding=0, _semantic=None):
     Wait for outstanding asynchronous copy group operations.
 
     Args:
-        num_outstanding (int): Number of outstanding copies to wait for. Defaults to 0.
+        num_outstanding (int): Wait until `num_outstanding` or less async copy groups in-flight. Defaults to 0.
     """
     num_outstanding = _unwrap_if_constexpr(num_outstanding)
     _semantic.builder.create_async_wait_group(num_outstanding)

--- a/python/triton/experimental/gluon/language/nvidia/ampere/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/ampere/mbarrier.py
@@ -5,6 +5,13 @@ __all__ = ["arrive", "init", "invalidate", "MBarrierLayout", "wait"]
 
 
 class MBarrierLayout(SwizzledSharedLayout):
+    """
+    Layout for mbarrier synchronization in Ampere and later architectures.
+
+    Args:
+        ctas_per_cga (int): CTAs per CGA grouping. Defaults to 1.
+        cta_split_num (int): CTA split factor. Defaults to 1.
+    """
 
     def __init__(self, ctas_per_cga: int = 1, cta_split_num: int = 1):
         super().__init__(
@@ -20,17 +27,39 @@ class MBarrierLayout(SwizzledSharedLayout):
 
 @builtin
 def init(mbarrier, count, _semantic=None):
+    """
+    Initialize an mbarrier with a specified count.
+
+    Args:
+        mbarrier (shared_memory_descriptor): The barrier object to initialize.
+        count (int): The initial count for the barrier.
+    """
     count = _unwrap_if_constexpr(count)
     _semantic.builder.create_mbarrier_init(mbarrier.handle, count)
 
 
 @builtin
 def invalidate(mbarrier, _semantic=None):
+    """
+    Invalidate an mbarrier, resetting its state.
+
+    Args:
+        mbarrier (shared_memory_descriptor): The barrier object to invalidate.
+    """
     _semantic.builder.create_mbarrier_inval(mbarrier.handle)
 
 
 @builtin
 def wait(mbarrier, phase, pred=True, deps=(), _semantic=None):
+    """
+    Wait until the mbarrier object completes its current phase.
+
+    Args:
+        mbarrier (shared_memory_descriptor): The barrier object to wait on.
+        phase (int): The phase index to wait for.
+        pred (bool): Predicate. Operation is skipped if predicate is False. Defaults to True.
+        deps (Sequence[shared_memory_descriptor]): Dependent allocations barrier is waiting on. Used to track liveness of dependent allocations. Defaults to ().
+    """
     phase = _semantic.to_tensor(phase)
     pred = _semantic.to_tensor(pred)
     deps = [x.handle for x in deps]
@@ -39,6 +68,13 @@ def wait(mbarrier, phase, pred=True, deps=(), _semantic=None):
 
 @builtin
 def arrive(mbarrier, *, pred=True, _semantic=None):
+    """
+    Arrive on an mbarrier, signaling that a thread has reached the barrier.
+
+    Args:
+        mbarrier (shared_memory_descriptor): The barrier object to arrive on.
+        pred (bool): Predicate. Operation is skipped if predicate is False. Defaults to True.
+    """
     count = 1
     pred = _semantic.to_tensor(pred)
     _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, pred.handle)

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -28,6 +28,14 @@ __all__ = [
 
 @dataclass(frozen=True, eq=True)
 class TensorMemoryLayout:
+    """
+    Describes the layout for tensor memory in Blackwell architecture.
+
+    Args:
+        block (Tuple[int, int]): Tiling block dimensions (M/rows, N/cols).
+        unpacked (bool): For sub-32 bit elements, whether they are unpacked to 32 bits.
+        cta_split_num (Optional[Tuple[int, int]]): CTA split factors. Defaults to None.
+    """
     block: Tuple[int, int]
     unpacked: bool
     cta_split_num: Optional[Tuple[int, int]] = None
@@ -91,6 +99,16 @@ class tensor_memory_descriptor_type(base_type):
 
 
 class tensor_memory_descriptor(base_value):
+    """
+    Represents a tensor memory descriptor handle for TMA operations.
+
+    Args:
+        handle (ir.Value): The IR handle of the descriptor.
+        element_ty (dtype): The data type of elements.
+        shape (List[int]): The shape of the descriptor.
+        layout (TensorMemoryLayout): The tensor memory layout.
+        alloc_shape (List[int]): The allocation shape.
+    """
 
     def __init__(self, handle, element_ty, shape, layout, alloc_shape):
         self.handle = handle
@@ -120,6 +138,15 @@ class tensor_memory_descriptor(base_value):
 
     @builtin
     def load(self, layout, _semantic: GluonSemantic) -> ttgl.tensor:
+        """
+        Load a tensor from tensor memory.
+
+        Args:
+            layout (DistributedLayout): Destination layout of the tensor.
+
+        Returns:
+            tensor: A distributed tensor containing the loaded data.
+        """
         layout = _unwrap_if_constexpr(layout)
         ret_ty = ttgl.distributed_type(self.dtype, self.shape, layout)
         builder = _semantic.builder
@@ -128,6 +155,13 @@ class tensor_memory_descriptor(base_value):
 
     @builtin
     def store(self, value, pred=True, _semantic: GluonSemantic = None) -> None:
+        """
+        Store a tensor into tensor memory.
+
+        Args:
+            value (tensor): The tensor to store.
+            pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
+        """
         pred = _unwrap_if_constexpr(pred)
         pred = _semantic.to_tensor(pred)
         assert value.shape == self.shape, f"source shape {value.shape} does not match destination shape {self.shape}"
@@ -136,6 +170,16 @@ class tensor_memory_descriptor(base_value):
 
     @builtin
     def slice(self, start, length, _semantic: GluonSemantic) -> None:
+        """
+        Create a subslice of tensor memory descriptor.
+
+        Args:
+            start (int): The starting index for subslice.
+            length (int): The length of the subslice.
+
+        Returns:
+            tensor_memory_descriptor: Descriptor for the subslice.
+        """
         start = _unwrap_if_constexpr(start)
         length = _unwrap_if_constexpr(length)
         _check(isinstance(start, int), lambda: "start must be a constant int")
@@ -151,6 +195,15 @@ class tensor_memory_descriptor(base_value):
 
     @builtin
     def index(self, index, _semantic: GluonSemantic = None) -> tensor_memory_descriptor:
+        """
+        Create a subview of tensor memory by indexing the first dimension.
+
+        Args:
+            index (tensor): The index tensor for the subview.
+
+        Returns:
+            tensor_memory_descriptor: Descriptor for the indexed subview.
+        """
         index = _semantic.to_tensor(index)
         builder = _semantic.builder
         offsets = [builder.get_int32(0)] * self.rank
@@ -163,6 +216,17 @@ class tensor_memory_descriptor(base_value):
 
     @builtin
     def _reinterpret(self, dtype, shape, layout, _semantic: GluonSemantic = None) -> tensor_memory_descriptor:
+        """
+        Reinterpret tensor memory descriptor with a new dtype, shape, and layout.
+
+        Args:
+            dtype (dtype): The new data type.
+            shape (Sequence[int]): The new shape.
+            layout (TensorMemoryLayout): The new layout.
+
+        Returns:
+            tensor_memory_descriptor: Descriptor with updated type and layout.
+        """
         dtype = _unwrap_if_constexpr(dtype)
         shape = [_unwrap_if_constexpr(s) for s in shape]
         layout = _unwrap_if_constexpr(layout)
@@ -174,6 +238,18 @@ class tensor_memory_descriptor(base_value):
 
 @builtin
 def allocate_tensor_memory(element_ty, shape, layout, value=None, _semantic=None):
+    """
+    Allocate tensor memory.
+
+    Args:
+        element_ty (dtype): The element data type.
+        shape (Sequence[int]): The descriptor shape.
+        layout (TensorMemoryLayout): The layout of the tensor memory.
+        value (tensor, optional): Initial tensor to copy. Defaults to None.
+
+    Returns:
+        tensor_memory_descriptor: Descriptor for the allocated memory.
+    """
     element_ty = _unwrap_if_constexpr(element_ty)
     shape = _unwrap_if_constexpr(shape)
     layout = _unwrap_if_constexpr(layout)
@@ -187,6 +263,19 @@ def allocate_tensor_memory(element_ty, shape, layout, value=None, _semantic=None
 
 @builtin
 def tcgen05_mma(a, b, acc, *, use_acc=True, pred=True, mbarriers=None, mbarrier_preds=None, _semantic=None):
+    """
+    Emit a GEN05 TensorCore MMA instruction.
+    acc = a * b + (acc if use_acc else 0)
+
+    Args:
+        a (tensor): First input operand tensor.
+        b (tensor): Second input operand tensor.
+        acc (tensor): Accumulator tensor.
+        use_acc (tensor or bool): Whether to use the initial value of the accumulator. Defaults to True.
+        pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
+        mbarriers (Sequence[shared_memory_descriptor], optional): Barriers to signal when the operation is complete. If None, mma is synchronous. Defaults to None.
+        mbarrier_preds (Sequence[bool], optional): Predicates for barriers. Defaults to None.
+    """
     use_acc = _semantic.to_tensor(use_acc)
     pred = _semantic.to_tensor(pred)
 

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -100,14 +100,7 @@ class tensor_memory_descriptor_type(base_type):
 
 class tensor_memory_descriptor(base_value):
     """
-    Represents a tensor memory descriptor handle for TMA operations.
-
-    Args:
-        handle (ir.Value): The IR handle of the descriptor.
-        element_ty (dtype): The data type of elements.
-        shape (List[int]): The shape of the descriptor.
-        layout (TensorMemoryLayout): The tensor memory layout.
-        alloc_shape (List[int]): The allocation shape.
+    Represents a tensor memory descriptor handle for Tensor Core Gen5 operations.
     """
 
     def __init__(self, handle, element_ty, shape, layout, alloc_shape):
@@ -171,7 +164,7 @@ class tensor_memory_descriptor(base_value):
     @builtin
     def slice(self, start, length, _semantic: GluonSemantic) -> None:
         """
-        Create a subslice of tensor memory descriptor.
+        Create a slice of the tensor memory descriptor along the last dimension.
 
         Args:
             start (int): The starting index for subslice.
@@ -264,14 +257,14 @@ def allocate_tensor_memory(element_ty, shape, layout, value=None, _semantic=None
 @builtin
 def tcgen05_mma(a, b, acc, *, use_acc=True, pred=True, mbarriers=None, mbarrier_preds=None, _semantic=None):
     """
-    Emit a GEN05 TensorCore MMA instruction.
+    Emit a 5th generation TensorCore MMA instruction.
     acc = a * b + (acc if use_acc else 0)
 
     Args:
-        a (tensor): First input operand tensor.
-        b (tensor): Second input operand tensor.
-        acc (tensor): Accumulator tensor.
-        use_acc (tensor or bool): Whether to use the initial value of the accumulator. Defaults to True.
+        a (shared_memory_descriptor): Left hand side operand in shared memory.
+        b (shared_memory_descriptor or tensor_memory_descriptor): Right hand side operand in shared or tensor memory.
+        acc (tensor_memory_descriptor): Accumulator value in tensor memory (mutated).
+        use_acc (bool): Whether to use the initial value of the accumulator. Defaults to True.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
         mbarriers (Sequence[shared_memory_descriptor], optional): Barriers to signal when the operation is complete. If None, mma is synchronous. Defaults to None.
         mbarrier_preds (Sequence[bool], optional): Predicates for barriers. Defaults to None.

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
@@ -20,6 +20,17 @@ __all__ = [
 
 @builtin
 def async_gather(tensor_desc, x_offsets, y_offset, barrier, result, pred=True, _semantic=None):
+    """
+    Asynchronously gather elements from global memory to shared memory using TMA.
+
+    Args:
+        tensor_desc (tensor_descriptor): The tensor memory descriptor.
+        x_offsets (tensor): X offsets tensor.
+        y_offset (tensor): Y offset tensor.
+        barrier (shared_memory_descriptor): Barrier that will be signaled when the operation is complete.
+        result (tensor): Result tensor handle.
+        pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
+    """
     pred = _semantic.to_tensor(pred)
     y_offset = _semantic.to_tensor(y_offset)
     _semantic.builder.create_async_tma_gather(tensor_desc.handle, x_offsets.handle, y_offset.handle, barrier.handle,
@@ -28,5 +39,14 @@ def async_gather(tensor_desc, x_offsets, y_offset, barrier, result, pred=True, _
 
 @builtin
 def async_scatter(tensor_desc, x_offsets, y_offset, src, _semantic=None):
+    """
+    Asynchronously scatter elements from shared memory to global memory using TMA.
+
+    Args:
+        tensor_desc (tensor_descriptor): The tensor memory descriptor.
+        x_offsets (tensor): X offsets tensor.
+        y_offset (tensor): Y offset tensor.
+        src (tensor): Source tensor.
+    """
     y_offset = _semantic.to_tensor(y_offset)
     _semantic.builder.create_async_tma_scatter(tensor_desc.handle, x_offsets.handle, y_offset.handle, src.handle)

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
@@ -24,11 +24,11 @@ def async_gather(tensor_desc, x_offsets, y_offset, barrier, result, pred=True, _
     Asynchronously gather elements from global memory to shared memory using TMA.
 
     Args:
-        tensor_desc (tensor_descriptor): The tensor memory descriptor.
-        x_offsets (tensor): X offsets tensor.
-        y_offset (tensor): Y offset tensor.
+        tensor_desc (tensor_descriptor): The tensor descriptor.
+        x_offsets (tensor): 1D tensor of X offsets.
+        y_offset (int): Scalar Y offset.
         barrier (shared_memory_descriptor): Barrier that will be signaled when the operation is complete.
-        result (tensor): Result tensor handle.
+        result (tensor_memory_descriptor): Result shared memory, must have NVMMASharedLayout.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
     """
     pred = _semantic.to_tensor(pred)
@@ -43,10 +43,10 @@ def async_scatter(tensor_desc, x_offsets, y_offset, src, _semantic=None):
     Asynchronously scatter elements from shared memory to global memory using TMA.
 
     Args:
-        tensor_desc (tensor_descriptor): The tensor memory descriptor.
-        x_offsets (tensor): X offsets tensor.
-        y_offset (tensor): Y offset tensor.
-        src (tensor): Source tensor.
+        tensor_desc (tensor_descriptor): The tensor descriptor.
+        x_offsets (tensor): 1D tensor of X offsets.
+        y_offset (int): Scalar Y offset.
+        src (tensor_memory_descriptor): The source data, must be in NVMMASharedLayout.
     """
     y_offset = _semantic.to_tensor(y_offset)
     _semantic.builder.create_async_tma_scatter(tensor_desc.handle, x_offsets.handle, y_offset.handle, src.handle)

--- a/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
@@ -7,18 +7,52 @@ __all__ = ["async_copy", "fence_async_shared", "mbarrier", "tma", "warpgroup_mma
 
 @_core.builtin
 def fence_async_shared(cluster=False, _semantic=None):
+    """
+    Issue a fence to complete asynchronous shared memory operations.
+
+    Args:
+        cluster (bool): Whether to fence across cluster. Defaults to False.
+    """
     cluster = _core._unwrap_if_constexpr(cluster)
     _semantic.builder.create_fence_async_shared(cluster)
 
 
 @_core.builtin
-def warpgroup_mma(a, b, acc, *, use_acc=True, precision=None, max_num_imprecise_acc=0, is_async=False, _semantic=None):
+def warpgroup_mma(a, b, acc, *, use_acc=True, precision=None, max_num_imprecise_acc=None, is_async=False,
+                  _semantic=None):
+    """
+    Perform warpgroup MMA (Tensor Core) operations.
+    acc = a * b + (acc if use_acc else 0)
+
+    Args:
+        a (tensor): First input tensor.
+        b (tensor): Second input tensor.
+        acc (tensor): Accumulator tensor.
+        use_acc (bool): Whether to use the initial value of the accumulator. Defaults to True.
+        precision (str, optional): Dot input precision. Defaults to builder default.
+        max_num_imprecise_acc (int): Max imprecise accumulations. Used for fp8 -> fp32 dot. Determines how many accumulation are done in limited precision. Defaults to None, which means no upcasting is done.
+        is_async (bool): Whether operation is asynchronous. Defaults to False.
+
+    Returns:
+        tensor: Result of warpgroup MMA operation.
+    """
     use_acc = _semantic.to_tensor(use_acc)
 
     if precision is None:
         precision = _semantic.builder.options.default_dot_input_precision
 
     precision = _semantic._str_to_dot_input_precision(precision)
+
+    K = a.type.shape[-1]
+    if max_num_imprecise_acc is None:
+        if a.dtype.is_fp8() and b.dtype.is_fp8():
+            max_num_imprecise_acc = _semantic.builder.options.max_num_imprecise_acc_default
+        else:
+            max_num_imprecise_acc = 0
+    else:
+        if a.dtype.is_fp8() and b.dtype.is_fp8() and max_num_imprecise_acc > K:
+            raise ValueError(f"max_num_imprecise_acc ({max_num_imprecise_acc}) must be <= K ({K})")
+
     max_num_imprecise_acc = _core._unwrap_if_constexpr(max_num_imprecise_acc)
     is_async = _core._unwrap_if_constexpr(is_async)
 
@@ -29,6 +63,13 @@ def warpgroup_mma(a, b, acc, *, use_acc=True, precision=None, max_num_imprecise_
 
 @_core.builtin
 def warpgroup_mma_wait(num_outstanding=0, deps=None, _semantic=None):
+    """
+    Wait until `num_outstanding` or less warpgroup MMA operations are in-flight.
+
+    Args:
+        num_outstanding (int): Number of outstanding warpgroup MMA operations to wait for. Defaults to 0.
+        deps (Sequence[tensor]): List of dependencies to wait on. Used to prevent the reordering of the operations.
+    """
     deps = [x.handle for x in deps] if deps is not None else []
     num_outstanding = _core._unwrap_if_constexpr(num_outstanding)
     _semantic.builder.create_warpgroup_mma_wait(deps, num_outstanding)

--- a/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
@@ -26,7 +26,7 @@ def warpgroup_mma(a, b, acc, *, use_acc=True, precision=None, max_num_imprecise_
 
     Args:
         a (tensor or shared_memory_descriptor): Left hand side operand.
-        b (tensor orshared_memory_descriptor): Right hand side operand.
+        b (tensor or shared_memory_descriptor): Right hand side operand.
         acc (tensor): Accumulator tensor.
         use_acc (bool): Whether to use the initial value of the accumulator. Defaults to True.
         precision (str, optional): Dot input precision. Defaults to builder default.

--- a/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
@@ -25,8 +25,8 @@ def warpgroup_mma(a, b, acc, *, use_acc=True, precision=None, max_num_imprecise_
     acc = a * b + (acc if use_acc else 0)
 
     Args:
-        a (tensor): First input tensor.
-        b (tensor): Second input tensor.
+        a (tensor or shared_memory_descriptor): Left hand side operand.
+        b (tensor orshared_memory_descriptor): Right hand side operand.
         acc (tensor): Accumulator tensor.
         use_acc (bool): Whether to use the initial value of the accumulator. Defaults to True.
         precision (str, optional): Dot input precision. Defaults to builder default.
@@ -68,7 +68,7 @@ def warpgroup_mma_wait(num_outstanding=0, deps=None, _semantic=None):
 
     Args:
         num_outstanding (int): Number of outstanding warpgroup MMA operations to wait for. Defaults to 0.
-        deps (Sequence[tensor]): List of dependencies to wait on. Used to prevent the reordering of the operations.
+        deps (Sequence[tensor]): List of dependencies that need to be kept alive while the mma is unfinished.
     """
     deps = [x.handle for x in deps] if deps is not None else []
     num_outstanding = _core._unwrap_if_constexpr(num_outstanding)

--- a/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
@@ -6,6 +6,14 @@ __all__ = ["arrive", "expect", "init", "invalidate", "MBarrierLayout", "wait"]
 
 @builtin
 def expect(mbarrier, bytes, pred=True, _semantic=None):
+    """
+    Expect a specific number of bytes being copied. When they are copied, the barrier is signaled.
+
+    Args:
+        mbarrier (shared_memory_descriptor): Barrier that will be signaled when the operation is complete.
+        bytes (int): Expected byte count.
+        pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
+    """
     bytes = _unwrap_if_constexpr(bytes)
     pred = _semantic.to_tensor(pred)
     _semantic.builder.create_mbarrier_expect(mbarrier.handle, bytes, pred.handle)
@@ -13,6 +21,14 @@ def expect(mbarrier, bytes, pred=True, _semantic=None):
 
 @builtin
 def arrive(mbarrier, *, count=1, pred=True, _semantic=None):
+    """
+    Arrive at an mbarrier with a specified count.
+
+    Args:
+        mbarrier (shared_memory_descriptor): Barrier to be signalled.
+        count (int): Count to arrive with. Defaults to 1.
+        pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
+    """
     count = _unwrap_if_constexpr(count)
     pred = _semantic.to_tensor(pred)
     _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, pred.handle)


### PR DESCRIPTION
Adding documentation for public gluon API. Generated by codex, with proof-reading and editing some of the issues by me. Formatting differs from triton docstrings, (using Google style rather than reST), but subjectively this seems more readable. Changing to reST formatting should be relatively easy if people have strong opinions about this.