### PR TITLE
Add support for ASTSource attr string name keys

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -57,13 +57,19 @@ class ASTSource:
         self.ext = "ttir"
         self.name = fn.__name__
         self.signature = signature
-        self.constants = dict()
-        if constexprs is not None:
-            for k, v in constexprs.items():
-                k = (fn.arg_names.index(k), ) if isinstance(k, str) else k
-                assert isinstance(k, tuple)
-                self.constants[k] = v
-        self.attrs = attrs or dict()
+
+        def _parse_arg_name_entries(dict_or_none):
+            result = dict()
+            if dict_or_none is not None:
+                for k, v in dict_or_none.items():
+                    k = (fn.arg_names.index(k), ) if isinstance(k, str) else k
+                    assert isinstance(k, tuple)
+                    result[k] = v
+            return result
+
+        self.constants = _parse_arg_name_entries(constexprs)
+        self.attrs = _parse_arg_name_entries(attrs)
+
         for k in self.signature.keys():
             if not isinstance(k, str):
                 raise TypeError("Signature keys must be string")


### PR DESCRIPTION
Add support for specifying the argument attr dictionary to triton.compiler.ASTSource with strings for key names rather than position tuples. This matches the support already available for constexpr values being supplied to ASTSource and shares common code for this purpose.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
