### PR TITLE
[release/3.7.x] AMD post-release cut cherry-picks

### DIFF
--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen2.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gen2.mlir
@@ -125,3 +125,67 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// Test for mixed FP8 types (f8E4M3FN x f8E5M2) - verifies that no fp_to_fp
+// conversion is generated since hardware supports mixed FP8 natively.
+// CHECK: #[[DOT_OP_PARENT:.+]] = #ttg.blocked<{{.*}}>
+// CHECK: #[[WMMA:.+]] = #ttg.amd_wmma<{version = 2, isTranspose = true, ctaLayout = {warp = {{\[\[0, 1\], \[1, 0\]\]}}}}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @wmma_dot_mixed_fp8_bf8(
+   // CHECK: %[[ARG_A:.+]]: tensor<32x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #[[DOT_OP_PARENT]]}>>
+   %0: tensor<32x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+   // CHECK-SAME: %[[ARG_B:.+]]: tensor<64x32xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #[[DOT_OP_PARENT]]}>>
+   %1: tensor<64x32xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+   %2: tensor<32x32x!tt.ptr<f32>, #blocked>) {
+    // CHECK-NOT: tt.fp_to_fp
+    // CHECK: %[[ARG_C:.+]] = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #[[DOT_OP_PARENT]]>
+    // CHECK: %[[OP_C:.+]] = ttg.convert_layout %[[ARG_C]]
+    // CHECK-SAME: -> tensor<32x32xf32, #[[WMMA]]>
+    %3 = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked>
+    // CHECK: %[[OP_A:.+]] = ttg.convert_layout %[[ARG_A]]
+    // CHECK-SAME: -> tensor<32x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #[[WMMA]]
+    // CHECK: %[[OP_B:.+]] = ttg.convert_layout %[[ARG_B]]
+    // CHECK-SAME: -> tensor<64x32xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #[[WMMA]]
+    // CHECK: %[[WMMA_RES:.+]] = tt.dot %[[OP_A]], %[[OP_B]], %[[OP_C]]
+    // CHECK-SAME: tensor<32x64xf8E4M3FN, {{.*}}> * tensor<64x32xf8E5M2, {{.*}}> -> tensor<32x32xf32, #[[WMMA]]>
+    %4 = tt.dot %0, %1, %3 : tensor<32x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x32xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x32xf32, #blocked>
+    // CHECK: ttg.convert_layout %[[WMMA_RES]]
+    // CHECK-SAME: -> tensor<32x32xf32, #[[DOT_OP_PARENT]]>
+    tt.store %2, %4 : tensor<32x32x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Test for mixed FP8 types in reverse order (f8E5M2 x f8E4M3FN) - verifies
+// hardware native support for bf8_fp8 WMMA instruction.
+// CHECK: #[[DOT_OP_PARENT:.+]] = #ttg.blocked<{{.*}}>
+// CHECK: #[[WMMA:.+]] = #ttg.amd_wmma<{version = 2, isTranspose = true, ctaLayout = {warp = {{\[\[0, 1\], \[1, 0\]\]}}}}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @wmma_dot_mixed_bf8_fp8(
+   // CHECK: %[[ARG_A:.+]]: tensor<32x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #[[DOT_OP_PARENT]]}>>
+   %0: tensor<32x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+   // CHECK-SAME: %[[ARG_B:.+]]: tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #[[DOT_OP_PARENT]]}>>
+   %1: tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+   %2: tensor<32x32x!tt.ptr<f32>, #blocked>) {
+    // CHECK-NOT: tt.fp_to_fp
+    // CHECK: %[[ARG_C:.+]] = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #[[DOT_OP_PARENT]]>
+    %3 = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked>
+    // CHECK: %[[OP_A:.+]] = ttg.convert_layout %[[ARG_A]]
+    // CHECK-SAME: -> tensor<32x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #[[WMMA]]
+    // CHECK: %[[OP_B:.+]] = ttg.convert_layout %[[ARG_B]]
+    // CHECK-SAME: -> tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #[[WMMA]]
+    // CHECK: %[[WMMA_RES:.+]] = tt.dot %[[OP_A]], %[[OP_B]]
+    // CHECK-SAME: tensor<32x64xf8E5M2, {{.*}}> * tensor<64x32xf8E4M3FN, {{.*}}> -> tensor<32x32xf32, #[[WMMA]]>
+    %4 = tt.dot %0, %1, %3 : tensor<32x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x32xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x32xf32, #blocked>
+    // CHECK: ttg.convert_layout %[[WMMA_RES]]
+    // CHECK-SAME: -> tensor<32x32xf32, #[[DOT_OP_PARENT]]>
+    tt.store %2, %4 : tensor<32x32x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-block-pingpong.mlir
+++ b/test/TritonGPU/amd/amd-block-pingpong.mlir
@@ -2032,3 +2032,76 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return %result#0 : tensor<128x128xf32, #mma>
   }
 }
+
+// -----
+
+// Test with FMA based dot, pingpong should skip optimization of such kernels.
+// Based on pingpong_small test.
+
+// CHECK-LABEL: fma_dot_neg
+// CHECK-NOT: rocdl.sched.barrier
+// CHECK-NOT: rocdl.s.setprio
+// CHECK-NOT: async
+
+#blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#fake_mma = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @fma_dot_neg(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #fake_mma>
+    %c1_i32 = arith.constant 1 : i32
+    %cst_0 = arith.constant dense<64> : tensor<64x128xi32, #blocked>
+    %cst_1 = arith.constant dense<64> : tensor<128x64xi32, #blocked1>
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %0 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x1x!tt.ptr<f16>, #blocked1>
+    %1 = tt.get_program_id x : i32
+    %2 = tt.splat %1 : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    %4 = arith.addi %2, %3 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked1}>>
+    %5 = tt.expand_dims %4 {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked1}>> -> tensor<128x1xi32, #blocked1>
+    %6 = tt.splat %arg3 : i32 -> tensor<128x1xi32, #blocked1>
+    %7 = arith.muli %5, %6 : tensor<128x1xi32, #blocked1>
+    %8 = tt.addptr %0, %7 : tensor<128x1x!tt.ptr<f16>, #blocked1>, tensor<128x1xi32, #blocked1>
+    %9 = tt.broadcast %8 : tensor<128x1x!tt.ptr<f16>, #blocked1> -> tensor<128x64x!tt.ptr<f16>, #blocked1>
+    %10 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>>
+    %11 = tt.expand_dims %10 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x64xi32, #blocked1>
+    %12 = tt.broadcast %11 : tensor<1x64xi32, #blocked1> -> tensor<128x64xi32, #blocked1>
+    %13 = tt.addptr %9, %12 : tensor<128x64x!tt.ptr<f16>, #blocked1>, tensor<128x64xi32, #blocked1>
+    %14 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<64x1x!tt.ptr<f16>, #blocked>
+    %15 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %16 = tt.expand_dims %15 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %17 = tt.addptr %14, %16 : tensor<64x1x!tt.ptr<f16>, #blocked>, tensor<64x1xi32, #blocked>
+    %18 = tt.broadcast %17 : tensor<64x1x!tt.ptr<f16>, #blocked> -> tensor<64x128x!tt.ptr<f16>, #blocked>
+    %19 = tt.splat %arg4 : i32 -> tensor<64x128xi32, #blocked>
+    %20 = tt.addptr %18, %19 : tensor<64x128x!tt.ptr<f16>, #blocked>, tensor<64x128xi32, #blocked>
+    %21 = ttg.local_alloc : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+    %22 = ttg.local_alloc : () -> !ttg.memdesc<1x64x128xf16, #shared1, #smem, mutable>
+    %23 = ttg.memdesc_index %21[%c0_i32] : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %24 = ttg.memdesc_index %22[%c0_i32] : !ttg.memdesc<1x64x128xf16, #shared1, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared1, #smem, mutable>
+    %25:6 = scf.for %arg5 = %c0_i32 to %c64_i32 step %c1_i32 iter_args(%arg6 = %cst, %arg7 = %13, %arg8 = %20, %arg9 = %c0_i32, %arg10 = %23, %arg11 = %24) -> (tensor<128x128xf32, #fake_mma>, tensor<128x64x!tt.ptr<f16>, #blocked1>, tensor<64x128x!tt.ptr<f16>, #blocked>, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x128xf16, #shared1, #smem, mutable>)  : i32 {
+      %26 = tt.addptr %arg7, %cst_1 : tensor<128x64x!tt.ptr<f16>, #blocked1>, tensor<128x64xi32, #blocked1>
+      %27 = tt.load %26 : tensor<128x64x!tt.ptr<f16>, #blocked1>
+      %28 = tt.addptr %arg8, %cst_0 : tensor<64x128x!tt.ptr<f16>, #blocked>, tensor<64x128xi32, #blocked>
+      %29 = tt.load %28 : tensor<64x128x!tt.ptr<f16>, #blocked>
+      %30 = ttg.local_load %arg10 : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #fake_mma}>>
+      %31 = ttg.local_load %arg11 : !ttg.memdesc<64x128xf16, #shared1, #smem, mutable> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #fake_mma}>>
+      %32 = arith.negf %31 : tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #fake_mma}>>
+      %33 = tt.dot %30, %32, %arg6 : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #fake_mma}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #fake_mma}>> -> tensor<128x128xf32, #fake_mma>
+      %34 = arith.addi %arg9, %c1_i32 : i32
+      %35 = arith.cmpi slt, %34, %c1_i32 : i32
+      %36 = arith.select %35, %34, %c0_i32 : i32
+      %37 = ttg.memdesc_index %21[%36] : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      ttg.local_store %27, %37 : tensor<128x64xf16, #blocked1> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %38 = ttg.memdesc_index %22[%36] : !ttg.memdesc<1x64x128xf16, #shared1, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared1, #smem, mutable>
+      ttg.local_store %29, %38 : tensor<64x128xf16, #blocked> -> !ttg.memdesc<64x128xf16, #shared1, #smem, mutable>
+      scf.yield %33, %26, %28, %36, %37, %38 : tensor<128x128xf32, #fake_mma>, tensor<128x64x!tt.ptr<f16>, #blocked1>, tensor<64x128x!tt.ptr<f16>, #blocked>, i32, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x128xf16, #shared1, #smem, mutable>
+    }
+    ttg.local_dealloc %21 : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+    ttg.local_dealloc %22 : !ttg.memdesc<1x64x128xf16, #shared1, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-pipeline-padded-layout-small-tile-gfx950.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-padded-layout-small-tile-gfx950.mlir
@@ -1,0 +1,33 @@
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-pipeline="use_async_copy=1" | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [16, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [1, 1], instrShape = [32, 32, 16], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: pipeline_padded_layout_gfx950
+  // CHECK-NOT: ttg.padded_shared
+  tt.func @pipeline_padded_layout_gfx950(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    // CHECK: ttg.async_wait %{{.*}}
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #mma>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x16xi32, #blocked>
+    %2 = tt.broadcast %1 : tensor<1x16xi32, #blocked> -> tensor<16x16xi32, #blocked>
+    %3 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #blocked>
+    %4 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<16x16x!tt.ptr<f16>, #blocked>
+    %5 = tt.addptr %3, %2 : tensor<16x16x!tt.ptr<f16>, #blocked>, tensor<16x16xi32, #blocked>
+    %6 = tt.addptr %4, %2 : tensor<16x16x!tt.ptr<f16>, #blocked>, tensor<16x16xi32, #blocked>
+
+    %7 = scf.for %arg3 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg4 = %cst) -> (tensor<16x16xf32, #mma>)  : i32 {
+      %9 = tt.load %5 {loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<16x16x!tt.ptr<f16>, #blocked>
+      %10 = tt.load %6 {loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<16x16x!tt.ptr<f16>, #blocked>
+      %11 = ttg.convert_layout %9 : tensor<16x16xf16, #blocked> -> tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+      %12 = ttg.convert_layout %10 : tensor<16x16xf16, #blocked> -> tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+      %13 = tt.dot %11, %12, %arg4 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<16x16xf32, #mma>
+      scf.yield %13 : tensor<16x16xf32, #mma>
+    } {tt.scheduled_max_stage = 1 : i32}
+
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-prepare-if-combining.mlir
+++ b/test/TritonGPU/amd/amd-prepare-if-combining.mlir
@@ -122,6 +122,49 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// CHECK-LABEL: sibling_ifs_with_nested_if
+//       CHECK: %[[LOAD:.+]] = ttg.local_load
+//  CHECK-NEXT: tt.trans %[[LOAD]]
+//  CHECK-NEXT: scf.if
+// CANON-LABEL: sibling_ifs_with_nested_if
+//       CANON: scf.if %arg0
+//       CANON:   scf.if %arg1
+//   CANON-NOT: scf.if
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_transposed = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @sibling_ifs_with_nested_if(%cond: i1, %cond2: i1, %smem: !ttg.memdesc<32x32xf32, #shared, #smem>, %a: tensor<32x32xf32, #blocked>) -> tensor<32x32xf32, #blocked> {
+    %x = ttg.local_load %smem : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #blocked>
+    %0 = scf.if %cond -> tensor<32x32xf32, #blocked> {
+      %inner = scf.if %cond2 -> tensor<32x32xf32, #blocked> {
+        %mul = arith.mulf %a, %a : tensor<32x32xf32, #blocked>
+        scf.yield %mul : tensor<32x32xf32, #blocked>
+      } else {
+        scf.yield %a : tensor<32x32xf32, #blocked>
+      }
+      scf.yield %inner : tensor<32x32xf32, #blocked>
+    } else {
+      %div = arith.divf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %div : tensor<32x32xf32, #blocked>
+    }
+    %1 = tt.trans %x {order = array<i32: 1, 0>} : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked_transposed>
+    %2 = scf.if %cond -> tensor<32x32xf32, #blocked_transposed> {
+      %add = arith.addf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+      scf.yield %add : tensor<32x32xf32, #blocked_transposed>
+    } else {
+      %sub = arith.subf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+      scf.yield %sub : tensor<32x32xf32, #blocked_transposed>
+    }
+    %3 = ttg.convert_layout %2 : tensor<32x32xf32, #blocked_transposed> -> tensor<32x32xf32, #blocked>
+    %4 = arith.addf %3, %0 : tensor<32x32xf32, #blocked>
+    tt.return %4 : tensor<32x32xf32, #blocked>
+  }
+}
+
+// -----
+
 // Negative test: ifs in different blocks
 // CHECK-LABEL: ifs_in_different_blocks
 //       CHECK: scf.if

--- a/test/TritonGPU/amd/amd-range-analysis.mlir
+++ b/test/TritonGPU/amd/amd-range-analysis.mlir
@@ -1425,7 +1425,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttg.local_store %16, %18 : tensor<32x128xf16, #blocked> -> !ttg.memdesc<32x128xf16, #shared1, #smem, mutable>
     // expected-remark@+1 {{unsigned : [0, 18446744073709551615] signed : [-9223372036854775808, 9223372036854775807]}}
     %19 = arith.subi %arg1, %arg2 : index
-    // expected-remark@+1 {{inferred total trip count: 0}}
+    // expected-remark@+1 {{inferred total trip count: 1025}}
     %20:6 = scf.for %arg5 = %arg0 to %19 step %arg2 iter_args(%arg6 = %4, %arg7 = %9, %arg8 = %cst_2, %arg9 = %c0_i32, %arg10 = %17, %arg11 = %18) -> (tensor<128x32x!tt.ptr<f16>, #blocked1>, tensor<32x128x!tt.ptr<f16>, #blocked>, tensor<128x128xf32, #mma>, i32, !ttg.memdesc<128x32xf16, #shared, #smem, mutable>, !ttg.memdesc<32x128xf16, #shared1, #smem, mutable>) {
       %33 = tt.addptr %arg6, %cst_1 : tensor<128x32x!tt.ptr<f16>, #blocked1>, tensor<128x32xi32, #blocked1>
       %34 = tt.addptr %arg7, %cst_0 : tensor<32x128x!tt.ptr<f16>, #blocked>, tensor<32x128xi32, #blocked>
@@ -1438,8 +1438,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
       %40 = tt.dot %36, %39, %arg8 : tensor<128x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<32x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x128xf32, #mma>
       %41 = arith.addi %arg9, %c1_i32 : i32
       %42 = arith.cmpi slt, %41, %c1_i32 : i32
-      // expected-remark@+2 {{unsigned : [0, 0] signed : [0, 0]}}
-      // expected-remark@+1 {{non-neg}}
       %43 = arith.select %42, %41, %c0_i32 : i32
       %44 = ttg.memdesc_index %10[%43] : !ttg.memdesc<1x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
       ttg.local_store %35, %44 : tensor<128x32xf16, #blocked1> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
@@ -1677,7 +1675,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %16 = tt.addptr %15, %14 : tensor<32x1x!tt.ptr<f32>, #blocked2>, tensor<32x1xi32, #blocked2>
     %17 = tt.broadcast %16 : tensor<32x1x!tt.ptr<f32>, #blocked2> -> tensor<32x128x!tt.ptr<f32>, #blocked2>
     %18 = ttg.convert_layout %17 : tensor<32x128x!tt.ptr<f32>, #blocked2> -> tensor<32x128x!tt.ptr<f32>, #blocked3>
-    // expected-remark@+1 {{inferred total trip count: 16711680}}
+    // expected-remark@+1 {{inferred total trip count: 16777215}}
     %19 = scf.for %arg3 = %1 to %8 step %2 iter_args(%arg4 = %cst) -> (tensor<32xf32, #blocked>)  : i32 {
       // expected-remark@+2 {{unsigned : [0, 2147483392] signed : [0, 2147483392]}}
       // expected-remark@+1 {{non-neg}}

--- a/test/TritonGPU/amd/mfma-mixed-f8-types.mlir
+++ b/test/TritonGPU/amd/mfma-mixed-f8-types.mlir
@@ -1,0 +1,40 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm="arch=gfx950" | FileCheck %s
+
+// Test bf8_fp8 with non-transposed layout.
+// A=bf8, B=fp8 -> intrinsic mfma.bf8.fp8, operands passed as (A, B)
+
+// CHECK-LABEL: mfma_16x16x32_bf8_fp8_non_transposed
+#mma_nt = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [16, 16, 32], isTransposed = false}>
+#dotOp0_nt = #ttg.dot_op<{opIdx = 0, parent = #mma_nt, kWidth = 8}>
+#dotOp1_nt = #ttg.dot_op<{opIdx = 1, parent = #mma_nt, kWidth = 8}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mfma_16x16x32_bf8_fp8_non_transposed_layout(
+      %arg0: tensor<16x32xf8E5M2, #dotOp0_nt>,
+      %arg1: tensor<32x16xf8E4M3FN, #dotOp1_nt>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #mma_nt>
+    // CHECK: rocdl.mfma.f32.16x16x32.bf8.fp8
+    %dot = tt.dot %arg0, %arg1, %cst : tensor<16x32xf8E5M2, #dotOp0_nt> * tensor<32x16xf8E4M3FN, #dotOp1_nt> -> tensor<16x16xf32, #mma_nt>
+    tt.return
+  }
+}
+
+// -----
+
+// Test bf8_fp8 with transposed layout.
+// A=bf8, B=fp8, but operands get swapped internally to (B, A)
+// Check that we swap intrinsic type selection
+
+// CHECK-LABEL: mfma_16x16x32_bf8_fp8_transposed
+#mma_t = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [16, 16, 32], isTransposed = true}>
+#dotOp0_t = #ttg.dot_op<{opIdx = 0, parent = #mma_t, kWidth = 8}>
+#dotOp1_t = #ttg.dot_op<{opIdx = 1, parent = #mma_t, kWidth = 8}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mfma_16x16x32_bf8_fp8_transposed_layout(
+      %arg0: tensor<128x128xf8E5M2, #dotOp0_t>,
+      %arg1: tensor<128x128xf8E4M3FN, #dotOp1_t>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma_t>
+    // CHECK: rocdl.mfma.f32.16x16x32.fp8.bf8
+    %dot = tt.dot %arg0, %arg1, %cst : tensor<128x128xf8E5M2, #dotOp0_t> * tensor<128x128xf8E4M3FN, #dotOp1_t> -> tensor<128x128xf32, #mma_t>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/Analysis/RangeAnalysis.cpp
+++ b/third_party/amd/lib/Analysis/RangeAnalysis.cpp
@@ -274,14 +274,15 @@ TritonIntegerRangeAnalysis::maybeGetTripCount(LoopLikeOpInterface loop) {
         const dataflow::IntegerValueRangeLattice *lattice =
             getLatticeElementFor(getProgramPointBefore(block), value);
         if (lattice != nullptr && !lattice->getValue().isUninitialized())
-          return getUpper ? lattice->getValue().getValue().smax()
-                          : lattice->getValue().getValue().smin();
+          return getUpper.value_or(false)
+                     ? lattice->getValue().getValue().smax()
+                     : lattice->getValue().getValue().smin();
       }
     }
     if (defaultVal)
       return *defaultVal;
-    return getUpper ? APInt::getSignedMaxValue(width)
-                    : APInt::getSignedMinValue(width);
+    return getUpper.value_or(false) ? APInt::getSignedMaxValue(width)
+                                    : APInt::getSignedMinValue(width);
   };
 
   Block *block = iv->getParentBlock();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1431,13 +1431,11 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
     auto D = dotOp.getD();
     OpBuilder builder(dotOp);
     Type AElType = dotOp.getA().getType().getElementType();
+    Type BElType = dotOp.getB().getType().getElementType();
+    auto maxBitWidth = std::max(AElType.getIntOrFloatBitWidth(),
+                                BElType.getIntOrFloatBitWidth());
     Type promoteType;
     if (isa<ttg::AMDMfmaEncodingAttr>(D.getType().getEncoding())) {
-      Type BElType = dotOp.getB().getType().getElementType();
-
-      auto maxBitWidth = std::max(AElType.getIntOrFloatBitWidth(),
-                                  BElType.getIntOrFloatBitWidth());
-
       // TODO check mfma tensor core version compatibility
       if (maxBitWidth == 8)
         return;
@@ -1450,7 +1448,8 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
       else if (maxBitWidth <= 32)
         promoteType = builder.getF32Type();
     } else if (isa<ttg::AMDWmmaEncodingAttr>(D.getType().getEncoding())) {
-      Type BElType = dotOp.getB().getType().getElementType();
+      if (maxBitWidth == 8)
+        return;
 
       if (AElType == BElType)
         return;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -1070,7 +1070,12 @@ void Pingponger::getDotPingponged() {
   auto encoding = cast<RankedTensorType>(aType).getEncoding();
   auto srcEncoding = cast<ttg::DotOperandEncodingAttr>(encoding);
   kWidth = srcEncoding.getKWidth();
-  auto mfmaEncoding = cast<ttg::AMDMfmaEncodingAttr>(srcEncoding.getParent());
+  auto mfmaEncoding =
+      dyn_cast<ttg::AMDMfmaEncodingAttr>(srcEncoding.getParent());
+  if (!mfmaEncoding) {
+    LDBG("Encountered non-MFMA layout");
+    return;
+  }
   SmallVector<int64_t> intShape;
   auto mnkDim = mfmaEncoding.getInstrShape();
   intShape.push_back(mnkDim[0]);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/PrepareIfCombining.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/PrepareIfCombining.cpp
@@ -26,9 +26,6 @@ namespace {
 
 static void handleIfPair(scf::IfOp currentIf, scf::IfOp nextIf,
                          DominanceInfo &domInfo) {
-  // Skip if they are not in the same block.
-  if (currentIf->getBlock() != nextIf->getBlock())
-    return;
   // Skip if they have different conditions.
   if (currentIf.getCondition() != nextIf.getCondition())
     return;
@@ -70,10 +67,14 @@ struct TritonAMDGPUPrepareIfCombiningPass
   void runOnOperation() override {
     triton::FuncOp funcOp = getOperation();
     DominanceInfo domInfo(funcOp);
-    SmallVector<scf::IfOp> ifOps;
-    funcOp.walk([&](scf::IfOp ifOp) { ifOps.push_back(ifOp); });
-    for (auto [currentIf, nextIf] : llvm::zip(ifOps, llvm::drop_begin(ifOps))) {
-      handleIfPair(currentIf, nextIf, domInfo);
+    DenseMap<Block *, SmallVector<scf::IfOp>> ifsByBlock;
+    funcOp.walk(
+        [&](scf::IfOp ifOp) { ifsByBlock[ifOp->getBlock()].push_back(ifOp); });
+    for (auto &[block, ifOps] : ifsByBlock) {
+      for (auto [currentIf, nextIf] :
+           llvm::zip(ifOps, llvm::drop_begin(ifOps))) {
+        handleIfPair(currentIf, nextIf, domInfo);
+      }
     }
   }
 };

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -215,6 +215,10 @@ ttg::PaddedSharedEncodingAttr composePaddedLayoutForAsyncCopyCDNA4(
   constexpr unsigned vecSize = 8; // in favor of dwordX4
   unsigned contigLanes = contigDim / vecSize;
   unsigned wrap = std::min(contigDim, 128u) / padding;
+  // wrap == 0 means padding > contigDim, which is not a valid configuration
+  if (wrap == 0) {
+    return {};
+  }
   unsigned requiredDim = warpSize / contigLanes * wrap;
   if (nonContigDim < requiredDim) {
     return {};


### PR DESCRIPTION
These are several post Triton 3.7 cut cherry-picks that are specific to AMD ROCm platform.

Ran several tests in this PyTorch PR:
https://github.com/pytorch/pytorch/pull/178958

 