### PR TITLE
Fix unknown location for map_elementwise op.

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -455,6 +455,10 @@ void init_triton_ir(py::module &&m) {
              auto loc = UnknownLoc::get(ty.getContext());
              self.addArgument(ty, loc);
            })
+      .def("add_argument_at",
+           [](Block &self, Type ty, Location loc) {
+             self.addArgument(ty, loc);
+           })
       .def("get_num_arguments", &Block::getNumArguments)
       .def("get_argument", &Block::getArgument)
       .def("dump", &Block::dump)

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -455,10 +455,8 @@ void init_triton_ir(py::module &&m) {
              auto loc = UnknownLoc::get(ty.getContext());
              self.addArgument(ty, loc);
            })
-      .def("add_argument_at",
-           [](Block &self, Type ty, Location loc) {
-             self.addArgument(ty, loc);
-           })
+      .def("add_argument_at", [](Block &self, Type ty,
+                                 Location loc) { self.addArgument(ty, loc); })
       .def("get_num_arguments", &Block::getNumArguments)
       .def("get_argument", &Block::getArgument)
       .def("dump", &Block::dump)

--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -425,7 +425,9 @@ def test_use_name_loc_as_prefix(fresh_triton_cache):
     check_template = inspect.getsource(kernel_basic_while.fn)
     run_filecheck("placeholder", h.asm["ttir"], check_template)
 
+
 def test_map_elementwise_has_lineinfo():
+
     @triton.jit
     def compare(x, y):
         if x < y:
@@ -434,11 +436,11 @@ def test_map_elementwise_has_lineinfo():
 
     @triton.jit
     def kernel(X, Y):
-       # CHECK-NOT: loc(unknown)
-       x = tl.load(X + tl.arange(0, 4))
-       y = tl.load(Y + tl.arange(0, 4))
-       z = tl.map_elementwise(compare, x, y)
-       tl.device_print("", z)
+        # CHECK-NOT: loc(unknown)
+        x = tl.load(X + tl.arange(0, 4))
+        y = tl.load(Y + tl.arange(0, 4))
+        z = tl.map_elementwise(compare, x, y)
+        tl.device_print("", z)
 
     kernel_info = kernel.warmup(torch.float32, torch.float32, grid=(1, ))
     check_template = inspect.getsource(kernel.fn)

--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -158,24 +158,24 @@ def test_line_info(func: str):
 
     file_lines = extract_file_lines(command, anchor, separator, kernel_info.asm[obj_kind])
     if func == "single":
-        assert (check_file_lines(file_lines, "test_line_info.py", 14))
-        assert (check_file_lines(file_lines, "test_line_info.py", 15))
+        assert (check_file_lines(file_lines, "test_line_info.py", 16))
+        assert (check_file_lines(file_lines, "test_line_info.py", 17))
     elif func == "call":
-        assert (check_file_lines(file_lines, "test_line_info.py", 25))
         assert (check_file_lines(file_lines, "test_line_info.py", 27))
+        assert (check_file_lines(file_lines, "test_line_info.py", 29))
     elif func == "call_noinline":
-        assert (check_file_lines(file_lines, "test_line_info.py", 39))
-        assert (check_file_lines(file_lines, "test_line_info.py", 32))
-        assert (check_file_lines(file_lines, "test_line_info.py", 32))
+        assert (check_file_lines(file_lines, "test_line_info.py", 41))
+        assert (check_file_lines(file_lines, "test_line_info.py", 34))
+        assert (check_file_lines(file_lines, "test_line_info.py", 34))
     elif func == "autotune":
-        assert (check_file_lines(file_lines, "test_line_info.py", 50))
-        assert (check_file_lines(file_lines, "test_line_info.py", 51))
         assert (check_file_lines(file_lines, "test_line_info.py", 52))
+        assert (check_file_lines(file_lines, "test_line_info.py", 53))
+        assert (check_file_lines(file_lines, "test_line_info.py", 54))
     elif func == "dot_combine":
-        assert (check_file_lines(file_lines, "test_line_info.py", 62))
-        assert (check_file_lines(file_lines, "test_line_info.py", 63, should_contain=False))
+        assert (check_file_lines(file_lines, "test_line_info.py", 64))
+        assert (check_file_lines(file_lines, "test_line_info.py", 65, should_contain=False))
     elif func == "cdiv":
-        assert (check_file_lines(file_lines, "test_line_info.py", 72))
+        assert (check_file_lines(file_lines, "test_line_info.py", 74))
 
 
 @pytest.mark.interpreter
@@ -188,22 +188,22 @@ def test_line_info_interpreter(func: str):
     expected_def_lineno = 0
     if func == "single":
         kernel = kernel_single
-        expected_def_lineno = 13
+        expected_def_lineno = 15
     elif func == "call":
         kernel = kernel_call
-        expected_def_lineno = 24
+        expected_def_lineno = 26
     elif func == "call_noinline":
         kernel = kernel_call_noinline
-        expected_def_lineno = 38
+        expected_def_lineno = 40
     elif func == "autotune":
         kernel = kernel_autotune.fn
-        expected_def_lineno = 49
+        expected_def_lineno = 51
     elif func == "dot_combine":
         kernel = kernel_dot_combine
-        expected_def_lineno = 59
+        expected_def_lineno = 61
     elif func == "cdiv":
         kernel = kernel_cdiv
-        expected_def_lineno = 69
+        expected_def_lineno = 71
     kernel.rewrite()
     assert kernel.rewriter.def_file_lineno == expected_def_lineno
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2808,7 +2808,7 @@ def map_elementwise(
     original_loc = builder.get_loc()
     for i, ty in enumerate(in_scalar_tys):
         for j in builtins.range(pack):
-            block.add_argument(ty.to_ir(builder))
+            block.add_argument_at(ty.to_ir(builder), original_loc)
             scalar_args.append(tensor(block.arg(i * pack + j), ty))
 
     with _insertion_guard(builder):
@@ -2820,6 +2820,7 @@ def map_elementwise(
             scalar_results = scalar_results,
 
         handles = [r.handle for r in scalar_results]
+        builder.set_loc(original_loc)
         builder.create_map_elementwise_ret(handles)
 
     fn_result_types = [x.type for x in scalar_results]

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2805,6 +2805,7 @@ def map_elementwise(
     builder = _semantic.builder
     block = builder.new_block()
     scalar_args = []
+    original_loc = builder.get_loc()
     for i, ty in enumerate(in_scalar_tys):
         for j in builtins.range(pack):
             block.add_argument(ty.to_ir(builder))
@@ -2832,6 +2833,7 @@ def map_elementwise(
         region = elementwise_op.get_region(0)
         region.push_back(block)
 
+    builder.set_loc(original_loc)
     result = _semantic.map_elementwise(args, scalar_result_types, pack, make_elementwise_region)
     return result[0] if is_single else result
 


### PR DESCRIPTION
The `tl.map_elementwise` op currently gets created with an unknown location. This can cause the `llvm.di_scope` pass to fail if the `tl.map_elementwise` lowering creates a call op. 

The location gets lost during setup of the op, so just save/restore it during the code gen.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `Trivial change`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
