### PR TITLE
Validate incompatible `cache_modifier`/`eviction_policy` combinations in NVIDIA backend

### DIFF
--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -reconcile-unrealized-casts 2>/dev/null | FileCheck %s --dump-input-context 20
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -reconcile-unrealized-casts --verify-diagnostics 2>/dev/null | FileCheck %s --dump-input-context 20
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: llvm.func @test_empty_kernel(%arg0: i32, %arg1: !llvm.ptr<1> {tt.pointee_type = f16}, %arg2: !llvm.ptr<1>, %arg3: !llvm.ptr<1>)
@@ -122,6 +122,80 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK: llvm.inline_asm has_side_effects asm_dialect = att {{.*}} "@$3 st.global.L1::evict_last.L2::cache_hint.b32 [ $1 + 0 ], { $0 }, $2;"
       tt.store %a_ptr_init, %cst_0, %cst evictionPolicy = evict_last : tensor<256x!tt.ptr<f32>, #blocked0>
       tt.return
+  }
+}
+
+// -----
+
+// PTX-illegal combinations of cache_modifier and eviction_policy.
+// Before this check, ptxas would fail with an opaque assembler error
+// (e.g. "Modifier '.evict_first' cannot be combined with modifier '.cs'").
+// The NVIDIA backend now emits a clear op error before PTX generation.
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @store_cs_evict_first(%ptrs : tensor<256x!tt.ptr<f32>, #blocked0>,
+                                %vals : tensor<256xf32, #blocked0>) {
+    // expected-error @+1 {{cache_modifier '.cs' is incompatible with eviction_policy 'evict_first'/'evict_last'}}
+    tt.store %ptrs, %vals evictionPolicy = evict_first cacheModifier = cs : tensor<256x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @store_cs_evict_last(%ptrs : tensor<256x!tt.ptr<f32>, #blocked0>,
+                               %vals : tensor<256xf32, #blocked0>) {
+    // expected-error @+1 {{cache_modifier '.cs' is incompatible with eviction_policy 'evict_first'/'evict_last'}}
+    tt.store %ptrs, %vals evictionPolicy = evict_last cacheModifier = cs : tensor<256x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @store_cg_evict_first(%ptrs : tensor<256x!tt.ptr<f32>, #blocked0>,
+                                %vals : tensor<256xf32, #blocked0>) {
+    // expected-error @+1 {{cache_modifier '.cg' is incompatible with eviction_policy 'evict_first'}}
+    tt.store %ptrs, %vals evictionPolicy = evict_first cacheModifier = cg : tensor<256x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @load_ca_evict_first(%ptrs : tensor<256x!tt.ptr<f32>, #blocked0>) {
+    // expected-error @+1 {{cache_modifier '.ca' is incompatible with eviction_policy 'evict_first'/'evict_last'}}
+    %0 = tt.load %ptrs evictionPolicy = evict_first cacheModifier = ca : tensor<256x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @load_ca_evict_last(%ptrs : tensor<256x!tt.ptr<f32>, #blocked0>) {
+    // expected-error @+1 {{cache_modifier '.ca' is incompatible with eviction_policy 'evict_first'/'evict_last'}}
+    %0 = tt.load %ptrs evictionPolicy = evict_last cacheModifier = ca : tensor<256x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @load_cg_evict_first(%ptrs : tensor<256x!tt.ptr<f32>, #blocked0>) {
+    // expected-error @+1 {{cache_modifier '.cg' is incompatible with eviction_policy 'evict_first'}}
+    %0 = tt.load %ptrs evictionPolicy = evict_first cacheModifier = cg : tensor<256x!tt.ptr<f32>, #blocked0>
+    tt.return
   }
 }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -188,6 +188,23 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       otherElems = unpackLLElements(loc, llOther, rewriter);
     }
 
+    // Validate cache_modifier + eviction_policy combinations that the PTX ISA
+    // forbids. This check belongs here (PTX codegen) rather than in the
+    // frontend semantic layer, which is backend-agnostic.
+    auto cache = op.getCache();
+    auto evict = op.getEvict();
+    if ((evict == triton::EvictionPolicy::EVICT_FIRST ||
+         evict == triton::EvictionPolicy::EVICT_LAST) &&
+        cache == triton::CacheModifier::CA)
+      return op.emitOpError(
+          "cache_modifier '.ca' is incompatible with eviction_policy "
+          "'evict_first'/'evict_last': .ca overrides L1 eviction policy");
+    if (evict == triton::EvictionPolicy::EVICT_FIRST &&
+        cache == triton::CacheModifier::CG)
+      return op.emitOpError(
+          "cache_modifier '.cg' is incompatible with eviction_policy "
+          "'evict_first': .cg bypasses L1 cache");
+
     // vectorized iteration through all the pointer/mask/other elements
     const int valueElemNBits =
         std::max(8u, valueElemTy.getIntOrFloatBitWidth());
@@ -398,6 +415,23 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
                        << " elemsPerThread = " << elemsPerThread << " mask is "
                        << mask << "\n";
     }
+
+    // Validate cache_modifier + eviction_policy combinations that the PTX ISA
+    // forbids. This check belongs here (PTX codegen) rather than in the
+    // frontend semantic layer, which is backend-agnostic.
+    auto cache = op.getCache();
+    auto evict = op.getEvict();
+    if ((evict == triton::EvictionPolicy::EVICT_FIRST ||
+         evict == triton::EvictionPolicy::EVICT_LAST) &&
+        cache == triton::CacheModifier::CS)
+      return op.emitOpError(
+          "cache_modifier '.cs' is incompatible with eviction_policy "
+          "'evict_first'/'evict_last': .cs bypasses L1 cache");
+    if (evict == triton::EvictionPolicy::EVICT_FIRST &&
+        cache == triton::CacheModifier::CG)
+      return op.emitOpError(
+          "cache_modifier '.cg' is incompatible with eviction_policy "
+          "'evict_first': .cg bypasses L1 cache");
 
     const size_t dtsize =
         std::max<int>(1, valueElemTy.getIntOrFloatBitWidth() / 8);


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests

- Select one of the following.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section.

---

## Why

When `tl.load`/`tl.store` is called with a PTX-illegal combination of `cache_modifier` and `eviction_policy`, Triton emits PTX that ptxas then rejects with an opaque assembler error:

```
ptxas error: Modifier '.evict_first' cannot be combined with modifier '.cs'
```

Users see a low-level message with no indication of which Python arguments caused it. The PTX ISA forbids combining certain cache modifiers with L1 eviction hints:
- `.cs` (cache streaming) bypasses L1; L1 eviction hints are undefined.
- `.ca` (cache all, load) overrides L1 eviction policy; hints conflict.
- `.cg` (cache global) bypasses L1; `evict_first` is invalid.

## What the fix does

Validate the combinations at PTX lowering time in `third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp` (`LoadOpConversion::matchAndRewrite` and `StoreOpConversion::matchAndRewrite`). On an illegal combination, emit a clear `op.emitOpError` before generating PTX.

The check lives in the NVIDIA backend, not the backend-agnostic `semantic.py`, so the Triton frontend remains neutral to PTX ISA constraints.

Combinations covered:

| op    | cache_modifier | eviction_policy          |
|-------|----------------|--------------------------|
| store | `.cs`          | `evict_first`, `evict_last` |
| store | `.cg`          | `evict_first`            |
| load  | `.ca`          | `evict_first`, `evict_last` |
| load  | `.cg`          | `evict_first`            |

Example error after this fix:

```
error: cache_modifier '.cs' is incompatible with eviction_policy
'evict_first'/'evict_last': .cs bypasses L1 cache
```

## Test plan

Added lit test cases to `test/Conversion/tritongpu_to_llvm.mlir` alongside the existing `store_with_cache_attr` / `load_with_l2_cache_hint` / `store_with_l2_cache_hint` tests. `--verify-diagnostics` was added to the existing RUN line so each illegal combination is checked via `expected-error`. Existing valid-path tests continue to pass unchanged.