### PR TITLE
[WS] Update aref ops and lower_aref pass 

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h
@@ -1,0 +1,14 @@
+#ifndef TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_UTILITY_H_
+#define TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_UTILITY_H_
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+namespace mlir::triton::nvidia_gpu {
+
+LogicalResult verifyBarrierType(Operation *op,
+                                mlir::triton::gpu::MemDescType barrierType);
+
+}
+
+#endif // TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_UTILITY_H_

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -24,8 +24,8 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
-
 #include "triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.cpp.inc"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h"
 
 using namespace mlir::triton::gpu;
 
@@ -129,15 +129,6 @@ LogicalResult WarpGroupDotWaitOp::inferReturnTypes(
   for (Value operand : operands)
     inferredReturnTypes.push_back(operand.getType());
   return mlir::success();
-}
-
-static LogicalResult
-verifyBarrierType(Operation *op, mlir::triton::gpu::MemDescType barrierType) {
-  if (!barrierType.getElementType().isInteger(64) ||
-      barrierType.getShape() != ArrayRef<int64_t>({1}))
-    return op->emitOpError(
-        "barrier allocation must be a descriptor of 1xi64 type");
-  return success();
 }
 
 // -- InitBarrierOp --

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   TensorMemoryAllocation.cpp
   TMALowering.cpp
   TMAUtilities.cpp
+  Utility.cpp
 
   DEPENDS
   TritonNvidiaGPUTransformsIncGen

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/Utility.cpp
@@ -1,0 +1,19 @@
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h"
+
+#define DEBUG_TYPE "ttng-utility"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+namespace mlir::triton::nvidia_gpu {
+
+using namespace triton;
+
+LogicalResult verifyBarrierType(Operation *op,
+                                mlir::triton::gpu::MemDescType barrierType) {
+  if (!barrierType.getElementType().isInteger(64) ||
+      barrierType.getShape() != ArrayRef<int64_t>({1}))
+    return op->emitOpError(
+        "barrier allocation must be a descriptor of 1xi64 type");
+  return success();
+}
+
+} // namespace mlir::triton::nvidia_gpu

--- a/test/NVWS/invalid.mlir
+++ b/test/NVWS/invalid.mlir
@@ -20,7 +20,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
   tt.func @aref_get_single(%d : !ttg.memdesc<1x64x16xf16, #shared0, #smem>, %e : !ttg.memdesc<2x16x32xf16, #shared0, #smem>) {
     %c0_i32 = arith.constant 0 : i32
     // expected-error @below {{Aref buffer is used elsewhere, Aref cannot guarantee async safety}}
-    %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<2x16x32xf16, #shared0, #smem>], 1>
+    %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<2x16x32xf16, #shared0, #smem>]>
     %1 = ttng.tmem_alloc %d : (!ttg.memdesc<1x64x16xf16, #shared0, #smem>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return
   }
@@ -35,7 +35,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
     %c0_i32 = arith.constant 0 : i32
     // expected-error @below {{Aref has different number of arguments than enter}}
-    %1 = nvws.aref.put.enter %0[%c0_i32, %c0_i32] :
+    %1 = nvws.aref.put.enter %0[%c0_i32] :
       !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
       -> !ttg.memdesc<64x16xf16, #shared0, #smem>
     tt.return
@@ -51,7 +51,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     %c0_i32 = arith.constant 0 : i32
     %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
     // expected-error @below {{Dimensions don't match}}
-    %1:2 = nvws.aref.put.enter %0[%c0_i32, %c0_i32] :
+    %1:2 = nvws.aref.put.enter %0[%c0_i32] :
       !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
       -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<32x32xf16, #shared0, #smem>
     tt.return
@@ -67,7 +67,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     %c0_i32 = arith.constant 0 : i32
     %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
     // expected-error @below {{MLIR Types don't match}}
-    nvws.aref.get.enter %0[%c0_i32, %c0_i32] :
+    nvws.aref.get.enter %0[%c0_i32] :
       !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
       -> !ttg.memdesc<64x16xf16, #shared0, #smem>, tensor<16x32xf16>
     tt.return

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -16,8 +16,8 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     // CHECK:   [[C1:%.*]] = arith.constant 1 : i32
     %ub = arith.constant 4 : i32
 
-    // CHECK:        [[EMPTY0:%.*]] = ttg.local_alloc {aref_empty_mbarriers}
-    // CHECK-NEXT:   [[FULL0:%.*]] = ttg.local_alloc {aref_full_mbarriers}
+    // CHECK:        [[EMPTY0:%.*]] = ttg.local_alloc
+    // CHECK-NEXT:   [[FULL0:%.*]] = ttg.local_alloc
     // CHECK-NEXT:   scf.for
     // CHECK-NEXT:     [[EMPTYSLICE:%.*]] = ttg.memdesc_subview [[EMPTY0]]
     // CHECK-NEXT:     ttng.init_barrier [[EMPTYSLICE]], 1
@@ -26,62 +26,62 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     // CHECK-NEXT:   }
     %aref0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
-    // CHECK:        [[EMPTY1:%.*]] = ttg.local_alloc {aref_empty_mbarriers}
-    // CHECK-NEXT:   [[FULL1:%.*]] = ttg.local_alloc {aref_full_mbarriers}
+    // CHECK:        [[EMPTY1:%.*]] = ttg.local_alloc
+    // CHECK-NEXT:   [[FULL1:%.*]] = ttg.local_alloc
     // CHECK-NEXT:   scf.for
     // CHECK-NEXT:     [[EMPTYSLICE:%.*]] = ttg.memdesc_subview [[EMPTY1]]
     // CHECK-NEXT:     ttng.init_barrier [[EMPTYSLICE]], 256
     // CHECK-NEXT:     [[FULLSLICE:%.*]] = ttg.memdesc_subview [[FULL1]]
     // CHECK-NEXT:     ttng.init_barrier [[FULLSLICE]], 128
     // CHECK-NEXT:   }
-    %aref1 = nvws.aref.create %d, %e {first_get} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+    %aref1 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
     nvws.warp_group
     partition0  num_warps(4) {
       // CHECK: [[IDX:%.*]]:4 = scf.for [[I:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[C1:%.*]] iter_args([[IDX0:%.*]] = [[C0]], [[IDX1:%.*]] = [[C0]], [[IDX2:%.*]] = [[C0]], [[IDX3:%.*]] = [[C0]])
       scf.for %i = %lb to %ub step %c1_i32 : i32{
 
-        // CHECK-NEXT: [[EMPTYIDX:%.*]] = arith.remsi [[IDX0]], [[C3]] {empty_mbar}
+        // CHECK-NEXT: [[EMPTYIDX:%.*]] = arith.remsi [[IDX0]], [[C3]]
         // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_subview [[EMPTY0]][[[EMPTYIDX]]]
-        // CHECK-NEXT: [[PHASE_DIV:%.*]] = arith.divsi [[IDX0]], [[C3]] {put_phase}
-        // CHECK-NEXT: [[PHASE_AND:%.*]] = arith.andi [[PHASE_DIV]], [[C1]] {put_phase}
-        // CHECK-NEXT: [[PHASE_XOR:%.*]] = arith.xori [[PHASE_AND]], [[C1]] {put_phase}
+        // CHECK-NEXT: [[PHASE_DIV:%.*]] = arith.divsi [[IDX0]], [[C3]]
+        // CHECK-NEXT: [[PHASE_AND:%.*]] = arith.andi [[PHASE_DIV]], [[C1]]
+        // CHECK-NEXT: [[PHASE_XOR:%.*]] = arith.xori [[PHASE_AND]], [[C1]]
         // CHECK-NEXT: ttng.wait_barrier [[EMPTYMBAR]], [[PHASE_XOR]]
         %1:2 = nvws.aref.put.enter %aref0[%c0_i32] {aref_tag = "put0"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
 
-        // CHECK-NEXT: [[STAGE:%.*]] = arith.remsi [[IDX0]], [[C3]] {put_stage}
+        // CHECK-NEXT: [[STAGE:%.*]] = arith.remsi [[IDX0]], [[C3]]
         // CHECK-NEXT: [[BUFA:%.*]] = ttg.memdesc_subview %arg0[[[STAGE]],{{.*}},{{.*}}]
         // CHECK-NEXT: [[BUFB:%.*]] = ttg.memdesc_subview %arg1[[[STAGE]],{{.*}},{{.*}}]
-        // CHECK-NEXT: [[FULLIDX:%.*]] = arith.remsi [[IDX2]], [[C3]] {full_mbar}
+        // CHECK-NEXT: [[FULLIDX:%.*]] = arith.remsi [[IDX2]], [[C3]]
         // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_subview [[FULL0]][[[FULLIDX]]]
         // CHECK-NEXT: ttng.barrier_expect [[FULLMBAR]], 0
-        // CHECK-NEXT: [[IDX0a:%.*]] = arith.addi [[IDX0]], [[C1]] {next_aref_index}
+        // CHECK-NEXT: [[IDX0a:%.*]] = arith.addi [[IDX0]], [[C1]]
         // CHECK-NEXT: "tma_load"([[BUFA]])
         // CHECK-NEXT: "cp_async"([[BUFB]])
         "tma_load"(%1#0) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>) -> ()
         "cp_async"(%1#1) : (!ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
 
-        // CHECK-NEXT: [[FULLIDX:%.*]] = arith.remsi [[IDX2]], [[C3]] {full_mbar}
+        // CHECK-NEXT: [[FULLIDX:%.*]] = arith.remsi [[IDX2]], [[C3]]
         // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_subview [[FULL0]][[[FULLIDX]]]
         // CHECK-NEXT: nvws.arrive_barrier [[FULLMBAR]], async_op = <tma_load>
         // CHECK-NEXT: nvws.arrive_barrier [[FULLMBAR]], async_op = <cp_async>
-        // CHECK-NEXT: [[IDX2a:%.*]] = arith.addi [[IDX2]], [[C1]] {next_aref_index}
+        // CHECK-NEXT: [[IDX2a:%.*]] = arith.addi [[IDX2]], [[C1]]
         nvws.aref.put.exit %aref0[%c0_i32] [#nvws.async_op<tma_load>, #nvws.async_op<cp_async>] {aref_tag = "put0"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
         // CHECK-NEXT: [[IDX13:%.*]]:2 = scf.if
         scf.if %cond {
 
-          // CHECK: arith.remsi [[IDX1]], [[C3]] {empty_mbar}
-          // CHECK: arith.divsi [[IDX1]], [[C3]] {put_phase}
-          // CHECK-NEXT: arith.andi {{.*}}, [[C1]] {put_phase}
-          // CHECK-NOT: arith.xori
+          // CHECK: arith.remsi [[IDX1]], [[C3]]
+          // CHECK: arith.divsi [[IDX1]], [[C3]]
+          // CHECK-NEXT: arith.andi {{.*}}, [[C1]]
+          // CHECK-NEXT: arith.xori
           // CHECK-NEXT: ttng.wait_barrier
-          // CHECK: [[IDX1a:%.*]] = arith.addi [[IDX1]], [[C1]] {next_aref_index}
+          // CHECK: [[IDX1a:%.*]] = arith.addi [[IDX1]], [[C1]]
           %2:2 = nvws.aref.put.enter %aref1[%c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
           "tmem_store"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
 
-          // CHECK: arith.remsi [[IDX3]], [[C3]] {full_mbar}
-          // CHECK: [[IDX3a:%.*]] = arith.addi [[IDX3]], [[C1]] {next_aref_index}
+          // CHECK: arith.remsi [[IDX3]], [[C3]]
+          // CHECK: [[IDX3a:%.*]] = arith.addi [[IDX3]], [[C1]]
           nvws.aref.put.exit %aref1[%c0_i32] [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
           // CHECK: scf.yield [[IDX1a]], [[IDX3a]]
@@ -96,23 +96,23 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
       // CHECK: [[IDX1:%.*]]:2 = scf.if
       scf.if %cond {
 
-        // CHECK: arith.remsi [[IDX]]#0, [[C3]] {empty_mbar}
-        // CHECK: arith.divsi [[IDX]]#0, [[C3]] {put_phase}
-        // CHECK: [[IDX0a:%.*]] = arith.addi [[IDX]]#0, [[C1]] {next_aref_index}
+        // CHECK: arith.remsi [[IDX]]#0, [[C3]]
+        // CHECK: arith.divsi [[IDX]]#0, [[C3]]
+        // CHECK: [[IDX0a:%.*]] = arith.addi [[IDX]]#0, [[C1]]
         %1:2 = nvws.aref.put.enter %aref0[%c0_i32] {aref_tag = "put1"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
         "tma_load"(%1#0) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>) -> ()
         "cp_async"(%1#1) : (!ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
 
-        // CHECK: arith.remsi [[IDX]]#2, [[C3]] {full_mbar}
-        // CHECK: [[IDX2a:%.*]] = arith.addi [[IDX]]#2, [[C1]] {next_aref_index}
+        // CHECK: arith.remsi [[IDX]]#2, [[C3]]
+        // CHECK: [[IDX2a:%.*]] = arith.addi [[IDX]]#2, [[C1]]
         nvws.aref.put.exit %aref0[%c0_i32] [#nvws.async_op<tma_load>, #nvws.async_op<cp_async>] {aref_tag = "put1"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
       }
 
-      // CHECK: arith.remsi [[IDX]]#1, [[C3]] {empty_mbar}
-      // CHECK: arith.divsi [[IDX]]#1, [[C3]] {put_phase}
+      // CHECK: arith.remsi [[IDX]]#1, [[C3]]
+      // CHECK: arith.divsi [[IDX]]#1, [[C3]]
       %1:2 = nvws.aref.put.enter %aref1[%c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
       "tmem_store"(%1#0, %1#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-      // CHECK: arith.remsi [[IDX]]#3, [[C3]] {full_mbar}
+      // CHECK: arith.remsi [[IDX]]#3, [[C3]]
       nvws.aref.put.exit %aref1[%c0_i32] [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
       nvws.warp_group.return
     }
@@ -120,21 +120,21 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
       // CHECK: [[IDX:%.*]]:4 = scf.for [[I:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[C1:%.*]] iter_args([[IDX0:%.*]] = [[C0]], [[IDX1:%.*]] = [[C0]], [[IDX2:%.*]] = [[C0]], [[IDX3:%.*]] = [[C0]])
       scf.for %i = %lb to %ub step %c1_i32 : i32{
 
-        // CHECK-NEXT: [[FULLIDX:%.*]] = arith.remsi [[IDX0]], [[C3]] {full_mbar}
+        // CHECK-NEXT: [[FULLIDX:%.*]] = arith.remsi [[IDX0]], [[C3]]
         // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_subview [[FULL0]][[[FULLIDX]]]
-        // CHECK-NEXT: [[PHASE_DIV:%.*]] = arith.divsi [[IDX0]], [[C3]] {get_phase}
-        // CHECK-NEXT: [[PHASE_AND:%.*]] = arith.andi [[PHASE_DIV]], [[C1]] {get_phase}
+        // CHECK-NEXT: [[PHASE_DIV:%.*]] = arith.divsi [[IDX0]], [[C3]]
+        // CHECK-NEXT: [[PHASE_AND:%.*]] = arith.andi [[PHASE_DIV]], [[C1]]
         // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE_AND]]
         %2:2 = nvws.aref.get.enter %aref0[%c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
 
-        // CHECK-NEXT: [[STAGE:%.*]] = arith.remsi [[IDX0]], [[C3]] {get_stage}
+        // CHECK-NEXT: [[STAGE:%.*]] = arith.remsi [[IDX0]], [[C3]]
         // CHECK-NEXT: [[BUFA:%.*]] = ttg.memdesc_subview %arg0[[[STAGE]],{{.*}},{{.*}}]
         // CHECK-NEXT: [[BUFB:%.*]] = ttg.memdesc_subview %arg1[[[STAGE]],{{.*}},{{.*}}]
         // CHECK-NEXT: arith.addi
         // CHECK-NEXT: "tc5mma"([[BUFA]], [[BUFB]])
         "tc5mma"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
 
-        // CHECK-NEXT: [[EMPTYIDX:%.*]] = arith.remsi [[IDX2]], [[C3]] {empty_mbar}
+        // CHECK-NEXT: [[EMPTYIDX:%.*]] = arith.remsi [[IDX2]], [[C3]]
         // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_subview [[EMPTY0]][[[EMPTYIDX]]]
         // CHECK-NEXT: nvws.arrive_barrier [[EMPTYMBAR]], async_op = <tc5mma>
         // CHECK-NEXT: arith.addi
@@ -142,15 +142,14 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
         // CHECK: [[IDX13:%.*]]:2 = scf.if
         scf.if %cond {
-          // CHECK: arith.remsi [[IDX1]], [[C3]] {full_mbar}
-          // CHECK: arith.divsi [[IDX1]], [[C3]] {get_phase}
-          // CHECK-NEXT: arith.andi {{.*}}, [[C1]] {get_phase}
-          // CHECK-NEXT: arith.xori {{.*}}, [[C1]] {get_phase}
+          // CHECK: arith.remsi [[IDX1]], [[C3]]
+          // CHECK: arith.divsi [[IDX1]], [[C3]]
+          // CHECK-NEXT: arith.andi {{.*}}, [[C1]]
           // CHECK-NEXT: ttng.wait_barrier
           %3:2 = nvws.aref.get.enter %aref1[%c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
           "tmem_load"(%3#0, %3#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
 
-          // CHECK: arith.remsi [[IDX3]], [[C3]] {empty_mbar}
+          // CHECK: arith.remsi [[IDX3]], [[C3]]
           // CHECK-NEXT: ttg.memdesc_subview
           // CHECK-NEXT: nvws.arrive_barrier {{.*}}, async_op = <none>
           nvws.aref.get.exit %aref1[%c0_i32] [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
@@ -162,15 +161,14 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
         // CHECK: scf.yield {{.*}}, [[IDX13]]#0, {{.*}}, [[IDX13]]#1
       }
       scf.if %cond {
-        // CHECK: arith.remsi [[IDX]]#0, [[C3]] {full_mbar}
-        // CHECK: arith.divsi [[IDX]]#0, [[C3]] {get_phase}
-        // CHECK-NEXT: arith.andi {{.*}}, [[C1]] {get_phase}
-        // CHECK-NOT: arith.xori
+        // CHECK: arith.remsi [[IDX]]#0, [[C3]]
+        // CHECK: arith.divsi [[IDX]]#0, [[C3]]
+        // CHECK-NEXT: arith.andi {{.*}}, [[C1]]
         // CHECK-NEXT: ttng.wait_barrier
         %2:2 = nvws.aref.get.enter %aref0[%c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
         "tc5mma"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
 
-        // CHECK: arith.remsi [[IDX]]#2, [[C3]] {empty_mbar}
+        // CHECK: arith.remsi [[IDX]]#2, [[C3]]
         nvws.aref.get.exit %aref0[%c0_i32] [#nvws.async_op<tc5mma>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
       }
       // CHECK: } else {

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -63,8 +63,8 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
         // CHECK-NEXT: [[FULLIDX:%.*]] = arith.remsi [[IDX2]], [[C3]]
         // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_subview [[FULL0]][[[FULLIDX]]]
-        // CHECK-NEXT: nvws.arrive_barrier [[FULLMBAR]], async_op = <tma_load>
-        // CHECK-NEXT: nvws.arrive_barrier [[FULLMBAR]], async_op = <cp_async>
+        // CHECK-NEXT: nvws.aref_complete [[FULLMBAR]], async_op = <tma_load>
+        // CHECK-NEXT: nvws.aref_complete [[FULLMBAR]], async_op = <cp_async>
         // CHECK-NEXT: [[IDX2a:%.*]] = arith.addi [[IDX2]], [[C1]]
         nvws.aref.put.exit %aref0[%c0_i32] [#nvws.async_op<tma_load>, #nvws.async_op<cp_async>] {aref_tag = "put0"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
@@ -136,7 +136,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
         // CHECK-NEXT: [[EMPTYIDX:%.*]] = arith.remsi [[IDX2]], [[C3]]
         // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_subview [[EMPTY0]][[[EMPTYIDX]]]
-        // CHECK-NEXT: nvws.arrive_barrier [[EMPTYMBAR]], async_op = <tc5mma>
+        // CHECK-NEXT: nvws.aref_complete [[EMPTYMBAR]], async_op = <tc5mma>
         // CHECK-NEXT: arith.addi
         nvws.aref.get.exit %aref0[%c0_i32] [#nvws.async_op<tc5mma>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
@@ -151,7 +151,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
           // CHECK: arith.remsi [[IDX3]], [[C3]]
           // CHECK-NEXT: ttg.memdesc_subview
-          // CHECK-NEXT: nvws.arrive_barrier {{.*}}, async_op = <none>
+          // CHECK-NEXT: nvws.aref_complete {{.*}}, async_op = <none>
           nvws.aref.get.exit %aref1[%c0_i32] [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
         }
         // CHECK: } else {

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -63,8 +63,8 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
         // CHECK-NEXT: [[FULLIDX:%.*]] = arith.remsi [[IDX2]], [[C3]]
         // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_subview [[FULL0]][[[FULLIDX]]]
-        // CHECK-NEXT: nvws.aref_complete [[FULLMBAR]], async_op = <tma_load>
-        // CHECK-NEXT: nvws.aref_complete [[FULLMBAR]], async_op = <cp_async>
+        // CHECK-NEXT: nvws.async_complete [[FULLMBAR]], async_op = <tma_load>
+        // CHECK-NEXT: nvws.async_complete [[FULLMBAR]], async_op = <cp_async>
         // CHECK-NEXT: [[IDX2a:%.*]] = arith.addi [[IDX2]], [[C1]]
         nvws.aref.put.exit %aref0[%c0_i32] [#nvws.async_op<tma_load>, #nvws.async_op<cp_async>] {aref_tag = "put0"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
@@ -136,7 +136,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
         // CHECK-NEXT: [[EMPTYIDX:%.*]] = arith.remsi [[IDX2]], [[C3]]
         // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_subview [[EMPTY0]][[[EMPTYIDX]]]
-        // CHECK-NEXT: nvws.aref_complete [[EMPTYMBAR]], async_op = <tc5mma>
+        // CHECK-NEXT: nvws.async_complete [[EMPTYMBAR]], async_op = <tc5mma>
         // CHECK-NEXT: arith.addi
         nvws.aref.get.exit %aref0[%c0_i32] [#nvws.async_op<tc5mma>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
@@ -151,7 +151,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
           // CHECK: arith.remsi [[IDX3]], [[C3]]
           // CHECK-NEXT: ttg.memdesc_subview
-          // CHECK-NEXT: nvws.aref_complete {{.*}}, async_op = <none>
+          // CHECK-NEXT: nvws.async_complete {{.*}}, async_op = <none>
           nvws.aref.get.exit %aref1[%c0_i32] [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
         }
         // CHECK: } else {

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -4,43 +4,184 @@
 #smem = #ttg.shared_memory
 #tmem = #ttng.tensor_memory
 module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  //CHECK: tt.func @aref_get_put
-  // CHECK-NEXT:   [[ZERO:%.*]] = arith.constant 0 : i32
-  // CHECK-NEXT:   [[ONE:%.*]] = arith.constant 1 : i32
-  // CHECK-NEXT:   [[EMPTY:%.*]] = ttg.local_alloc {aref_empty_mbarriers}
-  // CHECK-NEXT:   [[FULL:%.*]] = ttg.local_alloc {aref_full_mbarriers}
-  // CHECK-NEXT:   scf.for
-  // CHECK-NEXT:     [[EMPTYSLICE:%.*]] = ttg.memdesc_subview [[EMPTY]]
-  // CHECK-NEXT:     ttng.init_barrier [[EMPTYSLICE]], 0
-  // CHECK-NEXT:     [[FULLSLICE:%.*]] = ttg.memdesc_subview [[FULL]]
-  // CHECK-NEXT:     ttng.init_barrier [[FULLSLICE]], 1
-  // CHECK-NEXT:   }
-  // CHECK-NEXT:   [[EMPTYSLICE2:%.*]] = ttg.memdesc_subview [[EMPTY]]
-  // CHECK-NEXT:   ttng.wait_barrier [[EMPTYSLICE2]], [[ONE]]
-  // CHECK-NEXT:   [[A:%.*]] = ttg.memdesc_subview %arg0
-  // CHECK-NEXT:   [[B:%.*]] = ttg.memdesc_subview %arg1
-  // CHECK-NEXT:   "foo"([[A]], [[B]])
-  // CHECK-NEXT:   [[FULLSLICE2:%.*]] = ttg.memdesc_subview [[FULL]]
-  // CHECK-NEXT:   ttng.arrive_barrier [[FULLSLICE2]], 1
-  // CHECK-NEXT:   [[FULLSLICE3:%.*]] = ttg.memdesc_subview [[FULL]]
-  // CHECK-NEXT:   ttng.wait_barrier [[FULLSLICE3]], [[ZERO]]
-  // CHECK-NEXT:   [[AA:%.*]] = ttg.memdesc_subview %arg0
-  // CHECK-NEXT:   [[BB:%.*]] = ttg.memdesc_subview %arg1
-  // CHECK-NEXT:   "bar"([[AA]], [[BB]])
-  // CHECK-NEXT:   [[EMPTYSLICE3:%.*]] = ttg.memdesc_subview [[EMPTY]]
-  // CHECK-NEXT:   ttng.arrive_barrier [[EMPTYSLICE3]],
-  // CHECK-NEXT:   tt.return
-  // CHECK-NEXT: }
-  tt.func @aref_get_put(%d : !ttg.memdesc<1x64x16xf16, #shared0, #tmem>, %e : !ttg.memdesc<1x16x32xf16, #shared0, #smem>) {
+  //CHECK-LABEL: @aref_lowering
+  tt.func @aref_lowering(%d : !ttg.memdesc<3x64x16xf16, #shared0, #tmem>,
+                         %e : !ttg.memdesc<3x16x32xf16, #shared0, #smem>,
+                         %cond : i1) {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
-    %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #tmem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
-    %1:2 = nvws.aref.put.enter %0[%c0_i32, %c1_i32] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #tmem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
-    "foo"(%1#0, %1#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-    nvws.aref.put.exit %0[%c0_i32] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #tmem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
-    %2:2 = nvws.aref.get.enter %0[%c0_i32, %c0_i32] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #tmem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
-    "bar"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-    nvws.aref.get.exit %0[%c0_i32] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #tmem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
+    %lb = arith.constant 0 : i32
+    // CHECK:   [[C3:%.*]] = arith.constant 3 : i32
+    // CHECK:   [[C0:%.*]] = arith.constant 0 : i32
+    // CHECK:   [[C1:%.*]] = arith.constant 1 : i32
+    %ub = arith.constant 4 : i32
+
+    // CHECK:        [[EMPTY0:%.*]] = ttg.local_alloc {aref_empty_mbarriers}
+    // CHECK-NEXT:   [[FULL0:%.*]] = ttg.local_alloc {aref_full_mbarriers}
+    // CHECK-NEXT:   scf.for
+    // CHECK-NEXT:     [[EMPTYSLICE:%.*]] = ttg.memdesc_subview [[EMPTY0]]
+    // CHECK-NEXT:     ttng.init_barrier [[EMPTYSLICE]], 1
+    // CHECK-NEXT:     [[FULLSLICE:%.*]] = ttg.memdesc_subview [[FULL0]]
+    // CHECK-NEXT:     ttng.init_barrier [[FULLSLICE]], 129
+    // CHECK-NEXT:   }
+    %aref0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+
+    // CHECK:        [[EMPTY1:%.*]] = ttg.local_alloc {aref_empty_mbarriers}
+    // CHECK-NEXT:   [[FULL1:%.*]] = ttg.local_alloc {aref_full_mbarriers}
+    // CHECK-NEXT:   scf.for
+    // CHECK-NEXT:     [[EMPTYSLICE:%.*]] = ttg.memdesc_subview [[EMPTY1]]
+    // CHECK-NEXT:     ttng.init_barrier [[EMPTYSLICE]], 256
+    // CHECK-NEXT:     [[FULLSLICE:%.*]] = ttg.memdesc_subview [[FULL1]]
+    // CHECK-NEXT:     ttng.init_barrier [[FULLSLICE]], 128
+    // CHECK-NEXT:   }
+    %aref1 = nvws.aref.create %d, %e {first_get} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+
+    nvws.warp_group
+    partition0  num_warps(4) {
+      // CHECK: [[IDX:%.*]]:4 = scf.for [[I:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[C1:%.*]] iter_args([[IDX0:%.*]] = [[C0]], [[IDX1:%.*]] = [[C0]], [[IDX2:%.*]] = [[C0]], [[IDX3:%.*]] = [[C0]])
+      scf.for %i = %lb to %ub step %c1_i32 : i32{
+
+        // CHECK-NEXT: [[EMPTYIDX:%.*]] = arith.remsi [[IDX0]], [[C3]] {empty_mbar}
+        // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_subview [[EMPTY0]][[[EMPTYIDX]]]
+        // CHECK-NEXT: [[PHASE_DIV:%.*]] = arith.divsi [[IDX0]], [[C3]] {put_phase}
+        // CHECK-NEXT: [[PHASE_AND:%.*]] = arith.andi [[PHASE_DIV]], [[C1]] {put_phase}
+        // CHECK-NEXT: [[PHASE_XOR:%.*]] = arith.xori [[PHASE_AND]], [[C1]] {put_phase}
+        // CHECK-NEXT: ttng.wait_barrier [[EMPTYMBAR]], [[PHASE_XOR]]
+        %1:2 = nvws.aref.put.enter %aref0[%c0_i32] {aref_tag = "put0"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
+
+        // CHECK-NEXT: [[STAGE:%.*]] = arith.remsi [[IDX0]], [[C3]] {put_stage}
+        // CHECK-NEXT: [[BUFA:%.*]] = ttg.memdesc_subview %arg0[[[STAGE]],{{.*}},{{.*}}]
+        // CHECK-NEXT: [[BUFB:%.*]] = ttg.memdesc_subview %arg1[[[STAGE]],{{.*}},{{.*}}]
+        // CHECK-NEXT: [[FULLIDX:%.*]] = arith.remsi [[IDX2]], [[C3]] {full_mbar}
+        // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_subview [[FULL0]][[[FULLIDX]]]
+        // CHECK-NEXT: ttng.barrier_expect [[FULLMBAR]], 0
+        // CHECK-NEXT: [[IDX0a:%.*]] = arith.addi [[IDX0]], [[C1]] {next_aref_index}
+        // CHECK-NEXT: "tma_load"([[BUFA]])
+        // CHECK-NEXT: "cp_async"([[BUFB]])
+        "tma_load"(%1#0) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>) -> ()
+        "cp_async"(%1#1) : (!ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+
+        // CHECK-NEXT: [[FULLIDX:%.*]] = arith.remsi [[IDX2]], [[C3]] {full_mbar}
+        // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_subview [[FULL0]][[[FULLIDX]]]
+        // CHECK-NEXT: nvws.arrive_barrier [[FULLMBAR]], async_op = <tma_load>
+        // CHECK-NEXT: nvws.arrive_barrier [[FULLMBAR]], async_op = <cp_async>
+        // CHECK-NEXT: [[IDX2a:%.*]] = arith.addi [[IDX2]], [[C1]] {next_aref_index}
+        nvws.aref.put.exit %aref0[%c0_i32] [#nvws.async_op<tma_load>, #nvws.async_op<cp_async>] {aref_tag = "put0"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+
+        // CHECK-NEXT: [[IDX13:%.*]]:2 = scf.if
+        scf.if %cond {
+
+          // CHECK: arith.remsi [[IDX1]], [[C3]] {empty_mbar}
+          // CHECK: arith.divsi [[IDX1]], [[C3]] {put_phase}
+          // CHECK-NEXT: arith.andi {{.*}}, [[C1]] {put_phase}
+          // CHECK-NOT: arith.xori
+          // CHECK-NEXT: ttng.wait_barrier
+          // CHECK: [[IDX1a:%.*]] = arith.addi [[IDX1]], [[C1]] {next_aref_index}
+          %2:2 = nvws.aref.put.enter %aref1[%c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
+          "tmem_store"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+
+          // CHECK: arith.remsi [[IDX3]], [[C3]] {full_mbar}
+          // CHECK: [[IDX3a:%.*]] = arith.addi [[IDX3]], [[C1]] {next_aref_index}
+          nvws.aref.put.exit %aref1[%c0_i32] [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+
+          // CHECK: scf.yield [[IDX1a]], [[IDX3a]]
+        }
+        // CHECK-NEXT: } else {
+        // CHECK-NEXT:   scf.yield [[IDX1]], [[IDX3]]
+        // CHECK-NEXT: }
+
+        // CHECK: scf.yield [[IDX0a]], [[IDX13]]#0, [[IDX2a]], [[IDX13]]#1
+      }
+
+      // CHECK: [[IDX1:%.*]]:2 = scf.if
+      scf.if %cond {
+
+        // CHECK: arith.remsi [[IDX]]#0, [[C3]] {empty_mbar}
+        // CHECK: arith.divsi [[IDX]]#0, [[C3]] {put_phase}
+        // CHECK: [[IDX0a:%.*]] = arith.addi [[IDX]]#0, [[C1]] {next_aref_index}
+        %1:2 = nvws.aref.put.enter %aref0[%c0_i32] {aref_tag = "put1"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
+        "tma_load"(%1#0) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>) -> ()
+        "cp_async"(%1#1) : (!ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+
+        // CHECK: arith.remsi [[IDX]]#2, [[C3]] {full_mbar}
+        // CHECK: [[IDX2a:%.*]] = arith.addi [[IDX]]#2, [[C1]] {next_aref_index}
+        nvws.aref.put.exit %aref0[%c0_i32] [#nvws.async_op<tma_load>, #nvws.async_op<cp_async>] {aref_tag = "put1"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+      }
+
+      // CHECK: arith.remsi [[IDX]]#1, [[C3]] {empty_mbar}
+      // CHECK: arith.divsi [[IDX]]#1, [[C3]] {put_phase}
+      %1:2 = nvws.aref.put.enter %aref1[%c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
+      "tmem_store"(%1#0, %1#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+      // CHECK: arith.remsi [[IDX]]#3, [[C3]] {full_mbar}
+      nvws.aref.put.exit %aref1[%c0_i32] [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+      nvws.warp_group.return
+    }
+    partition1 num_warps(8) {
+      // CHECK: [[IDX:%.*]]:4 = scf.for [[I:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[C1:%.*]] iter_args([[IDX0:%.*]] = [[C0]], [[IDX1:%.*]] = [[C0]], [[IDX2:%.*]] = [[C0]], [[IDX3:%.*]] = [[C0]])
+      scf.for %i = %lb to %ub step %c1_i32 : i32{
+
+        // CHECK-NEXT: [[FULLIDX:%.*]] = arith.remsi [[IDX0]], [[C3]] {full_mbar}
+        // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_subview [[FULL0]][[[FULLIDX]]]
+        // CHECK-NEXT: [[PHASE_DIV:%.*]] = arith.divsi [[IDX0]], [[C3]] {get_phase}
+        // CHECK-NEXT: [[PHASE_AND:%.*]] = arith.andi [[PHASE_DIV]], [[C1]] {get_phase}
+        // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE_AND]]
+        %2:2 = nvws.aref.get.enter %aref0[%c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
+
+        // CHECK-NEXT: [[STAGE:%.*]] = arith.remsi [[IDX0]], [[C3]] {get_stage}
+        // CHECK-NEXT: [[BUFA:%.*]] = ttg.memdesc_subview %arg0[[[STAGE]],{{.*}},{{.*}}]
+        // CHECK-NEXT: [[BUFB:%.*]] = ttg.memdesc_subview %arg1[[[STAGE]],{{.*}},{{.*}}]
+        // CHECK-NEXT: arith.addi
+        // CHECK-NEXT: "tc5mma"([[BUFA]], [[BUFB]])
+        "tc5mma"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+
+        // CHECK-NEXT: [[EMPTYIDX:%.*]] = arith.remsi [[IDX2]], [[C3]] {empty_mbar}
+        // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_subview [[EMPTY0]][[[EMPTYIDX]]]
+        // CHECK-NEXT: nvws.arrive_barrier [[EMPTYMBAR]], async_op = <tc5mma>
+        // CHECK-NEXT: arith.addi
+        nvws.aref.get.exit %aref0[%c0_i32] [#nvws.async_op<tc5mma>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+
+        // CHECK: [[IDX13:%.*]]:2 = scf.if
+        scf.if %cond {
+          // CHECK: arith.remsi [[IDX1]], [[C3]] {full_mbar}
+          // CHECK: arith.divsi [[IDX1]], [[C3]] {get_phase}
+          // CHECK-NEXT: arith.andi {{.*}}, [[C1]] {get_phase}
+          // CHECK-NEXT: arith.xori {{.*}}, [[C1]] {get_phase}
+          // CHECK-NEXT: ttng.wait_barrier
+          %3:2 = nvws.aref.get.enter %aref1[%c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
+          "tmem_load"(%3#0, %3#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+
+          // CHECK: arith.remsi [[IDX3]], [[C3]] {empty_mbar}
+          // CHECK-NEXT: ttg.memdesc_subview
+          // CHECK-NEXT: nvws.arrive_barrier {{.*}}, async_op = <none>
+          nvws.aref.get.exit %aref1[%c0_i32] [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+        }
+        // CHECK: } else {
+        // CHECK-NEXT:   scf.yield [[IDX1]], [[IDX3]]
+        // CHECK-NEXT: }
+
+        // CHECK: scf.yield {{.*}}, [[IDX13]]#0, {{.*}}, [[IDX13]]#1
+      }
+      scf.if %cond {
+        // CHECK: arith.remsi [[IDX]]#0, [[C3]] {full_mbar}
+        // CHECK: arith.divsi [[IDX]]#0, [[C3]] {get_phase}
+        // CHECK-NEXT: arith.andi {{.*}}, [[C1]] {get_phase}
+        // CHECK-NOT: arith.xori
+        // CHECK-NEXT: ttng.wait_barrier
+        %2:2 = nvws.aref.get.enter %aref0[%c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
+        "tc5mma"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+
+        // CHECK: arith.remsi [[IDX]]#2, [[C3]] {empty_mbar}
+        nvws.aref.get.exit %aref0[%c0_i32] [#nvws.async_op<tc5mma>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+      }
+      // CHECK: } else {
+      // CHECK-NEXT:   scf.yield [[IDX]]#0, [[IDX]]#2
+      // CHECK-NEXT: }
+
+      %2:2 = nvws.aref.get.enter %aref1[%c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
+      "tmem_load"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #tmem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+      nvws.aref.get.exit %aref1[%c0_i32] [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+      nvws.warp_group.return
+    }
     tt.return
   }
 }

--- a/test/NVWS/ops.mlir
+++ b/test/NVWS/ops.mlir
@@ -23,8 +23,8 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
   tt.func @aref_get(%d : !ttg.memdesc<1x64x16xf16, #shared0, #smem>, %e : !ttg.memdesc<1x16x32xf16, #shared0, #smem>) {
     %c0_i32 = arith.constant {ttg.partition = [0, 1]} 0 : i32
     %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
-    %1:2 = nvws.aref.get.enter %0[%c0_i32, %c0_i32] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
-    nvws.aref.get.exit %0[%c0_i32] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
+    %1:2 = nvws.aref.get.enter %0[%c0_i32] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
+    nvws.aref.get.exit %0[%c0_i32] [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
     tt.return
   }
 }
@@ -40,8 +40,8 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
   tt.func @aref_put(%d : !ttg.memdesc<1x64x16xf16, #shared0, #smem>, %e : !ttg.memdesc<1x16x32xf16, #shared0, #smem>) {
     %c0_i32 = arith.constant {ttg.partition = [0, 1]} 0 : i32
     %0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
-    %1:2 = nvws.aref.put.enter %0[%c0_i32, %c0_i32] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
-    nvws.aref.put.exit %0[%c0_i32] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
+    %1:2 = nvws.aref.put.enter %0[%c0_i32] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>
+    nvws.aref.put.exit %0[%c0_i32] [#nvws.async_op<tc5mma>] : !nvws.aref<[!ttg.memdesc<1x64x16xf16, #shared0, #smem>, !ttg.memdesc<1x16x32xf16, #shared0, #smem>]>
     tt.return
   }
 }

--- a/third_party/nvidia/include/Dialect/NVWS/IR/Dialect.h
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/Dialect.h
@@ -34,9 +34,10 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 
+#include "nvidia/include/Dialect/NVWS/IR/NVWSAttrEnums.h.inc"
+
 #define GET_ATTRDEF_CLASSES
 #include "nvidia/include/Dialect/NVWS/IR/NVWSAttrDefs.h.inc"
-#include "nvidia/include/Dialect/NVWS/IR/NVWSAttrEnums.h.inc"
 
 #define GET_TYPEDEF_CLASSES
 #include "nvidia/include/Dialect/NVWS/IR/Types.h.inc"

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSAttrDefs.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSAttrDefs.td
@@ -47,4 +47,24 @@ def NVWS_TokenLoadTypeAttr : I32EnumAttr<
   let cppNamespace = "::mlir::triton::nvws";
 }
 
+def NVWS_AsyncOpAttr: I32EnumAttr<
+  "AsyncOp", "",
+  [
+    I32EnumAttrCase<"NONE", 0, "none">,
+    I32EnumAttrCase<"TMALoad", 1, "tma_load">,
+    I32EnumAttrCase<"TC5MMA", 2, "tc5mma">,
+    I32EnumAttrCase<"TMEMCopy", 3, "tmem_copy">,
+    I32EnumAttrCase<"CpAsync", 4, "cp_async">,
+    I32EnumAttrCase<"WGMMA", 5, "wgmma">,
+  ]> {
+  let cppNamespace = "::mlir::triton::nvws";
+  let genSpecializedAttr = 0;
+}
+
+def NVWS_AsyncOpEnum : EnumAttr<NVWS_Dialect, NVWS_AsyncOpAttr, "async_op"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
+def NVWS_AsyncOpArrayAttr : TypedArrayAttrBase<NVWS_AsyncOpEnum, "array of async op attributes">;
+
 #endif

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -155,20 +155,21 @@ def NVWS_WarpGroupReturnOp : NVWS_Op<"warp_group.return", [
   let assemblyFormat = "attr-dict";
 }
 
-def NVWS_ArriveBarrierOp : NVWS_Op<"arrive_barrier", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-    let summary = "mbarrier.arrive or tcgen5.commit";
+def NVWS_ArefCompleteOp : NVWS_Op<"arrive_barrier", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "mbarrier.arrive or tcgen5.commit";
 
-    let description = [{
-      Lowers to mbarrier.arrive.shared.b64, cp.async.mbarrier.arrive.noinc or
-      tcgen05.commit depending on the value of commit.
-       * This op allows all threads to arrive
-       * It has an optional "arrive after a given async op completes" semantics.
-    }];
+  let description = [{
+    Lowers to mbarrier.arrive.shared.b64, cp.async.mbarrier.arrive.noinc or
+    tcgen05.commit depending on the value of commit.
+     * This op allows all threads to arrive
+     * It has an optional "arrive after a given async op completes" semantics.
+  }];
 
-    let hasVerifier = 1;
-    let arguments = (ins TTG_MemDescType:$alloc, NVWS_AsyncOpEnum:$async_op);
-    let assemblyFormat = [{ $alloc `,` `async_op` `=` $async_op attr-dict `:` type($alloc)
-    }];
+  let hasVerifier = 1;
+  let arguments = (ins TTG_MemDescType:$alloc, NVWS_AsyncOpEnum:$async_op);
+  let assemblyFormat = [{
+    $alloc `,` `async_op` `=` $async_op attr-dict `:` type($alloc)
+  }];
 }
 
 def NVWS_CreateTokenOp : NVWS_Op<"create_token"> {

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -31,6 +31,7 @@ include "mlir/Interfaces/InferTypeOpInterface.td"  // SameOperandsAndResultType
 include "mlir/Interfaces/SideEffectInterfaces.td"  // Pure
 include "mlir/Interfaces/ViewLikeInterface.td"
 include "triton/Dialect/Triton/IR/TritonTypes.td"
+include "triton/Dialect/TritonGPU/IR/TritonGPUTypes.td"
 include "NVWSDialect.td"
 include "NVWSTypes.td"
 include "NVWSAttrDefs.td"
@@ -64,12 +65,11 @@ def NVWS_ArefGetEnterOp : NVWS_Op<"aref.get.enter"> {
                       These ArefGet "regions" can span multiple iterations. }];
 
   let arguments = (ins NVWS_ArefType:$aref,
-                       I32:$index,
-                       I32:$phase);
+                       I32:$index);
   let results = (outs Variadic<AnyType>:$results);
   let hasVerifier=1;
   let assemblyFormat = [{
-    $aref `[` $index `,` $phase `]` attr-dict
+    $aref `[` $index `]` attr-dict
     `:` type($aref) `->` type($results)
   }];
 }
@@ -80,9 +80,10 @@ def NVWS_ArefGetExitOp : NVWS_Op<"aref.get.exit"> {
                       These ArefGet "regions" can span multiple iterations. }];
 
   let arguments = (ins NVWS_ArefType:$aref,
-                       I32:$index);
+                       I32:$index,
+                       NVWS_AsyncOpArrayAttr:$async_ops);
   let assemblyFormat = [{
-    $aref `[` $index `]` attr-dict
+    $aref `[` $index `]` $async_ops attr-dict
     `:` type($aref)
  }];
 }
@@ -93,12 +94,11 @@ def NVWS_ArefPutEnterOp : NVWS_Op<"aref.put.enter"> {
                       These ArefPut "regions" can span multiple iterations. }];
 
   let arguments = (ins NVWS_ArefType:$aref,
-                       I32:$index,
-                       I32:$phase);
+                       I32:$index);
   let results = (outs Variadic<AnyType>:$results);
   let hasVerifier=1;
   let assemblyFormat = [{
-    $aref `[` $index `,` $phase `]` attr-dict
+    $aref `[` $index `]` attr-dict
     `:` type($aref) `->` type($results)
   }];
 }
@@ -109,9 +109,10 @@ def NVWS_ArefPutExitOp : NVWS_Op<"aref.put.exit"> {
                       These ArefPut "regions" can span multiple iterations. }];
 
   let arguments = (ins NVWS_ArefType:$aref,
-                       I32:$index);
+                       I32:$index,
+                       NVWS_AsyncOpArrayAttr:$async_ops);
   let assemblyFormat = [{
-    $aref `[` $index `]` attr-dict
+    $aref `[` $index `]` $async_ops attr-dict
     `:` type($aref)
  }];
 }
@@ -152,6 +153,22 @@ def NVWS_WarpGroupReturnOp : NVWS_Op<"warp_group.return", [
   }];
 
   let assemblyFormat = "attr-dict";
+}
+
+def NVWS_ArriveBarrierOp : NVWS_Op<"arrive_barrier", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+    let summary = "mbarrier.arrive or tcgen5.commit";
+
+    let description = [{
+      Lowers to mbarrier.arrive.shared.b64, cp.async.mbarrier.arrive.noinc or
+      tcgen05.commit depending on the value of commit.
+       * This op allows all threads to arrive
+       * It has an optional "arrive after a given async op completes" semantics.
+    }];
+
+    let hasVerifier = 1;
+    let arguments = (ins TTG_MemDescType:$alloc, NVWS_AsyncOpEnum:$async_op);
+    let assemblyFormat = [{ $alloc `,` `async_op` `=` $async_op attr-dict `:` type($alloc)
+    }];
 }
 
 def NVWS_CreateTokenOp : NVWS_Op<"create_token"> {

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -155,7 +155,7 @@ def NVWS_WarpGroupReturnOp : NVWS_Op<"warp_group.return", [
   let assemblyFormat = "attr-dict";
 }
 
-def NVWS_ArefCompleteOp : NVWS_Op<"aref_complete", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def NVWS_AsyncCompleteOp : NVWS_Op<"async_complete", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "mbarrier.arrive or tcgen5.commit";
 
   let description = [{

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -155,7 +155,7 @@ def NVWS_WarpGroupReturnOp : NVWS_Op<"warp_group.return", [
   let assemblyFormat = "attr-dict";
 }
 
-def NVWS_ArefCompleteOp : NVWS_Op<"arrive_barrier", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def NVWS_ArefCompleteOp : NVWS_Op<"aref_complete", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "mbarrier.arrive or tcgen5.commit";
 
   let description = [{

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSTypes.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSTypes.td
@@ -42,9 +42,8 @@ def NVWS_ArefType : NVWS_TypeDef<"Aref", "aref"> {
         as pipelining and warp specialization. Lowers to the underlying type, and
         operations that use this should insert appropriate barriers during lowering.
     }];
-  let parameters = (ins "TypeArrayAttr":$baseType,
-                         DefaultValuedParameter<"std::optional<int>", "0">:$numBatchAxes);
-  let assemblyFormat = "`<` $baseType (`,` $numBatchAxes^)? `>`";
+  let parameters = (ins "TypeArrayAttr":$baseType);
+  let assemblyFormat = "`<` $baseType `>`";
 }
 
 def NVWS_TokenType : NVWS_TypeDef<"Token", "token">;

--- a/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
@@ -5,6 +5,7 @@
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Utility.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 
@@ -140,18 +141,9 @@ void CreateTokenOp::build(::mlir::OpBuilder &builder,
   build(builder, state, resultType, num, loadType);
 }
 
-static LogicalResult
-verifyBarrierType(Operation *op, mlir::triton::gpu::MemDescType barrierType) {
-  if (!barrierType.getElementType().isInteger(64) ||
-      barrierType.getShape() != ArrayRef<int64_t>({1}))
-    return op->emitOpError(
-        "barrier allocation must be a descriptor of 1xi64 type");
-  return success();
-}
-
 // -- ArefCompleteOp --
 LogicalResult ArefCompleteOp::verify() {
-  if (failed(verifyBarrierType(*this, getAlloc().getType())))
+  if (failed(nvidia_gpu::verifyBarrierType(*this, getAlloc().getType())))
     return failure();
   return success();
 }

--- a/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
@@ -141,14 +141,14 @@ void CreateTokenOp::build(::mlir::OpBuilder &builder,
   build(builder, state, resultType, num, loadType);
 }
 
-// -- ArefCompleteOp --
-LogicalResult ArefCompleteOp::verify() {
+// -- AsyncCompleteOp --
+LogicalResult AsyncCompleteOp::verify() {
   if (failed(nvidia_gpu::verifyBarrierType(*this, getAlloc().getType())))
     return failure();
   return success();
 }
 
-void ArefCompleteOp::getEffects(
+void AsyncCompleteOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   effects.emplace_back(MemoryEffects::Read::get(), &getAllocMutable(),

--- a/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
@@ -149,14 +149,14 @@ verifyBarrierType(Operation *op, mlir::triton::gpu::MemDescType barrierType) {
   return success();
 }
 
-// -- ArriveBarrierOp --
-LogicalResult ArriveBarrierOp::verify() {
+// -- ArefCompleteOp --
+LogicalResult ArefCompleteOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))
     return failure();
   return success();
 }
 
-void ArriveBarrierOp::getEffects(
+void ArefCompleteOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   effects.emplace_back(MemoryEffects::Read::get(), &getAllocMutable(),

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -36,6 +36,7 @@
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "nvidia/include/Dialect/NVWS/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 using namespace mlir::triton;
@@ -55,28 +56,17 @@ namespace triton {
 
 namespace {
 
-struct ArefUseNode {
-  ArefUseNode *parent;
-  Operation *op;
-  SmallVector<ArefUseNode *> subOps;
-  bool containsAsync = false;
-};
+// ----------------------------------------------------------------------------
 
 struct ArefValue {
   Value emptyMbars;
   Value fullMbars;
   int depth;
-  SmallVector<ArefUseNode *> users;
-  SmallVector<Value> updatedValues;
+  SmallVector<Value> buffers;
 };
 
-struct ArefUseGraph {
-  llvm::MapVector<Operation *, ArefUseNode> nodes;
-  llvm::MapVector<Value, ArefValue> arefs;
-};
-
-MemDescType getMemDesc(PatternRewriter &rewriter, llvm::ArrayRef<int64_t> shape,
-                       Type intType) {
+MemDescType getBarrierMemDesc(PatternRewriter &rewriter,
+                              llvm::ArrayRef<int64_t> shape) {
   auto ctx = rewriter.getContext();
   Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
   auto barrierCTALayout = CTALayoutAttr::get(
@@ -84,265 +74,569 @@ MemDescType getMemDesc(PatternRewriter &rewriter, llvm::ArrayRef<int64_t> shape,
       /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
   auto barrierEncoding =
       SwizzledSharedEncodingAttr::get(ctx, 1, 1, 1, {0}, barrierCTALayout);
-  return MemDescType::get(shape, intType, barrierEncoding, sharedMemorySpace,
+  return MemDescType::get(shape, rewriter.getI64Type(), barrierEncoding,
+                          sharedMemorySpace,
                           /*mutableMemory=*/true);
 }
-MemDescType getBarrierMemDesc(PatternRewriter &rewriter,
-                              llvm::ArrayRef<int64_t> shape) {
-  return getMemDesc(rewriter, shape, rewriter.getI64Type());
-}
 
-Value getBarrierAt(PatternRewriter &rewriter, Location loc, Value mbars,
-                   Value idx) {
+Value getBarrier(PatternRewriter &rewriter, Location loc, Value mbars,
+                 Value idx) {
   auto memDesc = getBarrierMemDesc(rewriter, {1});
   return rewriter.create<triton::gpu::MemDescSubviewOp>(
       loc, memDesc, mbars, SmallVector<Value>{idx});
 }
 
-Value getBarrier(PatternRewriter &rewriter, Location loc, Value mBars,
-                 Value idx) {
-  return getBarrierAt(rewriter, loc, mBars, idx);
+Value getEmptyBarrier(PatternRewriter &rewriter, Location loc, ArefValue aref,
+                      Value arefIdx) {
+  // stage= arefIdx % depth
+  Value stage;
+  auto remsi = rewriter.create<arith::RemSIOp>(
+      loc, arefIdx, rewriter.create<arith::ConstantIntOp>(loc, aref.depth, 32));
+  remsi->setAttr("empty_mbar", rewriter.getUnitAttr());
+  stage = remsi;
+
+  return getBarrier(rewriter, loc, aref.emptyMbars, stage);
 }
 
-void waitOnMbar(PatternRewriter &rewriter, Location loc, Value mBars, Value idx,
-                Value phase) {
-  auto ctx = rewriter.getContext();
-  auto barrier = getBarrier(rewriter, loc, mBars, idx);
-  // wait on empty/full
-  auto waitOp =
-      rewriter.create<triton::nvidia_gpu::WaitBarrierOp>(loc, barrier, phase);
+Value getFullBarrier(PatternRewriter &rewriter, Location loc, ArefValue aref,
+                     Value arefIdx) {
+  Value stage;
+  auto remsi = rewriter.create<arith::RemSIOp>(
+      loc, arefIdx, rewriter.create<arith::ConstantIntOp>(loc, aref.depth, 32));
+  remsi->setAttr("full_mbar", rewriter.getUnitAttr());
+  stage = remsi;
+  return getBarrier(rewriter, loc, aref.fullMbars, stage);
 }
 
-void signalArrival(PatternRewriter &rewriter, Location loc, Value mBars,
-                   Value idx) {
-  // And a barrier arrive to signal completion of the region if none of the
-  // underlying ops are already async.
-  auto barrier = getBarrierAt(rewriter, loc, mBars, idx);
-  // wait on empty. Use a default phase for now, will rewrite later
-  rewriter.create<triton::nvidia_gpu::ArriveBarrierOp>(loc, barrier, 1);
+std::pair<WarpGroupOp, int> getWgIdx(Operation *op) {
+  if (auto wgOp = dyn_cast<WarpGroupOp>(op->getParentOp())) {
+    auto region = op->getParentRegion();
+    for (auto [idx, r] : llvm::enumerate(wgOp.getPartitionRegions())) {
+      if (&r == region)
+        return {wgOp, idx};
+    }
+    llvm_unreachable("op is not in any warp-group region");
+  }
+  if (isa<triton::FuncOp>(op))
+    return {nullptr, -1};
+  return getWgIdx(op->getParentOp());
+}
+
+std::pair<int, int> getArrivalCount(ArefCreateOp op) {
+  std::optional<int> producerArrivalCount, consumerArrivalCount;
+
+  for (auto user : op->getUsers()) {
+    auto [wgOp, idx] = getWgIdx(user);
+    auto numWarps = wgOp.getNumWarps()[idx];
+
+    if (auto putExitOp = dyn_cast<ArefPutExitOp>(user)) {
+      int count = 0;
+      for (auto prod : putExitOp.getAsyncOps()) {
+        auto kind = dyn_cast<AsyncOpAttr>(prod).getValue();
+        switch (kind) {
+        case AsyncOp::TC5MMA:
+        case AsyncOp::TMALoad:
+          count += 1;
+          break;
+        case AsyncOp::CpAsync:
+        case AsyncOp::NONE:
+          count += numWarps * 32;
+          break;
+        default:
+          llvm_unreachable("unknown producer kind");
+        }
+      }
+
+      if (producerArrivalCount) {
+        assert(*producerArrivalCount == count &&
+               "inconsistent producer arrival count");
+      } else {
+        producerArrivalCount = count;
+      }
+    } else if (auto getExitOp = dyn_cast<ArefGetExitOp>(user)) {
+      int count = 0;
+      for (auto consumer : getExitOp.getAsyncOps()) {
+        auto kind = dyn_cast<AsyncOpAttr>(consumer).getValue();
+        switch (kind) {
+        case AsyncOp::TC5MMA:
+          count += 1;
+          break;
+        case AsyncOp::NONE:
+        case AsyncOp::WGMMA:
+          count += numWarps * 32;
+          break;
+        default:
+          llvm_unreachable("unknown consumer kind");
+        }
+      }
+
+      if (consumerArrivalCount) {
+        assert(*consumerArrivalCount == count &&
+               "inconsistent consumer arrival count");
+      } else {
+        consumerArrivalCount = count;
+      }
+    }
+  }
+
+  assert(producerArrivalCount);
+  assert(consumerArrivalCount);
+
+  return {*producerArrivalCount, *consumerArrivalCount};
+}
+
+ArefValue createAndInitMbar(ArefCreateOp op, PatternRewriter &rewriter) {
+  auto [producerArrivalCount, consumerArrivalCount] = getArrivalCount(op);
+
+  MLIRContext *ctx = op.getContext();
+  auto loc = op.getLoc();
+  auto arefTy = op.getType();
+  auto baseType = arefTy.getBaseType();
+  auto arefBufTypes = llvm::to_vector(llvm::map_range(
+      arefTy.getBaseType(), [](Type type) { return cast<MemDescType>(type); }));
+  auto shape = arefBufTypes[0].getShape();
+  auto depth = shape[0];
+
+  MemDescType barrierMemDescType = getBarrierMemDesc(rewriter, {depth});
+  // Create two mbarriers
+  auto emptyMbars =
+      rewriter.create<LocalAllocOp>(loc, barrierMemDescType, Value());
+  emptyMbars->setAttr("aref_empty_mbarriers", rewriter.getUnitAttr());
+  auto fullMbars =
+      rewriter.create<LocalAllocOp>(loc, barrierMemDescType, Value());
+  fullMbars->setAttr("aref_full_mbarriers", rewriter.getUnitAttr());
+  auto lb = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
+  auto ub = rewriter.create<arith::ConstantIntOp>(loc, depth, 32);
+  auto step = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
+  auto dLoop = rewriter.create<scf::ForOp>(loc, lb, ub, step);
+  rewriter.setInsertionPointToStart(dLoop.getBody());
+
+  for (int i = 0; i < 2; ++i) {
+    auto mbars = i == 0 ? emptyMbars : fullMbars;
+    auto singleBarrier =
+        getBarrier(rewriter, loc, mbars, dLoop.getInductionVar());
+    int arrivalCount = i == 0 ? consumerArrivalCount : producerArrivalCount;
+    rewriter.create<InitBarrierOp>(loc, singleBarrier, arrivalCount);
+  }
+
+  return ArefValue{emptyMbars, fullMbars, static_cast<int>(depth),
+                   op.getOperands()};
+}
+
+SmallVector<Value> getSubViews(ArefValue arefVal, Value stage, Location loc,
+                               OpBuilder &rewriter) {
+  SmallVector<Value> views;
+  for (auto buffer : arefVal.buffers) {
+    SmallVector<Value> offsetsVal{stage};
+    auto memDescType = cast<MemDescType>(buffer.getType());
+    auto shape = memDescType.getShape();
+    auto rank = shape.size() - 1;
+
+    for (int i = 0; i < rank; ++i) {
+      offsetsVal.push_back(rewriter.create<arith::ConstantIntOp>(
+          loc, 0, rewriter.getIntegerType(32)));
+    }
+    SmallVector<int64_t> tensorShape(shape.begin() + 1, shape.end());
+    auto memDescTypeNew = MemDescType::get(
+        tensorShape, memDescType.getElementType(), memDescType.getEncoding(),
+        memDescType.getMemorySpace(), true);
+    Value singleBuffer = rewriter.create<MemDescSubviewOp>(loc, memDescTypeNew,
+                                                           buffer, offsetsVal);
+    views.push_back(singleBuffer);
+  }
+
+  return views;
+}
+
+void lowerAsyncLoads(ArefPutEnterOp op, PatternRewriter &rewriter,
+                     ArefValue arefVal) {
+  auto loc = op.getLoc();
+  // for now handle TMA loads in PutEnterOp
+  SmallVector<Operation *> loadOps;
+  for (auto result : op.getResults())
+    for (auto user : result.getUsers()) {
+      // Temporary workaround for lit testing: handle TMA loads here until a
+      // dedicated tma_load op is added to the NVWS dialect
+      if (user->getName().getStringRef() == "tma_load")
+        loadOps.push_back(user);
+    }
+  assert(loadOps.size() <= op.getResults().size());
+  if (loadOps.empty())
+    return;
+
+  // matching ArefPutExitOp is with ArefPutEnterOp
+  // we use aref_tag to match the two
+  //   %bufs:n = aref_put.enter %aref[%enter_idx] {aref_tag = tag}
+  //   tma_load %bufs[0]
+  //   ..
+  //   tma_load %bufs[n-1]
+  //   aref_put.exit %aref[%exit_idx] {aref_tag = tag}
+
+  // locate the matching aref_put.exit with the same tag, to get full barrier
+  ArefPutExitOp arefPutExitOp;
+  auto arefTag = op->getAttrOfType<StringAttr>("aref_tag").str();
+  for (auto user : op.getAref().getUsers()) {
+    if (auto exitOp = dyn_cast<ArefPutExitOp>(user)) {
+      if (exitOp->getAttrOfType<StringAttr>("aref_tag").str() == arefTag) {
+        arefPutExitOp = exitOp;
+        break;
+      }
+    }
+  }
+  assert(arefPutExitOp);
+  assert(arefPutExitOp.getAref() == op.getAref() &&
+         "Expecting matching Aref on the ArefPutExitOp");
+
+  Value fullBarrier =
+      getFullBarrier(rewriter, loc, arefVal, arefPutExitOp.getIndex());
+  Value pred = rewriter.create<arith::ConstantIntOp>(loc, 1, 1);
+  rewriter.create<triton::nvidia_gpu::BarrierExpectOp>(loc, fullBarrier, 0,
+                                                       pred);
+  return;
+}
+
+void waitOnBarrier(PatternRewriter &rewriter, Location loc, Value mbar,
+                   Value index, int depth, bool isPut, bool firstGet,
+                   std::string attrName) {
+  // phase = (index / depth) & 1
+  Operation *phase = rewriter.create<arith::DivSIOp>(
+      loc, index, rewriter.create<arith::ConstantIntOp>(loc, depth, 32));
+  phase->setAttr(attrName, rewriter.getUnitAttr());
+  phase = rewriter.create<arith::AndIOp>(
+      loc, phase->getResult(0),
+      rewriter.create<arith::ConstantIntOp>(loc, 1, 32));
+  phase->setAttr(attrName, rewriter.getUnitAttr());
+  if (isPut != firstGet) {
+    // If this is (isPut && !firstGet) or (!isPut && firstGet), we need to xor
+    // the phase with 1. In aref-tmem-insertion, put/get act as ping/pong for
+    // ownership transfer between two groups. When ownership is transferred
+    // between three groups via another aref, pong can be first to wait, so we
+    // need to xor the get phase instead of the put phase.
+    phase = rewriter.create<arith::XOrIOp>(
+        loc, phase->getResult(0),
+        rewriter.create<arith::ConstantIntOp>(loc, 1, 32));
+  }
+  phase->setAttr(attrName, rewriter.getUnitAttr());
+  rewriter.create<WaitBarrierOp>(loc, mbar, phase->getResult(0));
+}
+
+Value getStage(PatternRewriter &rewriter, Location loc, Value index, int depth,
+               std::string attrName) {
+  // stage = index % depth
+  Operation *stage = rewriter.create<arith::RemSIOp>(
+      loc, index, rewriter.create<arith::ConstantIntOp>(loc, depth, 32));
+  stage->setAttr(attrName, rewriter.getUnitAttr());
+  return stage->getResult(0);
+}
+
+LogicalResult rewritePutEnterOp(ArefCreateOp arefOp, ArefPutEnterOp op,
+                                PatternRewriter &rewriter, ArefValue arefVal) {
+  auto loc = op.getLoc();
+  rewriter.setInsertionPointAfter(op);
+
+  // get empty barrier at a given stage
+  Value emptyBarrier = getEmptyBarrier(rewriter, loc, arefVal, op.getIndex());
+
+  waitOnBarrier(rewriter, loc, emptyBarrier, op.getIndex(), arefVal.depth, true,
+                arefOp->hasAttr("first_get"), "put_phase");
+  Value stage =
+      getStage(rewriter, loc, op.getIndex(), arefVal.depth, "put_stage");
+  auto views = getSubViews(arefVal, stage, loc, rewriter);
+  assert(views.size() == op.getResults().size());
+
+  // TMA load need special handling as it requires fullMbarrier that
+  // we need to get from matching ArefPutExitOp
+  lowerAsyncLoads(op, rewriter, arefVal);
+
+  // replaces uses with views
+  for (int i = 0; i < arefVal.buffers.size(); ++i)
+    op.getResult(i).replaceAllUsesWith(views[i]);
+
+  return success();
+}
+
+LogicalResult rewriteGetEnterOp(ArefCreateOp arefOp, ArefGetEnterOp op,
+                                PatternRewriter &rewriter, ArefValue arefVal) {
+  auto loc = op.getLoc();
+  rewriter.setInsertionPointAfter(op);
+
+  Value fullBarrier = getFullBarrier(rewriter, loc, arefVal, op.getIndex());
+  waitOnBarrier(rewriter, loc, fullBarrier, op.getIndex(), arefVal.depth, false,
+                arefOp->hasAttr("first_get"), "get_phase");
+  Value stage =
+      getStage(rewriter, loc, op.getIndex(), arefVal.depth, "get_stage");
+  auto views = getSubViews(arefVal, stage, loc, rewriter);
+  assert(views.size() == op.getResults().size());
+
+  for (int i = 0; i < arefVal.buffers.size(); ++i)
+    op.getResult(i).replaceAllUsesWith(views[i]);
+
+  return success();
+}
+
+LogicalResult insertArriveBarrier(Location loc, ArrayAttr asyncOps,
+                                  PatternRewriter &rewriter, Value mbar) {
+
+  for (auto asyncOp : asyncOps) {
+    auto asyncOpEnum = cast<AsyncOpAttr>(asyncOp).getValue();
+    rewriter.create<nvws::ArriveBarrierOp>(loc, mbar, asyncOpEnum);
+  }
+
+  return success();
+}
+
+LogicalResult rewritePutExitOp(ArefPutExitOp op, PatternRewriter &rewriter,
+                               ArefValue arefVal) {
+  auto loc = op->getLoc();
+  rewriter.setInsertionPointAfter(op);
+  Value fullBarrier = getFullBarrier(rewriter, loc, arefVal, op.getIndex());
+  return insertArriveBarrier(loc, op.getAsyncOps(), rewriter, fullBarrier);
+}
+
+LogicalResult rewriteGetExitOp(ArefGetExitOp op, PatternRewriter &rewriter,
+                               ArefValue arefVal) {
+  auto loc = op->getLoc();
+  rewriter.setInsertionPointAfter(op);
+  Value emptyBarrier = getEmptyBarrier(rewriter, loc, arefVal, op.getIndex());
+  return insertArriveBarrier(loc, op.getAsyncOps(), rewriter, emptyBarrier);
 }
 
 class LowerArefCreate : public OpRewritePattern<ArefCreateOp> {
-  ArefUseGraph &graph;
-
 public:
   using OpRewritePattern::OpRewritePattern;
 
-  LowerArefCreate(mlir::MLIRContext *context, ArefUseGraph &graph)
-      : OpRewritePattern<ArefCreateOp>(context), graph(graph) {}
-
   LogicalResult matchAndRewrite(ArefCreateOp op,
                                 PatternRewriter &rewriter) const override {
-    if (graph.arefs.contains(op.getResult())) {
-      // We've already added the barriers for this op
-      return failure();
-    }
-    auto loc = op.getLoc();
-    auto ctx = op.getContext();
-    auto uses = op.getResult().getUses();
-    auto numBatches = op.getResult().getType().getNumBatchAxes();
-
-    int rank = 0;
-    if (numBatches)
-      rank = *numBatches;
-    if (rank > 1)
-      op.emitError("TODO: Implement multi-axis slicing");
-
-    int depth = 1;
-    if (rank == 1) {
-      if (auto mType = dyn_cast<MemDescType>(op.getOperand(0).getType()))
-        depth = mType.getShape()[0];
-      if (auto rType = dyn_cast<RankedTensorType>(op.getOperand(0).getType()))
-        depth = rType.getShape()[0];
-    }
-
-    rewriter.setInsertionPointAfter(op);
-    Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
-    auto barrierCTALayout = CTALayoutAttr::get(
-        /*context=*/ctx, /*CTAsPerCGA=*/{1},
-        /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
-    auto barrierEncoding =
-        SwizzledSharedEncodingAttr::get(ctx, 1, 1, 1, {0}, barrierCTALayout);
-    auto barrierType = MemDescType::get(
-        SmallVector<int64_t>{depth}, rewriter.getI64Type(), barrierEncoding,
-        sharedMemorySpace, /*mutableMemory=*/true);
-    // Create two mbarriers
-    auto emptyMbars = rewriter.create<LocalAllocOp>(loc, barrierType, Value());
-    emptyMbars->setAttr("aref_empty_mbarriers", rewriter.getUnitAttr());
-
-    auto fullMbars = rewriter.create<LocalAllocOp>(loc, barrierType, Value());
-    fullMbars->setAttr("aref_full_mbarriers", rewriter.getUnitAttr());
-
-    auto lb = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
-    auto ub = rewriter.create<arith::ConstantIntOp>(loc, depth, 32);
-    auto step = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
-    auto dLoop = rewriter.create<scf::ForOp>(loc, lb, ub, step);
-    rewriter.setInsertionPointToStart(dLoop.getBody());
-
-    for (int i = 0; i < 2; ++i) {
-      auto memDesc = getBarrierMemDesc(rewriter, {1});
-      auto singleBarrier = rewriter.create<triton::gpu::MemDescSubviewOp>(
-          loc, memDesc, i == 0 ? emptyMbars.getResult() : fullMbars.getResult(),
-          SmallVector<Value>{dLoop.getInductionVar()});
-      int count = i == 0 ? 0 : 1;
-      rewriter.create<InitBarrierOp>(loc, singleBarrier, count);
+    auto aref = createAndInitMbar(op, rewriter);
+    llvm::SmallSetVector<Operation *, 10> opToDelete;
+    opToDelete.insert(op.getOperation());
+    for (auto userOp : op->getUsers()) {
+      if (auto user = dyn_cast<ArefPutEnterOp>(userOp)) {
+        opToDelete.insert(user);
+        if (rewritePutEnterOp(op, user, rewriter, aref).failed())
+          return failure();
+      } else if (auto user = dyn_cast<ArefGetEnterOp>(userOp)) {
+        opToDelete.insert(user);
+        if (rewriteGetEnterOp(op, user, rewriter, aref).failed())
+          return failure();
+      } else if (auto user = dyn_cast<ArefPutExitOp>(userOp)) {
+        opToDelete.insert(user);
+        if (rewritePutExitOp(user, rewriter, aref).failed())
+          return failure();
+      } else if (auto user = dyn_cast<ArefGetExitOp>(userOp)) {
+        opToDelete.insert(user);
+        if (rewriteGetExitOp(user, rewriter, aref).failed())
+          return failure();
+      } else {
+        llvm_unreachable("users of aref can only be ArefPut or ArefGet");
+      }
     }
 
-    graph.arefs[op] =
-        ArefValue{emptyMbars.getResult(), fullMbars.getResult(), depth};
-    for (auto user : op.getResult().getUsers())
-      graph.arefs[op].users.push_back(&graph.nodes[user]);
+    for (auto it = opToDelete.rbegin(); it != opToDelete.rend(); ++it)
+      rewriter.eraseOp(*it);
 
     return success();
   }
 };
 
-template <bool put, typename T>
-LogicalResult LowerEnter(T op, PatternRewriter &rewriter, ArefUseGraph &graph) {
-  auto ctx = op.getContext();
-  auto loc = op.getLoc();
-  auto aref = op.getAref();
-  auto emptyMbars = graph.arefs[aref].emptyMbars;
-  auto fullMbars = graph.arefs[aref].fullMbars;
+// ----------------------------------------------------------------------------
 
-  rewriter.setInsertionPoint(op);
+template <class... Ts> struct ArefIndex;
+template <class T> struct ArefIndex<T> {
+  using ArefIndexMap = llvm::MapVector<Value /*aref*/, Value /*index*/>;
+  using ArefUseSet = llvm::SetVector<Value /*aref*/>;
 
-  auto zero = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
-  auto one = rewriter.create<arith::ConstantIntOp>(loc, 1, 32);
-
-  waitOnMbar(rewriter, loc, put ? emptyMbars : fullMbars, op.getIndex(),
-             op.getPhase());
-
-  SmallVector<Value> views;
-
-  // slice aref values
-  for (auto value : aref.template getDefiningOp<ArefCreateOp>().getOperands()) {
-    if (auto mType = dyn_cast<MemDescType>(value.getType())) {
-      auto shape = mType.getShape();
-      SmallVector<int64_t> tensorShape(shape.begin() + 1, shape.end());
-      auto memDescTypeNew =
-          MemDescType::get(tensorShape, mType.getElementType(),
-                           mType.getEncoding(), mType.getMemorySpace(), true);
-      SmallVector<Value> offsets(mType.getShape().size(), zero);
-      offsets[0] = op.getIndex();
-      Value singleBuffer = rewriter.create<triton::gpu::MemDescSubviewOp>(
-          loc, memDescTypeNew, value, offsets);
-      views.push_back(singleBuffer);
-    } else if (auto rType = dyn_cast<RankedTensorType>(value.getType())) {
-      return op.emitError("FIXME: In-register Tensors not yet supported");
-    } else {
-      return op.emitError("Aref input type not supported for slicing");
+  static ArefUseSet analyzeArefUseInBlock(Block *block, ArefUseSet arefUseSet) {
+    for (auto &op : *block) {
+      if (auto opT = dyn_cast<T>(op)) {
+        arefUseSet.insert(opT.getAref());
+      } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+        arefUseSet = analyzeArefUseInBlock(forOp.getBody(), arefUseSet);
+      } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        arefUseSet = analyzeArefUseInBlock(ifOp.thenBlock(), arefUseSet);
+        if (ifOp.elseBlock())
+          arefUseSet = analyzeArefUseInBlock(ifOp.elseBlock(), arefUseSet);
+      }
     }
+    return arefUseSet;
   }
 
-  if (op.getResults().size() != views.size())
-    return op.emitError("number of views and arguments mismatch.");
-  for (auto [ret, view] : zip(op.getResults(), views))
-    ret.replaceAllUsesWith(view);
+  static void assignArefIndexInForOp(scf::ForOp forOp,
+                                     ArefIndexMap &arefIndexMap) {
 
-  rewriter.eraseOp(op);
-  return success();
-}
-
-template <bool put, typename T>
-LogicalResult LowerExit(T op, PatternRewriter &rewriter, ArefUseGraph &graph) {
-  auto ctx = op.getContext();
-  auto loc = op.getLoc();
-  auto aref = op.getAref();
-  auto emptyMbars = graph.arefs[aref].emptyMbars;
-  auto fullMbars = graph.arefs[aref].fullMbars;
-
-  signalArrival(rewriter, loc, put ? fullMbars : emptyMbars, op.getIndex());
-  rewriter.eraseOp(op);
-  return success();
-}
-
-class LowerArefGetEnter : public OpRewritePattern<ArefGetEnterOp> {
-  ArefUseGraph &graph;
-
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  LowerArefGetEnter(mlir::MLIRContext *context, ArefUseGraph &graph)
-      : OpRewritePattern<ArefGetEnterOp>(context), graph(graph) {}
-
-  LogicalResult matchAndRewrite(ArefGetEnterOp op,
-                                PatternRewriter &rewriter) const override {
-    return LowerEnter<false>(op, rewriter, graph);
-  }
-};
-
-class LowerArefGetExit : public OpRewritePattern<ArefGetExitOp> {
-  ArefUseGraph &graph;
-
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  LowerArefGetExit(mlir::MLIRContext *context, ArefUseGraph &graph)
-      : OpRewritePattern<ArefGetExitOp>(context), graph(graph) {}
-
-  LogicalResult matchAndRewrite(ArefGetExitOp op,
-                                PatternRewriter &rewriter) const override {
-    return LowerExit<false>(op, rewriter, graph);
-  }
-};
-
-class LowerArefPutEnter : public OpRewritePattern<ArefPutEnterOp> {
-  ArefUseGraph &graph;
-
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  LowerArefPutEnter(mlir::MLIRContext *context, ArefUseGraph &graph)
-      : OpRewritePattern<ArefPutEnterOp>(context), graph(graph) {}
-
-  LogicalResult matchAndRewrite(ArefPutEnterOp op,
-                                PatternRewriter &rewriter) const override {
-    return LowerEnter<true>(op, rewriter, graph);
-  }
-};
-
-class LowerArefPutExit : public OpRewritePattern<ArefPutExitOp> {
-  ArefUseGraph &graph;
-
-public:
-  using OpRewritePattern::OpRewritePattern;
-
-  LowerArefPutExit(mlir::MLIRContext *context, ArefUseGraph &graph)
-      : OpRewritePattern<ArefPutExitOp>(context), graph(graph) {}
-
-  LogicalResult matchAndRewrite(ArefPutExitOp op,
-                                PatternRewriter &rewriter) const override {
-    return LowerExit<true>(op, rewriter, graph);
-  }
-};
-
-static ArefUseGraph analyzeArefUseDef(ModuleOp m) {
-  ArefUseGraph graph;
-  DenseSet<Operation *> seen;
-
-  ArefUseNode *parent = nullptr;
-  std::function<void(Operation * op)> createGraph;
-  // Psuedo recursion to get the dependency graph
-  createGraph = [&](Operation *op) {
-    if (seen.contains(op))
+    // find uses of arefs in forOp body
+    auto arefUseInBlock = analyzeArefUseInBlock(forOp.getBody(), {});
+    if (arefUseInBlock.empty())
       return;
-    ArefUseNode node;
-    node.parent = parent;
-    node.op = op;
-    if (isa<ArefCreateOp>(op)) {
-      graph.nodes[op] = node;
-    } else {
-      // TODO: Fill this out
-      return;
+
+    // add extra iterArgs to the forOp
+    SmallVector<Value> extraIterArgs;
+    SmallVector<Value *> arefIndexRefs;
+    for (auto aref : arefUseInBlock) {
+      extraIterArgs.push_back(arefIndexMap.lookup(aref));
+      arefIndexRefs.push_back(&arefIndexMap[aref]);
     }
-    seen.insert(op);
-  };
 
-  m.walk(createGraph);
+    // create new forOp with extra iterArgs
+    OpBuilder builder(forOp);
+    size_t nArgs = forOp.getRegionIterArgs().size();
+    forOp = addIterArgsToLoop(builder, forOp, extraIterArgs);
 
-  return graph;
-}
+    // update arefIndex with iterArgs in the forOp body
+    for (size_t idx = nArgs; idx < forOp.getRegionIterArgs().size(); ++idx)
+      *arefIndexRefs[idx - nArgs] = forOp.getRegionIterArgs()[idx];
+
+    // assign arefIndex in the forOp body
+    auto arefIndexMapInBlock =
+        assignArefIndexInBlock(forOp.getBody(), arefIndexMap);
+
+    // update yieldOp to return new indexes
+    SmallVector<Value> extraYieldArgs;
+    for (auto aref : arefUseInBlock)
+      extraYieldArgs.push_back(arefIndexMapInBlock[aref]);
+    appendToForOpYield(forOp, extraYieldArgs);
+
+    // update arefIndex with results from newForOp
+    for (size_t idx = nArgs; idx < forOp.getRegionIterArgs().size(); ++idx)
+      *arefIndexRefs[idx - nArgs] = forOp.getResult(idx);
+  }
+
+  static void assignArefIndexInIfOp(scf::IfOp ifOp,
+                                    ArefIndexMap &arefIndexMap) {
+
+    // find uses of aref in then-block
+    auto arefUseInIfOp = analyzeArefUseInBlock(ifOp.thenBlock(), {});
+    if (arefUseInIfOp.empty())
+      return;
+
+    // find uses of aref in else-block
+    arefUseInIfOp = ifOp.elseBlock()
+                        ? analyzeArefUseInBlock(ifOp.elseBlock(), arefUseInIfOp)
+                        : arefUseInIfOp;
+
+    // add extra results to the ifOp
+    SmallVector<Type> extraIfResults;
+    SmallVector<Value *> arefIndexRefs;
+    for (auto aref : arefUseInIfOp) {
+      extraIfResults.push_back(arefIndexMap.lookup(aref).getType());
+      arefIndexRefs.push_back(&arefIndexMap[aref]);
+    }
+
+    // create new ifOp with extra results
+    OpBuilder builder(ifOp);
+    size_t nArgs = ifOp.getResults().size();
+    auto newIfOp = replaceIfOpWithNewSignature(builder, ifOp, extraIfResults);
+
+    // assign arefIndex in then-body
+    auto arefIndexInThenBlock =
+        assignArefIndexInBlock(newIfOp.thenBlock(), arefIndexMap);
+
+    // assign arefIndex in else-body
+    auto arefIndexInElseBlock =
+        ifOp.elseBlock()
+            ? assignArefIndexInBlock(newIfOp.elseBlock(), arefIndexMap)
+            : arefIndexMap;
+
+    // update yieldOp to return new indexes
+    auto thenYieldOp = newIfOp.thenYield();
+    auto elseYieldOp = newIfOp.elseYield();
+    // insert new indexes to the yieldOp
+    for (auto aref : arefUseInIfOp) {
+      thenYieldOp->insertOperands(thenYieldOp.getNumOperands(),
+                                  arefIndexInThenBlock[aref]);
+      elseYieldOp->insertOperands(elseYieldOp.getNumOperands(),
+                                  arefIndexInElseBlock[aref]);
+    }
+    ifOp.erase();
+
+    // update arefIndex with results from newIfOp
+    for (size_t idx = nArgs; idx < newIfOp.getResults().size(); ++idx)
+      *arefIndexRefs[idx - nArgs] = newIfOp.getResult(idx);
+  }
+
+  static ArefIndexMap assignArefIndexInBlock(Block *block,
+                                             ArefIndexMap arefIndexMap) {
+    for (auto &op : llvm::make_early_inc_range(*block)) {
+      if (auto opT = dyn_cast<T>(op)) {
+        auto index = arefIndexMap.lookup(opT.getAref());
+        opT.getIndexMutable().assign(index);
+        OpBuilder builder(opT);
+        builder.setInsertionPointAfter(opT);
+        auto nextIndex = builder.create<arith::AddIOp>(
+            opT.getLoc(), index,
+            builder.create<arith::ConstantIntOp>(opT.getLoc(), 1, 32));
+        nextIndex->setAttr("next_aref_index", builder.getUnitAttr());
+        arefIndexMap[opT.getAref()] = nextIndex;
+      } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+        assignArefIndexInForOp(forOp, arefIndexMap);
+      } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        assignArefIndexInIfOp(ifOp, arefIndexMap);
+      }
+    }
+
+    return arefIndexMap;
+  }
+
+  static LogicalResult run(WarpGroupOp wgOp, std::string opName) {
+    // Verify that all puts and gets are in the same group; otherwise, the index
+    // would need to be communicated across groups, not currently supported.
+    Region *opRegion = {};
+
+    SetVector<Value> arefs;
+    wgOp.walk([&](T op) { arefs.insert(op.getAref()); });
+    for (auto aref : arefs) {
+      for (auto user : aref.getUsers()) {
+        if (isa<T>(user)) {
+          auto [wg, idx] = getWgIdx(user);
+          auto region = &wg.getPartitionRegions()[idx];
+          if (opRegion && opRegion != region) {
+            return mlir::emitWarning(user->getLoc(),
+                                     "All " + opName +
+                                         " must be in the same warp-group");
+          }
+          opRegion = region;
+        }
+      }
+    }
+
+    ArefUseSet arefUse;
+    for (auto region : wgOp.getRegions()) {
+      auto block = &region->getBlocks().front();
+      arefUse = analyzeArefUseInBlock(block, arefUse);
+    }
+
+    // initialize indexes
+    ArefIndexMap arefIndexMap;
+    for (auto aref : arefUse) {
+      OpBuilder builder(aref.getDefiningOp());
+      builder.setInsertionPointAfter(aref.getDefiningOp());
+      arefIndexMap[aref] =
+          builder.create<arith::ConstantIntOp>(aref.getLoc(), 0, 32);
+    }
+
+    for (auto region : wgOp.getRegions()) {
+      auto block = &region->getBlocks().front();
+      assignArefIndexInBlock(block, arefIndexMap);
+    }
+    return success();
+  }
+};
+
+template <> struct ArefIndex<> {
+  static LogicalResult run(WarpGroupOp wgOp) {
+    if (failed(ArefIndex<ArefPutEnterOp>::run(wgOp, "ArefPutEnterOp")))
+      return failure();
+    if (failed(ArefIndex<ArefPutExitOp>::run(wgOp, "ArefPutExitOp")))
+      return failure();
+    if (failed(ArefIndex<ArefGetEnterOp>::run(wgOp, "ArefGetEnterOp")))
+      return failure();
+    if (failed(ArefIndex<ArefGetExitOp>::run(wgOp, "ArefGetExitOp")))
+      return failure();
+    return success();
+  }
+};
+
+// ----------------------------------------------------------------------------
 
 } // anonymous namespace
 
@@ -352,26 +646,18 @@ public:
     MLIRContext *context = &getContext();
     mlir::ModuleOp m = getOperation();
 
-    ArefUseGraph graph = analyzeArefUseDef(m);
+    SmallVector<WarpGroupOp> wgOps;
+    m.walk([&](WarpGroupOp wgOp) { wgOps.push_back(wgOp); });
+    for (auto wgOp : wgOps) {
+      if (failed(ArefIndex<>::run(wgOp)))
+        signalPassFailure();
+    }
+    LLVM_DEBUG(llvm::dbgs() << "After arefIndexAssignment\n" << m << "\n");
 
     mlir::RewritePatternSet patterns(context);
-    patterns.add<LowerArefCreate>(context, graph);
+    patterns.add<LowerArefCreate>(context);
     GreedyRewriteConfig config;
-
     if (applyPatternsGreedily(m, std::move(patterns), config).failed())
-      signalPassFailure();
-
-    OpPassManager pm;
-    pm.addPass(mlir::createCSEPass());
-    if (failed(runPipeline(pm, m)))
-      return signalPassFailure();
-
-    mlir::RewritePatternSet patterns2(context);
-    patterns2.add<LowerArefGetEnter, LowerArefGetExit, LowerArefPutEnter,
-                  LowerArefPutExit>(context, graph);
-    GreedyRewriteConfig config2;
-
-    if (applyPatternsGreedily(m, std::move(patterns2), config2).failed())
       signalPassFailure();
   }
 };

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -335,7 +335,7 @@ LogicalResult insertArriveBarrier(Location loc, ArrayAttr asyncOps,
 
   for (auto asyncOp : asyncOps) {
     auto asyncOpEnum = cast<AsyncOpAttr>(asyncOp).getValue();
-    rewriter.create<nvws::ArefCompleteOp>(loc, mbar, asyncOpEnum);
+    rewriter.create<nvws::AsyncCompleteOp>(loc, mbar, asyncOpEnum);
   }
 
   return success();


### PR DESCRIPTION
* Update arefs ops to align with [`nvws`](https://github.com/triton-lang/triton/tree/aref_auto_ws) branch.
* Update lower_aref pass to:
    -  threads aref-index through control flow ops (aref-index is used to compute both stage and mbarrier phase)
    -  lowers arefs to mbarriers
    -  [TODO]: add support for `tma_load` aref lowering, and lowering `nvws::arrive_barrier` will be added in subsequent PRs enabling e2e functionality
* Updated lit-tests

cc: @masahi, @htyu, @manman-ren, @jeffniu-openai 


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
