### PR TITLE
[AMD][Gluon] Expose buffer load to local op

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -4,6 +4,7 @@
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Gluon/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
@@ -599,13 +600,20 @@ void init_gluon_ir(py::module &&m) {
            [](GluonOpBuilder &self, int numPartitions) -> Operation * {
              return self.create<ttg::WarpSpecializePartitionsOp>(numPartitions);
            })
-      .def("create_warp_specialize", [](GluonOpBuilder &self,
-                                        std::vector<Type> &resultTypes,
-                                        std::vector<Value> &explicitCaptures,
-                                        std::vector<int> &partitionNumWarps) {
-        return self.create<ttg::WarpSpecializeOp>(resultTypes, explicitCaptures,
-                                                  partitionNumWarps);
-      });
+      .def("create_warp_specialize",
+           [](GluonOpBuilder &self, std::vector<Type> &resultTypes,
+              std::vector<Value> &explicitCaptures,
+              std::vector<int> &partitionNumWarps) {
+             return self.create<ttg::WarpSpecializeOp>(
+                 resultTypes, explicitCaptures, partitionNumWarps);
+           })
+      .def("create_buffer_load_to_local",
+           [](GluonOpBuilder &self, Value dest, Value ptr, Value offsets,
+              Value mask, Value other, Value stride,
+              tt::CacheModifier cacheModifier) {
+             self.create<triton::amdgpu::BufferLoadToLocalOp>(
+                 dest, ptr, offsets, mask, other, stride, cacheModifier);
+           });
 
   py::class_<ttg::WarpSpecializeOp, OpState>(m, "WarpSpecializeOp",
                                              py::module_local())

--- a/python/triton/experimental/gluon/language/amd/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/__init__.py
@@ -1,3 +1,4 @@
 from ._layouts import AMDMFMALayout
+from . import cdna3
 
-__all__ = ["AMDMFMALayout"]
+__all__ = ["AMDMFMALayout", "cdna3"]

--- a/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
@@ -1,0 +1,30 @@
+from ..._core import builtin
+from triton._C.libtriton import ir
+
+__all__ = ["create_buffer_load_to_local"]
+
+
+@builtin
+def create_buffer_load_to_local(dest, ptr, offsets, mask=None, other=None, stride=None,
+                                cache_modifier="", _semantic=None):
+    """
+    AMD Buffer load operation. Similar to amdgpu.buffer_load op but directly writes to shared memory instead of into registers.
+
+    Args:
+        dest (shared_memory_descriptor): Destination shared memory descriptor.
+        ptr (tensor): Pointer tensor to load from.
+        offsets (tensor): Offsets tensor for the load operation.
+        mask (tensor, optional): Mask tensor for predicated loads. Defaults to None.
+        other (tensor, optional): Additional tensor for the load operation. Defaults to None.
+        stride (tensor, optional): Stride tensor for the load operation. Defaults to None.
+        cache_modifier (str): Cache modifier specifier. Defaults to "".
+    """
+    builder = _semantic.builder
+
+    mask = mask.handle if mask is not None else ir.value()
+    other = other.handle if other is not None else ir.value()
+    stride = stride.handle if stride is not None else ir.value()
+    cache_modifier = _semantic._str_to_load_cache_modifier(cache_modifier)
+
+    builder.create_buffer_load_to_local(dest.handle, ptr.handle, offsets.handle,
+                                        mask, other, stride, cache_modifier)


### PR DESCRIPTION
Expose AMD's buffer load to local op to gluon

Example usage:

```python
@gluon.jit
def kernel(ptr):
    blocked: ttgl.constexpr = ttgl.BlockedLayout([1], [64], [4], [0])
    shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0])

    dest = ttgl.allocate_shared_memory(ptr.dtype.element_ty, [256], shared)
    offsets = ttgl.arange(0, 256, layout=blocked)

    ttgl.amd.cdna3.create_buffer_load_to_local(dest, ptr, offsets)
```

Follow the code organization of https://github.com/triton-lang/triton/pull/7738/files#diff-7a5e2bdf8b7bf32280a2c882310405c421462987640cafee3b2a298ac037b639