### PR TITLE
[FRONTEND] Fix floating points argument passing 

### DIFF
--- a/python/test/unit/language/test_annotations.py
+++ b/python/test/unit/language/test_annotations.py
@@ -3,6 +3,7 @@ import torch
 import triton
 import triton.language as tl
 import pytest
+import numpy as np
 
 
 def annotated_function(return_type=None, **arg_types):
@@ -49,3 +50,22 @@ def test_unknown_annotation(device):
         _kernel[(1, )](x.shape[0], x.shape[0], 32)
     except AttributeError:
         pass
+
+
+# Test float annotations are properly respected
+@pytest.mark.parametrize(
+    ("dtype", "test_val"),
+    [(dtype, test_val)
+     for dtype in [tl.float16, tl.bfloat16, tl.float32, tl.float64]
+     for test_val in [0.0, 42.0, float("inf"), float("nan")]],
+)
+def test_float_annotation(device, dtype, test_val):
+
+    @triton.jit
+    @annotated_function(val=dtype)
+    def _kernel(ptr, val):
+        tl.store(ptr, val)
+
+    ptr = torch.empty(1, device=device)
+    _kernel[(1, )](ptr, test_val)
+    np.testing.assert_allclose(ptr.cpu().numpy(), [test_val], atol=1e-6)

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -163,13 +163,28 @@ def ty_to_cpp(ty):
         "u16": "uint16_t",
         "u32": "uint32_t",
         "u64": "uint64_t",
-        "fp16": "float",
-        "bf16": "float",
-        "fp32": "float",
-        "f32": "float",
+        "fp16": "double",
+        "bf16": "double",
+        "fp32": "double",
+        "f32": "double",
         "fp64": "double",
     }[ty]
 
+
+FLOAT_STORAGE_TYPE = {
+    "fp16": "uint16_t",
+    "bf16": "uint16_t",
+    "fp32": "uint32_t",
+    "f32": "uint32_t",
+    "fp64": "uint64_t",
+}
+FLOAT_PACK_FUNCTION = {
+    "fp16": "PyFloat_Pack2",
+    "bf16": "PyFloat_Pack2",
+    "fp32": "PyFloat_Pack4",
+    "f32": "PyFloat_Pack4",
+    "fp64": "PyFloat_Pack8",
+}
 
 _BASE_ARGS_FORMAT = "piiiKKOOOO"
 
@@ -226,7 +241,6 @@ def make_launcher(constants, signature, warp_size):
         if ty == "constexpr":
             return "O"
         return {
-            "float": "f",
             "double": "d",
             "long": "l",
             "int8_t": "b",
@@ -249,13 +263,30 @@ def make_launcher(constants, signature, warp_size):
     args_list = ', ' + ', '.join(f"&_arg{i}" for i, ty in signature.items()) if len(signature) > 0 else ''
     # Record the end of regular arguments;
     # subsequent arguments are architecture-specific descriptors, such as tensor descriptors for CUDA.
-    arg_decls = ', '.join(f"{ty_to_cpp(ty)} arg{i}" for i, ty in signature.items() if ty != "constexpr")
+    arg_decl_list = []
+    for i, ty in signature.items():
+        if ty == "constexpr":
+            continue
+        if ty in FLOAT_STORAGE_TYPE:
+            arg_decl_list.append(f"{FLOAT_STORAGE_TYPE[ty]} arg{i}")
+        else:
+            arg_decl_list.append(f"{ty_to_cpp(ty)} arg{i}")
+    arg_decls = ', '.join(arg_decl_list)
     internal_args_list = []
     for i, ty in signature.items():
         if ty[0] == "*":
             internal_args_list.append(f"ptr_info{i}.dev_ptr")
+        elif ty in FLOAT_STORAGE_TYPE:
+            internal_args_list.append(f"_arg{i}_storage")
         elif ty != "constexpr":
             internal_args_list.append(f"_arg{i}")
+
+    pack_floats = ""
+    for i, ty in signature.items():
+        if ty in FLOAT_STORAGE_TYPE:
+            pack_floats += f"{FLOAT_STORAGE_TYPE[ty]} _arg{i}_storage = 0;\n"
+            pack_floats += f"{FLOAT_PACK_FUNCTION[ty]}(_arg{i}, (void*)&_arg{i}_storage, 1);\n"
+
     libhip_path = _get_path_to_hip_runtime_dylib()
 
     # generate glue code
@@ -309,9 +340,6 @@ static struct HIPSymbolTable hipSymbolTable;
 bool initSymbolTable() {{
   // Use the HIP runtime library loaded into the existing process if it exits.
   void *lib = dlopen("libamdhip64.so", RTLD_NOLOAD);
-  if (lib) {{
-    // printf("[triton] chosen loaded libamdhip64.so in the process\\n");
-  }}
 
   // Otherwise, go through the list of search paths to dlopen the first HIP
   // driver library.
@@ -321,7 +349,6 @@ bool initSymbolTable() {{
       void *handle = dlopen(hipLibSearchPaths[i], RTLD_LAZY | RTLD_LOCAL);
       if (handle) {{
         lib = handle;
-        // printf("[triton] chosen %s\\n", hipLibSearchPaths[i]);
       }}
     }}
   }}
@@ -382,7 +409,6 @@ static inline void gpuAssert(hipError_t code, const char *file, int line)
 #define HIP_CHECK(ans) {{ gpuAssert((ans), __FILE__, __LINE__); }}
 
 static void _launch(int gridX, int gridY, int gridZ, int num_warps, int num_ctas, int launch_cooperative_grid, int clusterDimX, int clusterDimY, int clusterDimZ, int shared_memory, hipStream_t stream, hipFunction_t function{', ' + arg_decls if len(arg_decls) > 0 else ''}) {{
-  // printf("_launch hip kernel\\n");
   hipDeviceptr_t global_scratch = 0;
   void *params[] = {{ {', '.join(params)} }};
   if (gridX*gridY*gridZ > 0 && launch_cooperative_grid) {{
@@ -441,7 +467,6 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
 }}
 
 static PyObject* launch(PyObject* self, PyObject* args) {{
-   // printf("launch\\n");
   int gridX, gridY, gridZ;
   uint64_t _stream;
   uint64_t _function;
@@ -457,6 +482,8 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
                                            &launch_enter_hook, &launch_exit_hook {args_list})) {{
     return NULL;
   }}
+
+  {pack_floats}
 
   // extract kernel metadata
   int num_warps, num_ctas, shared_memory, clusterDimX, clusterDimY, clusterDimZ;

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -180,7 +180,7 @@ FLOAT_STORAGE_TYPE = {
 }
 FLOAT_PACK_FUNCTION = {
     "fp16": "PyFloat_Pack2",
-    "bf16": "PyFloat_Pack2",
+    "bf16": "PyFloat_Pack_BF16",
     "fp32": "PyFloat_Pack4",
     "f32": "PyFloat_Pack4",
     "fp64": "PyFloat_Pack8",
@@ -464,6 +464,14 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
   }}
   PyErr_SetString(PyExc_TypeError, "Pointer argument must be either uint64 or have data_ptr method");
   return ptr_info;
+}}
+
+static int PyFloat_Pack_BF16(double f, uint16_t *p, int) {{
+    float f32 = (float)f;
+    uint32_t u32 = *(uint32_t *)&f32;
+    uint16_t u16 = (uint16_t)(u32 >> 16);
+    *p = u16;
+    return 0;
 }}
 
 static PyObject* launch(PyObject* self, PyObject* args) {{

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -509,7 +509,7 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
     return NULL;
   }}
 
-  {'\n'.join(float_storage_decls)}
+  {' '.join(float_storage_decls)}
 
   // extract kernel metadata
   int num_warps, num_ctas, shared_memory, clusterDimX, clusterDimY, clusterDimZ;

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -111,11 +111,11 @@ FLOAT_STORAGE_TYPE = {
     "fp64": "uint64_t",
 }
 FLOAT_PACK_FUNCTION = {
-    "fp16": "PyFloat_Pack2",
-    "bf16": "PyFloat_Pack_BF16",
-    "fp32": "PyFloat_Pack4",
-    "f32": "PyFloat_Pack4",
-    "fp64": "PyFloat_Pack8",
+    "fp16": "pack_fp16",
+    "bf16": "pack_bf16",
+    "fp32": "pack_fp32",
+    "f32": "pack_fp32",
+    "fp64": "pack_fp64",
 }
 
 _BASE_ARGS_FORMAT = "iiiKKppOOOOO"
@@ -249,8 +249,7 @@ def make_launcher(constants, signature, tensordesc_meta):
         if ty == "nvTmaDesc"
     ]
     float_storage_decls = [
-        f"{FLOAT_STORAGE_TYPE[ty]} _arg{i}_storage = 0;"
-        f"{FLOAT_PACK_FUNCTION[ty]}(_arg{i}, (void*)&_arg{i}_storage, 1);"
+        f"{FLOAT_STORAGE_TYPE[ty]} _arg{i}_storage = {FLOAT_PACK_FUNCTION[ty]}(_arg{i});"
         for i, ty in signature.items()
         if ty in FLOAT_STORAGE_TYPE
     ]
@@ -472,12 +471,30 @@ static void ensureCudaContext() {{
   }}
 }}
 
-static int PyFloat_Pack_BF16(double f, uint16_t *p, int) {{
+static uint16_t pack_fp16(double f) {{
+    uint16_t result;
+    // from https://github.com/python/pythoncapi-compat
+#if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 && !defined(PYPY_VERSION)
+    _PyFloat_Pack2(f, (void*)&result, 1);
+#else
+    PyFloat_Pack2(f, (void*)&result, 1);
+#endif
+    return result;
+}}
+
+static uint16_t pack_bf16(double f) {{
     float f32 = (float)f;
-    uint32_t u32 = *(uint32_t *)&f32;
-    uint16_t u16 = (uint16_t)(u32 >> 16);
-    *p = u16;
-    return 0;
+    uint32_t u32 = *(uint32_t*)&f32;
+    return (uint16_t)(u32 >> 16);
+}}
+
+static uint32_t pack_fp32(double f) {{
+    float f32 = (float)f;
+    return *(uint32_t*)&f32;
+}}
+
+static uint64_t pack_fp64(double f) {{
+    return *(uint64_t*)&f;
 }}
 
 static PyObject* launch(PyObject* self, PyObject* args) {{


### PR DESCRIPTION
Fix #6176

```python
@triton.jit
def kernel(ptr, val: tl.float16):
    tl.store(ptr, val)

ptr = torch.tensor([0.0], device="cuda:0")
kernel[1,](ptr, 42.0)
print(ptr)  
# Expected: tensor([42.], device='cuda:0')
# Actual:   tensor([0.], device='cuda:0')
```

The issue is caused by naively passing a Python float to a Triton kernel that accepts `tl.float16`

Before this PR, the conversion chain for the float input looks like the following: 

```
         PyArg_ParseTuple             incorrectly passed to
PyFloat ================> float      ----------!!!----------> kernel that accepts tl.float16  
```

This PR always makes `PyArg_ParseTuple` to parse Python float to C double, and then calls [`PyFloat_Pack{2,4,8}`](https://docs.python.org/3/c-api/float.html#pack-functions) to convert it to its proper storage type. 

```
          PyArg_ParseTuple          PyFloat_Pack{2,4,8}                        passed to 
PyFloat ==================> double ====================>  uint{16,32,64}_t  -------------> kernel that accepts tl.float{16,32,64}
```

The generated code snippet looks something like this (for AMD backend)

```c
double _arg1;
PyArg_ParseTuple(args, "piiiKKOOOOOd", ..., &_arg1);
uint16_t _arg1_storage = 0;
PyFloat_Pack2(_arg1, (void*)&_arg1_storage, 1);
_launch(gridX, gridY, gridZ, ..., _arg1_storage);
```

- [x] Fix AMD backend
- [x] Fix NVIDIA backend
- [x] Add tests