### PR TITLE
[FRONTEND] Tidy up visit_With and add new tests.

### DIFF
--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -22,6 +22,7 @@ from .runtime._async_compile import AsyncCompileMode, FutureKernel
 from .compiler import compile, CompilationError
 from .errors import TritonError
 from .runtime._allocation import set_allocator
+from .language import context_manager
 
 from . import language
 from . import testing
@@ -37,6 +38,7 @@ __all__ = [
     "compile",
     "Config",
     "constexpr_function",
+    "context_manager",
     "FutureKernel",
     "heuristics",
     "InterpreterError",

--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -65,6 +65,7 @@ from .core import (
     dot_scaled,
     dtype,
     expand_dims,
+    extern,
     float16,
     float32,
     float64,
@@ -338,3 +339,8 @@ def str_to_ty(name, c):
         "B": int1,
     }
     return tys[name]
+
+
+def context_manager(fn):
+    import contextlib
+    return extern(contextlib.contextmanager(fn))

--- a/third_party/proton/proton/language.py
+++ b/third_party/proton/proton/language.py
@@ -53,14 +53,10 @@ def exit_scope(name: tl.constexpr, _semantic=None):
     record(is_start=False, scope_name=name, semantic=_semantic)
 
 
-class scope:
+tl.context_manager
 
-    def __init__(self, name: str, _semantic=None):
-        self.name = name
-        self.semantic = _semantic
 
-    def __enter__(self):
-        enter_scope(self.name, _semantic=self.semantic)
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        exit_scope(self.name, _semantic=self.semantic)
+def scope(name: str, _semantic=None):
+    enter_scope(name, _semantic=_semantic)
+    yield
+    exit_scope(name, _semantic=_semantic)


### PR DESCRIPTION
This change tidies up the `visit_With` method of `CodeGenerator` to use more builtin functionality. New frontend tests have been added for this so it can be tested outside of `proton`.  Additionally there's a new `tl.context_manager` utility for converting a function to be a context manager.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)