### PR TITLE
fix: RTNE rounding in interpreter float downcast (#8322)

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -1,6 +1,7 @@
 # fmt: off
 
 
+import os
 import numpy as np
 import torch
 import pytest
@@ -428,11 +429,12 @@ def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, mode, device, round
 @pytest.mark.interpreter
 def test_rtne_tie_to_even(device):
     """Regression test for #8322: interpreter RTNE rounds ties up instead of to even."""
-    # Values chosen to hit the tie-to-even case in f16 → f8e5m2 downcast.
+    if not os.environ.get("TRITON_INTERPRET", "") == "1":
+        pytest.skip("interpreter-only test")
     # f8e5m2 has 2 mantissa bits, so 8 bits are truncated from f16's 10.
-    # 9.0 (f16 0x4880): truncated=0.5 exactly, result LSB=0 (even) → stay at 8.0
-    # 11.0 (f16 0x4980): truncated=0.5 exactly, result LSB=1 (odd) → round up to 12.0
-    # 10.0 (f16 0x4900): truncated=0, no rounding → 10.0
+    # 9.0: truncated=0.5 exactly, result LSB=0 (even) → stay at 8.0
+    # 11.0: truncated=0.5 exactly, result LSB=1 (odd) → round up to 12.0
+    # 10.0: truncated=0, no rounding → 10.0
     src_f16 = torch.tensor([9.0, 10.0, 11.0], dtype=torch.float16, device=device)
     expected = torch.tensor([8.0, 10.0, 12.0], dtype=torch.float16, device=device)
 
@@ -441,7 +443,6 @@ def test_rtne_tie_to_even(device):
     src[:3] = src_f16
 
     dst = launch_type_convert_triton(src, tl.float16, tl.float8e5, device=device, rounding='rtne')
-    # Cast back to f16 to compare
     dst_f16 = launch_type_convert_triton(dst, tl.float8e5, tl.float16, device=device)
     dst_values = dst_f16[:3].to(torch.float16)
 

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -423,3 +423,26 @@ def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, mode, device, round
         assert(torch.all(torch.isnan(dst)))
     else:
         torch.testing.assert_close(dst, torch.full_like(dst, expected_result))
+
+
+@pytest.mark.interpreter
+def test_rtne_tie_to_even(device):
+    """Regression test for #8322: interpreter RTNE rounds ties up instead of to even."""
+    # Values chosen to hit the tie-to-even case in f16 → f8e5m2 downcast.
+    # f8e5m2 has 2 mantissa bits, so 8 bits are truncated from f16's 10.
+    # 9.0 (f16 0x4880): truncated=0.5 exactly, result LSB=0 (even) → stay at 8.0
+    # 11.0 (f16 0x4980): truncated=0.5 exactly, result LSB=1 (odd) → round up to 12.0
+    # 10.0 (f16 0x4900): truncated=0, no rounding → 10.0
+    src_f16 = torch.tensor([9.0, 10.0, 11.0], dtype=torch.float16, device=device)
+    expected = torch.tensor([8.0, 10.0, 12.0], dtype=torch.float16, device=device)
+
+    BLOCK_SIZE = 4096
+    src = torch.zeros(BLOCK_SIZE, dtype=torch.float16, device=device)
+    src[:3] = src_f16
+
+    dst = launch_type_convert_triton(src, tl.float16, tl.float8e5, device=device, rounding='rtne')
+    # Cast back to f16 to compare
+    dst_f16 = launch_type_convert_triton(dst, tl.float8e5, tl.float16, device=device)
+    dst_values = dst_f16[:3].to(torch.float16)
+
+    torch.testing.assert_close(dst_values, expected)

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -429,21 +429,19 @@ def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, mode, device, round
 @pytest.mark.interpreter
 def test_rtne_tie_to_even(device):
     """Regression test for #8322: interpreter RTNE rounds ties up instead of to even."""
-    if not os.environ.get("TRITON_INTERPRET", "") == "1":
-        pytest.skip("interpreter-only test")
     # f8e5m2 has 2 mantissa bits, so 8 bits are truncated from f16's 10.
     # 9.0: truncated=0.5 exactly, result LSB=0 (even) → stay at 8.0
     # 11.0: truncated=0.5 exactly, result LSB=1 (odd) → round up to 12.0
     # 10.0: truncated=0, no rounding → 10.0
-    src_f16 = torch.tensor([9.0, 10.0, 11.0], dtype=torch.float16, device=device)
-    expected = torch.tensor([8.0, 10.0, 12.0], dtype=torch.float16, device=device)
-
     BLOCK_SIZE = 4096
     src = torch.zeros(BLOCK_SIZE, dtype=torch.float16, device=device)
-    src[:3] = src_f16
+    src[0], src[1], src[2] = 9.0, 10.0, 11.0
 
     dst = launch_type_convert_triton(src, tl.float16, tl.float8e5, device=device, rounding='rtne')
-    dst_f16 = launch_type_convert_triton(dst, tl.float8e5, tl.float16, device=device)
-    dst_values = dst_f16[:3].to(torch.float16)
+    # f8e5: exponent_bits=5, mantissa_bits=2, exponent_bias=15
+    dst_f32 = launch_upcast_emulated(dst, 5, 2, 15, device=device)
+    results = dst_f32[:3].cpu().float()
 
-    torch.testing.assert_close(dst_values, expected)
+    assert results[0].item() == 8.0
+    assert results[1].item() == 10.0
+    assert results[2].item() == 12.0

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -210,10 +210,23 @@ def _convert_float(input, input_dtype, output_dtype, rounding_mode):
     if input_dtype.primitive_bitwidth > output_dtype.primitive_bitwidth:  # Downcast
         significand_output = (significand >> (input_dtype.fp_mantissa_width - output_dtype.fp_mantissa_width)) & (
             (1 << output_dtype.fp_mantissa_width) - 1)
-        if rounding_mode == _ir.ROUNDING_MODE.RTNE:  # Round to nearst even
-            # find the cut-off bit
-            cut_off = significand & (1 << (input_dtype.fp_mantissa_width - output_dtype.fp_mantissa_width - 1))
-            significand_output = significand_output + (cut_off > 0)
+        if rounding_mode == _ir.ROUNDING_MODE.RTNE:  # Round to nearest even
+            shift_amount = input_dtype.fp_mantissa_width - output_dtype.fp_mantissa_width
+            # Guard bit (most significant truncated bit)
+            guard_bit = (significand >> (shift_amount - 1)) & 1
+            # Sticky bits (all lower truncated bits OR'd together)
+            if shift_amount > 1:
+                sticky_mask = (1 << (shift_amount - 1)) - 1
+                sticky_bits = (significand & sticky_mask) != 0
+            else:
+                sticky_bits = np.zeros_like(significand, dtype=bool)
+            # LSB of the truncated result
+            lsb = significand_output & 1
+            # Round up if:
+            # 1. guard_bit=1 AND sticky_bits!=0 (truncated > half), OR
+            # 2. guard_bit=1 AND sticky_bits==0 AND lsb=1 (exactly half, round to even)
+            round_up = (guard_bit != 0) & (sticky_bits | (lsb != 0))
+            significand_output = significand_output + round_up
         significand_output = significand_output.astype(output_unint_dtype)
     else:  # Upcast
         significand_output = (significand.astype(output_unint_dtype) <<


### PR DESCRIPTION
Fix incorrect RTNE in the interpreter's float downcast path.
The old code rounded up whenever the guard bit was set.
Now uses the IEEE 754 formula: round_up = guard & (sticky | lsb).

Interpreter-only.

Fixes #8322

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.
- Select one of the following.
  - [x] I have not added any `lit` tests.