### PR TITLE
[Backend] Move shared memory address space to `target info`

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -298,7 +298,8 @@ private:
     unsigned rank = srcShapePerCTA.size();
 
     auto llvmElemTy = typeConverter->convertType(dstTy.getElementType());
-    auto elemPtrTy = ptr_ty(rewriter.getContext(), 3);
+    auto elemPtrTy =
+        ptr_ty(rewriter.getContext(), targetInfo.getSharedAddressSpace());
 
     Value smemBase =
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -253,7 +253,8 @@ static void rewritePartitionRegions(WarpSpecializeOp ws, Block *switchLoop,
           /*isPacked=*/true);
       Value capturePtr =
           LLVM::getSharedMemoryBase(b.getLoc(), b, targetInfo, ws);
-      LLVM::LLVMPointerType ptrTy = ptr_ty(b.getContext(), 3);
+      LLVM::LLVMPointerType ptrTy =
+          ptr_ty(b.getContext(), targetInfo.getSharedAddressSpace());
       for (auto [i, arg] :
            llvm::zip(llvm::seq<int32_t>(partition->getNumArguments()),
                      partition->getArguments())) {
@@ -399,7 +400,7 @@ static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
   // for all warps.
   // %warp_state_ptr = getelementptr ptr %state_tr[%rel_wid]
   // %warp_state = load i8 %warp_state_ptr
-  LLVM::LLVMPointerType ptrTy = ptr_ty(ctx, 3);
+  LLVM::LLVMPointerType ptrTy = ptr_ty(ctx, targetInfo.getSharedAddressSpace());
   Value warpStatePtr = b.gep(ptrTy, i8_ty, statePtr, relWid);
   // All threads in a warp reading from the same smem address will not create
   // bank conflicts and is better than predicated load.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -78,11 +78,12 @@ void populateTCGen5MMAOpToLLVMPattern(LLVMTypeConverter &typeConverter,
 
 void populateTensorMemoryOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                          RewritePatternSet &patterns,
+                                         const TargetInfo &targetInfo,
                                          PatternBenefit benefit);
 
 void populateTensorMemorySubviewOpToLLVMPattern(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
-    PatternBenefit benefit);
+    const TargetInfo &targetInfo, PatternBenefit benefit);
 } // namespace NVIDIA
 } // namespace triton
 } // namespace mlir

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -184,7 +184,8 @@ void TargetInfo::storeDShared(RewriterBase &rewriter, Location loc, Value ptr,
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   MLIRContext *ctx = rewriter.getContext();
   auto ptrTy = cast<LLVM::LLVMPointerType>(ptr.getType());
-  assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
+  assert(ptrTy.getAddressSpace() == getSharedAddressSpace() &&
+         "Invalid addr space for load_dsmem");
 
   if (!isa<VectorType>(val.getType())) {
     storeDShared(rewriter, loc, ptr, ctaId, packLLVector(loc, {val}, rewriter),
@@ -303,7 +304,8 @@ Value TargetInfo::loadDShared(RewriterBase &rewriter, Location loc, Value ptr,
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   MLIRContext *ctx = rewriter.getContext();
   auto ptrTy = cast<LLVM::LLVMPointerType>(ptr.getType());
-  assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
+  assert(ptrTy.getAddressSpace() == getSharedAddressSpace() &&
+         "Invalid addr space for load_dsmem");
 
   if (!isa<VectorType>(loadTy)) {
     SmallVector<Value> values = unpackLLVector(

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -113,7 +113,8 @@ struct ConvertTritonGPUToLLVM
     mlir::triton::NVIDIA::populateConvertLayoutOpToLLVMPatterns(
         typeConverter, targetInfo, patterns, benefit);
     mlir::triton::NVIDIA::populateTensorMemorySubviewOpToLLVMPattern(
-        typeConverter, patterns, patternBenefitNvidiaTensorCoreSubviewPattern);
+        typeConverter, patterns, targetInfo,
+        patternBenefitNvidiaTensorCoreSubviewPattern);
     mlir::triton::NVIDIA::populateTMAToLLVMPatterns(typeConverter, targetInfo,
                                                     patterns, benefit);
     populateDotOpToLLVMPatterns(typeConverter, patterns, computeCapability,
@@ -162,7 +163,7 @@ struct ConvertTritonGPUToLLVM
     mlir::triton::NVIDIA::populateMemoryOpToLLVMPatterns(
         typeConverter, targetInfo, patterns, benefit);
     mlir::triton::NVIDIA::populateTensorMemoryOpToLLVMPattern(
-        typeConverter, patterns, benefit);
+        typeConverter, patterns, targetInfo, benefit);
     mlir::triton::populateMakeRangeOpToLLVMPattern(typeConverter, targetInfo,
                                                    patterns, benefit);
     mlir::triton::NVIDIA::populateTCGen5MMAOpToLLVMPattern(typeConverter,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -160,7 +160,7 @@ LogicalResult lowerLdStMatrix(
   auto kWarp = S("warp");
   auto kBlock = S("block");
   auto kOffset = S("offset");
-  auto smemPtrTy = ptr_ty(ctx, 3);
+  auto smemPtrTy = ptr_ty(ctx, targetInfo.getSharedAddressSpace());
   auto bitwidth = llvmElemTy.getIntOrFloatBitWidth();
   // In the transpose case, consecutive elements are not stored contiguously
   // so we cannot split an fp32


### PR DESCRIPTION
In order to modularize downstream backends.