### PR TITLE
[rfc] mxfp act in and out matmul (not for persistent kernel yet)

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/_p_matmul_ogs.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/_p_matmul_ogs.py
@@ -1,3 +1,5 @@
+# isort: off
+# fmt: off
 import torch
 import triton
 import triton.language as tl
@@ -12,7 +14,6 @@ from triton_kernels.numerics_details.flexpoint import (
 from triton_kernels.numerics_details.mxfp_details._downcast_to_mxfp import MXFP_BLOCK_SIZE
 from ._common import make_matmul_repr, matmul_launch_metadata, swizzle2d, xcd_swizzle, get_scaled_dot_format_string
 
-# fmt: off
 
 @tl.constexpr_function
 def cuda_capability_geq(major, minor):
@@ -107,13 +108,15 @@ _matmul_ogs_repr = make_matmul_repr("_p_matmul_ogs", [0, 1, 2])
 def _p_matmul_ogs(
              Y, Out, stride_y_k, stride_y_z, stride_y_m, stride_y_n,
              YExpectedScale, YActualScale, YChecksumScale,
+             stride_y_mx_z, stride_y_mx_m, stride_y_mx_n,
              X, XPtr, stride_x_z, stride_x_m, stride_x_k,
              XScale,
+             XMxScale, stride_x_mx_z, stride_x_mx_m, stride_x_mx_k,
              W, stride_w_e, stride_w_k, stride_w_n, W_TRANSPOSE: tl.constexpr,
              WScale,
              MxScale, stride_mx_e, stride_mx_k, stride_mx_n,
              B, stride_b_e, # Bias
-             M, N, K, # shapes
+             NRows, M, N, K, # shapes
              # expt data
              Betas, Gammas,
              GatherIndx,
@@ -148,7 +151,8 @@ def _p_matmul_ogs(
              TOKENS_PER_EXPT_FOR_ANNOTATION=None,
              UPCAST_INDICES:tl.constexpr=False,
              DISABLE_Y_TMA: tl.constexpr=False,
-             SWAP_XW: tl.constexpr = False):
+             SWAP_XW: tl.constexpr = False,
+             IS_EPILOGUE_DEQUANT_MXFP8: tl.constexpr = False):
     tl.static_assert(SWIZZLE_MX_VALUE is None, "NYI. Value swizzling")
     Y = Out  # Y is passed for the purposes of annotation; replace it with Out
 

--- a/python/triton_kernels/triton_kernels/numerics_details/mxfp.py
+++ b/python/triton_kernels/triton_kernels/numerics_details/mxfp.py
@@ -5,7 +5,7 @@ import triton
 import torch
 import torch.nn.functional as F
 from .mxfp_details._upcast_from_mxfp import _upcast_from_mxfp
-from .mxfp_details._downcast_to_mxfp import _downcast_to_mxfp, MXFP_BLOCK_SIZE
+from .mxfp_details._downcast_to_mxfp import _downcast_to_mxfp, _dequantize_mxfp8_fn, MXFP_BLOCK_SIZE
 
 # -----------------------------------------------------------------------------
 #                      Dequantization / Quantization Utilities
@@ -298,3 +298,6 @@ def upcast_from_mxfp_torch(tensor: torch.Tensor, scale: torch.Tensor, target_dty
     out_tensor = out_tensor.transpose(axis, tensor.ndim - 1)
 
     return out_tensor
+
+
+dequantize_mxfp8_fn = _dequantize_mxfp8_fn

--- a/python/triton_kernels/triton_kernels/numerics_details/mxfp_details/_downcast_to_mxfp.py
+++ b/python/triton_kernels/triton_kernels/numerics_details/mxfp_details/_downcast_to_mxfp.py
@@ -151,3 +151,8 @@ def _downcast_to_mxfp(mx_tensor_ptr, stride_mxt_outer, stride_mxt_quant: tl.cons
 
     tl.store(mx_scale_ptr + mx_scale_offsets, scale_tensor, mask=full_scale_mask)
     tl.store(mx_tensor_ptr + mx_tensor_offsets, out_tensor, mask=full_mask_mxt)
+
+
+@triton.jit(repr=lambda _: "_dequantize_mxfp8")
+def _dequantize_mxfp8_fn(input, mask, pid=None):
+    return _compute_quant_and_scale(input, mask, tl.float8e4nv)

--- a/python/triton_kernels/triton_kernels/tensor.py
+++ b/python/triton_kernels/triton_kernels/tensor.py
@@ -1,15 +1,16 @@
-import torch
-from typing import Type
-from .reduction_details.reduce_bitmatrix import clear_sums, sum_bitmatrix_rows
 from dataclasses import dataclass, fields
+from typing import Type
+
+import torch
 from triton.tools.tensor_descriptor import TensorDescriptor
-from .tensor_details.layout import Layout, StridedLayout
+
+from .reduction_details.reduce_bitmatrix import clear_sums, sum_bitmatrix_rows
 from .target_info import cuda_capability_geq
+from .tensor_details.layout import Layout, StridedLayout
 
 
 @dataclass
 class Storage:
-
     data: torch.Tensor
     layout: Layout = None
 
@@ -90,7 +91,6 @@ def bitwidth(type: IntegerType | FloatType | torch.dtype):
 
 @dataclass
 class Tensor:
-
     storage: Storage | torch.Tensor
     dtype: IntegerType | FloatType | torch.dtype = None
     shape: list[int] | None = None
@@ -143,6 +143,11 @@ class Tensor:
 
     def element_size(self):
         return bitwidth(self.dtype) // 8
+
+    @property
+    def data(self):
+        t = self.storage
+        return t.data if isinstance(t, Storage) else t
 
 
 @dataclass


### PR DESCRIPTION
Not (yet) optimized matmul with mxfp8 act input and output (e.g., mxfp8 act input/output not supported with persistent kernel yet).

A few noteables:
* Not working with Hopper swizzling (but is working with Blackwell weight value/scale swizzling)
* Reusing actual_scale that is used for flexscale to pass mx scale in a couple of places not to grow number of arguments

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `added more test cases covering the changes in python/triton_kernels/tests/test_matmul.py`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
