### PR TITLE
[enhancement] Support choosing cuda device for triton.runtime

### DIFF
--- a/python/triton/backends/driver.py
+++ b/python/triton/backends/driver.py
@@ -33,7 +33,7 @@ class DriverBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_active_torch_device(self):
+    def get_active_torch_device(self, idx:int=None):
         pass
 
     @abstractmethod

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -704,10 +704,14 @@ class HIPDriver(GPUDriver):
         warp_size = device_properties['warpSize']
         return GPUTarget("hip", arch.split(':')[0], warp_size)
 
-    def get_active_torch_device(self):
+    def get_active_torch_device(self, idx:int=None):
         import torch
-        # when using hip devices, the device string in pytorch is "cuda"
-        return torch.device("cuda", self.get_current_device())
+        if idx is None:
+            idx = self.get_current_device()
+        if torch.cuda.device_count() <= idx:
+            raise ValueError(f"Invalid device index {idx}, only {torch.cuda.device_count()} devices available.")
+        torch.cuda.set_device(idx)
+        return torch.device("cuda", idx)
 
     def get_benchmarker(self):
         from triton.testing import do_bench

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -727,9 +727,14 @@ class CudaDriver(GPUDriver):
         warp_size = 32
         return GPUTarget("cuda", capability, warp_size)
 
-    def get_active_torch_device(self):
+    def get_active_torch_device(self, idx:int=None):
         import torch
-        return torch.device("cuda", self.get_current_device())
+        if idx is None:
+            idx = self.get_current_device()
+        if torch.cuda.device_count() <= idx:
+            raise ValueError(f"Invalid device index {idx}, only {torch.cuda.device_count()} devices available.")
+        torch.cuda.set_device(idx)
+        return torch.device("cuda", idx)
 
     def get_device_interface(self):
         import torch


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
