### PR TITLE
[CI] Continue running CI when gb200 errors out

### DIFF
--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -11,6 +11,8 @@ jobs:
   integration-tests-nvidia:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    # Let A100 and H100 continue even if GB200 fails, as it's a bit flaky
+    continue-on-error: ${{ matrix.runner[0] == 'nvidia-gb200'}}
     strategy:
       matrix:
         runner: ${{ fromJson(inputs.matrix) }}


### PR DESCRIPTION
gb200 is broken at the moment, this should allow the rest of CI to still run.