### PR TITLE
Restore maxNumImpreciseAcc guard for AddFOp

### DIFF
--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -257,14 +257,13 @@ public:
         return failure();
       }
     }
+    rewriter.modifyOpInPlace(dotOp, [&] {
+      dotOp.getCMutable().assign(isDotLHS ? addOp.getRhs() : addOp.getLhs());
+      dotOp->moveBefore(addOp);
+    });
+    rewriter.replaceAllUsesWith(addOp, dotOp.getResult());
+    return success();
   }
-  rewriter.modifyOpInPlace(dotOp, [&] {
-    dotOp.getCMutable().assign(isDotLHS ? addOp.getRhs() : addOp.getLhs());
-    dotOp->moveBefore(addOp);
-  });
-  rewriter.replaceAllUsesWith(addOp, dotOp.getResult());
-  return success();
-}
 };
 
 // AddIOp(DotOp(a, b, c), d) and c==0 => DotOp(a, b, d)

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -252,6 +252,11 @@ public:
     }
     if (!isZero(dotOp.getC()))
       return failure();
+    if constexpr (std::is_same_v<OpTy, arith::AddFOp>) {
+      if (dotOp.getMaxNumImpreciseAcc() != 0) {}
+        return failure();
+      }
+    }
     rewriter.modifyOpInPlace(dotOp, [&] {
       dotOp.getCMutable().assign(isDotLHS ? addOp.getRhs() : addOp.getLhs());
       dotOp->moveBefore(addOp);

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -253,17 +253,18 @@ public:
     if (!isZero(dotOp.getC()))
       return failure();
     if constexpr (std::is_same_v<OpTy, arith::AddFOp>) {
-      if (dotOp.getMaxNumImpreciseAcc() != 0) {}
+      if (dotOp.getMaxNumImpreciseAcc() != 0) {
         return failure();
       }
     }
-    rewriter.modifyOpInPlace(dotOp, [&] {
-      dotOp.getCMutable().assign(isDotLHS ? addOp.getRhs() : addOp.getLhs());
-      dotOp->moveBefore(addOp);
-    });
-    rewriter.replaceAllUsesWith(addOp, dotOp.getResult());
-    return success();
   }
+  rewriter.modifyOpInPlace(dotOp, [&] {
+    dotOp.getCMutable().assign(isDotLHS ? addOp.getRhs() : addOp.getLhs());
+    dotOp->moveBefore(addOp);
+  });
+  rewriter.replaceAllUsesWith(addOp, dotOp.getResult());
+  return success();
+}
 };
 
 // AddIOp(DotOp(a, b, c), d) and c==0 => DotOp(a, b, d)


### PR DESCRIPTION
This restores the legacy guard from Combine.td: we only fold `addf(dot, bias)` 
into `dot(..., C=bias)` when `maxNumImpreciseAcc == 0`. Without this, 
`use_fast_accum=False` kernels were silently rewritten into the fast-accum 
form, causing accuracy drift in FP8 tests. This change ensures precise 
accumulation semantics are preserved while keeping the optimization enabled 
when imprecise accumulation is allowed.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because existing tests should cover it.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
