### PR TITLE
[BENCH] Routing improvements

### DIFF
--- a/python/triton_kernels/tests/test_routing.py
+++ b/python/triton_kernels/tests/test_routing.py
@@ -5,7 +5,7 @@ from triton_kernels.testing import assert_close
 from triton_kernels.testing import assert_equal
 
 
-def init_data(n_tokens, n_expts_tot, dtype=torch.float32, device="cuda"):
+def init_data(n_tokens, n_expts_tot, dtype=torch.float16, device="cuda"):
     logits = torch.randn((n_tokens, n_expts_tot), dtype=dtype, device=device, requires_grad=True)
     return logits
 

--- a/python/triton_kernels/tests/test_routing.py
+++ b/python/triton_kernels/tests/test_routing.py
@@ -26,7 +26,7 @@ def test_op(n_tokens_pad, n_tokens_raw, n_expts_tot, n_expts_act, sm_first, use_
     else:
         n_routing_rows = torch.tensor([n_tokens_raw], dtype=torch.int32, device=device)
     n_gates_raw = n_tokens_raw * n_expts_act
-    tri_logits = init_data(n_tokens_pad, n_expts_tot, device=device).detach()
+    tri_logits = init_data(n_tokens_pad, n_expts_tot, device=device, dtype=torch.float32).detach()
     tri_logits[n_tokens_raw:, :] = float("inf")  # should not be used
     tri_logits = tri_logits.requires_grad_(True)
     ref_logits = tri_logits.clone().detach().requires_grad_(True)

--- a/python/triton_kernels/triton_kernels/routing.py
+++ b/python/triton_kernels/triton_kernels/routing.py
@@ -115,7 +115,8 @@ class SortTokens(torch.autograd.Function):
         gate_indx = combined_indx[n_gates_pad:]
         gate_scal = torch.empty(n_gates_pad, dtype=dtype, device=device)
 
-        token_offs_combined, token_offs_raw, token_offs_pad, block_pid_map, blocks1a, blocks2a, MEMSET_BLOCK_A, HIST2_BLOCK_M, block_m_log2_start, block_m_num = _compute_expt_data_internal(hist, n_expts_tot, n_gates_pad)
+        token_offs_combined, token_offs_raw, token_offs_pad, block_pid_map, blocks1a, blocks2a, MEMSET_BLOCK_A, HIST2_BLOCK_M, block_m_log2_start, block_m_num = _compute_expt_data_internal(
+            hist, n_expts_tot, n_gates_pad)
 
         blocks1b = cdiv(n_gates_pad * 2, MEMSET_BLOCK) + n_expts_tot + 1
         blocks2b = cdiv(n_tokens_pad, HIST_BLOCK_M)
@@ -252,7 +253,8 @@ def compute_expt_data(expt_hist, n_expts_tot, n_gates):
         return ExptData(None, None, None, None)
 
     # this just computes the kernel arguments:
-    token_offs_combined, token_offs_raw, token_offs_pad, block_pid_map, blocks1, blocks2, MEMSET_BLOCK, HIST2_BLOCK_M, block_m_log2_start, block_m_num = _compute_expt_data_internal(expt_hist, n_expts_tot, n_gates)
+    token_offs_combined, token_offs_raw, token_offs_pad, block_pid_map, blocks1, blocks2, MEMSET_BLOCK, HIST2_BLOCK_M, block_m_log2_start, block_m_num = _compute_expt_data_internal(
+        expt_hist, n_expts_tot, n_gates)
 
     _expt_data_memset[(blocks1, )](
         expt_hist, n_expts_tot,  #
@@ -284,7 +286,8 @@ def routing(logits, n_expts_act, sm_first=False, expt_indx=None, simulated_ep=1,
     # mutate bitmatrix
     if simulated_ep > 1:
         expt_scal, expt_indx, bitmatrix = prune_routing(expt_scal, expt_indx, bitmatrix, simulated_ep)
-    hist, topk_indx, gate_indx, gate_scal, token_offs_raw, token_offs_pad, block_pid_map = sort_tokens(expt_scal, expt_indx, bitmatrix)
+    hist, topk_indx, gate_indx, gate_scal, token_offs_raw, token_offs_pad, block_pid_map = sort_tokens(
+        expt_scal, expt_indx, bitmatrix)
 
     token_offs_pad = _unpack_into_dict(token_offs_pad)
     block_pid_map = _unpack_into_dict(block_pid_map)

--- a/python/triton_kernels/triton_kernels/routing.py
+++ b/python/triton_kernels/triton_kernels/routing.py
@@ -219,14 +219,15 @@ def compute_expt_data(expt_hist, n_expts_tot, n_gates):
     token_offs_pad = token_offs_combined[1:]
 
     block_pid_map = torch.empty((block_m_num, pad(max_n_tiles)), dtype=dtype, device=device)
+    memset_grid = torch.numel(block_pid_map) // MEMSET_BLOCK  # exact division
     # compute outputs
     token_offs_pad = token_offs_pad[:, :n_expts_tot + 1]
     block_pid_map = block_pid_map[:, :max_n_tiles]
-    memset_grid = cdiv(block_pid_map.shape[1], MEMSET_BLOCK) + 1
-    _expt_data_memset[(memset_grid * block_m_num + 1,)](
+
+    _expt_data_memset[(memset_grid + block_m_num + 1,)](
         expt_hist, n_expts_tot,  #
         token_offs_combined, token_offs_combined.stride(0),  #
-        block_pid_map, block_pid_map.stride(0),  #
+        block_pid_map,  #
         block_m_log2_start, SIZES=block_m_num, BLOCK=MEMSET_BLOCK,  # optimization parameters
         num_warps=1)
     _expt_data_compute[(n_expts_tot, block_m_num)](

--- a/python/triton_kernels/triton_kernels/routing.py
+++ b/python/triton_kernels/triton_kernels/routing.py
@@ -227,9 +227,9 @@ def _compute_expt_data_internal(expt_hist, n_expts_tot, n_gates):
         block_pid_map,  #
         block_m_log2_start, SIZES=block_m_num, BLOCK=MEMSET_BLOCK,  # optimization parameters
         num_warps=1)
-    _expt_data_compute[(n_expts_tot, block_m_num)](
+    _expt_data_compute[(n_expts_tot * block_m_num, )](
         expt_hist, token_offs_pad, token_offs_pad.stride(0), block_pid_map, block_pid_map.stride(0),  # outputs
-        block_m_log2_start, BLOCK=HIST2_BLOCK_M,  # optimization parameters
+        block_m_log2_start, SIZES=block_m_num, BLOCK=HIST2_BLOCK_M,  # optimization parameters
         num_warps=4)
 
     return token_offs_raw, token_offs_pad, block_pid_map

--- a/python/triton_kernels/triton_kernels/routing.py
+++ b/python/triton_kernels/triton_kernels/routing.py
@@ -120,7 +120,7 @@ class SortTokens(torch.autograd.Function):
             expt_offs, hist.shape[0], BLOCK_N=512  #
         )
         _routing_compute_indx_offs[(n_expts_tot, )](
-            expt_offs, partial_hist,  # inputs
+            partial_hist,  # inputs
             partial_hist.shape[0], partial_hist.stride(0), partial_hist.stride(1),  # outputs
             BLOCK_M=INDX_OFFS_BLOCK_M,  # tunable parameters
         )
@@ -128,7 +128,7 @@ class SortTokens(torch.autograd.Function):
         _routing_compute_indx[(cdiv(n_tokens_pad, HIST_BLOCK_M), )](
             topk_indx, gate_indx, gate_scal,  # outputs
             expt_scal, expt_indx, indx_offs, indx_offs.stride(0), indx_offs.stride(1),  # inputs
-            n_tokens_pad, n_tokens_raw,  # input shape
+            expt_offs, n_tokens_pad, n_tokens_raw,  # input shape
             BLOCK_M=HIST_BLOCK_M,  # tunable parameters
             N_EXPTS_ACT=n_expts_act,  # constants
             num_warps=1 if HIST_BLOCK_M * n_expts_act // 32 < 4 else 4  #

--- a/python/triton_kernels/triton_kernels/routing.py
+++ b/python/triton_kernels/triton_kernels/routing.py
@@ -221,7 +221,7 @@ def _compute_expt_data_internal(expt_hist, n_expts_tot, n_gates):
     token_offs_pad = token_offs_pad[:, :n_expts_tot + 1]
     block_pid_map = block_pid_map[:, :max_n_tiles]
 
-    _expt_data_memset[(memset_grid + block_m_num + 1,)](
+    _expt_data_memset[(memset_grid + block_m_num + 1, )](
         expt_hist, n_expts_tot,  #
         token_offs_combined, token_offs_combined.stride(0),  #
         block_pid_map,  #

--- a/python/triton_kernels/triton_kernels/routing_details/_expt_data.py
+++ b/python/triton_kernels/triton_kernels/routing_details/_expt_data.py
@@ -8,42 +8,38 @@ def _cdiv_pow2(n, log2_k):
 
 
 @triton.jit
-def _expt_data_memset(Hist, n_expts_tot, MDTokStarts, MDTileStarts, tile_starts_stridem, MDTileInfo, tile_infos_stridem,
-                      first_tile_dim_log2, BLOCK: tl.constexpr):
-    pid_n = tl.program_id(0)
-    pid_m = tl.program_id(1)
+def _expt_data_memset(Hist, n_expts_tot, MDStarts, tile_starts_stridem, MDTileInfo, tile_infos_stridem,
+                      first_tile_dim_log2, SIZES: tl.constexpr, BLOCK: tl.constexpr):
 
-    tile_dim_log2 = first_tile_dim_log2 + pid_m
-    # if pid == 0 - initialize cumsums
-    if pid_n == 0:
-        MDTileStarts += pid_m * tile_starts_stridem
+    pid = tl.program_id(0)
 
-        x_tok = tl.zeros([BLOCK], dtype=MDTokStarts.dtype.element_ty)
-        x_tile = tl.zeros([BLOCK], dtype=MDTileStarts.dtype.element_ty)
+    if pid <= SIZES:
 
-        Tok_ptrs = MDTokStarts + tl.arange(0, BLOCK)
-        Tile_ptrs = MDTileStarts + tl.arange(0, BLOCK)
+        MDStarts += pid * tile_starts_stridem
+        x_tile = tl.zeros([BLOCK], dtype=MDStarts.dtype.element_ty)
+        Tile_ptrs = MDStarts + tl.arange(0, BLOCK)
+        tile_dim_log2 = tl.where(pid == 0, 0, pid + first_tile_dim_log2 - 1)
 
         for i in range(0, n_expts_tot + 1, BLOCK):
+
             offs_n = tl.arange(0, BLOCK) + i
             mask_n0 = offs_n < n_expts_tot
-            mask_n1 = offs_n < n_expts_tot + 1
             hist_tok = tl.load(Hist + offs_n, mask=mask_n0, other=0)
             hist_tile = _cdiv_pow2(hist_tok, tile_dim_log2)
-            tok_starts = tl.cumsum(hist_tok, 0) + x_tok
-            x_tok += tl.sum(hist_tok, 0).to(MDTokStarts.dtype.element_ty)
+
             tile_starts = tl.cumsum(hist_tile, 0) + x_tile
-            x_tile += tl.sum(hist_tile, 0).to(MDTileStarts.dtype.element_ty)
-
-            tl.store(Tok_ptrs, tok_starts - hist_tok, mask=mask_n1)
-            tl.store(Tile_ptrs, tile_starts - hist_tile, mask=mask_n1)
-
-            Tok_ptrs += BLOCK
+            x_tile += tl.sum(hist_tile, 0).to(MDStarts.dtype.element_ty)
+            tl.store(Tile_ptrs, tile_starts - hist_tile)
             Tile_ptrs += BLOCK
 
     else:
+
+        pid -= (SIZES + 1)
+        pid_n = pid // SIZES
+        pid_m = pid % SIZES
+
         MDTileInfo += pid_m * tile_infos_stridem
-        TileInfoOut = MDTileInfo + (pid_n - 1) * BLOCK + tl.arange(0, BLOCK)
+        TileInfoOut = MDTileInfo + pid_n * BLOCK + tl.arange(0, BLOCK)
         tl.store(TileInfoOut, 0xffffffff)
 
 

--- a/python/triton_kernels/triton_kernels/routing_details/_expt_data.py
+++ b/python/triton_kernels/triton_kernels/routing_details/_expt_data.py
@@ -41,9 +41,12 @@ def _expt_data_memset(Hist, n_expts_tot, MDStarts, tile_starts_stridem, MDTileIn
 
 @triton.jit
 def _expt_data_compute(Hist, MDTileStarts, tile_starts_stridem, MDTileInfo, tile_info_stridem, first_tile_dim_log2,
-                       BLOCK: tl.constexpr):
-    expt_id = tl.program_id(0)
-    buff_id = tl.program_id(1)
+                       SIZES: tl.constexpr, BLOCK: tl.constexpr):
+
+    pid = tl.program_id(0)
+
+    expt_id = pid // SIZES
+    buff_id = pid % SIZES
 
     MDTileStarts += buff_id * tile_starts_stridem
     MDTileInfo += buff_id * tile_info_stridem

--- a/python/triton_kernels/triton_kernels/routing_details/_expt_data.py
+++ b/python/triton_kernels/triton_kernels/routing_details/_expt_data.py
@@ -8,8 +8,8 @@ def _cdiv_pow2(n, log2_k):
 
 
 @triton.jit
-def _expt_data_memset(Hist, n_expts_tot, MDStarts, tile_starts_stridem, MDTileInfo,
-                      first_tile_dim_log2, SIZES: tl.constexpr, BLOCK: tl.constexpr):
+def _expt_data_memset(Hist, n_expts_tot, MDStarts, tile_starts_stridem, MDTileInfo, first_tile_dim_log2,
+                      SIZES: tl.constexpr, BLOCK: tl.constexpr):
 
     pid = tl.program_id(0)
 
@@ -54,7 +54,7 @@ def _expt_data_compute(Hist, MDTileStarts, tile_starts_stridem, MDTileInfo, tile
 
     tile_off = tl.load(MDTileStarts + expt_id)
     MDTileInfo += tile_off
-    # MDTileInfo += tl.load(MDTilesStart + expt_id)
+
     for block_off in range(0, n_blocks, BLOCK):
         block_offs = block_off + tl.arange(0, BLOCK)
         data = (block_offs << 16) + expt_id

--- a/python/triton_kernels/triton_kernels/routing_details/_expt_data.py
+++ b/python/triton_kernels/triton_kernels/routing_details/_expt_data.py
@@ -8,7 +8,7 @@ def _cdiv_pow2(n, log2_k):
 
 
 @triton.jit
-def _expt_data_memset(Hist, n_expts_tot, MDStarts, tile_starts_stridem, MDTileInfo, tile_infos_stridem,
+def _expt_data_memset(Hist, n_expts_tot, MDStarts, tile_starts_stridem, MDTileInfo,
                       first_tile_dim_log2, SIZES: tl.constexpr, BLOCK: tl.constexpr):
 
     pid = tl.program_id(0)
@@ -35,11 +35,7 @@ def _expt_data_memset(Hist, n_expts_tot, MDStarts, tile_starts_stridem, MDTileIn
     else:
 
         pid -= (SIZES + 1)
-        pid_n = pid // SIZES
-        pid_m = pid % SIZES
-
-        MDTileInfo += pid_m * tile_infos_stridem
-        TileInfoOut = MDTileInfo + pid_n * BLOCK + tl.arange(0, BLOCK)
+        TileInfoOut = MDTileInfo + pid * BLOCK + tl.arange(0, BLOCK)
         tl.store(TileInfoOut, 0xffffffff)
 
 

--- a/python/triton_kernels/triton_kernels/routing_details/_routing_compute.py
+++ b/python/triton_kernels/triton_kernels/routing_details/_routing_compute.py
@@ -97,9 +97,8 @@ def _routing_clear_bitmatrix(Bitmatrix, stride_bm, stride_bn, shape_bn, cutoff, 
 
 
 @triton.jit
-def _routing_memset_indx(Indx, size, sentinel, BLOCK: tl.constexpr, ExpertHist, FinalExpertOffs, hist_size,
-                         n_expts_tot, PartialHist, shape_pm, stride_pm, stride_pn,  #
-                         BLOCK_N: tl.constexpr, BLOCK_M: tl.constexpr):
+def _routing_memset_indx(Indx, size, sentinel, BLOCK: tl.constexpr, ExpertHist, FinalExpertOffs, hist_size, n_expts_tot,
+                         PartialHist, shape_pm, stride_pm, stride_pn, BLOCK_N: tl.constexpr, BLOCK_M: tl.constexpr):
     pid = tl.program_id(0)
 
     if pid == n_expts_tot:


### PR DESCRIPTION
This improves end-to-end routing performance by about 30%:

- fp32 logits: 22.8us --> 18.0us
- fp16 logits: 17.3us --> 12.2us

by a combination of several optimisations, including liberally fusing kernels in order to reduce the total number of launches from 7 to 4. Now, we only have four obligatory kernel launches:

- `_topk_forward`
- `_sum_bitmatrix_rows`
- `_combined_routing_memset`
- `_combined_routing_compute`

although in an expert-sharding world there are extra kernels inserted between `_topk_forward` and `_sum_bitmatrix_rows` in order to mutate the bitmatrix and update the other data structures produced by `_topk_forward`.