### PR TITLE
[BACKEND] Don't accumulate the offsets from memdesc_subview on the base

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -352,6 +352,21 @@ public:
   SmallVector<Value> getStrides(triton::gpu::MemDescType memDesc, Location loc,
                                 RewriterBase &rewriter) const;
 
+  // Returns a mask representing all the bits of the memdesc offsets that
+  // may be modified by an affine offset coming from a memdesc_subview.
+  // The offsets are considered to be in the type of the memdesc.
+  // For padded layouts, we return the offsets without padding.
+  static uint64_t getMaskSpanOffsets(triton::gpu::MemDescType srcTy);
+
+  // Returns whether the shared memory access had a memdesc_subview
+  // that is rank-preserving (soon to be called memdesc_slice)
+  static bool isAffineSharedMemoryAccess(triton::gpu::MemDescType srcTy) {
+    return getMaskSpanOffsets(srcTy) != 0;
+  }
+
+  Value getShmemOffset(Location loc, RewriterBase &rewriter,
+                       triton::gpu::MemDescType srcTy) const;
+
   // TODO(Keren): deprecate the method once AMD backend has cleaned up
   Value getCSwizzleOffset(int dim) const {
     assert(dim >= 0 && dim < offsets.size());
@@ -369,7 +384,6 @@ private:
                                                ArrayRef<unsigned> layoutOrder,
                                                Location loc,
                                                RewriterBase &rewriter);
-
   Value base; // i32 ptr. The start address of the shared memory object.
   Type baseElemType;
   SmallVector<Value>
@@ -462,7 +476,6 @@ std::pair<Value, Value> getLaneAndWarpId(OpBuilder &rewriter, Location loc);
 // -----------------------------------------------------------------------
 using LLVM::SharedMemoryObject;
 using ::mlir::LLVM::delinearize;
-using ::mlir::LLVM::SharedMemoryObject;
 using ::mlir::triton::gpu::AMDMfmaEncodingAttr;
 using ::mlir::triton::gpu::AMDWmmaEncodingAttr;
 using ::mlir::triton::gpu::BlockedEncodingAttr;
@@ -473,24 +486,6 @@ using ::mlir::triton::gpu::SliceEncodingAttr;
 
 Value dot(RewriterBase &rewriter, Location loc, ArrayRef<Value> offsets,
           ArrayRef<Value> strides);
-
-/// Extend 2d shared object to 3d.
-///
-/// If tensor has 3 dimensions, returns original shared object.
-/// If tensor shape is [M, N], return shared object describing shape [1, M, N]
-///
-/// This Function is used to simplify processing of 2d and 3d dot operands,
-/// particularly in the conversion of local_load operation.
-///
-/// \param rewriter
-/// \param loc
-/// \param smemObj
-/// \param shape shape of a tensor represented by smemObj
-/// \returns shared object describing 3d tensor
-SharedMemoryObject
-getExpandedSharedMemoryObject(ConversionPatternRewriter &rewriter, Location loc,
-                              SharedMemoryObject smemObj,
-                              ArrayRef<int64_t> shape);
 
 // "Applies" the given layout by computing layout(indices) and returning the
 // resulting Values.
@@ -568,7 +563,8 @@ void storeDistributedToShared(triton::gpu::MemDescType dstTy,
 SmallVector<Value>
 lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
                 ArrayRef<Value> valsArray, // Input for store, output for load
-                Type llvmElemTy, Value smemBase,
+                Type llvmElemTy, Value smemBase, Value affineOffset,
+                uint64_t maskSpanAffineOffset,
                 ConversionPatternRewriter &rewriter,
                 const TargetInfoBase &targetInfo);
 
@@ -578,20 +574,21 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
 SmallVector<Value> lowerLdSt(
     Location loc, MLIRContext *ctx, LinearLayout cvt,
     ArrayRef<Value> valsArray, // Input for store, output for load
-    Type llvmElemTy, Value smemBase, ConversionPatternRewriter &rewriter,
+    Type llvmElemTy, Value smemBase, Value affineOffset,
+    uint64_t maskSpanAffineOffset, ConversionPatternRewriter &rewriter,
     const TargetInfoBase &targetInfo, std::optional<int> maybeMaxVecElems,
     std::function<SmallVector<Value>(ConversionPatternRewriter &, Location,
                                      ArrayRef<Value>, Value, int, VectorType)>
         lowerInst);
 
 // Lower local_load/local_store via ld.shared/st.shared
-SmallVector<Value> lowerLocalLdSt(Location loc, MLIRContext *ctx,
-                                  // Map from registers to offset
-                                  LinearLayout cvt, ArrayRef<Value> valsArray,
-                                  // Input for store, output for load
-                                  Type llvmElemTy, Value smemBase,
-                                  ConversionPatternRewriter &rewriter,
-                                  const TargetInfoBase &targetInfo);
+SmallVector<Value>
+lowerLocalLdSt(Location loc, MLIRContext *ctx,
+               LinearLayout cvt,          // Map from registers to offset
+               ArrayRef<Value> valsArray, // Input for store, empty for load
+               Type llvmElemTy, triton::gpu::MemDescType srcTy,
+               SharedMemoryObject smemObj, ConversionPatternRewriter &rewriter,
+               const TargetInfoBase &targetInfo);
 
 SmallVector<Value> unpackLLElements(Location loc, Value llvmStruct,
                                     RewriterBase &rewriter);

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -384,6 +384,7 @@ private:
                                                ArrayRef<unsigned> layoutOrder,
                                                Location loc,
                                                RewriterBase &rewriter);
+
   Value base; // i32 ptr. The start address of the shared memory object.
   Type baseElemType;
   SmallVector<Value>

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -126,7 +126,7 @@ std::optional<ColumnAction> regPermForDivide(const LinearLayout &A,
 ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout);
 
 std::pair<int64_t, ColumnAction>
-actionAdditiveStrides(const LinearLayout &layout);
+actionAdditiveStrides(const LinearLayout &layout, uint64_t maskSpanOffsets);
 
 // For a layout A with A.hasInDim(kReg), repeat the values so that they have
 // the same broadcasting as layout

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -202,6 +202,8 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
 
     assert(permutedInVals.size() == tileSize * nReps);
     SmallVector<Value> outVals;
+    auto affineOffset = b.i32_val(0);
+    auto maskSpanAffineOffset = 0;
     for (int i = 0; i < nReps; ++i) {
       if (i > 0)
         b.barrier();
@@ -210,11 +212,12 @@ struct ConvertLayoutOpUsingLinearLayoutsConversion
           ArrayRef<Value>(permutedInVals).slice(i * tileSize, tileSize);
       // Store
       lowerLdStShared(loc, ctx, storeCvt, tileInVals, llvmElemTy, smemBase,
-                      rewriter, targetInfo);
+                      affineOffset, maskSpanAffineOffset, rewriter, targetInfo);
       b.barrier();
       // Load
       SmallVector<Value> tileOutVals = lowerLdStShared(
-          loc, ctx, loadCvt, {}, llvmElemTy, smemBase, rewriter, targetInfo);
+          loc, ctx, loadCvt, {}, llvmElemTy, smemBase, affineOffset,
+          maskSpanAffineOffset, rewriter, targetInfo);
       llvm::append_range(outVals, tileOutVals);
     }
 

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -53,8 +53,8 @@ LogicalResult lowerLocalStore(Location loc, MLIRContext *ctx, Value regVal,
   auto kWarp = str_attr("warp");
   auto kOffset = str_attr("offset");
   cvt = cvt.sublayout({kReg, kLane, kWarp}, {kOffset});
-  lowerLocalLdSt(loc, ctx, cvt, inVals, llvmElemTy, smemObj.getBase(), rewriter,
-                 targetInfo);
+  lowerLocalLdSt(loc, ctx, cvt, inVals, llvmElemTy, memDescTy, smemObj,
+                 rewriter, targetInfo);
 
   return success();
 }
@@ -177,10 +177,9 @@ public:
     auto regTy = cast<RankedTensorType>(regVal.getType());
     auto typeConverter = getTypeConverter();
 
-    auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
-        loc, adaptor.getSrc(),
-        typeConverter->convertType(memDescTy.getElementType()), rewriter);
-    auto llvmElemTy = typeConverter->convertType(regTy.getElementType());
+    auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
+    auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
+                                                         llvmElemTy, rewriter);
 
     // See [Legacy local_load/local_store]
     if (!targetInfo.isCuda()) {
@@ -206,8 +205,8 @@ public:
     auto kOffset = str_attr("offset");
     cvt = cvt.sublayout({kReg, kLane, kWarp}, {kOffset});
 
-    auto outVals = lowerLocalLdSt(op.getLoc(), ctx, cvt, {}, llvmElemTy,
-                                  smemObj.getBase(), rewriter, targetInfo);
+    auto outVals = lowerLocalLdSt(loc, ctx, cvt, {}, llvmElemTy, memDescTy,
+                                  smemObj, rewriter, targetInfo);
 
     Value result = packLLElements(loc, typeConverter, outVals, rewriter, regTy);
     rewriter.replaceOp(op, result);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -435,189 +435,6 @@ Value emitPadding(Location loc, RewriterBase &rewriter,
 }
 
 namespace {
-
-SmallVector<Value> getSmemVecAddrVec(
-    const LinearLayout &regLayout, const LinearLayout &regToSharedLayout,
-    const LinearLayout &invertAllocSharedLayout,
-    const SharedMemoryObject &smemObj, triton::gpu::MemDescType sharedTy,
-    Type elemLlvmTy, ArrayRef<uint32_t> regIds, Value laneId, Value warpId,
-    Value blockId, Location loc, RewriterBase &rewriter) {
-
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-  MLIRContext *ctx = rewriter.getContext();
-  StringAttr kBlock = str_attr("block");
-  StringAttr kRegister = str_attr("register");
-  StringAttr kLane = str_attr("lane");
-  StringAttr kWarp = str_attr("warp");
-  auto shape = sharedTy.getShape();
-  auto allocShape = sharedTy.getAllocShape();
-  auto rank = shape.size();
-  auto sharedEnc =
-      cast<triton::gpu::SharedEncodingTrait>(sharedTy.getEncoding());
-
-  auto smemBase = smemObj.getBase();
-  auto smemOffsets = smemObj.getOffsets();
-  auto smemStrides = smemObj.getStrides(sharedTy, loc, rewriter);
-
-  SmallVector<Value> smemOffsetsComputed;
-  SmallVector<SmallVector<std::pair<StringAttr, Value>>> indicesVec;
-
-  // When loading or storing to shared memory, we consider two cases for
-  // performance reasons:
-  //
-  //   1. Non-swizzled shared memory.
-  //   2. Swizzled shared memory.
-  //
-  // Consider lowering `ttg.local_load %a`. In the first case, we can
-  // directly construct a linear layout using `%a`'s shape and shared memory
-  // encoding, irrespective of `%a`'s rank or whether it represents a slice of a
-  // larger tensor.
-  //
-  // The method does not apply for swizzled shared memory in some scenarios.
-  // Key properties of swizzling in Triton are:
-  //
-  //   - Swizzling applies only to tensors with rank ≥ 2.
-  //   - It is restricted to the last two dimensions of the tensor.
-  //   - These last two dimensions are always treated as the most "minor."
-  //
-  // An important edge case arises when `%a` results from `%a = ttg.subview %b`,
-  // where `%b` is swizzled (and so is `%a`). In this case, constructing a
-  // layout and determining shared memory offsets using `%a`'s shape is
-  // incorrect. This is because swizzling depends on the original shape of `%b`,
-  // which differs from `%a`'s shape. As a result, some locations may fall
-  // outside `%a`'s contiguous view of memory. Specifically, an element `[i
-  // (row_idx), j (col_idx)]` in `%a` might map to `[i, j']` after swizzling,
-  // where `j'` lies outside `%a`'s shape but still within `%b`'s shape.
-  //
-  // We propose case 2 (see comments below), which provides a more general
-  // solution for all swizzled shared memory scenarios, including the edge case
-  // mentioned above.
-  //
-  // Padded shared layout falls into case 1--we can rely on the logic for case 1
-  // to get the 1-D offset into shared memory. Then we just need to add the
-  // padding offset.
-  if (isSimpleSharedMemoryAccess(shape, allocShape, sharedEnc)) { // Case 1
-
-    // This reverts #5645, because it introduced increased register pressure in
-    // AMD backend.
-    // TODO: remove when new implementation performance reaches target level
-    if (auto swizzledSharedEnc =
-            mlir::dyn_cast<triton::gpu::SwizzledSharedEncodingAttr>(
-                sharedEnc)) {
-      auto regToSharedSwizzledLayout =
-          getRegToSharedLayout(ctx, shape, regLayout, swizzledSharedEnc,
-                               elemLlvmTy.getIntOrFloatBitWidth(), allocShape);
-      auto smemOrder = swizzledSharedEnc.getOrder();
-
-      auto swizzledIndicesVec =
-          applyLinearLayoutVec(loc, rewriter, regToSharedSwizzledLayout,
-                               {{kRegister, b.i32_val(0)},
-                                {kLane, laneId},
-                                {kWarp, warpId},
-                                {kBlock, b.i32_val(0)}},
-                               regIds);
-
-      auto reorderedStrides = applyPermutation(smemStrides, smemOrder);
-
-      for (auto &swizzledIndices : swizzledIndicesVec) {
-        SmallVector<Value> swizzledOffsets;
-        for (unsigned i = 0; i < swizzledIndices.size() - 1; ++i)
-          swizzledOffsets.push_back(swizzledIndices[i].second);
-
-        Value smemOffset =
-            dot(rewriter, loc, swizzledOffsets, reorderedStrides);
-        smemOffsetsComputed.push_back(smemOffset);
-      }
-    } else {
-      auto indicesVec = applyLinearLayoutVec(loc, rewriter, regToSharedLayout,
-                                             {{kRegister, b.i32_val(0)},
-                                              {kLane, laneId},
-                                              {kWarp, warpId},
-                                              {kBlock, blockId}},
-                                             regIds);
-
-      for (auto &indices : indicesVec) {
-        Value smemOffset = indices[0].second;
-
-        if (auto paddedLayout =
-                dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(sharedEnc)) {
-          // Apply the offset needed for padding.
-          Value padOffset =
-              emitPadding(loc, rewriter, paddedLayout, smemOffset);
-          smemOffset = b.add(smemOffset, padOffset);
-        }
-        smemOffsetsComputed.push_back(smemOffset);
-      }
-    }
-  } else { // Case 2 -> rank-reduced swizzling
-    assert(rank >= 2 && "Swizzling only applies to tensors with rank >= 2");
-    assert((isa<triton::gpu::SwizzledSharedEncodingAttr,
-                triton::gpu::AMDRotatingSharedEncodingAttr>(sharedEnc)) &&
-           "NVMMA layout not supported for sliced tensors");
-    // We define both tensor offsets and shared memory offsets:
-    //
-    //   - Tensor offsets: Relative offsets within a given tensor.
-    //   - Shared memory offsets: Absolute offsets within the shared memory.
-    //
-    // In Triton, the shared memory layout provides an invertible, one-to-one
-    // mapping between tensor offsets and shared memory offsets. The `base`
-    // field of any shared memory object represents both the shared memory
-    // offset and the tensor offset relative to the original tensor at
-    // allocation, prior to any subview operations.
-    //
-    // To determine the shared memory offsets for a specific register when
-    // dealing with swizzled and sliced tensors, the process involves:
-    //
-    //   1. Retrieving the original tensor's `invertAllocSharedLayout`, which
-    //   maps the allocated tensor's offsets back to shared memory offsets.
-    //   2. Reconstructing the register's offsets in the allocated tensor by
-    //   summing:
-    //      - The shared memory offsets of the current view's base, and
-    //      - The relative tensor offsets of the register.
-    //
-    // This approach ensures that "absolute" tensor offsets can be
-    // mapped to the correct shared memory addresses using
-    // `invertAllocSharedLayout`.
-
-    auto composedLayout = regLayout.compose(invertAllocSharedLayout);
-
-    auto indicesVec = applyLinearLayoutVec(loc, rewriter, composedLayout,
-                                           {{kRegister, b.i32_val(0)},
-                                            {kLane, laneId},
-                                            {kWarp, warpId},
-                                            {kBlock, blockId}},
-                                           regIds);
-
-    SmallVector<std::pair<StringAttr, Value>> smemOffsetPairs;
-    for (auto [attr, val] :
-         llvm::zip(invertAllocSharedLayout.getInDimNames(), smemOffsets)) {
-      smemOffsetPairs.emplace_back(attr, val);
-    }
-    Value smemOffsetsApplied =
-        applyLinearLayout(loc, rewriter, invertAllocSharedLayout,
-                          smemOffsetPairs)[0]
-            .second;
-
-    Value baseToAllocBaseDist = dot(rewriter, loc, smemOffsets, smemStrides);
-
-    for (auto &indices : indicesVec) {
-      Value smemOffset = indices[0].second;
-      smemOffset = b.xor_(smemOffset, smemOffsetsApplied);
-      smemOffset = b.sub(smemOffset, baseToAllocBaseDist);
-      smemOffsetsComputed.push_back(smemOffset);
-    }
-  }
-
-  SmallVector<Value> smemVecAddrs;
-  for (auto smemOffset : smemOffsetsComputed) {
-    auto vecAddr = b.gep(smemBase.getType(), elemLlvmTy, smemBase, smemOffset,
-                         LLVM::GEPNoWrapFlags::inbounds);
-    smemVecAddrs.push_back(vecAddr);
-  }
-
-  return smemVecAddrs;
-}
-
 std::pair<int, ColumnAction>
 largestVectorisation(MLIRContext *ctx, const LinearLayout &cvt, int bitwidth,
                      std::optional<int> maybeMaxVecElems = std::nullopt) {
@@ -655,7 +472,8 @@ largestVectorisation(MLIRContext *ctx, const LinearLayout &cvt, int bitwidth,
 SmallVector<Value>
 lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
                 ArrayRef<Value> valsArray, // Input for store, output for load
-                Type llvmElemTy, Value smemBase,
+                Type llvmElemTy, Value smemBase, Value affineOffset,
+                uint64_t maskSpanAffineOffset,
                 ConversionPatternRewriter &rewriter,
                 const TargetInfoBase &targetInfo) {
 
@@ -679,14 +497,15 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
       return unpackLLVector(loc, valsVec, rewriter);
     }
   };
-  return lowerLdSt(loc, ctx, cvt, valsArray, llvmElemTy, smemBase, rewriter,
-                   targetInfo, {}, emitLdSt);
+  return lowerLdSt(loc, ctx, cvt, valsArray, llvmElemTy, smemBase, affineOffset,
+                   maskSpanAffineOffset, rewriter, targetInfo, {}, emitLdSt);
 }
 
 SmallVector<Value> lowerLdSt(
     Location loc, MLIRContext *ctx, LinearLayout cvt,
     ArrayRef<Value> valsArray, // Input for store, output for load
-    Type llvmElemTy, Value smemBase, ConversionPatternRewriter &rewriter,
+    Type llvmElemTy, Value smemBase, Value affineOffset,
+    uint64_t maskSpanAffineOffset, ConversionPatternRewriter &rewriter,
     const TargetInfoBase &targetInfo, std::optional<int> maybeMaxVecElems,
     std::function<SmallVector<Value>(ConversionPatternRewriter &, Location,
                                      ArrayRef<Value>, Value, int, VectorType)>
@@ -713,7 +532,8 @@ SmallVector<Value> lowerLdSt(
   auto quot = *divideLeft(cvt, tile);
   LinearLayout reps = zerosLike(tile) * quot;
 
-  auto [nAdditive, permStrides] = actionAdditiveStrides(reps);
+  auto [nAdditive, permStrides] =
+      actionAdditiveStrides(reps, maskSpanAffineOffset);
   reps = permStrides.apply(reps);
   if (isStore) {
     vals = permStrides.apply(vals);
@@ -733,6 +553,9 @@ SmallVector<Value> lowerLdSt(
           loc, rewriter, i8Reps,
           {{kReg, b.i32_val(0)}, {kLane, laneId}, {kWarp, warpId}})[0]
           .second;
+  // TODO compute the offset already in i8
+  auto affineOffsetI8 = b.mul(affineOffset, b.i32_val(bitwidth / 8));
+  regBaseI8 = b.xor_(regBaseI8, affineOffsetI8);
   SmallVector<Value> outVals;
   auto vecTy = vec_ty(llvmElemTy, elemsPerVec);
   for (int i = 0; i < cvt.getInDimSize(kReg); i += nAdditive) {
@@ -762,12 +585,13 @@ SmallVector<Value> lowerLdSt(
   return outVals;
 }
 
-SmallVector<Value> lowerLocalLdSt(Location loc, MLIRContext *ctx,
-                                  LinearLayout cvt, ArrayRef<Value> valsArray,
-                                  // Input for store, output for load
-                                  Type llvmElemTy, Value smemBase,
-                                  ConversionPatternRewriter &rewriter,
-                                  const TargetInfoBase &targetInfo) {
+SmallVector<Value>
+lowerLocalLdSt(Location loc, MLIRContext *ctx,
+               LinearLayout cvt,          // Map from registers to offset
+               ArrayRef<Value> valsArray, // Input for store, empty for load
+               Type llvmElemTy, triton::gpu::MemDescType srcTy,
+               SharedMemoryObject smemObj, ConversionPatternRewriter &rewriter,
+               const TargetInfoBase &targetInfo) {
   assert(cvt.getNumOutDims() == 1);
   assert(*cvt.getOutDimNames().begin() == str_attr("offset"));
   auto isStore = !valsArray.empty();
@@ -779,15 +603,17 @@ SmallVector<Value> lowerLocalLdSt(Location loc, MLIRContext *ctx,
     if (isStore) {
       inVals = removeBroadcastSrc.apply(inVals);
     }
-    auto outVals = lowerLdStShared(loc, ctx, prmtCvt, inVals, llvmElemTy,
-                                   smemBase, rewriter, targetInfo);
+    auto outVals = lowerLocalLdSt(loc, ctx, prmtCvt, inVals, llvmElemTy, srcTy,
+                                  smemObj, rewriter, targetInfo);
     if (!isStore) {
       outVals = broadcastAs(outVals, cvt);
     }
     return outVals;
   }
-
-  return lowerLdStShared(loc, ctx, cvt, valsArray, llvmElemTy, smemBase,
+  auto affineOffset = smemObj.getShmemOffset(loc, rewriter, srcTy);
+  auto maskSpanAffineOffset = smemObj.getMaskSpanOffsets(srcTy);
+  return lowerLdStShared(loc, ctx, cvt, valsArray, llvmElemTy,
+                         smemObj.getBase(), affineOffset, maskSpanAffineOffset,
                          rewriter, targetInfo);
 }
 
@@ -820,20 +646,10 @@ bool emitTransferBetweenRegistersAndShared(
 
   // TODO(jlebar): We don't currently support loading from shared memory in a
   // different CTA.  We'd need to emit `mapa.shared::cluster` instructions.
-  for (int inBlock = 1; inBlock < regToSharedLayout.getInDimSize(kBlock);
-       inBlock *= 2) {
-    auto idx = regToSharedLayout.apply(
-        {{kRegister, 0}, {kLane, 0}, {kWarp, 0}, {kBlock, inBlock}});
-    // Intra-block offset must be 0
-    int32_t offset = idx[0].second;
-    if (offset != 0) {
-      return false;
-    }
-    // Check if there's any cross CTA load.
-    int32_t outBlock = idx[1].second;
-    if (outBlock != inBlock) {
-      return false;
-    }
+  if (regToSharedLayout.hasInDim(kBlock) &&
+      regToSharedLayout.hasOutDim(kBlock) &&
+      !regToSharedLayout.isTrivialOver({kBlock})) {
+    return false;
   }
 
   // Determine how many consecutive registers map to consecutive shmem elements
@@ -852,34 +668,38 @@ bool emitTransferBetweenRegistersAndShared(
   Value blockId =
       withCTAOffset ? target.getClusterCTAId(rewriter, loc) : b.i32_val(0);
 
-  // For kernels with a single CTA, `allocSharedLayout.sublayout(S("block"),
-  // outDims) == 0`. We need to take out the "block" dimension in order to use
-  // `invert`.
-  // For kernels with multiple CTAs per CGA,
-  // `allocSharedLayout.sublayout(S("block"), outDims) != 0`. We do not need to
-  // take out the "block" dimension.
-  // Thus we use `pseudoinvert` instead of `invert` here for simplicity.
-  auto allocShape = sharedTy.getAllocShape();
-  auto invertAllocSharedLayout = LinearLayout::empty();
-  if (!paddedLayout) {
-    // This is the legacy way of doing things that's much more ad-hoc
-    // For generic shared layouts it may or may not be correct
-    auto allocShape = sharedTy.getAllocShape();
-    auto trimShape = allocShape.take_back(sharedTy.getRank());
-    invertAllocSharedLayout = triton::gpu::toLinearLayout(
-                                  trimShape, sharedTy.getEncoding(), trimShape)
-                                  .pseudoinvert();
-  }
-
   int numElems = regToSharedLayout.getInDimSize(kRegister);
   auto vecTy = vec_ty(elemLlvmTy, vecElems);
   SmallVector<uint32_t> regIds;
   for (int i = 0; i < numElems / vecElems; i++) {
     regIds.push_back(i * vecElems);
   }
-  auto vecAddrVec = getSmemVecAddrVec(
-      regLayout, regToSharedLayout, invertAllocSharedLayout, smemObj, sharedTy,
-      elemLlvmTy, regIds, laneId, warpId, blockId, loc, rewriter);
+
+  auto smemBase = smemObj.getBase();
+
+  auto indicesVec = applyLinearLayoutVec(loc, rewriter, regToSharedLayout,
+                                         {{kRegister, b.i32_val(0)},
+                                          {kLane, laneId},
+                                          {kWarp, warpId},
+                                          {kBlock, blockId}},
+                                         regIds);
+
+  // Compute affine offset given by memdesc_subview
+  auto offset = smemObj.getShmemOffset(loc, rewriter, sharedTy);
+  SmallVector<Value> vecAddrVec;
+  for (auto &indices : indicesVec) {
+    Value smemOffset = indices[0].second;
+    smemOffset = b.xor_(smemOffset, offset);
+    if (paddedLayout) {
+      // Apply the offset needed for padding.
+      Value padOffset = emitPadding(loc, rewriter, paddedLayout, smemOffset);
+      smemOffset = b.add(smemOffset, padOffset);
+    }
+    auto vecAddr = b.gep(smemBase.getType(), elemLlvmTy, smemBase, smemOffset,
+                         LLVM::GEPNoWrapFlags::inbounds);
+    vecAddrVec.push_back(vecAddr);
+  }
+
   for (Value &vecAddr : vecAddrVec) {
     perVectorCallback(vecTy, vecAddr);
   }
@@ -1300,8 +1120,8 @@ SharedMemoryObject::getOrderForShape(ArrayRef<int64_t> shape,
     auto minRank = std::min<size_t>(shape.size(), layoutOrder.size());
     for (size_t i = 0; i < minRank; ++i)
       order[i] = layoutOrder[i] - rankDiff;
+    assert(isPermutationOfIota(order) && "Invalid order");
   }
-  assert(isPermutationOfIota(order) && "Invalid order");
   return order;
 }
 
@@ -1318,6 +1138,81 @@ SharedMemoryObject::getStridesForShape(ArrayRef<int64_t> shape,
     stride *= shape[idx];
   }
   return strides;
+}
+
+uint64_t
+SharedMemoryObject::getMaskSpanOffsets(triton::gpu::MemDescType srcTy) {
+  auto ctx = srcTy.getContext();
+  auto shape = srcTy.getShape();
+  auto allocShape = srcTy.getAllocShape();
+  assert(allocShape.size() >= shape.size());
+  assert(allocShape.size() - shape.size() <= 1);
+  allocShape = allocShape.take_back(shape.size());
+
+  // Early exist when there is no subview
+  if (allocShape == shape) {
+    return 0;
+  }
+  auto totalLl =
+      triton::gpu::toLinearLayout(allocShape, srcTy.getEncoding(), allocShape);
+  auto dimNames = standardOutDimNames(ctx, shape.size());
+  // Remove the kBlock dimension
+  auto kOffset = StringAttr::get(ctx, "offset");
+  totalLl = totalLl.sublayout({kOffset}, dimNames);
+  // Map from dimNames to offset
+  auto invLl = totalLl.invert();
+  SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;
+  for (auto dim : standardOutDimNames(srcTy.getContext(), shape.size())) {
+    logicalOffsets.push_back({dim, 0});
+  }
+
+  auto ret = 0;
+  for (auto [dim, shapes] : llvm::enumerate(llvm::zip(shape, allocShape))) {
+    auto [shape, allocShape] = shapes;
+    for (int j = llvm::Log2_32(shape); j < llvm::Log2_32(allocShape); ++j) {
+      logicalOffsets[dim].second = 1 << j;
+      ret |= invLl.apply(logicalOffsets)[0].second;
+    }
+    // Reset the offset for the next dimension
+    logicalOffsets[dim].second = 0;
+  }
+  return ret;
+}
+
+Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
+                                         triton::gpu::MemDescType srcTy) const {
+  auto ctx = srcTy.getContext();
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+  // If it did not have a memdesc_subview, we don't need to compute the offset
+  // as it is zero
+  if (!isAffineSharedMemoryAccess(srcTy)) {
+    return b.i32_val(0);
+  }
+
+  // We return the offset without the padding. The padding will be added in the
+  // lowering
+  if (auto paddedSharedEncoding =
+          dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(
+              srcTy.getEncoding())) {
+    auto allocShape64 = srcTy.getAllocShape();
+    SmallVector<unsigned> allocShape(allocShape64.begin(), allocShape64.end());
+    return LLVM::linearize(rewriter, loc, offsets, allocShape);
+  }
+
+  auto dimNames = standardOutDimNames(ctx, offsets.size());
+  SmallVector<std::pair<StringAttr, Value>> logicalOffsets;
+  for (auto [dim, offset] : llvm::zip(dimNames, offsets)) {
+    logicalOffsets.push_back({dim, offset});
+  }
+
+  auto allocShape = srcTy.getAllocShape();
+  LinearLayout ll =
+      triton::gpu::toLinearLayout(allocShape, srcTy.getEncoding(), allocShape);
+  ll = ll.sublayout({str_attr("offset")}, dimNames);
+  auto offset =
+      applyLinearLayout(loc, rewriter, ll.invert(), logicalOffsets)[0].second;
+  return offset;
 }
 
 Value getStructFromSharedMemoryObject(Location loc,
@@ -1642,23 +1537,6 @@ Value dot(RewriterBase &rewriter, Location loc, ArrayRef<Value> offsets,
     ret = b.add(ret, b.mul(offset, stride));
   }
   return ret;
-}
-
-SharedMemoryObject
-getExpandedSharedMemoryObject(ConversionPatternRewriter &rewriter, Location loc,
-                              SharedMemoryObject smemObj,
-                              ArrayRef<int64_t> shape) {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-  assert(shape.size() == 2 || shape.size() == 3);
-  auto offsets = smemObj.getOffsets();
-  auto rank = offsets.size();
-  assert(rank == shape.size());
-  if (rank == 3)
-    return smemObj;
-  offsets.insert(offsets.begin(), b.i32_val(0));
-  auto expandedSmemObj =
-      SharedMemoryObject(smemObj.getBase(), smemObj.getBaseElemType(), offsets);
-  return expandedSmemObj;
 }
 
 // Isolated a single warp specialize op from above.

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1206,9 +1206,7 @@ Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
     logicalOffsets.push_back({dim, offset});
   }
 
-  auto allocShape = srcTy.getAllocShape();
-  LinearLayout ll =
-      triton::gpu::toLinearLayout(allocShape, srcTy.getEncoding(), allocShape);
+  LinearLayout ll = triton::gpu::toLinearLayout(srcTy);
   ll = ll.sublayout({str_attr("offset")}, dimNames);
   auto offset =
       applyLinearLayout(loc, rewriter, ll.invert(), logicalOffsets)[0].second;

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -380,6 +380,8 @@ struct MemDescReshapeOpConversion
     auto srcSmemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                       llvmElemTy, rewriter);
     SmallVector<Value> offsets = srcSmemObj.getOffsets();
+    // FIXME: This should be done by composing a linear layout with its
+    // reshaped counterpart.
     SmallVector<unsigned> srcShape;
     for (int64_t d : op.getSrc().getType().getShape())
       srcShape.push_back(d);
@@ -480,7 +482,6 @@ struct MemDescSubviewOpConversion
     auto layoutOrder = getOrder(srcTy);
     auto enc = srcTy.getEncoding();
 
-    // newBase = base + offset
     auto smemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                    llvmElemTy, rewriter);
     SmallVector<Value> opOffsetVals = op.getOffsets();
@@ -488,45 +489,39 @@ struct MemDescSubviewOpConversion
     // Compute total offset
     auto rankReduced = srcTy.getRank() - destTy.getRank();
 
-    Value offset;
-    if (rankReduced || (destTy.getRank() == 1 && destTy.getDimSize(0) == 1)) {
-      auto smemStrides = smemObj.getStrides(srcTy, loc, rewriter);
-      SmallVector<Value> opSmemStrides(smemStrides.end() - opOffsetVals.size(),
-                                       smemStrides.end());
-      // We are splitting the pipelining dimension which may not be a power of 2
-      // so we can't use LinearLayouts
-      offset = dot(rewriter, loc, opOffsetVals, opSmemStrides);
-    } else {
-      auto dimNames = standardOutDimNames(ctx, opOffsetVals.size());
-      SmallVector<std::pair<StringAttr, Value>> logicalOffsets;
-      for (auto [dim, offset] : llvm::zip(dimNames, opOffsetVals)) {
-        logicalOffsets.push_back({dim, offset});
-      }
-      auto ll = toLinearLayout(srcTy);
-      // Checked in the verifier.
-      assert(ll.getInDimSize(str_attr("block")) == 1);
-      auto kOffset = str_attr("offset");
-      ll = ll.reshapeIns({{kOffset, ll.getTotalInDimSize()}});
-      offset = applyLinearLayout(loc, rewriter, ll.invert(), logicalOffsets)[0]
-                   .second;
-    }
-
-    if (auto paddedLayout = dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(
-            srcTy.getEncoding())) {
-      // Apply padding based on the computed offset
-      Value padOffset = emitPadding(loc, rewriter, paddedLayout, offset);
-      offset = b.add(offset, padOffset);
-    }
-
-    SmallVector<Value> offsetVals;
-    for (int i = rankReduced; i < opOffsetVals.size(); i++) {
-      offsetVals.push_back(b.add(opOffsetVals[i], smemObj.getOffsets()[i]));
-    }
-
     auto base = smemObj.getBase();
     auto elemPtrTy = base.getType();
-    smemObj = SharedMemoryObject(b.gep(elemPtrTy, llvmElemTy, base, offset),
-                                 llvmElemTy, offsetVals);
+    if (rankReduced || (destTy.getRank() == 1 && destTy.getDimSize(0) == 1)) {
+      // TODO Split into its own op
+      // At the moment we assume this is only used in the context of pipelining
+      // If we want to generalise it, we should use `applyLinearLayout` whenever
+      // all the shapes are powers of 2 and effectively treat it as the other
+      // memdesc_subview
+
+      // We just allow to split along the first dimension in the verifier
+      auto shape = srcTy.getShape().take_back(destTy.getRank());
+      auto stride = product(shape);
+      Value offset = b.mul(opOffsetVals[0], b.i32_val(stride));
+      // Remove the first offset
+      SmallVector<Value> offsetVals;
+      for (auto [oldOff, newOff] :
+           llvm::zip(smemObj.getOffsets(),
+                     ArrayRef<Value>(opOffsetVals).drop_front())) {
+        offsetVals.push_back(b.add(oldOff, newOff));
+      }
+      // Advance the pointer and keep the opOffsets as the new shape
+      smemObj = SharedMemoryObject(b.gep(elemPtrTy, llvmElemTy, base, offset),
+                                   llvmElemTy, offsetVals);
+    } else {
+      // Accumulate the logical offsets
+      SmallVector<Value> offsetVals;
+      for (auto [oldOff, newOff] :
+           llvm::zip(smemObj.getOffsets(), opOffsetVals)) {
+        offsetVals.push_back(b.add(oldOff, newOff));
+      }
+      smemObj = SharedMemoryObject(base, llvmElemTy, offsetVals);
+    }
+
     auto retVal = getStructFromSharedMemoryObject(loc, smemObj, rewriter);
     rewriter.replaceOp(op, retVal);
     return success();

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -510,10 +510,10 @@ struct MemDescSubviewOpConversion
       auto shape = srcTy.getShape().take_back(destTy.getRank());
       auto stride = product(shape);
       Value offset = b.mul(opOffsetVals[0], b.i32_val(stride));
-      // Remove the first offset
+      // Remove the first offsets
       SmallVector<Value> offsetVals;
       for (auto [oldOff, newOff] :
-           llvm::zip(smemObj.getOffsets(),
+           llvm::zip(ArrayRef<Value>(smemObj.getOffsets()).drop_front(),
                      ArrayRef<Value>(opOffsetVals).drop_front())) {
         offsetVals.push_back(b.add(oldOff, newOff));
       }

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -493,7 +493,7 @@ struct MemDescSubviewOpConversion
     auto elemPtrTy = base.getType();
     auto is1d = srcTy.getRank() == 1 && destTy.getRank() == 1 &&
                 destTy.getDimSize(0) == 1;
-    if (rankReduced) {
+    if (rankReduced || is1d) {
       if (is1d) {
         smemObj = SharedMemoryObject(
             b.gep(elemPtrTy, llvmElemTy, base, opOffsetVals[0]), llvmElemTy,

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -491,7 +491,15 @@ struct MemDescSubviewOpConversion
 
     auto base = smemObj.getBase();
     auto elemPtrTy = base.getType();
-    if (rankReduced || (destTy.getRank() == 1 && destTy.getDimSize(0) == 1)) {
+    auto is1d = srcTy.getRank() == 1 && destTy.getRank() == 1 &&
+                destTy.getDimSize(0) == 1;
+    if (rankReduced) {
+      if (is1d) {
+        smemObj = SharedMemoryObject(
+            b.gep(elemPtrTy, llvmElemTy, base, opOffsetVals[0]), llvmElemTy,
+            {b.i32_val(0)});
+        return success();
+      }
       // TODO Split into its own op
       // At the moment we assume this is only used in the context of pipelining
       // If we want to generalise it, we should use `applyLinearLayout` whenever

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -293,16 +293,17 @@ ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout) {
   return ColumnAction(permOrder, kReg, bases.size());
 }
 std::pair<int64_t, ColumnAction>
-actionAdditiveStrides(const LinearLayout &layout) {
+actionAdditiveStrides(const LinearLayout &layout, uint64_t maskSpanOffsets) {
   // We are looking to put at the front (after any zeros) any basis that does
   // not intersect with any bit moved by any basis in kLane / kWarp
+  // and that is not moved by any affine offset
   assert(layout.getNumInDims() != 0);
   auto kReg = *layout.getInDimNames().begin();
   assert(kReg.str() == "register");
   auto kLane = StringAttr::get(kReg.getContext(), "lane");
   auto kWarp = StringAttr::get(kReg.getContext(), "warp");
   assert(layout.getNumOutDims() == 1);
-  uint32_t bits = 0;
+  uint32_t bits = maskSpanOffsets;
   for (auto dim : {kLane, kWarp}) {
     const auto &bases = layout.getBases().lookup(dim);
     for (auto basis : bases) {

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -982,24 +982,18 @@ LinearLayout lstsq(const LinearLayout &A, const LinearLayout &B) {
   // Compute the pivot columns
   // Since A and B have the same image, each row will either have a pivot
   // or will be all zeros
-
   SmallVector<int32_t> pivotRowOfCol(numColsA, -1);
-  int rowIdx = -1;
-  for (auto [outDim, outDimSize] : A.getOutDims()) {
-    for (int r = 0; r < llvm::Log2_32(outDimSize); r++) {
-      rowIdx++;
-      uint64_t row = combinedMat[rowIdx];
-      if (row == 0) {
-        continue;
-      }
-
-      int c = __builtin_ctzll(row);
-      assert(c < numColsA &&
-             "Precondition broken. Im(B) not contained in Im(A)");
-      assert(pivotRowOfCol[c] == -1 &&
-             "duplicate pivot => matrix not in RREF or A not injective");
-      pivotRowOfCol[c] = rowIdx;
+  for (int r = 0; r < numRowsA; r++) {
+    uint64_t row = combinedMat[r];
+    if (row == 0) {
+      continue;
     }
+
+    int c = __builtin_ctzll(row);
+    assert(c < numColsA && "Precondition broken. Im(B) not contained in Im(A)");
+    assert(pivotRowOfCol[c] == -1 &&
+           "duplicate pivot => matrix not in RREF or A not injective");
+    pivotRowOfCol[c] = r;
   }
 
   std::unique_ptr<uint64_t[]> retMat(new uint64_t[numColsA]());

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -939,67 +939,73 @@ LinearLayout LinearLayout::compose(const LinearLayout &outer) const {
 namespace {
 std::unique_ptr<uint64_t[]> concatMatrices(const LinearLayout &A,
                                            const LinearLayout &B) {
-  // In plain words, "convert_layout does not change the shape of a tensor"
-  assert(A.getTotalOutDimSizeLog2() == B.getTotalOutDimSizeLog2() &&
-         "Matrices must have the same number of output dimensions");
-  int numRows = A.getTotalOutDimSizeLog2();
+  // conv
+  assert(A.getTotalOutDimSizeLog2() >= B.getTotalOutDimSizeLog2() &&
+         "A must have at least as many output bits as B");
   int numColsA = A.getTotalInDimSizeLog2();
 
   // rref expects the lower bits to be the lower indices of the matrix
   auto concat = getMatrix(A);
   auto BMat = getMatrix(B);
-  for (int r = 0; r < numRows; r++) {
-    concat[r] |= BMat[r] << numColsA;
+  int rowA = 0;
+  int rowB = 0;
+  for (auto [outDim, outDimSize] : A.getOutDims()) {
+    for (int r = 0; r < llvm::Log2_32(outDimSize); r++) {
+      if (r < llvm::Log2_32(B.getOutDimSize(outDim))) {
+        concat[rowA] |= BMat[rowB] << numColsA;
+        rowB++;
+      }
+      rowA++;
+    }
   }
   return concat;
 }
 
 LinearLayout lstsq(const LinearLayout &A, const LinearLayout &B) {
-  // Solve the system AX = B.
-  // We compute the solution X given by setting all the free variables to zero.
-  // If
+  // Solve the least square system AX = B
+  // and return the least square solution X by computing RREF and setting
+  // the free variables to zero.
+  // A and B may not be surjective, but we assume that Im(B) \subset Im(A)
   // Sketch of the algorithm:
   // https://github.com/triton-lang/triton/pull/5309#discussion_r1869084111
-  int numRows = A.getTotalOutDimSizeLog2();
+  assert(A.getTotalOutDimSizeLog2() >= B.getTotalOutDimSizeLog2() &&
+         "A.lstsq(B) called with incompatible output shapes");
+  int numRowsA = A.getTotalOutDimSizeLog2();
+  int numRowsB = B.getTotalOutDimSizeLog2();
   int numColsA = A.getTotalInDimSizeLog2();
   int numColsB = B.getTotalInDimSizeLog2();
   int numCols = numColsA + numColsB;
   std::unique_ptr<uint64_t[]> combinedMat = concatMatrices(A, B);
-  f2reduce::inplace_rref_strided(combinedMat.get(), numRows, numCols,
+  f2reduce::inplace_rref_strided(combinedMat.get(), numRowsA, numCols,
                                  /*stride=*/1);
 
   // Compute the pivot columns
   // Since A and B have the same image, each row will either have a pivot
   // or will be all zeros
+
   SmallVector<int32_t> pivotRowOfCol(numColsA, -1);
-  for (int r = 0; r < numRows; r++) {
-    auto row = combinedMat[r];
-    if (row == 0) {
-      continue;
+  int rowIdx = -1;
+  for (auto [outDim, outDimSize] : A.getOutDims()) {
+    for (int r = 0; r < llvm::Log2_32(outDimSize); r++) {
+      rowIdx++;
+      uint64_t row = combinedMat[rowIdx];
+      if (row == 0) {
+        continue;
+      }
+
+      int c = __builtin_ctzll(row);
+      assert(c < numColsA &&
+             "Precondition broken. Im(B) not contained in Im(A)");
+      assert(pivotRowOfCol[c] == -1 &&
+             "duplicate pivot => matrix not in RREF or A not injective");
+      pivotRowOfCol[c] = rowIdx;
     }
-    int c = __builtin_ctzll(row);
-    // We have Im(A) \not\subset Im(B).
-    // In this case we don't return a solution of the system.
-    // If A is injective, we'll return A_L^{-1}B where A_L is the left inverse
-    // of A, namely A_L A = I.
-    if (c >= numColsA) {
-      continue;
-    }
-    assert(pivotRowOfCol[c] == -1 &&
-           "duplicate pivot => A not in RREF or not injective");
-    pivotRowOfCol[c] = r;
   }
 
-  // Extract A^{-1}B and complete the matrix using zeros
   std::unique_ptr<uint64_t[]> retMat(new uint64_t[numColsA]());
   for (int c = 0; c < numColsA; ++c) {
     int row = pivotRowOfCol[c];
-    if (row == -1) {
-      retMat[c] = 0;
-    } else {
-      retMat[c] =
-          combinedMat[row] >> numColsA; // strip the A‑part, keep the B‑part
-    }
+    retMat[c] = (row == -1) ? 0 : (combinedMat[row] >> numColsA);
   }
 
   // We need names for the in/out dim of the flattened layout we're going to
@@ -1051,14 +1057,11 @@ LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
   const auto &B = *this;
   const auto A = outer.transposeOuts(outDims);
   for (auto dim : outDims) {
-    if (A.getOutDimSize(dim) != B.getOutDimSize(dim)) {
-      std::stringstream msg;
-      msg << "B.invertAndCompose(A) called with incompatible output shapes in ";
-      msg << "dim = " << std::string(dim.getValue()) << ": ";
-      msg << "A = " << A.getOutDimSize(dim) << ", ";
-      msg << "B = " << B.getOutDimSize(dim);
-      llvm::report_fatal_error(msg.str().c_str());
-    }
+    assert(A.getOutDimSize(dim) >= B.getOutDimSize(dim) &&
+           ("A.invertAndCompose(B) called with incompatible output shapes in " +
+            dim.str() + ": " + std::to_string(A.getOutDimSize(dim)) +
+            " >= " + std::to_string(B.getOutDimSize(dim)))
+               .c_str());
   }
 
   // Broadcasting heuristic
@@ -1073,6 +1076,9 @@ LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
   // - Otherwise, we just call lstsq (i.e. map all the equivalent elements
   //   to the same input element) to take advantage of broadcasting in shared
   //   memory and avoid saving repeated elements in shared memory
+
+  // FIXME: We should check that the other dimensions don't touch the image of
+  // this dimension.
   SmallVector<StringAttr> identityDims;
   for (auto dim : A.getInDimNames()) {
     if (B.hasInDim(dim) &&

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6358,8 +6358,6 @@ shared_layouts = [
 @pytest.mark.parametrize("M, N, M_tile_size, N_tile_size",
                          [[128, 128, 64, 64], [128, 128, 64, 32], [128, 64, 64, 32], [256, 128, 64, 64]])
 def test_split_subview(M, N, M_tile_size, N_tile_size, device='cuda'):
-    if not is_hip() and N_tile_size == 32:
-        pytest.skip("Will fix spliting along the swizzling pattern in the next PR")
     num_rows_per_warp = THREADS_PER_WARP // 4
     num_repeats_M = triton.cdiv(M, M_tile_size)
     num_repeats_N = triton.cdiv(N, N_tile_size)

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -436,7 +436,7 @@ module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.n
     // CHECK-NEXT: %[[SHL1:.+]] = llvm.shl %[[SHR1]], %[[CST3]] : i32
     // CHECK-NEXT: %[[ADD1:.+]] = llvm.add %[[ADD0]], %[[SHL1]] : i32
     // CHECK-NEXT: %[[ADD2:.+]] = llvm.add %[[XOR]], %[[ADD1]] : i32
-    // CHECK-NEXT: llvm.getelementptr %{{.+}}[%[[ADD2]]]
+    // CHECK: llvm.getelementptr inbounds %{{.+}}[%[[ADD2]]]
 
     %1 = ttg.memdesc_subview %arg0[%c1_i32, %c0_i32, %c0_i32] : !ttg.memdesc<2x64x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     %2 = ttg.local_load %1 : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> tensor<64x64xf16, #blocked>

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -556,8 +556,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-NEXT: llvm.extractvalue
     // CHECK-NEXT: llvm.extractvalue
     // CHECK-NEXT: llvm.extractvalue
+    // CHECK-NEXT: llvm.mlir.constant(1 : i32) : i32
+    // CHECK-NEXT: llvm.mlir.constant(32 : i32) : i32
     // CHECK-NEXT: llvm.mlir.constant(512 : i32) : i32
+    // CHECK-NEXT: llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT: llvm.mul
+    // CHECK-NEXT: llvm.add
+    // CHECK-NEXT: llvm.mul
+    // CHECK-NEXT: llvm.add
+    // CHECK-NEXT: llvm.mul
+    // CHECK-NEXT: llvm.add
     // CHECK-NEXT: llvm.add
     // CHECK-NEXT: llvm.add
     // CHECK-NEXT: llvm.getelementptr

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -556,16 +556,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-NEXT: llvm.extractvalue
     // CHECK-NEXT: llvm.extractvalue
     // CHECK-NEXT: llvm.extractvalue
-    // CHECK-NEXT: llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT: llvm.mlir.constant(32 : i32) : i32
     // CHECK-NEXT: llvm.mlir.constant(512 : i32) : i32
-    // CHECK-NEXT: llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT: llvm.mul
-    // CHECK-NEXT: llvm.add
-    // CHECK-NEXT: llvm.mul
-    // CHECK-NEXT: llvm.add
-    // CHECK-NEXT: llvm.mul
-    // CHECK-NEXT: llvm.add
     // CHECK-NEXT: llvm.add
     // CHECK-NEXT: llvm.add
     // CHECK-NEXT: llvm.getelementptr

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.cpp
@@ -67,21 +67,6 @@ Value computeOffset(ConversionPatternRewriter &rewriter, Location loc,
   return b.add(rowOffset, colOffset);
 }
 
-Value computeBasePtr(ConversionPatternRewriter &rewriter, Location loc,
-                     const SharedMemoryObject &smemObj,
-                     ArrayRef<Value> smemStrides) {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-  Value base = smemObj.getBase();
-  Type type = base.getType();
-  Type elemType = smemObj.getBaseElemType();
-  for (int i = 0; i < smemStrides.size(); ++i) {
-    Value offset =
-        b.sub(b.i32_val(0), b.mul(smemObj.getOffsets()[i], smemStrides[i]));
-    base = b.gep(type, elemType, base, offset);
-  }
-  return base;
-}
-
 bool isKContig(llvm::ArrayRef<unsigned> order, int opIdx) {
   auto rank = order.size();
   int kdim = opIdx == 0 ? rank - 1 : rank - 2;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
@@ -33,10 +33,6 @@ Value computeOffset(ConversionPatternRewriter &rewriter, Location loc,
                     ArrayRef<Value> strides,
                     gpu::SwizzledSharedEncodingAttr srcLayout);
 
-Value computeBasePtr(ConversionPatternRewriter &rewriter, Location loc,
-                     const SharedMemoryObject &smemObj,
-                     ArrayRef<Value> strides);
-
 bool isKContig(llvm::ArrayRef<unsigned> order, int opIdx);
 
 using computeTensorElemMappingInBlockT =

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -358,7 +358,7 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
           spatialWarpId, lane, warpsPerBlockNonK, numOfElems, numReps, smemObj,
           smemStrides, sharedLayout, nDim, mfmaInstrK);
     }
-    smemBase = AMD::computeBasePtr(rewriter, loc, smemObj, smemStrides);
+    smemBase = smemObj.getBase();
   }
 
   Type resElemTy = typeConverter->convertType(elemTy);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
@@ -214,7 +214,7 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
         spatialWarpId, lane, warpsPerBlockNonK, numElemsPerThreadPerRep,
         numReps, smemObj, smemStrides, sharedLayout, wmmaInstrNonK, wmmaInstrK);
   }
-  smemBase = AMD::computeBasePtr(rewriter, loc, smemObj, smemStrides);
+  smemBase = smemObj.getBase();
 
   Type resElemTy = typeConverter->convertType(elemTy);
   Type smemPtrTy = ptr_ty(rewriter.getContext(), 3);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -98,6 +98,19 @@ private:
   int numSlicePerBlockN;
 };
 
+static Value getOffsetedBase(Value v, gpu::MemDescType memDescTy,
+                             const TypeConverter *typeConverter,
+                             ConversionPatternRewriter &rewriter,
+                             Location loc) {
+  TritonLLVMOpBuilder tb(loc, rewriter);
+  auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
+  auto smemObj =
+      LLVM::getSharedMemoryObjectFromStruct(loc, v, llvmElemTy, rewriter);
+  auto offset = smemObj.getShmemOffset(loc, rewriter, memDescTy);
+  auto base = smemObj.getBase();
+  return tb.gep(base.getType(), llvmElemTy, base, offset);
+}
+
 } // namespace NVIDIA
 } // namespace triton
 } // namespace mlir

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -412,16 +412,10 @@ void convertDotImpl(const LLVMTypeConverter &typeConverter,
 
   Value baseA = loadedA;
   if (!aInTmem) {
-    baseA = getSharedMemoryObjectFromStruct(
-                loc, loadedA,
-                typeConverter.convertType(aTensorTy.getElementType()), rewriter)
-                .getBase();
+    baseA = getOffsetedBase(loadedA, aTensorTy, &typeConverter, rewriter, loc);
   }
   Value baseB =
-      getSharedMemoryObjectFromStruct(
-          loc, loadedB, typeConverter.convertType(bTensorTy.getElementType()),
-          rewriter)
-          .getBase();
+      getOffsetedBase(loadedB, bTensorTy, &typeConverter, rewriter, loc);
 
   auto [M, N, K] = op.shape;
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1282,8 +1282,10 @@ struct AsyncCopyGlobalToLocalOpConversion
     cvt = cvt.sublayout(
         {str_attr("register"), str_attr("lane"), str_attr("warp")},
         {str_attr("offset")});
-    lowerLdSt(loc, ctx, cvt, vals, resElemTy, smemObj.getBase(), rewriter,
-              targetInfo, maxVec, emitCpAsync);
+    auto affineOffset = smemObj.getShmemOffset(loc, rewriter, dstTy);
+    auto maskSpanAffineOffset = SharedMemoryObject::getMaskSpanOffsets(dstTy);
+    lowerLdSt(loc, ctx, cvt, vals, resElemTy, smemObj.getBase(), affineOffset,
+              maskSpanAffineOffset, rewriter, targetInfo, maxVec, emitCpAsync);
 
     // Drop the result token.
     Value zero = rewriter.create<LLVM::ConstantOp>(

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -147,8 +147,8 @@ LogicalResult lowerLdStMatrix(
   }
 
   // Choose up to 4 packs of 32-bit elements indexed by the next (at most) two
-  // bases as the vectorisation factor. We don't consider the basis of the
-  // tile for vectorisation so we substract them
+  // bases as the vectorisation factor. We don't consider the basis of the tile
+  // for vectorisation so we substract them
   auto vec = std::min<int32_t>(2, reps.getInDimSizeLog2(kReg) -
                                       llvm::Log2_32(32 / bitwidth));
 
@@ -159,8 +159,8 @@ LogicalResult lowerLdStMatrix(
   // Compute the addresses for the 0th tile
   // Here we implement the stmatrix.x4 addressing. As per the PTX docs, the
   // threads 0-7 hold the address of the first element of the 8 columns of the
-  // first submatrix, threads 8-15 for the second submatrix, etc. In general
-  // we map:
+  // first submatrix, threads 8-15 for the second submatrix, etc. In general we
+  // map:
   // - The lowest 3 bits of the laneId to the columns of each submatrix, which
   // is
   //   given by the 3 kLane bases of quotient that are not part of the tile
@@ -178,8 +178,8 @@ LogicalResult lowerLdStMatrix(
       laneBases.push_back(reps.getBasis(kReg, tileDimSizeReg + i));
     }
   } else {
-    // We choose the first basis of the register. In the future we could
-    // choose a basis that minimises the bank conflicts
+    // We choose the first basis of the register. In the future we could choose
+    // a basis that minimises the bank conflicts
     laneBases.push_back(reps.getBasis(kReg, 0));
     laneBases.push_back(reps.getBasis(kLane, 0));
     laneBases.push_back(reps.getBasis(kLane, 1));


### PR DESCRIPTION
Layouts coming from `memdesc_subview` are at heart affine layouts.
This is because partial evaluation of a linear map on some variables
gives you an affine map. More concretely, if `c` is a constant
and `x` is a variable, we have that `A(x ^ c) = A(x) ^ A(c)` where
`A(c)` is a constant. In `memdesc_subview`, `A` is the map from the
matrix into shared memory (the inverse of the shared memory linear layout)
and `c` are the offsets given in the IR of `memdesc_subview`.

Previously `memdesc_subview` would advance the pointer as `ptr += A(c)`.
This is incorrect, as the actual formula for the address is given by
`ptr + (A(c) ^ A(x))`, so we compensated for this when computing the
address by substracting the offsets and adding them as an xor
https://github.com/triton-lang/triton/blob/8e52b2e483eb072149801443e2e33b0b72d32bc5/lib/Conversion/TritonGPUToLLVM/Utility.cpp#L604-L605

In this PR we untangle these issues by:

1. Just advancing the base ptr when we index over the pipelining
   dimensions (this will be split out into its own op in a future PR)
2. Exposing two methods on SharedMemoryObject to compute the affine part
   of the layout (what we called `A(c)` above) and compute the bits that
   `A(c)` may have on. This second part is useful to perform
   optimisations.
3. Decreeing that shared layout will always return the layout of the
   full allocShape (minus the pipelining dimension). This means that
   `toLinearLayout(MemDescType)` may return a layout of a different
   output shape as the tensor it represents. This should not be a
   problem because of the next poitn
4. To account for the previous point, we generalise `invertAndCompose`
   to solve systems `AX = B` where `A` may have an output dimension larger
   than `B`. In this case we still compute the linear map compositon
   `A^{-1}B`, which is well defined as `Im(B) \subset Im(A)`

In the future we could consider always describing shared layouts as maps
from the tensor into the offsets. This would allow us to represent the
linear part of the affine map above via linear layouts, and we could
simply return a layout of the correct shape from
`toLinearLayout(MemDescType)`, rather than an oversized one.
This makes also intuitive sense, as we will never want to store the same
element in two different parts of the shared memory, so this map will
always be well-defined, while its inverse may not be, as it is the case
here.

We also take the chance to give a good clean-up to
`emitTransferBetweenRegistersAndShared` now that the logic is better
defined. The generated code should be comparable or better than the
previous one.
