### PR TITLE
[backend] Preserve original num_warps in metadata before warp-specialization overwrite

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -470,6 +470,8 @@ class HIPBackend(BaseBackend):
             amd.add_scalarize_packed_fops_llvm_pass(fns[0])
 
         # Get some metadata
+        if total_num_warps is not None and total_num_warps != metadata["num_warps"]:
+            metadata["num_warps_base"] = metadata["num_warps"]
         metadata["num_warps"] = total_warps_num
         metadata["shared"] = src.get_int_attr("ttg.shared")
         metadata["global_scratch_size"] = src.get_int_attr("ttg.global_scratch_memory_size")

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -431,7 +431,8 @@ class CUDABackend(BaseBackend):
         # Get some metadata
         # warp-specialization mutates num_warps
         total_num_warps = src.get_int_attr("ttg.total-num-warps")
-        if total_num_warps is not None:
+        if total_num_warps is not None and total_num_warps != metadata["num_warps"]:
+            metadata["num_warps_base"] = metadata["num_warps"]
             metadata["num_warps"] = total_num_warps
         metadata["shared"] = src.get_int_attr("ttg.shared")
         metadata["tmem_size"] = src.get_int_attr("ttg.tensor_memory_size")


### PR DESCRIPTION

## Problem

When warp-specialization is enabled, the `AllocateWarpGroups` pass computes a new total warp count (`baseNumWarps + numExtraWarpGroups * 4`) and stores it as the `ttg.total-num-warps` module attribute. During `make_llir`, this value **overwrites** `metadata["num_warps"]`, silently discarding the user-specified warp count.

For example, a user declares `num_warps=4`, but after warp-specialization the metadata reports `num_warps=12`. The original value of `4` is permanently lost.

This causes issues for downstream metadata consumers:
- **tritonparse**: Cannot distinguish user intent from compiler-internal warp allocation. Currently works around this by re-extracting the value from `triton.Config` source.
- **Proton profiler**: Reports thread counts based on the post-transformation `num_warps`, which may be misleading for performance analysis.
- **Reproducer generation**: Needs the original `num_warps` to correctly replay a compilation, not the inflated total.

## Solution

Before overwriting `metadata["num_warps"]`, save the user-specified value as `metadata["num_warps_base"]`. The naming follows the `baseNumWarps` terminology already used in `AllocateWarpGroups.cpp`.

The new key is **only added when warp-specialization actually changes the warp count** (i.e., when `ttg.total-num-warps` is present **and** differs from the original `num_warps`). This means the presence of `num_warps_base` in metadata is itself a clear signal that mutation occurred.

Both **NVIDIA (CUDA)** and **AMD (HIP)** backends are updated for consistency.

## Changes

- `third_party/nvidia/backend/compiler.py`: Save `metadata["num_warps_base"]` before overwriting `metadata["num_warps"]` in `CUDABackend.make_llir()`, only when the value actually changes.
- `third_party/amd/backend/compiler.py`: Save `metadata["num_warps_base"]` before overwriting `metadata["num_warps"]` in `HIPBackend.make_llir()`, only when the value actually changes.

## Impact

- **No breaking changes**: `metadata["num_warps"]` continues to hold the post-transformation value. All existing consumers (`pack_metadata`, `driver.c`, resource validation) are unaffected.
- **Backward compatible**: The new key is simply an addition to the metadata dict, which is serialized as JSON and loaded into a dynamically-generated namedtuple. No schema validation exists.
- **Cache compatible**: The new key does not affect cache key computation.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it's a metadata change`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
