### PR TITLE
[Hopper][WS] Add named barriers and a basic algorithm to enforce ping pong of the critical resource

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -263,6 +263,22 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier"> {
   let hasVerifier = 1;
 }
 
+def TTNG_NamedBarrierArriveOp : TTNG_Op<"arrive_barrier_named", []> {
+  let summary = "named barrier arrive";
+
+  let arguments = (ins I32:$bar, I32: $numThreads);
+
+  let assemblyFormat = "$bar `,` $numThreads attr-dict `:` type(operands)";
+}
+
+def TTNG_NamedBarrierWaitOp : TTNG_Op<"wait_barrier_named", []> {
+  let summary = "named barrier wait";
+
+  let arguments = (ins I32:$bar, I32: $numThreads);
+
+  let assemblyFormat = "$bar `,` $numThreads attr-dict `:` type(operands)";
+}
+
 def TTNG_AsyncCopyMbarrierArriveOp : TTNG_Op<"async_copy_mbarrier_arrive"> {
   let summary = "arrive on mbarrier once all previously issued copies are completed";
   let arguments = (ins

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -684,16 +684,16 @@ try:
 except BaseException:
     HAS_FLASH = False
 
-TORCH_HAS_FP8 = False  #hasattr(torch, 'float8_e5m2')
+TORCH_HAS_FP8 = hasattr(torch, 'float8_e5m2')
 BATCH, N_HEADS = 4, 32
 # vary seq length for fixed head and batch=4
 configs = []
-for HEAD_DIM in [128]:  #[64, 128]:
-    for mode in ["fwd"]:  #, "bwd"]:
-        for causal in [False]:  #True, False]:
+for HEAD_DIM in [64, 128]:
+    for mode in ["fwd", "bwd"]:
+        for causal in [True, False]:
             # Enable warpspec for causal fwd on Hopper
             enable_ws = mode == "fwd" and (is_blackwell() or (is_hopper() and not causal))
-            for warp_specialize in [True] if enable_ws else [False]:
+            for warp_specialize in [False, True] if enable_ws else [False]:
                 configs.append(
                     triton.testing.Benchmark(
                         x_names=["N_CTX"],

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -684,16 +684,16 @@ try:
 except BaseException:
     HAS_FLASH = False
 
-TORCH_HAS_FP8 = hasattr(torch, 'float8_e5m2')
+TORCH_HAS_FP8 = False  #hasattr(torch, 'float8_e5m2')
 BATCH, N_HEADS = 4, 32
 # vary seq length for fixed head and batch=4
 configs = []
-for HEAD_DIM in [64, 128]:
-    for mode in ["fwd", "bwd"]:
-        for causal in [True, False]:
+for HEAD_DIM in [128]:  #[64, 128]:
+    for mode in ["fwd"]:  #, "bwd"]:
+        for causal in [False]:  #True, False]:
             # Enable warpspec for causal fwd on Hopper
             enable_ws = mode == "fwd" and (is_blackwell() or (is_hopper() and not causal))
-            for warp_specialize in [False, True] if enable_ws else [False]:
+            for warp_specialize in [True] if enable_ws else [False]:
                 configs.append(
                     triton.testing.Benchmark(
                         x_names=["N_CTX"],

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -67,6 +67,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttng.arrive_barrier %alloc, 2, %pred : !ttg.memdesc<1xi64, #shared0, #smem>
     tt.return
   }
+
+  // CHECK-LABEL: arrive_barrier_named
+  tt.func @arrive_barrier_named(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
+    %c9_i32 = arith.constant 9 : i32
+    %c256_i32 = arith.constant 256 : i32
+    // CHECK-NEXT: [[BAR_ID:%.*]] = llvm.mlir.constant(9 : i32) : i32
+    // CHECK-NEXT: [[NUM_THRADS:%.*]] = llvm.mlir.constant(256 : i32) : i32
+    // CHECK-NEXT: "bar.arrive $0, $1;", "r,r" [[BAR_ID]], [[NUM_THRADS]]
+    ttng.arrive_barrier_named %c9_i32, %c256_i32 : i32, i32
+    tt.return
+  }
+
+  // CHECK-LABEL: wait_barrier_named
+  tt.func @wait_barrier_named(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
+    %c9_i32 = arith.constant 9 : i32
+    %c256_i32 = arith.constant 256 : i32
+    // CHECK-NEXT: [[BAR_ID:%.*]] = llvm.mlir.constant(9 : i32) : i32
+    // CHECK-NEXT: [[NUM_THRADS:%.*]] = llvm.mlir.constant(256 : i32) : i32
+    // CHECK-NEXT: "bar.sync $0, $1;", "r,r" [[BAR_ID]], [[NUM_THRADS]]
+    ttng.wait_barrier_named %c9_i32, %c256_i32 : i32, i32
+    tt.return
+  }
 }
 
 

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -89,4 +89,17 @@ def NVGPUTestWSCodePartition: Pass<"nvgpu-test-ws-code-partition", "mlir::Module
   ];
 }
 
+def NVGPUTestPingPongSync : Pass<"nvgpu-test-ping-pong-sync", "mlir::ModuleOp"> {
+  let summary = "test ping pong sync";
+
+  let description = "This pass inserts named barriers to enforce ping pong around critical resources";
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];
+  let options = [
+    Option<"numWarpGroups", "num-warp-groups",
+           "int32_t", /*default*/"0",
+           "number of warp groups for warp specialization">
+  ];
+}
+
 #endif // NV_TRANSFORMS_PASSES

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_triton_library(NVHopperTransforms
   WarpSpecialization.cpp
   WarpSpecialization/CodePartitionUtility.cpp
+  WarpSpecialization/PingPong.cpp
   WarpSpecialization/TaskIdPropagation.cpp
   WarpSpecialization/Utility.cpp
   WarpSpecialization/WSBuffer.cpp

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -16,6 +16,7 @@ int doTaskIdPropagate(triton::FuncOp &funcOp);
 bool doDataPartition(triton::FuncOp &funcOp, unsigned numConsumerGroups);
 void doCodePartition(triton::FuncOp &funcOp, unsigned numBuffers);
 void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups);
+void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups);
 
 #define GEN_PASS_DEF_NVGPUWARPSPECIALIZATION
 #include "nvidia/hopper/include/Transforms/Passes.h.inc"
@@ -94,6 +95,12 @@ public:
     if (dumpIntermediateSteps) {
       llvm::dbgs()
           << "// -----// WarpSpec internal IR Dump After: doCodePartition\n"
+          << moduleOp << "\n\n\n";
+    }
+    doPingPongSync(funcOp, numWarpGroups);
+    if (dumpIntermediateSteps) {
+      llvm::dbgs()
+          << "// -----// WarpSpec internal IR Dump After: doPingPongSync\n"
           << moduleOp << "\n\n\n";
     }
     doTokenLowering(funcOp, numWarpGroups - 1);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -1,0 +1,296 @@
+#include "Utility.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include <unordered_set>
+
+#define DEBUG_TYPE "nvgpu-ping-pong-sync"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace tt = mlir::triton;
+namespace ttng = ::mlir::triton::nvidia_gpu;
+namespace mlir {
+
+// Returns the taskId if op has a single taskId, otherwise, returns -1.
+static int getSingleTaskId(Operation *op) {
+  auto asyncTasks = getAsyncTaskIds(op);
+  if (asyncTasks.size() != 1)
+    return -1;
+  return asyncTasks[0];
+}
+
+// Treat exp2, mulf, addf, reduce as expensive computation when data type is
+// a tensor type of 1D or higher.
+static bool isExpensiveComp(Operation *op) {
+  if (!isa<arith::MulFOp>(op) && !isa<math::Exp2Op>(op) &&
+      !isa<arith::AddFOp>(op) && !isa<mlir::triton::ReduceOp>(op))
+    return false;
+  auto tensorTy = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  return tensorTy && tensorTy.getRank() >= 1;
+}
+
+static Value createGetAsyncTaskId(OpBuilder &builder, Operation *op) {
+  auto loc = op->getLoc();
+  return builder.create<ttng::GetAsyncTaskIdOp>(loc);
+}
+
+static bool isInnermostLoop(scf::ForOp forOp) {
+  for (Operation &nestedOp : forOp.getBody()->getOperations()) {
+    if (isa<scf::ForOp>(nestedOp)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+enum class ResourceType {
+  Gemm,
+  OtherComp,
+};
+const int PING_BARRIER = 9;
+const int PONG_BARRIER = 10;
+
+unsigned getLoopDepth(Operation *op) {
+  unsigned depth = 0;
+  auto pOp = op->getParentOfType<scf::ForOp>();
+  while (pOp) {
+    ++depth;
+    pOp = pOp->getParentOfType<scf::ForOp>();
+  }
+  return depth;
+}
+
+void getNestedFor(scf::IfOp ifOp,
+                  DenseMap<unsigned, SmallVector<Operation *>> &loopDepthMap) {
+  ifOp->walk<WalkOrder::PreOrder>([&](Operation *subOp) {
+    if (dyn_cast<scf::ForOp>(subOp)) {
+      unsigned tDepth = getLoopDepth(subOp);
+      loopDepthMap[tDepth].push_back(subOp);
+    }
+  });
+}
+
+Operation *moveBackward(Operation *endofGemm, scf::ForOp forOp) {
+  SmallVector<Operation *> opList;
+  for (auto &op : forOp.getBody()->without_terminator()) {
+    opList.push_back(&op);
+  }
+  bool found = false;
+  Operation *newEnd = endofGemm;
+  for (auto it = opList.rbegin(); it != opList.rend(); ++it) {
+    Operation *op = *it;
+    if (op == endofGemm) {
+      found = true;
+      continue;
+    }
+    if (found && isa<mlir::triton::DotOpInterface>(op)) {
+      break;
+    }
+    if (found)
+      newEnd = op;
+  }
+  return newEnd;
+}
+
+bool categorizeIf(scf::IfOp ifOp, bool &hasDot, bool &hasExpCudaOp) {
+  hasDot = false;
+  hasExpCudaOp = false;
+  bool hasFor = false;
+  ifOp->walk<WalkOrder::PreOrder>([&](Operation *subOp) {
+    LLVM_DEBUG({
+      LDBG("walk if");
+      subOp->dump();
+    });
+    if (isa<scf::ForOp>(subOp)) {
+      hasFor = true;
+    } else if (isa<mlir::triton::DotOpInterface>(subOp)) {
+      hasDot = true;
+    } else if (isExpensiveComp(subOp)) {
+      hasExpCudaOp = true;
+    }
+    LDBG("---- " << hasDot << " " << hasExpCudaOp << " " << hasFor);
+  });
+  LDBG("after walk if " << hasDot << " " << hasExpCudaOp << " " << hasFor);
+  return hasFor;
+}
+
+void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups) {
+  // Insert sync points in ForOp for consumer warp groups. Enable this pass
+  // when number of consumer warp groups == 2.
+  if (numConsumerGroups != 2)
+    return;
+
+  SmallVector<scf::ForOp> loops;
+  // Identify ForOps for consumer warp groups. Here we assume taskId 0 is for
+  // producer. This pass handles the case of a single forOp for two consumer
+  // warp groups.
+  // Find top-most IfOps, and find the top level ForOp, assuming only one top
+  // level ForOp. A few use cases: 1> Persistent with ForOp containing both
+  // cuda and tensor 2> Persistent with ForOp containing tensor, then epilogue
+  // with cuda
+  DenseMap<unsigned, SmallVector<Operation *>> loopDepthMap1;
+  DenseMap<unsigned, SmallVector<Operation *>> loopDepthMap2;
+  for (auto &block : funcOp.getBody().getBlocks()) {
+    for (Operation &bodyOp : block.getOperations()) {
+      Operation *op = &bodyOp;
+      if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        int wgId = getSingleTaskId(op);
+        // Assume taskId 0 is for producer. Assume we will visit taskId 1
+        // first.
+        if (wgId == 1) {
+          getNestedFor(ifOp, loopDepthMap1);
+        } else if (wgId == 2) {
+          getNestedFor(ifOp, loopDepthMap2);
+        }
+      }
+    }
+  }
+  // Verify loopDepthMap1 and loopDepthMap2: a single ForOp at depth of 0
+  // and a single ForOp at depth of 1.
+  LDBG("Found loops: " << loopDepthMap1.size());
+  if (loopDepthMap1.empty())
+    return;
+  if (loopDepthMap1[0].size() != 1)
+    return;
+  bool hasPersistent = loopDepthMap1.find(1) != loopDepthMap1.end();
+
+  // Assume two loops have the same ops. Check innermost loop.
+  SmallVector<Operation *> starts, ends;
+  for (unsigned iter = 0; iter < 2; ++iter) {
+    Operation *op = iter == 0 ? loopDepthMap1[hasPersistent ? 1 : 0][0]
+                              : loopDepthMap2[hasPersistent ? 1 : 0][0];
+    auto forOp = dyn_cast<scf::ForOp>(op);
+    Operation *startOfGemm = nullptr;
+    Operation *endOfGemm = nullptr;
+    // A simple heuristic for now:
+    //   Mark the start of a gemm section when hitting a DotLike op.
+    //   Mark the end of a gemm section once hitting an expensive non-dot
+    //   computation op.
+    for (auto &op : forOp.getBody()->without_terminator()) {
+      if (startOfGemm && endOfGemm)
+        break;
+      bool hasDot, isCudaCore;
+      bool hasError = false;
+      if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        // if containing expensive cuda core op
+        hasError = categorizeIf(ifOp, hasDot, isCudaCore);
+      } else {
+        LLVM_DEBUG({
+          LDBG("walk for");
+          op.dump();
+        });
+        hasDot = isa<mlir::triton::DotOpInterface>(op);
+        // hasDot = isa<nvidia_gpu::WarpGroupDotOp>(&op);
+        isCudaCore = isExpensiveComp(&op);
+        LDBG("walk for " << hasDot << " " << isCudaCore);
+      }
+      if (hasError || (hasDot && isCudaCore))
+        break;
+      if (hasDot && !isCudaCore && startOfGemm == nullptr) {
+        startOfGemm = &op;
+        continue;
+      }
+      if (!hasDot && isCudaCore && startOfGemm) {
+        endOfGemm = &op;
+        break;
+      }
+    }
+    if (startOfGemm) {
+      LLVM_DEBUG({
+        LDBG("found start of tensor core ops");
+        startOfGemm->dump();
+      });
+    }
+    if (endOfGemm) {
+      LLVM_DEBUG({
+        LDBG("found end of tensor core ops");
+        endOfGemm->dump();
+      });
+    }
+
+    if (!startOfGemm || !endOfGemm)
+      return;
+    starts.push_back(startOfGemm);
+    ends.push_back(endOfGemm);
+  }
+  // TODO: epilogue overlapping.
+  {
+    // "bar.arrive 9, 256" only when task Id is 2.
+    Operation *outerLoopTask2 = loopDepthMap2[0][0];
+    OpBuilder builder(outerLoopTask2);
+    builder.setInsertionPoint(outerLoopTask2);
+    auto forLoc = outerLoopTask2->getLoc();
+    Value pingBarrier =
+        builder.create<arith::ConstantIntOp>(forLoc, PING_BARRIER, 32);
+    Value numThreads = builder.create<arith::ConstantIntOp>(forLoc, 256, 32);
+    builder.create<ttng::NamedBarrierArriveOp>(forLoc, pingBarrier, numThreads);
+  }
+  for (unsigned idx = 0; idx < 2; ++idx) {
+    Operation *op = idx == 0 ? loopDepthMap1[hasPersistent ? 1 : 0][0]
+                             : loopDepthMap2[hasPersistent ? 1 : 0][0];
+    auto forOp = dyn_cast<scf::ForOp>(op);
+    OpBuilder builder(forOp);
+    Operation *startOfGemm = starts[idx];
+    Operation *endOfGemm = ends[idx];
+
+    // FIXME: hard-code using named barrier 9 and 10 in this pass.
+    // Prior to the forOp, add "bar.arrive 9, 256" only when task Id is 2.
+    // At startOfGemm, insert "bar.sync 8+taskId, 256"
+    // At endOfGemm, insert "bar.arrive 11-taskId, 256"
+    builder.setInsertionPoint(forOp);
+    auto forLoc = forOp->getLoc();
+
+    // FIXME: hard-code total number of threads to be 256 when
+    // numConsumerGroups is 2.
+    Value numThreads = builder.create<arith::ConstantIntOp>(forLoc, 256, 32);
+    // for taskId of 1, generate: bar.sync pingBarrier; bar.arrive pongBarrier
+    // for taskId of 2, outside of the loop, generate bar.arrive pingBarrier
+    //   inside the loop, generate bar.sync pongBarrier; bar.arrive
+    //   pingBarrier
+    Value pingBarrier =
+        builder.create<arith::ConstantIntOp>(forLoc, PING_BARRIER, 32);
+
+    int wgId = getSingleTaskId(forOp);
+    // At startOfGemm, insert "bar.sync 9 or 10, 256"
+    builder.setInsertionPoint(startOfGemm);
+    auto loc = startOfGemm->getLoc();
+    Value syncBarrier = builder.create<arith::ConstantIntOp>(
+        loc, wgId == 1 ? PING_BARRIER : PONG_BARRIER, 32);
+    builder.create<ttng::NamedBarrierWaitOp>(loc, syncBarrier, numThreads);
+
+    // At endOfGemm, insert "bar.arrive 10 or 9, 256"
+    Operation *insertBefore = endOfGemm;
+    insertBefore = moveBackward(endOfGemm, forOp);
+    builder.setInsertionPoint(insertBefore);
+    auto loc2 = endOfGemm->getLoc();
+    Value arriveBarrier = builder.create<arith::ConstantIntOp>(
+        loc2, wgId == 1 ? PONG_BARRIER : PING_BARRIER, 32);
+    builder.create<ttng::NamedBarrierArriveOp>(loc2, arriveBarrier, numThreads);
+  }
+}
+
+#define GEN_PASS_DEF_NVGPUTESTPINGPONGSYNC
+#include "nvidia/hopper/include/Transforms/Passes.h.inc"
+
+class NVGPUTestPingPongSyncPass
+    : public impl::NVGPUTestPingPongSyncBase<NVGPUTestPingPongSyncPass> {
+public:
+  using impl::NVGPUTestPingPongSyncBase<
+      NVGPUTestPingPongSyncPass>::NVGPUTestPingPongSyncBase;
+
+  void runOnFuncOp(triton::FuncOp funcOp) {
+    if (numWarpGroups >= 3)
+      // Assuming one producer warp group.
+      doPingPongSync(funcOp, numWarpGroups);
+  }
+
+  void runOnOperation() override {
+    getOperation()->walk([&](triton::FuncOp funcOp) { runOnFuncOp(funcOp); });
+  }
+};
+
+} // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -13,6 +13,7 @@
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
 namespace ttng = ::mlir::triton::nvidia_gpu;
 namespace mlir {
 
@@ -62,9 +63,9 @@ static unsigned getLoopDepth(Operation *op) {
   return depth;
 }
 
-void getNestedFor(scf::IfOp ifOp,
+void getNestedFor(Region *partition,
                   DenseMap<unsigned, SmallVector<Operation *>> &loopDepthMap) {
-  ifOp->walk<WalkOrder::PreOrder>([&](Operation *subOp) {
+  partition->walk([&](Operation *subOp) {
     if (dyn_cast<scf::ForOp>(subOp)) {
       unsigned tDepth = getLoopDepth(subOp);
       loopDepthMap[tDepth].push_back(subOp);
@@ -116,158 +117,154 @@ bool categorizeIf(scf::IfOp ifOp, bool &hasDot, bool &hasExpCudaOp) {
   return hasFor;
 }
 
-void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups) {
-  // Insert sync points in ForOp for consumer warp groups. Enable this pass
-  // when number of consumer warp groups == 2.
-  if (numWarpGroups < 3)
-    return;
-
-  SmallVector<scf::ForOp> loops;
-  // Identify ForOps for consumer warp groups. Here we assume taskId 0 is for
-  // producer. This pass handles the case of a single forOp for two consumer
-  // warp groups.
-  // Find top-most IfOps, and find the top level ForOp, assuming only one top
-  // level ForOp. A few use cases: 1> Persistent with ForOp containing both
-  // cuda and tensor 2> Persistent with ForOp containing tensor, then epilogue
-  // with cuda
-  DenseMap<unsigned, SmallVector<Operation *>> loopDepthMap1;
-  DenseMap<unsigned, SmallVector<Operation *>> loopDepthMap2;
-  for (auto &block : funcOp.getBody().getBlocks()) {
-    for (Operation &bodyOp : block.getOperations()) {
-      Operation *op = &bodyOp;
-      if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-        int wgId = getSingleTaskId(op);
-        // Assume taskId 0 is for producer. Assume we will visit taskId 1
-        // first.
-        if (wgId == 1) {
-          getNestedFor(ifOp, loopDepthMap1);
-        } else if (wgId == 2) {
-          getNestedFor(ifOp, loopDepthMap2);
-        }
-      }
+static void handleWarpSpec(ttg::WarpSpecializeOp wsOp) {
+  // ForOps in partition 0, map from loop depth to the ForOp.
+  DenseMap<unsigned, SmallVector<Operation *>> loopDepthPartition0;
+  // ForOps in partition 1, map from loop depth to the ForOp.
+  DenseMap<unsigned, SmallVector<Operation *>> loopDepthPartition1;
+  unsigned partitionId = 0;
+  for (Region *region : wsOp.getPartitionRegions()) {
+    LDBG("-- region " << region->getNumArguments());
+    // Assume default for producer.
+    if (partitionId == 0) {
+      getNestedFor(region, loopDepthPartition0);
+    } else if (partitionId == 1) {
+      getNestedFor(region, loopDepthPartition1);
     }
+    ++partitionId;
   }
-  // Verify loopDepthMap1 and loopDepthMap2: a single ForOp at depth of 0
-  // and a single ForOp at depth of 1.
-  LDBG("Found loops: " << loopDepthMap1.size());
-  if (loopDepthMap1.empty())
-    return;
-  if (loopDepthMap1[0].size() != 1)
-    return;
-  bool hasPersistent = loopDepthMap1.find(1) != loopDepthMap1.end();
 
-  // Assume two loops have the same ops. Check innermost loop.
+  // Verify a single ForOp at depth of 0, i.e a single outer ForOp.
+  LDBG("Found loops: " << loopDepthPartition0.size());
+  if (loopDepthPartition0.empty() || loopDepthPartition0[0].size() != 1)
+    return;
+  // Have a ForOp at depth of 1.
+  bool hasPersistent = loopDepthPartition0.find(1) != loopDepthPartition0.end();
+
+  // Find the region of gemms via [startOfGemm, endOfGemm)
   SmallVector<Operation *> starts, ends;
   for (unsigned iter = 0; iter < 2; ++iter) {
-    Operation *op = iter == 0 ? loopDepthMap1[hasPersistent ? 1 : 0][0]
-                              : loopDepthMap2[hasPersistent ? 1 : 0][0];
+    // Check partition 0 first, then partition 1.
+    // Find the innermost ForOp (i.e depth of 1 for persistent).
+    Operation *op = iter == 0 ? loopDepthPartition0[hasPersistent ? 1 : 0][0]
+                              : loopDepthPartition1[hasPersistent ? 1 : 0][0];
     auto forOp = dyn_cast<scf::ForOp>(op);
-    Operation *startOfGemm = nullptr;
-    Operation *endOfGemm = nullptr;
     // A simple heuristic for now:
     //   Mark the start of a gemm section when hitting a DotLike op.
     //   Mark the end of a gemm section once hitting an expensive non-dot
     //   computation op.
+    Operation *startOfGemm = nullptr;
+    Operation *endOfGemm = nullptr;
     for (auto &op : forOp.getBody()->without_terminator()) {
       if (startOfGemm && endOfGemm)
         break;
       bool hasDot, isCudaCore;
-      bool hasError = false;
       if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-        // if containing expensive cuda core op
-        hasError = categorizeIf(ifOp, hasDot, isCudaCore);
+        // Categorize IfOp to see if it contains dot or expensive cuda core op.
+        bool hasError = categorizeIf(ifOp, hasDot, isCudaCore);
+        // Bail out if IfOp contains both Dot and cuda core ops or contains
+        // ForOp.
+        if (hasError || (hasDot && isCudaCore))
+          break;
       } else {
-        LLVM_DEBUG({
-          LDBG("walk for");
-          op.dump();
-        });
         hasDot = isa<mlir::triton::DotOpInterface>(op);
-        // hasDot = isa<nvidia_gpu::WarpGroupDotOp>(&op);
         isCudaCore = isExpensiveComp(&op);
-        LDBG("walk for " << hasDot << " " << isCudaCore);
+        if (hasDot || isCudaCore) {
+          LLVM_DEBUG({
+            LDBG("walk op in for");
+            op.dump();
+          });
+          LDBG("-- hasDot " << hasDot << " cudaCoreOp " << isCudaCore);
+        }
       }
-      if (hasError || (hasDot && isCudaCore))
-        break;
-      if (hasDot && !isCudaCore && startOfGemm == nullptr) {
+      if (hasDot && startOfGemm == nullptr) {
+        // This is a dotop and we are trying to set startOfGemm.
         startOfGemm = &op;
+        LLVM_DEBUG({
+          LDBG("set start of Gemm region");
+          startOfGemm->dump();
+        });
         continue;
       }
-      if (!hasDot && isCudaCore && startOfGemm) {
+      if (isCudaCore && startOfGemm) {
+        // Already found startOfGemm, set endOfGemm prior to an expensive cuda
+        // core op.
         endOfGemm = &op;
+        LLVM_DEBUG({
+          LDBG("set end of Gemm region");
+          endOfGemm->dump();
+        });
         break;
       }
     }
-    if (startOfGemm) {
-      LLVM_DEBUG({
-        LDBG("found start of tensor core ops");
-        startOfGemm->dump();
-      });
-    }
-    if (endOfGemm) {
-      LLVM_DEBUG({
-        LDBG("found end of tensor core ops");
-        endOfGemm->dump();
-      });
-    }
-
     if (!startOfGemm || !endOfGemm)
       return;
     starts.push_back(startOfGemm);
     ends.push_back(endOfGemm);
   }
+
   // TODO: epilogue overlapping.
-  {
-    // "bar.arrive 9, 256" only when task Id is 2.
-    Operation *outerLoopTask2 = loopDepthMap2[0][0];
-    OpBuilder builder(outerLoopTask2);
-    builder.setInsertionPoint(outerLoopTask2);
-    auto forLoc = outerLoopTask2->getLoc();
-    Value pingBarrier =
-        builder.create<arith::ConstantIntOp>(forLoc, PING_BARRIER, 32);
-    Value numThreads = builder.create<arith::ConstantIntOp>(forLoc, 256, 32);
-    builder.create<ttng::NamedBarrierArriveOp>(forLoc, pingBarrier, numThreads);
-  }
+  // "bar.arrive PING, 256" prior to outer loop for partition 1.
+  Operation *outerLoopPartition1 = loopDepthPartition1[0][0];
+  OpBuilder builder(outerLoopPartition1);
+  builder.setInsertionPoint(outerLoopPartition1);
+  auto forLoc = outerLoopPartition1->getLoc();
+  Value pingBarrier =
+      builder.create<arith::ConstantIntOp>(forLoc, PING_BARRIER, 32);
+  // 256 threads for one partition of 4 warps.
+  Value numThreads = builder.create<arith::ConstantIntOp>(forLoc, 256, 32);
+  builder.create<ttng::NamedBarrierArriveOp>(forLoc, pingBarrier, numThreads);
+
   for (unsigned idx = 0; idx < 2; ++idx) {
-    Operation *op = idx == 0 ? loopDepthMap1[hasPersistent ? 1 : 0][0]
-                             : loopDepthMap2[hasPersistent ? 1 : 0][0];
+    // Find the innermost ForOp (i.e depth of 1 for persistent).
+    Operation *op = idx == 0 ? loopDepthPartition0[hasPersistent ? 1 : 0][0]
+                             : loopDepthPartition1[hasPersistent ? 1 : 0][0];
     auto forOp = dyn_cast<scf::ForOp>(op);
     OpBuilder builder(forOp);
     Operation *startOfGemm = starts[idx];
     Operation *endOfGemm = ends[idx];
 
-    // FIXME: hard-code using named barrier 9 and 10 in this pass.
-    // Prior to the forOp, add "bar.arrive 9, 256" only when task Id is 2.
-    // At startOfGemm, insert "bar.sync 8+taskId, 256"
-    // At endOfGemm, insert "bar.arrive 11-taskId, 256"
+    // At startOfGemm, insert "bar.sync PING, 256" for partition 0 or "bar.sync
+    // PONG" for partition 1 At endOfGemm, insert "bar.arrive PONG, 256" for
+    // partition 0 or "bar.arrive PING" for partition 1
     builder.setInsertionPoint(forOp);
     auto forLoc = forOp->getLoc();
-
-    // FIXME: hard-code total number of threads to be 256 when
-    // numConsumerGroups is 2.
+    // Hard-code number of threads to be 256 for each partition.
     Value numThreads = builder.create<arith::ConstantIntOp>(forLoc, 256, 32);
-    // for taskId of 1, generate: bar.sync pingBarrier; bar.arrive pongBarrier
-    // for taskId of 2, outside of the loop, generate bar.arrive pingBarrier
-    //   inside the loop, generate bar.sync pongBarrier; bar.arrive
-    //   pingBarrier
-    Value pingBarrier =
-        builder.create<arith::ConstantIntOp>(forLoc, PING_BARRIER, 32);
 
-    int wgId = getSingleTaskId(forOp);
-    // At startOfGemm, insert "bar.sync 9 or 10, 256"
     builder.setInsertionPoint(startOfGemm);
     auto loc = startOfGemm->getLoc();
     Value syncBarrier = builder.create<arith::ConstantIntOp>(
-        loc, wgId == 1 ? PING_BARRIER : PONG_BARRIER, 32);
+        loc, idx == 0 ? PING_BARRIER : PONG_BARRIER, 32);
     builder.create<ttng::NamedBarrierWaitOp>(loc, syncBarrier, numThreads);
 
-    // At endOfGemm, insert "bar.arrive 10 or 9, 256"
-    Operation *insertBefore = endOfGemm;
-    insertBefore = moveBackward(endOfGemm, forOp);
+    Operation *insertBefore = moveBackward(endOfGemm, forOp);
     builder.setInsertionPoint(insertBefore);
     auto loc2 = endOfGemm->getLoc();
     Value arriveBarrier = builder.create<arith::ConstantIntOp>(
-        loc2, wgId == 1 ? PONG_BARRIER : PING_BARRIER, 32);
+        loc2, idx == 0 ? PONG_BARRIER : PING_BARRIER, 32);
     builder.create<ttng::NamedBarrierArriveOp>(loc2, arriveBarrier, numThreads);
+  }
+}
+
+void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups) {
+  // Insert sync points in ForOp for consumer warp groups. Enable this pass
+  // when number of consumer warp groups == 2.
+  if (numWarpGroups != 3)
+    return;
+
+  SmallVector<scf::ForOp> loops;
+  // Identify ForOps for consumer warp groups. Check partitions to find regions
+  // of gemms.
+  DenseMap<unsigned, SmallVector<Operation *>> loopDepthPartition0;
+  DenseMap<unsigned, SmallVector<Operation *>> loopDepthPartition1;
+  for (auto &block : funcOp.getBody().getBlocks()) {
+    for (Operation &bodyOp : block.getOperations()) {
+      Operation *op = &bodyOp;
+      if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
+        handleWarpSpec(wsOp);
+      }
+    }
   }
 }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -271,20 +271,8 @@ struct NamedBarrierArriveOpConversion
   matchAndRewrite(triton::nvidia_gpu::NamedBarrierArriveOp op,
                   OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Location loc = op->getLoc();
-    std::string ptxAsm = "bar.arrive $0, $1;";
-
-    PTXBuilder ptxBuilder;
-    SmallVector<PTXBuilder::Operand *, 2> operands = {
-        ptxBuilder.newOperand(adaptor.getBar(), "r"),
-        ptxBuilder.newOperand(adaptor.getNumThreads(), "r")};
-
-    auto arriveOp = *ptxBuilder.create<>(ptxAsm);
-    arriveOp(operands, /*onlyAttachMLIRArgs=*/true);
-    auto voidTy = void_ty(getContext());
-    ptxBuilder.launch(rewriter, op.getLoc(), voidTy);
-
-    rewriter.eraseOp(op);
+    rewriter.replaceOpWithNewOp<NVVM::BarrierArriveOp>(op, adaptor.getBar(),
+                                                       adaptor.getNumThreads());
     return success();
   }
 };
@@ -297,20 +285,8 @@ struct NamedBarrierWaitOpConversion
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::NamedBarrierWaitOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Location loc = op->getLoc();
-    std::string ptxAsm = "bar.sync $0, $1;";
-
-    PTXBuilder ptxBuilder;
-    SmallVector<PTXBuilder::Operand *, 2> operands = {
-        ptxBuilder.newOperand(adaptor.getBar(), "r"),
-        ptxBuilder.newOperand(adaptor.getNumThreads(), "r")};
-
-    auto waitOp = *ptxBuilder.create<>(ptxAsm);
-    waitOp(operands, /*onlyAttachMLIRArgs=*/true);
-    auto voidTy = void_ty(getContext());
-    ptxBuilder.launch(rewriter, op.getLoc(), voidTy);
-
-    rewriter.eraseOp(op);
+    rewriter.replaceOpWithNewOp<NVVM::BarrierOp>(op, adaptor.getBar(),
+                                                 adaptor.getNumThreads());
     return success();
   }
 };


### PR DESCRIPTION
The algorithm itself is basic and needs some rework. Mostly putting a PR for discussion and maybe landing the named barriers first.

The algorithm identifies a region of GEMM and enforces a named barrier pair among two warp_spec regions. This is mostly for Hopper FA where we have two partitions with different data but same ops.