### PR TITLE
[Gluon] Require warp_specialize default_args and worker_args be tuples

### DIFF
--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -509,10 +509,6 @@ def warp_specialize(default_args, default_partition, worker_args, worker_partiti
     """
     worker_num_warps = [_unwrap_if_constexpr(w) for w in worker_num_warps]
     worker_num_regs = [_unwrap_if_constexpr(r) for r in worker_num_regs]
-    if not isinstance(default_args, tuple):
-        default_args = (default_args, )
-    if not isinstance(worker_args, tuple):
-        worker_args = (worker_args, )
     return _semantic.warp_specialize(default_args, default_partition, worker_args, worker_partitions, worker_num_warps,
                                      worker_num_regs, _generator)
 

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -420,6 +420,9 @@ class GluonSemantic(TritonSemantic[TensorTy]):
     def warp_specialize(self, default_args, default_partition, worker_args, worker_partitions,
                         worker_num_warps: Sequence[int], worker_num_regs: Sequence[int], generator):
         num_partitions = len(worker_partitions)
+        assert isinstance(default_args,
+                          tuple), f"default_args must be a tuple of arguments, but got {type(default_args)}"
+        assert isinstance(worker_args, tuple), f"worker_args must be a tuple of arguments, but got {type(default_args)}"
         assert num_partitions == len(
             worker_num_warps
         ), f"warp specialize got {num_partitions} partitions but {len(worker_num_warps)} warp counts"

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -420,9 +420,10 @@ class GluonSemantic(TritonSemantic[TensorTy]):
     def warp_specialize(self, default_args, default_partition, worker_args, worker_partitions,
                         worker_num_warps: Sequence[int], worker_num_regs: Sequence[int], generator):
         num_partitions = len(worker_partitions)
-        assert isinstance(default_args,
-                          tuple), f"default_args must be a tuple of arguments, but got {type(default_args)}"
-        assert isinstance(worker_args, tuple), f"worker_args must be a tuple of arguments, but got {type(default_args)}"
+        _check(isinstance(default_args, (tuple, ttgl.tuple)),
+               lambda: f"default_args must be a tuple of arguments, but got {type(default_args)}")
+        _check(isinstance(worker_args, (tuple, ttgl.tuple)),
+               lambda: f"worker_args must be a tuple of arguments, but got {type(worker_args)}")
         assert num_partitions == len(
             worker_num_warps
         ), f"warp specialize got {num_partitions} partitions but {len(worker_num_warps)} warp counts"


### PR DESCRIPTION
I'm not a fan of using `isinstance` here as it leads to an inconsistency. Say we want to pass a single argument `x` that happens to be a tuple of tensors, then that has to be passed as `(x,)` or otherwise the tuple will be interpreted as a list of arguments to pass to the worker function. 

The original PR (#8269) justified this as improving the error message, so I also add a validation check with a better error message if you forget to pass a tuple.