### PR TITLE
[Gluon] Add dedicated set_auto_layout op

### DIFF
--- a/include/triton/Dialect/Gluon/IR/CMakeLists.txt
+++ b/include/triton/Dialect/Gluon/IR/CMakeLists.txt
@@ -1,16 +1,17 @@
 set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
 
+set(LLVM_TARGET_DEFINITIONS GluonOps.td)
+mlir_tablegen(Ops.h.inc -gen-op-decls)
+mlir_tablegen(Ops.cpp.inc -gen-op-defs)
+add_mlir_doc(GluonOps GluonOps dialects/ -gen-op-doc)
+
 set(LLVM_TARGET_DEFINITIONS GluonDialect.td)
 mlir_tablegen(Dialect.h.inc -gen-dialect-decls -dialect=gluon)
 mlir_tablegen(Dialect.cpp.inc -gen-dialect-defs -dialect=gluon)
-mlir_tablegen(Ops.h.inc -gen-op-decls)
-mlir_tablegen(Ops.cpp.inc -gen-op-defs)
 add_mlir_doc(GluonDialect GluonDialect dialects/ -gen-dialect-doc)
-add_public_tablegen_target(GluonTableGen)
 
 set(LLVM_TARGET_DEFINITIONS GluonAttrDefs.td)
 mlir_tablegen(GluonAttrDefs.h.inc -gen-attrdef-decls)
 mlir_tablegen(GluonAttrDefs.cpp.inc -gen-attrdef-defs)
-mlir_tablegen(OpsEnums.h.inc -gen-enum-decls)
-mlir_tablegen(OpsEnums.cpp.inc -gen-enum-defs)
-add_public_tablegen_target(GluonAttrDefsIncGen)
+
+add_public_tablegen_target(GluonTableGen)

--- a/include/triton/Dialect/Gluon/IR/Dialect.h
+++ b/include/triton/Dialect/Gluon/IR/Dialect.h
@@ -6,3 +6,6 @@
 
 #define GET_ATTRDEF_CLASSES
 #include "triton/Dialect/Gluon/IR/GluonAttrDefs.h.inc"
+
+#define GET_OP_CLASSES
+#include "triton/Dialect/Gluon/IR/Ops.h.inc"

--- a/include/triton/Dialect/Gluon/IR/GluonOps.td
+++ b/include/triton/Dialect/Gluon/IR/GluonOps.td
@@ -1,0 +1,32 @@
+#ifndef GLUON_OPS
+#define GLUON_OPS
+
+include "triton/Dialect/Gluon/IR/GluonDialect.td"
+include "triton/Dialect/Gluon/IR/GluonAttrDefs.td"
+include "triton/Dialect/Triton/IR/TritonInterfaces.td"
+include "triton/Dialect/Triton/IR/TritonTypes.td"
+
+class Gluon_Op<string mnemonic, list<Trait> traits = []> :
+    Op<Gluon_Dialect, mnemonic,
+       !listconcat(traits, [VerifyTensorLayoutsTrait])> {
+}
+
+def Gluon_SetAutoLayoutOp : Gluon_Op<"set_auto_layout",
+                                 [SameOperandsAndResultShape,
+                                  SameOperandsAndResultElementType]> {
+  let summary = "set auto encoding to a concrete encoding type";
+
+  let arguments = (ins TT_Tensor:$src);
+
+  let results = (outs TT_Tensor:$result);
+
+  let builders = [
+    OpBuilder<(ins "Attribute":$encoding, "Value":$value)>
+  ];
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+}
+
+#endif // GLUON_OPS

--- a/lib/Dialect/Gluon/IR/CMakeLists.txt
+++ b/lib/Dialect/Gluon/IR/CMakeLists.txt
@@ -3,7 +3,6 @@ add_triton_library(GluonIR
 
   DEPENDS
   GluonTableGen
-  GluonAttrDefsIncGen
 
   LINK_LIBS PUBLIC
   TritonIR

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -114,10 +114,9 @@ static bool isConvertLayoutTrivial(RankedTensorType dstTy, Value value) {
   auto srcTy = cast<RankedTensorType>(value.getType());
   if (srcTy.getEncoding() == dstTy.getEncoding())
     return true;
-  // Handle unresolved layouts. auto -> T is trivial but T -> auto is not
-  // necessarily.
+  // Fail safe on unresolved layouts.
   if (isa<gluon::AutoEncodingAttr>(srcTy.getEncoding()))
-    return true;
+    return false;
   if (isa<gluon::AutoEncodingAttr>(dstTy.getEncoding()))
     return false;
 
@@ -403,6 +402,10 @@ void init_gluon_ir(py::module &&m) {
       .def("create_memdesc_reinterpret",
            [](GluonOpBuilder &self, Type resultType, Value src) -> Value {
              return self.create<ttg::MemDescReinterpretOp>(resultType, src);
+           })
+      .def("create_set_auto_layout",
+           [](GluonOpBuilder &self, Attribute layout, Value value) -> Value {
+             return self.create<gluon::SetAutoLayoutOp>(layout, value);
            })
       .def("create_split",
            [](GluonOpBuilder &self, Value &a) -> py::tuple {

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -73,41 +73,39 @@ def test_convert_layout_assert_trivial():
     # CHECK: ttg.convert_layout
     ttgl.convert_layout(value, equiv_layout, assert_trivial=True)
 
-    value = ttgl.arange(0, 128, layout=ttgl.AutoLayout())
-    # CHECK: ttg.convert_layout
-    ttgl.convert_layout(value, equiv_layout, assert_trivial=True)
-
 
 def test_convert_layout_not_trivial():
 
     @gluon.jit
-    def kernel():
-        src_layout: ttgl.constexpr = ttgl.BlockedLayout([2], [32], [4], [0])
-        dst_layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0])
-
+    def kernel(src_layout: ttgl.constexpr, dst_layout: ttgl.constexpr):
         value = ttgl.arange(0, 128, layout=src_layout)
         ttgl.convert_layout(value, dst_layout, assert_trivial=True)
 
     with pytest.raises(CompilationError) as e:
-        run_parser(kernel)
+        src_layout = ttgl.BlockedLayout([2], [32], [4], [0])
+        dst_layout = ttgl.BlockedLayout([1], [32], [4], [0])
+        kernel.warmup(src_layout, dst_layout, grid=(1, ))
 
-    assert "layout conversion from BlockedLayout(size_per_thread=(2)" in str(e.value.__cause__)
-    assert "to BlockedLayout(size_per_thread=(1)" in str(e.value.__cause__)
+    assert "layout conversion from BlockedLayout(size_per_thread=[2]" in str(e.value.__cause__)
+    assert "to BlockedLayout(size_per_thread=[1]" in str(e.value.__cause__)
     assert "is not trivial" in str(e.value.__cause__)
 
-    @gluon.jit
-    def kernel():
-        src_layout: ttgl.constexpr = ttgl.BlockedLayout([2], [32], [4], [0])
-        dst_layout: ttgl.constexpr = ttgl.AutoLayout()
+    with pytest.raises(CompilationError) as e:
+        src_layout = ttgl.BlockedLayout([2], [32], [4], [0])
+        dst_layout = ttgl.AutoLayout()
+        kernel.warmup(src_layout, dst_layout, grid=(1, ))
 
-        value = ttgl.arange(0, 128, layout=src_layout)
-        ttgl.convert_layout(value, dst_layout, assert_trivial=True)
+    assert "layout conversion from BlockedLayout(size_per_thread=[2]" in str(e.value.__cause__)
+    assert "to AutoLayout() is not trivial" in str(e.value.__cause__)
 
     with pytest.raises(CompilationError) as e:
-        run_parser(kernel)
+        src_layout: ttgl.constexpr = ttgl.AutoLayout()
+        dst_layout: ttgl.constexpr = ttgl.BlockedLayout([2], [32], [4], [0])
+        kernel.warmup(src_layout, dst_layout, grid=(1, ))
 
-    assert "layout conversion from BlockedLayout(size_per_thread=(2)" in str(e.value.__cause__)
-    assert "to AutoLayout() is not trivial" in str(e.value.__cause__)
+    assert "layout conversion from AutoLayout()" in str(e.value.__cause__)
+    assert "to BlockedLayout(size_per_thread=[2]" in str(e.value.__cause__)
+    assert "is not trivial" in str(e.value.__cause__)
 
 
 @gluon.jit
@@ -1223,6 +1221,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 @filecheck_test
 @gluon.jit
 def test_auto_layout():
+    # CHECK-DAG: [[BLOCKED:#.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
     # CHECK: [[X_1D:%.*]] = arith.constant dense<7> : tensor<16xi32, #gluon.auto_encoding>
     # CHECK: [[Y_1D:%.*]] = arith.constant dense<2> : tensor<8xi32, #gluon.auto_encoding>
     x = ttgl.full([16], 7, ttgl.int32, layout=ttgl.AutoLayout())[:, None]
@@ -1232,8 +1231,11 @@ def test_auto_layout():
     # CHECK: (tensor<16x8xi32, #gluon.auto_encoding>) -> tensor<16xi32, #gluon.auto_encoding
     ttgl.sum(z, axis=1)
 
-    # CHECK: tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #gluon.auto_encoding>
-    ttgl.arange(0, 32)
+    # CHECK: [[I:%.*]] = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #gluon.auto_encoding>
+    i = ttgl.arange(0, 32)
+
+    # CHECK: gluon.set_auto_layout [[I]] : tensor<32xi32, #gluon.auto_encoding> -> tensor<32xi32, [[BLOCKED]]
+    ttgl.set_auto_layout(i, ttgl.BlockedLayout([1], [32], [4], [0]))
 
 
 @filecheck_test
@@ -1245,13 +1247,13 @@ def test_auto_layout_broadcast():
     x = ttgl.full([16, 1], 1, ttgl.int32, layout=ttgl.AutoLayout())
     y = ttgl.full([1, 16], 2, ttgl.int32, layout=ttgl.BlockedLayout([1, 1], [1, 32], [4, 1], [1, 0]))
 
-    # CHECK: [[XCVT:%.*]] = ttg.convert_layout [[X]] : tensor<16x1xi32, #gluon.auto_encoding> -> tensor<16x1xi32, [[BLOCKED]]>
+    # CHECK: [[XCVT:%.*]] = gluon.set_auto_layout [[X]] : tensor<16x1xi32, #gluon.auto_encoding> -> tensor<16x1xi32, [[BLOCKED]]>
     # CHECK: [[XBCAST:%.*]] = tt.broadcast [[XCVT]]
     # CHECK: [[YBCAST:%.*]] = tt.broadcast [[Y]]
     # CHECK: arith.addi [[XBCAST]], [[YBCAST]] : tensor<16x16xi32, [[BLOCKED]]>
     _ = x + y
 
-    # CHECK: [[XCVT2:%.*]] = ttg.convert_layout [[X]] : tensor<16x1xi32, #gluon.auto_encoding> -> tensor<16x1xi32, [[BLOCKED]]>
+    # CHECK: [[XCVT2:%.*]] = gluon.set_auto_layout [[X]] : tensor<16x1xi32, #gluon.auto_encoding> -> tensor<16x1xi32, [[BLOCKED]]>
     # CHECK: [[YBCAST2:%.*]] = tt.broadcast [[Y]]
     # CHECK: [[XBCAST2:%.*]] = tt.broadcast [[XCVT2]]
     # CHECK: arith.muli [[YBCAST2]], [[XBCAST2]] : tensor<16x16xi32, [[BLOCKED]]>

--- a/python/triton/_filecheck.py
+++ b/python/triton/_filecheck.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import inspect
 import subprocess
@@ -84,6 +85,7 @@ def run_filecheck_test(kernel_fn):
 
 def filecheck_test(fn):
 
+    @functools.wraps(fn)
     def test_fn():
         run_filecheck_test(fn)
 

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -102,6 +102,7 @@ __all__ = [
     "full",
     "convert_layout",
     "allocate_shared_memory",
+    "set_auto_layout",
     "shared_memory_descriptor",
     "warp_specialize",
     *_IMPORT_FROM_TRITON,
@@ -415,6 +416,22 @@ def allocate_shared_memory(element_ty, shape, layout, value=None, _semantic=None
     shape = [_unwrap_if_constexpr(s) for s in shape]
     layout = _unwrap_if_constexpr(layout)
     return _semantic.allocate_shared(element_ty, shape, layout, value)
+
+
+@builtin
+def set_auto_layout(value, layout, _semantic=None):
+    """
+    Set a a tensor with AutoLayout to a concrete layout
+
+    Args:
+        value (tensor): The input tensor.
+        layout (DistribtedLayout): The target layout.
+
+    Returns:
+        tensor: The tensor with the new layout.
+    """
+    layout = _unwrap_if_constexpr(layout)
+    return _semantic.set_auto_layout(value, layout)
 
 
 @builtin

--- a/test/Gluon/auto_encoding.mlir
+++ b/test/Gluon/auto_encoding.mlir
@@ -8,12 +8,11 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     // CHECK: [[CST:%.*]] = arith.constant dense<7> : tensor<16xi32, #ttg.slice<{dim = 0, parent = [[BLOCKED]]}>>
     // CHECK: [[SLICE:%.*]] = tt.expand_dims [[CST]] {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = [[BLOCKED]]}>> -> tensor<1x16xi32, [[BLOCKED]]>
     // CHECK: [[BROADCAST:%.*]] = tt.broadcast [[SLICE]] : tensor<1x16xi32, [[BLOCKED]]> -> tensor<8x16xi32, [[BLOCKED]]>
-    // CHECK: [[RES:%.*]] = ttg.convert_layout [[BROADCAST]] : tensor<8x16xi32, [[BLOCKED]]> -> tensor<8x16xi32, [[BLOCKED]]>
-    // CHECK: tt.return [[RES]] : tensor<8x16xi32, [[BLOCKED]]>
+    // CHECK: tt.return [[BROADCAST]] : tensor<8x16xi32, [[BLOCKED]]>
     %x_1d = arith.constant dense<7> : tensor<16xi32, #gluon.auto_encoding>
     %x_slice = tt.expand_dims %x_1d {axis = 0 : i32} : tensor<16xi32, #gluon.auto_encoding> -> tensor<1x16xi32, #gluon.auto_encoding>
     %x_2d = tt.broadcast %x_slice : tensor<1x16xi32, #gluon.auto_encoding> -> tensor<8x16xi32, #gluon.auto_encoding>
-    %cvt = ttg.convert_layout %x_2d : tensor<8x16xi32, #gluon.auto_encoding> -> tensor<8x16xi32, #blocked>
+    %cvt = gluon.set_auto_layout %x_2d : tensor<8x16xi32, #gluon.auto_encoding> -> tensor<8x16xi32, #blocked>
     tt.return %cvt : tensor<8x16xi32, #blocked>
   }
 }
@@ -30,12 +29,11 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     // CHECK: [[CST:%.*]] = arith.constant dense<7> : tensor<16xi32, [[BLOCKED]]>
     // CHECK: [[CVT1:%.*]] = ttg.convert_layout [[CST]] : tensor<16xi32, [[BLOCKED]]> -> tensor<16xi32, [[BLOCKED1]]>
     // CHECK: [[ADD:%.*]] = arith.addi [[CVT1]], [[CVT1]] : tensor<16xi32, [[BLOCKED1]]>
-    // CHECK: [[CVT2:%.*]] = ttg.convert_layout [[ADD]] : tensor<16xi32, [[BLOCKED1]]> -> tensor<16xi32, [[BLOCKED1]]>
-    // CHECK: tt.return [[CVT2]] : tensor<16xi32, [[BLOCKED1]]>
+    // CHECK: tt.return [[ADD]] : tensor<16xi32, [[BLOCKED1]]>
     %0 = arith.constant dense<7> : tensor<16xi32, #blocked>
     %cvt1 = ttg.convert_layout %0 : tensor<16xi32, #blocked> -> tensor<16xi32, #gluon.auto_encoding>
     %add = arith.addi %cvt1, %cvt1 : tensor<16xi32, #gluon.auto_encoding>
-    %cvt2 = ttg.convert_layout %add : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked1>
+    %cvt2 = gluon.set_auto_layout %add : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked1>
     tt.return %cvt2 : tensor<16xi32, #blocked1>
   }
 }
@@ -55,8 +53,7 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     // CHECK: } else {
     // CHECK:   scf.yield [[C2]] : tensor<16xi32, [[BLOCKED]]>
     // CHECK: }
-    // CHECK: [[RES:%.*]] = ttg.convert_layout [[IF]] : tensor<16xi32, [[BLOCKED]]> -> tensor<16xi32, [[BLOCKED]]>
-    // CHECK: tt.return [[RES]] : tensor<16xi32, [[BLOCKED]]>
+    // CHECK: tt.return [[IF]] : tensor<16xi32, [[BLOCKED]]>
     %c1 = arith.constant dense<1> : tensor<16xi32, #gluon.auto_encoding>
     %c2 = arith.constant dense<2> : tensor<16xi32, #gluon.auto_encoding>
     %z = scf.if %arg0 -> tensor<16xi32, #gluon.auto_encoding> {
@@ -64,7 +61,7 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     } else {
       scf.yield %c2 : tensor<16xi32, #gluon.auto_encoding>
     }
-    %cvt = ttg.convert_layout %z : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked>
+    %cvt = gluon.set_auto_layout %z : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked>
     tt.return %cvt : tensor<16xi32, #blocked>
   }
 }
@@ -82,8 +79,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
     // CHECK:   [[MUL:%.*]] = arith.muli [[ITER_ARG]], [[CST]] : tensor<32xi32, [[BLOCKED]]>
     // CHECK:   scf.yield [[MUL]] : tensor<32xi32, [[BLOCKED]]>
     // CHECK: }
-    // CHECK: [[CVT:%.*]] = ttg.convert_layout [[IF]] : tensor<32xi32, [[BLOCKED]]> -> tensor<32xi32, [[BLOCKED]]>
-    // CHECK: tt.return [[CVT]] : tensor<32xi32, [[BLOCKED]]>
+    // CHECK: tt.return [[IF]] : tensor<32xi32, [[BLOCKED]]>
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
     %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #gluon.auto_encoding>
@@ -92,7 +88,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
       %2 = arith.muli %arg2, %cst : tensor<32xi32, #gluon.auto_encoding>
       scf.yield %2 : tensor<32xi32, #gluon.auto_encoding>
     }
-    %cvt = ttg.convert_layout %1 : tensor<32xi32, #gluon.auto_encoding> -> tensor<32xi32, #blocked>
+    %cvt = gluon.set_auto_layout %1 : tensor<32xi32, #gluon.auto_encoding> -> tensor<32xi32, #blocked>
     tt.return %cvt : tensor<32xi32, #blocked>
   }
 }
@@ -108,11 +104,10 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     // CHECK-DAG: [[BLOCKED:#.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
     // CHECK: [[CST:%.*]] = arith.constant 0 : i32
     // CHECK: [[SPLAT: %.*]] = tt.splat [[CST]] : i32 -> tensor<16xi32, [[BLOCKED]]>
-    // CHECK: [[RES:%.*]] = ttg.convert_layout [[RANGE]] : tensor<16xi32, [[BLOCKED]]> -> tensor<16xi32, [[BLOCKED]]>
-    // CHECK: tt.return [[RES]] : tensor<16xi32, [[BLOCKED]]>
+    // CHECK: tt.return [[RANGE]] : tensor<16xi32, [[BLOCKED]]>
     %cst = arith.constant 0 : i32
     %0 = tt.splat %cst : i32 -> tensor<16xi32, #gluon.auto_encoding>
-    %cvt = ttg.convert_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked>
+    %cvt = gluon.set_auto_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked>
     tt.return %cvt : tensor<16xi32, #blocked>
   }
 }

--- a/test/Gluon/invalid_auto_encoding.mlir
+++ b/test/Gluon/invalid_auto_encoding.mlir
@@ -7,8 +7,8 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
   tt.func public @infer_conflict() -> (tensor<16xi32, #blocked>, tensor<16xi32, #blocked1>) {
     // expected-error @+1 {{Found conflicting encodings for value}}
     %0 = arith.constant dense<7> : tensor<16xi32, #gluon.auto_encoding>
-    %cvt1 = ttg.convert_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked>
-    %cvt2 = ttg.convert_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked1>
+    %cvt1 = gluon.set_auto_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked>
+    %cvt2 = gluon.set_auto_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked1>
     tt.return %cvt1, %cvt2 : tensor<16xi32, #blocked>, tensor<16xi32, #blocked1>
   }
 }


### PR DESCRIPTION
<git-pr-chain>


[Gluon] Add dedicated set_auto_layout op

Instead of reusing `ttg.convert_layout`, this changes auto layouts
to only propagate from the gluon.set_auto_layout operation. Not only
does this make the purpose a bit clearer, it also allows us to:

1. Prevent DCE by making it impure, so you can ignore the return value
   and it will still set the encoding.
2. Express an allowed conversion without creating a conflict, e.g.:
```python
a = ...
ttgl.set_auto_layout(a, layout)
ttgl.store(ptrs, ttgl.convert_layout(a, ptrs.layout))
```
   which does the computation in one layout and the store in
   another.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #7504 👈 **YOU ARE HERE**


</git-pr-chain>

