### PR TITLE
[Runtime] Skip autotuning when pruning yields a single config

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -173,6 +173,44 @@ def test_prune_configs(with_perf_model: bool, device: str):
         assert records['capture_named_args']
 
 
+@pytest.mark.parametrize('use_perf_model', [False, True])
+def test_skip_bench_single_pruned_config(use_perf_model: bool, device: str):
+    N = 1024
+    src = torch.randn(N, device=device)
+    dst = torch.empty(N, device=device)
+    bench_calls = []
+
+    def tracking_do_bench(kernel_call, quantiles, **kwargs):
+        bench_calls.append(True)
+        return triton.testing.do_bench(kernel_call, quantiles=quantiles, warmup=1, rep=1)
+
+    def early_config_prune(configs, named_args, **kwargs):
+        return [configs[0]]
+
+    def perf_model(*args, **kwargs):
+        return kwargs['BLOCK_SIZE']
+
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
+
+    if use_perf_model:
+        prune_configs_by = {'perf_model': perf_model, 'top_k': 1}
+    else:
+        prune_configs_by = {'early_config_prune': early_config_prune}
+
+    @triton.autotune(configs=configs, key=['N'], prune_configs_by=prune_configs_by, do_bench=tracking_do_bench)
+    @triton.jit
+    def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + offsets, mask=offsets < N)
+        tl.store(dst + offsets, x, mask=offsets < N)
+
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
+    _kernel[grid](dst, src, N=N)
+    torch.testing.assert_close(src, dst)
+    # Benchmarking should be skipped when only one config remains after pruning
+    assert len(bench_calls) == 0, f"Expected no benchmark calls, got {len(bench_calls)}"
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
                     reason="Requires compute capability >= 9 for NV")
 def test_override_ttir(device):

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -224,20 +224,25 @@ class Autotuner(KernelInterface):
                 used_cached_result = False
                 pruned_configs = self.prune_configs(kwargs)
 
-                def benchmark():
-                    bench_start = time.time()
-                    timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
-                    bench_end = time.time()
-                    self.bench_time = bench_end - bench_start
-                    self.cache[key] = builtins.min(timings, key=timings.get)
-                    full_nargs = {**self.nargs, **kwargs, **self.cache[key].all_kwargs()}
-                    self.pre_hook(full_nargs, reset_only=True)
-                    self.configs_timings = timings
-
-                if self.cache_results:
-                    used_cached_result = self.check_disk_cache(key, pruned_configs, benchmark)
+                if len(pruned_configs) == 1:
+                    self.cache[key] = pruned_configs[0]
+                    used_cached_result = True
                 else:
-                    benchmark()
+
+                    def benchmark():
+                        bench_start = time.time()
+                        timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
+                        bench_end = time.time()
+                        self.bench_time = bench_end - bench_start
+                        self.cache[key] = builtins.min(timings, key=timings.get)
+                        full_nargs = {**self.nargs, **kwargs, **self.cache[key].all_kwargs()}
+                        self.pre_hook(full_nargs, reset_only=True)
+                        self.configs_timings = timings
+
+                    if self.cache_results:
+                        used_cached_result = self.check_disk_cache(key, pruned_configs, benchmark)
+                    else:
+                        benchmark()
 
             config = self.cache[key]
         else:


### PR DESCRIPTION
## Summary

When `prune_configs_by` returns only one config after pruning, the autotuner still benchmarks it unnecessarily. This PR adds a short-circuit to skip benchmarking in this case, consistent with the existing behavior when the initial config list has only one entry (line 243-244 in `autotuner.py`).

Closes #9821

## Changes

- **`python/triton/runtime/autotuner.py`**: After `prune_configs()`, check if only one config remains. If so, use it directly without benchmarking.
- **`python/test/unit/runtime/test_autotuner.py`**: Add parametrized test (`early_config_prune` and `perf_model` paths) verifying that benchmarking is skipped when pruning yields a single config.

<details>
<summary>Code diff explanation</summary>

Before (always benchmarks after pruning):
```python
pruned_configs = self.prune_configs(kwargs)

def benchmark():
    timings = {config: self._bench(...) for config in pruned_configs}
    self.cache[key] = builtins.min(timings, key=timings.get)
    ...

if self.cache_results:
    used_cached_result = self.check_disk_cache(key, pruned_configs, benchmark)
else:
    benchmark()
```

After (skips benchmarking when only one config remains):
```python
pruned_configs = self.prune_configs(kwargs)

if len(pruned_configs) == 1:
    self.cache[key] = pruned_configs[0]
    used_cached_result = True
else:
    def benchmark():
        ...
    if self.cache_results:
        ...
    else:
        benchmark()
```

</details>

## Test plan
- [x] New test `test_skip_bench_single_pruned_config` covers both `early_config_prune` and `perf_model` pruning paths
- [x] Test verifies `do_bench` is never called when pruning yields a single config
- [x] Test verifies kernel still produces correct output
- [ ] CI: existing `test_prune_configs` should continue to pass (prune path is unchanged)