### PR TITLE
Update 01-vector-add.py

### DIFF
--- a/python/tutorials/01-vector-add.py
+++ b/python/tutorials/01-vector-add.py
@@ -23,7 +23,7 @@ import torch
 import triton
 import triton.language as tl
 
-DEVICE = torch.device("cuda:0")
+DEVICE = torch.device(f"cuda:{torch.cuda.current_device()}")
 
 
 @triton.jit

--- a/python/tutorials/01-vector-add.py
+++ b/python/tutorials/01-vector-add.py
@@ -23,7 +23,7 @@ import torch
 import triton
 import triton.language as tl
 
-DEVICE = triton.runtime.driver.active.get_active_torch_device()
+DEVICE = torch.device("cuda:0")
 
 
 @triton.jit


### PR DESCRIPTION
Fix: https://github.com/triton-lang/triton/issues/5388 Correct device initialization to prevent AttributeError

The previous method of obtaining the active device, `triton.runtime.driver.active.get_active_torch_device()`, is no longer valid and causes an `AttributeError: 'CudaDriver' object has no attribute 'active'`. This is likely due to an internal API change within the Triton driver.

This commit replaces the faulty call with `torch.device("cuda:0")`. This uses the standard PyTorch API to specify the device, which is more stable and directly resolves the runtime error. This ensures that the device is correctly initialized without relying on a deprecated or changed internal Triton attribute.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
  - [x] This PR does not need a test because **it fixes a runtime initialization error in the test/benchmark setup itself. The change allows existing tests to run correctly without adding new functionality to be tested.**

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)