### PR TITLE
[Gluon] Verify tensor rank and layout rank match

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -2634,3 +2634,15 @@ def test_get_num_warps():
     print_num_warps()
     ttgl.warp_specialize((), print_num_warps, (), [print_num_warps, print_num_warps, print_num_warps], [1, 2, 8],
                          [24, 24, 24])
+
+
+def test_mismatch_shape_and_layout_rank():
+    @gluon.jit
+    def kernel():
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0])
+        _ = ttgl.full([1, 16, 16, 1, 16], 0, ttgl.float16, layout=layout)
+
+    with pytest.raises(CompilationError) as e:
+        run_parser(kernel)
+
+    assert "tensor shape and layout rank mismatch" in str(e.value.__cause__)

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from triton._C.libtriton.gluon_ir import GluonOpBuilder
     from ._semantic import GluonSemantic
 
-from ._layouts import SharedLayout, DistributedLayout, BlockedLayout, DotOperandLayout
+from ._layouts import SharedLayout, DistributedLayout, BlockedLayout, DotOperandLayout, AutoLayout
 from triton._C.libtriton import ir
 import triton.language.core as tl_core
 from triton.language.core import (
@@ -141,7 +141,9 @@ class distributed_type(block_type):
         super().__init__(element_ty, shape)
         self.layout = layout
         self.name = f"<{self.shape}, {self.element_ty}, {self.layout}>"
-        assert isinstance(layout, DistributedLayout)
+        assert isinstance(layout, DistributedLayout), "tensor layout must be a DistributedLayout"
+        if not isinstance(layout, AutoLayout):
+            assert len(shape) == layout.rank, f"tensor shape and layout rank mismatch: shape={shape}, layout={layout}, shape rank={len(shape)}, layout rank={layout.rank}"
 
     def to_ir(self, builder: ir.builder) -> ir.type:
         elem_ty = self.element_ty.to_ir(builder)

--- a/python/triton/experimental/gluon/language/_layouts.py
+++ b/python/triton/experimental/gluon/language/_layouts.py
@@ -23,6 +23,10 @@ class DistributedLayout:
     def type(self):
         return constexpr_type(self)
 
+    @property
+    def rank(self):
+        return len(self.cta_order)
+
 
 @dataclass(frozen=True)
 class AutoLayout(DistributedLayout):
@@ -32,6 +36,10 @@ class AutoLayout(DistributedLayout):
 
     def mangle(self):
         return "AL"
+
+    @property
+    def rank(self):
+        raise ValueError("AutoLayout has no rank")
 
 
 @dataclass(frozen=True)
@@ -141,6 +149,10 @@ class SliceLayout(DistributedLayout):
     def __hash__(self):
         return hash((self.dim, self.parent))
 
+    @property
+    def rank(self):
+        return self.parent.rank - 1
+
 
 @dataclass(frozen=True)
 class DistributedLinearLayout(DistributedLayout):
@@ -195,6 +207,10 @@ class DistributedLinearLayout(DistributedLayout):
             tuple(self.shape),
         ))
 
+    @property
+    def rank(self):
+        return len(self.shape)
+
 
 @dataclass(frozen=True)
 class DotOperandLayout(DistributedLayout):
@@ -223,6 +239,10 @@ class DotOperandLayout(DistributedLayout):
 
     def __hash__(self):
         return hash((self.operand_index, self.parent, self.k_width))
+
+    @property
+    def rank(self):
+        return self.parent.rank
 
 
 @dataclass(frozen=True, eq=True)


### PR DESCRIPTION
Failing to verify this can cause all sorts of weird crashes in the frontend due to violating invariants when calling into dialect (C++) code.
