### PR TITLE
Add Pyrefly type checking to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,14 @@ repos:
       - id: mypy
         pass_filenames: false
 
+  - repo: https://github.com/facebook/pyrefly-pre-commit
+    rev: 0.0.1
+    hooks:
+      - id: pyrefly-typecheck-specific-version
+        name: Pyrefly (type checking)
+        pass_filenames: false
+        additional_dependencies: ["pyrefly==0.30.0"]
+
   # Expand YAML anchors in files used by github workflows, because github can't
   # do this itself.  This lets us use anchors, which avoids code duplication.
   - repo: local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,18 @@ ignore = ["E501", "E701", "E731", "E741"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+
+[tool.pyrefly]
+project-includes = [
+    "python/triton/knobs.py",
+    "python/triton/runtime/build.py",
+    "python/triton/runtime/driver.py",
+    "python/triton/_utils.py",
+]
+
+project-excludes = ["**/build/"]
+
+[[tool.pyrefly.sub-config]]
+matches = "python/test/**"
+
+untyped-def-behavior = "skip-and-infer-return-any" # Replicate Mypy behavior for tests

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -7,3 +7,4 @@ pytest-xdist
 scipy>=1.7.1
 llnl-hatchet
 expecttest
+pyrefly==0.30.0

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -200,6 +200,7 @@ class env_nvidia_tool(env_base[str, NvidiaTool]):
     def get(self) -> NvidiaTool:
         return self.transform(getenv(self.key))
 
+    # pyrefly: ignore  # bad-override pyright agrees
     def transform(self, path: str) -> NvidiaTool:
         # We still add default as fallback in case the pointed binary isn't
         # accessible.
@@ -340,8 +341,11 @@ cache: cache_knobs
 class cache_knobs(base_knobs):
     home_dir: env_str = env_str("TRITON_HOME", os.path.expanduser("~/"))
 
+    # pyrefly: ignore  # unbound-name
     dump_dir = env_str_callable_default("TRITON_DUMP_DIR", lambda: cache.get_triton_dir("dump"))
+    # pyrefly: ignore  # unbound-name
     override_dir = env_str_callable_default("TRITON_OVERRIDE_DIR", lambda: cache.get_triton_dir("override"))
+    # pyrefly: ignore  # unbound-name
     dir = env_str_callable_default("TRITON_CACHE_DIR", lambda: cache.get_triton_dir("cache"))
 
     manager_class: env_class[CacheManager] = env_class("TRITON_CACHE_MANAGER", "CacheManager")


### PR DESCRIPTION
Triton does not check many Python files, however Pyrefly is faster so pre-commit time can improve. If Triton chooses to lean more into type checking in the future can leverage type inference from a modern type checker. 

- Pre-commit for mypy (16s cold, 1s warm), pyrefly (0.7s cold)
- Better IDE experience if developers use the VSCode or [other IDE](https://pyrefly.org/en/docs/IDE/#other-editors) extension for type inference
- TODO: remove mypy after approval

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it's a pre-commit hook tested as part of pre-commit flow.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
