### PR TITLE
Remove `#include <unistd.h>` from `specialize.cc` as unused

### DIFF
--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -5,7 +5,6 @@
 #include <functional>
 #include <pybind11/pybind11.h>
 #include <string>
-#include <unistd.h>
 #include <unordered_map>
 #include <utility>
 


### PR DESCRIPTION
In our case, it also breaks Windows build.