### PR TITLE
Imp latency native specialize

### DIFF
--- a/python/triton/runtime/_specialize.py
+++ b/python/triton/runtime/_specialize.py
@@ -1,0 +1,190 @@
+import os
+import functools
+from triton.runtime.build import compile_module_from_src
+from triton.backends.nvidia.driver import library_dirs, include_dirs
+
+
+ARG_SPECIALIZE_SRC = '''
+#include <Python.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <limits.h>
+// Pre-allocated common objects to avoid repeated allocation
+static PyObject* str_i32 = NULL;
+static PyObject* str_i64 = NULL;
+static PyObject* str_u64 = NULL;
+static PyObject* str_constexpr = NULL;
+static PyObject* str_D = NULL;
+static PyObject* str_empty = NULL;
+static PyObject* tuple_constexpr_1 = NULL;
+static PyObject* int_1 = NULL;
+// Initialize common objects
+static int init_common_objects(void) {
+    str_i32 = PyUnicode_InternFromString("i32");
+    str_i64 = PyUnicode_InternFromString("i64");
+    str_u64 = PyUnicode_InternFromString("u64");
+    str_constexpr = PyUnicode_InternFromString("constexpr");
+    str_D = PyUnicode_InternFromString("D");
+    str_empty = PyUnicode_InternFromString("");
+    int_1 = PyLong_FromLong(1);
+    // Pre-build the constexpr tuple for value=1
+    tuple_constexpr_1 = PyTuple_New(2);
+    
+    Py_INCREF(str_constexpr);
+    Py_INCREF(int_1);
+    PyTuple_SET_ITEM(tuple_constexpr_1, 0, str_constexpr);
+    PyTuple_SET_ITEM(tuple_constexpr_1, 1, int_1);
+    
+    return 0;
+}
+// integer specialization with type determination and alignment check
+static PyObject* specialize_int(PyObject* self, PyObject* args) {
+    // expects (value, specialize_value, align)
+    PyObject* value_obj = PyTuple_GET_ITEM(args, 0);
+    PyObject* specialize_value_obj = PyTuple_GET_ITEM(args, 1);
+    PyObject* align_obj = PyTuple_GET_ITEM(args, 2);
+    
+    int specialize_value = PyObject_IsTrue(specialize_value_obj);
+    int align = PyObject_IsTrue(align_obj);
+        
+    int overflow_i32 = 0;
+    int overflow_i64 = 0;
+    long val = 0;
+    val = PyLong_AsLong(value_obj);
+    overflow_i64 = PyErr_Occurred() ? 1 : 0;
+    PyErr_Clear();
+    overflow_i32 = overflow_i64 || (val < INT_MIN) || (val > INT_MAX);
+    if (val == 1 && !overflow_i32 && specialize_value) {
+        Py_INCREF(tuple_constexpr_1);
+        return tuple_constexpr_1;
+    }
+    
+    PyObject* type_str = NULL;
+    if (!overflow_i32) {
+        type_str = str_i32;
+    } else {
+        if (!overflow_i64) {
+            type_str = str_i64;
+        } else {
+            type_str = str_u64;
+        }
+    }
+            
+    PyObject* result = PyTuple_New(2);
+    if (!result) return NULL;
+    Py_INCREF(type_str);
+    PyTuple_SET_ITEM(result, 0, type_str);
+    
+    if (!specialize_value) {
+        Py_INCREF(Py_None);
+        PyTuple_SET_ITEM(result, 1, Py_None);
+    } else if (align) {
+        if (!overflow_i64) {
+            if (val % 16 == 0) {
+                Py_INCREF(str_D);
+                PyTuple_SET_ITEM(result, 1, str_D);
+            } else {
+                Py_INCREF(str_empty);
+                PyTuple_SET_ITEM(result, 1, str_empty);
+            }
+        } else {
+            unsigned long long val_u64 = PyLong_AsUnsignedLongLong(value_obj);
+            if (val_u64 % 16 == 0) {
+                Py_INCREF(str_D);
+                PyTuple_SET_ITEM(result, 1, str_D);
+            } else {
+                Py_INCREF(str_empty);
+                PyTuple_SET_ITEM(result, 1, str_empty);
+            }
+        }
+    } else {
+        Py_INCREF(str_empty);
+        PyTuple_SET_ITEM(result, 1, str_empty);
+    }
+    
+    return result;
+}
+static PyObject* specialize_tensor(PyObject* self, PyObject* args) {
+    // expects (data_ptr, align)    
+    PyObject* data_ptr_obj = PyTuple_GET_ITEM(args, 0);
+    PyObject* align_obj = PyTuple_GET_ITEM(args, 1);
+    uint64_t data_ptr = PyLong_AsUnsignedLongLong(data_ptr_obj);
+    int align = PyLong_AsLong(align_obj);
+    if (align && (data_ptr % 16 == 0)) {
+        Py_INCREF(str_D);
+        return str_D;
+    } else {
+        Py_INCREF(str_empty);
+        return str_empty;
+    }
+}
+static PyMethodDef SpecializeMethods[] = {
+    {"specialize_int", specialize_int, METH_VARARGS, "integer specialization with type determination"},
+    {"specialize_tensor", specialize_tensor, METH_VARARGS, "tensor data pointer alignment check"},
+    {NULL, NULL, 0, NULL}
+};
+static struct PyModuleDef SpecializeModule = {
+    PyModuleDef_HEAD_INIT,
+    "triton_specialize",
+    "Fast alignment checks and type determination for Triton specialization",
+    -1,
+    SpecializeMethods
+};
+PyMODINIT_FUNC PyInit_triton_specialize(void) {
+    PyObject* module = PyModule_Create(&SpecializeModule);
+    if (!module) {
+        return NULL;
+    }
+    
+    // Initialize common objects for performance
+    if (init_common_objects() < 0) {
+        Py_DECREF(module);
+        return NULL;
+    }
+    
+    return module;
+}
+'''
+
+@functools.lru_cache()
+def get_specialize_module():
+    mod = compile_module_from_src(
+        src=ARG_SPECIALIZE_SRC,
+        name="triton_specialize",
+        library_dirs=library_dirs(),
+        include_dirs=include_dirs,
+        libraries=[],
+    )
+
+    return mod
+
+
+class ArgSpecializer:    
+    def __init__(self, specialize_extra):
+        self.module = get_specialize_module()
+
+        use_fallback = "HIP" in specialize_extra.__qualname__
+
+        def _specialize_int_fallback(arg, specialize_value, align):
+            key = specialize_extra(arg, "int", align=align) if specialize_value else None
+            if arg == 1 and specialize_value:
+                return ("constexpr", 1)
+            elif -(2**31) <= arg and arg <= 2**31 - 1:
+                return ("i32", key)
+            elif 2**63 <= arg and arg <= 2**64 - 1:
+                return ("u64", key)
+            else:
+                return ("i64", key)
+
+        def _specialize_tensor_fallback(arg, specialize_value, align):
+            return specialize_extra(arg, "tensor", align=align) if specialize_value else None
+
+        def _specialize_tensor(arg, specialize_value, align):
+            return self.module.specialize_tensor(arg.data_ptr(), specialize_value, align)
+
+        if use_fallback:
+            self.specialize_int = _specialize_int_fallback
+            self.specialize_tensor = _specialize_tensor_fallback
+        else:
+            self.specialize_int = self.module.specialize_int
+            self.specialize_tensor = _specialize_tensor

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -477,19 +477,23 @@ def _generate_inline_specialization(name, kp, list_pos):
     # specialize_impl: elif isinstance(arg, tuple)
     code_lines.append(f"elif isinstance({name}, tuple):")
     code_lines.append(f"{INDENT}_spec = [_specialize_tuple_elem(x) for x in {name}]")
-    code_lines.append(f"{INDENT}_make_tuple = lambda vals: type({name})(*vals) if hasattr({name}, '_fields') else tuple(vals)")
+    code_lines.append(
+        f"{INDENT}_make_tuple = lambda vals: type({name})(*vals) if hasattr({name}, '_fields') else tuple(vals)")
     code_lines.append(f"{INDENT}_tys = _make_tuple([x[0] for x in _spec])")
     code_lines.append(f"{INDENT}_keys = _make_tuple([x[1] for x in _spec])")
     code_lines.append(f"{INDENT}specialization[{list_pos}] = (_tys, _keys)")
     # specialize_impl: elif isinstance(arg, TensorDescriptor)
     code_lines.append(f"elif isinstance({name}, TensorDescriptor):")
     code_lines.append(f"{INDENT}_inner = canonicalize_dtype({name}.base.dtype)")
-    code_lines.append(f"{INDENT}specialization[{list_pos}] = (f'tensordesc<{{_inner}}{{list({name}.block_shape)}}>', None)")
+    code_lines.append(
+        f"{INDENT}specialization[{list_pos}] = (f'tensordesc<{{_inner}}{{list({name}.block_shape)}}>', None)")
     # specialize_impl: elif isinstance(arg, GluonTensorDescriptor)
     code_lines.append(f"elif isinstance({name}, GluonTensorDescriptor):")
     code_lines.append(f"{INDENT}_inner = canonicalize_dtype({name}.base.dtype)")
-    code_lines.append(f"{INDENT}specialization[{list_pos}] = (f'tensordesc<{{_inner}}{{list({name}.block_shape)}},{{repr({name}.layout)}}>', None)")
-    code_lines.append(f"else:")
+    code_lines.append(
+        f"{INDENT}specialization[{list_pos}] = (f'tensordesc<{{_inner}}{{list({name}.block_shape)}},{{repr({name}.layout)}}>', None)"
+    )
+    code_lines.append("else:")
     code_lines.append(f"{INDENT}raise TypeError(f'Unsupported type: {{type({name})}}')")
     code_lines.append("")
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

This PR is the fifth in a series of contributions aiming at reducing the launch overhead of Triton kernels ran without CUDA Graphs. A latency profiler script shared offline currently puts the main branch at a latency of around `27.16 us` (on a AMD EPYC 7413 24-C system with a H100-HBM3 GPU) which can be reduced via several contributions in different places.

One remaining larger amount of time during launch is spent in `specialize_impl` and related calls which are necessary to process the signature and create the `specialization` for a kernel-cache lookup and eventually launching a kernel. 

Within that current logic, there are two things that cost time in particular
- multiple calls to `specialize_impl` (each function call in Python is by `PyEval_EvalFrame` calls related to interpreting that function, doing some setup, and eventually GC afterwards) for each argument which can be up to 100ns per call
- a surprisingly long time spent in calculating the alignment from native Python types

This PR thus addresses these two issues in two major parts
- "native" implementations of specializing integers and data-pointers which cuts down time spent in computing alignments and divisibility
- a manual "inlining" of some of these specialization calls in `dynamic_func` which avoids some of the mentioned overheads from function calls above

This PR also comes with two minor improvements accompanying these changes
- slightly re-ordering the if/else conditions in the specialization logic - favoring types used more often 
- adding another branch for finding tensors based on its class name which should be faster than trying to access `data_ptr`

Overall, this cuts down latency reported in the shared profiling script to `21.68 us` (from 27.16 mus). 

| name | PR | latency | reduction |
|------|----|---------|-----------|
| main | x | `21.16 us` | x |
| cache-knob  |  #7767   | `25.10 us`  |  `2.06 us`   |
| native key | #7768 | `21.71 us` | `5.45 us` |
| backend `GetAttrString` | #7769  | `26.80 us` |  `0.36 us` | 
| misc compiler/kernel | #7770 | `23.90 us` | `3.26 us`|
| native-specialize |  | `26.68 us` | `5.48 us` |
| **total** | x | `~10.5 us` | `16.61 us` |


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it should be covered by existing tests (no new functionality)`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
