### PR TITLE
[IMP][Launch Latency] cache env-vars via obj.__dict__ already in-place

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -24,6 +24,7 @@ class Env:
 env = Env()
 
 propagate_env: bool = True
+cache_env: bool = True
 
 
 def getenv(key: str) -> Optional[str]:
@@ -80,6 +81,11 @@ class env_base(Generic[SetType, GetType]):
         if self.name in obj.__dict__:
             return self.transform(obj.__dict__[self.name])
         else:
+            if cache_env:
+                env = self.env_val
+                raw_val = self.default() if env is None else self.from_env(env)
+                obj.__dict__[self.name] = raw_val
+                return self.transform(raw_val)
             return self.get()
 
     @property


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

This PR is the first out of a series of contributions aiming at reducing the launch overhead of Triton kernels ran without CUDA Graphs. A latency profiler script shared offline currently puts the main branch at a latency of around `27.17 us` (on a AMD EPYC 7413 24-C system) which can be reduced via several contributions in different places.

One current issue on main is that `knobs` expose certain tunable behaviors often set through environment variables. However, they are currently not cached leading to look-ups in each launch. Since the current code somewhat exposes interactions of `__set__` and `__get__` via the `obj.__dict__`, this simple change for now tries to achieve caching by re-using this logic and setting the environment variable during the first `__get__`.  This change reduces latency as reported in the shared script down to `25.1 us`.

Further reductions could be achieved by not relying on abstraction and inheritance along the hierarchy of knob utilities as each parent and each call into get/set adds latencies. However, this likely would require a major rewrite of the knob utilities and likely will produce more duplicated code. 

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it should be covered by existing tests (no new functionality)`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
