### PR TITLE
Revert "Include constexprs in cache keys, fixes #7322 (#7332)"

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -400,23 +400,6 @@ def test_no_cache_callable():
     assert not kernel.used_global_vals
 
 
-def test_constexpr_cache_invalidation_recreated(device):
-
-    def test_run(val):
-        VAL = tl.constexpr(val)
-
-        @triton.jit
-        def kernel(out):
-            tl.store(out, VAL)
-
-        out = torch.zeros(1, device=device)
-        kernel[(1, )](out)
-        return out.item()
-
-    assert test_run(123) == 123
-    assert test_run(1234) == 1234
-
-
 def test_jit_warmup_cache(device) -> None:
 
     @triton.jit

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -696,9 +696,6 @@ class JITFunction(KernelInterface[T]):
             dependencies_finder.visit(self.parse())
             self.hash = dependencies_finder.ret + str(self.starting_line_number)
             self.used_global_vals = dict(sorted(dependencies_finder.used_global_vals.items()))
-            # Include current constexpr values in cache key for proper invalidation
-            self.hash += str(self.used_global_vals)
-            self.hash = hashlib.sha256(self.hash.encode("utf-8")).hexdigest()
         return self.hash
 
     @property


### PR DESCRIPTION
This reverts #7332 as it essentially made the disk cache useless. Any function that calls another function lists it as a global value, and when printed that function includes the pointer to the python object which is not stable across different runs. Thus the cache always misses.
