### PR TITLE
[Proton] Fix proton intra kernel profiling buffer overflow warning

### DIFF
--- a/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
+++ b/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
@@ -55,13 +55,14 @@ void CircularLayoutParser::parseMetadata() {
   for (auto uid : getConfig().uidVec) {
     // Each event is 2 words (8 bytes) and countVec captures the number of words
     // of each warp captured during profiling
-    auto count = countVec[uid] / 2;
+    auto count = countVec[uid];
+    auto numEvent = count / 2;
 
-    if (count > maxCountPerUnit) {
+    if (numEvent > maxCountPerUnit) {
       std::cerr << "Warning (cta" << bt.blockId << ", warp" << uid
-                << "): first " << count - maxCountPerUnit
+                << "): first " << numEvent - maxCountPerUnit
                 << " events are dropped due to insufficient buffer size ("
-                << maxCountPerUnit << "/" << count << ")" << std::endl;
+                << maxCountPerUnit << "/" << numEvent << ")" << std::endl;
     }
 
     auto &trace = bt.traces.emplace_back();

--- a/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
+++ b/third_party/proton/common/lib/TraceDataIO/CircularLayoutParser.cpp
@@ -53,7 +53,9 @@ void CircularLayoutParser::parseMetadata() {
   int maxCountPerUnit = bt.bufSize / getConfig().uidVec.size() / 8;
 
   for (auto uid : getConfig().uidVec) {
-    auto count = countVec[uid];
+    // Each event is 2 words (8 bytes) and countVec captures the number of words
+    // of each warp captured during profiling
+    auto count = countVec[uid] / 2;
 
     if (count > maxCountPerUnit) {
       std::cerr << "Warning (cta" << bt.blockId << ", warp" << uid


### PR DESCRIPTION
Fixed the miscalculated event size that each warp captured for reporting the overflow warning.
