### PR TITLE
[proton] Reproduce and fix missing-graph correlation cleanup

### DIFF
--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -261,6 +261,15 @@ Recommended workflow:
 1. Prepare the target GPU machine.
 If you are iterating on the script from a laptop, do that there first, then sync either the Triton checkout or just `third_party/proton/tutorials/cupti_memory_growth.py` to the target GPU machine.
 
+If `"$HOME/code/triton"` does not exist on the target GPU machine and you want the
+repo-relative workflow, create a checkout first:
+
+```bash
+mkdir -p "$HOME/code"
+git clone https://github.com/triton-lang/triton.git "$HOME/code/triton"
+cd "$HOME/code/triton"
+```
+
 2. Run the compare flow on the target GPU machine.
 If you have a Triton checkout there:
 

--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -259,8 +259,17 @@ The tutorial [`tutorials/cupti_memory_growth.py`](tutorials/cupti_memory_growth.
 If that process also loads framework-bundled CUPTI libraries, use the cleaner
 [`tutorials/cupti_memory_growth_cuda_core.py`](tutorials/cupti_memory_growth_cuda_core.py)
 variant instead. It drives CUDA work through `cuda.core.experimental` and
-controls Proton through `triton._C.libproton` directly, so the process only
-loads the selected `libcupti.so`.
+controls Proton through `triton._C.libproton` directly.
+
+By default, the CUDA-core tutorial keeps the process in a clean single-CUPTI
+configuration and only loads Triton's selected `libcupti.so`.
+
+If you want to mimic a framework process that already mapped another CUPTI DSO
+before Proton starts, add `--preload-torch`. In that mode the summary JSON
+records both:
+
+- `loaded_cupti_libs_*`: exact `libcupti.so` selections from Triton's packaged directories
+- `loaded_libcupti_objects_*`: every mapped `libcupti*` object, including entries such as `torch/lib/libcupti.so.13`
 
 Recommended workflow:
 
@@ -312,6 +321,26 @@ python third_party/proton/tutorials/cupti_memory_growth_cuda_core.py \
   --workload direct
 ```
 
+To reproduce the CUDA-graph warning path in a process that preloads Torch's
+bundled `libcupti.so.13` before Proton starts:
+
+```bash
+cd "$HOME/code/triton"
+python third_party/proton/tutorials/cupti_memory_growth_cuda_core.py \
+  --output-dir /tmp/proton-cuda-core-torch-graph-1000x32 \
+  --iterations 1000 \
+  --warmup 5 \
+  --phase-every 1 \
+  --sample-every 100 \
+  --lifecycle step \
+  --kernels-per-step 32 \
+  --clear-completed-phases \
+  --workload graph \
+  --capture-before-start \
+  --post-finalize-sleep-ms 1000 \
+  --preload-torch
+```
+
 If the target GPU machine only has an installed Triton wheel, copy the script there and run:
 
 ```bash
@@ -341,6 +370,24 @@ python /tmp/cupti_memory_growth_cuda_core.py \
   --workload direct
 ```
 
+And for the Torch-preloaded graph-warning probe:
+
+```bash
+python /tmp/cupti_memory_growth_cuda_core.py \
+  --output-dir /tmp/proton-cuda-core-torch-graph-1000x32 \
+  --iterations 1000 \
+  --warmup 5 \
+  --phase-every 1 \
+  --sample-every 100 \
+  --lifecycle step \
+  --kernels-per-step 32 \
+  --clear-completed-phases \
+  --workload graph \
+  --capture-before-start \
+  --post-finalize-sleep-ms 1000 \
+  --preload-torch
+```
+
 3. Inspect the generated artifacts.
 The script writes one `summary_<label>.json` per CUPTI variant, plus `comparison.json`, under `--output-dir`.
 
@@ -350,6 +397,7 @@ The script writes one `summary_<label>.json` per CUPTI variant, plus `comparison
   - `samples.nvidia_smi_gpu_delta_mb`
   - `selected_cupti`
   - `loaded_cupti_libs_after_start`
+  - `loaded_libcupti_objects_after_start`
   - `env`
 
 If the issue is CUPTI-specific, one variant should show higher host RSS growth while `nvidia_smi_gpu_delta_mb` stays near zero in both runs.
@@ -358,14 +406,19 @@ For the CUDA-core-based comparison, `loaded_cupti_libs_after_start` should conta
 exactly one path. If it contains more than one `libcupti.so`, you are no longer
 running in the clean single-CUPTI configuration.
 
+For `--preload-torch`, expect `loaded_libcupti_objects_after_start` to contain at
+least two entries: Triton's selected `libcupti.so` and Torch's
+`libcupti.so.13`. That dual-CUPTI loader topology is intentional in that mode.
+
 4. Verify that the machine actually switched CUPTI variants.
-If both runs report the same `loaded_cupti_libs_after_start` value, the target machine did not switch to a different `libcupti.so`, so the comparison is not valid yet. In that case, inspect `selected_cupti`, `loaded_cupti_libs_after_start`, and `env` in both summary files before drawing conclusions from the RSS numbers.
+If both runs report the same `loaded_cupti_libs_after_start` value, the target machine did not switch to a different `libcupti.so`, so the comparison is not valid yet. In that case, inspect `selected_cupti`, `loaded_cupti_libs_after_start`, `loaded_libcupti_objects_after_start`, and `env` in both summary files before drawing conclusions from the RSS numbers.
 
 Current interpretation guidance for the CUDA-core-based tutorial:
 
 - `--workload direct` keeps retained RSS near zero in a clean process for both CUPTI variants.
 - `--workload graph --capture-before-start` reproduces Proton's `Cannot find graph for graphExecId` warning and shows stable retained RSS growth that is similar for both variants.
 - `--workload graph` captured after profiling starts can show transient differences if you sample immediately after `finalize()`. Use `--post-finalize-sleep-ms 1000` before treating a retained RSS gap as a stable CUPTI-version effect.
+- `--preload-torch` is useful when the real workload already imports Torch before Proton starts. In our GB200 validation, that mode reliably showed both Torch's `libcupti.so.13` and Triton's selected `libcupti.so`, but still produced the same retained RSS for generic and Blackwell CUPTI in the single-process graph-warning probe.
 
 ### Visualizing the profile data
 

--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -256,9 +256,13 @@ Therefore, `proton.deactivate(session_id=1)` is invalid, while `proton.deactivat
 
 The tutorial [`tutorials/cupti_memory_growth.py`](tutorials/cupti_memory_growth.py) compares process RSS across CUPTI library variants while running the same Triton + Proton workload. It is useful for isolating host-memory growth that appears only with a specific CUPTI build.
 
+Recommended workflow:
+
+1. Prepare the target GPU machine.
 If you are iterating on the script from a laptop, do that there first, then sync either the Triton checkout or just `third_party/proton/tutorials/cupti_memory_growth.py` to the target GPU machine.
 
-On the target GPU machine, if you have a Triton checkout:
+2. Run the compare flow on the target GPU machine.
+If you have a Triton checkout there:
 
 ```bash
 cd "$HOME/code/triton"
@@ -287,7 +291,21 @@ python /tmp/cupti_memory_growth.py \
   --clear-completed-phases
 ```
 
-The script writes one `summary_<label>.json` per CUPTI variant, plus `comparison.json`. Compare `rss_delta_bytes` and `rss_max_bytes` between the `generic` and `blackwell` runs. If the issue is CUPTI-specific, one variant should show higher host RSS growth while `nvidia_smi_gpu_delta_mb` stays near zero in both runs.
+3. Inspect the generated artifacts.
+The script writes one `summary_<label>.json` per CUPTI variant, plus `comparison.json`, under `--output-dir`.
+
+- `comparison.json` highlights the top-level deltas between the `generic` and `blackwell` runs.
+- `summary_generic.json` and `summary_blackwell.json` contain:
+  - `samples.rss_delta_bytes` and `samples.rss_max_bytes`
+  - `samples.nvidia_smi_gpu_delta_mb`
+  - `selected_cupti`
+  - `loaded_cupti_libs_after_start`
+  - `env`
+
+If the issue is CUPTI-specific, one variant should show higher host RSS growth while `nvidia_smi_gpu_delta_mb` stays near zero in both runs.
+
+4. Verify that the machine actually switched CUPTI variants.
+If both runs report the same `loaded_cupti_libs_after_start` value, the target machine did not switch to a different `libcupti.so`, so the comparison is not valid yet. In that case, inspect `selected_cupti`, `loaded_cupti_libs_after_start`, and `env` in both summary files before drawing conclusions from the RSS numbers.
 
 ### Visualizing the profile data
 

--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -252,6 +252,26 @@ proton --instrument=[instrumentation pass] script.py
 When profiling in the command line mode, the `proton.start` and `proton.finalize` functions are automatically called before and after the script execution. Any `proton.start` and `proton.finalize` functions in the script are ignored. Also, in the command line mode, only a single *session* is supported.
 Therefore, `proton.deactivate(session_id=1)` is invalid, while `proton.deactivate(session_id=0)` is valid.
 
+### CUPTI memory growth reproduction
+
+The tutorial [`tutorials/cupti_memory_growth.py`](tutorials/cupti_memory_growth.py) compares process RSS across CUPTI library variants while running the same Triton + Proton workload. It is useful for isolating host-memory growth that appears only with a specific CUPTI build.
+
+Run the packaged generic and Blackwell CUPTI variants back-to-back:
+
+```bash
+python third_party/proton/tutorials/cupti_memory_growth.py \
+  --output-dir /tmp/proton-cupti-compare \
+  --iterations 200 \
+  --warmup 5 \
+  --phase-every 1 \
+  --sample-every 20 \
+  --lifecycle step \
+  --kernels-per-step 32 \
+  --clear-completed-phases
+```
+
+The script writes one `summary_<label>.json` per CUPTI variant, plus `comparison.json`. Compare `rss_delta_bytes` and `rss_max_bytes` between the `generic` and `blackwell` runs. If the issue is CUPTI-specific, one variant should show higher host RSS growth while `nvidia_smi_gpu_delta_mb` stays near zero in both runs.
+
 ### Visualizing the profile data
 
 By default, proton profiles are in the *json* format and can be read by *Hatchet*. The following command visualizes the profile data on terminal.

--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -256,10 +256,16 @@ Therefore, `proton.deactivate(session_id=1)` is invalid, while `proton.deactivat
 
 The tutorial [`tutorials/cupti_memory_growth.py`](tutorials/cupti_memory_growth.py) compares process RSS across CUPTI library variants while running the same Triton + Proton workload. It is useful for isolating host-memory growth that appears only with a specific CUPTI build.
 
+If that process also loads framework-bundled CUPTI libraries, use the cleaner
+[`tutorials/cupti_memory_growth_cuda_core.py`](tutorials/cupti_memory_growth_cuda_core.py)
+variant instead. It drives CUDA work through `cuda.core.experimental` and
+controls Proton through `triton._C.libproton` directly, so the process only
+loads the selected `libcupti.so`.
+
 Recommended workflow:
 
 1. Prepare the target GPU machine.
-If you are iterating on the script from a laptop, do that there first, then sync either the Triton checkout or just `third_party/proton/tutorials/cupti_memory_growth.py` to the target GPU machine.
+If you are iterating on the script from a laptop, do that there first, then sync either the Triton checkout or just the tutorial script you want to run to the target GPU machine.
 
 If `"$HOME/code/triton"` does not exist on the target GPU machine and you want the
 repo-relative workflow, create a checkout first:
@@ -290,6 +296,22 @@ This repo-relative form only uses checkout code if the Triton Python package on 
 machine was installed from that checkout. If `triton_version_file` in the summary still
 points at `site-packages`, then the run used the installed wheel, not the checkout.
 
+For the cleaner CUDA-core-based comparison:
+
+```bash
+cd "$HOME/code/triton"
+python third_party/proton/tutorials/cupti_memory_growth_cuda_core.py \
+  --output-dir /tmp/proton-cuda-core-direct-200x32 \
+  --iterations 200 \
+  --warmup 5 \
+  --phase-every 1 \
+  --sample-every 20 \
+  --lifecycle step \
+  --kernels-per-step 32 \
+  --clear-completed-phases \
+  --workload direct
+```
+
 If the target GPU machine only has an installed Triton wheel, copy the script there and run:
 
 ```bash
@@ -302,6 +324,21 @@ python /tmp/cupti_memory_growth.py \
   --lifecycle step \
   --kernels-per-step 32 \
   --clear-completed-phases
+```
+
+Or, for the CUDA-core-based comparison:
+
+```bash
+python /tmp/cupti_memory_growth_cuda_core.py \
+  --output-dir /tmp/proton-cuda-core-direct-200x32 \
+  --iterations 200 \
+  --warmup 5 \
+  --phase-every 1 \
+  --sample-every 20 \
+  --lifecycle step \
+  --kernels-per-step 32 \
+  --clear-completed-phases \
+  --workload direct
 ```
 
 3. Inspect the generated artifacts.
@@ -317,8 +354,18 @@ The script writes one `summary_<label>.json` per CUPTI variant, plus `comparison
 
 If the issue is CUPTI-specific, one variant should show higher host RSS growth while `nvidia_smi_gpu_delta_mb` stays near zero in both runs.
 
+For the CUDA-core-based comparison, `loaded_cupti_libs_after_start` should contain
+exactly one path. If it contains more than one `libcupti.so`, you are no longer
+running in the clean single-CUPTI configuration.
+
 4. Verify that the machine actually switched CUPTI variants.
 If both runs report the same `loaded_cupti_libs_after_start` value, the target machine did not switch to a different `libcupti.so`, so the comparison is not valid yet. In that case, inspect `selected_cupti`, `loaded_cupti_libs_after_start`, and `env` in both summary files before drawing conclusions from the RSS numbers.
+
+Current interpretation guidance for the CUDA-core-based tutorial:
+
+- `--workload direct` keeps retained RSS near zero in a clean process for both CUPTI variants.
+- `--workload graph --capture-before-start` reproduces Proton's `Cannot find graph for graphExecId` warning and shows stable retained RSS growth that is similar for both variants.
+- `--workload graph` captured after profiling starts can show transient differences if you sample immediately after `finalize()`. Use `--post-finalize-sleep-ms 1000` before treating a retained RSS gap as a stable CUPTI-version effect.
 
 ### Visualizing the profile data
 

--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -277,6 +277,10 @@ python third_party/proton/tutorials/cupti_memory_growth.py \
   --clear-completed-phases
 ```
 
+This repo-relative form only uses checkout code if the Triton Python package on that
+machine was installed from that checkout. If `triton_version_file` in the summary still
+points at `site-packages`, then the run used the installed wheel, not the checkout.
+
 If the target GPU machine only has an installed Triton wheel, copy the script there and run:
 
 ```bash

--- a/third_party/proton/README.md
+++ b/third_party/proton/README.md
@@ -256,10 +256,27 @@ Therefore, `proton.deactivate(session_id=1)` is invalid, while `proton.deactivat
 
 The tutorial [`tutorials/cupti_memory_growth.py`](tutorials/cupti_memory_growth.py) compares process RSS across CUPTI library variants while running the same Triton + Proton workload. It is useful for isolating host-memory growth that appears only with a specific CUPTI build.
 
-Run the packaged generic and Blackwell CUPTI variants back-to-back:
+If you are iterating on the script from a laptop, do that there first, then sync either the Triton checkout or just `third_party/proton/tutorials/cupti_memory_growth.py` to the target GPU machine.
+
+On the target GPU machine, if you have a Triton checkout:
 
 ```bash
+cd "$HOME/code/triton"
 python third_party/proton/tutorials/cupti_memory_growth.py \
+  --output-dir /tmp/proton-cupti-compare \
+  --iterations 200 \
+  --warmup 5 \
+  --phase-every 1 \
+  --sample-every 20 \
+  --lifecycle step \
+  --kernels-per-step 32 \
+  --clear-completed-phases
+```
+
+If the target GPU machine only has an installed Triton wheel, copy the script there and run:
+
+```bash
+python /tmp/cupti_memory_growth.py \
   --output-dir /tmp/proton-cupti-compare \
   --iterations 200 \
   --warmup 5 \

--- a/third_party/proton/csrc/include/Profiler/GPUProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/GPUProfiler.h
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <cstdint>
 #include <deque>
+#include <iostream>
 #include <map>
 #include <stdexcept>
 #include <thread>
@@ -205,6 +206,19 @@ protected:
       });
     }
 
+    size_t purgeCompleted(uint64_t completedId) {
+      auto liveCorrelations = corrIdToExternId.snapshot();
+      size_t purged = 0;
+      for (const auto &[correlationId, externId] : liveCorrelations) {
+        if (correlationId > completedId)
+          continue;
+        corrIdToExternId.erase(correlationId);
+        externIdToState.erase(externId);
+        ++purged;
+      }
+      return purged;
+    }
+
     template <typename FlushFnT>
     void flush(uint64_t maxRetries, uint64_t sleepUs, FlushFnT &&flushFn) {
       flushFn();
@@ -216,6 +230,17 @@ protected:
         flushFn();
         completedId = maxCompletedCorrelationId.load();
         --retries;
+      }
+      if (completedId >= submittedId) {
+        auto liveBefore = corrIdToExternId.size();
+        auto purged = purgeCompleted(completedId);
+        if (purged > 0 && getBoolEnv("PROTON_CORRELATION_DEBUG", false)) {
+          std::cerr << "[PROTON] Purged " << purged
+                    << " completed correlation entries at flush"
+                    << " (live_before=" << liveBefore
+                    << ", live_after=" << corrIdToExternId.size()
+                    << ", completed_id=" << completedId << ")" << std::endl;
+        }
       }
     }
   };

--- a/third_party/proton/csrc/include/Profiler/GPUProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/GPUProfiler.h
@@ -178,7 +178,13 @@ protected:
   };
 
   struct Correlation {
+    // Highest correlation id we have seen leave the launch callback path.
+    // "submitted" means Proton has associated launch-side bookkeeping with
+    // this id and is now waiting for activity records to show up.
     std::atomic<uint64_t> maxSubmittedCorrelationId{0};
+    // Highest correlation id for which CUPTI activity processing has observed
+    // records in processActivityBuffer(). "completed" therefore means the
+    // device-side activity stream has caught up through this id.
     std::atomic<uint64_t> maxCompletedCorrelationId{0};
     // Mapping from a native profiler correlation id to an external id.
     CorrIdToExternIdMap corrIdToExternId;
@@ -206,12 +212,17 @@ protected:
       });
     }
 
+    // Drop launch-side correlation state once CUPTI activity handling has
+    // completed through completedId. This is safe only after flush() has
+    // observed completedId >= submittedId, i.e. once activity processing has
+    // caught up with everything submitted so far.
     size_t purgeCompleted(uint64_t completedId) {
-      auto liveCorrelations = corrIdToExternId.snapshot();
+      auto liveCorrelations = corrIdToExternId.collectIf(
+          [&](uint64_t correlationId, size_t) {
+            return correlationId <= completedId;
+          });
       size_t purged = 0;
       for (const auto &[correlationId, externId] : liveCorrelations) {
-        if (correlationId > completedId)
-          continue;
         corrIdToExternId.erase(correlationId);
         externIdToState.erase(externId);
         ++purged;

--- a/third_party/proton/csrc/include/Utility/Map.h
+++ b/third_party/proton/csrc/include/Utility/Map.h
@@ -88,6 +88,11 @@ public:
     return map.size();
   }
 
+  Container snapshot() const {
+    std::shared_lock<std::shared_mutex> lock(mutex);
+    return map;
+  }
+
   std::optional<std::reference_wrapper<Value>> find(const Key &key) {
     std::shared_lock<std::shared_mutex> lock(mutex);
     auto it = map.find(key);

--- a/third_party/proton/csrc/include/Utility/Map.h
+++ b/third_party/proton/csrc/include/Utility/Map.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <mutex>
+#include <vector>
 #include <shared_mutex>
 #include <utility>
 
@@ -91,6 +92,17 @@ public:
   Container snapshot() const {
     std::shared_lock<std::shared_mutex> lock(mutex);
     return map;
+  }
+
+  template <typename PredT>
+  std::vector<std::pair<Key, Value>> collectIf(PredT &&pred) const {
+    std::shared_lock<std::shared_mutex> lock(mutex);
+    std::vector<std::pair<Key, Value>> result;
+    for (const auto &[key, value] : map) {
+      if (pred(key, value))
+        result.emplace_back(key, value);
+    }
+    return result;
   }
 
   std::optional<std::reference_wrapper<Value>> find(const Key &key) {

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -641,7 +641,7 @@ void CuptiProfiler::CuptiProfilerPimpl::handleApiEnterLaunchCallbacks(
     if (!findGraph && !graphStates[graphExecId].captureStatusChecked) {
       graphStates[graphExecId].captureStatusChecked = true;
       std::cerr << "[PROTON] Cannot find graph for graphExecId: " << graphExecId
-                << ", and t may cause memory leak. To avoid this problem, "
+                << ", and it may cause memory leak. To avoid this problem, "
                    "please start profiling before the graph is created."
                 << std::endl;
     } else if (findGraph && !graphStates[graphExecId].captureStatusChecked) {

--- a/third_party/proton/test/unittest/CMakeLists.txt
+++ b/third_party/proton/test/unittest/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(TraceDataIO)
+add_subdirectory(Profiler)

--- a/third_party/proton/test/unittest/Profiler/CMakeLists.txt
+++ b/third_party/proton/test/unittest/Profiler/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_triton_ut(
+  NAME ProtonCorrelation
+  SRCS CorrelationTest.cpp
+)
+
+target_include_directories(ProtonCorrelation
+PRIVATE
+  "${PROTON_COMMON_DIR}/include"
+  "${PROTON_SRC_DIR}/include"
+)

--- a/third_party/proton/test/unittest/Profiler/CorrelationTest.cpp
+++ b/third_party/proton/test/unittest/Profiler/CorrelationTest.cpp
@@ -1,0 +1,52 @@
+#include "Profiler/GPUProfiler.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+namespace {
+
+class DummyProfiler : public proton::GPUProfiler<DummyProfiler> {
+public:
+  using proton::GPUProfiler<DummyProfiler>::Correlation;
+};
+
+using Correlation = DummyProfiler::Correlation;
+
+TEST(CorrelationTest, FlushPurgesCompletedCorrelationsOnceAllActivitiesFinish) {
+  Correlation correlation;
+  proton::DataToEntryMap emptyDataToEntry;
+
+  correlation.submit(1);
+  correlation.submit(2);
+  correlation.correlate(1, 101, std::numeric_limits<size_t>::max(),
+                        /*isMissingName=*/false, emptyDataToEntry);
+  correlation.correlate(2, 102, std::numeric_limits<size_t>::max(),
+                        /*isMissingName=*/false, emptyDataToEntry);
+  correlation.complete(2);
+
+  correlation.flush(/*maxRetries=*/0, /*sleepUs=*/0, []() {});
+
+  EXPECT_EQ(correlation.corrIdToExternId.size(), 0u);
+  EXPECT_EQ(correlation.externIdToState.size(), 0u);
+}
+
+TEST(CorrelationTest, FlushDoesNotPurgeWhileSubmittedActivitiesAreIncomplete) {
+  Correlation correlation;
+  proton::DataToEntryMap emptyDataToEntry;
+
+  correlation.submit(1);
+  correlation.submit(2);
+  correlation.correlate(1, 201, std::numeric_limits<size_t>::max(),
+                        /*isMissingName=*/false, emptyDataToEntry);
+  correlation.correlate(2, 202, std::numeric_limits<size_t>::max(),
+                        /*isMissingName=*/false, emptyDataToEntry);
+  correlation.complete(1);
+
+  correlation.flush(/*maxRetries=*/0, /*sleepUs=*/0, []() {});
+
+  EXPECT_EQ(correlation.corrIdToExternId.size(), 2u);
+  EXPECT_EQ(correlation.externIdToState.size(), 2u);
+}
+
+} // namespace

--- a/third_party/proton/tutorials/cupti_memory_growth.py
+++ b/third_party/proton/tutorials/cupti_memory_growth.py
@@ -4,8 +4,9 @@
 
 Examples:
 
-  Compare Triton's packaged generic and Blackwell CUPTI builds:
+  On the target GPU machine, from a Triton checkout:
 
+    cd "$HOME/code/triton"
     python third_party/proton/tutorials/cupti_memory_growth.py \
       --output-dir /tmp/proton-cupti-compare \
       --iterations 200 \
@@ -21,7 +22,20 @@ Examples:
     `blackwell` runs. A CUPTI-specific host-memory issue should show up as
     larger RSS growth for one library variant while GPU memory stays flat.
 
-  Run a single configuration with an explicit CUPTI directory:
+  If you only copied this file to the target GPU machine:
+
+    python /tmp/cupti_memory_growth.py \
+      --output-dir /tmp/proton-cupti-compare \
+      --iterations 200 \
+      --warmup 5 \
+      --phase-every 1 \
+      --sample-every 20 \
+      --lifecycle step \
+      --kernels-per-step 32 \
+      --clear-completed-phases
+
+  Run a single configuration with an explicit CUPTI directory on the target GPU
+  machine:
 
     python third_party/proton/tutorials/cupti_memory_growth.py \
       --single-run \

--- a/third_party/proton/tutorials/cupti_memory_growth.py
+++ b/third_party/proton/tutorials/cupti_memory_growth.py
@@ -221,6 +221,27 @@ def _query_nvidia_smi_process_memory_mb(pid: int) -> int | None:
     return 0
 
 
+def _read_loaded_shared_objects(needle: str) -> list[str]:
+    maps_path = Path("/proc/self/maps")
+    if not maps_path.exists():
+        return []
+
+    loaded: list[str] = []
+    seen: set[str] = set()
+    for line in maps_path.read_text().splitlines():
+        if needle not in line:
+            continue
+        parts = line.split()
+        if len(parts) < 6:
+            continue
+        path = parts[-1]
+        if path in seen:
+            continue
+        seen.add(path)
+        loaded.append(path)
+    return loaded
+
+
 def _load_cupti_info(cupti_dir: Path) -> dict[str, Any]:
     lib_path = cupti_dir / "libcupti.so"
     info: dict[str, Any] = {
@@ -387,17 +408,23 @@ def _run_single(args: argparse.Namespace) -> int:
         "triton_version_file": str(Path(triton.__file__).resolve()),
         "triton_target_backend": triton.runtime.driver.active.get_current_target().backend,
         "triton_target_arch": triton.runtime.driver.active.get_current_target().arch,
+        "triton_knobs": {
+            "cupti_lib_dir": triton.knobs.proton.cupti_lib_dir,
+            "cupti_lib_blackwell_dir": triton.knobs.proton.cupti_lib_blackwell_dir,
+        },
         "selected_cupti": cupti_info,
         "env": {
             "TRITON_CUPTI_LIB_PATH": os.environ.get("TRITON_CUPTI_LIB_PATH"),
             "TRITON_CUPTI_LIB_BLACKWELL_PATH": os.environ.get("TRITON_CUPTI_LIB_BLACKWELL_PATH"),
             "TRITON_PROFILE_BUFFER_SIZE": os.environ.get("TRITON_PROFILE_BUFFER_SIZE"),
         },
+        "loaded_cupti_libs_before_start": _read_loaded_shared_objects("libcupti.so"),
     }
 
     samples.append(_collect_sample(iteration=None, stage="pre_start", phase=current_phase, torch=torch))
     session = proton.start(str(profile_base), backend="cupti", context="shadow", mode=profile_mode)
     samples.append(_collect_sample(iteration=None, stage="post_start", phase=current_phase, torch=torch))
+    run_metadata["loaded_cupti_libs_after_start"] = _read_loaded_shared_objects("libcupti.so")
     if args.lifecycle == "step":
         proton.deactivate(session=session)
         samples.append(
@@ -440,6 +467,7 @@ def _run_single(args: argparse.Namespace) -> int:
 
     proton.finalize(output_format=args.data_format)
     samples.append(_collect_sample(iteration=args.iterations, stage="post_finalize", phase=current_phase, torch=torch))
+    run_metadata["loaded_cupti_libs_after_finalize"] = _read_loaded_shared_objects("libcupti.so")
 
     sample_path = output_dir / f"samples_{args.label}.csv"
     summary_path = output_dir / f"summary_{args.label}.json"
@@ -502,6 +530,20 @@ def _compare_summaries(summaries: list[dict[str, Any]]) -> dict[str, Any]:
         if base_samples["nvidia_smi_gpu_delta_mb"] is None or other_samples["nvidia_smi_gpu_delta_mb"] is None
         else other_samples["nvidia_smi_gpu_delta_mb"] - base_samples["nvidia_smi_gpu_delta_mb"],
     }
+    base_loaded = base.get("loaded_cupti_libs_after_start", [])
+    other_loaded = other.get("loaded_cupti_libs_after_start", [])
+    comparison["loaded_cupti_libs_after_start"] = {
+        "base_label": base["label"],
+        "other_label": other["label"],
+        "base": base_loaded,
+        "other": other_loaded,
+        "same": sorted(base_loaded) == sorted(other_loaded),
+    }
+    if comparison["loaded_cupti_libs_after_start"]["same"]:
+        comparison["warning"] = (
+            "Both runs resolved the same loaded libcupti.so path(s). "
+            "Verify the target machine actually switched CUPTI variants."
+        )
     return comparison
 
 

--- a/third_party/proton/tutorials/cupti_memory_growth.py
+++ b/third_party/proton/tutorials/cupti_memory_growth.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+
+"""Compare Proton worker memory growth across CUPTI library variants.
+
+Examples:
+
+  Compare Triton's packaged generic and Blackwell CUPTI builds:
+
+    python third_party/proton/tutorials/cupti_memory_growth.py \
+      --output-dir /tmp/proton-cupti-compare \
+      --iterations 200 \
+      --warmup 5 \
+      --phase-every 1 \
+      --sample-every 20 \
+      --lifecycle step \
+      --kernels-per-step 32 \
+      --clear-completed-phases
+
+    Inspect /tmp/proton-cupti-compare/comparison.json and compare the
+    `rss_delta_bytes` / `rss_max_bytes` fields between the `generic` and
+    `blackwell` runs. A CUPTI-specific host-memory issue should show up as
+    larger RSS growth for one library variant while GPU memory stays flat.
+
+  Run a single configuration with an explicit CUPTI directory:
+
+    python third_party/proton/tutorials/cupti_memory_growth.py \
+      --single-run \
+      --label cupti12 \
+      --cupti-dir /path/to/triton/backends/nvidia/lib/cupti \
+      --output-dir /tmp/proton-cupti12
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import ctypes
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a standalone Triton + Proton workload and record process memory "
+            "growth for one or more CUPTI library directories."
+        )
+    )
+    parser.add_argument(
+        "--single-run",
+        action="store_true",
+        help="Run only one CUPTI configuration in the current process.",
+    )
+    parser.add_argument(
+        "--label",
+        default="run",
+        help="Label used for the output files in --single-run mode.",
+    )
+    parser.add_argument(
+        "--cupti-dir",
+        default=None,
+        help=(
+            "CUPTI directory to force for this run. When set, both "
+            "TRITON_CUPTI_LIB_PATH and TRITON_CUPTI_LIB_BLACKWELL_PATH are set "
+            "to this directory before Triton is imported."
+        ),
+    )
+    parser.add_argument(
+        "--generic-cupti-dir",
+        default=None,
+        help="Override the Triton-packaged generic CUPTI directory for compare mode.",
+    )
+    parser.add_argument(
+        "--blackwell-cupti-dir",
+        default=None,
+        help="Override the Triton-packaged Blackwell CUPTI directory for compare mode.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="/tmp/proton-cupti-memory-growth",
+        help="Directory for CSV, JSON, and Proton profile outputs.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=20000,
+        help="Number of profiled kernel launches to execute per run.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=25,
+        help="Number of unprofiled warmup launches before measurements begin.",
+    )
+    parser.add_argument(
+        "--phase-every",
+        type=int,
+        default=1000,
+        help="Advance Proton data phase every N iterations.",
+    )
+    parser.add_argument(
+        "--sample-every",
+        type=int,
+        default=200,
+        help="Capture memory samples every N iterations.",
+    )
+    parser.add_argument(
+        "--numel",
+        type=int,
+        default=1 << 20,
+        help="Vector size for the Triton add kernel.",
+    )
+    parser.add_argument(
+        "--block-size",
+        type=int,
+        default=1024,
+        help="Block size for the Triton add kernel.",
+    )
+    parser.add_argument(
+        "--kernels-per-step",
+        type=int,
+        default=1,
+        help="Number of Triton kernel launches to issue inside each profiled step.",
+    )
+    parser.add_argument(
+        "--device",
+        type=int,
+        default=0,
+        help="CUDA device index to use.",
+    )
+    parser.add_argument(
+        "--data-format",
+        default="hatchet_msgpack",
+        choices=["hatchet", "hatchet_msgpack", "chrome_trace"],
+        help="Periodic flushing output format.",
+    )
+    parser.add_argument(
+        "--lifecycle",
+        default="step",
+        choices=["continuous", "step"],
+        help=(
+            "How to drive the Proton session. 'step' repeatedly activates, "
+            "records one profiled scope, then deactivates before the next "
+            "phase advance."
+        ),
+    )
+    parser.add_argument(
+        "--clear-completed-phases",
+        action="store_true",
+        help="Clear completed Proton phases as the run progresses.",
+    )
+    parser.add_argument(
+        "--sleep-ms",
+        type=float,
+        default=0.0,
+        help="Optional sleep between iterations to slow the workload down.",
+    )
+    return parser
+
+
+def _read_proc_status_bytes(field_name: str) -> int | None:
+    status_path = Path("/proc/self/status")
+    if not status_path.exists():
+        return None
+    prefix = f"{field_name}:"
+    for line in status_path.read_text().splitlines():
+        if not line.startswith(prefix):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            return None
+        value_kib = int(parts[1])
+        return value_kib * 1024
+    return None
+
+
+def _query_nvidia_smi_process_memory_mb(pid: int) -> int | None:
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-compute-apps=pid,used_gpu_memory",
+                "--format=csv,noheader,nounits",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:
+        return None
+
+    for line in result.stdout.splitlines():
+        parts = [part.strip() for part in line.split(",")]
+        if len(parts) != 2:
+            continue
+        if parts[0] != str(pid):
+            continue
+        try:
+            return int(parts[1])
+        except ValueError:
+            return None
+    return 0
+
+
+def _load_cupti_info(cupti_dir: Path) -> dict[str, Any]:
+    lib_path = cupti_dir / "libcupti.so"
+    info: dict[str, Any] = {
+        "cupti_dir": str(cupti_dir),
+        "lib_path": str(lib_path),
+        "lib_exists": lib_path.exists(),
+    }
+    if not lib_path.exists():
+        return info
+
+    version = ctypes.c_uint32()
+    cupti = ctypes.CDLL(str(lib_path))
+    rc = int(cupti.cuptiGetVersion(ctypes.byref(version)))
+    info["cupti_get_version_rc"] = rc
+    info["cupti_version"] = int(version.value)
+    sonames = sorted(path.name for path in cupti_dir.glob("libcupti.so*"))
+    info["libcupti_entries"] = sonames
+    return info
+
+
+def _collect_sample(iteration: int | None, stage: str, phase: int, torch: Any) -> dict[str, Any]:
+    rss_bytes = _read_proc_status_bytes("VmRSS")
+    vms_bytes = _read_proc_status_bytes("VmSize")
+    torch.cuda.synchronize()
+    sample = {
+        "timestamp_s": time.time(),
+        "iteration": iteration,
+        "stage": stage,
+        "phase": phase,
+        "pid": os.getpid(),
+        "rss_bytes": rss_bytes,
+        "vms_bytes": vms_bytes,
+        "cuda_memory_allocated_bytes": int(torch.cuda.memory_allocated()),
+        "cuda_memory_reserved_bytes": int(torch.cuda.memory_reserved()),
+        "cuda_max_memory_allocated_bytes": int(torch.cuda.max_memory_allocated()),
+        "cuda_max_memory_reserved_bytes": int(torch.cuda.max_memory_reserved()),
+        "nvidia_smi_process_used_memory_mb": _query_nvidia_smi_process_memory_mb(os.getpid()),
+    }
+    return sample
+
+
+def _summarize_samples(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    rss_values = [sample["rss_bytes"] for sample in samples if sample["rss_bytes"] is not None]
+    gpu_mb_values = [
+        sample["nvidia_smi_process_used_memory_mb"]
+        for sample in samples
+        if sample["nvidia_smi_process_used_memory_mb"] is not None
+    ]
+    summary: dict[str, Any] = {
+        "num_samples": len(samples),
+        "rss_start_bytes": rss_values[0] if rss_values else None,
+        "rss_end_bytes": rss_values[-1] if rss_values else None,
+        "rss_max_bytes": max(rss_values) if rss_values else None,
+        "rss_min_bytes": min(rss_values) if rss_values else None,
+        "rss_delta_bytes": (rss_values[-1] - rss_values[0]) if len(rss_values) >= 2 else None,
+        "nvidia_smi_gpu_start_mb": gpu_mb_values[0] if gpu_mb_values else None,
+        "nvidia_smi_gpu_end_mb": gpu_mb_values[-1] if gpu_mb_values else None,
+        "nvidia_smi_gpu_max_mb": max(gpu_mb_values) if gpu_mb_values else None,
+        "nvidia_smi_gpu_delta_mb": (gpu_mb_values[-1] - gpu_mb_values[0]) if len(gpu_mb_values) >= 2 else None,
+    }
+    return summary
+
+
+def _write_csv(samples: list[dict[str, Any]], path: Path) -> None:
+    fieldnames = [
+        "timestamp_s",
+        "iteration",
+        "stage",
+        "phase",
+        "pid",
+        "rss_bytes",
+        "vms_bytes",
+        "cuda_memory_allocated_bytes",
+        "cuda_memory_reserved_bytes",
+        "cuda_max_memory_allocated_bytes",
+        "cuda_max_memory_reserved_bytes",
+        "nvidia_smi_process_used_memory_mb",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(samples)
+
+
+def _configure_cupti_env(cupti_dir: str | None) -> None:
+    os.environ.setdefault("PROTON_LAUNCH_METADATA_NOSYNC", "1")
+    if cupti_dir is None:
+        os.environ.pop("TRITON_CUPTI_LIB_PATH", None)
+        os.environ.pop("TRITON_CUPTI_LIB_BLACKWELL_PATH", None)
+        return
+
+    os.environ["TRITON_CUPTI_LIB_PATH"] = cupti_dir
+    os.environ["TRITON_CUPTI_LIB_BLACKWELL_PATH"] = cupti_dir
+
+
+def _run_single(args: argparse.Namespace) -> int:
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    _configure_cupti_env(args.cupti_dir)
+
+    import torch
+    import triton
+    import triton.language as tl
+    import triton.profiler as proton
+
+    torch.cuda.set_device(args.device)
+    device = torch.device(f"cuda:{args.device}")
+
+    @triton.jit
+    def add_kernel(x_ptr, y_ptr, z_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+        pid = tl.program_id(axis=0)
+        offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+        y = tl.load(y_ptr + offsets, mask=mask, other=0.0)
+        tl.store(z_ptr + offsets, x + y, mask=mask)
+
+    numel = args.numel
+    grid = lambda meta: (triton.cdiv(numel, meta["BLOCK_SIZE"]), )
+    x = torch.rand((numel,), device=device, dtype=torch.float32)
+    y = torch.rand((numel,), device=device, dtype=torch.float32)
+    z = torch.empty_like(x)
+
+    for _ in range(args.warmup):
+        add_kernel[grid](x, y, z, numel, BLOCK_SIZE=args.block_size)
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats(device)
+
+    samples: list[dict[str, Any]] = []
+    current_phase = 0
+    last_cleared_phase = -1
+    profile_base = output_dir / f"profile_{args.label}"
+    profile_mode = f"periodic_flushing:format={args.data_format}"
+
+    selected_cupti_dir = None
+    if args.cupti_dir is not None:
+        selected_cupti_dir = Path(args.cupti_dir)
+    else:
+        target = triton.runtime.driver.active.get_current_target()
+        if target.backend == "cuda" and target.arch >= 100:
+            selected_cupti_dir = Path(triton.knobs.proton.cupti_lib_blackwell_dir)
+        else:
+            selected_cupti_dir = Path(triton.knobs.proton.cupti_lib_dir)
+
+    cupti_info = _load_cupti_info(selected_cupti_dir)
+    run_metadata = {
+        "label": args.label,
+        "python_executable": sys.executable,
+        "pid": os.getpid(),
+        "device": str(device),
+        "iterations": args.iterations,
+        "warmup": args.warmup,
+        "phase_every": args.phase_every,
+        "sample_every": args.sample_every,
+        "numel": args.numel,
+        "block_size": args.block_size,
+        "kernels_per_step": args.kernels_per_step,
+        "data_format": args.data_format,
+        "lifecycle": args.lifecycle,
+        "clear_completed_phases": bool(args.clear_completed_phases),
+        "sleep_ms": args.sleep_ms,
+        "triton_version_file": str(Path(triton.__file__).resolve()),
+        "triton_target_backend": triton.runtime.driver.active.get_current_target().backend,
+        "triton_target_arch": triton.runtime.driver.active.get_current_target().arch,
+        "selected_cupti": cupti_info,
+        "env": {
+            "TRITON_CUPTI_LIB_PATH": os.environ.get("TRITON_CUPTI_LIB_PATH"),
+            "TRITON_CUPTI_LIB_BLACKWELL_PATH": os.environ.get("TRITON_CUPTI_LIB_BLACKWELL_PATH"),
+            "TRITON_PROFILE_BUFFER_SIZE": os.environ.get("TRITON_PROFILE_BUFFER_SIZE"),
+        },
+    }
+
+    samples.append(_collect_sample(iteration=None, stage="pre_start", phase=current_phase, torch=torch))
+    session = proton.start(str(profile_base), backend="cupti", context="shadow", mode=profile_mode)
+    samples.append(_collect_sample(iteration=None, stage="post_start", phase=current_phase, torch=torch))
+    if args.lifecycle == "step":
+        proton.deactivate(session=session)
+        samples.append(
+            _collect_sample(iteration=None, stage="post_initial_deactivate", phase=current_phase, torch=torch)
+        )
+
+    for iteration in range(args.iterations):
+        if args.lifecycle == "step":
+            proton.activate(session=session)
+
+        with proton.scope(f"step_{iteration}" if args.lifecycle == "step" else "step"):
+            for _ in range(args.kernels_per_step):
+                add_kernel[grid](x, y, z, numel, BLOCK_SIZE=args.block_size)
+
+        if args.phase_every > 0 and (iteration + 1) % args.phase_every == 0:
+            current_phase = int(proton.data.advance_phase(session))
+
+        if args.lifecycle == "step":
+            proton.deactivate(session=session, flushing=False)
+
+        if args.phase_every > 0 and (iteration + 1) % args.phase_every == 0:
+            if args.clear_completed_phases and current_phase > 0:
+                clear_phase = current_phase - 1
+                if clear_phase > last_cleared_phase and proton.data.is_phase_complete(session, clear_phase):
+                    proton.data.clear(session, phase=clear_phase, clear_up_to_phase=True)
+                    last_cleared_phase = clear_phase
+
+        if iteration == 0 or (iteration + 1) % args.sample_every == 0 or iteration + 1 == args.iterations:
+            samples.append(
+                _collect_sample(
+                    iteration=iteration + 1,
+                    stage="loop",
+                    phase=current_phase,
+                    torch=torch,
+                )
+            )
+
+        if args.sleep_ms > 0:
+            time.sleep(args.sleep_ms / 1000.0)
+
+    proton.finalize(output_format=args.data_format)
+    samples.append(_collect_sample(iteration=args.iterations, stage="post_finalize", phase=current_phase, torch=torch))
+
+    sample_path = output_dir / f"samples_{args.label}.csv"
+    summary_path = output_dir / f"summary_{args.label}.json"
+    _write_csv(samples, sample_path)
+
+    summary = run_metadata | {
+        "sample_csv": str(sample_path),
+        "profile_base": str(profile_base),
+        "summary_json": str(summary_path),
+        "samples": _summarize_samples(samples),
+    }
+    with summary_path.open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    print(json.dumps(summary["samples"], sort_keys=True))
+    return 0
+
+
+def _detect_packaged_cupti_dirs() -> tuple[Path, Path]:
+    import triton
+
+    root = Path(triton.__file__).resolve().parent / "backends" / "nvidia" / "lib"
+    return root / "cupti", root / "cupti-blackwell"
+
+
+def _compare_summaries(summaries: list[dict[str, Any]]) -> dict[str, Any]:
+    comparison: dict[str, Any] = {"runs": summaries}
+    if len(summaries) < 2:
+        return comparison
+
+    base = summaries[0]
+    other = summaries[1]
+    base_samples = base["samples"]
+    other_samples = other["samples"]
+    comparison["rss_delta_bytes"] = {
+        "base_label": base["label"],
+        "other_label": other["label"],
+        "base": base_samples["rss_delta_bytes"],
+        "other": other_samples["rss_delta_bytes"],
+        "difference": None
+        if base_samples["rss_delta_bytes"] is None or other_samples["rss_delta_bytes"] is None
+        else other_samples["rss_delta_bytes"] - base_samples["rss_delta_bytes"],
+    }
+    comparison["rss_max_bytes"] = {
+        "base_label": base["label"],
+        "other_label": other["label"],
+        "base": base_samples["rss_max_bytes"],
+        "other": other_samples["rss_max_bytes"],
+        "difference": None
+        if base_samples["rss_max_bytes"] is None or other_samples["rss_max_bytes"] is None
+        else other_samples["rss_max_bytes"] - base_samples["rss_max_bytes"],
+    }
+    comparison["nvidia_smi_gpu_delta_mb"] = {
+        "base_label": base["label"],
+        "other_label": other["label"],
+        "base": base_samples["nvidia_smi_gpu_delta_mb"],
+        "other": other_samples["nvidia_smi_gpu_delta_mb"],
+        "difference": None
+        if base_samples["nvidia_smi_gpu_delta_mb"] is None or other_samples["nvidia_smi_gpu_delta_mb"] is None
+        else other_samples["nvidia_smi_gpu_delta_mb"] - base_samples["nvidia_smi_gpu_delta_mb"],
+    }
+    return comparison
+
+
+def _run_compare(args: argparse.Namespace) -> int:
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    generic_dir, blackwell_dir = _detect_packaged_cupti_dirs()
+    if args.generic_cupti_dir is not None:
+        generic_dir = Path(args.generic_cupti_dir)
+    if args.blackwell_cupti_dir is not None:
+        blackwell_dir = Path(args.blackwell_cupti_dir)
+
+    runs = [
+        ("generic", generic_dir),
+        ("blackwell", blackwell_dir),
+    ]
+
+    summaries: list[dict[str, Any]] = []
+    for label, cupti_dir in runs:
+        cmd = [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--single-run",
+            "--label",
+            label,
+            "--cupti-dir",
+            str(cupti_dir),
+            "--output-dir",
+            str(output_dir),
+            "--iterations",
+            str(args.iterations),
+            "--warmup",
+            str(args.warmup),
+            "--phase-every",
+            str(args.phase_every),
+            "--sample-every",
+            str(args.sample_every),
+            "--numel",
+            str(args.numel),
+            "--block-size",
+            str(args.block_size),
+            "--device",
+            str(args.device),
+            "--kernels-per-step",
+            str(args.kernels_per_step),
+            "--data-format",
+            args.data_format,
+            "--lifecycle",
+            args.lifecycle,
+            "--sleep-ms",
+            str(args.sleep_ms),
+        ]
+        if args.clear_completed_phases:
+            cmd.append("--clear-completed-phases")
+
+        subprocess.run(cmd, check=True)
+        summary_path = output_dir / f"summary_{label}.json"
+        with summary_path.open(encoding="utf-8") as handle:
+            summaries.append(json.load(handle))
+
+    comparison = _compare_summaries(summaries)
+    comparison_path = output_dir / "comparison.json"
+    with comparison_path.open("w", encoding="utf-8") as handle:
+        json.dump(comparison, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    print(json.dumps(comparison, indent=2, sort_keys=True))
+    return 0
+
+
+def main() -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    if args.single_run:
+        return _run_single(args)
+    return _run_compare(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/third_party/proton/tutorials/cupti_memory_growth_cuda_core.py
+++ b/third_party/proton/tutorials/cupti_memory_growth_cuda_core.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""Compare Proton memory growth across CUPTI library variants without Torch.
+"""Compare Proton memory growth across CUPTI library variants.
 
 Examples:
 
@@ -36,6 +36,23 @@ Examples:
 This variant drives CUDA work through ``cuda.core.experimental`` and controls
 Proton through ``triton._C.libproton`` directly so the process can stay free of
 framework-bundled CUPTI libraries.
+
+  Reproduce the same graph-warning path in a process that preloads Torch before
+  Proton starts:
+
+    python third_party/proton/tutorials/cupti_memory_growth_cuda_core.py \
+      --output-dir /tmp/proton-cuda-core-torch-graph-1000x32 \
+      --iterations 1000 \
+      --warmup 5 \
+      --phase-every 1 \
+      --sample-every 100 \
+      --lifecycle step \
+      --kernels-per-step 32 \
+      --clear-completed-phases \
+      --workload graph \
+      --capture-before-start \
+      --post-finalize-sleep-ms 1000 \
+      --preload-torch
 """
 
 from __future__ import annotations
@@ -189,6 +206,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="When --workload=graph, capture the graph before Proton starts.",
     )
+    parser.add_argument(
+        "--preload-torch",
+        action="store_true",
+        help=(
+            "Import torch before libproton so the process also maps any framework-bundled "
+            "libcupti DSOs (for example, torch/lib/libcupti.so.13)."
+        ),
+    )
     return parser
 
 
@@ -235,7 +260,7 @@ def _query_nvidia_smi_process_memory_mb(pid: int) -> int | None:
     return 0
 
 
-def _read_loaded_shared_objects(needle: str) -> list[str]:
+def _read_loaded_shared_objects(needle: str, *, exact_basename: bool = False) -> list[str]:
     maps_path = Path("/proc/self/maps")
     if not maps_path.exists():
         return []
@@ -249,11 +274,24 @@ def _read_loaded_shared_objects(needle: str) -> list[str]:
         if len(parts) < 6:
             continue
         path = parts[-1]
+        if exact_basename and Path(path).name != needle:
+            continue
         if path in seen:
             continue
         seen.add(path)
         loaded.append(path)
     return loaded
+
+
+def _maybe_preload_torch(enabled: bool) -> dict[str, Any] | None:
+    if not enabled:
+        return None
+
+    torch = importlib.import_module("torch")
+    return {
+        "version": getattr(torch, "__version__", None),
+        "file": str(Path(torch.__file__).resolve()) if getattr(torch, "__file__", None) else None,
+    }
 
 
 def _load_cupti_info(cupti_dir: Path) -> dict[str, Any]:
@@ -431,6 +469,16 @@ def _compare_summaries(summaries: list[dict[str, Any]]) -> dict[str, Any]:
             "Both runs resolved the same loaded libcupti.so path(s). "
             "Verify the target machine actually switched CUPTI variants."
         )
+
+    base_loaded_all = base.get("loaded_libcupti_objects_after_start", [])
+    other_loaded_all = other.get("loaded_libcupti_objects_after_start", [])
+    comparison["loaded_libcupti_objects_after_start"] = {
+        "base_label": base["label"],
+        "other_label": other["label"],
+        "base": base_loaded_all,
+        "other": other_loaded_all,
+        "same": sorted(base_loaded_all) == sorted(other_loaded_all),
+    }
     return comparison
 
 
@@ -439,6 +487,7 @@ def _run_single(args: argparse.Namespace) -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     _configure_cupti_env(args.cupti_dir)
+    preloaded_torch = _maybe_preload_torch(args.preload_torch)
 
     triton = importlib.import_module("triton")
     proton_data = importlib.import_module("triton.profiler.data")
@@ -498,6 +547,8 @@ def _run_single(args: argparse.Namespace) -> int:
         "post_finalize_sleep_ms": args.post_finalize_sleep_ms,
         "workload": args.workload,
         "capture_before_start": bool(args.capture_before_start),
+        "preload_torch": bool(args.preload_torch),
+        "preloaded_torch": preloaded_torch,
         "triton_version_file": str(Path(triton.__file__).resolve()),
         "device_id": args.device,
         "device_name": device.name,
@@ -509,14 +560,20 @@ def _run_single(args: argparse.Namespace) -> int:
             "TRITON_PROFILE_BUFFER_SIZE": os.environ.get("TRITON_PROFILE_BUFFER_SIZE"),
             "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH"),
         },
-        "loaded_cupti_libs_before_start": _read_loaded_shared_objects("libcupti.so"),
+        "loaded_cupti_libs_before_start": _read_loaded_shared_objects(
+            "libcupti.so", exact_basename=True
+        ),
+        "loaded_libcupti_objects_before_start": _read_loaded_shared_objects("libcupti"),
     }
 
     samples: list[dict[str, Any]] = []
     samples.append(_collect_sample(iteration=None, stage="pre_start", phase=current_phase, stream=stream))
     session = libproton.start(str(profile_base), "shadow", "tree", "cupti", profile_mode)
     samples.append(_collect_sample(iteration=None, stage="post_start", phase=current_phase, stream=stream))
-    run_metadata["loaded_cupti_libs_after_start"] = _read_loaded_shared_objects("libcupti.so")
+    run_metadata["loaded_cupti_libs_after_start"] = _read_loaded_shared_objects(
+        "libcupti.so", exact_basename=True
+    )
+    run_metadata["loaded_libcupti_objects_after_start"] = _read_loaded_shared_objects("libcupti")
 
     if args.workload == "graph" and not args.capture_before_start:
         graph = _build_graph(stream, kernel, buffer, args.numel, args.block_size, kernels_per_step=1)
@@ -572,7 +629,10 @@ def _run_single(args: argparse.Namespace) -> int:
                 stream=stream,
             )
         )
-    run_metadata["loaded_cupti_libs_after_finalize"] = _read_loaded_shared_objects("libcupti.so")
+    run_metadata["loaded_cupti_libs_after_finalize"] = _read_loaded_shared_objects(
+        "libcupti.so", exact_basename=True
+    )
+    run_metadata["loaded_libcupti_objects_after_finalize"] = _read_loaded_shared_objects("libcupti")
 
     sample_path = output_dir / f"samples_{args.label}.csv"
     summary_path = output_dir / f"summary_{args.label}.json"
@@ -650,6 +710,8 @@ def _run_compare(args: argparse.Namespace) -> int:
             cmd.append("--clear-completed-phases")
         if args.capture_before_start:
             cmd.append("--capture-before-start")
+        if args.preload_torch:
+            cmd.append("--preload-torch")
 
         subprocess.run(cmd, check=True)
         summary_path = output_dir / f"summary_{label}.json"

--- a/third_party/proton/tutorials/cupti_memory_growth_cuda_core.py
+++ b/third_party/proton/tutorials/cupti_memory_growth_cuda_core.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+
+"""Compare Proton memory growth across CUPTI library variants without Torch.
+
+Examples:
+
+  Compare Triton's packaged generic and Blackwell CUPTI builds in a clean
+  process that only loads the selected ``libcupti.so``:
+
+    python third_party/proton/tutorials/cupti_memory_growth_cuda_core.py \
+      --output-dir /tmp/proton-cuda-core-direct-200x32 \
+      --iterations 200 \
+      --warmup 5 \
+      --phase-every 1 \
+      --sample-every 20 \
+      --lifecycle step \
+      --kernels-per-step 32 \
+      --clear-completed-phases \
+      --workload direct
+
+  Reproduce the CUDA-graph warning path by capturing the graph before Proton
+  starts:
+
+    python third_party/proton/tutorials/cupti_memory_growth_cuda_core.py \
+      --output-dir /tmp/proton-cuda-core-graph-pre-200x32 \
+      --iterations 200 \
+      --warmup 5 \
+      --phase-every 1 \
+      --sample-every 20 \
+      --lifecycle step \
+      --kernels-per-step 32 \
+      --clear-completed-phases \
+      --workload graph \
+      --capture-before-start
+
+This variant drives CUDA work through ``cuda.core.experimental`` and controls
+Proton through ``triton._C.libproton`` directly so the process can stay free of
+framework-bundled CUPTI libraries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import ctypes
+import importlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a standalone CUDA-core + Proton workload and record process memory "
+            "growth for one or more CUPTI library directories."
+        )
+    )
+    parser.add_argument(
+        "--single-run",
+        action="store_true",
+        help="Run only one CUPTI configuration in the current process.",
+    )
+    parser.add_argument(
+        "--label",
+        default="run",
+        help="Label used for the output files in --single-run mode.",
+    )
+    parser.add_argument(
+        "--cupti-dir",
+        default=None,
+        help=(
+            "CUPTI directory to force for this run. When set, both "
+            "TRITON_CUPTI_LIB_PATH and TRITON_CUPTI_LIB_BLACKWELL_PATH are set "
+            "to this directory before libproton is imported."
+        ),
+    )
+    parser.add_argument(
+        "--generic-cupti-dir",
+        default=None,
+        help="Override the Triton-packaged generic CUPTI directory for compare mode.",
+    )
+    parser.add_argument(
+        "--blackwell-cupti-dir",
+        default=None,
+        help="Override the Triton-packaged Blackwell CUPTI directory for compare mode.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="/tmp/proton-cupti-memory-growth-cuda-core",
+        help="Directory for CSV, JSON, and Proton profile outputs.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=200,
+        help="Number of profiled iterations to execute per run.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=5,
+        help="Number of unprofiled warmup iterations before measurements begin.",
+    )
+    parser.add_argument(
+        "--phase-every",
+        type=int,
+        default=1,
+        help="Advance Proton data phase every N iterations.",
+    )
+    parser.add_argument(
+        "--sample-every",
+        type=int,
+        default=20,
+        help="Capture memory samples every N iterations.",
+    )
+    parser.add_argument(
+        "--numel",
+        type=int,
+        default=1 << 20,
+        help="Number of float32 elements in the device buffer.",
+    )
+    parser.add_argument(
+        "--block-size",
+        type=int,
+        default=256,
+        help="CUDA block size for the add kernel.",
+    )
+    parser.add_argument(
+        "--kernels-per-step",
+        type=int,
+        default=32,
+        help="Number of kernel launches or graph replays to issue inside each profiled step.",
+    )
+    parser.add_argument(
+        "--device",
+        type=int,
+        default=0,
+        help="CUDA device index to use.",
+    )
+    parser.add_argument(
+        "--data-format",
+        default="hatchet_msgpack",
+        choices=["hatchet", "hatchet_msgpack", "chrome_trace"],
+        help="Periodic flushing output format.",
+    )
+    parser.add_argument(
+        "--lifecycle",
+        default="step",
+        choices=["continuous", "step"],
+        help=(
+            "How to drive the Proton session. 'step' repeatedly activates, "
+            "records one profiled iteration, then deactivates before the next "
+            "phase advance."
+        ),
+    )
+    parser.add_argument(
+        "--clear-completed-phases",
+        action="store_true",
+        help="Clear completed Proton phases as the run progresses.",
+    )
+    parser.add_argument(
+        "--sleep-ms",
+        type=float,
+        default=0.0,
+        help="Optional sleep between iterations to slow the workload down.",
+    )
+    parser.add_argument(
+        "--post-finalize-sleep-ms",
+        type=float,
+        default=0.0,
+        help="Optional sleep after finalize before collecting a settled RSS sample.",
+    )
+    parser.add_argument(
+        "--workload",
+        default="direct",
+        choices=["direct", "graph"],
+        help=(
+            "CUDA workload shape. 'direct' launches kernels individually. "
+            "'graph' captures a CUDA graph once and replays it."
+        ),
+    )
+    parser.add_argument(
+        "--capture-before-start",
+        action="store_true",
+        help="When --workload=graph, capture the graph before Proton starts.",
+    )
+    return parser
+
+
+def _read_proc_status_bytes(field_name: str) -> int | None:
+    status_path = Path("/proc/self/status")
+    if not status_path.exists():
+        return None
+    prefix = f"{field_name}:"
+    for line in status_path.read_text().splitlines():
+        if not line.startswith(prefix):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            return None
+        return int(parts[1]) * 1024
+    return None
+
+
+def _query_nvidia_smi_process_memory_mb(pid: int) -> int | None:
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-compute-apps=pid,used_gpu_memory",
+                "--format=csv,noheader,nounits",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:
+        return None
+
+    for line in result.stdout.splitlines():
+        parts = [part.strip() for part in line.split(",")]
+        if len(parts) != 2:
+            continue
+        if parts[0] != str(pid):
+            continue
+        try:
+            return int(parts[1])
+        except ValueError:
+            return None
+    return 0
+
+
+def _read_loaded_shared_objects(needle: str) -> list[str]:
+    maps_path = Path("/proc/self/maps")
+    if not maps_path.exists():
+        return []
+
+    loaded: list[str] = []
+    seen: set[str] = set()
+    for line in maps_path.read_text().splitlines():
+        if needle not in line:
+            continue
+        parts = line.split()
+        if len(parts) < 6:
+            continue
+        path = parts[-1]
+        if path in seen:
+            continue
+        seen.add(path)
+        loaded.append(path)
+    return loaded
+
+
+def _load_cupti_info(cupti_dir: Path) -> dict[str, Any]:
+    lib_path = cupti_dir / "libcupti.so"
+    info: dict[str, Any] = {
+        "cupti_dir": str(cupti_dir),
+        "lib_path": str(lib_path),
+        "lib_exists": lib_path.exists(),
+    }
+    if not lib_path.exists():
+        return info
+
+    version = ctypes.c_uint32()
+    cupti = ctypes.CDLL(str(lib_path))
+    rc = int(cupti.cuptiGetVersion(ctypes.byref(version)))
+    info["cupti_get_version_rc"] = rc
+    info["cupti_version"] = int(version.value)
+    info["libcupti_entries"] = sorted(path.name for path in cupti_dir.glob("libcupti.so*"))
+    return info
+
+
+def _summarize_samples(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    rss_values = [sample["rss_bytes"] for sample in samples if sample["rss_bytes"] is not None]
+    gpu_mb_values = [
+        sample["nvidia_smi_process_used_memory_mb"]
+        for sample in samples
+        if sample["nvidia_smi_process_used_memory_mb"] is not None
+    ]
+    return {
+        "num_samples": len(samples),
+        "rss_start_bytes": rss_values[0] if rss_values else None,
+        "rss_end_bytes": rss_values[-1] if rss_values else None,
+        "rss_max_bytes": max(rss_values) if rss_values else None,
+        "rss_min_bytes": min(rss_values) if rss_values else None,
+        "rss_delta_bytes": (rss_values[-1] - rss_values[0]) if len(rss_values) >= 2 else None,
+        "nvidia_smi_gpu_start_mb": gpu_mb_values[0] if gpu_mb_values else None,
+        "nvidia_smi_gpu_end_mb": gpu_mb_values[-1] if gpu_mb_values else None,
+        "nvidia_smi_gpu_max_mb": max(gpu_mb_values) if gpu_mb_values else None,
+        "nvidia_smi_gpu_delta_mb": (gpu_mb_values[-1] - gpu_mb_values[0]) if len(gpu_mb_values) >= 2 else None,
+    }
+
+
+def _write_csv(samples: list[dict[str, Any]], path: Path) -> None:
+    fieldnames = [
+        "timestamp_s",
+        "iteration",
+        "stage",
+        "phase",
+        "pid",
+        "rss_bytes",
+        "vms_bytes",
+        "nvidia_smi_process_used_memory_mb",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(samples)
+
+
+def _configure_cupti_env(cupti_dir: str | None) -> None:
+    os.environ.setdefault("PROTON_LAUNCH_METADATA_NOSYNC", "1")
+    if cupti_dir is None:
+        os.environ.pop("TRITON_CUPTI_LIB_PATH", None)
+        os.environ.pop("TRITON_CUPTI_LIB_BLACKWELL_PATH", None)
+        return
+
+    os.environ["TRITON_CUPTI_LIB_PATH"] = cupti_dir
+    os.environ["TRITON_CUPTI_LIB_BLACKWELL_PATH"] = cupti_dir
+
+
+def _collect_sample(iteration: int | None, stage: str, phase: int, stream: Any) -> dict[str, Any]:
+    stream.sync()
+    return {
+        "timestamp_s": time.time(),
+        "iteration": iteration,
+        "stage": stage,
+        "phase": phase,
+        "pid": os.getpid(),
+        "rss_bytes": _read_proc_status_bytes("VmRSS"),
+        "vms_bytes": _read_proc_status_bytes("VmSize"),
+        "nvidia_smi_process_used_memory_mb": _query_nvidia_smi_process_memory_mb(os.getpid()),
+    }
+
+
+def _detect_packaged_cupti_dirs() -> tuple[Path, Path]:
+    triton = importlib.import_module("triton")
+    root = Path(triton.__file__).resolve().parent / "backends" / "nvidia" / "lib"
+    return root / "cupti", root / "cupti-blackwell"
+
+
+def _compile_kernel(device: Any) -> tuple[Any, Any]:
+    from cuda.core.experimental import Program, ProgramOptions
+
+    compute_capability = device.compute_capability
+    arch = f"sm_{compute_capability[0]}{compute_capability[1]}"
+    code = r"""
+extern "C" __global__ void add1(float *x, int n) {
+  int i = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+  if (i < n) {
+    x[i] += 1.0f;
+  }
+}
+"""
+    program = Program(code, "c++", ProgramOptions(arch=arch, std="c++17", name="cupti_memory_growth_cuda_core.cu"))
+    object_code = program.compile("cubin")
+    return program, object_code.get_kernel("add1")
+
+
+def _build_graph(stream: Any, kernel: Any, buffer: Any, numel: int, block_size: int, kernels_per_step: int) -> Any:
+    from cuda.core.experimental import LaunchConfig, launch
+
+    grid = max(1, (numel + block_size - 1) // block_size)
+    builder = stream.create_graph_builder()
+    builder.begin_building()
+    for _ in range(kernels_per_step):
+        launch(stream, LaunchConfig(grid=grid, block=block_size), kernel, buffer, numel)
+    builder.end_building()
+    graph = builder.complete()
+    stream.sync()
+    return graph
+
+
+def _run_workload_iteration(
+    *,
+    workload: str,
+    stream: Any,
+    kernel: Any,
+    buffer: Any,
+    numel: int,
+    block_size: int,
+    kernels_per_step: int,
+    graph: Any,
+) -> None:
+    from cuda.core.experimental import LaunchConfig, launch
+
+    if workload == "graph":
+        for _ in range(kernels_per_step):
+            graph.launch(stream)
+        return
+
+    grid = max(1, (numel + block_size - 1) // block_size)
+    for _ in range(kernels_per_step):
+        launch(stream, LaunchConfig(grid=grid, block=block_size), kernel, buffer, numel)
+
+
+def _compare_summaries(summaries: list[dict[str, Any]]) -> dict[str, Any]:
+    comparison: dict[str, Any] = {"runs": summaries}
+    if len(summaries) < 2:
+        return comparison
+
+    base = summaries[0]
+    other = summaries[1]
+    for key in ("rss_delta_bytes", "rss_max_bytes", "nvidia_smi_gpu_delta_mb"):
+        base_value = base["samples"][key]
+        other_value = other["samples"][key]
+        comparison[key] = {
+            "base_label": base["label"],
+            "other_label": other["label"],
+            "base": base_value,
+            "other": other_value,
+            "difference": None if base_value is None or other_value is None else other_value - base_value,
+        }
+
+    base_loaded = base.get("loaded_cupti_libs_after_start", [])
+    other_loaded = other.get("loaded_cupti_libs_after_start", [])
+    comparison["loaded_cupti_libs_after_start"] = {
+        "base_label": base["label"],
+        "other_label": other["label"],
+        "base": base_loaded,
+        "other": other_loaded,
+        "same": sorted(base_loaded) == sorted(other_loaded),
+    }
+    if comparison["loaded_cupti_libs_after_start"]["same"]:
+        comparison["warning"] = (
+            "Both runs resolved the same loaded libcupti.so path(s). "
+            "Verify the target machine actually switched CUPTI variants."
+        )
+    return comparison
+
+
+def _run_single(args: argparse.Namespace) -> int:
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    _configure_cupti_env(args.cupti_dir)
+
+    triton = importlib.import_module("triton")
+    proton_data = importlib.import_module("triton.profiler.data")
+    from triton._C.libproton import proton as libproton
+    from cuda.core.experimental import Device
+
+    device = Device(args.device)
+    device.set_current()
+    stream = device.create_stream()
+    _program, kernel = _compile_kernel(device)
+    buffer = device.allocate(args.numel * 4)
+
+    # Warm up module load and kernel launch before starting Proton.
+    for _ in range(args.warmup):
+        _run_workload_iteration(
+            workload="direct",
+            stream=stream,
+            kernel=kernel,
+            buffer=buffer,
+            numel=args.numel,
+            block_size=args.block_size,
+            kernels_per_step=1,
+            graph=None,
+        )
+    stream.sync()
+
+    graph = None
+    if args.workload == "graph" and args.capture_before_start:
+        graph = _build_graph(stream, kernel, buffer, args.numel, args.block_size, kernels_per_step=1)
+
+    current_phase = 0
+    last_cleared_phase = -1
+    profile_base = output_dir / f"profile_{args.label}"
+    profile_mode = f"periodic_flushing:format={args.data_format}"
+
+    selected_cupti_dir = Path(args.cupti_dir) if args.cupti_dir is not None else None
+    if selected_cupti_dir is None:
+        generic_dir, blackwell_dir = _detect_packaged_cupti_dirs()
+        selected_cupti_dir = blackwell_dir if device.compute_capability[0] >= 10 else generic_dir
+
+    cupti_info = _load_cupti_info(selected_cupti_dir)
+    run_metadata = {
+        "label": args.label,
+        "python_executable": sys.executable,
+        "pid": os.getpid(),
+        "iterations": args.iterations,
+        "warmup": args.warmup,
+        "phase_every": args.phase_every,
+        "sample_every": args.sample_every,
+        "numel": args.numel,
+        "block_size": args.block_size,
+        "kernels_per_step": args.kernels_per_step,
+        "data_format": args.data_format,
+        "lifecycle": args.lifecycle,
+        "clear_completed_phases": bool(args.clear_completed_phases),
+        "sleep_ms": args.sleep_ms,
+        "post_finalize_sleep_ms": args.post_finalize_sleep_ms,
+        "workload": args.workload,
+        "capture_before_start": bool(args.capture_before_start),
+        "triton_version_file": str(Path(triton.__file__).resolve()),
+        "device_id": args.device,
+        "device_name": device.name,
+        "device_compute_capability": list(device.compute_capability),
+        "selected_cupti": cupti_info,
+        "env": {
+            "TRITON_CUPTI_LIB_PATH": os.environ.get("TRITON_CUPTI_LIB_PATH"),
+            "TRITON_CUPTI_LIB_BLACKWELL_PATH": os.environ.get("TRITON_CUPTI_LIB_BLACKWELL_PATH"),
+            "TRITON_PROFILE_BUFFER_SIZE": os.environ.get("TRITON_PROFILE_BUFFER_SIZE"),
+            "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH"),
+        },
+        "loaded_cupti_libs_before_start": _read_loaded_shared_objects("libcupti.so"),
+    }
+
+    samples: list[dict[str, Any]] = []
+    samples.append(_collect_sample(iteration=None, stage="pre_start", phase=current_phase, stream=stream))
+    session = libproton.start(str(profile_base), "shadow", "tree", "cupti", profile_mode)
+    samples.append(_collect_sample(iteration=None, stage="post_start", phase=current_phase, stream=stream))
+    run_metadata["loaded_cupti_libs_after_start"] = _read_loaded_shared_objects("libcupti.so")
+
+    if args.workload == "graph" and not args.capture_before_start:
+        graph = _build_graph(stream, kernel, buffer, args.numel, args.block_size, kernels_per_step=1)
+        samples.append(_collect_sample(iteration=None, stage="post_graph_capture", phase=current_phase, stream=stream))
+
+    if args.lifecycle == "step":
+        libproton.deactivate(session, False)
+        samples.append(_collect_sample(iteration=None, stage="post_initial_deactivate", phase=current_phase, stream=stream))
+
+    for iteration in range(args.iterations):
+        if args.lifecycle == "step":
+            libproton.activate(session)
+
+        _run_workload_iteration(
+            workload=args.workload,
+            stream=stream,
+            kernel=kernel,
+            buffer=buffer,
+            numel=args.numel,
+            block_size=args.block_size,
+            kernels_per_step=args.kernels_per_step,
+            graph=graph,
+        )
+
+        if args.phase_every > 0 and (iteration + 1) % args.phase_every == 0:
+            current_phase = int(proton_data.advance_phase(session))
+
+        if args.lifecycle == "step":
+            libproton.deactivate(session, False)
+
+        if args.phase_every > 0 and (iteration + 1) % args.phase_every == 0:
+            if args.clear_completed_phases and current_phase > 0:
+                clear_phase = current_phase - 1
+                if clear_phase > last_cleared_phase and proton_data.is_phase_complete(session, clear_phase):
+                    proton_data.clear(session, phase=clear_phase, clear_up_to_phase=True)
+                    last_cleared_phase = clear_phase
+
+        if iteration == 0 or (iteration + 1) % args.sample_every == 0 or iteration + 1 == args.iterations:
+            samples.append(_collect_sample(iteration=iteration + 1, stage="loop", phase=current_phase, stream=stream))
+
+        if args.sleep_ms > 0:
+            time.sleep(args.sleep_ms / 1000.0)
+
+    libproton.finalize(session, args.data_format)
+    samples.append(_collect_sample(iteration=args.iterations, stage="post_finalize", phase=current_phase, stream=stream))
+    if args.post_finalize_sleep_ms > 0:
+        time.sleep(args.post_finalize_sleep_ms / 1000.0)
+        samples.append(
+            _collect_sample(
+                iteration=args.iterations,
+                stage="post_finalize_settled",
+                phase=current_phase,
+                stream=stream,
+            )
+        )
+    run_metadata["loaded_cupti_libs_after_finalize"] = _read_loaded_shared_objects("libcupti.so")
+
+    sample_path = output_dir / f"samples_{args.label}.csv"
+    summary_path = output_dir / f"summary_{args.label}.json"
+    _write_csv(samples, sample_path)
+
+    summary = run_metadata | {
+        "sample_csv": str(sample_path),
+        "profile_base": str(profile_base),
+        "summary_json": str(summary_path),
+        "samples": _summarize_samples(samples),
+    }
+    with summary_path.open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    print(json.dumps(summary["samples"], sort_keys=True))
+    return 0
+
+
+def _run_compare(args: argparse.Namespace) -> int:
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    generic_dir, blackwell_dir = _detect_packaged_cupti_dirs()
+    if args.generic_cupti_dir is not None:
+        generic_dir = Path(args.generic_cupti_dir)
+    if args.blackwell_cupti_dir is not None:
+        blackwell_dir = Path(args.blackwell_cupti_dir)
+
+    runs = [
+        ("generic", generic_dir),
+        ("blackwell", blackwell_dir),
+    ]
+
+    summaries: list[dict[str, Any]] = []
+    for label, cupti_dir in runs:
+        cmd = [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--single-run",
+            "--label",
+            label,
+            "--cupti-dir",
+            str(cupti_dir),
+            "--output-dir",
+            str(output_dir),
+            "--iterations",
+            str(args.iterations),
+            "--warmup",
+            str(args.warmup),
+            "--phase-every",
+            str(args.phase_every),
+            "--sample-every",
+            str(args.sample_every),
+            "--numel",
+            str(args.numel),
+            "--block-size",
+            str(args.block_size),
+            "--device",
+            str(args.device),
+            "--kernels-per-step",
+            str(args.kernels_per_step),
+            "--data-format",
+            args.data_format,
+            "--lifecycle",
+            args.lifecycle,
+            "--sleep-ms",
+            str(args.sleep_ms),
+            "--post-finalize-sleep-ms",
+            str(args.post_finalize_sleep_ms),
+            "--workload",
+            args.workload,
+        ]
+        if args.clear_completed_phases:
+            cmd.append("--clear-completed-phases")
+        if args.capture_before_start:
+            cmd.append("--capture-before-start")
+
+        subprocess.run(cmd, check=True)
+        summary_path = output_dir / f"summary_{label}.json"
+        with summary_path.open(encoding="utf-8") as handle:
+            summaries.append(json.load(handle))
+
+    comparison = _compare_summaries(summaries)
+    comparison_path = output_dir / "comparison.json"
+    with comparison_path.open("w", encoding="utf-8") as handle:
+        json.dump(comparison, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    print(json.dumps(comparison, indent=2, sort_keys=True))
+    return 0
+
+
+def main() -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    if args.single_run:
+        return _run_single(args)
+    return _run_compare(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add clean Proton reproduction tutorials for comparing CUPTI variants with and without Torch preloading extra `libcupti` objects
- fix Proton's missing-graph cleanup path so completed CUDA-graph launch correlations are purged at flush time instead of accumulating indefinitely
- add a small unit test that locks in the completed-vs-incomplete correlation flush behavior

## Root Cause
The key issue turned out not to be a stable pure CUPTI 12 vs 13 RSS split.

When a CUDA graph is created before Proton starts, `handleApiEnterLaunchCallbacks()` emits:

- `Cannot find graph for graphExecId: ... and it may cause memory leak`

but it still correlates the launch with an effectively unbounded node count. Normal cleanup in `processActivityKernel()` only retires graph-launch correlation state once the expected node count drains to zero, so that warning path leaves correlation entries behind.

On `devbox-gb200-vd64-spud-susu-0`, with a locally rebuilt Triton checkout and `PROTON_CORRELATION_DEBUG=1`, this repro:

```bash
cd /root/code/triton
PROTON_CORRELATION_DEBUG=1 python third_party/proton/tutorials/cupti_memory_growth_cuda_core.py \
  --output-dir /tmp/proton-corr-debug \
  --iterations 1000 \
  --warmup 5 \
  --phase-every 1 \
  --sample-every 100 \
  --lifecycle step \
  --kernels-per-step 32 \
  --clear-completed-phases \
  --workload graph \
  --capture-before-start \
  --post-finalize-sleep-ms 1000 \
  --preload-torch
```

reported:

```text
[PROTON] Purged 32000 completed correlation entries at flush (live_before=32000, live_after=0, completed_id=32000)
```

That `32000` exactly matches `iterations * kernels_per_step`, so the missing-graph path was leaving one orphaned correlation entry per graph replay.

## Reproduction
If the target process might load more than one `libcupti` object, prefer the clean tutorial when isolating Proton from framework-bundled CUPTI libraries:

```bash
python /tmp/cupti_memory_growth_cuda_core.py \
  --output-dir /tmp/proton-cuda-core-direct-200x32 \
  --iterations 200 \
  --warmup 5 \
  --phase-every 1 \
  --sample-every 20 \
  --lifecycle step \
  --kernels-per-step 32 \
  --clear-completed-phases \
  --workload direct
```

To reproduce the missing-graph warning path in that same process:

```bash
python /tmp/cupti_memory_growth_cuda_core.py \
  --output-dir /tmp/proton-cuda-core-graph-pre-200x32 \
  --iterations 200 \
  --warmup 5 \
  --phase-every 1 \
  --sample-every 20 \
  --lifecycle step \
  --kernels-per-step 32 \
  --clear-completed-phases \
  --workload graph \
  --capture-before-start
```

If you specifically want the Torch-preloaded dual-CUPTI topology, add `--preload-torch`.

## Testing
- `python -m py_compile third_party/proton/tutorials/cupti_memory_growth.py`
- `python -m py_compile third_party/proton/tutorials/cupti_memory_growth_cuda_core.py`
- `python third_party/proton/tutorials/cupti_memory_growth_cuda_core.py --help`
- `MAX_JOBS=64 python -m pip install -e .` on `devbox-gb200-vd64-spud-susu-0`
- `/root/code/triton/build/cmake.linux-aarch64-cpython-3.12/third_party/proton/test/unittest/Profiler/ProtonCorrelation --gtest_color=no`
- Torch-preloaded graph repro on `devbox-gb200-vd64-spud-susu-0` with `PROTON_CORRELATION_DEBUG=1`
