### PR TITLE
Remove `find_library(TERMINFO_LIBRARY tinfo)` from `CMakeLists.txt` as unused

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,6 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
 
-if(NOT WIN32)
-  find_library(TERMINFO_LIBRARY tinfo)
-endif()
-
 if(TRITON_BUILD_UT)
   # This is an aggregate target for all unit tests.
   add_custom_target(TritonUnitTests)


### PR DESCRIPTION
Closes #7156


`TERMINFO_LIBRARY` is unused since https://github.com/triton-lang/triton/commit/98ed7db8c1f3e7de6e67cbb3838f0692fb541be4