### PR TITLE
[INTERPRETER] Support dtype and constexpr comparison

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7633,6 +7633,7 @@ def test_side_effectful_reduction_2d(device, reduce_dim):
     torch.testing.assert_close(Z, X.sum(reduce_dim).to(torch.int32))
 
 
+@pytest.mark.interpreter
 def test_dtype(device):
 
     @triton.jit

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7532,7 +7532,7 @@ def test_dtype(device):
         tl.static_assert(dtype_x == tl.int8 or (dtype_x == tl.int16 or dtype_x == tl.int32))
 
     X = torch.empty(1, dtype=torch.int32, device=device)
-    kernel[(1,)](X)
+    kernel[(1, )](X)
 
 
 def test_side_effectful_scan(device):

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -7532,7 +7532,7 @@ def test_dtype(device):
         tl.static_assert(dtype_x == tl.int8 or (dtype_x == tl.int16 or dtype_x == tl.int32))
 
     X = torch.empty(1, dtype=torch.int32, device=device)
-    kernel.warmup(X, grid=(1, ))
+    kernel[(1,)](X)
 
 
 def test_side_effectful_scan(device):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -547,9 +547,9 @@ class dtype(base_type):
         return False
 
     def __eq__(self, other) -> bool:
-        if not isinstance(other, (dtype, constexpr)):
-            return False
         other = _unwrap_if_constexpr(other)
+        if not isinstance(other, dtype):
+            return False
         return self.name == other.name
 
     def __hash__(self):
@@ -672,9 +672,9 @@ class pointer_type(dtype):
         return self.const
 
     def __eq__(self, other) -> bool:
-        if not isinstance(other, (pointer_type, constexpr)):
-            return False
         other = _unwrap_if_constexpr(other)
+        if not isinstance(other, pointer_type):
+            return False
         return self.element_ty == other.element_ty and self.address_space == other.address_space and self.const == other.const
 
     @property

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -153,10 +153,10 @@ class base_value:
 
 class base_type:
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         raise NotImplementedError("Types must implement __eq__")
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         return not (self == other)
 
     def _unflatten_ir(self, handles: List[ir.value], cursor: int) -> Tuple[base_value, int]:
@@ -546,9 +546,10 @@ class dtype(base_type):
     def is_const():
         return False
 
-    def __eq__(self, other: dtype):
-        if not isinstance(other, dtype):
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, (dtype, constexpr)):
             return False
+        other = _unwrap_if_constexpr(other)
         return self.name == other.name
 
     def __hash__(self):
@@ -670,9 +671,10 @@ class pointer_type(dtype):
     def is_const(self):
         return self.const
 
-    def __eq__(self, other: pointer_type) -> bool:
-        if not isinstance(other, pointer_type):
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, (pointer_type, constexpr[pointer_type])):
             return False
+        other = _unwrap_if_constexpr(other)
         return self.element_ty == other.element_ty and self.address_space == other.address_space and self.const == other.const
 
     @property

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -672,7 +672,7 @@ class pointer_type(dtype):
         return self.const
 
     def __eq__(self, other) -> bool:
-        if not isinstance(other, (pointer_type, constexpr[pointer_type])):
+        if not isinstance(other, (pointer_type, constexpr)):
             return False
         other = _unwrap_if_constexpr(other)
         return self.element_ty == other.element_ty and self.address_space == other.address_space and self.const == other.const


### PR DESCRIPTION
Also removed `other`'s annotation because it violates [Liskov substitution principle](https://stackoverflow.com/questions/56860/what-is-an-example-of-the-liskov-substitution-principle): `It’s unsafe to override a method with a more specific argument type`