### PR TITLE
Fix missing return at end of strMMADTypeKind function

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -277,6 +277,7 @@ static std::string strMMADTypeKind(MMADTypeKind kind) {
   case MMADTypeKind::i8:
     return "i8";
   }
+  __builtin_unreachable();
 }
 
 static std::optional<std::pair<MMADTypeKind, SmallVector<Type>>>


### PR DESCRIPTION
This PR tries to fix this Triton build error when running `pip install .`:

```
2025-08-30T17:46:31.6279959Z       FAILED: [code=1]
2025-08-30T17:46:31.6280341Z       lib/Dialect/TritonNvidiaGPU/IR/CMakeFiles/TritonNvidiaGPUIR.dir/Ops.cpp.o
2025-08-30T17:46:31.6280801Z       /usr/bin/g++-13 -DGTEST_HAS_RTTI=0
2025-08-30T17:46:31.6281256Z       -I/tmp/triton/build/cmake.linux-x86_64-cpython-3.10/lib/Dialect/TritonNvidiaGPU/IR
2025-08-30T17:46:31.6281755Z       -I/tmp/triton/lib/Dialect/TritonNvidiaGPU/IR
2025-08-30T17:46:31.6282097Z       -I/tmp/triton/include -I/tmp/triton/.
2025-08-30T17:46:31.6282472Z       -I/github/home/.triton/llvm/llvm-064f02da-ubuntu-x64/include
2025-08-30T17:46:31.6282926Z       -I/tmp/triton/build/cmake.linux-x86_64-cpython-3.10/include
2025-08-30T17:46:31.6283297Z       -I/tmp/triton/third_party
2025-08-30T17:46:31.6283660Z       -I/tmp/triton/build/cmake.linux-x86_64-cpython-3.10/third_party
2025-08-30T17:46:31.6284089Z       -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17 -Werror
2025-08-30T17:46:31.6284487Z       -Wno-covered-switch-default -fvisibility=hidden -O2 -g
2025-08-30T17:46:31.6284931Z       -std=gnu++17  -fno-exceptions -funwind-tables -fno-rtti -MD -MT
2025-08-30T17:46:31.6285467Z       lib/Dialect/TritonNvidiaGPU/IR/CMakeFiles/TritonNvidiaGPUIR.dir/Ops.cpp.o
2025-08-30T17:46:31.6285900Z       -MF
2025-08-30T17:46:31.6286269Z       lib/Dialect/TritonNvidiaGPU/IR/CMakeFiles/TritonNvidiaGPUIR.dir/Ops.cpp.o.d
2025-08-30T17:46:31.6286716Z       -o
2025-08-30T17:46:31.6287072Z       lib/Dialect/TritonNvidiaGPU/IR/CMakeFiles/TritonNvidiaGPUIR.dir/Ops.cpp.o
2025-08-30T17:46:31.6287586Z       -c /tmp/triton/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
2025-08-30T17:46:31.6287985Z       /tmp/triton/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp:
2025-08-30T17:46:31.6288560Z       In function ‘std::string
2025-08-30T17:46:31.6289012Z       mlir::triton::nvidia_gpu::strMMADTypeKind({anonymous}::MMADTypeKind)’:
2025-08-30T17:46:31.6289549Z       /tmp/triton/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp:280:1: error: control
2025-08-30T17:46:31.6290051Z       reaches end of non-void function [-Werror=return-type]
2025-08-30T17:46:31.6290376Z         280 | }
2025-08-30T17:46:31.6290578Z             | ^
2025-08-30T17:46:31.6290782Z       At global scope:
2025-08-30T17:46:31.6291068Z       cc1plus: note: unrecognized command-line option
```
Full log: see https://github.com/pytorch/helion/actions/runs/17346701695/job/49247648525?pr=533 "Install Triton" tab status.

------

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `It's try to fix a build error due to missing return type at end of function`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
