### PR TITLE
[build] TRITON_LLVM_SYSTEM_SUFFIX to allow user-specified prebuilt llvm system

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,9 @@ def get_llvm_package_info():
         arch = {"x86_64": "x64", "arm64": "arm64", "aarch64": "arm64"}[platform.machine()]
     except KeyError:
         arch = platform.machine()
-    if system == "Darwin":
+    if (env_system_suffix := os.environ.get("TRITON_LLVM_SYSTEM_SUFFIX", None)):
+        system_suffix = env_system_suffix
+    elif system == "Darwin":
         system_suffix = f"macos-{arch}"
     elif system == "Linux":
         if arch == 'arm64' and is_linux_os('almalinux'):


### PR DESCRIPTION
On my machine, I have libc 2.34 (suggesting I can use ubuntu-x86), but glibcxx 3.4.29 (the llvm build on ubuntu 22.04 bakes in a dependency on GLIBCXX >= 3.4.30). This env variable (TRITON_LLVM_SYSTEM_SUFFIX) would allow a user to specify ubuntu-x86, centos-x86, almalinux-x86, etc. to specify one of the prebuilt LLVM packages.

See also: #7431, which tries to automatically identify the llvm package based on GLIBCXX versions.