### PR TITLE
[Gluon] Fix auto_encoding for ops which may infer multiple layouts

### DIFF
--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -84,7 +84,7 @@ from .core import (
     join,
     load,
     make_block_ptr,
-    map_elementwise,  # noqa
+    map_elementwise,
     max_constancy,
     max_contiguous,
     maximum,
@@ -209,6 +209,7 @@ __all__ = [
     "log",
     "log2",
     "make_block_ptr",
+    "map_elementwise",
     "math",
     "max",
     "max_constancy",

--- a/test/Gluon/invalid_auto_encoding.mlir
+++ b/test/Gluon/invalid_auto_encoding.mlir
@@ -5,7 +5,7 @@
 
 module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @infer_conflict() -> (tensor<16xi32, #blocked>, tensor<16xi32, #blocked1>) {
-    // expected-error @+1 {{Found conflicting encodings for value}}
+    // expected-error-re @+1 {{found conflicting encodings for value:{{.*}}  #ttg.blocked<{sizePerThread = [1]{{.*}}and{{.*}}  #ttg.blocked<{sizePerThread = [2]}}
     %0 = arith.constant dense<7> : tensor<16xi32, #gluon.auto_encoding>
     %cvt1 = gluon.set_auto_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked>
     %cvt2 = gluon.set_auto_layout %0 : tensor<16xi32, #gluon.auto_encoding> -> tensor<16xi32, #blocked1>


### PR DESCRIPTION
In the failing example we have:
```mlir
    %0 = tt.make_range {end = 8192 : i32, start = 0 : i32} : tensor<8192xi32, #gluon.auto_encoding>
    %1 = tt.reshape %0 : tensor<8192xi32, #gluon.auto_encoding> -> tensor<64x128xi32, #gluon.auto_encoding>
    %2 = gluon.set_auto_layout %1 : tensor<64x128xi32, #gluon.auto_encoding> -> tensor<64x128xi32, #blocked>
```
which currently fails with the error:
```python
/root/code/triton/test.py:43:52: error: 'tt.reshape' op Found conflicting encodings for value
            gl.arange(0, BLOCK_M * BLOCK_N).reshape((BLOCK_M, BLOCK_N)),
```

The issue is that we propagate the blocked layout backwards to get a linear layout for the `make_range` result, then the algorithm propagates that layout forward to the `reshape` result. However, it infers a linear layout and errors because it conflicts with the original blocked layout.

I fix this by setting a `mayVary` flag when an encoding comes from an inference result that isn't the only possibility. I then have special rules that resolve conflicts where one or more of the encodings is allowed to vary.