### PR TITLE
Add extra buffer for pipelined uses in later clusters than loads

### DIFF
--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -1647,3 +1647,34 @@ tt.func @scalar_load(%lb : index, %ub : index, %step : index,
   tt.return
 }
 }
+
+// -----
+
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// Test for conditional store pipelining bugfix
+// This test reproduces the race condition where conditional code (scf.if) gets moved to
+// epilogue cluster, causing users of loads to be scheduled in later clusters than the loads themselves.
+// The fix allocates extra buffer space when this situation is detected.
+// CHECK-LABEL: @conditional_store_race_fix
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x{{.*}}>
+// CHECK: scf.if %{{.*}} {
+
+tt.func @conditional_store_race_fix(%lb : index, %ub : index, %step : index,
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                 %out_ptr : tensor<128x32x!tt.ptr<f16>, #blocked1>,
+                 %cnd : i1) -> () {
+  scf.for %iv = %lb to %ub step %step : index {
+    // Load is in cluster 0, stage 0 (early cluster)
+    %a = tt.load %a_ptr_init {loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #blocked1>
+    // Conditional store is in cluster 2, stage 2 (later cluster than load: 2 > 0)
+    // This creates the race condition where the local load happens after
+    // the global-to-local copy for the next pipeline stage starts
+    scf.if %cnd {
+      tt.store %out_ptr, %a {loop.cluster = 2 : i32, loop.stage = 2 : i32} : tensor<128x32x!tt.ptr<f16>, #blocked1>
+    } {loop.cluster = 2 : i32, loop.stage = 2 : i32}
+  } {tt.scheduled_max_stage = 2 : i32}
+  tt.return
+}
+}


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests

**TLDR: This currently races and gives incorrect output:**

```
for i in tl.range(0, N, num_stages=2):
    out_idx = tl.load(arange_ptr + i + tl.arange(0, 1))
    if always_true_but_not_constexpr:
        tl.store(output_ptr + out_idx, i + 1)
```

Specifically, the `out_idx` races with the prior pipeline stage. This code currently writes `[0, 1, 2, 3, 4, 5, 6, 8, 0, 9, 10, 11, 12, 13, 14, 16, 17]`, when it should instead write `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]`.

What's going on? As I understand it, the problem is:

First, the conditional usage of `out_idx` is forced to the epilogueCluster by this code https://github.com/triton-lang/triton/blob/3b41514dc2526628deadbe5271b5596ffa2fb820/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp#L221-L240

This changes the overall shape of the pipeline. The TTGIR looks like this:

```
ttg.async_copy_global_to_local # warmup the pipeline
loop {
	...
	ttg.async_copy_global_to_local # load for the NEXT stage (NOT this iteration)
	... # at this moment, TWO copies are in-flight!
	ttg.async_wait, ttg.local_load # use the data loaded by the previous iteration
	...
}
```

But if I change the `if` to be `if True`, it looks like this:

```
ttg.async_copy_global_to_local # warmup the pipeline
loop {
	...
	ttg.async_wait, ttg.local_load # use the data loaded by the previous iteration
	...
	ttg.async_copy_global_to_local # load for the NEXT stage (NOT this iteration)
	...
}
```

There's nothing **inherently** wrong with either of these schedules, in my view. Nevertheless, the latter works fine, while the former currently has data races.

The reason is simple: The former schedule only works **if you have two buffers**, while the latter schedule works with only one buffer, because at no point in the latter schedule were there two copies in-flight.

Currently **both** of these variants generate `ttg.local_alloc : () -> !ttg.memdesc<1x1xi32, #shared, #smem, mutable>`, but that's just wrong for the first variant.

There currently is a case where we detect that the number of buffers must be one more than the stageDiff (aka, equal to the num_stages), here https://github.com/triton-lang/triton/blob/b08a27ee09d79e9e7b29969097b7bf5d0004ffcb/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp#L468-L471

In this PR, I detect if the user of the load has been assigned by the CoarseSchedule to a later cluster than the load itself. In that case, this load is destined for the next iteration of the loop, yet the load from the previous iteration of the loop is still in flight. Therefore, we need one more buffer space than otherwise.

**Full reproduction script:**

```py
import triton
import triton.language as tl
import torch
torch.set_default_device("cuda")
print(triton.__version__)
print(triton.__file__)

@triton.jit
def repro_kernel_constexpr(
    arange_ptr,
    output_ptr,
    loop_stages: tl.constexpr,
    N: tl.constexpr,
    always_true: tl.constexpr,
):
    for i in tl.range(0, N, num_stages=loop_stages):
        out_idx = tl.load(arange_ptr + i + tl.arange(0, 1))
        if always_true:
            tl.store(output_ptr + out_idx, i + 1)

@triton.jit
def repro_kernel(
    arange_ptr,
    output_ptr,
    loop_stages: tl.constexpr,
    N: tl.constexpr,
    always_true_but_not_constexpr,
):
    for i in tl.range(0, N, num_stages=loop_stages):
        out_idx = tl.load(arange_ptr + i + tl.arange(0, 1))
        if always_true_but_not_constexpr:
            tl.store(output_ptr + out_idx, i + 1)

N = 17
arange = torch.arange(N, dtype=torch.int32)
for kernel in [repro_kernel_constexpr, repro_kernel]:
    for loop_stages in [1, 2]:
        out = torch.zeros((N,), dtype=torch.int32)
        kernel[(1,)](arange, out, loop_stages, N, True)
        print(out.tolist())
        assert (out != 0).all()
```

Current output:

```
3.4.0
/home/ubuntu/.local/lib/python3.10/site-packages/triton/__init__.py
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
[0, 1, 2, 3, 4, 5, 6, 8, 0, 9, 10, 11, 12, 13, 14, 16, 17]
Traceback (most recent call last):
  File "/home/ubuntu/triton/repro.py", line 41, in <module>
    assert (out != 0).all()
AssertionError
```

Output with this PR:

```
3.5.0
/home/ubuntu/triton/python/triton/__init__.py
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
```

<details>
<summary>TTGIR before</summary>

```
#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
#loc = loc("/home/ubuntu/triton/repro.py":22:0)
#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
#smem = #ttg.shared_memory
module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
  tt.func public @repro_kernel(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32} loc("/home/ubuntu/triton/repro.py":22:0), %arg1: !tt.ptr<i32> {tt.divisibility = 16 : i32} loc("/home/ubuntu/triton/repro.py":22:0), %arg2: i1 loc("/home/ubuntu/triton/repro.py":22:0)) attributes {noinline = false} {
    %c17_i32 = arith.constant 17 : i32 loc(#loc1)
    %c0_i32 = arith.constant 0 : i32 loc(#loc1)
    %c1_i32 = arith.constant 1 : i32 loc(#loc1)
    %c-1_i32 = arith.constant -1 : i32 loc(#loc1)
    %c16_i32 = arith.constant 16 : i32 loc(#loc1)
    %cst = arith.constant dense<true> : tensor<1xi1, #blocked> loc(#loc1)
    %0 = ttg.local_alloc : () -> !ttg.memdesc<1x1xi32, #shared, #smem, mutable> loc(#loc2)
    %1 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>, #blocked> loc(#loc3)
    %2 = ttg.memdesc_subview %0[%c0_i32, %c0_i32] : !ttg.memdesc<1x1xi32, #shared, #smem, mutable> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> loc(#loc2)
    %3 = ttg.async_copy_global_to_local %1, %2 mask %cst : tensor<1x!tt.ptr<i32>, #blocked> -> <1xi32, #shared, #smem, mutable, 1x1> loc(#loc2)
    %4 = ttg.async_commit_group %3 loc(#loc2)
    %5:2 = scf.for %arg3 = %c0_i32 to %c17_i32 step %c1_i32 iter_args(%arg4 = %c-1_i32, %arg5 = %4) -> (i32, !ttg.async.token)  : i32 {
      %7 = arith.cmpi slt, %arg3, %c16_i32 : i32 loc(#loc4)
      %8 = arith.addi %arg3, %c1_i32 : i32 loc(#loc4)
      %9 = tt.addptr %arg0, %8 : !tt.ptr<i32>, i32 loc(#loc5)
      %10 = tt.splat %9 : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>, #blocked> loc(#loc3)
      %11 = ttg.memdesc_subview %0[%c0_i32, %c0_i32] : !ttg.memdesc<1x1xi32, #shared, #smem, mutable> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> loc(#loc2)
      %12 = tt.splat %7 : i1 -> tensor<1xi1, #blocked> loc(#loc4)
      %13 = ttg.async_copy_global_to_local %10, %11 mask %12 : tensor<1x!tt.ptr<i32>, #blocked> -> <1xi32, #shared, #smem, mutable, 1x1> loc(#loc2)
      %14 = ttg.async_commit_group %13 loc(#loc2)
      %15 = arith.addi %arg4, %c1_i32 : i32 loc(#loc4)
      %16 = arith.cmpi sge, %15, %c1_i32 : i32 loc(#loc4)
      %17 = arith.select %16, %c0_i32, %15 : i32 loc(#loc4)
      %18 = ttg.async_wait %arg5 {num = 1 : i32} loc(#loc2)
      %19 = ttg.memdesc_subview %0[%17, %c0_i32] : !ttg.memdesc<1x1xi32, #shared, #smem, mutable> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> loc(#loc2)
      %20 = ttg.local_load %19 token %18 : !ttg.memdesc<1xi32, #shared, #smem, mutable, 1x1> -> tensor<1xi32, #blocked> loc(#loc2)
      scf.if %arg2 {
        %21 = tt.splat %arg1 : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>, #blocked> loc(#loc7)
        %22 = tt.addptr %21, %20 : tensor<1x!tt.ptr<i32>, #blocked>, tensor<1xi32, #blocked> loc(#loc7)
        %23 = tt.splat %8 : i32 -> tensor<1xi32, #blocked> loc(#loc8)
        tt.store %22, %23 : tensor<1x!tt.ptr<i32>, #blocked> loc(#loc8)
      } loc(#loc6)
      scf.yield %17, %14 : i32, !ttg.async.token loc(#loc4)
    } {tt.num_stages = 2 : i32} loc(#loc4)
    %6 = ttg.async_wait  {num = 0 : i32} loc(#loc4)
    ttg.local_dealloc %0 : !ttg.memdesc<1x1xi32, #shared, #smem, mutable> loc(#loc4)
    tt.return loc(#loc9)
  } loc(#loc)
} loc(#loc)
#loc1 = loc(unknown)
#loc2 = loc("/home/ubuntu/triton/repro.py":30:26)
#loc3 = loc("/home/ubuntu/triton/repro.py":30:43)
#loc4 = loc("/home/ubuntu/triton/repro.py":29:28)
#loc5 = loc("/home/ubuntu/triton/repro.py":30:39)
#loc6 = loc("/home/ubuntu/triton/repro.py":31:11)
#loc7 = loc("/home/ubuntu/triton/repro.py":32:34)
#loc8 = loc("/home/ubuntu/triton/repro.py":32:43)
#loc9 = loc("/home/ubuntu/triton/repro.py":29:4)
```

</details>

<details>
<summary>TTGIR after</summary>

```
#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
#loc = loc("/home/ubuntu/triton/repro.py":22:0)
#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
#smem = #ttg.shared_memory
#loc10 = loc("arange_ptr"(#loc))
#loc11 = loc("output_ptr"(#loc))
#loc12 = loc("always_true_but_not_constexpr"(#loc))
module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
  tt.func public @repro_kernel(%arange_ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32} loc("arange_ptr"(#loc)), %output_ptr: !tt.ptr<i32> {tt.divisibility = 16 : i32} loc("output_ptr"(#loc)), %always_true_but_not_constexpr: i1 loc("always_true_but_not_constexpr"(#loc))) attributes {noinline = false} {
    %c17_i32 = arith.constant 17 : i32 loc(#loc1)
    %c0_i32 = arith.constant 0 : i32 loc(#loc1)
    %c1_i32 = arith.constant 1 : i32 loc(#loc1)
    %c-1_i32 = arith.constant -1 : i32 loc(#loc1)
    %c2_i32 = arith.constant 2 : i32 loc(#loc1)
    %c16_i32 = arith.constant 16 : i32 loc(#loc1)
    %cst = arith.constant dense<true> : tensor<1xi1, #blocked> loc(#loc1)
    %out_idx = ttg.local_alloc : () -> !ttg.memdesc<2x1xi32, #shared, #smem, mutable> loc(#loc13)
    %out_idx_0 = tt.splat %arange_ptr : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>, #blocked> loc(#loc14)
    %out_idx_1 = ttg.memdesc_index %out_idx[%c0_i32] : !ttg.memdesc<2x1xi32, #shared, #smem, mutable> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> loc(#loc13)
    %out_idx_2 = ttg.async_copy_global_to_local %out_idx_0, %out_idx_1 mask %cst : tensor<1x!tt.ptr<i32>, #blocked> -> <1xi32, #shared, #smem, mutable, 2x1> loc(#loc13)
    %out_idx_3 = ttg.async_commit_group tokens %out_idx_2 loc(#loc13)
    %0:3 = scf.for %arg3 = %c0_i32 to %c17_i32 step %c1_i32 iter_args(%arg4 = %c0_i32, %arg5 = %c-1_i32, %out_idx_4 = %out_idx_3) -> (i32, i32, !ttg.async.token)  : i32 {
      %2 = arith.cmpi slt, %arg3, %c16_i32 : i32 loc(#loc4)
      %3 = arith.addi %arg4, %c1_i32 : i32 loc(#loc4)
      %4 = arith.cmpi sge, %3, %c2_i32 : i32 loc(#loc4)
      %5 = arith.select %4, %c0_i32, %3 : i32 loc(#loc4)
      %6 = arith.addi %arg3, %c1_i32 : i32 loc(#loc4)
      %out_idx_5 = tt.addptr %arange_ptr, %6 : !tt.ptr<i32>, i32 loc(#loc15)
      %out_idx_6 = tt.splat %out_idx_5 : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>, #blocked> loc(#loc14)
      %out_idx_7 = ttg.memdesc_index %out_idx[%5] : !ttg.memdesc<2x1xi32, #shared, #smem, mutable> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> loc(#loc13)
      %7 = tt.splat %2 : i1 -> tensor<1xi1, #blocked> loc(#loc4)
      %out_idx_8 = ttg.async_copy_global_to_local %out_idx_6, %out_idx_7 mask %7 : tensor<1x!tt.ptr<i32>, #blocked> -> <1xi32, #shared, #smem, mutable, 2x1> loc(#loc13)
      %out_idx_9 = ttg.async_commit_group tokens %out_idx_8 loc(#loc13)
      %8 = arith.addi %arg5, %c1_i32 : i32 loc(#loc4)
      %9 = arith.cmpi sge, %8, %c2_i32 : i32 loc(#loc4)
      %10 = arith.select %9, %c0_i32, %8 : i32 loc(#loc4)
      %out_idx_10 = ttg.async_wait %out_idx_4 {num = 1 : i32} loc(#loc13)
      %out_idx_11 = ttg.memdesc_index %out_idx[%10] : !ttg.memdesc<2x1xi32, #shared, #smem, mutable> -> !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> loc(#loc13)
      %out_idx_12 = ttg.local_load %out_idx_11 token %out_idx_10 : !ttg.memdesc<1xi32, #shared, #smem, mutable, 2x1> -> tensor<1xi32, #blocked> loc(#loc13)
      scf.if %always_true_but_not_constexpr {
        %11 = tt.splat %output_ptr : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>, #blocked> loc(#loc7)
        %12 = tt.addptr %11, %out_idx_12 : tensor<1x!tt.ptr<i32>, #blocked>, tensor<1xi32, #blocked> loc(#loc7)
        %13 = tt.splat %6 : i32 -> tensor<1xi32, #blocked> loc(#loc8)
        tt.store %12, %13 : tensor<1x!tt.ptr<i32>, #blocked> loc(#loc8)
      } loc(#loc6)
      scf.yield %5, %10, %out_idx_9 : i32, i32, !ttg.async.token loc(#loc4)
    } {tt.num_stages = 2 : i32} loc(#loc4)
    %1 = ttg.async_wait {num = 0 : i32} loc(#loc4)
    ttg.local_dealloc %out_idx : !ttg.memdesc<2x1xi32, #shared, #smem, mutable> loc(#loc4)
    tt.return loc(#loc9)
  } loc(#loc)
} loc(#loc)
#loc1 = loc(unknown)
#loc2 = loc("/home/ubuntu/triton/repro.py":30:26)
#loc3 = loc("/home/ubuntu/triton/repro.py":30:43)
#loc4 = loc("/home/ubuntu/triton/repro.py":29:28)
#loc5 = loc("/home/ubuntu/triton/repro.py":30:39)
#loc6 = loc("/home/ubuntu/triton/repro.py":31:11)
#loc7 = loc("/home/ubuntu/triton/repro.py":32:34)
#loc8 = loc("/home/ubuntu/triton/repro.py":32:43)
#loc9 = loc("/home/ubuntu/triton/repro.py":29:4)
#loc13 = loc("out_idx"(#loc2))
#loc14 = loc("out_idx"(#loc3))
#loc15 = loc("out_idx"(#loc5))
```

</details>


As you'd expect, `ttg.local_alloc : () -> !ttg.memdesc<1x1xi32, #shared, #smem, mutable>` became `ttg.local_alloc : () -> !ttg.memdesc<2x1xi32, #shared, #smem, mutable>`.