### PR TITLE
Combine all prerequisite checks of tl.dot into dot_precheck

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2029,17 +2029,7 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
       Only one of :code:`input_precision` and :code:`allow_tf32` can be
       specified (i.e. at least one must be :code:`None`).
     """
-    assert input_precision is None or allow_tf32 is None, "Only one of input_precision and allow_tf32 can be specified"
-    if input_precision is None:
-        supports_tf32 = "tf32" in _semantic.builder.options.allowed_dot_input_precisions
-        input_precision = knobs.language.fp32_default or ("tf32" if (supports_tf32 and
-                                                                     (allow_tf32 or allow_tf32 is None)) else "ieee")
-
-    input_precision = _unwrap_if_constexpr(input_precision)
-    out_dtype = _unwrap_if_constexpr(out_dtype)
-    max_num_imprecise_acc = _unwrap_if_constexpr(max_num_imprecise_acc)
-    acc = _unwrap_if_constexpr(acc)
-    return _semantic.dot(input, other, acc, input_precision, max_num_imprecise_acc, out_dtype)
+    return _semantic.dot(input, other, acc, input_precision, allow_tf32, max_num_imprecise_acc, out_dtype)
 
 
 @builtin


### PR DESCRIPTION
Without changing any existing behaviors, this PR wraps all prerequisite checks of `tl.dot` into one function so that it can be reused by some other use case where we call a different dot such as https://github.com/facebookexperimental/triton/blob/tlx-main/third_party/tlx/language/mma_ops.py#L86