### PR TITLE
[WIP] Triton Tensor sharding

### DIFF
--- a/python/triton/tools/ragged_tma.py
+++ b/python/triton/tools/ragged_tma.py
@@ -5,7 +5,7 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 # fmt: off
 
 
-def create_ragged_descriptor(T, block_shape, ragged_dim=0):
+def create_ragged_descriptor(T, block_shape, ragged_dim=0) -> TensorDescriptor:
     """
     Given a 2- or 3-dimensional tensor T, this creates a 'ragged descriptor'
     which behaves like a concatenation (along the first axis) of subarrays

--- a/python/triton_kernels/pyproject.toml
+++ b/python/triton_kernels/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "triton_kernels"
 version = "1.0.0"
-dependencies = ["numpy", "pytest"]
+dependencies = ["numpy", "pytest", "typing-extensions", "torch"]
 
 [project.optional-dependencies]
 tests = ["llnl-hatchet", "matplotlib", "pandas"]

--- a/python/triton_kernels/triton_kernels/compaction.py
+++ b/python/triton_kernels/triton_kernels/compaction.py
@@ -3,7 +3,12 @@ from .compaction_details._masked_compaction import _masked_compaction
 from .tensor import Tensor
 
 
-def compaction(yv, yi, bitmask, sentinel=-1):
+def compaction(
+    yv: torch.Tensor,
+    yi: torch.Tensor,
+    bitmask: torch.Tensor | Tensor,  # REVIEW: torch.Tensor or triton_kernels.Tensor
+    sentinel: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Return compacted copies of *yv* and *yi* based on a per-row bitmask.
 
@@ -44,7 +49,12 @@ def compaction(yv, yi, bitmask, sentinel=-1):
     return ret_yv, ret_yi
 
 
-def compaction_torch(yv: torch.Tensor, yi: torch.Tensor, bitmask: torch.Tensor, sentinel=-1):
+def compaction_torch(
+    yv: torch.Tensor,
+    yi: torch.Tensor,
+    bitmask: torch.Tensor,
+    sentinel: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     reference implementation of `masked_compact`
     """

--- a/python/triton_kernels/triton_kernels/distributed_details/comms.py
+++ b/python/triton_kernels/triton_kernels/distributed_details/comms.py
@@ -1,0 +1,39 @@
+from typing import Callable
+
+from .shmem import Shmem
+
+_COMMS: dict[str, Callable[[], Shmem]] = {}
+
+try:
+    from .nvshmem import init_comms as _nv_init_comms
+
+    _COMMS["nccl"] = _nv_init_comms
+except Exception:
+    pass
+
+_SHMEM_BACKEND: str | None = None
+_SHMEM: Shmem | None = None
+
+
+def init_comms(backend: str) -> Shmem:
+    global _SHMEM_BACKEND
+    global _SHMEM
+
+    if _SHMEM_BACKEND is not None:
+        if _SHMEM_BACKEND != backend:
+            raise ValueError(f"init_comms() previously called with different backend {_SHMEM_BACKEND}, now {backend}")
+        assert _SHMEM is not None
+        return _SHMEM
+
+    init_fn = _COMMS.get(backend)
+    if init_fn is None:
+        raise ValueError(f"Comms backend {backend} not registered")
+    _SHMEM = init_fn()
+    _SHMEM_BACKEND = backend
+    return _SHMEM
+
+
+def shmem() -> Shmem:
+    if _SHMEM is None:
+        raise ValueError("init_comms() has not been called")
+    return _SHMEM

--- a/python/triton_kernels/triton_kernels/distributed_details/mesh.py
+++ b/python/triton_kernels/triton_kernels/distributed_details/mesh.py
@@ -1,27 +1,171 @@
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from functools import cache
+from math import prod
+from typing import Iterator, override
+
 import torch
 import torch.distributed as dist
-import torch.distributed._symmetric_memory as symm_mem
-from dataclasses import dataclass
-from typing import Tuple
-from math import prod
+
+from .comms import shmem
+from .shmem import Buffer, Collective, NoOpShmem
 
 # ------------------------------------------------------------
 # Symmetric memory pool
 # ------------------------------------------------------------
 
 
-class Mesh:
+class ProcessGroup(ABC):
+    _shmem_collective: Collective | None
 
-    def __init__(self, process_group: dist.ProcessGroup):
-        self.process_group = process_group
-        self.world_size = dist.get_world_size(process_group)
-        self.local_rank = dist.get_rank(process_group)
+    @property
+    def shmem_collective(self) -> Collective:
+        c = self._shmem_collective
+        if c is None:
+            raise ValueError("Must be group member")
+        return c
+
+    @property
+    def is_group_member(self) -> bool:
+        return self._shmem_collective is not None
+
+    def check_group_member(self) -> None:
+        _ = self.shmem_collective
+
+    @property
+    @abstractmethod
+    def local_rank(self) -> int:
+        ...
+
+    @property
+    def global_rank(self):
+        return default_process_group().local_rank
+
+    @property
+    @abstractmethod
+    def world_size(self) -> int:
+        ...
+
+    @abstractmethod
+    def get_global_rank(self, group_rank: int) -> int:
+        ...
+
+    @abstractmethod
+    def get_group_rank(self, global_rank: int) -> int:
+        ...
+
+    def sync(self) -> None:
+        self.shmem_collective.sync()
+
+    def barrier(self) -> None:
+        self.shmem_collective.barrier()
 
 
-class MockSymmetricMemoryHandle:
+class LocalProcessGroup(ProcessGroup):
 
-    def barrier(self, channel: int = 0):
-        pass
+    def __init__(self):
+        self._shmem_collective = NoOpShmem()
+
+    @property
+    @override
+    def local_rank(self) -> int:
+        return 0
+
+    @property
+    @override
+    def world_size(self) -> int:
+        return 1
+
+    @override
+    def get_global_rank(self, group_rank: int) -> int:
+        if group_rank == 0:
+            return self.global_rank
+        raise ValueError(f"The only valid rank in local meshes is 0, not {group_rank}")
+
+    @override
+    def get_group_rank(self, global_rank: int) -> int:
+        if global_rank == self.global_rank:
+            return 0
+        raise ValueError(f"Rank {global_rank} is not local")
+
+
+class TorchProcessGroup(ProcessGroup):
+    torch_process_group: dist.ProcessGroup
+
+    def __init__(self, process_group: dist.ProcessGroup | None = None) -> None:
+        assert dist.is_initialized(), "torch_process_group() called before initialization"
+
+        if process_group is None:
+            process_group = dist.group.WORLD
+            assert process_group is not None
+
+        self.torch_process_group = process_group
+
+        if process_group == dist.GroupMember.NON_GROUP_MEMBER:
+            self._shmem_collective = None
+        elif process_group is dist.group.WORLD:
+            self._shmem_collective = shmem()
+        else:
+            team = shmem().create_team(process_group)
+            assert team is not None, "BUG: team is None on group member"
+            self._shmem_collective = team
+
+    @property
+    @override
+    def local_rank(self) -> int:
+        self.check_group_member()
+        return dist.get_rank(self.torch_process_group)
+
+    @property
+    @override
+    def world_size(self) -> int:
+        self.check_group_member()
+        return dist.get_world_size(self.torch_process_group)
+
+    @override
+    def get_global_rank(self, group_rank: int) -> int:
+        self.check_group_member()
+        return dist.get_global_rank(self.torch_process_group, group_rank)
+
+    @override
+    def get_group_rank(self, global_rank: int) -> int:
+        self.check_group_member()
+        return dist.get_group_rank(self.torch_process_group, global_rank)
+
+
+@cache
+def default_process_group() -> ProcessGroup:
+    return TorchProcessGroup()
+
+
+@cache
+def local_process_group() -> ProcessGroup:
+    return LocalProcessGroup()
+
+
+def torch_process_group(process_group: dist.ProcessGroup) -> ProcessGroup:
+    return TorchProcessGroup(process_group=process_group)
+
+
+_CURRENT_PROCESS_GROUP = ContextVar[ProcessGroup | None](__name__ + "._CURRENT_MESH", default=None)
+
+
+def current_process_group() -> ProcessGroup:
+    pg = _CURRENT_PROCESS_GROUP.get()
+    return pg if pg is not None else default_process_group()
+
+
+@contextmanager
+def process_group(pg: ProcessGroup) -> Iterator[ProcessGroup]:
+    # In Python 3.14, this won't be necessary, as the token returned by ContextVar.set
+    # is already a context manager
+    token = _CURRENT_PROCESS_GROUP.set(pg)
+    try:
+        yield pg
+    finally:
+        _CURRENT_PROCESS_GROUP.reset(token)
 
 
 @dataclass
@@ -32,15 +176,24 @@ class _MemoryRegion:
 
 
 class SymmetricMemoryPool:
+    _is_initialized: bool
+    size: int
+    shmem_buffer: Buffer | None = None
+    bufs: tuple[torch.Tensor, ...]
+    regions: dict[str, _MemoryRegion]
+    process_group: TorchProcessGroup
 
-    def __init__(self, mesh: Mesh):
+    def __init__(self, process_group: ProcessGroup | None = None) -> None:
+        if process_group is None:
+            process_group = current_process_group()
+        if not isinstance(process_group, TorchProcessGroup):
+            raise ValueError(
+                f"SymmetricMemoryPool() requires the current process group to be TorchProcessGroup, not {type(process_group)}"
+            )
+
         self._is_initialized = False
-        self.size = 0
-        self.buf = None
-        self.bufs = None
-        self.hdl = None
         self.regions = {}
-        self.mesh = mesh
+        self.process_group = process_group
 
     @staticmethod
     def align_up(value: int, alignment: int) -> int:
@@ -60,40 +213,42 @@ class SymmetricMemoryPool:
         self.regions[name] = _MemoryRegion(base=base, size=size_aligned, alignment=alignment)
         return end
 
-    def make_empty(
+    def get_tensors(
         self,
-        shape: Tuple[int, ...],
+        shape: tuple[int, ...],
         dtype: torch.dtype,
         region: str,
-        region_offset: int = 0,
         clear: bool = False,
-    ) -> Tuple[torch.Tensor, ...]:
+    ) -> tuple[torch.Tensor, ...]:
         """
-        Allocate symmetric tensors from a reserved region.
+        Get symmetric tensors from a reserved region.
 
         Args:
             shape: Shape of the tensor to allocate.
             dtype: Data type of the tensor to allocate.
             region: Name of the reserved region to allocate from.
-            region_offset: Offset (in bytes) within the region to allocate from.
             clear: If True, zero out the allocated tensors.
         Returns:
             A tuple of tensors, one per rank in the process group.
         """
         if not self._is_initialized:
             raise RuntimeError("SymmetricMemoryPool is not initialized")
+        if not self.process_group.is_group_member:
+            raise RuntimeError("get_tensors() called on non-group member")
 
         region_info = self.regions.get(region)
         if region_info is None:
             raise ValueError(f"Region {region} not found")
 
         elem_size = torch.empty((), dtype=dtype).element_size()
-        if region_offset % elem_size != 0:
-            raise ValueError(f"Region offset {region_offset} not aligned to element size {elem_size}")
+        if region_info.base % elem_size != 0:
+            raise ValueError(f"Region base {region_info.base} not aligned to element size {elem_size}")
+        if region_info.alignment % elem_size != 0:
+            raise ValueError(f"Region alignment {region_info.alignment} not compatible with element size {elem_size}")
 
         numel = prod(shape)
         nbytes = numel * elem_size
-        region_start = region_info.base + region_offset
+        region_start = region_info.base
         region_end = region_info.base + region_info.size
 
         if region_start + nbytes > region_end:
@@ -102,38 +257,46 @@ class SymmetricMemoryPool:
             )
 
         tensors = []
-        for buf in self.bufs:
+        for i, buf in enumerate(self.bufs):
             storage = buf.untyped_storage()
             total = storage.nbytes()
-            if region_start + nbytes > total:
-                raise ValueError(f"Slice [{region_start}:{region_start + nbytes}) exceeds storage size {total} bytes.")
+            assert region_start + nbytes <= total, (
+                f"BUG: Slice [{region_start}:{region_start + nbytes}) exceeds storage size {total} bytes.")
             tensor = torch.empty(0, dtype=dtype, device=buf.device)
-            tensor.set_(storage, region_start // elem_size, torch.Size(shape))
-            if clear:
+
+            # the torch docs say that stride is optional
+            tensor.set_(storage, buf.storage_offset() + region_start // elem_size, torch.Size(shape))  # type: ignore
+            if clear and i == self.process_group.local_rank:
                 tensor.zero_()
             tensors.append(tensor)
+        if clear:
+            self.process_group.barrier()
 
         return tuple(tensors)
 
-    def _initialize(
-        self,
-        device: torch.device,
-    ) -> None:
+    def _initialize(self, ) -> None:
         if self._is_initialized:
             return
 
         self.size = int(sum(region.size for region in self.regions.values()))
-        if self.mesh.world_size > 1:
-            self.buf = symm_mem.empty((self.size, ), dtype=torch.uint8, device=device)
-            self.hdl = symm_mem.rendezvous(self.buf, group=self.mesh.process_group)
-            self.bufs = tuple(
-                self.hdl.get_buffer(r, self.buf.shape, self.buf.dtype) for r in range(self.mesh.world_size))
-            self.hdl.barrier(channel=0)
+        if not self.process_group.is_group_member:
+            self.bufs = ()
+        elif isinstance(self.process_group, LocalProcessGroup):
+            buf = torch.empty((self.size, ), dtype=torch.uint8)
+            self.bufs = (buf, )
         else:
-            self.buf = torch.empty((self.size, ), dtype=torch.uint8, device=device)
-            self.hdl = MockSymmetricMemoryHandle()
-            self.bufs = (self.buf, )
+            self.shmem_buffer = shmem().allocate(self.size)
+            self.bufs = tuple(
+                self.shmem_buffer.peer_buffer(self.process_group.get_global_rank(r))
+                for r in range(self.process_group.world_size))
+            self.process_group.barrier()
+
         self._is_initialized = True
+
+    def free(self) -> None:
+        if self.shmem_buffer is not None:
+            self.shmem_buffer.free()
+            self.shmem_buffer = None
 
     def initialize_matmul(
         self,
@@ -143,24 +306,34 @@ class SymmetricMemoryPool:
         n_expts_act: int,
         n_expts_tot: int,
         dtype: torch.dtype,
-        device: torch.device,
     ) -> None:
         if self._is_initialized:
             return
 
         BLOCK_N = 32
         BLOCK_M = 32
-        n_bytes_topk = n_tokens_global * n_expts_act * 4  # topk logits (float32): pessimistic estimate
-        n_bytes_topk += n_tokens_global * n_expts_act * 2  # topk indx (int16)
+        n_bytes_topk_vals = (n_tokens_global * n_expts_act * 4)  # topk logits (float32): pessimistic estimate
+        n_bytes_topk_indx = n_tokens_global * n_expts_act * 2  # topk indx (int16)
         cdiv = lambda x, y: (x + y - 1) // y
         num_blocks_m = cdiv(n_tokens_global, BLOCK_M)
         num_blocks_n = cdiv(n_expts_tot, BLOCK_N)
-        n_bytes_topk += num_blocks_m * BLOCK_M * num_blocks_n * BLOCK_N // 32 * 4  # expt bitmatrix (int32)
+        n_bytes_topk_bitmatrix = (num_blocks_m * BLOCK_M * num_blocks_n * BLOCK_N // 32 * 4)  # expt bitmatrix (int32)
         elem_size = torch.empty((), dtype=dtype).element_size()
         n_bytes_dp_to_ep = n_tokens_global * n_expts_act * d_input * elem_size
-        n_bytes_ep_to_dp = (n_tokens_global // self.mesh.world_size) * n_expts_act * d_model * elem_size
+        n_bytes_ep_to_dp = ((n_tokens_global // self.process_group.world_size) * n_expts_act * d_model * elem_size)
 
-        offset = self._reserve_region("topk", n_bytes_topk, 128, 0)
+        offset = self._reserve_region("topk_vals", n_bytes_topk_vals, 128, 0)
+        offset = self._reserve_region("topk_y_indx", n_bytes_topk_indx, 128, offset)
+        offset = self._reserve_region("topk_bitmatrix", n_bytes_topk_bitmatrix, 128, offset)
         offset = self._reserve_region("ep_to_dp", n_bytes_ep_to_dp, 128, offset)
         offset = self._reserve_region("dp_to_ep", n_bytes_dp_to_ep, 128, offset)
-        self._initialize(device=device)
+        self._initialize()
+
+
+@contextmanager
+def symmetric_memory_pool(process_group: ProcessGroup | None = None, ) -> Iterator[SymmetricMemoryPool]:
+    pool = SymmetricMemoryPool(process_group=process_group)
+    try:
+        yield pool
+    finally:
+        pool.free()

--- a/python/triton_kernels/triton_kernels/distributed_details/nvshmem.py
+++ b/python/triton_kernels/triton_kernels/distributed_details/nvshmem.py
@@ -1,0 +1,120 @@
+from dataclasses import dataclass
+from typing import Any, cast, override
+
+import nvshmem.core as nvshmem
+import nvshmem.core.interop.torch as nvshmem_torch
+import torch
+import torch.cuda
+import torch.distributed as tdist
+from cuda.core.experimental import Device  # type: ignore
+
+from .shmem import Buffer, Shmem, Team
+
+
+@dataclass
+class NVTeam(Team):
+    _h: Any
+
+    @override
+    def sync(self) -> None:
+        s = nvshmem.NvshmemStream(torch.cuda.current_stream())
+        nvshmem.sync(self._h, s)
+
+    @override
+    def barrier(self) -> None:
+        s = nvshmem.NvshmemStream(torch.cuda.current_stream())
+        nvshmem.barrier(self._h, s)
+
+
+@dataclass
+class NVBuffer(Buffer):
+    _local_tensor: torch.Tensor
+
+    @property
+    @override
+    def buffer(self) -> torch.Tensor:
+        return self._local_tensor
+
+    @override
+    def peer_buffer(self, global_rank: int) -> torch.Tensor:
+        if global_rank == nvshmem.my_pe():
+            return self.buffer
+
+        return cast(torch.Tensor, nvshmem.get_peer_tensor(self._local_tensor, global_rank))
+
+    @override
+    def free(self):
+        # TODO(tudor): Do not free. There is a bug in nvshmem4py whose fix is awaiting release
+        # as of 2/10/2026.
+        # nvshmem_torch.free_tensor(self._local_tensor)
+        pass
+
+
+class NVShmem(Shmem):
+
+    @override
+    def create_team(self, process_group: tdist.ProcessGroup) -> Team | None:
+        local_rank = tdist.get_rank(process_group)
+        if local_rank == -1:
+            # Not a member of the group; does not need to participate in team creation.
+            return None
+
+        uids = [nvshmem.get_team_unique_id() if local_rank == 0 else None]
+        tdist.broadcast_object_list(uids, src=tdist.get_global_rank(process_group, 0), group=process_group)
+
+        config = nvshmem.TeamConfig()
+        config.version = 2
+        config.num_contexts = 1
+        config.uniqueid = uids[0]
+
+        team = nvshmem.team_init(
+            team_config=config,
+            config_mask=0,
+            npes=tdist.get_world_size(process_group),
+            pe_idx_in_team=local_rank,
+        )
+
+        return NVTeam(
+            process_group=process_group,
+            _h=team,
+        )
+
+    @override
+    def allocate(self, size: int) -> Buffer:
+        # TODO: alignment? nvshmem_torch doesn't have alignment APIs
+        t = cast(torch.Tensor, nvshmem_torch.bytetensor(shape=(size, )))
+        return NVBuffer(_local_tensor=t)
+
+    @override
+    def sync(self) -> None:
+        s = nvshmem.NvshmemStream(torch.cuda.current_stream())
+        nvshmem.sync_all(s)
+
+    @override
+    def barrier(self) -> None:
+        s = nvshmem.NvshmemStream(torch.cuda.current_stream())
+        nvshmem.barrier_all(s)
+
+
+def init_comms() -> NVShmem:
+    if not tdist.is_initialized():
+        raise ValueError("Call torch.distributed.init_process_group() first")
+
+    rank = tdist.get_rank()
+
+    # TODO: this assumes the same GPU count for every node.
+    device_idx = rank % torch.cuda.device_count()
+    torch.cuda.set_device(torch.device(type="cuda", index=device_idx))
+
+    uids = [nvshmem.get_unique_id() if rank == 0 else None]
+    tdist.broadcast_object_list(uids, src=0)
+
+    nvshmem.init(
+        device=Device(device_idx),
+        uid=uids[0],
+        rank=rank,
+        nranks=tdist.get_world_size(),
+        initializer_method="uid",
+    )
+
+    return NVShmem()

--- a/python/triton_kernels/triton_kernels/distributed_details/shmem.py
+++ b/python/triton_kernels/triton_kernels/distributed_details/shmem.py
@@ -1,0 +1,77 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Never, override
+
+import torch
+import torch.distributed as tdist
+
+
+class Collective(ABC):
+    """Base class for collective operations."""
+
+    @abstractmethod
+    def sync(self) -> None:
+        ...
+
+    @abstractmethod
+    def barrier(self) -> None:
+        ...
+
+
+@dataclass
+class Team(Collective):
+    """Team (process group).
+
+    Maps 1:1 to a torch ProcessGroup; rank i in the team map 1:1 to ranks in the ProcessGroup."""
+
+    process_group: tdist.ProcessGroup
+
+
+class Buffer(ABC):
+    """Buffer; represents a symmetric ByteTensor."""
+
+    @property
+    @abstractmethod
+    def buffer(self) -> torch.Tensor:
+        ...
+
+    @abstractmethod
+    def peer_buffer(self, global_rank: int) -> torch.Tensor:
+        ...
+
+    @abstractmethod
+    def free(self) -> None:
+        """Free the buffer; explicit deallocation is required."""
+        ...
+
+
+class Shmem(Collective):
+
+    @abstractmethod
+    def create_team(self, process_group: tdist.ProcessGroup) -> Team | None:
+        """Create a team with the same members as `process_group`."""
+        ...
+
+    @abstractmethod
+    def allocate(self, size: int) -> Buffer:
+        """Allocate a symmetric buffer of given size."""
+        ...
+
+
+class NoOpShmem(Shmem):
+
+    @override
+    def create_team(self, process_group: tdist.ProcessGroup) -> Never:
+        raise NotImplementedError()
+
+    @override
+    def allocate(self, size: int) -> Never:
+        raise NotImplementedError()
+
+    @override
+    def sync(self) -> None:
+        pass
+
+    @override
+    def barrier(self) -> None:
+        pass

--- a/python/triton_kernels/triton_kernels/numerics.py
+++ b/python/triton_kernels/triton_kernels/numerics.py
@@ -1,5 +1,7 @@
-import torch
 from dataclasses import dataclass
+from typing import Iterator
+
+import torch
 
 # ------ global scaling -------
 
@@ -12,12 +14,12 @@ MAX_FINITE_FLOAT8E4B8 = 240.0
 class BaseFlexData:
     dtype: torch.dtype | None = None
 
-    def view(self, x: torch.Tensor):
+    def view(self, x: torch.Tensor) -> torch.Tensor:
         if self.dtype is None:
             return x
         return x.view(self.dtype)
 
-    def reinterpret(self, x):
+    def reinterpret(self, x: torch.Tensor) -> torch.Tensor:
         if self.dtype is None or x.dtype.itemsize > 1:
             return x
         return x.view(self.dtype)
@@ -28,7 +30,7 @@ class InFlexData(BaseFlexData):
     scale: torch.Tensor | None = None
 
     @property
-    def is_per_batch(self):
+    def is_per_batch(self) -> bool:
         return False if self.scale is None else len(self.scale) > 1
 
 
@@ -39,10 +41,10 @@ class OutFlexData(BaseFlexData):
     checksum_scale: torch.Tensor | None = None
 
     @property
-    def is_per_batch(self):
+    def is_per_batch(self) -> bool:
         return False if self.expected_scale is None else len(self.expected_scale) > 1
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[torch.Tensor | None]:
         yield self.expected_scale
         yield self.actual_scale
         yield self.checksum_scale

--- a/python/triton_kernels/triton_kernels/op.py
+++ b/python/triton_kernels/triton_kernels/op.py
@@ -1,0 +1,60 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable, ParamSpec, TypeVar
+
+from .tensor import Tensor
+from .tensor_types import TypeAssertion
+
+
+def _format_callable(func: Any) -> str:
+    unwrapped = inspect.unwrap(func)
+    module = inspect.getmodule(unwrapped)
+    qualname = getattr(unwrapped, "__qualname__", repr(unwrapped))
+    if module is None:
+        return qualname
+    return f"{module.__name__}.{qualname}"
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+@dataclass(kw_only=True)
+class Op:
+    # Type assertions for all tensor arguments; required for all tensor arguments.
+    types: dict[str, TypeAssertion] = field(default_factory=dict)
+
+    def __call__(self, forward: Callable[P, R]) -> Callable[P, R]:
+
+        def apply(*args: P.args, **kwargs: P.kwargs) -> R:
+            """Type-check and forward to wrapped function."""
+            func_name: str | None = None
+
+            def get_func_name() -> str:
+                nonlocal func_name
+                if func_name is None:
+                    func_name = _format_callable(forward)
+                return func_name
+
+            sig = inspect.signature(forward)
+            bound_args = sig.bind(*args, **kwargs)
+            bound_args.apply_defaults()
+
+            for name, value in bound_args.arguments.items():
+                is_tensor = isinstance(value, Tensor)
+                type_assertion = self.types.get(name)
+
+                if is_tensor:
+                    if type_assertion is None:
+                        raise ValueError(f"{get_func_name()}: parameter {name} is a tensor, but has no type assertion")
+                    check_result = type_assertion.is_valid(value)
+                    if not check_result:
+                        raise ValueError(f"{get_func_name()}: parameter {name}: type assertion failed: {check_result}")
+                elif type_assertion is not None:
+                    raise ValueError(
+                        f"{get_func_name()}: parameter {name} has type assertion, but is not a tensor (it is {type(value)})"
+                    )
+
+            return forward(*bound_args.args, **bound_args.kwargs)
+
+        return apply

--- a/python/triton_kernels/triton_kernels/proton_opts.py
+++ b/python/triton_kernels/triton_kernels/proton_opts.py
@@ -2,16 +2,16 @@
 
 import os
 
-_launch_metadata_allow_sync = None
+_launch_metadata_allow_sync: bool | None = None
 
 
-def launch_metadata_allow_sync():
+def launch_metadata_allow_sync() -> bool:
     global _launch_metadata_allow_sync
     if _launch_metadata_allow_sync is None:
         _launch_metadata_allow_sync = not (os.getenv("PROTON_LAUNCH_METADATA_NOSYNC") == "1")
     return _launch_metadata_allow_sync
 
 
-def set_launch_metadata_allow_sync(allow_sync: bool):
+def set_launch_metadata_allow_sync(allow_sync: bool) -> None:
     global _launch_metadata_allow_sync
     _launch_metadata_allow_sync = allow_sync

--- a/python/triton_kernels/triton_kernels/target_info.py
+++ b/python/triton_kernels/triton_kernels/target_info.py
@@ -68,5 +68,5 @@ def has_native_mxfp():
     return cuda_capability_geq(10, 0)
 
 
-def num_sms():
+def num_sms() -> int:
     return torch.cuda.get_device_properties(0).multi_processor_count

--- a/python/triton_kernels/triton_kernels/tensor_details/bitmatrix_details/sum_bitmatrix_rows.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/bitmatrix_details/sum_bitmatrix_rows.py
@@ -34,21 +34,31 @@ def vpopc(x):
         sa2: tl.constexpr = BLOCK_N // sa1
     # create 128-way sums in 8-bit fields:
     y = tl.reshape(y, [BATCHES, BLOCK_N // (sa1 * sa2), sa2, 1, 4])
-    y = (y >> (4 * tl.arange(0, 2))[None, None, None, :, None]) & 0x0f0f0f0f
+    y = (y >> (4 * tl.arange(0, 2))[None, None, None, :, None]) & 0x0F0F0F0F
     y = tl.sum(y, 2)  # [BATCHES, BLOCK_N // (sa1 * sa2), 2, 4]
     sa3: tl.constexpr = BLOCK_N // (sa1 * sa2)
     # create N-way sums in 32-bit fields:
     y = tl.reshape(y, [BATCHES, 1, sa3, 8])
-    y = (y >> (8 * tl.arange(0, 4))[None, :, None, None]) & 0x000000ff
+    y = (y >> (8 * tl.arange(0, 4))[None, :, None, None]) & 0x000000FF
     y = tl.sum(y, 2)  # [BATCHES, 4, 8]
     y = tl.reshape(y, x.shape[:-1] + [32])
     return y
 
 
 @triton.jit
-def _sum_bitmatrix_rows(B, shape_bm, stride_bm: tl.constexpr, stride_bn: tl.constexpr,  # input bitmatrix
-                        Out, OutPartials, stride_pm: tl.constexpr, stride_pn, shape_pn,  # outputs
-                        BLOCK_MM: tl.constexpr, BLOCK_M: tl.constexpr):
+def _sum_bitmatrix_rows(
+    B,
+    shape_bm,
+    stride_bm: tl.constexpr,
+    stride_bn: tl.constexpr,  # input bitmatrix
+    Out,
+    OutPartials,
+    stride_pm: tl.constexpr,
+    stride_pn,
+    shape_pn,  # outputs
+    BLOCK_MM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
     tl.static_assert(BLOCK_MM % BLOCK_M == 0)
     TILE_SIZE: tl.constexpr = BLOCK_MM // BLOCK_M
     if isinstance(shape_bm, tl.tensor) and shape_bm.dtype.is_ptr():
@@ -77,23 +87,30 @@ def sum_bitmatrix_rows(x, partials_block_size=None):
     assert partials_block_size is not None
     PARTIALS_BLOCK_M = partials_block_size
     n_rows, n_cols = x.shape
-    n_rows_max = x.shape_max[0]
+    n_rows_max = x.local_shape_max[0]
 
     TILE_SIZE = max(1, 128 // PARTIALS_BLOCK_M)
     BLOCK_MM = PARTIALS_BLOCK_M * TILE_SIZE
 
     grid_m = cdiv(n_rows_max, BLOCK_MM)
     grid_n = cdiv(n_cols, 32)
-    out = torch.zeros((cdiv(n_cols, 128) * 128, ), device=x.device, dtype=torch.int32)[:n_cols]
-    out_partials = torch.empty((grid_n * 32, grid_m * TILE_SIZE), device=x.device, dtype=torch.int32)
+    out = torch.zeros((cdiv(n_cols, 128) * 128, ), device=x.storage.data.device, dtype=torch.int32)[:n_cols]
+    out_partials = torch.empty((grid_n * 32, grid_m * TILE_SIZE), device=x.storage.data.device, dtype=torch.int32)
     out_partials = torch.transpose(out_partials, 0, 1)
     # output tensors
     _sum_bitmatrix_rows[(grid_m, grid_n)](
-        x.storage.data, n_rows, x.stride(0), x.stride(1),  # input
+        x.storage.data,
+        n_rows,
+        x.storage.data.stride(0),
+        x.storage.data.stride(1),  # input
         out,  # output [final reduction]
-        out_partials, out_partials.stride(0), out_partials.stride(1),
+        out_partials,
+        out_partials.stride(0),
+        out_partials.stride(1),
         out_partials.shape[1],  # output [partial reductions]
-        BLOCK_M=PARTIALS_BLOCK_M, BLOCK_MM=BLOCK_MM,  # constants
-        num_warps=8)
+        BLOCK_M=PARTIALS_BLOCK_M,
+        BLOCK_MM=BLOCK_MM,  # constants
+        num_warps=8,
+    )
     out_partials = out_partials[:cdiv(n_rows_max, PARTIALS_BLOCK_M), :]
     return out, out_partials

--- a/python/triton_kernels/triton_kernels/tensor_details/layout.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout.py
@@ -7,6 +7,7 @@ from .layout_details.hopper_value import HopperMXValueLayout
 from .layout_details.cdna4_scale import CDNA4MXScaleLayout
 from .layout_details.strided import StridedLayout
 from ..target_info import cuda_capability_geq, is_hip_cdna4
+from .ragged_tensor import RaggedTensorMetadata
 
 __all__ = [
     "Layout",
@@ -20,7 +21,7 @@ __all__ = [
 ]
 
 
-def make_default_matmul_mxfp4_w_layout(mx_axis: int):
+def make_default_matmul_mxfp4_w_layout(mx_axis: int) -> Layout:
     if cuda_capability_geq(10):
         return BlackwellMXValueLayout()
     elif cuda_capability_geq(9):
@@ -29,7 +30,7 @@ def make_default_matmul_mxfp4_w_layout(mx_axis: int):
         return StridedLayout(-2)
 
 
-def make_default_matmul_mxfp4_w_scale_layout(mx_axis: int, num_warps: int = 8):
+def make_default_matmul_mxfp4_w_scale_layout(mx_axis: int, num_warps: int = 8) -> Layout:
     if is_hip_cdna4():
         return CDNA4MXScaleLayout()
     else:
@@ -41,7 +42,7 @@ def make_default_matmul_mxfp4_w_scale_layout(mx_axis: int, num_warps: int = 8):
     return StridedLayout(-2)
 
 
-def make_default_matmul_mxfp8_act_scale_layout(ragged_metadata):
+def make_default_matmul_mxfp8_act_scale_layout(ragged_metadata: RaggedTensorMetadata, ) -> Layout:
     if cuda_capability_geq(10):
         return BlackwellActMXScaleLayout(ragged_metadata)
     return StridedLayout(-2)

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/base.py
@@ -1,29 +1,31 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Sequence
+
+import torch
 
 
 @dataclass(frozen=True)
 class LayoutTransformation(ABC):
-
     shape: list[int]
     is_fp4: bool
 
     @abstractmethod
-    def swizzle_data(self, data):
-        pass
+    def swizzle_data(self, data: torch.Tensor) -> torch.Tensor:
+        ...
 
     @abstractmethod
-    def unswizzle_data(self, data):
-        pass
+    def unswizzle_data(self, data: torch.Tensor) -> torch.Tensor:
+        ...
 
 
 @dataclass(frozen=True)
 class Layout(ABC):
 
     @abstractmethod
-    def make_transformation(self, shape: list[int]) -> LayoutTransformation:
-        pass
+    def make_transformation(self, shape: list[int], is_fp4: bool) -> LayoutTransformation:
+        ...
 
     @abstractmethod
-    def swizzle_block_shape(self, block_shape):
-        pass
+    def swizzle_block_shape(self, block_shape: Sequence[int]) -> Sequence[int]:
+        ...

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -21,7 +21,7 @@ class StridedLayout(Layout):
     # `major_dim == R - 1`.
     major_dim: int = -1
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not isinstance(self.major_dim, int):
             raise TypeError(f"StridedLayout(major_dim=...) must be an int, got {type(self.major_dim)}")
 
@@ -29,10 +29,10 @@ class StridedLayout(Layout):
         return StridedLayoutTransformation(shape, is_fp4, self.order(len(shape)))
 
     @property
-    def name(self):
+    def name(self) -> str:
         return "STRIDED"
 
-    def swizzle_block_shape(self, block_shape):
+    def swizzle_block_shape(self, block_shape: list[int]) -> list[int]:
         return block_shape
 
     def order(self, rank: int) -> list[int]:
@@ -59,7 +59,7 @@ class StridedLayoutTransformation(LayoutTransformation):
 
     order: list[int]
 
-    def swizzle_data(self, data):
+    def swizzle_data(self, data: torch.Tensor) -> torch.Tensor:
         assert data.stride(-1) == 1
         r = len(self.shape)
         if r == 0:
@@ -76,7 +76,7 @@ class StridedLayoutTransformation(LayoutTransformation):
         repack(data, -1, pd, self.is_fp4, out=out)
         return out
 
-    def unswizzle_data(self, data):
+    def unswizzle_data(self, data: torch.Tensor) -> torch.Tensor:
         assert data.stride(self.order[0]) == 1
         out_shape = list(self.shape)
         if self.is_fp4:

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/torch_utils.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/torch_utils.py
@@ -41,7 +41,13 @@ import torch
 #     return ret
 
 
-def repack(data: torch.Tensor, old_dim: int, new_dim: int, is_fp4: bool, out=None) -> torch.Tensor:
+def repack(
+    data: torch.Tensor,
+    old_dim: int,
+    new_dim: int,
+    is_fp4: bool,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
     old_dim %= data.ndim
     new_dim %= data.ndim
     if (not is_fp4) or (old_dim == new_dim):

--- a/python/triton_kernels/triton_kernels/tensor_details/sharding.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/sharding.py
@@ -1,0 +1,269 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Sequence, final, override
+
+import torch
+
+import triton
+import triton.language as tl
+from triton_kernels.distributed import ProcessGroup, default_process_group, local_process_group
+
+TL_SHARDING_LOCAL = tl.constexpr(0)
+TL_SHARDING_RANGE = tl.constexpr(1)
+
+
+def _size_to_scalar_tensor(
+    size: int | torch.Tensor,
+    device: torch.device | str | None = None,
+    dtype: torch.dtype = torch.int64,
+) -> torch.Tensor:
+    if isinstance(size, torch.Tensor):
+        if size.numel() != 1:
+            raise ValueError("size must be a scalar tensor")
+        return size.reshape(()).to(device=device, dtype=dtype)
+    return torch.tensor(size, device=device, dtype=dtype)
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ShardLocation:
+    rank: int
+    shard: slice
+
+
+@dataclass(frozen=True, kw_only=True)
+class Sharding(ABC):
+    mesh: ProcessGroup = field(default_factory=default_process_group)
+
+    @property
+    @abstractmethod
+    def triton_sharding_type(self) -> tl.constexpr:
+        ...
+
+    @abstractmethod
+    def full_map(self, size: int) -> Sequence[ShardLocation]:
+        """Return the entire mapping."""
+        ...
+
+    @abstractmethod
+    def map(self, idxs: torch.Tensor, size: int | torch.Tensor) -> torch.Tensor:
+        """Return the mapping of a set of indices.
+
+        Given a set of indices (of shape [k]), return a tensor of shape [replication_factor, k, 2]
+        locations. ret[.., 0] is the rank; ret[..., 1] is the local index on that rank.
+        """
+        ...
+
+    @final
+    def range_for_rank(self, rank: int, size: int | torch.Tensor) -> torch.Tensor:
+        """Return the contiguous index range [start, end) mapped to a given rank.
+
+        This works regardless of whether the size is known statically (int) or not
+        (scalar tensor). Note that the implementation is quite inefficient, so you probably
+        want to do computation inside the kernel, see range_for_rank_triton, below.
+        """
+        return self._range_for_rank(rank, _size_to_scalar_tensor(size))
+
+    @abstractmethod
+    def _range_for_rank(self, rank: int, size: torch.Tensor) -> torch.Tensor:
+        ...
+
+    @abstractmethod
+    def max_global_size(self, local_size: int) -> int:
+        ...
+
+    @property
+    def is_fully_replicated(self) -> bool:
+        return False
+
+    def uniform_width(self, size: int) -> int | None:
+        return None
+
+    @property
+    def is_local(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True, kw_only=True, init=False)
+class LocalSharding(Sharding):
+
+    def __init__(self):
+        super().__init__(mesh=local_process_group())
+
+    @override
+    def full_map(self, size: int) -> Sequence[ShardLocation]:
+        return (ShardLocation(shard=slice(0, size), rank=0), )
+
+    @override
+    def map(self, idxs: torch.Tensor, size: int | torch.Tensor) -> torch.Tensor:
+        ranks = torch.zeros_like(idxs)
+        return torch.stack((ranks, idxs), dim=1).unsqueeze(0)
+
+    @override
+    def _range_for_rank(self, rank: int, size: torch.Tensor) -> torch.Tensor:
+        zero = torch.zeros((), device=size.device, dtype=size.dtype)
+        return torch.stack((zero, size))
+
+    @override
+    def max_global_size(self, local_size: int) -> int:
+        return local_size
+
+    @property
+    @override
+    def triton_sharding_type(self) -> tl.constexpr:
+        return TL_SHARDING_LOCAL
+
+    @override
+    def uniform_width(self, size: int) -> int | None:
+        return size
+
+    @property
+    @override
+    def is_local(self) -> bool:
+        return True
+
+    @property
+    @override
+    def is_fully_replicated(self) -> bool:
+        return True
+
+
+@dataclass(frozen=True, kw_only=True)
+class RangeSharding(Sharding):
+    replication_factor: int = 1
+
+    @property
+    def n_shards(self) -> int:
+        return self.mesh.world_size // self.replication_factor
+
+    @property
+    @override
+    def is_fully_replicated(self) -> bool:
+        return self.n_shards == 1
+
+    # n_shards = n_ranks / replication_factor
+    # Shard j is mapped to ranks [j * replication_factor, (j + 1) * replication_factor)
+    # Index i is mapped to shard floor(i * n_shards / size)
+    #
+    # if q, r = divmod(size, n_shards)
+    # then shards [0, r) will have size q + 1
+    #      shards [r+1, s) will have size q
+
+    def __post_init__(self):
+        assert self.mesh.world_size % self.replication_factor == 0
+
+    @override
+    def full_map(self, size: int) -> Sequence[ShardLocation]:
+        q, r = divmod(size, self.n_shards)
+        locations = []
+        start = 0
+        for shard in range(self.n_shards):
+            shard_size = q + (shard < r)
+            end = start + shard_size
+            for replica in range(self.replication_factor):
+                locations.append(ShardLocation(rank=shard * self.replication_factor + replica, shard=slice(start, end)))
+            start = end
+        return locations
+
+    @override
+    def map(self, idxs: torch.Tensor, size: int | torch.Tensor) -> torch.Tensor:
+        r = self.replication_factor
+        n = idxs.shape[0]
+        idxs = torch.atleast_1d(idxs)
+        ranks = idxs * self.n_shards // size * self.replication_factor
+
+        idxs = idxs.unsqueeze(0).expand(r, n)
+        ranks = ranks.unsqueeze(0).expand(r, n)
+        replication = (torch.arange(r, dtype=idxs.dtype, device=idxs.device).unsqueeze(1).expand(r, n))
+
+        return torch.stack((ranks + replication, idxs), dim=2)
+
+    @override
+    def _range_for_rank(self, rank: int, size: torch.Tensor) -> torch.Tensor:
+        n_shards = torch.tensor(self.n_shards, device=size.device, dtype=size.dtype)
+        shard_t = torch.tensor(rank // self.replication_factor, device=size.device, dtype=size.dtype)
+        q = size // n_shards
+        r = size - q * n_shards
+        start = shard_t * q + torch.minimum(shard_t, r)
+        end = start + q + (shard_t < r).to(size.dtype)
+        return torch.stack((start, end))
+
+    @override
+    def max_global_size(self, local_size: int) -> int:
+        return local_size * self.n_shards
+
+    @property
+    @override
+    def triton_sharding_type(self) -> tl.constexpr:
+        return TL_SHARDING_RANGE
+
+    @override
+    def uniform_width(self, size: int) -> int | None:
+        q, r = divmod(size, self.n_shards)
+        return q if r == 0 else None
+
+
+if __name__ == "__main__":
+    SIZE_MAX = 18
+    sharding = RangeSharding(replication_factor=2)
+    idxs = torch.arange(SIZE_MAX)
+    print(sharding.full_map(SIZE_MAX))
+    print(sharding.map(idxs, SIZE_MAX))
+
+
+@triton.jit
+def range_sharding_range_for_rank_triton(
+    rank,
+    size,
+    REPLICATION_FACTOR: tl.constexpr,
+    WORLD_SIZE: tl.constexpr,
+):
+    """Kernel-callable equivalent of RangeSharding._range_for_rank.
+
+    Args:
+        rank: Rank id in the process group.
+        size: Global size being sharded.
+        REPLICATION_FACTOR: Number of replicas per shard.
+        WORLD_SIZE: Process-group size.
+    Returns:
+        (start, end): Contiguous half-open interval [start, end) for this rank's shard.
+    """
+    tl.static_assert(WORLD_SIZE % REPLICATION_FACTOR == 0)
+    n_shards: tl.constexpr = WORLD_SIZE // REPLICATION_FACTOR
+
+    shard_t = rank // REPLICATION_FACTOR
+    q = size // n_shards
+    r = size - q * n_shards
+    start = shard_t * q + tl.minimum(shard_t, r)
+    end = start + q + (shard_t < r).to(size.dtype)
+    return start, end
+
+
+@triton.jit
+def range_for_rank_triton(
+    rank,
+    size,
+    SHARDING_TYPE: tl.constexpr,
+    REPLICATION_FACTOR: tl.constexpr = 1,
+    WORLD_SIZE: tl.constexpr = 1,
+):
+    """Generic kernel-callable range dispatch for LocalSharding and RangeSharding.
+
+    `size` may be passed either as a scalar kernel arg or a pointer to a scalar.
+
+    SHARDING_TYPE must be one of:
+      - TL_SHARDING_LOCAL
+      - TL_SHARDING_RANGE
+    """
+    if isinstance(size, tl.tensor) and size.dtype.is_ptr():
+        size = tl.load(size)
+
+    tl.static_assert(
+        SHARDING_TYPE == TL_SHARDING_LOCAL or SHARDING_TYPE == TL_SHARDING_RANGE,
+        "SHARDING_TYPE must be TL_SHARDING_LOCAL or TL_SHARDING_RANGE",
+    )
+
+    if SHARDING_TYPE == TL_SHARDING_RANGE:
+        return range_sharding_range_for_rank_triton(rank, size, REPLICATION_FACTOR, WORLD_SIZE)
+
+    # TL_SHARDING_LOCAL
+    return 0, size

--- a/python/triton_kernels/triton_kernels/tensor_metadata.py
+++ b/python/triton_kernels/triton_kernels/tensor_metadata.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import InitVar, dataclass, field, replace
+from typing import TypeVar
+
+import torch
+
+from .tensor_details.dtype import FloatType, IntegerType
+from .tensor_details.sharding import LocalSharding, RangeSharding, Sharding
+
+
+@dataclass(kw_only=True)
+class TensorSharding:
+    dim: int
+    sharding: Sharding
+    sharding_size: int | torch.Tensor
+
+    def map(self, idxs: torch.Tensor) -> torch.Tensor:
+        return self.sharding.map(idxs, self.sharding_size)
+
+    def range_for_rank(self, rank: int) -> torch.Tensor:
+        return self.sharding.range_for_rank(rank, self.sharding_size)
+
+    @property
+    def uniform_width(self) -> int | None:
+        return (self.sharding.uniform_width(self.sharding_size) if isinstance(self.sharding_size, int) else None)
+
+    @property
+    def is_fully_replicated(self) -> bool:
+        return self.sharding.is_fully_replicated
+
+    @property
+    def is_local(self) -> bool:
+        return self.sharding.is_local
+
+
+@dataclass(kw_only=True)
+class TensorMetadata:
+    # Constructor arguments
+
+    # Data type
+    dtype: IntegerType | FloatType
+
+    # Global shape
+    shape: list[int | torch.Tensor] | None
+
+    # Sharding and sharding dimension
+    sharding: InitVar[Sharding | None] = None
+    sharding_dim: InitVar[int | None] = None
+
+    # Upper bounds on the shape of the local shard; if no dynamic dims, this may be
+    # unspecified, in which case it will be assumed to be the same as self.local_shape.
+    local_shape_max: list[int] | None = None
+
+    # Computed values
+
+    # Sharding, or None
+    tensor_sharding: TensorSharding | None = field(init=False, default=None)
+
+    # Dimension indices whose sizes are not known at compile time.
+    dynamic_dims: list[int] = field(init=False)
+
+    # Shape of the *local* shard, if sharded. (same as self.shape if unsharded)
+    local_shape: list[int | torch.Tensor] = field(init=False)
+
+    # Upper bounds on the shape of the global tensor. (same as self.local_shape_max if unsharded)
+    global_shape_max: list[int] = field(init=False)
+
+    def __post_init__(
+        self,
+        sharding: Sharding | None = None,
+        sharding_dim: int | None = None,
+        *,
+        default_shape: list[int] | None = None,
+    ) -> None:
+        if self.shape is None:
+            if default_shape is None:
+                raise ValueError("shape must be provided")
+            if self.dtype.bitwidth < 8:
+                raise ValueError("shape must be provided for sub-byte types")
+            if self.sharding is not None:
+                raise ValueError("shape must be provided if sharding")
+            self.shape = default_shape
+
+        if (sharding is not None) != (sharding_dim is not None):
+            raise ValueError("sharding and sharding_dim must be specified together")
+
+        self.shape = list(self.shape)
+
+        # validate shape: all elements must be `int` or numel-1 `torch.Tensor`
+        is_int = lambda s: isinstance(s, int)
+        is_item = lambda s: hasattr(s, "numel") and s.numel() == 1
+        assert all(is_int(s) or is_item(s) for s in self.shape)
+
+        self.dynamic_dims = [i for i, s in enumerate(self.shape) if not is_int(s)]
+
+        self.local_shape = list(self.shape)
+
+        if sharding is not None:
+            assert not sharding.is_local, (
+                "Do not use LocalSharding directly; use get_sharding_local_if_unset() if needed")
+            if sharding_dim < 0 or sharding_dim >= len(self.shape):
+                raise ValueError("sharding_dim out of range")
+            s = self.shape[sharding_dim]
+            self.tensor_sharding = TensorSharding(
+                dim=sharding_dim,
+                sharding=sharding,
+                sharding_size=s,
+            )
+            local_range = self.tensor_sharding.range_for_rank(sharding.mesh.local_rank)
+            local_size = local_range[1] - local_range[0]
+            assert isinstance(local_size, torch.Tensor)
+            if is_int(self.shape[sharding_dim]):
+                local_size = int(local_size.item())
+            self.local_shape[sharding_dim] = local_size
+
+        if self.local_shape_max is None:
+            if self.dynamic_dims:
+                raise ValueError("local_shape_max must be specified with dynamic dims")
+            self.local_shape_max = list(self.local_shape)
+        else:
+            if len(self.local_shape_max) != len(self.local_shape):
+                raise ValueError("local_shape_max and shape must have the same length")
+            for i, (s, smax) in enumerate(zip(self.local_shape, self.local_shape_max)):
+                if is_int(s) and s > smax:
+                    raise ValueError(f"Size {s} > max {smax} along dim {i}")
+
+        self.global_shape_max = list(self.local_shape_max)
+        if sharding is not None:
+            self.global_shape_max[sharding_dim] = sharding.max_global_size(self.local_shape_max[sharding_dim])
+
+
+def get_sharding_local_if_unset(t: TensorMetadata, dim: int) -> TensorSharding:
+    if ts := t.tensor_sharding:
+        if dim != ts.dim:
+            raise ValueError(f"Tensor is already sharded along dimension {ts.dim}")
+        return ts
+
+    return TensorSharding(
+        dim=dim,
+        sharding=LocalSharding(),
+        sharding_size=t.shape[dim],
+    )
+
+
+T = TypeVar("T", bound=TensorMetadata)
+
+
+def extend_sharding(t: T, dim: int, sharding: RangeSharding | None = None) -> T:
+    if t.tensor_sharding is not None:
+        raise ValueError("Tensor is already sharded")
+    if sharding is None:
+        sharding = RangeSharding()
+
+    new_shape = list(t.shape)
+    new_shape[dim] *= sharding.n_shards
+
+    return replace(t, shape=new_shape, sharding=sharding, sharding_dim=dim)

--- a/python/triton_kernels/triton_kernels/tensor_types.py
+++ b/python/triton_kernels/triton_kernels/tensor_types.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import operator
+from abc import abstractmethod
+from dataclasses import KW_ONLY, dataclass, field
+from types import NotImplementedType
+from typing import Any, Callable, ClassVar, Protocol, final, overload, override
+
+from .tensor_metadata import TensorMetadata
+
+# precedence:
+# 0: paren
+# 1: not (~)
+# 2: and (&)
+# 3: or (|)
+# 4: comparisons
+# (note that because we use bitwise operators, the precedence is *lower* than comparisons)
+
+
+@dataclass
+class CheckResult:
+    ok: bool = True
+    reason: str = ""
+
+    def __bool__(self):
+        return self.ok
+
+    def __str__(self):
+        return self.reason
+
+
+def _fail(reason: str) -> CheckResult:
+    return CheckResult(ok=False, reason=reason)
+
+
+def _ok() -> CheckResult:
+    return CheckResult()
+
+
+@dataclass
+class TypeAssertion:
+    _precedence: ClassVar[int] = 999
+
+    @final
+    def is_valid(self, t: TensorMetadata) -> CheckResult:
+        r = self._is_valid(t)
+        if isinstance(r, bool):
+            r = CheckResult(ok=r, reason=str(self))
+        return r
+
+    def _is_valid(self, t: TensorMetadata) -> bool | CheckResult:
+        return False
+
+    @overload
+    def __and__(self, other: TypeAssertion) -> TypeAssertion:
+        ...
+
+    @overload
+    def __and__(self, other: object) -> NotImplementedType:
+        ...
+
+    def __and__(self, other: object) -> TypeAssertion | NotImplementedType:
+        if not isinstance(other, TypeAssertion):
+            return NotImplemented
+
+        return And(left=self, right=other)
+
+    @overload
+    def __or__(self, other: TypeAssertion) -> TypeAssertion:
+        ...
+
+    @overload
+    def __or__(self, other: object) -> NotImplementedType:
+        ...
+
+    def __or__(self, other: object) -> TypeAssertion | NotImplementedType:
+        if not isinstance(other, TypeAssertion):
+            return NotImplemented
+
+        return Or(left=self, right=other)
+
+    def __invert__(self) -> TypeAssertion:
+        return Not(self)
+
+    def _format(self, other: TypeAssertion, *, right: bool = False) -> str:
+        other_prec = other._precedence + int(right)
+        return f"({other})" if other_prec > self._precedence else f"{other}"
+
+
+@dataclass
+class Unary(TypeAssertion):
+    item: TypeAssertion
+
+
+@dataclass
+class Not(Unary):
+    _precedence: ClassVar[int] = 1
+
+    @override
+    def _is_valid(self, t: TensorMetadata) -> CheckResult:
+        if isinstance(self.item, Not):
+            return self.item.item.is_valid(t)
+        else:
+            r = self.item.is_valid(t)
+            return CheckResult(ok=r.ok, reason="not " + r.reason)
+
+    def __str__(self) -> str:
+        return "~" + self._format(self.item)
+
+
+@dataclass
+class Binary(TypeAssertion):
+    left: TypeAssertion
+    right: TypeAssertion
+    _op_str: ClassVar[str]
+
+    def __str__(self) -> str:
+        return f"{self._format(self.left)} {self._op_str} {self._format(self.right, right=True)}"
+
+
+@dataclass
+class And(Binary):
+    _precedence: ClassVar[int] = 2
+    _op_str: ClassVar[str] = "&"
+
+    @override
+    def _is_valid(self, t: TensorMetadata) -> CheckResult:
+        return self.left.is_valid(t) and self.right.is_valid(t)
+
+    def __str__(self) -> str:
+        return self._format(self.left) + " & " + self._format(self.right, right=True)
+
+
+@dataclass
+class Or(Binary):
+    _precedence: ClassVar[int] = 3
+    _op_str: ClassVar[str] = "|"
+
+    @override
+    def _is_valid(self, t: TensorMetadata) -> CheckResult:
+        return self.left.is_valid(t) or self.right.is_valid(t)
+
+
+@dataclass
+class Atom(TypeAssertion):
+    _precedence: ClassVar[int] = 0
+
+
+@dataclass
+class Unsharded(Atom):
+
+    @override
+    def _is_valid(self, t: TensorMetadata) -> bool:
+        return t.tensor_sharding is None
+
+    def __str__(self) -> str:
+        return "Unsharded()"
+
+
+@dataclass
+class Sharded(Atom):
+    dim: int
+    _: KW_ONLY
+    uniform: bool = False
+
+    @override
+    def _is_valid(self, t: TensorMetadata) -> bool:
+        s = t.tensor_sharding
+        return (s is not None and self.dim == s.dim and not (self.uniform and s.uniform_width is None))
+
+    def __str__(self) -> str:
+        parts = [f"{self.dim}"]
+        if self.uniform:
+            parts.append(f"uniform={self.uniform}")
+        return f"Sharded({', '.join(parts)})"
+
+
+class Op(Protocol):
+    TYPES: dict[str, TypeAssertion]
+
+
+@dataclass
+class OpInput(Atom):
+    op: Op
+    name: str
+
+    _nested: TypeAssertion = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._nested = self.op.TYPES[self.name]
+
+    @override
+    def _is_valid(self, t: TensorMetadata) -> bool:
+        return self._nested.is_valid(t)
+
+
+@dataclass
+class Dim(Atom):
+    n: int
+
+    def _is_valid(self, t: TensorMetadata) -> bool:
+        return len(t.shape) == self.n
+
+    def __str__(self) -> str:
+        return f"Dim({self.n})"
+
+
+@dataclass
+class _Size:
+
+    @abstractmethod
+    def get(self, t: TensorMetadata) -> int:
+        ...
+
+    @overload
+    def __lt__(self, other: _Size) -> TypeAssertion:
+        ...
+
+    @overload
+    def __lt__(self, other: int) -> TypeAssertion:
+        ...
+
+    @overload
+    def __lt__(self, other: object) -> NotImplementedType:
+        ...
+
+    def __lt__(self, other: object) -> TypeAssertion | NotImplementedType:
+        return _make_comparison(self, other, "<", operator.__lt__)
+
+    @overload
+    def __le__(self, other: _Size) -> TypeAssertion:
+        ...
+
+    @overload
+    def __le__(self, other: int) -> TypeAssertion:
+        ...
+
+    @overload
+    def __le__(self, other: object) -> NotImplementedType:
+        ...
+
+    def __le__(self, other: object) -> TypeAssertion | NotImplementedType:
+        return _make_comparison(self, other, "<=", operator.__le__)
+
+    @overload
+    def __gt__(self, other: _Size) -> TypeAssertion:
+        ...
+
+    @overload
+    def __gt__(self, other: int) -> TypeAssertion:
+        ...
+
+    @overload
+    def __gt__(self, other: object) -> NotImplementedType:
+        ...
+
+    def __gt__(self, other: object) -> TypeAssertion | NotImplementedType:
+        return _make_comparison(self, other, ">", operator.__gt__)
+
+    @overload
+    def __ge__(self, other: _Size) -> TypeAssertion:
+        ...
+
+    @overload
+    def __ge__(self, other: int) -> TypeAssertion:
+        ...
+
+    @overload
+    def __ge__(self, other: object) -> NotImplementedType:
+        ...
+
+    def __ge__(self, other: object) -> TypeAssertion | NotImplementedType:
+        return _make_comparison(self, other, ">=", operator.__ge__)
+
+    @overload
+    def __eq__(self, other: _Size) -> TypeAssertion:
+        ...
+
+    @overload
+    def __eq__(self, other: int) -> TypeAssertion:
+        ...
+
+    @overload
+    def __eq__(self, other: object) -> NotImplementedType:
+        ...
+
+    def __eq__(self, other: object) -> TypeAssertion | NotImplementedType:
+        return _make_comparison(self, other, "==", operator.__eq__)
+
+    @overload
+    def __ne__(self, other: _Size) -> TypeAssertion:
+        ...
+
+    @overload
+    def __ne__(self, other: int) -> TypeAssertion:
+        ...
+
+    @overload
+    def __ne__(self, other: object) -> NotImplementedType:
+        ...
+
+    def __ne__(self, other: object) -> TypeAssertion | NotImplementedType:
+        return _make_comparison(self, other, "!=", operator.__ne__)
+
+
+@dataclass
+class _SizeComparison(TypeAssertion):
+    left: _Size
+    right: _Size
+    op_str: str
+    op: Callable[[Any, Any], bool]
+
+    _precedence: ClassVar[int] = 4
+
+    def _is_valid(self, t: TensorMetadata) -> bool:
+        left = self.left.get(t)
+        right = self.right.get(t)
+        return left is not None and right is not None and self.op(left, right)
+
+    def __str__(self) -> str:
+        return f"{self.left} {self.op_str} {self.right}"
+
+
+def _make_comparison(left: _Size, right: object, op_str: str, op: Callable[[Any, Any],
+                                                                           bool]) -> TypeAssertion | NotImplementedType:
+    if isinstance(right, int):
+        right = _ConstantSize(right)
+    elif not isinstance(right, _Size):
+        return NotImplemented
+    return _SizeComparison(left, right, op_str, op)
+
+
+@dataclass
+class _ConstantSize(_Size):
+    n: int
+
+    @override
+    def get(self, t: TensorMetadata) -> int | None:
+        return self.n
+
+    def __str__(self) -> str:
+        return str(self.n)
+
+
+@dataclass
+class _SizeIsStatic(Atom):
+    n: int
+
+    @override
+    def _is_valid(self, t: TensorMetadata) -> bool:
+        return self.n not in t.dynamic_dims
+
+    def __str__(self) -> str:
+        return f"Size({self.n}).is_static"
+
+
+@dataclass
+class Size(_Size):
+    n: int
+
+    @override
+    def get(self, t: TensorMetadata) -> int | None:
+        is_dynamic = self.n in t.dynamic_dims
+        return None if is_dynamic else t.shape[self.n]
+
+    @property
+    def is_dynamic(self) -> TypeAssertion:
+        return Not(self.is_static)
+
+    @property
+    def is_static(self) -> TypeAssertion:
+        return _SizeIsStatic(self.n)
+
+    def __str__(self):
+        return f"Size({self.n})"

--- a/python/triton_kernels/triton_kernels/topk.py
+++ b/python/triton_kernels/triton_kernels/topk.py
@@ -1,95 +1,204 @@
 import torch
+from torch.autograd.function import FunctionCtx
+
 import triton
-from triton_kernels.topk_details._topk_forward import _topk_forward
-from triton_kernels.topk_details._topk_backward import _topk_backward
-from triton_kernels.tensor import SparseMatrix, Tensor
-from triton_kernels.tensor_details.dtype import BIT
-from typing import Optional, Union
 from triton_kernels.distributed import SymmetricMemoryPool
-from triton_kernels.tensor import wrap_torch_tensor, dtype_to_torch_dtype
+from triton_kernels.op import Op
+from triton_kernels.tensor import SparseMatrix, Tensor, dtype_to_torch_dtype, wrap_torch_tensor
+from triton_kernels.tensor_details.dtype import BIT, DataType
+from triton_kernels.tensor_details.sharding import RangeSharding
+from triton_kernels.tensor_metadata import extend_sharding, get_sharding_local_if_unset
+from triton_kernels.tensor_types import Dim, Sharded, Size, Unsharded
+from triton_kernels.topk_details._topk_backward import _topk_backward
+from triton_kernels.topk_details._topk_forward import _topk_forward
 
 
-def make_empty(offset, shape, dtype, device, all_gather, symm_mem_pool):
+def make_empty(
+    shape: tuple[int, ...],
+    dtype: torch.dtype | DataType,
+    device: torch.device,
+    all_gather: bool,
+    symm_mem_pool: SymmetricMemoryPool | None,
+    region: str = "topk_vals",
+) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
     dtype = dtype_to_torch_dtype(dtype)
     if all_gather:
-        rank_id = symm_mem_pool.mesh.local_rank
-        ret_bufs = symm_mem_pool.make_empty(shape=shape, dtype=dtype, region="topk", region_offset=offset)
+        rank_id = symm_mem_pool.process_group.local_rank
+        ret_bufs = symm_mem_pool.get_tensors(shape=shape, dtype=dtype, region=region)
         ret = ret_bufs[rank_id]
-        offset = symm_mem_pool.align_up(offset + ret.numel() * ret.element_size(),
-                                        symm_mem_pool.regions["topk"].alignment)
-        return ret_bufs, ret, offset
+        return ret_bufs, ret
     ret = torch.empty(shape, dtype=dtype, device=device)
-    return (ret, ), ret, 0
+    return (ret, ), ret
 
 
-def topk_forward(x, k, apply_softmax=True, dim=1, y_indx=None, n_rows=None, all_gather=False, symm_mem_pool=None):
-    if not isinstance(x, Tensor):
-        x_shape = [x.shape[0] if n_rows is None else n_rows, x.shape[1]]
-        x_shape_max = [x.shape[0], x.shape[1]]
-        x = wrap_torch_tensor(x, shape=x_shape, shape_max=x_shape_max)
+def topk_forward(
+    x: Tensor,
+    k: int,
+    apply_softmax: bool = True,
+    dim: int = 1,
+    y_indx: torch.Tensor | None = None,
+    symm_mem_pool: SymmetricMemoryPool | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, Tensor]:
+    tensor_sharding = get_sharding_local_if_unset(x, 0)
+    all_gather = not tensor_sharding.is_local
+
     cdiv = lambda a, b: (a + b - 1) // b
     BLOCK_M = 32
     BLOCK_N = 32
     use_provided_indx = y_indx is not None
     assert symm_mem_pool is not None or not all_gather
     assert len(x.shape) == 2
-    assert x.shape_max[-1] < 32768
+    assert x.shape[-1] < 32768
     assert dim == 1
-    n_rows, n_cols = x.shape
-    n_rows_max, _ = x.shape_max
-    dev = x.device
-    n_rows_out_max = n_rows_max * symm_mem_pool.mesh.world_size if all_gather else n_rows_max
+
+    sharding = tensor_sharding.sharding
+    rank = sharding.mesh.local_rank
+    sharding_type = sharding.triton_sharding_type
+    world_size = sharding.mesh.world_size
+    replication_factor = getattr(sharding, "replication_factor", 1)
+    n_rows_local_max = x.local_shape_max[0]
+
+    n_rows_out_max, n_cols = x.global_shape_max
+    dev = x.storage.data.device
+
     # scratchpad tensors
     # NOTE: these are not returned
-    y_vals_bufs, y_vals, offset = make_empty(0, (n_rows_out_max, k), x.dtype, dev, all_gather=all_gather,
-                                             symm_mem_pool=symm_mem_pool)
+    y_vals_bufs, y_vals = make_empty(
+        (n_rows_out_max, k),
+        x.dtype,
+        dev,
+        all_gather=all_gather,
+        symm_mem_pool=symm_mem_pool,
+        region="topk_vals",
+    )
     if y_indx is None:
-        y_indx_bufs, y_indx, offset = make_empty(offset, (n_rows_out_max, k), torch.int16, dev, all_gather=all_gather,
-                                                 symm_mem_pool=symm_mem_pool)
+        y_indx_bufs, y_indx = make_empty(
+            (n_rows_out_max, k),
+            torch.int16,
+            dev,
+            all_gather=all_gather,
+            symm_mem_pool=symm_mem_pool,
+            region="topk_y_indx",
+        )
     else:
         y_indx_bufs = (y_indx, )
     # create bitmatrix in transposed memory layout:
     n_cols_pad = cdiv(n_cols, BLOCK_N) * BLOCK_N
     n_cols_words = n_cols_pad // 32
-    bitmatrix_bufs, bitmatrix_data, offset = make_empty(offset, (n_cols_words, cdiv(n_rows_out_max, 32) * 32),
-                                                        torch.uint32, dev, all_gather=all_gather,
-                                                        symm_mem_pool=symm_mem_pool)
-    bitmatrix_data = torch.transpose(bitmatrix_data, 0, 1)[:n_rows_max]
-    pids = cdiv(n_rows_max, BLOCK_M)
+    bitmatrix_bufs, bitmatrix_data = make_empty(
+        (n_cols_words, cdiv(n_rows_out_max, 32) * 32),
+        torch.uint32,
+        dev,
+        all_gather=all_gather,
+        symm_mem_pool=symm_mem_pool,
+        region="topk_bitmatrix",
+    )
+    bitmatrix_data = torch.transpose(bitmatrix_data, 0, 1)[:n_rows_local_max]
+    pids = cdiv(n_rows_local_max, BLOCK_M)
     _topk_forward[(pids, )](
-        x.storage.data, x.stride(0),  # inputs
-        y_vals_bufs, y_indx_bufs, y_vals.stride(0), use_provided_indx,  # output [topk]
-        bitmatrix_bufs, bitmatrix_data.stride(0), bitmatrix_data.stride(1),  # output [bitmatrix]
-        n_rows, n_cols,  # shapes
-        symm_mem_pool.mesh.local_rank * n_rows_max if all_gather else 0, BLOCK_M=BLOCK_M,
+        x.storage.data,
+        x.storage.data.stride(0),  # inputs
+        y_vals_bufs,
+        y_indx_bufs,
+        y_vals.stride(0),
+        use_provided_indx,  # output [topk]
+        bitmatrix_bufs,
+        bitmatrix_data.stride(0),
+        bitmatrix_data.stride(1),  # output [bitmatrix]
+        x.shape[0],
+        n_cols,  # shapes
+        rank,
+        BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,  # tunable parameter
-        APPLY_SOFTMAX=apply_softmax, N_EXPTS_PAD=n_cols_pad, N_EXPTS_ACT=k,  # constants
+        APPLY_SOFTMAX=apply_softmax,
+        N_EXPTS_PAD=n_cols_pad,
+        N_EXPTS_ACT=k,  # constants
+        SHARDING_TYPE=sharding_type,
+        REPLICATION_FACTOR=replication_factor,
+        WORLD_SIZE=world_size,
     )
     if all_gather:
-        symm_mem_pool.hdl.barrier(channel=0)
-    bitmatrix_shape = [n_rows * symm_mem_pool.mesh.world_size if all_gather else n_rows, n_cols]
-    bitmatrix_shape_max = [n_rows_out_max, None]
-    bitmatrix = wrap_torch_tensor(bitmatrix_data, dtype=BIT, shape=bitmatrix_shape, shape_max=bitmatrix_shape_max)
+        symm_mem_pool.process_group.barrier()
+
+    bitmatrix = wrap_torch_tensor(
+        bitmatrix_data,
+        dtype=BIT,
+        shape=x.shape[:],
+        local_shape_max=x.global_shape_max[:],
+    )
     return y_vals, y_indx, bitmatrix
 
 
-def topk_backward(x, y_indx, dy_vals, k, n_rows, apply_softmax):
+def topk_backward(
+    x: torch.Tensor,
+    y_indx: torch.Tensor,
+    dy_vals: torch.Tensor,
+    k: int,
+    n_rows: int | None,
+    apply_softmax: bool,
+) -> torch.Tensor:
     assert dy_vals.shape[-1] == k
     n_expts_pad = triton.next_power_of_2(x.shape[-1])
     dx = torch.empty_like(x)
     _topk_backward[(dy_vals.shape[0], )](
-        y_indx, y_indx.stride(0), dy_vals, dy_vals.stride(0), x, x.stride(0),  # inputs
+        y_indx,
+        y_indx.stride(0),
+        dy_vals,
+        dy_vals.stride(0),
+        x,
+        x.stride(0),  # inputs
         dx,  # outputs
-        dx.stride(0), x.shape[0], n_rows, x.shape[-1], APPLY_SOFTMAX=apply_softmax, N_EXPTS_ACT=k,
-        N_EXPTS_PAD=n_expts_pad)
+        dx.stride(0),
+        x.shape[0],
+        n_rows,
+        x.shape[-1],
+        APPLY_SOFTMAX=apply_softmax,
+        N_EXPTS_ACT=k,
+        N_EXPTS_PAD=n_expts_pad,
+    )
     return dx
+
+
+@Op(types={
+    "x": (Dim(2) & (Size(1) < 32768) & (Unsharded() | Sharded(0, uniform=True))),
+}, )
+def topk_triton(
+    x: Tensor,
+    k: int,
+    apply_softmax: bool = True,
+    dim: int = 1,
+    y_indx: torch.Tensor | None = None,
+    symm_mem_pool: SymmetricMemoryPool | None = None,
+) -> SparseMatrix:
+    y_vals, y_indx, bitmatrix = topk_forward(x, k, apply_softmax, dim, y_indx, symm_mem_pool)
+    return SparseMatrix(vals=y_vals, indx=y_indx, mask=bitmatrix)
 
 
 class TopK(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, x, k, apply_softmax, dim, y_indx, n_rows, all_gather, symm_mem_pool):
-        y_vals, y_indx, bitmatrix = topk_forward(x, k, apply_softmax, dim, y_indx, n_rows, all_gather, symm_mem_pool)
+    def forward(
+        ctx: FunctionCtx,
+        x: torch.Tensor,
+        k: int,
+        apply_softmax: bool,
+        dim: int,
+        y_indx: torch.Tensor | None,
+        n_rows: int | torch.Tensor | None,
+        all_gather: bool | None,
+        symm_mem_pool: SymmetricMemoryPool | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, Tensor]:
+        assert isinstance(x, torch.Tensor)
+
+        x_shape = [x.shape[0] if n_rows is None else n_rows, x.shape[1]]
+        x_triton = wrap_torch_tensor(x, shape=x_shape, local_shape_max=x.shape[:])
+        if all_gather:
+            assert symm_mem_pool is not None
+            x_triton = extend_sharding(x_triton, dim=0, sharding=RangeSharding(mesh=symm_mem_pool.process_group))
+
+        m = topk_triton(x_triton, k, apply_softmax, dim, y_indx, symm_mem_pool)
+        y_vals, y_indx, bitmatrix = m.vals, m.indx, m.mask
+
         ctx.save_for_backward(x, y_indx)
         ctx.apply_softmax = apply_softmax
         ctx.k = k
@@ -97,22 +206,27 @@ class TopK(torch.autograd.Function):
         return y_vals, y_indx, bitmatrix
 
     @staticmethod
-    def backward(ctx, dy_vals, _0, _1):
+    def backward(
+        ctx: FunctionCtx,
+        dy_vals: torch.Tensor,
+        _0: torch.Tensor | None,
+        _1: torch.Tensor | None,
+    ) -> tuple[torch.Tensor | None, None, None, None, None, None, None, None]:
         x, y_indx = ctx.saved_tensors
         dx = topk_backward(x, y_indx, dy_vals, ctx.k, ctx.n_rows, ctx.apply_softmax)
         return dx, None, None, None, None, None, None, None
 
 
 def topk(
-    x: Union[Tensor, torch.Tensor],
+    x: Tensor | torch.Tensor,  # REVIEW: torch.Tensor or triton_kernels.Tensor
     k: int,
     apply_softmax: bool = True,
     dim: int = 1,
-    y_indx: Optional[torch.Tensor] = None,
-    n_rows: Optional[int] = None,
-    all_gather: bool = False,
+    y_indx: torch.Tensor | None = None,
+    n_rows: int | None = None,
+    all_gather: bool | None = None,
     symm_mem_pool: SymmetricMemoryPool | None = None,
-):
+) -> SparseMatrix:
     """
     Computes the top-k values and indices along a specified dimension of a tensor.
     Note that the input can be either a `Tensor` or a `torch.Tensor`, but the output will always be a `torch.Tensor`.
@@ -137,17 +251,23 @@ def topk(
     -------
     SparseMatrix: sparse matrix equal to `x` with non-selected entries set to 0
     """
-    y_vals, y_indx, bitmatrix = TopK.apply(x, k, apply_softmax, dim, y_indx, n_rows, all_gather, symm_mem_pool)
-    return SparseMatrix(vals=y_vals, indx=y_indx, mask=bitmatrix)
+    if isinstance(x, torch.Tensor):
+        # Backwards compatibility
+        y_vals, y_indx, bitmatrix = TopK.apply(x, k, apply_softmax, dim, y_indx, n_rows, all_gather, symm_mem_pool)
+        return SparseMatrix(vals=y_vals, indx=y_indx, mask=bitmatrix)
+
+    assert all_gather is None
+    assert n_rows is None
+    return topk_triton(x, k, apply_softmax, dim, y_indx, symm_mem_pool)
 
 
 def topk_torch(
-    x,
-    k,
+    x: torch.Tensor,
+    k: int,
     apply_softmax: bool = True,
     dim: int = 1,
-    y_indx: Optional[torch.Tensor] = None,
-    n_rows: Optional[int] = None,
+    y_indx: torch.Tensor | None = None,
+    n_rows: int | None = None,
 ) -> SparseMatrix:
     if n_rows is None:
         n_rows = x.shape[0]
@@ -173,9 +293,9 @@ def topk_torch(
         y_vals, sort_indices = torch.sort(y_vals.float(), dim=1, descending=True, stable=True)
         y_indx = torch.gather(y_indx, 1, sort_indices)
     y_indx[n_rows:, :] = -1
-    rows = torch.arange(x.shape[0], device=device).unsqueeze(1).expand(-1, y_indx.shape[1]).reshape(-1)
+    rows = (torch.arange(x.shape[0], device=device).unsqueeze(1).expand(-1, y_indx.shape[1]).reshape(-1))
     cols = y_indx.reshape(-1)  # 64-bit safe for div/mod
-    word_idx = torch.div(cols, 32, rounding_mode='floor')
+    word_idx = torch.div(cols, 32, rounding_mode="floor")
     bit_idx = cols % 32
     masks = torch.ones_like(bit_idx) << bit_idx
     bitmatrix_data.index_put_((rows, word_idx), masks, accumulate=True)


### PR DESCRIPTION
This refactors the triton Tensor API to support sharding and more cleanly
separate the (virtual) tensor shape from the underlying storage layout.

`Tensor` now refers to a virtual tensor that may be split across processes in the
process group. `Tensor.storage` refers to the *local* part of the tensors residing on the current node.

`Tensor.shape` is now a list of int or (scalar) torch.Tensor; the shape along certain dimensions may not be known until runtime.

`Tensor.local_shape_max` contains upper bounds for the tensor's shape based on the local storage.

We also now support defining (forward-pass-only) ops with declarative type checking. See `Op` and `TypeAssertion` and the example in `topk_triton`.

`topk` is still a bit of a monster because of trying to keep backward compat throughout the OpenAI codebase.

