### PR TITLE
[LANG] Expand tl.target_info and fail gracefully on CPU

### DIFF
--- a/python/triton/language/target_info.py
+++ b/python/triton/language/target_info.py
@@ -1,10 +1,54 @@
 from triton.runtime import driver
+from triton.runtime.jit import constexpr_function
 
 __all__ = ["current_target"]
 
 
-def current_target(_semantic=None):
-    return driver.active.get_current_target()
+def current_target():
+    try:
+        active_driver = driver.active
+    except RuntimeError:
+        # If there is no active driver, return None
+        return None
+    return active_driver.get_current_target()
 
 
 current_target.__triton_builtin__ = True
+
+
+@constexpr_function
+def is_cuda():
+    target = current_target()
+    return target is not None and target.backend == "cuda"
+
+
+@constexpr_function
+def cuda_capability_geq(major, minor=0):
+    """
+    Determines whether we have compute capability >= (major, minor) and
+    returns this as a constexpr boolean. This can be used for guarding
+    inline asm implementations that require a certain compute capability.
+    """
+    target = current_target()
+    if target is None or target.backend != "cuda":
+        return False
+    assert isinstance(target.arch, int)
+    return target.arch >= major * 10 + minor
+
+
+@constexpr_function
+def is_hip():
+    target = current_target()
+    return target is not None and target.backend == "hip"
+
+
+@constexpr_function
+def is_hip_cdna3():
+    target = current_target()
+    return target is not None and target.arch == "gfx942"
+
+
+@constexpr_function
+def is_hip_cdna4():
+    target = current_target()
+    return target is not None and target.arch == "gfx950"

--- a/python/triton_kernels/triton_kernels/target_info.py
+++ b/python/triton_kernels/triton_kernels/target_info.py
@@ -2,41 +2,25 @@ import torch
 import triton
 import triton.language as tl
 
-cached_capabilities = {}
+from triton.language.target_info import (
+    cuda_capability_geq,
+    is_cuda,
+    is_hip,
+    is_hip_cdna3,
+    is_hip_cdna4,
+)
 
-
-@triton.constexpr_function
-def is_cuda():
-    return tl.target_info.current_target().backend == "cuda"
-
-
-@triton.constexpr_function
-def is_hip():
-    return tl.target_info.current_target().backend == "hip"
-
-
-@triton.constexpr_function
-def is_hip_cdna3():
-    return tl.target_info.current_target().arch == "gfx942"
-
-
-@triton.constexpr_function
-def is_hip_cdna4():
-    return tl.target_info.current_target().arch == "gfx950"
-
-
-@triton.constexpr_function
-def cuda_capability_geq(major, minor=0):
-    """
-    Determines whether we have compute capability >= (major, minor) and
-    returns this as a constexpr boolean. This can be used for guarding
-    inline asm implementations that require a certain compute capability.
-    """
-    target = tl.target_info.current_target()
-    if target.backend != "cuda":
-        return False
-    assert isinstance(target.arch, int)
-    return target.arch >= major * 10 + minor
+__all__ = [
+    "cuda_capability_geq",
+    "get_cdna_version",
+    "has_tma_gather",
+    "has_native_mxfp",
+    "is_cuda",
+    "is_hip",
+    "is_hip_cdna3",
+    "is_hip_cdna4",
+    "num_sms",
+]
 
 
 @triton.constexpr_function


### PR DESCRIPTION
This moves some target_info functions from kernels into the language. I also update `current_target()` to return `None` when there is no supported device found, which allows the target function to be called e.g. at import time.