### PR TITLE
[ConSan] ConSan env var should be cache invalidating

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -43,6 +43,7 @@ inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
     "ALLOW_LHS_TMEM_LAYOUT_CONVERSION",
     "TRITON_F32_DEFAULT",
     "TRITON_PREFER_TMEM_16x256_LAYOUT",
+    "TRITON_ENABLE_EXPERIMENTAL_CONSAN",
     // clang-format on
 };
 

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -111,16 +111,15 @@ def test_cache_miss_knob(device):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-def test_cache_miss_env(device):
+def test_cache_miss_env(device, monkeypatch):
     # First run without consan
     knobs.compilation.enable_experimental_consan = False
     run_failing_kernel(device)
 
     # Then run with consan and assert that if fails
-    os.environ["TRITON_ENABLE_EXPERIMENTAL_CONSAN"] = "1"
     os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+    monkeypatch.setenv("TRITON_ENABLE_EXPERIMENTAL_CONSAN", "1")
     result = run_in_process(run_failing_kernel, (device, ))
-    os.environ.pop("TRITON_ENABLE_EXPERIMENTAL_CONSAN")
     assert "device-side assert" in str(result.exc)
 
 

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -98,7 +98,7 @@ def run_failing_kernel(device):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-def test_cache_miss_knob(device):
+def test_cache_miss_knob(device, fresh_knobs):
     # First run without consan
     knobs.compilation.enable_experimental_consan = False
     run_failing_kernel(device)
@@ -125,9 +125,9 @@ def test_cache_miss_env(device, monkeypatch):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_async_tma_kernel(FAILURE, device, run_wrapper):
+def test_async_tma_kernel(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_async_tma_kernel, (FAILURE, device, False))
+        result = run_in_process(test_async_tma_kernel, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
@@ -171,9 +171,9 @@ def test_async_tma_kernel(FAILURE, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_tma_interleave_kernel(FAILURE, device, run_wrapper):
+def test_tma_interleave_kernel(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_tma_interleave_kernel, (FAILURE, device, False))
+        result = run_in_process(test_tma_interleave_kernel, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
@@ -229,9 +229,9 @@ def test_tma_interleave_kernel(FAILURE, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires ampere or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_async_copy(FAILURE, device, run_wrapper):
+def test_async_copy(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_async_copy, (FAILURE, device, False))
+        result = run_in_process(test_async_copy, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Accessing buffer with pending access. Pending access type: async_copy_global_to_shared" in result.driver_stderr_output
@@ -276,9 +276,9 @@ def test_async_copy(FAILURE, device, run_wrapper):
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
 @pytest.mark.parametrize("MEM_ACCESS_KIND", ["tma_cp", "local_store", "tmem_load", "tmem_store"])
-def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, run_wrapper):
+def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_tcgen5_mma, (FAILURE, MEM_ACCESS_KIND, device, False))
+        result = run_in_process(test_tcgen5_mma, (FAILURE, MEM_ACCESS_KIND, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             if MEM_ACCESS_KIND == "tma_cp":
@@ -344,9 +344,9 @@ def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] != 9, reason="Requires hopper")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_warpgroup_mma(FAILURE, device, run_wrapper):
+def test_warpgroup_mma(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_warpgroup_mma, (FAILURE, device, False))
+        result = run_in_process(test_warpgroup_mma, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Accessing buffer with pending access. Pending access type: warpgroup_mma operand read" in result.driver_stderr_output
@@ -388,9 +388,9 @@ def test_warpgroup_mma(FAILURE, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] != 9, reason="Requires hopper")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_warpgroup_mma2(FAILURE, device, run_wrapper):
+def test_warpgroup_mma2(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_warpgroup_mma2, (FAILURE, device, False))
+        result = run_in_process(test_warpgroup_mma2, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Accessing buffer with pending access. Pending access type: warpgroup_mma operand read" in result.driver_stderr_output
@@ -435,11 +435,11 @@ def test_warpgroup_mma2(FAILURE, device, run_wrapper):
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
 @pytest.mark.parametrize("BUF_IDX", [0, 1])
 @pytest.mark.parametrize("BAR_IDX", [0, 1, 2, 3])
-def test_tcgen5_mma_multibar(BUF_IDX, BAR_IDX, device, run_wrapper):
+def test_tcgen5_mma_multibar(BUF_IDX, BAR_IDX, device, run_wrapper, fresh_knobs):
     if BAR_IDX == 0:
         pytest.skip("Skipping due to wait on false-predicated barrier - not supported yet")
     if run_wrapper:
-        result = run_in_process(test_tcgen5_mma_multibar, (BUF_IDX, BAR_IDX, device, False))
+        result = run_in_process(test_tcgen5_mma_multibar, (BUF_IDX, BAR_IDX, device, False, None))
         if BAR_IDX // 2 < BUF_IDX:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
@@ -494,9 +494,9 @@ def inc_mod(x, mod):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_multibuffered_loop(FAILURE, device, run_wrapper):
+def test_multibuffered_loop(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_multibuffered_loop, (FAILURE, device, False))
+        result = run_in_process(test_multibuffered_loop, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
@@ -608,9 +608,9 @@ def test_multibuffered_loop(FAILURE, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] != 9, reason="Requires hopper")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_multibuffered_wgmma_loop(FAILURE, device, run_wrapper):
+def test_multibuffered_wgmma_loop(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_multibuffered_wgmma_loop, (FAILURE, device, False))
+        result = run_in_process(test_multibuffered_wgmma_loop, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Accessing buffer with pending access. Pending access type: warpgroup_mma operand read" in result.driver_stderr_output
@@ -689,9 +689,9 @@ def test_multibuffered_wgmma_loop(FAILURE, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_ws_store_wait_load(FAILURE, device, run_wrapper):
+def test_ws_store_wait_load(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_ws_store_wait_load, (FAILURE, device, False))
+        result = run_in_process(test_ws_store_wait_load, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
@@ -742,9 +742,9 @@ def test_ws_store_wait_load(FAILURE, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_ws_load_wait_store(FAILURE, device, run_wrapper):
+def test_ws_load_wait_store(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_ws_load_wait_store, (FAILURE, device, False))
+        result = run_in_process(test_ws_load_wait_store, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
@@ -795,9 +795,9 @@ def test_ws_load_wait_store(FAILURE, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 @pytest.mark.parametrize("MISSING_BAR", ["none", "1", "2"])
-def test_ws_two_loads_two_bars(MISSING_BAR, device, run_wrapper):
+def test_ws_two_loads_two_bars(MISSING_BAR, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_ws_two_loads_two_bars, (MISSING_BAR, device, False))
+        result = run_in_process(test_ws_two_loads_two_bars, (MISSING_BAR, device, False, None))
         if MISSING_BAR != "none":
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
@@ -857,9 +857,9 @@ def test_ws_two_loads_two_bars(MISSING_BAR, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_ws_two_loads_one_bar(FAILURE, device, run_wrapper):
+def test_ws_two_loads_one_bar(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_ws_two_loads_one_bar, (FAILURE, device, False))
+        result = run_in_process(test_ws_two_loads_one_bar, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
@@ -916,9 +916,9 @@ def test_ws_two_loads_one_bar(FAILURE, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 @pytest.mark.parametrize("MISSING_BAR", ["none", "0", "1", "2", "3"])
-def test_ws_two_loads_two_bars_loop(MISSING_BAR, device, run_wrapper):
+def test_ws_two_loads_two_bars_loop(MISSING_BAR, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_ws_two_loads_two_bars_loop, (MISSING_BAR, device, False))
+        result = run_in_process(test_ws_two_loads_two_bars_loop, (MISSING_BAR, device, False, None))
         if MISSING_BAR != "none":
             assert "device-side assert" in str(result.exc)
             if MISSING_BAR in ["0", "1"]:
@@ -999,9 +999,9 @@ def test_ws_two_loads_two_bars_loop(MISSING_BAR, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_ws_load_ordering(FAILURE, device, run_wrapper):
+def test_ws_load_ordering(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_ws_load_ordering, (FAILURE, device, False))
+        result = run_in_process(test_ws_load_ordering, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
@@ -1063,9 +1063,9 @@ def test_ws_load_ordering(FAILURE, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 @pytest.mark.parametrize("MISSING_BAR", ["none", "T2", "T3"])
-def test_ws_two_producers_two_consumers(MISSING_BAR, device, run_wrapper):
+def test_ws_two_producers_two_consumers(MISSING_BAR, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_ws_two_producers_two_consumers, (MISSING_BAR, device, False))
+        result = run_in_process(test_ws_two_producers_two_consumers, (MISSING_BAR, device, False, None))
         if MISSING_BAR != "none":
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding" in result.driver_stderr_output
@@ -1150,9 +1150,9 @@ def test_ws_two_producers_two_consumers(MISSING_BAR, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 @pytest.mark.parametrize("MISSING_BAR", ["none", "1", "2"])
-def test_ws_different_warp_sizes(MISSING_BAR, device, run_wrapper):
+def test_ws_different_warp_sizes(MISSING_BAR, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_ws_different_warp_sizes, (MISSING_BAR, device, False))
+        result = run_in_process(test_ws_different_warp_sizes, (MISSING_BAR, device, False, None))
         if MISSING_BAR != "none":
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
@@ -1218,9 +1218,9 @@ def test_ws_different_warp_sizes(MISSING_BAR, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_ws_async_copy_commits(FAILURE, device, run_wrapper):
+def test_ws_async_copy_commits(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_ws_async_copy_commits, (FAILURE, device, False))
+        result = run_in_process(test_ws_async_copy_commits, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
@@ -1279,9 +1279,9 @@ def test_ws_async_copy_commits(FAILURE, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_ws_async_copy_wait_visibility(FAILURE, device, run_wrapper):
+def test_ws_async_copy_wait_visibility(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_ws_async_copy_wait_visibility, (FAILURE, device, False))
+        result = run_in_process(test_ws_async_copy_wait_visibility, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert (("Buffer being accessed has outstanding writes" in result.driver_stderr_output)
@@ -1333,9 +1333,9 @@ def test_ws_async_copy_wait_visibility(FAILURE, device, run_wrapper):
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] != 9, reason="Requires hopper")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_ws_wgmma_wait_visibility(FAILURE, device, run_wrapper):
+def test_ws_wgmma_wait_visibility(FAILURE, device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_ws_wgmma_wait_visibility, (FAILURE, device, False))
+        result = run_in_process(test_ws_wgmma_wait_visibility, (FAILURE, device, False, None))
         if FAILURE:
             assert "device-side assert" in str(result.exc)
             assert "Accessing buffer with pending access. Pending access type: warpgroup_mma operand read" in result.driver_stderr_output
@@ -1386,9 +1386,9 @@ def test_ws_wgmma_wait_visibility(FAILURE, device, run_wrapper):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-def test_deadlock_two_partitions(device, run_wrapper):
+def test_deadlock_two_partitions(device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_deadlock_two_partitions, (device, False))
+        result = run_in_process(test_deadlock_two_partitions, (device, False, None))
         assert "device-side assert" in str(result.exc)
         assert "Deadlock detected" in result.driver_stderr_output
         return
@@ -1420,9 +1420,9 @@ def test_deadlock_two_partitions(device, run_wrapper):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-def test_deadlock_overarrival(device, run_wrapper):
+def test_deadlock_overarrival(device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_deadlock_overarrival, (device, False))
+        result = run_in_process(test_deadlock_overarrival, (device, False, None))
         assert "device-side assert" in str(result.exc)
         assert "Deadlock detected" in result.driver_stderr_output
         return
@@ -1449,9 +1449,9 @@ def test_deadlock_overarrival(device, run_wrapper):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-def test_deadlock_underarrival(device, run_wrapper):
+def test_deadlock_underarrival(device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_deadlock_underarrival, (device, False))
+        result = run_in_process(test_deadlock_underarrival, (device, False, None))
         assert "device-side assert" in str(result.exc)
         assert "Deadlock detected" in result.driver_stderr_output
         return
@@ -1485,9 +1485,9 @@ def test_deadlock_underarrival(device, run_wrapper):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-def test_deadlock_different_phases(device, run_wrapper):
+def test_deadlock_different_phases(device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_deadlock_different_phases, (device, False))
+        result = run_in_process(test_deadlock_different_phases, (device, False, None))
         assert result.exc is None
         assert result.driver_stderr_output == ""
         return
@@ -1520,9 +1520,9 @@ def test_deadlock_different_phases(device, run_wrapper):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-def test_deadlock_exempt_when_tma_signals(device, run_wrapper):
+def test_deadlock_exempt_when_tma_signals(device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_deadlock_exempt_when_tma_signals, (device, False))
+        result = run_in_process(test_deadlock_exempt_when_tma_signals, (device, False, None))
         assert result.exc is None
         assert result.driver_stderr_output == ""
         return
@@ -1563,9 +1563,9 @@ def test_deadlock_exempt_when_tma_signals(device, run_wrapper):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
-def test_barrier_underflow(device, run_wrapper):
+def test_barrier_underflow(device, run_wrapper, fresh_knobs):
     if run_wrapper:
-        result = run_in_process(test_barrier_underflow, (device, False))
+        result = run_in_process(test_barrier_underflow, (device, False, None))
         assert "device-side assert" in str(result.exc)
         assert "Barrier arrive underflow: current count would become negative" in result.driver_stderr_output
         return


### PR DESCRIPTION
Make the TRITON_ENABLE_EXPERIMENTAL_CONSAN cache invalidating and add tests verifying that there is no collision between consan enabled and disabled.