### PR TITLE
[BACKEND] support tt::TransOp in comesFromLoadOrBlockArg

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1573,6 +1573,10 @@ bool comesFromLoadOrBlockArg(Value v) {
       v = cvtOp.getSrc();
       continue;
     }
+    if (auto transOp = dyn_cast<tt::TransOp>(def)) {
+      v = transOp.getSrc();
+      continue;
+    }
     if (def->hasTrait<OpTrait::MemDescViewTrait>()) {
       v = def->getOperand(0);
       continue;


### PR DESCRIPTION
This patches a bug (https://github.com/pytorch/pytorch/issues/156028) which was introduced by #7066.

#7066 refactors comesFromLoadOrBlockArg so it can be used in PromoteLHSToTMem.cpp, and is intended to extend it to support all MemDescViewTrait ops. However, in this refactor, support for tt.TransOp was dropped, changing the behavior of AccelerateMatmul.cpp.

This PR adds tt::TransOp back into the set of ops supported by comesFromLoadOrBlockArg.

i.e.:
behavior before #7066: comesFromLoadOrBlockArg tracks loads past: ttg::ConvertLayoutOp, **tt::TransOp**
behavior after #7066: comesFromLoadOrBlockArg tracks loads past: ttg::ConvertLayoutOp, ttg::MemDescSubview, ttg::MemDescTransOp, ttg::MemDescReshapeOp, ttg::MemDescReinterpretOp
behavior after this PR: comesFromLoadOrBlockArg tracks loads past: ttg::ConvertLayoutOp, **tt::TransOp** ttg::MemDescSubview, ttg::MemDescTransOp, ttg::MemDescReshapeOp, ttg::MemDescReinterpretOp