### PR TITLE
Silence optional error in matchAndRewrite type inference failure.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -159,7 +159,7 @@ public:
     // `allocType` after a reshape.
     MemDescType innerTy;
     if (failed(MemDescReshapeOp::inferReturnTypes(
-            getContext(), allocOp.getLoc(), allocType, srcShape, innerTy)))
+            getContext(), /*loc=*/std::nullopt, allocType, srcShape, innerTy)))
       return failure();
 
     // For now don't apply the transformation if the new encoding is not an

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -1,4 +1,5 @@
-// RUN: triton-opt %s -split-input-file -tritongpu-optimize-dot-operands -canonicalize | FileCheck %s
+// RUN: triton-opt %s -split-input-file -tritongpu-optimize-dot-operands -canonicalize -verify-diagnostics | FileCheck %s
+
 
 
 #blockedA = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -291,5 +292,21 @@ module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num
     %a = ttg.local_alloc %r : (tensor<64x64xf32, #blocked1>) -> !ttg.memdesc<64x64xf32, #shared, #smem>
     // CHECK: tt.return
     tt.return %a: !ttg.memdesc<64x64xf32, #shared, #smem>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [8, 2, 2], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @reshape_memdesc_infer_failure_does_not_emit_diagnostic
+  tt.func @reshape_memdesc_infer_failure_does_not_emit_diagnostic(%arg: tensor<64x4x2xf32, #blocked>) -> !ttg.memdesc<64x8xf32, #shared, #smem> {
+    %r = tt.reshape %arg : tensor<64x4x2xf32, #blocked> -> tensor<64x8xf32, #blocked1>
+    %a = ttg.local_alloc %r : (tensor<64x8xf32, #blocked1>) -> !ttg.memdesc<64x8xf32, #shared, #smem>
+    // CHECK: tt.return
+    tt.return %a: !ttg.memdesc<64x8xf32, #shared, #smem>
   }
 }


### PR DESCRIPTION
Without this change, errors are emitted (and logged) when type inference fails and `emitOptionalError` is called.

When loc is not provided, `emitOptionalError` only returns failure. Failures to match are not real failures, and do not need to be reported.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because it is only fixing logging.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)