### PR TITLE
[Proton] Demangle kernel names

### DIFF
--- a/third_party/proton/csrc/include/Utility/String.h
+++ b/third_party/proton/csrc/include/Utility/String.h
@@ -1,6 +1,8 @@
 #ifndef PROTON_UTILITY_STRING_H_
 #define PROTON_UTILITY_STRING_H_
 
+#include <cstdlib>
+#include <cxxabi.h>
 #include <string>
 
 namespace proton {
@@ -56,6 +58,20 @@ inline std::vector<std::string> split(const std::string &str,
   }
   result.push_back(str.substr(start, end));
   return result;
+}
+
+inline std::string demangle(const std::string &mangledName) {
+  int status = 0;
+  char *demangled =
+      abi::__cxa_demangle(mangledName.c_str(), nullptr, nullptr, &status);
+
+  if (status == 0 && demangled) {
+    std::string result(demangled);
+    std::free(demangled);
+    return result;
+  }
+
+  return mangledName;
 }
 
 } // namespace proton

--- a/third_party/proton/csrc/lib/Data/TraceData.cpp
+++ b/third_party/proton/csrc/lib/Data/TraceData.cpp
@@ -1,6 +1,7 @@
 #include "Data/TraceData.h"
 #include "TraceDataIO/TraceWriter.h"
 #include "Utility/Errors.h"
+#include "Utility/String.h"
 #include "nlohmann/json.hpp"
 
 #include <algorithm>
@@ -385,8 +386,8 @@ convertToTimelineTrace(TraceData::Trace *trace,
       }
       parserResult->blockTraces.push_back(std::move(blockTrace));
     }
-    metadata->kernelName =
-        getStringValue(kernelEvent.cycleMetric, CycleMetric::KernelName);
+    metadata->kernelName = demangle(
+        getStringValue(kernelEvent.cycleMetric, CycleMetric::KernelName));
     metadata->scopeName = scopeIdToName;
     if (timeShiftCost > 0)
       timeShift(timeShiftCost, parserResult);
@@ -427,7 +428,7 @@ void dumpKernelMetricTrace(
       auto contexts = trace->getContexts(contextId);
 
       json element;
-      element["name"] = contexts.back().name;
+      element["name"] = demangle(contexts.back().name);
       element["cat"] = "kernel";
       element["ph"] = "X";
       element["ts"] = ts;
@@ -435,7 +436,7 @@ void dumpKernelMetricTrace(
       element["tid"] = streamId; // thread id = stream
       json callStack = json::array();
       for (auto const &ctx : contexts) {
-        callStack.push_back(ctx.name);
+        callStack.push_back(demangle(ctx.name));
       }
       element["args"]["call_stack"] = std::move(callStack);
 

--- a/third_party/proton/csrc/lib/Data/TreeData.cpp
+++ b/third_party/proton/csrc/lib/Data/TreeData.cpp
@@ -2,6 +2,7 @@
 #include "Context/Context.h"
 #include "Data/Metric.h"
 #include "Device.h"
+#include "Utility/String.h"
 #include "nlohmann/json.hpp"
 
 #include <limits>
@@ -209,7 +210,7 @@ void TreeData::dumpHatchet(std::ostream &os) const {
   std::map<uint64_t, std::set<uint64_t>> deviceIds;
   this->tree->template walk<Tree::WalkPolicy::PreOrder>([&](Tree::TreeNode
                                                                 &treeNode) {
-    const auto contextName = treeNode.name;
+    const auto contextName = demangle(treeNode.name);
     auto contextId = treeNode.id;
     json *jsonNode = jsonNodes[contextId];
     (*jsonNode)["frame"] = {{"name", contextName}, {"type", "function"}};


### PR DESCRIPTION
Some CUDA library kernel names are a C++ mangled function names. This PR demangles these before dumping the profiles.
We do this at save-time and not at runtime so we don't have any runtime overhead.
Handles both tree and trace dumps.

Before PR
```
0.001 ROOT
├─ 0.001 _ZN7cutlass7Kernel2I63cutlass_80_tensorop_bf16_s16816gemm_bf16_128x256_64x3_tn_align2EEvNT_6ParamsE
```

After PR
```
0.001 ROOT
├─ 0.001 void cutlass::Kernel2<cutlass_80_tensorop_bf16_s16816gemm_bf16_128x256_64x3_tn_align2>(cutlass_80_tensorop_bf16_s16816gemm_bf16_128x256_64x3_tn_align2::Params)
```

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
