### PR TITLE
[Build] Allow out-of-tree build with TRITON_BUILD_DIR (Rev.2)

### DIFF
--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -8,15 +8,10 @@ def get_base_dir():
     return os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 
-def _get_cmake_dir():
+def get_cmake_dir():
     plat_name = sysconfig.get_platform()
     python_version = sysconfig.get_python_version()
     dir_name = f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"
-    return Path(get_base_dir()) / "build" / dir_name
-
-
-def get_cmake_dir():
-    cmake_dir = os.getenv("TRITON_BUILD_DIR", default=_get_cmake_dir())
-    cmake_dir = Path(cmake_dir)
+    cmake_dir = Path(get_base_dir()) / "build" / dir_name
     cmake_dir.mkdir(parents=True, exist_ok=True)
     return cmake_dir

--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -9,7 +9,7 @@ def _get_base_dir() -> Path:
 
 
 def get_base_dir() -> str:
-    return _get_base_dir().as_posix()
+    return _get_base_dir().absolute().as_posix()
 
 
 def get_build_base() -> str:
@@ -25,4 +25,4 @@ def get_build_base() -> str:
 def get_cmake_dir(cmd, ext):
     cmake_dir = Path(cmd.build_temp) / ext.name
     cmake_dir.mkdir(parents=True, exist_ok=True)
-    return cmake_dir
+    return cmake_dir.absolute()

--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -4,14 +4,24 @@ import sys
 from pathlib import Path
 
 
-def get_base_dir():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+# base_dir: Root of source code
+
+def _get_base_dir() -> Path:
+    return Path(__file__).parent.parent
 
 
-def get_cmake_dir():
-    plat_name = sysconfig.get_platform()
-    python_version = sysconfig.get_python_version()
-    dir_name = f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"
-    cmake_dir = Path(get_base_dir()) / "build" / dir_name
+def get_base_dir() -> str:
+    return _get_base_dir().as_posix()
+
+
+def get_build_base() -> str:
+    build_base = os.getenv("TRITON_BUILD_DIR", default=(_get_base_dir() / "build"))
+    build_base = Path(build_base)
+    build_base.mkdir(parents=True, exist_ok=True)
+    return build_base.as_posix()
+
+
+def get_cmake_dir(cmd : 'setuptools.Command', ext : 'setuptools.Extension'):
+    cmake_dir = Path(cmd.build_temp) / ext.name
     cmake_dir.mkdir(parents=True, exist_ok=True)
     return cmake_dir

--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -1,10 +1,8 @@
 import os
-import sysconfig
-import sys
 from pathlib import Path
 
-
 # base_dir: Root of source code
+
 
 def _get_base_dir() -> Path:
     return Path(__file__).parent.parent
@@ -21,7 +19,10 @@ def get_build_base() -> str:
     return build_base.as_posix()
 
 
-def get_cmake_dir(cmd : 'setuptools.Command', ext : 'setuptools.Extension'):
+# cmd: setuptools.Command
+# ext: setuptools.Extension
+# Cannot use type hints due to ruff F821
+def get_cmake_dir(cmd, ext):
     cmake_dir = Path(cmd.build_temp) / ext.name
     cmake_dir.mkdir(parents=True, exist_ok=True)
     return cmake_dir

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,13 @@ from dataclasses import dataclass
 import pybind11
 
 try:
+    from setuptools.command.build import build
+except ImportError:
+    # Older setuptools does not have command.build
+    # https://github.com/pypa/setuptools/commit/b517cfae6b11c15834aa7aaf439bc45894a238f4
+    from distutils.command.build import build
+
+try:
     from setuptools.command.bdist_wheel import bdist_wheel
 except ImportError:
     from wheel.bdist_wheel import bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -824,7 +824,7 @@ setup(
     include_package_data=True,
     ext_modules=[CMakeExtension("triton", "triton/_C/")],
     cmdclass={
-        "build" : plugin_build,
+        "build": plugin_build,
         "bdist_wheel": plugin_bdist_wheel,
         "build_ext": CMakeBuild,
         "build_py": CMakeBuildPy,


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is a build system change.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Overview

This is a revised version of out-of-tree build with environment variable
`TRITON_BUILD_DIR`. The revise version sets `build.build_base` according to
`TRITON_BUILD_DIR`, which will be inherited by various variables defined in
other setuptool commands.

Fixes #7891

## Major Changes

* Relocate Triton CMake build directory to `self.build_temp / "triton"`
  - Consequently no need to customize  `CMakeClean.build_temp`
* Add custom build command which set `build.build_base` according to `TRITON_BUILD_DIR`

## Attempted but Failed Alternatives

### Remove `TRITON_BUILD_DIR` and using `--build-base` command line option

This is ideal solution which does not introduce project specific variables.
However, this is not supported by current `setuptools`: https://github.com/pypa/setuptools/issues/4732


