### PR TITLE
[Runtime] Parallel autotuner compilation

### DIFF
--- a/python/test/microbenchmark/bench_parallel_autotuner.py
+++ b/python/test/microbenchmark/bench_parallel_autotuner.py
@@ -1,6 +1,6 @@
 """Benchmark for parallel autotuner compilation.
 
-Measures autotuning time across worker counts and overlap modes.
+Measures autotuning and warmup time across worker counts and overlap modes.
 Each case uses a unique scale factor (derived from --key) to force fresh compilations.
 
 Usage:
@@ -26,7 +26,7 @@ CONFIGS = [
     for bk in [32, 64]
 ]
 
-CASES = [
+AUTOTUNE_CASES = [
     ("workers=1 (sequential)", 1, True),
     ("workers=0 (auto)", 0, True),
     ("workers=2, overlap=off", 2, False),
@@ -37,6 +37,15 @@ CASES = [
     ("workers=4, overlap=on", 4, True),
     ("workers=8, overlap=on", 8, True),
     ("workers=12, overlap=on", 12, True),
+]
+
+WARMUP_CASES = [
+    ("workers=1 (sequential)", 1),
+    ("workers=0 (auto)", 0),
+    ("workers=2", 2),
+    ("workers=4", 4),
+    ("workers=8", 8),
+    ("workers=12", 12),
 ]
 
 
@@ -98,6 +107,56 @@ def _run_matmul(scale):
     return elapsed
 
 
+def _run_warmup(scale):
+    """Define a fresh autotuned matmul kernel, warmup all configs, return elapsed time."""
+    from triton.runtime.jit import MockTensor
+
+    @triton.autotune(configs=list(CONFIGS), key=["M", "N", "K", "SCALE"])
+    @triton.jit
+    def matmul_kernel(
+        a_ptr, b_ptr, c_ptr,
+        M, N, K,
+        stride_am, stride_ak,
+        stride_bk, stride_bn,
+        stride_cm, stride_cn,
+        SCALE: tl.constexpr,
+        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        offs_k = tl.arange(0, BLOCK_K)
+        a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+        b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for _ in range(0, K, BLOCK_K):
+            a = tl.load(a_ptrs, mask=offs_k[None, :] < K)
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K)
+            acc += tl.dot(a, b)
+            a_ptrs += BLOCK_K * stride_ak
+            b_ptrs += BLOCK_K * stride_bk
+        acc = acc * SCALE
+        c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+        tl.store(c_ptrs, acc, mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+
+    M, N, K = 512, 512, 512
+
+    start = time.perf_counter()
+    matmul_kernel.warmup(
+        MockTensor(torch.float16), MockTensor(torch.float16), MockTensor(torch.float16),
+        M, N, K,
+        K, 1,  # stride_am, stride_ak
+        N, 1,  # stride_bk, stride_bn
+        N, 1,  # stride_cm, stride_cn
+        scale,
+        grid=(triton.cdiv(M, 32), triton.cdiv(N, 32)),
+    )
+    elapsed = time.perf_counter() - start
+
+    return elapsed
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Benchmark parallel autotuner")
@@ -110,18 +169,45 @@ def main():
     if args.key < 1 or args.key > 1000:
         parser.error("--key must be between 1 and 1000")
 
+    num_cases = len(AUTOTUNE_CASES) + len(WARMUP_CASES)
+
     print(f"Parallel autotuner benchmark - {len(CONFIGS)} configs, key={args.key}")
+
+    # Autotune benchmark (compile + bench)
     print()
+    print(f"  Autotune (compile + benchmark)")
     print(f"  {'Case':30s}  {'Time':>7s}  {'vs seq':>7s}")
     print(f"  {'-'*48}")
 
     baseline = None
-    for i, (label, workers, overlap) in enumerate(CASES):
-        scale = args.key * len(CASES) + i
+    for i, (label, workers, overlap) in enumerate(AUTOTUNE_CASES):
+        scale = args.key * num_cases + i
         os.environ["TRITON_AUTOTUNING_COMPILE_WORKERS"] = str(workers)
         os.environ["TRITON_AUTOTUNING_OVERLAP_BENCH"] = "1" if overlap else "0"
         try:
             elapsed = _run_matmul(scale)
+        except Exception as e:
+            print(f"  {label:30s}  FAILED (scale={scale})")
+            for line in str(e).split("\n")[-3:]:
+                print(f"    {line}")
+            continue
+        if baseline is None:
+            baseline = elapsed
+        speedup = baseline / elapsed if elapsed > 0 else float("inf")
+        print(f"  {label:30s}  {elapsed:6.2f}s  {speedup:5.2f}x")
+
+    # Warmup benchmark (compile only)
+    print()
+    print(f"  Warmup (compile only)")
+    print(f"  {'Case':30s}  {'Time':>7s}  {'vs seq':>7s}")
+    print(f"  {'-'*48}")
+
+    baseline = None
+    for i, (label, workers) in enumerate(WARMUP_CASES):
+        scale = args.key * num_cases + len(AUTOTUNE_CASES) + i
+        os.environ["TRITON_AUTOTUNING_COMPILE_WORKERS"] = str(workers)
+        try:
+            elapsed = _run_warmup(scale)
         except Exception as e:
             print(f"  {label:30s}  FAILED (scale={scale})")
             for line in str(e).split("\n")[-3:]:

--- a/python/test/microbenchmark/bench_parallel_autotuner.py
+++ b/python/test/microbenchmark/bench_parallel_autotuner.py
@@ -1,0 +1,137 @@
+"""Benchmark for parallel autotuner compilation.
+
+Measures autotuning time across worker counts and overlap modes.
+Each case uses a unique scale factor (derived from --key) to force fresh compilations.
+
+Usage:
+    python bench_parallel_autotuner.py              # starts at key=1
+    python bench_parallel_autotuner.py --key 100    # starts at key=100
+
+Each case uses key*num_cases+i as its scale factor, so consecutive keys never
+overlap. Increment --key between runs to force all-new compilations.
+"""
+
+import os
+import time
+
+import torch
+
+import triton
+import triton.language as tl
+
+CONFIGS = [
+    triton.Config({"BLOCK_M": bm, "BLOCK_N": bn, "BLOCK_K": bk})
+    for bm in [32, 64, 128]
+    for bn in [32, 64, 128]
+    for bk in [32, 64]
+]
+
+CASES = [
+    ("workers=1 (sequential)", 1, True),
+    ("workers=0 (auto)", 0, True),
+    ("workers=2, overlap=off", 2, False),
+    ("workers=4, overlap=off", 4, False),
+    ("workers=8, overlap=off", 8, False),
+    ("workers=12, overlap=off", 12, False),
+    ("workers=2, overlap=on", 2, True),
+    ("workers=4, overlap=on", 4, True),
+    ("workers=8, overlap=on", 8, True),
+    ("workers=12, overlap=on", 12, True),
+]
+
+
+def _run_matmul(scale):
+    """Define a fresh autotuned matmul kernel, run it, verify correctness, return elapsed time."""
+
+    @triton.autotune(configs=list(CONFIGS), key=["M", "N", "K", "SCALE"])
+    @triton.jit
+    def matmul_kernel(
+        a_ptr, b_ptr, c_ptr,
+        M, N, K,
+        stride_am, stride_ak,
+        stride_bk, stride_bn,
+        stride_cm, stride_cn,
+        SCALE: tl.constexpr,
+        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        offs_k = tl.arange(0, BLOCK_K)
+        a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+        b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for _ in range(0, K, BLOCK_K):
+            a = tl.load(a_ptrs, mask=offs_k[None, :] < K)
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K)
+            acc += tl.dot(a, b)
+            a_ptrs += BLOCK_K * stride_ak
+            b_ptrs += BLOCK_K * stride_bk
+        acc = acc * SCALE
+        c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+        tl.store(c_ptrs, acc, mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+
+    M, N, K = 512, 512, 512
+    a = torch.randn(M, K, device="cuda", dtype=torch.float16)
+    b = torch.randn(K, N, device="cuda", dtype=torch.float16)
+    c = torch.empty(M, N, device="cuda", dtype=torch.float16)
+
+    grid = lambda META: (triton.cdiv(M, META["BLOCK_M"]), triton.cdiv(N, META["BLOCK_N"]))
+
+    start = time.perf_counter()
+    matmul_kernel[grid](
+        a, b, c, M, N, K,
+        a.stride(0), a.stride(1),
+        b.stride(0), b.stride(1),
+        c.stride(0), c.stride(1),
+        scale,
+    )
+    torch.cuda.synchronize()
+    elapsed = time.perf_counter() - start
+
+    ref = torch.matmul(a.float(), b.float()).half() * scale
+    max_diff = (c - ref).abs().max().item()
+    if max_diff > 1.0 * scale:
+        raise RuntimeError(f"max_diff={max_diff:.4f} exceeds tolerance for scale={scale}")
+
+    return elapsed
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Benchmark parallel autotuner")
+    parser.add_argument(
+        "--key", type=int, default=1, help="Starting scale factor (1-1000). Each case gets "
+        "a unique scale derived from key * num_cases + i, so consecutive keys never "
+        "overlap. Increment between runs for fresh compilations. (default: 1)")
+    args = parser.parse_args()
+
+    if args.key < 1 or args.key > 1000:
+        parser.error("--key must be between 1 and 1000")
+
+    print(f"Parallel autotuner benchmark - {len(CONFIGS)} configs, key={args.key}")
+    print()
+    print(f"  {'Case':30s}  {'Time':>7s}  {'vs seq':>7s}")
+    print(f"  {'-'*48}")
+
+    baseline = None
+    for i, (label, workers, overlap) in enumerate(CASES):
+        scale = args.key * len(CASES) + i
+        os.environ["TRITON_AUTOTUNING_COMPILE_WORKERS"] = str(workers)
+        os.environ["TRITON_AUTOTUNING_OVERLAP_BENCH"] = "1" if overlap else "0"
+        try:
+            elapsed = _run_matmul(scale)
+        except Exception as e:
+            print(f"  {label:30s}  FAILED (scale={scale})")
+            for line in str(e).split("\n")[-3:]:
+                print(f"    {line}")
+            continue
+        if baseline is None:
+            baseline = elapsed
+        speedup = baseline / elapsed if elapsed > 0 else float("inf")
+        print(f"  {label:30s}  {elapsed:6.2f}s  {speedup:5.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/test/unit/runtime/test_parallel_autotuner.py
+++ b/python/test/unit/runtime/test_parallel_autotuner.py
@@ -1,0 +1,147 @@
+"""Tests for parallel autotuner compilation.
+
+Verifies correctness, restore_value, and exception handling across all
+code paths: sequential (workers=1), parallel with overlap disabled, and
+parallel with overlap enabled.
+
+Each test uses a unique SCALE constexpr per mode to force fresh compilations
+and avoid hitting the disk cache from a previous mode.
+"""
+
+import os
+
+import torch
+import pytest
+
+import triton
+import triton.language as tl
+
+
+def do_bench(kernel_call, quantiles, use_cuda_graph=False):
+    return triton.testing.do_bench(kernel_call, quantiles=quantiles, warmup=1, rep=1)
+
+
+MODES = [
+    (0, 1, True),
+    (1, 2, False),
+    (2, 2, True),
+]
+MODE_IDS = ["sequential", "parallel-no-overlap", "parallel-overlap"]
+
+CONFIGS = [
+    triton.Config(kwargs={"BLOCK_SIZE": 32}),
+    triton.Config(kwargs={"BLOCK_SIZE": 64}),
+    triton.Config(kwargs={"BLOCK_SIZE": 128}),
+    triton.Config(kwargs={"BLOCK_SIZE": 256}),
+]
+
+
+def _set_env(workers, overlap):
+    os.environ["TRITON_AUTOTUNING_COMPILE_WORKERS"] = str(workers)
+    os.environ["TRITON_AUTOTUNING_OVERLAP_BENCH"] = "1" if overlap else "0"
+
+
+def _clear_env():
+    os.environ.pop("TRITON_AUTOTUNING_COMPILE_WORKERS", None)
+    os.environ.pop("TRITON_AUTOTUNING_OVERLAP_BENCH", None)
+
+
+@pytest.mark.parametrize("mode_idx, workers, overlap", MODES, ids=MODE_IDS)
+def test_correctness(mode_idx, workers, overlap, device):
+    """Each code path produces correct results and selects a config."""
+    N = 4096
+    scale = 100 + mode_idx
+    src = torch.randn(N, device=device)
+    dst = torch.empty(N, device=device)
+
+    @triton.autotune(configs=list(CONFIGS), key=["N", "SCALE"])
+    @triton.jit
+    def copy_kernel(src_ptr, dst_ptr, N, SCALE: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+        offs = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offs < N
+        tl.store(dst_ptr + offs, tl.load(src_ptr + offs, mask=mask) * SCALE, mask=mask)
+
+    _set_env(workers, overlap)
+    try:
+        grid = lambda META: (triton.cdiv(N, META["BLOCK_SIZE"]),)
+        copy_kernel[grid](src, dst, N, scale)
+        torch.testing.assert_close(src * scale, dst)
+        assert copy_kernel.best_config is not None
+        assert copy_kernel.bench_time > 0
+    finally:
+        _clear_env()
+
+
+@pytest.mark.parametrize("mode_idx, workers, overlap", MODES, ids=MODE_IDS)
+def test_restore(mode_idx, workers, overlap, device):
+    """restore_value correctly restores tensor state between config benchmarks."""
+    N = 1024
+    scale = 200 + mode_idx
+    src = torch.zeros(N, device=device)
+
+    configs = [triton.Config(kwargs={"BLOCK_SIZE": 32}), triton.Config(kwargs={"BLOCK_SIZE": 128})]
+
+    @triton.autotune(configs=configs, key=["N", "SCALE"], restore_value=["src"], do_bench=do_bench)
+    @triton.jit
+    def _kernel(src, N, SCALE: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + offsets, mask=offsets < N) + SCALE
+        tl.store(src + offsets, x, mask=offsets < N)
+
+    _set_env(workers, overlap)
+    try:
+        grid = lambda META: (triton.cdiv(N, META["BLOCK_SIZE"]),)
+        _kernel[grid](src, N, scale)
+        expected = torch.full_like(src, scale, dtype=src.dtype)
+        triton.testing.assert_close(src, expected)
+    finally:
+        _clear_env()
+
+
+@pytest.mark.parametrize("mode_idx, workers, overlap", MODES, ids=MODE_IDS)
+def test_exceed_threads(mode_idx, workers, overlap, device):
+    """Configs that exceed hardware limits are handled gracefully."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    scale = 300 + mode_idx
+    x = torch.empty(1024, device=device, dtype=torch.float32)
+    y = torch.empty_like(x)
+    output = torch.empty_like(x)
+
+    configs = [
+        triton.Config({}, num_warps=128),
+        triton.Config({}, num_warps=4),
+    ]
+
+    exception_out_of_resource = None
+
+    def _post_hook(*args, exception):
+        nonlocal exception_out_of_resource
+        if exception is not None:
+            exception_out_of_resource = exception
+
+    @triton.autotune(configs=configs, key=["BLOCK_SIZE", "SCALE"], do_bench=do_bench, post_hook=_post_hook)
+    @triton.jit
+    def add_kernel(x_ptr, y_ptr, output_ptr, n_elements, SCALE: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+        pid = tl.program_id(0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        xv = tl.load(x_ptr + offsets, mask=mask)
+        yv = tl.load(y_ptr + offsets, mask=mask)
+        out = (xv + yv) * SCALE
+        tl.store(output_ptr + offsets, out, mask=mask)
+
+    _set_env(workers, overlap)
+    try:
+        def grid(meta):
+            return (triton.cdiv(x.numel(), meta["BLOCK_SIZE"]),)
+
+        add_kernel[grid](x, y, output, x.numel(), scale, BLOCK_SIZE=128)
+
+        warp_size = triton.runtime.driver.active.get_current_target().warp_size
+        assert exception_out_of_resource is not None and f"out of resource: threads, Required: {128 * warp_size}" in str(
+            exception_out_of_resource)
+    finally:
+        _clear_env()

--- a/python/test/unit/runtime/test_parallel_autotuner.py
+++ b/python/test/unit/runtime/test_parallel_autotuner.py
@@ -1,7 +1,7 @@
 """Tests for parallel autotuner compilation.
 
-Verifies correctness, restore_value, and exception handling across all
-code paths: sequential (workers=1), parallel with overlap disabled, and
+Verifies correctness, restore_value, exception handling, and warmup across
+all code paths: sequential (workers=1), parallel with overlap disabled, and
 parallel with overlap enabled.
 
 Each test uses a unique SCALE constexpr per mode to force fresh compilations
@@ -27,6 +27,12 @@ MODES = [
     (2, 2, True),
 ]
 MODE_IDS = ["sequential", "parallel-no-overlap", "parallel-overlap"]
+
+WARMUP_MODES = [
+    (0, 1),
+    (1, 2),
+]
+WARMUP_IDS = ["sequential", "parallel"]
 
 CONFIGS = [
     triton.Config(kwargs={"BLOCK_SIZE": 32}),
@@ -145,3 +151,27 @@ def test_exceed_threads(mode_idx, workers, overlap, device):
             exception_out_of_resource)
     finally:
         _clear_env()
+
+
+@pytest.mark.parametrize("mode_idx, workers", WARMUP_MODES, ids=WARMUP_IDS)
+def test_warmup(mode_idx, workers, device):
+    """Warmup compiles all configs without executing."""
+    from triton.runtime.jit import MockTensor
+
+    scale = 400 + mode_idx
+
+    @triton.autotune(configs=list(CONFIGS), key=["N", "SCALE"])
+    @triton.jit
+    def copy_kernel(src_ptr, dst_ptr, N, SCALE: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+        offs = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offs < N
+        tl.store(dst_ptr + offs, tl.load(src_ptr + offs, mask=mask) * SCALE, mask=mask)
+
+    os.environ["TRITON_AUTOTUNING_COMPILE_WORKERS"] = str(workers)
+    try:
+        ret = copy_kernel.warmup(MockTensor(torch.float16), MockTensor(torch.float16),
+                                 4096, scale, grid=(128,))
+        assert len(ret) == len(CONFIGS)
+        assert all(r is not None for r in ret)
+    finally:
+        os.environ.pop("TRITON_AUTOTUNING_COMPILE_WORKERS", None)

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -374,6 +374,17 @@ class compilation_knobs(base_knobs):
 class autotuning_knobs(base_knobs):
     cache: env_bool = env_bool("TRITON_CACHE_AUTOTUNING")
     print: env_bool = env_bool("TRITON_PRINT_AUTOTUNING")
+    # Number of threads for parallel kernel compilation during autotuning.
+    # 0 = auto (min(4, cpu_count//2)), 1 = sequential (original code path).
+    compile_workers: env_int = env_int("TRITON_AUTOTUNING_COMPILE_WORKERS", 1)
+    # When True and compile_workers > 1, benchmarking runs between compilations:
+    # as each config finishes compiling, it is benchmarked (sequentially) while
+    # remaining configs continue compiling in background threads. When False,
+    # all configs are compiled first, then benchmarked sequentially. The overlap
+    # option exists because background compilation activity could theoretically
+    # affect benchmark accuracy on unified-memory systems — though in practice
+    # any other background work on the system would have the same effect.
+    overlap_bench: env_bool = env_bool("TRITON_AUTOTUNING_OVERLAP_BENCH", True)
 
 
 class LaunchHook(Protocol):

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -168,6 +168,14 @@ class Autotuner(KernelInterface):
                 print(f"Autotuning failed with {e}")
             return [float("inf"), float("inf"), float("inf")]
 
+    @staticmethod
+    def _resolve_num_workers():
+        """Resolve the effective number of compile workers from the knob."""
+        num_workers = knobs.autotuning.compile_workers
+        if num_workers == 0:
+            num_workers = min(4, max(1, (os.cpu_count() or 1) // 2))
+        return num_workers
+
     def _compile_config(self, *args, config, **meta):
         """Compile a single config without benchmarking. Thread-safe."""
         current = dict(meta, **config.all_kwargs())
@@ -273,9 +281,7 @@ class Autotuner(KernelInterface):
                 pruned_configs = self.prune_configs(kwargs)
 
                 def benchmark():
-                    num_workers = knobs.autotuning.compile_workers
-                    if num_workers == 0:
-                        num_workers = min(4, max(1, (os.cpu_count() or 1) // 2))
+                    num_workers = self._resolve_num_workers()
 
                     bench_start = time.perf_counter()
                     if num_workers > 1 and len(pruned_configs) > 1:
@@ -342,13 +348,28 @@ class Autotuner(KernelInterface):
 
     def warmup(self, *args, **kwargs):
         self.nargs = dict(zip(self.arg_names, args))
-        ret = []
-        for autotune_config in self.prune_configs(kwargs):
-            ret.append(self.fn.warmup(
-                *args,
-                **kwargs,
-                **autotune_config.all_kwargs(),
-            ))
+        pruned_configs = self.prune_configs(kwargs)
+        num_workers = self._resolve_num_workers()
+        if num_workers > 1 and len(pruned_configs) > 1:
+            from concurrent.futures import ThreadPoolExecutor, as_completed
+            import sysconfig
+            sysconfig.get_config_vars()
+            ret = [None] * len(pruned_configs)
+            with ThreadPoolExecutor(max_workers=num_workers) as executor:
+                futures = {}
+                for i, autotune_config in enumerate(pruned_configs):
+                    future = executor.submit(self.fn.warmup, *args, **kwargs, **autotune_config.all_kwargs())
+                    futures[future] = i
+                for future in as_completed(futures):
+                    ret[futures[future]] = future.result()
+        else:
+            ret = []
+            for autotune_config in pruned_configs:
+                ret.append(self.fn.warmup(
+                    *args,
+                    **kwargs,
+                    **autotune_config.all_kwargs(),
+                ))
         self.nargs = None
         return ret
 

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import os
 import time
 import inspect
 import hashlib
@@ -167,6 +168,53 @@ class Autotuner(KernelInterface):
                 print(f"Autotuning failed with {e}")
             return [float("inf"), float("inf"), float("inf")]
 
+    def _compile_config(self, *args, config, **meta):
+        """Compile a single config without benchmarking. Thread-safe."""
+        current = dict(meta, **config.all_kwargs())
+        current['warmup'] = True
+        self.fn.run(*args, **current)
+
+    def _parallel_bench(self, *args, configs, num_workers, **kwargs):
+        """Compile configs in parallel, benchmark sequentially."""
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        from ..compiler.errors import CompileTimeAssertionFailure
+
+        # Workaround for thread-unsafe sysconfig initialization (Python <3.12).
+        # See https://github.com/python/cpython/issues/92452
+        import sysconfig
+        sysconfig.get_config_vars()
+
+        verbose = knobs.autotuning.print
+        overlap = knobs.autotuning.overlap_bench
+        timings = {}
+        failed = set()
+
+        with ThreadPoolExecutor(max_workers=num_workers) as executor:
+            future_to_config = {}
+            for config in configs:
+                future = executor.submit(self._compile_config, *args, config=config, **kwargs)
+                future_to_config[future] = config
+
+            for future in as_completed(future_to_config):
+                config = future_to_config[future]
+                try:
+                    future.result()
+                except (OutOfResources, CompileTimeAssertionFailure, PTXASError) as e:
+                    if verbose:
+                        print(f"Autotuning compile failed for {config}: {e}")
+                    timings[config] = [float("inf"), float("inf"), float("inf")]
+                    failed.add(config)
+                    continue
+                if overlap:
+                    timings[config] = self._bench(*args, config=config, **kwargs)
+
+        if not overlap:
+            for config in configs:
+                if config not in failed:
+                    timings[config] = self._bench(*args, config=config, **kwargs)
+
+        return timings
+
     def check_disk_cache(self, tuning_key, configs, bench_fn):
         # We can't serialize prehooks, so just give up and run the benchmarks.
         if not tuning_key or any(cfg.pre_hook for cfg in configs):
@@ -225,9 +273,17 @@ class Autotuner(KernelInterface):
                 pruned_configs = self.prune_configs(kwargs)
 
                 def benchmark():
-                    bench_start = time.time()
-                    timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
-                    bench_end = time.time()
+                    num_workers = knobs.autotuning.compile_workers
+                    if num_workers == 0:
+                        num_workers = min(4, max(1, (os.cpu_count() or 1) // 2))
+
+                    bench_start = time.perf_counter()
+                    if num_workers > 1 and len(pruned_configs) > 1:
+                        timings = self._parallel_bench(*args, configs=pruned_configs, num_workers=num_workers, **kwargs)
+                    else:
+                        timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
+                    bench_end = time.perf_counter()
+
                     self.bench_time = bench_end - bench_start
                     self.cache[key] = builtins.min(timings, key=timings.get)
                     full_nargs = {**self.nargs, **kwargs, **self.cache[key].all_kwargs()}


### PR DESCRIPTION
## Summary

Compiles autotuner configs in parallel via ThreadPoolExecutor, benchmarking sequentially as each finishes or after all complete depending on configuration. Also parallelizes `Autotuner.warmup()` (compile-only, no benchmarking) using the same worker pool. On a typical 18-config matmul autotune, 4 compile threads cuts total autotuning time by ~2.5x (compilation dominates; benchmarking is unaffected). Warmup sees higher gains (~3.7x at 12 workers) since there is no sequential benchmark floor.

Also switches bench timing from `time.time()` to `time.perf_counter()` for monotonic, higher-resolution elapsed time measurement and uniformity with the Windows fork.

Two knobs control behavior:

- `TRITON_AUTOTUNING_COMPILE_WORKERS` — number of compile threads. `0` = auto (`min(4, cpu_count//2)`), `1` = original sequential code path (default).

- `TRITON_AUTOTUNING_OVERLAP_BENCH` — when `True` (default) and workers > 1, each config is benchmarked as soon as it finishes compiling, while remaining configs continue compiling in background threads. Benchmarking is always sequential — only compilation is parallelized. When `False`, all configs compile first, then benchmark sequentially. Only meaningful when `compile_workers > 1`; with sequential compilation there is nothing to overlap.

`workers=1` falls through to the original unmodified code path — no ThreadPoolExecutor, no behavior change.

Closes #4806. Supersedes #5436.

### Benchmark (AMD gfx1151, 16 cores / 32 logical)

```
Parallel autotuner benchmark - 18 configs, key=900

  Autotune (compile + benchmark)
  Case                               Time   vs seq
  ------------------------------------------------
  workers=1 (sequential)            9.44s   1.00x
  workers=0 (auto)                  3.61s   2.62x
  workers=2, overlap=off            6.33s   1.49x
  workers=4, overlap=off            4.75s   1.99x
  workers=8, overlap=off            4.19s   2.26x
  workers=12, overlap=off           3.88s   2.44x
  workers=2, overlap=on             4.97s   1.90x
  workers=4, overlap=on             3.66s   2.58x
  workers=8, overlap=on             3.33s   2.83x
  workers=12, overlap=on            3.23s   2.92x

  Warmup (compile only)
  Case                               Time   vs seq
  ------------------------------------------------
  workers=1 (sequential)            7.26s   1.00x
  workers=0 (auto)                  2.78s   2.61x
  workers=2                         4.17s   1.74x
  workers=4                         2.99s   2.43x
  workers=8                         2.28s   3.19x
  workers=12                        1.98s   3.67x
```

Diminishing returns beyond 4 workers for autotune (sequential benchmarking is the floor). Warmup keeps scaling since it's compile-only.

### Testing

`test_parallel_autotuner.py` validates correctness, restore_value, exception handling, and warmup across all code paths: sequential (`workers=1`), parallel with overlap disabled, and parallel with overlap enabled. Existing `test_autotuner.py` passes unchanged with the new default (`workers=1`).

`bench_parallel_autotuner.py` in `test/microbenchmark/` provides standalone timing across worker counts for both autotune and warmup. A `--key` argument controls the starting scale factor; increment between runs for fresh compilations.

## New contributor declaration

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests.
- [x] I have not added any `lit` tests.
