### PR TITLE
[Gluon] Fix auto layout inconsistencies

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -104,6 +104,15 @@ def test_convert_layout_not_trivial(target):
     assert "layout conversion from BlockedLayout(size_per_thread=[2]" in str(e.value.__cause__)
     assert "to AutoLayout() is not trivial" in str(e.value.__cause__)
 
+    with pytest.raises(CompilationError) as e:
+        src_layout: ttgl.constexpr = ttgl.AutoLayout()
+        dst_layout: ttgl.constexpr = ttgl.BlockedLayout([2], [32], [4], [0])
+        kernel.warmup(src_layout, dst_layout, grid=(1, ))
+
+    assert "layout conversion from AutoLayout()" in str(e.value.__cause__)
+    assert "to BlockedLayout(size_per_thread=[2]" in str(e.value.__cause__)
+    assert "is not trivial" in str(e.value.__cause__)
+
 
 @gluon.jit
 def shared_memory_kernel(XBLOCK: ttgl.constexpr, YBLOCK: ttgl.constexpr, layout_a: ttgl.constexpr,

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from triton._C.libtriton.gluon_ir import GluonOpBuilder
     from ._semantic import GluonSemantic
 
-from ._layouts import SharedLayout, DistributedLayout, AutoLayout
+from ._layouts import SharedLayout, DistributedLayout
 from triton._C.libtriton import ir
 import triton.language.core as tl_core
 from triton.language.core import (
@@ -383,8 +383,6 @@ def convert_layout(value, layout, assert_trivial=False, _semantic=None):
         tensor: The tensor with the new layout.
     """
     layout = _unwrap_if_constexpr(layout)
-    if isinstance(value.type.layout, AutoLayout):
-        return set_auto_layout(value, layout, _semantic=_semantic)
     return _semantic.convert_layout(value, layout, assert_trivial)
 
 
@@ -397,7 +395,7 @@ def full(shape, value, dtype, layout=None, _semantic=None):
         shape (Sequence[int]): The shape of the tensor.
         value (int or float): The fill value.
         dtype (dtype): The data type for the tensor.
-        layout (DistributedLayout): The layout of the output tensor.
+        layout (Optional[DistributedLayout]): The layout of the output tensor, defaults to AutoLayout().
 
     Returns:
         tensor: A tensor where every element equals value.

--- a/python/triton/experimental/gluon/language/_standard.py
+++ b/python/triton/experimental/gluon/language/_standard.py
@@ -32,14 +32,14 @@ for name in _IMPORT_FROM_TRITON:
 
 
 @jit
-def zeros(shape, dtype, layout):
+def zeros(shape, dtype, layout=None):
     """
     Create a tensor filled with zeros.
 
     Args:
         shape (Sequence[int]): The shape of the tensor.
         dtype (dtype): The data type for the tensor.
-        layout (DistributedLayout): The distributed layout of the tensor.
+        layout (Optional[DistributedLayout]): The distributed layout of the tensor, defaults to AutoLayout().
 
     Returns:
         tensor: A tensor where every element is zero.


### PR DESCRIPTION
PR #7646 changed `gl.full` to default to auto layout but not `gl.zeros`.

PR #7589 changed `gl.convert_layout` to set the layout on auto layouts, which breaks code such as:
```python
a = ... # some auto layout
gl.set_auto_layout(a, compute_layout)
gl.store(..., gl.convert_layout(a, store_layout))
```