### PR TITLE
[AMD][GLUON] Support scalar other value for loads

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1769,80 +1769,41 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 """)
 
 
+@gluon.jit
+def amd_global_load_to_shared(ptr):
+    blocked: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [32, 2], [4, 1], [1, 0])
+    shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[1, 0])
+
+    smem = ttgl.allocate_shared_memory(ptr.dtype.element_ty, [128, 16], shared)
+    y_offset = ttgl.arange(0, 128, layout=ttgl.SliceLayout(1, blocked))
+    x_offset = ttgl.arange(0, 16, layout=ttgl.SliceLayout(0, blocked))
+    offsets = y_offset[:, None] * 16 + x_offset[None, :]
+
+    cdna4_async_copy.global_load_to_shared(smem, ptr + offsets)
+
+    # test mask and other
+    mask = (y_offset < 64)[:, None]
+
+    other = ttgl.full([128, 16], 0.0, ptr.dtype.element_ty, layout=blocked)
+    cdna4_async_copy.global_load_to_shared(smem, ptr + offsets, mask, other=other)
+
+    other = ttgl.full([128, 1], 0.0, ptr.dtype.element_ty, layout=blocked)
+    cdna4_async_copy.global_load_to_shared(smem, ptr + offsets, mask, other=other)
+
+    cdna4_async_copy.global_load_to_shared(smem, ptr + offsets, mask, other=0.0)
+
+
 @pytest.mark.parametrize("target", [HIP_TARGET_CDNA4])
 def test_amd_global_load_to_shared(target):
-
-    @gluon.jit
-    def kernel(ptr):
-        blocked: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [32, 2], [4, 1], [1, 0])
-        shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[1, 0])
-
-        smem = ttgl.allocate_shared_memory(ptr.dtype.element_ty, [128, 16], shared)
-        offsets = ttgl.arange(0, 128, layout=ttgl.SliceLayout(1, blocked))[:, None] * 16 + \
-                  ttgl.arange(0, 16, layout=ttgl.SliceLayout(0, blocked))[None, :]
-
-        cdna4_async_copy.global_load_to_shared(smem, ptr + offsets)
-        cdna4_async_copy.async_wait(0)
-
     ptr = MockTensor(ttgl.float16)
-    mod = run_parser(kernel, *make_args(ptr), target=target)
+    mod = run_parser(amd_global_load_to_shared, *make_args(ptr), target=target)
     expecttest.assert_expected_inline(
         anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<128x16xf16, #shared, #smem, mutable>
-    %1 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    %2 = tt.expand_dims %1 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
-    %c16_i32 = arith.constant 16 : i32
-    %c16_i32_0 = arith.constant 16 : i32
-    %cst = arith.constant dense<16> : tensor<128x1xi32, #blocked>
-    %3 = arith.muli %2, %cst : tensor<128x1xi32, #blocked>
-    %4 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
-    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x16xi32, #blocked>
-    %6 = tt.broadcast %3 : tensor<128x1xi32, #blocked> -> tensor<128x16xi32, #blocked>
-    %7 = tt.broadcast %5 : tensor<1x16xi32, #blocked> -> tensor<128x16xi32, #blocked>
-    %8 = arith.addi %6, %7 : tensor<128x16xi32, #blocked>
-    %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x16x!tt.ptr<f16>, #blocked>
-    %10 = tt.addptr %9, %8 : tensor<128x16x!tt.ptr<f16>, #blocked>, tensor<128x16xi32, #blocked>
-    %11 = ttg.async_copy_global_to_local %10, %0 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
-    %12 = ttg.async_wait {num = 0 : i32}
-    tt.return
-  }
-}
-""")
-
-
-@pytest.mark.parametrize("target", [HIP_TARGET_CDNA4])
-def test_amd_global_load_to_shared_with_broadcast(target):
-
-    @gluon.jit
-    def kernel(ptr):
-        blocked: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [32, 2], [4, 1], [1, 0])
-        shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[1, 0])
-
-        smem = ttgl.allocate_shared_memory(ptr.dtype.element_ty, [128, 16], shared)
-        y_offset = ttgl.arange(0, 128, layout=ttgl.SliceLayout(1, blocked))
-        x_offset = ttgl.arange(0, 16, layout=ttgl.SliceLayout(0, blocked))
-        offsets = y_offset[:, None] * 16 + x_offset[None, :]
-
-        mask = (y_offset < 64)[:, None]
-        other = tl.cast(0.0, ptr.dtype.element_ty)
-
-        cdna4_async_copy.global_load_to_shared(smem, ptr + offsets, mask, other)
-        cdna4_async_copy.async_wait(0)
-
-    ptr = MockTensor(ttgl.float16)
-    mod = run_parser(kernel, *make_args(ptr), target=target)
-    expecttest.assert_expected_inline(
-        anonymize_ir(mod.str_nodebug()), """\
-#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  tt.func public @amd_global_load_to_shared(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<128x16xf16, #shared, #smem, mutable>
     %1 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %2 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
@@ -1855,84 +1816,80 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = tt.broadcast %4 : tensor<128x1xi32, #blocked> -> tensor<128x16xi32, #blocked>
     %7 = tt.broadcast %5 : tensor<1x16xi32, #blocked> -> tensor<128x16xi32, #blocked>
     %8 = arith.addi %6, %7 : tensor<128x16xi32, #blocked>
+    %9 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x16x!tt.ptr<f16>, #blocked>
+    %10 = tt.addptr %9, %8 : tensor<128x16x!tt.ptr<f16>, #blocked>, tensor<128x16xi32, #blocked>
+    %11 = ttg.async_copy_global_to_local %10, %0 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %c64_i32 = arith.constant 64 : i32
     %cst_1 = arith.constant dense<64> : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    %9 = arith.cmpi slt, %1, %cst_1 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    %10 = tt.expand_dims %9 {axis = 1 : i32} : tensor<128xi1, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi1, #blocked>
-    %cst_2 = arith.constant 0.000000e+00 : f32
-    %11 = arith.truncf %cst_2 : f32 to f16
-    %12 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x16x!tt.ptr<f16>, #blocked>
-    %13 = tt.addptr %12, %8 : tensor<128x16x!tt.ptr<f16>, #blocked>, tensor<128x16xi32, #blocked>
-    %14 = tt.broadcast %10 : tensor<128x1xi1, #blocked> -> tensor<128x16xi1, #blocked>
-    %15 = tt.splat %11 : f16 -> tensor<128x16xf16, #blocked>
-    %16 = ttg.async_copy_global_to_local %13, %0 mask %14 other %15 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
-    %17 = ttg.async_wait {num = 0 : i32}
+    %12 = arith.cmpi slt, %1, %cst_1 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %13 = tt.expand_dims %12 {axis = 1 : i32} : tensor<128xi1, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi1, #blocked>
+    %cst_2 = arith.constant 0.000000e+00 : f16
+    %cst_3 = arith.constant dense<0.000000e+00> : tensor<128x16xf16, #blocked>
+    %14 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x16x!tt.ptr<f16>, #blocked>
+    %15 = tt.addptr %14, %8 : tensor<128x16x!tt.ptr<f16>, #blocked>, tensor<128x16xi32, #blocked>
+    %16 = tt.broadcast %13 : tensor<128x1xi1, #blocked> -> tensor<128x16xi1, #blocked>
+    %17 = ttg.async_copy_global_to_local %15, %0 mask %16 other %cst_3 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %cst_4 = arith.constant 0.000000e+00 : f16
+    %cst_5 = arith.constant dense<0.000000e+00> : tensor<128x1xf16, #blocked>
+    %18 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x16x!tt.ptr<f16>, #blocked>
+    %19 = tt.addptr %18, %8 : tensor<128x16x!tt.ptr<f16>, #blocked>, tensor<128x16xi32, #blocked>
+    %20 = tt.broadcast %13 : tensor<128x1xi1, #blocked> -> tensor<128x16xi1, #blocked>
+    %21 = tt.broadcast %cst_5 : tensor<128x1xf16, #blocked> -> tensor<128x16xf16, #blocked>
+    %22 = ttg.async_copy_global_to_local %19, %0 mask %20 other %21 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %23 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x16x!tt.ptr<f16>, #blocked>
+    %24 = tt.addptr %23, %8 : tensor<128x16x!tt.ptr<f16>, #blocked>, tensor<128x16xi32, #blocked>
+    %25 = tt.broadcast %13 : tensor<128x1xi1, #blocked> -> tensor<128x16xi1, #blocked>
+    %cst_6 = arith.constant 0.000000e+00 : f32
+    %26 = arith.truncf %cst_6 : f32 to f16
+    %27 = tt.splat %26 : f16 -> tensor<128x16xf16, #blocked>
+    %28 = ttg.async_copy_global_to_local %24, %0 mask %25 other %27 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     tt.return
   }
 }
 """)
+
+
+@gluon.jit
+def buffer_load_to_shared_kernel(ptr):
+    blocked: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 64], [4, 1], [1, 0])
+    shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[1, 0])
+
+    dest = ttgl.allocate_shared_memory(ptr.dtype.element_ty, [4, 64], shared)
+
+    y_index = ttgl.arange(0, 4, layout=ttgl.SliceLayout(1, blocked))
+    x_index = ttgl.arange(0, 64, layout=ttgl.SliceLayout(0, blocked))
+    offsets = y_index[:, None] * 64 + x_index[None, :]
+
+    cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets)
+
+    # test cache modifiers
+    cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets, cache_modifier=".ca")
+    cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets, cache_modifier=".cg")
+    cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets, cache_modifier=".cv")
+
+    # test mask and other
+    mask = (y_index < 2)[:, None]
+    other = ttgl.full([4, 64], 0.0, ptr.dtype.element_ty, layout=blocked)
+    cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets, mask, other=other)
+
+    other = ttgl.full([1, 64], 0.0, ptr.dtype.element_ty, layout=blocked)
+    cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets, mask, other=other)
+
+    cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets, mask, other=0.0)
 
 
 @pytest.mark.parametrize("target", [HIP_TARGET_CDNA4])
 def test_buffer_load_to_shared(target):
-
-    @gluon.jit
-    def kernel(ptr):
-        blocked: ttgl.constexpr = ttgl.BlockedLayout([1], [64], [4], [0])
-        shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0])
-
-        dest = ttgl.allocate_shared_memory(ptr.dtype.element_ty, [256], shared)
-        offsets = ttgl.arange(0, 256, layout=blocked)
-
-        cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets)
-
-    ptr = MockTensor(ttgl.float32)
-    mod = run_parser(kernel, *make_args(ptr), target=target)
-    expecttest.assert_expected_inline(
-        anonymize_ir(mod.str_nodebug()), """\
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<256xf32, #shared, #smem, mutable>
-    %1 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked>
-    %2 = amdgpu.buffer_load_to_local %arg0[%1] into %0 : <f32>[tensor<256xi32, #blocked>]  -> <256xf32, #shared, #smem, mutable>
-    tt.return
-  }
-}
-""")
-
-
-@pytest.mark.parametrize("target", [HIP_TARGET_CDNA4])
-def test_buffer_load_to_shared_with_broadcast(target):
-
-    @gluon.jit
-    def kernel(ptr):
-        blocked1: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 64], [4, 1], [1, 0])
-        shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[1, 0])
-
-        dest = ttgl.allocate_shared_memory(ptr.dtype.element_ty, [4, 64], shared)
-
-        y_index = ttgl.arange(0, 4, layout=ttgl.SliceLayout(1, blocked1))
-        x_index = ttgl.arange(0, 64, layout=ttgl.SliceLayout(0, blocked1))
-        offsets = y_index[:, None] * 64 + x_index[None, :]
-
-        mask = (y_index < 2)[:, None]
-        other = 0.0
-
-        cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets, mask, other)
-
-    ptr = MockTensor(ttgl.float32)
-    mod = run_parser(kernel, *make_args(ptr), target=target)
+    ptr = MockTensor(ttgl.float16)
+    mod = run_parser(buffer_load_to_shared_kernel, *make_args(ptr), target=target)
     expecttest.assert_expected_inline(
         anonymize_ir(mod.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<4x64xf32, #shared, #smem, mutable>
+  tt.func public @buffer_load_to_shared_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<4x64xf16, #shared, #smem, mutable>
     %1 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %2 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
     %3 = tt.expand_dims %1 {axis = 1 : i32} : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<4x1xi32, #blocked>
@@ -1944,86 +1901,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = tt.broadcast %4 : tensor<4x1xi32, #blocked> -> tensor<4x64xi32, #blocked>
     %7 = tt.broadcast %5 : tensor<1x64xi32, #blocked> -> tensor<4x64xi32, #blocked>
     %8 = arith.addi %6, %7 : tensor<4x64xi32, #blocked>
+    %9 = amdgpu.buffer_load_to_local %arg0[%8] into %0 : <f16>[tensor<4x64xi32, #blocked>]  -> <4x64xf16, #shared, #smem, mutable>
+    %10 = amdgpu.buffer_load_to_local %arg0[%8] cacheModifier = ca into %0 : <f16>[tensor<4x64xi32, #blocked>]  -> <4x64xf16, #shared, #smem, mutable>
+    %11 = amdgpu.buffer_load_to_local %arg0[%8] cacheModifier = cg into %0 : <f16>[tensor<4x64xi32, #blocked>]  -> <4x64xf16, #shared, #smem, mutable>
+    %12 = amdgpu.buffer_load_to_local %arg0[%8] cacheModifier = cv into %0 : <f16>[tensor<4x64xi32, #blocked>]  -> <4x64xf16, #shared, #smem, mutable>
     %c2_i32 = arith.constant 2 : i32
     %cst_1 = arith.constant dense<2> : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    %9 = arith.cmpi slt, %1, %cst_1 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    %10 = tt.expand_dims %9 {axis = 1 : i32} : tensor<4xi1, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<4x1xi1, #blocked>
-    %cst_2 = arith.constant 0.000000e+00 : f32
-    %11 = tt.broadcast %10 : tensor<4x1xi1, #blocked> -> tensor<4x64xi1, #blocked>
-    %cst_3 = arith.constant dense<0.000000e+00> : tensor<4x64xf32, #blocked>
-    %12 = amdgpu.buffer_load_to_local %arg0[%8] mask = %11 other = %cst_3 into %0 : <f32>[tensor<4x64xi32, #blocked>] tensor<4x64xf32, #blocked> -> <4x64xf32, #shared, #smem, mutable>
-    tt.return
-  }
-}
-""")
-
-
-@pytest.mark.parametrize("target", [HIP_TARGET_CDNA4])
-def test_buffer_load_to_shared_mask_other(target):
-
-    @gluon.jit
-    def kernel(ptr):
-        blocked: ttgl.constexpr = ttgl.BlockedLayout([1], [64], [4], [0])
-        shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0])
-
-        dest = ttgl.allocate_shared_memory(ptr.dtype.element_ty, [256], shared)
-        offsets = ttgl.arange(0, 256, layout=blocked)
-
-        mask = ttgl.full([256], 1, ttgl.int1, layout=blocked)
-        other = ttgl.full([256], 0, ptr.dtype.element_ty, layout=blocked)
-        cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets, mask, other)
-
-    ptr = MockTensor(ttgl.float32)
-    mod = run_parser(kernel, *make_args(ptr), target=target)
-    expecttest.assert_expected_inline(
-        anonymize_ir(mod.str_nodebug()), """\
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<256xf32, #shared, #smem, mutable>
-    %1 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked>
-    %true = arith.constant true
-    %cst = arith.constant dense<true> : tensor<256xi1, #blocked>
-    %cst_0 = arith.constant 0.000000e+00 : f32
-    %cst_1 = arith.constant dense<0.000000e+00> : tensor<256xf32, #blocked>
-    %2 = amdgpu.buffer_load_to_local %arg0[%1] mask = %cst other = %cst_1 into %0 : <f32>[tensor<256xi32, #blocked>] tensor<256xf32, #blocked> -> <256xf32, #shared, #smem, mutable>
-    tt.return
-  }
-}
-""")
-
-
-@pytest.mark.parametrize("target", [HIP_TARGET_CDNA4])
-def test_buffer_load_to_shared_cache_mods(target):
-
-    @gluon.jit
-    def kernel(ptr):
-        blocked: ttgl.constexpr = ttgl.BlockedLayout([1], [64], [4], [0])
-        shared: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0])
-
-        dest = ttgl.allocate_shared_memory(ptr.dtype.element_ty, [256], shared)
-        offsets = ttgl.arange(0, 256, layout=blocked)
-
-        cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets, cache_modifier=".ca")
-        cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets, cache_modifier=".cg")
-        cdna4_async_copy.buffer_load_to_shared(dest, ptr, offsets, cache_modifier=".cv")
-
-    ptr = MockTensor(ttgl.float32)
-    mod = run_parser(kernel, *make_args(ptr), target=target)
-    expecttest.assert_expected_inline(
-        anonymize_ir(mod.str_nodebug()), """\
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<256xf32, #shared, #smem, mutable>
-    %1 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked>
-    %2 = amdgpu.buffer_load_to_local %arg0[%1] cacheModifier = ca into %0 : <f32>[tensor<256xi32, #blocked>]  -> <256xf32, #shared, #smem, mutable>
-    %3 = amdgpu.buffer_load_to_local %arg0[%1] cacheModifier = cg into %0 : <f32>[tensor<256xi32, #blocked>]  -> <256xf32, #shared, #smem, mutable>
-    %4 = amdgpu.buffer_load_to_local %arg0[%1] cacheModifier = cv into %0 : <f32>[tensor<256xi32, #blocked>]  -> <256xf32, #shared, #smem, mutable>
+    %13 = arith.cmpi slt, %1, %cst_1 : tensor<4xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %14 = tt.expand_dims %13 {axis = 1 : i32} : tensor<4xi1, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<4x1xi1, #blocked>
+    %cst_2 = arith.constant 0.000000e+00 : f16
+    %cst_3 = arith.constant dense<0.000000e+00> : tensor<4x64xf16, #blocked>
+    %15 = tt.broadcast %14 : tensor<4x1xi1, #blocked> -> tensor<4x64xi1, #blocked>
+    %16 = amdgpu.buffer_load_to_local %arg0[%8] mask = %15 other = %cst_3 into %0 : <f16>[tensor<4x64xi32, #blocked>] tensor<4x64xf16, #blocked> -> <4x64xf16, #shared, #smem, mutable>
+    %cst_4 = arith.constant 0.000000e+00 : f16
+    %cst_5 = arith.constant dense<0.000000e+00> : tensor<1x64xf16, #blocked>
+    %17 = tt.broadcast %14 : tensor<4x1xi1, #blocked> -> tensor<4x64xi1, #blocked>
+    %18 = tt.broadcast %cst_5 : tensor<1x64xf16, #blocked> -> tensor<4x64xf16, #blocked>
+    %19 = amdgpu.buffer_load_to_local %arg0[%8] mask = %17 other = %18 into %0 : <f16>[tensor<4x64xi32, #blocked>] tensor<4x64xf16, #blocked> -> <4x64xf16, #shared, #smem, mutable>
+    %20 = tt.broadcast %14 : tensor<4x1xi1, #blocked> -> tensor<4x64xi1, #blocked>
+    %cst_6 = arith.constant 0.000000e+00 : f32
+    %21 = arith.truncf %cst_6 : f32 to f16
+    %22 = tt.splat %21 : f16 -> tensor<4x64xf16, #blocked>
+    %23 = amdgpu.buffer_load_to_local %arg0[%8] mask = %20 other = %22 into %0 : <f16>[tensor<4x64xi32, #blocked>] tensor<4x64xf16, #blocked> -> <4x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -2091,22 +1990,21 @@ def buffer_load_store_with_broadcast_kernel(x, y):
     a = ttgl.amd.cdna3.buffer_load(ptr=x, offsets=offsets, mask=mask, other=other, cache='.ca')
     ttgl.amd.cdna3.buffer_store(stored_value=a, ptr=y, offsets=offsets, mask=mask, cache='.cs')
 
-    other = 1.0
-    a = ttgl.amd.cdna3.buffer_load(ptr=x, offsets=offsets, mask=mask, other=other, cache='.ca')
+    a = ttgl.amd.cdna3.buffer_load(ptr=x, offsets=offsets, mask=mask, other=1.0, cache='.ca')
     ttgl.amd.cdna3.buffer_store(stored_value=a, ptr=y, offsets=offsets, mask=mask, cache='.cs')
 
 
 @pytest.mark.parametrize("target", [HIP_TARGET_CDNA3, HIP_TARGET_CDNA4])
 def test_buffer_load_store_with_broadcast(target):
-    x = MockTensor(ttgl.float32)
-    y = MockTensor(ttgl.float32)
+    x = MockTensor(ttgl.float16)
+    y = MockTensor(ttgl.float16)
     module = run_parser(buffer_load_store_with_broadcast_kernel, *make_args(x, y), target=target)
 
     expecttest.assert_expected_inline(
         anonymize_ir(module.str_nodebug()), """\
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @buffer_load_store_with_broadcast_kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+  tt.func public @buffer_load_store_with_broadcast_kernel(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
     %0 = tt.make_range {end = 4096 : i32, start = 0 : i32} : tensor<4096xi32, #gluon.auto_encoding>
     %1 = tt.reshape %0 : tensor<4096xi32, #gluon.auto_encoding> -> tensor<64x64xi32, #gluon.auto_encoding>
     %2 = ttg.convert_layout %1 : tensor<64x64xi32, #gluon.auto_encoding> -> tensor<64x64xi32, #blocked>
@@ -2115,21 +2013,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %true = arith.constant true
     %cst_1 = arith.constant dense<true> : tensor<64x1xi1, #blocked>
     %3 = tt.broadcast %cst_1 : tensor<64x1xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    %4 = amdgpu.buffer_load %arg0[%2], %3, %cst_0 cacheModifier = ca : tensor<64x64xf32, #blocked>
-    %5 = tt.broadcast %cst_1 : tensor<64x1xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdgpu.buffer_store %4, %arg1[%2], %5 cacheModifier = cs : tensor<64x64xf32, #blocked>
+    %4 = arith.truncf %cst_0 : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
+    %5 = amdgpu.buffer_load %arg0[%2], %3, %4 cacheModifier = ca : tensor<64x64xf16, #blocked>
+    %6 = tt.broadcast %cst_1 : tensor<64x1xi1, #blocked> -> tensor<64x64xi1, #blocked>
+    amdgpu.buffer_store %5, %arg1[%2], %6 cacheModifier = cs : tensor<64x64xf16, #blocked>
     %true_2 = arith.constant true
     %cst_3 = arith.constant dense<true> : tensor<1x64xi1, #blocked>
-    %6 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    %7 = amdgpu.buffer_load %arg0[%2], %6, %cst_0 cacheModifier = ca : tensor<64x64xf32, #blocked>
-    %8 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdgpu.buffer_store %7, %arg1[%2], %8 cacheModifier = cs : tensor<64x64xf32, #blocked>
-    %cst_4 = arith.constant 1.000000e+00 : f32
-    %9 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    %cst_5 = arith.constant dense<1.000000e+00> : tensor<64x64xf32, #blocked>
-    %10 = amdgpu.buffer_load %arg0[%2], %9, %cst_5 cacheModifier = ca : tensor<64x64xf32, #blocked>
+    %7 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
+    %8 = arith.truncf %cst_0 : tensor<64x64xf32, #blocked> to tensor<64x64xf16, #blocked>
+    %9 = amdgpu.buffer_load %arg0[%2], %7, %8 cacheModifier = ca : tensor<64x64xf16, #blocked>
+    %10 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
+    amdgpu.buffer_store %9, %arg1[%2], %10 cacheModifier = cs : tensor<64x64xf16, #blocked>
     %11 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
-    amdgpu.buffer_store %10, %arg1[%2], %11 cacheModifier = cs : tensor<64x64xf32, #blocked>
+    %cst_4 = arith.constant 1.000000e+00 : f32
+    %12 = arith.truncf %cst_4 : f32 to f16
+    %13 = tt.splat %12 : f16 -> tensor<64x64xf16, #blocked>
+    %14 = amdgpu.buffer_load %arg0[%2], %11, %13 cacheModifier = ca : tensor<64x64xf16, #blocked>
+    %15 = tt.broadcast %cst_3 : tensor<1x64xi1, #blocked> -> tensor<64x64xi1, #blocked>
+    amdgpu.buffer_store %14, %arg1[%2], %15 cacheModifier = cs : tensor<64x64xf16, #blocked>
     tt.return
   }
 }

--- a/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
@@ -33,7 +33,7 @@ def buffer_load(ptr, offsets, mask=None, other=None, cache=None, _semantic=None)
         ptr (pointer to scalar): Global memory scalar base pointer to load from.
         offsets (tensor): Offsets tensor for the load operation.
         mask (tensor, optional): Mask tensor for predicated loads. Defaults to None.
-        other (tensor, optional): Tensor providing default values for masked elements. Defaults to None.
+        other (tensor or scalar, optional): Tensor or scalar providing default values for masked elements. Defaults to None.
         cache_modifier (str): Cache modifier specifier. Defaults to "".
     """
     _verify_buffer_ops(ptr, offsets, mask, other)

--- a/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
@@ -18,11 +18,8 @@ def _verify_buffer_ops(ptr, offsets, mask=None, other=None):
     assert isinstance(offsets.type, ttgl.distributed_type), "expected offsets type to be a distributed_type"
     assert offsets.dtype.is_int32() or offsets.dtype.is_uint32(), "offsets element type must be int32 or uint32"
 
-    element_type = ptr.type.scalar.element_ty
-
     if other is not None:
         assert mask is not None, "when other is not None, mask should not be None"
-        assert other.dtype == element_type, "other must have the same data type as ptr scalar type"
 
 
 @builtin
@@ -47,6 +44,8 @@ def buffer_load(ptr, offsets, mask=None, other=None, cache=None, _semantic=None)
 
     other = _unwrap_if_constexpr(other)
     if other is not None:
+        other = _semantic.to_tensor(other)
+        other = _semantic.cast(other, ptr.dtype.element_ty)
         offsets, other = _semantic.broadcast_impl_value(offsets, other)
 
     other = other.handle if other is not None else ir.value()

--- a/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
@@ -53,6 +53,8 @@ def global_load_to_shared(dest, ptr, mask=None, other=None, cache_modifier="", _
         ptr, mask = _semantic.broadcast_impl_value(ptr, mask)
     other = _unwrap_if_constexpr(other)
     if other is not None:
+        other = _semantic.to_tensor(other)
+        other = _semantic.cast(other, ptr.dtype.element_ty)
         ptr, other = _semantic.broadcast_impl_value(ptr, other)
 
     cache_modifier = _semantic._str_to_load_cache_modifier(cache_modifier)
@@ -102,6 +104,8 @@ def buffer_load_to_shared(dest, ptr, offsets, mask=None, other=None, cache_modif
         offsets, mask = _semantic.broadcast_impl_value(offsets, mask)
     other = _unwrap_if_constexpr(other)
     if other is not None:
+        other = _semantic.to_tensor(other)
+        other = _semantic.cast(other, ptr.type.scalar.element_ty)
         offsets, other = _semantic.broadcast_impl_value(offsets, other)
 
     mask = mask.handle if mask is not None else ir.value()

--- a/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/async_copy.py
@@ -38,7 +38,7 @@ def global_load_to_shared(dest, ptr, mask=None, other=None, cache_modifier="", _
         dest (shared_memory_descriptor): Destination shared memory descriptor.
         ptr (pointer tensor): Tensor of pointers to global memory to load from.
         mask (tensor, optional): Mask tensor for predicated loads. Defaults to None.
-        other (tensor, optional): Tensor providing default values for masked elements. Defaults to None.
+        other (tensor or scalar, optional): Tensor or scalar providing default values for masked elements. Defaults to None.
         cache_modifier (str): Cache modifier specifier. Defaults to "".
     """
     _check(ptr.type.is_block(), lambda: "expected ptr to be a tensor")
@@ -92,7 +92,7 @@ def buffer_load_to_shared(dest, ptr, offsets, mask=None, other=None, cache_modif
         ptr (pointer to scalar): Global memory scalar base pointer to load from.
         offsets (tensor): Offsets tensor for the load operation.
         mask (tensor, optional): Mask tensor for predicated loads. Defaults to None.
-        other (tensor, optional): Tensor providing default values for masked elements. Defaults to None.
+        other (tensor or scalar, optional): Tensor or scalar providing default values for masked elements. Defaults to None.
         cache_modifier (str): Cache modifier specifier. Defaults to "".
     """
     _check(isinstance(offsets.type.layout, (BlockedLayout, SliceLayout)),


### PR DESCRIPTION
Support scalar other value for following ops:

- `amd.cdna3.buffer_load`
- `amd.cdna4.async_copy.buffer_load_to_shared` 
- `amd.cdna4.async_copy.global_load_to_shared`

We will explicitly convert scalar other to a tensor and cast to match the pointer type.