### PR TITLE
Fix get_int_dtype error in triton 3.5 to fix TransformerEngine

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -10,7 +10,7 @@ from typing import Union, Callable, List, Sequence, TypeVar, Optional, Tuple
 from dataclasses import dataclass
 import builtins
 from .. import knobs
-from ..runtime.jit import JITCallable
+from ..runtime.jit import constexpr_function, JITCallable
 import inspect
 
 from .._C.libtriton import ir
@@ -810,6 +810,7 @@ float64 = dtype('fp64')
 pi32_t = pointer_type(int32)
 
 
+@triton.constexpr_function
 def get_int_dtype(bitwidth: int, signed: bool) -> dtype:
     if bitwidth == 1:
         return int1


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

This is a tentative pr and I would like to hear what do you think (since I am not very familiar w/ triton). Shall I put this (and similar changes) here or in https://github.com/NVIDIA/TransformerEngine/pull/2286

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
