### PR TITLE
[AMD][NFC]Move LowerLoops from TritonAMDGPUScheduleLoops to TritonAMDGPUPipeline

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -158,7 +158,7 @@ public:
   // Set <stage, cluster> based on CoarseSchedule.
   void serialize(scf::ForOp &forOp) const;
   // Create a CoarseSchedule based on forOp's <stage, cluster>.
-  // If normalizeClusterId is true, cluster will be mapped to a sequence
+  // If normalizeClusterId is true, clusters will be mapped to a sequence
   // starting from 0.
   LogicalResult deSerialize(scf::ForOp &forOp, bool normalizeClusterId = true);
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Schedule.h
@@ -54,6 +54,7 @@ public:
     iterator end() { return orderClusters.end(); }
     const_iterator end() const { return orderClusters.end(); }
     size_t size() const { return orderClusters.size(); }
+    void clear() { orderClusters.clear(); }
     iterator newAtBack() {
       orderClusters.push_back(orderClusters.size());
       return std::prev(orderClusters.end());
@@ -157,7 +158,9 @@ public:
   // Set <stage, cluster> based on CoarseSchedule.
   void serialize(scf::ForOp &forOp) const;
   // Create a CoarseSchedule based on forOp's <stage, cluster>.
-  LogicalResult deSerialize(scf::ForOp &forOp);
+  // If normalizeClusterId is true, cluster will be mapped to a sequence
+  // starting from 0.
+  LogicalResult deSerialize(scf::ForOp &forOp, bool normalizeClusterId = true);
 
   static ClusterHash hashCluster(Cluster cluster) {
     return reinterpret_cast<ClusterHash>(&*cluster);

--- a/test/TritonGPU/amd/amd-pipeline-chained-dots.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-chained-dots.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=4 use_async_copy=1" -tritonamdgpu-pipeline="use_async_copy=1" -canonicalize | FileCheck %s
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=4" -tritonamdgpu-pipeline="use_async_copy=1" -canonicalize | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
 #mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = true}>

--- a/test/TritonGPU/loop-pipeline-combine-waits.mlir
+++ b/test/TritonGPU/loop-pipeline-combine-waits.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=3 use_async_copy=1 use_pingpong=1" -tritonamdgpu-pipeline="use_async_copy=1" | FileCheck %s
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=3" -tritonamdgpu-pipeline="use_async_copy=1 use_pingpong=1" | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
 #mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>

--- a/test/TritonGPU/loop-pipeline-hip.mlir
+++ b/test/TritonGPU/loop-pipeline-hip.mlir
@@ -1,5 +1,5 @@
 // RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops=num_stages=2 -tritonamdgpu-pipeline -canonicalize | FileCheck %s --check-prefixes=COMMON,SYNC
-// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=2 use_async_copy=1" -tritonamdgpu-pipeline="use_async_copy=1" -canonicalize | FileCheck %s --check-prefixes=COMMON,ASYNC
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=2" -tritonamdgpu-pipeline="use_async_copy=1" -canonicalize | FileCheck %s --check-prefixes=COMMON,ASYNC
 
 #blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -224,8 +224,8 @@ class HIPBackend(BaseBackend):
         use_async_copy = knobs.amd.use_async_copy
         use_block_pingpong = is_pingpong_schedule_enabled(options.arch, use_async_copy)
 
-        amd.passes.ttgpuir.add_schedule_loops(pm, options.num_stages, use_async_copy, use_block_pingpong)
-        amd.passes.ttgpuir.add_pipeline(pm, use_async_copy)
+        amd.passes.ttgpuir.add_schedule_loops(pm, options.num_stages)
+        amd.passes.ttgpuir.add_pipeline(pm, use_async_copy, use_block_pingpong)
         if use_async_copy:
             amd.passes.ttgpuir.add_coalesce_async_copy(pm, options.arch)
         passes.common.add_canonicalizer(pm)

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -16,13 +16,7 @@ def TritonAMDGPUScheduleLoops : Pass<"tritonamdgpu-schedule-loops", "mlir::Modul
   let options = [
     Option<"numStages", "num_stages",
            "int32_t", /*default*/"2",
-           "Number of Pipeline stages">,
-    Option<"useAsyncCopy", "use_async_copy",
-           "bool", /*default*/"false",
-           "Use AsyncCopyGlobalToLocal to directly load to shared memory">,
-    Option<"usePingpong", "use_pingpong",
-           "bool", /*default*/"false",
-           "Use schedules to enable block ping-pong">,
+           "Number of Pipeline stages">
   ];
 }
 
@@ -38,6 +32,9 @@ def TritonAMDGPUPipeline : Pass<"tritonamdgpu-pipeline", "mlir::ModuleOp"> {
     Option<"useAsyncCopy", "use_async_copy",
            "bool", /*default*/"false",
            "Use AsyncCopyGlobalToLocal to directly load to shared memory">,
+    Option<"usePingpong", "use_pingpong",
+           "bool", /*default*/"false",
+           "Use schedules to enable block ping-pong">
   ];
 }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonAMDGPUTransforms
   ReorderInstructions.cpp
   Pipeline.cpp
   ScheduleLoops.cpp
+  LowerLoops.cpp
   MfmaGroup.cpp
   WmmaGroup.cpp
   InThreadTranspose.cpp

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -1,0 +1,754 @@
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "amd/lib/TritonAMDGPUToLLVM/AsyncUtility.h"
+#include "amd/lib/TritonAMDGPUToLLVM/TargetInfo.h"
+#include "amd/lib/TritonAMDGPUTransforms/PipelineUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "llvm/Support/Debug.h"
+#include <variant>
+
+#define DEBUG_TYPE "tritonamdgpu-pipeline-lower-loops"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
+//===----------------------------------------------------------------------===//
+// This file will create a schedule that will be handed over to the pipeline
+// expander.
+// Software pipeliners are usually separated into two pieces, one that create a
+// modulo schedule and an expander that rewrites the loop and emits a prologue
+// and epilogue. This pass first calls a helper that will pre-process the IR
+// to create stream operations and create a modulo schedule. Then we call the
+// expander to generate the prologue and new loop and epilogue.
+//===----------------------------------------------------------------------===//
+
+using mlir::triton::AMD::AttrBypassLDS;
+
+namespace mlir {
+struct StreamCopyChainOps {
+  tt::LoadOp loadOp;
+  ttg::MemDescIndexOp subviewOp;
+  ttg::LocalStoreOp localStoreOp;
+  ttg::LocalLoadOp maybeLocalLoadOp;
+};
+
+struct AsyncCopyChainOps {
+  ttg::AsyncCopyGlobalToLocalOp copyOp;
+  ttg::AsyncCommitGroupOp commitOp;
+  ttg::AsyncWaitOp waitOp;
+  ttg::LocalLoadOp maybeLocalLoadOp;
+};
+
+using StreamOpVariant = std::variant<StreamCopyChainOps, AsyncCopyChainOps>;
+using LoadToStreamOpMap = llvm::MapVector<Operation *, StreamOpVariant>;
+
+AsyncCopyChainOps createAsyncCopy(tt::LoadOp loadOp, Value alloc,
+                                  Value extractIdx) {
+  OpBuilder builder(loadOp);
+  Location loc = loadOp.getLoc();
+
+  // Extract local subview from shared allocation
+  auto viewLoad = triton::createSingleBufferView(builder, alloc, extractIdx)
+                      .getDefiningOp<ttg::MemDescIndexOp>();
+
+  auto copyOp = builder.create<ttg::AsyncCopyGlobalToLocalOp>(
+      loc, loadOp.getPtr(), viewLoad, loadOp.getMask(), loadOp.getOther(),
+      loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
+  auto commitOp =
+      builder.create<ttg::AsyncCommitGroupOp>(loc, copyOp->getResult(0));
+  ttg::AsyncWaitOp waitOp =
+      builder.create<ttg::AsyncWaitOp>(loc, commitOp->getResult(0), 0);
+
+  auto maybeSharedLoad = tt::replaceUsesWithLocalLoad(
+      builder, loadOp->getResult(0), viewLoad, waitOp);
+
+  return {copyOp, commitOp, waitOp, maybeSharedLoad};
+}
+
+void scheduleLocalLoad(ttg::LocalLoadOp localLoadOp,
+                       tt::CoarseSchedule &schedule, int stage,
+                       const tt::CoarseSchedule::Cluster &cluster) {
+  schedule.insert(localLoadOp, stage, cluster);
+  // If its only user is a ConvertLayout, we place it into the same stage so
+  // it can be folded by a later pass
+  if (localLoadOp->hasOneUse()) {
+    auto cvt = *localLoadOp->getUsers().begin();
+    if (isa<ttg::ConvertLayoutOp>(cvt)) {
+      schedule.insert(cvt, stage, cluster);
+    }
+  }
+}
+
+StreamCopyChainOps createStreamCopy(tt::LoadOp loadOp, Value alloc,
+                                    Value extractIdx) {
+  OpBuilder builder(loadOp);
+  Location loc = loadOp.getLoc();
+
+  // Extract local subview from shared allocation
+  auto viewLoad = triton::createSingleBufferView(builder, alloc, extractIdx)
+                      .getDefiningOp<ttg::MemDescIndexOp>();
+
+  tt::LoadOp newLoadOp = cast<tt::LoadOp>(builder.clone(*loadOp));
+  auto storeOp = builder.create<ttg::LocalStoreOp>(loc, newLoadOp, viewLoad);
+  auto maybeLocalLoad =
+      tt::replaceUsesWithLocalLoad(builder, loadOp->getResult(0), viewLoad);
+
+  return {newLoadOp, viewLoad, storeOp, maybeLocalLoad};
+}
+
+// Returns the given |inputValue|'s dot user result encoding and updates |opIdx|
+// and |vecSize| with which dot operand |inputValue| is fed into if possible.
+ttg::AMDMfmaEncodingAttr getDotEncoding(Value inputValue, unsigned *opIdx,
+                                        unsigned *vecSize) {
+  if (!inputValue.hasOneUse())
+    return nullptr;
+
+  Operation *user = *inputValue.getUsers().begin();
+  if (user->getNumResults() != 1 ||
+      user->getBlock() != inputValue.getParentBlock())
+    return nullptr;
+
+  LDBG("getDotEncoding user: " << *user);
+  if (auto dotOp = dyn_cast<tt::DotOpInterface>(user)) {
+    OpOperand &use = *inputValue.getUses().begin();
+    *opIdx = use.getOperandNumber();
+    auto operandType = cast<RankedTensorType>(inputValue.getType());
+    *vecSize = ttg::toLinearLayout(operandType).getNumConsecutiveInOut();
+    auto dotType = cast<RankedTensorType>(dotOp->getResult(0).getType());
+    return dyn_cast<ttg::AMDMfmaEncodingAttr>(dotType.getEncoding());
+  }
+
+  return getDotEncoding(user->getResult(0), opIdx, vecSize);
+}
+
+// Adapted from
+// lib/Dialect/TritonGPU/Transforms/Utility.cpp::getSharedEncIfAllUsersAreDotEnc
+// to support AMDMfmaEncodingAttr.
+// TODO(max): figure out how to refactor to use upstream
+//
+// If all the transitive uses of the given value have are used by a convert to
+// the same dot operand encoding, return true and get the shared encoding that
+// needs to be used to be compatible with users' layouts.
+std::optional<ttg::SwizzledSharedEncodingAttr>
+getSharedEncIfAllUsersAreDotEnc(Value loadedValue) {
+  llvm::SmallVector<ttg::SwizzledSharedEncodingAttr> sharedEncs;
+  for (Operation *user : loadedValue.getUsers()) {
+    LDBG(" getSharedEncIfAllUsersAreDotEnc current user: " << *user);
+    if (user->getNumResults() != 1)
+      return std::nullopt;
+
+    ttg::SwizzledSharedEncodingAttr tempAttr;
+    Value userResult = user->getResult(0);
+    Type userResType = userResult.getType();
+    if (auto memDesc = dyn_cast<ttg::MemDescType>(userResType)) {
+      // First time we find a shared encoding in the chain, save it and try to
+      // use it if it is compatible with the other users.
+      tempAttr = cast<ttg::SwizzledSharedEncodingAttr>(memDesc.getEncoding());
+      // If the immediate user is ttg::LocalAllocOp, likely it's created in
+      // TritonAMDGPUOptimizeDotOperands. We should just respect it.
+      if (!getSharedEncIfAllUsersAreDotEnc(userResult).has_value() &&
+          !isa<ttg::LocalAllocOp>(user)) {
+        return std::nullopt;
+      }
+      LDBG("Deduced shared encoding candidate from memDesc: " << tempAttr);
+      sharedEncs.push_back(tempAttr);
+    } else {
+      if (!(isa<ttg::ConvertLayoutOp>(user) ||
+            user->hasTrait<OpTrait::LocalLoadTrait>()))
+        return std::nullopt;
+
+      auto srcTy = cast<ttg::TensorOrMemDesc>(loadedValue.getType());
+      auto ctaLayout = ttg::getCTALayout(srcTy.getEncoding());
+      auto order = getOrderForMemory(srcTy);
+      unsigned bitWidth = srcTy.getElementType().getIntOrFloatBitWidth();
+      SmallVector<unsigned> sharedOrder;
+      int rank = order.size();
+      // TODO rework this when shared -> dotOperand conversions support
+      // arbitrary shared memory ordering
+      if (rank == 3) {
+        // Move the batch dimension (dim #0) to be the last so that it will be
+        // the slowest varying dimension.
+        for (unsigned i = 0; i < rank; ++i)
+          if (order[i] != 0)
+            sharedOrder.emplace_back(order[i]);
+        sharedOrder.emplace_back(0);
+      } else {
+        sharedOrder = order;
+      }
+
+      auto userResEnc = cast<ttg::TensorOrMemDesc>(userResType).getEncoding();
+      if (auto dotOpEnc = dyn_cast<ttg::DotOperandEncodingAttr>(userResEnc)) {
+        tempAttr = ttg::SwizzledSharedEncodingAttr::get(
+            loadedValue.getContext(), dotOpEnc, srcTy.getShape(), sharedOrder,
+            ctaLayout, bitWidth, /*needTrans=*/false);
+        LDBG("Deduced shared encoding candidate from dot layout: " << tempAttr);
+        sharedEncs.push_back(tempAttr);
+      } else if (auto llEnc = dyn_cast<ttg::LinearEncodingAttr>(userResEnc)) {
+        // We use linear layout directly for scaled dot fp8 operands. For such
+        // cases, we need to look further down the def-use chain to find the dot
+        // op for the mfma layout to deduce operand index and other information.
+        unsigned opIdx;
+        unsigned vecSize;
+        if (auto mfmaEnc = getDotEncoding(userResult, &opIdx, &vecSize)) {
+          LDBG("deduced opIdx: " << opIdx << "; deduced vecSize: " << vecSize);
+          tempAttr = mfmaEnc.composeSharedLayoutForOperand(
+              ctaLayout, opIdx, srcTy.getShape(), order, vecSize, bitWidth,
+              /*needTrans=*/false);
+          LDBG("Deduced shared encoding candidate from mfma layout: "
+               << tempAttr);
+          sharedEncs.push_back(tempAttr);
+        }
+      }
+    }
+  }
+
+  auto equalSharedEncIgnoreVec = [](ttg::SwizzledSharedEncodingAttr a,
+                                    ttg::SwizzledSharedEncodingAttr b) {
+    if (!a || !b)
+      return false;
+    return (a.getPerPhase() == b.getPerPhase() &&
+            a.getMaxPhase() == b.getMaxPhase() &&
+            a.getOrder() == b.getOrder() &&
+            a.getCTALayout() == b.getCTALayout());
+  };
+  if (sharedEncs.empty() || !sharedEncs.front())
+    return std::nullopt;
+  auto maxVecSharedEnc = sharedEncs.front();
+
+  for (auto sharedEnc : sharedEncs) {
+    if (!equalSharedEncIgnoreVec(sharedEnc, maxVecSharedEnc)) {
+      LDBG("Incompatible shared encodings");
+      return std::nullopt;
+    }
+    if (sharedEnc.getVec() > maxVecSharedEnc.getVec()) {
+      maxVecSharedEnc = sharedEnc;
+    }
+  }
+
+  LDBG("Deduced shared encoding: " << maxVecSharedEnc);
+
+  return maxVecSharedEnc;
+}
+
+bool canBeConvertedToAsyncLoad(unsigned numBuffers, tt::LoadOp loadOp,
+                               Value alloc,
+                               tt::ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                               const tt::AMD::TargetInfo &targetInfo) {
+  // If we have a single buffer we would require another barrier after the
+  // local_reads so instead we fall back to pipeline with registers
+  // Removing this check will create incorrect IR, see
+  // MembarUtility.h:membarFilter
+  if (numBuffers <= 1)
+    return false;
+
+  // Compute the final vecSize we can use for the combination of sourceEncoding
+  // and sharedEncoding. We can only use AsyncCopy if the target supports the
+  // requested or a smaller vecSize because we cannot stride when loading
+  // directly to lds
+  auto srcTy = cast<RankedTensorType>(loadOp.getPtr().getType());
+  auto dstTy = cast<ttg::MemDescType>(alloc.getType());
+  auto regLayout = triton::gpu::toLinearLayout(srcTy);
+  // It's the allocation so we trim the multibuffer dimension
+  auto srcShape = dstTy.getShape().take_back(srcTy.getRank());
+  auto sharedLayout =
+      triton::gpu::toLinearLayout(srcShape, dstTy.getEncoding());
+  auto regToSharedLayout = regLayout.invertAndCompose(sharedLayout);
+
+  unsigned vecSize = regToSharedLayout.getNumConsecutiveInOut();
+  unsigned elemBitWidth = dstTy.getElementTypeBitWidth();
+
+  if (fitToValidDirectToLdsVecSize(vecSize, elemBitWidth, targetInfo) == 0)
+    return false;
+
+  // Checks whether the global pointer's contiguity and mask alignment allows
+  // for at least 32 bit wide loads
+  return triton::canBeConvertedToAsyncLoad(loadOp, axisInfoAnalysis);
+}
+
+// Convert load ops into shared memory allocation loads and apply
+// multi-buffering based on the required number of buffers.
+LoadToStreamOpMap
+createStreamOps(const LoadToInfoMap &loadToInfo, scf::ForOp &forOp,
+                const int &numBuffers, bool useAsyncCopy,
+                tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
+  IRRewriter builder(forOp);
+  Location loc = forOp.getLoc();
+  Value minusOne = builder.create<arith::ConstantIntOp>(loc, -1, 32);
+  Value zero = builder.create<arith::ConstantIntOp>(loc, 0, 32);
+  Value one = builder.create<arith::ConstantIntOp>(loc, 1, 32);
+  Value extractIdx = minusOne;
+  Value numBuffersVal =
+      builder.create<arith::ConstantIntOp>(loc, numBuffers, 32);
+
+  unsigned newOperandIndex = forOp.getBody()->getNumArguments();
+  // Patch the loop to add the new loop carried dependency.
+  forOp = addIterArgsToLoop(builder, forOp, {extractIdx});
+
+  // Create one counter for the extract indices to avoid creating long
+  // live range.
+  extractIdx = forOp.getBody()->getArgument(newOperandIndex);
+
+  builder.setInsertionPoint(forOp.getBody(), forOp.getBody()->begin());
+  extractIdx = builder.create<arith::AddIOp>(loc, extractIdx, one);
+  Value cndExt = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,
+                                               extractIdx, numBuffersVal);
+  extractIdx = builder.create<arith::SelectOp>(loc, cndExt, extractIdx, zero);
+
+  // Patch the yield with the updated counter.
+  appendToForOpYield(forOp, {extractIdx});
+
+  LoadToStreamOpMap loadToStreamOp;
+  for (auto &[l, info] : loadToInfo) {
+    if (!info.sharedEncoding)
+      continue;
+
+    auto loadOp = dyn_cast<tt::LoadOp>(l);
+    if (!loadOp)
+      continue;
+
+    // Create an allocation that can hold distance number of loadOp shapes.
+    auto ty = cast<RankedTensorType>(loadOp->getResultTypes()[0]);
+    Value alloc = triton::createAlloc(forOp, ty, loadOp->getLoc(),
+                                      info.sharedEncoding, numBuffers);
+    assert(alloc && "Failed to create alloc for the async load.");
+    auto arch = getAMDArch(loadOp->getParentOfType<ModuleOp>());
+    triton::AMD::TargetInfo targetInfo(arch ? arch->str() : "");
+
+    // Replace the old load with multi-buffered loads
+    if (useAsyncCopy &&
+        canBeConvertedToAsyncLoad(numBuffers, loadOp, alloc, axisInfoAnalysis,
+                                  targetInfo)) {
+      loadToStreamOp[loadOp] = createAsyncCopy(loadOp, alloc, extractIdx);
+    } else {
+      loadToStreamOp[loadOp] = createStreamCopy(loadOp, alloc, extractIdx);
+    }
+  }
+
+  return loadToStreamOp;
+}
+
+static void dumpSchedule(tt::CoarseSchedule &schedule, llvm::StringRef msg) {
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n";
+    LDBG(msg);
+    schedule.dump();
+  });
+};
+
+namespace SingleDotSchedule {
+using namespace mlir::SingleDotSchedule;
+
+// Init Schedule Config based on settings and loop characteristics.
+// Create clusters in order of ops in loop. This can interleave ops
+// from different stages in the same cluster to achieve better backend
+// scheduling.
+//   WARNING: Changing the order of schedule.clusters.newAtBack() calls
+//            can cause invalid schedules to be produced.
+LogicalResult initSchedule(int maxDist, Stages &stages, int numStages,
+                           int &numBuffers, bool useAsyncCopy, bool waitAtTail,
+                           Clusters &clusters, tt::CoarseSchedule &schedule) {
+  LDBG("Init SingleDotSchedule");
+  int lastStage = numStages - 1;
+  stages[SCHED_GLOBAL_LOAD] = 0;
+  stages[SCHED_LOCAL_STORE] = 0;
+  stages[SCHED_LOCAL_LOAD] = lastStage;
+  stages[SCHED_COMPUTE] = lastStage;
+  stages[SCHED_ASYNC_WAIT] = stages[SCHED_LOCAL_LOAD];
+
+  bool pairedGlobalLoadLocalStore = stages[SCHED_LOCAL_STORE] == 0;
+  stages[SCHED_LOCAL_STORE] += maxDist;
+  if (waitAtTail) {
+    stages[SCHED_ASYNC_WAIT] = std::max(0, stages[SCHED_LOCAL_LOAD] - 1);
+  }
+
+  LDBG(
+      "Stage schedule:" << "  GLOBAL_LOAD stage = " << stages[SCHED_GLOBAL_LOAD]
+                        << ", LOCAL_STORE stage = " << stages[SCHED_LOCAL_STORE]
+                        << ", LOCAL_LOAD stage = " << stages[SCHED_LOCAL_LOAD]
+                        << ", COMPUTE stage = " << stages[SCHED_COMPUTE]
+                        << ", ASYNC_WAIT stage = " << stages[SCHED_ASYNC_WAIT]
+                        << "; total = " << numStages);
+
+  if (stages[SCHED_LOCAL_STORE] >= numStages ||
+      stages[SCHED_LOCAL_STORE] > stages[SCHED_LOCAL_LOAD]) {
+    LDBG("Invalid stage schedule");
+    return failure();
+  }
+
+  // Calculate the number of buffers needed for each load.
+  // TODO: Use the precise number of buffers needed by the particular load.
+  numBuffers =
+      std::max(1, stages[SCHED_LOCAL_LOAD] - stages[SCHED_LOCAL_STORE]);
+  // If we use AsyncCopy we need one more buffer since we are not using a
+  // register buffer
+  if (useAsyncCopy) {
+    numBuffers += 1;
+  }
+
+  LDBG("deduced max shared memory buffer number = " << numBuffers);
+
+  // We place async wait as the first cluster because we want to have it being
+  // the first in the main loop after pipelining.
+  // In case we use async_copy with pingpong, we need to place async_wait at
+  // the end of the previous iteration, so it can guarantee the correct
+  // dependency when warp0 and warp1 are pipelined.
+  int asyncWaitCluster = waitAtTail ? 4 : 0;
+  // If tt.load and ttg.local_store are in the same stage
+  //   spread them apart to allow overlap with compute
+  // else
+  //   Initiate ttg.local_store before tt.load
+  int globalLoadCluster = 1;
+  int localStoreCluster = 3;
+  if (!pairedGlobalLoadLocalStore) {
+    globalLoadCluster = 3;
+    localStoreCluster = 2;
+  }
+
+  // If ttg.local_load and ttg.local_store are in the same stage
+  //   spread them apart to allow overlap with compute
+  // else if they share the buffer
+  //   ttg.local_load must come first
+  // else
+  //   schedule ttg.local_load in the middle
+  int localLoadCluster = globalLoadCluster;
+  if (stages[SCHED_LOCAL_LOAD] == stages[SCHED_LOCAL_STORE]) {
+    localLoadCluster = std::max(3, localStoreCluster + 1);
+  } else if (numBuffers == 1 && localLoadCluster >= localStoreCluster) {
+    // For 1 buffer, ttg.local_load must occur before ttg.local_store
+    localLoadCluster = localStoreCluster - 1;
+  }
+
+  // Schedule compute with ttg.local_load if paired
+  // otherwise, schedule in the middle
+  int computeCluster = 2;
+  if (stages[SCHED_LOCAL_LOAD] == stages[SCHED_COMPUTE]) {
+    computeCluster = localLoadCluster;
+  }
+
+  bool recoverCluster = schedule.clusters.size() > 0;
+  DenseMap<tt::CoarseSchedule::ClusterHash, int> clusterMap;
+  if (recoverCluster) {
+    for (auto &[op, stageAndCluster] : schedule.opToStageAndCluster) {
+      auto [stage, cluster] = stageAndCluster;
+      tt::CoarseSchedule::ClusterHash clusterHash =
+          tt::CoarseSchedule::hashCluster(cluster);
+      clusterMap[clusterHash] = *cluster;
+    }
+    schedule.clusters.clear();
+  }
+
+  // Make assignments
+  Clusters clusterVec;
+  std::generate(clusterVec.begin(), clusterVec.end(),
+                [&]() { return schedule.clusters.newAtBack(); });
+
+  clusters[SCHED_GLOBAL_LOAD] = clusterVec[globalLoadCluster];
+  clusters[SCHED_LOCAL_STORE] = clusterVec[localStoreCluster];
+  clusters[SCHED_LOCAL_LOAD] = clusterVec[localLoadCluster];
+  clusters[SCHED_COMPUTE] = clusterVec[computeCluster];
+  clusters[SCHED_ASYNC_WAIT] = clusterVec[asyncWaitCluster];
+
+  // Put global and compute clusters in right place
+  if (recoverCluster) {
+    for (auto &[op, stageAndCluster] : schedule.opToStageAndCluster) {
+      auto [stage, cluster] = stageAndCluster;
+      tt::CoarseSchedule::ClusterHash clusterHash =
+          tt::CoarseSchedule::hashCluster(stageAndCluster.second);
+      int oldClusterId = clusterMap[clusterHash];
+      if (oldClusterId == 0) {
+        stageAndCluster.second = clusters[SCHED_GLOBAL_LOAD];
+      } else {
+        assert(oldClusterId == 1);
+        stageAndCluster.second = clusters[SCHED_COMPUTE];
+      }
+    }
+  }
+
+  LDBG("Cluster schedule:" << "  GLOBAL_LOAD cluster = " << globalLoadCluster
+                           << ", LOCAL_STORE cluster = " << localStoreCluster
+                           << ", LOCAL_LOAD cluster = " << localLoadCluster
+                           << ", COMPUTE cluster = " << computeCluster
+                           << ", ASYNC_WAIT cluster = " << asyncWaitCluster
+                           << "; total = " << SCHED_SIZE);
+
+  return success();
+}
+
+void scheduleAsyncCopy(const AsyncCopyChainOps &asyncOps, tt::LoadOp loadOp,
+                       tt::CoarseSchedule &schedule, const Stages &stages,
+                       const Clusters &clusters) {
+  auto [copyOp, commitOp, waitOp, maybeLocalLoadOp] = asyncOps;
+  auto [loadStage, loadCluster] = schedule[loadOp];
+  schedule.insert(copyOp, loadStage, loadCluster);
+  // Place ttg.async_commit_group op following AsyncCopyGlobalToLocal so the
+  // later UpdateAsyncWaitCount pass can deduce better waitcnts
+  schedule.insert(commitOp, loadStage, loadCluster);
+  // If the LocalLoads are scheduled to a later stage than AsyncCopy we need to
+  // place the AsyncCopy prefetches after the AsyncWaits which create a barrier
+  // to ensure all warps are finished reading the shared buffer we will write
+  // into. This is done by scheduling AsyncWait as the first cluster.
+  // If AsyncCopy and LocalLoads are in the same stage we do not assign a
+  // schdule so they are placed before the LocalLoads
+  if (loadStage != stages[SCHED_LOCAL_LOAD])
+    schedule.insert(waitOp, stages[SCHED_ASYNC_WAIT],
+                    clusters[SCHED_ASYNC_WAIT]);
+
+  if (maybeLocalLoadOp && stages[SCHED_LOCAL_LOAD] != stages[SCHED_COMPUTE]) {
+    scheduleLocalLoad(maybeLocalLoadOp, schedule, stages[SCHED_LOCAL_LOAD],
+                      clusters[SCHED_LOCAL_LOAD]);
+  }
+}
+
+void scheduleStreamCopy(const StreamCopyChainOps &streamOps,
+                        tt::LoadOp oldLoadOp, tt::CoarseSchedule &schedule,
+                        const Stages &stages, const Clusters &clusters) {
+  auto [newLoadOp, subviewOp, localStoreOp, maybeLocalLoadOp] = streamOps;
+  auto [loadStage, loadCluster] = schedule[oldLoadOp];
+
+  schedule.insert(newLoadOp, loadStage, loadCluster);
+  schedule.insert(subviewOp, stages[SCHED_LOCAL_STORE],
+                  clusters[SCHED_LOCAL_STORE]);
+  schedule.insert(localStoreOp, stages[SCHED_LOCAL_STORE],
+                  clusters[SCHED_LOCAL_STORE]);
+  if (maybeLocalLoadOp && stages[SCHED_LOCAL_LOAD] != stages[SCHED_COMPUTE]) {
+    scheduleLocalLoad(maybeLocalLoadOp, schedule, stages[SCHED_LOCAL_LOAD],
+                      clusters[SCHED_LOCAL_LOAD]);
+  }
+}
+
+void scheduleStreamOps(const LoadToStreamOpMap &loadToStreamOp,
+                       tt::CoarseSchedule &schedule, const Stages &stages,
+                       const Clusters &clusters) {
+  for (auto [l, streamOps] : loadToStreamOp) {
+    auto loadOp = dyn_cast<tt::LoadOp>(l);
+    if (!loadOp)
+      continue;
+
+    if (auto asyncOps = std::get_if<AsyncCopyChainOps>(&streamOps)) {
+      scheduleAsyncCopy(*asyncOps, loadOp, schedule, stages, clusters);
+    } else if (auto sOps = std::get_if<StreamCopyChainOps>(&streamOps)) {
+      scheduleStreamCopy(*sOps, loadOp, schedule, stages, clusters);
+    }
+  }
+}
+
+void updateSchedule(scf::ForOp &forOp, const LoadToInfoMap &loadToInfo,
+                    tt::CoarseSchedule &schedule,
+                    triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                    int numStages, bool useAsyncCopy, bool waitAtTail) {
+  LDBG("SingleDotSchedule::updateSchedule");
+  Stages stages;
+  Clusters clusters;
+
+  int maxDist = 0;
+  for (auto &[l, info] : loadToInfo) {
+    maxDist = std::max(maxDist, info.distToUse);
+  }
+
+  int numBuffers = 1;
+  if (failed(initSchedule(maxDist, stages, numStages, numBuffers, useAsyncCopy,
+                          waitAtTail, clusters, schedule)))
+    return;
+
+  // Convert the loads into shared memory allocations and loads from them.
+  auto loadToStreamOps = createStreamOps(loadToInfo, forOp, numBuffers,
+                                         useAsyncCopy, axisInfoAnalysis);
+
+  scheduleStreamOps(loadToStreamOps, schedule, stages, clusters);
+  dumpSchedule(schedule, "Coarse schedule stream ops:");
+
+  scheduleDependencies(forOp, schedule);
+  dumpSchedule(schedule, "Coarse schedule with dependencies:");
+  ttg::scheduleDistanceOneDependencies(forOp, schedule);
+  dumpSchedule(schedule, "Coarse schedule with dist 1:");
+  tt::CoarseSchedule::Cluster computeCluster = clusters[SCHED_COMPUTE];
+  ttg::scheduleRemainingToLastStage(forOp, schedule, computeCluster);
+  dumpSchedule(schedule, "Final coarse schedule:");
+}
+} // namespace SingleDotSchedule
+
+namespace ChainedDotSchedule {
+using namespace mlir::ChainedDotSchedule;
+
+void scheduleAsyncCopy(const AsyncCopyChainOps &asyncOps, tt::LoadOp loadOp,
+                       tt::CoarseSchedule &schedule,
+                       const ChainedDotClusters &clusters) {
+  auto [loadStage, loadCluster] = schedule[loadOp];
+  auto [copyOp, commitOp, waitOp, maybeLocalLoadOp] = asyncOps;
+
+  schedule.insert(copyOp, loadStage, loadCluster);
+  // Place ttg.async_commit_group op following AsyncCopyGlobalToLocal so the
+  // later UpdateAsyncWaitCount pass can deduce better waitcnts
+  schedule.insert(commitOp, loadStage, loadCluster);
+
+  if (loadStage == STAGE_GLOBAL_LOAD_1) {
+    schedule.insert(waitOp, STAGE_LOCAL_LOAD_1, clusters[CLUSTER_ASYNC_WAIT_1]);
+    if (maybeLocalLoadOp)
+      scheduleLocalLoad(maybeLocalLoadOp, schedule, STAGE_LOCAL_LOAD_1,
+                        clusters[CLUSTER_LOCAL_LOAD_1]);
+  } else {
+    schedule.insert(waitOp, STAGE_LOCAL_LOAD_2, clusters[CLUSTER_ASYNC_WAIT_2]);
+    if (maybeLocalLoadOp)
+      scheduleLocalLoad(maybeLocalLoadOp, schedule, STAGE_LOCAL_LOAD_2,
+                        clusters[CLUSTER_LOCAL_LOAD_2]);
+  }
+}
+
+void scheduleStreamCopy(const StreamCopyChainOps &streamOps, tt::LoadOp loadOp,
+                        tt::CoarseSchedule &schedule,
+                        const ChainedDotClusters &clusters) {
+  auto [loadStage, loadCluster] = schedule[loadOp];
+  auto [copyOp, subviewOp, localStoreOp, maybeLocalLoadOp] = streamOps;
+  schedule.insert(copyOp, loadStage, loadCluster);
+
+  if (loadStage == STAGE_GLOBAL_LOAD_1) {
+    schedule.insert(subviewOp, STAGE_LOCAL_WRITE_1,
+                    clusters[CLUSTER_LOCAL_WRITE_1]);
+    schedule.insert(localStoreOp, STAGE_LOCAL_WRITE_1,
+                    clusters[CLUSTER_LOCAL_WRITE_1]);
+
+    if (maybeLocalLoadOp)
+      schedule.insert(maybeLocalLoadOp, STAGE_LOCAL_LOAD_1,
+                      clusters[CLUSTER_LOCAL_LOAD_1]);
+  } else {
+    schedule.insert(subviewOp, STAGE_LOCAL_WRITE_2,
+                    clusters[CLUSTER_LOCAL_WRITE_2]);
+    schedule.insert(localStoreOp, STAGE_LOCAL_WRITE_2,
+                    clusters[CLUSTER_LOCAL_WRITE_2]);
+    if (maybeLocalLoadOp)
+      schedule.insert(maybeLocalLoadOp, STAGE_LOCAL_LOAD_2,
+                      clusters[CLUSTER_LOCAL_LOAD_2]);
+  }
+
+  if (maybeLocalLoadOp) {
+    if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(
+            *maybeLocalLoadOp->getUsers().begin())) {
+      auto [localLoadStage, localLoadCluster] = schedule[maybeLocalLoadOp];
+      schedule.insert(cvt, localLoadStage, localLoadCluster);
+    }
+  }
+}
+
+void scheduleStreamOps(const LoadToStreamOpMap &loadToStreamOp,
+                       tt::CoarseSchedule &schedule,
+                       const ChainedDotClusters &clusters) {
+  for (auto [l, streamOps] : loadToStreamOp) {
+    auto loadOp = dyn_cast<tt::LoadOp>(l);
+    if (!loadOp)
+      continue;
+
+    if (auto asyncOps = std::get_if<AsyncCopyChainOps>(&streamOps)) {
+      scheduleAsyncCopy(*asyncOps, loadOp, schedule, clusters);
+    } else if (auto sOps = std::get_if<StreamCopyChainOps>(&streamOps)) {
+      scheduleStreamCopy(*sOps, loadOp, schedule, clusters);
+    }
+  }
+}
+
+void updateSchedule(scf::ForOp &forOp, const LoadToInfoMap &loadToInfo,
+                    tt::CoarseSchedule &schedule,
+                    triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                    bool useAsyncCopy) {
+  LDBG("ChainedDotSchedule::updateSchedule");
+  ChainedDotClusters clusters;
+  int cnt = clusters.size() - schedule.clusters.size();
+  for (int i = 0; i < cnt; i++) {
+    schedule.clusters.newAtBack();
+  }
+  auto it = schedule.clusters.begin();
+  for (int i = 0; i < clusters.size(); i++, it++) {
+    clusters[i] = it;
+  }
+
+  // Convert the loads into shared memory allocations and loads from them.
+  // TODO support different numBuffers
+  int numBuffers = useAsyncCopy ? 2 : 1;
+  auto loadToStreamOps = createStreamOps(loadToInfo, forOp, numBuffers,
+                                         useAsyncCopy, axisInfoAnalysis);
+  scheduleStreamOps(loadToStreamOps, schedule, clusters);
+
+  for (auto [l, _] : loadToInfo) {
+    schedule.erase(l);
+    l->erase();
+  }
+
+  scheduleDependencies(forOp, schedule);
+  dumpSchedule(schedule, "Coarse schedule with dependencies:");
+
+  triton::gpu::scheduleDistanceOneDependencies(forOp, schedule);
+  dumpSchedule(schedule, "Coarse schedule with dist 1:");
+
+  tt::CoarseSchedule::Cluster lastCluster = clusters.back();
+  triton::gpu::scheduleRemainingToLastStage(forOp, schedule, lastCluster);
+  dumpSchedule(schedule, "Final coarse schedule:");
+}
+} // namespace ChainedDotSchedule
+
+void lowerLoop(scf::ForOp forOp,
+               triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis,
+               bool useAsyncCopy, bool usePingpong) {
+  tt::CoarseSchedule schedule;
+  if (failed(schedule.deSerialize(forOp, /*normalizeClusterId=*/false))) {
+    return;
+  }
+
+  dumpSchedule(schedule, "[lowerLoops]deserialized schedule:");
+
+  int numStages = schedule.getNumStages();
+
+  // i.e., we can still disable `waitAtTail` by explicitly disabling
+  // pingpong, which is the only use case of this scheduling variant.
+  bool waitAtTail = usePingpong && (numStages == 3) && useAsyncCopy;
+
+  llvm::MapVector<Operation *, std::pair<int, Operation *>> loadOpToIndLevel =
+      getIndirectLevel(axisInfoAnalysis, forOp, numStages);
+
+  LoadToInfoMap loadToInfo;
+  for (const auto &[load, info] : loadOpToIndLevel) {
+    auto [distance, use] = info;
+    if (load->hasAttrOfType<BoolAttr>(AttrBypassLDS)) {
+      load->removeAttr(AttrBypassLDS);
+      loadToInfo[load] = {nullptr, distance, use};
+    } else {
+      LDBG("Deduce shared encoding for: " << *load);
+      auto sharedEncoding =
+          getSharedEncIfAllUsersAreDotEnc(load->getResult(0)).value_or(nullptr);
+      loadToInfo[load] = {sharedEncoding, distance, use};
+      LDBG("Populate loadInfo with shared encoding: " << sharedEncoding);
+    }
+  }
+
+  if (succeeded(mlir::ChainedDotSchedule::checkPreconditions(forOp, numStages,
+                                                             loadToInfo))) {
+    ChainedDotSchedule::updateSchedule(forOp, loadToInfo, schedule,
+                                       axisInfoAnalysis, useAsyncCopy);
+  } else {
+    SingleDotSchedule::updateSchedule(forOp, loadToInfo, schedule,
+                                      axisInfoAnalysis, numStages, useAsyncCopy,
+                                      waitAtTail);
+  }
+
+  dumpSchedule(schedule, "[lowerLoops]updated schedule:");
+
+  schedule.serialize(forOp);
+}
+
+void lowerLoops(ModuleOp moduleOp, bool useAsyncCopy, bool usePingpong) {
+  triton::AMD::ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
+  SmallVector<scf::ForOp> loops;
+  moduleOp->walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+  if (loops.empty())
+    return;
+  for (auto forOp : loops) {
+    lowerLoop(forOp, axisInfoAnalysis, useAsyncCopy, usePingpong);
+  }
+  if (useAsyncCopy) {
+    llvm::SmallSetVector<ttg::AsyncWaitOp, 8> waitOps;
+    moduleOp.walk([&](ttg::AsyncWaitOp waitOp) { waitOps.insert(waitOp); });
+    tt::combineRedundantWaitOps(waitOps);
+  }
+}
+
+} // namespace mlir

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
@@ -112,6 +112,7 @@ struct PipelinePass : impl::TritonAMDGPUPipelineBase<PipelinePass> {
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
+    lowerLoops(moduleOp, useAsyncCopy, usePingpong);
     expandLoops(moduleOp, useAsyncCopy);
 
     tt::removePipeliningAttributes(moduleOp);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/PipelineUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/PipelineUtility.h
@@ -6,6 +6,13 @@
 #include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
 
 namespace mlir {
+
+namespace triton::AMD {
+constexpr char AttrBypassLDS[] = "amdgpu.bypass_lds_load";
+}
+
+void lowerLoops(ModuleOp moduleOp, bool useAsyncCopy, bool usePingpong);
+
 struct LoadInfo {
   // Shared layout is used for loads feeding into dot ops.
   triton::gpu::SwizzledSharedEncodingAttr sharedEncoding = nullptr;
@@ -14,6 +21,10 @@ struct LoadInfo {
   Operation *use = nullptr;
 };
 using LoadToInfoMap = llvm::MapVector<Operation *, LoadInfo>;
+
+llvm::MapVector<Operation *, std::pair<int, Operation *>>
+getIndirectLevel(triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                 scf::ForOp &forOp, int numStages);
 
 namespace SingleDotSchedule {
 // Define categories of scheduling details per Operation types.

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
@@ -16,13 +16,9 @@
 #include <variant>
 
 //===----------------------------------------------------------------------===//
-// This file will create a schedule that will be handed over to the pipeline
-// expander.
-// Software pipeliners are usually separated into two pieces, one that create a
-// modulo schedule and an expander that rewrites the loop and emits a prologue
-// and epilogue. This pass first calls a helper that will pre-process the IR
-// to create stream operations and create a modulo schedule. Then we call the
-// expander to generate the prologue and new loop and epilogue.
+// This file will create a symbolic schedule for global memory access and
+// compute operations. Conditionally some optimizations will take places, e.g.
+// bypassLDS, etc.
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "tritonamdgpu-schedule-loops"
@@ -32,10 +28,59 @@
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 
+using mlir::triton::AMD::AttrBypassLDS;
+
 namespace mlir {
 
 #define GEN_PASS_DEF_TRITONAMDGPUSCHEDULELOOPS
 #include "TritonAMDGPUTransforms/Passes.h.inc"
+
+llvm::MapVector<Operation *, std::pair<int, Operation *>>
+getIndirectLevel(triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                 scf::ForOp &forOp, int numStages) {
+  auto arch = getAMDArch(forOp->getParentOfType<ModuleOp>());
+  triton::AMD::ISAFamily isaFamily = triton::AMD::ISAFamily::Unknown;
+  if (arch)
+    isaFamily = triton::AMD::deduceISAFamily(*arch);
+
+  bool pipelineWithoutDot = forOp->hasAttr(mlir::triton::kNumStagesAttrName);
+  bool filterSmallVectors =
+      isaFamily != triton::AMD::ISAFamily::CDNA4 && !isRDNA(isaFamily);
+  llvm::MapVector<Operation *, std::pair<int, Operation *>> loadOpToIndLevel =
+      triton::gpu::loadOpsToIndirectionLevel(forOp, pipelineWithoutDot,
+                                             axisInfoAnalysis, numStages,
+                                             filterSmallVectors);
+
+  return loadOpToIndLevel;
+}
+
+LogicalResult
+mlir::ChainedDotSchedule::checkPreconditions(scf::ForOp forOp, int numStages,
+                                             LoadToInfoMap loadToInfo) {
+  if (numStages != 4)
+    return failure();
+
+  auto dotOps = llvm::to_vector(forOp.getBody()->getOps<tt::DotOp>());
+
+  if (dotOps.size() != 2)
+    return failure();
+
+  // Check that the first dot feeds into the second
+  SetVector<Operation *> slice;
+  getForwardSlice(dotOps[0]->getResult(0), &slice);
+  if (!slice.contains(dotOps[1])) {
+    return failure();
+  }
+
+  // Reject loops with indirect loads
+  // TODO support indirect loads
+  if (llvm::any_of(loadToInfo,
+                   [](auto it) { return it.second.distToUse != 0; })) {
+    return failure();
+  }
+
+  return success();
+}
 
 namespace {
 //===----------------------------------------------------------------------===//
@@ -79,308 +124,6 @@ namespace {
 //       bounds may be shorter than num_stages. In this case, the epilogue
 //       iterations must align with the prologue.
 //
-
-struct StreamCopyChainOps {
-  tt::LoadOp loadOp;
-  ttg::MemDescIndexOp subviewOp;
-  ttg::LocalStoreOp localStoreOp;
-  ttg::LocalLoadOp maybeLocalLoadOp;
-};
-
-struct AsyncCopyChainOps {
-  ttg::AsyncCopyGlobalToLocalOp copyOp;
-  ttg::AsyncCommitGroupOp commitOp;
-  ttg::AsyncWaitOp waitOp;
-  ttg::LocalLoadOp maybeLocalLoadOp;
-};
-
-using StreamOpVariant = std::variant<StreamCopyChainOps, AsyncCopyChainOps>;
-using LoadToStreamOpMap = llvm::MapVector<Operation *, StreamOpVariant>;
-
-AsyncCopyChainOps createAsyncCopy(tt::LoadOp loadOp, Value alloc,
-                                  Value extractIdx) {
-  OpBuilder builder(loadOp);
-  Location loc = loadOp.getLoc();
-
-  // Extract local subview from shared allocation
-  auto viewLoad = triton::createSingleBufferView(builder, alloc, extractIdx)
-                      .getDefiningOp<ttg::MemDescIndexOp>();
-
-  auto copyOp = builder.create<ttg::AsyncCopyGlobalToLocalOp>(
-      loc, loadOp.getPtr(), viewLoad, loadOp.getMask(), loadOp.getOther(),
-      loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
-  auto commitOp =
-      builder.create<ttg::AsyncCommitGroupOp>(loc, copyOp->getResult(0));
-  ttg::AsyncWaitOp waitOp =
-      builder.create<ttg::AsyncWaitOp>(loc, commitOp->getResult(0), 0);
-
-  auto maybeSharedLoad = tt::replaceUsesWithLocalLoad(
-      builder, loadOp->getResult(0), viewLoad, waitOp);
-
-  return {copyOp, commitOp, waitOp, maybeSharedLoad};
-}
-
-void scheduleLocalLoad(ttg::LocalLoadOp localLoadOp,
-                       tt::CoarseSchedule &schedule, int stage,
-                       const tt::CoarseSchedule::Cluster &cluster) {
-  schedule.insert(localLoadOp, stage, cluster);
-  // If its only user is a ConvertLayout, we place it into the same stage so
-  // it can be folded by a later pass
-  if (localLoadOp->hasOneUse()) {
-    auto cvt = *localLoadOp->getUsers().begin();
-    if (isa<ttg::ConvertLayoutOp>(cvt)) {
-      schedule.insert(cvt, stage, cluster);
-    }
-  }
-}
-
-StreamCopyChainOps createStreamCopy(tt::LoadOp loadOp, Value alloc,
-                                    Value extractIdx) {
-  OpBuilder builder(loadOp);
-  Location loc = loadOp.getLoc();
-
-  // Extract local subview from shared allocation
-  auto viewLoad = triton::createSingleBufferView(builder, alloc, extractIdx)
-                      .getDefiningOp<ttg::MemDescIndexOp>();
-
-  tt::LoadOp newLoadOp = cast<tt::LoadOp>(builder.clone(*loadOp));
-  auto storeOp = builder.create<ttg::LocalStoreOp>(loc, newLoadOp, viewLoad);
-  auto maybeLocalLoad =
-      tt::replaceUsesWithLocalLoad(builder, loadOp->getResult(0), viewLoad);
-
-  return {newLoadOp, viewLoad, storeOp, maybeLocalLoad};
-}
-
-// Returns the given |inputValue|'s dot user result encoding and updates |opIdx|
-// and |vecSize| with which dot operand |inputValue| is fed into if possible.
-ttg::AMDMfmaEncodingAttr getDotEncoding(Value inputValue, unsigned *opIdx,
-                                        unsigned *vecSize) {
-  if (!inputValue.hasOneUse())
-    return nullptr;
-
-  Operation *user = *inputValue.getUsers().begin();
-  if (user->getNumResults() != 1 ||
-      user->getBlock() != inputValue.getParentBlock())
-    return nullptr;
-
-  LDBG("getDotEncoding user: " << *user);
-  if (auto dotOp = dyn_cast<tt::DotOpInterface>(user)) {
-    OpOperand &use = *inputValue.getUses().begin();
-    *opIdx = use.getOperandNumber();
-    auto operandType = cast<RankedTensorType>(inputValue.getType());
-    *vecSize = ttg::toLinearLayout(operandType).getNumConsecutiveInOut();
-    auto dotType = cast<RankedTensorType>(dotOp->getResult(0).getType());
-    return dyn_cast<ttg::AMDMfmaEncodingAttr>(dotType.getEncoding());
-  }
-
-  return getDotEncoding(user->getResult(0), opIdx, vecSize);
-}
-
-// Adapted from
-// lib/Dialect/TritonGPU/Transforms/Utility.cpp::getSharedEncIfAllUsersAreDotEnc
-// to support AMDMfmaEncodingAttr.
-// TODO(max): figure out how to refactor to use upstream
-//
-// If all the transitive uses of the given value have are used by a convert to
-// the same dot operand encoding, return true and get the shared encoding that
-// needs to be used to be compatible with users' layouts.
-std::optional<ttg::SwizzledSharedEncodingAttr>
-getSharedEncIfAllUsersAreDotEnc(Value loadedValue) {
-  llvm::SmallVector<ttg::SwizzledSharedEncodingAttr> sharedEncs;
-  for (Operation *user : loadedValue.getUsers()) {
-    LDBG(" getSharedEncIfAllUsersAreDotEnc current user: " << *user);
-    if (user->getNumResults() != 1)
-      return std::nullopt;
-
-    ttg::SwizzledSharedEncodingAttr tempAttr;
-    Value userResult = user->getResult(0);
-    Type userResType = userResult.getType();
-    if (auto memDesc = dyn_cast<ttg::MemDescType>(userResType)) {
-      // First time we find a shared encoding in the chain, save it and try to
-      // use it if it is compatible with the other users.
-      tempAttr = cast<ttg::SwizzledSharedEncodingAttr>(memDesc.getEncoding());
-      // If the immediate user is ttg::LocalAllocOp, likely it's created in
-      // TritonAMDGPUOptimizeDotOperands. We should just respect it.
-      if (!getSharedEncIfAllUsersAreDotEnc(userResult).has_value() &&
-          !isa<ttg::LocalAllocOp>(user)) {
-        return std::nullopt;
-      }
-      LDBG("Deduced shared encoding candidate from memDesc: " << tempAttr);
-      sharedEncs.push_back(tempAttr);
-    } else {
-      if (!(isa<ttg::ConvertLayoutOp>(user) ||
-            user->hasTrait<OpTrait::LocalLoadTrait>()))
-        return std::nullopt;
-
-      auto srcTy = cast<ttg::TensorOrMemDesc>(loadedValue.getType());
-      auto ctaLayout = ttg::getCTALayout(srcTy.getEncoding());
-      auto order = getOrderForMemory(srcTy);
-      unsigned bitWidth = srcTy.getElementType().getIntOrFloatBitWidth();
-      SmallVector<unsigned> sharedOrder;
-      int rank = order.size();
-      // TODO rework this when shared -> dotOperand conversions support
-      // arbitrary shared memory ordering
-      if (rank == 3) {
-        // Move the batch dimension (dim #0) to be the last so that it will be
-        // the slowest varying dimension.
-        for (unsigned i = 0; i < rank; ++i)
-          if (order[i] != 0)
-            sharedOrder.emplace_back(order[i]);
-        sharedOrder.emplace_back(0);
-      } else {
-        sharedOrder = order;
-      }
-
-      auto userResEnc = cast<ttg::TensorOrMemDesc>(userResType).getEncoding();
-      if (auto dotOpEnc = dyn_cast<ttg::DotOperandEncodingAttr>(userResEnc)) {
-        tempAttr = ttg::SwizzledSharedEncodingAttr::get(
-            loadedValue.getContext(), dotOpEnc, srcTy.getShape(), sharedOrder,
-            ctaLayout, bitWidth, /*needTrans=*/false);
-        LDBG("Deduced shared encoding candidate from dot layout: " << tempAttr);
-        sharedEncs.push_back(tempAttr);
-      } else if (auto llEnc = dyn_cast<ttg::LinearEncodingAttr>(userResEnc)) {
-        // We use linear layout directly for scaled dot fp8 operands. For such
-        // cases, we need to look further down the def-use chain to find the dot
-        // op for the mfma layout to deduce operand index and other information.
-        unsigned opIdx;
-        unsigned vecSize;
-        if (auto mfmaEnc = getDotEncoding(userResult, &opIdx, &vecSize)) {
-          LDBG("deduced opIdx: " << opIdx << "; deduced vecSize: " << vecSize);
-          tempAttr = mfmaEnc.composeSharedLayoutForOperand(
-              ctaLayout, opIdx, srcTy.getShape(), order, vecSize, bitWidth,
-              /*needTrans=*/false);
-          LDBG("Deduced shared encoding candidate from mfma layout: "
-               << tempAttr);
-          sharedEncs.push_back(tempAttr);
-        }
-      }
-    }
-  }
-
-  auto equalSharedEncIgnoreVec = [](ttg::SwizzledSharedEncodingAttr a,
-                                    ttg::SwizzledSharedEncodingAttr b) {
-    if (!a || !b)
-      return false;
-    return (a.getPerPhase() == b.getPerPhase() &&
-            a.getMaxPhase() == b.getMaxPhase() &&
-            a.getOrder() == b.getOrder() &&
-            a.getCTALayout() == b.getCTALayout());
-  };
-  if (sharedEncs.empty() || !sharedEncs.front())
-    return std::nullopt;
-  auto maxVecSharedEnc = sharedEncs.front();
-
-  for (auto sharedEnc : sharedEncs) {
-    if (!equalSharedEncIgnoreVec(sharedEnc, maxVecSharedEnc)) {
-      LDBG("Incompatible shared encodings");
-      return std::nullopt;
-    }
-    if (sharedEnc.getVec() > maxVecSharedEnc.getVec()) {
-      maxVecSharedEnc = sharedEnc;
-    }
-  }
-
-  LDBG("Deduced shared encoding: " << maxVecSharedEnc);
-
-  return maxVecSharedEnc;
-}
-
-bool canBeConvertedToAsyncLoad(unsigned numBuffers, tt::LoadOp loadOp,
-                               Value alloc,
-                               tt::ModuleAxisInfoAnalysis &axisInfoAnalysis,
-                               const tt::AMD::TargetInfo &targetInfo) {
-  // If we have a single buffer we would require another barrier after the
-  // local_reads so instead we fall back to pipeline with registers
-  // Removing this check will create incorrect IR, see
-  // MembarUtility.h:membarFilter
-  if (numBuffers <= 1)
-    return false;
-
-  // Compute the final vecSize we can use for the combination of sourceEncoding
-  // and sharedEncoding. We can only use AsyncCopy if the target supports the
-  // requested or a smaller vecSize because we cannot stride when loading
-  // directly to lds
-  auto srcTy = cast<RankedTensorType>(loadOp.getPtr().getType());
-  auto dstTy = cast<ttg::MemDescType>(alloc.getType());
-  auto regLayout = triton::gpu::toLinearLayout(srcTy);
-  // It's the allocation so we trim the multibuffer dimension
-  auto srcShape = dstTy.getShape().take_back(srcTy.getRank());
-  auto sharedLayout =
-      triton::gpu::toLinearLayout(srcShape, dstTy.getEncoding());
-  auto regToSharedLayout = regLayout.invertAndCompose(sharedLayout);
-
-  unsigned vecSize = regToSharedLayout.getNumConsecutiveInOut();
-  unsigned elemBitWidth = dstTy.getElementTypeBitWidth();
-
-  if (fitToValidDirectToLdsVecSize(vecSize, elemBitWidth, targetInfo) == 0)
-    return false;
-
-  // Checks whether the global pointer's contiguity and mask alignment allows
-  // for at least 32 bit wide loads
-  return triton::canBeConvertedToAsyncLoad(loadOp, axisInfoAnalysis);
-}
-
-// Convert load ops into shared memory allocation loads and apply
-// multi-buffering based on the required number of buffers.
-LoadToStreamOpMap
-createStreamOps(const LoadToInfoMap &loadToInfo, scf::ForOp &forOp,
-                const int &numBuffers, bool useAsyncCopy,
-                tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
-  IRRewriter builder(forOp);
-  Location loc = forOp.getLoc();
-  Value minusOne = builder.create<arith::ConstantIntOp>(loc, -1, 32);
-  Value zero = builder.create<arith::ConstantIntOp>(loc, 0, 32);
-  Value one = builder.create<arith::ConstantIntOp>(loc, 1, 32);
-  Value extractIdx = minusOne;
-  Value numBuffersVal =
-      builder.create<arith::ConstantIntOp>(loc, numBuffers, 32);
-
-  unsigned newOperandIndex = forOp.getBody()->getNumArguments();
-  // Patch the loop to add the new loop carried dependency.
-  forOp = addIterArgsToLoop(builder, forOp, {extractIdx});
-
-  // Create one counter for the extract indices to avoid creating long
-  // live range.
-  extractIdx = forOp.getBody()->getArgument(newOperandIndex);
-
-  builder.setInsertionPoint(forOp.getBody(), forOp.getBody()->begin());
-  extractIdx = builder.create<arith::AddIOp>(loc, extractIdx, one);
-  Value cndExt = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,
-                                               extractIdx, numBuffersVal);
-  extractIdx = builder.create<arith::SelectOp>(loc, cndExt, extractIdx, zero);
-
-  // Patch the yield with the updated counter.
-  appendToForOpYield(forOp, {extractIdx});
-
-  LoadToStreamOpMap loadToStreamOp;
-  for (auto &[l, info] : loadToInfo) {
-    if (!info.sharedEncoding)
-      continue;
-
-    auto loadOp = dyn_cast<tt::LoadOp>(l);
-    if (!loadOp)
-      continue;
-
-    // Create an allocation that can hold distance number of loadOp shapes.
-    auto ty = cast<RankedTensorType>(loadOp->getResultTypes()[0]);
-    Value alloc = triton::createAlloc(forOp, ty, loadOp->getLoc(),
-                                      info.sharedEncoding, numBuffers);
-    assert(alloc && "Failed to create alloc for the async load.");
-    auto arch = getAMDArch(loadOp->getParentOfType<ModuleOp>());
-    triton::AMD::TargetInfo targetInfo(arch ? arch->str() : "");
-
-    // Replace the old load with multi-buffered loads
-    if (useAsyncCopy &&
-        canBeConvertedToAsyncLoad(numBuffers, loadOp, alloc, axisInfoAnalysis,
-                                  targetInfo)) {
-      loadToStreamOp[loadOp] = createAsyncCopy(loadOp, alloc, extractIdx);
-    } else {
-      loadToStreamOp[loadOp] = createStreamCopy(loadOp, alloc, extractIdx);
-    }
-  }
-
-  return loadToStreamOp;
-}
 
 /// Returns true if for a given global load with loadType, loading instead with
 /// targetLLAttr maintains at least the same level of coalescing/vectorization
@@ -549,204 +292,12 @@ static Operation *bypassLDS(Operation *load, Operation *use) {
 
   // Finally, rewrite the load to use the inferred (better) encoding.
   auto newOp = convertDistributedOpEncoding(srcEnc, load);
+  newOp->setAttr(AttrBypassLDS, BoolAttr::get(load->getContext(), true));
   return newOp;
 };
 
-LoadToInfoMap
-preprocessLoop(triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis,
-               scf::ForOp &forOp, int numStages) {
-  auto arch = getAMDArch(forOp->getParentOfType<ModuleOp>());
-  triton::AMD::ISAFamily isaFamily = triton::AMD::ISAFamily::Unknown;
-  if (arch)
-    isaFamily = triton::AMD::deduceISAFamily(*arch);
-
-  bool pipelineWithoutDot = forOp->hasAttr(mlir::triton::kNumStagesAttrName);
-  bool filterSmallVectors =
-      isaFamily != triton::AMD::ISAFamily::CDNA4 && !isRDNA(isaFamily);
-  llvm::MapVector<Operation *, std::pair<int, Operation *>> loadOpToIndLevel =
-      triton::gpu::loadOpsToIndirectionLevel(forOp, pipelineWithoutDot,
-                                             axisInfoAnalysis, numStages,
-                                             filterSmallVectors);
-
-  LLVM_DEBUG({
-    LDBG("Found " << loadOpToIndLevel.size() << " loads to pipeline:");
-    for (const auto &[l, i] : loadOpToIndLevel) {
-      LDBG("  - load: " << *l);
-      LDBG("    at distance: " << i.first);
-      LDBG("    used by op: " << *i.second);
-    }
-  });
-
-  LoadToInfoMap loadToInfo;
-  for (const auto &[load, info] : loadOpToIndLevel) {
-    auto [distance, use] = info;
-    auto newLoad = bypassLDS(load, use);
-    if (newLoad) {
-      loadToInfo[newLoad] = {nullptr, distance, use};
-    } else {
-      LDBG("Deduce shared encoding for: " << *load);
-      auto sharedEncoding =
-          getSharedEncIfAllUsersAreDotEnc(load->getResult(0)).value_or(nullptr);
-      loadToInfo[load] = {sharedEncoding, distance, use};
-      LDBG("Populate loadInfo with shared encoding: " << sharedEncoding);
-    }
-  }
-
-  return loadToInfo;
-}
-
 namespace SingleDotSchedule {
 using namespace mlir::SingleDotSchedule;
-
-// Init Schedule Config based on settings and loop characteristics.
-// Create clusters in order of ops in loop. This can interleave ops
-// from different stages in the same cluster to achieve better backend
-// scheduling.
-//   WARNING: Changing the order of schedule.clusters.newAtBack() calls
-//            can cause invalid schedules to be produced.
-LogicalResult initSchedule(int maxDist, Stages &stages, int numStages,
-                           int &numBuffers, bool useAsyncCopy, bool waitAtTail,
-                           Clusters &clusters, tt::CoarseSchedule &schedule) {
-  LDBG("Init SingleDotSchedule");
-  int lastStage = numStages - 1;
-  stages[SCHED_GLOBAL_LOAD] = 0;
-  stages[SCHED_LOCAL_STORE] = 0;
-  stages[SCHED_LOCAL_LOAD] = lastStage;
-  stages[SCHED_COMPUTE] = lastStage;
-  stages[SCHED_ASYNC_WAIT] = stages[SCHED_LOCAL_LOAD];
-
-  bool pairedGlobalLoadLocalStore = stages[SCHED_LOCAL_STORE] == 0;
-  stages[SCHED_LOCAL_STORE] += maxDist;
-  if (waitAtTail) {
-    stages[SCHED_ASYNC_WAIT] = std::max(0, stages[SCHED_LOCAL_LOAD] - 1);
-  }
-
-  LDBG(
-      "Stage schedule:" << "  GLOBAL_LOAD stage = " << stages[SCHED_GLOBAL_LOAD]
-                        << ", LOCAL_STORE stage = " << stages[SCHED_LOCAL_STORE]
-                        << ", LOCAL_LOAD stage = " << stages[SCHED_LOCAL_LOAD]
-                        << ", COMPUTE stage = " << stages[SCHED_COMPUTE]
-                        << ", ASYNC_WAIT stage = " << stages[SCHED_ASYNC_WAIT]
-                        << "; total = " << numStages);
-
-  if (stages[SCHED_LOCAL_STORE] >= numStages ||
-      stages[SCHED_LOCAL_STORE] > stages[SCHED_LOCAL_LOAD]) {
-    LDBG("Invalid stage schedule");
-    return failure();
-  }
-
-  // Calculate the number of buffers needed for each load.
-  // TODO: Use the precise number of buffers needed by the particular load.
-  numBuffers =
-      std::max(1, stages[SCHED_LOCAL_LOAD] - stages[SCHED_LOCAL_STORE]);
-  // If we use AsyncCopy we need one more buffer since we are not using a
-  // register buffer
-  if (useAsyncCopy) {
-    numBuffers += 1;
-  }
-
-  LDBG("deduced max shared memory buffer number = " << numBuffers);
-
-  // We place async wait as the first cluster because we want to have it being
-  // the first in the main loop after pipelining.
-  // In case we use async_copy with pingpong, we need to place async_wait at
-  // the end of the previous iteration, so it can guarantee the correct
-  // dependency when warp0 and warp1 are pipelined.
-  int asyncWaitCluster = waitAtTail ? 4 : 0;
-  // If tt.load and ttg.local_store are in the same stage
-  //   spread them apart to allow overlap with compute
-  // else
-  //   Initiate ttg.local_store before tt.load
-  int globalLoadCluster = 1;
-  int localStoreCluster = 3;
-  if (!pairedGlobalLoadLocalStore) {
-    globalLoadCluster = 3;
-    localStoreCluster = 2;
-  }
-
-  // If ttg.local_load and ttg.local_store are in the same stage
-  //   spread them apart to allow overlap with compute
-  // else if they share the buffer
-  //   ttg.local_load must come first
-  // else
-  //   schedule ttg.local_load in the middle
-  int localLoadCluster = globalLoadCluster;
-  if (stages[SCHED_LOCAL_LOAD] == stages[SCHED_LOCAL_STORE]) {
-    localLoadCluster = std::max(3, localStoreCluster + 1);
-  } else if (numBuffers == 1 && localLoadCluster >= localStoreCluster) {
-    // For 1 buffer, ttg.local_load must occur before ttg.local_store
-    localLoadCluster = localStoreCluster - 1;
-  }
-
-  // Schedule compute with ttg.local_load if paired
-  // otherwise, schedule in the middle
-  int computeCluster = 2;
-  if (stages[SCHED_LOCAL_LOAD] == stages[SCHED_COMPUTE]) {
-    computeCluster = localLoadCluster;
-  }
-
-  // Make assignments
-  Clusters clusterVec;
-  std::generate(clusterVec.begin(), clusterVec.end(),
-                [&]() { return schedule.clusters.newAtBack(); });
-
-  clusters[SCHED_GLOBAL_LOAD] = clusterVec[globalLoadCluster];
-  clusters[SCHED_LOCAL_STORE] = clusterVec[localStoreCluster];
-  clusters[SCHED_LOCAL_LOAD] = clusterVec[localLoadCluster];
-  clusters[SCHED_COMPUTE] = clusterVec[computeCluster];
-  clusters[SCHED_ASYNC_WAIT] = clusterVec[asyncWaitCluster];
-
-  LDBG("Cluster schedule:" << "  GLOBAL_LOAD cluster = " << globalLoadCluster
-                           << ", LOCAL_STORE cluster = " << localStoreCluster
-                           << ", LOCAL_LOAD cluster = " << localLoadCluster
-                           << ", COMPUTE cluster = " << computeCluster
-                           << ", ASYNC_WAIT cluster = " << asyncWaitCluster
-                           << "; total = " << SCHED_SIZE);
-
-  return success();
-}
-
-void scheduleAsyncCopy(const AsyncCopyChainOps &asyncOps, tt::LoadOp loadOp,
-                       tt::CoarseSchedule &schedule, const Stages &stages,
-                       const Clusters &clusters) {
-  auto [copyOp, commitOp, waitOp, maybeLocalLoadOp] = asyncOps;
-  auto [loadStage, loadCluster] = schedule[loadOp];
-  schedule.insert(copyOp, loadStage, loadCluster);
-  // Place ttg.async_commit_group op following AsyncCopyGlobalToLocal so the
-  // later UpdateAsyncWaitCount pass can deduce better waitcnts
-  schedule.insert(commitOp, loadStage, loadCluster);
-  // If the LocalLoads are scheduled to a later stage than AsyncCopy we need to
-  // place the AsyncCopy prefetches after the AsyncWaits which create a barrier
-  // to ensure all warps are finished reading the shared buffer we will write
-  // into. This is done by scheduling AsyncWait as the first cluster.
-  // If AsyncCopy and LocalLoads are in the same stage we do not assign a
-  // schdule so they are placed before the LocalLoads
-  if (loadStage != stages[SCHED_LOCAL_LOAD])
-    schedule.insert(waitOp, stages[SCHED_ASYNC_WAIT],
-                    clusters[SCHED_ASYNC_WAIT]);
-
-  if (maybeLocalLoadOp && stages[SCHED_LOCAL_LOAD] != stages[SCHED_COMPUTE]) {
-    scheduleLocalLoad(maybeLocalLoadOp, schedule, stages[SCHED_LOCAL_LOAD],
-                      clusters[SCHED_LOCAL_LOAD]);
-  }
-}
-
-void scheduleStreamCopy(const StreamCopyChainOps &streamOps,
-                        tt::LoadOp oldLoadOp, tt::CoarseSchedule &schedule,
-                        const Stages &stages, const Clusters &clusters) {
-  auto [newLoadOp, subviewOp, localStoreOp, maybeLocalLoadOp] = streamOps;
-  auto [loadStage, loadCluster] = schedule[oldLoadOp];
-
-  schedule.insert(newLoadOp, loadStage, loadCluster);
-  schedule.insert(subviewOp, stages[SCHED_LOCAL_STORE],
-                  clusters[SCHED_LOCAL_STORE]);
-  schedule.insert(localStoreOp, stages[SCHED_LOCAL_STORE],
-                  clusters[SCHED_LOCAL_STORE]);
-  if (maybeLocalLoadOp && stages[SCHED_LOCAL_LOAD] != stages[SCHED_COMPUTE]) {
-    scheduleLocalLoad(maybeLocalLoadOp, schedule, stages[SCHED_LOCAL_LOAD],
-                      clusters[SCHED_LOCAL_LOAD]);
-  }
-}
 
 LogicalResult scheduleLoads(const LoadToInfoMap &loadToInfo, int maxDist,
                             int numStages, const Stages &stages,
@@ -775,25 +326,30 @@ LogicalResult scheduleLoads(const LoadToInfoMap &loadToInfo, int maxDist,
   return success();
 }
 
-void scheduleStreamOps(const LoadToStreamOpMap &loadToStreamOp,
-                       tt::CoarseSchedule &schedule, const Stages &stages,
-                       const Clusters &clusters) {
-  for (auto [l, streamOps] : loadToStreamOp) {
-    auto loadOp = dyn_cast<tt::LoadOp>(l);
-    if (!loadOp)
-      continue;
+void initSymbolicSchedule(int maxDist, Stages &stages, int numStages,
+                          Clusters &clusters, tt::CoarseSchedule &schedule) {
+  int lastStage = numStages - 1;
+  stages[SCHED_GLOBAL_LOAD] = 0;
+  stages[SCHED_LOCAL_STORE] = maxDist;
+  stages[SCHED_LOCAL_LOAD] = lastStage;
+  stages[SCHED_COMPUTE] = lastStage;
+  stages[SCHED_ASYNC_WAIT] = stages[SCHED_LOCAL_LOAD];
 
-    if (auto asyncOps = std::get_if<AsyncCopyChainOps>(&streamOps)) {
-      scheduleAsyncCopy(*asyncOps, loadOp, schedule, stages, clusters);
-    } else if (auto sOps = std::get_if<StreamCopyChainOps>(&streamOps)) {
-      scheduleStreamCopy(*sOps, loadOp, schedule, stages, clusters);
-    }
-  }
+  Clusters clusterVec;
+  std::generate(clusterVec.begin(), clusterVec.end(),
+                [&]() { return schedule.clusters.newAtBack(); });
+
+  // This is a symbolic cluster assignment. In this stage, we only focus on
+  // global load and compute ops.
+  int globalLoadCluster = 0;
+  int computeCluster = 1;
+
+  clusters[SCHED_GLOBAL_LOAD] = clusterVec[globalLoadCluster];
+  clusters[SCHED_COMPUTE] = clusterVec[computeCluster];
 }
 
 tt::CoarseSchedule
 buildSchedule(scf::ForOp &forOp, int numStages, const LoadToInfoMap &loadToInfo,
-              bool useAsyncCopy, bool waitAtTail,
               triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
   LDBG("Build SingleDotSchedule");
   tt::CoarseSchedule schedule(numStages);
@@ -814,30 +370,12 @@ buildSchedule(scf::ForOp &forOp, int numStages, const LoadToInfoMap &loadToInfo,
   }
 
   int numBuffers = 1;
-  if (failed(initSchedule(maxDist, stages, numStages, numBuffers, useAsyncCopy,
-                          waitAtTail, clusters, schedule)))
-    return {};
+  initSymbolicSchedule(maxDist, stages, numStages, clusters, schedule);
 
   if (failed(scheduleLoads(loadToInfo, maxDist, numStages, stages, clusters,
                            schedule)))
     return {};
   dumpSchedule("Coarse schedule loads only:");
-
-  // Convert the loads into shared memory allocations and loads from them.
-  auto loadToStreamOp = createStreamOps(loadToInfo, forOp, numBuffers,
-                                        useAsyncCopy, axisInfoAnalysis);
-  scheduleStreamOps(loadToStreamOp, schedule, stages, clusters);
-  dumpSchedule("Coarse schedule stream ops:");
-
-  scheduleDependencies(forOp, schedule);
-  dumpSchedule("Coarse schedule with dependencies:");
-
-  triton::gpu::scheduleDistanceOneDependencies(forOp, schedule);
-  dumpSchedule("Coarse schedule with dist 1:");
-
-  tt::CoarseSchedule::Cluster computeCluster = clusters[SCHED_COMPUTE];
-  triton::gpu::scheduleRemainingToLastStage(forOp, schedule, computeCluster);
-  dumpSchedule("Final coarse schedule:");
 
   return schedule;
 }
@@ -855,34 +393,6 @@ buildSchedule(scf::ForOp &forOp, int numStages, const LoadToInfoMap &loadToInfo,
 // pipeliner is meant to be used in combination with pingpong
 namespace ChainedDotSchedule {
 using namespace mlir::ChainedDotSchedule;
-
-LogicalResult checkPreconditions(scf::ForOp forOp, int numStages,
-                                 LoadToInfoMap loadToInfo) {
-  if (numStages != 4)
-    return failure();
-
-  auto dotOps = llvm::to_vector(forOp.getBody()->getOps<tt::DotOp>());
-
-  if (dotOps.size() != 2)
-    return failure();
-
-  // Check that the first dot feeds into the second
-  SetVector<Operation *> slice;
-  getForwardSlice(dotOps[0]->getResult(0), &slice);
-  if (!slice.contains(dotOps[1])) {
-    return failure();
-  }
-
-  // Reject loops with indirect loads
-  // TODO support indirect loads
-  if (llvm::any_of(loadToInfo,
-                   [](auto it) { return it.second.distToUse != 0; })) {
-    return failure();
-  }
-
-  return success();
-}
-
 // We schedule loads one stage in front of their dots
 LogicalResult
 scheduleLoads(std::array<tt::DotOp, 2> dotOps,
@@ -968,84 +478,8 @@ LogicalResult scheduleOpsBetweenDots(scf::ForOp forOp,
   return success();
 }
 
-void scheduleAsyncCopy(const AsyncCopyChainOps &asyncOps, tt::LoadOp loadOp,
-                       tt::CoarseSchedule &schedule,
-                       const ChainedDotClusters &clusters) {
-  auto [loadStage, loadCluster] = schedule[loadOp];
-  auto [copyOp, commitOp, waitOp, maybeLocalLoadOp] = asyncOps;
-
-  schedule.insert(copyOp, loadStage, loadCluster);
-  // Place ttg.async_commit_group op following AsyncCopyGlobalToLocal so the
-  // later UpdateAsyncWaitCount pass can deduce better waitcnts
-  schedule.insert(commitOp, loadStage, loadCluster);
-
-  if (loadStage == STAGE_GLOBAL_LOAD_1) {
-    schedule.insert(waitOp, STAGE_LOCAL_LOAD_1, clusters[CLUSTER_ASYNC_WAIT_1]);
-    if (maybeLocalLoadOp)
-      scheduleLocalLoad(maybeLocalLoadOp, schedule, STAGE_LOCAL_LOAD_1,
-                        clusters[CLUSTER_LOCAL_LOAD_1]);
-  } else {
-    schedule.insert(waitOp, STAGE_LOCAL_LOAD_2, clusters[CLUSTER_ASYNC_WAIT_2]);
-    if (maybeLocalLoadOp)
-      scheduleLocalLoad(maybeLocalLoadOp, schedule, STAGE_LOCAL_LOAD_2,
-                        clusters[CLUSTER_LOCAL_LOAD_2]);
-  }
-}
-
-void scheduleStreamCopy(const StreamCopyChainOps &streamOps, tt::LoadOp loadOp,
-                        tt::CoarseSchedule &schedule,
-                        const ChainedDotClusters &clusters) {
-  auto [loadStage, loadCluster] = schedule[loadOp];
-  auto [copyOp, subviewOp, localStoreOp, maybeLocalLoadOp] = streamOps;
-  schedule.insert(copyOp, loadStage, loadCluster);
-
-  if (loadStage == STAGE_GLOBAL_LOAD_1) {
-    schedule.insert(subviewOp, STAGE_LOCAL_WRITE_1,
-                    clusters[CLUSTER_LOCAL_WRITE_1]);
-    schedule.insert(localStoreOp, STAGE_LOCAL_WRITE_1,
-                    clusters[CLUSTER_LOCAL_WRITE_1]);
-
-    if (maybeLocalLoadOp)
-      schedule.insert(maybeLocalLoadOp, STAGE_LOCAL_LOAD_1,
-                      clusters[CLUSTER_LOCAL_LOAD_1]);
-  } else {
-    schedule.insert(subviewOp, STAGE_LOCAL_WRITE_2,
-                    clusters[CLUSTER_LOCAL_WRITE_2]);
-    schedule.insert(localStoreOp, STAGE_LOCAL_WRITE_2,
-                    clusters[CLUSTER_LOCAL_WRITE_2]);
-    if (maybeLocalLoadOp)
-      schedule.insert(maybeLocalLoadOp, STAGE_LOCAL_LOAD_2,
-                      clusters[CLUSTER_LOCAL_LOAD_2]);
-  }
-
-  if (maybeLocalLoadOp) {
-    if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(
-            *maybeLocalLoadOp->getUsers().begin())) {
-      auto [localLoadStage, localLoadCluster] = schedule[maybeLocalLoadOp];
-      schedule.insert(cvt, localLoadStage, localLoadCluster);
-    }
-  }
-}
-
-void scheduleStreamOps(const LoadToStreamOpMap &loadToStreamOp,
-                       tt::CoarseSchedule &schedule,
-                       const ChainedDotClusters &clusters) {
-  for (auto [l, streamOps] : loadToStreamOp) {
-    auto loadOp = dyn_cast<tt::LoadOp>(l);
-    if (!loadOp)
-      continue;
-
-    if (auto asyncOps = std::get_if<AsyncCopyChainOps>(&streamOps)) {
-      scheduleAsyncCopy(*asyncOps, loadOp, schedule, clusters);
-    } else if (auto sOps = std::get_if<StreamCopyChainOps>(&streamOps)) {
-      scheduleStreamCopy(*sOps, loadOp, schedule, clusters);
-    }
-  }
-}
-
 tt::CoarseSchedule
 buildSchedule(scf::ForOp &forOp, int numStages, const LoadToInfoMap &loadToInfo,
-              bool useAsyncCopy,
               triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
   LDBG("Build ChainedDotSchedule");
   tt::CoarseSchedule schedule(numStages);
@@ -1077,40 +511,36 @@ buildSchedule(scf::ForOp &forOp, int numStages, const LoadToInfoMap &loadToInfo,
   }
   dumpSchedule("Coarse schedule after schedule ops between dots:");
 
-  // Convert the loads into shared memory allocations and loads from them.
-  // TODO support different numBuffers
-  int numBuffers = useAsyncCopy ? 2 : 1;
-  auto loadToStreamOps =
-      createStreamOps(loadToInfo, forOp, /*numBuffers=*/numBuffers,
-                      useAsyncCopy, axisInfoAnalysis);
-  scheduleStreamOps(loadToStreamOps, schedule, clusters);
-  dumpSchedule("Coarse schedule stream ops:");
-
-  for (auto [l, _] : loadToInfo) {
-    schedule.erase(l);
-    l->erase();
-  }
-
-  scheduleDependencies(forOp, schedule);
-  dumpSchedule("Coarse schedule with dependencies:");
-
-  triton::gpu::scheduleDistanceOneDependencies(forOp, schedule);
-  dumpSchedule("Coarse schedule with dist 1:");
-
-  tt::CoarseSchedule::Cluster lastCluster = clusters.back();
-  triton::gpu::scheduleRemainingToLastStage(forOp, schedule, lastCluster);
-  dumpSchedule("Final coarse schedule:");
-
   return schedule;
 }
 } // namespace ChainedDotSchedule
 
-void pipelineLoop(scf::ForOp forOp, int numStages, bool useAsyncCopy,
-                  bool waitAtTail) {
+void pipelineLoop(scf::ForOp forOp, int numStages) {
   triton::AMD::ModuleAxisInfoAnalysis axisInfoAnalysis(
       forOp->getParentOfType<ModuleOp>());
 
-  LoadToInfoMap loadToInfo = preprocessLoop(axisInfoAnalysis, forOp, numStages);
+  llvm::MapVector<Operation *, std::pair<int, Operation *>> loadOpToIndLevel =
+      getIndirectLevel(axisInfoAnalysis, forOp, numStages);
+
+  LLVM_DEBUG({
+    LDBG("Found " << loadOpToIndLevel.size() << " loads to pipeline:");
+    for (const auto &[l, i] : loadOpToIndLevel) {
+      LDBG("  - load: " << *l);
+      LDBG("    at distance: " << i.first);
+      LDBG("    used by op: " << *i.second);
+    }
+  });
+
+  LoadToInfoMap loadToInfo;
+  for (const auto &[load, info] : loadOpToIndLevel) {
+    auto [distance, use] = info;
+    auto newLoad = bypassLDS(load, use);
+    if (newLoad) {
+      loadToInfo[newLoad] = {nullptr, distance, use};
+    } else {
+      loadToInfo[load] = {nullptr, distance, use};
+    }
+  }
 
   if (loadToInfo.empty()) {
     LDBG("couldn't find any pipeline-able loads:\n" << *forOp);
@@ -1119,13 +549,12 @@ void pipelineLoop(scf::ForOp forOp, int numStages, bool useAsyncCopy,
 
   tt::CoarseSchedule schedule;
 
-  if (succeeded(ChainedDotSchedule::checkPreconditions(forOp, numStages,
-                                                       loadToInfo))) {
-    schedule = ChainedDotSchedule::buildSchedule(
-        forOp, numStages, loadToInfo, useAsyncCopy, axisInfoAnalysis);
+  if (succeeded(mlir::ChainedDotSchedule::checkPreconditions(forOp, numStages,
+                                                             loadToInfo))) {
+    schedule = ChainedDotSchedule::buildSchedule(forOp, numStages, loadToInfo,
+                                                 axisInfoAnalysis);
   } else {
     schedule = SingleDotSchedule::buildSchedule(forOp, numStages, loadToInfo,
-                                                useAsyncCopy, waitAtTail,
                                                 axisInfoAnalysis);
   }
 
@@ -1155,11 +584,8 @@ struct ScheduleLoops : impl::TritonAMDGPUScheduleLoopsBase<ScheduleLoops> {
         LDBG("Loop not safe to pipeline:\n" << *forOp);
         continue;
       }
-      // i.e., we can still disable `waitAtTail` by explicitly disabling
-      // pingpong, which is the only use case of this scheduling variant.
       int numStagesThis = tt::getNumStagesOrDefault(forOp, numStages);
-      bool waitAtTail = usePingpong && (numStagesThis == 3) && useAsyncCopy;
-      pipelineLoop(forOp, numStagesThis, useAsyncCopy, waitAtTail);
+      pipelineLoop(forOp, numStagesThis);
     }
   }
 };

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -91,11 +91,10 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_fold_true_cmpi", mlir::createTritonAMDFoldTrueCmpI);
   ADD_PASS_OPTION_WRAPPER_1("add_block_pingpong",
                             mlir::createTritonAMDGPUBlockPingpong, int32_t);
-  ADD_PASS_OPTION_WRAPPER_3("add_schedule_loops",
-                            mlir::createTritonAMDGPUScheduleLoops, int, bool,
-                            bool);
-  ADD_PASS_OPTION_WRAPPER_1("add_pipeline", mlir::createTritonAMDGPUPipeline,
-                            bool);
+  ADD_PASS_OPTION_WRAPPER_1("add_schedule_loops",
+                            mlir::createTritonAMDGPUScheduleLoops, int);
+  ADD_PASS_OPTION_WRAPPER_2("add_pipeline", mlir::createTritonAMDGPUPipeline,
+                            bool, bool);
   ADD_PASS_OPTION_WRAPPER_1("add_coalesce_async_copy",
                             mlir::createTritonAMDGPUCoalesceAsyncCopy,
                             std::string);


### PR DESCRIPTION
This PR
- moved functions from `ScheduleLoops` to `LowerLoops` to match common path structure, including allocating lds, creating local/async load ops, and creating schedule for these ops.
- created symbolic clusters in `ScheduleLoops` and remap them to real clusters in `LowerLoops`
- Stopped deducing shared layout in `ScheduleLoops`, did that in `LowerLoops` instead
- replaced `preprocessLoop` with `getIndirectLevel` and a loop to generate `loadToInfo`
- created an attribute to hand over bypassLDS attribute from `ScheduleLoops` to `LowerLoops` through IR
- cleaned up pass arguments. Now `ScheduleLoops` only needs `numStages`. `Pipeline` only needs `useAsyncCopy` and `usePingPong`
- rephrase comments accordingly

It's part of a series of PRs to refactor StreamPipeliner.

Previous PRs:
- https://github.com/triton-lang/triton/pull/8307
- https://github.com/triton-lang/triton/pull/8295