### PR TITLE
[Backend] Emit `bar.warp.sync` for barriers of 1 warp

### DIFF
--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -8,7 +8,7 @@ llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 :
 llvm.func @rewrite_barriers() attributes {allocation.offset = 32 : i32} {
   // CHECK: barrier.sync.aligned 2, 128
   // CHECK: barrier.sync.aligned 3, 64
-  // CHECK: barrier.sync.aligned 4, 32
+  // CHECK: bar.warp.sync
 
   // CHECK: bb{{[0-9]+}}:
   // CHECK-NEXT: barrier.sync.aligned 0, 128


### PR DESCRIPTION
In warp specialized regions with only 1 warp, we can emit `bar.warp.sync` instead of barriers with a threadcount. This is slightly more efficient.
