### PR TITLE
Fix compiler warnings from Membar virtual function change

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -119,6 +119,8 @@ public:
   explicit MembarOrFenceAnalysis(Allocation *allocation, MembarFilterFn filter)
       : allocation(allocation), filter(filter) {}
 
+  virtual ~MembarOrFenceAnalysis() = default;
+
   /// Runs the membar analysis to the given operation, inserts a barrier if
   /// necessary.
   void run(FuncBlockInfoMapT &funcBlockInfoMap);
@@ -159,6 +161,8 @@ public:
   MembarAnalysis() = default;
   explicit MembarAnalysis(Allocation *allocation, MembarFilterFn filter)
       : MembarOrFenceAnalysis(allocation, filter) {}
+
+  ~MembarAnalysis() override = default;
 
 private:
   /// Updates the BlockInfo operation based on the operation.

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -51,8 +51,8 @@ struct TensorMemory : public SideEffects::Resource::Base<TensorMemory> {
 struct TMemAllocation {
   TMemAllocation(int numCols, int numRows)
       : numCols(numCols), numRows(numRows) {}
-  int numRows;
   int numCols;
+  int numRows;
 };
 
 TMemAllocation getTmemAllocSizes(gpu::MemDescType memDescType);


### PR DESCRIPTION
Fixes the `'mlir::MembarOrFenceAnalysis' has virtual functions but non-virtual destructor` warning that occurs due to adding a virtual function to the `MembarOrFenceAnalysis` base class. This error fails our `-Werror` check because we do not disable `non-virtual-dtor`.

I also fixed `warning: field 'numCols' will be initialized after field 'numRows'` since it showed up in my error trace, but this is not a warning that prompts errors, so there may be other locations where this warning is occurring.