### PR TITLE
[Backend] Allow splitting block_m=64 TMEM along N

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -34,6 +34,10 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h.inc"
 
+namespace mlir::triton::nvidia_gpu::impl {
+LogicalResult verifyMMAv5Op(Operation *op);
+} // namespace mlir::triton::nvidia_gpu::impl
+
 #define GET_ATTRDEF_CLASSES
 #include "triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.h.inc"
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.td
@@ -50,5 +50,9 @@ def MMAv5OpInterface : OpInterface<"MMAv5OpInterface"> {
                     "::mlir::Value",
                     "getToken">,
   ];
+
+  let verify = [{
+    return ::mlir::triton::nvidia_gpu::impl::verifyMMAv5Op($_op);
+  }];
 }
 #endif // TRITON_NVIDIAGPU_OP_INTERFACES

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -116,11 +116,11 @@ Attribute getTmemLoadStoreLayout32x32b(unsigned M, unsigned N,
     unsigned numWarpGroups = numWarps / 4;
     if (numBlocks == 1) {
       // Split along the N dimension
-      sizePerThread = {1, N / (numWarpGroups * 2)};
+      sizePerThread = {1, ceil<unsigned>(N, numWarpGroups * 2)};
       threadsPerWarp = {16, 2};
       warpsPerCTA = {4, numWarpGroups};
     } else {
-      sizePerThread = {1, N / 2};
+      sizePerThread = {1, ceil<unsigned>(N, 2)};
       threadsPerWarp = {16, 2};
       warpsPerCTA = {0, 0};
       // Distribute at most as many warp groups as there is blocks
@@ -138,7 +138,7 @@ Attribute getTmemLoadStoreLayout32x32b(unsigned M, unsigned N,
       warpsPerCTA = {4 * numWarpGroups, 1};
     } else {
       // Split along N dimension
-      sizePerThread = {1, N / numWarpGroups};
+      sizePerThread = {1, ceil<unsigned>(N, numWarpGroups)};
       threadsPerWarp = {32, 1};
       warpsPerCTA = {4, numWarpGroups};
     }

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -554,8 +554,11 @@ LogicalResult TMEMSubSliceOp::verify() {
       srcTy.getEncoding());
   if (!encoding)
     return emitOpError("The source must be a tensor memory buffer.");
-  if (encoding.getBlockM() != 128)
-    return emitOpError("The source must be a 128xN layout.");
+  if (!llvm::is_contained({64, 128}, encoding.getBlockM())) {
+    return emitOpError("The source tensor memory descriptor must have a 128xN "
+                       "or 64xN layout, got block_m=")
+           << encoding.getBlockM();
+  }
   auto dstTy = cast<triton::gpu::MemDescType>(getResult().getType());
   auto dstEncoding = dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
       dstTy.getEncoding());

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
@@ -240,10 +240,9 @@ allocateTMem(Operation *parentOp,
       allocs.push_back(alloc);
     }
     if (auto mmaOp = dyn_cast<MMAv5OpInterface>(op)) {
-      if (auto aEnc = dyn_cast<TensorMemoryEncodingAttr>(
-              mmaOp.getA().getType().getEncoding())) {
+      if (isa<TensorMemoryEncodingAttr>(mmaOp.getA().getType().getEncoding())) {
         TMemAllocation allocSize = getTmemAllocSizes(mmaOp.getA().getType());
-        if (aEnc.getBlockM() == 64) {
+        if (allocSize.numRows == 64) {
           // HW restriction, the A alloc and accumulator needs to be in the same
           // rows.
           rowIdConstraints.joinOps(getAlloc(mmaOp.getA()),

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
@@ -247,6 +247,16 @@ allocateTMem(Operation *parentOp,
           // rows.
           rowIdConstraints.joinOps(getAlloc(mmaOp.getA()),
                                    getAlloc(mmaOp.getAccumulator()));
+        } else {
+          // TODO: we need to handle cases where the format is blockM and we
+          // have multiple blocks.
+          assert((cast<TensorMemoryEncodingAttr>(
+                      mmaOp.getA().getType().getEncoding())
+                          .getBlockM() != 64 &&
+                  cast<TensorMemoryEncodingAttr>(
+                      mmaOp.getAccumulator().getType().getEncoding())
+                          .getBlockM() != 64) &&
+                 "interleaved layout with TMEM operand is not supported yet.");
         }
       }
     }

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -98,15 +98,6 @@ def test_convert_layout_not_trivial():
     assert "layout conversion from BlockedLayout(size_per_thread=[2]" in str(e.value.__cause__)
     assert "to AutoLayout() is not trivial" in str(e.value.__cause__)
 
-    with pytest.raises(CompilationError) as e:
-        src_layout: ttgl.constexpr = ttgl.AutoLayout()
-        dst_layout: ttgl.constexpr = ttgl.BlockedLayout([2], [32], [4], [0])
-        kernel.warmup(src_layout, dst_layout, grid=(1, ))
-
-    assert "layout conversion from AutoLayout()" in str(e.value.__cause__)
-    assert "to BlockedLayout(size_per_thread=[2]" in str(e.value.__cause__)
-    assert "is not trivial" in str(e.value.__cause__)
-
 
 @gluon.jit
 def shared_memory_kernel(XBLOCK: ttgl.constexpr, YBLOCK: ttgl.constexpr, layout_a: ttgl.constexpr,

--- a/python/test/unit/blackwell/test_tmem.py
+++ b/python/test/unit/blackwell/test_tmem.py
@@ -100,6 +100,7 @@ ttng.wait_barrier %93, %c0_i32 : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memor
             assert torch.equal(x[m * 32:(m + 1) * 32], z_tri[32 * i:32 * (i + 1), col_offset:(col_offset + 4)])
 
 
+@pytest.mark.skipif(torch.cuda.get_device_capability()[0] != 10, reason="Requires compute capability == 10")
 def test_tmem_subslice_block_m_64():
 
     @gluon.jit

--- a/python/test/unit/blackwell/test_tmem.py
+++ b/python/test/unit/blackwell/test_tmem.py
@@ -4,7 +4,6 @@ import tempfile
 
 import triton
 from triton.backends.compiler import GPUTarget
-from triton._internal_testing import is_blackwell
 
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
@@ -18,7 +17,7 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
 )
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires compute capability == 10")
+@pytest.mark.skipif(torch.cuda.get_device_capability()[0] != 10, reason="Requires compute capability == 10")
 def test_tmem_copy_2d():
     device = "cuda"
 
@@ -180,7 +179,7 @@ def test_tmem_subslice_block_m_64():
     torch.testing.assert_close(out_ref, out_tri, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires compute capability == 10")
+@pytest.mark.skipif(torch.cuda.get_device_capability()[0] != 10, reason="Requires compute capability == 10")
 def test_block_m_64_mma():
 
     @gluon.jit

--- a/python/test/unit/blackwell/test_tmem.py
+++ b/python/test/unit/blackwell/test_tmem.py
@@ -224,6 +224,10 @@ def test_block_m_64_mma():
         bar = ttgl.allocate_shared_memory(ttgl.int64, [1], ttgl.constexpr(mbarrier.MBarrierLayout()))
         mbarrier.init(bar, count=1)
 
+        # This is a manually tiled MMA where LHS is in TMEM with blockM=64,
+        # where we circumvent the limitation that LHS and accumulator need to
+        # share the same TMEM rows by storing the LHS twice.
+        #
         # TMEM      al   ar   c
         # [0, 16)   a0   a1   c0
         # [16, 32)  a1   a0   c1

--- a/python/test/unit/blackwell/test_tmem.py
+++ b/python/test/unit/blackwell/test_tmem.py
@@ -4,12 +4,22 @@ import tempfile
 
 import triton
 from triton.backends.compiler import GPUTarget
+from triton._internal_testing import is_blackwell
+
+from triton.experimental import gluon
+from triton.experimental.gluon import language as ttgl
+from triton.experimental.gluon.language.nvidia.blackwell import (
+    TensorMemoryLayout,
+    allocate_tensor_memory,
+    get_tmem_32x32b_reg_layout,
+    mbarrier,
+    tcgen05_mma,
+    tcgen05_commit,
+)
 
 
+@pytest.mark.skipif(not is_blackwell(), reason="Requires compute capability == 10")
 def test_tmem_copy_2d():
-    if not torch.cuda.is_available() or not torch.cuda.get_device_capability()[0] == 10:
-        pytest.skip("Test requires Blackwell target.")
-
     device = "cuda"
 
     smem_h = 256
@@ -89,3 +99,136 @@ ttng.wait_barrier %93, %c0_i32 : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memor
         for i in range(4):
             # Copied values are duplicated across warps
             assert torch.equal(x[m * 32:(m + 1) * 32], z_tri[32 * i:32 * (i + 1), col_offset:(col_offset + 4)])
+
+
+def test_tmem_subslice_block_m_64():
+
+    @gluon.jit
+    def kernel(s_ptr, o_ptr, out_ptr, acc_ptr):
+        BLOCK_M: ttgl.constexpr = 64
+        N: ttgl.constexpr = 128
+        BLOCK_N: ttgl.constexpr = 64
+
+        tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, BLOCK_N), unpacked=True)
+        s_tmem = allocate_tensor_memory(ttgl.float32, (BLOCK_M, N), layout=tmem_layout)
+        # o_tmem = allocate_tensor_memory(ttgl.float32, (BLOCK_M, N), layout=tmem_layout)
+
+        layout: ttgl.constexpr = get_tmem_32x32b_reg_layout(BLOCK_M, BLOCK_N, (BLOCK_M, N), num_warps=4)
+
+        offsets = ttgl.arange(0, BLOCK_M)[:, None] * N + ttgl.arange(0, N)[None, :]
+        offsets = ttgl.convert_layout(offsets, layout)
+        s = ttgl.load(s_ptr + offsets)
+        o = ttgl.load(o_ptr + offsets)
+
+        s_tmem.store(s)
+        # o_tmem.store(o)
+
+        p_tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, BLOCK_N), unpacked=False)
+        p_tmem = s_tmem.slice(0, N // 2)._reinterpret(ttgl.float16, [BLOCK_M, N], p_tmem_layout)
+        # p_tmem.store(ttgl.full((BLOCK_M, N), 0.0, dtype=ttgl.float16, layout=layout))
+
+        d1_tmem_layout: ttgl.constexpr = TensorMemoryLayout((BLOCK_M, 1), unpacked=True)
+        d1_layout: ttgl.constexpr = get_tmem_32x32b_reg_layout(BLOCK_M, 1, (BLOCK_M, 1), num_warps=4)
+
+        m_tmem = s_tmem.slice(N // 4, 1)._reinterpret(ttgl.float32, [BLOCK_M, 1], d1_tmem_layout)
+        m_tmem.store(ttgl.full((BLOCK_M, 1), 2.0, dtype=ttgl.float32, layout=d1_layout))
+        # l_tmem = s_tmem.slice(N // 4 + 1, 1)._reinterpret(ttgl.float32, [BLOCK_M, 1], d1_tmem_layout)
+        # l_tmem.store(ttgl.full((BLOCK_M, 1), 3.0, dtype=ttgl.float32, layout=d1_layout))
+        # a_tmem = s_tmem.slice(N // 4 + 2, 1)._reinterpret(ttgl.float32, [BLOCK_M, 1], d1_tmem_layout)
+        # a_tmem.store(ttgl.full((BLOCK_M, 1), 4.0, dtype=ttgl.float32, layout=d1_layout))
+
+        s = s_tmem.load(layout)
+
+
+        pa_tmem = p_tmem
+        pb_tmem = p_tmem.slice(N // 2, N)
+
+        # TMEM[0:16]  = [p0, p1, o0]
+        # TMEM[16:32] = [p1, p0, o1]
+        p = offsets.to(ttgl.float16)
+        pa_tmem.store(p)
+        p0, p1 = p.reshape((BLOCK_M, 2, N // 2)).permute(0, 2, 1).split()
+        p10 = ttgl.join(p0, p1).permute(0, 2, 1).reshape((BLOCK_M, N))
+        pb_tmem.store(ttgl.convert_layout(p10, layout, assert_trivial=True))
+
+        # shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=32, element_bitwidth=16, rank=2)
+
+        # lhs = ttgl.allocate_shared_memory(ttgl.float16, (BLOCK_M, N), shared_layout)
+        # rhs = ttgl.allocate_shared_memory(ttgl.float16, (N, N), shared_layout)
+
+        # lhs.store(ttgl.full((BLOCK_M, N), 1.0, dtype=ttgl.float16, layout=layout))
+        # rhs.store(ttgl.full((N, N), 1.0, dtype=ttgl.float16, layout=layout))
+
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], ttgl.constexpr(mbarrier.MBarrierLayout()))
+        mbarrier.init(bar, count=1)
+
+        # o0_tmem = o_tmem.slice(0, N // 2)
+        # o1_tmem = o_tmem.slice(N // 2, N // 2)
+
+        # rhs0 = rhs.slice(0, N // 2, dim=1)
+        # rhs1 = rhs.slice(N // 2, N // 2, dim=1)
+
+        # tcgen05_mma(pa_tmem.slice(0, N // 2), rhs0.slice(0, N // 2), o0_tmem)
+        # tcgen05_mma(pb_tmem.slice(0, N // 2), rhs0.slice(N // 2, N // 2), o0_tmem)
+        # tcgen05_mma(pa_tmem.slice(N // 2, N // 2), rhs1.slice(0, N // 2), o1_tmem)
+        # tcgen05_mma(pb_tmem.slice(N // 2, N // 2), rhs1.slice(N // 2, N // 2), o1_tmem)
+
+        # tcgen05_commit(bar)
+        # mbarrier.wait(bar, 0)
+        # mbarrier.invalidate(bar)
+
+        # o = o_tmem.load(layout)
+        # ttgl.store(acc_ptr + offsets, o)
+
+        ttgl.store(out_ptr + offsets, s)
+
+    torch.manual_seed(0)
+    s = torch.randn((64, 128), dtype=torch.float32, device="cuda")
+    o = torch.randn((64, 128), dtype=torch.float32, device="cuda")
+
+    out_tri = torch.empty_like(s)
+    acc_tri = torch.empty_like(o)
+    compiled = kernel[(1, )](s, o, out_tri, acc_tri)
+
+    ttgir = compiled.asm["ttgir"]
+    # Check that we have two 64x128xf32 allocations.
+    # print(ttgir)
+    # assert ttgir.count("ttng.tmem_alloc") == 2
+    # assert ttgir.count("ttng.tmem_alloc : () -> !ttg.memdesc<64x128xf32") == 2
+
+    # Check that we allocated only 128 columns of TMEM.
+    llir = compiled.asm["llir"]
+    # assert llir.count("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [$1], 128")
+
+    # Given TMEM[0:32] is the slice of TMEM for warpgroup 0, the expected layout
+    # of S is
+    #
+    #   TMEM[0:16]  = S[0:16, 0:64]
+    #   TMEM[16:32] = S[0:16, 64:128]
+    #
+    # When slicing S to obtain P, we expect it to overlap with the left half,
+    # i.e. S[0:16, 0:32] and S[0:16, 64:96].
+    out_ref = s
+    # out_ref[:, 0:32] = 0.0
+    # out_ref[:, 64:96] = 0.0
+
+    # Given S = [s0, s1, s2, s3], they are arranged like
+    #
+    #   TMEM[0:16]  = [s0, s1]
+    #   TMEM[16:32] = [s2, s3]
+    #
+    # Thus slicing S at  N//4 will obtain an offset to the beginning of s1.
+    out_ref[:, 32] = 2.0
+    # out_ref[:, 33] = 3.0
+    # out_ref[:, 34] = 4.0
+
+    torch.set_printoptions(threshold=10000)
+    print(out_tri[3, :])
+    print(out_ref[3, :])
+
+    torch.testing.assert_close(out_ref, out_tri, atol=0, rtol=0)
+
+    # print(acc_tri)
+
+
+test_tmem_subslice_block_m_64()

--- a/python/test/unit/blackwell/test_tmem.py
+++ b/python/test/unit/blackwell/test_tmem.py
@@ -265,10 +265,3 @@ def test_block_m_64_mma():
 
     d_ref = a @ b + c
     torch.testing.assert_close(d_ref, d_tri, rtol=0.08, atol=0)
-
-    print(compiled.asm["ptx"])
-    print(compiled.asm["sass"])
-
-
-test_tmem_subslice_block_m_64()
-test_block_m_64_mma()

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from triton._C.libtriton.gluon_ir import GluonOpBuilder
     from ._semantic import GluonSemantic
 
-from ._layouts import SharedLayout, DistributedLayout
+from ._layouts import SharedLayout, DistributedLayout, AutoLayout
 from triton._C.libtriton import ir
 import triton.language.core as tl_core
 from triton.language.core import (
@@ -382,6 +382,8 @@ def convert_layout(value, layout, assert_trivial=False, _semantic=None):
         tensor: The tensor with the new layout.
     """
     layout = _unwrap_if_constexpr(layout)
+    if isinstance(value.type.layout, AutoLayout):
+        return set_auto_layout(value, layout, _semantic=_semantic)
     return _semantic.convert_layout(value, layout, assert_trivial)
 
 

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -77,10 +77,10 @@ def get_tmem_32x32b_reg_layout(M, N, shape, num_warps, ctas_per_cga=None, cta_sp
     if M == 64:
         threads_per_warp = [16, 2]
         if num_blocks == 1:
-            size_per_thread = [1, N // (num_warp_groups * 2)]
+            size_per_thread = [1, triton.cdiv(N, num_warp_groups * 2)]
             warps_per_cta = [4, num_warp_groups]
         else:
-            size_per_thread = [1, N // 2]
+            size_per_thread = [1, triton.cdiv(N, 2)]
             warps_per_cta = [4 * min(blocks_per_tile[0], num_warp_groups)]
             warps_per_cta.append(triton.cdiv(num_warp_groups, warps_per_cta[0] // 4))
     else:
@@ -89,7 +89,7 @@ def get_tmem_32x32b_reg_layout(M, N, shape, num_warps, ctas_per_cga=None, cta_sp
             threads_per_warp = [32, 1]
             warps_per_cta = [4 * num_warp_groups, 1]
         else:
-            size_per_thread = [1, N // num_warp_groups]
+            size_per_thread = [1, triton.cdiv(N, num_warp_groups)]
             threads_per_warp = [32, 1]
             warps_per_cta = [4, num_warp_groups]
     return BlockedLayout(

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -633,6 +633,8 @@ tt.func private @reinterpret(%arg0: !ttg.memdesc<128xf32, #tmem, #ttng.tensor_me
 #tmem_unpacked = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 #tmem_x1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 1, unpacked = false>
 #tmem_x1_unpacked = #ttng.tensor_memory_encoding<blockM = 128, blockN = 2, unpacked = true>
+#tmem_bm64 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, unpacked = true>
+#tmem_bm64_unpacked = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, unpacked = false>
 
 #blocked_x1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 
@@ -655,6 +657,24 @@ tt.func private @subslice_packed(%arg0: !ttg.memdesc<128x128xf16, #tmem, #ttng.t
   // CHECK: llvm.add [[PTR]], [[OFFSET]]
   %0 = ttng.tmem_subslice %arg0 {N = 64 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory> -> !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory>
   tt.return %0 : !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory>
+}
+
+// CHECK-LABEL: @subslice_16x32bx2
+tt.func private @subslice_16x32bx2(%arg0: !ttg.memdesc<64x128xf32, #tmem_bm64, #ttng.tensor_memory>) -> !ttg.memdesc<64x64xf32, #tmem_bm64, #ttng.tensor_memory> {
+  // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(32 : i32)
+  // CHECK: [[PTR:%.*]] = llvm.ptrtoint
+  // CHECK: llvm.add [[PTR]], [[OFFSET]]
+  %0 = ttng.tmem_subslice %arg0 {N = 32 : i32} : !ttg.memdesc<64x128xf32, #tmem_bm64, #ttng.tensor_memory> -> !ttg.memdesc<64x64xf32, #tmem_bm64, #ttng.tensor_memory>
+  tt.return %0 : !ttg.memdesc<64x64xf32, #tmem_bm64, #ttng.tensor_memory>
+}
+
+// CHECK-LABEL: @subslice_16x32bx2_packed
+tt.func private @subslice_16x32bx2_packed(%arg0: !ttg.memdesc<64x128xf16, #tmem_bm64_unpacked, #ttng.tensor_memory>) -> !ttg.memdesc<64x64xf16, #tmem_bm64_unpacked, #ttng.tensor_memory> {
+  // CHECK: [[OFFSET:%.*]] = llvm.mlir.constant(16 : i32)
+  // CHECK: [[PTR:%.*]] = llvm.ptrtoint
+  // CHECK: llvm.add [[PTR]], [[OFFSET]]
+  %0 = ttng.tmem_subslice %arg0 {N = 32 : i32} : !ttg.memdesc<64x128xf16, #tmem_bm64_unpacked, #ttng.tensor_memory> -> !ttg.memdesc<64x64xf16, #tmem_bm64_unpacked, #ttng.tensor_memory>
+  tt.return %0 : !ttg.memdesc<64x64xf16, #tmem_bm64_unpacked, #ttng.tensor_memory>
 }
 
 // CHECK-LABEL: @load_store_x1

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -800,3 +800,22 @@ tt.func private @subslice_16x32bx2_interleaved_block4_offset(%arg0: !ttg.memdesc
 }
 
 }
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 1, unpacked = true>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [0, 1]}>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+// CHECK-LABEL: @load_store_16x32bx1_broadcast
+tt.func private @load_store_16x32bx1_broadcast(%arg0: !ttg.memdesc<64x1xf32, #tmem, #ttng.tensor_memory, mutable>) {
+  %true = arith.constant true
+  // CHECK: tcgen05.ld.sync.aligned.16x32bx2.x1.b32 {$0}, [$1 + 0], 0
+  %0 = ttng.tmem_load %arg0 : !ttg.memdesc<64x1xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x1xf32, #blocked>
+  // CHECK: @$0 tcgen05.st.sync.aligned.16x32bx2.x1.b32 [$1 + 0], 0, {$2}
+  ttng.tmem_store %0, %arg0, %true : tensor<64x1xf32, #blocked> -> !ttg.memdesc<64x1xf32, #tmem, #ttng.tensor_memory, mutable>
+  tt.return
+}
+
+}

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -215,8 +215,7 @@ public:
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    int numWarps = triton::gpu::lookupNumWarps(op);
-    if (numWarps == 1) {
+    if (triton::gpu::lookupNumWarps(op) == 1) {
       // If there is only one warp, the warp ID is always 0.
       rewriter.replaceOp(op, b.i32_val(0));
       return success();

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -215,7 +215,8 @@ public:
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    if (triton::gpu::lookupNumWarps(op) == 1) {
+    int numWarps = triton::gpu::lookupNumWarps(op);
+    if (numWarps == 1) {
       // If there is only one warp, the warp ID is always 0.
       rewriter.replaceOp(op, b.i32_val(0));
       return success();


### PR DESCRIPTION
There are a few restrictions: the subslice has to be at least 64x2. This is enforced by the fact that you can't actually construct the right layout for this at the moment. The second restriction is the N for the split must be even, otherwise it slices into one of the 64x2 chunks.
