### PR TITLE
[KERNELS] Fix warnings from `tl.where`

### DIFF
--- a/python/triton_kernels/triton_kernels/compaction_details/_masked_compaction.py
+++ b/python/triton_kernels/triton_kernels/compaction_details/_masked_compaction.py
@@ -11,9 +11,10 @@ def _masked_compaction(Yv, Yi, BitMask, stride_bm, stride_bn, RetYv, RetYi, sent
     rem = yi % 32
     active_bits = (tl.load(BitMask + pid_m * stride_bm + div * stride_bn) >> rem) & 1
     exc_cumsum = tl.cumsum(active_bits, 0) - active_bits
-    rev_arange = tl.where(active_bits, 0, K - 1 - tl.arange(0, K))
+    active_flags = active_bits.to(tl.int1)
+    rev_arange = tl.where(active_flags, 0, K - 1 - tl.arange(0, K))
     write_indx = exc_cumsum + rev_arange
-    yv = tl.where(active_bits, yv, sentinel)
-    yi = tl.where(active_bits, yi, sentinel)
+    yv = tl.where(active_flags, yv, sentinel)
+    yi = tl.where(active_flags, yi, sentinel)
     tl.store(RetYv + pid_m * K + write_indx, yv)
     tl.store(RetYi + pid_m * K + write_indx, yi)


### PR DESCRIPTION
```
tl.where with a non-boolean condition is deprecated and will error out in a future triton release. Got int64
```