### PR TITLE
[DRAFT][WS] extend partition representation to support e2e aref with tmem

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -1,6 +1,8 @@
 #ifndef TRITON_TRITONGPU_TRANSFORM_PIPELINE_PARTITION_H_
 #define TRITON_TRITONGPU_TRANSFORM_PIPELINE_PARTITION_H_
 
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -127,6 +129,9 @@ public:
   LLVM_DUMP_METHOD void dump() const;
 
 private:
+  void serializeBlock(mlir::Block *block, mlir::Builder &builder,
+                      const Partition *parentPartition = nullptr) const;
+
   // WarpSpecialization tag
   int tag;
   // Partitions are numbered [0, N).

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -118,6 +118,38 @@ bool WarpSchedule::trySchedule(Partition *partition, Operation *op) {
   return true;
 }
 
+void assignPartitionToBlock(mlir::Block *block, Partition *part,
+                            ArrayRef<std::unique_ptr<Partition>> partitions,
+                            DenseMap<Operation *, Partition *> &opToPartition);
+
+void assignPartitionToIfOp(scf::IfOp ifOp, Partition *part,
+                           ArrayRef<std::unique_ptr<Partition>> partitions,
+                           DenseMap<Operation *, Partition *> &opToPartition) {
+  assignPartitionToBlock(ifOp.thenBlock(), part, partitions, opToPartition);
+  if (ifOp.elseBlock()) {
+    assignPartitionToBlock(ifOp.elseBlock(), part, partitions, opToPartition);
+  }
+}
+
+void assignPartitionToBlock(mlir::Block *block, Partition *parentPartition,
+                            ArrayRef<std::unique_ptr<Partition>> partitions,
+                            DenseMap<Operation *, Partition *> &opToPartition) {
+  for (auto &op : block->getOperations()) {
+    Partition *part;
+    if (auto attr = op.getAttrOfType<IntegerAttr>(kPartitionAttrName)) {
+      int64_t idx = attr.getInt();
+      part = partitions[idx].get();
+    } else {
+      part = parentPartition;
+    }
+
+    opToPartition[&op] = part;
+    if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+      assignPartitionToIfOp(ifOp, parentPartition, partitions, opToPartition);
+    }
+  }
+}
+
 FailureOr<WarpSchedule> WarpSchedule::deserialize(scf::ForOp loop) {
   auto stages = loop->getAttrOfType<ArrayAttr>(kPartitionStagesAttrName);
   if (!stages)
@@ -149,22 +181,51 @@ FailureOr<WarpSchedule> WarpSchedule::deserialize(scf::ForOp loop) {
       partition = result.partitions[idx].get();
     }
     result.insert(partition, &op);
+
+    if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+      assignPartitionToIfOp(ifOp, partition, result.partitions,
+                            result.opToPartition);
+    }
   }
 
   return result;
 }
 
-void WarpSchedule::serialize(scf::ForOp loop) const {
-  SmallVector<Attribute> stages;
-  Builder b(loop.getContext());
-  for (Operation &op : loop.getBody()->without_terminator()) {
+void WarpSchedule::serializeBlock(Block *block, Builder &b,
+                                  const Partition *parentPartition) const {
+  for (Operation &op : block->without_terminator()) {
     if (Partition *partition = opToPartition.lookup(&op)) {
       if (partition == getRootPartition())
         continue;
       op.setAttr(kPartitionAttrName,
                  b.getI32IntegerAttr(partition->getIndex()));
+
+      if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+        serializeBlock(forOp.getBody(), b, partition);
+      } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        serializeBlock(ifOp.thenBlock(), b, partition);
+        if (ifOp.elseBlock()) {
+          serializeBlock(ifOp.elseBlock(), b, partition);
+        }
+      }
+    } else if (parentPartition) {
+      op.setAttr(kPartitionAttrName,
+                 b.getI32IntegerAttr(parentPartition->getIndex()));
+      if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        serializeBlock(ifOp.thenBlock(), b, parentPartition);
+        if (ifOp.elseBlock()) {
+          serializeBlock(ifOp.elseBlock(), b, parentPartition);
+        }
+      }
     }
   }
+}
+
+void WarpSchedule::serialize(scf::ForOp loop) const {
+  SmallVector<Attribute> stages;
+  Builder b(loop.getContext());
+  serializeBlock(loop.getBody(), b);
+
   for (Partition &partition : getPartitions())
     stages.push_back(b.getI32IntegerAttr(partition.getStage()));
   loop->setAttr(kPartitionStagesAttrName, b.getArrayAttr(stages));
@@ -234,6 +295,12 @@ void WarpSchedule::iterateOutputs(
   for (Operation *op : partition->getOps()) {
     for (OpOperand &use : op->getUses()) {
       Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
+
+      // if owner is ifOp, use actualy user of
+      if (isa<scf::IfOp>(owner)) {
+        owner = use.getOwner();
+      }
+
       if (isa<scf::YieldOp>(owner)) {
         // This value is used in a subsequent iteration.
         callback(owner, use);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -51,6 +51,44 @@ enum class LoopVarCategory {
   TensorResultFromOtherPartition,
 };
 
+SmallVector<size_t>
+getPartitionIndicesToCloneInto(const Partition *partition,
+                               const WarpSchedule &schedule) {
+  SmallVector<size_t> partitionIndices;
+
+  if (!partition || partition == schedule.getRootPartition()) {
+    for (size_t i = 0; i < schedule.getNumPartitions(); ++i) {
+      partitionIndices.push_back(i);
+    }
+  } else {
+    partitionIndices.push_back(partition->getIndex());
+  }
+
+  return partitionIndices;
+}
+
+// for IfOp, the partition is a list, each positional result to its partition
+SmallVector<size_t>
+getPartitionIndicesToCloneInto(scf::IfOp ifOp, const WarpSchedule &schedule) {
+  SetVector<size_t> bodyPartitions;
+  auto arrayAttr = ifOp->getAttrOfType<ArrayAttr>(kPartitionAttrName);
+  assert(arrayAttr.size() == ifOp.getResultTypes().size());
+  for (auto attr : arrayAttr) {
+    auto defIdx = cast<IntegerAttr>(attr).getInt();
+    if (defIdx == -1) {
+      SmallVector<size_t> partitionIndices;
+      for (size_t i = 0; i < schedule.getNumPartitions(); ++i) {
+        partitionIndices.push_back(i);
+      }
+      return partitionIndices;
+    } else {
+      bodyPartitions.insert(defIdx);
+    }
+  }
+  assert(!bodyPartitions.empty());
+  return SmallVector<size_t>{bodyPartitions.begin(), bodyPartitions.end()};
+}
+
 bool isTensorResultComputedBy(scf::ForOp loop, size_t resultIdx,
                               const Partition *partition,
                               const WarpSchedule &schedule) {
@@ -64,10 +102,26 @@ bool isTensorResultComputedBy(scf::ForOp loop, size_t resultIdx,
   return ret;
 }
 
+int getOpPartitionIdx(Operation *op) {
+  if (auto partition = op->getAttrOfType<IntegerAttr>(kPartitionAttrName)) {
+    return partition.getInt();
+  }
+  return -1;
+};
+
 SmallVector<LoopVarCategory> classifyLoopVars(scf::ForOp loop,
                                               const Partition *partition,
                                               const WarpSchedule &schedule) {
-  auto inPartition = [&](Operation *op) {
+  auto inPartition = [&](OpOperand &opnd) {
+    auto op = opnd.getOwner();
+    if (auto ifOp = dyn_cast<scf::IfOp>(op->getParentOp())) {
+      auto arrayAttr = ifOp->getAttrOfType<ArrayAttr>(kPartitionAttrName);
+      assert(arrayAttr.size() == ifOp.getResultTypes().size());
+      auto defIdx =
+          cast<IntegerAttr>(arrayAttr[opnd.getOperandNumber()]).getInt();
+      return defIdx == -1 || defIdx == partition->getIndex();
+    }
+
     const Partition *opPartition =
         schedule.getPartition(loop.getBody()->findAncestorOpInBlock(*op));
     return llvm::is_contained({partition, schedule.getRootPartition()},
@@ -87,7 +141,7 @@ SmallVector<LoopVarCategory> classifyLoopVars(scf::ForOp loop,
 
   SmallVector<LoopVarCategory> categories(loop.getNumRegionIterArgs());
   for (auto [i, arg] : llvm::enumerate(loop.getRegionIterArgs())) {
-    if (llvm::any_of(arg.getUsers(), inPartition)) {
+    if (llvm::any_of(arg.getUses(), inPartition)) {
       categories[i] = LoopVarCategory::Used;
     } else if (isTensorResultFromOtherPartition(i)) {
       categories[i] = LoopVarCategory::TensorResultFromOtherPartition;
@@ -149,21 +203,6 @@ void mapRange(ValueRange fromRange, ValueRange toRange, IRMapping &mapping) {
   }
 }
 
-SmallVector<size_t>
-getPartitionIndicesToCloneInto(const Partition *partition,
-                               const WarpSchedule &schedule) {
-  SmallVector<size_t> partitionIndices;
-
-  if (!partition || partition == schedule.getRootPartition()) {
-    for (size_t i = 0; i < schedule.getNumPartitions(); ++i) {
-      partitionIndices.push_back(i);
-    }
-  } else {
-    partitionIndices.push_back(partition->getIndex());
-  }
-
-  return partitionIndices;
-}
 int getPartitionIndex(Operation *op) {
   if (isa<nvws::WarpGroupOp>(op->getParentOp()))
     return op->getParentRegion()->getRegionNumber();
@@ -213,25 +252,30 @@ void cloneForOp(scf::ForOp forOp, SmallVector<WarpGroupBuilder> &builders,
 
 void cloneIfOp(scf::IfOp ifOp, SmallVector<WarpGroupBuilder> &builders,
                const WarpSchedule &schedule) {
-  auto partition = getPartition(ifOp, schedule);
-  auto partitionIndices = getPartitionIndicesToCloneInto(partition, schedule);
+  auto partitionIndices = getPartitionIndicesToCloneInto(ifOp, schedule);
 
   SmallVector<scf::IfOp> newIfOps;
   for (size_t idx : partitionIndices) {
     auto &b = builders[idx];
     auto cond = b.mapping.lookupOrDefault(ifOp.getCondition());
-    auto newIfOp = b.create<scf::IfOp>(ifOp.getLoc(), ifOp.getResultTypes(),
-                                       cond, ifOp.elseBlock() ? true : false);
+    SmallVector<Type> newIfResultTypes;
+    auto attrArray = ifOp->getAttrOfType<ArrayAttr>(kPartitionAttrName);
+    assert(attrArray.size() == ifOp.getResultTypes().size());
+    SmallVector<int> newIfResultIndices;
+    for (auto pos = 0; pos < ifOp.getResultTypes().size(); ++pos) {
+      auto defIdx = cast<IntegerAttr>(attrArray[pos]).getInt();
+      if (defIdx == -1 || defIdx == idx) {
+        newIfResultTypes.push_back(ifOp.getResult(pos).getType());
+        newIfResultIndices.push_back(pos);
+      }
+    }
+    auto newIfOp = b.create<scf::IfOp>(ifOp.getLoc(), newIfResultTypes, cond,
+                                       ifOp.elseBlock() ? true : false);
     newIfOp->setAttrs(ifOp->getAttrs());
     newIfOps.push_back(newIfOp);
 
-    mapRange(ifOp.getResults(), newIfOp.getResults(), b.mapping);
-    mapRange(ifOp.thenBlock()->getArguments(),
-             newIfOp.thenBlock()->getArguments(), b.mapping);
-
-    if (ifOp.elseBlock()) {
-      mapRange(ifOp.elseBlock()->getArguments(),
-               newIfOp.elseBlock()->getArguments(), b.mapping);
+    for (auto [newIdx, oldIdx] : llvm::enumerate(newIfResultIndices)) {
+      b.mapping.map(ifOp.getResult(oldIdx), newIfOp.getResult(newIdx));
     }
 
     b.setInsertionPointToStart(newIfOp.thenBlock());
@@ -240,8 +284,8 @@ void cloneIfOp(scf::IfOp ifOp, SmallVector<WarpGroupBuilder> &builders,
   cloneOpsInBlock(ifOp.thenBlock(), builders, schedule);
 
   if (auto elseBlock = ifOp.elseBlock()) {
-    for (auto [builder, newIfOp] : llvm::zip(builders, newIfOps)) {
-      builder.setInsertionPointToStart(newIfOp.elseBlock());
+    for (auto [idx, newIfOp] : llvm::zip(partitionIndices, newIfOps)) {
+      builders[idx].setInsertionPointToStart(newIfOp.elseBlock());
     }
     cloneOpsInBlock(elseBlock, builders, schedule);
   }
@@ -309,7 +353,6 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
   for (auto &op_ : *block) {
     auto op = &op_;
     auto partition = getPartition(op, schedule);
-    auto partitionIndices = getPartitionIndicesToCloneInto(partition, schedule);
 
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       cloneForOp(forOp, builders, schedule);
@@ -322,6 +365,13 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
         continue;
       }
 
+      SmallVector<size_t> partitionIndices;
+      if (auto ifOp = dyn_cast<scf::IfOp>(yieldOp->getParentOp())) {
+        partitionIndices = getPartitionIndicesToCloneInto(ifOp, schedule);
+      } else {
+        partitionIndices = getPartitionIndicesToCloneInto(partition, schedule);
+      }
+
       for (size_t idx : partitionIndices) {
         auto &builder = builders[idx];
         SmallVector<size_t> newOperandIndices;
@@ -331,8 +381,14 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
                   forOp, schedule.getPartition(builder.partitionId), schedule)
                   .first;
         } else {
+          auto ifOp = cast<scf::IfOp>(yieldOp->getParentOp());
+          auto attrArray = ifOp->getAttrOfType<ArrayAttr>(kPartitionAttrName);
+          assert(attrArray.size() == yieldOp.getOperands().size());
           for (size_t i = 0; i < yieldOp.getOperands().size(); ++i) {
-            newOperandIndices.push_back(i);
+            auto defIdx = cast<IntegerAttr>(attrArray[i]).getInt();
+            if (defIdx == -1 || defIdx == idx) {
+              newOperandIndices.push_back(i);
+            }
           }
         }
 
@@ -347,10 +403,63 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
         }
       }
     } else {
+      SmallVector<size_t> partitionIndices;
+      // WA until we assign partitions to index / phase update ops in
+      // AssignStagePhase
+      if (partition == schedule.getRootPartition()) {
+        if (auto ifOp = dyn_cast<scf::IfOp>(op->getParentOp())) {
+          partitionIndices = getPartitionIndicesToCloneInto(ifOp, schedule);
+        } else {
+          partitionIndices =
+              getPartitionIndicesToCloneInto(partition, schedule);
+        }
+      } else {
+        partitionIndices = getPartitionIndicesToCloneInto(partition, schedule);
+      }
       cloneOp(op, builders, partitionIndices);
     }
   }
 }
+
+void inferIfStmtPartitions(scf::IfOp ifOp) {
+  SmallVector<std::optional<int>> partitionIndices;
+  auto partitionIndex = [&](OpOperand &opnd) -> std::optional<int> {
+    if (auto defOp = opnd.get().getDefiningOp()) {
+      return getOpPartitionIdx(defOp);
+    }
+    return std::nullopt;
+  };
+  for (auto &opnd : ifOp.thenYield()->getOpOperands()) {
+    partitionIndices.push_back(partitionIndex(opnd));
+  }
+
+  if (ifOp.elseBlock()) {
+    for (auto [idx, opnd] :
+         llvm::enumerate(ifOp.elseYield()->getOpOperands())) {
+      auto index = partitionIndex(opnd);
+      if (index) {
+        if (partitionIndices[idx]) {
+          if (index != -1) {
+            assert(partitionIndices[idx] == index);
+          }
+        } else {
+          partitionIndices[idx] = index;
+        }
+      } else {
+        assert(partitionIndices[idx]);
+      }
+    }
+  }
+
+  llvm::SmallVector<Attribute> partitionAttrs;
+  for (auto partition : partitionIndices) {
+    partitionAttrs.push_back(mlir::IntegerAttr::get(
+        mlir::IntegerType::get(ifOp.getContext(), 32), *partition));
+  }
+  ifOp->setAttr(kPartitionAttrName,
+                ArrayAttr::get(ifOp.getContext(), partitionAttrs));
+}
+
 } // namespace
 
 LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
@@ -358,6 +467,14 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
   if (failed(scheduleOr))
     return failure();
   WarpSchedule schedule = std::move(*scheduleOr);
+  // XXX: once we insert tmem arefs this check will need to be disabled
+  //      becaused we will have partitioning that cannot be represent by
+  //      schedule e.g. if ..
+  //         op1 (partition 1)
+  //         op2 (partition 0)
+  //         .. etc
+  //      currently schedule assume that all ops inside if-stmt inherit
+  //      partition to which if-stmt originally was assigned
   if (failed(schedule.verify(loop)))
     return failure();
 
@@ -519,6 +636,8 @@ void PartitionLoops::runOnOperation() {
     if (loop->hasAttrOfType<ArrayAttr>(kPartitionStagesAttrName))
       loops.push_back(loop);
   });
+
+  getOperation().walk([&](scf::IfOp ifOp) { inferIfStmtPartitions(ifOp); });
 
   for (scf::ForOp loop : loops) {
     if (failed(partitionLoop(loop)))


### PR DESCRIPTION
updates partition representation that will needed to enable e2e workflow with arefs tmem 

- propagates partition from originally assigned to if-op to all ops inside the if-op (Masa's work)
- partition-loops pass now adds partition to result of each if-op, and updated cloneIfOp to keep only results that used in respective partition

@ThomasRaoux @Mogball @masahi 