### PR TITLE
[AMD][Draft] Fix make test failure in AMD backend

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3641,6 +3641,11 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
                 torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = self.prev_value
 
         with AccumulateInFp32():
+            # FIXME: HIP backend not support torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
+            #        need forcing an increase in the calculation precision of the reference.
+            if is_hip() and comp_dtype == torch.bfloat16:
+                return torch.matmul(x_upcast.type(torch.float32), y_upcast.type(torch.float32)).type(x_upcast.dtype)
+
             return torch.matmul(x_upcast, y_upcast)
 
     comp_dtype = torch.float16 if normal_type == "fp16" else torch.bfloat16

--- a/python/tutorials/gluon/07-persistence.py
+++ b/python/tutorials/gluon/07-persistence.py
@@ -53,7 +53,9 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     tcgen05_commit,
 )
 
-if torch.cuda.is_available():
+from triton._internal_testing import is_hip
+
+if torch.cuda.is_available() and (not is_hip()):
     from triton._C.libtriton import nvidia
     cublas_workspace = torch.empty(32 * 1024 * 1024, device="cuda", dtype=torch.uint8)
     cublas = nvidia.cublas.CublasLt(cublas_workspace)

--- a/python/tutorials/gluon/08-warp-specialization.py
+++ b/python/tutorials/gluon/08-warp-specialization.py
@@ -40,7 +40,9 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     tcgen05_commit,
 )
 
-if torch.cuda.is_available():
+from triton._internal_testing import is_hip
+
+if torch.cuda.is_available() and (not is_hip()):
     from triton._C.libtriton import nvidia
     cublas_workspace = torch.empty(32 * 1024 * 1024, device="cuda", dtype=torch.uint8)
     cublas = nvidia.cublas.CublasLt(cublas_workspace)

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1351,7 +1351,12 @@ public:
     auto srcElTy = srcTy.getElementType();
     auto dstElTy = dstTy.getElementType();
     if (isFloat(srcElTy) && isFloat(dstElTy)) {
-      auto rmode =
+      // FIXME: When converting a floating - point number with a smaller
+      // precision (such as float16) to one with a larger precision
+      // (such as float32), no rounding occurs. There is no need for, nor does
+      // it involve, a rounding mode. This kind of conversion is exact and lossless.
+      RoundingModeAttr rmode = srcElTy.getIntOrFloatBitWidth() <
+          dstElTy.getIntOrFloatBitWidth() ? nullptr :
           RoundingModeAttr::get(rewriter.getContext(), RoundingMode::RTNE);
       return rewriter.create<FpToFpOp>(loc, dstTy, v, rmode);
     }


### PR DESCRIPTION
* python/tutorials/gluon/02-layouts.py
* python/tutorials/gluon/03-async-copy.py
* python/tutorials/gluon/07-persistence.py
* python/tutorials/gluon/08-warp-specialization.py
  - **Root Cause**: HIP backend warp size should be 64.
  - **Solution**: Get warp size from runtime acitive backend

* python/test/unit/language/test_core.py
  - **Root Cause**: torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False not work on HIP backend.
  - **Solution**: Forcing an increase in the calculation precision of the reference.

* python/test/regression/test_functional_regressions.py::test_permutation_ptxas_bug
  - **Root Cause**: When converting a floating - point number with a smaller precision (such as float16) to one with a larger precision (such as float32), no rounding occurs. There is no need for, nor does it involve, a rounding mode. This kind of conversion is exact and lossless.
  - **Solution**: Check the widths of the source (src) and destination (dst). When the width of src is less than that of dst, do not set the round mode.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
