### PR TITLE
[BACKEND] Clear out warp_specialize attr when peeling out outer loop

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -1006,6 +1006,9 @@ static LogicalResult speculateInnerLoopLength(scf::ForOp outerLoop,
   newInnerLoop.replaceAllUsesWith(newInnerLoop.getInits());
   newInnerLoop.erase();
 
+  // Clear up the warp specialization attributes for the specialized loop.
+  newLoop->removeAttr(kWarpSpecializeAttrName);
+
   // Move the loop nest into the `else` branch.
   outerLoop.replaceAllUsesWith(ifOp.getResults());
   Block *block = b.createBlock(&ifOp.getElseRegion());

--- a/test/TritonGPU/fuse-nested-loops.mlir
+++ b/test/TritonGPU/fuse-nested-loops.mlir
@@ -473,7 +473,7 @@ tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
   // CHECK: scf.if [[IS_ZERO]]
   // CHECK-NEXT: scf.for %{{.*}} = [[LB]] to [[UB]] step %c1_i32
   // CHECK-NEXT:   "prologue"
-  // CHECK-NXET: }
+  // CHECK-NXET: } {tt.flatten}
 
   // CHECK: else
   // CHECK-COUNT-1: scf.for
@@ -487,7 +487,7 @@ tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
       "body"(%i, %j) : (i32, i32) -> ()
       scf.yield
     }
-  } {tt.flatten}
+  } {tt.flatten, tt.warp_specialize}
   tt.return
 }
 


### PR DESCRIPTION
When we are peeling out the outer loop remove the warp specialization flag so that the specialized loop doesn't get warp specialized
