### PR TITLE
Consider ext/broadcast later in slice for convert hoisting

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1303,8 +1303,7 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
     return;
 
   Operation *extOrBroadcastOp = nullptr;
-  unsigned sliceSize = slice.size();
-  for (unsigned i = 0; i < sliceSize; i++) {
+  for (unsigned i = 0; i < slice.size(); i++) {
     Value v = slice[i];
     Operation *op = v.getDefiningOp();
     if (!op || !isExtOrBroadcastOp(op))
@@ -1317,7 +1316,7 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
     // If we can rematerialize the rest of the ext slice we can ignore this ext
     // as it won't need a convert.
     if (succeeded(getRematerializableSlice(op->getOpOperand(0), srcEncoding,
-                                           slice, layout)))
+                                           slice, layout, isExtOrBroadcastOp)))
       continue;
 
     // Only apply it if there is a single ext op otherwise we would have to


### PR DESCRIPTION
Similar to `hoistConvertIntoConditionals`, extend the slice only up to the next ext/broadcast in each iteration. This allows us to hoist higher, since we can consider the highest such instruction in a chain.

It also makes some hoisting possible where previously no hoisting would have happened. This happens in the updated test, where it previously appeared that we have two exts that cannot be rematerialised, but with this change, one ext becomes rematerialisable because the slice between it and the other ext can be rematerialised. As a result, we end up hoisting the convert.