### PR TITLE
[PROTON] Unify python frame representation

### DIFF
--- a/third_party/proton/csrc/include/Utility/String.h
+++ b/third_party/proton/csrc/include/Utility/String.h
@@ -59,6 +59,11 @@ inline std::vector<std::string> split(const std::string &str,
   return result;
 }
 
+inline std::string formatFileLineFunction(const std::string &file, int line,
+                                          const std::string &function) {
+  return file + ":" + std::to_string(line) + "@" + function;
+}
+
 } // namespace proton
 
 #endif // PROTON_UTILITY_STRING_H_

--- a/third_party/proton/csrc/lib/Context/Python.cpp
+++ b/third_party/proton/csrc/lib/Context/Python.cpp
@@ -1,5 +1,6 @@
 #include "Context/Python.h"
 #include "pybind11/pybind11.h"
+#include "Utility/String.h"
 #include <algorithm>
 #include <string>
 
@@ -84,7 +85,7 @@ std::vector<Context> PythonContextSource::getContextsImpl() {
     size_t firstLineNo = f_code->co_firstlineno;
     std::string file = unpackPyobject(f_code->co_filename);
     std::string function = unpackPyobject(f_code->co_name);
-    auto pythonFrame = file + ":" + function + "@" + std::to_string(lineno);
+    auto pythonFrame = formatFileLineFunction(file, lineno, function);
     contexts.push_back(Context(pythonFrame));
     auto newFrame = getFrameBack(frame);
     Py_DECREF(frame);

--- a/third_party/proton/csrc/lib/Context/Python.cpp
+++ b/third_party/proton/csrc/lib/Context/Python.cpp
@@ -1,6 +1,6 @@
 #include "Context/Python.h"
-#include "pybind11/pybind11.h"
 #include "Utility/String.h"
+#include "pybind11/pybind11.h"
 #include <algorithm>
 #include <string>
 

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiPCSampling.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiPCSampling.cpp
@@ -387,9 +387,9 @@ void CuptiPCSampling::processPCSamplingData(ConfigureData *configureData,
             scopeId = data->addOp(externId, lineInfo.functionName);
           if (lineInfo.fileName.size())
             scopeId = data->addOp(
-                scopeId, lineInfo.dirName + "/" + lineInfo.fileName + ":" +
-                             std::to_string(lineInfo.lineNumber) + "@" +
-                             lineInfo.functionName);
+                scopeId, formatFileLineFunction(
+                             lineInfo.dirName + "/" + lineInfo.fileName,
+                             lineInfo.lineNumber, lineInfo.functionName));
           auto metricKind = static_cast<PCSamplingMetric::PCSamplingMetricKind>(
               configureData->stallReasonIndexToMetricIndex
                   [stallReason->pcSamplingStallReasonIndex]);

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -36,11 +36,16 @@ def test_torch(context, tmp_path: pathlib.Path):
         assert len(data[0]["children"]) == 1
         # bfs search until find the "elementwise_kernel" and then check its children
         queue = [data[0]]
+        import re
         while len(queue) > 0:
             parent_frame = queue.pop(0)
             for child in parent_frame["children"]:
                 if "elementwise_kernel" in child["frame"]["name"]:
                     assert len(child["children"]) == 0
+                    # check the regex of the parent name matches
+                    # file_name:line_number@function_name
+                    regex = r".+:\d+@.+"
+                    assert re.match(regex, parent_frame["frame"]["name"])
                     return
                 queue.append(child)
 


### PR DESCRIPTION
Previous pc sampling and cupti uses different format, now that they use the same format as "file_name:line_number@function_name"