### PR TITLE
[AMD] Fix wmma instructions for bf8 data type

### DIFF
--- a/test/Conversion/amd/tritongpu_wmma_dot_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_wmma_dot_to_llvm.mlir
@@ -9,6 +9,7 @@
 #mma2_i4 = #ttg.amd_wmma<{version = 2, warpsPerCTA = [2, 2], isTranspose = true, instrShape = [16, 16, 32]}>
 #mma3 = #ttg.amd_wmma<{version = 3, warpsPerCTA = [2, 2], instrShape = [16, 16, 32]}>
 #mma3_transposed = #ttg.amd_wmma<{version = 3, warpsPerCTA = [2, 2], isTranspose = true, instrShape = [16, 16, 32]}>
+#mma3_f8 = #ttg.amd_wmma<{version = 3, warpsPerCTA = [2, 2], instrShape = [16, 16, 64]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   //  CHECK-LABEL: wmma1_dot_operand
@@ -180,7 +181,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
     // CHECK-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
     // CHECK-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
-    // CHECK: llvm.call_intrinsic "llvm.amdgcn.wmma.f16.16x16x16.f16.v8f16.v8f16"{{.*}} : (vector<8xf16>, vector<8xf16>, vector<8xf16>, i1) -> vector<8xf16>
+    // CHECK: wmma.f16.16x16x16.f16{{.*}} : (vector<8xf16>, vector<8xf16>, vector<8xf16>, i1) -> vector<8xf16>
     %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma2, kWidth = 8}>> * tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma2, kWidth = 8}>> -> tensor<16x16xf16, #mma2>
     // CHECK-COUNT-8: llvm.extractelement {{.*}} : vector<8xf16>
     // CHECK-COUNT-8: llvm.insertelement {{.*}} : vector<1xf16>
@@ -191,18 +192,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
   // CHECK-LABEL: wmma2_transposed_dot
   tt.func @wmma2_transposed_dot(%arg0: tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma2_transposed, kWidth = 8}>>, %arg1: tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma2_transposed, kWidth = 8}>>, %arg2: tensor<16x16xf16, #mma2_transposed>) {
-    // CHECK: llvm.call_intrinsic "llvm.amdgcn.wmma.f16.16x16x16.f16.v8f16.v8f16"{{.*}} : (vector<8xf16>, vector<8xf16>, vector<8xf16>, i1) -> vector<8xf16>
+    // CHECK: wmma.f16.16x16x16.f16{{.*}} : (vector<8xf16>, vector<8xf16>, vector<8xf16>, i1) -> vector<8xf16>
     %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma2_transposed, kWidth = 8}>> * tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma2_transposed, kWidth = 8}>> -> tensor<16x16xf16, #mma2_transposed>
     tt.return
   }
 
-  //  GFX1250-LABEL: wmma3_dot_bf16
+  // GFX1250-LABEL: wmma3_dot_bf16
   tt.func @wmma3_dot_bf16(%arg0: tensor<16x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma3, kWidth = 8}>>, %arg1: tensor<32x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma3, kWidth = 8}>>, %arg2: tensor<16x16xf32, #mma3>, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
     // GFX1250-COUNT-16: llvm.insertelement {{.*}} : vector<16xbf16>
     // GFX1250-COUNT-16: llvm.insertelement {{.*}} : vector<16xbf16>
     // GFX1250-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GFX1250-COUNT-8: llvm.insertelement {{.*}} : vector<8xf32>
-    // GFX1250: wmma.f32.16x16x32.bf16.v8f32.v16bf16{{.*}} : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<8xf32>, i1, i1) -> vector<8xf32>
+    // GFX1250: wmma.f32.16x16x32.bf16{{.*}} : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<8xf32>, i1, i1) -> vector<8xf32>
     %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma3, kWidth = 8}>> * tensor<32x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma3, kWidth = 8}>> -> tensor<16x16xf32, #mma3>
 
     %ptr0 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>, #mma3>
@@ -210,17 +211,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 
-  //  GFX1250-LABEL: wmma3_transposed_dot_bf16
+  // GFX1250-LABEL: wmma3_transposed_dot_bf16
   tt.func @wmma3_transposed_dot_bf16(%arg0: tensor<16x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma3_transposed, kWidth = 8}>>, %arg1: tensor<32x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma3_transposed, kWidth = 8}>>, %arg2: tensor<16x16xf32, #mma3_transposed>, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
     // GFX1250-COUNT-16: llvm.insertelement {{.*}} : vector<16xbf16>
     // GFX1250-COUNT-16: llvm.insertelement {{.*}} : vector<16xbf16>
     // GFX1250-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GFX1250-COUNT-8: llvm.insertelement {{.*}} : vector<8xf32>
-    // GFX1250: wmma.f32.16x16x32.bf16.v8f32.v16bf16{{.*}} : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<8xf32>, i1, i1) -> vector<8xf32>
+    // GFX1250: wmma.f32.16x16x32.bf16{{.*}} : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<8xf32>, i1, i1) -> vector<8xf32>
     %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma3_transposed, kWidth = 8}>> * tensor<32x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma3_transposed, kWidth = 8}>> -> tensor<16x16xf32, #mma3_transposed>
 
     %ptr0 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>, #mma3_transposed>
     tt.store %ptr0, %0 : tensor<16x16x!tt.ptr<f32>, #mma3_transposed>
+    tt.return
+  }
+
+  // GFX1250-LABEL: wmma3_dot_bf8
+  tt.func @wmma3_dot_bf8(%arg0: tensor<16x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #mma3_f8, kWidth = 8}>>, %arg1: tensor<64x16xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #mma3_f8, kWidth = 8}>>, %arg2: tensor<16x16xf32, #mma3_f8>, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
+    // GFX1250-COUNT-16: llvm.insertelement {{.*}} : vector<32xi8>
+    // GFX1250-COUNT-16: llvm.insertelement {{.*}} : vector<32xi8>
+    // GFX1250-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
+    // GFX1250-COUNT-8: llvm.insertelement {{.*}} : vector<8xf32>
+    // GFX1250: wmma.f32.16x16x64.bf8.bf8{{.*}} : (vector<8xi32>, vector<8xi32>, i16, vector<8xf32>, i1, i1) -> vector<8xf32>
+    %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #mma3_f8, kWidth = 8}>> * tensor<64x16xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #mma3_f8, kWidth = 8}>> -> tensor<16x16xf32, #mma3_f8>
+
+    %ptr0 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>, #mma3_f8>
+    tt.store %ptr0, %0 : tensor<16x16x!tt.ptr<f32>, #mma3_f8>
     tt.return
   }
 

--- a/test/Conversion/amd/tritongpu_wmma_dot_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_wmma_dot_to_llvm.mlir
@@ -202,7 +202,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // GFX1250-COUNT-16: llvm.insertelement {{.*}} : vector<16xbf16>
     // GFX1250-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GFX1250-COUNT-8: llvm.insertelement {{.*}} : vector<8xf32>
-    // GFX1250: wmma.f32.16x16x32.bf16.bf16{{.*}} : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<8xf32>, i1, i1) -> vector<8xf32>
+    // GFX1250: wmma.f32.16x16x32.bf16.v8f32.v16bf16{{.*}} : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<8xf32>, i1, i1) -> vector<8xf32>
     %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma3, kWidth = 8}>> * tensor<32x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma3, kWidth = 8}>> -> tensor<16x16xf32, #mma3>
 
     %ptr0 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>, #mma3>
@@ -216,7 +216,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // GFX1250-COUNT-16: llvm.insertelement {{.*}} : vector<16xbf16>
     // GFX1250-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32)>
     // GFX1250-COUNT-8: llvm.insertelement {{.*}} : vector<8xf32>
-    // GFX1250: wmma.f32.16x16x32.bf16.bf16{{.*}} : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<8xf32>, i1, i1) -> vector<8xf32>
+    // GFX1250: wmma.f32.16x16x32.bf16.v8f32.v16bf16{{.*}} : (i1, vector<16xbf16>, i1, vector<16xbf16>, i16, vector<8xf32>, i1, i1) -> vector<8xf32>
     %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma3_transposed, kWidth = 8}>> * tensor<32x16xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma3_transposed, kWidth = 8}>> -> tensor<16x16xf32, #mma3_transposed>
 
     %ptr0 = tt.splat %arg3 : !tt.ptr<f32> -> tensor<16x16x!tt.ptr<f32>, #mma3_transposed>

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -161,7 +161,7 @@ Value generateWMMAIntrinsic(ConversionPatternRewriter &rewriter, Location loc,
       operands.push_back(b.int_val(1, 0));
     operands.push_back(valB);
 
-    if ((bElType.isBF16() || bElType.isF16()) || aElType.isInteger())
+    if ((bElType.isBF16() || bElType.isF16()) || aElType.isFloat(8))
       operands.push_back(b.int_val(16, 0));
     operands.push_back(valC);
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -72,51 +72,6 @@ ValueTable getValuesFromDotOperandLayoutStruct(
   return vals;
 }
 
-std::string getTypeStr(Type ty) {
-  std::string scalarName;
-  if (ty.isF32()) {
-    scalarName = "f32";
-  } else if (ty.isF16()) {
-    scalarName = "f16";
-  } else if (ty.isBF16()) {
-    scalarName = "bf16";
-  } else if (llvm::isa<Float8E4M3FNType>(ty)) {
-    scalarName = "fp8";
-  } else if (llvm::isa<Float8E5M2Type>(ty)) {
-    scalarName = "bf8";
-  } else if (ty.isInteger(32)) {
-    scalarName = "i32";
-  } else if (ty.isInteger(16)) {
-    scalarName = "i16";
-  } else if (ty.isInteger(8)) {
-    scalarName = "iu8";
-  } else if (ty.isInteger(4)) {
-    scalarName = "iu4";
-  } else if (auto vecTy = dyn_cast<VectorType>(ty)) {
-    auto elemType = vecTy.getElementType();
-    auto numElems = vecTy.getNumElements();
-    scalarName = "v" + std::to_string(numElems) + getTypeStr(elemType);
-  } else {
-    llvm::report_fatal_error("WMMA data type not supported");
-  }
-  return scalarName;
-}
-
-std::string addInstructionSuffix(std::string intrinsicName, unsigned kBase,
-                                 unsigned elemsPerVec, Type aElTy, Type bElTy,
-                                 Type dElTy, bool tied) {
-  if (tied) {
-    intrinsicName += ".tied";
-  } else {
-    if (isa<FloatType>(aElTy) && aElTy.getIntOrFloatBitWidth() == 8)
-      intrinsicName += "." + getTypeStr(bElTy);
-    intrinsicName += ".v" + std::to_string(elemsPerVec) + getTypeStr(dElTy);
-    intrinsicName += ".v" + std::to_string(kBase) + getTypeStr(aElTy);
-  }
-
-  return intrinsicName;
-}
-
 Value generateWMMAIntrinsic(ConversionPatternRewriter &rewriter, Location loc,
                             int wmmaVer, Value valA, Value valB, Value valC,
                             Type aElType, Type bElType, Type dElType,
@@ -257,11 +212,12 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
   auto elemsPerVec = mnkDim[0] * mnkDim[1] * paddedOutputElemSize / warpSize;
   auto dElemsToStorePerThread = mnkDim[0] * mnkDim[1] / warpSize;
   auto vecTy = vec_ty(dstElemTy, elemsPerVec);
+
   bool tied = numRepM % 2 == 0 && paddedOutputElemSize == 2;
   int tiedGroup = tied ? 2 : 1;
+  if (tied)
+    intrinsicName += ".tied";
 
-  intrinsicName = addInstructionSuffix(intrinsicName, kBase, elemsPerVec,
-                                       aElemTy, bElemTy, dElemTy, tied);
   for (int b = 0; b < numRepB; ++b) {
     for (int m = 0; m < numRepM / tiedGroup; ++m) {
       for (int n = 0; n < numRepN; ++n) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/WmmaGroup.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/WmmaGroup.cpp
@@ -97,7 +97,7 @@ WmmaDatabase::WmmaDatabase(MLIRContext *context) {
 
       // wmma_f32_16x16x32_bf16
       TRITON_WMMA_v(3, 16, 16, bf16T, bf16T, 16, f32T,
-                    "llvm.amdgcn.wmma.f32.16x16x32.bf16.bf16", 32, 16),
+                    "llvm.amdgcn.wmma.f32.16x16x32.bf16", 32, 16),
 
       // wmma_f32_16x16x16_f16
       TRITON_WMMA_v(1, 16, 16, f16T, f16T, 16, f32T,

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -113,15 +113,15 @@ def test_runtime_gemm(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, a_dtype, b_dtype, k_di
 
     torch.manual_seed(42)
 
-    a_dtype = getattr(torch, a_dtype)
-    b_dtype = getattr(torch, b_dtype)
-
     def create_operand(shape, dtype):
         if dtype == torch.bfloat16:
             return torch.randn(shape, dtype=dtype)
         else:
             assert dtype == torch.float8_e5m2
             return torch.randint(0x04, 0x7B, shape, dtype=torch.uint8).view(dtype)
+
+    a_dtype = getattr(torch, a_dtype)
+    b_dtype = getattr(torch, b_dtype)
 
     a = create_operand((M, K), a_dtype)
     b = create_operand((K, N), b_dtype)

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -10,6 +10,7 @@ import torch
 
 import triton
 from triton.backends.compiler import GPUTarget
+from triton._internal_testing import str_to_triton_dtype
 from triton.experimental import gluon
 import triton.experimental.gluon.language as ttgl
 
@@ -20,10 +21,11 @@ def gemm_kernel(a_ptr, b_ptr, c_ptr,  #
                 stride_am, stride_ak,  #
                 stride_bk, stride_bn,  #
                 stride_cm, stride_cn,  #
-                BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr):
+                BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr,  #
+                INSTR_SHAPE_K: ttgl.constexpr, K_WIDTH: ttgl.constexpr):
 
     BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [4, 1], [1, 0])
-    WMMA_LAYOUT: ttgl.constexpr = ttgl.amd.AMDWMMALayout(3, True, [2, 2], [16, 16, 32])
+    WMMA_LAYOUT: ttgl.constexpr = ttgl.amd.AMDWMMALayout(3, True, [2, 2], [16, 16, INSTR_SHAPE_K])
 
     pid = ttgl.program_id(axis=0)
     num_pid_m = ttgl.cdiv(M, BLOCK_M)
@@ -38,7 +40,7 @@ def gemm_kernel(a_ptr, b_ptr, c_ptr,  #
     offs_bn = pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))
     offs_b = offs_bk[:, None] * stride_bk + offs_bn[None, :] * stride_bn
 
-    accumulator = ttgl.zeros((BLOCK_M, BLOCK_N), dtype=ttgl.float32, layout=WMMA_LAYOUT)
+    accumulator = ttgl.zeros((BLOCK_M, BLOCK_N), dtype=c_ptr.type.element_ty, layout=WMMA_LAYOUT)
     for k in range(0, ttgl.cdiv(K, BLOCK_K)):
         mask_a = (offs_ak[None, :] < K - k * BLOCK_K) & (offs_am[:, None] < M)
         mask_b = (offs_bk[:, None] < K - k * BLOCK_K) & (offs_bn[None, :] < N)
@@ -46,9 +48,8 @@ def gemm_kernel(a_ptr, b_ptr, c_ptr,  #
         a = ttgl.load(a_ptr + offs_a, mask=mask_a, other=0.0)
         b = ttgl.load(b_ptr + offs_b, mask=mask_b, other=0.0)
 
-        a = ttgl.convert_layout(a, ttgl.DotOperandLayout(0, WMMA_LAYOUT, 8))
-        b = ttgl.convert_layout(b, ttgl.DotOperandLayout(1, WMMA_LAYOUT, 8))
-
+        a = ttgl.convert_layout(a, ttgl.DotOperandLayout(0, WMMA_LAYOUT, K_WIDTH))
+        b = ttgl.convert_layout(b, ttgl.DotOperandLayout(1, WMMA_LAYOUT, K_WIDTH))
         accumulator = ttgl.amd.gfx1250.wmma(a, b, accumulator)
 
         offs_a += BLOCK_K * stride_ak
@@ -62,33 +63,68 @@ def gemm_kernel(a_ptr, b_ptr, c_ptr,  #
 
 
 @pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(32, 32, 32), (64, 64, 64), (128, 128, 64)])
-def test_compile_gemm_bf16(BLOCK_M, BLOCK_N, BLOCK_K):
+@pytest.mark.parametrize("a_dtype,b_dtype,k_dim", [
+    ("bfloat16", "bfloat16", 32),
+    ("float8_e5m2", "float8_e5m2", 64),
+])
+def test_compile_gemm(BLOCK_M, BLOCK_N, BLOCK_K, a_dtype, b_dtype, k_dim):
+    if BLOCK_K < k_dim:
+        pytest.skip("Skip tests where BLOCK_K < k_dim")
+
+    a_dtype = str_to_triton_dtype(a_dtype).name
+    b_dtype = str_to_triton_dtype(b_dtype).name
+
     k = triton.compile(
         gluon._runtime.GluonASTSource(
             fn=gemm_kernel, signature={
-                "a_ptr": "*bf16", "b_ptr": "*bf16", "c_ptr": "*fp32", "M": "i32", "N": "i32", "K": "i32", "stride_am":
-                "i32", "stride_ak": "i32", "stride_bk": "i32", "stride_bn": "i32", "stride_cm": "i32", "stride_cn":
-                "i32", "BLOCK_M": "constexpr", "BLOCK_N": "constexpr", "BLOCK_K": "constexpr"
-            }, constexprs={"BLOCK_M": BLOCK_M, "BLOCK_N": BLOCK_N, "BLOCK_K": BLOCK_K}),
-        target=GPUTarget("hip", 'gfx1250', 32))
-
+                "a_ptr": f"*{a_dtype}", "b_ptr": f"*{b_dtype}", "c_ptr": "*fp32",  #
+                "M": "i32", "N": "i32", "K": "i32",  #
+                "stride_am": "i32", "stride_ak": "i32",  #
+                "stride_bk": "i32", "stride_bn": "i32",  #
+                "stride_cm": "i32", "stride_cn": "i32",  #
+                "BLOCK_M": "constexpr", "BLOCK_N": "constexpr", "BLOCK_K": "constexpr",  #
+                "INSTR_SHAPE_K": "constexpr", "K_WIDTH": "constexpr"
+            }, constexprs={
+                "BLOCK_M": BLOCK_M, "BLOCK_N": BLOCK_N, "BLOCK_K": BLOCK_K,  #
+                "INSTR_SHAPE_K": k_dim, "K_WIDTH": 8
+            }), target=GPUTarget("hip", 'gfx1250', 32))
     amdgcn = k.asm["amdgcn"]
-    pattern = r"v_wmma_f32_16x16x32_bf16"
-    assert re.search(pattern, amdgcn), "The AMDGCN assembly does not contain the expected WMMA instruction."
+
+    wmma_pattern = "v_wmma_"
+    wmma_pattern += "f32_"
+    wmma_pattern += "16x16x" + str(k_dim) + "_"
+    if a_dtype == "bf16":
+        wmma_pattern += "bf16"
+    if a_dtype == "fp8e5":
+        wmma_pattern += "bf8_bf8"
+
+    assert re.search(wmma_pattern, amdgcn), "The AMDGCN assembly does not contain the expected WMMA instruction."
 
 
-@pytest.mark.parametrize("M,N,K", [
-    (128, 128, 64),
-    (256, 256, 128),
-    (256, 128, 64),
-    (128, 256, 64),
-    (120, 120, 60),
-])
+@pytest.mark.parametrize("M,N,K", [(256, 256, 128), (250, 250, 120)])
 @pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(32, 32, 32), (64, 64, 64), (128, 128, 64)])
-def test_runtime_gemm_bf16(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K):
+@pytest.mark.parametrize("a_dtype,b_dtype,k_dim", [
+    ("bfloat16", "bfloat16", 32),
+    ("float8_e5m2", "float8_e5m2", 64),
+])
+def test_runtime_gemm(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, a_dtype, b_dtype, k_dim):
+    if BLOCK_K < k_dim:
+        pytest.skip("Skip tests where BLOCK_K < k_dim")
+
     torch.manual_seed(42)
-    a = torch.randn((M, K), dtype=torch.bfloat16)
-    b = torch.randn((K, N), dtype=torch.bfloat16)
+
+    a_dtype = getattr(torch, a_dtype)
+    b_dtype = getattr(torch, b_dtype)
+
+    def create_operand(shape, dtype):
+        if dtype == torch.bfloat16:
+            return torch.randn(shape, dtype=dtype)
+        else:
+            assert dtype == torch.float8_e5m2
+            return torch.randint(0x04, 0x7B, shape, dtype=torch.uint8).view(dtype)
+
+    a = create_operand((M, K), a_dtype)
+    b = create_operand((K, N), b_dtype)
     c = torch.zeros((M, N), dtype=torch.float32)
     stride_am, stride_ak = a.stride(0), a.stride(1)
     stride_bk, stride_bn = b.stride(0), b.stride(1)
@@ -104,7 +140,8 @@ def test_runtime_gemm_bf16(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K):
         stride_am, stride_ak,  #
         stride_bk, stride_bn,  #
         stride_cm, stride_cn,  #
-        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K)
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,  #
+        INSTR_SHAPE_K=k_dim, K_WIDTH=8)
 
     c_triton = c_device.cpu()
     c_torch = a.to(torch.float32) @ b.to(torch.float32)


### PR DESCRIPTION
This PR fixes various issues for bf8 data types in wmma:

- Fix the llvm arguments list for bf8.
- Drop the instruction suffix. The current suffix is wrong for bf8 data type. And it is unnecessary to include the instruction suffix.
- Add compile/runtime tests for bf8 on gfx1250.