### PR TITLE
Wrap datatypes into contexprs

### DIFF
--- a/python/test/unit/language/test_complex_conditionals.py
+++ b/python/test/unit/language/test_complex_conditionals.py
@@ -1,0 +1,27 @@
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+
+@pytest.mark.interpreter
+def test_complex_conditionals(device):
+    # Example that will fail because of "or"
+    # Guess it's related to order of evaluating/visiting nodes in Triton front-end.
+    @triton.jit
+    def test_if_or(x_ptr, out_ptr):
+        x = tl.load(x_ptr)
+        if (((x.dtype == tl.float32) or (x.dtype == tl.float16))
+                and not (x.dtype == tl.float32)) and (x.dtype == tl.float16 and x.dtype == tl.float32):
+            tl.store(out_ptr, 0)
+        else:
+            tl.store(out_ptr, 1)
+
+    x_float = torch.randn((32, ), dtype=torch.float32, device=device)
+    x_int = torch.randn((32, ), dtype=torch.float32, device=device).to(torch.int32)
+    out_ptr = torch.empty((1, ), dtype=torch.int32, device=device)
+
+    test_if_or[(8, 8)](x_float, out_ptr)
+    assert out_ptr == 0, "Expected 0"
+    test_if_or[(8, 8)](x_int, out_ptr)
+    assert out_ptr == 1, "Expected 1"

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -159,7 +159,7 @@ class base_type:
         raise NotImplementedError("Types must implement __eq__")
 
     def __ne__(self, other) -> bool:
-        return not (self == other)
+        return constexpr(not (self == other))
 
     def _unflatten_ir(self, handles: List[ir.value], cursor: int) -> Tuple[base_value, int]:
         """Build a frontend value with the current dtype, wrapping a list of existing handles.
@@ -557,8 +557,8 @@ class dtype(base_type):
     def __eq__(self, other) -> bool:
         other = _unwrap_if_constexpr(other)
         if not isinstance(other, dtype):
-            return False
-        return self.name == other.name
+            return constexpr(False)
+        return constexpr(self.name == other.name)
 
     def __hash__(self):
         return hash((self.name, ))
@@ -682,8 +682,9 @@ class pointer_type(dtype):
     def __eq__(self, other) -> bool:
         other = _unwrap_if_constexpr(other)
         if not isinstance(other, pointer_type):
-            return False
-        return self.element_ty == other.element_ty and self.address_space == other.address_space and self.const == other.const
+            return constexpr(False)
+        return constexpr(self.element_ty == other.element_ty and self.address_space == other.address_space
+                         and self.const == other.const)
 
     @property
     def scalar(self):
@@ -730,8 +731,8 @@ class block_type(dtype):
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, block_type):
-            return False
-        return self.element_ty == other.element_ty and self.shape == other.shape
+            return constexpr(False)
+        return constexpr(self.element_ty == other.element_ty and self.shape == other.shape)
 
     @property
     def scalar(self):
@@ -773,7 +774,7 @@ class tuple_type(base_type):
         return self.types[index]
 
     def __eq__(self, other):
-        return type(self) is type(other) and self.types == other.types and self.fields == other.fields
+        return constexpr(type(self) is type(other) and self.types == other.types and self.fields == other.fields)
 
     def _unflatten_ir(self, handles: List[ir.value], cursor: int) -> Tuple[tuple, int]:
         values = []
@@ -1355,11 +1356,11 @@ class tensor_descriptor_base_type(base_type):
 
     def __eq__(self, other) -> bool:
         if type(other) is not type(self):
-            return False
-        return self.block_type == other.block_type
+            return constexpr(False)
+        return constexpr(self.block_type == other.block_type)
 
     def __neq__(self, other) -> bool:
-        return not (self == other)
+        return constexpr(not (self == other))
 
     def mangle(self) -> str:
         return f"TD{self.block_type.mangle()}"
@@ -1479,8 +1480,8 @@ class tensor_descriptor_type(tensor_descriptor_base_type):
         self.strides_type._flatten_ir_types(builder, out)
 
     def __eq__(self, other):
-        return super().__eq__(other) and (self.shape_type == other.shape_type) and (self.strides_type
-                                                                                    == other.strides_type)
+        return constexpr(super().__eq__(other) and (self.shape_type == other.shape_type)
+                         and (self.strides_type == other.strides_type))
 
 
 class tensor_descriptor(tensor_descriptor_base):


### PR DESCRIPTION
Wraps bool results of eq and ne operations of various compile-time datatypes in core.py into contexprs to enable their proper use in complex compile-time expressions, including conditions of if-statements and such.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.
Tests that are already present in the Triton repo makes sure about backward compatibility of the change.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),

Ran:
make test-nogpu 
