### PR TITLE
Implemented a constants cache for TritonLLVMOpBuilder

### DIFF
--- a/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
+++ b/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
@@ -144,19 +144,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   tt.func public @buffer_load_to_local_cache_mods(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
                                 %arg2: !ttg.memdesc<64xf32, #shared, #smem, mutable>) {
     %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked>
-    // The first constant 0 skips the LDS offset which is also 0
+    // COMMON-DAG: %[[aux_ca:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // COMMON-DAG: %[[aux_cg:.*]] = llvm.mlir.constant(3 : i32) : i32
+    // COMMON-DAG: %[[aux_cv:.*]] = llvm.mlir.constant(17 : i32) : i32
     // COMMON: llvm.getelementptr
-    // COMMON: llvm.mlir.constant(0 : i32) : i32
-    // COMMON: llvm.mlir.constant(0 : i32) : i32
-    // COMMON: %[[aux_ca:.*]] = llvm.mlir.constant(0 : i32) : i32
     // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_ca]]
     %1 = amdgpu.buffer_load_to_local %arg0[%0] cacheModifier = ca into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     // COMMON: llvm.getelementptr
-    // COMMON: %[[aux_cg:.*]] = llvm.mlir.constant(3 : i32) : i32
     // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cg]]
     %2 = amdgpu.buffer_load_to_local %arg0[%0] cacheModifier = cg into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     // COMMON: llvm.getelementptr
-    // COMMON: %[[aux_cv:.*]] = llvm.mlir.constant(17 : i32) : i32
     // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cv]]
     %3 = amdgpu.buffer_load_to_local %arg0[%0] cacheModifier = cv into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
 

--- a/test/Conversion/amd/mfma-shortcut.mlir
+++ b/test/Conversion/amd/mfma-shortcut.mlir
@@ -37,17 +37,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   // GFX942-LABEL: mfma_dot_cvt_f8_mfma32
   tt.func public @mfma_dot_cvt_f8_mfma32(%arg0: tensor<128x32xf8E4M3FNUZ, #mfma>) {
+    // GFX942-DAG: [[c2:%.*]] = llvm.mlir.constant(2 : i32)
+    // GFX942-DAG: [[c3:%.*]] = llvm.mlir.constant(3 : i32)
+    // GFX942-DAG: [[c32:%.*]] = llvm.mlir.constant(32 : i32)
+    // GFX942-DAG: [[c64:%.*]] = llvm.mlir.constant(64 : i32)
+    // GFX942-DAG: [[c255:%.*]] = llvm.mlir.constant(255 : i32)
+
     // GFX942-NOT: store
     // GFX942-NOT: load
 
     // GFX942: [[val3:%.*]] = llvm.extractvalue %arg0[3]
     // GFX942: [[val7:%.*]] = llvm.extractvalue %arg0[7]
 
-    // GFX942-DAG: [[c32:%.*]] = llvm.mlir.constant(32 : i32)
-    // GFX942-DAG: [[c64:%.*]] = llvm.mlir.constant(64 : i32)
-
     // GFX942: [[threadId:%.*]] = rocdl.workitem.id.x
-    // GFX942: [[c255:%.*]] = llvm.mlir.constant(255 : i32)
     // GFX942: [[RTID:%.*]] = llvm.and [[threadId]], [[c255]]
     // GFX942: [[laneId:%.*]] = llvm.urem [[RTID]], [[c64]]
     // GFX942: [[mask0:%.*]] = llvm.icmp "slt" [[laneId]], [[c32]]
@@ -59,13 +61,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // GFX942: [[vec1:%.*]] = llvm.insertelement [[val7]], {{.*}} : vector<4xi8>
 
     // GFX942: [[bvec0:%.*]] = llvm.bitcast [[vec0]]
-    // GFX942: [[c2:%.*]] = llvm.mlir.constant(2 : i32)
+
     // GFX942: [[addr:%.*]] = llvm.shl [[addr32]], [[c2]]
     // GFX942: [[bShflVec0:%.*]] = rocdl.ds_bpermute [[addr]], [[bvec0]]
     // GFX942: [[shflVec0:%.*]] = llvm.bitcast [[bShflVec0]]
 
     // GFX942: [[bvec1:%.*]] = llvm.bitcast [[vec1]]
-    // GFX942: [[c2:%.*]] = llvm.mlir.constant(2 : i32)
     // GFX942: [[addr:%.*]] = llvm.shl [[addr32]], [[c2]]
     // GFX942: [[bShflVec1:%.*]] = rocdl.ds_bpermute [[addr]], [[bvec1]]
     // GFX942: [[shflVec1:%.*]] = llvm.bitcast [[bShflVec1]]
@@ -79,9 +80,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // GFX942: [[resVec0:%.*]] = llvm.select [[mask0]], [[vec0]], [[shflVec1]]
     // GFX942: [[resVec1:%.*]] = llvm.select [[mask0]], [[shflVec0]], [[vec1]]
 
-    // GFX942: [[c3:%.*]] = llvm.mlir.constant(3 : i32)
     // GFX942: [[resVal3:%.*]] = llvm.extractelement [[resVec0]][[[c3]] : i32] : vector<4xi8>
-    // GFX942: [[c3:%.*]] = llvm.mlir.constant(3 : i32) : i32
     // GFX942: [[resVal7:%.*]] = llvm.extractelement [[resVec1]][[[c3]] : i32] : vector<4xi8>
 
     // GFX942: llvm.insertvalue [[resVal3]], {{.*}}[3]
@@ -118,19 +117,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
   // GFX942-LABEL: mfma_dot_cvt_f8_mfma16
   tt.func public @mfma_dot_cvt_f8_mfma16(%arg0: tensor<128x32xf8E4M3FNUZ, #mfma>) {
+    // GFX942-DAG: [[c2:%.*]] = llvm.mlir.constant(2 : i32)
+    // GFX942-DAG: [[c3:%.*]] = llvm.mlir.constant(3 : i32)
+    // GFX942-DAG: [[c16:%.*]] = llvm.mlir.constant(16 : i32)
+    // GFX942-DAG: [[c32:%.*]] = llvm.mlir.constant(32 : i32)
+    // GFX942-DAG: [[c48:%.*]] = llvm.mlir.constant(48 : i32)
+    // GFX942-DAG: [[c64:%.*]] = llvm.mlir.constant(64 : i32)
+    // GFX942-DAG: [[c255:%.*]] = llvm.mlir.constant(255 : i32)
+
     // GFX942-NOT: store
     // GFX942-NOT: load
 
     // GFX942: [[val3:%.*]] = llvm.extractvalue %arg0[3]
     // GFX942: [[val7:%.*]] = llvm.extractvalue %arg0[7]
 
-    // GFX942-DAG: [[c16:%.*]] = llvm.mlir.constant(16 : i32)
-    // GFX942-DAG: [[c32:%.*]] = llvm.mlir.constant(32 : i32)
-    // GFX942-DAG: [[c48:%.*]] = llvm.mlir.constant(48 : i32)
-    // GFX942-DAG: [[c64:%.*]] = llvm.mlir.constant(64 : i32)
-
     // GFX942: [[threadId:%.*]] = rocdl.workitem.id.x
-    // GFX942: [[c255:%.*]] = llvm.mlir.constant(255 : i32)
     // GFX942: [[RTID:%.*]] = llvm.and [[threadId]], [[c255]]
     // GFX942: [[laneId:%.*]] = llvm.urem [[RTID]], [[c64]]
     // GFX942: [[mask0:%.*]] = llvm.icmp "slt" [[laneId]], [[c32]]
@@ -151,25 +152,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // GFX942: [[vec1:%.*]] = llvm.insertelement [[val7]], {{.*}} : vector<4xi8>
 
     // GFX942: [[bvec0:%.*]] = llvm.bitcast [[vec0]]
-    // GFX942: [[c2:%.*]] = llvm.mlir.constant(2 : i32)
     // GFX942: [[addr:%.*]] = llvm.shl [[addr16]], [[c2]]
     // GFX942: [[bShflVec0_16:%.*]] = rocdl.ds_bpermute [[addr]], [[bvec0]]
     // GFX942: [[shflVec0_16:%.*]] = llvm.bitcast [[bShflVec0_16]]
 
     // GFX942: [[bvec0:%.*]] = llvm.bitcast [[vec0]]
-    // GFX942: [[c2:%.*]] = llvm.mlir.constant(2 : i32)
     // GFX942: [[addr:%.*]] = llvm.shl [[addr32]], [[c2]]
     // GFX942: [[bShflVec0_32:%.*]] = rocdl.ds_bpermute [[addr]], [[bvec0]]
     // GFX942: [[shflVec0_32:%.*]] = llvm.bitcast [[bShflVec0_32]]
 
     // GFX942: [[bvec1:%.*]] = llvm.bitcast [[vec1]]
-    // GFX942: [[c2:%.*]] = llvm.mlir.constant(2 : i32)
     // GFX942: [[addr:%.*]] = llvm.shl [[addr32]], [[c2]]
     // GFX942: [[bShflVec1_32:%.*]] = rocdl.ds_bpermute [[addr]], [[bvec1]]
     // GFX942: [[shflVec1_32:%.*]] = llvm.bitcast [[bShflVec1_32]]
 
     // GFX942: [[bvec1:%.*]] = llvm.bitcast [[vec1]]
-    // GFX942: [[c2:%.*]] = llvm.mlir.constant(2 : i32)
     // GFX942: [[addr:%.*]] = llvm.shl [[addr48]], [[c2]]
     // GFX942: [[bShflVec1_48:%.*]] = rocdl.ds_bpermute [[addr]], [[bvec1]]
     // GFX942: [[shflVec1_48:%.*]] = llvm.bitcast [[bShflVec1_48]]
@@ -190,9 +187,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // GFX942-DAG: [[mask0_false:%.*]] = llvm.select [[mask1]], [[shflVec1_48]], [[vec1]] : i1, vector<4xi8>
     // GFX942: [[resVec1:%.*]] = llvm.select [[mask0]], [[mask0_true]], [[mask0_false]] : i1, vector<4xi8>
 
-    // GFX942: [[c3:%.*]] = llvm.mlir.constant(3 : i32)
     // GFX942: [[resVal3:%.*]] = llvm.extractelement [[resVec0]][[[c3]] : i32] : vector<4xi8>
-    // GFX942: [[c3:%.*]] = llvm.mlir.constant(3 : i32) : i32
     // GFX942: [[resVal7:%.*]] = llvm.extractelement [[resVec1]][[[c3]] : i32] : vector<4xi8>
 
     // GFX942: llvm.insertvalue [[resVal3]], {{.*}}[3]

--- a/test/Conversion/nvgpu_to_llvm.mlir
+++ b/test/Conversion/nvgpu_to_llvm.mlir
@@ -108,8 +108,8 @@ llvm.func @wgmma(%desc: i64, %in: !struct_64xf32) {
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 128 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tensor_memory_base_lowering
-  //      CHECK:    %[[TID:.+]] = nvvm.read.ptx.sreg.tid.x : i32
   //      CHECK:    %[[C32:.+]] = llvm.mlir.constant(32 : i32) : i32
+  //      CHECK:    %[[TID:.+]] = nvvm.read.ptx.sreg.tid.x : i32
   //      CHECK:    %[[PRED:.+]] = llvm.icmp "ult" %[[TID]], %[[C32]] : i32
   //      CHECK:    %[[SHMEM:.+]] = llvm.mlir.addressof @global_smem : !llvm.ptr<3>
   //      CHECK:    %[[A:.+]] = llvm.inline_asm has_side_effects
@@ -182,12 +182,12 @@ llvm.func @warpid_warp_specialize() {
   partition0() num_warps(4) {
     // 6*32 = 196
 
-    // CHECK: [[C32:%.*]] = llvm.mlir.constant(32 : i32)
-    // CHECK: [[C192:%.*]] = llvm.mlir.constant(192 : i32)
-    // CHECK: [[TIDX:%.*]] = nvvm.read.ptx.sreg.tid.x
-    // CHECK: [[REL_TIDX:%.*]] = llvm.sub [[TIDX]], [[C192]]
-    // CHECK: [[ID:%.*]] = llvm.udiv [[REL_TIDX]], [[C32]]
-    // CHECK: [[UNIFORM:%.*]] = nvvm.shfl.sync idx {{%[0-9]+}}, [[ID]]
+    // CHECK-DAG: [[C32:%.*]] = llvm.mlir.constant(32 : i32)
+    // CHECK-DAG: [[C192:%.*]] = llvm.mlir.constant(192 : i32)
+    //     CHECK: [[TIDX:%.*]] = nvvm.read.ptx.sreg.tid.x
+    //     CHECK: [[REL_TIDX:%.*]] = llvm.sub [[TIDX]], [[C192]]
+    //     CHECK: [[ID:%.*]] = llvm.udiv [[REL_TIDX]], [[C32]]
+    //     CHECK: [[UNIFORM:%.*]] = nvvm.shfl.sync idx {{%[0-9]+}}, [[ID]]
     %1 = nvgpu.warp_id
     // CHECK: "use"([[UNIFORM]])
     "use"(%1) : (i32) -> ()
@@ -196,12 +196,12 @@ llvm.func @warpid_warp_specialize() {
   partition1() num_warps(2) {
     // 4*32 = 128
 
-    // CHECK: [[C32:%.*]] = llvm.mlir.constant(32 : i32)
-    // CHECK: [[C128:%.*]] = llvm.mlir.constant(128 : i32)
-    // CHECK: [[TIDX:%.*]] = nvvm.read.ptx.sreg.tid.x
-    // CHECK: [[REL_TIDX:%.*]] = llvm.sub [[TIDX]], [[C128]]
-    // CHECK: [[ID:%.*]] = llvm.udiv [[REL_TIDX]], [[C32]]
-    // CHECK: [[UNIFORM:%.*]] = nvvm.shfl.sync idx {{%[0-9]+}}, [[ID]]
+    // CHECK-DAG: [[C32:%.*]] = llvm.mlir.constant(32 : i32)
+    // CHECK-DAG: [[C128:%.*]] = llvm.mlir.constant(128 : i32)
+    //     CHECK: [[TIDX:%.*]] = nvvm.read.ptx.sreg.tid.x
+    //     CHECK: [[REL_TIDX:%.*]] = llvm.sub [[TIDX]], [[C128]]
+    //     CHECK: [[ID:%.*]] = llvm.udiv [[REL_TIDX]], [[C32]]
+    //     CHECK: [[UNIFORM:%.*]] = nvvm.shfl.sync idx {{%[0-9]+}}, [[ID]]
     %1 = nvgpu.warp_id
     // CHECK: "use"([[UNIFORM]])
     "use"(%1) : (i32) -> ()

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -7,8 +7,8 @@
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: @tc_gen5_mma
-  // CHECK: %[[WID:.+]] = nvgpu.warp_id
   // CHECK: %[[C0:.+]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK: %[[WID:.+]] = nvgpu.warp_id
   // CHECK: %[[P0:.+]] = llvm.icmp "eq" %[[WID]], %[[C0]] : i32
   // CHECK: %[[P1:.+]] = llvm.and %{{.*}}, %[[P0]]  : i1
   // CHECK: llvm.cond_br %[[P1]]
@@ -199,16 +199,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale
+  // CHECK-DAG: %[[C0:.+]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK-DAG: %[[DESC0:.+]] = llvm.mlir.constant(144708608 : i32) : i32
+  // CHECK-DAG: %[[TRUE:.+]] = llvm.mlir.constant(true) : i1
+  // CHECK-DAG: %[[DESC1:.+]] = llvm.mlir.constant(681579536 : i32) : i32
+
   // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
   // CHECK: %[[WID:.+]] = nvgpu.warp_id
-  // CHECK: %[[C0:.+]] = llvm.mlir.constant(0 : i32) : i32
   // CHECK: %[[P0:.+]] = llvm.icmp "eq" %[[WID]], %[[C0]] : i32
   // CHECK: %[[P1:.+]] = llvm.and %{{.*}}, %[[P0]]  : i1
   // CHECK: llvm.cond_br %[[P1]]
-  // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(144708608 : i32) : i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]], %{{.+}}, %{{.+}}, %arg5
-  // CHECK: %[[TRUE:.+]] = llvm.mlir.constant(true) : i1
-  // CHECK: %[[DESC1:.+]] = llvm.mlir.constant(681579536 : i32) : i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC1]], %{{.+}}, %{{.+}}, %[[TRUE]]
   tt.func @tc_gen5_mma_block_scale(%a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<32x128xi8, #shared1, #ttg.shared_memory>,
@@ -239,13 +240,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_fp4_a
-  // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(144769664 : i32) : i32
+  // CHECK-DAG: %[[DESC0:.+]] = llvm.mlir.constant(144769664 : i32) : i32
+  // CHECK-DAG: %[[DESC1:.+]] = llvm.mlir.constant(681640592 : i32) : i32
+  // CHECK-DAG: %[[DESC2:.+]] = llvm.mlir.constant(1218511520 : i32) : i32
+  // CHECK-DAG: %[[DESC3:.+]] = llvm.mlir.constant(1755382448 : i32) : i32
+
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC0]]
-  // CHECK: %[[DESC1:.+]] = llvm.mlir.constant(681640592 : i32) : i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC1]]
-  // CHECK: %[[DESC2:.+]] = llvm.mlir.constant(1218511520 : i32) : i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC2]]
-  // CHECK: %[[DESC3:.+]] = llvm.mlir.constant(1755382448 : i32) : i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %{{.+}}, %{{.+}}, %{{.+}}, %[[DESC3]]
   tt.func @tc_gen5_mma_block_scale_fp4_a(%a: !ttg.memdesc<128x64xi8, #shared1, #ttg.shared_memory>,
                        %b: !ttg.memdesc<128x128xi8, #shared, #ttg.shared_memory>,
@@ -321,8 +323,8 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.thr
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_nvfp4
-  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
   // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(138413184 : i32) : i32
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
   tt.func @tc_gen5_mma_block_scale_nvfp4(%a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
@@ -354,10 +356,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_mxfp4
-  // CHECK-DAG: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
-  // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(146801792 : i32) : i32
+  // CHECK-DAG: %[[DESC0:.+]] = llvm.mlir.constant(146801792 : i32) : i32
+  // CHECK-DAG: %[[DESC1:.+]] = llvm.mlir.constant(1220543648 : i32) : i32
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %{{.*}} : !llvm.ptr<3> to i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
-  // CHECK: %[[DESC1:.+]] = llvm.mlir.constant(1220543648 : i32) : i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC1]]
   tt.func @tc_gen5_mma_block_scale_mxfp4(%a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<64x256xi8, #shared1, #ttg.shared_memory>,
@@ -671,8 +673,8 @@ tt.func @load_store_x1(%arg0: !ttg.memdesc<128x1xf32, #tmem_x1, #ttng.tensor_mem
 // CHECK-LABEL: @load_store_x1_unpacked
 tt.func @load_store_x1_unpacked(%arg0: !ttg.memdesc<128x2xf16, #tmem_x1_unpacked, #ttng.tensor_memory, mutable>) {
   %true = arith.constant true
-  // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
-  // CHECK: [[C1:%.*]] = llvm.mlir.constant(1 : i32)
+  // CHECK-DAG: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
+  // CHECK-DAG: [[C1:%.*]] = llvm.mlir.constant(1 : i32)
   // CHECK: [[V:%.*]] = llvm.inline_asm {{.*}}tcgen05.ld.sync{{.*}} (i32) -> i32
   // CHECK: [[F:%.*]] = llvm.bitcast [[V]] : i32 to vector<2xf16>
   // CHECK: extractelement [[F]][[[C0]] : i32]

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -27,10 +27,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: arrive_barrier
   tt.func @arrive_barrier(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>) {
-    // CHECK-NEXT: [[TID:%.*]] = nvvm.read.ptx.sreg.tid.x
-    // CHECK-NEXT: [[C127:%.*]] = llvm.mlir.constant(127 : i32)
+    // CHECK-DAG: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
+    // CHECK-DAG: [[C127:%.*]] = llvm.mlir.constant(127 : i32)
+
+    //      CHECK: [[TID:%.*]] = nvvm.read.ptx.sreg.tid.x
     // CHECK-NEXT: [[RTID:%.*]] = llvm.and [[TID]], [[C127]]
-    // CHECK-NEXT: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
     // CHECK-NEXT: [[IS_ZERO:%.*]] = llvm.icmp "eq" [[RTID]], [[C0]]
     // CHECK-NEXT: "@$0 mbarrier.arrive.shared::cta.b64 _, [$1], 2;", "b,r" [[IS_ZERO]], %arg0
     ttng.arrive_barrier %alloc, 2 : !ttg.memdesc<1xi64, #shared0, #smem>
@@ -39,10 +40,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: arrive_barrier_pred
   tt.func @arrive_barrier_pred(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
-    // CHECK-NEXT: [[TID:%.*]] = nvvm.read.ptx.sreg.tid.x
-    // CHECK-NEXT: [[C127:%.*]] = llvm.mlir.constant(127 : i32)
+    // CHECK-DAG: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
+    // CHECK-DAG: [[C127:%.*]] = llvm.mlir.constant(127 : i32)
+
+    //      CHECK: [[TID:%.*]] = nvvm.read.ptx.sreg.tid.x
     // CHECK-NEXT: [[RTID:%.*]] = llvm.and [[TID]], [[C127]]
-    // CHECK-NEXT: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
     // CHECK-NEXT: [[IS_ZERO:%.*]] = llvm.icmp "eq" [[RTID]], [[C0]]
     // CHECK-NEXT: [[PRED:%.*]] = llvm.and [[IS_ZERO]], %arg1
     // CHECK-NEXT: "@$0 mbarrier.arrive.shared::cta.b64 _, [$1], 2;", "b,r" [[PRED]], %arg0

--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -46,23 +46,26 @@ llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 :
 
 // CHECK-LABEL: @generate_switch_loop
 llvm.func @generate_switch_loop() attributes {allocation.offset = 32 : i32} {
-  // CHECK-NEXT: [[TIDX:%.*]] = nvvm.read.ptx.sreg.tid.x
-  // CHECK-NEXT: [[C32:%.*]] = llvm.mlir.constant(32 : i32)
+  // CHECK-DAG: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
+  // CHECK-DAG: [[C4:%.*]] = llvm.mlir.constant(4 : i32)
+  // CHECK-DAG: [[C31:%.*]] = llvm.mlir.constant(31 : i32)
+  // CHECK-DAG: [[C32:%.*]] = llvm.mlir.constant(32 : i32)
+  // CHECK-DAG: [[CNEG1:%.*]] = llvm.mlir.constant(-1 : i32)
+  // CHECK-DAG: [[B0:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-DAG: [[B1:%.*]] = llvm.mlir.constant(1 : i8)
+  // CHECK-DAG: [[B2:%.*]] = llvm.mlir.constant(2 : i8)
+  // CHECK-DAG: [[B3:%.*]] = llvm.mlir.constant(3 : i8)
+
+  //      CHECK: [[TIDX:%.*]] = nvvm.read.ptx.sreg.tid.x
   // CHECK-NEXT: [[WID:%.*]] = llvm.udiv [[TIDX]], [[C32]]
-  // CHECK-NEXT: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
-  // CHECK-NEXT: [[C31:%.*]] = llvm.mlir.constant(31 : i32)
-  // CHECK-NEXT: [[CNEG1:%.*]] = llvm.mlir.constant(-1 : i32)
   // CHECK-NEXT: [[WARP_ID:%.*]] = nvvm.shfl.sync idx [[CNEG1]], [[WID]], [[C0]], [[C31]]
-  // CHECK-NEXT: [[C4:%.*]] = llvm.mlir.constant(4 : i32)
   // CHECK-NEXT: [[IS_DEFAULT:%.*]] = llvm.icmp "ult" [[WARP_ID]], [[C4]]
   // CHECK-NEXT: llvm.cond_br [[IS_DEFAULT]], [[BODY:\^.*]], [[SWITCH_LOOP:\^.*]]
 
   // CHECK: [[SWITCH_LOOP]]:
   // CHECK-NEXT: "barrier.sync 1 ;"
-  // CHECK-NEXT: [[C32:%.*]] = llvm.mlir.constant(32 : i32)
   // CHECK-NEXT: [[SMEM_ADDR:%.*]] = llvm.mlir.addressof @global_smem
   // CHECK-NEXT: [[SMEM_BASE:%.*]] = llvm.getelementptr [[SMEM_ADDR]][[[C32]]] : (!llvm.ptr<3>, i32) -> !llvm.ptr<3>, i8
-  // CHECK-NEXT: [[C4:%.*]] = llvm.mlir.constant(4 : i32)
   // CHECK-NEXT: [[REL_WID:%.*]] = llvm.sub [[WARP_ID]], [[C4]]
 
   // CHECK-NEXT: [[STATE_PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][[[REL_WID]]]
@@ -101,33 +104,25 @@ llvm.func @generate_switch_loop() attributes {allocation.offset = 32 : i32} {
 
   // CHECK: [[BODY]]:
   // CHECK-NEXT: "before"
-  // CHECK-NEXT: [[C32:%.*]] = llvm.mlir.constant(32 : i32)
   // CHECK-NEXT: [[SMEM_ADDR:%.*]] = llvm.mlir.addressof @global_smem
   // CHECK-NEXT: [[SMEM_BASE:%.*]] = llvm.getelementptr [[SMEM_ADDR]][[[C32]]]
 
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][0]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-NEXT: llvm.store [[B0]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][1]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-NEXT: llvm.store [[B0]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][2]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-NEXT: llvm.store [[B0]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][3]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[B0]], [[PTR]]
 
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(1 : i8)
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][4]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(1 : i8)
+  // CHECK-NEXT: llvm.store [[B1]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][5]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[B1]], [[PTR]]
 
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(2 : i8)
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][6]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[B2]], [[PTR]]
 
   // CHECK: barrier.sync 1 ;
   // CHECK-NEXT: barrier.sync 1 ;
@@ -157,25 +152,23 @@ llvm.func @generate_switch_loop() attributes {allocation.offset = 32 : i32} {
   // CHECK: [[AFTER]]:
   // CHECK-NEXT: "after"
 
-  // CHECK-NEXT: [[C32:%.*]] = llvm.mlir.constant(32 : i32)
   // CHECK-NEXT: [[SMEM_ADDR:%.*]] = llvm.mlir.addressof @global_smem
   // CHECK-NEXT: [[SMEM_BASE:%.*]] = llvm.getelementptr [[SMEM_ADDR]][[[C32]]]
 
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(3 : i8)
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][0]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[B3]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][1]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[B3]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][2]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[B3]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][3]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[B3]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][4]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[B3]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][5]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[B3]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][6]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[B3]], [[PTR]]
   // CHECK-NEXT: barrier.sync 1 ;
   // CHECK-NEXT: llvm.return
   "after"() : () -> ()
@@ -192,6 +185,7 @@ llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 :
 
 // CHECK-LABEL: @pass_captures
 llvm.func @pass_captures() attributes {allocation.offset = 32 : i32} {
+  // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32)
   // CHECK: ^bb4:
   // CHECK-NEXT: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
   // CHECK-NEXT: [[SMEM_ADDR:%.*]] = llvm.mlir.addressof @global_smem
@@ -208,9 +202,8 @@ llvm.func @pass_captures() attributes {allocation.offset = 32 : i32} {
   // CHECK: ^bb5:
   // CHECK: [[INS:%.*]]:2 = "produce"()
   // CHECK: llvm.mlir.addressof @global_smem
-  // CHECK: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
-  // CHECK-NEXT: [[SMEM_ADDR:%.*]] = llvm.mlir.addressof @global_smem
-  // CHECK-NEXT: [[SMEM_BASE:%.*]] = llvm.getelementptr [[SMEM_ADDR]][[[C0]]]
+  // CHECK: [[SMEM_ADDR:%.*]] = llvm.mlir.addressof @global_smem
+  // CHECK-NEXT: [[SMEM_BASE:%.*]] = llvm.getelementptr [[SMEM_ADDR]][[[ZERO]]]
   // CHECK-NEXT: [[ARG0_PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][0, 0] : (!llvm.ptr<3>) -> !llvm.ptr<3>, !llvm.struct<packed (i32, i64)>
   // CHECK-NEXT: llvm.store [[INS]]#0, [[ARG0_PTR]] {alignment = 1 : i64}
   // CHECK-NEXT: [[ARG1_PTR:%.*]] = llvm.getelementptr [[SMEM_BASE]][0, 1] : (!llvm.ptr<3>) -> !llvm.ptr<3>, !llvm.struct<packed (i32, i64)>
@@ -239,6 +232,9 @@ llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 :
 
 // CHECK-LABEL: @partition_warpid_order
 llvm.func @partition_warpid_order() attributes {allocation.offset = 32 : i32} {
+  // CHECK-DAG: [[C0:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-DAG: [[C1:%.*]] = llvm.mlir.constant(1 : i8)
+  // CHECK-DAG: [[C2:%.*]] = llvm.mlir.constant(2 : i8)
   // CHECK: llvm.switch
   // CHECK-NEXT: 0: [[PARTITION0:\^.*]],
   // CHECK-NEXT: 1: [[PARTITION1:\^.*]],
@@ -255,50 +251,36 @@ llvm.func @partition_warpid_order() attributes {allocation.offset = 32 : i32} {
   // CHECK: llvm.mlir.addressof @global_smem
   // CHECK-NEXT: getelementptr
 
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(1 : i8)
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[0]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(1 : i8)
+  // CHECK-NEXT: llvm.store [[C1]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[1]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[C1]], [[PTR]]
 
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[2]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-NEXT: llvm.store [[C0]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[3]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-NEXT: llvm.store [[C0]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[4]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-NEXT: llvm.store [[C0]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[5]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[C0]], [[PTR]]
 
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(2 : i8)
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[6]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(2 : i8)
+  // CHECK-NEXT: llvm.store [[C2]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[7]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(2 : i8)
+  // CHECK-NEXT: llvm.store [[C2]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[8]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(2 : i8)
+  // CHECK-NEXT: llvm.store [[C2]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[9]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(2 : i8)
+  // CHECK-NEXT: llvm.store [[C2]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[10]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(2 : i8)
+  // CHECK-NEXT: llvm.store [[C2]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[11]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(2 : i8)
+  // CHECK-NEXT: llvm.store [[C2]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[12]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(2 : i8)
+  // CHECK-NEXT: llvm.store [[C2]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[13]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[C2]], [[PTR]]
   ttg.warp_specialize() attributes {allocation.offset = 0 : i32, warpGroupStartIds = array<i32: 6, 4, 10>}
   default {
     "ws0_default"() : () -> ()
@@ -329,6 +311,13 @@ llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 :
 
 // CHECK-LABEL: @multiple_specialize
 llvm.func @multiple_specialize() attributes {allocation.offset = 32 : i32} {
+  // CHECK-DAG: [[C0:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-DAG: [[C1:%.*]] = llvm.mlir.constant(1 : i8)
+  // CHECK-DAG: [[C2:%.*]] = llvm.mlir.constant(2 : i8)
+  // CHECK-DAG: [[C3:%.*]] = llvm.mlir.constant(3 : i8)
+  // CHECK-DAG: [[C4:%.*]] = llvm.mlir.constant(4 : i8)
+  // CHECK-DAG: [[C5:%.*]] = llvm.mlir.constant(5 : i8)
+  // CHECK-DAG: [[CNEG1:%.*]] = llvm.mlir.constant(-1 : i8)
   // CHECK: llvm.switch
   // CHECK-NEXT: 0: [[WS0_PARTITION0:\^.*]],
   // CHECK-NEXT: 1: [[WS0_PARTITION1:\^.*]],
@@ -353,30 +342,22 @@ llvm.func @multiple_specialize() attributes {allocation.offset = 32 : i32} {
 
   // CHECK: llvm.mlir.addressof @global_smem
   // CHECK-NEXT: getelementptr
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[0]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-NEXT: llvm.store [[C0]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[1]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-NEXT: llvm.store [[C0]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[2]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(0 : i8)
+  // CHECK-NEXT: llvm.store [[C0]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[3]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(1 : i8)
+  // CHECK-NEXT: llvm.store [[C0]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[4]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(1 : i8)
+  // CHECK-NEXT: llvm.store [[C1]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[5]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(2 : i8)
+  // CHECK-NEXT: llvm.store [[C1]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[6]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(-1 : i8)
+  // CHECK-NEXT: llvm.store [[C2]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[7]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[CNEG1]], [[PTR]]
   // CHECK: barrier.sync 1 ;
   // CHECK: "ws0_default"
   ttg.warp_specialize() attributes {allocation.offset = 0 : i32, warpGroupStartIds = array<i32: 4, 8, 10>}
@@ -399,30 +380,22 @@ llvm.func @multiple_specialize() attributes {allocation.offset = 32 : i32} {
 
   // CHECK: llvm.mlir.addressof @global_smem
   // CHECK-NEXT: getelementptr
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(4 : i8)
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[0]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(4 : i8)
+  // CHECK-NEXT: llvm.store [[C4]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[1]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(4 : i8)
+  // CHECK-NEXT: llvm.store [[C4]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[2]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(4 : i8)
+  // CHECK-NEXT: llvm.store [[C4]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[3]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(3 : i8)
+  // CHECK-NEXT: llvm.store [[C4]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[4]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(3 : i8)
+  // CHECK-NEXT: llvm.store [[C3]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[5]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(3 : i8)
+  // CHECK-NEXT: llvm.store [[C3]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[6]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(3 : i8)
+  // CHECK-NEXT: llvm.store [[C3]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[7]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[C3]], [[PTR]]
   // CHECK: barrier.sync 1 ;
   // CHECK: "ws1_default"
   ttg.warp_specialize() attributes {allocation.offset = 0 : i32, warpGroupStartIds = array<i32: 8, 4>}
@@ -441,30 +414,22 @@ llvm.func @multiple_specialize() attributes {allocation.offset = 32 : i32} {
 
   // CHECK: llvm.mlir.addressof @global_smem
   // CHECK-NEXT: getelementptr
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(-1 : i8)
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[0]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(-1 : i8)
+  // CHECK-NEXT: llvm.store [[CNEG1]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[1]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(-1 : i8)
+  // CHECK-NEXT: llvm.store [[CNEG1]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[2]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(-1 : i8)
+  // CHECK-NEXT: llvm.store [[CNEG1]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[3]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(-1 : i8)
+  // CHECK-NEXT: llvm.store [[CNEG1]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[4]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(-1 : i8)
+  // CHECK-NEXT: llvm.store [[CNEG1]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[5]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(-1 : i8)
+  // CHECK-NEXT: llvm.store [[CNEG1]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[6]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(-1 : i8)
+  // CHECK-NEXT: llvm.store [[CNEG1]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[7]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[CNEG1]], [[PTR]]
   // CHECK: barrier.sync 1 ;
   // CHECK: "ws2_default"
   ttg.warp_specialize() attributes {allocation.offset = 0 : i32, warpGroupStartIds = array<i32>}
@@ -475,30 +440,22 @@ llvm.func @multiple_specialize() attributes {allocation.offset = 32 : i32} {
 
   // CHECK: llvm.mlir.addressof @global_smem
   // CHECK-NEXT: getelementptr
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(5 : i8)
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[0]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(5 : i8)
+  // CHECK-NEXT: llvm.store [[C5]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[1]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(5 : i8)
+  // CHECK-NEXT: llvm.store [[C5]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[2]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(5 : i8)
+  // CHECK-NEXT: llvm.store [[C5]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[3]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(5 : i8)
+  // CHECK-NEXT: llvm.store [[C5]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[4]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(5 : i8)
+  // CHECK-NEXT: llvm.store [[C5]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[5]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(5 : i8)
+  // CHECK-NEXT: llvm.store [[C5]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[6]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
-  // CHECK-NEXT: [[CX:%.*]] = llvm.mlir.constant(5 : i8)
+  // CHECK-NEXT: llvm.store [[C5]], [[PTR]]
   // CHECK-NEXT: [[PTR:%.*]] = llvm.getelementptr %{{[0-9]+}}[7]
-  // CHECK-NEXT: llvm.store [[CX]], [[PTR]]
+  // CHECK-NEXT: llvm.store [[C5]], [[PTR]]
   // CHECK: barrier.sync 1 ;
   // CHECK: "ws3_default"
   ttg.warp_specialize() attributes {allocation.offset = 0 : i32, warpGroupStartIds = array<i32: 4>}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -24,6 +24,7 @@
 #include "triton/Analysis/Membar.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
@@ -83,6 +84,7 @@ struct ConvertTritonAMDGPUToLLVM
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
+    TritonLLVMOpBuilder::CacheGuard bcGuard;
 
     AMD::TargetInfo targetInfo(this->arch.getValue());
     if (targetInfo.getISAFamily() == AMD::ISAFamily::Unknown) {

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -787,6 +787,7 @@ public:
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
     RewritePatternSet patterns(context);
+    TritonLLVMOpBuilder::CacheGuard bcGuard;
 
 #define POPULATE_NVGPU_OP(SRC_OP, ASM)                                         \
   patterns.add<NVGPUOpGenericPattern<SRC_OP>>(context, ASM, Constraints(),     \

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -80,6 +80,7 @@ struct ConvertTritonGPUToLLVM
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
     TargetInfo targetInfo(computeCapability, ptxVersion);
+    TritonLLVMOpBuilder::CacheGuard bcGuard;
 
     // Allocate shared memory and set barrier
     ModuleAllocation allocation(mod);

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Analysis)
+add_subdirectory(Conversion)
 add_subdirectory(Dialect)
 add_subdirectory(Tools)

--- a/unittest/Conversion/CMakeLists.txt
+++ b/unittest/Conversion/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(TritonGPUToLLVM)

--- a/unittest/Conversion/TritonGPUToLLVM/CMakeLists.txt
+++ b/unittest/Conversion/TritonGPUToLLVM/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_triton_ut(
+  NAME TritonLLVMOpBuilderTest
+  SRCS TritonLLVMOpBuilderTest.cpp
+  LIBS
+    TritonGPUIR
+    TritonGPUTransforms
+    TritonNvidiaGPUTransforms
+)

--- a/unittest/Conversion/TritonGPUToLLVM/TritonLLVMOpBuilderTest.cpp
+++ b/unittest/Conversion/TritonGPUToLLVM/TritonLLVMOpBuilderTest.cpp
@@ -1,0 +1,212 @@
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/DebugStringHelper.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/Passes.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include <chrono>
+#include <gtest/gtest.h>
+#include <iostream>
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+
+class TritonLLVMOpBuilderTest : public ::testing::Test {
+protected:
+  MLIRContext ctx;
+  void SetUp() override {
+    ctx.getOrLoadDialect<mlir::LLVM::LLVMDialect>();
+    ctx.getOrLoadDialect<mlir::triton::TritonDialect>();
+  }
+};
+
+TEST_F(TritonLLVMOpBuilderTest, testCache) {
+  OpBuilder builder(&ctx);
+  auto loc = builder.getUnknownLoc();
+  auto module = ModuleOp::create(loc);
+  auto func = builder.create<mlir::triton::FuncOp>(
+      loc, "test", builder.getFunctionType({}, {}));
+  auto block = func.addEntryBlock();
+  auto build = [&builder]() {
+    TritonLLVMOpBuilder ttb(builder.getUnknownLoc(), builder);
+    ttb.i32_val(0);
+    ttb.i32_val(0);
+    ttb.i32_val(1);
+    ttb.i32_val(2);
+    SmallVector<Attribute, 16> values;
+    for (double v : {0., 0.5, 1., 1.5, 2., 3., 4., 6., -0., -0.5, -1., -1.5,
+                     -2., -3., -4., -6.})
+      values.push_back(builder.getFloatAttr(builder.getBF16Type(), v));
+    ttb.dense_val(VectorType::get({16}, builder.getBF16Type()), values);
+    ttb.dense_val(VectorType::get({16}, builder.getBF16Type()), values);
+  };
+  auto check = [&](bool empty = false) {
+    ASSERT_TRUE(mlir::verify(module).succeeded());
+
+    if (empty) {
+      ASSERT_TRUE(
+          isa<mlir::triton::ReturnOp>(*func.getBody().getOps().begin()));
+      return;
+    }
+
+    unsigned counter = 0;
+    for (auto &op : func.getBody().getOps()) {
+      if (auto c = dyn_cast<LLVM::ConstantOp>(op)) {
+        if (c.getType() == builder.getIntegerType(32)) {
+          auto v = dyn_cast<IntegerAttr>(c.getValueAttr()).getInt();
+          if (v >= 0 && v <= 2) {
+            ++counter;
+            continue;
+          }
+        } else if (auto vecType = dyn_cast<VectorType>(c.getType())) {
+          if (vecType.getElementType() == builder.getBF16Type() &&
+              vecType.getNumElements() == 16) {
+            ++counter;
+            continue;
+          }
+        }
+      } else if (isa<mlir::triton::ReturnOp>(op)) {
+        ++counter;
+        continue;
+      }
+
+      op.dump();
+      FAIL() << "Unexpected operation!";
+    }
+    ASSERT_EQ(counter, 5) << "Unexpected number of operations!"
+                          << " Expected 5, actual " << counter;
+  };
+
+  module.push_back(func);
+  builder.setInsertionPointToEnd(block);
+  builder.create<mlir::triton::ReturnOp>(loc);
+  builder.setInsertionPointToStart(block);
+
+  build();
+  check();
+
+  mlir::PassManager pm(&ctx);
+  pm.addPass(mlir::createCanonicalizerPass());
+  ASSERT_TRUE(pm.run(module).succeeded());
+  // Check if the constants has been removed by the canonicalizer
+  check(true);
+
+  build();
+  check();
+}
+
+// Fill vectors with constants and print timings
+TEST_F(TritonLLVMOpBuilderTest, testFillPerf) {
+  GTEST_SKIP();
+  OpBuilder builder(&ctx);
+  auto loc = builder.getUnknownLoc();
+  mlir::PassManager pm(&ctx);
+  pm.addPass(mlir::createCanonicalizerPass());
+  auto module = ModuleOp::create(loc);
+
+  unsigned size = 1024;
+  auto i32Type = builder.getIntegerType(32);
+  auto ptrType = LLVM::LLVMPointerType::get(&ctx);
+  auto intVecType = VectorType::get(size, i32Type);
+  auto ptrVecType = VectorType::get(size, ptrType);
+  auto func = builder.create<mlir::triton::FuncOp>(
+      loc, "test", builder.getFunctionType({ptrVecType}, {}));
+  module.push_back(func);
+  builder.setInsertionPointToStart(func.addEntryBlock());
+  auto ptrVec = func.getArgument(0);
+
+  TritonLLVMOpBuilder ttb(loc, builder);
+  auto start = std::chrono::high_resolution_clock::now();
+  for (int row = 0; row < 1024; ++row) {
+    Value vec = ttb.undef(intVecType);
+    for (int col = 0; col < 1024; ++col) {
+      vec = ttb.insert_element(vec, ttb.i32_val(col), ttb.i32_val(col));
+    }
+    Value ptr = ttb.extract_element(ptrVec, ttb.i32_val(row));
+    ttb.store(vec, ptr);
+  }
+  std::chrono::duration<double> time =
+      std::chrono::high_resolution_clock::now() - start;
+  std::cout << "Fill| Insertion time: " << time.count() << std::endl;
+
+  builder.create<mlir::triton::ReturnOp>(loc);
+  ASSERT_TRUE(mlir::verify(module).succeeded());
+  unsigned counter = 0;
+  for (auto &op : func.getBody().getOps()) {
+    if (auto c = dyn_cast<LLVM::ConstantOp>(op)) {
+      ASSERT_EQ(c.getType(), i32Type) << "Unexpected constant type";
+      ASSERT_GE(dyn_cast<IntegerAttr>(c.getValueAttr()).getInt(), 0);
+      ASSERT_LT(dyn_cast<IntegerAttr>(c.getValueAttr()).getInt(), size);
+      counter++;
+    }
+  }
+  ASSERT_EQ(counter, size);
+
+  start = std::chrono::high_resolution_clock::now();
+  ASSERT_TRUE(pm.run(module).succeeded());
+  time = std::chrono::high_resolution_clock::now() - start;
+  std::cout << "Fill| Canonicalizer time: " << time.count() << std::endl;
+  ASSERT_TRUE(mlir::verify(module).succeeded());
+}
+
+// Simillar to the above, but only creates the constants
+TEST_F(TritonLLVMOpBuilderTest, testCreatePerf) {
+  GTEST_SKIP();
+  OpBuilder builder(&ctx);
+  auto loc = builder.getUnknownLoc();
+  mlir::PassManager pm(&ctx);
+  pm.addPass(mlir::createCanonicalizerPass());
+  auto module = ModuleOp::create(loc);
+
+  unsigned size = 1024;
+  auto i32Type = builder.getIntegerType(32);
+  auto func = builder.create<mlir::triton::FuncOp>(
+      loc, "test", builder.getFunctionType({}, {}));
+  module.push_back(func);
+  builder.setInsertionPointToStart(func.addEntryBlock());
+
+  TritonLLVMOpBuilder ttb(loc, builder);
+  auto start = std::chrono::high_resolution_clock::now();
+  for (int row = 0; row < 1024; ++row) {
+    for (int col = 0; col < 1024; ++col) {
+      ttb.i32_val(col);
+      ttb.i32_val(col);
+    }
+    ttb.i32_val(row);
+  }
+  std::chrono::duration<double> time =
+      std::chrono::high_resolution_clock::now() - start;
+  std::cout << "Create| Insertion time: " << time.count() << std::endl;
+
+  builder.create<mlir::triton::ReturnOp>(loc);
+  ASSERT_TRUE(mlir::verify(module).succeeded());
+  unsigned counter = 0;
+  for (auto &op : func.getBody().getOps()) {
+    if (auto c = dyn_cast<LLVM::ConstantOp>(op)) {
+      ASSERT_EQ(c.getType(), i32Type) << "Unexpected constant type";
+      ASSERT_GE(dyn_cast<IntegerAttr>(c.getValueAttr()).getInt(), 0);
+      ASSERT_LT(dyn_cast<IntegerAttr>(c.getValueAttr()).getInt(), size);
+      counter++;
+    }
+  }
+  ASSERT_EQ(counter, size);
+
+  start = std::chrono::high_resolution_clock::now();
+  ASSERT_TRUE(pm.run(module).succeeded());
+  time = std::chrono::high_resolution_clock::now() - start;
+  std::cout << "Create| Canonicalizer time: " << time.count() << std::endl;
+  ASSERT_TRUE(isa<mlir::triton::ReturnOp>(*func.getBody().getOps().begin()));
+}
+} // namespace


### PR DESCRIPTION
The constants are created in the beginning of the entry block of a top-level isolated operation and then reused, that allows to avoid duplications. It makes IRs a bit more readable and the canonicalizer a bit faster.

The main motivation of implementing this feature is to make the intermediate IRs a bit more readable, when debugging. On the release builds, it also makes the constants creation and especially cleanup a bit faster. There are 2 pref tests, that measure times of constants creation and the canonicalizer pass. The first one creates a lot of unused constants, that are removed by canonicalizer. The second one is a bit more realistic - it not only creates the constants, but inserts them into vectors.
Here are the results:
```
Without cache:
Create| Insertion time: 0.378667
Create| Canonicalizer time: 0.341482
Fill| Insertion time: 0.648058
Fill| Canonicalizer time: 1.23455

With cache:
Create| Insertion time: 0.178808
Create| Canonicalizer time: 0.000576043
Fill| Insertion time: 0.385093
Fill| Canonicalizer time: 0.639965
```