### PR TITLE
[AMD] bug fix in convert_to_buffer_ops

### DIFF
--- a/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="arch-generation-name=gfx942"| FileCheck %s
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="arch-generation-name=gfx950"| FileCheck %s
 
 #blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
@@ -783,6 +784,71 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %19 = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
     %20 = tt.addptr %19, %18 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
     %21 = tt.atomic_rmw fadd, relaxed, gpu, %20, %15, %cst : (tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xf32, #blocked>, tensor<64xi1, #blocked>) -> tensor<64xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// This test is added to test if the 2nd operand of addptr is dominated by
+// a blockargument: the non-negative analysis will keep going.
+// or the result of get_program_id, the non-negative analysis will return true.
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @add(%in_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %out_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %M: i32 {tt.divisibility = 16 : i32}, %K: i32 {tt.divisibility = 16 : i32}, %stride_m: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %c32_i32 = arith.constant 32 : i32
+    %cst = arith.constant dense<true> : tensor<32x32xi1, #blocked>
+    %c31_i32 = arith.constant 31 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst_0 = arith.constant dense<32> : tensor<32x32xi32, #blocked>
+    %pid = tt.get_program_id x : i32
+    %offs = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %offs_1 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %0 = arith.cmpi sgt, %stride_m, %c0_i32 : i32
+    llvm.intr.assume %0 : i1
+    llvm.intr.assume %true : i1
+    %1 = arith.cmpi sgt, %M, %c0_i32 : i32
+    llvm.intr.assume %1 : i1
+    %2 = arith.cmpi sgt, %K, %c0_i32 : i32
+    llvm.intr.assume %2 : i1
+    %in_ptr_2 = arith.muli %pid, %K : i32
+    %in_ptr_3 = arith.muli %in_ptr_2, %c32_i32 : i32
+    %in_ptrs = tt.splat %in_ptr_3 : i32 -> tensor<32x32xi32, #blocked>
+    %in_ptrs_4 = tt.expand_dims %offs {axis = 1 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<32x1xi32, #blocked>
+    %in_ptrs_5 = tt.splat %stride_m : i32 -> tensor<32x1xi32, #blocked>
+    %in_ptrs_6 = arith.muli %in_ptrs_4, %in_ptrs_5 : tensor<32x1xi32, #blocked>
+    %in_ptrs_7 = tt.broadcast %in_ptrs_6 : tensor<32x1xi32, #blocked> -> tensor<32x32xi32, #blocked>
+    %in_ptrs_8 = tt.expand_dims %offs_1 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
+    %in_ptrs_9 = tt.broadcast %in_ptrs_8 : tensor<1x32xi32, #blocked> -> tensor<32x32xi32, #blocked>
+    %in_ptrs_10 = arith.addi %in_ptrs_7, %in_ptrs_9 : tensor<32x32xi32, #blocked>
+    %in_ptrs_11 = arith.addi %in_ptrs_10, %in_ptrs : tensor<32x32xi32, #blocked>
+    %out_ptrs = tt.splat %in_ptr_3 : i32 -> tensor<32x32xi32, #blocked>
+    %out_ptrs_12 = tt.expand_dims %offs {axis = 1 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<32x1xi32, #blocked>
+    %out_ptrs_13 = tt.splat %stride_m : i32 -> tensor<32x1xi32, #blocked>
+    %out_ptrs_14 = arith.muli %out_ptrs_12, %out_ptrs_13 : tensor<32x1xi32, #blocked>
+    %out_ptrs_15 = tt.broadcast %out_ptrs_14 : tensor<32x1xi32, #blocked> -> tensor<32x32xi32, #blocked>
+    %out_ptrs_16 = tt.expand_dims %offs_1 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
+    %out_ptrs_17 = tt.broadcast %out_ptrs_16 : tensor<1x32xi32, #blocked> -> tensor<32x32xi32, #blocked>
+    %out_ptrs_18 = arith.addi %out_ptrs_15, %out_ptrs_17 : tensor<32x32xi32, #blocked>
+    %out_ptrs_19 = arith.addi %out_ptrs_18, %out_ptrs : tensor<32x32xi32, #blocked>
+    %3 = arith.addi %K, %c31_i32 : i32
+    %4 = arith.divsi %3, %c32_i32 : i32
+    %out_ptrs_20:2 = scf.for %out_ptrs_21 = %c0_i32 to %4 step %c1_i32 iter_args(%in_ptrs_22 = %in_ptrs_11, %out_ptrs_23 = %out_ptrs_19) -> (tensor<32x32xi32, #blocked>, tensor<32x32xi32, #blocked>)  : i32 {
+      %a = tt.splat %in_ptr : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #blocked>
+      %a_24 = tt.addptr %a, %in_ptrs_22 : tensor<32x32x!tt.ptr<bf16>, #blocked>, tensor<32x32xi32, #blocked>
+      %a_25 = tt.load %a_24 : tensor<32x32x!tt.ptr<bf16>, #blocked>
+      %5 = tt.splat %out_ptr : !tt.ptr<bf16> -> tensor<32x32x!tt.ptr<bf16>, #blocked>
+      %6 = tt.addptr %5, %out_ptrs_23 : tensor<32x32x!tt.ptr<bf16>, #blocked>, tensor<32x32xi32, #blocked>
+      %7 = tt.atomic_rmw fadd, acq_rel, gpu, %6, %a_25, %cst : (tensor<32x32x!tt.ptr<bf16>, #blocked>, tensor<32x32xbf16, #blocked>, tensor<32x32xi1, #blocked>) -> tensor<32x32xbf16, #blocked>
+      %in_ptrs_26 = arith.addi %in_ptrs_22, %cst_0 : tensor<32x32xi32, #blocked>
+      %out_ptrs_27 = arith.addi %out_ptrs_23, %cst_0 : tensor<32x32xi32, #blocked>
+      scf.yield %in_ptrs_26, %out_ptrs_27 : tensor<32x32xi32, #blocked>, tensor<32x32xi32, #blocked>
+      // CHECK: %[[VAL:.*]] = amdgpu.buffer_load
+      // CHECK: %[[PTR:.*]] = tt.addptr
+      // CHECK-NEXt: amdgpu.buffer_atomic_rmw fadd, acq_rel, gpu, %[[PTR]] %[[VAL]]
+    }
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -1,3 +1,4 @@
+#include "TritonAMDGPUToLLVM/TargetUtils.h"
 #include "TritonAMDGPUTransforms/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -115,8 +116,30 @@ bool verifyNonNegativeExpr(
   // Recurse if the operation is defined
   Operation *op = expr.getDefiningOp();
   if (!op) {
-    LDBG("  No defining op, assuming possibly negative");
-    return false;
+    BlockArgument blockArg = cast<BlockArgument>(expr);
+    auto argNum = blockArg.getArgNumber();
+    Operation *parentOp = blockArg.getOwner()->getParentOp();
+    if (argNum == 0) {
+      // Only do the value range analyse for induction variable in the scf.for
+      if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+        auto lb = forOp.getLowerBound();
+        auto ub = forOp.getUpperBound();
+        return verifyNonNegativeExpr(lb, assumptions, solver) &&
+               verifyNonNegativeExpr(ub, assumptions, solver);
+      } else {
+        LDBG("Induction variable in a non scf.ForOp");
+        return false;
+      }
+    }
+
+    if (auto loopOp = dyn_cast<LoopLikeOpInterface>(parentOp)) {
+      mlir::ValueRange initArgs = loopOp.getInits();
+      size_t initArgIdx = argNum - 1;
+      return verifyNonNegativeExpr(initArgs[initArgIdx], assumptions, solver);
+    } else {
+      LDBG("Block argument of non loop-like operation.");
+      return false;
+    }
   }
 
   bool nonNegative =
@@ -141,6 +164,7 @@ bool verifyNonNegativeExpr(
           // Returns a tensor representing histogram: histograms only contain
           // buckets of non-negative values.
           .Case<triton::HistogramOp>([&](auto) { return true; })
+          .Case<triton::MakeRangeOp>([&](auto makeRangeOp) { return true; })
           .Case<triton::MakeRangeOp>([&](auto makeRangeOp) {
             // See the warning in TritonOps.td: getStart/getEnd return unsigned,
             // so we need to look through get*Attr.
@@ -436,10 +460,12 @@ struct ConvertTritonAtomicRMWOpToBufferAtomicRMW
 
     // float16 is the only 16-bit dtype supported by buffer atomic fadd on
     // gfx942
-    if (isaFamily == ISAFamily::CDNA3 && checkType.isBF16() &&
-        atomicRmwOp == RMWOp::FADD) {
-      return rewriter.notifyMatchFailure(op, "RMW FADD does not support bf16");
+    if ((isaFamily == ISAFamily::CDNA3 || isaFamily == ISAFamily::CDNA4) &&
+        checkType.isBF16() && atomicRmwOp == RMWOp::FADD) {
+      return rewriter.notifyMatchFailure(
+          op, "RMW FADD does not support bf16 on CDNA3");
     }
+
     LDBG("RMW FADD supported 16-bit type");
 
     auto vecSize = getVectorSize(ptr, axisAnalysisPass);
@@ -646,12 +672,13 @@ struct TritonAMDGPUConvertToBufferOpsPass
                  ConvertTritonLoadToBufferLoad<ttg::AsyncCopyGlobalToLocalOp>,
                  ConvertTritonStoreToBufferStore>(context, assumptions, solver);
 
-    // Gate buffer atomics behind CDNA3 for now
-    // GFX942-specific assumptions regarding cache coherence are made when
-    // lowering to LLVM
+    // Gate buffer atomics behind CDNA3 and CDNA4 for now.
+    // GFX942 and GFX950 assumptions regarding cache coherence are made when
+    // lowering to LLVM.
     triton::AMD::ISAFamily isaFamily =
         triton::AMD::deduceISAFamily(archGenerationName);
-    if (this->allowBufferAtomics && ISAFamily::CDNA3 == isaFamily)
+    if (this->allowBufferAtomics &&
+        (ISAFamily::CDNA3 == isaFamily || ISAFamily::CDNA4 == isaFamily))
       patterns.add<ConvertTritonAtomicRMWOpToBufferAtomicRMW>(
           context, assumptions, axisInfoAnalysis, solver, isaFamily);
     patterns.add<ConvertTritonAtomicCASOpToBufferAtomicCAS>(


### PR DESCRIPTION
There is validation check for pattern `ConvertTritonAtomicRMWOpToBufferAtomicRMW`, \
All the direct and un-direct operands will be scanned for a non-negative check.  \
Before this change, if the operand value is from `get_program_id` or block argument, \
the scan will stop and return false. \
For more details, please ref https://github.com/ROCm/triton-internal/issues/1188

This PR also enable `ConvertTritonAtomicRMWOpToBufferAtomicRMW` for CDNA4.
A lit test is added to verify it.