### PR TITLE
[Tests] Improve regex for test_compile_only_dot

### DIFF
--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -38,13 +38,13 @@ def test_compile_only_dot() -> None:
         triton.compiler.ASTSource(fn=simple_dot, signature={"a_base": "*fp16", "b_base": "*fp16", "out": "*fp16"},
                                   constexprs={}), target=GPUTarget("cuda", 100, 32))
     ttgir = k.asm["ttgir"]
-    pattern = (r"%(?P<A>\d+) = tt\.load"
+    pattern = (r"%(?P<A>\w+) = tt\.load"
                r"(.|\n)*?"
-               r"%(?P<A_SHMEM>\d+) = ttg\.local_alloc %(?P=A)"
+               r"%(?P<A_SHMEM>\w+) = ttg\.local_alloc %(?P=A)"
                r"(.|\n)*?"
-               r"%(?P<B>\d+) = tt\.load"
+               r"%(?P<B>\w+) = tt\.load"
                r"(.|\n)*?"
-               r"%(?P<B_SHMEM>\d+) = ttg\.local_alloc %(?P=B)"
+               r"%(?P<B_SHMEM>\w+) = ttg\.local_alloc %(?P=B)"
                r"(.|\n)*?"
                r"%(?P<TMEM_BASE>\w+) = ttng\.tmem_alloc"
                r"(.|\n)*?"


### PR DESCRIPTION
After #7521 this test could fail when TRITON_DISABLE_LINE_INFO=0 The CI sets TRITON_DISABLE_LINE_INFO=1 so variable names wouldn't be generated and the test would pass just with the \d+ regex.

An example is this:
```
; this one is ok
%14 = tt.load %9 : tensor<64x64x!tt.ptr<f16>, #blocked1> loc(#loc9)
; with variable name regex fails
%a = tt.load %a_ptr_9 : tensor<64x64x!tt.ptr<f16>, #blocked1> loc(#loc26)
```
Other tests seem to be already using \w so they are ok.