### PR TITLE
[WIP][TMA] Fix lowering TMA load when 2 users of differing encodings

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1542,7 +1542,6 @@ void replaceUsesWithLocalLoad(OpBuilder &builder, OpResult old,
   for (Operation *user : old.getUsers()) {
     if (auto userAlloc = dyn_cast<ttg::LocalAllocOp>(user)) {
       if (allocTy.getEncoding() == userAlloc.getType().getEncoding()) {
-        replaceUsesAndPropagateType(builder, userAlloc, alloc);
         allocsToErase.push_back(userAlloc);
       }
     }
@@ -1557,8 +1556,9 @@ void replaceUsesWithLocalLoad(OpBuilder &builder, OpResult old,
         loc, old.getType(), alloc, token);
     old.replaceAllUsesWith(sharedLoad.getResult());
   }
-  for (auto alloc : allocsToErase) {
-    alloc.erase();
+  for (auto userAlloc : allocsToErase) {
+    replaceUsesAndPropagateType(builder, userAlloc, alloc);
+    userAlloc.erase();
   }
 }
 


### PR DESCRIPTION
Recently a user reported a crash during TMA lowering in a kernel which roughly looks like
```
    y = Y_desc.load([offset, 0])
    for d_offset in tl.range(0, D, BLOCK_D):
        x = X_desc.load([offset, d_offset])
        xt = tl.trans(x)
        acc = tl.dot(xt, y)
        out += tl.dot(x, tl.dot(xt, y).to(dtype))
```
The error shows up as
```
error: operand #0 does not dominate this use
        xt = tl.trans(x)
```
Here's a minimized version of the faulty ttgir:
```
      %36 = "ttg.local_alloc"()
     ...
      %39 = "ttg.local_alloc"(%48)
      %40 = "ttg.memdesc_trans"(%39) <{order = array<i32: 1, 0>}>
      ...
      %48 = "ttg.local_load"(%36)
      "scf.yield"(%47#0) : (tensor<64x64xf32, #mma1>) -> ()
```

---

WIP: Need to think twice about why the fix in this PR is the right fix. Putting up for now in case anyone wants to comment