### PR TITLE
fix: missing dep `NVHopperTransforms` -> `TritonGPUTransforms`

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -18,5 +18,6 @@ add_triton_library(NVHopperTransforms
   LINK_LIBS PUBLIC
   TritonIR
   TritonGPUIR
+  TritonGPUTransforms
   MLIRTransformUtils
 )


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `this PR only adds a CMake dependency`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)


`NVHopperTransforms` target has translation units that use headers owned by `TritonGPUTransforms` but does not have a dependency onto `TritonGPUTransforms`. `TritonGPUTransforms`'s headers transitively include `tblgen`'d headers. Lack of ordering dependency causes non-deterministic build failures.

Example: `WSLowerToken.cpp` -> `TritonGPU/Transforms/Passes.h` -> `Dialect/NVWS/IR/Dialect.h` -> `NVWS/IR/NVWSAttrEnums.h.inc` (`tblgen` artifact)