### PR TITLE
Feature/bf16 fp32 out dtype

### DIFF
--- a/python/test/unit/runtime/test_blaslt.py
+++ b/python/test/unit/runtime/test_blaslt.py
@@ -22,7 +22,7 @@ def test_blaslt(m, n, k, dtype_str, device):
             pytest.skip("float8_e4m3fnuz is only supported on HIP CDNA3")
         if dtype_str == "float8_e4m3fn" and not is_hip_cdna4():
             pytest.skip("float8_e4m3fn is only supported on HIP CDNA4")
-        c_dtype = torch.bfloat16 if dtype_str in ("float8_e4m3fnuz", "float8_e4m3fn") else dtype
+        c_dtype = torch.float16 if dtype_str in ("float8_e4m3fnuz", "float8_e4m3fn") else dtype
         make_handle = lambda workspace: vendor.hipblas.HipblasLt(workspace)
     else:
         pytest.skip("test_blaslt is only supported on CUDA or HIP")

--- a/python/test/unit/runtime/test_blaslt.py
+++ b/python/test/unit/runtime/test_blaslt.py
@@ -22,7 +22,7 @@ def test_blaslt(m, n, k, dtype_str, device):
             pytest.skip("float8_e4m3fnuz is only supported on HIP CDNA3")
         if dtype_str == "float8_e4m3fn" and not is_hip_cdna4():
             pytest.skip("float8_e4m3fn is only supported on HIP CDNA4")
-        c_dtype = torch.float16 if dtype_str in ("float8_e4m3fnuz", "float8_e4m3fn") else dtype
+        c_dtype = torch.bfloat16 if dtype_str in ("float8_e4m3fnuz", "float8_e4m3fn") else dtype
         make_handle = lambda workspace: vendor.hipblas.HipblasLt(workspace)
     else:
         pytest.skip("test_blaslt is only supported on CUDA or HIP")

--- a/third_party/amd/include/hipblas_instance.h
+++ b/third_party/amd/include/hipblas_instance.h
@@ -163,7 +163,8 @@ class HipblasLtInstance {
   }
 
   void gemm_impl(int m, int n, int k, uint64_t A, uint64_t B, uint64_t C,
-                 uint64_t D, hipDataType dtype, float alpha, float beta) {
+                 uint64_t D, hipDataType dtype, hipDataType out_dtype, float alpha,
+                 float beta) {
 
     hipblasLtMatmulDesc_t matmulDesc = NULL;
 
@@ -211,13 +212,11 @@ class HipblasLtInstance {
           sizeof(b_in)));
     }
 
-    auto c_dtype = (isFP8) ? HIP_R_16F : dtype;
-
     successOrExit(hipblasLtMatrixLayoutCreate(&Adesc, dtype, k, m, k));
     successOrExit(hipblasLtMatrixLayoutCreate(&Bdesc, dtype, k, n, k));
-    successOrExit(hipblasLtMatrixLayoutCreate(&Cdesc, c_dtype, m, n, m));
+    successOrExit(hipblasLtMatrixLayoutCreate(&Cdesc, out_dtype, m, n, m));
 
-    successOrExit(hipblasLtMatrixLayoutCreate(&Ddesc, c_dtype, m, n, m));
+    successOrExit(hipblasLtMatrixLayoutCreate(&Ddesc, out_dtype, m, n, m));
     successOrExit(hipblasLtMatmulAlgoGetHeuristic(
         ltHandle, matmulDesc, Adesc, Bdesc, Cdesc, Ddesc, preference, 1,
         &heuristicResult, &returnedResults));
@@ -230,9 +229,9 @@ class HipblasLtInstance {
           << "), leading_dim=" << m << "\n";
       oss << "  B: dtype=" << dtype << ", shape=(" << n << "," << k
           << "), leading_dim=" << n << " (will be transposed)\n";
-      oss << "  C: dtype=" << c_dtype << ", shape=(" << m << "," << n
+      oss << "  C: dtype=" << out_dtype << ", shape=(" << m << "," << n
           << "), leading_dim=" << m << "\n";
-      oss << "  D: dtype=" << c_dtype << ", shape=(" << m << "," << n
+      oss << "  D: dtype=" << out_dtype << ", shape=(" << m << "," << n
           << "), leading_dim=" << m << "\n";
       oss << "  Compute type: " << computeType << "\n";
       oss << "  Requested algorithms: 1\n";
@@ -282,17 +281,17 @@ public:
   }
 
   void matmul(int m, int n, int k, uint64_t A, uint64_t B, uint64_t C,
-              hipDataType dtype) {
+              hipDataType dtype, hipDataType out_dtype) {
     // HIP is column-major, while triton is row-major, therefore we need to
     // reverse the order of the matrices ( A * B = (B^T * A^T)^T ).
     // Note: HipBLAS requires a valid C pointer even when beta=0, so we pass C
     // instead of 0
-    gemm_impl(n, m, k, B, A, C, C, dtype, 1.0f, 0.0f);
+    gemm_impl(n, m, k, B, A, C, C, dtype, out_dtype, 1.0f, 0.0f);
   }
 
   void gemm(int m, int n, int k, uint64_t A, uint64_t B, uint64_t C, uint64_t D,
-            hipDataType dtype, float alpha, float beta) {
-    gemm_impl(n, m, k, B, A, C, D, dtype, alpha, beta);
+            hipDataType dtype, hipDataType out_dtype, float alpha, float beta) {
+    gemm_impl(n, m, k, B, A, C, D, dtype, out_dtype, alpha, beta);
   }
 };
 #endif // TRITON_HIPBLAS_INSTANCE_H

--- a/third_party/amd/include/hipblas_instance.h
+++ b/third_party/amd/include/hipblas_instance.h
@@ -163,8 +163,8 @@ class HipblasLtInstance {
   }
 
   void gemm_impl(int m, int n, int k, uint64_t A, uint64_t B, uint64_t C,
-                 uint64_t D, hipDataType dtype, hipDataType out_dtype, float alpha,
-                 float beta) {
+                 uint64_t D, hipDataType dtype, hipDataType out_dtype,
+                 float alpha, float beta) {
 
     hipblasLtMatmulDesc_t matmulDesc = NULL;
 

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -160,18 +160,15 @@ static void checkMatmulConstraints(const std::string &A_dtype,
     throw std::runtime_error(oss.str());
   }
 
-  // For 8-bit inputs (any combination of FP8/BF8), restrict C to FP16 for now,
-  // matching the current hipBLAS wrapper behavior.
   if (A_is_fp8 && B_is_fp8) {
-    if (C_dtype != "torch.float16") {
+    if (C_dtype != "torch.float16" && C_dtype != "torch.float32" && C_dtype != "torch.bfloat16") {
       std::ostringstream oss;
       oss << "When A/B are 8-bit (float8_e4m3fn/e4m3fnuz or "
              "float8_e5m2fn/e5m2fnuz), C must"
-          << " be torch.float16.";
+          << " be torch.float16, torch.float32, or torch.bfloat16.";
       throw std::runtime_error(oss.str());
     }
   } else {
-    // Otherwise require all dtypes to match
     if (!(A_dtype == B_dtype && A_dtype == C_dtype)) {
       std::ostringstream oss;
       oss << "Data types do not match: A=" << A_dtype << ", B=" << B_dtype
@@ -220,6 +217,7 @@ struct HipBlasInit {
   int n;
   int k;
   hipDataType dtype;
+  hipDataType out_dtype;
 };
 
 static HipBlasInit initialize_hipblas_op(py::object &A, py::object &B,
@@ -240,8 +238,9 @@ static HipBlasInit initialize_hipblas_op(py::object &A, py::object &B,
 
     checkMatmulConstraints(A_dtype, B_dtype, OUT_dtype, A_shape, B_shape,
                            OUT_shape);
-    if (C_dtype != "torch.float16") {
-      throw std::runtime_error("C dtype must be float16, got " + C_dtype);
+    if (C_dtype != OUT_dtype) {
+      throw std::runtime_error("C dtype must match output dtype, got C=" +
+                               C_dtype + ", D=" + OUT_dtype);
     }
     if (C_shape != OUT_shape) {
       throw std::runtime_error("C and D shapes must match");
@@ -251,35 +250,41 @@ static HipBlasInit initialize_hipblas_op(py::object &A, py::object &B,
                            OUT_shape);
   }
 
-  std::string dtype_str = A_dtype.substr(A_dtype.find_last_of('.') + 1);
   hipDataType dtype;
-  if (dtype_str == "float8_e4m3fn") {
-    // supported for GFX950/MI350x.
+  if (A_dtype == "torch.float8_e4m3fn") {
     dtype = HIP_R_8F_E4M3;
-  } else if (dtype_str == "float8_e5m2fn") {
-    // supported for GFX950/MI350x.
+  } else if (A_dtype == "torch.float8_e5m2fn") {
     dtype = HIP_R_8F_E5M2;
-  } else if (dtype_str == "float8_e4m3fnuz") {
-    // supported for GFX942/MI300x.
+  } else if (A_dtype == "torch.float8_e4m3fnuz") {
     dtype = HIP_R_8F_E4M3_FNUZ;
-  } else if (dtype_str == "float8_e5m2fnuz") {
-    // supported for GFX942/MI300x.
+  } else if (A_dtype == "torch.float8_e5m2fnuz") {
     dtype = HIP_R_8F_E5M2_FNUZ;
-  } else if (dtype_str == "float16") {
+  } else if (A_dtype == "torch.float16") {
     dtype = HIP_R_16F;
-  } else if (dtype_str == "float32") {
+  } else if (A_dtype == "torch.float32") {
     dtype = HIP_R_32F;
-  } else if (dtype_str == "bfloat16") {
+  } else if (A_dtype == "torch.bfloat16") {
     dtype = HIP_R_16BF;
   } else {
-    throw std::runtime_error("Unsupported dtype for hipblasLt: " + dtype_str);
+    throw std::runtime_error("Unsupported dtype for hipblasLt: " + A_dtype);
+  }
+
+  hipDataType out_dtype;
+  if (OUT_dtype == "torch.float16") {
+    out_dtype = HIP_R_16F;
+  } else if (OUT_dtype == "torch.float32") {
+    out_dtype = HIP_R_32F;
+  } else if (OUT_dtype == "torch.bfloat16") {
+    out_dtype = HIP_R_16BF;
+  } else {
+    throw std::runtime_error("Unsupported output dtype for hipblasLt: " + OUT_dtype);
   }
 
   int m = A_shape[0];
   int n = B_shape[0];
   int k = A_shape[1];
 
-  return HipBlasInit{m, n, k, dtype};
+  return HipBlasInit{m, n, k, dtype, out_dtype};
 }
 
 static std::optional<std::string> lldInvoke(const char *inPath,
@@ -523,7 +528,7 @@ void init_triton_amd(py::module &&m) {
              auto C_ptr = C.attr("data_ptr")().cast<uint64_t>();
              auto init = initialize_hipblas_op(A, B, C, std::nullopt);
              self.matmul(init.m, init.n, init.k, A_ptr, B_ptr, C_ptr,
-                         init.dtype);
+                         init.dtype, init.out_dtype);
            })
       .def("gemm", [](HipblasLtInstance &self, py::object &A, py::object &B,
                       py::object &C, py::object &D, float alpha, float beta) {
@@ -533,6 +538,6 @@ void init_triton_amd(py::module &&m) {
         auto D_ptr = D.attr("data_ptr")().cast<uint64_t>();
         auto init = initialize_hipblas_op(A, B, D, C);
         self.gemm(init.m, init.n, init.k, A_ptr, B_ptr, C_ptr, D_ptr,
-                  init.dtype, alpha, beta);
+                  init.dtype, init.out_dtype, alpha, beta);
       });
 }

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -253,12 +253,16 @@ static HipBlasInit initialize_hipblas_op(py::object &A, py::object &B,
 
   hipDataType dtype;
   if (A_dtype == "torch.float8_e4m3fn") {
+    // Supported for GFX950.
     dtype = HIP_R_8F_E4M3;
   } else if (A_dtype == "torch.float8_e5m2fn") {
+    // supported for GFX950.
     dtype = HIP_R_8F_E5M2;
   } else if (A_dtype == "torch.float8_e4m3fnuz") {
+    // Supported for GFX942.
     dtype = HIP_R_8F_E4M3_FNUZ;
   } else if (A_dtype == "torch.float8_e5m2fnuz") {
+    // Supported for GFX942.
     dtype = HIP_R_8F_E5M2_FNUZ;
   } else if (A_dtype == "torch.float16") {
     dtype = HIP_R_16F;

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -161,7 +161,8 @@ static void checkMatmulConstraints(const std::string &A_dtype,
   }
 
   if (A_is_fp8 && B_is_fp8) {
-    if (C_dtype != "torch.float16" && C_dtype != "torch.float32" && C_dtype != "torch.bfloat16") {
+    if (C_dtype != "torch.float16" && C_dtype != "torch.float32" &&
+        C_dtype != "torch.bfloat16") {
       std::ostringstream oss;
       oss << "When A/B are 8-bit (float8_e4m3fn/e4m3fnuz or "
              "float8_e5m2fn/e5m2fnuz), C must"
@@ -277,7 +278,8 @@ static HipBlasInit initialize_hipblas_op(py::object &A, py::object &B,
   } else if (OUT_dtype == "torch.bfloat16") {
     out_dtype = HIP_R_16BF;
   } else {
-    throw std::runtime_error("Unsupported output dtype for hipblasLt: " + OUT_dtype);
+    throw std::runtime_error("Unsupported output dtype for hipblasLt: " +
+                             OUT_dtype);
   }
 
   int m = A_shape[0];


### PR DESCRIPTION
Previously I had made a mistake in reading the docs for hipBlasLt support table when adding bindings. For the output C dtype, bf16, fp16, and fp32 are supported and not just fp16. This PR just adds that support. 

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
