### PR TITLE
[WS]: partition-scheduler annotates all ops + fixes

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -17,6 +17,7 @@ class ForOp;
 } // namespace mlir
 
 static constexpr char kPartitionAttrName[] = "ttg.partition";
+static constexpr char kPartitionOutputsAttrName[] = "ttg.partition.outputs";
 static constexpr char kPartitionStagesAttrName[] = "ttg.partition.stages";
 static constexpr char kWarpSpecializeTagAttrName[] = "ttg.warp_specialize.tag";
 
@@ -121,6 +122,8 @@ bool hasPartition(Operation *op);
 // Annotate the op with the partition index or indices, and add the op
 // to the partitions it belongs to.
 void setPartition(Operation *op, Partition *partition);
+// Unset partition annotation from the op
+void unsetPartition(Operation *op);
 void setPartition(Operation *op, const SetVector<Partition *> &partitions);
 // Annotate the op with the partition indices. It should only be used in a pass
 // which does not work with Partition instances and iterate* functions, since

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -122,8 +122,6 @@ bool hasPartition(Operation *op);
 // Annotate the op with the partition index or indices, and add the op
 // to the partitions it belongs to.
 void setPartition(Operation *op, Partition *partition);
-// Unset partition annotation from the op
-void unsetPartition(Operation *op);
 void setPartition(Operation *op, const SetVector<Partition *> &partitions);
 // Annotate the op with the partition indices. It should only be used in a pass
 // which does not work with Partition instances and iterate* functions, since

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
@@ -36,7 +36,11 @@ void AutomaticWarpSpecialization::runOnOperation() {
   OpPassManager pm;
   pm.addPass(createTritonGPUPartitionScheduling());
   pm.addPass(createNVWSInsertAref());
+#if 0
+  pm.addPass(createNVWSInsertTmemAref());
+#else
   pm.addPass(createTritonGPULoadMMASpecialization({numStages}));
+#endif
   pm.addPass(createTritonGPURewritePartitionDependencies());
   // `int-range-optimizations` and SCCP are good at cleaning up loop arithmetic.
   // FIXME: Re-enable integer range analysis once it is fixed.

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -181,7 +181,6 @@ void setPartition(Operation *op, ArrayRef<int> partitionIds) {
   Builder b(op->getContext());
   op->setAttr(kPartitionAttrName, b.getDenseI32ArrayAttr(partitionIds));
 }
-void unsetPartition(Operation *op) { op->removeAttr(kPartitionAttrName); }
 
 void setPartition(Operation *op, const SetVector<int> &partitionIds) {
   SmallVector<int> partitions(partitionIds.begin(), partitionIds.end());

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -181,6 +181,7 @@ void setPartition(Operation *op, ArrayRef<int> partitionIds) {
   Builder b(op->getContext());
   op->setAttr(kPartitionAttrName, b.getDenseI32ArrayAttr(partitionIds));
 }
+void unsetPartition(Operation *op) { op->removeAttr(kPartitionAttrName); }
 
 void setPartition(Operation *op, const SetVector<int> &partitionIds) {
   SmallVector<int> partitions(partitionIds.begin(), partitionIds.end());

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionBuilder.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionBuilder.cpp
@@ -14,13 +14,6 @@ Value PartitionBuilder::boolCst(bool value) {
   return intCst(value, /*width=*/1);
 }
 
-void PartitionBuilder::assignStage(Operation *op, StageCluster stageCluster) {
-  if (stageCluster) {
-    op->setAttr(kLoopStageAttrName, getI32IntegerAttr(stageCluster->first));
-    op->setAttr(kLoopClusterAttrName, getI32IntegerAttr(stageCluster->second));
-  }
-}
-
 void PartitionBuilder::assignPartition(Operation *op, Partition &partition) {
   setPartition(op, &partition);
 }
@@ -31,4 +24,13 @@ StageCluster triton::gpu::getStageCluster(Operation *op) {
   if (!stageAttr || !clusterAttr)
     return std::nullopt;
   return std::make_pair(stageAttr.getInt(), clusterAttr.getInt());
+}
+
+void triton::gpu::setStageCluster(OpBuilder &b, Operation *op,
+                                  StageCluster stageCluster) {
+  if (stageCluster) {
+    op->setAttr(kLoopStageAttrName, b.getI32IntegerAttr(stageCluster->first));
+    op->setAttr(kLoopClusterAttrName,
+                b.getI32IntegerAttr(stageCluster->second));
+  }
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -51,17 +51,36 @@ enum class LoopVarCategory {
   TensorResultFromOtherPartition,
 };
 
+SetVector<int> getIfOpResultPartitionIds(scf::IfOp ifOp, int pos) {
+  auto arrayAttr = ifOp->getAttrOfType<ArrayAttr>(kPartitionOutputsAttrName);
+  assert(arrayAttr.size() == ifOp.getResultTypes().size());
+  auto partitionIdsRef = cast<DenseI32ArrayAttr>(arrayAttr[pos]).asArrayRef();
+  return {partitionIdsRef.begin(), partitionIdsRef.end()};
+}
+
+SetVector<int> getIfOpResultPartitionIds(scf::IfOp ifOp, Value value) {
+  for (auto result : ifOp.getResults()) {
+    if (result == value) {
+      auto pos = result.getResultNumber();
+      return getIfOpResultPartitionIds(ifOp, pos);
+    }
+  }
+  llvm_unreachable("value is not a result of if-stmt");
+}
+
 bool isTensorResultComputedBy(scf::ForOp loop, size_t resultIdx,
                               const Partition *partition,
                               const PartitionSet &partitions) {
-  bool ret = false;
-  partition->iterateOutputs(loop, [&](Operation *op, OpOperand &use) {
-    if (isa<scf::YieldOp>(op) && use.getOperandNumber() == resultIdx &&
-        isa<RankedTensorType>(loop.getResult(resultIdx).getType())) {
-      ret = true;
-    }
-  });
-  return ret;
+  auto value = loop.getYieldedValues()[resultIdx];
+  if (!isa<RankedTensorType>(value.getType()))
+    return false;
+  auto defOp = value.getDefiningOp();
+  auto partitionIds = *getPartitionIds(defOp);
+  if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
+    partitionIds = getIfOpResultPartitionIds(ifOp, value);
+  }
+  bool contained = llvm::is_contained(partitionIds, partition->getIndex());
+  return contained;
 }
 
 SmallVector<size_t> getPartitionIds(Operation *op, size_t numPartitions) {
@@ -78,9 +97,15 @@ SmallVector<size_t> getPartitionIds(Operation *op, size_t numPartitions) {
 SmallVector<LoopVarCategory> classifyLoopVars(scf::ForOp loop,
                                               const Partition *partition,
                                               const PartitionSet &partitions) {
-  auto inPartition = [&](Operation *op) {
-    auto opPartitionIds = getPartitionIds(op, partitions.getNumPartitions());
-    return llvm::is_contained(opPartitionIds, partition->getIndex());
+  auto inPartition = [&](OpOperand &opnd) {
+    auto op = opnd.getOwner();
+    auto partitionIds = getPartitionIds(op, partitions.getNumPartitions());
+    if (auto ifOp = dyn_cast<scf::IfOp>(op->getParentOp());
+        ifOp && isa<scf::YieldOp>(op)) {
+      auto ids = getIfOpResultPartitionIds(ifOp, opnd.getOperandNumber());
+      partitionIds = SmallVector<size_t>(ids.begin(), ids.end());
+    }
+    return llvm::is_contained(partitionIds, partition->getIndex());
   };
   auto isTensorResultFromOtherPartition = [&](int i) {
     for (auto otherPartition : partitions.getPartitions()) {
@@ -96,7 +121,7 @@ SmallVector<LoopVarCategory> classifyLoopVars(scf::ForOp loop,
 
   SmallVector<LoopVarCategory> categories(loop.getNumRegionIterArgs());
   for (auto [i, arg] : llvm::enumerate(loop.getRegionIterArgs())) {
-    if (llvm::any_of(arg.getUsers(), inPartition)) {
+    if (llvm::any_of(arg.getUses(), inPartition)) {
       categories[i] = LoopVarCategory::Used;
     } else if (isTensorResultFromOtherPartition(i)) {
       categories[i] = LoopVarCategory::TensorResultFromOtherPartition;
@@ -194,19 +219,24 @@ void cloneIfOp(scf::IfOp ifOp, SmallVector<WarpGroupBuilder> &builders,
   for (size_t idx : partitionIndices) {
     auto &b = builders[idx];
     auto cond = b.mapping.lookupOrDefault(ifOp.getCondition());
-    auto newIfOp = b.create<scf::IfOp>(ifOp.getLoc(), ifOp.getResultTypes(),
-                                       cond, ifOp.elseBlock() ? true : false);
+    SmallVector<Type> newIfResultTypes;
+    SmallVector<int> newIfResultIndices;
+    for (auto pos = 0; pos < ifOp.getResultTypes().size(); ++pos) {
+      auto partitionIds = getIfOpResultPartitionIds(ifOp, pos);
+      if (llvm::is_contained(partitionIds, b.partitionId)) {
+        newIfResultTypes.push_back(ifOp.getResult(pos).getType());
+        newIfResultIndices.push_back(pos);
+      }
+    }
+    auto newIfOp = b.create<scf::IfOp>(ifOp.getLoc(), newIfResultTypes, cond,
+                                       ifOp.elseBlock() ? true : false);
     newIfOp->setAttrs(ifOp->getAttrs());
     newIfOps.push_back(newIfOp);
 
-    mapRange(ifOp.getResults(), newIfOp.getResults(), b.mapping);
-    mapRange(ifOp.thenBlock()->getArguments(),
-             newIfOp.thenBlock()->getArguments(), b.mapping);
-
-    if (ifOp.elseBlock()) {
-      mapRange(ifOp.elseBlock()->getArguments(),
-               newIfOp.elseBlock()->getArguments(), b.mapping);
+    for (auto [newIdx, oldIdx] : llvm::enumerate(newIfResultIndices)) {
+      b.mapping.map(ifOp.getResult(oldIdx), newIfOp.getResult(newIdx));
     }
+    assert(ifOp.thenBlock()->getNumArguments() == 0);
 
     b.setInsertionPointToStart(newIfOp.thenBlock());
   }
@@ -214,8 +244,8 @@ void cloneIfOp(scf::IfOp ifOp, SmallVector<WarpGroupBuilder> &builders,
   cloneOpsInBlock(ifOp.thenBlock(), builders, partitions);
 
   if (auto elseBlock = ifOp.elseBlock()) {
-    for (auto [builder, newIfOp] : llvm::zip(builders, newIfOps)) {
-      builder.setInsertionPointToStart(newIfOp.elseBlock());
+    for (auto [idx, newIfOp] : llvm::zip(partitionIndices, newIfOps)) {
+      builders[idx].setInsertionPointToStart(newIfOp.elseBlock());
     }
     cloneOpsInBlock(elseBlock, builders, partitions);
   }
@@ -282,7 +312,6 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
                      const PartitionSet &partitions) {
   for (auto &op_ : *block) {
     auto op = &op_;
-    auto partitionIndices = getPartitionIds(op, partitions.getNumPartitions());
 
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       cloneForOp(forOp, builders, partitions);
@@ -295,6 +324,9 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
         continue;
       }
 
+      auto partitionIndices =
+          getPartitionIds(op, partitions.getNumPartitions());
+
       for (size_t idx : partitionIndices) {
         auto &builder = builders[idx];
         SmallVector<size_t> newOperandIndices;
@@ -305,8 +337,12 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
                   partitions)
                   .first;
         } else {
+          auto ifOp = cast<scf::IfOp>(yieldOp->getParentOp());
           for (size_t i = 0; i < yieldOp.getOperands().size(); ++i) {
-            newOperandIndices.push_back(i);
+            auto ids = getIfOpResultPartitionIds(ifOp, i);
+            if (llvm::is_contained(ids, builder.partitionId)) {
+              newOperandIndices.push_back(i);
+            }
           }
         }
 
@@ -321,39 +357,11 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
         }
       }
     } else {
+      auto partitionIndices =
+          getPartitionIds(op, partitions.getNumPartitions());
       cloneOp(op, builders, partitionIndices);
     }
   }
-}
-
-void assignRootPartition(scf::ForOp loop, PartitionSet &partitions) {
-  auto ctx = loop.getContext();
-  Builder b(ctx);
-  SetVector<Partition *> root;
-  for (int i = 0; i < partitions.getNumPartitions(); ++i) {
-    root.insert(partitions.getPartition(i));
-  }
-
-  for (Operation &op : loop.getBody()->without_terminator()) {
-    if (!hasPartition(&op)) {
-      setPartition(&op, root);
-    }
-  }
-}
-
-void assignRegionBodyPartition(scf::ForOp loop, PartitionSet &partitions) {
-  loop->walk([&](Operation *op) {
-    if (!isa<scf::ForOp>(op) && !hasPartition(op)) {
-      auto parentOp = loop.getBody()->findAncestorOpInBlock(*op);
-      if (auto partitionIds = triton::gpu::getPartitionIds(parentOp)) {
-        SetVector<Partition *> parentPartitions;
-        for (auto id : *partitionIds) {
-          parentPartitions.insert(partitions.getPartition(id));
-        }
-        setPartition(op, parentPartitions);
-      }
-    }
-  });
 }
 
 } // namespace
@@ -363,9 +371,6 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
   if (failed(partitionsOr))
     return failure();
   PartitionSet partitions = std::move(*partitionsOr);
-
-  assignRootPartition(loop, partitions);
-  assignRegionBodyPartition(loop, partitions);
 
   // Only the root node should have consumers at this point.
   for (const Partition &partition : partitions.getPartitions()) {
@@ -516,6 +521,75 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
   return success();
 }
 
+LogicalResult inferIfStmtPartitions(scf::IfOp ifOp) {
+  using PartitionSet = SetVector<int>;
+  PartitionSet ifOpPartitions;
+  SmallVector<std::optional<PartitionSet>> partitionIndices(
+      ifOp.getResultTypes().size());
+
+  auto processBlock = [&](Block *block) -> LogicalResult {
+    if (!block)
+      return success();
+
+    // for yield op, get partition of each result of if-stmt
+    auto yieldOp = cast<scf::YieldOp>(block->getTerminator());
+    for (auto &opnd : yieldOp->getOpOperands()) {
+      auto partitionIds = getPartitionIds(opnd.get().getDefiningOp());
+      if (!partitionIds)
+        continue;
+      auto idx = opnd.getOperandNumber();
+      if (partitionIndices[idx] && partitionIndices[idx] != partitionIds) {
+        return emitError(yieldOp.getLoc(),
+                         "inconsistent partitions for then/else "
+                         "branches yield operand");
+      }
+      partitionIndices[idx] = partitionIds;
+    }
+
+    // if-op partition set is the union of all op partitions in the block
+    for (auto &op : block->without_terminator()) {
+      auto opPartitions = getPartitionIds(&op);
+      for (auto p : *opPartitions) {
+        ifOpPartitions.insert(p);
+      }
+    }
+    return success();
+  };
+
+  if (failed(processBlock(ifOp.thenBlock())))
+    return failure();
+  if (failed(processBlock(ifOp.elseBlock())))
+    return failure();
+
+  llvm::SmallVector<Attribute> partitionAttrs;
+  for (auto [idx, partition] : llvm::enumerate(partitionIndices)) {
+    if (!partition) {
+      if (!isa<AsyncTokenType>(ifOp.getResult(idx).getType())) {
+        return emitError(ifOp.getLoc(),
+                         "partition not found for if-stmt result");
+      }
+      partition = SetVector<int>();
+      partition->insert(0);
+    }
+    ArrayRef<int> ids(partition->begin(), partition->end());
+    OpBuilder b(ifOp);
+    partitionAttrs.push_back(b.getDenseI32ArrayAttr(ids));
+  }
+  ifOp->setAttr(kPartitionOutputsAttrName,
+                ArrayAttr::get(ifOp.getContext(), partitionAttrs));
+  setPartition(ifOp, ifOpPartitions);
+  return success();
+} // namespace
+
+LogicalResult inferReduceOpPartitions(triton::ReduceOp reduceOp) {
+  auto terminator = reduceOp.getRegion().getBlocks().front().getTerminator();
+  auto partitionIds = getPartitionIds(terminator);
+  if (!partitionIds)
+    return emitError(reduceOp.getLoc(), "reduce op has no partition ids");
+  setPartition(reduceOp, *partitionIds);
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Pass Definition
 //===----------------------------------------------------------------------===//
@@ -544,6 +618,14 @@ void PartitionLoops::runOnOperation() {
   });
 
   for (scf::ForOp loop : loops) {
+    loop.walk([&](triton::ReduceOp reduceOp) {
+      if (failed(inferReduceOpPartitions(reduceOp)))
+        signalPassFailure();
+    });
+    loop.walk([&](scf::IfOp ifOp) {
+      if (failed(inferIfStmtPartitions(ifOp)))
+        signalPassFailure();
+    });
     if (failed(partitionLoop(loop)))
       return signalPassFailure();
   }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -79,8 +79,7 @@ bool isTensorResultComputedBy(scf::ForOp loop, size_t resultIdx,
   if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
     partitionIds = getIfOpResultPartitionIds(ifOp, value);
   }
-  bool contained = llvm::is_contained(partitionIds, partition->getIndex());
-  return contained;
+  return llvm::is_contained(partitionIds, partition->getIndex());
 }
 
 SmallVector<size_t> getPartitionIds(Operation *op, size_t numPartitions) {
@@ -517,7 +516,7 @@ LogicalResult triton::gpu::partitionLoop(scf::ForOp loop) {
   return success();
 }
 
-LogicalResult inferIfStmtPartitions(scf::IfOp ifOp) {
+LogicalResult inferIfOpPartitions(scf::IfOp ifOp) {
   using PartitionSet = SetVector<int>;
   PartitionSet ifOpPartitions;
   SmallVector<std::optional<PartitionSet>> partitionIndices(
@@ -575,7 +574,7 @@ LogicalResult inferIfStmtPartitions(scf::IfOp ifOp) {
                 ArrayAttr::get(ifOp.getContext(), partitionAttrs));
   setPartition(ifOp, ifOpPartitions);
   return success();
-} // namespace
+}
 
 LogicalResult inferReduceOpPartitions(triton::ReduceOp reduceOp) {
   auto terminator = reduceOp.getRegion().getBlocks().front().getTerminator();
@@ -619,7 +618,7 @@ void PartitionLoops::runOnOperation() {
         signalPassFailure();
     });
     loop.walk([&](scf::IfOp ifOp) {
-      if (failed(inferIfStmtPartitions(ifOp)))
+      if (failed(inferIfOpPartitions(ifOp)))
         signalPassFailure();
     });
     if (failed(partitionLoop(loop)))

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionLoops.cpp
@@ -312,6 +312,7 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
                      const PartitionSet &partitions) {
   for (auto &op_ : *block) {
     auto op = &op_;
+    auto partitionIndices = getPartitionIds(op, partitions.getNumPartitions());
 
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       cloneForOp(forOp, builders, partitions);
@@ -323,9 +324,6 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
       if (yieldOp.getOperands().empty()) {
         continue;
       }
-
-      auto partitionIndices =
-          getPartitionIds(op, partitions.getNumPartitions());
 
       for (size_t idx : partitionIndices) {
         auto &builder = builders[idx];
@@ -357,8 +355,6 @@ void cloneOpsInBlock(Block *block, SmallVector<WarpGroupBuilder> &builders,
         }
       }
     } else {
-      auto partitionIndices =
-          getPartitionIds(op, partitions.getNumPartitions());
       cloneOp(op, builders, partitionIndices);
     }
   }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -564,11 +564,11 @@ void assignRegionBodyPartition(scf::ForOp loop, PartitionSet &partitions) {
   });
 
   loop->walk([&](Operation *op) {
-    // unset partition in ops that have regions
+    // remove partition attribute in ops that have regions
     // such op's partition set will be inferred from regions
     // in partition-loops pass
     if (!isa<scf::ForOp>(op) && hasPartition(op) && op->getNumRegions() > 0) {
-      unsetPartition(op);
+      op->removeAttr(kPartitionAttrName);
     }
   });
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -528,6 +528,51 @@ void optimizePartitions(scf::ForOp loop, PartitionSet &partitions) {
   }
 }
 
+// TODO: Implement a mutually-recursive traversal that can handle
+//       nested control flow structures (if/reduce/for operations).
+//       While we don't currently have use cases requiring this,
+//       implementing it would prepare for when it is needed.
+void assignRootPartition(scf::ForOp loop, PartitionSet &partitions) {
+  auto ctx = loop.getContext();
+  Builder b(ctx);
+  SetVector<Partition *> root;
+  for (int i = 0; i < partitions.getNumPartitions(); ++i) {
+    root.insert(partitions.getPartition(i));
+  }
+
+  for (Operation &op : loop.getBody()->without_terminator()) {
+    if (!hasPartition(&op)) {
+      setPartition(&op, root);
+    }
+  }
+}
+
+void assignRegionBodyPartition(scf::ForOp loop, PartitionSet &partitions) {
+  loop->walk([&](Operation *op) {
+    if (isa<scf::YieldOp, scf::ForOp>(op) || hasPartition(op))
+      return WalkResult::advance();
+
+    auto parentOp = loop.getBody()->findAncestorOpInBlock(*op);
+    if (auto partitionIds = triton::gpu::getPartitionIds(parentOp)) {
+      SetVector<Partition *> parentPartitions;
+      for (auto id : *partitionIds) {
+        parentPartitions.insert(partitions.getPartition(id));
+      }
+      setPartition(op, parentPartitions);
+    }
+    return WalkResult::advance();
+  });
+
+  loop->walk([&](Operation *op) {
+    // unset partition in ops that have regions
+    // such op's partition set will be inferred from regions
+    // in partition-loops pass
+    if (!isa<scf::ForOp>(op) && hasPartition(op) && op->getNumRegions() > 0) {
+      unsetPartition(op);
+    }
+  });
+}
+
 //===----------------------------------------------------------------------===//
 // Pass Definition
 //===----------------------------------------------------------------------===//
@@ -557,6 +602,8 @@ void PartitionScheduling::runOnOperation() {
     if (std::optional<PartitionSet> partitions = getInitialPartitions(loop)) {
       propagatePartitions(loop, *partitions);
       optimizePartitions(loop, *partitions);
+      assignRootPartition(loop, *partitions);
+      assignRegionBodyPartition(loop, *partitions);
       loop->setAttr(
           kWarpSpecializeTagAttrName,
           IntegerAttr::get(IntegerType::get(loop.getContext(), 32), idx));

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -206,6 +206,12 @@ LogicalResult DependencyRewriter::run() {
        llvm::zip(partitions.getPartitions(), partitionUseInfo)) {
     // The amount of buffering is based on the longest distance to a user.
     for (auto &[output, info] : useInfo) {
+      // Skip AsyncTokenType outputs - they are handled correctly by design
+      // in a previous pass and should not be passed through shared memory
+      if (isa<AsyncTokenType>(output.getType())) {
+        continue;
+      }
+
       b.setLoc(output.getLoc());
       ImplicitLocOpBuilder endBuilder(b.getLoc(), loop->getNextNode());
 

--- a/test/NVWS/assign_stage_phase.mlir
+++ b/test/NVWS/assign_stage_phase.mlir
@@ -274,3 +274,66 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
     tt.return
   }
 }
+
+// -----
+
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @assign_stage_buffer
+  tt.func @assign_stage_buffer(%arg0: !tt.tensordesc<tensor<128x64xf16, #shared>>, %arg1: !tt.tensordesc<tensor<64x128xf16, #shared>>) {
+    %c32_i32 = arith.constant 32 : i32
+    %cst = arith.constant dense<1.000000e+00> : tensor<128x128xf32, #blocked>
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %true = arith.constant true
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %result = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %0 = nvws.aref.create %result : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>
+    %buffers, %token = nvws.aref.put.enter %0 : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>, !ttg.async.token
+    // CHECK: [[AREF:%.*]] = nvws.aref.create
+    // CHECK: {{.*}}, [[TOK:%.*]] = nvws.aref.put.enter [[AREF]][[[STAGE:%.*]], [[PHASE:%.*]]]
+    // CHECK-NEXT: nvws.aref.buffer [[AREF]][[[STAGE]]], [[TOK]]
+    %1 = nvws.aref.buffer %0, %token : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>, !ttg.async.token -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>
+    %2 = ttng.tmem_store %cst_0, %1[], %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>
+    // CHECK: scf.for {{.*}} iter_args([[TOK1:%.*]] = [[TOK]], [[SPUT:%.*]] = {{.*}}, {{.*}} = {{.*}}, {{.*}} = {{.*}}, {{.*}} = {{.*}})
+    %3 = scf.for %arg2 = %c0_i32 to %c32_i32 step %c1_i32 iter_args(%arg3 = %token) -> (!ttg.async.token)  : i32 {
+      %4:3 = "get_offsets"(%arg2) : (i32) -> (i32, i32, i32)
+      %5 = tt.descriptor_load %arg0[%4#0, %4#2] {ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<128x64xf16, #shared>> -> tensor<128x64xf16, #blocked1>
+      %6 = tt.descriptor_load %arg1[%4#1, %4#2] {ttg.partition = array<i32: 2>} : !tt.tensordesc<tensor<64x128xf16, #shared>> -> tensor<64x128xf16, #blocked1>
+      %7 = ttg.local_alloc %5 {ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked1>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %8 = ttg.local_alloc %6 {ttg.partition = array<i32: 2>} : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+      // CHECK: nvws.aref.buffer [[AREF]][[[SPUT]]], [[TOK1]]
+      %9 = nvws.aref.buffer %0, %arg3 {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>, !ttg.async.token -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>
+      %10 = ttng.tc_gen5_mma %7, %8, %9[], %true, %true {ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>
+      %11 = arith.cmpi eq, %arg2, %c0_i32 : i32
+      // CHECK: [[RET_IF:%.*]]:5 = scf.if
+      %12 = scf.if %11 -> (!ttg.async.token) {
+        nvws.aref.put.exit %0, %arg3 [#nvws.async_op<tc5mma>] {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>, !ttg.async.token
+        %buffers_1, %token_2 = nvws.aref.get.enter %0 {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>, !ttg.async.token
+        // CHECK: {{.*}}, [[TOK2:%.*]] = nvws.aref.get.enter [[AREF]][[[SGET:%.*]], [[PHASE:%.*]]]
+        // CHECK: nvws.aref.buffer [[AREF]][[[SGET]]], [[TOK2]]
+        %15 = nvws.aref.buffer %0, %token_2 {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>, !ttg.async.token -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>
+        %result_3, %token_4 = ttng.tmem_load %15[] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128> -> tensor<128x128xf32, #blocked>
+        nvws.aref.get.exit %0, %token_2 [#nvws.async_op<none>] {ttg.partition = array<i32: 0>} : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>, !ttg.async.token
+        "acc_user"(%result_3) : (tensor<128x128xf32, #blocked>) -> ()
+        %buffers_5, %token_6 = nvws.aref.put.enter %0 {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>, !ttg.async.token
+        // CHECK: {{.*}}, [[TOK2:%.*]] = nvws.aref.put.enter [[AREF]][[[SPUT1:%.*]], [[PHASE1:%.*]]]
+        // CHECK-NEXT: scf.yield [[TOK2]], [[SPUT1]]
+        scf.yield %token_6 : !ttg.async.token
+      } else {
+        scf.yield %arg3 : !ttg.async.token
+      } {ttg.partition = array<i32: 0>}
+      // CHECK: nvws.aref.buffer [[AREF]][[[RET_IF]]#1], [[RET_IF]]#0
+      %13 = nvws.aref.buffer %0, %12 {ttg.partition = array<i32: 1>} : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>, !ttg.async.token -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>
+      %14 = ttng.tmem_store %cst, %13[], %true {ttg.partition = array<i32: 1>} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable, 2x128x128>
+      scf.yield %12 : !ttg.async.token
+    } {tt.num_stages = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.warp_specialize.tag = 5 : i32}
+    nvws.aref.put.exit %0, %3 [#nvws.async_op<none>] : <[!ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>]>, !ttg.async.token
+    tt.return
+  }
+}

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -67,7 +67,7 @@ std::optional<std::pair<AllocOp, LoadOp>> isLoadAndAlloc(Value result) {
   if (!alloc)
     return std::nullopt;
   if (auto load = alloc.getSrc().template getDefiningOp<LoadOp>();
-      *getPartitionIds(alloc) == *getPartitionIds(load)) {
+      load && *getPartitionIds(alloc) == *getPartitionIds(load)) {
     // if alloc and load are in different partitions, they are treated as two
     // different producer operations.
     return std::make_pair(alloc, load);

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
@@ -626,7 +626,8 @@ LogicalResult runOnFunction(triton::FuncOp funcOp) {
   SmallVector<TmemAccessDag> tmemDags;
   funcOp.walk([&](TMEMAllocOp allocOp) {
     // skip allocOps with source and > 1 partition
-    if (!allocOp.getSrc() || getPartitionIds(allocOp)->size() <= 1)
+    auto partitionIds = getPartitionIds(allocOp);
+    if (!allocOp.getSrc() || (partitionIds && partitionIds->size() == 1))
       tmemDags.push_back(TmemAccessDag::build(allocOp));
   });
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
@@ -349,14 +349,15 @@ OpT createInto(
     OpBuilder &b, Location loc,
     std::pair<std::optional<PartitionId>, StageCluster> partitionIdStageCluster,
     Args &&...args) {
-  auto op = b.create<OpT>(loc, std::forward<Args>(args)...);
+  std::optional<SetVector<int>> partitionIds = SetVector<int>();
   if (partitionIdStageCluster.first) {
-    SetVector<int> partitionIds;
-    partitionIds.insert(*partitionIdStageCluster.first);
-    setPartition(op, partitionIds);
-    assignStage(b, op, partitionIdStageCluster.second);
+    partitionIds->insert(*partitionIdStageCluster.first);
+  } else {
+    partitionIds = std::nullopt;
   }
-  return op;
+  return triton::gpu::createInto<OpT>(b, loc, partitionIds,
+                                      partitionIdStageCluster.second,
+                                      std::forward<Args>(args)...);
 }
 
 struct TMEMAref {
@@ -624,8 +625,8 @@ LogicalResult insertTmemAref(TmemAccessDag &accessDag) {
 LogicalResult runOnFunction(triton::FuncOp funcOp) {
   SmallVector<TmemAccessDag> tmemDags;
   funcOp.walk([&](TMEMAllocOp allocOp) {
-    // if allocOp has src and has no partition, we skip it
-    if (!allocOp.getSrc() || getPartitionId(allocOp))
+    // skip allocOps with source and > 1 partition
+    if (!allocOp.getSrc() || getPartitionIds(allocOp)->size() <= 1)
       tmemDags.push_back(TmemAccessDag::build(allocOp));
   });
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -163,6 +163,12 @@ BarrierCount getArrivalCount(ArefCreateOp op) {
       }
     }
   }
+  // If the aref is not used within a warp-specialized loop, the pending counts
+  // will be equal 0. Set them to 1.
+  if (count.producerPendingCount == 0)
+    count.producerPendingCount = 1;
+  if (count.consumerPendingCount == 0)
+    count.consumerPendingCount = 1;
 
   return count;
 }
@@ -214,17 +220,21 @@ SmallVector<Value> getSubViews(ArefValue arefVal, Value stage, Location loc,
   SmallVector<Value> views;
   for (auto buffer : arefVal.buffers) {
     auto memDescType = cast<MemDescType>(buffer.getType());
-    auto shape = memDescType.getShape();
-    auto rank = shape.size() - 1;
-
-    SmallVector<int64_t> tensorShape(shape.begin() + 1, shape.end());
-    auto memDescTypeNew = MemDescType::get(
-        tensorShape, memDescType.getElementType(), memDescType.getEncoding(),
-        memDescType.getMemorySpace(), true);
-    auto singleBuffer =
-        rewriter.create<MemDescIndexOp>(loc, memDescTypeNew, buffer, stage);
-    assignStageCluster(singleBuffer, partitionIds, stageCluster, rewriter);
-    views.push_back(singleBuffer);
+    if (isa<nvidia_gpu::TensorMemoryScalesEncodingAttr>(
+            memDescType.getEncoding())) {
+      // tmem scales encoding doesn't support multi-buffering, use buffer as-is
+      views.push_back(buffer);
+    } else {
+      auto shape = memDescType.getShape();
+      SmallVector<int64_t> tensorShape(shape.begin() + 1, shape.end());
+      auto memDescTypeNew = MemDescType::get(
+          tensorShape, memDescType.getElementType(), memDescType.getEncoding(),
+          memDescType.getMemorySpace(), true);
+      auto singleBuffer =
+          rewriter.create<MemDescIndexOp>(loc, memDescTypeNew, buffer, stage);
+      assignStageCluster(singleBuffer, partitionIds, stageCluster, rewriter);
+      views.push_back(singleBuffer);
+    }
   }
 
   return views;
@@ -328,7 +338,8 @@ void rewritePutEnterOp(ArefPutEnterOp op, PatternRewriter &rewriter,
       break;
     }
   }
-  assert(exitOp);
+  if (!exitOp)
+    return;
   assert(exitOp.getAref() == op.getAref() &&
          "Expecting matching Aref on the ArefPutExitOp");
 
@@ -390,6 +401,17 @@ void rewriteGetEnterOp(ArefGetEnterOp op, PatternRewriter &rewriter,
     // a get enter op. After lowering, all buffers are mutable.
     propagateMutability(view);
   }
+}
+
+void rewriteArefBufferOp(ArefBufferOp op, PatternRewriter &rewriter,
+                         ArefValue arefVal) {
+  auto loc = op->getLoc();
+  rewriter.setInsertionPointAfter(op);
+  auto views = getSubViews(arefVal, op.getStage(), loc, rewriter,
+                           getPartitionIds(op), getStageCluster(op));
+  assert(views.size() == op.getBuffers().size());
+  for (int i = 0; i < op.getBuffers().size(); ++i)
+    op.getBuffers()[i].replaceAllUsesWith(views[i]);
 }
 
 void insertArriveBarrier(Location loc, ArrayRef<AsyncOp> asyncOps,
@@ -522,6 +544,8 @@ public:
         rewritePutExitOp(user, rewriter, aref);
       } else if (auto user = dyn_cast<ArefGetExitOp>(userOp)) {
         rewriteGetExitOp(user, rewriter, aref);
+      } else if (auto user = dyn_cast<ArefBufferOp>(userOp)) {
+        rewriteArefBufferOp(user, rewriter, aref);
       } else {
         llvm_unreachable("users of aref can only be ArefPut or ArefGet");
       }
@@ -565,7 +589,7 @@ void multiBufferAref(const SmallVector<ArefCreateOp> &arefOps, int numStages) {
 
     bool eligible = true;
     for (auto opnd : arefOp.getOperands()) {
-      if (!opnd.getDefiningOp()) {
+      if (!opnd.getDefiningOp() || isa<TMEMAllocOp>(opnd.getDefiningOp())) {
         eligible = false;
       }
     }


### PR DESCRIPTION
* all ops, except parent ops (if/reduce), are annotated with partition sets after `partition-scheduler`
* patch up downstream passes to handle this properly
* partition set of a parent op is inferred in `partition-loop` pass; also infers partitions set for each result
* extend `partition-loop` to partition if-stmt across different partition when loops are split
* patch `lower-mma-specialization` to annotate all ops, and patch unit test
* patch up remainig passes to play well with requirement that all ops must be annotated in ws-loops
* there are few remaining issues before `aref-tmem-insertion` can be enabled and `load-mma-specialzation` disabled, which is subject of subsequent PR