### PR TITLE
Fix ASAN `initialization-order-fiasco` issue in `tensor_layout_print.mlir` test

### DIFF
--- a/bin/triton-tensor-layout.cpp
+++ b/bin/triton-tensor-layout.cpp
@@ -39,29 +39,32 @@ using namespace mlir;
 // CLI options
 //===--------------------------------------------------------------------===//
 
-cl::OptionCategory PrinterCategory("Available Print Options",
-                                   "Options for the tensor layout printing.");
+static cl::OptionCategory &getPrinterCategory() {
+  static cl::OptionCategory PrinterCategory(
+      "Available Print Options", "Options for the tensor layout printing.");
+  return PrinterCategory;
+}
 
 static cl::opt<std::string> InputFile(
     "i", cl::desc("File that contains the tensor data layout attributes"),
-    cl::init(""), cl::value_desc("filename"), cl::cat(PrinterCategory));
+    cl::init(""), cl::value_desc("filename"), cl::cat(getPrinterCategory()));
 
 static cl::opt<std::string>
     OutputFile("o", cl::desc("Output file to write the layout into"),
                cl::init(""), cl::value_desc("filename"),
-               cl::cat(PrinterCategory));
+               cl::cat(getPrinterCategory()));
 
 static cl::opt<std::string>
     DataLayoutStr("l", cl::desc("Tensor data layout attribute in string"),
                   cl::value_desc("layout-string"), cl::init(""),
-                  cl::cat(PrinterCategory));
+                  cl::cat(getPrinterCategory()));
 
 static cl::list<std::string>
     AliasName("alias-names",
               cl::desc("A list of alias names (separated by comma) of the "
                        "layout attributes in the input file"),
               cl::value_desc("name1,name2,name3,..."), cl::CommaSeparated,
-              cl::ZeroOrMore, cl::cat(PrinterCategory));
+              cl::ZeroOrMore, cl::cat(getPrinterCategory()));
 
 static cl::opt<bool> UseHWPointOfView(
     "use-hw-view",
@@ -69,11 +72,11 @@ static cl::opt<bool> UseHWPointOfView(
         "Print the layout in hardware point of view. This means the output is "
         "from the warp's perspective. Otherwise, the output is from the "
         "tensor's perspective (e.g., each element maps to xxx thread)."),
-    cl::init(false), cl::cat(PrinterCategory));
+    cl::init(false), cl::cat(getPrinterCategory()));
 
 static cl::opt<std::string> TensorStr(
     "t", cl::desc("Tensor shape and element type (e.g., tensor<2x2xf32>)"),
-    cl::init(""), cl::value_desc("tensor-type"), cl::cat(PrinterCategory));
+    cl::init(""), cl::value_desc("tensor-type"), cl::cat(getPrinterCategory()));
 
 //===--------------------------------------------------------------------===//
 // Helper functions
@@ -180,7 +183,7 @@ static LogicalResult printLayoutFromString(MLIRContext *context,
 //===--------------------------------------------------------------------===//
 
 int main(int argc, char **argv) {
-  cl::HideUnrelatedOptions(PrinterCategory);
+  cl::HideUnrelatedOptions(getPrinterCategory());
   cl::ParseCommandLineOptions(argc, argv, "tensor layout printer\n");
 
   DialectRegistry registry;


### PR DESCRIPTION
IIUC, the initialization order between static and non-static variables is not guaranteed, so we can't use the previous non-static variable to initialize a static one later on. Working around that by moving it into a static function variable.

We discovered this when upgrading to a newer LLVM version, so it might only be reproducible with new LLVM.

Here is the error:

```
==3551==ERROR: AddressSanitizer: initialization-order-fiasco on address 0x557bc517caa0 at pc 0x557bc3f2fbb2 bp 0x7ffda74ef270 sp 0x7ffda74ef268

READ of size 8 at 0x557bc517caa0 thread T0

    #0 0x557bc3f2fbb1 in getName llvm/include/llvm/Support/CommandLine.h:194:38

    #1 0x557bc3f2fbb1 in operator() llvm/lib/Support/CommandLine.cpp:347:5

    #2 0x557bc3f2fbb1 in __invoke<(lambda at llvm/lib/Support/CommandLine.cpp:347:5) &, llvm::cl::OptionCategory *> libcxx/include/__type_traits/invoke.h:87:27

    #3 0x557bc3f2fbb1 in __count_if<std::__u::_ClassicAlgPolicy, llvm::SmallPtrSetIterator<llvm::cl::OptionCategory *>, llvm::SmallPtrSetIterator<llvm::cl::OptionCategory *>, std::__u::__identity, (lambda at llvm/lib/Support/CommandLine.cpp:347:5)> libcxx/include/__algorithm/count_if.h:30:9

    #4 0x557bc3f2fbb1 in count_if<llvm::SmallPtrSetIterator<llvm::cl::OptionCategory *>, (lambda at llvm/lib/Support/CommandLine.cpp:347:5)> libcxx/include/__algorithm/count_if.h:41:10

    #5 0x557bc3f2fbb1 in count_if<llvm::SmallPtrSet<llvm::cl::OptionCategory *, 16U> &, (lambda at llvm/lib/Support/CommandLine.cpp:347:5)> llvm/include/llvm/ADT/STLExtras.h:1981:10

    #6 0x557bc3f2fbb1 in registerCategory llvm/lib/Support/CommandLine.cpp:347:5

    #7 0x557bc3f2fbb1 in llvm::cl::OptionCategory::registerCategory() llvm/lib/Support/CommandLine.cpp:484:17

    #8 0x557bc4504950 in OptionCategory llvm/include/llvm/Support/CommandLine.h:191:5

    #9 0x557bc4504950 in __cxx_global_var_init llvm/lib/CodeGen/GlobalISel/Combiner.cpp:37:20
```
