### PR TITLE
[Tests] Fix assert bug for fp8e5 dot on sm120.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3480,7 +3480,8 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         if capability[0] == 9 and M >= 64 and N >= 8:
             assert 'wgmma.mma_async.sync.aligned.m64n128k32.f32.e5m2.e5m2' in ptx
         elif capability[0] >= 8 and M < 64:
-            assert 'mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32' in ptx
+            assert ('mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32'
+                    in ptx) or ('mma.sync.aligned.m16n8k32.row.col.f32.e5m2.e5m2.f32' in ptx)
     elif in_dtype == "float8e4nv" and out_dtype == tl.float32:
         if capability[0] == 9 and M >= 64 and N >= 8:
             assert 'wgmma.mma_async.sync.aligned.m64n128k32.f32.e4m3.e4m3' in ptx


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it fixes a test bug`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

Description:

This commit fixes a test bug where the PTX code was not correctly matching the expected string. The assertion has been updated to reflect the changes introduced by PR #7409 in the Triton repository.

Test environment:
Hardware: AMD 8945HX CPU, NVIDIA RTX 5070Ti Laptop GPU.
Operating System: Ubuntu 20.04, from WSL2.
Triton Version: The latest version from main branch.

Change details:

The original assertion checked for the PTX string 'mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32'.
<img width="1269" height="265" alt="image" src="https://github.com/user-attachments/assets/86390add-47ac-410e-b150-5b6b64795b90" />

After the changes in PR #7409, the PTX generated by the fp8e5 dot test should now be 'mma.sync.aligned.m16n8k32.row.col.f32.e5m2.e5m2.f32'.
<img width="1009" height="143" alt="image" src="https://github.com/user-attachments/assets/0b2bdcdb-3625-484d-849c-2c6688aea4e6" />


The test was failing because it expected the old PTX string, but the PTX code generated for the operation in this test had changed after the previous PR.

This update ensures that the test correctly checks the new PTX code, which now matches the changes made in Triton as part of PR #7409.

No other parts of the code were affected, and the test now passes successfully with the updated PTX assertion.
<img width="1265" height="238" alt="image" src="https://github.com/user-attachments/assets/451d6121-bf08-4dc7-8573-3faa2767e12f" />


Why this change was necessary:

PR #7409 updated the lowering logic for the fp8 dot operation in Triton. The original test assertion was expecting the old PTX code, while the newly generated PTX code is different. This commit updates the test to match the new PTX code generated after PR #7409, ensuring that the test now correctly checks the updated PTX code.

Additional notes:

This change only affects the test and does not impact other functionality.


