### PR TITLE
WIP: fix AxisInfo analysis

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1079,8 +1079,20 @@ void AxisInfoAnalysis::visitForOpInductionVar(
   ProgramPoint *programPoint = getProgramPointAfter(op);
   const auto &lb =
       getLatticeElementFor(programPoint, op.getLowerBound())->getValue();
+  if (lb.getDivisibility().empty()) {
+    auto definingOp = op.getLowerBound().getDefiningOp();
+    if (definingOp) {
+      auto result = visit(getProgramPointAfter(definingOp));
+    }
+  }
   const auto &step =
       getLatticeElementFor(programPoint, op.getStep())->getValue();
+  if (step.getDivisibility().empty()) {
+    auto definingOp = op.getStep().getDefiningOp();
+    if (definingOp) {
+      auto result = visit(getProgramPointAfter(definingOp));
+    }
+  }
 
   AxisInfo::DimVectorT knownContiguity(1, 1);
   AxisInfo::DimVectorT knownDivisibility(1, 1);

--- a/test/TritonGPU/coalesce.mlir
+++ b/test/TritonGPU/coalesce.mlir
@@ -213,3 +213,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_scf_for_after_if(%arg0: i32 {tt.divisibility = 16 : i32}, %arg1: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = arith.cmpi eq, %arg0, %arg1 : i32
+    %1 = scf.if %0 -> (i32) {
+      %3 = arith.addi %c0_i32, %c128_i32 : i32
+      scf.yield %3 : i32
+    } else {
+      scf.yield %c0_i32 : i32
+    }
+    %2 = scf.for %arg2 = %1 to %arg1 step %c128_i32 iter_args(%arg3 = %arg0) -> (i32)  : i32 {
+      scf.yield %arg3 : i32
+    }
+    tt.return
+  }
+}


### PR DESCRIPTION
For some reason if the result of an `scf.if` is used as induction var of `scf.for` without other usage in the middle, this result would not have any AxisInfo Lattice and `AxisInfoAnalysis::visitForOpInductionVar` will crash.

https://github.com/triton-lang/triton/blob/b58b65718348e3464328857588c5feb0b962d7c1/lib/Analysis/AxisInfo.cpp#L1100

```
const T& llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::operator[](llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::size_type) const [with T = long int; <template-parameter-1-2> = void; llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::const_reference = const long int&; llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::size_type = long unsigned int]: Assertion `idx < size()' failed.
```

Forcing a re-visit of the defining op of induction var or step var in this case seems to fix it, but it feels like there could be a better way to address it...

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
