### PR TITLE
[NFC] Update ConSan docs and move aux-data comments into Utility.h

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -142,7 +142,7 @@ On a barrier wait, ConSan:
 1. Acquires the ConSan lock.
 2. Verifies the barrier is initialized.
 3. Sets the current base thread's waiting flag and phase.
-4. Checks whether all active base threads are waiting on matching barrier
+4. [Deadlock] Checks whether all active base threads are waiting on matching barrier
    phases.
 5. Releases the lock and lets the real wait execute.
 6. Re-acquires the lock after the wait.

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -1,86 +1,243 @@
 # Triton Instrument Dialect and Concurrency Sanitizer (ConSan)
 
-### Overview
+## Overview
 
-ConSan instruments Triton IR to detect illegal concurrent accesses to shared and Tensor Core memory under warp specialization. It tracks per-buffer visibility of reads and writes across threads, models barrier-based synchronization, and models commit-count–based synchronization (cp.async, wgmma).
+ConSan instruments Triton IR with runtime checks for illegal concurrent access
+to shared memory and tensor memory. The pass tracks a per-buffer frontier of
+visible reads and writes, models mbarrier synchronization, and models
+commit-count synchronization for asynchronous operations such as `cp.async`,
+WGMMA, TMA store, and AMD TDM copies.
 
-Auxiliary state is kept in distributed tensors and global scratch memory, with types created on-demand per warp-specialization partition.
+The pass is target-hook based. The module target selects the hook
+implementation:
 
-### Thread model
+- `cuda:*` uses the NVIDIA hooks.
+- `hip:*` uses the AMD hooks.
 
-- Base threads: 16 warp-specialization (WS) threads (allowing for up to 16 partitions).
-- Peer classes: +16 TMA threads, +16 Tensor Core (TC) threads, and +16 CLC threads to model lack of ordering with base threads.
-- Total logical threads: 64.
+ConSan currently supports one public entry point in the module. It uses
+BufferRegion analysis to collect shared-memory buffers, tensor-memory buffers,
+and barrier allocations, then creates auxiliary state in distributed tensors and
+shared-cluster global scratch memory. Most state has a leading CTA dimension so
+cluster and multicast effects can be modeled explicitly.
 
-Indexing uses a logical thread id in [0, 64), with column vectors sized to 64 for layout convenience.
+## Visibility Model
 
-## Auxiliary data structures
+ConSan models races by tracking visibility of completed accesses, not by
+building a general happens-before graph. For each tracked buffer, ConSan records
+which logical threads can see the latest write, and which prior reads are
+visible to each logical thread. A memory operation is legal only if the issuing
+logical thread can see the completed accesses that would conflict with it.
 
-All types are generated on-demand (per partition) based on:
+Synchronization operations update visibility rather than creating vector-clock
+style ordering metadata. Barrier arrives and commits publish the accesses that
+are visible to the issuing logical thread. Barrier waits, commit-count waits,
+and target-specific synchronization then transfer that published visibility to
+the waiting logical thread and its peer thread classes. This keeps the runtime
+state close to the property ConSan needs to check: whether a given access has
+already been made visible as finished to the thread that is about to access the
+same buffer.
 
-- B: number of tracked buffers (power-of-two padded)
-- K: number of mbarriers (power-of-two padded)
-- T_bits: 64 (bitmask width)
-- T_commits: 16 (base threads; commit counters do not apply to TC/TMA/CLC helpers)
+## Thread Model
 
-“tensor” means a distributed Triton tensor; “scratch” means a pointer into global scratch memory. Shapes below are logical; actual encodings are partition-local blocked layouts.
+ConSan uses logical thread ids rather than hardware lane ids:
 
-- buffers (tensor, <B x i64>): Base pointers of all (sub)buffers per memory space
-- barriers (tensor, <K x i64>): Pointers of all mbarriers
-- writeVisibility (scratch, <B x i64>): Per-buffer bitmask. Bit i set ⇒ thread i can see latest completed write to that buffer
-- readVisibility (scratch, <B x 64 x i64>): Per-buffer, per-thread lanes. Each lane stores a 64-bit mask of other threads whose reads are visible to that lane’s thread
-- writeTracking (scratch, <B x K x i8>): Map buffers → barriers tracking writes (boolean stored in i8)
-- readTracking (scratch, <B x K x i64>): Map buffers → barriers tracking reads (bitmask of threads)
-- barrierStates (scratch, <K x i64>): Packed barrier metadata. Bit 0 stores the current phase, bits [1..20] the initial arrival count, bits [21..40] the current arrival count, and bits [41..61] the signed tx-count. The verifier checks underflow before updating, and flips the phase when both the current count and tx-count reach zero.
-- waiting (scratch, <K x i32>): Per-barrier bitfield describing waiting threads. Each base thread gets two bits: bit (2 * thread + 0) is the waiting flag, bit (2 * thread + 1) stores the phase the thread is waiting on.
-- outstandingCommits (scratch, <B x 16 x i8>): Per-buffer, per-base-thread commit counters for cp.async and wgmma
+- Base threads: 16 logical warp-specialization slots. The default region is
+  thread 0; warp-specialize partition regions use `partition_index + 1`.
+- TMA peer threads: 16 additional slots at offset 16.
+- Tensor Core peer threads: 16 additional slots at offset 32.
+- CLC peer threads: 16 additional slots at offset 48.
+- Total logical slots in use: 64. Visibility masks are 64 bits.
 
-## Visibility and legality rules
+For a base thread, `getThreadPeersMask` returns the base thread plus its TMA,
+Tensor Core, and CLC peers. For a TMA, Tensor Core, or CLC thread, it returns
+only that helper thread. Commit-count tracking uses only the 16 base-thread
+columns, so helper threads are folded back with `thread % 16` where commit
+counters are involved.
 
-- Reads are legal iff the reading thread sees the most recent write to the buffer (writeVisibility). There can be only one write in-flight.
-- Writes are legal iff the writing thread sees both all prior writes and all reads completed for that buffer.
+At a `ttg.warp_specialize`, the pass copies the default thread's read and write
+visibility to the destination partition peer masks so partition-local execution
+starts with the visibility frontier that existed before specialization.
 
-ConSan enforces these via two checks emitted before memory ops:
+## Runtime State
 
-- experimental_verify_write_visibility: “no one else is writing, or I can see the write”
-- experimental_verify_read_visibility: “my read-visibility lane is a superset of the OR of all lanes”
+ConSan keeps enough runtime state to answer two questions at each instrumented
+operation: which logical threads can see the latest writes, and which prior
+reads must be visible before a write is legal. The state is tracked separately
+for shared memory and tensor memory when those memory types are present.
 
-## Barrier-based synchronization
+At a high level, the pass maintains:
 
-ConSan separates “tracking” from “visibility transfer”:
+- Buffer and barrier descriptors discovered by BufferRegion analysis.
+- Read and write visibility frontiers for each tracked buffer.
+- Barrier lifecycle, waiting, and barrier-to-buffer tracking state.
+- Outstanding commit counters for commit-count-ordered asynchronous flows.
+- Optional alias metadata when tracked buffer regions overlap.
+- A shared-cluster lock that serializes instrumentation updates.
 
-- At memory ops that are tracked by a barrier (loads/stores, some TMEM ops):
-  - experimental_set_read_visibility / experimental_set_write_visibility updates the appropriate visibility table for the current thread and buffer.
-  - experimental_track_visible_reads / experimental_track_visible_writes snapshots current per-buffer visibility into readTracking/writeTracking for the given barrier.
-- At arrive/commit sites (e.g., tc commit, arrive on mbarrier): ConSan emits the track ops for both reads and writes.
-- At waits: experimental_transfer_visible_reads / experimental_transfer_visible_writes propagates tracked visibility from the barrier back into the waiting thread’s visibility, and this transfer is repeated to peer threads (base, TMA, TC, CLC) to keep the classes consistent.
+Most runtime state is CTA-indexed so cluster, multicast, and cross-CTA effects
+can be represented directly. Scratch state is zero-initialized once before the
+instrumented body runs, and the initialization is followed by a CTA or cluster
+barrier before any instrumented operation can use it.
 
-### Barrier phase/count tracking
+The exact auxiliary data layout is intentionally documented next to the
+implementation in `AuxDataMap` in
+`include/triton/Dialect/TritonInstrument/IR/Utility.h`.
 
-- experimental_init_barrier_state(barrier, count, barrierStates) initializes the per-barrier state with phase = 0 and both initial/current arrival counts = `count`.
-- experimental_verify_barrier_arrive(barrier, count, txCount, barrierStates) checks that subtracting `count` from the current arrival count would not underflow and that applying `txCount` keeps the tx-count in range. The codegen emits an assert if it would not.
-- experimental_update_barrier_state(barrier, count, txCount, barrierStates) applies the arrive and tx-count delta, flips the phase when both counts reach zero, and reloads the current count from the initial count.
+## Memory Legality
 
-### Deadlock detection
+For a read effect, ConSan checks that there is no outstanding write to the
+selected buffer, or that the reading thread can see the latest write. For a
+write effect, ConSan checks both write visibility and read visibility: the
+writing thread must see the latest write frontier and all prior reads for the
+selected buffer.
 
-ConSan records which phase each thread is waiting on:
+The runtime checks account for aliasing and CTA recipients. A check against one
+buffer is expanded through the alias metadata when BufferRegion analysis found
+overlapping tracked regions, and multi-CTA operations only inspect the CTA rows
+that the operation can affect.
 
-- experimental_set_waiting(barrier, baseThread, phase, barriers, waiting) sets the waiting flag for `baseThread` and stores the requested `phase`. The flag/phase bits share the waiting bitfield (two bits per base thread).
-- experimental_check_all_active_waiting(activeMask, barriers, waiting, barrierStates) filters waiting threads to those whose stored phase matches the current barrier phase. If all active threads are waiting on matching phases, it raises a deadlock assert.
-- experimental_clear_waiting(barrier, baseThread, barriers, waiting) clears the waiting bits for `baseThread`. Each wait clears its own state after the wait completes.
+After a barrier-tracked read, ConSan records that the current peer thread mask
+can see that read. After a barrier-tracked write, ConSan records the current
+peer thread mask as the new write frontier for the buffer and clears prior read
+state that the write supersedes.
 
-## Commit-count–based synchronization
+All normal instrumentation emitted around one IR operation is wrapped in the
+ConSan lock. Barrier waits are split into a locked pre-wait section and a locked
+post-wait section.
 
-Some hardware ops synchronize via “number of outstanding commits” rather than mbarriers.
+## CTA Recipients and Multicast
 
-- Stage: experimental_stage_access_for_commit marks the current thread’s buffer lane with -1 (staged) in outstandingCommits[B x 16].
-- Commit: experimental_commit_accesses turns -1 into 1 and increments positive entries for the committing thread column.
-- Wait (cp.async): experimental_clear_outstanding_commits_set_write(thread, commits, writeVisibility, N) clears entries with count > N for the current thread, and sets the writeVisibility bit for rows where any thread’s entry was cleared.
-- Wait (wgmma): experimental_clear_outstanding_commits_set_read(thread, commits, readVisibility, N) clears entries with count > N for the current thread, and sets the readVisibility bit for rows where any thread’s entry was cleared.
+Most multi-CTA instrumentation computes a CTA recipient bitset. That bitset is
+converted to a mask over the CTA dimension so only relevant CTA rows are checked
+or updated.
 
-Legality checks for commit-count flows:
+The target hooks compute recipients from the operation:
 
-- For writes to shared memory affected by cp.async: experimental_check_outstanding_commits(buffer, commits, "async_copy_global_to_shared") asserts the row for the buffer is all zeros (no pending writes), across all base-thread columns.
-- For reads of wgmma operands in shared memory: experimental_check_outstanding_commits(buffer, commits, "warpgroup_mma operand read") asserts the row is all zeros (no pending reads).
+- Non-multicast operations usually target the current CTA.
+- Multicast TMA loads update all result-recipient CTAs, while barrier arrivals
+  route to the leader barrier CTA.
+- NVIDIA two-CTA Tensor Core operations are predicated to the issuing CTA pair
+  leader.
+- TMA load effects that write one set of CTAs and signal a different leader
+  barrier remember the effect-recipient CTA rows so a later wait can transfer
+  write visibility to both the waiting CTA and the written CTA rows.
+- CLC try-cancel effects use all CTA rows for the barrier and memory effect,
+  with diagonal recipient handling for the written result rows.
 
-Note: The check op has no “thread” operand; it inspects the whole row for the buffer.
+## Barrier Synchronization
+
+ConSan separates barrier tracking from visibility transfer.
+
+For frontier-tracked barriers, an arrive or commit snapshots the current
+thread's visible writes and reads into the barrier's tracking state. A later
+wait transfers that tracked visibility to the waiting thread's peer class.
+
+Some effects use precise write tracking instead of frontier tracking. For
+example, NVIDIA TMA and CLC operations can attach only the buffers written by
+that operation to a barrier, together with the CTA rows reached by the memory
+effect.
+
+On a barrier wait, ConSan:
+
+1. Acquires the ConSan lock.
+2. Verifies the barrier is initialized.
+3. Sets the current base thread's waiting flag and phase.
+4. Checks whether all active base threads are waiting on matching barrier
+   phases.
+5. Releases the lock and lets the real wait execute.
+6. Re-acquires the lock after the wait.
+7. Transfers tracked write and read visibility from the barrier to the current
+   thread's peer mask for shared memory and tensor memory.
+8. Clears the current base thread's waiting bits.
+
+Write transfers also consult the recorded effect-recipient CTA rows, which lets
+TMA-style and CLC cross-CTA writes become visible in the CTA rows reached by the
+memory effect. Read transfers update the current CTA row.
+
+## Barrier Lifecycle and Deadlock Checks
+
+The barrier state table models initialized, invalidated, phase, arrival-count,
+and tx-count behavior:
+
+ConSan asserts that barriers are initialized before use and not reinitialized
+without invalidation. Arrivals are checked for count underflow and tx-count
+range violations before the shadow barrier state is updated. When both the
+current arrival count and tx-count reach zero, the shadow state flips phase and
+reloads the current count from the initial count. Invalidation clears the
+barrier lifecycle, waiting, and read/write tracking state.
+
+Deadlock detection records the phase each base thread is waiting on. The check
+aligns those stored phases with each barrier's current phase, filters to active
+base threads, and asserts if every active thread is waiting on a matching phase.
+
+## Commit-Count Synchronization
+
+Commit-count synchronization is used for operations whose completion is ordered
+by outstanding commit groups rather than by a barrier. It is only modeled for
+shared-memory buffers.
+
+Conceptually, an asynchronous access moves from staged, to committed but still
+outstanding, to cleared by a wait. Waiting clears accesses older than the
+pending-count threshold and transfers the corresponding read and/or write
+visibility to the waiting thread's peer mask.
+
+Before shared-memory reads and writes, ConSan checks target-defined outstanding
+commit kinds. The check inspects all relevant CTA/buffer rows, expands aliases
+when necessary, and can exclude the caller's own base-thread column for ordered
+commit kinds. That exclusion is used by targets whose operations complete in
+issue order within one ConSan logical partition, avoiding false positives for
+same-partition ordering while still checking cross-partition races.
+
+## Target Coverage
+
+The common hook implementation covers these TritonGPU operations:
+
+- `ttg.async_copy_global_to_local`: shared-memory write tracked with
+  `AsyncCp` commit counts.
+- `ttg.async_commit_group`: commits staged `AsyncCp` accesses.
+- `ttg.async_wait`: clears `AsyncCp` entries beyond the pending-count threshold
+  and transfers write visibility.
+- `ttg.local_load`: barrier-tracked shared-memory read.
+- `ttg.local_store`: barrier-tracked shared-memory write.
+- `ttg.local_alloc` with a source: barrier-tracked shared-memory write.
+
+NVIDIA hooks additionally cover:
+
+- `ttng.init_barrier`, `ttng.wait_barrier`, and `ttng.inval_barrier` lifecycle
+  and wait instrumentation.
+- `ttng.barrier_expect`, including tx-count accounting and the non-leader CTA
+  arrive path for multicast barriers.
+- `ttng.arrive_barrier`.
+- TMA loads as barrier-tracked writes with tx-count decrement and precise
+  effect-write tracking.
+- TMA stores as `TmaStore` commit-count reads, with `ttng.tma_store_wait`
+  transferring read visibility.
+- TMEM load, store, alloc-with-source, and copy operations.
+- TCGen5 MMA, scaled MMA, commit, and TMEM copy operations as Tensor Core peer
+  thread effects.
+- CLC try-cancel as a CLC peer-thread write with EffectWrites barrier tracking,
+  and CLC load-result as a barrier-tracked read.
+- Async WGMMA operands in shared memory as `Wgmma` commit-count reads, with
+  `ttng.warp_group_dot_wait` transferring read visibility.
+
+AMD hooks additionally cover:
+
+- AMD barrier init and wait instrumentation.
+- AMD explicit barrier arrives, with arrive count scaled by warps and threads
+  per warp.
+- Async TDM global-to-local and local-to-global copies. With a barrier, these
+  are modeled through barrier arrivals; without a barrier, they use `TmaStore`
+  commit counts and implicit commits.
+- AMD async wait variants for `AsyncCp`, and TDM wait variants for `TmaStore`
+  commit counts.
+- Ordered TDM commit kinds, using the self-column exclusion described above.
+
+## Current Limitations
+
+- ConSan models one logical thread per warp-specialization partition, not every
+  hardware lane. Target hooks compensate for known ordered same-partition
+  commit flows where possible.
+- Commit-count synchronization is only implemented for shared-memory buffers.
+- Global-memory race checking is handled by the separate global sanitizer, not
+  by ConSan.
+- The pass expects exactly one public entry point in the module.

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -232,12 +232,11 @@ AMD hooks additionally cover:
   commit counts.
 - Ordered TDM commit kinds, using the self-column exclusion described above.
 
-## Current Limitations
+## Implementation Notes
 
 - ConSan models one logical thread per warp-specialization partition, not every
   hardware lane. Target hooks compensate for known ordered same-partition
   commit flows where possible.
-- Commit-count synchronization is only implemented for shared-memory buffers.
 - Global-memory race checking is handled by the separate global sanitizer, not
   by ConSan.
 - The pass expects exactly one public entry point in the module.

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -110,8 +110,15 @@ struct ValueType {
       : value(value.first), type(value.second) {}
 };
 
-// Map from IR region to ConSan auxiliary data. Auxiliary data is a value
-// and an optional type, for values that are stored in the scratch memory.
+// Map from IR region to ConSan auxiliary data.
+//
+// Aux data is created in the entry function and then either rematerialized or
+// captured into warp-specialize partition regions. Each map member below is
+// keyed by the IR region that owns the value visible at an instrumentation
+// insertion point. For scratch-backed state, ValueType::value is the scratch
+// pointer and ValueType::type is the logical tensor type loaded from/stored to
+// that pointer. For tensor descriptors and constants, ValueType::value is the
+// tensor itself and ValueType::type is its type.
 struct AuxDataMap {
   struct RegionToValueMap {
     DenseMap<Region *, ValueType> values;
@@ -131,21 +138,81 @@ struct AuxDataMap {
     Region *getEnclosingParitionOrFunctionRegion(Operation *op);
   };
 
-  // Please see TritonInstrumentOps.td for more information on the auxiliary
-  // data structures.
+  // Shape notation:
+  //   C = CTAs in the cluster.
+  //   B = tracked buffers for one memory type, power-of-two padded.
+  //   K = tracked mbarriers, power-of-two padded.
+  //   T = logical ConSan thread bit slots, padded to 64.
+  //   P = base-thread commit columns, currently 16.
+  //
+  // Storage notation:
+  //   tensor  = distributed tensor value.
+  //   scratch = pointer to shared-cluster global scratch memory.
+
+  // tensor, <C x B x i64>
+  // Per-memory-type packed buffer descriptors. Each i64 stores the 32-bit base
+  // offset and 32-bit length of one shared-memory or tensor-memory region.
   RegionToValueMap buffers[numMemTypes];
+
+  // tensor, <C x K x i64>
+  // Packed descriptors for tracked mbarrier allocations. Barriers are shared
+  // memory descriptors.
   RegionToValueMap barriers;
+
+  // scratch, <C x K x i64>
+  // Packed barrier lifecycle state. Zero means invalid/uninitialized. Bit 0 is
+  // phase, bits [1..20] are the initial arrival count, bits [21..40] are the
+  // current arrival count, and bits [41..61] hold a signed tx-count.
   RegionToValueMap barrierStates;
+
+  // scratch, <C x K x i32>
+  // Per-barrier CTA bitsets of write-recipient rows reached by outstanding
+  // EffectWrites operations such as TMA and CLC. Used when a later wait
+  // transfers tracked writes.
   RegionToValueMap barrierWriteRecipients;
 
+  // scratch, <C x B x i64>
+  // Per-memory-type write frontier. Bit i means logical ConSan thread i can see
+  // the latest write to the buffer row.
   RegionToValueMap writeVisibility[numMemTypes];
+
+  // scratch, <C x B x K x i8>
+  // Per-memory-type buffer/barrier map for writes that a barrier tracks.
   RegionToValueMap writeTracking[numMemTypes];
+
+  // scratch, <C x B x T x i64>
+  // Per-memory-type read frontier. For each buffer and logical thread lane, the
+  // i64 value is a bitmask of reads visible to that lane's thread.
   RegionToValueMap readVisibility[numMemTypes];
+
+  // scratch, <C x B x K x i64>
+  // Per-memory-type buffer/barrier map for read visibility masks that a barrier
+  // tracks.
   RegionToValueMap readTracking[numMemTypes];
+
+  // scratch, <C x B x P x i8>
+  // Per-commit-kind outstanding commit counters for shared-memory buffers.
+  // Entries are 0 for none, -1 for staged but uncommitted, and positive for a
+  // committed access with an outstanding-group distance.
   RegionToValueMap commits[CommitKind::NumCommitKinds];
+
+  // tensor, <C x B x B x i1>
+  // Optional per-memory-type alias matrix. Created only when BufferRegion
+  // analysis finds cross-buffer aliasing; checks expand selected buffer rows
+  // through this matrix.
   RegionToValueMap aliasMatrices[numMemTypes];
+
+  // scratch pointer, i32
+  // Shared-cluster lock used to serialize ConSan instrumentation updates.
   RegionToValueMap lock;
+
+  // scratch, <C x K x i32>
+  // Deadlock-detection bitfield. Each base thread uses two bits: waiting flag
+  // and stored phase.
   RegionToValueMap waiting;
+
+  // True when a memory type has cross-buffer aliasing and therefore requires
+  // aliasMatrices to make visibility and commit checks conservative.
   std::array<bool, numMemTypes> hasNonTrivialAliasing{};
 
   void populateAndPassToWarpSpecialize(ModuleOp module,

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -11,28 +11,6 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/ErrorHandling.h"
 
-// clang-format off
-// Concurrency Sanitizer data structures:
-// ConSan keeps auxilary data requied for tracking memory accesses in tensors.
-// These tensors are stored as a distributed tensor or in global scratch memory.
-// C = CTAs, B = buffers, K = mbarriers, T = logical ConSan thread bit slots,
-// P = max number of warp-specialize partitions tracked by ConSan (16 for now).
-//
-// Name                   | Storage | Rank/Type          | Description
-// -----------------------|---------|--------------------|------------
-// buffers                | tensor  | <C x B x i64>      | Base pointers of all (sub)buffers
-// barriers               | tensor  | <C x K x i64>      | Pointers to all individual mbarriers
-// barrierStates          | scratch | <C x K x i64>      | Packed barrier phase (bit 0), arrival counts (bits[1..20] init, [21..40] current), and signed tx-count (bits[41..61]); zero means invalid/uninitialized
-// barrierWriteRecipients | scratch | <C x K x i32>      | CTA bitsets of EffectWrites rows published by each barrier
-// waiting                | scratch | <C x K x i32>      | Two bits per thread: waiting flag bit (LSB), stored phase bit (bit 1)
-// writeVisibility        | scratch | <C x B x i64>      | Per-buffer thread-visibility bitmask (bit i => thread i visible)
-// readVisibility         | scratch | <C x B x T x i64>  | Per-buffer, per-thread visibility lanes (row-updated; values are bitmasks)
-// writeTracking          | scratch | <C x B x K x i8>   | Map buffers -> barriers that track writes
-// readTracking           | scratch | <C x B x K x i64>  | Map buffers -> barriers that track reads
-// outstandingCommits
-//   (async/wgmma)        | scratch | <C x B x P x i8>   | Number of outstanding commits per buffer/base partition-thread (2D replaces prior 1D)
-// clang-format on
-
 namespace mlir {
 namespace triton {
 namespace instrument {


### PR DESCRIPTION
## Summary
- Updated `TritonInstrument.md` to reflect the current ConSan implementation, including target hooks, CTA-scoped aux data, barrier lifecycle, multicast handling, and commit-count synchronization.
- Moved the aux-data description out of `ConcurrencySanitizer.cpp` and into `AuxDataMap` in `Utility.h`.
- Added per-`RegionToValueMap` comments so each aux-data member has a clear declaration-site description.

## Testing
- Not run (not requested)