### PR TITLE
[WIP] Skip flaky `test_globaltimer` on gfx90a

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6003,8 +6003,9 @@ def test_num_threads(device):
     assert torch.sum(out) == 256
 
 
-@pytest.mark.parametrize('repeat_id', range(100))
-def test_globaltimer(device, repeat_id):
+def test_globaltimer(device):
+    if is_hip_cdna2():
+        pytest.skip("test_globaltimer is flaky on gfx90a")
     check_cuda_or_hip(device)
 
     @triton.jit

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6003,7 +6003,8 @@ def test_num_threads(device):
     assert torch.sum(out) == 256
 
 
-def test_globaltimer(device):
+@pytest.mark.parametrize('repeat_id', range(100))
+def test_globaltimer(device, repeat_id):
     check_cuda_or_hip(device)
 
     @triton.jit
@@ -6013,16 +6014,17 @@ def test_globaltimer(device):
         for i in range(10000):
             tl.store(Out1 + off, tl.load(Out1 + off) + 1)
         end = func()
-        tl.store(Out2, end - start)
+        tl.store(Out2, start)
+        tl.store(Out2 + 1, end)
 
     out1 = to_triton(np.zeros((128, ), dtype=np.int64), device=device)
-    out2 = to_triton(np.zeros((1, ), dtype=np.int64), device=device)
+    out2 = to_triton(np.zeros((2, ), dtype=np.int64), device=device)
     if is_cuda():
         func = tl.extra.cuda.globaltimer
     else:
         func = tl.extra.hip.memrealtime
     h = kernel[(1, )](out1, out2, func)
-    assert out2[0] > 0
+    assert out2[1] - out2[0] > 0
     if is_cuda():
         assert h.asm["ptx"].count("%globaltimer") == 2
     else:


### PR DESCRIPTION
Fix flaky `test_globaltimer ` on AMD introduced in #7282.

> FYI this may have added some flakiness to the CI - I have a failure here: https://github.com/triton-lang/triton/actions/runs/16141967476/job/45551308988?pr=6788 where rerunning it with no other changes resolved the issue. I also see that another submitted PR with unrelated changes has seen the same issue (https://github.com/triton-lang/triton/actions/runs/16139472771/job/45543368457) but runs after this are passing

_Originally posted by @vwbaker in https://github.com/triton-lang/triton/issues/7282#issuecomment-3048922698_
            

