### PR TITLE
[PROTON] Do not allow concurrent profiling with different modes

### DIFF
--- a/third_party/proton/csrc/include/Profiler/Cupti/CuptiProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/Cupti/CuptiProfiler.h
@@ -12,6 +12,9 @@ public:
 
 private:
   struct CuptiProfilerPimpl;
+
+  virtual void
+  doSetMode(const std::vector<std::string> &modeAndOptions) override;
 };
 
 } // namespace proton

--- a/third_party/proton/csrc/include/Profiler/GPUProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/GPUProfiler.h
@@ -32,16 +32,6 @@ public:
                     std::unordered_map<uint64_t, std::pair<size_t, size_t>>>;
   using ApiExternIdSet = ThreadSafeSet<size_t, std::unordered_set<size_t>>;
 
-  ConcreteProfilerT &enablePCSampling() {
-    pcSamplingEnabled = true;
-    return dynamic_cast<ConcreteProfilerT &>(*this);
-  }
-  ConcreteProfilerT &disablePCSampling() {
-    pcSamplingEnabled = false;
-    return dynamic_cast<ConcreteProfilerT &>(*this);
-  }
-  bool isPCSamplingEnabled() const { return pcSamplingEnabled; }
-
   ConcreteProfilerT &setLibPath(const std::string &libPath) {
     pImpl->setLibPath(libPath);
     return dynamic_cast<ConcreteProfilerT &>(*this);

--- a/third_party/proton/csrc/include/Profiler/Instrumentation/InstrumentationProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/Instrumentation/InstrumentationProfiler.h
@@ -24,7 +24,8 @@ protected:
   virtual void doStart() override;
   virtual void doFlush() override;
   virtual void doStop() override;
-  virtual void doSetMode(const std::vector<std::string> &modeAndOptions) override;
+  virtual void
+  doSetMode(const std::vector<std::string> &modeAndOptions) override;
 
   // InstrumentationInterface
   void initFunctionMetadata(

--- a/third_party/proton/csrc/include/Profiler/Instrumentation/InstrumentationProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/Instrumentation/InstrumentationProfiler.h
@@ -19,13 +19,12 @@ public:
   InstrumentationProfiler() = default;
   virtual ~InstrumentationProfiler();
 
-  InstrumentationProfiler *setMode(const std::vector<std::string> &mode);
-
 protected:
   // Profiler
   virtual void doStart() override;
   virtual void doFlush() override;
   virtual void doStop() override;
+  virtual void doSetMode(const std::vector<std::string> &modeAndOptions) override;
 
   // InstrumentationInterface
   void initFunctionMetadata(

--- a/third_party/proton/csrc/include/Profiler/Profiler.h
+++ b/third_party/proton/csrc/include/Profiler/Profiler.h
@@ -12,6 +12,7 @@
 #include <set>
 #include <shared_mutex>
 #include <string>
+#include <vector>
 
 namespace proton {
 

--- a/third_party/proton/csrc/include/Profiler/Profiler.h
+++ b/third_party/proton/csrc/include/Profiler/Profiler.h
@@ -74,10 +74,17 @@ public:
     return dataSet;
   }
 
+  Profiler *setMode(const std::vector<std::string> &modeAndOptions) {
+    std::unique_lock<std::shared_mutex> lock(mutex);
+    this->doSetMode(modeAndOptions);
+    return this;
+  }
+
 protected:
   virtual void doStart() = 0;
   virtual void doFlush() = 0;
   virtual void doStop() = 0;
+  virtual void doSetMode(const std::vector<std::string> &modeAndOptions) = 0;
 
   // `dataSet` can be accessed by both the user thread and the background
   // threads

--- a/third_party/proton/csrc/include/Profiler/Profiler.h
+++ b/third_party/proton/csrc/include/Profiler/Profiler.h
@@ -76,8 +76,14 @@ public:
 
   Profiler *setMode(const std::vector<std::string> &modeAndOptions) {
     std::unique_lock<std::shared_mutex> lock(mutex);
+    this->modeAndOptions = modeAndOptions;
     this->doSetMode(modeAndOptions);
     return this;
+  }
+
+  std::vector<std::string> getMode() const {
+    std::shared_lock<std::shared_mutex> lock(mutex);
+    return modeAndOptions;
   }
 
 protected:
@@ -93,6 +99,7 @@ protected:
 
 private:
   bool started{};
+  std::vector<std::string> modeAndOptions{};
 };
 
 } // namespace proton

--- a/third_party/proton/csrc/include/Profiler/Roctracer/RoctracerProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/Roctracer/RoctracerProfiler.h
@@ -12,6 +12,9 @@ public:
 
 private:
   struct RoctracerProfilerPimpl;
+
+  virtual void
+  doSetMode(const std::vector<std::string> &modeAndOptions) override;
 };
 
 } // namespace proton

--- a/third_party/proton/csrc/include/Session/Session.h
+++ b/third_party/proton/csrc/include/Session/Session.h
@@ -124,7 +124,8 @@ public:
   void setState(std::optional<Context> context);
 
 private:
-  void validateAndSetProfilerMode(Profiler *profiler, const std::string &mode);
+  Profiler *validateAndSetProfilerMode(Profiler *profiler,
+                                       const std::string &mode);
 
   std::unique_ptr<Session> makeSession(size_t id, const std::string &path,
                                        const std::string &profilerName,

--- a/third_party/proton/csrc/include/Session/Session.h
+++ b/third_party/proton/csrc/include/Session/Session.h
@@ -124,6 +124,8 @@ public:
   void setState(std::optional<Context> context);
 
 private:
+  void validateAndSetProfilerMode(Profiler *profiler, const std::string &mode);
+
   std::unique_ptr<Session> makeSession(size_t id, const std::string &path,
                                        const std::string &profilerName,
                                        const std::string &profilerPath,

--- a/third_party/proton/csrc/include/Session/Session.h
+++ b/third_party/proton/csrc/include/Session/Session.h
@@ -33,12 +33,15 @@ public:
 
   size_t getContextDepth();
 
+  std::string getMode();
+
 private:
   Session(size_t id, const std::string &path, Profiler *profiler,
           std::unique_ptr<ContextSource> contextSource,
-          std::unique_ptr<Data> data)
+          std::unique_ptr<Data> data, const std::string &mode = "")
       : id(id), path(path), profiler(profiler),
-        contextSource(std::move(contextSource)), data(std::move(data)) {}
+        contextSource(std::move(contextSource)), data(std::move(data)),
+        mode(mode) {}
 
   template <typename T> std::vector<T *> getInterfaces() {
     std::vector<T *> interfaces;
@@ -62,6 +65,7 @@ private:
   Profiler *profiler{};
   std::unique_ptr<ContextSource> contextSource{};
   std::unique_ptr<Data> data{};
+  std::string mode{};
 
   friend class SessionManager;
 };

--- a/third_party/proton/csrc/include/Session/Session.h
+++ b/third_party/proton/csrc/include/Session/Session.h
@@ -35,15 +35,12 @@ public:
 
   Profiler *getProfiler() { return profiler; }
 
-  std::string getMode() { return mode; }
-
 private:
   Session(size_t id, const std::string &path, Profiler *profiler,
           std::unique_ptr<ContextSource> contextSource,
-          std::unique_ptr<Data> data, const std::string &mode = "")
+          std::unique_ptr<Data> data)
       : id(id), path(path), profiler(profiler),
-        contextSource(std::move(contextSource)), data(std::move(data)),
-        mode(mode) {}
+        contextSource(std::move(contextSource)), data(std::move(data)) {}
 
   template <typename T> std::vector<T *> getInterfaces() {
     std::vector<T *> interfaces;
@@ -67,7 +64,6 @@ private:
   Profiler *profiler{};
   std::unique_ptr<ContextSource> contextSource{};
   std::unique_ptr<Data> data{};
-  std::string mode{};
 
   friend class SessionManager;
 };

--- a/third_party/proton/csrc/include/Session/Session.h
+++ b/third_party/proton/csrc/include/Session/Session.h
@@ -33,7 +33,9 @@ public:
 
   size_t getContextDepth();
 
-  std::string getMode();
+  Profiler *getProfiler() { return profiler; }
+
+  std::string getMode() { return mode; }
 
 private:
   Session(size_t id, const std::string &path, Profiler *profiler,

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -8,6 +8,7 @@
 #include "Profiler/Cupti/CuptiPCSampling.h"
 #include "Utility/Env.h"
 #include "Utility/Map.h"
+#include "Utility/String.h"
 
 #include <cstdlib>
 #include <iostream>

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -436,7 +436,7 @@ void CuptiProfiler::CuptiProfilerPimpl::doFlush() {
 
 void CuptiProfiler::CuptiProfilerPimpl::doStop() {
   if (profiler.pcSamplingEnabled) {
-    pcSamplingEnabled = false;
+    profiler.pcSamplingEnabled = false;
     CUcontext cuContext = nullptr;
     cuda::ctxGetCurrent<false>(&cuContext);
     if (cuContext)

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -436,6 +436,7 @@ void CuptiProfiler::CuptiProfilerPimpl::doFlush() {
 
 void CuptiProfiler::CuptiProfilerPimpl::doStop() {
   if (profiler.pcSamplingEnabled) {
+    pcSamplingEnabled = false;
     CUcontext cuContext = nullptr;
     cuda::ctxGetCurrent<false>(&cuContext);
     if (cuContext)

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -289,23 +289,23 @@ void CuptiProfiler::CuptiProfilerPimpl::callbackFn(void *userData,
     if (cbId == CUPTI_CBID_RESOURCE_MODULE_LOADED) {
       auto *moduleResource = static_cast<CUpti_ModuleResourceData *>(
           resourceData->resourceDescriptor);
-      if (profiler.isPCSamplingEnabled()) {
+      if (profiler.pcSamplingEnabled) {
         pImpl->pcSampling.loadModule(moduleResource->pCubin,
                                      moduleResource->cubinSize);
       }
     } else if (cbId == CUPTI_CBID_RESOURCE_MODULE_UNLOAD_STARTING) {
       auto *moduleResource = static_cast<CUpti_ModuleResourceData *>(
           resourceData->resourceDescriptor);
-      if (profiler.isPCSamplingEnabled()) {
+      if (profiler.pcSamplingEnabled) {
         pImpl->pcSampling.unloadModule(moduleResource->pCubin,
                                        moduleResource->cubinSize);
       }
     } else if (cbId == CUPTI_CBID_RESOURCE_CONTEXT_CREATED) {
-      if (profiler.isPCSamplingEnabled()) {
+      if (profiler.pcSamplingEnabled) {
         pImpl->pcSampling.initialize(resourceData->context);
       }
     } else if (cbId == CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING) {
-      if (profiler.isPCSamplingEnabled()) {
+      if (profiler.pcSamplingEnabled) {
         pImpl->pcSampling.finalize(resourceData->context);
       }
     } else {
@@ -372,11 +372,11 @@ void CuptiProfiler::CuptiProfilerPimpl::callbackFn(void *userData,
                     << std::endl;
       }
       profiler.correlation.correlate(callbackData->correlationId, numInstances);
-      if (profiler.isPCSamplingEnabled() && isDriverAPILaunch(cbId)) {
+      if (profiler.pcSamplingEnabled && isDriverAPILaunch(cbId)) {
         pImpl->pcSampling.start(callbackData->context);
       }
     } else if (callbackData->callbackSite == CUPTI_API_EXIT) {
-      if (profiler.isPCSamplingEnabled() && isDriverAPILaunch(cbId)) {
+      if (profiler.pcSamplingEnabled && isDriverAPILaunch(cbId)) {
         // XXX: Conservatively stop every GPU kernel for now
         auto scopeId = profiler.correlation.externIdQueue.back();
         pImpl->pcSampling.stop(

--- a/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
@@ -42,14 +42,16 @@ void InstrumentationProfiler::doStop() {
   }
 }
 
-void
-InstrumentationProfiler::doSetMode(const std::vector<std::string> &modeAndOptions) {
+void InstrumentationProfiler::doSetMode(
+    const std::vector<std::string> &modeAndOptions) {
   if (modeAndOptions.empty()) {
     throw std::runtime_error("Mode cannot be empty");
   }
-  if (modeAndOptions[0] == proton::toLower(DeviceTraits<DeviceType::CUDA>::name)) {
+  if (modeAndOptions[0] ==
+      proton::toLower(DeviceTraits<DeviceType::CUDA>::name)) {
     runtime = std::make_unique<CudaRuntime>();
-  } else if (modeAndOptions[0] == proton::toLower(DeviceTraits<DeviceType::HIP>::name)) {
+  } else if (modeAndOptions[0] ==
+             proton::toLower(DeviceTraits<DeviceType::HIP>::name)) {
     runtime = std::make_unique<HipRuntime>();
   } else {
     throw std::runtime_error("Unknown device type: " + modeAndOptions[0]);

--- a/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
@@ -47,10 +47,10 @@ void InstrumentationProfiler::doSetMode(
   if (modeAndOptions.empty()) {
     throw std::runtime_error("Mode cannot be empty");
   }
-  if (modeAndOptions[0] ==
+  if (proton::toLower(modeAndOptions[0]) ==
       proton::toLower(DeviceTraits<DeviceType::CUDA>::name)) {
     runtime = std::make_unique<CudaRuntime>();
-  } else if (modeAndOptions[0] ==
+  } else if (proton::toLower(modeAndOptions[0]) ==
              proton::toLower(DeviceTraits<DeviceType::HIP>::name)) {
     runtime = std::make_unique<HipRuntime>();
   } else {
@@ -102,7 +102,7 @@ InstrumentationProfiler::getParserConfig(uint64_t functionId,
   config->scratchMemSize =
       functionMetadata.at(functionId).getScratchMemorySize();
   if (!(modeOptions.count("granularity") == 0 ||
-        modeOptions.at("granularity") == proton::toLower("GRANULARITY.WARP"))) {
+        modeOptions.at("granularity") == "GRANULARITY.WARP")) {
     throw std::runtime_error("Only warp granularity is supported for now");
   }
   config->totalUnits = functionMetadata.at(functionId).getNumWarps();

--- a/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
@@ -100,7 +100,7 @@ InstrumentationProfiler::getParserConfig(uint64_t functionId,
   config->scratchMemSize =
       functionMetadata.at(functionId).getScratchMemorySize();
   if (!(modeOptions.count("granularity") == 0 ||
-        modeOptions.at("granularity") == "GRANULARITY.WARP")) {
+        modeOptions.at("granularity") == proton::toLower("GRANULARITY.WARP"))) {
     throw std::runtime_error("Only warp granularity is supported for now");
   }
   config->totalUnits = functionMetadata.at(functionId).getNumWarps();

--- a/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
@@ -5,7 +5,6 @@
 #include "Profiler/Instrumentation/CudaRuntime.h"
 #include "Profiler/Instrumentation/HipRuntime.h"
 #include "Utility/Numeric.h"
-#include "Utility/String.h"
 #include <algorithm>
 #include <limits>
 #include <map>
@@ -42,30 +41,28 @@ void InstrumentationProfiler::doStop() {
   }
 }
 
-InstrumentationProfiler *
-InstrumentationProfiler::setMode(const std::vector<std::string> &mode) {
-  if (mode.empty()) {
+void
+InstrumentationProfiler::doSetMode(const std::vector<std::string> &modeAndOptions) {
+  if (modeAndOptions.empty()) {
     throw std::runtime_error("Mode cannot be empty");
   }
-  if (toLower(mode[0]) == toLower(DeviceTraits<DeviceType::CUDA>::name)) {
+  if (modeAndOptions[0] == DeviceTraits<DeviceType::CUDA>::name) {
     runtime = std::make_unique<CudaRuntime>();
-  } else if (toLower(mode[0]) == toLower(DeviceTraits<DeviceType::HIP>::name)) {
+  } else if (modeAndOptions[0] == DeviceTraits<DeviceType::HIP>::name) {
     runtime = std::make_unique<HipRuntime>();
   } else {
-    throw std::runtime_error("Unknown device type: " + mode[0]);
+    throw std::runtime_error("Unknown device type: " + modeAndOptions[0]);
   }
-  for (size_t i = 1; i < mode.size(); ++i) {
-    auto delimiterPos = mode[i].find('=');
+  for (size_t i = 1; i < modeAndOptions.size(); ++i) {
+    auto delimiterPos = modeAndOptions[i].find('=');
     if (delimiterPos != std::string::npos) {
-      std::string key = mode[i].substr(0, delimiterPos);
-      std::string value = mode[i].substr(delimiterPos + 1);
+      std::string key = modeAndOptions[i].substr(0, delimiterPos);
+      std::string value = modeAndOptions[i].substr(delimiterPos + 1);
       modeOptions[key] = value;
     } else {
-      modeOptions[mode[i]] = "";
+      modeOptions[modeAndOptions[i]] = "";
     }
   }
-
-  return this;
 }
 namespace {
 

--- a/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Instrumentation/InstrumentationProfiler.cpp
@@ -5,6 +5,7 @@
 #include "Profiler/Instrumentation/CudaRuntime.h"
 #include "Profiler/Instrumentation/HipRuntime.h"
 #include "Utility/Numeric.h"
+#include "Utility/String.h"
 #include <algorithm>
 #include <limits>
 #include <map>
@@ -46,9 +47,9 @@ InstrumentationProfiler::doSetMode(const std::vector<std::string> &modeAndOption
   if (modeAndOptions.empty()) {
     throw std::runtime_error("Mode cannot be empty");
   }
-  if (modeAndOptions[0] == DeviceTraits<DeviceType::CUDA>::name) {
+  if (modeAndOptions[0] == proton::toLower(DeviceTraits<DeviceType::CUDA>::name)) {
     runtime = std::make_unique<CudaRuntime>();
-  } else if (modeAndOptions[0] == DeviceTraits<DeviceType::HIP>::name) {
+  } else if (modeAndOptions[0] == proton::toLower(DeviceTraits<DeviceType::HIP>::name)) {
     runtime = std::make_unique<HipRuntime>();
   } else {
     throw std::runtime_error("Unknown device type: " + modeAndOptions[0]);

--- a/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
@@ -414,4 +414,13 @@ RoctracerProfiler::RoctracerProfiler() {
 
 RoctracerProfiler::~RoctracerProfiler() = default;
 
+void RoctracerProfiler::doSetMode(
+    const std::vector<std::string> &modeAndOptions) {
+  auto mode = modeAndOptions[0];
+  if (!mode.empty()) {
+    throw std::invalid_argument(
+        "[PROTON] RoctracerProfiler: unsupported mode: " + mode);
+  }
+}
+
 } // namespace proton

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -98,7 +98,7 @@ std::unique_ptr<Session> SessionManager::makeSession(
   auto contextSource = makeContextSource(contextSourceName);
   auto data = makeData(dataName, path, contextSource.get());
   auto *session = new Session(id, path, profiler, std::move(contextSource),
-                              std::move(data));
+                              std::move(data), mode);
   return std::unique_ptr<Session>(session);
 }
 

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -174,7 +174,6 @@ size_t SessionManager::addSession(const std::string &path,
     return sessionId;
   }
   auto sessionId = nextSessionId++;
-  sessionPaths[path] = sessionId;
   auto newSession = makeSession(sessionId, path, profilerName, profilerPath,
                                 contextSourceName, dataName, mode);
   for (auto &[id, session] : sessions) {
@@ -184,6 +183,7 @@ size_t SessionManager::addSession(const std::string &path,
                                "but a different mode than existing sessions");
     }
   }
+  sessionPaths[path] = sessionId;
   sessions[sessionId] = std::move(newSession);
   return sessionId;
 }

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -20,7 +20,7 @@ Profiler *getProfiler(const std::string &name, const std::string &path,
     profiler->setLibPath(path);
     if (proton::toLower(modeAndOptions[0]) == "pcsampling") {
       profiler->enablePCSampling();
-    } else if (mode != 0) {
+    } else if (mode != "") {
       throw std::runtime_error("Unsupported cupti mode: " + mode);
     }
     return profiler;

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -77,12 +77,8 @@ void Session::finalize(const std::string &outputFormat) {
 size_t Session::getContextDepth() { return contextSource->getDepth(); }
 
 Profiler *SessionManager::validateAndSetProfilerMode(Profiler *profiler,
-                                                const std::string &mode) {
+                                                     const std::string &mode) {
   std::vector<std::string> modeAndOptions = proton::split(mode, ":");
-  for (auto &option : modeAndOptions) {
-    option = proton::toLower(option);
-  }
-
   for (auto &[id, session] : sessions) {
     if (session->getProfiler() == profiler &&
         session->getProfiler()->getMode() != modeAndOptions) {

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -20,7 +20,7 @@ Profiler *getProfiler(const std::string &name, const std::string &path,
     profiler->setLibPath(path);
     if (proton::toLower(modeAndOptions[0]) == "pcsampling") {
       profiler->enablePCSampling();
-    } else {
+    } else if (mode != 0) {
       throw std::runtime_error("Unsupported cupti mode: " + mode);
     }
     return profiler;

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -13,7 +13,7 @@ namespace proton {
 namespace {
 
 Profiler *makeProfiler(const std::string &name, const std::string &path,
-                      const std::string &mode) {
+                       const std::string &mode) {
   std::vector<std::string> modeAndOptions = proton::split(mode, ":");
   if (proton::toLower(name) == "cupti") {
     auto *profiler = &CuptiProfiler::instance();

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -76,7 +76,6 @@ def test_profile_mode(tmp_path: pathlib.Path):
             pytest.skip("PC sampling test is disabled")
 
         proton.start(str(temp_file0.with_suffix("")), mode="pcsampling")
-        assert temp_file0.exists()
 
         try:
             temp_file1 = tmp_path / "test_profile1.hatchet"

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -75,14 +75,11 @@ def test_profile_mode(tmp_path: pathlib.Path):
         if os.environ.get("PROTON_SKIP_PC_SAMPLING_TEST", "0") == "1":
             pytest.skip("PC sampling test is disabled")
 
-        temp_file1 = tmp_path / "test_profile1.hatchet"
-
-        proton.start(str(temp_file1.with_suffix("")), mode="pcsampling")
-        proton.finalize()
-        assert temp_file1.exists()
+        proton.start(str(temp_file0.with_suffix("")), mode="pcsampling")
+        assert temp_file0.exists()
 
         try:
-            proton.start(str(temp_file0.with_suffix("")), mode="pcsampling")
+            temp_file1 = tmp_path / "test_profile1.hatchet"
             proton.start(str(temp_file1.with_suffix("")))
         except Exception as e:
             assert "Cannot add session with different mode to existing sessions" in str(e)

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -82,7 +82,7 @@ def test_profile_mode(tmp_path: pathlib.Path):
         assert temp_file1.exists()
 
         try:
-            proton.start(str(temp_file0.with_suffix("")), mode="pc_sampling")
+            proton.start(str(temp_file0.with_suffix("")), mode="pcsampling")
             proton.start(str(temp_file1.with_suffix("")))
         except Exception as e:
             assert "Cannot add session with different mode to existing sessions" in str(e)

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -68,6 +68,8 @@ def test_profile_mode(tmp_path: pathlib.Path):
             proton.start(str(temp_file0.with_suffix("")), mode="pcsampling")
         except Exception as e:
             assert "Unsupported roctracer mode: pcsampling" in str(e)
+        finally:
+            proton.finalize()
     else:
         import os
         import pytest
@@ -86,6 +88,8 @@ def test_profile_mode(tmp_path: pathlib.Path):
             proton.start(str(temp_file1.with_suffix("")))
         except Exception as e:
             assert "Cannot add a session with the same profiler but a different mode than existing sessions" in str(e)
+        finally:
+            proton.finalize()
 
 
 def test_profile_decorator(tmp_path: pathlib.Path):

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -76,9 +76,12 @@ def test_profile_mode(tmp_path: pathlib.Path):
             pytest.skip("PC sampling test is disabled")
 
         proton.start(str(temp_file0.with_suffix("")), mode="pcsampling")
+        temp_file1 = tmp_path / "test_profile1.hatchet"
+        proton.start(str(temp_file1.with_suffix("")), mode="pcsampling")
+        proton.finalize()
 
         try:
-            temp_file1 = tmp_path / "test_profile1.hatchet"
+            proton.start(str(temp_file0.with_suffix("")), mode="pcsampling")
             proton.start(str(temp_file1.with_suffix("")))
         except Exception as e:
             assert "Cannot add session with different mode to existing sessions" in str(e)

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -96,16 +96,15 @@ def test_profile_mode(tmp_path: pathlib.Path):
         # Two sessions with different modes cannot coexist even if the first session is deactivated.
         # In proton, once we deactivate a session, its profiler is not stopped, so changing the profiler mode is not allowed
         # The only way to start a session with a different mode is to finalize all existing sessions first.
-        try: 
+        try:
             session_id = proton.start(str(temp_file0.with_suffix("")), mode="pcsampling")
-            proton.deactivate(session_id) 
+            proton.deactivate(session_id)
             temp_file1 = tmp_path / "test_profile1.hatchet"
             proton.start(str(temp_file1.with_suffix("")))
         except Exception as e:
             assert "Cannot add a session with the same profiler but a different mode than existing sessions" in str(e)
         finally:
             proton.finalize()
-
 
 
 def test_profile_decorator(tmp_path: pathlib.Path):

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -67,7 +67,7 @@ def test_profile_mode(tmp_path: pathlib.Path):
         try:
             proton.start(str(temp_file0.with_suffix("")), mode="pcsampling")
         except Exception as e:
-            assert "Unsupported roctracer mode: pcsampling" in str(e)
+            assert "RoctracerProfiler: unsupported mode: pcsampling" in str(e)
         finally:
             proton.finalize()
     else:

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -79,6 +79,7 @@ def test_profile_mode(tmp_path: pathlib.Path):
         temp_file1 = tmp_path / "test_profile1.hatchet"
         proton.start(str(temp_file1.with_suffix("")), mode="pcsampling")
         proton.finalize()
+        assert temp_file1.exists()
 
         try:
             proton.start(str(temp_file0.with_suffix("")), mode="pcsampling")

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -85,7 +85,7 @@ def test_profile_mode(tmp_path: pathlib.Path):
             proton.start(str(temp_file0.with_suffix("")), mode="pcsampling")
             proton.start(str(temp_file1.with_suffix("")))
         except Exception as e:
-            assert "Cannot add session with different mode to existing sessions" in str(e)
+            assert "Cannot add a session with the same profiler but a different mode than existing sessions" in str(e)
 
 
 def test_profile_decorator(tmp_path: pathlib.Path):


### PR DESCRIPTION
Different modes usually require different metrics to be collected. For instance, one mode may use PC sampling while another uses timing.

If two concurrent sessions share the same profiler instance, it becomes difficult to attribute different metrics to each session. Therefore, it is better to disable it.