### PR TITLE
[BACKEND] Restrict MMAV5/MMV3 usage for N < 16 and fix no-swizzle case

### DIFF
--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -91,7 +91,7 @@ def get_src_element_ty_size(dtype_str):
 @pytest.mark.parametrize("dtype_dst_str", ["float32", "float16", "float64"])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES", [(128, 128, 16, 4), (64, 128, 32, 4), (32, 32, 32, 4),
                                                                    (256, 128, 32, 4), (64, 512, 32, 2),
-                                                                   (512, 64, 32, 2), (64, 16, 16, 4)])
+                                                                   (512, 64, 32, 2), (64, 16, 32, 4)])
 @pytest.mark.parametrize("NUM_CTAS", [1, 2])
 @pytest.mark.parametrize("NUM_WARPS", [4, 8])
 @pytest.mark.parametrize("EPILOGUE_SUBTILE", [True, False])

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -102,8 +102,13 @@ static Value createDescriptor(ConversionPatternRewriter &rewriter, Location loc,
   default:
     llvm::report_fatal_error("Unsupported swizzling size.");
   }
-  desc.strideDimensionBaseOffset = swizzling >> 1;
-  desc.leadDimensionBaseOffset = (swizzling * stride) >> 4;
+  if (swizzling == 0) {
+    desc.leadDimensionBaseOffset = 16 >> 4; // 16 bytes.
+    desc.strideDimensionBaseOffset = (8 * 16) >> 4;
+  } else {
+    desc.leadDimensionBaseOffset = (swizzling * stride) >> 4;
+    desc.strideDimensionBaseOffset = swizzling >> 1;
+  }
   return b.int_val(64, desc.descriptor);
 }
 
@@ -139,18 +144,23 @@ Value mlir::triton::NVIDIA::DotOpMmaV3SmemLoader::smemLoad(
   if (trans) {
     std::swap(k, m);
   }
-  Value leading_offset =
-      tb.mul(tb.udiv(k, elemsPerSwizzlingRowVal),
-             tb.i32_val(shape[1 - fastMovingDim] * elemsPerSwizzlingRow));
-  Value stride_offset = tb.mul(m, elemsPerSwizzlingRowVal);
-  Value offset = tb.add(tb.add(leading_offset, stride_offset),
-                        tb.urem(k, elemsPerSwizzlingRowVal));
   Value off1;
-  // Avoid the runtime udiv if we know the elements are byte multiples
-  if (elemBits % 8) {
-    off1 = tb.udiv(tb.mul(tb.i32_val(elemBits), offset), tb.i32_val(8));
+  if (elemsPerSwizzlingRow > 0) {
+    Value leading_offset =
+        tb.mul(tb.udiv(k, elemsPerSwizzlingRowVal),
+               tb.i32_val(shape[1 - fastMovingDim] * elemsPerSwizzlingRow));
+    Value stride_offset = tb.mul(m, elemsPerSwizzlingRowVal);
+    Value offset = tb.add(tb.add(leading_offset, stride_offset),
+                          tb.urem(k, elemsPerSwizzlingRowVal));
+    // Avoid the runtime udiv if we know the elements are byte multiples
+    if (elemBits % 8) {
+      off1 = tb.udiv(tb.mul(tb.i32_val(elemBits), offset), tb.i32_val(8));
+    } else {
+      off1 = tb.mul(tb.i32_val(elemBits / 8), offset);
+    }
   } else {
-    off1 = tb.mul(tb.i32_val(elemBits / 8), offset);
+    off1 = tb.mul(k, tb.i32_val(shape[1 - fastMovingDim]));
+    off1 = tb.add(off1, tb.mul(m, tb.i32_val(1024)));
   }
   Value smemBase = tb.ptrtoint(i32_ty, base);
   smemBase = tb.add(smemBase, off1);


### PR DESCRIPTION
This prevent generating miscompiles for cases where the N dimension is too small. Technically we could support N=8 but it would require padding the shared memory.
