### PR TITLE
[FRONTEND] Remove incorrect and misleading error message from the return-in-while check

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -541,4 +541,7 @@ def test_return_in_while():
     # CHECK-LABEL: test_return_in_while
     i = 0
     while i < 10:
-        i = trivial_return(i + 1)
+        if i == 5:
+            i = trivial_return(i + 1)
+        else:
+            i = trivial_return(i + 1)

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -540,7 +540,7 @@ def trivial_return():
 @filecheck_test
 @triton.jit
 def test_call_in_while():
-    # CHECK-LABEL: test_return_in_while
+    # CHECK-LABEL: test_call_in_while
     i = 0
     while i < 10:
         if i == 5:

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -528,3 +528,16 @@ def test_specialized_recursion():
 
     # CHECK: func {{.*}}recursive_reduce__i32S4S
     # CHECK-COUNT-2: call {{.*}}recursive_reduce__i32S2S
+
+
+@triton.jit
+def trivial_return(x):
+    return x
+
+
+@filecheck_test
+@triton.jit
+def test_return_in_while():
+    i = 0
+    while i < 10:
+        i = trivial_return(i + 1)

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -544,9 +544,9 @@ def test_call_in_while():
     i = 0
     while i < 10:
         if i == 5:
-            i = trivial_return(i + 1)
+            trivial_return()
         else:
-            i = trivial_return(i + 1)
+            trivial_return()
 
 
 def test_return_in_while():

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -562,4 +562,4 @@ def test_return_in_while():
     with pytest.raises(CompilationError) as e:
         kernel.warmup(grid=(1, ))
 
-    assert "Cannot have `return` statements inside `while` or `for` statements in triton" in str(e.value.__cause__)
+    assert "Cannot have `return` statements inside `while` or `for` statements in triton" in str(e.value)

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -538,6 +538,7 @@ def trivial_return(x):
 @filecheck_test
 @triton.jit
 def test_return_in_while():
+    # CHECK-LABEL: test_return_in_while
     i = 0
     while i < 10:
         i = trivial_return(i + 1)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -852,13 +852,10 @@ class CodeGenerator(ast.NodeVisitor):
                     % ast.unparse(node.test))
                 cond = language.core._unsplat(cond, _semantic=self.semantic, _generator=self)
             cond = cond.to(language.int1, _semantic=self.semantic)
-            contains_return = ContainsReturnChecker(self.gscope).visit(node)
-            if contains_return:
+            if ContainsReturnChecker(self.gscope).visit(node):
                 if self.scf_stack:
                     raise self._unsupported(
-                        node, "Cannot have `return` statements inside `while` or `for` statements in triton "
-                        "(note that this also applies to `return` statements that are inside functions "
-                        "transitively called from within `while`/`for` statements)")
+                        node, "Cannot have `return` statements inside `while` or `for` statements in triton.")
                 self.visit_if_top_level(cond, node)
             else:
                 self.visit_if_scf(cond, node)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -147,9 +147,9 @@ class ContainsReturnChecker(ast.NodeVisitor):
         return any(self.visit(s) for s in body)
 
     def _visit_function(self, fn) -> bool:
-        # no need to check within the function as it won't cause an early return.
-        # If the function itself has unstructured control flow we may not be able to inline it causing poor performance.
-        # We should check for this and fail or emit a warning.
+        # No need to check within the function as it won't cause an early return.
+        # If the function itself has unstructured control flow we may not be able to inline it causing poor performance,
+        # we should check for this and emit a warning.
         return False
 
     def generic_visit(self, node) -> bool:


### PR DESCRIPTION
We actually don't check `return`s in functions being called within `while` or `for`.

```
    def _visit_function(self, fn) -> bool:
        # No need to check within the function as it won't cause an early return.
        # If the function itself has unstructured control flow we may not be able to inline it causing poor performance,
        # we should check for this and emit a warning.
        return False
```