### PR TITLE
[Backend] Check if `wait_barrier` is a constant true

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -160,7 +160,8 @@ struct WaitBarrierOpConversion
         typeConverter->convertType(op.getAlloc().getType().getElementType()),
         rewriter);
     auto loc = op.getLoc();
-    bool predicated = adaptor.getPred() != nullptr;
+    bool predicated =
+        adaptor.getPred() && !matchPattern(op.getPred(), m_NonZero());
     std::string ptx;
     if (targetInfo->getComputeCapability() < 90) {
       if (!predicated) {


### PR DESCRIPTION
When the `wait_barrier` predicate ends up being true, either generated from Gluon or for some other optimization, generate the non-predicated version of the instruction, which is slightly more efficient due to 1 less branch. I observed a speedup of like 3 TFLOPS on the attention kernel because of this. It was stable and reproducible and not just noise.