### PR TITLE
[PROTON-DEV] Enable Triton semantic for `trace_gen.py`

### DIFF
--- a/third_party/proton/test/unittest/util/trace_gen.py
+++ b/third_party/proton/test/unittest/util/trace_gen.py
@@ -5,6 +5,8 @@ import triton.profiler as proton
 import triton.profiler.language as pl
 from triton.profiler.hooks import InstrumentationHook
 
+pl.enable_semantic("triton")
+
 
 def write_tensor_to_file(tensor, filename):
     data_ptr = tensor.data_ptr()


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/7475 enforced Gluon semantic to be enabled by default, which results in the following error:

```py
def loop_kernel():
    for k in range(0, 20):
        pl.enter_scope("r0")
        ^
Unsupported semantic type: <class 'triton.language.semantic.TritonSemantic'>. Supported semantics are: {<class 'triton.experimental.gluon.language._semantic.GluonSemantic'>}
```

This PR attempts to fix that. 