### PR TITLE
[Gluon] Broadcast auto with concrete layouts

### DIFF
--- a/include/triton/Dialect/Gluon/Transforms/Passes.td
+++ b/include/triton/Dialect/Gluon/Transforms/Passes.td
@@ -11,4 +11,28 @@ def GluonResolveAutoEncodingsPass : Pass<"gluon-resolve-auto-encodings", "mlir::
 
 }
 
+def GluonCanonicalize: Pass<"gluon-canonicalize"> {
+  let summary = "reduced set of simplifications for TTGIR";
+
+  let description = [{
+    The `gluon-canonicalize` pass applies a reduced set of simplification
+    and canonicalization patterns to the module.
+  }];
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::cf::ControlFlowDialect",
+    "mlir::scf::SCFDialect",
+  ];
+}
+
+def GluonInline: Pass<"gluon-inline"> {
+  let summary = "reduced set of simplifications for TTGIR";
+
+  let description = [{
+    The `gluon-inline` pass applies a reduced set of simplification
+    and canonicalization patterns to the module.
+  }];
+  let dependentDialects = [];
+}
+
 #endif

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -360,18 +360,4 @@ def TritonGPUCoalesceAsyncCopy: Pass<"tritongpu-coalesce-async-copy", "mlir::Mod
                            "mlir::triton::TritonDialect"];
 }
 
-def TritonGPUCanonicalize: Pass<"tritongpu-canonicalize"> {
-  let summary = "reduced set of simplifications for TTGIR";
-
-  let description = [{
-    The `tritongpu-canonicalize` pass applies a reduced set of simplification
-    and canonicalization patterns to the module.
-  }];
-  let dependentDialects = [
-    "mlir::arith::ArithDialect",
-    "mlir::cf::ControlFlowDialect",
-    "mlir::scf::SCFDialect",
-  ];
-}
-
 #endif

--- a/lib/Dialect/Gluon/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Gluon/Transforms/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_triton_library(GluonTransforms
+  Canonicalize.cpp
+  Inline.cpp
   ResolveAutoEncodings.cpp
 
   DEPENDS

--- a/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
+++ b/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
@@ -1,25 +1,28 @@
+#include "triton/Dialect/Gluon/Transforms/Passes.h"
+
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "triton/Dialect/TritonGPU/IR/Dialect.h"
-#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
-#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 using namespace mlir;
 using namespace triton;
 namespace ttg = triton::gpu;
 namespace ttng = triton::nvidia_gpu;
+namespace gluon = mlir::triton::gluon;
 
-namespace mlir::triton::gpu {
-#define GEN_PASS_DEF_TRITONGPUCANONICALIZE
-#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
-} // namespace mlir::triton::gpu
+namespace mlir::triton::gluon {
+#define GEN_PASS_DEF_GLUONCANONICALIZE
+#include "triton/Dialect/Gluon/Transforms/Passes.h.inc"
+} // namespace mlir::triton::gluon
 
 namespace {
-struct Canonicalize
-    : public ttg::impl::TritonGPUCanonicalizeBase<Canonicalize> {
+struct Canonicalize : public gluon::impl::GluonCanonicalizeBase<Canonicalize> {
   void runOnOperation() override;
 };
 } // namespace

--- a/lib/Dialect/Gluon/Transforms/Inline.cpp
+++ b/lib/Dialect/Gluon/Transforms/Inline.cpp
@@ -1,0 +1,29 @@
+#include "triton/Dialect/Gluon/Transforms/Passes.h"
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+
+using namespace mlir;
+using namespace triton;
+namespace gluon = mlir::triton::gluon;
+
+namespace mlir::triton::gluon {
+#define GEN_PASS_DEF_GLUONINLINE
+#include "triton/Dialect/Gluon/Transforms/Passes.h.inc"
+} // namespace mlir::triton::gluon
+
+namespace {
+struct Inline : public gluon::impl::GluonInlineBase<Inline> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void Inline::runOnOperation() {
+  mlir::PassManager pm(&getContext());
+  pm.addPass(createInlinerPass(/*opPipelines=*/{}, [](OpPassManager &pm) {
+    pm.addPass(gluon::createGluonCanonicalize());
+  }));
+  if (failed(pm.run(getOperation())))
+    return signalPassFailure();
+}

--- a/lib/Dialect/Gluon/Transforms/ResolveAutoEncodings.cpp
+++ b/lib/Dialect/Gluon/Transforms/ResolveAutoEncodings.cpp
@@ -121,9 +121,12 @@ LogicalResult inferAutoLayouts(FuncOp func) {
       } else {
         auto srcEncoding = inferSrcEncoding(definingOp, enc);
         if (srcEncoding) {
-          if (failed(updateEncoding(
-                  llvm::to_vector_of<Value>(definingOp->getOperands()),
-                  srcEncoding)))
+          llvm::SmallVector<Value> tensorOperands;
+          for (auto operand : definingOp->getOperands())
+            if (isa<RankedTensorType>(operand.getType()))
+              tensorOperands.push_back(operand);
+
+          if (failed(updateEncoding(tensorOperands, srcEncoding)))
             return failure();
         }
       }

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_triton_library(TritonGPUTransforms
   AccelerateMatmul.cpp
-  Canonicalize.cpp
   Coalesce.cpp
   F32DotTC.cpp
   FuseNestedLoops.cpp

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -89,12 +89,6 @@ void init_triton_passes_ttgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_fuse_nested_loops", createTritonGPUFuseNestedLoops);
   ADD_PASS_WRAPPER_0("add_coalesce_async_copy",
                      createTritonGPUCoalesceAsyncCopy);
-  ADD_PASS_WRAPPER_0("add_canonicalizer", createTritonGPUCanonicalize);
-  ADD_PASS_WRAPPER_0("add_inliner", [] {
-    return createInlinerPass(/*opPipelines=*/{}, [](OpPassManager &pm) {
-      pm.addPass(createTritonGPUCanonicalize());
-    });
-  });
   ADD_PASS_WRAPPER_0("add_concurrency_sanitizer",
                      createTritonInstrumentConcurrencySanitizer);
 }
@@ -117,6 +111,8 @@ void init_gluon_passes(py::module &&m) {
   namespace gluon = mlir::triton::gluon;
   ADD_PASS_WRAPPER_0("add_resolve_auto_encodings",
                      gluon::createGluonResolveAutoEncodingsPass);
+  ADD_PASS_WRAPPER_0("add_canonicalizer", gluon::createGluonCanonicalize);
+  ADD_PASS_WRAPPER_0("add_inliner", gluon::createGluonInline);
 }
 
 void init_triton_passes(py::module &&m) {

--- a/python/triton/_filecheck.py
+++ b/python/triton/_filecheck.py
@@ -42,8 +42,9 @@ def run_filecheck(name, module_str, check_template):
             temp.write(check_template)
 
         try:
-            subprocess.check_output([filecheck_path, temp_expected, "--input-file", temp_module],
-                                    stderr=subprocess.STDOUT)
+            subprocess.check_output(
+                [filecheck_path, temp_expected, "--input-file", temp_module, "--dump-input-context=50"],
+                stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as error:
             decoded = error.output.decode('unicode_escape')
             raise ValueError(decoded)
@@ -60,8 +61,10 @@ def run_parser(kernel_fn):
     ir.load_dialects(context)
     stub_backend.load_dialects(context)
 
-    extra_options = src.parse_options()
-    options = stub_backend.parse_options(dict(**extra_options))
+    options = dict(sanitize_overflow=False)
+    options.update(src.parse_options())
+
+    options = stub_backend.parse_options(options)
     codegen_fns = stub_backend.get_codegen_implementation(options)
     module_map = stub_backend.get_module_map()
     module = src.make_ir(options, codegen_fns, module_map, context)

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -43,6 +43,7 @@ from triton.language.core import (
 )
 
 _IMPORT_FROM_TRITON: List[str] = [
+    "broadcast",
     "expand_dims",
     "inline_asm_elementwise",
     "join",
@@ -341,14 +342,14 @@ for name in _IMPORT_FROM_TRITON:
 
 
 @builtin
-def arange(start, end, layout, _semantic=None):
+def arange(start, end, layout=None, _semantic=None):
     """
     Generate a sequence tensor with values in [start, end) using a specified layout.
 
     Args:
         start (int): Inclusive start of the sequence.
         end (int): Exclusive end of the sequence.
-        layout (DistributedLayout): The layout of the output tensor.
+        layout (DistributedLayout): The layout of the output tensor. Defaults to AutoLayout.
 
     Returns:
         tensor: A 1D tensor containing sequential values.

--- a/test/Gluon/auto_encoding.mlir
+++ b/test/Gluon/auto_encoding.mlir
@@ -96,3 +96,23 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
     tt.return %cvt : tensor<32xi32, #blocked>
   }
 }
+
+
+// -----
+
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @infer_make_range() -> tensor<16xi32, #blocked> {
+    // CHECK-DAG: [[BLOCKED:#.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+    // CHECK: [[CST:%.*]] = arith.constant 0 : i32
+    // CHECK: [[SPLAT: %.*]] = tt.splat [[CST]] : i32 -> tensor<16xi32, [[BLOCKED]]>
+    // CHECK: [[RES:%.*]] = ttg.convert_layout [[RANGE]] : tensor<16xi32, [[BLOCKED]]> -> tensor<16xi32, [[BLOCKED]]>
+    // CHECK: tt.return [[RES]] : tensor<16xi32, [[BLOCKED]]>
+    %cst = arith.constant 0 : i32
+    %0 = tt.splat %cst : i32 -> tensor<16xi32, #gluon.auto_encoding>
+    %cvt = ttg.convert_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked>
+    tt.return %cvt : tensor<16xi32, #blocked>
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -270,11 +270,11 @@ class HIPBackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
 
-        passes.ttgpuir.add_inliner(pm)
+        passes.gluon.add_inliner(pm)
         passes.gluon.add_resolve_auto_encodings(pm)
         passes.common.add_sccp(pm)
         passes.ttir.add_loop_aware_cse(pm)
-        passes.ttgpuir.add_canonicalizer(pm)
+        passes.gluon.add_canonicalizer(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
 
         pm.run(mod)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -314,11 +314,11 @@ class CUDABackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
 
-        passes.ttgpuir.add_inliner(pm)
+        passes.gluon.add_inliner(pm)
         passes.gluon.add_resolve_auto_encodings(pm)
         passes.common.add_sccp(pm)
         passes.ttir.add_loop_aware_cse(pm)
-        passes.ttgpuir.add_canonicalizer(pm)
+        passes.gluon.add_canonicalizer(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
 
         pm.run(mod)


### PR DESCRIPTION
<git-pr-chain>


[Gluon] Broadcast auto with concrete layouts

This also makes `arange` return auto layout by default, so you can do
for example:
```python
xidx = gl.arange(0, 32)[:, None]
yidx = gl.arange(0, 16)[None, :]
off = xidx * x_stride + yidx * y_stride
off = gl.convert_layout(off, concrete_layout)
```

I also fixed `filecheck_test` to disable the overflow sanitizer, as it
can cause lit tests to fail if the check statements match with the
overflow sanitizer ops.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. #7489
1. #7490
1. 👉 #7491 👈 **YOU ARE HERE**

⚠️⚠️ Please **do not click the green "merge" button** unless you know what
you're doing.  This PR is part of a chain of PRs, and clicking the merge
button will not merge it into master. ⚠️⚠️ 
</git-pr-chain>





