### PR TITLE
[Gluon] Add `assert_trivial` flag to `ttgl.convert_layout`

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -4,6 +4,7 @@
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Gluon/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -108,6 +109,23 @@ struct GluonLayouts {
         py::object(layouts.attr("SwizzledSharedLayout")).release();
   }
 };
+
+static bool isConvertLayoutTrivial(RankedTensorType dstTy, Value value) {
+  auto srcTy = cast<RankedTensorType>(value.getType());
+  if (srcTy.getEncoding() == dstTy.getEncoding())
+    return true;
+  // Handle unresolved layouts. auto -> T is trivial but T -> auto is not
+  // necessarily.
+  if (isa<gluon::AutoEncodingAttr>(srcTy.getEncoding()))
+    return true;
+  if (isa<gluon::AutoEncodingAttr>(dstTy.getEncoding()))
+    return false;
+
+  // Check concrete layouts.
+  triton::LinearLayout cvt = minimalCvtLayout(srcTy, dstTy);
+  auto dims = llvm::to_vector(cvt.getInDimNames());
+  return dims.empty() || (dims.size() == 1 && dims.front() == "register");
+}
 
 template <typename T> std::vector<T> toStdVector(llvm::ArrayRef<T> array) {
   return std::vector<T>(array.begin(), array.end());
@@ -313,6 +331,11 @@ void init_gluon_ir(py::module &&m) {
              auto blockTyLayout = RankedTensorType::get(
                  blockTy.getShape(), blockTy.getElementType(), layout);
              return triton::TensorDescType::get(ctx, blockTyLayout, isSigned);
+           })
+      .def("is_convert_layout_trivial",
+           [](GluonOpBuilder &self, Type resultTy, Value value) -> bool {
+             auto dstTy = cast<RankedTensorType>(resultTy);
+             return isConvertLayoutTrivial(dstTy, value);
            })
       .def("create_async_copy_global_to_local",
            [](GluonOpBuilder &self, Value smem, Value pointer, Value mask,

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -61,6 +61,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 """)
 
 
+@filecheck_test
+@gluon.jit
+def test_convert_layout_assert_trivial():
+    # CHECK: test_convert_layout_assert_trivial
+    parent_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 128], [32, 1], [4, 1], [0, 1])
+    slice_layout: ttgl.constexpr = ttgl.SliceLayout(1, parent_layout)
+    equiv_layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+
+    value = ttgl.arange(0, 128, layout=slice_layout)
+    # CHECK: ttg.convert_layout
+    ttgl.convert_layout(value, equiv_layout, assert_trivial=True)
+
+
+def test_convert_layout_not_trivial():
+
+    @gluon.jit
+    def kernel():
+        src_layout: ttgl.constexpr = ttgl.BlockedLayout([2], [32], [4], [0])
+        dst_layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
+
+        value = ttgl.arange(0, 128, layout=src_layout)
+        ttgl.convert_layout(value, dst_layout, assert_trivial=True)
+
+    with pytest.raises(CompilationError) as e:
+        run_parser(kernel)
+
+    assert "layout conversion from BlockedLayout(size_per_thread=(2)" in str(e.value.__cause__)
+    assert "to BlockedLayout(size_per_thread=(1)" in str(e.value.__cause__)
+    assert "is not trivial" in str(e.value.__cause__)
+
+
 @gluon.jit
 def shared_memory_kernel(XBLOCK: ttgl.constexpr, YBLOCK: ttgl.constexpr, layout_a: ttgl.constexpr,
                          layout_b: ttgl.constexpr, smem_layout: ttgl.constexpr):

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -360,19 +360,20 @@ def arange(start, end, layout, _semantic=None):
 
 
 @builtin
-def convert_layout(value, layout, _semantic=None):
+def convert_layout(value, layout, assert_trivial=False, _semantic=None):
     """
     Convert a tensor to a different distributed layout.
 
     Args:
         value (tensor): The input tensor.
         layout (DistributedLayout): The target layout.
+        assert_trivial (bool): If True, asserts that the conversion is trivial (no data movement).
 
     Returns:
         tensor: The tensor with the new layout.
     """
     layout = _unwrap_if_constexpr(layout)
-    return _semantic.convert_layout(value, layout)
+    return _semantic.convert_layout(value, layout, assert_trivial)
 
 
 @builtin


### PR DESCRIPTION
This flag causes the frontend to check that the layout conversion ends up being trivial, i.e. at most registers are reordered within a lane. This is useful when writing kernels and managing layout restrictions of different ops that happen to work out to being trivial without having to worry about accidental performance regressiosn.