### PR TITLE
Fix loop-carried variable type error for JIT-specialized constexpr

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6378,6 +6378,31 @@ def test_temp_var_in_loop(device):
     assert (acc == out).all()
 
 
+def test_constexpr_reassign_in_loop(device):
+    # Regression test for #9547: when a stride argument gets JIT-specialized
+    # to constexpr and is then reassigned inside a loop, the compiler should
+    # relax it to a runtime value instead of raising a type mismatch error.
+
+    @triton.jit
+    def kernel(a_ptr, a0, b_ptr, b0, out, o0):
+        for i in range(0, 8, 2):
+            tl.store(out + i * o0, tl.load(a_ptr + i * a0))
+            a_ptr = b_ptr
+            a0 = b0
+
+    a = torch.arange(8, dtype=torch.int32, device=device)
+    b = torch.arange(8, dtype=torch.int32, device=device) + 10
+    out = torch.zeros(8, dtype=torch.int32, device=device)
+    kernel[(1, )](a, a.stride(0), b, b.stride(0), out, out.stride(0))
+
+    expected = torch.zeros(8, dtype=torch.int32, device=device)
+    expected[0] = a[0]  # i=0: reads from a
+    expected[2] = b[2]  # i=2: reads from b (a_ptr was reassigned)
+    expected[4] = b[4]  # i=4: reads from b
+    expected[6] = b[6]  # i=6: reads from b
+    assert torch.equal(out, expected)
+
+
 @pytest.mark.interpreter
 def test_num_programs(device):
     # Assuming that the kernel is launched with a grid of (11, 21, 31)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6403,6 +6403,22 @@ def test_constexpr_reassign_in_loop(device):
     assert torch.equal(out, expected)
 
 
+def test_user_constexpr_reassign_in_loop_errors(device):
+    # User-annotated tl.constexpr locals must NOT be relaxed to runtime
+    # values inside loops — that's a genuine type error.
+
+    @triton.jit
+    def kernel(out, BLOCK: tl.constexpr):
+        x: tl.constexpr = 1
+        for i in range(BLOCK):
+            tl.store(out + i, x)
+            x = tl.load(out + i)  # constexpr -> tensor: should fail
+
+    out = torch.zeros(4, dtype=torch.int32, device=device)
+    with pytest.raises(Exception):
+        kernel[(1, )](out, 4)
+
+
 @pytest.mark.interpreter
 def test_num_programs(device):
     # Assuming that the kernel is launched with a grid of (11, 21, 31)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -471,6 +471,13 @@ class CodeGenerator(ast.NodeVisitor):
 
             if _is_triton_value(live_val):
                 loop_val = self.lscope[name]
+
+                # When a JIT-specialized constexpr is reassigned in the loop
+                # body, relax it to a runtime tensor so it can be carried.
+                if isinstance(live_val, constexpr) and _is_triton_tensor(loop_val):
+                    live_val = self.semantic.to_tensor(_unwrap_if_constexpr(live_val))
+                    liveins[name] = live_val
+
                 self._verify_loop_carried_variable(name, loop_val, live_val)
 
                 live_handles = flatten_values_to_ir([live_val])

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -353,6 +353,10 @@ class CodeGenerator(ast.NodeVisitor):
     def _unsupported(self, node, message):
         return UnsupportedLanguageConstruct(self.jit_fn.src, node, message)
 
+    def _is_jit_constexpr_param(self, name):
+        """Check if `name` is a JIT function parameter annotated with tl.constexpr."""
+        return any(p.name == name and p.is_constexpr for p in self.jit_fn.params)
+
     def _is_constexpr_global(self, name):
         absent_marker = object()
         val = self.gscope.get(name, absent_marker)
@@ -472,11 +476,14 @@ class CodeGenerator(ast.NodeVisitor):
             if _is_triton_value(live_val):
                 loop_val = self.lscope[name]
 
-                # When a JIT-specialized constexpr is reassigned in the loop
-                # body, relax it to a runtime tensor so it can be carried.
+                # When a JIT-specialized constexpr *parameter* is reassigned
+                # in the loop body, relax it to a runtime tensor so it can
+                # be carried. User-annotated tl.constexpr locals must NOT be
+                # relaxed — reassigning them is a type error.
                 if isinstance(live_val, constexpr) and _is_triton_tensor(loop_val):
-                    live_val = self.semantic.to_tensor(_unwrap_if_constexpr(live_val))
-                    liveins[name] = live_val
+                    if self._is_jit_constexpr_param(name):
+                        live_val = self.semantic.to_tensor(_unwrap_if_constexpr(live_val))
+                        liveins[name] = live_val
 
                 self._verify_loop_carried_variable(name, loop_val, live_val)
 


### PR DESCRIPTION
Fixes #9547

When a stride argument is JIT-specialized to `constexpr` (e.g. `a.stride(0)` returning 1), reassigning it inside a loop causes a compilation error:

```
AssertionError("Loop carried variable a0 changed type,
  was <class 'tensor'> but is now <class 'constexpr'>")
```

**Root cause:** `_sanitize_value` in `visit_Assign` unwraps the constexpr and converts it to a tensor. The loop analysis in `_find_carries` then sees the initial value as constexpr but the loop body value as tensor, and the type assertion fails.

**Fix:** In `_find_carries`, when a JIT-specialized constexpr has been reassigned as a tensor in the loop body, relax the initial value from constexpr to a runtime tensor before the type check. This follows the approach suggested by @red1bluelost — since these are JIT-specialized (not user-annotated) constexpr values, relaxing them to runtime values is the right behavior.

Includes a regression test using the exact reproducer from the issue.