### PR TITLE
[Runtime] Cache autotune timings per-config for incremental updates

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -1,3 +1,8 @@
+import json
+import os
+import tempfile
+from unittest import mock
+
 import torch
 
 import triton
@@ -7,6 +12,7 @@ import pytest
 import pathlib
 import uuid
 from triton._internal_testing import is_cuda
+from triton.runtime.autotuner import Autotuner, Config
 
 
 def do_bench(kernel_call, quantiles, use_cuda_graph=False):
@@ -477,3 +483,235 @@ def test_prune_all_configs(device):
         assert e is not None and str(
             e
         ) == "Autotuner error: No valid autotuner configs after pruning. `early_config_prune` should return at least one config."
+
+
+# ---------------------------------------------------------------------------
+# Per-config cache tests (Issue #9822)
+# ---------------------------------------------------------------------------
+
+
+class _TempDirCacheManager:
+    """Cache manager backed by a real temporary directory."""
+
+    def __init__(self):
+        self._dir = tempfile.mkdtemp()
+
+    def get_file(self, filename):
+        path = os.path.join(self._dir, filename)
+        return path if os.path.exists(path) else None
+
+    def put(self, data, filename, binary=True):
+        path = os.path.join(self._dir, filename)
+        with open(path, "w") as f:
+            f.write(data)
+        return path
+
+
+def _make_autotuner_stub(configs):
+    """Build a minimal Autotuner-like object for ``check_disk_cache``."""
+    at = object.__new__(Autotuner)
+    at.configs = configs
+    at.cache = {}
+    at.configs_timings = {}
+    fn_stub = mock.MagicMock()
+    fn_stub.cache_key = "fake_fn_cache_key"
+    fn_stub.__name__ = "test_kernel"
+    fn_stub.fn = fn_stub
+    at.fn = fn_stub
+    return at
+
+
+def _write_cache_file(cache_mgr, fn_name, data):
+    file_name = f"{fn_name[:150]}.autotune.json"
+    cache_mgr.put(json.dumps(data), file_name, binary=False)
+
+
+@pytest.fixture()
+def _patch_cache_deps():
+    """Patch heavy dependencies used inside ``check_disk_cache``."""
+    with mock.patch("triton.runtime.autotuner.triton_key", return_value="test_triton_key"), \
+         mock.patch("triton.runtime.autotuner.get_cache_invalidating_env_vars", return_value={}), \
+         mock.patch("triton.runtime.autotuner.driver") as mock_driver, \
+         mock.patch("triton.runtime.autotuner.JITFunction", new=type(mock.MagicMock())):
+        mock_backend = mock.MagicMock()
+        mock_backend.hash.return_value = "fake_backend_hash"
+        with mock.patch("triton.compiler.compiler.make_backend", return_value=mock_backend):
+            mock_driver.active.get_current_target.return_value = "fake_target"
+            yield
+
+
+@pytest.fixture()
+def cache_mgr():
+    """Yield a ``_TempDirCacheManager`` patched into ``get_cache_manager``."""
+    cm = _TempDirCacheManager()
+    with mock.patch("triton.runtime.autotuner.get_cache_manager", return_value=cm):
+        yield cm
+
+
+class TestPerConfigCache:
+    """Tests for the per-config caching introduced in Issue #9822."""
+
+    @pytest.mark.usefixtures("_patch_cache_deps")
+    def test_add_new_config_only_benchmarks_new(self, cache_mgr):
+        config_a = Config({"BLOCK_SIZE": 32}, num_warps=4, num_stages=3)
+        config_b = Config({"BLOCK_SIZE": 64}, num_warps=4, num_stages=3)
+        config_c = Config({"BLOCK_SIZE": 128}, num_warps=4, num_stages=3)
+
+        _write_cache_file(
+            cache_mgr, "test_kernel", {
+                "version": 2,
+                "key": (1024, ),
+                "configs_timings": [
+                    (config_a.__dict__, [1.0, 0.9, 1.1]),
+                    (config_b.__dict__, [2.0, 1.8, 2.2]),
+                ],
+            })
+
+        at = _make_autotuner_stub([config_a, config_b, config_c])
+        benchmarked = []
+
+        def bench_fn(configs_to_bench=None):
+            if configs_to_bench is None:
+                configs_to_bench = [config_a, config_b, config_c]
+            benchmarked.extend(configs_to_bench)
+            at.configs_timings = {c: [3.0] for c in configs_to_bench}
+            at.cache[(1024, )] = configs_to_bench[0]
+
+        result = at.check_disk_cache((1024, ), [config_a, config_b, config_c], bench_fn)
+        assert result is False
+        assert benchmarked == [config_c]
+        assert at.cache[(1024, )] == config_a
+
+    @pytest.mark.usefixtures("_patch_cache_deps")
+    def test_remove_config_uses_remaining_cache(self, cache_mgr):
+        config_a = Config({"BLOCK_SIZE": 32}, num_warps=4, num_stages=3)
+        config_b = Config({"BLOCK_SIZE": 64}, num_warps=4, num_stages=3)
+
+        _write_cache_file(
+            cache_mgr, "test_kernel", {
+                "version": 2,
+                "key": (1024, ),
+                "configs_timings": [
+                    (config_a.__dict__, [1.0, 0.9, 1.1]),
+                    (config_b.__dict__, [2.0, 1.8, 2.2]),
+                ],
+            })
+
+        at = _make_autotuner_stub([config_b])
+        bench_called = False
+
+        def bench_fn(configs_to_bench=None):
+            nonlocal bench_called
+            bench_called = True
+
+        result = at.check_disk_cache((1024, ), [config_b], bench_fn)
+        assert result is True
+        assert bench_called is False
+        assert at.cache[(1024, )] == config_b
+
+    @pytest.mark.usefixtures("_patch_cache_deps")
+    def test_all_cached_skips_benchmark(self, cache_mgr):
+        config_a = Config({"BLOCK_SIZE": 32}, num_warps=4, num_stages=3)
+        config_b = Config({"BLOCK_SIZE": 64}, num_warps=4, num_stages=3)
+
+        _write_cache_file(
+            cache_mgr, "test_kernel", {
+                "version": 2,
+                "key": (1024, ),
+                "configs_timings": [
+                    (config_a.__dict__, [1.0, 0.9, 1.1]),
+                    (config_b.__dict__, [2.0, 1.8, 2.2]),
+                ],
+            })
+
+        at = _make_autotuner_stub([config_a, config_b])
+        bench_called = False
+
+        def bench_fn(configs_to_bench=None):
+            nonlocal bench_called
+            bench_called = True
+
+        result = at.check_disk_cache((1024, ), [config_a, config_b], bench_fn)
+        assert result is True
+        assert bench_called is False
+        assert at.cache[(1024, )] == config_a
+
+    @pytest.mark.usefixtures("_patch_cache_deps")
+    def test_old_format_fallback(self, cache_mgr):
+        config_a = Config({"BLOCK_SIZE": 32}, num_warps=4, num_stages=3)
+        config_b = Config({"BLOCK_SIZE": 64}, num_warps=4, num_stages=3)
+
+        _write_cache_file(
+            cache_mgr, "test_kernel", {
+                "key": (1024, ),
+                "configs_timings": [
+                    (config_a.__dict__, [1.0, 0.9, 1.1]),
+                    (config_b.__dict__, [2.0, 1.8, 2.2]),
+                ],
+            })
+
+        at = _make_autotuner_stub([config_a, config_b])
+        benched = []
+
+        def bench_fn(configs_to_bench=None):
+            if configs_to_bench is None:
+                configs_to_bench = [config_a, config_b]
+            benched.extend(configs_to_bench)
+            at.configs_timings = {c: [5.0] for c in configs_to_bench}
+            at.cache[(1024, )] = configs_to_bench[0]
+
+        result = at.check_disk_cache((1024, ), [config_a, config_b], bench_fn)
+        assert result is False
+        assert set(benched) == {config_a, config_b}
+
+    @pytest.mark.usefixtures("_patch_cache_deps")
+    def test_no_cache_file_benchmarks_all(self, cache_mgr):
+        config_a = Config({"BLOCK_SIZE": 32}, num_warps=4, num_stages=3)
+        config_b = Config({"BLOCK_SIZE": 64}, num_warps=4, num_stages=3)
+
+        at = _make_autotuner_stub([config_a, config_b])
+        benched = []
+
+        def bench_fn(configs_to_bench=None):
+            if configs_to_bench is None:
+                configs_to_bench = [config_a, config_b]
+            benched.extend(configs_to_bench)
+            at.configs_timings = {c: [1.0] for c in configs_to_bench}
+            at.cache[(1024, )] = configs_to_bench[0]
+
+        result = at.check_disk_cache((1024, ), [config_a, config_b], bench_fn)
+        assert result is False
+        assert set(benched) == {config_a, config_b}
+
+    @pytest.mark.usefixtures("_patch_cache_deps")
+    def test_cached_timings_for_removed_configs_preserved(self, cache_mgr):
+        config_a = Config({"BLOCK_SIZE": 32}, num_warps=4, num_stages=3)
+        config_b = Config({"BLOCK_SIZE": 64}, num_warps=4, num_stages=3)
+        config_c = Config({"BLOCK_SIZE": 128}, num_warps=4, num_stages=3)
+
+        _write_cache_file(
+            cache_mgr, "test_kernel", {
+                "version": 2,
+                "key": (1024, ),
+                "configs_timings": [
+                    (config_a.__dict__, [1.0, 0.9, 1.1]),
+                    (config_b.__dict__, [2.0, 1.8, 2.2]),
+                ],
+            })
+
+        at = _make_autotuner_stub([config_a, config_c])
+
+        def bench_fn(configs_to_bench=None):
+            if configs_to_bench is None:
+                configs_to_bench = [config_a, config_c]
+            at.configs_timings = {c: [3.0] for c in configs_to_bench}
+            at.cache[(1024, )] = configs_to_bench[0]
+
+        at.check_disk_cache((1024, ), [config_a, config_c], bench_fn)
+
+        # Read the cache file and verify config_b is still there.
+        path = cache_mgr.get_file("test_kernel.autotune.json")
+        with open(path) as f:
+            data = json.load(f)
+        cached = {Config(**c): t for c, t in data["configs_timings"]}
+        assert config_b in cached

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -180,34 +180,79 @@ class Autotuner(KernelInterface):
             fn = fn.fn
 
         env_vars = get_cache_invalidating_env_vars()
+        # Cache key does NOT include configs so that adding/removing configs
+        # only requires benchmarking the new ones instead of invalidating the
+        # entire cache.
         cache_key = [
             triton_key(),
             make_backend(driver.active.get_current_target()).hash(),
             fn.cache_key,
             str(sorted(env_vars.items())),
             str(tuning_key),
-        ] + [str(c) for c in configs]
+        ]
         cache_key = hashlib.sha256("-".join(cache_key).encode("utf-8")).hexdigest()
         cache = get_cache_manager(cache_key)
         file_name = f"{fn.__name__[:150]}.autotune.json"
         path = cache.get_file(file_name)
+
         if path:
             with open(path, "r") as cached_configs:
-                timings = json.load(cached_configs)["configs_timings"]
-                timings = {Config(**config): timing for config, timing in timings}
-                self.cache[tuning_key] = builtins.min(timings, key=timings.get)
-                self.configs_timings = timings
-            return True
+                data = json.load(cached_configs)
+
+            # Old format (no "version" field): fall back to full re-benchmark
+            # to avoid mixing incompatible cache layouts.
+            if "version" not in data:
+                bench_fn()
+                self._write_per_config_cache(cache, file_name, tuning_key)
+                return False
+
+            cached_timings = {Config(**config): timing for config, timing in data["configs_timings"]}
+
+            # Partition current configs into cached and uncached sets.
+            configs_set = set(configs)
+            hit_timings = {c: cached_timings[c] for c in configs_set if c in cached_timings}
+            uncached_configs = [c for c in configs if c not in cached_timings]
+
+            if not uncached_configs:
+                # All configs have cached timings -- skip benchmarking entirely.
+                self.configs_timings = hit_timings
+                self.cache[tuning_key] = builtins.min(hit_timings, key=hit_timings.get)
+                return True
+
+            # Benchmark only the uncached configs.
+            bench_fn(uncached_configs)
+
+            # Merge cached timings with newly benchmarked timings.
+            merged = dict(hit_timings)
+            merged.update(self.configs_timings)
+            self.configs_timings = merged
+            self.cache[tuning_key] = builtins.min(merged, key=merged.get)
+
+            # Persist the updated (cached + new) timings back to disk.
+            # Include all previously cached timings for configs not in the
+            # current list so they are not lost.
+            all_timings = dict(cached_timings)
+            all_timings.update(self.configs_timings)
+            self._write_per_config_cache(cache, file_name, tuning_key, all_timings)
+            return False
 
         bench_fn()
+        self._write_per_config_cache(cache, file_name, tuning_key)
+        return False
+
+    def _write_per_config_cache(self, cache, file_name, tuning_key, timings=None):
+        """Write per-config timing data using the v2 cache format."""
+        if timings is None:
+            timings = self.configs_timings
         cache.put(
             json.dumps({
+                "version":
+                2,
                 "key":
                 tuning_key,
                 "configs_timings":
-                [(config.__dict__, timings) for config, timings in self.configs_timings.items() if not config.pre_hook],
+                [(config.__dict__, timing) for config, timing in timings.items() if not config.pre_hook],
             }), file_name, binary=False)
-        return False
 
     def run(self, *args, **kwargs):
         self.nargs = dict(zip(self.arg_names, args))
@@ -224,9 +269,11 @@ class Autotuner(KernelInterface):
                 used_cached_result = False
                 pruned_configs = self.prune_configs(kwargs)
 
-                def benchmark():
+                def benchmark(configs_to_bench=None):
+                    if configs_to_bench is None:
+                        configs_to_bench = pruned_configs
                     bench_start = time.time()
-                    timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
+                    timings = {config: self._bench(*args, config=config, **kwargs) for config in configs_to_bench}
                     bench_end = time.time()
                     self.bench_time = bench_end - bench_start
                     self.cache[key] = builtins.min(timings, key=timings.get)


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Summary

When `cache_results` is set for `@triton.autotune`, timings are cached to disk. Previously, the cache key included the full list of configs (`[str(c) for c in configs]`), so **adding or removing a single config invalidated the entire cache** and forced a complete re-benchmark of all configs.

This PR removes configs from the cache key and introduces a v2 cache format that stores timings per-config independently, enabling incremental autotuning:

- **All cached** → skip benchmarking entirely (same as before)
- **New config added** → benchmark only the new config, merge with cached timings
- **Config removed** → use remaining cached timings, no re-benchmark needed
- **Old format cache** → fallback to full re-benchmark, rewrite as v2

### Changes

- **`python/triton/runtime/autotuner.py`**:
  - Remove `[str(c) for c in configs]` from `cache_key` computation
  - Add v2 format detection (`"version": 2` field)
  - Partition configs into cached/uncached sets and benchmark incrementally
  - Extract `_write_per_config_cache()` helper
  - `benchmark()` closure accepts optional `configs_to_bench` parameter

- **`python/test/unit/runtime/test_autotuner.py`**:
  - Add `TestPerConfigCache` class with 6 test cases covering: add config, remove config, all cached, old format fallback, no cache, and timing preservation for removed configs

<details>
<summary>Before (adding a config invalidates all cached timings)</summary>

```python
# cache_key includes all configs:
cache_key = [...] + [str(c) for c in configs]
# Result: changing config list → different hash → cache miss → re-benchmark ALL
```

</details>

<details>
<summary>After (only new configs are benchmarked)</summary>

```python
# cache_key excludes configs:
cache_key = [triton_key(), backend_hash, fn.cache_key, env_vars, tuning_key]
# Result: changing config list → same hash → load cache → benchmark only new configs
```

</details>

Closes #9822