### PR TITLE
[Backend] Add print-changed support to LLVM_IR_ENABLE_DUMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ See [`python/triton/knobs.py`](python/triton/knobs.py) for the full list of conf
    kernels. Use `MLIR_ENABLE_DUMP=kernelName` to dump for a specific kernel only.
   - Triton cache can interfere with the dump. In cases where `MLIR_ENABLE_DUMP=1` does not work, try cleaning your triton cache: `rm -r ~/.triton/cache/*`.
 - `MLIR_DUMP_PATH` specifies where `MLIR_ENABLE_DUMP` will dump to. If unset will dump to stderr.
-- `LLVM_IR_ENABLE_DUMP=1` dumps the IR before every pass run over the LLVM IR.
+- `LLVM_IR_ENABLE_DUMP` dumps LLVM IR during compilation. Set to `1` to dump IR
+  after every pass (print-after-all), or set to `print-changed` to only dump IR
+  when a pass modifies it (less verbose).
 - `TRITON_REPRODUCER_PATH=<reproducer_path>` will generate an MLIR reproducer file
   at `<reproducer_path>` before each MLIR compiler stage. If any of the stages fail,
   `<reproducer_path>` will be a local MLIR reproducer captured right before the failing pass.


### PR DESCRIPTION
As a llvm developer, -print-after-all and -debug are helpful for debugging, however there's a handy option: -print-changed which prints the IR "only if" the pass makes changes.

Note: This patch only add minimal support of -print-changed and prevent introducing new environment variable but reuse existing one.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it only adds a debug option`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
