### PR TITLE
[HIP] change default value of `waves_per_eu` to 0

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -30,7 +30,7 @@ def is_in_thread_transpose_enabled(arch):
 @dataclass(frozen=True)
 class HIPOptions:
     num_warps: int = 4
-    waves_per_eu: int = 1
+    waves_per_eu: int = 0
     num_stages: int = 2
     num_ctas: int = 1
     extern_libs: dict = None


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

`wave_per_eu` indicates how many waves are supposed to execute per eu (SIMD) simulteneously. Value 0 means compiler decides how many waves are assigned to each SIMD; Value 1 indicates only 1 wave per SIMD. Value 1 will impact small kernels like the `vector_add` since there can be far more than 1 wave executing simultaneously per SIMD. So, by default, it makes more sense for the compiler to decide the numbers of wave per eu unless user specifies that.  

The default value 1 actually affects the perf numbers of the tutorial example `01-vector-add.py`. Memory bandwidth regressed to 3.3TB/s with `wave_per_eu=1`, and it increases to 5.3TB/s with `wave_per_eu=0`. This PR changes the default value from 1 to 0.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
