### PR TITLE
[Doc] Add tables for the supported dtypes

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -375,6 +375,40 @@ def check_bit_width(value, shift_value):
 
 
 class dtype(base_type):
+    """Data types supported by a Triton `tensor` object.
+
+    Triton supports integer and floats data types.
+    The following tables shows which data types are supported:
+
+    **Floatint point dtypes**
+
+    ============    ======================================= =======
+    Dtype           Description                             S-E-M
+    ============    ======================================= =======
+    ``fp64``        64-bit double precision floating point. 1-11-52
+    ``fp32``        32-bit single precision floating point. 1-8-23
+    ``fp16``        16-bit half precision floating point.   1-5-10
+    ``bf16``        16-bit brain floating point.            1-8-7
+    ``fp8e5``       8-bit floating point.                   1-5-2
+    ``fp8e4nv``     8-bit floating point.                   1-4-3
+    ============    ======================================= =======
+
+    **Integer dtypes**
+
+    ============    =======================================
+    Dtype           Description
+    ============    =======================================
+    ``uint64``      64-bit integer (unsigned)
+    ``int64``       64-bit integer (signed)
+    ``uint32``      32-bit integer (unsigned)
+    ``int32``       32-bit integer (signed)
+    ``uint16``      16-bit integer (unsigned)
+    ``int16``       16-bit integer (signed)
+    ``uint8``       8-bit integer (unsigned)
+    ``int8``        8-bit integer (signed)
+    ============    =======================================
+    """
+
     SINT_TYPES = ['int8', 'int16', 'int32', 'int64']
     UINT_TYPES = ['int1', 'uint8', 'uint16', 'uint32', 'uint64']
     FP_TYPES = ['fp8e4b15', 'fp8e4nv', 'fp8e4b8', 'fp8e5', 'fp8e5b16', 'fp16', 'bf16', 'fp32', 'fp64']


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it adds documentation for supported data types.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)


This PR adds documentation for the `dtype` supported by Triton, as per issue #8458. These were added because the supported dtypes are not documented. I've opted to add two tables: one for the floats and one for the integers.

The following data types do not have documentation yet: `fp8e4b15`, `fp8e4b8`, and `fp8e5b16`. I was unable to find information on these variations of FP8.