### PR TITLE
Add chrome_trace_msgpack output for Proton trace data

### DIFF
--- a/third_party/proton/csrc/include/Data/Data.h
+++ b/third_party/proton/csrc/include/Data/Data.h
@@ -22,7 +22,13 @@
 
 namespace proton {
 
-enum class OutputFormat { Hatchet, HatchetMsgPack, ChromeTrace, Count };
+enum class OutputFormat {
+  Hatchet,
+  HatchetMsgPack,
+  ChromeTrace,
+  ChromeTraceMsgPack,
+  Count
+};
 
 class Data;
 

--- a/third_party/proton/csrc/lib/Data/Data.cpp
+++ b/third_party/proton/csrc/lib/Data/Data.cpp
@@ -154,10 +154,11 @@ void Data::dump(const std::string &outputFormat) {
                         : ".part_" + std::to_string(phase);
       const auto filePath =
           path + suffix + "." + outputFormatToString(outputFormatEnum);
-      const auto fileMode =
-          (outputFormatEnum == OutputFormat::HatchetMsgPack)
-              ? (std::ios::out | std::ios::binary | std::ios::trunc)
-              : (std::ios::out | std::ios::trunc);
+      const auto fileMode = (outputFormatEnum == OutputFormat::HatchetMsgPack ||
+                             outputFormatEnum == OutputFormat::ChromeTraceMsgPack)
+                                ? (std::ios::out | std::ios::binary |
+                                   std::ios::trunc)
+                                : (std::ios::out | std::ios::trunc);
       out.reset(
           new std::ofstream(filePath, fileMode)); // Opening a file for output
     }
@@ -172,6 +173,8 @@ OutputFormat parseOutputFormat(const std::string &outputFormat) {
     return OutputFormat::HatchetMsgPack;
   } else if (toLower(outputFormat) == "chrome_trace") {
     return OutputFormat::ChromeTrace;
+  } else if (toLower(outputFormat) == "chrome_trace_msgpack") {
+    return OutputFormat::ChromeTraceMsgPack;
   } else {
     throw std::runtime_error("Unknown output format: " + outputFormat);
   }
@@ -184,6 +187,8 @@ const std::string outputFormatToString(OutputFormat outputFormat) {
     return "hatchet_msgpack";
   } else if (outputFormat == OutputFormat::ChromeTrace) {
     return "chrome_trace";
+  } else if (outputFormat == OutputFormat::ChromeTraceMsgPack) {
+    return "chrome_trace_msgpack";
   }
   throw std::runtime_error("Unknown output format: " +
                            std::to_string(static_cast<int>(outputFormat)));

--- a/third_party/proton/csrc/lib/Data/TraceData.cpp
+++ b/third_party/proton/csrc/lib/Data/TraceData.cpp
@@ -188,15 +188,36 @@ std::string TraceData::toJsonString(size_t phase) const {
   return os.str();
 }
 
-std::vector<uint8_t> TraceData::toMsgPack(size_t phase) const {
-  std::ostringstream os;
-  dumpChromeTrace(os, phase);
-  MsgPackWriter writer;
-  writer.packStr(os.str());
-  return std::move(writer).take();
-}
-
 namespace {
+
+void packJsonValue(MsgPackWriter &writer, const json &value) {
+  if (value.is_null()) {
+    writer.packNil();
+  } else if (value.is_boolean()) {
+    writer.packBool(value.get<bool>());
+  } else if (value.is_number_unsigned()) {
+    writer.packUInt(value.get<uint64_t>());
+  } else if (value.is_number_integer()) {
+    writer.packInt(value.get<int64_t>());
+  } else if (value.is_number_float()) {
+    writer.packDouble(value.get<double>());
+  } else if (value.is_string()) {
+    writer.packStr(value.get_ref<const std::string &>());
+  } else if (value.is_array()) {
+    writer.packArray(static_cast<uint32_t>(value.size()));
+    for (const auto &element : value) {
+      packJsonValue(writer, element);
+    }
+  } else if (value.is_object()) {
+    writer.packMap(static_cast<uint32_t>(value.size()));
+    for (auto it = value.begin(); it != value.end(); ++it) {
+      writer.packStr(it.key());
+      packJsonValue(writer, it.value());
+    }
+  } else {
+    throw std::runtime_error("Unsupported json value for msgpack trace");
+  }
+}
 
 // Structure to pair CycleMetric with its context for processing
 struct CycleMetricWithContext {
@@ -389,6 +410,12 @@ void dumpCycleMetricTrace(std::vector<CycleMetricWithContext> &cycleEvents,
   writer.write(os);
 }
 
+json buildCycleMetricTraceJson(std::vector<CycleMetricWithContext> &cycleEvents) {
+  std::ostringstream os;
+  dumpCycleMetricTrace(cycleEvents, os);
+  return json::parse(os.str());
+}
+
 void dumpKernelMetricTrace(
     uint64_t minTimeStamp,
     const std::map<size_t, std::vector<KernelMetricWithContext>>
@@ -430,7 +457,143 @@ void dumpKernelMetricTrace(
     os << object.dump() << "\n";
   }
 }
+
+json buildKernelMetricTraceJson(
+    uint64_t minTimeStamp,
+    const std::map<size_t, std::vector<KernelMetricWithContext>>
+        &streamTraceEvents) {
+  json object = {
+      {"format", "chrome_trace_msgpack"},
+      {"version", 1},
+      {"displayTimeUnit", "us"},
+      {"traceEvents", json::array()},
+  };
+
+  for (const auto &[streamId, events] : streamTraceEvents) {
+    for (const auto &event : events) {
+      auto *kernelMetrics = event.kernelMetric;
+      uint64_t startTimeNs =
+          std::get<uint64_t>(kernelMetrics->getValue(KernelMetric::StartTime));
+      uint64_t endTimeNs =
+          std::get<uint64_t>(kernelMetrics->getValue(KernelMetric::EndTime));
+      double ts = static_cast<double>(startTimeNs - minTimeStamp) / 1000;
+      double dur = static_cast<double>(endTimeNs - startTimeNs) / 1000;
+
+      json element;
+      element["name"] = event.contexts.back().name;
+      element["cat"] = "kernel";
+      element["ph"] = "X";
+      element["ts"] = ts;
+      element["dur"] = dur;
+      element["tid"] = streamId;
+      json callStack = json::array();
+      for (const auto &ctx : event.contexts) {
+        callStack.push_back(ctx.name);
+      }
+      element["args"] = {{"call_stack", std::move(callStack)}};
+      object["traceEvents"].push_back(std::move(element));
+    }
+  }
+
+  return object;
+}
 } // namespace
+
+std::vector<uint8_t> TraceData::toMsgPack(size_t phase) const {
+  json chromeTraceObject;
+  tracePhases.withPtr(phase, [&](Trace *trace) {
+    std::set<size_t> virtualTargetEntryIds;
+    for (const auto &[_, event] : trace->getEvents()) {
+      for (const auto &[targetEntryId, _] : event.metricSet.linkedMetrics) {
+        virtualTargetEntryIds.insert(targetEntryId);
+      }
+      for (const auto &[targetEntryId, _] :
+           event.metricSet.linkedFlexibleMetrics) {
+        virtualTargetEntryIds.insert(targetEntryId);
+      }
+    }
+
+    std::map<size_t, std::vector<Context>> targetIdToVirtualContexts;
+    if (!virtualTargetEntryIds.empty()) {
+      tracePhases.withPtr(Data::kVirtualPhase, [&](Trace *virtualTrace) {
+        for (auto targetEntryId : virtualTargetEntryIds) {
+          auto &targetEvent = virtualTrace->getEvent(targetEntryId);
+          auto contexts = virtualTrace->getContexts(targetEvent.contextId);
+          contexts.erase(contexts.begin());
+          targetIdToVirtualContexts.emplace(targetEntryId, std::move(contexts));
+        }
+      });
+    }
+
+    auto &events = trace->getEvents();
+    std::map<size_t, std::vector<KernelMetricWithContext>> streamTraceEvents;
+    uint64_t minTimeStamp = std::numeric_limits<uint64_t>::max();
+    bool hasKernelMetrics = false, hasCycleMetrics = false;
+    std::vector<CycleMetricWithContext> cycleEvents;
+    cycleEvents.reserve(events.size());
+
+    auto processMetricMaps =
+        [&](const std::map<MetricKind, std::unique_ptr<Metric>> &metrics,
+            const std::vector<Context> &contexts) {
+          if (auto kernelIt = metrics.find(MetricKind::Kernel);
+              kernelIt != metrics.end()) {
+            auto *kernelMetric =
+                static_cast<KernelMetric *>(kernelIt->second.get());
+            const auto streamId = std::get<uint64_t>(
+                kernelMetric->getValue(KernelMetric::StreamId));
+            streamTraceEvents[streamId].emplace_back(kernelMetric, contexts);
+            const auto startTime = std::get<uint64_t>(
+                kernelMetric->getValue(KernelMetric::StartTime));
+            minTimeStamp = std::min(minTimeStamp, startTime);
+            hasKernelMetrics = true;
+          }
+          if (auto cycleIt = metrics.find(MetricKind::Cycle);
+              cycleIt != metrics.end()) {
+            auto *cycleMetric =
+                static_cast<CycleMetric *>(cycleIt->second.get());
+            cycleEvents.emplace_back(cycleMetric, contexts);
+            hasCycleMetrics = true;
+          }
+        };
+
+    for (const auto &[_, event] : events) {
+      auto baseContexts = trace->getContexts(event.contextId);
+      processMetricMaps(event.metricSet.metrics, baseContexts);
+      for (const auto &[targetEntryId, linkedMetrics] :
+           event.metricSet.linkedMetrics) {
+        auto contexts = baseContexts;
+        auto &virtualContexts = targetIdToVirtualContexts[targetEntryId];
+        contexts.insert(contexts.end(), virtualContexts.begin(),
+                        virtualContexts.end());
+        processMetricMaps(linkedMetrics, contexts);
+      }
+
+      if (hasKernelMetrics && hasCycleMetrics) {
+        throw std::runtime_error("only one active metric type is supported");
+      }
+    }
+
+    if (hasCycleMetrics) {
+      chromeTraceObject = buildCycleMetricTraceJson(cycleEvents);
+      chromeTraceObject["format"] = "chrome_trace_msgpack";
+      chromeTraceObject["version"] = 1;
+    } else if (hasKernelMetrics) {
+      chromeTraceObject =
+          buildKernelMetricTraceJson(minTimeStamp, streamTraceEvents);
+    } else {
+      chromeTraceObject = {
+          {"format", "chrome_trace_msgpack"},
+          {"version", 1},
+          {"displayTimeUnit", "us"},
+          {"traceEvents", json::array()},
+      };
+    }
+  });
+
+  MsgPackWriter writer;
+  packJsonValue(writer, chromeTraceObject);
+  return std::move(writer).take();
+}
 
 void TraceData::dumpChromeTrace(std::ostream &os, size_t phase) const {
   std::set<size_t> virtualTargetEntryIds;
@@ -523,6 +686,9 @@ void TraceData::doDump(std::ostream &os, OutputFormat outputFormat,
                        size_t phase) const {
   if (outputFormat == OutputFormat::ChromeTrace) {
     dumpChromeTrace(os, phase);
+  } else if (outputFormat == OutputFormat::ChromeTraceMsgPack) {
+    auto msgPack = toMsgPack(phase);
+    os.write(reinterpret_cast<const char *>(msgPack.data()), msgPack.size());
   } else {
     throw std::logic_error("Output format not supported");
   }

--- a/third_party/proton/csrc/lib/Profiler/GPUProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/GPUProfiler.cpp
@@ -116,7 +116,8 @@ void periodicFlushDataPhases(Data &data,
         std::ofstream ofs(pathWithPhase, std::ios::out | std::ios::trunc);
         ofs << jsonStr;
       }
-    } else if (periodicFlushingFormat == "hatchet_msgpack") {
+    } else if (periodicFlushingFormat == "hatchet_msgpack" ||
+               periodicFlushingFormat == "chrome_trace_msgpack") {
       std::vector<uint8_t> msgPack;
       if (timingEnabled) {
         const auto t0 = Clock::now();
@@ -186,8 +187,8 @@ void setPeriodicFlushingMode(bool &periodicFlushingEnabled,
       throw std::invalid_argument(std::string("[PROTON] ") + profilerName +
                                   ": unsupported option key: " + key);
     }
-    if (value != "hatchet_msgpack" && value != "chrome_trace" &&
-        value != "hatchet") {
+    if (value != "hatchet_msgpack" && value != "chrome_trace_msgpack" &&
+        value != "chrome_trace" && value != "hatchet") {
       throw std::invalid_argument(std::string("[PROTON] ") + profilerName +
                                   ": unsupported format: " + value);
     }

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -330,23 +330,13 @@ std::vector<uint8_t> SessionManager::getDataMsgPack(size_t sessionId,
                                                     size_t phase) {
   std::lock_guard<std::mutex> lock(mutex);
   auto *session = getSessionOrThrow(sessionId);
-  auto *treeData = dynamic_cast<TreeData *>(session->data.get());
-  if (!treeData) {
-    throw std::runtime_error(
-        "Only TreeData is supported for getData() for now");
-  }
-  return treeData->toMsgPack(phase);
+  return session->data->toMsgPack(phase);
 }
 
 std::string SessionManager::getData(size_t sessionId, size_t phase) {
   std::lock_guard<std::mutex> lock(mutex);
   auto *session = getSessionOrThrow(sessionId);
-  auto *treeData = dynamic_cast<TreeData *>(session->data.get());
-  if (!treeData) {
-    throw std::runtime_error(
-        "Only TreeData is supported for getData() for now");
-  }
-  return treeData->toJsonString(phase);
+  return session->data->toJsonString(phase);
 }
 
 void SessionManager::clearData(size_t sessionId, size_t phase,

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -95,8 +95,8 @@ def start(
                                                For "instrumentation", available options are [None].
                                                Each mode has a set of control knobs following with the mode name.
                                                For example, "periodic_flushing" mode has a knob:
-                                               - format: The output format of the profiling results. Available options are ["hatchet", "hatchet_msgpack", "chrome_trace"]. Default is "hatchet".
-                                               The can be set via `mode="periodic_flushing:format=chrome_trace"`.
+                                               - format: The output format of the profiling results. Available options are ["hatchet", "hatchet_msgpack", "chrome_trace", "chrome_trace_msgpack"]. Default is "hatchet".
+                                               The can be set via `mode="periodic_flushing:format=chrome_trace_msgpack"`.
         hook (Union[str, Hook], optional): The hook to use for profiling.
                                            You may pass either:
                                            - a string hook name, e.g. "triton" (kernel launch metadata), or
@@ -185,7 +185,7 @@ def finalize(session: Optional[int] = None, output_format: Optional[str] = "") -
     Args:
         session (int, optional): The session ID to finalize. If None, all sessions are finalized. Defaults to None.
         output_format (str, optional): The output format for the profiling results.
-                                       Available options are ["hatchet", "hatchet_msgpack", "chrome_trace"].
+                                       Available options are ["hatchet", "hatchet_msgpack", "chrome_trace", "chrome_trace_msgpack"].
 
     Returns:
         None

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -871,6 +871,47 @@ def test_trace(tmp_path: pathlib.Path, device: str):
         assert trace_events[-1]["args"]["call_stack"] == ["ROOT", "test", "foo"]
 
 
+def test_trace_msgpack(tmp_path: pathlib.Path, device: str):
+    import msgpack
+
+    temp_file = tmp_path / "test_trace.chrome_trace_msgpack"
+    session = proton.start(str(temp_file.with_suffix("")), data="trace")
+
+    @triton.jit
+    def foo(x, y, size: tl.constexpr):
+        offs = tl.arange(0, size)
+        tl.store(y + offs, tl.load(x + offs))
+
+    with proton.scope("init"):
+        x = torch.ones((1024, ), device=device, dtype=torch.float32)
+        y = torch.zeros_like(x)
+
+    with proton.scope("test"):
+        foo[(1, )](x, y, x.size()[0], num_warps=4)
+
+    in_memory_json = proton.data.get(session=session, phase=0)
+    assert len(in_memory_json["traceEvents"]) == 3
+    assert in_memory_json["traceEvents"][-1]["name"] == "foo"
+
+    in_memory = msgpack.loads(
+        proton.data.get_msgpack(session=session, phase=0),
+        raw=False,
+        strict_map_key=False,
+    )
+    assert in_memory["format"] == "chrome_trace_msgpack"
+    assert in_memory["version"] == 1
+    assert in_memory["displayTimeUnit"] == "us"
+    assert len(in_memory["traceEvents"]) == 3
+    assert in_memory["traceEvents"][-1]["name"] == "foo"
+    assert in_memory["traceEvents"][-1]["args"]["call_stack"] == ["ROOT", "test", "foo"]
+
+    proton.finalize(output_format="chrome_trace_msgpack")
+
+    with temp_file.open("rb") as f:
+        file_data = msgpack.load(f, raw=False, strict_map_key=False)
+    assert file_data == in_memory
+
+
 def test_scope_multiple_threads(tmp_path: pathlib.Path, device: str):
     temp_file = tmp_path / "test_scope_threads.hatchet"
     proton.start(str(temp_file.with_suffix("")))


### PR DESCRIPTION
## Summary
- add a real chrome_trace_msgpack Proton output format alongside chrome_trace
- serialize trace msgpack as structured Chrome-trace-shaped data instead of msgpack-wrapping a JSON string
- allow getData() / getDataMsgPack() to work for trace sessions and cover the new path with a focused test

## Testing
- git diff --check
- ruff check third_party/proton/proton/profile.py third_party/proton/test/test_profile.py
- python -m py_compile third_party/proton/proton/profile.py third_party/proton/test/test_profile.py
- pytest third_party/proton/test/test_profile.py -k 'test_trace_msgpack or test_trace' (fails during collection in this environment because hatchet is not installed)