### PR TITLE
[AMD][GFX12] Cache modifiers for buffer and async ops

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4359,7 +4359,7 @@ def test_load_cache_modifier(cache, device):
             if is_hip_cdna():
                 expected_cache_modifiers = {"": "", \
                                             ".ca": "", \
-                                            ".cg": "nt", \
+                                            ".cg": "sc0 nt", \
                                             ".cs": "sc0 nt", \
                                             ".cv": "sc0 sc1"}
             elif is_hip_rdna3():

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4351,6 +4351,9 @@ def test_load_cache_modifier(cache, device):
         global_load_line = [line for line in amdgcn.splitlines() if "global_load" in line]
         compiled_cache_modifiers = "invalid"
         expected_cache_modifiers = {}
+        if is_hip_cdna() or is_hip_cdna2():
+            # cache modifiers are not properly supported on CDNA1 and CDNA2, just check that kernel runs
+            return
         if buffer_load_line:
             # ", [0-9a-z]" matches last operand, which is expected to be constant
             # (offen)? matches an optional flag, the rest is expected to be cache related flags
@@ -4520,6 +4523,9 @@ def test_store_cache_modifier(cache, device):
         global_store_line = [line for line in amdgcn.splitlines() if "global_store" in line]
         compiled_cache_modifiers = "invalid"
         expected_cache_modifiers = {}
+        if is_hip_cdna() or is_hip_cdna2():
+            # cache modifiers are not properly supported on CDNA1 and CDNA2, just check that kernel runs
+            return
         if buffer_store_line:
             # ", [0-9a-z]" matches last operand, which is expected to be constant
             # (offen)? matches an optional flag, the rest is expected to be cache related flags

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4346,24 +4346,65 @@ def test_load_cache_modifier(cache, device):
     pgm = _kernel[(1, )](dst, src, CACHE=cache)
 
     if is_hip():
-        # TODO: support testing for remaining architectures
-        if not is_hip_cdna3() and not is_hip_cdna4():
-            return
         amdgcn = pgm.asm['amdgcn']
-        cg_cache_modifier_str = 'nt'
-        cs_cache_modifier_str = 'sc0 nt'
-        cv_cache_modifier_str = 'sc0 sc1'
         buffer_load_line = [line for line in amdgcn.splitlines() if "buffer_load" in line]
         global_load_line = [line for line in amdgcn.splitlines() if "global_load" in line]
-        load_line = global_load_line[0] if global_load_line else buffer_load_line[0]
-        if cache == '' or cache == '.ca':
-            assert cg_cache_modifier_str not in load_line
-        if cache == '.cg':
-            assert cg_cache_modifier_str in load_line
-        if cache == ".cs":
-            assert cs_cache_modifier_str in load_line
-        if cache == '.cv':
-            assert cv_cache_modifier_str in load_line
+        compiled_cache_modifiers = "invalid"
+        expected_cache_modifiers = {}
+        if buffer_load_line:
+            # ", [0-9a-z]" matches last operand, which is expected to be constant
+            # (offen)? matches an optional flag, the rest is expected to be cache related flags
+            m = re.match(".*, [0-9a-z]* (offen)? *(.*)$", buffer_load_line[0])
+            compiled_cache_modifiers = m.group(2)
+            if is_hip_cdna():
+                expected_cache_modifiers = {"": "", \
+                                            ".ca": "", \
+                                            ".cg": "nt", \
+                                            ".cs": "sc0 nt", \
+                                            ".cv": "sc0 sc1"}
+            elif is_hip_rdna3():
+                expected_cache_modifiers = {"": "", \
+                                            ".ca": "", \
+                                            ".cg": "glc", \
+                                            ".cs": "glc slc dlc", \
+                                            ".cv": "glc slc dlc"}
+            elif is_hip_rdna4() or is_hip_gfx1250():
+                expected_cache_modifiers = {"": "", \
+                                            ".ca": "", \
+                                            ".cg": "scope:SCOPE_DEV", \
+                                            ".cs": "th:TH_LOAD_NT", \
+                                            ".cv": "th:TH_LOAD_BYPASS scope:SCOPE_SYS"}
+        else:
+            assert global_load_line
+            # .*, [0-9a-z\[\]:]* matches last operand
+            # (scale_offset)? optional flag, the reset is expected to be cache flags
+            m = re.match(".*, [0-9a-z\\[\\]:]*( scale_offset)? *(.*)$", global_load_line[0])
+            compiled_cache_modifiers = m.group(2)
+
+            if is_hip_cdna():
+                expected_cache_modifiers = {"": "", \
+                                            ".ca": "", \
+                                            ".cg": "nt", \
+                                            ".cs": "nt", \
+                                            ".cv": "sc0 sc1"}
+            elif is_hip_rdna3():
+                expected_cache_modifiers = {"": "", \
+                                            ".ca": "", \
+                                            ".cg": "slc dlc", \
+                                            ".cs": "slc dlc", \
+                                            ".cv": "glc dlc"}
+            elif is_hip_rdna4() or is_hip_gfx1250():
+                expected_cache_modifiers = {"": "", \
+                                            ".ca": "", \
+                                            ".cg": "th:TH_LOAD_NT", \
+                                            ".cs": "th:TH_LOAD_NT", \
+                                            ".cv": "th:TH_LOAD_NT scope:SCOPE_SYS"}
+        for cache_mod in expected_cache_modifiers:
+            if cache_mod == cache:
+                assert compiled_cache_modifiers == expected_cache_modifiers[cache_mod]
+            else:
+                assert compiled_cache_modifiers != expected_cache_modifiers[cache_mod] or expected_cache_modifiers[
+                    cache_mod] == expected_cache_modifiers[cache]
 
     if is_cuda():
         ptx = pgm.asm['ptx']
@@ -4473,24 +4514,69 @@ def test_store_cache_modifier(cache, device):
     pgm = _kernel[(1, )](dst, src, CACHE=cache)
 
     if is_hip():
-        # TODO: support testing for remaining architectures
-        if not is_hip_cdna3() and not is_hip_cdna4():
-            return
         amdgcn = pgm.asm['amdgcn']
-        cs_cache_modifier_str = 'nt'
-        wt_cache_modifier_str = 'sc0 sc1'
+
         buffer_store_line = [line for line in amdgcn.splitlines() if "buffer_store" in line]
         global_store_line = [line for line in amdgcn.splitlines() if "global_store" in line]
-        store_line = global_store_line[0] if global_store_line else buffer_store_line[0]
-        if cache == '' or cache == '.wb' or cache == '.cg':
-            assert cs_cache_modifier_str not in store_line
-            assert wt_cache_modifier_str not in store_line
-        if cache == '.cs':
-            assert cs_cache_modifier_str in store_line
-            assert wt_cache_modifier_str not in store_line
-        if cache == '.wt':
-            assert cs_cache_modifier_str not in store_line
-            assert wt_cache_modifier_str in store_line
+        compiled_cache_modifiers = "invalid"
+        expected_cache_modifiers = {}
+        if buffer_store_line:
+            # ", [0-9a-z]" matches last operand, which is expected to be constant
+            # (offen)? matches an optional flag, the rest is expected to be cache related flags
+            m = re.match(".*, [0-9a-z]* (offen)? *(.*)$", buffer_store_line[0])
+            compiled_cache_modifiers = m.group(2)
+            if is_hip_cdna():
+                expected_cache_modifiers = {"": "", \
+                                            ".wb": "", \
+                                            ".cg": "", \
+                                            ".cs": "sc0 nt", \
+                                            ".wt": "sc0 sc1"}
+            elif is_hip_rdna3():
+                expected_cache_modifiers = {"": "", \
+                                            ".wb": "", \
+                                            ".cg": "", \
+                                            ".cs": "glc slc dlc", \
+                                            ".wt": "glc slc dlc"}
+            elif is_hip_rdna4() or is_hip_gfx1250():
+                expected_cache_modifiers = {"": "", \
+                                            ".wb": "", \
+                                            ".cg": "scope:SCOPE_DEV", \
+                                            ".cs": "th:TH_STORE_NT"}
+                if is_hip_rdna4():
+                    expected_cache_modifiers[".wt"] = "scope:SCOPE_SYS"
+                elif is_hip_gfx1250():
+                    expected_cache_modifiers[".wt"] = "th:TH_STORE_BYPASS scope:SCOPE_SYS"
+        else:
+            assert global_store_line
+            # .*, [0-9a-z\[\]:]* matches last operand
+            # (scale_offset)? optional flag, the reset is expected to be cache flags
+            m = re.match(".*, [0-9a-z\\[\\]:]*( scale_offset)? *(.*)$", global_store_line[0])
+            compiled_cache_modifiers = m.group(2)
+
+            if is_hip_cdna():
+                expected_cache_modifiers = {"": "", \
+                                            ".wb": "", \
+                                            ".cg": "", \
+                                            ".cs": "nt", \
+                                            ".wt": "sc0 sc1"}
+            elif is_hip_rdna3():
+                expected_cache_modifiers = {"": "", \
+                                            ".wb": "", \
+                                            ".cg": "", \
+                                            ".cs": "glc slc dlc", \
+                                            ".wt": "dlc"}
+            elif is_hip_rdna4() or is_hip_gfx1250():
+                expected_cache_modifiers = {"": "", \
+                                            ".wb": "", \
+                                            ".cg": "", \
+                                            ".cs": "th:TH_STORE_NT", \
+                                            ".wt": "th:TH_STORE_NT scope:SCOPE_SYS"}
+        for cache_mod in expected_cache_modifiers:
+            if cache_mod == cache:
+                assert compiled_cache_modifiers == expected_cache_modifiers[cache_mod]
+            else:
+                assert compiled_cache_modifiers != expected_cache_modifiers[cache_mod] or expected_cache_modifiers[
+                    cache_mod] == expected_cache_modifiers[cache]
 
     if is_cuda():
         ptx = pgm.asm['ptx']

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -94,7 +94,8 @@ def is_hip_rdna3():
 
 def is_hip_rdna4():
     target = get_current_target()
-    return target is not None and target.backend == 'hip' and 'gfx12' in target.arch
+    # check for gfx120 instead of gfx12, to avoid matching gfx1250
+    return target is not None and target.backend == 'hip' and 'gfx120' in target.arch
 
 
 def is_hip_gfx1250():

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1016,9 +1016,6 @@ struct AsyncCopyGlobalToLocalOpConversion
       if (targetInfo.requiresAliasInfoForAsyncOps())
         AMD::addAsyncCopyAliasScope(asyncLoadOp);
     } else if (targetInfo.getISAFamily() == ISAFamily::GFX1250) {
-      if (cacheMod != triton::CacheModifier::NONE) {
-        emitRemark(loc) << "cache modifiers not yet implemented on gfx1250";
-      }
       switch (vecBits) {
       case 32:
         if (multicastMask)
@@ -1157,10 +1154,6 @@ struct AsyncCopyLocalToGlobalOpConversion
     int32_t cacheModifiers =
         mlir::LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(
             cacheMod, /*isLoad=*/false, targetInfo);
-
-    if (cacheMod != triton::CacheModifier::NONE) {
-      emitRemark(loc) << "cache modifiers not yet implemented on gfx1250";
-    }
 
     auto emitStore = [&](int bits, Value dst, Value shmem) {
       std::string intrinsic =

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -558,6 +558,92 @@ static int32_t getCtrlBitsForCacheModifierOnRDNA3(triton::CacheModifier cm,
   return aux;
 }
 
+// Create the auxiliary/cache policy value for GFX12 family
+// ROCDL::RawPtrBufferLoad/StoreOp Vector Memory instructions (Flat, Global,
+// Scratch, and Buffer). These instructions have 2 control bits for scope and 3
+// control bits for temporal hint:
+// - SCOPE[1:0] System Cache level:
+//    0 CU  Coherent among all CU/WG threads in L1 cache
+//    1 SE  Coherent among all clients (threads) sharing a SE-cache(L2)
+//    2 DEV Coherent among all threads on the same device
+//    3 SYS Coherent in system
+// - TH[2:0] Temporal Hint for load:
+//    0 RT    regular temporal for both near and far caches
+//    1 NT    non-temporal (re-use not expected) for both near and far caches
+//    2 HT    High-priority temporal for both near and far caches
+//    3 LU    Last-use (non-temporal AND discard dirty if it hits)
+//    4 NT_RT non-temporal for near cache(s) and regular for far caches
+//    5 RT_NT regular for near cache(s) and non-temporal for far caches
+//    6 NT_HT non-temporal for near cache(s) and high-priority for far caches
+//    7       reserved
+// - TH[2:0] Temporal Hint for store:
+//    0 RT    regular temporal for both near and far caches
+//    1 NT    non-temporal (re-use not expected) for both near and far caches
+//    2 HT    High-priority temporal for both near and far caches
+//    3 WB    Same as "HT", but also overrides wr-rinse in far cache
+//    4 NT_RT non-temporal for near cache(s) and regular for far caches
+//    5 RT_NT regular for near cache(s) and non-temporal for far caches
+//    6 NT_HT non-temporal for near cache(s) and HT for far caches
+//    7 NT_WB non-temporal for near cache(s) and WB for far cache
+//
+// See detailed bit mapping of control bits of CPol enum
+// in llvm source code: llvm/lib/Target/AMDGPU/SIDefines.h
+//
+// Mapping between
+// -------+-----+-------+----+-
+// Op     | cm  | SCOPE | TH |
+// -------+-----+-------+----+-
+// Load   | .ca |  CU   | RT |
+//        | .cg |  DEV  | RT |
+//        | .cs |  CU   | NT |
+//        | .cv |  SYS  | LU | on gfx1250, this combination bypasses all caches
+// -------+-----+-------+----+-
+// Store  | .wb |  CU   | RT |
+//        | .cg |  DEV  | RT |
+//        | .cs |  CU   | NT |
+//        | .wt |  SYS  | RT | behavior for gfx12
+//        | .wt |  SYS  | WB | behavior for gfx1250, bypasses all caches
+// -------+-----+-------+----+-
+static int32_t getCtrlBitsForCacheModifierOn_GFX12(triton::CacheModifier cm,
+                                                   bool isLoad,
+                                                   bool cacheBypassAvailable) {
+  const int scopeShift = 3;
+  const int scopeCU = 0 << scopeShift;
+  const int scopeDev = 2 << scopeShift;
+  const int scopeSys = 3 << scopeShift;
+  const int THRegular = 0;
+  const int THNonTemp = 1;
+  const int THLastUse = 3;
+  const int THWriteBack = 3;
+  int aux = -1;
+  switch (cm) {
+  case triton::CacheModifier::CA:
+    aux = scopeCU | THRegular;
+    break;
+  case triton::CacheModifier::CG:
+    aux = scopeDev | THRegular;
+    break;
+  case triton::CacheModifier::CS:
+    aux = scopeCU | THNonTemp;
+    break;
+  case triton::CacheModifier::CV:
+    assert(isLoad);
+    aux = scopeSys | THLastUse;
+    break;
+  case triton::CacheModifier::WB:
+    assert(!isLoad);
+    aux = scopeCU | THRegular;
+    break;
+  case triton::CacheModifier::WT:
+    assert(!isLoad);
+    aux = scopeSys | (cacheBypassAvailable ? THWriteBack : THRegular);
+    break;
+  default:
+    aux = 0;
+  }
+  return aux;
+}
+
 static int32_t getDefaultCtrlBitsForCacheModifier(triton::CacheModifier cm) {
   return 0;
 }
@@ -578,6 +664,10 @@ int32_t getCtrlBitsForCacheModifierOnTarget(
     return getCtrlBitsForCacheModifierOn_CDNA3_CDNA4(cm, isLoad);
   case triton::AMD::ISAFamily::RDNA3:
     return getCtrlBitsForCacheModifierOnRDNA3(cm, isLoad);
+  case triton::AMD::ISAFamily::RDNA4:
+    return getCtrlBitsForCacheModifierOn_GFX12(cm, isLoad, /*$ bypass*/ false);
+  case triton::AMD::ISAFamily::GFX1250:
+    return getCtrlBitsForCacheModifierOn_GFX12(cm, isLoad, /*$ bypass*/ true);
   default:
     return getDefaultCtrlBitsForCacheModifier(cm);
   }

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -4305,3 +4305,67 @@ def test_runtime_tdm_gather_partial_column_block(N, num_warps, index_dtype):
             ref_out[dst_row] = inp[src_row]
 
     torch.testing.assert_close(out_result, ref_out)
+
+
+@gluon.jit
+def buffer_load_store_roundtrip_kernel(a_ptr, b_ptr, BLOCK: ttgl.constexpr, loadCM: ttgl.constexpr,
+                                       storeCM: ttgl.constexpr):
+    BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout([8], [32], [1], [0])
+    pid = ttgl.program_id(axis=0)
+    offs = pid * BLOCK + ttgl.arange(0, BLOCK, layout=BLOCKED_LAYOUT)
+    data = ttgl.amd.gfx1250.buffer_load(ptr=a_ptr, offsets=offs, cache=loadCM)
+    ttgl.amd.gfx1250.buffer_store(stored_value=data, ptr=b_ptr, offsets=offs, cache=storeCM)
+
+
+@gluon.jit
+def async_load_store_roundtrip_kernel(a_ptr, b_ptr, BLOCK: ttgl.constexpr, loadCM: ttgl.constexpr,
+                                      storeCM: ttgl.constexpr):
+    BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout([8], [32], [1], [0])
+    SHARED_LAYOUT: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK // 2, 8]], [BLOCK], [0])
+    pid = ttgl.program_id(axis=0)
+    offs = pid * BLOCK + ttgl.arange(0, BLOCK, layout=BLOCKED_LAYOUT)
+    buffer = ttgl.allocate_shared_memory(ttgl.float16, shape=[BLOCK], layout=SHARED_LAYOUT)
+    ttgl.amd.gfx1250.async_copy.global_to_shared(buffer, a_ptr + offs, cache_modifier=loadCM)
+    ttgl.amd.gfx1250.async_copy.shared_to_global(b_ptr + offs, buffer, cache_modifier=storeCM)
+
+
+@pytest.mark.parametrize("loadCM, storeCM", [(".ca", ".wb"), (".cg", ".cg"), (".cs", ".cs"), (".cv", ".wt")])
+@pytest.mark.parametrize("test_kernel", [buffer_load_store_roundtrip_kernel, async_load_store_roundtrip_kernel])
+def test_cache_modifier(loadCM, storeCM, test_kernel):
+    BLOCK = 256
+    N = 256
+
+    src = torch.rand((N, ), dtype=torch.float16).cuda()
+    dst = torch.empty((N, ), dtype=torch.float16).cuda()
+    pgm = test_kernel[(triton.cdiv(N, BLOCK), )](src, dst, BLOCK, loadCM, storeCM, num_warps=1)
+
+    torch.testing.assert_close(dst, src)
+
+    amdgcn = pgm.asm["amdgcn"]
+
+    load_found = False
+    store_found = False
+    for line in amdgcn.split("\n"):
+        if "buffer_load_b128" in line or "global_load_async_to_lds_b128" in line:
+            load_found = True
+            if loadCM == ".ca":
+                assert "scope" not in line and "th" not in line
+            if loadCM == ".cg":
+                assert "scope:SCOPE_DEV" in line and "th" not in line
+            if loadCM == ".cs":
+                assert "scope" not in line and "th:TH_LOAD_NT" in line
+            if loadCM == ".cv":
+                assert "scope:SCOPE_SYS" in line and "th:TH_LOAD_BYPASS" in line
+        if "buffer_store_b128" in line or "global_store_async_from_lds_b128" in line:
+            store_found = True
+            if storeCM == ".wb":
+                assert "scope" not in line and "th" not in line
+            if storeCM == ".cg":
+                assert "scope:SCOPE_DEV" in line and "th" not in line
+            if storeCM == "cs":
+                assert "scope" not in line and "th:TH_LOAD_NT" in line
+            if storeCM == ".wt":
+                assert "scope:SCOPE_SYS" in line and "th:TH_STORE_BYPASS" in line
+
+    assert load_found
+    assert store_found


### PR DESCRIPTION
This PR:
- enables generation of cache policy/modifiers in buffer and async operations(loads and stores) on GFX12 architectures. This include RDNA4 and GFX1250 hardware.
- improves cache modifier testing of currently supported architectures
