### PR TITLE
[WS] Rework partition representation

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -102,6 +102,12 @@ public:
   // Debug dump the partition set.
   LLVM_DUMP_METHOD void dump() const;
 
+  // Utility to be used when the op is known to belong to one partition
+  Partition *getPartition(Operation *op);
+
+  // Check if the operation belongs to all partitions
+  bool isInRootPartition(Operation *op);
+
 private:
   // WarpSpecialization tag
   int tag;
@@ -121,11 +127,6 @@ void setPartition(Operation *op, const SetVector<Partition *> &partitions);
 void setPartition(Operation *op, const SetVector<int> &partitionIds);
 
 std::optional<SetVector<int>> getPartitionIds(Operation *op);
-
-// Utility to be used when the op is known to belong to one partition
-Partition *getPartition(Operation *op, PartitionSet &partitions);
-
-bool isInRootPartition(Operation *op, PartitionSet &partitions);
 
 } // namespace mlir::triton::gpu
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -49,6 +49,11 @@ private:
   SmallVector<Operation *> ops;
 };
 
+bool setPartition(Operation *op, Partition *partition);
+std::optional<SetVector<int>> getPartitionIds(Operation *op);
+bool hasPartition(Operation*op);
+bool isOpInPartition(Operation *op, const Partition *partition);
+
 // A warp schedule divides a loop into multiple partitions. Ops in a loop are
 // assigned at most one partition. A warp schedule represents asynchronous
 // execution of the loop body, where partitions may execute simultaneously.

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -49,7 +49,8 @@ private:
   SmallVector<Operation *> ops;
 };
 
-bool setPartition(Operation *op, Partition *partition);
+void setPartition(Operation *op, Partition *partition);
+void setPartition(Operation *op, const SetVector<int>& partitionIds);
 std::optional<SetVector<int>> getPartitionIds(Operation *op);
 bool hasPartition(Operation*op);
 bool isOpInPartition(Operation *op, const Partition *partition);

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -91,7 +91,7 @@ void setPartition(Operation *op, Partition *partition);
 void setPartition(Operation *op, const SetVector<int> &partitionIds);
 std::optional<SetVector<int>> getPartitionIds(Operation *op);
 bool hasPartition(Operation *op);
-bool isOpInPartition(Operation *op, const Partition *partition);
+// Utility to be used when the op is known to belong to one partition
 Partition *getPartition(Operation *op, WarpSchedule &schedule);
 
 // Iterate the inputs of the partition. Input values are those that originate

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -21,7 +21,7 @@ static constexpr char kPartitionStagesAttrName[] = "ttg.partition.stages";
 static constexpr char kWarpSpecializeTagAttrName[] = "ttg.warp_specialize.tag";
 
 //===----------------------------------------------------------------------===//
-// WarpSchedule
+// PartitionSet
 //===----------------------------------------------------------------------===//
 
 namespace mlir::triton::gpu {
@@ -51,10 +51,10 @@ private:
   SmallVector<Operation *> ops;
 };
 
-// A warp schedule divides a loop into multiple partitions. Ops in a loop are
-// assigned at most one partition. A warp schedule represents asynchronous
+// A partition set divides a loop into multiple partitions. Ops in a loop are
+// assigned at most one partition. A partition set represents asynchronous
 // execution of the loop body, where partitions may execute simultaneously.
-class WarpSchedule {
+class PartitionSet {
 public:
   // Get WarpSpecialization tag
   int getTag() const { return tag; }
@@ -73,11 +73,11 @@ public:
   // Get the number of partitions.
   unsigned getNumPartitions() const { return partitions.size(); }
 
-  // Deserialize a warp schedule from an `scf.for` op using the attributes
+  // Deserialize a partition set from an `scf.for` op using the attributes
   // tagged on operations in its body.
-  static FailureOr<WarpSchedule> deserialize(scf::ForOp loop);
+  static FailureOr<PartitionSet> deserialize(scf::ForOp loop);
 
-  // Debug dump the schedule.
+  // Debug dump the partition set.
   LLVM_DUMP_METHOD void dump() const;
 
 private:
@@ -92,7 +92,7 @@ void setPartition(Operation *op, const SetVector<int> &partitionIds);
 std::optional<SetVector<int>> getPartitionIds(Operation *op);
 bool hasPartition(Operation *op);
 // Utility to be used when the op is known to belong to one partition
-Partition *getPartition(Operation *op, WarpSchedule &schedule);
+Partition *getPartition(Operation *op, PartitionSet &partitions);
 
 // Iterate the inputs of the partition. Input values are those that originate
 // from a different partition or a previous iteration of the current

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -77,29 +77,6 @@ public:
   // tagged on operations in its body.
   static FailureOr<WarpSchedule> deserialize(scf::ForOp loop);
 
-  // Iterate the inputs of the partition. Input values are those that originate
-  // from a different partition or a previous iteration of the current
-  // partition. E.g. partition B(i) may have inputs from A(i) or B(i-1). Note
-  // that the same value may be visited more than once.
-  void iterateInputs(scf::ForOp loop, const Partition *partition,
-                     function_ref<void(OpOperand &)> callback) const;
-  // Iterate the outputs of the partition. Output values are those that are
-  // consumed by a different partition or a future iteration of the current
-  // partition. E.g. partition A(i) may have outputs to B(i) or A(i+1). Note
-  // that the same value may be visited more than once.
-  void
-  iterateOutputs(scf::ForOp loop, const Partition *partition,
-                 function_ref<void(Operation *, OpOperand &)> callback) const;
-  // Iterate the defining ops of the inputs to the partition in the current and
-  // previous iterations, including the distance in the past.
-  void iterateDefs(scf::ForOp loop, const Partition *partition,
-                   function_ref<void(OpResult, unsigned)> callback) const;
-  // Iterate the uses of all outputs of the partition in the current iteration
-  // and in future iterations, including the distance in the future.
-  void iterateUses(
-      scf::ForOp loop, const Partition *partition,
-      function_ref<void(OpResult, OpOperand &, unsigned)> callback) const;
-
   // Debug dump the schedule.
   LLVM_DUMP_METHOD void dump() const;
 
@@ -116,6 +93,27 @@ std::optional<SetVector<int>> getPartitionIds(Operation *op);
 bool hasPartition(Operation *op);
 bool isOpInPartition(Operation *op, const Partition *partition);
 Partition *getPartition(Operation *op, WarpSchedule &schedule);
+
+// Iterate the inputs of the partition. Input values are those that originate
+// from a different partition or a previous iteration of the current
+// partition. E.g. partition B(i) may have inputs from A(i) or B(i-1). Note
+// that the same value may be visited more than once.
+void iterateInputs(scf::ForOp loop, const Partition *partition,
+                   function_ref<void(OpOperand &)> callback);
+// Iterate the outputs of the partition. Output values are those that are
+// consumed by a different partition or a future iteration of the current
+// partition. E.g. partition A(i) may have outputs to B(i) or A(i+1). Note
+// that the same value may be visited more than once.
+void iterateOutputs(scf::ForOp loop, const Partition *partition,
+                    function_ref<void(Operation *, OpOperand &)> callback);
+// Iterate the defining ops of the inputs to the partition in the current and
+// previous iterations, including the distance in the past.
+void iterateDefs(scf::ForOp loop, const Partition *partition,
+                 function_ref<void(OpResult, unsigned)> callback);
+// Iterate the uses of all outputs of the partition in the current iteration
+// and in future iterations, including the distance in the future.
+void iterateUses(scf::ForOp loop, const Partition *partition,
+                 function_ref<void(OpResult, OpOperand &, unsigned)> callback);
 
 } // namespace mlir::triton::gpu
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -21,7 +21,7 @@ static constexpr char kPartitionStagesAttrName[] = "ttg.partition.stages";
 static constexpr char kWarpSpecializeTagAttrName[] = "ttg.warp_specialize.tag";
 
 //===----------------------------------------------------------------------===//
-// WarpSchedule
+// PartitionSet
 //===----------------------------------------------------------------------===//
 
 namespace mlir::triton::gpu {
@@ -54,7 +54,7 @@ private:
 // A warp schedule divides a loop into multiple partitions. Ops in a loop are
 // assigned at most one partition. A warp schedule represents asynchronous
 // execution of the loop body, where partitions may execute simultaneously.
-class WarpSchedule {
+class PartitionSet {
 public:
   // Get WarpSpecialization tag
   int getTag() const { return tag; }
@@ -75,7 +75,7 @@ public:
 
   // Deserialize a warp schedule from an `scf.for` op using the attributes
   // tagged on operations in its body.
-  static FailureOr<WarpSchedule> deserialize(scf::ForOp loop);
+  static FailureOr<PartitionSet> deserialize(scf::ForOp loop);
 
   // Debug dump the schedule.
   LLVM_DUMP_METHOD void dump() const;
@@ -92,7 +92,7 @@ void setPartition(Operation *op, const SetVector<int> &partitionIds);
 std::optional<SetVector<int>> getPartitionIds(Operation *op);
 bool hasPartition(Operation *op);
 // Utility to be used when the op is known to belong to one partition
-Partition *getPartition(Operation *op, WarpSchedule &schedule);
+Partition *getPartition(Operation *op, PartitionSet &schedule);
 
 // Iterate the inputs of the partition. Input values are those that originate
 // from a different partition or a previous iteration of the current

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -145,6 +145,9 @@ private:
   std::unique_ptr<Partition> rootPartition =
       std::make_unique<Partition>(kSentinel, kSentinel);
 };
+
+Partition *getPartition(Operation *op, WarpSchedule &schedule);
+
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_TRITONGPU_TRANSFORM_PIPELINE_PARTITION_H_

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -32,7 +32,7 @@ class Partition {
 public:
   Partition(int idx, int stage) : idx(idx), stage(stage) {}
 
-  int getIndex() const { return idx; }
+  int getIndex() const { assert(idx >= 0); return idx; }
   int getStage() const { return stage; }
   ArrayRef<Operation *> getOps() const { return ops; }
   void addOp(Operation* op) {ops.push_back(op);}

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -90,7 +90,7 @@ private:
 // Annotate the op with the partition index or indices, and add the op
 // to the partitions it belongs to.
 void setPartition(Operation *op, Partition *partition);
-void setPartition(Operation *op, const SetVector<Partition*> &partitions);
+void setPartition(Operation *op, const SetVector<Partition *> &partitions);
 // Annotate the op with the partition indices. It should only be used in a pass
 // which does not work with Partition instances and iterate* functions, since
 // it does not keep the op attributes and the op list of a partition in sync.

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -30,12 +30,11 @@ namespace mlir::triton::gpu {
 // relative to its consumers.
 class Partition {
 public:
-  Partition(int idx, int stage) : idx(idx), stage(stage) {}
-
-  int getIndex() const {
-    assert(idx >= 0);
-    return idx;
+  Partition(int idx, int stage) : idx(idx), stage(stage) {
+    assert(idx >= 0 && "A partition index must be nonnegative.");
   }
+
+  int getIndex() const { return idx; }
   int getStage() const { return stage; }
   ArrayRef<Operation *> getOps() const { return ops; }
   void addOp(Operation *op) { ops.push_back(op); }
@@ -110,6 +109,8 @@ private:
   SmallVector<std::unique_ptr<Partition>> partitions;
 };
 
+bool hasPartition(Operation *op);
+
 // Annotate the op with the partition index or indices, and add the op
 // to the partitions it belongs to.
 void setPartition(Operation *op, Partition *partition);
@@ -120,10 +121,10 @@ void setPartition(Operation *op, const SetVector<Partition *> &partitions);
 void setPartition(Operation *op, const SetVector<int> &partitionIds);
 
 std::optional<SetVector<int>> getPartitionIds(Operation *op);
+
 // Utility to be used when the op is known to belong to one partition
 Partition *getPartition(Operation *op, PartitionSet &partitions);
 
-bool hasPartition(Operation *op);
 bool isInRootPartition(Operation *op, PartitionSet &partitions);
 
 } // namespace mlir::triton::gpu

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -87,15 +87,21 @@ private:
   SmallVector<std::unique_ptr<Partition>> partitions;
 };
 
-// Annotate the op with the partition index, and
+// Annotate the op with the partition index or indices, and add the op
+// to the partitions it belongs to.
 void setPartition(Operation *op, Partition *partition);
-// TODO: remove this one?
-void setPartition(Operation *op, const SetVector<int> &partitionIds);
 void setPartition(Operation *op, const SetVector<Partition*> &partitions);
+// Annotate the op with the partition indices. It should only be used in a pass
+// which does not work with Partition instances and iterate* functions, since
+// it does not keep the op attributes and the op list of a partition in sync.
+void setPartition(Operation *op, const SetVector<int> &partitionIds);
+
 std::optional<SetVector<int>> getPartitionIds(Operation *op);
-bool hasPartition(Operation *op);
 // Utility to be used when the op is known to belong to one partition
 Partition *getPartition(Operation *op, PartitionSet &partitions);
+
+bool hasPartition(Operation *op);
+bool isInRootPartition(Operation *op, PartitionSet &partitions);
 
 // Iterate the inputs of the partition. Input values are those that originate
 // from a different partition or a previous iteration of the current

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -87,8 +87,11 @@ private:
   SmallVector<std::unique_ptr<Partition>> partitions;
 };
 
+// Annotate the op with the partition index, and
 void setPartition(Operation *op, Partition *partition);
+// TODO: remove this one?
 void setPartition(Operation *op, const SetVector<int> &partitionIds);
+void setPartition(Operation *op, const SetVector<Partition*> &partitions);
 std::optional<SetVector<int>> getPartitionIds(Operation *op);
 bool hasPartition(Operation *op);
 // Utility to be used when the op is known to belong to one partition

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -32,14 +32,16 @@ class Partition {
 public:
   Partition(int idx, int stage) : idx(idx), stage(stage) {}
 
-  int getIndex() const { assert(idx >= 0); return idx; }
+  int getIndex() const {
+    assert(idx >= 0);
+    return idx;
+  }
   int getStage() const { return stage; }
   ArrayRef<Operation *> getOps() const { return ops; }
-  void addOp(Operation* op) {ops.push_back(op);}
+  void addOp(Operation *op) { ops.push_back(op); }
 
 private:
   void setIndex(int idx) { this->idx = idx; }
-  friend class WarpSchedule;
 
   // The partition number.
   int idx;
@@ -49,18 +51,10 @@ private:
   SmallVector<Operation *> ops;
 };
 
-void setPartition(Operation *op, Partition *partition);
-void setPartition(Operation *op, const SetVector<int>& partitionIds);
-std::optional<SetVector<int>> getPartitionIds(Operation *op);
-bool hasPartition(Operation*op);
-bool isOpInPartition(Operation *op, const Partition *partition);
-
 // A warp schedule divides a loop into multiple partitions. Ops in a loop are
 // assigned at most one partition. A warp schedule represents asynchronous
 // execution of the loop body, where partitions may execute simultaneously.
 class WarpSchedule {
-  static constexpr int kSentinel = -1;
-
 public:
   // Get WarpSpecialization tag
   int getTag() const { return tag; }
@@ -68,44 +62,20 @@ public:
   // Create a new partition with a stage.
   Partition *addPartition(unsigned stage);
 
-  // Get the partition the op belongs to.
-  Partition *getPartition(Operation *op);
-  // Get the partition the op belongs to.
-  const Partition *getPartition(Operation *op) const;
   // Get the partition at the index.
   Partition *getPartition(unsigned idx);
   // Get the partition at the index.
   const Partition *getPartition(unsigned idx) const;
-  // Insert an operation into a partition.
-  void insert(Partition *partition, Operation *op);
   // Return an iterator range over the partitions.
   auto getPartitions() { return llvm::make_pointee_range(partitions); }
   // Return an iterator range over the partitions.
   auto getPartitions() const { return llvm::make_pointee_range(partitions); }
   // Get the number of partitions.
   unsigned getNumPartitions() const { return partitions.size(); }
-  // Get the root partition.
-  Partition *getRootPartition() { return rootPartition.get(); }
-  // Get the root partition.
-  const Partition *getRootPartition() const { return rootPartition.get(); }
-
-  // Return true if an operation is assigned to a partition.
-  bool isScheduled(Operation *op) const;
-  // Schedule an operation to a partition if it is not already scheduled. Return
-  // true if the operation was scheduled.
-  bool trySchedule(Partition *partition, Operation *op);
 
   // Deserialize a warp schedule from an `scf.for` op using the attributes
   // tagged on operations in its body.
   static FailureOr<WarpSchedule> deserialize(scf::ForOp loop);
-  // Serialize a warp schedule by writing the partition stage and mappings
-  // as attributes on operations in the loop.
-  void serialize(scf::ForOp loop) const;
-  // Verify that the warp schedule is valid by checking the SSA dependencies
-  // between the schedules.
-  LogicalResult verify(scf::ForOp loop) const;
-  // Remove partition attributes.
-  static void eraseFrom(scf::ForOp loop);
 
   // Iterate the inputs of the partition. Input values are those that originate
   // from a different partition or a previous iteration of the current
@@ -138,15 +108,13 @@ private:
   int tag;
   // Partitions are numbered [0, N).
   SmallVector<std::unique_ptr<Partition>> partitions;
-  // A mapping from operation to its partition.
-  DenseMap<Operation *, Partition *> opToPartition;
-  // The root partition contains operations that are not assigned to a
-  // partition. Operations not assigned to partitions are assumed to be "free"
-  // and can be cloned as necessary.
-  std::unique_ptr<Partition> rootPartition =
-      std::make_unique<Partition>(kSentinel, kSentinel);
 };
 
+void setPartition(Operation *op, Partition *partition);
+void setPartition(Operation *op, const SetVector<int> &partitionIds);
+std::optional<SetVector<int>> getPartitionIds(Operation *op);
+bool hasPartition(Operation *op);
+bool isOpInPartition(Operation *op, const Partition *partition);
 Partition *getPartition(Operation *op, WarpSchedule &schedule);
 
 } // namespace mlir::triton::gpu

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -35,6 +35,7 @@ public:
   int getIndex() const { return idx; }
   int getStage() const { return stage; }
   ArrayRef<Operation *> getOps() const { return ops; }
+  void addOp(Operation* op) {ops.push_back(op);}
 
 private:
   void setIndex(int idx) { this->idx = idx; }

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -38,6 +38,7 @@ public:
   int getStage() const { return stage; }
   ArrayRef<Operation *> getOps() const { return ops; }
   void addOp(Operation *op) { ops.push_back(op); }
+  bool hasOp(Operation *op) const;
 
   // Iterate the inputs of the partition. Input values are those that originate
   // from a different partition or a previous iteration of the current

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -21,7 +21,7 @@ static constexpr char kPartitionStagesAttrName[] = "ttg.partition.stages";
 static constexpr char kWarpSpecializeTagAttrName[] = "ttg.warp_specialize.tag";
 
 //===----------------------------------------------------------------------===//
-// PartitionSet
+// WarpSchedule
 //===----------------------------------------------------------------------===//
 
 namespace mlir::triton::gpu {
@@ -54,7 +54,7 @@ private:
 // A warp schedule divides a loop into multiple partitions. Ops in a loop are
 // assigned at most one partition. A warp schedule represents asynchronous
 // execution of the loop body, where partitions may execute simultaneously.
-class PartitionSet {
+class WarpSchedule {
 public:
   // Get WarpSpecialization tag
   int getTag() const { return tag; }
@@ -75,7 +75,7 @@ public:
 
   // Deserialize a warp schedule from an `scf.for` op using the attributes
   // tagged on operations in its body.
-  static FailureOr<PartitionSet> deserialize(scf::ForOp loop);
+  static FailureOr<WarpSchedule> deserialize(scf::ForOp loop);
 
   // Debug dump the schedule.
   LLVM_DUMP_METHOD void dump() const;
@@ -92,7 +92,7 @@ void setPartition(Operation *op, const SetVector<int> &partitionIds);
 std::optional<SetVector<int>> getPartitionIds(Operation *op);
 bool hasPartition(Operation *op);
 // Utility to be used when the op is known to belong to one partition
-Partition *getPartition(Operation *op, PartitionSet &schedule);
+Partition *getPartition(Operation *op, WarpSchedule &schedule);
 
 // Iterate the inputs of the partition. Input values are those that originate
 // from a different partition or a previous iteration of the current

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -75,7 +75,7 @@ public:
 
   // Deserialize a partition set from an `scf.for` op using the attributes
   // tagged on operations in its body.
-  static FailureOr<PartitionSet> deserialize(scf::ForOp loop);
+  static FailureOr<PartitionSet> fromLoop(scf::ForOp loop);
 
   // Debug dump the partition set.
   LLVM_DUMP_METHOD void dump() const;

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -201,12 +201,6 @@ findSharedMemorySinkOps(Value value, SmallVectorImpl<Operation *> &sinkOps) {
   return success();
 }
 
-Partition *getPartition(Operation *op, WarpSchedule &schedule) {
-  auto id = getPartitionIds(op);
-  assert(id && id->size() == 1);
-  return schedule.getPartition((*id)[0]);
-}
-
 LogicalResult PipelinedLoad::determineLiveRange(Block &container,
                                                 DominanceInfo &domInfo,
                                                 PostDominanceInfo &postDomInfo,

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -913,16 +913,13 @@ void LoadMMASpecialization::runOnOperation() {
   });
   for (scf::ForOp loop : loops) {
     FailureOr<WarpSchedule> schedule = WarpSchedule::deserialize(loop);
-    if (failed(schedule)) {
-      llvm::outs() << "foo\n";
+    if (failed(schedule))
       continue;
-    }
-      llvm::outs() << "bar\n";
-    // auto [loads, mmas] = getPartitionScheme(loop);
-    // if (loads.empty() && mmas.empty())
-    //   continue;
-    // int loopNumStages = getNumStagesOrDefault(loop, numStages);
-    // if (failed(lowerLoops(loop, loads, mmas, *schedule, loopNumStages)))
-    //   continue;
+    auto [loads, mmas] = getPartitionScheme(loop);
+    if (loads.empty() && mmas.empty())
+      continue;
+    int loopNumStages = getNumStagesOrDefault(loop, numStages);
+    if (failed(lowerLoops(loop, loads, mmas, *schedule, loopNumStages)))
+      continue;
   }
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -908,7 +908,7 @@ void LoadMMASpecialization::runOnOperation() {
       loops.push_back(loop);
   });
   for (scf::ForOp loop : loops) {
-    FailureOr<PartitionSet> partitions = PartitionSet::deserialize(loop);
+    FailureOr<PartitionSet> partitions = PartitionSet::fromLoop(loop);
     if (failed(partitions))
       continue;
     auto [loads, mmas] = getPartitionScheme(loop);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -471,7 +471,8 @@ LogicalResult PipelinedLoadGroup::lowerLoads(PartitionSet &partitions,
 //===----------------------------------------------------------------------===//
 
 static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
-                                 PartitionSet &partitions, DominanceInfo &domInfo,
+                                 PartitionSet &partitions,
+                                 DominanceInfo &domInfo,
                                  PostDominanceInfo &postDomInfo) {
   ttng::MMAv5OpInterface mmaOp = mma.mmaOp;
   auto fail = [&](StringRef msg) { return emitWarning(mmaOp.getLoc(), msg); };
@@ -673,7 +674,8 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
     defOp = inBody(defOp);
     auto partitionIds = getPartitionIds(defOp);
 
-    if (!partitionIds || partitionIds->size() == partitions.getNumPartitions()) {
+    if (!partitionIds ||
+        partitionIds->size() == partitions.getNumPartitions()) {
       // If the MMA operand is coming from outside the loop, move the alloc out.
       auto allocOp = dyn_cast<LocalAllocOp>(defOp);
       if (allocOp && loop.isDefinedOutsideOfLoop(allocOp.getSrc()))

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -420,7 +420,7 @@ LogicalResult PipelinedLoadGroup::lowerLoads(WarpSchedule &schedule,
       b.setInsertionPoint(liveUntilOp);
       auto arriveOp = b.createInto<ttng::ArriveBarrierOp>(
           userPartition, userStageCluster, curEmptyBar, 1);
-      arriveOps[schedule.getPartition(liveUntilOp)] = arriveOp;
+      arriveOps[getPartition(liveUntilOp, schedule)] = arriveOp;
     }
   }
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -39,7 +39,7 @@ struct PipelinedLoad {
   }
   LogicalResult determineLiveRange(Block &container, DominanceInfo &domInfo,
                                    PostDominanceInfo &postDomInfo,
-                                   WarpSchedule &schedule);
+                                   PartitionSet &schedule);
 
   Operation *loadOp;
   RankedTensorType type;
@@ -204,7 +204,7 @@ findSharedMemorySinkOps(Value value, SmallVectorImpl<Operation *> &sinkOps) {
 LogicalResult PipelinedLoad::determineLiveRange(Block &container,
                                                 DominanceInfo &domInfo,
                                                 PostDominanceInfo &postDomInfo,
-                                                WarpSchedule &schedule) {
+                                                PartitionSet &schedule) {
   // Find the liveBefore and liveUntil operations of the load.
   llvm::MapVector<Partition *, SmallVector<Operation *>> regSinks, shmemSinks;
   for (Operation *user : loadOp->getUsers()) {
@@ -294,7 +294,7 @@ namespace {
 struct PipelinedLoadGroup {
   Location getLoc();
   void allocateAref(scf::ForOp &loop, int numStages);
-  LogicalResult lowerLoads(WarpSchedule &schedule, DominanceInfo &domInfo,
+  LogicalResult lowerLoads(PartitionSet &schedule, DominanceInfo &domInfo,
                            PostDominanceInfo &postDomInfo);
 
   SmallVector<PipelinedLoad> loads;
@@ -365,7 +365,7 @@ static void lowerTMACopy(PartitionBuilder &b, Partition &loadPartition,
   }
 }
 
-LogicalResult PipelinedLoadGroup::lowerLoads(WarpSchedule &schedule,
+LogicalResult PipelinedLoadGroup::lowerLoads(PartitionSet &schedule,
                                              DominanceInfo &domInfo,
                                              PostDominanceInfo &postDomInfo) {
   // Insert before the group of loads.
@@ -471,7 +471,7 @@ LogicalResult PipelinedLoadGroup::lowerLoads(WarpSchedule &schedule,
 //===----------------------------------------------------------------------===//
 
 static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
-                                 WarpSchedule &schedule, DominanceInfo &domInfo,
+                                 PartitionSet &schedule, DominanceInfo &domInfo,
                                  PostDominanceInfo &postDomInfo) {
   ttng::MMAv5OpInterface mmaOp = mma.mmaOp;
   auto fail = [&](StringRef msg) { return emitWarning(mmaOp.getLoc(), msg); };
@@ -844,7 +844,7 @@ static LogicalResult pipelineMMA(scf::ForOp &loop, PipelinedMMA &mma,
 
 LogicalResult lowerLoops(scf::ForOp &loop, MutableArrayRef<PipelinedLoad> loads,
                          MutableArrayRef<PipelinedMMA> mmas,
-                         WarpSchedule &schedule, int numLoadStages) {
+                         PartitionSet &schedule, int numLoadStages) {
   Block &body = *loop.getBody();
   DominanceInfo domInfo(loop);
   PostDominanceInfo postDomInfo(loop);
@@ -906,7 +906,7 @@ void LoadMMASpecialization::runOnOperation() {
       loops.push_back(loop);
   });
   for (scf::ForOp loop : loops) {
-    FailureOr<WarpSchedule> schedule = WarpSchedule::deserialize(loop);
+    FailureOr<PartitionSet> schedule = PartitionSet::deserialize(loop);
     if (failed(schedule))
       continue;
     auto [loads, mmas] = getPartitionScheme(loop);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -93,9 +93,9 @@ void setPartition(Operation *op, Partition *partition) {
   partition->addOp(op);
 }
 
-void setPartition(Operation *op, const SetVector<Partition*> &partitions) {
+void setPartition(Operation *op, const SetVector<Partition *> &partitions) {
   SmallVector<int> partitionIds;
-  for (auto partition: partitions) {
+  for (auto partition : partitions) {
     partitionIds.push_back(partition->getIndex());
     partition->addOp(op);
   }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -41,6 +41,9 @@ std::optional<SetVector<int>> getPartitionIds(Operation *op) {
   if (!attrs) {
     return std::nullopt;
   }
+  if (!isa<DenseI32ArrayAttr>(attrs)) {
+    op->dump();
+  }
   SetVector<int> partitionIds;
   for (auto id : cast<DenseI32ArrayAttr>(attrs).asArrayRef()) {
     partitionIds.insert(id);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -26,7 +26,7 @@ const Partition *PartitionSet::getPartition(unsigned idx) const {
   return partitions[idx].get();
 }
 
-FailureOr<PartitionSet> PartitionSet::deserialize(scf::ForOp loop) {
+FailureOr<PartitionSet> PartitionSet::fromLoop(scf::ForOp loop) {
   auto stages = loop->getAttrOfType<ArrayAttr>(kPartitionStagesAttrName);
   if (!stages)
     return failure();

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -118,14 +118,6 @@ std::optional<SetVector<int>> getPartitionIds(Operation *op) {
 
 bool hasPartition(Operation *op) { return getPartitionIds(op) != std::nullopt; }
 
-bool isOpInPartition(Operation *op, const Partition *partition) {
-  auto partitionIds = getPartitionIds(op);
-  if (!partitionIds) {
-    return false;
-  }
-  return partitionIds->contains(partition->getIndex());
-}
-
 void iterateInputs(scf::ForOp loop, const Partition *partition,
                    function_ref<void(OpOperand &)> callback) {
   for (Operation *op : partition->getOps()) {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -11,22 +11,22 @@ using namespace triton;
 using namespace triton::gpu;
 
 //===----------------------------------------------------------------------===//
-// PartitionSet
+// WarpSchedule
 //===----------------------------------------------------------------------===//
 
-Partition *PartitionSet::addPartition(unsigned stage) {
+Partition *WarpSchedule::addPartition(unsigned stage) {
   partitions.push_back(std::make_unique<Partition>(partitions.size(), stage));
   return partitions.back().get();
 }
 
-Partition *PartitionSet::getPartition(unsigned idx) {
+Partition *WarpSchedule::getPartition(unsigned idx) {
   return partitions[idx].get();
 }
-const Partition *PartitionSet::getPartition(unsigned idx) const {
+const Partition *WarpSchedule::getPartition(unsigned idx) const {
   return partitions[idx].get();
 }
 
-FailureOr<PartitionSet> PartitionSet::deserialize(scf::ForOp loop) {
+FailureOr<WarpSchedule> WarpSchedule::deserialize(scf::ForOp loop) {
   auto stages = loop->getAttrOfType<ArrayAttr>(kPartitionStagesAttrName);
   if (!stages)
     return failure();
@@ -35,7 +35,7 @@ FailureOr<PartitionSet> PartitionSet::deserialize(scf::ForOp loop) {
   if (!tag)
     return failure();
 
-  PartitionSet result;
+  WarpSchedule result;
   result.tag = tag.getInt();
   for (auto [idx, attr] : llvm::enumerate(stages)) {
     auto stage = dyn_cast<IntegerAttr>(attr);
@@ -62,7 +62,7 @@ FailureOr<PartitionSet> PartitionSet::deserialize(scf::ForOp loop) {
   return result;
 }
 
-void PartitionSet::dump() const {
+void WarpSchedule::dump() const {
   for (auto [i, partition] :
        llvm::enumerate(llvm::make_pointee_range(partitions))) {
     llvm::errs() << "=== PARTITION #" << i << " ===\n";
@@ -192,7 +192,7 @@ void iterateUses(scf::ForOp loop, const Partition *partition,
   }
 }
 
-Partition *getPartition(Operation *op, PartitionSet &schedule) {
+Partition *getPartition(Operation *op, WarpSchedule &schedule) {
   auto id = getPartitionIds(op);
   assert(id && id->size() == 1);
   return schedule.getPartition((*id)[0]);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -22,8 +22,20 @@ Partition *PartitionSet::addPartition(unsigned stage) {
 Partition *PartitionSet::getPartition(unsigned idx) {
   return partitions[idx].get();
 }
+
 const Partition *PartitionSet::getPartition(unsigned idx) const {
   return partitions[idx].get();
+}
+
+Partition *PartitionSet::getPartition(Operation *op) {
+  auto id = getPartitionIds(op);
+  assert(id && id->size() == 1);
+  return getPartition((*id)[0]);
+}
+
+bool PartitionSet::isInRootPartition(Operation *op) {
+  auto partitionIds = getPartitionIds(op);
+  return !partitionIds || partitionIds->size() == getNumPartitions();
 }
 
 FailureOr<PartitionSet> PartitionSet::fromLoop(scf::ForOp loop) {
@@ -120,18 +132,7 @@ std::optional<SetVector<int>> getPartitionIds(Operation *op) {
   return partitionIds;
 }
 
-Partition *getPartition(Operation *op, PartitionSet &partitions) {
-  auto id = getPartitionIds(op);
-  assert(id && id->size() == 1);
-  return partitions.getPartition((*id)[0]);
-}
-
 bool hasPartition(Operation *op) { return getPartitionIds(op) != std::nullopt; }
-
-bool isInRootPartition(Operation *op, PartitionSet &partitions) {
-  auto partitionIds = getPartitionIds(op);
-  return !partitionIds || partitionIds->size() == partitions.getNumPartitions();
-}
 
 void Partition::iterateInputs(scf::ForOp loop,
                               function_ref<void(OpOperand &)> callback) const {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -199,7 +199,7 @@ void WarpSchedule::iterateInputs(
         // This value originates from a previous iteration.
         assert(llvm::is_contained(loop.getRegionIterArgs(), arg));
         callback(operand);
-      } else if (partitionIds &&
+      } else if (!partitionIds ||
                  !llvm::is_contained(*partitionIds, partition->getIndex())) {
         // This value originates from a different partition in the same
         // iteration.
@@ -220,7 +220,7 @@ void WarpSchedule::iterateOutputs(
       if (isa<scf::YieldOp>(owner)) {
         // This value is used in a subsequent iteration.
         callback(owner, use);
-      } else if (partitionIds &&
+      } else if (!partitionIds ||
                  !llvm::is_contained(*partitionIds, partition->getIndex())) {
         // This value is used in a different partition in the same iteration.
         callback(owner, use);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -1,4 +1,5 @@
 #include "triton/Dialect/TritonGPU/Transforms/Partition.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "llvm/ADT/SCCIterator.h"
@@ -18,8 +19,8 @@ bool setPartition(Operation *op, Partition *partition) {
   }
 
   Builder b(op->getContext());
-  SmallVector<Attribute, 4> attrs{b.getI32IntegerAttr(partition->getIndex())};
-  op->setAttr(kPartitionAttrName, ArrayAttr::get(op->getContext(), attrs));
+  SmallVector<int> partitions{partition->getIndex()};
+  op->setAttr(kPartitionAttrName, b.getDenseI32ArrayAttr(partitions));
   partition->addOp(op);
   return true;
 }
@@ -33,8 +34,8 @@ std::optional<SetVector<int>> getPartitionIds(Operation *op) {
     return std::nullopt;
   }
   SetVector<int> partitionIds;
-  for (auto attr : cast<ArrayAttr>(attrs)) {
-    partitionIds.insert(cast<IntegerAttr>(attr).getInt());
+  for (auto id : cast<DenseI32ArrayAttr>(attrs).asArrayRef()) {
+    partitionIds.insert(id);
   }
   return partitionIds;
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -276,3 +276,13 @@ void WarpSchedule::dump() const {
   }
   llvm::errs() << "\n";
 }
+
+namespace mlir::triton::gpu {
+
+Partition *getPartition(Operation *op, WarpSchedule &schedule) {
+  auto id = getPartitionIds(op);
+  assert(id && id->size() == 1);
+  return schedule.getPartition((*id)[0]);
+}
+
+} // namespace mlir::triton::gpu

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -18,9 +18,11 @@ Partition *WarpSchedule::addPartition(unsigned stage) {
 }
 
 Partition *WarpSchedule::getPartition(Operation *op) {
+  assert(false);
   return opToPartition.lookup(op);
 }
 const Partition *WarpSchedule::getPartition(Operation *op) const {
+  assert(false);
   return opToPartition.lookup(op);
 }
 
@@ -32,16 +34,19 @@ const Partition *WarpSchedule::getPartition(unsigned idx) const {
 }
 
 void WarpSchedule::insert(Partition *partition, Operation *op) {
+  assert(false);
   partition->ops.push_back(op);
   opToPartition[op] = partition;
 }
 
 bool WarpSchedule::isScheduled(Operation *op) const {
+  assert(false);
   const Partition *partition = getPartition(op);
   return partition && partition != getRootPartition();
 }
 
 bool WarpSchedule::trySchedule(Partition *partition, Operation *op) {
+  assert(false);
   if (isScheduled(op))
     return false;
   insert(partition, op);
@@ -49,6 +54,7 @@ bool WarpSchedule::trySchedule(Partition *partition, Operation *op) {
 }
 
 FailureOr<WarpSchedule> WarpSchedule::deserialize(scf::ForOp loop) {
+  assert(false);
   auto stages = loop->getAttrOfType<ArrayAttr>(kPartitionStagesAttrName);
   if (!stages)
     return failure();
@@ -85,6 +91,7 @@ FailureOr<WarpSchedule> WarpSchedule::deserialize(scf::ForOp loop) {
 }
 
 void WarpSchedule::serialize(scf::ForOp loop) const {
+  assert(false);
   SmallVector<Attribute> stages;
   Builder b(loop.getContext());
   for (Operation &op : loop.getBody()->without_terminator()) {
@@ -101,6 +108,7 @@ void WarpSchedule::serialize(scf::ForOp loop) const {
 }
 
 LogicalResult WarpSchedule::verify(scf::ForOp loop) const {
+  assert(false);
   // The root partition is only allowed to transitively depend on itself.
   bool failed = false;
   iterateInputs(loop, getRootPartition(), [&](OpOperand &input) {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -225,6 +225,12 @@ void WarpSchedule::iterateOutputs(
     scf::ForOp loop, const Partition *partition,
     function_ref<void(Operation *, OpOperand &)> callback) const {
   for (Operation *op : partition->getOps()) {
+    // TODO: Is this correct
+    if (getPartitionIds(op)->size() == getNumPartitions()) {
+      // skip ops in the root partition
+      continue;
+    }
+
     for (OpOperand &use : op->getUses()) {
       Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
       auto partitionIds = getPartitionIds(owner);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -225,12 +225,6 @@ void WarpSchedule::iterateOutputs(
     scf::ForOp loop, const Partition *partition,
     function_ref<void(Operation *, OpOperand &)> callback) const {
   for (Operation *op : partition->getOps()) {
-    // TODO: Is this correct
-    if (getPartitionIds(op)->size() == getNumPartitions()) {
-      // skip ops in the root partition
-      continue;
-    }
-
     for (OpOperand &use : op->getUses()) {
       Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
       auto partitionIds = getPartitionIds(owner);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -11,22 +11,22 @@ using namespace triton;
 using namespace triton::gpu;
 
 //===----------------------------------------------------------------------===//
-// WarpSchedule
+// PartitionSet
 //===----------------------------------------------------------------------===//
 
-Partition *WarpSchedule::addPartition(unsigned stage) {
+Partition *PartitionSet::addPartition(unsigned stage) {
   partitions.push_back(std::make_unique<Partition>(partitions.size(), stage));
   return partitions.back().get();
 }
 
-Partition *WarpSchedule::getPartition(unsigned idx) {
+Partition *PartitionSet::getPartition(unsigned idx) {
   return partitions[idx].get();
 }
-const Partition *WarpSchedule::getPartition(unsigned idx) const {
+const Partition *PartitionSet::getPartition(unsigned idx) const {
   return partitions[idx].get();
 }
 
-FailureOr<WarpSchedule> WarpSchedule::deserialize(scf::ForOp loop) {
+FailureOr<PartitionSet> PartitionSet::deserialize(scf::ForOp loop) {
   auto stages = loop->getAttrOfType<ArrayAttr>(kPartitionStagesAttrName);
   if (!stages)
     return failure();
@@ -35,7 +35,7 @@ FailureOr<WarpSchedule> WarpSchedule::deserialize(scf::ForOp loop) {
   if (!tag)
     return failure();
 
-  WarpSchedule result;
+  PartitionSet result;
   result.tag = tag.getInt();
   for (auto [idx, attr] : llvm::enumerate(stages)) {
     auto stage = dyn_cast<IntegerAttr>(attr);
@@ -62,7 +62,7 @@ FailureOr<WarpSchedule> WarpSchedule::deserialize(scf::ForOp loop) {
   return result;
 }
 
-void WarpSchedule::dump() const {
+void PartitionSet::dump() const {
   for (auto [i, partition] :
        llvm::enumerate(llvm::make_pointee_range(partitions))) {
     llvm::errs() << "=== PARTITION #" << i << " ===\n";
@@ -192,10 +192,10 @@ void iterateUses(scf::ForOp loop, const Partition *partition,
   }
 }
 
-Partition *getPartition(Operation *op, WarpSchedule &schedule) {
+Partition *getPartition(Operation *op, PartitionSet &partitions) {
   auto id = getPartitionIds(op);
   assert(id && id->size() == 1);
-  return schedule.getPartition((*id)[0]);
+  return partitions.getPartition((*id)[0]);
 }
 
 } // namespace mlir::triton::gpu

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -13,7 +13,8 @@ namespace mlir::triton::gpu {
 
 bool setPartition(Operation *op, Partition *partition) {
   if (op->getAttr(kPartitionAttrName)) {
-    // TODO: what to do in this case
+    // Allow overwriting in this case
+    // TODO: is this the right thing to do
   }
 
   Builder b(op->getContext());

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -12,17 +12,25 @@ using namespace triton::gpu;
 
 namespace mlir::triton::gpu {
 
-bool setPartition(Operation *op, Partition *partition) {
+void setPartition(Operation *op, ArrayRef<int> partitionIds) {
+  Builder b(op->getContext());
+  op->setAttr(kPartitionAttrName, b.getDenseI32ArrayAttr(partitionIds));
+}
+
+void setPartition(Operation *op, const SetVector<int>& partitionIds) {
+  SmallVector<int> partitions(partitionIds.begin(), partitionIds.end());
+  setPartition(op, partitions);
+}
+
+void setPartition(Operation *op, Partition *partition) {
   if (op->getAttr(kPartitionAttrName)) {
     // Allow overwriting in this case
     // TODO: is this the right thing to do
   }
 
-  Builder b(op->getContext());
   SmallVector<int> partitions{partition->getIndex()};
-  op->setAttr(kPartitionAttrName, b.getDenseI32ArrayAttr(partitions));
+  setPartition(op, partitions);
   partition->addOp(op);
-  return true;
 }
 
 std::optional<SetVector<int>> getPartitionIds(Operation *op) {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -98,6 +98,15 @@ void setPartition(Operation *op, Partition *partition) {
   partition->addOp(op);
 }
 
+void setPartition(Operation *op, const SetVector<Partition*> &partitions) {
+  SmallVector<int> partitionIds;
+  for (auto partition: partitions) {
+    partitionIds.push_back(partition->getIndex());
+    partition->addOp(op);
+  }
+  setPartition(op, partitionIds);
+}
+
 std::optional<SetVector<int>> getPartitionIds(Operation *op) {
   if (!op) {
     return std::nullopt;

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionBuilder.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionBuilder.cpp
@@ -22,7 +22,7 @@ void PartitionBuilder::assignStage(Operation *op, StageCluster stageCluster) {
 }
 
 void PartitionBuilder::assignPartition(Operation *op, Partition &partition) {
-  op->setAttr(kPartitionAttrName, getI32IntegerAttr(partition.getIndex()));
+  setPartition(op, &partition);
 }
 
 StageCluster triton::gpu::getStageCluster(Operation *op) {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -344,6 +344,11 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
   for (const Partition &partition : schedule.getPartitions()) {
     bool failed = false;
     auto callback = [&](OpResult output, OpOperand &use, unsigned distance) {
+      auto defOpPartitionIds = getPartitionIds(output.getDefiningOp());
+      if (!defOpPartitionIds ||
+          defOpPartitionIds->size() == schedule.getNumPartitions()) {
+        return;
+      }
       auto partitionIds = getPartitionIds(use.getOwner());
       if (!partitionIds ||
           partitionIds->size() == schedule.getNumPartitions() ||

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -55,7 +55,7 @@ bool isTensorResultComputedBy(scf::ForOp loop, size_t resultIdx,
                               const Partition *partition,
                               const WarpSchedule &schedule) {
   bool ret = false;
-  schedule.iterateOutputs(loop, partition, [&](Operation *op, OpOperand &use) {
+  iterateOutputs(loop, partition, [&](Operation *op, OpOperand &use) {
     if (isa<scf::YieldOp>(op) && use.getOperandNumber() == resultIdx &&
         isa<RankedTensorType>(loop.getResult(resultIdx).getType())) {
       ret = true;
@@ -400,7 +400,7 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
             << partitionId << " here";
       }
     };
-    schedule.iterateUses(loop, &partition, callback);
+    iterateUses(loop, &partition, callback);
     if (failed)
       return failure();
   }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -363,7 +363,7 @@ void assignRegionBodyPartition(scf::ForOp loop) {
 } // namespace
 
 LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
-  FailureOr<PartitionSet> partitionsOr = PartitionSet::deserialize(loop);
+  FailureOr<PartitionSet> partitionsOr = PartitionSet::fromLoop(loop);
   if (failed(partitionsOr))
     return failure();
   PartitionSet partitions = std::move(*partitionsOr);
@@ -535,7 +535,7 @@ struct PartitionLoops
 
 void PartitionLoops::runOnOperation() {
   // Collect for loops to warp specialize. This pass expects the loop to already
-  // be scheduled.
+  // be annotated with partitions.
   SmallVector<scf::ForOp> loops;
   getOperation().walk([&](scf::ForOp loop) {
     if (loop->hasAttrOfType<ArrayAttr>(kPartitionStagesAttrName))

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -53,7 +53,7 @@ enum class LoopVarCategory {
 
 bool isTensorResultComputedBy(scf::ForOp loop, size_t resultIdx,
                               const Partition *partition,
-                              const PartitionSet &schedule) {
+                              const WarpSchedule &schedule) {
   bool ret = false;
   iterateOutputs(loop, partition, [&](Operation *op, OpOperand &use) {
     if (isa<scf::YieldOp>(op) && use.getOperandNumber() == resultIdx &&
@@ -77,7 +77,7 @@ SmallVector<size_t> getPartitionIds(Operation *op, size_t numPartitions) {
 
 SmallVector<LoopVarCategory> classifyLoopVars(scf::ForOp loop,
                                               const Partition *partition,
-                                              const PartitionSet &schedule) {
+                                              const WarpSchedule &schedule) {
   auto inPartition = [&](Operation *op) {
     auto opPartitionIds = getPartitionIds(op, schedule.getNumPartitions());
     return llvm::is_contained(opPartitionIds, partition->getIndex());
@@ -133,7 +133,7 @@ getLoopVarIndicesToKeep(scf::ForOp loop, const Partition *partition,
 
 std::pair<SmallVector<size_t>, SmallVector<std::optional<size_t>>>
 getLoopVarIndicesToKeep(scf::ForOp loop, const Partition *partition,
-                        const PartitionSet &schedule) {
+                        const WarpSchedule &schedule) {
   auto loopVarCategories = classifyLoopVars(loop, partition, schedule);
   return getLoopVarIndicesToKeep(loop, partition, loopVarCategories);
 }
@@ -152,10 +152,10 @@ int getPartitionIndex(Operation *op) {
 }
 
 void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
-                     const PartitionSet &schedule);
+                     const WarpSchedule &schedule);
 
 void cloneForOp(scf::ForOp forOp, SmallVector<WarpGroupBuilder> &builders,
-                const PartitionSet &schedule) {
+                const WarpSchedule &schedule) {
   SmallVector<scf::ForOp> newForOps;
   for (auto [b, partition] : llvm::zip(builders, schedule.getPartitions())) {
     auto [newLoopIndices, _] =
@@ -194,7 +194,7 @@ void cloneForOp(scf::ForOp forOp, SmallVector<WarpGroupBuilder> &builders,
 }
 
 void cloneIfOp(scf::IfOp ifOp, SmallVector<WarpGroupBuilder> &builders,
-               const PartitionSet &schedule) {
+               const WarpSchedule &schedule) {
   auto partitionIndices = getPartitionIds(ifOp, schedule.getNumPartitions());
 
   SmallVector<scf::IfOp> newIfOps;
@@ -234,7 +234,7 @@ void cloneIfOp(scf::IfOp ifOp, SmallVector<WarpGroupBuilder> &builders,
 
 void cloneReduceOp(triton::ReduceOp reduceOp,
                    SmallVector<WarpGroupBuilder> &builders,
-                   const PartitionSet &schedule) {
+                   const WarpSchedule &schedule) {
   auto partitionIndices =
       getPartitionIds(reduceOp, schedule.getNumPartitions());
 
@@ -286,7 +286,7 @@ void cloneOp(Operation *op, SmallVector<WarpGroupBuilder> &builders,
 }
 
 void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
-                     const PartitionSet &schedule) {
+                     const WarpSchedule &schedule) {
   for (auto &op_ : *block) {
     auto op = &op_;
     auto partitionIndices = getPartitionIds(op, schedule.getNumPartitions());
@@ -362,10 +362,10 @@ void assignRegionBodyPartition(scf::ForOp loop) {
 } // namespace
 
 LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
-  FailureOr<PartitionSet> scheduleOr = PartitionSet::deserialize(loop);
+  FailureOr<WarpSchedule> scheduleOr = WarpSchedule::deserialize(loop);
   if (failed(scheduleOr))
     return failure();
-  PartitionSet schedule = std::move(*scheduleOr);
+  WarpSchedule schedule = std::move(*scheduleOr);
 
   assignRootPartition(loop, schedule.getNumPartitions());
   assignRegionBodyPartition(loop);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -55,7 +55,7 @@ bool isTensorResultComputedBy(scf::ForOp loop, size_t resultIdx,
                               const Partition *partition,
                               const PartitionSet &partitions) {
   bool ret = false;
-  iterateOutputs(loop, partition, [&](Operation *op, OpOperand &use) {
+  partition->iterateOutputs(loop, [&](Operation *op, OpOperand &use) {
     if (isa<scf::YieldOp>(op) && use.getOperandNumber() == resultIdx &&
         isa<RankedTensorType>(loop.getResult(resultIdx).getType())) {
       ret = true;
@@ -391,7 +391,7 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
             << partitionId << " here";
       }
     };
-    iterateUses(loop, &partition, callback);
+    partition.iterateUses(loop, callback);
     if (failed)
       return failure();
   }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -308,7 +308,8 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
         if (auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp())) {
           newOperandIndices =
               getLoopVarIndicesToKeep(
-                  forOp, partitions.getPartition(builder.partitionId), partitions)
+                  forOp, partitions.getPartition(builder.partitionId),
+                  partitions)
                   .first;
         } else {
           for (size_t i = 0; i < yieldOp.getOperands().size(); ++i) {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -144,13 +144,6 @@ void mapRange(ValueRange fromRange, ValueRange toRange, IRMapping &mapping) {
   }
 }
 
-// TODO: remove this
-int getPartitionIndex(Operation *op) {
-  if (isa<nvws::WarpGroupOp>(op->getParentOp()))
-    return op->getParentRegion()->getRegionNumber();
-  return getPartitionIndex(op->getParentOp());
-}
-
 void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
                      const PartitionSet &partitions);
 
@@ -186,8 +179,8 @@ void cloneForOp(scf::ForOp forOp, SmallVector<WarpGroupBuilder> &builders,
 
   cloneOpsInBlock(forOp.getBody(), builders, partitions);
 
-  for (auto newForOp : newForOps) {
-    builders[getPartitionIndex(newForOp)].setInsertionPointAfter(newForOp);
+  for (auto [i, newForOp] : enumerate(newForOps)) {
+    builders[i].setInsertionPointAfter(newForOp);
     newForOp.walk([&](Operation *op) { op->removeAttr(kPartitionAttrName); });
     newForOp->removeAttr(kPartitionStagesAttrName);
   }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -188,6 +188,7 @@ void cloneForOp(scf::ForOp forOp, SmallVector<WarpGroupBuilder> &builders,
 
   for (auto newForOp : newForOps) {
     builders[getPartitionIndex(newForOp)].setInsertionPointAfter(newForOp);
+    WarpSchedule::eraseFrom(newForOp);
   }
 }
 
@@ -364,8 +365,8 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
       return failure();
   }
 
-  // There is nothing to do if the loop does not have any partition.
-  if (llvm::size(schedule.getPartitions()) == 0)
+  // There is nothing to do if the loop has 1 or fewer partitions.
+  if (llvm::size(schedule.getPartitions()) <= 1)
     return success();
 
   auto numPartitions = schedule.getNumPartitions();

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -188,7 +188,8 @@ void cloneForOp(scf::ForOp forOp, SmallVector<WarpGroupBuilder> &builders,
 
   for (auto newForOp : newForOps) {
     builders[getPartitionIndex(newForOp)].setInsertionPointAfter(newForOp);
-    WarpSchedule::eraseFrom(newForOp);
+    newForOp.walk([&](Operation *op) { op->removeAttr(kPartitionAttrName); });
+    newForOp->removeAttr(kPartitionStagesAttrName);
   }
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -373,11 +373,11 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
   for (const Partition &partition : partitions.getPartitions()) {
     bool failed = false;
     auto callback = [&](OpResult output, OpOperand &use, unsigned distance) {
-      if (isInRootPartition(output.getDefiningOp(), partitions)) {
+      if (partitions.isInRootPartition(output.getDefiningOp())) {
         return;
       }
       auto partitionIds = getPartitionIds(use.getOwner());
-      if (isInRootPartition(use.getOwner(), partitions) ||
+      if (partitions.isInRootPartition(use.getOwner()) ||
           llvm::is_contained(*partitionIds, partition.getIndex()))
         return;
       failed = true;

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -16,7 +16,7 @@ using namespace triton::gpu;
 namespace ttng = triton::nvidia_gpu;
 
 std::optional<int> getPartitionId(Operation *op) {
-  auto ids = ::getPartitionIds(op);
+  auto ids = getPartitionIds(op);
   if (!ids) {
     return std::nullopt;
   }
@@ -367,10 +367,10 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
     // Look at the definitions directly feeding into this operation.
     iterateDefs(loop, op, [&](OpResult def) {
       Operation *defOp = def.getDefiningOp();
-      if (hasPartition(defOp)) {
+      if (auto partitionId = getPartitionId(defOp)) {
         // The input originates from an operation already assigned to a
         // partition. Add this as a def partition.
-        cluster->defPartitions.insert(schedule.getPartition(defOp));
+        cluster->defPartitions.insert(schedule.getPartition(*partitionId));
       } else {
         // If the input is not reachable from a partition, ignore it.
         if (!hasDefPartition(loop, defOp, schedule))

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -526,11 +526,10 @@ void rematerializeBroadcasts(PartitionSet &partitions, OpOperand *use) {
 void optimizeSchedule(scf::ForOp loop, PartitionSet &partitions) {
   for (Partition &partition : partitions.getPartitions()) {
     SmallVector<OpOperand *> uses;
-    iterateOutputs(loop, &partition,
-                            [&](Operation *defOp, OpOperand &use) {
-                              if (!isa<scf::YieldOp>(use.getOwner()))
-                                uses.push_back(&use);
-                            });
+    iterateOutputs(loop, &partition, [&](Operation *defOp, OpOperand &use) {
+      if (!isa<scf::YieldOp>(use.getOwner()))
+        uses.push_back(&use);
+    });
     for (OpOperand *use : uses)
       rematerializeBroadcasts(partitions, use);
   }
@@ -572,7 +571,7 @@ void PartitionScheduling::runOnOperation() {
       SmallVector<Attribute> stages;
       Builder b(loop.getContext());
       for (Partition &partition : partitions->getPartitions())
-	stages.push_back(b.getI32IntegerAttr(partition.getStage()));
+        stages.push_back(b.getI32IntegerAttr(partition.getStage()));
       loop->setAttr(kPartitionStagesAttrName, b.getArrayAttr(stages));
     }
   }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -153,6 +153,14 @@ static void scheduleUsers(scf::ForOp loop, WarpSchedule &schedule,
   }
 }
 
+static bool isOpInPartition(Operation *op, const Partition *partition) {
+  auto partitionIds = getPartitionIds(op);
+  if (!partitionIds) {
+    return false;
+  }
+  return partitionIds->contains(partition->getIndex());
+}
+
 // Given a partitioning scheme, determine an initial schedule by performing a
 // first-order partition assignment to the operations in the scheme and its
 // users and/or dependencies. This sets up the initial partitioning of the ops.

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -531,11 +531,11 @@ void optimizeSchedule(scf::ForOp loop, WarpSchedule &schedule) {
 void assignRootPartition(scf::ForOp loop, int numPartitions) {
   auto ctx = loop.getContext();
   Builder b(ctx);
-  SmallVector<Attribute, 4> attrs;
+  SmallVector<int> ids;
   for (int i = 0; i < numPartitions; ++i) {
-    attrs.push_back(b.getI32IntegerAttr(i));
+    ids.push_back(i);
   }
-  auto partitionAttr = ArrayAttr::get(ctx, attrs);
+  auto partitionAttr = b.getDenseI32ArrayAttr(ids);
 
   for (Operation &op : loop.getBody()->without_terminator()) {
     if (!hasPartition(&op)) {

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -18,6 +18,7 @@ namespace ttng = triton::nvidia_gpu;
 //===----------------------------------------------------------------------===//
 // assignPartitions
 //===----------------------------------------------------------------------===//
+
 bool trySetPartition(Operation *op, Partition *partition) {
   if (hasPartition(op)) {
     return false;

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -342,7 +342,7 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
         opClusters.getOrCreate(defOp)->sinkPartitions.insert(&partition);
       }
     };
-    schedule.iterateDefs(loop, &partition, defCallback);
+    iterateDefs(loop, &partition, defCallback);
 
     // For each partition, place users of its outputs in a cluster if it is not
     // already assigned to a partition.
@@ -353,7 +353,7 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
         opClusters.getOrCreate(user)->defPartitions.insert(&partition);
       }
     };
-    schedule.iterateUses(loop, &partition, useCallback);
+    iterateUses(loop, &partition, useCallback);
   }
 
   // Now we have a pile of single-operation clusters directly adjacent to the
@@ -455,7 +455,7 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
       if (opsInCluster.contains(defOp))
         critPath.insert(defOp);
     };
-    schedule.iterateDefs(loop, sinkPartition, callback);
+    iterateDefs(loop, sinkPartition, callback);
     for (unsigned i = 0; i < critPath.size(); ++i) {
       Operation *op = critPath[i];
       iterateDefs(loop, op, [&](OpResult def) {
@@ -518,7 +518,7 @@ void rematerializeBroadcasts(WarpSchedule &schedule, OpOperand *use) {
 void optimizeSchedule(scf::ForOp loop, WarpSchedule &schedule) {
   for (Partition &partition : schedule.getPartitions()) {
     SmallVector<OpOperand *> uses;
-    schedule.iterateOutputs(loop, &partition,
+    iterateOutputs(loop, &partition,
                             [&](Operation *defOp, OpOperand &use) {
                               if (!isa<scf::YieldOp>(use.getOwner()))
                                 uses.push_back(&use);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -159,11 +159,6 @@ static void scheduleUsers(scf::ForOp loop, WarpSchedule &schedule,
 // first-order partition assignment to the operations in the scheme and its
 // users and/or dependencies. This sets up the initial partitioning of the ops.
 static std::optional<WarpSchedule> getInitialSchedule(scf::ForOp loop) {
-  // Check for an existing schedule.
-  if (FailureOr<WarpSchedule> scheduleOr = WarpSchedule::deserialize(loop);
-      succeeded(scheduleOr))
-    return {std::move(*scheduleOr)};
-
   // Start by creating the default partition, a partition for for all loads, and
   // a partition for all MMAs.
   WarpSchedule schedule;
@@ -357,7 +352,6 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
         opClusters.getOrCreate(user)->defPartitions.insert(&partition);
       }
     };
-    // TODO
     schedule.iterateUses(loop, &partition, useCallback);
   }
 
@@ -456,7 +450,6 @@ void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
       if (opsInCluster.contains(defOp))
         critPath.insert(defOp);
     };
-    // TODO
     schedule.iterateDefs(loop, sinkPartition, callback);
     for (unsigned i = 0; i < critPath.size(); ++i) {
       Operation *op = critPath[i];

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -24,7 +24,7 @@ bool setPartition(Operation *op, Partition *partition) {
   Builder b(op->getContext());
   SmallVector<Attribute, 4> attrs{b.getI32IntegerAttr(partition->getIndex())};
   op->setAttr(kPartitionAttrName, ArrayAttr::get(op->getContext(), attrs));
-  // TODO: Add op into the op list of partition?
+  partition->addOp(op);
   return true;
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -84,7 +84,7 @@ static void iterateUsers(scf::ForOp loop, Operation *op,
 
 // Check if any of the inputs to `op` are reachable from a non-null partition.
 static bool hasDefPartition(scf::ForOp loop, Operation *op,
-                            PartitionSet &schedule) {
+                            WarpSchedule &schedule) {
   SmallVector<Operation *> worklist{op};
   DenseSet<Operation *> seen;
   while (!worklist.empty()) {
@@ -102,7 +102,7 @@ static bool hasDefPartition(scf::ForOp loop, Operation *op,
 
 // Recursively schedule the dependencies of an operation, stopping when
 // encountering an operation that is already assigned.
-static void scheduleDependencies(scf::ForOp loop, PartitionSet &schedule,
+static void scheduleDependencies(scf::ForOp loop, WarpSchedule &schedule,
                                  Partition *partition, Operation *op) {
   SmallVector<Value> deps;
   for (Value value : getNestedOperands(op)) {
@@ -130,7 +130,7 @@ static void scheduleDependencies(scf::ForOp loop, PartitionSet &schedule,
 
 // Recursively schedule the users of an operation, stopping when
 // encountering an operation that is already assigned.
-static void scheduleUsers(scf::ForOp loop, PartitionSet &schedule,
+static void scheduleUsers(scf::ForOp loop, WarpSchedule &schedule,
                           Partition *partition, Operation *op) {
   SmallVector<OpOperand *> uses;
   for (OpOperand &use : op->getUses())
@@ -164,14 +164,14 @@ static bool isOpInPartition(Operation *op, const Partition *partition) {
 // Given a partitioning scheme, determine an initial schedule by performing a
 // first-order partition assignment to the operations in the scheme and its
 // users and/or dependencies. This sets up the initial partitioning of the ops.
-static std::optional<PartitionSet> getInitialSchedule(scf::ForOp loop) {
+static std::optional<WarpSchedule> getInitialSchedule(scf::ForOp loop) {
   // Check for an existing schedule.
-  if (FailureOr<PartitionSet> scheduleOr = PartitionSet::deserialize(loop);
+  if (FailureOr<WarpSchedule> scheduleOr = WarpSchedule::deserialize(loop);
       succeeded(scheduleOr))
     return {std::move(*scheduleOr)};
   // Start by creating the default partition, a partition for for all loads, and
   // a partition for all MMAs.
-  PartitionSet schedule;
+  WarpSchedule schedule;
   Partition *defaultPartition = schedule.addPartition(0);
   Partition *mmaPartition = schedule.addPartition(1);
   Partition *loadPartition = schedule.addPartition(0);
@@ -337,7 +337,7 @@ struct OpClusters : public llvm::MapVector<Operation *, OpCluster *> {
 // operation in a partition. This function propagates partitions by first
 // forming contiguous clusters from the unassigned operations and then deciding
 // what to do with the operations in that cluster.
-void propagatePartitions(scf::ForOp loop, PartitionSet &schedule) {
+void propagatePartitions(scf::ForOp loop, WarpSchedule &schedule) {
   OpClusters opClusters;
 
   for (Partition &partition : schedule.getPartitions()) {
@@ -502,7 +502,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule) {
 
 // Rematerialize chains of broadcasts where the user is in a different partition
 // than the broadcast to reduce the amount of data that needs to be transferred.
-void rematerializeBroadcasts(PartitionSet &schedule, OpOperand *use) {
+void rematerializeBroadcasts(WarpSchedule &schedule, OpOperand *use) {
   static_assert(
       std::is_base_of_v<OpTrait::OneResult<BroadcastOp>, BroadcastOp> &&
       std::is_base_of_v<OpTrait::OneResult<ExpandDimsOp>, ExpandDimsOp>);
@@ -523,7 +523,7 @@ void rematerializeBroadcasts(PartitionSet &schedule, OpOperand *use) {
   }
 }
 
-void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
+void optimizeSchedule(scf::ForOp loop, WarpSchedule &schedule) {
   for (Partition &partition : schedule.getPartitions()) {
     SmallVector<OpOperand *> uses;
     iterateOutputs(loop, &partition,
@@ -562,7 +562,7 @@ void PartitionScheduling::runOnOperation() {
       loops.push_back(loop);
   });
   for (auto [idx, loop] : llvm::enumerate(loops)) {
-    if (std::optional<PartitionSet> schedule = getInitialSchedule(loop)) {
+    if (std::optional<WarpSchedule> schedule = getInitialSchedule(loop)) {
       propagatePartitions(loop, *schedule);
       optimizeSchedule(loop, *schedule);
       loop->setAttr(

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -587,10 +587,15 @@ void PartitionScheduling::runOnOperation() {
       optimizeSchedule(loop, *schedule);
       assignRootPartition(loop, schedule->getNumPartitions());
       assignIfBodyPartition(loop);
-      // assign partition to body ops
       loop->setAttr(
           kWarpSpecializeTagAttrName,
           IntegerAttr::get(IntegerType::get(loop.getContext(), 32), idx));
+
+      SmallVector<Attribute> stages;
+      Builder b(loop.getContext());
+      for (Partition &partition : schedule->getPartitions())
+	stages.push_back(b.getI32IntegerAttr(partition.getStage()));
+      loop->setAttr(kPartitionStagesAttrName, b.getArrayAttr(stages));
     }
   }
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -350,7 +350,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &partitions) {
         opClusters.getOrCreate(defOp)->sinkPartitions.insert(&partition);
       }
     };
-    iterateDefs(loop, &partition, defCallback);
+    partition.iterateDefs(loop, defCallback);
 
     // For each partition, place users of its outputs in a cluster if it is not
     // already assigned to a partition.
@@ -361,7 +361,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &partitions) {
         opClusters.getOrCreate(user)->defPartitions.insert(&partition);
       }
     };
-    iterateUses(loop, &partition, useCallback);
+    partition.iterateUses(loop, useCallback);
   }
 
   // Now we have a pile of single-operation clusters directly adjacent to the
@@ -463,7 +463,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &partitions) {
       if (opsInCluster.contains(defOp))
         critPath.insert(defOp);
     };
-    iterateDefs(loop, sinkPartition, callback);
+    sinkPartition->iterateDefs(loop, callback);
     for (unsigned i = 0; i < critPath.size(); ++i) {
       Operation *op = critPath[i];
       iterateDefs(loop, op, [&](OpResult def) {
@@ -526,7 +526,7 @@ void rematerializeBroadcasts(PartitionSet &partitions, OpOperand *use) {
 void optimizePartitions(scf::ForOp loop, PartitionSet &partitions) {
   for (Partition &partition : partitions.getPartitions()) {
     SmallVector<OpOperand *> uses;
-    iterateOutputs(loop, &partition, [&](Operation *defOp, OpOperand &use) {
+    partition.iterateOutputs(loop, [&](Operation *defOp, OpOperand &use) {
       if (!isa<scf::YieldOp>(use.getOwner()))
         uses.push_back(&use);
     });

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -290,7 +290,6 @@ LogicalResult DependencyRewriter::run() {
   // Rewrite the loop to add the new results. Calling this function with no
   // indices set will just resize the results.
   eraseLoopCarriedValues(loop, {});
-  // Update the schedule.
   return success();
 }
 
@@ -299,7 +298,7 @@ LogicalResult DependencyRewriter::run() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult triton::gpu::rewritePartitionDependencies(scf::ForOp &loop) {
-  FailureOr<PartitionSet> partitionsOr = PartitionSet::deserialize(loop);
+  FailureOr<PartitionSet> partitionsOr = PartitionSet::fromLoop(loop);
   if (failed(partitionsOr))
     return failure();
   PartitionSet partitions = std::move(*partitionsOr);
@@ -331,7 +330,7 @@ struct RewritePartitionDependencies
 
 void RewritePartitionDependencies::runOnOperation() {
   // Collect for loops to warp specialize. This pass expects the loop to
-  // already be scheduled.
+  // already be annotated with partitions.
   SmallVector<scf::ForOp> loops;
   getOperation().walk([&](scf::ForOp loop) {
     if (loop->hasAttrOfType<ArrayAttr>(kPartitionStagesAttrName))

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -164,7 +164,8 @@ LogicalResult DependencyRewriter::run() {
                                 .getUses()) {
           collectUses(newUse);
         }
-      } else if (partitionIds && !llvm::is_contained(*partitionIds, partition.getIndex())) {
+      } else if (partitionIds &&
+                 !llvm::is_contained(*partitionIds, partition.getIndex())) {
         // This value is used in a different partition in the same iteration.
         uses.emplace_back(use.get(), &use, 0);
       }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -174,6 +174,10 @@ LogicalResult DependencyRewriter::run() {
       }
     };
     for (Operation *op : partition.getOps()) {
+      if (getPartitionIds(op)->size() == schedule.getNumPartitions()) {
+        // skip ops in the root partition
+        continue;
+      }
       for (OpOperand &use : op->getUses()) {
         collectUses(use);
       }
@@ -187,7 +191,6 @@ LogicalResult DependencyRewriter::run() {
         assert(distance > 0 && "self-recursion must occur in the future");
         return;
       }
-      Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
       UseInfo &info = useInfo[output];
       info.consumers[{usePartition, distance}].push_back(&use);
     };

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -171,7 +171,7 @@ LogicalResult DependencyRewriter::run() {
       }
     };
     for (Operation *op : partition.getOps()) {
-      if (isInRootPartition(op, partitions)) {
+      if (partitions.isInRootPartition(op)) {
         // skip ops in the root partition
         continue;
       }
@@ -182,7 +182,7 @@ LogicalResult DependencyRewriter::run() {
 
     auto callback = [&](Value output, OpOperand &use, unsigned distance) {
       Operation *user = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
-      Partition *usePartition = getPartition(user, partitions);
+      Partition *usePartition = partitions.getPartition(user);
       // Ignore uses in the same partition in the future.
       if (usePartition == &partition) {
         assert(distance > 0 && "self-recursion must occur in the future");

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -110,7 +110,7 @@ struct AsyncRef {
 // Helper class for dependency rewriting.
 class DependencyRewriter {
 public:
-  DependencyRewriter(WarpSchedule &schedule, scf::ForOp &loop)
+  DependencyRewriter(PartitionSet &schedule, scf::ForOp &loop)
       : schedule(schedule), loop(loop), b(loop.getLoc(), loop),
         endBuilder(loop.getLoc(), loop->getNextNode()) {}
 
@@ -122,7 +122,7 @@ private:
                               unsigned maxDistance);
 
   // The schedule to apply.
-  WarpSchedule &schedule;
+  PartitionSet &schedule;
   // The loop to partition.
   scf::ForOp &loop;
   // The builders to use.
@@ -302,10 +302,10 @@ LogicalResult DependencyRewriter::run() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult triton::gpu::rewritePartitionDependencies(scf::ForOp &loop) {
-  FailureOr<WarpSchedule> scheduleOr = WarpSchedule::deserialize(loop);
+  FailureOr<PartitionSet> scheduleOr = PartitionSet::deserialize(loop);
   if (failed(scheduleOr))
     return failure();
-  WarpSchedule schedule = std::move(*scheduleOr);
+  PartitionSet schedule = std::move(*scheduleOr);
   DependencyRewriter rewriter(schedule, loop);
   if (failed(rewriter.run()))
     return failure();

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -171,7 +171,7 @@ LogicalResult DependencyRewriter::run() {
       }
     };
     for (Operation *op : partition.getOps()) {
-      if (getPartitionIds(op)->size() == partitions.getNumPartitions()) {
+      if (isInRootPartition(op, partitions)) {
         // skip ops in the root partition
         continue;
       }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -110,7 +110,7 @@ struct AsyncRef {
 // Helper class for dependency rewriting.
 class DependencyRewriter {
 public:
-  DependencyRewriter(PartitionSet &schedule, scf::ForOp &loop)
+  DependencyRewriter(WarpSchedule &schedule, scf::ForOp &loop)
       : schedule(schedule), loop(loop), b(loop.getLoc(), loop),
         endBuilder(loop.getLoc(), loop->getNextNode()) {}
 
@@ -122,7 +122,7 @@ private:
                               unsigned maxDistance);
 
   // The schedule to apply.
-  PartitionSet &schedule;
+  WarpSchedule &schedule;
   // The loop to partition.
   scf::ForOp &loop;
   // The builders to use.
@@ -302,10 +302,10 @@ LogicalResult DependencyRewriter::run() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult triton::gpu::rewritePartitionDependencies(scf::ForOp &loop) {
-  FailureOr<PartitionSet> scheduleOr = PartitionSet::deserialize(loop);
+  FailureOr<WarpSchedule> scheduleOr = WarpSchedule::deserialize(loop);
   if (failed(scheduleOr))
     return failure();
-  PartitionSet schedule = std::move(*scheduleOr);
+  WarpSchedule schedule = std::move(*scheduleOr);
   DependencyRewriter rewriter(schedule, loop);
   if (failed(rewriter.run()))
     return failure();

--- a/test/NVWS/assign_stage_phase.mlir
+++ b/test/NVWS/assign_stage_phase.mlir
@@ -19,7 +19,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>
     // CHECK: [[IDX:%.*]]:6 = scf.for [[I:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[S0:%.*]] = [[C2]], [[P0:%.*]] = [[C0]], [[S1:%.*]] = [[C2]], [[P1:%.*]] = [[C1]], [[S2:%.*]] = [[C2]], [[P2:%.*]] = [[C1]])
     scf.for %arg3 = %arg0 to %arg1 step %arg2  : i32 {
-      %2 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
+      %2 = "op_a"() {ttg.partition = array<i32: 0>} : () -> tensor<1xi32, #blocked>
       // CHECK: op_a
       // CHECK-NEXT: [[S0a:%.*]] = arith.addi [[S0]], [[C1]]
       // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S0a]], [[C3]]
@@ -27,22 +27,22 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: [[P0a:%.*]] = arith.xori [[P0]], [[C1]]
       // CHECK-NEXT: [[P0b:%.*]] = arith.select [[CMP]], [[P0a]], [[P0]]
       // CHECK-NEXT: put.enter [[AREF]][[[S0b]], [[P0b]]]
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      ttg.local_store %2, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %2, %buffers {ttg.partition = array<i32: 0>} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
       // CHECK: put.exit [[AREF]][[[S0b]]]
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
 
       // CHECK-NEXT: [[S1a:%.*]] = arith.addi [[S1]], [[C1]]
       // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S1a]], [[C3]]
       // CHECK-NEXT: [[S1b:%.*]] = arith.select [[CMP]], [[C0]], [[S1a]]
       // CHECK-NEXT: [[P1a:%.*]] = arith.xori [[P1]], [[C1]]
       // CHECK-NEXT: [[P1b:%.*]] = arith.select [[CMP]], [[P1a]], [[P1]]
-      // CHECK-NEXT: {{.*}}, [[TOK1:%.*]] = nvws.aref.get.enter [[AREF]][[[S1b]], [[P1b]]] {ttg.partition = 1 : i32}
-      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %3 = ttg.local_load %buffers_0 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      // CHECK: get.exit [[AREF]][[[S1b]]], [[TOK1]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
-      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_b"(%3) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
+      // CHECK-NEXT: {{.*}}, [[TOK1:%.*]] = nvws.aref.get.enter [[AREF]][[[S1b]], [[P1b]]] {ttg.partition = array<i32: 1>}
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %3 = ttg.local_load %buffers_0 {ttg.partition = array<i32: 1>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      // CHECK: get.exit [[AREF]][[[S1b]]], [[TOK1]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
+      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_b"(%3) {ttg.partition = array<i32: 1>} : (tensor<1xi32, #blocked>) -> ()
 
       // CHECK: op_b
       // CHECK-NEXT: [[S2a:%.*]] = arith.addi [[S2]], [[C1]]
@@ -50,13 +50,13 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: [[S2b:%.*]] = arith.select [[CMP]], [[C0]], [[S2a]]
       // CHECK-NEXT: [[P2a:%.*]] = arith.xori [[P2]], [[C1]]
       // CHECK-NEXT: [[P2b:%.*]] = arith.select [[CMP]], [[P2a]], [[P2]]
-      // CHECK-NEXT: {{.*}}, [[TOK2:%.*]] = nvws.aref.get.enter [[AREF]][[[S2b]], [[P2b]]] {ttg.partition = 2 : i32}
-      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %4 = ttg.local_load %buffers_2 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      // CHECK: get.exit [[AREF]][[[S2b]]], [[TOK2]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
-      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_c"(%4) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
-      "op_d"(%4) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      // CHECK-NEXT: {{.*}}, [[TOK2:%.*]] = nvws.aref.get.enter [[AREF]][[[S2b]], [[P2b]]] {ttg.partition = array<i32: 2>}
+      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %4 = ttg.local_load %buffers_2 {ttg.partition = array<i32: 2>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      // CHECK: get.exit [[AREF]][[[S2b]]], [[TOK2]] [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
+      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_c"(%4) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
+      "op_d"(%4) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
       // CHECK: op_c
       // CHECK-NEXT: op_d
       // CHECK-NEXT: yield [[S0b]], [[P0b]], [[S1b]], [[P1b]], [[S2b]], [[P2b]]
@@ -99,12 +99,12 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
       // CHECK-NEXT: [[P0a:%.*]] = arith.xori [[P0]], [[C1]]
       // CHECK-NEXT: [[P0b:%.*]] = arith.select [[CMP]], [[P0a]], [[P0]]
       // CHECK-NEXT: put.enter [[AREF0]][[[S0b]], [[P0b]]]
-      %1:3 = nvws.aref.put.enter %aref0[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-      "op1"(%1#0) {ttg.partition = 0 : i32}: (!ttg.memdesc<64x16xf16, #shared0, #smem>) -> ()
-      "op2"(%1#1)  {ttg.partition = 0 : i32} : (!ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+      %1:3 = nvws.aref.put.enter %aref0[%c0_i32, %c0_i32] {ttg.partition = array<i32: 0>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+      "op1"(%1#0) {ttg.partition = array<i32: 0>}: (!ttg.memdesc<64x16xf16, #shared0, #smem>) -> ()
+      "op2"(%1#1)  {ttg.partition = array<i32: 0>} : (!ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
       // CHECK: op2
       // CHECK-NEXT: put.exit [[AREF0]][[[S0b]]]
-      nvws.aref.put.exit %aref0[%c0_i32], %1#2 [#nvws.async_op<tma_load>, #nvws.async_op<none>] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+      nvws.aref.put.exit %aref0[%c0_i32], %1#2 [#nvws.async_op<tma_load>, #nvws.async_op<none>] {ttg.partition = array<i32: 0>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
 
 
       // CHECK-NEXT: [[S1a:%.*]] = arith.addi [[S1]], [[C1]]
@@ -112,12 +112,12 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
       // CHECK-NEXT: [[S1b:%.*]] = arith.select [[CMP]], [[C0]], [[S1a]]
       // CHECK-NEXT: [[P1a:%.*]] = arith.xori [[P1]], [[C1]]
       // CHECK-NEXT: [[P1b:%.*]] = arith.select [[CMP]], [[P1a]], [[P1]]
-      // CHECK-NEXT: {{.*}}, [[TOK1:%.*]] = nvws.aref.get.enter [[AREF0]][[[S1b]], [[P1b]]] {ttg.partition = 1 : i32}
-      %2:3 = nvws.aref.get.enter %aref0[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-      "op3"(%2#0, %2#1) {ttg.partition = 1 : i32}: (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+      // CHECK-NEXT: {{.*}}, [[TOK1:%.*]] = nvws.aref.get.enter [[AREF0]][[[S1b]], [[P1b]]] {ttg.partition = array<i32: 1>}
+      %2:3 = nvws.aref.get.enter %aref0[%c0_i32, %c0_i32] {ttg.partition = array<i32: 1>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+      "op3"(%2#0, %2#1) {ttg.partition = array<i32: 1>}: (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
       // CHECK: op3
-      // CHECK-NEXT: get.exit [[AREF0]][[[S1b]]], [[TOK1]] [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32}
-      nvws.aref.get.exit %aref0[%c0_i32], %2#2 [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+      // CHECK-NEXT: get.exit [[AREF0]][[[S1b]]], [[TOK1]] [#nvws.async_op<tc5mma>] {ttg.partition = array<i32: 1>}
+      nvws.aref.get.exit %aref0[%c0_i32], %2#2 [#nvws.async_op<tc5mma>] {ttg.partition = array<i32: 1>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
       // CHECK: [[IDX1:%.*]]:4 = scf.if
       scf.if %cond {
         // CHECK-NEXT: [[S2a:%.*]] = arith.addi [[S2]], [[C1]]
@@ -125,23 +125,23 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
         // CHECK-NEXT: [[S2b:%.*]] = arith.select [[CMP]], [[C0]], [[S2a]]
         // CHECK-NEXT: [[P2a:%.*]] = arith.xori [[P2]], [[C1]]
         // CHECK-NEXT: [[P2b:%.*]] = arith.select [[CMP]], [[P2a]], [[P2]]
-        // CHECK-NEXT: {{.*}}, [[TOK2:%.*]] = nvws.aref.put.enter [[AREF1]][[[S2b]], [[P2b]]] {ttg.partition = 0 : i32}
+        // CHECK-NEXT: {{.*}}, [[TOK2:%.*]] = nvws.aref.put.enter [[AREF1]][[[S2b]], [[P2b]]] {ttg.partition = array<i32: 0>}
         // CHECK-NEXT: op4
         // CHECK-NEXT: put.exit [[AREF1]][[[S2b]]]
-        %4:3 = nvws.aref.put.enter %aref1[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-        "op4"(%4#0, %4#1) {ttg.partition = 0 : i32} : (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-        nvws.aref.put.exit %aref1[%c0_i32], %4#2 [#nvws.async_op<none>] {ttg.partition = 0 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+        %4:3 = nvws.aref.put.enter %aref1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 0>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+        "op4"(%4#0, %4#1) {ttg.partition = array<i32: 0>} : (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+        nvws.aref.put.exit %aref1[%c0_i32], %4#2 [#nvws.async_op<none>] {ttg.partition = array<i32: 0>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
         // CHECK-NEXT: [[S3a:%.*]] = arith.addi [[S3]], [[C1]]
         // CHECK-NEXT: [[CMP:%.*]] = arith.cmpi eq, [[S3a]], [[C3]]
         // CHECK-NEXT: [[S3b:%.*]] = arith.select [[CMP]], [[C0]], [[S3a]]
         // CHECK-NEXT: [[P3a:%.*]] = arith.xori [[P3]], [[C1]]
         // CHECK-NEXT: [[P3b:%.*]] = arith.select [[CMP]], [[P3a]], [[P3]]
-        // CHECK-NEXT: {{.*}}, [[TOK3:%.*]] = nvws.aref.get.enter [[AREF1]][[[S3b]], [[P3b]]] {ttg.partition = 1 : i32}
+        // CHECK-NEXT: {{.*}}, [[TOK3:%.*]] = nvws.aref.get.enter [[AREF1]][[[S3b]], [[P3b]]] {ttg.partition = array<i32: 1>}
         // CHECK-NEXT: op5
-        // CHECK-NEXT: get.exit [[AREF1]][[[S3b]]], [[TOK3]] [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32}
-        %5:3 = nvws.aref.get.enter %aref1[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
-        "op5"(%5#0, %5#1) {ttg.partition = 1 : i32}: (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
-        nvws.aref.get.exit %aref1[%c0_i32], %5#2 [#nvws.async_op<tc5mma>] {ttg.partition = 1 : i32} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
+        // CHECK-NEXT: get.exit [[AREF1]][[[S3b]]], [[TOK3]] [#nvws.async_op<tc5mma>] {ttg.partition = array<i32: 1>}
+        %5:3 = nvws.aref.get.enter %aref1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 1>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]> -> !ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>, !ttg.async.token
+        "op5"(%5#0, %5#1) {ttg.partition = array<i32: 1>}: (!ttg.memdesc<64x16xf16, #shared0, #smem>, !ttg.memdesc<16x32xf16, #shared0, #smem>) -> ()
+        nvws.aref.get.exit %aref1[%c0_i32], %5#2 [#nvws.async_op<tc5mma>] {ttg.partition = array<i32: 1>} : !nvws.aref<[!ttg.memdesc<3x64x16xf16, #shared0, #smem>, !ttg.memdesc<3x16x32xf16, #shared0, #smem>]>, !ttg.async.token
         // CHECK-NEXT: yield [[S2b]], [[P2b]], [[S3b]], [[P3b]]
       }
       // CHECK-NEXT: } else {

--- a/test/NVWS/insert_aref.mlir
+++ b/test/NVWS/insert_aref.mlir
@@ -30,30 +30,30 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     // CHECK-NEXT: [[AREF2:%.*]] = nvws.aref.create [[AREF_BUF2]]
     %1 = scf.for %arg5 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg6 = %0) -> (!ttg.async.token)  : i32 {
       %2 = arith.muli %arg5, %c64_i32 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
-      // CHECK: [[C_ZERO1:%.*]] = arith.constant {ttg.partition = 2 : i32} 0
-      // CHECK: [[PUT_BUF1:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]][[[C_ZERO1]], [[C_ZERO1]]] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32}
+      // CHECK: [[C_ZERO1:%.*]] = arith.constant {ttg.partition = array<i32: 2>} 0
+      // CHECK: [[PUT_BUF1:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]][[[C_ZERO1]], [[C_ZERO1]]] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
       // CHECK-NEXT: nvws.descriptor_load {{.*}} 16384 [[PUT_BUF1]]
-      // CHECK: [[C_ZERO2:%.*]] = arith.constant {ttg.partition = 2 : i32} 0
-      // CHECK: nvws.aref.put.exit [[AREF1]][[[C_ZERO2]]], [[TOKEN1]] [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32}
-      // CHECK: [[C_ZERO3:%.*]] = arith.constant {ttg.partition = 1 : i32} 0
-      // CHECK: [[GET_BUF1:%.*]], [[GET_TOKEN1:%.*]] = nvws.aref.get.enter [[AREF1]][[[C_ZERO3]], [[C_ZERO3]]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
-      %3 = tt.descriptor_load %arg3[%arg1, %2] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      // CHECK: [[C_ZERO2:%.*]] = arith.constant {ttg.partition = array<i32: 2>} 0
+      // CHECK: nvws.aref.put.exit [[AREF1]][[[C_ZERO2]]], [[TOKEN1]] [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
+      // CHECK: [[C_ZERO3:%.*]] = arith.constant {ttg.partition = array<i32: 1>} 0
+      // CHECK: [[GET_BUF1:%.*]], [[GET_TOKEN1:%.*]] = nvws.aref.get.enter [[AREF1]][[[C_ZERO3]], [[C_ZERO3]]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
+      %3 = tt.descriptor_load %arg3[%arg1, %2] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
       // CHECK: [[PUT_BUF2:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]]
       // CHECK-NEXT: nvws.descriptor_load {{.*}} 16384 [[PUT_BUF2]]
       // CHECK: nvws.aref.put.exit [[AREF2]]
       // CHECK: [[GET_BUF2:%.*]], [[GET_TOKEN2:%.*]] = nvws.aref.get.enter [[AREF2]]
-      %4 = tt.descriptor_load %arg4[%arg2, %2] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      %4 = tt.descriptor_load %arg4[%arg2, %2] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
 
-      %5 = ttg.local_alloc %3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
-      %6 = ttg.local_alloc %4 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %5 = ttg.local_alloc %3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %6 = ttg.local_alloc %4 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
 
-      // CHECK:  [[RHS:%.*]] = ttg.memdesc_trans [[GET_BUF2]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = 1 : i32}
-      %7 = ttg.memdesc_trans %6 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
+      // CHECK:  [[RHS:%.*]] = ttg.memdesc_trans [[GET_BUF2]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>}
+      %7 = ttg.memdesc_trans %6 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
       // CHECK: ttng.tc_gen5_mma [[GET_BUF1]], [[RHS]], {{.*}}, {{.*}}, {{.*}}
-      %8 = ttng.tc_gen5_mma %5, %7, %result[%arg6], %true, %true {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %8 = ttng.tc_gen5_mma %5, %7, %result[%arg6], %true, %true {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       // CHECK: nvws.aref.get.exit [[AREF2]][{{.*}}], [[GET_TOKEN2]]
-      // CHECK: [[C_ZERO4:%.*]] = arith.constant {ttg.partition = 1 : i32} 0
-      // CHECK: nvws.aref.get.exit [[AREF1]][[[C_ZERO4]]], [[GET_TOKEN1]] [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
+      // CHECK: [[C_ZERO4:%.*]] = arith.constant {ttg.partition = array<i32: 1>} 0
+      // CHECK: nvws.aref.get.exit [[AREF1]][[[C_ZERO4]]], [[GET_TOKEN1]] [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
       scf.yield %8 : !ttg.async.token
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     %result_0, %token_1 = ttng.tmem_load %result[%1] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
@@ -69,12 +69,12 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       // CHECK: nvws.aref.put.enter
       // CHECK: nvws.descriptor_load
       // CHECK: nvws.aref.put.exit
-      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 1 : i32, loop.stage = 0, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 1 : i32, loop.stage = 0, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
       // CHECK: {{.*}}, [[GET_TOKEN:%.*]] = nvws.aref.get.enter
       // CHECK: [[REG:%.*]] = ttg.local_load
       // CHECK: nvws.aref.get.exit {{.*}}, [[GET_TOKEN]] [#nvws.async_op<none>]
       // CHECK: "use"([[REG]])
-      "use"(%0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
+      "use"(%0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked1>) -> ()
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
@@ -85,8 +85,8 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %c1_i32 = arith.constant 1 : i32
     // CHECK-NOT: nvws.aref.create
     scf.for %arg2 = %c0_i32 to %arg1 step %c1_i32  : i32 {
-      %0 = "producer"(%arg0, %arg2) {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 1 : i32} : (tensor<128x64xf16, #blocked1>, i32) -> tensor<128x64xf16, #blocked1>
-      "use"(%0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
+      %0 = "producer"(%arg0, %arg2) {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : (tensor<128x64xf16, #blocked1>, i32) -> tensor<128x64xf16, #blocked1>
+      "use"(%0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked1>) -> ()
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
@@ -99,17 +99,17 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       // CHECK: nvws.aref.put.enter
       // CHECK: nvws.descriptor_load
       // CHECK: nvws.aref.put.exit
-      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
-      %alloc = ttg.local_alloc %0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
-      // CHECK-DAG: [[GET_BUF1:%.*]], [[GET_TOKEN1:%.*]] = nvws.aref.get.enter {{.*}} {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
-      // CHECK-DAG: [[GET_BUF2:%.*]], [[GET_TOKEN2:%.*]] = nvws.aref.get.enter {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
-      // CHECK-DAG: [[REG:%.*]] = ttg.local_load [[GET_BUF1]] {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
-      // CHECK-DAG: nvws.aref.get.exit {{.*}}, [[GET_TOKEN1]] [#nvws.async_op<none>] {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      %alloc = ttg.local_alloc %0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      // CHECK-DAG: [[GET_BUF1:%.*]], [[GET_TOKEN1:%.*]] = nvws.aref.get.enter {{.*}} {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
+      // CHECK-DAG: [[GET_BUF2:%.*]], [[GET_TOKEN2:%.*]] = nvws.aref.get.enter {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
+      // CHECK-DAG: [[REG:%.*]] = ttg.local_load [[GET_BUF1]] {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
+      // CHECK-DAG: nvws.aref.get.exit {{.*}}, [[GET_TOKEN1]] [#nvws.async_op<none>] {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
       // CHECK: "use1"([[REG]])
       // CHECK: "use2"([[GET_BUF2]])
-      // CHECK: nvws.aref.get.exit {{.*}}, [[GET_TOKEN2]] [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
-      "use1"(%0) {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
-      "use2"(%alloc) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : (!ttg.memdesc<128x64xf16, #shared, #smem>) -> ()
+      // CHECK: nvws.aref.get.exit {{.*}}, [[GET_TOKEN2]] [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
+      "use1"(%0) {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked1>) -> ()
+      "use2"(%alloc) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (!ttg.memdesc<128x64xf16, #shared, #smem>) -> ()
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
@@ -122,15 +122,15 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       // CHECK: nvws.aref.put.enter
       // CHECK: nvws.descriptor_load
       // CHECK: nvws.aref.put.exit
-      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = 1 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
-      %alloc = ttg.local_alloc %0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %0 = tt.descriptor_load %arg0[%arg2, %arg2] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      %alloc = ttg.local_alloc %0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
       // CHECK: [[GET_BUF:%.*]], [[GET_TOKEN:%.*]] = nvws.aref.get.enter {{.*}} {loop.cluster = 0 : i32, loop.stage = 1
-      // CHECK: [[REG:%.*]] = ttg.local_load [[GET_BUF]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+      // CHECK: [[REG:%.*]] = ttg.local_load [[GET_BUF]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
       // CHECK: "use1"([[REG]])
       // CHECK: "use2"([[GET_BUF]])
       // CHECK: nvws.aref.get.exit {{.*}}, [[GET_TOKEN]] {{.*}} {loop.cluster = 1 : i32, loop.stage = 1
-      "use1"(%0) {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked1>) -> ()
-      "use2"(%alloc) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (!ttg.memdesc<128x64xf16, #shared, #smem>) -> ()
+      "use1"(%0) {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked1>) -> ()
+      "use2"(%alloc) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (!ttg.memdesc<128x64xf16, #shared, #smem>) -> ()
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
@@ -146,26 +146,26 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %result = ttng.tmem_alloc %cst_0 : (tensor<128x8xi8, #linear>) -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
     %0 = scf.for %arg6 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg7 = %cst) -> (tensor<128x128xf32, #blocked>)  : i32 {
       %1 = arith.muli %arg6, %c64_i32 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
-      %2 = tt.descriptor_load %arg3[%arg1, %1] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf8E4M3FN, #shared3>> -> tensor<128x64xf8E4M3FN, #blocked1>
-      %3 = tt.descriptor_load %arg4[%arg2, %1] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf8E4M3FN, #shared3>> -> tensor<128x64xf8E4M3FN, #blocked1>
-      %5 = ttg.local_alloc %2 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x64xf8E4M3FN, #blocked1>) -> !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>
-      %6 = ttg.local_alloc %3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x64xf8E4M3FN, #blocked1>) -> !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>
+      %2 = tt.descriptor_load %arg3[%arg1, %1] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf8E4M3FN, #shared3>> -> tensor<128x64xf8E4M3FN, #blocked1>
+      %3 = tt.descriptor_load %arg4[%arg2, %1] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf8E4M3FN, #shared3>> -> tensor<128x64xf8E4M3FN, #blocked1>
+      %5 = ttg.local_alloc %2 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf8E4M3FN, #blocked1>) -> !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>
+      %6 = ttg.local_alloc %3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf8E4M3FN, #blocked1>) -> !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>
 
       // CHECK: nvws.aref.put.enter
       // CHECK: nvws.descriptor_load
       // CHECK: nvws.aref.put.exit
-      %4 = tt.descriptor_load %arg5[%arg1, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x8xi8, #shared2>> -> tensor<128x8xi8, #linear>
+      %4 = tt.descriptor_load %arg5[%arg1, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x8xi8, #shared2>> -> tensor<128x8xi8, #linear>
 
       // CHECK: nvws.aref.get.enter
       // CHECK: [[REG:%.*]] = ttg.local_load
       // CHECK: nvws.aref.get.exit
       // CHECK: tmem_alloc [[REG]]
-      %result_1 = ttng.tmem_alloc %4 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 2 : i32} : (tensor<128x8xi8, #linear>) -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
+      %result_1 = ttng.tmem_alloc %4 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x8xi8, #linear>) -> !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
 
-      %7 = ttg.memdesc_trans %6 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem> -> !ttg.memdesc<64x128xf8E4M3FN, #shared4, #smem>
-      %result_2, %token = ttng.tmem_alloc %arg7 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x128xf32, #blocked>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
-      %8 = ttng.tc_gen5_mma_scaled %5, %7, %result_2[%token], %result, %result_1, %true, %true lhs = e4m3 rhs = e4m3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>, !ttg.memdesc<64x128xf8E4M3FN, #shared4, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>, !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
-      %result_3, %token_4 = ttng.tmem_load %result_2[%8] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      %7 = ttg.memdesc_trans %6 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem> -> !ttg.memdesc<64x128xf8E4M3FN, #shared4, #smem>
+      %result_2, %token = ttng.tmem_alloc %arg7 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x128xf32, #blocked>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %8 = ttng.tc_gen5_mma_scaled %5, %7, %result_2[%token], %result, %result_1, %true, %true lhs = e4m3 rhs = e4m3 {loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf8E4M3FN, #shared3, #smem>, !ttg.memdesc<64x128xf8E4M3FN, #shared4, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>, !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>
+      %result_3, %token_4 = ttng.tmem_load %result_2[%8] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
       scf.yield %result_3 : tensor<128x128xf32, #blocked>
     } {tt.num_stages = 2 : i64, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return

--- a/test/NVWS/lower_aref.mlir
+++ b/test/NVWS/lower_aref.mlir
@@ -29,7 +29,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<3x1xi32, #shared, #smem, mutable>
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>
     scf.for %arg3 = %arg0 to %arg1 step %arg2 : i32 {
-      %3 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
+      %3 = "op_a"() {ttg.partition = array<i32: 0>} : () -> tensor<1xi32, #blocked>
       // CHECK: op_a
       // CHECK-NEXT: addi
       // CHECK-NEXT: cmpi
@@ -37,42 +37,42 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: xori
       // CHECK-NEXT: [[PHASE:%.*]] = arith.select
       // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]][[[STAGE]]]
-      // CHECK-NEXT: ttng.wait_barrier [[EMPTYMBAR]], [[PHASE]] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[EMPTYMBAR]], [[PHASE]] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 0>}
       // CHECK: local_store
       // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]][[[STAGE]]]
-      // CHECK-NEXT: ttng.arrive_barrier [[FULLMBAR]], 1 {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32}
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      ttg.local_store %3, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      // CHECK-NEXT: ttng.arrive_barrier [[FULLMBAR]], 1 {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 0>}
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %3, %buffers {ttg.partition = array<i32: 0>} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {loop.cluster = 1 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
       // CHECK: addi
       // CHECK-NEXT: cmpi
       // CHECK-NEXT: [[STAGE:%.*]] = arith.select
       // CHECK-NEXT: xori
       // CHECK-NEXT: [[PHASE:%.*]] = arith.select
       // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]][[[STAGE]]]
-      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE]] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE]] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 1>}
       // CHECK: local_load
       // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]][[[STAGE]]]
-      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32}
-      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %14 = ttg.local_load %buffers_0 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_b"(%14) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
+      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 1>}
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %14 = ttg.local_load %buffers_0 {ttg.partition = array<i32: 1>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 2 : i32, loop.stage = 3 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_b"(%14) {ttg.partition = array<i32: 1>} : (tensor<1xi32, #blocked>) -> ()
       // CHECK: addi
       // CHECK-NEXT: cmpi
       // CHECK-NEXT: [[STAGE:%.*]] = arith.select
       // CHECK-NEXT: xori
       // CHECK-NEXT: [[PHASE:%.*]] = arith.select
       // CHECK-NEXT: [[FULLMBAR:%.*]] = ttg.memdesc_index [[FULL]][[[STAGE]]]
-      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE]] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[FULLMBAR]], [[PHASE]] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = array<i32: 2>}
       // CHECK: local_load
       // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]][[[STAGE]]]
-      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32}
-      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %20 = ttg.local_load %buffers_2 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_c"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
-      "op_d"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR]], 1 {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = array<i32: 2>}
+      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %20 = ttg.local_load %buffers_2 {ttg.partition = array<i32: 2>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {loop.cluster = 3 : i32, loop.stage = 4 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_c"(%20) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
+      "op_d"(%20) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
     } {ttg.partition.stages = [0 : i32, 2 : i32, 2 : i32], ttg.warp_specialize.tag = 0 : i32}
     // CHECK: } {ttg.partition.stages =
     // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
@@ -109,24 +109,24 @@ module attributes {"ttg.num-warps" = 4 : i32} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<3x1xi32, #shared, #smem, mutable>
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>
     scf.for %arg3 = %arg0 to %arg1 step %arg2 : i32 {
-      %3 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      ttg.local_store %3, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = 0 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %14 = ttg.local_load %buffers_0 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {ttg.partition = 1 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_b"(%14) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
-      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %20 = ttg.local_load %buffers_2 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {ttg.partition = 2 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_c"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
-      "op_d"(%20) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
-      %buffers_4, %token_5 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 3 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %26 = ttg.local_load %buffers_4 {ttg.partition = 3 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_5 [#nvws.async_op<none>] {ttg.partition = 3 : i32} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_e"(%26) {ttg.partition = 3 : i32} : (tensor<1xi32, #blocked>) -> ()
-      "op_f"(%26) {ttg.partition = 3 : i32} : (tensor<1xi32, #blocked>) -> ()
+      %3 = "op_a"() {ttg.partition = array<i32: 0>} : () -> tensor<1xi32, #blocked>
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %3, %buffers {ttg.partition = array<i32: 0>} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %14 = ttg.local_load %buffers_0 {ttg.partition = array<i32: 1>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_b"(%14) {ttg.partition = array<i32: 1>} : (tensor<1xi32, #blocked>) -> ()
+      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %20 = ttg.local_load %buffers_2 {ttg.partition = array<i32: 2>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_c"(%20) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
+      "op_d"(%20) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
+      %buffers_4, %token_5 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 3>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %26 = ttg.local_load %buffers_4 {ttg.partition = array<i32: 3>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_5 [#nvws.async_op<none>] {ttg.partition = array<i32: 3>} : <[!ttg.memdesc<3x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_e"(%26) {ttg.partition = array<i32: 3>} : (tensor<1xi32, #blocked>) -> ()
+      "op_f"(%26) {ttg.partition = array<i32: 3>} : (tensor<1xi32, #blocked>) -> ()
     } {ttg.partition.stages = [0 : i32, 2 : i32, 2 : i32, 3 : i32], ttg.warp_specialize.tag = 0 : i32}
     // CHECK: } {ttg.partition.stages =
     // CHECK-NEXT: [[EMPTYMBAR:%.*]] = ttg.memdesc_index [[EMPTY]]
@@ -170,10 +170,10 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: [[FULLBAR1:%.*]] = ttg.memdesc_index [[FULL1]]
       // CHECK-NEXT: ttng.arrive_barrier [[FULLBAR1]], 1
       // CHECK: op_a
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = 0 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      ttg.local_store %arg5, %buffers {ttg.partition = 0 : i32} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = 0 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      %5 = "op_a"() {ttg.partition = 0 : i32} : () -> tensor<1xi32, #blocked>
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      ttg.local_store %arg5, %buffers {ttg.partition = array<i32: 0>} : tensor<1xi32, #blocked> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<none>] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      %5 = "op_a"() {ttg.partition = array<i32: 0>} : () -> tensor<1xi32, #blocked>
 
       // CHECK: arith.select
       // CHECK: [[PHASE:%.*]] = arith.select
@@ -183,10 +183,10 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: [[EMPTYMBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
       // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR1]], 1
       // CHECK: op_d
-      %buffers_1, %token_2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 1 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %8 = ttg.local_load %buffers_1 {ttg.partition = 1 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_2 [#nvws.async_op<none>] {ttg.partition = 1 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_d"(%8) {ttg.partition = 1 : i32} : (tensor<1xi32, #blocked>) -> ()
+      %buffers_1, %token_2 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %8 = ttg.local_load %buffers_1 {ttg.partition = array<i32: 1>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_2 [#nvws.async_op<none>] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_d"(%8) {ttg.partition = array<i32: 1>} : (tensor<1xi32, #blocked>) -> ()
 
       // CHECK: arith.select
       // CHECK: [[PHASE:%.*]] = arith.select
@@ -196,10 +196,10 @@ module attributes {"ttg.num-warps" = 4 : i32} {
       // CHECK-NEXT: [[EMPTYMBAR1:%.*]] = ttg.memdesc_index [[EMPTY1]]
       // CHECK-NEXT: ttng.arrive_barrier [[EMPTYMBAR1]], 1
       // CHECK: op_d
-      %buffers_3, %token_4 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = 2 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
-      %11 = ttg.local_load %buffers_3 {ttg.partition = 2 : i32} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
-      nvws.aref.get.exit %1[%c0_i32], %token_4 [#nvws.async_op<none>] {ttg.partition = 2 : i32} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
-      "op_d"(%11) {ttg.partition = 2 : i32} : (tensor<1xi32, #blocked>) -> ()
+      %buffers_3, %token_4 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1>, !ttg.async.token
+      %11 = ttg.local_load %buffers_3 {ttg.partition = array<i32: 2>} : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked>
+      nvws.aref.get.exit %1[%c0_i32], %token_4 [#nvws.async_op<none>] {ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x1xi32, #shared, #smem, mutable>]>, !ttg.async.token
+      "op_d"(%11) {ttg.partition = array<i32: 2>} : (tensor<1xi32, #blocked>) -> ()
       scf.yield %5 : tensor<1xi32, #blocked>
     } {ttg.partition.stages = [1 : i32, 0 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     ttg.local_dealloc %0 : !ttg.memdesc<1x1xi32, #shared, #smem, mutable>
@@ -240,33 +240,33 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     ttng.init_barrier %9, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable, 1x1>
     %10 = scf.for %arg5 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg6 = %2) -> (!ttg.async.token)  : i32 {
       %11 = arith.muli %arg5, %c64_i32 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
-      // CHECK-COUNT-1: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32}
+      // CHECK-COUNT-1: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
       // CHECK: [[BUF_A_SLICE:%.*]] = ttg.memdesc_index [[BUF_A]]
       // CHECK: [[BUF_B_SLICE:%.*]] = ttg.memdesc_index [[BUF_B]]
       // CHECK: [[TMA_FULL_SLICE:%.*]] = ttg.memdesc_index [[TMA_FULL]]
-      // CHECK: ttng.async_tma_copy_global_to_local {{.*}} [[BUF_A_SLICE]], [[TMA_FULL_SLICE]], {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32}
-      // CHECK: ttng.async_tma_copy_global_to_local {{.*}} [[BUF_B_SLICE]], [[TMA_FULL_SLICE]], {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32}
-      %buffers, %token_2 = nvws.aref.put.enter %4[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
-      nvws.descriptor_load %arg3[%arg1, %11] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
-      nvws.aref.put.exit %4[%c0_i32], %token_2 [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_3, %token_4 = nvws.aref.get.enter %4[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
-      %buffers_5, %token_6 = nvws.aref.put.enter %6[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
-      nvws.descriptor_load %arg4[%arg2, %11] 16384 %buffers_5 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
-      nvws.aref.put.exit %6[%c0_i32], %token_6 [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_7, %token_8 = nvws.aref.get.enter %6[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
+      // CHECK: ttng.async_tma_copy_global_to_local {{.*}} [[BUF_A_SLICE]], [[TMA_FULL_SLICE]], {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
+      // CHECK: ttng.async_tma_copy_global_to_local {{.*}} [[BUF_B_SLICE]], [[TMA_FULL_SLICE]], {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
+      %buffers, %token_2 = nvws.aref.put.enter %4[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
+      nvws.descriptor_load %arg3[%arg1, %11] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
+      nvws.aref.put.exit %4[%c0_i32], %token_2 [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_3, %token_4 = nvws.aref.get.enter %4[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
+      %buffers_5, %token_6 = nvws.aref.put.enter %6[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
+      nvws.descriptor_load %arg4[%arg2, %11] 16384 %buffers_5 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
+      nvws.aref.put.exit %6[%c0_i32], %token_6 [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_7, %token_8 = nvws.aref.get.enter %6[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
 
-      // CHECK-COUNT-1: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
+      // CHECK-COUNT-1: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
       // CHECK: [[BUF_A_SLICE:%.*]] = ttg.memdesc_index [[BUF_A]]
       // CHECK: [[BUF_B_SLICE:%.*]] = ttg.memdesc_index [[BUF_B]]
       // CHECK: [[BUF_B_SLICE_TRANS:%.*]] = ttg.memdesc_trans [[BUF_B_SLICE]] {loop.cluster = 0 : i32, loop.stage = 1 : i32
-      %12 = ttg.memdesc_trans %buffers_7 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> !ttg.memdesc<64x128xf16, #shared2, #smem, 1x64x128>
+      %12 = ttg.memdesc_trans %buffers_7 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> !ttg.memdesc<64x128xf16, #shared2, #smem, 1x64x128>
       %13 = arith.cmpi eq, %arg5, %7 : i32
       // CHECK: ttng.tc_gen5_mma [[BUF_A_SLICE]], [[BUF_B_SLICE_TRANS]]
-      %14 = ttng.tc_gen5_mma %buffers_3, %12, %1[], %true, %true, %9[%13] {is_async, loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32, ttg.partition = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.memdesc<64x128xf16, #shared2, #smem, 1x64x128>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 1x128x128>, !ttg.memdesc<1xi64, #shared1, #smem, mutable, 1x1>
+      %14 = ttng.tc_gen5_mma %buffers_3, %12, %1[], %true, %true, %9[%13] {is_async, loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.memdesc<64x128xf16, #shared2, #smem, 1x64x128>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 1x128x128>, !ttg.memdesc<1xi64, #shared1, #smem, mutable, 1x1>
       // CHECK: [[TMA_EMPTY_SLICE:%.*]] = ttg.memdesc_index [[TMA_EMPTY]]
-      // CHECK-COUNT-1: ttng.tc_gen5_commit [[TMA_EMPTY_SLICE]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
-      nvws.aref.get.exit %6[%c0_i32], %token_8 [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      nvws.aref.get.exit %4[%c0_i32], %token_4 [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      // CHECK-COUNT-1: ttng.tc_gen5_commit [[TMA_EMPTY_SLICE]] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
+      nvws.aref.get.exit %6[%c0_i32], %token_8 [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      nvws.aref.get.exit %4[%c0_i32], %token_4 [#nvws.async_op<tc5mma>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
       scf.yield %0 : !ttg.async.token
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
@@ -291,23 +291,23 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>
     scf.for %arg2 = %c0_i32 to %arg1 step %c1_i32  : i32 {
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
-      nvws.descriptor_load %arg0[%arg2, %arg2] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 2 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
-      %2 = ttg.local_load %buffers_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> tensor<128x64xf16, #blocked>
-      // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
+      nvws.descriptor_load %arg0[%arg2, %arg2] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
+      %2 = ttg.local_load %buffers_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> tensor<128x64xf16, #blocked>
+      // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
       // CHECK: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
-      // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
-      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
-      "use1"(%2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked>) -> ()
+      // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
+      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_2, %token_3 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
+      "use1"(%2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked>) -> ()
       // CHECK: "use2"
-      // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
+      // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
       // CHECK: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
-      // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32}
-      "use2"(%buffers_2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : (!ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>) -> ()
-      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>}
+      "use2"(%buffers_2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (!ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>) -> ()
+      nvws.aref.get.exit %1[%c0_i32], %token_3 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
@@ -331,20 +331,20 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
     %1 = nvws.aref.create %0 : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>
     scf.for %arg2 = %c0_i32 to %arg1 step %c1_i32  : i32 {
-      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
-      nvws.descriptor_load %arg0[%arg2, %arg2] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 1 : i32} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
-      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = 1 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
-      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
-      %2 = ttg.local_load %buffers_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> tensor<128x64xf16, #blocked>
-       // CHECK: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+      %buffers, %token = nvws.aref.put.enter %1[%c0_i32, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>, !ttg.async.token
+      nvws.descriptor_load %arg0[%arg2, %arg2] 16384 %buffers {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<tensor<128x64xf16, #shared>>, i32, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 1x128x64>
+      nvws.aref.put.exit %1[%c0_i32], %token [#nvws.async_op<tma_load>] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+      %buffers_0, %token_1 = nvws.aref.get.enter %1[%c0_i32, %c0_i32] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]> -> !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>, !ttg.async.token
+      %2 = ttg.local_load %buffers_0 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : !ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64> -> tensor<128x64xf16, #blocked>
+       // CHECK: ttng.wait_barrier {{.*}}, {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
        // CHECK: "use1"
        // CHECK: "use2"
-       // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+       // CHECK: ttng.fence_async_shared {bCluster = false, loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
        // CHECK: [[EMPTYSLICE:%.*]] = ttg.memdesc_index [[EMPTY]]
-       // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
-      "use1"(%2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<128x64xf16, #blocked>) -> ()
-      "use2"(%buffers_0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (!ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>) -> ()
-      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
+       // CHECK: ttng.arrive_barrier [[EMPTYSLICE]], 1 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
+      "use1"(%2) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked>) -> ()
+      "use2"(%buffers_0) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (!ttg.memdesc<128x64xf16, #shared, #smem, 1x128x64>) -> ()
+      nvws.aref.get.exit %1[%c0_i32], %token_1 [#nvws.async_op<none>] {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : <[!ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>]>, !ttg.async.token
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }

--- a/test/TritonGPU/load-mma-specialization.mlir
+++ b/test/TritonGPU/load-mma-specialization.mlir
@@ -740,7 +740,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag(
       // CHECK-NEXT: ttng.wait_barrier [[ACC_READY_BUF0]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
       // CHECK-NEXT: [[C:%.*]], [[USER_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][]
       // CHECK-NEXT: ttng.arrive_barrier [[ACC_EMPTY_BUF0]], 1 {ttg.partition = array<i32: 0>}
-      // CHECK-NEXT: "acc_user"([[C]]) {ttg.partition = array<i32: 0>}
+      // CHECK-NEXT: "acc_user"([[C]])
       "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
     // CHECK-NEXT: }
     }
@@ -1231,7 +1231,7 @@ tt.func @local_alloc_into_mma(
   %c1 = arith.constant 1 : i32
   %acc, %acc_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
   %true = arith.constant true
-  // CHECK: [[LHS_SHARED:%.*]] = ttg.local_alloc %arg1 {{.*}} : (tensor<128x64xf16, {{.*}}>) -> !ttg.memdesc<128x64xf16,
+  // CHECK: [[LHS_SHARED:%.*]] = ttg.local_alloc %arg1 : (tensor<128x64xf16, {{.*}}>) -> !ttg.memdesc<128x64xf16,
   // CHECK: scf.for
   scf.for %i = %c0 to %ub step %c1 iter_args(%tok = %acc_tok) -> !ttg.async.token : i32 {
     // CHECK: barrier_expect [[LOAD_READY_BAR:%.*]], 16384 {ttg.partition = array<i32: 2>}

--- a/test/TritonGPU/load-mma-specialization.mlir
+++ b/test/TritonGPU/load-mma-specialization.mlir
@@ -1025,7 +1025,7 @@ tt.func @specialize_load_only(%desc: !tt.tensordesc<tensor<128x64xf16, #shared>>
   scf.for %i = %c0_i32 to %ub step %c1_i32 : i32 {
     // CHECK: wait_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
     // CHECK-NEXT: local_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
-    // CHECK-NEXT: fence_async_shared {{.*}}partition = 0
+    // CHECK-NEXT: fence_async_shared {{.*}}partition = array<i32: 0>
     // CHECK-NEXT: arrive_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
     %val = tt.descriptor_load %desc[%i, %i] {loop.cluster = 1 : i32, loop.stage = 0}: !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #oper_layout>
     "use"(%val) {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<128x64xf16, #oper_layout>) -> ()
@@ -1041,8 +1041,8 @@ tt.func @fp4_padded_load(%desc: !tt.tensordesc<tensor<1x256x64xui8, #fp4_padded_
   scf.for %i = %c0_i32 to %ub step %c1_i32 : i32 {
     // CHECK: [[IDX:%.*]] = arith.muli [[I]], %c2_i32 : i32
     // CHECK: async_tma_copy_global_to_local %arg{{[0-9]+}}[[[I]], [[IDX]]]
-    %val = tt.descriptor_load %desc[%i, %i] {loop.cluster = 1 : i32, loop.stage = 0, ttg.partition = 2 : i32} : !tt.tensordesc<tensor<1x256x64xui8, #fp4_padded_shared>> -> tensor<256x64xi8, #oper_layout>
-    "use"(%val) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32} : (tensor<256x64xi8, #oper_layout>) -> ()
+    %val = tt.descriptor_load %desc[%i, %i] {loop.cluster = 1 : i32, loop.stage = 0, ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<1x256x64xui8, #fp4_padded_shared>> -> tensor<256x64xi8, #oper_layout>
+    "use"(%val) {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<256x64xi8, #oper_layout>) -> ()
   } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize}
   tt.return
 }

--- a/test/TritonGPU/load-mma-specialization.mlir
+++ b/test/TritonGPU/load-mma-specialization.mlir
@@ -97,25 +97,25 @@ tt.func @warp_specialize_tma_matmul(
     %off_k = arith.muli %k, %BLOCK_K : i32
 
     // CHECK-NEXT: [[READY_MBAR:%.*]] = ttg.memdesc_index [[READY_MBARS]]{{\[}}[[IDX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[READY_MBAR]], [[PHASE]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[READY_MBAR]], [[PHASE]] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: [[OPER_MBAR:%.*]] = ttg.memdesc_index [[OPER_MBARS]]{{\[}}[[IDX]]{{\]}}
-    // CHECK-NEXT: ttng.barrier_expect [[OPER_MBAR]], 32768 {ttg.partition = 2 : i32}
+    // CHECK-NEXT: ttng.barrier_expect [[OPER_MBAR]], 32768 {ttg.partition = array<i32: 2>}
 
     // CHECK-NEXT: [[A_BUF:%.*]] = ttg.memdesc_index [[A_BUFS]]{{\[}}[[IDX]]{{\]}}
-    // CHECK-NEXT: ttng.async_tma_copy_global_to_local [[A_DESC]][[[OFF_M]], [[OFF_K]]] [[A_BUF]], [[OPER_MBAR]], [[TRUE]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: ttng.async_tma_copy_global_to_local [[A_DESC]][[[OFF_M]], [[OFF_K]]] [[A_BUF]], [[OPER_MBAR]], [[TRUE]] {ttg.partition = array<i32: 2>}
     %a_reg = tt.descriptor_load %a_desc[%off_m, %off_k] : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #oper_layout>
     // CHECK-NEXT: [[B_BUF:%.*]] = ttg.memdesc_index [[B_BUFS]]{{\[}}[[IDX]]{{\]}}
-    // CHECK-NEXT: ttng.async_tma_copy_global_to_local [[B_DESC]][[[OFF_N]], [[OFF_K]]] [[B_BUF]], [[OPER_MBAR]], [[TRUE]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: ttng.async_tma_copy_global_to_local [[B_DESC]][[[OFF_N]], [[OFF_K]]] [[B_BUF]], [[OPER_MBAR]], [[TRUE]] {ttg.partition = array<i32: 2>}
     %b_reg = tt.descriptor_load %b_desc[%off_n, %off_k] : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #oper_layout>
 
     %a_shared = ttg.local_alloc %a_reg : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
     %b_shared = ttg.local_alloc %b_reg : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
-    // CHECK-NEXT: [[B_T:%.*]] = ttg.memdesc_trans [[B_BUF]] {order = array<i32: 1, 0>, ttg.partition = 1 : i32}
-    // CHECK-NEXT: ttng.wait_barrier [[OPER_MBAR]], [[PHASE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[B_T:%.*]] = ttg.memdesc_trans [[B_BUF]] {order = array<i32: 1, 0>, ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: ttng.wait_barrier [[OPER_MBAR]], [[PHASE]] {ttg.partition = array<i32: 1>}
     %b_T_shared = ttg.memdesc_trans %b_shared {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared_trans, #smem>
     %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
     // CHECK-NEXT: [[IS_LAST:%.*]] = arith.cmpi eq, [[K]], [[LAST_ITER]]
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma [[A_BUF]], [[B_T]], [[ACC_BUF]][], [[TRUE]], [[TRUE]], [[READY_MBAR]][%true], [[DONE_MBAR0]][[[IS_LAST]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma [[A_BUF]], [[B_T]], [[ACC_BUF]][], [[TRUE]], [[TRUE]], [[READY_MBAR]][%true], [[DONE_MBAR0]][[[IS_LAST]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_T_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared_trans, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
 
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
@@ -186,7 +186,7 @@ tt.func @unsupported_load() {
 
     %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
     // CHECK: [[IS_LAST:%.*]] = arith.cmpi eq, %{{.*}}, %c31_i32
-    // CHECK-NEXT: ttng.tc_gen5_mma %{{.*}}, [[ACC]][], %true, %true, [[DONE_MBAR0]][[[IS_LAST]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.tc_gen5_mma %{{.*}}, [[ACC]][], %true, %true, [[DONE_MBAR0]][[[IS_LAST]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -344,15 +344,15 @@ tt.func @matmul_tma_acc_with_unconditional_user(
     // CHECK-NEXT: [[ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
 
     // CHECK-NEXT: [[CUR_ACC_READY_BAR:%.*]] = ttg.memdesc_index [[ACC_READY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][%true] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][%true] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
 
-    // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[C:%.*]], [[LOAD_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[C:%.*]], [[LOAD_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][] {ttg.partition = array<i32: 0>}
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
     // CHECK-NEXT: [[CUR_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = 0 : i32}
+    // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = array<i32: 0>}
     "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
 
     // CHECK-NEXT: [[ACC_INDEX_INCR:%.*]] = arith.addi [[ACC_INDEX]], %c1_i32
@@ -361,12 +361,12 @@ tt.func @matmul_tma_acc_with_unconditional_user(
     // CHECK-NEXT: [[ACC_NEXT_INDEX:%.*]] = arith.select [[ACC_ROLLVER]], %c0_i32, [[ACC_INDEX_INCR]]
     // CHECK-NEXT: [[ACC_NEXT_PHASE:%.*]] = arith.select [[ACC_ROLLVER]], [[ACC_PHASE_INCR]], [[ACC_PHASE]]
 
-    // CHECK-NEXT: "acc_user"([[C]]) {ttg.partition = 0 : i32}
+    // CHECK-NEXT: "acc_user"([[C]]) {ttg.partition = array<i32: 0>}
 
     // CHECK-NEXT: [[NEXT_ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[ACC_NEXT_INDEX]]{{\]}}
     // CHECK-NEXT: [[NEXT_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_NEXT_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[ACC_NEXT_PHASE]], %true {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ACC_RESET]], [[NEXT_ACC_BUF]][], %true {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[ACC_NEXT_PHASE]], %true {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ACC_RESET]], [[NEXT_ACC_BUF]][], %true {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
@@ -433,7 +433,7 @@ tt.func @matmul_tma_acc_with_conditional_user(
     // CHECK-NEXT: [[ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
     // CHECK-NEXT: [[CUR_ACC_READY_BAR:%.*]] = ttg.memdesc_index [[ACC_READY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
     // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][[[DO_EPILOGUE]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][[[DO_EPILOGUE]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -441,12 +441,12 @@ tt.func @matmul_tma_acc_with_conditional_user(
 
     // CHECK-NEXT: scf.if [[DO_EPILOGUE]]
     scf.if %do_epilogue {
-      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
       // CHECK-NEXT: [[C:%.*]], [[USER_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][]
       // CHECK-NEXT: "acc_user"([[C]])
       "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
       // CHECK-NEXT: [[CUR_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: }
     }
 
@@ -460,8 +460,8 @@ tt.func @matmul_tma_acc_with_conditional_user(
 
     // CHECK-NEXT: [[ACC_NEXT_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[EPILOGUE_ACC_NEXT_INDEX]]{{\]}}
     // CHECK-NEXT: [[NEXT_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[EPILOGUE_ACC_NEXT_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: ttng.tmem_store [[ACC_RESET]], [[ACC_NEXT_BUF]][], %true {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: ttng.tmem_store [[ACC_RESET]], [[ACC_NEXT_BUF]][], %true {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
@@ -528,7 +528,7 @@ tt.func @matmul_tma_acc_with_conditional_def(
     // CHECK-NEXT: [[ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
 
     // CHECK-NEXT: [[CUR_ACC_READY_BAR:%.*]] = ttg.memdesc_index [[ACC_READY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][%true] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][%true] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -536,10 +536,10 @@ tt.func @matmul_tma_acc_with_conditional_def(
     %do_epilogue = arith.cmpi eq, %k, %c0_i32 : i32
     %acc_reset = arith.select %do_epilogue, %zero, %c : tensor<128x128xf32, #acc_layout>
 
-    // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[C:%.*]], [[LOAD_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[C:%.*]], [[LOAD_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: [[CUR_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = 0 : i32}
+    // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = array<i32: 0>}
 
     // CHECK-NEXT: [[ACC_INDEX_INCR:%.*]] = arith.addi [[ACC_INDEX]], %c1_i32
     // CHECK-NEXT: [[ACC_PHASE_INCR:%.*]] = arith.xori [[ACC_PHASE]], %c1_i32
@@ -552,8 +552,8 @@ tt.func @matmul_tma_acc_with_conditional_def(
 
     // CHECK-NEXT: [[NEXT_ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[ACC_NEXT_INDEX]]{{\]}}
     // CHECK-NEXT: [[NEXT_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_NEXT_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[ACC_NEXT_PHASE]], %true {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ZERO]], [[NEXT_ACC_BUF]][], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[ACC_NEXT_PHASE]], %true {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ZERO]], [[NEXT_ACC_BUF]][], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
@@ -620,7 +620,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use(
 
     // CHECK-NEXT: [[CUR_ACC_READY_BAR:%.*]] = ttg.memdesc_index [[ACC_READY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
     // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][[[DO_EPILOGUE]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], %true, %true, {{.*}}, [[CUR_ACC_READY_BAR]][[[DO_EPILOGUE]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -629,12 +629,12 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use(
 
     // CHECK-NEXT: scf.if [[DO_EPILOGUE]]
     scf.if %do_epilogue {
-      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BAR]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
       // CHECK-NEXT: [[C:%.*]], [[USER_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][]
       // CHECK-NEXT: "acc_user"([[C]])
       "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
       // CHECK-NEXT: [[CUR_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BAR]], 1 {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: }
     }
 
@@ -648,8 +648,8 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use(
 
     // CHECK-NEXT: [[NEXT_ACC_BUF:%.*]] = ttg.memdesc_index [[ACC_BUFS]]{{\[}}[[EPILOGUE_ACC_NEXT_INDEX]]{{\]}}
     // CHECK-NEXT: [[NEXT_ACC_EMPTY_BAR:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[EPILOGUE_ACC_NEXT_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ZERO]], [[NEXT_ACC_BUF]][], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BAR]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[STORE_TOK:%.*]] = ttng.tmem_store [[ZERO]], [[NEXT_ACC_BUF]][], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
@@ -723,8 +723,8 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag(
     %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #oper_layout>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
     %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
 
-    // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi eq, [[K:%.*]], %c0_i32 : i32
-    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], [[FLAG]], %true, {{.*}}, [[ACC_READY_BUF0]][[[DO_EPILOGUE]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi eq, [[K:%.*]], %c0_i32
+    // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], [[FLAG]], %true, {{.*}}, [[ACC_READY_BUF0]][[[DO_EPILOGUE]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %flag, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -737,9 +737,9 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag(
     scf.if %do_epilogue {
       // CHECK-NEXT: "some_op"()
       "some_op"() : () -> ()
-      // CHECK-NEXT: ttng.wait_barrier [[ACC_READY_BUF0]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[ACC_READY_BUF0]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
       // CHECK-NEXT: [[C:%.*]], [[USER_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][]
-      // CHECK-NEXT: ttng.arrive_barrier [[ACC_EMPTY_BUF0]], 1 {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.arrive_barrier [[ACC_EMPTY_BUF0]], 1 {ttg.partition = array<i32: 0>}
       // CHECK-NEXT: "acc_user"([[C]])
       "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
     // CHECK-NEXT: }
@@ -747,7 +747,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_no_multibuf_flag(
 
     // CHECK-NEXT: [[ACC_NEXT_PHASE:%.*]] = arith.xori [[ACC_PHASE]], %c1_i32
     // CHECK-NEXT: [[EPILOGUE_ACC_NEXT_PHASE:%.*]] = arith.select [[DO_EPILOGUE]], [[ACC_NEXT_PHASE]], [[ACC_PHASE]]
-    // CHECK-NEXT: ttng.wait_barrier [[ACC_EMPTY_BUF0]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[ACC_EMPTY_BUF0]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
@@ -788,24 +788,24 @@ tt.func @matmul_scaled_rhs_scales_tma(
     %off_k = arith.muli %k, %BLOCK_K : i32
 
     // CHECK: ttng.wait_barrier
-    // CHECK-COUNT-3: async_tma_copy_global_to_local {{.*}} {ttg.partition = 2 : i32}
+    // CHECK-COUNT-3: async_tma_copy_global_to_local {{.*}} {ttg.partition = array<i32: 2>}
     %a_reg = tt.descriptor_load %a_desc[%off_m, %off_k] : !tt.tensordesc<tensor<128x64xf8E4M3FN, #nvmma_smem>> -> tensor<128x64xf8E4M3FN, #oper_layout>
     %b_reg = tt.descriptor_load %b_desc[%off_n, %off_k] : !tt.tensordesc<tensor<128x64xf8E4M3FN, #nvmma_smem>> -> tensor<128x64xf8E4M3FN, #oper_layout>
     %b_scales_reg = tt.descriptor_load %b_scale_desc[%off_m, %c0_i32] : !tt.tensordesc<tensor<128x8xi8, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>>> -> tensor<128x8xi8, #scales>
 
     %a_sh = ttg.local_alloc %a_reg : (tensor<128x64xf8E4M3FN, #oper_layout>) -> !ttg.memdesc<128x64xf8E4M3FN, #nvmma_smem, #smem>
     %b_sh_raw = ttg.local_alloc %b_reg : (tensor<128x64xf8E4M3FN, #oper_layout>) -> !ttg.memdesc<128x64xf8E4M3FN, #nvmma_smem, #smem>
-    // CHECK-NEXT: memdesc_trans {{.*}} ttg.partition = 1 : i32
+    // CHECK-NEXT: memdesc_trans {{.*}} ttg.partition = array<i32: 1>
     %b_sh = ttg.memdesc_trans %b_sh_raw {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf8E4M3FN, #nvmma_smem, #smem> -> !ttg.memdesc<64x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>, #smem>
 
-    // CHECK-NEXT: wait_barrier {{.*}} {ttg.partition = 1 : i32}
+    // CHECK-NEXT: wait_barrier {{.*}} {ttg.partition = array<i32: 1>}
 
     %b_scales_tmem = ttng.tmem_alloc %b_scales_reg : (tensor<128x8xi8, #scales>) -> !ttg.memdesc<128x8xi8, #ttng.tensor_memory_scales_encoding<>, #ttng.tensor_memory>
 
     %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
 
     // CHECK-NEXT: [[IS_LAST:%.*]] = arith.cmpi eq, %arg6, [[LAST_ITER]]
-    // CHECK-NEXT: tc_gen5_mma_scaled {{.*}} {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: tc_gen5_mma_scaled {{.*}} {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma_scaled %a_sh, %b_sh, %c_tmem[%c_tok], %a_scales_tmem, %b_scales_tmem, %true, %true lhs = e4m3 rhs = e4m3 : !ttg.memdesc<128x64xf8E4M3FN, #nvmma_smem, #smem>, !ttg.memdesc<64x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x8xi8, #ttng.tensor_memory_scales_encoding<>, #ttng.tensor_memory>, !ttg.memdesc<128x8xi8, #ttng.tensor_memory_scales_encoding<>, #ttng.tensor_memory>
 
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
@@ -894,11 +894,11 @@ tt.func @user_partition_has_cycle(
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_T_shared, %c_tmem[%c_tok], %false, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared_trans, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
-    // CHECK: [[TIMES_TWO:%.*]] = arith.addf [[PRODUCT]], [[PRODUCT]] {ttg.partition = 0 : i32}
+    // CHECK: [[TIMES_TWO:%.*]] = arith.addf [[PRODUCT]], [[PRODUCT]] {ttg.partition = array<i32: 0>}
     %times_two = arith.addf %product, %product : tensor<128x128xf32, #acc_layout>
-    // CHECK: [[C:%.*]], %{{.*}} = ttng.tmem_load {{.*}} {ttg.partition = 0 : i32}
+    // CHECK: [[C:%.*]], %{{.*}} = ttng.tmem_load {{.*}} {ttg.partition = array<i32: 0>}
     // CHECK: arrive_barrier
-    // CHECK: [[NEXT_PRODUCT:%.*]] = arith.mulf [[TIMES_TWO]], [[C]] {ttg.partition = 0 : i32}
+    // CHECK: [[NEXT_PRODUCT:%.*]] = arith.mulf [[TIMES_TWO]], [[C]] {ttg.partition = array<i32: 0>}
     %next_product = arith.mulf %times_two, %c : tensor<128x128xf32, #acc_layout>
 
     // CHECK: yield [[NEXT_PRODUCT]]
@@ -973,7 +973,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_flag(
     // CHECK-NEXT: [[CUR_ACC_READY_BUF:%.*]] = ttg.memdesc_index [[ACC_READY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
 
     // CHECK-NEXT: [[DO_EPILOGUE:%.*]] = arith.cmpi eq, [[K:%.*]], %c0_i32
-    // CHECK-NEXT: ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], [[FLAG]], %true, {{.*}}, [[CUR_ACC_READY_BUF]][[[DO_EPILOGUE]]] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.tc_gen5_mma %{{[0-9]+}}, %{{[0-9]+}}, [[ACC_BUF]][], [[FLAG]], %true, {{.*}}, [[CUR_ACC_READY_BUF]][[[DO_EPILOGUE]]] {is_async, ttg.partition = array<i32: 1>}
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %flag, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
 
@@ -984,14 +984,14 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_flag(
 
     // CHECK-NEXT: scf.if [[DO_EPILOGUE]]
     scf.if %do_epilogue {
-      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BUF]], [[ACC_PHASE]] {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.wait_barrier [[CUR_ACC_READY_BUF]], [[ACC_PHASE]] {ttg.partition = array<i32: 0>}
       // CHECK-NEXT: "some_op"()
       "some_op"() : () -> ()
       // CHECK-NEXT: [[C:%.*]], [[USER_TOK:%.*]] = ttng.tmem_load [[ACC_BUF]][]
       // CHECK-NEXT: "acc_user"([[C]])
       "acc_user"(%c) : (tensor<128x128xf32, #acc_layout>) -> ()
       // CHECK-NEXT: [[CUR_ACC_EMPTY_BUF:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[ACC_INDEX]]{{\]}}
-      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BUF]], 1 {ttg.partition = 0 : i32}
+      // CHECK-NEXT: ttng.arrive_barrier [[CUR_ACC_EMPTY_BUF]], 1 {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: }
     }
 
@@ -1004,7 +1004,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use_flag(
     // CHECK-NEXT: [[EPILOGUE_ACC_NEXT_PHASE:%.*]] = arith.select [[DO_EPILOGUE]], [[ACC_NEXT_PHASE]], [[ACC_PHASE]]
 
     // CHECK-NEXT: [[NEXT_ACC_EMPTY_BUF:%.*]] = ttg.memdesc_index [[ACC_EMPTY_BUFS]]{{\[}}[[EPILOGUE_ACC_NEXT_INDEX]]{{\]}}
-    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BUF]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: ttng.wait_barrier [[NEXT_ACC_EMPTY_BUF]], [[EPILOGUE_ACC_NEXT_PHASE]], [[DO_EPILOGUE]] {ttg.partition = array<i32: 1>}
 
     // CHECK: arith.addi
     // CHECK-NOT: arith.addi
@@ -1023,10 +1023,10 @@ tt.func @specialize_load_only(%desc: !tt.tensordesc<tensor<128x64xf16, #shared>>
   %c1_i32 = arith.constant 1 : i32
   // CHECK: local_alloc : () -> !ttg.memdesc<3x128x64xf16,
   scf.for %i = %c0_i32 to %ub step %c1_i32 : i32 {
-    // CHECK: wait_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+    // CHECK: wait_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
     // CHECK-NEXT: fence_async_shared {{.*}}partition = 0
-    // CHECK-NEXT: arrive_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = 0 : i32}
+    // CHECK-NEXT: arrive_barrier {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>}
     %val = tt.descriptor_load %desc[%i, %i] {loop.cluster = 1 : i32, loop.stage = 0}: !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #oper_layout>
     "use"(%val) {loop.cluster = 0 : i32, loop.stage = 1 : i32} : (tensor<128x64xf16, #oper_layout>) -> ()
   } {tt.num_stages = 3 : i32, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize}
@@ -1191,12 +1191,12 @@ tt.func @store_mma_load(
     %lhs = tt.descriptor_load %lhs_desc[%i, %i] : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #oper_layout>
 
     // CHECK-NEXT: wait_barrier [[LOAD_READY_BAR]], {{.*}}partition = 0
-    // CHECK-NEXT: [[LHS:%.*]] = ttg.local_load [[LOAD_BUF]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[LHS:%.*]] = ttg.local_load [[LOAD_BUF]] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: fence_async_shared {{.*}}partition = 0
     // CHECK-NEXT: arrive_barrier [[LOAD_EMPTY_BAR]], {{.*}}partition = 0
-    // CHECK-NEXT: [[LHS_OP:%.*]] = arith.addf [[LHS]], [[LHS]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_store [[LHS_OP]], [[LHS_SHARED]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: fence_async_shared {bCluster = false, ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[LHS_OP:%.*]] = arith.addf [[LHS]], [[LHS]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_store [[LHS_OP]], [[LHS_SHARED]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: fence_async_shared {bCluster = false, ttg.partition = array<i32: 0>}
     %lhs_op = arith.addf %lhs, %lhs : tensor<128x64xf16, #oper_layout>
     %lhs_shared = ttg.local_alloc %lhs_op : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
 
@@ -1234,7 +1234,7 @@ tt.func @local_alloc_into_mma(
   // CHECK: [[LHS_SHARED:%.*]] = ttg.local_alloc %arg1 : (tensor<128x64xf16, {{.*}}>) -> !ttg.memdesc<128x64xf16,
   // CHECK: scf.for
   scf.for %i = %c0 to %ub step %c1 iter_args(%tok = %acc_tok) -> !ttg.async.token : i32 {
-    // CHECK: barrier_expect [[LOAD_READY_BAR:%.*]], 16384 {ttg.partition = 2 : i32}
+    // CHECK: barrier_expect [[LOAD_READY_BAR:%.*]], 16384 {ttg.partition = array<i32: 2>}
     %lhs_shared = ttg.local_alloc %lhs_reg : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
     %rhs_reg = tt.descriptor_load %rhs_desc[%i, %i] : !tt.tensordesc<tensor<64x128xf16, #shared>> -> tensor<64x128xf16, #oper_layout>
 
@@ -1242,10 +1242,10 @@ tt.func @local_alloc_into_mma(
     // CHECK-NEXT: [[RHS_REG:%.*]] = ttg.local_load {{.*}}partition = 0
     // CHECK-NEXT: fence_async_shared {{.*}}partition = 0
     // CHECK-NEXT: arrive_barrier
-    // CHECK-NEXT: [[RHS_REG_MOD:%.*]] = arith.addf [[RHS_REG]], [[RHS_REG]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[RHS_REG_MOD:%.*]] = arith.addf [[RHS_REG]], [[RHS_REG]] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: wait_barrier [[MMA_OPER_BAR:%.*]], %arg{{.*}}partition = 0
-    // CHECK-NEXT: local_store [[RHS_REG_MOD]], [[RHS_SHARED:%.*]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: fence_async_shared {bCluster = false, ttg.partition = 0 : i32}
+    // CHECK-NEXT: local_store [[RHS_REG_MOD]], [[RHS_SHARED:%.*]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: fence_async_shared {bCluster = false, ttg.partition = array<i32: 0>}
     // CHECK-NEXT: arrive_barrier [[MMA_READY_BAR:%.*]], 1 {{.*}}partition = 0
     %rhs_reg_mod = arith.addf %rhs_reg, %rhs_reg : tensor<64x128xf16, #oper_layout>
     %rhs_shared = ttg.local_alloc %rhs_reg_mod : (tensor<64x128xf16, #oper_layout>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
@@ -1458,29 +1458,29 @@ tt.func public @attention_forward(
   ) : i32 {
 
     // CHECK-NEXT: [[K_EMPTY_BAR:%.*]] = ttg.memdesc_index [[K_EMPTY_MBARS]]{{\[}}[[K_INDEX]]{{\]}}
-    // CHECK-NEXT: wait_barrier [[K_EMPTY_BAR]], [[K_PHASE]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: wait_barrier [[K_EMPTY_BAR]], [[K_PHASE]] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: [[K_READY_BAR:%.*]] = ttg.memdesc_index [[K_READY_MBARS]]{{\[}}[[K_INDEX]]{{\]}}
-    // CHECK-NEXT: barrier_expect [[K_READY_BAR]], 8192 {ttg.partition = 2 : i32}
+    // CHECK-NEXT: barrier_expect [[K_READY_BAR]], 8192 {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: [[K_BUF:%.*]] = ttg.memdesc_index [[K_BUFS]]{{\[}}[[K_INDEX]]{{\]}}
-    // CHECK-NEXT: async_tma_copy_global_to_local [[K_DESC]][[[I]], %c0_i32] [[K_BUF]], [[K_READY_BAR]], %true {ttg.partition = 2 : i32}
+    // CHECK-NEXT: async_tma_copy_global_to_local [[K_DESC]][[[I]], %c0_i32] [[K_BUF]], [[K_READY_BAR]], %true {ttg.partition = array<i32: 2>}
     %K = tt.descriptor_load %K_desc[%i, %c0_i32] : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #load_blocked>
     %K_shared = ttg.local_alloc %K : (tensor<64x64xf16, #load_blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
 
-    // CHECK-NEXT: [[K_TRANS:%.*]] = ttg.memdesc_trans [[K_BUF]] {order = array<i32: 1, 0>, ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[K_TRANS:%.*]] = ttg.memdesc_trans [[K_BUF]] {order = array<i32: 1, 0>, ttg.partition = array<i32: 1>}
     %K_trans = ttg.memdesc_trans %K_shared {order = array<i32: 1, 0>} : !ttg.memdesc<64x64xf16, #shared, #smem> -> !ttg.memdesc<64x64xf16, #shared_T, #smem>
-    // CHECK-NEXT: wait_barrier [[K_READY_BAR]], [[K_PHASE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: wait_barrier [[K_READY_BAR]], [[K_PHASE]] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: [[QK_BUF:%.*]] = ttg.memdesc_index [[QK_TMEM]]{{\[}}[[QK_INDEX]]{{\]}}
     // CHECK-NEXT: [[QK_EMPTY_BAR:%.*]] = ttg.memdesc_index [[QK_EMPTY_MBARS]]{{\[}}[[QK_INDEX]]{{\]}}
-    // CHECK-NEXT: wait_barrier [[QK_EMPTY_BAR]], [[QK_PHASE]], %true {ttg.partition = 1 : i32}
+    // CHECK-NEXT: wait_barrier [[QK_EMPTY_BAR]], [[QK_PHASE]], %true {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: [[QK_READY_BAR:%.*]] = ttg.memdesc_index [[QK_READY_MBARS]]{{\[}}[[QK_INDEX]]{{\]}}
-    // CHECK-NEXT: tc_gen5_mma [[Q_SHARED]], [[K_TRANS]], [[QK_BUF]][], %false, %true, [[K_EMPTY_BAR]][%true], [[QK_READY_BAR]][%true] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: tc_gen5_mma [[Q_SHARED]], [[K_TRANS]], [[QK_BUF]][], %false, %true, [[K_EMPTY_BAR]][%true], [[QK_READY_BAR]][%true] {is_async, ttg.partition = array<i32: 1>}
     %QK_tmem, %QK_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<256x64xf32, #tmem_acc, #ttng.tensor_memory, mutable>, !ttg.async.token)
     %QK_mma_tok = ttng.tc_gen5_mma %Q_shared, %K_trans, %QK_tmem[%QK_tok], %false, %true : !ttg.memdesc<256x64xf16, #shared, #smem>, !ttg.memdesc<64x64xf16, #shared_T, #smem>, !ttg.memdesc<256x64xf32, #tmem_acc, #ttng.tensor_memory, mutable>
 
-    // CHECK-NEXT: wait_barrier [[QK_READY_BAR]], [[QK_PHASE]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[QK:%.*]], [[QK_LOAD_TOK:%.*]] = ttng.tmem_load [[QK_BUF]][] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: wait_barrier [[QK_READY_BAR]], [[QK_PHASE]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[QK:%.*]], [[QK_LOAD_TOK:%.*]] = ttng.tmem_load [[QK_BUF]][] {ttg.partition = array<i32: 0>}
     %QK, %QK_load_tok = ttng.tmem_load %QK_tmem[%QK_mma_tok] : !ttg.memdesc<256x64xf32, #tmem_acc, #ttng.tensor_memory, mutable> -> tensor<256x64xf32, #blocked>
-    // CHECK-NEXT: arrive_barrier [[QK_EMPTY_BAR]], 1 {ttg.partition = 0 : i32}
+    // CHECK-NEXT: arrive_barrier [[QK_EMPTY_BAR]], 1 {ttg.partition = array<i32: 0>}
 
     // CHECK-NEXT: [[QK_INDEX_INCR:%.*]] = arith.addi [[QK_INDEX]], %c1_i32
     // CHECK-NEXT: [[QK_PHASE_INCR:%.*]] = arith.xori [[QK_PHASE]], %c1_i32
@@ -1488,17 +1488,17 @@ tt.func public @attention_forward(
     // CHECK-NEXT: [[QK_NEXT_INDEX:%.*]] = arith.select [[QK_ROLLVER]], %c0_i32, [[QK_INDEX_INCR]]
     // CHECK-NEXT: [[QK_NEXT_PHASE:%.*]] = arith.select [[QK_ROLLVER]], [[QK_PHASE_INCR]], [[QK_PHASE]]
 
-    // CHECK-NEXT: [[ROW_MAX:%.*]] = "compute_row_max"([[QK]], [[QK_SCALE]]) {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[ROW_MAX:%.*]] = "compute_row_max"([[QK]], [[QK_SCALE]]) {ttg.partition = array<i32: 0>}
     %row_max = "compute_row_max"(%QK, %qk_scale) : (tensor<256x64xf32, #blocked>, f32) -> tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    // CHECK-NEXT: [[QK_ADJ:%.*]] = "sub_row_max"([[QK]], [[ROW_MAX]], [[QK_SCALE]]) {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[QK_ADJ:%.*]] = "sub_row_max"([[QK]], [[ROW_MAX]], [[QK_SCALE]]) {ttg.partition = array<i32: 0>}
     %QK_adj = "sub_row_max"(%QK, %row_max, %qk_scale) : (tensor<256x64xf32, #blocked>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, f32) -> tensor<256x64xf32, #blocked>
-    // CHECK-NEXT: [[SOFTMAX:%.*]] = math.exp2 [[QK_ADJ]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[SOFTMAX:%.*]] = math.exp2 [[QK_ADJ]] {ttg.partition = array<i32: 0>}
     %softmax = math.exp2 %QK_adj : tensor<256x64xf32, #blocked>
 
     // CHECK-NEXT: [[DIFF_CORR:%.*]] = arith.subf [[M_I]], [[ROW_MAX]] {ttg.partition = 3 : i32}
-    // CHECK-NEXT: [[DIFF_SOFT:%.*]] = arith.subf [[M_I]], [[ROW_MAX]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[DIFF_SOFT:%.*]] = arith.subf [[M_I]], [[ROW_MAX]] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: [[ALPHA_CORR:%.*]] = math.exp2 [[DIFF_CORR]] {ttg.partition = 3 : i32}
-    // CHECK-NEXT: [[ALPHA_SOFT:%.*]] = math.exp2 [[DIFF_SOFT]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[ALPHA_SOFT:%.*]] = math.exp2 [[DIFF_SOFT]] {ttg.partition = array<i32: 0>}
     %diff = arith.subf %m_i, %row_max : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %alpha = math.exp2 %diff : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
 
@@ -1508,11 +1508,11 @@ tt.func public @attention_forward(
       %68 = arith.addf %arg29, %arg30 : f32
       // CHECK: tt.reduce.return
       tt.reduce.return %68 : f32
-    // CHECK-NEXT: {ttg.partition = 0 : i32}
+    // CHECK-NEXT: {ttg.partition = array<i32: 0>}
     }) : (tensor<256x64xf32, #blocked>) -> tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    // CHECK-NEXT: [[L_I_SCALED:%.*]] = arith.mulf [[L_I]], [[ALPHA_SOFT]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[L_I_SCALED:%.*]] = arith.mulf [[L_I]], [[ALPHA_SOFT]] {ttg.partition = array<i32: 0>}
     %l_i_scaled = arith.mulf %l_i, %alpha : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    // CHECK-NEXT: [[NEXT_L_I:%.*]] = arith.addf [[L_I_SCALED]], [[L_IJ]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[NEXT_L_I:%.*]] = arith.addf [[L_I_SCALED]], [[L_IJ]] {ttg.partition = array<i32: 0>}
     %next_l_i = arith.addf %l_i_scaled, %l_ij : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
 
     // CHECK-NEXT: [[ALPHA_0:%.*]] = tt.expand_dims [[ALPHA_CORR]] {axis = 1 : i32, ttg.partition = 3 : i32}
@@ -1527,29 +1527,29 @@ tt.func public @attention_forward(
     %acc_corrected = arith.mulf %acc, %alpha_1 : tensor<256x64xf32, #blocked>
 
     // CHECK-NEXT: [[V_EMPTY_BAR:%.*]] = ttg.memdesc_index [[V_EMPTY_MBARS]]{{\[}}[[V_INDEX]]{{\]}}
-    // CHECK-NEXT: wait_barrier [[V_EMPTY_BAR]], [[V_PHASE]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: wait_barrier [[V_EMPTY_BAR]], [[V_PHASE]] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: [[V_READY_BAR:%.*]] = ttg.memdesc_index [[V_READY_MBARS]]{{\[}}[[V_INDEX]]{{\]}}
-    // CHECK-NEXT: barrier_expect [[V_READY_BAR]], 8192 {ttg.partition = 2 : i32}
+    // CHECK-NEXT: barrier_expect [[V_READY_BAR]], 8192 {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: [[V_BUF:%.*]] = ttg.memdesc_index [[V_BUFS]]{{\[}}[[V_INDEX]]{{\]}}
-    // CHECK-NEXT: async_tma_copy_global_to_local [[V_DESC]][[[I]], %c0_i32] [[V_BUF]], [[V_READY_BAR]], %true {ttg.partition = 2 : i32}
+    // CHECK-NEXT: async_tma_copy_global_to_local [[V_DESC]][[[I]], %c0_i32] [[V_BUF]], [[V_READY_BAR]], %true {ttg.partition = array<i32: 2>}
     %V = tt.descriptor_load %V_desc[%i, %c0_i32] : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #load_blocked>
     %V_shared = ttg.local_alloc %V : (tensor<64x64xf16, #load_blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
 
-    // CHECK-NEXT: [[P:%.*]] = arith.truncf [[SOFTMAX]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: wait_barrier [[P_EMPTY_BAR0]], [[P_PHASE]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: tmem_store [[P]], [[P_BUF]], %true {ttg.partition = 0 : i32}
-    // CHECK-NEXT: arrive_barrier [[P_READY_BAR0]], 1 {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[P:%.*]] = arith.truncf [[SOFTMAX]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: wait_barrier [[P_EMPTY_BAR0]], [[P_PHASE]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: tmem_store [[P]], [[P_BUF]], %true {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: arrive_barrier [[P_READY_BAR0]], 1 {ttg.partition = array<i32: 0>}
     %P = arith.truncf %softmax : tensor<256x64xf32, #blocked> to tensor<256x64xf16, #blocked>
 
     // CHECK-NEXT: tmem_store [[ACC_CORRECTED]], [[PV_0]][], %true {ttg.partition = 3 : i32}
     // CHECK-NEXT: arrive_barrier [[PV_EMPTY_BAR0]], 1 {ttg.partition = 3 : i32}
 
-    // CHECK-NEXT: wait_barrier [[V_READY_BAR]], [[V_PHASE]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: wait_barrier [[PV_EMPTY_BAR0]], [[NEXT_PV_PHASE]], %true {ttg.partition = 1 : i32}
-    // CHECK-NEXT: wait_barrier [[P_READY_BAR0]], [[P_PHASE]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: wait_barrier [[V_READY_BAR]], [[V_PHASE]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: wait_barrier [[PV_EMPTY_BAR0]], [[NEXT_PV_PHASE]], %true {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: wait_barrier [[P_READY_BAR0]], [[P_PHASE]] {ttg.partition = array<i32: 1>}
     %P_tmem = ttng.tmem_alloc %P : (tensor<256x64xf16, #blocked>) -> !ttg.memdesc<256x64xf16, #tmem_lhs, #ttng.tensor_memory>
     %acc_tmem, %acc_tok = ttng.tmem_alloc %acc_corrected : (tensor<256x64xf32, #blocked>) -> (!ttg.memdesc<256x64xf32, #tmem_acc, #ttng.tensor_memory, mutable>, !ttg.async.token)
-    // CHECK-NEXT: tc_gen5_mma [[P_BUF]], [[V_BUF]], [[PV_0]][], %true, %true, [[V_EMPTY_BAR]][%true], [[PV_READY_BAR0]][%true], [[P_EMPTY_BAR0]][%true] {is_async, ttg.partition = 1 : i32}
+    // CHECK-NEXT: tc_gen5_mma [[P_BUF]], [[V_BUF]], [[PV_0]][], %true, %true, [[V_EMPTY_BAR]][%true], [[PV_READY_BAR0]][%true], [[P_EMPTY_BAR0]][%true] {is_async, ttg.partition = array<i32: 1>}
     %PV_mma_tok = ttng.tc_gen5_mma %P_tmem, %V_shared, %acc_tmem[%acc_tok], %true, %true : !ttg.memdesc<256x64xf16, #tmem_lhs, #ttng.tensor_memory>, !ttg.memdesc<64x64xf16, #shared, #smem>, !ttg.memdesc<256x64xf32, #tmem_acc, #ttng.tensor_memory, mutable>
     %O, %O_tok = ttng.tmem_load %acc_tmem[%PV_mma_tok] : !ttg.memdesc<256x64xf32, #tmem_acc, #ttng.tensor_memory, mutable> -> tensor<256x64xf32, #blocked>
 

--- a/test/TritonGPU/partition-loops.mlir
+++ b/test/TritonGPU/partition-loops.mlir
@@ -20,7 +20,7 @@ tt.func @one_partition(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: scf.for
   scf.for %i = %lb to %ub step %step : i32 {
     // CHECK-NEXT: op_a
-    "op_a"() {ttg.partition = 0} : () -> ()
+    "op_a"() {ttg.partition = array<i32: 0>} : () -> ()
   } {ttg.partition.stages = [0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -89,17 +89,17 @@ tt.func @multiple_partitions(%lb: i32, %ub: i32, %step: i32) {
     %a = arith.addi %i, %i : i32
     %b = arith.addi %i, %a : i32
 
-    %0 = "op_a"(%i) {ttg.partition = 0} : (i32) -> i32
-    "op_b"(%0) {ttg.partition = 0} : (i32) -> ()
-    "op_b"(%0) {ttg.partition = 0} : (i32) -> ()
+    %0 = "op_a"(%i) {ttg.partition = array<i32: 0>} : (i32) -> i32
+    "op_b"(%0) {ttg.partition = array<i32: 0>} : (i32) -> ()
+    "op_b"(%0) {ttg.partition = array<i32: 0>} : (i32) -> ()
 
-    %1 = "op_a"(%a) {ttg.partition = 1} : (i32) -> i32
-    "op_b"(%1) {ttg.partition = 1} : (i32) -> ()
-    "op_b"(%1) {ttg.partition = 1} : (i32) -> ()
+    %1 = "op_a"(%a) {ttg.partition = array<i32: 1>} : (i32) -> i32
+    "op_b"(%1) {ttg.partition = array<i32: 1>} : (i32) -> ()
+    "op_b"(%1) {ttg.partition = array<i32: 1>} : (i32) -> ()
 
-    %2 = "op_a"(%b) {ttg.partition = 2} : (i32) -> i32
-    "op_b"(%2) {ttg.partition = 2} : (i32) -> ()
-    "op_b"(%2) {ttg.partition = 2} : (i32) -> ()
+    %2 = "op_a"(%b) {ttg.partition = array<i32: 2>} : (i32) -> i32
+    "op_b"(%2) {ttg.partition = array<i32: 2>} : (i32) -> ()
+    "op_b"(%2) {ttg.partition = array<i32: 2>} : (i32) -> ()
   } {ttg.partition.stages = [0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -149,33 +149,33 @@ tt.func @multiple_partitions_two_loops(%lb: i32, %ub: i32, %step: i32,
   // CHECK-NEXT: }
   // CHECK-NEXT: "op_02e"([[RET]]#2)
 
-  "op_00b"() {ttg.partition = 0, ttg.warp_specialize.tag = 0} : () -> ()
-  "op_01b"() {ttg.partition = 1, ttg.warp_specialize.tag = 0} : () -> ()
-  "op_02b"() {ttg.partition = 2, ttg.warp_specialize.tag = 0} : () -> ()
+  "op_00b"() {ttg.partition = array<i32: 0>, ttg.warp_specialize.tag = 0} : () -> ()
+  "op_01b"() {ttg.partition = array<i32: 1>, ttg.warp_specialize.tag = 0} : () -> ()
+  "op_02b"() {ttg.partition = array<i32: 2>, ttg.warp_specialize.tag = 0} : () -> ()
   %ret:3 = scf.for %i = %lb to %ub step %step iter_args(%arg0 = %c0, %arg1 = %c1, %arg2 = %c2) -> (i32, i32, i32) : i32 {
     %a = arith.addi %i, %i : i32
     %b = arith.addi %i, %a : i32
 
-    %0 = "op_a"(%i) {ttg.partition = 0} : (i32) -> i32
-    "op_b"(%arg0) {ttg.partition = 0} : (i32) -> ()
-    "op_b"(%0) {ttg.partition = 0} : (i32) -> ()
+    %0 = "op_a"(%i) {ttg.partition = array<i32: 0>} : (i32) -> i32
+    "op_b"(%arg0) {ttg.partition = array<i32: 0>} : (i32) -> ()
+    "op_b"(%0) {ttg.partition = array<i32: 0>} : (i32) -> ()
 
-    %1 = "op_a"(%a) {ttg.partition = 1} : (i32) -> i32
-    "op_b"(%arg1) {ttg.partition = 1} : (i32) -> ()
-    "op_b"(%1) {ttg.partition = 1} : (i32) -> ()
+    %1 = "op_a"(%a) {ttg.partition = array<i32: 1>} : (i32) -> i32
+    "op_b"(%arg1) {ttg.partition = array<i32: 1>} : (i32) -> ()
+    "op_b"(%1) {ttg.partition = array<i32: 1>} : (i32) -> ()
 
-    %2 = "op_a"(%b) {ttg.partition = 2} : (i32) -> i32
-    "op_b"(%arg2) {ttg.partition = 2} : (i32) -> ()
-    "op_b"(%2) {ttg.partition = 2} : (i32) -> ()
+    %2 = "op_a"(%b) {ttg.partition = array<i32: 2>} : (i32) -> i32
+    "op_b"(%arg2) {ttg.partition = array<i32: 2>} : (i32) -> ()
+    "op_b"(%2) {ttg.partition = array<i32: 2>} : (i32) -> ()
 
     %v0 = arith.addi %arg0, %arg0 : i32
     %v1 = arith.addi %arg1, %arg1 : i32
     %v2 = arith.addi %arg2, %arg2 : i32
     scf.yield %v0, %v1, %v2: i32, i32, i32
   } {ttg.partition.stages = [0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
-  "op_00e"(%ret#0) {ttg.partition = 0, ttg.warp_specialize.tag = 0} : (i32) -> ()
-  "op_01e"(%ret#1) {ttg.partition = 1, ttg.warp_specialize.tag = 0} : (i32) -> ()
-  "op_02e"(%ret#2) {ttg.partition = 2, ttg.warp_specialize.tag = 0} : (i32) -> ()
+  "op_00e"(%ret#0) {ttg.partition = array<i32: 0>, ttg.warp_specialize.tag = 0} : (i32) -> ()
+  "op_01e"(%ret#1) {ttg.partition = array<i32: 1>, ttg.warp_specialize.tag = 0} : (i32) -> ()
+  "op_02e"(%ret#2) {ttg.partition = array<i32: 2>, ttg.warp_specialize.tag = 0} : (i32) -> ()
 
   // CHECK: partition0 num_warps(4)
   // CHECK-NEXT: op_10b
@@ -194,28 +194,28 @@ tt.func @multiple_partitions_two_loops(%lb: i32, %ub: i32, %step: i32,
   // CHECK-NEXT: scf.for
   // CHECK: } {ttg.warp_specialize.tag = 1
   // CHECK-NEXT: op_12e
-  "op_10b"() {ttg.partition = 0, ttg.warp_specialize.tag = 1} : () -> ()
-  "op_11b"() {ttg.partition = 1, ttg.warp_specialize.tag = 1} : () -> ()
-  "op_12b"() {ttg.partition = 2, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_10b"() {ttg.partition = array<i32: 0>, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_11b"() {ttg.partition = array<i32: 1>, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_12b"() {ttg.partition = array<i32: 2>, ttg.warp_specialize.tag = 1} : () -> ()
   scf.for %i = %lb to %ub step %step : i32 {
     %a = arith.addi %i, %i : i32
     %b = arith.addi %i, %a : i32
 
-    %0 = "op_a"(%i) {ttg.partition = 0} : (i32) -> i32
-    "op_b"(%0) {ttg.partition = 0} : (i32) -> ()
-    "op_b"(%0) {ttg.partition = 0} : (i32) -> ()
+    %0 = "op_a"(%i) {ttg.partition = array<i32: 0>} : (i32) -> i32
+    "op_b"(%0) {ttg.partition = array<i32: 0>} : (i32) -> ()
+    "op_b"(%0) {ttg.partition = array<i32: 0>} : (i32) -> ()
 
-    %1 = "op_a"(%a) {ttg.partition = 1} : (i32) -> i32
-    "op_b"(%1) {ttg.partition = 1} : (i32) -> ()
-    "op_b"(%1) {ttg.partition = 1} : (i32) -> ()
+    %1 = "op_a"(%a) {ttg.partition = array<i32: 1>} : (i32) -> i32
+    "op_b"(%1) {ttg.partition = array<i32: 1>} : (i32) -> ()
+    "op_b"(%1) {ttg.partition = array<i32: 1>} : (i32) -> ()
 
-    %2 = "op_a"(%b) {ttg.partition = 2} : (i32) -> i32
-    "op_b"(%2) {ttg.partition = 2} : (i32) -> ()
-    "op_b"(%2) {ttg.partition = 2} : (i32) -> ()
+    %2 = "op_a"(%b) {ttg.partition = array<i32: 2>} : (i32) -> i32
+    "op_b"(%2) {ttg.partition = array<i32: 2>} : (i32) -> ()
+    "op_b"(%2) {ttg.partition = array<i32: 2>} : (i32) -> ()
   } {ttg.partition.stages = [0, 0, 0], ttg.warp_specialize.tag = 1 : i32}
-  "op_10e"() {ttg.partition = 0, ttg.warp_specialize.tag = 1} : () -> ()
-  "op_11e"() {ttg.partition = 1, ttg.warp_specialize.tag = 1} : () -> ()
-  "op_12e"() {ttg.partition = 2, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_10e"() {ttg.partition = array<i32: 0>, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_11e"() {ttg.partition = array<i32: 1>, ttg.warp_specialize.tag = 1} : () -> ()
+  "op_12e"() {ttg.partition = array<i32: 2>, ttg.warp_specialize.tag = 1} : () -> ()
   tt.return
 }
 
@@ -235,8 +235,8 @@ tt.func @split_block_arguments(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT:     [[X:%.*]] = "op_b"([[B]])
   // CHECK-NEXT:     yield [[X]] : i32
   scf.for %i = %lb to %ub step %step iter_args(%a = %c0_i32, %b = %c1_i32) -> (i32, i32) : i32 {
-    %0 = "op_a"(%a) {ttg.partition = 0} : (i32) -> i32
-    %1 = "op_b"(%b) {ttg.partition = 1} : (i32) -> i32
+    %0 = "op_a"(%a) {ttg.partition = array<i32: 0>} : (i32) -> i32
+    %1 = "op_b"(%b) {ttg.partition = array<i32: 1>} : (i32) -> i32
     scf.yield %0, %1 : i32, i32
   } {ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -277,9 +277,9 @@ tt.func @partition_outputs(%lb: i32, %ub: i32, %step: i32) -> (!ty, !ty, !ty) {
   // CHECK-NEXT: local_store [[OUT]], [[C_BUF]]
 
   %outs:3 = scf.for %i = %lb to %ub step %step iter_args(%a = %cst0, %b = %cst1, %c = %cst2) -> (!ty, !ty, !ty) : i32 {
-    %0 = "op_a"(%i, %a) {ttg.partition = 0} : (i32, !ty) -> !ty
-    %1 = "op_b"(%i, %b) {ttg.partition = 1} : (i32, !ty) -> !ty
-    %2 = "op_c"(%i, %c) {ttg.partition = 2} : (i32, !ty) -> !ty
+    %0 = "op_a"(%i, %a) {ttg.partition = array<i32: 0>} : (i32, !ty) -> !ty
+    %1 = "op_b"(%i, %b) {ttg.partition = array<i32: 1>} : (i32, !ty) -> !ty
+    %2 = "op_c"(%i, %c) {ttg.partition = array<i32: 2>} : (i32, !ty) -> !ty
     scf.yield %0, %1, %2 : !ty, !ty, !ty
   } {ttg.partition.stages = [0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
 
@@ -296,10 +296,10 @@ tt.func @partition_outputs(%lb: i32, %ub: i32, %step: i32) -> (!ty, !ty, !ty) {
 tt.func @future_conditional_self_use(%lb: i32, %ub: i32, %step: i32, %cond: i1) {
   %c0_i32 = arith.constant 0 : i32
   scf.for %i = %lb to %ub step %step iter_args(%k = %c0_i32) -> i32 : i32 {
-    %0 = "op_a"() {ttg.partition = 0 : i32} : () -> i32
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> i32
     scf.if %cond {
       "use"(%k) : (i32) -> ()
-    } {ttg.partition = 0 : i32}
+    } {ttg.partition = array<i32: 0>}
     scf.yield %0 : i32
   } {ttg.partition.stages = [0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -316,7 +316,7 @@ tt.func @trivial_tensor_captures(%arg0: f16, %lb: i32, %ub: i32, %step: i32) {
     // CHECK: partition1 num_warps(4)
     // CHECK-NEXT: scf.for
     // CHECK-NEXT: "use"([[RANGE]], [[SPLAT]])
-    "use"(%0, %1) {ttg.partition = 1} : (tensor<256xi32>, tensor<32xf16>) -> ()
+    "use"(%0, %1) {ttg.partition = array<i32: 1>} : (tensor<256xi32>, tensor<32xf16>) -> ()
   } {ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -330,7 +330,7 @@ tt.func @tensor_captures_over_smem(%lb: i32, %ub: i32, %step: i32) {
     // CHECK: partition1
     // CHECK-NEXT: scf.for
     // CHECK-NEXT: "use"([[VALUE]])
-    "use"(%0) {ttg.partition = 1} : (tensor<32xf16, #blocked>) -> ()
+    "use"(%0) {ttg.partition = array<i32: 1>} : (tensor<32xf16, #blocked>) -> ()
   } {ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -350,9 +350,9 @@ tt.func @dce_before_warp_allocation(%lb: i32, %ub: i32, %step: i32) {
     } else {
       scf.yield %idxs : tensor<128xi32, #blocked>
     }
-    "op_a"(%0) {ttg.partition = 0 : i32} : (tensor<128xi32, #blocked>) -> ()
-    "op_b"(%i) {ttg.partition = 1 : i32} : (i32) -> ()
-    "op_c"(%0) {ttg.partition = 2 : i32} : (tensor<128xi32, #blocked>) -> ()
+    "op_a"(%0) {ttg.partition = array<i32: 0>} : (tensor<128xi32, #blocked>) -> ()
+    "op_b"(%i) {ttg.partition = array<i32: 1>} : (i32) -> ()
+    "op_c"(%0) {ttg.partition = array<i32: 2>} : (tensor<128xi32, #blocked>) -> ()
     scf.yield %0 : tensor<128xi32, #blocked>
   } {ttg.partition.stages = [0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -391,7 +391,7 @@ tt.func @clone_then_capture(%arg0: i32) {
   // CHECK: scf.for
   scf.for %arg1 = %c0_i32 to %arg0 step %c1_i32  : i32 {
     // CHECK: "use"([[V]])
-    "use"(%1) {ttg.partition = 1 : i32} : (tensor<4xi32, #blocked>) -> ()
+    "use"(%1) {ttg.partition = array<i32: 1>} : (tensor<4xi32, #blocked>) -> ()
   } {ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -408,9 +408,9 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 tt.func @still_has_ssa_deps(%lb: i32, %ub: i32, %step: i32) {
   scf.for %i = %lb to %ub step %step : i32 {
     // expected-warning @below {{non-root partition #0 has direct SSA consumer}}
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // expected-note @below {{use at distance 0 in partition #1 here}}
-    "op_b"(%0) {ttg.partition = 1} : (!ty) -> ()
+    "op_b"(%0) {ttg.partition = array<i32: 1>} : (!ty) -> ()
   } {ttg.partition.stages = [0, 1], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }

--- a/test/TritonGPU/partition-scheduling.mlir
+++ b/test/TritonGPU/partition-scheduling.mlir
@@ -144,20 +144,20 @@ tt.func @optimize_broadcast(%arg0: i32) {
   %c1_i32 = arith.constant 1 : i32
   // CHECK: scf.for
   scf.for %i = %c0_i32 to %arg0 step %c1_i32 : i32 {
-    // CHECK: [[X:%.*]] = "producer"{{.*}}partition = 0
-    %x = "producer"() {ttg.partition = 0 : i32} : () -> tensor<128xf32>
+    // CHECK: [[X:%.*]] = "producer"{{.*}}partition = [0
+    %x = "producer"() {ttg.partition = [0 : i32]} : () -> tensor<128xf32>
 
-    // CHECK-DAG: [[X0_P0:%.*]] = tt.expand_dims [[X]] {{.*}}partition = [0
-    // CHECK-DAG: [[X0_P1:%.*]] = tt.expand_dims [[X]] {{.*}}partition = [1
-    %x0 = tt.expand_dims %x {axis = 0 : i32} : tensor<128xf32> -> tensor<1x128xf32>
-    // CHECK-DAG: [[X1_P0:%.*]] = tt.broadcast [[X0_P0]] {{.*}}partition = [0
-    // CHECK-DAG: [[X1_P1:%.*]] = tt.broadcast [[X0_P1]] {{.*}}partition = [1
-    %x1 = tt.broadcast %x0 : tensor<1x128xf32> -> tensor<128x128xf32>
+    // CHECK-DAG: [[X0_P0:%.*]] = tt.expand_dims [[X]] {{.*}}partition = [0 : i32]
+    // CHECK-DAG: [[X0_P1:%.*]] = tt.expand_dims [[X]] {{.*}}partition = [1 : i32]
+    %x0 = tt.expand_dims %x {axis = 0 : i32, ttg.partition = [0 : i32, 1 : i32]} : tensor<128xf32> -> tensor<1x128xf32>
+    // CHECK-DAG: [[X1_P0:%.*]] = tt.broadcast [[X0_P0]] {{.*}}partition = [0 : i32]
+    // CHECK-DAG: [[X1_P1:%.*]] = tt.broadcast [[X0_P1]] {{.*}}partition = [1 : i32]
+    %x1 = tt.broadcast %x0 {ttg.partition = [0 : i32, 1 : i32]} : tensor<1x128xf32> -> tensor<128x128xf32>
 
-    // CHECK: "use"([[X1_P0]]) {{.*}}partition = [0
-    "use"(%x1) {ttg.partition = 0 : i32} : (tensor<128x128xf32>) -> ()
-    // CHECK: "use"([[X1_P1]]) {{.*}}partition = [1
-    "use"(%x1) {ttg.partition = 1 : i32} : (tensor<128x128xf32>) -> ()
+    // CHECK: "use"([[X1_P0]]) {{.*}}partition = [0 : i32]
+    "use"(%x1) {ttg.partition = [0 : i32]} : (tensor<128x128xf32>) -> ()
+    // CHECK: "use"([[X1_P1]]) {{.*}}partition = [1 : i32]
+    "use"(%x1) {ttg.partition = [1 : i32]} : (tensor<128x128xf32>) -> ()
   } {tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }

--- a/test/TritonGPU/partition-scheduling.mlir
+++ b/test/TritonGPU/partition-scheduling.mlir
@@ -51,7 +51,7 @@ tt.func public @attention_forward(
     %QK, %QK_load_tok = ttng.tmem_load %QK_tmem[%QK_mma_tok] : !ttg.memdesc<256x64xf32, #tmem_acc, #ttng.tensor_memory, mutable> -> tensor<256x64xf32, #blocked>
     %row_max = "compute_row_max"(%QK, %qk_scale) : (tensor<256x64xf32, #blocked>, f32) -> tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %QK_adj = "sub_row_max"(%QK, %row_max, %qk_scale) : (tensor<256x64xf32, #blocked>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, f32) -> tensor<256x64xf32, #blocked>
-    // CHECK: [[SOFTMAX:%.*]] = math.exp2 {{.*}} {ttg.partition = [0 : i32]} : tensor<256x64xf32
+    // CHECK: [[SOFTMAX:%.*]] = math.exp2 {{.*}} {ttg.partition = array<i32: 0>} : tensor<256x64xf32
     %softmax = math.exp2 %QK_adj : tensor<256x64xf32, #blocked>
     %diff = arith.subf %m_i, %row_max : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %alpha = math.exp2 %diff : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
@@ -69,9 +69,9 @@ tt.func public @attention_forward(
 
     %acc_corrected = arith.mulf %acc, %alpha_1 : tensor<256x64xf32, #blocked>
 
-    // CHECK: [[X:%.*]] = arith.addf [[SOFTMAX]], [[SOFTMAX]] {ttg.partition = [0 : i32]}
+    // CHECK: [[X:%.*]] = arith.addf [[SOFTMAX]], [[SOFTMAX]] {ttg.partition = array<i32: 0>}
     %x = arith.addf %softmax, %softmax : tensor<256x64xf32, #blocked>
-    // CHECK-NEXT: [[ACC_X:%.*]] = arith.addf %{{.*}}, [[X]] {ttg.partition = [3 : i32]}
+    // CHECK-NEXT: [[ACC_X:%.*]] = arith.addf %{{.*}}, [[X]] {ttg.partition = array<i32: 3>}
     %acc_x = arith.addf %acc, %x : tensor<256x64xf32, #blocked>
     %e = "sum"(%acc_x) : (tensor<256x64xf32, #blocked>) -> tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %next_e_i = arith.addf %e_i, %e : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
@@ -114,22 +114,22 @@ tt.func public @mma_operand_view(
 
   scf.for %i = %c0_i32 to %n_tiles step %c64_i32 : i32 {
     %K = tt.descriptor_load %K_desc[%i, %c0_i32] : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #load_blocked>
-    // CHECK: [[K_SHARED:%.*]] = ttg.local_alloc {{.*}}partition = [2
+    // CHECK: [[K_SHARED:%.*]] = ttg.local_alloc {{.*}}partition = array<i32: 2>
     %K_shared = ttg.local_alloc %K : (tensor<64x64xf16, #load_blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
 
-    // CHECK-DAG: [[TRANS_MMA:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = [1
-    // CHECK-DAG: [[K_VIEW:%.*]] = ttg.memdesc_subslice [[TRANS_MMA]]{{.*}}partition = [1
-    // CHECK-DAG: [[TRANS_USER:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = [0
+    // CHECK-DAG: [[TRANS_MMA:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = array<i32: 1>
+    // CHECK-DAG: [[K_VIEW:%.*]] = ttg.memdesc_subslice [[TRANS_MMA]]{{.*}}partition = array<i32: 1>
+    // CHECK-DAG: [[TRANS_USER:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = array<i32: 0>
     %K_trans = ttg.memdesc_trans %K_shared {order = array<i32: 1, 0>} : !ttg.memdesc<64x64xf16, #shared, #smem> -> !ttg.memdesc<64x64xf16, #shared_T, #smem>
     %K_view = ttg.memdesc_subslice %K_trans [0, 0]  : !ttg.memdesc<64x64xf16, #shared_T, #smem> -> !ttg.memdesc<64x64xf16, #shared_T, #smem>
 
-    // CHECK: ttng.tc_gen5_mma %arg0, [[K_VIEW]]{{.*}}partition = [1
+    // CHECK: ttng.tc_gen5_mma %arg0, [[K_VIEW]]{{.*}}partition = array<i32: 1>
     %QK_mma_tok = ttng.tc_gen5_mma %Q_shared, %K_view, %QK_tmem[%QK_tok], %false, %true : !ttg.memdesc<256x64xf16, #shared, #smem>, !ttg.memdesc<64x64xf16, #shared_T, #smem>, !ttg.memdesc<256x64xf32, #tmem_acc, #ttng.tensor_memory, mutable>
 
-    // CHECK: local_load [[TRANS_USER]] {{.*}}partition = [0
+    // CHECK: local_load [[TRANS_USER]] {{.*}}partition = array<i32: 0>
     %x = ttg.local_load %K_trans : !ttg.memdesc<64x64xf16, #shared_T, #smem> -> tensor<64x64xf16, #load_blocked>
 
-    // CHECK: tmem_load {{.*}}partition = [0
+    // CHECK: tmem_load {{.*}}partition = array<i32: 0>
     %QK, %QK_load_tok = ttng.tmem_load %QK_tmem[%QK_mma_tok] : !ttg.memdesc<256x64xf32, #tmem_acc, #ttng.tensor_memory, mutable> -> tensor<256x64xf32, #blocked>
 
     "use"(%x, %QK) : (tensor<64x64xf16, #load_blocked>, tensor<256x64xf32, #blocked>) -> ()
@@ -144,20 +144,20 @@ tt.func @optimize_broadcast(%arg0: i32) {
   %c1_i32 = arith.constant 1 : i32
   // CHECK: scf.for
   scf.for %i = %c0_i32 to %arg0 step %c1_i32 : i32 {
-    // CHECK: [[X:%.*]] = "producer"{{.*}}partition = [0
-    %x = "producer"() {ttg.partition = [0 : i32]} : () -> tensor<128xf32>
+    // CHECK: [[X:%.*]] = "producer"{{.*}}partition = array<i32: 0>
+    %x = "producer"() {ttg.partition = array<i32: 0>} : () -> tensor<128xf32>
 
-    // CHECK-DAG: [[X0_P0:%.*]] = tt.expand_dims [[X]] {{.*}}partition = [0 : i32]
-    // CHECK-DAG: [[X0_P1:%.*]] = tt.expand_dims [[X]] {{.*}}partition = [1 : i32]
-    %x0 = tt.expand_dims %x {axis = 0 : i32, ttg.partition = [0 : i32, 1 : i32]} : tensor<128xf32> -> tensor<1x128xf32>
-    // CHECK-DAG: [[X1_P0:%.*]] = tt.broadcast [[X0_P0]] {{.*}}partition = [0 : i32]
-    // CHECK-DAG: [[X1_P1:%.*]] = tt.broadcast [[X0_P1]] {{.*}}partition = [1 : i32]
-    %x1 = tt.broadcast %x0 {ttg.partition = [0 : i32, 1 : i32]} : tensor<1x128xf32> -> tensor<128x128xf32>
+    // CHECK-DAG: [[X0_P0:%.*]] = tt.expand_dims [[X]] {{.*}}partition = array<i32: 0>
+    // CHECK-DAG: [[X0_P1:%.*]] = tt.expand_dims [[X]] {{.*}}partition = array<i32: 1>
+    %x0 = tt.expand_dims %x {axis = 0 : i32, ttg.partition = array<i32: 0, 1>} : tensor<128xf32> -> tensor<1x128xf32>
+    // CHECK-DAG: [[X1_P0:%.*]] = tt.broadcast [[X0_P0]] {{.*}}partition = array<i32: 0>
+    // CHECK-DAG: [[X1_P1:%.*]] = tt.broadcast [[X0_P1]] {{.*}}partition = array<i32: 1>
+    %x1 = tt.broadcast %x0 {ttg.partition = array<i32: 0, 1>} : tensor<1x128xf32> -> tensor<128x128xf32>
 
-    // CHECK: "use"([[X1_P0]]) {{.*}}partition = [0 : i32]
-    "use"(%x1) {ttg.partition = [0 : i32]} : (tensor<128x128xf32>) -> ()
-    // CHECK: "use"([[X1_P1]]) {{.*}}partition = [1 : i32]
-    "use"(%x1) {ttg.partition = [1 : i32]} : (tensor<128x128xf32>) -> ()
+    // CHECK: "use"([[X1_P0]]) {{.*}}partition = array<i32: 0>
+    "use"(%x1) {ttg.partition = array<i32: 0>} : (tensor<128x128xf32>) -> ()
+    // CHECK: "use"([[X1_P1]]) {{.*}}partition = array<i32: 1>
+    "use"(%x1) {ttg.partition = array<i32: 1>} : (tensor<128x128xf32>) -> ()
   } {tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }

--- a/test/TritonGPU/partition-scheduling.mlir
+++ b/test/TritonGPU/partition-scheduling.mlir
@@ -114,22 +114,22 @@ tt.func public @mma_operand_view(
 
   scf.for %i = %c0_i32 to %n_tiles step %c64_i32 : i32 {
     %K = tt.descriptor_load %K_desc[%i, %c0_i32] : !tt.tensordesc<tensor<64x64xf16, #shared>> -> tensor<64x64xf16, #load_blocked>
-    // CHECK: [[K_SHARED:%.*]] = ttg.local_alloc {{.*}}partition = 2
+    // CHECK: [[K_SHARED:%.*]] = ttg.local_alloc {{.*}}partition = [2
     %K_shared = ttg.local_alloc %K : (tensor<64x64xf16, #load_blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
 
-    // CHECK-DAG: [[TRANS_MMA:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = 1
-    // CHECK-DAG: [[K_VIEW:%.*]] = ttg.memdesc_subslice [[TRANS_MMA]]{{.*}}partition = 1
-    // CHECK-DAG: [[TRANS_USER:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = 0
+    // CHECK-DAG: [[TRANS_MMA:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = [1
+    // CHECK-DAG: [[K_VIEW:%.*]] = ttg.memdesc_subslice [[TRANS_MMA]]{{.*}}partition = [1
+    // CHECK-DAG: [[TRANS_USER:%.*]] = ttg.memdesc_trans [[K_SHARED]] {{.*}}partition = [0
     %K_trans = ttg.memdesc_trans %K_shared {order = array<i32: 1, 0>} : !ttg.memdesc<64x64xf16, #shared, #smem> -> !ttg.memdesc<64x64xf16, #shared_T, #smem>
     %K_view = ttg.memdesc_subslice %K_trans [0, 0]  : !ttg.memdesc<64x64xf16, #shared_T, #smem> -> !ttg.memdesc<64x64xf16, #shared_T, #smem>
 
-    // CHECK: ttng.tc_gen5_mma %arg0, [[K_VIEW]]{{.*}}partition = 1
+    // CHECK: ttng.tc_gen5_mma %arg0, [[K_VIEW]]{{.*}}partition = [1
     %QK_mma_tok = ttng.tc_gen5_mma %Q_shared, %K_view, %QK_tmem[%QK_tok], %false, %true : !ttg.memdesc<256x64xf16, #shared, #smem>, !ttg.memdesc<64x64xf16, #shared_T, #smem>, !ttg.memdesc<256x64xf32, #tmem_acc, #ttng.tensor_memory, mutable>
 
-    // CHECK: local_load [[TRANS_USER]] {{.*}}partition = 0
+    // CHECK: local_load [[TRANS_USER]] {{.*}}partition = [0
     %x = ttg.local_load %K_trans : !ttg.memdesc<64x64xf16, #shared_T, #smem> -> tensor<64x64xf16, #load_blocked>
 
-    // CHECK: tmem_load {{.*}}partition = 0
+    // CHECK: tmem_load {{.*}}partition = [0
     %QK, %QK_load_tok = ttng.tmem_load %QK_tmem[%QK_mma_tok] : !ttg.memdesc<256x64xf32, #tmem_acc, #ttng.tensor_memory, mutable> -> tensor<256x64xf32, #blocked>
 
     "use"(%x, %QK) : (tensor<64x64xf16, #load_blocked>, tensor<256x64xf32, #blocked>) -> ()
@@ -147,16 +147,16 @@ tt.func @optimize_broadcast(%arg0: i32) {
     // CHECK: [[X:%.*]] = "producer"{{.*}}partition = 0
     %x = "producer"() {ttg.partition = 0 : i32} : () -> tensor<128xf32>
 
-    // CHECK-DAG: [[X0_P0:%.*]] = tt.expand_dims [[X]] {{.*}}partition = 0
-    // CHECK-DAG: [[X0_P1:%.*]] = tt.expand_dims [[X]] {{.*}}partition = 1
+    // CHECK-DAG: [[X0_P0:%.*]] = tt.expand_dims [[X]] {{.*}}partition = [0
+    // CHECK-DAG: [[X0_P1:%.*]] = tt.expand_dims [[X]] {{.*}}partition = [1
     %x0 = tt.expand_dims %x {axis = 0 : i32} : tensor<128xf32> -> tensor<1x128xf32>
-    // CHECK-DAG: [[X1_P0:%.*]] = tt.broadcast [[X0_P0]] {{.*}}partition = 0
-    // CHECK-DAG: [[X1_P1:%.*]] = tt.broadcast [[X0_P1]] {{.*}}partition = 1
+    // CHECK-DAG: [[X1_P0:%.*]] = tt.broadcast [[X0_P0]] {{.*}}partition = [0
+    // CHECK-DAG: [[X1_P1:%.*]] = tt.broadcast [[X0_P1]] {{.*}}partition = [1
     %x1 = tt.broadcast %x0 : tensor<1x128xf32> -> tensor<128x128xf32>
 
-    // CHECK: "use"([[X1_P0]]) {{.*}}partition = 0
+    // CHECK: "use"([[X1_P0]]) {{.*}}partition = [0
     "use"(%x1) {ttg.partition = 0 : i32} : (tensor<128x128xf32>) -> ()
-    // CHECK: "use"([[X1_P1]]) {{.*}}partition = 1
+    // CHECK: "use"([[X1_P1]]) {{.*}}partition = [1
     "use"(%x1) {ttg.partition = 1 : i32} : (tensor<128x128xf32>) -> ()
   } {tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32], ttg.warp_specialize.tag = 0 : i32}
   tt.return

--- a/test/TritonGPU/rewrite-partition-dependencies.mlir
+++ b/test/TritonGPU/rewrite-partition-dependencies.mlir
@@ -13,25 +13,25 @@ tt.func @two_consumers(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: [[ABUF:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<1x1xi32, {{.*}}>
   // CHECK-NEXT: [[AREF:%.*]] = nvws.aref.create [[ABUF]]
   scf.for %i = %lb to %ub step %step iter_args() -> () : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK: [[VAL:%.*]] = "op_a"
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[VAL]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: ttg.local_store [[VAL]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
 
-    "op_b"(%0) {ttg.partition = 1} : (!ty) -> ()
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    "op_b"(%0) {ttg.partition = array<i32: 1>} : (!ty) -> ()
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"([[VAL]])
 
-    "op_c"(%0) {ttg.partition = 2} : (!ty) -> ()
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    "op_c"(%0) {ttg.partition = array<i32: 2>} : (!ty) -> ()
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: "op_c"([[VAL]])
     // CHECK-NEXT: "op_d"([[VAL]])
-    "op_d"(%0) {ttg.partition = 2} : (!ty) -> ()
+    "op_d"(%0) {ttg.partition = array<i32: 2>} : (!ty) -> ()
   } {ttg.partition.stages = [0, 2, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -44,16 +44,16 @@ tt.func @distance_one(%lb: i32, %ub: i32, %step: i32) {
   %cst = arith.constant dense<0> : !ty
   // CHECK: scf.for [[IV:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[K:%.*]] = {{.*}})
   scf.for %i = %lb to %ub step %step iter_args(%k = %cst) -> (!ty) : i32 {
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[K]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: ttg.local_store [[K]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK: [[VAL:%.*]] = "op_a"
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"([[VAL]])
-    "op_b"(%k) {ttg.partition = 1} : (!ty) -> ()
+    "op_b"(%k) {ttg.partition = array<i32: 1>} : (!ty) -> ()
 
     scf.yield %0 : !ty
   } {ttg.partition.stages = [0, 0], ttg.warp_specialize.tag = 0 : i32}
@@ -68,41 +68,41 @@ tt.func @complex_case(%lb: i32, %ub: i32, %step: i32) {
   %cst = arith.constant dense<0> : !ty
   // CHECK: scf.for [[IV:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[K:%.*]] = {{.*}}, [[L:%.*]] = {{.*}})
   scf.for %i = %lb to %ub step %step iter_args(%k = %cst, %l = %cst) -> (!ty, !ty) : i32 {
-    // CHECK: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]][[[C0]], [[C0]]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[L]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]][[[C0]]], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]][[[C0]], [[C0]]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[K]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]][[[C0]]], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]][[[C0]], [[C0]]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: ttg.local_store [[L]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]][[[C0]]], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]][[[C0]], [[C0]]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: ttg.local_store [[K]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]][[[C0]]], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
 
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK-NEXT: op_a
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF1]][[[C0]], [[C0]]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[K1:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF1]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF1]][[[C0]], [[C0]]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[K1:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF1]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"([[K1]])
-    "op_b"(%k) {ttg.partition = 1} : (!ty) -> ()
+    "op_b"(%k) {ttg.partition = array<i32: 1>} : (!ty) -> ()
 
 
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF1]][[[C0]], [[C0]]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: [[K2:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF1]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF1]][[[C0]], [[C0]]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: [[K2:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF1]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: "op_c"([[K2]])
     // CHECK-NEXT: "op_c"([[K2]])
-    "op_c"(%k) {ttg.partition = 2} : (!ty) -> ()
-    "op_c"(%k) {ttg.partition = 2} : (!ty) -> ()
+    "op_c"(%k) {ttg.partition = array<i32: 2>} : (!ty) -> ()
+    "op_c"(%k) {ttg.partition = array<i32: 2>} : (!ty) -> ()
 
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF2]][[[C0]], [[C0]]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[L1:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF2]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF2]][[[C0]], [[C0]]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[L1:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF2]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_d"([[L1]])
-    "op_d"(%l) {ttg.partition = 1} : (!ty) -> ()
+    "op_d"(%l) {ttg.partition = array<i32: 1>} : (!ty) -> ()
 
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF2]][[[C0]], [[C0]]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: [[L2:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF2]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF2]][[[C0]], [[C0]]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: [[L2:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF2]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: "op_d"([[L2]])
-    "op_d"(%l) {ttg.partition = 2} : (!ty) -> ()
+    "op_d"(%l) {ttg.partition = array<i32: 2>} : (!ty) -> ()
     scf.yield %0, %k : !ty, !ty
   } {ttg.partition.stages = [0, 2, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -119,23 +119,23 @@ tt.func @reuse_argument(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: [[AREF:%.*]] = nvws.aref.create
   // CHECK-NEXT: scf.for
   scf.for %i = %lb to %ub step %step iter_args(%k = %cst0, %l = %cst1) -> (!ty, !ty) : i32 {
-    // CHECK-NEXT: {{.*}}, [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]][{{.*}}] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: {{.*}}, [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]][{{.*}}] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: local_store
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF]][{{.*}}], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF]][{{.*}}], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: op_a
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
 
-    // CHECK-NEXT: aref.get.enter [[AREF]][{{.*}}] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: local_load {{.*}} {ttg.partition = 1 : i32}
-    // CHECK-NEXT: aref.get.exit [[AREF]][{{.*}}], {{.*}} [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: aref.get.enter [[AREF]][{{.*}}] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: local_load {{.*}} {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: aref.get.exit [[AREF]][{{.*}}], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: op_d
-    "op_d"(%l) {ttg.partition = 1} : (!ty) -> ()
+    "op_d"(%l) {ttg.partition = array<i32: 1>} : (!ty) -> ()
 
-    // CHECK-NEXT: aref.get.enter [[AREF]][{{.*}}] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: local_load {{.*}} {ttg.partition = 2 : i32}
-    // CHECK-NEXT: aref.get.exit [[AREF]][{{.*}}], {{.*}} [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: aref.get.enter [[AREF]][{{.*}}] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: local_load {{.*}} {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: aref.get.exit [[AREF]][{{.*}}], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: op_d
-    "op_d"(%l) {ttg.partition = 2} : (!ty) -> ()
+    "op_d"(%l) {ttg.partition = array<i32: 2>} : (!ty) -> ()
     scf.yield %0, %k : !ty, !ty
   } {ttg.partition.stages = [1, 0, 0], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -159,35 +159,35 @@ tt.func @multiplicity_branch(%lb: i32, %ub: i32, %step: i32) {
 
   // CHECK: scf.for [[IV:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[A:%.*]] = {{.*}}, [[B:%.*]] = {{.*}}, [[C:%.*]] = {{.*}})
   scf.for %i = %lb to %ub step %step iter_args(%a = %cst0, %b = %cst1, %c = %cst2) -> (!ty, !ty, !ty) : i32 {
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN3:%.*]] = nvws.aref.put.enter [[AREF3]][{{.*}}] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_store [[C]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF3]][{{.*}}], [[TOKEN3]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]][{{.*}}] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_store [[B]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]][{{.*}}], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]][{{.*}}] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_store [[A]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]][{{.*}}], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN3:%.*]] = nvws.aref.put.enter [[AREF3]][{{.*}}] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_store [[C]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF3]][{{.*}}], [[TOKEN3]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]][{{.*}}] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_store [[B]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]][{{.*}}], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]][{{.*}}] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_store [[A]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]][{{.*}}], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: op_a
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
 
     // CHECK: aref.get.enter [[AREF1]]
     // CHECK-NEXT: local_load
     // CHECK-NEXT: aref.get.exit [[AREF1]]
     // CHECK-NEXT: op_b
-    "op_b"(%a) {ttg.partition = 1}: (!ty) -> ()
+    "op_b"(%a) {ttg.partition = array<i32: 1>}: (!ty) -> ()
 
     // CHECK: aref.get.enter [[AREF2]]
     // CHECK-NEXT: local_load
     // CHECK-NEXT: aref.get.exit [[AREF2]]
     // CHECK-NEXT: op_c
-    "op_c"(%b) {ttg.partition = 2}: (!ty) -> ()
+    "op_c"(%b) {ttg.partition = array<i32: 2>}: (!ty) -> ()
 
     // CHECK: aref.get.enter [[AREF3]]
     // CHECK-NEXT: local_load
     // CHECK-NEXT: aref.get.exit [[AREF3]]
     // CHECK-NEXT: op_d
-    "op_d"(%c) {ttg.partition = 3}: (!ty) -> ()
+    "op_d"(%c) {ttg.partition = array<i32: 3>}: (!ty) -> ()
 
     scf.yield %0, %a, %a : !ty, !ty, !ty
   } {ttg.partition.stages = [0, 0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
@@ -212,35 +212,35 @@ tt.func @multiplicity_branch2(%lb: i32, %ub: i32, %step: i32) {
 
   // CHECK: scf.for [[IV:%.*]] = [[LB:%.*]] to [[UB:%.*]] step [[STEP:%.*]] iter_args([[A:%.*]] = {{.*}}, [[B:%.*]] = {{.*}}, [[C:%.*]] = {{.*}})
   scf.for %i = %lb to %ub step %step iter_args(%a = %cst0, %b = %cst1, %c = %cst2) -> (!ty, !ty, !ty) : i32 {
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN3:%.*]] = nvws.aref.put.enter [[AREF3]][{{.*}}] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: local_store [[C]], [[BUF]] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF3]][{{.*}}], [[TOKEN3]] [#nvws.async_op<none>] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]][{{.*}}] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: local_store [[B]], [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]][{{.*}}], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]][{{.*}}] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: local_store [[A]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]][{{.*}}], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN3:%.*]] = nvws.aref.put.enter [[AREF3]][{{.*}}] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: local_store [[C]], [[BUF]] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF3]][{{.*}}], [[TOKEN3]] [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN2:%.*]] = nvws.aref.put.enter [[AREF2]][{{.*}}] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: local_store [[B]], [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF2]][{{.*}}], [[TOKEN2]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN1:%.*]] = nvws.aref.put.enter [[AREF1]][{{.*}}] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: local_store [[A]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF1]][{{.*}}], [[TOKEN1]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
     // CHECK-NEXT: op_a
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
 
-    // CHECK: aref.get.enter [[AREF1]][{{.*}}, {{.*}}] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[A1:%.*]] = ttg.local_load {{.*}} {ttg.partition = 1 : i32}
+    // CHECK: aref.get.enter [[AREF1]][{{.*}}, {{.*}}] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[A1:%.*]] = ttg.local_load {{.*}} {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: aref.get.exit [[AREF1]]
-    // CHECK-NEXT: "op_b"([[A1]]) {ttg.partition = 1 : i32}
-    %d = "op_b"(%a) {ttg.partition = 1}: (!ty) -> !ty
+    // CHECK-NEXT: "op_b"([[A1]]) {ttg.partition = array<i32: 1>}
+    %d = "op_b"(%a) {ttg.partition = array<i32: 1>}: (!ty) -> !ty
 
-    // CHECK: aref.get.enter [[AREF2]][{{.*}}, {{.*}}] {ttg.partition = 2 : i32}
-    // CHECK-NEXT: [[B1:%.*]] = ttg.local_load {{.*}} {ttg.partition = 2 : i32}
+    // CHECK: aref.get.enter [[AREF2]][{{.*}}, {{.*}}] {ttg.partition = array<i32: 2>}
+    // CHECK-NEXT: [[B1:%.*]] = ttg.local_load {{.*}} {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: aref.get.exit [[AREF2]]
-    // CHECK-NEXT: "op_c"([[B1]]) {ttg.partition = 2 : i32}
-    %e = "op_c"(%b) {ttg.partition = 2}: (!ty) -> !ty
+    // CHECK-NEXT: "op_c"([[B1]]) {ttg.partition = array<i32: 2>}
+    %e = "op_c"(%b) {ttg.partition = array<i32: 2>}: (!ty) -> !ty
 
     // CHECK: aref.get.enter [[AREF3]][{{.*}}, {{.*}}] {ttg.partition = 3 : i32}
     // CHECK-NEXT: [[C1:%.*]] = ttg.local_load {{.*}} {ttg.partition = 3 : i32}
     // CHECK-NEXT: aref.get.exit [[AREF3]]
-    // CHECK-NEXT: "op_d"([[C1]]) {ttg.partition = 3 : i32}
-    "op_d"(%c) {ttg.partition = 3}: (!ty) -> ()
+    // CHECK-NEXT: "op_d"([[C1]]) {ttg.partition = array<i32: 3> : i32}
+    "op_d"(%c) {ttg.partition = array<i32: 3>}: (!ty) -> ()
 
     scf.yield %0, %d, %e : !ty, !ty, !ty
   } {ttg.partition.stages = [0, 0, 0, 0], ttg.warp_specialize.tag = 0 : i32}
@@ -254,7 +254,7 @@ tt.func @self_recursion(%lb: i32, %ub: i32, %step: i32) {
   // CHECK: iter_args([[ARG:%arg[0-9]+]] = %cst)
   %0 = scf.for %i = %lb to %ub step %step iter_args(%k = %cst) -> (!ty) : i32 {
     // CHECK-NEXT: [[OUT:%.*]] = "op_a"([[ARG]])
-    %0 = "op_a"(%k) {ttg.partition = 0} : (!ty) -> !ty
+    %0 = "op_a"(%k) {ttg.partition = array<i32: 0>} : (!ty) -> !ty
     // CHECK: yield [[OUT]]
     scf.yield %0 : !ty
   } {ttg.partition.stages = [0], ttg.warp_specialize.tag = 0 : i32}
@@ -265,13 +265,13 @@ tt.func @self_recursion(%lb: i32, %ub: i32, %step: i32) {
 tt.func @self_recursion_and_use(%lb: i32, %ub: i32, %step: i32) {
   %cst = arith.constant dense<0> : !ty
   %0 = scf.for %i = %lb to %ub step %step iter_args(%k = %cst) -> (!ty) : i32 {
-    %0 = "op_a"(%k) {ttg.partition = 0} : (!ty) -> !ty
+    %0 = "op_a"(%k) {ttg.partition = array<i32: 0>} : (!ty) -> !ty
     // CHECK: "op_a"
     // CHECK-NEXT: nvws.aref.put.enter
     // CHECK-NEXT: local_store
     // CHECK-NEXT: nvws.aref.put.exit
 
-    "op_b"(%0) {ttg.partition = 1} : (!ty) -> !ty
+    "op_b"(%0) {ttg.partition = array<i32: 1>} : (!ty) -> !ty
     // CHECK-NEXT: nvws.aref.get.enter
     // CHECK-NEXT: ttg.local_load
     // CHECK-NEXT: nvws.aref.get.exit
@@ -285,7 +285,7 @@ tt.func @self_recursion_and_use(%lb: i32, %ub: i32, %step: i32) {
 // CHECK-LABEL: @conditional_consumer
 tt.func @conditional_consumer(%lb: i32, %ub: i32, %step: i32) {
   scf.for %i = %lb to %ub step %step : i32 {
-    %0 = "producer"() {ttg.partition = 0} : () -> !ty
+    %0 = "producer"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK: "producer"
     // CHECK-NEXT: nvws.aref.put.enter
     // CHECK-NEXT: local_store
@@ -304,8 +304,8 @@ tt.func @conditional_consumer(%lb: i32, %ub: i32, %step: i32) {
     } else {
       %2 = "something"() : () -> !ty
       scf.yield %2 : !ty
-    } {ttg.partition = 1}
-    "keep"(%1) {ttg.partition = 1} : (!ty) -> ()
+    } {ttg.partition = array<i32: 1>}
+    "keep"(%1) {ttg.partition = array<i32: 1>} : (!ty) -> ()
   } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
 }
@@ -378,7 +378,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 tt.func @invalid_attribute(%lb: i32, %ub: i32, %step: i32) {
   scf.for %k = %lb to %ub step %step : i32 {
     // expected-error @below {{invalid partition index -1}}
-    "op"() {ttg.partition = -1} : () -> ()
+    "op"() {ttg.partition = array<i32: -1>} : () -> ()
     scf.yield
   } {ttg.partition.stages = [2, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -401,18 +401,18 @@ tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: [[AREF2:%.*]] = nvws.aref.create
 
   scf.for %i = %lb to %ub step %step : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK: "op_a"
-    // CHECK-NEXT: nvws.aref.put.enter [[AREF1]][[[C0]], [[C0]]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF1]][[[C0]], [[C0]]] {ttg.partition = array<i32: 0>}
 
-    %1 = "op_b"(%0) {ttg.partition = 1} : (!ty) -> !ty
-    // CHECK: nvws.aref.get.exit [[AREF1]][[[C0]]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    %1 = "op_b"(%0) {ttg.partition = array<i32: 1>} : (!ty) -> !ty
+    // CHECK: nvws.aref.get.exit [[AREF1]][[[C0]]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"
-    // CHECK-NEXT: nvws.aref.put.enter [[AREF2]][[[C0]], [[C0]]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF2]][[[C0]], [[C0]]] {ttg.partition = array<i32: 1>}
 
-    // CHECK: nvws.aref.get.exit [[AREF2]][[[C0]]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK: nvws.aref.get.exit [[AREF2]][[[C0]]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
 
-    "op_c"(%1) {ttg.partition = 0} : (!ty) -> ()
+    "op_c"(%1) {ttg.partition = array<i32: 0>} : (!ty) -> ()
     scf.yield
   } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return
@@ -436,22 +436,22 @@ tt.func @cycle_in_partition(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: ttg.local_alloc
   // CHECK-NEXT: [[AREF3:%.*]] = nvws.aref.create
   scf.for %j = %lb to %ub step %step : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> !ty
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> !ty
     // CHECK: "op_a"
-    // CHECK-NEXT: nvws.aref.put.enter [[AREF1]][[[C0]], [[C0]]] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF1]][[[C0]], [[C0]]] {ttg.partition = array<i32: 0>}
 
-    %1 = "op_b"(%0) {ttg.partition = 1} : (!ty) -> !ty
-    // CHECK: nvws.aref.get.exit [[AREF1]][[[C0]]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    %1 = "op_b"(%0) {ttg.partition = array<i32: 1>} : (!ty) -> !ty
+    // CHECK: nvws.aref.get.exit [[AREF1]][[[C0]]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"
-    // CHECK-NEXT: nvws.aref.put.enter [[AREF2]][[[C0]], [[C0]]] {ttg.partition = 1 : i32}
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF2]][[[C0]], [[C0]]] {ttg.partition = array<i32: 1>}
 
-    %2 = "op_c"(%1) {ttg.partition = 2} : (!ty) -> !ty
-    // CHECK: nvws.aref.get.exit [[AREF2]][[[C0]]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 2 : i32}
+    %2 = "op_c"(%1) {ttg.partition = array<i32: 2>} : (!ty) -> !ty
+    // CHECK: nvws.aref.get.exit [[AREF2]][[[C0]]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 2>}
     // CHECK-NEXT: "op_c"
-    // CHECK-NEXT: nvws.aref.put.enter [[AREF3]][[[C0]], [[C0]]] {ttg.partition = 2 : i32}
+    // CHECK-NEXT: nvws.aref.put.enter [[AREF3]][[[C0]], [[C0]]] {ttg.partition = array<i32: 2>}
 
-    "op_c"(%2) {ttg.partition = 0} : (!ty) -> ()
-    // CHECK: nvws.aref.get.exit [[AREF3]][[[C0]]], {{.*}} [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    "op_c"(%2) {ttg.partition = array<i32: 0>} : (!ty) -> ()
+    // CHECK: nvws.aref.get.exit [[AREF3]][[[C0]]], {{.*}} [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
     // CHECK: "op_c"
     scf.yield
   } {ttg.partition.stages = [0, 2, 3], ttg.warp_specialize.tag = 0 : i32}
@@ -470,7 +470,7 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 tt.func @invalid_root_partition(%lb: i32, %ub: i32, %step: i32) {
   scf.for %i = %lb to %ub step %step : i32 {
     // expected-note @below {{operand defined here in partition #0 at distance 0}}
-    %0 = "partition"() {ttg.partition = 0} : () -> index
+    %0 = "partition"() {ttg.partition = array<i32: 0>} : () -> index
     // expected-warning @below {{operation in the root partition depends on a value that originates from a non-root partition through operand #0}}
     "root"(%0) : (index) -> ()
     scf.yield
@@ -493,7 +493,7 @@ tt.func @invalid_root_partition(%lb: i32, %ub: i32, %step: i32) {
     // expected-warning @below {{operation in the root partition depends on a value that originates from a non-root partition through operand #0}}
     "root"(%k) : (index) -> ()
     // expected-note @below {{operand defined here in partition #0 at distance 1}}
-    %0 = "partition"() {ttg.partition = 0} : () -> index
+    %0 = "partition"() {ttg.partition = array<i32: 0>} : () -> index
     scf.yield %0 : index
   } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
   tt.return

--- a/test/TritonGPU/rewrite-partition-dependencies.mlir
+++ b/test/TritonGPU/rewrite-partition-dependencies.mlir
@@ -326,18 +326,18 @@ tt.func @scalar_consumers(%lb: i32, %ub: i32, %step: i32) {
   // CHECK-NEXT: [[ABUF:%.*]] = ttg.local_alloc : () -> !ttg.memdesc<1x1xi32, {{.*}}>
   // CHECK-NEXT: [[AREF:%.*]] = nvws.aref.create [[ABUF]]
   scf.for %i = %lb to %ub step %step iter_args() -> () : i32 {
-    %0 = "op_a"() {ttg.partition = 0} : () -> i32
+    %0 = "op_a"() {ttg.partition = array<i32: 0>} : () -> i32
     // CHECK: [[VAL:%.*]] = "op_a"
-    // CHECK-NEXT: [[VAL_TENSOR:%.*]] = tt.splat [[VAL]] {ttg.partition = 0 : i32} : i32 -> tensor<1xi32, #blocked>
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: ttg.local_store [[VAL_TENSOR]], [[BUF]] {ttg.partition = 0 : i32}
-    // CHECK-NEXT: nvws.aref.put.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 0 : i32}
+    // CHECK-NEXT: [[VAL_TENSOR:%.*]] = tt.splat [[VAL]] {ttg.partition = array<i32: 0>} : i32 -> tensor<1xi32, #blocked>
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.put.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: ttg.local_store [[VAL_TENSOR]], [[BUF]] {ttg.partition = array<i32: 0>}
+    // CHECK-NEXT: nvws.aref.put.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 0>}
 
-    "op_b"(%0) {ttg.partition = 1} : (i32) -> ()
-    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = 1 : i32}
-    // CHECK-NEXT: [[VAL_SCALAR:%.*]] = tt.unsplat [[VAL]] {ttg.partition = 1 : i32} : tensor<1xi32, #blocked>
-    // CHECK-NEXT: nvws.aref.get.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = 1 : i32}
+    "op_b"(%0) {ttg.partition = array<i32: 1>} : (i32) -> ()
+    // CHECK-NEXT: [[BUF:%.*]], [[TOKEN:%.*]] = nvws.aref.get.enter [[AREF]][[[C0]], [[C0]]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[VAL:%.*]] = ttg.local_load [[BUF]] {ttg.partition = array<i32: 1>}
+    // CHECK-NEXT: [[VAL_SCALAR:%.*]] = tt.unsplat [[VAL]] {ttg.partition = array<i32: 1>} : tensor<1xi32, #blocked>
+    // CHECK-NEXT: nvws.aref.get.exit [[AREF]][[[C0]]], [[TOKEN]] [#nvws.async_op<none>] {ttg.partition = array<i32: 1>}
     // CHECK-NEXT: "op_b"([[VAL_SCALAR]])
 
   } {ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
@@ -272,7 +272,7 @@ template <class T> struct AssignStagePhase {
   }
 
   static LogicalResult run(ArefCreateOp arefOp) {
-    SetVector<int> partitionIds;
+    std::set<int> partitionIds;
     for (auto user : arefOp->getUsers()) {
       // Each partition requires its own stage/phase tracking for proper
       // multi-user handling; collect partition IDs in which this aref is used

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -475,7 +475,7 @@ public:
     });
 
     for (scf::ForOp loop : loops) {
-      FailureOr<PartitionSet> partitions = PartitionSet::deserialize(loop);
+      FailureOr<PartitionSet> partitions = PartitionSet::fromLoop(loop);
       if (failed(partitions))
         continue;
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -47,7 +47,7 @@ bool samePartition(Operation *op1, Operation *op2) {
 }
 
 SmallVector<ProducedValueInfo> getProducedValues(Operation *op, Block *loopBody,
-                                                 PartitionSet &schedule) {
+                                                 WarpSchedule &schedule) {
   SmallVector<ProducedValueInfo> producedValues;
   auto partitionIds = getPartitionIds(op);
 
@@ -147,7 +147,7 @@ int getTxCount(Operation *descOp) {
 
 void createNVWSDescriptorLoadOp(OpBuilder &builder, Operation *ttDescLoadOp,
                                 Value dataBuf, Partition *producerPartition,
-                                PartitionSet &schedule, Location loc) {
+                                WarpSchedule &schedule, Location loc) {
   auto txCount = getTxCount(ttDescLoadOp);
   if (auto descLoad = dyn_cast<triton::DescriptorLoadOp>(ttDescLoadOp)) {
     auto newDescLoad = builder.create<triton::nvws::DescriptorLoadOp>(
@@ -183,7 +183,7 @@ StageCluster getStageClusterForProducer(Value producedValue) {
 SmallVector<Operation *> createArefPut(PartitionBuilder &builder,
                                        ArefCreateOp aref, std::string arefTag,
                                        ProducedValueInfo producedValue,
-                                       PartitionSet &schedule) {
+                                       WarpSchedule &schedule) {
   auto loc = producedValue.result.getLoc();
   auto arefBufType = cast<MemDescType>(aref.getBuffers()[0].getType());
   Value result = producedValue.result;
@@ -254,7 +254,7 @@ SmallVector<Operation *> createArefPut(PartitionBuilder &builder,
 
 SetVector<Operation *> getTransitiveConsumers(Operation *op,
                                               Partition *consumerPartition,
-                                              PartitionSet &schedule) {
+                                              WarpSchedule &schedule) {
   SetVector<Operation *> opConsumers;
   auto isMemDesc = [](auto res) { return isa<MemDescType>(res.getType()); };
   for (auto user : op->getUsers()) {
@@ -275,7 +275,7 @@ SetVector<Operation *> getTransitiveConsumers(Operation *op,
 
 SmallVector<Operation *> getTransitiveConsumers(const SetVector<Value> &results,
                                                 Partition *consumerPartition,
-                                                PartitionSet &schedule) {
+                                                WarpSchedule &schedule) {
   SetVector<Operation *> opSet;
   for (auto result : results) {
     auto consumers = getTransitiveConsumers(result.getDefiningOp(),
@@ -332,7 +332,7 @@ getEnterAndExitStageClustersOfUses(const SetVector<Value> &producedResults,
 void createArefGet(PartitionBuilder &builder, scf::ForOp loop,
                    ArefCreateOp aref, std::string arefTag,
                    const SetVector<Value> &results,
-                   Partition *consumerPartition, PartitionSet &schedule) {
+                   Partition *consumerPartition, WarpSchedule &schedule) {
   OpBuilder::InsertionGuard g(builder);
   // The vector "results" contains either
   // 1. One of local_load(desc_load()) or desc_load()
@@ -418,7 +418,7 @@ void createArefGet(PartitionBuilder &builder, scf::ForOp loop,
 };
 
 bool insertArefs(PartitionBuilder &builder, scf::ForOp loop,
-                 PartitionSet &schedule, ProducedValueInfo producedValue,
+                 WarpSchedule &schedule, ProducedValueInfo producedValue,
                  int arefTag) {
   // Collect uses of local_alloc(desc_load()) or desc_load() results by each
   // partition
@@ -482,7 +482,7 @@ public:
     });
 
     for (scf::ForOp loop : loops) {
-      FailureOr<PartitionSet> schedule = PartitionSet::deserialize(loop);
+      FailureOr<WarpSchedule> schedule = WarpSchedule::deserialize(loop);
       if (failed(schedule))
         continue;
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -35,12 +35,6 @@ struct ProducedValueInfo {
   Value result;
 };
 
-Partition *getPartition(Operation *op, WarpSchedule &schedule) {
-  auto id = getPartitionIds(op);
-  assert(id && id->size() == 1);
-  return schedule.getPartition((*id)[0]);
-}
-
 bool samePartition(Operation *op1, Operation *op2) {
   auto part1 = getPartitionIds(op1);
   auto part2 = getPartitionIds(op2);

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -54,7 +54,7 @@ SmallVector<ProducedValueInfo> getProducedValues(Operation *op, Block *loopBody,
   if (partitionIds && partitionIds->size() == 1) {
     for (auto result : op->getResults()) {
       producedValues.push_back(
-          {partitions.getPartition((*partitionIds)[0]), result});
+          {partitions.getPartition(partitionIds->front()), result});
     }
   }
 
@@ -338,9 +338,7 @@ void createArefGet(PartitionBuilder &builder, scf::ForOp loop,
   auto loc = results[0].getLoc();
 
   auto filterUse = [&](Operation *use) {
-    auto partitionIds = getPartitionIds(use);
-    if (!partitionIds ||
-        partitionIds->size() == partitions.getNumPartitions()) {
+    if (isInRootPartition(use, partitions)) {
       return false;
     }
     return getPartition(use, partitions) == consumerPartition;

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -339,7 +339,8 @@ void createArefGet(PartitionBuilder &builder, scf::ForOp loop,
 
   auto filterUse = [&](Operation *use) {
     auto partitionIds = getPartitionIds(use);
-    if (!partitionIds || partitionIds->size() == partitions.getNumPartitions()) {
+    if (!partitionIds ||
+        partitionIds->size() == partitions.getNumPartitions()) {
       return false;
     }
     return getPartition(use, partitions) == consumerPartition;
@@ -355,7 +356,8 @@ void createArefGet(PartitionBuilder &builder, scf::ForOp loop,
       tokenType);
   setPartition(getEnterOp, consumerPartition);
 
-  auto consumers = getTransitiveConsumers(results, consumerPartition, partitions);
+  auto consumers =
+      getTransitiveConsumers(results, consumerPartition, partitions);
   assert(consumers.size() > 0);
   auto asyncKinds = getConsumerAsyncOpKinds(consumers, aref.getContext());
   Value dataBuf = getEnterOp.getBuffers()[0];

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -65,7 +65,8 @@ namespace {
 
 // ----------------------------------------------------------------------------
 
-void assignStageCluster(Operation *op, std::optional<SetVector<int>> partitionIds,
+void assignStageCluster(Operation *op,
+                        std::optional<SetVector<int>> partitionIds,
                         StageCluster stageCluster, OpBuilder &builder) {
   if (partitionIds) {
     setPartition(op, *partitionIds);
@@ -284,7 +285,8 @@ void lowerTMALoad(ArefPutEnterOp op, Value fullBarrier,
 void insertWaitOp(PatternRewriter &rewriter, Operation *op, Value barrier,
                   Value phase, Value stage) {
   auto waitOp = rewriter.create<WaitBarrierOp>(op->getLoc(), barrier, phase);
-  assignStageCluster(waitOp, getPartitionIds(op), getStageCluster(op), rewriter);
+  assignStageCluster(waitOp, getPartitionIds(op), getStageCluster(op),
+                     rewriter);
 }
 
 void rewritePutEnterOp(ArefPutEnterOp op, PatternRewriter &rewriter,

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -65,11 +65,11 @@ namespace {
 
 // ----------------------------------------------------------------------------
 
-void assignStageCluster(Operation *op, std::optional<PartitionId> partitionId,
+void assignStageCluster(Operation *op, std::optional<SetVector<int>> partitionIds,
                         StageCluster stageCluster, OpBuilder &builder) {
-  if (partitionId) {
-    op->setAttr(kPartitionAttrName,
-                builder.getI32IntegerAttr(partitionId->index()));
+  if (partitionIds) {
+    setPartition(op, *partitionIds);
+
     if (stageCluster) {
       op->setAttr(triton::kLoopStageAttrName,
                   builder.getI32IntegerAttr(stageCluster->first));
@@ -110,19 +110,21 @@ SmallVector<AsyncOp> castAsyncOpAttrs(ArrayAttr opAttrs) {
 }
 
 BarrierCount getArrivalCount(ArefCreateOp op) {
-  std::set<PartitionId> producerGroups, consumerGroups;
+  SetVector<int> producerGroups, consumerGroups;
   BarrierCount count;
 
   for (auto user : op->getUsers()) {
-    auto partitionId = getPartitionId(user);
-    if (!partitionId)
+    auto partitionIds = getPartitionIds(user);
+    if (!partitionIds)
       continue;
 
+    assert(partitionIds->size() == 1);
+
     if (auto putExitOp = dyn_cast<ArefPutExitOp>(user)) {
-      if (producerGroups.count(*partitionId)) {
+      if (producerGroups.count(partitionIds->front())) {
         continue;
       }
-      producerGroups.insert(*partitionId);
+      producerGroups.insert(partitionIds->front());
       for (auto kind : castAsyncOpAttrs(putExitOp.getAsyncOps())) {
         switch (kind) {
         case AsyncOp::TC5MMA:
@@ -135,10 +137,10 @@ BarrierCount getArrivalCount(ArefCreateOp op) {
         }
       }
     } else if (auto getExitOp = dyn_cast<ArefGetExitOp>(user)) {
-      if (consumerGroups.count(*partitionId)) {
+      if (consumerGroups.count(partitionIds->front())) {
         continue;
       }
-      consumerGroups.insert(*partitionId);
+      consumerGroups.insert(partitionIds->front());
       for (auto kind : castAsyncOpAttrs(getExitOp.getAsyncOps())) {
         switch (kind) {
         case AsyncOp::TC5MMA:
@@ -282,7 +284,7 @@ void lowerTMALoad(ArefPutEnterOp op, Value fullBarrier,
 void insertWaitOp(PatternRewriter &rewriter, Operation *op, Value barrier,
                   Value phase, Value stage) {
   auto waitOp = rewriter.create<WaitBarrierOp>(op->getLoc(), barrier, phase);
-  assignStageCluster(waitOp, getPartitionId(op), getStageCluster(op), rewriter);
+  assignStageCluster(waitOp, getPartitionIds(op), getStageCluster(op), rewriter);
 }
 
 void rewritePutEnterOp(ArefPutEnterOp op, PatternRewriter &rewriter,
@@ -373,7 +375,7 @@ void rewriteGetEnterOp(ArefGetEnterOp op, PatternRewriter &rewriter,
 
 void insertArriveBarrier(Location loc, ArrayRef<AsyncOp> asyncOps,
                          PatternRewriter &rewriter, Value mbar,
-                         std::optional<PartitionId> partitionId,
+                         std::optional<SetVector<int>> partitionIds,
                          StageCluster stageCluster) {
   for (auto asyncOpEnum : asyncOps) {
     Operation *arriveOp = {};
@@ -394,7 +396,7 @@ void insertArriveBarrier(Location loc, ArrayRef<AsyncOp> asyncOps,
       llvm_unreachable("unknown async op");
     }
     if (arriveOp)
-      assignStageCluster(arriveOp, partitionId, stageCluster, rewriter);
+      assignStageCluster(arriveOp, partitionIds, stageCluster, rewriter);
   }
 }
 
@@ -404,7 +406,7 @@ void rewritePutExitOp(ArefPutExitOp op, PatternRewriter &rewriter,
   rewriter.setInsertionPointAfter(op);
   Value fullBarrier = getFullBarrier(rewriter, loc, arefVal, op.getStage());
   insertArriveBarrier(loc, castAsyncOpAttrs(op.getAsyncOps()), rewriter,
-                      fullBarrier, getPartitionId(op), getStageCluster(op));
+                      fullBarrier, getPartitionIds(op), getStageCluster(op));
 }
 
 void rewriteGetExitOp(ArefGetExitOp op, PatternRewriter &rewriter,
@@ -435,20 +437,20 @@ void rewriteGetExitOp(ArefGetExitOp op, PatternRewriter &rewriter,
 
   if (needFence) {
     auto fence = rewriter.create<FenceAsyncSharedOp>(loc, /*bCluster=*/false);
-    assignStageCluster(fence, getPartitionId(op), stageCluster, rewriter);
+    assignStageCluster(fence, getPartitionIds(op), stageCluster, rewriter);
   }
 
   Value emptyBarrier = getEmptyBarrier(rewriter, loc, arefVal, op.getStage());
   return insertArriveBarrier(loc, asyncKinds, rewriter, emptyBarrier,
-                             getPartitionId(op), stageCluster);
+                             getPartitionIds(op), stageCluster);
 }
 
 DenseSet<MMAv5OpInterface> getAsyncMMAv5Consumers(Value aref) {
   DenseSet<MMAv5OpInterface> mmav5Ops;
   for (auto arefUser : aref.getUsers()) {
     if (auto getEnter = dyn_cast<ArefGetEnterOp>(arefUser)) {
-      auto id = getPartitionId(getEnter);
-      if (id && id->index() == 0) {
+      auto id = getPartitionIds(getEnter);
+      if (id && id->front() == 0) {
         // Ignore mmav5 ops in the default partition. They are not warp
         // specialized.
         continue;

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.cpp
@@ -25,17 +25,4 @@ ArefCreateOp createArefCreateOp(OpBuilder &builder, ArrayRef<Type> arefTypes,
   return builder.create<ArefCreateOp>(loc, arefTy, allocOps);
 }
 
-std::optional<PartitionId> getPartitionId(Operation *op) {
-  if (auto partitionAttr = op->getAttrOfType<IntegerAttr>(kPartitionAttrName)) {
-    IntegerAttr tagAttr;
-    while (op && !tagAttr) {
-      tagAttr = op->getAttrOfType<IntegerAttr>(kWarpSpecializeTagAttrName);
-      op = op->getParentOp();
-    }
-    if (tagAttr)
-      return PartitionId(partitionAttr.getInt(), tagAttr.getInt());
-  }
-  return {};
-}
-
 } // namespace mlir::triton::nvws

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.h
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.h
@@ -22,14 +22,6 @@ inline std::optional<int> findValuePosInRange(const Range &range,
   return {};
 }
 
-struct PartitionId : std::pair<int, int> {
-  PartitionId(int index, int tag) : std::pair<int, int>(index, tag) {}
-  int &index() { return first; }
-  int &tag() { return second; }
-};
-
-std::optional<PartitionId> getPartitionId(Operation *op);
-
 } // namespace mlir::triton::nvws
 
 #endif // NVIDIA_NVWS_TRANSFORMS_UTILITY_H_


### PR DESCRIPTION
`WarpSchedule` is renamed to `PartitionSet`, since it is now just a container of created partitions. It no longer owns a mapping between ops and partitions, which are now done exclusively by free functions like `setPartition`, `getPartitionIds` etc which only looks at the op

Other notable changes
* Partition attributes are now a set (represented as `array<i32>`).
* The concrete instance of "root partition" is gone but the code still uses the term to refer to ops belonging to all partitions. 
* At the beginning of `PartitionLoops`, unannotated ops, including those within if or reduce ops, are annotated with their parent partitions.
