### PR TITLE
[TEST] Reset `jit_cache_hook` and `jit_cache_hook` in the `fresh_triton_cache` fixture

### DIFF
--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -20,16 +20,9 @@ def fresh_triton_cache():
     with tempfile.TemporaryDirectory() as tmpdir:
         from triton import knobs
 
-        old_jit_cache_hook = getattr(knobs.runtime, "jit_cache_hook", None)
-        old_post_compile_hook = getattr(knobs.runtime, "jit_post_compile_hook", None)
-
-        with knobs.cache.scope():
+        with knobs.cache.scope(), knobs.runtime.scope():
             knobs.cache.dir = tmpdir
-            try:
-                yield tmpdir
-            finally:
-                knobs.runtime.jit_cache_hook = old_jit_cache_hook
-                knobs.runtime.jit_post_compile_hook = old_post_compile_hook
+            yield tmpdir
 
 
 @pytest.fixture

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -19,9 +19,17 @@ def device(request):
 def fresh_triton_cache():
     with tempfile.TemporaryDirectory() as tmpdir:
         from triton import knobs
+
+        old_jit_cache_hook = getattr(knobs.runtime, "jit_cache_hook", None)
+        old_post_compile_hook = getattr(knobs.runtime, "jit_post_compile_hook", None)
+
         with knobs.cache.scope():
             knobs.cache.dir = tmpdir
-            yield tmpdir
+            try:
+                yield tmpdir
+            finally:
+                knobs.runtime.jit_cache_hook = old_jit_cache_hook
+                knobs.runtime.jit_post_compile_hook = old_post_compile_hook
 
 
 @pytest.fixture

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -583,7 +583,6 @@ def test_preload(device, fresh_triton_cache) -> None:
 
     triton.knobs.runtime.jit_cache_hook = inc_counter
     final_kernel = kernel_add.warmup(torch.float32, torch.float32, torch.float32, 32, tl.float32, grid=(1, ))
-    triton.knobs.runtime.jit_cache_hook = None
     assert counter == 0
     assert len(kernel_add.device_caches[device][0]) == 1
     assert final_kernel.hash == hash
@@ -692,8 +691,6 @@ def test_function_arguments(device):
     def kernel(Y, fn: tl.constexpr, fn_args):
         tl.store(Y, fn(*fn_args))
 
-    triton.knobs.runtime.jit_cache_hook = None
-    triton.knobs.runtime.jit_post_compile_hook = None
     y = torch.zeros((5, ), dtype=torch.int32, device=device)
     kernel[(1, )](y[0], func1, tuple())
     kernel[(1, )](y[1], func2, tuple())

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -16,10 +16,8 @@ def test_knobs_utils(fresh_knobs) -> None:
         baz: triton.knobs.env_opt_str = triton.knobs.env_opt_str("BAZ")
         quux: triton.knobs.env_opt_bool = triton.knobs.env_opt_bool("QUUX")
 
-    instance = test_knobs()
-
     # Make sure knobs works
-    assert instance.knobs == {
+    assert test_knobs.knobs == {
         "foo": "triton",
         "bar": True,
         "baz": None,
@@ -28,27 +26,27 @@ def test_knobs_utils(fresh_knobs) -> None:
 
     # Now make sure copying works properly, otherwise all other tests in this
     # file aren't trustworthy.
-    instance.bar = False
-    instance.quux = True
-    assert instance.foo == "triton"
-    assert not instance.bar
-    assert instance.baz is None
-    assert instance.quux
-    assert instance.knobs == {
+    test_knobs.bar = False
+    test_knobs.quux = True
+    assert test_knobs.foo == "triton"
+    assert not test_knobs.bar
+    assert test_knobs.baz is None
+    assert test_knobs.quux
+    assert test_knobs.knobs == {
         "foo": "triton",
         "bar": False,
         "baz": None,
         "quux": True,
     }
 
-    second = instance.copy()
+    second = test_knobs.copy()
     assert second.foo == "triton"
     assert not second.bar
     assert second.baz is None
     assert second.quux
 
     second.foo = "tritium"
-    assert instance.foo != "tritium"
+    assert test_knobs.foo != "tritium"
     assert second.foo == "tritium"
 
     # Ditto on trustworthiness if reset() doesn't work.
@@ -60,7 +58,7 @@ def test_knobs_utils(fresh_knobs) -> None:
         "quux": None,
     }
     # Triple check original instance didn't change.
-    assert instance.knobs == {
+    assert test_knobs.knobs == {
         "foo": "triton",
         "bar": False,
         "baz": None,

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -16,8 +16,10 @@ def test_knobs_utils(fresh_knobs) -> None:
         baz: triton.knobs.env_opt_str = triton.knobs.env_opt_str("BAZ")
         quux: triton.knobs.env_opt_bool = triton.knobs.env_opt_bool("QUUX")
 
+    instance = test_knobs()
+
     # Make sure knobs works
-    assert test_knobs.knobs == {
+    assert instance.knobs == {
         "foo": "triton",
         "bar": True,
         "baz": None,
@@ -26,27 +28,27 @@ def test_knobs_utils(fresh_knobs) -> None:
 
     # Now make sure copying works properly, otherwise all other tests in this
     # file aren't trustworthy.
-    test_knobs.bar = False
-    test_knobs.quux = True
-    assert test_knobs.foo == "triton"
-    assert not test_knobs.bar
-    assert test_knobs.baz is None
-    assert test_knobs.quux
-    assert test_knobs.knobs == {
+    instance.bar = False
+    instance.quux = True
+    assert instance.foo == "triton"
+    assert not instance.bar
+    assert instance.baz is None
+    assert instance.quux
+    assert instance.knobs == {
         "foo": "triton",
         "bar": False,
         "baz": None,
         "quux": True,
     }
 
-    second = test_knobs.copy()
+    second = instance.copy()
     assert second.foo == "triton"
     assert not second.bar
     assert second.baz is None
     assert second.quux
 
     second.foo = "tritium"
-    assert test_knobs.foo != "tritium"
+    assert instance.foo != "tritium"
     assert second.foo == "tritium"
 
     # Ditto on trustworthiness if reset() doesn't work.
@@ -58,7 +60,7 @@ def test_knobs_utils(fresh_knobs) -> None:
         "quux": None,
     }
     # Triple check original instance didn't change.
-    assert test_knobs.knobs == {
+    assert instance.knobs == {
         "foo": "triton",
         "bar": False,
         "baz": None,

--- a/python/triton_kernels/tests/conftest.py
+++ b/python/triton_kernels/tests/conftest.py
@@ -26,13 +26,6 @@ def fresh_triton_cache():
     with tempfile.TemporaryDirectory() as tmpdir:
         from triton import knobs
 
-        old_jit_cache_hook = getattr(knobs.runtime, "jit_cache_hook", None)
-        old_post_compile_hook = getattr(knobs.runtime, "jit_post_compile_hook", None)
-
-        with knobs.cache.scope():
+        with knobs.cache.scope(), knobs.runtime.scope():
             knobs.cache.dir = tmpdir
-            try:
-                yield tmpdir
-            finally:
-                knobs.runtime.jit_cache_hook = old_jit_cache_hook
-                knobs.runtime.jit_post_compile_hook = old_post_compile_hook
+            yield tmpdir

--- a/python/triton_kernels/tests/test_specialize.py
+++ b/python/triton_kernels/tests/test_specialize.py
@@ -38,7 +38,7 @@ def cacheable_kernel():
     return get_specialized_kernel()
 
 
-def test_cacheable(device, fresh_knobs, fresh_triton_cache):
+def test_cacheable(device, fresh_triton_cache):
     specialized_kernel = get_specialized_kernel()
 
     specialization_data = None

--- a/python/triton_kernels/tests/test_specialize.py
+++ b/python/triton_kernels/tests/test_specialize.py
@@ -38,7 +38,7 @@ def cacheable_kernel():
     return get_specialized_kernel()
 
 
-def test_cacheable(device, fresh_knobs):
+def test_cacheable(device, fresh_knobs, fresh_triton_cache):
     specialized_kernel = get_specialized_kernel()
 
     specialization_data = None


### PR DESCRIPTION
These are not environment variables and thereby cannot be automatically reset by `knobs.reset`