### PR TITLE
[IR][RFC] Enabling swizzling for dot encoding in some specific case

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1111,18 +1111,22 @@ swizzleDotOperandLike(RankedTensorType type, ttg::CTALayoutAttr ctaLayout) {
       type.getElementTypeBitWidth(), false);
 }
 
-RankedTensorType getPotentialDotType(Operation* op) {
+RankedTensorType getPotentialDotType(Operation *op) {
   if (op->getNumResults() != 1) {
     return nullptr;
   }
-  if(isa<ttg::LocalLoadOp, ttg::ConvertLayoutOp, tt::TransOp, ReshapeOp>(*op)) {
+  if (isa<ttg::LocalLoadOp, ttg::ConvertLayoutOp, tt::TransOp, ReshapeOp>(
+          *op)) {
     auto dstTy = cast<RankedTensorType>(op->getResult(0).getType());
-    int res_user_cnt = std::distance(op->getResult(0).user_begin(), op->getResult(0).user_end());
-    if(isa<ttg::DotOperandEncodingAttr>(dstTy.getEncoding()) || res_user_cnt != 1) {
+    int res_user_cnt = std::distance(op->getResult(0).user_begin(),
+                                     op->getResult(0).user_end());
+    if (isa<ttg::DotOperandEncodingAttr>(dstTy.getEncoding()) ||
+        res_user_cnt != 1) {
       return dstTy;
     } else {
-      // If there is only one user, we could go further to check whether the user is a dot or not.
-      mlir::Operation* userOp = *op->getUsers().begin();
+      // If there is only one user, we could go further to check whether the
+      // user is a dot or not.
+      mlir::Operation *userOp = *op->getUsers().begin();
       if (userOp) {
         auto child_dstType = getPotentialDotType(userOp);
         if (child_dstType) {
@@ -1167,9 +1171,11 @@ getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible) {
 
       // FIXME This may not be correct for multiple CTA, but getCTALayout is NYI
       // for LinearEncodingAttr
-      auto CTALayout = isa<ttg::LinearEncodingAttr, ttg::DotOperandEncodingAttr>(dstTy.getEncoding())
-                           ? ttg::getCTALayout(srcTy.getEncoding())
-                           : ttg::getCTALayout(dstTy.getEncoding());
+      auto CTALayout =
+          isa<ttg::LinearEncodingAttr, ttg::DotOperandEncodingAttr>(
+              dstTy.getEncoding())
+              ? ttg::getCTALayout(srcTy.getEncoding())
+              : ttg::getCTALayout(dstTy.getEncoding());
 
       if (auto dot =
               dyn_cast<ttg::DotOperandEncodingAttr>(dstTy.getEncoding())) {


### PR DESCRIPTION
## Background
Fix #5916

In this issue, it use a `reshape` and `trans` op before invoke a `dot`, these ops block the checking for `dot encoding` for `local_load` (triton only check the immediate user yet), therefore it will introduce much bank conflict if we didn't do swizzling in such a case, which hurts performance. 

Its IR looks like:

```
%77 = ttg.local_load %76 token %75 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : !ttg.memdesc<64x1x64xf16, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 2, 1]}>, #ttg.shared_memory, mutable, 2x64x1x64> -> tensor<64x1x64xf16, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
%78 = ttg.convert_layout %77 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<64x1x64xf16, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>> -> tensor<64x1x64xf16, #ttg.linear<{register = [[0, 0, 1], [8, 0, 0], [0, 0, 8], [0, 0, 16], [0, 0, 32], [32, 0, 0]], lane = [[0, 0, 2], [0, 0, 4], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[0, 0, 0], [0, 0, 0], [16, 0, 0]], block = []}>>
%79 = tt.reshape %67 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<1x64x64xf16, #ttg.linear<{register = [[0, 0, 1], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 32, 0]], lane = [[0, 0, 2], [0, 0, 4], [0, 1, 0], [0, 2, 0], [0, 4, 0]], warp = [[0, 8, 0], [0, 16, 0], [0, 0, 0]], block = []}>> -> tensor<64x64xf16, #ttg.linear<{register = [[0, 1], [0, 8], [0, 16], [0, 32], [32, 0]], lane = [[0, 2], [0, 4], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0], [0, 0]], block = []}>>
%80 = tt.trans %79 {loop.cluster = 0 : i32, loop.stage = 2 : i32, order = array<i32: 1, 0>} : tensor<64x64xf16, #ttg.linear<{register = [[0, 1], [0, 8], [0, 16], [0, 32], [32, 0]], lane = [[0, 2], [0, 4], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0], [0, 0]], block = []}>> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 1, parent = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>, kWidth = 2}>>
%81 = tt.reshape %78 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<64x1x64xf16, #ttg.linear<{register = [[0, 0, 1], [8, 0, 0], [0, 0, 8], [0, 0, 16], [0, 0, 32], [32, 0, 0]], lane = [[0, 0, 2], [0, 0, 4], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[0, 0, 0], [0, 0, 0], [16, 0, 0]], block = []}>> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>, kWidth = 2}>>
%82 = tt.dot %81, %80, %arg4, inputPrecision = tf32 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>, kWidth = 2}>> * tensor<64x64xf16, #ttg.dot_op<{opIdx = 1, parent = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>, kWidth = 2}>> -> tensor<64x64xf32, #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>>
```

<details>
<summary> Simple repro and whole IR </summary>
Code:

```
import torch
import triton
import triton.language as tl

aten = torch.ops.aten
empty_strided_cuda = torch._C._dynamo.guards._empty_strided_cuda


@triton.autotune(
    configs=[
        triton.Config({"XBLOCK": 64, "YBLOCK": 64, "R0_BLOCK": 64}, num_stages=3, num_warps=8),
    ],
    key=[],
)
@triton.jit
def triton_3d_mm(in_ptr0, in_ptr1, out_ptr0, YBLOCK: tl.constexpr, XBLOCK: tl.constexpr, R0_BLOCK: tl.constexpr):
    ynumel, xnumel, r0_numel = 2048, 2048, 2048
    RBLOCK: tl.constexpr = R0_BLOCK

    xoffset = tl.program_id(0) * XBLOCK
    yoffset = tl.program_id(1) * YBLOCK
    roffset = 0

    xindex = xoffset + tl.arange(0, XBLOCK)[:, None, None]
    yindex = yoffset + tl.arange(0, YBLOCK)[None, :, None]
    r0_base = roffset + tl.arange(0, RBLOCK)[None, None, :]

    _tmp5 = tl.full([XBLOCK, YBLOCK], 0, tl.float32)
    for r0_offset in range(0, r0_numel, R0_BLOCK):
        r0_index = r0_offset + r0_base

        tmp0 = tl.load(in_ptr0 + (r0_index + 2048 * yindex))  # (1,Y,R)
        tmp1 = tl.load(in_ptr1 + (xindex + 2048 * r0_index))  # (X,1,R)

        tmp0_ = tl.trans(tmp0.reshape([YBLOCK, RBLOCK]))  # (R,Y)
        tmp1_ = tmp1.reshape([XBLOCK, RBLOCK])  # (X,R)

        _tmp5 += tl.dot(tmp1_, tmp0_)  # (X,R) x (R,Y)

    _tmp5 = _tmp5[:,:,None] # (X,Y,1)
    tl.store(out_ptr0 + (xindex + 2048 * yindex), _tmp5.to(tl.float16))

is_First = True

def call3d(args):
    arg0_1, arg1_1 = args
    torch.cuda.set_device(0)
    buf0 = empty_strided_cuda((2048, 2048), (2048, 1), torch.float16)
    grid = lambda meta: (triton.cdiv(2048, meta["XBLOCK"]), triton.cdiv(2048, meta["YBLOCK"]))
    kernel = triton_3d_mm[grid](arg0_1, arg1_1, buf0)
    global is_First
    if is_First:
        # print(kernel.asm['ptx'])
        # print("\n=====================\n")
        # print(kernel.asm['sass'])
        is_First = False
    return buf0,


def benchmark_compiled_module(times=10, repeat=1):
    from torch._dynamo.testing import rand_strided
    from torch._inductor.utils import print_performance

    arg0_1 = rand_strided((2048, 2048), (2048, 1), device='cuda:0', dtype=torch.float16)
    arg1_1 = rand_strided((2048, 2048), (2048, 1), device='cuda:0', dtype=torch.float16)

    print("3D MM Time:")
    print_performance(lambda: call3d([arg0_1, arg1_1]), times=times, repeat=repeat)

if __name__ == "__main__":
    benchmark_compiled_module()
```

IR:
```
// -----// SoftwarePipeliner internal IR Dump After: LowerLoops
module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:86", "ttg.threads-per-warp" = 32 : i32} {
  tt.func public @triton_3d_mm(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
    %cst = arith.constant dense<2048> : tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %cst_0 = arith.constant dense<2048> : tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
    %cst_1 = arith.constant dense<2048> : tensor<1x1x64xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
    %c0_i32 = arith.constant 0 : i32
    %c2048_i32 = arith.constant 2048 : i32
    %c64_i32 = arith.constant 64 : i32
    %cst_2 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>>
    %0 = tt.get_program_id x : i32
    %1 = arith.muli %0, %c64_i32 : i32
    %2 = tt.get_program_id y : i32
    %3 = arith.muli %2, %c64_i32 : i32
    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>}>}>>
    %5 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>}>}>>
    %6 = tt.expand_dims %4 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>}>}>> -> tensor<64x1xi32, #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>}>>
    %7 = tt.expand_dims %5 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>}>}>> -> tensor<64x1xi32, #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>}>>
    %8 = tt.expand_dims %6 {axis = 2 : i32} : tensor<64x1xi32, #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>}>> -> tensor<64x1x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
    %9 = tt.expand_dims %7 {axis = 2 : i32} : tensor<64x1xi32, #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>}>> -> tensor<64x1x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %10 = tt.splat %1 : i32 -> tensor<64x1x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
    %11 = tt.splat %1 : i32 -> tensor<64x1x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %12 = arith.addi %10, %8 : tensor<64x1x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
    %13 = arith.addi %11, %9 : tensor<64x1x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %14 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>}>}>>
    %15 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>}>}>>
    %16 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>}>}>>
    %17 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>}>}>>
    %18 = tt.expand_dims %14 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>}>}>> -> tensor<1x64xi32, #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>}>>
    %19 = tt.expand_dims %15 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>}>}>> -> tensor<1x64xi32, #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>}>>
    %20 = tt.expand_dims %16 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>}>}>> -> tensor<1x64xi32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>}>>
    %21 = tt.expand_dims %17 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>}>}>> -> tensor<1x64xi32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>}>>
    %22 = tt.expand_dims %18 {axis = 2 : i32} : tensor<1x64xi32, #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>}>> -> tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
    %23 = tt.expand_dims %19 {axis = 2 : i32} : tensor<1x64xi32, #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>}>> -> tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %24 = tt.splat %3 : i32 -> tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
    %25 = tt.splat %3 : i32 -> tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %26 = arith.addi %24, %22 : tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
    %27 = arith.addi %25, %23 : tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %28 = tt.expand_dims %20 {axis = 1 : i32} : tensor<1x64xi32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>}>> -> tensor<1x1x64xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
    %29 = tt.expand_dims %21 {axis = 1 : i32} : tensor<1x64xi32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>}>> -> tensor<1x1x64xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
    %30 = arith.muli %26, %cst_0 : tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
    %31 = tt.broadcast %30 : tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>> -> tensor<1x64x64xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
    %32 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x64x64x!tt.ptr<f16>, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
    %33 = tt.broadcast %12 : tensor<64x1x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>> -> tensor<64x1x64xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
    %34 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<64x1x64x!tt.ptr<f16>, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
    %35 = ttg.local_alloc : () -> !ttg.memdesc<2x1x64x64xf16, #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [2, 1, 0]}>, #ttg.shared_memory, mutable>
    %36 = ttg.local_alloc : () -> !ttg.memdesc<2x64x1x64xf16, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 2, 1]}>, #ttg.shared_memory, mutable>
    %c-1_i32 = arith.constant -1 : i32
    %c0_i32_3 = arith.constant 0 : i32
    %c1_i32 = arith.constant 1 : i32
    %c0_i32_4 = arith.constant 0 : i32
    %c0_i32_5 = arith.constant 0 : i32
    %37:3 = scf.for %arg3 = %c0_i32 to %c2048_i32 step %c64_i32 iter_args(%arg4 = %cst_2, %arg5 = %c-1_i32, %arg6 = %c-1_i32) -> (tensor<64x64xf32, #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>>, i32, i32)  : i32 {
      %c2_i32 = arith.constant {loop.cluster = 2 : i32, loop.stage = 0 : i32} 2 : i32
      %48 = arith.addi %arg5, %c1_i32 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32
      %49 = arith.cmpi sge, %48, %c2_i32 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32
      %50 = arith.select %49, %c0_i32_3, %48 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32
      %51 = arith.addi %arg6, %c1_i32 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : i32
      %52 = arith.cmpi sge, %51, %c2_i32 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : i32
      %53 = arith.select %52, %c0_i32_3, %51 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : i32
      %54 = tt.splat %arg3 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32 -> tensor<1x1x64xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
      %55 = tt.splat %arg3 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32 -> tensor<1x1x64xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
      %56 = arith.addi %54, %28 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<1x1x64xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
      %57 = arith.addi %55, %29 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<1x1x64xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
      %58 = tt.broadcast %56 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<1x1x64xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>> -> tensor<1x64x64xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
      %59 = arith.addi %58, %31 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<1x64x64xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
      %60 = tt.addptr %32, %59 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<1x64x64x!tt.ptr<f16>, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>, tensor<1x64x64xi32, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
      %c0_i32_6 = arith.constant {loop.cluster = 2 : i32, loop.stage = 0 : i32} 0 : i32
      %61 = ttg.memdesc_subview %35[%50, %c0_i32_6, %c0_i32_6, %c0_i32_6] {loop.cluster = 2 : i32, loop.stage = 0 : i32} : !ttg.memdesc<2x1x64x64xf16, #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [2, 1, 0]}>, #ttg.shared_memory, mutable> -> !ttg.memdesc<1x64x64xf16, #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [2, 1, 0]}>, #ttg.shared_memory, mutable, 2x1x64x64>
      %62 = ttg.async_copy_global_to_local %60, %61 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<1x64x64x!tt.ptr<f16>, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>> -> <1x64x64xf16, #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [2, 1, 0]}>, #ttg.shared_memory, mutable, 2x1x64x64>
      %63 = ttg.async_commit_group %62 {loop.cluster = 2 : i32, loop.stage = 0 : i32}
      %64 = ttg.async_wait %63 {loop.cluster = 0 : i32, loop.stage = 2 : i32, num = 0 : i32}
      %c0_i32_7 = arith.constant {loop.cluster = 0 : i32, loop.stage = 2 : i32} 0 : i32
      %65 = ttg.memdesc_subview %35[%53, %c0_i32_7, %c0_i32_7, %c0_i32_7] {loop.cluster = 0 : i32, loop.stage = 2 : i32} : !ttg.memdesc<2x1x64x64xf16, #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [2, 1, 0]}>, #ttg.shared_memory, mutable> -> !ttg.memdesc<1x64x64xf16, #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [2, 1, 0]}>, #ttg.shared_memory, mutable, 2x1x64x64>
      %66 = ttg.local_load %65 token %64 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : !ttg.memdesc<1x64x64xf16, #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [2, 1, 0]}>, #ttg.shared_memory, mutable, 2x1x64x64> -> tensor<1x64x64xf16, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>>
      %67 = ttg.convert_layout %66 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<1x64x64xf16, #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 4, 8], warpsPerCTA = [1, 8, 1], order = [2, 1, 0]}>> -> tensor<1x64x64xf16, #ttg.linear<{register = [[0, 0, 1], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 32, 0]], lane = [[0, 0, 2], [0, 0, 4], [0, 1, 0], [0, 2, 0], [0, 4, 0]], warp = [[0, 8, 0], [0, 16, 0], [0, 0, 0]], block = []}>>
      %68 = arith.muli %57, %cst_1 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<1x1x64xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
      %69 = tt.broadcast %68 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<1x1x64xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>> -> tensor<64x1x64xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
      %70 = arith.addi %33, %69 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<64x1x64xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
      %71 = tt.addptr %34, %70 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<64x1x64x!tt.ptr<f16>, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>, tensor<64x1x64xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
      %c0_i32_8 = arith.constant {loop.cluster = 2 : i32, loop.stage = 0 : i32} 0 : i32
      %72 = ttg.memdesc_subview %36[%50, %c0_i32_8, %c0_i32_8, %c0_i32_8] {loop.cluster = 2 : i32, loop.stage = 0 : i32} : !ttg.memdesc<2x64x1x64xf16, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 2, 1]}>, #ttg.shared_memory, mutable> -> !ttg.memdesc<64x1x64xf16, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 2, 1]}>, #ttg.shared_memory, mutable, 2x64x1x64>
      %73 = ttg.async_copy_global_to_local %71, %72 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<64x1x64x!tt.ptr<f16>, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>> -> <64x1x64xf16, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 2, 1]}>, #ttg.shared_memory, mutable, 2x64x1x64>
      %74 = ttg.async_commit_group %73 {loop.cluster = 2 : i32, loop.stage = 0 : i32}
      %75 = ttg.async_wait %74 {loop.cluster = 0 : i32, loop.stage = 2 : i32, num = 0 : i32}
      %c0_i32_9 = arith.constant {loop.cluster = 0 : i32, loop.stage = 2 : i32} 0 : i32
      %76 = ttg.memdesc_subview %36[%53, %c0_i32_9, %c0_i32_9, %c0_i32_9] {loop.cluster = 0 : i32, loop.stage = 2 : i32} : !ttg.memdesc<2x64x1x64xf16, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 2, 1]}>, #ttg.shared_memory, mutable> -> !ttg.memdesc<64x1x64xf16, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 2, 1]}>, #ttg.shared_memory, mutable, 2x64x1x64>
      %77 = ttg.local_load %76 token %75 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : !ttg.memdesc<64x1x64xf16, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 2, 1]}>, #ttg.shared_memory, mutable, 2x64x1x64> -> tensor<64x1x64xf16, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>>
      %78 = ttg.convert_layout %77 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<64x1x64xf16, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 1, 4], warpsPerCTA = [1, 1, 8], order = [0, 2, 1]}>> -> tensor<64x1x64xf16, #ttg.linear<{register = [[0, 0, 1], [8, 0, 0], [0, 0, 8], [0, 0, 16], [0, 0, 32], [32, 0, 0]], lane = [[0, 0, 2], [0, 0, 4], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[0, 0, 0], [0, 0, 0], [16, 0, 0]], block = []}>>
      %79 = tt.reshape %67 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<1x64x64xf16, #ttg.linear<{register = [[0, 0, 1], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 32, 0]], lane = [[0, 0, 2], [0, 0, 4], [0, 1, 0], [0, 2, 0], [0, 4, 0]], warp = [[0, 8, 0], [0, 16, 0], [0, 0, 0]], block = []}>> -> tensor<64x64xf16, #ttg.linear<{register = [[0, 1], [0, 8], [0, 16], [0, 32], [32, 0]], lane = [[0, 2], [0, 4], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0], [0, 0]], block = []}>>
      %80 = tt.trans %79 {loop.cluster = 0 : i32, loop.stage = 2 : i32, order = array<i32: 1, 0>} : tensor<64x64xf16, #ttg.linear<{register = [[0, 1], [0, 8], [0, 16], [0, 32], [32, 0]], lane = [[0, 2], [0, 4], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0], [0, 0]], block = []}>> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 1, parent = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>, kWidth = 2}>>
      %81 = tt.reshape %78 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<64x1x64xf16, #ttg.linear<{register = [[0, 0, 1], [8, 0, 0], [0, 0, 8], [0, 0, 16], [0, 0, 32], [32, 0, 0]], lane = [[0, 0, 2], [0, 0, 4], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[0, 0, 0], [0, 0, 0], [16, 0, 0]], block = []}>> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>, kWidth = 2}>>
      %82 = tt.dot %81, %80, %arg4, inputPrecision = tf32 {loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>, kWidth = 2}>> * tensor<64x64xf16, #ttg.dot_op<{opIdx = 1, parent = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>, kWidth = 2}>> -> tensor<64x64xf32, #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>>
      scf.yield %82, %50, %53 : tensor<64x64xf32, #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>>, i32, i32
    } {tt.scheduled_max_stage = 2 : i32}
    %38 = ttg.async_wait  {num = 0 : i32}
    ttg.local_dealloc %36 : !ttg.memdesc<2x64x1x64xf16, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 2, 1]}>, #ttg.shared_memory, mutable>
    ttg.local_dealloc %35 : !ttg.memdesc<2x1x64x64xf16, #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [2, 1, 0]}>, #ttg.shared_memory, mutable>
    %39 = ttg.convert_layout %37#0 : tensor<64x64xf32, #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 4], instrShape = [16, 8]}>> -> tensor<64x64xf32, #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>}>>
    %40 = tt.expand_dims %39 {axis = 2 : i32} : tensor<64x64xf32, #ttg.slice<{dim = 2, parent = #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>}>> -> tensor<64x64x1xf32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %41 = arith.muli %27, %cst : tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %42 = tt.broadcast %13 : tensor<64x1x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>> -> tensor<64x64x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %43 = tt.broadcast %41 : tensor<1x64x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>> -> tensor<64x64x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %44 = arith.addi %42, %43 : tensor<64x64x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %45 = tt.splat %arg2 : !tt.ptr<f16> -> tensor<64x64x1x!tt.ptr<f16>, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %46 = tt.addptr %45, %44 : tensor<64x64x1x!tt.ptr<f16>, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>, tensor<64x64x1xi32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    %47 = arith.truncf %40 : tensor<64x64x1xf32, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>> to tensor<64x64x1xf16, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    tt.store %46, %47 : tensor<64x64x1x!tt.ptr<f16>, #ttg.blocked<{sizePerThread = [8, 1, 1], threadsPerWarp = [8, 4, 1], warpsPerCTA = [1, 8, 1], order = [0, 2, 1]}>>
    tt.return
  }
}
```
</details>

## What this PR do

This PR try to traversal a single user chain to check whether there is a `dot encoding` in this chain, which could help we fix the issue mentioned above.

## Performance
For the code in the reported issue, we could see **2x** perf gain.
Before:
```
3D MM Time:
0.000706
2D MM Time:
0.000331
```
After:
```
3D MM Time:
0.000338
2D MM Time:
0.000347
```


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `This PR is in RFC stage, will add test later`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
