### PR TITLE
[AMD] Enable TDM with column major tensors and partitioned encodings

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -12,6 +12,20 @@
 #include "../../backend/include/TDMCommon.h"
 
 namespace mlir::LLVM::AMD {
+
+// `PartitionedSharedEncodingAttr` stores `partitionDim` in logical tensor
+// order. TDM `blockShape` / `warpsPerCTA` use descriptor order: for col-major,
+// `swapTrailingDims`  exchanges the last two dims.
+// This function updates partition dim accordingly.
+static unsigned mapLogicalPartitionDimToDescriptor(unsigned logicalPartitionDim,
+                                                   unsigned numDims,
+                                                   bool isRowMajor) {
+  assert(logicalPartitionDim < numDims && "partitionDim out of range");
+  if (isRowMajor || logicalPartitionDim < numDims - 2)
+    return logicalPartitionDim;
+  return logicalPartitionDim == numDims - 2 ? numDims - 1 : numDims - 2;
+}
+
 namespace {
 
 // Helper to decode a value spanning two 32-bit words
@@ -52,11 +66,13 @@ SmallVector<unsigned> distributeTDMWarps(ArrayRef<int64_t> blockShape,
 // the linear stream won't align with the shared memory row structure.
 //
 // Returns: (warpsPerCTA, numTDMInstructions)
-std::pair<SmallVector<unsigned>, unsigned> distributeTDMWarpsAlignToPartition(
-    ArrayRef<int64_t> blockShape, int numWarps,
-    PartitionedSharedEncodingAttr partitionedEnc) {
+static std::pair<SmallVector<unsigned>, unsigned>
+distributeTDMWarpsAlignToPartition(ArrayRef<int64_t> blockShape, int numWarps,
+                                   PartitionedSharedEncodingAttr partitionedEnc,
+                                   bool isRowMajor) {
   unsigned numDims = blockShape.size();
-  unsigned partitionDim = partitionedEnc.getPartitionDim();
+  unsigned partitionDim = mapLogicalPartitionDimToDescriptor(
+      partitionedEnc.getPartitionDim(), numDims, isRowMajor);
   unsigned numLogicalPieces = partitionedEnc.getNumLogicalPieces();
   int64_t pieceSize =
       blockShape[partitionDim] / static_cast<int64_t>(numLogicalPieces);
@@ -107,10 +123,12 @@ std::pair<SmallVector<unsigned>, unsigned> distributeTDMWarpsAlignToPartition(
 
 std::pair<SmallVector<unsigned>, unsigned>
 distributeTDMWarpsAlignToPartition(ArrayRef<int64_t> blockShape, int numWarps,
-                                   Attribute encoding) {
+                                   Attribute encoding, bool isRowMajor) {
+  // blockShape must be in descriptor space (col-major: trailing two dims
+  // swapped). For partitioned encodings, map logical partitionDim accordingly.
   if (auto partitionedEnc = dyn_cast<PartitionedSharedEncodingAttr>(encoding))
     return distributeTDMWarpsAlignToPartition(blockShape, numWarps,
-                                              partitionedEnc);
+                                              partitionedEnc, isRowMajor);
   return {distributeTDMWarps(blockShape, numWarps), 1};
 }
 
@@ -265,13 +283,19 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
   // chunk stays within a single partition piece.  When multi-instr is needed,
   // the effective extent along partitionDim is the slice extent
   // (warps * pieceSize), not the full block extent.
+  // blockShape is already in descriptor space (swapped for col-major above).
   {
     auto [warpsPerCTA, numInstr] = distributeTDMWarpsAlignToPartition(
-        blockShape, numWarps, sharedEncoding);
+        blockShape, numWarps, sharedEncoding, isRowMajor);
     if (auto partitionedEnc =
             dyn_cast<PartitionedSharedEncodingAttr>(sharedEncoding);
-        partitionedEnc && numInstr > 1)
-      blockShape[partitionedEnc.getPartitionDim()] /= numInstr;
+        partitionedEnc && numInstr > 1) {
+      // partitionDim from the encoding is logical; match descriptor trailing
+      // swap (see mapLogicalPartitionDimToDescriptor).
+      unsigned pDim = mapLogicalPartitionDimToDescriptor(
+          partitionedEnc.getPartitionDim(), numDims, isRowMajor);
+      blockShape[pDim] /= numInstr;
+    }
 
     for (size_t i = 0; i < numDims; ++i) {
       blockShape[i] = llvm::divideCeil(blockShape[i], warpsPerCTA[i]);
@@ -1031,9 +1055,13 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
 
   auto partitionedEnc = dyn_cast<PartitionedSharedEncodingAttr>(encoding);
 
-  // Compute warp distribution -- partition-aligned when needed.
-  auto [warpsPerCTA, numTDMInstructions] =
-      distributeTDMWarpsAlignToPartition(blockShape, numWarps, encoding);
+  // Compute warp distribution in descriptor space (swapped for col-major).
+  // warpsPerCTA indices correspond to descriptor-space dimensions.
+  SmallVector<int64_t> descBlockShape(blockShape.begin(), blockShape.end());
+  if (!isRowMajor)
+    swapTrailingDims(descBlockShape);
+  auto [warpsPerCTA, numTDMInstructions] = distributeTDMWarpsAlignToPartition(
+      descBlockShape, numWarps, encoding, isRowMajor);
 
   // Fast path: single instruction covers the entire block.
   if (numTDMInstructions == 1) {
@@ -1057,9 +1085,11 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
   //   3. Build a LinearLayout for the slice (fewer groups)
   //   4. Emit one TDM intrinsic
   unsigned partitionDim = partitionedEnc.getPartitionDim();
+  unsigned descriptorPartitionDim =
+      mapLogicalPartitionDimToDescriptor(partitionDim, numDims, isRowMajor);
   unsigned numLogicalPieces = partitionedEnc.getNumLogicalPieces();
   int64_t pieceSize = blockShape[partitionDim] / numLogicalPieces;
-  unsigned warpsAlongPartition = warpsPerCTA[partitionDim];
+  unsigned warpsAlongPartition = warpsPerCTA[descriptorPartitionDim];
   int64_t sliceExtent = static_cast<int64_t>(warpsAlongPartition) * pieceSize;
 
   unsigned numPartitions = partitionedEnc.getNumPartitions();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -102,7 +102,7 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
 // distribution with numTDMInstructions = 1.
 std::pair<SmallVector<unsigned>, unsigned>
 distributeTDMWarpsAlignToPartition(ArrayRef<int64_t> blockShape, int numWarps,
-                                   Attribute encoding);
+                                   Attribute encoding, bool isRowMajor);
 
 // Calculate the number of TDM gather/scatter instructions needed.
 // - numIndices: number of row indices

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -447,16 +447,20 @@ struct TritonAMDGPUUpdateAsyncWaitCountPass
         if (auto copyOp = dyn_cast<AsyncTDMCopyGlobalToLocalOp>(op)) {
           auto smemTy = copyOp.getResult().getType();
           int numWarps = ttg::lookupNumWarps(op);
+          // numInstr depends only on numLogicalPieces and numWarps, not on
+          // the coordinate space, so isRowMajor=true is fine here.
           auto [_, numInstr] =
               mlir::LLVM::AMD::distributeTDMWarpsAlignToPartition(
-                  smemTy.getShape(), numWarps, smemTy.getEncoding());
+                  smemTy.getShape(), numWarps, smemTy.getEncoding(),
+                  /*isRowMajor=*/true);
           return numInstr;
         } else if (auto copyOp = dyn_cast<AsyncTDMCopyLocalToGlobalOp>(op)) {
           auto smemTy = copyOp.getSrc().getType();
           int numWarps = ttg::lookupNumWarps(op);
           auto [_, numInstr] =
               mlir::LLVM::AMD::distributeTDMWarpsAlignToPartition(
-                  smemTy.getShape(), numWarps, smemTy.getEncoding());
+                  smemTy.getShape(), numWarps, smemTy.getEncoding(),
+                  /*isRowMajor=*/true);
           return numInstr;
         } else if (isa<AsyncTDMScatterOp, AsyncTDMGatherOp>(op)) {
           // For scatter and gather we need to get the count of TDM intrinsics

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -1434,7 +1434,7 @@ def test_runtime_tensor_copy(M, N, BLOCK_M, BLOCK_N, NUM_BUFFERS, ASYNC_LOAD_TYP
 def partitioned_tdm_copy_kernel(a_ptr, b_ptr, M, N,  #
                                 BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr,  #
                                 NUM_PARTITIONS: ttgl.constexpr, NUM_GROUPS: ttgl.constexpr,  #
-                                PARTITION_DIM: ttgl.constexpr):
+                                PARTITION_DIM: ttgl.constexpr, COL_MAJOR: ttgl.constexpr):
     """TDM load with PartitionedSharedLayout, then store via registers."""
     num_warps: ttgl.constexpr = ttgl.num_warps()
 
@@ -1445,19 +1445,31 @@ def partitioned_tdm_copy_kernel(a_ptr, b_ptr, M, N,  #
         inner_shape_m: ttgl.constexpr = BLOCK_M
         inner_shape_n: ttgl.constexpr = BLOCK_N // (NUM_PARTITIONS * NUM_GROUPS)
 
+    if COL_MAJOR:
+        order: ttgl.constexpr = [0, 1]
+    else:
+        order: ttgl.constexpr = [1, 0]
+
     inner_layout: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[32, 4]], [inner_shape_m, inner_shape_n],
-                                                                             [1, 0])
+                                                                             order)
     smem_layout: ttgl.constexpr = PartitionedSharedLayout(NUM_PARTITIONS, NUM_GROUPS, PARTITION_DIM, inner_layout)
 
-    block_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [num_warps, 1], [1, 0])
+    if COL_MAJOR:
+        block_layout: ttgl.constexpr = ttgl.BlockedLayout([8, 1], [8, 4], [1, num_warps], [0, 1])
+    else:
+        block_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [num_warps, 1], [1, 0])
 
     pid_m = ttgl.program_id(axis=0)
     pid_n = ttgl.program_id(axis=1)
     idx_m = pid_m * BLOCK_M
     idx_n = pid_n * BLOCK_N
 
-    a_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=a_ptr, shape=(M, N), strides=(N, 1),
-                                                         block_shape=(BLOCK_M, BLOCK_N), layout=smem_layout)
+    if COL_MAJOR:
+        a_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=a_ptr, shape=(M, N), strides=(1, M),
+                                                             block_shape=(BLOCK_M, BLOCK_N), layout=smem_layout)
+    else:
+        a_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=a_ptr, shape=(M, N), strides=(N, 1),
+                                                             block_shape=(BLOCK_M, BLOCK_N), layout=smem_layout)
     a_buffer = ttgl.allocate_shared_memory(a_desc.dtype, a_desc.block_shape, a_desc.layout)
 
     ttgl.amd.gfx1250.tdm.async_load(a_desc, [idx_m, idx_n], a_buffer)
@@ -1467,7 +1479,10 @@ def partitioned_tdm_copy_kernel(a_ptr, b_ptr, M, N,  #
 
     offs_bm = idx_m + ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, block_layout))
     offs_bn = idx_n + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, block_layout))
-    offs_b = (offs_bm[:, None] * N) + offs_bn[None, :]
+    if COL_MAJOR:
+        offs_b = offs_bm[:, None] + offs_bn[None, :] * M
+    else:
+        offs_b = (offs_bm[:, None] * N) + offs_bn[None, :]
     b_mask = (offs_bm[:, None] < M) & (offs_bn[None, :] < N)
     ttgl.store(b_ptr + offs_b, a, mask=b_mask)
 
@@ -1478,6 +1493,8 @@ def partitioned_tdm_copy_kernel(a_ptr, b_ptr, M, N,  #
     [
         # # --- partitionDim = 0 (rows) ---
         # 2 partitions x 1 group = 2 pieces along dim0 -> 4 warps covers it
+        # Row-major: dim0 != inner(1), subdivision -> warps=[4,1], 1 instr.
+        # Col-major: dim0 == inner(0), no subdivision -> warps=[2,2], 1 instr.
         (64, 32, 2, 1, 0),
         # 2 partitions x 2 groups = 4 pieces along dim0 -> 4 warps covers it
         (64, 32, 2, 2, 0),
@@ -1486,7 +1503,9 @@ def partitioned_tdm_copy_kernel(a_ptr, b_ptr, M, N,  #
         # 2 partitions x 8 groups = 16 pieces along dim0 -> 4 warps < 16 -> 4 instructions
         (128, 64, 2, 2, 0),
         # --- partitionDim = 1 (cols) ---
-        # 2 partitions x 1 group = 2 pieces along dim1
+        # 2 partitions x 1 group = 2 pieces along dim1 -> 4 warps covers it
+        # Row-major: dim1 == inner(1), no subdivision -> warps=[2,2], 1 instr.
+        # Col-major: dim1 != inner(0), subdivision -> warps=[1,4], 1 instr.
         (32, 64, 2, 1, 1),
         # 2 partitions x 2 groups = 4 pieces along dim1 -> 4 warps covers it
         (64, 64, 2, 2, 1),
@@ -1496,27 +1515,32 @@ def partitioned_tdm_copy_kernel(a_ptr, b_ptr, M, N,  #
         (64, 256, 2, 8, 1),
     ],
 )
-@pytest.mark.parametrize("num_warps", [4])
-@pytest.mark.parametrize("M,N", [(256, 256)])
-def test_runtime_partitioned_tdm_load(BLOCK_M, BLOCK_N, NUM_PARTITIONS, NUM_GROUPS, PARTITION_DIM, num_warps, M, N):
+@pytest.mark.parametrize("COL_MAJOR", [False, True])
+def test_runtime_partitioned_tdm_load(BLOCK_M, BLOCK_N, NUM_PARTITIONS, NUM_GROUPS, PARTITION_DIM, COL_MAJOR):
     """Test TDM async_load with PartitionedSharedLayout (global -> LDS)."""
+    M, N = 256, 256
+    num_warps = 4
     torch.manual_seed(42)
     a = torch.randint(0x0, 0xFFFF, (M, N), dtype=torch.uint16)
-    b = torch.zeros_like(a)
 
-    a_device = a.cuda()
-    b_device = b.cuda()
+    if COL_MAJOR:
+        a_device = a.T.contiguous().T.cuda()
+        b_device = torch.zeros((N, M), dtype=a.dtype).cuda().T
+    else:
+        a_device = a.cuda()
+        b_device = torch.zeros_like(a).cuda()
 
     grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
     partitioned_tdm_copy_kernel[grid](a_device, b_device, M, N, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
                                       NUM_PARTITIONS=NUM_PARTITIONS, NUM_GROUPS=NUM_GROUPS, PARTITION_DIM=PARTITION_DIM,
-                                      num_warps=num_warps)
+                                      COL_MAJOR=COL_MAJOR, num_warps=num_warps)
 
     b_triton = b_device.cpu()
     mismatched = (b_triton != a).sum().item()
     total = a.numel()
     assert mismatched == 0, (f"Mismatch: {mismatched}/{total} ({100*mismatched/total:.1f}%) elements differ. "
-                             f"partitionDim={PARTITION_DIM}, numPartitions={NUM_PARTITIONS}, numGroups={NUM_GROUPS}")
+                             f"partitionDim={PARTITION_DIM}, numPartitions={NUM_PARTITIONS}, numGroups={NUM_GROUPS}, "
+                             f"colMajor={COL_MAJOR}")
 
 
 @gluon.jit


### PR DESCRIPTION
Fixes AMD TDM lowering for partitioned shared layouts when tensors are  column-major: logical partitionDim from the encoding must line up with descriptor blockShape / warpsPerCTA, where col-major already applies swapTrailingDims (only the last two axes are exchanged). 


