### PR TITLE
fix: add missing negation in WSDataPartition thenYieldArg check

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition.mlir
@@ -151,3 +151,37 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Test that scf.if results are correctly partitioned when fed into a dot.
+// This exercises the thenYieldArg/elseYieldArg paths in getBackwardSliceToPartition.
+// CHECK-LABEL: @if_result_partition
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @if_result_partition(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %arg2: !tt.ptr<f16>, %cond: i1) {
+    %cst = arith.constant {async_task_id = array<i32: 1, 2>} dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %0 = tt.splat %arg0 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %1 = tt.splat %arg1 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    // Two loads that feed into the if branches
+    %a = tt.load %0 {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+    %b = tt.load %1 {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+    // Pick one based on condition
+    %sel = scf.if %cond -> (tensor<128x64xf16, #blocked>) {
+      scf.yield {async_task_id = array<i32: 0>} %a : tensor<128x64xf16, #blocked>
+    } else {
+      scf.yield {async_task_id = array<i32: 0>} %b : tensor<128x64xf16, #blocked>
+    } {async_task_id = array<i32: 0>}
+    %lhs = ttg.local_alloc %sel {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %2 = tt.splat %arg2 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<64x256x!tt.ptr<f16>, #blocked1>
+    %rhs_val = tt.load %2 {async_task_id = array<i32: 0>} : tensor<64x256x!tt.ptr<f16>, #blocked1>
+    %rhs = ttg.local_alloc %rhs_val {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+    // CHECK: ttng.warp_group_dot
+    %dot = ttng.warp_group_dot %lhs, %rhs, %cst {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition.mlir
@@ -168,17 +168,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %0 = tt.splat %arg0 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
     %1 = tt.splat %arg1 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
     // Two loads that feed into the if branches
+    // CHECK: tt.load {{.*}} : tensor<128x64x!tt.ptr<f16>
     %a = tt.load %0 {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+    // CHECK: tt.load {{.*}} : tensor<128x64x!tt.ptr<f16>
     %b = tt.load %1 {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
     // Pick one based on condition
+    // CHECK: scf.if
+    // CHECK:   scf.yield
+    // CHECK: } else {
+    // CHECK:   scf.yield
     %sel = scf.if %cond -> (tensor<128x64xf16, #blocked>) {
       scf.yield {async_task_id = array<i32: 0>} %a : tensor<128x64xf16, #blocked>
     } else {
       scf.yield {async_task_id = array<i32: 0>} %b : tensor<128x64xf16, #blocked>
     } {async_task_id = array<i32: 0>}
+    // CHECK: ttg.local_alloc
     %lhs = ttg.local_alloc %sel {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    // CHECK: tt.load {{.*}} : tensor<64x256x!tt.ptr<f16>
     %2 = tt.splat %arg2 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<64x256x!tt.ptr<f16>, #blocked1>
     %rhs_val = tt.load %2 {async_task_id = array<i32: 0>} : tensor<64x256x!tt.ptr<f16>, #blocked1>
+    // CHECK: ttg.local_alloc
     %rhs = ttg.local_alloc %rhs_val {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
     // CHECK: ttng.warp_group_dot
     %dot = ttng.warp_group_dot %lhs, %rhs, %cst {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>

--- a/test/Hopper/WarpSpecialization/ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition.mlir
@@ -167,30 +167,39 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst = arith.constant {async_task_id = array<i32: 1, 2>} dense<0.000000e+00> : tensor<128x256xf32, #mma>
     %0 = tt.splat %arg0 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
     %1 = tt.splat %arg1 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
-    // Two loads that feed into the if branches
-    // CHECK: tt.load {{.*}} : tensor<128x64x!tt.ptr<f16>
-    %a = tt.load %0 {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
-    // CHECK: tt.load {{.*}} : tensor<128x64x!tt.ptr<f16>
-    %b = tt.load %1 {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
-    // Pick one based on condition
-    // CHECK: scf.if
-    // CHECK:   scf.yield
+    // Each branch loads from a different pointer, preventing fold to select.
+    // CHECK: scf.if {{.*}} -> (tensor<64x64xf16, #blocked>, tensor<64x64xf16, #blocked>)
+    // CHECK:   tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>, #blocked>
+    // CHECK:   tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>, #blocked>
+    // CHECK:   scf.yield {{.*}} : tensor<64x64xf16, #blocked>, tensor<64x64xf16, #blocked>
     // CHECK: } else {
-    // CHECK:   scf.yield
+    // CHECK:   tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>, #blocked>
+    // CHECK:   tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>, #blocked>
+    // CHECK:   scf.yield {{.*}} : tensor<64x64xf16, #blocked>, tensor<64x64xf16, #blocked>
     %sel = scf.if %cond -> (tensor<128x64xf16, #blocked>) {
+      %a = tt.load %0 {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
       scf.yield {async_task_id = array<i32: 0>} %a : tensor<128x64xf16, #blocked>
     } else {
+      %b = tt.load %1 {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
       scf.yield {async_task_id = array<i32: 0>} %b : tensor<128x64xf16, #blocked>
     } {async_task_id = array<i32: 0>}
-    // CHECK: ttg.local_alloc
+    // CHECK: ttg.local_alloc {{.*}} : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
+    // CHECK: ttg.local_alloc {{.*}} : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
     %lhs = ttg.local_alloc %sel {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
-    // CHECK: tt.load {{.*}} : tensor<64x256x!tt.ptr<f16>
+    // CHECK: tt.load {{.*}} : tensor<64x256x!tt.ptr<f16>, #blocked1>
     %2 = tt.splat %arg2 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<64x256x!tt.ptr<f16>, #blocked1>
     %rhs_val = tt.load %2 {async_task_id = array<i32: 0>} : tensor<64x256x!tt.ptr<f16>, #blocked1>
-    // CHECK: ttg.local_alloc
+    // CHECK: ttg.local_alloc {{.*}} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
     %rhs = ttg.local_alloc %rhs_val {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
-    // CHECK: ttng.warp_group_dot
+    // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
+    // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
     %dot = ttng.warp_group_dot %lhs, %rhs, %cst {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+    %trunc = arith.truncf %dot {async_task_id = array<i32: 1, 2>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
+    %cvt = ttg.convert_layout %trunc {async_task_id = array<i32: 1, 2>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
+    // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, #blocked1>
+    // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, #blocked1>
+    %3 = tt.splat %arg2 {async_task_id = array<i32: 1, 2>} : !tt.ptr<f16> -> tensor<128x256x!tt.ptr<f16>, #blocked1>
+    tt.store %3, %cvt {async_task_id = array<i32: 1, 2>} : tensor<128x256x!tt.ptr<f16>, #blocked1>
     tt.return
   }
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -321,8 +321,8 @@ static bool getBackwardSliceToPartition(Value v,
       partitionScheme.opPartitionDims[ifOp.elseYield()] = currentDim;
       auto thenYieldArg = ifOp.thenYield().getOperand(resultIndex);
       auto elseYieldArg = ifOp.elseYield().getOperand(resultIndex);
-      if (getBackwardSliceToPartition(thenYieldArg, partitionScheme,
-                                      currentDim))
+      if (!getBackwardSliceToPartition(thenYieldArg, partitionScheme,
+                                       currentDim))
         return false;
       if (!getBackwardSliceToPartition(elseYieldArg, partitionScheme,
                                        currentDim))


### PR DESCRIPTION
## Summary

Fixes #9559

The `thenYieldArg` branch in `getBackwardSliceToPartition` (line 324) was missing the `!` negation operator, causing inverted error handling compared to all other call sites.

## Bug

```cpp
// BEFORE (line 324) — returns false on SUCCESS (wrong)
if (getBackwardSliceToPartition(thenYieldArg, partitionScheme, currentDim))
    return false;

// The else branch directly below already has the correct pattern:
if (!getBackwardSliceToPartition(elseYieldArg, partitionScheme, currentDim))
    return false;
```

All other call sites in the same function use `if (!getBackwardSliceToPartition(...)) return false;` to propagate failure. This was the only one without the negation, as confirmed by @htyu in the issue thread.

## Change

Single-character fix — add `!` to match the consistent pattern across the file.
Added a lit test with `scf.if` result feeding into a dot to cover this path.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section.