### PR TITLE
runtime: optionally initialize tritonparse structured logging when available

### DIFF
--- a/python/triton/runtime/__init__.py
+++ b/python/triton/runtime/__init__.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 from .autotuner import (Autotuner, Config, Heuristics, autotune, heuristics)
 from .cache import RedisRemoteCacheBackend, RemoteCacheBackend
 from .driver import driver
@@ -21,3 +23,9 @@ __all__ = [
     "RemoteCacheBackend",
     "TensorWrapper",
 ]
+
+# TritonParse initialization must be called after knobs initialization
+if importlib.util.find_spec("tritonparse") is not None:
+    import tritonparse.structured_logging
+
+    tritonparse.structured_logging.init_with_env()


### PR DESCRIPTION
### Summary
This PR adds an optional hook to initialize [TritonParse](https://github.com/meta-pytorch/tritonparse) structured logging during runtime import.
After knobs are initialized, we check for the presence of tritonparse using importlib.util.find_spec, and if available, call structured_logging.init_with_env().

### Rationale

- Provides early, environment-based logging for users with tritonparse.
- No changes for users without it (safe no-op).
- No new dependencies or API surface changes.

### Open Question
I placed the initialization in `python/triton/runtime/__init__.py` for early runtime coverage. If there is a more appropriate location, feedback is welcome.

cc @davidberard98 @danzimm 

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `TritonParse is only enabled when it is installed`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
