### PR TITLE
[FRONTEND] Validate scale tensor dtype in dot_scaled

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -582,3 +582,22 @@ def test_err_nested_function_def():
     err_msg = format_exception(e.type, value=e.value, tb=e.tb)
     assert "StopIteration" not in err_msg, "nested def should not leak StopIteration"
     assert "nested function" in err_msg, "error should mention nested function"
+
+
+def test_dot_scaled_invalid_scale_dtype(fresh_triton_cache):
+
+    @triton.jit
+    def kernel():
+        M: tl.constexpr = 32
+        K: tl.constexpr = 64
+        N: tl.constexpr = 32
+        a = tl.full((M, K), 0, tl.uint8)
+        b = tl.full((K, N), 0, tl.uint8)
+        lhs_scale = tl.full((M, 2), 0.0, tl.float32)
+        rhs_scale = tl.full((N, 2), 0, tl.uint8)
+        acc = tl.full((M, N), 0.0, tl.float32)
+        tl.dot_scaled(a, lhs_scale, "e5m2", b, rhs_scale, "e5m2", acc, False, True, True, tl.float32)
+
+    with pytest.raises(CompilationError, match="lhs_scale must be uint8.*or float8e4nv"):
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))
+

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2363,14 +2363,14 @@ def dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=None,
     :param lhs: The first tensor to be multiplied.
     :type lhs: 2D tensor representing fp4, fp8 or bf16 elements. Fp4 elements are packed into uint8 inputs with the first element in lower bits. Fp8 are stored as uint8 or the corresponding fp8 type.
     :param lhs_scale: Scale factor for lhs tensor. Shape should be [M, K//group_size] when lhs is [M, K], where group_size is 32 if scales type are `e8m0`.
-    :type lhs_scale: e8m0 type represented as an uint8 tensor, or None.
+    :type lhs_scale: uint8 tensor (e8m0, for MX formats) or float8e4nv tensor (for nvfp4 format), or None.
     :param lhs_format: format of the lhs tensor. Available formats: {:code:`e2m1`, :code:`e4m3`, :code:`e5m2`, :code:`bf16`, :code:`fp16`}.
     :type lhs_format: str
     :param rhs: The second tensor to be multiplied.
     :type rhs: 2D tensor representing fp4, fp8 or bf16 elements. Fp4 elements are packed into uint8 inputs with the first element in lower bits. Fp8 are stored as uint8 or the corresponding fp8 type.
     :param rhs_scale: Scale factor for rhs tensor. Shape should be [N, K//group_size] where rhs is [K, N].
                       Important: Do NOT transpose rhs_scale
-    :type rhs_scale: e8m0 type represented as an uint8 tensor, or None.
+    :type rhs_scale: uint8 tensor (e8m0, for MX formats) or float8e4nv tensor (for nvfp4 format), or None.
     :param rhs_format: format of the rhs tensor. Available formats: {:code:`e2m1`, :code:`e4m3`, :code:`e5m2`, :code:`bf16`, :code:`fp16`}.
     :type rhs_format: str
     :param acc: The accumulator tensor. If not None, the result is added to this tensor.

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1562,7 +1562,14 @@ class TritonSemantic(Generic[TensorTy]):
                    rhs_scale: Optional[TensorTy], rhs_format: str, acc: TensorTy | None, fast_math: bool,
                    lhs_k_pack: bool, rhs_k_pack: bool, out_dtype: tl.dtype) -> TensorTy:
         assert lhs.type.is_block() and rhs.type.is_block()
-        #TODO: validate types.
+        rhs_scale_is_none = rhs_scale is None or (isinstance(rhs_scale, tl.constexpr) and rhs_scale.value is None)
+        lhs_scale_is_none = lhs_scale is None or (isinstance(lhs_scale, tl.constexpr) and lhs_scale.value is None)
+        if not lhs_scale_is_none:
+            assert lhs_scale.dtype in (tl.uint8, tl.float8e4nv), \
+                f"lhs_scale must be uint8 (e8m0) or float8e4nv (nvfp4). Got {lhs_scale.dtype}"
+        if not rhs_scale_is_none:
+            assert rhs_scale.dtype in (tl.uint8, tl.float8e4nv), \
+                f"rhs_scale must be uint8 (e8m0) or float8e4nv (nvfp4). Got {rhs_scale.dtype}"
         lhs_rank = len(lhs.shape)
         rhs_rank = len(rhs.shape)
         assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
@@ -1573,8 +1580,6 @@ class TritonSemantic(Generic[TensorTy]):
         allowed_formats = {"e2m1", "e4m3", "e5m2", "bf16", "fp16"}
         assert lhs_format in allowed_formats, f"NYI: lhs_format {lhs_format}"
         assert rhs_format in allowed_formats, f"NYI: rhs_format {rhs_format}"
-        rhs_scale_is_none = rhs_scale is None or (isinstance(rhs_scale, tl.constexpr) and rhs_scale.value is None)
-        lhs_scale_is_none = lhs_scale is None or (isinstance(lhs_scale, tl.constexpr) and lhs_scale.value is None)
         lhs = self._bitcast_to_fp_type(lhs, lhs_format)
         rhs = self._bitcast_to_fp_type(rhs, rhs_format)
 


### PR DESCRIPTION
Add compile-time dtype validation for scale tensors in tl.dot_scaled,
catching invalid types (e.g. float32) early with a clear error message
instead of failing deep in the backend.
- Validates that lhs_scale/rhs_scale are uint8 (e8m0) or float8e4nv (nvfp4)
- Moves *_scale_is_none computation before validation
- Updates docstring in core.py to document both accepted scale types
- Adds compile-time error test (no GPU required)
---
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run pre-commit run --from-ref origin/main --to-ref HEAD.
- Select one of the following.
  - [x] I have added tests.
    - /python/test for end-to-end tests
  - [ ] This PR does not need a test because FILL THIS IN.
- Select one of the following.
  - [x] I have not added any lit tests.
  - [ ] The lit tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section.