### PR TITLE
Add native buffered periodic profiles

### DIFF
--- a/third_party/proton/csrc/Proton.cpp
+++ b/third_party/proton/csrc/Proton.cpp
@@ -216,6 +216,21 @@ static void initProton(pybind11::module &&m) {
       },
       pybind11::arg("sessionId"), pybind11::arg("phase"));
   m.def(
+      "get_buffered_profiles",
+      [](size_t sessionId, bool clear) {
+        pybind11::list bufferedProfiles;
+        for (auto &profile :
+             SessionManager::instance().getBufferedProfiles(sessionId, clear)) {
+          bufferedProfiles.append(pybind11::make_tuple(
+              profile.first,
+              pybind11::bytes(
+                  reinterpret_cast<const char *>(profile.second.data()),
+                  profile.second.size())));
+        }
+        return bufferedProfiles;
+      },
+      pybind11::arg("sessionId"), pybind11::arg("clear") = false);
+  m.def(
       "clear_data",
       [](size_t sessionId, size_t phase, bool clearUpToPhase) {
         SessionManager::instance().clearData(sessionId, phase, clearUpToPhase);

--- a/third_party/proton/csrc/Proton.cpp
+++ b/third_party/proton/csrc/Proton.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <stdexcept>
 #include <variant>
 #include <vector>
@@ -217,10 +218,11 @@ static void initProton(pybind11::module &&m) {
       pybind11::arg("sessionId"), pybind11::arg("phase"));
   m.def(
       "get_buffered_profiles",
-      [](size_t sessionId, bool clear) {
+      [](size_t sessionId, bool clear, size_t maxProfiles, size_t minPhase) {
         pybind11::list bufferedProfiles;
         for (auto &profile :
-             SessionManager::instance().getBufferedProfiles(sessionId, clear)) {
+             SessionManager::instance().getBufferedProfiles(
+                 sessionId, clear, maxProfiles, minPhase)) {
           bufferedProfiles.append(pybind11::make_tuple(
               profile.first,
               pybind11::bytes(
@@ -229,7 +231,23 @@ static void initProton(pybind11::module &&m) {
         }
         return bufferedProfiles;
       },
-      pybind11::arg("sessionId"), pybind11::arg("clear") = false);
+      pybind11::arg("sessionId"), pybind11::arg("clear") = false,
+      pybind11::arg("maxProfiles") = 0, pybind11::arg("minPhase") = 0);
+  m.def(
+      "get_buffered_profile_serialized_up_to_phase",
+      [](size_t sessionId) -> std::optional<size_t> {
+        return SessionManager::instance().getBufferedProfileSerializedUpToPhase(
+            sessionId);
+      },
+      pybind11::arg("sessionId"));
+  m.def(
+      "get_buffered_profile_stats",
+      [](size_t sessionId) {
+        const auto [profileCount, byteCount] =
+            SessionManager::instance().getBufferedProfileStats(sessionId);
+        return pybind11::make_tuple(profileCount, byteCount);
+      },
+      pybind11::arg("sessionId"));
   m.def(
       "clear_data",
       [](size_t sessionId, size_t phase, bool clearUpToPhase) {

--- a/third_party/proton/csrc/include/Data/Data.h
+++ b/third_party/proton/csrc/include/Data/Data.h
@@ -6,6 +6,7 @@
 #include "PhaseStore.h"
 #include <atomic>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <limits>
 #include <map>
@@ -94,6 +95,16 @@ public:
     }
   };
 
+  struct BufferedProfile {
+    size_t phase{0};
+    std::vector<uint8_t> payload{};
+  };
+
+  struct BufferedProfileStats {
+    size_t profileCount{0};
+    size_t byteCount{0};
+  };
+
   Data(const std::string &path, ContextSource *contextSource)
       : path(path), contextSource(contextSource) {}
   virtual ~Data() = default;
@@ -122,6 +133,33 @@ public:
 
   /// Atomically get current and complete phases.
   PhaseInfo getPhaseInfo() const;
+
+  /// Set the maximum number of buffered profile payload bytes retained in
+  /// memory. When the budget is exceeded, the oldest buffered profiles are
+  /// dropped until the new payload fits.
+  void setBufferedProfileMaxBytes(size_t maxBytes);
+
+  /// Get the maximum number of buffered profile payload bytes retained in
+  /// memory.
+  size_t getBufferedProfileMaxBytes() const;
+
+  /// Append a serialized phase profile payload to the in-memory buffer.
+  void appendBufferedProfile(size_t phase, std::vector<uint8_t> payload);
+
+  /// Append a serialized phase profile payload represented as text.
+  void appendBufferedProfile(size_t phase, const std::string &payload);
+
+  /// Return buffered serialized phase profiles. If `clear` is true, the
+  /// returned profiles are removed from the in-memory buffer.
+  std::vector<BufferedProfile> getBufferedProfiles(bool clear = false);
+
+  /// Return the current buffered profile count and payload byte total.
+  BufferedProfileStats getBufferedProfileStats() const;
+
+  /// Return the highest completed phase that has already been serialized into
+  /// the buffered profile ring, even if it has since been dropped from the
+  /// retained payload queue due to the byte budget.
+  size_t getBufferedProfileSerializedUpToPhase() const;
 
   /// Add an op to the data of the current phase.
   /// If `opName` is empty, just use the current context as is.
@@ -205,6 +243,10 @@ protected:
   mutable std::shared_mutex mutex;
   const std::string path{};
   ContextSource *contextSource{};
+  size_t bufferedProfileMaxBytes{0};
+  size_t bufferedProfileBytes{0};
+  size_t bufferedProfileSerializedUpToPhase{kNoCompletePhase};
+  std::deque<BufferedProfile> bufferedProfiles{};
 
 private:
   PhaseStoreBase *phaseStore{};

--- a/third_party/proton/csrc/include/Data/Data.h
+++ b/third_party/proton/csrc/include/Data/Data.h
@@ -150,8 +150,12 @@ public:
   void appendBufferedProfile(size_t phase, const std::string &payload);
 
   /// Return buffered serialized phase profiles. If `clear` is true, the
-  /// returned profiles are removed from the in-memory buffer.
-  std::vector<BufferedProfile> getBufferedProfiles(bool clear = false);
+  /// returned profiles are removed from the in-memory buffer. If `maxProfiles`
+  /// is non-zero, return at most that many profiles. Profiles older than
+  /// `minPhase` are skipped, and are also removed when `clear` is true.
+  std::vector<BufferedProfile> getBufferedProfiles(bool clear = false,
+                                                   size_t maxProfiles = 0,
+                                                   size_t minPhase = 0);
 
   /// Return the current buffered profile count and payload byte total.
   BufferedProfileStats getBufferedProfileStats() const;

--- a/third_party/proton/csrc/include/Profiler/GPUProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/GPUProfiler.h
@@ -25,6 +25,12 @@ namespace proton {
 
 namespace detail {
 
+struct PeriodicFlushingConfig {
+  bool enabled{false};
+  std::string format{"hatchet"};
+  size_t bufferMaxBytes{0};
+};
+
 void flushDataPhasesImpl(
     const bool periodicFlushEnabled, const std::string &periodicFlushingFormat,
     std::map<Data *, size_t> &dataFlushedPhases,
@@ -38,10 +44,9 @@ void updateDataPhases(
         &dataPhases,
     Data *data, size_t phase);
 
-void setPeriodicFlushingMode(bool &periodicFlushingEnabled,
-                             std::string &periodicFlushingFormat,
-                             const std::vector<std::string> &modeAndOptions,
-                             const char *profilerName);
+PeriodicFlushingConfig
+parsePeriodicFlushingMode(const std::vector<std::string> &modeAndOptions,
+                          const char *profilerName);
 } // namespace detail
 
 // Singleton<ConcreteProfilerT>: Each concrete GPU profiler, e.g.,

--- a/third_party/proton/csrc/include/Session/Session.h
+++ b/third_party/proton/csrc/include/Session/Session.h
@@ -97,6 +97,9 @@ public:
 
   std::string getData(size_t sessionId, size_t phase);
 
+  std::vector<std::pair<size_t, std::vector<uint8_t>>>
+  getBufferedProfiles(size_t sessionId, bool clear);
+
   void clearData(size_t sessionId, size_t phase, bool clearUpToPhase = false);
 
   size_t advanceDataPhase(size_t sessionId);

--- a/third_party/proton/csrc/include/Session/Session.h
+++ b/third_party/proton/csrc/include/Session/Session.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <numeric>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -98,7 +99,13 @@ public:
   std::string getData(size_t sessionId, size_t phase);
 
   std::vector<std::pair<size_t, std::vector<uint8_t>>>
-  getBufferedProfiles(size_t sessionId, bool clear);
+  getBufferedProfiles(size_t sessionId, bool clear, size_t maxProfiles = 0,
+                      size_t minPhase = 0);
+
+  std::optional<size_t>
+  getBufferedProfileSerializedUpToPhase(size_t sessionId);
+
+  std::pair<size_t, size_t> getBufferedProfileStats(size_t sessionId);
 
   void clearData(size_t sessionId, size_t phase, bool clearUpToPhase = false);
 

--- a/third_party/proton/csrc/lib/Data/Data.cpp
+++ b/third_party/proton/csrc/lib/Data/Data.cpp
@@ -1,13 +1,36 @@
 #include "Data/Data.h"
 #include "Utility/String.h"
 
+#include <chrono>
 #include <fstream>
 #include <iostream>
+#include <mutex>
 #include <stdexcept>
 
 #include <shared_mutex>
 
 namespace proton {
+
+namespace {
+
+void maybeLogOversizedBufferedProfileDrop(size_t payloadBytes,
+                                          size_t bufferedProfileMaxBytes) {
+  using Clock = std::chrono::steady_clock;
+  static std::mutex warningMutex;
+  static auto lastWarning = Clock::time_point::min();
+
+  std::lock_guard<std::mutex> guard(warningMutex);
+  const auto now = Clock::now();
+  if (now - lastWarning < std::chrono::seconds(10)) {
+    return;
+  }
+  lastWarning = now;
+  std::cerr << "[PROTON] Dropping buffered profile payload of " << payloadBytes
+            << " bytes because it exceeds buffer_max_bytes="
+            << bufferedProfileMaxBytes << std::endl;
+}
+
+} // namespace
 
 void DataEntry::upsertMetric(std::unique_ptr<Metric> metric) const {
   auto &metrics = metricSet.get().metrics;
@@ -166,6 +189,8 @@ void Data::appendBufferedProfile(size_t phase, std::vector<uint8_t> payload) {
           ? phase
           : std::max(bufferedProfileSerializedUpToPhase, phase);
   if (payloadBytes > bufferedProfileMaxBytes) {
+    maybeLogOversizedBufferedProfileDrop(payloadBytes,
+                                         bufferedProfileMaxBytes);
     return;
   }
   while (!bufferedProfiles.empty() &&

--- a/third_party/proton/csrc/lib/Data/Data.cpp
+++ b/third_party/proton/csrc/lib/Data/Data.cpp
@@ -137,8 +137,82 @@ Data::PhaseInfo Data::getPhaseInfo() const {
                    completeUpToPhase};
 }
 
+void Data::setBufferedProfileMaxBytes(size_t maxBytes) {
+  std::unique_lock<std::shared_mutex> lock(mutex);
+  bufferedProfileMaxBytes = maxBytes;
+  while (!bufferedProfiles.empty() && bufferedProfileBytes > bufferedProfileMaxBytes) {
+    bufferedProfileBytes -= bufferedProfiles.front().payload.size();
+    bufferedProfiles.pop_front();
+  }
+  if (bufferedProfileMaxBytes == 0) {
+    bufferedProfiles.clear();
+    bufferedProfileBytes = 0;
+  }
+}
+
+size_t Data::getBufferedProfileMaxBytes() const {
+  std::shared_lock<std::shared_mutex> lock(mutex);
+  return bufferedProfileMaxBytes;
+}
+
+void Data::appendBufferedProfile(size_t phase, std::vector<uint8_t> payload) {
+  const auto payloadBytes = payload.size();
+  std::unique_lock<std::shared_mutex> lock(mutex);
+  if (bufferedProfileMaxBytes == 0) {
+    return;
+  }
+  bufferedProfileSerializedUpToPhase =
+      bufferedProfileSerializedUpToPhase == kNoCompletePhase
+          ? phase
+          : std::max(bufferedProfileSerializedUpToPhase, phase);
+  if (payloadBytes > bufferedProfileMaxBytes) {
+    return;
+  }
+  while (!bufferedProfiles.empty() &&
+         bufferedProfileBytes + payloadBytes > bufferedProfileMaxBytes) {
+    bufferedProfileBytes -= bufferedProfiles.front().payload.size();
+    bufferedProfiles.pop_front();
+  }
+  bufferedProfileBytes += payloadBytes;
+  bufferedProfiles.push_back(BufferedProfile{phase, std::move(payload)});
+}
+
+void Data::appendBufferedProfile(size_t phase, const std::string &payload) {
+  appendBufferedProfile(phase, std::vector<uint8_t>(payload.begin(), payload.end()));
+}
+
+std::vector<Data::BufferedProfile> Data::getBufferedProfiles(bool clear) {
+  std::unique_lock<std::shared_mutex> lock(mutex);
+  if (!clear) {
+    return {bufferedProfiles.begin(), bufferedProfiles.end()};
+  }
+
+  std::vector<BufferedProfile> profiles;
+  profiles.reserve(bufferedProfiles.size());
+  while (!bufferedProfiles.empty()) {
+    profiles.push_back(std::move(bufferedProfiles.front()));
+    bufferedProfiles.pop_front();
+  }
+  bufferedProfileBytes = 0;
+  return profiles;
+}
+
+Data::BufferedProfileStats Data::getBufferedProfileStats() const {
+  std::shared_lock<std::shared_mutex> lock(mutex);
+  return BufferedProfileStats{bufferedProfiles.size(), bufferedProfileBytes};
+}
+
+size_t Data::getBufferedProfileSerializedUpToPhase() const {
+  std::shared_lock<std::shared_mutex> lock(mutex);
+  return bufferedProfileSerializedUpToPhase;
+}
+
 void Data::dump(const std::string &outputFormat) {
   std::shared_lock<std::shared_mutex> lock(mutex);
+
+  if (path.empty() && bufferedProfileMaxBytes > 0) {
+    return;
+  }
 
   OutputFormat outputFormatEnum = outputFormat.empty()
                                       ? getDefaultOutputFormat()

--- a/third_party/proton/csrc/lib/Data/Data.cpp
+++ b/third_party/proton/csrc/lib/Data/Data.cpp
@@ -1,36 +1,13 @@
 #include "Data/Data.h"
 #include "Utility/String.h"
 
-#include <chrono>
 #include <fstream>
 #include <iostream>
-#include <mutex>
 #include <stdexcept>
 
 #include <shared_mutex>
 
 namespace proton {
-
-namespace {
-
-void maybeLogOversizedBufferedProfileDrop(size_t payloadBytes,
-                                          size_t bufferedProfileMaxBytes) {
-  using Clock = std::chrono::steady_clock;
-  static std::mutex warningMutex;
-  static auto lastWarning = Clock::time_point::min();
-
-  std::lock_guard<std::mutex> guard(warningMutex);
-  const auto now = Clock::now();
-  if (now - lastWarning < std::chrono::seconds(10)) {
-    return;
-  }
-  lastWarning = now;
-  std::cerr << "[PROTON] Dropping buffered profile payload of " << payloadBytes
-            << " bytes because it exceeds buffer_max_bytes="
-            << bufferedProfileMaxBytes << std::endl;
-}
-
-} // namespace
 
 void DataEntry::upsertMetric(std::unique_ptr<Metric> metric) const {
   auto &metrics = metricSet.get().metrics;
@@ -189,8 +166,9 @@ void Data::appendBufferedProfile(size_t phase, std::vector<uint8_t> payload) {
           ? phase
           : std::max(bufferedProfileSerializedUpToPhase, phase);
   if (payloadBytes > bufferedProfileMaxBytes) {
-    maybeLogOversizedBufferedProfileDrop(payloadBytes,
-                                         bufferedProfileMaxBytes);
+    std::cerr << "[PROTON] Dropping buffered profile payload of "
+              << payloadBytes << " bytes because it exceeds buffer_max_bytes="
+              << bufferedProfileMaxBytes << std::endl;
     return;
   }
   while (!bufferedProfiles.empty() &&

--- a/third_party/proton/csrc/lib/Data/Data.cpp
+++ b/third_party/proton/csrc/lib/Data/Data.cpp
@@ -184,19 +184,44 @@ void Data::appendBufferedProfile(size_t phase, const std::string &payload) {
   appendBufferedProfile(phase, std::vector<uint8_t>(payload.begin(), payload.end()));
 }
 
-std::vector<Data::BufferedProfile> Data::getBufferedProfiles(bool clear) {
+std::vector<Data::BufferedProfile> Data::getBufferedProfiles(bool clear,
+                                                             size_t maxProfiles,
+                                                             size_t minPhase) {
   std::unique_lock<std::shared_mutex> lock(mutex);
+  auto reachedMaxProfiles = [maxProfiles](size_t count) {
+    return maxProfiles != 0 && count >= maxProfiles;
+  };
+
   if (!clear) {
-    return {bufferedProfiles.begin(), bufferedProfiles.end()};
+    std::vector<BufferedProfile> profiles;
+    profiles.reserve(bufferedProfiles.size());
+    for (const auto &profile : bufferedProfiles) {
+      if (profile.phase < minPhase) {
+        continue;
+      }
+      if (reachedMaxProfiles(profiles.size())) {
+        break;
+      }
+      profiles.push_back(profile);
+    }
+    return profiles;
   }
 
   std::vector<BufferedProfile> profiles;
   profiles.reserve(bufferedProfiles.size());
+  while (!bufferedProfiles.empty() &&
+         bufferedProfiles.front().phase < minPhase) {
+    bufferedProfileBytes -= bufferedProfiles.front().payload.size();
+    bufferedProfiles.pop_front();
+  }
   while (!bufferedProfiles.empty()) {
+    if (reachedMaxProfiles(profiles.size())) {
+      break;
+    }
+    bufferedProfileBytes -= bufferedProfiles.front().payload.size();
     profiles.push_back(std::move(bufferedProfiles.front()));
     bufferedProfiles.pop_front();
   }
-  bufferedProfileBytes = 0;
   return profiles;
 }
 

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -829,9 +829,10 @@ void CuptiProfiler::doSetMode(const std::vector<std::string> &modeAndOptions) {
   if (proton::toLower(mode) == "pcsampling") {
     pcSamplingEnabled = true;
   } else if (proton::toLower(mode) == "periodic_flushing") {
-    detail::setPeriodicFlushingMode(periodicFlushingEnabled,
-                                    periodicFlushingFormat, modeAndOptions,
-                                    "CuptiProfiler");
+    const auto config =
+        detail::parsePeriodicFlushingMode(modeAndOptions, "CuptiProfiler");
+    periodicFlushingEnabled = config.enabled;
+    periodicFlushingFormat = config.format;
   } else if (!mode.empty()) {
     throw std::invalid_argument("[PROTON] CuptiProfiler: unsupported mode: " +
                                 mode);

--- a/third_party/proton/csrc/lib/Profiler/GPUProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/GPUProfiler.cpp
@@ -39,12 +39,24 @@ computeFlushRangesAndPeekPhases(
     // "complete" phase yet. So we flush up to phase.second - 1.
     const size_t endPhaseToFlush = phase.second - 1;
 
+    size_t flushedPhase = Data::kNoCompletePhase;
+    if (flushedPhaseIt != dataFlushedPhases.end()) {
+      flushedPhase = flushedPhaseIt->second;
+    }
+    if (data->getBufferedProfileMaxBytes() > 0) {
+      const auto serializedUpToPhase =
+          data->getBufferedProfileSerializedUpToPhase();
+      if (flushedPhase == Data::kNoCompletePhase) {
+        flushedPhase = serializedUpToPhase;
+      } else if (serializedUpToPhase != Data::kNoCompletePhase) {
+        flushedPhase = std::max(flushedPhase, serializedUpToPhase);
+      }
+    }
+
     size_t minPhaseToFlush = 0;
-    if (flushedPhaseIt == dataFlushedPhases.end() ||
-        flushedPhaseIt->second == Data::kNoCompletePhase) {
+    if (flushedPhase == Data::kNoCompletePhase) {
       minPhaseToFlush = 0;
     } else {
-      const auto flushedPhase = flushedPhaseIt->second;
       if (endPhaseToFlush <= flushedPhase) {
         continue;
       }
@@ -81,6 +93,8 @@ void periodicFlushDataPhases(Data &data,
                              PeriodicFlushStats &stats) {
   using Clock = std::chrono::steady_clock;
   const auto &path = data.getPath();
+  const bool bufferProfiles = data.getBufferedProfileMaxBytes() > 0;
+  const bool writeOutputs = !path.empty();
 
   for (auto startPhase = minPhaseToFlush; startPhase <= maxPhaseToFlush;
        startPhase++) {
@@ -100,6 +114,14 @@ void periodicFlushDataPhases(Data &data,
         ++stats.toJsonCalls;
       } else {
         jsonStr = data.toJsonString(startPhase);
+      }
+
+      if (bufferProfiles) {
+        data.appendBufferedProfile(startPhase, jsonStr);
+      }
+
+      if (!writeOutputs) {
+        continue;
       }
 
       if (timingEnabled) {
@@ -128,6 +150,14 @@ void periodicFlushDataPhases(Data &data,
         ++stats.toMsgPackCalls;
       } else {
         msgPack = data.toMsgPack(startPhase);
+      }
+
+      if (bufferProfiles) {
+        data.appendBufferedProfile(startPhase, msgPack);
+      }
+
+      if (!writeOutputs) {
+        continue;
       }
 
       if (timingEnabled) {
@@ -170,31 +200,35 @@ void periodicClearDataPhases(Data &data, size_t maxPhaseToFlush,
 
 } // namespace
 
-void setPeriodicFlushingMode(bool &periodicFlushingEnabled,
-                             std::string &periodicFlushingFormat,
-                             const std::vector<std::string> &modeAndOptions,
-                             const char *profilerName) {
-  periodicFlushingEnabled = true;
-  if (modeAndOptions.size() < 2)
-    periodicFlushingFormat = "hatchet";
-
-  auto delimiterPos = modeAndOptions[1].find('=');
-  if (delimiterPos != std::string::npos) {
-    const std::string key = modeAndOptions[1].substr(0, delimiterPos);
-    const std::string value = modeAndOptions[1].substr(delimiterPos + 1);
-    if (key != "format") {
+PeriodicFlushingConfig
+parsePeriodicFlushingMode(const std::vector<std::string> &modeAndOptions,
+                          const char *profilerName) {
+  PeriodicFlushingConfig config;
+  config.enabled = true;
+  for (size_t i = 1; i < modeAndOptions.size(); ++i) {
+    const auto delimiterPos = modeAndOptions[i].find('=');
+    if (delimiterPos == std::string::npos) {
+      throw std::invalid_argument(std::string("[PROTON] ") + profilerName +
+                                  ": unsupported option: " +
+                                  modeAndOptions[i]);
+    }
+    const std::string key = modeAndOptions[i].substr(0, delimiterPos);
+    const std::string value = modeAndOptions[i].substr(delimiterPos + 1);
+    if (key == "format") {
+      if (value != "hatchet_msgpack" && value != "chrome_trace" &&
+          value != "hatchet") {
+        throw std::invalid_argument(std::string("[PROTON] ") + profilerName +
+                                    ": unsupported format: " + value);
+      }
+      config.format = value;
+    } else if (key == "buffer_max_bytes") {
+      config.bufferMaxBytes = std::stoull(value);
+    } else {
       throw std::invalid_argument(std::string("[PROTON] ") + profilerName +
                                   ": unsupported option key: " + key);
     }
-    if (value != "hatchet_msgpack" && value != "chrome_trace" &&
-        value != "hatchet") {
-      throw std::invalid_argument(std::string("[PROTON] ") + profilerName +
-                                  ": unsupported format: " + value);
-    }
-    periodicFlushingFormat = value;
-  } else {
-    periodicFlushingFormat = "hatchet";
   }
+  return config;
 }
 
 void updateDataPhases(std::map<Data *, std::pair<size_t, size_t>> &dataPhases,

--- a/third_party/proton/csrc/lib/Profiler/GPUProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/GPUProfiler.cpp
@@ -152,31 +152,31 @@ void periodicFlushDataPhases(Data &data,
         msgPack = data.toMsgPack(startPhase);
       }
 
+      if (writeOutputs) {
+        if (timingEnabled) {
+          const auto t0 = Clock::now();
+          std::ofstream ofs(pathWithPhase,
+                            std::ios::out | std::ios::binary |
+                                std::ios::trunc);
+          ofs.write(reinterpret_cast<const char *>(msgPack.data()),
+                    msgPack.size());
+          ofs.flush();
+          const auto t1 = Clock::now();
+          stats.totalMsgPackWriteUs +=
+              std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0)
+                  .count();
+          ++stats.msgPackWriteCalls;
+        } else {
+          std::ofstream ofs(pathWithPhase,
+                            std::ios::out | std::ios::binary |
+                                std::ios::trunc);
+          ofs.write(reinterpret_cast<const char *>(msgPack.data()),
+                    msgPack.size());
+        }
+      }
+
       if (bufferProfiles) {
-        data.appendBufferedProfile(startPhase, msgPack);
-      }
-
-      if (!writeOutputs) {
-        continue;
-      }
-
-      if (timingEnabled) {
-        const auto t0 = Clock::now();
-        std::ofstream ofs(pathWithPhase,
-                          std::ios::out | std::ios::binary | std::ios::trunc);
-        ofs.write(reinterpret_cast<const char *>(msgPack.data()),
-                  msgPack.size());
-        ofs.flush();
-        const auto t1 = Clock::now();
-        stats.totalMsgPackWriteUs +=
-            std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0)
-                .count();
-        ++stats.msgPackWriteCalls;
-      } else {
-        std::ofstream ofs(pathWithPhase,
-                          std::ios::out | std::ios::binary | std::ios::trunc);
-        ofs.write(reinterpret_cast<const char *>(msgPack.data()),
-                  msgPack.size());
+        data.appendBufferedProfile(startPhase, std::move(msgPack));
       }
     }
   }

--- a/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/RocTracer/RoctracerProfiler.cpp
@@ -440,9 +440,10 @@ void RoctracerProfiler::doSetMode(
     const std::vector<std::string> &modeAndOptions) {
   auto mode = modeAndOptions[0];
   if (proton::toLower(mode) == "periodic_flushing") {
-    detail::setPeriodicFlushingMode(periodicFlushingEnabled,
-                                    periodicFlushingFormat, modeAndOptions,
-                                    "RoctracerProfiler");
+    const auto config =
+        detail::parsePeriodicFlushingMode(modeAndOptions, "RoctracerProfiler");
+    periodicFlushingEnabled = config.enabled;
+    periodicFlushingFormat = config.format;
   } else if (!mode.empty()) {
     throw std::invalid_argument(
         "[PROTON] RoctracerProfiler: unsupported mode: " + mode);

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -95,6 +95,13 @@ std::unique_ptr<Session> SessionManager::makeSession(
   profiler = validateAndSetProfilerMode(profiler, mode);
   auto contextSource = makeContextSource(contextSourceName);
   auto data = makeData(dataName, path, contextSource.get());
+  auto modeAndOptions = proton::split(mode, ":");
+  if (!modeAndOptions.empty() &&
+      proton::toLower(modeAndOptions[0]) == "periodic_flushing") {
+    const auto config =
+        detail::parsePeriodicFlushingMode(modeAndOptions, profilerName.c_str());
+    data->setBufferedProfileMaxBytes(config.bufferMaxBytes);
+  }
   auto *session = new Session(id, path, profiler, std::move(contextSource),
                               std::move(data));
   return std::unique_ptr<Session>(session);
@@ -347,6 +354,46 @@ std::string SessionManager::getData(size_t sessionId, size_t phase) {
         "Only TreeData is supported for getData() for now");
   }
   return treeData->toJsonString(phase);
+}
+
+std::vector<std::pair<size_t, std::vector<uint8_t>>>
+SessionManager::getBufferedProfiles(size_t sessionId, bool clear) {
+  std::lock_guard<std::mutex> lock(mutex);
+  auto *session = getSessionOrThrow(sessionId);
+  auto *data = session->data.get();
+  if (data->getBufferedProfileMaxBytes() > 0) {
+    const auto phaseInfo = data->getPhaseInfo();
+    if (phaseInfo.completeUpTo != Data::kNoCompletePhase) {
+      const auto serializedUpToPhase =
+          data->getBufferedProfileSerializedUpToPhase();
+      const size_t minPhaseToSerialize =
+          serializedUpToPhase == Data::kNoCompletePhase
+              ? 0
+              : serializedUpToPhase + 1;
+      if (minPhaseToSerialize <= phaseInfo.completeUpTo) {
+        const auto modeAndOptions = session->getProfiler()->getMode();
+        const auto config = detail::parsePeriodicFlushingMode(modeAndOptions,
+                                                              "SessionManager");
+        const auto outputFormat = parseOutputFormat(config.format);
+        for (size_t phase = minPhaseToSerialize; phase <= phaseInfo.completeUpTo;
+             ++phase) {
+          if (outputFormat == OutputFormat::HatchetMsgPack) {
+            data->appendBufferedProfile(phase, data->toMsgPack(phase));
+          } else {
+            data->appendBufferedProfile(phase, data->toJsonString(phase));
+          }
+        }
+        data->clear(phaseInfo.completeUpTo, /*clearUpToPhase=*/true);
+      }
+    }
+  }
+  auto profiles = data->getBufferedProfiles(clear);
+  std::vector<std::pair<size_t, std::vector<uint8_t>>> serializedProfiles;
+  serializedProfiles.reserve(profiles.size());
+  for (auto &profile : profiles) {
+    serializedProfiles.emplace_back(profile.phase, std::move(profile.payload));
+  }
+  return serializedProfiles;
 }
 
 void SessionManager::clearData(size_t sessionId, size_t phase,

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -357,7 +357,8 @@ std::string SessionManager::getData(size_t sessionId, size_t phase) {
 }
 
 std::vector<std::pair<size_t, std::vector<uint8_t>>>
-SessionManager::getBufferedProfiles(size_t sessionId, bool clear) {
+SessionManager::getBufferedProfiles(size_t sessionId, bool clear,
+                                    size_t maxProfiles, size_t minPhase) {
   std::lock_guard<std::mutex> lock(mutex);
   auto *session = getSessionOrThrow(sessionId);
   auto *data = session->data.get();
@@ -387,13 +388,33 @@ SessionManager::getBufferedProfiles(size_t sessionId, bool clear) {
       }
     }
   }
-  auto profiles = data->getBufferedProfiles(clear);
+  auto profiles = data->getBufferedProfiles(clear, maxProfiles, minPhase);
   std::vector<std::pair<size_t, std::vector<uint8_t>>> serializedProfiles;
   serializedProfiles.reserve(profiles.size());
   for (auto &profile : profiles) {
     serializedProfiles.emplace_back(profile.phase, std::move(profile.payload));
   }
   return serializedProfiles;
+}
+
+std::optional<size_t>
+SessionManager::getBufferedProfileSerializedUpToPhase(size_t sessionId) {
+  std::lock_guard<std::mutex> lock(mutex);
+  auto *session = getSessionOrThrow(sessionId);
+  const auto serializedUpToPhase =
+      session->data->getBufferedProfileSerializedUpToPhase();
+  if (serializedUpToPhase == Data::kNoCompletePhase) {
+    return std::nullopt;
+  }
+  return serializedUpToPhase;
+}
+
+std::pair<size_t, size_t>
+SessionManager::getBufferedProfileStats(size_t sessionId) {
+  std::lock_guard<std::mutex> lock(mutex);
+  auto *session = getSessionOrThrow(sessionId);
+  const auto stats = session->data->getBufferedProfileStats();
+  return {stats.profileCount, stats.byteCount};
 }
 
 void SessionManager::clearData(size_t sessionId, size_t phase,

--- a/third_party/proton/proton/data.py
+++ b/third_party/proton/proton/data.py
@@ -37,6 +37,25 @@ def get_msgpack(session: Optional[int] = 0, phase: int = 0):
     return libproton.get_data_msgpack(session, phase)
 
 
+def get_buffered_profiles(session: Optional[int] = 0, clear: bool = False):
+    """
+    Retrieves phase-tagged serialized profiles buffered in Proton's native
+    in-memory ring buffer.
+
+    Args:
+        session (Optional[int]): The session ID of the profiling session, or None if profiling is inactive.
+        clear (bool): Whether to clear buffered profiles after retrieval.
+
+    Returns:
+        list[tuple[int, bytes]]: A list of ``(phase, payload)`` tuples in FIFO order.
+    """
+    if session is None:
+        return []
+    if flags.command_line and session != 0:
+        raise ValueError("Only one session can retrieve buffered profiles when running from the command line.")
+    return list(libproton.get_buffered_profiles(session, clear))
+
+
 def advance_phase(session: Optional[int] = 0) -> Optional[int]:
     """
     Advances the profiling phase for a given session.

--- a/third_party/proton/proton/data.py
+++ b/third_party/proton/proton/data.py
@@ -37,7 +37,12 @@ def get_msgpack(session: Optional[int] = 0, phase: int = 0):
     return libproton.get_data_msgpack(session, phase)
 
 
-def get_buffered_profiles(session: Optional[int] = 0, clear: bool = False):
+def get_buffered_profiles(
+    session: Optional[int] = 0,
+    clear: bool = False,
+    max_profiles: int = 0,
+    min_phase: int = 0,
+):
     """
     Retrieves phase-tagged serialized profiles buffered in Proton's native
     in-memory ring buffer.
@@ -45,6 +50,8 @@ def get_buffered_profiles(session: Optional[int] = 0, clear: bool = False):
     Args:
         session (Optional[int]): The session ID of the profiling session, or None if profiling is inactive.
         clear (bool): Whether to clear buffered profiles after retrieval.
+        max_profiles (int): Maximum number of profiles to return. A value of 0 means unlimited.
+        min_phase (int): Minimum phase to return. Older profiles are removed when ``clear`` is true.
 
     Returns:
         list[tuple[int, bytes]]: A list of ``(phase, payload)`` tuples in FIFO order.
@@ -53,7 +60,29 @@ def get_buffered_profiles(session: Optional[int] = 0, clear: bool = False):
         return []
     if flags.command_line and session != 0:
         raise ValueError("Only one session can retrieve buffered profiles when running from the command line.")
-    return list(libproton.get_buffered_profiles(session, clear))
+    return list(libproton.get_buffered_profiles(session, clear, max_profiles, min_phase))
+
+
+def get_buffered_profile_serialized_up_to_phase(session: Optional[int] = 0):
+    """
+    Returns the newest completed phase serialized into Proton's native buffer.
+    """
+    if session is None:
+        return None
+    if flags.command_line and session != 0:
+        raise ValueError("Only one session can retrieve buffered profiles when running from the command line.")
+    return libproton.get_buffered_profile_serialized_up_to_phase(session)
+
+
+def get_buffered_profile_stats(session: Optional[int] = 0):
+    """
+    Returns ``(profile_count, byte_count)`` for Proton's native profile buffer.
+    """
+    if session is None:
+        return (0, 0)
+    if flags.command_line and session != 0:
+        raise ValueError("Only one session can retrieve buffered profile stats when running from the command line.")
+    return libproton.get_buffered_profile_stats(session)
 
 
 def advance_phase(session: Optional[int] = 0) -> Optional[int]:

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -96,6 +96,9 @@ def start(
                                                Each mode has a set of control knobs following with the mode name.
                                                For example, "periodic_flushing" mode has a knob:
                                                - format: The output format of the profiling results. Available options are ["hatchet", "hatchet_msgpack", "chrome_trace"]. Default is "hatchet".
+                                               - buffer_max_bytes: Retain completed serialized phase profiles in Proton's
+                                                 native in-memory ring buffer with this total payload byte budget. Retrieve
+                                                 buffered payloads with `triton.profiler.data.get_buffered_profiles()`.
                                                The can be set via `mode="periodic_flushing:format=chrome_trace"`.
         hook (Union[str, Hook], optional): The hook to use for profiling.
                                            You may pass either:

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -1270,7 +1270,97 @@ def test_periodic_flushing(tmp_path, fresh_knobs, data_format, buffer_size, devi
         num_scopes += len(data[0]["children"])
     assert num_scopes == 10000
 
+def _child_names_from_msgpack_payload(payload: bytes) -> list[str]:
+    import msgpack
 
+    database = msgpack.unpackb(payload, raw=False, strict_map_key=False)
+    return [child["frame"]["name"] for child in database[0].get("children", [])]
+
+
+def _make_periodic_buffer_kernel():
+
+    @triton.jit
+    def buffered_kernel(x, y, size: tl.constexpr):
+        offs = tl.arange(0, size)
+        tl.store(y + offs, tl.load(x + offs))
+
+    return buffered_kernel
+
+
+def _run_buffered_periodic_phase(session: int, kernel, x, y, scope_name: str) -> None:
+    with proton.scope(scope_name):
+        kernel[(1, )](x, y, x.numel())
+    proton.data.advance_phase(session=session)
+    proton.deactivate(session, flushing=True)
+
+
+def test_periodic_flushing_buffers_profiles_in_memory(fresh_knobs, device: str):
+    fresh_knobs.proton.profile_buffer_size = 256 * 1024
+    kernel = _make_periodic_buffer_kernel()
+    x = torch.ones((16, ), device=device)
+    y = torch.zeros_like(x)
+
+    session = proton.start(
+        "",
+        context="shadow",
+        data="tree",
+        mode="periodic_flushing:format=hatchet_msgpack:buffer_max_bytes=1048576",
+    )
+
+    try:
+        _run_buffered_periodic_phase(session, kernel, x, y, "phase_zero")
+        buffered_profiles = proton.data.get_buffered_profiles(session=session)
+        assert [phase for phase, _ in buffered_profiles] == [0]
+        assert "phase_zero" in _child_names_from_msgpack_payload(buffered_profiles[0][1])
+
+        proton.activate(session)
+        _run_buffered_periodic_phase(session, kernel, x, y, "phase_one")
+        drained_profiles = proton.data.get_buffered_profiles(session=session, clear=True)
+        assert [phase for phase, _ in drained_profiles] == [0, 1]
+        assert "phase_one" in _child_names_from_msgpack_payload(drained_profiles[1][1])
+        assert proton.data.get_buffered_profiles(session=session) == []
+    finally:
+        proton.finalize(session, output_format="hatchet_msgpack")
+
+
+def test_periodic_flushing_in_memory_buffer_drops_oldest(fresh_knobs, device: str):
+    fresh_knobs.proton.profile_buffer_size = 256 * 1024
+    kernel = _make_periodic_buffer_kernel()
+    x = torch.ones((16, ), device=device)
+    y = torch.zeros_like(x)
+
+    measure_session = proton.start(
+        "",
+        context="shadow",
+        data="tree",
+        mode="periodic_flushing:format=hatchet_msgpack:buffer_max_bytes=1048576",
+    )
+    try:
+        _run_buffered_periodic_phase(measure_session, kernel, x, y, "phase_keep")
+        measured_profiles = proton.data.get_buffered_profiles(
+            session=measure_session,
+            clear=True,
+        )
+        assert [phase for phase, _ in measured_profiles] == [0]
+        measured_size = len(measured_profiles[0][1])
+    finally:
+        proton.finalize(measure_session, output_format="hatchet_msgpack")
+
+    session = proton.start(
+        "",
+        context="shadow",
+        data="tree",
+        mode=f"periodic_flushing:format=hatchet_msgpack:buffer_max_bytes={2 * measured_size - 1}",
+    )
+    try:
+        _run_buffered_periodic_phase(session, kernel, x, y, "phase_keep")
+        proton.activate(session)
+        _run_buffered_periodic_phase(session, kernel, x, y, "phase_drop")
+        buffered_profiles = proton.data.get_buffered_profiles(session=session, clear=True)
+        assert [phase for phase, _ in buffered_profiles] == [1]
+        assert "phase_drop" in _child_names_from_msgpack_payload(buffered_profiles[0][1])
+    finally:
+        proton.finalize(session, output_format="hatchet_msgpack")
 @pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
 @pytest.mark.parametrize("buffer_size", [256 * 1024, 64 * 1024 * 1024])
 @pytest.mark.parametrize("data_format", ["hatchet_msgpack", "hatchet"])

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -1309,15 +1309,19 @@ def test_periodic_flushing_buffers_profiles_in_memory(fresh_knobs, device: str):
 
     try:
         _run_buffered_periodic_phase(session, kernel, x, y, "phase_zero")
-        buffered_profiles = proton.data.get_buffered_profiles(session=session)
+        buffered_profiles = proton.data.get_buffered_profiles(session=session, max_profiles=1)
         assert [phase for phase, _ in buffered_profiles] == [0]
         assert "phase_zero" in _child_names_from_msgpack_payload(buffered_profiles[0][1])
 
         proton.activate(session)
         _run_buffered_periodic_phase(session, kernel, x, y, "phase_one")
-        drained_profiles = proton.data.get_buffered_profiles(session=session, clear=True)
-        assert [phase for phase, _ in drained_profiles] == [0, 1]
-        assert "phase_one" in _child_names_from_msgpack_payload(drained_profiles[1][1])
+        drained_profiles = proton.data.get_buffered_profiles(session=session, clear=True, max_profiles=1)
+        assert [phase for phase, _ in drained_profiles] == [0]
+        assert "phase_zero" in _child_names_from_msgpack_payload(drained_profiles[0][1])
+
+        remaining_profiles = proton.data.get_buffered_profiles(session=session, clear=True, max_profiles=1, min_phase=1)
+        assert [phase for phase, _ in remaining_profiles] == [1]
+        assert "phase_one" in _child_names_from_msgpack_payload(remaining_profiles[0][1])
         assert proton.data.get_buffered_profiles(session=session) == []
     finally:
         proton.finalize(session, output_format="hatchet_msgpack")


### PR DESCRIPTION
## Summary
- add a native bounded in-memory buffer for Proton periodic-flushing phase payloads
- expose buffered profile reads through the Proton Python bindings
- backfill completed phases on read and reconcile callback-side flush tracking so later flushes do not reserialize cleared phases

## Validation
- `db-0`: rebuild and reinstall `triton-3.6.0-cp312-cp312-linux_aarch64.whl`
- `db-0`: `pytest third_party/proton/test/test_profile.py -k "buffers_profiles_in_memory or in_memory_buffer_drops_oldest"`
- `db-0`: focused one-phase and two-phase Python repros for `get_buffered_profiles()` and msgpack parsing
- `db-0`: OpenAI `ProtonProfiler` smoke consuming buffered phases from the rebuilt wheel