### PR TITLE
Version suffix should contains only one plus-character even when TRITON_WHEEL_VERSION_SUFFIX is used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -775,8 +775,19 @@ def get_git_version_suffix():
         return get_git_commit_hash()
 
 
+def get_triton_version_suffix():
+    # Either "" or "+<githash>", "<githash>" itself does not contain any plus-characters.
+    git_sfx = get_git_version_suffix()
+    # Should start with "+" that will replaced with "-" if needed
+    env_sfx = os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
+    # version suffix can only contain one plus-character
+    if "+" in git_sfx and "+" in env_sfx:
+        env_sfx = env_sfx.replace("+", "-")
+    return git_sfx + env_sfx
+
+
 # keep it separate for easy substitution
-TRITON_VERSION = "3.5.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
+TRITON_VERSION = "3.5.0" + get_triton_version_suffix()
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 10)


### PR DESCRIPTION
Triton version information can only contain one plus-character. The plus-character is used for distinguishing additional version suffix information from the base major.minor.patch version scheme.

Version information is constructed in the setup.py in a following way:

version = 3.5.0 + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")

Here the get_git_version_suffix() will return "" for release builds and "+" for other builds. Version can also contain only a one plus-character, otherwise error is thrown.

If we set
os.environ["TRITON_WHEEL_VERSION_SUFFIX"] = "+rocmsdk20250806"

1) For release builds the version would be: "3.5.0+rocmsdk20250806" that is OK.
2) For development builds the version would be: "3.5.0+githash+rocmsdk20250806" which is not OK
   because the second "+" would need to be replaced with the "-"-character
   to avoid a following type of exception:

File ".venv_sdk/lib/python3.12/site-packages/packaging/version.py", line 202, in __init__
    raise InvalidVersion(f"Invalid version: {version!r}")
    packaging.version.InvalidVersion: Invalid version: '3.4.0+gitd04b0f4a+rocmsdk20250806'

Current way to avoid error, is to check on the build side whether build tag points to release version of triton or not
and then either include or not the build character in the env[TRITON_WHEEL_VERSION_SUFFIX] variable.
This adds quite a lot of extra complexity to the build scripts. Easier solution is to check in setup.py whether the env[TRITON_WHEEL_VERSION_SUFFIX] should contain the plus-character or not and if needed replace the plus-character with the dash-character.

Fixes: https://github.com/triton-lang/triton/issues/8203

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X ] I am not making a trivial change, such as fixing a typo in a comment.

- [X ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X ] This PR does not need a test because `FILL THIS IN`.
  Current CI tests should already fail if there is problem in the triton versioning.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
