### PR TITLE
Add `llc` to the lit tool configuration

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -59,6 +59,7 @@ tools = [
     'triton-opt',
     'triton-llvm-opt',
     'mlir-translate',
+    'llc',
     ToolSubst('%PYTHON', config.python_executable, unresolved='ignore'),
 ]
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because the confirmation that this works is that the existing lit tests continue to function.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

The triton lit tests leverage several llvm & mlir tools such as opt, mlir-translate and llc. These are generally configured to come directly from the llvm build that triton is using, but llc is not. This means that right now the llc version on the system will be used instead and if it doesn't match the rest of the tools, we can end up with failures. An example failure is using an older version than the llvm build and missing features (such as `ptx83`). To fix this issue, configure lit to use the `llc` directly from the llvm build.
