### PR TITLE
[Backend] Fix various issues with smem base offsets

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -377,6 +377,8 @@ public:
 
   Value getShmemOffset(Location loc, RewriterBase &rewriter,
                        triton::gpu::MemDescType srcTy) const;
+  Value getShmemAffineBase(Location loc, RewriterBase &rewriter,
+                           triton::gpu::MemDescType srcTy) const;
 
   // TODO(Keren): deprecate the method once AMD backend has cleaned up
   Value getCSwizzleOffset(int dim) const {

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -741,7 +741,7 @@ def TTNG_TMEMCopyOp : TTNG_Op<"tmem_copy"> {
     Optional<TTG_MemDescType>:$barrier
   );
 
-  let assemblyFormat = [{$src `,` $dst `,` $barrier attr-dict `:` functional-type(operands, results)}];
+  let assemblyFormat = [{$src `,` $dst (`,` $barrier^)? attr-dict `:` qualified(type(operands))}];
   let hasVerifier = 1;
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1209,6 +1209,14 @@ Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
   return offset;
 }
 
+Value SharedMemoryObject::getShmemAffineBase(
+    Location loc, RewriterBase &rewriter,
+    triton::gpu::MemDescType srcTy) const {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value offset = getShmemOffset(loc, rewriter, srcTy);
+  return b.gep(base.getType(), baseElemType, base, offset);
+}
+
 Value getStructFromSharedMemoryObject(Location loc,
                                       const SharedMemoryObject &smemObj,
                                       RewriterBase &rewriter) {

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -561,8 +561,8 @@ struct MemDescReinterpretOpConversion
 
     auto smemObj =
         getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(), srcElemTy, b);
-    SharedMemoryObject newObj(smemObj.getBase(), dstElemTy, dstTy.getRank(),
-                              loc, b);
+    Value newBase = smemObj.getShmemAffineBase(loc, b, srcTy);
+    SharedMemoryObject newObj(newBase, dstElemTy, dstTy.getRank(), loc, b);
     b.replaceOp(op, getStructFromSharedMemoryObject(loc, newObj, b));
     return success();
   }

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -15,8 +15,8 @@ from triton._internal_testing import (
 )
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
-from triton.experimental.gluon.language.nvidia.ampere import async_copy, mbarrier
-from triton.experimental.gluon.language.nvidia.hopper import tma, fence_async_shared
+from triton.experimental.gluon.language.nvidia.ampere import async_copy
+from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier, fence_async_shared
 from triton.experimental.gluon.language.nvidia import hopper
 from triton.experimental.gluon.language.amd.cdna4 import async_copy as cdna4_async_copy
 from triton.experimental.gluon.language.extra import libdevice
@@ -665,3 +665,68 @@ def test_block_m_64_mma():
 
     d_ref = a @ b + c
     torch.testing.assert_close(d_ref, d_tri, rtol=0.08, atol=0)
+
+
+def test_slice_reinterpret():
+    BLOCK = ttgl.constexpr(2048)
+    SPLIT_BLOCK = ttgl.constexpr(BLOCK // 2)
+    XBLOCK = ttgl.constexpr(32)
+    YBLOCK = ttgl.constexpr(SPLIT_BLOCK // 4 // XBLOCK)
+    NUM_THREADS = ttgl.constexpr(THREADS_PER_WARP)
+
+    @gluon.jit
+    def kernel(in_ptr, out_ptr):
+        smem_layout_1d: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0])
+        smem_layout_2d: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+        smem = ttgl.allocate_shared_memory(ttgl.int8, [BLOCK], smem_layout_1d)
+        smem_slice0 = smem.slice(0, SPLIT_BLOCK)
+        smem_slice1 = smem.slice(SPLIT_BLOCK, SPLIT_BLOCK)._reinterpret(ttgl.int32, [XBLOCK, YBLOCK], smem_layout_2d)
+
+        offs = ttgl.arange(0, XBLOCK)[:, None] * YBLOCK + ttgl.arange(0, YBLOCK)[None, :]
+        blocked: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, NUM_THREADS], [1, 4], [1, 0])
+        value = ttgl.load(ttgl.set_auto_layout(in_ptr + offs, blocked))
+
+        blocked_1d: ttgl.constexpr = ttgl.BlockedLayout([1], [NUM_THREADS], [4], [0])
+        smem_slice1.store(value)
+        smem_slice0.store(ttgl.zeros((SPLIT_BLOCK, ), dtype=ttgl.int8, layout=blocked_1d))
+        value = smem_slice1.load(blocked)
+        ttgl.store(ttgl.set_auto_layout(out_ptr + offs, blocked), value)
+
+    input = torch.randint(0, 100, (XBLOCK, YBLOCK), dtype=torch.int32, device="cuda")
+    output = torch.empty_like(input)
+    kernel[(1, )](input, output)
+    torch.testing.assert_close(input, output, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
+def test_tma_slice():
+    XBLOCK = YBLOCK = ttgl.constexpr(128)
+
+    @gluon.jit
+    def kernel(in_desc, out_desc):
+        smem = ttgl.allocate_shared_memory(in_desc.dtype, [2 * XBLOCK, YBLOCK], in_desc.layout)
+        smem_slice0 = smem.slice(0, XBLOCK)
+        smem_slice1 = smem.slice(XBLOCK, XBLOCK)
+
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], ttgl.constexpr(mbarrier.MBarrierLayout()))
+        mbarrier.init(bar, count=1)
+
+        mbarrier.expect(bar, in_desc.block_type.nbytes)
+        tma.async_copy_global_to_shared(in_desc, [0, 0], bar, smem_slice1)
+        mbarrier.wait(bar, phase=0)
+
+        blocked: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0])
+        smem_slice0.store(ttgl.zeros((XBLOCK, YBLOCK), dtype=ttgl.float32, layout=blocked))
+
+        tma.async_copy_shared_to_global(out_desc, [0, 0], smem_slice1)
+        tma.store_wait(0)
+
+    input = torch.rand((XBLOCK, YBLOCK), dtype=torch.float32, device="cuda")
+    output = torch.empty_like(input)
+
+    block_shape = [XBLOCK.value, YBLOCK.value]
+    layout = ttgl.NVMMASharedLayout.get_default_for(block_shape, ttgl.float32)
+    in_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, block_shape, layout)
+    out_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(output, block_shape, layout)
+    kernel[(1, )](in_desc, out_desc)
+    torch.testing.assert_close(input, output, atol=0, rtol=0)

--- a/test/Analysis/test-membar-ttng.mlir
+++ b/test/Analysis/test-membar-ttng.mlir
@@ -139,7 +139,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     %1 = ttng.tmem_alloc  {tensor_memory_col_offset = 256 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x16xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>
     // gpu.barrier
     // CHECK: tmem_copy
-    ttng.tmem_copy %0, %1,  : (!ttg.memdesc<1x2048xf8E4M3FN, #shared, #smem>, !ttg.memdesc<128x16xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>) -> ()
+    ttng.tmem_copy %0, %1 : !ttg.memdesc<1x2048xf8E4M3FN, #shared, #smem>, !ttg.memdesc<128x16xf8E4M3FN, #tmem_scales, #ttng.tensor_memory, mutable>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -300,16 +300,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 32, unpacked = true>
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @tmem_copy_2d(%src: !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory>,
-                               %dst: !ttg.memdesc<128x32xi32, #tmem, #ttng.tensor_memory, mutable>,
-			       %barrier: !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>) {
-    // CHECK-COUNT-8: tcgen05.cp.cta_group::1.warpx4.32x128b
-    // CHECK: tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64
-    ttng.tmem_copy %src, %dst, %barrier : (!ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>) -> ()
 
-    tt.return
-  }
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+
+tt.func public @tmem_copy_2d(%src: !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory>,
+                             %dst: !ttg.memdesc<128x32xi32, #tmem, #ttng.tensor_memory, mutable>,
+		                         %barrier: !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>) {
+  // CHECK-COUNT-8: tcgen05.cp.cta_group::1.warpx4.32x128b
+  // CHECK: tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64
+  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
+  tt.return
+}
+
+tt.func public @tmem_copy_2d_slice(%src: !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory, 1024x16>,
+                                   %dst: !ttg.memdesc<128x32xi32, #tmem, #ttng.tensor_memory, mutable>) {
+  // CHECK: [[OFF0:%.*]] = llvm.extractvalue %arg0[1]
+  // CHECK: [[OFF1:%.*]] = llvm.extractvalue %arg0[2]
+  // CHECK-COUNT-8: tcgen05.cp.cta_group::1.warpx4.32x128b
+  ttng.tmem_copy %src, %dst : !ttg.memdesc<256x16xi8, #shared, #ttg.shared_memory, 1024x16>, !ttg.memdesc<128x32xi32, #tmem, #ttng.tensor_memory, mutable>
+  tt.return
+}
+
 }
 
 // -----

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -35,7 +35,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %cst = arith.constant dense<0> : tensor<128x4xi8, #scales>
     %0 = ttng.tmem_alloc %cst : (tensor<128x4xi8, #scales>) -> !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory>
     // expected-error @+1 {{Cannot copy into an immutable alloc}}
-    ttng.tmem_copy %arg, %0,  : (!ttg.memdesc<1x512xi8, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory>) -> ()
+    ttng.tmem_copy %arg, %0 : !ttg.memdesc<1x512xi8, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<128x4xi8, #tmem, #ttng.tensor_memory>
     tt.return
   }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -910,11 +910,10 @@ struct TensorMemoryCopyOpConversion
     auto srcTy = cast<MemDescType>(op.getSrc().getType());
     assert(isa<triton::gpu::SharedMemorySpaceAttr>(srcTy.getMemorySpace()));
 
-    Value baseSrc =
-        LLVM::getSharedMemoryObjectFromStruct(
-            loc, adaptor.getSrc(),
-            typeConverter->convertType(srcTy.getElementType()), rewriter)
-            .getBase();
+    Type elemTy = typeConverter->convertType(srcTy.getElementType());
+    auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
+                                                         elemTy, rewriter);
+    Value baseSrc = smemObj.getShmemAffineBase(loc, rewriter, srcTy);
 
     Value baseDst = adaptor.getDst();
     auto elemPtrTy = ptr_ty(rewriter.getContext(), 3);


### PR DESCRIPTION
Stacked PRs:
 * __->__#7937
 * #7936


--- --- ---

### [Backend] Fix various issues with smem base offsets


Many ops were using `smemObj.getBase()` without applying the offsets to
get the part of smem to read to write. This is incorrect since the
offsets may be nonzero. This PR fixes as many of these issues I could
identify and adds tests for this.
