### PR TITLE
Add float8_e8m0fnu to type canonicalization list

### DIFF
--- a/python/triton/_utils.py
+++ b/python/triton/_utils.py
@@ -75,6 +75,7 @@ type_canonicalisation_dict = {
     "float8_e5m2": "fp8e5",
     "float8e5b16": "fp8e5b16",
     "float8_e5m2fnuz": "fp8e5b16",
+    "float8_e8m0fnu": "uint8",
     "half": "fp16",
     "float16": "fp16",
     "bfloat16": "bf16",


### PR DESCRIPTION
Part of https://github.com/triton-lang/triton/issues/6054

## Summary
- In PyTorch we usually view torch.float8_e8m0fnu data as uint8 before passing to triton, since e8m0 is not part of the triton canonicalization list. This was a simple workaround.
- However, recently we've encountered a situation where our torch native mxfp8 training code hits the error below when we apply `torch.compile`, as torch inductor codegens triton kernels which attempt to utilize the torch.float8_e8m0fnu data directly. 
- Implementing a workaround for this in inductor is probably more involved than just fixing it in Triton. 

## Changes
Add float8_e8m0fnu to the type canonicalization list, simply represented internally in triton as uint8.

## Error
```
Traceback (most recent call last):
  File "/home/danvm/torchtitan/repro.py", line 52, in <module>
    main()
  File "/home/danvm/torchtitan/repro.py", line 39, in main
    copy_kernel[grid](
  File "/home/danvm/.conda/envs/torch/lib/python3.12/site-packages/triton/runtime/jit.py", line 419, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/danvm/.conda/envs/torch/lib/python3.12/site-packages/triton/runtime/jit.py", line 723, in run
    bound_args, specialization, options = binder(*args, **kwargs)
                                          ^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 4, in dynamic_func
  File "/home/danvm/.conda/envs/torch/lib/python3.12/site-packages/triton/runtime/jit.py", line 375, in specialize_impl
    res = ("*k" if dsk[1] else "*") + canonicalize_dtype(dsk[0])
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/danvm/.conda/envs/torch/lib/python3.12/site-packages/triton/_utils.py", line 105, in canonicalize_dtype
    return type_canonicalisation_dict[dtype_str]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'float8_e8m0fnu'
```

## Repro
```python
import torch
import triton
import triton.language as tl

@triton.jit
def copy_kernel(
    in_ptr,
    out_ptr,
    n_elements,
    BLOCK_SIZE: tl.constexpr,
):
    pid = tl.program_id(axis=0)
    block_start = pid * BLOCK_SIZE
    offsets = tl.arange(0, BLOCK_SIZE)
    current_offsets = block_start + offsets
    mask = current_offsets < n_elements
    data = tl.load(in_ptr + current_offsets, mask=mask)
    tl.store(out_ptr + current_offsets, data, mask=mask)


def main():
    if not torch.cuda.is_available():
        print("CUDA is not available. This example requires a GPU.")
        return

    # Check for FP8 support
    if not torch.cuda.get_device_capability()[0] >= 9:
        print("Warning: this example has only been tested on H100 GPUs with CUDA capability 9.0")

    x_fp32 = torch.randn(256, 256, device='cuda')
    x_e8m0 = x_fp32.to(torch.float8_e8m0fnu) # Naive casting just for demonstration purposes
    out_buffer = torch.zeros_like(x_e8m0)

    BLOCK_SIZE = 128
    grid = lambda meta: (triton.cdiv(x_e8m0.numel(), meta['BLOCK_SIZE']),)

    # Launch the kernel
    copy_kernel[grid](
        x_e8m0,
        out_buffer,
        x_e8m0.numel(),
        BLOCK_SIZE=BLOCK_SIZE
    )

    are_close = torch.allclose(x_e8m0.to(torch.float32), out_buffer.to(torch.float32))
    print(f"Verification (numerical closeness): {'Success' if are_close else 'Failure'}")
    assert are_close, "Kernel copy failed!"


if __name__ == "__main__":
    main()
```

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
