### PR TITLE
[AMD] Convert to bufferOp if baseptr is a func arg with tt.pointer_range=32 attr

### DIFF
--- a/test/TritonGPU/amd/amd-convert-buffer-ops-2.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops-2.mlir
@@ -1,6 +1,24 @@
-// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="arch-generation-name=gfx942 skip-small-tensor-ofst-analysis=true"| FileCheck %s --check-prefixes=COMMON,GFX942-ONLY
-// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="arch-generation-name=gfx950 skip-small-tensor-ofst-analysis=true"| FileCheck %s --check-prefixes=COMMON,GFX950-ONLY
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="arch-generation-name=gfx942"| FileCheck %s --check-prefixes=COMMON,GFX942-ONLY
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="arch-generation-name=gfx950"| FileCheck %s --check-prefixes=COMMON,GFX950-ONLY
 
+//////////////////////////////////////////////////////////////////////////////
+//
+//   This file contains lit tests primarily for buffer-ops conversion for
+// small-tensor (size <= 2G) with skip-small-tensor-ofst-analysis being off
+// (default value).
+//
+//   The initial revision of this file is copied from amd-convert-buffer-ops.mlir
+// with following changes:
+//    - some completely irrelevant tests are removed
+//    - some tests are slightly modified to demonstrate some conversion
+//      can be done with skip-small-tensor-ofst-analysis=false
+//
+// TODO: some testings still need polishing to make them more relevant to
+// small-tensor-offset related optimization. Regardless, it's no harm to keep
+// them.
+//
+//////////////////////////////////////////////////////////////////////////////
+//
 #blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // COMMON-LABEL: simple
@@ -30,67 +48,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   }
 }
 
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
-// COMMON-LABEL: buffer_stride
-  tt.func public @buffer_stride(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}) {
-    %c48_i32 = arith.constant 48 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %c0_i32 = arith.constant 0 : i32
-    %0 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<256x1xi32, #blocked>
-    %cmp = arith.cmpi sgt, %arg6, %c0_i32 : i32
-    llvm.intr.assume %cmp : i1
-    %2 = tt.splat %arg6 : i32 -> tensor<256x1xi32, #blocked>
-    %3 = arith.muli %1, %2 : tensor<256x1xi32, #blocked>
-    %4 = tt.addptr %arg0, %c32_i32 : !tt.ptr<f16>, i32
-    %5 = tt.broadcast %3 : tensor<256x1xi32, #blocked> -> tensor<256x64xi32, #blocked>
-    %6 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
-    %7 = tt.expand_dims %6 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
-    %8 = tt.broadcast %7 : tensor<1x64xi32, #blocked> -> tensor<256x64xi32, #blocked>
-    %9 = arith.addi %8, %5 : tensor<256x64xi32, #blocked>
-    %10 = tt.splat %4 : !tt.ptr<f16> -> tensor<256x64x!tt.ptr<f16>, #blocked>
-    %11 = tt.addptr %10, %9 : tensor<256x64x!tt.ptr<f16>, #blocked>, tensor<256x64xi32, #blocked>
-
-    // COMMON: %[[splat:.*]] = tt.splat %arg[[#stride:]]
-    // COMMON: %[[mul:.*]] = arith.muli %[[#]], %[[splat]]
-    // COMMON: %[[ptr:.*]] = tt.addptr %arg0
-    // COMMON: %[[bcast1:.*]] = tt.broadcast %[[mul]]
-    // COMMON: %[[bcast0:.*]] = tt.broadcast %[[#]]
-    // COMMON: %[[offset:.*]] = arith.addi %[[bcast0]], %[[bcast1]]
-    // COMMON: %[[buffer:.*]] = amdgpu.buffer_load %[[ptr]][%[[offset]]] stride = %arg[[#stride]]
-
-    %12 = tt.load %11 : tensor<256x64x!tt.ptr<f16>, #blocked>
-    %13 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    %14 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
-    %15 = tt.expand_dims %13 {axis = 1 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<256x1xi32, #blocked>
-    %16 = tt.expand_dims %14 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
-    %cmp1 = arith.cmpi sgt, %arg8, %c0_i32 : i32
-    llvm.intr.assume %cmp1 : i1
-    %17 = tt.splat %arg8 : i32 -> tensor<256x1xi32, #blocked>
-    %18 = arith.muli %17, %15 : tensor<256x1xi32, #blocked>
-    %19 = tt.addptr %arg2, %c48_i32 : !tt.ptr<f16>, i32
-    %20 = tt.broadcast %18 : tensor<256x1xi32, #blocked> -> tensor<256x64xi32, #blocked>
-    %21 = tt.broadcast %16 : tensor<1x64xi32, #blocked> -> tensor<256x64xi32, #blocked>
-    %22 = tt.addptr %19, %c48_i32 : !tt.ptr<f16>, i32
-    %23 = arith.addi %21, %20 : tensor<256x64xi32, #blocked>
-    %24 = tt.splat %22 : !tt.ptr<f16> -> tensor<256x64x!tt.ptr<f16>, #blocked>
-    %25 = tt.addptr %24, %23 : tensor<256x64x!tt.ptr<f16>, #blocked>, tensor<256x64xi32, #blocked>
-
-    // COMMON: %[[splatb:.*]] = tt.splat %arg[[#strideb:]]
-    // COMMON: %[[mulb:.*]] = arith.muli %[[splatb]], %[[#]]
-    // COMMON: %[[bcast1b:.*]] = tt.broadcast %[[mulb]]
-    // COMMON: %[[bcast0b:.*]] = tt.broadcast %[[#]]
-    // COMMON: %[[ptrb:.*]] = tt.addptr
-    // COMMON: %[[offsetb:.*]] = arith.addi %[[bcast0b]], %[[bcast1b]]
-    // COMMON: buffer_store %[[buffer]], %[[ptrb]][%[[offsetb]]] stride = %arg[[#strideb]]
-
-    tt.store %25, %12 : tensor<256x64x!tt.ptr<f16>, #blocked>
-    tt.return
-  }
-}
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
@@ -172,6 +129,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32}  {
 }
 
 // -----
+// NOTE: compared to @non_canonical_ptr in amd-convert-buffer-ops.mlir, the load
+// can be converted to buffer-loads.
 
 #blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32}  {
@@ -179,7 +138,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32}  {
   tt.func @non_canonical_ptr(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: tensor<1024xi32, #blocked>) -> tensor<1024xf32, #blocked>{
     %8 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
     %9 = tt.addptr %8, %arg1: tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked>
-    // COMMON: tt.load
+    // COMMON: buffer_load
     %10 = tt.load %9 : tensor<1024x!tt.ptr<f32>, #blocked>
     tt.return %10 : tensor<1024xf32, #blocked>
   }
@@ -187,13 +146,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32}  {
 
 // -----
 
+// NOTE: compared the @assume_eq_non_neg in amd-convert-buffer-ops.mlir.
+//  tt.load and tt.store can be converted without tl.assume.
+
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // COMMON-LABEL: assume_eq_non_neg
   tt.func @assume_eq_non_neg(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2: i32) {
     %c10_i32 = arith.constant 10 : i32
-    %0 = arith.cmpi eq, %arg2, %c10_i32 : i32
-    llvm.intr.assume %0 : i1
     // COMMON: %[[range:.*]] = tt.make_range
     %1 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #blocked>
     // COMMON: %[[ptr:.*]] = tt.addptr %arg0, %arg2
@@ -202,7 +162,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %4 = tt.addptr %3, %1 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
     %5 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>, #blocked>
     %6 = tt.addptr %5, %1 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
-    // COMMON: %[[loaded:.*]] = amdgpu.buffer_load %arg1[%1]
+    // COMMON: %[[loaded:.*]] = amdgpu.buffer_load %arg1[%[[range]]]
     %7 = tt.load %6 : tensor<16x!tt.ptr<bf16>, #blocked>
     // COMMON: amdgpu.buffer_store %[[loaded]], %[[ptr]][%[[range]]]
     tt.store %4, %7 : tensor<16x!tt.ptr<bf16>, #blocked>
@@ -211,14 +171,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 }
 
 // -----
+
+// NOTE: compared to the @assume_nonneg_less in amd-convert-buffer-ops.mlir.
+//  tl.assume are removed.
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // COMMON-LABEL: assume_nonneg_less
   tt.func @assume_nonneg_less(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2: i32) {
     %c10_i32 = arith.constant 5 : i32
-    %0 = arith.cmpi slt, %c10_i32, %arg2 : i32
-    llvm.intr.assume %0 : i1
+    // %0 = arith.cmpi slt, %c10_i32, %arg2 : i32
+    // llvm.intr.assume %0 : i1
     // COMMON: %[[range:.*]] = tt.make_range
     %1 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #blocked>
     // COMMON: %[[ptr:.*]] = tt.addptr %arg0, %arg2
@@ -227,7 +190,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %4 = tt.addptr %3, %1 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
     %5 = tt.splat %arg1 : !tt.ptr<bf16> -> tensor<16x!tt.ptr<bf16>, #blocked>
     %6 = tt.addptr %5, %1 : tensor<16x!tt.ptr<bf16>, #blocked>, tensor<16xi32, #blocked>
-    // COMMON: %[[loaded:.*]] = amdgpu.buffer_load %arg1[%1]
+    // COMMON: %[[loaded:.*]] = amdgpu.buffer_load %arg1[%[[range]]]
     %7 = tt.load %6 : tensor<16x!tt.ptr<bf16>, #blocked>
     // COMMON: amdgpu.buffer_store %[[loaded]], %[[ptr]][%[[range]]]
     tt.store %4, %7 : tensor<16x!tt.ptr<bf16>, #blocked>
@@ -236,6 +199,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 }
 
 // -----
+
+// NOTE: compared to the @assume_nonneg_less in amd-convert-buffer-ops.mlir.
+//  tl.assume are removed.
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
@@ -245,13 +211,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     llvm.intr.assume %0 : i1
     %1 = arith.subi %arg2, %arg3 : i32
     %2 = arith.cmpi sge, %1, %arg4 : i32
-    llvm.intr.assume %2 : i1
+    // llvm.intr.assume %2 : i1
     %3 = arith.subi %1, %arg4 : i32
     %4 = arith.cmpi slt, %3, %arg5 : i32
-    llvm.intr.assume %4 : i1
+    // llvm.intr.assume %4 : i1
     %5 = arith.subi %arg5, %3 : i32
     %6 = arith.cmpi sle, %5, %arg6 : i32
-    llvm.intr.assume %6 : i1
+    // llvm.intr.assume %6 : i1
     %7 = arith.subi %arg6, %5 : i32
     %8 = arith.minsi %1, %3 : i32
     %9 = arith.minsi %8, %5 : i32
@@ -597,64 +563,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
-// COMMON-LABEL: buffer_load_to_local
-  tt.func public @buffer_load_to_local(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32},
-                                       %arg10: !ttg.memdesc<256x64xf16, #shared, #smem, mutable>, %arg11: tensor<256x64xi1, #blocked>, %arg12: tensor<256x64xf16, #blocked>) {
-    %c48_i32 = arith.constant 48 : i32
-    %c32_i32 = arith.constant 32 : i32
-    %c0_i32 = arith.constant 0 : i32
-    %0 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    %1 = tt.expand_dims %0 {axis = 1 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<256x1xi32, #blocked>
-    %cmp = arith.cmpi sgt, %arg6, %c0_i32 : i32
-    llvm.intr.assume %cmp : i1
-    %2 = tt.splat %arg6 : i32 -> tensor<256x1xi32, #blocked>
-    %3 = arith.muli %1, %2 : tensor<256x1xi32, #blocked>
-    %4 = tt.addptr %arg0, %c32_i32 : !tt.ptr<f16>, i32
-    %5 = tt.broadcast %3 : tensor<256x1xi32, #blocked> -> tensor<256x64xi32, #blocked>
-    %6 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
-    %7 = tt.expand_dims %6 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
-    %8 = tt.broadcast %7 : tensor<1x64xi32, #blocked> -> tensor<256x64xi32, #blocked>
-    %9 = arith.addi %8, %5 : tensor<256x64xi32, #blocked>
-    %10 = tt.splat %4 : !tt.ptr<f16> -> tensor<256x64x!tt.ptr<f16>, #blocked>
-    %11 = tt.addptr %10, %9 : tensor<256x64x!tt.ptr<f16>, #blocked>, tensor<256x64xi32, #blocked>
-
-    // COMMON: %[[splat:.*]] = tt.splat %arg[[#stride:]]
-    // COMMON: %[[mul:.*]] = arith.muli %[[#]], %[[splat]]
-    // COMMON: %[[ptr:.*]] = tt.addptr %arg0
-    // COMMON: %[[bcast1:.*]] = tt.broadcast %[[mul]]
-    // COMMON: %[[bcast0:.*]] = tt.broadcast %[[#]]
-    // COMMON: %[[offset:.*]] = arith.addi %[[bcast0]], %[[bcast1]]
-
-    // COMMON: %[[buffer:.*]] = amdgpu.buffer_load_to_local %[[ptr]][%[[offset]]] stride = %arg[[#stride]] into %arg10
-    %12 = ttg.async_copy_global_to_local %11, %arg10 : tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
-
-    // COMMON: %[[buffer:.*]] = amdgpu.buffer_load_to_local %[[ptr]][%[[offset]]] other = %arg12 stride = %arg[[#stride]] into %arg10
-    %13 = ttg.async_copy_global_to_local %11, %arg10 other %arg12: tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
-
-    // COMMON: %[[buffer:.*]] = amdgpu.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 stride = %arg[[#stride]] into %arg10
-    %14 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11: tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
-
-    // COMMON: %[[buffer:.*]] = amdgpu.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 other = %arg12 stride = %arg[[#stride]] into %arg10
-    %15 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11 other %arg12 : tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
-
-    // COMMON: %[[buffer:.*]] = amdgpu.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 other = %arg12 stride = %arg[[#stride]] cacheModifier = ca into %arg10
-    %16 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11 other %arg12 cacheModifier = ca: tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
-
-    // COMMON: %[[buffer:.*]] = amdgpu.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 other = %arg12 stride = %arg[[#stride]] cacheModifier = cg into %arg10
-    %17 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11 other %arg12 cacheModifier = cg: tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
-
-    // COMMON: %[[buffer:.*]] = amdgpu.buffer_load_to_local %[[ptr]][%[[offset]]] mask = %arg11 other = %arg12 stride = %arg[[#stride]] cacheModifier = cv into %arg10
-    %18 = ttg.async_copy_global_to_local %11, %arg10 mask %arg11 other %arg12 cacheModifier = cv: tensor<256x64x!tt.ptr<f16>, #blocked> -> <256x64xf16, #shared, #smem, mutable>
-    tt.return
-  }
-}
-
-// -----
-
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 16], warpsPerCTA = [2, 2], order = [1, 0]}>
 
 module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
@@ -703,88 +611,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %8 = tt.splat %7 : !tt.ptr<i64> -> tensor<1024x!tt.ptr<i64>, #blocked>
     %9 = tt.addptr %8, %2 : tensor<1024x!tt.ptr<i64>, #blocked>, tensor<1024xi32, #blocked>
     tt.store %9, %6 : tensor<1024x!tt.ptr<i64>, #blocked>
-    tt.return
-  }
-}
-
-// -----
-
-// The following two regression tests (all_false_mask and all_true_mask) are to
-// make sure that a buffer-op does not have to take mask-operand if and only if
-// its mask operand is a all-true-predicate.
-//
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
-  // COMMON-LABEL: all_false_mask
-  tt.func public @all_false_mask(%in_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
-                                 %idx_ptr: !tt.ptr<i64> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
-                                 %out_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
-                                 %shape0: i32, %shape1: i32) {
-    %cst = arith.constant dense<false> : tensor<64xi1, #blocked>
-    %c64_i32 = arith.constant 64 : i32
-    %0 = tt.get_program_id x : i32
-    %1 = arith.muli %0, %c64_i32 : i32
-    %2 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked>
-    %3 = tt.splat %1 : i32 -> tensor<64xi32, #blocked>
-    %4 = arith.addi %3, %2 : tensor<64xi32, #blocked>
-    %5 = tt.splat %shape1 : i32 -> tensor<64xi32, #blocked>
-    %6 = arith.divsi %4, %5 : tensor<64xi32, #blocked>
-    %7 = arith.muli %5, %6 : tensor<64xi32, #blocked>
-    %8 = tt.addptr %idx_ptr, %1 : !tt.ptr<i64>, i32
-    %9 = tt.splat %8 : !tt.ptr<i64> -> tensor<64x!tt.ptr<i64>, #blocked>
-    %10 = tt.addptr %9, %2 : tensor<64x!tt.ptr<i64>, #blocked>, tensor<64xi32, #blocked>
-    %11 = tt.load %10, %cst : tensor<64x!tt.ptr<i64>, #blocked>
-    // COMMON: amdgpu.buffer_load %[[ptr1:.*]][%[[ofst1:.*]]], %[[mask1:.*]] : tensor<64xi64, #blocked>
-    %12 = tt.addptr %in_ptr, %1 : !tt.ptr<f32>, i32
-    %13 = tt.splat %12 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
-    %14 = tt.addptr %13, %2 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
-    %15 = tt.load %14, %cst : tensor<64x!tt.ptr<f32>, #blocked>
-    // COMMON: amdgpu.buffer_load %[[ptr2:.*]][%[[ofst2:.*]]], %[[mask2:.*]] : tensor<64xf32, #blocked>
-    %16 = arith.extsi %7 : tensor<64xi32, #blocked> to tensor<64xi64, #blocked>
-    %17 = arith.addi %11, %16 : tensor<64xi64, #blocked>
-    %18 = arith.trunci %17 : tensor<64xi64, #blocked> to tensor<64xi32, #blocked>
-    %19 = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
-    %20 = tt.addptr %19, %18 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
-    %21 = tt.atomic_rmw fadd, relaxed, gpu, %20, %15, %cst : (tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xf32, #blocked>, tensor<64xi1, #blocked>) -> tensor<64xf32, #blocked>
-    tt.return
-  }
-}
-
-// -----
-
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
-  // COMMON-LABEL: all_true_mask
-  tt.func public @all_true_mask(%in_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
-                                %idx_ptr: !tt.ptr<i64> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
-                                %out_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
-                                %shape0: i32, %shape1: i32) {
-    %cst = arith.constant dense<true> : tensor<64xi1, #blocked>
-    %c64_i32 = arith.constant 64 : i32
-    %0 = tt.get_program_id x : i32
-    %1 = arith.muli %0, %c64_i32 : i32
-    %2 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked>
-    %3 = tt.splat %1 : i32 -> tensor<64xi32, #blocked>
-    %4 = arith.addi %3, %2 : tensor<64xi32, #blocked>
-    %5 = tt.splat %shape1 : i32 -> tensor<64xi32, #blocked>
-    %6 = arith.divsi %4, %5 : tensor<64xi32, #blocked>
-    %7 = arith.muli %5, %6 : tensor<64xi32, #blocked>
-    %8 = tt.addptr %idx_ptr, %1 : !tt.ptr<i64>, i32
-    %9 = tt.splat %8 : !tt.ptr<i64> -> tensor<64x!tt.ptr<i64>, #blocked>
-    %10 = tt.addptr %9, %2 : tensor<64x!tt.ptr<i64>, #blocked>, tensor<64xi32, #blocked>
-    %11 = tt.load %10, %cst : tensor<64x!tt.ptr<i64>, #blocked>
-    // COMMON: amdgpu.buffer_load %[[ptr1:.*]][%[[ofst1:.*]]] : tensor<64xi64, #blocked>
-    %12 = tt.addptr %in_ptr, %1 : !tt.ptr<f32>, i32
-    %13 = tt.splat %12 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
-    %14 = tt.addptr %13, %2 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
-    %15 = tt.load %14, %cst : tensor<64x!tt.ptr<f32>, #blocked>
-    // COMMON: amdgpu.buffer_load %[[ptr2:.*]][%[[ofst2:.*]]] : tensor<64xf32, #blocked>
-    %16 = arith.extsi %7 : tensor<64xi32, #blocked> to tensor<64xi64, #blocked>
-    %17 = arith.addi %11, %16 : tensor<64xi64, #blocked>
-    %18 = arith.trunci %17 : tensor<64xi64, #blocked> to tensor<64xi32, #blocked>
-    %19 = tt.splat %out_ptr : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #blocked>
-    %20 = tt.addptr %19, %18 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
-    %21 = tt.atomic_rmw fadd, relaxed, gpu, %20, %15, %cst : (tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xf32, #blocked>, tensor<64xi1, #blocked>) -> tensor<64xf32, #blocked>
     tt.return
   }
 }

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -143,6 +143,9 @@ def TritonAMDGPUConvertToBufferOps : Pass<"tritonamdgpu-convert-buffer-ops", "ml
     Option<"allowBufferAtomics", "allow-buffer-atomics",
            "bool", /*default*/"true",
            "Allow buffer atomic operations when the hardware supports it.">,
+    Option<"skipSmallTensorOfstAnalysis", "skip-small-tensor-ofst-analysis",
+          "bool", /*default=*/"false",
+           "If base-pointer is a small-tensor's base, do conversion without analyzing offset's value range">,
   ];
 }
 


### PR DESCRIPTION
This change, combined with the previous PR-7939, is to convert memory accesses of small-tensors into buffer-ops *WITHOUT* analyzing their offsets' value range.

* Little context
  - We informally call a tensor "small-tensor" if it is no more than 2G byte in size.
  - a jit function is specialized to differentiate "small-tensor" and bulky ones; a function formal argument is tagged with tt.pointer_range=32 if it binds to a small-tensor.

* This Change
  - This change, combined with the previous PR-7939, is to convert memory accesses of small-tensors into buffer-ops *WITHOUT* analyzing their offsets' value range.
  - The contribution of PR-7939 is to reveal the base-pointer, and this PR is to *blindly* perform such conversion.
  - It side-steps the defect/limitation of offset-range-analysis, and it's safe!

* TODO
  - If the offset of the mem-op of small-tensor is 64-bit quantity, we can cast the offset to 32-bit and then convert it.

* Option
  - Pass option: skip-small-tensor-ofst-analysis={false|true}, false by default
