### PR TITLE
[GLUON] Fix and test for an issue with default mbar predicates for MMAv5

### DIFF
--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -280,8 +280,7 @@ def tcgen05_mma(a, b, acc, *, use_acc=True, pred=True, mbarriers=None, mbarrier_
         mbarriers = [bar.handle for bar in mbarriers]
         if mbarrier_preds is None:
             true = _semantic.to_tensor(True)
-            mbarrier_preds = [true] * len(mbarriers)
-            mbarrier_preds = _semantic._convert_to_ir_values(mbarrier_preds, require_i64=False)
+            mbarrier_preds = [true.handle] * len(mbarriers)
         else:
             mbarrier_preds = _semantic._convert_to_ir_values(mbarrier_preds, require_i64=False)
 

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -281,6 +281,7 @@ def tcgen05_mma(a, b, acc, *, use_acc=True, pred=True, mbarriers=None, mbarrier_
         if mbarrier_preds is None:
             true = _semantic.to_tensor(True)
             mbarrier_preds = [true] * len(mbarriers)
+            mbarrier_preds = _semantic._convert_to_ir_values(mbarrier_preds, require_i64=False)
         else:
             mbarrier_preds = _semantic._convert_to_ir_values(mbarrier_preds, require_i64=False)
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1791,7 +1791,7 @@ class TritonSemantic(Generic[TensorTy]):
             if elem.dtype != tl.int64 and require_i64:
                 return self.builder.create_int_cast(elem.handle, self.builder.get_int64_ty(),
                                                     elem.dtype.is_int_signed())
-            elif elem.dtype == tl.int64 and not require_i64:
+            elif elem.dtype != tl.int32 and not require_i64:
                 assert False, "Block pointers only support 32 bit `offsets/block_shape`, " \
                     "add a `.to(tl.int32)` or use regular indexing for 64 bit support"
             return elem.handle

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1791,7 +1791,7 @@ class TritonSemantic(Generic[TensorTy]):
             if elem.dtype != tl.int64 and require_i64:
                 return self.builder.create_int_cast(elem.handle, self.builder.get_int64_ty(),
                                                     elem.dtype.is_int_signed())
-            elif elem.dtype != tl.int32 and not require_i64:
+            elif elem.dtype == tl.int64 and not require_i64:
                 assert False, "Block pointers only support 32 bit `offsets/block_shape`, " \
                     "add a `.to(tl.int32)` or use regular indexing for 64 bit support"
             return elem.handle


### PR DESCRIPTION
In case mbars are provided to `blackwell.tcgen05_mma` while predicates are missing we need to convert python bools to ir values.