### PR TITLE
[AMD][BACKEND] Lower direct-to-lds loads via `lowerLdSt` instead of `emitTransferBetweenRegistersAndShared`

### DIFF
--- a/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
+++ b/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
@@ -147,8 +147,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // The first constant 0 skips the LDS offset which is also 0
     // COMMON: llvm.getelementptr
     // COMMON: llvm.mlir.constant(0 : i32) : i32
-    // COMMON: llvm.mlir.constant(0 : i32) : i32
     // COMMON: %[[aux_ca:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // COMMON: llvm.mlir.constant(0 : i32) : i32
     // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_ca]]
     %1 = amdgpu.buffer_load_to_local %arg0[%0] cacheModifier = ca into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     // COMMON: llvm.getelementptr

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -499,11 +499,11 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
         warpId, rewriter, targetInfo, vec, lowerInst);
   }
 
-  void emitOtherStores(RewriterBase &rewriter, Location loc,
-                       const LLVMTypeConverter *typeConverter, VectorType vecTy,
-                       Value mask, ArrayRef<Value> otherElems, Value shmemAddr,
-                       Value laneId, bool hasSwizzling,
-                       Value swizzleLaneOffset) const {
+  void emitOtherStore(RewriterBase &rewriter, Location loc,
+                      const LLVMTypeConverter *typeConverter, VectorType vecTy,
+                      Value mask, ArrayRef<Value> otherElems, Value shmemAddr,
+                      Value laneId, bool hasSwizzling,
+                      Value swizzleLaneOffset) const {
     TritonLLVMOpBuilder b(loc, rewriter);
     Value storeVal = packElementRangeIntoVector(rewriter, typeConverter, loc,
                                                 vecTy, otherElems, 0);
@@ -820,9 +820,9 @@ struct BufferLoadToLocalOpConversion
       AMD::addAsyncCopyAliasScope(bufferLoadToLds);
 
       if (hasOther) {
-        emitOtherStores(rewriter, loc, this->getTypeConverter(), vecTy,
-                        maskElem, otherElems, shmemAddr, laneId, hasSwizzling,
-                        swizzleLaneOffset);
+        emitOtherStore(rewriter, loc, this->getTypeConverter(), vecTy, maskElem,
+                       otherElems, shmemAddr, laneId, hasSwizzling,
+                       swizzleLaneOffset);
       }
 
       rewriter.setInsertionPointToStart(afterLoadBlock);
@@ -954,9 +954,9 @@ struct AsyncCopyGlobalToLocalOpConversion
       rewriter.setInsertionPointToStart(afterLoadBlock);
 
       if (hasOther) {
-        emitOtherStores(rewriter, loc, this->getTypeConverter(), vecTy,
-                        maskElem, otherElems, shmemAddr, laneId, hasSwizzling,
-                        swizzleLaneOffset);
+        emitOtherStore(rewriter, loc, this->getTypeConverter(), vecTy, maskElem,
+                       otherElems, shmemAddr, laneId, hasSwizzling,
+                       swizzleLaneOffset);
       }
 
       return {};

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -805,10 +805,11 @@ struct BufferLoadToLocalOpConversion
       return {};
     };
 
+    auto [_, warpId] = getLaneAndWarpId(rewriter, loc);
     lowerLdSt(
         loc, ctx, cvt, vals, resElemTy, smemObj.getBase(),
-        [](Value v) { return v; }, affineOffset, maskSpanAffineOffset, rewriter,
-        targetInfo, vec, emitBufferLoadLds, true);
+        [](Value v) { return v; }, affineOffset, maskSpanAffineOffset, laneId,
+        warpId, rewriter, targetInfo, vec, emitBufferLoadLds);
 
     // Drop the result token.
     Value zero = rewriter.create<LLVM::ConstantOp>(
@@ -987,10 +988,11 @@ struct AsyncCopyGlobalToLocalOpConversion
       return {};
     };
 
+    auto [_, warpId] = getLaneAndWarpId(rewriter, loc);
     lowerLdSt(
         loc, ctx, cvt, vals, resElemTy, smemObj.getBase(),
-        [](Value v) { return v; }, affineOffset, maskSpanAffineOffset, rewriter,
-        targetInfo, maxVec, emitGlobalLoadLds, true);
+        [](Value v) { return v; }, affineOffset, maskSpanAffineOffset, laneId,
+        warpId, rewriter, targetInfo, maxVec, emitGlobalLoadLds);
 
     // Drop the result token.
     Value zero = rewriter.create<LLVM::ConstantOp>(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -492,11 +492,12 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
         LLVM::getSharedMemoryObjectFromStruct(loc, llDst, resElemTy, rewriter);
     auto affineOffset = smemObj.getShmemOffset(loc, rewriter, dstTy);
     auto maskSpanAffineOffset = SharedMemoryObject::getMaskSpanOffsets(dstTy);
-    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+    auto [_, warpId] = getLaneAndWarpId(rewriter, loc);
+    // We pass laneId==0 because GFX9 requires a scalar base pointer into LDS
     lowerLdSt(
         loc, ctx, cvt, loadVals, resElemTy, smemObj.getBase(),
-        [](Value v) { return v; }, affineOffset, maskSpanAffineOffset, laneId,
-        warpId, rewriter, targetInfo, vec, lowerInst);
+        [](Value v) { return v; }, affineOffset, maskSpanAffineOffset,
+        b.i32_val(0), warpId, rewriter, targetInfo, vec, lowerInst);
   }
 
   void emitOtherStore(RewriterBase &rewriter, Location loc,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -476,7 +476,7 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
     TritonLLVMOpBuilder b(loc, rewriter);
     auto *ctx = rewriter.getContext();
 
-    // Remove broadcasted registers
+    // Build src to shared layout and remove broadcasted registers
     auto srcLayout = triton::gpu::toLinearLayout(srcTy);
     auto removeBroadcastSrc = actionRemoveBroadcastedRegs(srcLayout);
     srcLayout = removeBroadcastSrc.apply(srcLayout);


### PR DESCRIPTION
Refactors the lowering of `ttg.async_copy_global_to_local` and `amdgpu.buffer_load_to_local` to use the common lowering path via `lowerLdSt`, similar to https://github.com/triton-lang/triton/pull/7314.
