### PR TITLE
[Frontend] Enable specialized recursion

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -690,6 +690,7 @@ class JITFunction(KernelInterface[T]):
     def cache_key(self):
         # TODO : hash should be attribute of `self`
         if self.hash is None:
+            self.hash = f"recursion:{self._fn_name}"
             nonlocals = inspect.getclosurevars(self.fn).nonlocals
             dependencies_finder = DependenciesFinder(name=self._fn_name, globals=self.__globals__, nonlocals=nonlocals,
                                                      src=self.src)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -690,6 +690,8 @@ class JITFunction(KernelInterface[T]):
     def cache_key(self):
         # TODO : hash should be attribute of `self`
         if self.hash is None:
+            # Set a placeholder hash to break recursion in case the function
+            # transitively calls itself. The full hash is set after.
             self.hash = f"recursion:{self._fn_name}"
             nonlocals = inspect.getclosurevars(self.fn).nonlocals
             dependencies_finder = DependenciesFinder(name=self._fn_name, globals=self.__globals__, nonlocals=nonlocals,


### PR DESCRIPTION
This PR changes the dependencies finder to not infinitely loop when the unspecialized call graph has a cycle. This allows a function to recurse on a specialized version of itself. This allows neat patterns when writing code, i.e. progressively splitting an arbitrary tensor down to N elements, etc.
