### PR TITLE
[NVIDIA] Add native MXFP, NVFP FP4 scaled_dot for SM120

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -137,6 +137,7 @@ LinearLayout chooseScaledMfmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
 
 LinearLayout getSM120DotScaledScaleLayout(MLIRContext *ctx, int dotOperandIdx,
                                           ArrayRef<int64_t> dotOperandShape,
+                                          unsigned groupSize,
                                           ArrayRef<unsigned> tilesPerWarp,
                                           ArrayRef<unsigned> warpsPerCTA,
                                           unsigned instrM, unsigned instrN,

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1425,8 +1425,9 @@ LinearLayout chooseDsReadB64TrLayout(Attribute enc, ArrayRef<int64_t> shape,
 //   - In this implementation, each lane in a quad has the same scale factor.
 LinearLayout getSM120DotScaledScaleLayout(
     MLIRContext *ctx, int dotOperandIdx, ArrayRef<int64_t> dotOperandShape,
-    ArrayRef<unsigned> tilesPerWarp, ArrayRef<unsigned> warpsPerCTA,
-    unsigned mmaInstrM, unsigned mmaInstrN, CTALayoutAttr ctaLayoutAttr) {
+    unsigned groupSize, ArrayRef<unsigned> tilesPerWarp,
+    ArrayRef<unsigned> warpsPerCTA, unsigned mmaInstrM, unsigned mmaInstrN,
+    CTALayoutAttr ctaLayoutAttr) {
   unsigned rank = dotOperandShape.size();
   auto outDims = standardOutDimNames(ctx, rank);
 
@@ -1444,26 +1445,47 @@ LinearLayout getSM120DotScaledScaleLayout(
   const int totalWarps = mWarps * nWarps;
   const unsigned mRep_warp = tilesPerWarp[mIndex];
   const unsigned nRep_warp = tilesPerWarp[nIndex];
-  const unsigned kRep = std::min<unsigned>(kSize, 2);
-
+  // Each scale applies to K / groupSize consecutive elements along the K
+  // dimension. Examples:
+  // - FP8: groupSize = 1, K = 32 => 32 elements per scale
+  // - MXFP4 (int8 scales): groupSize = 2, K = 64 => 32 elements per scale
+  // - NVFP4 (float8 scales): groupSize = 4, K = 64 => 16 elements per scale
+  const unsigned kRep = kSize / groupSize;
   std::vector<std::vector<int32_t>> registerBase;
   std::vector<std::vector<int32_t>> laneBase;
   std::vector<std::vector<int32_t>> warpBase;
   if (dotOperandIdx == 0) { // per-row A-scale
     laneBase = {{0, 8}, {0, 0}, {0, 1}, {0, 2}, {0, 4}};
+    if (groupSize == 2)
+      registerBase.push_back({1, 0});
+    else if (groupSize == 4) {
+      registerBase.push_back({1, 0});
+      registerBase.push_back({2, 0});
+    }
     for (int offset = instrM * mWarps; offset < instrM * mWarps * mRep_warp;
          offset <<= 1)
       registerBase.push_back({0, offset});
+    for (int k = 1; k < kRep; k += 1)
+      registerBase.push_back({static_cast<int32_t>(groupSize << (k - 1)), 0});
     for (int w = mWarps; w < totalWarps; w <<= 1)
       warpBase.push_back({0, 0});
     for (int offset = instrM; offset < instrM * mWarps; offset <<= 1)
       warpBase.push_back({0, offset});
   } else { // per-col B-scale
     laneBase = {{0, 0}, {0, 0}, {0, 1}, {0, 2}, {0, 4}};
-    if (nRep_warp > 1)
-      registerBase.push_back({0, nWarps * instrN});
+
+    if (groupSize == 2)
+      registerBase.push_back({1, 0});
+    else if (groupSize == 4) {
+      registerBase.push_back({1, 0});
+      registerBase.push_back({2, 0});
+    }
+    for (int offset = instrN * nWarps; offset < instrN * nWarps * nRep_warp;
+         offset <<= 1)
+      registerBase.push_back({0, offset});
     for (int k = 1; k < kRep; k += 1)
-      registerBase.push_back({1 << (k - 1), 0});
+      registerBase.push_back({static_cast<int32_t>(groupSize << (k - 1)), 0});
+
     for (int offset = instrN; offset < instrN * nWarps; offset <<= 1)
       warpBase.push_back({0, offset});
     for (int w = nWarps; w < totalWarps; w <<= 1)

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -3601,6 +3601,7 @@ TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout_AScale_Basic) {
   // warpsPerCTA = [4, 1], instrM = 16, instrN = 8
   auto layout = getSM120DotScaledScaleLayout(
       &ctx, /*dotOperandIdx=*/0, /*dotOperandShape=*/{128, 32},
+      /*groupSize=*/1,
       /*tilesPerWarp=*/{1, 1}, /*warpsPerCTA=*/{4, 1},
       /*mmaInstrM=*/16, /*mmaInstrN=*/8,
       /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));
@@ -3621,6 +3622,7 @@ TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout_BScale_Basic) {
   // warpsPerCTA = [1, 4], instrM = 16, instrN = 8
   auto layout = getSM120DotScaledScaleLayout(
       &ctx, /*dotOperandIdx=*/1, /*dotOperandShape=*/{32, 128},
+      /*groupSize=*/1,
       /*tilesPerWarp=*/{1, 1}, /*warpsPerCTA=*/{1, 4},
       /*mmaInstrM=*/16, /*mmaInstrN=*/8,
       /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));
@@ -3640,6 +3642,7 @@ TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout_MultiWarp) {
   // A-scale with 2x2 warp layout
   auto layout = getSM120DotScaledScaleLayout(
       &ctx, /*dotOperandIdx=*/0, /*dotOperandShape=*/{256, 64},
+      /*groupSize=*/1,
       /*tilesPerWarp=*/{2, 1}, /*warpsPerCTA=*/{2, 2},
       /*mmaInstrM=*/16, /*mmaInstrN=*/8,
       /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));
@@ -3662,6 +3665,7 @@ TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout_MultiWarp) {
 
   layout = getSM120DotScaledScaleLayout(
       &ctx, /*dotOperandIdx=*/1, /*dotOperandShape=*/{256, 64},
+      /*groupSize=*/1,
       /*tilesPerWarp=*/{2, 1}, /*warpsPerCTA=*/{2, 2},
       /*mmaInstrM=*/16, /*mmaInstrN=*/8,
       /*ctaLayout=*/CTALayoutAttr::get(&ctx, {1, 1}, {1, 1}, {1, 0}));


### PR DESCRIPTION
## Summary
- Replace decomposition fallback by implementing native MXFP fp4 and NVFP fp4 MMA for SM120.


I'll add benchmark accordingly

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
