### PR TITLE
[BACKEND] Sink tmem allocs after pipelining to reduce liveranges

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -61,7 +61,7 @@ def TritonGPUHoistTMEMAlloc : Pass<"tritongpu-hoist-tmem-alloc", "mlir::ModuleOp
                            "mlir::scf::SCFDialect",
                            "mlir::arith::ArithDialect"];
   let options = [
-    Option<"hoistOutOfIf", "hoist-out-of-if",
+    Option<"postPipeline", "post-pipeline",
            "bool", /*default*/"false",
            "Hoist TMEM allocations out of if statements">
   ];

--- a/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
@@ -480,8 +480,7 @@ public:
     auto firstInitIt = forOp.getInitArgsMutable().begin();
     int baseOpNo = firstInitIt->getOperandNumber();
     int tokIdx = tokUse.getOperandNumber() - baseOpNo;
-    if (tokIdx < 0 || tokIdx >= (int)forOp.getInitArgs().size())
-      return failure();
+    assert(tokIdx >= 0 && tokIdx < (int)forOp.getInitArgs().size());
 
     // Ensure the memory descriptor result of the alloc is only used inside the
     // loop. Otherwise sinking would break users after the loop.

--- a/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
@@ -1,3 +1,6 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -418,6 +421,105 @@ public:
   }
 };
 
+// Helper: return true if the value is a constant false boolean.
+static bool isConstFalse(Value v) {
+  if (auto cst = v.getDefiningOp<arith::ConstantOp>()) {
+    if (auto attr = dyn_cast<BoolAttr>(cst.getValueAttr()))
+      return !attr.getValue();
+  }
+  return false;
+}
+
+// Helper to detect if the use of an alloc fully overwrites it.
+struct AllocUse {
+  Operation *useOp;
+  MutableOperandRange dep;
+};
+
+static FailureOr<AllocUse> useOverwritesAlloc(ttng::TMEMAllocOp alloc,
+                                              BlockArgument tokArg) {
+  if (!tokArg.hasOneUse())
+    return failure();
+  OpOperand &onlyUse = *tokArg.use_begin();
+  Operation *useOp = onlyUse.getOwner();
+  if (auto store = dyn_cast<ttng::TMEMStoreOp>(useOp)) {
+    if (store.getDst() != alloc.getResult())
+      return failure();
+    return AllocUse{useOp, store.getDepMutable()};
+  }
+  if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(useOp)) {
+    if (onlyUse.get() == mma.getAccDep() &&
+        mma.getAccumulator() == alloc.getResult() &&
+        isConstFalse(mma.useAccumulator()))
+      return AllocUse{useOp, mma.getAccDepMutable()};
+  }
+  return failure();
+}
+
+class SinkTMemAlloc : public OpRewritePattern<ttng::TMEMAllocOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttng::TMEMAllocOp alloc,
+                                PatternRewriter &rewriter) const override {
+    // Only handle allocs that produce a token.
+    if (!alloc.getToken())
+      return failure();
+
+    // Find a forOp that takes the alloc token as an init arg.
+    // Limit to the simple case where the token has exactly one use.
+    if (!alloc.getToken().hasOneUse())
+      return failure();
+    OpOperand &tokUse = *alloc.getToken().use_begin();
+    auto userFor = dyn_cast<scf::ForOp>(tokUse.getOwner());
+    if (!userFor)
+      return failure();
+    scf::ForOp forOp = userFor;
+    if (forOp.getInitArgs().empty())
+      return failure();
+    auto firstInitIt = forOp.getInitArgsMutable().begin();
+    int baseOpNo = firstInitIt->getOperandNumber();
+    int tokIdx = tokUse.getOperandNumber() - baseOpNo;
+    if (tokIdx < 0 || tokIdx >= (int)forOp.getInitArgs().size())
+      return failure();
+
+    // Ensure the memory descriptor result of the alloc is only used inside the
+    // loop. Otherwise sinking would break users after the loop.
+    for (Operation *user : alloc.getResult().getUsers()) {
+      if (!forOp->isProperAncestor(user))
+        return failure();
+    }
+
+    BlockArgument tokArg = forOp.getRegionIterArg(tokIdx);
+
+    // Check if the op consuming the tocken fully overwrites the alloc. This
+    // means there is no loop carried values.
+    auto sinkable = useOverwritesAlloc(alloc, tokArg);
+    if (failed(sinkable))
+      return failure();
+    Operation *useOp = sinkable->useOp;
+
+    // Since the alloc is not used outside the loop its token should not be
+    // used.
+    assert(forOp.getResult(tokIdx).use_empty());
+
+    // Move the alloc just before the store to minimize live range inside the
+    // loop.
+    rewriter.moveOpBefore(alloc, useOp);
+    sinkable->dep.assign(alloc.getToken());
+
+    // Leave the token loop arguments to dead code.
+    auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+    yield.setOperand(tokIdx, forOp.getRegionIterArg(tokIdx));
+    rewriter.setInsertionPoint(forOp);
+    auto poisonTok = ub::PoisonOp::create(
+        rewriter, forOp.getLoc(), forOp.getInitArgs()[tokIdx].getType());
+    forOp.getInitArgsMutable()[tokIdx].assign(poisonTok);
+
+    return success();
+  }
+};
+
 // Given an operation that uses a token, return its forwarded token. This
 // assumes the memory variable is not loop carried.
 static Value getTokenFromOp(Operation *op) {
@@ -529,7 +631,7 @@ struct HoistTMEMAlloc
 
   void runOnOperation() override {
     ModuleOp m = getOperation();
-    if (!hoistOutOfIf) {
+    if (!postPipeline) {
       SmallVector<ttng::MMAv5OpInterface> mmaOps;
       m.walk([&](ttng::MMAv5OpInterface mmaOp) { mmaOps.push_back(mmaOp); });
       for (auto mmaOp : mmaOps) {
@@ -553,13 +655,23 @@ struct HoistTMEMAlloc
     patterns.add<RotateTMEMStoreInLoop, RotateTMEMLoadInLoop,
                  CombineTMEMLoadAndStore, CombineTMEMStoreAndSelect,
                  SinkTMEMLoad, RemoveUnusedTMEMLoad>(&getContext());
-    if (hoistOutOfIf) {
+    if (postPipeline) {
       patterns.add<CombineTMEMStoreAndAlloc, HoistTMEMAllocOutOfIf,
                    TMEMLoadForwarding>(&getContext());
     }
     scf::ForOp::getCanonicalizationPatterns(patterns, &getContext());
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       llvm_unreachable("Failed to hoist tmem_store");
+    }
+
+    // Finally try to sink the alloc that can be to reduce tmem liveranges.
+    if (postPipeline) {
+      mlir::RewritePatternSet postPatterns(&getContext());
+      postPatterns.add<SinkTMemAlloc>(&getContext());
+      if (failed(
+              applyPatternsGreedily(getOperation(), std::move(postPatterns)))) {
+        signalPassFailure();
+      }
     }
 
     // TODO: currently some code assumes that a mutable tmem alloc doesn't have

--- a/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
@@ -421,11 +421,12 @@ public:
   }
 };
 
-// Helper: return true if the value is a constant false boolean.
-static bool isConstFalse(Value v) {
+// Helper: return true if the value is a constant boolean with the expected
+// value.
+static bool isConstBool(Value v, bool expected) {
   if (auto cst = v.getDefiningOp<arith::ConstantOp>()) {
     if (auto attr = dyn_cast<BoolAttr>(cst.getValueAttr()))
-      return !attr.getValue();
+      return attr.getValue() == expected;
   }
   return false;
 }
@@ -443,14 +444,16 @@ static FailureOr<AllocUse> useOverwritesAlloc(ttng::TMEMAllocOp alloc,
   OpOperand &onlyUse = *tokArg.use_begin();
   Operation *useOp = onlyUse.getOwner();
   if (auto store = dyn_cast<ttng::TMEMStoreOp>(useOp)) {
-    if (store.getDst() != alloc.getResult())
+    if (store.getDst() != alloc.getResult() ||
+        !isConstBool(store.getPred(), true))
       return failure();
     return AllocUse{useOp, store.getDepMutable()};
   }
   if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(useOp)) {
     if (onlyUse.get() == mma.getAccDep() &&
         mma.getAccumulator() == alloc.getResult() &&
-        isConstFalse(mma.useAccumulator()))
+        isConstBool(mma.useAccumulator(), false) &&
+        isConstBool(mma.getPredicate(), true))
       return AllocUse{useOp, mma.getAccDepMutable()};
   }
   return failure();

--- a/test/TritonGPU/hoist-tmem-alloc.mlir
+++ b/test/TritonGPU/hoist-tmem-alloc.mlir
@@ -49,6 +49,58 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // POST-PIPELINE-LABEL: @do_not_sink_alloc_to_predicated_mma
+  // POST-PIPELINE: %[[ACC_TM:.*]], %[[ALLOC_TOK:.*]] = ttng.tmem_alloc : ()
+  // POST-PIPELINE: scf.for {{.*}} iter_args(%[[TOK:.*]] = %[[ALLOC_TOK]])
+  // POST-PIPELINE-NOT: ttng.tmem_alloc
+  // POST-PIPELINE:   %[[MMA_TOK:.*]] = ttng.tc_gen5_mma {{.*}}, {{.*}}, %[[ACC_TM]][%[[TOK]]]
+  tt.func public @do_not_sink_alloc_to_predicated_mma(%A: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>,
+                                                      %B: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>,
+                                                      %pred: i1,
+                                                      %iters: i32) {
+    %false = arith.constant false
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %acc_tm, %alloc_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %res_tok = scf.for %i = %c0_i32 to %iters step %c1_i32 iter_args(%tok = %alloc_tok) -> (!ttg.async.token)  : i32 {
+      %mma_tok = ttng.tc_gen5_mma %A, %B, %acc_tm[%tok], %false, %pred : !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      scf.yield %mma_tok : !ttg.async.token
+    }
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // POST-PIPELINE-LABEL: @do_not_sink_alloc_to_predicated_store
+  // POST-PIPELINE: %[[ACC_TM:.*]], %[[ALLOC_TOK:.*]] = ttng.tmem_alloc : ()
+  // POST-PIPELINE: scf.for {{.*}} iter_args(%[[TOK:.*]] = %[[ALLOC_TOK]])
+  // POST-PIPELINE-NOT: ttng.tmem_alloc
+  // POST-PIPELINE:   %[[STORE_TOK:.*]] = ttng.tmem_store {{.*}}, %[[ACC_TM]][%[[TOK]]], %{{.*}}
+  tt.func public @do_not_sink_alloc_to_predicated_store(%src: tensor<128x128xf32, #blocked>,
+                                                        %pred: i1,
+                                                        %iters: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %acc_tm, %alloc_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %res_tok = scf.for %i = %c0_i32 to %iters step %c1_i32 iter_args(%tok = %alloc_tok) -> (!ttg.async.token)  : i32 {
+      %store_tok = ttng.tmem_store %src, %acc_tm[%tok], %pred : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      scf.yield %store_tok : !ttg.async.token
+    }
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // POST-PIPELINE-LABEL: @sink_alloc_to_mma_use_acc_false
   // POST-PIPELINE: scf.for
   // POST-PIPELINE:   %[[ACC_TM:.*]], %[[ALLOC_TOK:.*]] = ttng.tmem_alloc : ()
@@ -57,6 +109,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
                                                   %B: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>,
                                                   %iters: i32) {
     %false = arith.constant false
+    %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32
     // Allocate accumulator outside the loop; it will be sunk next to the MMA
@@ -64,7 +117,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %res_tok = scf.for %i = %c0_i32 to %iters step %c1_i32 iter_args(%tok = %alloc_tok) -> (!ttg.async.token)  : i32 {
       // useAccumulator is false, so the accumulator source is ignored; the pattern
       // should accept this as fully overwriting the allocation and sink the alloc here.
-      %mma_tok = ttng.tc_gen5_mma %A, %B, %acc_tm[%tok], %false, %false : !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %mma_tok = ttng.tc_gen5_mma %A, %B, %acc_tm[%tok], %false, %true : !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       scf.yield %mma_tok : !ttg.async.token
     }
     tt.return


### PR DESCRIPTION
This allows sinking allocs back into the loop in case it is still possible. This does the reverse of alloc hoisting but it is okay since it is done after pipelining.
