### PR TITLE
[TritonGPU] Augment FuseNestedLoops to handle dependent inner loop bounds

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -40,7 +40,10 @@ bool isPureScalarOp(Operation *op);
 bool getDominatingValueSetOpsToHoist(
     DominanceInfo &domInfo, Operation *refOp, ArrayRef<Value> valueSet,
     llvm::SetVector<Operation *> &toHoist,
-    function_ref<bool(Operation *)> canHoist = isPureScalarOp);
+    function_ref<bool(Operation *)> canHoist = isPureScalarOp,
+    function_ref<bool(BlockArgument)> canUseArg = [](BlockArgument) {
+      return false;
+    });
 
 // Hoist the given set of operations above the reference operation.
 void hoistOpsBefore(Operation *refOp,

--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -1,11 +1,15 @@
+#include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
 #include "mlir/Transforms/RegionUtils.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include <queue>
 
@@ -240,8 +244,8 @@ static Logue createLogueFrom(llvm::iterator_range<Block::iterator> ops,
 // recursively. This includes integer division, which are not speculatable, but
 // we know they will never divide by zero.
 static bool canHoistLoopBoundComputation(Operation *op) {
-  auto isScalar = [](Type type) { return type.isIntOrIndexOrFloat(); };
-  return isMemoryEffectFree(op) &&
+  auto isScalar = [](Type type) { return type.isIntOrIndexOrFloat() || isa<PointerType>(type); };
+  return (isMemoryEffectFree(op) || hasSingleEffect<MemoryEffects::Read>(op)) &&
          llvm::all_of(op->getOperandTypes(), isScalar) &&
          llvm::all_of(op->getResultTypes(), isScalar);
 }
@@ -251,8 +255,22 @@ static bool canHoistLoopBoundComputation(Operation *op) {
 static bool isOuterLoopInvariant(mlir::DominanceInfo &domInfo, scf::ForOp outer,
                                  ArrayRef<Value> values,
                                  llvm::SetVector<Operation *> &toHoist) {
-  return getDominatingValueSetOpsToHoist(domInfo, outer, values, toHoist,
-                                         canHoistLoopBoundComputation);
+  return getDominatingValueSetOpsToHoist(
+      domInfo, outer, values, toHoist, canHoistLoopBoundComputation,
+      [&](BlockArgument arg) {
+        return isa<FuncOp>(arg.getOwner()->getParentOp());
+      });
+}
+
+static bool canSliceBounds(mlir::DominanceInfo &domInfo, scf::ForOp outer,
+                           ArrayRef<Value> values,
+                           llvm::SetVector<Operation *> &ops) {
+  return getDominatingValueSetOpsToHoist(
+      domInfo, outer, values, ops, canHoistLoopBoundComputation,
+      [&](BlockArgument arg) {
+        return arg == outer.getInductionVar() ||
+               isa<FuncOp>(arg.getOwner()->getParentOp());
+      });
 }
 
 // Pessimistically assume the internal storage bitwidth for index types.
@@ -263,13 +281,19 @@ static unsigned getIntTypeWidth(Type type) {
 }
 
 // Generate IR to compute the number of iterations of a loop.
-static Value computeNumIters(ImplicitLocOpBuilder &b, scf::ForOp loop) {
+static Value computeNumIters(ImplicitLocOpBuilder &b, Value lowerBound,
+                             Value upperBound, Value step) {
   // len(range(lb, ub, step)) = ceildiv(ub - lb, step)
   // This works even if step is negative.
-  Value diff =
-      b.create<arith::SubIOp>(loop.getUpperBound(), loop.getLowerBound());
+  Value diff = b.create<arith::SubIOp>(upperBound, lowerBound);
   // Let someone else prove it can be unsigned.
-  return b.create<arith::CeilDivSIOp>(diff, loop.getStep());
+  return b.create<arith::CeilDivSIOp>(diff, step);
+}
+
+// Generate IR to compute the number of iterations of a loop.
+static Value computeNumIters(ImplicitLocOpBuilder &b, scf::ForOp loop) {
+  return computeNumIters(b, loop.getLowerBound(), loop.getUpperBound(),
+                         loop.getStep());
 }
 
 // Cast an integer or index value to an integer or index `type`, if necessary.
@@ -333,6 +357,21 @@ static scf::IfOp eraseIfResults(ImplicitLocOpBuilder &b, scf::IfOp ifOp,
   return newIf;
 }
 
+namespace {
+struct InnerLoop {
+  InnerLoop(scf::ForOp op, llvm::SetVector<Operation *> slicedOps)
+      : op(op), slicedOps(std::move(slicedOps)) {}
+
+  // Return true if the loop bounds are outer loop invariant.
+  bool isOuterLoopInvariant() const { return slicedOps.empty(); }
+
+  // The actual loop op.
+  scf::ForOp op;
+  // Ops that must be sliced to compute the loop bounds
+  llvm::SetVector<Operation *> slicedOps;
+};
+} // namespace
+
 // Given a one level loop nest in the form
 //
 //   for i in range(lbi, ubi, stepi):
@@ -358,11 +397,9 @@ static scf::IfOp eraseIfResults(ImplicitLocOpBuilder &b, scf::IfOp ifOp,
 //   inner_len = max(1, len_j0) + max(1, len_j1) + ... + max(1, len_jN) - N
 //   total_iters = len_i * inner_len
 //
-//   T = -1
+//   T = 0
 //   i = lbi - stepi
 //   for _ in range(total_iters):
-//     T = 0 if T == (inner_len - 1) else T + 1
-//
 //     if T == 0:
 //       i += stepi
 //       prologue0(i)
@@ -400,6 +437,7 @@ static scf::IfOp eraseIfResults(ImplicitLocOpBuilder &b, scf::IfOp ifOp,
 //
 //     if T == max(1, len_j0) + max(1, len_j1) + ... + max(1, len_jN) - (N + 1):
 //       epilogue(i)
+//     T = 0 if T == (inner_len - 1) else T + 1
 //
 // This routine can be applied recursively on a loop nest tree, leaf-to-root, to
 // flatten the loop nest into a single loop. However, this routine only fuses
@@ -471,7 +509,7 @@ static scf::IfOp eraseIfResults(ImplicitLocOpBuilder &b, scf::IfOp ifOp,
 static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   scf::ForOp outer = parent->loop;
 
-  SmallVector<scf::ForOp> innerLoops;
+  SmallVector<InnerLoop> innerLoops;
   llvm::SetVector<Operation *> toHoist;
   for (LoopNestNode *child : parent->children) {
     scf::ForOp inner = child->loop;
@@ -480,14 +518,24 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
     // Check if the inner loop bounds are or can be made invariant to the outer
     // loop. Check them all at once to avoid adding ops to `toHoist` if not
     // necessary.
-    if (!isOuterLoopInvariant(
+    if (isOuterLoopInvariant(
             domInfo, outer,
             {inner.getLowerBound(), inner.getUpperBound(), inner.getStep()},
-            toHoist))
+            toHoist)) {
+      // Add this child to the list of loops to fuse.
+      innerLoops.push_back({child->loop, {}});
       continue;
+    }
 
-    // Add this child to the list of loops to fuse.
-    innerLoops.push_back(child->loop);
+    // Check if the loop bounds can be sliced.
+    llvm::SetVector<Operation *> slicedOps;
+    if (canSliceBounds(
+            domInfo, outer,
+            {inner.getLowerBound(), inner.getUpperBound(), inner.getStep()},
+            slicedOps)) {
+      innerLoops.push_back({child->loop, std::move(slicedOps)});
+      continue;
+    }
   }
 
   // From the perspective of the overall analysis, we can delete all the
@@ -513,15 +561,25 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   // Generate the computations of the fused loop bounds.
   Location loc = outer.getLoc();
   ImplicitLocOpBuilder b(loc, outer);
-  Value lenOuter = computeNumIters(b, outer);
-  SmallVector<Value> lenInners;
-  for (scf::ForOp loop : innerLoops) {
-    // len_jk = len(range(lbjk, ubjk, stepjk))
-    Value lenInner = computeNumIters(b, loop);
-    intTyWidth = std::max(intTyWidth, getIntTypeWidth(lenInner.getType()));
-    lenInners.push_back(lenInner);
+  for (InnerLoop &loop : innerLoops) {
+    intTyWidth = std::max(intTyWidth,
+                          getIntTypeWidth(loop.op.getInductionVar().getType()));
   }
   auto intTy = b.getIntegerType(intTyWidth);
+  bool allInvariant = llvm::all_of(
+      innerLoops, [](InnerLoop &loop) { return loop.isOuterLoopInvariant(); });
+
+  Value lenOuter = computeNumIters(b, outer);
+  SmallVector<Value> lenInners;
+  for (InnerLoop &loop : innerLoops) {
+    // len_jk = len(range(lbjk, ubjk, stepjk))
+    Value lenInner;
+    if (loop.isOuterLoopInvariant())
+      lenInner = castIntIfNecessary(b, computeNumIters(b, loop.op), intTy);
+    else
+      lenInner = createPoisonOrZero(b, intTy);
+    lenInners.push_back(lenInner);
+  }
 
   auto intTyCst = [&](int64_t v) {
     return b.create<arith::ConstantOp>(IntegerAttr::get(intTy, v));
@@ -530,20 +588,47 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   // inner_len = max(1, len_j0) + max(1, len_j1) + ... + max(1, len_jN) - N
   unsigned N = innerLoops.size() - 1;
   Value innerLen = intTyCst(0);
-  // Keep all the partial sums because we need them later.
-  SmallVector<Value> partialInnerSums;
-  partialInnerSums.push_back(innerLen);
-  for (Value lenInner : lenInners) {
-    lenInner = castIntIfNecessary(b, lenInner, intTy);
-    lenInner = b.create<arith::MaxSIOp>(intTyCst(1), lenInner);
-    innerLen = b.create<arith::AddIOp>(innerLen, lenInner);
-    partialInnerSums.push_back(innerLen);
+  for (auto [loop, lenInner] : llvm::zip(innerLoops, lenInners)) {
+    if (!loop.isOuterLoopInvariant())
+      continue;
+    innerLen = b.create<arith::AddIOp>(
+        innerLen, b.create<arith::MaxSIOp>(intTyCst(1), lenInner));
   }
   innerLen = b.create<arith::SubIOp>(innerLen, intTyCst(N));
 
   // total_iters = len_i * inner_len
   Value totalIters =
       b.create<arith::MulIOp>(castIntIfNecessary(b, lenOuter, intTy), innerLen);
+
+  // Generate a loop to compute the total number of iterations for inner loops
+  // whose bounds are not outer loop invariant.
+  IRMapping mapping;
+  auto peeledLen =
+      scf::ForOp::create(b, outer.getLowerBound(), outer.getUpperBound(),
+                         outer.getStep(), {totalIters});
+  totalIters = peeledLen.getRegionIterArg(0);
+  mapping.map(outer.getInductionVar(), peeledLen.getInductionVar());
+  b.setInsertionPointToStart(peeledLen.getBody());
+  for (InnerLoop &loop : innerLoops) {
+    if (loop.isOuterLoopInvariant())
+      continue;
+    // Cloned the sliced ops into the peeled loop.
+    for (Operation *op : topologicalSort(loop.slicedOps)) {
+      if (!mapping.contains(op))
+        b.clone(*op, mapping);
+    }
+    Value numIters =
+        computeNumIters(b, mapping.lookupOrDefault(loop.op.getLowerBound()),
+                        mapping.lookupOrDefault(loop.op.getUpperBound()),
+                        mapping.lookupOrDefault(loop.op.getStep()));
+    numIters = castIntIfNecessary(b, numIters, intTy);
+    // Accumulate into the total number of iterations.
+    numIters = b.create<arith::MaxSIOp>(intTyCst(1), numIters);
+    totalIters = b.create<arith::AddIOp>(totalIters, numIters);
+  }
+  b.create<scf::YieldOp>(totalIters);
+  totalIters = peeledLen.getResults().front();
+  b.setInsertionPointAfter(peeledLen);
 
   // The outputs of the prologue, each epilogue, and all inner loop bodies need
   // to carried through the fused loop.
@@ -552,14 +637,14 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
     logues.push_back(createLogueFrom({begin, end}, domInfo));
   };
   // prologue0
-  addLogue(outer.getBody()->begin(), innerLoops.front()->getIterator());
+  addLogue(outer.getBody()->begin(), innerLoops.front().op->getIterator());
   // prologuek where 0 < k <= N
   for (auto i : llvm::seq<unsigned>(0, innerLoops.size() - 1)) {
-    addLogue(std::next(innerLoops[i]->getIterator()),
-             innerLoops[i + 1]->getIterator());
+    addLogue(std::next(innerLoops[i].op->getIterator()),
+             innerLoops[i + 1].op->getIterator());
   }
   // epilogue
-  addLogue(std::next(innerLoops.back()->getIterator()),
+  addLogue(std::next(innerLoops.back().op->getIterator()),
            // Don't include the outer loop yield.
            std::prev(outer.getBody()->end()));
 
@@ -572,24 +657,28 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   // - The outputs of each logue
   SmallVector<Value> fusedInits;
 
-  // T = -1
-  fusedInits.push_back(intTyCst(-1));
+  // T = 0
+  fusedInits.push_back(intTyCst(0));
   // i = lbi - stepi
   fusedInits.push_back(
       b.create<arith::SubIOp>(outer.getLowerBound(), outer.getStep()));
 
   unsigned outerArgsStartIdx = fusedInits.size();
   llvm::append_range(fusedInits, outer.getInits());
+  unsigned lenInnersStartIdx = fusedInits.size();
+  llvm::append_range(fusedInits, lenInners);
+  unsigned innerLenStartIdx = fusedInits.size();
+  fusedInits.push_back(innerLen);
 
   // Everything else is initialized to undef.
   unsigned ivarStartIdx = fusedInits.size();
-  for (scf::ForOp loop : innerLoops) {
+  for (InnerLoop &loop : innerLoops) {
     fusedInits.push_back(
-        createPoisonOrZero(b, loop.getInductionVar().getType()));
+        createPoisonOrZero(b, loop.op.getInductionVar().getType()));
   }
   unsigned innerOutsStartIdx = fusedInits.size();
-  for (scf::ForOp loop : innerLoops) {
-    for (Type resultType : loop.getResultTypes())
+  for (InnerLoop &loop : innerLoops) {
+    for (Type resultType : loop.op.getResultTypes())
       fusedInits.push_back(createPoisonOrZero(b, resultType));
   }
   unsigned logueOutsStartIdx = fusedInits.size();
@@ -607,21 +696,20 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
                  fused.getRegionIterArgs().slice(outerArgsStartIdx))) {
     arg.replaceAllUsesWith(fusedArg);
   }
+  ValueRange lenInnersRange =
+      fused.getRegionIterArgs().slice(lenInnersStartIdx, lenInners.size());
+  for (auto [lenInner, lenInnerArg] : llvm::zip(lenInners, lenInnersRange))
+    lenInner = lenInnerArg;
   b.setInsertionPointToStart(fused.getBody());
 
-  // T = 0 if T == (inner_len - 1) else T + 1
   Value T = fused.getRegionIterArg(0);
-  Value nextT = b.create<arith::AddIOp>(T, intTyCst(1));
-  Value rollover =
-      b.create<arith::CmpIOp>(arith::CmpIPredicate::eq, T,
-                              b.create<arith::SubIOp>(innerLen, intTyCst(1)));
-  T = b.create<arith::SelectOp>(rollover, intTyCst(0), nextT);
-
   // `i` is computed inside the first prologue.
   Value curI = fused.getRegionIterArg(1);
   Value i;
 
-  assert(partialInnerSums.size() == N + 2);
+  auto lenInnersIt =
+      ValueRange(fused.getRegionIterArgs()).begin() + lenInnersStartIdx;
+
   ArrayRef<BlockArgument> ivars = fused.getRegionIterArgs().slice(ivarStartIdx);
   auto bodyOutsIt =
       ValueRange(fused.getRegionIterArgs()).begin() + innerOutsStartIdx;
@@ -633,21 +721,28 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
     //   [[if k == 0]] i += stepi
     //   prologuek(i)
     //   jk = lbjk
-    Value innerStartT =
-        b.create<arith::SubIOp>(partialInnerSums[k], intTyCst(k));
+    Value innerStartT = intTyCst(0);
+    for (unsigned i = 0; i < k; ++i) {
+      innerStartT = b.create<arith::AddIOp>(
+          innerStartT, b.create<arith::MaxSIOp>(intTyCst(1), lenInners[i]));
+    }
+    innerStartT = b.create<arith::SubIOp>(innerStartT, intTyCst(k));
     Value prologueCond =
         b.create<arith::CmpIOp>(arith::CmpIPredicate::eq, T, innerStartT);
 
     // The `scf.if` outputs will be `jk` and the outputs of prologuek. We also
     // have to initialize the inner loop iter args.
-    scf::ForOp inner = innerLoops[k];
+    scf::ForOp inner = innerLoops[k].op;
     Logue &prologue = logues[k];
 
     SmallVector<Type> prologueOutTypes{inner.getInductionVar().getType()};
     llvm::append_range(prologueOutTypes, prologue.getOutputTypes());
     llvm::append_range(prologueOutTypes, inner.getInits().getTypes());
-    if (k == 0)
+    if (k == 0) {
       prologueOutTypes.push_back(curI.getType());
+      prologueOutTypes.append(innerLoops.size(), intTy);
+      prologueOutTypes.push_back(innerLen.getType());
+    }
     auto prologueIf = b.create<scf::IfOp>(prologueOutTypes, prologueCond);
     prologueIfs.push_back(prologueIf);
 
@@ -661,6 +756,24 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
       i = b.create<arith::AddIOp>(curI, outer.getStep());
       mlir::replaceAllUsesInRegionWith(outer.getInductionVar(), i,
                                        prologueIf.getThenRegion());
+
+      // Compute the variant inner loop lengths.
+      IRMapping mapping;
+      for (auto [loop, lenInner] : llvm::zip(innerLoops, lenInners)) {
+        if (loop.isOuterLoopInvariant())
+          continue;
+        for (Operation *op : topologicalSort(loop.slicedOps)) {
+          if (!mapping.contains(op))
+            b.clone(*op, mapping);
+        }
+        lenInner =
+            computeNumIters(b, mapping.lookupOrDefault(loop.op.getLowerBound()),
+                            mapping.lookupOrDefault(loop.op.getUpperBound()),
+                            mapping.lookupOrDefault(loop.op.getStep()));
+        lenInner = castIntIfNecessary(b, lenInner, intTy);
+        innerLen = b.create<arith::AddIOp>(
+            innerLen, b.create<arith::MaxSIOp>(intTyCst(1), lenInner));
+      }
     }
 
     // Yield the initialized jk, the prologue outputs, and the initial values of
@@ -669,8 +782,11 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
     SmallVector<Value> thenOuts{inner.getLowerBound()};
     llvm::append_range(thenOuts, prologue.getOutputs());
     llvm::append_range(thenOuts, inner.getInits());
-    if (k == 0)
+    if (k == 0) {
       thenOuts.push_back(i);
+      llvm::append_range(thenOuts, lenInners);
+      thenOuts.push_back(innerLen);
+    }
     b.create<scf::YieldOp>(thenOuts);
 
     // In the `else` region, just yield the last values of jk, the outputs, and
@@ -681,8 +797,14 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
     SmallVector<Value> elseOuts{lastJk};
     elseOuts.append(logueOutsIt, logueOutsIt + numOuts);
     elseOuts.append(bodyOutsIt, bodyOutsIt + inner.getNumResults());
-    if (k == 0)
+    if (k == 0) {
       elseOuts.push_back(curI);
+      llvm::append_range(elseOuts, lenInnersRange);
+      // Peephole the passthrough of `innerLen` since MLIR will not optimize it
+      // away for us.
+      elseOuts.push_back(
+          allInvariant ? innerLen : fused.getRegionIterArg(innerLenStartIdx));
+    }
     logueOutsIt += numOuts;
     b.create<scf::YieldOp>(elseOuts);
 
@@ -699,7 +821,10 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
       iterArg.replaceAllUsesWith(init);
     // Replace uses of `i` elsewhere with the prologue result.
     if (k == 0) {
-      i = prologueIf.getResults().back();
+      ValueRange results = prologueIf.getResults();
+      i = results.drop_back(1 + lenInners.size()).back();
+      lenInners = results.drop_back().take_back(lenInners.size());
+      innerLen = results.back();
       outer.getInductionVar().replaceAllUsesWith(i);
     }
 
@@ -786,21 +911,30 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   epilogue.replaceAllUsesWith(epilogueIf.getResults(),
                               epilogueIf.getThenRegion());
 
+  // T = 0 if T == (inner_len - 1) else T + 1
+  b.setInsertionPointToEnd(fused.getBody());
+  Value nextT = b.create<arith::AddIOp>(T, intTyCst(1));
+  Value rollover =
+      b.create<arith::CmpIOp>(arith::CmpIPredicate::eq, T,
+                              b.create<arith::SubIOp>(innerLen, intTyCst(1)));
+  T = b.create<arith::SelectOp>(rollover, intTyCst(0), nextT);
+
   // Finally, create the yield of the fused loop.
   SmallVector<Value> outerOuts{T, i};
   llvm::append_range(outerOuts, outerYield.getOperands());
+  llvm::append_range(outerOuts, lenInners);
+  outerOuts.push_back(innerLen);
   for (scf::IfOp bodyIf : bodyIfs)
     outerOuts.push_back(/*jk=*/bodyIf.getResult(0));
   for (auto [bodyIf, loop] : llvm::zip(bodyIfs, innerLoops)) {
     llvm::append_range(outerOuts,
-                       bodyIf.getResults().slice(1, loop.getNumResults()));
+                       bodyIf.getResults().slice(1, loop.op.getNumResults()));
   }
   for (auto [logueIf, logue] : llvm::zip(prologueIfs, llvm::drop_end(logues))) {
     llvm::append_range(outerOuts,
                        logueIf.getResults().slice(1, logue.getNumOutputs()));
   }
 
-  b.setInsertionPointToEnd(fused.getBody());
   b.create<scf::YieldOp>(outerOuts);
   outer.replaceAllUsesWith(
       fused.getResults().slice(outerArgsStartIdx, outer.getNumResults()));
@@ -816,12 +950,12 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   SmallVector<Value> reset, forwarded;
   for (auto [loop, ifOp, bodyIf, prologue] :
        llvm::zip(innerLoops, prologueIfs, bodyIfs, logues)) {
-    unsigned numResults = loop.getNumResults();
+    unsigned numResults = loop.op.getNumResults();
     unsigned prologueSkip = 1 + prologue.getNumOutputs();
 
     llvm::BitVector removeIndices(prologueSkip + numResults);
     SmallVector<Value> replaceWith;
-    for (auto [i, init] : llvm::enumerate(loop.getInits())) {
+    for (auto [i, init] : llvm::enumerate(loop.op.getInits())) {
       if (init.getParentRegion() == &fused.getBodyRegion())
         continue;
       // Initialize this in the outer loop.
@@ -858,15 +992,15 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
 
   // Propagate warp specialization flags.
   if (outer->hasAttr(kWarpSpecializeAttrName) ||
-      llvm::any_of(innerLoops, [](scf::ForOp loop) {
-        return loop->hasAttr(kWarpSpecializeAttrName);
+      llvm::any_of(innerLoops, [](InnerLoop &loop) {
+        return loop.op->hasAttr(kWarpSpecializeAttrName);
       }))
     fused->setAttr(kWarpSpecializeAttrName, b.getUnitAttr());
 
   // Propagate the `tt.disallow_acc_multi_buffer` attribute to the parent loop.
   bool disallowAccMultiBuffer = getDisallowAccMultiBuffer(outer);
-  for (scf::ForOp loop : innerLoops) {
-    disallowAccMultiBuffer |= getDisallowAccMultiBuffer(loop);
+  for (InnerLoop &loop : innerLoops) {
+    disallowAccMultiBuffer |= getDisallowAccMultiBuffer(loop.op);
   }
   if (disallowAccMultiBuffer)
     fused->setAttr(kDisallowAccMultiBufferAttrName, b.getUnitAttr());
@@ -876,10 +1010,11 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   int numStages = 1;
   if (auto stageAttr = outer->getAttrOfType<IntegerAttr>(kNumStagesAttrName))
     numStages = stageAttr.getInt();
-  for (scf::ForOp loop : innerLoops) {
-    if (auto stageAttr = loop->getAttrOfType<IntegerAttr>(kNumStagesAttrName))
+  for (InnerLoop &loop : innerLoops) {
+    if (auto stageAttr =
+            loop.op->getAttrOfType<IntegerAttr>(kNumStagesAttrName))
       numStages = std::max<int>(numStages, stageAttr.getInt());
-    loop.erase();
+    loop.op.erase();
   }
   outer.erase();
   parent->loop = fused;
@@ -964,6 +1099,30 @@ static void optimizeEpilogueDependencies(scf::ForOp outerLoop,
           {outerLoop.getBody()->begin(), innerLoop->getIterator()}, inEpilogue);
 }
 
+// Crudely match llvm.assume(ub > lb) or llvm.assume(lb < ub).
+static LogicalResult matchPositiveTripCount(scf::ForOp loop) {
+  for (Operation *user : loop.getUpperBound().getUsers()) {
+    if (auto cmp = dyn_cast<arith::CmpIOp>(user)) {
+      if (llvm::none_of(cmp->getUsers(),
+                        [](Operation *op) { return isa<LLVM::AssumeOp>(op); }))
+        continue;
+      if (cmp.getPredicate() == (loop.getUnsignedCmp()
+                                     ? arith::CmpIPredicate::ugt
+                                     : arith::CmpIPredicate::sgt) &&
+          cmp.getLhs() == loop.getUpperBound() &&
+          cmp.getRhs() == loop.getLowerBound())
+        return success();
+      if (cmp.getPredicate() == (loop.getUnsignedCmp()
+                                     ? arith::CmpIPredicate::ult
+                                     : arith::CmpIPredicate::slt) &&
+          cmp.getLhs() == loop.getLowerBound() &&
+          cmp.getRhs() == loop.getUpperBound())
+        return success();
+    }
+  }
+  return failure();
+}
+
 // Speculate the length of the inner loop such that the loop is known to execute
 // at least once. This way, the inner loop body does not have to be placed
 // inside a conditional in the fused loop, which interacts better with the
@@ -971,9 +1130,17 @@ static void optimizeEpilogueDependencies(scf::ForOp outerLoop,
 static LogicalResult speculateInnerLoopLength(scf::ForOp outerLoop,
                                               scf::ForOp innerLoop,
                                               mlir::DominanceInfo &domInfo) {
+  Location loc = innerLoop.getLoc();
+  ImplicitLocOpBuilder b(loc, outerLoop);
+
+  // Check if the inner loop is known to execute at least once.
+  if (succeeded(matchPositiveTripCount(innerLoop))) {
+    innerLoop->setAttr(kMustExecuteAttrName, b.getUnitAttr());
+    return success();
+  }
+
   // The inner loop bounds must be outer-loop invariant to speculate from
   // outside the loop nest.
-  Location loc = innerLoop.getLoc();
   llvm::SetVector<Operation *> toHoist;
   if (!isOuterLoopInvariant(domInfo, outerLoop,
                             {innerLoop.getLowerBound(),
@@ -985,7 +1152,6 @@ static LogicalResult speculateInnerLoopLength(scf::ForOp outerLoop,
   hoistOpsBefore(outerLoop, toHoist);
 
   // Mark the inner loop.
-  ImplicitLocOpBuilder b(loc, outerLoop);
   innerLoop->setAttr(kMustExecuteAttrName, b.getUnitAttr());
 
   // Speculate on whether the length of the inner loop is zero.

--- a/test/TritonGPU/fuse-nested-loops.mlir
+++ b/test/TritonGPU/fuse-nested-loops.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --allow-unregistered-dialect --tritongpu-fuse-nested-loops -cse | FileCheck %s
+// RUN: triton-opt %s --allow-unregistered-dialect --tritongpu-fuse-nested-loops -canonicalize -cse | FileCheck %s
 
 // CHECK-LABEL: @empty_function
 tt.func @empty_function() {
@@ -28,7 +28,7 @@ tt.func @no_fusion(%lb: index, %ub: index, %step: index) -> index {
 tt.func @fuse_one_level_simple(%lbi: i64, %ubi: i64, %stepi: i64, %lbj: i64, %ubj: i64, %stepj: i64) {
   // len_i = len(range(lbi, ubi, stepi))
   //
-  // CHECK-NEXT: [[DIFF_I:%.*]] = arith.subi [[UBI]], [[LBI]]
+  // CHECK:      [[DIFF_I:%.*]] = arith.subi [[UBI]], [[LBI]]
   // CHECK-NEXT: [[LEN_I:%.*]] = arith.ceildivsi [[DIFF_I]], [[STEPI]]
 
   // len_j = len(range(lbj0, ubj0, stepj0))
@@ -38,10 +38,7 @@ tt.func @fuse_one_level_simple(%lbi: i64, %ubi: i64, %stepi: i64, %lbj: i64, %ub
 
   // inner_len = max(1, len_j0)
   //
-  // CHECK-NEXT: [[PLEN0:%.*]] = arith.constant 0 : i64
-  // CHECK:      [[LEN_J_CLAMP:%.*]] = arith.maxsi %c1_i64, [[LEN_J]]
-  // CHECK-NEXT: [[PLEN1:%.*]] = arith.addi [[PLEN0]], [[LEN_J_CLAMP]]
-  // CHECK-NEXT: [[INNER_LEN:%.*]] = arith.subi [[PLEN1]], %c0_i64
+  // CHECK:      [[INNER_LEN:%.*]] = arith.maxsi [[LEN_J]], %c1_i64
 
   // total_iters = len_i * max(1, inner_len)
   //
@@ -54,28 +51,21 @@ tt.func @fuse_one_level_simple(%lbi: i64, %ubi: i64, %stepi: i64, %lbj: i64, %ub
   //
   // CHECK: [[I_INIT:%.*]] = arith.subi [[LBI]], [[STEPI]]
   // CHECK: scf.for %{{.*}} = %c0_i64 to [[TOTAL_ITERS]] step %c1_i64 iter_args(
-  // CHECK-SAME: [[T_ARG:%.*]] = %c-1_i64, [[I_ARG:%.*]] = [[I_INIT]], [[J_ARG:%.*]] = %c0_i64) -> (i64, i64, i64) : i64 {
+  // CHECK-SAME: [[T:%.*]] = %c0_i64, [[I_ARG:%.*]] = [[I_INIT]], [[J_ARG:%.*]] = %c0_i64) -> (i64, i64, i64) : i64 {
   scf.for %i = %lbi to %ubi step %stepi : i64 {
-    // T = 0 if T == (inner_len - 1) else T + 1
-    //
-    // CHECK:      [[T_PLUS_1:%.*]] = arith.addi [[T_ARG]], %c1_i64
-    // CHECK-NEXT: [[T_END:%.*]] = arith.subi [[INNER_LEN]], %c1_i64
-    // CHECK-NEXT: [[ROLLOVER:%.*]] = arith.cmpi eq, [[T_ARG]], [[T_END]]
-    // CHECK-NEXT: [[T:%.*]] = arith.select [[ROLLOVER]], %c0_i64, [[T_PLUS_1]]
-
     // if T == 0:
     //   i += stepi
     //   prologue(i)
     //   j = lbj
     //
-    // CHECK:      [[START:%.*]] = arith.subi %c0_i64, %c0_i64 : i64
-    // CHECK-NEXT: [[PROLOGUE_COND:%.*]] = arith.cmpi eq, [[T]], [[START]]
-    // CHECK-NEXT: [[JI:%.*]]:2 = scf.if [[PROLOGUE_COND]] -> (i64, i64) {
-    // CHECK-NEXT:   [[I:%.*]] = arith.addi [[I_ARG]], [[STEPI]]
-    // CHECK-NEXT:   "prologue"([[I]]) : (i64) -> ()
-    // CHECK-NEXT:   yield [[LBJ]], [[I]]
+    // CHECK-NEXT: [[PROLOGUE_COND:%.*]] = arith.cmpi eq, [[T]], %c0_i64
+    // CHECK-NEXT: [[J:%.*]] = arith.select [[PROLOGUE_COND]], [[LBJ]], [[J_ARG]]
+    // CHECK-NEXT: [[I:%.*]] = scf.if [[PROLOGUE_COND]] -> (i64) {
+    // CHECK-NEXT:   [[I_INCR:%.*]] = arith.addi [[I_ARG]], [[STEPI]]
+    // CHECK-NEXT:   "prologue"([[I_INCR]]) : (i64) -> ()
+    // CHECK-NEXT:   yield [[I_INCR]]
     // CHECK-NEXT: } else {
-    // CHECK-NEXT:   yield [[J_ARG]], [[I_ARG]]
+    // CHECK-NEXT:   yield [[I_ARG]]
     // CHECK-NEXT: }
     "prologue"(%i) : (i64) -> ()
 
@@ -83,16 +73,15 @@ tt.func @fuse_one_level_simple(%lbi: i64, %ubi: i64, %stepi: i64, %lbj: i64, %ub
     //   body(i, j)
     //   j += stepj
     //
-    // CHECK:      [[END:%.*]] = arith.addi [[START]], [[LEN_J]]
-    // CHECK-NEXT: [[GE:%.*]] = arith.cmpi sge, [[T]], [[START]]
-    // CHECK-NEXT: [[LT:%.*]] = arith.cmpi slt, [[T]], [[END]]
+    // CHECK:      [[GE:%.*]] = arith.cmpi sge, [[T]], %c0_i64
+    // CHECK-NEXT: [[LT:%.*]] = arith.cmpi slt, [[T]], [[LEN_J]]
     // CHECK-NEXT: [[COND:%.*]] = arith.andi [[GE]], [[LT]]
     // CHECK-NEXT: [[J_NEXT:%.*]] = scf.if [[COND]] -> (i64) {
-    // CHECK-NEXT:   "body"([[JI]]#1, [[JI]]#0) : (i64, i64) -> ()
-    // CHECK-NEXT:   [[J_INCR:%.*]] = arith.addi [[JI]]#0, [[STEPJ]]
+    // CHECK-NEXT:   "body"([[I]], [[J]]) : (i64, i64) -> ()
+    // CHECK-NEXT:   [[J_INCR:%.*]] = arith.addi [[J]], [[STEPJ]]
     // CHECK-NEXT:   yield [[J_INCR]]
     // CHECK-NEXT: } else {
-    // CHECK-NEXT:   yield [[JI]]#0
+    // CHECK-NEXT:   yield [[J]]
     // CHECK-NEXT: }
     scf.for %j = %lbj to %ubj step %stepj : i64 {
       "body"(%i, %j) : (i64, i64) -> ()
@@ -102,14 +91,19 @@ tt.func @fuse_one_level_simple(%lbi: i64, %ubi: i64, %stepi: i64, %lbj: i64, %ub
     //   epilogue(i)
     //   i += stepi
     //
+    // CHECK:      [[T_END:%.*]] = arith.subi [[INNER_LEN]], %c1_i64
     // CHECK-NEXT: [[EPILOGUE_COND:%.*]] = arith.cmpi eq, [[T]], [[T_END]]
     // CHECK-NEXT: scf.if [[EPILOGUE_COND]] {
-    // CHECK-NEXT:   "epilogue"([[JI]]#1) : (i64) -> ()
-    // CHECK-NEXT: } else {
+    // CHECK-NEXT:   "epilogue"([[I]]) : (i64) -> ()
     // CHECK-NEXT: }
     "epilogue"(%i) : (i64) -> ()
 
-    // CHECK-NEXT: yield [[T]], [[JI]]#1, [[J_NEXT]] : i64, i64, i64
+    // T = 0 if T == (inner_len - 1) else T + 1
+    //
+    // CHECK:      [[T_PLUS_1:%.*]] = arith.addi [[T]], %c1_i64
+    // CHECK-NEXT: [[T_NEXT:%.*]] = arith.select [[EPILOGUE_COND]], %c0_i64, [[T_PLUS_1]]
+
+    // CHECK-NEXT: yield [[T_NEXT]], [[I]], [[J_NEXT]] : i64, i64, i64
   } {"ttg.always-fuse"}
   tt.return
 }
@@ -120,7 +114,7 @@ tt.func @fuse_one_level_simple(%lbi: i64, %ubi: i64, %stepi: i64, %lbj: i64, %ub
 tt.func @fuse_one_level_inouts(%lbi: i64, %ubi: i64, %stepi: i64, %lbj: i64, %ubj: i64, %stepj: i64, %inout: index) -> index {
   // CHECK: [[I_INIT:%.*]] = arith.subi [[LBI]], [[STEPI]]
   // CHECK: [[OUTER_OUTS:%.*]]:6 = scf.for %{{.*}} = %c0_i64 to [[TOTAL_ITERS:%.*]] step %c1_i64 iter_args(
-  // CHECK-SAME: [[T_ARG:%arg[0-9]+]] = %c-1_i64,
+  // CHECK-SAME: [[T:%arg[0-9]+]] = %c0_i64,
   // CHECK-SAME: [[I_ARG:%arg[0-9]+]] = [[I_INIT]]
   // CHECK-SAME: [[M:%arg[0-9]+]] = [[INOUT]]
   // CHECK-SAME: [[J_ARG:%arg[0-9]+]] = %c0_i64
@@ -133,18 +127,19 @@ tt.func @fuse_one_level_inouts(%lbi: i64, %ubi: i64, %stepi: i64, %lbj: i64, %ub
     //   prologue(i)
     //   j = lbj
     //
-    // CHECK:      [[PROLOGUE_OUTS:%.*]]:4 = scf.if %{{[0-9]+}} -> (i64, index, index, i64) {
+    // CHECK:      [[PROLOGUE_COND:%.*]] = arith.cmpi eq, [[T]], %c0_i64
+    // CHECK-NEXT: [[J:%.*]] = arith.select [[PROLOGUE_COND]], [[LBJ]], [[J_ARG]]
+    // CHECK-NEXT: [[K:%.*]] = arith.select [[PROLOGUE_COND]], [[M]], [[K_ARG]]
+    // CHECK-NEXT: [[PROLOGUE_OUTS:%.*]]:2 = scf.if [[PROLOGUE_COND]] -> (index, i64) {
     // CHECK-NEXT:   [[I:%.*]] = arith.addi [[I_ARG]], [[STEPI]]
     // CHECK-NEXT:   [[PROLOGUE_RES:%.*]] = "prologue"([[I]], [[INOUT]], [[M]]) : (i64, index, index) -> index
-    // CHECK-NEXT:   yield [[LBJ]], [[PROLOGUE_RES]], [[M]], [[I]]
+    // CHECK-NEXT:   yield [[PROLOGUE_RES]], [[I]]
     // CHECK-NEXT: } else {
-    // CHECK-NEXT:   yield [[J_ARG]], [[PROLOGUE_OUT_ARG]], [[K_ARG]], [[I_ARG]]
+    // CHECK-NEXT:   yield [[PROLOGUE_OUT_ARG]], [[I_ARG]]
     // CHECK-NEXT: }
     //
-    // J := [[PROLOGUE_OUTS]]#0
-    // PROLOGUE_OUT := [[PROLOGUE_OUTS]]#1
-    // K := [[PROLOGUE_OUTS]]#2
-    // I := [[PROLOGUE_OUTS]]#3
+    // PROLOGUE_OUT := [[PROLOGUE_OUTS]]#0
+    // I := [[PROLOGUE_OUTS]]#1
     %prologue_out = "prologue"(%i, %inout, %m) : (i64, index, index) -> index
 
     // if T >= 0 and T < len_j:
@@ -152,11 +147,11 @@ tt.func @fuse_one_level_inouts(%lbi: i64, %ubi: i64, %stepi: i64, %lbj: i64, %ub
     //   j += stepj
     //
     // CHECK:      [[BODY_OUTS:%.*]]:2 = scf.if {{.*}} -> (i64, index) {
-    // CHECK-NEXT:   [[BODY_OUT:%.*]] = "body"([[PROLOGUE_OUTS]]#3, [[PROLOGUE_OUTS]]#0, [[PROLOGUE_OUTS]]#2, [[PROLOGUE_OUTS]]#1, [[M]]) : (i64, i64, index, index, index) -> index
-    // CHECK-NEXT:   [[J_INCR:%.*]] = arith.addi [[PROLOGUE_OUTS]]#0, [[STEPJ]]
+    // CHECK-NEXT:   [[BODY_OUT:%.*]] = "body"([[PROLOGUE_OUTS]]#1, [[J]], [[K]], [[PROLOGUE_OUTS]]#0, [[M]]) : (i64, i64, index, index, index) -> index
+    // CHECK-NEXT:   [[J_INCR:%.*]] = arith.addi [[J]], [[STEPJ]]
     // CHECK-NEXT:   yield [[J_INCR]], [[BODY_OUT]]
     // CHECK-NEXT: } else {
-    // CHECK-NEXT:   yield [[PROLOGUE_OUTS]]#0, [[K_ARG]]
+    // CHECK-NEXT:   yield [[J]], [[K_ARG]]
     // CHECK-NEXT: }
     %inner_out = scf.for %j = %lbj to %ubj step %stepj iter_args(%k = %m) -> index : i64 {
       %body_out = "body"(%i, %j, %k, %prologue_out, %m) : (i64, i64, index, index, index) -> index
@@ -168,14 +163,14 @@ tt.func @fuse_one_level_inouts(%lbi: i64, %ubi: i64, %stepi: i64, %lbj: i64, %ub
     //   i += stepi
     //
     // CHECK:      [[EPILOGUE_OUTS:%.*]] = scf.if {{.*}} -> (index) {
-    // CHECK-NEXT:   [[EPILOGUE_OUT:%.*]] = "epilogue"([[PROLOGUE_OUTS]]#3, [[PROLOGUE_OUTS]]#1, [[BODY_OUTS]]#1, [[M]]) : (i64, index, index, index) -> index
+    // CHECK-NEXT:   [[EPILOGUE_OUT:%.*]] = "epilogue"([[PROLOGUE_OUTS]]#1, [[PROLOGUE_OUTS]]#0, [[BODY_OUTS]]#1, [[M]]) : (i64, index, index, index) -> index
     // CHECK-NEXT:   yield [[EPILOGUE_OUT]]
     // CHECK-NEXT: } else {
     // CHECK-NEXT:   yield [[M]]
     // CHECK-NEXT: }
     %epilogue_out = "epilogue"(%i, %prologue_out, %inner_out, %m) : (i64, index, index, index) -> index
 
-    // CHECK-NEXT: yield %{{.*}}, [[PROLOGUE_OUTS]]#3, [[EPILOGUE_OUTS]], [[BODY_OUTS]]#0, [[BODY_OUTS]]#1, [[PROLOGUE_OUTS]]#1 : i64, i64, index, i64, index, index
+    // CHECK: yield %{{.*}}, [[PROLOGUE_OUTS]]#1, [[EPILOGUE_OUTS]], [[BODY_OUTS]]#0, [[BODY_OUTS]]#1, [[PROLOGUE_OUTS]]#0 : i64, i64, index, i64, index, index
     scf.yield %epilogue_out : index
   } {"ttg.always-fuse"}
   // CHECK: return [[OUTER_OUTS]]#2
@@ -203,19 +198,17 @@ tt.func @multiple_loops(
   // CHECK-NEXT: [[DIFF_J2:%.*]] = arith.subi [[UBJ2]], [[LBJ2]]
   // CHECK-NEXT: [[LEN_J2:%.*]] = arith.ceildivsi [[DIFF_J2]], [[STEPJ2]]
 
-  // CHECK:      [[PLEN0:%.*]] = arith.constant 0 : i64
-  // CHECK:      [[LEN_J0_CLAMP:%.*]] = arith.maxsi %c1_i64, [[LEN_J0]]
-  // CHECK-NEXT: [[PLEN1:%.*]] = arith.addi [[PLEN0]], [[LEN_J0_CLAMP]]
-  // CHECK-NEXT: [[LEN_J1_CLAMP:%.*]] = arith.maxsi %c1_i64, [[LEN_J1]]
+  // CHECK:      [[PLEN1:%.*]] = arith.maxsi [[LEN_J0]], %c1_i64
+  // CHECK-NEXT: [[LEN_J1_CLAMP:%.*]] = arith.maxsi [[LEN_J1]], %c1_i64
   // CHECK-NEXT: [[PLEN2:%.*]] = arith.addi [[PLEN1]], [[LEN_J1_CLAMP]]
-  // CHECK-NEXT: [[LEN_J2_CLAMP:%.*]] = arith.maxsi %c1_i64, [[LEN_J2]]
+  // CHECK-NEXT: [[LEN_J2_CLAMP:%.*]] = arith.maxsi [[LEN_J2]], %c1_i64
   // CHECK-NEXT: [[PLEN3:%.*]] = arith.addi [[PLEN2]], [[LEN_J2_CLAMP]]
   // CHECK:      [[INNER_LEN:%.*]] = arith.subi [[PLEN3]], %c2_i64
   // CHECK-NEXT: [[TOTAL_ITERS:%.*]] = arith.muli [[LEN_I]], [[INNER_LEN]]
 
   // CHECK:      [[I_INIT:%.*]] = arith.subi [[LBI]], [[STEPI]]
   // CHECK:      [[OUTS:%.*]]:12 = scf.for %{{.*}} = %c0_i64 to [[TOTAL_ITERS]] step %c1_i64 iter_args(
-  // CHECK-SAME: [[T_ARG:%arg[0-9]+]] = %c-1_i64,
+  // CHECK-SAME: [[T:%arg[0-9]+]] = %c0_i64,
   // CHECK-SAME: [[I_ARG:%arg[0-9]+]] = [[I_INIT]],
   // CHECK-SAME: [[M:%arg[0-9]+]] = [[M0]],
   // CHECK-SAME: [[J0_ARG:%arg[0-9]+]] = %c0_i64,
@@ -229,31 +222,25 @@ tt.func @multiple_loops(
   // CHECK-SAME: [[PROLOGUE2_ARG:%arg[0-9]+]] = %cst)
   %mN = scf.for %i = %lbi to %ubi step %stepi iter_args(%m = %m0) -> f32 : i64 {
 
-    // CHECK:      [[T_PLUS_1:%.*]] = arith.addi [[T_ARG]], %c1_i64
-    // CHECK-NEXT: [[T_END:%.*]] = arith.subi [[INNER_LEN]], %c1_i64
-    // CHECK-NEXT: [[ROLLOVER:%.*]] = arith.cmpi eq, [[T_ARG]], [[T_END]]
-    // CHECK-NEXT: [[T:%.*]] = arith.select [[ROLLOVER]], %c0_i64, [[T_PLUS_1]]
-
-    // CHECK:      [[START0:%.*]] = arith.subi [[PLEN0]], %c0_i64
-    // CHECK-NEXT: [[PROLOGUE_COND0:%.*]] = arith.cmpi eq, [[T]], [[START0]]
-    // CHECK-NEXT: [[PROLOGUE0_OUTS:%.*]]:4 = scf.if [[PROLOGUE_COND0]]
+    // CHECK-NEXT: [[PROLOGUE_COND0:%.*]] = arith.cmpi eq, [[T]], %c0_i64
+    // CHECK-NEXT: [[J0:%.*]] = arith.select [[PROLOGUE_COND0]], [[LBJ0]], [[J0_ARG]]
+    // CHECK-NEXT: [[PROLOGUE0_OUTS:%.*]]:3 = scf.if [[PROLOGUE_COND0]]
     // CHECK-NEXT:   [[I:%.*]] = arith.addi [[I_ARG]], [[STEPI]]
     // CHECK-NEXT:   [[RES:%.*]] = "prologue0"([[I]], [[M]])
-    // CHECK-NEXT:   yield [[LBJ0]], [[RES]], [[RES]], [[I]]
+    // CHECK-NEXT:   yield [[RES]], [[RES]], [[I]]
     // CHECK-NEXT: else
-    // CHECK-NEXT:   yield [[J0_ARG]], [[PROLOGUE0_ARG]], [[BODY0_ARG]], [[I_ARG]]
+    // CHECK-NEXT:   yield [[PROLOGUE0_ARG]], [[BODY0_ARG]], [[I_ARG]]
     %k00 = "prologue0"(%i, %m) : (i64, f32) -> f32
 
-    // CHECK:      [[END0:%.*]] = arith.addi [[START0]], [[LEN_J0]]
-    // CHECK-NEXT: [[GE0:%.*]] = arith.cmpi sge, [[T]], [[START0]]
-    // CHECK-NEXT: [[LT0:%.*]] = arith.cmpi slt, [[T]], [[END0]]
+    // CHECK:      [[GE0:%.*]] = arith.cmpi sge, [[T]], %c0_i64
+    // CHECK-NEXT: [[LT0:%.*]] = arith.cmpi slt, [[T]], [[LEN_J0]]
     // CHECK-NEXT: [[BODY_COND0:%.*]] = arith.andi [[GE0]], [[LT0]]
     // CHECK-NEXT: [[BODY0_OUTS:%.*]]:2 = scf.if [[BODY_COND0]]
-    // CHECK-NEXT:   [[RES:%.*]] = "body0"([[PROLOGUE0_OUTS]]#3, [[PROLOGUE0_OUTS]]#0, [[PROLOGUE0_OUTS]]#2)
-    // CHECK-NEXT:   [[NEXT_J0:%.*]] = arith.addi [[PROLOGUE0_OUTS]]#0, [[STEPJ0]]
+    // CHECK-NEXT:   [[RES:%.*]] = "body0"([[PROLOGUE0_OUTS]]#2, [[J0]], [[PROLOGUE0_OUTS]]#1)
+    // CHECK-NEXT:   [[NEXT_J0:%.*]] = arith.addi [[J0]], [[STEPJ0]]
     // CHECK-NEXT:   yield [[NEXT_J0]], [[RES]]
     // CHECK-NEXT: else
-    // CHECK-NEXT:   yield [[PROLOGUE0_OUTS]]#0, [[BODY0_ARG]]
+    // CHECK-NEXT:   yield [[J0]], [[BODY0_ARG]]
     %k0N = scf.for %j0 = %lbj0 to %ubj0 step %stepj0 iter_args(%k0 = %k00) -> f32 : i64 {
       %res = "body0"(%i, %j0, %k0) : (i64, i64, f32) -> f32
       scf.yield %res : f32
@@ -261,11 +248,12 @@ tt.func @multiple_loops(
 
     // CHECK:      [[START1:%.*]] = arith.subi [[PLEN1]], %c1_i64
     // CHECK-NEXT: [[PROLOGUE_COND1:%.*]] = arith.cmpi eq, [[T]], [[START1]]
-    // CHECK-NEXT: [[PROLOGUE1_OUTS:%.*]]:3 = scf.if [[PROLOGUE_COND1]]
-    // CHECK-NEXT:   [[RES:%.*]] = "prologue1"([[PROLOGUE0_OUTS]]#3, [[BODY0_OUTS]]#1)
-    // CHECK-NEXT:   yield [[LBJ1]], [[RES]], [[RES]]
+    // CHECK-NEXT: [[J1:%.*]] = arith.select [[PROLOGUE_COND1]], [[LBJ1]], [[J1_ARG]]
+    // CHECK-NEXT: [[PROLOGUE1_OUTS:%.*]]:2 = scf.if [[PROLOGUE_COND1]]
+    // CHECK-NEXT:   [[RES:%.*]] = "prologue1"([[PROLOGUE0_OUTS]]#2, [[BODY0_OUTS]]#1)
+    // CHECK-NEXT:   yield [[RES]], [[RES]]
     // CHECK-NEXT: else
-    // CHECK-NEXT:   yield [[J1_ARG]], [[PROLOGUE1_ARG]], [[BODY1_ARG]]
+    // CHECK-NEXT:   yield [[PROLOGUE1_ARG]], [[BODY1_ARG]]
     %k10 = "prologue1"(%i, %k0N) : (i64, f32) -> f32
 
     // CHECK:      [[END1:%.*]] = arith.addi [[START1]], [[LEN_J1]]
@@ -273,11 +261,11 @@ tt.func @multiple_loops(
     // CHECK-NEXT: [[LT1:%.*]] = arith.cmpi slt, [[T]], [[END1]]
     // CHECK-NEXT: [[BODY_COND1:%.*]] = arith.andi [[GE1]], [[LT1]]
     // CHECK-NEXT: [[BODY1_OUTS:%.*]]:2 = scf.if [[BODY_COND1]]
-    // CHECK-NEXT:   [[RES:%.*]] = "body1"([[PROLOGUE0_OUTS]]#3, [[PROLOGUE1_OUTS]]#0, [[PROLOGUE1_OUTS]]#2)
-    // CHECK-NEXT:   [[NEXT_J1:%.*]] = arith.addi [[PROLOGUE1_OUTS]]#0, [[STEPJ1]]
+    // CHECK-NEXT:   [[RES:%.*]] = "body1"([[PROLOGUE0_OUTS]]#2, [[J1]], [[PROLOGUE1_OUTS]]#1)
+    // CHECK-NEXT:   [[NEXT_J1:%.*]] = arith.addi [[J1]], [[STEPJ1]]
     // CHECK-NEXT:   yield [[NEXT_J1]], [[RES]]
     // CHECK-NEXT: else
-    // CHECK-NEXT:   yield [[PROLOGUE1_OUTS]]#0, [[BODY1_ARG]]
+    // CHECK-NEXT:   yield [[J1]], [[BODY1_ARG]]
     %k1N = scf.for %j1 = %lbj1 to %ubj1 step %stepj1 iter_args(%k1 = %k10) -> f32 : i64 {
       %res = "body1"(%i, %j1, %k1) : (i64, i64, f32) -> f32
       scf.yield %res : f32
@@ -285,11 +273,12 @@ tt.func @multiple_loops(
 
     // CHECK:      [[START2:%.*]] = arith.subi [[PLEN2]], %c2_i64
     // CHECK-NEXT: [[PROLOGUE_COND2:%.*]] = arith.cmpi eq, [[T]], [[START2]]
-    // CHECK-NEXT: [[PROLOGUE2_OUTS:%.*]]:3 = scf.if [[PROLOGUE_COND2]]
-    // CHECK-NEXT:   [[RES:%.*]] = "prologue2"([[PROLOGUE0_OUTS]]#3, [[BODY1_OUTS]]#1)
-    // CHECK-NEXT:   yield [[LBJ2]], [[RES]], [[RES]]
+    // CHECK-NEXT: [[J2:%.*]] = arith.select [[PROLOGUE_COND2]], [[LBJ2]], [[J2_ARG]]
+    // CHECK-NEXT: [[PROLOGUE2_OUTS:%.*]]:2 = scf.if [[PROLOGUE_COND2]]
+    // CHECK-NEXT:   [[RES:%.*]] = "prologue2"([[PROLOGUE0_OUTS]]#2, [[BODY1_OUTS]]#1)
+    // CHECK-NEXT:   yield [[RES]], [[RES]]
     // CHECK-NEXT: else
-    // CHECK-NEXT:   yield [[J2_ARG]], [[PROLOGUE2_ARG]], [[BODY2_ARG]]
+    // CHECK-NEXT:   yield [[PROLOGUE2_ARG]], [[BODY2_ARG]]
     %k20 = "prologue2"(%i, %k1N) : (i64, f32) -> f32
 
     // CHECK:      [[END2:%.*]] = arith.addi [[START2]], [[LEN_J2]]
@@ -297,27 +286,31 @@ tt.func @multiple_loops(
     // CHECK-NEXT: [[LT2:%.*]] = arith.cmpi slt, [[T]], [[END2]]
     // CHECK-NEXT: [[BODY_COND2:%.*]] = arith.andi [[GE2]], [[LT2]]
     // CHECK-NEXT: [[BODY2_OUTS:%.*]]:2 = scf.if [[BODY_COND2]]
-    // CHECK-NEXT:   [[RES:%.*]] = "body2"([[PROLOGUE0_OUTS]]#3, [[PROLOGUE2_OUTS]]#0, [[PROLOGUE2_OUTS]]#2)
-    // CHECK-NEXT:   [[NEXT_J2:%.*]] = arith.addi [[PROLOGUE2_OUTS]]#0, [[STEPJ2]]
+    // CHECK-NEXT:   [[RES:%.*]] = "body2"([[PROLOGUE0_OUTS]]#2, [[J2]], [[PROLOGUE2_OUTS]]#1)
+    // CHECK-NEXT:   [[NEXT_J2:%.*]] = arith.addi [[J2]], [[STEPJ2]]
     // CHECK-NEXT:   yield [[NEXT_J2]], [[RES]]
     // CHECK-NEXT: else
-    // CHECK-NEXT:   yield [[PROLOGUE2_OUTS]]#0, [[BODY2_ARG]]
+    // CHECK-NEXT:   yield [[J2]], [[BODY2_ARG]]
     %k2N = scf.for %j2 = %lbj2 to %ubj2 step %stepj2 iter_args(%k2 = %k20) -> f32 : i64 {
       %res = "body2"(%i, %j2, %k2) : (i64, i64, f32) -> f32
       scf.yield %res : f32
     }
 
-    // CHECK:      [[EPILOGUE_COND:%.*]] = arith.cmpi eq, [[T]], [[T_END]]
+    // CHECK:      [[T_END:%.*]] = arith.subi [[PLEN3]], %c3_i64
+    // CHECK-NEXT: [[EPILOGUE_COND:%.*]] = arith.cmpi eq, [[T]], [[T_END]]
     // CHECK-NEXT: [[EPILOGUE_OUTS:%.*]] = scf.if [[EPILOGUE_COND]]
-    // CHECK-NEXT:   [[RES:%.*]] = "epilogue"([[PROLOGUE0_OUTS]]#3, [[BODY2_OUTS]]#1)
+    // CHECK-NEXT:   [[RES:%.*]] = "epilogue"([[PROLOGUE0_OUTS]]#2, [[BODY2_OUTS]]#1)
     // CHECK-NEXT:   yield [[RES]]
     // CHECK-NEXT:  else
     // CHECK-NEXT:   yield [[M]]
     %out = "epilogue"(%i, %k2N) : (i64, f32) -> f32
 
-    // CHECK:      scf.yield [[T]], [[PROLOGUE0_OUTS]]#3, [[EPILOGUE_OUTS]],
+    // CHECK:      [[T_PLUS_1:%.*]] = arith.addi [[T]], %c1_i64
+    // CHECK-NEXT: [[T_NEXT:%.*]] = arith.select [[EPILOGUE_COND]], %c0_i64, [[T_PLUS_1]]
+
+    // CHECK:      scf.yield [[T_NEXT]], [[PROLOGUE0_OUTS]]#2, [[EPILOGUE_OUTS]],
     // CHECK-SAME:           [[BODY0_OUTS]]#0, [[BODY1_OUTS]]#0, [[BODY2_OUTS]]#0,
-    // CHECK-SAME:           [[PROLOGUE0_OUTS]]#1, [[PROLOGUE1_OUTS]]#1, [[PROLOGUE2_OUTS]]#1 :
+    // CHECK-SAME:           [[PROLOGUE0_OUTS]]#0, [[PROLOGUE1_OUTS]]#0, [[PROLOGUE2_OUTS]]#0 :
     scf.yield %out : f32
   } {"ttg.always-fuse"}
   // CHECK: return [[OUTS]]#2
@@ -345,7 +338,7 @@ tt.func @two_loop_nests(%lbi: i64, %ubi: i64, %stepi: i64, %lbj: i64, %ubj: i64,
 // CHECK-LABEL: @hoist_loop_bound_computations
 // CHECK-SAME: [[LBI:%.*]]: i64, [[UBI:%.*]]: i64, [[STEPI:%.*]]: i64
 tt.func @hoist_loop_bound_computations(%lbi: i64, %ubi: i64, %stepi: i64) {
-  // CHECK-NEXT: [[LBJ:%.*]] = arith.addi [[LBI]], [[STEPI]]
+  // CHECK:      [[LBJ:%.*]] = arith.addi [[LBI]], [[STEPI]]
   // CHECK-NEXT: [[UBJ:%.*]] = arith.addi [[UBI]], [[STEPI]]
   // CHECK-NEXT: [[STEPJ:%.*]] = arith.addi [[STEPI]], [[STEPI]]
 
@@ -359,12 +352,12 @@ tt.func @hoist_loop_bound_computations(%lbi: i64, %ubi: i64, %stepi: i64) {
     %lbj = arith.addi %lbi, %stepi : i64
     %ubj = arith.addi %ubi, %stepi : i64
     %stepj = arith.addi %stepi, %stepi : i64
-    // CHECK: [[J:%.*]]:2 = scf.if
-    // CHECK:   yield [[LBJ]]
+    // CHECK: [[J:%.*]] = arith.select %{{.*}}, [[LBJ]], %arg{{[0-9]+}}
+    // CHECK-NEXT: scf.if
 
     // CHECK: scf.if
     // CHECK-NEXT: "body"
-    // CHECK-NEXT: arith.addi [[J]]#0, [[STEPJ]]
+    // CHECK-NEXT: arith.addi [[J]], [[STEPJ]]
     scf.for %j = %lbj to %ubj step %stepj : i64 {
       "body"(%i, %j) : (i64, i64) -> ()
     }
@@ -372,25 +365,42 @@ tt.func @hoist_loop_bound_computations(%lbi: i64, %ubi: i64, %stepi: i64) {
   tt.return
 }
 
-// CHECK-LABEL: @cannot_fuse
-tt.func @cannot_fuse(%lbi: i64, %ubi: i64, %stepi: i64) {
-  // CHECK-COUNT-2: scf.for
+// CHECK-LABEL: @dependent_inner_loop
+// CHECK-SAME: [[LBI:%.*]]: i64, [[UBI:%.*]]: i64, [[STEPI:%.*]]: i64
+tt.func @dependent_inner_loop(%lbi: i64, %ubi: i64, %stepi: i64) {
+  // CHECK:      [[TOTAL_ITERS:%.*]] = scf.for [[I:%.*]] = [[LBI]] to [[UBI]] step [[STEPI]] iter_args([[SUM:%.*]] = %c0_i64)
+  // CHECK-NEXT:   [[LBJ:%.*]] = arith.addi [[LBI]], [[STEPI]]
+  // CHECK-NEXT:   [[UBJ:%.*]] = arith.addi [[UBI]], [[I]]
+  // CHECK-NEXT:   [[STEPJ:%.*]] = arith.addi [[STEPI]], [[STEPI]]
+  // CHECK-NEXT:   [[DIFF_J:%.*]] = arith.subi [[UBJ]], [[LBJ]]
+  // CHECK-NEXT:   [[LEN_J:%.*]] = arith.ceildivsi [[DIFF_J]], [[STEPJ]]
+  // CHECK-NEXT:   [[CLAMPED_LEN_J:%.*]] = arith.maxsi [[LEN_J]], %c1_i64
+  // CHECK-NEXT:   [[ACC:%.*]] = arith.addi [[SUM]], [[CLAMPED_LEN_J]]
+  // CHECK-NEXT:   yield [[ACC]]
+  // CHECK-NEXT: }
+
+  // CHECK-NEXT: [[I_INIT:%.*]] = arith.subi [[LBI]], [[STEPI]]
+  // CHECK-NEXT: [[OUTS:%.*]]:8 = scf.for {{.*}} = %c0_i64 to [[TOTAL_ITERS]] step %c1_i64 iter_args(
+  // CHECK-SAME: [[T:%arg[0-9]+]] = %c0_i64,
+  // CHECK-SAME: [[I_ARG:%arg[0-9]+]] = [[I_INIT]],
+  // CHECK-SAME: [[J_ARG:%arg[0-9]+]] = %c0_i64,
   scf.for %i = %lbi to %ubi step %stepi : i64 {
     %lbj = arith.addi %lbi, %stepi : i64
     %ubj = arith.addi %ubi, %i : i64
     %stepj = arith.addi %stepi, %stepi : i64
+    "prologue"(%i) : (i64) -> ()
     scf.for %j = %lbj to %ubj step %stepj : i64 {
       "body"(%i, %j) : (i64, i64) -> ()
     }
+    "epilogue"(%i) : (i64) -> ()
   } {"ttg.always-fuse"}
-  // CHECK-NOT: scf.for
   tt.return
 }
 
 // CHECK-LABEL: @upcast_i16_to_i32
 // CHECK-SAME: [[LBI:%.*]]: i32, [[UBI:%.*]]: i32, [[STEPI:%.*]]: i32, [[LBJ:%.*]]: i16, [[UBJ:%.*]]: i16, [[STEPJ:%.*]]: i16
 tt.func @upcast_i16_to_i32(%lbi: i32, %ubi: i32, %stepi: i32, %lbj: i16, %ubj: i16, %stepj: i16) {
-  // CHECK-NEXT: [[DIFF_I:%.*]] = arith.subi [[UBI]], [[LBI]] : i32
+  // CHECK:      [[DIFF_I:%.*]] = arith.subi [[UBI]], [[LBI]] : i32
   // CHECK-NEXT: [[LEN_I:%.*]] = arith.ceildivsi [[DIFF_I]], [[STEPI]] : i32
   // CHECK-NEXT: [[DIFF_J:%.*]] = arith.subi [[UBJ]], [[LBJ]] : i16
   // CHECK-NEXT: [[LEN_J:%.*]] = arith.ceildivsi [[DIFF_J]], [[STEPJ]] : i16
@@ -407,7 +417,7 @@ tt.func @upcast_i16_to_i32(%lbi: i32, %ubi: i32, %stepi: i32, %lbj: i16, %ubj: i
 // CHECK-LABEL: @upcast_index_to_i64
 // CHECK-SAME: [[LBI:%.*]]: index, [[UBI:%.*]]: index, [[STEPI:%.*]]: index, [[LBJ:%.*]]: index, [[UBJ:%.*]]: index, [[STEPJ:%.*]]: index
 tt.func @upcast_index_to_i64(%lbi: index, %ubi: index, %stepi: index, %lbj: index, %ubj: index, %stepj: index) {
-  // CHECK-NEXT: [[DIFF_I:%.*]] = arith.subi [[UBI]], [[LBI]] : index
+  // CHECK:      [[DIFF_I:%.*]] = arith.subi [[UBI]], [[LBI]] : index
   // CHECK-NEXT: [[LEN_I:%.*]] = arith.ceildivsi [[DIFF_I]], [[STEPI]] : index
   // CHECK-NEXT: [[DIFF_J:%.*]] = arith.subi [[UBJ]], [[LBJ]] : index
   // CHECK-NEXT: [[LEN_J:%.*]] = arith.ceildivsi [[DIFF_J]], [[STEPJ]] : index
@@ -466,8 +476,7 @@ tt.func @preserve_stage_count(%lb: i32, %ub: i32) {
 tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
   %c1_i32 = arith.constant 1 : i32
 
-  // CHECK: [[DIFF:%.*]] = arith.subi [[UB]], [[LB]]
-  // CHECK: [[LEN:%.*]] = arith.ceildivsi [[DIFF]], %c1_i32
+  // CHECK: [[LEN:%.*]] = arith.subi [[UB]], [[LB]]
   // CHECK: [[IS_ZERO:%.*]] = arith.cmpi eq, [[LEN]], %c0_i32
 
   // CHECK: scf.if [[IS_ZERO]]
@@ -479,9 +488,13 @@ tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
   // CHECK-COUNT-1: scf.for
   // CHECK-NOT: scf.for
   scf.for %i = %lb to %ub step %c1_i32 : i32 {
-    // CHECK: "prologue"
+    // CHECK: scf.if
+    // CHECK-NEXT: arith.addi
+    // CHECK-NEXT: "prologue"
     "prologue"(%i) : (i32) -> ()
-    // CHECK: scf.if %true
+    // CHECK: else
+    // CHECK-NEXT: scf.yield
+    // CHECK-NEXT: }
     scf.for %j = %lb to %ub step %c1_i32 : i32 {
       // CHECK-NEXT: "body"
       "body"(%i, %j) : (i32, i32) -> ()
@@ -496,10 +509,7 @@ tt.func @fuse_attr_speculate(%lb: i32, %ub: i32) {
 tt.func @speculate_hoist(%lb: i32, %ub: i32) {
   %c1_i32 = arith.constant 1 : i32
 
-  // CHECK: [[UBJ:%.*]] = arith.addi [[LB]], [[UB]]
-  // CHECK: [[DIFF:%.*]] = arith.subi [[UBJ]], [[LB]]
-  // CHECK: [[LEN:%.*]] = arith.ceildivsi [[DIFF]], %c1_i32
-  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi eq, [[LEN]], %c0_i32
+  // CHECK: [[IS_ZERO:%.*]] = arith.cmpi eq, [[UB]], %c0_i32
 
   // CHECK: scf.if [[IS_ZERO]]
   scf.for %i = %lb to %ub step %c1_i32 : i32 {
@@ -522,16 +532,18 @@ tt.func @sink_prologue_to_epilogue(%ub: i32) {
   // CHECK: else
   // CHECK: scf.for
   %0 = scf.for %i = %c0_i32 to %ub step %c1_i32 iter_args(%k = %c0_i32) -> i32 : i32 {
-    // CHECK: [[PROLOGUE_OUTS:%.*]]:2 = scf.if
+    // CHECK: [[PROLOGUE_OUTS:%.*]] = scf.if
     %0 = arith.addi %i, %ub : i32
-    // CHECK: scf.if %true
+    // CHECK: else
+    // CHECK-NEXT: scf.yield
+    // CHECK-NEXT: }
     // CHECK-NEXT: "body"
     scf.for %j = %c0_i32 to %ub step %c1_i32 : i32 {
       "body"(%i, %j) : (i32, i32) -> ()
       scf.yield
     }
     // CHECK: scf.if
-    // CHECK-NEXT: [[V0:%.*]] = arith.addi [[PROLOGUE_OUTS]]#1, [[UB]]
+    // CHECK-NEXT: [[V0:%.*]] = arith.addi [[PROLOGUE_OUTS]], [[UB]]
     // CHECK-NEXT: [[V1:%.*]] = arith.addi [[V0]], [[UB]]
     %1 = arith.addi %0, %ub : i32
     // CHECK-NEXT: "epilogue"([[V1]])
@@ -562,7 +574,7 @@ tt.func @prologue_output(%ub: i32) {
     // CHECK: scf.if {{%[0-9]+}} {
     // CHECK-NEXT: "epilogue"
     "epilogue"(%i) : (i32) -> ()
-    // CHECK-NEXT: } else {
+    // CHECK-NEXT: }
     scf.yield %next : i32
   } {"ttg.always-fuse"}
 


### PR DESCRIPTION
This PR teaches FuseNestedLoops to handle inner loops whose loop bounds are some (pure) function of the outer loop bounds. FuseNestedLoops slices the inner loop bound computations into a loop before the fused loop to compute the total number of fused iterations. Then, inside the first fused prologue, the inner loop lengths for the current outer loop iterations are computed. The pass supports a mix of inner loops whose bounds can be made outer loop invariant and those that are not.

This patch also adds a small hack that pattern matches `tl.assume(ub > lb)` for the inner loop bounds to allow speculation (i.e. all inner loops execute at least once).