### PR TITLE
[FRONTEND] Add care_padding load control

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4286,6 +4286,72 @@ def test_masked_load_scalar(num_ctas, mask_val, other_val, device):
     torch.testing.assert_close(output, reference_out)
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("dtype", [torch.int32, torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("care_padding", [False, True])
+@pytest.mark.parametrize("other", [None, 0, 7])
+def test_masked_load_care_padding(dtype, care_padding, other, device):
+    size = 128
+    input_size = size - 7
+    input = torch.arange(input_size, dtype=dtype, device=device)
+    output = torch.empty((size, ), dtype=dtype, device=device)
+
+    @triton.jit
+    def kernel(in_ptr, out_ptr, in_size: tl.constexpr, out_size: tl.constexpr, CARE_PADDING: tl.constexpr):
+        offsets = tl.arange(0, out_size)
+        x = GENERATE_TEST_HERE
+        tl.store(out_ptr + offsets, x)
+
+    load_expr = "tl.load(in_ptr + offsets, mask=offsets < in_size, care_padding=CARE_PADDING)"
+    if other is not None:
+        load_expr = f"tl.load(in_ptr + offsets, mask=offsets < in_size, other={other}, care_padding=CARE_PADDING)"
+    patched_kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': load_expr})
+
+    patched_kernel[(1, )](input, output, input_size, size, care_padding)
+
+    torch.testing.assert_close(output[:input_size], input)
+    if other is not None:
+        expected_padding = torch.full((size - input_size, ), other, dtype=dtype, device=device)
+        torch.testing.assert_close(output[input_size:], expected_padding)
+    elif care_padding:
+        expected_padding = torch.zeros((size - input_size, ), dtype=dtype, device=device)
+        torch.testing.assert_close(output[input_size:], expected_padding)
+
+
+@pytest.mark.interpreter
+@pytest.mark.parametrize("dtype", [torch.int32, torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("care_padding", [False, True])
+def test_block_ptr_load_care_padding(dtype, care_padding, device):
+    shape = (8, 8)
+    block_shape = (8, 8)
+    input_shape = (6, 5)
+    input = torch.arange(input_shape[0] * input_shape[1], dtype=dtype, device=device).reshape(input_shape)
+    output = torch.empty(shape, dtype=dtype, device=device)
+
+    @triton.jit
+    def kernel(in_ptr, out_ptr, in_shape0: tl.constexpr, in_shape1: tl.constexpr, block_shape0: tl.constexpr,
+               block_shape1: tl.constexpr, CARE_PADDING: tl.constexpr):
+        in_block_ptr = tl.make_block_ptr(
+            base=in_ptr,
+            shape=(in_shape0, in_shape1),
+            strides=(in_shape1, 1),
+            offsets=(0, 0),
+            block_shape=(block_shape0, block_shape1),
+            order=(1, 0),
+        )
+        x = tl.load(in_block_ptr, boundary_check=(0, 1), care_padding=CARE_PADDING)
+        offsets = tl.arange(0, block_shape0)[:, None] * block_shape1 + tl.arange(0, block_shape1)[None, :]
+        tl.store(out_ptr + offsets, x)
+
+    kernel[(1, )](input, output, input_shape[0], input_shape[1], block_shape[0], block_shape[1], care_padding)
+
+    torch.testing.assert_close(output[:input_shape[0], :input_shape[1]], input)
+    if care_padding:
+        expected = torch.zeros(shape, dtype=dtype, device=device)
+        expected[:input_shape[0], :input_shape[1]] = input
+        torch.testing.assert_close(output, expected)
+
+
 # Testing masked loads with a copy to shared memory.
 # FIXME: Shape too small for ldmatrix when num_ctas=4
 @pytest.mark.interpreter

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1817,7 +1817,7 @@ class _block_ptr:
                           _semantic=_semantic)
 
     def load(self, mask=None, other=None, boundary_check=(), padding_option="", cache_modifier="", eviction_policy="",
-             volatile=False, _semantic=None):
+             volatile=False, care_padding=False, _semantic=None):
         if mask is not None or other is not None:
             raise ValueError("`mask` and `other` arguments cannot be specified for loading block pointers")
 
@@ -1825,6 +1825,7 @@ class _block_ptr:
         cache_modifier = _unwrap_if_constexpr(cache_modifier)
         eviction_policy = _unwrap_if_constexpr(eviction_policy)
         volatile = _unwrap_if_constexpr(volatile)
+        care_padding = _unwrap_if_constexpr(care_padding)
         if padding_option is None:
             padding_option = ""
         ptrs, mask = self._materialize(boundary_check, _semantic=_semantic)
@@ -1841,7 +1842,7 @@ class _block_ptr:
             raise ValueError(f"Padding option {padding_option} not supported")
 
         return load(ptrs, mask=mask, other=generated_other, cache_modifier=cache_modifier,
-                    eviction_policy=eviction_policy, volatile=volatile, _semantic=_semantic)
+                    eviction_policy=eviction_policy, volatile=volatile, care_padding=care_padding, _semantic=_semantic)
 
     def store(self, value, mask=None, boundary_check=(), cache_modifier="", eviction_policy="", _semantic=None):
         if mask is not None:
@@ -2393,7 +2394,7 @@ def dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=None,
 
 @builtin
 def load(pointer, mask=None, other=None, boundary_check=(), padding_option="", cache_modifier="", eviction_policy="",
-         volatile=False, _semantic=None):
+         volatile=False, care_padding=False, _semantic=None):
     """
     Return a tensor of data whose values are loaded from memory at location defined by `pointer`:
 
@@ -2436,11 +2437,16 @@ def load(pointer, mask=None, other=None, boundary_check=(), padding_option="", c
     :type eviction_policy: str, optional
     :param volatile: changes volatile option in NVIDIA PTX
     :type volatile: bool, optional
+    :param care_padding: represents whether user cares about padding value or not, default is False, works as below:
+        1. if 'other' is not None, 'care_padding' takes no effect.
+        2. if 'other' is None and 'care_padding' = True, loaded tensor will fill zeroes on masked places.
+        3. if 'other' is None and 'care_padding' = False, masked places on loaded tensor will be random values.
+    :type care_padding: bool, optional
     """
     if _is_block_ptr(pointer):
         return pointer.load(mask=mask, other=other, boundary_check=boundary_check, padding_option=padding_option,
                             cache_modifier=cache_modifier, eviction_policy=eviction_policy, volatile=volatile,
-                            _semantic=_semantic)
+                            care_padding=care_padding, _semantic=_semantic)
 
     # `mask` and `other` can be constexpr
     mask = _unwrap_if_constexpr(mask)
@@ -2453,8 +2459,9 @@ def load(pointer, mask=None, other=None, boundary_check=(), padding_option="", c
     cache_modifier = _unwrap_if_constexpr(cache_modifier)
     eviction_policy = _unwrap_if_constexpr(eviction_policy)
     volatile = _unwrap_if_constexpr(volatile)
+    care_padding = _unwrap_if_constexpr(care_padding)
     return _semantic.load(pointer, mask, other, boundary_check, padding_option, cache_modifier, eviction_policy,
-                          volatile)
+                          volatile, care_padding)
 
 
 @builtin

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -996,7 +996,8 @@ class TritonSemantic(Generic[TensorTy]):
         return scope
 
     def load(self, ptr: TensorTy, mask: Optional[TensorTy], other: Optional[TensorTy], boundary_check: Tuple,
-             padding_option: str, cache_modifier: str, eviction_policy: str, is_volatile: bool) -> TensorTy:
+             padding_option: str, cache_modifier: str, eviction_policy: str, is_volatile: bool,
+             care_padding: bool) -> TensorTy:
         cache = self._str_to_load_cache_modifier(cache_modifier)
         eviction = self._str_to_eviction_policy(eviction_policy)
         padding = self._str_to_padding_option(padding_option)
@@ -1011,6 +1012,12 @@ class TritonSemantic(Generic[TensorTy]):
                              "pointers or loading a scalar. Because the compiler does not know the boundary; please "
                              "use block pointers (defined by `make_block_ptr`) instead")
 
+        if mask is not None and other is None and care_padding:
+            # Get element type to determine default padding value
+            elt_ty = ptr.type.scalar.element_ty
+            # Use 0.0 for floating point types, 0 for integer types
+            default_value = 0.0 if elt_ty.is_floating() else 0
+            other = self.to_tensor(default_value)
         # For a pointer of scalar, check the type of `mask` and `other`
         if not ptr.type.is_block():
             if mask and mask.type.is_block():


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
Add care_padding control to tl.load

Add a care_padding option to tl.load so callers can choose
whether masked-out lanes need defined padding values when
other is not provided.
# New contributor declaration
- [ x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
