### PR TITLE
Add support for 5 triton backends instead of 4

### DIFF
--- a/python/src/main.cc
+++ b/python/src/main.cc
@@ -8,11 +8,12 @@ namespace py = pybind11;
 #define FOR_EACH_2(MACRO, X, ...) MACRO(X) FOR_EACH_1(MACRO, __VA_ARGS__)
 #define FOR_EACH_3(MACRO, X, ...) MACRO(X) FOR_EACH_2(MACRO, __VA_ARGS__)
 #define FOR_EACH_4(MACRO, X, ...) MACRO(X) FOR_EACH_3(MACRO, __VA_ARGS__)
+#define FOR_EACH_5(MACRO, X, ...) MACRO(X) FOR_EACH_4(MACRO, __VA_ARGS__)
 
 #define FOR_EACH_NARG(...) FOR_EACH_NARG_(__VA_ARGS__, FOR_EACH_RSEQ_N())
 #define FOR_EACH_NARG_(...) FOR_EACH_ARG_N(__VA_ARGS__)
-#define FOR_EACH_ARG_N(_1, _2, _3, _4, N, ...) N
-#define FOR_EACH_RSEQ_N() 4, 3, 2, 1, 0
+#define FOR_EACH_ARG_N(_1, _2, _3, _4, _5, N, ...) N
+#define FOR_EACH_RSEQ_N() 5, 4, 3, 2, 1, 0
 
 #define CONCATENATE(x, y) CONCATENATE1(x, y)
 #define CONCATENATE1(x, y) x##y


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because the build and tests that exist validate that support for multiple backends continues to work. There's also no explicit test at the moment for the number of backends and one would be non-trivial to write.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
    
This change adds support for one more element in the `FOR_EACH_P` macro (and therefore its dependencies) - in particular, currently the macro supports 4 elements and after this change, it will support 5.

The macro is only used in one place currently - to iterate over the supported backends, for example:

```
FOR_EACH_P(DECLARE_BACKEND, TRITON_BACKENDS_TUPLE)
```

With the addition of gluon, the default number of backends is now 3 (gluon, cuda, amd) which only leaves "room" for one more backend. So if one wanted to add `triton-shared`, that would be the limit of backends they can support unless they explicitly drop one of the defaults. By bumping the number here, triton can support the defaults + 2 more backends which is the behavior from before the addition of gluon.