### PR TITLE
[AMD] Enable General Swizzling ConvertLayoutOp

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -275,9 +275,8 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
     assert(cvtNeedsSharedMemory(op.getSrc().getType(), op.getType()));
 
     // Try to use swizzling to implement the conversion
-    // HACK Remove once AMD tests pass for the swizzling path
-    if (targetInfo.isCuda() && succeeded(transferWithinBlockSwizzling(
-                                   op, adaptor.getSrc(), rewriter))) {
+    if (succeeded(
+            transferWithinBlockSwizzling(op, adaptor.getSrc(), rewriter))) {
       return success();
     }
 

--- a/test/Conversion/amd/convert_layout.mlir
+++ b/test/Conversion/amd/convert_layout.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --convert-builtin-func-to-llvm | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 | FileCheck %s
 
 #blocked0 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 16], warpsPerCTA = [2, 2], order = [0, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
@@ -8,16 +8,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     // verify that following convert layout uses general swizzling
 
-    // CHECK-DAG: [[SMEM:%.*]] = llvm.mlir.addressof @global_smem
-    // CHECK-DAG: [[CST_0:%.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NOT: llvm.add
     // CHECK-COUNT-6: llvm.select
     // CHECK-NOT: llvm.add
-    // CHECK-DAG: [[OFFSET_0:%.*]] = llvm.xor
-    // CHECK-DAG: [[OFFSET_1:%.*]] = llvm.xor [[CST_0]], [[OFFSET_0]] : i32
-    // CHECK-DAG: [[OFFSET_2:%.*]] = llvm.xor [[OFFSET_1]], [[CST_0]] : i32
-    // CHECK-DAG: [[OFFSET_3:%.*]] = llvm.add [[OFFSET_2]], [[CST_0]] : i32
-    // CHECK-DAG: llvm.getelementptr inbounds [[SMEM]]{{\[}}[[OFFSET_3]]{{\]}}
+    // CHECK: [[OFFSET_0:%.*]] = llvm.xor
+    // CHECK: [[OFFSET_1:%.*]] = llvm.xor {{.*}}, [[OFFSET_0]] : i32
+    // CHECK: [[OFFSET_2:%.*]] = llvm.xor [[OFFSET_1]], {{.*}} : i32
+    // CHECK: [[OFFSET_3:%.*]] = llvm.add [[OFFSET_2]], {{.*}} : i32
+    // CHECK: llvm.getelementptr inbounds {{.*}}{{\[}}[[OFFSET_3]]{{\]}}
 
     %0 = ttg.convert_layout %arg0 : tensor<64x64xf32, #blocked0> -> tensor<64x64xf32, #blocked1>
     tt.store %arg1, %0 : tensor<64x64x!tt.ptr<f32>, #blocked1>
@@ -36,13 +34,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // verify that following convert layout uses padded path
     // see getVecAddr lambda in transferWithinBlockImpl function
 
-    // CHECK-DAG: [[SMEM:%.*]] = llvm.mlir.addressof @global_smem
-    // CHECK-DAG: [[CST_5:%.*]] = llvm.mlir.constant(5 : i32) : i32
-    // CHECK-DAG: [[CST_0:%.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-DAG: [[OFFSET_0:%.*]] = llvm.lshr {{.*}}, [[CST_5]] : i32
-    // CHECK-DAG: [[OFFSET_1:%.*]] = llvm.shl [[OFFSET_0]], [[CST_0]] : i32
-    // CHECK-DAG: [[OFFSET_2:%.*]] = llvm.add [[OFFSET_1]], {{.*}} : i32
-    // CHECK-DAG: llvm.getelementptr inbounds [[SMEM]]{{\[}}[[OFFSET_2]]{{\]}}
+    // CHECK: [[CST_5:%.*]] = llvm.mlir.constant(5 : i32) : i32
+    // CHECK: [[OFFSET_0:%.*]] = llvm.lshr {{.*}}, [[CST_5]] : i32
+    // CHECK: [[CST_0:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: [[OFFSET_1:%.*]] = llvm.shl [[OFFSET_0]], [[CST_0]] : i32
+    // CHECK: [[OFFSET_2:%.*]] = llvm.add [[OFFSET_1]], {{.*}} : i32
+    // CHECK: llvm.getelementptr inbounds {{.*}}{{\[}}[[OFFSET_2]]{{\]}}
 
     %0 = ttg.convert_layout %arg0 {amdgpu.use_padded_scratch_shmem} : tensor<64x64xf32, #blocked0> -> tensor<64x64xf32, #blocked1>
     tt.store %arg1, %0 : tensor<64x64x!tt.ptr<f32>, #blocked1>

--- a/test/Conversion/amd/convert_layout.mlir
+++ b/test/Conversion/amd/convert_layout.mlir
@@ -8,13 +8,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     // verify that following convert layout uses general swizzling
 
-    // CHECK: [[CST_128:%.*]] = llvm.mlir.constant(128 : i32) : i32
-    // CHECK: [[SEL:%.*]]= llvm.select {{.*}}, {{.*}}, [[CST_128]]
-    // CHECK: [[OFFSET_0:%.*]] = llvm.xor {{.*}}, [[SEL]]
-    // CHECK: [[OFFSET_1:%.*]] = llvm.xor {{.*}}, [[OFFSET_0]] : i32
-    // CHECK: [[OFFSET_2:%.*]] = llvm.xor [[OFFSET_1]], {{.*}} : i32
-    // CHECK: [[OFFSET_3:%.*]] = llvm.add [[OFFSET_2]], {{.*}} : i32
-    // CHECK: llvm.getelementptr inbounds {{.*}}{{\[}}[[OFFSET_3]]{{\]}}
+    // CHECK-NOT: llvm.lshr
 
     %0 = ttg.convert_layout %arg0 : tensor<64x64xf32, #blocked0> -> tensor<64x64xf32, #blocked1>
     tt.store %arg1, %0 : tensor<64x64x!tt.ptr<f32>, #blocked1>

--- a/test/Conversion/amd/convert_layout.mlir
+++ b/test/Conversion/amd/convert_layout.mlir
@@ -1,0 +1,51 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --convert-builtin-func-to-llvm | FileCheck %s
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 16], warpsPerCTA = [2, 2], order = [0, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK: llvm.mlir.global external @global_smem
+  tt.func @convert_layout_general_swizzling(%arg0: tensor<64x64xf32, #blocked0>, %arg1: tensor<64x64x!tt.ptr<f32>, #blocked1>) {
+
+    // verify that following convert layout uses general swizzling
+
+    // CHECK-DAG: [[SMEM:%.*]] = llvm.mlir.addressof @global_smem
+    // CHECK-DAG: [[CST_0:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-NOT: llvm.add
+    // CHECK-COUNT-6: llvm.select
+    // CHECK-NOT: llvm.add
+    // CHECK-DAG: [[OFFSET_0:%.*]] = llvm.xor
+    // CHECK-DAG: [[OFFSET_1:%.*]] = llvm.xor [[CST_0]], [[OFFSET_0]] : i32
+    // CHECK-DAG: [[OFFSET_2:%.*]] = llvm.xor [[OFFSET_1]], [[CST_0]] : i32
+    // CHECK-DAG: [[OFFSET_3:%.*]] = llvm.add [[OFFSET_2]], [[CST_0]] : i32
+    // CHECK-DAG: llvm.getelementptr inbounds [[SMEM]]{{\[}}[[OFFSET_3]]{{\]}}
+
+    %0 = ttg.convert_layout %arg0 : tensor<64x64xf32, #blocked0> -> tensor<64x64xf32, #blocked1>
+    tt.store %arg1, %0 : tensor<64x64x!tt.ptr<f32>, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [2, 2], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 16], warpsPerCTA = [2, 2], order = [0, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: convert_layout_padding_swizzling
+  tt.func @convert_layout_padding_swizzling(%arg0: tensor<64x64xf32, #blocked0>, %arg1: tensor<64x64x!tt.ptr<f32>, #blocked1>) {
+
+    // verify that following convert layout uses padded path
+    // see getVecAddr lambda in transferWithinBlockImpl function
+
+    // CHECK-DAG: [[SMEM:%.*]] = llvm.mlir.addressof @global_smem
+    // CHECK-DAG: [[CST_5:%.*]] = llvm.mlir.constant(5 : i32) : i32
+    // CHECK-DAG: [[CST_0:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG: [[OFFSET_0:%.*]] = llvm.lshr {{.*}}, [[CST_5]] : i32
+    // CHECK-DAG: [[OFFSET_1:%.*]] = llvm.shl [[OFFSET_0]], [[CST_0]] : i32
+    // CHECK-DAG: [[OFFSET_2:%.*]] = llvm.add [[OFFSET_1]], {{.*}} : i32
+    // CHECK-DAG: llvm.getelementptr inbounds [[SMEM]]{{\[}}[[OFFSET_2]]{{\]}}
+
+    %0 = ttg.convert_layout %arg0 {amdgpu.use_padded_scratch_shmem} : tensor<64x64xf32, #blocked0> -> tensor<64x64xf32, #blocked1>
+    tt.store %arg1, %0 : tensor<64x64x!tt.ptr<f32>, #blocked1>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUsage.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUsage.cpp
@@ -100,8 +100,8 @@ class OptimizeAMDLDSUsage
 
     if (!cvtOp->hasAttr(triton::AMD::AttrSharedMemPadded)) {
       auto emptyAttribute = UnitAttr::get(ctx);
-      // Padded conversion seems more friendly with this optimization use it
-      // instead of general swizzling.
+      // Padded conversion seems more friendly with this optimization
+      // use it instead of general swizzling.
       cvtOp->setAttr(triton::AMD::AttrSharedMemPadded, emptyAttribute);
       // if padded layout drops LDS usage on itself, we are done, return
       if (triton::AMD::getConvertLayoutScratchInBytes(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUsage.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUsage.cpp
@@ -94,15 +94,26 @@ class OptimizeAMDLDSUsage
     LDBG("Trying fit " << cvtOp << " into " << targetLDSSize << " bytes");
     OpBuilder builder(cvtOp);
 
+    auto ctx = builder.getContext();
     auto srcType = cvtOp.getSrc().getType();
     auto dstType = cvtOp.getType();
+
+    if (!cvtOp->hasAttr(triton::AMD::AttrSharedMemPadded)) {
+      auto emptyAttribute = UnitAttr::get(ctx);
+      // Padded conversion seems more friendly with this optimization use it
+      // instead of general swizzling.
+      cvtOp->setAttr(triton::AMD::AttrSharedMemPadded, emptyAttribute);
+      // if padded layout drops LDS usage on itself, we are done, return
+      if (triton::AMD::getConvertLayoutScratchInBytes(
+              srcType, dstType, /*usePadding*/ true) <= targetLDSSize)
+        return;
+    }
 
     auto srcEnc =
         cast<triton::gpu::DistributedEncodingTrait>(srcType.getEncoding());
     auto dstEnc =
         cast<triton::gpu::DistributedEncodingTrait>(dstType.getEncoding());
 
-    auto ctx = srcEnc.getContext();
     auto rank = srcType.getRank();
 
     unsigned numWarps = triton::gpu::lookupNumWarps(cvtOp);
@@ -243,13 +254,6 @@ public:
       triton::AMD::TargetInfo targetInfo(this->targetArch.c_str());
       LDSLimit = targetInfo.getSharedMemorySize();
     }
-
-    auto context = mod.getContext();
-    auto emptyAttribute = UnitAttr::get(context);
-    // TODO choose between padded and swizzled memory patterns
-    mod.walk([emptyAttribute](triton::gpu::ConvertLayoutOp op) -> void {
-      op->setAttr(mlir::triton::AMD::AttrSharedMemPadded, emptyAttribute);
-    });
 
     ModuleAllocation allocAnalysis(
         mod, mlir::triton::AMD::AMDAllocationAnalysisScratchSizeFn);


### PR DESCRIPTION
This PR:
- Enables ConvertLayoutOp general swizzling for AMD
- Introduces simple heuristic in OptimizeLDSUsage so we use padding based swizzling only if it is required to reduce LDS consumption
- Adds AMD specific ttg->llvm conversion pattern to process forced padding separately from general swizzling
