### PR TITLE
[Release Only] Install torch rc before compiling triton 3.4.x

### DIFF
--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -74,6 +74,8 @@ jobs:
           if [ "${{ matrix.runner[0] }}" == "nvidia-gb200" ]; then
             source /venv/bin/activate
           fi
+          # install torch rc
+          python3 -m pip install torch --index-url https://download.pytorch.org/whl/test/cu128
           nproc
           nvidia-smi
           echo "PATH is '$PATH'"


### PR DESCRIPTION
Seeing an issue during integation test for Nvidia:
https://github.com/triton-lang/triton/actions/runs/16318528360/job/46090164496?pr=7532
