### PR TITLE
[ANALYSIS] Fix the divisibility of rem op with pessimistic analysis

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -487,11 +487,6 @@ private:
       // lhs = gcd(d_lhs, d_rhs) * k'' = gcd(d_lhs, d_rhs) * d + r
       // r must be divisible by gcd(d_lhs, d_rhs)
       return gcd(lhs.getDivisibility(dim), rhs.getDivisibility(dim));
-    } else if (resTy &&
-               AxisInfoVisitor::isConstantDim(lhs, resTy.getShape(), dim) &&
-               lhs.getConstantValue().has_value() &&
-               lhs.getConstantValue().value() < rhs.getDivisibility(dim)) {
-      return lhs.getDivisibility(dim);
     }
     // Otherwise we shouldn't assume any divisibility.
     // For example:

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -469,9 +469,11 @@ private:
     // The minimal contiguity is gcd(d_lhs, d_rhs).
     // Since gcd(d_lhs, d_rhs) maybe > len(lhs),
     // we need to use another gcd to get the actual contiguity.
-    if (AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
-      contiguity = gcd(lhs.getContiguity(dim),
-                       gcd(lhs.getDivisibility(dim), rhs.getDivisibility(dim)));
+    if (AxisInfoVisitor::isContiguousDim(lhs, shape, dim) &&
+        AxisInfoVisitor::isConstantDim(rhs, shape, dim)) {
+      contiguity = std::max(contiguity, gcd(lhs.getContiguity(dim),
+                                            gcd(lhs.getDivisibility(dim),
+                                                rhs.getDivisibility(dim))));
     }
     return contiguity;
   }

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -480,11 +480,22 @@ private:
 
   int64_t getDivisibility(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                           int dim) override {
-    // lhs: d_lhs * k = gcd(d_lhs, d_rhs) * k' * k = gcd(d_lhs, d_rhs) * k''
-    // rhs: d_rhs * p = gcd(d_lhs, d_rhs) * p' * p = gcd(d_lhs, d_rhs) * p''
-    // lhs = gcd(d_lhs, d_rhs) * k'' = gcd(d_lhs, d_rhs) * d + r
-    // r must be divisible by gcd(d_lhs, d_rhs)
-    return gcd(lhs.getDivisibility(dim), rhs.getDivisibility(dim));
+    if (rhs.getConstancy(dim) > 1) {
+      // lhs: d_lhs * k = gcd(d_lhs, d_rhs) * k' * k = gcd(d_lhs, d_rhs) * k''
+      // rhs: d_rhs * p = gcd(d_lhs, d_rhs) * p' * p = gcd(d_lhs, d_rhs) * p''
+      // lhs = gcd(d_lhs, d_rhs) * k'' = gcd(d_lhs, d_rhs) * d + r
+      // r must be divisible by gcd(d_lhs, d_rhs)
+      return gcd(lhs.getDivisibility(dim), rhs.getDivisibility(dim));
+    } else if (AxisInfoVisitor::isConstantDim(rhs, lhs.getShape(), dim) &&
+               rhs.getConstantValue().has_value() &&
+               rhs.getConstantValue().value() < lhs.getDivisibility(dim)) {
+      return lhs.getDivisibility(dim);
+    }
+    // Otherwise we shouldn't assume any divisibility.
+    // For example:
+    // lhs: [2, 2, 4, 4], rhs: [0, 1, 2, 3]
+    // lhs % rhs = [0, 0, 0, 1]
+    return 1;
   };
 
   int64_t getConstancy(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -190,7 +190,7 @@ tt.func @rem() {
   %4 = arith.constant dense<64> : tensor<128xi32>
   // expected-remark @below {{contiguity = [64], divisibility = [64], constancy = [1], constant_value = <none>}}
   %5 = arith.remsi %0, %4 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %6 = arith.remsi %4, %0 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [2], constancy = [128], constant_value = 66}}
   %7 = arith.constant dense<66> : tensor<128xi32>
@@ -200,7 +200,7 @@ tt.func @rem() {
   %9 = arith.constant dense<192> : tensor<128xi32>
   // expected-remark @below {{contiguity = [64], divisibility = [64], constancy = [1], constant_value = <none>}}
   %10 = arith.remsi %0, %9 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %11 = arith.remsi %9, %0 : tensor<128xi32>
   // expected-remark @below {{contiguity = [128], divisibility = [32], constancy = [1], constant_value = <none>}}
   %12 = tt.make_range {end = 160 : i32, start = 32 : i32} : tensor<128xi32>

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -203,7 +203,7 @@ tt.func @rem() {
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %11 = arith.remsi %9, %0 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [32], constancy = [128], constant_value = 32}}
-  %12 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<128xi32>
+  %12 = tt.make_range {end = 160 : i32, start = 32 : i32} : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %13 = arith.remsi %0, %12 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -200,7 +200,7 @@ tt.func @rem() {
   %9 = arith.constant dense<192> : tensor<128xi32>
   // expected-remark @below {{contiguity = [64], divisibility = [64], constancy = [1], constant_value = <none>}}
   %10 = arith.remsi %0, %9 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = <none>}}
   %11 = arith.remsi %9, %0 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [32], constancy = [128], constant_value = 32}}
   %12 = tt.make_range {end = 160 : i32, start = 32 : i32} : tensor<128xi32>

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -202,7 +202,7 @@ tt.func @rem() {
   %10 = arith.remsi %0, %9 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = <none>}}
   %11 = arith.remsi %9, %0 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [128], divisibility = [32], constancy = [1], constant_value = 32}}
+  // expected-remark @below {{contiguity = [128], divisibility = [32], constancy = [1], constant_value = <none>}}
   %12 = tt.make_range {end = 160 : i32, start = 32 : i32} : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %13 = arith.remsi %0, %12 : tensor<128xi32>

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -202,7 +202,7 @@ tt.func @rem() {
   %10 = arith.remsi %0, %9 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = <none>}}
   %11 = arith.remsi %9, %0 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [32], constancy = [1], constant_value = 32}}
+  // expected-remark @below {{contiguity = [128], divisibility = [32], constancy = [1], constant_value = 32}}
   %12 = tt.make_range {end = 160 : i32, start = 32 : i32} : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %13 = arith.remsi %0, %12 : tensor<128xi32>

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -196,6 +196,22 @@ tt.func @rem() {
   %7 = arith.constant dense<66> : tensor<128xi32>
   // expected-remark @below {{contiguity = [2], divisibility = [2], constancy = [1], constant_value = <none>}}
   %8 = arith.remui %0, %7 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = 192}}
+  %9 = arith.constant dense<192> : tensor<128xi32>
+  // expected-remark @below {{contiguity = [64], divisibility = [64], constancy = [1], constant_value = <none>}}
+  %10 = arith.remsi %0, %9 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %11 = arith.remsi %9, %0 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [32], constancy = [128], constant_value = 32}}
+  %12 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %13 = arith.remsi %0, %12 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %14 = arith.remsi %12, %0 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [32], divisibility = [32], constancy = [1], constant_value = <none>}}
+  %15 = arith.remsi %12, %4 : tensor<128xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %16 = arith.remsi %4, %12 : tensor<128xi32>
   tt.return
 }
 

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -202,7 +202,7 @@ tt.func @rem() {
   %10 = arith.remsi %0, %9 : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [1], constant_value = <none>}}
   %11 = arith.remsi %9, %0 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [32], constancy = [128], constant_value = 32}}
+  // expected-remark @below {{contiguity = [1], divisibility = [32], constancy = [1], constant_value = 32}}
   %12 = tt.make_range {end = 160 : i32, start = 32 : i32} : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
   %13 = arith.remsi %0, %12 : tensor<128xi32>


### PR DESCRIPTION
When `rhs` has a contiguity > 1, it's difficult to specialize conditions to get optimal divisibility estimates.

For example, `[128, 128 128, ..., 128] % [0, 1, 2, 3, ...] = [0, 0, 0, 2, ...]`