### PR TITLE
Don't run link test on amd

### DIFF
--- a/python/test/unit/test_link.py
+++ b/python/test/unit/test_link.py
@@ -25,6 +25,10 @@ def add_one_indirect(x_ptr, SQRT: tl.constexpr) -> None:
 @pytest.mark.parametrize("use_libdevice", (False, True))
 @pytest.mark.parametrize("kernel", (add_one, add_one_indirect))
 def test_link_extern_libs(use_libdevice, kernel):
+    if not (torch.cuda.is_available() and torch.version.cuda):
+        pytest.skip("Test only applies to the Nvidia backend.")
+        return
+
     link_called: bool = False
 
     def callback(frame, event, arg):


### PR DESCRIPTION
I'm not sure how https://github.com/triton-lang/triton/pull/7570 passed CI, since
A) The AMD backend prunes paths but does not elide the call to `link_extern_libs`. (Which is what the unit test checks.)
B) It doesn't appear to prune `ocml.bc` or `ockl.bc`

So back to the original plan of skipping on AMD. (But with `torch.version.cuda` to actually differentiate properly.) CC @antiagainst @peterbell10 (Apologies for introducing broken unit tests.)
