### PR TITLE
[Makefile] Adding dev-install-triton-non-verbose dev-install-torch-url targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,16 @@ dev-install-torch:
 dev-install-triton:
 	$(PYTHON) -m pip install -e . --no-build-isolation -v
 
+.PHONY: dev-install-triton-non-verbose
+dev-install-triton-non-verbose:
+	$(PYTHON) -m pip install -e . --no-build-isolation
+
+.PHONY: dev-install-torch-url
+dev-install-torch-url:
+	# install torch from url (for nightly) but ensure pytorch-triton isn't installed
+	$(PYTHON) -m pip install --no-cache-dir --pre torch --index-url $(TORCH_URL)
+	$(PYTHON) -m pip uninstall pytorch-triton pytorch-triton-rocm -y
+
 .PHONY: dev-install
 .NOPARALLEL: dev-install
 dev-install: dev-install-requires dev-install-triton


### PR DESCRIPTION
Adding dev-install-triton-non-verbose in order to build with less verbose output, and dev-install-torch-url to install the Torch nightly provided the correct URL:


```bash
export TORCH_URL=https://download.pytorch.org/whl/nightly/cu126
make dev-install-torch-url
```

```bash
make dev-install-triton-non-verbose
...
Successfully built triton
Installing collected packages: triton
  Attempting uninstall: triton
    Found existing installation: triton 3.4.0+git1a086509
    Uninstalling triton-3.4.0+git1a086509:
      Successfully uninstalled triton-3.4.0+git1a086509
Successfully installed triton-3.4.0+gitc17c500f

[notice] A new release of pip available: 22.3.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
```
