### PR TITLE
[FRONTEND] Fix PyFloat_Pack2 casting

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -470,9 +470,9 @@ static uint16_t pack_fp16(double f) {{
     uint16_t result;
     // from https://github.com/python/pythoncapi-compat
 #if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 && !defined(PYPY_VERSION)
-    _PyFloat_Pack2(f, (void*)&result, 1);
+    _PyFloat_Pack2(f, (unsigned char*)&result, 1);
 #else
-    PyFloat_Pack2(f, (void*)&result, 1);
+    PyFloat_Pack2(f, (unsigned char*)&result, 1);
 #endif
     return result;
 }}

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -475,9 +475,9 @@ static uint16_t pack_fp16(double f) {{
     uint16_t result;
     // from https://github.com/python/pythoncapi-compat
 #if 0x030600B1 <= PY_VERSION_HEX && PY_VERSION_HEX <= 0x030B00A1 && !defined(PYPY_VERSION)
-    _PyFloat_Pack2(f, (void*)&result, 1);
+    _PyFloat_Pack2(f, (unsigned char*)&result, 1);
 #else
-    PyFloat_Pack2(f, (void*)&result, 1);
+    PyFloat_Pack2(f, (unsigned char*)&result, 1);
 #endif
     return result;
 }}


### PR DESCRIPTION
Fix issue found by @anmyachev  at https://github.com/triton-lang/triton/pull/7439

> Should it be like: `_PyFloat_Pack2(f, (unsigned char *)&result, 1);`? (this is how it is implemented in https://github.com/python/pythoncapi-compat/blob/b541b98df1e3e5aabb5def27422a75c876f5a88a/pythoncapi_compat.h#L488)
> 
> I see the following issue with current approach:
> 
> ```shell
> python/test/unit/language/test_annotations.py /tmp/tmp9qfrehja/main.cpp:148:5: error: no matching function for call to '_PyFloat_Pack2'
>   148 |     _PyFloat_Pack2(f, (void*)&result, 1);
>       |     ^~~~~~~~~~~~~~
> /home/jovyan/.conda/envs/xpu/include/python3.10/floatobject.h:87:17: note: candidate function not viable: cannot convert argument of incomplete type 'void *' to
>       'unsigned char *' for 2nd argument
>    87 | PyAPI_FUNC(int) _PyFloat_Pack2(double x, unsigned char *p, int le);
>       |                 ^                        ~~~~~~~~~~~~~~~~
> 1 error generated.
> ```

