### PR TITLE
update ptxas and nvidia toolchain for sm103 (gb300)

### DIFF
--- a/cmake/nvidia-toolchain-version.json
+++ b/cmake/nvidia-toolchain-version.json
@@ -1,8 +1,8 @@
 {
-  "ptxas": "12.8.93",
-  "cuobjdump": "12.8.55",
-  "nvdisasm": "12.8.55",
-  "cudacrt": "12.8.61",
-  "cudart": "12.8.57",
-  "cupti": "12.8.90"
+  "ptxas": "12.9.86",
+  "cuobjdump": "12.9.82",
+  "nvdisasm": "12.9.88",
+  "cudacrt": "12.9.86",
+  "cudart": "12.9.79",
+  "cupti": "12.9.79"
 }


### PR DESCRIPTION
fixes errors with ptxas via torch/vllm:
```
torch._inductor.exc.InductorError: RuntimeError: Failed to run autotuning code block: No valid triton configs. PTXASError: PTXAS error: Internal Triton PTX codegen error
(VllmWorker TP0 pid=9311) ERROR 08-25 01:25:18 [multiproc_executor.py:602] `ptxas` stderr:
(VllmWorker TP0 pid=9311) ERROR 08-25 01:25:18 [multiproc_executor.py:602] ptxas fatal   : Value 'sm_103a' is not defined for option 'gpu-name'
```

I'm not sure if there's a reason to hold this for older arch support? 12.8 vs 12.9 in my experience so far has been pretty smooth for ampere/hopper/blackwell, not sure what other considerations might apply.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `existing tests should pass with 12.9, I doubt anyone has sm103 in CI, and other projects don't support it well yet`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
