### PR TITLE
[AMD] Enable more tests under python/test/unit

### DIFF
--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -123,7 +123,10 @@ jobs:
           pytest --capture=tee-sys -rfs third_party/amd/python/test/test_extract_slice_concat_op.py
           TRITON_ALWAYS_COMPILE=1 pytest --capture=tee-sys -rfs third_party/amd/python/test/test_scalarize_packed_fops.py
           cd python/test/unit
-          pytest --capture=tee-sys -rfs -n 12 language runtime tools \
+          pytest --capture=tee-sys -rfs -n 12 \
+                 --ignore=blackwell \
+                 --ignore=cuda \
+                 --ignore=instrumentation \
                  --ignore=language/test_line_info.py \
                  --ignore=test_debug.py
           # TODO: uncomment


### PR DESCRIPTION
This turns all unit tests under `python/test/unit`
with explicit ignores for those not suitable.
This way we automatically pick up tests.
