### PR TITLE
[ConSan] Add support for Tensor Memory

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/CMakeLists.txt
+++ b/include/triton/Dialect/TritonInstrument/IR/CMakeLists.txt
@@ -8,6 +8,8 @@ add_mlir_doc(TritonInstrumentDialect TritonInstrumentDialect dialects/ -gen-dial
 set(LLVM_TARGET_DEFINITIONS TritonInstrumentOps.td)
 mlir_tablegen(Ops.h.inc -gen-op-decls)
 mlir_tablegen(Ops.cpp.inc -gen-op-defs)
+mlir_tablegen(OpsEnums.h.inc -gen-enum-decls)
+mlir_tablegen(OpsEnums.cpp.inc -gen-enum-defs)
 add_mlir_doc(TritonInstrumentOps TritonInstrumentOps dialects/ -gen-op-doc)
 
 add_public_tablegen_target(TritonInstrumentTableGen)

--- a/include/triton/Dialect/TritonInstrument/IR/Dialect.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Dialect.h
@@ -5,6 +5,8 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
+#include "triton/Dialect/TritonInstrument/IR/OpsEnums.h.inc"
+
 #define GET_OP_CLASSES
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h.inc"
 #include "triton/Dialect/TritonInstrument/IR/Ops.h.inc"

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentAttrDefs.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentAttrDefs.td
@@ -7,7 +7,7 @@ def TT_MemTypeAttr : I32EnumAttr<
     "MemType", "",
     [
         I32EnumAttrCase<"SHARED", 0, "shared">,
-        I32EnumAttrCase<"TMEM", 1, "tmem">,
+        I32EnumAttrCase<"TENSOR", 1, "tensor">,
     ]> {
     let cppNamespace = "::mlir::triton::instrument";
 }

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentAttrDefs.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentAttrDefs.td
@@ -1,0 +1,15 @@
+#ifndef TRITONINSTRUMENT_ATTR_DEFS
+#define TRITONINSTRUMENT_ATTR_DEFS
+
+include "mlir/IR/EnumAttr.td"
+
+def TT_MemTypeAttr : I32EnumAttr<
+    "MemType", "",
+    [
+        I32EnumAttrCase<"SHARED", 0, "shared">,
+        I32EnumAttrCase<"TMEM", 1, "tmem">,
+    ]> {
+    let cppNamespace = "::mlir::triton::instrument";
+}
+
+#endif // TRITONINSTRUMENT_ATTR_DEFS

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -207,6 +207,25 @@ def TTI_ExperimentalClearReadBarrierOp : TTI_Op<"experimental_clear_read_barrier
 }
 
 
+def TTI_ExperimentalCheckBarrierWritesClearedOp : TTI_Op<"experimental_check_barrier_writes_cleared", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "verify that the barrier is not used to track any writes";
+  let description = [{
+    Verify that the barrier is not used to track any writes.
+  }];
+  let arguments = (ins
+    TTG_MemDescType:$mbar,
+    TT_Tensor:$barriers,
+    TT_PtrLike:$writeBars,
+    TypeAttr:$writeBarsType,
+    Optional<I1>:$pred
+  );
+  let assemblyFormat = [{
+    $mbar `{` $barriers `,` $writeBars `(` $writeBarsType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($writeBars)
+  }];
+  let hasVerifier = 1;
+}
+
+
 // TODO: Potentially resolve the naming/functionality clash with commit_write_with_barrier
 def TTI_ExperimentalStageWriteForCommitOp : TTI_Op<"experimental_stage_write_for_commit", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "Preapre to an async copy of a buffer. Staged until commit_group is called.";

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -51,9 +51,13 @@ def TTI_ExperimentalCheckOutstandingWritesOp : TTI_Op<"experimental_check_outsta
   let summary = "check if there are outstanding writes to a buffer guarded by a mbar";
   let description = [{
     Check if the writeState tensor has non-zero value associated with the buffer.
-    // TODO: explain how the value is checked for hwPipelined ops
-    If hwPipelined is true, error won't be trigerred if another pipelined
-    write is outstanding.
+
+    `writeState` is a tensor of 8b bitfields, where:
+    - bit 0: 1 if the buffer is being written to
+    - bit 1: 1 if the write is *not* hwPipelined
+
+    If hwPipelined is true, shift the bitfield by 1 to check the second bit - this
+    means that the error won't be triggered if another pipelined write is outstanding.
   }];
   let arguments = (ins
     TTG_MemDescType:$buf,
@@ -94,7 +98,14 @@ def TTI_ExperimentalCheckOutstandingReadsOp : TTI_Op<"experimental_check_outstan
 def TTI_ExperimentalMarkAsWriteOp : TTI_Op<"experimental_mark_as_write", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "mark a buffer as being written to using mbar as a guard";
   let description = [{
-    Mark a buffer as being written to using mbar as a guard.
+    Mark a buffer as being written to. It is not yet tracked by a barrier, until
+    `commit_write_with_barrier` is called, at which point all the buffers being written
+    to are marked as tracked by the barrier.
+
+    `writeState` is a tensor of 8b bitfields, where:
+    - bit 0: 1 if the buffer is being written to
+    - bit 1: 1 if the write is *not* hwPipelined
+
     If hwPipelined is true, the write won't trigger an error if another pipelined
     write is executed later without waiting for the barrier.
   }];
@@ -131,7 +142,7 @@ def TTI_ExperimentalCommitWriteWithBarrierOp : TTI_Op<"experimental_commit_write
   let assemblyFormat = [{
     $mbar `{` $barriers `,` $writeBars `(` $writeBarsType `)` `,` $writeState `(` $writeStateType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($writeBars) `,` type($writeState)
   }];
-  // let hasVerifier = 1;
+  let hasVerifier = 1;
 }
 
 
@@ -173,6 +184,7 @@ def TTI_ExperimentalClearWriteBarrierOp : TTI_Op<"experimental_clear_write_barri
   let assemblyFormat = [{
     $mbar `{` $barriers `,` $writeBars `(` $writeBarsType `)` `,` $writeState `(` $writeStateType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($writeBars) `,` type($writeState)
   }];
+  let hasVerifier = 1;
 }
 
 

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -6,6 +6,7 @@ include "triton/Dialect/TritonGPU/IR/TritonGPUTypes.td"
 include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "triton/Dialect/TritonInstrument/IR/TritonInstrumentAttrDefs.td"
 
 //
 // Interfaces
@@ -33,15 +34,15 @@ def TTI_ExperimentalAssertInThreadOp : TTI_Op<"experimental_assert_in_thread", [
 }
 
 
-def TTI_ExperimentalSharedBufferPointersOp : TTI_Op<"experimental_shared_buffer_pointers", [Pure]> {
+def TTI_ExperimentalBufferPointersOp : TTI_Op<"experimental_buffer_pointers", [Pure]> {
   let summary = "definte an array of pointers to shared memory buffers";
   let description = [{
     Create a tensor of pointers to shared memory buffers.
   }];
-  let arguments = (ins DenseI32ArrayAttr:$offsets);
+  let arguments = (ins DenseI32ArrayAttr:$offsets, TT_MemTypeAttr:$memType);
   let results = (outs TT_Tensor:$result);
   let assemblyFormat = [{
-    attr-dict `:` type($result)
+    $offsets `,` $memType attr-dict `:` type($result)
   }];
 }
 

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -51,16 +51,21 @@ def TTI_ExperimentalCheckOutstandingWritesOp : TTI_Op<"experimental_check_outsta
   let summary = "check if there are outstanding writes to a buffer guarded by a mbar";
   let description = [{
     Check if there are outstanding writes to a buffer guarded by a mbar.
+    If hwPipelined is true, error won't be trigerred if another pipelined
+    write is outstanding.
   }];
   let arguments = (ins
     TTG_MemDescType:$buf,
     TT_Tensor:$buffers,
     TT_PtrLike:$writeBars,
     TypeAttr:$writeBarsType,
+    TT_PtrLike:$writeState,
+    TypeAttr:$writeStateType,
+    I1Attr:$hwPipelined,
     Optional<I1>:$pred
   );
   let assemblyFormat = [{
-    $buf `{` $buffers `,` $writeBars `(` $writeBarsType `)` `}` (`,` $pred^)? attr-dict `:` type($buf) `,` type($buffers) `,` type($writeBars)
+    $buf `{` $buffers `,` $writeBars `(` $writeBarsType `)` `,` $writeState `(` $writeStateType `)` `}` (`,` $pred^)? `pipelined` $hwPipelined attr-dict `:` type($buf) `,` type($buffers) `,` type($writeBars) `,` type($writeState)
   }];
   let hasVerifier = 1;
 }
@@ -89,19 +94,41 @@ def TTI_ExperimentalMarkAsWriteOp : TTI_Op<"experimental_mark_as_write", [Memory
   let summary = "mark a buffer as being written to using mbar as a guard";
   let description = [{
     Mark a buffer as being written to using mbar as a guard.
+    If hwPipelined is true, the write won't trigger an error if another pipelined
+    write is executed later without waiting for the barrier.
   }];
   let arguments = (ins
     TTG_MemDescType:$buf,
-    TTG_MemDescType:$mbar,
     TT_Tensor:$buffers,
-    TT_PtrLike:$writeBars,
-    TypeAttr:$writeBarsType,
+    TT_PtrLike:$writeState,
+    TypeAttr:$writeStateType,
+    I1Attr:$hwPipelined,
     Optional<I1>:$pred
   );
   let assemblyFormat = [{
-    $buf `,` $mbar `{` $buffers `,` $writeBars `(` $writeBarsType `)` `}` (`,` $pred^)? attr-dict `:` type($buf) `,` type($mbar) `,` type($buffers) `,` type($writeBars)
+    $buf `{` $buffers `,` $writeState `(` $writeStateType `)` `}` (`,` $pred^)? `pipelined` $hwPipelined attr-dict `:` type($buf) `,` type($buffers) `,` type($writeState)
   }];
   let hasVerifier = 1;
+}
+
+
+def TTI_ExperimentalCommitWriteWithBarrierOp : TTI_Op<"experimental_commit_write_with_barrier", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "Mark all buffers being currently written as tracked by the barrier.";
+  let description = [{
+    Mark all buffers being currently written as tracked by the barrier.
+  }];
+  let arguments = (ins
+    TTG_MemDescType:$mbar,
+    TT_PtrLike:$writeBars,
+    TypeAttr:$writeBarsType,
+    TT_PtrLike:$writeState,
+    TypeAttr:$writeStateType,
+    Optional<I1>:$pred
+  );
+  let assemblyFormat = [{
+    $mbar `{` $writeBars `(` $writeBarsType `)` `,` $writeState `(` $writeStateType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($writeBars) `,` type($writeState)
+  }];
+  // let hasVerifier = 1;
 }
 
 
@@ -133,12 +160,15 @@ def TTI_ExperimentalClearWriteBarrierOp : TTI_Op<"experimental_clear_write_barri
   }];
   let arguments = (ins
     TTG_MemDescType:$mbar,
+    TT_Tensor:$barriers,
     TT_PtrLike:$writeBars,
     TypeAttr:$writeBarsType,
+    TT_PtrLike:$writeState,
+    TypeAttr:$writeStateType,
     Optional<I1>:$pred
   );
   let assemblyFormat = [{
-    $mbar `{` $writeBars `(` $writeBarsType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($writeBars)
+    $mbar `{` $barriers `,` $writeBars `(` $writeBarsType `)` `,` $writeState `(` $writeStateType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($writeBars) `,` type($writeState)
   }];
 }
 
@@ -161,6 +191,8 @@ def TTI_ExperimentalClearReadBarrierOp : TTI_Op<"experimental_clear_read_barrier
   let hasVerifier = 1;
 }
 
+
+// TODO: Potentially resolve the naming/functionality clash with commit_write_with_barrier
 def TTI_ExperimentalStageWriteForCommitOp : TTI_Op<"experimental_stage_write_for_commit", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "Preapre to an async copy of a buffer. Staged until commit_group is called.";
   let description = [{

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -50,7 +50,8 @@ def TTI_ExperimentalBufferPointersOp : TTI_Op<"experimental_buffer_pointers", [P
 def TTI_ExperimentalCheckOutstandingWritesOp : TTI_Op<"experimental_check_outstanding_writes", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "check if there are outstanding writes to a buffer guarded by a mbar";
   let description = [{
-    Check if there are outstanding writes to a buffer guarded by a mbar.
+    Check if the writeState tensor has non-zero value associated with the buffer.
+    // TODO: explain how the value is checked for hwPipelined ops
     If hwPipelined is true, error won't be trigerred if another pipelined
     write is outstanding.
   }];
@@ -115,10 +116,12 @@ def TTI_ExperimentalMarkAsWriteOp : TTI_Op<"experimental_mark_as_write", [Memory
 def TTI_ExperimentalCommitWriteWithBarrierOp : TTI_Op<"experimental_commit_write_with_barrier", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "Mark all buffers being currently written as tracked by the barrier.";
   let description = [{
-    Mark all buffers being currently written as tracked by the barrier.
+    For all buffers currently marked in writeState tensor, mark them as tracked by the mbar in
+    writeBars tensor.
   }];
   let arguments = (ins
     TTG_MemDescType:$mbar,
+    TT_Tensor:$barriers,
     TT_PtrLike:$writeBars,
     TypeAttr:$writeBarsType,
     TT_PtrLike:$writeState,
@@ -126,7 +129,7 @@ def TTI_ExperimentalCommitWriteWithBarrierOp : TTI_Op<"experimental_commit_write
     Optional<I1>:$pred
   );
   let assemblyFormat = [{
-    $mbar `{` $writeBars `(` $writeBarsType `)` `,` $writeState `(` $writeStateType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($writeBars) `,` type($writeState)
+    $mbar `{` $barriers `,` $writeBars `(` $writeBarsType `)` `,` $writeState `(` $writeStateType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($writeBars) `,` type($writeState)
   }];
   // let hasVerifier = 1;
 }

--- a/lib/Conversion/TritonInstrumentToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonInstrumentToLLVM/CMakeLists.txt
@@ -7,4 +7,5 @@ add_triton_library(TritonInstrumentToLLVM
     TritonIR
     TritonGPUIR
     TritonInstrumentIR
+    TritonNvidiaGPUIR
 )

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -244,7 +244,7 @@ struct BufferPointersOpConversion
       base = getSharedMemoryBase(rewriter,
                                  op->getParentOfType<FunctionOpInterface>());
     } else {
-      assert(op.getMemType() == tti::MemType::TMEM &&
+      assert(op.getMemType() == tti::MemType::TENSOR &&
              "Unsupported memory type");
       TritonLLVMOpBuilder b(loc, rewriter);
       base = rewriter.create<nvgpu::TensorMemoryBaseAddress>(loc);

--- a/lib/Dialect/TritonInstrument/IR/Dialect.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Dialect.cpp
@@ -5,7 +5,6 @@
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 
 #include "triton/Dialect/TritonInstrument/IR/Dialect.cpp.inc"
-
 using namespace mlir::triton::instrument;
 
 void TritonInstrumentDialect::initialize() {

--- a/lib/Dialect/TritonInstrument/IR/Ops.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Ops.cpp
@@ -124,4 +124,12 @@ LogicalResult ExperimentalClearReadBarrierOp::verify() {
   return success();
 }
 
+LogicalResult ExperimentalCheckBarrierWritesClearedOp::verify() {
+  auto writeBarsType = cast<RankedTensorType>(getWriteBarsType());
+  auto barriersType = getBarriers().getType();
+  if (writeBarsType.getShape()[1] != barriersType.getShape()[0])
+    return emitError() << "writeBars dim 1 must match number of barriers";
+  return success();
+}
+
 } // namespace mlir::triton::instrument

--- a/lib/Dialect/TritonInstrument/IR/Ops.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Ops.cpp
@@ -4,6 +4,8 @@
 #define GET_OP_CLASSES
 #include "triton/Dialect/TritonInstrument/IR/Ops.cpp.inc"
 
+#include "triton/Dialect/TritonInstrument/IR/OpsEnums.cpp.inc"
+
 using namespace mlir;
 namespace {
 // readBars should have encoding that ensures that all its elements reside

--- a/lib/Dialect/TritonInstrument/IR/Ops.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Ops.cpp
@@ -8,9 +8,9 @@
 
 using namespace mlir;
 namespace {
-// readBars should have encoding that ensures that all its elements reside
-// in a single thread
-bool verifyReadBarsEncoding(RankedTensorType readBarsType) {
+// readBars/writeBars should have encoding that ensures that all its elements
+// reside in a single thread
+bool verifyBarsEncoding(RankedTensorType readBarsType) {
   auto encoding =
       cast<triton::gpu::BlockedEncodingAttr>(readBarsType.getEncoding());
   int rank = encoding.getRank();
@@ -27,12 +27,20 @@ bool verifyReadBarsEncoding(RankedTensorType readBarsType) {
 namespace mlir::triton::instrument {
 
 LogicalResult ExperimentalCheckOutstandingWritesOp::verify() {
-  auto writeBarsType = cast<RankedTensorType>(getWriteBarsType());
+  auto writeStateType = cast<RankedTensorType>(getWriteStateType());
   auto buffersType = getBuffers().getType();
-  if (writeBarsType.getShape() != buffersType.getShape() ||
-      writeBarsType.getEncoding() != buffersType.getEncoding())
+  if (writeStateType.getShape() != buffersType.getShape() ||
+      writeStateType.getEncoding() != buffersType.getEncoding())
     return emitError()
-           << "writeBars and buffers must have the same shape and encoding";
+           << "writeState and buffers must have the same shape and encoding";
+  auto writeBarsType = cast<RankedTensorType>(getWriteBarsType());
+  // writeBars is 2D tensor of shape [num_buffers, num_barriers]
+  if (writeBarsType.getShape()[0] != buffersType.getShape()[0])
+    return emitError() << "writeBars dim 0 must match number of buffers";
+
+  if (!verifyBarsEncoding(writeBarsType))
+    return emitError() << "writeBars must have encoding that ensures that all "
+                          "its elements reside in a single thread";
   return success();
 }
 
@@ -43,7 +51,7 @@ LogicalResult ExperimentalCheckOutstandingReadsOp::verify() {
   if (readBarsType.getShape()[0] != buffersType.getShape()[0])
     return emitError() << "readBars dim 0 must match number of buffers";
 
-  if (!verifyReadBarsEncoding(readBarsType))
+  if (!verifyBarsEncoding(readBarsType))
     return emitError() << "readBars must have encoding that ensures that all "
                           "its elements reside in a single thread";
   return success();
@@ -51,11 +59,11 @@ LogicalResult ExperimentalCheckOutstandingReadsOp::verify() {
 
 LogicalResult ExperimentalMarkAsWriteOp::verify() {
   auto buffersType = getBuffers().getType();
-  auto writeBarsType = cast<RankedTensorType>(getWriteBarsType());
-  if (writeBarsType.getShape() != buffersType.getShape() ||
-      writeBarsType.getEncoding() != buffersType.getEncoding())
+  auto writeStateType = cast<RankedTensorType>(getWriteStateType());
+  if (writeStateType.getShape() != buffersType.getShape() ||
+      writeStateType.getEncoding() != buffersType.getEncoding())
     return emitError()
-           << "writeBars and buffers must have the same shape and encoding";
+           << "writeState and buffers must have the same shape and encoding";
   return success();
 }
 
@@ -68,7 +76,7 @@ LogicalResult ExperimentalMarkAsReadOp::verify() {
     return emitError() << "readBars dim 0 must match number of buffers";
   if (readBarsType.getShape()[1] != barriersType.getShape()[0])
     return emitError() << "readBars dim 1 must match number of barriers";
-  if (!verifyReadBarsEncoding(readBarsType))
+  if (!verifyBarsEncoding(readBarsType))
     return emitError() << "readBars must have encoding that ensures that all "
                           "its elements reside in a single thread";
   return success();
@@ -80,7 +88,7 @@ LogicalResult ExperimentalClearReadBarrierOp::verify() {
   // readBars is 2D tensor of shape [num_buffers, num_barriers]
   if (readBarsType.getShape()[1] != barriersType.getShape()[0])
     return emitError() << "readBars dim 0 must match number of barriers";
-  if (!verifyReadBarsEncoding(readBarsType))
+  if (!verifyBarsEncoding(readBarsType))
     return emitError() << "readBars must have encoding that ensures that all "
                           "its elements reside in a single thread";
   return success();

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -401,6 +401,14 @@ private:
           }
         }
       }
+      if (auto commitOp = dyn_cast<ttng::TCGen5CommitOp>(op)) {
+        b.create<tti::ExperimentalCommitWriteWithBarrierOp>(
+            commitOp.getBarrier(), barriers,
+            writeBarriersAlloc[(int)MemType::TMEM],
+            writeBarriersType[(int)MemType::TMEM],
+            writeStateAlloc[(int)MemType::TMEM],
+            writeStateType[(int)MemType::TMEM], commitOp.getPred());
+      }
       if (auto asyncCommitGroupOp = dyn_cast<ttg::AsyncCommitGroupOp>(op)) {
         b.create<tti::ExperimentalCommitWritesOp>(writeCommitsAlloc,
                                                   writeCommitsType, nullptr);

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -417,6 +417,20 @@ private:
         b.create<tti::ExperimentalClearWriteCommitsOp>(
             writeCommitsAlloc, writeCommitsType, asyncWaitOp.getNum(), nullptr);
       }
+      if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op)) {
+        if (writeBarriersAlloc[(int)MemType::SHARED]) {
+          b.create<tti::ExperimentalCheckBarrierWritesClearedOp>(
+              expectOp.getAlloc(), barriers,
+              writeBarriersAlloc[(int)MemType::SHARED],
+              writeBarriersType[(int)MemType::SHARED], expectOp.getPred());
+        }
+        if (writeBarriersAlloc[(int)MemType::TENSOR]) {
+          b.create<tti::ExperimentalCheckBarrierWritesClearedOp>(
+              expectOp.getAlloc(), barriers,
+              writeBarriersAlloc[(int)MemType::TENSOR],
+              writeBarriersType[(int)MemType::TENSOR], expectOp.getPred());
+        }
+      }
     });
   }
 

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -375,7 +375,7 @@ private:
                   pred = b.create<arith::AndIOp>(effect.pred, pred);
                 }
                 b.create<tti::ExperimentalCommitWriteWithBarrierOp>(
-                    barrier, writeBarriersAlloc[(int)memType],
+                    barrier, barriers, writeBarriersAlloc[(int)memType],
                     writeBarriersType[(int)memType],
                     writeStateAlloc[(int)memType], writeStateType[(int)memType],
                     pred);

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -129,6 +129,7 @@ def tma_interleave_kernel(input_desc, XBLOCK: ttgl.constexpr, FAILURE: ttgl.cons
     mbarrier.expect(bar.index(1), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
     tma.async_copy_global_to_shared(input_desc, [0, 0], bar.index(0), smem.index(0))
     tma.async_copy_global_to_shared(input_desc, [0, 0], bar.index(1), smem.index(1))
+
     mbarrier.wait(bar.index(0), 1)
     mbarrier.wait(bar.index(1), 1)
 
@@ -146,7 +147,7 @@ def test_tma_interleave_kernel(FAILURE, device, run_wrapper):
         result = run_in_process(test_tma_interleave_kernel, (FAILURE, device, False))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
-            assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+            assert "Barrier is being reused while still tracking writes" in result.driver_stderr_output
         else:
             assert result.exc is None
             assert result.driver_stderr_output == ""

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -19,6 +19,13 @@ except RuntimeError:
     pass  # start method already set
 
 
+@pytest.fixture
+def run_wrapper():
+    # Use DISABLE_SUBPROCESS to run the tests in the main process
+    # (useful for debugging but assert in any test will make all the tests fail)
+    return not os.environ.get("DISABLE_SUBPROCESS")
+
+
 class ProcessResult:
 
     def __init__(self, exc, driver_stderr_output):
@@ -79,26 +86,27 @@ def async_tma_kernel(input_desc, XBLOCK: ttgl.constexpr, FAILURE: ttgl.constexpr
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_async_tma_kernel(FAILURE, device, subprocess=False):
-    if subprocess:
-        knobs.compilation.enable_experimental_consan = True
-        os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
-
-        # ConSan requires a global memory allocation
-        def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-            return torch.empty(size, device="cuda", dtype=torch.int8)
-
-        triton.set_allocator(alloc_fn)
-        XBLOCK = 128
-        input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
-        shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
-        input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
-        async_tma_kernel[(1, )](input_desc, XBLOCK, FAILURE=FAILURE, num_warps=4)
-    else:
-        result = run_in_process(test_async_tma_kernel, (FAILURE, device, True))
+def test_async_tma_kernel(FAILURE, device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_async_tma_kernel, (FAILURE, device, False))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        return
+
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+    XBLOCK = 128
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
+    async_tma_kernel[(1, )](input_desc, XBLOCK, FAILURE=FAILURE, num_warps=4)
 
 
 @gluon.jit
@@ -133,29 +141,30 @@ def tma_interleave_kernel(input_desc, XBLOCK: ttgl.constexpr, FAILURE: ttgl.cons
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_tma_interleave_kernel(FAILURE, device, subprocess=False):
-    if subprocess:
-        knobs.compilation.enable_experimental_consan = True
-        os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
-
-        # ConSan requires a global memory allocation
-        def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-            return torch.empty(size, device="cuda", dtype=torch.int8)
-
-        triton.set_allocator(alloc_fn)
-        XBLOCK = 128
-        input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
-        shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
-        input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
-        tma_interleave_kernel[(1, )](input_desc, XBLOCK, FAILURE=FAILURE, num_warps=4)
-    else:
-        result = run_in_process(test_tma_interleave_kernel, (FAILURE, device, True))
+def test_tma_interleave_kernel(FAILURE, device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_tma_interleave_kernel, (FAILURE, device, False))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
         else:
             assert result.exc is None
             assert result.driver_stderr_output == ""
+        return
+
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+    XBLOCK = 128
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
+    tma_interleave_kernel[(1, )](input_desc, XBLOCK, FAILURE=FAILURE, num_warps=4)
 
 
 @gluon.jit
@@ -181,28 +190,28 @@ def async_copy_kernel(input, XBLOCK: ttgl.constexpr, FAILURE: ttgl.constexpr):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires ampere or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_async_copy(FAILURE, device, subprocess=False):
-    if subprocess:
-        knobs.compilation.enable_experimental_consan = True
-        os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
-
-        # ConSan requires a global memory allocation
-        def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-            return torch.empty(size, device="cuda", dtype=torch.int8)
-
-        triton.set_allocator(alloc_fn)
-        XBLOCK = 128
-        input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
-        async_copy_kernel[(1, )](input, XBLOCK, FAILURE=FAILURE, num_warps=4)
-
-    else:
-        result = run_in_process(test_async_copy, (FAILURE, device, True))
+def test_async_copy(FAILURE, device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_async_copy, (FAILURE, device, False))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
         else:
             assert result.exc is None
             assert result.driver_stderr_output == ""
+        return
+
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+    XBLOCK = 128
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    async_copy_kernel[(1, )](input, XBLOCK, FAILURE=FAILURE, num_warps=4)
 
 
 @gluon.jit
@@ -241,23 +250,9 @@ def tcgen5_mma_kernel(input_desc, XBLOCK: ttgl.constexpr, FAILURE: ttgl.constexp
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
 @pytest.mark.parametrize("MEM_ACCESS_KIND", ["tma_cp", "tmem_load", "tmem_store"])
-def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, subprocess=False):
-    if subprocess:
-        knobs.compilation.enable_experimental_consan = True
-        os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
-
-        # ConSan requires a global memory allocation
-        def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-            return torch.empty(size, device="cuda", dtype=torch.int8)
-
-        triton.set_allocator(alloc_fn)
-        XBLOCK = 128
-        input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
-        shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
-        input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
-        tcgen5_mma_kernel[(1, )](input_desc, XBLOCK, FAILURE=FAILURE, MEM_ACCESS_KIND=MEM_ACCESS_KIND, num_warps=4)
-    else:
-        result = run_in_process(test_tcgen5_mma, (FAILURE, MEM_ACCESS_KIND, device, True))
+def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_tcgen5_mma, (FAILURE, MEM_ACCESS_KIND, device, False))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             if MEM_ACCESS_KIND == "tma_cp":
@@ -269,6 +264,78 @@ def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, subprocess=False):
         else:
             assert result.exc is None
             assert result.driver_stderr_output == ""
+        return
+
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+    XBLOCK = 128
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
+    tcgen5_mma_kernel[(1, )](input_desc, XBLOCK, FAILURE=FAILURE, MEM_ACCESS_KIND=MEM_ACCESS_KIND, num_warps=4)
+
+
+@gluon.jit
+def tcgen5_mma_multibar_kernel(input_desc, XBLOCK: ttgl.constexpr, BUF_IDX: ttgl.constexpr, BAR_IDX: ttgl.constexpr):
+    acc_layout: ttgl.constexpr = blackwell.TensorMemoryLayout([XBLOCK, XBLOCK], unpacked=True, cta_split_num=[1, 1])
+    blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1],
+                                                        warps_per_cta=[4, 1], order=[0, 1])
+    smemA = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], input_desc.layout)
+    smemB = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], input_desc.layout)
+    bar = ttgl.allocate_shared_memory(ttgl.int64, [4, 1], mbarrier.MBarrierLayout())
+    acc = blackwell.allocate_tensor_memory(ttgl.float32, [2, XBLOCK, XBLOCK], acc_layout)
+    for i in range(4):
+        mbarrier.init(bar.index(i), count=1)
+
+    blackwell.tcgen05_mma(smemA, smemB.permute([1, 0]), acc.index(0), mbarriers=[bar.index(0),
+                                                                                 bar.index(1)],
+                          mbarrier_preds=[False, True])
+    blackwell.tcgen05_mma(smemA, smemB.permute([1, 0]), acc.index(1), mbarriers=[bar.index(2)])
+    blackwell.tcgen05_commit(bar.index(3))
+
+    mbarrier.wait(bar.index(BAR_IDX), 0)
+
+    acc.index(BUF_IDX).store(ttgl.full([XBLOCK, XBLOCK], 42, ttgl.float32, blocked_layout))
+
+    for i in range(4):
+        mbarrier.invalidate(bar.index(i))
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
+@pytest.mark.parametrize("BUF_IDX", [0, 1])
+@pytest.mark.parametrize("BAR_IDX", [0, 1, 2, 3])
+def test_tcgen5_mma_multibar(BUF_IDX, BAR_IDX, device, run_wrapper):
+    if BAR_IDX == 0:
+        pytest.skip("Skipping due to wait on false-predicated barrier - not supported yet")
+    if run_wrapper:
+        result = run_in_process(test_tcgen5_mma_multibar, (BUF_IDX, BAR_IDX, device, False))
+        if BAR_IDX // 2 < BUF_IDX:
+            assert "device-side assert" in str(result.exc)
+            assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+    XBLOCK = 128
+
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
+    tcgen5_mma_multibar_kernel[(1, )](input_desc, XBLOCK, BUF_IDX, BAR_IDX, num_warps=4)
 
 
 @gluon.jit
@@ -365,26 +432,27 @@ def multibuffered_loop_tma_kernel(input_desc, XBLOCK: ttgl.constexpr, FAILURE: t
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_multibuffered_loop(FAILURE, device, subprocess=False):
-    if subprocess:
-        knobs.compilation.enable_experimental_consan = True
-        os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
-
-        # ConSan requires a global memory allocation
-        def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-            return torch.empty(size, device="cuda", dtype=torch.int8)
-
-        triton.set_allocator(alloc_fn)
-        XBLOCK = 128
-        input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
-        shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
-        input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
-        multibuffered_loop_tma_kernel[(1, )](input_desc, XBLOCK, FAILURE=FAILURE, num_warps=4)
-    else:
-        result = run_in_process(test_multibuffered_loop, (FAILURE, device, True))
+def test_multibuffered_loop(FAILURE, device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_multibuffered_loop, (FAILURE, device, False))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
         else:
             assert result.exc is None
             assert result.driver_stderr_output == ""
+        return
+
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+    XBLOCK = 128
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
+    multibuffered_loop_tma_kernel[(1, )](input_desc, XBLOCK, FAILURE=FAILURE, num_warps=4)

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -1,6 +1,32 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-gpu-to-llvm | FileCheck %s --dump-input-context 20
 
 #blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_buffer_pointers_tmem
+// CHECK:nvgpu.tensor_memory_base
+tt.func private @experimental_buffer_pointers_tmem() {
+  tti.experimental_buffer_pointers [0, 42], tmem : tensor<2xi64, #blocked>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_buffer_pointers_shared
+// CHECK: llvm.ptrtoint %arg0
+tt.func private @experimental_buffer_pointers_shared() {
+  tti.experimental_buffer_pointers [0, 42], shared : tensor<2xi64, #blocked>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -6,7 +6,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
 // CHECK-LABEL: @experimental_buffer_pointers_tmem
 // CHECK:nvgpu.tensor_memory_base
 tt.func private @experimental_buffer_pointers_tmem() {
-  tti.experimental_buffer_pointers [0, 42], tmem : tensor<2xi64, #blocked>
+  tti.experimental_buffer_pointers [0, 42], tensor : tensor<2xi64, #blocked>
   tt.return
 }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -5,17 +5,27 @@
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK: #[[BUFS_L:.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+  // CHECK: #[[WRT_BARS_L:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
   // CHECK: @single_local_alloc
   tt.func public @single_local_alloc() {
     // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64, #[[BUFS_L]]>
-    // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64, #[[BUFS_L]]>
-    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
-    // CHECK: %[[SPLAT:.*]] = tt.splat %[[WRT_BARS_GLOB]] : !tt.ptr<i64> -> tensor<1x!tt.ptr<i64>, #[[BUFS_L]]>
-    // CHECK: %[[RANGE:.*]] = tt.make_range {end = 1 : i32, start = 0 : i32} : tensor<1xi32, #[[BUFS_L]]>
-    // CHECK: %[[STRIDE0:.*]] = arith.constant dense<1> : tensor<1xi32, #[[BUFS_L]]>
-    // CHECK: %[[OFFS0:.*]] = arith.muli %[[RANGE]], %[[STRIDE0]]
-    // CHECK: %[[ADD:.*]] = tt.addptr %[[SPLAT]], %[[OFFS0]] : tensor<1x!tt.ptr<i64>, #[[BUFS_L]]>, tensor<1xi32, #[[BUFS_L]]>
-    // CHECK: tt.store %[[ADD]], %cst : tensor<1x!tt.ptr<i64>, #[[BUFS_L]]>
+    // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8, #[[WRT_BARS_L]]>
+    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[SPLAT:.*]] = tt.splat %[[WRT_BARS_GLOB]] : !tt.ptr<i8> -> tensor<1x1x!tt.ptr<i8>, #[[WRT_BARS_L]]>
+    // CHECK: %[[RANGE0:.*]] = tt.make_range {end = 1 : i32, start = 0 : i32} : tensor<1xi32, #ttg.slice<{dim = 1, parent = #[[WRT_BARS_L]]}>>
+    // CHECK: %[[STRIDE0:.*]] = arith.constant dense<1> : tensor<1xi32, #ttg.slice<{dim = 1, parent = #[[WRT_BARS_L]]}>>
+    // CHECK: %[[OFFS0:.*]] = arith.muli %[[RANGE0]], %[[STRIDE0]]
+    // CHECK: %[[EXP0:.*]] = tt.expand_dims %[[OFFS0]] {axis = 1 : i32} : tensor<1xi32, #ttg.slice<{dim = 1, parent = #[[WRT_BARS_L]]}>> -> tensor<1x1xi32, #[[WRT_BARS_L]]>
+    // CHECK: %[[ADD0:.*]] = tt.addptr %[[SPLAT]], %[[EXP0]] : tensor<1x1x!tt.ptr<i8>, #[[WRT_BARS_L]]>, tensor<1x1xi32, #[[WRT_BARS_L]]>
+    // CHECK: %[[RANGE1:.*]] = tt.make_range {end = 1 : i32, start = 0 : i32} : tensor<1xi32, #ttg.slice<{dim = 0, parent = #[[WRT_BARS_L]]}>
+    // CHECK: %[[STRIDE1:.*]] = arith.constant dense<1> : tensor<1xi32, #ttg.slice<{dim = 0, parent = #[[WRT_BARS_L]]}>
+    // CHECK: %[[OFFS1:.*]] = arith.muli %[[RANGE1]], %[[STRIDE1]]
+    // CHECK: %[[EXP1:.*]] = tt.expand_dims %[[OFFS1]] {axis = 0 : i32} : tensor<1xi32, #ttg.slice<{dim = 0, parent = #[[WRT_BARS_L]]}>> -> tensor<1x1xi32, #[[WRT_BARS_L]]>
+    // CHECK: %[[ADD1:.*]] = tt.addptr %[[ADD0]], %[[EXP1]] : tensor<1x1x!tt.ptr<i8>, #[[WRT_BARS_L]]>, tensor<1x1xi32, #[[WRT_BARS_L]]>
+    // CHECK: tt.store %[[ADD1]], %cst : tensor<1x1x!tt.ptr<i8>, #[[WRT_BARS_L]]>
+    // CHECK: %[[WRITE_STATE:.*]] = arith.constant dense<0> : tensor<1xi8, #[[BUFS_L]]>
+    // CHECK: %[[WRT_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: tt.store {{.*}}, %[[WRITE_STATE]]
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -31,12 +41,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @two_local_alloc
   tt.func public @two_local_alloc() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096], shared : tensor<2xi64, #blocked>
-    // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<2xi64, #blocked>
-    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096], shared : tensor<2xi64,
+    // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<2x1xi8,
+    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_STATE:.*]] = arith.constant dense<0> : tensor<2xi8,
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
-    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
@@ -50,13 +61,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @three_local_alloc
   tt.func public @three_local_alloc() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096, 8192, 0], shared : tensor<4xi64, #blocked>
-    // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<4xi64, #blocked>
-    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 32 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096, 8192, 0], shared : tensor<4xi64,
+    // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<4x1xi8,
+    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 4 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_STATE:.*]] = arith.constant dense<0> : tensor<4xi8,
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %2 = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
-    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 12288 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
@@ -70,9 +82,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @three_sub_bufs
   tt.func public @three_sub_bufs() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096, 8192, 0], shared : tensor<4xi64, #blocked>
-    // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<4xi64, #blocked>
-    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 32 : i32} : !tt.ptr<i64>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096, 8192, 0], shared : tensor<4xi64,
+    // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<4x1xi8,
+    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 4 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_STATE:.*]] = arith.constant dense<0> : tensor<4xi8,
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable>
     %1 = ttg.memdesc_index %0, %c0_i32 : !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -105,7 +118,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[EXP:.*]] = tt.expand_dims %[[OFFS]] {axis = 0 : i32} : tensor<4xi32, #ttg.slice<{dim = 0, parent = #[[READ_BARS_L]]}>> -> tensor<1x4xi32, #[[READ_BARS_L]]>
     // CHECK: %[[BROAD:.*]] = tt.broadcast %[[EXP]] : tensor<1x4xi32, #[[READ_BARS_L]]> -> tensor<2x4xi32, #[[READ_BARS_L]]>
     // CHECK: %[[PTR1:.*]] = tt.addptr %[[PTR0]], %[[BROAD]] : tensor<2x4x!tt.ptr<i8>, #[[READ_BARS_L]]>, tensor<2x4xi32, #[[READ_BARS_L]]>
-    // CHECK: tt.store %[[PTR1]], %cst_1 : tensor<2x4x!tt.ptr<i8>, #[[READ_BARS_L]]>
+    // CHECK: tt.store %[[PTR1]], {{.*}} : tensor<2x4x!tt.ptr<i8>, #[[READ_BARS_L]]>
     %c0 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<4x1xi64, #shared1, #smem, mutable>
@@ -129,14 +142,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @tmem_alloc() {
     // CHECK-DAG: %[[TMEM_BUFS:.*]] = tti.experimental_buffer_pointers [0], tmem : tensor<1xi64, #[[BUFS_L]]>
     // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [4096], shared : tensor<1xi64, #[[BUFS_L]]>
-    // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64, #[[BUFS_L]]>
-    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
-    // CHECK: %[[SPLAT:.*]] = tt.splat %[[WRT_BARS_GLOB]] : !tt.ptr<i64> -> tensor<1x!tt.ptr<i64>, #[[BUFS_L]]>
-    // CHECK: %[[RANGE:.*]] = tt.make_range {end = 1 : i32, start = 0 : i32} : tensor<1xi32, #[[BUFS_L]]>
-    // CHECK: %[[STRIDE0:.*]] = arith.constant dense<1> : tensor<1xi32, #[[BUFS_L]]>
-    // CHECK: %[[OFFS0:.*]] = arith.muli %[[RANGE]], %[[STRIDE0]]
-    // CHECK: %[[ADD:.*]] = tt.addptr %[[SPLAT]], %[[OFFS0]] : tensor<1x!tt.ptr<i64>, #[[BUFS_L]]>, tensor<1xi32, #[[BUFS_L]]>
-    // CHECK: tt.store %[[ADD]], %cst : tensor<1x!tt.ptr<i64>, #[[BUFS_L]]>
+    // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8,
+    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_STATE:.*]] = arith.constant dense<0> : tensor<1xi8,
     %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -154,17 +162,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @async_tma_copy_global_to_local(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
     // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64
-    // CHECK: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64
-    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8
+    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_STATE:.*]] = arith.constant dense<0> : tensor<1xi8,
+    // CHECK: %[[WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[READ_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8
     // CHECK: %[[READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[OUTSTANDING_COMMITS:.*]] = arith.constant dense<0> : tensor<1xi8
+    // CHECK: %[[OUTSTANDING_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK: tti.experimental_check_outstanding_writes {{.*}}{%[[BUFFERS]], %[[WRT_BARS_GLOB]](tensor<1xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_writes {{.*}}{%[[BUFFERS]], %[[WRT_BARS_GLOB]](tensor<1x1xi8, #{{.*}}>), %[[WRITE_STATE_GLOB]](tensor<1xi8, #{{.*}}>)}, %true pipelined false
+    // CHECK: tti.experimental_check_write_commit {{.*}}{%[[BUFFERS]], %[[OUTSTANDING_COMMITS_GLOB]](tensor<1xi8, #{{.*}}>)}
     // CHECK: tti.experimental_check_outstanding_reads {{.*}}{%[[BUFFERS]], %[[READ_BARS_GLOB]](tensor<1x1xi8, #{{.*}}>)}
+    // CHECK: tti.experimental_mark_as_write {{.*}}{%[[BUFFERS]], %[[WRITE_STATE_GLOB]](tensor<1xi8, #{{.*}}>)}, %true pipelined false
+    // CHECK: tti.experimental_commit_write_with_barrier {{.*}}{%[[WRT_BARS_GLOB]](tensor<1x1xi8, #{{.*}}>), %[[WRITE_STATE_GLOB]](tensor<1xi8, #{{.*}}>)}
     ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %bar, %true : !tt.tensordesc<tensor<32x32xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -180,16 +195,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @wait_barrier(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
     // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64, #blocked>
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64, #blocked>
-    // CHECK: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64, #blocked>
-    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
-    // CHECK: %[[READ_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8
+    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK: tti.experimental_clear_write_barrier {{.*}}{%[[WRT_BARS_GLOB]](tensor<1xi64, #blocked>)}
+    // CHECK: tti.experimental_clear_write_barrier {{.*}}{%[[BARRIERS]], %[[WRT_BARS_GLOB]](tensor<1x1xi8, #{{.*}}>), %[[WRITE_STATE_GLOB]](tensor<1xi8, #{{.*}}>)}
     // CHECK: tti.experimental_clear_read_barrier {{.*}}{%[[BARRIERS]], %[[READ_BARS_GLOB]](tensor<1x1xi8, #blocked1>)}
     ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
@@ -208,25 +222,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK-DAG: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 32768], shared : tensor<2xi64
     // CHECK-DAG: %[[TM_BUFS:.*]] = tti.experimental_buffer_pointers [0], tmem : tensor<1xi64
     // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64
-    // CHECK: %[[SM_WRITE_BARS:.*]] = arith.constant dense<0> : tensor<2xi64
-    // CHECK: %[[SM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
-    // CHECK: %[[SM_READ_BARS:.*]] = arith.constant dense<0> : tensor<2x1xi8
+    // CHECK: %[[SM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
+    // CHECK: %[[SM_WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
     // CHECK: %[[SM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
-    // CHECK: %[[TM_WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64
-    // CHECK: %[[TM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
-    // CHECK: %[[TM_READ_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8
+    // CHECK: %[[TM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[TM_WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[TM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
 
-    // CHECK: tti.experimental_check_outstanding_writes %[[A:.*]]{%[[SM_BUFS]], %[[SM_WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_writes %[[A:.*]]{%[[SM_BUFS]], %[[SM_WRT_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>), %[[SM_WRITE_STATE_GLOB]](tensor<2xi8, #{{.*}}>)}, %true pipelined false
     // CHECK: tti.experimental_check_write_commit %[[A]]{%[[SM_BUFS]], %[[WRT_COMMITS_GLOB]](tensor<2xi8, #blocked>)}
     // CHECK: tti.experimental_mark_as_read %[[A]], %[[BAR:.*]]{%[[SM_BUFS]], %[[BARRIERS]], %[[SM_READ_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>)}
-    // CHECK: tti.experimental_check_outstanding_writes %[[B:.*]]{%[[SM_BUFS]], %[[SM_WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_writes %[[B:.*]]{%[[SM_BUFS]], %[[SM_WRT_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>), %[[SM_WRITE_STATE_GLOB]](tensor<2xi8, #{{.*}}>)}, %true pipelined false
     // CHECK: tti.experimental_check_write_commit %[[B]]{%[[SM_BUFS]], %[[WRT_COMMITS_GLOB]](tensor<2xi8, #blocked>)}
     // CHECK: tti.experimental_mark_as_read %[[B]], %[[BAR:.*]]{%[[SM_BUFS]], %[[BARRIERS]], %[[SM_READ_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>)}
-    // CHECK: tti.experimental_check_outstanding_writes %[[ACC:.*]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<1xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_writes %[[ACC:.*]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<1x1xi8, #{{.*}}>), %[[TM_WRITE_STATE_GLOB]](tensor<1xi8, #{{.*}}>)}, %true pipelined true
     // CHECK: tti.experimental_check_outstanding_reads %[[ACC]]{%[[TM_BUFS]], %[[TM_READ_BARS_GLOB]](tensor<1x1xi8, #{{.*}}>)}
-    // CHECK: tti.experimental_mark_as_write %[[ACC]], %[[BAR]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<1xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_mark_as_write %[[ACC]]{%[[TM_BUFS]], %[[TM_WRITE_STATE_GLOB]](tensor<1xi8, #{{.*}}>)}, {{.*}} pipelined true
+    // CHECK: tti.experimental_commit_write_with_barrier {{.*}}{%[[TM_WRT_BARS_GLOB]](tensor<1x1xi8, #{{.*}}>), %[[TM_WRITE_STATE_GLOB]](tensor<1xi8, #{{.*}}>)}
     // CHECK: ttng.tc_gen5_mma %[[A]], %[[B]], %[[ACC]][], {{.*}}, {{.*}}, %[[BAR]]
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
@@ -250,28 +263,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @tcgen5_mma_lhs_in_tmem
   tt.func public @tcgen5_mma_lhs_in_tmem(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
-    // CHECK: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [32768], shared : tensor<1xi64
-    // CHECK: %[[TM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 128], tmem : tensor<2xi64
-    // CHECK: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64
-    // CHECK: %[[SM_WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64
-    // CHECK: %[[SM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
-    // CHECK: %[[SM_READ_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8
+    // CHECK-DAG: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [32768], shared : tensor<1xi64
+    // CHECK-DAG: %[[TM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 128], tmem : tensor<2xi64
+    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64
+    // CHECK: %[[SM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[SM_WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[SM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
-    // CHECK: %[[TM_WRITE_BARS:.*]] = arith.constant dense<0> : tensor<2xi64
-    // CHECK: %[[TM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
-    // CHECK: %[[TM_READ_BARS:.*]] = arith.constant dense<0> : tensor<2x1xi8
+    // CHECK: %[[TM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
+    // CHECK: %[[TM_WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
     // CHECK: %[[TM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
     // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
 
-    // CHECK: tti.experimental_check_outstanding_writes %[[A:.*]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
-    // CHECK-NOT: tti.experimental_check_write_commit
+    // CHECK: tti.experimental_check_outstanding_writes %[[A:.*]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>), %[[TM_WRITE_STATE_GLOB]](tensor<2xi8, #{{.*}}>)}, %true pipelined false
     // CHECK: tti.experimental_mark_as_read %[[A]], %[[BAR:.*]]{%[[TM_BUFS]], %[[BARRIERS]], %[[TM_READ_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>)}
-    // CHECK: tti.experimental_check_outstanding_writes %[[B:.*]]{%[[SM_BUFS]], %[[SM_WRT_BARS_GLOB]](tensor<1xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_writes %[[B:.*]]{%[[SM_BUFS]], %[[SM_WRT_BARS_GLOB]](tensor<1x1xi8, #{{.*}}>), %[[SM_WRITE_STATE_GLOB]](tensor<1xi8, #{{.*}}>)}, %true pipelined false
     // CHECK: tti.experimental_check_write_commit %[[B]]{%[[SM_BUFS]], %[[WRT_COMMITS_GLOB]](tensor<1xi8, #blocked>)}
     // CHECK: tti.experimental_mark_as_read %[[B]], %[[BAR:.*]]{%[[SM_BUFS]], %[[BARRIERS]], %[[SM_READ_BARS_GLOB]](tensor<1x1xi8, #{{.*}}>)}
-    // CHECK: tti.experimental_check_outstanding_writes %[[ACC:.*]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_writes %[[ACC:.*]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>), %[[TM_WRITE_STATE_GLOB]](tensor<2xi8, #{{.*}}>)}, %true pipelined true
     // CHECK: tti.experimental_check_outstanding_reads %[[ACC]]{%[[TM_BUFS]], %[[TM_READ_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>)}
-    // CHECK: tti.experimental_mark_as_write %[[ACC]], %[[BAR]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_mark_as_write %[[ACC]]{%[[TM_BUFS]], %[[TM_WRITE_STATE_GLOB]](tensor<2xi8, #{{.*}}>)}, {{.*}} pipelined true
+    // CHECK: tti.experimental_commit_write_with_barrier {{.*}}{%[[TM_WRT_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>), %[[TM_WRITE_STATE_GLOB]](tensor<2xi8, #{{.*}}>)}
     // CHECK: ttng.tc_gen5_mma %[[A]], %[[B]], %[[ACC]][], {{.*}}, {{.*}}, %[[BAR]]
     %c0_i32 = arith.constant 0 : i32
     %0 = ttng.tmem_alloc  {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem1, #ttng.tensor_memory, mutable>
@@ -320,7 +331,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-LABEL: @async_copy_local_to_global_with_barriers
   tt.func public @async_copy_local_to_global_with_barriers(%ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
     // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64
-    // CHECK: %[[WRITE_COMMITS:.*]] = arith.constant dense<0> : tensor<1xi8
+    // CHECK: %[[SM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[SM_WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[SM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
 
     // CHECK: tti.experimental_check_outstanding_writes

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -315,7 +315,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     %result = ttng.tmem_alloc  {tensor_memory_col_offset = 128 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
     %true = arith.constant true
-    ttng.tc_gen5_mma %0, %1, %result[], %true, %true, %bar[%true] : !ttg.memdesc<128x128xf16, #tmem1, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.tc_gen5_mma %0, %1, %result[], %true, %true, %bar[%true] {is_async} : !ttg.memdesc<128x128xf16, #tmem1, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -7,7 +7,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: #[[BUFS_L:.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
   // CHECK: @single_local_alloc
   tt.func public @single_local_alloc() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 0>} : tensor<1xi64, #[[BUFS_L]]>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64, #[[BUFS_L]]>
     // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64, #[[BUFS_L]]>
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
     // CHECK: %[[SPLAT:.*]] = tt.splat %[[WRT_BARS_GLOB]] : !tt.ptr<i64> -> tensor<1x!tt.ptr<i64>, #[[BUFS_L]]>
@@ -31,7 +31,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @two_local_alloc
   tt.func public @two_local_alloc() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 0, 4096>} : tensor<2xi64, #blocked>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096], shared : tensor<2xi64, #blocked>
     // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<2xi64, #blocked>
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -50,7 +50,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @three_local_alloc
   tt.func public @three_local_alloc() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 0, 4096, 8192, 0>} : tensor<4xi64, #blocked>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096, 8192, 0], shared : tensor<4xi64, #blocked>
     // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<4xi64, #blocked>
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 32 : i32} : !tt.ptr<i64>
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -70,7 +70,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @three_sub_bufs
   tt.func public @three_sub_bufs() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 0, 4096, 8192, 0>} : tensor<4xi64, #blocked>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096, 8192, 0], shared : tensor<4xi64, #blocked>
     // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<4xi64, #blocked>
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 32 : i32} : !tt.ptr<i64>
     %c0_i32 = arith.constant 0 : i32
@@ -122,11 +122,38 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK: #[[BUFS_L:.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+  // CHECK: @tmem_alloc
+  tt.func public @tmem_alloc() {
+    // CHECK-DAG: %[[TMEM_BUFS:.*]] = tti.experimental_buffer_pointers [0], tmem : tensor<1xi64, #[[BUFS_L]]>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [4096], shared : tensor<1xi64, #[[BUFS_L]]>
+    // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64, #[[BUFS_L]]>
+    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK: %[[SPLAT:.*]] = tt.splat %[[WRT_BARS_GLOB]] : !tt.ptr<i64> -> tensor<1x!tt.ptr<i64>, #[[BUFS_L]]>
+    // CHECK: %[[RANGE:.*]] = tt.make_range {end = 1 : i32, start = 0 : i32} : tensor<1xi32, #[[BUFS_L]]>
+    // CHECK: %[[STRIDE0:.*]] = arith.constant dense<1> : tensor<1xi32, #[[BUFS_L]]>
+    // CHECK: %[[OFFS0:.*]] = arith.muli %[[RANGE]], %[[STRIDE0]]
+    // CHECK: %[[ADD:.*]] = tt.addptr %[[SPLAT]], %[[OFFS0]] : tensor<1x!tt.ptr<i64>, #[[BUFS_L]]>, tensor<1xi32, #[[BUFS_L]]>
+    // CHECK: tt.store %[[ADD]], %cst : tensor<1x!tt.ptr<i64>, #[[BUFS_L]]>
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_tma_copy_global_to_local
   tt.func public @async_tma_copy_global_to_local(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 0>} : tensor<1xi64
-    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 65536>} : tensor<1xi64
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64
+    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64
     // CHECK: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
     // CHECK: %[[READ_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8
@@ -151,8 +178,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @wait_barrier
   tt.func public @wait_barrier(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 0>} : tensor<1xi64, #blocked>
-    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 65536>} : tensor<1xi64, #blocked>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64, #blocked>
+    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64, #blocked>
     // CHECK: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64, #blocked>
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
     // CHECK: %[[READ_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8
@@ -178,26 +205,82 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @tcgen5_mma
   tt.func public @tcgen5_mma(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 0, 32768>} : tensor<2xi64
-    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 65536>} : tensor<1xi64
-    // CHECK: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<2xi64
-    // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
-    // CHECK: %[[READ_BARS:.*]] = arith.constant dense<0> : tensor<2x1xi8
-    // CHECK: %[[READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
+    // CHECK-DAG: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 32768], shared : tensor<2xi64
+    // CHECK-DAG: %[[TM_BUFS:.*]] = tti.experimental_buffer_pointers [0], tmem : tensor<1xi64
+    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64
+    // CHECK: %[[SM_WRITE_BARS:.*]] = arith.constant dense<0> : tensor<2xi64
+    // CHECK: %[[SM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
+    // CHECK: %[[SM_READ_BARS:.*]] = arith.constant dense<0> : tensor<2x1xi8
+    // CHECK: %[[SM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
+    // CHECK: %[[TM_WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64
+    // CHECK: %[[TM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK: %[[TM_READ_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8
+    // CHECK: %[[TM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
 
-    // CHECK: tti.experimental_check_outstanding_writes %[[A:.*]]{%[[BUFFERS]], %[[WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
-    // CHECK: tti.experimental_mark_as_read %[[A]], %[[BAR:.*]]{%[[BUFFERS]], %[[BARRIERS]], %[[READ_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>)}
-    // CHECK: tti.experimental_check_outstanding_writes %[[B:.*]]{%[[BUFFERS]], %[[WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
-    // CHECK: tti.experimental_mark_as_read %[[B]], %[[BAR:.*]]{%[[BUFFERS]], %[[BARRIERS]], %[[READ_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>)}
-    // CHECK: ttng.tc_gen5_mma %[[A]], %[[B]], {{.*}}, {{.*}}, {{.*}}, %[[BAR]]
+    // CHECK: tti.experimental_check_outstanding_writes %[[A:.*]]{%[[SM_BUFS]], %[[SM_WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_check_write_commit %[[A]]{%[[SM_BUFS]], %[[WRT_COMMITS_GLOB]](tensor<2xi8, #blocked>)}
+    // CHECK: tti.experimental_mark_as_read %[[A]], %[[BAR:.*]]{%[[SM_BUFS]], %[[BARRIERS]], %[[SM_READ_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_writes %[[B:.*]]{%[[SM_BUFS]], %[[SM_WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_check_write_commit %[[B]]{%[[SM_BUFS]], %[[WRT_COMMITS_GLOB]](tensor<2xi8, #blocked>)}
+    // CHECK: tti.experimental_mark_as_read %[[B]], %[[BAR:.*]]{%[[SM_BUFS]], %[[BARRIERS]], %[[SM_READ_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_writes %[[ACC:.*]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<1xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_reads %[[ACC]]{%[[TM_BUFS]], %[[TM_READ_BARS_GLOB]](tensor<1x1xi8, #{{.*}}>)}
+    // CHECK: tti.experimental_mark_as_write %[[ACC]], %[[BAR]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<1xi64, #{{.*}}>)}
+    // CHECK: ttng.tc_gen5_mma %[[A]], %[[B]], %[[ACC]][], {{.*}}, {{.*}}, %[[BAR]]
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 32768 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    %result = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %result = ttng.tmem_alloc  {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
     %true = arith.constant true
     ttng.tc_gen5_mma %0, %1, %result[], %true, %true, %bar[%true] {is_async} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = false>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @tcgen5_mma_lhs_in_tmem
+  tt.func public @tcgen5_mma_lhs_in_tmem(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
+    // CHECK: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [32768], shared : tensor<1xi64
+    // CHECK: %[[TM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 128], tmem : tensor<2xi64
+    // CHECK: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64
+    // CHECK: %[[SM_WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1xi64
+    // CHECK: %[[SM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 8 : i32} : !tt.ptr<i64>
+    // CHECK: %[[SM_READ_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8
+    // CHECK: %[[SM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+    // CHECK: %[[TM_WRITE_BARS:.*]] = arith.constant dense<0> : tensor<2xi64
+    // CHECK: %[[TM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 8 : i32, nbytes = 16 : i32} : !tt.ptr<i64>
+    // CHECK: %[[TM_READ_BARS:.*]] = arith.constant dense<0> : tensor<2x1xi8
+    // CHECK: %[[TM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
+    // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
+
+    // CHECK: tti.experimental_check_outstanding_writes %[[A:.*]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
+    // CHECK-NOT: tti.experimental_check_write_commit
+    // CHECK: tti.experimental_mark_as_read %[[A]], %[[BAR:.*]]{%[[TM_BUFS]], %[[BARRIERS]], %[[TM_READ_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_writes %[[B:.*]]{%[[SM_BUFS]], %[[SM_WRT_BARS_GLOB]](tensor<1xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_check_write_commit %[[B]]{%[[SM_BUFS]], %[[WRT_COMMITS_GLOB]](tensor<1xi8, #blocked>)}
+    // CHECK: tti.experimental_mark_as_read %[[B]], %[[BAR:.*]]{%[[SM_BUFS]], %[[BARRIERS]], %[[SM_READ_BARS_GLOB]](tensor<1x1xi8, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_writes %[[ACC:.*]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_check_outstanding_reads %[[ACC]]{%[[TM_BUFS]], %[[TM_READ_BARS_GLOB]](tensor<2x1xi8, #{{.*}}>)}
+    // CHECK: tti.experimental_mark_as_write %[[ACC]], %[[BAR]]{%[[TM_BUFS]], %[[TM_WRT_BARS_GLOB]](tensor<2xi64, #{{.*}}>)}
+    // CHECK: ttng.tc_gen5_mma %[[A]], %[[B]], %[[ACC]][], {{.*}}, {{.*}}, %[[BAR]]
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttng.tmem_alloc  {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem1, #ttng.tensor_memory, mutable>
+    %1 = ttg.local_alloc {allocation.offset = 32768 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %result = ttng.tmem_alloc  {tensor_memory_col_offset = 128 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %true = arith.constant true
+    ttng.tc_gen5_mma %0, %1, %result[], %true, %true, %bar[%true] : !ttg.memdesc<128x128xf16, #tmem1, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
 }
@@ -210,7 +293,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_copy_local_to_global
   tt.func public @async_copy_local_to_global(%ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
-    // CHECK: %[[BUFFERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 0>} : tensor<1xi64
+    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64
     // CHECK: %[[WRITE_COMMITS:.*]] = arith.constant dense<0> : tensor<1xi8
     // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
 
@@ -236,7 +319,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_copy_local_to_global_with_barriers
   tt.func public @async_copy_local_to_global_with_barriers(%ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
-    // CHECK: %[[BUFFERS:.*]] = tti.experimental_shared_buffer_pointers {offsets = array<i32: 0>} : tensor<1xi64
+    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64
     // CHECK: %[[WRITE_COMMITS:.*]] = arith.constant dense<0> : tensor<1xi8
     // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
 


### PR DESCRIPTION
This PR covers three main changes to Concurrency Sanitizer:
1. Adding support for Tensor Memory - implementation between shared and tensor memory is 95% common
2. Adding support for writes tracked by multiple buffers and tcgen05_commit. Commit mechanism is generic and is modeled fairly close after HW - any 'outstanding' write (one that hasn't been waited on yet) is started to be tracked by a barrier when the commit is called.
3. Implicit HW pipelining of tcgen05 operations. For now modeled loosely, by creating a class of ops that are "hwPipelined", and these ops do not assert when they write to a mem being written by another "hwPipelined" op. This is in general overly optimistic, as hw pipelining is not commutative, and also dependent on the operands. We can decide if we need to make this check more robust.

What's coming next:
1. Checks for wgmma (should be fairly easy since it is similar to cp_async)
2. Adding checks for the rest of shmem operations (just emit the check ops)
3. A bit of a refactor to cp_async and to llvm lowering to make it easier to write and maintain