### PR TITLE
[ConSan] Deadlock Detection

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -409,4 +409,80 @@ def TTI_ExperimentalCheckOutstandingCommitsOp : TTI_Op<"experimental_check_outst
   let hasVerifier = 1;
 }
 
+// ===== Deadlock detection ops =====
+
+def TTI_ExperimentalSetSignallingOp : TTI_Op<"experimental_set_signalling", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "Mark a barrier as being signalled by a peer thread index";
+  let description = [{
+    For the barrier row matching mbar, set signalling[row] |= (1 << bitIndex).
+  }];
+  let arguments = (ins
+    TTG_MemDescType:$mbar,
+    I32Attr:$bitIndex,
+    TT_Tensor:$barriers,
+    TT_PtrLike:$signalling,
+    TypeAttr:$signallingType,
+    Optional<I1>:$pred
+  );
+  let assemblyFormat = [{
+    $mbar `,` $bitIndex `{` $barriers `,` $signalling `(` $signallingType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($signalling)
+  }];
+}
+
+def TTI_ExperimentalMaybeSetWaitingOp : TTI_Op<"experimental_maybe_set_waiting", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "If barrier has no signalling peers, set waiting bit for base thread";
+  let description = [{
+    If signalling[row] == 0 for the matching barrier, set waiting[row] |= (1 << baseThread).
+  }];
+  let arguments = (ins
+    TTG_MemDescType:$mbar,
+    I32Attr:$baseThread,
+    TT_Tensor:$barriers,
+    TT_PtrLike:$waiting,
+    TypeAttr:$waitingType,
+    TT_PtrLike:$signalling,
+    TypeAttr:$signallingType,
+    Optional<I1>:$pred
+  );
+  let assemblyFormat = [{
+    $mbar `,` $baseThread `{` $barriers `,` $waiting `(` $waitingType `)` `,` $signalling `(` $signallingType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($waiting) `,` type($signalling)
+  }];
+}
+
+def TTI_ExperimentalCheckAllActiveWaitingOp : TTI_Op<"experimental_check_all_active_waiting", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "Assert that not all active threads are waiting";
+  let description = [{
+    OR-reduce waiting rows to a single mask and assert that (waitingMask & activeMask) != activeMask.
+  }];
+  let arguments = (ins
+    I32Attr:$activeMask,
+    TT_PtrLike:$waiting,
+    TypeAttr:$waitingType,
+    Optional<I1>:$pred
+  );
+  let assemblyFormat = [{
+    $activeMask `,` $waiting `(` $waitingType `)` (`,` $pred^)? attr-dict `:` type($waiting)
+  }];
+}
+
+def TTI_ExperimentalClearWaitingAndSignallingOp : TTI_Op<"experimental_clear_waiting_and_signalling", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "Clear waiting bit for base thread and reset signalling for barrier";
+  let description = [{
+    For the matching barrier row, clear waiting[row] bit for baseThread and set signalling[row] = 0.
+  }];
+  let arguments = (ins
+    TTG_MemDescType:$mbar,
+    I32Attr:$baseThread,
+    TT_Tensor:$barriers,
+    TT_PtrLike:$waiting,
+    TypeAttr:$waitingType,
+    TT_PtrLike:$signalling,
+    TypeAttr:$signallingType,
+    Optional<I1>:$pred
+  );
+  let assemblyFormat = [{
+    $mbar `,` $baseThread `{` $barriers `,` $waiting `(` $waitingType `)` `,` $signalling `(` $signallingType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($waiting) `,` type($signalling)
+  }];
+}
+
 #endif // TRITONINSTRUMENT_OPS

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -534,4 +534,41 @@ def TTI_ExperimentalClearWaitingOp : TTI_Op<"experimental_clear_waiting", [Memor
   }];
 }
 
+
+// ===== Visibility replication ops =====
+
+def TTI_ExperimentalCopyWriteVisibilityOp : TTI_Op<"experimental_copy_write_visibility", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "replicate write visibility from one thread to others";
+  let description = [{
+    Copy the write-visibility bit of sourceThread to every thread listed in destMask for all buffers. Destination bits are overwritten.
+  }];
+  let arguments = (ins
+    I32Attr:$sourceThread,
+    I64Attr:$destMask,
+    TT_PtrLike:$writeVisibility,
+    TypeAttr:$writeVisibilityType,
+    Optional<I1>:$pred
+  );
+  let assemblyFormat = [{
+    $sourceThread `,` $destMask `{` $writeVisibility `(` $writeVisibilityType `)` `}` (`,` $pred^)? attr-dict `:` type($writeVisibility)
+  }];
+}
+
+def TTI_ExperimentalCopyReadVisibilityOp : TTI_Op<"experimental_copy_read_visibility", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "replicate read visibility rows from one thread to others";
+  let description = [{
+    Copy the read-visibility row of sourceThread to every thread listed in destMask for all buffers. Destination rows are overwritten.
+  }];
+  let arguments = (ins
+    I32Attr:$sourceThread,
+    I64Attr:$destMask,
+    TT_PtrLike:$readVisibility,
+    TypeAttr:$readVisibilityType,
+    Optional<I1>:$pred
+  );
+  let assemblyFormat = [{
+    $sourceThread `,` $destMask `{` $readVisibility `(` $readVisibilityType `)` `}` (`,` $pred^)? attr-dict `:` type($readVisibility)
+  }];
+}
+
 #endif // TRITONINSTRUMENT_OPS

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -12,16 +12,18 @@ include "triton/Dialect/TritonInstrument/IR/TritonInstrumentAttrDefs.td"
 // ConSan keeps auxilary data requied for tracking memory accesses in tensors.
 // These tensors are stored as a distributed tensor or in global scratch memory.
 //
-// Name            | Storage | Rank/Type       | Description
-// ----------------|---------|-----------------|------------
-// buffers         | tensor  | <B x i64>       | Base pointers of all (sub)buffers
-// barriers        | tensor  | <K x i64>       | Pointers to all individual mbarriers
-// writeVisibility | scratch | <B x i64>       | Per-buffer thread-visibility bitmask (bit i => thread i visible)
-// readVisibility  | scratch | <B x T x i64>   | Per-buffer, per-thread visibility lanes (row-updated; values are bitmasks)
-// writeTracking   | scratch | <B x K x i8>    | Map buffers -> barriers that track writes
-// readTracking    | scratch | <B x K x i64>   | Map buffers -> barriers that track reads
+// Name              | Storage | Rank/Type       | Description
+// ------------------|---------|-----------------|------------
+// buffers           | tensor  | <B x i64>       | Base pointers of all (sub)buffers
+// barriers          | tensor  | <K x i64>       | Pointers to all individual mbarriers
+// barrierStates     | scratch | <K x i32>       | Packed barrier phase (bit 0) and arrival counts (bits[1..8] init, [9..16] current)
+// waiting           | scratch | <K x i32>       | Two bits per thread: waiting flag bit (LSB), stored phase bit (bit 1)
+// writeVisibility   | scratch | <B x i64>       | Per-buffer thread-visibility bitmask (bit i => thread i visible)
+// readVisibility    | scratch | <B x T x i64>   | Per-buffer, per-thread visibility lanes (row-updated; values are bitmasks)
+// writeTracking     | scratch | <B x K x i8>    | Map buffers -> barriers that track writes
+// readTracking      | scratch | <B x K x i64>   | Map buffers -> barriers that track reads
 // outstandingCommits
-//   (async/wgmma) | scratch | <B x T x i8>    | Number of outstanding commits per buffer/thread (2D replaces prior 1D)
+//   (async/wgmma)   | scratch | <B x T x i8>    | Number of outstanding commits per buffer/thread (2D replaces prior 1D)
 
 //
 // Interfaces
@@ -62,6 +64,9 @@ def TTI_ExperimentalBufferPointersOp : TTI_Op<"experimental_buffer_pointers", [P
 }
 
 
+// ===== Critical section lock ops =====
+
+
 def TTI_ExperimentalLockAcquireOp : TTI_Op<"experimental_lock_acquire", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
   let summary = "Acquire a lock.";
   let description = [{
@@ -84,6 +89,9 @@ def TTI_ExperimentalLockReleaseOp : TTI_Op<"experimental_lock_release", [MemoryE
     $lock (`,` $pred^)? attr-dict `:` type($lock)
   }];
 }
+
+
+// ===== Barrier based synchronization ops =====
 
 
 def TTI_ExperimentalSetWriteVisibilityOp : TTI_Op<"experimental_set_write_visibility", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
@@ -313,6 +321,9 @@ def TTI_ExperimentalVerifyReadVisibilityOp : TTI_Op<"experimental_verify_read_vi
   }];
   let hasVerifier = 1;
 }
+
+
+// ===== Commit-count–based synchronization ops =====
 
 
 def TTI_ExperimentalStageAccessForCommitOp : TTI_Op<"experimental_stage_access_for_commit", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -409,66 +409,106 @@ def TTI_ExperimentalCheckOutstandingCommitsOp : TTI_Op<"experimental_check_outst
   let hasVerifier = 1;
 }
 
-// ===== Deadlock detection ops =====
 
-def TTI_ExperimentalSetSignallingOp : TTI_Op<"experimental_set_signalling", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
-  let summary = "Mark a barrier as being signalled by a peer thread index";
+// ===== Barrier state ops =====
+
+def TTI_ExperimentalInitBarrierStateOp : TTI_Op<"experimental_init_barrier_state", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "initialize the auxiliary barrier state";
   let description = [{
-    For the barrier row matching mbar, set signalling[row] |= (1 << bitIndex).
+    Initialize the tracked barrier state to phase 0 and set both the initial and current arrival counts.
   }];
   let arguments = (ins
     TTG_MemDescType:$mbar,
-    I32Attr:$bitIndex,
+    I32Attr:$count,
     TT_Tensor:$barriers,
-    TT_PtrLike:$signalling,
-    TypeAttr:$signallingType,
-    Optional<I1>:$pred
+    TT_PtrLike:$states,
+    TypeAttr:$statesType
   );
   let assemblyFormat = [{
-    $mbar `,` $bitIndex `{` $barriers `,` $signalling `(` $signallingType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($signalling)
+    $mbar `,` $count `{` $barriers `,` $states `(` $statesType `)` `}` attr-dict `:` type($mbar) `,` type($barriers) `,` type($states)
   }];
 }
 
-def TTI_ExperimentalMaybeSetWaitingOp : TTI_Op<"experimental_maybe_set_waiting", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
-  let summary = "If barrier has no signalling peers, set waiting bit for base thread";
+def TTI_ExperimentalVerifyBarrierArriveOp : TTI_Op<"experimental_verify_barrier_arrive", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "verify an arrive count against the tracked barrier state";
   let description = [{
-    If signalling[row] == 0 for the matching barrier, set waiting[row] |= (1 << baseThread).
+    Check that applying the arrive count would not drive the tracked current count negative. Triggers an assertion on failure.
+  }];
+  let arguments = (ins
+    TTG_MemDescType:$mbar,
+    I32Attr:$count,
+    TT_Tensor:$barriers,
+    TT_PtrLike:$states,
+    TypeAttr:$statesType,
+    Optional<I1>:$pred
+  );
+  let assemblyFormat = [{
+    $mbar `,` $count `{` $barriers `,` $states `(` $statesType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($states)
+  }];
+}
+
+def TTI_ExperimentalUpdateBarrierStateOp : TTI_Op<"experimental_update_barrier_state", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "update the auxiliary barrier state after a verified arrive";
+  let description = [{
+    Apply an arrive count to the tracked barrier state, toggling the phase when the count reaches zero and reloading the current count from the initial count.
+  }];
+  let arguments = (ins
+    TTG_MemDescType:$mbar,
+    I32Attr:$count,
+    TT_Tensor:$barriers,
+    TT_PtrLike:$states,
+    TypeAttr:$statesType,
+    Optional<I1>:$pred
+  );
+  let assemblyFormat = [{
+    $mbar `,` $count `{` $barriers `,` $states `(` $statesType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($states)
+  }];
+}
+
+// ===== Deadlock detection ops =====
+
+def TTI_ExperimentalSetWaitingOp : TTI_Op<"experimental_set_waiting", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "Mark the base thread as waiting on the given barrier phase";
+  let description = [{
+    For the barrier row matching mbar, set the waiting flag for baseThread and record the barrier phase being waited on.
   }];
   let arguments = (ins
     TTG_MemDescType:$mbar,
     I32Attr:$baseThread,
+    I32:$phase,
     TT_Tensor:$barriers,
     TT_PtrLike:$waiting,
     TypeAttr:$waitingType,
-    TT_PtrLike:$signalling,
-    TypeAttr:$signallingType,
     Optional<I1>:$pred
   );
   let assemblyFormat = [{
-    $mbar `,` $baseThread `{` $barriers `,` $waiting `(` $waitingType `)` `,` $signalling `(` $signallingType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($waiting) `,` type($signalling)
+    $mbar `,` $baseThread `,` $phase `{` $barriers `,` $waiting `(` $waitingType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($waiting)
   }];
 }
 
 def TTI_ExperimentalCheckAllActiveWaitingOp : TTI_Op<"experimental_check_all_active_waiting", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
-  let summary = "Assert that not all active threads are waiting";
+  let summary = "Assert that not all active threads are waiting on matching phases";
   let description = [{
-    OR-reduce waiting rows to a single mask and assert that (waitingMask & activeMask) != activeMask.
+    Filter waiting threads to those whose recorded phase matches the current barrier phase, OR-reduce across barriers, and assert that (waitingMask & activeMask) != activeMask.
   }];
   let arguments = (ins
     I32Attr:$activeMask,
+    TT_Tensor:$barriers,
     TT_PtrLike:$waiting,
     TypeAttr:$waitingType,
+    TT_PtrLike:$barrierStates,
+    TypeAttr:$barrierStatesType,
     Optional<I1>:$pred
   );
   let assemblyFormat = [{
-    $activeMask `,` $waiting `(` $waitingType `)` (`,` $pred^)? attr-dict `:` type($waiting)
+    $activeMask `,` $barriers `,` $waiting `(` $waitingType `)` `,` $barrierStates `(` $barrierStatesType `)` (`,` $pred^)? attr-dict `:` type($barriers) `,` type($waiting) `,` type($barrierStates)
   }];
 }
 
-def TTI_ExperimentalClearWaitingAndSignallingOp : TTI_Op<"experimental_clear_waiting_and_signalling", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
-  let summary = "Clear waiting bit for base thread and reset signalling for barrier";
+def TTI_ExperimentalClearWaitingOp : TTI_Op<"experimental_clear_waiting", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "Clear the waiting state for the given base thread";
   let description = [{
-    For the matching barrier row, clear waiting[row] bit for baseThread and set signalling[row] = 0.
+    For the barrier row matching mbar, clear both the waiting flag and stored phase for baseThread.
   }];
   let arguments = (ins
     TTG_MemDescType:$mbar,
@@ -476,12 +516,10 @@ def TTI_ExperimentalClearWaitingAndSignallingOp : TTI_Op<"experimental_clear_wai
     TT_Tensor:$barriers,
     TT_PtrLike:$waiting,
     TypeAttr:$waitingType,
-    TT_PtrLike:$signalling,
-    TypeAttr:$signallingType,
     Optional<I1>:$pred
   );
   let assemblyFormat = [{
-    $mbar `,` $baseThread `{` $barriers `,` $waiting `(` $waitingType `)` `,` $signalling `(` $signallingType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($waiting) `,` type($signalling)
+    $mbar `,` $baseThread `{` $barriers `,` $waiting `(` $waitingType `)` `}` (`,` $pred^)? attr-dict `:` type($mbar) `,` type($barriers) `,` type($waiting)
   }];
 }
 

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -19,7 +19,8 @@ Operation *createLoadScratchMemory(OpBuilder &b, Location loc, Value alloc,
 Value expandOuterSlicedDim(OpBuilder &b, Location loc, Value tensor);
 TypedValue<RankedTensorType> createConstIntTensor(OpBuilder &builder,
                                                   Location loc, int64_t val,
-                                                  RankedTensorType tensorType);
+                                                  RankedTensorType tensorType,
+                                                  bool isSigned = false);
 FuncOp getEntryPoint(ModuleOp module);
 gpu::DistributedEncodingTrait
 getSingleDimSliceEncoding(gpu::BlockedEncodingAttr encoding, int dim);
@@ -45,6 +46,7 @@ struct AuxDataMap {
 
   RegionToValueMap buffers[numMemTypes];
   RegionToValueMap barriers;
+  RegionToValueMap barrierStates;
 
   RegionToValueMap writeVisibility[numMemTypes];
   RegionToValueMap writeTracking[numMemTypes];
@@ -54,10 +56,8 @@ struct AuxDataMap {
   RegionToValueMap wgmmaCommits;
   RegionToValueMap lock;
   // Deadlock detection aux data
-  // waiting: per-barrier bitmask of base threads waiting (i16)
+  // waiting: per-barrier bitmask storing waiting flag and phase per thread
   RegionToValueMap waiting;
-  // signalling: per-barrier bitmask of peer threads signalling (i32)
-  RegionToValueMap signalling;
 
   void populateAndPassToWarpSpecialize(ModuleOp module);
 

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -53,6 +53,11 @@ struct AuxDataMap {
   RegionToValueMap asyncCpCommits;
   RegionToValueMap wgmmaCommits;
   RegionToValueMap lock;
+  // Deadlock detection aux data
+  // waiting: per-barrier bitmask of base threads waiting (i16)
+  RegionToValueMap waiting;
+  // signalling: per-barrier bitmask of peer threads signalling (i32)
+  RegionToValueMap signalling;
 
   void populateAndPassToWarpSpecialize(ModuleOp module);
 

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -44,6 +44,8 @@ struct AuxDataMap {
     Region *getEnclosingParitionOrFunctionRegion(Operation *op);
   };
 
+  // Please see TritonInstrumentOps.td for more information on the auxiliary
+  // data structures.
   RegionToValueMap buffers[numMemTypes];
   RegionToValueMap barriers;
   RegionToValueMap barrierStates;
@@ -55,8 +57,6 @@ struct AuxDataMap {
   RegionToValueMap asyncCpCommits;
   RegionToValueMap wgmmaCommits;
   RegionToValueMap lock;
-  // Deadlock detection aux data
-  // waiting: per-barrier bitmask storing waiting flag and phase per thread
   RegionToValueMap waiting;
 
   void populateAndPassToWarpSpecialize(ModuleOp module);

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1440,7 +1440,7 @@ def test_deadlock_underarrival(device, run_wrapper):
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 def test_deadlock_different_phases(device, run_wrapper):
     if run_wrapper:
-        result = run_in_process(test_deadlock_underarrival, (device, False))
+        result = run_in_process(test_deadlock_different_phases, (device, False))
         assert result.exc is None
         assert result.driver_stderr_output == ""
         return

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -574,8 +574,6 @@ def test_multibuffered_wgmma_loop(FAILURE, device, run_wrapper):
 
     triton.set_allocator(alloc_fn)
 
-    # ---
-
     @gluon.jit
     def kernel(input_desc, FAILURE: ttgl.constexpr):
         num_buffers: ttgl.constexpr = 2 if FAILURE else 3
@@ -945,6 +943,7 @@ def test_ws_two_loads_two_bars_loop(MISSING_BAR, device, run_wrapper):
     kernel[(1, )](output, MISSING_BAR=MISSING_BAR, num_warps=4)
 
 
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_ws_load_ordering(FAILURE, device, run_wrapper):
     if run_wrapper:

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -945,83 +945,6 @@ def test_ws_two_loads_two_bars_loop(MISSING_BAR, device, run_wrapper):
     kernel[(1, )](output, MISSING_BAR=MISSING_BAR, num_warps=4)
 
 
-@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-def test_deadlock_two_partitions_detected(device, run_wrapper):
-    if run_wrapper:
-        result = run_in_process(test_deadlock_two_partitions_detected, (device, False))
-        assert "device-side assert" in str(result.exc)
-        assert "Deadlock detected" in result.driver_stderr_output
-        return
-    knobs.compilation.enable_experimental_consan = True
-    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
-
-    # ConSan requires a global memory allocation
-    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-        return torch.empty(size, device="cuda", dtype=torch.int8)
-
-    triton.set_allocator(alloc_fn)
-
-    @gluon.jit
-    def ws_default(bar):
-        mbarrier.wait(bar.index(0), phase=0)
-
-    @gluon.jit
-    def ws_1(bar):
-        mbarrier.wait(bar.index(1), phase=0)
-
-    @gluon.jit
-    def kernel():
-        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], mbarrier.MBarrierLayout())
-        mbarrier.init(bar.index(0), count=1)
-        mbarrier.init(bar.index(1), count=1)
-        ttgl.warp_specialize((bar, ), ws_default, (bar, ), [ws_1], [4], [32])
-
-    kernel[(1, )](num_warps=4)
-
-
-@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-def test_deadlock_exempt_when_tma_signals(device, run_wrapper):
-    if run_wrapper:
-        result = run_in_process(test_deadlock_exempt_when_tma_signals, (device, False))
-        assert result.exc is None
-        assert result.driver_stderr_output == ""
-        return
-    knobs.compilation.enable_experimental_consan = True
-    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
-
-    # ConSan requires a global memory allocation
-    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
-        return torch.empty(size, device="cuda", dtype=torch.int8)
-
-    triton.set_allocator(alloc_fn)
-
-    @gluon.jit
-    def ws_default(input_desc, smem, bar):
-        mbarrier.expect(bar.index(0), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
-        tma.async_copy_global_to_shared(input_desc, [0, 0], bar.index(0), smem.index(0))
-        mbarrier.wait(bar.index(0), phase=0)
-
-    @gluon.jit
-    def ws_1(input_desc, smem, bar):
-        mbarrier.expect(bar.index(1), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
-        tma.async_copy_global_to_shared(input_desc, [0, 0], bar.index(1), smem.index(1))
-        mbarrier.wait(bar.index(1), phase=0)
-
-    @gluon.jit
-    def kernel(input_desc):
-        shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
-        smem = ttgl.allocate_shared_memory(ttgl.float16, [2, XBLOCK, XBLOCK], shared_layout)
-        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], mbarrier.MBarrierLayout())
-        mbarrier.init(bar.index(0), count=1)
-        mbarrier.init(bar.index(1), count=1)
-        ttgl.warp_specialize((input_desc, smem, bar), ws_default, (input_desc, smem, bar), [ws_1], [4], [32])
-
-    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
-    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
-    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK.value, XBLOCK.value], shared_layout)
-    kernel[(1, )](input_desc, num_warps=4)
-
-
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_ws_load_ordering(FAILURE, device, run_wrapper):
     if run_wrapper:
@@ -1407,3 +1330,222 @@ def test_ws_wgmma_wait_visibility(FAILURE, device, run_wrapper):
                              (smem, bar, FAILURE, blocked_layout), [ws_1], [4], [32])
 
     kernel[(1, )](FAILURE=FAILURE, num_warps=4)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+def test_deadlock_two_partitions(device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_deadlock_two_partitions, (device, False))
+        assert "device-side assert" in str(result.exc)
+        assert "Deadlock detected" in result.driver_stderr_output
+        return
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    @gluon.jit
+    def ws_default(bar):
+        mbarrier.wait(bar.index(0), phase=0)
+
+    @gluon.jit
+    def ws_1(bar):
+        mbarrier.wait(bar.index(1), phase=0)
+
+    @gluon.jit
+    def kernel():
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar.index(0), count=1)
+        mbarrier.init(bar.index(1), count=1)
+        ttgl.warp_specialize((bar, ), ws_default, (bar, ), [ws_1], [4], [32])
+
+    kernel[(1, )](num_warps=4)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+def test_deadlock_overarrival(device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_deadlock_overarrival, (device, False))
+        assert "device-side assert" in str(result.exc)
+        assert "Deadlock detected" in result.driver_stderr_output
+        return
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    @gluon.jit
+    def ws_default(bar):
+        mbarrier.arrive(bar.index(1), count=1)
+        mbarrier.arrive(bar.index(1), count=1)
+        mbarrier.wait(bar.index(0), phase=0)
+
+    @gluon.jit
+    def ws_1(bar):
+        mbarrier.wait(bar.index(1), phase=0)
+
+    @gluon.jit
+    def kernel():
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar.index(0), count=1)
+        mbarrier.init(bar.index(1), count=1)
+        ttgl.warp_specialize((bar, ), ws_default, (bar, ), [ws_1], [4], [32])
+
+    kernel[(1, )](num_warps=4)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+def test_deadlock_underarrival(device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_deadlock_underarrival, (device, False))
+        assert "device-side assert" in str(result.exc)
+        assert "Deadlock detected" in result.driver_stderr_output
+        return
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    @gluon.jit
+    def ws_default(bar):
+        mbarrier.arrive(bar.index(1), count=1)
+        mbarrier.wait(bar.index(0), phase=0)
+
+    @gluon.jit
+    def ws_1(bar):
+        mbarrier.arrive(bar.index(0), count=1)
+        mbarrier.wait(bar.index(1), phase=0)
+
+    @gluon.jit
+    def kernel():
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar.index(0), count=2)
+        mbarrier.init(bar.index(1), count=2)
+        ttgl.warp_specialize((bar, ), ws_default, (bar, ), [ws_1], [4], [32])
+
+    kernel[(1, )](num_warps=4)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+def test_deadlock_different_phases(device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_deadlock_underarrival, (device, False))
+        assert result.exc is None
+        assert result.driver_stderr_output == ""
+        return
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    @gluon.jit
+    def ws_default(bar):
+        mbarrier.wait(bar.index(0), phase=0)
+        mbarrier.arrive(bar.index(0), count=1)
+
+    @gluon.jit
+    def ws_1(bar):
+        mbarrier.wait(bar.index(0), phase=1)
+
+    @gluon.jit
+    def kernel():
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1, 1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar.index(0), count=1)
+        mbarrier.arrive(bar.index(0), count=1)
+        ttgl.warp_specialize((bar, ), ws_default, (bar, ), [ws_1], [4], [32])
+
+    kernel[(1, )](num_warps=4)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+def test_deadlock_exempt_when_tma_signals(device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_deadlock_exempt_when_tma_signals, (device, False))
+        assert result.exc is None
+        assert result.driver_stderr_output == ""
+        return
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    @gluon.jit
+    def ws_default(input_desc, smem, bar):
+        mbarrier.expect(bar.index(0), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+        tma.async_copy_global_to_shared(input_desc, [0, 0], bar.index(0), smem.index(0))
+        mbarrier.wait(bar.index(0), phase=0)
+
+    @gluon.jit
+    def ws_1(input_desc, smem, bar):
+        mbarrier.expect(bar.index(1), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+        tma.async_copy_global_to_shared(input_desc, [0, 0], bar.index(1), smem.index(1))
+        mbarrier.wait(bar.index(1), phase=0)
+
+    @gluon.jit
+    def kernel(input_desc):
+        shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [2, XBLOCK, XBLOCK], shared_layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar.index(0), count=1)
+        mbarrier.init(bar.index(1), count=1)
+        ttgl.warp_specialize((input_desc, smem, bar), ws_default, (input_desc, smem, bar), [ws_1], [4], [32])
+
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK.value, XBLOCK.value], shared_layout)
+    kernel[(1, )](input_desc, num_warps=4)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+def test_barrier_underflow(device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_barrier_underflow, (device, False))
+        assert "device-side assert" in str(result.exc)
+        assert "Barrier arrive underflow: current count would become negative" in result.driver_stderr_output
+        return
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    @gluon.jit
+    def ws_default(bar):
+        mbarrier.arrive(bar.index(1), count=2)
+        mbarrier.wait(bar.index(0), phase=0)
+
+    @gluon.jit
+    def ws_1(bar):
+        mbarrier.wait(bar.index(1), phase=0)
+
+    @gluon.jit
+    def kernel():
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar.index(0), count=1)
+        mbarrier.init(bar.index(1), count=1)
+        ttgl.warp_specialize((bar, ), ws_default, (bar, ), [ws_1], [4], [32])
+
+    kernel[(1, )](num_warps=4)

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -574,6 +574,8 @@ def test_multibuffered_wgmma_loop(FAILURE, device, run_wrapper):
 
     triton.set_allocator(alloc_fn)
 
+    # ---
+
     @gluon.jit
     def kernel(input_desc, FAILURE: ttgl.constexpr):
         num_buffers: ttgl.constexpr = 2 if FAILURE else 3
@@ -944,6 +946,82 @@ def test_ws_two_loads_two_bars_loop(MISSING_BAR, device, run_wrapper):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+def test_deadlock_two_partitions_detected(device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_deadlock_two_partitions_detected, (device, False))
+        assert "device-side assert" in str(result.exc)
+        assert "Deadlock detected" in result.driver_stderr_output
+        return
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    @gluon.jit
+    def ws_default(bar):
+        mbarrier.wait(bar.index(0), phase=0)
+
+    @gluon.jit
+    def ws_1(bar):
+        mbarrier.wait(bar.index(1), phase=0)
+
+    @gluon.jit
+    def kernel():
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar.index(0), count=1)
+        mbarrier.init(bar.index(1), count=1)
+        ttgl.warp_specialize((bar, ), ws_default, (bar, ), [ws_1], [4], [32])
+
+    kernel[(1, )](num_warps=4)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+def test_deadlock_exempt_when_tma_signals(device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(test_deadlock_exempt_when_tma_signals, (device, False))
+        assert result.exc is None
+        assert result.driver_stderr_output == ""
+        return
+    knobs.compilation.enable_experimental_consan = True
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    # ConSan requires a global memory allocation
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    @gluon.jit
+    def ws_default(input_desc, smem, bar):
+        mbarrier.expect(bar.index(0), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+        tma.async_copy_global_to_shared(input_desc, [0, 0], bar.index(0), smem.index(0))
+        mbarrier.wait(bar.index(0), phase=0)
+
+    @gluon.jit
+    def ws_1(input_desc, smem, bar):
+        mbarrier.expect(bar.index(1), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+        tma.async_copy_global_to_shared(input_desc, [0, 0], bar.index(1), smem.index(1))
+        mbarrier.wait(bar.index(1), phase=0)
+
+    @gluon.jit
+    def kernel(input_desc):
+        shared_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [2, XBLOCK, XBLOCK], shared_layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar.index(0), count=1)
+        mbarrier.init(bar.index(1), count=1)
+        ttgl.warp_specialize((input_desc, smem, bar), ws_default, (input_desc, smem, bar), [ws_1], [4], [32])
+
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK.value, XBLOCK.value], shared_layout)
+    kernel[(1, )](input_desc, num_warps=4)
+
+
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_ws_load_ordering(FAILURE, device, run_wrapper):
     if run_wrapper:

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -194,6 +194,39 @@ tt.func private @experimental_set_read_visibility(
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_copy_write_visibility
+// CHECK: st.global
+tt.func private @experimental_copy_write_visibility(
+  %writeVis: !tt.ptr<i64>
+) {
+  tti.experimental_copy_write_visibility 0, 6{%writeVis(tensor<2xi64, #blocked>)} : !tt.ptr<i64>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blockedThreads = #ttg.blocked<{sizePerThread = [2, 64], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_copy_read_visibility
+// CHECK: st.global
+tt.func private @experimental_copy_read_visibility(
+  %readVis: !tt.ptr<i64>
+) {
+  tti.experimental_copy_read_visibility 0, 6{%readVis(tensor<2x64xi64, #blockedThreads>)} : !tt.ptr<i64>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [2, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -12,6 +12,78 @@ tt.func private @experimental_buffer_pointers_tmem() {
 }
 
 // -----
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_set_signalling
+// CHECK: st.global
+tt.func private @experimental_set_signalling(
+  %mbar: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
+  %barriers: tensor<2xi64, #blocked>,
+  %signalling: !tt.ptr<i32>
+) {
+  tti.experimental_set_signalling %mbar, 3{%barriers, %signalling(tensor<2xi32, #blocked>)} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i32>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_maybe_set_waiting
+// CHECK: st.global
+tt.func private @experimental_maybe_set_waiting(
+  %mbar: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
+  %barriers: tensor<2xi64, #blocked>,
+  %waiting: !tt.ptr<i16>,
+  %signalling: !tt.ptr<i32>
+) {
+  tti.experimental_maybe_set_waiting %mbar, 5{%barriers, %waiting(tensor<2xi16, #blocked>), %signalling(tensor<2xi32, #blocked>)} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i16>, !tt.ptr<i32>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_check_all_active_waiting
+// CHECK: @__assertfail
+tt.func private @experimental_check_all_active_waiting(
+  %waiting: !tt.ptr<i16>
+) {
+  // active mask 3 -> two active base threads (bits 0 and 1)
+  tti.experimental_check_all_active_waiting 3, %waiting(tensor<2xi16, #blocked>) : !tt.ptr<i16>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_clear_waiting_and_signalling
+// CHECK: st.global
+tt.func private @experimental_clear_waiting_and_signalling(
+  %mbar: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
+  %barriers: tensor<2xi64, #blocked>,
+  %waiting: !tt.ptr<i16>,
+  %signalling: !tt.ptr<i32>
+) {
+  tti.experimental_clear_waiting_and_signalling %mbar, 7{%barriers, %waiting(tensor<2xi16, #blocked>), %signalling(tensor<2xi32, #blocked>)} : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, tensor<2xi64, #blocked>, !tt.ptr<i16>, !tt.ptr<i32>
+  tt.return
+}
+}
+
+// -----
 
 #blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 
@@ -472,6 +544,9 @@ tt.func private @experimental_assert_in_thread_all(
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
 // CHECK-LABEL: @experimental_lock_acquire
 // CHECK: 09atom.global.acquire.gpu.cas.b32
@@ -487,6 +562,9 @@ tt.func private @experimental_lock_acquire(
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
 // CHECK-LABEL: @experimental_lock_release
 // CHECK: nvvm.barrier0

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -179,6 +179,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tti.experimental_init_barrier_state {{.*}}, 1{%[[BARRIERS]],
     // CHECK: tti.experimental_verify_write_visibility {{.*}}, 16{%[[BUFFERS]], %[[WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>)}, "", %true
     // CHECK: tti.experimental_verify_read_visibility {{.*}}, 16{%[[BUFFERS]], %[[READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>)}, "", %true
     // CHECK: tti.experimental_set_write_visibility {{.*}}, 65536{%[[BUFFERS]], %[[WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>)}, %true
@@ -186,7 +187,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tti.experimental_clear_read_visibility {{.*}}{%[[BUFFERS]], %[[READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>)}, %true
     // CHECK: tti.experimental_clear_read_tracking {{.*}}{%[[BUFFERS]], %[[READ_TRACKING_GLOB]](tensor<1x1xi64, #{{.*}}>)}, %true
     // CHECK: tti.experimental_track_visible_writes {{.*}}, 16{%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>), %[[WRITE_TRACKING_GLOB]](tensor<1x1xi8, #{{.*}}>)}
-    // CHECK: tti.experimental_set_signalling
+    // CHECK: tti.experimental_verify_barrier_arrive {{.*}}, 1
+    // CHECK: tti.experimental_update_barrier_state {{.*}}, 1
     ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %bar, %true : !tt.tensordesc<tensor<32x32xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -306,14 +308,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
-    // CHECK-DAG: tti.experimental_maybe_set_waiting %{{.*}}, 0
-    // CHECK-DAG: tti.experimental_check_all_active_waiting 1
+    // CHECK-DAG: tti.experimental_set_waiting %{{.*}}, 0, %c0_i32
+    // CHECK-DAG: tti.experimental_check_all_active_waiting 1, %[[BARRIERS]], {{.*}}, {{.*}}
     // CHECK: ttng.wait_barrier
     ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
     // CHECK: tti.experimental_transfer_visible_writes {{.*}}{%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>), %[[WRITE_TRACKING_GLOB]](tensor<1x1xi8, #{{.*}}>)}
     // CHECK: tti.experimental_transfer_visible_reads {{.*}}{%[[BARRIERS]], %[[READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>), %[[READ_TRACKING_GLOB]](tensor<1x1xi64, #{{.*}}>)}
-    // CHECK: tti.experimental_clear_waiting_and_signalling
+    // CHECK: tti.experimental_clear_waiting
     // CHECK: tti.experimental_lock_release
     tt.return
   }
@@ -327,16 +329,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @arrive_barrier
   tt.func public @arrive_barrier(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
+    // CHECK-DAG: %[[BSTATE_INIT:.*]] = arith.constant dense<0> : tensor<1xi32, #{{.*}}>
+    // CHECK-DAG: %[[BSTATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 4 : i32, nbytes = 4 : i32} : !tt.ptr<i32>
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tti.experimental_init_barrier_state {{.*}}, 1
     // CHECK: tti.experimental_lock_acquire
     // CHECK: tti.experimental_track_visible_writes
     // CHECK: tti.experimental_track_visible_reads
+    // CHECK: tti.experimental_verify_barrier_arrive {{.*}}, 2
+    // CHECK: tti.experimental_update_barrier_state {{.*}}, 2
     // CHECK: tti.experimental_lock_release
-    ttng.arrive_barrier %bar, 1, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.arrive_barrier %bar, 2, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
 }
@@ -365,16 +372,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: tti.experimental_verify_write_visibility %[[A:.*]], 32{%[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]](tensor<2xi64, #{{.*}}>)}, "A", %true
     // CHECK: tti.experimental_set_read_visibility %[[A]], 4294967296{%[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>)}, %true
-    // CHECK: tti.experimental_track_visible_reads %[[BAR:.*]], 32{%[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>), %[[SM_READ_TRACKING_GLOB]](tensor<2x1xi64, #{{.*}}>)}
     // CHECK: tti.experimental_verify_write_visibility %[[B:.*]], 32{%[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]](tensor<2xi64, #{{.*}}>)}, "B", %true
     // CHECK: tti.experimental_set_read_visibility %[[B]], 4294967296{%[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>)}, %true
-    // CHECK: tti.experimental_track_visible_reads %[[BAR]], 32{%[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>), %[[SM_READ_TRACKING_GLOB]](tensor<2x1xi64, #{{.*}}>)}
     // CHECK: tti.experimental_verify_write_visibility %[[ACC:.*]], 32{%[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>)}, "Acc", %true
     // CHECK: tti.experimental_verify_read_visibility %[[ACC]], 32{%[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>)}, "Acc", %true
     // CHECK: tti.experimental_set_write_visibility %[[ACC]], 4294967296{%[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>)}, %true
     // CHECK: tti.experimental_clear_write_tracking %[[ACC]]{%[[TM_BUFS]], %[[TM_WRITE_TRACKING_GLOB]](tensor<1x1xi8, #{{.*}}>)}, %true
     // CHECK: tti.experimental_clear_read_visibility %[[ACC]]{%[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>)}, %true
     // CHECK: tti.experimental_clear_read_tracking %[[ACC]]{%[[TM_BUFS]], %[[TM_READ_TRACKING_GLOB]](tensor<1x1xi64, #{{.*}}>)}, %true
+    // CHECK: tti.experimental_track_visible_writes %[[BAR:.*]], 32{%[[BARRIERS]], %[[SM_WRITE_VISIBILITY_GLOB]](tensor<2xi64, #{{.*}}>), %[[SM_WRITE_TRACKING_GLOB]](tensor<2x1xi8, #{{.*}}>)}
+    // CHECK: tti.experimental_track_visible_reads %[[BAR]], 32{%[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>), %[[SM_READ_TRACKING_GLOB]](tensor<2x1xi64, #{{.*}}>)}
     // CHECK: tti.experimental_track_visible_writes %[[BAR]], 32{%[[BARRIERS]], %[[TM_WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>), %[[TM_WRITE_TRACKING_GLOB]](tensor<1x1xi8, #{{.*}}>)}
     // CHECK: tti.experimental_track_visible_reads %[[BAR]], 32{%[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>), %[[TM_READ_TRACKING_GLOB]](tensor<1x1xi64, #{{.*}}>)}
     // CHECK: ttng.tc_gen5_mma %[[A]], %[[B]], %[[ACC]][], {{.*}}, {{.*}}, %[[BAR]]
@@ -415,21 +422,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: tti.experimental_verify_write_visibility %[[A:.*]], 32{%[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]](tensor<2xi64, #{{.*}}>)}, "A", %true
     // CHECK: tti.experimental_set_read_visibility %[[A]], 4294967296{%[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>)}, %true
-    // CHECK: tti.experimental_track_visible_reads %[[BAR:.*]], 32{%[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>), %[[TM_READ_TRACKING_GLOB]](tensor<2x1xi64, #{{.*}}>)}
-    // CHECK: tti.experimental_set_signalling %[[BAR]], 16
     // CHECK: tti.experimental_verify_write_visibility %[[B:.*]], 32{%[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>)}, "B", %true
     // CHECK: tti.experimental_set_read_visibility %[[B]], 4294967296{%[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>)}, %true
-    // CHECK: tti.experimental_track_visible_reads %[[BAR]], 32{%[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>), %[[SM_READ_TRACKING_GLOB]](tensor<1x1xi64, #{{.*}}>)}
-    // CHECK: tti.experimental_set_signalling %[[BAR]], 16
     // CHECK: tti.experimental_verify_write_visibility %[[ACC:.*]], 32{%[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]](tensor<2xi64, #{{.*}}>)}, "Acc", %true
     // CHECK: tti.experimental_verify_read_visibility %[[ACC]], 32{%[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>)}, "Acc"
     // CHECK: tti.experimental_set_write_visibility %[[ACC]], 4294967296{%[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]](tensor<2xi64, #{{.*}}>)}, %true
     // CHECK: tti.experimental_clear_write_tracking %[[ACC]]{%[[TM_BUFS]], %[[TM_WRITE_TRACKING_GLOB]](tensor<2x1xi8, #{{.*}}>)}, %true
     // CHECK: tti.experimental_clear_read_visibility %[[ACC]]{%[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>)}, %true
     // CHECK: tti.experimental_clear_read_tracking %[[ACC]]{%[[TM_BUFS]], %[[TM_READ_TRACKING_GLOB]](tensor<2x1xi64, #{{.*}}>)}, %true
+    // CHECK: tti.experimental_track_visible_writes %[[BAR:.*]], 32{%[[BARRIERS]], %[[SM_WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>), %[[SM_WRITE_TRACKING_GLOB]](tensor<1x1xi8, #{{.*}}>)}
+    // CHECK: tti.experimental_track_visible_reads %[[BAR]], 32{%[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>), %[[SM_READ_TRACKING_GLOB]](tensor<1x1xi64, #{{.*}}>)}
     // CHECK: tti.experimental_track_visible_writes %[[BAR]], 32{%[[BARRIERS]], %[[TM_WRITE_VISIBILITY_GLOB]](tensor<2xi64, #{{.*}}>), %[[TM_WRITE_TRACKING_GLOB]](tensor<2x1xi8, #{{.*}}>)}
     // CHECK: tti.experimental_track_visible_reads %[[BAR]], 32{%[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>), %[[TM_READ_TRACKING_GLOB]](tensor<2x1xi64, #{{.*}}>)}
-    // CHECK: tti.experimental_set_signalling %[[BAR]], 16
+    // CHECK: tti.experimental_verify_barrier_arrive %[[BAR]], 1
+    // CHECK: tti.experimental_update_barrier_state %[[BAR]], 1
     // CHECK: tti.experimental_lock_release
     // CHECK: ttng.tc_gen5_mma %[[A]], %[[B]], %[[ACC]][], {{.*}}, {{.*}}, %[[BAR]]
     %c0_i32 = arith.constant 0 : i32
@@ -453,15 +459,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @tcgen5_commit
   tt.func public @tcgen5_commit(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
-    // CHECK: tti.experimental_track_visible_writes
-    // CHECK: tti.experimental_track_visible_reads
-    // CHECK-DAG: tti.experimental_set_signalling
+
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %result = ttng.tmem_alloc  {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
     %bar = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tti.experimental_init_barrier_state {{.*}}, 1
     %true = arith.constant true
+    // CHECK: tti.experimental_track_visible_writes
+    // CHECK: tti.experimental_track_visible_reads
+    // CHECK: tti.experimental_track_visible_writes
+    // CHECK: tti.experimental_track_visible_reads
+    // CHECK: tti.experimental_verify_barrier_arrive {{.*}}, 1
+    // CHECK: tti.experimental_update_barrier_state {{.*}}, 1
     ttng.tc_gen5_commit %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
@@ -869,8 +880,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
       // CHECK: tti.experimental_lock_acquire
-      // CHECK: tti.experimental_maybe_set_waiting %{{.*}}, 0
-      // CHECK: tti.experimental_check_all_active_waiting 3
+      // CHECK: tti.experimental_set_waiting %{{.*}}, 0, %c0_i32
+      // CHECK: tti.experimental_check_all_active_waiting 3, {{.*}}, {{.*}}, {{.*}}
       // CHECK: tti.experimental_lock_release
       %c0_i32 = arith.constant 0 : i32
       %true = arith.constant true
@@ -880,8 +891,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     partition0(%arg1: !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) num_warps(4) {
       // CHECK: partition0
       // CHECK: tti.experimental_lock_acquire
-      // CHECK: tti.experimental_maybe_set_waiting %{{.*}}, 1
-      // CHECK: tti.experimental_check_all_active_waiting 3
+      // CHECK: tti.experimental_set_waiting %{{.*}}, 1, %c0_i32
+      // CHECK: tti.experimental_check_all_active_waiting 3, {{.*}}, {{.*}}, {{.*}}
       // CHECK: tti.experimental_lock_release
       %c0_i32 = arith.constant 0 : i32
       %true = arith.constant true

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -785,6 +785,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tti.experimental_copy_write_visibility 0, 8590065666
+    // CHECK: tti.experimental_copy_read_visibility 0, 8590065666
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
       // CHECK: tti.experimental_lock_acquire
@@ -823,6 +825,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tti.experimental_copy_write_visibility 0, 8590065666
+    // CHECK: tti.experimental_copy_read_visibility 0, 8590065666
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
       %c0_i32 = arith.constant 0 : i32
@@ -851,6 +855,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tti.experimental_copy_write_visibility 0, 8590065666
+    // CHECK: tti.experimental_copy_read_visibility 0, 8590065666
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
       ttg.warp_yield

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -186,6 +186,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tti.experimental_clear_read_visibility {{.*}}{%[[BUFFERS]], %[[READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>)}, %true
     // CHECK: tti.experimental_clear_read_tracking {{.*}}{%[[BUFFERS]], %[[READ_TRACKING_GLOB]](tensor<1x1xi64, #{{.*}}>)}, %true
     // CHECK: tti.experimental_track_visible_writes {{.*}}, 16{%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>), %[[WRITE_TRACKING_GLOB]](tensor<1x1xi8, #{{.*}}>)}
+    // CHECK: tti.experimental_set_signalling
     ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %bar, %true : !tt.tensordesc<tensor<32x32xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -305,11 +306,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK-DAG: tti.experimental_maybe_set_waiting %{{.*}}, 0
+    // CHECK-DAG: tti.experimental_check_all_active_waiting 1
+    // CHECK: ttng.wait_barrier
+    ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
     // CHECK: tti.experimental_transfer_visible_writes {{.*}}{%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>), %[[WRITE_TRACKING_GLOB]](tensor<1x1xi8, #{{.*}}>)}
     // CHECK: tti.experimental_transfer_visible_reads {{.*}}{%[[BARRIERS]], %[[READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>), %[[READ_TRACKING_GLOB]](tensor<1x1xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_clear_waiting_and_signalling
     // CHECK: tti.experimental_lock_release
-    ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
 }
@@ -411,9 +416,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tti.experimental_verify_write_visibility %[[A:.*]], 32{%[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]](tensor<2xi64, #{{.*}}>)}, "A", %true
     // CHECK: tti.experimental_set_read_visibility %[[A]], 4294967296{%[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>)}, %true
     // CHECK: tti.experimental_track_visible_reads %[[BAR:.*]], 32{%[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>), %[[TM_READ_TRACKING_GLOB]](tensor<2x1xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_set_signalling %[[BAR]], 16
     // CHECK: tti.experimental_verify_write_visibility %[[B:.*]], 32{%[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]](tensor<1xi64, #{{.*}}>)}, "B", %true
     // CHECK: tti.experimental_set_read_visibility %[[B]], 4294967296{%[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>)}, %true
     // CHECK: tti.experimental_track_visible_reads %[[BAR]], 32{%[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]](tensor<1x64xi64, #{{.*}}>), %[[SM_READ_TRACKING_GLOB]](tensor<1x1xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_set_signalling %[[BAR]], 16
     // CHECK: tti.experimental_verify_write_visibility %[[ACC:.*]], 32{%[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]](tensor<2xi64, #{{.*}}>)}, "Acc", %true
     // CHECK: tti.experimental_verify_read_visibility %[[ACC]], 32{%[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>)}, "Acc"
     // CHECK: tti.experimental_set_write_visibility %[[ACC]], 4294967296{%[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]](tensor<2xi64, #{{.*}}>)}, %true
@@ -422,6 +429,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tti.experimental_clear_read_tracking %[[ACC]]{%[[TM_BUFS]], %[[TM_READ_TRACKING_GLOB]](tensor<2x1xi64, #{{.*}}>)}, %true
     // CHECK: tti.experimental_track_visible_writes %[[BAR]], 32{%[[BARRIERS]], %[[TM_WRITE_VISIBILITY_GLOB]](tensor<2xi64, #{{.*}}>), %[[TM_WRITE_TRACKING_GLOB]](tensor<2x1xi8, #{{.*}}>)}
     // CHECK: tti.experimental_track_visible_reads %[[BAR]], 32{%[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]](tensor<2x64xi64, #{{.*}}>), %[[TM_READ_TRACKING_GLOB]](tensor<2x1xi64, #{{.*}}>)}
+    // CHECK: tti.experimental_set_signalling %[[BAR]], 16
+    // CHECK: tti.experimental_lock_release
     // CHECK: ttng.tc_gen5_mma %[[A]], %[[B]], %[[ACC]][], {{.*}}, {{.*}}, %[[BAR]]
     %c0_i32 = arith.constant 0 : i32
     %0 = ttng.tmem_alloc  {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem1, #ttng.tensor_memory, mutable>
@@ -446,8 +455,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @tcgen5_commit(%arg0: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
     // CHECK: tti.experimental_track_visible_writes
     // CHECK: tti.experimental_track_visible_reads
-    // CHECK: tti.experimental_track_visible_writes
-    // CHECK: tti.experimental_track_visible_reads
+    // CHECK-DAG: tti.experimental_set_signalling
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %result = ttng.tmem_alloc  {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
@@ -841,6 +849,45 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       %1 = ttg.memdesc_index %arg1[%c0_i32] : !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
       ttg.warp_return
     } : (!ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 2>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @ws_wait_barrier
+  tt.func public @ws_wait_barrier() {
+    %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
+    default {
+      // CHECK: tti.experimental_lock_acquire
+      // CHECK: tti.experimental_maybe_set_waiting %{{.*}}, 0
+      // CHECK: tti.experimental_check_all_active_waiting 3
+      // CHECK: tti.experimental_lock_release
+      %c0_i32 = arith.constant 0 : i32
+      %true = arith.constant true
+      ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+      ttg.warp_yield
+    }
+    partition0(%arg1: !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) num_warps(4) {
+      // CHECK: partition0
+      // CHECK: tti.experimental_lock_acquire
+      // CHECK: tti.experimental_maybe_set_waiting %{{.*}}, 1
+      // CHECK: tti.experimental_check_all_active_waiting 3
+      // CHECK: tti.experimental_lock_release
+      %c0_i32 = arith.constant 0 : i32
+      %true = arith.constant true
+      ttng.wait_barrier %arg2, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>) -> ()
     tt.return
   }
 }


### PR DESCRIPTION
Adding deadlock detection to ConSan.
To detect deadlocks we first need to keep track of the barrier state - we introduce `barrierState` count and phase aux structure that encodes information about phase, init_count and current_count. We then instrument barrier inits and arrivals - init set up init_count = current_count = cout; phase = 0. Arrival decrements current_count and if it hits 0, flips the phase and re-sets current_count. We treat TMA and TC commits as barrier arrivals with count=1.
With that information we can then check if all the threads are waiting (which constitutes a deadlock). To do that we instrument entries and exits from barrier_wait. We introduce `waiting` aux structure, that keeps track of waiting threads, and mapping to which barrier they are waiting on. When issuing a wait, the thread adds itself to the `waiting`, and checks if all the other threads are also waiting. Thread that waits on a barrier with phase that does not match the current phase of that barrier (info from `barrierState`) is not considered waiting.
Verified that we catch deadlocks with cases like barriers underarrival (didn't flip the phase), overarrival (flipped the phase too many times), etc. 