### PR TITLE
[KERNELS] Skip test_upcast_mxfp4_to_bf16 on AMD

### DIFF
--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -1,4 +1,5 @@
 import pytest
+from triton._internal_testing import is_cuda
 from triton_kernels.tensor import wrap_torch_tensor, convert_layout, FP4
 from triton_kernels.tensor_details.layout import HopperMXScaleLayout, HopperMXValueLayout
 from triton_kernels.numerics_details.mxfp import downcast_to_mxfp, upcast_from_mxfp
@@ -69,6 +70,7 @@ def _upcast_mxfp4_to_bf16(Y, X, XScale, x_stride_m, x_stride_n, x_scale_stride_m
     tl.store(Y + offs_y, y)
 
 
+@pytest.mark.skipif(not is_cuda(), reason="Only supported on cuda")
 def test_upcast_mxfp4_to_bf16():
     mx_axis = 0
     num_warps = 4


### PR DESCRIPTION
This test was merged with AMD CI failing and it's now blocking merges. See #7591