### PR TITLE
[BC breaking][FRONTEND] Add hooks around kernel loads

### DIFF
--- a/python/test/unit/runtime/test_launch.py
+++ b/python/test/unit/runtime/test_launch.py
@@ -71,6 +71,39 @@ def test_memory_leak(device) -> None:
         tracemalloc.stop()
 
 
+def test_load_hook() -> None:
+
+    used_start_hook = False
+    start_hash = None
+
+    def hook_start(module, function, name, metadata_group, hash):
+        nonlocal used_start_hook
+        nonlocal start_hash
+        start_hash = hash
+        used_start_hook = True
+
+    used_end_hook = False
+    end_hash = None
+
+    def hook_end(module, function, name, metadata_group, hash):
+        nonlocal used_end_hook
+        nonlocal end_hash
+        end_hash = hash
+        used_end_hook = True
+
+    @triton.jit
+    def kernel(x):
+        pass
+
+    # launch kernel
+    triton.knobs.runtime.kernel_load_start_hook = hook_start
+    triton.knobs.runtime.kernel_load_end_hook = hook_end
+    kernel[(1, 3, 2)](6)
+    assert used_start_hook
+    assert used_end_hook
+    assert start_hash == end_hash
+
+
 # LATENCY_THRESHOLD_US = 46
 
 # def test_kernel_launch_latency() -> None:

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -377,7 +377,8 @@ class LaunchHook(Protocol):
 
 class InitHandleHook(Protocol):
 
-    def __call__(self, function: Optional[Callable], module: Optional[object], metadata_group: dict[str, str]) -> None:
+    def __call__(self, function: Optional[Callable], module: Optional[object], metadata_group: dict[str, str],
+                 hash: str) -> None:
         ...
 
 
@@ -416,7 +417,8 @@ class runtime_knobs(base_knobs):
 
     launch_enter_hook: Optional[LaunchHook] = None
     launch_exit_hook: Optional[LaunchHook] = None
-    init_handle_hook: Optional[InitHandleHook] = None
+    kernel_load_start_hook: Optional[InitHandleHook] = None
+    kernel_load_end_hook: Optional[InitHandleHook] = None
 
     # Hook for inspecting compiled functions and modules
     jit_cache_hook: Optional[JITHook] = None

--- a/third_party/proton/proton/hooks/hook.py
+++ b/third_party/proton/proton/hooks/hook.py
@@ -36,9 +36,9 @@ class HookManager:
     session_hooks: Dict[int, Dict[Hook, bool]] = defaultdict(lambda: defaultdict(bool))
 
     @staticmethod
-    def init_handle(module: Any, function: Any, name: str, metadata_group: Dict[str, str]) -> None:
+    def init_handle(module: Any, function: Any, name: str, metadata_group: Dict[str, str], hash: str) -> None:
         for hook in HookManager.active_hooks:
-            hook.init_handle(module, function, name, metadata_group)
+            hook.init_handle(module, function, name, metadata_group, hash)
 
     @staticmethod
     def enter(lazy_dict: LazyDict) -> None:
@@ -99,7 +99,7 @@ class HookManager:
         if knobs.runtime.launch_enter_hook is None:
             knobs.runtime.launch_enter_hook = HookManager.enter
             knobs.runtime.launch_exit_hook = HookManager.exit
-            knobs.runtime.init_handle_hook = HookManager.init_handle
+            knobs.runtime.kernel_load_end_hook = HookManager.init_handle
 
     @staticmethod
     def unregister(session: Optional[int] = None) -> None:
@@ -124,4 +124,4 @@ class HookManager:
         if not HookManager.active_hooks:
             knobs.runtime.launch_enter_hook = None
             knobs.runtime.launch_exit_hook = None
-            knobs.runtime.init_handle_hook = None
+            knobs.runtime.kernel_load_end_hook = None

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -232,7 +232,7 @@ class InstrumentationHook(Hook):
         # Reset the buffer reference
         self.buffer = None
 
-    def init_handle(self, module: Any, function: Any, name: str, metadata_group: Dict[str, str]) -> None:
+    def init_handle(self, module: Any, function: Any, name: str, metadata_group: Dict[str, str], hash: str) -> None:
         if not function:
             return
 

--- a/third_party/proton/proton/hooks/launch.py
+++ b/third_party/proton/proton/hooks/launch.py
@@ -23,7 +23,7 @@ class LaunchHook(Hook):
             cls._instance = super(LaunchHook, cls).__new__(cls)
         return cls._instance
 
-    def init_handle(self, module, function, name: str, metadata_group: dict) -> None:
+    def init_handle(self, module, function, name: str, metadata_group: dict, hash: str) -> None:
         pass
 
     def activate(self):


### PR DESCRIPTION
This allows tracking potential timeout in the driver when loading a kernel

Breaks backward compatibility as it changes the hook name and signature
