### PR TITLE
[NFC] Limit the range of integers so that the sum does not overflow in reduce test case

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2518,9 +2518,8 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, device):
     rs = RandomState(17)
     # limit the range of integers so that the sum does not overflow
     if dtype_str in integral_dtypes:
-        iinfo = np.iinfo(getattr(np, dtype_str))
-        low = iinfo.min // shape
-        high = iinfo.max // shape
+        low = 0 if dtype_str in uint_dtypes else -100
+        high = 100
         x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs, low=low, high=high)
     else:
         x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2519,8 +2519,8 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, device):
     # limit the range of integers so that the sum does not overflow
     if dtype_str in integral_dtypes:
         iinfo = np.iinfo(getattr(np, dtype_str))
-        low = iinfo.min // 2
-        high = iinfo.max // 2
+        low = iinfo.min // shape
+        high = iinfo.max // shape
         x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs, low=low, high=high)
     else:
         x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2517,7 +2517,13 @@ def test_reduce1d(op, dtype_str, shape, num_ctas, device):
     # input
     rs = RandomState(17)
     # limit the range of integers so that the sum does not overflow
-    x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs)
+    if dtype_str in integral_dtypes:
+        iinfo = np.iinfo(getattr(np, dtype_str))
+        low = iinfo.min // 2
+        high = iinfo.max // 2
+        x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs, low=low, high=high)
+    else:
+        x = numpy_random((shape, ), dtype_str=dtype_str, rs=rs)
     numpy_op = {
         'sum': np.sum,
         'max': np.max,


### PR DESCRIPTION
Our CI hit an overflow issue in reduce test case with Triton Interpreter.

```
FAILED language/test_core.py::test_reduce1d[4-1-1-sum-int32-32] - triton.runtime.errors.InterpreterError: InterpreterError("OverflowError('Python integer -4736833654 out of bounds for int32')")
FAILED language/test_core.py::test_reduce1d[4-1-1-sum-int32-64] - triton.runtime.errors.InterpreterError: InterpreterError("OverflowError('Python integer -17340316748 out of bounds for int32')")
FAILED language/test_core.py::test_reduce1d[4-1-1-sum-int32-128] - triton.runtime.errors.InterpreterError: InterpreterError("OverflowError('Python integer -15950412024 out of bounds for int32')")
FAILED language/test_core.py::test_reduce1d[4-1-1-sum-int32-512] - triton.runtime.errors.InterpreterError: InterpreterError("OverflowError('Python integer 6080852592 out of bounds for int32')")
```

There is a comment in the test_reduce1d about limiting the range of Integers in case overflow but without actual code.
Add the limitation as the comment.