### PR TITLE
[Nvidia] Disable WS with num_warps < 4

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
@@ -33,6 +33,11 @@ struct AutomaticWarpSpecialization
 } // namespace
 
 void AutomaticWarpSpecialization::runOnOperation() {
+  ModuleOp mod = getOperation();
+  int numWarps = lookupNumWarps(mod);
+  // Warp specialization requires at least 4 warps.
+  if (numWarps < 4)
+    return;
   OpPassManager pm;
   pm.addPass(createTritonGPUPartitionScheduling());
   pm.addPass(createTritonGPULoadMMASpecialization({numStages}));

--- a/test/TritonGPU/automatic-warp-specialization.mlir
+++ b/test/TritonGPU/automatic-warp-specialization.mlir
@@ -306,7 +306,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.targ
       %24 = ttg.convert_layout %23 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #blocked> -> tensor<128x64xf16, #linear>
       %25 = tt.trans %24 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : tensor<128x64xf16, #linear> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
       %26 = ttg.convert_layout %22 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #blocked> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
-      %27 = tt.dot %26, %25, %arg19, inputPrecision = tf32 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x128xf32, #mma> loc(#loc23)
+      %27 = tt.dot %26, %25, %arg19, inputPrecision = tf32 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x128xf32, #mma>
       scf.yield %27 : tensor<128x128xf32, #mma>
     } {tt.scheduled_max_stage = 1 : i32}
     %19 = arith.truncf %18 : tensor<128x128xf32, #mma> to tensor<128x128xf16, #mma>

--- a/test/TritonGPU/automatic-warp-specialization.mlir
+++ b/test/TritonGPU/automatic-warp-specialization.mlir
@@ -298,7 +298,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.targ
     %15 = arith.divsi %14, %c64_i32 : i32
     %16 = arith.muli %11, %c128_i32 : i32
     %17 = arith.muli %13, %c128_i32 : i32
-    // CHECK-LABEL-NOT: ttg.warp_specialize
+    // CHECK-NOT: ttg.warp_specialize
     %18 = scf.for %arg18 = %c0_i32 to %15 step %c1_i32 iter_args(%arg19 = %cst) -> (tensor<128x128xf32, #mma>)  : i32 {
       %21 = arith.muli %arg18, %c64_i32 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
       %22 = tt.descriptor_load %arg0[%16, %21] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked>


### PR DESCRIPTION
The warp specialization lowering is written with the expectation that the user will provide at least 4 warps. This implicit assumption can lead to compiler crashes in the warp group lower steps. For example, here is a place in the code that will crash: https://github.com/triton-lang/triton/blob/286e91fd07633b4391287e5a6992ab2498edb121/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp#L148 because the initial ID will not take the if statement when its not divisible by 4. You can validate this by running `09-persistent-matmul.py` but changing the number of warps to 2.

This PR disables WS with num_warps < 4 given the number of issues this encounters in the implementation.