### PR TITLE
Get MLIRContext from `newOp`, not the deleted `load`

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
@@ -300,7 +300,7 @@ static Operation *bypassLDS(Operation *load, Operation *use) {
 
   // Finally, rewrite the load to use the inferred (better) encoding.
   auto newOp = convertDistributedOpEncoding(srcEnc, load);
-  newOp->setAttr(AttrBypassLDS, BoolAttr::get(load->getContext(), true));
+  newOp->setAttr(AttrBypassLDS, BoolAttr::get(newOp->getContext(), true));
   return newOp;
 };
 


### PR DESCRIPTION
The `load` op is erased in `convertDistributedOpEncoding` so we should get the MLIR context from the `newOp` when setting op attributes. Interestingly, I found this issue only because the `loop-pipeline-hip.mlir` lit test crashed with bad access on my Mac laptop (ARM). On Linux/x86 the test runs fine w/ and w/out this fix. 