### PR TITLE
[WS] reorder partition-loops and lower-aref

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
@@ -42,8 +42,9 @@ void AutomaticWarpSpecialization::runOnOperation() {
   // pm.addPass(arith::createIntRangeOptimizationsPass());
   pm.addPass(createSCCPPass());
   pm.addPass(createCSEPass());
-  pm.addPass(createTritonGPUPartitionLoops());
+  pm.addPass(createNVWSAssignStagePhase());
   pm.addPass(createNVWSLowerAref());
+  pm.addPass(createTritonGPUPartitionLoops());
   pm.addPass(createNVWSLowerWarpGroup());
   if (failed(runPipeline(pm, getOperation())))
     return signalPassFailure();

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -811,16 +811,7 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
     Value lastIndex = loop.getResult(index.getArgNumber() - 1);
     Value lastPhase = loop.getResult(phase.getArgNumber() - 1);
     Value lastBar = createSingleBufferView(b, nodes.back().barNext, lastIndex);
-    auto waitBarrierOp = b.create<ttng::WaitBarrierOp>(lastBar, lastPhase);
-    auto node_front = nodes.front();
-    auto partition = schedule.getPartition(inBody(node_front.op));
-    PartitionBuilder b(waitBarrierOp->getLoc(), waitBarrierOp);
-    lastBar.getDefiningOp()->setAttr(kWarpSpecializeTagAttrName,
-                                     b.getI32IntegerAttr(schedule.getTag()));
-    waitBarrierOp->setAttr(kWarpSpecializeTagAttrName,
-                           b.getI32IntegerAttr(schedule.getTag()));
-    b.assignPartition(lastBar.getDefiningOp(), *partition);
-    b.assignPartition(waitBarrierOp, *partition);
+    b.create<ttng::WaitBarrierOp>(lastBar, lastPhase);
   }
 
   llvm::SetVector<Operation *> predOps;

--- a/test/NVWS/assign_stage_phase.mlir
+++ b/test/NVWS/assign_stage_phase.mlir
@@ -1,0 +1,155 @@
+// RUN: triton-opt %s -split-input-file --allow-unregistered-dialect --nvws-assign-stage-phase  -canonicalize | FileCheck %s
+
+#shared0 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+  //CHECK-LABEL: @two_consumers
+  tt.func @two_consumers(%arg0: i32, %arg1: i32, %arg2: i32) {
+    // CHECK:   [[C3:%.*]] = arith.constant 3 : i32
+    // CHECK:   [[C1:%.*]] = arith.constant 1 : i32
+    // CHECK:   [[C2:%.*]] = arith.constant 2 : i32
+    // CHECK:   [[C0:%.*]] = arith.constant 0 : i32
+    %ub = arith.constant 4 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<3x1xi32, #shared, #smem, mutable>
+    // CHECK: [[AREF:%.*]] = nvws.aref.create
+    %1 = nvws.aref.create %0 : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>
+    // CHECK: [[IDX:%.*]]:6 = scf.for [[I:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[S0:%.*]] = [[C2]], [[P0:%.*]] = [[C0]], [[S1:%.*]] = [[C2]], [[P1:%.*]] = [[C1]], [[S2:%.*]] = [[C2]], [[P2:%.*]] = [[C1]])
+    scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
+      %2 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
+      // CHECK: op_a
+      // CHECK-NEXT: [[S0a:%.*]] = arith.addi [[S0]], [[C1]]
+      // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S0a]], [[C3]]
+      // CHECK-NEXT: [[S0b:%.*]] = arith.select [[CMP]], [[C0]], [[S0a]]
+      // CHECK-NEXT: [[P0a:%.*]] = arith.xori [[P0]], [[C1]]
+      // CHECK-NEXT: [[P0b:%.*]] = arith.select [[CMP]], [[P0a]], [[P0]]
+      // CHECK-NEXT: put.enter [[AREF]][[[S0b]], [[P0b]]]
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %2, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      // CHECK: put.exit [[AREF]][[[S0b]]]
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+
+      // CHECK-NEXT: [[S1a:%.*]] = arith.addi [[S1]], [[C1]]
+      // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S1a]], [[C3]]
+      // CHECK-NEXT: [[S1b:%.*]] = arith.select [[CMP]], [[C0]], [[S1a]]
+      // CHECK-NEXT: [[P1a:%.*]] = arith.xori [[P1]], [[C1]]
+      // CHECK-NEXT: [[P1b:%.*]] = arith.select [[CMP]], [[P1a]], [[P1]]
+      // CHECK-NEXT: {{.*}}, [[TOK1:%.*]] = nvws.aref.get.enter [[AREF]][[[S1b]], [[P1b]]] {ttg.partition = 1 : i32}
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %3 = ttg.local_load %buffers_0 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      // CHECK: get.exit [[AREF]][[[S1b]]], [[TOK1]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_b"(%3) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
+
+      // CHECK: op_b
+      // CHECK-NEXT: [[S2a:%.*]] = arith.addi [[S2]], [[C1]]
+      // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S2a]], [[C3]]
+      // CHECK-NEXT: [[S2b:%.*]] = arith.select [[CMP]], [[C0]], [[S2a]]
+      // CHECK-NEXT: [[P2a:%.*]] = arith.xori [[P2]], [[C1]]
+      // CHECK-NEXT: [[P2b:%.*]] = arith.select [[CMP]], [[P2a]], [[P2]]
+      // CHECK-NEXT: {{.*}}, [[TOK2:%.*]] = nvws.aref.get.enter [[AREF]][[[S2b]], [[P2b]]] {ttg.partition = 2 : i32}
+      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %4 = ttg.local_load %buffers_2 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      // CHECK: get.exit [[AREF]][[[S2b]]], [[TOK2]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_c"(%4) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      "op_d"(%4) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      // CHECK: op_c
+      // CHECK-NEXT: op_d
+      // CHECK-NEXT: yield [[S0b]], [[P0b]], [[S1b]], [[P1b]], [[S2b]], [[P2b]]
+
+    } {ttg.paArtition.stages = [0 : i32, 2 : i32, 2 : i32], ttg.warp_specialize.tag = 0 : i32}
+
+    ttg.local_dealloc %0 : !ttg.memdesc<3x1xi32, #shared, #smem, mutable>
+    tt.return
+  }
+
+}
+
+// -----
+
+#shared0 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  //CHECK-LABEL: @aref_lowering
+  tt.func @aref_lowering(%d : !ttg.memdesc<3x64x16xf16, #shared0, #smem>,
+                         %e : !ttg.memdesc<3x16x32xf16, #shared0, #smem>,
+                         %cond : i1) {
+    // CHECK:   [[C3:%.*]] = arith.constant 3 : i32
+    // CHECK:   [[C2:%.*]] = arith.constant 2 : i32
+    // CHECK:   [[C0:%.*]] = arith.constant 0 : i32
+    // CHECK:   [[C1:%.*]] = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %lb = arith.constant 0 : i32
+    %ub = arith.constant 4 : i32
+
+    // CHECK: [[AREF0:%.*]] = nvws.aref.create
+    // CHECK-NEXT: [[AREF1:%.*]] = nvws.aref.create
+    %aref0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+    %aref1 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
+    // CHECK: [[IDX:%.*]]:8 = scf.for [[I:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[S0:%.*]] = [[C2]], [[P0:%.*]] = [[C0]], [[S1:%.*]] = [[C2]], [[P1:%.*]] = [[C1]], [[S2:%.*]] = [[C2]], [[P2:%.*]] = [[C0]], [[S3:%.*]] = [[C2]], [[P3:%.*]] = [[C1]])
+    scf.for %i = %lb to %ub step %c1_i32 : i32{
+      // CHECK: [[S0a:%.*]] = arith.addi [[S0]], [[C1]]
+      // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S0a]], [[C3]]
+      // CHECK-NEXT: [[S0b:%.*]] = arith.select [[CMP]], [[C0]], [[S0a]]
+      // CHECK-NEXT: [[P0a:%.*]] = arith.xori [[P0]], [[C1]]
+      // CHECK-NEXT: [[P0b:%.*]] = arith.select [[CMP]], [[P0a]], [[P0]]
+      // CHECK-NEXT: put.enter [[AREF0]][[[S0b]], [[P0b]]]
+      %1:3 = nvws.aref.put.enter %aref0[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+      "op1"(%1#0) {ttg.partition = 0 : i32}: (!ttg.memdesc<64x16xf16, #shared0, #smem>) -> ()
+      "op2"(%1#1)  {ttg.partition = 0 : i32} : (!ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+      // CHECK: op2
+      // CHECK-NEXT: put.exit [[AREF0]][[[S0b]]]
+      nvws.aref.put.exit %aref0[%c0_i32], %1#2 [#nvws.async_op<tma_load>, #nvws.async_op<none>] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+
+
+      // CHECK-NEXT: [[S1a:%.*]] = arith.addi [[S1]], [[C1]]
+      // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S1a]], [[C3]]
+      // CHECK-NEXT: [[S1b:%.*]] = arith.select [[CMP]], [[C0]], [[S1a]]
+      // CHECK-NEXT: [[P1a:%.*]] = arith.xori [[P1]], [[C1]]
+      // CHECK-NEXT: [[P1b:%.*]] = arith.select [[CMP]], [[P1a]], [[P1]]
+      // CHECK-NEXT: {{.*}}, [[TOK1:%.*]] = nvws.aref.get.enter [[AREF0]][[[S1b]], [[P1b]]] {ttg.partition = 1 : i32}
+      %2:3 = nvws.aref.get.enter %aref0[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+      "op3"(%2#0, %2#1) {ttg.partition = 1 : i32}: (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+      // CHECK: op3
+      // CHECK-NEXT: get.exit [[AREF0]][[[S1b]]], [[TOK1]] [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32}
+      nvws.aref.get.exit %aref0[%c0_i32], %2#2 [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+      // CHECK: [[IDX1:%.*]]:4 = scf.if
+      scf.if %cond {
+        // CHECK-NEXT: [[S2a:%.*]] = arith.addi [[S2]], [[C1]]
+        // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S2a]], [[C3]]
+        // CHECK-NEXT: [[S2b:%.*]] = arith.select [[CMP]], [[C0]], [[S2a]]
+        // CHECK-NEXT: [[P2a:%.*]] = arith.xori [[P2]], [[C1]]
+        // CHECK-NEXT: [[P2b:%.*]] = arith.select [[CMP]], [[P2a]], [[P2]]
+        // CHECK-NEXT: {{.*}}, [[TOK2:%.*]] = nvws.aref.put.enter [[AREF1]][[[S2b]], [[P2b]]] {ttg.partition = 0 : i32}
+        // CHECK-NEXT: op4
+        // CHECK-NEXT: put.exit [[AREF1]][[[S2b]]]
+        %4:3 = nvws.aref.put.enter %aref1[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+        "op4"(%4#0, %4#1) {ttg.partition = 0 : i32} : (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+        nvws.aref.put.exit %aref1[%c0_i32], %4#2 [#nvws.async_op<none>] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+        // CHECK-NEXT: [[S3a:%.*]] = arith.addi [[S3]], [[C1]]
+        // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S3a]], [[C3]]
+        // CHECK-NEXT: [[S3b:%.*]] = arith.select [[CMP]], [[C0]], [[S3a]]
+        // CHECK-NEXT: [[P3a:%.*]] = arith.xori [[P3]], [[C1]]
+        // CHECK-NEXT: [[P3b:%.*]] = arith.select [[CMP]], [[P3a]], [[P3]]
+        // CHECK-NEXT: {{.*}}, [[TOK3:%.*]] = nvws.aref.get.enter [[AREF1]][[[S3b]], [[P3b]]] {ttg.partition = 1 : i32}
+        // CHECK-NEXT: op5
+        // CHECK-NEXT: get.exit [[AREF1]][[[S3b]]], [[TOK3]] [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32}
+        %5:3 = nvws.aref.get.enter %aref1[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+        "op5"(%5#0, %5#1) {ttg.partition = 1 : i32}: (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+        nvws.aref.get.exit %aref1[%c0_i32], %5#2 [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+        // CHECK-NEXT: yield [[S2b]], [[P2b]], [[S3b]], [[P3b]]
+      }
+      // CHECK-NEXT: } else {
+      // CHECK-NEXT: yield [[S2]], [[P2]], [[S3]], [[P3]]
+      // CHECK-NEXT: }
+      // CHECK: scf.yield [[S0b]], [[P0b]], [[S1b]], [[P1b]], [[IDX1]]#0, [[IDX1]]#1, [[IDX1]]#2, [[IDX1]]#3
+
+    } {ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -1,18 +1,20 @@
-// RUN: triton-opt %s -split-input-file --allow-unregistered-dialect --nvws-lower-aref | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allow-unregistered-dialect --nvws-lower-aref -canonicalize | FileCheck %s
 
-#shared0 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32} {
 
-  //CHECK-LABEL: @two_consumers
+  // CHECK-LABEL: @two_consumers
   tt.func @two_consumers(%arg0: i32, %arg1: i32, %arg2: i32) {
     %c0_i32 = arith.constant 0 : i32
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
-    %1 = nvws.aref.create %0 : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c3_i32 = arith.constant 3 : i32
     // CHECK: [[BUF:%.*]] = ttg.local_alloc
     // CHECK-NEXT: [[EMPTY:%.*]] = ttg.local_alloc
+    // CHECK-NEXT: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.init_barrier [[EMPTYSLICE]], 2
     // CHECK-NEXT: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
     // CHECK-NEXT: ttng.init_barrier [[EMPTYSLICE]], 2
     // CHECK-NEXT: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
@@ -22,545 +24,227 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     // CHECK-NEXT: ttng.init_barrier [[FULLSLICE]], 1
     // CHECK-NEXT: [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL]]
     // CHECK-NEXT: ttng.init_barrier [[FULLSLICE]], 1
-    nvws.warp_group
-    partition0 num_warps(4) {
-      scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-        %2 = "op_a"() : () -> tensor<1xi32, #blocked>
-        %3, %token3 = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 3 : i32}: <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        ttg.local_store %2, %3 : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>
-        // CHECK: op_a
-        // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
-        // CHECK-NEXT: ttng.wait_barrier [[EMPTYMBAR]], {{.*}} {loop.cluster = 1 : i32, loop.stage = 3 : i32}
-        // CHECK: local_store
-        // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
-        // CHECK-NEXT: ttng.arrive_barrier [[FULLMBAR]], 1 {loop.cluster = 1 : i32, loop.stage = 3 : i32}
-        nvws.aref.put.exit %1[%c0_i32], %token3 [#nvws.async_op<none>] {loop.cluster = 1 : i32, loop.stage = 3 : i32} : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      }
-      nvws.warp_group.yield
-    }
-    partition1 num_warps(4) {
-      scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-        // CHECK: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
-        // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], {{.*}} {loop.cluster = 2 : i32, loop.stage = 3 : i32}
-        // CHECK: [[VAL:%.*]] = ttg.local_load
-        // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
-        // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 2 : i32, loop.stage = 3 : i32}
-        // CHECK: "op_b"([[VAL]])
-        %2:2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 2 : i32, loop.stage = 3 : i32}: <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        %3 = ttg.local_load %2#0 : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked>
-        nvws.aref.get.exit %1[%c0_i32], %2#1 [#nvws.async_op<none>] {loop.cluster = 2 : i32, loop.stage = 3 : i32} : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        "op_b"(%3) : (tensor<1xi32, #blocked>) -> ()
-      }
-      nvws.warp_group.return
-    }
-    partition2 num_warps(4) {
-      scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-        // CHECK: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
-        // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], {{.*}} {loop.cluster = 3 : i32, loop.stage = 4 : i32}
-        // CHECK: [[VAL:%.*]] = ttg.local_load
-        // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
-        // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 3 : i32, loop.stage = 4 : i32}
-        // CHECK: "op_c"([[VAL]])
-        // CHECK: "op_d"([[VAL]])
-        %2:2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 3 : i32, loop.stage = 4 : i32}: <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        %3 = ttg.local_load %2#0 : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked>
-        nvws.aref.get.exit %1[%c0_i32], %2#1 [#nvws.async_op<none>] {loop.cluster = 3 : i32, loop.stage = 4 : i32} : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        "op_c"(%3) : (tensor<1xi32, #blocked>) -> ()
-        "op_d"(%3) : (tensor<1xi32, #blocked>) -> ()
-      }
-      nvws.warp_group.return
-    }
-    // CHECK: nvws.warp_group.return
-    // CHECK-NEXT: }
+    // CHECK-NEXT: [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL]]
+    // CHECK-NEXT: ttng.init_barrier [[FULLSLICE]], 1
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<3x1xi32, #shared, #smem, mutable>
+    %1 = nvws.aref.create %0 : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>
+    %2:6 = scf.for %arg3 = %arg0 to %arg1 step %arg2 iter_args(%arg4 = %c2_i32, %arg5 = %c0_i32, %arg6 = %c2_i32, %arg7 = %c1_i32, %arg8 = %c2_i32, %arg9 = %c1_i32) -> (i32, i32, i32, i32, i32, i32)  : i32 {
+      %3 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
+      %4 = arith.addi %arg4, %c1_i32 : i32
+      %5 = arith.cmpi eq, %4, %c3_i32 : i32
+      %6 = arith.select %5, %c0_i32, %4 : i32
+      %7 = arith.xori %arg5, %c1_i32 : i32
+      %8 = arith.select %5, %7, %arg5 : i32
+      // CHECK: op_a
+      // CHECK-NEXT: addi
+      // CHECK-NEXT: cmpi
+      // CHECK-NEXT: [[STAGE:%.*]] = arith.select
+      // CHECK-NEXT: xori
+      // CHECK-NEXT: [[PHASE:%.*]] = arith.select
+      // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]][[[STAGE]]]
+      // CHECK-NEXT: ttng.wait_barrier [[EMPTYMBAR]], [[PHASE]] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32}
+      // CHECK: local_store
+      // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]][[[STAGE]]]
+      // CHECK-NEXT: ttng.arrive_barrier [[FULLMBAR]], 1 {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32}
+      %buffers, %token = nvws.aref.put.enter %1[%6, %8] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %3, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      nvws.aref.put.exit %1[%6], %token [#nvws.async_op<none>] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      %9 = arith.addi %arg6, %c1_i32 : i32
+      %10 = arith.cmpi eq, %9, %c3_i32 : i32
+      %11 = arith.select %10, %c0_i32, %9 : i32
+      %12 = arith.xori %arg7, %c1_i32 : i32
+      %13 = arith.select %10, %12, %arg7 : i32
+
+      // CHECK: addi
+      // CHECK-NEXT: cmpi
+      // CHECK-NEXT: [[STAGE:%.*]] = arith.select
+      // CHECK-NEXT: xori
+      // CHECK-NEXT: [[PHASE:%.*]] = arith.select
+      // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]][[[STAGE]]]
+      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE]] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32}
+      // CHECK: local_load
+      // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]][[[STAGE]]]
+      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32}
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%11, %13] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %14 = ttg.local_load %buffers_0 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%11], %token_1 [#nvws.async_op<none>] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_b"(%14) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
+      %15 = arith.addi %arg8, %c1_i32 : i32
+      %16 = arith.cmpi eq, %15, %c3_i32 : i32
+      %17 = arith.select %16, %c0_i32, %15 : i32
+      %18 = arith.xori %arg9, %c1_i32 : i32
+      %19 = arith.select %16, %18, %arg9 : i32
+
+      // CHECK: addi
+      // CHECK-NEXT: cmpi
+      // CHECK-NEXT: [[STAGE:%.*]] = arith.select
+      // CHECK-NEXT: xori
+      // CHECK-NEXT: [[PHASE:%.*]] = arith.select
+      // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]][[[STAGE]]]
+      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE]] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32}
+      // CHECK: local_load
+      // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]][[[STAGE]]]
+      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32}
+      %buffers_2, %token_3 = nvws.aref.get.enter %1[%17, %19] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %20 = ttg.local_load %buffers_2 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%17], %token_3 [#nvws.async_op<none>] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_c"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      "op_d"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      scf.yield %6, %8, %11, %13, %17, %19 : i32, i32, i32, i32, i32, i32
+    } {ttg.partition.stages = [0 : i32, 2 : i32, 2 : i32], ttg.warp_specialize.tag = 0 : i32}
+    // CHECK: } {ttg.partition.stages =
+    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
+    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
+    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
+    // CHECK-NEXT: ttg.local_dealloc
+    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
+    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
     // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
     // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
     // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
     // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
     // CHECK-NEXT: ttg.local_dealloc
-    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
-    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
-    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
-    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
-    // CHECK-NEXT: ttg.local_dealloc
-    ttg.local_dealloc %0 : !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
+    ttg.local_dealloc %0 : !ttg.memdesc<3x1xi32, #shared, #smem, mutable>
     tt.return
   }
 
   //CHECK-LABEL: @three_consumers
   tt.func @three_consumers(%arg0: i32, %arg1: i32, %arg2: i32) {
     %c0_i32 = arith.constant 0 : i32
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
-    %1 = nvws.aref.create %0 : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>
+    %c2_i32 = arith.constant 2 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c3_i32 = arith.constant 3 : i32
     // CHECK: [[BUF:%.*]] = ttg.local_alloc
     // CHECK-NEXT: [[EMPTY:%.*]] = ttg.local_alloc
     // CHECK-NEXT: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
     // CHECK-NEXT: ttng.init_barrier [[EMPTYSLICE]], 3
-    // CHECK-NEXT: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
-    // CHECK-NEXT: ttng.init_barrier [[EMPTYSLICE]], 3
-    // CHECK-NEXT: [[FULL:%.*]] = ttg.local_alloc
+    // CHECK: [[FULL:%.*]] = ttg.local_alloc
     // CHECK-NEXT: [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL]]
     // CHECK-NEXT: ttng.init_barrier [[FULLSLICE]], 1
-    // CHECK-NEXT: [[FULLSLICE:%.*]] = ttg.memdesc_index [[FULL]]
-    // CHECK-NEXT: ttng.init_barrier [[FULLSLICE]], 1
-    nvws.warp_group
-    partition0 num_warps(4) {
-      scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-        %2 = "op_a"() : () -> tensor<1xi32, #blocked>
-        %3, %token3 = nvws.aref.put.enter %1[%c0_i32, %c0_i32] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        ttg.local_store %2, %3 : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>
-        // CHECK: op_a
-        // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
-        // CHECK-NEXT: ttng.wait_barrier [[EMPTYMBAR]]
-        // CHECK: local_store
-        // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
-        // CHECK-NEXT: ttng.arrive_barrier [[FULLMBAR]], 1
-        nvws.aref.put.exit %1[%c0_i32], %token3 [#nvws.async_op<none>] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      }
-      nvws.warp_group.yield
-    }
-    partition1 num_warps(4) {
-      scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-        // CHECK: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
-        // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]]
-        // CHECK: [[VAL:%.*]] = ttg.local_load
-        // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
-        // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1
-        // CHECK: "op_b"([[VAL]])
-        %2:2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        %3 = ttg.local_load %2#0 : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked>
-        nvws.aref.get.exit %1[%c0_i32], %2#1 [#nvws.async_op<none>] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        "op_b"(%3) : (tensor<1xi32, #blocked>) -> ()
-      }
-      nvws.warp_group.return
-    }
-    partition2 num_warps(4) {
-      scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-        // CHECK: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
-        // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]]
-        // CHECK: [[VAL:%.*]] = ttg.local_load
-        // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
-        // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1
-        // CHECK: "op_c"([[VAL]])
-        // CHECK: "op_d"([[VAL]])
-        %2:2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        %3 = ttg.local_load %2#0 : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked>
-        nvws.aref.get.exit %1[%c0_i32], %2#1 [#nvws.async_op<none>] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        "op_c"(%3) : (tensor<1xi32, #blocked>) -> ()
-        "op_d"(%3) : (tensor<1xi32, #blocked>) -> ()
-      }
-      nvws.warp_group.return
-    }
-    partition3 num_warps(4) {
-      scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-        // CHECK: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
-        // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]]
-        // CHECK: [[VAL:%.*]] = ttg.local_load
-        // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
-        // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1
-        // CHECK: "op_c"([[VAL]])
-        // CHECK: "op_d"([[VAL]])
-        %2:2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        %3 = ttg.local_load %2#0 : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked>
-        nvws.aref.get.exit %1[%c0_i32], %2#1 [#nvws.async_op<none>] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        "op_c"(%3) : (tensor<1xi32, #blocked>) -> ()
-        "op_d"(%3) : (tensor<1xi32, #blocked>) -> ()
-      }
-      nvws.warp_group.return
-    }
-    ttg.local_dealloc %0 : !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<3x1xi32, #shared, #smem, mutable>
+    %1 = nvws.aref.create %0 : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>
+    %2:8 = scf.for %arg3 = %arg0 to %arg1 step %arg2 iter_args(%arg4 = %c2_i32, %arg5 = %c0_i32, %arg6 = %c2_i32, %arg7 = %c1_i32, %arg8 = %c2_i32, %arg9 = %c1_i32, %arg10 = %c2_i32, %arg11 = %c1_i32) -> (i32, i32, i32, i32, i32, i32, i32, i32)  : i32 {
+      %3 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
+      %4 = arith.addi %arg4, %c1_i32 : i32
+      %5 = arith.cmpi eq, %4, %c3_i32 : i32
+      %6 = arith.select %5, %c0_i32, %4 : i32
+      %7 = arith.xori %arg5, %c1_i32 : i32
+      %8 = arith.select %5, %7, %arg5 : i32
+      %buffers, %token = nvws.aref.put.enter %1[%6, %8] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %3, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      nvws.aref.put.exit %1[%6], %token [#nvws.async_op<none>] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      %9 = arith.addi %arg6, %c1_i32 : i32
+      %10 = arith.cmpi eq, %9, %c3_i32 : i32
+      %11 = arith.select %10, %c0_i32, %9 : i32
+      %12 = arith.xori %arg7, %c1_i32 : i32
+      %13 = arith.select %10, %12, %arg7 : i32
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%11, %13] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %14 = ttg.local_load %buffers_0 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%11], %token_1 [#nvws.async_op<none>] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_b"(%14) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
+      %15 = arith.addi %arg8, %c1_i32 : i32
+      %16 = arith.cmpi eq, %15, %c3_i32 : i32
+      %17 = arith.select %16, %c0_i32, %15 : i32
+      %18 = arith.xori %arg9, %c1_i32 : i32
+      %19 = arith.select %16, %18, %arg9 : i32
+      %buffers_2, %token_3 = nvws.aref.get.enter %1[%17, %19] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %20 = ttg.local_load %buffers_2 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%17], %token_3 [#nvws.async_op<none>] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_c"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      "op_d"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      %21 = arith.addi %arg10, %c1_i32 : i32
+      %22 = arith.cmpi eq, %21, %c3_i32 : i32
+      %23 = arith.select %22, %c0_i32, %21 : i32
+      %24 = arith.xori %arg11, %c1_i32 : i32
+      %25 = arith.select %22, %24, %arg11 : i32
+      %buffers_4, %token_5 = nvws.aref.get.enter %1[%23, %25] {ttg.partition = 3 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %26 = ttg.local_load %buffers_4 {ttg.partition = 3 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%23], %token_5 [#nvws.async_op<none>] {ttg.partition = 3 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_e"(%26) {ttg.partition = 3 : i32} : (tensor<1xi32, #blocked>) -> ()
+      "op_f"(%26) {ttg.partition = 3 : i32} : (tensor<1xi32, #blocked>) -> ()
+      scf.yield %6, %8, %11, %13, %17, %19, %23, %25 : i32, i32, i32, i32, i32, i32, i32, i32
+    } {ttg.partition.stages = [0 : i32, 2 : i32, 2 : i32, 3 : i32], ttg.warp_specialize.tag = 0 : i32}
+    // CHECK: } {ttg.partition.stages =
+    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
+    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
+    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
+    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
+    // CHECK-NEXT: ttg.local_dealloc
+    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
+    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
+    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
+    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
+    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]]
+    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
+    // CHECK-NEXT: ttg.local_dealloc
+    ttg.local_dealloc %0 : !ttg.memdesc<3x1xi32, #shared, #smem, mutable>
     tt.return
   }
-}
 
-// -----
 
-#shared0 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  //CHECK-LABEL: @aref_lowering
-  tt.func @aref_lowering(%d : !ttg.memdesc<3x64x16xf16, #shared0, #smem>,
-                         %e : !ttg.memdesc<3x16x32xf16, #shared0, #smem>,
-                         %cond : i1) {
+  //CHECK-LABEL: @reuse_argument
+  tt.func @reuse_argument(%arg0: i32, %arg1: i32, %arg2: i32) {
+    %true = arith.constant true
+    %cst = arith.constant dense<1> : tensor<1xi32, #blocked>
+    %cst_0 = arith.constant dense<0> : tensor<1xi32, #blocked>
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
-    %lb = arith.constant 0 : i32
-    // CHECK:   [[C3:%.*]] = arith.constant 3 : i32
-    // CHECK:   [[C0:%.*]] = arith.constant 0 : i32
-    // CHECK:   [[C1:%.*]] = arith.constant 1 : i32
-    %ub = arith.constant 4 : i32
-
-    // CHECK:   [[EMPTY1:%.*]] = ttg.local_alloc
-    // CHECK:   init_barrier
-    // CHECK:   init_barrier
-    // CHECK:   init_barrier
-    // CHECK:   [[FULL1:%.*]] = ttg.local_alloc
-    // CHECK:   init_barrier
-    // CHECK:   init_barrier
-    // CHECK:   init_barrier
-    %aref0 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
-
-    // CHECK:   [[EMPTY0:%.*]] = ttg.local_alloc
-    // CHECK:   init_barrier
-    // CHECK:   init_barrier
-    // CHECK:   init_barrier
-    // CHECK:   [[FULL0:%.*]] = ttg.local_alloc
-    // CHECK:   init_barrier
-    // CHECK:   init_barrier
-    // CHECK:   init_barrier
-    %aref1 = nvws.aref.create %d, %e : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>
-
-    nvws.warp_group
-    partition0  num_warps(4) {
-      // CHECK: [[IDX:%.*]]:6 = scf.for [[I:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[C1:%.*]] iter_args([[S0:%.*]] = [[C0]], [[P0:%.*]] = [[C1]], [[S1:%.*]] = [[C0]], [[P1:%.*]] = [[C1]], [[S2:%.*]] = [[C0]],  [[S3:%.*]] = [[C0]])
-      scf.for %i = %lb to %ub step %c1_i32 : i32{
-
-        // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY0]]{{\[}}[[S0]]{{\]}}
-        // CHECK-NEXT: ttng.wait_barrier [[EMPTYMBAR]], [[P0]]
-        %1:3 = nvws.aref.put.enter %aref0[%c0_i32, %c0_i32] {aref_tag = "put0"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-
-        // CHECK-NEXT: [[BUFA:%.*]] = ttg.memdesc_index %arg0{{\[}}[[S0]]{{\]}}
-        // CHECK-NEXT: [[BUFB:%.*]] = ttg.memdesc_index %arg1{{\[}}[[S0]]{{\]}}
-        // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL0]]{{\[}}[[S2]]{{\]}}
-        // CHECK-NEXT: ttng.barrier_expect [[FULLMBAR]], 0
-        // CHECK-NEXT: [[S0a:%.*]] = arith.addi [[S0]], [[C1]]
-        // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S0a]], [[C3]]
-        // CHECK-NEXT: [[S0b:%.*]] = arith.select [[CMP]], [[C0]], [[S0a]]
-        // CHECK-NEXT: [[P0a:%.*]] = arith.xori [[P0]], [[C1]]
-        // CHECK-NEXT: [[P0b:%.*]] = arith.select [[CMP]], [[P0a]], [[P0]]
-        // CHECK-NEXT: "tma_load"([[BUFA]])
-        // CHECK-NEXT: "sts"([[BUFB]])
-        "tma_load"(%1#0) : (!ttg.memdesc<64x16xf16, #shared0, #smem>) -> ()
-        "sts"(%1#1) : (!ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-
-        // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL0]]{{\[}}[[S2]]{{\]}}
-        // CHECK-NEXT: ttng.arrive_barrier [[FULLMBAR]], 1
-        // CHECK-NEXT: [[S2a:%.*]] = arith.addi [[S2]], [[C1]]
-        // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S2a]], [[C3]]
-        // CHECK-NEXT: [[S2b:%.*]] = arith.select [[CMP]], [[C0]], [[S2a]]
-        nvws.aref.put.exit %aref0[%c0_i32], %1#2 [#nvws.async_op<tma_load>, #nvws.async_op<none>] {aref_tag = "put0"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
-
-        // CHECK-NEXT: [[SP1S3:%.*]]:3 = scf.if
-        scf.if %cond {
-
-          // CHECK-NEXT: [[BAR:%.*]] = ttg.memdesc_index {{.*}}{{\[}}[[S1]]{{\]}}
-          // CHECK-NEXT: ttng.wait_barrier [[BAR]], [[P1]]
-          // CHECK: [[S1a:%.*]] = arith.addi [[S1]], [[C1]]
-          // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S1a]], [[C3]]
-          // CHECK-NEXT: [[S1b:%.*]] = arith.select [[CMP]], [[C0]], [[S1a]]
-          // CHECK-NEXT: [[P1a:%.*]] = arith.xori [[P1]], [[C1]]
-          // CHECK-NEXT: [[P1b:%.*]] = arith.select [[CMP]], [[P1a]], [[P1]]
-
-          %2:3 = nvws.aref.put.enter %aref1[%c0_i32, %c0_i32] {aref_tag = "put1"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-          "tmem_store"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-
-          // CHECK: [[BAR:%.*]] = ttg.memdesc_index {{.*}}{{\[}}[[S3]]{{\]}}
-          // CHECK-NEXT: ttng.arrive_barrier [[BAR]], 1
-          // CHECK: [[S3a:%.*]] = arith.addi [[S3]], [[C1]]
-          // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S3a]], [[C3]]
-          // CHECK-NEXT: [[S3b:%.*]] = arith.select [[CMP]], [[C0]], [[S3a]]
-          nvws.aref.put.exit %aref1[%c0_i32], %2#2 [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
-
-          // CHECK: scf.yield [[S1b]], [[P1b]], [[S3b]]
-        }
-        // CHECK-NEXT: } else {
-        // CHECK-NEXT:   scf.yield [[S1]], [[P1]], [[S3]]
-        // CHECK-NEXT: }
-
-        // CHECK: scf.yield [[S0b]], [[P0b]], [[SP1S3]]#0, [[SP1S3]]#1, [[S2b]], [[SP1S3]]#2
-        // CHECK-NEXT: }
-      }
-
-      // CHECK-NEXT: [[IDX1:%.*]]:3 = scf.if
-      scf.if %cond {
-
-        // CHECK-NEXT: [[BAR:%.*]] = ttg.memdesc_index {{.*}}{{\[}}[[IDX]]#0{{\]}}
-        // CHECK-NEXT: ttng.wait_barrier [[BAR]], [[IDX]]#1
-        %1:3 = nvws.aref.put.enter %aref0[%c0_i32, %c0_i32] {aref_tag = "put1"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-        "tma_load"(%1#0) : (!ttg.memdesc<64x16xf16, #shared0, #smem>) -> ()
-        "sts"(%1#1) : (!ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-        //CHECK: sts
-
-        // CHECK: [[BAR:%.*]] = ttg.memdesc_index {{.*}}{{\[}}[[IDX]]#4{{\]}}
-        // CHECK-NEXT: ttng.arrive_barrier [[BAR]]
-        nvws.aref.put.exit %aref0[%c0_i32], %1#2 [#nvws.async_op<tma_load>, #nvws.async_op<none>] {aref_tag = "put1"} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
-      }
-
-      // CHECK: [[BAR:%.*]] = ttg.memdesc_index {{.*}}{{\[}}[[IDX]]#2{{\]}}
-      // CHECK-NEXT: ttng.wait_barrier [[BAR]], [[IDX]]#3
-      %1:3 = nvws.aref.put.enter %aref1[%c0_i32, %c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-      "tmem_store"(%1#0, %1#1) : (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-      // CHECK: [[BAR:%.*]] = ttg.memdesc_index {{.*}}{{\[}}[[IDX]]#5{{\]}}
-      // CHECK-NEXT: ttng.arrive_barrier [[BAR]], 1
-      nvws.aref.put.exit %aref1[%c0_i32], %1#2 [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
-      nvws.warp_group.return
-    }
-    partition1 num_warps(8) {
-      // CHECK: [[IDX:%.*]]:6 = scf.for [[I:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[C1:%.*]] iter_args([[S0:%.*]] = [[C0]], [[P0:%.*]] = [[C0]], [[S1:%.*]] = [[C0]], [[P1:%.*]] = [[C0]], [[S2:%.*]] = [[C0]], [[S3:%.*]] = [[C0]])
-      scf.for %i = %lb to %ub step %c1_i32 : i32{
-
-        // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL0]]{{\[}}[[S0]]{{\]}}
-        // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[P0]]
-        %2:3 = nvws.aref.get.enter %aref0[%c0_i32, %c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-
-        // CHECK-NEXT: [[BUFA:%.*]] = ttg.memdesc_index %arg0{{\[}}[[S0]]{{\]}}
-        // CHECK-NEXT: [[BUFB:%.*]] = ttg.memdesc_index %arg1{{\[}}[[S0]]{{\]}}
-        // CHECK-NEXT: arith.addi
-        // CHECK-NEXT: arith.cmpi
-        // CHECK-NEXT: arith.select
-        // CHECK-NEXT: arith.xori
-        // CHECK-NEXT: arith.select
-        // CHECK-NEXT: "tc5mma"([[BUFA]], [[BUFB]])
-        "tc5mma"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-
-        // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY0]]{{\[}}[[S2]]{{\]}}
-        // CHECK-NEXT: ttng.tc_gen5_commit [[EMPTYMBAR]]
-        // CHECK-NEXT: arith.addi
-        // CHECK-NEXT: arith.cmpi
-        // CHECK-NEXT: arith.select
-        // CHECK-NOT: arith.xori
-        // CHECK-NOT: arith.select
-        nvws.aref.get.exit %aref0[%c0_i32], %2#2 [#nvws.async_op<tc5mma>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
-
-        // CHECK: [[IDX13:%.*]]:3 = scf.if
-        scf.if %cond {
-          // CHECK: [[BAR:%.*]] = ttg.memdesc_index {{.*}}{{\[}}[[S1]]{{\]}}
-          // CHECK-NEXT: ttng.wait_barrier  [[BAR]], [[P1]]
-          %3:3 = nvws.aref.get.enter %aref1[%c0_i32, %c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-          "tmem_load"(%3#0, %3#1) : (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-          // CHECK: tmem_load
-
-          // CHECK-NEXT: [[BAR:%.*]] = ttg.memdesc_index {{.*}}{{\[}}[[S3]]{{\]}}
-          // CHECK-NEXT: ttng.arrive_barrier [[BAR]], 1
-          nvws.aref.get.exit %aref1[%c0_i32], %3#2 [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
-        }
-        // CHECK: } else {
-        // CHECK-NEXT:   scf.yield [[S1]], [[P1]], [[S3]]
-        // CHECK-NEXT: }
-
-        // CHECK: scf.yield {{.*}}, {{.*}}, [[IDX13]]#0, [[IDX13]]#1, {{.*}}, [[IDX13]]#2
-      }
-      scf.if %cond {
-        // CHECK: [[BAR:%.*]] = ttg.memdesc_index {{.*}}{{\[}}[[IDX]]#0{{\]}}
-        // CHECK-NEXT: ttng.wait_barrier  [[BAR]], [[IDX]]#1
-        %2:3 = nvws.aref.get.enter %aref0[%c0_i32, %c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-        "tc5mma"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-
-        // CHECK: [[BAR:%.*]] = ttg.memdesc_index {{.*}}{{\[}}[[IDX]]#4{{\]}}
-        // CHECK-NEXT: ttng.tc_gen5_commit  [[BAR]]
-        nvws.aref.get.exit %aref0[%c0_i32], %2#2 [#nvws.async_op<tc5mma>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
-      }
-      // CHECK: } else {
-      // CHECK-NEXT:   scf.yield [[IDX]]#0, [[IDX]]#1, [[IDX]]#4
-      // CHECK-NEXT: }
-
-      %2:3 = nvws.aref.get.enter %aref1[%c0_i32, %c0_i32] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-      "tmem_load"(%2#0, %2#1) : (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-      nvws.aref.get.exit %aref1[%c0_i32], %2#2 [#nvws.async_op<none>] : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
-      nvws.warp_group.return
-    }
-    // CHECK: warp_group.return
-    // CHECK-NEXT: }
-    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL0]]
-    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
-    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL0]]
-    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
-    // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL0]]
-    // CHECK-NEXT: ttng.inval_barrier [[FULLMBAR]]
-    // CHECK-NEXT: ttg.local_dealloc
-    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY0]]
-    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
-    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY0]]
-    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
-    // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY0]]
-    // CHECK-NEXT: ttng.inval_barrier [[EMPTYMBAR]]
-    // CHECK-NEXT: ttg.local_dealloc
-    tt.return
-  }
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-warps" = 4 : i32} {
-  //CHECK-LABEL: @complex_case
-  tt.func @complex_case(%arg0: i32, %arg1: i32, %arg2: i32) {
-    %c0_i32 = arith.constant 0 : i32
-    %cst = arith.constant dense<0> : tensor<1xi32, #blocked>
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
-    %1 = nvws.aref.create %0 : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>
-    %2 = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
-    %3 = nvws.aref.create %2 : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>
-    // CHECK: ttg.local_alloc
-    // CHECK-NEXT: ttg.local_alloc
-    // CHECK-NEXT: [[EMPTY2:%.*]] = ttg.local_alloc
-    // CHECK-NEXT: memdesc_index
-    // CHECK-NEXT: init_barrier
-    // CHECK-NEXT: memdesc_index
-    // CHECK-NEXT: init_barrier
-    // CHECK-NEXT: [[FULL2:%.*]] = ttg.local_alloc
-    // CHECK-NEXT: memdesc_index
-    // CHECK-NEXT: init_barrier
-    // CHECK-NEXT: memdesc_index
-    // CHECK-NEXT: init_barrier
-
-    // CHECK-NEXT: [[EMPTY1:%.*]] = ttg.local_alloc
-    // CHECK-NEXT: memdesc_index
-    // CHECK-NEXT: init_barrier
-    // CHECK-NEXT: memdesc_index
-    // CHECK-NEXT: init_barrier
-    // CHECK-NEXT: [[FULL1:%.*]] = ttg.local_alloc
-    // CHECK-NEXT: memdesc_index
-    // CHECK-NEXT: init_barrier
-    // CHECK-NEXT: memdesc_index
-    // CHECK-NEXT: init_barrier
-    nvws.warp_group
-    partition0 num_warps(4) {
-      %5:2 = scf.for %arg3 = %arg0 to %arg1 step %arg2 iter_args(%arg4 = %cst, %arg5 = %cst) -> (tensor<1xi32, #blocked>, tensor<1xi32, #blocked>)  : i32 {
-        // CHECK: [[EMPTYBAR2:%.*]] = ttg.memdesc_index [[EMPTY2]]
-        // CHECK-NEXT: ttng.wait_barrier [[EMPTYBAR2]]
-        // CHECK: local_store
-        // CHECK-NEXT: [[FULLBAR2:%.*]] = ttg.memdesc_index [[FULL2]]
-        // CHECK-NEXT: ttng.arrive_barrier [[FULLBAR2]], 1
-        %6, %token6 = nvws.aref.put.enter %3[%c0_i32, %c0_i32] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        ttg.local_store %arg5, %6 : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>
-        nvws.aref.put.exit %3[%c0_i32], %token6 [#nvws.async_op<none>] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        %7, %token7 = nvws.aref.put.enter %1[%c0_i32, %c0_i32] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        // CHECK: [[EMPTYBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
-        // CHECK-NEXT: ttng.wait_barrier [[EMPTYBAR1]]
-        // CHECK: local_store
-        // CHECK-NEXT: [[FULLBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
-        // CHECK-NEXT: ttng.arrive_barrier [[FULLBAR1]], 1
-        ttg.local_store %arg4, %7 : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>
-        nvws.aref.put.exit %1[%c0_i32], %token7 [#nvws.async_op<none>] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        %8 = "op_a"() : () -> tensor<1xi32, #blocked>
-        scf.yield %8, %arg4 : tensor<1xi32, #blocked>, tensor<1xi32, #blocked>
-      }
-      nvws.warp_group.yield %5#0, %5#1 : tensor<1xi32, #blocked>, tensor<1xi32, #blocked>
-    }
-    partition1 num_warps(4) {
-      scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-        // CHECK: [[FULLBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
-        // CHECK-NEXT: ttng.wait_barrier [[FULLBAR1]]
-        // CHECK: [[VAL:%.*]] = ttg.local_load
-        // CHECK-NEXT: [[EMPTYBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
-        // CHECK-NEXT: ttng.arrive_barrier [[EMPTYBAR1]], 1
-        // CHECK: "op_b"([[VAL]])
-        %5:2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        %6 = ttg.local_load %5#0 : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked>
-        nvws.aref.get.exit %1[%c0_i32], %5#1 [#nvws.async_op<none>] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        "op_b"(%6) : (tensor<1xi32, #blocked>) -> ()
-        // CHECK: [[FULLBAR2:%.*]] = ttg.memdesc_index [[FULL2]]
-        // CHECK-NEXT: ttng.wait_barrier [[FULLBAR2]]
-        // CHECK: [[VAL:%.*]] = ttg.local_load
-        // CHECK-NEXT: [[EMPTYBAR2:%.*]] = ttg.memdesc_index [[EMPTY2]]
-        // CHECK-NEXT: ttng.arrive_barrier [[EMPTYBAR2]], 1
-        // CHECK: "op_d"([[VAL]])
-        %7:2 = nvws.aref.get.enter %3[%c0_i32, %c0_i32] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        %8 = ttg.local_load %7#0 : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked>
-        nvws.aref.get.exit %3[%c0_i32], %7#1 [#nvws.async_op<none>] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        "op_d"(%8) : (tensor<1xi32, #blocked>) -> ()
-      }
-      nvws.warp_group.return
-    }
-    partition2 num_warps(4) {
-      scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-        // CHECK: [[FULLBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
-        // CHECK-NEXT: ttng.wait_barrier [[FULLBAR1]]
-        // CHECK: [[VAL:%.*]] = ttg.local_load
-        // CHECK-NEXT: [[EMPTYBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
-        // CHECK-NEXT: ttng.arrive_barrier [[EMPTYBAR1]], 1
-        // CHECK: "op_c"([[VAL]])
-        // CHECK-NEXT: "op_c"([[VAL]])
-        %5:2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        %6 = ttg.local_load %5#0 : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked>
-        nvws.aref.get.exit %1[%c0_i32], %5#1 [#nvws.async_op<none>] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        "op_c"(%6) : (tensor<1xi32, #blocked>) -> ()
-        "op_c"(%6) : (tensor<1xi32, #blocked>) -> ()
-        // CHECK: [[FULLBAR2:%.*]] = ttg.memdesc_index [[FULL2]]
-        // CHECK-NEXT: ttng.wait_barrier [[FULLBAR2]]
-        // CHECK: [[VAL:%.*]] = ttg.local_load
-        // CHECK-NEXT: [[EMPTYBAR2:%.*]] = ttg.memdesc_index [[EMPTY2]]
-        // CHECK-NEXT: ttng.arrive_barrier [[EMPTYBAR2]], 1
-        // CHECK: "op_d"([[VAL]])
-        %7:2 = nvws.aref.get.enter %3[%c0_i32, %c0_i32] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        %8 = ttg.local_load %7#0 : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked>
-        nvws.aref.get.exit %3[%c0_i32], %7#1 [#nvws.async_op<none>] : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        "op_d"(%8) : (tensor<1xi32, #blocked>) -> ()
-      }
-      nvws.warp_group.return
-    }
-    ttg.local_dealloc %2 : !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
-    ttg.local_dealloc %0 : !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
-    tt.return
-  }
-}
-
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-warps" = 4 : i32} {
-  tt.func @reuse_argument(%arg0: i32, %arg1: i32, %arg2: i32) {
-    %c0_i32 = arith.constant 0 : i32
-    %cst = arith.constant dense<0> : tensor<1xi32, #blocked>
-    %cst_0 = arith.constant dense<1> : tensor<1xi32, #blocked>
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
-    %1 = nvws.aref.create %0 : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>
     // CHECK: ttg.local_alloc
     // CHECK: [[EMPTY1:%.*]] = ttg.local_alloc
     // CHECK: [[FULL1:%.*]] = ttg.local_alloc
-    nvws.warp_group
-    partition0 num_warps(4) {
-      %2:2 = scf.for %arg3 = %arg0 to %arg1 step %arg2 iter_args(%arg4 = %cst, %arg5 = %cst_0) -> (tensor<1xi32, #blocked>, tensor<1xi32, #blocked>)  : i32 {
-        // CHECK: [[EMPTYBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
-        // CHECK-NEXT: ttng.wait_barrier [[EMPTYBAR1]]
-        // CHECK: local_store
-        // CHECK-NEXT: [[FULLBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
-        // CHECK-NEXT: ttng.arrive_barrier [[FULLBAR1]], 1
-        // CHECK: op_a
-        %3, %token3 = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        ttg.local_store %arg5, %3 {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>
-        nvws.aref.put.exit %1[%c0_i32], %token3 [#nvws.async_op<none>] {ttg.partition = 0 : i32} : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        %4 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
-        scf.yield %4, %arg4 : tensor<1xi32, #blocked>, tensor<1xi32, #blocked>
-      } {ttg.partition.stages = [1 : i32, 0 : i32, 0 : i32]}
-      nvws.warp_group.yield %2#0, %2#1 : tensor<1xi32, #blocked>, tensor<1xi32, #blocked>
-    }
-    partition1 num_warps(4) {
-      scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-        // CHECK: [[FULLBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
-        // CHECK-NEXT: ttng.wait_barrier [[FULLBAR1]]
-        // CHECK: [[VAL:%.*]] = ttg.local_load
-        // CHECK-NEXT: [[EMPTYBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
-        // CHECK-NEXT: ttng.arrive_barrier [[EMPTYBAR1]], 1
-        // CHECK: "op_d"([[VAL]])
-        %5:2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        %6 = ttg.local_load %5#0 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked>
-        nvws.aref.get.exit %1[%c0_i32], %5#1 [#nvws.async_op<none>] {ttg.partition = 1 : i32} : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        "op_d"(%6) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
-      } {ttg.partition.stages = [1 : i32, 0 : i32, 0 : i32]}
-      nvws.warp_group.return
-    }
-    partition2 num_warps(4) {
-      scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-        // CHECK: [[FULLBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
-        // CHECK-NEXT: ttng.wait_barrier [[FULLBAR1]]
-        // CHECK: [[VAL:%.*]] = ttg.local_load
-        // CHECK-NEXT: [[EMPTYBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
-        // CHECK-NEXT: ttng.arrive_barrier [[EMPTYBAR1]], 1
-        // CHECK: "op_d"([[VAL]])
-        %7:2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 2 : i32} : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1>, !ttg.async.token
-        %8 = ttg.local_load %7#0 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked>
-        nvws.aref.get.exit %1[%c0_i32], %7#1 [#nvws.async_op<none>] {ttg.partition = 2 : i32} : <[!ttg.memdesc<2x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-        "op_d"(%8) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
-      } {ttg.partition.stages = [1 : i32, 0 : i32, 0 : i32]}
-      nvws.warp_group.return
-    }
-    ttg.local_dealloc %0 : !ttg.memdesc<2x1xi32, #shared, #smem, mutable>
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<1x1xi32, #shared, #smem, mutable>
+    %1 = nvws.aref.create %0 : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>
+    // CHECK: [[IDX:%.*]]:5 = scf.for
+    %2:8 = scf.for %arg3 = %arg0 to %arg1 step %arg2 iter_args(%arg4 = %cst_0, %arg5 = %cst, %arg6 = %c0_i32, %arg7 = %c0_i32, %arg8 = %c0_i32, %arg9 = %c1_i32, %arg10 = %c0_i32, %arg11 = %c1_i32) -> (tensor<1xi32, #blocked>, tensor<1xi32, #blocked>, i32, i32, i32, i32, i32, i32)  : i32 {
+      %3 = arith.xori %arg7, %c1_i32 : i32
+      %4 = arith.select %true, %3, %arg7 : i32
+      // CHECK-NEXT: [[PHASE:%.*]] = arith.xori
+      // CHECK: [[EMPTYBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
+      // CHECK-NEXT: ttng.wait_barrier [[EMPTYBAR1]], [[PHASE]]
+      // CHECK: local_store
+      // CHECK-NEXT: [[FULLBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
+      // CHECK-NEXT: ttng.arrive_barrier [[FULLBAR1]], 1
+      // CHECK: op_a
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %4] {ttg.partition = 0 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %arg5, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = 0 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      %5 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
+
+      // CHECK-NEXT: [[PHASE:%.*]] = arith.xori
+      // CHECK: [[FULLMBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
+      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR1]], [[PHASE]]
+      // CHECK: local_load
+      // CHECK-NEXT: [[EMPTYMBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
+      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR1]], 1
+      // CHECK: op_d
+      %6 = arith.xori %arg9, %c1_i32 : i32
+      %7 = arith.select %true, %6, %arg9 : i32
+      %buffers_1, %token_2 = nvws.aref.get.enter %1[%c0_i32, %7] {ttg.partition = 1 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %8 = ttg.local_load %buffers_1 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_2 [#nvws.async_op<none>] {ttg.partition = 1 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_d"(%8) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
+
+      // CHECK-NEXT: [[PHASE:%.*]] = arith.xori
+      // CHECK: [[FULLMBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
+      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR1]], [[PHASE]]
+      // CHECK: local_load
+      // CHECK-NEXT: [[EMPTYMBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
+      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR1]], 1
+      // CHECK: op_d
+      %9 = arith.xori %arg11, %c1_i32 : i32
+      %10 = arith.select %true, %9, %arg11 : i32
+      %buffers_3, %token_4 = nvws.aref.get.enter %1[%c0_i32, %10] {ttg.partition = 2 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %11 = ttg.local_load %buffers_3 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_4 [#nvws.async_op<none>] {ttg.partition = 2 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_d"(%11) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      scf.yield %5, %arg4, %c0_i32, %4, %c0_i32, %7, %c0_i32, %10 : tensor<1xi32, #blocked>, tensor<1xi32, #blocked>, i32, i32, i32, i32, i32, i32
+    } {ttg.partition.stages = [1 : i32, 0 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
+    ttg.local_dealloc %0 : !ttg.memdesc<1x1xi32, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/load-mma-specialization.mlir
+++ b/test/TritonGPU/load-mma-specialization.mlir
@@ -132,8 +132,7 @@ tt.func @warp_specialize_tma_matmul(
   // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32
   } {tt.warp_specialize, tt.num_stages = 2 : i32}
 
-  // CHECK-NEXT: [[DONE_MBAR0a:%.*]] = ttg.memdesc_index [[DONE_MBAR]]{{\[}}[[C0]]{{\]}} {ttg.partition = 1 : i32, ttg.warp_specialize.tag = 0 : i32}
-  // CHECK-NEXT: ttng.wait_barrier [[DONE_MBAR0a]], %c0_i32 {ttg.partition = 1 : i32, ttg.warp_specialize.tag = 0 : i32}
+  // CHECK-NEXT: ttng.wait_barrier [[DONE_MBAR0]], %c0_i32
   // CHECK-NEXT: ttng.inval_barrier [[DONE_MBAR0]]
   // CHECK-NEXT: ttg.local_dealloc [[DONE_MBAR]]
 
@@ -195,8 +194,7 @@ tt.func @unsupported_load() {
   // CHECK: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 1 : i32
   } {tt.warp_specialize}
 
-  // CHECK-NEXT: [[DONE_MBAR0a:%.*]] = ttg.memdesc_index [[DONE_MBAR]]{{\[}}[[C0]]{{\]}} {ttg.partition = 1 : i32, ttg.warp_specialize.tag = 1 : i32}
-  // CHECK-NEXT: ttng.wait_barrier [[DONE_MBAR0a]], %c0_i32 {ttg.partition = 1 : i32, ttg.warp_specialize.tag = 1 : i32}
+  // CHECK-NEXT: ttng.wait_barrier [[DONE_MBAR0]], %c0_i32
   // CHECK-NEXT: ttng.inval_barrier [[DONE_MBAR0]]
   // CHECK-NEXT: ttg.local_dealloc [[DONE_MBAR]]
 
@@ -1575,8 +1573,7 @@ tt.func public @attention_forward(
   // CHECK-NEXT: ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32
   } {tt.warp_specialize}
 
-  // CHECK-NEXT: [[PV_READY_BAR0a:%.*]] = ttg.memdesc_index [[PV_READY_MBARS]]{{\[}}%c0_i32{{\]}} {ttg.partition = 3 : i32, ttg.warp_specialize.tag = 0 : i32}
-  // CHECK-NEXT: wait_barrier [[PV_READY_BAR0a]], [[OUTS]]#9 {ttg.partition = 3 : i32, ttg.warp_specialize.tag = 0 : i32}
+  // CHECK-NEXT: wait_barrier [[PV_READY_BAR0]], [[OUTS]]#9
 
   "use"(%loop_outs#0, %loop_outs#1, %loop_outs#2) : (tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<256x64xf32, #blocked>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>) -> ()
 

--- a/third_party/nvidia/include/Dialect/NVWS/Transforms/Passes.td
+++ b/third_party/nvidia/include/Dialect/NVWS/Transforms/Passes.td
@@ -43,6 +43,23 @@ def NVWSLowerWarpGroup : Pass<"nvws-lower-warp-group", "mlir::ModuleOp"> {
   ];
 }
 
+def NVWSAssignStagePhase : Pass<"nvws-assign-stage-phase", "mlir::ModuleOp"> {
+  let summary = "Assign buffer stage to nvws.aref.*.";
+
+  let description = [{
+    Assign buffer stage & phase to nvws.aref.*
+
+    The pass will assign buffer stage to each aref op, and phase for enter ops.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::nvws::NVWSDialect",
+    "mlir::triton::TritonDialect",
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+}
+
 def NVWSLowerAref : Pass<"nvws-lower-aref", "mlir::ModuleOp"> {
   let summary = "Convert nvws.aref.* to ttng.*barrier* ops.";
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2025 NVIDIA Corporation & Affiliates. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "Utilities.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
+
+#include "Utilities.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/AttrTypeSubElements.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
+#include "nvidia/include/Dialect/NVWS/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PartitionBuilder.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/ErrorHandling.h"
+
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
+using namespace mlir::triton::nvidia_gpu;
+using namespace mlir::triton::nvws;
+
+#define DEBUG_TYPE "nvws-lower-aref"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir {
+namespace triton {
+
+#define GEN_PASS_DEF_NVWSASSIGNSTAGEPHASE
+#include "nvidia/include/Dialect/NVWS/Transforms/Passes.h.inc"
+namespace {
+template <class T> struct AssignStagePhase {
+  struct StagePhase {
+    Value stage;
+    Value phase;
+    Value token;
+  };
+  Value aref;
+  PartitionId partitionId;
+  DenseMap<Value, int> tokToStagePosMap;
+
+  AssignStagePhase(Value aref, PartitionId partitionId)
+      : aref(aref), partitionId(partitionId) {}
+
+  T isValidOp(Operation *op) {
+    if (isa<T>(op) && op->getOperand(0) == aref) {
+      auto opPartitionId = getPartitionId(op);
+      if (!opPartitionId || *opPartitionId == partitionId)
+        return cast<T>(op);
+    }
+    return {};
+  }
+
+  bool analyzeArefUseInBlock(Block *block) {
+    for (auto &op : *block) {
+      if (isValidOp(&op)) {
+        return true;
+      } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+        if (analyzeArefUseInBlock(forOp.getBody()))
+          return true;
+      } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        if (analyzeArefUseInBlock(ifOp.thenBlock()))
+          return true;
+        if (ifOp.elseBlock() && analyzeArefUseInBlock(ifOp.elseBlock()))
+          return true;
+      }
+    }
+    return false;
+  }
+
+  void assignArefIndexInForOp(scf::ForOp forOp, StagePhase &index) {
+
+    // find uses of arefs in forOp body
+    if (!analyzeArefUseInBlock(forOp.getBody()))
+      return;
+
+    // add extra iterArgs to the forOp
+    SmallVector<Value> extraIterArgs{index.stage, index.phase};
+    SmallVector<Value *> arefIndexRefs{&index.stage, &index.phase};
+    llvm::MapVector<int, Value *> arefTokenRefs;
+
+    if (auto pos = findValuePosInRange(forOp.getInitArgs(), index.token)) {
+      // keep reference of the token position to latest token value
+      // we will need it update with the value returned from forOp
+      arefTokenRefs[*pos] = &index.token;
+      // update token value with iter argument
+      index.token = forOp.getRegionIterArgs()[*pos];
+    }
+    // create new forOp with extra iterArgs
+    OpBuilder builder(forOp);
+    size_t nArgs = forOp.getRegionIterArgs().size();
+    forOp = addIterArgsToLoop(builder, forOp, extraIterArgs);
+
+    // update arefIndex with iterArgs in the forOp body
+    for (size_t idx = nArgs; idx < forOp.getRegionIterArgs().size(); ++idx)
+      *arefIndexRefs[idx - nArgs] = forOp.getRegionIterArgs()[idx];
+
+    // assign arefIndex in the forOp body
+    auto indexInBlock = assignArefIndexInBlock(forOp.getBody(), index);
+
+    // update yieldOp to return new indexes
+    SmallVector<Value> extraYieldArgs;
+    auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+
+    // associate token with stage positional argument in the yieldOp
+    // we will need this in propagateStage function that will assign stage
+    // to arefBuffer and arefExit ops
+    tokToStagePosMap[indexInBlock.token] = nArgs + extraYieldArgs.size();
+    extraYieldArgs.push_back(indexInBlock.stage);
+    if (index.phase)
+      extraYieldArgs.push_back(indexInBlock.phase);
+    appendToForOpYield(forOp, extraYieldArgs);
+
+    // update arefIndex with results from newForOp
+    for (size_t idx = nArgs; idx < forOp.getRegionIterArgs().size(); ++idx)
+      *arefIndexRefs[idx - nArgs] = forOp.getResult(idx);
+    for (auto [idx, arefTokenRef] : arefTokenRefs)
+      *arefTokenRef = forOp.getResult(idx);
+  }
+
+  void assignArefIndexInIfOp(scf::IfOp ifOp, StagePhase &index) {
+
+    auto useInThenBlock = analyzeArefUseInBlock(ifOp.thenBlock());
+    auto useInElseBlock =
+        ifOp.elseBlock() ? analyzeArefUseInBlock(ifOp.elseBlock()) : false;
+    if (!useInThenBlock && !useInElseBlock)
+      return;
+
+    // add extra results to the ifOp
+    SmallVector<Type> extraIfResults{index.stage.getType(),
+                                     index.phase.getType()};
+    SmallVector<Value *> arefIndexRefs{&index.stage, &index.phase};
+
+    // create new ifOp with extra results
+    OpBuilder builder(ifOp);
+    size_t nArgs = ifOp.getResults().size();
+    auto newIfOp = replaceIfOpWithNewSignature(builder, ifOp, extraIfResults);
+
+    // assign arefIndex in then-body
+    auto thenIndex = assignArefIndexInBlock(newIfOp.thenBlock(), index);
+
+    // assign arefIndex in else-body
+    auto elseIndex = newIfOp.elseBlock()
+                         ? assignArefIndexInBlock(newIfOp.elseBlock(), index)
+                         : index;
+
+    // update yieldOp to return new indexes
+    auto thenYieldOp = newIfOp.thenYield();
+    auto elseYieldOp = newIfOp.elseYield();
+    // insert new indexes to the yieldOp
+    llvm::MapVector<int, Value *> arefTokenRefs;
+
+    // find token pos in yieldOp and make a reference to  arefIndexMap value
+    if (auto pos =
+            findValuePosInRange(thenYieldOp->getOperands(), index.token)) {
+      arefTokenRefs[*pos] = &index.token;
+    }
+    if (auto pos =
+            findValuePosInRange(elseYieldOp->getOperands(), index.token)) {
+      arefTokenRefs[*pos] = &index.token;
+    }
+
+    tokToStagePosMap[thenIndex.token] = thenYieldOp.getNumOperands();
+    tokToStagePosMap[elseIndex.token] = elseYieldOp.getNumOperands();
+    thenYieldOp->insertOperands(thenYieldOp.getNumOperands(), thenIndex.stage);
+    elseYieldOp->insertOperands(elseYieldOp.getNumOperands(), elseIndex.stage);
+    if (thenIndex.phase) {
+      thenYieldOp->insertOperands(thenYieldOp.getNumOperands(),
+                                  thenIndex.phase);
+      elseYieldOp->insertOperands(elseYieldOp.getNumOperands(),
+                                  elseIndex.phase);
+    }
+    ifOp.erase();
+
+    // update arefIndex with results from newIfOp
+    for (size_t idx = nArgs; idx < newIfOp.getResults().size(); ++idx)
+      *arefIndexRefs[idx - nArgs] = newIfOp.getResult(idx);
+    for (auto [idx, arefTokenRef] : arefTokenRefs)
+      *arefTokenRef = newIfOp.getResult(idx);
+  }
+
+  StagePhase assignArefIndexInBlock(Block *block, StagePhase index) {
+    for (auto &op : llvm::make_early_inc_range(*block)) {
+      if (auto opT = isValidOp(&op)) {
+        ImplicitLocOpBuilder b(opT.getLoc(), opT);
+
+        auto nextStage = b.create<arith::AddIOp>(
+            index.stage, b.create<arith::ConstantIntOp>(1, 32));
+        auto arefBuf = opT.getAref()
+                           .template getDefiningOp<nvws::ArefCreateOp>()
+                           .getOperand(0);
+        auto depth = cast<MemDescType>(arefBuf.getType()).getShape().front();
+
+        auto cnd =
+            b.create<arith::CmpIOp>(arith::CmpIPredicate::eq, nextStage,
+                                    b.create<arith::ConstantIntOp>(depth, 32));
+        auto zero = b.create<arith::ConstantIntOp>(0, 32);
+        index.stage = b.create<arith::SelectOp>(cnd, zero, nextStage);
+
+        auto nextPhase = b.create<arith::XOrIOp>(
+            index.phase, b.create<arith::ConstantIntOp>(1, 32));
+        index.phase = b.create<arith::SelectOp>(cnd, nextPhase, index.phase);
+
+        index.token = opT.getToken();
+        opT.getStageMutable().assign(index.stage);
+        opT->setOperand(2, index.phase);
+
+      } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+        assignArefIndexInForOp(forOp, index);
+      } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        assignArefIndexInIfOp(ifOp, index);
+      }
+    }
+
+    return index;
+  }
+
+  void propagateStage(Value token, Value stage,
+                      DenseSet<Operation *> &visited) {
+    for (auto &tokUse : token.getUses()) {
+      auto owner = tokUse.getOwner();
+      if (visited.contains(owner))
+        continue;
+      visited.insert(owner);
+      if (isa<ArefGetExitOp, ArefPutExitOp>(owner)) {
+        owner->setOperand(2, stage);
+      } else if (auto yieldOp = dyn_cast<scf::YieldOp>(owner)) {
+        auto tokPos = tokUse.getOperandNumber();
+        auto stagePos = tokToStagePosMap.at(token);
+        auto parentOp = yieldOp->getParentOp();
+        if (auto forOp = dyn_cast<scf::ForOp>(parentOp))
+          propagateStage(forOp.getRegionIterArgs()[tokPos],
+                         forOp.getRegionIterArgs()[stagePos], visited);
+        propagateStage(parentOp->getResult(tokPos),
+                       parentOp->getResult(stagePos), visited);
+      }
+    }
+  }
+
+  static LogicalResult run(ArefCreateOp arefOp) {
+
+    std::set<PartitionId> partitionIds;
+    for (auto user : arefOp->getUsers()) {
+      // Each partition requires its own stage/phase tracking for proper
+      // multi-user handling; collect partition IDs in which this aref is used
+      if (isa<T>(user)) {
+        if (auto partitionId = getPartitionId(user))
+          partitionIds.insert(*partitionId);
+      }
+    }
+
+    // initialize indexes
+    StagePhase index;
+    ImplicitLocOpBuilder b(arefOp.getLoc(), arefOp);
+    b.setInsertionPointAfter(arefOp);
+    auto depth =
+        cast<MemDescType>(arefOp.getOperand(0).getType()).getShape().front();
+    index.stage = b.create<arith::ConstantIntOp>(depth - 1, 32);
+
+    static_assert(std::is_same_v<T, ArefPutEnterOp> ||
+                      std::is_same_v<T, ArefGetEnterOp>,
+                  "ArefPutEnterOp or ArefGetEnterOp expected");
+    auto initPhase = std::is_same_v<T, ArefPutEnterOp> ? 0 : 1;
+    index.phase = b.create<arith::ConstantIntOp>(initPhase, 32);
+
+    for (auto partitionId : partitionIds) {
+      // assign stage/phase to enter/exit Ops in each partition aref is used
+      AssignStagePhase arefIndex(arefOp.getResult(), partitionId);
+
+      // assign stage/phase to enterOps
+      arefIndex.assignArefIndexInBlock(arefOp->getBlock(), index);
+
+      // propagate stage to exitOps following enterOp token
+      for (auto user : arefOp->getUsers())
+        if (auto enterOp = dyn_cast<T>(user)) {
+          DenseSet<Operation *> visited;
+          arefIndex.propagateStage(enterOp.getToken(), enterOp.getStage(),
+                                   visited);
+        }
+    }
+
+    return success();
+  }
+};
+
+static LogicalResult assignStagePhase(triton::FuncOp funcOp) {
+  SmallVector<ArefCreateOp> arefOps;
+  funcOp.walk([&](ArefCreateOp arefOp) { arefOps.push_back(arefOp); });
+  for (auto arefOp : arefOps) {
+    if (failed(AssignStagePhase<ArefPutEnterOp>::run(arefOp)))
+      return failure();
+    if (failed(AssignStagePhase<ArefGetEnterOp>::run(arefOp)))
+      return failure();
+  }
+  return success();
+}
+
+// ----------------------------------------------------------------------------
+
+} // anonymous namespace
+
+class NVWSAssignStagePhase
+    : public impl::NVWSAssignStagePhaseBase<NVWSAssignStagePhase> {
+public:
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    mlir::ModuleOp m = getOperation();
+
+    m.walk([&](triton::FuncOp funcOp) {
+      if (failed(assignStagePhase(funcOp)))
+        signalPassFailure();
+    });
+  }
+}; // namespace triton
+
+} // namespace triton
+} // namespace mlir

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(NVWSTransforms
   LowerWarpGroup.cpp
   InsertAref.cpp
   Utilities.cpp
+  AssignStagePhase.cpp
 
   DEPENDS
   NVWSTransformsIncGen

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -21,9 +21,11 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include "Utilities.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/AttrTypeSubElements.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -38,6 +40,7 @@
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "nvidia/include/Dialect/NVWS/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Partition.h"
 #include "triton/Dialect/TritonGPU/Transforms/PartitionBuilder.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -63,13 +66,17 @@ namespace {
 
 // ----------------------------------------------------------------------------
 
-void assignStageCluster(Operation *op, StageCluster stageCluster,
-                        OpBuilder &builder) {
-  if (stageCluster) {
-    op->setAttr(triton::kLoopStageAttrName,
-                builder.getI32IntegerAttr(stageCluster->first));
-    op->setAttr(triton::kLoopClusterAttrName,
-                builder.getI32IntegerAttr(stageCluster->second));
+void assignStageCluster(Operation *op, std::optional<PartitionId> partitionId,
+                        StageCluster stageCluster, OpBuilder &builder) {
+  if (partitionId) {
+    op->setAttr(kPartitionAttrName,
+                builder.getI32IntegerAttr(partitionId->index()));
+    if (stageCluster) {
+      op->setAttr(triton::kLoopStageAttrName,
+                  builder.getI32IntegerAttr(stageCluster->first));
+      op->setAttr(triton::kLoopClusterAttrName,
+                  builder.getI32IntegerAttr(stageCluster->second));
+    }
   }
 }
 
@@ -90,16 +97,6 @@ Value getFullBarrier(PatternRewriter &rewriter, Location loc, ArefValue aref,
   return createSingleBufferView(rewriter, aref.fullMbars, stage);
 }
 
-std::pair<WarpGroupOp, int> getWarpGroupIdx(Operation *op) {
-  if (auto wgOp = dyn_cast<WarpGroupOp>(op->getParentOp())) {
-    auto region = op->getParentRegion();
-    return {wgOp, region->getRegionNumber()};
-  }
-  if (isa<triton::FuncOp>(op))
-    return {nullptr, -1};
-  return getWarpGroupIdx(op->getParentOp());
-}
-
 struct BarrierCount {
   int producerPendingCount;
   int consumerPendingCount;
@@ -107,11 +104,12 @@ struct BarrierCount {
 
 BarrierCount getArrivalCount(ArefCreateOp op) {
   std::optional<int> producerPendingCount, consumerPendingCount;
-  SetVector<int> consumerGroups;
+  std::set<PartitionId> consumerGroups;
 
   for (auto user : op->getUsers()) {
-    auto [wgOp, idx] = getWarpGroupIdx(user);
-    auto numWarps = wgOp.getNumWarps()[idx];
+    auto partitionId = getPartitionId(user);
+    if (!partitionId)
+      continue;
 
     if (auto putExitOp = dyn_cast<ArefPutExitOp>(user)) {
       int pendingCount = 0;
@@ -154,7 +152,7 @@ BarrierCount getArrivalCount(ArefCreateOp op) {
                "inconsistent producer pending count");
       }
       producerPendingCount = pendingCount;
-      consumerGroups.insert(idx);
+      consumerGroups.insert(*partitionId);
     }
   }
 
@@ -166,6 +164,22 @@ BarrierCount getArrivalCount(ArefCreateOp op) {
   return {*producerPendingCount, *consumerPendingCount};
 }
 
+Value createBarriers(ImplicitLocOpBuilder &b1, ImplicitLocOpBuilder &b2,
+                     int numBarriers, int arrivalCount) {
+  Value barrierAlloc = createScalarAlloc(b1, b1.getI64Type(), numBarriers);
+  for (unsigned i = 0; i < numBarriers; i++) {
+    Value barrierView = createSingleBufferView(b1, barrierAlloc, i);
+    b1.create<InitBarrierOp>(barrierView, arrivalCount);
+  }
+  // Invalidate and deallocate the barriers.
+  for (unsigned i = 0; i < numBarriers; i++) {
+    Value barrierView = createSingleBufferView(b2, barrierAlloc, i);
+    b2.create<InvalBarrierOp>(barrierView);
+  }
+  b2.create<LocalDeallocOp>(barrierAlloc);
+  return barrierAlloc;
+}
+
 ArefValue createAndInitMbar(ArefCreateOp op, PatternRewriter &rewriter) {
   BarrierCount count = getArrivalCount(op);
 
@@ -175,11 +189,17 @@ ArefValue createAndInitMbar(ArefCreateOp op, PatternRewriter &rewriter) {
   auto shape = arefBufTypes[0].getShape();
   auto depth = shape[0];
 
-  auto wgOp = getWarpGroupIdx(*op->getUsers().begin()).first;
-  auto emptyMbars =
-      triton::createBarrierAlloc(wgOp, depth, count.producerPendingCount);
-  auto fullMbars =
-      triton::createBarrierAlloc(wgOp, depth, count.consumerPendingCount);
+  SetVector<Operation *> arefUsers;
+  for (auto user : op->getUsers())
+    arefUsers.insert(user);
+  auto sorted = topologicalSort(arefUsers);
+
+  ImplicitLocOpBuilder b1(op->getLoc(), op), b2(op->getLoc(), op);
+  auto op1 = op->getBlock()->findAncestorOpInBlock(*sorted.back());
+  b2.setInsertionPointAfter(op1);
+
+  auto emptyMbars = createBarriers(b1, b2, depth, count.producerPendingCount);
+  auto fullMbars = createBarriers(b1, b2, depth, count.consumerPendingCount);
 
   return ArefValue{emptyMbars, fullMbars, static_cast<int>(depth),
                    op.getOperands()};
@@ -247,6 +267,12 @@ void lowerAsyncLoads(ArefPutEnterOp op, PatternRewriter &rewriter,
   return;
 }
 
+void insertWaitOp(PatternRewriter &rewriter, Operation *op, Value barrier,
+                  Value phase, Value stage) {
+  auto waitOp = rewriter.create<WaitBarrierOp>(op->getLoc(), barrier, phase);
+  assignStageCluster(waitOp, getPartitionId(op), getStageCluster(op), rewriter);
+}
+
 void rewritePutEnterOp(ArefCreateOp arefOp, ArefPutEnterOp op,
                        PatternRewriter &rewriter, ArefValue arefVal) {
   auto loc = op.getLoc();
@@ -255,9 +281,7 @@ void rewritePutEnterOp(ArefCreateOp arefOp, ArefPutEnterOp op,
   // get empty barrier at a given stage
   Value emptyBarrier = getEmptyBarrier(rewriter, loc, arefVal, op.getStage());
 
-  auto waitOp =
-      rewriter.create<WaitBarrierOp>(loc, emptyBarrier, op.getPhase());
-  assignStageCluster(waitOp, getStageCluster(op), rewriter);
+  insertWaitOp(rewriter, op, emptyBarrier, op.getPhase(), op.getStage());
   auto views = getSubViews(arefVal, op.getStage(), loc, rewriter);
   assert(views.size() == op.getBuffers().size());
 
@@ -276,8 +300,7 @@ void rewriteGetEnterOp(ArefCreateOp arefOp, ArefGetEnterOp op,
   rewriter.setInsertionPointAfter(op);
 
   Value fullBarrier = getFullBarrier(rewriter, loc, arefVal, op.getStage());
-  auto waitOp = rewriter.create<WaitBarrierOp>(loc, fullBarrier, op.getPhase());
-  assignStageCluster(waitOp, getStageCluster(op), rewriter);
+  insertWaitOp(rewriter, op, fullBarrier, op.getPhase(), op.getStage());
   auto views = getSubViews(arefVal, op.getStage(), loc, rewriter);
   assert(views.size() == op.getBuffers().size());
 
@@ -287,6 +310,7 @@ void rewriteGetEnterOp(ArefCreateOp arefOp, ArefGetEnterOp op,
 
 void insertArriveBarrier(Location loc, ArrayAttr asyncOps,
                          PatternRewriter &rewriter, Value mbar,
+                         std::optional<PartitionId> partitionId,
                          StageCluster stageCluster) {
   for (auto asyncOp : asyncOps) {
     auto asyncOpEnum = cast<AsyncOpAttr>(asyncOp).getValue();
@@ -309,7 +333,7 @@ void insertArriveBarrier(Location loc, ArrayAttr asyncOps,
       llvm_unreachable("unknown async op");
     }
     if (arriveOp)
-      assignStageCluster(arriveOp, stageCluster, rewriter);
+      assignStageCluster(arriveOp, partitionId, stageCluster, rewriter);
   }
 }
 
@@ -319,7 +343,7 @@ void rewritePutExitOp(ArefPutExitOp op, PatternRewriter &rewriter,
   rewriter.setInsertionPointAfter(op);
   Value fullBarrier = getFullBarrier(rewriter, loc, arefVal, op.getStage());
   insertArriveBarrier(loc, op.getAsyncOps(), rewriter, fullBarrier,
-                      getStageCluster(op));
+                      getPartitionId(op), getStageCluster(op));
 }
 
 void rewriteGetExitOp(ArefGetExitOp op, PatternRewriter &rewriter,
@@ -328,7 +352,7 @@ void rewriteGetExitOp(ArefGetExitOp op, PatternRewriter &rewriter,
   rewriter.setInsertionPointAfter(op);
   Value emptyBarrier = getEmptyBarrier(rewriter, loc, arefVal, op.getStage());
   insertArriveBarrier(loc, op.getAsyncOps(), rewriter, emptyBarrier,
-                      getStageCluster(op));
+                      getPartitionId(op), getStageCluster(op));
 }
 
 class LowerArefCreate : public OpRewritePattern<ArefCreateOp> {
@@ -356,247 +380,18 @@ public:
     }
 
     auto sorted = topologicalSort(opToDelete);
-    for (auto it = sorted.rbegin(); it != sorted.rend(); ++it) {
+    OpBuilder b(op);
+    auto replToken =
+        b.create<ub::PoisonOp>(op.getLoc(), b.getType<AsyncTokenType>());
+    for (auto op : sorted) {
+      if (auto enterOp = dyn_cast<ArefPutEnterOp>(op))
+        enterOp.getToken().replaceAllUsesWith(replToken);
+      else if (auto enterOp = dyn_cast<ArefGetEnterOp>(op))
+        enterOp.getToken().replaceAllUsesWith(replToken);
+    }
+    for (auto it = sorted.rbegin(); it != sorted.rend(); ++it)
       rewriter.eraseOp(*it);
-    }
 
-    return success();
-  }
-};
-
-// ----------------------------------------------------------------------------
-
-template <class... Ts> struct ArefIndex;
-template <class T> struct ArefIndex<T> {
-  struct Index {
-    // Having stage and phase as separate values, rather than encoding them
-    // into a single index, results in better performance. Same approach is used
-    // in CUTLASS and CUTEDSL, and this may allow PTXAS to better optimize code.
-    Value stage;
-    Value phase;
-  };
-  using ArefIndexMap = llvm::MapVector<Value /*aref*/, Index>;
-  using ArefUseSet = llvm::SetVector<Value /*aref*/>;
-
-  static ArefUseSet analyzeArefUseInBlock(Block *block, ArefUseSet arefUseSet) {
-    for (auto &op : *block) {
-      if (auto opT = dyn_cast<T>(op)) {
-        arefUseSet.insert(opT.getAref());
-      } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
-        arefUseSet = analyzeArefUseInBlock(forOp.getBody(), arefUseSet);
-      } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-        arefUseSet = analyzeArefUseInBlock(ifOp.thenBlock(), arefUseSet);
-        if (ifOp.elseBlock())
-          arefUseSet = analyzeArefUseInBlock(ifOp.elseBlock(), arefUseSet);
-      }
-    }
-    return arefUseSet;
-  }
-
-  static void assignArefIndexInForOp(scf::ForOp forOp,
-                                     ArefIndexMap &arefIndexMap) {
-
-    // find uses of arefs in forOp body
-    auto arefUseInBlock = analyzeArefUseInBlock(forOp.getBody(), {});
-    if (arefUseInBlock.empty())
-      return;
-
-    // add extra iterArgs to the forOp
-    SmallVector<Value> extraIterArgs;
-    SmallVector<Value *> arefIndexRefs;
-    for (auto aref : arefUseInBlock) {
-      auto index = arefIndexMap.lookup(aref);
-      extraIterArgs.push_back(index.stage);
-      arefIndexRefs.push_back(&arefIndexMap[aref].stage);
-      if (index.phase) {
-        extraIterArgs.push_back(index.phase);
-        arefIndexRefs.push_back(&arefIndexMap[aref].phase);
-      }
-    }
-
-    // create new forOp with extra iterArgs
-    OpBuilder builder(forOp);
-    size_t nArgs = forOp.getRegionIterArgs().size();
-    forOp = addIterArgsToLoop(builder, forOp, extraIterArgs);
-
-    // update arefIndex with iterArgs in the forOp body
-    for (size_t idx = nArgs; idx < forOp.getRegionIterArgs().size(); ++idx)
-      *arefIndexRefs[idx - nArgs] = forOp.getRegionIterArgs()[idx];
-
-    // assign arefIndex in the forOp body
-    auto arefIndexMapInBlock =
-        assignArefIndexInBlock(forOp.getBody(), arefIndexMap);
-
-    // update yieldOp to return new indexes
-    SmallVector<Value> extraYieldArgs;
-    for (auto aref : arefUseInBlock) {
-      auto &index = arefIndexMapInBlock[aref];
-      extraYieldArgs.push_back(index.stage);
-      if (index.phase)
-        extraYieldArgs.push_back(index.phase);
-    }
-    appendToForOpYield(forOp, extraYieldArgs);
-
-    // update arefIndex with results from newForOp
-    for (size_t idx = nArgs; idx < forOp.getRegionIterArgs().size(); ++idx)
-      *arefIndexRefs[idx - nArgs] = forOp.getResult(idx);
-  }
-
-  static void assignArefIndexInIfOp(scf::IfOp ifOp,
-                                    ArefIndexMap &arefIndexMap) {
-
-    // find uses of aref in then-block
-    auto arefUseInIfOp = analyzeArefUseInBlock(ifOp.thenBlock(), {});
-    if (arefUseInIfOp.empty())
-      return;
-
-    // find uses of aref in else-block
-    arefUseInIfOp = ifOp.elseBlock()
-                        ? analyzeArefUseInBlock(ifOp.elseBlock(), arefUseInIfOp)
-                        : arefUseInIfOp;
-
-    // add extra results to the ifOp
-    SmallVector<Type> extraIfResults;
-    SmallVector<Value *> arefIndexRefs;
-    for (auto aref : arefUseInIfOp) {
-      auto index = arefIndexMap.lookup(aref);
-      extraIfResults.push_back(index.stage.getType());
-      arefIndexRefs.push_back(&arefIndexMap[aref].stage);
-      if (index.phase) {
-        extraIfResults.push_back(index.phase.getType());
-        arefIndexRefs.push_back(&arefIndexMap[aref].phase);
-      }
-    }
-
-    // create new ifOp with extra results
-    OpBuilder builder(ifOp);
-    size_t nArgs = ifOp.getResults().size();
-    auto newIfOp = replaceIfOpWithNewSignature(builder, ifOp, extraIfResults);
-
-    // assign arefIndex in then-body
-    auto arefIndexInThenBlock =
-        assignArefIndexInBlock(newIfOp.thenBlock(), arefIndexMap);
-
-    // assign arefIndex in else-body
-    auto arefIndexInElseBlock =
-        ifOp.elseBlock()
-            ? assignArefIndexInBlock(newIfOp.elseBlock(), arefIndexMap)
-            : arefIndexMap;
-
-    // update yieldOp to return new indexes
-    auto thenYieldOp = newIfOp.thenYield();
-    auto elseYieldOp = newIfOp.elseYield();
-    // insert new indexes to the yieldOp
-    for (auto aref : arefUseInIfOp) {
-      auto &thenIndex = arefIndexInThenBlock[aref];
-      auto &elseIndex = arefIndexInElseBlock[aref];
-      thenYieldOp->insertOperands(thenYieldOp.getNumOperands(),
-                                  thenIndex.stage);
-      elseYieldOp->insertOperands(elseYieldOp.getNumOperands(),
-                                  elseIndex.stage);
-      if (thenIndex.phase) {
-        thenYieldOp->insertOperands(thenYieldOp.getNumOperands(),
-                                    thenIndex.phase);
-        elseYieldOp->insertOperands(elseYieldOp.getNumOperands(),
-                                    elseIndex.phase);
-      }
-    }
-    ifOp.erase();
-
-    // update arefIndex with results from newIfOp
-    for (size_t idx = nArgs; idx < newIfOp.getResults().size(); ++idx)
-      *arefIndexRefs[idx - nArgs] = newIfOp.getResult(idx);
-  }
-
-  static ArefIndexMap assignArefIndexInBlock(Block *block,
-                                             ArefIndexMap arefIndexMap) {
-    for (auto &op : llvm::make_early_inc_range(*block)) {
-      if (auto opT = dyn_cast<T>(op)) {
-        auto index = arefIndexMap.lookup(opT.getAref());
-
-        OpBuilder builder(opT);
-        builder.setInsertionPointAfter(opT);
-
-        // compute next stage
-        opT.getStageMutable().assign(index.stage);
-        auto nextStage = builder.create<arith::AddIOp>(
-            opT.getLoc(), index.stage,
-            builder.create<arith::ConstantIntOp>(opT.getLoc(), 1, 32));
-        auto arefBuf = opT.getAref()
-                           .template getDefiningOp<nvws::ArefCreateOp>()
-                           .getOperand(0);
-        auto depth = cast<MemDescType>(arefBuf.getType()).getShape().front();
-
-        auto cnd = builder.create<arith::CmpIOp>(
-            opT.getLoc(), arith::CmpIPredicate::eq, nextStage,
-            builder.create<arith::ConstantIntOp>(opT.getLoc(), depth, 32));
-        auto zero = builder.create<arith::ConstantIntOp>(opT.getLoc(), 0, 32);
-        arefIndexMap[opT.getAref()].stage =
-            builder.create<arith::SelectOp>(opT.getLoc(), cnd, zero, nextStage);
-
-        if (index.phase) {
-          // if this is an enterOp, compute next phase
-          opT->setOperand(2, index.phase);
-          auto nextPhase = builder.create<arith::XOrIOp>(
-              opT.getLoc(), index.phase,
-              builder.create<arith::ConstantIntOp>(opT.getLoc(), 1, 32));
-          arefIndexMap[opT.getAref()].phase = builder.create<arith::SelectOp>(
-              opT.getLoc(), cnd, nextPhase, index.phase);
-        }
-
-      } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
-        assignArefIndexInForOp(forOp, arefIndexMap);
-      } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-        assignArefIndexInIfOp(ifOp, arefIndexMap);
-      }
-    }
-
-    return arefIndexMap;
-  }
-
-  static LogicalResult run(WarpGroupOp wgOp, std::string opName) {
-    ArefUseSet arefUse;
-    for (auto region : wgOp.getRegions()) {
-      auto block = &region->getBlocks().front();
-      arefUse = analyzeArefUseInBlock(block, arefUse);
-    }
-
-    // initialize indexes
-    ArefIndexMap arefIndexMap;
-    for (auto aref : arefUse) {
-      OpBuilder builder(aref.getDefiningOp());
-      builder.setInsertionPointAfter(aref.getDefiningOp());
-      arefIndexMap[aref].stage =
-          builder.create<arith::ConstantIntOp>(aref.getLoc(), 0, 32);
-      if (std::is_same_v<T, ArefPutEnterOp>) {
-        arefIndexMap[aref].phase =
-            builder.create<arith::ConstantIntOp>(aref.getLoc(), 1, 32);
-      } else if (std::is_same_v<T, ArefGetEnterOp>) {
-        arefIndexMap[aref].phase =
-            builder.create<arith::ConstantIntOp>(aref.getLoc(), 0, 32);
-      } else {
-        arefIndexMap[aref].phase = {};
-      }
-    }
-
-    for (auto region : wgOp.getRegions()) {
-      auto block = &region->getBlocks().front();
-      assignArefIndexInBlock(block, arefIndexMap);
-    }
-    return success();
-  }
-};
-
-template <> struct ArefIndex<> {
-  static LogicalResult run(WarpGroupOp wgOp) {
-    if (failed(ArefIndex<ArefPutEnterOp>::run(wgOp, "ArefPutEnterOp")))
-      return failure();
-    if (failed(ArefIndex<ArefPutExitOp>::run(wgOp, "ArefPutExitOp")))
-      return failure();
-    if (failed(ArefIndex<ArefGetEnterOp>::run(wgOp, "ArefGetEnterOp")))
-      return failure();
-    if (failed(ArefIndex<ArefGetExitOp>::run(wgOp, "ArefGetExitOp")))
-      return failure();
     return success();
   }
 };
@@ -610,14 +405,6 @@ public:
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     mlir::ModuleOp m = getOperation();
-
-    SmallVector<WarpGroupOp> wgOps;
-    m.walk([&](WarpGroupOp wgOp) { wgOps.push_back(wgOp); });
-    for (auto wgOp : wgOps) {
-      if (failed(ArefIndex<>::run(wgOp)))
-        signalPassFailure();
-    }
-    LLVM_DEBUG(llvm::dbgs() << "After arefIndexAssignment\n" << m << "\n");
 
     mlir::RewritePatternSet patterns(context);
     patterns.add<LowerArefCreate>(context);

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.h
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.h
@@ -12,6 +12,24 @@ Operation *createAlloc(OpBuilder &builder, Location loc,
 ArefCreateOp createArefCreateOp(OpBuilder &builder, ArrayRef<Type> arefTypes,
                                 ValueRange allocOps, Location loc);
 
+template <typename Range>
+inline std::optional<int> findValuePosInRange(const Range &range,
+                                              mlir::Value v) {
+  for (auto [pos, arg] : llvm::enumerate(range)) {
+    if (arg == v)
+      return pos;
+  }
+  return {};
+}
+
+struct PartitionId : std::pair<int, int> {
+  PartitionId(int index, int tag) : std::pair<int, int>(index, tag) {}
+  int &index() { return first; }
+  int &tag() { return second; }
+};
+
+std::optional<PartitionId> getPartitionId(Operation *op);
+
 } // namespace mlir::triton::nvws
 
 #endif // NVIDIA_NVWS_TRANSFORMS_UTILITY_H_

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -81,6 +81,8 @@ void init_triton_nvidia_passes_nvws(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_lower_warp_group",
                      mlir::triton::createNVWSLowerWarpGroup);
   ADD_PASS_WRAPPER_0("add_lower_aref", mlir::triton::createNVWSLowerAref);
+  ADD_PASS_WRAPPER_0("add_assign_stage_phase",
+                     mlir::triton::createNVWSAssignStagePhase);
 }
 
 void init_triton_hopper_passes(py::module &&m) {


### PR DESCRIPTION
* Reorder `partition-loops` and `lower-aref` passes
* Split `lower-aref` to `lower-aref` and `assign-stage-phase` passes
    * the split separates concerns, as `assign-stage-phase` is more complex pass and testing/debugging can be focused on correctness stage/phase assignment w/o added complexity of `aref->mbarrier` lowering. 
    * `assign-stage-phase` uses enterOp token to assign same stage variable that enterOp uses to exitOp, instead of previously having separate stage for enterOps/exitOps.
    *  `lower-aref` testing verifies correctness of `aref->mbarrier` lowerings
* in `load-mma-specialization` don't place final `waitOp` inside ws-region, revert to original behavior before https://github.com/triton-lang/triton/pull/7757, as that change causes perf regression with this pR.  Keeping ws.tag to differentiate partitions in different loops as it will be relied upon in `aref-tmem-insertion` (WIP).
   
This is prep PR needed for `aref-tmem-insertion` WIP (will be submitted after this one)

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
