### PR TITLE
[BACKEND] vectorise getSmemVecAddr

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -559,7 +559,8 @@ SmallVector<Value> getSmemVecAddrVec(
         if (auto paddedLayout =
                 dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(sharedEnc)) {
           // Apply the offset needed for padding.
-          Value padOffset = emitPadding(loc, rewriter, paddedLayout, smemOffset);
+          Value padOffset =
+              emitPadding(loc, rewriter, paddedLayout, smemOffset);
           smemOffset = b.add(smemOffset, padOffset);
         }
         smemOffsetsComputed.push_back(smemOffset);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -559,7 +559,7 @@ SmallVector<Value> getSmemVecAddrVec(
 
     SmallVector<std::pair<StringAttr, Value>> smemOffsetPairs;
     for (auto [attr, val] :
-        llvm::zip(invertAllocSharedLayout.getInDimNames(), smemOffsets)) {
+         llvm::zip(invertAllocSharedLayout.getInDimNames(), smemOffsets)) {
       smemOffsetPairs.emplace_back(attr, val);
     }
     Value smemOffsetsApplied =

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -534,7 +534,7 @@ Value getSmemVecAddr(const LinearLayout &regLayout,
                                            {kBlock, blockId}}));
     for (auto i = 0; i < rank; i++) {
       multiDimTensorOffsets[i].second =
-          b.add(multiDimTensorOffsets[i].second, smemOffsets[i]);
+          b.xor_(multiDimTensorOffsets[i].second, smemOffsets[i]);
     }
     smemOffset = applyLinearLayout(loc, rewriter, invertAllocSharedLayout,
                                    multiDimTensorOffsets)[0]

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -403,7 +403,7 @@ module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.n
     // CHECK-NEXT: %[[SHL1:.+]] = llvm.shl %[[SHR1]], %[[CST3]] : i32
     // CHECK-NEXT: %[[ADD1:.+]] = llvm.add %[[ADD0]], %[[SHL1]] : i32
     // CHECK-NEXT: %[[ADD2:.+]] = llvm.add %[[XOR]], %[[ADD1]] : i32
-    // CHECK-NEXT: llvm.getelementptr inbounds %{{.+}}[%[[ADD2]]]
+    // CHECK: llvm.getelementptr inbounds %{{.+}}[%[[ADD2]]]
 
     // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xf16>, !llvm.ptr<3>
     %0 = ttg.local_alloc %arg0 : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>


### PR DESCRIPTION
We make the following modifications to `getSmemVecAddr`:
 - replacing add with `_xor`;
 - hoisiting the `_xor` out of the `applyLinearLayout`;
 - fusing the two `applyLinearLayout`s together;
 - vectorising the whole `getSmemVecAddr` function.

The combination of these changes enables us to avoid calling `applyLinearLayout` inside a loop within the function `emitTransferBetweenRegistersAndShared` and hopefully get better IR that leads to superior runtime performance.