### PR TITLE
Add support for assignment ("walrus") expressions

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5512,6 +5512,16 @@ def test_poison_return(device):
         assert "poison" in h.asm["llir"], h.asm["llir"]
 
 
+def test_named_expr(device):
+
+    @triton.jit
+    def test():
+        x = (y := 0)
+        assert x == 0 and x == y
+
+    test[(1, )]()
+
+
 # -----------------------
 # test extra
 # -----------------------

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -740,6 +740,14 @@ class CodeGenerator(ast.NodeVisitor):
         self.visit(assign)
         return self.visit(lhs)
 
+    def visit_NamedExpr(self, node: ast.NamedExpr):
+        # Named expressions are simple and can only be of the form x := value
+        target = node.target.id
+        with self._name_loc_prefix(target):
+            value = self.visit(node.value)
+            self.set_value(target, value)
+            return value
+
     def visit_Name(self, node):
         if type(node.ctx) is ast.Store:
             return node.id


### PR DESCRIPTION
These are fairly simple, but the implementation intentionally chooses to skip sanitizing values because there is no "out" like there is with assignment to preserve constexprs using an annotation. I would argue that sanitization is actually undesirable in general (see #8749 for rationale) but that is a discussion for another day.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
