### PR TITLE
[AMD] Added clamping for Fp8E4M3 and Fp8E5M2

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -7,7 +7,7 @@ import pytest
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4
 
 
 def matching_int(dtype):
@@ -366,3 +366,77 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
 
     for i in range(256):
         downcast_test(getattr(tl, src_dtype), getattr(tl, dst_dtype), rounding, *stuff, max_repr, i, device=device)
+
+@pytest.mark.parametrize("src_dtype, dst_dtype, rounding", [
+    ('float32', 'float8e4nv', 'rtne'),
+    ('float16', 'float8e4nv', 'rtne'),
+    ('bfloat16', 'float8e4nv', 'rtne'),
+    ('float32', 'float8e5', 'rtne'),
+    ('float16', 'float8e5', 'rtne'),
+    ('bfloat16', 'float8e5', 'rtne'),
+])
+@pytest.mark.parametrize("mode", [
+    'max', 'min', 'inf', '-inf', 'nan',
+])
+def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, rounding, mode, device):
+    if src_dtype != 'float32' and torch.cuda.get_device_capability(0) < (9, 0):
+        pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
+
+    if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and torch.cuda.get_device_capability(0) < (9, 0):
+        pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
+
+    if is_hip_cdna2():
+        pytest.skip(f"{dst_dtype} downcast to {dst_dtype} with clamping is not fully tested on AMDGPU CDNA2")
+
+    if is_hip_cdna3() and src_dtype == 'bfloat16':
+        pytest.skip(f"{dst_dtype} downcast to {dst_dtype} with clamping is not fully tested on AMDGPU CDNA3")
+
+    if is_hip_cdna3() and src_dtype in ('float32', 'float16') and mode in ('inf', '-inf'):
+        pytest.skip(f"{src_dtype} downcast to {dst_dtype} with clamping for `inf` or `-inf` "
+                    "is not fully tested on AMDGPU CDNA3")
+
+    converter = {
+        tl.float8e4nv: torch.float8_e4m3fn,
+        tl.float8e5: torch.float8_e5m2,
+        tl.float16: torch.float16,
+        tl.bfloat16: torch.bfloat16,
+        tl.float32: torch.float32
+    }
+
+    tl_src_dtype = getattr(tl, src_dtype)
+    tl_dst_dtype = getattr(tl, dst_dtype)
+
+    torch_src_dtype = converter[tl_src_dtype]
+    torch_dst_dtype = converter[tl_dst_dtype]
+
+    if mode in ('max', 'min'):
+        # Added to input to exceed the representation range to produce NaN
+        exceed_value = 100.0
+        test_value = torch.finfo(torch_dst_dtype).max + exceed_value
+        expected_result = torch.finfo(torch_dst_dtype).max
+    if mode in ('inf', '-inf'):
+        test_value = torch.inf
+        expected_result = torch.finfo(torch_dst_dtype).max
+    if mode in ('nan'):
+        test_value = torch.nan
+        expected_result = torch.nan
+    if mode in ('min', '-inf'):
+        test_value *= -1.0
+        expected_result *= -1.0
+
+    BLOCK_SIZE = 1024
+    shape = (BLOCK_SIZE * 2,)
+    src = torch.full(shape, test_value, dtype=torch_src_dtype, device=device)
+    dst = torch.empty(shape, dtype=torch_dst_dtype, device=device)
+
+    type_convert_triton[(src.shape[0] // BLOCK_SIZE,)](
+        triton.reinterpret(src, torch_src_dtype),
+        triton.reinterpret(dst, torch_dst_dtype),
+        rounding,
+        BLOCK_SIZE
+    )
+
+    if mode == 'nan':
+        assert(torch.all(torch.isnan(dst)))
+    else:
+        torch.testing.assert_close(dst, torch.full_like(dst, expected_result))

--- a/python/triton_kernels/tests/test_mxfp.py
+++ b/python/triton_kernels/tests/test_mxfp.py
@@ -146,8 +146,8 @@ def test_mxfp_casting(
     if is_hip():
         if swizzle_value is not None or swizzle_scale is not None:
             pytest.skip("Other swizzling patterns are not supported by AMD GPU")
-        if quant_dtype == 'float8_e4m3fn':
-            pytest.skip("float8_e4m3fn cast hasn't been fully tested on AMD GPU")
+        if quant_dtype == 'float8_e4m3fn' and is_hip_cdna3():
+            pytest.skip("float8_e4m3fn cast hasn't been fully tested on AMD CDNA3")
         if quant_dtype == 'float8_e5m2' and is_hip_cdna3():
             pytest.skip("float8_e5m2 cast hasn't been fully tested on AMD CDNA3")
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -23,6 +23,241 @@ namespace {
 //===----------------------------------------------------------------------===//
 // Data type conversion utility functions
 //===----------------------------------------------------------------------===//
+
+template <typename FPType> struct FPTypeInfo {
+  FPTypeInfo(Location loc, ConversionPatternRewriter &rewriter,
+             TritonLLVMOpBuilder &builder)
+      : loc(loc), rewriter(rewriter), b(builder) {}
+  IntegerType getIntType() {
+    if constexpr (std::is_same_v<FPType, Float32Type>) {
+      return i32_ty;
+    }
+    if constexpr (std::is_same_v<FPType, Float16Type> ||
+                  std::is_same_v<FPType, BFloat16Type>) {
+      return i16_ty;
+    }
+    if constexpr (std::is_same_v<FPType, Float8E4M3FNType> ||
+                  std::is_same_v<FPType, Float8E5M2Type>) {
+      return i8_ty;
+    }
+    return nullptr;
+  }
+  Value getSignMask() {
+    if constexpr (std::is_same_v<FPType, Float32Type>) {
+      return b.i32_val(0x80000000);
+    }
+    if constexpr (std::is_same_v<FPType, Float16Type> ||
+                  std::is_same_v<FPType, BFloat16Type>) {
+      return b.i16_val(0x8000);
+    }
+    if constexpr (std::is_same_v<FPType, Float8E4M3FNType> ||
+                  std::is_same_v<FPType, Float8E5M2Type>) {
+      return b.i8_val(0x80);
+    }
+    return nullptr;
+  }
+  Value getExpMask() {
+    if constexpr (std::is_same_v<FPType, Float32Type>) {
+      return b.i32_val(0x7F800000);
+    }
+    if constexpr (std::is_same_v<FPType, Float16Type>) {
+      return b.i16_val(0x7C00);
+    }
+    if constexpr (std::is_same_v<FPType, BFloat16Type>) {
+      return b.i16_val(0x7F80);
+    }
+    if constexpr (std::is_same_v<FPType, Float8E4M3FNType>) {
+      return b.i8_val(0x78);
+    }
+    if constexpr (std::is_same_v<FPType, Float8E5M2Type>) {
+      return b.i8_val(0x7C);
+    }
+    return nullptr;
+  }
+  Value getMantissaMask() {
+    if constexpr (std::is_same_v<FPType, Float32Type>) {
+      return b.i32_val(0x007FFFFF);
+    }
+    if constexpr (std::is_same_v<FPType, Float16Type>) {
+      return b.i16_val(0x03FF);
+    }
+    if constexpr (std::is_same_v<FPType, BFloat16Type>) {
+      return b.i16_val(0x007F);
+    }
+    if constexpr (std::is_same_v<FPType, Float8E4M3FNType>) {
+      return b.i8_val(0x07);
+    }
+    if constexpr (std::is_same_v<FPType, Float8E5M2Type>) {
+      return b.i8_val(0x03);
+    }
+    return nullptr;
+  }
+  bool allowedNegativeZero() {
+    // Note: all `FPType` which are prefixed with UZ must return false;
+    return true;
+  }
+  float getMaxAsFloat() {
+    uint32_t value = 0;
+    if constexpr (std::is_same_v<FPType, Float32Type>) {
+      value = 0x7F7FFFFF;
+    }
+    if constexpr (std::is_same_v<FPType, Float16Type>) {
+      value = 0x477FE000;
+    }
+    if constexpr (std::is_same_v<FPType, BFloat16Type>) {
+      value = 0x7F7F0000;
+    }
+    if constexpr (std::is_same_v<FPType, Float8E4M3FNType>) {
+      value = 0x43E00000;
+    }
+    if constexpr (std::is_same_v<FPType, Float8E5M2Type>) {
+      value = 0x47600000;
+    }
+    return *(reinterpret_cast<float *>(&value));
+  }
+
+  float getMinAsFloat() {
+    uint32_t value = 0;
+    if constexpr (std::is_same_v<FPType, Float32Type>) {
+      value = 0xFF7FFFFF;
+    }
+    if constexpr (std::is_same_v<FPType, Float16Type>) {
+      value = 0xC77FE000;
+    }
+    if constexpr (std::is_same_v<FPType, BFloat16Type>) {
+      value = 0xFF7F0000;
+    }
+    if constexpr (std::is_same_v<FPType, Float8E4M3FNType>) {
+      value = 0xC3E00000;
+    }
+    if constexpr (std::is_same_v<FPType, Float8E5M2Type>) {
+      value = 0xC7600000;
+    }
+    return *(reinterpret_cast<float *>(&value));
+  }
+
+  Value getPositiveNan() {
+    if constexpr (std::is_same_v<FPType, Float32Type>) {
+      return toLLVMIntValue(0x7FFFFFFF);
+    }
+    if constexpr (std::is_same_v<FPType, Float16Type>) {
+      return toLLVMIntValue(0x7FFF);
+    }
+    if constexpr (std::is_same_v<FPType, BFloat16Type>) {
+      return toLLVMIntValue(0x7FFF);
+    }
+    if constexpr (std::is_same_v<FPType, Float8E4M3FNType> ||
+                  std::is_same_v<FPType, Float8E5M2Type>) {
+      return toLLVMIntValue(0x7F);
+    }
+    return nullptr;
+  }
+
+  Value getMaxPositive() {
+    if constexpr (std::is_same_v<FPType, Float32Type>) {
+      return toLLVMIntValue(0x7F7FFFFF);
+    }
+    if constexpr (std::is_same_v<FPType, Float16Type>) {
+      return toLLVMIntValue(0x7BFF);
+    }
+    if constexpr (std::is_same_v<FPType, BFloat16Type>) {
+      return toLLVMIntValue(0x7F7F);
+    }
+    if constexpr (std::is_same_v<FPType, Float8E4M3FNType>) {
+      return toLLVMIntValue(0x7E);
+    }
+    if constexpr (std::is_same_v<FPType, Float8E5M2Type>) {
+      return toLLVMIntValue(0x7B);
+    }
+    return nullptr;
+  }
+
+  Value toLLVMIntValue(int32_t val) {
+    if constexpr (std::is_same_v<FPType, Float32Type>) {
+      return b.i32_val(val);
+    }
+    if constexpr (std::is_same_v<FPType, Float16Type> ||
+                  std::is_same_v<FPType, BFloat16Type>) {
+      return b.i16_val(val);
+    }
+    if constexpr (std::is_same_v<FPType, Float8E4M3FNType> ||
+                  std::is_same_v<FPType, Float8E5M2Type>) {
+      return b.i8_val(val);
+    }
+    return nullptr;
+  }
+  Value toLLVMFloatValue(float val) {
+    if constexpr (std::is_same_v<FPType, Float32Type>) {
+      return b.f32_val(val);
+    }
+    if constexpr (std::is_same_v<FPType, Float16Type>) {
+      return b.f16_val(val);
+    }
+    if constexpr (std::is_same_v<FPType, BFloat16Type>) {
+      return b.bf16_val(val);
+    }
+    // skipped on purpose: Float8E4M3FNType, Float8E5M2Type
+    return nullptr;
+  }
+  Location loc;
+  ConversionPatternRewriter &rewriter;
+  TritonLLVMOpBuilder &b;
+};
+
+template <typename SrcFPType, typename DstFPType>
+Value clampOCP(Location loc, ConversionPatternRewriter &rewriter, Value orig,
+               Value converted) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  FPTypeInfo<SrcFPType> srcFpInfo(loc, rewriter, b);
+  FPTypeInfo<DstFPType> dstFpInfo(loc, rewriter, b);
+
+  Value srcTypeZero = srcFpInfo.toLLVMIntValue(0);
+  Value dstTypeZero = dstFpInfo.toLLVMIntValue(0);
+
+  auto srcIntType = srcFpInfo.getIntType();
+
+  auto srcIntValue = b.bitcast(orig, srcIntType);
+  Value isSrcNegative = b.icmp_eq(b.and_(srcIntValue, srcFpInfo.getSignMask()),
+                                  srcFpInfo.getSignMask());
+  Value dstSign = b.select(isSrcNegative, dstFpInfo.getSignMask(), dstTypeZero);
+  Value srcExp = b.and_(srcIntType, srcIntValue, srcFpInfo.getExpMask());
+  Value srcMantissa =
+      b.and_(srcIntType, srcIntValue, srcFpInfo.getMantissaMask());
+
+  Value isSrcExpZero = b.icmp_eq(srcExp, srcTypeZero);
+  Value isSrcExpFull = b.icmp_eq(srcExp, srcFpInfo.getExpMask());
+
+  Value isSrcMantissaZero = b.icmp_eq(srcMantissa, srcTypeZero);
+  Value isSrcMantissaNonZero = b.icmp_ne(srcMantissa, srcTypeZero);
+
+  Value isSrcNan = b.and_(isSrcExpFull, isSrcMantissaNonZero);
+  Value isSrcInf = b.and_(isSrcExpFull, isSrcMantissaZero);
+
+  Value isSrcOverflowMax =
+      b.fcmp_ogt(orig, srcFpInfo.toLLVMFloatValue(dstFpInfo.getMaxAsFloat()));
+  Value isSrcOverflowMin =
+      b.fcmp_olt(orig, srcFpInfo.toLLVMFloatValue(dstFpInfo.getMinAsFloat()));
+  Value isSrcOverflow = b.or_(isSrcOverflowMax, isSrcOverflowMin);
+
+  Value clamped =
+      b.select(isSrcNan, b.or_(dstSign, dstFpInfo.getPositiveNan()), converted);
+  if (dstFpInfo.allowedNegativeZero()) {
+    clamped = b.select(isSrcInf, b.or_(dstSign, dstFpInfo.getMaxPositive()),
+                       converted);
+  } else {
+    clamped = b.select(isSrcInf, dstFpInfo.getPositiveNan(), converted);
+  }
+  clamped = b.select(isSrcOverflow, b.or_(dstSign, dstFpInfo.getMaxPositive()),
+                     converted);
+  if (!dstFpInfo.allowedNegativeZero()) {
+    Value isSrcNegativieZero =
+        b.and_(b.and_(isSrcExpZero, isSrcMantissaZero), isSrcNegative);
+    clamped =
+        b.select(isSrcNegativieZero, dstFpInfo.toLLVMIntValue(0), converted);
+  }
+  return clamped;
+}
+
 // Convert Ocp Fp8/Bf8 to Fp16/Bf16/Fp32 on CDNA4
 template <typename ConvertOp>
 static SmallVector<Value>
@@ -136,8 +371,13 @@ static SmallVector<Value>
 Fp16_to_Fp8E5M2_RTNE_HW(Location loc, ConversionPatternRewriter &rewriter,
                         const SmallVector<Value> &v) {
   assert(v.size() == 2);
-  return cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkBf8F16Op>(loc, rewriter,
-                                                               v[0], v[1]);
+  auto convertedValues = cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkBf8F16Op>(
+      loc, rewriter, v[0], v[1]);
+  convertedValues[0] = clampOCP<Float16Type, Float8E5M2Type>(
+      loc, rewriter, v[0], convertedValues[0]);
+  convertedValues[1] = clampOCP<Float16Type, Float8E5M2Type>(
+      loc, rewriter, v[1], convertedValues[1]);
+  return convertedValues;
 }
 
 ConverterT Fp16_to_Fp8E5M2_RTNE(AMD::ISAFamily isaFamily) {
@@ -272,8 +512,14 @@ static SmallVector<Value>
 Fp16_to_Fp8E4M3FN_RTNE_HW(Location loc, ConversionPatternRewriter &rewriter,
                           const SmallVector<Value> &v) {
   assert(v.size() == 2);
-  return cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkFp8F16Op>(loc, rewriter,
-                                                               v[0], v[1]);
+  auto convertedValues = cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkFp8F16Op>(
+      loc, rewriter, v[0], v[1]);
+
+  convertedValues[0] = clampOCP<Float16Type, Float8E4M3FNType>(
+      loc, rewriter, v[0], convertedValues[0]);
+  convertedValues[1] = clampOCP<Float16Type, Float8E4M3FNType>(
+      loc, rewriter, v[1], convertedValues[1]);
+  return convertedValues;
 }
 
 ConverterT Fp16_to_Fp8E4M3FN_RTNE(AMD::ISAFamily isaFamily) {
@@ -361,8 +607,14 @@ static SmallVector<Value> Fp32_to_Fp8E4M3FN(Location loc,
                                             ConversionPatternRewriter &rewriter,
                                             const SmallVector<Value> &v) {
   assert(v.size() == 2);
-  return cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkFp8F32Op>(loc, rewriter,
-                                                               v[0], v[1]);
+  auto convertedValues = cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkFp8F32Op>(
+      loc, rewriter, v[0], v[1]);
+
+  convertedValues[0] = clampOCP<Float32Type, Float8E4M3FNType>(
+      loc, rewriter, v[0], convertedValues[0]);
+  convertedValues[1] = clampOCP<Float32Type, Float8E4M3FNType>(
+      loc, rewriter, v[1], convertedValues[1]);
+  return convertedValues;
 }
 
 // Convert Fp32 to OCP Bf8 on CDNA4
@@ -370,8 +622,13 @@ static SmallVector<Value>
 Fp32_to_Fp8E5M2_RTNE(Location loc, ConversionPatternRewriter &rewriter,
                      const SmallVector<Value> &v) {
   assert(v.size() == 2);
-  return cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkBf8F32Op>(loc, rewriter,
-                                                               v[0], v[1]);
+  auto convertedValues = cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkBf8F32Op>(
+      loc, rewriter, v[0], v[1]);
+  convertedValues[0] = clampOCP<Float32Type, Float8E5M2Type>(
+      loc, rewriter, v[0], convertedValues[0]);
+  convertedValues[1] = clampOCP<Float32Type, Float8E5M2Type>(
+      loc, rewriter, v[1], convertedValues[1]);
+  return convertedValues;
 }
 
 // Fp32 -> Nanoo Bf8 on CDNA3
@@ -927,8 +1184,13 @@ static SmallVector<Value>
 Bf16_to_Fp8E5M2_HW(Location loc, ConversionPatternRewriter &rewriter,
                    const SmallVector<Value> &v) {
   assert(v.size() == 2);
-  return cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkBf8Bf16Op>(loc, rewriter,
-                                                                v[0], v[1]);
+  auto convertedValues = cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkBf8Bf16Op>(
+      loc, rewriter, v[0], v[1]);
+  convertedValues[0] = clampOCP<BFloat16Type, Float8E5M2Type>(
+      loc, rewriter, v[0], convertedValues[0]);
+  convertedValues[1] = clampOCP<BFloat16Type, Float8E5M2Type>(
+      loc, rewriter, v[1], convertedValues[1]);
+  return convertedValues;
 }
 
 static ConverterT Bf16_to_Fp8E5M2(AMD::ISAFamily isaFamily) {
@@ -940,8 +1202,14 @@ static SmallVector<Value> Bf16_to_Fp8E4M3FN(Location loc,
                                             ConversionPatternRewriter &rewriter,
                                             const SmallVector<Value> &v) {
   assert(v.size() == 2);
-  return cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkFp8Bf16Op>(loc, rewriter,
-                                                                v[0], v[1]);
+  auto convertedValues = cvtScalePkDowncastToFp8<ROCDL::CvtScaleF32PkFp8Bf16Op>(
+      loc, rewriter, v[0], v[1]);
+
+  convertedValues[0] = clampOCP<BFloat16Type, Float8E4M3FNType>(
+      loc, rewriter, v[0], convertedValues[0]);
+  convertedValues[1] = clampOCP<BFloat16Type, Float8E4M3FNType>(
+      loc, rewriter, v[1], convertedValues[1]);
+  return convertedValues;
 }
 
 // fp8e4m3fn to bf16


### PR DESCRIPTION
There are several conversion ops on the NV side using satfinite mode, but on the AMD side, some of those are in non-saturation mode. We need to align AMD ops with NV.

For example, fp32 to OCP fp8 on mi350 is lowered to ROCDL::CvtScaleF32PkFp8F32Op, and is eventually lowered to v_cvt_scalef32_pk_fp8_f32, which, according to ISA, is in non-saturation mode. But on the NV side, it's lowered to
cvt.rn.satfinite.e4m3x2.f32, which is in saturation mode.

Here is the full list of conversion instruction which doesn't support saturation:

| Conversion        | ROCDL dialect                 | Instruction                |
| ----------------- | ----------------------------- | -------------------------- |
| fp32 to fp8e4m3fn | ROCDL::CvtScaleF32PkFp8F32Op  | v_cvt_scalef32_pk_fp8_f32  |
| fp32 to fp8e5m2   | ROCDL::CvtScaleF32PkBf8F32Op  | v_cvt_scalef32_pk_bf8_f32  |
| fp16 to fp8e4m3fn | ROCDL::CvtScaleF32PkFp8F16Op  | v_cvt_scalef32_pk_fp8_f16  |
| fp16 to fp8e5m2   | ROCDL::CvtScaleF32PkBf8F16Op  | v_cvt_scalef32_pk_bf8_f16  |
| bf16 to fp8e4m3fn | ROCDL::CvtScaleF32PkFp8Bf16Op | v_cvt_scalef32_pk_fp8_bf16 |
| bf16 to fp8e5m2   | ROCDL::CvtScaleF32PkBf8Bf16Op | v_cvt_scalef32_pk_bf8_bf16 |

This PR 
- adds software clamping for aforementioned instructions
- adds a test to test clamping `python/test/unit/language/test_conversions.py::test_typeconvert_downcast_clamping`
- loosens constrains for `/home/rdorozhi/work/triton/python/triton_kernels/tests/test_mxfp.py` regarding MI350

The purpose of this PR is to enable some missing tests to test correctness. We will continue: 1) enable clamped downcasting for  MI300; 2) try to come up with a more performant solution

cc: @antiagainst, @knwng