### PR TITLE
[IMP][Launch Latency] use native key of hashing tuples of hashable types

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -588,7 +588,7 @@ class JITFunction(KernelInterface[T]):
         bound_args, specialization, options = binder(*args, **kwargs)
 
         # compute cache key
-        key = str(specialization) + str(options)
+        key = tuple(specialization) + tuple(sorted(options.items()))
         kernel = kernel_cache.get(key, None)
 
         # Kernel is not cached; we have to compile.


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

This PR is the second out of a series of contributions aiming at reducing the launch overhead of Triton kernels ran without CUDA Graphs. A latency profiler script shared offline currently puts the main branch at a latency of around `27.17 us` (on a AMD EPYC 7413 24-C system) which can be reduced via several contributions in different places.

One larger amount of time in the launch phase is spent in `PyObject_Str` and `PyObject_Repr` calls eventually root-causes to happen in the conversion of the `specialization` and `options` into a string-key for the lookup in the kernel cache. As this key is only used for lookup, however, and as the underlying data-structures should be mostly collections of hashable types (for instance `list[tuple[str, str|int|...]` or `dict[str, str|int|bool|...]`), it might be faster to convert these structures into tuples and let the native mechanisms in Python produce a key based on native hashing mechanisms. 

This change reduces latency as reported in the shared script down to `21.71 us` (from `27.16 us`).

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it should be covered by existing tests (no new functionality)`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
