### PR TITLE
Fix f32->f8 overflow

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -429,12 +429,12 @@ static Value downcastToFp8_RTNE_oneValue(Location loc,
 
   // Get sign and absolute value
   Value intVal = b.bitcast(v, srcIntType);
-  int32_t signMask = 1 << (srcWidth - 1);
+  uint32_t signMask = 1 << (srcWidth - 1);
   Value sign =
       b.trunc(i8_ty, b.lshr(b.and_(intVal, srcFpInfo.toLLVMIntValue(signMask)),
                             srcFpInfo.toLLVMIntValue(srcWidth - 8)));
 
-  int32_t absoluteMask = signMask - 1;
+  uint32_t absoluteMask = signMask - 1;
   intVal = b.and_(intVal, srcFpInfo.toLLVMIntValue(absoluteMask));
 
   // Rounding to nearest even


### PR DESCRIPTION
This conversion can lead to an overflow when subtracting 1 when the signed bit is set. Change to uint32. This is caught when running Conversion/amd/fp_to_fp.mlir with asan