### PR TITLE
[AMD] Fix test_split_subview on gfx11/gfx12

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6360,8 +6360,7 @@ shared_layouts = [
 def test_split_subview(M, N, M_tile_size, N_tile_size, device='cuda'):
     if not is_hip() and N_tile_size == 32:
         pytest.skip("Will fix spliting along the swizzling pattern in the next PR")
-    threads_per_warp = 64 if is_hip() else 32
-    num_rows_per_warp = threads_per_warp // 4
+    num_rows_per_warp = THREADS_PER_WARP // 4
     num_repeats_M = triton.cdiv(M, M_tile_size)
     num_repeats_N = triton.cdiv(N, N_tile_size)
 


### PR DESCRIPTION
This was fixed by #7457 but then partially overwritten by #7480.