### PR TITLE
[Proton] Check and error out on insufficient profiling memory

### DIFF
--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -37,6 +37,15 @@ class CudaAllocator:
         # more efficient profiling data processing, rather than relying solely on post-processing.
         aligned_size = max(aligned_size, self.instrumentation_hook.profile_buffer_size)
 
+        # FIXME(fywkevin): remove this constraint after we have support for periodic buffer dumping.
+        # This matches `DEFAULT_HOST_BUFFER_SIZE` in
+        # triton/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
+        DEFAULT_HOST_BUFFER_SIZE = 64 * 1024 * 1024 # 64 MB
+        if aligned_size > DEFAULT_HOST_BUFFER_SIZE:
+            raise RuntimeError(
+                f"Profiler buffer size exceeds the maximum supported size ({DEFAULT_HOST_BUFFER_SIZE} bytes).\n"
+                f"Tried to allocate {aligned_size} byte. Please consider using a smaller grid size.")
+
         # Create the buffer
         import torch
         buffer = torch.empty((aligned_size, ), dtype=torch.uint8, device="cuda")

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -40,7 +40,7 @@ class CudaAllocator:
         # FIXME(fywkevin): remove this constraint after we have support for periodic buffer dumping.
         # This matches `DEFAULT_HOST_BUFFER_SIZE` in
         # triton/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
-        DEFAULT_HOST_BUFFER_SIZE = 64 * 1024 * 1024 # 64 MB
+        DEFAULT_HOST_BUFFER_SIZE = 64 * 1024 * 1024  # 64 MB
         if aligned_size > DEFAULT_HOST_BUFFER_SIZE:
             raise RuntimeError(
                 f"Profiler buffer size exceeds the maximum supported size ({DEFAULT_HOST_BUFFER_SIZE} bytes).\n"


### PR DESCRIPTION
Add a checking and error msg to prevent libproton silent crash when dumping profiler buffer during profiler exit hook.
