### PR TITLE
[Backend] Use byte permutes in intra-warp layout conversion

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -181,10 +181,19 @@ private:
 // `pReg` and `pLane` are square layouts each with only one input and output
 // dimension. `mixedTranspositions` holds pairs of integers (i, j)
 // corresponding to the transposition (r_i l_j) of the i-th register basis
-// vector with the j-th lane basis vector.
+// vector with the j-th lane basis vector along with 16-bit selectors for byte
+// permute instructions.
 struct DecomposedWarpConversion {
+  struct TranspositionInfo {
+    std::pair<int, int> transposition;
+    uint16_t topPreSel = 0x3210;
+    uint16_t botPreSel = 0x7654;
+    uint16_t topPostSel = 0x3210;
+    uint16_t botPostSel = 0x7654;
+  };
+
   triton::LinearLayout pReg, pLane;
-  SmallVector<std::pair<int, int>> mixedTranspositions;
+  SmallVector<TranspositionInfo> mixedTranspositions;
 };
 
 // Produces a decomposition of a permutation describing a warp-local layout
@@ -196,7 +205,7 @@ struct DecomposedWarpConversion {
 // represented as a permutation.
 DecomposedWarpConversion
 getWarpLayoutConvertDecomposition(RankedTensorType srcTy,
-                                  RankedTensorType dstTy);
+                                  RankedTensorType dstTy, int bitwidth);
 
 // Decomposes a reshape into simpler pieces.
 //

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -48,6 +48,9 @@ public:
   virtual Value shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
                            Value i) const = 0;
 
+  virtual Value permute(RewriterBase &rewriter, Location loc, Value a, Value b,
+                        Value selector) const = 0;
+
   virtual Value programId(RewriterBase &rewriter, Location loc,
                           ModuleOp moduleOp, ProgramIDDim axis) const = 0;
 

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -16,6 +16,7 @@
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
+#include "llvm/ADT/SmallSet.h"
 
 namespace mlir {
 
@@ -249,7 +250,7 @@ unsigned ScanLoweringHelper::getScratchSizeInBytes() {
 
 DecomposedWarpConversion
 getWarpLayoutConvertDecomposition(RankedTensorType srcTy,
-                                  RankedTensorType dstTy) {
+                                  RankedTensorType dstTy, int bitwidth) {
   // Two layouts, ll_src and ll_dst, representing the same tensor can be
   // viewed as surjections of GF(2) vector spaces:
   //
@@ -278,11 +279,12 @@ getWarpLayoutConvertDecomposition(RankedTensorType srcTy,
   // subsequences of consecutive lane bits from cycles involving both bit types.
   // Further explanation of this method is below.
   //
-  // The decomposition is performed in two stages. First, we compute the
+  // The decomposition is performed in three stages. First, we compute the
   // permutation matrix `P` by using `invertAndCompose` to generate a skeleton
   // and then fill in any zero columns. Second, we walk the cycles of `P` to
   // factor out mixed transpositions to build `mixedTranspositions`, `pReg`, and
-  // `pLane`.
+  // `pLane`. Finally, we determine any selectors needed for byte permute
+  // instructions in place of `selp` instructions when packing registers.
 
   // We remove any broadcasting in the register dimensions of the layouts before
   // forming the permutation `P` as the components of the decomposition directly
@@ -336,19 +338,14 @@ getWarpLayoutConvertDecomposition(RankedTensorType srcTy,
     T = padWithZeros(T);
   }
 
-  // Flatten outs for ease of building `P`, and reorder outs as flattening
-  // depends on output dimension order.
-  if (outDimNames != llvm::to_vector(T.getOutDimNames()))
-    T = T.transposeOuts(outDimNames);
-  S = S.flattenOuts();
-  T = T.flattenOuts();
-
   // We compute T^transpose \circ S, which serves as a skeleton for `P`, then
   // fill in zero columns, prioritizing producing fixed points. As we only need
   // the basis vectors of `P`, we never actually produce the LinearLayout.
   auto pBases = S.invertAndCompose(T).getBases();
 
   // Find the common and uncommon zeros of S and T
+  S = S.flattenOuts();
+  T = T.flattenOuts();
   SmallVector<std::pair<int32_t, int32_t>> srcFreeZeros;
   SmallVector<std::pair<int32_t, int32_t>> dstFreeZeros;
   for (auto [dimIdx, dim] : llvm::enumerate(inDimNames)) {
@@ -461,11 +458,215 @@ getWarpLayoutConvertDecomposition(RankedTensorType srcTy,
   }
   assert(visited.all() && "Cycle walk incomplete");
 
+  // When possible, we fuse permutations of 'low' register bits together
+  // with a mixed transposition, resulting in byte permute instructions instead
+  // of `select` instructions. After processing, no low register bits appear in
+  // the returned list of mixed transpositions.
+  int m = mixedTranspositions.size();
+  int nPackPrelim = llvm::Log2_32(std::clamp(32 / bitwidth, 1, 4));
+  int nPack = std::min(nPackPrelim, nRegBases - m);
+  // Consider for example the cycle
+  //
+  //        (r2 r1 l0 r0 r3) = (r0 l0) * (r2 r1 r0 r3)
+  //                         = (r3 r0) * (r3 l0) * (r3 r1) * (r3 r2)
+  //
+  // with `nPack` = 2 so that r0 and r1 are considered low bits. We want to
+  // factor out any low bits from `pReg` and to incorporate them into the data
+  // of the mixed transposition. After processing, the contribution to `pReg`
+  // is reduced to (r3 r2) and the mixed transposition recorded is (r3 l0), with
+  // the effects of (r3 r0) and (r3 r1) encoded in the returned selectors.
+  // In general, low bits occurring immediately before l_j modify the selectors
+  // of the `prmt` before the shuffle, while low bits occurring immediately
+  // after l_k modify the selectors of the `prmt` after the shuffle. Unmodified
+  // selectors correspond to `select` instructions.
+  // Cases like (l0 r0 r1) must be handled by selecting a 'partner' bit that is
+  // not used in another mixed transposition and conjugating out a low bit:
+  //
+  //           (l0 r0 r1) = (r2 r1) * (l0 r0 r2) * (r2 r1)
+  //                      = (r2 r1) * (r2 r0) * (r2 l0) * (r2 r1).
+  //
+  // Conjugation does not affect `pReg`. However, the set of fused mixed and
+  // low-bit transpositions is noncommutative in cases where there are no
+  // intervening high bits in between distinct sequences of lane bits as the
+  // paired low bit is used in modifying the selectors of both factors:
+  //
+  //    (l0 r0 r1 l1 r2) = (r3 r0)(r3 l0)(r3 r0) * (r2 l1)(r2 r1)(r2 r0).
+  //
+  // Processing of mixed transpositions is performed by determining the `head`
+  // and `tail` of an excision of bits in cycles of `pReg` and building lists
+  // of low bits acting as selector modifiers. In the noncommutative cases, we
+  // opt to restrict the number of post-shuffle modifiers to one.
+
+  auto permuteSelector = [nPack](uint16_t sel, int bitIdx) {
+    int lo = bitIdx + (2 - nPack);
+    uint16_t maskHi = 0x4444;
+    uint16_t maskLo = 0x1111 << lo;
+    uint16_t fixed = sel & ~maskHi & ~maskLo;
+    int shift = 2 - lo;
+    return fixed | ((maskHi & sel) >> shift) | ((maskLo & sel) << shift);
+  };
+  auto generateSelectors = [&](int head, int tail, auto &&lowBits) {
+    uint16_t topSel = 0x3210;
+    uint16_t botSel = 0x7654;
+    for (auto lowBit : lowBits) {
+      topSel = permuteSelector(topSel, lowBit);
+      botSel = permuteSelector(botSel, lowBit);
+      if (lowBit != head && lowBit != tail)
+        regBases[lowBit][0] = 1 << lowBit;
+    }
+    return std::pair{topSel, botSel};
+  };
+
+  llvm::SmallSet<int32_t, 6> pairedRegBits;
+  for (auto [rBit, lBit] : mixedTranspositions)
+    pairedRegBits.insert(rBit);
+
+  // A low bit in a mixed transposition must be replaced by a high bit. The
+  // choice of high bit can affect instruction count. If the first high bit
+  // found when walking along `pReg` is unpaired, then that bit is the best
+  // choice. We reorder the transpositions to guarantee this during processing.
+  auto next = [&](int b) { return llvm::Log2_32(regBases[b][0]); };
+  auto nextHighFree = [&](auto p) {
+    int curr = p.first;
+    do {
+      if (curr >= nPack)
+        return curr == p.first || !pairedRegBits.contains(curr);
+      curr = next(curr);
+    } while (curr != p.first);
+    return false;
+  };
+  std::stable_partition(mixedTranspositions.begin(), mixedTranspositions.end(),
+                        nextHighFree);
+  // If `P` has an isolated low-bit mixed transposition, and `pReg` maps a low
+  // bit to an open high bit, then the high bit should be used as the partner.
+  auto prev = [&](int b) {
+    int tail = b;
+    int curr = next(b);
+    while (curr != b) {
+      tail = curr;
+      curr = next(curr);
+    }
+    return tail;
+  };
+  auto findPartner = [&](int lowBit, auto &preShufLoBits) {
+    if (nPack == 2) {
+      int otherLow = 1 - lowBit;
+      int b = next(otherLow);
+      if (next(lowBit) == lowBit && b >= nPack && !pairedRegBits.contains(b) &&
+          !pairedRegBits.contains(otherLow)) {
+        preShufLoBits.push_back(otherLow);
+        regBases[prev(otherLow)][0] = 1 << b;
+        pairedRegBits.insert(b);
+        return b;
+      }
+    }
+    int potentialPartner = nPack;
+    while (pairedRegBits.contains(potentialPartner))
+      ++potentialPartner;
+    pairedRegBits.insert(potentialPartner);
+    return potentialPartner;
+  };
+
+  SmallVector<DecomposedWarpConversion::TranspositionInfo> ret;
+  ret.reserve(mixedTranspositions.size());
+
+  for (auto p : mixedTranspositions) {
+    int rBit = p.first;
+    int lBit = p.second;
+    SmallVector<int> cycle;
+    int currBit = rBit;
+    do {
+      cycle.push_back(currBit);
+      currBit = next(currBit);
+    } while (currBit != rBit);
+
+    // Find any low register bits adjacent to the excised lane bits which aren't
+    // used in other mixed transpositions.
+    auto isBoundary = [&](int bit) {
+      return bit >= nPack || (pairedRegBits.contains(bit) && bit != rBit);
+    };
+    auto forwardEnd = llvm::find_if(cycle, isBoundary);
+    auto backwardEnd = std::find_if(cycle.rbegin(), cycle.rend(), isBoundary);
+    SmallVector<int> postShufLoBits(cycle.begin(), forwardEnd);
+    SmallVector<int> preShufLoBits(cycle.rbegin(), backwardEnd);
+    int head;
+    int tail;
+    int partnerBit = -1;
+
+    // Case work to determine what to conjugate out.
+    if (forwardEnd != cycle.end()) {
+      if (*forwardEnd == rBit || !pairedRegBits.contains(*forwardEnd)) {
+        // End at original or unpaired high bit. E.g. (l0 r0 r2) or (l0 r2)
+        // No conjugation needed.
+        head = partnerBit = *forwardEnd;
+      } else {
+        // End at different paired bit. E.g. (l0 r0 r1 l1 r2)
+        // Non-leading factor in a noncommutative case.
+        // Conjugate by first low bit in forward walk.
+        head = postShufLoBits.front();
+        preShufLoBits.push_back(head);
+        postShufLoBits.resize(1);
+        pairedRegBits.erase(head);
+      }
+      tail = *backwardEnd;
+      if (tail < nPack && pairedRegBits.contains(tail)) {
+        // Non-terminal factor in a noncommutative case.
+        preShufLoBits.insert(preShufLoBits.begin(), tail);
+      }
+    } else {
+      if (next(rBit) != rBit && pairedRegBits.contains(next(rBit))) {
+        // Symmetric noncommutative case. E.g. (l0 r0 l1 r1)
+        preShufLoBits.erase(preShufLoBits.begin());
+        postShufLoBits.pop_back();
+        pairedRegBits.erase(postShufLoBits.front());
+        head = rBit;
+        tail = next(rBit);
+      } else {
+        // Isolated low bits with single mixed transposition. E.g. (l0 r0 r1)
+        if (postShufLoBits.size() == 2)
+          postShufLoBits.pop_back();
+        head = tail = preShufLoBits.front();
+      }
+    }
+
+    if (partnerBit < 0)
+      partnerBit = findPartner(head, preShufLoBits);
+    auto [topPostSel, botPostSel] =
+        generateSelectors(head, tail, llvm::reverse(postShufLoBits));
+    auto [topPreSel, botPreSel] = generateSelectors(head, tail, preShufLoBits);
+    regBases[tail][0] = 1 << head;
+
+    DecomposedWarpConversion::TranspositionInfo info;
+    info.transposition = {partnerBit, lBit};
+    info.topPreSel = topPreSel;
+    info.botPreSel = botPreSel;
+    info.topPostSel = topPostSel;
+    info.botPostSel = botPostSel;
+
+    // In noncommutative cases, post-shuffle selectors of non-leading terms come
+    // from a single low bit by design, so we can determine where to insert a
+    // non-terminal factor by examining processed selectors.
+    if (!preShufLoBits.empty()) {
+      uint16_t sel = (nPack - preShufLoBits.back()) == 2 ? 0x6240 : 0x5410;
+      auto it =
+          llvm::find_if(ret, [&](auto &t) { return t.topPostSel == sel; });
+      ret.insert(it, info);
+    } else {
+      ret.push_back(info);
+    }
+  }
+  if (nPack == 2 && regBases[0][0] == 2 && regBases[1][0] == 1 && ret.size()) {
+    // If (r0 r1) was originally in `P`, fold it into a mixed transposition.
+    auto &t = ret.back();
+    t.topPostSel = 0x3120;
+    t.botPostSel = 0x7564;
+  }
+
   auto pReg = LinearLayout(std::move(pRegBases), {{kReg, 1 << nRegBases}},
                            /*requireSurjective=*/true);
   auto pLane = LinearLayout(std::move(pLaneBases), {{kLane, 1 << nLaneBases}},
                             /*requireSurjective=*/true);
-  return {std::move(pReg), std::move(pLane), std::move(mixedTranspositions)};
+  return {std::move(pReg), std::move(pLane), std::move(ret)};
 }
 
 SmallVector<std::pair<SmallVector<int64_t>, SmallVector<int64_t>>>
@@ -763,7 +964,7 @@ bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
   auto kLane = StringAttr::get(ctx, "lane");
   if (to_vector(layout.getOutDimNames()) ==
       SmallVector<StringAttr, 2>{kRegister, kLane}) {
-    auto factors = getWarpLayoutConvertDecomposition(srcTy, dstTy);
+    auto factors = getWarpLayoutConvertDecomposition(srcTy, dstTy, 32);
     return (factors.mixedTranspositions.size() < 2);
   }
   return false;

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -292,11 +292,11 @@ struct ConvertLayoutOpConversion
     // register index bits with lane index bits. Our goal is to implement P
     // using predicated selects and warp-shuffles. We have two tools for this:
     //  - An out-of-place `Ship` method which implements one mixed transposition
-    //    at a time using 1.5 * R selects and .5 * R shuffles each.
+    //    at a time using 1.5 * R selects/permutes and .5 * R shuffles each.
     //  - An in-place `Swap` method which can simultaneously implement P_lane
-    //    and multiple mixed transpositions at a time using 2 * m * R selects
-    //    and either (1 - (1/2)^m) * R shuffles if `pLaneIsTrivial` or R
-    //    shuffles otherwise.
+    //    and multiple mixed transpositions at a time using 2 * m * R selects/
+    //    permutes and either (1 - (1/2)^m) * R shuffles if `pLaneIsTrivial` and
+    //    R shuffles otherwise.
     // Here, R denotes the number of 32-bit registers in use after packing (or
     // splitting, if applied to 64-bit types or pointers), and in the `Swap`
     // method, `m` denotes the number of mixed transpositions passed in.

--- a/test/Conversion/tritongpu_to_ptx_mmav3.mlir
+++ b/test/Conversion/tritongpu_to_ptx_mmav3.mlir
@@ -10,7 +10,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
     // CHECK-COUNT-64: ld.param.b8
 
-    // Intra-warp layout conversions can be viewed as a permutation of register
+    // Intra-warp layout conversions can be viewed as permutations of register
     // and lane basis vectors. This can be read off from the linear layouts:
     //
     // #mma:     register: [[0,1], [8,0], [0,8], [0,16], [0,32], [64,0]]
@@ -21,28 +21,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     //               lane: [[0,4], [0,8], [1,0], [2,0], [4,0]]
     //               warp: [[16,0], [32,0]]
     //
-    // The layout conversion is described by the permutation (r1 r2 l1 l0),
-    // which factors as (r1 l1)(l0 l1)(r1 r2).
+    // This layout conversion is described by the permutation (r1 r2 l1 l0),
+    // which factors as (r2 r1)(r2 l1)(l0 l1).
     //
     // Register basis vectors correspond to the bits of the indices of the 64
     // separate registers which hold the original elements. Since we end up
     // packing 4 elements per register, we end up with only 16 registers in
-    // total before shuffling. The `transferWithinWarp` implementation handles
-    // register packing by ensuring that elements are packed together only if
-    // under the layout conversion, they end up in the same destination lane.
-    // To do this, it rearranges the 64 registers so that it can pack 4
-    // consecutive elements at a time according to their new register index.
-    //
-    // The transposition (r1 l1) above indicates that intially, elements with
-    // register indices whose r1 bit is on are to be moved to new lanes. We thus
-    // need to rearrange the registers. The algorithm chooses the next register
-    // bit > 1 which is not used in a mixed transposition. In this case,
-    // that bit is r2. Algebrically, this corresponds to conjugating the
-    // permutation with (r1 r2). This produces (r1 r2)(r2 l1)(l0 l1). The new
-    // (r1 r2) at the end rearranges elements after unpacking, and only
-    // (r2 l1)(l0 l1) matters for tracking the movement of the packed registers.
-    // From the point of view of the packed registers, the symbol `r2` now
-    // corresponds to the 0th bit of a (packed) register's index.
+    // total before shuffling. The `transferWithinWarp` implementation in this
+    // case packs elements without rearranging elements beforehand. After
+    // packing the symbol `r2` corresponds to the 0th bit of a register's index.
     //
     // The transposition (r2 l1) is a bit swap which is implemented in-place as:
     //  1. r2 ^= l1
@@ -102,12 +89,35 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-DAG: shfl.sync.idx.b32     {{.*}}, [[LANEID_PERM_F]], 31, -1;
     // CHECK-DAG: shfl.sync.idx.b32     {{.*}}, [[LANEID_PERM_F]], 31, -1;
 
-    // Finally, the last set of selects are performed, using the value of l1 as
-    // the predicate (step 3).
+    // The effects of the register bit permutation (r2 r1) are fused with step
+    // 3 of the implementation of (r2 l1), producing `prmt` instructions instead
+    // of `selp`s. The `prmt`s have selectors which are dependent on the value
+    // of the l1 bit. For packed register indices with the r2 bit off, the pair
+    // of selectors used is 0x5410 and 0x1054, while for those with the r2 bit
+    // on, we have selectors 0x7632 and 0x3276. These are 21520, 4180, 30258,
+    // and 12918 in decimal, respectively.
 
     // CHECK-DAG: and.b32           [[L1_VAL:%.*]], [[TID]], 2;
     // CHECK-DAG: setp.eq.s32       [[L1_OFF:%.*]], [[L1_VAL]], 0;
-    // CHECK-COUNT-16: selp.b32     {{.*}}, {{.*}}, [[L1_OFF]];
+    // CHECK:     selp.b32          [[SEL1:%.*]], 21520, 4180, [[L1_OFF]];
+    // CHECK:     selp.b32          [[SEL2:%.*]], 30258, 12918, [[L1_OFF]];
+
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL1]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL2]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL1]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL2]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL1]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL2]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL1]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL2]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL1]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL2]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL1]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL2]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL1]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL2]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL1]];
+    // CHECK-DAG: prmt.b32          {{.*}}, {{.*}}, {{.*}}, [[SEL2]];
 
     // CHECK-COUNT-64: bfe.u32
     // CHECK-COUNT-64: st.volatile.global.b8

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -137,6 +137,14 @@ Value TargetInfo::shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
   return LLVM::AMD::shuffleIdx(loc, rewriter, val, i, getISAFamily());
 }
 
+Value TargetInfo::permute(RewriterBase &rewriter, Location loc, Value a,
+                          Value b, Value selector) const {
+  // Warning: The `a` and `b` operands are ordered to align with Nvidia's `prmt`
+  // Both use little-endian ordering, but AMD puts the MSBs of the data in the
+  // 0-th operand.
+  return LLVM::AMD::permute(loc, rewriter, b, a, selector);
+}
+
 Value TargetInfo::programId(RewriterBase &rewriter, Location loc,
                             ModuleOp moduleOp, ProgramIDDim axis) const {
   return LLVM::AMD::llGetPid(loc, rewriter, moduleOp, axis);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -43,6 +43,9 @@ public:
   Value shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
                    Value i) const override;
 
+  Value permute(RewriterBase &rewriter, Location loc, Value a, Value b,
+                Value selector) const override;
+
   Value programId(RewriterBase &rewriter, Location loc, ModuleOp moduleOp,
                   ProgramIDDim axis) const override;
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -284,6 +284,14 @@ Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i,
                        b.i32_val(0x1f));
 }
 
+Value permute(Location loc, RewriterBase &rewriter, Value a, Value b,
+              Value selector) {
+  Value args[] = {a, b, selector};
+  auto op = createLLVMIntrinsicCallOp(rewriter, loc, "llvm.amdgcn.perm", i32_ty,
+                                      args);
+  return op.getResult(0);
+}
+
 Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
                ProgramIDDim axis) {
   Value blockId =

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -37,6 +37,9 @@ Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i,
                  mlir::triton::AMD::ISAFamily isaFamily =
                      mlir::triton::AMD::ISAFamily::Unknown);
 
+Value permute(Location loc, RewriterBase &rewriter, Value a, Value b,
+              Value selector);
+
 Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
                ProgramIDDim axis);
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -435,6 +435,11 @@ Value TargetInfo::shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
   return LLVM::NVIDIA::shuffleIdx(loc, rewriter, val, i);
 }
 
+Value TargetInfo::permute(RewriterBase &rewriter, Location loc, Value a,
+                          Value b, Value selector) const {
+  return LLVM::NVIDIA::permute(loc, rewriter, a, b, selector);
+}
+
 Value TargetInfo::programId(RewriterBase &rewriter, Location loc,
                             ModuleOp moduleOp, ProgramIDDim axis) const {
   return LLVM::NVIDIA::llGetPid(loc, rewriter, moduleOp, axis);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -36,6 +36,9 @@ public:
   Value shuffleIdx(RewriterBase &rewriter, Location loc, Value val,
                    Value i) const override;
 
+  Value permute(RewriterBase &rewriter, Location loc, Value a, Value b,
+                Value selector) const override;
+
   Value programId(RewriterBase &rewriter, Location loc, ModuleOp moduleOp,
                   ProgramIDDim axis) const override;
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -113,8 +113,8 @@ Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
 }
 
 Value permute(Location loc, RewriterBase &rewriter, Value a, Value b,
-              Value mask) {
-  Value args[] = {a, b, mask};
+              Value selector) {
+  Value args[] = {a, b, selector};
   auto op =
       createLLVMIntrinsicCallOp(rewriter, loc, "llvm.nvvm.prmt", i32_ty, args);
   return op.getResult(0);


### PR DESCRIPTION
### Issue
We patch an oversight in #7558 where reindexing sub-32-bit elements before or after unpacking them from vectors can cause LLVM’s InstCombine to materialize `shufflevector`s in real kernels that lower to byte permute instructions, which are not optimized away. 

This was believed to cause a small regression in #7574. In the context of that PR, one has 8-bit elements packed into registers and a layout conversion described by the permutation `(r1 r2 l1 l0)` of register (`r*`) and lane (`l*`) basis vectors. Due to register packing, `r1` corresponds to an intra-register index bit.

The current algorithm interprets
```
(r1 r2 l1 l0) = (r2 r1) * (r2 l1)(l0 l1),
```
implements `(r2 l1)(l0 l1)` using a `select-shuffle-select` pattern, and then applies `(r2 r1)` by reindexing the elements after extraction. As the elements are immediately repacked, InstCombine produces `shufflevector` instructions from the extract-insert pattern, resulting in one `prmt` per packed register. 

### Fix
It is possible to fuse the effects of these intra-register index bit permutations to the first and/or third stages of the `select-shuffle-select` pattern of the conversion algorithm. In most cases, this happens when in the cycle decomposition of the layout conversion, the intra-register index bit is adjacent to a lane index bit within a cycle, as in the above example. 

### Future work
To the best of my knowledge, this PR handles all cases where the above fusion is possible. However, there are cases where it is not possible which have potential for further optimization due to InstCombine’s lack of coverage:

Suppose we have four input `v4i8`s whose elements are rearranged via extraction and insertion into four output `v4i8`s in a manner such that each output vector contains one element from each of the four input vectors. In this case, LLVM generates 4 chains of 3 `prmt`s to build the output vectors, but it is possible to carry this out using two stages of 4 independent `prmt`s, thus reducing depth and instruction count. 

This pattern can also exist in layout conversions that take the `transferWithinWarp` path, but as it is truly an intra-thread pattern, this optimization should be implemented in `transferWithinThread` and invoked within `transferWithinWarp` in a future PR. 