### PR TITLE
Add a knob to disable autotuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ See [`python/triton/knobs.py`](python/triton/knobs.py) for the full list of conf
 - `TRITON_F32_DEFAULT` sets the default input precision of `tl.dot` when using 32-bit floats, which can be either `ieee`, `tf32`, or `tf32x3`.
 - `TRITON_FRONT_END_DEBUGGING=1` disables exception wrapping when an error occurs in the compiler frontend, allowing the full stack trace to be seen.
 - `TRITON_DISABLE_LINE_INFO=1` removes all line information from the module.
+- `TRITON_DISABLE_AUTOTUNE=1` disables autotuning for all kernels, just selecting the first valid config.
 
 > [!NOTE]
 > Some of these environment variables don't have a knob in `knobs.py`-- those are only relevant to the C++ layer(s), hence they don't exist in the python layer.

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -360,6 +360,7 @@ class compilation_knobs(base_knobs):
     allow_non_constexpr_globals: env_bool = env_bool("TRITON_ALLOW_NON_CONSTEXPR_GLOBALS")
     enable_experimental_consan: env_bool = env_bool("TRITON_ENABLE_EXPERIMENTAL_CONSAN")
     listener: Union[CompilationListener, None] = None
+    disable_autotune: env_bool = env_bool("TRITON_DISABLE_AUTOTUNE")
 
 
 class autotuning_knobs(base_knobs):

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -221,7 +221,7 @@ class Autotuner(KernelInterface):
             if key not in self.cache:
                 used_cached_result = False
                 pruned_configs = self.prune_configs(kwargs)
-                if knobs.compilation_knobs.disable_autotune:
+                if knobs.compilation.disable_autotune:
                     pruned_configs = [pruned_configs[0]]
 
                 def benchmark():

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -221,6 +221,8 @@ class Autotuner(KernelInterface):
             if key not in self.cache:
                 used_cached_result = False
                 pruned_configs = self.prune_configs(kwargs)
+                if knobs.compilation_knobs.disable_autotune:
+                    pruned_configs = [pruned_configs[0]]
 
                 def benchmark():
                     bench_start = time.time()


### PR DESCRIPTION
When bisecting Triton related issues we have found it helpful to limit the number of kernels generated. One simple but pretty powerful approach has just been to disable autotuning and select the first valid config. The PR adds an environment variable/knob that does this globally.

For a bit more context, we have found this especially useful when upgrading our internal Triton version at Meta. This may require running a model end to end to check for a regression, so if we detect an issue being able to quickly bisect the number of generated kernels is extremely helpful, especially since many of the issues we saw weren't dependent on a particular configuration.