### PR TITLE
[ANALYSIS] Fix divisibility estimation for min/max/select ops

### DIFF
--- a/include/triton/Dialect/Triton/IR/Utility.h
+++ b/include/triton/Dialect/Triton/IR/Utility.h
@@ -33,7 +33,7 @@ template <typename VecT> auto product(const VecT &vec) {
 template <typename Int> Int ceil(Int m, Int n) { return (m + n - 1) / n; }
 
 /// Get the highest power of 2 divisor of an integer.
-template <typename T> T highestPowOf2Divisor(T n) {
+template <typename T> constexpr T highestPowOf2Divisor(T n) {
   // When n is 0 or min, return the highest power of 2. The min case is handled
   // separately to avoid underflow when T is a signed integer. Technically
   // in that case the correct divisor is -n, but this value is outside the

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1216,13 +1216,7 @@ void AxisInfo::initPessimisticStateFromFunc(int argNumber, T funcOp,
   DimVectorT constancy;
   for (auto d = 0; d < lhs.getRank(); ++d) {
     contiguity.push_back(gcd(lhs.getContiguity(d), rhs.getContiguity(d)));
-    if (lhs.getContiguity(d) == rhs.getContiguity(d)) {
-      divisibility.push_back(
-          gcd(lhs.getDivisibility(d), rhs.getDivisibility(d)));
-    } else {
-      divisibility.push_back(gcd(lhs.getDivisibility(d), rhs.getDivisibility(d),
-                                 lhs.getContiguity(d), rhs.getContiguity(d)));
-    }
+    divisibility.push_back(gcd(lhs.getDivisibility(d), rhs.getDivisibility(d)));
     constancy.push_back(gcd(lhs.getConstancy(d), rhs.getConstancy(d)));
   }
   std::optional<int64_t> constantValue;

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -460,22 +460,22 @@ tt.func @max_min() {
   %5 = arith.constant dense<4> : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = 8}}
   %6 = arith.maxsi %4, %5 : tensor<128xi32>
-  // expected-remark @below {{contiguity = [8], divisibility = [4], constancy = [1], constant_value = <none>}}
-  %7 = tt.make_range { end = 12 : i32, start = 4 : i32 } : tensor<8xi32>
-  // expected-remark @below {{contiguity = [8], divisibility = [1073741824], constancy = [1], constant_value = <none>}}
-  %8 = tt.make_range { end = 8 : i32, start = 0 : i32 } : tensor<8xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [8], constancy = [8], constant_value = 8}}
-  %9 = arith.constant dense<8> : tensor<8xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [2], constancy = [8], constant_value = 2}}
-  %10 = arith.constant dense<2> : tensor<8xi32>
+  tt.return
+}
+
+// -----
+
+// A complicated example with different contiguity and divisibility in lhs and rhs.
+// To simplify construction of the test we just pass attributes from the arguments
+tt.func @contiguity_dependent_divisibility(%arg0: tensor<8xi32> {tt.contiguity = 8 : i32, tt.divisibility = 4 : i32, tt.constancy = 1 : i32}, %arg1: tensor<8xi32> {tt.contiguity = 2 : i32, tt.divisibility = 8 : i32, tt.constancy = 1 : i32}) {
   // expected-remark @below {{contiguity = [2], divisibility = [2], constancy = [1], constant_value = <none>}}
-  %11 = arith.remsi %8, %10 : tensor<8xi32>
+  %0 = arith.maxsi %arg0, %arg1 : tensor<8xi32>
   // expected-remark @below {{contiguity = [2], divisibility = [2], constancy = [1], constant_value = <none>}}
-  %12 = arith.addi %11, %9 : tensor<8xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
-  %13 = arith.maxsi %12, %7 : tensor<8xi32>
-  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
-  %14 = arith.minsi %12, %7 : tensor<8xi32>
+  %1 = arith.minsi %arg0, %arg1 : tensor<8xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [4611686018427387904], constancy = [1], constant_value = 0}}
+  %2 = arith.constant 0 : i1
+  // expected-remark @below {{contiguity = [2], divisibility = [2], constancy = [1], constant_value = <none>}}
+  %3 = arith.select %2, %0, %1 : tensor<8xi32>
   tt.return
 }
 

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -460,12 +460,22 @@ tt.func @max_min() {
   %5 = arith.constant dense<4> : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = 8}}
   %6 = arith.maxsi %4, %5 : tensor<128xi32>
-  %7 = tt.make_range { end = 8 : i32, start = 0 : i32 } : tensor<8xi32>
-  %8 = arith.constant dense<8> : tensor<8xi32>
-  %9 = arith.constant dense<2> : tensor<8xi32>
-  %10 = arith.remsi %7, %9 : tensor<8xi32>
-  %11 = arith.maxsi %10, %8 : tensor<8xi32>
-  %12 = arith.minsi %10, %8 : tensor<8xi32>
+  // expected-remark @below {{contiguity = [8], divisibility = [4], constancy = [1], constant_value = <none>}}
+  %7 = tt.make_range { end = 12 : i32, start = 4 : i32 } : tensor<8xi32>
+  // expected-remark @below {{contiguity = [8], divisibility = [1073741824], constancy = [1], constant_value = <none>}}
+  %8 = tt.make_range { end = 8 : i32, start = 0 : i32 } : tensor<8xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [8], constancy = [8], constant_value = 8}}
+  %9 = arith.constant dense<8> : tensor<8xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [2], constancy = [8], constant_value = 2}}
+  %10 = arith.constant dense<2> : tensor<8xi32>
+  // expected-remark @below {{contiguity = [2], divisibility = [2], constancy = [1], constant_value = <none>}}
+  %11 = arith.remsi %8, %10 : tensor<8xi32>
+  // expected-remark @below {{contiguity = [2], divisibility = [2], constancy = [1], constant_value = <none>}}
+  %12 = arith.addi %11, %9 : tensor<8xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %13 = arith.maxsi %12, %7 : tensor<8xi32>
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %14 = arith.minsi %12, %7 : tensor<8xi32>
   tt.return
 }
 

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -460,6 +460,12 @@ tt.func @max_min() {
   %5 = arith.constant dense<4> : tensor<128xi32>
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = 8}}
   %6 = arith.maxsi %4, %5 : tensor<128xi32>
+  %7 = tt.make_range { end = 8 : i32, start = 0 : i32 } : tensor<8xi32>
+  %8 = arith.constant dense<8> : tensor<8xi32>
+  %9 = arith.constant dense<2> : tensor<8xi32>
+  %10 = arith.remsi %7, %9 : tensor<8xi32>
+  %11 = arith.maxsi %10, %8 : tensor<8xi32>
+  %12 = arith.minsi %10, %8 : tensor<8xi32>
   tt.return
 }
 


### PR DESCRIPTION
And also simplifies gcd invocation and lifts `kMaxDivisor` into a constant expression