### PR TITLE
Respect disallow acc multibuffer in WS mode

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -195,7 +195,8 @@ public:
           // a different partition than the MMA, so we can correctly set the
           // latency.
           if (isWarpSpecialized(forOp)) {
-            if (ttng::hasAccReadModifyWrite(mma, forOp))
+            if (ttng::hasAccReadModifyWrite(mma, forOp) ||
+                getDisallowAccMultiBuffer(forOp))
               opLatency.erase(&op); // can't pipeline the MMA
             else
               opLatency[&op] += 1;


### PR DESCRIPTION
In automatic warp specialization mode we were disregarding the `disallow_acc_multibuffer` flag, multi-buffering the tmem even if the user told us not to.