### PR TITLE
[AMD] Enable dot_scaled on gfx11

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2119,10 +2119,10 @@ LogicalResult DotOperandEncodingAttr::verify(
   }
 
   if (auto parentAttr = mlir::dyn_cast<AMDWmmaEncodingAttr>(parent)) {
-    if (kWidth != 16 && parentAttr.getVersion() == 1 ||
+    if (kWidth != 8 && kWidth != 16 && parentAttr.getVersion() == 1 ||
         kWidth != 4 && kWidth != 8 && kWidth != 16 &&
             parentAttr.getVersion() == 2)
-      return emitError() << "ttg.dot_op kWidth parameter must be 16 for "
+      return emitError() << "ttg.dot_op kWidth parameter must be 8/16 for "
                             "gfx11 and 4/8/16 for gfx12 (including packed "
                             "cases for `scaled_dot`)";
     return success();

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -35,6 +35,7 @@ from triton._internal_testing import (
     is_hip_cdna2,
     is_hip_cdna3,
     is_hip_cdna4,
+    is_hip_gfx11,
     is_hip_gfx12,
     is_xpu,
     get_arch,
@@ -78,7 +79,7 @@ elif is_hip():
     # 0 is a special value for automatic heuristic
     if is_hip_cdna():
         mma_nonk_sizes = [0, 16, 32]
-    elif is_hip_gfx12():
+    elif is_hip_gfx11() or is_hip_gfx12():
         mma_nonk_sizes = [16]
 else:
     THREADS_PER_WARP = 32
@@ -3743,12 +3744,12 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
         if cc < (8, 9):
             pytest.skip("float8e4nv not supported on CUDA < 8.9")
     if is_hip():
-        if not (is_hip_cdna() or is_hip_gfx12()):
+        if not (is_hip_cdna() or is_hip_gfx11() or is_hip_gfx12()):
             pytest.skip("scaled_dot only implemented for HIP CDNA and gfx12")
         if "e4m3" in (mxfp_type, normal_type):
             if not (is_hip_cdna3() or is_hip_cdna4() or is_hip_gfx12()):
                 pytest.skip(f"scaled_dot({mxfp_type}, {normal_type}) only implemented for CDNA3, CDNA4, gfx12")
-        if mma == 16 and K == 64 and not is_hip_gfx12():
+        if mma == 16 and K == 64 and not (is_hip_gfx12() or is_hip_gfx11()):
             pytest.skip(f"K == {K} too small for mfma {mma} in scaled_dot")
 
     @triton.jit

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3745,7 +3745,7 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
             pytest.skip("float8e4nv not supported on CUDA < 8.9")
     if is_hip():
         if not (is_hip_cdna() or is_hip_gfx11() or is_hip_gfx12()):
-            pytest.skip("scaled_dot only implemented for HIP CDNA and gfx12")
+            pytest.skip("scaled_dot only implemented for HIP CDNA, gfx11, gfx12")
         if "e4m3" in (mxfp_type, normal_type):
             if not (is_hip_cdna3() or is_hip_cdna4() or is_hip_gfx12()):
                 pytest.skip(f"scaled_dot({mxfp_type}, {normal_type}) only implemented for CDNA3, CDNA4, gfx12")

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -74,6 +74,12 @@ def is_hip_cdna4():
     return target is not None and target.backend == 'hip' and target.arch == 'gfx950'
 
 
+def is_hip_gfx11():
+    target = get_current_target()
+    print(target.arch)
+    return target is not None and target.backend == 'hip' and 'gfx11' in target.arch
+
+
 def is_hip_gfx12():
     target = get_current_target()
     return target is not None and target.backend == 'hip' and 'gfx12' in target.arch

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -76,7 +76,6 @@ def is_hip_cdna4():
 
 def is_hip_gfx11():
     target = get_current_target()
-    print(target.arch)
     return target is not None and target.backend == 'hip' and 'gfx11' in target.arch
 
 

--- a/test/TritonGPU/invalid-attributes.mlir
+++ b/test/TritonGPU/invalid-attributes.mlir
@@ -42,18 +42,13 @@
 
 // -----
 
-// expected-error@+2 {{ttg.dot_op kWidth parameter must be 16 for gfx11 and 4/8/16 for gfx12 (including packed cases for `scaled_dot`)}}
+// expected-error@+2 {{ttg.dot_op kWidth parameter must be 8/16 for gfx11 and 4/8/16 for gfx12 (including packed cases for `scaled_dot`)}}
 #wmma = #ttg.amd_wmma<{version = 1, warpsPerCTA = [1, 4]}>
 #dot_op = #ttg.dot_op<{opIdx = 1, parent = #wmma}>
 
 // -----
 
-// expected-error@+2 {{ttg.dot_op kWidth parameter must be 16 for gfx11 and 4/8/16 for gfx12 (including packed cases for `scaled_dot`)}}
-#wmma = #ttg.amd_wmma<{version = 1, warpsPerCTA = [1, 4]}>
-#dot_op = #ttg.dot_op<{opIdx = 1, parent = #wmma, kWidth = 8}>
-
-// -----
-// expected-error@+2 {{ttg.dot_op kWidth parameter must be 16 for gfx11 and 4/8/16 for gfx12 (including packed cases for `scaled_dot`)}}
+// expected-error@+2 {{ttg.dot_op kWidth parameter must be 8/16 for gfx11 and 4/8/16 for gfx12 (including packed cases for `scaled_dot`)}}
 #wmma = #ttg.amd_wmma<{version = 2, warpsPerCTA = [1, 4]}>
 #dot_op = #ttg.dot_op<{opIdx = 1, parent = #wmma, kWidth = 32}>
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1453,11 +1453,8 @@ struct TritonAMDGPUAccelerateMatmulPass
           /*benefit=*/2);
       break;
     case ISAFamily::RDNA3:
-      // Only gfx12 is supported for now
-      if (getWmmaVersion(archGenerationName) == 2) {
-        ttg::populateDecomposeScaledBlockedPatterns(mfmaPatterns,
-                                                    /*benefit=*/3);
-      }
+      ttg::populateDecomposeScaledBlockedPatterns(mfmaPatterns,
+                                                  /*benefit=*/3);
       mfmaPatterns.add<::BlockedToWMMA>(
           context, getWmmaVersion(archGenerationName), matrixInstructionSize,
           /*benefit=*/2);


### PR DESCRIPTION
I saw some occasional test failures, but after disabling True16, tests seem to pass fine.