### PR TITLE
Remove unnecessary dependence

### DIFF
--- a/test/lib/Proton/CMakeLists.txt
+++ b/test/lib/Proton/CMakeLists.txt
@@ -3,5 +3,4 @@ add_mlir_library(TritonTestProton
 
   LINK_LIBS PUBLIC
   MLIRPass
-  ${triton_libs}
 )

--- a/third_party/amd/test/lib/Analysis/CMakeLists.txt
+++ b/third_party/amd/test/lib/Analysis/CMakeLists.txt
@@ -12,5 +12,4 @@ add_mlir_library(TritonAMDGPUTestAnalysis
 
   LINK_LIBS PUBLIC
   MLIRPass
-  ${triton_libs}
 )


### PR DESCRIPTION
We identified unnecessary dependencies in the tests for Proton and the AMD analysis pass. Specifically, the `third_party/amd` directory is processed in CMake (line 204 of the root CMakeLists.txt) before the `triton_libs` variable is set at line 214. As a result, when the target `TritonAMDGPUTestAnalysis` accesses `triton_libs`, it resolves to an empty string, which seems to be a bug.


We’ve verified that whenever these two MLIR libraries are used, specifically in `bin/CMakeLists.txt`, the corresponding targets are always linked to `triton_libs`. Therefore, it's safe to remove the explicit linkage to `triton_libs` in `TritonTestProton` and `TritonAMDGPUTestAnalysis`, as it is redundant.