### PR TITLE
[Gluon][Test] Use AOT for frontend test

### DIFF
--- a/python/triton/experimental/gluon/_runtime.py
+++ b/python/triton/experimental/gluon/_runtime.py
@@ -17,16 +17,13 @@ class GluonASTSource(ASTSource):
         self.ext = "ttgir"
 
     def make_ir(self, options, codegen_fns, module_map, context):
-        from triton.compiler.compiler import make_backend
         from triton.compiler.code_generator import ast_to_ttir
 
         builder = ir.builder(context)
         module = builder.create_module()
 
         # Assign module attributes eagerly, as they are needed to verify layouts
-        target = triton.runtime.driver.active.get_current_target()
-        backend = make_backend(target)
-        target = backend.get_target_name(options)
+        target = f"{options.backend_name}:{options.arch}"
 
         module.set_attr("ttg.target", builder.get_string_attr(target))
         module.set_attr("ttg.num-warps", builder.get_int32_attr(options.num_warps))


### PR DESCRIPTION
This allows us to run these frontend tests on CPU so that the frontend tests can be more like compiler LIT tests and later we can enable AMD GPU support and still maintain simple expecttest workflow.

In order to do this, this commit introduce a new `aot_compile_gluon` utility and associated helpers for building constexprs and function signatures.

Along the way, this commit also fixed an issue in gluon `make_ir` where it queries the current active runtime's target.