### PR TITLE
[RELEASE-ONLY] Revert buffer ops default enablement on AMD

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -434,7 +434,7 @@ class nvidia_knobs(base_knobs):
 
 
 class amd_knobs(base_knobs):
-    use_buffer_ops: env_bool = env_bool("AMDGCN_USE_BUFFER_OPS", True)
+    use_buffer_ops: env_bool = env_bool("AMDGCN_USE_BUFFER_OPS", False)
     dump_amdgcn: env_bool = env_bool("AMDGCN_ENABLE_DUMP")
     libhip_path: env_opt_str = env_opt_str("TRITON_LIBHIP_PATH")
     lld_path: env_opt_str = env_opt_str("TRITON_HIP_LLD_PATH")


### PR DESCRIPTION
Buffer op default enablement is resulting in corresponding PT UT failure
https://github.com/ROCm/triton/issues/830

Disabling in release branch for stability while we develop a fix for main