### PR TITLE
Add maxnreg support for ROCm/AMD backend

### DIFF
--- a/python/triton/experimental/gluon/_runtime.py
+++ b/python/triton/experimental/gluon/_runtime.py
@@ -34,7 +34,8 @@ class GluonASTSource(ASTSource):
         module.set_attr("ttg.threads-per-warp", builder.get_int32_attr(options.warp_size))
 
         is_cuda = options.backend_name == "cuda"
-        if is_cuda and options.maxnreg is not None:
+        is_hip = options.backend_name == "hip"
+        if (is_cuda or is_hip) and options.maxnreg is not None:
             module.set_attr("ttg.maxnreg", builder.get_int32_attr(options.maxnreg))
 
         module = ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -203,7 +203,7 @@ class Autotuner(KernelInterface):
         cache.put(
             json.dumps({
                 "key":
-                tuning_key,
+                [str(k) for k in tuning_key],
                 "configs_timings":
                 [(config.__dict__, timings) for config, timings in self.configs_timings.items() if not config.pre_hook],
             }), file_name, binary=False)
@@ -314,7 +314,8 @@ class Config:
     :type num_ctas: int
     :type maxnreg: Optional[int]
     :ivar maxnreg: maximum number of registers one thread can use.  Corresponds
-                       to ptx .maxnreg directive.  Not supported on all platforms.
+                       to ptx .maxnreg directive on CUDA and amdgpu-num-vgpr on ROCm.
+                       Not supported on all platforms.
     :ivar pre_hook: a function that will be called before the kernel is called. Parameters of this
                     function are args.
     :ivar ir_override: filename of a user-defined IR (*.{ttgir|llir|ptx|amdgcn}).

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -2,7 +2,7 @@ from triton.backends.compiler import BaseBackend, GPUTarget, Language
 from triton._C.libtriton import ir, passes, llvm, amd
 from triton import knobs
 from dataclasses import dataclass
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 from types import ModuleType
 import os
 import hashlib
@@ -61,6 +61,10 @@ class HIPOptions:
     allow_flush_denorm: bool = False
     max_num_imprecise_acc_default: int = 0
     backend_name: str = 'hip'
+    # maxnreg corresponds to the amdgpu-num-vgpr attribute, which controls the
+    # maximum number of VGPRs (vector registers) used per work-item. Similar to
+    # CUDA's .maxnreg PTX directive. Not supported on all platforms.
+    maxnreg: Optional[int] = None
     instrumentation_mode: str = ""
 
     # The following option provides hints to the AMDGPU backend regarding instruction scheduling
@@ -429,6 +433,12 @@ class HIPBackend(BaseBackend):
         fns[0].add_fn_attr("amdgpu-waves-per-eu", f"{options.waves_per_eu}, {options.waves_per_eu}")
         denormal_mode = "preserve-sign" if options.allow_flush_denorm else "ieee"
         fns[0].add_fn_attr("denormal-fp-math-f32", denormal_mode)
+        # maxnreg can come from options (autotuner) or from ttg.maxnreg on the module (e.g. Gluon)
+        maxnreg = options.maxnreg
+        if maxnreg is None and hasattr(src, 'get_int_attr'):
+            maxnreg = src.get_int_attr("ttg.maxnreg")
+        if maxnreg is not None:
+            fns[0].add_fn_attr("amdgpu-num-vgpr", str(maxnreg))
         if knobs.compilation.enable_asan:
             fns[0].add_fn_target_feature("+xnack")
             fns[0].add_fn_asan_attr()


### PR DESCRIPTION
- Add maxnreg option to HIPOptions in AMD backend compiler
- Set amdgpu-num-vgpr LLVM attribute when maxnreg is specified
- Support maxnreg from options (autotuner) or ttg.maxnreg module attr (Gluon)
- Update Gluon runtime to set ttg.maxnreg for HIP backend
- Update autotuner documentation for ROCm support

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
