### PR TITLE
Include constexprs in cache keys, fixes #7322

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -238,10 +238,10 @@ def test_kernel_global_var_change(device):
     assert x == torch.ones_like(x)
 
     GLOBAL_VAR = 2
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(triton.compiler.errors.CompilationError) as e:
         kernel[(1, )](x)
 
-    assert "global variable" in str(e.value).lower()
+    assert "Cannot access global variable" in str(e.value)
 
 
 GLOBAL = 42  # noqa
@@ -264,29 +264,6 @@ def test_local_shadows_global():
 
 
 CONSTEXPR_GLOBAL = tl.constexpr(42)
-
-
-def test_local_does_not_shadow_global():
-    global CONSTEXPR_GLOBAL
-
-    @triton.jit
-    def kernel():
-        a = CONSTEXPR_GLOBAL  # noqa
-        _, CONSTEXPR_GLOBAL = 0, 0  # noqa
-
-    CONSTEXPR_GLOBAL = tl.constexpr(42)
-    kernel[(1, )]()
-    CONSTEXPR_GLOBAL = tl.constexpr(43)
-
-    # Error because the `CONSTEXPR_GLOBAL` we're modifying is the same
-    # `CONSTEXPR_GLOBAL` that's read inside `kernel`.  (Alternatively, we could
-    # make this kernel an error altogether, as it is if it's a pure Python
-    # function -- the fact that we store to `CONSTEXPR_GLOBAL` inside the kernel
-    # makes the first read a read of the local variable, which doesn't exist
-    # yet.)
-    with pytest.raises(RuntimeError):
-        kernel[(1, )]()
-
 
 CONFLICTING_GLOBAL = tl.constexpr(0)
 
@@ -362,27 +339,6 @@ def test_cache_builtin_as_global():
     assert "global variable" in str(e.value).lower()
 
 
-def test_cache_closure():
-
-    def make_closure(cst):
-
-        @triton.jit
-        def closure():
-            tl.full((16, ), cst, dtype=tl.int32)
-
-        return closure
-
-    cst = tl.constexpr(42)
-    closure = make_closure(cst)
-
-    closure[(1, )]()
-    cst.value = 43
-    with pytest.raises(RuntimeError) as e:
-        closure[(1, )]()
-
-    assert "cst has changed since we compiled this kernel, from constexpr[42] to constexpr[43]" in str(e.value)
-
-
 @triton.jit
 def no_cache_callable_inner():
     pass
@@ -397,6 +353,68 @@ def test_no_cache_callable():
     kernel[(1, )]()
     # `no_cache_callable_inner` should not be entered into used_global_vals.
     assert not kernel.used_global_vals
+
+
+def test_constexpr_cache_invalidation_recreated(device):
+
+    def test_run(val):
+        VAL = tl.constexpr(val)
+
+        @triton.jit
+        def kernel(out):
+            tl.store(out, VAL)
+
+        out = torch.zeros(1, device=device)
+        kernel[(1, )](out)
+        return out.item()
+
+    assert test_run(123) == 123
+    assert test_run(1234) == 1234
+
+
+def test_constexpr_cache_invalidation_captured(device):
+    VAL = tl.constexpr(123)
+
+    @triton.jit
+    def kernel(out):
+        tl.store(out, VAL)
+
+    out = torch.zeros(1, device=device)
+    kernel[(1, )](out)
+    assert out == 123
+
+    VAL = tl.constexpr(1234)
+    out = torch.zeros(1, device=device)
+    kernel[(1, )](out)
+    assert out == 1234
+
+    VAL.value = 12345
+    out = torch.zeros(1, device=device)
+    kernel[(1, )](out)
+    assert out == 12345
+
+
+def test_constexpr_cache_invalidation_global(device):
+    global VAL
+    VAL = tl.constexpr(123)
+
+    @triton.jit
+    def kernel(out):
+        tl.store(out, VAL)
+
+    out = torch.zeros(1, device=device)
+    kernel[(1, )](out)
+    assert out == 123
+
+    VAL = tl.constexpr(1234)
+    out = torch.zeros(1, device=device)
+    kernel[(1, )](out)
+    assert out == 1234
+
+    VAL.value = 12345
+    out = torch.zeros(1, device=device)
+    kernel[(1, )](out)
+    assert out == 12345
 
 
 def test_jit_warmup_cache(device) -> None:


### PR DESCRIPTION
Triton "allows" you to use globals, such as `GLOBAL_VAR = tl.constexpr(123)` in your kernels. This "somewhat" works. However, if you edit the value of these globals, triton will silently stick with the old value. You can kick it into using the new value with `rm -rf ~/.triton`. See #7322.

This PR pulls those global (or nonlocal) constexpr values into the cache keys.

The tests mostly cover my issue. I added the constexpr values to two different keys. If you remove either, the tests stop passing. I have not found a reasonable case where the tests pass but my actual issue #7322 remains but possibly I have missed something.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

