### PR TITLE
[NVIDIA] Update min_dot_sizes

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -396,9 +396,9 @@ def test_min_dot_size(dtype):
     error_msg = "Input shapes should have "
     if is_cuda():
         if dtype.primitive_bitwidth == 8:
-            error_msg += "M >= 16, N >= 16 and K >= 32"
+            error_msg += "M >= 16, N >= 8 and K >= 32"
         else:
-            error_msg = "M >= 16, N >= 16 and K >= 16"
+            error_msg = "M >= 16, N >= 8 and K >= 16"
     elif is_hip():
         # hip supports arbitrary sizes
         error_msg = None

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -23,9 +23,9 @@ def min_dot_size(target: GPUTarget):
         rhs_bitwidth = rhs_type.scalar.primitive_bitwidth
         assert lhs_bitwidth == rhs_bitwidth, "lhs and rhs bitwidth must be the same"
         if lhs_bitwidth == 8:
-            return (16, 16, 32)
+            return (16, 8, 32)
         else:
-            return (16, 16, 16)
+            return (16, 8, 16)
 
     return check_dot_compatibility
 


### PR DESCRIPTION
The original sizes (16 on N) are unnecessarily high 
