### PR TITLE
fix: missing dependency `TritonIR` -> `TritonGPUIR`'s tbl-gen headers

### DIFF
--- a/lib/Dialect/Triton/IR/CMakeLists.txt
+++ b/lib/Dialect/Triton/IR/CMakeLists.txt
@@ -14,6 +14,7 @@ add_triton_library(TritonIR
   DEPENDS
   TritonTableGen
   TritonCanonicalizeIncGen
+  TritonGPUIR.Interface
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/lib/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -1,3 +1,11 @@
+add_custom_target(TritonGPUIR.Interface
+  DEPENDS
+  TritonGPUTableGen
+  TritonGPUAttrDefsIncGen
+  TritonGPUTypeInterfacesIncGen
+  TritonGPUOpInterfacesIncGen
+)
+
 add_triton_library(TritonGPUIR
   Dialect.cpp
   LinearLayoutConversions.cpp
@@ -6,10 +14,7 @@ add_triton_library(TritonGPUIR
   Types.cpp
 
   DEPENDS
-  TritonGPUTableGen
-  TritonGPUAttrDefsIncGen
-  TritonGPUTypeInterfacesIncGen
-  TritonGPUOpInterfacesIncGen
+  TritonGPUIR.Interface
 
   LINK_LIBS PUBLIC
   MLIRGPUDialect


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `cmake-only change`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

`TritonIR`'s `Traits.cpp` uses `TritonGPUIR` headers which transitively include `TritonGPUIR` owned tbl-gen headers. This causes non-deterministic build failures.

Fix: Add a custom target to gather and sequence all of `TritonGPUIR`'s generated interfaces; have both `TritonIR` and `TritonGPUIR` depend on this custom target. `TritonIR` cannot directly depend on `TritonGPUIR` as this would cause a cycle.

Example include path (there are others too): `Traits.cpp` -> `TritonGPU/IR/Types.h` -> `TritonGPU/IR/Attributes.h` -> `TritonGPU/IR/TritonGPUInterfaces.h` -> `TritonGPU/IR/OpInterfaces.h.inc`

