### PR TITLE
[Gluon] Fix description in layout explanation in gluon tutorial

### DIFF
--- a/python/tutorials/gluon/02-layouts.py
+++ b/python/tutorials/gluon/02-layouts.py
@@ -56,7 +56,7 @@ If `order` was `[0, 1]` (col-major order), the tile would look like:
 
 Likewise, `threads_per_warp=[16, 2]` indicates how the tensor elements owned by
 a single thread are tiled to obtain the elements owned by a single warp. For
-`order=[0, 1]`, the warp tile of threads looks like:
+`order=[1, 0]`, the warp tile of threads looks like:
 
 ```
 [[ T0,  T1],

--- a/python/tutorials/gluon/02-layouts.py
+++ b/python/tutorials/gluon/02-layouts.py
@@ -35,8 +35,8 @@ of the tensor are tiled.
 
 In this example, `size_per_thread=[2, 4]` indicates that within each block, each
 thread owns a contiguous `2x4` subtile of the tensor, stored as registers in
-that thread. `order=[1, 0]` indicates that the layout tiles the columns first
-then the rows, i.e. column-major order. For a thread T, the tile looks like:
+that thread. `order=[1, 0]` indicates that the layout tiles the rows first
+then the columns, i.e. row-major order. For a thread T, the tile looks like:
 
 ```
 [[T:0, T:1, T:2, T:3],
@@ -47,7 +47,7 @@ When visualizing layouts, we sometimes represent which warp, lane, and register
 are mapped to which tensor element. Notice that the registers increment over the
 inner dimension.
 
-If `order` was `[0, 1]` (row-major order), the tile would look like:
+If `order` was `[0, 1]` (col-major order), the tile would look like:
 
 ```
 [[T:0, T:2, T:4, T:6],
@@ -56,7 +56,7 @@ If `order` was `[0, 1]` (row-major order), the tile would look like:
 
 Likewise, `threads_per_warp=[16, 2]` indicates how the tensor elements owned by
 a single thread are tiled to obtain the elements owned by a single warp. For
-`order=[1, 0]`, the warp tile of threads looks like:
+`order=[0, 1]`, the warp tile of threads looks like:
 
 ```
 [[ T0,  T1],


### PR DESCRIPTION
- Previously, orders were incorrectly described.
- This makes the layout visualization and explanation consistent with the actual implementation.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it is a description fix`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
