### PR TITLE
[FRONT END] Ignore float annotations

### DIFF
--- a/python/test/unit/language/test_annotations.py
+++ b/python/test/unit/language/test_annotations.py
@@ -49,3 +49,14 @@ def test_unknown_annotation(device):
         _kernel[(1, )](x.shape[0], x.shape[0], 32)
     except AttributeError:
         pass
+
+
+# Test that float annotations are ignored
+def test_float_annotation(device):
+
+    @triton.jit
+    def _kernel(X: tl.float16):
+        tl.device_assert(X.dtype == tl.float32)
+
+    x = 1.1
+    _kernel[(1, )](x)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -291,7 +291,9 @@ class KernelParam:
         elif a.startswith("*"):
             a = a[1:]
         if a in set(type_canonicalisation_dict.values()):
-            return self.annotation
+            # only support annotations for int and uint.
+            if a[:1] in ["i", "u"]:
+                return self.annotation
         return ""
 
     @cached_property


### PR DESCRIPTION
Return to the previous behavior of triton where float type annotations are ignored. This prevents generating wrong code when using tl.float other than 32. The problem originated from this PR: https://github.com/triton-lang/triton/pull/6152
