### PR TITLE
[Triton] Fix loop aware CSE not checking op result index

### DIFF
--- a/lib/Dialect/Triton/Transforms/LoopAwareCSE.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopAwareCSE.cpp
@@ -93,6 +93,8 @@ bool LoopCSEDriver::areEqualInLoop(Value a, Value b) {
 
   Operation *aDef = a.getDefiningOp();
   Operation *bDef = b.getDefiningOp();
+  if (cast<OpResult>(a).getResultNumber() != cast<OpResult>(b).getResultNumber())
+    return false;
   // For it to be known that the operation results have the same value, they
   // must be side effect free.
   if (!isMemoryEffectFree(aDef) || !isMemoryEffectFree(bDef))

--- a/lib/Dialect/Triton/Transforms/LoopAwareCSE.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopAwareCSE.cpp
@@ -93,7 +93,8 @@ bool LoopCSEDriver::areEqualInLoop(Value a, Value b) {
 
   Operation *aDef = a.getDefiningOp();
   Operation *bDef = b.getDefiningOp();
-  if (cast<OpResult>(a).getResultNumber() != cast<OpResult>(b).getResultNumber())
+  if (cast<OpResult>(a).getResultNumber() !=
+      cast<OpResult>(b).getResultNumber())
     return false;
   // For it to be known that the operation results have the same value, they
   // must be side effect free.


### PR DESCRIPTION
Turns out operations can have more than one result.