### PR TITLE
[TEST] Use two different monkey patch objects for environment variable restore

### DIFF
--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -25,9 +25,9 @@ def fresh_triton_cache():
 
 
 @pytest.fixture
-def fresh_knobs(monkeypatch):
+def fresh_knobs():
     from triton._internal_testing import _fresh_knobs_impl
-    fresh_function, reset_function = _fresh_knobs_impl(monkeypatch)
+    fresh_function, reset_function = _fresh_knobs_impl()
     try:
         yield fresh_function()
     finally:
@@ -35,14 +35,14 @@ def fresh_knobs(monkeypatch):
 
 
 @pytest.fixture
-def fresh_knobs_except_libraries(monkeypatch):
+def fresh_knobs_except_libraries():
     """
     A variant of `fresh_knobs` that keeps library path
     information from the environment as these may be
     needed to successfully compile kernels.
     """
     from triton._internal_testing import _fresh_knobs_impl
-    fresh_function, reset_function = _fresh_knobs_impl(monkeypatch, skipped_attr={"build", "nvidia", "amd"})
+    fresh_function, reset_function = _fresh_knobs_impl(skipped_attr={"build", "nvidia", "amd"})
     try:
         yield fresh_function()
     finally:

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -239,7 +239,8 @@ def _fresh_knobs_impl(skipped_attr: Optional[Set[str]] = None):
     def reset_function():
         for name, knobset in knobs_map.items():
             setattr(knobs, name, knobset)
-        # undo should be placed before del os.environ
+        # `undo` should be placed before `del os.environ`
+        # Otherwise, it may restore environment variables that monkeypatch deleted
         monkeypatch.undo()
         for k in env_to_unset:
             if k in os.environ:

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -204,11 +204,13 @@ def unwrap_tensor(t: Union[torch.Tensor, triton.runtime.jit.TensorWrapper]) -> t
     return t
 
 
-def _fresh_knobs_impl(monkeypatch, skipped_attr: Optional[Set[str]] = None):
+def _fresh_knobs_impl(skipped_attr: Optional[Set[str]] = None):
     from triton import knobs
 
     if skipped_attr is None:
         skipped_attr = set()
+
+    monkeypatch = pytest.MonkeyPatch()
 
     knobs_map = {
         name: knobset
@@ -237,6 +239,8 @@ def _fresh_knobs_impl(monkeypatch, skipped_attr: Optional[Set[str]] = None):
     def reset_function():
         for name, knobset in knobs_map.items():
             setattr(knobs, name, knobset)
+        # undo should be placed before del os.environ
+        monkeypatch.undo()
         for k in env_to_unset:
             if k in os.environ:
                 del os.environ[k]

--- a/python/triton_kernels/tests/conftest.py
+++ b/python/triton_kernels/tests/conftest.py
@@ -11,9 +11,9 @@ def device(request):
 
 
 @pytest.fixture
-def fresh_knobs(monkeypatch):
+def fresh_knobs():
     from triton._internal_testing import _fresh_knobs_impl
-    fresh_function, reset_function = _fresh_knobs_impl(monkeypatch)
+    fresh_function, reset_function = _fresh_knobs_impl()
     try:
         yield fresh_function()
     finally:


### PR DESCRIPTION
This is a quite interesting problem.

Long story short, without the PR we cannot clean up variables set in the tests.

And running `pytest test_knobs.py` after applying the following diff will fail

```
diff --git a/python/test/unit/test_knobs.py b/python/test/unit/test_knobs.py
index ba2c8517c..808198076 100644
--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -117,6 +117,10 @@ def test_env_updated(fresh_knobs, monkeypatch):
     assert os.environ["TRITON_HOME"] == "/foo/bar"


+def test_none():
+    assert "TRITON_HIP_LOCAL_PREFETCH" not in os.environ
+
+
```