### PR TITLE
[release/3.5.x] Revert buffer ops default enablement on AMD

### DIFF
--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -77,13 +77,10 @@ def test_knobs_scope(fresh_knobs, monkeypatch):
 
     assert fresh_knobs.amd.global_prefetch == 4
     assert fresh_knobs.amd.local_prefetch == 3
-    assert fresh_knobs.amd.use_buffer_ops
 
     # Just to prove that use_buffer_ops is coming from env
     monkeypatch.setenv("AMDGCN_USE_BUFFER_OPS", "0")
     assert not fresh_knobs.amd.use_buffer_ops
-    monkeypatch.delenv("AMDGCN_USE_BUFFER_OPS")
-    assert fresh_knobs.amd.use_buffer_ops
 
     with fresh_knobs.amd.scope():
         fresh_knobs.amd.global_prefetch = 5
@@ -97,13 +94,10 @@ def test_knobs_scope(fresh_knobs, monkeypatch):
 
     assert fresh_knobs.amd.global_prefetch == 4
     assert fresh_knobs.amd.local_prefetch == 3
-    assert fresh_knobs.amd.use_buffer_ops
 
     # Just to prove that use_buffer_ops is coming from env
     monkeypatch.setenv("AMDGCN_USE_BUFFER_OPS", "0")
     assert not fresh_knobs.amd.use_buffer_ops
-    monkeypatch.delenv("AMDGCN_USE_BUFFER_OPS")
-    assert fresh_knobs.amd.use_buffer_ops
 
 
 def test_env_updated(fresh_knobs, monkeypatch):

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -486,7 +486,7 @@ class nvidia_knobs(base_knobs):
 
 
 class amd_knobs(base_knobs):
-    use_buffer_ops: env_bool = env_bool("AMDGCN_USE_BUFFER_OPS", True)
+    use_buffer_ops: env_bool = env_bool("AMDGCN_USE_BUFFER_OPS")
     # Note: This requires use_buffer_ops be true to have any effect
     use_buffer_atomics: env_bool = env_bool("AMDGCN_USE_BUFFER_ATOMICS", True)
     dump_amdgcn: env_bool = env_bool("AMDGCN_ENABLE_DUMP")

--- a/third_party/amd/python/test/test_scalarize_packed_fops.py
+++ b/third_party/amd/python/test/test_scalarize_packed_fops.py
@@ -64,6 +64,8 @@ def test_check_not_scalarize():
 # check scalarization "fixes"
 def test_check_scalarized():
     triton.knobs.amd.scalarize_packed_fops = True
+    triton.knobs.amd.use_buffer_ops = True
+
     kernel = triton.compile(str(Path(__file__).parent / "attn_fwd.ttir"), target=current_target)
 
     # check the specific IR pattern was rewritten


### PR DESCRIPTION
Buffer op default enablement is resulting in corresponding PT UT failure https://github.com/ROCm/triton/issues/830

Disabling in release branch for stability while we develop a fix for main. Note: we're definitely open to reverting this change and landing the buffer ops fixes if they are able to get pytorch tests to pass.