### PR TITLE
[AMD][Gluon] Tighten up verification for AMDMFMALayout

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -207,9 +207,8 @@ py::object layoutToGluon(Attribute layout) {
       } else if (elemType.isF32()) {
         typeName = "fp32";
       } else {
-        // The parameter layout is a valid AMDMfmaEncodingAttr obj and the
-        // verification make sure the elemType is fp64, fp32 or int32, so, the
-        // typeName here must be int32.
+        // The AMDMfmaEncodingAttr mlir attribute has already verified element
+        // type is fp64, fp32 or int32; so, the typeName here must be int32.
         typeName = "int32";
       }
     }

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -207,8 +207,9 @@ py::object layoutToGluon(Attribute layout) {
       } else if (elemType.isF32()) {
         typeName = "fp32";
       } else {
-        // The layout is valid or else, the AMDMfmaEncodingAttr will
-        // fail in verification, which means elem_type is int32.
+        // The parameter layout is a valid AMDMfmaEncodingAttr obj and the
+        // verification make sure the elemType is fp64, fp32 or int32, so, the
+        // typeName here must be int32.
         typeName = "int32";
       }
     }

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1460,7 +1460,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 
 @gluon.jit
-def add_fp(a, b):
+def add_int(a, b):
     return a + b
 
 
@@ -1470,34 +1470,35 @@ def infer_layout_for_amd_mfma_kernel():
                                                        elem_type=ttgl.int32, warps_per_cta=[4,
                                                                                             1], tiles_per_warp=[4, 1],
                                                        ctas_per_cga=[1, 1], cta_split_num=[1, 1], cta_order=[1, 0])
-    a = ttgl.full([128, 32], 1.0, ttgl.float32, layout)
-    b = ttgl.reduce(a, 1, add_fp)
+    a = ttgl.full([128, 32], 1, ttgl.int32, layout)
+    b = ttgl.reduce(a, 1, add_int)
     ttgl.static_assert(b.type.layout == ttgl.SliceLayout(1, layout))
 
 
 @pytest.mark.parametrize("target", [HIP_TARGET_CDNA3, HIP_TARGET_CDNA4])
 def test_infer_layout_for_amd_mfma(target):
     module = run_parser(infer_layout_for_amd_mfma_kernel, target=target)
+
     expecttest.assert_expected_inline(
         anonymize_ir(module.str_nodebug()), """\
 #mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [4, 1], tilesPerWarp = [4, 1], instrShape = [32, 32], isTransposed = true, elementType = i32}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @infer_layout_for_amd_mfma_kernel() attributes {noinline = false} {
-    %cst = arith.constant 1.000000e+00 : f32
-    %cst_0 = arith.constant dense<1.000000e+00> : tensor<128x32xf32, #mma>
-    %0 = "tt.reduce"(%cst_0) <{axis = 1 : i32}> ({
-    ^bb0(%arg0: f32, %arg1: f32):
-      %1 = tt.call @test_frontend.add_fp__fp32_fp32__(%arg0, %arg1) : (f32, f32) -> f32
-      tt.reduce.return %1 : f32
-    }) : (tensor<128x32xf32, #mma>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<1> : tensor<128x32xi32, #mma>
+    %0 = "tt.reduce"(%cst) <{axis = 1 : i32}> ({
+    ^bb0(%arg0: i32, %arg1: i32):
+      %1 = tt.call @test_frontend.add_int__i32_i32__(%arg0, %arg1) : (i32, i32) -> i32
+      tt.reduce.return %1 : i32
+    }) : (tensor<128x32xi32, #mma>) -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #mma}>>
     tt.return
   }
-  tt.func private @test_frontend.add_fp__fp32_fp32__(%arg0: f32, %arg1: f32) -> f32 attributes {noinline = false} {
-    %0 = arith.addf %arg0, %arg1 : f32
-    tt.return %0 : f32
+  tt.func private @test_frontend.add_int__i32_i32__(%arg0: i32, %arg1: i32) -> i32 attributes {noinline = false} {
+    %0 = arith.addi %arg0, %arg1 : i32
+    tt.return %0 : i32
   ^bb1:  // no predecessors
-    %1 = ub.poison : f32
-    tt.return %1 : f32
+    %1 = ub.poison : i32
+    tt.return %1 : i32
   }
 }
 """)

--- a/python/triton/experimental/gluon/language/amd/_layouts.py
+++ b/python/triton/experimental/gluon/language/amd/_layouts.py
@@ -52,12 +52,7 @@ class AMDMFMALayout(DistributedLayout):
         self.verify()
 
     def _to_ir(self, builder):
-        type = builder.get_float_ty()
-        if self.elem_type is ttgl.float64:
-            type = builder.get_double_ty()
-        elif self.elem_type is ttgl.int32:
-            type = builder.get_int32_ty()
-
+        type = self.elem_type.to_ir(builder)
         return builder.get_amd_mfma_layout(self.version, self.tiles_per_warp, self.warps_per_cta, self.ctas_per_cga,
                                            self.cta_split_num, self.cta_order, self.instr_shape, self.transposed, type)
 
@@ -71,7 +66,7 @@ class AMDMFMALayout(DistributedLayout):
         return f"MFMA_{self.version}_{stringify(self.instr_shape)}_{self.transposed}_{stringify(self.warps_per_cta)}_{stringify(self.tiles_per_warp)}_{self.elem_type}_{stringify(self.ctas_per_cga)}_{stringify(self.cta_split_num)}_{stringify(self.cta_order)}_MFMA"
 
     def verify(self):
-        assert self.version > 0 and self.version <= 4, "version must be in the [0, 4] range"
+        assert self.version >= 1 and self.version <= 4, "version must be in the [1, 4] range"
         valid_shapes = [[32, 32], [16, 16], [64, 4], [4, 64]]
         assert self.instr_shape in valid_shapes, "Invalid instr shape, valid shapes are " + str(valid_shapes)
 

--- a/python/triton/experimental/gluon/language/amd/_layouts.py
+++ b/python/triton/experimental/gluon/language/amd/_layouts.py
@@ -49,17 +49,15 @@ class AMDMFMALayout(DistributedLayout):
         super().__setattr__("cta_split_num", _unwrap_if_constexpr(self.cta_split_num))
         super().__setattr__("cta_order", _unwrap_if_constexpr(self.cta_order))
 
-        assert self.elem_type.is_fp32() or self.elem_type.is_fp64(
-        ), "The element type in AMDMFMALayout should be float32 or float64 type"
-
-        rank = len(self.cta_order)
-        _realize_cta_layout(self, rank)
-        assert len(self.ctas_per_cga) == rank
-        assert len(self.cta_split_num) == rank
-        assert len(self.cta_order) == rank
+        self.verify()
 
     def _to_ir(self, builder):
-        type = builder.get_float_ty() if self.elem_type is ttgl.float32 else builder.get_double_ty()
+        type = builder.get_float_ty()
+        if self.elem_type is ttgl.float64:
+            type = builder.get_double_ty()
+        elif self.elem_type is ttgl.int32:
+            type = builder.get_int32_ty()
+
         return builder.get_amd_mfma_layout(self.version, self.tiles_per_warp, self.warps_per_cta, self.ctas_per_cga,
                                            self.cta_split_num, self.cta_order, self.instr_shape, self.transposed, type)
 
@@ -71,3 +69,17 @@ class AMDMFMALayout(DistributedLayout):
             return "_".join(map(str, x))
 
         return f"MFMA_{self.version}_{stringify(self.instr_shape)}_{self.transposed}_{stringify(self.warps_per_cta)}_{stringify(self.tiles_per_warp)}_{self.elem_type}_{stringify(self.ctas_per_cga)}_{stringify(self.cta_split_num)}_{stringify(self.cta_order)}_MFMA"
+
+    def verify(self):
+        assert self.version >= 0 and self.version <= 4, "version must be in the [0, 4] range"
+        valid_shapes = [[32, 32], [16, 16], [64, 4], [4, 64]]
+        assert self.instr_shape in valid_shapes, "Invalid instr_shape, valid_shapres are " + str(valid_shapes)
+
+        assert self.elem_type.is_fp32() or self.elem_type.is_fp64() or self.elem_type.is_int32(
+        ), "The element type in AMDMFMALayout should be float32 or float64 type"
+
+        rank = len(self.cta_order)
+        _realize_cta_layout(self, rank)
+        assert len(self.ctas_per_cga) == rank
+        assert len(self.cta_split_num) == rank
+        assert len(self.cta_order) == rank

--- a/python/triton/experimental/gluon/language/amd/_layouts.py
+++ b/python/triton/experimental/gluon/language/amd/_layouts.py
@@ -71,12 +71,12 @@ class AMDMFMALayout(DistributedLayout):
         return f"MFMA_{self.version}_{stringify(self.instr_shape)}_{self.transposed}_{stringify(self.warps_per_cta)}_{stringify(self.tiles_per_warp)}_{self.elem_type}_{stringify(self.ctas_per_cga)}_{stringify(self.cta_split_num)}_{stringify(self.cta_order)}_MFMA"
 
     def verify(self):
-        assert self.version >= 0 and self.version <= 4, "version must be in the [0, 4] range"
+        assert self.version > 0 and self.version <= 4, "version must be in the [0, 4] range"
         valid_shapes = [[32, 32], [16, 16], [64, 4], [4, 64]]
-        assert self.instr_shape in valid_shapes, "Invalid instr_shape, valid_shapres are " + str(valid_shapes)
+        assert self.instr_shape in valid_shapes, "Invalid instr shape, valid shapes are " + str(valid_shapes)
 
-        assert self.elem_type.is_fp32() or self.elem_type.is_fp64() or self.elem_type.is_int32(
-        ), "The element type in AMDMFMALayout should be float32 or float64 type"
+        assert self.elem_type.is_fp32() or self.elem_type.is_fp64() \
+          or self.elem_type.is_int32() , "The element type in AMDMFMALayout should be float32 or float64 type"
 
         rank = len(self.cta_order)
         _realize_cta_layout(self, rank)

--- a/python/triton/experimental/gluon/language/amd/_layouts.py
+++ b/python/triton/experimental/gluon/language/amd/_layouts.py
@@ -68,10 +68,10 @@ class AMDMFMALayout(DistributedLayout):
     def verify(self):
         assert self.version >= 1 and self.version <= 4, "version must be in the [1, 4] range"
         valid_shapes = [[32, 32], [16, 16], [64, 4], [4, 64]]
-        assert self.instr_shape in valid_shapes, "Invalid instr shape, valid shapes are " + str(valid_shapes)
+        assert self.instr_shape in valid_shapes, "invalid intrinsic shape; accepted shapes are " + str(valid_shapes)
 
         assert self.elem_type.is_fp32() or self.elem_type.is_fp64() \
-          or self.elem_type.is_int32() , "The element type in AMDMFMALayout should be float32 or float64 type"
+          or self.elem_type.is_int32() , "element type must be float32, float64, or int32"
 
         rank = len(self.cta_order)
         _realize_cta_layout(self, rank)


### PR DESCRIPTION
Add more verification for AMDMFMALayout in Gluon so the verification rules are aligned with the verification rules in AMDMfmaEncodingAttr.  
With this change, if there are some invalid inputs in the gluon code, the error will be identified earlier.
