### PR TITLE
Fix LLVM build for Windows

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -29,13 +29,6 @@ jobs:
       fail-fast: true
       matrix:
         config:
-        - {runner: 'Ubuntu 22.04', runs_on: 'ubuntu-22.04', target-os: 'ubuntu', arch: 'x64'}
-        - {runner: 'Ubuntu 22.04 ARM64', runs_on: 'ubuntu-22.04', target-os: 'ubuntu', arch: 'arm64'}
-        - {runner: 'CentOS 7', runs_on: ['self-hosted', 'CPU'], target-os: 'centos', arch: 'x64'}
-        - {runner: 'AlmaLinux 8', runs_on: ['self-hosted', 'CPU'], target-os: 'almalinux', arch: 'x64'}
-        - {runner: 'AlmaLinux 8 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'almalinux', arch: 'arm64'}
-        - {runner: 'MacOS X64', runs_on: 'macos-13', target-os: 'macos', arch: 'x64'}
-        - {runner: 'MacOS ARM64', runs_on: 'macos-13', target-os: 'macos', arch: 'arm64'}
         - {runner: 'Windows Latest', runs_on: 'windows-latest', target-os: 'windows', arch: 'x64'}
 
     steps:
@@ -66,6 +59,12 @@ jobs:
         repository: llvm/llvm-project
         path: llvm-project
         ref: ${{ env.llvm_commit_hash }}
+
+    - name: Apply patch
+      shell: bash
+      run: |
+        # like in https://github.com/llvm/llvm-project/pull/156711
+        sed -i 's/\[SEP:\[\/\\\\\]\]/[SEP:[\/\\\\]+]/g' mlir/test/python/ir/auto_location.py
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
CI for Windows broken: https://github.com/triton-lang/triton/actions/runs/17419518063/job/49454994952

Maybe we can rerun `llvm-build.yml` only for Windows with my patch?

@peterbell10 @ThomasRaoux 


This is for 6ca2dda9bdd331d007d6fab342db5a85f9b23c7d. If it works I can do this for another pin updates.