### PR TITLE
[TritonGPU] Preserve memdesc_reshape encoding on type propagation

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1456,9 +1456,27 @@ void replaceUsesAndPropagateType(
       newVal = ttg::MemDescTransOp::create(builder, trans.getLoc(), val,
                                            trans.getOrder());
     } else if (auto reshape = dyn_cast<ttg::MemDescReshapeOp>(user)) {
-      auto shape = reshape.getType().getShape();
-      newVal =
-          ttg::MemDescReshapeOp::create(builder, reshape.getLoc(), val, shape);
+      // Use inferReturnTypes to compute the correct allocShape and mutability
+      // from the new source, but preserve the original reshape's encoding
+      // rather than re-inferring it (which can change e.g. nvmma_shared to
+      // shared_linear).
+      ttg::MemDescType inferredType;
+      LogicalResult result = ttg::MemDescReshapeOp::inferReturnTypes(
+          builder.getContext(), reshape.getLoc(),
+          cast<ttg::MemDescType>(val.getType()),
+          reshape.getType().getShape(), inferredType);
+      assert(succeeded(result) && "failed to infer reshape return type");
+      assert(ttg::areLayoutsEquivalent(
+                 inferredType.getShape(),
+                 cast<ttg::LayoutEncodingTrait>(reshape.getType().getEncoding()),
+                 cast<ttg::LayoutEncodingTrait>(inferredType.getEncoding())) &&
+             "preserved encoding is not equivalent to inferred encoding");
+      Type newDstType = ttg::MemDescType::get(
+          inferredType.getShape(), inferredType.getElementType(),
+          reshape.getType().getEncoding(), inferredType.getMemorySpace(),
+          inferredType.getMutableMemory(), inferredType.getAllocShape());
+      newVal = ttg::MemDescReshapeOp::create(builder, reshape.getLoc(),
+                                             newDstType, val);
     }
     assert(newVal && "unhandled memdesc view");
     newVal.getDefiningOp()->setAttrs(user->getAttrs());

--- a/test/NVWS/insert_aref.mlir
+++ b/test/NVWS/insert_aref.mlir
@@ -779,3 +779,32 @@ tt.func @aref_result_outside_scheduled_loop(%lb: i32, %ub: i32, %step: i32) {
   tt.return
 }
 }
+
+// -----
+
+// Test that memdesc_reshape preserves nvmma_shared encoding after aref insertion.
+// A 3D shared_linear alloc is reshaped to 2D nvmma_shared and fed to a TMA store.
+// Without the fix, replaceUsesAndPropagateType re-infers the encoding as
+// shared_linear, which fails the TMA store verifier ("TMA descriptor must have
+// NVMMA shared layout").
+
+#blocked3d = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [2, 2, 1], order = [2, 1, 0]}>
+#sl3d = #ttg.shared_linear<{offset = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [1, 0, 8], [2, 0, 16], [4, 0, 32], [8, 0, 0], [16, 0, 0], [32, 0, 0], [64, 0, 0], [0, 1, 0]]}, alignment = 1024>
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @reshape_preserves_encoding
+  tt.func @reshape_preserves_encoding(%src: tensor<128x2x64xbf16, #blocked3d>,
+      %desc: !tt.tensordesc<128x128xbf16, #nvmma>,
+      %lb: i32, %ub: i32, %step: i32) {
+    %c0 = arith.constant 0 : i32
+    scf.for %iv = %lb to %ub step %step : i32 {
+      %alloc = ttg.local_alloc %src {ttg.partition = array<i32: 0>} : (tensor<128x2x64xbf16, #blocked3d>) -> !ttg.memdesc<128x2x64xbf16, #sl3d, #smem>
+      %reshaped = ttg.memdesc_reshape %alloc {ttg.partition = array<i32: 1>} : !ttg.memdesc<128x2x64xbf16, #sl3d, #smem> -> !ttg.memdesc<128x128xbf16, #nvmma, #smem>
+      // CHECK: ttng.async_tma_copy_local_to_global
+      ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %reshaped {ttg.partition = array<i32: 1>} : !tt.tensordesc<128x128xbf16, #nvmma>, !ttg.memdesc<128x128xbf16, #nvmma, #smem>
+    } {tt.warp_specialize, ttg.partition = array<i32: 0, 1>, ttg.partition.stages = [0, 2], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}


### PR DESCRIPTION
When `replaceUsesAndPropagateType` recreates a `MemDescReshapeOp` (e.g. during aref insertion), the old code re-inferred the encoding from the source. This silently changed encodings like `#ttg.nvmma_shared` to `#ttg.shared_linear`, since `inferMemDescReshapeOpEncoding` always produces `#ttg.shared_linear` when the source has `#ttg.shared_linear` encoding — even though the two may have equivalent LinearLayouts.

Fix: call `inferReturnTypes` to compute the correct allocShape from the new source, then preserve the original reshape's encoding.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
