### PR TITLE
[Frontend] Promote `_aggregate` to public

### DIFF
--- a/python/examples/gluon/01-attention-forward.py
+++ b/python/examples/gluon/01-attention-forward.py
@@ -5,8 +5,6 @@ import triton
 import pytest
 import itertools
 
-from triton.language.core import _aggregate as aggregate
-
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
@@ -42,7 +40,7 @@ def get_mma_instr_shape(shape, element_ty):
 # ===-----------------------------------------------------------------------===#
 
 
-@aggregate
+@gluon.aggregate
 class BarrierCounter:
     index: gl.tensor
     phase: gl.tensor
@@ -62,7 +60,7 @@ class BarrierCounter:
 
 def Channel(T, alloc_fn):
 
-    @aggregate
+    @gluon.aggregate
     class ChannelType:
         mem: T
         ready_bars: gl.shared_memory_descriptor
@@ -122,7 +120,7 @@ def Channel(T, alloc_fn):
                 mbarrier.invalidate(self.ready_bars.index(i))
                 mbarrier.invalidate(self.empty_bars.index(i))
 
-    @aggregate
+    @gluon.aggregate
     class Producer:
         channel: ChannelType
         counter: BarrierCounter
@@ -133,7 +131,7 @@ def Channel(T, alloc_fn):
             next = Producer(self.channel, self.counter.increment())
             return mem, ready_bar, next
 
-    @aggregate
+    @gluon.aggregate
     class Consumer:
         channel: ChannelType
         counter: BarrierCounter
@@ -171,7 +169,7 @@ def issue_async_tma_load(smem, bar, desc, offset):
 # ===-----------------------------------------------------------------------===#
 
 
-@aggregate
+@gluon.aggregate
 class AttentionConfig:
     qk_scale: gl.tensor
     Z: gl.tensor
@@ -279,7 +277,7 @@ class AttentionConfig:
         return AttentionProgram(self, start_m, off_hz, offset_y, qo_offset_y)
 
 
-@aggregate
+@gluon.aggregate
 class ProgramScheduler:
     config: AttentionConfig
     start_pid: gl.tensor
@@ -306,7 +304,7 @@ class ProgramScheduler:
         return self.config.get_program(pid_m, pid_n)
 
 
-@aggregate
+@gluon.aggregate
 class AttentionProgram:
     config: AttentionConfig
     start_m: gl.tensor

--- a/python/examples/gluon/02-conv-common.py
+++ b/python/examples/gluon/02-conv-common.py
@@ -2,8 +2,6 @@ import torch
 
 import triton
 
-from triton.language.core import _aggregate as aggregate
-
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 from triton.experimental.gluon.language.nvidia.hopper import mbarrier
@@ -73,7 +71,7 @@ def ensure_tma_compatible_strides(tensor, alignment_bytes=16):
     return tensor
 
 
-@aggregate
+@gluon.aggregate
 class Counter:
     index: gl.tensor
     phase: gl.tensor
@@ -93,7 +91,7 @@ class Counter:
         return Counter(index, phase, self.num_barriers)
 
 
-@aggregate
+@gluon.aggregate
 class PersistentTileScheduler:
     pid_start: gl.tensor
     pid_end: gl.tensor

--- a/python/examples/gluon/02-conv-dgrad.py
+++ b/python/examples/gluon/02-conv-dgrad.py
@@ -8,8 +8,6 @@ import torch
 import triton
 import triton.language as tl
 
-from triton.language.core import _aggregate as aggregate
-
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor, TensorDescriptorIm2Col
@@ -83,7 +81,7 @@ normalize_2d = _conv_common.normalize_2d
 # uses a persistent scheduler and runs only `min(num_sms, logical_tiles)` CTAs.
 
 
-@aggregate
+@gluon.aggregate
 class DgradConfig:
     N: gl.tensor
     Co: gl.tensor
@@ -164,7 +162,7 @@ class DgradConfig:
         return DgradProgram(self, pid_m, pid_n, split_k_idx, k_start, k_iters_this_split)
 
 
-@aggregate
+@gluon.aggregate
 class DgradProgram:
     config: DgradConfig
     pid_m: gl.tensor
@@ -205,7 +203,7 @@ class DgradProgram:
         return iter_co, iter_r, iter_s, k_offset
 
 
-@aggregate
+@gluon.aggregate
 class PartitionArgs:
     config: DgradConfig
     grad_y_desc: tma.tensor_descriptor_im2col

--- a/python/examples/gluon/02-conv-fprop.py
+++ b/python/examples/gluon/02-conv-fprop.py
@@ -8,8 +8,6 @@ import torch
 import triton
 import triton.language as tl
 
-from triton.language.core import _aggregate as aggregate
-
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor, TensorDescriptorIm2Col
@@ -74,7 +72,7 @@ normalize_2d = _conv_common.normalize_2d
 #   K_GEMM = R * S * Ci          (reduction over filter x input channels)
 
 
-@aggregate
+@gluon.aggregate
 class ConvConfig:
     N: gl.tensor
     H: gl.tensor
@@ -127,7 +125,7 @@ class ConvConfig:
         return self.R * self.S * gl.cdiv(self.Ci, self.BLOCK_K)
 
 
-@aggregate
+@gluon.aggregate
 class ConvProgram:
     config: ConvConfig
     pid_m: gl.tensor
@@ -149,7 +147,7 @@ class ConvProgram:
 # ===-----------------------------------------------------------------------===#
 
 
-@aggregate
+@gluon.aggregate
 class PartitionArgs:
     config: ConvConfig
     in_desc: tma.tensor_descriptor_im2col

--- a/python/examples/gluon/02-conv-wgrad.py
+++ b/python/examples/gluon/02-conv-wgrad.py
@@ -8,8 +8,6 @@ import torch
 import triton
 import triton.language as tl
 
-from triton.language.core import _aggregate as aggregate
-
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor, TensorDescriptorIm2Col
@@ -86,7 +84,7 @@ normalize_2d = _conv_common.normalize_2d
 # ===-----------------------------------------------------------------------===#
 
 
-@aggregate
+@gluon.aggregate
 class WgradConfig:
     N: gl.tensor
     Ci: gl.tensor
@@ -159,7 +157,7 @@ class WgradConfig:
         return WgradProgram(self, pid_co, ci_block, iter_r, iter_s, split_k_idx, k_start, k_iters_this_split)
 
 
-@aggregate
+@gluon.aggregate
 class WgradProgram:
     config: WgradConfig
     pid_co: gl.tensor
@@ -198,7 +196,7 @@ class WgradProgram:
 # ===-----------------------------------------------------------------------===#
 
 
-@aggregate
+@gluon.aggregate
 class PartitionArgs:
     config: WgradConfig
     in_desc: tma.tensor_descriptor_im2col

--- a/python/examples/gluon/03-matmul-multicta.py
+++ b/python/examples/gluon/03-matmul-multicta.py
@@ -17,7 +17,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
 )
 from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
-from triton.language.core import _aggregate as aggregate
 
 
 def is_blackwell():
@@ -168,7 +167,7 @@ def _planar_snake(lin_idx, m_tiles, n_tiles, minor_dim: gl.constexpr, tile_width
     return major, minor
 
 
-@aggregate
+@gluon.aggregate
 class Counter:
     index: gl.tensor
     phase: gl.tensor
@@ -188,7 +187,7 @@ class Counter:
         return Counter(index, phase, self.num_barriers)
 
 
-@aggregate
+@gluon.aggregate
 class ClcTileSchedulerConsumer:
     has_work: gl.tensor
     tile_id: gl.tensor
@@ -290,7 +289,7 @@ class ClcTileSchedulerConsumer:
         )
 
 
-@aggregate
+@gluon.aggregate
 class PartitionArgs:
     a_desc: tma.tensor_descriptor
     b_desc: tma.tensor_descriptor

--- a/python/examples/gluon/04-2cta-block-scale-matmul.py
+++ b/python/examples/gluon/04-2cta-block-scale-matmul.py
@@ -17,7 +17,6 @@ import triton
 import triton.experimental.gluon as gluon
 import triton.experimental.gluon.language as gl
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
-from triton.language.core import _aggregate as aggregate
 
 from triton._C.libtriton import nvidia
 
@@ -316,7 +315,7 @@ def issue_mma(consumer, c_bars, a_bufs, b_bufs, a_scale_bufs, b_scale_bufs, prod
     return consumer.next(pred), producer.next(pred)
 
 
-@aggregate
+@gluon.aggregate
 class Counter:
     index: gl.tensor
     phase: gl.tensor
@@ -336,7 +335,7 @@ class Counter:
         return Counter(index, phase, self.num_barriers)
 
 
-@aggregate
+@gluon.aggregate
 class ClcTileSchedulerConsumer:
     has_work: gl.tensor
     tile_id: gl.tensor
@@ -443,7 +442,7 @@ class ClcTileSchedulerConsumer:
 # ---------------------------------------------------------------------------
 
 
-@aggregate
+@gluon.aggregate
 class PartitionArgs:
     a_desc: tma.tensor_descriptor
     b_desc: tma.tensor_descriptor

--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -11,7 +11,6 @@ import triton.experimental.gluon.language.nvidia.blackwell.tma as tma
 from triton.experimental.gluon.language.nvidia.blackwell import float2
 import triton.experimental.gluon.language.nvidia.hopper.mbarrier as mbarrier
 import triton.language.extra.libdevice as libdevice
-from triton.language.core import _aggregate as aggregate
 from triton.testing import do_bench_cudagraph
 
 from triton_kernels.distributed import make_expt_dict_uniform
@@ -183,7 +182,7 @@ def split_m_subtiles(values, subtile_factor: gl.constexpr):
     return subtiles
 
 
-@aggregate
+@gluon.aggregate
 class PartitionArgs:
     x_desc: tma.tensor_descriptor
     w_desc: tma.tensor_descriptor

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -441,7 +441,7 @@ def warp_specialize_worker1(a, b, e: ttgl.constexpr):
     pass
 
 
-@tl.core._aggregate
+@gluon.aggregate
 class Pair:
     first: tl.tensor
     second: tl.tensor

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -475,7 +475,7 @@ def test_unused_result():
     assert expected_err_msg == obtained_err_msg
 
 
-@tl.core._aggregate
+@triton.aggregate
 class Square:
     x: tl.tensor
 

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -26,7 +26,7 @@ def anchor(v):
     pass
 
 
-@tl.core._aggregate
+@triton.aggregate
 class Pair:
     first: tl.tensor
     second: tl.tensor
@@ -115,7 +115,7 @@ def test_jit_method():
     anchor(b)
 
 
-@tl.core._aggregate
+@triton.aggregate
 class TypeWithJitGetItem:
     value: tl.tensor
 
@@ -138,7 +138,7 @@ def test_jit_getitem():
     # CHECK: tt.return [[ARG0]]
 
 
-@tl.core._aggregate
+@triton.aggregate
 class TypeWithBuiltinInitializer:
     value: tl.tensor
 
@@ -158,7 +158,7 @@ def test_aggregate_initializers():
 
 def test_aggregate_auto_init_assigns_members():
 
-    @tl.core._aggregate
+    @triton.aggregate
     class State:
         x: tl.constexpr
         y: tl.constexpr
@@ -176,7 +176,7 @@ def test_aggregate_auto_init_with_tuples():
         x: tl.constexpr
         y: tl.constexpr
 
-    @tl.core._aggregate
+    @triton.aggregate
     class State:
         shape: tl.tuple
         strides: tl.tuple
@@ -197,7 +197,7 @@ def test_aggregate_auto_init_with_tuples():
 
 def test_aggregate_auto_init_respects_user_defined_init():
 
-    @tl.core._aggregate
+    @triton.aggregate
     class State:
         x: tl.constexpr
 
@@ -262,7 +262,7 @@ def test_call_in_loop():
         acc = accumulate(acc, i)
 
 
-@tl.core._aggregate
+@triton.aggregate
 class FunctionParent:
 
     @triton.jit
@@ -285,7 +285,7 @@ def test_function_name_mangling():
     FunctionParent.function_with_name()
 
 
-@tl.core._aggregate
+@triton.aggregate
 class AggregateWithConstexpr:
     a: tl.tensor
     b: tl.constexpr
@@ -318,7 +318,7 @@ def test_aggregate_with_constexpr():
     # CHECK: arith.addi %arg0, %cst : tensor<4xi32>
 
 
-@tl.core._aggregate
+@triton.aggregate
 class AggregateWithTuple:
     a: tl.tuple
 
@@ -403,7 +403,7 @@ def test_constexpr_getitem():
 @triton.constexpr_function
 def Box(T):
 
-    @tl.core._aggregate
+    @triton.aggregate
     class BoxImpl:
         value: T
 
@@ -509,7 +509,7 @@ def test_tuple_constexpr():
     run_parser(foo, args=(test, ))
 
 
-@tl.core._aggregate
+@triton.aggregate
 class AggregateWithConstexprFunction:
     val: tl.constexpr
     val_squared: tl.constexpr

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -28,9 +28,11 @@ from . import testing
 from . import tools
 
 must_use_result = language.core.must_use_result
+aggregate = language.core._aggregate
 
 __all__ = [
     "AsyncCompileMode",
+    "aggregate",
     "autotune",
     "cdiv",
     "CompilationError",
@@ -44,7 +46,6 @@ __all__ = [
     "JITFunction",
     "KernelInterface",
     "language",
-    "max_shared_mem",
     "MockTensor",
     "must_use_result",
     "next_power_of_2",

--- a/python/triton/experimental/gluon/__init__.py
+++ b/python/triton/experimental/gluon/__init__.py
@@ -1,6 +1,6 @@
 from ._runtime import GluonJITFunction, constexpr_function, jit
-from triton.language.core import must_use_result
+from triton import must_use_result, aggregate
 from . import nvidia
 from . import amd
 
-__all__ = ["GluonJITFunction", "constexpr_function", "jit", "must_use_result", "nvidia", "amd"]
+__all__ = ["aggregate", "amd", "constexpr_function", "GluonJITFunction", "jit", "must_use_result", "nvidia"]

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -14,9 +14,9 @@ from ._layouts import (SharedLayout, DistributedLayout, BlockedLayout, DotOperan
 from triton._C.libtriton import ir
 import triton.language.core as tl_core
 from triton.language.core import (
-    constexpr,
     base_value,
     base_type,
+    constexpr,
     dtype,
     block_type,  # TODO: block type with layout info
     pointer_type,

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/float2.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/float2.py
@@ -1,4 +1,4 @@
-from triton.language.core import _aggregate as aggregate
+from triton.experimental.gluon import aggregate
 from triton.experimental.gluon.language import _core as ttgl, _standard as stdlib
 from triton.experimental.gluon._runtime import constexpr_function, jit
 

--- a/python/tutorials/gluon/07-persistence.py
+++ b/python/tutorials/gluon/07-persistence.py
@@ -33,7 +33,6 @@ from functools import partial
 from typing import Union
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
-from triton.language.core import _aggregate as aggregate
 
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.experimental.gluon.language.nvidia.hopper import (
@@ -85,13 +84,13 @@ def get_flops(ms, M, N, K):
 # of tensor core operations so that our persistent matmul can be used on both
 # Hopper and Blackwell.
 #
-# We can use @aggregate to define a class that contains the state of the
+# We can use @gluon.aggregate to define a class that contains the state of the
 # matmul. We will define the API of our MMA wrapper to be like WGMMA's, because
 # is the more restrictive of the two.
 
 
 # MMA wrapper for WGMMA, which maps directly to the WGMMA functions.
-@aggregate
+@gluon.aggregate
 class WGMMA:
     acc: Union[warpgroup_mma_accumulator, gl.tensor]
     use_acc: gl.tensor
@@ -123,7 +122,7 @@ class WGMMA:
 # MMA wrapper for tcgen05. In order to implement `wait_num_outstanding`, we
 # need to allocate barriers and keep track of how many MMAs have been issued.
 # State will be tracked with an accumulator.
-@aggregate
+@gluon.aggregate
 class MMAv5:
     use_acc: gl.tensor
     acc_tmem: tensor_memory_descriptor
@@ -322,7 +321,7 @@ if __name__ == "__main__" and not profiling_with_ncu:
 # scheduling strategy, starting with a basic row-major tile scheduler.
 
 
-@aggregate
+@gluon.aggregate
 class PersistentTileScheduler:
     pid_start: gl.tensor
     pid_end: gl.tensor
@@ -497,7 +496,7 @@ def GroupedPersistentTileScheduler(GROUP_SIZE_M):
     GROUP_SIZE_M = gl.constexpr(GROUP_SIZE_M)
 
     # Like C++ templates!
-    @aggregate
+    @gluon.aggregate
     class GroupedPersistentTileSchedulerImpl:
         start_pid: gl.tensor
         num_pid_m: gl.tensor

--- a/python/tutorials/gluon/08-warp-specialization.py
+++ b/python/tutorials/gluon/08-warp-specialization.py
@@ -28,7 +28,6 @@ from functools import partial
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 
-from triton.language.core import _aggregate as aggregate
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier, fence_async_shared
 from triton.experimental.gluon.language.nvidia.blackwell import (
@@ -385,7 +384,7 @@ if __name__ == "__main__":
 
 
 # Helper class for passing arguments around partitions.
-@aggregate
+@gluon.aggregate
 class PartitionArgs:
     a_desc: tma.tensor_descriptor
     b_desc: tma.tensor_descriptor
@@ -402,7 +401,7 @@ class PartitionArgs:
 
 
 # Counter abstraction for tracking barrier index and phase.
-@aggregate
+@gluon.aggregate
 class Counter:
     index: gl.tensor
     phase: gl.tensor

--- a/python/tutorials/gluon/10-tcgen05-copy.py
+++ b/python/tutorials/gluon/10-tcgen05-copy.py
@@ -82,7 +82,6 @@ import triton
 import torch
 import triton.experimental.gluon as gluon
 import triton.experimental.gluon.language as gl
-from triton.language.core import _aggregate as aggregate
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
@@ -217,7 +216,7 @@ def test_tcgen05_copy_nvmma_shared(M, N, TMEM_BLOCK_N, dtype, swizzle):
 # TMA for the epilogue store also reduces contention for the TMA pipe.
 
 
-@aggregate
+@gluon.aggregate
 class PartitionArgs:
     a_desc: tma.tensor_descriptor
     b_desc: tma.tensor_descriptor

--- a/python/tutorials/gluon/11-tcgen05-mma-scaled.py
+++ b/python/tutorials/gluon/11-tcgen05-mma-scaled.py
@@ -68,7 +68,6 @@ import triton.experimental.gluon as gluon
 import triton.experimental.gluon.language as gl
 from dataclasses import replace
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
-from triton.language.core import _aggregate as aggregate
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
@@ -1334,7 +1333,7 @@ def mma_scaled_pipelined_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale_de
 # wrote simplify writing the warp-specialized code.
 
 
-@aggregate
+@gluon.aggregate
 class PartitionArgs:
     a_desc: tma.tensor_descriptor
     b_desc: tma.tensor_descriptor

--- a/python/tutorials/gluon/12-cluster-launch-control.py
+++ b/python/tutorials/gluon/12-cluster-launch-control.py
@@ -33,7 +33,6 @@ from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 from triton.experimental.gluon.nvidia.blackwell import TensorDescriptor
 from triton.experimental.gluon.language.nvidia.blackwell import tma, mbarrier, fence_async_shared, clc
-from triton.language.core import _aggregate as aggregate
 
 
 def is_blackwell():
@@ -56,7 +55,7 @@ t7 = importlib.import_module("07-persistence")
 # changed ClcTileScheduler interface to support dynamic scheduling.
 
 
-@aggregate
+@gluon.aggregate
 class ClcTileScheduler:
     has_work: gl.tensor
     tile_id: gl.tensor
@@ -94,7 +93,7 @@ class ClcTileScheduler:
 # so we can directly compare the benifits of dynamic scheduling.
 
 
-@aggregate
+@gluon.aggregate
 class StaticTileScheduler:
     has_work: gl.tensor
     tile_id: gl.tensor

--- a/python/tutorials/gluon/14-multicta.py
+++ b/python/tutorials/gluon/14-multicta.py
@@ -81,7 +81,6 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
 )
 from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
-from triton.language.core import _aggregate as aggregate
 
 # Re-use baseline tutorials for comparisons.
 t8 = importlib.import_module("08-warp-specialization")
@@ -680,7 +679,7 @@ def _planar_snake(lin_idx, m_tiles, n_tiles, minor_dim: gl.constexpr, tile_width
     return major, minor
 
 
-@aggregate
+@gluon.aggregate
 class ClcTileSchedulerConsumer:
     has_work: gl.tensor
     tile_id: gl.tensor
@@ -776,7 +775,7 @@ class ClcTileSchedulerConsumer:
         )
 
 
-@aggregate
+@gluon.aggregate
 class MatmulPartitionArgs:
     a_desc: tma.tensor_descriptor
     b_desc: tma.tensor_descriptor

--- a/third_party/amd/python/examples/gluon/f16_fa_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_fa_gfx1250.py
@@ -5,7 +5,6 @@ This file implements a BSHD Flash Attention and tests against torch reference.
 import torch
 from triton.experimental import gluon
 import triton.experimental.gluon.language as gl
-from triton.language.core import _aggregate as aggregate
 import pytest
 
 
@@ -29,7 +28,7 @@ except ImportError:
     from gfx1250_utils import static_profile
 
 
-@aggregate
+@gluon.aggregate
 class AttentionConfig:
     SEQLEN_Q: gl.constexpr
     SEQLEN_K: gl.constexpr
@@ -84,7 +83,7 @@ class AttentionConfig:
         self.p_layout = gl.constexpr(gl.DotOperandLayout(0, self.pv_layout, 8))
 
 
-@aggregate
+@gluon.aggregate
 class AttentionProgram:
     cfg: AttentionConfig
 

--- a/third_party/amd/python/examples/gluon/f16_gemm_common_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_gemm_common_gfx1250.py
@@ -7,7 +7,6 @@ persistent and StreamK GEMM implementations.
 """
 
 from triton.experimental import gluon
-from triton.language.core import _aggregate as aggregate
 import triton.experimental.gluon.language as ttgl
 
 
@@ -267,7 +266,7 @@ def apply_activation_epilogue(acc, ACTIVATION: ttgl.constexpr, ACC_LAYOUT: ttgl.
     return result
 
 
-@aggregate
+@gluon.aggregate
 class TileScheduler:
     """
     Tile Scheduler

--- a/third_party/amd/python/examples/gluon/f16_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_gemm_gfx1250.py
@@ -4,7 +4,6 @@ import torch
 import triton
 import math
 from triton.experimental import gluon
-from triton.language.core import _aggregate as aggregate
 import triton.experimental.gluon.language as ttgl
 from triton._C.libtriton.gluon_ir import make_cga_layout
 
@@ -633,7 +632,7 @@ def test_runtime_gemm_tdm_pipelined_single_warp_per_simd_schedule(BLOCK_M, BLOCK
 
 
 # Helper class for passing arguments around partitions.
-@aggregate
+@gluon.aggregate
 class PartitionArgs:
     a_desc: ttgl.amd.gfx1250.tdm.tensor_descriptor
     b_desc: ttgl.amd.gfx1250.tdm.tensor_descriptor
@@ -664,7 +663,7 @@ class PartitionArgs:
 
 
 # Helper class for passing arguments around persistent warp-specialization partitions.
-@aggregate
+@gluon.aggregate
 class PersistentPartitionArgs:
     a_desc: ttgl.amd.gfx1250.tdm.tensor_descriptor
     b_desc: ttgl.amd.gfx1250.tdm.tensor_descriptor
@@ -706,7 +705,7 @@ class PersistentPartitionArgs:
 
 
 # Helper class for passing arguments around persistent warp-specialization partitions (subtiled variant).
-@aggregate
+@gluon.aggregate
 class PersistentPartitionSubtiledArgs:
     a_desc: ttgl.amd.gfx1250.tdm.tensor_descriptor
     b_desc: ttgl.amd.gfx1250.tdm.tensor_descriptor
@@ -757,7 +756,7 @@ class PersistentPartitionSubtiledArgs:
         self.QUADRANT_N = ttgl.constexpr(QUADRANT_N)
 
 
-@aggregate
+@gluon.aggregate
 class PhaseCounter:
     """Tracks iteration count and computes phase."""
     iteration: ttgl.tensor

--- a/third_party/amd/python/examples/gluon/mxfp_fa_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/mxfp_fa_gfx1250.py
@@ -12,7 +12,6 @@ import torch
 import math
 
 from triton import cdiv
-from triton.language.core import _aggregate as aggregate
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from triton.experimental import gluon
 import triton.experimental.gluon.language as ttgl
@@ -110,7 +109,7 @@ def get_wmma_layout(shape, num_warps, packed=False, preshuffled=False, warp_axis
     return ttgl.amd.AMDWMMALayout(3, True, warp_bases, reg_bases, instr_shape, rank=rank)
 
 
-@aggregate
+@gluon.aggregate
 class MemoryBlock:
     """
     MemoryBlock groups variables to describe a block of 2D/3D tensor in global memory.
@@ -155,7 +154,7 @@ class MemoryBlock:
         return MemoryBlock(base, offs, mask, block_shape)
 
 
-@aggregate
+@gluon.aggregate
 class MemoryUnit:
     """
     MemoryUnit wraps a global-memory tensor descriptor and its corresponding shared-memory slots.
@@ -192,7 +191,7 @@ class MemoryUnit:
         return MemoryUnit(smem, desc)
 
 
-@aggregate
+@gluon.aggregate
 class KVMemory:
     k_mem: MemoryUnit
     v_mem: MemoryUnit
@@ -355,7 +354,7 @@ class KVMemory:
         return buffer
 
 
-@aggregate
+@gluon.aggregate
 class KVScaleMemory:
     k_mem: MemoryUnit
     v_mem: MemoryUnit
@@ -510,7 +509,7 @@ class KVScaleMemory:
         return buffer
 
 
-@aggregate
+@gluon.aggregate
 class AttentionConfigBase:
     Q_TYPE: ttgl.constexpr  # the data type for Q, either 'e5m2' or 'e4m3'
     P_TYPE: ttgl.constexpr  # the data type for P; we always assume P_TYPE == Q_TYPE
@@ -552,7 +551,7 @@ class AttentionConfigBase:
 
 
 @composition
-@aggregate
+@gluon.aggregate
 class GlobalScaledAttentionConfig:
     base: AttentionConfigBase
 
@@ -616,7 +615,7 @@ class GlobalScaledAttentionConfig:
         self.CONVERT_LAYOUT_TRIVIAL = ttgl.constexpr(True if P_K_WIDTH == 8 else False)
 
 
-@aggregate
+@gluon.aggregate
 class GlobalScaledAttentionProgram:
     cfg: GlobalScaledAttentionConfig
 
@@ -1407,7 +1406,7 @@ class GlobalScaledAttentionProgram:
 
 
 @composition
-@aggregate
+@gluon.aggregate
 class BlockScaledAttentionConfig:
     base: AttentionConfigBase
 
@@ -1496,7 +1495,7 @@ class BlockScaledAttentionConfig:
         self.P_SCALING = ttgl.constexpr(P_SCALING)
 
 
-@aggregate
+@gluon.aggregate
 class BlockScaledAttentionProgram:
     cfg: BlockScaledAttentionConfig
 

--- a/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
@@ -5,7 +5,6 @@ from triton.experimental import gluon
 import triton.experimental.gluon.language as gl
 from triton.experimental.gluon.language.amd.gfx1250 import tdm
 from triton.experimental.gluon.language.amd.gfx1250 import async_copy as cp
-from triton.language.core import _aggregate as aggregate
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 
 # Handle imports for both pytest (module context) and direct execution
@@ -41,7 +40,7 @@ def get_wmma_layout(num_warps, packed, scale_preshuffle):
     return gl.amd.AMDWMMALayout(3, True, warp_bases, reg_bases, instr_shape)
 
 
-@aggregate
+@gluon.aggregate
 class MXFPGEMMConfig:
     BLOCK_M: gl.constexpr
     BLOCK_N: gl.constexpr
@@ -153,7 +152,7 @@ class MXFPGEMMConfig:
                                                     [self.BLOCK_N_PRESHUFFLED, self.BLOCK_K_SCALE_PRESHUFFLED], [1, 0]))
 
 
-@aggregate
+@gluon.aggregate
 class ScaleAsyncCopyDescriptor:
     cfg: MXFPGEMMConfig
     op_idx: gl.constexpr
@@ -203,7 +202,7 @@ class ScaleAsyncCopyDescriptor:
             cp.commit_group()
 
 
-@aggregate
+@gluon.aggregate
 class MXFPGEMMProgramBase:
 
     @gluon.constexpr_function
@@ -279,7 +278,7 @@ class MXFPGEMMProgramBase:
 
 
 @composition
-@aggregate
+@gluon.aggregate
 class MXFPGEMMPipelinedProgram:
     base: MXFPGEMMProgramBase
 
@@ -412,7 +411,7 @@ class MXFPGEMMPipelinedProgram:
 
 
 @composition
-@aggregate
+@gluon.aggregate
 class MXFPGEMMSliceKProgram:
     base: MXFPGEMMProgramBase
 
@@ -637,7 +636,7 @@ class MXFPGEMMSliceKProgram:
         gl.amd.gfx1250.buffer_store(accumulator, self.c_ptr, self.c_offs, mask=self.c_mask)
 
 
-@aggregate
+@gluon.aggregate
 class MXFPGEMMSliceNKProgram:
     cfg: MXFPGEMMConfig
     a_buffer: gl.shared_memory_descriptor


### PR DESCRIPTION
Instead of the previous private name `triton.language.core._aggregate`, aggregates are now publicly available as `triton.aggregate` and `gluon.aggregate`.

The old spelling is also retained for backward compatibility.