### PR TITLE
Fix func signature conversion to ttgir

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -499,12 +499,12 @@ public:
   matchAndRewrite(triton::FuncOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto converter = getTypeConverter();
-    TypeConverter::SignatureConversion result =
+    TypeConverter::SignatureConversion signatureConversion =
         converter->convertBlockSignature(&op.getBody().front()).value();
 
-    auto newFuncType =
-        FunctionType::get(rewriter.getContext(), result.getConvertedTypes(),
-                          op.getFunctionType().getResults());
+    auto newFuncType = FunctionType::get(
+        rewriter.getContext(), signatureConversion.getConvertedTypes(),
+        op.getFunctionType().getResults());
 
     auto newOp =
         rewriter.create<triton::FuncOp>(op.getLoc(), op.getName(), newFuncType);
@@ -515,8 +515,8 @@ public:
     // Convert just the entry block. The remaining unstructured control flow is
     // converted by br patterns.
     if (!newOp.getBody().empty())
-      rewriter.applySignatureConversion(&newOp.getBody().front(), result,
-                                        converter);
+      rewriter.applySignatureConversion(&newOp.getBody().front(),
+                                        signatureConversion, converter);
     rewriter.replaceOp(op, newOp);
     return success();
   }

--- a/test/Conversion/triton_to_tritongpu.mlir
+++ b/test/Conversion/triton_to_tritongpu.mlir
@@ -168,3 +168,13 @@ tt.func @cf_br(%ptr: !tt.ptr<i32>) {
   tt.store %ptrs, %arg0 : tensor<128x!tt.ptr<i32>>
   tt.return
 }
+
+// -----
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, unpacked = true>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_func1(%arg0: tensor<64x1xi32>,%arg1: !ttg.memdesc<1x64x64xf32, #tmem, #ttng.tensor_memory, mutable>) attributes {noinline = false} {
+    %1 = tt.broadcast %arg0 : tensor<64x1xi32> -> tensor<64x64xi32>
+    tt.return
+  }
+}

--- a/test/Conversion/triton_to_tritongpu.mlir
+++ b/test/Conversion/triton_to_tritongpu.mlir
@@ -171,9 +171,11 @@ tt.func @cf_br(%ptr: !tt.ptr<i32>) {
 
 // -----
 
-#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, unpacked = true>
+// CHECK-DAG: [[BLOCKED:#.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @test_func1(%arg0: tensor<64x1xi32>,%arg1: !ttg.memdesc<1x64x64xf32, #tmem, #ttng.tensor_memory, mutable>) attributes {noinline = false} {
+  // CHECK: %arg0: tensor<64x1xi32, [[BLOCKED]]>
+  tt.func public @test_func1(%arg0: tensor<64x1xi32>) attributes {noinline = false} {
+    // CHECK: tt.broadcast {{.*}} : tensor<64x1xi32, [[BLOCKED]]> -> tensor<64x64xi32, [[BLOCKED]]>
     %1 = tt.broadcast %arg0 : tensor<64x1xi32> -> tensor<64x64xi32>
     tt.return
   }


### PR DESCRIPTION
https://github.com/triton-lang/triton/blob/4b36a8a88af2b81ce2fb1d9245bd425268071338/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp#L104-L112

shows that we indeed want to support passing a RankedTensorType as a func arg. However, the dialect conversion is not working well here.

The issue is the new created FuncOp was not using a properly converted FunctionType, and the SignatureConversion object passed to applySignatureConversion was empty without any converted type.

The code change comes from this example:

https://github.com/llvm/llvm-project/blob/751e6c08b2f6cd40908b8810a2a2da476e88417e/mlir/lib/Transforms/Utils/DialectConversion.cpp#L3072-L3083

Prior to this PR, the added test case would fail with this error:
```
FAIL: TRITON :: Conversion/triton_to_tritongpu.mlir (131 of 197)
******************** TEST 'TRITON :: Conversion/triton_to_tritongpu.mlir' FAILED ********************
Exit Code: 1

Command Output (stderr):
--
RUN: at line 1: /data/users/pchen7e4/triton/build/cmake.linux-x86_64-cpython-3.11/bin/triton-opt /data/users/pchen7e4/triton/test/Conversion/triton_to_tritongpu.mlir -split-input-file -convert-triton-to-tritongpu='target=cuda:80 num-warps=2' | FileCheck /data/users/pchen7e4/triton/test/Conversion/triton_to_tritongpu.mlir
+ /data/users/pchen7e4/triton/build/cmake.linux-x86_64-cpython-3.11/bin/triton-opt /data/users/pchen7e4/triton/test/Conversion/triton_to_tritongpu.mlir -split-input-file '-convert-triton-to-tritongpu=target=cuda:80 num-warps=2'
+ FileCheck /data/users/pchen7e4/triton/test/Conversion/triton_to_tritongpu.mlir
/data/users/pchen7e4/triton/test/Conversion/triton_to_tritongpu.mlir:177:30: error: failed to legalize unresolved materialization from () to ('tensor<64x1xi32>') that remained live after conversion
  tt.func public @test_func1(%arg0: tensor<64x1xi32>) attributes {noinline = false} {
                             ^
/data/users/pchen7e4/triton/test/Conversion/triton_to_tritongpu.mlir:177:30: note: see current operation: %0 = "builtin.unrealized_conversion_cast"() : () -> tensor<64x1xi32>
/data/users/pchen7e4/triton/test/Conversion/triton_to_tritongpu.mlir:179:10: note: see existing live user here: %1 = "tt.broadcast"(%0) : (tensor<64x1xi32>) -> tensor<64x64xi32>
    %1 = tt.broadcast %arg0 : tensor<64x1xi32> -> tensor<64x64xi32>
         ^
```
