### PR TITLE
[AMD] Enable global_load_tr_b128 on gfx12

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -86,6 +86,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUCanonicalizePointers();
   mlir::registerTritonAMDGPUConvertToBufferOps();
   mlir::registerTritonAMDGPUInThreadTranspose();
+  mlir::registerTritonAMDGPUConvertToTransposeLoads();
   mlir::registerTritonAMDGPUCoalesceAsyncCopy();
   mlir::registerTritonAMDGPUUpdateAsyncWaitCount();
   mlir::triton::registerTritonAMDGPUInsertInstructionSchedHints();

--- a/include/triton/Dialect/Triton/IR/Traits.h
+++ b/include/triton/Dialect/Triton/IR/Traits.h
@@ -119,6 +119,11 @@ public:
 template <typename ConcreteType>
 struct AsyncRegions : public TraitBase<ConcreteType, AsyncRegions> {};
 
+// This trait indicates that the layout of this operation should be preserved
+// and propagated to other ops if possible
+template <typename ConcreteType>
+struct LayoutAnchor : public TraitBase<ConcreteType, LayoutAnchor> {};
+
 } // namespace OpTrait
 } // namespace mlir
 

--- a/include/triton/Dialect/Triton/IR/TritonInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonInterfaces.td
@@ -13,6 +13,7 @@ def SameLoadStoreOperandsAndResultShape : NativeOpTrait<"SameLoadStoreOperandsAn
 def SameLoadStoreOperandsEncoding : NativeOpTrait<"SameLoadStoreOperandsEncoding">;
 def SameLoadStoreOperandsAndResultEncoding : NativeOpTrait<"SameLoadStoreOperandsAndResultEncoding">;
 def AsyncRegions : NativeOpTrait<"AsyncRegions">;
+def LayoutAnchor : NativeOpTrait<"LayoutAnchor">;
 
 // A trait equivalent to InferTypeOpAdaptor, but that checks for structural
 // equivalence of the layouts of the result rather than just layout equality.

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -272,6 +272,12 @@ LinearLayout chooseLdMatrixLayout(Attribute enc, ArrayRef<int64_t> shape,
 LinearLayout chooseDsReadB64TrLayout(Attribute enc, ArrayRef<int64_t> shape,
                                      int32_t elemBitWidth);
 
+// The primary goal of this function is to efficiently load 2D tiles of a
+// tensor from global memory using the `global_load_tr` instruction for AMD
+// GPUs.
+std::pair<LinearLayout, LinearLayout>
+chooseGlobalLoadTrLayout(Attribute enc, ArrayRef<int64_t> shape);
+
 LinearLayout getScaleTMEMStoreLinearLayout(RankedTensorType scaleType,
                                            int numWarps);
 

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -274,7 +274,7 @@ LinearLayout chooseDsReadB64TrLayout(Attribute enc, ArrayRef<int64_t> shape,
 
 // The primary goal of this function is to efficiently load 2D tiles of a
 // tensor from global memory using the `global_load_tr` instruction for AMD
-// GPUs.
+// GPUs. Returns a pair of address and data layout.
 std::pair<LinearLayout, LinearLayout>
 chooseGlobalLoadTrLayout(Attribute enc, ArrayRef<int64_t> shape);
 

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -759,51 +759,74 @@ LinearLayout chooseDotDsReadB64TrLayout(DotOperandEncodingAttr dotMfmaLayout,
 
 std::pair<LinearLayout, LinearLayout>
 chooseGlobalLoadTrLayout(Attribute enc, ArrayRef<int64_t> shape) {
-  auto dotOpEncoding = cast<DotOperandEncodingAttr>(enc);
-  auto wmmaEncoding = cast<AMDWmmaEncodingAttr>(dotOpEncoding.getParent());
-  StringAttr kRegister =
-      StringAttr::get(dotOpEncoding.getContext(), "register");
-  StringAttr kLane = StringAttr::get(dotOpEncoding.getContext(), "lane");
-  StringAttr kWarp = StringAttr::get(dotOpEncoding.getContext(), "warp");
-  SmallVector<unsigned> order =
-      getOrderForDotOperand(dotOpEncoding.getOpIdx(), 2, /*kContig*/ true);
-  std::array<unsigned, 2> memOrder = {order[1], order[0]};
-  SmallVector<StringAttr> standardOutDims = permuteDimNames(
-      triton::standardOutDimNames(dotOpEncoding.getContext(), 2), order);
+  // Try to find an address, data layout pair for a global_load_tr instruction
+  // so that the current data encoding is transposed. Eight lanes load an 8x8
+  // block of values and transpose them before storing into registers. For
+  // details on this instruction and layout, see 11.6.2. in
+  // https://www.amd.com/content/dam/amd/en/documents/radeon-tech-docs/instruction-set-architectures/rdna4-instruction-set-architecture.pdf
+  // We use a simplified version here that is more similar to the wmma layout
+  // used in triton
+  auto currentEncoding = cast<BlockedEncodingAttr>(enc);
+  MLIRContext *ctx = currentEncoding.getContext();
+  StringAttr kRegister = S("register");
+  StringAttr kLane = S("lane");
+  StringAttr kWarp = S("warp");
 
-  // Each warps loads four 8x8 subtiles which are transposed before storing to
-  // VGPRs
+  // We have to create two layouts. One for the address and one for the data in
+  // registers. Before storing to registers, every 8x8 block of values is
+  // transposed, so the address and data layouts are identical apart from the
+  // first three basis vectors of the register and lane dimension.
+
+  // The global load layout is assumed to be optimized for vectorized loads, but
+  // later needs to be transposed by a convert_layout. With global_load_tr we
+  // can keep the memory order, but transpose the subtiles before storing them
+  // into registers to reduce the overhead of the convert_layout.
+  SmallVector<unsigned> memOrder(currentEncoding.getOrder());
+  SmallVector<StringAttr> memDims = permuteDimNames(
+      triton::standardOutDimNames(currentEncoding.getContext(), 2), memOrder);
+
+  // Each subtile is stored in 8 lanes and 4 VGPRs
+  const int tileSize = 8;
+  const int tilesPerWarp = /*WARP_SIZE*/ 32 / tileSize;
   auto tileAddrLayout =
-      (LinearLayout::identity1D(8, kRegister, standardOutDims[1]) *
-       LinearLayout::identity1D(8, kLane, standardOutDims[0]))
-          .transposeOuts(standardOutDims);
+      LinearLayout::identity1D(tileSize, kRegister, memDims[0]) *
+      LinearLayout::identity1D(tileSize, kLane, memDims[1]);
   auto tileDataLayout =
-      LinearLayout::identity1D(8, kRegister, standardOutDims[0]) *
-      LinearLayout::identity1D(8, kLane, standardOutDims[1]);
+      (LinearLayout::identity1D(tileSize, kRegister, memDims[1]) *
+       LinearLayout::identity1D(tileSize, kLane, memDims[0]))
+          .transposeOuts(memDims);
 
-  // Try to place subtiles on the k dimension first
-  std::array<unsigned, 2> numSubtilesPerWarp = {0, 0};
-  numSubtilesPerWarp[0] = std::min((int)shape[memOrder[0]] / 8, 4);
-  numSubtilesPerWarp[1] = 4 / numSubtilesPerWarp[0];
+  // Try to place the four subtiles of a single global_load_tr instruction on
+  // the non-contiguous memory dimension first
+  std::array<unsigned, 2> numSubtilesPerWarp = {/*contiguous*/ 0,
+                                                /*non-contiguous*/ 0};
+  numSubtilesPerWarp[1] =
+      std::min((int)shape[memOrder[1]] / tileSize, tilesPerWarp);
+  numSubtilesPerWarp[0] = tilesPerWarp / numSubtilesPerWarp[1];
   LinearLayout subtileLayout = identityStandardND(
-      kLane, {numSubtilesPerWarp[memOrder[1]], numSubtilesPerWarp[memOrder[0]]},
+      kLane, {numSubtilesPerWarp[memOrder[0]], numSubtilesPerWarp[memOrder[1]]},
       memOrder);
 
-  // Try to place warps on the non-k dimension first
+  // Try to place warps in a thread block on the contiguous memory dimension
+  // first
   int64_t numWarps =
-      wmmaEncoding.getWarpsPerCTA()[0] * wmmaEncoding.getWarpsPerCTA()[1];
-  std::array<unsigned, 2> numWarpsPerCTA = {0, 0};
-  numWarpsPerCTA[0] =
-      std::min(shape[memOrder[0]] / (numSubtilesPerWarp[0] * 8), numWarps);
+      currentEncoding.getWarpsPerCTA()[0] * currentEncoding.getWarpsPerCTA()[1];
+  std::array<unsigned, 2> numWarpsPerCTA = {/*contiguous*/ 0,
+                                            /*non-contiguous*/ 0};
+  numWarpsPerCTA[0] = std::min(
+      shape[memOrder[0]] / (numSubtilesPerWarp[0] * tileSize), numWarps);
   numWarpsPerCTA[1] = numWarps / numWarpsPerCTA[0];
   LinearLayout warpLayout = identityStandardND(
       kWarp, {numWarpsPerCTA[memOrder[0]], numWarpsPerCTA[memOrder[1]]},
       memOrder);
 
+  // Combine the subtile, warp and thread block layouts and tile the whole
+  // tensor
+  auto ctaLayout = currentEncoding.getCTALayout();
   return {combineCtaCgaWithShape(tileAddrLayout * subtileLayout * warpLayout,
-                                 wmmaEncoding.getCTALayout(), shape),
+                                 ctaLayout, shape),
           combineCtaCgaWithShape(tileDataLayout * subtileLayout * warpLayout,
-                                 wmmaEncoding.getCTALayout(), shape)};
+                                 ctaLayout, shape)};
 }
 
 LinearLayout mfmaDotToLinearLayout(DotOperandEncodingAttr dotMfmaLayout,

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -186,6 +186,8 @@ bool isLayoutAnchor(Operation *op) {
   if (isa<DotOp, DotScaledOp, nvidia_gpu::WarpGroupDotOp, AtomicRMWOp,
           AtomicCASOp, triton::nvidia_gpu::TMEMLoadOp>(op))
     return true;
+  if (op->hasTrait<OpTrait::LayoutAnchor>())
+    return true;
   if (auto gatherOp = dyn_cast<GatherOp>(op))
     return gatherOp.getEfficientLayout();
 

--- a/test/Conversion/amd/global_load_transpose.mlir
+++ b/test/Conversion/amd/global_load_transpose.mlir
@@ -1,0 +1,31 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch="gfx1200" | FileCheck %s
+
+#linear = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [8, 0], [16, 0]], lane = [[1, 0], [2, 0], [4, 0], [0, 8], [0, 16]], warp = [[0, 0]], block = []}>
+#mma = #ttg.amd_wmma<{version = 2, isTranspose = false, warpsPerCTA = [1, 2]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: wmma_dot0_transpose
+  tt.func @wmma_dot0_transpose(%arg0: !tt.ptr<bf16>) {
+    %0 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #linear>
+    // CHECK-COUNT-2: llvm.amdgcn.global.load.tr.b128
+    %1 = amdgpu.global_load_transpose %0 : tensor<32x32x!tt.ptr<bf16>, #linear> -> tensor<32x32xbf16, #linear1>
+    %2 = ttg.convert_layout %1 : tensor<32x32xbf16, #linear1> -> tensor<32x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    tt.return
+  }
+}
+
+// -----
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[0, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [0, 8], [0, 16]], lane = [[0, 1], [0, 2], [0, 4], [8, 0], [16, 0]], warp = [[0, 0]], block = []}>
+#mma = #ttg.amd_wmma<{version = 2, isTranspose = false, warpsPerCTA = [1, 2]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: wmma_dot1_transpose
+  tt.func @wmma_dot1_transpose(%arg0: !tt.ptr<bf16>) {
+    %0 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #linear>
+    // CHECK-COUNT-2: llvm.amdgcn.global.load.tr.b128
+    %1 = amdgpu.global_load_transpose %0 : tensor<32x32x!tt.ptr<bf16>, #linear> -> tensor<32x32xbf16, #linear1>
+    %2 = ttg.convert_layout %1 : tensor<32x32xbf16, #linear1> -> tensor<32x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    tt.return
+  }
+}

--- a/test/Conversion/amd/wmma_transpose_load.mlir
+++ b/test/Conversion/amd/wmma_transpose_load.mlir
@@ -1,0 +1,59 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-transpose-loads --tritongpu-reduce-data-duplication --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch="gfx1200" | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
+#mma = #ttg.amd_wmma<{version = 2, warpsPerCTA = [1, 2], isTranspose = false}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: wmma_dot0
+  tt.func @wmma_dot0(%arg0: !tt.ptr<bf16>) {
+    %addr = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #blocked>
+    // CHECK-NOT: llvm.amdgcn.global.load.tr.b128
+    %tensor_data = tt.load %addr : tensor<32x32x!tt.ptr<bf16>, #blocked>
+    %tensor_dot = ttg.convert_layout %tensor_data : tensor<32x32xbf16, #blocked> -> tensor<32x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 2], order = [0, 1]}>
+#mma = #ttg.amd_wmma<{version = 2, warpsPerCTA = [1, 2], isTranspose = false}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: wmma_dot1
+  tt.func @wmma_dot1(%arg0: !tt.ptr<bf16>) {
+    %addr = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #blocked1>
+    %tensor_data = tt.load %addr : tensor<32x32x!tt.ptr<bf16>, #blocked1>
+    // CHECK-NOT: llvm.amdgcn.global.load.tr.b128
+    %tensor_dot = ttg.convert_layout %tensor_data : tensor<32x32xbf16, #blocked1> -> tensor<32x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 2], order = [0, 1]}>
+#mma = #ttg.amd_wmma<{version = 2, warpsPerCTA = [1, 2], isTranspose = false}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: wmma_dot0_transpose
+  tt.func @wmma_dot0_transpose(%arg0: !tt.ptr<bf16>) {
+    %addr = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #blocked1>
+    // CHECK-COUNT-2: llvm.amdgcn.global.load.tr.b128
+    %tensor_data = tt.load %addr : tensor<32x32x!tt.ptr<bf16>, #blocked1>
+    %tensor_dot = ttg.convert_layout %tensor_data : tensor<32x32xbf16, #blocked1> -> tensor<32x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
+#mma = #ttg.amd_wmma<{version = 2, warpsPerCTA = [1, 2], isTranspose = false}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: wmma_dot1_transpose
+  tt.func @wmma_dot1_transpose(%arg0: !tt.ptr<bf16>) {
+    %addr = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #blocked>
+    // CHECK-COUNT-2: llvm.amdgcn.global.load.tr.b128
+    %tensor_data = tt.load %addr : tensor<32x32x!tt.ptr<bf16>, #blocked>
+    %tensor_dot = ttg.convert_layout %tensor_data : tensor<32x32xbf16, #blocked> -> tensor<32x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/convert-to-transpose-loads.mlir
+++ b/test/TritonGPU/amd/convert-to-transpose-loads.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-transpose-loads --tritongpu-reduce-data-duplication --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch="gfx1200" | FileCheck %s
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-transpose-loads | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
 #mma = #ttg.amd_wmma<{version = 2, warpsPerCTA = [1, 2], isTranspose = false}>
@@ -6,7 +6,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
   // CHECK-LABEL: wmma_dot0
   tt.func @wmma_dot0(%arg0: !tt.ptr<bf16>) {
     %addr = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #blocked>
-    // CHECK-NOT: llvm.amdgcn.global.load.tr.b128
+    // CHECK-NOT: amdgpu.global_load_transpose
     %tensor_data = tt.load %addr : tensor<32x32x!tt.ptr<bf16>, #blocked>
     %tensor_dot = ttg.convert_layout %tensor_data : tensor<32x32xbf16, #blocked> -> tensor<32x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
     tt.return
@@ -21,8 +21,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
   // CHECK-LABEL: wmma_dot1
   tt.func @wmma_dot1(%arg0: !tt.ptr<bf16>) {
     %addr = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #blocked1>
+    // CHECK-NOT: amdgpu.global_load_transpose
     %tensor_data = tt.load %addr : tensor<32x32x!tt.ptr<bf16>, #blocked1>
-    // CHECK-NOT: llvm.amdgcn.global.load.tr.b128
     %tensor_dot = ttg.convert_layout %tensor_data : tensor<32x32xbf16, #blocked1> -> tensor<32x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     tt.return
   }
@@ -36,7 +36,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
   // CHECK-LABEL: wmma_dot0_transpose
   tt.func @wmma_dot0_transpose(%arg0: !tt.ptr<bf16>) {
     %addr = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #blocked1>
-    // CHECK-COUNT-2: llvm.amdgcn.global.load.tr.b128
+    // CHECK: amdgpu.global_load_transpose
     %tensor_data = tt.load %addr : tensor<32x32x!tt.ptr<bf16>, #blocked1>
     %tensor_dot = ttg.convert_layout %tensor_data : tensor<32x32xbf16, #blocked1> -> tensor<32x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
     tt.return
@@ -51,7 +51,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
   // CHECK-LABEL: wmma_dot1_transpose
   tt.func @wmma_dot1_transpose(%arg0: !tt.ptr<bf16>) {
     %addr = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #blocked>
-    // CHECK-COUNT-2: llvm.amdgcn.global.load.tr.b128
+    // CHECK: amdgpu.global_load_transpose
     %tensor_data = tt.load %addr : tensor<32x32x!tt.ptr<bf16>, #blocked>
     %tensor_dot = ttg.convert_layout %tensor_data : tensor<32x32xbf16, #blocked> -> tensor<32x32xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
     tt.return

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -26,6 +26,10 @@ def is_in_thread_transpose_enabled(arch):
     return (arch == "gfx942") if knobs.amd.use_in_thread_transpose is None else knobs.amd.use_in_thread_transpose
 
 
+def is_global_load_transpose_enabled(arch):
+    return "gfx12" in arch
+
+
 @dataclass(frozen=True)
 class HIPOptions:
     num_warps: int = 4
@@ -228,6 +232,8 @@ class HIPBackend(BaseBackend):
         if options.schedule_hint.lower() != "none":
             amd.passes.ttgpuir.insert_instruction_sched_hints(pm, options.schedule_hint)
         passes.ttgpuir.add_optimize_dot_operands(pm, True)
+        if is_global_load_transpose_enabled(options.arch):
+            amd.passes.ttgpuir.add_convert_to_transpose_loads(pm)
         passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_reduce_data_duplication(pm)
         if is_in_thread_transpose_enabled(options.arch):

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -591,27 +591,27 @@ def LocalLoadPackedTransposedOp : TT_AMDGPU_Op<"local_load_packed_tranposed", [L
   let hasVerifier = 1;
 }
 
-// LoadWarpTranspose
+//===----------------------------------------------------------------------===//
+// GlobalLoadTranspose
 //===----------------------------------------------------------------------===//
 
 def GlobalLoadTransposeOp : TT_AMDGPU_Op<"global_load_transpose", [
   SameLoadStoreOperandsAndResultShape,
   LayoutAnchor]> {
-  let summary = "Load tensors with transpose";
-
-  let hasVerifier = 1;
+  let summary = "Load tensor from global memory and transpose into registers";
 
   let description = [{
     Similar to a normal load operation, but transposes values before storing to registers.
-    This can be used to efficiently load tensors where k is not contiguous whithout any
+    This can be used to efficiently load tensors where k is not contiguous without any
     expensive shared memory/in-thread transpose.
   }];
 
-  let arguments = (ins AnyTypeOf<[TT_PtrLike, TT_TensorPtr]>:$ptr);
+  let arguments = (ins Arg<TT_PtrTensor, "", [MemRead<GlobalMemory>]>:$ptr);
 
   let results = (outs TT_Tensor:$result);
 
   let assemblyFormat = [{$ptr attr-dict `:` type($ptr) `->` type($result)}];
+  let hasVerifier = 1;
 }
 
 #endif

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -591,4 +591,27 @@ def LocalLoadPackedTransposedOp : TT_AMDGPU_Op<"local_load_packed_tranposed", [L
   let hasVerifier = 1;
 }
 
+// LoadWarpTranspose
+//===----------------------------------------------------------------------===//
+
+def GlobalLoadTransposeOp : TT_AMDGPU_Op<"global_load_transpose", [
+  SameLoadStoreOperandsAndResultShape,
+  LayoutAnchor]> {
+  let summary = "Load tensors with transpose";
+
+  let hasVerifier = 1;
+
+  let description = [{
+    Similar to a normal load operation, but transposes values before storing to registers.
+    This can be used to efficiently load tensors where k is not contiguous whithout any
+    expensive shared memory/in-thread transpose.
+  }];
+
+  let arguments = (ins AnyTypeOf<[TT_PtrLike, TT_TensorPtr]>:$ptr);
+
+  let results = (outs TT_Tensor:$result);
+
+  let assemblyFormat = [{$ptr attr-dict `:` type($ptr) `->` type($result)}];
+}
+
 #endif

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -146,6 +146,15 @@ def TritonAMDGPUConvertToBufferOps : Pass<"tritonamdgpu-convert-buffer-ops", "ml
   ];
 }
 
+def TritonAMDGPUConvertToTransposeLoads : Pass<"tritonamdgpu-convert-transpose-loads", "mlir::ModuleOp"> {
+  let summary = "Replace tt.load operations with amdgpu.load_warp_transpose when possible";
+
+  let description = [{This pass analyses tt.load operations and, depending on the layout conversions to dot_op, determines
+  if it would be beneficial to use transpose loads to improve vectorization.}];
+
+  let dependentDialects = ["mlir::triton::amdgpu::TritonAMDGPUDialect"];
+}
+
 def TritonAMDGPUBlockPingpong: Pass<"tritonamdgpu-block-pingpong", "mlir::ModuleOp"> {
   let summary = "Interleaving instructions from two warps on the same SIMD to better utilize matrix core";
 

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -146,11 +146,12 @@ def TritonAMDGPUConvertToBufferOps : Pass<"tritonamdgpu-convert-buffer-ops", "ml
   ];
 }
 
-def TritonAMDGPUConvertToTransposeLoads : Pass<"tritonamdgpu-convert-transpose-loads", "mlir::ModuleOp"> {
-  let summary = "Replace tt.load operations with amdgpu.load_warp_transpose when possible";
+def TritonAMDGPUConvertToTransposeLoads : Pass<"tritonamdgpu-convert-transpose-loads", "mlir::triton::FuncOp"> {
+  let summary = "Replace tt.load operations with amdgpu.global_load_transpose when possible";
 
-  let description = [{This pass analyses tt.load operations and, depending on the layout conversions to dot_op, determines
-  if it would be beneficial to use transpose loads to improve vectorization.}];
+  let description = [{This pass analyzes tt.load --> ttg.convert_layout chains and replaces the load with
+    amdgpu.global_load_transpose if it improves vectorization of shared memory operations
+  }];
 
   let dependentDialects = ["mlir::triton::amdgpu::TritonAMDGPUDialect"];
 }

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -519,13 +519,11 @@ LogicalResult GlobalLoadTransposeOp::verify() {
   auto srcShape = srcTy.getShape();
   auto dstShape = dstTy.getShape();
   if (srcShape.size() != 2)
-    return emitOpError("src needs to be two dimensional");
-  if (dstShape.size() != 2)
-    return emitOpError("dst needs to be two dimensional");
+    return emitOpError("shape needs to be two dimensional");
 
   auto dstElemTy = dstTy.getElementType();
   if (!dstElemTy.isIntOrFloat() || dstElemTy.getIntOrFloatBitWidth() != 16) {
-    emitOpError("Datatype needs to be 16bit");
+    emitOpError("datatype needs to be 16bit");
   }
   if (getPointeeType(srcTy.getElementType()) != dstTy.getElementType()) {
     emitOpError("result element type needs to match the pointed type of ptr");
@@ -534,26 +532,33 @@ LogicalResult GlobalLoadTransposeOp::verify() {
   MLIRContext *ctx = srcTy.getContext();
   auto kReg = StringAttr::get(ctx, "register");
   auto kLane = StringAttr::get(ctx, "lane");
+
   SmallVector<StringAttr> outDims = standardOutDimNames(ctx, 2);
   LinearLayout srcLayout =
       triton::gpu::toLinearLayout(srcTy).transposeOuts(outDims);
   LinearLayout dstLayout =
       triton::gpu::toLinearLayout(dstTy).transposeOuts(outDims);
-  std::array<LinearLayout, 2> tile = {
+  // Create an 8x8 subtile across the register and lane dimension and its
+  // transpose
+  std::array<LinearLayout, 2> subtile = {
       LinearLayout::identity1D(8, kReg, outDims[0]) *
           LinearLayout::identity1D(8, kLane, outDims[1]),
       (LinearLayout::identity1D(8, kReg, outDims[1]) *
        LinearLayout::identity1D(8, kLane, outDims[0]))
           .transposeOuts(outDims)};
 
+  // We need to check that the address layout tiles the tensor with 8x8 subtiles
+  // and that the data layout is identical, apart from each subtile being
+  // transposed. This check succeeds if one of the two subtiles successfully
+  // divides srcLayout and the other successfully divides dstLayout.
   auto valid_and_equal = [](std::optional<LinearLayout> a,
                             std::optional<LinearLayout> b) {
     return a.has_value() && a == b;
   };
-  if (!valid_and_equal(divideLeft(srcLayout, tile[0]),
-                       divideLeft(dstLayout, tile[1])) &&
-      !valid_and_equal(divideLeft(srcLayout, tile[1]),
-                       divideLeft(dstLayout, tile[0]))) {
+  if (!valid_and_equal(divideLeft(srcLayout, subtile[0]),
+                       divideLeft(dstLayout, subtile[1])) &&
+      !valid_and_equal(divideLeft(srcLayout, subtile[1]),
+                       divideLeft(dstLayout, subtile[0]))) {
     return emitOpError("src and dst layout need to be equal apart from "
                        "transposing each 8x8 register/lane block");
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -645,6 +645,72 @@ struct BufferLoadOpConversion
   }
 };
 
+struct GlobalLoadTransposeOpConversion
+    : public ConvertOpToLLVMPattern<triton::amdgpu::GlobalLoadTransposeOp>,
+      public LoadStoreConversionBase {
+  using ConvertOpToLLVMPattern<
+      triton::amdgpu::GlobalLoadTransposeOp>::ConvertOpToLLVMPattern;
+
+  GlobalLoadTransposeOpConversion(LLVMTypeConverter &converter,
+                                  const AMD::TargetInfo &targetInfo,
+                                  ModuleAxisInfoAnalysis &axisAnalysisPass,
+                                  PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<triton::amdgpu::GlobalLoadTransposeOp>(converter,
+                                                                      benefit),
+        LoadStoreConversionBase(targetInfo, axisAnalysisPass) {}
+
+  LogicalResult
+  matchAndRewrite(triton::amdgpu::GlobalLoadTransposeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op->getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    // original values
+    Value ptr = op.getPtr();
+
+    // adaptor values
+    assert(!isTensorPointerType(ptr.getType()) &&
+           "Cannot convert load with a tensor pointer into LLVM; "
+           "this case should be transformed to normal load before lowering");
+    Value llPtr = adaptor.getPtr();
+
+    Type valueTy = op.getType();
+    Type valueElemTy =
+        typeConverter->convertType(getElementTypeOrSelf(valueTy));
+    unsigned vecSize = 8;
+    unsigned numElems = getTotalElemsPerThread(ptr.getType());
+
+    // Get the LLVM values for pointers
+    auto ptrElems = unpackLLElements(loc, llPtr, rewriter);
+    assert(ptrElems.size() == numElems);
+
+    VectorType v8i16 = vec_ty(i16_ty, vecSize);
+
+    SmallVector<Value> loadedVals;
+    for (size_t vecStart = 0; vecStart < numElems; vecStart += vecSize) {
+      Value ptr = ptrElems[vecStart];
+      Value transposeLoadV8 =
+          b.bitcast(LLVM::createLLVMIntrinsicCallOp(
+                        rewriter, loc, "llvm.amdgcn.global.load.tr.b128.v4i16",
+                        v8i16, ValueRange{ptr})
+                        ->getResult(0),
+                    vec_ty(valueElemTy, vecSize));
+      for (size_t ii = 0; ii < vecSize; ++ii) {
+        Value vecIdx = createIndexAttrConstant(
+            rewriter, loc, getTypeConverter()->getIndexType(), ii);
+        Value loaded = b.extract_element(valueElemTy, transposeLoadV8, vecIdx);
+        loadedVals.push_back(loaded);
+      }
+    }
+
+    Type llvmResultStructTy = getTypeConverter()->convertType(valueTy);
+    Value resultStruct = packLLElements(loc, getTypeConverter(), loadedVals,
+                                        rewriter, llvmResultStructTy);
+    rewriter.replaceOp(op, {resultStruct});
+    return success();
+  }
+};
+
 struct BufferLoadToLocalOpConversion
     : public ConvertOpToLLVMPattern<triton::amdgpu::BufferLoadToLocalOp>,
       public DirectToLdsLoadConversionBase {
@@ -1804,10 +1870,10 @@ void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                        PatternBenefit benefit) {
   patterns.add<AtomicCASOpConversion, AtomicRMWOpConversion, LoadOpConversion,
                StoreOpConversion, BufferLoadOpConversion,
-               BufferLoadToLocalOpConversion, BufferStoreOpConversion,
-               BufferAtomicRMWOpConversion, AsyncCopyGlobalToLocalOpConversion,
-               BufferAtomicCASOpConversion>(typeConverter, targetInfo,
-                                            axisInfoAnalysis, benefit);
+               GlobalLoadTransposeOpConversion, BufferLoadToLocalOpConversion,
+               BufferStoreOpConversion, BufferAtomicRMWOpConversion,
+               AsyncCopyGlobalToLocalOpConversion, BufferAtomicCASOpConversion>(
+      typeConverter, targetInfo, axisInfoAnalysis, benefit);
   patterns.add<AsyncWaitOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<AsyncCommitGroupOpConversion>(typeConverter, benefit);
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_triton_library(TritonAMDGPUTransforms
   FoldTrueCmpIOp.cpp
   UpdateAsyncWaitCount.cpp
   Utility.cpp
+  ConvertToTransposeLoads.cpp
 
   DEPENDS
   TritonAMDGPUIR

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -1569,6 +1569,8 @@ void TritonAMDGPUCanonicalizePointersPass::runOnOperation() {
     return !opsToRewrite.contains(op);
   };
 
+  target.addDynamicallyLegalDialect<mlir::triton::amdgpu::TritonAMDGPUDialect>(
+      isLegal);
   target.addDynamicallyLegalDialect<tt::TritonDialect>(isLegal);
   target.addDynamicallyLegalDialect<triton::gpu::TritonGPUDialect>(isLegal);
   target.addDynamicallyLegalDialect<scf::SCFDialect>(isLegal);
@@ -1591,6 +1593,7 @@ void TritonAMDGPUCanonicalizePointersPass::runOnOperation() {
       MaterializeFatPointer<tt::AtomicCASOp>,
       MaterializeFatPointer<tt::AtomicRMWOp>,
       MaterializeFatPointer<tt::BitcastOp>, MaterializeFatPointer<tt::LoadOp>,
+      MaterializeFatPointer<mlir::triton::amdgpu::GlobalLoadTransposeOp>,
       MaterializeFatPointer<triton::gpu::AsyncCopyGlobalToLocalOp>,
       MaterializeFatPointer<tt::PtrToIntOp>, MaterializeFatPointer<tt::StoreOp>,
       MaterializeFatPointerVariadic<tt::CallOp>,

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToTransposeLoads.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToTransposeLoads.cpp
@@ -1,0 +1,106 @@
+#include "mlir/Pass/Pass.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "triton/Tools/LayoutUtils.h"
+
+namespace ttg = mlir::triton::gpu;
+namespace tt = mlir::triton;
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONAMDGPUCONVERTTOTRANSPOSELOADS
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+
+namespace {
+
+static void loadTranspose(tt::LoadOp loadOp) {
+  IRRewriter b(loadOp);
+  OpResult loadedData = loadOp->getResult(0);
+  // We only use this instruction for load<#blocked> -> convert_layout ->
+  // dot_op<#wmma> chains for now
+  if (loadOp.getMask())
+    return;
+  auto loadedTensorType = dyn_cast<RankedTensorType>(loadedData.getType());
+  if (!loadedTensorType || !loadedTensorType.getElementType().isFloat(16) ||
+      !isa<triton::gpu::BlockedEncodingAttr>(loadedTensorType.getEncoding()))
+    return;
+  auto shape = loadedTensorType.getShape();
+  if (shape.size() != 2 || shape[0] % 16 != 0 || shape[1] % 16 != 0)
+    return;
+  auto convertLayout =
+      dyn_cast<ttg::ConvertLayoutOp>(*loadedData.getUsers().begin());
+  if (!convertLayout || !loadedData.hasOneUse())
+    return;
+
+  auto convertLayoutResultType =
+      dyn_cast<RankedTensorType>(convertLayout->getResult(0).getType());
+  if (!convertLayoutResultType)
+    return;
+  triton::gpu::DotOperandEncodingAttr resultLayout =
+      dyn_cast<triton::gpu::DotOperandEncodingAttr>(
+          convertLayoutResultType.getEncoding());
+  if (!resultLayout)
+    return;
+  ttg::AMDWmmaEncodingAttr wmmaEncoding =
+      dyn_cast<triton::gpu::AMDWmmaEncodingAttr>(resultLayout.getParent());
+  if (!wmmaEncoding || wmmaEncoding.getVersion() != 2)
+    return;
+
+  auto loadedEncoding =
+      cast<triton::gpu::BlockedEncodingAttr>(loadedTensorType.getEncoding());
+  if (resultLayout.getOpIdx() == 0 && loadedEncoding.getOrder()[0] == 1 ||
+      resultLayout.getOpIdx() == 1 && loadedEncoding.getOrder()[0] == 0)
+    // k is the contiguous dimension -> No need to transpose
+    return;
+
+  // Found a suboptimal load that would require shared memory transposing
+  auto wmmaLayoutBases =
+      wmmaEncoding.toLinearLayout(convertLayoutResultType.getShape())
+          .getBases();
+  auto [layoutAddr, layoutData] = triton::gpu::chooseGlobalLoadTrLayout(
+      resultLayout, convertLayoutResultType.getShape());
+  // Eight lanes load an 8x8 block of values and transpose them before storing
+  // into registers. For details on this instruction and layout, see 11.6.2. in
+  // https://www.amd.com/content/dam/amd/en/documents/radeon-tech-docs/instruction-set-architectures/rdna4-instruction-set-architecture.pdf
+  // We use a simplified version here that is more similar to the wmma layout
+  // used in triton
+  auto transposedLoadEncodingAddr = triton::gpu::LinearEncodingAttr::get(
+      loadedEncoding.getContext(), layoutAddr);
+  auto transposedLoadEncodingData = triton::gpu::LinearEncodingAttr::get(
+      loadedEncoding.getContext(), layoutData);
+  auto newAddrType = cast<RankedTensorType>(loadOp.getPtr().getType())
+                         .cloneWithEncoding(transposedLoadEncodingAddr);
+  auto newLoadedTensorType =
+      loadedTensorType.cloneWithEncoding(transposedLoadEncodingData);
+  // We first need to convert the addresses to the wmma format
+  b.setInsertionPoint(loadOp);
+  auto newPtr = b.create<ttg::ConvertLayoutOp>(loadOp->getLoc(), newAddrType,
+                                               loadOp.getPtr());
+  b.replaceOpWithNewOp<triton::amdgpu::GlobalLoadTransposeOp>(
+      loadOp, newLoadedTensorType, newPtr);
+}
+
+} // anonymous namespace
+
+struct TritonAMDGPUConvertToTransposeLoadsPass
+    : public impl::TritonAMDGPUConvertToTransposeLoadsBase<
+          TritonAMDGPUConvertToTransposeLoadsPass> {
+public:
+  using impl::TritonAMDGPUConvertToTransposeLoadsBase<
+      TritonAMDGPUConvertToTransposeLoadsPass>::
+      TritonAMDGPUConvertToTransposeLoadsBase;
+
+  void runOnOperation() override {
+    mlir::ModuleOp moduleOp = getOperation();
+
+    SmallVector<tt::LoadOp> loadOps;
+    moduleOp.walk([&](tt::LoadOp loadOp) { loadOps.push_back(loadOp); });
+
+    for (auto loadOp : loadOps)
+      loadTranspose(loadOp);
+  }
+};
+
+} // namespace mlir

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -76,8 +76,10 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
   ADD_PASS_OPTION_WRAPPER_2("add_convert_to_buffer_ops",
                             mlir::createTritonAMDGPUConvertToBufferOps,
                             const std::string &, bool);
-  ADD_PASS_WRAPPER_0("add_convert_to_transpose_loads",
-                     mlir::createTritonAMDGPUConvertToTransposeLoads);
+  m.def("add_convert_to_transpose_loads", [](mlir::PassManager &pm) {
+    pm.addNestedPass<mlir::triton::FuncOp>(
+        mlir::createTritonAMDGPUConvertToTransposeLoads());
+  });
   ADD_PASS_WRAPPER_0("add_reorder_instructions",
                      mlir::createTritonAMDGPUReorderInstructions);
   ADD_PASS_WRAPPER_0("add_fold_true_cmpi", mlir::createTritonAMDFoldTrueCmpI);

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -76,6 +76,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
   ADD_PASS_OPTION_WRAPPER_2("add_convert_to_buffer_ops",
                             mlir::createTritonAMDGPUConvertToBufferOps,
                             const std::string &, bool);
+  ADD_PASS_WRAPPER_0("add_convert_to_transpose_loads",
+                     mlir::createTritonAMDGPUConvertToTransposeLoads);
   ADD_PASS_WRAPPER_0("add_reorder_instructions",
                      mlir::createTritonAMDGPUReorderInstructions);
   ADD_PASS_WRAPPER_0("add_fold_true_cmpi", mlir::createTritonAMDFoldTrueCmpI);


### PR DESCRIPTION
The global_load_tr_b128 instruction allows us to load non-k-contiguous tensors with vectorized loads directly from global memory. Each 8x8 block of 16-bit values in 8 lanes and 4 vgprs is transposed before storing to registers. This is enabled for `load -> convert_layout -> dot` chains, which should be the most common case.
