### PR TITLE
[IMP][Launch Latency] slightly improved NVIDIA driver backend

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -369,6 +369,9 @@ typedef struct _DevicePtrInfo {{
     bool valid;
 }} DevicePtrInfo;
 
+static PyObject* data_ptr_str = NULL;
+static PyObject* tma_desc_cpu_ptr_str = NULL;
+
 static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
   DevicePtrInfo ptr_info;
   ptr_info.dev_ptr = 0;
@@ -381,7 +384,10 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
     // valid nullptr
     return ptr_info;
   }}
-  PyObject *ptr = PyObject_GetAttrString(obj, "data_ptr");
+  if (!data_ptr_str) {{
+    data_ptr_str = PyUnicode_FromString("data_ptr");
+  }}
+  PyObject* ptr = PyObject_GetAttr(obj, data_ptr_str);
   if(ptr){{
     PyObject *empty_tuple = PyTuple_New(0);
     PyObject *ret = PyObject_Call(ptr, empty_tuple, NULL);
@@ -419,8 +425,10 @@ static inline CUtensorMap* getTmaDesc(PyObject *obj) {{
     PyErr_SetString(PyExc_SystemError, "getTmaDesc() requires 64-bit compilation");
     return NULL;
   }}
-
-  PyObject *method_handle = PyObject_GetAttrString(obj, "tma_desc_cpu_ptr");
+  if (!tma_desc_cpu_ptr_str) {{
+    tma_desc_cpu_ptr_str = PyUnicode_FromString("tma_desc_cpu_ptr");
+  }}
+  PyObject *method_handle = PyObject_GetAttr(obj, tma_desc_cpu_ptr_str);
   if (!method_handle) {{
     PyErr_SetString(PyExc_TypeError, "tma_desc_cpu_ptr() method does not exist");
     return NULL;

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -384,9 +384,6 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
     // valid nullptr
     return ptr_info;
   }}
-  if (!data_ptr_str) {{
-    data_ptr_str = PyUnicode_FromString("data_ptr");
-  }}
   PyObject* ptr = PyObject_GetAttr(obj, data_ptr_str);
   if(ptr){{
     PyObject *empty_tuple = PyTuple_New(0);
@@ -424,9 +421,6 @@ static inline CUtensorMap* getTmaDesc(PyObject *obj) {{
   if (sizeof(CUtensorMap*) != 8) {{
     PyErr_SetString(PyExc_SystemError, "getTmaDesc() requires 64-bit compilation");
     return NULL;
-  }}
-  if (!tma_desc_cpu_ptr_str) {{
-    tma_desc_cpu_ptr_str = PyUnicode_FromString("tma_desc_cpu_ptr");
   }}
   PyObject *method_handle = PyObject_GetAttr(obj, tma_desc_cpu_ptr_str);
   if (!method_handle) {{
@@ -602,6 +596,14 @@ static struct PyModuleDef ModuleDef = {{
 PyMODINIT_FUNC PyInit___triton_launcher(void) {{
   PyObject *m = PyModule_Create(&ModuleDef);
   if(m == NULL) {{
+    return NULL;
+  }}
+  data_ptr_str = PyUnicode_InternFromString("data_ptr");
+  if(data_ptr_str == NULL) {{
+    return NULL;
+  }}
+  tma_desc_cpu_ptr_str = PyUnicode_FromString("tma_desc_cpu_ptr");
+  if(tma_desc_cpu_ptr_str == NULL) {{
     return NULL;
   }}
   PyModule_AddFunctions(m, ModuleMethods);

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -602,7 +602,7 @@ PyMODINIT_FUNC PyInit___triton_launcher(void) {{
   if(data_ptr_str == NULL) {{
     return NULL;
   }}
-  tma_desc_cpu_ptr_str = PyUnicode_FromString("tma_desc_cpu_ptr");
+  tma_desc_cpu_ptr_str = PyUnicode_InternFromString("tma_desc_cpu_ptr");
   if(tma_desc_cpu_ptr_str == NULL) {{
     return NULL;
   }}


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

This PR is the third in a series of contributions aiming at reducing the launch overhead of Triton kernels ran without CUDA Graphs. A latency profiler script shared offline currently puts the main branch at a latency of around `27.16 us` (on a AMD EPYC 7413 24-C system) which can be reduced via several contributions in different places.

This PR comes with minor improvements in the NVIDIA driver backend (for `getPointer` in particular). By caching the string representations of `"data_ptr"` (and `"tma_desc_cpu_ptr"`) manually, one can switch from using `PyObject_GetAttrString` to `PyObject_GetAttr` which saves a bit of time and for several tensor inputs can accumulate up to `0.5 us` or more.

With the shared latency script in particular, the latency goes down to `26.80 us` (from `27.16 us`).

| name | PR | latency | reduction |
|------|----|---------|-----------|
| main | x | `27.16 us` | x |
| cache-knob  |  #7767   | `25.10 us`  |  `2.06 us`   |
| native key | #7768 | `21.71 us` | `5.45 us` |
| backend `GetAttrString` | #7769  | `26.80 us` |  `0.36 us` | 
| misc compiler/kernel | #7770 | `23.90 us` | `3.26 us`|
| native-specialize | #7771 | `21.68 us` | `5.48 us` |
| **total** | x | `~10.5 us` | `16.61 us` |


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it should be covered by existing tests (no new functionality)`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
