### PR TITLE
[Backend] Fix alias analysis with `ub.poison`

### DIFF
--- a/lib/Analysis/Alias.cpp
+++ b/lib/Analysis/Alias.cpp
@@ -2,6 +2,7 @@
 
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 
 namespace mlir {
 
@@ -37,6 +38,9 @@ LogicalResult SharedMemoryAliasAnalysis::visitOperation(
     pessimistic = false;
   } else if (op->hasTrait<OpTrait::MemDescViewTrait>()) {
     aliasInfo = AliasInfo(operands[0]->getValue());
+    pessimistic = false;
+  } else if (isa<ub::PoisonOp>(op)) {
+    aliasInfo = AliasInfo();
     pessimistic = false;
   } else {
     assert(!isa<triton::gpu::MemDescType>(result.getType()) &&


### PR DESCRIPTION
Optimistically assume poison values alias nothing.
