### PR TITLE
[BACKEND] Fix swizzling=0 support for matrix descriptors and generalize wgmma lowering

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2709,7 +2709,8 @@ struct TritonGPUInferLayoutInterface
     auto mmaRetEncoding = mlir::dyn_cast<NvidiaMmaEncodingAttr>(retEncoding);
     if (mmaRetEncoding && mmaRetEncoding.isHopper()) {
       auto dotOpEnc = mlir::dyn_cast<DotOperandEncodingAttr>(operandEncoding);
-      if (!mlir::isa<NVMMASharedEncodingAttr>(operandEncoding) &&
+      if (!mlir::isa<NVMMASharedEncodingAttr, SharedLinearEncodingAttr>(
+              operandEncoding) &&
           !(opIdx == 0 && dotOpEnc && dotOpEnc.getOpIdx() == 0 &&
             mlir::isa<NvidiaMmaEncodingAttr>(dotOpEnc.getParent()))) {
         return emitOptionalError(

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -50,7 +50,7 @@ LogicalResult WarpGroupDotOp::inferReturnTypes(
 
   // verify encodings
   auto aEnc = cast<TensorOrMemDesc>(operands[0].getType()).getEncoding();
-  auto bEnc = cast<TensorOrMemDesc>(operands[1].getType()).getEncoding();
+  auto bEnc = cast<MemDescType>(operands[1].getType()).getEncoding();
   auto retEnc = accTy.getEncoding();
   if (aEnc) {
     assert(bEnc);
@@ -70,10 +70,11 @@ LogicalResult WarpGroupDotOp::verify() {
   if (!nvmmaEnc || !nvmmaEnc.isHopper())
     return emitOpError("WGMMA result layout must be Hopper NVMMA");
 
-  if (!isa<NVMMASharedEncodingAttr, DotOperandEncodingAttr>(
-          getA().getType().getEncoding()))
+  if (!isa<NVMMASharedEncodingAttr, DotOperandEncodingAttr,
+           SharedLinearEncodingAttr>(getA().getType().getEncoding()))
     return emitOpError("WGMMA A operand must have NVMMA shared or dot layout");
-  if (!isa<NVMMASharedEncodingAttr>(getB().getType().getEncoding()))
+  if (!isa<NVMMASharedEncodingAttr, SharedLinearEncodingAttr>(
+          getB().getType().getEncoding()))
     return emitOpError("WGMMA B operand must have NVMMA shared layout");
 
   auto numWarps = gpu::lookupNumWarps(getOperation());

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -1,4 +1,5 @@
 import torch
+import math
 import pytest
 import re
 from itertools import product
@@ -196,8 +197,7 @@ def test_warpgroup_mma(ASYNC):
                           for acc_dtype in [torch.float16, torch.float32]
                           if bitwidth == 16 or (acc_dtype == torch.float32 and not transpose_a and transpose_b)])
 @pytest.mark.parametrize("warps", ([8, 1], [4, 2], [4, 1]))
-# Swizzling 0 does not map to a valid memory descriptor lol
-@pytest.mark.parametrize("swizzling_a, swizzling_b", product([32, 64, 128], repeat=2))
+@pytest.mark.parametrize("swizzling_a, swizzling_b", product([0, 32, 64, 128], repeat=2))
 @pytest.mark.parametrize("shape_m, shape_n, shape_k", [(1, 1, 1), (2, 4, 1), (2, 2, 4)])
 def test_warpgroup_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps, swizzling_a, swizzling_b,
                                      shape_m, shape_n, shape_k):
@@ -238,7 +238,24 @@ def test_warpgroup_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dty
     K *= shape_k
     instr_shape[1] *= shape_n
 
-    shared_mem_accum = M * K * bitwidth // 8 + K * N * bitwidth // 8
+    def get_shared_swizzling_zero(M, K, transpose):
+        # K-contig
+        if transpose:
+            K, M = M, K
+        bases = []
+        for i in range(int(math.log2(128 // bitwidth))):
+            bases.append([0, 1 << i])
+        for i in range(int(math.log2(M))):
+            bases.append([1 << i, 0])
+        for i in range(int(math.log2(K // (128 // bitwidth)))):
+            offset = int(math.log2(128 // bitwidth)) + i
+            bases.append([0, 1 << offset])
+        if transpose:
+            for i in range(len(bases)):
+                bases[i] = [bases[i][1], bases[i][0]]
+        return ttgl.SharedLinearLayout(bases)
+
+    shared_mem_accum = (M + N) * K * bitwidth // 8
     if triton.runtime.driver.active.utils.get_device_properties(
             triton.runtime.driver.active.get_current_device())["max_shared_mem"] < shared_mem_accum:
         pytest.skip("Skipped due to insufficient shared memory on this GPU.")
@@ -248,10 +265,16 @@ def test_warpgroup_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dty
     out_dtype = torch.float32
 
     block_layout = ttgl.BlockedLayout([1, 1], [1, THREADS_PER_WARP], warps_per_cta=warps, order=[1, 0])
-    shared_layout_a = ttgl.NVMMASharedLayout(swizzle_byte_width=swizzling_a, element_bitwidth=bitwidth, rank=2,
-                                             transposed=transpose_a)
-    shared_layout_b = ttgl.NVMMASharedLayout(swizzle_byte_width=swizzling_b, element_bitwidth=bitwidth, rank=2,
-                                             transposed=transpose_b)
+    if swizzling_a == 0:
+        shared_layout_a = get_shared_swizzling_zero(M, K, transpose_a)
+    else:
+        shared_layout_a = ttgl.NVMMASharedLayout(swizzle_byte_width=swizzling_a, element_bitwidth=bitwidth, rank=2,
+                                                 transposed=transpose_a)
+    if swizzling_b == 0:
+        shared_layout_b = get_shared_swizzling_zero(K, N, transpose_b)
+    else:
+        shared_layout_b = ttgl.NVMMASharedLayout(swizzle_byte_width=swizzling_b, element_bitwidth=bitwidth, rank=2,
+                                                 transposed=transpose_b)
     mma_layout = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=warps, instr_shape=instr_shape)
 
     torch.manual_seed(0)
@@ -297,9 +320,9 @@ def test_warpgroup_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dty
         torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = allow_fp16_red
 
     if bitwidth == 8:
-        atol, rtol = 0.5, 0.5
+        atol, rtol = 5e-2, 5e-1
     elif bitwidth == 16:
-        atol, rtol = 3e-2, 1e-1
+        atol, rtol = 5e-2, 5e-1
     else:
         atol, rtol = 5e-4, 5e-3
     torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -200,7 +200,12 @@ def test_warpgroup_mma(ASYNC):
 @pytest.mark.parametrize("swizzling_a, swizzling_b", product([0, 32, 64, 128], repeat=2))
 @pytest.mark.parametrize("shape_m, shape_n, shape_k", [(1, 1, 1), (2, 4, 1), (2, 2, 4)])
 def test_warpgroup_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps, swizzling_a, swizzling_b,
-                                     shape_m, shape_n, shape_k):
+                                     shape_m, shape_n, shape_k, fresh_knobs):
+
+    # FIXME: Workaround for a bug in PTXAS when the shared layout is transposed and the swizzling is 0
+    if bitwidth == 16 and ((transpose_a and swizzling_a == 0 and shape_m > 1) or
+                           (not transpose_b and swizzling_b == 0 and shape_n > 1)):
+        fresh_knobs.nvidia.disable_ptxas_opt = True
 
     torch_dtype_map = {
         8: torch.float8_e4m3fn,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -455,7 +455,7 @@ void convertDotImpl(const LLVMTypeConverter &typeConverter,
   } else {
     auto isFp4a = op.numBitsPerElementA == 4;
     aLoader = std::make_unique<DotOpMmaSmemLoader>(DotOpMmaSmemLoader::build(
-        loc, rewriter, aTensorTy, baseA, aOperandShape, 5, isFp4a));
+        loc, rewriter, aTensorTy, baseA, aOperandShape, 0, 5, isFp4a));
   }
 
   auto isFp4b = op.numBitsPerElementB == 4;
@@ -470,7 +470,7 @@ void convertDotImpl(const LLVMTypeConverter &typeConverter,
   // It's a massive code smell tho
   DotOpMmaSmemLoader bLoader = DotOpMmaSmemLoader::build(
       loc, rewriter, bTensorTy, baseB, {mmaSizeK, mmaSizeN / (twoCTAs ? 2 : 1)},
-      5, isFp4b);
+      1, 5, isFp4b);
 
   DotConversion::InstDesc desc{mmaSizeM, mmaSizeN, {numRepM, numRepN, numRepK},
                                transA,   transB,   interleaved,


### PR DESCRIPTION
We fix a bug we had in the matrix descriptor lowering. We also add
comprehensive gluon tests for the `swizzling=0` case. To do so, we allow
`wgmma` to accept `SharedLinearLayout` when it takes a shared memory
argument.

While testing all the cases for `swizzling=0` we found a `ptxas` bug in some of them.
For now, we disable `ptxas` optimisations in some of the test cases to work around this.