### PR TITLE
[AMD] Improve layout selection in optimize-lds-usage pass to prefer swizzled layouts

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
@@ -101,13 +101,20 @@ estimateResourcesForReplacement(OpBuilder builder,
   RankedTensorType dstTy = cvtOp.getType();
   RankedTensorType intermediateTy = RankedTensorType::get(
       srcTy.getShape(), srcTy.getElementType(), tmpLayout);
-  bool usePadding = cvtOp->hasAttr(AttrSharedMemPadded);
+  auto *ctx = cvtOp->getContext();
 
-  int tmpCvtLDS =
-      getConvertLayoutScratchInBytes(srcTy, intermediateTy, usePadding);
-  int newCvtLDS =
-      getConvertLayoutScratchInBytes(intermediateTy, dstTy, usePadding);
-  res.LDS = std::max(tmpCvtLDS, newCvtLDS);
+  int tmpCvtLDS = getConvertLayoutScratchInBytes(srcTy, intermediateTy,
+                                                 /*usePadding*/ true);
+  int tmpCvtLDSNoPad = getConvertLayoutScratchInBytes(srcTy, intermediateTy,
+                                                      /*usePadding*/ false);
+  int newCvtLDS = getConvertLayoutScratchInBytes(intermediateTy, dstTy,
+                                                 /*usePadding*/ true);
+  int newCvtLDSNoPad = getConvertLayoutScratchInBytes(intermediateTy, dstTy,
+                                                      /*usePadding*/ false);
+
+  res.LDSPad = std::max(tmpCvtLDS, newCvtLDS);
+  res.LDSNoPad = std::max(tmpCvtLDSNoPad, newCvtLDSNoPad);
+
   return res;
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
@@ -113,7 +113,7 @@ estimateResourcesForReplacement(OpBuilder builder,
                                                       /*usePadding*/ false);
 
   res.LDSPad = std::max(tmpCvtLDS, newCvtLDS);
-  res.LDSNoPad = std::max(tmpCvtLDSNoPad, newCvtLDSNoPad);
+  res.LDSSwizzle = std::max(tmpCvtLDSNoPad, newCvtLDSNoPad);
 
   return res;
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.h
@@ -33,7 +33,7 @@ createNewConvertOps(OpBuilder &builder, triton::gpu::ConvertLayoutOp &cvtOp,
 
 struct Resources {
   int LDSPad;
-  int LDSNoPad;
+  int LDSSwizzle;
 };
 
 Resources

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.h
@@ -32,7 +32,8 @@ createNewConvertOps(OpBuilder &builder, triton::gpu::ConvertLayoutOp &cvtOp,
                     Attribute tmpLayout);
 
 struct Resources {
-  int LDS;
+  int LDSPad;
+  int LDSNoPad;
 };
 
 Resources


### PR DESCRIPTION
# PR Description

## What changed
This PR optimizes the `optimize-lds-usage` pass by improving layout selection strategy for convert-layout operations. The changes include:

- Removed hardcoded preference for padded layouts in the AMD-specific LDS optimization pass
- Enhanced `estimateResourcesForReplacement` method to calculate memory requirements for both padded and swizzled layouts
- Modified layout selection logic to prefer swizzled layouts when LDS limits allow, falling back to padded layouts only when necessary

## Why this change was needed
The `optimize-lds-usage` pass previously enforced padded layouts based on the assumption that "padded conversion seems more friendly with this optimization." While this approach reduced LDS consumption, it came with significant performance penalties:

- Hundreds of additional LLVM IR lines generated for padded versions
- Reduced vectorization

**The New Approach:**
- Prioritizes swizzled layouts for better performance and vectorization
- Only falls back to padded layouts when swizzled versions exceed LDS limits
- Maintains the pass's core functionality of reducing shared memory consumption through intermediate buffering
- Achieves better balance between LDS usage and execution performance