### PR TITLE
[AMD] Add ISAFamily for RDNA4

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -323,8 +323,8 @@ def is_layout_applicable(layout) -> bool:
         target_arch = triton.runtime.driver.active.get_current_target().arch
         if isinstance(layout, PaddedSharedLayout):
             return True
-        elif "gfx11" in target_arch:
-            # RDNA 3
+        elif any(arch for arch in ["gfx11", "gfx12"] if arch in target_arch):
+            # RDNA 3, 4
             return isinstance(layout, WmmaLayout)
         elif any(arch for arch in ["gfx8", "gfx9"] if arch in target_arch):
             # CDNA 1, 2, 3, 4

--- a/third_party/amd/include/TritonAMDGPUToLLVM/TargetUtils.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/TargetUtils.h
@@ -15,6 +15,7 @@ enum class ISAFamily {
   RDNA1,
   RDNA2,
   RDNA3,
+  RDNA4,
 };
 
 // Deduces the corresponding ISA family for the given target gfx |arch|.

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -54,8 +54,8 @@ Value BufferEmitter::createResourceDescriptor(Value basePtr,
   //              3 = either swizzles or testing against offset field)
   // bits 30-31: Type (must be 0)
   uint32_t flags = (7 << 12) | (4 << 15);
-  if (targetInfo.getISAFamily() == ISAFamily::RDNA2 ||
-      targetInfo.getISAFamily() == ISAFamily::RDNA3) {
+  if (llvm::is_contained({ISAFamily::RDNA2, ISAFamily::RDNA3, ISAFamily::RDNA4},
+                         targetInfo.getISAFamily())) {
     flags |= (1 << 24);
     uint32_t oob = 3;
     flags |= (oob << 28);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -298,7 +298,8 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
     return false;
   if (isCDNA(getISAFamily()) && getISAFamily() == ISAFamily::CDNA1)
     return false;
-  if (isRDNA(getISAFamily()) && getISAFamily() != ISAFamily::RDNA3)
+  if (isRDNA(getISAFamily()) &&
+      llvm::is_contained({ISAFamily::RDNA1, ISAFamily::RDNA2}, getISAFamily()))
     return false;
 
   Operation *reduxOp = op.getSingleCombiner();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetUtils.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetUtils.cpp
@@ -23,8 +23,10 @@ ISAFamily deduceISAFamily(llvm::StringRef arch) {
     break;
   }
 
-  // RNDA ISA cases
-  if (kind >= llvm::AMDGPU::GK_GFX1100 && kind <= llvm::AMDGPU::GK_GFX1201)
+  // RDNA ISA cases
+  if (kind >= llvm::AMDGPU::GK_GFX1200 && kind <= llvm::AMDGPU::GK_GFX1201)
+    return ISAFamily::RDNA4;
+  if (kind >= llvm::AMDGPU::GK_GFX1100 && kind <= llvm::AMDGPU::GK_GFX1153)
     return ISAFamily::RDNA3;
   if (kind >= llvm::AMDGPU::GK_GFX1030 && kind <= llvm::AMDGPU::GK_GFX1036)
     return ISAFamily::RDNA2;
@@ -42,6 +44,7 @@ bool supportsVDot(llvm::StringRef arch) {
   case AMD::ISAFamily::CDNA4:
   case AMD::ISAFamily::RDNA2:
   case AMD::ISAFamily::RDNA3:
+  case AMD::ISAFamily::RDNA4:
     return true;
   default:
     break;
@@ -68,6 +71,7 @@ bool isRDNA(ISAFamily isaFamily) {
   case ISAFamily::RDNA1:
   case ISAFamily::RDNA2:
   case ISAFamily::RDNA3:
+  case ISAFamily::RDNA4:
     return true;
   default:
     break;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -151,10 +151,11 @@ static Value shuffleCommonImpl(Location loc, RewriterBase &rewriter,
       }
     } else {
       if (!llvm::is_contained({ISAFamily::CDNA2, ISAFamily::CDNA3,
-                               ISAFamily::CDNA4, ISAFamily::RDNA3},
+                               ISAFamily::CDNA4, ISAFamily::RDNA3,
+                               ISAFamily::RDNA4},
                               isaFamily)) {
-        // DPP is only supported for CDNA2/CDNA3/CDNA4/RDNA3 right now, so we
-        // fallback to ds_swizzle for other architectures.
+        // DPP is only supported for CDNA2/CDNA3/CDNA4/RDNA3/RDNA4 right now, so
+        // we fallback to ds_swizzle for other architectures.
         //
         // This map facilates the butterfly shuffle pattern for a stride less
         // than 16. The pattern stride is the key of the map.

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1454,6 +1454,7 @@ struct TritonAMDGPUAccelerateMatmulPass
           /*benefit=*/2);
       break;
     case ISAFamily::RDNA3:
+    case ISAFamily::RDNA4:
       ttg::populateDecomposeScaledBlockedPatterns(mfmaPatterns,
                                                   /*benefit=*/3);
       mfmaPatterns.add<::BlockedToWMMA>(


### PR DESCRIPTION
RDNA4 is currently treated as RDNA3. This patch splits the current family into an RDNA3 and an RDNA4 family. Behavior should be unchanged.