### PR TITLE
[Gluon] Wrap `warp_specialize` arguments in tuple if necessary

### DIFF
--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -510,9 +510,9 @@ def warp_specialize(default_args, default_partition, worker_args, worker_partiti
     worker_num_warps = [_unwrap_if_constexpr(w) for w in worker_num_warps]
     worker_num_regs = [_unwrap_if_constexpr(r) for r in worker_num_regs]
     if not isinstance(default_args, tuple):
-        default_args = (default_args,)
+        default_args = (default_args, )
     if not isinstance(worker_args, tuple):
-        worker_args = (worker_args,)
+        worker_args = (worker_args, )
     return _semantic.warp_specialize(default_args, default_partition, worker_args, worker_partitions, worker_num_warps,
                                      worker_num_regs, _generator)
 

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -509,6 +509,10 @@ def warp_specialize(default_args, default_partition, worker_args, worker_partiti
     """
     worker_num_warps = [_unwrap_if_constexpr(w) for w in worker_num_warps]
     worker_num_regs = [_unwrap_if_constexpr(r) for r in worker_num_regs]
+    if not isinstance(default_args, tuple):
+        default_args = (default_args,)
+    if not isinstance(worker_args, tuple):
+        worker_args = (worker_args,)
     return _semantic.warp_specialize(default_args, default_partition, worker_args, worker_partitions, worker_num_warps,
                                      worker_num_regs, _generator)
 


### PR DESCRIPTION
This avoids potentially confusing error messages when there is just one argument and it isn't passed as `(arg,)`
