### PR TITLE
[Docs] Add gluon to rendered docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,8 +76,11 @@ third_party/nvidia/backend/lib/gsan.ll
 
 # Docs
 docs/_build/
+docs/_generated/
+docs/gluon/api/generated/
 docs/python-api/generated/
 docs/dialects/
+docs/getting-started/examples
 docs/getting-started/tutorials
 docs/sg_execution_times.rst
 !python/tutorials/*.py

--- a/docs/_templates/autosummary/gluon-module.rst
+++ b/docs/_templates/autosummary/gluon-module.rst
@@ -1,0 +1,59 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+{% if attributes %}
+.. rubric:: {{ _('Module Attributes') }}
+
+.. autosummary::
+   :nosignatures:
+{% for item in attributes %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+
+{% if functions %}
+.. rubric:: {{ _('Functions') }}
+
+.. autosummary::
+   :toctree:
+   :nosignatures:
+{% for item in functions %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+
+{% if classes %}
+.. rubric:: {{ _('Classes') }}
+
+.. autosummary::
+   :toctree:
+   :nosignatures:
+{% for item in classes %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+
+{% if exceptions %}
+.. rubric:: {{ _('Exceptions') }}
+
+.. autosummary::
+   :toctree:
+   :nosignatures:
+{% for item in exceptions %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+
+{% if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+   :nosignatures:
+   :template: autosummary/gluon-module.rst
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,20 +23,208 @@
 # -- General configuration ------------------------------------------------
 
 import os
-import platform
+import re
 import shutil
 import sys
 import sysconfig
+from collections import defaultdict
+from itertools import count
 from pathlib import Path
 
 import sphinx_rtd_theme
+from myst_sphinx_gallery import GalleryConfig
 from sphinx_gallery.sorting import FileNameSortKey
+
+GLUON_TUTORIALS_SRC = Path("../python/tutorials/gluon")
+GLUON_TUTORIALS_GENERATED = Path("_generated/gluon-tutorials")
+GLUON_TUTORIALS_GALLERY = Path("getting-started/tutorials/gluon")
+GLUON_EXAMPLES_SRC = Path("../python/examples/gluon")
+GLUON_EXAMPLES_GENERATED = Path("_generated/gluon-examples")
+GLUON_EXAMPLES_GALLERY = Path("getting-started/examples/gluon")
+
+GLUON_MYST_GALLERIES = [
+    {
+        "src": GLUON_TUTORIALS_SRC,
+        "generated": GLUON_TUTORIALS_GENERATED,
+        "gallery": GLUON_TUTORIALS_GALLERY,
+        "title": "Gluon Tutorials",
+        "header_ref": "example_gluon_tutorials_header",
+        "description": """\
+These tutorials can be found in ``python/tutorials/gluon``.
+""",
+        "ignore": {"__init__.py", "conftest.py"},
+    },
+    {
+        "src": GLUON_EXAMPLES_SRC,
+        "generated": GLUON_EXAMPLES_GENERATED,
+        "gallery": GLUON_EXAMPLES_GALLERY,
+        "title": "Gluon Examples",
+        "header_ref": "example_gluon_examples_header",
+        "description": """\
+These examples can be found in ``python/examples/gluon``.
+""",
+        "ignore": {"__init__.py", "conftest.py", "02-conv-common.py"},
+    },
+]
 
 
 def process_sig(app, what, name, obj, options, signature, return_annotation):
     if signature and '_builder' in signature:
         signature = signature.split('_builder')[0] + ")"
     return (signature, return_annotation)
+
+
+def is_gluon_docstring(app, name, obj):
+    env = getattr(app, "env", None)
+    temp_data = getattr(env, "temp_data", {}) if env is not None else {}
+    docname = temp_data.get("docname") or getattr(env, "docname", "") or ""
+    module = getattr(obj, "__module__", "")
+    return (docname.startswith("gluon/") or name.startswith("triton.experimental.gluon")
+            or module.startswith("triton.experimental.gluon"))
+
+
+def process_gluon_docstring(app, what, name, obj, options, lines):
+    if not is_gluon_docstring(app, name, obj):
+        return
+
+    from sphinx.ext.napoleon.docstring import GoogleDocstring
+
+    result_lines = GoogleDocstring(lines, app.config, app, what, name, obj, options).lines()
+    lines[:] = result_lines.copy()
+
+
+def setup_gluon_napoleon(app):
+    from sphinx.ext.napoleon import Config as NapoleonConfig
+
+    for name, default, rebuild, types in NapoleonConfig._config_values:
+        app.add_config_value(name, default, rebuild, types=types)
+    app.connect("autodoc-process-docstring", process_gluon_docstring)
+
+
+def sphinx_gallery_blocks_to_markdown(blocks, gallery_conf, target_dir):
+    from sphinx_gallery.notebook import rst2md
+
+    parts = []
+    heading_level_counter = count(start=1)
+    heading_levels = defaultdict(lambda: next(heading_level_counter))
+
+    for label, content, _ in blocks:
+        content = content.rstrip()
+        if not content:
+            continue
+        if label == "code":
+            parts.append(f"```python\n{content}\n```")
+        else:
+            fences = []
+
+            def stash_fence(match):
+                fences.append(match.group(0))
+                return f"\nGLUON_MARKDOWN_FENCE_{len(fences) - 1}\n"
+
+            # Sphinx-Gallery's notebook converter treats text as reST. Protect
+            # native Markdown fences first so output snippets can contain
+            # reST-looking lines without being rewritten as headings.
+            protected = re.sub(r"```.*?```", stash_fence, content, flags=re.DOTALL)
+            protected = re.sub(r"(?m)^%%\s*$\n?", "", protected)
+            markdown = rst2md(protected + "\n", gallery_conf, target_dir, heading_levels)
+            for i, fence in enumerate(fences):
+                markdown = markdown.replace(f"GLUON_MARKDOWN_FENCE_{i}", fence)
+            parts.append(markdown.rstrip())
+    return "\n\n".join(part for part in parts if part) + "\n"
+
+
+def title_from_filename(path):
+    words = re.sub(r"^\d+-", "", path.stem).replace("_", "-").split("-")
+
+    def format_word(word):
+        lower = word.lower()
+        if lower in {"cta", "bmm", "moe", "tma"}:
+            return lower.upper()
+        if lower == "tcgen05":
+            return "TCGen05"
+        cta_match = re.match(r"^(\d+)cta$", lower)
+        if cta_match:
+            return f"{cta_match.group(1)}CTA"
+        return word.capitalize()
+
+    return " ".join(format_word(word) for word in words if word)
+
+
+def python_source_to_markdown(source_path, gallery_conf, target_dir, source_label):
+    from sphinx_gallery.py_source_parser import split_code_and_text_blocks
+    from sphinx.errors import ExtensionError
+
+    try:
+        _, blocks = split_code_and_text_blocks(source_path)
+    except ExtensionError as exc:
+        if "Could not find docstring" not in str(exc):
+            raise
+        source = source_path.read_text(encoding="utf-8")
+        fence = "`" * (max((len(match.group(0)) for match in re.finditer(r"`{3,}", source)), default=2) + 1)
+        title = title_from_filename(source_path)
+        return f"""\
+# {title}
+
+This example can be found at ``{source_label}/{source_path.name}``.
+
+{fence}python
+{source.rstrip()}
+{fence}
+"""
+
+    return sphinx_gallery_blocks_to_markdown(blocks, gallery_conf, target_dir)
+
+
+def generate_gluon_myst_galleries(app):
+    gallery_conf = app.config.sphinx_gallery_conf.copy()
+
+    for gallery in GLUON_MYST_GALLERIES:
+        src_dir = (Path(app.srcdir) / gallery["src"]).resolve()
+        generated_dir = Path(app.srcdir) / gallery["generated"]
+        gallery_dir = Path(app.srcdir) / gallery["gallery"]
+
+        shutil.rmtree(generated_dir, ignore_errors=True)
+        shutil.rmtree(gallery_dir, ignore_errors=True)
+        generated_dir.mkdir(parents=True)
+        gallery_dir.mkdir(parents=True)
+
+        title = gallery["title"]
+        (generated_dir / "GALLERY_HEADER.rst").write_text(
+            f"{title}\n{'=' * len(title)}\n\n{gallery['description']}",
+            encoding="utf-8",
+        )
+
+        for source_path in sorted(src_dir.glob("*.py")):
+            if source_path.name in gallery["ignore"]:
+                continue
+            source_label = gallery["src"].as_posix().removeprefix("../")
+            markdown = python_source_to_markdown(
+                source_path,
+                gallery_conf,
+                str(generated_dir),
+                source_label,
+            )
+            (generated_dir / source_path.with_suffix(".md").name).write_text(markdown, encoding="utf-8")
+
+
+def fix_gluon_myst_gallery_paths(app):
+    for gallery in GLUON_MYST_GALLERIES:
+        gallery_dir = gallery["gallery"]
+        index = Path(app.srcdir) / gallery_dir / "index.rst"
+        if not index.exists():
+            continue
+
+        text = index.read_text(encoding="utf-8")
+        old = f":img-top: /{gallery_dir.stem}/"
+        new = f":img-top: /{gallery_dir.as_posix()}/"
+        text = text.replace(old, new)
+        text = re.sub(
+            rf"(?m)^\.\. _example_{re.escape(gallery_dir.stem)}_header:$",
+            f".. _{gallery['header_ref']}:",
+            text,
+            count=1,
+        )
+        index.write_text(text, encoding="utf-8")
 
 
 def get_cmake_dir():
@@ -98,6 +286,9 @@ def setup(app):
     import sphinx
 
     app.connect("autodoc-process-signature", process_sig)
+    setup_gluon_napoleon(app)
+    app.connect("builder-inited", generate_gluon_myst_galleries, priority=100)
+    app.connect("builder-inited", fix_gluon_myst_gallery_paths, priority=700)
     max_jobs = os.getenv("MAX_JOBS", str(2 * os.cpu_count()))
     print(f"Installing Triton Python package using {max_jobs} threads")
     subprocess.run("pip install -e ../", shell=True, env=os.environ.copy())
@@ -152,10 +343,10 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.autosummary',
     'sphinx.ext.coverage',
-    'sphinx.ext.napoleon',
     'sphinx_multiversion',
     'sphinx.ext.autosectionlabel',
     'myst_parser',
+    'myst_sphinx_gallery',
 ]
 autosummary_generate = True
 
@@ -174,15 +365,20 @@ sphinx_gallery_conf = {
     'examples_dirs': '../python/tutorials/',
     'gallery_dirs': 'getting-started/tutorials',
     'filename_pattern': '',
-    'ignore_pattern': r'(__init__\.py|11.*.py)',
+    'ignore_pattern': r'(__init__\.py|conftest\.py|11-programmatic-dependent-launch\.py)',
     'within_subsection_order': FileNameSortKey,
     'reference_url': {
         'sphinx_gallery': None,
     },
-    # Examples don't work on non-Linux platforms, because they actually run
-    # Triton.  But it's nice to be able to run the rest of the docs build.
-    'abort_on_example_error': platform.system() == 'Linux',
+    'abort_on_example_error': False,
 }
+
+myst_sphinx_gallery_config = GalleryConfig(
+    examples_dirs=[gallery["generated"] for gallery in GLUON_MYST_GALLERIES],
+    gallery_dirs=[gallery["gallery"] for gallery in GLUON_MYST_GALLERIES],
+    root_dir=Path(__file__).parent,
+    base_gallery=True,
+)
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -195,8 +391,10 @@ html_sidebars = {
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-# source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
 
 # The master toctree document.
 master_doc = 'index'
@@ -225,7 +423,7 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', '_generated', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -240,7 +438,6 @@ todo_include_todos = False
 #
 
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -261,7 +261,7 @@ def setup_generated_mlir_docs():
 
     rst_string = f"""
 Triton MLIR Dialects and Ops
-=====================
+============================
 
 .. toctree::
    :maxdepth: 1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -349,6 +349,7 @@ extensions = [
     'myst_sphinx_gallery',
 ]
 autosummary_generate = True
+autosummary_ignore_module_all = False
 
 # versioning config
 smv_tag_whitelist = r'^(v3.7.0)$'

--- a/docs/gluon/api/amd.cdna3.rst
+++ b/docs/gluon/api/amd.cdna3.rst
@@ -1,0 +1,19 @@
+AMD CDNA 3
+==========
+
+.. currentmodule:: triton.experimental.gluon.language.amd.cdna3
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    buffer_load
+    buffer_store
+    buffer_atomic_add
+    buffer_atomic_and
+    buffer_atomic_max
+    buffer_atomic_min
+    buffer_atomic_or
+    buffer_atomic_xchg
+    buffer_atomic_xor
+    mfma

--- a/docs/gluon/api/amd.cdna4.rst
+++ b/docs/gluon/api/amd.cdna4.rst
@@ -1,0 +1,22 @@
+AMD CDNA 4
+==========
+
+.. currentmodule:: triton.experimental.gluon.language.amd.cdna4
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    async_copy
+    buffer_load
+    buffer_store
+    buffer_atomic_add
+    buffer_atomic_and
+    buffer_atomic_max
+    buffer_atomic_min
+    buffer_atomic_or
+    buffer_atomic_xchg
+    buffer_atomic_xor
+    get_mfma_scale_layout
+    mfma
+    mfma_scaled

--- a/docs/gluon/api/amd.rdna3.rst
+++ b/docs/gluon/api/amd.rdna3.rst
@@ -1,0 +1,10 @@
+AMD RDNA 3
+==========
+
+.. currentmodule:: triton.experimental.gluon.language.amd.rdna3
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    wmma

--- a/docs/gluon/api/amd.rdna4.rst
+++ b/docs/gluon/api/amd.rdna4.rst
@@ -1,0 +1,10 @@
+AMD RDNA 4
+==========
+
+.. currentmodule:: triton.experimental.gluon.language.amd.rdna4
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    wmma

--- a/docs/gluon/api/amd.rst
+++ b/docs/gluon/api/amd.rst
@@ -1,0 +1,28 @@
+AMD
+===
+
+Target-specific Gluon APIs for AMD GPU generations.
+
+Common APIs
+-----------
+
+.. currentmodule:: triton.experimental.gluon.language.amd
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    AMDMFMALayout
+    AMDWMMALayout
+    warp_pipeline_stage
+
+GPU Generations
+---------------
+
+.. toctree::
+   :maxdepth: 1
+
+   CDNA 3 <amd.cdna3>
+   CDNA 4 <amd.cdna4>
+   RDNA 3 <amd.rdna3>
+   RDNA 4 <amd.rdna4>

--- a/docs/gluon/api/index.rst
+++ b/docs/gluon/api/index.rst
@@ -1,0 +1,26 @@
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Gluon
+   :hidden:
+
+   Runtime API <runtime>
+   Language API <language>
+   NVIDIA Intrinsics <nvidia>
+   AMD Intrinsics <amd>
+
+.. rubric:: Core APIs
+
+- :doc:`Runtime API <runtime>`: JIT decorators, result handling, and host-side
+  tensor descriptors used to launch Gluon kernels.
+- :doc:`Language API <language>`: the core Gluon programming model, layouts,
+  memory operations, math operations, and compile-time helpers.
+
+.. rubric:: Target Intrinsics
+
+- :doc:`NVIDIA Intrinsics <nvidia>`: target-specific APIs for NVIDIA Ampere,
+  Hopper, and Blackwell GPUs.
+- :doc:`AMD Intrinsics <amd>`: target-specific APIs for AMD CDNA and RDNA GPU
+  generations.

--- a/docs/gluon/api/language.rst
+++ b/docs/gluon/api/language.rst
@@ -1,0 +1,241 @@
+Language API
+============
+
+.. currentmodule:: triton.experimental.gluon.language
+
+Types
+-----
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    tensor
+    shared_memory_descriptor
+    distributed_type
+
+
+Programming Model
+-----------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    program_id
+    num_programs
+    num_warps
+    num_ctas
+    warp_specialize
+    barrier
+
+
+Creation Ops
+------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    allocate_shared_memory
+    arange
+    cast
+    full
+    full_like
+    zeros
+    zeros_like
+    to_tensor
+
+Layout Ops
+----------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    bank_conflicts
+    convert_layout
+    set_auto_layout
+    to_linear_layout
+
+Shape Manipulation Ops
+----------------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    broadcast
+    expand_dims
+    join
+    map_elementwise
+    permute
+    ravel
+    reshape
+    split
+
+
+Memory Ops
+----------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    load
+    store
+
+
+Atomic Ops
+----------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    atomic_add
+    atomic_and
+    atomic_cas
+    atomic_max
+    atomic_min
+    atomic_or
+    atomic_xchg
+    atomic_xor
+
+
+Linear Algebra Ops
+------------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    dot_fma
+
+
+Indexing Ops
+------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    gather
+    where
+
+
+Math Ops
+--------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    abs
+    add
+    cdiv
+    ceil
+    clamp
+    cos
+    div_rn
+    erf
+    exp
+    exp2
+    fdiv
+    floor
+    fma
+    fp4_to_fp
+    log
+    log2
+    maximum
+    minimum
+    mul
+    rsqrt
+    sin
+    sqrt
+    sqrt_rn
+    sub
+    umulhi
+
+
+Reduction Ops
+-------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    reduce
+    reduce_or
+    sum
+    max
+    min
+    xor_sum
+
+
+Scan Ops
+--------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    associative_scan
+    histogram
+
+
+Layout Classes
+--------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    AutoLayout
+    BlockedLayout
+    CoalescedLayout
+    DotOperandLayout
+    DistributedLinearLayout
+    NVMMADistributedLayout
+    NVMMASharedLayout
+    PaddedSharedLayout
+    SharedLinearLayout
+    SliceLayout
+    SwizzledSharedLayout
+
+
+Iterators
+---------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    static_range
+
+
+Inline Assembly
+---------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    inline_asm_elementwise
+
+
+Compiler Hints and Debugging
+----------------------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    assume
+    max_constancy
+    max_contiguous
+    multiple_of
+    static_assert
+    static_print
+    device_assert
+    device_print

--- a/docs/gluon/api/nvidia.ampere.rst
+++ b/docs/gluon/api/nvidia.ampere.rst
@@ -6,7 +6,13 @@ NVIDIA Ampere
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: autosummary/gluon-module.rst
 
     async_copy
     mbarrier
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
     mma_v2

--- a/docs/gluon/api/nvidia.ampere.rst
+++ b/docs/gluon/api/nvidia.ampere.rst
@@ -1,0 +1,12 @@
+NVIDIA Ampere
+=============
+
+.. currentmodule:: triton.experimental.gluon.language.nvidia.ampere
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    async_copy
+    mbarrier
+    mma_v2

--- a/docs/gluon/api/nvidia.blackwell.rst
+++ b/docs/gluon/api/nvidia.blackwell.rst
@@ -1,0 +1,20 @@
+NVIDIA Blackwell
+================
+
+.. currentmodule:: triton.experimental.gluon.language.nvidia.blackwell
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    allocate_tensor_memory
+    async_copy
+    clc
+    fence_async_shared
+    mbarrier
+    mma_v2
+    tensor_memory_descriptor
+    tensor_memory_descriptor_type
+    TensorMemoryLayout
+    TensorMemoryScalesLayout
+    tma

--- a/docs/gluon/api/nvidia.blackwell.rst
+++ b/docs/gluon/api/nvidia.blackwell.rst
@@ -6,15 +6,22 @@ NVIDIA Blackwell
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: autosummary/gluon-module.rst
 
-    allocate_tensor_memory
     async_copy
     clc
-    fence_async_shared
     mbarrier
+    tma
+
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    allocate_tensor_memory
+    fence_async_shared
     mma_v2
     tensor_memory_descriptor
     tensor_memory_descriptor_type
     TensorMemoryLayout
     TensorMemoryScalesLayout
-    tma

--- a/docs/gluon/api/nvidia.hopper.rst
+++ b/docs/gluon/api/nvidia.hopper.rst
@@ -1,0 +1,17 @@
+NVIDIA Hopper
+=============
+
+.. currentmodule:: triton.experimental.gluon.language.nvidia.hopper
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    async_copy
+    cluster
+    fence_async_shared
+    mbarrier
+    mma_v2
+    tma
+    warpgroup_mma
+    warpgroup_mma_wait

--- a/docs/gluon/api/nvidia.hopper.rst
+++ b/docs/gluon/api/nvidia.hopper.rst
@@ -6,12 +6,19 @@ NVIDIA Hopper
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: autosummary/gluon-module.rst
 
     async_copy
     cluster
-    fence_async_shared
     mbarrier
-    mma_v2
     tma
+
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    fence_async_shared
+    mma_v2
     warpgroup_mma
     warpgroup_mma_wait

--- a/docs/gluon/api/nvidia.rst
+++ b/docs/gluon/api/nvidia.rst
@@ -1,0 +1,11 @@
+NVIDIA
+======
+
+Target-specific Gluon APIs for NVIDIA GPU generations.
+
+.. toctree::
+   :maxdepth: 1
+
+   Ampere <nvidia.ampere>
+   Hopper <nvidia.hopper>
+   Blackwell <nvidia.blackwell>

--- a/docs/gluon/api/runtime.rst
+++ b/docs/gluon/api/runtime.rst
@@ -1,0 +1,28 @@
+Runtime API
+===========
+
+.. currentmodule:: triton.experimental.gluon
+
+Runtime
+-------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    GluonJITFunction
+    jit
+    constexpr_function
+    must_use_result
+
+
+Host-Side Descriptors
+---------------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    nvidia.hopper.TensorDescriptor
+    nvidia.hopper.TensorDescriptorIm2Col
+    nvidia.blackwell.TensorDescriptor

--- a/docs/gluon/index.rst
+++ b/docs/gluon/index.rst
@@ -1,0 +1,12 @@
+Gluon Overview
+==============
+
+Gluon is Triton's lower-level GPU programming model. It exposes layouts,
+shared memory, warp specialization, and target-specific features directly so
+advanced kernels can trade convenience for control.
+
+- Browse the :doc:`tutorial gallery <../getting-started/tutorials/gluon/index>` for
+  Gluon tutorials.
+- Browse the :doc:`examples gallery <../getting-started/examples/gluon/index>` for
+  complete Gluon example kernels.
+- Browse the :doc:`Gluon API reference <api/index>`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ Getting Started
    getting-started/tutorials/index
 
 
-Python API
+Triton API
 ----------
 
 - :doc:`triton <python-api/triton>`
@@ -38,6 +38,24 @@ Python API
    python-api/triton.language
    python-api/triton.testing
    python-api/triton-semantics
+
+
+Gluon
+-----
+
+- Learn about Gluon's lower-level programming model in the :doc:`Gluon overview <gluon/index>`.
+- Browse the :doc:`Gluon tutorials <getting-started/tutorials/gluon/index>`,
+  :doc:`examples <getting-started/examples/gluon/index>`, and :doc:`API reference <gluon/api/index>`.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Gluon
+   :hidden:
+
+   Overview <gluon/index>
+   Tutorials <getting-started/tutorials/gluon/index>
+   Examples <getting-started/examples/gluon/index>
+   API Reference <gluon/api/index>
 
 
 Triton MLIR Dialects and Ops

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,7 +59,7 @@ Gluon
 
 
 Triton MLIR Dialects and Ops
---------------------
+----------------------------
 
 - :doc:`Triton MLIR Dialects and Ops <dialects/dialects>`
 

--- a/docs/python-api/triton.language.rst
+++ b/docs/python-api/triton.language.rst
@@ -64,7 +64,7 @@ Linear Algebra Ops
 
 
 Memory/Pointer Ops
-----------
+------------------
 
 .. autosummary::
     :toctree: generated

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ cmake
 sphinx
 matplotlib
 myst_parser
+myst-sphinx-gallery
 sphinx-rtd-theme
 pandas<3.0
 pytest

--- a/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna3/__init__.py
@@ -132,6 +132,7 @@ def buffer_store(stored_value, ptr, offsets, mask=None, cache=None, _semantic: G
     """
     AMD buffer store a tensor directly to global memory via a scalar base pointer and a tensor of
     offsets instead of a tensor of pointers.
+
     Args:
         stored_value (tensor to be stored): The tensor to be stored to global memory.
         ptr (pointer to scalar): Global memory scalar base pointer to store to.

--- a/python/triton/experimental/gluon/language/nvidia/hopper/tma.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/tma.py
@@ -23,6 +23,11 @@ __all__ = [
     "async_load_im2col",
     "async_store",
     "store_wait",
+    "tensor_descriptor",
+    "tensor_descriptor_im2col",
+    "tensor_descriptor_type",
+    "tensor_descriptor_im2col_type",
+    "make_tensor_descriptor",
 ]
 
 

--- a/python/tutorials/10-block-scaled-matmul.py
+++ b/python/tutorials/10-block-scaled-matmul.py
@@ -471,7 +471,7 @@ def bench_block_scaled(K, block_scale_type="nvfp4", reps=10, warmup_reps=10):
             _ = cublas_block_scaled_matmul(a, a_scale_cublas, b, b_scale_cublas, block_scale_type=block_scale_type)
 
     # Benchmark
-    proton.activate(0)
+    proton.activate()
     for _ in range(reps):
         _ = block_scaled_matmul(a_desc, a_scale_desc, b_desc, b_scale_desc, torch.float16, M, N, K, rep_m, rep_n, rep_k,
                                 configs)
@@ -482,7 +482,7 @@ def bench_block_scaled(K, block_scale_type="nvfp4", reps=10, warmup_reps=10):
             with proton.scope(f"cublas [M={M}, N={N}, K={K}]",
                               {"bytes": bytes_per_elem * (M * K_bytes + N * K_bytes + M * N), "flops": 2. * M * N * K}):
                 _ = cublas_block_scaled_matmul(a, a_scale_cublas, b, b_scale_cublas, block_scale_type=block_scale_type)
-    proton.deactivate(0)
+    proton.deactivate()
     print("Done benchmarking")
 
 
@@ -704,10 +704,10 @@ def bench_block_scaled_amd(K, block_scale_type="mxfp4", reps=10, mfma_nonkdim=16
     x = x_mxfp4.to_packed_tensor(dim=1)
     w = w_mxfp4.to_packed_tensor(dim=1)
 
-    proton.activate(0)
+    proton.activate()
     for _ in range(reps):
         _ = block_scaled_matmul_amd(x, w, x_scales_triton, w_scales_triton, configs)
-    proton.deactivate(0)
+    proton.deactivate()
     print("Done benchmarking")
 
 
@@ -738,7 +738,7 @@ if __name__ == "__main__":
 
         if args.bench:
             proton.start("block_scaled_matmul", hook="triton")
-            proton.deactivate(0)  # Skip argument creation
+            proton.deactivate()  # Skip argument creation
             for K in range(args.K_range[0], args.K_range[1] + 1, args.K_step):
                 if is_cuda():
                     bench_block_scaled(K, reps=10000, block_scale_type=args.format)

--- a/python/tutorials/gluon/06-tcgen05.py
+++ b/python/tutorials/gluon/06-tcgen05.py
@@ -1,5 +1,5 @@
 """
-The 5th Generation TensorCore^TM
+The 5th Generation TensorCore{sup}`TM`
 ================================
 
 This tutorial covers the APIs for interacting with Tensor Cores on Blackwell
@@ -76,6 +76,7 @@ if __name__ == "__main__" and not is_blackwell():
 #     block=(blockM, blockN),
 #     unpacked=True,
 # )
+# ```
 #
 # The tensor is divided into (blockM, blockN) blocks, where blockM must be 64
 # or 128. blockN must be a power of 2 between [1, 256]. For dtypes smaller than

--- a/python/tutorials/gluon/07-persistence.py
+++ b/python/tutorials/gluon/07-persistence.py
@@ -300,6 +300,7 @@ if __name__ == "__main__" and not profiling_with_ncu:
     print()
 
 # %%
+# ```text
 # BLOCK_K num_buffers num_warps Blackwell  Hopper
 #     128           2         4    735.96
 #     128           2         8    697.97  489.26
@@ -307,6 +308,7 @@ if __name__ == "__main__" and not profiling_with_ncu:
 #      64           3         8    973.94  673.67
 #      64           4         4   1175.70
 #      64           4         8   1072.83  669.16
+# ```
 #
 # Blackwell performance lines up with what we have seen in previous tutorials,
 # but on Hopper we see some wins. On Hopper, performance plateaus at 3 buffers,
@@ -453,6 +455,7 @@ if __name__ == "__main__" and not profiling_with_ncu:
     print()
 
 # %%
+# ```text
 # BLOCK_K num_buffers num_warps  Blackwell  Hopper
 #     128           2         4     712.25
 #     128           2         8     686.64  502.84
@@ -460,6 +463,7 @@ if __name__ == "__main__" and not profiling_with_ncu:
 #      64           3         8     938.81  661.11
 #      64           4         4    1142.26
 #      64           4         8    1071.46  658.84
+# ```
 #
 # The Hopper kernel sees a modest improvement, but the Blackwell kernel
 # performance is slightly lower. Let's capture a profile of the kernels on
@@ -551,12 +555,14 @@ if __name__ == "__main__" and not profiling_with_ncu:
     print()
 
 # %%
+# ```text
 # GROUP_SIZE_M Blackwell  Hopper
 #            1   1025.11  649.09
 #            2   1050.43  651.32
 #            4   1032.71  655.51
 #            6   1057.27  652.39
 #            8   1179.94  648.42
+# ```
 #
 # At GROUP_SIZE_M=8, we recover performance on Blackwell. In fact, under ncu we
 # see the L2 hit rate increases to 70%, which suggests there are other ways to
@@ -761,6 +767,7 @@ if __name__ == "__main__":
         print(f"{K:>5} {r0:>17.2f} {r1:>13.2f} {r2:>11.2f} {r3:>9.2f}")
 
 # %%
+# ```text
 # Blackwell results:
 #
 #     K     nonpersistent    persistent   pipelined    cublas
@@ -770,7 +777,9 @@ if __name__ == "__main__":
 #  4096           1164.05       1120.92     1143.47   1563.98
 #  8192           1160.93       1074.97     1185.40   1491.84
 # 16384           1185.62       1096.34     1296.93   1548.42
+# ```
 #
+# ```text
 # Hopper results:
 #
 #     K     nonpersistent    persistent   pipelined    cublas
@@ -780,6 +789,7 @@ if __name__ == "__main__":
 #  4096            609.36        630.10      640.48    646.30
 #  8192            629.44        646.22      661.57    661.11
 # 16384            653.79        660.29      670.00    665.49
+# ```
 #
 # Persistent matmul, when pipelined, gains more performance relative to
 # nonpersistent at lower K, as we would expect. Load balancing can be

--- a/python/tutorials/gluon/13-conv-im2col.py
+++ b/python/tutorials/gluon/13-conv-im2col.py
@@ -77,7 +77,7 @@ if __name__ == "__main__" and not t7.is_hopper_or_newer():
 
 # %%
 # Tutorial Motivation
-# ===================
+# -------------------
 #
 # Before diving into kernels, we first explain the concept of
 # **im2col convolution**: rewriting convolution as GEMM by flattening each
@@ -90,7 +90,7 @@ if __name__ == "__main__" and not t7.is_hopper_or_newer():
 #
 # %%
 # What is a 2D Convolution?
-# =======================
+# -------------------------
 #
 # A 2D convolution slides a small filter (kernel) across an input image and
 # computes a weighted sum at every position. For a single-channel example
@@ -128,7 +128,7 @@ if __name__ == "__main__" and not t7.is_hopper_or_newer():
 #
 # %%
 # The im2col Algorithm
-# ====================
+# --------------------
 #
 # **im2col** (image to column) rearranges the input so that convolution becomes
 # a standard matrix multiplication (GEMM). The idea is:
@@ -229,7 +229,7 @@ if __name__ == "__main__" and not t7.is_hopper_or_newer():
 #
 # %%
 # Shared Kernel for All Examples
-# ==============================
+# ------------------------------
 #
 # All examples use the same kernel structure - only the TensorDescriptor
 # configuration and load coordinates differ.
@@ -303,7 +303,7 @@ def run_tma_im2col(title, pixel_box_lower_corner, pixel_box_upper_corner, coord,
 
 # %%
 # Example 1: Basic Loading (No Padding)
-# =====================================
+# -------------------------------------
 #
 # Load all 16 pixels (4x4 grid) from a [1, 4, 4, 32] tensor.
 # - coord = [0, 0, 0, 0], offsets = [0, 0]
@@ -384,7 +384,7 @@ if __name__ == "__main__":
 
 # %%
 # Example 2: Loading from Padded Region
-# =====================================
+# -------------------------------------
 #
 # With pixel_box_lower_corner=[-1,-1] and pixel_box_upper_corner=[-1,-1],
 # access boundary is H in [-1, 2], W in [-1, 2].
@@ -484,7 +484,7 @@ if __name__ == "__main__":
 
 # %%
 # Example 3: Offset Shifts Access Boundary
-# ========================================
+# ----------------------------------------
 #
 # Same TensorDescriptor as Example 2, but with offsets=[1, 1].
 # This shifts the access boundary from [-1, 2] to [0, 3], covering the original tensor.
@@ -570,7 +570,7 @@ if __name__ == "__main__":
 
 # %%
 # Example 4: Loading Across Multiple Batches
-# ==========================================
+# ------------------------------------------
 #
 # This example shows loading pixels that span across multiple images (batches).
 # Input: [2, 4, 4, 32] - 2 batches of 4x4 images with 32 channels
@@ -700,7 +700,7 @@ if __name__ == "__main__":
 
 # %%
 # Example 5: Multi-Batch with Padded Access Boundary
-# ==================================================
+# --------------------------------------------------
 #
 # This example combines multi-batch loading with padding.
 # With pixel_box_lower_corner=[-1,-1] and pixel_box_upper_corner=[-1,-1],
@@ -851,7 +851,7 @@ if __name__ == "__main__":
 
 # %%
 # Implicit GEMM with TMA im2col
-# ==============================
+# ------------------------------
 #
 # **Explicit im2col** physically constructs the matrix A in memory. This is
 # simple but wastes memory because overlapping patches duplicate input data.
@@ -904,7 +904,7 @@ if __name__ == "__main__":
 #
 # %%
 # Gluon Kernel
-# ============
+# ------------
 #
 # The kernel below implements a single-buffered implicit GEMM convolution.
 # ``store_output_tile`` is factored out as a helper; everything else is
@@ -1034,7 +1034,7 @@ def conv2d_im2col_kernel(
 
 # %%
 # Host-Side Launcher
-# ==================
+# ------------------
 #
 # The host side sets up TMA descriptors and launches the kernel.
 # The critical part is configuring the ``TensorDescriptorIm2Col`` with the
@@ -1147,7 +1147,7 @@ def conv2d_tma_im2col(input_nhwc, weight, stride=1, padding=0, BLOCK_M=64, BLOCK
 
 # %%
 # Testing
-# =======
+# -------
 #
 # We compare our TMA im2col convolution against PyTorch's conv2d.
 
@@ -1177,7 +1177,7 @@ def test_conv2d_tma_im2col(N, H, W, Ci, Co, R, S, stride, padding):
 
 # %%
 # Summary
-# =======
+# -------
 #
 # In this tutorial we learned:
 #

--- a/python/tutorials/gluon/14-multicta.py
+++ b/python/tutorials/gluon/14-multicta.py
@@ -224,6 +224,7 @@ benchmark_multicta_softmax_f32()
 
 # %%
 # Softmax benchmark results
+# ```text
 # Benchmarking multicta_softmax
 # ============================
 #   shape         CTAs  warps  time (ms)  bandwidth (GB/s)
@@ -238,6 +239,7 @@ benchmark_multicta_softmax_f32()
 #  32768 x 65536      4      4      2.836           6057.26
 #  16384 x 131072     8      4      3.142           5468.66
 #   8192 x 262144    16      4      3.627           4736.15
+# ```
 #
 # We see that here using multiCTA we are able to get very good performance across the board.
 #


### PR DESCRIPTION
This adds a new GLUON section between PYTHON API and TRITON MLIR DIALECTS in the side bar. It contains the tutorials, examples and a gluon API reference. The tutorials have a special logic in `docs/conf.py` that lets them use markdown instead of restructured text markup,  which makes it both render correctly and keep a readable text format.