### PR TITLE
[ConSan] Support for WGMMA. Checks on non-async shmem and tmem accesses

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentAttrDefs.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentAttrDefs.td
@@ -6,8 +6,8 @@ include "mlir/IR/EnumAttr.td"
 def TT_MemTypeAttr : I32EnumAttr<
     "MemType", "",
     [
-        I32EnumAttrCase<"SHARED", 0, "shared">,
-        I32EnumAttrCase<"TENSOR", 1, "tensor">,
+        I32EnumAttrCase<"SHARED_MEM", 0, "shared_mem">,
+        I32EnumAttrCase<"TENSOR_MEM", 1, "tensor_mem">,
     ]> {
     let cppNamespace = "::mlir::triton::instrument";
 }

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -227,69 +227,70 @@ def TTI_ExperimentalCheckBarrierWritesClearedOp : TTI_Op<"experimental_check_bar
 
 
 // TODO: Potentially resolve the naming/functionality clash with commit_write_with_barrier
-def TTI_ExperimentalStageWriteForCommitOp : TTI_Op<"experimental_stage_write_for_commit", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
-  let summary = "Preapre to an async copy of a buffer. Staged until commit_group is called.";
+def TTI_ExperimentalStageAccessForCommitOp : TTI_Op<"experimental_stage_access_for_commit", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "";
   let description = [{
-    Preapre to an async copy of a buffer. Staged until commit_group is called. The implementation will write `-1` to the
-    `write_commits` tensor under the indices corresponding to the buffer.
+    For operations that use `outstanding` to track the number of outstanding commits (rather than mbarriers),
+    mark the buffer as being accessed, but not commited yet, by marking it with `-1`.
   }];
   let arguments = (ins
     TTG_MemDescType:$buf,
     TT_Tensor:$buffers,
-    TT_PtrLike:$writeCommits,
-    TypeAttr:$writeCommitsType,
+    TT_PtrLike:$outstandingCommits,
+    TypeAttr:$outstandingCommitsType,
     Optional<I1>:$pred
   );
   let assemblyFormat = [{
-    $buf `{` $buffers `,` $writeCommits `(` $writeCommitsType `)` `}` (`,` $pred^)? attr-dict `:` type($buf) `,` type($buffers) `,` type($writeCommits)
+    $buf `{` $buffers `,` $outstandingCommits `(` $outstandingCommitsType `)` `}` (`,` $pred^)? attr-dict `:` type($buf) `,` type($buffers) `,` type($outstandingCommits)
   }];
   // let hasVerifier = 1;
 }
 
-def TTI_ExperimentalCommitWritesOp : TTI_Op<"experimental_commit_writes", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
-  let summary = "Commit all the staged writes for all the buffers.";
+def TTI_ExperimentalCommitAccessesOp : TTI_Op<"experimental_commit_accesses", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "Commit all the staged accesses for all the buffers.";
   let description = [{
-    Commit all the staged writes for all the buffers.
+    Commit all the staged accesses for all the buffers.
   }];
   let arguments = (ins
-    TT_PtrLike:$writeCommits,
-    TypeAttr:$writeCommitsType,
+    TT_PtrLike:$outstandingCommits,
+    TypeAttr:$outstandingCommitsType,
     Optional<I1>:$pred);
   let assemblyFormat = [{
-    `{` $writeCommits `(` $writeCommitsType `)` `}` (`,` $pred^)? attr-dict `:` type($writeCommits)
+    `{` $outstandingCommits `(` $outstandingCommitsType `)` `}` (`,` $pred^)? attr-dict `:` type($outstandingCommits)
   }];
   // let hasVerifier = 1;
 }
 
-def TTI_ExperimentalClearWriteCommitsOp : TTI_Op<"experimental_clear_write_commits", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
-  let summary = "Clear all the write commits more distant than `outstandingNum.";
+def TTI_ExperimentalClearOutstandingCommitsOp : TTI_Op<"experimental_clear_outstanding_commits", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "Clear all the outstanding commits more distant than `outstandingNum.";
   let description = [{
-    Clear all the write commits more distant than `outstandingNum` from the current thread.
+    Clear all the outstanding commits more distant than `outstandingNum` from the current thread.
   }];
   let arguments = (ins
-    TT_PtrLike:$writeCommits,
-    TypeAttr:$writeCommitsType,
+    TT_PtrLike:$outstandingCommits,
+    TypeAttr:$outstandingCommitsType,
     I32Attr:$outstandingNum,
     Optional<I1>:$pred);
   let assemblyFormat = [{
-    `{` $writeCommits `(` $writeCommitsType `)` `}` `,` $outstandingNum (`,` $pred^)? attr-dict `:` type($writeCommits)
+    `{` $outstandingCommits `(` $outstandingCommitsType `)` `}` `,` $outstandingNum (`,` $pred^)? attr-dict `:` type($outstandingCommits)
   }];
   // let hasVerifier = 1;
 }
 
-def TTI_ExperimentalCheckWriteCommitOp : TTI_Op<"experimental_check_write_commit", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
-  let summary = "Check if the buffer has an outstanding write commit.";
+def TTI_ExperimentalCheckOutstandingCommitsOp : TTI_Op<"experimental_check_outstanding_commits", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "Check if the buffer has an outstanding commit.";
   let description = [{
-    Check if the buffer has an outstanding write commit.
+    Check if the buffer has an outstanding commit.
   }];
   let arguments = (ins
     TTG_MemDescType:$buf,
     TT_Tensor:$buffers,
-    TT_PtrLike:$writeCommits,
-    TypeAttr:$writeCommitsType,
+    TT_PtrLike:$outstandingCommits,
+    TypeAttr:$outstandingCommitsType,
+    StrAttr:$pendingAccessType,
     Optional<I1>:$pred);
   let assemblyFormat = [{
-    $buf `{` $buffers `,` $writeCommits `(` $writeCommitsType `)` `}` (`,` $pred^)? attr-dict `:` type($buf) `,` type($buffers) `,` type($writeCommits)
+    $buf `{` $buffers `,` $outstandingCommits `(` $outstandingCommitsType `)` `}` `,` $pendingAccessType (`,` $pred^)? attr-dict `:` type($buf) `,` type($buffers) `,` type($outstandingCommits)
   }];
   // let hasVerifier = 1;
 }

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -47,7 +47,7 @@ def TTI_ExperimentalBufferPointersOp : TTI_Op<"experimental_buffer_pointers", [P
 }
 
 
-def TTI_ExperimentalCheckOutstandingWritesOp : TTI_Op<"experimental_check_outstanding_writes", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+def TTI_ExperimentalCheckWriteStateOp : TTI_Op<"experimental_check_write_state", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "check if there are outstanding writes to a buffer guarded by a mbar";
   let description = [{
     Check if the writeState tensor has non-zero value associated with the buffer.
@@ -76,7 +76,7 @@ def TTI_ExperimentalCheckOutstandingWritesOp : TTI_Op<"experimental_check_outsta
 }
 
 
-def TTI_ExperimentalCheckOutstandingReadsOp : TTI_Op<"experimental_check_outstanding_reads", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+def TTI_ExperimentalCheckReadBarriersOp : TTI_Op<"experimental_check_read_barriers", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "check if there are outstanding reads from a buffer guarded by a mbar";
   let description = [{
     Check if there are outstanding reads from a buffer guarded by a mbar.
@@ -95,8 +95,8 @@ def TTI_ExperimentalCheckOutstandingReadsOp : TTI_Op<"experimental_check_outstan
 }
 
 
-def TTI_ExperimentalMarkAsWriteOp : TTI_Op<"experimental_mark_as_write", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
-  let summary = "mark a buffer as being written to using mbar as a guard";
+def TTI_ExperimentalSetWriteStateOp : TTI_Op<"experimental_set_write_state", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "mark a buffer as being written in writeState tensor";
   let description = [{
     Mark a buffer as being written to. It is not yet tracked by a barrier, until
     `commit_write_with_barrier` is called, at which point all the buffers being written
@@ -226,7 +226,6 @@ def TTI_ExperimentalCheckBarrierWritesClearedOp : TTI_Op<"experimental_check_bar
 }
 
 
-// TODO: Potentially resolve the naming/functionality clash with commit_write_with_barrier
 def TTI_ExperimentalStageAccessForCommitOp : TTI_Op<"experimental_stage_access_for_commit", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "";
   let description = [{
@@ -243,7 +242,7 @@ def TTI_ExperimentalStageAccessForCommitOp : TTI_Op<"experimental_stage_access_f
   let assemblyFormat = [{
     $buf `{` $buffers `,` $outstandingCommits `(` $outstandingCommitsType `)` `}` (`,` $pred^)? attr-dict `:` type($buf) `,` type($buffers) `,` type($outstandingCommits)
   }];
-  // let hasVerifier = 1;
+  let hasVerifier = 1;
 }
 
 def TTI_ExperimentalCommitAccessesOp : TTI_Op<"experimental_commit_accesses", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
@@ -258,7 +257,6 @@ def TTI_ExperimentalCommitAccessesOp : TTI_Op<"experimental_commit_accesses", [M
   let assemblyFormat = [{
     `{` $outstandingCommits `(` $outstandingCommitsType `)` `}` (`,` $pred^)? attr-dict `:` type($outstandingCommits)
   }];
-  // let hasVerifier = 1;
 }
 
 def TTI_ExperimentalClearOutstandingCommitsOp : TTI_Op<"experimental_clear_outstanding_commits", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
@@ -274,7 +272,6 @@ def TTI_ExperimentalClearOutstandingCommitsOp : TTI_Op<"experimental_clear_outst
   let assemblyFormat = [{
     `{` $outstandingCommits `(` $outstandingCommitsType `)` `}` `,` $outstandingNum (`,` $pred^)? attr-dict `:` type($outstandingCommits)
   }];
-  // let hasVerifier = 1;
 }
 
 def TTI_ExperimentalCheckOutstandingCommitsOp : TTI_Op<"experimental_check_outstanding_commits", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
@@ -292,7 +289,7 @@ def TTI_ExperimentalCheckOutstandingCommitsOp : TTI_Op<"experimental_check_outst
   let assemblyFormat = [{
     $buf `{` $buffers `,` $outstandingCommits `(` $outstandingCommitsType `)` `}` `,` $pendingAccessType (`,` $pred^)? attr-dict `:` type($buf) `,` type($buffers) `,` type($outstandingCommits)
   }];
-  // let hasVerifier = 1;
+  let hasVerifier = 1;
 }
 
 #endif // TRITONINSTRUMENT_OPS

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -146,7 +146,7 @@ def TTI_ExperimentalCommitWriteWithBarrierOp : TTI_Op<"experimental_commit_write
 }
 
 
-def TTI_ExperimentalMarkAsReadOp : TTI_Op<"experimental_mark_as_read", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+def TTI_ExperimentalSetReadBarrierOp : TTI_Op<"experimental_set_read_barrier", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "mark a buffer as being read from using mbar as a guard";
   let description = [{
     Mark a buffer as being read from using mbar as a guard.

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -237,11 +237,11 @@ struct BufferPointersOpConversion
     auto bufPointers =
         createInitializedIntArrayTensor(rewriter, loc, encoding, values);
     Value base = nullptr;
-    if (op.getMemType() == tti::MemType::SHARED) {
+    if (op.getMemType() == tti::MemType::SHARED_MEM) {
       base = getSharedMemoryBase(rewriter,
                                  op->getParentOfType<FunctionOpInterface>());
     } else {
-      assert(op.getMemType() == tti::MemType::TENSOR &&
+      assert(op.getMemType() == tti::MemType::TENSOR_MEM &&
              "Unsupported memory type");
       TritonLLVMOpBuilder b(loc, rewriter);
       base = rewriter.create<nvgpu::TensorMemoryBaseAddress>(loc);

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -279,11 +279,11 @@ struct BufferPointersOpConversion
   }
 };
 
-struct CheckOutstandingWritesOpConversion
-    : public ConvertOpToLLVMPattern<tti::ExperimentalCheckOutstandingWritesOp> {
+struct CheckWriteStateOpConversion
+    : public ConvertOpToLLVMPattern<tti::ExperimentalCheckWriteStateOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
-  LogicalResult matchAndRewrite(tti::ExperimentalCheckOutstandingWritesOp op,
+  LogicalResult matchAndRewrite(tti::ExperimentalCheckWriteStateOp op,
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &b) const override {
     Location loc = op.getLoc();
@@ -327,11 +327,11 @@ struct CheckOutstandingWritesOpConversion
   }
 };
 
-struct CheckOutstandingReadsOpConversion
-    : public ConvertOpToLLVMPattern<tti::ExperimentalCheckOutstandingReadsOp> {
+struct CheckReadBarriersOpConversion
+    : public ConvertOpToLLVMPattern<tti::ExperimentalCheckReadBarriersOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
-  LogicalResult matchAndRewrite(tti::ExperimentalCheckOutstandingReadsOp op,
+  LogicalResult matchAndRewrite(tti::ExperimentalCheckReadBarriersOp op,
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &b) const override {
     Location loc = op.getLoc();
@@ -375,11 +375,11 @@ struct CheckOutstandingReadsOpConversion
   }
 };
 
-struct MarkAsWriteOpConversion
-    : public ConvertOpToLLVMPattern<tti::ExperimentalMarkAsWriteOp> {
+struct SetWriteStateOpConversion
+    : public ConvertOpToLLVMPattern<tti::ExperimentalSetWriteStateOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
-  LogicalResult matchAndRewrite(tti::ExperimentalMarkAsWriteOp op,
+  LogicalResult matchAndRewrite(tti::ExperimentalSetWriteStateOp op,
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &b) const override {
     Location loc = op.getLoc();
@@ -473,11 +473,11 @@ struct CommitWriteWithBarrierOpConversion
   }
 };
 
-struct MarkAsReadOpConversion
-    : public ConvertOpToLLVMPattern<tti::ExperimentalMarkAsReadOp> {
+struct SetReadBarrierOpConversion
+    : public ConvertOpToLLVMPattern<tti::ExperimentalSetReadBarrierOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
-  LogicalResult matchAndRewrite(tti::ExperimentalMarkAsReadOp op,
+  LogicalResult matchAndRewrite(tti::ExperimentalSetReadBarrierOp op,
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &b) const override {
     Location loc = op.getLoc();
@@ -891,11 +891,11 @@ void mlir::triton::populateInstrumentationToLLVMPatterns(
     RewritePatternSet &patterns, PatternBenefit benefit) {
   patterns.add<AssertInThreadOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<BufferPointersOpConversion>(typeConverter);
-  patterns.add<CheckOutstandingWritesOpConversion>(typeConverter);
-  patterns.add<CheckOutstandingReadsOpConversion>(typeConverter);
-  patterns.add<MarkAsWriteOpConversion>(typeConverter);
+  patterns.add<CheckWriteStateOpConversion>(typeConverter);
+  patterns.add<CheckReadBarriersOpConversion>(typeConverter);
+  patterns.add<SetWriteStateOpConversion>(typeConverter);
   patterns.add<CommitWriteWithBarrierOpConversion>(typeConverter);
-  patterns.add<MarkAsReadOpConversion>(typeConverter);
+  patterns.add<SetReadBarrierOpConversion>(typeConverter);
   patterns.add<ClearWriteBarrierOpConversion>(typeConverter);
   patterns.add<ClearReadBarrierOpConversion>(typeConverter);
   patterns.add<CheckBarrierWritesClearedOpConversion>(typeConverter);

--- a/lib/Dialect/TritonInstrument/IR/Ops.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Ops.cpp
@@ -26,7 +26,7 @@ bool verifyBarsEncoding(RankedTensorType readBarsType) {
 
 namespace mlir::triton::instrument {
 
-LogicalResult ExperimentalCheckOutstandingWritesOp::verify() {
+LogicalResult ExperimentalCheckWriteStateOp::verify() {
   auto writeStateType = cast<RankedTensorType>(getWriteStateType());
   auto buffersType = getBuffers().getType();
   if (writeStateType.getShape() != buffersType.getShape() ||
@@ -44,7 +44,7 @@ LogicalResult ExperimentalCheckOutstandingWritesOp::verify() {
   return success();
 }
 
-LogicalResult ExperimentalCheckOutstandingReadsOp::verify() {
+LogicalResult ExperimentalCheckReadBarriersOp::verify() {
   auto readBarsType = cast<RankedTensorType>(getReadBarsType());
   auto buffersType = getBuffers().getType();
   // readBars is 2D tensor of shape [num_buffers, num_barriers]
@@ -57,7 +57,7 @@ LogicalResult ExperimentalCheckOutstandingReadsOp::verify() {
   return success();
 }
 
-LogicalResult ExperimentalMarkAsWriteOp::verify() {
+LogicalResult ExperimentalSetWriteStateOp::verify() {
   auto buffersType = getBuffers().getType();
   auto writeStateType = cast<RankedTensorType>(getWriteStateType());
   if (writeStateType.getShape() != buffersType.getShape() ||
@@ -82,7 +82,7 @@ LogicalResult ExperimentalCommitWriteWithBarrierOp::verify() {
   return success();
 }
 
-LogicalResult ExperimentalMarkAsReadOp::verify() {
+LogicalResult ExperimentalSetReadBarrierOp::verify() {
   auto buffersType = getBuffers().getType();
   auto barriersType = getBarriers().getType();
   auto readBarsType = cast<RankedTensorType>(getReadBarsType());
@@ -129,6 +129,26 @@ LogicalResult ExperimentalCheckBarrierWritesClearedOp::verify() {
   auto barriersType = getBarriers().getType();
   if (writeBarsType.getShape()[1] != barriersType.getShape()[0])
     return emitError() << "writeBars dim 1 must match number of barriers";
+  return success();
+}
+
+LogicalResult ExperimentalStageAccessForCommitOp::verify() {
+  auto buffersType = getBuffers().getType();
+  auto outstandingCommitsType =
+      cast<RankedTensorType>(getOutstandingCommitsType());
+  if (buffersType.getShape()[0] != outstandingCommitsType.getShape()[0])
+    return emitError()
+           << "buffers and outstandingCommits must have the same size";
+  return success();
+}
+
+LogicalResult ExperimentalCheckOutstandingCommitsOp::verify() {
+  auto buffersType = getBuffers().getType();
+  auto outstandingCommitsType =
+      cast<RankedTensorType>(getOutstandingCommitsType());
+  if (buffersType.getShape()[0] != outstandingCommitsType.getShape()[0])
+    return emitError()
+           << "buffers and outstandingCommits must have the same size";
   return success();
 }
 

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -279,7 +279,7 @@ private:
   void addWriteChecks(ImplicitLocOpBuilder &b, Value buf, Value pred,
                       MemType memType, bool hwPipelined) {
     if (barriers) {
-      b.create<tti::ExperimentalCheckOutstandingWritesOp>(
+      b.create<tti::ExperimentalCheckWriteStateOp>(
           buf, buffersTensor[(int)memType], writeBarriersAlloc[(int)memType],
           writeBarriersType[(int)memType], writeStateAlloc[(int)memType],
           writeStateType[(int)memType], hwPipelined, pred);
@@ -295,7 +295,7 @@ private:
   void addReadChecks(ImplicitLocOpBuilder &b, Value buf, Value pred,
                      MemType memType) {
     if (barriers) {
-      b.create<tti::ExperimentalCheckOutstandingReadsOp>(
+      b.create<tti::ExperimentalCheckReadBarriersOp>(
           buf, buffersTensor[(int)memType], readBarriersAlloc[(int)memType],
           readBarriersType[(int)memType], pred);
     }
@@ -443,7 +443,7 @@ private:
                   if (pred && effect.pred) {
                     pred = b.create<arith::AndIOp>(effect.pred, pred);
                   }
-                  b.create<tti::ExperimentalMarkAsReadOp>(
+                  b.create<tti::ExperimentalSetReadBarrierOp>(
                       buf, barrier, buffersTensor[(int)memType], barriers,
                       readBarriersAlloc[(int)memType],
                       readBarriersType[(int)memType], pred);
@@ -479,7 +479,7 @@ private:
                     buf, buffersTensor[(int)memType], asyncCpCommitsAlloc,
                     asyncCpCommitsType, effect.pred);
               } else {
-                b.create<tti::ExperimentalMarkAsWriteOp>(
+                b.create<tti::ExperimentalSetWriteStateOp>(
                     buf, buffersTensor[(int)memType],
                     writeStateAlloc[(int)memType], writeStateType[(int)memType],
                     effect.hwPipelined, effect.pred);

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -6,6 +6,7 @@ from triton import knobs
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia import blackwell
+from triton.experimental.gluon.language.nvidia import hopper
 from triton.experimental.gluon.language.nvidia import ampere
 from triton.experimental.gluon.language.nvidia.blackwell import mbarrier, tma
 from triton._internal_testing import is_cuda
@@ -196,7 +197,7 @@ def test_async_copy(FAILURE, device, run_wrapper):
         result = run_in_process(test_async_copy, (FAILURE, device, False))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
-            assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+            assert "Accessing buffer with pending access. Pending access type: async_copy_global_to_shared" in result.driver_stderr_output
         else:
             assert result.exc is None
             assert result.driver_stderr_output == ""
@@ -236,6 +237,8 @@ def tcgen5_mma_kernel(input_desc, XBLOCK: ttgl.constexpr, FAILURE: ttgl.constexp
         mbarrier.expect(bar.index(1), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
         tma.async_copy_global_to_shared(input_desc, [0, 0], bar.index(1), smemA)
         mbarrier.wait(bar.index(1), 0)
+    elif MEM_ACCESS_KIND == "local_store":
+        smemA.store(ttgl.full([XBLOCK, XBLOCK], 42, ttgl.float16, blocked_layout))
     elif MEM_ACCESS_KIND == "tmem_load":
         res = acc.load(blocked_layout)
         smemAcc = ttgl.allocate_shared_memory(ttgl.float32, [XBLOCK, XBLOCK], input_desc.layout, res)
@@ -250,7 +253,7 @@ def tcgen5_mma_kernel(input_desc, XBLOCK: ttgl.constexpr, FAILURE: ttgl.constexp
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-@pytest.mark.parametrize("MEM_ACCESS_KIND", ["tma_cp", "tmem_load", "tmem_store"])
+@pytest.mark.parametrize("MEM_ACCESS_KIND", ["tma_cp", "local_store", "tmem_load", "tmem_store"])
 def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, run_wrapper):
     if run_wrapper:
         result = run_in_process(test_tcgen5_mma, (FAILURE, MEM_ACCESS_KIND, device, False))
@@ -306,6 +309,100 @@ def tcgen5_mma_multibar_kernel(input_desc, XBLOCK: ttgl.constexpr, BUF_IDX: ttgl
 
     for i in range(4):
         mbarrier.invalidate(bar.index(i))
+
+
+@gluon.jit
+def warpgroup_mma_kernel(input, XBLOCK: ttgl.constexpr, FAILURE: ttgl.constexpr):
+    smem_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    smemA = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], smem_layout)
+    smemB = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], smem_layout)
+
+    blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1],
+                                                        warps_per_cta=[4, 1], order=[0, 1])
+
+    acc_layout: ttgl.constexpr = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=[4, 1],
+                                                             instr_shape=[16, 32, 16])
+    acc = ttgl.zeros([XBLOCK, XBLOCK], ttgl.float16, acc_layout)
+    acc = hopper.warpgroup_mma(smemA, smemB, acc, is_async=True)
+    if FAILURE:
+        smemA.store(ttgl.full([XBLOCK, XBLOCK], 42, ttgl.float16, blocked_layout))
+    hopper.warpgroup_mma_wait(num_outstanding=0, deps=[acc])
+    smemA.store(ttgl.full([XBLOCK, XBLOCK], 42, ttgl.float16, blocked_layout))
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] != 9, reason="Requires hopper")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_warpgroup_mma(FAILURE, device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_warpgroup_mma, (FAILURE, device, False))
+        if FAILURE:
+            assert "device-side assert" in str(result.exc)
+            assert "Accessing buffer with pending access. Pending access type: warpgroup_mma operand read" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    XBLOCK = 128
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    warpgroup_mma_kernel[(1, )](input, XBLOCK, FAILURE=FAILURE)
+
+
+@gluon.jit
+def warpgroup_mma_kernel2(input, XBLOCK: ttgl.constexpr, FAILURE: ttgl.constexpr):
+    smem_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    smemA = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], smem_layout)
+    smemB = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], smem_layout)
+
+    blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1],
+                                                        warps_per_cta=[4, 1], order=[0, 1])
+
+    acc_layout: ttgl.constexpr = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=[4, 1],
+                                                             instr_shape=[16, 32, 16])
+    acc = ttgl.zeros([XBLOCK, XBLOCK], ttgl.float16, acc_layout)
+    acc = hopper.warpgroup_mma(smemA, smemB, acc, is_async=True)
+    acc = hopper.warpgroup_mma(smemA, smemB, acc, is_async=True)
+    hopper.warpgroup_mma_wait(num_outstanding=1, deps=[acc])
+    if FAILURE:
+        smemA.store(ttgl.full([XBLOCK, XBLOCK], 42, ttgl.float16, blocked_layout))
+    hopper.warpgroup_mma_wait(num_outstanding=0, deps=[acc])
+    smemA.store(ttgl.full([XBLOCK, XBLOCK], 42, ttgl.float16, blocked_layout))
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] != 9, reason="Requires hopper")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_warpgroup_mma2(FAILURE, device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_warpgroup_mma2, (FAILURE, device, False))
+        if FAILURE:
+            assert "device-side assert" in str(result.exc)
+            assert "Accessing buffer with pending access. Pending access type: warpgroup_mma operand read" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    XBLOCK = 128
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    warpgroup_mma_kernel[(1, )](input, XBLOCK, FAILURE=FAILURE)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
@@ -457,3 +554,85 @@ def test_multibuffered_loop(FAILURE, device, run_wrapper):
     shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
     input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
     multibuffered_loop_tma_kernel[(1, )](input_desc, XBLOCK, FAILURE=FAILURE, num_warps=4)
+
+
+@gluon.jit
+def multibuffered_loop_wgmma_kernel(input_desc, XBLOCK: ttgl.constexpr, FAILURE: ttgl.constexpr):
+    num_buffers: ttgl.constexpr = 2 if FAILURE else 3
+
+    mma_layout: ttgl.constexpr = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=[4, 1],
+                                                             instr_shape=[16, 32, 16])
+    acc = ttgl.zeros([XBLOCK, XBLOCK], ttgl.float32, mma_layout)
+
+    smemA = ttgl.allocate_shared_memory(ttgl.float16, [num_buffers, XBLOCK, XBLOCK], input_desc.layout)
+    smemB = ttgl.allocate_shared_memory(ttgl.float16, [num_buffers, XBLOCK, XBLOCK], input_desc.layout)
+    barLoadA = ttgl.allocate_shared_memory(ttgl.int64, [num_buffers, 1], mbarrier.MBarrierLayout())
+    barLoadB = ttgl.allocate_shared_memory(ttgl.int64, [num_buffers, 1], mbarrier.MBarrierLayout())
+    for i in range(num_buffers):
+        mbarrier.init(barLoadA.index(i), count=1)
+        mbarrier.init(barLoadB.index(i), count=1)
+
+    phase = 0
+    ins_id = 0
+    ext_id = 0
+
+    # ins_id = 0
+    mbarrier.expect(barLoadA.index(ins_id), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+    tma.async_copy_global_to_shared(input_desc, [0, 0], barLoadA.index(ins_id), smemA.index(ins_id))
+
+    mbarrier.expect(barLoadB.index(ins_id), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+    tma.async_copy_global_to_shared(input_desc, [0, 0], barLoadB.index(ins_id), smemB.index(ins_id))
+    ins_id = inc_mod(ins_id, num_buffers)
+
+    # ins_id = 1
+    ub = 10
+    for i in range(ub):
+        if i < ub - 1:
+            mbarrier.expect(barLoadA.index(ins_id), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+            tma.async_copy_global_to_shared(input_desc, [0, 0], barLoadA.index(ins_id), smemA.index(ins_id))
+
+            mbarrier.expect(barLoadB.index(ins_id), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+            tma.async_copy_global_to_shared(input_desc, [0, 0], barLoadB.index(ins_id), smemB.index(ins_id))
+            ins_id = inc_mod(ins_id, num_buffers)
+
+        mbarrier.wait(barLoadA.index(ext_id), phase)
+        mbarrier.wait(barLoadB.index(ext_id), phase)
+
+        acc = hopper.warpgroup_mma(smemA.index(ext_id), smemB.index(ext_id), acc, is_async=True)
+        hopper.warpgroup_mma_wait(num_outstanding=1, deps=[acc])
+        ext_id = inc_mod(ext_id, num_buffers)
+        if ext_id == 0:
+            phase = (phase + 1) % 2
+    hopper.warpgroup_mma_wait(num_outstanding=0, deps=[acc])
+
+    for i in range(num_buffers):
+        mbarrier.invalidate(barLoadA.index(i))
+        mbarrier.invalidate(barLoadB.index(i))
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] != 9, reason="Requires hopper")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_multibuffered_wgmma_loop(FAILURE, device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_multibuffered_wgmma_loop, (FAILURE, device, False))
+        if FAILURE:
+            assert "device-side assert" in str(result.exc)
+            assert "Accessing buffer with pending access. Pending access type: warpgroup_mma operand read" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+    XBLOCK = 128
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK, XBLOCK], shared_layout)
+    multibuffered_loop_wgmma_kernel[(1, )](input_desc, XBLOCK, FAILURE=FAILURE, num_warps=4)

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -34,9 +34,9 @@ tt.func private @experimental_buffer_pointers_shared() {
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @experimental_check_outstanding_writes
+// CHECK-LABEL: @experimental_check_write_state
 // CHECK: @__assertfail
-tt.func private @experimental_check_outstanding_writes(
+tt.func private @experimental_check_write_state(
   %buf: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
   %buffers: tensor<2xi64, #blocked>,
   %barriers: tensor<4xi64, #blocked1>,
@@ -44,7 +44,7 @@ tt.func private @experimental_check_outstanding_writes(
   %writeState: !tt.ptr<i8>,
   %readBars: !tt.ptr<i8>
 ) {
-  tti.experimental_check_outstanding_writes %buf {%buffers, %writeBars(tensor<2x4xi8, #blocked2>), %writeState(tensor<2xi8, #blocked>)} pipelined false : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i8>, !tt.ptr<i8>
+  tti.experimental_check_write_state %buf {%buffers, %writeBars(tensor<2x4xi8, #blocked2>), %writeState(tensor<2xi8, #blocked>)} pipelined false : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i8>, !tt.ptr<i8>
   tt.return
 }
 }
@@ -58,14 +58,14 @@ tt.func private @experimental_check_outstanding_writes(
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @experimental_check_outstanding_reads
+// CHECK-LABEL: @experimental_check_read_barriers
 // CHECK: @__assertfail
-tt.func private @experimental_check_outstanding_reads(
+tt.func private @experimental_check_read_barriers(
   %buf: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
   %buffers: tensor<2xi64, #blocked>,
   %readBars: !tt.ptr<i8>
 ) {
-  tti.experimental_check_outstanding_reads %buf {%buffers, %readBars(tensor<2x2xi8, #blocked2>)} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i8>
+  tti.experimental_check_read_barriers %buf {%buffers, %readBars(tensor<2x2xi8, #blocked2>)} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i8>
   tt.return
 }
 }
@@ -79,9 +79,9 @@ tt.func private @experimental_check_outstanding_reads(
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @experimental_mark_as_write
+// CHECK-LABEL: @experimental_set_write_state
 // CHECK: st.global
-tt.func private @experimental_mark_as_write(
+tt.func private @experimental_set_write_state(
   %buf: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
   %buffers: tensor<2xi64, #blocked>,
   %barriers: tensor<4xi64, #blocked1>,
@@ -89,7 +89,7 @@ tt.func private @experimental_mark_as_write(
   %writeState: !tt.ptr<i8>,
   %readBars: !tt.ptr<i8>
 ) {
-  tti.experimental_mark_as_write %buf {%buffers, %writeState(tensor<2xi8, #blocked>)} pipelined false : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i8>
+  tti.experimental_set_write_state %buf {%buffers, %writeState(tensor<2xi8, #blocked>)} pipelined false : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i8>
   tt.return
 }
 }
@@ -153,16 +153,16 @@ tt.func private @experimental_commit_write_with_barrier(
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @experimental_mark_as_read
+// CHECK-LABEL: @experimental_set_read_barrier
 // CHECK: st.global
-tt.func private @experimental_mark_as_read(
+tt.func private @experimental_set_read_barrier(
   %buf: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
   %mbar: !ttg.memdesc<1xi64, #shared1, #smem, mutable>,
   %buffers: tensor<2xi64, #blocked>,
   %barriers: tensor<2xi64, #blocked>,
   %readBars: !tt.ptr<i8>
 ) {
-  tti.experimental_mark_as_read %buf, %mbar {%buffers, %barriers, %readBars(tensor<2x2xi8, #blocked2>)} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>, tensor<2xi64, #blocked>, tensor<2xi64, #blocked>, !tt.ptr<i8>
+  tti.experimental_set_read_barrier %buf, %mbar {%buffers, %barriers, %readBars(tensor<2x2xi8, #blocked2>)} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>, tensor<2xi64, #blocked>, tensor<2xi64, #blocked>, !tt.ptr<i8>
   tt.return
 }
 }

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -220,14 +220,14 @@ tt.func private @experimental_clear_read_barrier(
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @experimental_stage_write_for_commit
+// CHECK-LABEL: @experimental_stage_access_for_commit
 // CHECK: st.global
-tt.func private @experimental_stage_write_for_commit(
+tt.func private @experimental_stage_access_for_commit(
   %buf: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
   %buffers: tensor<2xi64, #blocked>,
   %writeCommits: !tt.ptr<i8>
 ) {
-  tti.experimental_stage_write_for_commit %buf {%buffers, %writeCommits(tensor<2xi8, #blocked>)} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i8>
+  tti.experimental_stage_access_for_commit %buf {%buffers, %writeCommits(tensor<2xi8, #blocked>)} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i8>
   tt.return
 }
 }
@@ -239,14 +239,14 @@ tt.func private @experimental_stage_write_for_commit(
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @experimental_check_write_commit
+// CHECK-LABEL: @experimental_check_outstanding_commits
 // CHECK: @__assertfail
-tt.func private @experimental_check_write_commit(
+tt.func private @experimental_check_outstanding_commits(
   %buf: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
   %buffers: tensor<2xi64, #blocked>,
   %writeCommits: !tt.ptr<i8>
 ) {
-  tti.experimental_check_write_commit %buf {%buffers, %writeCommits(tensor<2xi8, #blocked>)} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i8>
+  tti.experimental_check_outstanding_commits %buf {%buffers, %writeCommits(tensor<2xi8, #blocked>)}, "dummy" : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i8>
   tt.return
 }
 }
@@ -258,12 +258,12 @@ tt.func private @experimental_check_write_commit(
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @experimental_commit_writes
+// CHECK-LABEL: @experimental_commit_accesses
 // CHECK: st.global
-tt.func private @experimental_commit_writes(
+tt.func private @experimental_commit_accesses(
   %writeCommits: !tt.ptr<i8>
 ) {
-  tti.experimental_commit_writes {%writeCommits(tensor<2xi8, #blocked>)} : !tt.ptr<i8>
+  tti.experimental_commit_accesses {%writeCommits(tensor<2xi8, #blocked>)} : !tt.ptr<i8>
   tt.return
 }
 }
@@ -275,12 +275,12 @@ tt.func private @experimental_commit_writes(
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-// CHECK-LABEL: @experimental_clear_write_commits
+// CHECK-LABEL: @experimental_clear_outstanding_commits
 // CHECK: st.global
-tt.func private @experimental_clear_write_commits(
-  %writeCommits: !tt.ptr<i8>
+tt.func private @experimental_clear_outstanding_commits(
+  %outstandingCommits: !tt.ptr<i8>
 ) {
-  tti.experimental_clear_write_commits {%writeCommits(tensor<2xi8, #blocked>)}, 42 : !tt.ptr<i8>
+  tti.experimental_clear_outstanding_commits {%outstandingCommits(tensor<2xi8, #blocked>)}, 42 : !tt.ptr<i8>
   tt.return
 }
 }

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -6,7 +6,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
 // CHECK-LABEL: @experimental_buffer_pointers_tmem
 // CHECK:nvgpu.tensor_memory_base
 tt.func private @experimental_buffer_pointers_tmem() {
-  tti.experimental_buffer_pointers [0, 42], tensor : tensor<2xi64, #blocked>
+  tti.experimental_buffer_pointers [0, 42], tensor_mem : tensor<2xi64, #blocked>
   tt.return
 }
 }
@@ -19,7 +19,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
 // CHECK-LABEL: @experimental_buffer_pointers_shared
 // CHECK: llvm.ptrtoint %arg0
 tt.func private @experimental_buffer_pointers_shared() {
-  tti.experimental_buffer_pointers [0, 42], shared : tensor<2xi64, #blocked>
+  tti.experimental_buffer_pointers [0, 42], shared_mem : tensor<2xi64, #blocked>
   tt.return
 }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -8,7 +8,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: #[[WRT_BARS_L:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
   // CHECK: @single_local_alloc
   tt.func public @single_local_alloc() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64, #[[BUFS_L]]>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared_mem : tensor<1xi64, #[[BUFS_L]]>
     // CHECK: %[[WRITE_STATE:.*]] = arith.constant dense<0> : tensor<1xi8, #[[BUFS_L]]>
     // CHECK: %[[WRT_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: tt.store {{.*}}, %[[WRITE_STATE]]
@@ -41,7 +41,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @two_local_alloc
   tt.func public @two_local_alloc() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096], shared : tensor<2xi64,
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096], shared_mem : tensor<2xi64,
     // CHECK: %[[WRITE_STATE:.*]] = arith.constant dense<0> : tensor<2xi8,
     // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<2x1xi8,
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
@@ -61,7 +61,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @three_local_alloc
   tt.func public @three_local_alloc() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096, 8192, 0], shared : tensor<4xi64,
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096, 8192, 0], shared_mem : tensor<4xi64,
     // CHECK: %[[WRITE_STATE:.*]] = arith.constant dense<0> : tensor<4xi8,
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 4 : i32} : !tt.ptr<i8>
     // CHECK: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<4x1xi8,
@@ -82,7 +82,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @three_sub_bufs
   tt.func public @three_sub_bufs() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096, 8192, 0], shared : tensor<4xi64,
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0, 4096, 8192, 0], shared_mem : tensor<4xi64,
     // CHECK: %[[WRITE_STATE:.*]] = arith.constant dense<0> : tensor<4xi8,
     // CHECK-DAG: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<4x1xi8,
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 4 : i32} : !tt.ptr<i8>
@@ -140,9 +140,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: #[[BUFS_L:.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
   // CHECK: @tmem_alloc
   tt.func public @tmem_alloc() {
-    // CHECK: %[[TMEM_BUFS:.*]] = tti.experimental_buffer_pointers [0], tensor : tensor<1xi64, #[[BUFS_L]]>
+    // CHECK: %[[TMEM_BUFS:.*]] = tti.experimental_buffer_pointers [0], tensor_mem : tensor<1xi64, #[[BUFS_L]]>
     // CHECK: %[[TM_WRITE_STATE:.*]] = arith.constant dense<0> : tensor<1xi8,
-    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [4096], shared : tensor<1xi64, #[[BUFS_L]]>
+    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [4096], shared_mem : tensor<1xi64, #[[BUFS_L]]>
     // CHECK: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8,
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -160,10 +160,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_tma_copy_global_to_local
   tt.func public @async_tma_copy_global_to_local(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
-    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64
+    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared_mem : tensor<1xi64
     // CHECK: %[[WRITE_STATE:.*]] = arith.constant dense<0> : tensor<1xi8,
     // CHECK: %[[WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
-    // CHECK: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64
+    // CHECK: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared_mem : tensor<1xi64
     // CHECK: %[[WRITE_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[READ_BARS:.*]] = arith.constant dense<0> : tensor<1x1xi8
@@ -280,9 +280,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @wait_barrier
   tt.func public @wait_barrier(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
-    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64, #blocked>
+    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared_mem : tensor<1xi64, #blocked>
     // CHECK: %[[WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
-    // CHECK: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64, #blocked>
+    // CHECK: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared_mem : tensor<1xi64, #blocked>
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     %true = arith.constant true
@@ -305,9 +305,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @wait_barrier
   tt.func public @wait_barrier(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64, #blocked>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared_mem : tensor<1xi64, #blocked>
     // CHECK: %[[WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
-    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64, #blocked>
+    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared_mem : tensor<1xi64, #blocked>
     // CHECK: %[[WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     %true = arith.constant true
@@ -330,11 +330,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @tcgen5_mma
   tt.func public @tcgen5_mma(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
-    // CHECK-DAG: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 32768], shared : tensor<2xi64
+    // CHECK-DAG: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 32768], shared_mem : tensor<2xi64
     // CHECK: %[[SM_WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
-    // CHECK-DAG: %[[TM_BUFS:.*]] = tti.experimental_buffer_pointers [0], tensor : tensor<1xi64
+    // CHECK-DAG: %[[TM_BUFS:.*]] = tti.experimental_buffer_pointers [0], tensor_mem : tensor<1xi64
     // CHECK: %[[TM_WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
-    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64
+    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared_mem : tensor<1xi64
     // CHECK: %[[SM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
     // CHECK: %[[SM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
     // CHECK: %[[TM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
@@ -371,11 +371,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @tcgen5_mma_lhs_in_tmem
   tt.func public @tcgen5_mma_lhs_in_tmem(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
-    // CHECK: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [32768], shared : tensor<1xi64
+    // CHECK: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [32768], shared_mem : tensor<1xi64
     // CHECK: %[[SM_WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
-    // CHECK: %[[TM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 128], tensor : tensor<2xi64
+    // CHECK: %[[TM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 128], tensor_mem : tensor<2xi64
     // CHECK: %[[TM_WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
-    // CHECK: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared : tensor<1xi64
+    // CHECK: %[[BARRIERS:.*]] = tti.experimental_buffer_pointers [65536], shared_mem : tensor<1xi64
     // CHECK: %[[SM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[SM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[TM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
@@ -410,7 +410,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_copy_global_to_local
   tt.func public @async_copy_global_to_local(%ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
-    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64
+    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared_mem : tensor<1xi64
     // CHECK: %[[WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[WRITE_COMMITS:.*]] = arith.constant dense<0> : tensor<1xi8
     // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
@@ -437,7 +437,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_copy_global_to_local_with_barriers
   tt.func public @async_copy_global_to_local_with_barriers(%ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
-    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared : tensor<1xi64
+    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_pointers [0], shared_mem : tensor<1xi64
     // CHECK: %[[SM_WRT_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[SM_WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
     // CHECK: %[[SM_READ_BARS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 1 : i32} : !tt.ptr<i8>
@@ -511,7 +511,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @warp_group_dot
   tt.func public @warp_group_dot(%acc: tensor<128x128xf16, #mma>) {
-    // CHECK: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 32768], shared : tensor<2xi64
+    // CHECK: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 32768], shared_mem : tensor<2xi64
     // CHECK: %[[WRITE_STATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
     // CHECK: %[[SM_WGMMA_READS:.*]] = arith.constant dense<0> : tensor<2xi8
     // CHECK: %[[SM_WGMMA_WRITES_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
@@ -537,7 +537,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @warp_group_dot_sync
   tt.func public @warp_group_dot_sync(%acc: tensor<128x128xf16, #mma>) {
-    // CHECK: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 32768], shared : tensor<2xi64
+    // CHECK: %[[SM_BUFS:.*]] = tti.experimental_buffer_pointers [0, 32768], shared_mem : tensor<2xi64
     // CHECK: %[[SM_WGMMA_READS:.*]] = arith.constant dense<0> : tensor<2xi8
     // CHECK: %[[SM_WGMMA_WRITES_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 1 : i32, nbytes = 2 : i32} : !tt.ptr<i8>
 


### PR DESCRIPTION
This PR covers:
* Adding support for wgmma checks (ops marked as read until wgmma_wait)
* Adding checks on any shmem and tmem access - this finalizes the basic support for pipelined kernels
* Slight refactor of IR - op and attribute names
