### PR TITLE
[TensorDescriptors] Handle pessimistic state with correct rank information

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1209,6 +1209,8 @@ void AxisInfo::initDimVectorFromHint(Attribute attr, DimVectorT *vec) {
   if (triton::PointerType ty = dyn_cast<triton::PointerType>(value.getType()))
     if (TensorType elemTy = dyn_cast<TensorType>(ty.getPointeeType()))
       rank = elemTy.getRank();
+  if (auto descTy = dyn_cast<triton::TensorDescInterface>(value.getType()))
+    rank = descTy.getBlockType().getRank();
 
   DimVectorT knownContiguity(rank, 1);
   DimVectorT knownDivisibility(rank, 1);

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -1162,3 +1162,12 @@ tt.func @dead_op_pessimistic() {
   }
   tt.return
 }
+
+// -----
+
+// Verify that tensor descriptor types get the correct rank in pessimistic state.
+tt.func @make_tensor_desc(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i64) {
+  // expected-remark @below {{contiguity = [1, 1], divisibility = [1, 1], constancy = [1, 1], constant_value = <none>}}
+  %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg1], [%arg2, %arg2] : <f32>, <tensor<128x64xf32>>
+  tt.return
+}


### PR DESCRIPTION
Tdescriptor `getPessimisticValueState` is not setting correct rank information, defaulting to 1 which is incorrect and may be causing some potential issues in the future