### PR TITLE
[LANGUAGE] Make tl.max and tl.min NaN propagation configurable

### DIFF
--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1275,7 +1275,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %0 = tt.call @triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL_c0_cFalse_cNone(%cst_0) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
     %1 = tt.call @triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL_c1_cFalse_cNone(%cst_0) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
     %2 = tt.call @triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL_cNone_cFalse_cNone(%cst_0) : (tensor<16x16xf32, #blocked>) -> f32
-    %3 = tt.call @triton.language.standard.max__fp32S16SLSL0_B1_1_1_32_4_1_1_0_BSLL_c0_cFalse_cTrue_cFalse(%0) : (tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32
+    %3 = tt.call @"triton.language.standard.max__fp32S16SLSL0_B1_1_1_32_4_1_1_0_BSLL_c0_cFalse_cTrue_cFalse_c<PROPAGATE_NAN.NONE: 0>"(%0) : (tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32
     %4 = ttg.convert_layout %1 : tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
     %5:2 = "tt.reduce"(%cst_0, %cst_2) <{axis = 0 : i32}> ({
     ^bb0(%arg1: f32, %arg2: f32, %arg3: f32, %arg4: f32):
@@ -1333,10 +1333,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ub.poison : f32
     tt.return %2 : f32
   }
-  tt.func private @triton.language.standard.max__fp32S16SLSL0_B1_1_1_32_4_1_1_0_BSLL_c0_cFalse_cTrue_cFalse(%arg0: tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32 attributes {noinline = false} {
+  tt.func private @"triton.language.standard.max__fp32S16SLSL0_B1_1_1_32_4_1_1_0_BSLL_c0_cFalse_cTrue_cFalse_c<PROPAGATE_NAN.NONE: 0>"(%arg0: tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32 attributes {noinline = false} {
     %0 = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
     ^bb0(%arg1: f32, %arg2: f32):
-      %2 = tt.call @triton.language.standard._elementwise_max__fp32_fp32(%arg1, %arg2) : (f32, f32) -> f32
+      %2 = tt.call @triton.language.standard._elementwise_max_ignore_nan__fp32_fp32(%arg1, %arg2) : (f32, f32) -> f32
       tt.reduce.return %2 : f32
     }) : (tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32
     tt.return %0 : f32
@@ -1344,7 +1344,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %1 = ub.poison : f32
     tt.return %1 : f32
   }
-  tt.func private @triton.language.standard._elementwise_max__fp32_fp32(%arg0: f32, %arg1: f32) -> f32 attributes {noinline = false} {
+  tt.func private @triton.language.standard._elementwise_max_ignore_nan__fp32_fp32(%arg0: f32, %arg1: f32) -> f32 attributes {noinline = false} {
     %0 = arith.maxnumf %arg0, %arg1 : f32
     tt.return %0 : f32
   ^bb1:  // no predecessors

--- a/python/test/unit/language/test_standard.py
+++ b/python/test/unit/language/test_standard.py
@@ -183,3 +183,135 @@ def test_unsqueeze(dim, device):
     expected = torch.arange(0, 8, device=device, dtype=torch.int32)
     expected = expected.reshape(2, 4).unsqueeze(dim).reshape(-1)
     assert (out == expected).all()
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("propagate_nan", [tl.PropagateNan.NONE, tl.PropagateNan.ALL])
+def test_max_propagate_nan(propagate_nan, device):
+
+    @triton.jit
+    def max_kernel(in_ptr, out_ptr, propagate_nan: tl.constexpr):
+        a = tl.load(in_ptr + tl.arange(0, 8)[:, None] * 8 + tl.arange(0, 8)[None, :])
+        a = tl.max(a, 0, propagate_nan=propagate_nan)
+        tl.store(out_ptr + tl.arange(0, 8), a)
+
+    a = torch.randn((8, 8), device=device)
+    a[1, 2] = torch.nan
+    a[4, 6] = torch.nan
+
+    std = a.clone()
+    nan_cols = torch.isnan(std).any(dim=0)
+    std[torch.isnan(std)] = -torch.inf
+    std = std.max(0)[0]
+    if propagate_nan == tl.PropagateNan.ALL:
+        std[nan_cols] = torch.nan
+
+    ans = torch.zeros((8, ), dtype=torch.float32, device=device)
+    max_kernel[1, 1, 1](a, ans, propagate_nan)
+    torch.testing.assert_close(std, ans, equal_nan=True)
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("propagate_nan", [tl.PropagateNan.NONE, tl.PropagateNan.ALL])
+def test_min_propagate_nan(propagate_nan, device):
+
+    @triton.jit
+    def min_kernel(in_ptr, out_ptr, propagate_nan: tl.constexpr):
+        a = tl.load(in_ptr + tl.arange(0, 8)[:, None] * 8 + tl.arange(0, 8)[None, :])
+        a = tl.min(a, 0, propagate_nan=propagate_nan)
+        tl.store(out_ptr + tl.arange(0, 8), a)
+
+    a = torch.randn((8, 8), device=device)
+    a[1, 2] = torch.nan
+    a[4, 6] = torch.nan
+
+    std = a.clone()
+    nan_cols = torch.isnan(std).any(dim=0)
+    std[torch.isnan(std)] = torch.inf
+    std = std.min(0)[0]
+    if propagate_nan == tl.PropagateNan.ALL:
+        std[nan_cols] = torch.nan
+
+    ans = torch.zeros((8, ), dtype=torch.float32, device=device)
+    min_kernel[1, 1, 1](a, ans, propagate_nan)
+    torch.testing.assert_close(std, ans, equal_nan=True)
+
+
+def _reference_reduce_with_indices(x, op, propagate_nan, tie_break_left):
+    values = []
+    indices = []
+    fill_value = -torch.inf if op == "max" else torch.inf
+
+    for column in x.T:
+        nan_indices = torch.nonzero(torch.isnan(column), as_tuple=False).flatten()
+        if propagate_nan == tl.PropagateNan.ALL and len(nan_indices) > 0:
+            values.append(torch.tensor(torch.nan, device=x.device, dtype=x.dtype))
+            indices.append(nan_indices[0 if tie_break_left else -1])
+            continue
+
+        clean = column.clone()
+        clean[torch.isnan(clean)] = fill_value
+        if op == "max":
+            value, index = torch.max(clean, dim=0)
+        else:
+            value, index = torch.min(clean, dim=0)
+        values.append(value)
+        indices.append(index)
+
+    return torch.stack(values), torch.stack(indices).to(torch.int32)
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("op", ["max", "min"])
+@pytest.mark.parametrize("propagate_nan", [tl.PropagateNan.NONE, tl.PropagateNan.ALL])
+@pytest.mark.parametrize("tie_break_left", [True, False])
+def test_reduce_return_indices_propagate_nan(op, propagate_nan, tie_break_left, device):
+
+    @triton.jit
+    def reduce_kernel(in_ptr, out_val_ptr, out_idx_ptr, propagate_nan: tl.constexpr, tie_break_left: tl.constexpr,
+                      op: tl.constexpr):
+        a = tl.load(in_ptr + tl.arange(0, 4)[:, None] * 4 + tl.arange(0, 4)[None, :])
+        if op == "max":
+            values, indices = tl.max(a, 0, return_indices=True, return_indices_tie_break_left=tie_break_left,
+                                     propagate_nan=propagate_nan)
+        else:
+            values, indices = tl.min(a, 0, return_indices=True, return_indices_tie_break_left=tie_break_left,
+                                     propagate_nan=propagate_nan)
+        offs = tl.arange(0, 4)
+        tl.store(out_val_ptr + offs, values)
+        tl.store(out_idx_ptr + offs, indices)
+
+    x = torch.tensor([[1.0, 5.0, 9.0, 0.0], [torch.nan, -1.0, 3.0, 4.0], [3.0, 2.0, torch.nan, torch.nan],
+                      [2.0, torch.nan, 7.0, 6.0]], device=device)
+
+    expected_values, expected_indices = _reference_reduce_with_indices(x, op, propagate_nan, tie_break_left)
+    actual_values = torch.empty((4, ), dtype=torch.float32, device=device)
+    actual_indices = torch.empty((4, ), dtype=torch.int32, device=device)
+
+    reduce_kernel[(1, )](x, actual_values, actual_indices, propagate_nan, tie_break_left, op)
+    torch.testing.assert_close(expected_values, actual_values, equal_nan=True)
+    torch.testing.assert_close(expected_indices, actual_indices)
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_reduce_return_indices_propagate_nan_tie_break_left(op, device):
+
+    @triton.jit
+    def reduce_kernel(in_ptr, out_idx_ptr, op: tl.constexpr):
+        a = tl.load(in_ptr + tl.arange(0, 4)[:, None] * 4 + tl.arange(0, 4)[None, :])
+        if op == "max":
+            _, indices = tl.max(a, 0, return_indices=True, return_indices_tie_break_left=True,
+                                propagate_nan=tl.PropagateNan.ALL)
+        else:
+            _, indices = tl.min(a, 0, return_indices=True, return_indices_tie_break_left=True,
+                                propagate_nan=tl.PropagateNan.ALL)
+        tl.store(out_idx_ptr + tl.arange(0, 4), indices)
+
+    x = torch.tensor([[1.0, torch.nan, 9.0, 0.0], [torch.nan, -1.0, torch.nan, 4.0], [3.0, torch.nan, 5.0, torch.nan],
+                      [2.0, 7.0, torch.nan, 6.0]], device=device)
+    expected_indices = torch.tensor([1, 0, 1, 2], dtype=torch.int32, device=device)
+    actual_indices = torch.empty((4, ), dtype=torch.int32, device=device)
+
+    reduce_kernel[(1, )](x, actual_indices, op)
+    torch.testing.assert_close(expected_indices, actual_indices)

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from ..runtime.jit import jit, constexpr_function
 from . import core
+from .extra.libdevice import isnan
 from . import math
 
 # constexpr utilities
@@ -144,12 +145,22 @@ def zeros_like(input):
 
 
 @jit
-def _argmax_combine(value1, index1, value2, index2, tie_break_left):
+def _isnan(value):
+    if not core.constexpr(value.dtype.is_floating()):
+        return core.full(value.shape, 0, core.int1)
+    if core.constexpr(value.dtype.is_fp64()):
+        return isnan(value)
+    return isnan(value.to(core.float32))
+
+
+@jit
+def _argmax_combine(value1, index1, value2, index2, tie_break_left, propagate_nan):
     if tie_break_left:
-        tie = value1 == value2 and index1 < index2
+        tie = (value1 == value2 or (_isnan(value1) and _isnan(value2))) and index1 < index2
     else:
         tie = False
-    gt = value1 > value2 or tie
+    gt = ((propagate_nan and _isnan(value1) and not _isnan(value2))
+          or (not propagate_nan and not _isnan(value1) and _isnan(value2)) or value1 > value2 or tie)
     v_ret = core.where(gt, value1, value2)
     i_ret = core.where(gt, index1, index2)
     return v_ret, i_ret
@@ -157,30 +168,51 @@ def _argmax_combine(value1, index1, value2, index2, tie_break_left):
 
 @jit
 def _argmax_combine_tie_break_left(value1, index1, value2, index2):
-    return _argmax_combine(value1, index1, value2, index2, True)
+    return _argmax_combine(value1, index1, value2, index2, True, False)
 
 
 @jit
 def _argmax_combine_tie_break_fast(value1, index1, value2, index2):
-    return _argmax_combine(value1, index1, value2, index2, False)
+    return _argmax_combine(value1, index1, value2, index2, False, False)
 
 
 @jit
-def _elementwise_max(a, b):
-    return core.maximum(a, b)
+def _argmax_combine_tie_break_left_propagate_nan(value1, index1, value2, index2):
+    return _argmax_combine(value1, index1, value2, index2, True, True)
+
+
+@jit
+def _argmax_combine_tie_break_fast_propagate_nan(value1, index1, value2, index2):
+    return _argmax_combine(value1, index1, value2, index2, False, True)
+
+
+@jit
+def _elementwise_max_ignore_nan(a, b):
+    return core.maximum(a, b, propagate_nan=core.PropagateNan.NONE)
+
+
+@jit
+def _elementwise_max_propagate_nan(a, b):
+    return core.maximum(a, b, propagate_nan=core.PropagateNan.ALL)
 
 
 @core._tensor_member_fn
 @jit
 @core._add_reduction_docstr("maximum", return_indices_arg="return_indices",
                             tie_break_arg="return_indices_tie_break_left")
-def max(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False):
+def max(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False,
+        propagate_nan: core.constexpr = core.PropagateNan.NONE):
     input = core._promote_bfloat16_to_float32(input)
     if return_indices:
+        if propagate_nan == core.PropagateNan.ALL:
+            if return_indices_tie_break_left:
+                return core._reduce_with_indices(input, axis, _argmax_combine_tie_break_left_propagate_nan,
+                                                 keep_dims=keep_dims)
+            return core._reduce_with_indices(input, axis, _argmax_combine_tie_break_fast_propagate_nan,
+                                             keep_dims=keep_dims)
         if return_indices_tie_break_left:
             return core._reduce_with_indices(input, axis, _argmax_combine_tie_break_left, keep_dims=keep_dims)
-        else:
-            return core._reduce_with_indices(input, axis, _argmax_combine_tie_break_fast, keep_dims=keep_dims)
+        return core._reduce_with_indices(input, axis, _argmax_combine_tie_break_fast, keep_dims=keep_dims)
     else:
         if core.constexpr(input.dtype.primitive_bitwidth) < core.constexpr(32):
             if core.constexpr(input.dtype.is_floating()):
@@ -188,7 +220,9 @@ def max(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
             else:
                 assert input.dtype.is_int(), "Expecting input to be integer type"
                 input = input.to(core.int32)
-        return core.reduce(input, axis, _elementwise_max, keep_dims=keep_dims)
+        if propagate_nan == core.PropagateNan.ALL:
+            return core.reduce(input, axis, _elementwise_max_propagate_nan, keep_dims=keep_dims)
+        return core.reduce(input, axis, _elementwise_max_ignore_nan, keep_dims=keep_dims)
 
 
 @core._tensor_member_fn
@@ -203,12 +237,13 @@ def argmax(input, axis, tie_break_left=True, keep_dims=False):
 
 
 @jit
-def _argmin_combine(value1, index1, value2, index2, tie_break_left):
+def _argmin_combine(value1, index1, value2, index2, tie_break_left, propagate_nan):
     if tie_break_left:
-        tie = value1 == value2 and index1 < index2
+        tie = (value1 == value2 or (_isnan(value1) and _isnan(value2))) and index1 < index2
     else:
         tie = False
-    lt = value1 < value2 or tie
+    lt = ((propagate_nan and _isnan(value1) and not _isnan(value2))
+          or (not propagate_nan and not _isnan(value1) and _isnan(value2)) or value1 < value2 or tie)
     value_ret = core.where(lt, value1, value2)
     index_ret = core.where(lt, index1, index2)
     return value_ret, index_ret
@@ -216,30 +251,51 @@ def _argmin_combine(value1, index1, value2, index2, tie_break_left):
 
 @jit
 def _argmin_combine_tie_break_left(value1, index1, value2, index2):
-    return _argmin_combine(value1, index1, value2, index2, True)
+    return _argmin_combine(value1, index1, value2, index2, True, False)
 
 
 @jit
 def _argmin_combine_tie_break_fast(value1, index1, value2, index2):
-    return _argmin_combine(value1, index1, value2, index2, False)
+    return _argmin_combine(value1, index1, value2, index2, False, False)
 
 
 @jit
-def _elementwise_min(a, b):
-    return core.minimum(a, b)
+def _argmin_combine_tie_break_left_propagate_nan(value1, index1, value2, index2):
+    return _argmin_combine(value1, index1, value2, index2, True, True)
+
+
+@jit
+def _argmin_combine_tie_break_fast_propagate_nan(value1, index1, value2, index2):
+    return _argmin_combine(value1, index1, value2, index2, False, True)
+
+
+@jit
+def _elementwise_min_ignore_nan(a, b):
+    return core.minimum(a, b, propagate_nan=core.PropagateNan.NONE)
+
+
+@jit
+def _elementwise_min_propagate_nan(a, b):
+    return core.minimum(a, b, propagate_nan=core.PropagateNan.ALL)
 
 
 @core._tensor_member_fn
 @jit
 @core._add_reduction_docstr("minimum", return_indices_arg="return_indices",
                             tie_break_arg="return_indices_tie_break_left")
-def min(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False):
+def min(input, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False,
+        propagate_nan: core.constexpr = core.PropagateNan.NONE):
     input = core._promote_bfloat16_to_float32(input)
     if return_indices:
+        if propagate_nan == core.PropagateNan.ALL:
+            if return_indices_tie_break_left:
+                return core._reduce_with_indices(input, axis, _argmin_combine_tie_break_left_propagate_nan,
+                                                 keep_dims=keep_dims)
+            return core._reduce_with_indices(input, axis, _argmin_combine_tie_break_fast_propagate_nan,
+                                             keep_dims=keep_dims)
         if return_indices_tie_break_left:
             return core._reduce_with_indices(input, axis, _argmin_combine_tie_break_left, keep_dims=keep_dims)
-        else:
-            return core._reduce_with_indices(input, axis, _argmin_combine_tie_break_fast, keep_dims=keep_dims)
+        return core._reduce_with_indices(input, axis, _argmin_combine_tie_break_fast, keep_dims=keep_dims)
     else:
         if core.constexpr(input.dtype.primitive_bitwidth) < 32:
             if core.constexpr(input.dtype.is_floating()):
@@ -247,7 +303,9 @@ def min(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
             else:
                 assert input.dtype.is_int(), "Expecting input to be integer type"
                 input = input.to(core.int32)
-        return core.reduce(input, axis, _elementwise_min, keep_dims=keep_dims)
+        if propagate_nan == core.PropagateNan.ALL:
+            return core.reduce(input, axis, _elementwise_min_propagate_nan, keep_dims=keep_dims)
+        return core.reduce(input, axis, _elementwise_min_ignore_nan, keep_dims=keep_dims)
 
 
 @core._tensor_member_fn

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -930,6 +930,68 @@ class ReduceOps(ReduceScanOpInterface):
             ret.append(self.to_tensor(data, input[i].dtype))
         return ret
 
+    def min_max_with_indices(self, input, val_reduce_op, idx_reduce_op, tie_break_left=True, propagate_nan=False):
+        input = input[0] if isinstance(input, tuple) else input
+        input, axis = self.unravel((input, ), self.axis)
+        input = input[0]
+        data = input.handle.data
+        moved = np.moveaxis(data, axis, 0)
+        flattened = moved.reshape(moved.shape[0], -1)
+
+        values = np.empty(flattened.shape[1], dtype=data.dtype)
+        indices = np.empty(flattened.shape[1], dtype=np.int32)
+        select_idx = 0 if tie_break_left else -1
+        fill_value = np.inf if val_reduce_op == np.min else -np.inf
+        is_floating = np.issubdtype(data.dtype, np.floating)
+
+        def reduce_column(column):
+            if not is_floating:
+                best_value = val_reduce_op(column)
+                if tie_break_left:
+                    winner = idx_reduce_op(column)
+                else:
+                    best_indices = np.flatnonzero(column == best_value)
+                    winner = best_indices[select_idx]
+                return column[winner], winner
+
+            nan_indices = np.flatnonzero(np.isnan(column))
+            if nan_indices.size == column.shape[0] or (propagate_nan and nan_indices.size > 0):
+                winner = nan_indices[select_idx]
+                return np.nan, winner
+
+            clean = column.copy()
+            if nan_indices.size > 0:
+                clean[nan_indices] = fill_value
+            if tie_break_left:
+                winner = idx_reduce_op(clean)
+            else:
+                best_value = val_reduce_op(clean)
+                best_indices = np.flatnonzero(clean == best_value)
+                winner = best_indices[select_idx]
+            return column[winner], winner
+
+        for column_idx, column in enumerate(flattened.T):
+            values[column_idx], indices[column_idx] = reduce_column(column)
+
+        output_shape = moved.shape[1:]
+        values = values.reshape(output_shape)
+        indices = indices.reshape(output_shape)
+
+        if self.keep_dims:
+            if self.axis is not None:
+                values = np.expand_dims(values, axis)
+                indices = np.expand_dims(indices, axis)
+            else:
+                for _ in range(len(data.shape)):
+                    values = np.expand_dims(values, 0)
+                    indices = np.expand_dims(indices, 0)
+
+        elif self.axis is None:
+            values = values.item()
+            indices = indices.item()
+
+        return self.to_tensor(values, input.dtype), self.to_tensor(indices, tl.int32)
+
     def min_max(self, input, val_reduce_op, idx_reduce_op=None):
         # If input is a tuple, it must be (val, index), and we only take val
         input = input[0] if isinstance(input, tuple) else input
@@ -953,12 +1015,30 @@ class ReduceOps(ReduceScanOpInterface):
 
     def apply_impl(self, input):
         if self.combine_fn == tl.standard._argmin_combine_tie_break_left:
-            return self.min_max(input[0], val_reduce_op=np.min, idx_reduce_op=np.argmin)
+            return self.min_max_with_indices(input[0], val_reduce_op=np.min, idx_reduce_op=np.argmin)
         elif self.combine_fn == tl.standard._argmax_combine_tie_break_left:
-            return self.min_max(input[0], val_reduce_op=np.max, idx_reduce_op=np.argmax)
-        elif self.combine_fn == tl.standard._elementwise_max:
+            return self.min_max_with_indices(input[0], val_reduce_op=np.max, idx_reduce_op=np.argmax)
+        elif self.combine_fn == tl.standard._argmin_combine_tie_break_fast:
+            return self.min_max_with_indices(input[0], val_reduce_op=np.min, idx_reduce_op=np.argmin,
+                                             tie_break_left=False)
+        elif self.combine_fn == tl.standard._argmax_combine_tie_break_fast:
+            return self.min_max_with_indices(input[0], val_reduce_op=np.max, idx_reduce_op=np.argmax,
+                                             tie_break_left=False)
+        elif self.combine_fn == tl.standard._argmin_combine_tie_break_left_propagate_nan:
+            return self.min_max_with_indices(input[0], val_reduce_op=np.min, idx_reduce_op=np.argmin,
+                                             propagate_nan=True)
+        elif self.combine_fn == tl.standard._argmin_combine_tie_break_fast_propagate_nan:
+            return self.min_max_with_indices(input[0], val_reduce_op=np.min, idx_reduce_op=np.argmin,
+                                             tie_break_left=False, propagate_nan=True)
+        elif self.combine_fn == tl.standard._argmax_combine_tie_break_left_propagate_nan:
+            return self.min_max_with_indices(input[0], val_reduce_op=np.max, idx_reduce_op=np.argmax,
+                                             propagate_nan=True)
+        elif self.combine_fn == tl.standard._argmax_combine_tie_break_fast_propagate_nan:
+            return self.min_max_with_indices(input[0], val_reduce_op=np.max, idx_reduce_op=np.argmax,
+                                             tie_break_left=False, propagate_nan=True)
+        elif self.combine_fn == tl.standard._elementwise_max_ignore_nan:
             return self.min_max(input[0], val_reduce_op=np.nanmax, idx_reduce_op=None)
-        elif self.combine_fn == tl.standard._elementwise_min:
+        elif self.combine_fn == tl.standard._elementwise_min_ignore_nan:
             return self.min_max(input[0], val_reduce_op=np.nanmin, idx_reduce_op=None)
         elif self.combine_fn == tl.standard._sum_combine:
             return self.sum(input[0])


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
tl.max currently follows a "nan ignore" reduction style. This matches Triton's existing behavior, but it also means users cannot request NaN-propagating semantics when that is the more appropriate choice for their workload.

This change makes NaN handling in tl.max configurable. The default behavior remains unchanged for existing users, while also allowing users to request NaN propagation explicitly when they want reductions to surface invalid values instead of ignoring them.

This is useful for workloads that rely on stricter numerical behavior or use NaNs to signal invalid intermediate results. It preserves backward compatibility while making tl.max more flexible for users with different requirements.
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it preserves the existing default behavior and only adds an optional control for NaN handling`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
