### PR TITLE
Add unused variable flag and make required fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ endfunction()
 
 # Disable warnings that show up in external code (gtest;pybind11)
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-covered-switch-default -fvisibility=hidden")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wunused-variable -Wno-covered-switch-default -fvisibility=hidden")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244 /wd4624 /wd4715 /wd4530")
 endif()

--- a/include/triton/Analysis/AxisInfo.h
+++ b/include/triton/Analysis/AxisInfo.h
@@ -206,7 +206,7 @@ public:
                                   axisinfo::CallbackType callback = nullptr)
       : CallGraph<AxisInfoMapT>(moduleOp) {
     SmallVector<FunctionOpInterface> funcs;
-    for (auto root : getRoots()) {
+    for ([[maybe_unused]] auto root : getRoots()) {
       walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
           // Pre-order edge walk callback
           [](CallOpInterface callOp, FunctionOpInterface funcOp) {},

--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -174,7 +174,6 @@ public:
     Type elemTy = this->getTypeConverter()->convertType(resultElementTy);
     SmallVector<SmallVector<Value>> allOperands;
     for (auto operand : adaptor.getOperands()) {
-      auto argTy = op->getOperand(0).getType();
       auto subOperands = unpackLLElements(loc, operand, rewriter);
       allOperands.resize(subOperands.size());
       for (auto v : llvm::enumerate(subOperands))

--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -69,7 +69,6 @@ def DotOpInterface : OpInterface<"DotOpInterface"> {
         auto aTy = cast<ShapedType>($_op.getA().getType());
         auto bTy = cast<ShapedType>($_op.getB().getType());
         auto cTy = cast<ShapedType>($_op->getOperand(2).getType());
-        auto dTy = cast<ShapedType>($_op.getD().getType());
         auto aShape = aTy.getShape();
         auto bShape = bTy.getShape();
         auto cShape = cTy.getShape();

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -288,7 +288,8 @@ def TTG_MemDescReshapeOp : TTG_Op<"memdesc_reshape", [Pure,
               [{
                 MemDescType dstTy;
                 auto srcTy = cast<MemDescType>(src.getType());
-                auto result = inferReturnTypes($_builder.getContext(),
+                [[maybe_unused]] auto result = inferReturnTypes(
+                                           $_builder.getContext(),
                                            $_builder.getUnknownLoc(),
                                            srcTy, shape, dstTy);
                 assert(succeeded(result) && "failed to infer return types");

--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -817,9 +817,12 @@ public:
   ColumnAction() = default;
   ColumnAction(ArrayRef<size_t> action, StringAttr inDim, size_t inSizeLog2)
       : action(action), inDim(inDim), inSizeLog2(inSizeLog2) {
+#ifndef NDEBUG
     auto it = llvm::max_element(action);
     // Assert in the constructor... ugh
     assert(it == action.end() || *it < inSizeLog2);
+#endif
+
     // In many cases the action will be the identity, so we save that as an
     // early return
     m_isIdentity = action.size() == inSizeLog2 &&

--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -57,6 +57,7 @@ inline const std::set<std::string> CACHE_NEUTRAL_ENV_VARS = {
 namespace tools {
 
 inline void assertIsRecognized(const std::string &env) {
+#ifndef NDEBUG
   bool is_invalidating = CACHE_INVALIDATING_ENV_VARS.find(env.c_str()) !=
                          CACHE_INVALIDATING_ENV_VARS.end();
   bool is_neutral =
@@ -64,6 +65,7 @@ inline void assertIsRecognized(const std::string &env) {
   std::string errmsg = env + "is not recognized. "
                              "Please add it to triton/tools/sys/getenv.hpp";
   assert((is_invalidating || is_neutral) && errmsg.c_str());
+#endif
 }
 
 static std::mutex getenv_mutex;

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -300,7 +300,6 @@ private:
       // with element locations:
       // [4, 5, 6, 7]
       // It is "strided contiguous" with a divisibility of 16 bytes
-      auto rank = lhs.getRank();
       auto elemSize = std::max<int64_t>(
           1, triton::getPointeeBitWidth(op.getPtr().getType()) / 8);
       rhsDivisibility = multiplyDivisor(rhs.getDivisibility(dim), elemSize);
@@ -324,7 +323,6 @@ private:
         return {lhs.getConstantValue().value() -
                 rhs.getConstantValue().value()};
       } else if constexpr (std::is_same_v<OpTy, triton::AddPtrOp>) {
-        auto rank = lhs.getRank();
         auto elemSize = std::max<int64_t>(
             1, triton::getPointeeBitWidth(op.getPtr().getType()) / 8);
         auto rhsValue = rhs.getConstantValue().value() * elemSize;
@@ -489,7 +487,6 @@ private:
 
   int64_t getDivisibility(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                           int dim) override {
-    auto resTy = dyn_cast<RankedTensorType>(op.getType());
     if (rhs.getConstancy(dim) > 1) {
       // lhs: d_lhs * k = gcd(d_lhs, d_rhs) * k' * k = gcd(d_lhs, d_rhs) * k''
       // rhs: d_rhs * p = gcd(d_lhs, d_rhs) * p' * p = gcd(d_lhs, d_rhs) * p''
@@ -886,7 +883,6 @@ private:
       // Treat [2^n,2^n+1,...]'s divisibility as 1 instead of 2^n
       lhsDivisibility = 1;
     }
-    auto numBits = log2Int(lhsDivisibility);
     return multiplyDivisor(lhsDivisibility, 1ll << shift);
   }
 

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -159,7 +159,7 @@ void MembarOrFenceAnalysis::visitTerminator(
 
 void MembarAnalysis::insertBarrier(Operation *op, OpBuilder *builder) {
   OpBuilder::InsertionGuard g(*builder);
-  auto barrierOp = builder->create<gpu::BarrierOp>(op->getLoc());
+  builder->create<gpu::BarrierOp>(op->getLoc());
 }
 
 void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,

--- a/lib/Conversion/TritonGPUToLLVM/AssertOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AssertOpToLLVM.cpp
@@ -19,8 +19,6 @@ struct AssertOpConversion : public ConvertOpToLLVMPattern<triton::AssertOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    auto ctx = rewriter.getContext();
-    auto typeConverter = getTypeConverter();
     auto elems = unpackLLElements(loc, adaptor.getCondition(), rewriter);
     auto elemTy = elems[0].getType();
     Value condition = b.int_val(elemTy.getIntOrFloatBitWidth(), 0);
@@ -52,7 +50,6 @@ struct AssertOpConversion : public ConvertOpToLLVMPattern<triton::AssertOp> {
   void llAssert(Operation *op, Value condition, StringRef message,
                 ConversionPatternRewriter &rewriter) const {
 
-    auto ctx = rewriter.getContext();
     auto loc = op->getLoc();
 
     StringRef file = "unknown";

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -39,7 +39,6 @@ struct ConvertLayoutOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     MLIRContext *ctx = op.getContext();
 
-    const auto &shape = op.getType().getShape();
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getType();
 
@@ -95,8 +94,6 @@ struct ConvertLayoutOpConversion
     StringAttr kRegister = str_attr("register");
     assert(!cvtNeedsSharedMemory(op.getSrc().getType(), op.getType()));
 
-    auto srcTy = op.getSrc().getType();
-    auto dstTy = op.getType();
     auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
     SmallVector<Value> outVals(conversion.getInDimSize(kRegister));
     for (int i = 0; i < outVals.size(); i++) {
@@ -424,11 +421,10 @@ struct ConvertLayoutOpConversion
       ArrayRef<TranspositionInfo> mixedTranspositions) const {
     auto *ctx = rewriter.getContext();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    StringAttr kReg = str_attr("register");
     StringAttr kLane = str_attr("lane");
 
     SmallVector<Value> vals(inVals.begin(), inVals.end());
-    int m = mixedTranspositions.size();
+    [[maybe_unused]] int m = mixedTranspositions.size();
     int numRegs = inVals.size();
     // A single mixed transposition (r_i l_j) which swaps the i-th register
     // index bit and the j-th lane index bit of an element applies a tiled 2x2

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -17,8 +17,7 @@ public:
 
   Value multiplyVectors(ArrayRef<Value> a, ArrayRef<Value> b,
                         Value c) override {
-    auto K = a.size();
-    assert(b.size() == K);
+    assert(b.size() == a.size());
     Value accum = c;
     Type tgtTy = accum.getType();
     for (auto it = llvm::zip(a, b).begin(); it != llvm::zip(a, b).end(); ++it) {
@@ -49,7 +48,6 @@ public:
 LogicalResult convertFMADot(DotOp op, DotOp::Adaptor adaptor,
                             const LLVMTypeConverter *typeConverter,
                             ConversionPatternRewriter &rewriter) {
-  auto *ctx = rewriter.getContext();
   auto loc = op.getLoc();
   GenericFMAVectorMultiplier multiplier(rewriter, loc);
   return parametricConvertFMADot(op, adaptor, typeConverter, rewriter,

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMADotUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMADotUtility.cpp
@@ -54,7 +54,6 @@ ValueTableFMA getValueTableFromStructFMA(
   assert(elems.size() == numElemsRep * product(repetitions));
   assert(kDim == 1 || kDim == 2);
   assert(nonKDim == 1 || nonKDim == 2);
-  const unsigned bDim = 0;
 
   for (unsigned idx = 0; idx < elems.size(); ++idx) {
     auto inRepLinearIdx = idx % numElemsRep;
@@ -79,7 +78,6 @@ LogicalResult parametricConvertFMADot(DotOp op, DotOp::Adaptor adaptor,
                                       const LLVMTypeConverter *typeConverter,
                                       ConversionPatternRewriter &rewriter,
                                       FMAVectorMultiplier &multiplier) {
-  auto *ctx = rewriter.getContext();
   auto loc = op.getLoc();
 
   auto A = op.getA();
@@ -116,7 +114,6 @@ LogicalResult parametricConvertFMADot(DotOp op, DotOp::Adaptor adaptor,
 
   unsigned K = aShapePerCTA[2];
 
-  unsigned threadTileShape[3];
   unsigned repetitions[3];
   for (int i = 0; i < 3; ++i) {
     repetitions[i] =

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -339,7 +339,6 @@ struct ElementwiseInlineAsmOpConversion
     // Layout is unpackedOperands[operand][elem].
     SmallVector<SmallVector<Value>> unpackedOperands;
     for (auto operand : adaptor.getOperands()) {
-      auto argTy = op->getOperand(0).getType();
       auto subOperands = unpackLLElements(loc, operand, rewriter);
       unpackedOperands.push_back(subOperands);
     }
@@ -612,7 +611,6 @@ struct MapElementwiseOpConversion
     }
 
     auto &scalarOp = op.getScalarOp();
-    Region &parent = *rewriter.getBlock()->getParent();
 
     auto nOutputs = op.getNumResults();
     SmallVector<Value> scalarOutputs(nOutputs * nElems);

--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -107,7 +107,6 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
   // Map the MLIR attribute `tt.nv_tma_desc` to the appropriate LLVM and NVVM
   // attributes.
   static void handleByvalTmaDescArgs(LLVM::LLVMFuncOp &llvmFuncOp) {
-    const bool isKernel = triton::isKernel(llvmFuncOp);
     for (unsigned i = 0; i < llvmFuncOp.getNumArguments(); ++i) {
       const auto attrs = llvmFuncOp.getArgAttrDict(i);
       if (!attrs) {
@@ -119,12 +118,11 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
           const auto i32_type =
               mlir::IntegerType::get(llvmFuncOp.getContext(), 32);
           assert(attr.getValue() == mlir::IntegerAttr::get(i32_type, 1));
-          assert(isKernel &&
+          assert(triton::isKernel(llvmFuncOp) &&
                  "tt.nv_tma_desc is not supported for device functions");
 
           // See
           // https://github.com/google/jax/blob/main/jaxlib/mosaic/gpu/passes.cc
-          mlir::BlockArgument arg = llvmFuncOp.getArgument(i);
           const auto byteType =
               mlir::IntegerType::get(llvmFuncOp.getContext(), 8);
           const auto arrayType = mlir::LLVM::LLVMArrayType::get(

--- a/lib/Conversion/TritonGPUToLLVM/GatherOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/GatherOpToLLVM.cpp
@@ -263,8 +263,7 @@ void GatherOpConversion::emitWarpLocalGather(
   auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
   Value blockId = targetInfo.getClusterCTAId(rewriter, loc);
 
-  unsigned /*N=*/srcRegsPerThread = srcLayout.getInDimSize(kRegister);
-  assert(srcRegsPerThread == srcValues.size());
+  assert(/*N=*/srcLayout.getInDimSize(kRegister) == srcValues.size());
 
   // Given a index value, we need to know which sources register values it could
   // index into. This is invariant to anything other than the register, which we

--- a/lib/Conversion/TritonGPUToLLVM/GlobalScratchMemoryAllocation.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/GlobalScratchMemoryAllocation.cpp
@@ -22,7 +22,7 @@ static void allocateGMem(Operation *parentOp,
   parentOp->walk([&](triton::CallOp call) {
     auto callable = call.resolveCallable();
     if (!callable->hasAttr("ttg.global_scratch_memory_size")) {
-      auto inserted = callStack.insert(parentOp);
+      [[maybe_unused]] auto inserted = callStack.insert(parentOp);
       assert(inserted && "call cycle detected");
       allocateGMem(callable, callStack);
       callStack.remove(parentOp);

--- a/lib/Conversion/TritonGPUToLLVM/MakeRangeOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MakeRangeOpToLLVM.cpp
@@ -20,7 +20,6 @@ struct MakeRangeOpConversion
     Location loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     RankedTensorType ty = op.getType();
-    auto shape = ty.getShape();
     auto layout = ty.getEncoding();
     auto elemTy = ty.getElementType();
     assert(elemTy.isInteger(32));

--- a/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
@@ -90,11 +90,12 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
                    ArrayRef<SmallVector<Value>> indices,
                    ArrayRef<int> dimWidths, bool hex,
                    ConversionPatternRewriter &rewriter, bool isSigned) const {
+#ifndef NDEBUG
     assert(!elems.empty());
     assert(elems.size() == indices.size());
-    assert(dimWidths.size() == indices.front().size());
-
     size_t rank = dimWidths.size();
+    assert(rank == indices.front().size());
+#endif
 
     // Format is:
     //   pid (<x>, <y>, <z>) idx (<i1>, <i2>, ...)<prefix> (operand <n>) <elem>

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -334,8 +334,6 @@ private:
     triton::ReduceOp op = helper.getOperation();
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    auto srcLayout = helper.getSrcLayout();
-    auto axis = op.getAxis();
     auto smemOrder = helper.getOrderWithAxisAtBeginning();
     SmallVector<Value> results(op.getNumOperands());
     for (unsigned i = 0; i < op.getNumOperands(); ++i) {

--- a/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
@@ -252,8 +252,6 @@ static void AddPartialReduceOneWarp(SmallVector<SmallVector<Value>> &srcValues,
   unsigned parallelElementsPerThread = helper.getNonAxisNumElementsPerThread();
   unsigned elementStride = helper.getAxisElementStride();
   unsigned threadStride = helper.getAxisThreadStride();
-  unsigned axisNumWarps = helper.getAxisNumWarpsWithUniqueData();
-  unsigned numParallelLane = helper.getNonAxisNumThreadsPerCTA();
   unsigned scanDim = helper.getAxisNumThreadsPerWarpWithUniqueData();
   Value maskFirstWarp = b.icmp_eq(warpId, b.i32_val(0));
   Value maskFirstLane = b.icmp_eq(laneIdAxis, b.i32_val(0));

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -493,11 +493,10 @@ emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
   auto vecIndices =
       applyLinearLayoutVec(loc, rewriter, ll, commonIndices, registerIndices);
 
-  unsigned rank = shape.size();
   SmallVector<SmallVector<Value>> ret;
   for (auto &indices : vecIndices) {
     SmallVector<Value> vals;
-    assert(indices.size() == rank);
+    assert(indices.size() == shape.size());
     for (auto &idx : indices)
       vals.push_back(idx.second);
     ret.push_back(vals);
@@ -746,9 +745,7 @@ bool emitTransferBetweenRegistersAndShared(
   StringAttr kRegister = str_attr("register");
   StringAttr kLane = str_attr("lane");
   StringAttr kWarp = str_attr("warp");
-  StringAttr kOffset = str_attr("offset");
 
-  auto shape = sharedTy.getShape();
   auto paddedEnc =
       dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(sharedTy.getEncoding());
   LinearLayout regToSharedLayout = LinearLayout::empty();

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -22,9 +22,7 @@ namespace ttng = mlir::triton::nvidia_gpu;
 
 Value createFullLike(OpBuilder &builder, Location loc, Value scalar,
                      RankedTensorType tensorTy) {
-  auto scalarTy = scalar.getType();
-  auto elemTy = tensorTy.getElementType();
-  assert(scalarTy == elemTy &&
+  assert(scalar.getType() == tensorTy.getElementType() &&
          "Expected scalar to be of the same type as the tensor elements");
   return builder.create<triton::SplatOp>(loc, tensorTy, scalar);
 }
@@ -127,7 +125,7 @@ Value createMaxReduce(OpBuilder &b, Location loc, Value tensor, int axis) {
   auto cmpOp =
       b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, arg0, arg1);
   auto result = b.create<arith::SelectOp>(loc, cmpOp, arg0, arg1);
-  auto returnOp = b.create<tt::ReduceReturnOp>(loc, std::vector<Value>{result});
+  b.create<tt::ReduceReturnOp>(loc, std::vector<Value>{result});
   return reduceOp->getResult(0);
 }
 
@@ -148,7 +146,6 @@ struct AssertInThreadOpConversion
   matchAndRewrite(tti::ExperimentalAssertInThreadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto tensorTy = cast<RankedTensorType>(op.getCondition().getType());
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     SmallVector<Value> condElems =
         unpackLLElements(loc, adaptor.getCondition(), rewriter);
@@ -163,8 +160,8 @@ struct AssertInThreadOpConversion
     assert(condTy.isSignedInteger() ||
            condTy.isSignlessInteger() &&
                "Unsupported type for assert_in_thread");
-    Value zero = rewriter.create<LLVM::ConstantOp>(
-        loc, condTy, rewriter.getZeroAttr(condTy));
+    rewriter.create<LLVM::ConstantOp>(loc, condTy,
+                                      rewriter.getZeroAttr(condTy));
     for (auto elem : condElems) {
       if (check_any) {
         condition = b.or_(condition, elem);
@@ -232,8 +229,6 @@ struct BufferPointersOpConversion
   matchAndRewrite(tti::ExperimentalBufferPointersOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto *ctx = rewriter.getContext();
-    auto module = op->getParentOfType<ModuleOp>();
     auto values = adaptor.getOffsets();
     auto encoding =
         cast<ttg::BlockedEncodingAttr>(op.getResult().getType().getEncoding());

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -292,7 +292,6 @@ struct TritonCatPattern : public OpConversionPattern<triton::CatOp> {
     auto lhsTotalElemsPerThread = triton::gpu::getTotalElemsPerThread(lhsType);
     auto rhsTotalElemsPerThread = triton::gpu::getTotalElemsPerThread(rhsType);
     auto retTotalElemsPerThread = triton::gpu::getTotalElemsPerThread(retType);
-    auto retShape = retType.getShape();
     auto retOrder = retEncoding.getOrder();
     auto retThreadsPerWarp = retEncoding.getThreadsPerWarp();
     auto retWarpsPerCTA = retEncoding.getWarpsPerCTA();

--- a/lib/Dialect/Gluon/Transforms/ResolveAutoEncodings.cpp
+++ b/lib/Dialect/Gluon/Transforms/ResolveAutoEncodings.cpp
@@ -203,7 +203,6 @@ LogicalResult inferAutoLayouts(FuncOp func) {
   }
 
   // 3. Transfer propagated encodings into the graph
-  auto ctx = func.getContext();
   for (auto &[val, info] : valueToEncoding) {
     auto existingTy = cast<RankedTensorType>(val.getType());
     assert(isa<gluon::AutoEncodingAttr>(existingTy.getEncoding()));
@@ -252,7 +251,6 @@ public:
   using BaseT::BaseT;
 
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
     // Do layout inference
     if (failed(inferAutoLayouts(m)))

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -775,9 +775,10 @@ void ReshapeOp::build(OpBuilder &builder, OperationState &state,
   auto srcEnc = srcTy.getEncoding();
   Attribute dstEnc;
   if (srcEnc) {
-    auto result = cast<DialectInferLayoutInterface>(&srcEnc.getDialect())
-                      ->inferReshapeOpEncoding(srcTy.getShape(), srcEnc, shape,
-                                               dstEnc, state.location);
+    [[maybe_unused]] auto result =
+        cast<DialectInferLayoutInterface>(&srcEnc.getDialect())
+            ->inferReshapeOpEncoding(srcTy.getShape(), srcEnc, shape, dstEnc,
+                                     state.location);
     assert(succeeded(result));
   }
   auto dstTy = RankedTensorType::get(shape, srcTy.getElementType(), dstEnc);

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -603,7 +603,7 @@ SmallVector<T> repeatInterleave(const SmallVectorImpl<T> &vs, int nRepeat) {
   SmallVector<T> result;
   result.reserve(vs.size() * nRepeat);
   for (auto v : vs)
-    for (auto _ : llvm::seq(nRepeat))
+    for ([[maybe_unused]] auto _ : llvm::seq(nRepeat))
       result.push_back(v);
   return result;
 }

--- a/lib/Dialect/Triton/Transforms/LoopPeeling.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopPeeling.cpp
@@ -15,7 +15,6 @@ void peelLoopEpilogue(
   SmallVector<Operation *> loopBodyOps;
   IRRewriter rewriter(forOp);
   Location loc = forOp.getLoc();
-  Type type = forOp.getStep().getType();
 
   // Fetch loop bounds and step
   Value lowerBound = forOp.getLowerBound();

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -131,8 +131,7 @@ bool isExpensiveView(Type srcType, Type dstType) {
  */
 static SmallVector<unsigned> eraseOrder(ArrayRef<unsigned> order,
                                         unsigned dim) {
-  unsigned rank = order.size();
-  assert(dim < rank && "Invalid dim to erase");
+  assert(dim < order.size() && "Invalid dim to erase");
   SmallVector<unsigned> resOrder;
   for (unsigned i : order)
     if (i < dim)
@@ -1213,7 +1212,6 @@ void AMDMfmaEncodingAttr::print(AsmPrinter &printer) const {
           << "version = " << getVersion() //
           << ", warpsPerCTA = [" << getWarpsPerCTA() << "]";
 
-  auto tilesPerWarp = getTilesPerWarp();
   if (!hasUnitTilesPerWarp()) {
     printer << ", tilesPerWarp = [" << getTilesPerWarp() << "]";
   }
@@ -2726,7 +2724,7 @@ struct TritonGPUInferLayoutInterface
     // Try join on last dim
     auto axis = dstShape.size() - 1;
     auto newLl = LinearLayout::empty();
-    auto result =
+    [[maybe_unused]] auto result =
         tryJoinOnAxis(ctx, ll, newLl, /*fwdInference=*/true, axis, loc);
 
     assert(result.succeeded());
@@ -3385,12 +3383,7 @@ bool triton::gpu::areLayoutsEquivalent(ArrayRef<int64_t> shape,
 }
 
 bool triton::gpu::isInnermostContiguous(MemDescType type, unsigned numElems) {
-  ArrayRef<int64_t> shape = type.getShape();
-  Attribute enc = type.getEncoding();
-  MLIRContext *ctx = enc.getContext();
-
   LinearLayout actual = toLinearLayout(type);
-  StringAttr fastestIn = *actual.getInDimNames().begin();
 
   // Flatten actual outs in reverse order to produce a row-major flattening
   // of the layout

--- a/lib/Dialect/TritonGPU/IR/LayoutUtility.cpp
+++ b/lib/Dialect/TritonGPU/IR/LayoutUtility.cpp
@@ -7,8 +7,7 @@ namespace mlir::triton::gpu {
 
 CTALayoutAttr permuteCTALayout(MLIRContext *ctx, CTALayoutAttr layout,
                                ArrayRef<int> order) {
-  auto n = order.size();
-  assert(n == layout.getRank() && "order and layout rank mismatch");
+  assert(order.size() == layout.getRank() && "order and layout rank mismatch");
 
   auto invOrder = inversePermutation(order);
   llvm::SmallVector<unsigned> invOrderUnsigned(invOrder.begin(),

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -120,9 +120,11 @@ LinearLayout combineCtaCgaWithShape(LinearLayout ctaLayout,
   ctaLayout = ensureLayoutNotLargerThan(ctaLayout, ctaShape);
 
   LinearLayout ret = (ctaLayout * cgaLayout).transposeOuts(outDimNames);
+#ifndef NDEBUG
   for (auto dim : ret.getOutDimNames()) {
     assert(ret.getOutDimSize(dim) == labeledShape[dim]);
   }
+#endif
   return ret;
 }
 
@@ -732,7 +734,6 @@ LinearLayout mfmaDotToLinearLayout(DotOperandEncodingAttr dotMfmaLayout,
 
   auto rank = shape.size();
   bool hasBatchDim = rank == 3;
-  int mIndex = 0 + hasBatchDim;
 
   int32_t kWidth = dotMfmaLayout.getKWidth();
   auto kDimIndex = dotMfmaLayout.getOpIdx() == 0 ? rank - 1 : rank - 2;
@@ -915,12 +916,10 @@ LinearLayout wmmaDotOperandToLinearLayout(DotOperandEncodingAttr dotWmmaLayout,
   auto rank = shape.size();
   bool hasBatchDim = rank == 3;
   auto kDim = dotWmmaLayout.getOpIdx() == 0 ? rank - 1 : rank - 2;
-  int32_t kSize = shape[kDim];
   MLIRContext *ctx = dotWmmaLayout.getContext();
   SmallVector<StringAttr> outDimNames = standardOutDimNames(ctx, rank);
   StringAttr kRegister = S("register");
   StringAttr kLane = S("lane");
-  StringAttr kWarp = S("warp");
   // lane order
   // operand A: [1, 0] / [2, 1, 0]
   // operand B: [0, 1] / [1, 2, 0]
@@ -1138,7 +1137,6 @@ DotOperandEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   } else if (auto wmmaLayout = mlir::dyn_cast<AMDWmmaEncodingAttr>(parent)) {
     return wmmaDotOperandToLinearLayout(*this, shape);
   } else {
-    auto mma = mlir::cast<NvidiaMmaEncodingAttr>(parent);
     return nvidiaDotToLinearLayout(shape, *this);
   }
 }
@@ -1415,7 +1413,6 @@ LinearLayout chooseScaledMfmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
   StringAttr kRegister = StringAttr::get(ctx, "register");
   StringAttr kLane = StringAttr::get(ctx, "lane");
   StringAttr kWarp = StringAttr::get(ctx, "warp");
-  StringAttr kBlock = StringAttr::get(ctx, "block");
 
   // Fetch the tilesPerWarp value in the M dimension for operand A, or in the N
   // dimension for operand B.
@@ -1693,7 +1690,6 @@ getTmemLoadStoreLayout16x256(int M, int N, RankedTensorType oldType,
 
   using basisT = std::vector<std::vector<int32_t>>;
   StringAttr kRegister = StringAttr::get(ctx, "register");
-  StringAttr kLane = StringAttr::get(ctx, "lane");
   StringAttr kWarp = StringAttr::get(ctx, "warp");
   SmallVector<StringAttr> outDimNames = standardOutDimNames(ctx, 2);
 

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -416,13 +416,12 @@ void Fp4ToFpOp::build(OpBuilder &builder, OperationState &state,
                       int32_t axis) {
   auto srcTy = src.getType();
   auto shape = llvm::to_vector(srcTy.getShape());
-  auto rank = srcTy.getRank();
-  assert(0 <= axis && axis < rank);
+  assert(0 <= axis && axis < srcTy.getRank());
   shape[axis] *= 2;
 
   Attribute inEnc = srcTy.getEncoding();
   Attribute outEnc;
-  auto result =
+  [[maybe_unused]] auto result =
       inEnc.getDialect()
           .getRegisteredInterface<triton::DialectInferLayoutInterface>()
           ->inferFp4ToFpOpEncoding(shape, axis, inEnc, outEnc,
@@ -994,7 +993,7 @@ void WarpSpecializeOp::build(OpBuilder &builder, OperationState &state,
   build(builder, state, resultTypes, /*explicitCaptures=*/ValueRange(),
         partitionNumWarps, {}, {}, {});
   OpBuilder::InsertionGuard guard(builder);
-  Block *container = builder.createBlock(state.regions.back().get());
+  builder.createBlock(state.regions.back().get());
   builder.create<WarpSpecializePartitionsOp>(state.location,
                                              partitionNumRegions);
 }
@@ -1023,7 +1022,6 @@ ParseResult WarpSpecializeOp::parse(OpAsmParser &p, OperationState &result) {
   while (succeeded(p.parseOptionalKeyword(
       ("partition" + Twine(partitionNumWarps.size()).str())))) {
     partitionArgs.clear();
-    SMLoc regionLoc = p.getCurrentLocation();
     if (p.parseArgumentList(partitionArgs, AsmParser::Delimiter::Paren,
                             /*allowType=*/true) ||
         p.parseKeyword("num_warps") || p.parseLParen() ||

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -324,7 +324,6 @@ public:
       return failure();
 
     bool aFromLoad = comesFromLoadOrBlockArg(dotOp.getA());
-    bool bFromLoad = comesFromLoadOrBlockArg(dotOp.getB());
     auto origDotOp = dotOp;
 
     Value a = dotOp.getA();
@@ -518,7 +517,6 @@ public:
         dotOp.getInputPrecision() != InputPrecision::TF32)
       return failure();
     auto oldAType = dotOp.getA().getType();
-    auto oldBType = dotOp.getB().getType();
     bool useTwoCTAs = canUseTwoCTAs(dotOp);
     if (useTwoCTAs) {
       b = splitBOperand(b, rewriter);
@@ -653,8 +651,6 @@ public:
     // operands
     Value a = dotOp.getA();
     Value b = dotOp.getB();
-    auto oldAType = a.getType();
-    auto oldBType = b.getType();
 
     bool IsAMixedPrecFp4 = false;
     bool IsBMixedPrecFp4 = false;

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -404,7 +404,6 @@ public:
 
     Operation *newDot = nullptr;
     bool aFromLoad = comesFromLoadOrBlockArg(a);
-    bool bFromLoad = comesFromLoadOrBlockArg(b);
 
     if (mmaResult.versionMajor == 3) {
       auto eltType = cast<RankedTensorType>(a.getType()).getElementType();

--- a/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
@@ -48,7 +48,6 @@ struct ClipAsyncCopySizePerThread
     auto sharedEnc = dyn_cast<SwizzledSharedEncodingAttr>(dstTy.getEncoding());
     if (!sharedEnc)
       return failure();
-    auto sharedVec = sharedEnc.getVec();
 
     // obtain max contiguous copy size
     // Note this can be further optimized, as copyContigSize can be even

--- a/lib/Dialect/TritonGPU/Transforms/CombineTensorSelectAndIf.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CombineTensorSelectAndIf.cpp
@@ -21,7 +21,6 @@ static void canonicalizeSelectUsersInSCFIf(ModuleOp input) {
   llvm::MapVector<std::pair<Value, Value>, SmallVector<Operation *>>
       usersNeedreplaced;
   input.walk([&](arith::SelectOp selectOp) {
-    auto *parentBlock = selectOp->getBlock();
     Value condition = selectOp.getOperand(0);
     Value trueVal = selectOp.getOperand(1);
     Value falseVal = selectOp.getOperand(2);
@@ -81,7 +80,6 @@ class CombineTensorSelectAndIfPass
           CombineTensorSelectAndIfPass> {
 public:
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
     canonicalizeSelectUsersInSCFIf(m);
 
@@ -133,7 +131,7 @@ public:
         newIfOp.getElseRegion().takeBody(ifOp.getElseRegion());
       } else {
         // Create an empty yield
-        auto yieldOp = newIfOp.getElseBodyBuilder().create<scf::YieldOp>(loc);
+        newIfOp.getElseBodyBuilder().create<scf::YieldOp>(loc);
       }
 
       SmallVector<Value> ifYieldOperands = newIfOp.thenYield().getOperands();

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
@@ -195,7 +195,6 @@ private:
         (opIdx == 0 ? scaledDotOp.getAElemType() : scaledDotOp.getBElemType());
     auto fastMath = scaledDotOp.getFastMath();
 
-    auto *ctx = rewriter.getContext();
     auto loc = v.getLoc();
     auto mod = scaledDotOp->getParentOfType<ModuleOp>();
     auto rank = v.getType().getRank();

--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -1008,7 +1008,7 @@ static LogicalResult speculateInnerLoopLength(scf::ForOp outerLoop,
 
   // Move the loop nest into the `else` branch.
   outerLoop.replaceAllUsesWith(ifOp.getResults());
-  Block *block = b.createBlock(&ifOp.getElseRegion());
+  b.createBlock(&ifOp.getElseRegion());
   outerLoop->remove();
   b.insert(outerLoop);
   b.create<scf::YieldOp>(outerLoop.getResults());

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
@@ -21,8 +21,6 @@ public:
 
   LogicalResult matchAndRewrite(triton::nvidia_gpu::TMEMAllocOp op,
                                 PatternRewriter &rewriter) const override {
-    MLIRContext *ctx = op.getContext();
-    Location loc = op.getLoc();
     if (op.getSrc() == nullptr)
       return failure();
     SmallVector<Operation *> users(op.getResult().getUsers().begin(),

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -163,11 +163,9 @@ public:
       return failure();
 
     MemDescType allocType = allocOp.getType();
-    auto allocEncoding = allocType.getEncoding();
 
     RankedTensorType srcTy = reshapeOp.getSrc().getType();
     auto srcShape = srcTy.getShape();
-    auto dstShape = allocType.getShape();
 
     // We use the fact that forward and backward inference are the same for
     // MemDescReshapeOp to infer the source MemDescType that would produce

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MMAv5PipelineUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MMAv5PipelineUtility.cpp
@@ -269,7 +269,6 @@ bool ttng::hasLoadsAfterMMA(ttng::MMAv5OpInterface mma, scf::ForOp forOp) {
 ttng::TMEMAllocOp ttng::createTMemAlloc(OpBuilder &builder,
                                         ttng::TMEMAllocOp oldTMemAllocOp,
                                         bool multiBufferred, int numStages) {
-  Location loc = oldTMemAllocOp.getLoc();
   auto oldRetType = oldTMemAllocOp.getType();
   SmallVector<int64_t> shape = {oldRetType.getShape().begin(),
                                 oldRetType.getShape().end()};

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
@@ -496,7 +496,6 @@ LogicalResult LoopPipelinerInternal::createKernel(
   SmallVector<Value> predicates(maxStage + 1, nullptr);
   if (!peelEpilogue) {
     // Create a predicate for each stage except the last stage.
-    Location loc = newForOp.getLoc();
     for (unsigned i = 0; i < maxStage; i++) {
       // c = ub - (maxStage - i) * step
       predicates[i] = emitPredicateStageFn(rewriter, newForOp.getInductionVar(),

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
@@ -51,7 +51,6 @@ static void createTMAAsyncCopy(scf::ForOp forOp, const TMAStore &store,
                                Value alloc) {
   OpBuilder builder(store.op);
   Location loc = store.op->getLoc();
-  RankedTensorType ty = store.src.getType();
 
   // Put wait before the local_store make the store truly async. We know
   // that we are the only user of the CopyLocalToGlobal.

--- a/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
@@ -231,11 +231,10 @@ LogicalResult Prefetcher::initialize() {
     auto bType = dot.getB().getType();
     auto aEnc =
         mlir::cast<triton::gpu::DotOperandEncodingAttr>(aType.getEncoding());
-    auto bEnc =
+    [[maybe_unused]] auto bEnc =
         mlir::cast<triton::gpu::DotOperandEncodingAttr>(bType.getEncoding());
     int aKWidth = aEnc.getKWidth();
-    int bKWidth = bEnc.getKWidth();
-    assert(aKWidth == bKWidth);
+    assert(aKWidth == bEnc.getKWidth());
 
     auto kSize = aType.getShape().back();
 

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -422,7 +422,7 @@ static Attribute inferTransOpDstEncoding(Attribute srcEnc,
 static Attribute inferDstEncoding(triton::gpu::Fp4ToFpOp op, Attribute srcEnc) {
   Attribute dstEnc;
   auto shape = op.getSrc().getType().getShape();
-  auto result =
+  [[maybe_unused]] auto result =
       srcEnc.getDialect()
           .getRegisteredInterface<triton::DialectInferLayoutInterface>()
           ->inferFp4ToFpOpEncoding(shape, op.getAxis(), srcEnc, dstEnc,
@@ -474,7 +474,7 @@ static Attribute inferReshapeOpDstEncoding(ArrayRef<int64_t> srcShape,
     return {};
 
   Attribute dstEnc;
-  auto result =
+  [[maybe_unused]] auto result =
       srcEnc.getDialect()
           .getRegisteredInterface<triton::DialectInferLayoutInterface>()
           ->inferReshapeOpEncoding(srcShape, srcEnc, dstShape, dstEnc,
@@ -1040,13 +1040,14 @@ int getNVIDIAComputeCapability(Operation *module) {
       module->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName);
   assert(targetAttr && "Expected a target attribute on the module operation");
 
-  StringRef ref = targetAttr.strref();
+  [[maybe_unused]] StringRef ref = targetAttr.strref();
   assert(ref.starts_with("cuda:") &&
          "expected target attribute to be prefixed with \"cuda:\"");
 
   StringRef capabilityStr = ref.drop_front(5); // drop the "cuda:"
   int computeCapability;
-  bool parseError = capabilityStr.getAsInteger(10, computeCapability);
+  [[maybe_unused]] bool parseError =
+      capabilityStr.getAsInteger(10, computeCapability);
   assert(!parseError &&
          "invalid compute capability string in target attribute");
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -502,7 +502,6 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
   Value firstView = createSingleBufferView(b, allocOp, b.intCst(0));
   b.setInsertionPointAfter(loop);
   Value lastIndex = loop.getResult(index.getArgNumber() - 1);
-  Value lastPhase = loop.getResult(phase.getArgNumber() - 1);
   Value lastView = createSingleBufferView(b, allocOp, lastIndex);
 
   // Find users of the accumulator in the loop and sort them by program order.

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -130,7 +130,7 @@ getLoopVarIndicesToKeep(scf::ForOp loop, const Partition *partition,
 }
 
 const Partition *getPartition(Operation *op, const WarpSchedule &schedule) {
-  auto origOp = op;
+  [[maybe_unused]] auto origOp = op;
   while (op && !schedule.getPartition(op)) {
     op = op->getParentOp();
   }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -69,7 +69,7 @@ struct AsyncRef {
     auto exitOp = [this, &partition, srcStageCluster,
                    token](PartitionBuilder &b) {
       auto zero = b.create<arith::ConstantOp>(b.getI32IntegerAttr(0));
-      auto exitOp = b.createInto<triton::nvws::ArefPutExitOp>(
+      b.createInto<triton::nvws::ArefPutExitOp>(
           partition, srcStageCluster, aref, token, zero,
           b.getArrayAttr(SmallVector<Attribute>{triton::nvws::AsyncOpAttr::get(
               aref.getContext(), triton::nvws::AsyncOp::NONE)}));
@@ -87,7 +87,7 @@ struct AsyncRef {
     auto exitOp = [this, &partition, srcStageCluster,
                    token](PartitionBuilder &b) {
       auto zero = b.create<arith::ConstantOp>(b.getI32IntegerAttr(0));
-      auto exitOp = b.createInto<triton::nvws::ArefGetExitOp>(
+      b.createInto<triton::nvws::ArefGetExitOp>(
           partition, srcStageCluster, aref, token, zero,
           b.getArrayAttr(SmallVector<Attribute>{triton::nvws::AsyncOpAttr::get(
               aref.getContext(), triton::nvws::AsyncOp::NONE)}));
@@ -183,7 +183,6 @@ LogicalResult DependencyRewriter::run() {
         assert(distance > 0 && "self-recursion must occur in the future");
         return;
       }
-      Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
       UseInfo &info = useInfo[output];
       info.consumers[{usePartition, distance}].push_back(&use);
     };
@@ -231,8 +230,6 @@ LogicalResult DependencyRewriter::run() {
       b.setLoc(output.getLoc());
       ImplicitLocOpBuilder endBuilder(b.getLoc(), loop->getNextNode());
       AsyncRef aref = allocateAsyncValue(tensorType, maxDistance);
-
-      unsigned numConsumers = info.consumers.size();
 
       for (auto &[key, uses] : info.consumers) {
         assert(!uses.empty() && "expected at least one use");

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -637,7 +637,6 @@ private:
         {size}, elType, getThreadLocalBlockedEncoding(size));
     SmallVector<APInt> apInts = llvm::to_vector(
         llvm::map_range(values, [](int64_t v) { return APInt(64, v); }));
-    auto denseAttr = DenseElementsAttr::get(tensorType, apInts);
     auto op = builder.create<tti::ExperimentalBufferPointersOp>(
         tensorType, values, memType);
     return op;
@@ -659,7 +658,6 @@ private:
 
   Value createInitializedScratchMemory(ImplicitLocOpBuilder &b,
                                        TypedValue<RankedTensorType> tensor) {
-    auto encoding = tensor.getType().getEncoding();
     Type elType = tensor.getType().getElementType();
     int elSize = elType.getIntOrFloatBitWidth() / 8;
     int numEls = product(tensor.getType().getShape());

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -178,7 +178,6 @@ getTmemLoadLayoutSplitLongM(RankedTensorType tensorType, MemDescType memType,
   auto llEncoding = dyn_cast<LinearEncodingAttr>(tensorType.getEncoding());
   if (!llEncoding)
     return {};
-  auto CTALayout = getCTALayout(tensorType.getEncoding());
   auto shapePerCTA = mlir::triton::gpu::getShapePerCTA(tensorType);
   if (numWarps != 8)
     return {};

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -71,7 +71,8 @@ findBufferAccessMemdescSubview(Operation *subview) {
     src = indexOp.getSrc();
     shape = to_vector(indexOp.getType().getShape());
     offsets = {indexOp.getIndex()};
-    for (auto i : llvm::seq(std::max<int>(0, shape.size() - 1)))
+    for ([[maybe_unused]] auto i :
+         llvm::seq(std::max<int>(0, shape.size() - 1)))
       offsets.push_back(builder.create<arith::ConstantIntOp>(loc, 0, 32));
   } else {
     auto subsliceOp = cast<ttg::MemDescSubsliceOp>(subview);
@@ -262,7 +263,6 @@ struct TritonNvidiaGPUInterleaveTMemPass
       TritonNvidiaGPUInterleaveTMemPass>::TritonNvidiaGPUInterleaveTMemPassBase;
 
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
     SmallVector<std::pair<Operation *, Value>> opsToSink;
     m.walk([&](Operation *op) {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
@@ -84,8 +84,6 @@ struct TCGen5MMAScaleSharedToTmemConversion
 
   LogicalResult matchAndRewrite(TCGen5MMAScaledOp op,
                                 PatternRewriter &rewriter) const override {
-    Location loc = op.getLoc();
-    MLIRContext *context = op->getContext();
     auto aScaleType = op.getAScale().getType();
     auto bScaleType = op.getBScale().getType();
     int blockM = op.getBlockM();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
@@ -366,7 +366,6 @@ public:
   using BaseT::BaseT;
 
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
     assignMemoryLayouts(m);
   }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
@@ -188,15 +188,13 @@ public:
     auto subSlice0 = b.create<TMEMSubSliceOp>(loc, tmem, 0, splitNSize);
     auto cvt0 =
         b.create<ttg::ConvertLayoutOp>(loc, newStoreType, joinOp.getLhs());
-    auto store0 =
-        b.create<TMEMStoreOp>(loc, subSlice0, cvt0.getResult(), truePred);
+    b.create<TMEMStoreOp>(loc, subSlice0, cvt0.getResult(), truePred);
     // Second slice.
     auto subSlice1 =
         b.create<TMEMSubSliceOp>(loc, tmem, splitNSize, splitNSize);
     auto cvt1 =
         b.create<ttg::ConvertLayoutOp>(loc, newStoreType, joinOp.getRhs());
-    auto store1 =
-        b.create<TMEMStoreOp>(loc, subSlice1, cvt1.getResult(), truePred);
+    b.create<TMEMStoreOp>(loc, subSlice1, cvt1.getResult(), truePred);
     b.eraseOp(storeOp);
     return success();
   }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
@@ -182,7 +182,7 @@ CTAPlanner::~CTAPlanner() {
 
 void CTAPlanner::run(triton::FuncOp &funcOp) {
   assert(!tiled && "Please create a new CTAPlanner");
-  static const unsigned maxSteps = 10000;
+  [[maybe_unused]] static const unsigned maxSteps = 10000;
 
   auto nextStep = [&]() {
     ++step;
@@ -528,8 +528,7 @@ bool CTAPlanner::propagateForward(CastOp cast) {
 }
 
 void CTAPlanner::eraseCastOp(CastOp cast) {
-  Value output = cast.getResult(0);
-  assert(getNumUsers(output) == 0 &&
+  assert(getNumUsers(cast.getResult(0)) == 0 &&
          "Cannot erase CastOp because it is still in use");
   cast.erase();
 }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -66,7 +66,6 @@ public:
 
   LogicalResult matchAndRewrite(DescriptorLoadOp op,
                                 PatternRewriter &rewriter) const override {
-    auto loc = op.getLoc();
     auto createLoad = [&](Value tmaPtr, Value barrierAlloc, Value alloc,
                           Value pred) {
       auto indices = translateTMAIndices(
@@ -170,7 +169,6 @@ public:
 
   LogicalResult matchAndRewrite(MakeTensorDescOp op,
                                 PatternRewriter &rewriter) const override {
-    MLIRContext *ctx = op.getContext();
     auto loc = op.getLoc();
     auto alloc = rewriter.create<triton::gpu::GlobalScratchAllocOp>(
         loc, getPointerType(rewriter.getI8Type()), TMA_SIZE_BYTES, TMA_ALIGN);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
@@ -399,7 +399,6 @@ public:
 
   void runOnOperation() override {
     ModuleOp mod = getOperation();
-    MLIRContext *ctx = &getContext();
 
     DenseMap<triton::nvidia_gpu::TMEMAllocOp, int> offsets;
     // TODO: handle cases with multiple function with TMEMAllocOp.

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -237,7 +237,6 @@ std::pair<int, int> logBankConflicts(ArrayRef<int32_t> tileSrc,
                                      int32_t bitwidth) {
   auto *ctx = smem.getOutDimNames().begin()->getContext();
   auto smemFlat = smem.flattenOuts();
-  auto inDim = *smem.getInDimNames().begin();
   // Take all the bases in the first bank (32 bits)
   auto smemBases =
       flatten(smemFlat.flattenIns(), *smemFlat.getInDimNames().begin());
@@ -365,8 +364,9 @@ optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
 
   const int32_t dim = src.getTotalOutDimSizeLog2();
   auto *ctx = src.getInDimNames().begin()->getContext();
-  auto kReg = StringAttr::get(ctx, "register");
 
+#ifndef NDEBUG
+  auto kReg = StringAttr::get(ctx, "register");
   auto regsNotZero = [kReg](const LinearLayout &ll) {
     return llvm::all_of(
         ll.getBases().lookup(kReg),
@@ -378,6 +378,7 @@ optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
   assert(
       regsNotZero(dst) &&
       "Remove register broadcasting from dst. See actionRemoveBroadcastedRegs");
+#endif
 
   llvm::SmallVector<int32_t> bankSrc;
   bankSrc.append(vbasis.begin(), vbasis.end());

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -227,7 +227,6 @@ std::optional<ColumnAction> regPermForDivide(const LinearLayout &A,
   auto multiplyByTileSize =
       [&](ArrayRef<int32_t> bBasis) -> std::vector<int32_t> {
     std::vector<int32_t> result;
-    size_t idx = 0;
     assert(bBasis.size() == A.getNumOutDims());
     for (auto [dim, b] : llvm::zip(A.getOutDimNames(), bBasis)) {
       result.push_back(b << log2QuotSize.lookup(dim));
@@ -296,8 +295,6 @@ actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
   assert(layout.getNumInDims() != 0);
   auto kReg = *layout.getInDimNames().begin();
   assert(kReg.str() == "register");
-  auto kLane = StringAttr::get(kReg.getContext(), "lane");
-  auto kWarp = StringAttr::get(kReg.getContext(), "warp");
   assert(layout.getNumOutDims() == 1);
   uint32_t bits = maskSpanOffsets;
   llvm::SetVector<uint32_t> tileBases;

--- a/third_party/amd/lib/Analysis/AMDGPUAllocation.cpp
+++ b/third_party/amd/lib/Analysis/AMDGPUAllocation.cpp
@@ -53,9 +53,6 @@ SmallVector<unsigned> getRepShapeForCvt(RankedTensorType srcTy,
 
 std::pair<unsigned, unsigned>
 getScratchCvtInOutVecLengths(RankedTensorType srcTy, RankedTensorType dstTy) {
-  Attribute srcLayout = srcTy.getEncoding();
-  Attribute dstLayout = dstTy.getEncoding();
-
   auto srcLinAttr = gpu::toLinearEncoding(srcTy);
   auto dstLinAttr = gpu::toLinearEncoding(dstTy);
   auto inOrd = srcLinAttr.getOrder();
@@ -82,8 +79,6 @@ ScratchConfig getScratchConfigForCvt(RankedTensorType srcTy,
     return ScratchConfig({}, {});
   ScratchConfig scratchConfig(repShape, repShape);
   auto rank = repShape.size();
-  Attribute srcLayout = srcTy.getEncoding();
-  Attribute dstLayout = dstTy.getEncoding();
 
   assert(cvtNeedsSharedMemory(srcTy, dstTy));
   auto outOrd = gpu::getOrder(dstTy);

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -69,7 +69,6 @@ bool hasMatchingCTATileLayoutForSliceConcat(
     RankedTensorType srcTy, RankedTensorType dstTy,
     std::function<void(const Twine &)> emitError) {
   auto srcShape = srcTy.getShape();
-  auto dstShape = dstTy.getShape();
   auto srcLL = triton::gpu::toLinearLayout(srcTy);
   auto dstLL = triton::gpu::toLinearLayout(dstTy);
 

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ConcatOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ConcatOpToLLVM.cpp
@@ -24,14 +24,11 @@ struct ConcatOpConversion : public ConvertOpToLLVMPattern<amdgpu::ConcatOp> {
         cast<RankedTensorType>(op.getResult().getType());
 
     ArrayRef<int64_t> dstShape = resultType.getShape();
-    Attribute dstEncoding = resultType.getEncoding();
 
     Value srcVal = op.getSources()[0];
     RankedTensorType srcType = cast<RankedTensorType>(srcVal.getType());
     ArrayRef<int64_t> srcShape = srcType.getShape();
-    Attribute srcEncoding = srcType.getEncoding();
 
-    MLIRContext *context = resultType.getContext();
     auto linearLayoutSrc = triton::gpu::toLinearLayout(srcType);
     auto outDimNames = llvm::to_vector(linearLayoutSrc.getOutDimNames());
     // Call transposeOuts, to ensure that order of input and output tensor

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ExtractSliceOpToLLVM.cpp
@@ -106,7 +106,6 @@ struct ExtractSliceOpConversion
   LogicalResult
   matchAndRewrite(amdgpu::ExtractSliceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto srcTy = op.getSource().getType();
     return processLayout(op, adaptor, rewriter);
   }
 };

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/AtomicRMWOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/AtomicRMWOpsEmitter.cpp
@@ -97,8 +97,8 @@ Value genPrefixSum(RewriterBase &rewriter, Value v0) {
   auto loc = v0.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-  auto v0Ty = v0.getType();
-  assert(v0Ty.getIntOrFloatBitWidth() == i32_ty.getIntOrFloatBitWidth());
+  assert(v0.getType().getIntOrFloatBitWidth() ==
+         i32_ty.getIntOrFloatBitWidth());
 
   Value v1 = v0;
   // v_add_f32 v1, v0, v0 row_shr:1 bound_ctrl:0

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -112,7 +112,6 @@ BufferEmitter::emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc,
   SmallVector<Value, 6> commonArgs;
   fillCommonArgs(type, rsrcDesc, offset, pred, cm, /*isBufferLoad=*/true,
                  commonArgs);
-  Type bufferType = getBufferOpType(type, false);
   return rewriter.create<ROCDL::RawPtrBufferLoadLdsOp>(
       loc, TypeRange{},
       ValueRange{

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
@@ -160,7 +160,6 @@ private:
     StringRef calleeName = callOp.getCallee().value();
 
     auto operands = callOp.getOperands();
-    auto result = callOp.getResult();
 
     LLVM::LLVMFunctionType calleeType = callOp.getCalleeFunctionType();
     Type returnType = calleeType.getReturnType();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
@@ -32,7 +32,6 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
   LogicalResult
   matchAndRewrite(triton::DotOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Location loc = op->getLoc();
     // D = A * B + C
     Value D = op.getResult();
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -24,9 +24,8 @@ class AMDFMAVectorMultiplier : public FMAVectorMultiplier {
   DotIntrinsic chooseIntrinsic(DotOp op) {
     auto aOpTy = cast<RankedTensorType>(op.getA().getType());
     auto aElemTy = aOpTy.getElementType();
-    auto bOpTy = cast<RankedTensorType>(op.getA().getType());
-    auto bElemTy = aOpTy.getElementType();
-    assert(aElemTy == bElemTy);
+    assert(aElemTy ==
+           cast<RankedTensorType>(op.getB().getType()).getElementType());
     auto dOpTy = cast<RankedTensorType>(op.getD().getType());
     auto dElemTy = dOpTy.getElementType();
     auto mod = op->getParentOfType<ModuleOp>();
@@ -97,7 +96,6 @@ class AMDFMAVectorMultiplier : public FMAVectorMultiplier {
     SmallVector<Type> argTypes;
     for (auto arg : args)
       argTypes.push_back(arg.getType());
-    auto funcType = LLVM::LLVMFunctionType::get(intrinsic.outElemTy, argTypes);
     auto d = LLVM::createLLVMIntrinsicCallOp(
         rewriter, loc, intrinsic.intrinsicName, intrinsic.outElemTy, args);
     return d.getResult(0);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -91,17 +91,13 @@ WMMAInstrType getWMMAInstrTypeFromDot(DotOp op) {
   auto aOperandTy = op.getA().getType();
   auto aTensorTy = cast<RankedTensorType>(aOperandTy);
   auto aElemTy = aTensorTy.getElementType();
-  auto bOperandTy = op.getB().getType();
-  auto bTensorTy = cast<RankedTensorType>(bOperandTy);
-  auto bElemTy = bTensorTy.getElementType();
-  assert(aElemTy == bElemTy);
-  auto cOperandTy = op.getC().getType();
-  auto cTensorTy = cast<RankedTensorType>(cOperandTy);
-  auto cElemTy = cTensorTy.getElementType();
+  assert(aElemTy ==
+         cast<RankedTensorType>(op.getB().getType()).getElementType());
   auto dOperandTy = op.getD().getType();
   auto dTensorTy = cast<RankedTensorType>(dOperandTy);
   auto dElemTy = dTensorTy.getElementType();
-  assert(cElemTy == dElemTy);
+  assert(cast<RankedTensorType>(op.getC().getType()).getElementType() ==
+         dElemTy);
 
   if (dElemTy.isF32() && aElemTy.isF16())
     return WMMAInstrType::FP32_FP16;
@@ -232,7 +228,6 @@ Value generateWMMAIntrinsic(ConversionPatternRewriter &rewriter, Location loc,
                             std::optional<bool> tiedLower) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-  LLVM::FastmathFlagsAttr defaultFlags{};
   SmallVector<Value> operands;
   if (aElType.isInteger())
     operands.push_back(b.int_val(1, !aElType.isUnsignedInteger()));
@@ -269,7 +264,6 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
   auto wmmaLayout = cast<AMDWmmaEncodingAttr>(
       cast<RankedTensorType>(op.getResult().getType()).getEncoding());
   int wmmaVer = wmmaLayout.getVersion();
-  auto warpsPerCTA = wmmaLayout.getWarpsPerCTA();
   auto mnkDim = AMDWmmaEncodingAttr::getMNKDimPerInstr();
 
   auto loc = op.getLoc();
@@ -299,7 +293,6 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
   unsigned kDim = maybeWmmaIntrinsic->kDim;
 
   auto aEncoding = cast<DotOperandEncodingAttr>(aTensorTy.getEncoding());
-  auto bEncoding = cast<DotOperandEncodingAttr>(bTensorTy.getEncoding());
   int kWidth = aEncoding.getKWidth();
   intrinsicName = maybeWmmaIntrinsic->name;
 
@@ -403,6 +396,7 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
 LogicalResult convertWMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                           const LLVMTypeConverter *typeConverter,
                           ConversionPatternRewriter &rewriter) {
+#ifndef NDEBUG
   auto rankedTType = [](Value tensor) {
     return cast<RankedTensorType>(tensor.getType());
   };
@@ -419,6 +413,7 @@ LogicalResult convertWMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   assert(cTensorTy.getShape()[0] == dTensorTy.getShape()[0] &&
          cTensorTy.getShape()[1] == dTensorTy.getShape()[1] &&
          "DotOp's $c operand should pass the same number of values as $d");
+#endif
 
   return convertDot(op, adaptor, rewriter, typeConverter);
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -31,8 +31,6 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     MemDescType srcTy = op.getSrc().getType();
     RankedTensorType dstTy = op.getType();
-    Attribute srcLayout = srcTy.getEncoding();
-    Attribute dstLayout = dstTy.getEncoding();
 
     if (isPackedLoad || canUseTransLoad(op, srcTy, dstTy)) {
       return lowerSharedToDotOperandTransLL(op, adaptor,
@@ -56,7 +54,6 @@ private:
       return false;
     }
 
-    auto tilesPerWarp = mfmaEnc.getTilesPerWarp();
     if (!mfmaEnc.hasUnitTilesPerWarp()) {
       return false;
     }
@@ -186,7 +183,7 @@ private:
     SmallVector<Value> elemsI32;
     mlir::Type retTy = dstTy;
     auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
-    bool valid = emitTransferBetweenRegistersAndShared(
+    [[maybe_unused]] bool valid = emitTransferBetweenRegistersAndShared(
         ldsTransLayout, srcTy, llvmElemTy,
         /*maxVecElems=*/std::nullopt, smemObj, loc, rewriter, targetInfo,
         laneId, warpId, [&](VectorType vecTy, Value vecAddr) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUsage.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUsage.cpp
@@ -216,7 +216,6 @@ class OptimizeAMDLDSUsage
   computeTargetScratchBufferSize(triton::gpu::ConvertLayoutOp op,
                                  Allocation *allocation,
                                  ArrayRef<Allocation::BufferId> liveBuffers) {
-    int totalSize = 0;
     auto scratchBufferId = allocation->getBufferId(op.getOperation());
     int64_t scratchBufferSize = allocation->getAllocatedSize(scratchBufferId);
     size_t totalLDSConsumption = 0;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
@@ -101,7 +101,6 @@ estimateResourcesForReplacement(OpBuilder builder,
   RankedTensorType dstTy = cvtOp.getType();
   RankedTensorType intermediateTy = RankedTensorType::get(
       srcTy.getShape(), srcTy.getElementType(), tmpLayout);
-  auto *ctx = cvtOp->getContext();
 
   int tmpCvtLDS = getConvertLayoutScratchInBytes(srcTy, intermediateTy,
                                                  /*usePadding*/ true);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
@@ -111,7 +111,6 @@ struct TritonAMDGPULowerInstructionSchedHints
 
   void runOnOperation() override {
     MLIRContext *ctx = &getContext();
-    ModuleOp mod = getOperation();
 
     ConversionTarget target(*ctx);
     target.addLegalDialect<LLVM::LLVMDialect>();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
@@ -260,7 +260,6 @@ public:
     auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
 
     bool useFp16 = op.getType().getElementType().isF16();
-    Type retElemType = useFp16 ? f16_ty : bf16_ty;
 
     // Given that MFMA layout for the A tensor arranges thread in a column-major
     // manner, for the current tid, it's at row (tid % mDim). When we set up

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -530,7 +530,6 @@ int32_t getCtrlBitsForCacheModifierOnTarget(
 
 Value cvtFp32ToFp16RTNE_oneValue(Location loc, RewriterBase &rewriter,
                                  const Value &v) {
-  LLVM::RoundingMode rm = LLVM::RoundingMode::NearestTiesToEven;
   return rewriter.create<LLVM::FPTruncOp>(loc, f16_ty, v);
 }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -456,7 +456,6 @@ public:
 
     auto mDim = mfmaInstr->mDim;
     auto nDim = mfmaInstr->nDim;
-    auto kDim = mfmaInstr->kDim;
     auto kBase = mfmaInstr->kBase;
 
     auto warpsPerTile =
@@ -656,7 +655,6 @@ public:
 
     unsigned mDim = mfmaInstr->mDim;
     unsigned nDim = mfmaInstr->nDim;
-    unsigned kDim = mfmaInstr->kDim;
     unsigned kBase = mfmaInstr->kBase;
 
     // For mxfp4 A/B tensor, we pack every two values into one int8 value there.
@@ -883,7 +881,6 @@ public:
 
     auto mDim = mfmaInstr->mDim;
     auto nDim = mfmaInstr->nDim;
-    auto kDim = mfmaInstr->kDim;
     auto kBase = mfmaInstr->kBase;
     assert(mDim == nDim);
 
@@ -1001,7 +998,6 @@ public:
     a = convertInputLayout(a, 0);
     b = convertInputLayout(b, 1);
 
-    StringAttr kWarp = StringAttr::get(ctx, "warp");
     auto convertScaleLayout = [&](TensorValue scale,
                                   llvm::ArrayRef<int64_t> valShape,
                                   LinearLayout dotLL, int idx) -> Value {
@@ -1203,7 +1199,6 @@ public:
 
     auto mDim = wmmaInstr->mDim;
     auto nDim = wmmaInstr->nDim;
-    auto kDim = wmmaInstr->kDim;
     auto kBase = wmmaInstr->kBase;
 
     // get WMMA encoding for the given number of warps

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -821,12 +821,11 @@ void Pingponger::addAsymmetricSyncToLoop(OpBuilder &builder, Location loc) {
                                                warpIDX, constZero);
   auto warpHigh = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne,
                                                 warpIDX, constZero);
-  auto condBarrierHigh =
-      builder.create<tt::amdgpu::CondBarrierOp>(loc, warpHigh);
+  builder.create<tt::amdgpu::CondBarrierOp>(loc, warpHigh);
 
   // Insert condbarrier::first_half after the end of the loop
   builder.setInsertionPointAfter(forOp);
-  auto condBarrierLow = builder.create<tt::amdgpu::CondBarrierOp>(loc, warpLow);
+  builder.create<tt::amdgpu::CondBarrierOp>(loc, warpLow);
 }
 
 void Pingponger::getDotPingponged() {
@@ -838,7 +837,6 @@ void Pingponger::getDotPingponged() {
   }
 
   OpBuilder builder(forOp);
-  MLIRContext *ctx = forOp.getContext();
   Location loc = forOp.getLoc();
 
   forOp->walk([&](Operation *op) {
@@ -916,7 +914,6 @@ void Pingponger::getDotPingponged() {
     auto scaledDotType = scaledDotOps[0].getType();
     auto scaledDotShape = scaledDotType.getShape();
     auto aType = scaledDotOps[0].getA().getType();
-    auto aShape = aType.getShape();
     auto elemWidth = aType.getElementTypeBitWidth();
 
     // MxN = 256x256

--- a/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
@@ -634,6 +634,7 @@ matchInThreadTransposePattern(ttg::LocalLoadOp lLoad) {
     pattern.globalLoads.insert_range(globalLoadSearch.value());
   }
 
+#ifndef NDEBUG
   LDBG("found global loads: " << pattern.globalLoads.size());
   for (auto load : pattern.globalLoads)
     LDBG(load);
@@ -643,6 +644,7 @@ matchInThreadTransposePattern(ttg::LocalLoadOp lLoad) {
   LDBG("found shared mem values: " << pattern.sharedMemVals.size());
   for (auto val : pattern.sharedMemVals)
     LDBG(val);
+#endif
 
   if (pattern.globalLoads.empty()) {
     LDBG("Did not find global load operation");

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -119,8 +119,6 @@ struct TritonAMDGPUUpdateAsyncWaitCountPass
       return;
     }
 
-    ModuleOp m = getOperation();
-
     SmallVector<ttg::AsyncWaitOp> waitOps;
     getOperation()->walk(
         [&](ttg::AsyncWaitOp waitOp) { waitOps.push_back(waitOp); });

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -43,11 +43,7 @@ public:
     // CodePartitioning to correctly handle channels in else block.
     bool hasElse = false;
     funcOp->walk([&](scf::IfOp ifOp) {
-      if (ifOp.elseBlock()) {
-        for (Operation &op : ifOp.elseBlock()->getOperations()) {
-          hasElse = true;
-        }
-      }
+      hasElse |= ifOp.elseBlock() && !ifOp.elseBlock()->getOperations().empty();
     });
     if (hasElse)
       return;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.cpp
@@ -30,9 +30,6 @@ void setAsyncTaskIds(Operation *op, ArrayRef<AsyncTaskId> asyncTaskIds) {
   SmallVector<AsyncTaskId> sortedAsyncTaskIds(asyncTaskIds.begin(),
                                               asyncTaskIds.end());
   sort(sortedAsyncTaskIds);
-  auto i32Ty = IntegerType::get(op->getContext(), 32);
-  auto size = static_cast<int64_t>(sortedAsyncTaskIds.size());
-  auto vecTy = VectorType::get(size, i32Ty);
   op->setAttr("async_task_id",
               DenseI32ArrayAttr::get(op->getContext(), sortedAsyncTaskIds));
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
@@ -151,8 +151,7 @@ scf::IfOp rewriteIfOp(scf::IfOp ifOp, SmallVector<Operation *> &taskTopOps,
 
   // Go through region ops in the thenBlock. updateAccumLoopCount takes current
   // accumCnt value and returns the value at the end of the thenBlock.
-  Value endAccum =
-      updateAccumLoopCount(opList, taskTopOps, regionsWithChannels, prevAccum);
+  updateAccumLoopCount(opList, taskTopOps, regionsWithChannels, prevAccum);
 
   SmallVector<Value> ifYieldOperands = newIfOp.thenYield().getOperands();
 
@@ -169,12 +168,13 @@ scf::IfOp rewriteIfOp(scf::IfOp ifOp, SmallVector<Operation *> &taskTopOps,
     }
     // We need to differentiate channels in then region vs. in else region.
     // For now, only handle the case where channels are in then region.
+#ifndef NDEBUG
     for (auto *op : opListElse)
       assert(!enclosingAChannel(op, regionsWithChannels));
+#endif
   } else {
     // Create an empty yield
-    auto yieldOp =
-        newIfOp.getElseBodyBuilder().create<scf::YieldOp>(ifOp.getLoc());
+    newIfOp.getElseBodyBuilder().create<scf::YieldOp>(ifOp.getLoc());
   }
 
   SmallVector<Value> elseYieldOperands = newIfOp.elseYield().getOperands();
@@ -487,8 +487,7 @@ scf::ForOp createNewLoopWrapper(scf::ForOp origForOp,
     if (auto tOp = dyn_cast<scf::IfOp>(&op))
       opList.push_back(&op);
   }
-  Value endAccum =
-      updateAccumLoopCount(opList, taskTopOps, regionsWithChannels, prevAccum);
+  updateAccumLoopCount(opList, taskTopOps, regionsWithChannels, prevAccum);
   LLVM_DEBUG({
     LDBG("-- before replacing yieldOp ");
     newForOp.dump();

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -178,7 +178,6 @@ void collectAsyncChannels(SmallVector<std::unique_ptr<Channel>> &channels,
         });
         return;
       }
-      auto producerTaskId = producerTaskIds.front();
       unsigned producerNumBuffers = numBuffers;
       if (auto forOp = op->getParentOfType<scf::ForOp>()) {
         producerNumBuffers = getNumBuffersOrDefault(forOp, numBuffers);
@@ -689,7 +688,6 @@ void createToken(
 static ttng::TMEMAllocOp createTMemAlloc(OpBuilder &builder,
                                          ttng::TMEMAllocOp oldTMemAllocOp,
                                          int numBuffers) {
-  Location loc = oldTMemAllocOp.getLoc();
   auto oldRetType = oldTMemAllocOp.getType();
   SmallVector<int64_t> shape = {oldRetType.getShape().begin(),
                                 oldRetType.getShape().end()};

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -485,16 +485,16 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
       op->dump();
     });
     // For debugging purposes, check to see if the original op is still in use.
-    bool hasUse = false;
-    for (unsigned i = 0; i < op->getNumResults(); ++i) {
-      for (Operation *user : op->getResult(i).getUsers()) {
-        hasUse = true;
-        LLVM_DEBUG({
+    LLVM_DEBUG({
+      bool hasUse = false;
+      for (unsigned i = 0; i < op->getNumResults(); ++i) {
+        for (Operation *user : op->getResult(i).getUsers()) {
+          hasUse = true;
           LDBG("op has use ");
           user->dump();
-        });
+        }
       }
-    }
+    });
     op->erase();
   }
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskPartition.cpp
@@ -52,19 +52,6 @@ void doTaskPartition(triton::FuncOp &funcOp, unsigned numWarpGroups) {
   if (loops.empty() || loads.empty() || dots.empty())
     return;
 
-  auto getLoopLevel = [&](Operation *op) {
-    // Compute loop depth
-    unsigned depth = 0;
-    Operation *parent = op->getParentOp();
-    while (parent) {
-      if (isa<scf::ForOp>(parent)) {
-        ++depth;
-      }
-      parent = parent->getParentOp();
-    }
-    return depth;
-  };
-
   // Step 1. Select loads into the first task, which is the producer task by
   // default. Place dots into the second task, which is the consumer.
   // Only consider loads that are connected to a dot op in a loop.

--- a/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/IR/Ops.cpp
@@ -120,16 +120,12 @@ LogicalResult WarpGroupOp::verify() {
 }
 
 ParseResult WarpGroupOp::parse(OpAsmParser &p, OperationState &result) {
-  auto ctx = p.getBuilder().getContext();
-
-  SMLoc operandLoc = p.getCurrentLocation();
   if (p.parseOptionalAttrDictWithKeyword(result.attributes))
     return failure();
 
   SmallVector<int32_t> partitionNumWarps;
   while (succeeded(p.parseOptionalKeyword(
       ("partition" + Twine(partitionNumWarps.size()).str())))) {
-    SMLoc regionLoc = p.getCurrentLocation();
     if (p.parseKeyword("num_warps") || p.parseLParen() ||
         p.parseInteger(partitionNumWarps.emplace_back()) || p.parseRParen() ||
         p.parseRegion(*result.addRegion()))

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
@@ -133,7 +133,6 @@ template <class T> struct AssignStagePhase {
 
     // update yieldOp to return new indexes
     SmallVector<Value> extraYieldArgs;
-    auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
 
     // associate token with stage positional argument in the yieldOp
     // we will need this in propagateStage function that will assign stage
@@ -336,7 +335,6 @@ class NVWSAssignStagePhase
     : public impl::NVWSAssignStagePhaseBase<NVWSAssignStagePhase> {
 public:
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
     mlir::ModuleOp m = getOperation();
 
     m.walk([&](triton::FuncOp funcOp) {

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -325,7 +325,6 @@ void createArefGet(PartitionBuilder &builder, scf::ForOp loop,
   // In the second case, we only need to emit one enter / exit since we know
   // that the two results are used by consumers in the same partition.
   assert(results.size() == 1 || results.size() == 2);
-  auto loc = results[0].getLoc();
 
   auto filterUse = [&](Operation *use) {
     return schedule.getPartition(use) == consumerPartition;
@@ -365,7 +364,6 @@ void createArefGet(PartitionBuilder &builder, scf::ForOp loop,
 
   for (auto result : results) {
     if (auto localAlloc = result.getDefiningOp<LocalAllocOp>()) {
-      auto memDescType = cast<MemDescType>(result.getType());
       auto callback = [&](Operation *oldOp, Operation *newOp) {
         assert(schedule.getPartition(oldOp) == consumerPartition);
         schedule.insert(consumerPartition, newOp);

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -211,7 +211,6 @@ SmallVector<Value> getSubViews(ArefValue arefVal, Value stage, Location loc,
   for (auto buffer : arefVal.buffers) {
     auto memDescType = cast<MemDescType>(buffer.getType());
     auto shape = memDescType.getShape();
-    auto rank = shape.size() - 1;
 
     SmallVector<int64_t> tensorShape(shape.begin() + 1, shape.end());
     auto memDescTypeNew = MemDescType::get(

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -517,7 +517,7 @@ public:
     auto typeB = opB.getType();
     auto typeOutput = op.getType();
     auto structTypeA = dyn_cast<LLVM::LLVMStructType>(typeA);
-    auto structTypeB = dyn_cast<LLVM::LLVMStructType>(typeB);
+    [[maybe_unused]] auto structTypeB = dyn_cast<LLVM::LLVMStructType>(typeB);
     auto structTypeOutput = dyn_cast<LLVM::LLVMStructType>(typeOutput);
     assert(!structTypeB && "Operand B can not be registers");
     assert(structTypeOutput && "Output and C operand must be registers");
@@ -634,7 +634,6 @@ static Value createTMAlloc(IRRewriter &rewriter, LLVM::LLVMFuncOp func,
   allocOp(
       {ptxBuilder.newOperand(pred, "b"), ptxBuilder.newOperand(sharedMem, "r")},
       /*onlyAttachMLIRArgs=*/true);
-  auto voidTy = void_ty(func->getContext());
   ptxBuilder.launch(rewriter, loc, void_ty(func->getContext()));
   rewriter.create<NVVM::Barrier0Op>(loc);
   Value address = b.load(i32_ty, sharedMem);
@@ -659,7 +658,6 @@ void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, size_t size, Value pred,
     OpBuilder b(ret);
     auto ctx = ret->getContext();
     auto loc = ret.getLoc();
-    auto voidTy = void_ty(ctx);
     b.create<NVVM::Barrier0Op>(loc);
     PTXBuilder ptxBuilder;
     // Calculate the predicate in the inline asm to avoid creating long

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -159,7 +159,6 @@ struct WaitBarrierOpConversion
         op.getLoc(), adaptor.getAlloc(),
         typeConverter->convertType(op.getAlloc().getType().getElementType()),
         rewriter);
-    auto loc = op.getLoc();
     bool predicated =
         adaptor.getPred() && !matchPattern(op.getPred(), m_NonZero());
     std::string ptx;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -18,7 +18,7 @@ using namespace mlir::triton;
 using namespace mlir::triton::gpu;
 using mlir::LLVM::NVIDIA::lowerLdStMatrix;
 
-constexpr int kPtrBitWidth = 64;
+[[maybe_unused]] constexpr int kPtrBitWidth = 64;
 struct ConvertLayoutOpSwizzlingConversion
     : public ConvertOpToLLVMPattern<triton::gpu::ConvertLayoutOp> {
   const NVIDIA::TargetInfo &targetInfo;
@@ -34,7 +34,6 @@ struct ConvertLayoutOpSwizzlingConversion
                   ConversionPatternRewriter &rewriter) const override {
     MLIRContext *ctx = op.getContext();
 
-    const auto &shape = op.getType().getShape();
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getType();
 
@@ -188,7 +187,7 @@ struct ConvertLayoutOpSwizzlingConversion
       } else {
         assert(idxSrc == 1 || idxSrc == 2);
         bool transpose = idxSrc == 2;
-        auto result = lowerLdStMatrix(
+        [[maybe_unused]] auto result = lowerLdStMatrix(
             loc, storeCvt, transpose, tileInVals, smemBase, affineOffset,
             maskSpanAffineOffset, llvmElemTy, rewriter, targetInfo);
         assert(succeeded(result));
@@ -204,7 +203,7 @@ struct ConvertLayoutOpSwizzlingConversion
       } else {
         assert(idxDst == 1 || idxDst == 2);
         bool transpose = idxDst == 2;
-        auto result = lowerLdStMatrix(
+        [[maybe_unused]] auto result = lowerLdStMatrix(
             loc, loadCvt, transpose, tileOutVals, smemBase, affineOffset,
             maskSpanAffineOffset, llvmElemTy, rewriter, targetInfo);
         assert(succeeded(result));
@@ -284,7 +283,6 @@ private:
                               OpAdaptor adaptor,
                               ConversionPatternRewriter &rewriter,
                               const NVIDIA::TargetInfo &targetInfo) const {
-    MLIRContext *ctx = rewriter.getContext();
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto typeConverter = getTypeConverter();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -323,7 +323,6 @@ static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
     return mlir::emitError(module.getLoc(),
                            "module missing 'ttg.total-num-warps' attribute");
   }
-  unsigned totalNumThreads = totalNumWarpsAttr.getInt() * threadsPerWarp;
 
   // Determine how many registers the worker warps can surrender before they
   // begin execution.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -30,7 +30,6 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
   LogicalResult
   matchAndRewrite(triton::DotOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Location loc = op->getLoc();
     // D = A * B + C
     Value A = op.getA();
     Value D = op.getResult();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -26,8 +26,8 @@ Value loadC(Value tensor, Value llTensor,
          "Currently, we only support $c with a mma layout.");
   // Load a normal C tensor with mma layout, that should be a
   // LLVM::struct with fcSize elements.
-  auto structTy = cast<LLVM::LLVMStructType>(llTensor.getType());
-  assert(structTy.getBody().size() == fcSize &&
+  assert(cast<LLVM::LLVMStructType>(llTensor.getType()).getBody().size() ==
+             fcSize &&
          "DotOp's $c operand should pass the same number of values as $d in "
          "mma layout.");
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -678,11 +678,13 @@ convertMMAImpl(DotOpInterface op, Value llvmA, Value llvmB, Value llvmC,
                const std::map<TensorCoreType, std::string> &mmaInstructions,
                const EmitMmaCallback &emitMma) {
   auto loc = op.getLoc();
+#ifndef NDEBUG
   auto aType = cast<RankedTensorType>(op.getA().getType());
   auto bType = cast<RankedTensorType>(op.getB().getType());
   assert(mlir::isa<DotOperandEncodingAttr>(aType.getEncoding()) &&
          mlir::isa<DotOperandEncodingAttr>(bType.getEncoding()) &&
          "Both $a and %b should be DotOperand layout.");
+#endif
 
   Value cOperand = op->getOperand(2);
   Value loadedC = loadC(cOperand, llvmC, typeConverter, loc, rewriter);
@@ -865,8 +867,6 @@ LogicalResult convertMMADotScaled(triton::DotScaledOp op,
                              ValueTableV2 &aTable, ValueTableV2 &bTable,
                              const SmallVector<Value> &cValues,
                              RankedTensorType dTy, int repK) {
-    const unsigned numCPackedElem = 4u / numMmaRets;
-
     // aScaleValue, bScaleValue selection logic for the scale factor
     // depends on the layout selection in
     // LinearLayoutConversions.cpp::getSM120DotScaledScaleLayout

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -664,6 +664,7 @@ struct TCGen5MMAOpConversion
   LogicalResult
   matchAndRewrite(ttng::TCGen5MMAOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+#ifndef NDEBUG
     auto AEnc = op.getA().getType().getEncoding();
     auto BEnc = op.getB().getType().getEncoding();
     assert(
@@ -671,6 +672,7 @@ struct TCGen5MMAOpConversion
         "Operand A should use Shared or Tensor memory layout.");
     assert(isa<NVMMASharedEncodingAttr>(BEnc) &&
            "Operand B should use Shared layout.");
+#endif
     convertDot(*getTypeConverter(), rewriter, op.getLoc(), op, adaptor);
     rewriter.eraseOp(op);
     return success();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -413,7 +413,6 @@ struct FpToFpOpConversion
     auto F16TyID = TypeID::get<Float16Type>();
     auto BF16TyID = TypeID::get<BFloat16Type>();
     auto F32TyID = TypeID::get<Float32Type>();
-    auto F64TyID = TypeID::get<Float64Type>();
 
     auto undefRounding = static_cast<RoundingMode>(-1);
 
@@ -626,7 +625,6 @@ struct FPToSIOpConversion
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    auto inElemTy = getElementType(op.getIn());
     return {rewriter.create<LLVM::FPToSIOp>(loc, elemTy, operands[0][0])};
   }
 };

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -253,7 +253,6 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     // vectorized iteration through all the pointer/mask/other elements
     const int valueElemNBits =
         std::max(8u, valueElemTy.getIntOrFloatBitWidth());
-    const int numVecs = numElems / vec;
 
     // Load redundantly in all dims except reg
     auto freeVarMasks = getFreeVariableMasks(ptr.getType());
@@ -280,9 +279,12 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       const size_t totalWidth = valueElemNBits * vec;
       const size_t width = std::min(totalWidth, maxWordWidth);
       const size_t nWords = std::max<size_t>(1, totalWidth / width);
-      const size_t wordNElems = width / valueElemNBits;
       const size_t movWidth = width < 16 ? 16 : width;
+#ifndef NDEBUG
+      const size_t wordNElems = width / valueElemNBits;
+      const int numVecs = numElems / vec;
       assert(wordNElems * nWords * numVecs == numElems);
+#endif
 
       PTXBuilder ptxBuilder;
 
@@ -470,7 +472,6 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
         emitRedundantThreadPredicate(freeVarMasks, rewriter, loc, targetInfo);
     uint32_t regMask = freeVarMasks[str_attr("reg")];
 
-    const int numVecs = elemsPerThread / vec;
     for (size_t vecStart = 0; vecStart < elemsPerThread; vecStart += vec) {
       if (!isCanonicalIndex(vecStart, regMask)) {
         // Don't emit store ops for redundant elements within a thread
@@ -484,7 +485,10 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
       const size_t width = std::min(totalWidth, maxWordWidth);
       const size_t nWords = std::max<size_t>(1, totalWidth / width);
       const size_t wordNElems = width / valueElemNBits;
+#ifndef NDEBUG
+      const int numVecs = elemsPerThread / vec;
       assert(wordNElems * nWords * numVecs == elemsPerThread);
+#endif
 
       // TODO(Superjomn) Add cache policy fields to StoreOp.
       // TODO(Superjomn) Deal with cache policy here.
@@ -852,7 +856,6 @@ public:
                 : triton::nvgpu::MemSemantic::RELAXED,
             ScopeMap[op.getScope()]);
 
-        auto ASMReturnTy = void_ty(ctx);
         if (op.getResult().use_empty()) {
           rewriter.eraseOp(op);
           return success();
@@ -1075,7 +1078,6 @@ public:
           resultVals[i] = ret;
         }
       } else {
-        auto ASMReturnTy = void_ty(ctx);
         atom(dstOpr, ptrOpr, valOpr).maybePredicate(pred);
         auto old = ptxBuilderAtomicRMW.launch(rewriter, loc, valueElemTy);
         if (op.getResult().use_empty()) {
@@ -1115,10 +1117,7 @@ struct AsyncCopyGlobalToLocalOpConversion
     auto ctx = getContext();
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    Value res = op.getResult();
     Value mask = op.getMask();
-    Value other = op.getOther();
-    auto funcOp = op->getParentOfType<FunctionOpInterface>();
 
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getResult().getType();
@@ -1127,7 +1126,6 @@ struct AsyncCopyGlobalToLocalOpConversion
     Value llDst = adaptor.getResult();
     Value llSrc = adaptor.getSrc();
     Value llMask = adaptor.getMask();
-    Value llOther = adaptor.getOther();
 
     // %src
     auto srcElems = unpackLLElements(loc, llSrc, rewriter);
@@ -1345,11 +1343,6 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     pred = b.and_(pred, LLVM::NVIDIA::createElectPredicate(loc, rewriter));
 
     auto smemTy = op.getResult().getType();
-    Attribute encoding = smemTy.getEncoding();
-    auto mmaEncoding = dyn_cast_or_null<NVMMASharedEncodingAttr>(encoding);
-    int elementSizeInBytes =
-        op.getResult().getType().getElementType().getIntOrFloatBitWidth() / 8;
-    int packingFactor = (mmaEncoding && mmaEncoding.getFp4Padded()) ? 2 : 1;
 
     auto shapePerCTA = ttg::getShapePerCTA(smemTy);
     int rank = op.getCoord().size();
@@ -1435,17 +1428,14 @@ LogicalResult convertTMAStoreLikeOp(Operation *op,
   // Select just one thread for the TMA copy. This also helps the compiler to
   // figure out that the op is uniform.
   Value pred = LLVM::NVIDIA::createElectPredicate(loc, rewriter);
-  int elementSizeInBytes = srcTy.getElementType().getIntOrFloatBitWidth() / 8;
 
   auto mod = op->getParentOfType<ModuleOp>();
   int numWarps = ttg::lookupNumWarps(op);
   int warpSize = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
   Value warpID = rewriter.create<nvgpu::WarpIdOp>(loc);
   auto shapePerCTA = ttg::getShapePerCTA(srcTy);
-  int elementsPerCTA = product(shapePerCTA);
 
   auto rank = coords.size();
-  auto encoding = srcTy.getEncoding();
 
   auto msgToPackedOffset = getMsgToPackedOffsetLayout(srcTy);
   auto smemLayout = ttg::toLinearLayout(srcTy);
@@ -1479,7 +1469,6 @@ LogicalResult convertTMAStoreLikeOp(Operation *op,
 
     auto offsets = applyLinearLayout(loc, rewriter, msgToOffset,
                                      {{kMsg, copyIdxVal}, {kBlock, ctaId}});
-    int operandIdx = 2;
     for (int i = 0; i < rank; i++) {
       Value coord = coords[rank - i - 1];
       if (i < offsets.size())
@@ -1580,7 +1569,6 @@ static LogicalResult iterateGatherScatterIndices(
   Location loc = op->getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-  StringAttr kDim0 = str_attr("dim0");
   StringAttr kDim1 = str_attr("dim1");
   StringAttr kMsg = str_attr("msg");
   StringAttr kRegister = str_attr("register");
@@ -1617,7 +1605,6 @@ static LogicalResult iterateGatherScatterIndices(
   Value smemBase = smemObj.getShmemAffineBase(loc, rewriter, smemType);
 
   unsigned threadsPerWarp = xCoordsLayout.getInDimSize(kLane);
-  unsigned numWarps = xCoordsLayout.getInDimSize(kWarp);
 
   // Each gather4 instructions reads contigDimSize columns, 4 rows at a time.
   auto shapePerCTA = ttg::getShapePerCTA(smemType);
@@ -1705,7 +1692,6 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
     triton::nvidia_gpu::AsyncTMAGatherOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   Location loc = op.getLoc();
-  MLIRContext *ctx = getContext();
 
   LLVM::LLVMVoidType voidTy = void_ty(op->getContext());
   auto barrierMemObj = LLVM::getSharedMemoryObjectFromStruct(
@@ -1762,7 +1748,6 @@ LogicalResult AsyncTMAScatterOpConversion::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
   Location loc = op.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  MLIRContext *ctx = getContext();
   LLVM::LLVMVoidType voidTy = void_ty(op->getContext());
 
   // Callback to generate the scatter4 instruction.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -183,8 +183,8 @@ void TargetInfo::storeDShared(RewriterBase &rewriter, Location loc, Value ptr,
                               Value pred) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   MLIRContext *ctx = rewriter.getContext();
-  auto ptrTy = cast<LLVM::LLVMPointerType>(ptr.getType());
-  assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
+  assert(cast<LLVM::LLVMPointerType>(ptr.getType()).getAddressSpace() == 3 &&
+         "Invalid addr space for load_dsmem");
 
   if (!isa<VectorType>(val.getType())) {
     storeDShared(rewriter, loc, ptr, ctaId, packLLVector(loc, {val}, rewriter),
@@ -246,7 +246,6 @@ void TargetInfo::storeDShared(RewriterBase &rewriter, Location loc, Value ptr,
     assert(elemBitwidth == 32 || elemBitwidth == 64);
     int maxVec = 128 / elemBitwidth;
 
-    auto newVecTy = vec_ty(elemTy, maxVec);
     SmallVector<Value> vals = unpackLLVector(loc, val, rewriter);
     for (int i = 0; i < vec / maxVec; i++) {
       auto newPtr = b.gep(ptr.getType(), elemTy, ptr, b.i32_val(i * maxVec),
@@ -302,8 +301,8 @@ Value TargetInfo::loadDShared(RewriterBase &rewriter, Location loc, Value ptr,
                               Value pred, Operation *localLoadOp) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   MLIRContext *ctx = rewriter.getContext();
-  auto ptrTy = cast<LLVM::LLVMPointerType>(ptr.getType());
-  assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
+  assert(cast<LLVM::LLVMPointerType>(ptr.getType()).getAddressSpace() == 3 &&
+         "Invalid addr space for load_dsmem");
 
   if (!isa<VectorType>(loadTy)) {
     SmallVector<Value> values = unpackLLVector(
@@ -512,7 +511,6 @@ void TargetInfo::printf(RewriterBase &rewriter, Value formatStrStart,
                         ArrayRef<bool> isSigned) const {
   auto *ctx = rewriter.getContext();
   Type ptr = ptr_ty(ctx);
-  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
   auto funcOp = getVprintfDeclaration(rewriter);
   auto loc = UnknownLoc::get(ctx);
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -569,7 +567,6 @@ void TargetInfo::assertFail(RewriterBase &rewriter, Location loc,
                             int line) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   auto funcOp = getAssertfailDeclaration(rewriter);
-  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
   llvm::SmallString<64> messageString(message), fileString(file),
       funcString(func);
   messageString.push_back('\0');

--- a/third_party/proton/Dialect/lib/Dialect/ProtonGPU/IR/Ops.cpp
+++ b/third_party/proton/Dialect/lib/Dialect/ProtonGPU/IR/Ops.cpp
@@ -22,7 +22,6 @@ namespace gpu {
 LogicalResult CircularStoreOp::verify() {
   auto scopeId = getScopeId();
   auto segmentType = getSegment().getType();
-  auto granularity = segmentType.getGranularity();
   auto selectedIds = segmentType.getSelectIds();
   auto bufferSizeInBytes = segmentType.getNBytes();
   auto mod = getOperation()->getParentOfType<ModuleOp>();

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/AllocateProtonGlobalScratchBuffer.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/AllocateProtonGlobalScratchBuffer.cpp
@@ -46,10 +46,12 @@ struct AllocateProtonGlobalScratchBufferPass
     if (alignments.empty())
       return;
 
+#ifndef NDEBUG
     bool allAlignmentsEqual = std::equal(alignments.begin() + 1,
                                          alignments.end(), alignments.begin());
     assert(allAlignmentsEqual &&
            "all global scratch buffer alignment values must be the same");
+#endif
     mod->setAttr("ttg.profile_scratch_memory_size",
                  builder.getI32IntegerAttr(cumulativeMemorySize));
     mod->setAttr("ttg.profile_scratch_memory_alignment",

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/PatternProtonGPUOpToLLVM.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/PatternProtonGPUOpToLLVM.cpp
@@ -112,7 +112,6 @@ struct FinalizeOpConversion
     //  | profiled data (allocBufferSize bytes)         |
     //  +-----------------------------------------------+
     const int metadataWordSize = circularHeaderWordSize + numWarps;
-    const int scratchWordSize = metadataWordSize + bufferSizeInWords;
 
     auto &tritonTargetInfo = targetInfo.getTritonTargetInfo();
 
@@ -321,7 +320,6 @@ struct GlobalScratchAllocOpConversion
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto *ctx = rewriter.getContext();
-    auto &tritonTargetInfo = targetInfo.getTritonTargetInfo();
 
     auto funcOp = op->getParentOfType<LLVM::LLVMFuncOp>();
     if (!funcOp) {
@@ -445,7 +443,6 @@ struct RestoreCtxOpConversion
 
     auto mod = op.getOperation()->getParentOfType<ModuleOp>();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    int numWarps = getTotalNumWarps(mod);
 
     // We need to use the absolute warp id in case warp specialization is used.
     Value threadId = getRawThreadId(rewriter, loc);
@@ -492,8 +489,6 @@ struct SaveCtxOpConversion
 
     auto mod = op.getOperation()->getParentOfType<ModuleOp>();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-
-    int numWarps = getTotalNumWarps(mod);
 
     int numLanes = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
     Value warpSize = b.i32_val(numLanes);

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
@@ -84,7 +84,7 @@ Value TargetInfo::processorId(ConversionPatternRewriter &rewriter,
                               Location loc) const {
   GCNBuilder builder;
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  auto &gethwid = *builder.create("s_getreg_b32");
+  builder.create("s_getreg_b32");
 
   Value xcc_id = b.i32_val(0);
   llvm::AMDGPU::GPUKind GPUKind = llvm::AMDGPU::parseArchAMDGCN(this->arch);

--- a/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
+++ b/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
@@ -137,8 +137,6 @@ LogicalResult replaceProtonRecordOp(OpBuilder &builder, FuncOp func,
 int getAllocSharedMemSize(int maxSharedMemSize, int sharedMemUsed,
                           int segmentNum) {
   const int bytesPerEntry = gpu::getBytesPerClockEntry();
-  const int wordsPerEntry = bytesPerEntry / 4; // 1 word = 4 bytes
-  const int circularHeaderSize = gpu::getCircularHeaderSize(); // byte size
   sharedMemUsed = llvm::alignTo(sharedMemUsed, bytesPerEntry);
   if (sharedMemUsed >= maxSharedMemSize) {
     // We just assume there's enough shared memory and error out if not during

--- a/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
+++ b/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
@@ -17,9 +17,11 @@ std::shared_ptr<CircularLayoutParserResult> CircularLayoutParser::getResult() {
 }
 
 void CircularLayoutParser::parse() {
+#ifndef NDEBUG
   auto &uidVec = getConfig().uidVec;
   assert(uidVec.size());
   assert(std::is_sorted(uidVec.begin(), uidVec.end()));
+#endif
 
   int numBlocks = getConfig().numBlocks;
   const int scratchMemSize = getConfig().scratchMemSize;
@@ -85,7 +87,6 @@ void CircularLayoutParser::parseProfileEvents() {
 void CircularLayoutParser::parseSegment(
     int segmentByteSize, CircularLayoutParserResult::Trace &trace) {
 
-  auto state = ParseState::INIT;
   int idealSize = trace.count * kWordSize;
   int byteSize = std::min(idealSize, segmentByteSize);
   const int maxNumEntries = byteSize / (kWordSize * kWordsPerEntry);
@@ -186,11 +187,11 @@ std::shared_ptr<CircularLayoutParserResult>
 proton::readCircularLayoutTrace(ByteSpan &buffer, bool applyTimeShift) {
   CircularLayoutParserConfig config;
   auto decoder = EntryDecoder(buffer);
-  uint32_t version = decoder.decode<I32Entry>()->value;
+  [[maybe_unused]] uint32_t version = decoder.decode<I32Entry>()->value;
   assert(version == 1 && "Version mismatch");
   buffer.skip(8);
   uint32_t payloadOffset = decoder.decode<I32Entry>()->value;
-  uint32_t payloadSize = decoder.decode<I32Entry>()->value;
+  [[maybe_unused]] uint32_t payloadSize = decoder.decode<I32Entry>()->value;
   uint32_t device = decoder.decode<I32Entry>()->value;
   config.device = decodeDevice(device);
   config.numBlocks = decoder.decode<I32Entry>()->value;

--- a/third_party/proton/csrc/lib/Context/Python.cpp
+++ b/third_party/proton/csrc/lib/Context/Python.cpp
@@ -81,7 +81,6 @@ std::vector<Context> PythonContextSource::getContextsImpl() {
   while (frame != nullptr) {
     PyCodeObject *f_code = getFrameCodeObject(frame);
     size_t lineno = PyFrame_GetLineNumber(frame);
-    size_t firstLineNo = f_code->co_firstlineno;
     std::string file = unpackPyobject(f_code->co_filename);
     std::string function = unpackPyobject(f_code->co_name);
     auto pythonFrame = file + ":" + function + "@" + std::to_string(lineno);

--- a/third_party/proton/csrc/lib/Data/TraceData.cpp
+++ b/third_party/proton/csrc/lib/Data/TraceData.cpp
@@ -215,7 +215,6 @@ void TraceData::addMetrics(
   // The profile data is deactivated, ignore the metric
   if (scopeIdIt == scopeIdToContextId.end())
     return;
-  auto contextId = scopeIdIt->second;
   if (!trace->hasEvent(scopeId))
     return;
   auto &event = trace->getEvent(scopeId);

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiPCSampling.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiPCSampling.cpp
@@ -134,7 +134,6 @@ CUpti_PCSamplingData allocPCSamplingData(size_t collectNumPCs,
                                          size_t numValidStallReasons) {
   uint32_t libVersion = 0;
   cupti::getVersion<true>(&libVersion);
-  size_t pcDataSize = sizeof(CUpti_PCSamplingPCData);
   // Since CUPTI 12.4, a new field (i.e., correlationId) is added to
   // CUpti_PCSamplingPCData, which breaks the ABI compatibility.
   // Instead of using workarounds, we emit an error message and exit the
@@ -431,7 +430,6 @@ void CuptiPCSampling::finalize(CUcontext context) {
   cupti::getContextId<true>(context, &contextId);
   if (!contextInitialized.contain(contextId))
     return;
-  auto *configureData = getConfigureData(contextId);
   contextIdToConfigureData.erase(contextId);
   contextInitialized.erase(contextId);
   disablePCSampling(context);

--- a/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
@@ -44,8 +44,6 @@ public:
 
 private:
   void initDeviceOffset() {
-    int dc = 0;
-    auto ret = hip::getDeviceCount<true>(&dc);
     hsa::iterateAgents(
         [](hsa_agent_t agent, void *data) {
           auto &offset = *static_cast<int *>(data);

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -566,7 +566,6 @@ TEST_F(LinearEncodingTest, DistributedEncodingToLinearEncoding) {
       ASSERT_EQ(linearLayout, expandedLL);
 
       // Test that methods of DistributedEncoding return the same values
-      Type eltTy = Float32Type::get(&ctx);
 
       ASSERT_EQ(distributedEncoding.getTotalElemsPerThread(shape),
                 linearEncoding.getTotalElemsPerThread(shape));

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -3559,10 +3559,6 @@ TEST_F(LinearLayoutConversionsTest, TensorMemory_blockM_128) {
 }
 
 TEST_F(LinearLayoutConversionsTest, TensorMemory_Packed) {
-  auto d0 = S("dim0");
-  auto d1 = S("dim1");
-  auto rows = S("rows");
-  auto cols = S("cols");
   auto enc = tmem(128, 128, /*unpacked*/ false, 1, 1);
   auto encUnpacked = tmem(128, 128, /*unpacked*/ true, 1, 1);
   // Packed and unpacked map to the same layout
@@ -3580,7 +3576,6 @@ TEST_F(LinearLayoutConversionsTest, TensorMemory_Packed) {
 TEST_F(LinearLayoutConversionsTest, TensorMemory_CTASplit) {
   auto d0 = S("dim0");
   auto d1 = S("dim1");
-  auto kRow = S("row");
   auto kCol = S("col");
   auto enc = tmem(64, 128, /*unpacked*/ true, 2, 1);
   auto enc1 = tmem(64, 128, /*unpacked*/ true, 1, 1);
@@ -3601,7 +3596,6 @@ TEST_F(LinearLayoutConversionsTest, TensorMemory_CTASplit) {
   // The non-contiguous tile stays non-contiguous even in the multiCTA setup
   auto noncontigTile =
       toLinearLayout({64, 64}, tmem(64, 64, /*unpacked*/ true, 1, 1));
-  auto noncontigEnc = tmem(64, 64, /*unpacked*/ true, 2, 2);
   EXPECT_EQ(toLinearLayout({128, 128}, enc),
             noncontigTile * LinearLayout::identity1D(2, kCol, d0) *
                 LinearLayout::identity1D(2, kCol, d1));

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -843,7 +843,6 @@ TEST_F(LinearLayoutTest, BlackwellMixedPrecisionDotScaledSMEM) {
 TEST_F(LinearLayoutTest, BlackwellMixedPrecisionDotScaledSMEMSwizzled) {
   int M = 16;
   int KPadded8b = 128;
-  int numFp4Elems = M * KPadded8b;
   int KPacked8b = KPadded8b / 2;
   int elemBitWidth = 8;
   int tileWidthBytes = 128;


### PR DESCRIPTION
This adds the `-Wunused-variable` flag to the build and fixes any errors that show up as a result of building with `REL_WITH_DEB_INFO=1` or without. This is a follow up from https://github.com/triton-lang/triton/pull/6901.

These fixes include:
- Removing unused variables
- Folding some variables only used in `assert`s into the `assert` statements
- Adding `[[maybe_unused]]` to other variables used only in `assert`s (where it makes sense, maybe where the variable name contributes to readability)
- Wrapping larger chunks of `assert`s in `#ifndef NDEBUG // #endif` macros
- Changing some instances of `Value value = builder.create(...);` to just `builder.create(...);` where `value` is unused

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `it only removes unused variables/adds maybe_unuseds/#ifndef NDEBUG so the existing test suite passing should suffice`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
