### PR TITLE
[AMD][GFX12] Unit test failure on RDNA4 for fp8/bfp8 with 8/16 bit bias.

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -7,7 +7,7 @@ import pytest
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_gfx12
 
 
 def matching_int(dtype):
@@ -290,8 +290,8 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
             with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
                 launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)
             return
-        if src_dtype in ('float8e4b8', 'float8e5b16') and is_hip_cdna2():
-            pytest.skip(f"{src_dtype} is not supported on AMDGPU CDNA2")
+        if src_dtype in ('float8e4b8', 'float8e5b16') and is_hip_cdna2() or is_hip_gfx12:
+            pytest.skip(f"{src_dtype} is not supported on AMDGPU CDNA2 and RDNA4")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias, max_repr)
     stuff = {
@@ -343,8 +343,8 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
             pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU CDNA3")
 
     if is_hip():
-        if dst_dtype in ('float8e4b8', 'float8e5b16') and is_hip_cdna2():
-            pytest.skip(f"{dst_dtype} is not supported on AMDGPU CDNA2")
+        if dst_dtype in ('float8e4b8', 'float8e5b16') and is_hip_cdna2() or is_hip_gfx12():
+            pytest.skip(f"{dst_dtype} is not supported on AMDGPU CDNA2 and RDNA4")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias)
     stuff = {


### PR DESCRIPTION
RDNA4 supports fp8/bfp8 with 7/15 bit bias, there is no support for fp8/bfp8 with 8 and 16 bit bias on RDNA4 architecture. 

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because I am fixing a test.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
