### PR TITLE
[CMAKE] Fix the dependencies fo NVGPU and NVIDIAGPU libraries

### DIFF
--- a/third_party/nvidia/lib/NVGPUToLLVM/CMakeLists.txt
+++ b/third_party/nvidia/lib/NVGPUToLLVM/CMakeLists.txt
@@ -3,5 +3,7 @@ add_triton_library(NVGPUToLLVM
 
     DEPENDS
     NVGPUConversionPassIncGen
+
+    LINK_LIBS PUBLIC
     NVGPUIR
 )

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
@@ -29,4 +29,6 @@ add_triton_library(TritonNVIDIAGPUToLLVM
     TritonProtonToLLVM
     TritonInstrumentToLLVM
     MLIRReconcileUnrealizedCasts
+    NVGPUToLLVM
+    MLIRUBToLLVM
 )


### PR DESCRIPTION
NVGPU dependencies were not transitive (public) and NVIDIAGPU was
missing a couple
