### PR TITLE
[Warp Spec] Optimize partitioning by hoisting above broadcasts

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -149,10 +149,14 @@ static void scheduleUsers(scf::ForOp loop, WarpSchedule &schedule,
 // first-order partition assignment to the operations in the scheme and its
 // users and/or dependencies. This sets up the initial partitioning of the ops.
 static std::optional<WarpSchedule> getInitialSchedule(scf::ForOp loop) {
-  WarpSchedule schedule;
+  // Check for an existing schedule.
+  if (FailureOr<WarpSchedule> scheduleOr = WarpSchedule::deserialize(loop);
+      succeeded(scheduleOr))
+    return {std::move(*scheduleOr)};
 
   // Start by creating the default partition, a partition for for all loads, and
   // a partition for all MMAs.
+  WarpSchedule schedule;
   Partition *defaultPartition = schedule.addPartition(0);
   Partition *mmaPartition = schedule.addPartition(1);
   Partition *loadPartition = schedule.addPartition(0);
@@ -479,6 +483,39 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
   }
 }
 
+// Rematerialize chains of broadcasts where the user is in a different partition
+// than the broadcast to reduce the amount of data that needs to be transferred.
+void rematerializeBroadcasts(WarpSchedule &schedule, OpOperand *use) {
+  static_assert(
+      std::is_base_of_v<OpTrait::OneResult<BroadcastOp>, BroadcastOp> &&
+      std::is_base_of_v<OpTrait::OneResult<ExpandDimsOp>, ExpandDimsOp>);
+
+  Operation *defOp = use->get().getDefiningOp();
+  while (isa_and_nonnull<BroadcastOp, ExpandDimsOp>(defOp)) {
+    Operation *clone = OpBuilder(defOp).clone(*defOp);
+    Partition *userPartition = schedule.getPartition(use->getOwner());
+    assert(userPartition && "user not scheduled");
+    schedule.insert(userPartition, clone);
+    use->set(clone->getResult(0));
+
+    defOp = clone->getOperand(0).getDefiningOp();
+    use = &clone->getOpOperand(0);
+  }
+}
+
+void optimizeSchedule(scf::ForOp loop, WarpSchedule &schedule) {
+  for (Partition &partition : schedule.getPartitions()) {
+    SmallVector<OpOperand *> uses;
+    schedule.iterateOutputs(loop, &partition,
+                            [&](Operation *defOp, OpOperand &use) {
+                              if (!isa<scf::YieldOp>(use.getOwner()))
+                                uses.push_back(&use);
+                            });
+    for (OpOperand *use : uses)
+      rematerializeBroadcasts(schedule, use);
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // Pass Definition
 //===----------------------------------------------------------------------===//
@@ -507,6 +544,7 @@ void PartitionScheduling::runOnOperation() {
   for (scf::ForOp loop : loops) {
     if (std::optional<WarpSchedule> schedule = getInitialSchedule(loop)) {
       propagatePartitions(loop, *schedule);
+      optimizeSchedule(loop, *schedule);
       schedule->serialize(loop);
     }
   }

--- a/test/TritonGPU/rewrite-partition-dependencies.mlir
+++ b/test/TritonGPU/rewrite-partition-dependencies.mlir
@@ -337,7 +337,7 @@ tt.func @no_def_op(%lb: i32, %ub: i32, %step: i32) {
 module attributes {"ttg.num-warps" = 4 : i32} {
 
 tt.func @invalid_attribute(%lb: i32, %ub: i32, %step: i32) {
-  // expected-warning @below {{partition stages attribute 'ttg.partition.stages' has invalid element "a"}}
+  // expected-error @below {{partition stages attribute 'ttg.partition.stages' has invalid element "a"}}
   scf.for %i = %lb to %ub step %step : i32 {
     scf.yield
   } {ttg.partition.stages = ["a"]}
@@ -359,7 +359,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 
 tt.func @invalid_attribute(%lb: i32, %ub: i32, %step: i32) {
   scf.for %k = %lb to %ub step %step : i32 {
-    // expected-warning @below {{invalid partition index -1}}
+    // expected-error @below {{invalid partition index -1}}
     "op"() {ttg.partition = -1} : () -> ()
     scf.yield
   } {ttg.partition.stages = [2, 2]}


### PR DESCRIPTION
This PR adds a small optimization step to partitioning that transforms

```mlir
%x = producer() partition=0
%y = broadcast %x : <Axf32> -> <AxBxf32> partition=0
use(%y) partition=1
```

Into

```mlir
%x = producer() partition=0
%y = broadcast %x : <Axf32> -> <AxBxf32> partition=1
use(%y) partition=1
```

To reduce the amount of shared memory needed.
