### PR TITLE
Allow out-of-tree build with environment variable TRITON_BUILD_DIR.

### DIFF
--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -8,10 +8,15 @@ def get_base_dir():
     return os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 
-def get_cmake_dir():
+def _get_cmake_dir():
     plat_name = sysconfig.get_platform()
     python_version = sysconfig.get_python_version()
     dir_name = f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"
-    cmake_dir = Path(get_base_dir()) / "build" / dir_name
+    return Path(get_base_dir()) / "build" / dir_name
+
+
+def get_cmake_dir():
+    cmake_dir = os.getenv("TRITON_BUILD_DIR", default=_get_cmake_dir())
+    cmake_dir = Path(cmake_dir)
     cmake_dir.mkdir(parents=True, exist_ok=True)
     return cmake_dir


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because customizable build directory is usually not a subject to test.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

# Rationale

Current Triton uses a fixed build directory `f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"` when installing with `pip install .`, when the same python is used, regardless of the venv target or source code version. This creates conflicts when

* Users switches Triton source version but did not clean the build directory.
    + This is a little hard to notice since most `pip install .` will use a temporary directory to build
* Users installing Triton into multiple venv at the same time.

With this option, users can specify an out-of-tree build directory to avoid such conflicts.

# Alternatives

PIP usually uses /tmp/pip-build-env-xxxx/ as the temporary build directory. However I have not found documentation about how to locate this directory in `pip/setuptools`.
