### PR TITLE
[AMD][GLUON] Expose wmma for RDNA3 and RDNA4

### DIFF
--- a/python/triton/experimental/gluon/language/amd/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/__init__.py
@@ -1,4 +1,5 @@
 from ._layouts import AMDMFMALayout, AMDWMMALayout
 from . import cdna3, cdna4
+from . import rdna3, rdna4
 
-__all__ = ["AMDMFMALayout", "AMDWMMALayout", "cdna3", "cdna4"]
+__all__ = ["AMDMFMALayout", "AMDWMMALayout", "cdna3", "cdna4", "rdna3", "rdna4"]

--- a/python/triton/experimental/gluon/language/amd/rdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/rdna3/__init__.py
@@ -1,0 +1,23 @@
+from triton import knobs
+from triton.experimental.gluon.language import _core as ttgl
+from triton.experimental.gluon.language._semantic import _check
+
+from .._layouts import AMDWMMALayout
+from ..._core import builtin
+
+__all__ = ["wmma"]
+
+
+@builtin
+def wmma(a, b, acc, _semantic=None):
+    """
+    """
+    _check(acc is not None, lambda: "acc is required")
+    layout = acc.type.layout
+    _check(
+        isinstance(layout, AMDWMMALayout) and layout.version == 1,
+        lambda: "Expected layout to be an instance of AMDWMMALayout with version 1")
+
+    handle = _semantic.dot(a, b, acc, input_precision=knobs.language.fp32_default, max_num_imprecise_acc=None,
+                           out_dtype=acc.dtype).handle
+    return ttgl.tensor(handle, acc.type)

--- a/python/triton/experimental/gluon/language/amd/rdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/rdna3/__init__.py
@@ -3,6 +3,7 @@ from triton.experimental.gluon.language import _core as ttgl
 from triton.experimental.gluon.language._semantic import _check
 
 from .._layouts import AMDWMMALayout
+from ..._layouts import DotOperandLayout
 from ..._core import builtin
 
 __all__ = ["wmma"]
@@ -23,6 +24,12 @@ def wmma(a, b, acc, _semantic=None):
     _check(
         isinstance(layout, AMDWMMALayout) and layout.version == 1,
         lambda: "Expected layout to be an instance of AMDWMMALayout with version 1")
+    _check(
+        isinstance(a.type.layout, DotOperandLayout) and a.type.layout.parent == layout,
+        lambda: "Expected a's layout to be a DotOperandLayout with parent matching AMDWMMALayout")
+    _check(
+        isinstance(b.type.layout, DotOperandLayout) and b.type.layout.parent == layout,
+        lambda: "Expected b's layout to be a DotOperandLayout with parent matching AMDWMMALayout")
 
     handle = _semantic.dot(a, b, acc, input_precision=knobs.language.fp32_default, max_num_imprecise_acc=None,
                            out_dtype=acc.dtype).handle

--- a/python/triton/experimental/gluon/language/amd/rdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/rdna3/__init__.py
@@ -11,6 +11,12 @@ __all__ = ["wmma"]
 @builtin
 def wmma(a, b, acc, _semantic=None):
     """
+    Computes matrix-multiplication of a * b + acc using AMD WMMA instruction.
+
+    Args:
+        a (tensor): The operand a to be multiplied.
+        b (tensor): The operand b to be multiplied.
+        acc (tensor): The accumulator tensor.
     """
     _check(acc is not None, lambda: "acc is required")
     layout = acc.type.layout

--- a/python/triton/experimental/gluon/language/amd/rdna4/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/rdna4/__init__.py
@@ -1,0 +1,23 @@
+from triton import knobs
+from triton.experimental.gluon.language import _core as ttgl
+from triton.experimental.gluon.language._semantic import _check
+
+from .._layouts import AMDWMMALayout
+from ..._core import builtin
+
+__all__ = ["wmma"]
+
+
+@builtin
+def wmma(a, b, acc, _semantic=None):
+    """
+    """
+    _check(acc is not None, lambda: "acc is required")
+    layout = acc.type.layout
+    _check(
+        isinstance(layout, AMDWMMALayout) and layout.version == 2,
+        lambda: "Expected layout to be an instance of AMDWMMALayout with version 2")
+
+    handle = _semantic.dot(a, b, acc, input_precision=knobs.language.fp32_default, max_num_imprecise_acc=None,
+                           out_dtype=acc.dtype).handle
+    return ttgl.tensor(handle, acc.type)

--- a/python/triton/experimental/gluon/language/amd/rdna4/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/rdna4/__init__.py
@@ -3,6 +3,7 @@ from triton.experimental.gluon.language import _core as ttgl
 from triton.experimental.gluon.language._semantic import _check
 
 from .._layouts import AMDWMMALayout
+from ..._layouts import DotOperandLayout
 from ..._core import builtin
 
 __all__ = ["wmma"]
@@ -23,6 +24,12 @@ def wmma(a, b, acc, _semantic=None):
     _check(
         isinstance(layout, AMDWMMALayout) and layout.version == 2,
         lambda: "Expected layout to be an instance of AMDWMMALayout with version 2")
+    _check(
+        isinstance(a.type.layout, DotOperandLayout) and a.type.layout.parent == layout,
+        lambda: "Expected a's layout to be a DotOperandLayout with parent matching AMDWMMALayout")
+    _check(
+        isinstance(b.type.layout, DotOperandLayout) and b.type.layout.parent == layout,
+        lambda: "Expected b's layout to be a DotOperandLayout with parent matching AMDWMMALayout")
 
     handle = _semantic.dot(a, b, acc, input_precision=knobs.language.fp32_default, max_num_imprecise_acc=None,
                            out_dtype=acc.dtype).handle

--- a/python/triton/experimental/gluon/language/amd/rdna4/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/rdna4/__init__.py
@@ -11,6 +11,12 @@ __all__ = ["wmma"]
 @builtin
 def wmma(a, b, acc, _semantic=None):
     """
+    Computes matrix-multiplication of a * b + acc using AMD WMMA instruction.
+
+    Args:
+        a (tensor): The operand a to be multiplied.
+        b (tensor): The operand b to be multiplied.
+        acc (tensor): The accumulator tensor.
     """
     _check(acc is not None, lambda: "acc is required")
     layout = acc.type.layout


### PR DESCRIPTION
This PR exposes WMMA instruction for RDNA3 and RDNA4. Similar to `amd.cdna4.mfma`, both are wrapper around `tl.dot` with additional checks of input layouts. Add a wmma kernel which has been tested on Radeon RX 9070 XT (RDNA4) and Radeon RX 7900 XTX (RDNA3).