### PR TITLE
[CI][AMD] Let other runners continue even if gfx950 one fails

### DIFF
--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -11,6 +11,8 @@ jobs:
   integration-tests-amd:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
+    # Let other runners continue even if gfx950 fails
+    continue-on-error: ${{ matrix.runner[0] == 'amd-gfx950'}}
     strategy:
       matrix:
         runner: ${{ fromJson(inputs.matrix) }}


### PR DESCRIPTION
We have some infra issue with gfx950 runners right now.
