### PR TITLE
[Hopper][WS] Fix UB in channel sorting

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -359,25 +359,16 @@ void groupChannels(
 
   // Reorder channels associated with one entry based on program order of the
   // producers.
-  for (auto &kv : consumerChannels) {
-    if (kv.second.size() > 1) {
-      auto &allOps = kv.second.front()->getSrcOp()->getBlock()->getOperations();
-      std::sort(
-          kv.second.begin(), kv.second.end(), [&](Channel *a, Channel *b) {
-            auto itrA =
-                std::find_if(allOps.begin(), allOps.end(), [&](Operation &op) {
-                  Operation *opPointer = &op;
-                  return opPointer == a->getSrcOp();
-                });
-            auto itrB =
-                std::find_if(allOps.begin(), allOps.end(), [&](Operation &op) {
-                  Operation *opPointer = &op;
-                  return opPointer == b->getSrcOp();
-                });
-            assert(itrA != allOps.end() && itrB != allOps.end());
-            return std::distance(itrA, itrB) < 0;
-          });
+  for (auto &group : make_second_range(consumerChannels)) {
+    auto &allOps = group.front()->getSrcOp()->getBlock()->getOperations();
+    DenseMap<Operation *, size_t> opIdx;
+    opIdx.reserve(allOps.size());
+    for (auto [idx, op] : enumerate(allOps)) {
+      opIdx[&op] = idx;
     }
+    sort(group, [&](Channel *a, Channel *b) {
+      return opIdx[a->getSrcOp()] < opIdx[b->getSrcOp()];
+    });
   }
 
   // Switch to using channel as the key instead of ops as ops can be volatile.
@@ -587,6 +578,18 @@ void createToken(
   DenseMap<ttng::TCGen5MMAOp, Channel *> gen5Barriers;
   for (auto *key : orderedChannels) {
     auto it = channelsGroupedByConsumers.find(key);
+    LLVM_DEBUG({
+      LDBG("createToken key:");
+      LDBG("consumer: ");
+      key->getDstOp()->dump();
+
+      LDBG("createToken channelsGroupedByConsumers:");
+      for (auto map_key : make_first_range(channelsGroupedByConsumers)) {
+        LDBG("representative consumer: ");
+        map_key->getDstOp()->dump();
+      }
+    });
+    assert(it != channelsGroupedByConsumers.end());
     Channel *channel = it->second.front();
 
     CommChannel commChannel;


### PR DESCRIPTION
In ~50% of test runs I was getting failures in `test/Hopper/WarpSpecialization/ws_code_partition.mlir`'s `_matmul_layernorm_persistent_one_producer_one_consumer_one_epilog` test, with the following error:

> assertion failed at third_party/llvm/llvm-project/llvm/include/llvm/ADT/DenseMap.h:1290 in pointer llvm::DenseMapIterator<mlir::Channel *, llvm::SmallVector<mlir::Channel *>, llvm::DenseMapInfo<mlir::Channel *>, llvm::detail::DenseMapPair<mlir::Channel *, llvm::SmallVector<mlir::Channel *>>, true>::operator->() const [KeyT = mlir::Channel *, ValueT = llvm::SmallVector<mlir::Channel *>, KeyInfoT = llvm::DenseMapInfo<mlir::Channel *>, Bucket = llvm::detail::DenseMapPair<mlir::Channel *, llvm::SmallVector<mlir::Channel *>>, IsConst = true]: Ptr != End && "dereferencing end() iterator"

Turns out the channel order in the groups was indeterministic between runs, which caused inconsistent / unexpected group keys. I tracked this down to an UB issue in sorting the channels, where the `llvm::ilist_iterator` return by `allOps.begin() / end()` was only a bidirectional iterator, and not a random access iterator.

Using `std::distance(a, b)` on non-random-access iterators [is UB if `a` comes after `b`](https://en.cppreference.com/w/cpp/iterator/distance.html). The shortest fix for this would have been to change the return condition to `std::distance(allOps.begin(), itrA) < std::distance(allOpsBegin(),itrB)`, but I found the entire implementation of that sort quite difficult to reason about due to nested lambdas and algorithms.

Instead, I rewrote the sort so it's quite a bit shorter and with less nesting, and should also have lower complexity (`O(n log n + block_size)` vs `(O(n log n * block_size)` previously).
