### PR TITLE
[LAYOUTS] Fix memdesc_subviews when we don't slice along the swizzling pattern

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -15,7 +15,8 @@
 #include <unordered_map>
 
 // LinearLayoutCache Utils
-using CacheKey = std::tuple<std::vector<int64_t>, mlir::Attribute>;
+using CacheKey =
+    std::tuple<std::vector<int64_t>, mlir::Attribute, std::vector<int64_t>>;
 
 namespace llvm {
 template <typename T> size_t hash_value(const std::vector<T> &vec) {

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -47,7 +47,8 @@ class MemDescType;
 // elemBitWidth is the bit width of one element in the layout.  This is required
 // to compute the linear layout for MMAv3 (i.e. Hopper) shared layouts (i.e.
 // shared layouts with nvmma_shared layout) but is otherwise unused.
-LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout);
+LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout,
+                            ArrayRef<int64_t> allocationShape);
 LinearLayout toLinearLayout(RankedTensorType type);
 LinearLayout toLinearLayout(MemDescType type);
 LinearLayout toLinearLayout(TensorOrMemDesc type);

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
@@ -22,7 +22,7 @@ def TritonGPU_Dialect : Dialect {
   let extraClassDeclaration = [{
     void registerTypes();
 
-    LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout);
+    LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout, ArrayRef<int64_t> allocationShape);
     LinearEncodingAttr toLinearEncoding(ArrayRef<int64_t> shape, Attribute layout);
 
     static int getNumCTAs(ModuleOp mod);

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -325,7 +325,7 @@ private:
       bases;
 
   llvm::MapVector<StringAttr, int32_t /*size*/> outDims;
-  bool surjective = true;
+  int32_t rank = 0;
 
 public:
   using BasesT = decltype(bases);
@@ -425,10 +425,11 @@ public:
       ArrayRef<std::pair<StringAttr, std::vector<std::vector<int32_t>>>> bases,
       ArrayRef<std::pair<StringAttr, int32_t>> outDims, bool requireSurjective);
 
-  bool isSurjective() const { return surjective; }
+  bool isSurjective() const { return rank == getTotalOutDimSizeLog2(); }
+  bool isInjective() const { return rank == getTotalInDimSizeLog2(); }
 
   bool isInvertible() const {
-    return surjective && getTotalInDimSize() == getTotalOutDimSize();
+    return isSurjective() && getTotalInDimSize() == getTotalOutDimSize();
   }
 
   const BasesT &getBases() const { return bases; }

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -40,11 +40,13 @@ namespace {
 LinearLayout getRegToSharedLayout(MLIRContext *ctx, ArrayRef<int64_t> shape,
                                   LinearLayout regLayout,
                                   triton::gpu::SharedEncodingTrait dstEnc,
-                                  int elemBitWidth) {
+                                  int elemBitWidth,
+                                  ArrayRef<int64_t> allocShape) {
   StringAttr kBlock = StringAttr::get(ctx, ("block"));
   int rank = shape.size();
 
-  LinearLayout sharedLayout = triton::gpu::toLinearLayout(shape, dstEnc);
+  LinearLayout sharedLayout =
+      triton::gpu::toLinearLayout(shape, dstEnc, allocShape);
   auto sharedOrder = triton::gpu::getOrder(dstEnc, shape);
 
   // sharedLayout's in-dims are currently (offset, block).  Reshape to
@@ -378,7 +380,7 @@ emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
   MLIRContext *ctx = rewriter.getContext();
   auto shape = type.getShape();
 
-  LinearLayout ll = triton::gpu::toLinearLayout(shape, layout);
+  LinearLayout ll = triton::gpu::toLinearLayout(shape, layout, {});
 
   StringAttr kRegister = str_attr("register");
   StringAttr kLane = str_attr("lane");
@@ -503,7 +505,7 @@ SmallVector<Value> getSmemVecAddrVec(
                 sharedEnc)) {
       auto regToSharedSwizzledLayout =
           getRegToSharedLayout(ctx, shape, regLayout, swizzledSharedEnc,
-                               elemLlvmTy.getIntOrFloatBitWidth());
+                               elemLlvmTy.getIntOrFloatBitWidth(), allocShape);
       auto smemOrder = swizzledSharedEnc.getOrder();
 
       auto swizzledIndicesVec =
@@ -659,9 +661,9 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
   bool isStore = !valsArray.empty();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-  auto emitCpAsync = [&](ConversionPatternRewriter &rewriter, Location loc,
-                         ArrayRef<Value> vals, Value shmemAddr, int idx,
-                         VectorType vecTy) -> SmallVector<Value> {
+  auto emitLdSt = [&](ConversionPatternRewriter &rewriter, Location loc,
+                      ArrayRef<Value> vals, Value shmemAddr, int idx,
+                      VectorType vecTy) -> SmallVector<Value> {
     auto length = vecTy.getNumElements();
     if (isStore) {
       Value valsVec =
@@ -677,7 +679,7 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
     }
   };
   return lowerLdSt(loc, ctx, cvt, valsArray, llvmElemTy, smemBase, rewriter,
-                   targetInfo, {}, emitCpAsync);
+                   targetInfo, {}, emitLdSt);
 }
 
 SmallVector<Value> lowerLdSt(
@@ -859,11 +861,13 @@ bool emitTransferBetweenRegistersAndShared(
   auto allocShape = sharedTy.getAllocShape();
   auto invertAllocSharedLayout = LinearLayout::empty();
   if (!paddedLayout) {
-    // For now this is only needed for the cases where we have swizzling.
-    invertAllocSharedLayout =
-        triton::gpu::toLinearLayout(allocShape.take_back(sharedTy.getRank()),
-                                    sharedTy.getEncoding())
-            .pseudoinvert();
+    // This is the legacy way of doing things that's much more ad-hoc
+    // For generic shared layouts it may or may not be correct
+    auto allocShape = sharedTy.getAllocShape();
+    auto trimShape = allocShape.take_back(sharedTy.getRank());
+    invertAllocSharedLayout = triton::gpu::toLinearLayout(
+                                  trimShape, sharedTy.getEncoding(), trimShape)
+                                  .pseudoinvert();
   }
 
   int numElems = regToSharedLayout.getInDimSize(kRegister);
@@ -1473,7 +1477,7 @@ delinearize(RewriterBase &rewriter, Location loc,
             triton::gpu::DistributedEncodingTrait layout,
             ArrayRef<int64_t> shape, StringAttr dimName, Value linear) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  auto ll = triton::gpu::toLinearLayout(shape, layout);
+  auto ll = triton::gpu::toLinearLayout(shape, layout, {});
   auto linearLayout =
       triton::gpu::LinearEncodingAttr::get(rewriter.getContext(), ll);
   assert(ll.hasInDim(dimName));

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -471,35 +471,24 @@ struct MemDescSubviewOpConversion
     // newBase = base + offset
     auto smemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                    llvmElemTy, rewriter);
-    auto smemStrides = smemObj.getStrides(srcTy, loc, rewriter);
     SmallVector<Value> opOffsetVals = op.getOffsets();
     // We assume we always create a subview of the last dimensions
-    SmallVector<Value> opSmemStrides(smemStrides.end() - opOffsetVals.size(),
-                                     smemStrides.end());
     // Compute total offset
-    SmallVector<Value> offsetVals;
-    auto destRank = op.getResult().getType().getRank();
-    auto rankReduced = srcTy.getRank() - destRank;
-    for (int i = rankReduced; i < opOffsetVals.size(); i++) {
-      offsetVals.push_back(b.add(opOffsetVals[i], smemObj.getOffsets()[i]));
-    }
+    auto rankReduced = srcTy.getRank() - destTy.getRank();
 
     Value offset;
     if (rankReduced || (destTy.getRank() == 1 && destTy.getDimSize(0) == 1)) {
+      auto smemStrides = smemObj.getStrides(srcTy, loc, rewriter);
+      SmallVector<Value> opSmemStrides(smemStrides.end() - opOffsetVals.size(),
+                                       smemStrides.end());
       // We are splitting the pipelining dimension which may not be a power of 2
       // so we can't use LinearLayouts
       offset = dot(rewriter, loc, opOffsetVals, opSmemStrides);
     } else {
       auto dimNames = standardOutDimNames(ctx, opOffsetVals.size());
       SmallVector<std::pair<StringAttr, Value>> logicalOffsets;
-      // This assumes the subviews are additive, in the sense that we can
-      // compute the offset of one and an add it to the offset of the previous
-      // one we computed. We check for this in the verifier.
-      for (int i = 0; i < rankReduced; i++) {
-        logicalOffsets.push_back({dimNames[i], b.i32_val(0)});
-      }
-      for (int i = rankReduced; i < opOffsetVals.size(); i++) {
-        logicalOffsets.push_back({dimNames[i], offsetVals[i - rankReduced]});
+      for (auto [dim, offset] : llvm::zip(dimNames, opOffsetVals)) {
+        logicalOffsets.push_back({dim, offset});
       }
       auto ll = toLinearLayout(srcTy);
       // Checked in the verifier.
@@ -515,6 +504,11 @@ struct MemDescSubviewOpConversion
       // Apply padding based on the computed offset
       Value padOffset = emitPadding(loc, rewriter, paddedLayout, offset);
       offset = b.add(offset, padOffset);
+    }
+
+    SmallVector<Value> offsetVals;
+    for (int i = rankReduced; i < opOffsetVals.size(); i++) {
+      offsetVals.push_back(b.add(opOffsetVals[i], smemObj.getOffsets()[i]));
     }
 
     auto base = smemObj.getBase();

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -39,11 +39,14 @@ namespace gpu {
 
 LinearEncodingAttr TritonGPUDialect::toLinearEncoding(ArrayRef<int64_t> shape,
                                                       Attribute layout) {
-  CacheKey key{std::vector<int64_t>(shape.begin(), shape.end()), layout};
+  // LinearEncoding is a DistributedLayout
+  std::vector<int64_t> allocationShape;
+  CacheKey key{std::vector<int64_t>(shape.begin(), shape.end()), layout,
+               allocationShape};
   if (auto result = leCache.get(key)) {
     return *result;
   }
-  auto linearLayout = toLinearLayout(shape, layout);
+  auto linearLayout = toLinearLayout(shape, layout, {});
   auto linearEncoding =
       LinearEncodingAttr::get(layout.getContext(), std::move(linearLayout));
   leCache.set(key, linearEncoding);
@@ -2339,7 +2342,7 @@ struct TritonGPUInferLayoutInterface
       return success();
     }
 
-    auto ll = toLinearLayout(shape, operandEncoding);
+    auto ll = toLinearLayout(shape, operandEncoding, {});
     auto transposedLl = transposeLinearLayout(ll, order);
     resultEncoding = LinearEncodingAttr::get(ctx, std::move(transposedLl));
     return success();
@@ -2708,7 +2711,7 @@ struct TritonGPUInferLayoutInterface
       SmallVector<int64_t> joinedShape(shape);
       joinedShape.push_back(2);
       auto parent = enc.getParent();
-      auto parentLL = toLinearLayout(joinedShape, parent);
+      auto parentLL = toLinearLayout(joinedShape, parent, {});
 
       Attribute splitEnc;
       auto result = inferSplitOpEncoding(parent, splitEnc, joinedShape, loc);
@@ -2744,7 +2747,7 @@ struct TritonGPUInferLayoutInterface
     }
 
     // Append dim to shape
-    auto ll = toLinearLayout(shape, srcEnc);
+    auto ll = toLinearLayout(shape, srcEnc, {});
     SmallVector<int64_t> dstShape(shape.begin(), shape.end());
     dstShape.push_back(1);
     ll = ll.reshapeOuts(standardOutDimPairs(ctx, dstShape));
@@ -2800,7 +2803,7 @@ struct TritonGPUInferLayoutInterface
     auto ctx = getContext();
 
     // Split on last dim
-    auto ll = toLinearLayout(shape, srcEnc);
+    auto ll = toLinearLayout(shape, srcEnc, {});
     auto newLl = LinearLayout::empty();
     auto result =
         tryJoinOnAxis(ctx, ll, newLl, /*fwdInference=*/false, axis, loc);
@@ -2869,7 +2872,7 @@ struct TritonGPUInferLayoutInterface
       }
     }
 
-    auto ll = toLinearLayout(shape, inEnc);
+    auto ll = toLinearLayout(shape, inEnc, {});
     auto newLl = LinearLayout::empty();
     auto result = tryJoinOnAxis(ctx, ll, newLl, fwdInference, axis, loc);
     if (!result.succeeded())
@@ -3397,8 +3400,8 @@ int triton::gpu::lookupThreadsPerWarp(OpBuilder &rewriter) {
 bool triton::gpu::areLayoutsEquivalent(ArrayRef<int64_t> shape,
                                        DistributedEncodingTrait lhs,
                                        DistributedEncodingTrait rhs) {
-  auto lhsLL = triton::gpu::toLinearLayout(shape, lhs);
-  auto rhsLL = triton::gpu::toLinearLayout(shape, rhs);
+  auto lhsLL = triton::gpu::toLinearLayout(shape, lhs, {});
+  auto rhsLL = triton::gpu::toLinearLayout(shape, rhs, {});
   return lhsLL == rhsLL;
 }
 

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -122,6 +122,24 @@ LinearLayout combineCtaCgaWithShape(LinearLayout ctaLayout,
   return ret;
 }
 
+static LinearLayout memdescSubview(LinearLayout layout,
+                                   ArrayRef<int64_t> shape) {
+  // We remove the extra bases from the inverse of the layout and then invert it
+  // back This is sound as the initial layout is invertible so we don't lose any
+  // information in the process of inverting twice
+  auto inverse = layout.invert();
+  auto bases = inverse.getBases();
+  for (auto [s, dim] : llvm::zip(shape, inverse.getInDimNames())) {
+    auto &base = bases[dim];
+    base.resize(llvm::Log2_32(s));
+  }
+  auto subviewInv =
+      LinearLayout(bases, inverse.getOutDims(), /*requiresSurjective=*/false);
+  // subviewInv is injective but not surjective
+  // subviewInv.pseudoinvert() is surjective
+  return subviewInv.pseudoinvert();
+}
+
 LinearLayout swizzledSharedToLinearLayout(ArrayRef<int64_t> shape,
                                           SwizzledSharedEncodingAttr shared) {
   MLIRContext *ctx = shared.getContext();
@@ -1102,7 +1120,8 @@ LinearLayout SliceEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   // First compute the linear layout for this layout's parent.
   SmallVector<int64_t> parentShape(shape);
   parentShape.insert(parentShape.begin() + getDim(), 1);
-  LinearLayout parentLL = triton::gpu::toLinearLayout(parentShape, getParent());
+  LinearLayout parentLL =
+      triton::gpu::toLinearLayout(parentShape, getParent(), {});
 
   // Remove dimension getDim() from the parent layout.
   //
@@ -1141,9 +1160,12 @@ LinearLayout SliceEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
                       llvm::to_vector(sliceLL.getOutDimNames()));
 }
 
-LinearLayout TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape,
-                                              Attribute layout) {
-  CacheKey key{std::vector<int64_t>(shape.begin(), shape.end()), layout};
+LinearLayout
+TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape, Attribute layout,
+                                 ArrayRef<int64_t> allocationShape) {
+  CacheKey key{
+      std::vector<int64_t>(shape.begin(), shape.end()), layout,
+      std::vector<int64_t>(allocationShape.begin(), allocationShape.end())};
   if (auto result = llCache.get(key)) {
     return *result;
   }
@@ -1152,16 +1174,43 @@ LinearLayout TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape,
   // To add a new layout add an else-if clause
   LinearLayout result = LinearLayout::empty();
   if (auto distributed = dyn_cast<DistributedEncodingTrait>(layout)) {
+    assert(allocationShape.empty() &&
+           "allocationShape not supported for distributed layout");
     result = distributed.toLinearLayout(shape);
   } else {
+    assert(!allocationShape.empty() &&
+           "allocationShape not supported for shared layout");
+    // We allow the first dimension to not be a power of 2 to model pipelining
+    if (!llvm::isPowerOf2_32(allocationShape.front()) ||
+        allocationShape.size() > shape.size()) {
+      allocationShape = allocationShape.drop_front();
+    }
+    // We just allow memdesc_views of at most one dimension larger than shape
+    assert(
+        allocationShape.size() == shape.size() &&
+        "allocationShape must be the same size or at most one larger as shape");
+    assert(llvm::all_of(allocationShape,
+                        [](int64_t dim) {
+                          return llvm::isPowerOf2_32(dim) && dim >= 1;
+                        }) &&
+           "allocationShape must be a postive power of 2");
+    assert(llvm::all_of(llvm::zip(allocationShape, shape),
+                        [](auto dims) {
+                          return std::get<0>(dims) >= std::get<1>(dims);
+                        }) &&
+           "allocationShape must be at least as large as shape");
+
     if (auto shared = dyn_cast<SwizzledSharedEncodingAttr>(layout)) {
-      result = swizzledSharedToLinearLayout(shape, shared);
+      result = swizzledSharedToLinearLayout(allocationShape, shared);
     } else if (auto shared = dyn_cast<NVMMASharedEncodingAttr>(layout)) {
-      result = nvmmaSharedToLinearLayout(shape, shared);
+      result = nvmmaSharedToLinearLayout(allocationShape, shared);
     } else if (auto sbl = dyn_cast<AMDRotatingSharedEncodingAttr>(layout)) {
-      result = sharedToLinearLayoutAMDRotating(shape, sbl);
+      result = sharedToLinearLayoutAMDRotating(allocationShape, sbl);
     } else {
       assert(0 && "unknown layout");
+    }
+    if (shape != allocationShape) {
+      result = memdescSubview(result, shape);
     }
   }
 
@@ -1170,11 +1219,12 @@ LinearLayout TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape,
 }
 
 LinearLayout toLinearLayout(RankedTensorType type) {
-  return toLinearLayout(type.getShape(), type.getEncoding());
+  return toLinearLayout(type.getShape(), type.getEncoding(), {});
 }
 
 LinearLayout toLinearLayout(MemDescType type) {
-  return toLinearLayout(type.getShape(), type.getEncoding());
+  return toLinearLayout(type.getShape(), type.getEncoding(),
+                        type.getAllocShape());
 }
 
 LinearLayout toLinearLayout(TensorOrMemDesc type) {
@@ -1186,10 +1236,11 @@ LinearLayout toLinearLayout(TensorOrMemDesc type) {
   }
 }
 
-LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout) {
+LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout,
+                            ArrayRef<int64_t> allocationShape) {
   auto *ctx = layout.getContext();
-  return ctx->getLoadedDialect<TritonGPUDialect>()->toLinearLayout(shape,
-                                                                   layout);
+  return ctx->getLoadedDialect<TritonGPUDialect>()->toLinearLayout(
+      shape, layout, allocationShape);
 }
 
 LinearLayout getLayoutWithinBlock(const LinearLayout &layout) {

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -172,8 +172,9 @@ static Attribute inferSrcEncodingMemDescReshape(ArrayRef<int64_t> srcShape,
       mmaEncoding.getTransposed(), mmaEncoding.getElementBitWidth(),
       mmaEncoding.getFp4Padded(), CTALayout);
   // Big guns, check linear layouts are equivalent
-  auto srcLL = toLinearLayout(srcShape, srcEncoding);
-  auto dstLL = toLinearLayout(dstShape, dstEncoding);
+  auto allocShape = dstType.getAllocShape();
+  auto srcLL = toLinearLayout(srcShape, srcEncoding, allocShape);
+  auto dstLL = toLinearLayout(dstShape, dstEncoding, allocShape);
   auto ctx = dstEncoding.getContext();
   if (reshapeLayout(ctx, srcLL, dstShape) != dstLL) {
     return {};

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -310,10 +310,11 @@ mlir::triton::getDefiningOpAndDistance(scf::ForOp forOp, Value value) {
 
 int mlir::triton::getCopyVecBytes(RankedTensorType registerTy,
                                   ttg::SharedEncodingTrait sharedEnc) {
-  auto regLayout = triton::gpu::toLinearLayout(registerTy.getShape(),
-                                               registerTy.getEncoding());
-  auto sharedLayout =
-      triton::gpu::toLinearLayout(registerTy.getShape(), sharedEnc);
+  auto shape = registerTy.getShape();
+  auto regLayout =
+      triton::gpu::toLinearLayout(shape, registerTy.getEncoding(), {});
+  // FIXME: Here we should pass a MemDescType instead of a SharedEncodingTrait!!
+  auto sharedLayout = triton::gpu::toLinearLayout(shape, sharedEnc, shape);
   auto regToSharedLayout = regLayout.invertAndCompose(sharedLayout);
   const int vecElems = regToSharedLayout.getNumConsecutiveInOut();
   return vecElems * registerTy.getElementTypeBitWidth() / 8;

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -271,12 +271,11 @@ LinearLayout::checkInvariants(bool requireSurjective) {
   // the rank of our matrix using Gaussian elimination, which runs in O(n^3)
   // for an n x n matrix.  Our matrix size is sum(inDimSizeLog2) x
   // sum(outDimSizeLog2), so this should be plenty fast.
-  this->surjective =
+  this->rank =
       getMatrixRank(getMatrix(*this), /*numRows=*/getTotalOutDimSizeLog2(),
-                    /*numCols=*/getTotalInDimSizeLog2()) ==
-      getTotalOutDimSizeLog2();
+                    /*numCols=*/getTotalInDimSizeLog2());
 
-  if (requireSurjective && !surjective) {
+  if (requireSurjective && !isSurjective()) {
     return "Layout is expected to be surjective, i.e. every `out` coordinate "
            "can be reached by some `in` coordinate, but was not:" +
            toString();
@@ -404,7 +403,7 @@ LinearLayout LinearLayout::transposeIns(ArrayRef<StringAttr> newInDims) const {
     newBases[inDim] = bases.find(inDim)->second;
   }
   return LinearLayout(std::move(newBases), llvm::to_vector(outDims),
-                      surjective);
+                      isSurjective());
 }
 
 LinearLayout
@@ -432,7 +431,7 @@ LinearLayout::transposeOuts(ArrayRef<StringAttr> newOutDims) const {
   for (auto outDim : newOutDims) {
     newOutDimSizes.push_back({outDim, getOutDimSize(outDim)});
   }
-  return LinearLayout(std::move(newBases), newOutDimSizes, surjective);
+  return LinearLayout(std::move(newBases), newOutDimSizes, isSurjective());
 }
 
 LinearLayout LinearLayout::reshapeIns(
@@ -464,7 +463,7 @@ LinearLayout LinearLayout::reshapeIns(
     }
   }
   return LinearLayout(std::move(newBases), llvm::to_vector(outDims),
-                      surjective);
+                      isSurjective());
 }
 
 LinearLayout LinearLayout::reshapeOuts(
@@ -510,7 +509,7 @@ LinearLayout LinearLayout::reshapeOuts(
     }
   }
 
-  return LinearLayout(std::move(newBases), newOutDims, surjective);
+  return LinearLayout(std::move(newBases), newOutDims, isSurjective());
 }
 
 LinearLayout LinearLayout::concatIns(const LinearLayout &other) const {
@@ -956,9 +955,9 @@ std::unique_ptr<uint64_t[]> concatMatrices(const LinearLayout &A,
 }
 
 LinearLayout lstsq(const LinearLayout &A, const LinearLayout &B) {
-  // Solve the least square system AX = B for A = outer, B = *this
-  // and return the least square solution X of minimal norm
-  // A and B may not be surjective, but we assume that Im(B) \subset Im(A)
+  // Solve the system AX = B.
+  // We compute the solution X given by setting all the free variables to zero.
+  // If
   // Sketch of the algorithm:
   // https://github.com/triton-lang/triton/pull/5309#discussion_r1869084111
   int numRows = A.getTotalOutDimSizeLog2();
@@ -972,25 +971,31 @@ LinearLayout lstsq(const LinearLayout &A, const LinearLayout &B) {
   // Compute the pivot columns
   // Since A and B have the same image, each row will either have a pivot
   // or will be all zeros
-  SmallVector<int32_t> pivotCols;
+  SmallVector<int32_t> pivotRowOfCol(numColsA, -1);
   for (int r = 0; r < numRows; r++) {
     auto row = combinedMat[r];
     if (row == 0) {
       continue;
     }
     int c = __builtin_ctzll(row);
-    assert(c < numColsA && "Precondition broken. Im(B) not contained in Im(A)");
-    assert(pivotCols.empty() ||
-           pivotCols.back() < c && "Pivot columns are not in increasing order");
-    pivotCols.push_back(c);
+    // We have Im(A) \not\subset Im(B).
+    // In this case we don't return a solution of the system.
+    // If A is injective, we'll return A_L^{-1}B where A_L is the left inverse
+    // of A, namely A_L A = I.
+    if (c >= numColsA) {
+      continue;
+    }
+    assert(pivotRowOfCol[c] == -1 &&
+           "duplicate pivot => A not in RREF or not injective");
+    pivotRowOfCol[c] = r;
   }
 
   // Extract A^{-1}B and complete the matrix using zeros
   std::unique_ptr<uint64_t[]> retMat(new uint64_t[numColsA]());
-  int j = 0;
-  for (int r = 0; r < numColsA; r++) {
-    auto isPivot = j < pivotCols.size() && pivotCols[j] == r;
-    retMat[r] = isPivot ? combinedMat[j++] >> numColsA : 0;
+  for (int c = 0; c < numColsA; ++c) {
+    int row = pivotRowOfCol[c];
+    retMat[c] =
+        combinedMat[row] >> numColsA; // strip the A‑part, keep the B‑part
   }
 
   // We need names for the in/out dim of the flattened layout we're going to
@@ -1051,11 +1056,6 @@ LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
       llvm::report_fatal_error(msg.str().c_str());
     }
   }
-
-  // We'll write A^{-1} to mean the inverse or the pseudo-inverse of A
-  // We are computing A^{-1}B so A must be surjective so that
-  // it has a left inverse.
-  assert(A.isSurjective());
 
   // Broadcasting heuristic
   // Imagine we have two layouts with `warps = [[0, 0],  [0, 0]]`
@@ -1119,9 +1119,6 @@ LinearLayout LinearLayout::invert() const {
 }
 
 LinearLayout LinearLayout::pseudoinvert() const {
-  // A^-1(x) = A^-1(I(x)), thus A.invert() = I.invertAndCompose(A)
-  assert(isSurjective() &&
-         "A linear layout must be surjective to compute its pseudoinverse");
   LinearLayout identity = LinearLayout::empty();
   for (auto outDim : getOutDimNames()) {
     identity *= LinearLayout::identity1D(getOutDimSize(outDim), outDim, outDim);

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6331,15 +6331,15 @@ shared_layouts = [
 @pytest.mark.parametrize("M, N, M_tile_size, N_tile_size",
                          [[128, 128, 64, 64], [128, 128, 64, 32], [128, 64, 64, 32], [256, 128, 64, 64]])
 def test_split_subview(M, N, M_tile_size, N_tile_size, device='cuda'):
-    if not is_hip():
-        pytest.skip("the test is temporary disabled for the Nvidia backend.")
-
-    num_raws_per_warp = THREADS_PER_WARP // 4
-    num_repeats_M = int(M / M_tile_size)
-    num_repeats_N = int(N / N_tile_size)
+    if not is_hip() and N_tile_size == 32:
+        pytest.skip("Will fix spliting along the swizzling pattern in the next PR")
+    threads_per_warp = 64 if is_hip() else 32
+    num_rows_per_warp = threads_per_warp // 4
+    num_repeats_M = triton.cdiv(M, M_tile_size)
+    num_repeats_N = triton.cdiv(N, N_tile_size)
 
     ir = f"""
-    #blocked = #ttg.blocked<{{sizePerThread=[1, 8], threadsPerWarp=[{num_raws_per_warp}, 4], warpsPerCTA=[4, 1], order=[1, 0], CTAsPerCGA=[1, 1], CTASplitNum=[1, 1], CTAOrder=[0, 1]}}>
+    #blocked = #ttg.blocked<{{sizePerThread=[1, 8], threadsPerWarp=[{num_rows_per_warp}, 4], warpsPerCTA=[4, 1], order=[1, 0], CTAsPerCGA=[1, 1], CTASplitNum=[1, 1], CTAOrder=[0, 1]}}>
     #shared = #ttg.swizzled_shared<{{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0]}}>
     #smem = #ttg.shared_memory
 

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -356,7 +356,8 @@ TEST_F(Fp4ToFpOpTest, Fp4ToFpOpLayoutPropagation) {
           std::nullopt);
       EXPECT_TRUE(succeeded(result));
       // Structural equality.
-      EXPECT_EQ(toLinearLayout(shape, newSrcEnc), toLinearLayout(shape, enc));
+      EXPECT_EQ(toLinearLayout(shape, newSrcEnc, {}),
+                toLinearLayout(shape, enc, {}));
       // We'll have equality iff dstEnc is a legacy encoding.
       if (!isa<LinearEncodingAttr>(dstEnc)) {
         EXPECT_EQ(newSrcEnc, enc);
@@ -387,7 +388,8 @@ TEST_F(JoinOpTest, JoinOpLayoutPropagation) {
       }
       auto rank = shape.size();
       // Join only supports Linear or Blocked
-      auto linear = LinearEncodingAttr::get(&ctx, toLinearLayout(shape, enc));
+      auto linear =
+          LinearEncodingAttr::get(&ctx, toLinearLayout(shape, enc, {}));
       // Test that we can do a round trip from src to dst encoding and back.
       Attribute dstEnc;
       LogicalResult result = inferLayout->inferDefaultJoinOpEncoding(
@@ -400,7 +402,8 @@ TEST_F(JoinOpTest, JoinOpLayoutPropagation) {
                                                  std::nullopt);
       EXPECT_TRUE(succeeded(result));
       // Structural equality.
-      EXPECT_EQ(toLinearLayout(shape, newSrcEnc), toLinearLayout(shape, enc));
+      EXPECT_EQ(toLinearLayout(shape, newSrcEnc, {}),
+                toLinearLayout(shape, enc, {}));
       // We'll have equality iff dstEnc is a legacy encoding.
       if (!isa<LinearEncodingAttr>(dstEnc)) {
         EXPECT_EQ(newSrcEnc, enc);
@@ -436,8 +439,8 @@ TEST_F(JoinOpTest, JoinOpLayoutPropagation) {
       assert(succeeded(result));
       // The layouts should be structurally the same
       // but reshapeEnc will likely be a LinearEncodingAttr
-      EXPECT_EQ(toLinearLayout(newShape, reshapedEnc),
-                toLinearLayout(newShape, dstEnc));
+      EXPECT_EQ(toLinearLayout(newShape, reshapedEnc, {}),
+                toLinearLayout(newShape, dstEnc, {}));
     }
   }
 }


### PR DESCRIPTION
The previous way of handling `memdesc_subviews` in the context of
LinearLayouts was wrong.

Consider a shmem layout of 1D of a shmem with `64` elements of the form
```
A = {offset = [1, 2, 5, 10, 32, 16], {dim0=64}}
```
If we take a `subview` of A, we should get the layout
```
A_sub = {offset = [1, 2, 5, 10, 0, 16], {dim0=32}}
```
which maps the full shared memory onto a tensor with `32` elements. When
we take A_sub^{-1}B for `B` a distributed layout on a tensor of `32`
elements to load this layout it will give us the correct mapping on the
offsets, as expected.

This PR fixes this at large by passing the initial shape of the shared
memory, and then resizing in the creation of the `LinearLayout` the
layout. This shows what we already realised at an IR level, that
subviews effectively depend not only on the shape of the layout, but
also the initial shape of the shared_memory.

This PR also removes a number of hacks that worked around the issue above

To do this, we generalise `lstsq` to compute a left inverse of A in when
`A` is injective but its image is not a subset of that of `B`.

The case where we split along a dimension that's within the swizzling
pattern will be fixed in a follow-up PR.
