### PR TITLE
[AMD] Update BufferOps Non-Negative Check to be in Bytes

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -251,10 +251,13 @@ bool canUseBufferOps(Value ptr,
   if (nonNegativeOffset) {
     if (const auto *r =
             solver->lookupState<dataflow::IntegerValueRangeLattice>(offset)) {
+      // Check for initialization because not all code uses the RangeAnalysis
+      // at this time.
+      // TODO: Remove!!!!
       if (r->getValue().isUninitialized())
-        return false;
+        return true;
       if (AMD::isEmptyInitializedRange(r->getValue().getValue()))
-        return false;
+        return true;
       const ConstantIntRanges &range = r->getValue().getValue();
       int64_t maxValue = range.smax().getSExtValue() * elementByteWidth;
       return maxValue >= 0 && maxValue <= std::numeric_limits<int32_t>::max();


### PR DESCRIPTION
The offset for BufferOps requires a non-negative offset in **bytes**. The current check just verifies the offset is non-negative.

This code can't be fully tested because there is still code that doesn't use the Range Analysis. This code should be removed in which case this code can be simplified and becomes universally correct.