### PR TITLE
[KERNELS] Fix roofline plots for kernels that are only compute-bound

### DIFF
--- a/python/triton_kernels/bench/bench_mlp.py
+++ b/python/triton_kernels/bench/bench_mlp.py
@@ -197,7 +197,7 @@ def roofline_mlp(batch_ranges, dim1, dim2, n_expts_tot, n_expts_act, x_dtype, w_
     x_comp = xs[knee:]
     y_comp = [max_tflops] * len(x_comp)
     ax.plot(x_bw, y_bw, "--", label=f"BW-bound  ({max_tbps:.1f} TB/s)", color="blue")
-    ax.plot(x_comp, y_comp, "--", label=f"Compute-bound  ({max_tflops:.0f} TFLOP/s)", color="yellow")
+    ax.plot(x_comp, y_comp, "--", label=f"Compute-bound  ({max_tflops:.0f} TFLOP/s)", color="orange")
     x_bw, x_comp = xs[:knee], xs[knee:]
     x_bw = [x_bw[0], x_comp[0]]
     y_bw = [opints[0] * max_tbps, max_tflops]

--- a/python/triton_kernels/bench/bench_mlp.py
+++ b/python/triton_kernels/bench/bench_mlp.py
@@ -188,7 +188,16 @@ def roofline_mlp(batch_ranges, dim1, dim2, n_expts_tot, n_expts_act, x_dtype, w_
     ax.set_ylim(100, max_tflops + 500)
     # plot roofline
     opints = [p.opint for p in perfs]
-    knee = bisect_left(opints, max_tflops / max_tbps) - 1
+    knee = bisect_left(opints, max_tflops / max_tbps)
+    if knee > 0:  # has a bandwidth-bound knee
+        x_bw = [xs[0], xs[knee]]
+        y_bw = [opints[0] * max_tbps, max_tflops]
+    else:  # no knee found, compute-bound only
+        x_bw = y_bw = []
+    x_comp = xs[knee:]
+    y_comp = [max_tflops] * len(x_comp)
+    ax.plot(x_bw, y_bw, "--", label=f"BW-bound  ({max_tbps:.1f} TB/s)", color="blue")
+    ax.plot(x_comp, y_comp, "--", label=f"Compute-bound  ({max_tflops:.0f} TFLOP/s)", color="yellow")
     x_bw, x_comp = xs[:knee], xs[knee:]
     x_bw = [x_bw[0], x_comp[0]]
     y_bw = [opints[0] * max_tbps, max_tflops]

--- a/python/triton_kernels/bench/bench_mlp.py
+++ b/python/triton_kernels/bench/bench_mlp.py
@@ -190,7 +190,7 @@ def roofline_mlp(batch_ranges, dim1, dim2, n_expts_tot, n_expts_act, x_dtype, w_
     opints = [p.opint for p in perfs]
     knee = bisect_left(opints, max_tflops / max_tbps)
     if knee > 0:  # has a bandwidth-bound knee
-        x_bw = [xs[0], xs[knee]]
+        x_bw = [xs[0], xs[knee - 1]]
         y_bw = [opints[0] * max_tbps, max_tflops]
     else:  # no knee found, compute-bound only
         x_bw = y_bw = []


### PR DESCRIPTION
Previous result

<img width="840" height="600" alt="roofline" src="https://github.com/user-attachments/assets/73a532f3-7af2-48fb-83e1-78618ca0538e" />

After fix

<img width="840" height="600" alt="roofline" src="https://github.com/user-attachments/assets/dcb84a2a-4723-4880-be10-a4d83a2e7587" />
