### PR TITLE
[NVWS] Assign final try_wait to a partition.

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -18,6 +18,7 @@ class ForOp;
 
 static constexpr char kPartitionAttrName[] = "ttg.partition";
 static constexpr char kPartitionStagesAttrName[] = "ttg.partition.stages";
+static constexpr char kWarpSpecializeTagAttrName[] = "ttg.warp_specialize.tag";
 
 //===----------------------------------------------------------------------===//
 // WarpSchedule
@@ -54,6 +55,9 @@ class WarpSchedule {
   static constexpr int kSentinel = -1;
 
 public:
+  // Get WarpSpecialization tag
+  int getTag() const { return tag; }
+
   // Create a new partition with a stage.
   Partition *addPartition(unsigned stage);
 
@@ -123,6 +127,8 @@ public:
   LLVM_DUMP_METHOD void dump() const;
 
 private:
+  // WarpSpecialization tag
+  int tag;
   // Partitions are numbered [0, N).
   SmallVector<std::unique_ptr<Partition>> partitions;
   // A mapping from operation to its partition.

--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -115,8 +115,7 @@ DenseMap<Operation *, int> deserializeLatencies(Operation *op);
 Value createScalarAlloc(ImplicitLocOpBuilder &rewriter, Type type,
                         unsigned numBuffers);
 // Create an allocation and init the mbarriers.
-Value createBarrierAlloc(scf::ForOp forOp, int numBarriers,
-                         int arriveCount = 1);
+Value createBarrierAlloc(Operation *op, int numBarriers, int arriveCount = 1);
 // Create an allocation that can hold distance number of tensor shapes.
 Value createAlloc(Operation *insertBefore, RankedTensorType ty, Location loc,
                   gpu::SharedEncodingTrait sharedEnc, unsigned distance);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -465,9 +465,9 @@ Value mlir::triton::createScalarAlloc(ImplicitLocOpBuilder &rewriter, Type type,
 }
 
 // Create an allocation and init the mbarriers.
-Value mlir::triton::createBarrierAlloc(scf::ForOp forOp, int numBarriers,
+Value mlir::triton::createBarrierAlloc(Operation *op, int numBarriers,
                                        int arriveCount) {
-  ImplicitLocOpBuilder rewriter(forOp.getLoc(), forOp);
+  ImplicitLocOpBuilder rewriter(op->getLoc(), op);
 
   Value barrierAlloc =
       createScalarAlloc(rewriter, rewriter.getI64Type(), numBarriers);
@@ -476,7 +476,7 @@ Value mlir::triton::createBarrierAlloc(scf::ForOp forOp, int numBarriers,
     rewriter.create<ttng::InitBarrierOp>(barrierView, arriveCount);
   }
   // Invalidate and deallocate the barriers.
-  rewriter.setInsertionPointAfter(forOp);
+  rewriter.setInsertionPointAfter(op);
   for (unsigned i = 0; i < numBarriers; i++) {
     Value barrierView = createSingleBufferView(rewriter, barrierAlloc, i);
     rewriter.create<ttng::InvalBarrierOp>(barrierView);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -123,7 +123,12 @@ FailureOr<WarpSchedule> WarpSchedule::deserialize(scf::ForOp loop) {
   if (!stages)
     return failure();
 
+  auto tag = loop->getAttrOfType<IntegerAttr>(kWarpSpecializeTagAttrName);
+  if (!tag)
+    return failure();
+
   WarpSchedule result;
+  result.tag = tag.getInt();
   for (auto [idx, attr] : llvm::enumerate(stages)) {
     auto stage = dyn_cast<IntegerAttr>(attr);
     if (!stage || stage.getInt() < 0) {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -143,46 +143,6 @@ const Partition *getPartition(Operation *op, const WarpSchedule &schedule) {
   return nullptr;
 }
 
-void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
-                     const WarpSchedule &schedule);
-
-void cloneForOp(scf::ForOp forOp, SmallVector<WarpGroupBuilder> &builders,
-                const WarpSchedule &schedule) {
-  SmallVector<scf::ForOp> newForOps;
-  for (auto [b, partition] : llvm::zip(builders, schedule.getPartitions())) {
-    auto [newLoopIndices, _] =
-        getLoopVarIndicesToKeep(forOp, &partition, schedule);
-    auto lb = b.mapping.lookupOrDefault(forOp.getLowerBound());
-    auto ub = b.mapping.lookupOrDefault(forOp.getUpperBound());
-    auto step = b.mapping.lookupOrDefault(forOp.getStep());
-    SmallVector<Value> initArgs;
-    for (auto idx : newLoopIndices) {
-      initArgs.push_back(forOp.getInitArgs()[idx]);
-    }
-    auto newForOp =
-        b.create<scf::ForOp>(forOp.getLoc(), lb, ub, step, initArgs);
-    newForOp->setAttrs(forOp->getAttrs());
-    newForOps.push_back(newForOp);
-
-    b.mapping.map(forOp.getInductionVar(), newForOp.getInductionVar());
-
-    auto oldIterArgs = forOp.getRegionIterArgs();
-    auto newIterArgs = newForOp.getRegionIterArgs();
-    for (auto [newIdx, oldIdx] : llvm::enumerate(newLoopIndices)) {
-      b.mapping.map(oldIterArgs[oldIdx], newIterArgs[newIdx]);
-      b.mapping.map(forOp.getResult(oldIdx), newForOp.getResult(newIdx));
-    }
-
-    b.setInsertionPointToStart(newForOp.getBody());
-  }
-
-  cloneOpsInBlock(forOp.getBody(), builders, schedule);
-
-  for (auto newForOp : newForOps) {
-    WarpSchedule::eraseFrom(newForOp);
-  }
-}
-
 void mapRange(ValueRange fromRange, ValueRange toRange, IRMapping &mapping) {
   for (auto [from, to] : llvm::zip(fromRange, toRange)) {
     mapping.map(from, to);
@@ -203,6 +163,47 @@ getPartitionIndicesToCloneInto(const Partition *partition,
   }
 
   return partitionIndices;
+}
+
+void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
+                     const WarpSchedule &schedule);
+
+void cloneForOp(scf::ForOp forOp, SmallVector<WarpGroupBuilder> &builders,
+                const WarpSchedule &schedule) {
+  SmallVector<std::pair<int, scf::ForOp>> newForOps;
+  for (auto [b, partition] : llvm::zip(builders, schedule.getPartitions())) {
+    auto [newLoopIndices, _] =
+        getLoopVarIndicesToKeep(forOp, &partition, schedule);
+    auto lb = b.mapping.lookupOrDefault(forOp.getLowerBound());
+    auto ub = b.mapping.lookupOrDefault(forOp.getUpperBound());
+    auto step = b.mapping.lookupOrDefault(forOp.getStep());
+    SmallVector<Value> initArgs;
+    for (auto idx : newLoopIndices) {
+      initArgs.push_back(forOp.getInitArgs()[idx]);
+    }
+    auto newForOp =
+        b.create<scf::ForOp>(forOp.getLoc(), lb, ub, step, initArgs);
+    newForOp->setAttrs(forOp->getAttrs());
+    newForOps.push_back(std::make_pair(partition.getIndex(), newForOp));
+
+    b.mapping.map(forOp.getInductionVar(), newForOp.getInductionVar());
+
+    auto oldIterArgs = forOp.getRegionIterArgs();
+    auto newIterArgs = newForOp.getRegionIterArgs();
+    for (auto [newIdx, oldIdx] : llvm::enumerate(newLoopIndices)) {
+      b.mapping.map(oldIterArgs[oldIdx], newIterArgs[newIdx]);
+      b.mapping.map(forOp.getResult(oldIdx), newForOp.getResult(newIdx));
+    }
+
+    b.setInsertionPointToStart(newForOp.getBody());
+  }
+
+  cloneOpsInBlock(forOp.getBody(), builders, schedule);
+
+  for (auto [partitionIdx, newForOp] : newForOps) {
+    builders[partitionIdx].setInsertionPointAfter(newForOp);
+    WarpSchedule::eraseFrom(newForOp);
+  }
 }
 
 void cloneIfOp(scf::IfOp ifOp, SmallVector<WarpGroupBuilder> &builders,
@@ -284,6 +285,20 @@ void cloneReduceOp(triton::ReduceOp reduceOp,
   }
 }
 
+void cloneOp(Operation *op, SmallVector<WarpGroupBuilder> &builders,
+             SmallVector<size_t> const &partitionIndices) {
+  if (op->getNumRegions() != 0) {
+    llvm::report_fatal_error(
+        "Ops are expected to be regionless at this point.");
+  }
+
+  for (size_t idx : partitionIndices) {
+    auto &builder = builders[idx];
+    auto newOp = builder.clone(*op, builder.mapping);
+    mapRange(op->getResults(), newOp->getResults(), builder.mapping);
+  }
+}
+
 void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
                      const WarpSchedule &schedule) {
   for (auto &op_ : *block) {
@@ -327,16 +342,7 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
         }
       }
     } else {
-      if (op->getNumRegions() != 0) {
-        llvm::report_fatal_error(
-            "Ops are expected to be regionless at this point.");
-      }
-
-      for (size_t idx : partitionIndices) {
-        auto &builder = builders[idx];
-        auto newOp = builder.clone(*op, builder.mapping);
-        mapRange(op->getResults(), newOp->getResults(), builder.mapping);
-      }
+      cloneOp(op, builders, partitionIndices);
     }
   }
 }
@@ -411,13 +417,26 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
     builders.push_back(WarpGroupBuilder(&block, block.end(), partitionId));
   }
 
-  cloneForOp(loop, builders, schedule);
+  SmallVector<Operation *> opsToErase;
+  for (auto &op_ : *loop->getBlock()) {
+    auto op = &op_;
+    auto wsTag = op->getAttrOfType<IntegerAttr>(kWarpSpecializeTagAttrName);
+    if (!wsTag || wsTag.getInt() != schedule.getTag())
+      continue;
+    if (auto partitionId = op->getAttrOfType<IntegerAttr>(kPartitionAttrName)) {
+      cloneOp(op, builders, {static_cast<size_t>(partitionId.getInt())});
+      opsToErase.push_back(op);
+    } else {
+      assert(loop.getOperation() == op && "Unexpected op");
+      cloneForOp(loop, builders, schedule);
+      opsToErase.push_back(loop);
+    }
+  }
 
   for (auto [b, region, partition] : llvm::zip(
            builders, wgOp.getPartitionRegions(), schedule.getPartitions())) {
-    auto newForOp = cast<scf::ForOp>(region.front().front());
+    auto newForOp = *region.front().getOps<scf::ForOp>().begin();
     auto outputs = newForOp.getResults();
-    b.setInsertionPointAfter(newForOp);
 
     if (b.partitionId == 0) {
       b.create<nvws::WarpGroupYieldOp>(wgOp.getLoc(), outputs);
@@ -463,7 +482,8 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
     }
   }
 
-  loop->erase();
+  for (auto op : llvm::reverse(opsToErase))
+    op->erase();
 
   return success();
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -541,11 +541,14 @@ void PartitionScheduling::runOnOperation() {
     if (loop->hasAttr(kWarpSpecializeAttrName))
       loops.push_back(loop);
   });
-  for (scf::ForOp loop : loops) {
+  for (auto [idx, loop] : llvm::enumerate(loops)) {
     if (std::optional<WarpSchedule> schedule = getInitialSchedule(loop)) {
       propagatePartitions(loop, *schedule);
       optimizeSchedule(loop, *schedule);
       schedule->serialize(loop);
+      loop->setAttr(
+          kWarpSpecializeTagAttrName,
+          IntegerAttr::get(IntegerType::get(loop.getContext(), 32), idx));
     }
   }
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -140,8 +140,6 @@ AsyncRef DependencyRewriter::allocateAsyncValue(RankedTensorType tensorType,
       triton::nvws::TypeArrayAttr::get(b.getContext(), alloc.getType()));
   auto aref = b.create<triton::nvws::ArefCreateOp>(b.getLoc(), arefTy, alloc);
 
-  endBuilder.create<nvws::ArefDestroyOp>(aref);
-
   return AsyncRef{aref, getBufferViewType(allocType),
                   b.getType<AsyncTokenType>()};
 }

--- a/test/NVWS/insert_aref.mlir
+++ b/test/NVWS/insert_aref.mlir
@@ -55,7 +55,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       // CHECK: [[C_ZERO4:%.*]] = arith.constant {ttg.partition = 1 : i32} 0
       // CHECK: nvws.aref.get.exit [[AREF1]][[[C_ZERO4]]], [[GET_TOKEN1]] [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
       scf.yield %8 : !ttg.async.token
-    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]}
+    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     %result_0, %token_1 = ttng.tmem_load %result[%1] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
     "use"(%result_0) : (tensor<128x128xf32, #blocked>) -> ()
     tt.return
@@ -75,7 +75,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       // CHECK: nvws.aref.get.exit {{.*}}, [[GET_TOKEN]] [#nvws.async_op<none>]
       // CHECK: "use"([[REG]])
       "use"(%0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
-    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]}
+    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
 
@@ -87,7 +87,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     scf.for %arg2 = %c0_i32 to %arg1 step %c1_i32  : i32 {
       %0 = "producer"(%arg0, %arg2) {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 1 : i32} : (tensor<128x64xf16, #blocked1>, i32) -> tensor<128x64xf16, #blocked1>
       "use"(%0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
-    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]}
+    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
 
@@ -110,7 +110,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       // CHECK: nvws.aref.get.exit {{.*}}, [[GET_TOKEN2]] [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
       "use1"(%0) {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
       "use2"(%alloc) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : (!ttg.memdesc<128x64xf16, #shared, #smem>) -> ()
-    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]}
+    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
 
@@ -131,7 +131,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       // CHECK: nvws.aref.get.exit {{.*}}, [[GET_TOKEN]] {{.*}} {loop.cluster = 1 : i32, loop.stage = 1
       "use1"(%0) {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
       "use2"(%alloc) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (!ttg.memdesc<128x64xf16, #shared, #smem>) -> ()
-    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]}
+    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
 
@@ -167,7 +167,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       %8 = ttng.tc_gen5_mma_scaled %5, %7, %result_2[%token], %result, %result_1, %true, %true lhs = e4m3 rhs = e4m3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>, !ttg.memdesc<64x128xf8E4M3FN, #shared4, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>, !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
       %result_3, %token_4 = ttng.tmem_load %result_2[%8] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
       scf.yield %result_3 : tensor<128x128xf32, #blocked>
-    } {tt.num_stages = 2 : i64, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]}
+    } {tt.num_stages = 2 : i64, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
 }

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -68,14 +68,14 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       }
       nvws.warp_group.return
     }
-    ttg.local_dealloc %0 : !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
-    nvws.aref.destroy %1 : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>
-    // CHECK: ttg.local_dealloc
+    // CHECK: nvws.warp_group.return
+    // CHECK-NEXT: }
     // CHECK-NEXT: scf.for
     // CHECK-NEXT:   [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
     // CHECK-NEXT:   ttng.inval_barrier [[EMPTYMBAR]]
     // CHECK-NEXT:   [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
     // CHECK-NEXT:   ttng.inval_barrier [[FULLMBAR]]
+    ttg.local_dealloc %0 : !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
     tt.return
   }
 
@@ -350,14 +350,12 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
       nvws.aref.get.exit %aref1[%c0_i32], %2#2 [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
       nvws.warp_group.return
     }
-    nvws.aref.destroy %aref0 : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
     // CHECK: scf.for
     // CHECK-NEXT:   [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY0]]
     // CHECK-NEXT:   ttng.inval_barrier [[EMPTYMBAR]]
     // CHECK-NEXT:   [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL0]]
     // CHECK-NEXT:   ttng.inval_barrier [[FULLMBAR]]
     // CHECK-NEXT: }
-    nvws.aref.destroy %aref1 : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
     // CHECK-NEXT: scf.for
     // CHECK-NEXT:   [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY1]]
     // CHECK-NEXT:   ttng.inval_barrier [[EMPTYMBAR]]
@@ -552,5 +550,3 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     tt.return
   }
 }
-
-// -----

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -176,7 +176,6 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 
 #shared0 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
-#tmem = #ttng.tensor_memory
 module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
   //CHECK-LABEL: @aref_lowering
   tt.func @aref_lowering(%d : !ttg.memdesc<3x64x16xf16, #shared0, #smem>,
@@ -198,7 +197,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     // CHECK:   init_barrier
     // CHECK:   init_barrier
     // CHECK:   init_barrier
-    %aref0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+    %aref0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
     // CHECK:   [[EMPTY0:%.*]] = ttg.local_alloc
     // CHECK:   init_barrier
@@ -208,7 +207,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     // CHECK:   init_barrier
     // CHECK:   init_barrier
     // CHECK:   init_barrier
-    %aref1 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+    %aref1 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
     nvws.warp_group
     partition0  num_warps(4) {

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -13,13 +13,15 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>
     // CHECK: [[BUF:%.*]] = ttg.local_alloc
     // CHECK-NEXT: [[EMPTY:%.*]] = ttg.local_alloc
+    // CHECK-NEXT: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.init_barrier [[EMPTYSLICE]], 2
+    // CHECK-NEXT: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.init_barrier [[EMPTYSLICE]], 2
     // CHECK-NEXT: [[FULL:%.*]] = ttg.local_alloc
-    // CHECK-NEXT: scf.for
-    // CHECK-NEXT:   [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
-    // CHECK-NEXT:   ttng.init_barrier [[EMPTYSLICE]], 2
-    // CHECK-NEXT:   [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL]]
-    // CHECK-NEXT:   ttng.init_barrier [[FULLSLICE]], 1
-    // CHECK-NEXT: }
+    // CHECK-NEXT: [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL]]
+    // CHECK-NEXT: ttng.init_barrier [[FULLSLICE]], 1
+    // CHECK-NEXT: [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL]]
+    // CHECK-NEXT: ttng.init_barrier [[FULLSLICE]], 1
     nvws.warp_group
     partition0 num_warps(4) {
       scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
@@ -70,11 +72,16 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     }
     // CHECK: nvws.warp_group.return
     // CHECK-NEXT: }
-    // CHECK-NEXT: scf.for
-    // CHECK-NEXT:   [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
-    // CHECK-NEXT:   ttng.inval_barrier [[EMPTYMBAR]]
-    // CHECK-NEXT:   [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
-    // CHECK-NEXT:   ttng.inval_barrier [[FULLMBAR]]
+    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
+    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
+    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
+    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
+    // CHECK-NEXT: ttg.local_dealloc
+    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
+    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
+    // CHECK-NEXT: ttg.local_dealloc
     ttg.local_dealloc %0 : !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
     tt.return
   }
@@ -86,13 +93,15 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>
     // CHECK: [[BUF:%.*]] = ttg.local_alloc
     // CHECK-NEXT: [[EMPTY:%.*]] = ttg.local_alloc
+    // CHECK-NEXT: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.init_barrier [[EMPTYSLICE]], 3
+    // CHECK-NEXT: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.init_barrier [[EMPTYSLICE]], 3
     // CHECK-NEXT: [[FULL:%.*]] = ttg.local_alloc
-    // CHECK-NEXT: scf.for
-    // CHECK-NEXT:   [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
-    // CHECK-NEXT:   ttng.init_barrier [[EMPTYSLICE]], 3
-    // CHECK-NEXT:   [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL]]
-    // CHECK-NEXT:   ttng.init_barrier [[FULLSLICE]], 1
-    // CHECK-NEXT: }
+    // CHECK-NEXT: [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL]]
+    // CHECK-NEXT: ttng.init_barrier [[FULLSLICE]], 1
+    // CHECK-NEXT: [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL]]
+    // CHECK-NEXT: ttng.init_barrier [[FULLSLICE]], 1
     nvws.warp_group
     partition0 num_warps(4) {
       scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
@@ -181,25 +190,25 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
     // CHECK:   [[C1:%.*]] = arith.constant 1 : i32
     %ub = arith.constant 4 : i32
 
-    // CHECK:        [[EMPTY0:%.*]] = ttg.local_alloc
-    // CHECK-NEXT:   [[FULL0:%.*]] = ttg.local_alloc
-    // CHECK-NEXT:   scf.for
-    // CHECK-NEXT:     [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY0]]
-    // CHECK-NEXT:     ttng.init_barrier [[EMPTYSLICE]], 1
-    // CHECK-NEXT:     [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL0]]
-    // CHECK-NEXT:     ttng.init_barrier [[FULLSLICE]], 2
-    // CHECK-NEXT:   }
-    %aref0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+    // CHECK:   [[EMPTY1:%.*]] = ttg.local_alloc
+    // CHECK:   init_barrier
+    // CHECK:   init_barrier
+    // CHECK:   init_barrier
+    // CHECK:   [[FULL1:%.*]] = ttg.local_alloc
+    // CHECK:   init_barrier
+    // CHECK:   init_barrier
+    // CHECK:   init_barrier
+    %aref0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
-    // CHECK:        [[EMPTY1:%.*]] = ttg.local_alloc
-    // CHECK-NEXT:   [[FULL1:%.*]] = ttg.local_alloc
-    // CHECK-NEXT:   scf.for
-    // CHECK-NEXT:     [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY1]]
-    // CHECK-NEXT:     ttng.init_barrier [[EMPTYSLICE]], 1
-    // CHECK-NEXT:     [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL1]]
-    // CHECK-NEXT:     ttng.init_barrier [[FULLSLICE]], 1
-    // CHECK-NEXT:   }
-    %aref1 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+    // CHECK:   [[EMPTY0:%.*]] = ttg.local_alloc
+    // CHECK:   init_barrier
+    // CHECK:   init_barrier
+    // CHECK:   init_barrier
+    // CHECK:   [[FULL0:%.*]] = ttg.local_alloc
+    // CHECK:   init_barrier
+    // CHECK:   init_barrier
+    // CHECK:   init_barrier
+    %aref1 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #tmem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
 
     nvws.warp_group
     partition0  num_warps(4) {
@@ -350,17 +359,22 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
       nvws.aref.get.exit %aref1[%c0_i32], %2#2 [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
       nvws.warp_group.return
     }
-    // CHECK: scf.for
-    // CHECK-NEXT:   [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY0]]
-    // CHECK-NEXT:   ttng.inval_barrier [[EMPTYMBAR]]
-    // CHECK-NEXT:   [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL0]]
-    // CHECK-NEXT:   ttng.inval_barrier [[FULLMBAR]]
+    // CHECK: warp_group.return
     // CHECK-NEXT: }
-    // CHECK-NEXT: scf.for
-    // CHECK-NEXT:   [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY1]]
-    // CHECK-NEXT:   ttng.inval_barrier [[EMPTYMBAR]]
-    // CHECK-NEXT:   [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL1]]
-    // CHECK-NEXT:   ttng.inval_barrier [[FULLMBAR]]
+    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL0]]
+    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
+    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL0]]
+    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
+    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL0]]
+    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
+    // CHECK-NEXT: ttg.local_dealloc
+    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY0]]
+    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
+    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY0]]
+    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
+    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY0]]
+    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
+    // CHECK-NEXT: ttg.local_dealloc
     tt.return
   }
 }
@@ -380,22 +394,28 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     %2 = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
     %3 = nvws.aref.create %2 : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>
     // CHECK: ttg.local_alloc
-    // CHECK-NEXT: [[EMPTY1:%.*]] = ttg.local_alloc
-    // CHECK-NEXT: [[FULL1:%.*]] = ttg.local_alloc
-    // CHECK-NEXT: scf.for
-    // CHECK-NEXT:   [[EMPTYBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
-    // CHECK-NEXT:   init_barrier [[EMPTYBAR1]], 2
-    // CHECK-NEXT:   [[FULLBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
-    // CHECK-NEXT:   init_barrier [[FULLBAR1]], 1
-
-    // CHECK: ttg.local_alloc
+    // CHECK-NEXT: ttg.local_alloc
     // CHECK-NEXT: [[EMPTY2:%.*]] = ttg.local_alloc
+    // CHECK-NEXT: memdesc_index
+    // CHECK-NEXT: init_barrier
+    // CHECK-NEXT: memdesc_index
+    // CHECK-NEXT: init_barrier
     // CHECK-NEXT: [[FULL2:%.*]] = ttg.local_alloc
-    // CHECK-NEXT: scf.for
-    // CHECK-NEXT:   [[EMPTYBAR2:%.*]] = ttg.memdesc_index [[EMPTY2]]
-    // CHECK-NEXT:   init_barrier [[EMPTYBAR2]], 2
-    // CHECK-NEXT:   [[FULLBAR2:%.*]] = ttg.memdesc_index [[FULL2]]
-    // CHECK-NEXT:   init_barrier [[FULLBAR2]], 1
+    // CHECK-NEXT: memdesc_index
+    // CHECK-NEXT: init_barrier
+    // CHECK-NEXT: memdesc_index
+    // CHECK-NEXT: init_barrier
+
+    // CHECK-NEXT: [[EMPTY1:%.*]] = ttg.local_alloc
+    // CHECK-NEXT: memdesc_index
+    // CHECK-NEXT: init_barrier
+    // CHECK-NEXT: memdesc_index
+    // CHECK-NEXT: init_barrier
+    // CHECK-NEXT: [[FULL1:%.*]] = ttg.local_alloc
+    // CHECK-NEXT: memdesc_index
+    // CHECK-NEXT: init_barrier
+    // CHECK-NEXT: memdesc_index
+    // CHECK-NEXT: init_barrier
     nvws.warp_group
     partition0 num_warps(4) {
       %5:2 = scf.for %arg3 = %arg0 to %arg1 step %arg2 iter_args(%arg4 = %cst, %arg5 = %cst) -> (tensor<1xi32, #blocked>, tensor<1xi32, #blocked>)  : i32 {
@@ -492,13 +512,8 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>
     // CHECK: ttg.local_alloc
-    // CHECK-NEXT: [[EMPTY1:%.*]] = ttg.local_alloc
-    // CHECK-NEXT: [[FULL1:%.*]] = ttg.local_alloc
-    // CHECK-NEXT: scf.for
-    // CHECK-NEXT:   [[EMPTYBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
-    // CHECK-NEXT:   init_barrier [[EMPTYBAR1]], 2
-    // CHECK-NEXT:   [[FULLBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
-    // CHECK-NEXT:   init_barrier [[FULLBAR1]], 1
+    // CHECK: [[EMPTY1:%.*]] = ttg.local_alloc
+    // CHECK: [[FULL1:%.*]] = ttg.local_alloc
     nvws.warp_group
     partition0 num_warps(4) {
       %2:2 = scf.for %arg3 = %arg0 to %arg1 step %arg2 iter_args(%arg4 = %cst, %arg5 = %cst_0) -> (tensor<1xi32, #blocked>, tensor<1xi32, #blocked>)  : i32 {

--- a/test/TritonGPU/load-mma-specialization.mlir
+++ b/test/TritonGPU/load-mma-specialization.mlir
@@ -129,10 +129,11 @@ tt.func @warp_specialize_tma_matmul(
     // CHECK-NEXT: yield %{{[0-9]+}}, [[IDX_NEXT]], [[PHASE_NEXT]]
     scf.yield %c : tensor<128x128xf32, #acc_layout>
 
-  // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
+  // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32
   } {tt.warp_specialize, tt.num_stages = 2 : i32}
 
-  // CHECK-NEXT: ttng.wait_barrier [[DONE_MBAR0]], %c0_i32
+  // CHECK-NEXT: [[DONE_MBAR0a:%.*]] = ttg.memdesc_index [[DONE_MBAR]], [[C0]] {ttg.partition = 1 : i32, ttg.warp_specialize.tag = 0 : i32}
+  // CHECK-NEXT: ttng.wait_barrier [[DONE_MBAR0a]], %c0_i32 {ttg.partition = 1 : i32, ttg.warp_specialize.tag = 0 : i32}
   // CHECK-NEXT: ttng.inval_barrier [[DONE_MBAR0]]
   // CHECK-NEXT: ttg.local_dealloc [[DONE_MBAR]]
 
@@ -152,7 +153,6 @@ tt.func @warp_specialize_tma_matmul(
   "use"(%result) : (tensor<128x128xf32, #acc_layout>) -> ()
   tt.return
 }
-
 // FUNC-LABEL: @unsupported_load
 // TMEM: ttng.tmem_alloc
 // TMEM: scf.for
@@ -163,6 +163,7 @@ tt.func @unsupported_load() {
   %c1_i32 = arith.constant 1 : i32
   %true = arith.constant true
   // CHECK-DAG: [[ZERO:%.*]] = arith.constant dense<0.0
+  // CHECK-DAG: [[C0:%.*]] = arith.constant 0 : i32
   %zero = arith.constant dense<0.0> : tensor<128x128xf32, #acc_layout>
   %k_tiles = arith.constant 32 : i32
 
@@ -191,10 +192,11 @@ tt.func @unsupported_load() {
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
     scf.yield %c : tensor<128x128xf32, #acc_layout>
-  // CHECK: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32]
+  // CHECK: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 1 : i32
   } {tt.warp_specialize}
 
-  // CHECK-NEXT: ttng.wait_barrier [[DONE_MBAR0]], %c0_i32
+  // CHECK-NEXT: [[DONE_MBAR0a:%.*]] = ttg.memdesc_index [[DONE_MBAR]], [[C0]] {ttg.partition = 1 : i32, ttg.warp_specialize.tag = 1 : i32}
+  // CHECK-NEXT: ttng.wait_barrier [[DONE_MBAR0a]], %c0_i32 {ttg.partition = 1 : i32, ttg.warp_specialize.tag = 1 : i32}
   // CHECK-NEXT: ttng.inval_barrier [[DONE_MBAR0]]
   // CHECK-NEXT: ttg.local_dealloc [[DONE_MBAR]]
 
@@ -1570,10 +1572,11 @@ tt.func public @attention_forward(
     // CHECK-NEXT: yield [[NEXT_L_I]], [[ROW_MAX]], %{{[0-9]+}}, [[K_NEXT_INDEX]], [[K_NEXT_PHASE]], [[V_NEXT_INDEX]], [[V_NEXT_PHASE]], [[QK_NEXT_INDEX]], [[QK_NEXT_PHASE]], [[NEXT_PV_PHASE]], [[NEXT_P_PHASE]]
 
     scf.yield %next_l_i, %O, %row_max : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<256x64xf32, #blocked>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
-  // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 1 : i32]
+  // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32
   } {tt.warp_specialize}
 
-  // CHECK-NEXT: wait_barrier [[PV_READY_BAR0]], [[OUTS]]#9
+  // CHECK-NEXT: [[PV_READY_BAR0a:%.*]] = ttg.memdesc_index [[PV_READY_MBARS]], %c0_i32 {ttg.partition = 3 : i32, ttg.warp_specialize.tag = 0 : i32}
+  // CHECK-NEXT: wait_barrier [[PV_READY_BAR0a]], [[OUTS]]#9 {ttg.partition = 3 : i32, ttg.warp_specialize.tag = 0 : i32}
 
   "use"(%loop_outs#0, %loop_outs#1, %loop_outs#2) : (tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<256x64xf32, #blocked>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>) -> ()
 

--- a/test/TritonGPU/partition-scheduling.mlir
+++ b/test/TritonGPU/partition-scheduling.mlir
@@ -158,7 +158,7 @@ tt.func @optimize_broadcast(%arg0: i32) {
     "use"(%x1) {ttg.partition = 0 : i32} : (tensor<128x128xf32>) -> ()
     // CHECK: "use"([[X1_P1]]) {{.*}}partition = 1
     "use"(%x1) {ttg.partition = 1 : i32} : (tensor<128x128xf32>) -> ()
-  } {tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32]}
+  } {tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 

--- a/test/TritonGPU/rewrite-partition-dependencies.mlir
+++ b/test/TritonGPU/rewrite-partition-dependencies.mlir
@@ -32,7 +32,7 @@ tt.func @two_consumers(%lb: i32, %ub: i32, %step: i32) {
     // CHECK-NEXT: "op_c"([[VAL]])
     // CHECK-NEXT: "op_d"([[VAL]])
     "op_d"(%0) {ttg.partition = 2} : (!ty) -> ()
-  } {ttg.partition.stages = [0, 2, 2]}
+  } {ttg.partition.stages = [0, 2, 2], ttg.warp_specialize.tag = 0 : i32}
   // CHECK: nvws.aref.destroy [[AREF]]
   tt.return
 }
@@ -57,7 +57,7 @@ tt.func @distance_one(%lb: i32, %ub: i32, %step: i32) {
     "op_b"(%k) {ttg.partition = 1} : (!ty) -> ()
 
     scf.yield %0 : !ty
-  } {ttg.partition.stages = [0, 0]}
+  } {ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
   // CHECK: nvws.aref.destroy [[AREF]]
   tt.return
 }
@@ -106,7 +106,7 @@ tt.func @complex_case(%lb: i32, %ub: i32, %step: i32) {
     // CHECK-NEXT: "op_d"([[L2]])
     "op_d"(%l) {ttg.partition = 2} : (!ty) -> ()
     scf.yield %0, %k : !ty, !ty
-  } {ttg.partition.stages = [0, 2, 2]}
+  } {ttg.partition.stages = [0, 2, 2], ttg.warp_specialize.tag = 0 : i32}
   // CHECK: nvws.aref.destroy [[AREF1]]
   // CHECK: nvws.aref.destroy [[AREF2]]
   tt.return
@@ -141,7 +141,7 @@ tt.func @reuse_argument(%lb: i32, %ub: i32, %step: i32) {
     // CHECK-NEXT: op_d
     "op_d"(%l) {ttg.partition = 2} : (!ty) -> ()
     scf.yield %0, %k : !ty, !ty
-  } {ttg.partition.stages = [1, 0, 0]}
+  } {ttg.partition.stages = [1, 0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 
@@ -194,7 +194,7 @@ tt.func @multiplicity_branch(%lb: i32, %ub: i32, %step: i32) {
     "op_d"(%c) {ttg.partition = 3}: (!ty) -> ()
 
     scf.yield %0, %a, %a : !ty, !ty, !ty
-  } {ttg.partition.stages = [0, 0, 0, 0]}
+  } {ttg.partition.stages = [0, 0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
   // CHECK: nvws.aref.destroy [[AREF1]]
   // CHECK: nvws.aref.destroy [[AREF2]]
   // CHECK: nvws.aref.destroy [[AREF3]]
@@ -250,7 +250,7 @@ tt.func @multiplicity_branch2(%lb: i32, %ub: i32, %step: i32) {
     "op_d"(%c) {ttg.partition = 3}: (!ty) -> ()
 
     scf.yield %0, %d, %e : !ty, !ty, !ty
-  } {ttg.partition.stages = [0, 0, 0, 0]}
+  } {ttg.partition.stages = [0, 0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 
@@ -264,7 +264,7 @@ tt.func @self_recursion(%lb: i32, %ub: i32, %step: i32) {
     %0 = "op_a"(%k) {ttg.partition = 0} : (!ty) -> !ty
     // CHECK: yield [[OUT]]
     scf.yield %0 : !ty
-  } {ttg.partition.stages = [0]}
+  } {ttg.partition.stages = [0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 
@@ -285,7 +285,7 @@ tt.func @self_recursion_and_use(%lb: i32, %ub: i32, %step: i32) {
     // CHECK-NEXT: "op_b"
 
     scf.yield %0 : !ty
-  } {ttg.partition.stages = [0, 1]}
+  } {ttg.partition.stages = [0, 1], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 
@@ -313,7 +313,7 @@ tt.func @conditional_consumer(%lb: i32, %ub: i32, %step: i32) {
       scf.yield %2 : !ty
     } {ttg.partition = 1}
     "keep"(%1) {ttg.partition = 1} : (!ty) -> ()
-  } {ttg.partition.stages = [0, 2]}
+  } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 
@@ -340,7 +340,7 @@ tt.func @invalid_attribute(%lb: i32, %ub: i32, %step: i32) {
   // expected-error @below {{partition stages attribute 'ttg.partition.stages' has invalid element "a"}}
   scf.for %i = %lb to %ub step %step : i32 {
     scf.yield
-  } {ttg.partition.stages = ["a"]}
+  } {ttg.partition.stages = ["a"], ttg.warp_specialize.tag = 0 : i32}
   scf.for %j = %lb to %ub step %step : i32 {
     scf.yield
   }
@@ -362,7 +362,7 @@ tt.func @invalid_attribute(%lb: i32, %ub: i32, %step: i32) {
     // expected-error @below {{invalid partition index -1}}
     "op"() {ttg.partition = -1} : () -> ()
     scf.yield
-  } {ttg.partition.stages = [2, 2]}
+  } {ttg.partition.stages = [2, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 
@@ -396,7 +396,7 @@ tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
 
     "op_c"(%1) {ttg.partition = 0} : (!ty) -> ()
     scf.yield
-  } {ttg.partition.stages = [0, 2]}
+  } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 
@@ -436,7 +436,7 @@ tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
     // CHECK: nvws.aref.get.exit [[AREF3]][[[C0]]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 0 : i32}
     // CHECK: "op_c"
     scf.yield
-  } {ttg.partition.stages = [0, 2, 3]}
+  } {ttg.partition.stages = [0, 2, 3], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 
@@ -456,7 +456,7 @@ tt.func @invalid_root_partition(%lb: i32, %ub: i32, %step: i32) {
     // expected-warning @below {{operation in the root partition depends on a value that originates from a non-root partition through operand #0}}
     "root"(%0) : (index) -> ()
     scf.yield
-  } {ttg.partition.stages = [0, 2]}
+  } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 
@@ -477,7 +477,7 @@ tt.func @invalid_root_partition(%lb: i32, %ub: i32, %step: i32) {
     // expected-note @below {{operand defined here in partition #0 at distance 1}}
     %0 = "partition"() {ttg.partition = 0} : () -> index
     scf.yield %0 : index
-  } {ttg.partition.stages = [0, 2]}
+  } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
 

--- a/test/TritonGPU/rewrite-partition-dependencies.mlir
+++ b/test/TritonGPU/rewrite-partition-dependencies.mlir
@@ -33,7 +33,6 @@ tt.func @two_consumers(%lb: i32, %ub: i32, %step: i32) {
     // CHECK-NEXT: "op_d"([[VAL]])
     "op_d"(%0) {ttg.partition = 2} : (!ty) -> ()
   } {ttg.partition.stages = [0, 2, 2], ttg.warp_specialize.tag = 0 : i32}
-  // CHECK: nvws.aref.destroy [[AREF]]
   tt.return
 }
 
@@ -58,7 +57,6 @@ tt.func @distance_one(%lb: i32, %ub: i32, %step: i32) {
 
     scf.yield %0 : !ty
   } {ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
-  // CHECK: nvws.aref.destroy [[AREF]]
   tt.return
 }
 
@@ -107,8 +105,6 @@ tt.func @complex_case(%lb: i32, %ub: i32, %step: i32) {
     "op_d"(%l) {ttg.partition = 2} : (!ty) -> ()
     scf.yield %0, %k : !ty, !ty
   } {ttg.partition.stages = [0, 2, 2], ttg.warp_specialize.tag = 0 : i32}
-  // CHECK: nvws.aref.destroy [[AREF1]]
-  // CHECK: nvws.aref.destroy [[AREF2]]
   tt.return
 }
 
@@ -195,9 +191,6 @@ tt.func @multiplicity_branch(%lb: i32, %ub: i32, %step: i32) {
 
     scf.yield %0, %a, %a : !ty, !ty, !ty
   } {ttg.partition.stages = [0, 0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
-  // CHECK: nvws.aref.destroy [[AREF1]]
-  // CHECK: nvws.aref.destroy [[AREF2]]
-  // CHECK: nvws.aref.destroy [[AREF3]]
   tt.return
 }
 

--- a/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
+++ b/third_party/nvidia/include/Dialect/NVWS/IR/NVWSOps.td
@@ -61,17 +61,6 @@ def NVWS_ArefCreateOp : NVWS_Op<"aref.create", [
   let hasVerifier = 1;
 }
 
-def NVWS_ArefDestroyOp : NVWS_Op<"aref.destroy"> {
-  let summary = "Destroy an asynchronous reference.";
-  let description = [{
-    Destroy an asynchronous reference.
-  }];
-  let arguments = (ins NVWS_ArefType:$aref);
-  let assemblyFormat = [{
-    $aref attr-dict `:` type($aref)
-  }];
-}
-
 def NVWS_ArefGetEnterOp : NVWS_Op<"aref.get.enter"> {
   let summary = "Enter ArefGet region where the buffer can be used to read data";
   let description = [{ Enter a "region" where you can freely read from the buffer)


### PR DESCRIPTION
* Final `wait_barrier`s are now assigned to a partition it was used inside the loop, to move them inside the `ttng.warp_group`. If it was not used inside the loop, assign it to a partition with arrive (like in matmul case). This change is necessary to enable automatic phase computation in the `lower-aref` pass, when `aref`s will be used for TMEM ownership transfer in a subsequent PR.
* Add `ttg.warp_specialize.tag` attribute to a warp-specialized loop, and to ops with assigned partitions outside the loop, to see which partitioned ops outside the loop belong to which warp-specialization part of the code.
* Now that all `try_wait`s are inside partitions, we can remove the `aref.destroy` op and let the `lower-aref` pass insert the `inval_barrier` right after the `ttng.warp_group` op. Aref insertion passes no longer need to worry about this step.

cc: @masahi 


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
