### PR TITLE
Fix lit subfolder tests failing when run via ninja check-triton-lit-tests-<folder>

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
   MAIN_CONFIG
-  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
 )
 
 set(TRITON_TEST_DEPENDS
@@ -28,4 +28,4 @@ add_lit_testsuite(check-triton-lit-tests "Running the triton regression tests"
 
 set_target_properties(check-triton-lit-tests PROPERTIES FOLDER "Tests")
 
-add_lit_testsuites(TRITON-LIT-TESTS ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TRITON_TEST_DEPENDS})
+add_lit_testsuites(TRITON-LIT-TESTS ${CMAKE_CURRENT_BINARY_DIR} DEPENDS ${TRITON_TEST_DEPENDS})


### PR DESCRIPTION
### Summary

This PR fixes an issue where running a specific lit test folder
(e.g., `Conversion`) using `ninja check-triton-lit-tests-<folder>` fails
with the error:
```
AttributeError: ‘NoneType’ object has no attribute ‘use_lit_shell’
```
### Changes
Use binary dir in TRITON-LIT-TESTS and set MAIN_CONFIG to lit.site.cfg.py.
### Related Issue

Fixes #7965

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [✅ ] I am not making a trivial change, such as fixing a typo in a comment.

- [✅ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [✅ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [✅ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [✅ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
