### PR TITLE
[AMD] Added initial support for mxfp6 data type

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -705,6 +705,8 @@ def TT_DotScaledOp : TT_Op<"dot_scaled", [Pure,
                                              int32_t &scaleFactor,
                                              std::string &errMsg);
       int32_t deduceScaleFactor();
+      Type getAElemMLIRType();
+      Type getBElemMLIRType();
     }];
 
     let hasVerifier = 1;

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -419,6 +419,36 @@ int32_t DotScaledOp::deduceScaleFactor() {
   return scaleFactor;
 }
 
+static Type getScaleDotElemMLIRType(ScaleDotElemType type, MLIRContext *ctx) {
+  switch (type) {
+  case ScaleDotElemType::E2M1:
+    return mlir::Float4E2M1FNType::get(ctx);
+  case ScaleDotElemType::E2M3:
+    return mlir::Float6E2M3FNType::get(ctx);
+  case ScaleDotElemType::E3M2:
+    return mlir::Float6E3M2FNType::get(ctx);
+  case ScaleDotElemType::E4M3:
+    return mlir::Float8E4M3FNType::get(ctx);
+  case ScaleDotElemType::E5M2:
+    return mlir::Float8E5M2Type::get(ctx);
+  case ScaleDotElemType::BF16:
+    return mlir::BFloat16Type::get(ctx);
+  case ScaleDotElemType::FP16:
+    return mlir::Float16Type::get(ctx);
+  default:
+    llvm_unreachable("unsupported ScaleDotElemType!");
+  };
+  return nullptr;
+}
+
+Type DotScaledOp::getAElemMLIRType() {
+  return getScaleDotElemMLIRType(getAElemType(), getContext());
+}
+
+Type DotScaledOp::getBElemMLIRType() {
+  return getScaleDotElemMLIRType(getBElemType(), getContext());
+}
+
 //-- MakeRangeOp --
 OpFoldResult MakeRangeOp::fold(FoldAdaptor adaptor) {
   // make_range(start, start + 1) -> constant(start)

--- a/python/test/unit/language/test_mxfp.py
+++ b/python/test/unit/language/test_mxfp.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
+from triton.tools.mxfp import MXFP4Tensor, MXFP6Tensor, MXScaleTensor
 
 
 class MXBaseTest:
@@ -93,6 +93,116 @@ class TestMXFP4Tensor(MXBaseTest):
 
     def test_empty_tensor(self, device):
         tensor = MXFP4Tensor(torch.tensor([], device=device))
+        assert tensor.to(torch.float32).numel() == 0
+
+
+class TestMXFP6Tensor(MXBaseTest):
+
+    @pytest.mark.parametrize("K, N", [(64, 128), (128, 256)])
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_roundtrip(self, K, N, device, exp_width):
+        tensor = MXFP6Tensor(size=(K, N), device=device, e=exp_width).random()
+        tensor2 = MXFP6Tensor(tensor.to(torch.float32), e=exp_width)
+        torch.testing.assert_close(tensor.data, tensor2.data)
+
+    @pytest.mark.parametrize("K, N, dim", [(64, 128, 0), (64, 128, 1)])
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_packed_tensor(self, K, N, dim, device, exp_width):
+        tensor = MXFP6Tensor(size=(K, N), device=device, e=exp_width).random()
+        packed = tensor.to_packed_tensor(dim=dim)
+        unpacked = tensor.unpack_packed_tensor(packed, dim=dim)
+        torch.testing.assert_close(tensor.data, unpacked)
+
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_padding(self, device, exp_width):
+        tensor_pad = MXFP6Tensor(torch.tensor([1, 2, 3, 4], device=device), e=exp_width)
+        pad_packed = tensor_pad.to_packed_tensor(dim=0)
+        torch.testing.assert_close(tensor_pad.data, tensor_pad.unpack_packed_tensor(pad_packed, dim=0))
+
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_zero_values(self, exp_width, device):
+        test_values = torch.tensor([0.0, -0.0], device=device)
+        tensor = MXFP6Tensor(data=test_values, e=exp_width)
+        expected_encodings = torch.tensor([0b000000, 0b100000], dtype=torch.uint8, device=device)
+        assert torch.equal(tensor.data, expected_encodings), "Zero values should be encoded as 0"
+        torch.testing.assert_close(tensor.to(torch.float32), test_values)
+
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_out_of_range_values(self, device, exp_width):
+        max_value = 7.5 if exp_width == 2 else 28.0
+        overflow_value = max_value + 0.5
+        test_values = torch.tensor([overflow_value, -overflow_value, float('inf'), float('-inf')], device=device)
+        tensor = MXFP6Tensor(data=test_values, e=exp_width)
+        expected_values = torch.tensor([max_value, -max_value, max_value, -max_value], device=device)
+        torch.testing.assert_close(tensor.to(torch.float32), expected_values)
+
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_subnormal_numbers(self, exp_width, device):
+        test_values = torch.tensor([0.1, 0.2, 0.3, 0.4], device=device)
+        tensor = MXFP6Tensor(test_values, e=exp_width)
+        if exp_width == 2:
+            expected_values = torch.tensor([0.125, 0.250, 0.250, 0.375], device=device)
+        else:
+            expected_values = torch.tensor([0.0000, 0.2500, 0.3125, 0.3750], device=device)
+        torch.testing.assert_close(tensor.to(torch.float32), expected_values)
+
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_rounding_edge_cases(self, exp_width, device):
+        if exp_width == 2:
+            test_values = torch.tensor([0.95, 1.05, 1.95, 2.10, 3.90, 4.05], device=device)
+        else:
+            test_values = torch.tensor([0.95, 1.05, 1.95, 2.05, 3.95, 4.05], device=device)
+        expected_values = torch.tensor([1.00, 1.00, 2.00, 2.00, 4.00, 4.00], device=device)
+        tensor = MXFP6Tensor(test_values, e=exp_width)
+        torch.testing.assert_close(tensor.to(torch.float32), expected_values)
+
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_negative_values(self, exp_width, device):
+        test_values = torch.tensor([-0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0], device=device)
+        tensor = MXFP6Tensor(test_values, e=exp_width)
+        torch.testing.assert_close(tensor.to(torch.float32), test_values)
+
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_negative_out_of_range(self, exp_width, device):
+        if exp_width == 2:
+            tensor = MXFP6Tensor(torch.tensor([-8.0, -9.0, -10.0], device=device), e=exp_width)
+            expected_values = torch.tensor([-7.5, -7.5, -7.5], device=device)
+        else:
+            tensor = MXFP6Tensor(torch.tensor([-29.0, -30.0, -31.0], device=device), e=exp_width)
+            expected_values = torch.tensor([-28.0, -28.0, -28.0], device=device)
+        torch.testing.assert_close(tensor.to(torch.float32), expected_values)
+
+    @pytest.mark.parametrize("shape, dim", [
+        ((1024, ), 0),
+        ((128, 256), 0),
+        ((128, 256), 1),
+        ((64, 64, 64), 2),
+    ])
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_packing(self, shape, dim, exp_width, device):
+        tensor = MXFP6Tensor(size=shape, device=device, e=exp_width).random()
+        packed = tensor.to_packed_tensor(dim=dim)
+        unpacked = tensor.unpack_packed_tensor(packed, dim=dim)
+        torch.testing.assert_close(tensor.data, unpacked)
+
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_packing_with_padding(self, exp_width, device):
+        shape = (7, 8)
+        dim = 1
+        tensor = MXFP6Tensor(size=shape, device=device, e=exp_width).random()
+        packed = tensor.to_packed_tensor(dim=dim)
+        unpacked = tensor.unpack_packed_tensor(packed, dim=dim)
+        torch.testing.assert_close(tensor.data, unpacked)
+
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_invalid_packing_dimension(self, exp_width, device):
+        tensor = MXFP6Tensor(size=(4, 4), device=device, e=exp_width).random()
+        with pytest.raises(AssertionError):
+            tensor.to_packed_tensor(dim=2)  # Invalid dimension
+
+    @pytest.mark.parametrize("exp_width", [2, 3])
+    def test_empty_tensor(self, exp_width, device):
+        tensor = MXFP6Tensor(torch.tensor([], device=device), e=exp_width)
         assert tensor.to(torch.float32).numel() == 0
 
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1511,8 +1511,8 @@ class TritonSemantic(Generic[TensorTy]):
         triton_ty = {"e5m2": tl.float8e5, "e4m3": tl.float8e4nv, "bf16": tl.bfloat16, "fp16":
                      tl.float16}.get(float_format)
         if triton_ty is None:
-            assert float_format == "e2m1", f"Internal Error: Unexpected float format: {float_format}"
-            assert val.dtype == tl.uint8, f"e2m1 format must be packed as uint8. Got {val.dtype}"
+            assert float_format in ["e2m1", "e2m3", "e3m2"], f"Internal Error: Unexpected float format: {float_format}"
+            assert val.dtype == tl.uint8, f"e2m1/e2m3/e3m2 format must be packed as uint8. Got {val.dtype}"
             return val
         if val.dtype == triton_ty:
             return val
@@ -1547,7 +1547,7 @@ class TritonSemantic(Generic[TensorTy]):
         rhs_format: str = rhs_format.value
         lhs_format_enum = self._str_to_fp_type(lhs_format)
         rhs_format_enum = self._str_to_fp_type(rhs_format)
-        allowed_formats = {"e2m1", "e4m3", "e5m2", "bf16", "fp16"}
+        allowed_formats = {"e2m1", "e2m3", "e3m2", "e4m3", "e5m2", "bf16", "fp16"}
         assert lhs_format in allowed_formats, f"NYI: lhs_format {lhs_format}"
         assert rhs_format in allowed_formats, f"NYI: rhs_format {rhs_format}"
         rhs_scale_is_none = rhs_scale is None or (isinstance(rhs_scale, tl.constexpr) and rhs_scale.value is None)

--- a/python/triton/tools/mxfp.py
+++ b/python/triton/tools/mxfp.py
@@ -2,6 +2,7 @@
 Helper classes for working with low precision floating point types that
 align with the opencompute (OCP) microscaling (MX) specification.
   * MXFP4Tensor: 4-bit E2M1 floating point data
+  * MXFP6Tensor: 6-bit E2M3/E3M2 floating point data
   * MXScaleTensor: 8-bit E8M0 floating point data
 Reference: https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
 """
@@ -228,6 +229,256 @@ class MXFP4Tensor:
             data = data[tuple(indices)]
 
         return data.type(torch.uint8)
+
+
+class MXFP6Tensor:
+
+    def __init__(self, data=None, size=None, device=None, e=2):
+        """
+        Tensor class for working with six bit E2M3/E3M2 floating point data as defined by the
+        opencompute microscaling specification.
+
+
+        Parameters:
+        - data: A torch tensor of float32 numbers to convert to fp6e2m3/fp6e3m2 microscaling format.
+        - size: The size of the tensor to create.
+        - device: The device on which to create the tensor.
+        """
+        self.device = device
+        self.s_shift = 5
+        self.e_size = e
+        self.m_size = 5 - e
+        if data is not None:
+            assert isinstance(data, torch.Tensor), "Parameter data must be a torch tensor"
+            self.device = data.device
+            self.data = self._from_float(data)
+        elif size is not None:
+            self.size = size if isinstance(size, tuple) else (size, )
+        else:
+            raise ValueError("Either parameter data or size must be provided")
+
+    def ravel(self):
+        return self.data.ravel()
+
+    def random(self):
+        upper_bound = 7.5 if self.e_size == 2 else 28.0
+        data = upper_bound * torch.rand(self.size, dtype=torch.float32, device=self.device)
+        self.data = self._from_float(data)
+        return self
+
+    def to(self, dtype):
+        """
+        Convert fp6e2m3/fp6e3m2 data to float32.
+
+        Returns:
+        - A torch tensor of type dtype representing the fp6e2m3/fp6e3m2 data.
+        """
+        assert dtype == torch.float32, "Currently only float32 is supported for fp6e2m3/fp6e3m2 to float conversion"
+
+        data = self.data
+        E_shift = self.m_size
+        E_mask = 0x3 if self.e_size == 2 else 0x7
+        M_mask = 0x3 if self.m_size == 2 else 0x7
+
+        S = ((data >> self.s_shift) & 0x1).type(dtype)
+        E = ((data >> E_shift) & E_mask).type(dtype)
+        M = (data & M_mask).type(dtype)
+
+        # The MXF6 E2M3 or E3M2 spec defines 0bS00000 as zero
+        value = torch.zeros_like(S)
+        is_zero = (E == 0) & (M == 0)
+        non_zero_mask = ~is_zero
+        if non_zero_mask.any():
+            S_nz = S[non_zero_mask]
+            E_nz = E[non_zero_mask]
+            M_nz = M[non_zero_mask]
+
+            sign = torch.pow(-1, S_nz)
+            # Normal and subnormal handling for the exponent and mantissa
+            E_bias = 1 if self.e_size == 2 else 3
+            M_factor = 0.25 if self.m_size == 2 else 0.125
+            exponent = torch.where(E_nz == 0, E_nz, E_nz - E_bias)
+            mantissa = torch.where(E_nz == 0, M_nz * M_factor, 1.0 + M_nz * M_factor)
+            value_nz = sign * torch.pow(2, exponent) * mantissa
+
+            value[non_zero_mask] = value_nz
+
+        # For zeros, the values must remain zero with the correct sign
+        value[is_zero & (S == 1)] *= -1
+        return value.type(torch.float32)
+
+    def _from_float(self, values):
+        """
+        Convert float32 numbers to mxf6 e2m3/e3m2 format.
+        * No encodings are reserved for Inf or NaN in mxf6.
+        * Conversion from float supports roundTiesToEven rounding mode.
+        * If a value exceeds the mxf6 representable range after rounding,
+          clamps to the maximum mxf6 magnitude, preserving the sign.
+        * If a value has magnitude less than the minimum subnormal magnitude
+          in mxf6 after rounding, converts to zero.
+
+        Parameters:
+        - values: A torch tensor of float32 numbers to convert to fp6e2m3 format.
+        """
+        S = torch.signbit(values).type(torch.uint8)
+        abs_values = torch.abs(values)
+
+        is_zero = (abs_values == 0)
+        is_invalid = torch.isnan(values) | torch.isinf(values)
+
+        # Enumerate all possible E2M3/E3M2 exponent and mantissa values. We will
+        # use these to compare the distance between float32 and all possible
+        # E2M3/E3M2 floats to find the nearest E2M3/E3M2 representable value
+        E_shift = self.m_size
+        E_range = 4 if self.e_size == 2 else 8
+        E_bits = torch.arange(0, E_range, dtype=torch.uint8, device=self.device)
+        M_range = 4 if self.m_size == 2 else 8
+        M_factor = 0.25 if self.m_size == 2 else 0.125
+        M_bits = torch.arange(0, M_range, dtype=torch.uint8, device=self.device)
+        E_bias = 1 if self.e_size == 2 else 3
+
+        candidate_values = []
+        candidate_E = []
+        candidate_M = []
+
+        for E in E_bits:
+            if E == 0:
+                # Subnormals
+                exponent = 0
+                for M in M_bits:
+                    significand = M * M_factor
+                    value = significand * (2**exponent)
+                    candidate_values.append(value)
+                    candidate_E.append(E)
+                    candidate_M.append(M)
+            else:
+                # Normals
+                exponent = E.item() - E_bias
+                for M in M_bits:
+                    significand = 1.0 + M * M_factor
+                    value = significand * (2**exponent)
+                    candidate_values.append(value)
+                    candidate_E.append(E)
+                    candidate_M.append(M)
+
+        candidates = torch.tensor(candidate_values, dtype=torch.float32, device=self.device)
+        candidate_E = torch.tensor(candidate_E, dtype=torch.uint8, device=self.device)
+        candidate_M = torch.tensor(candidate_M, dtype=torch.uint8, device=self.device)
+
+        abs_values_flat = abs_values.view(-1)
+        N = abs_values_flat.shape[0]
+        abs_values_expanded = abs_values_flat.unsqueeze(1)
+
+        # Clamp invalid values to the max e2m3/e3m2 representable value
+        max_candidate_value = candidates.max().item()
+
+        abs_values_flat[is_invalid.view(-1)] = max_candidate_value
+
+        # Compute distance between all abs_values and candidate e2m1 values
+        errors = torch.abs(abs_values_expanded - candidates.unsqueeze(0))
+
+        # To implement roundTiesToEven, we need to break ties by preferring
+        # even mantissas (M == 0). We do so by adding an epsilon bias to shift
+        # the closest candidate with an even mantissa closer to the float value
+        min_errors, _ = torch.min(errors, dim=1, keepdim=True)
+        is_tie = (errors == min_errors)
+        # More than one candidate has the min error for some float value
+        if torch.any(is_tie):
+            M_bits_expanded = candidate_M.unsqueeze(0).expand(N, -1)
+            tie_breaker = (M_bits_expanded == 0).type(torch.int32)
+
+            errors = errors - (tie_breaker * 1e-6)
+
+        best_indices = torch.argmin(errors, dim=1)
+
+        E_selected = candidate_E[best_indices]
+        M_selected = candidate_M[best_indices]
+        E = E_selected.view(abs_values.shape)
+        M = M_selected.view(abs_values.shape)
+
+        E[is_zero] = 0
+        M[is_zero] = 0
+
+        return ((S << self.s_shift) | (E << E_shift) | M).type(torch.uint8)
+
+    def to_packed_tensor(self, dim):
+        """
+        Packs 32 e2m3 elements into 24 uint8's along the specified dimension.
+        and padding the last 8 uint8's with 0's
+
+        Parameters:
+        - dim: The dimension along which to pack the elements.
+
+        Returns:
+        - A torch tensor of dtype uint8 with 32 e2m3 elements packed into one uint8.
+        """
+        data = self.data
+        orig_shape = data.shape
+        assert 0 <= dim < data.ndim, \
+            "The dimension to pack along is not within the range of tensor dimensions"
+        size_along_dim = data.size(dim)
+        assert size_along_dim % 4 == 0, "Dim must be multiple of 4"
+        new_size_along_dim = size_along_dim // 4
+        new_shape = list(data.shape)
+        new_shape[dim] = new_size_along_dim
+        # reshape to the dim dimension to dim/4, 4
+        new_shape.insert(dim + 1, 4)
+        data = data.reshape(*new_shape)
+
+        elem0 = data.select(dim + 1, 0)
+        elem1 = data.select(dim + 1, 1)
+        elem2 = data.select(dim + 1, 2)
+        elem3 = data.select(dim + 1, 3)
+
+        # pack the 4 fp6e2m3 into 3 uint8's
+        out0 = (elem1 << 6) | elem0
+        out1 = (elem2 << 4) | ((elem1 >> 2) & 0xF)
+        out2 = elem3 << 2 | ((elem2 >> 4) & 0x3)
+        out3 = torch.zeros_like(elem0)
+
+        packed = torch.stack((out0, out1, out2, out3), dim=dim + 1)
+        packed = packed.reshape(orig_shape)
+
+        return packed
+
+    def unpack_packed_tensor(self, packed_tensor, dim):
+        """
+        Unpacks a tensor where 4 fp6e2m3 elements are packed into 3 uint8.
+
+        Parameters:
+        - packed_tensor: The packed tensor
+        - dim: The dimension along which the tensor was packed.
+        - original_shape: The shape of the original tensor before packing.
+
+        Returns:
+        - A tensor with the original data unpacked into uint8 elements containing one
+          fp6e2m3 element in the least significant bits.
+        """
+        original_shape = packed_tensor.shape
+        size_along_dim = packed_tensor.size(dim)
+        assert size_along_dim % 4 == 0, "Dim must be multiple of 4"
+        new_size_along_dim = size_along_dim // 4
+        new_shape = list(packed_tensor.shape)
+        new_shape[dim] = new_size_along_dim
+
+        # reshape to the dim dimension to dim/4, 4
+        new_shape.insert(dim + 1, 4)
+        packed_tensor = packed_tensor.reshape(*new_shape)
+
+        elem0 = packed_tensor.select(dim + 1, 0)
+        elem1 = packed_tensor.select(dim + 1, 1)
+        elem2 = packed_tensor.select(dim + 1, 2)
+        packed_tensor.select(dim + 1, 3)
+
+        out0 = elem0 & 0x3F
+        out1 = ((elem1 << 2) & 0x3C) | ((elem0 >> 6) & 0x3)
+        out2 = ((elem2 << 4) & 0x30) | ((elem1 >> 4) & 0xF)
+        out3 = (elem2 >> 2) & 0x3F
+
+        unpacked = torch.stack((out0, out1, out2, out3), dim=dim + 1)
+        unpacked = unpacked.reshape(original_shape)
+
+        return unpacked.type(torch.uint8)
 
 
 class MXScaleTensor:

--- a/test/TritonGPU/amd/accelerate-amd-matmul-mfma-gfx950.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-mfma-gfx950.mlir
@@ -135,6 +135,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK{LITERAL}: #linear = #ttg.linear<{register = [[0, 2], [64, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 1]], warp = [[0, 0], [32, 0]], block = []}>
+// CHECK{LITERAL}: #linear1 = #ttg.linear<{register = [[0, 2], [64, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 1]], warp = [[32, 0], [0, 0]], block = []}>
+// CHECK-LABEL: mfma_dot_scaled_mxfp6e2_mxfp6e2
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mfma_dot_scaled_mxfp6e2_mxfp6e2(
+      %arg0: tensor<128x128xi8, #blocked>,
+      %arg1: tensor<128x128xi8, #blocked>,
+      %arg2: tensor<128x4xi8, #blocked1>,
+      %arg3: tensor<128x4xi8, #blocked1>,
+      %arg4: tensor<128x128x!tt.ptr<f32>, #blocked>
+      ) {
+    // CHECK-NOT: arith.constant dense<127> : tensor<128x4xi8, #linear>
+    // CHECK-NOT: arith.constant dense<127> : tensor<128x4xi8, #linear1>
+    // CHECK-NOT: tt.fp_to_fp
+    // CHECK: %[[C:.+]] = ttg.convert_layout {{.*}} : tensor<128x128xf32, #blocked> -> tensor<128x128xf32, #mma>
+    // CHECK: %[[A:.+]] = ttg.convert_layout {{.*}} : tensor<128x128xi8, #blocked> -> tensor<128x128xi8, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 32}>>
+    // CHECK: %[[B:.+]] = ttg.convert_layout {{.*}} : tensor<128x128xi8, #blocked> -> tensor<128x128xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 32}>>
+    // CHECK: %[[SCALE0:.+]] = ttg.convert_layout {{.*}} : tensor<128x4xi8, #blocked1> -> tensor<128x4xi8, #linear>
+    // CHECK: %[[SCALE1:.+]] = ttg.convert_layout {{.*}} : tensor<128x4xi8, #blocked1> -> tensor<128x4xi8, #linear1>
+    // CHECK: tt.dot_scaled %[[A]] scale %[[SCALE0]], %[[B]] scale %[[SCALE1]], %[[C]] lhs = e2m3 rhs = e2m3
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %1 = tt.dot_scaled %arg0 scale %arg2, %arg1 scale %arg3, %cst lhs = e2m3 rhs = e2m3 {fastMath = false} : tensor<128x128xi8, #blocked>, tensor<128x4xi8, #blocked1> * tensor<128x128xi8, #blocked>, tensor<128x4xi8, #blocked1> -> tensor<128x128xf32, #blocked>
+    tt.store %arg4, %1 : tensor<128x128x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK-LABEL: mfma_dot_scaled_fp8e4_mxfp4
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   tt.func public @mfma_dot_scaled_fp8e4_mxfp4(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -287,7 +287,7 @@ struct DotOpMFMAConversionHelper {
     intrinsicName = maybeMfmaIntrinsic->name;
 
     // If we are using XF32, the kWidth (and kBase) is double that of F32.
-    if (aTensorTy.getElementType().isF32() && allowXF32)
+    if (elemTyA.isF32() && allowXF32)
       kWidth *= 2;
 
     const auto kDimInstrSize = mfmaLayout.getInstrShapeForOperand(kWidth, 0)[1];
@@ -324,11 +324,11 @@ struct DotOpMFMAConversionHelper {
 
     bool preserveBF16 = intrinsicName.contains(".bf16") && mfmaVersion >= 4;
     auto operandA = getValuesFromDotOperandLayoutStruct(
-        loadedA, numRepB, numRepM, numRepKA, kWidth, kBase,
-        aTensorTy.getElementType(), allowXF32, preserveBF16);
+        loadedA, numRepB, numRepM, numRepKA, kWidth, kBase, elemTyA, nullptr,
+        allowXF32, preserveBF16);
     auto operandB = getValuesFromDotOperandLayoutStruct(
-        loadedB, numRepB, numRepN, numRepKB, kWidth, kBase,
-        bTensorTy.getElementType(), allowXF32, preserveBF16);
+        loadedB, numRepB, numRepN, numRepKB, kWidth, kBase, elemTyB, nullptr,
+        allowXF32, preserveBF16);
 
     int warpSize = triton::gpu::lookupThreadsPerWarp(rewriter);
     int elemsPerVec = mDim * nDim / warpSize;
@@ -408,27 +408,29 @@ struct DotOpMFMAConversionHelper {
   /// rawElems is a vector of kBase elements. Each element is of the raw
   /// element type from the input. We need to prepare a vector of kBase
   /// elements of appropriate element type required by mfma instructions.
-  Value prepareOperands(Value rawElems, int kBase, Type type, bool preserveBF16,
-                        bool isConstantScale = false,
-                        bool isFP6 = false) const {
+  Value prepareOperands(Value rawElems, Type rawType, Type underlyingType,
+                        int kBase, bool preserveBF16,
+                        bool isConstantScale = false) const {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     Value results;
 
-    // Construct a vector type of kBase elements with desired type
+    const bool isFP6 = isa<Float6E2M3FNType, Float6E3M2FNType>(underlyingType);
+
+    // Construct a vector raw type of kBase elements with desired type
     if (isFP6)
-      assert(type.getIntOrFloatBitWidth() == 8);
+      assert(rawType.getIntOrFloatBitWidth() == 8);
     const int vecSize = isFP6 ? (kBase * 3) / 4 : kBase;
 
-    auto vecTy = vec_ty(type, vecSize);
-    if (type.isBF16() && !preserveBF16)
+    auto vecTy = vec_ty(rawType, vecSize);
+    if (rawType.isBF16() && !preserveBF16)
       vecTy = vec_ty(i16_ty, vecSize);
     Value vec = b.undef(vecTy);
 
     // For each element in rawElems, extract the element as the desired type,
     // bitcast it if needed, and insert it into vec.
     for (int elemId = 0, counter = 0; elemId < kBase; ++elemId) {
-      auto val = b.extract_element(type, rawElems, b.i32_val(elemId));
-      if (type.isBF16() && !preserveBF16) {
+      auto val = b.extract_element(rawType, rawElems, b.i32_val(elemId));
+      if (rawType.isBF16() && !preserveBF16) {
         // rocdl.mfma.f32.32x32x8bf16.1k calls for input of i16 type
         auto cast = b.bitcast(val, i16_ty);
         vec = b.insert_element(vecTy, vec, cast, b.i32_val(elemId));
@@ -441,7 +443,7 @@ struct DotOpMFMAConversionHelper {
 
     // Now we have a vector of kBase elements of desired type.
     // Then we need to prepare vec for results.
-    if (type.getIntOrFloatBitWidth() == 8) {
+    if (rawType.getIntOrFloatBitWidth() == 8) {
       if (vecSize == 1) {
         // This is only for the scale operands of scaled mfma on CDNA4
         results = b.zext(i32_ty, b.bitcast(vec, i8_ty));
@@ -467,11 +469,15 @@ struct DotOpMFMAConversionHelper {
   }
 
   /// Converts dot operand structure to value table and converts types
-  /// appropriate for mfma instructions
+  /// appropriate for mfma instructions.
+  /// Note, for many case, underlyingType and wrappedType are the same.
+  /// These are different for FP4 and FP6 because they are packed into
+  /// larger types.
   virtual ValueTable getValuesFromDotOperandLayoutStruct(
       Value value, int batch, int nonKRep, int kRepInKWidth, int kWidth,
-      int kBase, Type type, bool allowXF32, bool preserveBF16,
-      bool isConstantScale = false, bool isFP6 = false) const {
+      int kBase, Type underlyingType, Type wrappedType, bool allowXF32,
+      bool preserveBF16, bool isConstantScale = false) const {
+    wrappedType = wrappedType == nullptr ? underlyingType : wrappedType;
     auto tb = TritonLLVMOpBuilder(loc, rewriter);
     auto elems = unpackLLElements(loc, value, rewriter);
     // number of kBase-element vectors
@@ -493,33 +499,36 @@ struct DotOpMFMAConversionHelper {
           // Step 1: construct each kBase-element vector by
           //         - extracting kBase elements from elems and
           //         - putting them into a kBase-element vector, i.e. rawElems
-          Type elemTy = typeConverter->convertType(type);
-          Type ty = vec_ty(elemTy, kBase);
-          Value rawElems = tb.undef(ty);
+          Type wrappedElemTy = typeConverter->convertType(wrappedType);
+          Type wrappedTy = vec_ty(wrappedElemTy, kBase);
+          Value rawElems = tb.undef(wrappedTy);
           for (int k = 0; k < kBase; ++k) {
             auto index = linearize({b, nonK, kBaseVec, k}, strides);
-            rawElems =
-                tb.insert_element(ty, rawElems, elems[index], tb.i32_val(k));
+            rawElems = tb.insert_element(wrappedTy, rawElems, elems[index],
+                                         tb.i32_val(k));
           }
 
-          // Step 2: process rawElems based on element type
+          // Step 2: process rawElems based on element wrapped type
           // Note that for f32/fp64 input and XF32 is not allowed, nothing needs
           // to be done and rawElems is inserted into the ValueTable directly
-          if ((type.isF32() || type.isF64()) && !allowXF32) {
+          if ((wrappedType.isF32() || wrappedType.isF64()) && !allowXF32) {
             dotOpVals[{b, nonK, kBaseVec}] =
-                tb.extract_element(type, rawElems, tb.i32_val(0));
+                tb.extract_element(wrappedType, rawElems, tb.i32_val(0));
           } else {
             Value vals;
-            if (type.isF32() && allowXF32) {
-              vals = prepareOperands(rawElems, kBase, f32_ty, preserveBF16);
-            } else if (type.getIntOrFloatBitWidth() == 8) {
-              vals = prepareOperands(rawElems, kBase, i8_ty, preserveBF16,
-                                     isConstantScale, isFP6);
-            } else if (type.isBF16()) {
-              vals = prepareOperands(rawElems, kBase, bf16_ty, preserveBF16);
+            if (wrappedType.isF32() && allowXF32) {
+              vals = prepareOperands(rawElems, f32_ty, underlyingType, kBase,
+                                     preserveBF16);
+            } else if (wrappedType.getIntOrFloatBitWidth() == 8) {
+              vals = prepareOperands(rawElems, i8_ty, underlyingType, kBase,
+                                     preserveBF16, isConstantScale);
+            } else if (wrappedType.isBF16()) {
+              vals = prepareOperands(rawElems, bf16_ty, underlyingType, kBase,
+                                     preserveBF16);
             } else {
-              assert(type.isF16() && "Unsupported data type");
-              vals = prepareOperands(rawElems, kBase, f16_ty, preserveBF16);
+              assert(wrappedType.isF16() && "Unsupported data type");
+              vals = prepareOperands(rawElems, f16_ty, underlyingType, kBase,
+                                     preserveBF16);
             }
 
             // Step 3: Insert the processed vals into the ValueTable
@@ -629,11 +638,6 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
     Type aElemMLIRType = op.getAElemMLIRType();
     Type bElemMLIRType = op.getBElemMLIRType();
 
-    const bool isAFP6 = aElemType == ScaleDotElemType::E2M3 ||
-                        aElemType == ScaleDotElemType::E3M2;
-    const bool isBFP6 = bElemType == ScaleDotElemType::E2M3 ||
-                        bElemType == ScaleDotElemType::E3M2;
-
     int64_t kDimOperandSize = aTensorTy.getShape().back();
 
     auto ctx = op.getContext();
@@ -704,13 +708,11 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
     int bNonKPackedVals = scaleBKBase / bkPackedVals;
 
     auto operandA = getValuesFromDotOperandLayoutStruct(
-        loadedA, numRepB, numRepM, numRepK, aKWidth, aKBase,
-        aTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false, false,
-        isAFP6);
+        loadedA, numRepB, numRepM, numRepK, aKWidth, aKBase, aElemMLIRType,
+        elemTyA, allowXF32, /*preserveBF16=*/false, false);
     auto operandB = getValuesFromDotOperandLayoutStruct(
-        loadedB, numRepB, numRepN, numRepK, bKWidth, bKBase,
-        bTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false, false,
-        isBFP6);
+        loadedB, numRepB, numRepN, numRepK, bKWidth, bKBase, bElemMLIRType,
+        elemTyB, allowXF32, /*preserveBF16=*/false, false);
 
     // Scales have the same replica distributions as their corresponding
     // operands.
@@ -718,15 +720,17 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
     ValueTable operandBScale;
     if (existBothScales) {
       auto aScaleTensorTy = cast<RankedTensorType>(aScale.getType());
+      auto aScaleElemTy = aScaleTensorTy.getElementType();
       operandAScale = getValuesFromDotOperandLayoutStruct(
           loadedAScale, numRepB, numRepM, numRepK, scaleKWidth, scaleAKBase,
-          aScaleTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false,
+          aScaleElemTy, nullptr, allowXF32, /*preserveBF16=*/false,
           isAScaleConstant);
 
       auto bScaleTensorTy = cast<RankedTensorType>(bScale.getType());
+      auto bScaleElemTy = bScaleTensorTy.getElementType();
       operandBScale = getValuesFromDotOperandLayoutStruct(
           loadedBScale, numRepB, numRepN, numRepK, scaleKWidth, scaleBKBase,
-          bScaleTensorTy.getElementType(), allowXF32, /*preserveBF16=*/false,
+          bScaleElemTy, nullptr, allowXF32, /*preserveBF16=*/false,
           isBScaleConstant);
     }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -32,7 +32,6 @@ using namespace mlir::triton;
 
 namespace {
 
-using ::mlir::LLVM::AMD::scaleDotElemTypeToMLIRType;
 using ::mlir::LLVM::AMD::shuffleXor;
 using ::mlir::triton::gpu::AMDMfmaEncodingAttr;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;
@@ -627,6 +626,9 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
       llvm::report_fatal_error("unsuported data type\n");
     }
 
+    Type aElemMLIRType = op.getAElemMLIRType();
+    Type bElemMLIRType = op.getBElemMLIRType();
+
     const bool isAFP6 = aElemType == ScaleDotElemType::E2M3 ||
                         aElemType == ScaleDotElemType::E3M2;
     const bool isBFP6 = bElemType == ScaleDotElemType::E2M3 ||
@@ -638,8 +640,7 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
     constexpr bool allowXF32 = false;
     FailureOr<MfmaIntrinsic> maybeMfmaIntrinsic =
         MfmaIntrinsic::get(op.getLoc(), mfmaVersion, mDim, nDim, kDim,
-                           scaleDotElemTypeToMLIRType(ctx, aElemType),
-                           scaleDotElemTypeToMLIRType(ctx, bElemType),
+                           aElemMLIRType, bElemMLIRType,
                            /*withScale=*/true, allowXF32);
     if (failed(maybeMfmaIntrinsic))
       return op.emitError("no matching matrix core intrinsic ")

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -584,10 +584,8 @@ LogicalResult convertScaledDot(triton::DotScaledOp op,
   auto dstElemTy = dTensorTy.getElementType();
   auto fc = unpackLLElements(loc, loadedC, rewriter);
 
-  Type scaledAElemType =
-      LLVM::AMD::scaleDotElemTypeToMLIRType(op.getContext(), op.getAElemType());
-  Type scaledBElemType =
-      LLVM::AMD::scaleDotElemTypeToMLIRType(op.getContext(), op.getBElemType());
+  Type scaledAElemType = op.getAElemMLIRType();
+  Type scaledBElemType = op.getBElemMLIRType();
 
   unsigned warpSize = gpu::lookupThreadsPerWarp(rewriter);
   // compute number of output elements that each thread holds for one WMMA

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -580,27 +580,6 @@ unsigned getVectorSize(Value ptr, Value offset,
   return std::min<unsigned>(128 / pointeeBitWidth, contiguity);
 }
 
-Type scaleDotElemTypeToMLIRType(MLIRContext *ctx, triton::ScaleDotElemType t) {
-  switch (t) {
-  case triton::ScaleDotElemType::FP16:
-    return Float16Type::get(ctx);
-  case triton::ScaleDotElemType::BF16:
-    return BFloat16Type::get(ctx);
-  case triton::ScaleDotElemType::E4M3:
-    return Float8E4M3FNType::get(ctx);
-  case triton::ScaleDotElemType::E5M2:
-    return Float8E5M2Type::get(ctx);
-  case triton::ScaleDotElemType::E3M2:
-    return Float6E3M2FNType::get(ctx);
-  case triton::ScaleDotElemType::E2M3:
-    return Float6E2M3FNType::get(ctx);
-  case triton::ScaleDotElemType::E2M1:
-    return Float4E2M1FNType::get(ctx);
-  default:
-    llvm_unreachable("unsupported ScaleDotElemType!");
-  }
-}
-
 bool canCoalesceWriteIntoSharedMemory(MLIRContext *ctx,
                                       const LinearLayout &srcToSharedLayout,
                                       unsigned threadsPerWarp,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -93,8 +93,6 @@ unsigned getVectorSize(Value ptr, ModuleAxisInfoAnalysis &axisAnalysisPass);
 unsigned getVectorSize(Value ptr, Value offset,
                        ModuleAxisInfoAnalysis &axisAnalysisPass);
 
-Type scaleDotElemTypeToMLIRType(MLIRContext *ctx, triton::ScaleDotElemType t);
-
 // Returns true if we can perform coalesced write from the source encoding to
 // the destination encoding for a given vec size.
 bool canCoalesceWriteIntoSharedMemory(MLIRContext *ctx,

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -806,8 +806,15 @@ public:
 
     ScaleDotElemType aElemType = dotOp.getAElemType();
     ScaleDotElemType bElemType = dotOp.getBElemType();
-    if (!isF16F8F4(aElemType) || !isF16F8F4(bElemType))
-      return rewriter.notifyMatchFailure(dotOp, "NYI: mxfp6 operand");
+    auto supportsTypes = [](ScaleDotElemType elemType) {
+      return elemType == ScaleDotElemType::E2M1 ||
+             elemType == ScaleDotElemType::E4M3 ||
+             elemType == ScaleDotElemType::E5M2 ||
+             elemType == ScaleDotElemType::BF16 ||
+             elemType == ScaleDotElemType::FP16;
+    };
+    if (!supportsTypes(aElemType) || !supportsTypes(bElemType))
+      return rewriter.notifyMatchFailure(dotOp, "unknown operand type");
 
     MLIRContext *ctx = dotOp.getContext();
     auto moduleOp = dotOp->getParentOfType<ModuleOp>();
@@ -1084,12 +1091,14 @@ public:
     ScaleDotElemType bElemType = dotOp.getBElemType();
     auto supportsTypes = [](ScaleDotElemType elemType) {
       return elemType == ScaleDotElemType::E2M1 ||
+             elemType == ScaleDotElemType::E3M2 ||
+             elemType == ScaleDotElemType::E2M3 ||
              elemType == ScaleDotElemType::E4M3 ||
              elemType == ScaleDotElemType::E5M2;
     };
 
     if (!supportsTypes(aElemType) || !supportsTypes(bElemType)) {
-      return rewriter.notifyMatchFailure(dotOp, "NYI: mxfp6");
+      return rewriter.notifyMatchFailure(dotOp, "unknown operand type");
     }
 
     bool bothScalesAbsent = !aScale && !bScale;
@@ -1142,11 +1151,24 @@ public:
     auto order = ttg::getMatrixOrder(rank, /*rowMajor=*/true);
     auto standardOutDims = standardOutDimNames(ctx, rank);
 
-    // For the mfma_scale_f32_*_f8f6f4 instructions, each thread consumes 32
-    // elements. But since two fp4 elements are packed into one int8, the
-    // kWidth is 16 for fp4.
     const unsigned kWidth = kBase;
     assert(kWidth == 32);
+
+    auto selectKWidthForDotOperand = [kWidth](ScaleDotElemType elemType) {
+      // For the mfma_scale_f32_*_f8f6f4 instructions
+      if (elemType == ScaleDotElemType::E3M2 ||
+          elemType == ScaleDotElemType::E2M3)
+        // Regarding fp6, there is a single 32-element consecutive group along
+        // K-dim
+        return kWidth;
+      else
+        // Regarding fp8, there are two 16-element consecutive groups
+        // distributed along K-dim. Regarding fp4, there is a single 32-element
+        // consecutive group along K-dim But since two fp4 elements are packed
+        // into one int8; thus the kWidth is halved for fp4.
+        return kWidth / 2;
+    };
+
     using basisT = std::vector<std::vector<int32_t>>;
 
     auto aShape = a.getType().getShape();
@@ -1158,8 +1180,9 @@ public:
                                   unsigned opIdx) -> TensorValue {
       auto vType = v.getType();
 
-      auto newEnc =
-          DotOperandEncodingAttr::get(ctx, opIdx, mfmaEnc, kWidth / 2);
+      const ScaleDotElemType elemType = opIdx == 0 ? aElemType : bElemType;
+      auto newEnc = DotOperandEncodingAttr::get(
+          ctx, opIdx, mfmaEnc, selectKWidthForDotOperand(elemType));
 
       bool kPacked = opIdx == 0 ? dotOp.getLhsKPack() : dotOp.getRhsKPack();
       if (kPacked == false) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -247,8 +247,6 @@ FailureOr<MfmaIntrinsic> chooseMfmaInstruction(tt::DotOp dot, int mfmaVersion,
 
 FailureOr<MfmaIntrinsic> chooseMfmaInstruction(tt::DotScaledOp dot,
                                                int mfmaVersion, int nonKDim) {
-  using ::mlir::LLVM::AMD::scaleDotElemTypeToMLIRType;
-
   auto ctx = dot.getContext();
   int64_t inputKDim = dot.getA().getType().getShape().back();
   if (dot.getAElemType() == ScaleDotElemType::E2M1 && dot.getLhsKPack()) {
@@ -256,8 +254,8 @@ FailureOr<MfmaIntrinsic> chooseMfmaInstruction(tt::DotScaledOp dot,
     // need to multiply it by 2.
     inputKDim *= 2;
   }
-  Type aElemType = scaleDotElemTypeToMLIRType(ctx, dot.getAElemType());
-  Type bElemType = scaleDotElemTypeToMLIRType(ctx, dot.getBElemType());
+  Type aElemType = dot.getAElemMLIRType();
+  Type bElemType = dot.getBElemMLIRType();
   return chooseMfmaInstruction(dot.getLoc(), mfmaVersion, dot.getC().getType(),
                                aElemType, bElemType, inputKDim, nonKDim,
                                /*withScale=*/true, /*allowXF32=*/false);


### PR DESCRIPTION
This PR adds some initial support for the `mxfp6` data type on AMD GPUs (GFX950), which later can be extended and improved. Every 4 `fp6` elements are packed into 24 bits. To stick to the power of 2, we pad the pack (i.e., 4x `fp6` elements) with 8 bits. This PR brings changes to the AMD backend as well as to the Triton frontend and tests.

Note, the current implementation doesn't bring any benefits regrading reducing traffic between CUs and HBM but 1) reduces the number of VGPRs per MFMA instruction in comparison to MXFP8 dtype and 2) allows wider range of input values in comparison to MXFP4 dtype. 

Note, MXFP6 support for GFX1250+ comes in a next PR

cc @scxiao, @antiagainst 
