### PR TITLE
Update 02-fused-softmax.py

### DIFF
--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -205,12 +205,13 @@ assert torch.allclose(y_triton, y_torch), (y_triton, y_torch)
         x_names=['N'],  # argument names to use as an x-axis for the plot
         x_vals=[128 * i for i in range(2, 100)],  # different possible values for `x_name`
         line_arg='provider',  # argument name whose value corresponds to a different line in the plot
-        line_vals=['triton', 'torch'],  # possible values for `line_arg``
+        line_vals=['triton', 'torch', 'native_softmax'],  # possible values for `line_arg``
         line_names=[
             "Triton",
             "Torch",
+            "Native Softmax"
         ],  # label name for the lines
-        styles=[('blue', '-'), ('green', '-')],  # line styles
+        styles=[('blue', '-'), ('green', '-'), ('red', '-')],  # line styles
         ylabel="GB/s",  # label name for the y-axis
         plot_name="softmax-performance",  # name for the plot. Used also as a file name for saving the plot.
         args={'M': 4096},  # values for function arguments not in `x_names` and `y_name`
@@ -223,6 +224,8 @@ def benchmark(M, N, provider):
         ms = triton.testing.do_bench(lambda: torch.softmax(x, axis=-1))
     if provider == 'triton':
         ms = triton.testing.do_bench(lambda: softmax(x))
+    if provider == 'native_softmax':
+        ms = triton.testing.do_bench(lambda: naive_softmax(x))
     gbps = lambda ms: 2 * x.numel() * x.element_size() * 1e-9 / (ms * 1e-3)
     return gbps(ms)
 


### PR DESCRIPTION
docs: Align softmax tutorial benchmark with description

The documentation for the softmax tutorial states that it compares three implementations: the Triton kernel, torch.softmax, and a naive_softmax implementation.

However, the accompanying code example only benchmarks the Triton and Torch versions, omitting the naive implementation. This discrepancy can cause confusion for users following the tutorial.

This commit updates the benchmark code to include the `native_softmax` comparison, ensuring the code accurately reflects the tutorial's description. The changes include:
- Adding 'native_softmax' to the `line_vals` list.
- Adding "Native Softmax" to the `line_names` list.
- Adding the corresponding logic branch to the `benchmark` function.

Here is my code result:
<img width="571" height="432" alt="image" src="https://github.com/user-attachments/assets/bf6dc821-2ee4-4acc-8002-0cc2188d3497" />

---
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because **the change is a fix to the benchmark code itself within the documentation, aligning it with the existing description. No new functionality is introduced that would require separate tests.**

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)