### PR TITLE
[ANALYSIS] Fix hint analysis in axis info

### DIFF
--- a/include/triton/Analysis/AxisInfo.h
+++ b/include/triton/Analysis/AxisInfo.h
@@ -108,10 +108,13 @@ public:
 
   std::optional<int64_t> getConstantValue() const { return constantValue; }
 
-  template <class T>
-  static void
-  initPessimisticStateFromFunc(int argNumber, T funcOp, DimVectorT *contiguity,
-                               DimVectorT *divisibility, DimVectorT *constancy);
+  static void initPessimisticStateFromFunc(int argNumber,
+                                           FunctionOpInterface funcOp,
+                                           DimVectorT *contiguity,
+                                           DimVectorT *divisibility,
+                                           DimVectorT *constancy);
+
+  static void initDimVectorFromHint(Attribute attr, DimVectorT *vec);
 
   bool operator==(const AxisInfo &other) const {
     return contiguity == other.contiguity &&

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1054,18 +1054,12 @@ LogicalResult AxisInfoAnalysis::visitOperation(
   auto newContiguity = curr.getContiguity();
   auto newDivisibility = curr.getDivisibility();
   auto newConstancy = curr.getConstancy();
-  if (Attribute attr = op->getDiscardableAttr("tt.contiguity")) {
-    auto vals = cast<DenseElementsAttr>(attr).getValues<int>();
-    newContiguity = AxisInfo::DimVectorT(vals.begin(), vals.end());
-  }
-  if (Attribute attr = op->getDiscardableAttr("tt.divisibility")) {
-    auto vals = cast<DenseElementsAttr>(attr).getValues<int>();
-    newDivisibility = AxisInfo::DimVectorT(vals.begin(), vals.end());
-  }
-  if (Attribute attr = op->getDiscardableAttr("tt.constancy")) {
-    auto vals = cast<DenseElementsAttr>(attr).getValues<int>();
-    newConstancy = AxisInfo::DimVectorT(vals.begin(), vals.end());
-  }
+  AxisInfo::initDimVectorFromHint(
+      op->getDiscardableAttr("tt.contiguity"), &newContiguity);
+  AxisInfo::initDimVectorFromHint(
+      op->getDiscardableAttr("tt.divisibility"), &newDivisibility);
+  AxisInfo::initDimVectorFromHint(
+      op->getDiscardableAttr("tt.constancy"), &newConstancy);
   curr = AxisInfo(newContiguity, newDivisibility, newConstancy,
                   curr.getConstantValue());
   // join all lattice elements
@@ -1110,12 +1104,12 @@ void AxisInfoAnalysis::visitWarpSpecializeExplicitCaptures(
 
 } // anonymous namespace
 
-template <class T>
-void AxisInfo::initPessimisticStateFromFunc(int argNumber, T funcOp,
+void AxisInfo::initPessimisticStateFromFunc(int argNumber,
+                                            FunctionOpInterface funcOp,
                                             DimVectorT *contiguity,
                                             DimVectorT *divisibility,
                                             DimVectorT *constancy) {
-  // liast of attributes that we care about
+  // list of attributes that we care about
   SmallVector<std::pair<DimVectorT *, std::string>> retVecs;
   retVecs.push_back({contiguity, "tt.contiguity"});
   retVecs.push_back({divisibility, "tt.divisibility"});
@@ -1123,12 +1117,16 @@ void AxisInfo::initPessimisticStateFromFunc(int argNumber, T funcOp,
   // initialize attributes one by one
   for (auto [vec, attrName] : retVecs) {
     Attribute attr = funcOp.getArgAttr(argNumber, attrName);
-    if (auto int_attr = dyn_cast_or_null<IntegerAttr>(attr))
-      *vec = DimVectorT(contiguity->size(), int_attr.getValue().getZExtValue());
-    if (auto dense_attr = dyn_cast_or_null<DenseElementsAttr>(attr)) {
-      auto vals = dense_attr.getValues<int>();
-      *vec = DimVectorT(vals.begin(), vals.end());
-    }
+    AxisInfo::initDimVectorFromHint(attr, vec);
+  }
+}
+
+void AxisInfo::initDimVectorFromHint(Attribute attr, DimVectorT *vec) {
+  if (auto int_attr = dyn_cast_or_null<IntegerAttr>(attr))
+    *vec = DimVectorT(1, int_attr.getValue().getZExtValue());
+  if (auto dense_attr = dyn_cast_or_null<DenseElementsAttr>(attr)) {
+    auto vals = dense_attr.getValues<int>();
+    *vec = DimVectorT(vals.begin(), vals.end());
   }
 }
 
@@ -1172,18 +1170,12 @@ void AxisInfo::initPessimisticStateFromFunc(int argNumber, T funcOp,
     }
     // Other operations are conservatively initialized with the lowest possible
     // divisibility, contiguity, and constancy unless they have specified.
-    if (Attribute attr = op->getDiscardableAttr("tt.divisibility")) {
-      auto vals = cast<DenseElementsAttr>(attr).getValues<int>();
-      knownDivisibility = DimVectorT(vals.begin(), vals.end());
-    }
-    if (Attribute attr = op->getDiscardableAttr("tt.contiguity")) {
-      auto vals = cast<DenseElementsAttr>(attr).getValues<int>();
-      knownContiguity = DimVectorT(vals.begin(), vals.end());
-    }
-    if (Attribute attr = op->getDiscardableAttr("tt.constancy")) {
-      auto vals = cast<DenseElementsAttr>(attr).getValues<int>();
-      knownConstancy = DimVectorT(vals.begin(), vals.end());
-    }
+    AxisInfo::initDimVectorFromHint(op->getDiscardableAttr("tt.divisibility"),
+                                    &knownDivisibility);
+    AxisInfo::initDimVectorFromHint(op->getDiscardableAttr("tt.contiguity"),
+                                    &knownContiguity);
+    AxisInfo::initDimVectorFromHint(op->getDiscardableAttr("tt.constancy"),
+                                    &knownConstancy);
   }
 
   return AxisInfo(knownContiguity, knownDivisibility, knownConstancy);

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1054,12 +1054,12 @@ LogicalResult AxisInfoAnalysis::visitOperation(
   auto newContiguity = curr.getContiguity();
   auto newDivisibility = curr.getDivisibility();
   auto newConstancy = curr.getConstancy();
-  AxisInfo::initDimVectorFromHint(
-      op->getDiscardableAttr("tt.contiguity"), &newContiguity);
-  AxisInfo::initDimVectorFromHint(
-      op->getDiscardableAttr("tt.divisibility"), &newDivisibility);
-  AxisInfo::initDimVectorFromHint(
-      op->getDiscardableAttr("tt.constancy"), &newConstancy);
+  AxisInfo::initDimVectorFromHint(op->getDiscardableAttr("tt.contiguity"),
+                                  &newContiguity);
+  AxisInfo::initDimVectorFromHint(op->getDiscardableAttr("tt.divisibility"),
+                                  &newDivisibility);
+  AxisInfo::initDimVectorFromHint(op->getDiscardableAttr("tt.constancy"),
+                                  &newConstancy);
   curr = AxisInfo(newContiguity, newDivisibility, newConstancy,
                   curr.getConstantValue());
   // join all lattice elements

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -858,7 +858,7 @@ tt.func @tensor_ptr(%arg0: !tt.ptr<tensor<64x16xi32>, 1>) {
 
 // -----
 
-tt.func public @chained_for(%8: tensor<128x64x!tt.ptr<bf16>> {tt.divisibility = [16, 16] : i32}) {
+tt.func public @chained_for(%8: tensor<128x64x!tt.ptr<bf16>> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>}) {
   // expected-remark @below {{contiguity = [1, 1], divisibility = [1, 1], constancy = [1, 1], constant_value = <none>}}
   %cst = arith.constant dense<0.000000e+00> : tensor<128x64xbf16>
   // expected-remark @below {{contiguity = [1], divisibility = [16], constancy = [1], constant_value = 16}}

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -961,6 +961,8 @@ tt.func @if_into_for_step(%i1 : i1) {
 tt.func @op_annotation(%i32 : i32) {
   %c0 = arith.constant 0 : i32
   // expected-remark @below {{contiguity = [1], divisibility = [4096], constancy = [1], constant_value = <none>}}
-  %ret = arith.addi %c0, %i32 { tt.divisibility = 4096 : i32 } : i32
+  %ret0 = arith.addi %c0, %i32 { tt.divisibility = 4096 : i32 } : i32
+  // expected-remark @below {{contiguity = [1, 1], divisibility = [1024, 1024], constancy = [1, 1], constant_value = <none>}}
+  %ret1 = tt.splat %ret0 { tt.divisibility = dense<[1024, 1024]> : tensor<2xi32> } : i32 -> tensor<128x64xi32>
   tt.return
-}           
+}

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -955,3 +955,12 @@ tt.func @if_into_for_step(%i1 : i1) {
   }
   tt.return
 }
+
+// -----
+
+tt.func @op_annotation(%i32 : i32) {
+  %c0 = arith.constant 0 : i32
+  // expected-remark @below {{contiguity = [1], divisibility = [4096], constancy = [1], constant_value = <none>}}
+  %ret = arith.addi %c0, %i32 { tt.divisibility = 4096 : i32 } : i32
+  tt.return
+}           

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -858,7 +858,7 @@ tt.func @tensor_ptr(%arg0: !tt.ptr<tensor<64x16xi32>, 1>) {
 
 // -----
 
-tt.func public @chained_for(%8: tensor<128x64x!tt.ptr<bf16>> {tt.divisibility = 16 : i32}) {
+tt.func public @chained_for(%8: tensor<128x64x!tt.ptr<bf16>> {tt.divisibility = [16, 16] : i32}) {
   // expected-remark @below {{contiguity = [1, 1], divisibility = [1, 1], constancy = [1, 1], constant_value = <none>}}
   %cst = arith.constant dense<0.000000e+00> : tensor<128x64xbf16>
   // expected-remark @below {{contiguity = [1], divisibility = [16], constancy = [1], constant_value = 16}}

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -962,7 +962,7 @@ tt.func @op_annotation(%i32 : i32) {
   %c0 = arith.constant 0 : i32
   // expected-remark @below {{contiguity = [1], divisibility = [4096], constancy = [1], constant_value = <none>}}
   %ret0 = arith.addi %c0, %i32 { tt.divisibility = 4096 : i32 } : i32
-  // expected-remark @below {{contiguity = [1, 1], divisibility = [1024, 1024], constancy = [1, 1], constant_value = <none>}}
+  // expected-remark @below {{contiguity = [1, 1], divisibility = [1024, 1024], constancy = [128, 64], constant_value = <none>}}
   %ret1 = tt.splat %ret0 { tt.divisibility = dense<[1024, 1024]> : tensor<2xi32> } : i32 -> tensor<128x64xi32>
   tt.return
 }

--- a/test/TritonGPU/automatic-warp-specialization.mlir
+++ b/test/TritonGPU/automatic-warp-specialization.mlir
@@ -142,7 +142,7 @@ tt.func @matmul_tma_and_regular_load(
 
     %a = tt.descriptor_gather %a_desc[%indices, %off_k] : (!tt.tensordesc<tensor<1x64xf16, #shared>>, tensor<128xi32, #indices_layout>, i32) -> tensor<128x64xf16, #oper_layout>
 
-    %b_ptrs = tt.addptr %b_ptr, %offs_n {tt.divisibility = dense<[16, 16]> : tensor<64x128xi32>, tt.contiguity = dense<[1, 64]> : tensor<64x128xi32>, tt.constancy = dense<[1, 1]> : tensor<64x128xi32>} : tensor<64x128x!tt.ptr<f16>, #b_layout>, tensor<64x128xi32, #b_layout>
+    %b_ptrs = tt.addptr %b_ptr, %offs_n {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 64]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>} : tensor<64x128x!tt.ptr<f16>, #b_layout>, tensor<64x128xi32, #b_layout>
     %b = tt.load %b_ptrs : tensor<64x128x!tt.ptr<f16>, #b_layout>
 
     %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>

--- a/test/TritonGPU/automatic-warp-specialization.mlir
+++ b/test/TritonGPU/automatic-warp-specialization.mlir
@@ -117,7 +117,7 @@ tt.func @matmul_tma_acc_with_conditional_def_and_use(
 // CHECK-LABEL: @matmul_tma_and_regular_load
 tt.func @matmul_tma_and_regular_load(
   %a_desc: !tt.tensordesc<tensor<1x64xf16, #shared>>,
-  %b_ptr_init: tensor<64x128x!tt.ptr<f16>, #b_layout> {tt.divisibility = 16 : i32, tt.contiguity = 64 : i32}
+  %b_ptr_init: tensor<64x128x!tt.ptr<f16>, #b_layout> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 64]> : tensor<2xi32>}
 ) {
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
@@ -142,7 +142,7 @@ tt.func @matmul_tma_and_regular_load(
 
     %a = tt.descriptor_gather %a_desc[%indices, %off_k] : (!tt.tensordesc<tensor<1x64xf16, #shared>>, tensor<128xi32, #indices_layout>, i32) -> tensor<128x64xf16, #oper_layout>
 
-    %b_ptrs = tt.addptr %b_ptr, %offs_n {tt.divisibility = dense<16> : tensor<64x128xi32>, tt.contiguity = dense<64> : tensor<64x128xi32>, tt.constancy = dense<1> : tensor<64x128xi32>} : tensor<64x128x!tt.ptr<f16>, #b_layout>, tensor<64x128xi32, #b_layout>
+    %b_ptrs = tt.addptr %b_ptr, %offs_n {tt.divisibility = dense<[16, 16]> : tensor<64x128xi32>, tt.contiguity = dense<[1, 64]> : tensor<64x128xi32>, tt.constancy = dense<[1, 1]> : tensor<64x128xi32>} : tensor<64x128x!tt.ptr<f16>, #b_layout>, tensor<64x128xi32, #b_layout>
     %b = tt.load %b_ptrs : tensor<64x128x!tt.ptr<f16>, #b_layout>
 
     %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>

--- a/test/TritonGPU/loop-pipeline-blackwell.mlir
+++ b/test/TritonGPU/loop-pipeline-blackwell.mlir
@@ -35,7 +35,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK:   scf.yield %[[PHASE_NEXT]], %[[BAR_IDX_NEXT]], {{.*}}, %[[BAR_SLICE]], %[[PHASE]], %[[A_OP]], %[[B_OP]]
   // CHECK: ttg.local_dealloc %[[BAR_BUF]]
   // CHECK: ttng.tmem_load %[[TMEM_BUF]]
-  tt.func public @chained_dot_scaled_acc(%A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg3: i32) -> tensor<128x128xf16, #blocked> {
+  tt.func public @chained_dot_scaled_acc(%A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg3: i32) -> tensor<128x128xf16, #blocked> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %cst2 = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked>

--- a/test/TritonGPU/loop-pipeline-blackwell.mlir
+++ b/test/TritonGPU/loop-pipeline-blackwell.mlir
@@ -35,7 +35,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK:   scf.yield %[[PHASE_NEXT]], %[[BAR_IDX_NEXT]], {{.*}}, %[[BAR_SLICE]], %[[PHASE]], %[[A_OP]], %[[B_OP]]
   // CHECK: ttg.local_dealloc %[[BAR_BUF]]
   // CHECK: ttng.tmem_load %[[TMEM_BUF]]
-  tt.func public @chained_dot_scaled_acc(%A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg3: i32) -> tensor<128x128xf16, #blocked> {
+  tt.func public @chained_dot_scaled_acc(%A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg3: i32) -> tensor<128x128xf16, #blocked> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %cst2 = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked>

--- a/test/TritonGPU/loop-pipeline-hip.mlir
+++ b/test/TritonGPU/loop-pipeline-hip.mlir
@@ -752,7 +752,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // COMMON-LABEL: @reject_fp64_pipelining_with_async_copy_gfx942
 // ASYNC-NOT: ttg.async_copy_global_to_local
 tt.func @reject_fp64_pipelining_with_async_copy_gfx942(
-                  %a_ptr : tensor<128x32x!tt.ptr<f64>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %a_ptr : tensor<128x32x!tt.ptr<f64>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %B : tensor<32x128xf64, #B>, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf64, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf64, #C>
   %loop = scf.for %iv = %lb to %ub step %step iter_args(%prev_c = %c_init) -> (tensor<128x128xf64, #C>) : i32 {
@@ -782,8 +782,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // ASYNC: ttg.async_copy_global_to_local
 // ASYNC: tt.load
 tt.func @pipeline_fp64_with_async_copy_gfx950(
-                  %a_ptr : tensor<128x32x!tt.ptr<f64>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                  %b_ptr : tensor<32x128x!tt.ptr<f64>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 2] : tensor<2xi32>},
+                  %a_ptr : tensor<128x32x!tt.ptr<f64>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                  %b_ptr : tensor<32x128x!tt.ptr<f64>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 2]> : tensor<2xi32>},
                   %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf64, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf64, #C>
   %loop = scf.for %iv = %lb to %ub step %step iter_args(%prev_c = %c_init) -> (tensor<128x128xf64, #C>) : i32 {

--- a/test/TritonGPU/loop-pipeline-hip.mlir
+++ b/test/TritonGPU/loop-pipeline-hip.mlir
@@ -752,7 +752,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // COMMON-LABEL: @reject_fp64_pipelining_with_async_copy_gfx942
 // ASYNC-NOT: ttg.async_copy_global_to_local
 tt.func @reject_fp64_pipelining_with_async_copy_gfx942(
-                  %a_ptr : tensor<128x32x!tt.ptr<f64>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %a_ptr : tensor<128x32x!tt.ptr<f64>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %B : tensor<32x128xf64, #B>, %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf64, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf64, #C>
   %loop = scf.for %iv = %lb to %ub step %step iter_args(%prev_c = %c_init) -> (tensor<128x128xf64, #C>) : i32 {
@@ -782,8 +782,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // ASYNC: ttg.async_copy_global_to_local
 // ASYNC: tt.load
 tt.func @pipeline_fp64_with_async_copy_gfx950(
-                  %a_ptr : tensor<128x32x!tt.ptr<f64>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %b_ptr : tensor<32x128x!tt.ptr<f64>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 2 : i32},
+                  %a_ptr : tensor<128x32x!tt.ptr<f64>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %b_ptr : tensor<32x128x!tt.ptr<f64>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 2] : tensor<2xi32>},
                   %lb: i32, %ub: i32, %step: i32) -> tensor<128x128xf64, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf64, #C>
   %loop = scf.for %iv = %lb to %ub step %step iter_args(%prev_c = %c_init) -> (tensor<128x128xf64, #C>) : i32 {

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -618,7 +618,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // COMMON-LABEL: dot_prologue_epilogue
   // COMMON: {{.*}}, {{.*}}, %[[EXT:.*]]: i32, {{.*}}
-  tt.func @dot_prologue_epilogue(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %ext: i32, %inc: tensor<64x16xi32, #blocked> {tt.divisibility = 16 : i32}) -> tensor<128x16xf32, #mma1> {
+  tt.func @dot_prologue_epilogue(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %ext: i32, %inc: tensor<64x16xi32, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>}) -> tensor<128x16xf32, #mma1> {
     %cst = arith.constant dense<0> : tensor<64x16xi32, #blocked>
     %cst2 = arith.constant dense<0> : tensor<128x64xi32, #blocked1>
     %c0_i32 = arith.constant 0 : i32
@@ -691,7 +691,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-NOCANON-LABEL: pipeline_downstream_dependencies
   // CHECK-NOCANON: {{.*}}, {{.*}}, %[[EXT:.*]]: i32, {{.*}}
-  tt.func @pipeline_downstream_dependencies(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %ext: i32, %inc: tensor<64x16xi32, #blocked> {tt.divisibility = 16 : i32}) -> tensor<128x16xf32, #mma1> {
+  tt.func @pipeline_downstream_dependencies(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %ext: i32, %inc: tensor<64x16xi32, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>}) -> tensor<128x16xf32, #mma1> {
     %cst = arith.constant dense<0> : tensor<64x16xi32, #blocked>
     %cst1 = arith.constant dense<1> : tensor<64x16xi32, #blocked>
     %cst2 = arith.constant dense<0> : tensor<128x64xi32, #blocked1>

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -469,7 +469,7 @@ tt.func @indirect_bmm_scalar(%77: i64 {tt.divisibility=16: i32},
                    %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility=16: i32, tt.contiguity=2 : i32},
                    %75: !tt.ptr<i64>,
                    %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -522,10 +522,10 @@ tt.func @indirect_bmm_scalar(%77: i64 {tt.divisibility=16: i32},
 
 tt.func @indirect_bmm_scalar_dist_one(%77: i64 {tt.divisibility=16: i32},
                    %76: index,
-                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 2] : tensor<2xi32>},
+                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 2]> : tensor<2xi32>},
                    %75: !tt.ptr<i64>,
                    %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -621,10 +621,10 @@ tt.func @indirect_bmm_scalar_dist_one(%77: i64 {tt.divisibility=16: i32},
 
 tt.func @indirect_bmm_vector(%77: tensor<16x16xi64, #BL> {tt.divisibility=16: i32, tt.constancy=16: i32},
                    %76: index,
-                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 2] : tensor<2xi32>},
+                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 2]> : tensor<2xi32>},
                    %75: tensor<16x!tt.ptr<i64>, #BLs1>,
                    %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -1070,10 +1070,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 tt.func @indirect_load_shared_layout(%77: tensor<16x16xi64, #BL> {tt.divisibility=16: i32, tt.constancy=16: i32},
                    %76: index,
-                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 2] : tensor<2xi32>},
+                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 2]> : tensor<2xi32>},
                    %75: tensor<16x!tt.ptr<i64>, #BLs1>,
                    %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -1402,10 +1402,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 tt.func @load_convert_layout(%77: tensor<16x16xi64, #BL> {tt.divisibility=16: i32, tt.constancy=16: i32},
                    %76: index,
-                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 2] : tensor<2xi32>},
+                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 2]> : tensor<2xi32>},
                    %75: tensor<16x!tt.ptr<i64>, #BLs1>,
                    %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
   %1 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #BLs1>
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %cst_0 = arith.constant dense<2> : tensor<16xi32, #BLs1>
@@ -1711,7 +1711,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK: ttg.async_copy_global_to_local {{.*}} mask %[[FALSE]]
 // CHECK: scf.for
 tt.func @peeled_prologue_statically_dead(
-                  %a_ptr : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %a_ptr : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %B : tensor<32x128xf16, #B>) -> tensor<128x128xf32, #C> {
   %lb = arith.constant 0 : i32
   %ub = arith.constant 2 : i32

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -469,7 +469,7 @@ tt.func @indirect_bmm_scalar(%77: i64 {tt.divisibility=16: i32},
                    %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility=16: i32, tt.contiguity=2 : i32},
                    %75: !tt.ptr<i64>,
                    %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility=16: i32, tt.contiguity=16 : i32}) -> tensor<16x16xf32, #C>{
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -522,10 +522,10 @@ tt.func @indirect_bmm_scalar(%77: i64 {tt.divisibility=16: i32},
 
 tt.func @indirect_bmm_scalar_dist_one(%77: i64 {tt.divisibility=16: i32},
                    %76: index,
-                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility=16: i32, tt.contiguity=2 : i32},
+                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 2] : tensor<2xi32>},
                    %75: !tt.ptr<i64>,
                    %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility=16: i32, tt.contiguity=16 : i32}) -> tensor<16x16xf32, #C>{
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -621,10 +621,10 @@ tt.func @indirect_bmm_scalar_dist_one(%77: i64 {tt.divisibility=16: i32},
 
 tt.func @indirect_bmm_vector(%77: tensor<16x16xi64, #BL> {tt.divisibility=16: i32, tt.constancy=16: i32},
                    %76: index,
-                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility=16: i32, tt.contiguity=2 : i32},
+                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 2] : tensor<2xi32>},
                    %75: tensor<16x!tt.ptr<i64>, #BLs1>,
                    %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility=16: i32, tt.contiguity=16 : i32}) -> tensor<16x16xf32, #C>{
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -1070,10 +1070,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 tt.func @indirect_load_shared_layout(%77: tensor<16x16xi64, #BL> {tt.divisibility=16: i32, tt.constancy=16: i32},
                    %76: index,
-                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility=16: i32, tt.contiguity=2 : i32},
+                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 2] : tensor<2xi32>},
                    %75: tensor<16x!tt.ptr<i64>, #BLs1>,
                    %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility=16: i32, tt.contiguity=16 : i32}) -> tensor<16x16xf32, #C>{
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -1402,10 +1402,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 tt.func @load_convert_layout(%77: tensor<16x16xi64, #BL> {tt.divisibility=16: i32, tt.constancy=16: i32},
                    %76: index,
-                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility=16: i32, tt.contiguity=2 : i32},
+                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 2] : tensor<2xi32>},
                    %75: tensor<16x!tt.ptr<i64>, #BLs1>,
                    %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility=16: i32, tt.contiguity=16 : i32}) -> tensor<16x16xf32, #C>{
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
   %1 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #BLs1>
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %cst_0 = arith.constant dense<2> : tensor<16xi32, #BLs1>
@@ -1711,7 +1711,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK: ttg.async_copy_global_to_local {{.*}} mask %[[FALSE]]
 // CHECK: scf.for
 tt.func @peeled_prologue_statically_dead(
-                  %a_ptr : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %a_ptr : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %B : tensor<32x128xf16, #B>) -> tensor<128x128xf32, #C> {
   %lb = arith.constant 0 : i32
   %ub = arith.constant 2 : i32

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -466,10 +466,10 @@ tt.func @matmul_loop_single_pipeline(%lb : index, %ub : index, %step : index,
 //       AMD-DAG:     ttg.local_dealloc %[[LOCAL_ALLOC_1]]
 tt.func @indirect_bmm_scalar(%77: i64 {tt.divisibility=16: i32},
                    %76: index,
-                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility=16: i32, tt.contiguity=2 : i32},
+                   %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 2]> : tensor<2xi32>},
                    %75: !tt.ptr<i64>,
-                   %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
+                   %78: tensor<16x16xi32, #AL> {tt.constancy = dense<[16, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C> {
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -524,8 +524,8 @@ tt.func @indirect_bmm_scalar_dist_one(%77: i64 {tt.divisibility=16: i32},
                    %76: index,
                    %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 2]> : tensor<2xi32>},
                    %75: !tt.ptr<i64>,
-                   %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
+                   %78: tensor<16x16xi32, #AL> {tt.constancy = dense<[16, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C> {
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -619,12 +619,12 @@ tt.func @indirect_bmm_scalar_dist_one(%77: i64 {tt.divisibility=16: i32},
 
 // AMD_PREFETCH-LABEL: tt.func @indirect_bmm_vector
 
-tt.func @indirect_bmm_vector(%77: tensor<16x16xi64, #BL> {tt.divisibility=16: i32, tt.constancy=16: i32},
+tt.func @indirect_bmm_vector(%77: tensor<16x16xi64, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.constancy = dense<[16, 16]> : tensor<2xi32>},
                    %76: index,
                    %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 2]> : tensor<2xi32>},
                    %75: tensor<16x!tt.ptr<i64>, #BLs1>,
-                   %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
+                   %78: tensor<16x16xi32, #AL> {tt.constancy = dense<[16, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C> {
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -1068,12 +1068,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #A = #ttg.dot_op<{opIdx = 0, parent = #C, kWidth=2}>
 #B = #ttg.dot_op<{opIdx = 1, parent = #C, kWidth=2}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-tt.func @indirect_load_shared_layout(%77: tensor<16x16xi64, #BL> {tt.divisibility=16: i32, tt.constancy=16: i32},
+tt.func @indirect_load_shared_layout(%77: tensor<16x16xi64, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.constancy = dense<[16, 16]> : tensor<2xi32>},
                    %76: index,
                    %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 2]> : tensor<2xi32>},
                    %75: tensor<16x!tt.ptr<i64>, #BLs1>,
-                   %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
+                   %78: tensor<16x16xi32, #AL> {tt.constancy = dense<[16, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C> {
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %c4_i32 = arith.constant 4 : i32
   %c1 = arith.constant 1 : index
@@ -1400,12 +1400,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 #B = #ttg.dot_op<{opIdx = 1, parent = #C, kWidth=2}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-tt.func @load_convert_layout(%77: tensor<16x16xi64, #BL> {tt.divisibility=16: i32, tt.constancy=16: i32},
+tt.func @load_convert_layout(%77: tensor<16x16xi64, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.constancy = dense<[16, 16]> : tensor<2xi32>},
                    %76: index,
                    %49: tensor<16x16x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 2]> : tensor<2xi32>},
                    %75: tensor<16x!tt.ptr<i64>, #BLs1>,
-                   %78: tensor<16x16xi32, #AL> {tt.constancy=16: i32, tt.divisibility=16: i32},
-                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C>{
+                   %78: tensor<16x16xi32, #AL> {tt.constancy = dense<[16, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
+                   %60: tensor<16x16x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<16x16xf32, #C> {
   %1 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #BLs1>
   %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #C>
   %cst_0 = arith.constant dense<2> : tensor<16xi32, #BLs1>

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -297,8 +297,8 @@ tt.func @indirect_load_few_stages(%lb : index, %ub : index, %step : index,
     %b_off = tt.load %b_ind_ptr : tensor<32x128x!tt.ptr<i32>, #BL>
     %next_a_ind_ptr = tt.addptr %a_ind_ptr, %a_ind_off : tensor<128x32x!tt.ptr<i32>, #AL>, tensor<128x32xi32, #AL>
     %next_b_ind_ptr = tt.addptr %b_ind_ptr, %b_ind_off : tensor<32x128x!tt.ptr<i32>, #BL>, tensor<32x128xi32, #BL>
-    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<128x32xi32>, tt.contiguity = dense<[1, 32]> : tensor<128x32xi32>, tt.constancy = dense<[1, 1]> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
-    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<[16, 16]> : tensor<32x128xi32>, tt.contiguity = dense<[1, 32]> : tensor<32x128xi32>, tt.constancy = dense<[1, 1]> : tensor<32x128xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
+    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
     // CHECK: tt.load {{.*}} {tt.latency = 1 : i32}
     %a_ = tt.load %next_a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
     %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A>

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -263,8 +263,8 @@ tt.func @indirect_load_cust_stages(%lb : index, %ub : index, %step : index,
     %b_off = tt.load %b_ind_ptr : tensor<32x128x!tt.ptr<i32>, #BL>
     %next_a_ind_ptr = tt.addptr %a_ind_ptr, %a_ind_off : tensor<128x32x!tt.ptr<i32>, #AL>, tensor<128x32xi32, #AL>
     %next_b_ind_ptr = tt.addptr %b_ind_ptr, %b_ind_off : tensor<32x128x!tt.ptr<i32>, #BL>, tensor<32x128xi32, #BL>
-    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<128x32xi32>, tt.contiguity = dense<[1, 32]> : tensor<128x32xi32>, tt.constancy = dense<[1, 1]> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
-    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<[16, 16]> : tensor<32x128xi32>, tt.contiguity = dense<[1, 32]> : tensor<32x128xi32>, tt.constancy = dense<[1, 1]> : tensor<32x128xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
+    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
     // CHECK: tt.load {{.*}} {tt.latency = 2 : i32}
     %a_ = tt.load %next_a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
     %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A>

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -13,8 +13,8 @@
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @default_stages
 tt.func @default_stages(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x128xf32, #C> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -39,7 +39,7 @@ tt.func @default_stages(%lb : index, %ub : index, %step : index,
 // CHECK-LABEL: @small_load
 // We should *not* assign latency to the load of b_ptr.
 tt.func @small_load(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
                   %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL>) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
@@ -65,8 +65,8 @@ tt.func @small_load(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @load_into_shared
 tt.func @load_into_shared(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x128xf32, #mma> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #mma> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #mma>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -90,8 +90,8 @@ tt.func @load_into_shared(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @load_into_lt_4b
 tt.func @load_into_lt_4b(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x128xf32, #mma> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #mma> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #mma>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -117,8 +117,8 @@ tt.func @load_into_lt_4b(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @intermediate_use
 tt.func @intermediate_use(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x128xf32, #C> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -144,10 +144,10 @@ tt.func @intermediate_use(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @indirect_load
 tt.func @indirect_load(%lb : index, %ub : index, %step : index,
-                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x128xf32, #C> {
+                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_ind_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_ind_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -176,9 +176,9 @@ tt.func @indirect_load(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @mixed_loads
 tt.func @mixed_loads(%lb : index, %ub : index, %step : index,
-                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x128xf32, #C> {
+                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_ind_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -204,8 +204,8 @@ tt.func @mixed_loads(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @per_loop_stages
 tt.func @per_loop_stages(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> (tensor<128x128xf32, #C>, tensor<128x128xf32, #C>) {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> (tensor<128x128xf32, #C>, tensor<128x128xf32, #C>) {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -248,10 +248,10 @@ tt.func @per_loop_stages(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @indirect_load_cust_stages
 tt.func @indirect_load_cust_stages(%lb : index, %ub : index, %step : index,
-                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x128xf32, #C> {
+                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_ind_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_ind_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -280,10 +280,10 @@ tt.func @indirect_load_cust_stages(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @indirect_load_few_stages
 tt.func @indirect_load_few_stages(%lb : index, %ub : index, %step : index,
-                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x128xf32, #C> {
+                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_ind_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_ind_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -314,7 +314,7 @@ tt.func @indirect_load_few_stages(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @non_dot_pipeline
 tt.func @non_dot_pipeline(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x32xf16, #A> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x32xf16, #A> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x32xf16, #A>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
 
@@ -333,7 +333,7 @@ tt.func @non_dot_pipeline(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @no_pipeline
 tt.func @no_pipeline(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x32xf16, #A> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x32xf16, #A> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x32xf16, #A>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
 
@@ -353,8 +353,8 @@ tt.func @no_pipeline(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @intermediate_use
 tt.func @intermediate_use_cust_stages(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = 16 : i32, tt.contiguity = 32 : i32}) -> tensor<128x128xf32, #C> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -389,8 +389,8 @@ tt.func @intermediate_use_cust_stages(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_overwrite_acc
 tt.func @tc_gen5_mma_overwrite_acc(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -421,8 +421,8 @@ tt.func @tc_gen5_mma_overwrite_acc(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_acc_use_false
 tt.func @tc_gen5_mma_acc_use_false(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %false = arith.constant false
@@ -453,8 +453,8 @@ tt.func @tc_gen5_mma_acc_use_false(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_acc_use_false
 tt.func @tc_gen5_mma_acc_use_false(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>,
                   %acc_use_init : i1) -> () {
   %true = arith.constant true
@@ -487,8 +487,8 @@ tt.func @tc_gen5_mma_acc_use_false(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_acc_use_false_dist_1
 tt.func @tc_gen5_mma_acc_use_false_dist_1(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>,
                   %acc_use_init : i1) -> () {
   %true = arith.constant true
@@ -522,8 +522,8 @@ tt.func @tc_gen5_mma_acc_use_false_dist_1(%lb : index, %ub : index, %step : inde
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_acc_use_false_outside_loop
 tt.func @tc_gen5_mma_acc_use_false_outside_loop(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>,
                   %acc_use_init : i1) -> () {
   %true = arith.constant true
@@ -556,8 +556,8 @@ tt.func @tc_gen5_mma_acc_use_false_outside_loop(%lb : index, %ub : index, %step 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_overwrite_acc_outside_loop
 tt.func @tc_gen5_mma_overwrite_acc_outside_loop(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -624,7 +624,7 @@ tt.func @tc_gen5_mma_overwrite_acc_small_load(%lb : index, %ub : index, %step : 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_B_outside
 tt.func @tc_gen5_mma_B_outside(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %B: tensor<128x128xf16, #blocked1>,
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
@@ -653,7 +653,7 @@ tt.func @tc_gen5_mma_B_outside(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_disallow_multibuffer
 tt.func @tc_gen5_mma_disallow_multibuffer(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %B: tensor<128x128xf16, #blocked1>,
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
@@ -682,7 +682,7 @@ tt.func @tc_gen5_mma_disallow_multibuffer(%lb : index, %ub : index, %step : inde
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_B_outside2
 tt.func @tc_gen5_mma_B_outside2(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %B_sh: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>,
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
@@ -710,7 +710,7 @@ tt.func @tc_gen5_mma_B_outside2(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_non_load_operand1
 tt.func @tc_gen5_mma_non_load_operand1(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -740,7 +740,7 @@ tt.func @tc_gen5_mma_non_load_operand1(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_non_load_operand2
 tt.func @tc_gen5_mma_non_load_operand2(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -769,7 +769,7 @@ tt.func @tc_gen5_mma_non_load_operand2(%lb : index, %ub : index, %step : index,
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @select_after_mma
-  tt.func public @select_after_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @select_after_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %cst_0 = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -808,8 +808,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_scaled
 tt.func @tc_gen5_mma_scaled(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
                   %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
@@ -851,10 +851,10 @@ tt.func @tc_gen5_mma_scaled(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_scaled_tmem_scales
 tt.func @tc_gen5_mma_scaled_tmem_scales(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %A_sc_ptr: tensor<128x8x!tt.ptr<i8>, #scales> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %B_sc_ptr: tensor<128x8x!tt.ptr<i8>, #scales> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_sc_ptr: tensor<128x8x!tt.ptr<i8>, #scales> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %B_sc_ptr: tensor<128x8x!tt.ptr<i8>, #scales> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -955,7 +955,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @two_dots
-  tt.func public @two_dots(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg4: i32) {
+  tt.func public @two_dots(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i32) {
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -992,7 +992,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @changed_acc_before_mma
-  tt.func public @changed_acc_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @changed_acc_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %cst_0 = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked1>

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -187,7 +187,7 @@ tt.func @mixed_loads(%lb : index, %ub : index, %step : index,
     // CHECK: tt.load {{.*}} {tt.latency = 1 : i32}
     %a_off = tt.load %a_ind_ptr : tensor<128x32x!tt.ptr<i32>, #AL>
     %next_a_ind_ptr = tt.addptr %a_ind_ptr, %a_ind_off : tensor<128x32x!tt.ptr<i32>, #AL>, tensor<128x32xi32, #AL>
-    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<128x32xi32>, tt.contiguity = dense<[1, 32]> : tensor<128x32xi32>, tt.constancy = dense<[1, 1]> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
     %next_b_ptr = tt.addptr %b_ptr, %b_off : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
     // CHECK: tt.load {{.*}} {tt.latency = 1 : i32}
     %a_ = tt.load %next_a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -159,8 +159,8 @@ tt.func @indirect_load(%lb : index, %ub : index, %step : index,
     %b_off = tt.load %b_ind_ptr : tensor<32x128x!tt.ptr<i32>, #BL>
     %next_a_ind_ptr = tt.addptr %a_ind_ptr, %a_ind_off : tensor<128x32x!tt.ptr<i32>, #AL>, tensor<128x32xi32, #AL>
     %next_b_ind_ptr = tt.addptr %b_ind_ptr, %b_ind_off : tensor<32x128x!tt.ptr<i32>, #BL>, tensor<32x128xi32, #BL>
-    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<128x32xi32>, tt.contiguity = dense<[1, 32]> : tensor<128x32xi32>, tt.constancy = dense<[1, 1]> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
-    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<[16, 16]> : tensor<32x128xi32>, tt.contiguity = dense<[1, 32]> : tensor<32x128xi32>, tt.constancy = dense<[1, 1]> : tensor<32x128xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
+    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
     // CHECK: tt.load {{.*}} {tt.latency = 1 : i32}
     %a_ = tt.load %next_a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
     %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A>

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -159,8 +159,8 @@ tt.func @indirect_load(%lb : index, %ub : index, %step : index,
     %b_off = tt.load %b_ind_ptr : tensor<32x128x!tt.ptr<i32>, #BL>
     %next_a_ind_ptr = tt.addptr %a_ind_ptr, %a_ind_off : tensor<128x32x!tt.ptr<i32>, #AL>, tensor<128x32xi32, #AL>
     %next_b_ind_ptr = tt.addptr %b_ind_ptr, %b_ind_off : tensor<32x128x!tt.ptr<i32>, #BL>, tensor<32x128xi32, #BL>
-    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<16> : tensor<128x32xi32>, tt.contiguity = dense<32> : tensor<128x32xi32>, tt.constancy = dense<1> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
-    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<16> : tensor<32x128xi32>, tt.contiguity = dense<32> : tensor<32x128xi32>, tt.constancy = dense<1> : tensor<32x128xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
+    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<128x32xi32>, tt.contiguity = dense<[1, 32]> : tensor<128x32xi32>, tt.constancy = dense<[1, 1]> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<[16, 16]> : tensor<32x128xi32>, tt.contiguity = dense<[1, 32]> : tensor<32x128xi32>, tt.constancy = dense<[1, 1]> : tensor<32x128xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
     // CHECK: tt.load {{.*}} {tt.latency = 1 : i32}
     %a_ = tt.load %next_a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
     %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A>
@@ -187,7 +187,7 @@ tt.func @mixed_loads(%lb : index, %ub : index, %step : index,
     // CHECK: tt.load {{.*}} {tt.latency = 1 : i32}
     %a_off = tt.load %a_ind_ptr : tensor<128x32x!tt.ptr<i32>, #AL>
     %next_a_ind_ptr = tt.addptr %a_ind_ptr, %a_ind_off : tensor<128x32x!tt.ptr<i32>, #AL>, tensor<128x32xi32, #AL>
-    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<16> : tensor<128x32xi32>, tt.contiguity = dense<32> : tensor<128x32xi32>, tt.constancy = dense<1> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<128x32xi32>, tt.contiguity = dense<[1, 32]> : tensor<128x32xi32>, tt.constancy = dense<[1, 1]> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
     %next_b_ptr = tt.addptr %b_ptr, %b_off : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
     // CHECK: tt.load {{.*}} {tt.latency = 1 : i32}
     %a_ = tt.load %next_a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
@@ -263,8 +263,8 @@ tt.func @indirect_load_cust_stages(%lb : index, %ub : index, %step : index,
     %b_off = tt.load %b_ind_ptr : tensor<32x128x!tt.ptr<i32>, #BL>
     %next_a_ind_ptr = tt.addptr %a_ind_ptr, %a_ind_off : tensor<128x32x!tt.ptr<i32>, #AL>, tensor<128x32xi32, #AL>
     %next_b_ind_ptr = tt.addptr %b_ind_ptr, %b_ind_off : tensor<32x128x!tt.ptr<i32>, #BL>, tensor<32x128xi32, #BL>
-    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<16> : tensor<128x32xi32>, tt.contiguity = dense<32> : tensor<128x32xi32>, tt.constancy = dense<1> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
-    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<16> : tensor<32x128xi32>, tt.contiguity = dense<32> : tensor<32x128xi32>, tt.constancy = dense<1> : tensor<32x128xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
+    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<128x32xi32>, tt.contiguity = dense<[1, 32]> : tensor<128x32xi32>, tt.constancy = dense<[1, 1]> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<[16, 16]> : tensor<32x128xi32>, tt.contiguity = dense<[1, 32]> : tensor<32x128xi32>, tt.constancy = dense<[1, 1]> : tensor<32x128xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
     // CHECK: tt.load {{.*}} {tt.latency = 2 : i32}
     %a_ = tt.load %next_a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
     %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A>
@@ -297,8 +297,8 @@ tt.func @indirect_load_few_stages(%lb : index, %ub : index, %step : index,
     %b_off = tt.load %b_ind_ptr : tensor<32x128x!tt.ptr<i32>, #BL>
     %next_a_ind_ptr = tt.addptr %a_ind_ptr, %a_ind_off : tensor<128x32x!tt.ptr<i32>, #AL>, tensor<128x32xi32, #AL>
     %next_b_ind_ptr = tt.addptr %b_ind_ptr, %b_ind_off : tensor<32x128x!tt.ptr<i32>, #BL>, tensor<32x128xi32, #BL>
-    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<16> : tensor<128x32xi32>, tt.contiguity = dense<32> : tensor<128x32xi32>, tt.constancy = dense<1> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
-    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<16> : tensor<32x128xi32>, tt.contiguity = dense<32> : tensor<32x128xi32>, tt.constancy = dense<1> : tensor<32x128xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
+    %next_a_ptr = tt.addptr %a_ptr, %a_off {tt.divisibility = dense<[16, 16]> : tensor<128x32xi32>, tt.contiguity = dense<[1, 32]> : tensor<128x32xi32>, tt.constancy = dense<[1, 1]> : tensor<128x32xi32>} : tensor<128x32x!tt.ptr<f16>, #AL>, tensor<128x32xi32, #AL>
+    %next_b_ptr = tt.addptr %b_ptr, %b_off {tt.divisibility = dense<[16, 16]> : tensor<32x128xi32>, tt.contiguity = dense<[1, 32]> : tensor<32x128xi32>, tt.constancy = dense<[1, 1]> : tensor<32x128xi32>} : tensor<32x128x!tt.ptr<f16>, #BL>, tensor<32x128xi32, #BL>
     // CHECK: tt.load {{.*}} {tt.latency = 1 : i32}
     %a_ = tt.load %next_a_ptr : tensor<128x32x!tt.ptr<f16>, #AL>
     %a = ttg.convert_layout %a_ : tensor<128x32xf16, #AL> -> tensor<128x32xf16, #A>
@@ -810,8 +810,8 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 tt.func @tc_gen5_mma_scaled(%lb : index, %ub : index, %step : index,
                   %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
-                  %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                  %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                  %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = dense<[16, 16, 16, 16, 16]> : tensor<5xi32>, tt.contiguity = dense<[1, 1, 1, 1, 1]> : tensor<5xi32>},
+                  %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = dense<[16, 16, 16, 16, 16]> : tensor<5xi32>, tt.contiguity = dense<[1, 1, 1, 1, 1]> : tensor<5xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -13,8 +13,8 @@
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @default_stages
 tt.func @default_stages(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -39,7 +39,7 @@ tt.func @default_stages(%lb : index, %ub : index, %step : index,
 // CHECK-LABEL: @small_load
 // We should *not* assign latency to the load of b_ptr.
 tt.func @small_load(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
                   %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL>) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
@@ -65,8 +65,8 @@ tt.func @small_load(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @load_into_shared
 tt.func @load_into_shared(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #mma> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x128xf32, #mma> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #mma>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -90,8 +90,8 @@ tt.func @load_into_shared(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @load_into_lt_4b
 tt.func @load_into_lt_4b(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #mma> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x128xf32, #mma> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #mma>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -117,8 +117,8 @@ tt.func @load_into_lt_4b(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @intermediate_use
 tt.func @intermediate_use(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -144,10 +144,10 @@ tt.func @intermediate_use(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @indirect_load
 tt.func @indirect_load(%lb : index, %ub : index, %step : index,
-                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
+                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_ind_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_ind_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -176,9 +176,9 @@ tt.func @indirect_load(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @mixed_loads
 tt.func @mixed_loads(%lb : index, %ub : index, %step : index,
-                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
+                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_ind_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -204,8 +204,8 @@ tt.func @mixed_loads(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @per_loop_stages
 tt.func @per_loop_stages(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> (tensor<128x128xf32, #C>, tensor<128x128xf32, #C>) {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> (tensor<128x128xf32, #C>, tensor<128x128xf32, #C>) {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -248,10 +248,10 @@ tt.func @per_loop_stages(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @indirect_load_cust_stages
 tt.func @indirect_load_cust_stages(%lb : index, %ub : index, %step : index,
-                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
+                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_ind_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_ind_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -280,10 +280,10 @@ tt.func @indirect_load_cust_stages(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @indirect_load_few_stages
 tt.func @indirect_load_few_stages(%lb : index, %ub : index, %step : index,
-                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
+                  %a_ind_ptr_init : tensor<128x32x!tt.ptr<i32>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ind_ptr_init : tensor<32x128x!tt.ptr<i32>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_ind_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_ind_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -314,7 +314,7 @@ tt.func @indirect_load_few_stages(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @non_dot_pipeline
 tt.func @non_dot_pipeline(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x32xf16, #A> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x32xf16, #A> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x32xf16, #A>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
 
@@ -333,7 +333,7 @@ tt.func @non_dot_pipeline(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @no_pipeline
 tt.func @no_pipeline(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x32xf16, #A> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x32xf16, #A> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x32xf16, #A>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
 
@@ -353,8 +353,8 @@ tt.func @no_pipeline(%lb : index, %ub : index, %step : index,
 
 // CHECK-LABEL: @intermediate_use
 tt.func @intermediate_use_cust_stages(%lb : index, %ub : index, %step : index,
-                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>},
-                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 32] : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
+                  %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #AL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>},
+                  %b_ptr_init : tensor<32x128x!tt.ptr<f16>, #BL> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 32]> : tensor<2xi32>}) -> tensor<128x128xf32, #C> {
   %c_init = arith.constant dense<0.00e+00> : tensor<128x128xf32, #C>
   %a_off = arith.constant dense<4> : tensor<128x32xi32, #AL>
   %b_off = arith.constant dense<4> : tensor<32x128xi32, #BL>
@@ -389,8 +389,8 @@ tt.func @intermediate_use_cust_stages(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_overwrite_acc
 tt.func @tc_gen5_mma_overwrite_acc(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -421,8 +421,8 @@ tt.func @tc_gen5_mma_overwrite_acc(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_acc_use_false
 tt.func @tc_gen5_mma_acc_use_false(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %false = arith.constant false
@@ -453,8 +453,8 @@ tt.func @tc_gen5_mma_acc_use_false(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_acc_use_false
 tt.func @tc_gen5_mma_acc_use_false(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>,
                   %acc_use_init : i1) -> () {
   %true = arith.constant true
@@ -487,8 +487,8 @@ tt.func @tc_gen5_mma_acc_use_false(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_acc_use_false_dist_1
 tt.func @tc_gen5_mma_acc_use_false_dist_1(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>,
                   %acc_use_init : i1) -> () {
   %true = arith.constant true
@@ -522,8 +522,8 @@ tt.func @tc_gen5_mma_acc_use_false_dist_1(%lb : index, %ub : index, %step : inde
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_acc_use_false_outside_loop
 tt.func @tc_gen5_mma_acc_use_false_outside_loop(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>,
                   %acc_use_init : i1) -> () {
   %true = arith.constant true
@@ -556,8 +556,8 @@ tt.func @tc_gen5_mma_acc_use_false_outside_loop(%lb : index, %ub : index, %step 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_overwrite_acc_outside_loop
 tt.func @tc_gen5_mma_overwrite_acc_outside_loop(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -624,7 +624,7 @@ tt.func @tc_gen5_mma_overwrite_acc_small_load(%lb : index, %ub : index, %step : 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_B_outside
 tt.func @tc_gen5_mma_B_outside(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %B: tensor<128x128xf16, #blocked1>,
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
@@ -653,7 +653,7 @@ tt.func @tc_gen5_mma_B_outside(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_disallow_multibuffer
 tt.func @tc_gen5_mma_disallow_multibuffer(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %B: tensor<128x128xf16, #blocked1>,
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
@@ -682,7 +682,7 @@ tt.func @tc_gen5_mma_disallow_multibuffer(%lb : index, %ub : index, %step : inde
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_B_outside2
 tt.func @tc_gen5_mma_B_outside2(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %B_sh: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>,
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
@@ -710,7 +710,7 @@ tt.func @tc_gen5_mma_B_outside2(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_non_load_operand1
 tt.func @tc_gen5_mma_non_load_operand1(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -740,7 +740,7 @@ tt.func @tc_gen5_mma_non_load_operand1(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_non_load_operand2
 tt.func @tc_gen5_mma_non_load_operand2(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -769,7 +769,7 @@ tt.func @tc_gen5_mma_non_load_operand2(%lb : index, %ub : index, %step : index,
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @select_after_mma
-  tt.func public @select_after_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @select_after_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %cst_0 = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -808,8 +808,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_scaled
 tt.func @tc_gen5_mma_scaled(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
                   %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
@@ -851,10 +851,10 @@ tt.func @tc_gen5_mma_scaled(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @tc_gen5_mma_scaled_tmem_scales
 tt.func @tc_gen5_mma_scaled_tmem_scales(%lb : index, %ub : index, %step : index,
-                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                  %A_sc_ptr: tensor<128x8x!tt.ptr<i8>, #scales> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                  %B_sc_ptr: tensor<128x8x!tt.ptr<i8>, #scales> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                  %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                  %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                  %A_sc_ptr: tensor<128x8x!tt.ptr<i8>, #scales> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                  %B_sc_ptr: tensor<128x8x!tt.ptr<i8>, #scales> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
@@ -955,7 +955,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @two_dots
-  tt.func public @two_dots(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i32) {
+  tt.func public @two_dots(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg4: i32) {
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -992,7 +992,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @changed_acc_before_mma
-  tt.func public @changed_acc_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @changed_acc_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %cst_0 = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked1>

--- a/test/TritonGPU/pipeline-assign-latencies.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies.mlir
@@ -810,8 +810,8 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 tt.func @tc_gen5_mma_scaled(%lb : index, %ub : index, %step : index,
                   %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                   %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
-                  %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = dense<[16, 16, 16, 16, 16]> : tensor<5xi32>, tt.contiguity = dense<[1, 1, 1, 1, 1]> : tensor<5xi32>},
-                  %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = dense<[16, 16, 16, 16, 16]> : tensor<5xi32>, tt.contiguity = dense<[1, 1, 1, 1, 1]> : tensor<5xi32>},
+                  %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = dense<[16, 16, 16, 16, 16]> : tensor<5xi32>, tt.contiguity = dense<[1, 1, 1, 1, 16]> : tensor<5xi32>},
+                  %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = dense<[16, 16, 16, 16, 16]> : tensor<5xi32>, tt.contiguity = dense<[1, 1, 1, 1, 16]> : tensor<5xi32>},
                   %acc_init : tensor<128x128xf32, #blocked1>) -> () {
   %true = arith.constant true
   %acc_tm = ttng.tmem_alloc %acc_init : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -187,7 +187,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK: scf.for
 // CHECK:   tt.load {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 tt.func @one_dep_sync(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<1x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16]> : tensor<1xi32>, tt.contiguity = dense<[16]> : tensor<ixi32>}) -> () {
+                 %a_ptr_init : tensor<1x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16]> : tensor<1xi32>, tt.contiguity = dense<[16]> : tensor<1xi32>}) -> () {
   scf.for %iv = %lb to %ub step %step : index {
     %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<1x!tt.ptr<f16>, #A>
     "use"(%a) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<1xf16, #A>) -> ()

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -48,7 +48,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-DAG:   ttg.async_wait  {num = 0 : i32}
 
 tt.func @one_dep_async(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
   scf.for %iv = %lb to %ub step %step : index {
     %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
     "use"(%a) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x32xf16, #A>) -> ()
@@ -67,7 +67,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @one_dep_barrier_wait
 // CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x128x64
 tt.func @one_dep_barrier_wait(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                 %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                  %bar : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>,
                  %phase : i32) -> () {
   scf.for %iv = %lb to %ub step %step : index {
@@ -91,7 +91,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @one_dep_barrier_wait_trans
 // CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x128x64
 tt.func @one_dep_barrier_wait_trans(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                 %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                  %bar : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>,
                  %phase : i32) -> () {
   scf.for %iv = %lb to %ub step %step : index {
@@ -119,7 +119,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK:   "use1"(%[[A_VAL]]) {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 // CHECK:   "use2"(%[[A_VAL]]) {loop.cluster = 0 : i32, loop.stage = 3 : i32}
 tt.func @different_use_stages(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
   scf.for %iv = %lb to %ub step %step : index {
     %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
     "use1"(%a) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x32xf16, #A>) -> ()
@@ -144,7 +144,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK:   "use"{{.*}} {loop.cluster = 0 : i32, loop.stage = 3 : i32}
 
 tt.func @used_by_if_yield(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                  %init_a : tensor<128x32xf16, #A>,
                  %cnd : i1) -> () {
   scf.for %iv = %lb to %ub step %step : index {
@@ -166,7 +166,7 @@ tt.func @used_by_if_yield(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @dist1_load
 tt.func @dist1_load(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                  %init_a : tensor<128x32xf16, #A>) -> () {
   %_ = scf.for %iv = %lb to %ub step %step iter_args(%prev_a = %init_a) -> (tensor<128x32xf16, #A>) : index {
     "use_next_iter"(%prev_a) {loop.cluster = 2 : i32, loop.stage = 0 : i32} : (tensor<128x32xf16, #A>) -> ()
@@ -226,7 +226,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-DAG:   ttg.local_dealloc %[[A]]
 // CHECK-DAG:   ttg.async_wait  {num = 0 : i32}
 tt.func @one_dep_local_alloc(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
   scf.for %iv = %lb to %ub step %step : index {
     %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
     %a_alloc = ttg.local_alloc %a {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x32xf16, #A>) -> !ttg.memdesc<128x32xf16, #shared, #ttg.shared_memory, mutable>
@@ -244,8 +244,8 @@ tt.func @one_dep_local_alloc(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @one_load_group
 tt.func @one_load_group(%lb : index, %ub : index, %step : index,
-                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                       %b_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
+                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                       %b_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
   // CHECK-DAG: %[[MINUS_ONE:.*]] = arith.constant -1
   // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0
   // CHECK-DAG: %[[ONE:.*]] = arith.constant 1
@@ -275,9 +275,9 @@ tt.func @one_load_group(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @two_load_groups
 tt.func @two_load_groups(%lb : index, %ub : index, %step : index,
-                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                       %b_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                       %c_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
+                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                       %b_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                       %c_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
   // CHECK-DAG: %[[MINUS_ONE:.*]] = arith.constant -1
   // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0
   // CHECK-DAG: %[[ONE:.*]] = arith.constant 1
@@ -316,7 +316,7 @@ tt.func @two_load_groups(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @dependent_loads
 tt.func @dependent_loads(%lb : index, %ub : index, %step : index,
-                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
+                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
   // CHECK-DAG: %[[MINUS_ONE:.*]] = arith.constant -1
   // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0
   // CHECK-DAG: %[[ONE:.*]] = arith.constant 1
@@ -366,7 +366,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @dependent_loads_asymmetric
 // Loads have different latencies, should create two load groups.
 tt.func @dependent_loads_asymmetric(%lb : index, %ub : index, %step : index,
-                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
+                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
   // CHECK-DAG: %[[MINUS_ONE:.*]] = arith.constant -1
   // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0
   // CHECK-DAG: %[[ONE:.*]] = arith.constant 1
@@ -422,7 +422,7 @@ tt.func @dependent_loads_asymmetric(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @unused_load
 tt.func @unused_load(%lb : index, %ub : index, %step : index,
-                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
+                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> () {
   // CHECK: scf.for
   scf.for %iv = %lb to %ub step %step : index {
     // CHECK: dummy
@@ -472,8 +472,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-DAG: ttg.local_dealloc %[[B]]
   // CHECK-DAG: ttg.async_wait  {num = 0 : i32}
   tt.func public @shmem_pipelining_mmav3(%lb : index, %ub : index, %step : index,
-                                              %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                                              %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<128x128xf16, #mma> {
+                                              %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                                              %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<128x128xf16, #mma> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
     %c0_i32 = arith.constant 0 : i32
@@ -528,8 +528,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-DAG:   ttg.async_wait  {num = 0 : i32}
   tt.func public @no_shmem_pipelining_incompat_layout(
                     %lb : index, %ub : index, %step : index,
-                    %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                    %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<128x128xf32, #mma> {
+                    %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                    %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<128x128xf32, #mma> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
     %c0_i32 = arith.constant 0 : i32
@@ -592,8 +592,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-DAG: ttg.async_wait  {num = 0 : i32}
   tt.func public @no_shmem_pipelining_other_used(
                       %lb : index, %ub : index, %step : index,
-                      %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                      %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                      %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                      %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                       %mask: tensor<128x128xi1, #blocked1> {tt.constancy = 128 : i32},
                       %other: tensor<128x128xf16, #blocked1> {tt.constancy = 128 : i32}) -> tensor<128x128xf16, #mma> {
     %true = arith.constant true
@@ -670,8 +670,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-DAG: ttg.local_dealloc %[[BAR]]
   // CHECK-DAG: ttg.async_wait {num = 0 : i32}
   tt.func public @shmem_pipelining_mmav5(%lb : index, %ub : index, %step : index,
-                                              %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                                              %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<128x128xf16, #blocked> {
+                                              %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                                              %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>}) -> tensor<128x128xf16, #blocked> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %c0_i32 = arith.constant 0 : i32
@@ -927,8 +927,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x1x2x32x4x4xi8
   // CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x1x2x32x4x4xi8
   tt.func public @pipelining_mmav5_scaled(%lb : index, %ub : index, %step : index,
-                                              %A_ptr: tensor<128x128x!tt.ptr<f8E5M2>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
-                                              %B_ptr: tensor<128x128x!tt.ptr<f8E5M2>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                                              %A_ptr: tensor<128x128x!tt.ptr<f8E5M2>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
+                                              %B_ptr: tensor<128x128x!tt.ptr<f8E5M2>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                                               %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
                                               %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> tensor<128x128xf32, #blocked1> {
     %true = arith.constant true
@@ -964,7 +964,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @cnd_store_before_mma
-  tt.func public @cnd_store_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @cnd_store_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %cst_0 = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -1041,7 +1041,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: } {tt.scheduled_max_stage = 3 : i32}
   // CHECK: %[[ACC_TM_SLICE:.*]] = ttg.memdesc_index %[[ACC_TM]]{{\[}}%[[FOR_RES]]#2{{\]}}
   // CHECK: %[[LOAD_ACC:.*]], %[[RES_TOK:.*]] = ttng.tmem_load %[[ACC_TM_SLICE]][]
-  tt.func public @simple_persistent_mmav5(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @simple_persistent_mmav5(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = "init_acc"() : () -> tensor<128x128xf32, #blocked1>
     %cst_0 = "override_acc"() : () -> tensor<128x128xf32, #blocked1>
@@ -1121,7 +1121,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: } {tt.scheduled_max_stage = 3 : i32}
   // CHECK: %[[ACC_TM_SLICE:.*]] = ttg.memdesc_index %[[ACC_TM]]{{\[}}%[[FOR_RES]]#2{{\]}}
   // CHECK: %[[LOAD_ACC:.*]], %[[RES_TOK:.*]] = ttng.tmem_load %[[ACC_TM_SLICE]][]
-  tt.func public @simple_persistent_mmav5_acc_flag(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @simple_persistent_mmav5_acc_flag(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = "init_acc"() : () -> tensor<128x128xf32, #blocked1>
     %cst_0 = "override_acc"() : () -> tensor<128x128xf32, #blocked1>
@@ -1159,7 +1159,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @mmav5_load_in_different_cluster
-  tt.func public @mmav5_load_in_different_cluster(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i1) -> tensor<128x128xf16, #blocked> {
+  tt.func public @mmav5_load_in_different_cluster(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: i32, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg4: i1) -> tensor<128x128xf16, #blocked> {
     %true = arith.constant true
     %false = arith.constant false
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
@@ -1238,7 +1238,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttng.inval_barrier %[[BAR_SLICE1]]
   // CHECK: ttg.local_dealloc %[[BAR_BUF]]
   // CHECK: ttng.tmem_load %[[TMEM_BUF]][%[[FOR_RES]]#0]
-  tt.func public @chained_dot_wait_before_store(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i1) -> tensor<128x128xf16, #blocked> {
+  tt.func public @chained_dot_wait_before_store(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: i32, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg4: i1) -> tensor<128x128xf16, #blocked> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %c0_i32 = arith.constant 0 : i32
@@ -1274,7 +1274,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @multibuf_tmem1
-  tt.func public @multibuf_tmem1(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i32) {
+  tt.func public @multibuf_tmem1(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg4: i32) {
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -1304,7 +1304,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @multibuf_tmem2
-  tt.func public @multibuf_tmem2(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i32) {
+  tt.func public @multibuf_tmem2(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg4: i32) {
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -1334,7 +1334,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @two_dots
-  tt.func public @two_dots(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i32) {
+  tt.func public @two_dots(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg4: i32) {
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -1459,7 +1459,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK:   %[[MMA_TOK:.+]] = ttng.tc_gen5_mma %[[A_SLICE:.*]], %[[B_SLICE:.*]], %[[TMEM_BUF]][%[[STORE_TOK]]], {{.*}}, {{.*}}, %[[BAR_SLICE]][%true] {is_async, loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK:   ttng.wait_barrier %[[BAR_SLICE]], {{.*}} {loop.cluster = 1 : i32, loop.stage = 3 : i32}
   // CHECK:   scf.yield %[[MMA_TOK]]
-  tt.func public @changed_acc_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @changed_acc_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %cst_0 = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -1502,8 +1502,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttg.async_copy_global_to_local {{.*}} {loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.tc_gen5_mma {{.*}} {is_async, loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 1 : i32, loop.stage = 3 : i32}
-  tt.func public @changed_acc_unpipelineable_operand(%A: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>},
-                                                     %B: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>},
+  tt.func public @changed_acc_unpipelineable_operand(%A: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
+                                                     %B: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
                                                       %arg1: i32, %arg2: i32, %arg3: i32) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %true = arith.constant true
@@ -1544,8 +1544,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttng.tmem_load {{.*}} {loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.tc_gen5_mma {{.*}} {is_async, loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 1 : i32, loop.stage = 3 : i32}
-  tt.func public @changed_acc_unpipelineable_operand2(%A: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>},
-                                                     %B: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>},
+  tt.func public @changed_acc_unpipelineable_operand2(%A: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
+                                                     %B: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
                                                       %arg1: i32, %arg2: i32, %arg3: i32) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %true = arith.constant true
@@ -1589,7 +1589,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttg.async_copy_global_to_local {{.*}} {loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.tc_gen5_mma {{.*}} {is_async, loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 1 : i32, loop.stage = 3 : i32}
-  tt.func public @wait_before_tmem_alloc(%A: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>},
+  tt.func public @wait_before_tmem_alloc(%A: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
                                          %B: tensor<128x128xf16, #blocked1> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},
                                          %arg1: i32, %arg2: i32, %arg3: i32) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -1663,7 +1663,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK: scf.if %{{.*}} {
 
 tt.func @conditional_store_race_fix(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                  %out_ptr : tensor<128x32x!tt.ptr<f16>, #blocked1>,
                  %cnd : i1) -> () {
   scf.for %iv = %lb to %ub step %step : index {

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -187,7 +187,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK: scf.for
 // CHECK:   tt.load {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 tt.func @one_dep_sync(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<1x!tt.ptr<f16>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> () {
+                 %a_ptr_init : tensor<1x!tt.ptr<f16>, #A> {tt.divisibility = dense<[16]> : tensor<1xi32>, tt.contiguity = dense<[16]> : tensor<ixi32>}) -> () {
   scf.for %iv = %lb to %ub step %step : index {
     %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<1x!tt.ptr<f16>, #A>
     "use"(%a) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<1xf16, #A>) -> ()

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -594,8 +594,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
                       %lb : index, %ub : index, %step : index,
                       %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                       %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
-                      %mask: tensor<128x128xi1, #blocked1> {tt.constancy = 128 : i32},
-                      %other: tensor<128x128xf16, #blocked1> {tt.constancy = 128 : i32}) -> tensor<128x128xf16, #mma> {
+                      %mask: tensor<128x128xi1, #blocked1> {tt.constancy = dense<[128, 128]> : tensor<2xi32>},
+                      %other: tensor<128x128xf16, #blocked1> {tt.constancy = dense<[128, 128]> : tensor<2xi32>}) -> tensor<128x128xf16, #mma> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
     %c0_i32 = arith.constant 0 : i32
@@ -1590,7 +1590,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttng.tc_gen5_mma {{.*}} {is_async, loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 1 : i32, loop.stage = 3 : i32}
   tt.func public @wait_before_tmem_alloc(%A: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
-                                         %B: tensor<128x128xf16, #blocked1> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},
+                                         %B: tensor<128x128xf16, #blocked1> {tt.contiguity = dense<[1, 16]> : tensor<2xi32>, tt.divisibility = dense<[16, 16]> : tensor<2xi32>},
                                          %arg1: i32, %arg2: i32, %arg3: i32) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %true = arith.constant true

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -929,8 +929,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   tt.func public @pipelining_mmav5_scaled(%lb : index, %ub : index, %step : index,
                                               %A_ptr: tensor<128x128x!tt.ptr<f8E5M2>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
                                               %B_ptr: tensor<128x128x!tt.ptr<f8E5M2>, #blocked1> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[1, 16]> : tensor<2xi32>},
-                                              %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                                              %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> tensor<128x128xf32, #blocked1> {
+                                              %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = dense<[16, 16, 16, 16, 16]> : tensor<5xi32>, tt.contiguity = dense<[1, 1, 1, 1, 16]> : tensor<5xi32>},
+                                              %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = dense<[16, 16, 16, 16, 16]> : tensor<5xi32>, tt.contiguity = dense<[1, 1, 1, 1, 16]> : tensor<5xi32>}) -> tensor<128x128xf32, #blocked1> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %c0_i32 = arith.constant 0 : i32

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -48,7 +48,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-DAG:   ttg.async_wait  {num = 0 : i32}
 
 tt.func @one_dep_async(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> () {
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
   scf.for %iv = %lb to %ub step %step : index {
     %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
     "use"(%a) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x32xf16, #A>) -> ()
@@ -67,7 +67,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @one_dep_barrier_wait
 // CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x128x64
 tt.func @one_dep_barrier_wait(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                 %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                  %bar : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>,
                  %phase : i32) -> () {
   scf.for %iv = %lb to %ub step %step : index {
@@ -91,7 +91,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @one_dep_barrier_wait_trans
 // CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x128x64
 tt.func @one_dep_barrier_wait_trans(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                 %a_ptr_init : tensor<128x64x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                  %bar : !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory, mutable>,
                  %phase : i32) -> () {
   scf.for %iv = %lb to %ub step %step : index {
@@ -119,7 +119,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK:   "use1"(%[[A_VAL]]) {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 // CHECK:   "use2"(%[[A_VAL]]) {loop.cluster = 0 : i32, loop.stage = 3 : i32}
 tt.func @different_use_stages(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> () {
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
   scf.for %iv = %lb to %ub step %step : index {
     %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
     "use1"(%a) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x32xf16, #A>) -> ()
@@ -144,7 +144,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK:   "use"{{.*}} {loop.cluster = 0 : i32, loop.stage = 3 : i32}
 
 tt.func @used_by_if_yield(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                  %init_a : tensor<128x32xf16, #A>,
                  %cnd : i1) -> () {
   scf.for %iv = %lb to %ub step %step : index {
@@ -166,7 +166,7 @@ tt.func @used_by_if_yield(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @dist1_load
 tt.func @dist1_load(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                  %init_a : tensor<128x32xf16, #A>) -> () {
   %_ = scf.for %iv = %lb to %ub step %step iter_args(%prev_a = %init_a) -> (tensor<128x32xf16, #A>) : index {
     "use_next_iter"(%prev_a) {loop.cluster = 2 : i32, loop.stage = 0 : i32} : (tensor<128x32xf16, #A>) -> ()
@@ -226,7 +226,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-DAG:   ttg.local_dealloc %[[A]]
 // CHECK-DAG:   ttg.async_wait  {num = 0 : i32}
 tt.func @one_dep_local_alloc(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> () {
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
   scf.for %iv = %lb to %ub step %step : index {
     %a = tt.load %a_ptr_init {loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x32x!tt.ptr<f16>, #A>
     %a_alloc = ttg.local_alloc %a {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x32xf16, #A>) -> !ttg.memdesc<128x32xf16, #shared, #ttg.shared_memory, mutable>
@@ -244,8 +244,8 @@ tt.func @one_dep_local_alloc(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @one_load_group
 tt.func @one_load_group(%lb : index, %ub : index, %step : index,
-                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                       %b_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> () {
+                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                       %b_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
   // CHECK-DAG: %[[MINUS_ONE:.*]] = arith.constant -1
   // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0
   // CHECK-DAG: %[[ONE:.*]] = arith.constant 1
@@ -275,9 +275,9 @@ tt.func @one_load_group(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @two_load_groups
 tt.func @two_load_groups(%lb : index, %ub : index, %step : index,
-                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                       %b_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                       %c_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> () {
+                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                       %b_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                       %c_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
   // CHECK-DAG: %[[MINUS_ONE:.*]] = arith.constant -1
   // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0
   // CHECK-DAG: %[[ONE:.*]] = arith.constant 1
@@ -316,7 +316,7 @@ tt.func @two_load_groups(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @dependent_loads
 tt.func @dependent_loads(%lb : index, %ub : index, %step : index,
-                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> () {
+                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
   // CHECK-DAG: %[[MINUS_ONE:.*]] = arith.constant -1
   // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0
   // CHECK-DAG: %[[ONE:.*]] = arith.constant 1
@@ -366,7 +366,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @dependent_loads_asymmetric
 // Loads have different latencies, should create two load groups.
 tt.func @dependent_loads_asymmetric(%lb : index, %ub : index, %step : index,
-                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> () {
+                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
   // CHECK-DAG: %[[MINUS_ONE:.*]] = arith.constant -1
   // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0
   // CHECK-DAG: %[[ONE:.*]] = arith.constant 1
@@ -422,7 +422,7 @@ tt.func @dependent_loads_asymmetric(%lb : index, %ub : index, %step : index,
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK-LABEL: @unused_load
 tt.func @unused_load(%lb : index, %ub : index, %step : index,
-                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> () {
+                       %a_ptr_init : tensor<128x32x!tt.ptr<f32>, #A> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> () {
   // CHECK: scf.for
   scf.for %iv = %lb to %ub step %step : index {
     // CHECK: dummy
@@ -472,8 +472,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-DAG: ttg.local_dealloc %[[B]]
   // CHECK-DAG: ttg.async_wait  {num = 0 : i32}
   tt.func public @shmem_pipelining_mmav3(%lb : index, %ub : index, %step : index,
-                                              %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                                              %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> tensor<128x128xf16, #mma> {
+                                              %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                                              %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<128x128xf16, #mma> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
     %c0_i32 = arith.constant 0 : i32
@@ -528,8 +528,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-DAG:   ttg.async_wait  {num = 0 : i32}
   tt.func public @no_shmem_pipelining_incompat_layout(
                     %lb : index, %ub : index, %step : index,
-                    %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                    %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> tensor<128x128xf32, #mma> {
+                    %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                    %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<128x128xf32, #mma> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
     %c0_i32 = arith.constant 0 : i32
@@ -592,8 +592,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-DAG: ttg.async_wait  {num = 0 : i32}
   tt.func public @no_shmem_pipelining_other_used(
                       %lb : index, %ub : index, %step : index,
-                      %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                      %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                      %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                      %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                       %mask: tensor<128x128xi1, #blocked1> {tt.constancy = 128 : i32},
                       %other: tensor<128x128xf16, #blocked1> {tt.constancy = 128 : i32}) -> tensor<128x128xf16, #mma> {
     %true = arith.constant true
@@ -670,8 +670,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-DAG: ttg.local_dealloc %[[BAR]]
   // CHECK-DAG: ttg.async_wait {num = 0 : i32}
   tt.func public @shmem_pipelining_mmav5(%lb : index, %ub : index, %step : index,
-                                              %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                                              %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> tensor<128x128xf16, #blocked> {
+                                              %A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                                              %B_ptr: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>}) -> tensor<128x128xf16, #blocked> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %c0_i32 = arith.constant 0 : i32
@@ -927,8 +927,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x1x2x32x4x4xi8
   // CHECK: ttg.local_alloc : () -> !ttg.memdesc<3x1x2x32x4x4xi8
   tt.func public @pipelining_mmav5_scaled(%lb : index, %ub : index, %step : index,
-                                              %A_ptr: tensor<128x128x!tt.ptr<f8E5M2>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
-                                              %B_ptr: tensor<128x128x!tt.ptr<f8E5M2>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                                              %A_ptr: tensor<128x128x!tt.ptr<f8E5M2>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
+                                              %B_ptr: tensor<128x128x!tt.ptr<f8E5M2>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                                               %A_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
                                               %B_sc_ptr: tensor<1x2x32x4x4x!tt.ptr<i8>, #blocked2> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32}) -> tensor<128x128xf32, #blocked1> {
     %true = arith.constant true
@@ -964,7 +964,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @cnd_store_before_mma
-  tt.func public @cnd_store_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @cnd_store_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %cst_0 = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -1041,7 +1041,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: } {tt.scheduled_max_stage = 3 : i32}
   // CHECK: %[[ACC_TM_SLICE:.*]] = ttg.memdesc_index %[[ACC_TM]]{{\[}}%[[FOR_RES]]#2{{\]}}
   // CHECK: %[[LOAD_ACC:.*]], %[[RES_TOK:.*]] = ttng.tmem_load %[[ACC_TM_SLICE]][]
-  tt.func public @simple_persistent_mmav5(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @simple_persistent_mmav5(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = "init_acc"() : () -> tensor<128x128xf32, #blocked1>
     %cst_0 = "override_acc"() : () -> tensor<128x128xf32, #blocked1>
@@ -1121,7 +1121,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: } {tt.scheduled_max_stage = 3 : i32}
   // CHECK: %[[ACC_TM_SLICE:.*]] = ttg.memdesc_index %[[ACC_TM]]{{\[}}%[[FOR_RES]]#2{{\]}}
   // CHECK: %[[LOAD_ACC:.*]], %[[RES_TOK:.*]] = ttng.tmem_load %[[ACC_TM_SLICE]][]
-  tt.func public @simple_persistent_mmav5_acc_flag(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @simple_persistent_mmav5_acc_flag(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = "init_acc"() : () -> tensor<128x128xf32, #blocked1>
     %cst_0 = "override_acc"() : () -> tensor<128x128xf32, #blocked1>
@@ -1159,7 +1159,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @mmav5_load_in_different_cluster
-  tt.func public @mmav5_load_in_different_cluster(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: i32, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg4: i1) -> tensor<128x128xf16, #blocked> {
+  tt.func public @mmav5_load_in_different_cluster(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i1) -> tensor<128x128xf16, #blocked> {
     %true = arith.constant true
     %false = arith.constant false
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
@@ -1238,7 +1238,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttng.inval_barrier %[[BAR_SLICE1]]
   // CHECK: ttg.local_dealloc %[[BAR_BUF]]
   // CHECK: ttng.tmem_load %[[TMEM_BUF]][%[[FOR_RES]]#0]
-  tt.func public @chained_dot_wait_before_store(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: i32, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg4: i1) -> tensor<128x128xf16, #blocked> {
+  tt.func public @chained_dot_wait_before_store(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i1) -> tensor<128x128xf16, #blocked> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
     %c0_i32 = arith.constant 0 : i32
@@ -1274,7 +1274,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @multibuf_tmem1
-  tt.func public @multibuf_tmem1(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg4: i32) {
+  tt.func public @multibuf_tmem1(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i32) {
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -1304,7 +1304,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @multibuf_tmem2
-  tt.func public @multibuf_tmem2(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg4: i32) {
+  tt.func public @multibuf_tmem2(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i32) {
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -1334,7 +1334,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @two_dots
-  tt.func public @two_dots(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg4: i32) {
+  tt.func public @two_dots(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg3: tensor<128x128x!tt.ptr<f32>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg4: i32) {
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
@@ -1459,7 +1459,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK:   %[[MMA_TOK:.+]] = ttng.tc_gen5_mma %[[A_SLICE:.*]], %[[B_SLICE:.*]], %[[TMEM_BUF]][%[[STORE_TOK]]], {{.*}}, {{.*}}, %[[BAR_SLICE]][%true] {is_async, loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK:   ttng.wait_barrier %[[BAR_SLICE]], {{.*}} {loop.cluster = 1 : i32, loop.stage = 3 : i32}
   // CHECK:   scf.yield %[[MMA_TOK]]
-  tt.func public @changed_acc_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
+  tt.func public @changed_acc_before_mma(%arg0: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg1: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>}, %arg2: i32) -> tensor<128x128xf16, #blocked1> {
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %cst_0 = arith.constant dense<2.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -1502,8 +1502,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttg.async_copy_global_to_local {{.*}} {loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.tc_gen5_mma {{.*}} {is_async, loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 1 : i32, loop.stage = 3 : i32}
-  tt.func public @changed_acc_unpipelineable_operand(%A: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},
-                                                     %B: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},
+  tt.func public @changed_acc_unpipelineable_operand(%A: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>},
+                                                     %B: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>},
                                                       %arg1: i32, %arg2: i32, %arg3: i32) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %true = arith.constant true
@@ -1544,8 +1544,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttng.tmem_load {{.*}} {loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.tc_gen5_mma {{.*}} {is_async, loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 1 : i32, loop.stage = 3 : i32}
-  tt.func public @changed_acc_unpipelineable_operand2(%A: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},
-                                                     %B: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},
+  tt.func public @changed_acc_unpipelineable_operand2(%A: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>},
+                                                     %B: tensor<128x128x!tt.ptr<f16>, #blocked> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>},
                                                       %arg1: i32, %arg2: i32, %arg3: i32) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
     %true = arith.constant true
@@ -1589,7 +1589,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttg.async_copy_global_to_local {{.*}} {loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.tc_gen5_mma {{.*}} {is_async, loop.cluster = 2 : i32, loop.stage = 2 : i32}
   // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 1 : i32, loop.stage = 3 : i32}
-  tt.func public @wait_before_tmem_alloc(%A: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},
+  tt.func public @wait_before_tmem_alloc(%A: tensor<128x128x!tt.ptr<f16>, #blocked1> {tt.contiguity = [1, 16] : tensor<2xi32>, tt.divisibility = [16, 16] : tensor<2xi32>},
                                          %B: tensor<128x128xf16, #blocked1> {tt.contiguity = 16 : i32, tt.divisibility = 16 : i32},
                                          %arg1: i32, %arg2: i32, %arg3: i32) {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
@@ -1663,7 +1663,7 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK: scf.if %{{.*}} {
 
 tt.func @conditional_store_race_fix(%lb : index, %ub : index, %step : index,
-                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #blocked1> {tt.divisibility = 16 : i32, tt.contiguity = 16 : i32},
+                 %a_ptr_init : tensor<128x32x!tt.ptr<f16>, #blocked1> {tt.divisibility = [16, 16] : tensor<2xi32>, tt.contiguity = [1, 16] : tensor<2xi32>},
                  %out_ptr : tensor<128x32x!tt.ptr<f16>, #blocked1>,
                  %cnd : i1) -> () {
   scf.for %iv = %lb to %ub step %step : index {


### PR DESCRIPTION
Two previous have been fixed.

1. Hints annotated on scalar operations were not taken effective previously.
2. In mlir, there were a lot of mismatch between tensor ranks and hint ranks. 