### PR TITLE
[AMD] Fix assertion in CanonicalizePointers

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -986,6 +986,24 @@ private:
       newOffset = createTruncIOffset(rewriter, curLoc, newOffset,
                                      rewriter.getI32Type());
     }
+
+    // If the newOffset is not created in this function, chances are it could
+    // already be mapped to another value, say y. In that case, we need to
+    // use y instead of newOffset. Otherwise, consider the following sequence,
+    // this operation (op1) feeds its result to op2 as the operand0. When op2
+    // is visited, the framework will associate the op2.operand0, via
+    // OneToNOpAdaptor, with <fatPtrBase, y> instead of <fatPtrBase, newOffset>.
+    //
+    //   op1: r = this-addPtr ...
+    //   op2:   = op r, ...
+    //
+    // If we were using <fatPtrBase, newOffset> to set an entry in fatPtrs, we
+    // would not be able to lookup the entry when op2 is visited, as it will
+    // use index <fatPtrBase, y>.
+    if (auto remapped = rewriter.getRemappedValue(newOffset);
+        remapped != newOffset)
+      newOffset = remapped;
+
     LDBG("   -- new offset: " << newOffset);
 
     rewriter.replaceOpWithMultiple(addPtrOp, {{fatPtrBase, newOffset}});


### PR DESCRIPTION
Fix https://github.com/ROCm/triton-internal/issues/1224

The problem is an asserion arising from python/triton_kernels/bench/bench_mlp.py.

The root cause in short is that, the patten-matching code tres to use a value, say x, which is already mapped to y (by patten-matching framework), as a key to populate map (not maintained by rewrite framework). It should have used y for map index.

The problem can be depicted as following, consider two ops
  1: r = op1 ...
  2: ... op2 r, ...

The patten-matching rule tries to replace op1's result r with {a,b}
  s1: rewriter.replaceOpWithMultiple(op1, {a, b})
  s2: key = {a, b}
  s3: local-map[key] = something_awesome.

However, at this moment, b is already mapped to c. when op2 is visited. The information associated with op2.operand0 is {a, c} instead of {a, b}. If we were using {a, c} as key to lookup the local-map, we would not find an value.

The fix is to replace s2 as:
   if (auto b2 = rewriter.getRemappedValue(b)
      b = b2;

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.
  - [x] in a process to minimize a test case; make a PR first the unblock folks waiting for the fix.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
