### PR TITLE
[AMD][gfx9] Restore token-aware wait count derivation on asyncmark ta…

### DIFF
--- a/test/TritonGPU/amd/amd-block-pingpong-asyncmark-multi-token.mlir
+++ b/test/TritonGPU/amd/amd-block-pingpong-asyncmark-multi-token.mlir
@@ -1,0 +1,68 @@
+// RUN: triton-opt %s --tritonamdgpu-block-pingpong=num-stages=3 | FileCheck %s
+// RUN: triton-opt %s --tritonamdgpu-block-pingpong=num-stages=3 --tritonamdgpu-update-async-wait-count=gfx-arch=gfx950 | FileCheck %s
+
+// BlockPingpong's transformTwoClusterWithLocalLoadAndAll combines per-operand
+// ttg.async_waits into a single multi-token wait. The Pipeline pass's
+// updateWaits already set each input wait's `num` to the in-flight commit-
+// group count it can tolerate; the merged wait must preserve the *minimum*
+// of those counts so the pipeline isn't accidentally serialized.
+//
+// On asyncmark targets (CDNA3/CDNA4) this `num` lowers straight to
+// rocdl.wait.asyncmark(N), and UpdateAsyncWaitCount is a no-op since PR #9883
+// - so whatever num BlockPingpong writes is what reaches the hardware. The
+// second RUN line confirms UpdateAsyncWaitCount leaves the wait untouched.
+
+#blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [32, 2], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 4], instrShape = [16, 16, 32], isTransposed = true}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [0, 1]}>
+#shared1 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 16, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: async_ns3_gemm_pingpong_multi_token
+  // The two per-operand waits in the input carry num=2 and num=1; pingpong
+  // fuses them into a single multi-token wait that preserves min(2, 1) = 1.
+  // CHECK: scf.for
+  // CHECK: ttg.async_wait %{{[^,]+}}, %{{[^,]+}} {num = 1 : i32}
+  tt.func public @async_ns3_gemm_pingpong_multi_token(
+      %arg0: i32,
+      %arg1: tensor<256x32x!tt.ptr<bf16>, #blocked>,
+      %arg2: tensor<32x256x!tt.ptr<bf16>, #blocked1>,
+      %arg3: !ttg.memdesc<256x32xbf16, #shared, #smem, mutable>,
+      %arg4: !ttg.memdesc<256x32xbf16, #shared, #smem, mutable>,
+      %arg5: !ttg.async.token,
+      %arg6: !ttg.memdesc<32x256xbf16, #shared1, #smem, mutable>,
+      %arg7: !ttg.memdesc<32x256xbf16, #shared1, #smem, mutable>,
+      %arg8: !ttg.async.token,
+      %arg9: !ttg.async.token,
+      %arg10: !ttg.async.token,
+      %arg11: tensor<256x32xi32, #blocked>,
+      %arg12: tensor<32x256xi32, #blocked1>,
+      %arg13: !ttg.memdesc<3x256x32xbf16, #shared, #smem, mutable>,
+      %arg14: !ttg.memdesc<3x32x256xbf16, #shared1, #smem, mutable>) {
+    %c3_i32 = arith.constant 3 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x256xf32, #mma>
+    %0:12 = scf.for %arg15 = %c0_i32 to %arg0 step %c1_i32 iter_args(%arg16 = %cst, %arg17 = %arg1, %arg18 = %arg2, %arg19 = %c1_i32, %arg20 = %arg3, %arg21 = %arg4, %arg22 = %arg5, %arg23 = %arg6, %arg24 = %arg7, %arg25 = %arg8, %arg26 = %arg9, %arg27 = %arg10) -> (tensor<256x256xf32, #mma>, tensor<256x32x!tt.ptr<bf16>, #blocked>, tensor<32x256x!tt.ptr<bf16>, #blocked1>, i32, !ttg.memdesc<256x32xbf16, #shared, #smem, mutable>, !ttg.memdesc<256x32xbf16, #shared, #smem, mutable>, !ttg.async.token, !ttg.memdesc<32x256xbf16, #shared1, #smem, mutable>, !ttg.memdesc<32x256xbf16, #shared1, #smem, mutable>, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+      %1 = tt.addptr %arg17, %arg11 : tensor<256x32x!tt.ptr<bf16>, #blocked>, tensor<256x32xi32, #blocked>
+      %2 = tt.addptr %arg18, %arg12 : tensor<32x256x!tt.ptr<bf16>, #blocked1>, tensor<32x256xi32, #blocked1>
+      %3 = arith.addi %arg19, %c1_i32 : i32
+      %4 = arith.cmpi slt, %3, %c3_i32 : i32
+      %5 = arith.select %4, %3, %c0_i32 : i32
+      %6 = ttg.memdesc_index %arg13[%5] : !ttg.memdesc<3x256x32xbf16, #shared, #smem, mutable> -> !ttg.memdesc<256x32xbf16, #shared, #smem, mutable>
+      %7 = ttg.async_copy_global_to_local %1, %6 : tensor<256x32x!tt.ptr<bf16>, #blocked> -> <256x32xbf16, #shared, #smem, mutable>
+      %8 = ttg.async_commit_group tokens %7
+      %9 = ttg.local_load %arg20 token %arg22 : !ttg.memdesc<256x32xbf16, #shared, #smem, mutable> -> tensor<256x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+      %10 = ttg.memdesc_index %arg14[%5] : !ttg.memdesc<3x32x256xbf16, #shared1, #smem, mutable> -> !ttg.memdesc<32x256xbf16, #shared1, #smem, mutable>
+      %11 = ttg.async_copy_global_to_local %2, %10 : tensor<32x256x!tt.ptr<bf16>, #blocked1> -> <32x256xbf16, #shared1, #smem, mutable>
+      %12 = ttg.async_commit_group tokens %11
+      %13 = ttg.local_load %arg23 token %arg25 : !ttg.memdesc<32x256xbf16, #shared1, #smem, mutable> -> tensor<32x256xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+      %14 = tt.dot %9, %13, %arg16 : tensor<256x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<32x256xbf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<256x256xf32, #mma>
+      %15 = ttg.async_wait %arg26 {num = 2 : i32}
+      %16 = ttg.async_wait %arg27 {num = 1 : i32}
+      scf.yield %14, %1, %2, %5, %arg21, %6, %15, %arg24, %10, %16, %8, %12 : tensor<256x256xf32, #mma>, tensor<256x32x!tt.ptr<bf16>, #blocked>, tensor<32x256x!tt.ptr<bf16>, #blocked1>, i32, !ttg.memdesc<256x32xbf16, #shared, #smem, mutable>, !ttg.memdesc<256x32xbf16, #shared, #smem, mutable>, !ttg.async.token, !ttg.memdesc<32x256xbf16, #shared1, #smem, mutable>, !ttg.memdesc<32x256xbf16, #shared1, #smem, mutable>, !ttg.async.token, !ttg.async.token, !ttg.async.token
+    }
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/amd-pipeline-asyncmark-wait-num.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-asyncmark-wait-num.mlir
@@ -1,0 +1,60 @@
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=3" -tritonamdgpu-pipeline="use_async_copy=1" -canonicalize | FileCheck %s
+
+// On asyncmark targets (CDNA3/CDNA4) ttg.async_wait's `num` lowers straight to
+// wait.asyncmark(N), so the pipeliner-authored num=0 ("wait for all") would
+// serialize the SWP (PR #9883). Verify the pipeline pass runs updateWaits and
+// rewrites the steady-state wait to a non-zero commit-group count.
+
+#blocked = #ttg.blocked<{sizePerThread = [2, 1], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [16, 16, 4], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: async_wait_num_stages3
+  // Single load, num_stages=3 -> 1 commit allowed in flight.
+  // CHECK: scf.for
+  // CHECK:   ttg.async_wait %{{.*}} {num = 1 : i32}
+  // CHECK:   scf.yield
+  tt.func @async_wait_num_stages3(
+      %arg0: tensor<16x32x!tt.ptr<f32>, #blocked> {tt.contiguity = dense<[1, 2]> : tensor<2xi32>, tt.divisibility = dense<16> : tensor<2xi32>},
+      %arg1: tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>,
+      %lb: i32, %ub: i32, %step: i32) -> tensor<16x32xf32, #mma> {
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<16x32xf32, #mma>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<16x32xf32, #mma>) : i32 {
+      %a = tt.load %arg0 : tensor<16x32x!tt.ptr<f32>, #blocked>
+      %a_dot = ttg.convert_layout %a : tensor<16x32xf32, #blocked> -> tensor<16x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+      %c = tt.dot %a_dot, %arg1, %acc : tensor<16x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<16x32xf32, #mma>
+      scf.yield %c : tensor<16x32xf32, #mma>
+    }
+    tt.return %result : tensor<16x32xf32, #mma>
+  }
+}
+
+// -----
+
+// Two loads (gemm-shaped) at num_stages=3: each iteration emits two commit
+// groups, the steady-state multi-token wait must allow both in flight, so
+// updateWaits should derive num=2.
+
+#blockedA = #ttg.blocked<{sizePerThread = [2, 1], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blockedB = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [16, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [16, 16, 4], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: gemm_two_loads_stages3
+  // CHECK: scf.for
+  // CHECK:   ttg.async_wait %{{[^,]+}}, %{{[^,]+}} {num = 2 : i32}
+  // CHECK:   scf.yield
+  tt.func @gemm_two_loads_stages3(
+      %argA: tensor<16x32x!tt.ptr<f32>, #blockedA> {tt.contiguity = dense<[1, 2]> : tensor<2xi32>, tt.divisibility = dense<16> : tensor<2xi32>},
+      %argB: tensor<32x32x!tt.ptr<f32>, #blockedB> {tt.contiguity = dense<[2, 1]> : tensor<2xi32>, tt.divisibility = dense<16> : tensor<2xi32>},
+      %lb: i32, %ub: i32, %step: i32) -> tensor<16x32xf32, #mma> {
+    %cst_acc = arith.constant dense<0.000000e+00> : tensor<16x32xf32, #mma>
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %cst_acc) -> (tensor<16x32xf32, #mma>) : i32 {
+      %a = tt.load %argA : tensor<16x32x!tt.ptr<f32>, #blockedA>
+      %b = tt.load %argB : tensor<32x32x!tt.ptr<f32>, #blockedB>
+      %a_dot = ttg.convert_layout %a : tensor<16x32xf32, #blockedA> -> tensor<16x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>
+      %b_dot = ttg.convert_layout %b : tensor<32x32xf32, #blockedB> -> tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>
+      %c = tt.dot %a_dot, %b_dot, %acc : tensor<16x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<32x32xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<16x32xf32, #mma>
+      scf.yield %c : tensor<16x32xf32, #mma>
+    }
+    tt.return %result : tensor<16x32xf32, #mma>
+  }
+}

--- a/test/TritonGPU/amd/amd-update-async-wait-count-asyncmark.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count-asyncmark.mlir
@@ -1,0 +1,47 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=gfx-arch=gfx950 | FileCheck %s
+
+// For CDNA3/CDNA4, ttg.async_wait is generated from 3 sources:
+//   - By pipeliner, num computed within the pass.
+//   - By block-pingpong, num computed within the pass.
+//   - By gluon, num filled by user.
+//
+// On CDNA3/CDNA4, since PR #9883, UpdateAsyncWaitCount stays no-op for all 3
+// cases, which is checked by this test.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: single_token_two_crossed
+  // Wait on %1 with %3 and %5 between - derivation would yield num=2; sentinel
+  // num=7 must survive.
+  // CHECK: ttg.async_wait %{{[^,]+}} {num = 7 : i32}
+  tt.func public @single_token_two_crossed(%arg0: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg1: tensor<128x16x!tt.ptr<f16>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>}) {
+    %0 = ttg.async_copy_global_to_local %arg1, %arg0 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group tokens %0
+    %2 = ttg.async_copy_global_to_local %arg1, %arg0 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %3 = ttg.async_commit_group tokens %2
+    %4 = ttg.async_copy_global_to_local %arg1, %arg0 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %5 = ttg.async_commit_group tokens %4
+    %6 = ttg.async_wait %1 {num = 7 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: tokenless_wait_preserved
+  // Tokenless wait carries a producer-authored num that derivation cannot
+  // recover from a def chain - num=3 stays put.
+  // CHECK: ttg.async_wait {num = 3 : i32}
+  tt.func public @tokenless_wait_preserved(%arg0: !ttg.memdesc<128x16xf16, #shared, #smem, mutable>, %arg1: tensor<128x16x!tt.ptr<f16>, #blocked> {tt.divisibility = dense<[16, 16]> : tensor<2xi32>, tt.contiguity = dense<[16, 16]> : tensor<2xi32>}) {
+    %0 = ttg.async_copy_global_to_local %arg1, %arg0 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
+    %1 = ttg.async_commit_group tokens %0
+    ttg.async_wait {num = 3 : i32}
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -865,12 +865,14 @@ Pingponger::transformTwoClusterWithLocalLoadAndAll(OpBuilder &builder,
   auto newAsyncWaitOp = asyncWaitOps[0];
   if (asyncWaitOps.size() > 1) {
     SmallVector<Value> tokens;
+    int32_t minNum = std::numeric_limits<int32_t>::max();
     for (auto asyncWaitOp : asyncWaitOps) {
       for (auto token : asyncWaitOp.getAsyncToken()) {
         tokens.push_back(token);
       }
+      minNum = std::min<int32_t>(minNum, asyncWaitOp.getNum());
     }
-    newAsyncWaitOp = ttg::AsyncWaitOp::create(builder, loc, tokens, 0);
+    newAsyncWaitOp = ttg::AsyncWaitOp::create(builder, loc, tokens, minNum);
     for (auto asyncWaitOp : asyncWaitOps) {
       asyncWaitOp.getResult().replaceAllUsesWith(newAsyncWaitOp.getResult());
       asyncWaitOp->erase();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
@@ -1,6 +1,8 @@
-#include "TritonAMDGPUTransforms/Passes.h"
+#include "TritonAMDGPUToLLVM/TargetUtils.h"
+#include "TritonAMDGPUTransforms/Passes.h" // IWYU pragma: keep
 #include "amd/lib/TritonAMDGPUTransforms/PipelineUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
 #define DEBUG_TYPE "tritonamdgpu-pipeline-expand-loops"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -123,9 +125,23 @@ struct PipelinePass : impl::TritonAMDGPUPipelineBase<PipelinePass> {
     expandLoops(moduleOp);
 
     if (useAsyncCopy) {
-      llvm::SmallSetVector<ttg::AsyncWaitOp, 8> waitOps;
-      moduleOp.walk([&](ttg::AsyncWaitOp waitOp) { waitOps.insert(waitOp); });
-      tt::combineRedundantWaitOps(waitOps);
+      auto arch = getAMDArch(moduleOp);
+      auto family =
+          arch ? tt::AMD::deduceISAFamily(*arch) : tt::AMD::ISAFamily::Unknown;
+      // Only asyncmark targets (CDNA3/CDNA4) need updateWaits here: their
+      // lowering reads ttg.async_wait's `num` directly into wait.asyncmark(N),
+      // and PR #9883 made UpdateAsyncWaitCount a no-op on those archs, so
+      // without this call the pipeliner-authored num=0 would serialize the
+      // SWP. Every other family keeps the prior combineRedundantWaitOps-only
+      // path: their num is re-derived downstream by UpdateAsyncWaitCount.
+      if (family == tt::AMD::ISAFamily::CDNA3 ||
+          family == tt::AMD::ISAFamily::CDNA4) {
+        mlir::triton::updateWaits(moduleOp);
+      } else {
+        llvm::SmallSetVector<ttg::AsyncWaitOp, 8> waitOps;
+        moduleOp.walk([&](ttg::AsyncWaitOp waitOp) { waitOps.insert(waitOp); });
+        tt::combineRedundantWaitOps(waitOps);
+      }
     }
 
     tt::removePipeliningAttributes(moduleOp);


### PR DESCRIPTION
…rgets

PR #9883 made UpdateAsyncWaitCount a no-op for CDNA3/CDNA4. The lowering then emits wait.asyncmark with the pipeliner-authored ttg.async_wait num, which is 0 ("wait for all groups") for token-bearing waits. LLVM honors that as s_waitcnt vmcnt(0), serializing the software pipeline. On a 4096^3 a16w16 gemm (MI350X) that costs ~33% (888 -> 588 TFLOPS).

Restore the analysis on asyncmark targets by walking each token's def-use chain (across loop iter args / yield, taking the minimum across paths) and counting ttg.async_commit_group ops crossed - that count is the correct N for wait.asyncmark, since each commit group lowers to one rocdl.asyncmark. Tokenless waits already carry a pipeliner-authored commit-group count and are left unchanged.

The pass is restructured around a single loop parameterized by a (countFn, replaceFn) pair. Asyncmark targets pass (countCommitGroup, setNum); other targets pass (countAsyncLoadInstructions, replace with amdg.async_wait) - same shape, different lambdas. The two op-replacement lambdas share a templated helper to dedup the
getAsyncToken/getNum/replaceOpWithNewOp/setAttr boilerplate. ModuleAxisInfoAnalysis is now lazy via std::optional and only constructed on the non-asyncmark branch where it is actually used.

Adds amd-update-async-wait-count-asyncmark.mlir with cases for single-token, multi-token min, tokenless-unchanged, and loop-carried tokens.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
