### PR TITLE
[build] fix local llvm build when .llvm-project/build doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PYTHON ?= python
 BUILD_DIR := $(shell cd python; $(PYTHON) -c 'from build_helpers import get_cmake_dir; print(get_cmake_dir())')
 TRITON_OPT := $(BUILD_DIR)/bin/triton-opt
 PYTEST := $(PYTHON) -m pytest
-LLVM_BUILD_PATH ?= $(realpath .llvm-project/build)
+LLVM_BUILD_PATH ?= "$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/.llvm-project/build"
 NUM_PROCS ?= 8
 
 # Incremental builds


### PR DESCRIPTION
The previous command (`$(realdir .llvm-project/build)`) works only if .llvm-project/build already exists. The new command will get the absolute path of the directory in which the Makefile exists, and then append `.llvm-project/build`.