### PR TITLE
Disable TMA for empty tensors

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -567,3 +567,28 @@ def test_fused_act(m, n, k, mode, split_k, do_gather, do_scatter, fused_scatter,
     except opt_flags.InapplicableConstraint:
         pytest.skip("inapplicable constraint")
     assert_close(a, b)
+
+
+@pytest.mark.parametrize("m, n, k", [
+    (320, 2**19, 0),
+    (4096, 4096, 0),
+])
+@pytest.mark.parametrize("view_x_as_zero_cols", [False, True])
+def test_zero_reduction_dim(m, n, k, view_x_as_zero_cols):
+    torch.manual_seed(0)
+
+    if view_x_as_zero_cols:
+        x = torch.randn(m, m, device="cuda", dtype=torch.bfloat16)
+        x = x[:0, :].transpose(-1, -2)
+    else:
+        x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(k, n, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(n, device="cuda", dtype=torch.float32)
+
+    try:
+        tri_y = matmul_ogs(x, w, bias)
+    except opt_flags.InapplicableConstraint:
+        pytest.skip("inapplicable constraint")
+    ref_y = matmul_ogs_torch(x, w, bias, round_x=lambda x, idx: x, round_y=lambda y: y)
+
+    assert_close(ref_y, tri_y)

--- a/python/triton_kernels/triton_kernels/matmul_ogs.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs.py
@@ -435,8 +435,8 @@ def matmul_ogs(x, w, bias,
         assert x.shape[0] == w.shape[0]
     # compute optimization flags
     out_dtype = precision_config.out_dtype or x.dtype
-    can_use_tma = x.storage.is_tma_compliant() and \
-                  w.storage.is_tma_compliant() and \
+    can_use_tma = x.numel() > 0 and x.storage.is_tma_compliant() and \
+                  w.numel() > 0 and w.storage.is_tma_compliant() and \
                  (w_scale is None or w_scale.storage.is_tma_compliant())
     # hopper w/ mxfp4 doesn't support TMA
     can_use_tma = can_use_tma and (torch.cuda.get_device_capability()[0] > 9 or bitwidth(w.dtype) != 4)


### PR DESCRIPTION
empty 2d tensors are viewed as 3D with a leading 1 dimension which leads to computed strides that are invalid with TMA