### PR TITLE
[AMD][BACKEND] Clamp padInterval based on TDM limits in composePaddedLayout

### DIFF
--- a/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
+++ b/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
@@ -154,6 +154,34 @@ tt.func public @descriptor_load_dot_operand(%arg0: !tt.ptr<f16> {tt.divisibility
 }
 
 // -----
+// Test that we clamp the pad interval to the hardware maximum (1024 bytes -> 512 bf16 elements)
+#blocked_large_k   = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked1_large_k  = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#mma_large_k = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[1, 0], [2, 0], [4, 0]]}, instrShape = [16, 16, 32]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$PADDED_A:.*]] = #ttg.padded_shared<[512:+8] {
+// CHECK-DAG: #[[$PADDED_B:.*]] = #ttg.padded_shared<[128:+16] {
+// CHECK-NOT: #ttg.padded_shared<[1024:+
+// CHECK-LABEL: @descriptor_load_dot_operand_large_k
+tt.func public @descriptor_load_dot_operand_large_k(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i64, %arg5: i64) {
+  // CHECK: tt.make_tensor_descriptor {{.*}} : <f16>, <tensor<512x1024xf16, #[[$PADDED_A]]>>
+  // CHECK: tt.make_tensor_descriptor {{.*}} : <f16>, <tensor<1024x64xf16, #[[$PADDED_B]]>>
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %cst = arith.constant dense<0.000000e+00> : tensor<512x64xf32, #mma_large_k>
+  %0 = tt.make_tensor_descriptor %arg0, [%arg2, %arg3], [%arg4, %c1_i64] : <f16>, <tensor<512x1024xf16>>
+  %1 = tt.make_tensor_descriptor %arg1, [%arg3, %arg2], [%arg5, %c1_i64] : <f16>, <tensor<1024x64xf16>>
+  %2 = tt.descriptor_load %0[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<512x1024xf16>> -> tensor<512x1024xf16, #blocked_large_k>
+  %3 = tt.descriptor_load %1[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<1024x64xf16>> -> tensor<1024x64xf16, #blocked1_large_k>
+  %4 = ttg.convert_layout %2 : tensor<512x1024xf16, #blocked_large_k> -> tensor<512x1024xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_large_k, kWidth = 8}>>
+  %5 = ttg.convert_layout %3 : tensor<1024x64xf16, #blocked1_large_k> -> tensor<1024x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_large_k, kWidth = 8}>>
+  %6 = tt.dot %4, %5, %cst : tensor<512x1024xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_large_k, kWidth = 8}>> * tensor<1024x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_large_k, kWidth = 8}>> -> tensor<512x64xf32, #mma_large_k>
+  tt.return
+}
+}
+
+// -----
 // Test propagation of descriptor encoding through for and if (load in both then and else)
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.padded_shared<[32:+2] { order = [1, 0], shape = [64, 32] }>

--- a/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
+++ b/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
@@ -165,15 +165,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK-NOT: #ttg.padded_shared<[1024:+
 // CHECK-LABEL: @descriptor_load_dot_operand_large_k
 tt.func public @descriptor_load_dot_operand_large_k(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i64, %arg5: i64) {
-  // CHECK: tt.make_tensor_descriptor {{.*}} : <f16>, <tensor<512x1024xf16, #[[$PADDED_A]]>>
-  // CHECK: tt.make_tensor_descriptor {{.*}} : <f16>, <tensor<1024x64xf16, #[[$PADDED_B]]>>
+  // CHECK: tt.make_tensor_descriptor {{.*}} : <f16>, <512x1024xf16, #[[$PADDED_A]]>
+  // CHECK: tt.make_tensor_descriptor {{.*}} : <f16>, <1024x64xf16, #[[$PADDED_B]]>
   %c0_i32 = arith.constant 0 : i32
   %c1_i64 = arith.constant 1 : i64
   %cst = arith.constant dense<0.000000e+00> : tensor<512x64xf32, #mma_large_k>
-  %0 = tt.make_tensor_descriptor %arg0, [%arg2, %arg3], [%arg4, %c1_i64] : <f16>, <tensor<512x1024xf16>>
-  %1 = tt.make_tensor_descriptor %arg1, [%arg3, %arg2], [%arg5, %c1_i64] : <f16>, <tensor<1024x64xf16>>
-  %2 = tt.descriptor_load %0[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<512x1024xf16>> -> tensor<512x1024xf16, #blocked_large_k>
-  %3 = tt.descriptor_load %1[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<1024x64xf16>> -> tensor<1024x64xf16, #blocked1_large_k>
+  %0 = tt.make_tensor_descriptor %arg0, [%arg2, %arg3], [%arg4, %c1_i64] : <f16>, <512x1024xf16>
+  %1 = tt.make_tensor_descriptor %arg1, [%arg3, %arg2], [%arg5, %c1_i64] : <f16>, <1024x64xf16>
+  %2 = tt.descriptor_load %0[%c0_i32, %c0_i32] : !tt.tensordesc<512x1024xf16> -> tensor<512x1024xf16, #blocked_large_k>
+  %3 = tt.descriptor_load %1[%c0_i32, %c0_i32] : !tt.tensordesc<1024x64xf16> -> tensor<1024x64xf16, #blocked1_large_k>
   %4 = ttg.convert_layout %2 : tensor<512x1024xf16, #blocked_large_k> -> tensor<512x1024xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_large_k, kWidth = 8}>>
   %5 = ttg.convert_layout %3 : tensor<1024x64xf16, #blocked1_large_k> -> tensor<1024x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_large_k, kWidth = 8}>>
   %6 = tt.dot %4, %5, %cst : tensor<512x1024xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_large_k, kWidth = 8}>> * tensor<1024x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_large_k, kWidth = 8}>> -> tensor<512x64xf32, #mma_large_k>

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -325,14 +325,18 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
   SmallVector<Value> group1(8, b.i32_val(0));
   int32_t dataSize = log2(elementSizeInBytes);
   unsigned dwordSize = 32;
-  auto padIntervalInDwords = padInterval * elementBitWidth / dwordSize;
+  auto padIntervalBits = padInterval * elementBitWidth;
+  assert(padIntervalBits % dwordSize == 0 &&
+         "padInterval must be a multiple of dwordSize(32bit)");
+  auto padIntervalInDwords = padIntervalBits / dwordSize;
   auto padAmountInDwords = padAmount * elementBitWidth / dwordSize;
   group1[0] = b.or_(group1[0], b.i32_val(dataSize << 16));
   if (padIntervalInDwords > 0 && padAmountInDwords > 0) {
     assert(llvm::isPowerOf2_32(padIntervalInDwords));
-    int32_t log2PadInterval = log2(padIntervalInDwords);
+    int32_t log2PadIntervalDwords = log2(padIntervalInDwords);
+    assert(log2PadIntervalDwords <= 8 && "padInterval too large");
     group1[0] = b.or_(group1[0], b.i32_val(1 << 20));
-    group1[0] = b.or_(group1[0], b.i32_val((log2PadInterval - 1) << 22));
+    group1[0] = b.or_(group1[0], b.i32_val((log2PadIntervalDwords - 1) << 22));
     group1[0] = b.or_(group1[0], b.i32_val((padAmountInDwords - 1) << 25));
   }
   // Encode 32-bit tensor shapes

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -457,6 +457,13 @@ composePaddedLayoutWMMA(int opIdx, unsigned vecWidth,
   unsigned bankWrapInterval = ldsNumBanks * ldsBankWidthInBytes / elemBytes;
   unsigned padInterval =
       std::max(static_cast<unsigned>(innerDimLength), bankWrapInterval);
+
+  // TDM only supports a maximum pad interval of 256 * 32bit.
+  // TODO: this will produce conflicts for very large INNER_DIMS (>1024bytes),
+  // we could scale the pad amount if this becomes an issue.
+  unsigned maxPadIntervalElems = 256u * 32u / typeWidthInBit;
+  padInterval = std::min(padInterval, maxPadIntervalElems);
+
   auto *context = srcTy.getContext();
   return triton::gpu::PaddedSharedEncodingAttr::get(
       context, {{padInterval, padAmount}}, order, shape, CGALayout);


### PR DESCRIPTION
Before this PR if the padInterval was larger than 1024bytes (maximum of TDM) we would silently miscompile and truncate the padding amount during lowering.