### PR TITLE
Fix the missing 'break' in RoctracerProfiler

### DIFF
--- a/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
@@ -271,6 +271,7 @@ void RoctracerProfiler::RoctracerProfilerPimpl::apiCallback(
         uint32_t StreamCaptureCount = pImpl->StreamToCaptureCount[Stream];
         pImpl->GraphToNumInstances[Graph] = StreamCaptureCount;
         pImpl->StreamToCapture.erase(Stream);
+        break;
       }
       case HIP_API_ID_hipLaunchKernel: {
         hipStream_t Stream = data->args.hipLaunchKernel.stream;


### PR DESCRIPTION
In apiCallback() function case HIP_API_ID_hipStreamBeginCapture is missing a 'break' and causing unintentional fall-through to HIP_API_ID_hipLaunchKernel.



<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [] This PR does not need a test because ``.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
