### PR TITLE
 Update RewritePartitionDepdencies to insert arefs

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -130,7 +130,8 @@ def TritonGPURewritePartitionDependencies : Pass<"tritongpu-rewrite-partition-de
     "mlir::triton::gpu::TritonGPUDialect",
     "mlir::scf::SCFDialect",
     "mlir::arith::ArithDialect",
-    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+    "mlir::triton::nvws::NVWSDialect"
   ];
 }
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -7,6 +7,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/Support/LLVM.h"
+#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Interfaces.h"
 #include "triton/Dialect/Triton/IR/Utility.h"

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
@@ -3,6 +3,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
+#include "third_party/nvidia/include/Dialect/NVWS/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
@@ -42,6 +43,8 @@ void AutomaticWarpSpecialization::runOnOperation() {
   pm.addPass(createSCCPPass());
   pm.addPass(createCSEPass());
   pm.addPass(createTritonGPUPartitionLoops());
+  pm.addPass(createNVWSLowerAref());
+  pm.addPass(createNVWSLowerWarpGroup());
   if (failed(runPipeline(pm, getOperation())))
     return signalPassFailure();
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -499,10 +499,4 @@ void PartitionLoops::runOnOperation() {
     if (failed(partitionLoop(loop)))
       return signalPassFailure();
   }
-
-  OpPassManager pm;
-  pm.addPass(mlir::triton::createNVWSLowerWarpGroup());
-
-  if (failed(runPipeline(pm, getOperation())))
-    return signalPassFailure();
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -2,6 +2,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
+#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Partition.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
@@ -9,11 +10,11 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonGPU/Transforms/WarpSpecialization.h"
 #include "llvm/ADT/SCCIterator.h"
+#include "llvm/ADT/STLExtras.h"
 
 using namespace mlir;
 using namespace triton;
 using namespace triton::gpu;
-namespace ttng = triton::nvidia_gpu;
 
 //===----------------------------------------------------------------------===//
 // Helpers
@@ -28,229 +29,69 @@ static Operation *getEarliestUser(ArrayRef<OpOperand *> uses) {
 }
 
 //===----------------------------------------------------------------------===//
-// Multiplicity
-//===----------------------------------------------------------------------===//
-
-namespace {
-// Partition results are passed into future loop iterations through the region
-// iter args of the loop. However, a specific block argument's SSA users could
-// belong to multiple partitions or another `scf.yield`, where it is passed into
-// another future iterations. Tracing forward the uses of a partition output
-// creates a tree where each branch represents a series of block arguments and
-// their corresponding initial values. Each use of the output in a future
-// iteration is somewhere along the tree. To codegen the right initial values,
-// the tree is flattened such that only the root node has multiple children.
-//
-// Consider:
-//
-//   for ... iter_args(%arg0 = %init0, %arg1 = %init1, %arg2 = %init2)
-//     %output = f() {partition = 0}
-//     use(%arg0)    {partition = 1}
-//     use(%arg0)    {partition = 2}
-//     use(%arg1)    {partition = 3}
-//     use(%arg2)    {partition = 4}
-//     yield %output, %arg0, %arg0
-//
-// The first iteration of partitions 1 and 2 must read `%init0` for the i+1
-// value of `%output`, but partitions 2 and 3 read `%init1` and `%init2`
-// respectively as the i+2 values of `%output`.
-//
-// The corresponding tree is:
-//
-//   %output (root) -> %arg0 -> %arg1
-//                         \--> %arg2
-//
-struct Multiplicity {
-  // A node in the multiplicity tree, representing a region iter arg.
-  struct Node {
-    // The index of the region iter arg.
-    unsigned argIdx = -1;
-    // The depth of the node in the tree, which actually represents the
-    // distance.
-    unsigned depth = 0;
-    // The children nodes, i.e. the region iter args whose values are derived
-    // from this iter arg.
-    llvm::SmallSetVector<Node *, 2> children;
-
-    // This value is set later but represents the branch index of the flattened
-    // tree that this node belongs to.
-    int number = -1;
-  };
-
-  // Get or create a node in the tree for the given region iter index and at a
-  // certain depth (distance).
-  Node *getOrCreate(unsigned idx, unsigned depth);
-  // Add nodes to the multiplicity tree given uses of an output at a paritition
-  // and distance.
-  void add(ArrayRef<OpOperand *> uses, unsigned distance, scf::YieldOp yield);
-
-  // The total branch depth is the number of nodes in the flattened tree, and
-  // the number of extra buffers needed.
-  unsigned getTotalBranchDepth();
-  // Flatten the tree by assigning each node to a branch. A callback is invoked
-  // for each branch and the start and end indices of the nodes along that
-  // branch.
-  void number(
-      function_ref<void(ArrayRef<Node *>, unsigned, unsigned)> branchCallback);
-
-  // The root node, which represents the partition output itself.
-  std::unique_ptr<Node> root = std::make_unique<Node>();
-  // All the nodes in the tree, mapped by region iter arg index.
-  llvm::MapVector<unsigned, std::unique_ptr<Node>> nodes;
-  // Map from branch index to buffer start and end index, populated by `number`.
-  SmallVector<std::pair<unsigned, unsigned>> segments;
-};
-} // namespace
-
-Multiplicity::Node *Multiplicity::getOrCreate(unsigned idx, unsigned depth) {
-  std::unique_ptr<Node> &node = nodes[idx];
-  if (!node) {
-    node = std::make_unique<Node>();
-    node->argIdx = idx;
-    node->depth = depth;
-  }
-  // Check that the node is consistent.
-  assert(node->depth == depth && "conflicting node");
-  return node.get();
-}
-
-// A partition output used a future iteration could get carried as an iter arg
-// that is used in two different partitions. Consider:
-//
-//   scf.for %i = %lb to %ub step %step (%arg = %init)
-//     %next = op_c()   {ttg.partition = 0}
-//     op_a(%arg)       {ttg.partition = 1}
-//     op_b(%arg)       {ttg.partition = 2}
-//     scf.yield %next
-//
-// Output `%next` is used in partitions #1 and #2 but through the same arg.
-void Multiplicity::add(ArrayRef<OpOperand *> uses, unsigned distance,
-                       scf::YieldOp yield) {
-  for (OpOperand *use : uses) {
-    OpOperand *curUse = use;
-    SmallVector<unsigned> trace;
-    for (unsigned d = distance; d; --d) {
-      auto arg = cast<BlockArgument>(curUse->get());
-      unsigned idx = arg.getArgNumber() - 1;
-      trace.push_back(idx);
-      curUse = &yield.getResultsMutable()[idx];
-    }
-    Multiplicity::Node *parent = root.get();
-    for (auto [depth, idx] : llvm::enumerate(llvm::reverse(trace))) {
-      Multiplicity::Node *node = getOrCreate(idx, depth + 1);
-      parent->children.insert(node);
-      parent = node;
-    }
-  }
-}
-
-void Multiplicity::number(
-    function_ref<void(ArrayRef<Node *>, unsigned, unsigned)> branchCallback) {
-  // Depth-first traversal of the tree. Each new branch is assigned to an
-  // incremented branch index. Thus, the "flattened" tree is virtual and isn't
-  // bigger than the actual tree.
-  SmallVector<Node *> dfs;
-  dfs.push_back(root.get());
-  int number = 0;
-  unsigned segmentStart = 0;
-  // Keep the traceback of the nodes along the virtual branch.
-  SmallVector<Node *> trace;
-  while (!dfs.empty()) {
-    Node *node = dfs.pop_back_val();
-    trace.push_back(node);
-    // Assign the branch index.
-    node->number = number;
-    llvm::append_range(dfs, node->children);
-
-    // If there are no children, we know we reached the end of a branch.
-    if (node->children.empty()) {
-      // Save the segment indices.
-      segments.emplace_back(segmentStart, segmentStart + node->depth);
-      auto [start, end] = segments.back();
-      assert(node->depth == trace.size() - 1);
-      // Don't include the root.
-      branchCallback(ArrayRef(trace).drop_front(), start, end);
-
-      // Move to the next branch.
-      segmentStart += node->depth;
-      ++number;
-      if (!dfs.empty())
-        trace.resize(dfs.back()->depth);
-    }
-  }
-}
-
-unsigned Multiplicity::getTotalBranchDepth() {
-  unsigned multiplicitySize = 0;
-  for (Multiplicity::Node &node :
-       llvm::make_pointee_range(llvm::make_second_range(nodes))) {
-    if (node.children.empty())
-      multiplicitySize += node.depth;
-  }
-  return multiplicitySize;
-}
-
-//===----------------------------------------------------------------------===//
 // UseInfo
 //===----------------------------------------------------------------------===//
 
 namespace {
 // Use information for a partition SSA output.
 struct UseInfo {
-  // Get the maximum distance to a use, according for stage and iteration, given
-  // the partition where the value is defined.
+  // Get the maximum distance to a use, according for stage and iteration,
+  // given the partition where the value is defined.
   int getMaxUseDistance(const Partition &partitition);
 
   // Map from partition and distance to the uses in that partition.
   llvm::MapVector<std::pair<Partition *, unsigned>, SmallVector<OpOperand *>>
       consumers;
-  // The multiplicity tree of the output.
-  Multiplicity multiplicity;
 };
 } // namespace
 
 int UseInfo::getMaxUseDistance(const Partition &partition) {
   int maxDistance = 0;
   for (auto [usePartition, distance] : llvm::make_first_range(consumers)) {
-    int dist = usePartition->getStage() - partition.getStage() + distance;
-    assert(dist > 0 && "expected verifier to check schedule validity");
+    int dist = 2 + distance;
     maxDistance = std::max(maxDistance, dist);
   }
   return maxDistance;
 }
-
 //===----------------------------------------------------------------------===//
 // AsyncRef
 //===----------------------------------------------------------------------===//
 
 namespace {
 struct AsyncRef {
-  Value getValueView(ImplicitLocOpBuilder &b, Value idx) const {
-    Value zero = b.create<arith::ConstantOp>(b.getI32IntegerAttr(0));
-    SmallVector<Value> offsets(allocType.getRank(), zero);
-    offsets.front() = idx;
-    return b.create<MemDescSubviewOp>(viewType, alloc, offsets);
-  }
-  Value getReadyView(ImplicitLocOpBuilder &b, Value idx) const {
-    return createSingleBufferView(b, readyBars, idx);
-  }
-  Value getEmptyView(ImplicitLocOpBuilder &b, Value idx) const {
-    return createSingleBufferView(b, emptyBars, idx);
-  }
-  auto getView(ImplicitLocOpBuilder &b, Value idx) const {
-    auto valView = getValueView(b, idx);
-    auto readyView = getReadyView(b, idx);
-    auto emptyView = getEmptyView(b, idx);
-    return std::make_tuple(valView, readyView, emptyView);
+  auto putView(PartitionBuilder &b, Partition &partition,
+               StageCluster srcStageCluster) {
+    auto zero = b.create<arith::ConstantOp>(b.getI32IntegerAttr(0));
+    auto enterOp = b.createInto<triton::nvws::ArefPutEnterOp>(
+        partition, srcStageCluster, viewType, aref, zero);
+
+    auto exitOp = [this, &partition, srcStageCluster](PartitionBuilder &b) {
+      auto zero = b.create<arith::ConstantOp>(b.getI32IntegerAttr(0));
+      auto exitOp = b.createInto<triton::nvws::ArefPutExitOp>(
+          partition, srcStageCluster, aref, zero,
+          b.getArrayAttr(SmallVector<Attribute>{triton::nvws::AsyncOpAttr::get(
+              aref.getContext(), triton::nvws::AsyncOp::NONE)}));
+    };
+    return std::make_tuple(enterOp.getResult(0), exitOp);
   }
 
-  unsigned multiplicitySize;
-  unsigned maxDistance;
-  Value alloc;
-  Value readyBars;
-  Value emptyBars;
+  auto getView(PartitionBuilder &b, Partition &partition,
+               StageCluster srcStageCluster) {
+    auto zero = b.create<arith::ConstantOp>(b.getI32IntegerAttr(0));
+    auto enterOp = b.createInto<triton::nvws::ArefGetEnterOp>(
+        partition, srcStageCluster, viewType, aref, zero);
 
-  MemDescType allocType;
+    auto exitOp = [this, &partition, srcStageCluster](PartitionBuilder &b) {
+      auto zero = b.create<arith::ConstantOp>(b.getI32IntegerAttr(0));
+      auto exitOp = b.createInto<triton::nvws::ArefGetExitOp>(
+          partition, srcStageCluster, aref, zero,
+          b.getArrayAttr(SmallVector<Attribute>{triton::nvws::AsyncOpAttr::get(
+              aref.getContext(), triton::nvws::AsyncOp::NONE)}));
+    };
+    return std::make_tuple(enterOp.getResult(0), exitOp);
+  }
+
+  Value aref;
   MemDescType viewType;
 };
 
@@ -269,15 +110,8 @@ public:
   LogicalResult run();
 
 private:
-  void resolveOutputMultiplicity(llvm::MapVector<OpResult, UseInfo> &useInfo,
-                                 const Partition &partition);
-  AsyncRef allocateAsyncValue(RankedTensorType tensorType, unsigned maxDistance,
-                              unsigned multiplicitySize);
-  void initializeBarriers(int index, const AsyncRef &aref,
-                          unsigned numConsumers, Value init);
-  std::pair<Value, Value> createAndGetAsyncIndex(
-      const AsyncRef &aref,
-      function_ref<void(int &, Value &, Value)> extraCondition = {});
+  AsyncRef allocateAsyncValue(RankedTensorType tensorType,
+                              unsigned maxDistance);
 
   // The schedule to apply.
   WarpSchedule &schedule;
@@ -288,111 +122,54 @@ private:
 };
 } // namespace
 
-void DependencyRewriter::resolveOutputMultiplicity(
-    llvm::MapVector<OpResult, UseInfo> &useInfo, const Partition &partition) {
-  auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
-  for (UseInfo &info : llvm::make_second_range(useInfo)) {
-    for (auto [key, uses] : info.consumers) {
-      auto [usePartition, distance] = key;
-      assert(usePartition != &partition && "unexpected self-recursion");
-      if (distance == 0) {
-        // This is a use of the output in the current iteration.
-        continue;
-      }
-      // We have uses of a value in a future iteration.
-      info.multiplicity.add(uses, distance, yield);
-    }
-  }
-}
-
 AsyncRef DependencyRewriter::allocateAsyncValue(RankedTensorType tensorType,
-                                                unsigned multiplicitySize,
                                                 unsigned maxDistance) {
   OpBuilder::InsertionGuard guard(b);
   b.setInsertionPoint(loop);
-  unsigned numBars = multiplicitySize + maxDistance;
+  unsigned numBars = maxDistance;
   Value alloc = createAlloc(loop, tensorType, b.getLoc(),
                             getSharedEncoding(tensorType), numBars);
-  Value readyBars = createScalarAlloc(b, b.getI64Type(), numBars);
-  Value emptyBars = createScalarAlloc(b, b.getI64Type(), numBars);
   auto allocType = cast<MemDescType>(alloc.getType());
-  return AsyncRef{multiplicitySize,
-                  maxDistance,
-                  alloc,
-                  readyBars,
-                  emptyBars,
-                  allocType,
-                  getBufferViewType(allocType)};
-}
+  auto arefTy = triton::nvws::ArefType::get(
+      b.getContext(),
+      triton::nvws::TypeArrayAttr::get(b.getContext(), alloc.getType()));
+  auto aref = b.create<triton::nvws::ArefCreateOp>(b.getLoc(), arefTy, alloc);
 
-// Initialize the barriers for a particular buffer. If there is an initial value
-// for the buffer, store it and mark the buffer as ready to be consumed.
-void DependencyRewriter::initializeBarriers(int index, const AsyncRef &aref,
-                                            unsigned numConsumers, Value init) {
-  OpBuilder::InsertionGuard guard(b);
-  b.setInsertionPoint(loop);
-
-  Value idx = b.intCst(index);
-  if (init) {
-    Value view = aref.getValueView(b, idx);
-    b.create<LocalStoreOp>(init, view);
-  }
-
-  Value readyView = aref.getReadyView(b, idx);
-  Value emptyView = aref.getEmptyView(b, idx);
-  b.create<ttng::InitBarrierOp>(readyView, 1);
-  b.create<ttng::InitBarrierOp>(emptyView, numConsumers);
-  if (init)
-    b.create<ttng::ArriveBarrierOp>(readyView, 1);
-  else
-    b.create<ttng::ArriveBarrierOp>(emptyView, numConsumers);
-
-  endBuilder.create<ttng::InvalBarrierOp>(readyView);
-  endBuilder.create<ttng::InvalBarrierOp>(emptyView);
-}
-
-std::pair<Value, Value> DependencyRewriter::createAndGetAsyncIndex(
-    const AsyncRef &aref,
-    function_ref<void(int &, Value &, Value)> extraCondition) {
-  Block *body = loop.getBody();
-  Value one = b.intCst(1);
-
-  // Thread the phase and buffer index through the loop. The index is
-  // pre-incremented.
-  Value idx = body->addArgument(b.getI32Type(), b.getLoc());
-  Value phase = body->addArgument(b.getI32Type(), b.getLoc());
-  idx = b.create<arith::AddIOp>(idx, one);
-  Value nextPhase = b.create<arith::XOrIOp>(phase, one);
-  Value cnd = b.create<arith::CmpIOp>(
-      arith::CmpIPredicate::eq, idx,
-      b.intCst(aref.multiplicitySize + aref.maxDistance));
-  // The phase flips when we reach the end of all buffers.
-  phase = b.create<arith::SelectOp>(cnd, nextPhase, phase);
-
-  int startIdx = aref.multiplicitySize;
-  if (extraCondition)
-    extraCondition(startIdx, cnd, idx);
-
-  idx = b.create<arith::SelectOp>(cnd, b.intCst(aref.multiplicitySize), idx);
-
-  auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
-  yield.getResultsMutable().append({idx, phase});
-  OpBuilder::InsertionGuard guard(b);
-  b.setInsertionPoint(loop);
-  // The index is preincremented so subtract 1 from the start.
-  loop.getInitArgsMutable().append({b.intCst(startIdx - 1), b.intCst(0)});
-  return {idx, phase};
+  return AsyncRef{aref, getBufferViewType(allocType)};
 }
 
 LogicalResult DependencyRewriter::run() {
-  SmallVector<llvm::MapVector<OpResult, UseInfo>> partitionUseInfo;
-  auto yield = cast<scf::YieldOp>(loop.getBody()->getTerminator());
+  SmallVector<llvm::MapVector<Value, UseInfo>> partitionUseInfo;
 
   for (const Partition &partition : schedule.getPartitions()) {
     // Find all consumers of all outputs of this partition, tracking the
-    // specific partition and distance of each use.
+    // specific Partition
     auto &useInfo = partitionUseInfo.emplace_back();
-    auto callback = [&](OpResult output, OpOperand &use, unsigned distance) {
+    SmallVector<std::tuple<Value, OpOperand *, unsigned>> uses;
+
+    std::function<void(OpOperand &)> collectUses;
+    collectUses = [&](OpOperand &use) {
+      Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
+      if (isa<scf::YieldOp>(owner)) {
+        // This value is used in a subsequent iteration.
+        // collect the uses of the appropriate loop arg
+        for (auto &newUse : loop.getBody()
+                                ->getArgument(use.getOperandNumber() + 1)
+                                .getUses()) {
+          collectUses(newUse);
+        }
+      } else if (schedule.getPartition(owner) != &partition) {
+        // This value is used in a different partition in the same iteration.
+        uses.emplace_back(use.get(), &use, 0);
+      }
+    };
+    for (Operation *op : partition.getOps()) {
+      for (OpOperand &use : op->getUses()) {
+        collectUses(use);
+      }
+    }
+
+    auto callback = [&](Value output, OpOperand &use, unsigned distance) {
       Operation *user = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
       Partition *usePartition = schedule.getPartition(user);
       // Ignore uses in the same partition in the future.
@@ -400,11 +177,18 @@ LogicalResult DependencyRewriter::run() {
         assert(distance > 0 && "self-recursion must occur in the future");
         return;
       }
+      Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
       UseInfo &info = useInfo[output];
       info.consumers[{usePartition, distance}].push_back(&use);
     };
-    schedule.iterateUses(loop, &partition, callback);
-    resolveOutputMultiplicity(useInfo, partition);
+
+    while (!uses.empty()) {
+      auto [output, use, distance] = uses.pop_back_val();
+      Operation *owner =
+          loop.getBody()->findAncestorOpInBlock(*use->getOwner());
+      if (!isa<scf::YieldOp>(owner))
+        callback(output, *use, distance);
+    }
   }
 
   // Cut all SSA dependencies by passing outputs through shared memory.
@@ -412,7 +196,8 @@ LogicalResult DependencyRewriter::run() {
        llvm::zip(schedule.getPartitions(), partitionUseInfo)) {
     // The amount of buffering is based on the longest distance to a user.
     for (auto &[output, info] : useInfo) {
-      // FIXME: No IR support for passing simple scalars through shared memory.
+      // FIXME: No IR support for passing simple scalars through shared
+      // memory.
       auto tensorType = dyn_cast<RankedTensorType>(output.getType());
       if (!tensorType) {
         return mlir::emitWarning(output.getLoc(),
@@ -420,37 +205,28 @@ LogicalResult DependencyRewriter::run() {
                                  "partitions are supported");
       }
 
+      Operation *defOp;
+      Value tmp = output;
+      while (true) {
+        if (auto arg = dyn_cast<BlockArgument>(tmp)) {
+          tmp = loop.getBody()->getTerminator()->getOperand(arg.getArgNumber() -
+                                                            1);
+          continue;
+        }
+        defOp = tmp.getDefiningOp();
+        break;
+      }
+
       // Buffer the value based on the greatest distance to a consumer
       // partition.
       int maxDistance = info.getMaxUseDistance(partition);
-      // Number the branches of the multiplicity tree. The total number of
-      // required buffers includes the lengths of all branches.
-      int multiplicitySize = info.multiplicity.getTotalBranchDepth();
 
       // Allocate buffers for the value and its associated barriers.
       b.setLoc(output.getLoc());
       ImplicitLocOpBuilder endBuilder(b.getLoc(), loop->getNextNode());
-      AsyncRef aref =
-          allocateAsyncValue(tensorType, multiplicitySize, maxDistance);
+      AsyncRef aref = allocateAsyncValue(tensorType, maxDistance);
 
-      // Initialize the initial values of the loop-carried dependencies.
       unsigned numConsumers = info.consumers.size();
-      info.multiplicity.number([&](ArrayRef<Multiplicity::Node *> nodes,
-                                   unsigned start, unsigned end) {
-        for (auto [i, node] : llvm::zip(llvm::seq(start, end), nodes)) {
-          initializeBarriers(i, aref, numConsumers,
-                             loop.getInitArgs()[node->argIdx]);
-        }
-      });
-
-      // Initialize the buffers.
-      for (auto i : llvm::seq(maxDistance)) {
-        initializeBarriers(multiplicitySize + i, aref, numConsumers,
-                           /*init=*/Value());
-      }
-      // Deallocate shared memory after the buffers are deinitialized.
-      endBuilder.create<LocalDeallocOp>(aref.readyBars);
-      endBuilder.create<LocalDeallocOp>(aref.emptyBars);
 
       for (auto &[key, uses] : info.consumers) {
         assert(!uses.empty() && "expected at least one use");
@@ -459,60 +235,35 @@ LogicalResult DependencyRewriter::run() {
             loop.getBody()->findAncestorOpInBlock(*earliestUser));
 
         auto [usePartition, distance] = key;
-        auto modifyStart = [&, distance = distance, uses = uses, info = &info](
-                               int &startIdx, Value &cnd, Value idx) {
-          if (distance == 0)
-            return;
-          unsigned argIdx =
-              cast<BlockArgument>(uses.front()->get()).getArgNumber() - 1;
-          Multiplicity::Node *node =
-              info->multiplicity.nodes.find(argIdx)->second.get();
-          auto [start, end] = info->multiplicity.segments[node->number];
-          startIdx = end - node->depth;
-          assert(node->depth && startIdx >= start && "incorrect numbering?");
-          // Micro-optimization: if the index would roll onto
-          // `multiplicitySize` anyways, skip generating the check.
-          if (end != multiplicitySize) {
-            Value initEnd = b.create<arith::CmpIOp>(arith::CmpIPredicate::eq,
-                                                    idx, b.intCst(end));
-            cnd = b.create<arith::OrIOp>(cnd, initEnd);
-          }
-        };
-        auto [idx, phase] = createAndGetAsyncIndex(aref, modifyStart);
 
         // Wait for the value to be available.
-        auto [view, readyView, emptyView] = aref.getView(b, idx);
         StageCluster sinkSrcCluster = getStageCluster(earliestUser);
-        b.createInto<ttng::WaitBarrierOp>(*usePartition, sinkSrcCluster,
-                                          readyView, phase);
+        auto [view, exitOp] = aref.getView(b, *usePartition, sinkSrcCluster);
         // Load the value at the current index and replace uses in this
         // partition with it.
         Value value = b.createInto<LocalLoadOp>(*usePartition, sinkSrcCluster,
                                                 tensorType, view);
         for (OpOperand *use : uses)
           use->set(value);
-        // Mark the buffer as ready.
-        b.createInto<ttng::ArriveBarrierOp>(*usePartition, sinkSrcCluster,
-                                            emptyView, 1);
+        exitOp(b);
       }
 
-      // Set up production of the value.
-      b.setInsertionPointAfter(output.getDefiningOp());
-      auto [idx, phase] = createAndGetAsyncIndex(aref);
-      auto [view, readyView, emptyView] = aref.getView(b, idx);
-      StageCluster srcStageCluster = getStageCluster(output.getDefiningOp());
-      b.createInto<ttng::WaitBarrierOp>(partition, srcStageCluster, emptyView,
-                                        phase);
+      // Set up production of the value
+      if (isa<BlockArgument>(output))
+        b.setInsertionPointToStart(loop.getBody());
+      else
+        b.setInsertionPointAfter(defOp);
+
+      StageCluster srcStageCluster = getStageCluster(defOp);
+      auto [view, exitOp] = aref.putView(b, partition, srcStageCluster);
       b.createInto<LocalStoreOp>(partition, srcStageCluster, output, view);
-      b.createInto<ttng::ArriveBarrierOp>(partition, srcStageCluster, readyView,
-                                          1);
+      exitOp(b);
     }
   }
 
   // Rewrite the loop to add the new results. Calling this function with no
   // indices set will just resize the results.
   eraseLoopCarriedValues(loop, {});
-
   // Update the schedule.
   schedule.serialize(loop);
   return success();
@@ -556,8 +307,8 @@ struct RewritePartitionDependencies
 } // namespace
 
 void RewritePartitionDependencies::runOnOperation() {
-  // Collect for loops to warp specialize. This pass expects the loop to already
-  // be scheduled.
+  // Collect for loops to warp specialize. This pass expects the loop to
+  // already be scheduled.
   SmallVector<scf::ForOp> loops;
   getOperation().walk([&](scf::ForOp loop) {
     if (loop->hasAttrOfType<ArrayAttr>(kPartitionStagesAttrName))

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -151,7 +151,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
           // CHECK: arith.remsi [[IDX3]], [[C3]]
           // CHECK-NEXT: ttg.memdesc_subview
-          // CHECK-NEXT: nvws.async_complete {{.*}}, async_op = <none>
+          // CHECK-NEXT: ttng.arrive_barrier {{.*}}, 256
           nvws.aref.get.exit %aref1[%c0_i32] [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
         }
         // CHECK: } else {

--- a/test/TritonGPU/rewrite-partition-dependencies.mlir
+++ b/test/TritonGPU/rewrite-partition-dependencies.mlir
@@ -1,285 +1,68 @@
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-rewrite-partition-dependencies -verify-diagnostics -canonicalize | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
 !ty = tensor<1xi32, #blocked>
 
 module attributes {"ttg.num-warps" = 4 : i32} {
 
 // CHECK-LABEL: @two_consumers
 tt.func @two_consumers(%lb: i32, %ub: i32, %step: i32) {
-  // CHECK: [[BUFFERS:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32,
-  // CHECK-NEXT: [[READY_BARS:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<2xi64,
-  // CHECK-NEXT: [[EMPTY_BARS:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<2xi64,
-
-  // CHECK-NEXT: [[READY0:%.*]] = ttg.memdesc_subview [[READY_BARS]][%c0_i32]
-  // CHECK-NEXT: [[EMPTY0:%.*]] = ttg.memdesc_subview [[EMPTY_BARS]][%c0_i32]
-  // CHECK-NEXT: ttng.init_barrier [[READY0]], 1
-  // CHECK-NEXT: ttng.init_barrier [[EMPTY0]], 2
-  // CHECK-NEXT: ttng.arrive_barrier [[EMPTY0]], 2
-
-  // CHECK-NEXT: [[READY1:%.*]] = ttg.memdesc_subview [[READY_BARS]][%c1_i32]
-  // CHECK-NEXT: [[EMPTY1:%.*]] = ttg.memdesc_subview [[EMPTY_BARS]][%c1_i32]
-  // CHECK-NEXT: ttng.init_barrier [[READY1]], 1
-  // CHECK-NEXT: ttng.init_barrier [[EMPTY1]], 2
-  // CHECK-NEXT: ttng.arrive_barrier [[EMPTY1]], 2
-
-  // CHECK-NEXT: %{{[0-9]+}}:6 = scf.for %arg{{[0-9]+}} = %arg0 to %arg1 step %arg2 iter_args(
-  // CHECK-SAME:   [[CONSUMER_IDX0:%arg[0-9]+]] = %c-1_i32
-  // CHECK-SAME:   [[CONSUMER_PHASE0:%arg[0-9]+]] = %c0_i32
-  // CHECK-SAME:   [[CONSUMER_IDX1:%arg[0-9]+]] = %c-1_i32
-  // CHECK-SAME:   [[CONSUMER_PHASE1:%arg[0-9]+]] = %c0_i32
-  // CHECK-SAME:   [[PRODUCER_IDX:%arg[0-9]+]] = %c-1_i32
-  // CHECK-SAME:   [[PRODUCER_PHASE:%arg[0-9]+]] = %c0_i32
+  // CHECK: [[C0:%.*]] = arith.constant 0 : i32
+  // CHECK-NEXT: [[ABUF:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32, {{.*}}>
+  // CHECK-NEXT: [[AREF:%.*]] = nvws.aref.create [[ABUF]]
   scf.for %i = %lb to %ub step %step iter_args() -> () : i32 {
-    // CHECK-NEXT: [[OUTPUT:%.*]] = "op_a"() {ttg.partition = 0 : i32}
     %0 = "op_a"() {ttg.partition = 0} : () -> !ty
-    // CHECK-NEXT: [[NEXT_IDX:%.*]] = arith.addi [[PRODUCER_IDX]], %c1_i32
-    // CHECK-NEXT: [[NEXT_PHASE:%.*]] = arith.xori [[PRODUCER_PHASE]], %c1_i32
-    // CHECK-NEXT: [[ROLLOVER:%.*]] = arith.cmpi eq, [[NEXT_IDX]], %c2_i32
-    // CHECK-NEXT: [[PHASE0:%.*]] = arith.select [[ROLLOVER]], [[NEXT_PHASE]], [[PRODUCER_PHASE]]
-    // CHECK-NEXT: [[IDX0:%.*]] = arith.select [[ROLLOVER]], %c0_i32, [[NEXT_IDX]]
-    // CHECK-NEXT: [[VIEW:%.*]] = ttg.memdesc_subview [[BUFFERS]][[[IDX0]], %c0_i32]
-    // CHECK-NEXT: [[READY:%.*]] = ttg.memdesc_subview [[READY_BARS]][[[IDX0]]]
-    // CHECK-NEXT: [[EMPTY:%.*]] = ttg.memdesc_subview [[EMPTY_BARS]][[[IDX0]]]
-    // CHECK-NEXT: ttng.wait_barrier [[EMPTY]], [[PHASE0]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[OUTPUT]], [[VIEW]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttng.arrive_barrier [[READY]], 1 {ttg.partition = 0 : i32}
+    // CHECK: [[VAL:%.*]] = "op_a"
+    // CHECK-NEXT: [[BUF:%.*]] = nvws.aref.put.enter [[AREF]][[[C0]]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: ttg.local_store [[VAL]], [[BUF]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF]][[[C0]]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
 
-    // CHECK-NEXT: [[NEXT_IDX:%.*]] = arith.addi [[CONSUMER_IDX0]], %c1_i32
-    // CHECK-NEXT: [[NEXT_PHASE:%.*]] = arith.xori [[CONSUMER_PHASE0]], %c1_i32
-    // CHECK-NEXT: [[ROLLOVER:%.*]] = arith.cmpi eq, [[NEXT_IDX]], %c2_i32
-    // CHECK-NEXT: [[PHASE1:%.*]] = arith.select [[ROLLOVER]], [[NEXT_PHASE]], [[CONSUMER_PHASE0]]
-    // CHECK-NEXT: [[IDX1:%.*]] = arith.select [[ROLLOVER]], %c0_i32, [[NEXT_IDX]]
-    // CHECK-NEXT: [[VIEW:%.*]] = ttg.memdesc_subview [[BUFFERS]][[[IDX1]], %c0_i32]
-    // CHECK-NEXT: [[READY:%.*]] = ttg.memdesc_subview [[READY_BARS]][[[IDX1]]]
-    // CHECK-NEXT: [[EMPTY:%.*]] = ttg.memdesc_subview [[EMPTY_BARS]][[[IDX1]]]
-    // CHECK-NEXT: ttng.wait_barrier [[READY]], [[PHASE1]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[VALUE:%.*]] = ttg.local_load [[VIEW]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: ttng.arrive_barrier [[EMPTY]], 1 {ttg.partition = 1 : i32}
-    // CHECK-NEXT: "op_b"([[VALUE]]) {ttg.partition = 1 : i32}
     "op_b"(%0) {ttg.partition = 1} : (!ty) -> ()
+    // CHECK-NEXT: [[BUF:%.*]] = nvws.aref.get.enter [[AREF]][[[C0]]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF]][[[C0]]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: "op_b"([[VAL]])
 
-    // CHECK-NEXT: [[NEXT_IDX:%.*]] = arith.addi [[CONSUMER_IDX1]], %c1_i32
-    // CHECK-NEXT: [[NEXT_PHASE:%.*]] = arith.xori [[CONSUMER_PHASE1]], %c1_i32
-    // CHECK-NEXT: [[ROLLOVER:%.*]] = arith.cmpi eq, [[NEXT_IDX]], %c2_i32
-    // CHECK-NEXT: [[PHASE2:%.*]] = arith.select [[ROLLOVER]], [[NEXT_PHASE]], [[CONSUMER_PHASE1]]
-    // CHECK-NEXT: [[IDX2:%.*]] = arith.select [[ROLLOVER]], %c0_i32, [[NEXT_IDX]]
-    // CHECK-NEXT: [[VIEW:%.*]] = ttg.memdesc_subview [[BUFFERS]][[[IDX2]], %c0_i32]
-    // CHECK-NEXT: [[READY:%.*]] = ttg.memdesc_subview [[READY_BARS]][[[IDX2]]]
-    // CHECK-NEXT: [[EMPTY:%.*]] = ttg.memdesc_subview [[EMPTY_BARS]][[[IDX2]]]
-    // CHECK-NEXT: ttng.wait_barrier [[READY]], [[PHASE2]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: [[VALUE:%.*]] = ttg.local_load [[VIEW]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: ttng.arrive_barrier [[EMPTY]], 1 {ttg.partition = 2 : i32}
-    // CHECK-NEXT: "op_d"([[VALUE]]) {ttg.partition = 2 : i32}
+    "op_c"(%0) {ttg.partition = 2} : (!ty) -> ()
+    // CHECK-NEXT: [[BUF:%.*]] = nvws.aref.get.enter [[AREF]][[[C0]]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF]][[[C0]]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: "op_c"([[VAL]])
+    // CHECK-NEXT: "op_d"([[VAL]])
     "op_d"(%0) {ttg.partition = 2} : (!ty) -> ()
-
-    // CHECK-NEXT: yield [[IDX1]], [[PHASE1]], [[IDX2]], [[PHASE2]], [[IDX0]], [[PHASE0]]
-
-  // CHECK-NEXT: ttg.partition.stages = [0 : i32, 2 : i32, 2 : i32]
   } {ttg.partition.stages = [0, 2, 2]}
-  // CHECK-NEXT: ttg.local_dealloc [[BUFFERS]]
-  // CHECK-NEXT: ttng.inval_barrier [[READY0]]
-  // CHECK-NEXT: ttng.inval_barrier [[EMPTY0]]
-  // CHECK-NEXT: ttng.inval_barrier [[READY1]]
-  // CHECK-NEXT: ttng.inval_barrier [[EMPTY1]]
-  // CHECK-NEXT: ttg.local_dealloc [[READY_BARS]]
-  // CHECK-NEXT: ttg.local_dealloc [[EMPTY_BARS]]
   tt.return
 }
 
 // CHECK-LABEL: @distance_one
 tt.func @distance_one(%lb: i32, %ub: i32, %step: i32) {
+  // CHECK: [[C0:%.*]] = arith.constant 0 : i32
+  // CHECK: [[ABUF:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32, {{.*}}>
+  // CHECK-NEXT: [[AREF:%.*]] = nvws.aref.create [[ABUF]]
   %cst = arith.constant dense<0> : !ty
-
-  // CHECK: [[BUFFERS:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32,
-  // CHECK-NEXT: [[READY_BARS:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<2xi64,
-  // CHECK-NEXT: [[EMPTY_BARS:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<2xi64,
-
-  // CHECK-NEXT: [[INIT:%.*]] = ttg.memdesc_subview [[BUFFERS]][%c0_i32, %c0_i32]
-  // CHECK-NEXT: ttg.local_store %cst, [[INIT]]
-  // CHECK-NEXT: [[READY0:%.*]] = ttg.memdesc_subview [[READY_BARS]][%c0_i32]
-  // CHECK-NEXT: [[EMPTY0:%.*]] = ttg.memdesc_subview [[EMPTY_BARS]][%c0_i32]
-  // CHECK-NEXT: ttng.init_barrier [[READY0]], 1
-  // CHECK-NEXT: ttng.init_barrier [[EMPTY0]], 1
-  // CHECK-NEXT: ttng.arrive_barrier [[READY0]], 1
-
-  // CHECK-NEXT: [[READY1:%.*]] = ttg.memdesc_subview [[READY_BARS]][%c1_i32]
-  // CHECK-NEXT: [[EMPTY1:%.*]] = ttg.memdesc_subview [[EMPTY_BARS]][%c1_i32]
-  // CHECK-NEXT: ttng.init_barrier [[READY1]], 1
-  // CHECK-NEXT: ttng.init_barrier [[EMPTY1]], 1
-  // CHECK-NEXT: ttng.arrive_barrier [[EMPTY1]], 1
-
-  // CHECK-NEXT: %{{[0-9]+}}:4 = scf.for %arg{{[0-9]+}} = %arg0 to %arg1 step %arg2 iter_args(
-  // CHECK-SAME:   [[CONSUMER_IDX:%arg[0-9]+]] = %c-1_i32
-  // CHECK-SAME:   [[CONSUMER_PHASE:%arg[0-9]+]] = %c0_i32
-  // CHECK-SAME:   [[PRODUCER_IDX:%arg[0-9]+]] = %c0_i32
-  // CHECK-SAME:   [[PRODUCER_PHASE:%arg[0-9]+]] = %c0_i32
+  // CHECK: scf.for [[IV:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[K:%.*]] = {{.*}})
   scf.for %i = %lb to %ub step %step iter_args(%k = %cst) -> (!ty) : i32 {
-    // CHECK-NEXT: [[OUTPUT:%.*]] = "op_a"() {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[BUF:%.*]] = nvws.aref.put.enter [[AREF]][[[C0]]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: ttg.local_store [[K]], [[BUF]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF]][[[C0]]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
     %0 = "op_a"() {ttg.partition = 0} : () -> !ty
-    // CHECK-NEXT: [[NEXT_IDX:%.*]] = arith.addi [[PRODUCER_IDX]], %c1_i32
-    // CHECK-NEXT: [[NEXT_PHASE:%.*]] = arith.xori [[PRODUCER_PHASE]], %c1_i32
-    // CHECK-NEXT: [[ROLLOVER:%.*]] = arith.cmpi eq, [[NEXT_IDX]], %c2_i32
-    // CHECK-NEXT: [[PHASE0:%.*]] = arith.select [[ROLLOVER]], [[NEXT_PHASE]], [[PRODUCER_PHASE]]
-    // CHECK-NEXT: [[IDX0:%.*]] = arith.select [[ROLLOVER]], %c1_i32, [[NEXT_IDX]]
-    // CHECK-NEXT: [[VIEW:%.*]] = ttg.memdesc_subview [[BUFFERS]][[[IDX0]], %c0_i32]
-    // CHECK-NEXT: [[READY:%.*]] = ttg.memdesc_subview [[READY_BARS]][[[IDX0]]]
-    // CHECK-NEXT: [[EMPTY:%.*]] = ttg.memdesc_subview [[EMPTY_BARS]][[[IDX0]]]
-    // CHECK-NEXT: ttng.wait_barrier [[EMPTY]], [[PHASE0]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[OUTPUT]], [[VIEW]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttng.arrive_barrier [[READY]], 1 {ttg.partition = 0 : i32}
-
-    // CHECK-NEXT: [[NEXT_IDX:%.*]] = arith.addi [[CONSUMER_IDX]], %c1_i32
-    // CHECK-NEXT: [[NEXT_PHASE:%.*]] = arith.xori [[CONSUMER_PHASE]], %c1_i32
-    // CHECK-NEXT: [[ROLLOVER:%.*]] = arith.cmpi eq, [[NEXT_IDX]], %c2_i32
-    // CHECK-NEXT: [[PHASE1:%.*]] = arith.select [[ROLLOVER]], [[NEXT_PHASE]], [[CONSUMER_PHASE]]
-    // CHECK-NEXT: [[IDX1:%.*]] = arith.select [[ROLLOVER]], %c1_i32, [[NEXT_IDX]]
-    // CHECK-NEXT: [[VIEW:%.*]] = ttg.memdesc_subview [[BUFFERS]][[[IDX1]], %c0_i32]
-    // CHECK-NEXT: [[READY:%.*]] = ttg.memdesc_subview [[READY_BARS]][[[IDX1]]]
-    // CHECK-NEXT: [[EMPTY:%.*]] = ttg.memdesc_subview [[EMPTY_BARS]][[[IDX1]]]
-    // CHECK-NEXT: ttng.wait_barrier [[READY]], [[PHASE1]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[VALUE:%.*]] = ttg.local_load [[VIEW]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: ttng.arrive_barrier [[EMPTY]], 1 {ttg.partition = 1 : i32}
-    // CHECK-NEXT: "op_b"([[VALUE]]) {ttg.partition = 1 : i32}
+    // CHECK: [[VAL:%.*]] = "op_a"
+    // CHECK-NEXT: [[BUF:%.*]] = nvws.aref.get.enter [[AREF]][[[C0]]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF]][[[C0]]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: "op_b"([[VAL]])
     "op_b"(%k) {ttg.partition = 1} : (!ty) -> ()
 
-    // CHECK-NEXT: yield [[IDX1]], [[PHASE1]], [[IDX0]], [[PHASE0]]
     scf.yield %0 : !ty
   } {ttg.partition.stages = [0, 0]}
   tt.return
 }
 
-// CHECK-LABEL: @complex_case
-tt.func @complex_case(%lb: i32, %ub: i32, %step: i32) {
-  // CHECK-COUNT-2: ttg.local_alloc : () -> !ttg.memdesc<6xi64,
-  // CHECK: ttng.init_barrier %{{.*}}, 4
-  %cst = arith.constant dense<0> : !ty
-  // CHECK: iter_args
-  // CHECK-SAME: [[CIDX0:%arg[0-9]+]] = %c0_i32, %arg{{[0-9]+}}
-  // CHECK-SAME: [[CIDX1:%arg[0-9]+]] = %c0_i32, %arg{{[0-9]+}}
-  // CHECK-SAME: [[CIDX2:%arg[0-9]+]] = %c-1_i32, %arg{{[0-9]+}}
-  // CHECK-SAME: [[CIDX3:%arg[0-9]+]] = %c-1_i32, %arg{{[0-9]+}}
-  // CHECK-SAME: [[PIDX0:%arg[0-9]+]] = %c1_i32, %arg{{[0-9]+}}
-  scf.for %i = %lb to %ub step %step iter_args(%k = %cst, %l = %cst) -> (!ty, !ty) : i32 {
-    // CHECK: op_a
-    // CHECK: [[NEXT:%.*]] = arith.addi [[PIDX0]], %c1_i32
-    // CHECK: [[ROLLOVER:%.*]] = arith.cmpi eq, [[NEXT]], %c6_i32
-    // CHECK: select [[ROLLOVER]], %c2_i32, [[NEXT]]
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
-
-    // CHECK: arith.addi [[CIDX0]], %c1_i32
-    // CHECK: select %{{.*}}, %c2_i32
-    // CHECK: op_b
-    "op_b"(%k) {ttg.partition = 1} : (!ty) -> ()
-
-    // CHECK: arith.addi [[CIDX1]], %c1_i32
-    // CHECK: select %{{.*}}, %c2_i32
-    // CHECK-COUNT-2: op_c
-    "op_c"(%k) {ttg.partition = 2} : (!ty) -> ()
-    "op_c"(%k) {ttg.partition = 2} : (!ty) -> ()
-
-    // CHECK: arith.addi [[CIDX2]], %c1_i32
-    // CHECK: select %{{.*}}, %c2_i32
-    // CHECK: op_d
-    "op_d"(%l) {ttg.partition = 1} : (!ty) -> ()
-
-    // CHECK: arith.addi [[CIDX3]], %c1_i32
-    // CHECK: select %{{.*}}, %c2_i32
-    // CHECK: op_d
-    "op_d"(%l) {ttg.partition = 2} : (!ty) -> ()
-    scf.yield %0, %k : !ty, !ty
-  } {ttg.partition.stages = [0, 2, 2]}
-  tt.return
-}
-
-// CHECK-LABEL: @reuse_argument
-tt.func @reuse_argument(%lb: i32, %ub: i32, %step: i32) {
-  // CHECK-DAG: [[CST0:%.*]] = arith.constant dense<0>
-  // CHECK-DAG: [[CST1:%.*]] = arith.constant dense<1>
-  %cst0 = arith.constant dense<0> : !ty
-  %cst1 = arith.constant dense<1> : !ty
-
-  // CHECK: [[BUFFERS:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<3x1xi32
-  // CHECK: [[VALUE:%.*]] = ttg.memdesc_subview [[BUFFERS]][%c0_i32, %c0_i32]
-  // CHECK: local_store [[CST0]], [[VALUE]]
-  // CHECK: [[VALUE:%.*]] = ttg.memdesc_subview [[BUFFERS]][%c1_i32, %c0_i32]
-  // CHECK: local_store [[CST1]], [[VALUE]]
-  scf.for %i = %lb to %ub step %step iter_args(%k = %cst0, %l = %cst1) -> (!ty, !ty) : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
-    "op_d"(%l) {ttg.partition = 1} : (!ty) -> ()
-    "op_d"(%l) {ttg.partition = 2} : (!ty) -> ()
-    scf.yield %0, %k : !ty, !ty
-  } {ttg.partition.stages = [1, 0, 0]}
-  tt.return
-}
-
-// CHECK-LABEL: @multiplicity_branch
-tt.func @multiplicity_branch(%lb: i32, %ub: i32, %step: i32) {
-  // CHECK-DAG: [[CST0:%.*]] = arith.constant dense<0>
-  // CHECK-DAG: [[CST1:%.*]] = arith.constant dense<1>
-  // CHECK-DAG: [[CST2:%.*]] = arith.constant dense<2>
-  %cst0 = arith.constant dense<0> : !ty
-  %cst1 = arith.constant dense<1> : !ty
-  %cst2 = arith.constant dense<2> : !ty
-
-  // CHECK: [[BUFFERS:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<6x1xi32
-
-  // CHECK: [[VALUE:%.*]] = ttg.memdesc_subview [[BUFFERS]][%c0_i32, %c0_i32]
-  // CHECK: local_store [[CST0]], [[VALUE]]
-  // CHECK: [[VALUE:%.*]] = ttg.memdesc_subview [[BUFFERS]][%c1_i32, %c0_i32]
-  // CHECK: local_store [[CST2]], [[VALUE]]
-
-  // CHECK: [[VALUE:%.*]] = ttg.memdesc_subview [[BUFFERS]][%c2_i32, %c0_i32]
-  // CHECK: local_store [[CST0]], [[VALUE]]
-  // CHECK: [[VALUE:%.*]] = ttg.memdesc_subview [[BUFFERS]][%c3_i32, %c0_i32]
-  // CHECK: local_store [[CST1]], [[VALUE]]
-
-  // CHECK: iter_args
-  // CHECK-SAME: [[CIDX0:%arg[0-9]+]] = %c0_i32, %arg{{[0-9]+}}
-  // CHECK-SAME: [[CIDX1:%arg[0-9]+]] = %c1_i32, %arg{{[0-9]+}}
-  // CHECK-SAME: [[CIDX2:%arg[0-9]+]] = %c-1_i32, %arg{{[0-9]+}}
-  // CHECK-SAME: [[PIDX0:%arg[0-9]+]] = %c3_i32, %arg{{[0-9]+}}
-  scf.for %i = %lb to %ub step %step iter_args(%a = %cst0, %b = %cst1, %c = %cst2) -> (!ty, !ty, !ty) : i32 {
-    // CHECK: [[OUT:%.*]] = "op_a"()
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
-    // CHECK: [[NEXT_IDX:%.*]] = arith.addi [[PIDX0]], %c1_i32
-    // CHECK: [[ROLLOVER:%.*]] = arith.cmpi eq, [[NEXT_IDX]], %c6_i32
-    // CHECK: [[IDX:%.*]] = arith.select [[ROLLOVER]], %c4_i32, [[NEXT_IDX]]
-    // CHECK: memdesc_subview [[BUFFERS]][[[IDX]], %c0_i32]
-
-    // CHECK: [[NEXT_IDX:%.*]] = arith.addi [[CIDX0]], %c1_i32
-    // CHECK: [[LAST:%.*]] = arith.cmpi eq, [[NEXT_IDX]], %c6_i32
-    // CHECK: [[AT_END:%.*]] = arith.cmpi eq, [[NEXT_IDX]], %c2_i32
-    // CHECK: [[ROLLOVER:%.*]] = arith.ori [[LAST]], [[AT_END]]
-    // CHECK: [[IDX:%.*]] = arith.select [[ROLLOVER]], %c4_i32, [[NEXT_IDX]]
-    // CHECK: memdesc_subview [[BUFFERS]][[[IDX]], %c0_i32]
-    // CHECK: op_b
-    "op_b"(%a) {ttg.partition = 1}: (!ty) -> ()
-
-    // CHECK: [[NEXT_IDX:%.*]] = arith.addi [[CIDX1]], %c1_i32
-    // CHECK: [[ROLLOVER:%.*]] = arith.cmpi eq, [[NEXT_IDX]], %c6_i32
-    // CHECK: [[IDX:%.*]] = arith.select [[ROLLOVER]], %c4_i32, [[NEXT_IDX]]
-    // CHECK: memdesc_subview [[BUFFERS]][[[IDX]], %c0_i32]
-    // CHECK: op_c
-    "op_c"(%b) {ttg.partition = 2}: (!ty) -> ()
-
-    // CHECK: [[NEXT_IDX:%.*]] = arith.addi [[CIDX2]], %c1_i32
-    // CHECK: [[LAST:%.*]] = arith.cmpi eq, [[NEXT_IDX]], %c6_i32
-    // CHECK: [[AT_END:%.*]] = arith.cmpi eq, [[NEXT_IDX]], %c2_i32
-    // CHECK: [[ROLLOVER:%.*]] = arith.ori [[LAST]], [[AT_END]]
-    // CHECK: [[IDX:%.*]] = arith.select [[ROLLOVER]], %c4_i32, [[NEXT_IDX]]
-    // CHECK: memdesc_subview [[BUFFERS]][[[IDX]], %c0_i32]
-    // CHECK: op_d
-    "op_d"(%c) {ttg.partition = 3}: (!ty) -> ()
-
-    scf.yield %0, %a, %a : !ty, !ty, !ty
-  } {ttg.partition.stages = [0, 0, 0, 0]}
-  tt.return
-}
-
 // CHECK-LABEL: @self_recursion
 tt.func @self_recursion(%lb: i32, %ub: i32, %step: i32) {
-  // CHECK-NOT: ttg.local_alloc
+  // CHECK-NOT: nvws.aref.create
   %cst = arith.constant dense<0> : !ty
   // CHECK: iter_args([[ARG:%arg[0-9]+]] = %cst)
   %0 = scf.for %i = %lb to %ub step %step iter_args(%k = %cst) -> (!ty) : i32 {
@@ -294,17 +77,19 @@ tt.func @self_recursion(%lb: i32, %ub: i32, %step: i32) {
 // CHECK-LABEL: @self_recursion_and_use
 tt.func @self_recursion_and_use(%lb: i32, %ub: i32, %step: i32) {
   %cst = arith.constant dense<0> : !ty
-  // CHECK: iter_args([[ARG:%arg[0-9]+]] = %cst,
   %0 = scf.for %i = %lb to %ub step %step iter_args(%k = %cst) -> (!ty) : i32 {
-    // CHECK-NEXT: [[OUT:%.*]] = "op_a"([[ARG]])
-    // CHECK: local_store [[OUT]]
     %0 = "op_a"(%k) {ttg.partition = 0} : (!ty) -> !ty
+    // CHECK: "op_a"
+    // CHECK-NEXT: nvws.aref.put.enter
+    // CHECK-NEXT: local_store
+    // CHECK-NEXT: nvws.aref.put.exit
 
-    // CHECK: [[VALUE:%.*]] = ttg.local_load
-    // CHECK: "op_b"([[VALUE]])
     "op_b"(%0) {ttg.partition = 1} : (!ty) -> !ty
+    // CHECK-NEXT: nvws.aref.get.enter
+    // CHECK-NEXT: ttg.local_load
+    // CHECK-NEXT: nvws.aref.get.exit
+    // CHECK-NEXT: "op_b"
 
-    // CHECK: yield [[OUT]]
     scf.yield %0 : !ty
   } {ttg.partition.stages = [0, 1]}
   tt.return
@@ -312,18 +97,20 @@ tt.func @self_recursion_and_use(%lb: i32, %ub: i32, %step: i32) {
 
 // CHECK-LABEL: @conditional_consumer
 tt.func @conditional_consumer(%lb: i32, %ub: i32, %step: i32) {
-  // CHECK: ttg.local_alloc : () -> !ttg.memdesc<2x1xi32
   scf.for %i = %lb to %ub step %step : i32 {
-    // CHECK: producer
     %0 = "producer"() {ttg.partition = 0} : () -> !ty
-    // CHECK: rand
+    // CHECK: "producer"
+    // CHECK-NEXT: nvws.aref.put.enter
+    // CHECK-NEXT: local_store
+    // CHECK-NEXT: nvws.aref.put.exit
     %cond = "rand"() : () -> i1
-    // CHECK: wait_barrier
+    // CHECK-NEXT: "rand"
+    // CHECK-NEXT: nvws.aref.get.enter
     // CHECK-NEXT: [[VALUE:%.*]] = ttg.local_load
-    // CHECK-NEXT: arrive_barrier
+    // CHECK-NEXT: nvws.aref.get.exit
     // CHECK-NEXT: scf.if
     %1 = scf.if %cond -> !ty {
-      // CHECK-NEXT: something
+      // CHECK-NEXT: "something"
       "something"() : () -> ()
       // CHECK-NEXT: yield [[VALUE]]
       scf.yield %0 : !ty
@@ -395,13 +182,25 @@ tt.func @invalid_attribute(%lb: i32, %ub: i32, %step: i32) {
 module attributes {"ttg.num-warps" = 4 : i32} {
 
 tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
-  // expected-warning @below {{warp schedule contains a cycle}}
+  // CHECK: [[C0:%.*]] = arith.constant 0 : i32
+  // CHECK: ttg.local_alloc
+  // CHECK-NEXT: [[AREF1:%.*]] = nvws.aref.create
+  // CHECK-NEXT: ttg.local_alloc
+  // CHECK-NEXT: [[AREF2:%.*]] = nvws.aref.create
+
   scf.for %i = %lb to %ub step %step : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> index
-    // expected-note @below {{operation in partition #1 uses value defined in partition #0}}
-    %1 = "op_b"(%0) {ttg.partition = 1} : (index) -> index
-    // expected-note @below {{operation in partition #0 uses value defined in partition #1}}
-    "op_c"(%1) {ttg.partition = 0} : (index) -> ()
+    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    // CHECK: "op_a"
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF1]][[[C0]]] {ttg.partition = 0 : i32}
+
+    %1 = "op_b"(%0) {ttg.partition = 1} : (!ty) -> !ty
+    // CHECK: nvws.aref.get.exit [[AREF1]][[[C0]]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: "op_b"
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF2]][[[C0]]] {ttg.partition = 1 : i32}
+
+    // CHECK: nvws.aref.get.exit [[AREF2]][[[C0]]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+
+    "op_c"(%1) {ttg.partition = 0} : (!ty) -> ()
     scf.yield
   } {ttg.partition.stages = [0, 2]}
   tt.return
@@ -417,15 +216,31 @@ tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
 module attributes {"ttg.num-warps" = 4 : i32} {
 
 tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
-  // expected-warning @below {{warp schedule contains a cycle}}
+  // CHECK: [[C0:%.*]] = arith.constant 0 : i32
+  // CHECK: ttg.local_alloc
+  // CHECK-NEXT: [[AREF1:%.*]] = nvws.aref.create
+  // CHECK-NEXT: ttg.local_alloc
+  // CHECK-NEXT: [[AREF2:%.*]] = nvws.aref.create
+  // CHECK-NEXT: ttg.local_alloc
+  // CHECK-NEXT: [[AREF3:%.*]] = nvws.aref.create
   scf.for %j = %lb to %ub step %step : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> index
-    // expected-note @below {{operation in partition #1 uses value defined in partition #0}}
-    %1 = "op_b"(%0) {ttg.partition = 1} : (index) -> index
-    // expected-note @below {{operation in partition #2 uses value defined in partition #1}}
-    %2 = "op_c"(%1) {ttg.partition = 2} : (index) -> index
-    // expected-note @below {{operation in partition #0 uses value defined in partition #2}}
-    "op_c"(%2) {ttg.partition = 0} : (index) -> ()
+    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    // CHECK: "op_a"
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF1]][[[C0]]] {ttg.partition = 0 : i32}
+
+    %1 = "op_b"(%0) {ttg.partition = 1} : (!ty) -> !ty
+    // CHECK: nvws.aref.get.exit [[AREF1]][[[C0]]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: "op_b"
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF2]][[[C0]]] {ttg.partition = 1 : i32}
+
+    %2 = "op_c"(%1) {ttg.partition = 2} : (!ty) -> !ty
+    // CHECK: nvws.aref.get.exit [[AREF2]][[[C0]]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: "op_c"
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF3]][[[C0]]] {ttg.partition = 2 : i32}
+
+    "op_c"(%2) {ttg.partition = 0} : (!ty) -> ()
+    // CHECK: nvws.aref.get.exit [[AREF3]][[[C0]]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK: "op_c"
     scf.yield
   } {ttg.partition.stages = [0, 2, 3]}
   tt.return
@@ -467,48 +282,6 @@ tt.func @invalid_root_partition(%lb: i32, %ub: i32, %step: i32) {
     "root"(%k) : (index) -> ()
     // expected-note @below {{operand defined here in partition #0 at distance 1}}
     %0 = "partition"() {ttg.partition = 0} : () -> index
-    scf.yield %0 : index
-  } {ttg.partition.stages = [0, 2]}
-  tt.return
-}
-
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-!ty = tensor<1xi32, #blocked>
-
-module attributes {"ttg.num-warps" = 4 : i32} {
-
-tt.func @invalid_partition_stage(%lb: i32, %ub: i32, %step: i32) {
-  // expected-warning @below {{partition #0 has stage 2 but is consumed by partition #1 with stage 0}}
-  scf.for %i = %lb to %ub step %step : i32 {
-    // expected-note @below {{value defined here in partition #0}}
-    %0 = "op_a"() {ttg.partition = 0} : () -> index
-    // expected-note @below {{use of value defined in partition #0}}
-    "op_b"(%0) {ttg.partition = 1} : (index) -> ()
-  } {ttg.partition.stages = [2, 0]}
-  tt.return
-}
-
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-!ty = tensor<1xi32, #blocked>
-
-module attributes {"ttg.num-warps" = 4 : i32} {
-
-tt.func @invalid_future_partition(%lb: i32, %ub: i32, %step: i32) {
-  %c0 = arith.constant 0 : index
-  // expected-warning @below {{partition #1 has stage 2 but is consumed by partition #0 with stage 0 at distance 1}}
-  scf.for %i = %lb to %ub step %step iter_args(%k = %c0) -> index : i32 {
-    // expected-note @below {{use of value defined in partition #1 at 1 iterations in the future}}
-    "op_a"(%k) {ttg.partition = 0} : (index) -> ()
-    // expected-note @below {{value defined here in partition #1}}
-    %0 = "op_b"() {ttg.partition = 1} : () -> index
     scf.yield %0 : index
   } {ttg.partition.stages = [0, 2]}
   tt.return

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -184,9 +184,9 @@ def NVWS_AsyncCompleteOp : NVWS_Op<"async_complete", [DeclareOpInterfaceMethods<
   }];
 
   let hasVerifier = 1;
-  let arguments = (ins TTG_MemDescType:$alloc, NVWS_AsyncOpEnum:$async_op);
+  let arguments = (ins TTG_MemDescType:$alloc, NVWS_AsyncOpEnum:$async_op, Optional<I1>:$pred);
   let assemblyFormat = [{
-    $alloc `,` `async_op` `=` $async_op attr-dict `:` type($alloc)
+    $alloc `,` `async_op` `=` $async_op (`,` $pred^)? attr-dict `:` type($alloc)
   }];
 }
 

--- a/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
@@ -21,8 +21,9 @@ LogicalResult ArefCreateOp::verify() {
   SmallVector<int> dims;
   for (auto operand : getOperands()) {
     SmallVector<Operation *> users(operand.user_begin(), operand.user_end());
-    if (!llvm::all_of(users,
-                      [](Operation *op) { return isa<ArefCreateOp>(op); }))
+    if (!llvm::all_of(users, [](Operation *op) {
+          return isa<ArefCreateOp, gpu::LocalDeallocOp>(op);
+        }))
       return emitError("Aref buffer is used elsewhere, Aref cannot guarantee "
                        "async safety");
     auto type = operand.getType();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -132,6 +132,16 @@ Value createElectPredicateWarp0(Location loc, RewriterBase &rewriter) {
   return b.and_(warp0, createElectPredicate(loc, rewriter));
 }
 
+void createTcgen05Commit(ConversionPatternRewriter &rewriter, Location loc,
+                         Value barrier, Value pred) {
+  PTXBuilder ptxBuilder;
+  auto *barrierOperand = ptxBuilder.newAddrOperand(barrier, "r");
+  std::string opcode = "tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64";
+  auto &barrierOp = *ptxBuilder.create<PTXInstr>(opcode);
+  barrierOp(barrierOperand).predicate(pred);
+  ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
+}
+
 } // namespace NVIDIA
 } // namespace LLVM
 } // namespace mlir

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
@@ -43,6 +43,9 @@ Value createElectPredicateWarp0(Location loc, RewriterBase &rewriter);
 // Create bar.warp.sync
 void createSyncWarp(Location loc, OpBuilder &builder);
 
+void createTcgen05Commit(ConversionPatternRewriter &rewriter, Location loc,
+                         Value barrier, Value pred);
+
 } // namespace NVIDIA
 } // namespace LLVM
 


### PR DESCRIPTION
 * Integrates Remove Rewrite multiplicity ([PR7371](https://github.com/triton-lang/triton/pull/7371))
 * Teaches `RewritePartitionDependencies` to insert arefs.
 * Lower `nvws::async_complete` to `mbarrier.arrive`/`tcgen05.commit`

We currently cannot lower `nvws::async_complete` to `mbarrier.arrive` because the `LowerAref` pass computes the arrival count using `num_warps`, which may be modified later by the `OptimizePartitionWarps` pass. The arrival count then disagrees with the actual number of threads in the group, leading to hang.

Data indicates that using `mbarrier.arrive` yields meaningful performance improvements, compated to `ttng.arrive_barrier` (see tables below in comments). However, resolving this issue is orthogonal to the current PR and will be addressed in a follow-up.



<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
