### PR TITLE
[release/3.7.x][AMD][BACKEND] Fix mixed types MFMA fp8 instruction selection (#9567)

### DIFF
--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -74,6 +74,13 @@ jobs:
           echo "/venv/bin" >> $GITHUB_PATH
           echo "VIRTUAL_ENV=/venv" >> $GITHUB_ENV
           echo "PYTHONHOME=" >> $GITHUB_ENV
+      - name: Setup Python environment for H100
+        if: ${{ startsWith(matrix.config.runner_type, 'nvidia-h100') }}
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" /venv
+          echo "/venv/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=/venv" >> $GITHUB_ENV
+          echo "PYTHONHOME=" >> $GITHUB_ENV
       - name: Install Triton
         env:
           CUDA_HOME: "/usr/local/cuda"

--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -9,15 +9,16 @@ on:
 
 jobs:
   integration-tests-nvidia:
-    runs-on: ${{ matrix.runner }}
+    name: integration-tests-nvidia (${{ matrix.config.name }})
+    runs-on: ${{ matrix.config.runs_on }}
     timeout-minutes: 60
     # Let A100 and H100 continue even if GB200 fails, as it's a bit flaky
-    continue-on-error: ${{ matrix.runner[0] == 'nvidia-gb200'}}
+    continue-on-error: ${{ startsWith(matrix.config.runner_type, 'nvidia-gb200') }}
     strategy:
       matrix:
-        runner: ${{ fromJson(inputs.matrix) }}
+        config: ${{ fromJson(inputs.matrix) }}
     env:
-      RUNNER_TYPE: ${{ matrix.runner[0] }}
+      RUNNER_TYPE: ${{ matrix.config.runner_type }}
       TRITON_BUILD_WITH_CCACHE: "true"
       TRITON_BUILD_WITH_CLANG_LLD: "TRUE"
       TRITON_USE_ASSERT_ENABLED_LLVM: "TRUE"
@@ -69,7 +70,7 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Setup Python environment for GB200
-        if: ${{ matrix.runner[0] == 'nvidia-gb200' }}
+        if: ${{ startsWith(matrix.config.runner_type, 'nvidia-gb200') }}
         run: |
           echo "/venv/bin" >> $GITHUB_PATH
           echo "VIRTUAL_ENV=/venv" >> $GITHUB_ENV
@@ -97,7 +98,7 @@ jobs:
       - name: Run python tests on CUDA
         run: make NUM_PROCS=24 test-unit
       - name: Run interpreter tests
-        if: ${{ matrix.runner[0] == 'nvidia-h100' }}
+        if: ${{ matrix.config.runner_type == 'nvidia-h100' }}
         run: make test-interpret
       - name: Run regression tests
         run: make test-regression

--- a/.github/workflows/runner-preparation.yml
+++ b/.github/workflows/runner-preparation.yml
@@ -95,11 +95,11 @@ jobs:
         if: env.enable_integration == 'true'
         run: |
           if [ x"${{ github.repository }}" == x"triton-lang/triton" ]; then
-            echo '::set-output name=matrix-NVIDIA::[["nvidia-a100"], ["nvidia-h100"], ["nvidia-gb200"]]'
+            echo '::set-output name=matrix-NVIDIA::[{"name":"nvidia-a100","runner_type":"nvidia-a100","runs_on":["nvidia-a100"]},{"name":"nvidia-h100","runner_type":"nvidia-h100","runs_on":["nvidia-h100"]},{"name":"nvidia-gb200","runner_type":"nvidia-gb200","runs_on":{"group":"gb200-runner-set"}}]'
             echo '::set-output name=matrix-AMD::[["self-hosted", "gfx90a"], ["amd-gfx942"], ["amd-gfx950"]]'
             echo '::set-output name=matrix-MACOS::[["macos-latest"]]'
           else
-            echo '::set-output name=matrix-NVIDIA::["ubuntu-latest"]'
+            echo '::set-output name=matrix-NVIDIA::[{"name":"ubuntu-latest","runner_type":"ubuntu-latest","runs_on":"ubuntu-latest"}]'
             echo '::set-output name=matrix-AMD::["ubuntu-latest"]'
             echo '::set-output name=matrix-MACOS::[["macos-latest"]]'
           fi

--- a/test/TritonGPU/amd/mfma-mixed-f8-types.mlir
+++ b/test/TritonGPU/amd/mfma-mixed-f8-types.mlir
@@ -1,0 +1,40 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm="arch=gfx950" | FileCheck %s
+
+// Test bf8_fp8 with non-transposed layout.
+// A=bf8, B=fp8 -> intrinsic mfma.bf8.fp8, operands passed as (A, B)
+
+// CHECK-LABEL: mfma_16x16x32_bf8_fp8_non_transposed
+#mma_nt = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [16, 16, 32], isTransposed = false}>
+#dotOp0_nt = #ttg.dot_op<{opIdx = 0, parent = #mma_nt, kWidth = 8}>
+#dotOp1_nt = #ttg.dot_op<{opIdx = 1, parent = #mma_nt, kWidth = 8}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mfma_16x16x32_bf8_fp8_non_transposed_layout(
+      %arg0: tensor<16x32xf8E5M2, #dotOp0_nt>,
+      %arg1: tensor<32x16xf8E4M3FN, #dotOp1_nt>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #mma_nt>
+    // CHECK: rocdl.mfma.f32.16x16x32.bf8.fp8
+    %dot = tt.dot %arg0, %arg1, %cst : tensor<16x32xf8E5M2, #dotOp0_nt> * tensor<32x16xf8E4M3FN, #dotOp1_nt> -> tensor<16x16xf32, #mma_nt>
+    tt.return
+  }
+}
+
+// -----
+
+// Test bf8_fp8 with transposed layout.
+// A=bf8, B=fp8, but operands get swapped internally to (B, A)
+// Check that we swap intrinsic type selection
+
+// CHECK-LABEL: mfma_16x16x32_bf8_fp8_transposed
+#mma_t = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [16, 16, 32], isTransposed = true}>
+#dotOp0_t = #ttg.dot_op<{opIdx = 0, parent = #mma_t, kWidth = 8}>
+#dotOp1_t = #ttg.dot_op<{opIdx = 1, parent = #mma_t, kWidth = 8}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @mfma_16x16x32_bf8_fp8_transposed_layout(
+      %arg0: tensor<128x128xf8E5M2, #dotOp0_t>,
+      %arg1: tensor<128x128xf8E4M3FN, #dotOp1_t>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma_t>
+    // CHECK: rocdl.mfma.f32.16x16x32.fp8.bf8
+    %dot = tt.dot %arg0, %arg1, %cst : tensor<128x128xf8E5M2, #dotOp0_t> * tensor<128x128xf8E4M3FN, #dotOp1_t> -> tensor<128x128xf32, #mma_t>
+    tt.return
+  }
+}


### PR DESCRIPTION
Upstream cherry-pick `eaaa75cf5d` onto `release/3.7.x`.

Aggregate testing of a group of cherry-picks is being done here: https://github.com/pytorch/pytorch/pull/178958