### PR TITLE
[BACKEND] Add preferred cluster fallback

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -60,6 +60,8 @@ LogicalResult verifyMMAv5Op(Operation *op);
 namespace mlir::triton::nvidia_gpu {
 
 constexpr static char AttrTwoCTAsName[] = "ttng.two-ctas";
+constexpr static char AttrPreferredClusterFallbackCTAsName[] =
+    "ttng.preferred-cluster-fallback-ctas";
 
 inline bool getModuleTwoCTAs(ModuleOp mod) {
   auto attr = mod->getAttrOfType<BoolAttr>(AttrTwoCTAsName);
@@ -68,6 +70,16 @@ inline bool getModuleTwoCTAs(ModuleOp mod) {
 
 inline bool getModuleTwoCTAs(Operation *op) {
   return getModuleTwoCTAs(op->getParentOfType<ModuleOp>());
+}
+
+inline int getModulePreferredClusterFallbackCTAs(ModuleOp mod) {
+  auto attr =
+      mod->getAttrOfType<IntegerAttr>(AttrPreferredClusterFallbackCTAsName);
+  return attr ? attr.getInt() : 0;
+}
+
+inline int getModulePreferredClusterFallbackCTAs(Operation *op) {
+  return getModulePreferredClusterFallbackCTAs(op->getParentOfType<ModuleOp>());
 }
 
 struct TensorMemory : public SideEffects::Resource::Base<TensorMemory> {
@@ -147,6 +159,8 @@ getDistributedLayoutForTmemLdSt(gpu::MemDescType memType, TMemAccessAtom atom,
                                 unsigned numWarps);
 
 SmallVector<uint16_t> getCTABroadcastMasks(bool twoCTAs, ValueRange descs);
+
+uint32_t getTCGen5MmaBarrierCount(ValueRange descs, bool fallback);
 
 // Compact encoding of a CTA multicast group for a given broadcast mask:
 // `fixedBits` selects the CTA-id bits that identify the group leader, and

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -78,10 +78,6 @@ inline int getModulePreferredClusterFallbackCTAs(ModuleOp mod) {
   return attr ? attr.getInt() : 0;
 }
 
-inline int getModulePreferredClusterFallbackCTAs(Operation *op) {
-  return getModulePreferredClusterFallbackCTAs(op->getParentOfType<ModuleOp>());
-}
-
 struct TensorMemory : public SideEffects::Resource::Base<TensorMemory> {
   StringRef getName() const final { return "<TensorMemory>"; }
   SideEffects::Resource *getParent() const override { return nullptr; }
@@ -160,7 +156,8 @@ getDistributedLayoutForTmemLdSt(gpu::MemDescType memType, TMemAccessAtom atom,
 
 SmallVector<uint16_t> getCTABroadcastMasks(bool twoCTAs, ValueRange descs);
 
-uint32_t getTCGen5MmaBarrierCount(ValueRange descs, bool fallback);
+uint32_t getTCGen5MmaBarrierCount(ValueRange descs, bool twoCTAs,
+                                  bool fallback);
 
 // Compact encoding of a CTA multicast group for a given broadcast mask:
 // `fixedBits` selects the CTA-id bits that identify the group leader, and

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -274,6 +274,18 @@ def TTNG_InitBarrierOp : TTNG_Op<"init_barrier", [
   let hasVerifier = 1;
 }
 
+def TTNG_InitMmaBarrierOp : TTNG_Op<"init_mma_barrier", [
+    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>]> {
+  let summary = "Initialize a barrier for tcgen05 MMA completion.";
+
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$alloc,
+    Variadic<TTG_MemDescType>:$descs
+  );
+  let assemblyFormat = "$alloc (`,` $descs^)? attr-dict `:` qualified(type($alloc)) (`,` qualified(type($descs))^)?";
+  let hasVerifier = 1;
+}
+
 def TTNG_InvalBarrierOp : TTNG_Op<"inval_barrier", [
     DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>]> {
   let summary = "Invalidate a barrier allocation.";

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -221,4 +221,23 @@ def TritonNvidiaGPUCheckMatmulTwoCTAPass : Pass<"triton-nvidia-check-matmul-two-
   }];
 }
 
+def TritonNvidiaGPUPreferredClusterFallbackPass : Pass<"triton-nvidia-preferred-cluster-fallback", "mlir::ModuleOp"> {
+  let summary = "Enable preferred cluster launches with a smaller fallback cluster";
+
+  let description = [{
+    Proves a multi-CTA module only communicates within CTA pairs and marks it
+    for preferred-cluster launch with a 2-CTA fallback cluster.
+  }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+                           "mlir::triton::TritonDialect"];
+
+  let options = [
+    Option<"computeCapability", "compute-capability",
+           "int32_t", /*default*/"90",
+           "device compute capability">
+  ];
+}
+
 #endif

--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -3,6 +3,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 namespace {
 
@@ -91,7 +92,10 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
       newFuncOp->setAttr(NVVM::NVVMDialect::getMaxnregAttrName(), maxnregAttr);
 
     // Do we want to do this for nCTAs == 1 whenever sm >= 90?
-    if (numCTAs > 1) {
+    auto preferredClusterFallbackCTAs =
+        funcOp->getParentOfType<ModuleOp>()->getAttrOfType<IntegerAttr>(
+            triton::nvidia_gpu::AttrPreferredClusterFallbackCTAsName);
+    if (numCTAs > 1 && !preferredClusterFallbackCTAs) {
       // Request a specific number of CTAs per cluster in the generated PTX.
       newFuncOp->setAttr(NVVM::NVVMDialect::getClusterDimAttrName(),
                          rewriter.getDenseI32ArrayAttr(numCTAs));

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -191,8 +191,8 @@ TypedValue<MemDescType> InitBarrierOp::getBarrier() { return getAlloc(); }
 LogicalResult InitMmaBarrierOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))
     return failure();
-  if (getDescs().empty() || getDescs().size() > 2)
-    return emitOpError("expects one or two descriptors");
+  if (getDescs().empty() || getDescs().size() > 4)
+    return emitOpError("expects one to four descriptors");
   auto barrierTy = cast<MemDescType>(getAlloc().getType());
   int numCTAs = gpu::lookupNumCTAs(getOperation());
   if (barrierTy.getShape().size() != 1 || barrierTy.getNumElements() != numCTAs)
@@ -1713,26 +1713,35 @@ SmallVector<uint16_t> getCTABroadcastMasks(bool twoCTAs, ValueRange descs) {
   return broadcastMasks;
 }
 
-uint32_t getTCGen5MmaBarrierCount(ValueRange descs, bool fallback) {
+uint32_t getTCGen5MmaBarrierCount(ValueRange descs, bool twoCTAs,
+                                  bool fallback) {
   if (descs.empty())
     return 1;
 
   auto kBlock = StringAttr::get(descs.front().getContext(), "block");
-  auto getBroadcastMask = [&](Value desc) {
+  SmallVector<uint32_t> masks;
+  for (Value desc : descs) {
     auto descTy = cast<gpu::MemDescType>(desc.getType());
     uint32_t mask =
         toLinearLayout(descTy).getFreeVariableMasks().lookup(kBlock);
-    return fallback ? mask & 1 : mask;
-  };
+    if (fallback)
+      mask &= 1;
+    if (twoCTAs)
+      mask &= ~1u;
+    masks.push_back(mask);
+  }
 
-  if (descs.size() == 1)
-    return 1 << llvm::popcount(getBroadcastMask(descs.front()));
-
-  assert(descs.size() == 2 && "expected at most two descriptors");
-  uint32_t lhsMask = getBroadcastMask(descs[0]);
-  uint32_t rhsMask = getBroadcastMask(descs[1]);
-  return (1 << llvm::popcount(lhsMask)) + (1 << llvm::popcount(rhsMask)) -
-         (1 << llvm::popcount(lhsMask & rhsMask));
+  assert(masks.size() <= 4 && "expected at most four descriptors");
+  int32_t count = 0;
+  for (uint32_t subset = 1; subset < (1u << masks.size()); ++subset) {
+    uint32_t intersection = ~0u;
+    for (auto [i, mask] : llvm::enumerate(masks))
+      if (subset & (1u << i))
+        intersection &= mask;
+    int32_t size = 1u << llvm::popcount(intersection);
+    count += llvm::popcount(subset) & 1 ? size : -size;
+  }
+  return count;
 }
 
 TMAMulticastMaskEncoding getTMAMulticastMaskEncoding(int numCTAs,

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -165,6 +165,9 @@ LogicalResult WarpGroupDotWaitOp::verify() {
   return success();
 }
 
+static LogicalResult verifyCompletionBarrierLayout(Operation *op,
+                                                   Value barrier);
+
 // -- InitBarrierOp --
 LogicalResult InitBarrierOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))
@@ -183,6 +186,23 @@ LogicalResult InitBarrierOp::verify() {
 }
 
 TypedValue<MemDescType> InitBarrierOp::getBarrier() { return getAlloc(); }
+
+// -- InitMmaBarrierOp --
+LogicalResult InitMmaBarrierOp::verify() {
+  if (failed(verifyBarrierType(*this, getAlloc().getType())))
+    return failure();
+  if (getDescs().empty() || getDescs().size() > 2)
+    return emitOpError("expects one or two descriptors");
+  auto barrierTy = cast<MemDescType>(getAlloc().getType());
+  int numCTAs = gpu::lookupNumCTAs(getOperation());
+  if (barrierTy.getShape().size() != 1 || barrierTy.getNumElements() != numCTAs)
+    return emitOpError("requires a 1D barrier with one element per CTA");
+  if (failed(verifyCompletionBarrierLayout(getOperation(), getAlloc())))
+    return failure();
+  return success();
+}
+
+TypedValue<MemDescType> InitMmaBarrierOp::getBarrier() { return getAlloc(); }
 
 // -- InvalBarrierOp --
 LogicalResult InvalBarrierOp::verify() {
@@ -1691,6 +1711,28 @@ SmallVector<uint16_t> getCTABroadcastMasks(bool twoCTAs, ValueRange descs) {
     broadcastMasks.push_back(1);
   }
   return broadcastMasks;
+}
+
+uint32_t getTCGen5MmaBarrierCount(ValueRange descs, bool fallback) {
+  if (descs.empty())
+    return 1;
+
+  auto kBlock = StringAttr::get(descs.front().getContext(), "block");
+  auto getBroadcastMask = [&](Value desc) {
+    auto descTy = cast<gpu::MemDescType>(desc.getType());
+    uint32_t mask =
+        toLinearLayout(descTy).getFreeVariableMasks().lookup(kBlock);
+    return fallback ? mask & 1 : mask;
+  };
+
+  if (descs.size() == 1)
+    return 1 << llvm::popcount(getBroadcastMask(descs.front()));
+
+  assert(descs.size() == 2 && "expected at most two descriptors");
+  uint32_t lhsMask = getBroadcastMask(descs[0]);
+  uint32_t rhsMask = getBroadcastMask(descs[1]);
+  return (1 << llvm::popcount(lhsMask)) + (1 << llvm::popcount(rhsMask)) -
+         (1 << llvm::popcount(lhsMask & rhsMask));
 }
 
 TMAMulticastMaskEncoding getTMAMulticastMaskEncoding(int numCTAs,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   OptimizeDescriptorEncoding.cpp
   OptimizeTMemLayouts.cpp
   PlanCTA.cpp
+  PreferredClusterFallback.cpp
   PromoteLHSToTMem.cpp
   ProxyFenceInsertion.cpp
   RemoveTMEMTokens.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -24,6 +24,17 @@ namespace {
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
+static bool hasTCGen5CommitCrossCTA(Operation *op) {
+  SmallVector<Value> descs;
+  if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op))
+    descs = mma.getCompletionDescs();
+  else if (auto commit = dyn_cast<ttng::TCGen5CommitOp>(op))
+    llvm::append_range(descs, commit.getDescs());
+  else
+    return false;
+  return !ttng::getCTABroadcastMasks(ttng::getModuleTwoCTAs(op), descs).empty();
+}
+
 static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
   if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
     if (!isRead)
@@ -41,8 +52,8 @@ static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
     auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
     return splitNum[reduce.getAxis()] > 1;
   }
-  if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op)) {
-    return mma.getTwoCtas();
+  if (isa<ttng::MMAv5OpInterface, ttng::TCGen5CommitOp>(op)) {
+    return hasTCGen5CommitCrossCTA(op);
   } else if (isa<ttng::TMEMCopyOp>(op)) {
     return ttng::getModuleTwoCTAs(op);
   } else if (auto tma = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
@@ -104,17 +115,20 @@ usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
 
   if (auto mma = dyn_cast<ttng::MMAv5OpInterface>(op)) {
     auto barrierOp = cast<ttg::MBarrierOpInterface>(op);
-    return mma.getTwoCtas() &&
+    return hasTCGen5CommitCrossCTA(op) &&
            llvm::any_of(barrierOp.getBarriers(), aliasesTracked);
   }
   if (auto commit = dyn_cast<ttng::TCGen5CommitOp>(op)) {
-    return ttng::getModuleTwoCTAs(op) && aliasesTracked(commit.getBarrier());
+    return hasTCGen5CommitCrossCTA(op) && aliasesTracked(commit.getBarrier());
   }
   if (auto tma = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
     return tma.getMulticast() && aliasesTracked(tma.getBarrier());
   }
   if (auto clc = dyn_cast<ttng::CLCTryCancelOp>(op)) {
     return aliasesTracked(clc.getMbarrier());
+  }
+  if (auto store = dyn_cast<ttng::AsyncSharedStoreOp>(op)) {
+    return aliasesTracked(store.getMbarrier());
   }
   return false;
 }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -77,8 +77,10 @@ static bool hasUnresolvedCrossClusterDependency(const BlockInfo &blockInfo) {
          hasDistributedDependency(blockInfo.syncWriteSlices, /*isRead=*/false);
 }
 
-static bool isCrossCTAMBarrier(ttng::InitBarrierOp initBarrierOp, int numCTAs) {
-  auto barrierTy = cast<ttg::MemDescType>(initBarrierOp.getBarrier().getType());
+static bool isCrossCTAMBarrier(ttg::MBarrierOpInterface initBarrierOp,
+                               int numCTAs) {
+  auto barrierTy =
+      cast<ttg::MemDescType>(initBarrierOp.getBarriers().front().getType());
   return barrierTy.getShape()[0] != numCTAs;
 }
 
@@ -117,10 +119,10 @@ usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
   return false;
 }
 
-static bool requiresCrossCTAMBarrierInitSync(ttng::InitBarrierOp initBarrierOp,
-                                             FunctionOpInterface funcOp,
-                                             Allocation *allocation,
-                                             int numCTAs) {
+static bool
+requiresCrossCTAMBarrierInitSync(ttg::MBarrierOpInterface initBarrierOp,
+                                 FunctionOpInterface funcOp,
+                                 Allocation *allocation, int numCTAs) {
   // Barrier init sync is needed for barriers that are themselves cross-CTA,
   // and also for per-CTA barriers consumed by multi-CTA ops that multicast or
   // otherwise fan out barrier state across the cluster.
@@ -128,8 +130,8 @@ static bool requiresCrossCTAMBarrierInitSync(ttng::InitBarrierOp initBarrierOp,
     return true;
 
   Allocation::BufferIdSetT initBarrierBuffers;
-  for (auto bufferId :
-       allocation->getAllBufferIdsWithAliases(initBarrierOp.getBarrier())) {
+  for (auto bufferId : allocation->getAllBufferIdsWithAliases(
+           initBarrierOp.getBarriers().front())) {
     assert(bufferId != Allocation::InvalidBufferId);
     initBarrierBuffers.insert(bufferId);
   }
@@ -150,7 +152,7 @@ static bool requiresCrossCTAMBarrierInitSync(ttng::InitBarrierOp initBarrierOp,
 static bool nestedOpUsesTrackedMBarrier(Operation *op,
                                         const Allocation::BufferIdSetT &tracked,
                                         Allocation *allocation) {
-  if (isa<ttng::InitBarrierOp, ttg::LocalAllocOp>(op))
+  if (isa<ttng::InitBarrierOp, ttng::InitMmaBarrierOp, ttg::LocalAllocOp>(op))
     return false;
 
   if (auto memEffects = dyn_cast<MemoryEffectOpInterface>(op)) {
@@ -190,9 +192,7 @@ insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
   llvm::SetVector<Operation *> crossCTAInitAnchors;
   Allocation::BufferIdSetT trackedBarrierBuffers;
 
-  // Find all cross-CTA mbarrier.init ops and map each
-  // one to the containing top-level op that bounds the insertion window.
-  funcOp.walk([&](ttng::InitBarrierOp initBarrierOp) {
+  auto processInitBarrier = [&](ttg::MBarrierOpInterface initBarrierOp) {
     if (!requiresCrossCTAMBarrierInitSync(initBarrierOp, funcOp, allocation,
                                           numCTAs))
       return;
@@ -200,11 +200,20 @@ insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
         topLevelRegion.findAncestorOpInRegion(*initBarrierOp.getOperation());
     assert(topLevelAnchor && "init op must be inside the function region");
     crossCTAInitAnchors.insert(topLevelAnchor);
-    for (auto bufferId :
-         allocation->getAllBufferIdsWithAliases(initBarrierOp.getBarrier())) {
+    for (auto bufferId : allocation->getAllBufferIdsWithAliases(
+             initBarrierOp.getBarriers().front())) {
       assert(bufferId != Allocation::InvalidBufferId);
       trackedBarrierBuffers.insert(bufferId);
     }
+  };
+
+  // Find all cross-CTA mbarrier init ops and map each
+  // one to the containing top-level op that bounds the insertion window.
+  funcOp.walk([&](Operation *op) {
+    if (auto initBarrierOp = dyn_cast<ttng::InitBarrierOp>(op))
+      processInitBarrier(initBarrierOp);
+    if (auto initMmaBarrierOp = dyn_cast<ttng::InitMmaBarrierOp>(op))
+      processInitBarrier(initMmaBarrierOp);
   });
   // Nothing to do
   if (crossCTAInitAnchors.empty())

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -57,6 +57,11 @@ public:
                        barrierTy.getNumElements();
       return BarrierInitInfo{initOp.getAlloc(), count};
     }
+    if (auto initOp = dyn_cast<ttng::InitMmaBarrierOp>(op)) {
+      uint32_t count = ttng::getTCGen5MmaBarrierCount(initOp.getDescs(),
+                                                      /*fallback=*/false);
+      return BarrierInitInfo{initOp.getAlloc(), count};
+    }
     return std::nullopt;
   }
 
@@ -111,6 +116,10 @@ public:
     };
     if (auto initOp = dyn_cast<ttng::InitBarrierOp>(op))
       mask = getBarrierMask(initOp.getAlloc());
+    if (auto initOp = dyn_cast<ttng::InitMmaBarrierOp>(op))
+      mask = getBarrierMask(initOp.getAlloc());
+    if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op))
+      mask = getBarrierMask(expectOp.getAlloc());
     if (auto waitOp = dyn_cast<ttng::WaitBarrierOp>(op))
       mask = getBarrierMask(waitOp.getAlloc());
     if (auto invalOp = dyn_cast<ttng::InvalBarrierOp>(op))

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -58,8 +58,8 @@ public:
       return BarrierInitInfo{initOp.getAlloc(), count};
     }
     if (auto initOp = dyn_cast<ttng::InitMmaBarrierOp>(op)) {
-      uint32_t count = ttng::getTCGen5MmaBarrierCount(initOp.getDescs(),
-                                                      /*fallback=*/false);
+      uint32_t count = ttng::getTCGen5MmaBarrierCount(
+          initOp.getDescs(), ttng::getModuleTwoCTAs(op), /*fallback=*/false);
       return BarrierInitInfo{initOp.getAlloc(), count};
     }
     return std::nullopt;
@@ -118,8 +118,6 @@ public:
       mask = getBarrierMask(initOp.getAlloc());
     if (auto initOp = dyn_cast<ttng::InitMmaBarrierOp>(op))
       mask = getBarrierMask(initOp.getAlloc());
-    if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op))
-      mask = getBarrierMask(expectOp.getAlloc());
     if (auto waitOp = dyn_cast<ttng::WaitBarrierOp>(op))
       mask = getBarrierMask(waitOp.getAlloc());
     if (auto invalOp = dyn_cast<ttng::InvalBarrierOp>(op))

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PreferredClusterFallback.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PreferredClusterFallback.cpp
@@ -1,0 +1,133 @@
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Visitors.h"
+
+namespace ttg = mlir::triton::gpu;
+namespace ttng = mlir::triton::nvidia_gpu;
+
+namespace mlir::triton::nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUPREFERREDCLUSTERFALLBACKPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+static bool hasCrossCTAConvertLayout(ttg::ConvertLayoutOp cvt) {
+  auto kBlock = StringAttr::get(cvt->getContext(), "block");
+  auto conversion = minimalCvtLayout(cvt.getSrc().getType(), cvt.getType());
+  return conversion.hasInDim(kBlock);
+}
+
+static bool hasCrossCTAReduce(triton::ReduceOp reduce) {
+  auto srcTy = reduce.getInputTypes()[0];
+  auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
+  return splitNum[reduce.getAxis()] > 1;
+}
+
+static bool moduleRequestsConSan(ModuleOp mod) {
+  for (StringRef attrName :
+       {"ttg.instrumentation_mode", "triton.instrumentation_mode"}) {
+    auto attr = mod->getAttrOfType<StringAttr>(attrName);
+    if (attr && attr.getValue().contains("consan"))
+      return true;
+  }
+  return false;
+}
+
+class TritonNvidiaGPUPreferredClusterFallbackPass
+    : public impl::TritonNvidiaGPUPreferredClusterFallbackPassBase<
+          TritonNvidiaGPUPreferredClusterFallbackPass> {
+public:
+  using impl::TritonNvidiaGPUPreferredClusterFallbackPassBase<
+      TritonNvidiaGPUPreferredClusterFallbackPass>::
+      TritonNvidiaGPUPreferredClusterFallbackPassBase;
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    mod->removeAttr(AttrPreferredClusterFallbackCTAsName);
+
+    int numCTAs = ttg::TritonGPUDialect::getNumCTAs(mod);
+    if (computeCapability < 100 || numCTAs <= 2)
+      return;
+
+    if (moduleRequestsConSan(mod))
+      return;
+
+    WalkResult result = mod.walk([&](Operation *op) -> WalkResult {
+      auto unsupported = [&] { return WalkResult::interrupt(); };
+
+      // You can do pretty much anything with inline asm
+      if (isa<triton::ElementwiseInlineAsmOp>(op))
+        return unsupported();
+
+      // You can synchronise CTAs with global atomic operations
+      if (isa<triton::AtomicRMWOp, triton::AtomicCASOp>(op))
+        return unsupported();
+
+      // NYI: CLC can redirect a CTA to work from a different program.  To
+      // support preferred fallback, ProgramCTAIdOp must be derived from the
+      // canceled CTA id returned by CLC, not from the thief CTA's block id.
+      // This seems tricky to implement
+      if (isa<ttng::CLCTryCancelOp, ttng::CLCLoadResultOp,
+              ttng::CLCIsCanceledOp, ttng::CLCGetProgramIdOp>(op))
+        return unsupported();
+
+      // NYI: We could have cvt_layout in the first 2 CTAs or reduces
+      if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+        if (hasCrossCTAConvertLayout(cvt))
+          return unsupported();
+        return WalkResult::advance();
+      }
+
+      if (auto reduce = dyn_cast<triton::ReduceOp>(op)) {
+        if (hasCrossCTAReduce(reduce))
+          return unsupported();
+        return WalkResult::advance();
+      }
+
+      if (auto arrive = dyn_cast<ttng::ClusterArriveOp>(op)) {
+        if (!arrive.getRelaxed())
+          return unsupported();
+        return WalkResult::advance();
+      }
+      if (auto barrier = dyn_cast<ttng::ClusterBarrierOp>(op)) {
+        if (!barrier.getRelaxed())
+          return unsupported();
+        return WalkResult::advance();
+      }
+
+      if (auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(op)) {
+        auto kBlock = StringAttr::get(barrierOp->getContext(), "block");
+        for (Value barrier : barrierOp.getBarriers()) {
+          auto barrierTy = cast<ttg::MemDescType>(barrier.getType());
+          uint32_t cgaBroadcastMask =
+              toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
+
+          // Broadcast mbarriers use another CTA's barrier, so we only allow
+          // broadcast on the first bit (i.e., CTA0 and CTA1).
+          if (cgaBroadcastMask > 1)
+            return unsupported();
+        }
+      }
+
+      return WalkResult::advance();
+    });
+
+    if (result.wasInterrupted())
+      return;
+
+    mod->setAttr(AttrPreferredClusterFallbackCTAsName,
+                 IntegerAttr::get(IntegerType::get(mod.getContext(), 32), 2));
+  }
+};
+
+} // namespace
+
+} // namespace mlir::triton::nvidia_gpu

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PreferredClusterFallback.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PreferredClusterFallback.cpp
@@ -19,18 +19,6 @@ namespace mlir::triton::nvidia_gpu {
 
 namespace {
 
-static bool hasCrossCTAConvertLayout(ttg::ConvertLayoutOp cvt) {
-  auto kBlock = StringAttr::get(cvt->getContext(), "block");
-  auto conversion = minimalCvtLayout(cvt.getSrc().getType(), cvt.getType());
-  return conversion.hasInDim(kBlock);
-}
-
-static bool hasCrossCTAReduce(triton::ReduceOp reduce) {
-  auto srcTy = reduce.getInputTypes()[0];
-  auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
-  return splitNum[reduce.getAxis()] > 1;
-}
-
 static bool moduleRequestsConSan(ModuleOp mod) {
   for (StringRef attrName :
        {"ttg.instrumentation_mode", "triton.instrumentation_mode"}) {
@@ -68,7 +56,8 @@ public:
         return unsupported();
 
       // You can synchronise CTAs with global atomic operations
-      if (isa<triton::AtomicRMWOp, triton::AtomicCASOp>(op))
+      if (isa<triton::AtomicRMWOp, triton::AtomicCASOp, triton::AtomicPollOp>(
+              op))
         return unsupported();
 
       // NYI: CLC can redirect a CTA to work from a different program.  To
@@ -81,16 +70,52 @@ public:
 
       // NYI: We could have cvt_layout in the first 2 CTAs or reduces
       if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
-        if (hasCrossCTAConvertLayout(cvt))
+        auto kBlock = StringAttr::get(cvt->getContext(), "block");
+        auto conversion =
+            minimalCvtLayout(cvt.getSrc().getType(), cvt.getType());
+        if (conversion.hasInDim(kBlock))
           return unsupported();
         return WalkResult::advance();
       }
 
       if (auto reduce = dyn_cast<triton::ReduceOp>(op)) {
-        if (hasCrossCTAReduce(reduce))
+        auto srcTy = reduce.getInputTypes()[0];
+        auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
+        if (splitNum[reduce.getAxis()] > 1)
           return unsupported();
         return WalkResult::advance();
       }
+
+      // These operations can address distributed shared memory using a logical
+      // CTA rank that is not present in the fallback cluster.
+      if (isa<ttg::LocalGatherOp, ttg::LocalScatterOp,
+              ttg::LocalAtomicScatterRMWOp, ttng::AsyncSharedStoreOp>(op))
+        return unsupported();
+
+      auto hasCrossCTASharedTransfer = [&](Type srcTy, Type dstTy) {
+        auto kBlock = StringAttr::get(op->getContext(), "block");
+        return !isCvtDimSync(
+            ttg::toLinearLayout(cast<ttg::TensorOrMemDesc>(srcTy)),
+            ttg::toLinearLayout(cast<ttg::TensorOrMemDesc>(dstTy)), kBlock);
+      };
+      if (auto load = dyn_cast<ttg::LocalLoadOp>(op)) {
+        if (hasCrossCTASharedTransfer(load.getSrc().getType(), load.getType()))
+          return unsupported();
+      } else if (auto store = dyn_cast<ttg::LocalStoreOp>(op)) {
+        if (hasCrossCTASharedTransfer(store.getSrc().getType(),
+                                      store.getDst().getType()))
+          return unsupported();
+      } else if (auto alloc = dyn_cast<ttg::LocalAllocOp>(op)) {
+        if (alloc.getSrc() && hasCrossCTASharedTransfer(
+                                  alloc.getSrc().getType(), alloc.getType()))
+          return unsupported();
+      }
+
+      // A statically-counted completion barrier cannot adapt to the smaller
+      // multicast group selected by preferred fallback.
+      if (auto init = dyn_cast<ttng::InitBarrierOp>(op))
+        if (init.getCount() > 1)
+          return unsupported();
 
       if (auto arrive = dyn_cast<ttng::ClusterArriveOp>(op)) {
         if (!arrive.getRelaxed())

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -78,6 +78,7 @@ bool ignoreOpForProxyFence(Operation *op) {
          isa<triton::nvidia_gpu::ArriveBarrierOp,
              triton::nvidia_gpu::TMEMCopyOp, triton::nvidia_gpu::WaitBarrierOp,
              triton::nvidia_gpu::InitBarrierOp,
+             triton::nvidia_gpu::InitMmaBarrierOp,
              triton::nvidia_gpu::InvalBarrierOp>(op);
 }
 

--- a/python/examples/gluon/03-matmul-multicta.py
+++ b/python/examples/gluon/03-matmul-multicta.py
@@ -12,7 +12,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     clc,
     tcgen05_commit,
     tcgen05_mma,
-    tcgen05_mma_barrier_count,
     tensor_memory_descriptor,
 )
 from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
@@ -483,6 +482,15 @@ def _matmul_kernel(
     dtype: gl.constexpr = a_desc.dtype
     a_bufs = gl.allocate_shared_memory(dtype, [STAGES] + a_desc.block_shape, a_desc.layout)
     b_bufs = gl.allocate_shared_memory(dtype, [STAGES] + b_desc.block_shape, b_desc.layout)
+    # MMA completion barrier counts are derived from the multicast TMA layouts.
+    # Equiv. consumed_barrier. Barrier TCGEN05 MMA -> Load TMA
+    load_empty_bars = mbarrier.allocate_mbarrier(batch=STAGES)
+    # Equiv. ab_tma_barrier. Barrier Load TMA -> TCGEN05 MMA
+    load_ready_bars = mbarrier.allocate_mbarrier(batch=STAGES, two_ctas=TWO_CTAS)
+    for i in gl.static_range(STAGES):
+        mbarrier.init_tcgen05_mma(load_empty_bars.index(i), [a_bufs.index(0), b_bufs.index(0)])
+        mbarrier.init(load_ready_bars.index(i), count=1)
+
     tmem_layout: gl.constexpr = TensorMemoryLayout(
         [BLOCK_SIZE_M, BLOCK_N // get_split_dim(CGA_LAYOUT, 1)],
         col_stride=1,
@@ -490,17 +498,6 @@ def _matmul_kernel(
         two_ctas=TWO_CTAS,
     )
     acc_bufs = allocate_tensor_memory(gl.float32, [ACC_STAGES, BLOCK_M, BLOCK_N], tmem_layout)
-    # Number of CTAs that will arrive on the barrier from a tcgen05_commit after an MMA instruction
-    mma_barrier_count: gl.constexpr = tcgen05_mma_barrier_count([a_bufs.index(0), b_bufs.index(0)], multicast=True,
-                                                                two_ctas=acc_bufs.index(0).type.layout.two_ctas)
-
-    # Equiv. consumed_barrier. Barrier TCGEN05 MMA -> Load TMA
-    load_empty_bars = mbarrier.allocate_mbarrier(batch=STAGES)
-    # Equiv. ab_tma_barrier. Barrier Load TMA -> TCGEN05 MMA
-    load_ready_bars = mbarrier.allocate_mbarrier(batch=STAGES, two_ctas=TWO_CTAS)
-    for i in gl.static_range(STAGES):
-        mbarrier.init(load_empty_bars.index(i), count=mma_barrier_count)
-        mbarrier.init(load_ready_bars.index(i), count=1)
 
     # Equiv. store_done_barrier. Barrier Store TMA -> TCGEN05 MMA
     acc_empty_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES, two_ctas=TWO_CTAS)
@@ -508,7 +505,7 @@ def _matmul_kernel(
     acc_ready_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     for i in gl.static_range(ACC_STAGES):
         mbarrier.init(acc_empty_bars.index(i), count=1)
-        mbarrier.init(acc_ready_bars.index(i), count=mma_barrier_count)
+        mbarrier.init_tcgen05_mma(acc_ready_bars.index(i), [a_bufs.index(0), b_bufs.index(0)])
 
     clc_barriers = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     clc_planar_ready_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
@@ -574,6 +571,7 @@ def matmul_with_config(
     cga_layout,
     epilogue_size_n,
     subtile_stages,
+    return_compiled=False,
 ):
     if block_size_n // get_split_dim(cga_layout, 1) > 256:
         raise ValueError(
@@ -620,7 +618,7 @@ def matmul_with_config(
         num_tiles = triton.cdiv(M, tile_m) * triton.cdiv(N, tile_n)
         return (num_tiles, )
 
-    _matmul_kernel[grid](
+    compiled = _matmul_kernel[grid](
         a_desc,
         b_desc,
         c_desc,
@@ -640,7 +638,7 @@ def matmul_with_config(
         num_warps=4,
         num_ctas=2**len(cga_layout),
     )
-    return c
+    return (c, compiled) if return_compiled else c
 
 
 def matmul(a, b):
@@ -721,6 +719,41 @@ def test_matmul_matches_torch(
     except triton.OutOfResources:
         pytest.skip("Out of resources")
     torch.testing.assert_close(expected, actual, atol=1e-1, rtol=1e-2)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("cga_layout", [
+    ((1, 0), ),
+    ((1, 0), (2, 0)),
+    ((1, 0), (2, 0), (4, 0)),
+    ((1, 0), (2, 0), (4, 0), (8, 0)),
+])
+def test_matmul_warp_specialized_clc(cga_layout):
+    torch.manual_seed(0)
+    M, N, K = 100, 200, 200
+    a = torch.rand((M, K), device=torch.device("cuda"), dtype=torch.float16)
+    b = torch.rand((K, N), device=torch.device("cuda"), dtype=torch.float16)
+
+    actual, compiled = matmul_with_config(
+        a,
+        b,
+        block_size_m=64,
+        block_size_n=128,
+        block_size_k=64,
+        grid_minor_dim=0,
+        grid_tile_width=8,
+        stages=2,
+        acc_stages=2,
+        cga_layout=cga_layout,
+        epilogue_size_n=get_epilogue_size_n(64, 128, cga_layout),
+        subtile_stages=4,
+        return_compiled=True,
+    )
+
+    assert compiled.metadata.preferred_cluster_fallback_ctas == 0
+    assert "clusterlaunchcontrol" in compiled.asm["ptx"]
+    assert ".reqnctapercluster" in compiled.asm["ptx"]
+    torch.testing.assert_close(torch.matmul(a, b), actual, atol=1e-1, rtol=1e-2)
 
 
 ########################################################

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -902,6 +902,10 @@ void init_gluon_ir(py::module_ &m) {
            [](GluonOpBuilder &self, Value memDesc, int count) {
              self.create<ttng::InitBarrierOp>(memDesc, count);
            })
+      .def("create_mma_barrier_init",
+           [](GluonOpBuilder &self, Value memDesc, std::vector<Value> &descs) {
+             self.create<ttng::InitMmaBarrierOp>(memDesc, descs);
+           })
       .def("create_mbarrier_inval",
            [](GluonOpBuilder &self, Value memDesc) {
              self.create<ttng::InvalBarrierOp>(memDesc);

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1530,9 +1530,7 @@ def test_tma_tcgen05_mma_multicast_loop(FAILURE, device, run_wrapper, monkeypatc
         tma_bar = mbarrier.allocate_mbarrier(two_ctas=True)
         mbarrier.init(tma_bar, count=1)
         mma_bar = mbarrier.allocate_mbarrier()
-        mma_bar_count: ttgl.constexpr = blackwell.tcgen05_mma_barrier_count([smemA, smemB], True,
-                                                                            acc.type.layout.two_ctas)
-        mbarrier.init(mma_bar, count=mma_bar_count)
+        mbarrier.init_tcgen05_mma(mma_bar, [smemA, smemB])
 
         phase_tma = 0
         phase_mma = 0

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -372,6 +372,8 @@ def test_tma_multicast_copy(ctas_per_cga):
     )
     expect_multicast = any(ctas_per_cga[i] > cga_split_num[i] for i in range(len(ctas_per_cga)))
     assert (".multicast::cluster" in compiled.asm["ptx"]) == expect_multicast
+    if is_blackwell() and num_ctas > 2:
+        assert compiled.metadata.preferred_cluster_fallback_ctas == 2
     torch.testing.assert_close(out, inp, atol=0, rtol=0)
 
 
@@ -649,7 +651,7 @@ def tcgen05_mma_scaled_direct_multicast_kernel(a_desc, b_desc, out_ptr, BLOCK_M:
     tma_bar = mbarrier.allocate_mbarrier(two_ctas=True)
     mbarrier.init(tma_bar, count=1)
     mma_bar = mbarrier.allocate_mbarrier()
-    mma_descs: ttgl.constexpr = [smem_a, smem_b]
+    mma_descs: ttgl.constexpr = [smem_a, smem_b, a_scale, b_scale]
     mbarrier.init_tcgen05_mma(mma_bar, mma_descs)
 
     phase_tma = 0
@@ -5020,7 +5022,7 @@ def mma_scaled_tcgen05_copy_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
     mbarrier.init(tma_bar, count=1)
 
     mma_bar = mbarrier.allocate_mbarrier()
-    mma_descs: ttgl.constexpr = [a_smem, b_smem] if multicast else ()
+    mma_descs: ttgl.constexpr = [a_smem, b_smem, a_scale_tmem, b_scale_tmem] if multicast else ()
     mbarrier.init_tcgen05_mma(mma_bar, mma_descs)
 
     phase_tma = 0

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -34,7 +34,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     TensorMemoryScalesLayout,
     allocate_tensor_memory,
-    tcgen05_mma_barrier_count,
     tcgen05_mma,
     tcgen05_mma_scaled,
     tcgen05_commit,
@@ -467,7 +466,7 @@ def tcgen05_mma_multicast_commit_kernel(a_desc, b_desc, out_ptrs, BLOCK_M: ttgl.
     tma_bar = mbarrier.allocate_mbarrier(two_ctas=acc_tmem_layout.two_ctas)
     mbarrier.init(tma_bar, count=1)
     mma_bar = mbarrier.allocate_mbarrier()
-    mbarrier.init(mma_bar, count=tcgen05_mma_barrier_count([smem_a, smem_b], True, acc_tmem.type.layout.two_ctas))
+    mbarrier.init_tcgen05_mma(mma_bar, [smem_a, smem_b])
 
     mbarrier.expect(tma_bar, a_desc.nbytes_per_cta + b_desc.nbytes_per_cta)
     tma.async_load(a_desc, [0, 0], tma_bar, smem_a, multicast=True)
@@ -650,7 +649,8 @@ def tcgen05_mma_scaled_direct_multicast_kernel(a_desc, b_desc, out_ptr, BLOCK_M:
     tma_bar = mbarrier.allocate_mbarrier(two_ctas=True)
     mbarrier.init(tma_bar, count=1)
     mma_bar = mbarrier.allocate_mbarrier()
-    mbarrier.init(mma_bar, count=tcgen05_mma_barrier_count([smem_a, smem_b], True, acc.type.layout.two_ctas))
+    mma_descs: ttgl.constexpr = [smem_a, smem_b]
+    mbarrier.init_tcgen05_mma(mma_bar, mma_descs)
 
     phase_tma = 0
     phase_mma = 0
@@ -987,8 +987,8 @@ def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, out_desc, gather_idx_p
         )
         mma_bar = mbarrier.allocate_mbarrier()
         phase_mma = 0
-        mbarrier.init(mma_bar, count=tcgen05_mma_barrier_count([smem_a, smem_b], multicast,
-                                                               acc_tmem.type.layout.two_ctas))
+        mma_descs: ttgl.constexpr = [smem_a, smem_b] if multicast else ()
+        mbarrier.init_tcgen05_mma(mma_bar, mma_descs)
     else:
         acc = ttgl.zeros([BLOCK_M, BLOCK_N], dtype=ttgl.float32, layout=acc_layout)
 
@@ -5020,9 +5020,8 @@ def mma_scaled_tcgen05_copy_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale
     mbarrier.init(tma_bar, count=1)
 
     mma_bar = mbarrier.allocate_mbarrier()
-    mma_bar_count: ttgl.constexpr = tcgen05_mma_barrier_count([a_smem, b_smem], multicast=multicast,
-                                                              two_ctas=acc_tmem.type.layout.two_ctas)
-    mbarrier.init(mma_bar, count=mma_bar_count)
+    mma_descs: ttgl.constexpr = [a_smem, b_smem] if multicast else ()
+    mbarrier.init_tcgen05_mma(mma_bar, mma_descs)
 
     phase_tma = 0
     phase_mma = 0

--- a/python/triton/experimental/gluon/language/nvidia/ampere/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/ampere/mbarrier.py
@@ -5,7 +5,15 @@ from triton.experimental.gluon._runtime import constexpr_function, jit
 from triton.experimental.gluon.language._layouts import SwizzledSharedLayout
 from triton.experimental.gluon.language._core import builtin, _unwrap_if_constexpr
 
-__all__ = ["allocate_mbarrier", "arrive", "init", "invalidate", "MBarrierLayout", "wait"]
+__all__ = [
+    "allocate_mbarrier",
+    "arrive",
+    "init",
+    "init_tcgen05_mma",
+    "invalidate",
+    "MBarrierLayout",
+    "wait",
+]
 
 
 class MBarrierLayout(SwizzledSharedLayout):
@@ -77,6 +85,25 @@ def init(mbarrier, count, _semantic=None):
     """
     count = _unwrap_if_constexpr(count)
     _semantic.builder.create_mbarrier_init(mbarrier.handle, count)
+
+
+@builtin
+def init_tcgen05_mma(mbarrier, descs=(), _semantic=None):
+    descs = _unwrap_if_constexpr(descs)
+    num_ctas: ttgl.constexpr = ttgl.num_ctas(_semantic=_semantic)
+    num_ctas = _unwrap_if_constexpr(num_ctas)
+    cga_layout: ttgl.constexpr = [[2**i] for i in range(num_ctas.bit_length() - 1)]
+    actual_cga_layout: ttgl.constexpr = [list(basis) for basis in mbarrier.layout.cga_layout]
+    ttgl.static_assert(
+        list(mbarrier.shape) == [num_ctas] and actual_cga_layout == cga_layout,
+        "tcgen05 MMA barriers must have shape [num_ctas] and 1D cga_layout",
+        _semantic=_semantic,
+    )
+    if not descs:
+        _semantic.builder.create_mbarrier_init(mbarrier.handle, 1)
+        return
+    desc_handles = [desc.handle for desc in descs]
+    _semantic.builder.create_mma_barrier_init(mbarrier.handle, desc_handles)
 
 
 @builtin

--- a/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
@@ -1,4 +1,4 @@
-from ..ampere.mbarrier import MBarrierLayout, allocate_mbarrier, init, invalidate, wait
+from ..ampere.mbarrier import MBarrierLayout, allocate_mbarrier, init, init_tcgen05_mma, invalidate, wait
 from ..._core import _unwrap_if_constexpr, builtin
 
 __all__ = [
@@ -7,6 +7,7 @@ __all__ = [
     "expect",
     "fence_init_release_cluster",
     "init",
+    "init_tcgen05_mma",
     "invalidate",
     "MBarrierLayout",
     "wait",

--- a/python/tutorials/gluon/14-multicta.py
+++ b/python/tutorials/gluon/14-multicta.py
@@ -337,8 +337,8 @@ if __name__ == "__main__" and is_hopper_or_newer():
 # - create any barrier that must be waited on before the lead CTA issues
 #   `tcgen05_mma` with
 #   `mbarrier.allocate_mbarrier(..., two_ctas=True)`;
-# - when initializing an mbarrier used to wait on MMA completion, pass
-#   `two_ctas=...` to `tcgen05_mma_barrier_count`.
+# - when initializing an mbarrier used to wait on MMA completion, use
+#   `mbarrier.init_tcgen05_mma(...)`.
 #
 # Such a pre-MMA barrier needs `two_ctas=True` so that the lead CTA waits for
 # both rows before issuing the collective op. In this single-tile example that is
@@ -481,8 +481,8 @@ cga_layout_b = get_cga_layout(cga_layout, 1, two_ctas=False)
 #   broadcast group;
 # - `tcgen05_mma(..., multicast=True)` multicasts its mbarrier arrival before
 #   the next TMA overwrites the shared-memory tile;
-# - `tcgen05_mma_barrier_count(..., multicast=True, ...)` initializes that
-#   mbarrier with the matching arrival count.
+# - `mbarrier.init_tcgen05_mma(...)` initializes that mbarrier with the
+#   matching arrival count.
 #
 # The TMA synchronization pattern itself is otherwise the same as for a regular
 # load: initialize a barrier, `expect` the byte count, issue the TMA, then wait

--- a/python/tutorials/gluon/14-multicta.py
+++ b/python/tutorials/gluon/14-multicta.py
@@ -76,7 +76,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     clc,
     tcgen05_commit,
     tcgen05_mma,
-    tcgen05_mma_barrier_count,
     tensor_memory_descriptor,
 )
 from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
@@ -546,9 +545,10 @@ def test_tma_multicast_copy():
 # group to complete before it can continue the next iteration, as otherwise the next iteration's
 # TMA loads will overwrite the data from the previous iteration before it has finished consuming it.
 #
-# As such, in this case, we need to use tcgen05_mma_barrier_count to compute the number of CTAs
-# in a multicast group. Similarly we set the `multicast=True` flag on the tcgen05_mma instruction
-# to note that it will have to wait for the multicast group to complete before it can continue.
+# As such, in this case, we need to initialize the MMA completion barrier using
+# `mbarrier.init_tcgen05_mma`. Similarly we set the `multicast=True` flag on
+# the tcgen05_mma instruction to note that it will have to wait for the
+# multicast group to complete before it can continue.
 #
 # These functions are generic, so a pattern of this form would work also for non-multicast kernels
 # or non-2CTA kernels.
@@ -567,9 +567,7 @@ def tma_tcgen05_kernel(a_desc, b_desc, out_desc, NUM_K_TILES: gl.constexpr, acc_
     tma_bar = mbarrier.allocate_mbarrier(two_ctas=True)
     mma_bar = mbarrier.allocate_mbarrier()
     mbarrier.init(tma_bar, count=1)
-    mbarrier.init(
-        mma_bar, count=tcgen05_mma_barrier_count([smem_a, smem_b], multicast=True,
-                                                 two_ctas=acc_tmem.type.layout.two_ctas))
+    mbarrier.init_tcgen05_mma(mma_bar, [smem_a, smem_b])
 
     phase_tma = 0
     phase_mma = 0
@@ -1002,20 +1000,18 @@ def matmul_multicta_kernel(
         two_ctas=two_ctas,
     )
     acc_bufs = allocate_tensor_memory(gl.float32, [ACC_STAGES, block_m, block_n], tmem_layout)
-    mma_barrier_count: gl.constexpr = tcgen05_mma_barrier_count([a_bufs.index(0), b_bufs.index(0)], multicast=True,
-                                                                two_ctas=acc_bufs.index(0).type.layout.two_ctas)
 
     load_empty_bars = mbarrier.allocate_mbarrier(batch=STAGES)
     load_ready_bars = mbarrier.allocate_mbarrier(batch=STAGES, two_ctas=two_ctas)
     for i in gl.static_range(STAGES):
-        mbarrier.init(load_empty_bars.index(i), count=mma_barrier_count)
+        mbarrier.init_tcgen05_mma(load_empty_bars.index(i), [a_bufs.index(0), b_bufs.index(0)])
         mbarrier.init(load_ready_bars.index(i), count=1)
 
     acc_empty_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES, two_ctas=two_ctas)
     acc_ready_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     for i in gl.static_range(ACC_STAGES):
         mbarrier.init(acc_empty_bars.index(i), count=1)
-        mbarrier.init(acc_ready_bars.index(i), count=mma_barrier_count)
+        mbarrier.init_tcgen05_mma(acc_ready_bars.index(i), [a_bufs.index(0), b_bufs.index(0)])
 
     clc_barriers = mbarrier.allocate_mbarrier(batch=ACC_STAGES)
     clc_planar_ready_bars = mbarrier.allocate_mbarrier(batch=ACC_STAGES)

--- a/test/Conversion/clc_to_llvm.mlir
+++ b/test/Conversion/clc_to_llvm.mlir
@@ -27,6 +27,22 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#sharedClc4 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0], [0]]}>
+#barrier4 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, "ttng.preferred-cluster-fallback-ctas" = 2 : i32} {
+  // CHECK-LABEL: clc_try_cancel_preferred_fallback
+  tt.func @clc_try_cancel_preferred_fallback(%result: !ttg.memdesc<2xi64, #sharedClc4, #smem>, %mbar: !ttg.memdesc<1xi64, #barrier4, #smem>) {
+    // CHECK: %[[RANK:.+]] = nvvm.read.ptx.sreg.cluster.ctarank
+    // CHECK: llvm.icmp "eq" %[[RANK]], {{.*}} : i32
+    // CHECK: clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128
+    ttng.clc_try_cancel %result, %mbar {multicast = false} : !ttg.memdesc<2xi64, #sharedClc4, #smem>, !ttg.memdesc<1xi64, #barrier4, #smem>
+    tt.return
+  }
+}
+
+// -----
+
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {

--- a/test/Conversion/nvgpu_to_llvm.mlir
+++ b/test/Conversion/nvgpu_to_llvm.mlir
@@ -1,15 +1,29 @@
 // RUN: triton-opt %s --convert-nv-gpu-to-llvm -allow-unregistered-dialect -split-input-file | FileCheck %s
 
-// CHECK-LABEL: @cluster_id
-llvm.func @cluster_id() -> i32 {
-  // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
-  // CHECK-NOT: nvvm.read.ptx.sreg.cluster.ctaid.x
-  // CHECK-NOT: nvvm.read.ptx.sreg.cluster.ctaid.y
-  // CHECK-NOT: nvvm.read.ptx.sreg.cluster.ctaid.z
-  // CHECK-NOT: nvvm.read.ptx.sreg.cluster.nctaid.x
-  // CHECK-NOT: nvvm.read.ptx.sreg.cluster.nctaid.y
-  %id = nvg.cluster_id
-  llvm.return %id : i32
+// CHECK-LABEL: @program_cta_id
+module attributes {"ttg.num-ctas" = 2 : i32} {
+  llvm.func @program_cta_id() -> i32 {
+    // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
+    // CHECK-NOT: nvvm.read.ptx.sreg.cluster.ctaid.x
+    // CHECK-NOT: nvvm.read.ptx.sreg.cluster.ctaid.y
+    // CHECK-NOT: nvvm.read.ptx.sreg.cluster.ctaid.z
+    // CHECK-NOT: nvvm.read.ptx.sreg.cluster.nctaid.x
+    // CHECK-NOT: nvvm.read.ptx.sreg.cluster.nctaid.y
+    %id = nvg.program_cta_id
+    llvm.return %id : i32
+  }
+}
+
+// CHECK-LABEL: @program_cta_id_preferred_fallback
+module attributes {"ttg.num-ctas" = 8 : i32, "ttng.preferred-cluster-fallback-ctas" = 2 : i32} {
+  llvm.func @program_cta_id_preferred_fallback() -> i32 {
+    // CHECK: %[[NUM_CTAS:.+]] = llvm.mlir.constant(8 : i32)
+    // CHECK: %[[CTAID:.+]] = nvvm.read.ptx.sreg.ctaid.x
+    // CHECK: %[[CLUSTER_ID:.+]] = llvm.urem %[[CTAID]], %[[NUM_CTAS]] : i32
+    // CHECK: llvm.return %[[CLUSTER_ID]] : i32
+    %id = nvg.program_cta_id
+    llvm.return %id : i32
+  }
 }
 
 // -----

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1777,8 +1777,8 @@ tt.func @test_get_program_id(%a: tensor<32x!tt.ptr<i32>, #blocked0>) {
   %blockidy = tt.get_program_id y: i32
   %blockidz = tt.get_program_id z : i32
   // CHECK: clusterid.x
-  // CHECK: clusterid.y
-  // CHECK: clusterid.z
+  // CHECK: ctaid.y
+  // CHECK: ctaid.z
   %v0 = arith.addi %blockidx, %blockidy : i32
   %v1 = arith.addi %v0, %blockidz : i32
   %0 = tt.splat %v1 : i32 -> tensor<32xi32, #blocked0>
@@ -1819,8 +1819,8 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
     %blockdimy = tt.get_num_programs y : i32
     %blockdimz = tt.get_num_programs z : i32
     // CHECK: nclusterid.x
-    // CHECK: nclusterid.y
-    // CHECK: nclusterid.z
+    // CHECK: nctaid.y
+    // CHECK: nctaid.z
     %v0 = arith.addi %blockdimx, %blockdimy : i32
     %v1 = arith.addi %v0, %blockdimz : i32
     %0 = tt.splat %v1 : i32 -> tensor<32xi32, #blocked0>
@@ -3012,11 +3012,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.profile_scratch_memory_alignment = 128 : i32, ttg.profile_scratch_memory_size = 2304 : i32} {
   // CHECK-LABEL: @profile_scratch_ptr_uses_i64
-  // CHECK: %[[CLUSTER_Z:.*]] = nvvm.read.ptx.sreg.clusterid.z : i32
-  // CHECK: %[[NCLUSTER_Y:.*]] = nvvm.read.ptx.sreg.nclusterid.y : i32
-  // CHECK: %[[CLUSTER_Z_I64:.*]] = llvm.zext %[[CLUSTER_Z]] : i32 to i64
-  // CHECK: %[[NCLUSTER_Y_I64:.*]] = llvm.zext %[[NCLUSTER_Y]] : i32 to i64
-  // CHECK: %[[LINEAR_Z:.*]] = llvm.mul %[[CLUSTER_Z_I64]], %[[NCLUSTER_Y_I64]] : i64
+  // CHECK: %[[CTA_Z:.*]] = nvvm.read.ptx.sreg.ctaid.z : i32
+  // CHECK: %[[NCTA_Y:.*]] = nvvm.read.ptx.sreg.nctaid.y : i32
+  // CHECK: %[[CTA_Z_I64:.*]] = llvm.zext %[[CTA_Z]] : i32 to i64
+  // CHECK: %[[NCTA_Y_I64:.*]] = llvm.zext %[[NCTA_Y]] : i32 to i64
+  // CHECK: %[[LINEAR_Z:.*]] = llvm.mul %[[CTA_Z_I64]], %[[NCTA_Y_I64]] : i64
   // CHECK: %[[NUM_CTAS:.*]] = llvm.mlir.constant(4 : i64) : i64
   // CHECK: %[[CTA_OFFSET:.*]] = llvm.mul %{{.*}}, %[[NUM_CTAS]] : i64
   // CHECK: %[[PROFILE_SIZE:.*]] = llvm.mlir.constant(2304 : i64) : i64

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1366,7 +1366,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32} {
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: convert_layout_loads_local_replica
   // CHECK: llvm.store
-  // CHECK: nvg.cluster_id
+  // CHECK: nvg.program_cta_id
   // CHECK-NOT: nvvm.mapa
   // CHECK: llvm.load
   // CHECK-NOT: nvvm.cluster.arrive
@@ -2312,7 +2312,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: local_load_uses_local_cta
-  // CHECK: nvg.cluster_id
+  // CHECK: nvg.program_cta_id
   // CHECK-NOT: nvvm.mapa
   // CHECK: llvm.load
   tt.func public @local_load_uses_local_cta(%arg0: !ttg.memdesc<2xf32, #shared, #smem>) {
@@ -2328,7 +2328,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: local_store_uses_local_cta
-  // CHECK: nvg.cluster_id
+  // CHECK: nvg.program_cta_id
   // CHECK-NOT: nvvm.mapa
   // CHECK: llvm.store
   tt.func public @local_store_uses_local_cta(%arg0: tensor<2xf32, #reg>, %arg1: !ttg.memdesc<2xf32, #shared, #smem, mutable>) {

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -495,7 +495,7 @@ tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.sh
   // CHECK: [[IS_WARP_0:%.*]] = llvm.icmp "eq" {{.*}}, [[ZERO]] : i32
   // CHECK: [[ELECT:%.*]] = nvvm.elect.sync
   // CHECK: [[WARP_PRED:%.*]] = llvm.and [[IS_WARP_0]], [[ELECT]]
-  // CHECK: nvg.cluster_id
+  // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
   // CHECK: llvm.and {{.*}}, {{.*}} : i32
   // CHECK: [[IS_CLUSTER_0:%.*]] = llvm.icmp "eq" {{.*}}, [[ZERO]]
   // CHECK: [[LEAD_PRED:%.*]] = llvm.and [[WARP_PRED]], [[IS_CLUSTER_0]]
@@ -512,7 +512,7 @@ tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.sh
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true} {
   // CHECK-LABEL: @tma_scatter_broadcast_two_ctas
-  // CHECK: %[[CTA:.+]] = nvg.cluster_id
+  // CHECK: %[[CTA:.+]] = nvvm.read.ptx.sreg.cluster.ctarank
   // CHECK: %[[MASK:.+]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK: %[[CTA_IN_GROUP:.+]] = llvm.and %[[CTA]], %[[MASK]] : i32
   // CHECK: %[[ZERO:.+]] = llvm.mlir.constant(0 : i32) : i32

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -512,7 +512,7 @@ tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.sh
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true} {
   // CHECK-LABEL: @tma_scatter_broadcast_two_ctas
-  // CHECK: %[[CTA:.+]] = nvvm.read.ptx.sreg.cluster.ctarank
+  // CHECK: %[[CTA:.+]] = nvg.program_cta_id
   // CHECK: %[[MASK:.+]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK: %[[CTA_IN_GROUP:.+]] = llvm.and %[[CTA]], %[[MASK]] : i32
   // CHECK: %[[ZERO:.+]] = llvm.mlir.constant(0 : i32) : i32

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -15,6 +15,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#barrier4 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#mcastA = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0], [1, 0]]}>
+#mcastB = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0], [0, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true, "ttng.preferred-cluster-fallback-ctas" = 2 : i32} {
+  // CHECK-LABEL: init_mma_barrier_four_descs_two_ctas
+  tt.func @init_mma_barrier_four_descs_two_ctas(%a: !ttg.memdesc<128x128xf16, #mcastA, #smem>, %b: !ttg.memdesc<128x128xf16, #mcastB, #smem>) {
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4xi64, #barrier4, #smem, mutable>
+    // CHECK: %[[ACTUAL_CTAS:.*]] = nvvm.read.ptx.sreg.cluster.nctaid.x
+    // CHECK: %[[PREFERRED_CTAS:.*]] = llvm.mlir.constant(4 : i32)
+    // CHECK: %[[IS_FALLBACK:.*]] = llvm.icmp "ne" %[[ACTUAL_CTAS]], %[[PREFERRED_CTAS]]
+    // CHECK: %[[FALLBACK_COUNT:.*]] = llvm.mlir.constant(1 : i32)
+    // CHECK: %[[PREFERRED_COUNT:.*]] = llvm.mlir.constant(2 : i32)
+    // CHECK: llvm.select %[[IS_FALLBACK]], %[[FALLBACK_COUNT]], %[[PREFERRED_COUNT]]
+    // CHECK: @$0 mbarrier.init.shared::cta.b64 [$1], $2;
+    ttng.init_mma_barrier %barrier, %a, %b, %a, %b : !ttg.memdesc<4xi64, #barrier4, #smem, mutable>, !ttg.memdesc<128x128xf16, #mcastA, #smem>, !ttg.memdesc<128x128xf16, #mcastB, #smem>, !ttg.memdesc<128x128xf16, #mcastA, #smem>, !ttg.memdesc<128x128xf16, #mcastB, #smem>
+    tt.return
+  }
+}
+
+// -----
+
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
@@ -416,7 +438,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_local_to_global_broadcast
   // CHECK: elect.sync
-  // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
+  // CHECK: nvg.program_cta_id
   // CHECK: llvm.and
   // CHECK: llvm.icmp "eq"
   // CHECK: "@$0 cp.async.bulk.tensor.2d.global.shared::cta.bulk_group [$1, {$2, $3}], [$4];", "b,l,r,r,r" {{.*}} : (i1, !llvm.ptr, i32, i32, !llvm.ptr<3>) -> !llvm.void
@@ -658,7 +680,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   }
 
   // CHECK-LABEL: @local_gather_scatter_broadcast
-  // CHECK: nvg.cluster_id
+  // CHECK: nvg.program_cta_id
   // CHECK-NOT: nvvm.mapa
   // CHECK: llvm.load {{.*}} : !llvm.ptr<3> -> i32
   // CHECK: nvvm.barrier
@@ -810,7 +832,7 @@ module attributes {"ttg.num-ctas" = 16 : i32, "ttg.num-warps" = 1 : i32, "ttg.th
   }
 
   // CHECK-LABEL: @local_gather_partial_broadcast_16_ctas
-  // CHECK: %[[CTA:.*]] = nvg.cluster_id
+  // CHECK: %[[CTA:.*]] = nvg.program_cta_id
   // CHECK: %[[CTA_SHIFTED:.*]] = llvm.shl %[[CTA]], %{{.*}} : i32
   // CHECK: %[[PACKED:.*]] = llvm.or %{{.*}}, %[[CTA_SHIFTED]] : i32
   // CHECK: %[[LO_SHIFT:.*]] = llvm.mlir.constant(5 : i32)

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -21,10 +21,29 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: init_barrier_cluster_broadcast
   tt.func @init_barrier_cluster_broadcast() {
     %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1xi64, #shared0, #smem, mutable>
-    // CHECK: nvg.cluster_id
+    // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
     // CHECK: @$0 mbarrier.init.shared::cta.b64 [$1], 2;
     ttng.init_barrier %alloc, 1 : !ttg.memdesc<1xi64, #shared0, #smem, mutable>
     ttng.inval_barrier %alloc : !ttg.memdesc<1xi64, #shared0, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#mcast = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0], [0, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, "ttng.preferred-cluster-fallback-ctas" = 2 : i32} {
+  // CHECK-LABEL: init_mma_barrier_preferred_fallback
+  tt.func @init_mma_barrier_preferred_fallback() {
+    %barrier = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<4xi64, #barrier, #smem, mutable>
+    %desc = ttg.local_alloc {allocation.offset = 8 : i32} : () -> !ttg.memdesc<128x128xf16, #mcast, #smem, mutable>
+    // CHECK: nvvm.read.ptx.sreg.cluster.nctaid.x
+    // CHECK: llvm.select
+    // CHECK: @$0 mbarrier.init.shared::cta.b64 [$1], $2;
+    ttng.init_mma_barrier %barrier, %desc : !ttg.memdesc<4xi64, #barrier, #smem, mutable>, !ttg.memdesc<128x128xf16, #mcast, #smem, mutable>
+    ttng.inval_barrier %barrier : !ttg.memdesc<4xi64, #barrier, #smem, mutable>
     tt.return
   }
 }
@@ -36,7 +55,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: inval_barrier_cluster_broadcast
   tt.func @inval_barrier_cluster_broadcast(%alloc: !ttg.memdesc<1xi64, #shared0, #smem, mutable>) {
-    // CHECK: nvg.cluster_id
+    // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
     // CHECK: llvm.ptrtoint
     // CHECK: llvm.and
     // CHECK: llvm.inttoptr
@@ -118,7 +137,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: arrive_barrier_cluster_broadcast
   tt.func @arrive_barrier_cluster_broadcast(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>) {
     // CHECK: nvvm.barrier
-    // CHECK-NOT: nvg.cluster_id
+    // CHECK-NOT: nvg.program_cta_id
     // CHECK: llvm.ptrtoint
     // CHECK: llvm.and
     // CHECK: llvm.inttoptr
@@ -397,7 +416,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_local_to_global_broadcast
   // CHECK: elect.sync
-  // CHECK: nvg.cluster_id
+  // CHECK: nvvm.read.ptx.sreg.cluster.ctarank
   // CHECK: llvm.and
   // CHECK: llvm.icmp "eq"
   // CHECK: "@$0 cp.async.bulk.tensor.2d.global.shared::cta.bulk_group [$1, {$2, $3}], [$4];", "b,l,r,r,r" {{.*}} : (i1, !llvm.ptr, i32, i32, !llvm.ptr<3>) -> !llvm.void
@@ -458,7 +477,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: expect_barrier_cluster_broadcast
   // CHECK: nvvm.barrier
-  // CHECK-NOT: nvg.cluster_id
+  // CHECK-NOT: nvg.program_cta_id
   // CHECK: llvm.ptrtoint
   // CHECK: llvm.and
   // CHECK: llvm.inttoptr

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -2,6 +2,51 @@
 
 // -----
 
+#sharedCommit = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#barrierCommit = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // Multicast commit can complete a per-CTA barrier on another CTA even when
+  // this is not a two-CTA MMA kernel.
+  // CHECK-LABEL: @cluster_tc_gen5_commit_multicast_with_per_cta_barrier
+  // CHECK: ttng.init_mma_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.tc_gen5_commit
+  tt.func @cluster_tc_gen5_commit_multicast_with_per_cta_barrier(%desc: !ttg.memdesc<128x128xf16, #sharedCommit, #smem>) {
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierCommit, #smem, mutable>
+    ttng.init_mma_barrier %barrier, %desc : !ttg.memdesc<2xi64, #barrierCommit, #smem, mutable>, !ttg.memdesc<128x128xf16, #sharedCommit, #smem>
+    ttng.tc_gen5_commit %barrier descs %desc : !ttg.memdesc<2xi64, #barrierCommit, #smem, mutable>, !ttg.memdesc<128x128xf16, #sharedCommit, #smem>
+    tt.return
+  }
+}
+
+// -----
+
+#sharedMMA = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#barrierMMA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#tmemMMA = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @cluster_tc_gen5_mma_multicast_with_per_cta_barrier
+  // CHECK: ttng.init_mma_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.tc_gen5_mma
+  tt.func @cluster_tc_gen5_mma_multicast_with_per_cta_barrier(%a: !ttg.memdesc<128x128xf16, #sharedMMA, #smem>, %b: !ttg.memdesc<128x128xf16, #sharedMMA, #smem>, %acc: !ttg.memdesc<128x128xf32, #tmemMMA, #ttng.tensor_memory, mutable>) {
+    %false = arith.constant false
+    %true = arith.constant true
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    ttng.init_mma_barrier %barrier, %a, %b : !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>, !ttg.memdesc<128x128xf16, #sharedMMA, #smem>, !ttg.memdesc<128x128xf16, #sharedMMA, #smem>
+    ttng.tc_gen5_mma %a, %b, %acc, %false, %true, %barrier[%true] {is_async, multicast} : !ttg.memdesc<128x128xf16, #sharedMMA, #smem>, !ttg.memdesc<128x128xf16, #sharedMMA, #smem>, !ttg.memdesc<128x128xf32, #tmemMMA, #ttng.tensor_memory, mutable>, !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #blockedSplitN = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>

--- a/test/TritonNvidiaGPU/preferred_cluster_fallback.mlir
+++ b/test/TritonNvidiaGPU/preferred_cluster_fallback.mlir
@@ -81,6 +81,64 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_atomic_poll
+  tt.func @reject_atomic_poll(%ptr: !tt.ptr<i32>, %expected: i32) {
+    %matched = tt.atomic_poll acquire, gpu, %ptr, %expected : !tt.ptr<i32>, i32 -> i1
+    tt.return
+  }
+}
+
+// -----
+
+#blockedStore = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0], [0]]}>
+#sharedStore = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0], [0]]}>
+#barrierStore = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_async_shared_store
+  tt.func @reject_async_shared_store(%src: tensor<128xi32, #blockedStore>, %dst: !ttg.memdesc<128xi32, #sharedStore, #smem, mutable>, %barrier: !ttg.memdesc<4xi64, #barrierStore, #smem, mutable>) {
+    ttng.async_shared_store %src, %dst, %barrier : tensor<128xi32, #blockedStore> -> !ttg.memdesc<128xi32, #sharedStore, #smem, mutable>, !ttg.memdesc<4xi64, #barrierStore, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blockedShared = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0], [2, 0]]}>
+#sharedCrossCTA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1], [0, 2]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_cross_cta_local_store
+  tt.func @reject_cross_cta_local_store(%src: tensor<256x128xf16, #blockedShared>, %dst: !ttg.memdesc<256x128xf16, #sharedCrossCTA, #smem, mutable>) {
+    ttg.local_store %src, %dst : tensor<256x128xf16, #blockedShared> -> !ttg.memdesc<256x128xf16, #sharedCrossCTA, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrierLocal = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#mcast = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0], [0, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_static_mma_completion_count
+  tt.func @reject_static_mma_completion_count(%barrier: !ttg.memdesc<4xi64, #barrierLocal, #smem, mutable>, %desc: !ttg.memdesc<128x128xf16, #mcast, #smem>) {
+    ttng.init_barrier %barrier, 2 : !ttg.memdesc<4xi64, #barrierLocal, #smem, mutable>
+    ttng.tc_gen5_commit %barrier descs %desc : !ttg.memdesc<4xi64, #barrierLocal, #smem, mutable>, !ttg.memdesc<128x128xf16, #mcast, #smem>
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
   // CHECK-LABEL: tt.func @reject_clc
   tt.func @reject_clc(%clc: i128) -> i32 {
     %pid = ttng.clc_get_program_id %clc, x : i128 -> i32

--- a/test/TritonNvidiaGPU/preferred_cluster_fallback.mlir
+++ b/test/TritonNvidiaGPU/preferred_cluster_fallback.mlir
@@ -1,0 +1,124 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-preferred-cluster-fallback=compute-capability=100 | FileCheck %s
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: "ttng.preferred-cluster-fallback-ctas" = 2 : i32
+  // CHECK-LABEL: tt.func @safe_no_cross_cta
+  tt.func @safe_no_cross_cta() {
+    tt.return
+  }
+}
+
+// -----
+
+#blockedM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0], [2, 0]]}>
+#blockedN = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1], [0, 2]]}>
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_cross_cta_convert
+  tt.func @reject_cross_cta_convert(%arg0: tensor<256x128xf16, #blockedM>) -> tensor<256x128xf16, #blockedN> {
+    %cvt = ttg.convert_layout %arg0 : tensor<256x128xf16, #blockedM> -> tensor<256x128xf16, #blockedN>
+    tt.return %cvt : tensor<256x128xf16, #blockedN>
+  }
+}
+
+// -----
+
+#blockedReduce = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0], [2, 0]]}>
+#sliceReduce = #ttg.slice<{dim = 0, parent = #blockedReduce}>
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_cross_cta_reduce
+  tt.func @reject_cross_cta_reduce(%arg0: tensor<256x128xf16, #blockedReduce>) -> tensor<128xf16, #sliceReduce> {
+    %red = "tt.reduce"(%arg0) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedReduce>) -> tensor<128xf16, #sliceReduce>
+    tt.return %red : tensor<128xf16, #sliceReduce>
+  }
+}
+
+#blockedInline = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[1], [2]]}>
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_any_inline_asm
+  tt.func @reject_any_inline_asm(%arg0: tensor<128xi32, #blockedInline>) -> tensor<128xi32, #blockedInline> {
+    %asm = tt.elementwise_inline_asm "add.u32 $0, $1, 1;" {constraints = "=r,r", packed_element = 1 : i32, pure = true} %arg0 : tensor<128xi32, #blockedInline> -> tensor<128xi32, #blockedInline>
+    tt.return %asm : tensor<128xi32, #blockedInline>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_atomic_rmw
+  tt.func @reject_atomic_rmw(%arg0: !tt.ptr<f32>) {
+    %true = arith.constant true
+    %cst = arith.constant 1.000000e+00 : f32
+    %0 = tt.atomic_rmw fadd, relaxed, gpu, %arg0, %cst, %true : (!tt.ptr<f32>, f32, i1) -> f32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_atomic_cas
+  tt.func @reject_atomic_cas(%arg0: !tt.ptr<i32>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %0 = tt.atomic_cas relaxed, gpu, %arg0, %c0, %c1 : (!tt.ptr<i32>, i32, i32) -> i32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_clc
+  tt.func @reject_clc(%clc: i128) -> i32 {
+    %pid = ttng.clc_get_program_id %clc, x : i128 -> i32
+    tt.return %pid : i32
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.instrumentation_mode" = "consan"} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_consan_marked_module
+  tt.func @reject_consan_marked_module() {
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_two_ctas
+  tt.func @reject_two_ctas() {
+    tt.return
+  }
+}
+
+// -----
+
+#barrierAll = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0], [0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-NOT: ttng.preferred-cluster-fallback-ctas
+  // CHECK-LABEL: tt.func @reject_mbarrier_group_larger_than_pair
+  tt.func @reject_mbarrier_group_larger_than_pair(%barrier: !ttg.memdesc<1xi64, #barrierAll, #smem, mutable>) {
+    %c0 = arith.constant 0 : i32
+    ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #barrierAll, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -220,6 +220,7 @@ class CUDABackend(BaseBackend):
             metadata.num_warps,
             metadata.num_ctas,
             metadata.shared,
+            getattr(metadata, "preferred_cluster_fallback_ctas", 0),
         )
 
     def get_codegen_implementation(self, options):
@@ -385,6 +386,8 @@ class CUDABackend(BaseBackend):
         nvidia.passes.ttgpuir.add_allocate_shared_memory_nv(pm, capability, ptx_version)
         nvidia.passes.ttnvgpuir.add_allocate_tensor_memory(pm)
         nvidia.passes.ttnvgpuir.add_check_matmul_two_cta(pm)
+        if "consan" not in options.instrumentation_mode and not options.launch_cooperative_grid:
+            nvidia.passes.ttnvgpuir.add_preferred_cluster_fallback(pm, capability)
         # instrumentation point here so we can override IRs above (e.g., ttir and ttgir)
         if CUDABackend.instrumentation:
             CUDABackend.instrumentation.patch("ttgpuir_to_llvmir", pm, mod.context)
@@ -460,6 +463,7 @@ class CUDABackend(BaseBackend):
         metadata["global_scratch_align"] = src.get_int_attr("ttg.global_scratch_memory_alignment") or 1
         metadata["profile_scratch_size"] = src.get_int_attr("ttg.profile_scratch_memory_size") or 0
         metadata["profile_scratch_align"] = src.get_int_attr("ttg.profile_scratch_memory_alignment") or 1
+        metadata["preferred_cluster_fallback_ctas"] = src.get_int_attr("ttng.preferred-cluster-fallback-ctas") or 0
         ret = str(llvm_mod)
         del llvm_mod
         del context

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -8,6 +8,12 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+#define TRITON_HAS_PREFERRED_CLUSTER_LAUNCH 1
+#else
+#define TRITON_HAS_PREFERRED_CLUSTER_LAUNCH 0
+#endif
+
 typedef struct {
   PyObject_HEAD;
   _Alignas(alignof(CUtensorMap)) CUtensorMap tensorMap;
@@ -929,12 +935,13 @@ cleanup:
 }
 
 static void _launch(int gridX, int gridY, int gridZ, int num_warps,
-                    int num_ctas, int launch_cooperative_grid, int launch_pdl,
+                    int num_ctas, int preferred_cluster_fallback_ctas,
+                    int launch_cooperative_grid, int launch_pdl,
                     int shared_memory, CUstream stream, CUfunction function,
                     void **params) {
   if (gridX * gridY * gridZ > 0) {
-    // 4 attributes that we can currently pass maximum
-    CUlaunchAttribute launchAttr[4];
+    // 5 attributes that we can currently pass maximum
+    CUlaunchAttribute launchAttr[5];
     static cuLaunchKernelEx_t cuLaunchKernelExHandle = NULL;
     if (cuLaunchKernelExHandle == NULL) {
       cuLaunchKernelExHandle = getLaunchKernelExHandle();
@@ -967,14 +974,30 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps,
       ++num_attrs;
     }
 
+    int launch_cluster_dim = preferred_cluster_fallback_ctas != 0
+                                 ? preferred_cluster_fallback_ctas
+                                 : num_ctas;
     if (num_ctas != 1) {
       CUlaunchAttribute clusterAttr = {};
       clusterAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
-      clusterAttr.value.clusterDim.x = num_ctas;
+      clusterAttr.value.clusterDim.x = launch_cluster_dim;
       clusterAttr.value.clusterDim.y = 1;
       clusterAttr.value.clusterDim.z = 1;
       launchAttr[num_attrs] = clusterAttr;
       ++num_attrs;
+
+#if TRITON_HAS_PREFERRED_CLUSTER_LAUNCH
+      if (preferred_cluster_fallback_ctas != 0) {
+        CUlaunchAttribute preferredClusterAttr = {};
+        preferredClusterAttr.id =
+            CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
+        preferredClusterAttr.value.preferredClusterDim.x = num_ctas;
+        preferredClusterAttr.value.preferredClusterDim.y = 1;
+        preferredClusterAttr.value.preferredClusterDim.z = 1;
+        launchAttr[num_attrs] = preferredClusterAttr;
+        ++num_attrs;
+      }
+#endif
 
       CUlaunchAttribute clusterSchedulingAttr = {};
       clusterSchedulingAttr.id =
@@ -1376,7 +1399,7 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   uint64_t _function;
   int launch_cooperative_grid;
   int launch_pdl;
-  int num_warps, num_ctas, shared_memory;
+  int num_warps, num_ctas, shared_memory, preferred_cluster_fallback_ctas;
   PyObject *launch_metadata = NULL;
   PyObject *launch_enter_hook = NULL;
   PyObject *launch_exit_hook = NULL;
@@ -1385,14 +1408,21 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   PyObject *arg_annotations = NULL;
   Py_buffer signature;
   PyObject *kernel_args = NULL;
-  if (!PyArg_ParseTuple(args, "iiiKKpp(iii)OOOOOOy*O", &gridX, &gridY, &gridZ,
+  if (!PyArg_ParseTuple(args, "iiiKKpp(iiii)OOOOOOy*O", &gridX, &gridY, &gridZ,
                         &_stream, &_function, &launch_cooperative_grid,
                         &launch_pdl, &num_warps, &num_ctas, &shared_memory,
-                        &launch_metadata, &launch_enter_hook, &launch_exit_hook,
+                        &preferred_cluster_fallback_ctas, &launch_metadata,
+                        &launch_enter_hook, &launch_exit_hook,
                         &global_scratch_obj, &profile_scratch_obj,
                         &arg_annotations, &signature, &kernel_args)) {
     return NULL;
   }
+
+#if !TRITON_HAS_PREFERRED_CLUSTER_LAUNCH
+  // Older CUDA headers cannot spell the preferred-cluster launch attribute.
+  // Ignore the optional fallback and launch the preferred cluster as required.
+  preferred_cluster_fallback_ctas = 0;
+#endif
 
   // launch entry hook.
   if (!launchHook(launch_enter_hook, launch_metadata)) {
@@ -1459,9 +1489,9 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   }
 
   Py_BEGIN_ALLOW_THREADS;
-  _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid,
-          launch_pdl, shared_memory, (CUstream)_stream, (CUfunction)_function,
-          params);
+  _launch(gridX, gridY, gridZ, num_warps, num_ctas,
+          preferred_cluster_fallback_ctas, launch_cooperative_grid, launch_pdl,
+          shared_memory, (CUstream)_stream, (CUfunction)_function, params);
   Py_END_ALLOW_THREADS;
   if (PyErr_Occurred()) {
     goto cleanup;

--- a/third_party/nvidia/include/Dialect/NVGPU/IR/NVGPUOps.td
+++ b/third_party/nvidia/include/Dialect/NVGPU/IR/NVGPUOps.td
@@ -105,7 +105,7 @@ def NVGPU_WGMMAOp : NVGPU_Op<"wgmma", []> {
   let assemblyFormat = "$opA `,` $opB `,` $useC (`,` $opC^)? attr-dict `:` functional-type(operands, $res)";
 }
 
-def NVGPU_ClusterCTAIdOp : NVGPU_Op<"cluster_id", [Pure]> {
+def NVGPU_ProgramCTAIdOp : NVGPU_Op<"program_cta_id", [Pure]> {
   let results = (outs I32:$result);
   let assemblyFormat = "attr-dict";
 }

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -223,11 +223,28 @@ public:
   }
 };
 
-class ClusterCTAIdOpPattern : public OpRewritePattern<ttn::ClusterCTAIdOp> {
-  using OpRewritePattern<ttn::ClusterCTAIdOp>::OpRewritePattern;
+class ProgramCTAIdOpPattern : public OpRewritePattern<ttn::ProgramCTAIdOp> {
+  using OpRewritePattern<ttn::ProgramCTAIdOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(ttn::ClusterCTAIdOp op,
+  LogicalResult matchAndRewrite(ttn::ProgramCTAIdOp op,
                                 PatternRewriter &rewriter) const override {
+    auto moduleOp = op->getParentOfType<ModuleOp>();
+    assert(moduleOp && moduleOp->hasAttr("ttg.num-ctas") &&
+           "ProgramCTAIdOp requires a TritonGPU module with ttg.num-ctas");
+
+    auto loc = op.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(moduleOp);
+    if (numCTAs == 1) {
+      rewriter.replaceOp(op, b.i32_val(0));
+      return success();
+    }
+    if (LLVM::NVIDIA::usePreferredClusterFallback(moduleOp)) {
+      Value ctaId = NVVM::BlockIdXOp::create(rewriter, loc, i32_ty);
+      rewriter.replaceOp(op, b.urem(ctaId, b.i32_val(numCTAs)));
+      return success();
+    }
+
     // We could use the value range from LLVM, but it seems to change the
     // codegen quite a bit. Adding an `and` with `nCTAs - 1` generates similar
     // code than not doing anything, so we don't do anything for now. At the end
@@ -645,7 +662,7 @@ public:
     ModuleOp mod = getOperation();
     RewritePatternSet patterns(context);
 
-    patterns.add<ClusterCTAIdOpPattern, WGMMAOpPattern, LoadAcquireOpPattern,
+    patterns.add<ProgramCTAIdOpPattern, WGMMAOpPattern, LoadAcquireOpPattern,
                  WGMMAWaitGroupOpPattern, WarpIdOpPattern>(context);
 
     if (applyPatternsGreedily(mod, std::move(patterns)).failed())

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -173,10 +173,11 @@ struct InitMmaBarrierOpConversion
             LLVM::NVIDIA::getLeaderCTAPredicate(loc, rewriter, barrierTy))
       pred = b.and_(pred, *leaderPred);
 
+    bool twoCTAs = triton::nvidia_gpu::getModuleTwoCTAs(op);
     int preferredCount = triton::nvidia_gpu::getTCGen5MmaBarrierCount(
-        op.getDescs(), /*fallback=*/false);
+        op.getDescs(), twoCTAs, /*fallback=*/false);
     int fallbackCount = triton::nvidia_gpu::getTCGen5MmaBarrierCount(
-        op.getDescs(), /*fallback=*/true);
+        op.getDescs(), twoCTAs, /*fallback=*/true);
 
     Value initCount;
     if (preferredCount == fallbackCount) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -148,6 +148,61 @@ struct InitBarrierOpConversion
   }
 };
 
+struct InitMmaBarrierOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::InitMmaBarrierOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  const NVIDIA::TargetInfo *targetInfo;
+  InitMmaBarrierOpConversion(LLVMTypeConverter &typeConverter,
+                             PatternBenefit benefit,
+                             NVIDIA::TargetInfo &targetInfo)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        targetInfo(&targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::InitMmaBarrierOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto barrierTy = op.getAlloc().getType();
+    auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
+        loc, adaptor.getAlloc(),
+        typeConverter->convertType(barrierTy.getElementType()), rewriter);
+
+    Value pred = getElectWarp0OrThread0(*targetInfo, b);
+    if (auto leaderPred =
+            LLVM::NVIDIA::getLeaderCTAPredicate(loc, rewriter, barrierTy))
+      pred = b.and_(pred, *leaderPred);
+
+    int preferredCount = triton::nvidia_gpu::getTCGen5MmaBarrierCount(
+        op.getDescs(), /*fallback=*/false);
+    int fallbackCount = triton::nvidia_gpu::getTCGen5MmaBarrierCount(
+        op.getDescs(), /*fallback=*/true);
+
+    Value initCount;
+    if (preferredCount == fallbackCount) {
+      initCount = b.i32_val(preferredCount);
+    } else {
+      Value actualNumCTAs =
+          NVVM::ClusterDimBlocksXOp::create(rewriter, loc, i32_ty);
+      int numCTAs = triton::gpu::lookupNumCTAs(op);
+      Value isFallback = b.icmp_ne(actualNumCTAs, b.i32_val(numCTAs));
+      initCount = b.select(isFallback, b.i32_val(fallbackCount),
+                           b.i32_val(preferredCount));
+    }
+
+    ::mlir::triton::PTXBuilder ptxBuilder;
+    auto &barSyncOp =
+        *ptxBuilder.create("@$0 mbarrier.init.shared::cta.b64 [$1], $2;");
+    barSyncOp({ptxBuilder.newOperand(pred, "b"),
+               ptxBuilder.newOperand(smemObj.getBase(), "r"),
+               ptxBuilder.newOperand(initCount, "r")},
+              /*onlyAttachMLIRArgs=*/true);
+    ptxBuilder.launch(rewriter, loc, void_ty(op->getContext()));
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct InvalBarrierOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::InvalBarrierOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -400,7 +455,7 @@ struct CLCTryCancelOpConversion
     auto numCTAs = ttg::lookupNumCTAs(op);
     if (numCTAs > 1) {
       TritonLLVMOpBuilder b(loc, rewriter);
-      auto clusterCtaId = targetInfo->getClusterCTAId(rewriter, loc);
+      Value clusterCtaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
       pred = b.and_(pred, b.icmp_eq(clusterCtaId, b.i32_val(0)));
     }
 
@@ -552,8 +607,8 @@ void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
   patterns.add<FenceAsyncSharedOpConversion>(typeConverter, benefit);
   patterns.add<FenceMBarrierInitReleaseClusterOpConversion>(typeConverter,
                                                             benefit);
-  patterns.add<InitBarrierOpConversion, InvalBarrierOpConversion>(
-      typeConverter, benefit, targetInfo);
+  patterns.add<InitBarrierOpConversion, InitMmaBarrierOpConversion,
+               InvalBarrierOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<WaitBarrierOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<BarrierExpectConversion>(typeConverter, benefit);
   patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1197,7 +1197,7 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     auto kMsg = str_attr("msg");
     auto kBlock = str_attr("block");
     const auto numCopies = msgToOffset.getInDimSize(kMsg);
-    auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+    Value ctaId = triton::nvgpu::ProgramCTAIdOp::create(rewriter, loc);
     // We multicast if the flag is on and the block layout has broadcasting
     bool multicast = op.getMulticast();
     Value multicastMask;
@@ -1209,7 +1209,8 @@ struct AsyncTMACopyGlobalToLocalOpConversion
           LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, maskCGABroadcast);
       // If we multicast, we emit the full message from the representative CTA
       // meaning the CTA with the lowest CTA id in a multicast group.
-      auto ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
+      Value physicalCtaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
+      Value ctaIdInGroup = b.and_(physicalCtaId, b.i32_val(maskCGABroadcast));
       pred = b.and_(pred, b.icmp_eq(ctaIdInGroup, b.i32_val(0)));
     }
 
@@ -1351,13 +1352,14 @@ LogicalResult convertTMAStoreLikeOp(Operation *op,
   auto kBlock = str_attr("block");
   auto numCopies = msgToOffset.getInDimSize(kMsg);
   auto zero = b.i32_val(0);
-  auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+  Value ctaId = triton::nvgpu::ProgramCTAIdOp::create(rewriter, loc);
   uint32_t maskCGABroadcast = smemLayout.getFreeVariableMasks().lookup(kBlock);
   if (maskCGABroadcast != 0) {
     // Stores and reductions operate from CTA-local shared memory, so if the
     // source tile is broadcast across CTAs only the lead CTA should issue the
     // TMA message.
-    Value ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
+    Value physicalCtaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
+    Value ctaIdInGroup = b.and_(physicalCtaId, b.i32_val(maskCGABroadcast));
     pred = b.and_(pred, b.icmp_eq(ctaIdInGroup, zero));
   }
 
@@ -1561,7 +1563,7 @@ static LogicalResult iterateGatherScatterIndices(
     return op->emitError("x offsets must be broadcasted across each warp");
 
   Value warpId = mlir::triton::gpu::WarpIdOp::create(rewriter, loc);
-  Value blockId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+  Value blockId = triton::nvgpu::ProgramCTAIdOp::create(rewriter, loc);
   auto ctaOffsets = applyLinearLayout(
       loc, rewriter, msgToOffset, {{kMsg, b.i32_val(0)}, {kBlock, blockId}});
   assert(ctaOffsets.size() == 2 && ctaOffsets.back().first == kDim1);
@@ -1635,7 +1637,7 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
                                     .lookup(kBlock);
     multicastMask =
         LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, maskCGABroadcast);
-    Value ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+    Value ctaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
     Value ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
     pred = b.and_(pred, b.icmp_eq(ctaIdInGroup, b.i32_val(0)));
   }
@@ -1725,7 +1727,7 @@ LogicalResult AsyncTMAScatterOpConversion::matchAndRewrite(
   if (maskCGABroadcast != 0) {
     // `scatter4` only reads from the current CTA's shared memory, so if the
     // source is broadcast across CTAs only the lead CTA should issue it.
-    Value ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+    Value ctaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
     Value ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
     pred = b.icmp_eq(ctaIdInGroup, b.i32_val(0));
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1358,8 +1358,7 @@ LogicalResult convertTMAStoreLikeOp(Operation *op,
     // Stores and reductions operate from CTA-local shared memory, so if the
     // source tile is broadcast across CTAs only the lead CTA should issue the
     // TMA message.
-    Value physicalCtaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
-    Value ctaIdInGroup = b.and_(physicalCtaId, b.i32_val(maskCGABroadcast));
+    Value ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
     pred = b.and_(pred, b.icmp_eq(ctaIdInGroup, zero));
   }
 
@@ -1727,7 +1726,7 @@ LogicalResult AsyncTMAScatterOpConversion::matchAndRewrite(
   if (maskCGABroadcast != 0) {
     // `scatter4` only reads from the current CTA's shared memory, so if the
     // source is broadcast across CTAs only the lead CTA should issue it.
-    Value ctaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
+    Value ctaId = triton::nvgpu::ProgramCTAIdOp::create(rewriter, loc);
     Value ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
     pred = b.icmp_eq(ctaIdInGroup, b.i32_val(0));
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/SPMDOpToLLVM.cpp
@@ -7,26 +7,31 @@ namespace {
 using namespace mlir;
 using namespace mlir::triton;
 
-static Value getNumPrograms(OpBuilder &rewriter, int numCTAs, Location loc,
-                            ProgramIDDim axis) {
-  if (numCTAs == 1) {
-    switch (axis) {
-    case ProgramIDDim::X:
-      return NVVM::GridDimXOp::create(rewriter, loc, i32_ty);
-    case ProgramIDDim::Y:
-      return NVVM::GridDimYOp::create(rewriter, loc, i32_ty);
-    case ProgramIDDim::Z:
-      return NVVM::GridDimZOp::create(rewriter, loc, i32_ty);
+static Value getNumPrograms(OpBuilder &rewriter, ModuleOp moduleOp,
+                            Location loc, ProgramIDDim axis) {
+  int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(moduleOp);
+  bool preferredFallback = LLVM::NVIDIA::usePreferredClusterFallback(moduleOp);
+  switch (axis) {
+  case ProgramIDDim::X: {
+    // Multi-CTA launches expand the CUDA grid in X. Fixed cluster launches can
+    // read the logical program grid from %nclusterid.x; preferred fallback must
+    // read %nctaid.x and divide by the static preferred cluster size.
+    Value ret = numCTAs == 1 || preferredFallback
+                    ? Value(NVVM::GridDimXOp::create(rewriter, loc, i32_ty))
+                    : Value(NVVM::ClusterDimXOp::create(rewriter, loc, i32_ty));
+
+    if (preferredFallback) {
+      auto b = TritonLLVMOpBuilder(loc, rewriter);
+      ret = b.udiv(ret, b.i32_val(numCTAs));
     }
-  } else {
-    switch (axis) {
-    case ProgramIDDim::X:
-      return NVVM::ClusterDimXOp::create(rewriter, loc, i32_ty);
-    case ProgramIDDim::Y:
-      return NVVM::ClusterDimYOp::create(rewriter, loc, i32_ty);
-    case ProgramIDDim::Z:
-      return NVVM::ClusterDimZOp::create(rewriter, loc, i32_ty);
-    }
+    return ret;
+  }
+  case ProgramIDDim::Y:
+    // Clusters are always launched as {numCTAs, 1, 1}, so Y/Z are already the
+    // logical program grid for all cluster modes.
+    return NVVM::GridDimYOp::create(rewriter, loc, i32_ty);
+  case ProgramIDDim::Z:
+    return NVVM::GridDimZOp::create(rewriter, loc, i32_ty);
   }
   llvm_unreachable("invalid axis");
 }
@@ -39,15 +44,11 @@ struct GetNumProgramsOpConversion
   LogicalResult
   matchAndRewrite(triton::GetNumProgramsOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // It is not easy to get the compute capability here, so we use numCTAs to
-    // decide the semantic of GetNumProgramsOp. If numCTAs = 1, then
-    // GetNumProgramsOp is converted to "%nctaid", otherwise it is converted to
-    // "%nclusterid".
-    int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(
-        op->getParentOfType<ModuleOp>());
-
-    rewriter.replaceOp(
-        op, getNumPrograms(rewriter, numCTAs, op.getLoc(), op.getAxis()));
+    // getNumPrograms handles the X-only CUDA grid expansion used for multi-CTA
+    // launches.
+    rewriter.replaceOp(op,
+                       getNumPrograms(rewriter, op->getParentOfType<ModuleOp>(),
+                                      op.getLoc(), op.getAxis()));
     return success();
   }
 };

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -135,7 +135,7 @@ Value TargetInfo::getClusterCTAId(RewriterBase &rewriter, Location loc) const {
   if (triton::gpu::lookupNumCTAs(&rewriter.getInsertionBlock()->front()) == 1)
     return arith::ConstantIntOp::create(rewriter, loc, 0, 32);
 
-  return triton::nvgpu::ClusterCTAIdOp::create(rewriter, loc,
+  return triton::nvgpu::ProgramCTAIdOp::create(rewriter, loc,
                                                rewriter.getI32Type());
 }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -235,7 +235,7 @@ struct ConvertTritonGPUToLLVM
     // Fold CTAId when there is only 1 CTA.
     int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(mod);
     if (numCTAs == 1) {
-      mod.walk([](triton::nvgpu::ClusterCTAIdOp id) {
+      mod.walk([](triton::nvgpu::ProgramCTAIdOp id) {
         OpBuilder b(id);
         Value zero = LLVM::createConstantI32(id->getLoc(), b, 0);
         id.replaceAllUsesWith(zero);
@@ -298,10 +298,10 @@ bool NVIDIA::canSkipBarSync(Operation *before, Operation *after,
                             Allocation *allocation) {
   // These mbarrier ops are single threaded, so are always synchronized wrt.
   // each other.
-  if (isa<ttng::InitBarrierOp, ttng::InvalBarrierOp, ttng::BarrierExpectOp>(
-          before) &&
-      isa<ttng::InitBarrierOp, ttng::InvalBarrierOp, ttng::BarrierExpectOp>(
-          after))
+  if (isa<ttng::InitBarrierOp, ttng::InitMmaBarrierOp, ttng::InvalBarrierOp,
+          ttng::BarrierExpectOp>(before) &&
+      isa<ttng::InitBarrierOp, ttng::InitMmaBarrierOp, ttng::InvalBarrierOp,
+          ttng::BarrierExpectOp>(after))
     return true;
 
   // wait_barrier will never run ahead of the load it's waiting on

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -4,6 +4,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace mlir {
@@ -81,34 +82,41 @@ Value shuffleIdx(Location loc, RewriterBase &rewriter, Value val, Value i) {
                        b.i32_val(0x1f));
 }
 
+bool usePreferredClusterFallback(ModuleOp moduleOp) {
+  return triton::nvidia_gpu::getModulePreferredClusterFallbackCTAs(moduleOp) >
+         0;
+}
+
 Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
                ProgramIDDim axis) {
   assert(moduleOp);
 
-  // It is not easy to get the compute capability here, so we use numCTAs to
-  // decide the semantic of GetProgramIdOp. If numCTAs = 1, then
-  // GetProgramIdOp is converted to "%ctaid", otherwise it is converted to
-  // "%clusterid".
+  // Triton clusters are one-dimensional in X. Program ids for Y/Z are raw CUDA
+  // block ids; X depends on cluster mode.
   int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(moduleOp);
 
-  if (numCTAs == 1) {
-    switch (axis) {
-    case ProgramIDDim::X:
-      return NVVM::BlockIdXOp::create(rewriter, loc, i32_ty);
-    case ProgramIDDim::Y:
-      return NVVM::BlockIdYOp::create(rewriter, loc, i32_ty);
-    case ProgramIDDim::Z:
-      return NVVM::BlockIdZOp::create(rewriter, loc, i32_ty);
+  bool preferredFallback = usePreferredClusterFallback(moduleOp);
+  switch (axis) {
+  case ProgramIDDim::X: {
+    // Multi-CTA launches expand the CUDA grid in X. Fixed cluster launches can
+    // read the logical program id from %clusterid.x; preferred fallback must
+    // read %ctaid.x and divide by the static preferred cluster size.
+    Value ret = numCTAs == 1 || preferredFallback
+                    ? Value(NVVM::BlockIdXOp::create(rewriter, loc, i32_ty))
+                    : Value(NVVM::ClusterIdXOp::create(rewriter, loc, i32_ty));
+
+    if (preferredFallback) {
+      auto b = TritonLLVMOpBuilder(loc, rewriter);
+      ret = b.udiv(ret, b.i32_val(numCTAs));
     }
-  } else {
-    switch (axis) {
-    case ProgramIDDim::X:
-      return NVVM::ClusterIdXOp::create(rewriter, loc, i32_ty);
-    case ProgramIDDim::Y:
-      return NVVM::ClusterIdYOp::create(rewriter, loc, i32_ty);
-    case ProgramIDDim::Z:
-      return NVVM::ClusterIdZOp::create(rewriter, loc, i32_ty);
-    }
+    return ret;
+  }
+  case ProgramIDDim::Y:
+    // Clusters are always launched as {numCTAs, 1, 1}, so Y/Z are already the
+    // logical program id for all cluster modes.
+    return NVVM::BlockIdYOp::create(rewriter, loc, i32_ty);
+  case ProgramIDDim::Z:
+    return NVVM::BlockIdZOp::create(rewriter, loc, i32_ty);
   }
   llvm_unreachable("invalid axis");
 }
@@ -139,15 +147,37 @@ Value createElectPredicateWarp0(Location loc, OpBuilder &rewriter) {
   return b.and_(warp0, createElectPredicate(loc, rewriter));
 }
 
-Value createTMAMulticastMask(Location loc, ConversionPatternRewriter &rewriter,
-                             uint16_t broadcastBits) {
-  int numCTAs = triton::gpu::lookupNumCTAs(rewriter);
+static Value createTMAMulticastMask(Location loc,
+                                    ConversionPatternRewriter &rewriter,
+                                    uint16_t broadcastBits, int numCTAs) {
   auto encoding =
       triton::nvidia_gpu::getTMAMulticastMaskEncoding(numCTAs, broadcastBits);
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+  Value ctaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
   Value base = b.and_(ctaId, b.i32_val(encoding.fixedBits));
   return b.shl(b.i32_val(encoding.pattern), base);
+}
+
+Value createTMAMulticastMask(Location loc, ConversionPatternRewriter &rewriter,
+                             uint16_t broadcastBits) {
+  ModuleOp moduleOp =
+      rewriter.getInsertionBlock()->getParentOp()->getParentOfType<ModuleOp>();
+  int fallbackCTAs =
+      triton::nvidia_gpu::getModulePreferredClusterFallbackCTAs(moduleOp);
+  if (!fallbackCTAs)
+    return createTMAMulticastMask(loc, rewriter, broadcastBits,
+                                  triton::gpu::lookupNumCTAs(rewriter));
+
+  int preferredCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(moduleOp);
+  Value preferredMask =
+      createTMAMulticastMask(loc, rewriter, broadcastBits, preferredCTAs);
+  Value fallbackMask =
+      createTMAMulticastMask(loc, rewriter, broadcastBits, fallbackCTAs);
+
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value actualNCTA = NVVM::ClusterDimBlocksXOp::create(rewriter, loc, i32_ty);
+  Value isFallback = b.icmp_eq(actualNCTA, b.i32_val(fallbackCTAs));
+  return b.select(isFallback, fallbackMask, preferredMask);
 }
 
 uint32_t getCGABroadcastMask(mlir::triton::gpu::MemDescType barrierTy) {
@@ -163,7 +193,7 @@ getLeaderCTAPredicate(Location loc, ConversionPatternRewriter &rewriter,
   if (!maskCGABroadcast)
     return std::nullopt;
 
-  Value ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+  Value ctaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
   Value ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
   return std::optional<Value>(b.icmp_eq(ctaIdInGroup, b.i32_val(0)));
 }
@@ -185,7 +215,7 @@ Value getLeaderAddress(Location loc, ConversionPatternRewriter &rewriter,
 
 Value createLeadCTAPredicate(Location loc, RewriterBase &rewriter) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  Value leftClusterId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+  Value leftClusterId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
   leftClusterId = b.and_(leftClusterId, b.i32_val(1));
   Value cluster0 = b.icmp_eq(leftClusterId, b.i32_val(0));
   return cluster0;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
@@ -44,6 +44,8 @@ Value permute(Location loc, RewriterBase &rewriter, Value a, Value b,
 Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
                ProgramIDDim axis);
 
+bool usePreferredClusterFallback(ModuleOp moduleOp);
+
 /// Create a predicate with just single active thread.
 Value createElectPredicate(Location loc, OpBuilder &rewriter);
 Value createElectPredicateWarp0(Location loc, OpBuilder &rewriter);

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -165,6 +165,13 @@ createInitializeWSClusterBarriersWrapper(int32_t capability,
   return mlir::triton::createInitializeWSClusterBarriers(options);
 }
 
+static std::unique_ptr<mlir::Pass>
+createTritonNvidiaGPUPreferredClusterFallbackWrapper(int32_t capability) {
+  ttng::TritonNvidiaGPUPreferredClusterFallbackPassOptions options;
+  options.computeCapability = capability;
+  return ttng::createTritonNvidiaGPUPreferredClusterFallbackPass(options);
+}
+
 void init_triton_nvidia_passes_ttnvgpuir(py::module_ &m) {
   ADD_PASS_WRAPPER_0("add_plan_cta", ttng::createTritonNvidiaGPUPlanCTAPass);
   ADD_PASS_WRAPPER_1("add_fence_insertion",
@@ -183,6 +190,9 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module_ &m) {
                      ttng::createTritonNvidiaGPURemoveTMEMTokensPass);
   ADD_PASS_WRAPPER_0("add_check_matmul_two_cta",
                      ttng::createTritonNvidiaGPUCheckMatmulTwoCTAPass);
+  ADD_PASS_WRAPPER_1("add_preferred_cluster_fallback",
+                     createTritonNvidiaGPUPreferredClusterFallbackWrapper,
+                     int32_t);
   ADD_PASS_WRAPPER_0("add_nvgpu_to_llvm",
                      mlir::triton::createConvertNVGPUToLLVM);
   ADD_PASS_WRAPPER_2("add_initialize_ws_cluster_barriers",


### PR DESCRIPTION
When running multiCTA kernels for `numCTAs > 2`, we are leaving some
perf on the table as GPUs may be able not use every single SM. This is
because SMs are grouped in TPCs (pairs of SMs) which then are grouped on
GPCs (sets of TPCs). Every SM is part of a TPC, but not every TPC is
part of a GPC of size 8, so if we launch a kernel with `numCTAs == 16`
where each CTA takes a full SM, this may only be run on GPCs with size
at least 8, leaving every other SM unused.

To account for this, NVIDIA exposes an API
```
CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION
```
starting on SM100.

When invoking this API, we tell the GPU that we want to execute the
kernel with `numCTAs` if possible, but if not, use a fallback number of
CTAs and run it on less SMs.

Simplest use case to keep in mind for this feature:
```
for:
  a = tma_load a_desc, multicast=true
  b = tma_load b_desc, multicast=true
  acc += tcgen05_mma(a, b)
tma_store acc
```

In this PR, we add a pass that checks for cross-CTA data movement that
would make this invariant not hold. If all the ops in the kernel are
alright, then we apply the optimisation.

Then we change the lowerings with the following invariants:

#### `nvgpu::ClusterCTAIdOp` returns the global ctaId
In other words, this will always return the same number regardless of
whether the kernel was split or not.
For example, if we have a grid of 2 CGAs with 4 CTAs each and the second
launch is split into 2 launches, then we'll get
```
Launch 00 4CTAs: ClusterCTAIdOp: 0-3
Launch 10 2CTAs: ClusterCTAIdOp: 0-1
Launch 11 2CTAs: ClusterCTAIdOp: 2-3
```

In other words, this should be used to compute addresses in global
memory.

#### `NVVM::ClusterId` gives the relative cta_id wrt. the launched CGA size
This will depend on the runtime launch size of the program In the
example above
```
Launch 00 4CTAs: NVVM::ClusterId: 0-3
Launch 10 2CTAs: NVVM::ClusterId: 0-1
Launch 11 2CTAs: NVVM::ClusterId: 0-1
```

This should be used to generate masks for multicast, for example, or to
compute predicates.

Under this model the pid is invariant under the splits, so the program
semantics under this transformation don't vary.
