### PR TITLE
[LAYOUS] Implement toLinearLayout for TensorMemoryEncodingAttr

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
@@ -13,21 +13,21 @@ def TTG_TensorMemorySpace : AttrDef<TritonNvidiaGPU_Dialect, "TensorMemorySpace"
     across TMEM 128 rows.
 
     Blocks are distributed along M dimension first and then N dimension. This is an arbitrary
-    convention that need to be followed operations reading/writing to TMEM.
+    convention that needs to be followed by operations reading/writing to TMEM.
 
-    a tensor <128x128xf32> with blockM = 64 and blockN = 64 will be distributed as follows:
+    a tensor <128x128xf32> with blockM = 64 and blockN = 32 will be distributed as follows:
 
-        \ col    0        1           31       32            64             96           127
-    rows: 0  ( 0,  0) ( 0,  1) ... ( 0, 31)  (64,  0) ...   (0, 64) ...  (64, 64) ...  (64, 96)
+        \ col    0        1            31         32            64            96           127
+    rows: 0  ( 0,  0) ( 0,  1) ... ( 0,  31)  ( 0,  32) ... ( 0,  64) ... ( 0,  96) ... ( 0,  127)
           1
          ...
-          15 (15,  0) (15,  1) ... (15, 31)  (79,  0) ...   (15, 64) ... (79, 64) ...  (79, 96)
-          16 ( 0, 32) ( 0, 33) ... ( 0, 63)  (64, 32) ...   ( 0, 96) ... (64, 96) ...  (64, 127)
+          15 (15,  0) (15,  1) ... (15,  31)  (15,  32) ... (15,  64) ... (15,  96) ... (15,  127)
+          16 (64,  0) (64,  1) ... (64,  31)  (64,  32) ... (64,  64) ... (64,  96) ... (64,  127)
          ...
-          31 (15, 32) (15, 33) ... (15, 63)  (79, 32) ...   (15, 96) ... (79, 96) ...  (79, 127)
-          32 (16,  0) (16,  1) ... (16, 31)  (80,  0) ...   (16, 64) ... (80, 64) ...  (80, 96)
-         ...
-         127 (63, 32) (63, 33) ... (63, 63)  (127, 32) ...  (63, 96) ... (127, 96)...  (127, 127)
+          31 (79,  0) (79,  1) ... (79,  31)  (79,  32) ... (79,  64) ... (79,  96) ... (79,  127)
+          32 (16,  0) (16,  1) ... (16,  31)  (16,  32) ... (16,  64) ... (16,  96) ... (16,  127)
+         ..
+         127 (127, 0) (127, 1) ... (127, 31) (127, 32) ... (127, 64) ... (127, 96) ... (127, 127)
   }];
 }
 
@@ -47,6 +47,7 @@ def TTG_TensorMemoryEncodingAttr : AttrDef<TritonNvidiaGPU_Dialect, "TensorMemor
     DefaultValuedParameter<"unsigned", "1">:$CTASplitM,
     DefaultValuedParameter<"unsigned", "1">:$CTASplitN
   );
+  let genVerifyDecl = 1;
   let assemblyFormat = "`<` struct(params) `>`";
 }
 

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -4,6 +4,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
@@ -12,6 +13,8 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
+
+using mlir::triton::nvidia_gpu::TensorMemoryEncodingAttr;
 
 namespace mlir::triton::gpu {
 namespace {
@@ -1185,6 +1188,95 @@ LinearLayout SliceEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
                       llvm::to_vector(sliceLL.getOutDimNames()));
 }
 
+LinearLayout tensorMemoryToLinearLayout(ArrayRef<int64_t> shape,
+                                        TensorMemoryEncodingAttr encoding) {
+  // We model tensorMemory as a 2D layout. Interestingly enough, we craft the
+  // map as going from the matrix into the tensorMemory, rather than the other
+  // way around. We do this because of the following reasons:
+  // - When packed=True, the coordinate (0, 0) would have to map to BOTH
+  // elements (0, 0) and (0, 1)
+  // - For blockM=64, when we have a tensor of shape 64xblockN, we leave every
+  // other 16 rows empty.
+  //   This cannot be modelled as a map from TMEM into the tensor as you don't
+  //   have an element to map row 16 to
+  // - Whenever we use TMEM or SHMEM layouts, we always first invert them
+  // - We never want to have broadcasting in TMEM, so the map from Tensor to
+  // TMEM is always well-defined
+  assert(shape.size() == 2);
+  auto *ctx = encoding.getContext();
+  auto rows = S("rows");
+  auto cols = S("cols");
+  auto dims = standardOutDimNames(ctx, 2);
+  if (!encoding.getUnpacked()) {
+    auto packing = LinearLayout::zeros1D(2, dims[1], cols);
+    auto newEncoding = TensorMemoryEncodingAttr::get(
+        ctx, encoding.getBlockM(), encoding.getBlockN(), /*unpacked=*/true,
+        encoding.getCTASplitM(), encoding.getCTASplitN());
+    return packing *
+           tensorMemoryToLinearLayout({shape[0], shape[1] / 2}, newEncoding);
+  }
+  // The CTAOrder = [0, 1] so se start by N so that it ends up as ((tile *
+  // splitM) * splitN) We append them to the cols dimension
+  if (encoding.getCTASplitN() > 1) {
+    auto split =
+        LinearLayout::identity1D(encoding.getCTASplitN(), dims[1], cols);
+    auto newEncoding = TensorMemoryEncodingAttr::get(
+        ctx, encoding.getBlockM(), encoding.getBlockN(), encoding.getUnpacked(),
+        encoding.getCTASplitM(), 1);
+    return tensorMemoryToLinearLayout(
+               {shape[0], shape[1] / encoding.getCTASplitN()}, newEncoding) *
+           split;
+  }
+  if (encoding.getCTASplitM() > 1) {
+    auto split =
+        LinearLayout::identity1D(encoding.getCTASplitM(), dims[0], cols);
+    auto newEncoding = TensorMemoryEncodingAttr::get(
+        ctx, encoding.getBlockM(), encoding.getBlockN(), encoding.getUnpacked(),
+        1, encoding.getCTASplitN());
+    return tensorMemoryToLinearLayout(
+               {shape[0] / encoding.getCTASplitM(), shape[1]}, newEncoding) *
+           split;
+  }
+  assert(encoding.getCTASplitM() == 1 && encoding.getCTASplitN() == 1 &&
+         encoding.getUnpacked());
+
+  auto left = to_vector(shape);
+  auto blockM = encoding.getBlockM();
+  auto blockN = encoding.getBlockN();
+  assert(blockM == 64 || blockM == 128);
+  LinearLayout tile;
+  if (blockM == 64) {
+    tile = LinearLayout::identity1D(16, dims[0], rows) *
+           LinearLayout::identity1D(blockN, dims[1], cols);
+    auto bases = tile.getBases();
+    bases[dims[0]].push_back({32, 0});
+    bases[dims[0]].push_back({64, 0});
+    left[0] /= blockM;
+    left[1] /= blockN;
+    // order = [0, 1] so we start by dim0
+    if (left[0] > 1) {
+      bases[dims[0]].push_back({16, 0});
+      left[0] /= 2;
+    } else if (left[1] > 1) {
+      bases[dims[1]].push_back({16, 0});
+      left[1] /= 2;
+    }
+    tile = LinearLayout(bases, {{rows, 128}, {cols, blockN}},
+                        /*requireSurjective*/ false);
+
+  } else {
+    tile = LinearLayout::identity1D(blockM, dims[0], rows) *
+           LinearLayout::identity1D(blockN, dims[1], cols);
+    left[0] /= blockM;
+    left[1] /= blockN;
+  }
+  assert(left[0] >= 1 && left[1] >= 1);
+  // Broadcast the remaining dimensions in order [0, 1]
+  tile = tile * LinearLayout::identity1D(left[0], dims[0], cols) *
+         LinearLayout::identity1D(left[1], dims[1], cols);
+  return tile;
+}
+
 LinearLayout
 TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape, Attribute layout,
                                  ArrayRef<int64_t> allocationShape) {
@@ -1202,7 +1294,7 @@ TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape, Attribute layout,
     assert(allocationShape.empty() &&
            "allocationShape not supported for distributed layout");
     result = distributed.toLinearLayout(shape);
-  } else {
+  } else if (isa<SharedEncodingTrait>(layout)) {
     assert(!allocationShape.empty() &&
            "allocationShape not supported for shared layout");
     allocationShape = allocationShape.take_back(shape.size());
@@ -1226,6 +1318,9 @@ TritonGPUDialect::toLinearLayout(ArrayRef<int64_t> shape, Attribute layout,
     } else {
       assert(0 && "unknown layout");
     }
+  } else {
+    auto tensorMemoryEncoding = cast<TensorMemoryEncodingAttr>(layout);
+    result = tensorMemoryToLinearLayout(shape, tensorMemoryEncoding);
   }
 
   llCache.set(std::move(key), result);

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -1,6 +1,8 @@
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "mlir/IR/DialectImplementation.h" // required by `Types.cpp.inc`
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/TypeSwitch.h" // required by `Types.cpp.inc`
 
 using namespace mlir;
@@ -89,6 +91,44 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
                                   ArrayRef<int64_t> allocShape) {
   if (allocShape.size() < shape.size())
     emitError() << "alloc shape must have at least as many dimensions as shape";
+  if (llvm::any_of(shape, [](int64_t dim) { return dim < 0; }))
+    emitError() << "shape must have non-negative dimensions";
+  if (llvm::any_of(llvm::zip(shape, allocShape), [](auto pair) {
+        return std::get<0>(pair) > std::get<1>(pair);
+      }))
+    emitError() << "shape must be less than or equal to allocShape";
+  auto ctx = encoding.getContext();
+  if (auto enc = dyn_cast<nvidia_gpu::TensorMemoryEncodingAttr>(encoding)) {
+    if (shape.size() != 2) {
+      return emitError() << "shape must be a 2-element array";
+    }
+    if (memorySpace != nvidia_gpu::TensorMemorySpaceAttr::get(ctx)) {
+      return emitError() << "memorySpace must be TensorMemorySpace";
+    }
+    if (shape != allocShape) {
+      return emitError() << "shape must be equal to allocShape";
+    }
+    if (shape[0] < enc.getBlockM() * enc.getCTASplitM() ||
+        shape[1] < enc.getBlockN() * enc.getCTASplitN() *
+                       (enc.getUnpacked() ? 2 : 1)) {
+      return emitError() << "shape must be at least "
+                         << enc.getBlockM() * enc.getCTASplitM() << "x"
+                         << enc.getBlockN() * enc.getCTASplitN() *
+                                (enc.getUnpacked() ? 2 : 1);
+    }
+    auto ll = toLinearLayout(shape, enc, {});
+    auto dims = standardOutDimNames(ctx, 2);
+    if (ll.getInDimSize(dims[0]) != shape[0] ||
+        ll.getInDimSize(dims[1]) != shape[1]) {
+      return emitError() << "shape must be equal to "
+                         << ll.getInDimSize(dims[0]) << "x"
+                         << ll.getInDimSize(dims[1]);
+    }
+  } else if (auto enc = dyn_cast<SharedEncodingTrait>(encoding)) {
+    // TODO Add verifier
+  } else {
+    return emitError() << "unsupported encoding";
+  }
   return success();
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -223,6 +223,21 @@ bool isDistributedLayoutTMemCompatible(Operation *op,
   return areLayoutsEquivalent(tensorType.getShape(), layout, enc);
 }
 
+LogicalResult TensorMemoryEncodingAttr::verify(
+    function_ref<InFlightDiagnostic()> emitError, unsigned blockM,
+    unsigned blockN, bool unpacked, unsigned CTASplitM, unsigned CTASplitN) {
+  if (CTASplitM < 1 || CTASplitN < 1) {
+    return emitError() << "CTASplitM and CTASplitN must be greater than 0";
+  }
+  if (blockM != 64 && blockM != 128) {
+    return emitError() << "blockM must be 64 or 128";
+  }
+  if (!llvm::isPowerOf2_32(blockN) || blockN > 512) {
+    return emitError() << "blockN must be a power of 2 and less than 512";
+  }
+  return success();
+}
+
 LogicalResult impl::verifyMMAv5Op(Operation *op) {
   auto isInterleaved = [](MemDescType memdesc) {
     auto enc = dyn_cast<TensorMemoryEncodingAttr>(memdesc.getEncoding());

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -3,6 +3,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/StrUtil.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Signals.h"
@@ -16,13 +17,16 @@ std::ostream &operator<<(std::ostream &os, StringAttr str) {
 }
 } // namespace mlir
 
+using mlir::triton::nvidia_gpu::TensorMemoryEncodingAttr;
 namespace mlir::triton::gpu {
 
 static LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout) {
-  if (isa<DistributedEncodingTrait>(layout)) {
+  if (isa<DistributedEncodingTrait>(layout))
     return toLinearLayout(shape, layout, {});
-  } else {
-    assert(isa<SharedEncodingTrait>(layout));
+  else if (isa<SharedEncodingTrait>(layout))
+    return toLinearLayout(shape, layout, shape);
+  else {
+    assert(isa<TensorMemoryEncodingAttr>(layout));
     return toLinearLayout(shape, layout, shape);
   }
 }
@@ -30,7 +34,14 @@ namespace {
 
 class LinearLayoutConversionsTest : public ::testing::Test {
 public:
-  void SetUp() { ctx.getOrLoadDialect<TritonGPUDialect>(); }
+  void SetUp() {
+    mlir::DialectRegistry registry;
+    registry.insert<TritonGPUDialect,
+                    mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect>();
+    ctx.appendDialectRegistry(registry);
+    ctx.getOrLoadDialect<TritonGPUDialect>();
+    ctx.getOrLoadDialect<mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect>();
+  }
 
   BlockedEncodingAttr blocked(ArrayRef<unsigned> spt, ArrayRef<unsigned> tpw,
                               ArrayRef<unsigned> wpb, ArrayRef<unsigned> cpg,
@@ -136,6 +147,12 @@ public:
     return AMDRotatingSharedEncodingAttr::get(
         &ctx, vec, perPhase, maxPhase, ord,
         CTALayoutAttr::get(&ctx, cpg, cSplit, cOrd));
+  }
+
+  TensorMemoryEncodingAttr tmem(unsigned blockM, unsigned blockN, bool unpacked,
+                                unsigned ctaSplitM, unsigned ctaSplitN) {
+    return TensorMemoryEncodingAttr::get(&ctx, blockM, blockN, unpacked,
+                                         ctaSplitM, ctaSplitN);
   }
 
   StringAttr S(StringRef str) { return StringAttr::get(&ctx, str); }
@@ -3505,6 +3522,93 @@ TEST_F(LinearLayoutConversionsTest, MMAv5Fp4Padded) {
                        {16, 0}}},
                      {S("block"), {}}},
                     {S("dim0"), S("dim1")}));
+}
+
+TEST_F(LinearLayoutConversionsTest, TensorMemory_blockM_64) {
+  auto enc = tmem(64, 64, /*unpacked=*/true, 1, 1);
+  auto d0 = S("dim0");
+  auto d1 = S("dim1");
+  auto rows = S("rows");
+  auto cols = S("cols");
+  LinearLayout expected1 = LinearLayout(
+      {{d0, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {32, 0}, {64, 0}, {16, 0}}},
+       {d1, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {0, 32}}}},
+      {{rows, 128}, {cols, 64}}, /*requireSurjective=*/true);
+  EXPECT_EQ(toLinearLayout({128, 64}, enc), expected1);
+  // Tensor just fits blockMxblockN -> the layout is not surjective (does not
+  // cover basis {16, 0})
+  LinearLayout expected2 =
+      LinearLayout({{d0, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {32, 0}, {64, 0}}},
+                    {d1, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {0, 32}}}},
+                   {{rows, 128}, {cols, 64}}, /*requireSurjective=*/false);
+  EXPECT_EQ(toLinearLayout({64, 64}, enc), expected2);
+  // Broadcasts M then N
+  LinearLayout expected3 = LinearLayout(
+      {{d0,
+        {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {32, 0}, {64, 0}, {16, 0}, {0, 64}}},
+       {d1, {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {0, 32}, {0, 128}}}},
+      {{rows, 128}, {cols, 256}}, /*requireSurjective=*/true);
+  EXPECT_EQ(toLinearLayout({256, 128}, enc), expected3);
+  // Fits N in basis {16, 0} if there's not enough blockM
+  LinearLayout expected4 = LinearLayout(
+      {{d0, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {32, 0}, {64, 0}}},
+       {d1,
+        {{0, 1}, {0, 2}, {0, 4}, {0, 8}, {0, 16}, {0, 32}, {16, 0}, {0, 64}}}},
+      {{rows, 128}, {cols, 128}}, /*requireSurjective=*/true);
+  EXPECT_EQ(toLinearLayout({64, 256}, enc), expected4);
+}
+
+TEST_F(LinearLayoutConversionsTest, TensorMemory_blockM_128) {
+  auto enc = tmem(128, 128, /*unpacked=*/true, 1, 1);
+  auto d0 = S("dim0");
+  auto d1 = S("dim1");
+  auto rows = S("rows");
+  auto cols = S("cols");
+  LinearLayout tile = LinearLayout::identity1D(128, d0, rows) *
+                      LinearLayout::identity1D(128, d1, cols);
+  EXPECT_EQ(toLinearLayout({128, 128}, enc), tile);
+  EXPECT_EQ(toLinearLayout({256, 128}, enc),
+            tile * LinearLayout::identity1D(2, d0, rows));
+  EXPECT_EQ(toLinearLayout({256, 256}, enc),
+            tile * LinearLayout::identity1D(2, d0, rows) *
+                LinearLayout::identity1D(2, d1, cols));
+}
+
+TEST_F(LinearLayoutConversionsTest, TensorMemory_Packed) {
+  auto enc = tmem(128, 128, /*unpacked*/ false, 1, 1);
+  auto padding = LinearLayout::zeros1D(2, S("dim1"), S("cols"));
+  EXPECT_EQ(toLinearLayout({128, 128}, enc),
+            padding * toLinearLayout({64, 128}, enc));
+  enc = tmem(64, 128, /*unpacked*/ false, 1, 2);
+  EXPECT_EQ(toLinearLayout({128, 128}, enc),
+            padding * toLinearLayout({64, 128}, enc));
+  enc = tmem(64, 128, /*unpacked*/ false, 2, 1);
+  EXPECT_EQ(toLinearLayout({128, 128}, enc),
+            padding * toLinearLayout({64, 128}, enc));
+  enc = tmem(64, 128, /*unpacked*/ false, 2, 2);
+  EXPECT_EQ(toLinearLayout({128, 128}, enc),
+            padding * toLinearLayout({64, 128}, enc));
+}
+
+TEST_F(LinearLayoutConversionsTest, TensorMemory_CTASplit) {
+  auto tile = toLinearLayout({64, 128}, tmem(64, 64, /*unpacked*/ true, 1, 1));
+  auto enc = tmem(64, 128, /*unpacked*/ true, 2, 1);
+  EXPECT_EQ(toLinearLayout({128, 128}, enc),
+            tile * LinearLayout::identity1D(2, S("dim0"), S("cols")));
+  enc = tmem(64, 64, /*unpacked*/ true, 1, 2);
+  EXPECT_EQ(toLinearLayout({128, 128}, enc),
+            tile * LinearLayout::identity1D(2, S("dim1"), S("cols")));
+  enc = tmem(64, 64, /*unpacked*/ true, 2, 2);
+  EXPECT_EQ(toLinearLayout({128, 256}, enc),
+            tile * LinearLayout::identity1D(2, S("dim0"), S("cols")) *
+                LinearLayout::identity1D(2, S("dim1"), S("cols")));
+  // The non-contiguous tile stays non-contiguous even in the multiCTA setup
+  auto noncontigTile =
+      toLinearLayout({64, 64}, tmem(64, 64, /*unpacked*/ true, 1, 1));
+  auto noncontigEnc = tmem(64, 64, /*unpacked*/ true, 2, 2);
+  EXPECT_EQ(toLinearLayout({128, 128}, enc),
+            noncontigTile * LinearLayout::identity1D(2, S("dim0"), S("cols")) *
+                LinearLayout::identity1D(2, S("dim1"), S("cols")));
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This `toLinearLayout` is a bit different to way we construct the layouts
for SharedEncoding. In particular, here we map the tensor into the
memory, and not the other way around. This is to be able to model the
`packed=True` version of the layout, where we map two different elements
to the same `M/N` location.

Representing it this way is not an issue in practice, as we always use
these layouts by composing their inverse with a distributed layout, so
this way we simply have the inverse already at hand.
