### PR TITLE
Update __init__.py

### DIFF
--- a/python/triton/tools/__init__.py
+++ b/python/triton/tools/__init__.py
@@ -1,0 +1,3 @@
+from .tensor_descriptor import TensorDescriptor
+
+__all__ = ["TensorDescriptor"]


### PR DESCRIPTION
Tried importing tensor_descriptor from triton.tools but we're missing the target and based on pattern matching with the compiler/__init__.py it seems like we need to expose it.

```
In [20]: triton.tools.tensor_descriptor
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[20], line 1
----> 1 triton.tools.tensor_descriptor

ImportError: cannot import name 'tensor_descriptor' from 'triton.tools'
```


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because this should be a target change.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
