### PR TITLE
[AMD][BACKEND] Disable direct-to-lds loads on CDNA1 and CDNA2

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -579,8 +579,6 @@ bool TargetInfo::supportVectorizedAtomics() const {
 
 bool TargetInfo::supportsDirectToLdsLoadBitWidth(int bitWidth) const {
   switch (getISAFamily()) {
-  case ISAFamily::CDNA1:
-  case ISAFamily::CDNA2:
   case ISAFamily::CDNA3:
     // Disable 8 and 16 bits because they get extended to 32 bit.
     return llvm::is_contained({32, /*16, 8*/}, bitWidth);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
@@ -241,8 +241,9 @@ public:
 
     mlir::RewritePatternSet patterns(context);
 
-    if (!AMD::isCDNA(targetInfo.getISAFamily()))
-      return; // This pass is CDNA specific.
+    if (!llvm::is_contained({AMD::ISAFamily::CDNA3, AMD::ISAFamily::CDNA4},
+                            targetInfo.getISAFamily()))
+      return; // This pass is CDNA3 and CDNA4 specific.
 
     // Precompute the contiguity of all AsyncCopy ops based on the src and
     // mask contiguity/alignment to avoid rebuilding ModuleAxisInfoAnalysis


### PR DESCRIPTION
`CDNA1` and `CDNA2` do not have support to load from HBM to shared memory.