### PR TITLE
[BACKEND][TESTS] Add `-reconcile-unrealized-casts` in "to LLVM" test

### DIFF
--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1,4 +1,7 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm 2>/dev/null | FileCheck %s --dump-input-context 20
+// RUN: triton-opt %s -split-input-file \
+// RUN:   --allocate-shared-memory-nv --convert-triton-gpu-to-llvm \
+// RUN:   --reconcile-unrealized-casts 2>/dev/null \
+// RUN:   | FileCheck %s --dump-input-context 20
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: llvm.func @test_empty_kernel(%arg0: i32, %arg1: !llvm.ptr<1>, %arg2: !llvm.ptr<1>, %arg3: !llvm.ptr<1>)


### PR DESCRIPTION
This PR adds the `-reconcile-unrealized-casts` pass to the `RUN` line of the `tritongpu_to_llvm.mlir` test. This ensures that left-over `unrealized_casts` ops are cleaned up, which can occur starting from llvm/llvm-project#158298, and which would otherwise break this test. Adding the pass is the recommended solution from the description of that PR.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

<!--- - [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`. -->
- [x] I have run my changes against our internal test infrastructure.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a *new* test because `I am only changing an existing test`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
