### PR TITLE
[Triton] Disable MLIR multithreading

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -321,15 +321,15 @@ void init_triton_ir(py::module &&m) {
       .export_values();
 
   py::class_<MLIRContext>(m, "context", py::module_local())
-      .def(py::init<>())
+      .def(py::init<>(
+          // Triton compilation does not make use of MLIR threading, so disable
+          // it to avoid threadpool overhead.
+          []() { return MLIRContext(MLIRContext::Threading::DISABLED); }))
       .def("printOpOnDiagnostic",
            [](MLIRContext &self, bool v) { self.printOpOnDiagnostic(v); })
-      .def("printStackTraceOnDiagnostic",
-           [](MLIRContext &self, bool v) {
-             self.printStackTraceOnDiagnostic(v);
-           })
-      .def("disable_multithreading",
-           [](MLIRContext &self) { self.disableMultithreading(); });
+      .def("printStackTraceOnDiagnostic", [](MLIRContext &self, bool v) {
+        self.printStackTraceOnDiagnostic(v);
+      });
 
   py::class_<SourceMgrDiagnosticHandler>(m, "source_mgr_diag",
                                          py::module_local())

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -347,17 +347,6 @@ def compile(src, target=None, options=None, _env_vars=None):
     metadata_group[metadata_filename] = fn_cache_manager.put(json.dumps(metadata, default=vars), metadata_filename,
                                                              binary=False)
     fn_cache_manager.put_group(metadata_filename, metadata_group)
-    # Compilation completed, disabling multithreading in context.
-    # This is needed to safely finalize threads pool inside context: if current process forks before
-    # python GC deletes context object, thread pool in child process will be invalid, which could
-    # lead to child crash or hang.
-    #
-    # However disabling multithreading causes the code to hang if the ASAN pass is enabled
-    # this is likely due to the llvm-symbolizer forking a process
-    # TODO: Reconcile the difference here between the ASAN and non-ASAN path with enabling
-    # multithreading in the MLIR context
-    if not knobs.compilation.enable_asan:
-        context.disable_multithreading()
 
     # notify any listener
     if compilation_listener:


### PR DESCRIPTION
Within compilation of a single kernel, Triton does not make much use of MLIR threading (mostly module-level passes, most modules have a single function). When composed with Python-level async compilation, this can lead to an explosion of idle threads due to each MLIR context having its own `nproc` number of threads in a threadpool. Disable MLIR threading entirely to avoid this.
