### PR TITLE
[AMD] Support per-function PID bounds on TritonIntegerRangeAnalysis (…

### DIFF
--- a/test/TritonGPU/amd/amd-pid-bounds.mlir
+++ b/test/TritonGPU/amd/amd-pid-bounds.mlir
@@ -68,3 +68,148 @@ module attributes {"ttg.num-warps" = 4 : i32, "test.pid-bound-x" = 127 : i64} {
     tt.return
   }
 }
+
+// -----
+
+// Test per-function PID bounds: two functions in the same module with
+// different PID x bounds. Per-function bounds should not leak across functions.
+
+// CHECK-LABEL: tt.func @per_func_bounds_a
+// CHECK-LABEL: tt.func @per_func_bounds_b
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @per_func_bounds_a() attributes {"test.pid-bound-x" = 31 : i64} {
+    // expected-remark@+2 {{unsigned : [0, 31] signed : [0, 31]}}
+    // expected-remark@+1 {{non-neg}}
+    %pid_x = tt.get_program_id x : i32
+    tt.return
+  }
+
+  tt.func @per_func_bounds_b() attributes {"test.pid-bound-x" = 3 : i64} {
+    // expected-remark@+2 {{unsigned : [0, 3] signed : [0, 3]}}
+    // expected-remark@+1 {{non-neg}}
+    %pid_x = tt.get_program_id x : i32
+    tt.return
+  }
+}
+
+// -----
+
+// Test that per-function bounds take precedence over global module bounds.
+// Module sets global pid-bound-x=127, but func overrides to 7.
+
+// CHECK-LABEL: tt.func @per_func_overrides_global
+// CHECK-LABEL: tt.func @uses_global_bound
+module attributes {"ttg.num-warps" = 4 : i32, "test.pid-bound-x" = 127 : i64} {
+  tt.func @per_func_overrides_global() attributes {"test.pid-bound-x" = 7 : i64} {
+    // expected-remark@+2 {{unsigned : [0, 7] signed : [0, 7]}}
+    // expected-remark@+1 {{non-neg}}
+    %pid_x = tt.get_program_id x : i32
+    tt.return
+  }
+
+  tt.func @uses_global_bound() {
+    // expected-remark@+2 {{unsigned : [0, 127] signed : [0, 127]}}
+    // expected-remark@+1 {{non-neg}}
+    %pid_x = tt.get_program_id x : i32
+    tt.return
+  }
+}
+
+// -----
+
+// Test per-function bounds on different axes across functions.
+
+// CHECK-LABEL: tt.func @per_func_x_bound
+// CHECK-LABEL: tt.func @per_func_y_bound
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @per_func_x_bound() attributes {"test.pid-bound-x" = 15 : i64} {
+    // expected-remark@+2 {{unsigned : [0, 15] signed : [0, 15]}}
+    // expected-remark@+1 {{non-neg}}
+    %pid_x = tt.get_program_id x : i32
+    // y has no bound set — should use default
+    // expected-remark@+2 {{unsigned : [0, 2147483647] signed : [0, 2147483647]}}
+    // expected-remark@+1 {{non-neg}}
+    %pid_y = tt.get_program_id y : i32
+    tt.return
+  }
+
+  tt.func @per_func_y_bound() attributes {"test.pid-bound-y" = 7 : i64} {
+    // x has no bound set — should use default
+    // expected-remark@+2 {{unsigned : [0, 2147483647] signed : [0, 2147483647]}}
+    // expected-remark@+1 {{non-neg}}
+    %pid_x = tt.get_program_id x : i32
+    // expected-remark@+2 {{unsigned : [0, 7] signed : [0, 7]}}
+    // expected-remark@+1 {{non-neg}}
+    %pid_y = tt.get_program_id y : i32
+    tt.return
+  }
+}
+
+// -----
+
+// Test per-function bounds with full boundary mask folding.
+// Two functions in the same module: func_a tiles M=1024 with N=32 (PID x
+// bound 31), func_b tiles M=256 with N=64 (PID x bound 3). Each function's
+// mask should fold independently using its own PID bound.
+
+// CHECK-LABEL: tt.func @per_func_fold_mask_a
+// CHECK-LABEL: tt.func @per_func_fold_mask_b
+module attributes {"ttg.num-warps" = 4 : i32} {
+  tt.func @per_func_fold_mask_a() attributes {"test.pid-bound-x" = 31 : i64} {
+    // expected-remark@+2 {{unsigned : [0, 31] signed : [0, 31]}}
+    // expected-remark@+1 {{non-neg}}
+    %pid = tt.get_program_id x : i32
+    // expected-remark@+2 {{unsigned : [32, 32] signed : [32, 32]}}
+    // expected-remark@+1 {{non-neg}}
+    %c32 = arith.constant 32 : i32
+    // expected-remark@+2 {{unsigned : [0, 992] signed : [0, 992]}}
+    // expected-remark@+1 {{non-neg}}
+    %offset = arith.muli %pid, %c32 : i32
+    // expected-remark@+2 {{unsigned : [0, 31] signed : [0, 31]}}
+    // expected-remark@+1 {{non-neg}}
+    %range = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    // expected-remark@+2 {{unsigned : [0, 992] signed : [0, 992]}}
+    // expected-remark@+1 {{non-neg}}
+    %splat = tt.splat %offset : i32 -> tensor<32xi32>
+    // expected-remark@+2 {{unsigned : [0, 1023] signed : [0, 1023]}}
+    // expected-remark@+1 {{non-neg}}
+    %idx = arith.addi %splat, %range : tensor<32xi32>
+    // expected-remark@+2 {{unsigned : [1024, 1024] signed : [1024, 1024]}}
+    // expected-remark@+1 {{non-neg}}
+    %c1024 = arith.constant dense<1024> : tensor<32xi32>
+    // pid*32+[0,31] ∈ [0,1023] < 1024 → always true
+    // expected-remark@+2 {{unsigned : [1, 1] signed : [-1, -1]}}
+    // expected-remark@+1 {{result is true}}
+    %mask = arith.cmpi slt, %idx, %c1024 : tensor<32xi32>
+    tt.return
+  }
+
+  tt.func @per_func_fold_mask_b() attributes {"test.pid-bound-x" = 3 : i64} {
+    // expected-remark@+2 {{unsigned : [0, 3] signed : [0, 3]}}
+    // expected-remark@+1 {{non-neg}}
+    %pid = tt.get_program_id x : i32
+    // expected-remark@+2 {{unsigned : [64, 64] signed : [64, 64]}}
+    // expected-remark@+1 {{non-neg}}
+    %c64 = arith.constant 64 : i32
+    // expected-remark@+2 {{unsigned : [0, 192] signed : [0, 192]}}
+    // expected-remark@+1 {{non-neg}}
+    %offset = arith.muli %pid, %c64 : i32
+    // expected-remark@+2 {{unsigned : [0, 63] signed : [0, 63]}}
+    // expected-remark@+1 {{non-neg}}
+    %range = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    // expected-remark@+2 {{unsigned : [0, 192] signed : [0, 192]}}
+    // expected-remark@+1 {{non-neg}}
+    %splat = tt.splat %offset : i32 -> tensor<64xi32>
+    // expected-remark@+2 {{unsigned : [0, 255] signed : [0, 255]}}
+    // expected-remark@+1 {{non-neg}}
+    %idx = arith.addi %splat, %range : tensor<64xi32>
+    // expected-remark@+2 {{unsigned : [256, 256] signed : [256, 256]}}
+    // expected-remark@+1 {{non-neg}}
+    %c256 = arith.constant dense<256> : tensor<64xi32>
+    // pid*64+[0,63] ∈ [0,255] < 256 → always true
+    // expected-remark@+2 {{unsigned : [1, 1] signed : [-1, -1]}}
+    // expected-remark@+1 {{result is true}}
+    %mask = arith.cmpi slt, %idx, %c256 : tensor<64xi32>
+    tt.return
+  }
+}

--- a/third_party/amd/include/Analysis/RangeAnalysis.h
+++ b/third_party/amd/include/Analysis/RangeAnalysis.h
@@ -41,9 +41,18 @@ struct TritonIntegerRangeAnalysis : dataflow::IntegerRangeAnalysis {
       : dataflow::IntegerRangeAnalysis(solver), assumptions(assumptions),
         domInfo(dominanceInfo), assumeNoArithOverflow(assumeNoArithOverflow_) {}
 
-  /// Set the maximum PID value for a given axis. When set, GetProgramIdOp
-  /// for that axis will use [0, maxPID] instead of the default range.
+  /// Set the maximum PID value for a given axis (global). When set,
+  /// GetProgramIdOp for that axis will use [0, maxPID] instead of the default
+  /// range. Per-function bounds (below) take precedence over global bounds.
   void setPidBound(int axis, int64_t maxPID) { pidBounds[axis] = maxPID; }
+
+  /// Set the maximum PID value for a given axis within a specific function.
+  /// Per-function bounds take precedence over global bounds set via
+  /// setPidBound(axis, maxPID). This is needed when a module contains multiple
+  /// functions with different PID ranges on the same axis.
+  void setPidBound(Operation *funcOp, int axis, int64_t maxPID) {
+    funcPidBounds[funcOp][axis] = maxPID;
+  }
 
   void setToEntryState(dataflow::IntegerValueRangeLattice *lattice) override;
 
@@ -163,9 +172,14 @@ private:
   DominanceInfo *domInfo = nullptr;
   bool assumeNoArithOverflow = false;
 
-  /// Optional per-axis PID bounds. When set via setPidBound(), these override
-  /// the default kDefaultMaxPrograms for GetProgramIdOp on the given axis.
+  /// Optional global per-axis PID bounds. When set via setPidBound(axis, max),
+  /// these override the default kDefaultMaxPrograms for GetProgramIdOp.
   llvm::SmallDenseMap<int, int64_t> pidBounds;
+
+  /// Optional per-function per-axis PID bounds. When set via
+  /// setPidBound(funcOp, axis, max), these take precedence over global
+  /// pidBounds for GetProgramIdOp ops inside that function.
+  llvm::DenseMap<Operation *, llvm::SmallDenseMap<int, int64_t>> funcPidBounds;
 };
 
 std::optional<SmallVector<std::optional<ConstantIntRanges>>>

--- a/third_party/amd/lib/Analysis/RangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/RangeAnalysis.cpp
@@ -543,10 +543,26 @@ LogicalResult TritonIntegerRangeAnalysis::visitOperationHelper(
     llvm::TypeSwitch<Operation *>(op)
         .Case<GetProgramIdOp>([&](auto getPIDOp) {
           int axis = getPIDOp.getAxisAsInt();
-          auto it = pidBounds.find(axis);
-          uint64_t maxPID =
-              it != pidBounds.end() ? it->second : kDefaultMaxPrograms - 1;
-          inferResultRangesPID(getPIDOp, maxPID, joinCallback);
+          // Lookup order: per-function bound > global bound > default.
+          std::optional<uint64_t> maxPID;
+          if (auto parentFunc =
+                  getPIDOp->template getParentOfType<FuncOp>()) {
+            auto funcIt = funcPidBounds.find(parentFunc.getOperation());
+            if (funcIt != funcPidBounds.end()) {
+              auto axisIt = funcIt->second.find(axis);
+              if (axisIt != funcIt->second.end()) {
+                maxPID = axisIt->second;
+              }
+            }
+          }
+          if (!maxPID) {
+            auto it = pidBounds.find(axis);
+            if (it != pidBounds.end()) {
+              maxPID = it->second;
+            }
+          }
+          inferResultRangesPID(
+              getPIDOp, maxPID.value_or(kDefaultMaxPrograms - 1), joinCallback);
         })
         .Case<GetNumProgramsOp>([&](auto getPIDOp) {
           inferResultRangesPID(getPIDOp, kDefaultMaxPrograms, joinCallback);

--- a/third_party/amd/test/lib/Analysis/TestAMDRangeAnalysis.cpp
+++ b/third_party/amd/test/lib/Analysis/TestAMDRangeAnalysis.cpp
@@ -34,14 +34,30 @@ struct TestAMDRangeAnalysisPass
         solver->load<AMD::TritonIntegerRangeAnalysis>(
             assumptions, &getAnalysis<DominanceInfo>());
 
-    // Apply PID bounds from module attributes (e.g. "test.pid-bound-x"=127).
+    // Apply global PID bounds from module attributes
+    // (e.g. "test.pid-bound-x"=127).
     for (auto [axis, name] : llvm::zip(
              SmallVector<int>{0, 1, 2},
              SmallVector<StringRef>{"test.pid-bound-x", "test.pid-bound-y",
                                     "test.pid-bound-z"})) {
-      if (auto attr = mod->getAttrOfType<IntegerAttr>(name))
+      if (auto attr = mod->getAttrOfType<IntegerAttr>(name)) {
         rangeAnalysis->setPidBound(axis, attr.getInt());
+      }
     }
+
+    // Apply per-function PID bounds from function attributes
+    // (e.g. "test.pid-bound-x"=31 on a specific tt.func).
+    mod->walk([&](FuncOp funcOp) {
+      for (auto [axis, name] : llvm::zip(
+               SmallVector<int>{0, 1, 2},
+               SmallVector<StringRef>{"test.pid-bound-x", "test.pid-bound-y",
+                                      "test.pid-bound-z"})) {
+        if (auto attr = funcOp->getAttrOfType<IntegerAttr>(name)) {
+          rangeAnalysis->setPidBound(
+              funcOp.getOperation(), axis, attr.getInt());
+        }
+      }
+    });
 
     AMD::initializeFuncOps(mod, rangeAnalysis);
     if (failed(solver->initializeAndRun(getOperation())))


### PR DESCRIPTION
…#9830)

Add `setPidBound(funcOp, axis, maxPID)` overload to support per-function PID bounds. Per-function bounds take precedence over global bounds.

This is needed when a module contains multiple functions with different PID ranges on the same axis — for example, when boundary mask folding infers different PID bounds for each kernel function in the module. With the existing global `setPidBound(axis, maxPID)`, bounds from one function would leak into others, causing incorrect range inference.

Lookup order for GetProgramIdOp:
  per-function bound > global bound > kDefaultMaxPrograms - 1

The global `setPidBound(axis, maxPID)` API is unchanged and remains the simple path for single-function modules.

Add lit tests verifying:
- Two functions with different bounds on the same axis (no leaking)
- Per-function bound overriding a global module bound
- Different axes across functions

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
