### PR TITLE
[Runtime] Make `AsyncCompileMode` thread safe

### DIFF
--- a/python/triton/runtime/_allocation.py
+++ b/python/triton/runtime/_allocation.py
@@ -29,5 +29,4 @@ def set_allocator(allocator: Allocator):
     The allocator function is called during kernel launch for kernels that
     require additional global memory workspace.
     """
-    global _allocator
     _allocator.set(allocator)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -757,7 +757,7 @@ class JITFunction(KernelInterface[T]):
             return None
         src = self.ASTSource(self, signature, constexprs, attrs)
 
-        async_mode = _async_compile.active_mode
+        async_mode = _async_compile.active_mode.get()
         if async_mode is not None:
 
             env_vars = get_cache_invalidating_env_vars()


### PR DESCRIPTION
In the same vein as #7685

We rely on the global variable `active_mode`, so if you were to use `AsyncCompileMode` in two different threads they may race with each other.

