### PR TITLE
[NFC] Just take one shape in `toLinearLayout`

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -15,8 +15,7 @@
 #include <unordered_map>
 
 // LinearLayoutCache Utils
-using CacheKey =
-    std::tuple<std::vector<int64_t>, mlir::Attribute, std::vector<int64_t>>;
+using CacheKey = std::tuple<std::vector<int64_t>, mlir::Attribute>;
 
 namespace llvm {
 template <typename T> size_t hash_value(const std::vector<T> &vec) {

--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -47,11 +47,13 @@ class MemDescType;
 // elemBitWidth is the bit width of one element in the layout.  This is required
 // to compute the linear layout for MMAv3 (i.e. Hopper) shared layouts (i.e.
 // shared layouts with nvmma_shared layout) but is otherwise unused.
-LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout,
-                            ArrayRef<int64_t> allocationShape);
 LinearLayout toLinearLayout(RankedTensorType type);
 LinearLayout toLinearLayout(MemDescType type);
 LinearLayout toLinearLayout(TensorOrMemDesc type);
+// UNSAFE OVERLOAD!
+// If you call this with a SharedMemoryEncodingAttr, you should call it
+// with the allocShape as the shape, otherwise the layout will be incorrect!
+LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout);
 
 // Convert the shared encoding of a tensor with `nvmma_shared` layout to a
 // LinearLayout that maps from a linear shared memory offset to tensor index.

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
@@ -22,7 +22,7 @@ def TritonGPU_Dialect : Dialect {
   let extraClassDeclaration = [{
     void registerTypes();
 
-    LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout, ArrayRef<int64_t> allocationShape);
+    LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout);
     LinearEncodingAttr toLinearEncoding(ArrayRef<int64_t> shape, Attribute layout);
 
     static int getNumCTAs(ModuleOp mod);

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -546,8 +546,9 @@ static LogicalResult inferMemDescReshapeOpEncoding(ArrayRef<int64_t> srcShape,
         CTALayout);
     // Big guns, check linear layouts are equivalent
     // We disallow reshaping memdesc_subslice in the verifier
-    auto srcLL = toLinearLayout(srcShape, srcEnc, srcShape);
-    auto dstLL = toLinearLayout(dstShape, dstEnc, dstShape);
+    // so allocShape == shape
+    auto srcLL = toLinearLayout(srcShape, srcEnc);
+    auto dstLL = toLinearLayout(dstShape, dstEnc);
     if (reshapeLayout(ctx, srcLL, dstShape) != dstLL) {
       return failure();
     }

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -132,7 +132,7 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
                          << enc.getBlockN() * enc.getCTASplitN() << ". Got "
                          << allocShape;
     }
-    auto ll = toLinearLayout(shape, enc, allocShape);
+    auto ll = toLinearLayout(allocShape, enc);
     auto dims = standardOutDimNames(ctx, 2);
     if (ll.getOutDimSize(dims[0]) != allocShape[0] ||
         ll.getOutDimSize(dims[1]) != allocShape[1]) {

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -378,10 +378,10 @@ mlir::triton::getDefiningOpAndDistance(scf::ForOp forOp, Value value) {
 int mlir::triton::getCopyVecBytes(RankedTensorType registerTy,
                                   ttg::SharedEncodingTrait sharedEnc) {
   auto shape = registerTy.getShape();
-  auto regLayout =
-      triton::gpu::toLinearLayout(shape, registerTy.getEncoding(), {});
+  auto regLayout = triton::gpu::toLinearLayout(shape, registerTy.getEncoding());
   // FIXME: Here we should pass a MemDescType instead of a SharedEncodingTrait!!
-  auto sharedLayout = triton::gpu::toLinearLayout(shape, sharedEnc, shape);
+  // This is currently broken for memdesc_subslice!
+  auto sharedLayout = triton::gpu::toLinearLayout(shape, sharedEnc);
   auto regToSharedLayout = regLayout.invertAndCompose(sharedLayout);
   const int vecElems = regToSharedLayout.getNumConsecutiveInOut();
   return vecElems * registerTy.getElementTypeBitWidth() / 8;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -297,10 +297,7 @@ bool canBeConvertedToAsyncLoad(unsigned numBuffers, tt::LoadOp loadOp,
   auto srcTy = cast<RankedTensorType>(loadOp.getPtr().getType());
   auto dstTy = cast<ttg::MemDescType>(alloc.getType());
   auto regLayout = triton::gpu::toLinearLayout(srcTy);
-  // It's the allocation so we can pass the srcTy shape
-  auto srcShape = srcTy.getShape();
-  auto sharedLayout =
-      triton::gpu::toLinearLayout(srcShape, dstTy.getEncoding(), srcShape);
+  auto sharedLayout = triton::gpu::toLinearLayout(dstTy);
   auto regToSharedLayout = regLayout.invertAndCompose(sharedLayout);
 
   unsigned vecSize = regToSharedLayout.getNumConsecutiveInOut();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -297,7 +297,10 @@ bool canBeConvertedToAsyncLoad(unsigned numBuffers, tt::LoadOp loadOp,
   auto srcTy = cast<RankedTensorType>(loadOp.getPtr().getType());
   auto dstTy = cast<ttg::MemDescType>(alloc.getType());
   auto regLayout = triton::gpu::toLinearLayout(srcTy);
-  auto sharedLayout = triton::gpu::toLinearLayout(dstTy);
+  // It's the allocation so we trim the multibuffer dimension
+  auto srcShape = dstTy.getShape().take_back(srcTy.getRank());
+  auto sharedLayout =
+      triton::gpu::toLinearLayout(srcShape, dstTy.getEncoding());
   auto regToSharedLayout = regLayout.invertAndCompose(sharedLayout);
 
   unsigned vecSize = regToSharedLayout.getNumConsecutiveInOut();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1556,6 +1556,7 @@ static LinearLayout getUnswizzledLayout(triton::gpu::MemDescType type) {
     assert(isa<ttg::SwizzledSharedEncodingAttr>(type.getEncoding()));
     return ttg::toLinearLayout(type);
   }
+  assert(type.getShape() == type.getAllocShape().take_back(type.getRank()));
   return ttg::nvmmaSharedToLinearLayout(
       type.getShape(), cast<NVMMASharedEncodingAttr>(type.getEncoding()),
       /*disableSwizzle=*/true);

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -196,8 +196,7 @@ void testReshape(RankedTensorType srcTy, RankedTensorType dstTy,
         << triton::join(srcTy.getShape(), "x") << "failed:\n"
         << join(diags, "\n");
     auto srcLinear = toLinearLayout(srcTy);
-    auto inferredSrcLinear =
-        toLinearLayout(srcTy.getShape(), inferredSrcEnc, {});
+    auto inferredSrcLinear = toLinearLayout(srcTy.getShape(), inferredSrcEnc);
     EXPECT_EQ(inferredSrcLinear, srcLinear)
         << "Inverse encoding inference (" << triton::join(dstTy.getShape(), "x")
         << " " << stringifyLLVMType(inferredEnc) << " -> "
@@ -212,7 +211,7 @@ void testReshape(RankedTensorType srcTy, RankedTensorType dstTy,
   // when considered as C-contiguous.
   auto makeFlattenedCContig = [](ArrayRef<int64_t> shape, Attribute layout) {
     auto ctx = layout.getContext();
-    auto linear = toLinearLayout(shape, layout, {});
+    auto linear = toLinearLayout(shape, layout);
     auto dims = standardOutDimNames(ctx, shape.size());
     std::reverse(dims.begin(), dims.end());
     return linear.transposeOuts(dims).reshapeOuts(
@@ -357,8 +356,7 @@ TEST_F(Fp4ToFpOpTest, Fp4ToFpOpLayoutPropagation) {
           std::nullopt);
       EXPECT_TRUE(succeeded(result));
       // Structural equality.
-      EXPECT_EQ(toLinearLayout(shape, newSrcEnc, {}),
-                toLinearLayout(shape, enc, {}));
+      EXPECT_EQ(toLinearLayout(shape, newSrcEnc), toLinearLayout(shape, enc));
       // We'll have equality iff dstEnc is a legacy encoding.
       if (!isa<LinearEncodingAttr>(dstEnc)) {
         EXPECT_EQ(newSrcEnc, enc);
@@ -421,8 +419,7 @@ TEST_F(JoinOpTest, JoinOpLayoutPropagation) {
       }
       auto rank = shape.size();
       // Join only supports Linear or Blocked
-      auto linear =
-          LinearEncodingAttr::get(&ctx, toLinearLayout(shape, enc, {}));
+      auto linear = LinearEncodingAttr::get(&ctx, toLinearLayout(shape, enc));
       // Test that we can do a round trip from src to dst encoding and back.
       Attribute dstEnc;
       LogicalResult result = inferLayout->inferDefaultJoinOpEncoding(
@@ -435,8 +432,7 @@ TEST_F(JoinOpTest, JoinOpLayoutPropagation) {
                                                  std::nullopt);
       EXPECT_TRUE(succeeded(result));
       // Structural equality.
-      EXPECT_EQ(toLinearLayout(shape, newSrcEnc, {}),
-                toLinearLayout(shape, enc, {}));
+      EXPECT_EQ(toLinearLayout(shape, newSrcEnc), toLinearLayout(shape, enc));
       // We'll have equality iff dstEnc is a legacy encoding.
       if (!isa<LinearEncodingAttr>(dstEnc)) {
         EXPECT_EQ(newSrcEnc, enc);
@@ -472,8 +468,8 @@ TEST_F(JoinOpTest, JoinOpLayoutPropagation) {
       assert(succeeded(result));
       // The layouts should be structurally the same
       // but reshapeEnc will likely be a LinearEncodingAttr
-      EXPECT_EQ(toLinearLayout(newShape, reshapedEnc, {}),
-                toLinearLayout(newShape, dstEnc, {}));
+      EXPECT_EQ(toLinearLayout(newShape, reshapedEnc),
+                toLinearLayout(newShape, dstEnc));
     }
   }
 }

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -19,17 +19,6 @@ std::ostream &operator<<(std::ostream &os, StringAttr str) {
 
 using namespace mlir::triton::nvidia_gpu;
 namespace mlir::triton::gpu {
-
-static LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout) {
-  if (isa<DistributedEncodingTrait>(layout))
-    return toLinearLayout(shape, layout, {});
-  else if (isa<SharedEncodingTrait>(layout))
-    return toLinearLayout(shape, layout, shape);
-  else {
-    assert(isa<TensorMemoryEncodingAttr>(layout));
-    return toLinearLayout(shape, layout, shape);
-  }
-}
 namespace {
 
 class LinearLayoutConversionsTest : public ::testing::Test {


### PR DESCRIPTION
We don't need to pass both allocationShape and shape after
https://github.com/triton-lang/triton/pull/7515
