### PR TITLE
Fix issue #7821: TritonAMDAnalysis depends on TritonAMDGPU/IR/Dialect.h.inc which is not captured in cmake

### DIFF
--- a/third_party/amd/lib/Analysis/CMakeLists.txt
+++ b/third_party/amd/lib/Analysis/CMakeLists.txt
@@ -5,6 +5,7 @@ add_triton_library(TritonAMDAnalysis
 
   DEPENDS
   TritonTableGen
+  TritonAMDGPUTableGen
 
   LINK_LIBS PUBLIC
   MLIRAnalysis


### PR DESCRIPTION
The library TritonAMDAnalysis includes Dialect.h which in turn includes Dialect.h.inc. This means that for the library to build successfully, the tablegen target that produces Dialect.h.inc must run first. That target is TritonAMDGPUTableGen. However, TritonAMDAnalysis has no dependency on TritonAMDGPUTableGen resulting in spurious build breaks. This change adds the missing dependency.

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because it's a build issue - the test is the build

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
