### PR TITLE
[Impr] add fp8 x mxfp4 group matmul with internally fp8 dot support in hopper platform

### DIFF
--- a/python/triton_kernels/triton_kernels/target_info.py
+++ b/python/triton_kernels/triton_kernels/target_info.py
@@ -1,3 +1,4 @@
+import builtins
 import torch
 import triton
 import triton.language as tl
@@ -68,3 +69,15 @@ def has_native_mxfp():
 
 def num_sms():
     return torch.cuda.get_device_properties(0).multi_processor_count
+
+HIP_FP8_E4M3_FNUZ_MAX = 224.0
+
+if is_hip():
+    FP8_E4M3_MAX = HIP_FP8_E4M3_FNUZ_MAX
+else:
+    FP8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max # 448
+
+FP8_E4M3_MIN = -FP8_E4M3_MAX
+
+builtins.FP8_E4M3_MAX = FP8_E4M3_MAX
+builtins.FP8_E4M3_MIN = FP8_E4M3_MIN

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -272,6 +272,13 @@ def _unpack_fp4_to_bf16_triton(x):
 
 
 @triton.jit
+def mxfp4_to_fp8_e4m3_fn_trition(x, scale, mx_axis: tl.constexpr, fp8_dtype: tl.constexpr):
+    bf16 = mxfp4_to_bf16_triton(x, scale, mx_axis)
+    fp8 = bf16.to(fp8_dtype)
+    return fp8
+
+
+@triton.jit
 def mxfp4_to_bf16_triton(x, scale, mx_axis: tl.constexpr):
     """
     Implements the bit-untwiddling of a 32-bit integer (8 mxfp4 elements):


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

# Description

Original `MoE` group matmul trition kernel for `mxfp4` weights internally converts weight data to `bf16`, however, `fp8 matmul` in hopper platform promised be faster than `bf16 matmul`. 

During the benchmarching, we found the `bf16 x mfp4` lags far behind `fp8 x fp8`, partially attributed to the fact that the `mxfp4` layout conversion is too complex (mapping and grouping elements based on runtime threads-layout logics in python side, making it even more complex than writing pure cuda codes).

Hence I add an `use_fp8_matmul` option so that people can enable `fp8 matmul` (instead of `bf16 matmul`) insider kernel code gen to see how performance dramatically degraded when fp8 internally enabled.

Since Deepseekv3, we have generally verified that block-wise fp8 is accurate,  32-groups scaling should be even more accurate (perhaps better with e4m3 scalar type). We will later implement `fp8 centric matmul` to for `mxfp4` inputs.

# Benchmark test

## dense test (ep == 1) for **fp8 x mxfp4** MoE group matmul

<img width="800" height="201" alt="截屏2025-08-14 12 27 50" src="https://github.com/user-attachments/assets/367f8348-41c1-4ede-805b-b6e3907b0d00" />

## dense test (ep == 1) for **bf16 x mxfp4** MoE group matmul

<img width="800" height="222" alt="截屏2025-08-14 12 26 31" src="https://github.com/user-attachments/assets/31c18904-a4f6-4936-90e6-29ec6cb1b388" />

## general TP1-EP1 fp8 x fp8 roofline

<img width="400" height="600" alt="roofline" src="https://github.com/user-attachments/assets/c15694ac-5ce5-46df-b443-06b034577d13" />







