### PR TITLE
Slice to a scalar lead to unexpected result shape (#6122)

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -858,12 +858,6 @@ def test_slice(device):
         t = data[None, None::None, None]
         tl.static_assert(t.shape == [1, XBLOCK, 1])
 
-        t = data[:, None]
-        tl.static_assert(t.shape == [XBLOCK, 1])
-
-        t = data[:, None, None]
-        tl.static_assert(t.shape == [XBLOCK, 1, 1])
-
         scalar = tl.full([], 1, tl.int32)
         tl.static_assert(scalar.shape == [])
 
@@ -872,18 +866,6 @@ def test_slice(device):
 
         t = scalar[None, None]
         tl.static_assert(t.shape == [1, 1])
-
-        t = scalar[None, :, None]
-        tl.static_assert(t.shape == [1, 1])
-
-        t = scalar[:, None]
-        tl.static_assert(t.shape == [1])
-
-        t = scalar[:, :, None]
-        tl.static_assert(t.shape == [1])
-
-        t = scalar[None, None, None]
-        tl.static_assert(t.shape == [1, 1, 1])
 
     slice_kernel[(1, )](XBLOCK=32)
 
@@ -903,6 +885,33 @@ def test_invalid_slice(device):
 
     with pytest.raises(triton.TritonError, match='unsupported tensor index'):
         _kernel[(1, )](dst=dst)
+
+    @triton.jit
+    def scalar_none_slice_none():
+        scalar = tl.full([], 1, tl.int32)
+        t = scalar[None, :, None]
+
+    @triton.jit
+    def scalar_slice_none():
+        scalar = tl.full([], 1, tl.int32)
+        t = scalar[:, None]
+
+    @triton.jit
+    def scalar_slice_slice_none():
+        scalar = tl.full([], 1, tl.int32)
+        t = scalar[:, :, None]
+
+    with pytest.raises(triton.TritonError) as exc_info:
+        scalar_none_slice_none[(1, )]()
+    assert "too many indices for tensor: tensor is 0-dimensional, but 1 were indexed" in str(exc_info.value.__cause__)
+
+    with pytest.raises(triton.TritonError) as exc_info:
+        scalar_slice_none[(1, )]()
+    assert "too many indices for tensor: tensor is 0-dimensional, but 1 were indexed" in str(exc_info.value.__cause__)
+
+    with pytest.raises(triton.TritonError) as exc_info:
+        scalar_slice_slice_none[(1, )]()
+    assert "too many indices for tensor: tensor is 0-dimensional, but 2 were indexed" in str(exc_info.value.__cause__)
 
 
 # ----------------

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -858,6 +858,12 @@ def test_slice(device):
         t = data[None, None::None, None]
         tl.static_assert(t.shape == [1, XBLOCK, 1])
 
+        t = data[:, None]
+        tl.static_assert(t.shape == [XBLOCK, 1])
+
+        t = data[:, None, None]
+        tl.static_assert(t.shape == [XBLOCK, 1, 1])
+
         scalar = tl.full([], 1, tl.int32)
         tl.static_assert(scalar.shape == [])
 
@@ -866,6 +872,18 @@ def test_slice(device):
 
         t = scalar[None, None]
         tl.static_assert(t.shape == [1, 1])
+
+        t = scalar[None, :, None]
+        tl.static_assert(t.shape == [1, 1])
+
+        t = scalar[:, None]
+        tl.static_assert(t.shape == [1])
+
+        t = scalar[:, :, None]
+        tl.static_assert(t.shape == [1])
+
+        t = scalar[None, None, None]
+        tl.static_assert(t.shape == [1, 1, 1])
 
     slice_kernel[(1, )](XBLOCK=32)
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1111,9 +1111,7 @@ class tensor(base_value):
         if isinstance(slices, tuple):
             slices = slices.values
 
-        slice_count = sum(
-            isinstance(sl, (builtins.slice, slice)) and all(
-                _unwrap_if_constexpr(arg) is None for arg in (sl.start, sl.stop, sl.step)) for sl in slices)
+        slice_count = sum(_unwrap_if_constexpr(sl) is not None for sl in slices)
 
         # check if we're trying to index more dimensions than exist
         if slice_count > len(self.shape):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1111,13 +1111,14 @@ class tensor(base_value):
         if isinstance(slices, tuple):
             slices = slices.values
 
-        slice_count = sum(isinstance(sl, (builtins.slice, slice)) and
-                         all(_unwrap_if_constexpr(arg) is None for arg in (sl.start, sl.stop, sl.step))
-                         for sl in slices)
+        slice_count = sum(
+            isinstance(sl, (builtins.slice, slice)) and all(
+                _unwrap_if_constexpr(arg) is None for arg in (sl.start, sl.stop, sl.step)) for sl in slices)
 
         # check if we're trying to index more dimensions than exist
         if slice_count > len(self.shape):
-            raise ValueError(f"too many indices for tensor: tensor is {len(self.shape)}-dimensional, but {slice_count} were indexed")
+            raise ValueError(
+                f"too many indices for tensor: tensor is {len(self.shape)}-dimensional, but {slice_count} were indexed")
 
         ret = self
         for dim, sl in enumerate(slices):


### PR DESCRIPTION
**Update:** just adds validation/emits structured error for invalid indexing. 

~~The `__getitem__` implementation in tensor incorrectly used the slice tuple index as the dimension parameter for `expand_dims`, causing out-of-bounds errors when the index exceeded the tensor's rank. For example, `scalar[None, :, None]` attempted to call `expand_dims` on a 1D tensor at the third slice position, resulting in a crash. Described more fully in #6122 (Slice to a scalar lead to unexpected result shape).~~

~~This patch tracks the actual insertion position independently of the slice index. When `None` is encountered, `expand_dims` is called at `result_dim`. When `:` is encountered on an existing dimension, we skip past that dimension, so subsequent insertions occur at the correct position. This preserves the correct behavior for patterns like `tensor_1d[:, None]` (which should produce shape `[4, 1]` not `[1, 4]`), while preventing crashes on cases like `scalar[None, :, None]`.~~

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
