### PR TITLE
[Bugfix] Update truncation from i32 to i8 when storing to i1

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2588,6 +2588,10 @@ def test_sum_dtype(device):
     kernel_default_int[(1, )](out)
     assert out[0] == 32 * 32
 
+    out = torch.empty(1, dtype=torch.bool, device=device)
+    kernel_default_int[(1, )](out)
+    assert out[0] == True
+
     out = torch.empty(1, dtype=torch.bfloat16, device=device)
     kernel_default_float[(1, )](out)
     torch.testing.assert_close(out[0], torch.tensor(32 * 32, dtype=torch.bfloat16, device=device))

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1219,6 +1219,7 @@ class TritonSemantic(Generic[TensorTy]):
             elt_ty = tl.int8
             ptr_ty = tl.pointer_type(elt_ty, ptr_ty.address_space)
             ptr = self.cast(ptr, ptr_ty)
+            val = self.cast(val, tl.int1)
 
         # Cast to target data type
         val = self.cast(val, elt_ty)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1219,7 +1219,8 @@ class TritonSemantic(Generic[TensorTy]):
             elt_ty = tl.int8
             ptr_ty = tl.pointer_type(elt_ty, ptr_ty.address_space)
             ptr = self.cast(ptr, ptr_ty)
-            val = self.cast(val, tl.int1)
+            if val.type.scalar != tl.int1:
+                val = self.cast(val, tl.int1)
 
         # Cast to target data type
         val = self.cast(val, elt_ty)


### PR DESCRIPTION

tl.sum with boolean output leads to storing `i32` to `i8`. However, using bitwise truncation return 0 when result is a multiple of 256.

This PR fixes #9991 by explictly cast the result as tl.int1 before storing result into boolean output tensor.



<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `too simple?`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
