### PR TITLE
[AMD][BACKEND] Enable LDS transpose loading for fp4 packed along K types

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -213,14 +213,7 @@ private:
     auto bitwidth = typeConverter->convertType(dstTy.getElementType())
                         .getIntOrFloatBitWidth();
 
-    // Triton does not natively support the FP4 type, so it is packed and
-    // represented as an i8. Currently, the only way to distinguish FP4 from an
-    // actual int8 is by checking whether the localLoad is used in a scaled dot
-    // operation, as int8 is never used in one.
-    bool isFP4 = isUsedByDotScaledOp(localLoad) && bitwidth == 8 &&
-                 dstTy.getElementType().isInteger();
-
-    if (isFP4 || (bitwidth != 16 && bitwidth != 8)) {
+    if (bitwidth != 16 && bitwidth != 8) {
       return false;
     }
 


### PR DESCRIPTION
This was defensively disabled in a previous commit but has been verified to work fine.
FP4 when packed along K dimension needs to use ds_read_tr8 when loaded from shared memory and transpose is needed. This is because packing needs to stay the same so we need to operate on FP4 as if they were i8 types, this way we don't change the packing order.

Note: the LIT test that I've added is to show what the previous behaviour was in comparison to current. The code was explicitly checking dot_scaled usage so I've written the test to show the new behaviour based on that. Although new behaviour doesn't need to look at dot_scaled anymore.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
