### PR TITLE
[OAI] Exclude function from being wrapped in tl.constexpr()

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -563,3 +563,12 @@ def test_return_in_while():
         kernel.warmup(grid=(1, ))
 
     assert "Cannot have `return` statements inside `while` or `for` statements in triton" in str(e.value)
+
+
+def test_no_constexpr_function():
+
+    def foo():
+        pass
+
+    with pytest.raises(TypeError, match="constexpr must not be a function"):
+        foo = tl.constexpr(foo)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 import builtins
 from .. import knobs
 from ..runtime.jit import JITFunction
+from types import FunctionType
 import inspect
 
 from .._C.libtriton import ir
@@ -200,6 +201,8 @@ class constexpr(base_value):
     """
 
     def __init__(self, value):
+        if isinstance(value, FunctionType):
+            raise TypeError('constexpr must not be a function')
         while isinstance(value, constexpr):
             value = value.value
         self.value = value


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
