### PR TITLE
Fix abs on FNUZ FP8 types incorrectly converting NaN to zero

### DIFF
--- a/test/Conversion/amd/abs_fp8.mlir
+++ b/test/Conversion/amd/abs_fp8.mlir
@@ -1,0 +1,50 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=arch=gfx942 | FileCheck %s
+
+// Verify that abs on FNUZ FP8 types preserves NaN (0x80).
+// The lowering must include an icmp+select to keep abs(NaN)=NaN,
+// because simply clearing the sign bit turns 0x80 into 0x00 (zero).
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+// CHECK-LABEL: llvm.func @abs_f8E4M3FNUZ
+// CHECK: llvm.mlir.constant(127 : i8)
+// CHECK: llvm.and
+// CHECK: llvm.mlir.constant(-128 : i8)
+// CHECK: llvm.icmp "eq"
+// CHECK: llvm.select
+  tt.func public @abs_f8E4M3FNUZ(%arg0: f8E4M3FNUZ) {
+    %0 = math.absf %arg0 : f8E4M3FNUZ
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+// CHECK-LABEL: llvm.func @abs_f8E5M2FNUZ
+// CHECK: llvm.mlir.constant(127 : i8)
+// CHECK: llvm.and
+// CHECK: llvm.mlir.constant(-128 : i8)
+// CHECK: llvm.icmp "eq"
+// CHECK: llvm.select
+  tt.func public @abs_f8E5M2FNUZ(%arg0: f8E5M2FNUZ) {
+    %0 = math.absf %arg0 : f8E5M2FNUZ
+    tt.return
+  }
+}
+
+// -----
+
+// Non-FNUZ FP8 types should NOT have the icmp+select NaN guard.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+// CHECK-LABEL: llvm.func @abs_f8E4M3FN
+// CHECK:     llvm.mlir.constant(127 : i8)
+// CHECK:     llvm.and
+// CHECK-NOT: llvm.icmp
+// CHECK-NOT: llvm.select
+// CHECK:     llvm.return
+  tt.func public @abs_f8E4M3FN(%arg0: f8E4M3FN) {
+    %0 = math.absf %arg0 : f8E4M3FN
+    tt.return
+  }
+}


### PR DESCRIPTION
## Problem

The `AbsFOpConversion` lowering in `ElementwiseOpToLLVM.cpp` computes `abs` on FP8 types stored as integers by AND-ing with a bitmask that clears the sign bit. For FNUZ float types (`Float8E4M3FNUZ`, `Float8E5M2FNUZ`, `Float8E4M3B11FNUZ`), this is incorrect: these types encode NaN as `0x80` — the sign bit set with all mantissa and exponent bits zero. Clearing the sign bit produces `0x00`, silently converting NaN to positive zero.

This differs from standard FP8 types (e.g. `Float8E4M3FN`) where NaN uses the all-exponents-one encoding (`0x7F`/`0xFF`), so the AND mask preserves NaN correctly.

## Fix

After the existing AND to clear the sign bit, insert an `icmp eq` against the NaN encoding (`1 << (num_bits - 1)`), and `select` to return the original NaN constant when the input matches. This adds two instructions only for FNUZ types; the non-FNUZ path is unchanged.

```
result = and(input, 0x7F)        // clear sign bit
isNan  = icmp eq input, 0x80     // check for FNUZ NaN encoding
output = select(isNan, 0x80, result)
```

## Changes

- **`lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp`**: Guard the sign-bit-clearing result with an `icmp eq` + `select` for FNUZ types, keyed on `isa<Float8E4M3FNUZType, Float8E5M2FNUZType, Float8E4M3B11FNUZType>`.
- **`test/Conversion/amd/abs_fp8.mlir`**: Lit test verifying the lowering emits the `icmp`+`select` guard for `f8E4M3FNUZ` and `f8E5M2FNUZ`, and does NOT emit it for `f8E4M3FN` (negative check).
- **`python/test/unit/language/test_core.py`**: 
  - Extend `test_abs_fp8` parametrization to include `float8e4b8` and `float8e5b16` with appropriate skip conditions (CDNA3-only on HIP, skipped on CUDA).
  - Fix `convert_float_to_float32` to handle FNUZ special cases: `0x80` maps to NaN (not negative zero), no infinities.

## Testing

Lit test (`abs_fp8.mlir`) and pytest (`test_abs_fp8`, `test_abs`) all pass on gfx942.