### PR TITLE
Fix autotuner cache serialization for non-string tuning keys

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -42,6 +42,27 @@ def test_kwargs(use_cuda_graph: bool, device: str):
     assert len(_kernel.cache) == 2
 
 
+def test_dtype_cache_results(device: str):
+    M, N = 1024, 16
+    src = torch.randn(M * N, device=device)
+    dst = torch.empty(M * N, device=device)
+
+    configs = [triton.Config(kwargs={'BLOCK_SIZE_M': 32}), triton.Config(kwargs={'BLOCK_SIZE_M': 128})]
+
+    @triton.autotune(configs=configs, key=["DTYPE"], cache_results=True)
+    @triton.jit
+    def _kernel(dst, src, stride_m: tl.constexpr, DTYPE: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_M: tl.constexpr):
+        offsets_m = tl.program_id(0) * stride_m + tl.arange(0, BLOCK_SIZE_M)
+        offsets_n = tl.arange(0, BLOCK_SIZE_N)
+        x = tl.load(src + offsets_m[:, None] * BLOCK_SIZE_N + offsets_n[None, :])
+        x = x.to(DTYPE)
+        tl.store(dst + offsets_m[:, None] * BLOCK_SIZE_N + offsets_n[None, :], x)
+
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE_M']), )
+    _kernel[grid](dst, src, N, tl.float32, N)
+    assert len(_kernel.cache) == 1
+
+
 def test_no_do_bench(device: str):
     M, N = 1024, 16
     src = torch.randn(M * N, device=device)

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -203,7 +203,7 @@ class Autotuner(KernelInterface):
         cache.put(
             json.dumps({
                 "key":
-                tuning_key,
+                [str(k) for k in tuning_key],
                 "configs_timings":
                 [(config.__dict__, timings) for config, timings in self.configs_timings.items() if not config.pre_hook],
             }), file_name, binary=False)


### PR DESCRIPTION
Convert tuning_key elements to strings before JSON serialization to avoid TypeError when tuning_key contains non-serializable types.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
```
Traceback (most recent call last):
  File "/aiter/op_tests/triton_tests/test_pa_decode_gluon2.py", line 2480, in <module>
    sliding_window_accuracy_test()
  File "/aiter/op_tests/triton_tests/test_pa_decode_gluon2.py", line 2415, in sliding_window_accuracy_test
    parse_arg_and_run_test()
  File "/aiter/op_tests/triton_tests/test_pa_decode_gluon2.py", line 2067, in parse_arg_and_run_test
    results_df = run_multi_pa_gluon_test(
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/aiter/op_tests/triton_tests/test_pa_decode_gluon2.py", line 2025, in run_multi_pa_gluon_test
    result = _run_single_test((test_config, idx + 1, len(test_configs_to_run)))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/aiter/op_tests/triton_tests/test_pa_decode_gluon2.py", line 1914, in _run_single_test
    result = run_pa_gluon_test(
             ^^^^^^^^^^^^^^^^^^
  File "/aiter/aiter/test_common.py", line 128, in wrapper
    ret = func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/aiter/op_tests/triton_tests/test_pa_decode_gluon2.py", line 1549, in run_pa_gluon_test
    _, gluon_time = run_gluon_kernel(
                    ^^^^^^^^^^^^^^^^^
  File "/aiter/aiter/test_common.py", line 54, in wrapper
    iter_used_memory, inputSize, _, _ = device_memory_profiling(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/aiter/aiter/test_common.py", line 160, in device_memory_profiling
    data = func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/aiter/op_tests/triton_tests/test_pa_decode_gluon2.py", line 1208, in run_gluon_kernel
    torch.ops.aiter.pa_decode_gluon(
  File "/opt/venv/lib/python3.12/site-packages/torch/_ops.py", line 1243, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/utils/_device.py", line 103, in __torch_function__
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/_ops.py", line 1243, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/aiter/csrc/cpp_itfs/torch_utils.py", line 112, in _op_func
    return op_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/aiter/aiter/ops/triton/gluon/pa_decode_gluon.py", line 3610, in pa_decode_gluon
    _paged_attention_decode_v2_with_dot_kernel_reshape_wrapper(
  File "/aiter/aiter/ops/triton/gluon/pa_decode_gluon.py", line 3047, in _paged_attention_decode_v2_with_dot_kernel_reshape_wrapper
    paged_attention_decode_sliding_window[grid](
  File "/triton/python/triton/runtime/jit.py", line 419, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/triton/python/triton/runtime/autotuner.py", line 236, in run
    used_cached_result = self.check_disk_cache(key, pruned_configs, benchmark)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/triton/python/triton/runtime/autotuner.py", line 202, in check_disk_cache
    json.dumps({
  File "/usr/lib/python3.12/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type dtype is not JSON serializable
```
triton.language.dtype as tuning key meets above error.
Fix by the PR
