### PR TITLE
[IMP][Launch Latency] misc improvements to compiler/kernel

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -462,6 +462,9 @@ class CompiledKernel:
         if knobs.runtime.init_handle_hook is not None:
             knobs.runtime.init_handle_hook(self.module, self.function, self.name, self.metadata_group)
 
+    def result(self):
+        return self
+
     def __getattribute__(self, name):
         if name == 'run':
             self._init_handles()

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -443,7 +443,7 @@ class CompiledKernel:
             return
         device = driver.active.get_current_device()
         # create launcher
-        self.run = driver.active.launcher_cls(self.src, self.metadata)
+        self._run = driver.active.launcher_cls(self.src, self.metadata)
         # not enough shared memory to run the kernel
         max_shared = max_shared_mem(device)
         if self.metadata.shared > max_shared:
@@ -465,10 +465,10 @@ class CompiledKernel:
     def result(self):
         return self
 
-    def __getattribute__(self, name):
-        if name == 'run':
-            self._init_handles()
-        return super().__getattribute__(name)
+    @property
+    def run(self):
+        self._init_handles()
+        return self._run
 
     def launch_metadata(self, grid, stream, *args):
         if knobs.runtime.launch_enter_hook is None:

--- a/python/triton/runtime/driver.py
+++ b/python/triton/runtime/driver.py
@@ -51,10 +51,7 @@ class LazyProxy(Generic[T]):
 class DriverConfig:
 
     def __init__(self) -> None:
-        if lazy_driver_init:
-            self.default: LazyProxy[DriverBase] = LazyProxy(_create_driver)
-        else:
-            self.default: DriverBase = _create_driver()
+        self.default = Union[LazyProxy[DriverBase], DriverBase] = LazyProxy(_create_driver) if lazy_driver_init else _create_driver()
         self.active: Union[LazyProxy[DriverBase], DriverBase] = self.default
 
     def set_active(self, driver: DriverBase) -> None:

--- a/python/triton/runtime/driver.py
+++ b/python/triton/runtime/driver.py
@@ -51,8 +51,8 @@ class LazyProxy(Generic[T]):
 class DriverConfig:
 
     def __init__(self) -> None:
-        init_fn = LazyProxy(_create_driver) if lazy_driver_init else _create_driver()
-        self.default = Union[LazyProxy[DriverBase], DriverBase] = init_fn
+        _init_fn = LazyProxy(_create_driver) if lazy_driver_init else _create_driver()
+        self.default: Union[LazyProxy[DriverBase], DriverBase] = _init_fn
         self.active: Union[LazyProxy[DriverBase], DriverBase] = self.default
 
     def set_active(self, driver: DriverBase) -> None:

--- a/python/triton/runtime/driver.py
+++ b/python/triton/runtime/driver.py
@@ -13,6 +13,7 @@ def _create_driver() -> DriverBase:
 
 
 T = TypeVar("T")
+lazy_driver_init: bool = False
 
 
 class LazyProxy(Generic[T]):
@@ -50,7 +51,10 @@ class LazyProxy(Generic[T]):
 class DriverConfig:
 
     def __init__(self) -> None:
-        self.default: LazyProxy[DriverBase] = LazyProxy(_create_driver)
+        if lazy_driver_init:
+            self.default: LazyProxy[DriverBase] = LazyProxy(_create_driver)
+        else:
+            self.default: DriverBase = _create_driver()
         self.active: Union[LazyProxy[DriverBase], DriverBase] = self.default
 
     def set_active(self, driver: DriverBase) -> None:

--- a/python/triton/runtime/driver.py
+++ b/python/triton/runtime/driver.py
@@ -51,7 +51,8 @@ class LazyProxy(Generic[T]):
 class DriverConfig:
 
     def __init__(self) -> None:
-        self.default = Union[LazyProxy[DriverBase], DriverBase] = LazyProxy(_create_driver) if lazy_driver_init else _create_driver()
+        init_fn = LazyProxy(_create_driver) if lazy_driver_init else _create_driver()
+        self.default = Union[LazyProxy[DriverBase], DriverBase] = init_fn
         self.active: Union[LazyProxy[DriverBase], DriverBase] = self.default
 
     def set_active(self, driver: DriverBase) -> None:

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -616,8 +616,7 @@ class JITFunction(KernelInterface[T]):
             grid_0 = grid[0]
             grid_1 = grid[1] if grid_size > 1 else 1
             grid_2 = grid[2] if grid_size > 2 else 1
-            if hasattr(kernel, "result"):
-                kernel = kernel.result()
+            kernel = kernel.result()
             # launch kernel
             launch_metadata = kernel.launch_metadata(grid, stream, *bound_args.values())
             kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

This PR is the fourth in a series of contributions aiming at reducing the launch overhead of Triton kernels ran without CUDA Graphs. A latency profiler script shared offline currently puts the main branch at a latency of around `27.16 us` (on a AMD EPYC 7413 24-C system with a H100 GPU) which can be reduced via several contributions in different places.

This PR makes several minor changes to the compiler/kernel of similar nature
- add `result` method explicitly to `CompiledKernel` to avoid combination of `hasattr/getattr` in launch code
- avoid expensive `__getattribute__` by defining `run` as property which then initializes handles there
- avoid a similar improvement for accessing the default driver by avoiding lazy initialization and going through `LazyProxy`

These changes bring down latency as reported in the shared script down to `23.9 us` (from `27.16 us`).


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it should be covered by existing tests (no new functionality)`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
