### PR TITLE
[AMD][Gluon] Add support for CDNA4 mfma scale

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -297,7 +297,7 @@ def test_amd_mfma_scaled(M, N, K, rhs_scale, mxfp_type, normal_type, num_warps, 
     DIV_FACTOR_A = 2 if type_a == "e2m1" else 1
     DIV_FACTOR_B = 2 if type_b == "e2m1" else 1
     x = make_arg((M, K // DIV_FACTOR_A), type_a, col_major=False)
-    y = make_arg((K // DIV_FACTOR_B, N), type_b, col_major=True)
+    y = make_arg((K // DIV_FACTOR_B, N), type_b, col_major=False)
 
     min_scale, max_scale = (0, 142) if comp_dtype == torch.bfloat16 else (124, 131)
     scale_x = torch.randint(min_scale, max_scale + 1, (M, K // 32), dtype=torch.uint8, device=device)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -230,15 +230,15 @@ def test_amd_mfma_scaled(M, N, K, rhs_scale, mxfp_type, normal_type, num_warps, 
             a_offsets = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, a_scale_layout))[:, None] * SCALE_BLOCK_K + \
                         ttgl.arange(0, SCALE_BLOCK_K, layout=ttgl.SliceLayout(0, a_scale_layout))[None, :]
             a_scale = ttgl.amd.cdna4.buffer_load(a_scale, a_offsets)
-
-            b_scale = ttgl.full([BLOCK_M, SCALE_BLOCK_K], 127, dtype=ttgl.int8, layout=b_scale_layout)
         else:
-            assert b_scale is not None
             a_scale = ttgl.full([BLOCK_M, SCALE_BLOCK_K], 127, dtype=ttgl.int8, layout=a_scale_layout)
 
+        if b_scale is not None:
             b_scale_offsets = ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(1, b_scale_layout))[:, None] * SCALE_BLOCK_K + \
                               ttgl.arange(0, SCALE_BLOCK_K, layout=ttgl.SliceLayout(0, b_scale_layout))[None, :]
             b_scale = ttgl.amd.cdna4.buffer_load(b_scale, b_scale_offsets)
+        else:
+            b_scale = ttgl.full([BLOCK_M, SCALE_BLOCK_K], 127, dtype=ttgl.int8, layout=b_scale_layout)
 
         c = ttgl.amd.cdna4.mfma_scaled(a, a_scale, type_a, b, b_scale, type_b, zero, layout=mfma_layout)
         c = c.to(out.dtype.element_ty)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -292,8 +292,6 @@ def test_amd_mfma_scaled(M, N, K, rhs_scale, mxfp_type, normal_type):
         scale_y = None
 
     def make_finite(x, dtype):
-        # e5m2 has too many non-finite values when sampled uniformly (1 / 32) and
-        # Fp8E5M2_to_Bf16 doesn't preserve NaNs (fixme)
         if dtype not in ("e5m2", "e4m3"):
             return x
         if dtype == "e5m2" and comp_dtype == torch.float16:

--- a/python/triton/experimental/gluon/language/amd/_layouts.py
+++ b/python/triton/experimental/gluon/language/amd/_layouts.py
@@ -73,7 +73,7 @@ class AMDMFMALayout(DistributedLayout):
         assert self.elem_type.is_fp32() or self.elem_type.is_fp64() \
           or self.elem_type.is_int32() , "element type must be float32, float64, or int32"
 
-        rank = len(self.cta_order)
+        rank = len(self.warps_per_cta)
         _realize_cta_layout(self, rank)
         assert len(self.ctas_per_cga) == rank
         assert len(self.cta_split_num) == rank

--- a/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
-from triton.language.core import knobs
 from triton.experimental.gluon.language import _core as ttgl
 from triton._C.libtriton import ir
 from ..._core import builtin, int32, uint32, float32, _unwrap_if_constexpr
@@ -114,6 +113,6 @@ def buffer_store(stored_value, ptr, offsets, mask=None, cache=None, _semantic: G
 
 
 @builtin
-def mfma(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_imprecise_acc=None,
-         out_dtype=float32, layout=None, _semantic=None):
+def mfma(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_imprecise_acc=None, out_dtype=float32,
+         layout=None, _semantic=None):
     ...

--- a/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
+from triton.language.core import knobs
 from triton.experimental.gluon.language import _core as ttgl
 from triton._C.libtriton import ir
-from ..._core import builtin, int32, uint32, _unwrap_if_constexpr
+from ..._core import builtin, int32, uint32, float32, _unwrap_if_constexpr
 from ..._semantic import _check
 
 if TYPE_CHECKING:
@@ -90,7 +91,7 @@ def buffer_load(ptr, offsets, mask=None, other=None, cache=None, _semantic=None)
 
 
 @builtin
-def buffer_store(stored_value, ptr, offsets, mask, cache=None, _semantic: GluonSemantic = None):
+def buffer_store(stored_value, ptr, offsets, mask=None, cache=None, _semantic: GluonSemantic = None):
     """
     AMD buffer store a tensor directly to global memory via a scalar base pointer and a tensor of
     offsets instead of a tensor of pointers.
@@ -110,3 +111,9 @@ def buffer_store(stored_value, ptr, offsets, mask, cache=None, _semantic: GluonS
     cache_modifier = _semantic._str_to_load_cache_modifier(cache) if cache is not None else ir.CACHE_MODIFIER.NONE
 
     _semantic.builder.create_buffer_store(stored_value.handle, ptr.handle, offsets.handle, mask, cache_modifier)
+
+
+@builtin
+def mfma(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_imprecise_acc=None,
+         out_dtype=float32, layout=None, _semantic=None):
+    ...

--- a/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from triton.experimental.gluon.language import _core as ttgl
 from triton._C.libtriton import ir
-from ..._core import builtin, int32, uint32, float32, _unwrap_if_constexpr
+from ..._core import builtin, int32, uint32, _unwrap_if_constexpr
 from ..._semantic import _check
 
 if TYPE_CHECKING:
@@ -110,9 +110,3 @@ def buffer_store(stored_value, ptr, offsets, mask=None, cache=None, _semantic: G
     cache_modifier = _semantic._str_to_load_cache_modifier(cache) if cache is not None else ir.CACHE_MODIFIER.NONE
 
     _semantic.builder.create_buffer_store(stored_value.handle, ptr.handle, offsets.handle, mask, cache_modifier)
-
-
-@builtin
-def mfma(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_imprecise_acc=None, out_dtype=float32,
-         layout=None, _semantic=None):
-    ...

--- a/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
@@ -1,19 +1,34 @@
 from triton.experimental.gluon.language import _core as ttgl
 from ..._core import builtin, float32, _unwrap_if_constexpr
+from .._layouts import AMDMFMALayout
 from ..cdna3 import buffer_load_to_shared, buffer_load, buffer_store
 
 __all__ = ["buffer_load_to_shared", "buffer_load", "buffer_store", "mfma_scaled"]
 
 
 @builtin
-def mfma_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc, fast_math=False, lhs_k_pack=True,
-                rhs_k_pack=True, out_dtype=float32, layout=None, _semantic=None):
-    out_dtype = _unwrap_if_constexpr(out_dtype)
-    assert out_dtype == float32, "Only float32 is supported for out_dtype at the moment"
-    tensor = _semantic.dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc, fast_math, lhs_k_pack,
-                                  rhs_k_pack, out_dtype)
+def mfma_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc, fast_math=False, layout=None,
+                _semantic=None):
+    """
+    AMD MFMA scaled operation, supported only on CDNA4 hardware. This is thin
+    wrapper around the `tl.dot_scaled` operation, with enforced mfma layout.
 
-    assert layout is not None, "Layout must be specified for mfma_scaled"
+    Args:
+        lhs (tensor): Left-hand side tensor.
+        lhs_scale (tensor): Scale tensor for the left-hand side.
+        lhs_format (str): Format of the left-hand side tensor.
+        rhs (tensor): Right-hand side tensor.
+        rhs_scale (tensor): Scale tensor for the right-hand side.
+        rhs_format (str): Format of the right-hand side tensor.
+        acc (tensor): Accumulator tensor.
+        fast_math (bool, optional): Enable fast math. Defaults to False.
+        layout (ttgl.amd.AMDMFMALayout): Layout for the operation.
+    """
     layout = _unwrap_if_constexpr(layout)
+    assert isinstance(layout, AMDMFMALayout), "Expected layout to be an instance of AMDMFMALayout"
+
+    tensor = _semantic.dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc, fast_math, True, True,
+                                  float32)
+
     ret_ty = ttgl.distributed_type(tensor.dtype, tensor.shape, layout)
     return ttgl.tensor(tensor.handle, ret_ty)

--- a/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
@@ -1,3 +1,21 @@
-from ..cdna3 import buffer_load_to_shared, buffer_load, buffer_store
+from triton.language.core import knobs
+from triton.experimental.gluon.language import _core as ttgl
+from ..._core import builtin, float32, _unwrap_if_constexpr
+from ..cdna3 import buffer_load_to_shared, buffer_load, buffer_store, mfma
 
-__all__ = ["buffer_load_to_shared", "buffer_load", "buffer_store"]
+__all__ = ["buffer_load_to_shared", "buffer_load", "buffer_store", "mfma", "mfma_scaled"]
+
+
+@builtin
+def mfma_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc,
+                fast_math=False, lhs_k_pack=True, rhs_k_pack=True, out_dtype=float32,
+                layout=None, _semantic=None):
+    out_dtype = _unwrap_if_constexpr(out_dtype)
+    assert out_dtype == float32, "Only float32 is supported for out_dtype at the moment"
+    tensor = _semantic.dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc, fast_math, lhs_k_pack,
+                                  rhs_k_pack, out_dtype)
+
+    assert layout is not None, "Layout must be specified for mfma_scaled"
+    layout = _unwrap_if_constexpr(layout)
+    ret_ty = ttgl.distributed_type(tensor.dtype, tensor.shape, layout)
+    return ttgl.tensor(tensor.handle, ret_ty)

--- a/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
@@ -14,12 +14,12 @@ def mfma_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc, fas
     wrapper around the `tl.dot_scaled` operation, with enforced mfma layout.
 
     Args:
-        lhs (tensor): Left-hand side tensor.
-        lhs_scale (tensor): Scale tensor for the left-hand side.
-        lhs_format (str): Format of the left-hand side tensor.
-        rhs (tensor): Right-hand side tensor.
-        rhs_scale (tensor): Scale tensor for the right-hand side.
-        rhs_format (str): Format of the right-hand side tensor.
+        lhs (tensor): The first tensor to be multiplied.
+        lhs_scale (tensor): Scale factor for lhs tensor.
+        lhs_format (str): Format of the lhs tensor.
+        rhs (tensor): The second tensor to be multiplied.
+        rhs_scale (tensor): Scale factor for rhs tensor.
+        rhs_format (str): Format of the rhs tensor.
         acc (tensor): Accumulator tensor.
         fast_math (bool, optional): Enable fast math. Defaults to False.
         layout (ttgl.amd.AMDMFMALayout): Layout for the operation.

--- a/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
@@ -1,4 +1,3 @@
-from triton.language.core import knobs
 from triton.experimental.gluon.language import _core as ttgl
 from ..._core import builtin, float32, _unwrap_if_constexpr
 from ..cdna3 import buffer_load_to_shared, buffer_load, buffer_store, mfma
@@ -7,9 +6,8 @@ __all__ = ["buffer_load_to_shared", "buffer_load", "buffer_store", "mfma", "mfma
 
 
 @builtin
-def mfma_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc,
-                fast_math=False, lhs_k_pack=True, rhs_k_pack=True, out_dtype=float32,
-                layout=None, _semantic=None):
+def mfma_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc, fast_math=False, lhs_k_pack=True,
+                rhs_k_pack=True, out_dtype=float32, layout=None, _semantic=None):
     out_dtype = _unwrap_if_constexpr(out_dtype)
     assert out_dtype == float32, "Only float32 is supported for out_dtype at the moment"
     tensor = _semantic.dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc, fast_math, lhs_k_pack,

--- a/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
@@ -1,8 +1,8 @@
 from triton.experimental.gluon.language import _core as ttgl
 from ..._core import builtin, float32, _unwrap_if_constexpr
-from ..cdna3 import buffer_load_to_shared, buffer_load, buffer_store, mfma
+from ..cdna3 import buffer_load_to_shared, buffer_load, buffer_store
 
-__all__ = ["buffer_load_to_shared", "buffer_load", "buffer_store", "mfma", "mfma_scaled"]
+__all__ = ["buffer_load_to_shared", "buffer_load", "buffer_store", "mfma_scaled"]
 
 
 @builtin


### PR DESCRIPTION
This PR added  support for CDNA4 mfma scale in Gluon. Under the hood it still used `dot_scaled` but with enforece mfma layout. Added an example dot kernel with mxfp8 * mxfp4 for testing. Test cases are adopted from `python/test/unit/language/test_core.py::test_scaled_dot`
