### PR TITLE
Dtype documentation

### DIFF
--- a/docs/python-api/triton.language.rst
+++ b/docs/python-api/triton.language.rst
@@ -227,3 +227,13 @@ Debug Ops
     static_assert
     device_print
     device_assert
+
+
+Valid tl.dtype Data Types
+-----------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    

--- a/docs/python-api/triton.language.rst
+++ b/docs/python-api/triton.language.rst
@@ -236,4 +236,25 @@ Valid tl.dtype Data Types
     :toctree: generated
     :nosignatures:
 
+    is_fp8e4nv
+    is_fp8e4b8
+    is_fp8e4b15
+    is_fp8e5
+    is_fp8e5b16
+    is_fp16
+    is_bf16
+    is_fp32
+    is_fp64
+    is_int1
+    is_int8
+    is_int16
+    is_int32
+    is_int64
+    is_uint8
+    is_uint16
+    is_uint32
+    is_uint64
+    is_void
+
+
     

--- a/docs/python-api/triton.language.rst
+++ b/docs/python-api/triton.language.rst
@@ -255,6 +255,3 @@ Valid tl.dtype Data Types
     is_uint32
     is_uint64
     is_void
-
-
-    

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -437,9 +437,15 @@ class dtype(base_type):
         return 'fp8' in self.name
 
     def is_fp8e4nv(self):
+        """
+        8-bit floating point, as in E4M3 from https://arxiv.org/pdf/2209.05433
+        """
         return self.name == 'fp8e4nv'
 
     def is_fp8e4b8(self):
+        """
+        8-bit floating point, from https://arxiv.org/pdf/2206.02915
+        """
         return self.name == 'fp8e4b8'
 
     def is_fp8e4b15(self):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -438,62 +438,110 @@ class dtype(base_type):
 
     def is_fp8e4nv(self):
         """
-        8-bit floating point, as in E4M3 from https://arxiv.org/pdf/2209.05433
+        8-bit floating point, as in E4M3FN from https://arxiv.org/pdf/2209.05433
         """
         return self.name == 'fp8e4nv'
 
     def is_fp8e4b8(self):
         """
-        8-bit floating point, from https://arxiv.org/pdf/2206.02915
+        8-bit floating point, as in E4M3FNUZ from https://arxiv.org/pdf/2206.02915
         """
         return self.name == 'fp8e4b8'
 
     def is_fp8e4b15(self):
+        """
+        8-bit floating point E4M3 variant with bias 15
+        """
         return self.name == 'fp8e4b15'
 
     def is_fp8e5(self):
+        """
+        8-bit floating point, as in E5M2 from https://arxiv.org/pdf/2209.05433
+        """
         return self.name == 'fp8e5'
 
     def is_fp8e5b16(self):
+        """
+        8-bit floating point, as in E5M2FNUZ from https://arxiv.org/pdf/2206.02915
+        """
         return self.name == 'fp8e5b16'
 
     def is_fp16(self):
+        """
+        16-bit floating point, defined in https://en.wikipedia.org/wiki/IEEE_754
+        """
         return self.name == 'fp16'
 
     def is_bf16(self):
+        """
+        16-bit brain floating point, defined in https://en.wikipedia.org/wiki/Bfloat16_floating-point_format
+        """
         return self.name == 'bf16'
 
     def is_fp32(self):
+        """
+        32-bit floating point, defined in https://en.wikipedia.org/wiki/IEEE_754
+        """
         return self.name == 'fp32'
 
     def is_fp64(self):
+        """
+        64-bit floating point, as in https://en.wikipedia.org/wiki/IEEE_754
+        """
         return self.name == 'fp64'
 
     def is_int1(self):
+        """
+        1-bit [unsigned] integer, used as boolean
+        """
         return self.name == 'int1'
 
     def is_int8(self):
+        """
+        8-bit [signed] integer
+        """
         return self.name == 'int8'
 
     def is_int16(self):
+        """
+        16-bit [signed] integer
+        """
         return self.name == 'int16'
 
     def is_int32(self):
+        """
+        32-bit [signed] integer
+        """
         return self.name == 'int32'
 
     def is_int64(self):
+        """
+        64-bit [signed] integer
+        """
         return self.name == 'int64'
 
     def is_uint8(self):
+        """
+        8-bit [unsigned] integer
+        """
         return self.name == 'uint8'
 
     def is_uint16(self):
+        """
+        16-bit [unsigned] integer
+        """
         return self.name == 'uint16'
 
     def is_uint32(self):
+        """
+        32-bit [unsigned] integer
+        """
         return self.name == 'uint32'
 
     def is_uint64(self):
+        """
+        64-bit [unsigned] integer
+        """
         return self.name == 'uint64'
 
     def is_floating(self):
@@ -544,6 +592,9 @@ class dtype(base_type):
 
     @staticmethod
     def is_void():
+        """
+        unimplemented NaN type
+        """
         raise RuntimeError("Not implemented")
 
     @staticmethod


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `This PR provides additional documentation`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

From issue #8458, there's a demonstrated need for better documentation on valid data types for `tl.dtypes `, so I added that and the corresponding RST code for this to render in the site documentation. My documentation is based on seeing how these types are asserted as correct in unit tests and some research to find the primary sources. (P.S. This is my first open source contribution! Please leave feedback and let me know if there's anything of particular need I could work on next.)