### PR TITLE
Add support for TMA with NaN as the out-of-bounds value

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -1051,7 +1051,8 @@ def TT_MakeTensorDescOp : TT_Op<"make_tensor_descriptor", [
   let arguments = (ins
     TT_Ptr:$base,
     Variadic<I32>:$shape,
-    Variadic<I64>:$strides
+    Variadic<I64>:$strides,
+    DefaultValuedAttr<BoolAttr, "false">:$oobFillNaN
   );
 
   let results = (outs TT_TensorDescType:$result);
@@ -1059,7 +1060,7 @@ def TT_MakeTensorDescOp : TT_Op<"make_tensor_descriptor", [
   let assemblyFormat = "$base `,` `[` $shape `]` `,` `[` $strides `]` attr-dict `:` type($base) `,` type($result)";
 
   let builders = [
-    OpBuilder<(ins "Value":$base, "ValueRange":$shape, "ValueRange":$strides, "ArrayRef<int32_t>":$blockShape, "bool":$isSignedInteger)>
+    OpBuilder<(ins "Value":$base, "ValueRange":$shape, "ValueRange":$strides, "ArrayRef<int32_t>":$blockShape, "bool":$isSignedInteger, "bool":$oobFillNaN)>
   ];
 
   let extraClassDeclaration = [{

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1020,7 +1020,7 @@ OpFoldResult AdvanceOp::fold(FoldAdaptor adaptor) {
 void MakeTensorDescOp::build(OpBuilder &builder, OperationState &state,
                              Value base, ValueRange shape, ValueRange strides,
                              ArrayRef<int32_t> blockShape,
-                             bool isSignedInteger) {
+                             bool isSignedInteger, bool oobFillNaN) {
   auto ptrTy = dyn_cast<triton::PointerType>(base.getType());
   if (!ptrTy) {
     llvm::report_fatal_error("Expected pointer type");
@@ -1030,7 +1030,7 @@ void MakeTensorDescOp::build(OpBuilder &builder, OperationState &state,
   auto blockTy = RankedTensorType::get(blockShape64, elemTy);
   auto descTy =
       TensorDescType::get(builder.getContext(), blockTy, isSignedInteger);
-  return build(builder, state, descTy, base, shape, strides);
+  return build(builder, state, descTy, base, shape, strides, oobFillNaN);
 }
 
 // The following ops, including `call`, `func`, and `return` are copied and

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
@@ -304,6 +304,8 @@ LogicalResult createTMADesc(Value tmaPtr, MakeTensorDescOp op,
     return failure();
   }
 
+  int32_t fillMode = op.getOobFillNaN() ? 1 : 0;
+
   builder.create<TensormapCreateOp>(
       loc,
       /*desc_ptr=*/tmaPtr,
@@ -315,7 +317,7 @@ LogicalResult createTMADesc(Value tmaPtr, MakeTensorDescOp op,
       /*elem_type*/ builder.getI32IntegerAttr(*elemTypeEnum),
       /*interleave_layout*/ builder.getI32IntegerAttr(0),
       /*swizzle_mode=*/builder.getI32IntegerAttr(swizzleMode),
-      /*fill_mode=*/builder.getI32IntegerAttr(0));
+      /*fill_mode=*/builder.getI32IntegerAttr(fillMode));
   return success();
 }
 

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1762,9 +1762,9 @@ void init_triton_ir(py::module &&m) {
       .def("create_make_tensor_descriptor",
            [](TritonOpBuilder &self, Value &base, std::vector<Value> &shape,
               std::vector<Value> &strides, std::vector<int32_t> &tensorShape,
-              bool isSignedInteger) -> Value {
+              bool isSignedInteger, bool oobFillNaN) -> Value {
              return self.create<MakeTensorDescOp>(base, shape, strides,
-                                                  tensorShape, isSignedInteger);
+                                                  tensorShape, isSignedInteger, oobFillNaN);
            });
 
   py::class_<PassManager>(m, "pass_manager", py::module_local())

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -156,8 +156,7 @@ def test_tensor_descriptor_functional_interface(dtype_str, device):
     torch.testing.assert_close(unwrap_tensor(inp), unwrap_tensor(out))
 
 
-@pytest.mark.skipif(not (is_cuda() and torch.cuda.is_available() and torch.cuda.get_device_capability(0)[0] >= 9),
-                    reason="Requires NVIDIA Hopper or newer")
+@pytest.mark.skipif(is_hip(), reason="Currently unsupported by HIP devices")
 def test_tensor_descriptor_oob_fill_mode_device(device):
     import torch
     @triton.jit
@@ -197,8 +196,7 @@ def test_tensor_descriptor_oob_fill_mode_device(device):
     assert torch.all(torch.isnan(out_nan[:, N:]))
 
 
-@pytest.mark.skipif(not (is_cuda() and torch.cuda.is_available() and torch.cuda.get_device_capability(0)[0] >= 9),
-                    reason="Requires NVIDIA Hopper or newer")
+@pytest.mark.skipif(is_hip(), reason="Currently unsupported by HIP devices")
 def test_host_tensor_descriptor_oob_fill_mode():
     import torch
     M, N = 8, 20

--- a/python/triton/experimental/gluon/nvidia/hopper.py
+++ b/python/triton/experimental/gluon/nvidia/hopper.py
@@ -13,6 +13,7 @@ class TensorDescriptor:
     strides: List[int]
     block_shape: List[int]
     layout: NVMMASharedLayout
+    oob_fill_nan: bool = False
 
     def __post_init__(self):
         rank = len(self.shape)
@@ -30,11 +31,12 @@ class TensorDescriptor:
         assert isinstance(self.layout, NVMMASharedLayout), "Layout must be NVMMASharedLayout"
 
     @staticmethod
-    def from_tensor(tensor: Any, block_shape: List[int], layout: NVMMASharedLayout):
+    def from_tensor(tensor: Any, block_shape: List[int], layout: NVMMASharedLayout, oob_fill_nan: bool = False):
         return TensorDescriptor(
             tensor,
             tensor.shape,
             tensor.stride(),
             block_shape,
             layout,
+            oob_fill_nan,
         )

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2228,6 +2228,7 @@ def make_tensor_descriptor(
     shape: List[tensor],
     strides: List[tensor],
     block_shape: List[constexpr],
+    oob_fill_nan: constexpr = False,
     _semantic=None,
 ) -> tensor_descriptor:
     """Make a tensor descriptor object
@@ -2277,7 +2278,7 @@ def make_tensor_descriptor(
         inplace_abs[grid](x, M, N, M_BLOCK, N_BLOCK)
 
     """
-    return _semantic.make_tensor_descriptor(base, shape, strides, block_shape)
+    return _semantic.make_tensor_descriptor(base, shape, strides, block_shape, oob_fill_nan)
 
 
 # -----------------------

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1902,6 +1902,7 @@ class TritonSemantic(Generic[TensorTy]):
         shape: List[TensorTy],
         strides: List[TensorTy],
         block_shape: List[tl.constexpr],
+        oob_fill_nan: bool = False,
     ) -> tl.tensor_descriptor:
         ndim = len(shape)
         if not (1 <= ndim <= 5):
@@ -1934,5 +1935,6 @@ class TritonSemantic(Generic[TensorTy]):
         is_signed_int = base.type.element_ty.is_int_signed()
 
         handle = self.builder.create_make_tensor_descriptor(base_handle, [s.handle for s in shape],
-                                                            [s.handle for s in strides], block_shape, is_signed_int)
+                                                            [s.handle for s in strides], block_shape, is_signed_int,
+                                                            oob_fill_nan)
         return tl.tensor_descriptor(handle, shape, strides, type)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1162,6 +1162,7 @@ def _implicit_cvt(arg):
             shape=[_implicit_cvt(s) for s in arg.shape],
             strides=strides,
             block_shape=[tl.constexpr(b) for b in arg.block_shape],
+            oob_fill_nan=arg.oob_fill_nan,
         )
     return arg
 
@@ -1205,6 +1206,7 @@ class GridExecutor:
                     arg.shape,
                     arg.strides,
                     arg.block_shape,
+                    arg.oob_fill_nan,
                 )
             elif not hasattr(arg, "data_ptr"):
                 return arg

--- a/python/triton/tools/tensor_descriptor.py
+++ b/python/triton/tools/tensor_descriptor.py
@@ -9,6 +9,7 @@ class TensorDescriptor:
     shape: List[int]
     strides: List[int]
     block_shape: List[int]
+    oob_fill_nan: bool = False
 
     def __post_init__(self):
         rank = len(self.shape)
@@ -26,10 +27,11 @@ class TensorDescriptor:
         assert self.strides[-1] == 1, "Last dimension must be contiguous"
 
     @staticmethod
-    def from_tensor(tensor: Any, block_shape: List[int]):
+    def from_tensor(tensor: Any, block_shape: List[int], oob_fill_nan: bool = False):
         return TensorDescriptor(
             tensor,
             tensor.shape,
             tensor.stride(),
             block_shape,
+            oob_fill_nan,
         )

--- a/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
+++ b/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
@@ -136,5 +136,5 @@ module {
 // CHECK-SAME: %[[PTR:[^:]*]]
 // CHECK-DAG: %[[c1:.*]] = arith.constant 1 : i64
 // CHECK-DAG: %[[c256:.*]] = arith.constant 256 : i64
-// CHECK: %{{.*}}:5 = tt.call @callee(%[[PTR]], %[[c256]], %[[c256]], %[[c256]], %[[c1]])
-// CHECK-SAME -> (!tt.ptr<f32>, i64, i64, i64, i64)
+// CHECK: %{{.*}}:6 = tt.call @callee(%[[PTR]], %[[c256]], %[[c256]], %[[c256]], %[[c1]], %false)
+// CHECK-SAME -> (!tt.ptr<f32>, i64, i64, i64, i64, i1)

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -204,6 +204,7 @@ def make_launcher(constants, signature, warp_size):
                 output.append("*" + dtype)
                 for _ in range(2 * ndim):
                     output.append("i64")
+                output.append("i1")
                 # Currently the host side tensor descriptors get passed in as a
                 # tensor desc, shape, and strides. We have no way to use these
                 # shape and strides when processing tensor descriptors which is
@@ -606,7 +607,7 @@ def wrap_handle_tensor_descriptor(launcher):
                 # descriptors which is why we provide our own decomposition
                 # above. Sadly this means we have to pass the shape and strides
                 # twice.
-                final_args.extend([arg.base, *arg.shape, *arg.strides, *arg.shape, *arg.strides])
+                final_args.extend([arg.base, *arg.shape, arg.oob_fill_nan, *arg.strides, *arg.shape, *arg.strides])
             else:
                 final_args.append(arg)
         return launcher(*meta_args, *final_args)

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -285,12 +285,13 @@ static PyObject *fillTMADescriptor(PyObject *self, PyObject *args) {
   int swizzle;
   int elemSize;
   int elemType;
+  int oobNan;
   PyObject *blockSize;
   PyObject *shape;
   PyObject *strides;
 
-  if (!PyArg_ParseTuple(args, "KKiiiOOO", &desc_address, &global_address,
-                        &swizzle, &elemSize, &elemType, &blockSize, &shape,
+  if (!PyArg_ParseTuple(args, "KKiiiiOOO", &desc_address, &global_address,
+                        &swizzle, &elemSize, &elemType, &oobNan, &blockSize, &shape,
                         &strides)) {
     return NULL;
   }
@@ -368,7 +369,9 @@ static PyObject *fillTMADescriptor(PyObject *self, PyObject *args) {
       (CUtensorMap *)desc_address, elemType, rank, (void *)global_address,
       shapeInt, stridesLL, blockSizeInt, elementStrides,
       CU_TENSOR_MAP_INTERLEAVE_NONE, swizzle,
-      CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE));
+      CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+      oobNan ? CU_TENSOR_MAP_FLOAT_OOB_FILL_NAN_REQUEST_ZERO_FMA
+             : CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE));
   Py_RETURN_NONE;
 
 cleanup:

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -148,6 +148,8 @@ def make_launcher(constants, signature, tensordesc_meta):
                     # we have to pass the shape and strides twice.
                     for _ in range(2 * ndim):
                         output.append("i64")
+
+                    output.append("i1")
                 else:
                     output.append("nvTmaDesc")
 
@@ -620,7 +622,7 @@ def make_tensordesc_arg(arg, metadata):
         # descriptors which is why we provide our own decomposition
         # above. Sadly this means we have to pass the shape and strides
         # twice.
-        return [arg.base, *arg.shape, *arg.strides, *arg.shape, *arg.strides]
+        return [arg.base, *arg.shape, *arg.strides, arg.oob_fill_nan, *arg.shape, *arg.strides]
 
     swizzle = metadata["swizzle"]
     elem_size = metadata["elem_size"]

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -645,6 +645,7 @@ def make_tensordesc_arg(arg, metadata):
         swizzle,
         elem_size,
         TMA_DTYPE_DEVICE_TO_HOST[elem_type],
+        1 if getattr(arg, 'oob_fill_nan', False) else 0,
         block_size,
         shape,
         strides,


### PR DESCRIPTION
- support for passing oobFillNaN = true on TMA descriptor creation for both host and device TMAs
- forwards this argument down to tma descriptor creation
- implement the NaN other value in the TMA fallback path 