### PR TITLE
[TensorDesc] Add extra stride validation to interpreter

### DIFF
--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -88,10 +88,18 @@ class TensorDescHandle:
         assert self.base.data.item() % 16 == 0, "base must be 16-byte aligned"
         assert len(self.strides) == self.ndim
         assert len(self.block_shape) == self.ndim
+        assert self.ndim >= 1, "descriptor cannot be 0 dimensional"
 
         for stride in self.strides[:-1]:
             assert stride.data.item() % 16 == 0, "stride must be 16-byte aligned"
         assert self.strides[-1].data.item() == 1, "last dim must be contiguous"
+        for i in range(self.ndim - 1):
+            stride = self.strides[i].data.item()
+            prev_stride = self.strides[i + 1].data.item()
+            prev_size = self.shape[i + 1].data.item()
+            assert stride >= prev_stride, "strides must be ordered largest to smallest"
+            assert (stride % prev_stride) == 0, "strides must be even multiples of smaller strides"
+            assert (stride // prev_stride) >= prev_size, "invalid stride"
 
     def materialize_pointers(self, offsets: List[TensorHandle]):
         assert len(offsets) == self.ndim


### PR DESCRIPTION
Ref: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html#group__CUDA__TENSOR__MEMORY_1ga7c7d2aaac9e49294304e755e6f341d7

Note there is a formatting error in the docs, all tensor descriptors regardless of dtype need to satisfy:
```cpp
globalStrides[0] = globalDim[0] * elementSizeInBytes(tensorDataType) + padding[0];
for (int i = 0; i < tensorRank - 1; i++) {
    globalStrides[i] = globalStrides[i – 1] * (globalDim[i] + padding[i]);
    assert(globalStrides[i] >= globalDim[i]);
}
```