### PR TITLE
Move the tensor descriptor block size check.

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
@@ -253,6 +253,13 @@ LogicalResult createTMADesc(Value tmaPtr, MakeTensorDescOp op,
       getTMABlockShape(encoding, shapePerCTA, /*packedSize=*/false);
   auto contigDimSize = blockShape.back();
 
+  if (contigDimSize * elemSize < 16) {
+    return op->emitError("Descriptor block shape must have at least 16 bytes "
+                         "in the last dimension, but got ")
+           << contigDimSize << " * " << elemSize << " = "
+           << (contigDimSize * elemSize) << " bytes";
+  }
+
   llvm::SmallVector<Value> boxDim;
   if (fp4Padded && contigDimSize != 128) {
     return op->emitError(

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1858,13 +1858,6 @@ class TritonSemantic(Generic[TensorTy]):
             raise ValueError(f"Expected {ndim} strides but got {len(strides)}")
         if len(block_shape) != ndim:
             raise ValueError(f"Expected block_shape to have {ndim} dimensions but got {len(strides)}")
-        assert isinstance(base.dtype, tl.pointer_type)
-        elem_size = base.dtype.element_ty.primitive_bitwidth // 8
-        contig_dim_size = tl._unwrap_if_constexpr(block_shape[-1])
-        if contig_dim_size * elem_size < 16:
-            raise ValueError(
-                f"Descriptor block shape must have at least 16 bytes in the last dimension, but got {contig_dim_size} * {elem_size} = {contig_dim_size * elem_size} bytes"
-            )
 
         strides[-1] = tl._unwrap_if_constexpr(strides[-1])
         if strides[-1] != 1:


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
Move a check from when a make_tensor_descriptor operation is created to when the operation is lowered to tma.

Not all backends share this restriction and the TritonRewriteTensorDescriptorToPointerPass handles these cases. By moving the error to the tma lowering it allows other backends to use these small tensor descriptors.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `Covered by existing tests. I had to modify the tma tests in test_core.py`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
