### PR TITLE
[DOC] Update install instructions in docs

### DIFF
--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -16,13 +16,6 @@ You can install the latest stable release of Triton from pip:
 
 Binary wheels are available for CPython 3.9-3.13.
 
-And the latest nightly release:
-
-.. code-block:: bash
-
-      pip install -U --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/ triton-nightly
-
-
 -----------
 From Source
 -----------

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -35,9 +35,10 @@ You can install the Python package from source by running the following commands
 
 .. code-block:: bash
 
-      git clone https://github.com/triton-lang/triton.git;
-      cd triton/python;
-      pip install ninja cmake wheel; # build-time dependencies
+      git clone https://github.com/triton-lang/triton.git
+      cd triton
+
+      pip install -r python/requirements.txt # build-time dependencies
       pip install -e .
 
 Note that, if llvm is not present on your system, the setup.py script will download the official LLVM static libraries and link against that.

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -50,7 +50,7 @@ You can then test your installation by running the unit tests:
 .. code-block:: bash
 
       pip install -e '.[tests]'
-      pytest -vs test/unit/
+      pytest -vs python/test/unit/
 
 and the benchmarks
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -38,16 +38,15 @@ Note that, if llvm is not present on your system, the setup.py script will downl
 
 For building with a custom LLVM, review the `Building with a custom LLVM <https://github.com/triton-lang/triton?tab=readme-ov-file#building-with-a-custom-llvm>`_ section on Github.
 
-You can then test your installation by running the unit tests:
+You can then test your installation by running the tests:
 
 .. code-block:: bash
 
-      pip install -e '.[tests]'
-      pytest -vs python/test/unit/
+      # One-time setup
+      make dev-install
 
-and the benchmarks
+      # To run all tests (requires a GPU)
+      make test
 
-.. code-block:: bash
-
-      cd bench
-      python -m run --with-plots --result-dir /tmp/triton-bench
+      # Or, to run tests without a GPU
+      make test-nogpu

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -14,7 +14,7 @@ You can install the latest stable release of Triton from pip:
 
       pip install triton
 
-Binary wheels are available for CPython 3.8-3.12 and PyPy 3.8-3.9.
+Binary wheels are available for CPython 3.9-3.13.
 
 And the latest nightly release:
 


### PR DESCRIPTION
I noticed the install commands on [the docs](https://triton-lang.org/main/getting-started/installation.html#python-package) are outdated (executing them as-is gives `triton/python does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.`).

This PR updates those instructions to match those currently in the readme, specifically:
- Install from `pip install -e python`  to `pip install -e .`
- Wheels from `CPython 3.8-3.12 and PyPy 3.8-3.9.` to `CPython 3.9-3.13.` (match readme)
- Removes the nightly installation instruction
- Tests to the new `make dev-install; make test; make test-nogpu` setup

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it just fixes outdated installation instructions in the docs`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
