### PR TITLE
[Draft][WS][Hopper] Support general buffer reuse across communication channels

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -33,10 +33,34 @@ bool immediateEnclosing(scf::IfOp ifOp, Operation *subOp) {
   return !enclosing(ifOp, pOp.getOperation());
 }
 
+// Control Ops can be replaced during the pass, but channel srcOp/dstOp should
+// be valid.
+static bool needAccumCntForReuse(Operation *ctrlOp, ReuseGroup *group) {
+  // Goes through each channel in the ResuseGroup, check srcOp and dstOp to
+  // see if it is inside ctrlOp.
+  for (auto *ch : group->channels) {
+    if (auto forOp = dyn_cast<scf::ForOp>(ctrlOp)) {
+      if (enclosing(forOp, ch->getSrcOp()))
+        return true;
+      if (enclosing(forOp, ch->getDstOp()))
+        return true;
+    }
+    if (auto ifOp = dyn_cast<scf::IfOp>(ctrlOp)) {
+      if (enclosing(ifOp, ch->getSrcOp()))
+        return true;
+      if (enclosing(ifOp, ch->getDstOp()))
+        return true;
+    }
+  }
+  return false;
+}
+
 // Return number of AccumCnts for the given ctrlOp. We need one for each nested
-// region that contains a channel.
+// region that contains a channel. Also add accumCnt for each ReuseGroup. We can
+// use a simplify pass later on to remove redundant accumCnt.
 unsigned getAccumCnts(Operation *ctrlOp,
-                      const DenseSet<Operation *> &regionsWithChannels) {
+                      const DenseSet<Operation *> &regionsWithChannels,
+                      ReuseConfig *config) {
   unsigned cnt = 0;
   LDBG("getAccumCnts: " << ctrlOp);
   for (auto *op : regionsWithChannels) {
@@ -57,12 +81,35 @@ unsigned getAccumCnts(Operation *ctrlOp,
     }
     llvm_unreachable("region op other than If/For is not supported");
   }
+  if (!config)
+    return cnt;
+  // Go through each ReuseGroup, and see if we need accumCnt for the given
+  // ctrlOp. We need one for a given ReuseGroup when ctrlOp encloses an op from
+  // the ReuseGroup.
+  for (auto &group : config->groups)
+    if (needAccumCntForReuse(ctrlOp, &group))
+      ++cnt;
   return cnt;
 }
 
-// Assume parentForOp has accumCnt for the specified ctrlOp.
+// Figure out the argument index for parentForOp, associated with either
+// ctrlOp or with the reuse group. For the latter, we ignore ctrlOp,
+// get numbers of arguments for unique channels in parentForOp, then
+// decide accumCnts for reuse groups. When reuseGroupIdx is negative,
+// we find the argument index associated with unique channels inside
+// ctrlOp.
 unsigned getAccumArgIdx(scf::ForOp parentForOp, Operation *ctrlOp,
-                        const DenseSet<Operation *> &regionsWithChannels) {
+                        const DenseSet<Operation *> &regionsWithChannels,
+                        ReuseConfig *config, int reuseGroupIdx) {
+  if (reuseGroupIdx >= 0) {
+    auto cnts = getAccumCnts(parentForOp, regionsWithChannels, nullptr);
+    for (unsigned idx = 0; idx < reuseGroupIdx; ++idx) {
+      if (needAccumCntForReuse(parentForOp.getOperation(),
+                               config->getGroup(idx)))
+        ++cnts;
+      return cnts;
+    }
+  }
   // Walk parentForOp in preorder.
   unsigned preOrderId = 0, ctrlId = 0;
   bool found = false;
@@ -83,6 +130,62 @@ unsigned getAccumArgIdx(scf::ForOp parentForOp, Operation *ctrlOp,
   LDBG("getAccumArgIdx: " << parentForOp.getOperation() << " " << ctrlOp << " "
                           << ctrlId);
   return ctrlId;
+}
+
+// Find channels of reuse group that are inside regionOp. If the channel is
+// directly in regionOp, add the channel's DstOp, otherwise add the region Op
+// that is directly in regionOp and encloses the channel.
+void getReuseChannels(ReuseGroup *group, Operation *regionOp,
+                      SmallVector<Operation *> &chList) {
+  // Goes through body of regionOp, if the body op is a regionOp, check
+  // to see if it contains a channel in the reuse group.
+  if (auto ifOp = dyn_cast<scf::IfOp>(regionOp)) {
+    for (Operation &op : ifOp.thenBlock()->getOperations()) {
+      if (isa<scf::ForOp>(&op) || isa<scf::IfOp>(&op)) {
+        if (needAccumCntForReuse(&op, group))
+          chList.push_back(&op);
+      } else {
+        // Check if op is dstOp of a channel in reuse group. Assume srcOp and
+        // dstOp has the same enclosing parentOp.
+        for (auto *ch : group->channels) {
+          if (&op == ch->getDstOp())
+            chList.push_back(&op);
+        }
+      }
+    }
+    return;
+  }
+  if (auto forOp = dyn_cast<scf::ForOp>(regionOp)) {
+    for (Operation &op : forOp.getBody()->without_terminator()) {
+      if (isa<scf::ForOp>(&op) || isa<scf::IfOp>(&op)) {
+        if (needAccumCntForReuse(&op, group))
+          chList.push_back(&op);
+      } else {
+        // Check if op is dstOp of a channel in reuse group. Assume srcOp and
+        // dstOp has the same enclosing parentOp.
+        for (auto *ch : group->channels) {
+          if (&op == ch->getDstOp())
+            chList.push_back(&op);
+        }
+      }
+    }
+    return;
+  }
+  assert(false);
+}
+
+// regionOp must contains channels in config[idx].
+unsigned getReuseAccumArgIdx(Operation *regionOp,
+                             const DenseSet<Operation *> &regionsWithChannels,
+                             ReuseConfig *config, int reuseGroupIdx) {
+  auto cnts = getAccumCnts(regionOp, regionsWithChannels, nullptr);
+  unsigned argIdx = 0;
+  assert(reuseGroupIdx >= 0 && reuseGroupIdx < config->getGroupSize());
+  for (unsigned idx = 0; idx < reuseGroupIdx; ++idx) {
+    if (needAccumCntForReuse(regionOp, config->getGroup(reuseGroupIdx)))
+      ++argIdx;
+  }
+  return cnts + argIdx;
 }
 
 // Compute and return the buffer index and phase for a given accumulate count.
@@ -129,13 +232,15 @@ std::pair<Value, Value> getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder,
 //     ElseYield ForC.arg[accumIfB]
 //   Channel D --> uses ForA.arg[accumForA]
 Value getAccumCount(OpBuilderWithAsyncTaskIds &builder, Operation *op,
-                    const DenseSet<Operation *> &regionsWithChannels) {
+                    const DenseSet<Operation *> &regionsWithChannels,
+                    ReuseConfig *config, int reuseGroupIdx) {
   auto parentForOp = op->getParentOfType<scf::ForOp>();
   auto *pOp = op->getParentOp();
   // Get parentForOp.arg[pOp]
   unsigned tSize = parentForOp.getBody()->getArguments().size();
-  unsigned parentTCnts = getAccumCnts(parentForOp, regionsWithChannels);
-  unsigned accumArgId = getAccumArgIdx(parentForOp, pOp, regionsWithChannels);
+  unsigned parentTCnts = getAccumCnts(parentForOp, regionsWithChannels, config);
+  unsigned accumArgId = getAccumArgIdx(parentForOp, pOp, regionsWithChannels,
+                                       config, reuseGroupIdx);
   Value accumCnt =
       parentForOp.getBody()->getArgument(tSize - parentTCnts + accumArgId);
 
@@ -148,8 +253,10 @@ Value getAccumCount(OpBuilderWithAsyncTaskIds &builder, Operation *op,
 void getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder, Operation *op,
                           unsigned numBuffers,
                           const DenseSet<Operation *> &regionsWithChannels,
-                          Value &bufferIdx, Value &phase) {
-  Value accumCnt = getAccumCount(builder, op, regionsWithChannels);
+                          Value &bufferIdx, Value &phase, ReuseConfig *config,
+                          int reuseGroupIdx) {
+  Value accumCnt =
+      getAccumCount(builder, op, regionsWithChannels, config, reuseGroupIdx);
   std::tie(bufferIdx, phase) =
       getBufferIdxAndPhase(builder, op->getLoc(), accumCnt, numBuffers);
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -851,7 +851,7 @@ desyncTCGen5MMAOp(OpBuilderWithAsyncTaskIds &builder, ttng::TCGen5MMAOp mmaOp,
                   Value barrierAlloc, Value bufferIdx, Value inPhase,
                   unsigned numBuffers, Operation *headProducer,
                   DenseSet<Operation *> &regionsWithChannels,
-                  mlir::DominanceInfo &dom) {
+                  mlir::DominanceInfo &dom, ReuseConfig *config) {
   // Attach the barrier as an operand of the mma op.
   builder.setInsertionPoint(mmaOp);
   builder.setAsyncTaskIdsFromOp(mmaOp);
@@ -1161,9 +1161,10 @@ void insertAsyncComm(
         auto iter = commChannel.consumerBarriers.find(consumerTaskId);
         Value consumerBarrier = iter->second;
         // Use consumerBarrier as gen5 inline barrier.
-        auto tmemWaitBarrier = desyncTCGen5MMAOp(
-            builder, mmaOp, consumerBarrier, bufferIdx, phase,
-            masterChannel->numBuffers, headProducer, regionsWithChannels, dom);
+        auto tmemWaitBarrier =
+            desyncTCGen5MMAOp(builder, mmaOp, consumerBarrier, bufferIdx, phase,
+                              masterChannel->numBuffers, headProducer,
+                              regionsWithChannels, dom, config);
         tmemWaitBarriers[mmaOp] = tmemWaitBarrier;
       }
     }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -43,11 +43,14 @@ static unsigned getNumBuffersOrDefault(scf::ForOp forOp, unsigned numBuffers) {
 }
 
 // Get the bufferIdx and phase for the last iteration of the immediate scope.
-std::pair<Value, Value> getOutOfScopeBufferIdxAndPhase(
-    OpBuilderWithAsyncTaskIds &builder, Operation *op, unsigned numBuffers,
-    const DenseSet<Operation *> &regionsWithChannels) {
+std::pair<Value, Value>
+getOutOfScopeBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder,
+                               Operation *op, unsigned numBuffers,
+                               const DenseSet<Operation *> &regionsWithChannels,
+                               ReuseConfig *config, int reuseGroupIdx) {
   // Get the current in-scope accumulation count for op.
-  Value accumCnt = getAccumCount(builder, op, regionsWithChannels);
+  Value accumCnt =
+      getAccumCount(builder, op, regionsWithChannels, config, reuseGroupIdx);
 
   // Get the out-of-scope accumulation count.
   assert(isa<BlockArgument>(accumCnt) &&
@@ -146,12 +149,12 @@ static void createChannel(Operation *producerOp, Operation *op,
             // Always use two buffers for TMEM channels.
             channels.push_back(std::make_unique<ttng::TmemDataChannel>(
                 producerTaskId, consumerTaskIds, tmemAllocOp, dotOp, userOp,
-                user.second, NUM_TMEM_BUFFERS));
+                user.second, NUM_TMEM_BUFFERS, channels.size()));
           }
         } else {
-          channels.push_back(
-              std::make_unique<Channel>(producerTaskId, consumerTaskIds, userOp,
-                                        user.second, producerNumBuffers));
+          channels.push_back(std::make_unique<Channel>(
+              producerTaskId, consumerTaskIds, userOp, user.second,
+              producerNumBuffers, channels.size()));
         }
       }
     }
@@ -571,6 +574,16 @@ static Value createBarrierAlloc(triton::FuncOp funcOp, unsigned distance) {
   return barrierAlloc;
 }
 
+static int channelInReuseGroup(Channel *channel, ReuseConfig *config) {
+  for (unsigned idx = 0; idx < config->getGroupSize(); idx++) {
+    for (auto *ch : config->getGroup(idx)->channels) {
+      if (channel == ch)
+        return idx;
+    }
+  }
+  return -1;
+}
+
 // channelsGroupedByConsumers: channels are grouped together.
 // Go through each group, check the first channel in the group, create a token
 // for each consumer taskId. Return a map that maps each channel + consumer
@@ -581,13 +594,20 @@ void createToken(
         &channelsGroupedByConsumers,
     const SmallVector<Channel *> &orderedChannels, triton::FuncOp funcOp,
     const DenseMap<Channel *, std::pair<Operation *, Operation *>> &copyOpMap,
-    DenseMap<Channel *, CommChannel> &tokenMap) {
+    DenseMap<Channel *, CommChannel> &tokenMap, ReuseConfig *config) {
   OpBuilder builder(funcOp);
   builder.setInsertionPointToStart(&(funcOp.getBody().front()));
   DenseMap<ttng::TCGen5MMAOp, Channel *> gen5Barriers;
   for (auto *key : orderedChannels) {
+    // Does channelsGroupedByConsumers work with reuse?
     auto it = channelsGroupedByConsumers.find(key);
     Channel *channel = it->second.front();
+    // For each reuse group, choose a representative channel.
+    int reuseGrp = channelInReuseGroup(channel, config);
+    if (reuseGrp >= 0) {
+      if (channel != config->getGroup(reuseGrp)->channels[0])
+        continue;
+    }
 
     CommChannel commChannel;
     auto producerOp = it->second.front()->getSrcOp();
@@ -661,6 +681,11 @@ void createToken(
     for (auto &c : it->second) {
       tokenMap[c] = commChannel;
     }
+    // For channels in the same reuse group as channel.
+    if (reuseGrp >= 0) {
+      for (auto *reuse : config->getGroup(reuseGrp)->channels)
+        tokenMap[reuse] = commChannel;
+    }
   }
 
   LLVM_DEBUG({
@@ -705,7 +730,8 @@ static ttng::TMEMAllocOp createTMemAlloc(OpBuilder &builder,
 // the buffer array will contain numBuffers.
 DenseMap<Channel *, Value> createBuffer(
     DenseMap<Channel *, SmallVector<Channel *>> &channelsGroupedByProducers,
-    const SmallVector<Channel *> &orderedChannels, triton::FuncOp funcOp) {
+    const SmallVector<Channel *> &orderedChannels, triton::FuncOp funcOp,
+    ReuseConfig *config) {
 
   DenseMap<Channel *, Value> bufferMap;
   MLIRContext *context = funcOp.getContext();
@@ -804,6 +830,15 @@ DenseMap<Channel *, Value> createBuffer(
     for (auto c : channels)
       bufferMap[c] = buffer;
   }
+  unsigned groupId = 0;
+  for (unsigned idx = 0; idx < config->getGroupSize(); ++idx) {
+    for (auto *c : config->getGroup(idx)->channels) {
+      bufferMap[c].getDefiningOp()->setAttr(
+          "allocation.shareGroup",
+          IntegerAttr::get(IntegerType::get(context, 32), groupId));
+    }
+    ++groupId;
+  }
   return bufferMap;
 }
 
@@ -870,7 +905,7 @@ desyncTCGen5MMAOp(OpBuilderWithAsyncTaskIds &builder, ttng::TCGen5MMAOp mmaOp,
       // Compute the barrier from the last consumer instance
       // Extract the accum count from the consumer block.
       std::tie(bufferIdx, phase) = getOutOfScopeBufferIdxAndPhase(
-          builder, mmaOp, numBuffers, regionsWithChannels);
+          builder, mmaOp, numBuffers, regionsWithChannels, config, -1);
       phase = builder.createWithAsyncTaskIds<arith::ExtSIOp>(
           user->getLoc(), builder.getI32Type(), phase);
       consumerBarrier =
@@ -908,7 +943,7 @@ void insertAsyncComm(
     const DenseMap<Channel *, DenseMap<int, Value>> &barrierAllocMap,
     const DenseMap<Channel *, Value> &bufferMap,
     const DenseMap<Channel *, std::pair<Operation *, Operation *>> &copyOpMap,
-    DenseSet<Operation *> &regionsWithChannels) {
+    DenseSet<Operation *> &regionsWithChannels, ReuseConfig *config) {
 
   // Find the operation that is along producer's parent chain, and its parent
   // is the same op as producer's parent. Here p is producer, and c is consumer.
@@ -1069,7 +1104,7 @@ void insertAsyncComm(
         headProducer->dump();
       });
       getBufferIdxAndPhase(builder, headProducer, kv.second.front()->numBuffers,
-                           regionsWithChannels, bufferIdx, phase);
+                           regionsWithChannels, bufferIdx, phase, config);
     } else {
       // Producer is not in a ForOp, create phase and bufferIdx here.
       bufferIdx = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
@@ -1252,7 +1287,9 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
   }
   DenseSet<Operation *> regionsWithChannels;
   collectRegionsWithChannels(channels, regionsWithChannels);
-  appendAccumCntsForOps(asyncTaskTopOps, channels, regionsWithChannels);
+  ReuseConfig config;
+  appendAccumCntsForOps(asyncTaskTopOps, channels, regionsWithChannels,
+                        &config);
   LLVM_DEBUG({
     LDBG("\n\nafter appendAccumCntsForOps");
     funcOp.dump();
@@ -1260,7 +1297,7 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
 
   // Step 5: Create buffers. An array of buffers for each channel.
   DenseMap<Channel *, Value> bufferMap =
-      createBuffer(channelsGroupedByProducers, channels, funcOp);
+      createBuffer(channelsGroupedByProducers, channels, funcOp, &config);
   LLVM_DEBUG({
     LDBG("\n\nafter createBuffer");
     funcOp.dump();
@@ -1270,7 +1307,7 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
   // producers.
   DenseMap<Channel *, std::pair<Operation *, Operation *>> copyOpMap;
   insertAsyncCopy(funcOp, channelsGroupedByProducers, bufferMap, copyOpMap,
-                  regionsWithChannels);
+                  regionsWithChannels, &config);
   LLVM_DEBUG({
     LDBG("\n\nwith async copy");
     funcOp.dump();
@@ -1281,7 +1318,7 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
   DenseMap<Channel *, DenseMap<int, Value>> barrierAllocMap;
   DenseMap<Channel *, CommChannel> tokenMap;
   createToken(channelsGroupedByConsumers, orderedChannels, funcOp, copyOpMap,
-              tokenMap);
+              tokenMap, &config);
   LLVM_DEBUG({
     LDBG("\n\nafter createToken");
     funcOp.dump();
@@ -1290,7 +1327,7 @@ void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers) {
   // Step 8: add async communication ops (ProducerAcquire etc). Also lower
   // TMA loads.
   insertAsyncComm(funcOp, channelsGroupedByConsumers, tokenMap, barrierAllocMap,
-                  bufferMap, copyOpMap, regionsWithChannels);
+                  bufferMap, copyOpMap, regionsWithChannels, &config);
   LLVM_DEBUG({
     LDBG("\n\nwith SyncOps");
     funcOp.dump();

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -296,7 +296,7 @@ void insertAsyncCopy(
         &channelsGroupedByProducers,
     const DenseMap<Channel *, Value> &bufferMap,
     DenseMap<Channel *, std::pair<Operation *, Operation *>> &copyOpMap,
-    DenseSet<Operation *> &regionsWithChannels) {
+    DenseSet<Operation *> &regionsWithChannels, ReuseConfig *config) {
   // For each producer op, create a async_copy or local_store from the producer
   // to the buffer. Create a local_load from the buffer at the dominating
   // consumer.
@@ -361,7 +361,7 @@ void insertAsyncCopy(
         srcOp->dump();
       });
       getBufferIdxAndPhase(builder, srcOp, kv.getFirst()->numBuffers,
-                           regionsWithChannels, bufferIdx, phase);
+                           regionsWithChannels, bufferIdx, phase, config);
     } else {
       // Producer is not in a ForOp, create phase and bufferIdx here which will
       // be used by both producer and consumers.


### PR DESCRIPTION
The reuse strategy will be defined by ReuseConfig. CodePartition will use ReuseConfig to emit buffers and barriers for channels sharing the same buffer. This patch implements the logic to generate accumCnt for each reuse group by rewriting If ops and For ops.