### PR TITLE
[BACKEND] Always lower tcgen05.ld/st via generic LinearLayout code

### DIFF
--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1269,10 +1269,6 @@ tensorMemoryScalesToLinearLayout(ArrayRef<int64_t> shape,
   // We choose repOrder = [0, 1]
   auto tile =
       LinearLayout::identity1D(std::min<int>(32, shape[0]), kRow, dims[0]) *
-      LinearLayout::zeros1D(std::max<int>(1, 32 / shape[0]), kRow, dims[0]) *
-      // When shape[1] < 4, we emit an 'unpacked' layout (0 or 1 bases)
-      // When we emit 1 base, we will divide it out in the lowering after
-      // packing
       LinearLayout::identity1D(std::min<int>(4, shape[1]), kCol, dims[1]) *
       // reps
       LinearLayout::identity1D(std::max<int>(1, shape[0] / 32), kCol, dims[0]) *

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -96,9 +96,13 @@ ensureLayoutNotLargerThan(const LinearLayout &layout,
     }
     bases[kRegister] = std::move(newBasesRegister);
   }
+  auto outDims = layout.getOutDims();
+  for (auto &[outDim, outDimSize] : outDims) {
+    outDimSize = std::min<int32_t>(outDimSize, shape.lookup(outDim));
+  }
 
-  return LinearLayout(std::move(bases),
-                      llvm::to_vector(layout.getOutDimNames()));
+  return LinearLayout(std::move(bases), std::move(outDims),
+                      /*requireSurjective=*/false);
 }
 
 // For each out-dim d, ensure the layout's out-size (i.e. its codomain) is no

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -27,37 +27,22 @@ static constexpr int maxRegisters = 256;
 namespace {
 
 struct TMemAccessAtom {
-  int opBitWidth;
   int colsPerThread;
   int rowsPerThread;
-  int rowStored;
   const char *opShape;
-  bool usesSecondHalfOffset;
 };
 
-constexpr TMemAccessAtom TMemAccess32x32b{.opBitWidth = 32,
-                                          .colsPerThread = 1,
-                                          .rowsPerThread = 1,
-                                          .rowStored = 32,
-                                          .opShape = "32x32b",
-                                          .usesSecondHalfOffset = false};
+constexpr TMemAccessAtom TMemAccess32x32b{
+    .colsPerThread = 1, .rowsPerThread = 1, .opShape = "32x32b"};
 
-constexpr TMemAccessAtom TMemAccess16x256b{.opBitWidth = 256,
-                                           .colsPerThread = 2,
-                                           .rowsPerThread = 2,
-                                           .rowStored = 16,
-                                           .opShape = "16x256b",
-                                           .usesSecondHalfOffset = false};
+constexpr TMemAccessAtom TMemAccess16x256b{
+    .colsPerThread = 2, .rowsPerThread = 2, .opShape = "16x256b"};
 
-constexpr TMemAccessAtom TMemAccess16x32bx2{.opBitWidth = 32,
-                                            .colsPerThread = 1,
-                                            .rowsPerThread = 1,
-                                            .rowStored = 32,
-                                            .opShape = "16x32bx2",
-                                            .usesSecondHalfOffset = true};
+constexpr TMemAccessAtom TMemAccess16x32bx2{
+    .colsPerThread = 1, .rowsPerThread = 1, .opShape = "16x32bx2"};
 
-static std::optional<LinearLayout> getReps(const LinearLayout &cvt,
-                                           const LinearLayout &tile) {
+std::optional<LinearLayout> getReps(const LinearLayout &cvt,
+                                    const LinearLayout &tile) {
   // Close cousin of doing zerosLike(tile) * divideLeft(cvt, tile)
   // This one is a tad more general in the sense that it allows to divide
   //  cvt:
@@ -172,7 +157,7 @@ static std::optional<LinearLayout> getReps(const LinearLayout &cvt,
 }
 
 // Similar to largestVectorisation in TritonGPUToLLVM/Utility.cpp
-static std::optional<std::tuple<LinearLayout, ColumnAction, int>>
+std::optional<std::tuple<LinearLayout, ColumnAction, int>>
 getVec(const LinearLayout &cvt, const LinearLayout &tile, int maxnreg,
        int bitwidth) {
   auto *ctx = cvt.getInDimNames().begin()->getContext();
@@ -223,8 +208,8 @@ getVec(const LinearLayout &cvt, const LinearLayout &tile, int maxnreg,
                          (i / 2) * tile.getInDimSize(kReg));
 }
 
-static LinearLayout getTileLayout(MLIRContext *ctx, TMemAccessAtom atom,
-                                  int bitwidth, bool unpacked) {
+LinearLayout getTileLayout(MLIRContext *ctx, TMemAccessAtom atom, int bitwidth,
+                           bool unpacked, int nRow) {
   auto kReg = str_attr("register");
   auto kLane = str_attr("lane");
   auto kWarp = str_attr("warp");
@@ -245,11 +230,13 @@ static LinearLayout getTileLayout(MLIRContext *ctx, TMemAccessAtom atom,
   } else {
     llvm_unreachable("Unsupported TMEM access atom");
   }
+  auto nCol = tile.getOutDimSize(kCol);
   auto bases = tile.getBases();
   bases[kWarp].push_back({32, 0});
   bases[kWarp].push_back({64, 0});
-  auto ret = LinearLayout(
-      bases, {{kRow, 128}, {kCol, tile.getOutDimSize(kCol)}}, false);
+  auto ret = LinearLayout(bases, {{kRow, 128}, {kCol, nCol}}, false);
+  // Broadcast the row dimension if it's smaller than 128
+  ret = ensureLayoutNotLargerThan(ret, {{kRow, nRow}, {kCol, nCol}}, true);
   // For unpacked, the tile above is for 32-bit elements, so we have to multiply
   // by identity1D(32 / bitwidth, kReg, kCol) to get the correct tile to allow
   // us to divide the cvt layout by it
@@ -259,358 +246,59 @@ static LinearLayout getTileLayout(MLIRContext *ctx, TMemAccessAtom atom,
   return ret;
 }
 
-struct TMemMessageTraits {
-  TMemAccessAtom atom;
-  bool usesSecondHalfOffset;
-  int numThreadsPerWarp;
-  int maxNumRepeats;
-  int maxCols;
-  int numRows;
-  int numCols;
-  int numRepeats;
-  int numRegs;
-
-  bool operator<(const TMemMessageTraits &other) const {
-    return numRegs < other.numRegs;
-  }
-
-  LLVM_DUMP_METHOD void dump() const {
-    llvm::dbgs() << "TMemMessageTraits:\n";
-    llvm::dbgs() << "  atom.opBitWidth: " << atom.opBitWidth << "\n";
-    llvm::dbgs() << "  atom.colsPerThread: " << atom.colsPerThread << "\n";
-    llvm::dbgs() << "  atom.rowsPerThread: " << atom.rowsPerThread << "\n";
-    llvm::dbgs() << "  atom.opShape: " << atom.opShape << "\n";
-    llvm::dbgs() << "  atom.usesSecondHalfOffset: " << atom.usesSecondHalfOffset
-                 << "\n";
-    llvm::dbgs() << "  usesSecondHalfOffset: " << usesSecondHalfOffset << "\n";
-    llvm::dbgs() << "  numThreadsPerWarp: " << numThreadsPerWarp << "\n";
-    llvm::dbgs() << "  maxNumRepeats: " << maxNumRepeats << "\n";
-    llvm::dbgs() << "  maxCols: " << maxCols << "\n";
-    llvm::dbgs() << "  numRows: " << numRows << "\n";
-    llvm::dbgs() << "  numCols: " << numCols << "\n";
-    llvm::dbgs() << "  numRepeats: " << numRepeats << "\n";
-    llvm::dbgs() << "  numRegs: " << numRegs << "\n";
-  }
-};
-
-struct TMemRuntimeInfo {
-  static constexpr int numRowsPerWarp = 32;
-  int numWarps;
-  int numWarpGroups;
-  int numElementsPer32B;
-  int numElements;
-  int numCols;
-  int blockM;
-  int blockN;
-  bool unpackedb16;
-  bool useStridedMessage;
-  int numBlocks;
-  bool blocksInterleaved;
-  int numColsPerBlock;
-  int colsPerWarpGroup;
-  bool splitWarpgroupsAlongM;
-  TMemAccessAtom layoutAtom;
-
-  LLVM_DUMP_METHOD void dump() const {
-    llvm::dbgs() << "TMemRuntimeInfo:\n";
-    llvm::dbgs() << "  numWarps: " << numWarps << "\n";
-    llvm::dbgs() << "  numWarpGroups: " << numWarpGroups << "\n";
-    llvm::dbgs() << "  numElementsPer32B: " << numElementsPer32B << "\n";
-    llvm::dbgs() << "  numElements: " << numElements << "\n";
-    llvm::dbgs() << "  numCols: " << numCols << "\n";
-    llvm::dbgs() << "  blockM: " << blockM << "\n";
-    llvm::dbgs() << "  blockN: " << blockN << "\n";
-    llvm::dbgs() << "  unpackedb16: " << unpackedb16 << "\n";
-    llvm::dbgs() << "  useStridedMessage: " << useStridedMessage << "\n";
-    llvm::dbgs() << "  numBlocks: " << numBlocks << "\n";
-    llvm::dbgs() << "  blocksInterleaved: " << blocksInterleaved << "\n";
-    llvm::dbgs() << "  numColsPerBlock: " << numColsPerBlock << "\n";
-    llvm::dbgs() << "  colsPerWarpGroup: " << colsPerWarpGroup << "\n";
-    llvm::dbgs() << "  splitWarpgroupsAlongM: " << splitWarpgroupsAlongM
-                 << "\n";
-    llvm::dbgs() << "  message shape: " << layoutAtom.opShape << "\n";
-  }
-};
-
-TMemMessageTraits getTMemMessageFromAtom(const TMemAccessAtom &atom,
-                                         int narrowingFactor) {
-  TMemMessageTraits m;
-  m.atom = atom;
-  m.usesSecondHalfOffset = atom.usesSecondHalfOffset;
-  m.numThreadsPerWarp = 32;
-  m.maxNumRepeats =
-      largestTmemLoadStore / (atom.colsPerThread * atom.rowsPerThread);
-  m.maxCols = (atom.opBitWidth / 32) * m.maxNumRepeats;
-  m.numRows = m.numThreadsPerWarp / atom.rowsPerThread;
-  m.numCols = m.maxCols / narrowingFactor;
-  m.numRepeats = m.numCols / (atom.opBitWidth / 32);
-  m.numRegs = atom.colsPerThread * atom.rowsPerThread * m.numRepeats;
-  return m;
-}
-
-// Narrow the TMEM message by reducing the number of registers per TMEM
-// instruction such that:
-// - No instruction uses more than half the available registers at a time.
-// - If the total number of registers required by the workload is more than half
-//   of the available registers, don't use the largest TMEM message.
-int getTMemMessageNarrowingFactor(const TMemAccessAtom &atom,
-                                  int workloadThreadRegs, int maxnreg) {
-  const int allowedRegUsage = maxnreg / 2;
-  int narrowingFactor = 1;
-  while (getTMemMessageFromAtom(atom, narrowingFactor).numRegs >
-             allowedRegUsage ||
-         workloadThreadRegs > allowedRegUsage) {
-    workloadThreadRegs /= 2;
-    narrowingFactor *= 2;
-  }
-  return narrowingFactor;
-}
-
-int getEffectiveRegs(bool unpackedb16, bool useStridedMessage, int numRegs) {
-  // The effective register count is less when using unpacked or strided
-  // messages
-  if (unpackedb16) {
-    numRegs /= 2;
-  }
-  if (useStridedMessage) {
-    numRegs /= 2;
-  }
-  return std::max(1, numRegs);
-}
-
-// If the workload runtime requires fewer registers than the default message
-// width, use the widest possible message that matches the workload
-TMemMessageTraits constrainMessageFromWorkload(TMemMessageTraits m,
-                                               const TMemRuntimeInfo &info,
-                                               int numRegs) {
-  m.numRegs =
-      getEffectiveRegs(info.unpackedb16, info.useStridedMessage, numRegs);
-  m.numRegs = std::min(largestTmemLoadStore, m.numRegs);
-  // Invert the above formulas to calculate the effective runtime message width
-  m.numCols = (m.numRegs * (m.atom.opBitWidth / 32)) /
-              (m.atom.colsPerThread * m.atom.rowsPerThread);
-  // Half as many registers are needed for 16-bit packed elements,
-  // so twice as many columns are accessed per message.
-  if (info.unpackedb16)
-    m.numCols *= info.numElementsPer32B;
-  m.numRepeats = m.numCols / (m.atom.opBitWidth / 32);
-  return m;
-}
-
-SmallVector<Value> packToI32(ArrayRef<Value> values, Location loc,
-                             ConversionPatternRewriter &rewriter) {
+SmallVector<Value> pack(ArrayRef<Value> values, Type outType, Location loc,
+                        ConversionPatternRewriter &rewriter) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   SmallVector<Value> packedValues;
-  Type elType = values[0].getType();
-  int numElementsPer32B = 32 / elType.getIntOrFloatBitWidth();
-  if (numElementsPer32B == 1)
-    return to_vector(values);
-  Value packed = b.undef(vec_ty(elType, numElementsPer32B));
-  for (int i = 0; i < values.size(); i++) {
-    Value val = values[i];
-    packed = b.insert_element(packed.getType(), packed, val,
-                              b.i32_val(i % numElementsPer32B));
-    if (i % numElementsPer32B == numElementsPer32B - 1 ||
-        i == values.size() - 1) {
-      packed = b.bitcast(packed, i32_ty);
-      packedValues.push_back(packed);
-      packed = b.undef(vec_ty(elType, numElementsPer32B));
+  Type inType = values[0].getType();
+  auto inbitwidth = inType.getIntOrFloatBitWidth();
+  auto outbitwidth = outType.getIntOrFloatBitWidth();
+  assert(inbitwidth <= outbitwidth);
+  if (inbitwidth == outbitwidth) {
+    for (auto &val : values) {
+      packedValues.push_back(b.bitcast(val, outType));
     }
+    return packedValues;
+  }
+
+  auto vecSize = outbitwidth / inbitwidth;
+  auto vecTy = vec_ty(inType, vecSize);
+  for (int i = 0; i < values.size(); i += vecSize) {
+    Value packed = b.undef(vecTy);
+    for (int j = 0; j < vecSize; j++) {
+      Value val = values[i + j];
+      packed = b.insert_element(vecTy, packed, val, b.i32_val(j));
+    }
+    packed = b.bitcast(packed, outType);
+    packedValues.emplace_back(std::move(packed));
   }
   return packedValues;
 }
 
-SmallVector<Value> unpackFromI32(ArrayRef<Value> packedValues, Type elemTy,
-                                 Location loc,
-                                 ConversionPatternRewriter &rewriter) {
+SmallVector<Value> unpack(ArrayRef<Value> packedValues, Type outType,
+                          Location loc, ConversionPatternRewriter &rewriter) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  int numElementsPer32B = 32 / elemTy.getIntOrFloatBitWidth();
-  if (numElementsPer32B == 1) {
-    SmallVector<Value> unpackedValues;
-    for (int i = 0; i < packedValues.size(); i++) {
-      unpackedValues.push_back(b.bitcast(packedValues[i], elemTy));
+  Type inType = packedValues[0].getType();
+  auto inbitwidth = inType.getIntOrFloatBitWidth();
+  auto outbitwidth = outType.getIntOrFloatBitWidth();
+  assert(inbitwidth >= outbitwidth);
+  SmallVector<Value> unpackedValues;
+  if (inbitwidth == outbitwidth) {
+    for (auto &val : packedValues) {
+      unpackedValues.push_back(b.bitcast(val, outType));
     }
     return unpackedValues;
   }
-  SmallVector<Value> unpackedValues;
-  Type packedTy = vec_ty(elemTy, numElementsPer32B);
+  auto vecSize = inbitwidth / outbitwidth;
+  auto vecTy = vec_ty(outType, vecSize);
   for (int i = 0; i < packedValues.size(); i++) {
-    Value packed = b.bitcast(packedValues[i], packedTy);
-    for (int j = 0; j < numElementsPer32B; j++) {
-      unpackedValues.push_back(b.extract_element(packed, b.i32_val(j)));
+    Value packed = b.bitcast(packedValues[i], vecTy);
+    for (int j = 0; j < vecSize; j++) {
+      unpackedValues.push_back(
+          b.extract_element(outType, packed, b.i32_val(j)));
     }
   }
   return unpackedValues;
-}
-
-static bool is16x256Layout(RankedTensorType tensorType, Attribute memEncoding,
-                           int numWarps) {
-  auto tmemLayout =
-      dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(memEncoding);
-  if (!tmemLayout)
-    return false;
-  int blockM = tmemLayout.getBlockM();
-  int blockN = tmemLayout.getBlockN();
-  std::optional<LinearLayout> ll0 =
-      getTmemLoadStoreLayout16x256(blockM, blockN, tensorType, numWarps);
-  auto ll1 = toLinearLayout(tensorType);
-  return ll0.has_value() && ll0.value() == ll1;
-}
-
-TMemRuntimeInfo getTMemRuntimeInfo(Operation *op, RankedTensorType tensorType,
-                                   MemDescType memType) {
-  TMemRuntimeInfo info;
-  static_assert(TMemRuntimeInfo::numRowsPerWarp == 32,
-                "A single warp must access exactly 32 rows of tmem");
-  assert(
-      nvidia_gpu::isDistributedLayoutTMemCompatible(op, tensorType, memType) &&
-      "unsupported distributed layout for tensor memory");
-
-  info.numWarps = triton::gpu::lookupNumWarps(op);
-  assert(info.numWarps % 4 == 0 && "Unexpected number of warps");
-  info.numWarpGroups = info.numWarps / 4;
-  info.numElementsPer32B = 32 / tensorType.getElementTypeBitWidth();
-  auto shapePerCTA = mlir::triton::gpu::getShapePerCTA(tensorType);
-  info.numElements = product(shapePerCTA);
-
-  triton::nvidia_gpu::TMemAllocation tmemAlloc =
-      triton::nvidia_gpu::getTmemAllocSizes(memType);
-  info.numCols = tmemAlloc.numCols;
-
-  info.blockM = 0;
-  info.blockN = 0;
-  info.unpackedb16 = false;
-  if (auto attr = dyn_cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(
-          memType.getEncoding())) {
-    info.blockM = attr.getBlockM();
-    info.blockN = attr.getBlockN();
-    assert((!attr.getUnpacked() || info.numElementsPer32B <= 2) &&
-           "unsupported unpacked layout");
-    info.unpackedb16 = attr.getUnpacked() && (info.numElementsPer32B == 2);
-  } else {
-    assert(isa<triton::nvidia_gpu::TensorMemoryScalesEncodingAttr>(
-               memType.getEncoding()) &&
-           "Expecting a tensor memory encoding attribute");
-    info.blockM = 128;
-    info.blockN = 32;
-  }
-
-  info.splitWarpgroupsAlongM =
-      nvidia_gpu::isDistributedLayoutSplitMTmemLoadStore(tensorType, memType,
-                                                         info.numWarps);
-  info.numBlocks = ceil<int>(info.numElements, info.blockM * info.blockN);
-  info.blocksInterleaved = (info.numBlocks > 1 && info.blockM == 64);
-  info.numColsPerBlock = info.numCols / info.numBlocks;
-  info.useStridedMessage = false;
-  if (info.blocksInterleaved) {
-    info.numColsPerBlock *= 2;
-  }
-  if (info.splitWarpgroupsAlongM) {
-    info.colsPerWarpGroup = info.numColsPerBlock;
-    info.useStridedMessage = true;
-    assert(info.blockM == 128);
-  } else {
-    int numWarpGroupsPerBlock = ceil<int>(info.numWarpGroups, info.numBlocks);
-    info.colsPerWarpGroup = info.numColsPerBlock / numWarpGroupsPerBlock;
-    // If more than one warp group processes the same block,
-    // then fewer columns must be processed per message per warp group
-    info.numColsPerBlock /= numWarpGroupsPerBlock;
-  }
-  if (is16x256Layout(tensorType, memType.getEncoding(), info.numWarps)) {
-    assert(info.useStridedMessage == false);
-    info.layoutAtom = TMemAccess16x256b;
-  } else {
-    info.useStridedMessage |= (info.blockM == 64);
-    if (info.useStridedMessage) {
-      info.layoutAtom = TMemAccess16x32bx2;
-    } else {
-      info.layoutAtom = TMemAccess32x32b;
-    }
-  }
-  return info;
-}
-
-void calculateAddressAndEmitTmemMessage(
-    Location loc, Value baseAddress, const TMemRuntimeInfo &info,
-    const TMemMessageTraits &message, ConversionPatternRewriter &rewriter,
-    const std::function<void(Value, int, std::optional<int>, bool, int, bool)>
-        &createMemoryOp) {
-
-  TritonLLVMOpBuilder b(loc, rewriter);
-  Value warpId = rewriter.create<nvgpu::WarpIdOp>(loc);
-  // Note: optimizing this when we know `info.numWarpGroups` is 1 can result in
-  // performance regressions.
-  Value warpIdInGroup = b.urem(warpId, b.i32_val(4));
-  Value warpGroupId = b.udiv(warpId, b.i32_val(4));
-
-  // When split along M, blockM=128 and num_warps=8, and a strided message is
-  // selected such that all 8 warps read a 16 rows of a block at a time.
-  int blocksPerWarpTile = info.splitWarpgroupsAlongM ? 1 : info.numWarpGroups;
-  for (int block = 0; block < info.numBlocks; block += blocksPerWarpTile) {
-    Value address = b.ptrtoint(i32_ty, baseAddress);
-    Value blockId = b.i32_val(block);
-    Value startColumnId = b.i32_val(0);
-    Value blockRowId =
-        b.mul(warpIdInGroup, b.i32_val(TMemRuntimeInfo::numRowsPerWarp));
-
-    if (info.splitWarpgroupsAlongM) {
-      // When split along M warp 0 loads the 16 top rows, warp 4 loads the 16
-      // bottom rows.
-      blockRowId = b.add(blockRowId, b.mul(warpGroupId, b.i32_val(16)));
-    } else {
-      int numWarpGroupsPerBlock = ceil<int>(info.numWarpGroups, info.numBlocks);
-      Value warpGroupIdInBlock =
-          b.urem(warpGroupId, b.i32_val(numWarpGroupsPerBlock));
-      blockId =
-          b.add(blockId, b.udiv(warpGroupId, b.i32_val(numWarpGroupsPerBlock)));
-      startColumnId =
-          b.mul(warpGroupIdInBlock, b.i32_val(info.colsPerWarpGroup));
-    }
-
-    if (info.blocksInterleaved) {
-      Value blockIdIsOdd = b.urem(blockId, b.i32_val(2));
-      Value blockIdPrevEven = b.sub(blockId, blockIdIsOdd);
-      blockRowId = b.add(blockRowId, b.mul(blockIdIsOdd, b.i32_val(16)));
-      startColumnId =
-          b.add(startColumnId,
-                b.mul(blockIdPrevEven, b.i32_val(info.numColsPerBlock / 2)));
-    } else {
-      startColumnId =
-          b.add(startColumnId, b.mul(blockId, b.i32_val(info.numColsPerBlock)));
-    }
-
-    // A strided message accesses twice as many columns per message,
-    // thus half as many messages are required
-    int numColumns = info.useStridedMessage ? info.numColsPerBlock / 2
-                                            : info.numColsPerBlock;
-    // For messages that span only 16 rows (e.g. 16x256b), multiple messages
-    // are required to cover the entire set of rows per warp.
-    int numRowPerWarp =
-        (info.layoutAtom.rowStored == 16 && info.blockM == 64) ? 16 : 32;
-
-    assert(message.numRows > 0);
-    assert(message.numCols > 0);
-    for (int rowStart = 0; rowStart < numRowPerWarp;
-         rowStart += message.numRows) {
-      for (int colStart = 0; colStart < std::max(1, numColumns);
-           colStart += message.numCols) {
-
-        Value rowOffset = b.add(blockRowId, b.i32_val(rowStart));
-        Value warpGroupAddress =
-            b.add(address, b.shl(rowOffset, b.i32_val(16)));
-        warpGroupAddress = b.add(warpGroupAddress, startColumnId);
-
-        std::optional<int> secondHalfColOffset;
-        if (info.useStridedMessage) {
-          // Offset to half way through the set of columns for this warpgroup.
-          secondHalfColOffset = numColumns;
-        }
-        createMemoryOp(warpGroupAddress, colStart, secondHalfColOffset,
-                       info.unpackedb16, message.numRegs,
-                       info.useStridedMessage);
-      }
-    }
-  }
 }
 
 void createTensorMemoryStore(Location loc, Value address, int colOffset,
@@ -648,30 +336,10 @@ void createTensorMemoryStore(Location loc, Value address, int colOffset,
   ptxBuilder.launch(rewriter, loc, voidTy);
 }
 
-TMemMessageTraits selectTMemMessage(const TMemRuntimeInfo &info, int maxnreg) {
-  auto atom = info.layoutAtom;
-
-  int totalRegsNeeded =
-      getEffectiveRegs(info.unpackedb16, info.useStridedMessage,
-                       info.numCols / info.numWarpGroups);
-  int narrowingFactor =
-      getTMemMessageNarrowingFactor(atom, totalRegsNeeded, maxnreg);
-  auto narrowedMessage = getTMemMessageFromAtom(atom, narrowingFactor);
-  narrowedMessage = constrainMessageFromWorkload(narrowedMessage, info,
-                                                 narrowedMessage.numRegs);
-
-  auto maxWidthMessage = getTMemMessageFromAtom(atom, /*narrowingFactor=*/1);
-  int numRegs = (info.layoutAtom.rowStored == 16) ? info.colsPerWarpGroup / 2
-                                                  : info.colsPerWarpGroup;
-  maxWidthMessage =
-      constrainMessageFromWorkload(maxWidthMessage, info, numRegs);
-  return std::min(narrowedMessage, maxWidthMessage);
-}
-
 // Get the maximum number of registers per thread based on the context. This is
 // by default 256, but it can be overridden by `ttg.maxnreg` set on the module
 // or a contextual register limit set by the compiler on partitions.
-static int getContextualMaxNReg(Operation *op) {
+int getContextualMaxNReg(Operation *op) {
   // Check the immediate parent op to see if it places a register constraint.
   auto getFromParent = [](Operation *op) -> std::optional<int> {
     Operation *parent = op->getParentOp();
@@ -717,33 +385,6 @@ static int getContextualMaxNReg(Operation *op) {
     maxnreg = std::min<int>(maxnreg, maxnregAttr.getInt());
 
   return maxnreg;
-}
-
-static void lowerStoreToTensorMemory(Location loc, Operation *op,
-                                     TypedValue<RankedTensorType> src,
-                                     TypedValue<MemDescType> dest, Value llSrc,
-                                     Value pred, Value tmemBase,
-                                     ConversionPatternRewriter &rewriter) {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-  SmallVector<Value> srcValues = unpackLLElements(loc, llSrc, rewriter);
-  srcValues = packToI32(srcValues, loc, rewriter);
-  auto info = getTMemRuntimeInfo(op, src.getType(), dest.getType());
-  const TMemMessageTraits message =
-      selectTMemMessage(info, getContextualMaxNReg(op));
-  int regIdx = 0;
-  calculateAddressAndEmitTmemMessage(
-      loc, tmemBase, info, message, rewriter,
-      [&](Value startAddress, int colOffset,
-          std::optional<int> secondHalfColOffset, bool unpackedb16,
-          int regsPerMsg, bool useStridedMessage) {
-        SmallVector<Value> srcValuesSlice(srcValues.begin() + regIdx,
-                                          srcValues.begin() + regIdx +
-                                              regsPerMsg);
-        regIdx += regsPerMsg;
-        createTensorMemoryStore(loc, startAddress, colOffset, srcValuesSlice,
-                                secondHalfColOffset, pred, unpackedb16,
-                                message.atom, rewriter);
-      });
 }
 
 Value createTensorMemoryLoad(Location loc, MLIRContext *ctx, Value address,
@@ -827,7 +468,6 @@ lowerTMemLdSt(Location loc, MLIRContext *ctx,
               ArrayRef<Value> vals, TMemAccessAtom atom, Type llvmElemTy,
               Value tmemBase, Value pred, int valsPerMessage, bool unpacked,
               std::optional<uint32_t> secondHalfOffset) {
-  assert(atom.usesSecondHalfOffset == secondHalfOffset.has_value());
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   auto kReg = str_attr("register");
   auto kLane = str_attr("lane");
@@ -842,7 +482,7 @@ lowerTMemLdSt(Location loc, MLIRContext *ctx,
     assert(unpacked);
     SmallVector<Value> inVals;
     if (isStore) {
-      inVals = packToI32(vals, loc, rewriter);
+      inVals = pack(vals, i32_ty, loc, rewriter);
     }
     // kill the first logValsPerReg bases of kReg as they are now packed
     // again, super hacky, we should probably do this when building the
@@ -861,7 +501,7 @@ lowerTMemLdSt(Location loc, MLIRContext *ctx,
       return failure();
     auto outVals = std::move(*outValsOr);
     if (!isStore) {
-      outVals = unpackFromI32(outVals, llvmElemTy, loc, rewriter);
+      outVals = unpack(outVals, llvmElemTy, loc, rewriter);
     }
     return outVals;
   }
@@ -916,10 +556,11 @@ lowerTMemLdSt(Location loc, MLIRContext *ctx,
   return resultVals;
 }
 
-static FailureOr<SmallVector<Value>> lowerTMemLdSt(
-    Location loc, MLIRContext *ctx, ConversionPatternRewriter &rewriter,
-    const LinearLayout &cvt, ArrayRef<Value> vals, Type llvmElemTy,
-    triton::gpu::MemDescType srcTy, Value tmemBase, int maxnreg, Value pred) {
+FailureOr<SmallVector<Value>>
+lowerTMemLdSt(Location loc, MLIRContext *ctx,
+              ConversionPatternRewriter &rewriter, const LinearLayout &cvt,
+              ArrayRef<Value> vals, Type llvmElemTy, Value tmemBase,
+              int maxnreg, bool unpacked, Value pred) {
   assert(cvt.getNumOutDims() == 2);
   bool isStore = !vals.empty();
   // Remove broadcasting in the registers
@@ -930,8 +571,9 @@ static FailureOr<SmallVector<Value>> lowerTMemLdSt(
     if (isStore) {
       inVals = removeBroadcastSrc.apply(inVals);
     }
-    auto outValsOr = lowerTMemLdSt(loc, ctx, rewriter, prmtCvt, inVals,
-                                   llvmElemTy, srcTy, tmemBase, maxnreg, pred);
+    auto outValsOr =
+        lowerTMemLdSt(loc, ctx, rewriter, prmtCvt, inVals, llvmElemTy, tmemBase,
+                      maxnreg, unpacked, pred);
     if (failed(outValsOr))
       return failure();
     auto outVals = std::move(*outValsOr);
@@ -940,9 +582,6 @@ static FailureOr<SmallVector<Value>> lowerTMemLdSt(
     }
     return outVals;
   }
-  auto enc =
-      cast<triton::nvidia_gpu::TensorMemoryEncodingAttr>(srcTy.getEncoding());
-  bool unpacked = enc.getUnpacked();
   auto kReg = str_attr("register");
   auto kLane = str_attr("lane");
   auto kRow = str_attr("row");
@@ -954,7 +593,7 @@ static FailureOr<SmallVector<Value>> lowerTMemLdSt(
   if (!unpacked && llvmElemTy.getIntOrFloatBitWidth() < 32) {
     SmallVector<Value> inVals;
     if (isStore) {
-      inVals = packToI32(vals, loc, rewriter);
+      inVals = pack(vals, i32_ty, loc, rewriter);
     }
     auto bitwidth = llvmElemTy.getIntOrFloatBitWidth();
     auto maybeQuot =
@@ -962,17 +601,18 @@ static FailureOr<SmallVector<Value>> lowerTMemLdSt(
     assert(maybeQuot.has_value());
     auto quot = *maybeQuot;
     auto outValsOr = lowerTMemLdSt(loc, ctx, rewriter, quot, inVals, i32_ty,
-                                   srcTy, tmemBase, maxnreg, pred);
+                                   tmemBase, maxnreg, unpacked, pred);
     if (failed(outValsOr))
       return failure();
     auto outVals = std::move(*outValsOr);
     if (!isStore) {
-      outVals = unpackFromI32(outVals, llvmElemTy, loc, rewriter);
+      outVals = unpack(outVals, llvmElemTy, loc, rewriter);
     }
     return outVals;
   }
   assert(!isStore || cvt.getInDimSize(kReg) == vals.size());
   auto bitwidth = llvmElemTy.getIntOrFloatBitWidth();
+  auto nRow = cvt.getOutDimSize(kRow);
 
   // The algorithm goes as:
   // - Try to match the tile with one of the standard messages
@@ -984,7 +624,7 @@ static FailureOr<SmallVector<Value>> lowerTMemLdSt(
   std::optional<std::tuple<TMemAccessAtom, LinearLayout, ColumnAction, int>>
       msgInfo;
   for (auto atom : {TMemAccess32x32b, TMemAccess16x256b}) {
-    auto tile = getTileLayout(ctx, atom, bitwidth, unpacked);
+    auto tile = getTileLayout(ctx, atom, bitwidth, unpacked, nRow);
     auto maybeReps = getVec(cvt, tile, maxnreg, bitwidth);
     if (maybeReps) {
       // Cannot match more than one
@@ -997,7 +637,8 @@ static FailureOr<SmallVector<Value>> lowerTMemLdSt(
   if (!msgInfo) {
     // Quotient by the smaller tile and then, if possible, we set the
     // secondHalfOffset to the last kLane basis
-    auto tile = getTileLayout(ctx, TMemAccess16x32bx2, bitwidth, unpacked);
+    auto tile =
+        getTileLayout(ctx, TMemAccess16x32bx2, bitwidth, unpacked, nRow);
     auto maybeReps = getVec(cvt, tile, maxnreg, bitwidth);
     if (maybeReps) {
       auto [reps, perm, numRegsPerMessage] = std::move(*maybeReps);
@@ -1026,7 +667,7 @@ static FailureOr<SmallVector<Value>> lowerTMemLdSt(
   }
   auto outValsOr = lowerTMemLdSt(
       loc, ctx, rewriter, reps, inVals, atom, llvmElemTy, tmemBase, pred,
-      numRegsPerMessage, unpacked && llvmElemTy.getIntOrFloatBitWidth() == 16,
+      numRegsPerMessage, unpacked && llvmElemTy.getIntOrFloatBitWidth() < 32,
       secondHalfOffset);
   if (failed(outValsOr))
     return failure();
@@ -1042,7 +683,6 @@ static FailureOr<SmallVector<Value>> lowerTMemLdStFromTypes(
     Location loc, MLIRContext *ctx, ConversionPatternRewriter &rewriter,
     RankedTensorType regTy, MemDescType memTy, Value tmemBase, int maxnreg,
     Value pred, Type llvmElemTy, ArrayRef<Value> storeVals) {
-  assert(isa<nvidia_gpu::TensorMemoryEncodingAttr>(memTy.getEncoding()));
   auto memLayout = toLinearLayout(memTy);
   auto regLayout = toLinearLayout(regTy);
   auto cvt = regLayout.invertAndCompose(memLayout);
@@ -1056,9 +696,57 @@ static FailureOr<SmallVector<Value>> lowerTMemLdStFromTypes(
       divideRight(cvt, LinearLayout::identity1D(nCTAs, kBlock, kCol));
   assert(maybeQuot.has_value());
   auto quot = maybeQuot->unsqueezeIn(kBlock);
+  bool unpacked;
+  if (auto enc = dyn_cast<TensorMemoryEncodingAttr>(memTy.getEncoding())) {
+    unpacked = enc.getUnpacked();
+  } else {
+    assert(isa<TensorMemoryScalesEncodingAttr>(memTy.getEncoding()));
+    unpacked = regTy.getDimSize(1) < 4;
+  }
 
-  return lowerTMemLdSt(loc, ctx, rewriter, quot, storeVals, llvmElemTy, memTy,
-                       tmemBase, maxnreg, pred);
+  // Handle K = 1 and K = 2 cases
+  auto undefShmem =
+      isa<TensorMemoryScalesEncodingAttr>(memTy.getEncoding()) && unpacked;
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  bool isStore = !storeVals.empty();
+  auto inVals = to_vector(storeVals);
+  auto packedLlvmElemTy = llvmElemTy;
+  if (undefShmem) {
+    auto K = regTy.getDimSize(1);
+    assert(K < 4);
+
+    if (K == 1) {
+      packedLlvmElemTy = f16_ty;
+    }
+
+    // The unpacked layout also expects an llvmElemTy of f16
+    if (isStore) {
+      if (K == 1) {
+        for (auto &val : inVals) {
+          val = b.bitcast(b.zext(i16_ty, val), llvmElemTy);
+        }
+      }
+    }
+    auto kReg = str_attr("register");
+    assert(inVals.size() == quot.getInDimSize(kReg));
+  }
+
+  auto resultValsOr =
+      lowerTMemLdSt(loc, ctx, rewriter, quot, inVals, packedLlvmElemTy,
+                    tmemBase, maxnreg, unpacked, pred);
+  if (failed(resultValsOr))
+    return failure();
+  auto resultVals = std::move(*resultValsOr);
+  if (!isStore && undefShmem) {
+    // Need to truncate the resultVals to the original llvmElemTy
+    auto K = regTy.getDimSize(1);
+    if (K == 1) {
+      for (auto &val : resultVals) {
+        val = b.trunc(llvmElemTy, val);
+      }
+    }
+  }
+  return resultVals;
 }
 
 struct TensorMemoryLoadOpConversion
@@ -1076,41 +764,17 @@ struct TensorMemoryLoadOpConversion
     auto regTy = cast<RankedTensorType>(op.getType());
     auto memTy = cast<MemDescType>(op.getSrc().getType());
 
-    SmallVector<Value> resultVals;
-    if (isa<nvidia_gpu::TensorMemoryScalesEncodingAttr>(memTy.getEncoding())) {
-      // Legacy path
-      auto info = getTMemRuntimeInfo(op, regTy, memTy);
-      const TMemMessageTraits message =
-          selectTMemMessage(info, getContextualMaxNReg(op));
-      calculateAddressAndEmitTmemMessage(
-          loc, tmemBase, info, message, rewriter,
-          [&](Value startAddress, int colOffset,
-              std::optional<int> secondHalfColOffset, bool unpackedb16,
-              int regsPerMessage, bool useStridedMessage) {
-            Value packedValues = createTensorMemoryLoad(
-                loc, ctx, startAddress, colOffset, secondHalfColOffset,
-                unpackedb16, regsPerMessage, message.atom, rewriter);
-            auto results =
-                unpackResults(packedValues, op.getType().getElementType(),
-                              regsPerMessage, loc, rewriter);
-            resultVals.append(results.begin(), results.end());
-          });
-    } else if (isa<nvidia_gpu::TensorMemoryEncodingAttr>(memTy.getEncoding())) {
-      auto b = TritonLLVMOpBuilder(loc, rewriter);
-      auto maxnreg = getContextualMaxNReg(op);
-      auto resultValsOr =
-          lowerTMemLdStFromTypes(loc, ctx, rewriter, regTy, memTy, tmemBase,
-                                 maxnreg, b.i1_val(true), llvmElemTy, {});
-      if (failed(resultValsOr))
-        return failure();
-      resultVals = std::move(*resultValsOr);
-    } else {
-      assert(false && "Unsupported tmem encoding");
-    }
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto maxnreg = getContextualMaxNReg(op);
+    auto resultValsOr =
+        lowerTMemLdStFromTypes(loc, ctx, rewriter, regTy, memTy, tmemBase,
+                               maxnreg, b.i1_val(true), llvmElemTy, {});
+    if (failed(resultValsOr))
+      return failure();
 
     Type structTy = getTypeConverter()->convertType(op.getType());
-    Value resultStruct =
-        packLLElements(loc, getTypeConverter(), resultVals, rewriter, structTy);
+    Value resultStruct = packLLElements(loc, getTypeConverter(), *resultValsOr,
+                                        rewriter, structTy);
     // Wait insertion could be moved to the TTGIR level if needed.
     rewriter.create<NVVM::Tcgen05WaitOp>(loc, NVVM::Tcgen05WaitKind::LOAD);
     rewriter.replaceOp(op, {resultStruct});
@@ -1136,19 +800,13 @@ struct TensorMemoryStoreOpConversion
     auto regTy = cast<RankedTensorType>(op.getSrc().getType());
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    if (isa<nvidia_gpu::TensorMemoryEncodingAttr>(memTy.getEncoding())) {
-      auto maxnreg = getContextualMaxNReg(op);
-      SmallVector<Value> srcValues =
-          unpackLLElements(loc, adaptor.getSrc(), rewriter);
-      auto lowered =
-          lowerTMemLdStFromTypes(loc, ctx, rewriter, regTy, memTy, tmemBase,
-                                 maxnreg, pred, llvmElemTy, srcValues);
-      if (failed(lowered))
-        return failure();
-    } else {
-      lowerStoreToTensorMemory(loc, op, op.getSrc(), op.getDst(),
-                               adaptor.getSrc(), pred, tmemBase, rewriter);
-    }
+    auto maxnreg = getContextualMaxNReg(op);
+    auto srcValuesOr =
+        lowerTMemLdStFromTypes(loc, ctx, rewriter, regTy, memTy, tmemBase,
+                               maxnreg, pred, llvmElemTy, {});
+    if (failed(srcValuesOr))
+      return failure();
+    auto srcValues = std::move(*srcValuesOr);
     rewriter.create<NVVM::Tcgen05WaitOp>(loc, NVVM::Tcgen05WaitKind::STORE);
 
     // Emit a barrier to ensure all threads have finished writing to tensor
@@ -1185,29 +843,18 @@ struct TensorMemoryAllocOpConversion
     auto shape = op.getType().getShape();
 
     if (op.getSrc()) {
+      auto regTy = cast<RankedTensorType>(op.getSrc().getType());
       auto memTy = cast<MemDescType>(op.getResult().getType());
-      if (isa<nvidia_gpu::TensorMemoryEncodingAttr>(memTy.getEncoding())) {
-        auto regTy = cast<RankedTensorType>(op.getSrc().getType());
-        auto llvmElemTy =
-            getTypeConverter()->convertType(regTy.getElementType());
-        auto maxnreg = getContextualMaxNReg(op);
-        SmallVector<Value> srcValues =
-            unpackLLElements(loc, adaptor.getSrc(), rewriter);
-        Value ptr = b.inttoptr(base.getType(), allocAddress);
-        auto lowered = lowerTMemLdStFromTypes(loc, ctx, rewriter, regTy, memTy,
-                                              ptr, maxnreg, b.i1_val(true),
-                                              llvmElemTy, srcValues);
-        if (failed(lowered))
-          return failure();
-      } else {
-        // Cast to address space 3 as the shared memory object uses 3.
-        // TODO: clean this up and use either a int or ptr address space 6
-        auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext(), 3);
-        Value ptr = b.inttoptr(ptrTy, allocAddress);
-        lowerStoreToTensorMemory(loc, op, op.getSrc(), op.getResult(),
-                                 adaptor.getSrc(), b.i1_val(true), ptr,
-                                 rewriter);
-      }
+      auto llvmElemTy = getTypeConverter()->convertType(regTy.getElementType());
+      auto maxnreg = getContextualMaxNReg(op);
+      SmallVector<Value> srcValues =
+          unpackLLElements(loc, adaptor.getSrc(), rewriter);
+      Value ptr = b.inttoptr(base.getType(), allocAddress);
+      auto resultValsOr =
+          lowerTMemLdStFromTypes(loc, ctx, rewriter, regTy, memTy, ptr, maxnreg,
+                                 b.i1_val(true), llvmElemTy, srcValues);
+      if (failed(resultValsOr))
+        return failure();
       rewriter.create<NVVM::Tcgen05WaitOp>(loc, NVVM::Tcgen05WaitKind::STORE);
       // Emit a barrier to ensure all threads have finished writing to tensor
       // memory before any use of the tensor memory.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -667,7 +667,7 @@ lowerTMemLdSt(Location loc, MLIRContext *ctx,
   }
   auto outValsOr = lowerTMemLdSt(
       loc, ctx, rewriter, reps, inVals, atom, llvmElemTy, tmemBase, pred,
-      numRegsPerMessage, unpacked && llvmElemTy.getIntOrFloatBitWidth() < 32,
+      numRegsPerMessage, unpacked && llvmElemTy.getIntOrFloatBitWidth() == 16,
       secondHalfOffset);
   if (failed(outValsOr))
     return failure();


### PR DESCRIPTION
We now add support for `TensorMemoryScalesEncoding` in `toLinearLayout`
and we reuse the generic lowering to lower it.
