### PR TITLE
[triton-ext][CMake] Disable building example plugins for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,8 +452,10 @@ if(TRITON_BUILD_PYTHON_MODULE)
     "${TRITON_WHEEL_DIR}/FileCheck"
     COPYONLY)
 
-  # Build plugins when building libtriton since they depend on libtriton.
-  add_subdirectory(examples/plugins)
+  if (TRITON_EXT_ENABLED)
+    # Build plugins when building libtriton since they depend on libtriton.
+    add_subdirectory(examples/plugins)
+  endif()
 endif()
 
 if (UNIX AND NOT APPLE AND NOT TRITON_EXT_ENABLED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,7 +452,9 @@ if(TRITON_BUILD_PYTHON_MODULE)
     "${TRITON_WHEEL_DIR}/FileCheck"
     COPYONLY)
 
-  if (TRITON_EXT_ENABLED)
+  # Example plugin shared libraries link with unresolved LLVM/MLIR symbols when TRITON_EXT_ENABLED is OFF.
+  # With MSVC, unresolved symbols are an error when linking DLLs.
+  if (NOT MSVC)
     # Build plugins when building libtriton since they depend on libtriton.
     add_subdirectory(examples/plugins)
   endif()


### PR DESCRIPTION
After https://github.com/triton-lang/triton/pull/9783, building/linking the example plugins on Windows with MSVC fails due to unresolved LLVM/MLIR symbols at link time. MSVC requires all symbols to be resolved when linking DLLs.

Per review feedback, this PR skips building the example plugin shared libraries on Windows with MSVC. This preserves the CI signal for building the plugins on other platforms.

Note: Triton plugins are not supported on Windows at the moment. This PR does not address that.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is a small fix to disable some build target in a particular situation.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
