### PR TITLE
Extend AxisInfo analysis to support DenseElementsAttr

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -243,7 +243,8 @@ public:
           /*knownConstantValue=*/{value});
     }
 
-    // -------------------------------------- New code --------------------------------------
+    // -------------------------------------- New code
+    // --------------------------------------
     auto denseAttr = dyn_cast<DenseElementsAttr>(op.getValue());
     if (denseAttr && denseAttr.getElementType().isIntOrIndex()) {
       TensorType ty = cast<TensorType>(denseAttr.getType());
@@ -268,7 +269,8 @@ public:
         SmallVector<int64_t> idx(rank, 0);
         int64_t tmp = s;
         for (int64_t k = rank - 1; k >= 0; --k) {
-          if (k == d) continue;
+          if (k == d)
+            continue;
           int64_t sz = ty.getShape()[k];
           idx[k] = tmp % sz;
           tmp /= sz;
@@ -301,7 +303,8 @@ public:
               }
             }
           }
-          if (allGroupsConst) bestConst = groupSize;
+          if (allGroupsConst)
+            bestConst = groupSize;
         }
         constancy[d] = bestConst;
 
@@ -340,13 +343,12 @@ public:
             minDiv = std::min(minDiv, highestPowOf2Divisor(first));
           }
         }
-        divisibility[d] = (minDiv == std::numeric_limits<int64_t>::max()) ? 1 : minDiv;
+        divisibility[d] =
+            (minDiv == std::numeric_limits<int64_t>::max()) ? 1 : minDiv;
       }
 
       return AxisInfo(contiguity, divisibility, constancy);
     }
-
-
 
     return AxisInfo();
   }
@@ -1139,7 +1141,6 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver,
                   MaxMinOpAxisInfoVisitor<arith::MinUIOp>>();
   visitors.append<LoadOpAxisInfoVisitor>();
 
-  
   if (callback)
     callback(visitors);
 }

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -7,6 +7,10 @@ tt.func @cast() {
   %0 = arith.extsi %cst : i32 to i64
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = 1}}
   %cst_tensor = arith.constant dense<1> : tensor<128xi32>
+  // expected-remark @below {{contiguity = [4], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %cst_dense_tensor =  arith.constant dense<[1,2,3,4,8,9,10,11]> : tensor<8xi32>
+  // expected-remark @below {{contiguity = [1, 4], divisibility = [1, 2], constancy = [1, 1], constant_value = <none>}}
+  %cst_dense_tensor_2d = arith.constant dense<[[10,11,12,13,18,19,20,21], [20, 21, 22, 23, 28, 29, 30, 31]]> : tensor<2x8xi32>
   // Bitcast preserves axis info for same-width types.
   // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [128], constant_value = 1}}
   %1 = tt.bitcast %cst_tensor : tensor<128xi32> -> tensor<128xf32>


### PR DESCRIPTION
AxisInfo analysis for arith.constant previously handled IntegerAttr, BoolAttr, and SplatElementsAttr, but it did not support DenseElementsAttr.

This caused incomplete analysis for constants represented as dense element attributes, potentially affecting downstream optimizations or transformations that rely on accurate AxisInfo.

This patch adds support for DenseElementsAttr, ensuring that AxisInfo can now correctly interpret both single-value constants and dense constants. This resolves the TODO in AxisInfo.cpp and improves the robustness of the analysis without changing the behavior for existing attribute types.

By handling dense constants, future passes and analyses can rely on more complete information, reducing the risk of incorrect assumptions or missed optimizations.
This resolves the TODO in AxisInfo.cpp.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
