### PR TITLE
Disable add_fold_true_cmpi pass

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -250,7 +250,6 @@ class HIPBackend(BaseBackend):
             passes.common.add_canonicalizer(pm)
             amd.passes.ttgpuir.add_convert_to_buffer_ops(pm, options.arch, knobs.amd.use_buffer_atomics)
 
-        amd.passes.ttgpuir.add_fold_true_cmpi(pm)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)


### PR DESCRIPTION
As discussed on slack we have seen multiple issues from IMA resulting from this pass. The IMAs can result from either pruning masks or pruning branches, which leads to unsafe control flow.

Leaving the source pass in the codebase to allow attempts to make it safer and re-enable it.