### PR TITLE
Support 0-sized matmuls

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags_details/opt_flags_nvidia.py
@@ -47,6 +47,8 @@ def compute_block_k(m: int, k: int | None, is_persistent: bool, lhs_dtype, rhs_d
 def compute_split_k(block_k: int, k: int | None, grid_size: int) -> int:
     device_props = torch.cuda.get_device_properties(0)
     n_sms = device_props.multi_processor_count
+    if grid_size == 0:
+        return 1
     split_k = n_sms // grid_size
     if k is not None:
         # avoid split_k for small k


### PR DESCRIPTION
This allows to matrix-multiply tensors with 0 elements.

Example of current failure:
```python
>>> from triton_kernels.matmul_ogs import matmul_ogs_torch, matmul_ogs

>>> import torch
>>>
>>> x = torch.ones((5, 0, 7), device="cuda", dtype=torch.bfloat16)

>>> y = torch.ones((5, 7, 9), device="cuda", dtype=torch.bfloat16)
>>> b = torch.ones((5, 9), device="cuda", dtype=torch.bfloat16)
>>>
>>> matmul_ogs_torch(x, y, b, round_x=lambda x, _: x, round_y=lambda y: y)
tensor([], device='cuda:0', size=(5, 0, 9), dtype=torch.bfloat16)
>>>
>>> matmul_ogs(x, y, b)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/.pyenv/versions/3.12.9/lib/python3.12/site-packages/triton_kernels/matmul_ogs.py", line 446, in matmul_ogs
    opt_flags = make_opt_flags(out_dtype, x.dtype, w.dtype, precision_config,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.12.9/lib/python3.12/site-packages/triton_kernels/matmul_ogs_details/opt_flags.py", line 299, in make_opt_flags
    return make_default_opt_flags_nvidia(*args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.12.9/lib/python3.12/site-packages/triton_kernels/matmul_ogs_details/opt_flags.py", line 192, in make_default_opt_flags_nvidia
    split_k = opt_flags_nvidia.compute_split_k(block_k, k, estimated_actual_grid_size)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.12.9/lib/python3.12/site-packages/triton_kernels/matmul_ogs_details/opt_flags_details/opt_flags_nvidia.py", line 48, in compute_split_k
    split_k = n_sms // grid_size
              ~~~~~~^^~~~~~~~~~~
ZeroDivisionError: integer division or modulo by zero
```