### PR TITLE
Enable PartitionedSharedEncodingAttr in the memdesc_subslice lowering 

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -2,6 +2,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
@@ -537,28 +538,63 @@ struct MemDescSubsliceOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto *ctx = op.getContext();
     auto srcTy = op.getSrc().getType();
     auto llvmElemTy = getTypeConverter()->convertType(srcTy.getElementType());
-
-    // PartitionedSharedEncoding is not yet supported for memdesc_subslice
-    if (isa<PartitionedSharedEncodingAttr>(srcTy.getEncoding())) {
-      return rewriter.notifyMatchFailure(
-          op,
-          "PartitionedSharedEncoding not yet supported in memdesc_subslice");
-    }
 
     auto smemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                    llvmElemTy, rewriter);
     auto opOffsetVals = op.getOffsets();
 
-    auto base = smemObj.getBase();
     // Accumulate the logical offsets
     SmallVector<Value> offsetVals;
     for (auto [oldOffVal, opOff] :
          llvm::zip(smemObj.getOffsets(), opOffsetVals)) {
       offsetVals.push_back(b.add(oldOffVal, b.i32_val(opOff)));
     }
-    smemObj = SharedMemoryObject(base, llvmElemTy, offsetVals);
+
+    // For PartitionedSharedEncoding we need to pick the right base at load
+    // time. Let
+    //   o     = this op's static subslice offsets (one per dim),
+    //   c     = a logical coord into the destination subslice,
+    //   L     = the shared LL (inputs: offset, partition, block;
+    //                          outputs: dim0, dim1, ...).
+    //
+    //   (1) c_src = c + o
+    //   (2) verifier makes o's bits disjoint from c's bits per dim, so:
+    //         c + o = c ^ o                                   (bit-disjoint)
+    //   (3) L^-1 is linear, so projecting (2) onto the partition component:
+    //         partition(L^-1(c_src)) = partition(L^-1(c)) ^ S
+    //       where  S = partition(L^-1(o))
+    //   (4) the existing lowering already computes i = partition(L^-1(c))
+    //       and indexes bases[i]; from (3) the correct base is:
+    //         bases[i ^ S]
+    //   (5) precompute that rotation once here
+    //         newBases[i] = oldBases[i ^ S]
+    //
+    // The offset component of (3) is already XORed in by getShmemOffset at
+    // load time; only the partition component needs this fix.
+    SmallVector<Value> newBases = llvm::to_vector(smemObj.getBases());
+    if (newBases.size() > 1) {
+      LinearLayout ll = triton::gpu::isPaddedEncoding(srcTy.getEncoding())
+                            ? triton::gpu::paddedLinearLayout(srcTy)
+                            : triton::gpu::toLinearLayout(srcTy);
+      auto kPartition = StringAttr::get(ctx, "partition");
+      assert(ll.hasInDim(kPartition) &&
+             "multiple bases require a partition input dim");
+      auto dimNames = standardOutDimNames(ctx, opOffsetVals.size());
+      SmallVector<std::pair<StringAttr, int32_t>> namedOffsets;
+      for (auto [dim, off] : llvm::zip(dimNames, opOffsetVals))
+        namedOffsets.push_back({dim, off});
+      auto partitionLayout = ll.invert().sublayout(dimNames, {kPartition});
+      int32_t partitionShift = partitionLayout.apply(namedOffsets)[0].second;
+      SmallVector<Value> rotated(newBases.size());
+      for (size_t i = 0; i < newBases.size(); ++i)
+        rotated[i] = newBases[i ^ partitionShift];
+      newBases = std::move(rotated);
+    }
+
+    smemObj = SharedMemoryObject(newBases, llvmElemTy, offsetVals);
     auto retVal = getStructFromSharedMemoryObject(loc, smemObj, rewriter);
     rewriter.replaceOp(op, retVal);
     return success();

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -556,7 +556,7 @@ struct MemDescSubsliceOpConversion
     // For PartitionedSharedEncoding we need to pick the right base at load
     // time. Let
     //   o     = this op's static subslice offsets (one per dim),
-    //   c     = a logical coord into the destination subslice,
+    //   c     = a logical base indices to the current subslice op,
     //   L     = the shared LL (inputs: offset, partition, block;
     //                          outputs: dim0, dim1, ...).
     //

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1021,12 +1021,12 @@ LogicalResult MemDescSubsliceOp::verify() {
 
   auto ctx = getContext();
   LinearLayout ll;
-  if (auto paddedEncoding = dyn_cast<PaddedSharedEncodingAttr>(srcEnc)) {
+  if (auto paddedEncoding = triton::gpu::getPaddedEncoding(srcEnc)) {
     if (paddedEncoding.getRank() < srcTy.getRank()) {
       return emitError("SubSlice of low rank PaddedSharedEncoding from higher "
                        "rank tensors is not supported yet");
     }
-    ll = paddedEncoding.getLinearComponent();
+    ll = triton::gpu::paddedLinearLayout(srcTy);
   } else {
     ll = triton::gpu::toLinearLayout(srcTy);
   }

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -1719,12 +1719,18 @@ def test_gather_layouts(axis, src_layout, index_layout, src_shape, idx_shape, de
                          [[128, 128, 64, 64], [128, 128, 64, 32], [128, 64, 64, 32], [256, 128, 64, 64]])
 @pytest.mark.parametrize("shared_layout_cfg", [
     pytest.param(("swizzled", None, None, None), id="swizzled"),
-    pytest.param(("partitioned", 0, 2, 1), id="partitioned-dim0-p2-g1"),
-    pytest.param(("partitioned", 0, 2, 2), id="partitioned-dim0-p2-g2"),
-    pytest.param(("partitioned", 0, 4, 1), id="partitioned-dim0-p4-g1"),
-    pytest.param(("partitioned", 1, 2, 1), id="partitioned-dim1-p2-g1"),
-    pytest.param(("partitioned", 1, 2, 2), id="partitioned-dim1-p2-g2"),
-    pytest.param(("partitioned", 1, 4, 1), id="partitioned-dim1-p4-g1"),
+    pytest.param(("partitioned-swizzled", 0, 2, 1), id="partitioned-swizzled-dim0-p2-g1"),
+    pytest.param(("partitioned-swizzled", 0, 2, 2), id="partitioned-swizzled-dim0-p2-g2"),
+    pytest.param(("partitioned-swizzled", 0, 4, 1), id="partitioned-swizzled-dim0-p4-g1"),
+    pytest.param(("partitioned-swizzled", 1, 2, 1), id="partitioned-swizzled-dim1-p2-g1"),
+    pytest.param(("partitioned-swizzled", 1, 2, 2), id="partitioned-swizzled-dim1-p2-g2"),
+    pytest.param(("partitioned-swizzled", 1, 4, 1), id="partitioned-swizzled-dim1-p4-g1"),
+    pytest.param(("partitioned-padded", 0, 2, 1), id="partitioned-padded-dim0-p2-g1"),
+    pytest.param(("partitioned-padded", 0, 2, 2), id="partitioned-padded-dim0-p2-g2"),
+    pytest.param(("partitioned-padded", 0, 4, 1), id="partitioned-padded-dim0-p4-g1"),
+    pytest.param(("partitioned-padded", 1, 2, 1), id="partitioned-padded-dim1-p2-g1"),
+    pytest.param(("partitioned-padded", 1, 2, 2), id="partitioned-padded-dim1-p2-g2"),
+    pytest.param(("partitioned-padded", 1, 4, 1), id="partitioned-padded-dim1-p4-g1"),
 ])
 def test_memdesc_subslice(M, N, M_tile_size, N_tile_size, shared_layout_cfg, device):
     if M % M_tile_size != 0 or N % N_tile_size != 0:
@@ -1734,10 +1740,23 @@ def test_memdesc_subslice(M, N, M_tile_size, N_tile_size, shared_layout_cfg, dev
     if layout_type == "swizzled":
         shared_layout = ttgl.SwizzledSharedLayout(vec=8, per_phase=1, max_phase=8, order=[1, 0])
     else:
-        assert layout_type == "partitioned"
-        if is_cuda():
-            pytest.skip("PartitionedSharedLayout is not supported in NV backend")
-        inner_layout = ttgl.SwizzledSharedLayout(vec=4, per_phase=2, max_phase=8, order=[1, 0])
+        assert layout_type in ("partitioned-swizzled", "partitioned-padded")
+        if not is_hip():
+            pytest.skip("PartitionedSharedLayout is supported only on AMD backend")
+        if layout_type == "partitioned-swizzled":
+            inner_layout = ttgl.SwizzledSharedLayout(vec=4, per_phase=2, max_phase=8, order=[1, 0])
+        else:
+            pad_interval, pad_amount = 16, 4
+            # Skip cases that would not fit in LDS on the current architecture.
+            elem_size = 2  # float16
+            padded_bytes = ((M * N * (pad_interval + pad_amount)) // pad_interval) * elem_size
+            if padded_bytes >= get_hip_lds_size():
+                pytest.skip(f"Partitioned-padded allocation ({padded_bytes} B) exceeds LDS ({get_hip_lds_size()} B)")
+            inner_layout = ttgl.PaddedSharedLayout.with_identity_for(
+                interval_padding_pairs=[[pad_interval, pad_amount]],
+                shape=[M, N],
+                order=[1, 0],
+            )
         shared_layout = PartitionedSharedLayout(
             num_partitions=num_partitions,
             num_groups=num_groups,

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -1717,14 +1717,37 @@ def test_gather_layouts(axis, src_layout, index_layout, src_shape, idx_shape, de
 
 @pytest.mark.parametrize("M, N, M_tile_size, N_tile_size",
                          [[128, 128, 64, 64], [128, 128, 64, 32], [128, 64, 64, 32], [256, 128, 64, 64]])
-def test_memdesc_subslice(M, N, M_tile_size, N_tile_size, device):
+@pytest.mark.parametrize("shared_layout_cfg", [
+    pytest.param(("swizzled", None, None, None), id="swizzled"),
+    pytest.param(("partitioned", 0, 2, 1), id="partitioned-dim0-p2-g1"),
+    pytest.param(("partitioned", 0, 2, 2), id="partitioned-dim0-p2-g2"),
+    pytest.param(("partitioned", 0, 4, 1), id="partitioned-dim0-p4-g1"),
+    pytest.param(("partitioned", 1, 2, 1), id="partitioned-dim1-p2-g1"),
+    pytest.param(("partitioned", 1, 2, 2), id="partitioned-dim1-p2-g2"),
+    pytest.param(("partitioned", 1, 4, 1), id="partitioned-dim1-p4-g1"),
+])
+def test_memdesc_subslice(M, N, M_tile_size, N_tile_size, shared_layout_cfg, device):
     if M % M_tile_size != 0 or N % N_tile_size != 0:
         pytest.skip(f"Shape size ({M}, {N}) must be divisible by tile size ({M_tile_size}, {N_tile_size})")
+
+    layout_type, partition_dim, num_partitions, num_groups = shared_layout_cfg
+    if layout_type == "swizzled":
+        shared_layout = ttgl.SwizzledSharedLayout(vec=8, per_phase=1, max_phase=8, order=[1, 0])
+    else:
+        assert layout_type == "partitioned"
+        if is_cuda():
+            pytest.skip("PartitionedSharedLayout is not supported in NV backend")
+        inner_layout = ttgl.SwizzledSharedLayout(vec=4, per_phase=2, max_phase=8, order=[1, 0])
+        shared_layout = PartitionedSharedLayout(
+            num_partitions=num_partitions,
+            num_groups=num_groups,
+            partition_dim=partition_dim,
+            partition_layout=inner_layout,
+        )
 
     num_rows_per_warp = THREADS_PER_WARP // 4
     blocked_layout = ttgl.BlockedLayout(size_per_thread=[1, 8], threads_per_warp=[num_rows_per_warp, 4],
                                         warps_per_cta=[4, 1], order=[1, 0])
-    shared_layout = ttgl.SwizzledSharedLayout(vec=8, per_phase=1, max_phase=8, order=[1, 0])
 
     @gluon.jit
     def kernel(


### PR DESCRIPTION
The verifier is generalized to handle partitioned-wrapping-padded encodings, and the conversion now supports slices along the partition dim by computing  S = partition(L^-1(o)) at compile time and XOR-rotating the per-partition base pointers (newBases[i] = oldBases[i ^ S]). 
Correctness follows from linearity of L^-1 plus the verifier's bit-disjointness guarantee.  Full derivation is in the in-code comment. 
Testing: Appended test_memdesc_subslice with parameters covering partitioned layouts 
across both partition dims.