### PR TITLE
Conditionally include Proton tests

### DIFF
--- a/third_party/proton/CMakeLists.txt
+++ b/third_party/proton/CMakeLists.txt
@@ -53,7 +53,9 @@ add_subdirectory("${PROTON_COMMON_DIR}")
 add_subdirectory("${PROTON_SRC_DIR}")
 
 # ============ Add subdirectory with proton tests ============
-add_subdirectory(test)
+if(TRITON_BUILD_UT)
+  add_subdirectory(test)
+endif()
 
 # ============ Possibly handle macOS specifics ============
 if(APPLE)


### PR DESCRIPTION
Adds a condition on `TRITON_BUILD_UT` before including Proton tests. 

When `TRITON_BUILD_UT` is `OFF` without adding this condition, a build failure occurs. This is because the Proton tests cmake calls the `add_triton_ut` function, however this function is not declared when `TRITON_BUILD_UT` is `OFF`. 

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it's a build bug fix.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
