### PR TITLE
[AMD] Fix matmul unit test failure on RDNA4

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -60,6 +60,8 @@ class AMDFMAVectorMultiplier : public FMAVectorMultiplier {
            dElemTy);
     chosenOp.vectorSize = 1;
     chosenOp.outElemTy = aElemTy;
+    if (aElemTy.isF64())
+      chosenOp.intrinsicName = "llvm.fmuladd.f64";
     if (aElemTy.isF32())
       chosenOp.intrinsicName = "llvm.fmuladd.f32";
     if (aElemTy.isF16())

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1194,7 +1194,7 @@ public:
       auto elTy = opTy.getElementType();
       if (elTy != expectedElTy)
         return false;
-      if (!elTy.isF16() && !elTy.isF32())
+      if (!elTy.isF16() && !elTy.isF32() && !elTy.isF64())
         return false;
     }
     return true;


### PR DESCRIPTION
This PR fixes language/test_matmul.py::test_simple_matmul failures for fp64 on RDNA4. 
There were 4 failing test cases of the form test_matmul.py::test_simple_matmul[float64 - float64], These failures were specific to the RDNA4 backend and are now resolved by this PR.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because I fixed a test.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
