### PR TITLE
[Gluon][Tests] Make frontend tests independent of the active target

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -64,9 +64,7 @@ def TTG_AsyncCommitGroupOp : TTG_Op<"async_commit_group"> {
   let results = (outs TTG_AsyncToken:$asyncToken);
   let arguments = (ins Variadic<TTG_AsyncToken>:$inputTokens);
 
-  let assemblyFormat = [{
-    $inputTokens attr-dict
-  }];
+  let assemblyFormat = [{($inputTokens ^)?attr-dict}];
 
   let extraClassDeclaration = [{
     static bool isSupported(int computeCapability) {

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -20,8 +20,8 @@ TARGET_PAT = re.compile('ttg.target = "[^"]*"')
 PTRRANGE_PAT = re.compile('(, )?tt.pointer_range = 32 : i32')
 
 BLACKWELL_TARGET = GPUTarget("cuda", 100, 32)
-HOPPER_TARGET = GPUTarget("cuda", 100, 32)
-AMPERE_TARGET = GPUTarget("cuda", 100, 32)
+HOPPER_TARGET = GPUTarget("cuda", 90, 32)
+AMPERE_TARGET = GPUTarget("cuda", 80, 32)
 HIP_TARGET = GPUTarget("hip", "gfx1200", 32)
 
 ALL_TARGETS = [AMPERE_TARGET, HOPPER_TARGET, BLACKWELL_TARGET, HIP_TARGET]

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1,10 +1,9 @@
 import expecttest
-from triton.runtime.jit import MockTensor
 import torch
 import pytest
 import re
 
-from triton import knobs
+from triton.backends.compiler import GPUTarget
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia import blackwell
@@ -12,15 +11,29 @@ from triton.experimental.gluon.language.nvidia import hopper
 from triton.experimental.gluon.language.nvidia.blackwell import mbarrier, tma, TensorMemoryLayout, async_copy
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton._filecheck import filecheck_test, run_parser
+from triton.runtime.jit import MockTensor
 import triton.language as tl
-from triton._internal_testing import is_cuda, is_ampere_or_newer, is_blackwell, is_hopper, is_hopper_or_newer
 from triton.compiler.errors import CompilationError, CompileTimeAssertionFailure
 
 TARGET_PAT = re.compile('ttg.target = "[^"]*"')
+# HIP backend can add this attribute to function parameters
+PTRRANGE_PAT = re.compile('(, )?tt.pointer_range = 32 : i32')
+
+BLACKWELL_TARGET = GPUTarget("cuda", 100, 32)
+HOPPER_TARGET = GPUTarget("cuda", 100, 32)
+AMPERE_TARGET = GPUTarget("cuda", 100, 32)
+HIP_TARGET = GPUTarget("hip", "gfx1200", 32)
+
+ALL_TARGETS = [AMPERE_TARGET, HOPPER_TARGET, BLACKWELL_TARGET, HIP_TARGET]
 
 
 def anonymize_ir(ir):
-    return TARGET_PAT.sub('ttg.target = "..."', ir)
+    ir = TARGET_PAT.sub('ttg.target = "..."', ir)
+    return PTRRANGE_PAT.sub('', ir)
+
+
+def make_args(*args, **kwargs):
+    return args, kwargs
 
 
 @gluon.jit
@@ -29,35 +42,27 @@ def convert_layout_kernel(XBLOCK: ttgl.constexpr, layout_a: ttgl.constexpr, layo
     res = ttgl.convert_layout(x, layout_b)  # noqa: F841
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
-def test_convert_layout(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
+@pytest.mark.parametrize("target", ALL_TARGETS)
+def test_convert_layout(target):
     layout_a = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32], warps_per_cta=[4], order=[0])
     layout_b = ttgl.SliceLayout(
         1, ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[1, 32], warps_per_cta=[1, 4], order=[1, 0]))
-    h = convert_layout_kernel.warmup(128, layout_a, layout_b, num_warps=layout_a.warps_per_cta[0], grid=(1, ))
+    mod = run_parser(
+        convert_layout_kernel,
+        *make_args(128, layout_a, layout_b, num_warps=layout_a.warps_per_cta[0]),
+        target=target,
+    )
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @convert_layout_kernel() attributes {noinline = false} {
-    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked> loc(#loc)
-    %1 = ttg.convert_layout %0 : tensor<128xi32, #blocked> -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
-""")
-    expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["ttgir"]), """\
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @convert_layout_kernel() attributes {noinline = false} {
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked>
+    %1 = ttg.convert_layout %0 : tensor<128xi32, #blocked> -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    tt.return
+  }
+}
 """)
 
 
@@ -74,7 +79,8 @@ def test_convert_layout_assert_trivial():
     ttgl.convert_layout(value, equiv_layout, assert_trivial=True)
 
 
-def test_convert_layout_not_trivial():
+@pytest.mark.parametrize("target", ALL_TARGETS)
+def test_convert_layout_not_trivial(target):
 
     @gluon.jit
     def kernel(src_layout: ttgl.constexpr, dst_layout: ttgl.constexpr):
@@ -84,7 +90,7 @@ def test_convert_layout_not_trivial():
     with pytest.raises(CompilationError) as e:
         src_layout = ttgl.BlockedLayout([2], [32], [4], [0])
         dst_layout = ttgl.BlockedLayout([1], [32], [4], [0])
-        kernel.warmup(src_layout, dst_layout, grid=(1, ))
+        run_parser(kernel, *make_args(src_layout, dst_layout), target=target)
 
     assert "layout conversion from BlockedLayout(size_per_thread=[2]" in str(e.value.__cause__)
     assert "to BlockedLayout(size_per_thread=[1]" in str(e.value.__cause__)
@@ -93,7 +99,7 @@ def test_convert_layout_not_trivial():
     with pytest.raises(CompilationError) as e:
         src_layout = ttgl.BlockedLayout([2], [32], [4], [0])
         dst_layout = ttgl.AutoLayout()
-        kernel.warmup(src_layout, dst_layout, grid=(1, ))
+        run_parser(kernel, *make_args(src_layout, dst_layout), target=target)
 
     assert "layout conversion from BlockedLayout(size_per_thread=[2]" in str(e.value.__cause__)
     assert "to AutoLayout() is not trivial" in str(e.value.__cause__)
@@ -112,34 +118,34 @@ def shared_memory_kernel(XBLOCK: ttgl.constexpr, YBLOCK: ttgl.constexpr, layout_
     unused._keep_alive()
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
-def test_shared_memory(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
+@pytest.mark.parametrize("target", ALL_TARGETS)
+def test_shared_memory(target):
     layout_a = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[1, 32], warps_per_cta=[4, 1], order=[1, 0])
     layout_b = ttgl.BlockedLayout(size_per_thread=[1, 4], threads_per_warp=[1, 32], warps_per_cta=[4, 1], order=[1, 0])
     smem_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=32, rank=2)
-    h = shared_memory_kernel.warmup(8, 32, layout_a, layout_b, smem_layout, num_warps=layout_a.warps_per_cta[0],
-                                    grid=(1, ))
+    mod = run_parser(
+        shared_memory_kernel,
+        *make_args(8, 32, layout_a, layout_b, smem_layout, num_warps=layout_a.warps_per_cta[0]),
+        target=target,
+    )
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @shared_memory_kernel() attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable> loc(#loc)
-    %c0_i32 = arith.constant 0 : i32 loc(#loc)
-    %cst = arith.constant dense<0> : tensor<8x32xi32, #blocked> loc(#loc)
-    %1 = ttg.local_alloc %cst : (tensor<8x32xi32, #blocked>) -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable> loc(#loc)
-    %2 = ttg.local_load %1 : !ttg.memdesc<8x32xi32, #shared, #smem, mutable> -> tensor<8x32xi32, #blocked1> loc(#loc)
-    ttg.local_store %cst, %1 : tensor<8x32xi32, #blocked> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable> loc(#loc)
-    ttg.local_dealloc %0 : !ttg.memdesc<8x32xi32, #shared, #smem, mutable> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable>
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0> : tensor<8x32xi32, #blocked>
+    %1 = ttg.local_alloc %cst : (tensor<8x32xi32, #blocked>) -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable>
+    %2 = ttg.local_load %1 : !ttg.memdesc<8x32xi32, #shared, #smem, mutable> -> tensor<8x32xi32, #blocked1>
+    ttg.local_store %cst, %1 : tensor<8x32xi32, #blocked> -> !ttg.memdesc<8x32xi32, #shared, #smem, mutable>
+    ttg.local_dealloc %0 : !ttg.memdesc<8x32xi32, #shared, #smem, mutable>
+    tt.return
+  }
+}
 """)
 
 
@@ -160,45 +166,45 @@ def tensor_memory_kernel(layout: ttgl.constexpr, tmem_layout: ttgl.constexpr):
         buffers.index(ivar).load(layout)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires blackwell tensor cores")
-def test_tensor_memory(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
+def test_tensor_memory():
     layout = ttgl.BlockedLayout(size_per_thread=[1, 64], threads_per_warp=[32, 1], warps_per_cta=[4, 1], order=[0, 1])
     tmem_layout = TensorMemoryLayout(block=[128, 128], unpacked=True)
-    h = tensor_memory_kernel.warmup(layout, tmem_layout, num_warps=4, grid=(1, ))
+    mod = run_parser(
+        tensor_memory_kernel,
+        *make_args(layout, tmem_layout, num_warps=4),
+        target=BLACKWELL_TARGET,
+    )
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 #tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, unpacked = true>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @tensor_memory_kernel() attributes {noinline = false} {
-    %c0_i32 = arith.constant 0 : i32 loc(#loc)
-    %cst = arith.constant dense<0> : tensor<128x128xi32, #blocked> loc(#loc)
-    %result = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> loc(#loc)
-    %result_0 = ttng.tmem_alloc %cst : (tensor<128x128xi32, #blocked>) -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> loc(#loc)
-    %result_1 = ttng.tmem_load %result_0 : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xi32, #blocked> loc(#loc)
-    %true = arith.constant true loc(#loc)
-    ttng.tmem_store %cst, %result_0, %true : tensor<128x128xi32, #blocked> -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> loc(#loc)
-    %0 = ttng.tmem_subslice %result_0 {N = 0 : i32} : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xi32, #tmem1, #ttng.tensor_memory, mutable, 128x128> loc(#loc)
-    %1 = ttng.tmem_subslice %result_0 {N = 64 : i32} : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xi32, #tmem1, #ttng.tensor_memory, mutable, 128x128> loc(#loc)
-    %result_2 = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc)
-    %c0_i32_3 = arith.constant 0 : i32 loc(#loc)
-    %c2_i32 = arith.constant 2 : i32 loc(#loc)
-    %c1_i32 = arith.constant 1 : i32 loc(#loc)
-    %2 = arith.bitcast %c0_i32_3 : i32 to i32 loc(#loc)
-    %3 = arith.bitcast %c2_i32 : i32 to i32 loc(#loc)
-    %4 = arith.bitcast %c1_i32 : i32 to i32 loc(#loc)
-    %5 = ub.poison : i32 loc(#loc)
-    scf.for %ivar = %2 to %3 step %4  : i32 {
-      %6 = ttg.memdesc_index %result_2, %ivar : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128> loc(#loc)
-      %result_4 = ttng.tmem_load %6 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128> -> tensor<128x128xf32, #blocked> loc(#loc)
-    } loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0> : tensor<128x128xi32, #blocked>
+    %result = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %result_0 = ttng.tmem_alloc %cst : (tensor<128x128xi32, #blocked>) -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %result_1 = ttng.tmem_load %result_0 : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xi32, #blocked>
+    %true = arith.constant true
+    ttng.tmem_store %cst, %result_0, %true : tensor<128x128xi32, #blocked> -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %0 = ttng.tmem_subslice %result_0 {N = 0 : i32} : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xi32, #tmem1, #ttng.tensor_memory, mutable, 128x128>
+    %1 = ttng.tmem_subslice %result_0 {N = 64 : i32} : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xi32, #tmem1, #ttng.tensor_memory, mutable, 128x128>
+    %result_2 = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %c0_i32_3 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %2 = arith.bitcast %c0_i32_3 : i32 to i32
+    %3 = arith.bitcast %c2_i32 : i32 to i32
+    %4 = arith.bitcast %c1_i32 : i32 to i32
+    %5 = ub.poison : i32
+    scf.for %arg0 = %2 to %3 step %4  : i32 {
+      %6 = ttg.memdesc_index %result_2, %arg0 : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>
+      %result_4 = ttng.tmem_load %6 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128> -> tensor<128x128xf32, #blocked>
+    }
+    tt.return
+  }
+}
 """)
 
 
@@ -212,31 +218,32 @@ def shared_memory_subview_kernel(XBLOCK: ttgl.constexpr, layout: ttgl.constexpr,
     view.store(value.trans())
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
-def test_shared_memory_subview(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
+@pytest.mark.parametrize("target", ALL_TARGETS)
+def test_shared_memory_subview(target):
     layout = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[1, 32], warps_per_cta=[4, 1], order=[1, 0])
     smem_layout = ttgl.SwizzledSharedLayout(1, 1, 1, [1, 0])
-    h = shared_memory_subview_kernel.warmup(256, layout, smem_layout, num_warps=4, grid=(1, ))
+    mod = run_parser(
+        shared_memory_subview_kernel,
+        *make_args(256, layout, smem_layout, num_warps=4),
+        target=target,
+    )
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @shared_memory_subview_kernel() attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<256x256xi32, #shared, #smem, mutable> loc(#loc)
-    %1 = ttg.memdesc_subslice %0[0, 128] : !ttg.memdesc<256x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<256x128xi32, #shared, #smem, mutable, 256x256> loc(#loc)
-    %2 = ttg.local_load %1 : !ttg.memdesc<256x128xi32, #shared, #smem, mutable, 256x256> -> tensor<256x128xi32, #blocked> loc(#loc)
-    %3 = ttg.memdesc_subslice %0[128, 0] : !ttg.memdesc<256x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x256xi32, #shared, #smem, mutable, 256x256> loc(#loc)
-    %4 = tt.trans %2 {order = array<i32: 1, 0>} : tensor<256x128xi32, #blocked> -> tensor<128x256xi32, #blocked1> loc(#loc)
-    ttg.local_store %4, %3 : tensor<128x256xi32, #blocked1> -> !ttg.memdesc<128x256xi32, #shared, #smem, mutable, 256x256> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<256x256xi32, #shared, #smem, mutable>
+    %1 = ttg.memdesc_subslice %0[0, 128] : !ttg.memdesc<256x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<256x128xi32, #shared, #smem, mutable, 256x256>
+    %2 = ttg.local_load %1 : !ttg.memdesc<256x128xi32, #shared, #smem, mutable, 256x256> -> tensor<256x128xi32, #blocked>
+    %3 = ttg.memdesc_subslice %0[128, 0] : !ttg.memdesc<256x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<128x256xi32, #shared, #smem, mutable, 256x256>
+    %4 = tt.trans %2 {order = array<i32: 1, 0>} : tensor<256x128xi32, #blocked> -> tensor<128x256xi32, #blocked1>
+    ttg.local_store %4, %3 : tensor<128x256xi32, #blocked1> -> !ttg.memdesc<128x256xi32, #shared, #smem, mutable, 256x256>
+    tt.return
+  }
+}
 """)
 
 
@@ -247,36 +254,37 @@ def shared_memory_index_kernel(XBLOCK: ttgl.constexpr, layout: ttgl.constexpr, s
         smem.index(ivar).load(layout)
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
-def test_shared_memory_index(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
+@pytest.mark.parametrize("target", ALL_TARGETS)
+def test_shared_memory_index(target):
     layout = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32], warps_per_cta=[4], order=[0])
     smem_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=32, rank=2)
-    h = shared_memory_index_kernel.warmup(256, layout, smem_layout, num_warps=4, grid=(1, ))
+    mod = run_parser(
+        shared_memory_index_kernel,
+        *make_args(256, layout, smem_layout, num_warps=4),
+        target=target,
+    )
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @shared_memory_index_kernel() attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<4x256xi32, #shared, #smem, mutable> loc(#loc)
-    %c0_i32 = arith.constant 0 : i32 loc(#loc)
-    %c4_i32 = arith.constant 4 : i32 loc(#loc)
-    %c1_i32 = arith.constant 1 : i32 loc(#loc)
-    %1 = arith.bitcast %c0_i32 : i32 to i32 loc(#loc)
-    %2 = arith.bitcast %c4_i32 : i32 to i32 loc(#loc)
-    %3 = arith.bitcast %c1_i32 : i32 to i32 loc(#loc)
-    %4 = ub.poison : i32 loc(#loc)
-    scf.for %ivar = %1 to %2 step %3  : i32 {
-      %5 = ttg.memdesc_index %0, %ivar : !ttg.memdesc<4x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<256xi32, #shared, #smem, mutable, 4x256> loc(#loc)
-      %6 = ttg.local_load %5 : !ttg.memdesc<256xi32, #shared, #smem, mutable, 4x256> -> tensor<256xi32, #blocked> loc(#loc)
-    } loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<4x256xi32, #shared, #smem, mutable>
+    %c0_i32 = arith.constant 0 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %1 = arith.bitcast %c0_i32 : i32 to i32
+    %2 = arith.bitcast %c4_i32 : i32 to i32
+    %3 = arith.bitcast %c1_i32 : i32 to i32
+    %4 = ub.poison : i32
+    scf.for %arg0 = %1 to %2 step %3  : i32 {
+      %5 = ttg.memdesc_index %0, %arg0 : !ttg.memdesc<4x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<256xi32, #shared, #smem, mutable, 4x256>
+      %6 = ttg.local_load %5 : !ttg.memdesc<256xi32, #shared, #smem, mutable, 4x256> -> tensor<256xi32, #blocked>
+    }
+    tt.return
+  }
+}
 """)
 
 
@@ -300,10 +308,11 @@ def shared_memory_cast_kernel():
     smem._reinterpret(ttgl.int8, [1024], ttgl.SwizzledSharedLayout(1, 1, 1, [0, 1]))
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
-def test_shared_memory_cast(fresh_knobs):
+@pytest.mark.parametrize("target", ALL_TARGETS)
+def test_shared_memory_cast(target):
+    mod = run_parser(shared_memory_cast_kernel, target=target)
     expecttest.assert_expected_inline(
-        anonymize_ir(run_parser(shared_memory_cast_kernel).str_nodebug()), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
 #shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CTAsPerCGA = [1, 1, 1, 1], CTASplitNum = [1, 1, 1, 1], CTAOrder = [3, 2, 1, 0]}>
@@ -455,31 +464,28 @@ def mbarrier_kernel():
     mbarrier.invalidate(bar)
 
 
-@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires hopper or newer")
-def test_mbarrier(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
-    h = mbarrier_kernel.warmup(grid=(1, ))
+@pytest.mark.parametrize("target", [HOPPER_TARGET, BLACKWELL_TARGET])
+def test_mbarrier(target):
+    mod = run_parser(mbarrier_kernel, target=target)
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @mbarrier_kernel() attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
-    ttng.init_barrier %0, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
-    %true = arith.constant true loc(#loc)
-    ttng.barrier_expect %0, 4, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
-    %true_0 = arith.constant true loc(#loc)
-    ttng.arrive_barrier %0, 1, %true_0 : !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
-    %c0_i32 = arith.constant 0 : i32 loc(#loc)
-    %true_1 = arith.constant true loc(#loc)
-    ttng.wait_barrier %0, %c0_i32, %true_1 deps %0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
-    ttng.inval_barrier %0 : !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %0, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %true = arith.constant true
+    ttng.barrier_expect %0, 4, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %true_0 = arith.constant true
+    ttng.arrive_barrier %0, 1, %true_0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %c0_i32 = arith.constant 0 : i32
+    %true_1 = arith.constant true
+    ttng.wait_barrier %0, %c0_i32, %true_1 deps %0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.inval_barrier %0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
 """)
 
 
@@ -491,31 +497,27 @@ def tcgen05_mma_kernel(nvmma_layout: ttgl.constexpr, acc_layout: ttgl.constexpr)
     blackwell.tcgen05_mma(a, b, acc)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires blackwell tensor core")
-def test_tcgen05_mma(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
+def test_tcgen05_mma():
     nvmma_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
     acc_layout = TensorMemoryLayout([128, 128], unpacked=True)
 
-    h = tcgen05_mma_kernel.warmup(nvmma_layout, acc_layout, grid=(1, ))
+    mod = run_parser(tcgen05_mma_kernel, *make_args(nvmma_layout, acc_layout), target=BLACKWELL_TARGET)
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @tcgen05_mma_kernel() attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc)
-    %1 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc)
-    %result = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc)
-    %true = arith.constant true loc(#loc)
-    %true_0 = arith.constant true loc(#loc)
-    %2 = ttng.tc_gen5_mma %0, %1, %result[], %true, %true_0 : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %result = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %true = arith.constant true
+    %true_0 = arith.constant true
+    %2 = ttng.tc_gen5_mma %0, %1, %result[], %true, %true_0 : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
 """)
 
 
@@ -528,34 +530,30 @@ def tcgen05_mma_mbar_kernel(nvmma_layout: ttgl.constexpr, acc_layout: ttgl.const
     blackwell.tcgen05_mma(a, b, acc, mbarriers=[bar])
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires blackwell tensor core")
-def test_tcgen05_mma_mbar(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
+def test_tcgen05_mma_mbar():
     nvmma_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
     acc_layout = TensorMemoryLayout([128, 128], unpacked=True)
 
-    h = tcgen05_mma_mbar_kernel.warmup(nvmma_layout, acc_layout, grid=(1, ))
+    mod = run_parser(tcgen05_mma_mbar_kernel, *make_args(nvmma_layout, acc_layout), target=BLACKWELL_TARGET)
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, unpacked = true>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @tcgen05_mma_mbar_kernel() attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc)
-    %1 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc)
-    %2 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    %result = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc)
-    %true = arith.constant true loc(#loc)
-    %true_0 = arith.constant true loc(#loc)
-    %true_1 = arith.constant true loc(#loc)
-    %3 = ttng.tc_gen5_mma %0, %1, %result[], %true, %true_0, %2[%true_1] {is_async} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %2 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %result = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %true = arith.constant true
+    %true_0 = arith.constant true
+    %true_1 = arith.constant true
+    %3 = ttng.tc_gen5_mma %0, %1, %result[], %true, %true_0, %2[%true_1] {is_async} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    tt.return
+  }
+}
 """)
 
 
@@ -577,30 +575,30 @@ def warpgroup_mma_kernel(nvmma_layout: ttgl.constexpr, acc_layout: ttgl.constexp
     hopper.warpgroup_mma(a, b, acc)
 
 
-@pytest.mark.skipif(not is_hopper(), reason="Requires Hopper WGMMA")
-def test_warpgroup_mma(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
+def test_warpgroup_mma():
     nvmma_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
     mma_layout = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=[4, 1], instr_shape=[16, 32, 16])
-    h = warpgroup_mma_kernel.warmup(nvmma_layout, mma_layout, grid=(1, ))
+    mod = run_parser(
+        warpgroup_mma_kernel,
+        *make_args(nvmma_layout, mma_layout),
+        target=HOPPER_TARGET,
+    )
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 32, 16]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @warpgroup_mma_kernel() attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc)
-    %1 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc)
-    %cst = arith.constant 0.000000e+00 : f16 loc(#loc)
-    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #mma> loc(#loc)
-    %true = arith.constant true loc(#loc)
-    %2 = ttng.warp_group_dot %0, %1, %cst_0, %true {inputPrecision = 0 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> * !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16, #mma> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %cst = arith.constant 0.000000e+00 : f16
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #mma>
+    %true = arith.constant true
+    %2 = ttng.warp_group_dot %0, %1, %cst_0, %true {inputPrecision = 0 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> * !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16, #mma>
+    tt.return
+  }
+}
 """)
 
 
@@ -611,23 +609,19 @@ def warpgroup_mma_wait_kernel():
     hopper.warpgroup_mma_wait(num_outstanding=1, deps=[acc])
 
 
-@pytest.mark.skipif(not is_hopper(), reason="Requires Hopper WGMMA")
-def test_warpgroup_mma_wait(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
-    h = warpgroup_mma_wait_kernel.warmup(grid=(1, ))
+def test_warpgroup_mma_wait():
+    mod = run_parser(warpgroup_mma_wait_kernel, target=HOPPER_TARGET)
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 32, 16]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @warpgroup_mma_wait_kernel() attributes {noinline = false} {
-    %cst = arith.constant 0.000000e+00 : f16 loc(#loc)
-    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #mma> loc(#loc)
-    %0 = ttng.warp_group_dot_wait %cst_0 {pendings = 1 : i32} : tensor<128x128xf16, #mma> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %cst = arith.constant 0.000000e+00 : f16
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #mma>
+    %0 = ttng.warp_group_dot_wait %cst_0 {pendings = 1 : i32} : tensor<128x128xf16, #mma>
+    tt.return
+  }
+}
 """)
 
 
@@ -648,45 +642,45 @@ def async_tma_kernel(input_desc, XBLOCK: ttgl.constexpr):
     tma.store_wait(0)
 
 
-@pytest.mark.skipif(not is_hopper_or_newer(), reason="TMA requires at least Hopper")
-def test_async_tma(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
+@pytest.mark.parametrize("target", [HOPPER_TARGET, BLACKWELL_TARGET])
+def test_async_tma(target):
     input = torch.randn((1024, 1024), device="cuda", dtype=torch.float16)
     XBLOCK = 128
     shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
     input_desc = TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
 
-    h = async_tma_kernel.warmup(input_desc, XBLOCK, grid=(1, ), num_warps=4)
+    mod = run_parser(
+        async_tma_kernel,
+        *make_args(input_desc, XBLOCK, num_warps=4),
+        target=target,
+    )
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
-#loc1 = loc("input_desc")
+        anonymize_ir(mod.str_nodebug()), """\
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @async_tma_kernel(%input_desc: !tt.tensordesc<tensor<128x128xf16, #shared>> loc("input_desc"), %input_desc_0: i32 loc("input_desc"), %input_desc_1: i32 loc("input_desc"), %input_desc_2: i64 loc("input_desc"), %input_desc_3: i64 loc("input_desc")) attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc)
-    %1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    %c0_i32 = arith.constant 0 : i32 loc(#loc)
-    %c0_i32_4 = arith.constant 0 : i32 loc(#loc)
-    %true = arith.constant true loc(#loc)
-    ttng.async_tma_copy_global_to_local %input_desc[%c0_i32, %c0_i32_4] %0, %1, %true : !tt.tensordesc<tensor<128x128xf16, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc)
-    %true_5 = arith.constant true loc(#loc)
-    ttng.barrier_expect %1, 32768, %true_5 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    %c0_i32_6 = arith.constant 0 : i32 loc(#loc)
-    %true_7 = arith.constant true loc(#loc)
-    ttng.wait_barrier %1, %c0_i32_6, %true_7 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    ttng.inval_barrier %1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    %c0_i32_8 = arith.constant 0 : i32 loc(#loc)
-    %c0_i32_9 = arith.constant 0 : i32 loc(#loc)
-    ttng.async_tma_copy_local_to_global %input_desc[%c0_i32_8, %c0_i32_9] %0 : !tt.tensordesc<tensor<128x128xf16, #shared>>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc)
-    ttng.async_tma_store_wait {pendings = 0 : i32} loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+  tt.func public @async_tma_kernel(%arg0: !tt.tensordesc<tensor<128x128xf16, #shared>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64) attributes {noinline = false} {
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i32_0 = arith.constant 0 : i32
+    %true = arith.constant true
+    ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32_0] %0, %1, %true : !tt.tensordesc<tensor<128x128xf16, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %true_1 = arith.constant true
+    ttng.barrier_expect %1, 32768, %true_1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %c0_i32_2 = arith.constant 0 : i32
+    %true_3 = arith.constant true
+    ttng.wait_barrier %1, %c0_i32_2, %true_3 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.inval_barrier %1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %c0_i32_4 = arith.constant 0 : i32
+    %c0_i32_5 = arith.constant 0 : i32
+    ttng.async_tma_copy_local_to_global %arg0[%c0_i32_4, %c0_i32_5] %0 : !tt.tensordesc<tensor<128x128xf16, #shared>>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}
 """)
 
 
@@ -708,45 +702,44 @@ def async_tma_blackwell_kernel(input_desc, XBLOCK: ttgl.constexpr):
     tma.store_wait(0)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-def test_async_tma_blackwell(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
+def test_async_tma_blackwell():
     input = torch.randn((1024, 1024), device="cuda", dtype=torch.float16)
     XBLOCK = 128
     shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
     input_desc = TensorDescriptor.from_tensor(input, [1, XBLOCK], shared_layout)
 
-    h = async_tma_blackwell_kernel.warmup(input_desc, XBLOCK, grid=(1, ), num_warps=4)
+    mod = run_parser(
+        async_tma_blackwell_kernel,
+        *make_args(input_desc, XBLOCK, num_warps=4),
+        target=BLACKWELL_TARGET,
+    )
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
-#loc1 = loc("input_desc")
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @async_tma_blackwell_kernel(%input_desc: !tt.tensordesc<tensor<1x128xf16, #shared>> loc("input_desc"), %input_desc_0: i32 loc("input_desc"), %input_desc_1: i32 loc("input_desc"), %input_desc_2: i64 loc("input_desc"), %input_desc_3: i64 loc("input_desc")) attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc)
-    %1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    %true = arith.constant true loc(#loc)
-    %c0_i32 = arith.constant 0 : i32 loc(#loc)
-    ttng.async_tma_gather %input_desc[%2, %c0_i32] %0, %1, %true : !tt.tensordesc<tensor<1x128xf16, #shared>>, tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, i32, !ttg.memdesc<1xi64, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, i1 loc(#loc)
-    %true_4 = arith.constant true loc(#loc)
-    ttng.barrier_expect %1, 32768, %true_4 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    %c0_i32_5 = arith.constant 0 : i32 loc(#loc)
-    %true_6 = arith.constant true loc(#loc)
-    ttng.wait_barrier %1, %c0_i32_5, %true_6 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    ttng.inval_barrier %1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> loc(#loc)
-    %c0_i32_7 = arith.constant 0 : i32 loc(#loc)
-    ttng.async_tma_scatter %input_desc[%2, %c0_i32_7] %0 : !tt.tensordesc<tensor<1x128xf16, #shared>>, tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, i32, !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc)
-    ttng.async_tma_store_wait {pendings = 0 : i32} loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+  tt.func public @async_tma_blackwell_kernel(%arg0: !tt.tensordesc<tensor<1x128xf16, #shared>>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64) attributes {noinline = false} {
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    ttng.async_tma_gather %arg0[%2, %c0_i32] %0, %1, %true : !tt.tensordesc<tensor<1x128xf16, #shared>>, tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, i32, !ttg.memdesc<1xi64, #shared1, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, i1
+    %true_0 = arith.constant true
+    ttng.barrier_expect %1, 32768, %true_0 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %c0_i32_1 = arith.constant 0 : i32
+    %true_2 = arith.constant true
+    ttng.wait_barrier %1, %c0_i32_1, %true_2 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.inval_barrier %1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %c0_i32_3 = arith.constant 0 : i32
+    ttng.async_tma_scatter %arg0[%2, %c0_i32_3] %0 : !tt.tensordesc<tensor<1x128xf16, #shared>>, tensor<128xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, i32, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    ttng.async_tma_store_wait {pendings = 0 : i32}
+    tt.return
+  }
+}
 """)
 
 
@@ -822,31 +815,28 @@ def broadcast_kernel():
     0 + a + b
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
-def test_broadcast(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
-    h = broadcast_kernel.warmup(sanitize_overflow=False, grid=(1, ))
+@pytest.mark.parametrize("target", ALL_TARGETS)
+def test_broadcast(target):
+    mod = run_parser(broadcast_kernel, target=target)
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @broadcast_kernel() attributes {noinline = false} {
-    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x16xi32, #blocked> loc(#loc)
-    %2 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>> loc(#loc)
-    %3 = tt.expand_dims %2 {axis = 1 : i32} : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<16x1xi32, #blocked> loc(#loc)
-    %c0_i32 = arith.constant 0 : i32 loc(#loc)
-    %c0_i32_0 = arith.constant 0 : i32 loc(#loc)
-    %cst = arith.constant dense<0> : tensor<1x16xi32, #blocked> loc(#loc)
-    %4 = arith.addi %cst, %1 : tensor<1x16xi32, #blocked> loc(#loc)
-    %5 = tt.broadcast %4 : tensor<1x16xi32, #blocked> -> tensor<16x16xi32, #blocked> loc(#loc)
-    %6 = tt.broadcast %3 : tensor<16x1xi32, #blocked> -> tensor<16x16xi32, #blocked> loc(#loc)
-    %7 = arith.addi %5, %6 : tensor<16x16xi32, #blocked> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x16xi32, #blocked>
+    %2 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %3 = tt.expand_dims %2 {axis = 1 : i32} : tensor<16xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<16x1xi32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i32_0 = arith.constant 0 : i32
+    %cst = arith.constant dense<0> : tensor<1x16xi32, #blocked>
+    %4 = arith.addi %cst, %1 : tensor<1x16xi32, #blocked>
+    %5 = tt.broadcast %4 : tensor<1x16xi32, #blocked> -> tensor<16x16xi32, #blocked>
+    %6 = tt.broadcast %3 : tensor<16x1xi32, #blocked> -> tensor<16x16xi32, #blocked>
+    %7 = arith.addi %5, %6 : tensor<16x16xi32, #blocked>
+    tt.return
+  }
+}
 """)
 
 
@@ -877,47 +867,44 @@ def math_kernel():
     ttgl.fma(a, b, c)
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
-def test_math(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
-    h = math_kernel.warmup(sanitize_overflow=False, grid=(1, ))
+@pytest.mark.parametrize("target", ALL_TARGETS)
+def test_math(target):
+    mod = run_parser(math_kernel, target=target)
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @math_kernel() attributes {noinline = false} {
-    %cst = arith.constant 1.000000e+00 : f32 loc(#loc)
-    %cst_0 = arith.constant dense<1.000000e+00> : tensor<16x16xf32, #blocked> loc(#loc)
-    %cst_1 = arith.constant 2.000000e+00 : f32 loc(#loc)
-    %cst_2 = arith.constant dense<2.000000e+00> : tensor<16x16xf32, #blocked> loc(#loc)
-    %cst_3 = arith.constant 4.000000e+00 : f32 loc(#loc)
-    %cst_4 = arith.constant dense<4.000000e+00> : tensor<16x16xf32, #blocked> loc(#loc)
-    %c1_i32 = arith.constant 1 : i32 loc(#loc)
-    %cst_5 = arith.constant dense<1> : tensor<16x16xi32, #blocked> loc(#loc)
-    %c1_i32_6 = arith.constant 1 : i32 loc(#loc)
-    %cst_7 = arith.constant dense<1> : tensor<16x16xi32, #blocked> loc(#loc)
-    %0 = tt.mulhiui %cst_5, %cst_7 : tensor<16x16xi32, #blocked> loc(#loc)
-    %1 = math.exp %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %2 = math.exp2 %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %3 = math.log %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %4 = math.log2 %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %5 = math.cos %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %6 = math.sin %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %7 = math.sqrt %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %8 = tt.precise_sqrt %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %9 = math.rsqrt %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %10 = math.absf %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %11 = arith.divf %cst_0, %cst_2 : tensor<16x16xf32, #blocked> loc(#loc)
-    %12 = tt.precise_divf %cst_0, %cst_2 : tensor<16x16xf32, #blocked> loc(#loc)
-    %13 = math.erf %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %14 = math.floor %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %15 = math.ceil %cst_0 : tensor<16x16xf32, #blocked> loc(#loc)
-    %16 = math.fma %cst_0, %cst_2, %cst_4 : tensor<16x16xf32, #blocked> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %cst = arith.constant 1.000000e+00 : f32
+    %cst_0 = arith.constant dense<1.000000e+00> : tensor<16x16xf32, #blocked>
+    %cst_1 = arith.constant 2.000000e+00 : f32
+    %cst_2 = arith.constant dense<2.000000e+00> : tensor<16x16xf32, #blocked>
+    %cst_3 = arith.constant 4.000000e+00 : f32
+    %cst_4 = arith.constant dense<4.000000e+00> : tensor<16x16xf32, #blocked>
+    %c1_i32 = arith.constant 1 : i32
+    %cst_5 = arith.constant dense<1> : tensor<16x16xi32, #blocked>
+    %c1_i32_6 = arith.constant 1 : i32
+    %cst_7 = arith.constant dense<1> : tensor<16x16xi32, #blocked>
+    %0 = tt.mulhiui %cst_5, %cst_7 : tensor<16x16xi32, #blocked>
+    %1 = math.exp %cst_0 : tensor<16x16xf32, #blocked>
+    %2 = math.exp2 %cst_0 : tensor<16x16xf32, #blocked>
+    %3 = math.log %cst_0 : tensor<16x16xf32, #blocked>
+    %4 = math.log2 %cst_0 : tensor<16x16xf32, #blocked>
+    %5 = math.cos %cst_0 : tensor<16x16xf32, #blocked>
+    %6 = math.sin %cst_0 : tensor<16x16xf32, #blocked>
+    %7 = math.sqrt %cst_0 : tensor<16x16xf32, #blocked>
+    %8 = tt.precise_sqrt %cst_0 : tensor<16x16xf32, #blocked>
+    %9 = math.rsqrt %cst_0 : tensor<16x16xf32, #blocked>
+    %10 = math.absf %cst_0 : tensor<16x16xf32, #blocked>
+    %11 = arith.divf %cst_0, %cst_2 : tensor<16x16xf32, #blocked>
+    %12 = tt.precise_divf %cst_0, %cst_2 : tensor<16x16xf32, #blocked>
+    %13 = math.erf %cst_0 : tensor<16x16xf32, #blocked>
+    %14 = math.floor %cst_0 : tensor<16x16xf32, #blocked>
+    %15 = math.ceil %cst_0 : tensor<16x16xf32, #blocked>
+    %16 = math.fma %cst_0, %cst_2, %cst_4 : tensor<16x16xf32, #blocked>
+    tt.return
+  }
+}
 """)
 
 
@@ -948,57 +935,97 @@ def reduce_kernel(out):
     tl.store(out + ttgl.arange(0, 16, s0.type.layout), result)
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
-def test_reduce(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
-    h = reduce_kernel.warmup(MockTensor(ttgl.float32), sanitize_overflow=False, grid=(1, ))
+@pytest.mark.parametrize("target", ALL_TARGETS)
+def test_reduce(target):
+    mod = run_parser(reduce_kernel, *make_args(MockTensor(ttgl.float32)), target=target)
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["ttgir"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-#loc = loc(unknown)
-#loc1 = loc("out")
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @reduce_kernel(%out: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("out")) attributes {noinline = false} {
-    %cst = arith.constant dense<2.000000e+00> : tensor<16x16xf32, #blocked> loc(#loc)
-    %cst_0 = arith.constant dense<1.000000e+00> : tensor<16x16xf32, #blocked> loc(#loc)
-    %0 = "tt.reduce"(%cst_0) <{axis = 0 : i32}> ({
-    ^bb0(%arg1: f32 loc(unknown), %arg2: f32 loc(unknown)):
-      %12 = arith.addf %arg1, %arg2 : f32 loc(#loc)
-      tt.reduce.return %12 : f32 loc(#loc)
-    }) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    %1 = "tt.reduce"(%cst_0) <{axis = 1 : i32}> ({
-    ^bb0(%arg1: f32 loc(unknown), %arg2: f32 loc(unknown)):
-      %12 = arith.addf %arg1, %arg2 : f32 loc(#loc)
-      tt.reduce.return %12 : f32 loc(#loc)
-    }) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>> loc(#loc)
-    %2 = "tt.reduce"(%0) <{axis = 0 : i32}> ({
-    ^bb0(%arg1: f32 loc(unknown), %arg2: f32 loc(unknown)):
-      %12 = arith.maxnumf %arg1, %arg2 : f32 loc(#loc)
-      tt.reduce.return %12 : f32 loc(#loc)
-    }) : (tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32 loc(#loc)
-    %3 = ttg.convert_layout %1 : tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    %4:2 = "tt.reduce"(%cst_0, %cst) <{axis = 0 : i32}> ({
-    ^bb0(%arg1: f32 loc(unknown), %arg2: f32 loc(unknown), %arg3: f32 loc(unknown), %arg4: f32 loc(unknown)):
-      %12 = arith.addf %arg1, %arg3 : f32 loc(#loc)
-      %13 = arith.addf %arg2, %arg4 : f32 loc(#loc)
-      tt.reduce.return %12, %13 : f32, f32 loc(#loc)
-    }) : (tensor<16x16xf32, #blocked>, tensor<16x16xf32, #blocked>) -> (tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>, tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) loc(#loc)
-    %5 = tt.splat %2 : f32 -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    %6 = arith.addf %5, %3 : tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    %7 = arith.addf %6, %4#0 : tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    %8 = arith.addf %7, %4#1 : tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    %9 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    %10 = tt.splat %out : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    %11 = tt.addptr %10, %9 : tensor<16x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #blocked}>>, tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    tt.store %11, %8 : tensor<16x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
+  tt.func public @reduce_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant 1.000000e+00 : f32
+    %cst_0 = arith.constant dense<1.000000e+00> : tensor<16x16xf32, #blocked>
+    %cst_1 = arith.constant 2.000000e+00 : f32
+    %cst_2 = arith.constant dense<2.000000e+00> : tensor<16x16xf32, #blocked>
+    %0 = tt.call @"triton.language.standard.sum__fp32S16_16SLB1_1B1_32B4_1B1_0B1_1B1_1B1_0BL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cNone"(%cst_0) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %1 = tt.call @"triton.language.standard.sum__fp32S16_16SLB1_1B1_32B4_1B1_0B1_1B1_1B1_0BL__(1,)cconstexpr_1__(2,)cconstexpr_False__(3,)cNone"(%cst_0) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %2 = tt.call @"triton.language.standard.max__fp32S16SLSL0_B1_1B1_32B4_1B1_0B1_1B1_1B1_0BSLL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cconstexpr_True__(4,)cconstexpr_False_"(%0) : (tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32
+    %3 = ttg.convert_layout %1 : tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %4:2 = "tt.reduce"(%cst_0, %cst_2) <{axis = 0 : i32}> ({
+    ^bb0(%arg1: f32, %arg2: f32, %arg3: f32, %arg4: f32):
+      %12:2 = tt.call @test_frontend.pair_add__fp32_fp32_fp32_fp32__(%arg1, %arg2, %arg3, %arg4) : (f32, f32, f32, f32) -> (f32, f32)
+      tt.reduce.return %12#0, %12#1 : f32, f32
+    }) : (tensor<16x16xf32, #blocked>, tensor<16x16xf32, #blocked>) -> (tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>, tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>)
+    %5 = tt.splat %2 : f32 -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %6 = arith.addf %5, %3 : tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %7 = arith.addf %6, %4#0 : tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %8 = arith.addf %7, %4#1 : tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %9 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %10 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %11 = tt.addptr %10, %9 : tensor<16x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #blocked}>>, tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    tt.store %11, %8 : tensor<16x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #blocked}>>
+    tt.return
+  }
+  tt.func private @"triton.language.standard.sum__fp32S16_16SLB1_1B1_32B4_1B1_0B1_1B1_1B1_0BL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cNone"(%arg0: tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>> attributes {noinline = false} {
+    %0 = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %2 = tt.call @triton.language.standard._sum_combine__fp32_fp32__(%arg1, %arg2) : (f32, f32) -> f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    tt.return %0 : tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+  ^bb1:  // no predecessors
+    %1 = ub.poison : tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    tt.return %1 : tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+  }
+  tt.func private @triton.language.standard._sum_combine__fp32_fp32__(%arg0: f32, %arg1: f32) -> f32 attributes {noinline = false} {
+    %0 = arith.addf %arg0, %arg1 : f32
+    tt.return %0 : f32
+  ^bb1:  // no predecessors
+    %1 = ub.poison : f32
+    tt.return %1 : f32
+  }
+  tt.func private @"triton.language.standard.sum__fp32S16_16SLB1_1B1_32B4_1B1_0B1_1B1_1B1_0BL__(1,)cconstexpr_1__(2,)cconstexpr_False__(3,)cNone"(%arg0: tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>> attributes {noinline = false} {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %2 = tt.call @triton.language.standard._sum_combine__fp32_fp32__(%arg1, %arg2) : (f32, f32) -> f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %0 : tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  ^bb1:  // no predecessors
+    %1 = ub.poison : tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %1 : tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  }
+  tt.func private @"triton.language.standard.max__fp32S16SLSL0_B1_1B1_32B4_1B1_0B1_1B1_1B1_0BSLL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cconstexpr_True__(4,)cconstexpr_False_"(%arg0: tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32 attributes {noinline = false} {
+    %0 = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %2 = tt.call @triton.language.standard._elementwise_max__fp32_fp32__(%arg1, %arg2) : (f32, f32) -> f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32
+    tt.return %0 : f32
+  ^bb1:  // no predecessors
+    %1 = ub.poison : f32
+    tt.return %1 : f32
+  }
+  tt.func private @triton.language.standard._elementwise_max__fp32_fp32__(%arg0: f32, %arg1: f32) -> f32 attributes {noinline = false} {
+    %0 = arith.maxnumf %arg0, %arg1 : f32
+    tt.return %0 : f32
+  ^bb1:  // no predecessors
+    %1 = ub.poison : f32
+    tt.return %1 : f32
+  }
+  tt.func private @test_frontend.pair_add__fp32_fp32_fp32_fp32__(%arg0: f32, %arg1: f32, %arg2: f32, %arg3: f32) -> (f32, f32) attributes {noinline = false} {
+    %0 = arith.addf %arg0, %arg2 : f32
+    %1 = arith.addf %arg1, %arg3 : f32
+    tt.return %0, %1 : f32, f32
+  ^bb1:  // no predecessors
+    %2 = ub.poison : f32
+    %3 = ub.poison : f32
+    tt.return %2, %3 : f32, f32
+  }
+}
 """)
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 @filecheck_test
 @gluon.jit
 def test_elementwise_core():
@@ -1026,20 +1053,18 @@ def linear_layout_kernel():
     ttgl.arange(0, 256, layout=ll)
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
-def test_linear_layout(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-    h = linear_layout_kernel.warmup(grid=(1, ))
+@pytest.mark.parametrize("target", ALL_TARGETS)
+def test_linear_layout(target):
+    mod = run_parser(linear_layout_kernel, target=target)
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #linear = #ttg.linear<{register = [[1]], lane = [[2], [4], [8], [16], [32]], warp = [[64], [128]], block = []}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @linear_layout_kernel() attributes {noinline = false} {
-    %0 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #linear> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %0 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #linear>
+    tt.return
+  }
+}
 """)
 
 
@@ -1180,41 +1205,43 @@ def async_copy_kernel(inp, xnumel, XBLOCK: ttgl.constexpr):
     async_copy.wait_group(0)
 
 
-@pytest.mark.skipif(not is_ampere_or_newer(), reason="Requires ampere")
-def test_async_copy(fresh_knobs):
-    knobs.compilation.disable_line_info = True
-
-    h = async_copy_kernel.warmup(MockTensor(ttgl.float16), xnumel=100, XBLOCK=128, sanitize_overflow=False, grid=(1, ))
+@pytest.mark.parametrize("target", [AMPERE_TARGET, HOPPER_TARGET, BLACKWELL_TARGET])
+def test_async_copy(target):
+    mod = run_parser(
+        async_copy_kernel,
+        *make_args(MockTensor(ttgl.float16), xnumel=100, XBLOCK=128),
+        target=target,
+    )
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["ttgir"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-#loc1 = loc("inp")
-#loc2 = loc("xnumel")
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @async_copy_kernel(%inp: !tt.ptr<f16> {tt.divisibility = 16 : i32} loc("inp"), %xnumel: i32 loc("xnumel")) attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<128xf16, #shared, #smem, mutable> loc(#loc)
-    %1 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked> loc(#loc)
-    %2 = tt.splat %xnumel : i32 -> tensor<128xi32, #blocked> loc(#loc)
-    %3 = arith.cmpi slt, %1, %2 {tt.constancy = dense<2> : tensor<1xi32>} : tensor<128xi32, #blocked> loc(#loc)
-    %4 = tt.splat %inp : !tt.ptr<f16> -> tensor<128x!tt.ptr<f16>, #blocked> loc(#loc)
-    %5 = tt.addptr %4, %1 : tensor<128x!tt.ptr<f16>, #blocked>, tensor<128xi32, #blocked> loc(#loc)
-    %6 = ttg.async_copy_global_to_local %5, %0 : tensor<128x!tt.ptr<f16>, #blocked> -> <128xf16, #shared, #smem, mutable> loc(#loc)
-    %7 = ttg.async_copy_global_to_local %5, %0 mask %3 cacheModifier = ca evictionPolicy = evict_last {isVolatile = true} : tensor<128x!tt.ptr<f16>, #blocked> -> <128xf16, #shared, #smem, mutable> loc(#loc)
-    %8 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
-    ttng.async_copy_mbarrier_arrive %8 : !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
-    ttng.async_copy_mbarrier_arrive %8 {noIncrement} : !ttg.memdesc<1xi64, #shared, #smem, mutable> loc(#loc)
-    %9 = ttg.async_commit_group  loc(#loc)
-    %10 = ttg.async_wait  {num = 0 : i32} loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+  tt.func public @async_copy_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: i32) attributes {noinline = false} {
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<128xf16, #shared, #smem, mutable>
+    %1 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked>
+    %2 = tt.splat %arg1 : i32 -> tensor<128xi32, #blocked>
+    %3 = arith.cmpi slt, %1, %2 {tt.constancy = dense<2> : tensor<1xi32>} : tensor<128xi32, #blocked>
+    %4 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x!tt.ptr<f16>, #blocked>
+    %5 = tt.addptr %4, %1 : tensor<128x!tt.ptr<f16>, #blocked>, tensor<128xi32, #blocked>
+    %6 = ttg.async_copy_global_to_local %5, %0 : tensor<128x!tt.ptr<f16>, #blocked> -> <128xf16, #shared, #smem, mutable>
+    %7 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x!tt.ptr<f16>, #blocked>
+    %8 = tt.addptr %7, %1 : tensor<128x!tt.ptr<f16>, #blocked>, tensor<128xi32, #blocked>
+    %9 = ttg.async_copy_global_to_local %8, %0 mask %3 cacheModifier = ca evictionPolicy = evict_last {isVolatile = true} : tensor<128x!tt.ptr<f16>, #blocked> -> <128xf16, #shared, #smem, mutable>
+    %10 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.async_copy_mbarrier_arrive %10 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.async_copy_mbarrier_arrive %10 {noIncrement} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %11 = ttg.async_commit_group
+    %12 = ttg.async_wait  {num = 0 : i32}
+    tt.return
+  }
+}
 """)
 
 
-def test_split_join_subtile(fresh_knobs):
+@pytest.mark.parametrize("target", ALL_TARGETS)
+def test_split_join_subtile(target):
 
     @gluon.jit
     def kernel():
@@ -1225,28 +1252,26 @@ def test_split_join_subtile(fresh_knobs):
         y = ttgl.join(a, b).permute([0, 2, 1]).reshape([128, 128])
         _ = x + y
 
-    knobs.compilation.disable_line_info = True
-    h = kernel.warmup(grid=(1, ), sanitize_overflow=False)
+    mod = run_parser(kernel, target=target)
     expecttest.assert_expected_inline(
-        anonymize_ir(h.asm["source"]), """\
+        anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 2, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 64, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @kernel() attributes {noinline = false} {
-    %c1_i32 = arith.constant 1 : i32 loc(#loc)
-    %cst = arith.constant dense<1> : tensor<128x128xi32, #blocked> loc(#loc)
-    %0 = tt.reshape %cst : tensor<128x128xi32, #blocked> -> tensor<128x2x64xi32, #blocked1> loc(#loc)
-    %1 = tt.trans %0 {order = array<i32: 0, 2, 1>} : tensor<128x2x64xi32, #blocked1> -> tensor<128x64x2xi32, #blocked2> loc(#loc)
-    %outLHS, %outRHS = tt.split %1 : tensor<128x64x2xi32, #blocked2> -> tensor<128x64xi32, #ttg.slice<{dim = 2, parent = #blocked2}>> loc(#loc)
-    %2 = tt.join %outLHS, %outRHS : tensor<128x64xi32, #ttg.slice<{dim = 2, parent = #blocked2}>> -> tensor<128x64x2xi32, #blocked2> loc(#loc)
-    %3 = tt.trans %2 {order = array<i32: 0, 2, 1>} : tensor<128x64x2xi32, #blocked2> -> tensor<128x2x64xi32, #blocked1> loc(#loc)
-    %4 = tt.reshape %3 : tensor<128x2x64xi32, #blocked1> -> tensor<128x128xi32, #blocked> loc(#loc)
-    %5 = arith.addi %cst, %4 : tensor<128x128xi32, #blocked> loc(#loc)
-    tt.return loc(#loc)
-  } loc(#loc)
-} loc(#loc)
-#loc = loc(unknown)
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<1> : tensor<128x128xi32, #blocked>
+    %0 = tt.reshape %cst : tensor<128x128xi32, #blocked> -> tensor<128x2x64xi32, #blocked1>
+    %1 = tt.trans %0 {order = array<i32: 0, 2, 1>} : tensor<128x2x64xi32, #blocked1> -> tensor<128x64x2xi32, #blocked2>
+    %outLHS, %outRHS = tt.split %1 : tensor<128x64x2xi32, #blocked2> -> tensor<128x64xi32, #ttg.slice<{dim = 2, parent = #blocked2}>>
+    %2 = tt.join %outLHS, %outRHS : tensor<128x64xi32, #ttg.slice<{dim = 2, parent = #blocked2}>> -> tensor<128x64x2xi32, #blocked2>
+    %3 = tt.trans %2 {order = array<i32: 0, 2, 1>} : tensor<128x64x2xi32, #blocked2> -> tensor<128x2x64xi32, #blocked1>
+    %4 = tt.reshape %3 : tensor<128x2x64xi32, #blocked1> -> tensor<128x128xi32, #blocked>
+    %5 = arith.addi %cst, %4 : tensor<128x128xi32, #blocked>
+    tt.return
+  }
+}
 """)
 
 

--- a/python/triton/_filecheck.py
+++ b/python/triton/_filecheck.py
@@ -8,6 +8,7 @@ import triton
 from triton.compiler import ASTSource, make_backend
 from triton.backends.compiler import GPUTarget
 from triton.experimental.gluon._runtime import GluonASTSource
+from triton.runtime.jit import create_function_from_signature
 from triton._C.libtriton import ir
 
 # ===-----------------------------------------------------------------------===#
@@ -16,7 +17,6 @@ from triton._C.libtriton import ir
 
 # Stub target for testing the frontend.
 stub_target = GPUTarget("cuda", 100, 32)
-stub_backend = make_backend(stub_target)
 
 triton_dir = os.path.dirname(__file__)
 filecheck_path = os.path.join(triton_dir, "FileCheck")
@@ -51,24 +51,29 @@ def run_filecheck(name, module_str, check_template):
             raise ValueError(decoded)
 
 
-def run_parser(kernel_fn):
-    sigkeys = [x.name for x in kernel_fn.params]
-    sigvals = [f"arg{i}" for i in range(len(sigkeys))]
-    signature = {k: v for (k, v) in zip(sigkeys, sigvals)}
+def run_parser(kernel_fn, args=(), kwargs={}, target=stub_target):
+    if "sanitize_overflow" not in kwargs:
+        kwargs = dict(kwargs)
+        kwargs["sanitize_overflow"] = False
+    backend = make_backend(target)
+    binder = create_function_from_signature(
+        kernel_fn.signature,
+        kernel_fn.params,
+        backend,
+    )
+
+    bound_args, specialization, options = binder(*args, **kwargs)
+    options, signature, constexprs, attrs = kernel_fn._pack_args(backend, kwargs, bound_args, specialization, options)
     source_cls = GluonASTSource if kernel_fn.is_gluon() else ASTSource
-    src = source_cls(fn=kernel_fn, signature=signature)
+    src = source_cls(kernel_fn, signature, constexprs, attrs)
 
     context = ir.context()
     ir.load_dialects(context)
-    stub_backend.load_dialects(context)
+    backend.load_dialects(context)
 
-    options = dict(sanitize_overflow=False)
-    options.update(src.parse_options())
-
-    options = stub_backend.parse_options(options)
-    codegen_fns = stub_backend.get_codegen_implementation(options)
-    module_map = stub_backend.get_module_map()
-    module = src.make_ir(stub_target, options, codegen_fns, module_map, context)
+    codegen_fns = backend.get_codegen_implementation(options)
+    module_map = backend.get_module_map()
+    module = src.make_ir(target, options, codegen_fns, module_map, context)
     assert module.verify()
     return module
 

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -547,6 +547,30 @@ class JITFunction(KernelInterface[T]):
         binder = create_function_from_signature(self.signature, self.params, backend)
         return {}, target, backend, binder
 
+    def _pack_args(self, backend, kwargs, bound_args, specialization, options):
+        # options
+        options = backend.parse_options(kwargs)
+        # signature
+        sigkeys = [x.name for x in self.params]
+        sigvals = [x[0] for x in specialization]
+        signature = {k: v for (k, v) in zip(sigkeys, sigvals)}
+        # check arguments
+        assert "device_type" not in kwargs, "device_type option is deprecated; current target will be used"
+        assert "device" not in kwargs, "device option is deprecated; current device will be used"
+        assert "stream" not in kwargs, "stream option is deprecated; current stream will be used"
+        for k in kwargs:
+            if k not in options.__dict__ and k not in sigkeys:
+                raise KeyError("Keyword argument %s was specified but unrecognised" % k)
+        # constexprs
+        constexprs = find_paths_if(sigvals, lambda _, val: val == "constexpr")
+        constexprs = {path: get_iterable_path(list(bound_args.values()), path) for path in constexprs}
+        # attributes
+        attrvals = [x[1] for x in specialization]
+        attrs = find_paths_if(attrvals, lambda _, x: isinstance(x, str))
+        attrs = {k: backend.parse_attr(get_iterable_path(attrvals, k)) for k in attrs}
+
+        return options, signature, constexprs, attrs
+
     def run(self, *args, grid, warmup, **kwargs):
         kwargs["debug"] = kwargs.get("debug", self.debug) or knobs.runtime.debug
 
@@ -569,26 +593,8 @@ class JITFunction(KernelInterface[T]):
 
         # Kernel is not cached; we have to compile.
         if kernel is None:
-            # options
-            options = backend.parse_options(kwargs)
-            # signature
-            sigkeys = [x.name for x in self.params]
-            sigvals = [x[0] for x in specialization]
-            signature = {k: v for (k, v) in zip(sigkeys, sigvals)}
-            # check arguments
-            assert "device_type" not in kwargs, "device_type option is deprecated; current target will be used"
-            assert "device" not in kwargs, "device option is deprecated; current device will be used"
-            assert "stream" not in kwargs, "stream option is deprecated; current stream will be used"
-            for k in kwargs:
-                if k not in options.__dict__ and k not in sigkeys:
-                    raise KeyError("Keyword argument %s was specified but unrecognised" % k)
-            # constexprs
-            constexprs = find_paths_if(sigvals, lambda _, val: val == "constexpr")
-            constexprs = {path: get_iterable_path(list(bound_args.values()), path) for path in constexprs}
-            # attributes
-            attrvals = [x[1] for x in specialization]
-            attrs = find_paths_if(attrvals, lambda _, x: isinstance(x, str))
-            attrs = {k: backend.parse_attr(get_iterable_path(attrvals, k)) for k in attrs}
+            options, signature, constexprs, attrs = self._pack_args(backend, kwargs, bound_args, specialization,
+                                                                    options)
 
             kernel = self._do_compile(key, signature, device, constexprs, options, attrs, warmup)
             if kernel is None:


### PR DESCRIPTION
This changes all gluon frontend tests to use `run_parser`. To achieve this, I also expand `run_parser` to support kernel arguments and non-blackwell targets.

This also allows us to test with the gfx1200 hip target which also has 32 threads per warp.

Closes #7667