### PR TITLE
[AMD][BACKEND] Coalesce direct-to-lds loads with padded encodings

### DIFF
--- a/test/TritonGPU/amd/amd-coalesce-async-copy.mlir
+++ b/test/TritonGPU/amd/amd-coalesce-async-copy.mlir
@@ -18,24 +18,6 @@ tt.func @async_copy_1d(%input: tensor<1024x!tt.ptr<f32>, #blocked>,
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-#shared = #ttg.padded_shared<[4:+4] {order = [0], shape = [1024]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-// sizePerThread = [1] because we have no information about contiguity of src pointers
-// CHECK: #[[$NEW_BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
-// CHECK-LABEL: async_copy_with_padding
-tt.func @async_copy_with_padding(%input: tensor<1024x!tt.ptr<f32>, #blocked>,
-    %view: !ttg.memdesc<1024xf32, #shared, #smem, mutable>) {
-  // CHECK: %{{.*}} = ttg.convert_layout %{{.*}} : {{.*}} -> tensor<1024x!tt.ptr<f32>, #[[$NEW_BLOCKED]]>
-  // CHECK: %{{.*}} = ttg.async_copy_global_to_local %{{.*}}: tensor<1024x!tt.ptr<f32>, #[[$NEW_BLOCKED]]>
-  %token = ttg.async_copy_global_to_local %input, %view: tensor<1024x!tt.ptr<f32>, #blocked> -> <1024xf32, #shared, #smem, mutable>
-  tt.return
-}
-}
-
-// -----
-
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
@@ -183,6 +165,78 @@ tt.func @async_copy_2d_swizzled(%input: tensor<64x64x!tt.ptr<f16>, #blocked>,
     %view: !ttg.memdesc<64x64xf16, #shared, #smem, mutable>) {
   // CHECK: %{{.*}} = ttg.async_copy_global_to_local {{.*}} -> <64x64xf16, #shared, #smem, mutable>
   %token = ttg.async_copy_global_to_local %input, %view: tensor<64x64x!tt.ptr<f16>, #blocked> -> <64x64xf16, #shared, #smem, mutable>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.padded_shared<[4:+4] {order = [0], shape = [1024]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+// Padded encoding with an identity mapping does produce coalesced writes so we should not rewrite
+// CHECK: #[[$NEW_BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+// CHECK-LABEL: padded_layout_with_identity
+tt.func @padded_layout_with_identity(%input: tensor<1024x!tt.ptr<f32>, #blocked>,
+    %view: !ttg.memdesc<1024xf32, #shared, #smem, mutable>) {
+  // CHECK-NOT: ttg.convert_layout
+  // CHECK: %{{.*}} = ttg.async_copy_global_to_local %{{.*}}: tensor<1024x!tt.ptr<f32>, #[[$NEW_BLOCKED]]>
+  %token = ttg.async_copy_global_to_local %input, %view: tensor<1024x!tt.ptr<f32>, #blocked> -> <1024xf32, #shared, #smem, mutable>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.padded_shared<[64:+4] {offset = [[1], [2], [4], [8], [64], [128], [16], [32]], block = []}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+// We rearange in 4 blocks of 16 elements, check that we transfer it to the src encoding to write coalesced to lds
+// CHECK: #[[$NEW_SRC_ENCODING:.*]] = #ttg.linear
+// CHECK-SAME{LITERAL}: register = [], lane = [[1], [2], [4], [8], [64], [128]], warp = [[16], [32]], block = []
+// CHECK-LABEL: padded_layout_with_simple_rearanging
+tt.func @padded_layout_with_simple_rearanging(%input: tensor<256x!tt.ptr<f32>, #blocked>,
+    %view: !ttg.memdesc<256xf32, #shared, #smem, mutable>) {
+  // CHECK: %{{.*}} = ttg.async_copy_global_to_local %{{.*}}: tensor<256x!tt.ptr<f32>, #[[$NEW_SRC_ENCODING]]>
+  %token = ttg.async_copy_global_to_local %input, %view: tensor<256x!tt.ptr<f32>, #blocked> -> <256xf32, #shared, #smem, mutable>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.padded_shared<[64:+4] {offset = [[1], [2], [4], [8], [16], [32], [256], [512], [64], [128]], block = []}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+// We rearange in 4 blocks of 16 elements, check that we transfer it to the src encoding to write coalesced to lds
+// CHECK: #[[$NEW_SRC_ENCODING:.*]] = #ttg.linear
+// CHECK-SAME{LITERAL}: register = [[1], [2]], lane = [[4], [8], [16], [32], [256], [512]], warp = [[64], [128]], block = []
+// CHECK-LABEL: padded_layout_with_vectorization_and_rearanging
+tt.func @padded_layout_with_vectorization_and_rearanging(%input: tensor<1024x!tt.ptr<f32>, #blocked> {tt.contiguity = 4 : i32, tt.divisibility = 16 : i32},
+    %view: !ttg.memdesc<1024xf32, #shared, #smem, mutable>) {
+  // CHECK: %{{.*}} = ttg.async_copy_global_to_local %{{.*}}: tensor<1024x!tt.ptr<f32>, #[[$NEW_SRC_ENCODING]]>
+  %token = ttg.async_copy_global_to_local %input, %view: tensor<1024x!tt.ptr<f32>, #blocked> -> <1024xf32, #shared, #smem, mutable>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.padded_shared<[64:+4] {offset = [[1], [2], [4], [8], [64], [16], [32]], block = []}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+// Check that we add a broadcast in case not each lane in the WG can read unique data
+// CHECK: #[[$NEW_SRC_ENCODING:.*]] = #ttg.linear
+// CHECK-SAME{LITERAL}: register = [], lane = [[1], [2], [4], [8], [64], [16]], warp = [[32], [0]], block = []
+// CHECK-LABEL: padded_layout_requiring_broadcasting
+tt.func @padded_layout_requiring_broadcasting(%input: tensor<128x!tt.ptr<f32>, #blocked>,
+    %view: !ttg.memdesc<128xf32, #shared, #smem, mutable>) {
+  // CHECK: %{{.*}} = ttg.async_copy_global_to_local %{{.*}}: tensor<128x!tt.ptr<f32>, #[[$NEW_SRC_ENCODING]]>
+  %token = ttg.async_copy_global_to_local %input, %view: tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
   tt.return
 }
 }

--- a/test/TritonGPU/amd/amd-coalesce-async-copy.mlir
+++ b/test/TritonGPU/amd/amd-coalesce-async-copy.mlir
@@ -22,7 +22,7 @@ tt.func @async_copy_1d(%input: tensor<1024x!tt.ptr<f32>, #blocked>,
 #shared = #ttg.padded_shared<[4:+4] {order = [0], shape = [1024]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-// Padded encoding with an identity mapping does produce coalesced writes so we should not rewrite
+// Padded encoding with an identity mapping does produce coalesced writes so we should not change the blocked encoding
 // CHECK: #[[$NEW_BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 // CHECK-LABEL: async_copy_with_padding
 tt.func @async_copy_with_padding(%input: tensor<1024x!tt.ptr<f32>, #blocked>,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -885,10 +885,6 @@ struct AsyncCopyGlobalToLocalOpConversion
 
     auto srcTy = op.getSrc().getType();
 
-    if (!isa<BlockedEncodingAttr, SliceEncodingAttr>(srcTy.getEncoding()))
-      return rewriter.notifyMatchFailure(
-          op, "requires Blocked or Slice encoding for src");
-
     auto dstTy = op.getResult().getType();
     auto dstEnc = dstTy.getEncoding();
     auto resElemTy = getTypeConverter()->convertType(dstTy.getElementType());

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
@@ -181,18 +181,14 @@ struct CoalesceAsyncCopyWrites
       StringAttr kBlock = StringAttr::get(ctx, "block");
 
       triton::LinearLayout newRegLayout(
-          {
-              {kRegister, regBases},
-              {kLane, laneBases},
-              {kWarp, warpBases},
-          },
+          {{kRegister, regBases}, {kLane, laneBases}, {kWarp, warpBases}},
           standardOutDims);
 
       newRegLayout = triton::gpu::combineCtaCgaWithShape(
           newRegLayout, blockedEnc.getCTALayout(), srcTy.getShape());
 
       auto newRegToShared = newRegLayout.invertAndCompose(sharedLayout);
-      if (newRegLayout.getNumConsecutiveInOut() < loadContig) {
+      if (newRegToShared.getNumConsecutiveInOut() < loadContig) {
         return rewriter.notifyMatchFailure(
             copyOp, "could not coalesce global addresses based on the linear "
                     "component of the padded encoding");


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/7929 allows us to rearrange rows/cache line sizes chunks in LDS in addtion to padding to be able to avoid bank conflicts. This PR adds support to rewrite the `BlockedEncoding` to a `DistributedLinearEncoding` of the `ttg.async_copy_global_to_local` so each warp writes a contiguous chunk into LDS, as required by the hardware on GFX9.

Note that as long as we are just rearranging rows and do not do any element wise swizzling the resulting LinearLayout will satisfy all required properties of a `DistributedSharedEncoding`. The verifier of the `PaddedSharedEncoding` checks this already and additionally the builder of the `DistributedLinearEncoding` will trigger an assert if we break any of the properties (surjective, moves into a single direction per basis etc.).