### PR TITLE
Complete out-of-tree build with environment variable TRITON_BUILD_DIR

### DIFF
--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -19,7 +19,7 @@ def _get_dir_common(prefix):
     dir_name = f"{prefix}.{plat_name}-{sys.implementation.name}-{python_version}"
     path = _get_build_base() / dir_name
     path.mkdir(parents=True, exist_ok=True)
-    return path.as_posix()
+    return path
 
 
 def get_cmake_dir():

--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -5,18 +5,28 @@ from pathlib import Path
 
 
 def get_base_dir():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    return Path(__file__).parent.parent
 
+def _get_build_base():
+    build_base = os.getenv("TRITON_BUILD_DIR", default=(get_base_dir() / "build"))
+    return Path(build_base)
 
-def _get_cmake_dir():
+def _get_dir_common(prefix):
     plat_name = sysconfig.get_platform()
     python_version = sysconfig.get_python_version()
-    dir_name = f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"
-    return Path(get_base_dir()) / "build" / dir_name
-
+    dir_name = f"{prefix}.{plat_name}-{sys.implementation.name}-{python_version}"
+    path = _get_build_base() / dir_name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 def get_cmake_dir():
-    cmake_dir = os.getenv("TRITON_BUILD_DIR", default=_get_cmake_dir())
-    cmake_dir = Path(cmake_dir)
-    cmake_dir.mkdir(parents=True, exist_ok=True)
-    return cmake_dir
+    return _get_dir_common("cmake")
+
+def get_build_lib():
+    return _get_dir_common("lib")
+
+def get_build_temp():
+    return _get_dir_common("temp")
+
+def get_bdist_dir():
+    return _get_dir_common("bdist")

--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -7,9 +7,11 @@ from pathlib import Path
 def get_base_dir():
     return Path(__file__).parent.parent
 
+
 def _get_build_base():
     build_base = os.getenv("TRITON_BUILD_DIR", default=(get_base_dir() / "build"))
     return Path(build_base)
+
 
 def _get_dir_common(prefix):
     plat_name = sysconfig.get_platform()
@@ -19,14 +21,18 @@ def _get_dir_common(prefix):
     path.mkdir(parents=True, exist_ok=True)
     return path.as_posix()
 
+
 def get_cmake_dir():
     return _get_dir_common("cmake")
+
 
 def get_build_lib():
     return _get_dir_common("lib")
 
+
 def get_build_temp():
     return _get_dir_common("temp")
+
 
 def get_bdist_dir():
     return _get_dir_common("bdist")

--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -17,7 +17,7 @@ def _get_dir_common(prefix):
     dir_name = f"{prefix}.{plat_name}-{sys.implementation.name}-{python_version}"
     path = _get_build_base() / dir_name
     path.mkdir(parents=True, exist_ok=True)
-    return path
+    return path.as_posix()
 
 def get_cmake_dir():
     return _get_dir_common("cmake")

--- a/setup.py
+++ b/setup.py
@@ -383,7 +383,7 @@ class CMakeBuildPy(build_py):
 
     def initialize_options(self):
         super().initialize_options()
-        self.build_lib = get_build_lib()
+        self.build_lib = get_build_lib().as_posix()
 
     def run(self) -> None:
         self.run_command('build_ext')

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,13 @@ except ImportError:
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from python.build_helpers import get_base_dir, get_cmake_dir
+from python.build_helpers import (
+    get_base_dir,
+    get_cmake_dir,
+    get_build_lib,
+    get_build_temp,
+    get_bdist_dir,
+)
 
 
 def is_git_repo():
@@ -375,6 +381,10 @@ class CMakeClean(clean):
 
 class CMakeBuildPy(build_py):
 
+    def initialize_options(self):
+        super().initialize_options()
+        self.build_lib = get_build_lib().as_posix()
+
     def run(self) -> None:
         self.run_command('build_ext')
         return super().run()
@@ -396,6 +406,8 @@ class CMakeBuild(build_ext):
     def initialize_options(self):
         build_ext.initialize_options(self)
         self.base_dir = get_base_dir()
+        self.build_lib = get_build_lib()
+        self.build_temp = get_build_temp()
 
     def finalize_options(self):
         build_ext.finalize_options(self)
@@ -695,6 +707,10 @@ def add_links(external_only):
 
 
 class plugin_bdist_wheel(bdist_wheel):
+
+    def initialize_options(self):
+        super().initialize_options()
+        self.bdist_dir = get_bdist_dir()
 
     def run(self):
         add_links(external_only=True)

--- a/setup.py
+++ b/setup.py
@@ -383,7 +383,7 @@ class CMakeBuildPy(build_py):
 
     def initialize_options(self):
         super().initialize_options()
-        self.build_lib = get_build_lib().as_posix()
+        self.build_lib = get_build_lib()
 
     def run(self) -> None:
         self.run_command('build_ext')


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Overview

This is a following up PR of #7347, which the new env var `TRITON_BUILD_DIR` was added to allow moving `f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"` to an alternative location. However, a few directories are still using the in-source location `build/`.

This PR completes the relocation of these remaining directories.