### PR TITLE
[Proton] Fix global time trace precision

### DIFF
--- a/third_party/proton/common/include/TraceDataIO/TraceWriter.h
+++ b/third_party/proton/common/include/TraceDataIO/TraceWriter.h
@@ -50,7 +50,8 @@ public:
   void write(std::ostream &outfile) override final;
 
 private:
-  void writeKernel(nlohmann::json &object, const KernelTrace &kernelTrace);
+  void writeKernel(nlohmann::json &object, const KernelTrace &kernelTrace,
+                   const uint64_t minInitTime);
 
   const std::vector<std::string> kChromeColor = {"cq_build_passed",
                                                  "cq_build_failed",

--- a/third_party/proton/common/lib/TraceDataIO/TraceWriter.cpp
+++ b/third_party/proton/common/lib/TraceDataIO/TraceWriter.cpp
@@ -8,6 +8,21 @@
 using namespace proton;
 using json = nlohmann::json;
 
+namespace {
+
+uint64_t getMinInitTime(const std::vector<KernelTrace> &streamTrace) {
+  uint64_t minInitTime = std::numeric_limits<uint64_t>::max();
+  for (const auto &kernelTrace : streamTrace)
+    for (const auto &bt : kernelTrace.first->blockTraces) {
+      if (bt.initTime < minInitTime) {
+        minInitTime = bt.initTime;
+      }
+    }
+  return minInitTime;
+}
+
+} // namespace
+
 StreamTraceWriter::StreamTraceWriter(
     const std::vector<KernelTrace> &streamTrace, const std::string &path)
     : streamTrace(streamTrace), path(path) {}
@@ -43,8 +58,10 @@ void StreamChromeTraceWriter::write(std::ostream &outfile) {
 
   json object = {{"displayTimeUnit", "ns"}, {"traceEvents", json::array()}};
 
+  const auto minInitTime = getMinInitTime(streamTrace);
+
   for (const auto &kernelTrace : streamTrace) {
-    writeKernel(object, kernelTrace);
+    writeKernel(object, kernelTrace, minInitTime);
   }
   outfile << object.dump() << "\n";
 }
@@ -144,7 +161,8 @@ std::vector<int> assignLineIds(
 } // namespace
 
 void StreamChromeTraceWriter::writeKernel(json &object,
-                                          const KernelTrace &kernelTrace) {
+                                          const KernelTrace &kernelTrace,
+                                          const uint64_t minInitTime) {
   auto result = kernelTrace.first;
   auto metadata = kernelTrace.second;
 
@@ -192,16 +210,14 @@ void StreamChromeTraceWriter::writeKernel(json &object,
           else
             name = metadata->scopeName.at(scopeId);
 
-          double freq = 1000; // Unit: MHz
+          float freq = 1000.0; // Unit: MHz
 
-          double startCycle = event.first->cycle;      // Unit: cycle
-          double endCycle = event.second->cycle;       // Unit: cycle
-          double dur = (endCycle - startCycle) / freq; // Unit: us
-
-          double startCycleRel =
-              startCycle - blockToMinCycle[ctaId];       // Unit: cycle
-          double startTimeRel = startCycleRel / freq;    // Unit: us
-          double ts = bt->initTime / 1e3 + startTimeRel; // Unit: us
+          int64_t cycleAdjust =
+              static_cast<int64_t>(bt->initTime - minInitTime) -
+              static_cast<int64_t>(blockToMinCycle[ctaId]);
+          int64_t ts = static_cast<int64_t>(event.first->cycle) + cycleAdjust;
+          int64_t dur =
+              static_cast<int64_t>(event.second->cycle) - event.first->cycle;
 
           json element;
           element["cname"] = color;
@@ -210,8 +226,8 @@ void StreamChromeTraceWriter::writeKernel(json &object,
           element["ph"] = "X";
           element["pid"] = pid;
           element["tid"] = tid;
-          element["ts"] = ts;
-          element["dur"] = dur;
+          element["ts"] = static_cast<float>(ts) / freq;
+          element["dur"] = static_cast<float>(dur) / freq;
           json args;
           args["Finalization Time (ns)"] = bt->postFinalTime - bt->preFinalTime;
           args["Frequency (MHz)"] = freq;

--- a/third_party/proton/test/unittest/TraceDataIO/ChromeTraceWriterTest.cpp
+++ b/third_party/proton/test/unittest/TraceDataIO/ChromeTraceWriterTest.cpp
@@ -97,8 +97,8 @@ TEST_F(ChromeTraceWriterTest, SingleBlock) {
   EXPECT_EQ(data["traceEvents"].size(), 2);
   EXPECT_EQ(data["traceEvents"][0]["name"], "s1");
   EXPECT_EQ(data["traceEvents"][1]["name"], "scope_7");
-  EXPECT_EQ(data["traceEvents"][0]["ts"], 0.0);
-  EXPECT_EQ(data["traceEvents"][1]["ts"], 0.1);
+  EXPECT_FLOAT_EQ(data["traceEvents"][0]["ts"], 0.0);
+  EXPECT_FLOAT_EQ(data["traceEvents"][1]["ts"], 0.1);
 }
 
 TEST_F(ChromeTraceWriterTest, MultiBlockMultiWarp) {
@@ -202,10 +202,10 @@ TEST_F(ChromeTraceWriterTest, MultiKernel) {
 
   EXPECT_EQ(data.empty(), false);
   EXPECT_EQ(data["traceEvents"][0]["cat"], "kernel1");
-  EXPECT_EQ(data["traceEvents"][0]["ts"], 0.0);
-  EXPECT_EQ(data["traceEvents"][0]["dur"], 400.0);
+  EXPECT_FLOAT_EQ(data["traceEvents"][0]["ts"], 0.0);
+  EXPECT_FLOAT_EQ(data["traceEvents"][0]["dur"], 400.0);
   EXPECT_EQ(data["traceEvents"][1]["cat"], "kernel1");
   EXPECT_EQ(data["traceEvents"][2]["cat"], "kernel2");
-  EXPECT_EQ(data["traceEvents"][2]["ts"], 10000.0);
-  EXPECT_EQ(data["traceEvents"][2]["dur"], 400.0);
+  EXPECT_FLOAT_EQ(data["traceEvents"][2]["ts"], 10000.0);
+  EXPECT_FLOAT_EQ(data["traceEvents"][2]["dur"], 400.0);
 }


### PR DESCRIPTION
The current approach that converts global init time to `double` will introduce precision problem. Note that the global time read from the timer is a very larger `uint64` number, we should be very careful about the bits handling here. This PR carefully handles the bits to make output trace accurate with global time offset (like the figure).

<img width="1650" height="602" alt="fine-grained-accurate" src="https://github.com/user-attachments/assets/ea752f3d-09d4-48a5-9264-9d6328da1736" />
