### PR TITLE
[AMD][gfx9] Use asyncmark/wait_asyncmark for CDNA3/CDNA4 buffer_load_to_lds

### DIFF
--- a/test/Conversion/amd/async-ops-alias-scopes.mlir
+++ b/test/Conversion/amd/async-ops-alias-scopes.mlir
@@ -16,7 +16,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     %ptr = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x1x!tt.ptr<f32>, #blocked>
     %mask = tt.splat %maskVal : i1 -> tensor<64x1xi1, #blocked>
 
-    // COMMON: rocdl.global.load.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
+    // COMMON: rocdl.global.load.async.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
     // Check that store for 'other' has alias information set
     // COMMON: llvm.store {{.*}} {alias_scopes = [[[$LOCAL_LOAD_SCOPE]]], {{.*}}, noalias_scopes = [[[$ASYNC_COPY_SCOPE]]]
     %0 = ttg.async_copy_global_to_local %ptr, %arg1 mask %mask other %other : tensor<64x1x!tt.ptr<f32>, #blocked> -> <64x1xf32, #shared, #smem, mutable>
@@ -41,7 +41,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %mask = tt.splat %maskVal : i1 -> tensor<8x64xi1, #blocked>
     %other = arith.constant dense<1.000000e+00> : tensor<8x64xf32, #blocked>
 
-    // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
     // Check that store for 'other' has alias information set
     // COMMON: llvm.store {{.*}} {alias_scopes = [[[$LOCAL_LOAD_SCOPE]]], {{.*}}, noalias_scopes = [[[$ASYNC_COPY_SCOPE]]]
     %65 = amdg.buffer_load_to_local %arg1[%arg2] mask=%mask other=%other into %arg3 : <f32>[tensor<8x64xi32, #blocked>] tensor<8x64xf32, #blocked> -> <8x64xf32, #shared, #smem, mutable>
@@ -107,7 +107,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     // We need the splat to allow the AxisAnalysis to work during lowering
     %ptr = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x1x!tt.ptr<f32>, #blocked>
 
-    // COMMON: rocdl.global.load.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
+    // COMMON: rocdl.global.load.async.lds {{.*}} {alias_scopes = [[[$ASYNC_COPY_SCOPE]]]
     %0 = ttg.async_copy_global_to_local %ptr, %arg1 : tensor<64x1x!tt.ptr<f32>, #blocked> -> <64x1xf32, #shared, #smem, mutable>
     %1 = ttg.async_commit_group tokens %0
 

--- a/test/Conversion/amd/async_ops_to_llvm.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm.mlir
@@ -1,5 +1,5 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s --check-prefix=GFX950
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --verify-diagnostics | FileCheck %s
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
@@ -11,9 +11,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
                                 %arg2: !ttg.memdesc<32x64xf32, #shared, #smem, mutable>) {
     // We need the splat to allow the AxisAnalysis to work during lowering
     %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>, #blocked>
-    // Each thread needs to load 8 elements and we load 1 (sizePerThread) per global.load.lds
-    // CHECK-COUNT-8: rocdl.global.load.lds
-    // CHECK-NOT: rocdl.global.load.lds
+    // Each thread needs to load 8 elements and we load 1 (sizePerThread) per load.
+    // CDNA3/CDNA4 use the async variant so LLVM tracks via asyncmark.
+    // CHECK-COUNT-8: rocdl.global.load.async.lds
+    // CHECK-NOT: rocdl.global.load.async.lds
     %2 = ttg.async_copy_global_to_local %1, %arg2 : tensor<32x64x!tt.ptr<f32>, #blocked> -> <32x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -31,9 +32,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
                                 %arg2: !ttg.memdesc<32x64xf32, #shared, #smem, mutable>) {
     // We need the splat to allow the AxisAnalysis to work during lowering
     %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>, #blocked>
-    // Each thread needs to load 8 elements and we load 1 () per global.load.lds
-    // CHECK-COUNT-8: rocdl.global.load.lds
-    // CHECK-NOT: rocdl.global.load.lds
+    // Each thread needs to load 8 elements and we load 1 () per load
+    // CHECK-COUNT-8: rocdl.global.load.async.lds
+    // CHECK-NOT: rocdl.global.load.async.lds
     %2 = ttg.async_copy_global_to_local %1, %arg2 : tensor<32x64x!tt.ptr<f32>, #blocked> -> <32x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -56,9 +57,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %4 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x64x!tt.ptr<f16>, #blocked>
     %5 = tt.addptr %4, %3 : tensor<32x64x!tt.ptr<f16>, #blocked>, tensor<32x64xi32, #blocked>
 
-    // Each thread needs to load 8 elements and we load 2 (sizePerThread) per global.load.lds
-    // CHECK-COUNT-4: rocdl.global.load.lds
-    // CHECK-NOT: rocdl.global.load.lds
+    // Each thread needs to load 8 elements and we load 2 (sizePerThread) per load
+    // CHECK-COUNT-4: rocdl.global.load.async.lds
+    // CHECK-NOT: rocdl.global.load.async.lds
     %6 = ttg.async_copy_global_to_local %5, %arg2 : tensor<32x64x!tt.ptr<f16>, #blocked> -> <32x64xf16, #shared, #smem, mutable>
     tt.return
   }
@@ -66,63 +67,35 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
-  // GFX950-LABEL: async_copy_vectorized_8xf16
-  tt.func public @async_copy_vectorized_8xf16(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
-                                %arg1: i32 {tt.divisibility = 16 : i32},
-                                %arg2: !ttg.memdesc<32x64xf16, #shared, #smem, mutable>) {
-    // We need the index calculation so AxisAnalysis sees that we can vectorize the load
-    %1 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
-    %2 = tt.expand_dims %1 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
-    %3 = tt.broadcast %2 : tensor<1x64xi32, #blocked> -> tensor<32x64xi32, #blocked>
-    %4 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x64x!tt.ptr<f16>, #blocked>
-    %5 = tt.addptr %4, %3 : tensor<32x64x!tt.ptr<f16>, #blocked>, tensor<32x64xi32, #blocked>
-
-    // Each thread needs to load 8 elements and we load 8 (sizePerThread) per global.load.lds
-    // GFX950: rocdl.global.load.lds
-    // GFX950-next: llvm.return
-
-    // GFX942 does not support vectorization > 4bytes
-    // expected-error@+1 {{failed to legalize operation 'ttg.async_copy_global_to_local' that was explicitly marked illegal}}
-    %6 = ttg.async_copy_global_to_local %5, %arg2 : tensor<32x64x!tt.ptr<f16>, #blocked> -> <32x64xf16, #shared, #smem, mutable>
-    tt.return
-  }
-}
-
-// -----
+// NOTE: The async_copy_vectorized_8xf16 test (GFX950 supports 8-byte loads,
+// GFX942 does not) has been moved to async_ops_to_llvm_errors.mlir to avoid
+// split-input-file issues with expected-error annotations across arch runs.
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   // CHECK-LABEL: async_wait
+  // GFX950-LABEL: async_wait
   tt.func public @async_wait(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
                              %arg1: i32 {tt.divisibility = 16 : i32},
                              %arg2: !ttg.memdesc<32x64xf16, #shared, #smem, mutable>) {
-    // The waitcnt stores all counters in one i32 bits 15:14 and 3:0 store the vmcnt we have to wait on
-    // CHECK: rocdl.s.waitcnt -49168
-    // CHECK: rocdl.s.waitcnt 49279
-    // CHECK: rocdl.s.barrier
+    // CDNA3/CDNA4 use wait_asyncmark instead of s_waitcnt
+    // CHECK: rocdl.wait.asyncmark 0
+    // GFX950: rocdl.wait.asyncmark 0
     amdg.async_wait {num_inst = 0 : i32}
-    // CHECK: rocdl.s.waitcnt -49167
-    // CHECK: rocdl.s.waitcnt 49279
-    // CHECK: rocdl.s.barrier
+    // CHECK: rocdl.wait.asyncmark 1
+    // GFX950: rocdl.wait.asyncmark 1
     amdg.async_wait {num_inst = 1 : i32}
-    // CHECK: rocdl.s.waitcnt -2
-    // CHECK: rocdl.s.waitcnt 49279
-    // CHECK: rocdl.s.barrier
+    // CHECK: rocdl.wait.asyncmark 62
+    // GFX950: rocdl.wait.asyncmark 62
     amdg.async_wait {num_inst = 62 : i32}
-    // CHECK: rocdl.s.waitcnt -1
-    // CHECK: rocdl.s.waitcnt 49279
-    // CHECK: rocdl.s.barrier
+    // CHECK: rocdl.wait.asyncmark 63
+    // GFX950: rocdl.wait.asyncmark 63
     amdg.async_wait {num_inst = 63 : i32}
     // Check that we clamp values > 63
-    // CHECK: rocdl.s.waitcnt -1
-    // CHECK: rocdl.s.waitcnt 49279
-    // CHECK: rocdl.s.barrier
+    // CHECK: rocdl.wait.asyncmark 63
+    // GFX950: rocdl.wait.asyncmark 63
     amdg.async_wait {num_inst = 64 : i32}
     tt.return
   }
@@ -133,13 +106,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   // CHECK-LABEL: async_commit_group
+  // GFX950-LABEL: async_commit_group
   tt.func public @async_commit_group(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
                                      %arg1: i32 {tt.divisibility = 16 : i32},
                                      %arg2: !ttg.memdesc<32x64xf16, #shared, #smem, mutable>) {
+    // CDNA3/CDNA4 emit asyncmark for async group tracking
+    // CHECK: rocdl.asyncmark
     // CHECK: llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT: llvm.return
+    // GFX950: rocdl.asyncmark
+    // GFX950: llvm.mlir.constant(0 : i32) : i32
+    // GFX950-NEXT: llvm.return
     ttg.async_commit_group
     tt.return
   }
@@ -179,25 +158,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // Note that mask/other alignment is 1 so we need 4 conditionals
 
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
 
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
 
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
 
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
@@ -243,7 +222,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: rocdl.ds_bpermute
     // CHECK: rocdl.ballot
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
@@ -251,7 +230,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: rocdl.ds_bpermute
     // CHECK: rocdl.ballot
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
@@ -259,7 +238,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: rocdl.ds_bpermute
     // CHECK: rocdl.ballot
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
@@ -267,7 +246,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: rocdl.ds_bpermute
     // CHECK: rocdl.ballot
     // CHECK: llvm.cond_br
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     // CHECK-NEXT: llvm.br
     // CHECK: llvm.cond_br
     // CHECK: llvm.store
@@ -292,13 +271,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 16 : i32, ttg.sha
     // Each thread needs to load 1 element and we load 1 (sizePerThread) per global.load.lds
 
     // CHECK: llvm.getelementptr
-    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, 4, 0, 0
+    // CHECK: rocdl.global.load.async.lds {{.*}}, {{.*}}, 4, 0, 0
     %2 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = ca: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
     // CHECK: llvm.getelementptr
-    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, 4, 0, 3
+    // CHECK: rocdl.global.load.async.lds {{.*}}, {{.*}}, 4, 0, 3
     %3 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cg: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
     // CHECK: llvm.getelementptr
-    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, 4, 0, 17
+    // CHECK: rocdl.global.load.async.lds {{.*}}, {{.*}}, 4, 0, 17
     %4 = ttg.async_copy_global_to_local %1, %arg2 cacheModifier = cv: tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -313,7 +292,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // CHECK-LABEL: async_copy_contiguity_hint
   tt.func @async_copy_contiguity_hint(%v: tensor<256x!tt.ptr<f16>, #blocked>, %smem: !ttg.memdesc<256xf16, #shared1D, #smem, mutable>) {
     // Check we load 4 bytes at a time
-    // CHECK: rocdl.global.load.lds {{.*}}, {{.*}}, 4
+    // CHECK: rocdl.global.load.async.lds {{.*}}, {{.*}}, 4
     %0 = ttg.async_copy_global_to_local %v, %smem {contiguity = 2 : i32} : tensor<256x!tt.ptr<f16>, #blocked> -> !ttg.memdesc<256xf16, #shared1D, #smem, mutable>
     tt.return
   }
@@ -332,7 +311,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>, #blocked>
     %2 = ttg.memdesc_subslice %arg2 [0, 0]  : !ttg.memdesc<32x128xf32, #shared, #smem, mutable> -> !ttg.memdesc<32x64xf32, #shared, #smem, mutable, 32x128>
     // We slice in the fastest dim but each warp loads one row, therefore we can write coalesced into LDS
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     %3 = ttg.async_copy_global_to_local %1, %2 : tensor<32x64x!tt.ptr<f32>, #blocked> -> <32x64xf32, #shared, #smem, mutable, 32x128>
     tt.return
   }
@@ -351,7 +330,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x32x!tt.ptr<f32>, #blocked>
     %2 = ttg.memdesc_subslice %arg2 [0, 0]  : !ttg.memdesc<64x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable, 64x32>
     // We slice into the slowest dim which does not break coalesced writes into LDS
-    // CHECK: rocdl.global.load.lds
+    // CHECK: rocdl.global.load.async.lds
     %3 = ttg.async_copy_global_to_local %1, %2 : tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable, 64x32>
     tt.return
   }

--- a/test/Conversion/amd/async_ops_to_llvm.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm.mlir
@@ -67,10 +67,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
-// NOTE: The async_copy_vectorized_8xf16 test (GFX950 supports 8-byte loads,
-// GFX942 does not) has been moved to async_ops_to_llvm_errors.mlir to avoid
-// split-input-file issues with expected-error annotations across arch runs.
-
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
@@ -80,23 +76,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   tt.func public @async_wait(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
                              %arg1: i32 {tt.divisibility = 16 : i32},
                              %arg2: !ttg.memdesc<32x64xf16, #shared, #smem, mutable>) {
-    // CDNA3/CDNA4 use wait_asyncmark instead of s_waitcnt
+    // CDNA3/CDNA4 lower ttg.async_wait directly to wait_asyncmark.
+    // The commit group count is passed through without clamping since
+    // LLVM will compute the final waitcnt.
     // CHECK: rocdl.wait.asyncmark 0
     // GFX950: rocdl.wait.asyncmark 0
-    amdg.async_wait {num_inst = 0 : i32}
+    ttg.async_wait {num = 0 : i32}
     // CHECK: rocdl.wait.asyncmark 1
     // GFX950: rocdl.wait.asyncmark 1
-    amdg.async_wait {num_inst = 1 : i32}
+    ttg.async_wait {num = 1 : i32}
     // CHECK: rocdl.wait.asyncmark 62
     // GFX950: rocdl.wait.asyncmark 62
-    amdg.async_wait {num_inst = 62 : i32}
+    ttg.async_wait {num = 62 : i32}
     // CHECK: rocdl.wait.asyncmark 63
     // GFX950: rocdl.wait.asyncmark 63
-    amdg.async_wait {num_inst = 63 : i32}
-    // Check that we clamp values > 63
-    // CHECK: rocdl.wait.asyncmark 63
-    // GFX950: rocdl.wait.asyncmark 63
-    amdg.async_wait {num_inst = 64 : i32}
+    ttg.async_wait {num = 63 : i32}
+    // No clamping — LLVM handles it based on instruction count
+    // CHECK: rocdl.wait.asyncmark 64
+    // GFX950: rocdl.wait.asyncmark 64
+    ttg.async_wait {num = 64 : i32}
     tt.return
   }
 }

--- a/test/Conversion/amd/async_ops_to_llvm_errors.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm_errors.mlir
@@ -1,0 +1,22 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --verify-diagnostics
+
+// GFX942 does not support vectorization > 4bytes for direct-to-LDS loads
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @async_copy_vectorized_8xf16_error(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                %arg1: i32 {tt.divisibility = 16 : i32},
+                                %arg2: !ttg.memdesc<32x64xf16, #shared, #smem, mutable>) {
+    %1 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %2 = tt.expand_dims %1 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %3 = tt.broadcast %2 : tensor<1x64xi32, #blocked> -> tensor<32x64xi32, #blocked>
+    %4 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x64x!tt.ptr<f16>, #blocked>
+    %5 = tt.addptr %4, %3 : tensor<32x64x!tt.ptr<f16>, #blocked>, tensor<32x64xi32, #blocked>
+
+    // expected-error@+1 {{failed to legalize operation 'ttg.async_copy_global_to_local' that was explicitly marked illegal}}
+    %6 = ttg.async_copy_global_to_local %5, %arg2 : tensor<32x64x!tt.ptr<f16>, #blocked> -> <32x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
+++ b/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
@@ -13,8 +13,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // Each thread needs to load 8 elements and we load 1 (sizePerThread) per buffer load instruction
     // COMMON: rocdl.make.buffer.rsrc
     // COMMON-NOT: rocdl.make.buffer.rsrc
-    // COMMON-COUNT-8: rocdl.raw.ptr.buffer.load.lds
-    // COMMON-NOT: rocdl.raw.ptr.buffer.load.lds
+    // COMMON-COUNT-8: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
     %65 = amdg.buffer_load_to_local %arg1[%arg2] into %arg3 : <f32>[tensor<32x64xi32, #blocked>] -> <32x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -41,8 +41,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, ttg.sha
     // Each thread needs to load 2 elements and we load 2 (sizePerThread) per buffer load instruction
     // COMMON: rocdl.make.buffer.rsrc
     // COMMON-NOT: rocdl.make.buffer.rsrc
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON-NOT: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
     %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
     tt.return
   }
@@ -69,11 +69,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, ttg.sha
     // Each thread needs to load 8 elements and we load 8 (sizePerThread) per buffer load instruction
     // GFX950: rocdl.make.buffer.rsrc
     // GFX950-NOT: rocdl.make.buffer.rsrc
-    // GFX950: rocdl.raw.ptr.buffer.load.lds
-    // GFX950-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX950: rocdl.raw.ptr.buffer.load.async.lds
+    // GFX950-NOT: rocdl.raw.ptr.buffer.load.async.lds
 
     // GFX942 does not support vectorization > 4bytes so we cannot lower it
-    // GFX942-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX942-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // GFX942: amdg.buffer_load_to_local
     %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
     tt.return
@@ -101,11 +101,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // Each thread needs to load 8 elements and we load 8 (sizePerThread) per buffer load instruction
     // GFX950: rocdl.make.buffer.rsrc
     // GFX950-NOT: rocdl.make.buffer.rsrc
-    // GFX950: rocdl.raw.ptr.buffer.load.lds
-    // GFX950-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX950: rocdl.raw.ptr.buffer.load.async.lds
+    // GFX950-NOT: rocdl.raw.ptr.buffer.load.async.lds
 
     // GFX942 does not support vectorization > 4bytes so we cannot lower it
-    // GFX942-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX942-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // GFX942: amdg.buffer_load_to_local
     %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<256x8xi32, #blocked>]  -> <256x8xf16, #shared, #smem, mutable>
     tt.return
@@ -146,7 +146,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // Each thread needs to load 4 elements and we load 1 (sizePerThread) per buffer load instruction
     // Note that mask/other alignment is 1 so we need 4 conditionals
 
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
@@ -154,19 +154,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // COMMON: [[AND:%.*]] = llvm.and
     // COMMON: llvm.cond_br [[AND]]
 
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
-    // COMMON-NOT: rocdl.raw.ptr.buffer.load.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON-NOT: _predicated_store
     // COMMON-NOT: llvm.cond_br
     // COMMON-NOT: llvm.store
@@ -191,15 +191,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // COMMON-NEXT: %[[IMM0:.*]] = llvm.mlir.constant(0 : i32) : i32
     // COMMON-NEXT: %[[aux_ca:.*]] = llvm.mlir.constant(0 : i32) : i32
     // COMMON-NEXT: %[[IMM1:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // COMMON-NEXT: rocdl.raw.ptr.buffer.load.lds {{.*}}, {{.*}}, {{.*}}, %[[VOFFSET]], %[[IMM1]], %[[IMM0]], %[[aux_ca]]
+    // COMMON-NEXT: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, %[[VOFFSET]], %[[IMM1]], %[[IMM0]], %[[aux_ca]]
     %1 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = ca into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     // COMMON: llvm.getelementptr
     // COMMON: %[[aux_cg:.*]] = llvm.mlir.constant(3 : i32) : i32
-    // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cg]]
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cg]]
     %2 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = cg into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
     // COMMON: llvm.getelementptr
     // COMMON: %[[aux_cv:.*]] = llvm.mlir.constant(17 : i32) : i32
-    // COMMON: rocdl.raw.ptr.buffer.load.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cv]]
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux_cv]]
     %3 = amdg.buffer_load_to_local %arg0[%0] cacheModifier = cv into %arg2: <f32>[tensor<64xi32, #blocked>] -> <64xf32, #shared, #smem, mutable>
 
     tt.return
@@ -221,10 +221,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // COMMON: rocdl.make.buffer.rsrc
     // COMMON-NOT: rocdl.make.buffer.rsrc
     // COMMON: rocdl.ds_bpermute
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: rocdl.ds_bpermute
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON-NOT: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
     %65 = amdg.buffer_load_to_local %arg1[%arg2] into %arg3 : <f32>[tensor<16x64xi32, #blocked>] -> <16x64xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -266,31 +266,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
-    // COMMON: rocdl.raw.ptr.buffer.load.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON: llvm.cond_br
     // COMMON: llvm.store
 
     // COMMON-NOT: rocdl.ds_bpermute
     // COMMON-NOT: rocdl.ballot
-    // COMMON-NOT: rocdl.raw.ptr.buffer.load.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // COMMON-NOT: _predicated_store
 
     amdg.buffer_load_to_local %arg1[%arg2] mask=%67 other=%cst_0 into %arg3 : <f32>[tensor<32x32xi32, #blocked>] tensor<32x32xf32, #blocked>  -> <32x32xf32, #shared, #smem, mutable>
@@ -318,11 +318,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 32 : i32, ttg.sha
 
     // Each thread needs to load 8 elements and we load 8 (sizePerThread) per buffer load instruction
     // GFX950: rocdl.make.buffer.rsrc
-    // GFX950: rocdl.raw.ptr.buffer.load.lds
-    // GFX950-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX950: rocdl.raw.ptr.buffer.load.async.lds
+    // GFX950-NOT: rocdl.raw.ptr.buffer.load.async.lds
 
     // GFX942 does not support vectorization > 4bytes so we cannot lower it
-    // GFX942-NOT: rocdl.raw.ptr.buffer.load.lds
+    // GFX942-NOT: rocdl.raw.ptr.buffer.load.async.lds
     // GFX942: amdg.buffer_load_to_local
     %8 = amdg.buffer_load_to_local %arg1[%7] into %arg2 : <f16>[tensor<64x64xi32, #blocked>]  -> <64x64xf16, #shared, #smem, mutable>
     tt.return
@@ -339,7 +339,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   tt.func @buffer_load_to_local_contiguity_hint(%ptr: !tt.ptr<f16>, %off: tensor<256xi32, #blocked>, %lds: !ttg.memdesc<256xf16, #shared1D, #smem, mutable>) {
     // Check we load 4 bytes
     // COMMON: %[[LOAD_BYTES:.*]] = llvm.mlir.constant(4 : i32) : i32
-    // COMMON: rocdl.raw.ptr.buffer.load.lds %{{.*}}, %{{.*}}, %[[LOAD_BYTES]]
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds %{{.*}}, %{{.*}}, %[[LOAD_BYTES]]
     %0 = amdg.buffer_load_to_local %ptr[%off] into %lds {contiguity = 2 : i32} : <f16>[tensor<256xi32, #blocked>] -> <256xf16, #shared1D, #smem, mutable>
     tt.return
   }

--- a/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
@@ -25,10 +25,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     // CHECK: amdg.async_wait {num_inst = 0
     ttg.async_wait {num = 0 : i32}
-    // CHECK: amdg.async_wait {num_inst = 2
+    // CHECK: amdg.async_wait {num_inst = 1
     ttg.async_wait {num = 1 : i32}
     // Check we stop at function boundary
-    // CHECK: amdg.async_wait {num_inst = 3
+    // CHECK: amdg.async_wait {num_inst = 2
     ttg.async_wait {num = 2 : i32}
     // CHECK: amdg.async_wait {num_inst = 3
     ttg.async_wait {num = 3 : i32}
@@ -48,10 +48,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.async_copy_global_to_local %ptr1Inst, %memDesc1Inst : tensor<64x16x!tt.ptr<f16>, #blocked> -> <64x16xf16, #shared, #smem, mutable>
 
     // We expect 1 because the async copy above has not been committed yet
-    // CHECK: amdg.async_wait {num_inst = 1
+    // CHECK: amdg.async_wait {num_inst = 0
     ttg.async_wait {num = 0 : i32}
     // -1 can be used to wait on all, even non committed async ops
-    // CHECK: amdg.async_wait {num_inst = 0
+    // CHECK: amdg.async_wait {num_inst = -1
     ttg.async_wait {num = -1 : i32}
 
     tt.return
@@ -86,7 +86,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: amdg.async_wait {num_inst = 1
     ttg.async_wait {num = 1: i32}
 
-    // CHECK: amdg.async_wait {num_inst = 3
+    // CHECK: amdg.async_wait {num_inst = 2
     ttg.async_wait {num = 2: i32}
 
 
@@ -113,7 +113,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: amdg.async_wait {num_inst = 1
     ttg.async_wait {num = 1: i32}
     // Check we do not loop in an if but instead continue upwards
-    // CHECK: amdg.async_wait {num_inst = 1
+    // CHECK: amdg.async_wait {num_inst = 2
     ttg.async_wait {num = 2: i32}
 
     scf.if %cond {
@@ -166,7 +166,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       scf.yield
     }
     // The shortest path (else->then) contains 2 async ops -> instruction count 2
-    // CHECK: amdg.async_wait {num_inst = 2
+    // CHECK: amdg.async_wait {num_inst = 1
     ttg.async_wait {num = 1: i32}
 
     tt.return
@@ -216,7 +216,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.async_commit_group
     ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     ttg.async_commit_group
-    // CHECK: amdg.async_wait {num_inst = 6
+    // CHECK: amdg.async_wait {num_inst = 3
     ttg.async_wait {num = 3: i32}
 
     scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 : i32 {
@@ -263,14 +263,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // The loop has 3 commits group which produce 2,1,1 (in program order) async instructions
     scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 : i32 {
       // 2 full loop iterations => 8
-      // CHECK: amdg.async_wait {num_inst = 8
+      // CHECK: amdg.async_wait {num_inst = 6
       ttg.async_wait {num = 6: i32}
 
       ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       ttg.async_commit_group
 
       // Wait on 1 full loop iteration (4) + the commit group above (2)
-      // CHECK: amdg.async_wait {num_inst = 6
+      // CHECK: amdg.async_wait {num_inst = 4
       ttg.async_wait {num = 4: i32}
 
       scf.if %cond {
@@ -288,13 +288,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       ttg.async_commit_group
 
       // Wait on 1 full loop iteration (4) + the commit group above (1)
-      // CHECK: amdg.async_wait {num_inst = 5
+      // CHECK: amdg.async_wait {num_inst = 4
       ttg.async_wait {num = 4: i32}
 
       scf.yield
     }
     // 2 Full loop iterations (2 * 4)
-    // CHECK: amdg.async_wait {num_inst = 8
+    // CHECK: amdg.async_wait {num_inst = 6
     ttg.async_wait {num = 6: i32}
 
     tt.return
@@ -316,16 +316,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     ttg.async_commit_group
     %69 = scf.while (%arg10 = %cond) : (i1) -> (i1) {
-      // CHECK: amdg.async_wait {num_inst = 2
+      // CHECK: amdg.async_wait {num_inst = 1
       ttg.async_wait {num = 1: i32}
       scf.condition(%arg10) %arg10 : i1
     } do {
     ^bb0(%arg12: i1):
-      // CHECK: amdg.async_wait {num_inst = 2
+      // CHECK: amdg.async_wait {num_inst = 1
       ttg.async_wait {num = 1: i32}
       scf.yield %arg12 : i1
     }
-    // CHECK: amdg.async_wait {num_inst = 2
+    // CHECK: amdg.async_wait {num_inst = 1
     ttg.async_wait {num = 1: i32}
 
     tt.return
@@ -347,7 +347,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.async_commit_group
     ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     ttg.async_commit_group
-    // CHECK: amdg.async_wait {num_inst = 6
+    // CHECK: amdg.async_wait {num_inst = 3
     ttg.async_wait {num = 3: i32}
 
     %70 = scf.while (%arg10 = %cond) : (i1) -> (i1) {
@@ -387,7 +387,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.async_commit_group
     ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     ttg.async_commit_group
-    // CHECK: amdg.async_wait {num_inst = 6
+    // CHECK: amdg.async_wait {num_inst = 3
     ttg.async_wait {num = 3: i32}
 
     %71 = scf.while (%arg10 = %cond) : (i1) -> (i1) {
@@ -449,7 +449,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     } do {
     ^bb0(%arg12: i1):
       // 1 commit group in Before-block + 5 commits groups in prologue = 7
-      // CHECK: amdg.async_wait {num_inst = 7
+      // CHECK: amdg.async_wait {num_inst = 6
       ttg.async_wait {num = 6: i32}
       ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       ttg.async_commit_group
@@ -460,7 +460,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         // 2 Instructions
         ttg.async_commit_group
         // 1 commit group(2) to escape for, 1 commits group(2) in rest of while after block, 1 commit group (2) in while before block and 3 commits group in prologue = 9
-        // CHECK: amdg.async_wait {num_inst = 9
+        // CHECK: amdg.async_wait {num_inst = 6
         ttg.async_wait {num = 6: i32}
 
         scf.if %cond {
@@ -468,7 +468,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
           ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
 
           // Same as above but we also have to count the 2 async_copies above = 9+3
-          // CHECK: amdg.async_wait {num_inst = 12
+          // CHECK: amdg.async_wait {num_inst = 6
           ttg.async_wait {num = 6: i32}
         } else {
           ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
@@ -482,11 +482,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
           // 3 Instructions
           ttg.async_commit_group
           // 1 commit group (3) in this block, 2 commits group in the rest of the for body (2+2), 1 commits group(2) in rest of while after block, 1 commit group (2) in while before block, 1 commit group (1) in epilogue = 12
-          // CHECK: amdg.async_wait {num_inst = 12
+          // CHECK: amdg.async_wait {num_inst = 6
           ttg.async_wait {num = 6: i32}
         }
         // Same as above but skips the if (first commit group(3)) and instead counts one more in the prologue (1) = 10
-        // CHECK: amdg.async_wait {num_inst = 10
+        // CHECK: amdg.async_wait {num_inst = 6
         ttg.async_wait {num = 6: i32}
         scf.for %arg15 = %c0_i32 to %arg0 step %c1_i32 : i32 {
           ttg.async_copy_global_to_local %ptr1Inst, %memDesc1Inst : tensor<64x16x!tt.ptr<f16>, #blocked> -> <64x16xf16, #shared, #smem, mutable>
@@ -496,19 +496,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
           // 2 Instructions
           ttg.async_commit_group
           // Just staying in the loop is the lowest path (3 per iteration and we do 3 iterations)
-          // CHECK: amdg.async_wait {num_inst = 9
+          // CHECK: amdg.async_wait {num_inst = 6
           ttg.async_wait {num = 6: i32}
           scf.yield
         }
         // Just stay in the inner loop for the lowest path
-        // CHECK: amdg.async_wait {num_inst = 9
+        // CHECK: amdg.async_wait {num_inst = 6
         ttg.async_wait {num = 6: i32}
         scf.yield
       }
       scf.yield %arg12 : i1
     }
     // While before-body (2) + 5 prologue groups = 7
-    // CHECK: amdg.async_wait {num_inst = 7
+    // CHECK: amdg.async_wait {num_inst = 6
     ttg.async_wait {num = 6: i32}
 
     tt.return
@@ -538,22 +538,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       } {triton.warp_pipeline.stage = "stage1"}
 
       // Wait for both execute regions
-      // CHECK: amdg.async_wait {num_inst = 3
+      // CHECK: amdg.async_wait {num_inst = 2
       ttg.async_wait {num = 2 : i32}
 
       // Check that we only traverse each execute region once
-      // CHECK: amdg.async_wait {num_inst = 3
+      // CHECK: amdg.async_wait {num_inst = 6
       ttg.async_wait {num = 6 : i32}
 
       // Wait only for the second execute region
-      // CHECK: amdg.async_wait {num_inst = 2
+      // CHECK: amdg.async_wait {num_inst = 1
       ttg.async_wait {num = 1 : i32}
 
       scf.yield
     }
 
     // Wait for both nested execute regions
-    // CHECK: amdg.async_wait {num_inst = 3
+    // CHECK: amdg.async_wait {num_inst = 2
     ttg.async_wait {num = 2 : i32}
 
     tt.return

--- a/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx950 | FileCheck %s
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx1250 | FileCheck %s
 
 // The number in SSA symbolic names represents the number of generated async load operation at assembly level a ttg.async_copy_global_to_local will generate, which is counted by this pass.
 // For example `ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst ..` will generate two global_load_async_to_lds_b128 assembly instruction
@@ -25,11 +25,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     // CHECK: amdg.async_wait {num_inst = 0
     ttg.async_wait {num = 0 : i32}
-    // CHECK: amdg.async_wait {num_inst = 1
-    ttg.async_wait {num = 1 : i32}
-    // Check we stop at function boundary
+    // 1 outstanding commit group (2nd): 2 instructions
     // CHECK: amdg.async_wait {num_inst = 2
+    ttg.async_wait {num = 1 : i32}
+    // 2 outstanding commit groups: 2 + 1 = 3 instructions
+    // CHECK: amdg.async_wait {num_inst = 3
     ttg.async_wait {num = 2 : i32}
+    // Only 2 commit groups exist, stop at function boundary
     // CHECK: amdg.async_wait {num_inst = 3
     ttg.async_wait {num = 3 : i32}
 
@@ -47,11 +49,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Emit 1 instruction
     ttg.async_copy_global_to_local %ptr1Inst, %memDesc1Inst : tensor<64x16x!tt.ptr<f16>, #blocked> -> <64x16xf16, #shared, #smem, mutable>
 
-    // We expect 1 because the async copy above has not been committed yet
-    // CHECK: amdg.async_wait {num_inst = 0
+    // No commit groups found, walk to function boundary: 1 instruction
+    // CHECK: amdg.async_wait {num_inst = 1
     ttg.async_wait {num = 0 : i32}
-    // -1 can be used to wait on all, even non committed async ops
-    // CHECK: amdg.async_wait {num_inst = -1
+    // -1 means wait on all — immediate stop → conservative 0
+    // CHECK: amdg.async_wait {num_inst = 0
     ttg.async_wait {num = -1 : i32}
 
     tt.return
@@ -86,7 +88,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: amdg.async_wait {num_inst = 1
     ttg.async_wait {num = 1: i32}
 
-    // CHECK: amdg.async_wait {num_inst = 2
+    // CHECK: amdg.async_wait {num_inst = 3
     ttg.async_wait {num = 2: i32}
 
 
@@ -113,7 +115,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: amdg.async_wait {num_inst = 1
     ttg.async_wait {num = 1: i32}
     // Check we do not loop in an if but instead continue upwards
-    // CHECK: amdg.async_wait {num_inst = 2
+    // CHECK: amdg.async_wait {num_inst = 1
     ttg.async_wait {num = 2: i32}
 
     scf.if %cond {
@@ -166,7 +168,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       scf.yield
     }
     // The shortest path (else->then) contains 2 async ops -> instruction count 2
-    // CHECK: amdg.async_wait {num_inst = 1
+    // CHECK: amdg.async_wait {num_inst = 2
     ttg.async_wait {num = 1: i32}
 
     tt.return
@@ -216,7 +218,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.async_commit_group
     ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     ttg.async_commit_group
-    // CHECK: amdg.async_wait {num_inst = 3
+    // 3 outstanding commit groups, each ptr2Inst emits 2 instr → 6
+    // CHECK: amdg.async_wait {num_inst = 6
     ttg.async_wait {num = 3: i32}
 
     scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 : i32 {
@@ -263,14 +266,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // The loop has 3 commits group which produce 2,1,1 (in program order) async instructions
     scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 : i32 {
       // 2 full loop iterations => 8
-      // CHECK: amdg.async_wait {num_inst = 6
+      // CHECK: amdg.async_wait {num_inst = 8
       ttg.async_wait {num = 6: i32}
 
       ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       ttg.async_commit_group
 
       // Wait on 1 full loop iteration (4) + the commit group above (2)
-      // CHECK: amdg.async_wait {num_inst = 4
+      // CHECK: amdg.async_wait {num_inst = 6
       ttg.async_wait {num = 4: i32}
 
       scf.if %cond {
@@ -288,13 +291,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       ttg.async_commit_group
 
       // Wait on 1 full loop iteration (4) + the commit group above (1)
-      // CHECK: amdg.async_wait {num_inst = 4
+      // CHECK: amdg.async_wait {num_inst = 5
       ttg.async_wait {num = 4: i32}
 
       scf.yield
     }
     // 2 Full loop iterations (2 * 4)
-    // CHECK: amdg.async_wait {num_inst = 6
+    // CHECK: amdg.async_wait {num_inst = 8
     ttg.async_wait {num = 6: i32}
 
     tt.return
@@ -316,16 +319,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     ttg.async_commit_group
     %69 = scf.while (%arg10 = %cond) : (i1) -> (i1) {
-      // CHECK: amdg.async_wait {num_inst = 1
+      // CHECK: amdg.async_wait {num_inst = 2
       ttg.async_wait {num = 1: i32}
       scf.condition(%arg10) %arg10 : i1
     } do {
     ^bb0(%arg12: i1):
-      // CHECK: amdg.async_wait {num_inst = 1
+      // CHECK: amdg.async_wait {num_inst = 2
       ttg.async_wait {num = 1: i32}
       scf.yield %arg12 : i1
     }
-    // CHECK: amdg.async_wait {num_inst = 1
+    // CHECK: amdg.async_wait {num_inst = 2
     ttg.async_wait {num = 1: i32}
 
     tt.return
@@ -347,7 +350,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.async_commit_group
     ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     ttg.async_commit_group
-    // CHECK: amdg.async_wait {num_inst = 3
+    // CHECK: amdg.async_wait {num_inst = 6
     ttg.async_wait {num = 3: i32}
 
     %70 = scf.while (%arg10 = %cond) : (i1) -> (i1) {
@@ -387,7 +390,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.async_commit_group
     ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     ttg.async_commit_group
-    // CHECK: amdg.async_wait {num_inst = 3
+    // CHECK: amdg.async_wait {num_inst = 6
     ttg.async_wait {num = 3: i32}
 
     %71 = scf.while (%arg10 = %cond) : (i1) -> (i1) {
@@ -449,7 +452,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     } do {
     ^bb0(%arg12: i1):
       // 1 commit group in Before-block + 5 commits groups in prologue = 7
-      // CHECK: amdg.async_wait {num_inst = 6
+      // CHECK: amdg.async_wait {num_inst = 7
       ttg.async_wait {num = 6: i32}
       ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       ttg.async_commit_group
@@ -460,7 +463,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         // 2 Instructions
         ttg.async_commit_group
         // 1 commit group(2) to escape for, 1 commits group(2) in rest of while after block, 1 commit group (2) in while before block and 3 commits group in prologue = 9
-        // CHECK: amdg.async_wait {num_inst = 6
+        // CHECK: amdg.async_wait {num_inst = 9
         ttg.async_wait {num = 6: i32}
 
         scf.if %cond {
@@ -468,7 +471,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
           ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
 
           // Same as above but we also have to count the 2 async_copies above = 9+3
-          // CHECK: amdg.async_wait {num_inst = 6
+          // CHECK: amdg.async_wait {num_inst = 12
           ttg.async_wait {num = 6: i32}
         } else {
           ttg.async_copy_global_to_local %ptr2Inst, %memDesc2Inst : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
@@ -482,11 +485,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
           // 3 Instructions
           ttg.async_commit_group
           // 1 commit group (3) in this block, 2 commits group in the rest of the for body (2+2), 1 commits group(2) in rest of while after block, 1 commit group (2) in while before block, 1 commit group (1) in epilogue = 12
-          // CHECK: amdg.async_wait {num_inst = 6
+          // CHECK: amdg.async_wait {num_inst = 12
           ttg.async_wait {num = 6: i32}
         }
         // Same as above but skips the if (first commit group(3)) and instead counts one more in the prologue (1) = 10
-        // CHECK: amdg.async_wait {num_inst = 6
+        // CHECK: amdg.async_wait {num_inst = 10
         ttg.async_wait {num = 6: i32}
         scf.for %arg15 = %c0_i32 to %arg0 step %c1_i32 : i32 {
           ttg.async_copy_global_to_local %ptr1Inst, %memDesc1Inst : tensor<64x16x!tt.ptr<f16>, #blocked> -> <64x16xf16, #shared, #smem, mutable>
@@ -496,19 +499,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
           // 2 Instructions
           ttg.async_commit_group
           // Just staying in the loop is the lowest path (3 per iteration and we do 3 iterations)
-          // CHECK: amdg.async_wait {num_inst = 6
+          // CHECK: amdg.async_wait {num_inst = 9
           ttg.async_wait {num = 6: i32}
           scf.yield
         }
         // Just stay in the inner loop for the lowest path
-        // CHECK: amdg.async_wait {num_inst = 6
+        // CHECK: amdg.async_wait {num_inst = 9
         ttg.async_wait {num = 6: i32}
         scf.yield
       }
       scf.yield %arg12 : i1
     }
     // While before-body (2) + 5 prologue groups = 7
-    // CHECK: amdg.async_wait {num_inst = 6
+    // CHECK: amdg.async_wait {num_inst = 7
     ttg.async_wait {num = 6: i32}
 
     tt.return
@@ -538,22 +541,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       } {triton.warp_pipeline.stage = "stage1"}
 
       // Wait for both execute regions
-      // CHECK: amdg.async_wait {num_inst = 2
+      // CHECK: amdg.async_wait {num_inst = 3
       ttg.async_wait {num = 2 : i32}
 
       // Check that we only traverse each execute region once
-      // CHECK: amdg.async_wait {num_inst = 6
+      // CHECK: amdg.async_wait {num_inst = 3
       ttg.async_wait {num = 6 : i32}
 
       // Wait only for the second execute region
-      // CHECK: amdg.async_wait {num_inst = 1
+      // CHECK: amdg.async_wait {num_inst = 2
       ttg.async_wait {num = 1 : i32}
 
       scf.yield
     }
 
     // Wait for both nested execute regions
-    // CHECK: amdg.async_wait {num_inst = 2
+    // CHECK: amdg.async_wait {num_inst = 3
     ttg.async_wait {num = 2 : i32}
 
     tt.return

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -604,7 +604,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %0 = amdg.buffer_load_to_local %ptr[%offsets] into %dest : <i32>[tensor<64xi32, #linear_warp_free>]  -> <64xi32, #shared_simple, #smem, mutable>
     %1 = ttg.async_commit_group
 
-    // With asyncmark, num is passed through directly
+    // Warp free variable means 0 instructions emitted for this warp config
     // CHECK: amdg.async_wait {num_inst = 0
     %2 = ttg.async_wait {num = 1 : i32}
     tt.return
@@ -626,7 +626,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %dest: !ttg.memdesc<256xi32, #shared_simple2, #smem, mutable>) {
     %0 = amdg.buffer_load_to_local %ptr[%offsets] into %dest : <i32>[tensor<256xi32, #linear_reg_zero>]  -> <256xi32, #shared_simple2, #smem, mutable>
     %1 = ttg.async_commit_group
-    // With asyncmark, num is passed through directly
+    // Register zero bases should not inflate count: 1 instruction
     // CHECK: amdg.async_wait {num_inst = 1
     %2 = ttg.async_wait {num = 1 : i32}
     tt.return

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx950 | FileCheck %s
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx1250 | FileCheck %s --check-prefix=GFX1250
 
 // Simple case without any branching
 
@@ -17,10 +18,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group tokens %2
 
-    // Do not wait on the second async_copy => waitcnt 2
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
+    // With asyncmark (CDNA3/CDNA4), wait count is passed through directly
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %9 = ttg.async_wait %1 {num = 0 : i32}
-    // No async_copies in between => waitcnt 0
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
@@ -44,11 +44,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %1 = ttg.async_commit_group tokens %0
     // Emits 2 direct to lds instructions
     %2 = amdg.buffer_load_to_local %arg2[%arg3] into %arg5 : <f16>[tensor<16x256xi32, #blocked1>]  -> <16x256xf16, #shared1, #smem, mutable>
-    // Do not wait on the second buffer_load_to_local => waitcnt 2
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
+    // With asyncmark, wait count is passed through directly
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %3 = ttg.async_commit_group tokens %2
     %4 = ttg.async_wait %1 {num = 0 : i32}
-    // No buffer_load_to_local in between => waitcnt 0
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %5 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
@@ -74,11 +73,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group tokens %2
 
-    // Do not wait on the second async_copy => waitcnt 2
+    // With asyncmark, wait count is passed through directly
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %9 = ttg.async_wait %3 {num = 0 : i32}
-    // No async_copies in between => waitcnt 0
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %1 {num = 0 : i32}
     tt.return
   }
@@ -105,7 +103,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     %4 = tt.load %arg3 : tensor<128x16x!tt.ptr<f16>, #blocked>
 
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
+    // With asyncmark, wait count is passed through directly
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %9 = ttg.async_wait %1 {num = 0 : i32}
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
@@ -134,7 +133,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group tokens %2
     %8:2 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %3) -> (!ttg.async.token, !ttg.async.token)  : i32 {
-      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 0
+      // With asyncmark, num is passed through directly
+      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 2
       %10 = ttg.async_wait %arg15, %arg16 {num = 2 : i32}
       %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       %12 = ttg.async_commit_group tokens %11
@@ -173,7 +173,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
-      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 3
+      // With asyncmark, num is passed through directly
+      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 2
       %10 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
       %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       %12 = ttg.async_commit_group tokens %11
@@ -212,13 +213,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %7 = ttg.async_commit_group tokens %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token) : i32 {
       %103 = scf.if %cond -> (!ttg.async.token) {
-        // We wait on both tokens so we interleave with one iteration => 3
-        // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 3
+        // With asyncmark, num is passed through directly
+        // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 2
         %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
         scf.yield %token1 : !ttg.async.token
       } else {
-        // We only wait on the token of the first load so we can interleave one more load => 3 + 2
-        // CHECK: amdg.async_wait {{.*}} {num_inst = 5
+        // CHECK: amdg.async_wait {{.*}} {num_inst = 1
         %token2 = ttg.async_wait %arg15 {num = 1 : i32}
         scf.yield %token2 : !ttg.async.token
       }
@@ -262,8 +262,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %103 = scf.if %cond -> (!ttg.async.token) {
         %cond_load = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
         %cond_load_commit = ttg.async_commit_group tokens %cond_load
-        // We wait on both tokens (3) and additionally we should count the load inside our block (+2) => 5
-        // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 5
+        // With asyncmark, num is passed through directly
+        // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 2
         %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
         scf.yield %token1 : !ttg.async.token
       } else {
@@ -306,8 +306,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
-      // The then block contains 3 instructions and the else 1 so we expect the count to be 3 (1 + 2) because there are also 2 instructions outside the scf.if in the loop body
-      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 3
+      // With asyncmark, num is passed through directly
+      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 2
       %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
 
       %103 = scf.if %cond -> (!ttg.async.token) {
@@ -349,9 +349,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Emits 1 direct to lds instruction
     %6 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
-    // Dynamic iteration count so we should not count its body
+    // Dynamic iteration count — with asyncmark, num is passed through
     %30 = scf.for %arg21 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg30 = %6) -> (!ttg.async.token) : i32 {
-      // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+      // CHECK: amdg.async_wait {{.*}} {num_inst = 1
       %31 = ttg.async_wait %arg30 {num = 1 : i32}
       // Emits 1 direct to lds instruction
       %32 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
@@ -383,16 +383,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Emits 1 direct to lds instruction
     %6 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
-    // Loop with 4 iterations => 4 instructions
+    // With asyncmark, num is passed through directly
     %30 = scf.for %arg21 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg30 = %6) -> (!ttg.async.token) : i32 {
-      // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+      // CHECK: amdg.async_wait {{.*}} {num_inst = 1
       %31 = ttg.async_wait %arg30 {num = 1 : i32}
       // Emits 1 direct to lds instruction
       %32 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       %33 = ttg.async_commit_group tokens %32
       scf.yield %33 : !ttg.async.token
     }
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 5
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 1
     %10 = ttg.async_wait %1 {num = 1 : i32}
     tt.return
   }
@@ -434,6 +434,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: simple_local_to_global_waitcnt
+  // GFX1250-LABEL: simple_local_to_global_waitcnt
   tt.func public @simple_local_to_global_waitcnt(%arg1: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, %arg2: tensor<32x32x!tt.ptr<f32>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>}) {
     // Emits 2 async store instructions (256 bits per thread, split into 2x128-bit stores)
     %0 = amdg.async_copy_local_to_global %arg1, %arg2 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
@@ -442,11 +443,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = amdg.async_copy_local_to_global %arg1, %arg2 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
     %3 = ttg.async_commit_group tokens %2
 
-    // Do not wait on the second async_copy => waitcnt 2
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
-    %9 = ttg.async_wait %1 {num = 0 : i32}
-    // No async_copies in between => waitcnt 0
+    // gfx950 (asyncmark): pass through num directly
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+    // gfx1250: instruction counting — 2 outstanding
+    // GFX1250: amdg.async_wait {{.*}} {num_inst = 2
+    %9 = ttg.async_wait %1 {num = 0 : i32}
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+    // GFX1250: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
   }
@@ -461,6 +464,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: mix_global_to_local_and_local_to_global
+  // GFX1250-LABEL: mix_global_to_local_and_local_to_global
   tt.func public @mix_global_to_local_and_local_to_global(%arg1: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, %arg2: tensor<32x32x!tt.ptr<f32>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>}) {
     // Emits 2 async load instructions
     %0 = ttg.async_copy_global_to_local %arg2, %arg1 : tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
@@ -469,11 +473,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = amdg.async_copy_local_to_global %arg1, %arg2 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
     %3 = ttg.async_commit_group tokens %2
 
-    // Do not wait on the store => waitcnt 2
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
-    %9 = ttg.async_wait %1 {num = 0 : i32}
-    // No async_copies in between => waitcnt 0
+    // gfx950 (asyncmark): pass through num directly
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+    // GFX1250: amdg.async_wait {{.*}} {num_inst = 2
+    %9 = ttg.async_wait %1 {num = 0 : i32}
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+    // GFX1250: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
   }
@@ -488,6 +493,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: mix_async_copy_and_async_tdm_copy
+  // GFX1250-LABEL: mix_async_copy_and_async_tdm_copy
   tt.func public @mix_async_copy_and_async_tdm_copy(%memDesc: !ttg.memdesc<128x8xf16, #shared, #smem, mutable>, %tensorDesc: !tt.tensordesc<128x8xf16>, %mask: i32, %ptr: tensor<128x8x!tt.ptr<f16>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>}
   ) {
     %c0_i32 = arith.constant 0 : i32
@@ -504,18 +510,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %5 = ttg.async_copy_global_to_local %ptr, %memDesc : tensor<128x8x!tt.ptr<f16>, #blocked> -> <128x8xf16, #shared, #smem, mutable>
     %51 = ttg.async_commit_group tokens %4, %5
 
-    // Check that we do not take other load types into account (async_tdm_copy vs async_copy)
-
+    // TDM waits use separate counter — not affected by asyncmark
     // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 1
+    // GFX1250: amdg.async_tdm_intrinsic_wait {{.*}} {count = 1
     %tw1 = amdg.async_tdm_wait %1 {num = 0 : i32}
 
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
+    // gfx950 (asyncmark): pass through num directly
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+    // GFX1250: amdg.async_wait {{.*}} {num_inst = 2
     %cw1 = ttg.async_wait %21 {num = 0 : i32}
 
     // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 0
+    // GFX1250: amdg.async_tdm_intrinsic_wait {{.*}} {count = 0
     %w2 = amdg.async_tdm_wait %3 {num = 0 : i32}
 
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+    // GFX1250: amdg.async_wait {{.*}} {num_inst = 0
     %cw2 = ttg.async_wait %51 {num = 0 : i32}
     tt.return
   }
@@ -543,6 +553,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %inner_commit = ttg.async_commit_group tokens %inner
     }
 
+    // With asyncmark, num is passed through directly
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %1 {num = 0 : i32}
     tt.return
@@ -605,8 +616,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %0 = amdg.buffer_load_to_local %ptr[%offsets] into %dest : <i32>[tensor<64xi32, #linear_warp_free>]  -> <64xi32, #shared_simple, #smem, mutable>
     %1 = ttg.async_commit_group
 
-    // The load above contributes 0 instructions, so waitcnt should be 0
-    // CHECK: amdg.async_wait {num_inst = 0
+    // With asyncmark, num is passed through directly
+    // CHECK: amdg.async_wait {num_inst = 1
     %2 = ttg.async_wait {num = 1 : i32}
     tt.return
   }
@@ -627,8 +638,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %dest: !ttg.memdesc<256xi32, #shared_simple2, #smem, mutable>) {
     %0 = amdg.buffer_load_to_local %ptr[%offsets] into %dest : <i32>[tensor<256xi32, #linear_reg_zero>]  -> <256xi32, #shared_simple2, #smem, mutable>
     %1 = ttg.async_commit_group
-    // Without zero-base removal, register dim size is 2 which would give
-    // num_inst = 2. With zero-base removal, it correctly gives num_inst = 1.
+    // With asyncmark, num is passed through directly
     // CHECK: amdg.async_wait {num_inst = 1
     %2 = ttg.async_wait {num = 1 : i32}
     tt.return

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -1,5 +1,4 @@
-// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx950 | FileCheck %s
-// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx1250 | FileCheck %s --check-prefix=GFX1250
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=arch-generation-name=gfx1250 | FileCheck %s
 
 // Simple case without any branching
 
@@ -18,9 +17,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group tokens %2
 
-    // With asyncmark (CDNA3/CDNA4), wait count is passed through directly
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+    // Wait on token %1: 2 instructions outstanding (second async_copy emits 2)
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %9 = ttg.async_wait %1 {num = 0 : i32}
+    // Wait on token %3: 0 instructions outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
@@ -44,10 +44,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %1 = ttg.async_commit_group tokens %0
     // Emits 2 direct to lds instructions
     %2 = amdg.buffer_load_to_local %arg2[%arg3] into %arg5 : <f16>[tensor<16x256xi32, #blocked1>]  -> <16x256xf16, #shared1, #smem, mutable>
-    // With asyncmark, wait count is passed through directly
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %3 = ttg.async_commit_group tokens %2
+    // Wait on token %1: 2 instructions outstanding (second buffer_load emits 2)
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %4 = ttg.async_wait %1 {num = 0 : i32}
+    // Wait on token %3: 0 instructions outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %5 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
@@ -73,10 +74,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group tokens %2
 
-    // With asyncmark, wait count is passed through directly
+    // Wait on token %3: 0 instructions outstanding (nothing after %3)
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %9 = ttg.async_wait %3 {num = 0 : i32}
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+    // Wait on token %1: 2 instructions outstanding (second async_copy emits 2)
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %10 = ttg.async_wait %1 {num = 0 : i32}
     tt.return
   }
@@ -103,9 +105,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     %4 = tt.load %arg3 : tensor<128x16x!tt.ptr<f16>, #blocked>
 
-    // With asyncmark, wait count is passed through directly
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+    // Wait on token %1: 2 instructions outstanding (tt.load ignored, second async_copy emits 2)
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %9 = ttg.async_wait %1 {num = 0 : i32}
+    // Wait on token %3: 0 instructions outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
@@ -133,8 +136,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group tokens %2
     %8:2 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %3) -> (!ttg.async.token, !ttg.async.token)  : i32 {
-      // With asyncmark, num is passed through directly
-      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 2
+      // min over tokens: %arg16 has 0 outstanding → overall 0
+      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 0
       %10 = ttg.async_wait %arg15, %arg16 {num = 2 : i32}
       %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       %12 = ttg.async_commit_group tokens %11
@@ -173,8 +176,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
-      // With asyncmark, num is passed through directly
-      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 2
+      // 2 loads per buffer: first emits 1, second emits 2 → 3 per iteration
+      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 3
       %10 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
       %11 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       %12 = ttg.async_commit_group tokens %11
@@ -213,12 +216,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %7 = ttg.async_commit_group tokens %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token) : i32 {
       %103 = scf.if %cond -> (!ttg.async.token) {
-        // With asyncmark, num is passed through directly
-        // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 2
+        // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 3
         %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
         scf.yield %token1 : !ttg.async.token
       } else {
-        // CHECK: amdg.async_wait {{.*}} {num_inst = 1
+        // CHECK: amdg.async_wait {{.*}} {num_inst = 5
         %token2 = ttg.async_wait %arg15 {num = 1 : i32}
         scf.yield %token2 : !ttg.async.token
       }
@@ -262,8 +264,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %103 = scf.if %cond -> (!ttg.async.token) {
         %cond_load = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
         %cond_load_commit = ttg.async_commit_group tokens %cond_load
-        // With asyncmark, num is passed through directly
-        // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 2
+        // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 5
         %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
         scf.yield %token1 : !ttg.async.token
       } else {
@@ -306,8 +307,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %6 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
     %8:4 = scf.for %arg14 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg15 = %1, %arg16 = %5, %arg17 = %3, %arg18 = %7) -> (!ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
-      // With asyncmark, num is passed through directly
-      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 2
+      // CHECK: amdg.async_wait {{.*}}, {{.*}} {num_inst = 3
       %token1 = ttg.async_wait %arg15, %arg17 {num = 2 : i32}
 
       %103 = scf.if %cond -> (!ttg.async.token) {
@@ -349,9 +349,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Emits 1 direct to lds instruction
     %6 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
-    // Dynamic iteration count — with asyncmark, num is passed through
+    // Dynamic iteration count
     %30 = scf.for %arg21 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg30 = %6) -> (!ttg.async.token) : i32 {
-      // CHECK: amdg.async_wait {{.*}} {num_inst = 1
+      // CHECK: amdg.async_wait {{.*}} {num_inst = 0
       %31 = ttg.async_wait %arg30 {num = 1 : i32}
       // Emits 1 direct to lds instruction
       %32 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
@@ -383,16 +383,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Emits 1 direct to lds instruction
     %6 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %7 = ttg.async_commit_group tokens %6
-    // With asyncmark, num is passed through directly
     %30 = scf.for %arg21 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg30 = %6) -> (!ttg.async.token) : i32 {
-      // CHECK: amdg.async_wait {{.*}} {num_inst = 1
+      // CHECK: amdg.async_wait {{.*}} {num_inst = 0
       %31 = ttg.async_wait %arg30 {num = 1 : i32}
       // Emits 1 direct to lds instruction
       %32 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
       %33 = ttg.async_commit_group tokens %32
       scf.yield %33 : !ttg.async.token
     }
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 1
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 5
     %10 = ttg.async_wait %1 {num = 1 : i32}
     tt.return
   }
@@ -434,7 +433,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: simple_local_to_global_waitcnt
-  // GFX1250-LABEL: simple_local_to_global_waitcnt
   tt.func public @simple_local_to_global_waitcnt(%arg1: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, %arg2: tensor<32x32x!tt.ptr<f32>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>}) {
     // Emits 2 async store instructions (256 bits per thread, split into 2x128-bit stores)
     %0 = amdg.async_copy_local_to_global %arg1, %arg2 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
@@ -443,13 +441,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = amdg.async_copy_local_to_global %arg1, %arg2 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
     %3 = ttg.async_commit_group tokens %2
 
-    // gfx950 (asyncmark): pass through num directly
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
-    // gfx1250: instruction counting — 2 outstanding
-    // GFX1250: amdg.async_wait {{.*}} {num_inst = 2
+    // Wait on token %1: 2 store instructions outstanding
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %9 = ttg.async_wait %1 {num = 0 : i32}
+    // Wait on token %3: 0 outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
-    // GFX1250: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
   }
@@ -464,7 +460,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: mix_global_to_local_and_local_to_global
-  // GFX1250-LABEL: mix_global_to_local_and_local_to_global
   tt.func public @mix_global_to_local_and_local_to_global(%arg1: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, %arg2: tensor<32x32x!tt.ptr<f32>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>}) {
     // Emits 2 async load instructions
     %0 = ttg.async_copy_global_to_local %arg2, %arg1 : tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
@@ -473,12 +468,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = amdg.async_copy_local_to_global %arg1, %arg2 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
     %3 = ttg.async_commit_group tokens %2
 
-    // gfx950 (asyncmark): pass through num directly
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
-    // GFX1250: amdg.async_wait {{.*}} {num_inst = 2
+    // Wait on token %1: 2 store instructions outstanding
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %9 = ttg.async_wait %1 {num = 0 : i32}
+    // Wait on token %3: 0 outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
-    // GFX1250: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %3 {num = 0 : i32}
     tt.return
   }
@@ -493,7 +487,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: mix_async_copy_and_async_tdm_copy
-  // GFX1250-LABEL: mix_async_copy_and_async_tdm_copy
   tt.func public @mix_async_copy_and_async_tdm_copy(%memDesc: !ttg.memdesc<128x8xf16, #shared, #smem, mutable>, %tensorDesc: !tt.tensordesc<128x8xf16>, %mask: i32, %ptr: tensor<128x8x!tt.ptr<f16>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>}
   ) {
     %c0_i32 = arith.constant 0 : i32
@@ -510,22 +503,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %5 = ttg.async_copy_global_to_local %ptr, %memDesc : tensor<128x8x!tt.ptr<f16>, #blocked> -> <128x8xf16, #shared, #smem, mutable>
     %51 = ttg.async_commit_group tokens %4, %5
 
-    // TDM waits use separate counter — not affected by asyncmark
     // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 1
-    // GFX1250: amdg.async_tdm_intrinsic_wait {{.*}} {count = 1
     %tw1 = amdg.async_tdm_wait %1 {num = 0 : i32}
 
-    // gfx950 (asyncmark): pass through num directly
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
-    // GFX1250: amdg.async_wait {{.*}} {num_inst = 2
+    // Wait on token %21: 2 async_copy instructions outstanding
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
     %cw1 = ttg.async_wait %21 {num = 0 : i32}
 
     // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 0
-    // GFX1250: amdg.async_tdm_intrinsic_wait {{.*}} {count = 0
     %w2 = amdg.async_tdm_wait %3 {num = 0 : i32}
 
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
-    // GFX1250: amdg.async_wait {{.*}} {num_inst = 0
     %cw2 = ttg.async_wait %51 {num = 0 : i32}
     tt.return
   }
@@ -553,7 +541,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %inner_commit = ttg.async_commit_group tokens %inner
     }
 
-    // With asyncmark, num is passed through directly
+    // Wait on token %1: if path contributes 1, else (skip) contributes 0 → min = 0
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
     %10 = ttg.async_wait %1 {num = 0 : i32}
     tt.return
@@ -617,7 +605,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %1 = ttg.async_commit_group
 
     // With asyncmark, num is passed through directly
-    // CHECK: amdg.async_wait {num_inst = 1
+    // CHECK: amdg.async_wait {num_inst = 0
     %2 = ttg.async_wait {num = 1 : i32}
     tt.return
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -124,18 +124,14 @@ Value BufferEmitter::emitLoad(Type type, Value rsrcDesc, Value offset,
 
 Operation *BufferEmitter::emitLoadToLds(Type type, Value byteWidth,
                                         Value rsrcDesc, Value offset, Value dst,
-                                        Value pred,
-                                        triton::CacheModifier cm) {
+                                        Value pred, triton::CacheModifier cm) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   SmallVector<Value, 6> commonArgs;
   fillCommonArgs(type, rsrcDesc, offset, pred, cm, /*isBufferLoad=*/true,
                  commonArgs);
   Type bufferType = getBufferOpType(type, false);
 
-  bool useAsync = llvm::is_contained(
-      {ISAFamily::CDNA3, ISAFamily::CDNA4}, targetInfo.getISAFamily());
-
-  if (useAsync) {
+  if (targetInfo.useAsyncMarks()) {
     // Use the async intrinsic so that LLVM's SIInsertWaitcnts tracks
     // these operations via asyncmark/wait_asyncmark instead of generating
     // conservative vmcnt(0) waits.

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -122,14 +122,36 @@ Value BufferEmitter::emitLoad(Type type, Value rsrcDesc, Value offset,
   return data;
 }
 
-ROCDL::RawPtrBufferLoadLdsOp
-BufferEmitter::emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc,
-                             Value offset, Value dst, Value pred,
-                             triton::CacheModifier cm) {
+Operation *BufferEmitter::emitLoadToLds(Type type, Value byteWidth,
+                                        Value rsrcDesc, Value offset, Value dst,
+                                        Value pred,
+                                        triton::CacheModifier cm) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   SmallVector<Value, 6> commonArgs;
   fillCommonArgs(type, rsrcDesc, offset, pred, cm, /*isBufferLoad=*/true,
                  commonArgs);
+  Type bufferType = getBufferOpType(type, false);
+
+  bool useAsync = llvm::is_contained(
+      {ISAFamily::CDNA3, ISAFamily::CDNA4}, targetInfo.getISAFamily());
+
+  if (useAsync) {
+    // Use the async intrinsic so that LLVM's SIInsertWaitcnts tracks
+    // these operations via asyncmark/wait_asyncmark instead of generating
+    // conservative vmcnt(0) waits.
+    return ROCDL::RawPtrBufferLoadAsyncLdsOp::create(
+        rewriter, loc, TypeRange{},
+        ValueRange{
+            commonArgs[0], // Buffer descriptor
+            dst,           // LDS base ptr
+            byteWidth,     // Instr size
+            commonArgs[1], // Buffer offset
+            b.i32_val(0),  // LDS offset
+            commonArgs[2], // Instruction offset
+            commonArgs[3], // AUX
+        });
+  }
+
   return ROCDL::RawPtrBufferLoadLdsOp::create(
       rewriter, loc, TypeRange{},
       ValueRange{

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -131,24 +131,10 @@ Operation *BufferEmitter::emitLoadToLds(Type type, Value byteWidth,
                  commonArgs);
   Type bufferType = getBufferOpType(type, false);
 
-  if (targetInfo.useAsyncMarks()) {
-    // Use the async intrinsic so that LLVM's SIInsertWaitcnts tracks
-    // these operations via asyncmark/wait_asyncmark instead of generating
-    // conservative vmcnt(0) waits.
-    return ROCDL::RawPtrBufferLoadAsyncLdsOp::create(
-        rewriter, loc, TypeRange{},
-        ValueRange{
-            commonArgs[0], // Buffer descriptor
-            dst,           // LDS base ptr
-            byteWidth,     // Instr size
-            commonArgs[1], // Buffer offset
-            b.i32_val(0),  // LDS offset
-            commonArgs[2], // Instruction offset
-            commonArgs[3], // AUX
-        });
-  }
-
-  return ROCDL::RawPtrBufferLoadLdsOp::create(
+  // buffer_load_to_lds is only supported on gfx942/gfx950 which always use
+  // asyncmark. Emit the async intrinsic so LLVM's SIInsertWaitcnts tracks
+  // these operations via asyncmark/wait_asyncmark.
+  return ROCDL::RawPtrBufferLoadAsyncLdsOp::create(
       rewriter, loc, TypeRange{},
       ValueRange{
           commonArgs[0], // Buffer descriptor
@@ -158,8 +144,7 @@ Operation *BufferEmitter::emitLoadToLds(Type type, Value byteWidth,
           b.i32_val(0),  // LDS offset
           commonArgs[2], // Instruction offset
           commonArgs[3], // AUX
-      },
-      ArrayRef<NamedAttribute>());
+      });
 }
 
 Value BufferEmitter::emitAtomicCAS(Type type, Value rsrcDesc, Value offset,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -122,9 +122,10 @@ Value BufferEmitter::emitLoad(Type type, Value rsrcDesc, Value offset,
   return data;
 }
 
-Operation *BufferEmitter::emitLoadToLds(Type type, Value byteWidth,
-                                        Value rsrcDesc, Value offset, Value dst,
-                                        Value pred, triton::CacheModifier cm) {
+ROCDL::RawPtrBufferLoadAsyncLdsOp
+BufferEmitter::emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc,
+                             Value offset, Value dst, Value pred,
+                             triton::CacheModifier cm) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   SmallVector<Value, 6> commonArgs;
   fillCommonArgs(type, rsrcDesc, offset, pred, cm, /*isBufferLoad=*/true,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.h
@@ -70,11 +70,10 @@ struct BufferEmitter {
   Value emitLoad(Type type, Value rsrcDesc, Value offset, Value pred,
                  Value falseVal, CacheModifier cm);
 
-  // Emit a predicated rocdl.raw.ptr.buffer.load.lds
-  ROCDL::RawPtrBufferLoadLdsOp emitLoadToLds(Type type, Value byteWidth,
-                                             Value rsrcDesc, Value offset,
-                                             Value dst, Value pred,
-                                             CacheModifier cm);
+  // Emit a predicated rocdl.raw.ptr.buffer.load.lds (or async variant)
+  Operation *emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc,
+                           Value offset, Value dst, Value pred,
+                           CacheModifier cm);
 
   // Emit a predicated rocdl.raw.ptr.buffer.atomic.* RMWOp
   Value emitAtomicRMW(RMWOp rmwType, Type type, Value rsrcDesc, Value offset,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.h
@@ -70,10 +70,13 @@ struct BufferEmitter {
   Value emitLoad(Type type, Value rsrcDesc, Value offset, Value pred,
                  Value falseVal, CacheModifier cm);
 
-  // Emit a predicated rocdl.raw.ptr.buffer.load.lds (or async variant)
-  Operation *emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc,
-                           Value offset, Value dst, Value pred,
-                           CacheModifier cm);
+  // Emit a rocdl.raw.ptr.buffer.load.async.lds for direct-to-LDS loads.
+  // Always emits the async variant since buffer_load_to_lds is only supported
+  // on gfx942/gfx950 which use asyncmark-based synchronization.
+  ROCDL::RawPtrBufferLoadAsyncLdsOp emitLoadToLds(Type type, Value byteWidth,
+                                                  Value rsrcDesc, Value offset,
+                                                  Value dst, Value pred,
+                                                  CacheModifier cm);
 
   // Emit a predicated rocdl.raw.ptr.buffer.atomic.* RMWOp
   Value emitAtomicRMW(RMWOp rmwType, Type type, Value rsrcDesc, Value offset,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1010,8 +1010,7 @@ struct AsyncCopyGlobalToLocalOpConversion
         mlir::LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(
             cacheMod, /*isLoad=*/true, targetInfo);
 
-    if (llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4},
-                           targetInfo.getISAFamily())) {
+    if (targetInfo.useAsyncMarks()) {
       // Use the async intrinsic so LLVM tracks these via asyncmark
       auto asyncLoadOp = ROCDL::GlobalLoadAsyncLDSOp::create(
           rewriter, loc, srcPtr, shmemAddr, vecBits / 8,
@@ -2340,45 +2339,18 @@ struct AsyncWaitOpConversion
     auto loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    switch (targetInfo.getISAFamily()) {
-    case ISAFamily::CDNA1:
-    case ISAFamily::CDNA2: {
-      // global.load.lds uses vmcnt to synchronize
-      // The rocdl op stores all available counters in a single int32 value (v).
-      // The vmcnt (6 bits) is split into a lower 3:0 and higher 5:4 parts.
-      // The lower part is stored in bits 3:0 of v and the higher part in bits
-      // 15:14. We have to set all other bits in v to 1 to signal we are not
-      // interested in those.
-
-      // Clamp vmcnt to 6bits; a lower vmcnt will produce a conservative wait
-      unsigned vmCnt = std::min(63u, op.getNumInst());
-
-      // Extract low and high bits and combine while setting all other bits to 1
-      unsigned lowBits = vmCnt & 0xF;
-      unsigned highBits = vmCnt >> 4 << 14;
-      unsigned otherCnts = ~0xC00F; // C00F has bits 15:14 and 3:0 set
-      unsigned waitValue = lowBits | highBits | otherCnts;
-
-      ROCDL::SWaitcntOp::create(rewriter, loc, waitValue);
-      break;
-    }
-    case ISAFamily::CDNA3:
-    case ISAFamily::CDNA4: {
+    if (targetInfo.useAsyncMarks()) {
       // Use wait_asyncmark which lets LLVM compute correct vmcnt values
       // that account for both buffer_load_to_lds and regular buffer_load.
       unsigned asyncCnt = std::min(63u, op.getNumInst());
       ROCDL::WaitAsyncmarkOp::create(rewriter, loc, asyncCnt);
-      break;
-    }
-    case ISAFamily::GFX1250: {
-      // Clamp asyncCnt to 6bits(hw imit); lower means conservative
+    } else if (targetInfo.getISAFamily() == ISAFamily::GFX1250) {
+      // Clamp asyncCnt to 6bits(hw limit); lower means conservative
       unsigned asyncCnt = std::min(63u, op.getNumInst());
       ROCDL::WaitAsynccntOp::create(rewriter, loc, asyncCnt);
-      break;
-    }
-    default:
+    } else {
       return rewriter.notifyMatchFailure(
-          op, "Only supported on CDNA target architecture");
+          op, "async wait not supported on this target architecture");
     }
 
     // Drop the result AsyncToken
@@ -2421,14 +2393,8 @@ struct AsyncCommitGroupOpConversion
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
     // Emit asyncmark for architectures that use async tracking
-    switch (targetInfo.getISAFamily()) {
-    case ISAFamily::CDNA3:
-    case ISAFamily::CDNA4:
+    if (targetInfo.useAsyncMarks())
       ROCDL::AsyncmarkOp::create(rewriter, loc);
-      break;
-    default:
-      break;
-    }
 
     // Drop the result AsyncToken
     rewriter.replaceOp(op, b.i32_val(0));
@@ -2534,7 +2500,8 @@ void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
   patterns.add<AsyncWaitOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<TDMPrefetchConversion>(typeConverter, targetInfo, benefit);
   patterns.add<AsyncTDMIntrinsicWaitConversion>(typeConverter, benefit);
-  patterns.add<AsyncCommitGroupOpConversion>(typeConverter, targetInfo, benefit);
+  patterns.add<AsyncCommitGroupOpConversion>(typeConverter, targetInfo,
+                                             benefit);
   patterns.add<AsyncCopyMbarrierArriveOpConversion>(typeConverter, benefit);
 }
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -820,11 +820,13 @@ struct BufferLoadToLocalOpConversion
 
       auto [loadBlock, afterLoadBlock] = emitBranch(rewriter, loc, cond);
 
-      auto bufferLoadToLds = bufferEmitter.emitLoadToLds(
+      auto *bufferLoadToLds = bufferEmitter.emitLoadToLds(
           vecTy, vecBytesVal, rsrcDesc, offsetElem, shmemAddr,
           hasOther ? b.true_val() : maybeSwizzledMaskElem, op.getCache());
       if (targetInfo.requiresAliasInfoForAsyncOps())
-        AMD::addAsyncCopyAliasScope(bufferLoadToLds);
+        if (auto aliasOp =
+                dyn_cast<LLVM::AliasAnalysisOpInterface>(bufferLoadToLds))
+          AMD::addAsyncCopyAliasScope(aliasOp);
 
       if (hasOther) {
         emitOtherStore(rewriter, loc, this->getTypeConverter(), vecTy, maskElem,
@@ -1010,11 +1012,12 @@ struct AsyncCopyGlobalToLocalOpConversion
 
     if (llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4},
                            targetInfo.getISAFamily())) {
-      auto globalLoadLdsOp = ROCDL::GlobalLoadLDSOp::create(
+      // Use the async intrinsic so LLVM tracks these via asyncmark
+      auto asyncLoadOp = ROCDL::GlobalLoadAsyncLDSOp::create(
           rewriter, loc, srcPtr, shmemAddr, vecBits / 8,
           /*offset=*/0, cacheModifiers, nullptr, nullptr, nullptr);
       if (targetInfo.requiresAliasInfoForAsyncOps())
-        AMD::addAsyncCopyAliasScope(globalLoadLdsOp);
+        AMD::addAsyncCopyAliasScope(asyncLoadOp);
     } else if (targetInfo.getISAFamily() == ISAFamily::GFX1250) {
       if (cacheMod != triton::CacheModifier::NONE) {
         emitRemark(loc) << "cache modifiers not yet implemented on gfx1250";
@@ -2339,9 +2342,7 @@ struct AsyncWaitOpConversion
 
     switch (targetInfo.getISAFamily()) {
     case ISAFamily::CDNA1:
-    case ISAFamily::CDNA2:
-    case ISAFamily::CDNA3:
-    case ISAFamily::CDNA4: {
+    case ISAFamily::CDNA2: {
       // global.load.lds uses vmcnt to synchronize
       // The rocdl op stores all available counters in a single int32 value (v).
       // The vmcnt (6 bits) is split into a lower 3:0 and higher 5:4 parts.
@@ -2359,6 +2360,14 @@ struct AsyncWaitOpConversion
       unsigned waitValue = lowBits | highBits | otherCnts;
 
       ROCDL::SWaitcntOp::create(rewriter, loc, waitValue);
+      break;
+    }
+    case ISAFamily::CDNA3:
+    case ISAFamily::CDNA4: {
+      // Use wait_asyncmark which lets LLVM compute correct vmcnt values
+      // that account for both buffer_load_to_lds and regular buffer_load.
+      unsigned asyncCnt = std::min(63u, op.getNumInst());
+      ROCDL::WaitAsyncmarkOp::create(rewriter, loc, asyncCnt);
       break;
     }
     case ISAFamily::GFX1250: {
@@ -2400,17 +2409,34 @@ struct AsyncTDMIntrinsicWaitConversion
 
 struct AsyncCommitGroupOpConversion
     : public ConvertOpToLLVMPattern<AsyncCommitGroupOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  AsyncCommitGroupOpConversion(LLVMTypeConverter &converter,
+                               const AMD::TargetInfo &targetInfo,
+                               PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(converter, benefit), targetInfo(targetInfo) {}
 
   LogicalResult
   matchAndRewrite(AsyncCommitGroupOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Drop the result AsyncToken
     auto loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    // Emit asyncmark for architectures that use async tracking
+    switch (targetInfo.getISAFamily()) {
+    case ISAFamily::CDNA3:
+    case ISAFamily::CDNA4:
+      ROCDL::AsyncmarkOp::create(rewriter, loc);
+      break;
+    default:
+      break;
+    }
+
+    // Drop the result AsyncToken
     rewriter.replaceOp(op, b.i32_val(0));
     return success();
   }
+
+private:
+  const AMD::TargetInfo &targetInfo;
 };
 
 struct AsyncCopyMbarrierArriveOpConversion
@@ -2508,7 +2534,7 @@ void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
   patterns.add<AsyncWaitOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<TDMPrefetchConversion>(typeConverter, targetInfo, benefit);
   patterns.add<AsyncTDMIntrinsicWaitConversion>(typeConverter, benefit);
-  patterns.add<AsyncCommitGroupOpConversion>(typeConverter, benefit);
+  patterns.add<AsyncCommitGroupOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<AsyncCopyMbarrierArriveOpConversion>(typeConverter, benefit);
 }
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -824,9 +824,8 @@ struct BufferLoadToLocalOpConversion
           vecTy, vecBytesVal, rsrcDesc, offsetElem, shmemAddr,
           hasOther ? b.true_val() : maybeSwizzledMaskElem, op.getCache());
       if (targetInfo.requiresAliasInfoForAsyncOps())
-        if (auto aliasOp =
-                dyn_cast<LLVM::AliasAnalysisOpInterface>(bufferLoadToLds))
-          AMD::addAsyncCopyAliasScope(aliasOp);
+        AMD::addAsyncCopyAliasScope(
+            cast<LLVM::AliasAnalysisOpInterface>(bufferLoadToLds));
 
       if (hasOther) {
         emitOtherStore(rewriter, loc, this->getTypeConverter(), vecTy, maskElem,
@@ -2326,6 +2325,40 @@ struct AtomicRMWOpConversion
   }
 };
 
+// Lower ttg.async_wait directly to wait_asyncmark for architectures that use
+// asyncmark-based synchronization (CDNA3/CDNA4). The commit group count from
+// ttg.async_wait is passed through without clamping since LLVM will compute
+// the final waitcnt based on #instructions instead of #commitGroups.
+struct TTGAsyncWaitOpConversion : public ConvertOpToLLVMPattern<AsyncWaitOp> {
+  TTGAsyncWaitOpConversion(LLVMTypeConverter &converter,
+                           const AMD::TargetInfo &targetInfo,
+                           PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(converter, benefit), targetInfo(targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(AsyncWaitOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!targetInfo.useAsyncMarks())
+      return rewriter.notifyMatchFailure(
+          op, "ttg.async_wait should have been lowered to amdg.async_wait by "
+              "UpdateAsyncWaitCount for non-asyncmark targets");
+
+    auto loc = op->getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    // Pass through the commit group count. LLVM will compute the correct
+    // vmcnt based on asyncmark/wait_asyncmark markers.
+    ROCDL::WaitAsyncmarkOp::create(rewriter, loc, op.getNum());
+
+    // Drop the result AsyncToken
+    rewriter.replaceOp(op, b.i32_val(0));
+    return success();
+  }
+
+private:
+  const AMD::TargetInfo &targetInfo;
+};
+
 struct AsyncWaitOpConversion
     : public ConvertOpToLLVMPattern<amdgpu::AsyncWaitOp> {
   AsyncWaitOpConversion(LLVMTypeConverter &converter,
@@ -2339,12 +2372,7 @@ struct AsyncWaitOpConversion
     auto loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    if (targetInfo.useAsyncMarks()) {
-      // Use wait_asyncmark which lets LLVM compute correct vmcnt values
-      // that account for both buffer_load_to_lds and regular buffer_load.
-      unsigned asyncCnt = std::min(63u, op.getNumInst());
-      ROCDL::WaitAsyncmarkOp::create(rewriter, loc, asyncCnt);
-    } else if (targetInfo.getISAFamily() == ISAFamily::GFX1250) {
+    if (targetInfo.getISAFamily() == ISAFamily::GFX1250) {
       // Clamp asyncCnt to 6bits(hw limit); lower means conservative
       unsigned asyncCnt = std::min(63u, op.getNumInst());
       ROCDL::WaitAsynccntOp::create(rewriter, loc, asyncCnt);
@@ -2497,6 +2525,7 @@ void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                AsyncTDMCopyLocalToGlobalOpConversion,
                AsyncTDMScatterOpConversion, AsyncTDMGatherOpConversion>(
       typeConverter, targetInfo, axisInfoAnalysis, benefit);
+  patterns.add<TTGAsyncWaitOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<AsyncWaitOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<TDMPrefetchConversion>(typeConverter, targetInfo, benefit);
   patterns.add<AsyncTDMIntrinsicWaitConversion>(typeConverter, benefit);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -820,12 +820,11 @@ struct BufferLoadToLocalOpConversion
 
       auto [loadBlock, afterLoadBlock] = emitBranch(rewriter, loc, cond);
 
-      auto *bufferLoadToLds = bufferEmitter.emitLoadToLds(
+      auto bufferLoadToLds = bufferEmitter.emitLoadToLds(
           vecTy, vecBytesVal, rsrcDesc, offsetElem, shmemAddr,
           hasOther ? b.true_val() : maybeSwizzledMaskElem, op.getCache());
       if (targetInfo.requiresAliasInfoForAsyncOps())
-        AMD::addAsyncCopyAliasScope(
-            cast<LLVM::AliasAnalysisOpInterface>(bufferLoadToLds));
+        AMD::addAsyncCopyAliasScope(bufferLoadToLds);
 
       if (hasOther) {
         emitOtherStore(rewriter, loc, this->getTypeConverter(), vecTy, maskElem,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -839,6 +839,11 @@ bool TargetInfo::supportsBufferLoadToLocal() const {
                             getISAFamily());
 }
 
+bool TargetInfo::useAsyncMarks() const {
+  return llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4},
+                            getISAFamily());
+}
+
 bool TargetInfo::supportsBufferAtomicRMW() const {
   return llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4,
                              ISAFamily::RDNA4, ISAFamily::GFX1250},

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -117,6 +117,12 @@ public:
   bool supportsDirectFromLdsStoreBitWidth(int bitWidth) const;
   bool supportsBufferLoadToLocal() const;
 
+  // Whether this target uses asyncmark/wait_asyncmark intrinsics for
+  // buffer_load_to_lds synchronization instead of vmcnt-based waits.
+  // When true, LLVM's SIInsertWaitcnts tracks LDS-bound loads separately,
+  // avoiding conservative vmcnt(0) barriers.
+  bool useAsyncMarks() const;
+
   bool supportsMultiCTALaunch() const;
   bool supportsTDM() const;
   bool supportsClusterLoadBitWidth(int biwWidth) const;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -118,9 +118,7 @@ public:
   bool supportsBufferLoadToLocal() const;
 
   // Whether this target uses asyncmark/wait_asyncmark intrinsics for
-  // buffer_load_to_lds synchronization instead of vmcnt-based waits.
-  // When true, LLVM's SIInsertWaitcnts tracks LDS-bound loads separately,
-  // avoiding conservative vmcnt(0) barriers.
+  // async memory ops synchronization instead of waitcnt-based intrinsics waits.
   bool useAsyncMarks() const;
 
   bool supportsMultiCTALaunch() const;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
@@ -52,8 +52,14 @@ public:
   }
 
   std::optional<WaitOpInfo> getWaitOpInfo(Operation *op) const override {
-    // AMD amdgpu::AsyncWaitOp replaces ttg::AsyncWaitOp after
-    // UpdateAsyncWaitCount. Read the preserved commit-group count.
+    // On asyncmark targets (CDNA3/CDNA4), ttg::AsyncWaitOp is kept as-is
+    // by UpdateAsyncWaitCount — read the commit group count directly.
+    if (auto asyncWaitOp = dyn_cast<ttg::AsyncWaitOp>(op)) {
+      return WaitOpInfo{tti::CommitKind::AsyncCp, (int)asyncWaitOp.getNum(),
+                        /*transferWrites=*/true, /*transferReads=*/false};
+    }
+    // On non-asyncmark targets, amdgpu::AsyncWaitOp replaces ttg::AsyncWaitOp
+    // after UpdateAsyncWaitCount. Read the preserved commit-group count.
     if (auto asyncWaitOp = dyn_cast<ttag::AsyncWaitOp>(op)) {
       if (auto attr = asyncWaitOp->getAttrOfType<IntegerAttr>(
               "ttg.num_commit_groups")) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -397,21 +397,6 @@ struct TritonAMDGPUUpdateAsyncWaitCountPass
       return;
     }
 
-    // For HW which does not support async loads (GFX9) but only direct-to-lds,
-    // we still use the waitcnt to support interleaving of direct-to-lds loads
-    // when pipelining. The flag is used to emit warnings in case we find
-    // tt.loads/store which make the computed count conservative and hinder
-    // performance.
-    bool supportsAsyncLoads = true;
-    switch (targetInfo.getISAFamily()) {
-    case triton::AMD::ISAFamily::CDNA3:
-    case triton::AMD::ISAFamily::CDNA4:
-      supportsAsyncLoads = false;
-      break;
-    default:
-      break;
-    }
-
     ModuleOp m = getOperation();
 
     // ttg.async_wait should only count async **non** tdm load:
@@ -419,35 +404,36 @@ struct TritonAMDGPUUpdateAsyncWaitCountPass
     getOperation()->walk(
         [&](ttg::AsyncWaitOp waitOp) { waitOps.push_back(waitOp); });
 
-    ModuleAxisInfoAnalysis axisInfo(m);
-    // Cache #intrinsic per asyc op to avoid expensive recomputations
-    DenseMap<Operation *, int> intrinsicCountCache;
-    auto countAsyncLoadInstructions = [&](Operation *op) {
-      auto found = intrinsicCountCache.find(op);
-      if (found != intrinsicCountCache.end()) {
-        return found->second;
-      }
-      auto v = getOpNumberOfAsyncCopyInstructions(op, targetInfo, axisInfo,
-                                                  !supportsAsyncLoads);
-      intrinsicCountCache[op] = v;
-      return v;
-    };
-
-    // Note: AsyncWaits should ignore TDM ops; different HW counter
-    bool useAsyncMarks = llvm::is_contained(
-        {triton::AMD::ISAFamily::CDNA3, triton::AMD::ISAFamily::CDNA4},
-        targetInfo.getISAFamily());
-
-    for (auto waitOp : waitOps) {
-      IRRewriter builder(waitOp->getContext());
-      if (useAsyncMarks) {
-        // With asyncmark/wait_asyncmark, LLVM handles vmcnt computation.
-        // Pass through the commit group count directly.
+    // With asyncmark/wait_asyncmark, LLVM handles vmcnt computation —
+    // Triton no longer needs to walk the IR and count outstanding async
+    // intrinsics. Pass through the commit group count directly and skip
+    // the expensive ModuleAxisInfoAnalysis below.
+    if (targetInfo.useAsyncMarks()) {
+      for (auto waitOp : waitOps) {
+        IRRewriter builder(waitOp->getContext());
         auto tokens = waitOp.getAsyncToken();
         builder.setInsertionPointAfter(waitOp);
         builder.replaceOpWithNewOp<amdgpu::AsyncWaitOp>(waitOp, tokens,
                                                         waitOp.getNum());
-      } else {
+      }
+    } else {
+      // GFX1250 (and future arches without asyncmark) use instruction counting.
+      ModuleAxisInfoAnalysis axisInfo(m);
+      DenseMap<Operation *, int> intrinsicCountCache;
+      auto countAsyncLoadInstructions = [&](Operation *op) {
+        auto found = intrinsicCountCache.find(op);
+        if (found != intrinsicCountCache.end()) {
+          return found->second;
+        }
+        auto v = getOpNumberOfAsyncCopyInstructions(
+            op, targetInfo, axisInfo,
+            /*emitRemarkOnNonAsyncOp=*/false);
+        intrinsicCountCache[op] = v;
+        return v;
+      };
+
+      for (auto waitOp : waitOps) {
+        IRRewriter builder(waitOp->getContext());
         updateWaitCount(waitOp, countAsyncLoadInstructions, builder);
       }
     }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -434,9 +434,22 @@ struct TritonAMDGPUUpdateAsyncWaitCountPass
     };
 
     // Note: AsyncWaits should ignore TDM ops; different HW counter
+    bool useAsyncMarks = llvm::is_contained(
+        {triton::AMD::ISAFamily::CDNA3, triton::AMD::ISAFamily::CDNA4},
+        targetInfo.getISAFamily());
+
     for (auto waitOp : waitOps) {
       IRRewriter builder(waitOp->getContext());
-      updateWaitCount(waitOp, countAsyncLoadInstructions, builder);
+      if (useAsyncMarks) {
+        // With asyncmark/wait_asyncmark, LLVM handles vmcnt computation.
+        // Pass through the commit group count directly.
+        auto tokens = waitOp.getAsyncToken();
+        builder.setInsertionPointAfter(waitOp);
+        builder.replaceOpWithNewOp<amdgpu::AsyncWaitOp>(waitOp, tokens,
+                                                        waitOp.getNum());
+      } else {
+        updateWaitCount(waitOp, countAsyncLoadInstructions, builder);
+      }
     }
 
     // amdgpu.AsyncTDMWait should only count async tdm ops

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -399,25 +399,16 @@ struct TritonAMDGPUUpdateAsyncWaitCountPass
 
     ModuleOp m = getOperation();
 
-    // ttg.async_wait should only count async **non** tdm load:
-    SmallVector<ttg::AsyncWaitOp> waitOps;
-    getOperation()->walk(
-        [&](ttg::AsyncWaitOp waitOp) { waitOps.push_back(waitOp); });
-
     // With asyncmark/wait_asyncmark, LLVM handles vmcnt computation —
     // Triton no longer needs to walk the IR and count outstanding async
-    // intrinsics. Pass through the commit group count directly and skip
-    // the expensive ModuleAxisInfoAnalysis below.
-    if (targetInfo.useAsyncMarks()) {
-      for (auto waitOp : waitOps) {
-        IRRewriter builder(waitOp->getContext());
-        auto tokens = waitOp.getAsyncToken();
-        builder.setInsertionPointAfter(waitOp);
-        builder.replaceOpWithNewOp<amdgpu::AsyncWaitOp>(waitOp, tokens,
-                                                        waitOp.getNum());
-      }
-    } else {
+    // intrinsics. Keep the ttg.async_wait ops unchanged (they track
+    // commit groups) and lower them directly to wait_asyncmark later.
+    if (!targetInfo.useAsyncMarks()) {
       // GFX1250 (and future arches without asyncmark) use instruction counting.
+      SmallVector<ttg::AsyncWaitOp> waitOps;
+      getOperation()->walk(
+          [&](ttg::AsyncWaitOp waitOp) { waitOps.push_back(waitOp); });
+
       ModuleAxisInfoAnalysis axisInfo(m);
       DenseMap<Operation *, int> intrinsicCountCache;
       auto countAsyncLoadInstructions = [&](Operation *op) {


### PR DESCRIPTION
## Problem

  On CDNA3 (gfx942) and CDNA4 (gfx950), there are two issues with `buffer_load_to_lds` synchronization:

  **1. Conservative waits before `ds_read` due to sync modeling**

  LLVM models `buffer_load_to_lds` as a synchronous operation that writes to LDS. When it sees a subsequent `ds_read` from
  LDS, it assumes a potential data hazard and inserts a conservative `s_waitcnt vmcnt(0)` — even when the addresses are
  disjoint. The current workaround annotates `buffer_load_to_lds` and LDS loads with no-alias attributes so LLVM skips the
  barrier. This is fragile and relies on alias analysis heuristics.

  **2. Conflicting wait count management between Triton and LLVM**

  `buffer_load_to_lds` and regular `buffer_load` share the same hardware `vmcnt` counter. Triton manages the wait counts for
   `buffer_load_to_lds`, while LLVM independently manages wait counts for `buffer_load` — without accounting for the
  outstanding `buffer_load_to_lds` instructions on the same counter. This leads to LLVM inserting very conservative
  `s_waitcnt vmcnt(0)` before some `ds_read` instructions, because it doesn't know how many total outstanding loads (of both
   types) are pending. The no-alias workaround cannot solve this problem.

  ## Solution

  LLVM recently added `asyncmark` / `wait_asyncmark` intrinsics that properly solve both issues. When using the
  async-variant intrinsics (`llvm.amdgcn.raw.ptr.buffer.load.lds.async`, `llvm.amdgcn.global.load.lds.async`) alongside
  these markers, LLVM models LDS-bound loads as async operations rather than synchronous ones. This means:

  - LLVM no longer treats `buffer_load_to_lds` as an immediate LDS write, so it doesn't insert spurious waits before
  `ds_read` (solving issue 1)
  - LLVM has full visibility into both load types and can compute precise wait counts on the shared `vmcnt` counter (solving
   issue 2)

  This is a strictly better solution than the no-alias workaround for both issues.

  This PR switches CDNA3/CDNA4 to use the async intrinsic variants and asyncmark-based synchronization:

  - **BufferOpsEmitter**: Emit `rocdl.raw.ptr.buffer.load.async.lds` instead of `rocdl.raw.ptr.buffer.load.lds`
  - **LoadStoreOpToLLVM**: Emit `rocdl.global.load.async.lds` for global-to-LDS copies, `rocdl.asyncmark` for commit groups,
   and `rocdl.wait.asyncmark` for async waits
  - **UpdateAsyncWaitCount**: With asyncmark, LLVM handles vmcnt computation — Triton passes through the commit group count
  directly and skips the expensive `ModuleAxisInfoAnalysis`
  - **TargetInfo**: Add `useAsyncMarks()` feature flag to centralize the arch check (makes future arch enablement a one-line
   change)