### PR TITLE
[BACKEND][NVIDIA] Update ptxas_options knobs default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ See [`python/triton/knobs.py`](python/triton/knobs.py) for the full list of conf
 - `TRITON_F32_DEFAULT` sets the default input precision of `tl.dot` when using 32-bit floats, which can be either `ieee`, `tf32`, or `tf32x3`.
 - `TRITON_FRONT_END_DEBUGGING=1` disables exception wrapping when an error occurs in the compiler frontend, allowing the full stack trace to be seen.
 - `TRITON_DISABLE_LINE_INFO=1` removes all line information from the module.
+- `PTXAS_OPTIONS` passes additional command-line options to the PTX assembler `ptxas` (Only on NVIDIA).
 
 > [!NOTE]
 > Some of these environment variables don't have a knob in `knobs.py`-- those are only relevant to the C++ layer(s), hence they don't exist in the python layer.

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ See [`python/triton/knobs.py`](python/triton/knobs.py) for the full list of conf
 - `TRITON_F32_DEFAULT` sets the default input precision of `tl.dot` when using 32-bit floats, which can be either `ieee`, `tf32`, or `tf32x3`.
 - `TRITON_FRONT_END_DEBUGGING=1` disables exception wrapping when an error occurs in the compiler frontend, allowing the full stack trace to be seen.
 - `TRITON_DISABLE_LINE_INFO=1` removes all line information from the module.
-- `PTXAS_OPTIONS` passes additional command-line options to the PTX assembler `ptxas` (Only on NVIDIA).
+- `PTXAS_OPTIONS` passes additional command-line options to the PTX assembler `ptxas` (only on NVIDIA).
 
 > [!NOTE]
 > Some of these environment variables don't have a knob in `knobs.py`-- those are only relevant to the C++ layer(s), hence they don't exist in the python layer.

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -247,30 +247,41 @@ def test_nvidia_tool(fresh_knobs, tmp_path, monkeypatch):
     default_ptxas = triton_root / "backends/nvidia/bin/ptxas"
 
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
+    assert fresh_knobs.nvidia.ptxas_options == None
 
     tmp_ptxas = tmp_path / "ptxas-special"
     shutil.copy(default_ptxas, tmp_ptxas)
     monkeypatch.setenv("TRITON_PTXAS_PATH", str(tmp_ptxas))
+    monkeypatch.setenv("PTXAS_OPTIONS", "--verbose")
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == tmp_ptxas.resolve()
+    assert fresh_knobs.nvidia.ptxas_options == "--verbose"
 
     # Don't prop so that the `del` is correctly tested
     fresh_knobs.propagate_env = False
     fresh_knobs.nvidia.ptxas = str(default_ptxas)
+    fresh_knobs.nvidia.ptxas_options = "--device-debug"
     fresh_knobs.propagate_env = True
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
+    assert fresh_knobs.nvidia.ptxas_options == "--device-debug"
 
     del fresh_knobs.nvidia.ptxas
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == tmp_ptxas.resolve()
+    assert fresh_knobs.nvidia.ptxas_options == "--verbose"
 
     # Triple check scope works
     with fresh_knobs.nvidia.scope():
         fresh_knobs.nvidia.ptxas = str(default_ptxas)
+        fresh_knobs.nvidia.ptxas_options = "--device-debug"
         assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
+        assert fresh_knobs.nvidia.ptxas_options == "--device-debug"
 
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == tmp_ptxas.resolve()
+    assert fresh_knobs.nvidia.ptxas_options == "--verbose"
 
     monkeypatch.delenv("TRITON_PTXAS_PATH")
+    monkeypatch.delenv("PTXAS_OPTIONS")
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
+    assert fresh_knobs.nvidia.ptxas_options == None
 
 
 def test_opt_bool(fresh_knobs, monkeypatch):

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -247,7 +247,7 @@ def test_nvidia_tool(fresh_knobs, tmp_path, monkeypatch):
     default_ptxas = triton_root / "backends/nvidia/bin/ptxas"
 
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
-    assert fresh_knobs.nvidia.ptxas_options == None
+    assert fresh_knobs.nvidia.ptxas_options is None
 
     tmp_ptxas = tmp_path / "ptxas-special"
     shutil.copy(default_ptxas, tmp_ptxas)
@@ -282,7 +282,7 @@ def test_nvidia_tool(fresh_knobs, tmp_path, monkeypatch):
     monkeypatch.delenv("TRITON_PTXAS_PATH")
     monkeypatch.delenv("PTXAS_OPTIONS")
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
-    assert fresh_knobs.nvidia.ptxas_options == None
+    assert fresh_knobs.nvidia.ptxas_options is None
 
 
 def test_opt_bool(fresh_knobs, monkeypatch):

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -265,6 +265,7 @@ def test_nvidia_tool(fresh_knobs, tmp_path, monkeypatch):
     assert fresh_knobs.nvidia.ptxas_options == "--device-debug"
 
     del fresh_knobs.nvidia.ptxas
+    del fresh_knobs.nvidia.ptxas_options
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == tmp_ptxas.resolve()
     assert fresh_knobs.nvidia.ptxas_options == "--verbose"
 

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -478,6 +478,7 @@ class nvidia_knobs(base_knobs):
 
     dump_nvptx: env_bool = env_bool("NVPTX_ENABLE_DUMP")
     disable_ptxas_opt: env_bool = env_bool("DISABLE_PTXAS_OPT")
+    ptxas_options: env_opt_str = env_opt_str("PTXAS_OPTIONS")
     mock_ptx_version: env_opt_str = env_opt_str("TRITON_MOCK_PTX_VERSION")
     dump_ptxas_log: env_bool = env_bool("TRITON_DUMP_PTXAS_LOG")
 

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -113,7 +113,7 @@ class CUDAOptions:
     maxnreg: Optional[int] = None
     cluster_dims: tuple = (1, 1, 1)
     ptx_version: int = None
-    ptx_options: str = None
+    ptx_options: str = os.environ.get("PTXAS_OPTIONS", None)
     ir_override: Optional[str] = None  # filename of a user-defined IR (*.{ttir|ttgir|llir|ptx})
     enable_fp_fusion: bool = True
     launch_cooperative_grid: bool = False
@@ -460,12 +460,6 @@ class CUDABackend(BaseBackend):
 
             # Accept more ptxas options if provided
             ptx_extra_options = opt.ptx_options.split(" ") if opt.ptx_options else []
-
-            # Accept more ptxas options if ptxas related envs are provided
-            if not knobs.nvidia.disable_ptxas_opt and (ptxas_options := os.environ.get("PTXAS_OPTIONS", None)):
-                kernel_name = os.environ.get("PTXAS_OPTIONS_KERNEL", None)
-                if not kernel_name or kernel_name == metadata["name"]:
-                    ptx_extra_options.extend(ptxas_options.split(" "))
 
             ptxas_cmd = [
                 ptxas, *debug_info, *fmad, '-v', *disable_opt, *ptx_extra_options, f'--gpu-name={arch}', fsrc.name,

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -462,9 +462,7 @@ class CUDABackend(BaseBackend):
             ptx_extra_options = opt.ptx_options.split(" ") if opt.ptx_options else []
 
             # Accept more ptxas options if ptxas related envs are provided
-            if not knobs.nvidia.disable_ptxas_opt and (
-                ptxas_options := os.environ.get("PTXAS_OPTIONS", None)
-            ):
+            if not knobs.nvidia.disable_ptxas_opt and (ptxas_options := os.environ.get("PTXAS_OPTIONS", None)):
                 kernel_name = os.environ.get("PTXAS_OPTIONS_KERNEL", None)
                 if not kernel_name or kernel_name == metadata["name"]:
                     ptx_extra_options.extend(ptxas_options.split(" "))

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -113,7 +113,7 @@ class CUDAOptions:
     maxnreg: Optional[int] = None
     cluster_dims: tuple = (1, 1, 1)
     ptx_version: int = None
-    ptx_options: str = os.environ.get("PTXAS_OPTIONS", None)
+    ptx_options: Optional[str] = knobs.nvidia.ptxas_options
     ir_override: Optional[str] = None  # filename of a user-defined IR (*.{ttir|ttgir|llir|ptx})
     enable_fp_fusion: bool = True
     launch_cooperative_grid: bool = False

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -461,6 +461,14 @@ class CUDABackend(BaseBackend):
             # Accept more ptxas options if provided
             ptx_extra_options = opt.ptx_options.split(" ") if opt.ptx_options else []
 
+            # Accept more ptxas options if ptxas related envs are provided
+            if not knobs.nvidia.disable_ptxas_opt and (
+                ptxas_options := os.environ.get("PTXAS_OPTIONS", None)
+            ):
+                kernel_name = os.environ.get("PTXAS_OPTIONS_KERNEL", None)
+                if not kernel_name or kernel_name == metadata["name"]:
+                    ptx_extra_options.extend(ptxas_options.split(" "))
+
             ptxas_cmd = [
                 ptxas, *debug_info, *fmad, '-v', *disable_opt, *ptx_extra_options, f'--gpu-name={arch}', fsrc.name,
                 '-o', fbin


### PR DESCRIPTION
This PR sets the default value of the ptxas_options knob to be the value of the `PTXAS_OPTIONS` environment variable.
We need this option when we want to apply extra ptxas options across a range of Triton kernels, without changing their call sites.

# New contributor declaration

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] This PR does not need a test because this is a small change of reading ptxas options from environment variables.

- Select one of the following.
  - [x] I have not added any `lit` tests.
