### PR TITLE
[AMD][BACKEND] Adjust asynccnt computation for split async_stores

### DIFF
--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -13,12 +13,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Emits 1 direct to lds instruction
     %0 = ttg.async_copy_global_to_local %arg3, %arg1 : tensor<128x16x!tt.ptr<f16>, #blocked> -> <128x16xf16, #shared, #smem, mutable>
     %1 = ttg.async_commit_group tokens %0
-    // Emits 2 direct to lds instructions
+    // Emits 4 direct to lds instructions (padding interval limits vec to 4)
     %2 = ttg.async_copy_global_to_local %arg4, %arg2 : tensor<16x256x!tt.ptr<f16>, #blocked1> -> <16x256xf16, #shared1, #smem, mutable>
     %3 = ttg.async_commit_group tokens %2
 
     // Wait on token %1: 2 instructions outstanding (second async_copy emits 2)
-    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 4
     %9 = ttg.async_wait %1 {num = 0 : i32}
     // Wait on token %3: 0 instructions outstanding
     // CHECK: amdg.async_wait {{.*}} {num_inst = 0
@@ -34,7 +34,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
-#shared1 = #ttg.padded_shared<[4:+4] {order = [1, 0], shape = [16, 256]}>
+#shared1 = #ttg.padded_shared<[16:+4] {order = [1, 0], shape = [16, 256]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   // CHECK-LABEL: simple_buffer_load_to_local_waitcnt
@@ -420,6 +420,34 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // No async_copies in between => waitcnt 0
     // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 0
     %w2 = amdg.async_tdm_wait %2 {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: contiguity_hint_waitcnt
+  tt.func public @contiguity_hint_waitcnt(%arg1: !ttg.memdesc<64x32xf16, #shared, #smem, mutable>, %arg2: tensor<64x32x!tt.ptr<f16>, #blocked>) {
+    // Dummy commit group to wait on both loads
+    %0 = ttg.async_commit_group
+
+    // 16 loads since vec=1 and no hints
+    %1 = ttg.async_copy_global_to_local %arg2, %arg1 : tensor<64x32x!tt.ptr<f16>, #blocked> -> <64x32xf16, #shared, #smem, mutable>
+    %2 = ttg.async_commit_group tokens %1
+
+    // Contig hint bumps contig to 8 -> 2 loads
+    %3 = ttg.async_copy_global_to_local %arg2, %arg1 {contiguity = 8 : i32} : tensor<64x32x!tt.ptr<f16>, #blocked> -> <64x32xf16, #shared, #smem, mutable>
+    %4 = ttg.async_commit_group tokens %3
+
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
+    %5 = ttg.async_wait %2 {num = 0 : i32}
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 18
+    %6 = ttg.async_wait %0 {num = 0 : i32}
+
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -453,6 +453,29 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: bf16_local_to_global_split_waitcnt
+  tt.func public @bf16_local_to_global_split_waitcnt(%arg1: !ttg.memdesc<4x32xbf16, #shared, #smem, mutable>, %arg2: tensor<4x32x!tt.ptr<bf16>, #blocked>) {
+    // Emits 2 async store intrinsics (16-bit store split into two 8-bit stores)
+    %0 = amdg.async_copy_local_to_global %arg1, %arg2 : !ttg.memdesc<4x32xbf16, #shared, #smem, mutable> -> tensor<4x32x!tt.ptr<bf16>, #blocked>
+    %1 = ttg.async_commit_group tokens %0
+    // Emits 2 async store intrinsics
+    %2 = amdg.async_copy_local_to_global %arg1, %arg2 : !ttg.memdesc<4x32xbf16, #shared, #smem, mutable> -> tensor<4x32x!tt.ptr<bf16>, #blocked>
+    %3 = ttg.async_commit_group tokens %2
+
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2
+    %9 = ttg.async_wait %1 {num = 0 : i32}
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 0
+    %10 = ttg.async_wait %3 {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
 // Test mixing async_copy_global_to_local and async_copy_local_to_global on GFX1250
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -62,13 +62,10 @@ int getNumberOfAsyncCopyInstructions(RankedTensorType globalType,
                                      ModuleAxisInfoAnalysis &axisInfo,
                                      AMD::TargetInfo targetInfo, bool isStore) {
   LinearLayout globalLayout = tt::gpu::toLinearLayout(globalType);
-  LinearLayout sharedLayout;
-  if (auto paddedEnc = dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(
-          sharedType.getEncoding())) {
-    sharedLayout = paddedEnc.getLinearComponent();
-  } else {
-    sharedLayout = triton::gpu::toLinearLayout(sharedType);
-  }
+  triton::LinearLayout sharedLayout =
+      triton::gpu::isPaddedEncoding(sharedType.getEncoding())
+          ? paddedLinearLayout(sharedType)
+          : toLinearLayout(sharedType);
   LinearLayout globalToSharedLayout =
       globalLayout.invertAndCompose(sharedLayout);
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -60,7 +60,8 @@ int getNumberOfAsyncCopyInstructions(RankedTensorType globalType,
                                      ttg::MemDescType sharedType, Value mask,
                                      int ptrContig, int contigHint,
                                      ModuleAxisInfoAnalysis &axisInfo,
-                                     AMD::TargetInfo targetInfo, bool isStore) {
+                                     const AMD::TargetInfo &targetInfo,
+                                     bool isStore) {
   LinearLayout globalLayout = tt::gpu::toLinearLayout(globalType);
   triton::LinearLayout sharedLayout =
       triton::gpu::isPaddedEncoding(sharedType.getEncoding())
@@ -78,14 +79,21 @@ int getNumberOfAsyncCopyInstructions(RankedTensorType globalType,
     return 0;
   }
 
+  // We progressively tighten the pointer contiguity to mirror the lowering of
+  // async ops, starting with the mask alignment.
   if (mask)
     ptrContig = std::min<int>(ptrContig, axisInfo.getMaskAlignment(mask));
 
-  // The contigHint can bump the contig of ptr/mask related contiguity.
+  // Ops may carry a contiguity hint that raises the contiguity beyond what
+  // the pointer and mask axis info analysis can prove.
   ptrContig = std::max<int>(ptrContig, contigHint);
+
+  // The global-to-shared layout limits the consecutive elements which can be
+  // transferred by a single async intrinsic.
   ptrContig =
       std::min(ptrContig, globalToSharedLayout.getNumConsecutiveInOut());
-  // For padded encodings restrict vec by the min interval
+
+  // For padded layouts the padding interval limits the vectorization.
   auto srcEnc = sharedType.getEncoding();
   if (auto padEnc = dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(srcEnc)) {
     ptrContig = std::min<int>(ptrContig, padEnc.getMinInterval());

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -59,7 +59,8 @@ namespace {
 int getNumberOfAsyncCopyInstructions(RankedTensorType globalType,
                                      ttg::MemDescType sharedType, Value mask,
                                      int contig,
-                                     ModuleAxisInfoAnalysis &axisInfo) {
+                                     ModuleAxisInfoAnalysis &axisInfo,
+                                     AMD::TargetInfo targetInfo, bool isStore) {
   LinearLayout globalLayout = tt::gpu::toLinearLayout(globalType);
   LinearLayout sharedLayout;
   if (auto paddedEnc = dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(
@@ -91,7 +92,20 @@ int getNumberOfAsyncCopyInstructions(RankedTensorType globalType,
   auto kReg = StringAttr::get(globalType.getContext(), "register");
   int numberOfRegisters =
       globalToSharedLayout.removeZeroBasesAlongDim(kReg).getInDimSize(kReg);
-  return std::max(1, numberOfRegisters / contig);
+  int numInstructions = std::max(1, numberOfRegisters / contig);
+
+  // On targets where a given vector width is unsupported but half of it is,
+  // the store lowering splits each async store into two half-width stores
+  if (isStore) {
+    int elemBitWidth = sharedType.getElementType().getIntOrFloatBitWidth();
+    int vecBits = contig * elemBitWidth;
+    if (!targetInfo.supportsDirectFromLdsStoreBitWidth(vecBits) &&
+        targetInfo.supportsDirectFromLdsStoreBitWidth(vecBits / 2)) {
+      numInstructions *= 2;
+    }
+  }
+
+  return numInstructions;
 }
 
 // Return the number of generated intrinsics for async ops; 0 otherwise
@@ -103,9 +117,9 @@ int getOpNumberOfAsyncCopyInstructions(Operation *op,
                                        bool emitRemarkOnNonAsyncOp) {
   if (auto copyOp = dyn_cast<ttg::AsyncCopyGlobalToLocalOp>(op)) {
     int contig = LLVM::AMD::getVectorSize(copyOp.getSrc(), axisInfo);
-    return getNumberOfAsyncCopyInstructions(copyOp.getSrc().getType(),
-                                            copyOp.getResult().getType(),
-                                            copyOp.getMask(), contig, axisInfo);
+    return getNumberOfAsyncCopyInstructions(
+        copyOp.getSrc().getType(), copyOp.getResult().getType(),
+        copyOp.getMask(), contig, axisInfo, targetInfo, /*isStore=*/false);
   } else if (auto bufferOp = dyn_cast<amdgpu::BufferLoadToLocalOp>(op)) {
     auto ptrType = cast<RankedTensorType>(LLVM::AMD::getPointerTypeWithShape(
         bufferOp.getPtr(), bufferOp.getOffsets()));
@@ -113,12 +127,12 @@ int getOpNumberOfAsyncCopyInstructions(Operation *op,
                                           bufferOp.getOffsets(), axisInfo);
     return getNumberOfAsyncCopyInstructions(
         ptrType, bufferOp.getDest().getType(), bufferOp.getMask(), contig,
-        axisInfo);
+        axisInfo, targetInfo, /*isStore=*/false);
   } else if (auto copyOp = dyn_cast<amdgpu::AsyncCopyLocalToGlobalOp>(op)) {
     int contig = LLVM::AMD::getVectorSize(copyOp.getDst(), axisInfo);
-    return getNumberOfAsyncCopyInstructions(copyOp.getDst().getType(),
-                                            copyOp.getSrc().getType(),
-                                            copyOp.getMask(), contig, axisInfo);
+    return getNumberOfAsyncCopyInstructions(
+        copyOp.getDst().getType(), copyOp.getSrc().getType(), copyOp.getMask(),
+        contig, axisInfo, targetInfo, /*isStore=*/true);
   } else if (emitRemarkOnNonAsyncOp) {
     SmallVector<mlir::MemoryEffects::EffectInstance> effects;
     if (auto memEffectIface = dyn_cast<MemoryEffectOpInterface>(op))

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -58,7 +58,7 @@ namespace {
 // mapping between global and shared memory addresses.
 int getNumberOfAsyncCopyInstructions(RankedTensorType globalType,
                                      ttg::MemDescType sharedType, Value mask,
-                                     int contig,
+                                     int ptrContig, int contigHint,
                                      ModuleAxisInfoAnalysis &axisInfo,
                                      AMD::TargetInfo targetInfo, bool isStore) {
   LinearLayout globalLayout = tt::gpu::toLinearLayout(globalType);
@@ -80,10 +80,19 @@ int getNumberOfAsyncCopyInstructions(RankedTensorType globalType,
   if (globalToSharedLayout.getFreeVariableMasks().lookup(kWarp) != 0) {
     return 0;
   }
-  contig = std::min(contig, globalToSharedLayout.getNumConsecutiveInOut());
 
   if (mask)
-    contig = std::min<int>(contig, axisInfo.getMaskAlignment(mask));
+    ptrContig = std::min<int>(ptrContig, axisInfo.getMaskAlignment(mask));
+
+  // The contigHint can bump the contig of ptr/mask related contiguity.
+  ptrContig = std::max<int>(ptrContig, contigHint);
+  ptrContig =
+      std::min(ptrContig, globalToSharedLayout.getNumConsecutiveInOut());
+  // For padded encodings restrict vec by the min interval
+  auto srcEnc = sharedType.getEncoding();
+  if (auto padEnc = dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(srcEnc)) {
+    ptrContig = std::min<int>(ptrContig, padEnc.getMinInterval());
+  }
 
   // Divide number of registers by contig to get the number of async intrinsics.
   // Strip zero bases from the register dimension first — a zero basis means
@@ -92,13 +101,13 @@ int getNumberOfAsyncCopyInstructions(RankedTensorType globalType,
   auto kReg = StringAttr::get(globalType.getContext(), "register");
   int numberOfRegisters =
       globalToSharedLayout.removeZeroBasesAlongDim(kReg).getInDimSize(kReg);
-  int numInstructions = std::max(1, numberOfRegisters / contig);
+  int numInstructions = std::max(1, numberOfRegisters / ptrContig);
 
-  // On targets where a given vector width is unsupported but half of it is,
-  // the store lowering splits each async store into two half-width stores
+  // When a given vector width is unsupported but half of it is, the store
+  // lowering splits each async store into two half-width stores.
   if (isStore) {
     int elemBitWidth = sharedType.getElementType().getIntOrFloatBitWidth();
-    int vecBits = contig * elemBitWidth;
+    int vecBits = ptrContig * elemBitWidth;
     if (!targetInfo.supportsDirectFromLdsStoreBitWidth(vecBits) &&
         targetInfo.supportsDirectFromLdsStoreBitWidth(vecBits / 2)) {
       numInstructions *= 2;
@@ -119,7 +128,8 @@ int getOpNumberOfAsyncCopyInstructions(Operation *op,
     int contig = LLVM::AMD::getVectorSize(copyOp.getSrc(), axisInfo);
     return getNumberOfAsyncCopyInstructions(
         copyOp.getSrc().getType(), copyOp.getResult().getType(),
-        copyOp.getMask(), contig, axisInfo, targetInfo, /*isStore=*/false);
+        copyOp.getMask(), contig, copyOp.getContiguity(), axisInfo, targetInfo,
+        /*isStore=*/false);
   } else if (auto bufferOp = dyn_cast<amdgpu::BufferLoadToLocalOp>(op)) {
     auto ptrType = cast<RankedTensorType>(LLVM::AMD::getPointerTypeWithShape(
         bufferOp.getPtr(), bufferOp.getOffsets()));
@@ -127,12 +137,12 @@ int getOpNumberOfAsyncCopyInstructions(Operation *op,
                                           bufferOp.getOffsets(), axisInfo);
     return getNumberOfAsyncCopyInstructions(
         ptrType, bufferOp.getDest().getType(), bufferOp.getMask(), contig,
-        axisInfo, targetInfo, /*isStore=*/false);
+        bufferOp.getContiguity(), axisInfo, targetInfo, /*isStore=*/false);
   } else if (auto copyOp = dyn_cast<amdgpu::AsyncCopyLocalToGlobalOp>(op)) {
     int contig = LLVM::AMD::getVectorSize(copyOp.getDst(), axisInfo);
     return getNumberOfAsyncCopyInstructions(
         copyOp.getDst().getType(), copyOp.getSrc().getType(), copyOp.getMask(),
-        contig, axisInfo, targetInfo, /*isStore=*/true);
+        contig, copyOp.getContiguity(), axisInfo, targetInfo, /*isStore=*/true);
   } else if (emitRemarkOnNonAsyncOp) {
     SmallVector<mlir::MemoryEffects::EffectInstance> effects;
     if (auto memEffectIface = dyn_cast<MemoryEffectOpInterface>(op))


### PR DESCRIPTION
After https://github.com/triton-lang/triton/pull/9994 we split `16bit` wide async_stores into 2 `8bit` wide which requires changes to the waitcnt computation.
We were also missing some other restrictions on the final `contig`.

Note that after LLVM lands the AsyncMarker support for async_load/TDM we can remove the whole pass, so I did not want to do a full refactor to share the functionality.