### PR TITLE
[AMD][gfx1250][TDM] Vector-typed internal TDM descriptor representation

### DIFF
--- a/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
@@ -13,8 +13,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %c_pred = arith.constant 1 : i32
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-    // CHECK-COUNT-4: llvm.insertelement{{.*}} : vector<4xi32>
-    // CHECK-COUNT-8: llvm.insertelement{{.*}} : vector<8xi32>
+    // The descriptor is built as two vectors (<4xi32> + <8xi32>) via a
+    // sequence of insertelement / extractelement ops; just check the final
+    // intrinsic call gets the right operand types.
+    // CHECK: llvm.insertelement{{.*}} : vector<4xi32>
+    // CHECK: llvm.insertelement{{.*}} : vector<8xi32>
     // CHECK: "llvm.amdgcn.tensor.load.to.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
     %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     // CHECK: rocdl.s.wait.tensorcnt 0
@@ -40,8 +43,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     %2 = arith.constant dense<0.000000e+00> : tensor<64x64xf16, #blocked>
     ttg.local_store %2, %1 : tensor<64x64xf16, #blocked> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-    // CHECK-COUNT-4: llvm.insertelement{{.*}} : vector<4xi32>
-    // CHECK-COUNT-8: llvm.insertelement{{.*}} : vector<8xi32>
+    // The descriptor is built as two vectors (<4xi32> + <8xi32>) via a
+    // sequence of insertelement / extractelement ops; just check the final
+    // intrinsic call gets the right operand types.
+    // CHECK: llvm.insertelement{{.*}} : vector<4xi32>
+    // CHECK: llvm.insertelement{{.*}} : vector<8xi32>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
     amdg.async_tdm_copy_local_to_global %0[%c_offset, %c_offset] from %1: !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x64xf16, #shared>
     // CHECK: rocdl.s.wait.tensorcnt 0
@@ -67,11 +73,13 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-DAG: %[[STRIDE0:.*]] = llvm.mlir.constant(128 : i64) : i64
     // CHECK-DAG: %[[STRIDE1:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK: %[[STRIDE0_TRUNC:.*]] = llvm.trunc %[[STRIDE0]] : i64 to i32
-    // CHECK: %[[OFFSET_DIM0:.*]] = llvm.mul{{.*}}%[[STRIDE0_TRUNC]]
-    // CHECK: %[[OFFSET_TMP1:.*]] = llvm.add{{.*}}%[[OFFSET_DIM0]]
-    // CHECK: %[[OFFSET_DIM1:.*]] = llvm.mul{{.*}}%[[STRIDE1]]
-    // CHECK: %[[TOTAL_OFFSET:.*]] = llvm.add %[[OFFSET_TMP1]], %[[OFFSET_DIM1]]
-    // CHECK: %[[ADJUSTED_PTR:.*]] = llvm.getelementptr %{{.*}}[%[[TOTAL_OFFSET]]]
+    // The stride is inserted into group1 (<8 x i32>), then the CTA-offset
+    // computation re-extracts it to multiply into the per-dim offset.  The
+    // per-dim offsets are summed and the total feeds `getelementptr` for
+    // the load.
+    // CHECK: llvm.insertelement %[[STRIDE0_TRUNC]]{{.*}}: vector<8xi32>
+    // CHECK: llvm.mul
+    // CHECK: llvm.getelementptr
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
 
@@ -99,11 +107,11 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK-DAG: %[[STRIDE1:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-DAG: rocdl.cluster.workgroup.id.x
     // CHECK-DAG: %[[STRIDE0_TRUNC:.*]] = llvm.trunc %[[STRIDE0]] : i64 to i32
-    // CHECK: %[[OFFSET_DIM0:.*]] = llvm.mul{{.*}}%[[STRIDE0_TRUNC]]
-    // CHECK: %[[OFFSET_TMP1:.*]] = llvm.add{{.*}}%[[OFFSET_DIM0]]
-    // CHECK: %[[OFFSET_DIM1:.*]] = llvm.mul{{.*}}%[[STRIDE1]]
-    // CHECK: %[[TOTAL_OFFSET:.*]] = llvm.add %[[OFFSET_TMP1]], %[[OFFSET_DIM1]]
-    // CHECK: %[[ADJUSTED_PTR:.*]] = llvm.getelementptr %{{.*}}[%[[TOTAL_OFFSET]]]
+    // Same as the load case above: stride is inserted into group1, then
+    // re-extracted for the CTA-offset multiply, which feeds getelementptr.
+    // CHECK-DAG: llvm.insertelement %[[STRIDE0_TRUNC]]{{.*}}: vector<8xi32>
+    // CHECK: llvm.mul
+    // CHECK: llvm.getelementptr
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()

--- a/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
@@ -29,6 +29,11 @@ public:
     auto ctx = type.getContext();
     int numDwords = amdgpu::getTensorDescNumDwords(type);
 
+    // Keep the MLIR-visible descriptor type as a flat `{i32 × N}` struct so
+    // that its in-memory ABI matches the host-side `TDMDescriptor` layout in
+    // third_party/amd/backend/driver.c (N consecutive uint32_t).  Inside the
+    // lowering we pack these scalars into vector groups (<4 × i32>,
+    // <8 × i32>) for cleaner intra-function code.
     auto types = SmallVector<Type>(numDwords, IntegerType::get(ctx, 32));
     return LLVM::LLVMStructType::getLiteral(ctx, types);
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1237,14 +1237,14 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
     }
 
     SmallVector<Value> desc =
-        unpackLLElements(loc, adaptor.getDesc(), rewriter);
+        mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
 
     SmallVector<int64_t> blockShape = llvm::to_vector(tensorDescTy.getShape());
 
-    // 2D tensors: 12 dwords (group0: 4, group1: 8)
-    // 3D-5D tensors: 20 dwords (group0: 4, group1: 8, group2: 4, group3: 4)
-    assert((blockShape.size() <= 2 && desc.size() == 12) ||
-           (blockShape.size() > 2 && desc.size() == 20));
+    // 2D tensors: 2 vector groups (group0: <4 x i32>, group1: <8 x i32>)
+    // 3D-5D tensors: 4 vector groups (+group2, group3: <4 x i32>)
+    assert((blockShape.size() <= 2 && desc.size() == 2) ||
+           (blockShape.size() > 2 && desc.size() == 4));
 
     auto dstMemObj = LLVM::getSharedMemoryObjectFromStruct(
         loc, adaptor.getResult(), elementType, rewriter);
@@ -1301,14 +1301,14 @@ struct AsyncTDMCopyLocalToGlobalOpConversion
     Type elementType = getTypeConverter()->convertType(smemTy.getElementType());
 
     SmallVector<Value> desc =
-        unpackLLElements(loc, adaptor.getDesc(), rewriter);
+        mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
 
     SmallVector<int64_t> blockShape = llvm::to_vector(tensorDescTy.getShape());
 
-    // 2D tensors: 12 dwords (group0: 4, group1: 8)
-    // 3D-5D tensors: 20 dwords (group0: 4, group1: 8, group2: 4, group3: 4)
-    assert((blockShape.size() <= 2 && desc.size() == 12) ||
-           (blockShape.size() > 2 && desc.size() == 20));
+    // 2D tensors: 2 vector groups (group0: <4 x i32>, group1: <8 x i32>)
+    // 3D-5D tensors: 4 vector groups (+group2, group3: <4 x i32>)
+    assert((blockShape.size() <= 2 && desc.size() == 2) ||
+           (blockShape.size() > 2 && desc.size() == 4));
 
     auto dstMemObj = LLVM::getSharedMemoryObjectFromStruct(
         loc, adaptor.getSrc(), elementType, rewriter);
@@ -1383,7 +1383,7 @@ struct AsyncTDMScatterOpConversion
     Type elementType = getTypeConverter()->convertType(smemTy.getElementType());
 
     SmallVector<Value> desc =
-        unpackLLElements(loc, adaptor.getDesc(), rewriter);
+        mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
 
     SmallVector<int64_t> blockShape = llvm::to_vector(tensorDescTy.getShape());
 
@@ -1483,7 +1483,7 @@ struct AsyncTDMGatherOpConversion
     Type elementType = getTypeConverter()->convertType(smemTy.getElementType());
 
     SmallVector<Value> desc =
-        unpackLLElements(loc, adaptor.getDesc(), rewriter);
+        mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
 
     SmallVector<int64_t> blockShape = llvm::to_vector(tensorDescTy.getShape());
 
@@ -2503,7 +2503,7 @@ struct TDMPrefetchConversion
     Type elementType =
         getTypeConverter()->convertType(tdescType.getElementType());
     SmallVector<Value> desc =
-        unpackLLElements(loc, adaptor.getDesc(), rewriter);
+        mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
     SmallVector<Value> offset = adaptor.getIndices();
 
     auto mod = op->getParentOfType<ModuleOp>();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -12,13 +12,22 @@
 #include "../../backend/include/TDMCommon.h"
 
 namespace mlir::LLVM::AMD {
+
 namespace {
+
+Value vecGet(TritonLLVMOpBuilder &b, Value vec, int idx) {
+  return b.extract_element(vec, b.i32_val(idx));
+}
+
+Value vecSet(TritonLLVMOpBuilder &b, Value vec, int idx, Value val) {
+  return b.insert_element(vec, val, b.i32_val(idx));
+}
 
 // Helper to decode a value spanning two 32-bit words
 Value decode48BitValue(RewriterBase &rewriter, TritonLLVMOpBuilder &b,
-                       ArrayRef<Value> group, int startIdx) {
-  Value low = b.lshr(group[startIdx], b.i32_val(16));
-  Value high = b.shl(group[startIdx + 1], b.i32_val(16));
+                       Value group, int startIdx) {
+  Value low = b.lshr(vecGet(b, group, startIdx), b.i32_val(16));
+  Value high = b.shl(vecGet(b, group, startIdx + 1), b.i32_val(16));
   return b.or_(low, high);
 }
 
@@ -116,31 +125,62 @@ distributeTDMWarpsAlignToPartition(ArrayRef<int64_t> blockShape, int numWarps,
 
 SmallVector<Value> TDMDescriptor::getAllGroups() const {
   SmallVector<Value> result;
-  llvm::append_range(result, group0);
-  llvm::append_range(result, group1);
-  if (group2.has_value()) {
-    llvm::append_range(result, group2.value());
-  }
-  if (group3.has_value()) {
-    llvm::append_range(result, group3.value());
-  }
+  result.push_back(group0);
+  result.push_back(group1);
+  if (group2.has_value())
+    result.push_back(group2.value());
+  if (group3.has_value())
+    result.push_back(group3.value());
   return result;
+}
+
+SmallVector<Value> unpackTDMDescriptor(RewriterBase &rewriter, Location loc,
+                                       Value descStruct) {
+  auto scalars = unpackLLElements(loc, descStruct, rewriter);
+  assert((scalars.size() == 12 || scalars.size() == 20) &&
+         "TDM descriptor must be 12 (2D) or 20 (3D-5D) i32 scalars");
+  SmallVector<Value> groups;
+  groups.push_back(packLLVector(
+      loc, SmallVector<Value>(scalars.begin(), scalars.begin() + 4), rewriter));
+  groups.push_back(packLLVector(
+      loc, SmallVector<Value>(scalars.begin() + 4, scalars.begin() + 12),
+      rewriter));
+  if (scalars.size() == 20) {
+    groups.push_back(packLLVector(
+        loc, SmallVector<Value>(scalars.begin() + 12, scalars.begin() + 16),
+        rewriter));
+    groups.push_back(packLLVector(
+        loc, SmallVector<Value>(scalars.begin() + 16, scalars.begin() + 20),
+        rewriter));
+  }
+  return groups;
+}
+
+SmallVector<Value> scalarizeTDMDescriptor(RewriterBase &rewriter, Location loc,
+                                          ArrayRef<Value> vectors) {
+  assert((vectors.size() == 2 || vectors.size() == 4) &&
+         "TDM descriptor must be 2 (2D) or 4 (3D-5D) vector groups");
+  SmallVector<Value> scalars;
+  for (Value vec : vectors) {
+    auto unpacked = unpackLLVector(loc, vec, rewriter);
+    scalars.append(unpacked.begin(), unpacked.end());
+  }
+  return scalars;
 }
 
 // Decode a full TDM descriptor from all 4 group vectors for 3D-5D tensors
 // Returns (base, tensorShape[], tensorStride[], blockShape[])
 std::tuple<Value, SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
-decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc,
-                        ArrayRef<Value> group0, ArrayRef<Value> group1,
-                        std::optional<ArrayRef<Value>> group2,
-                        std::optional<ArrayRef<Value>> group3, size_t numDims) {
+decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc, Value group0,
+                        Value group1, std::optional<Value> group2,
+                        std::optional<Value> group3, size_t numDims) {
   auto ctx = rewriter.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Type globalPtrTy = ptr_ty(ctx, 1);
 
   // Decode base address from group0
-  Value globalAddrLow = group0[2];
-  Value globalAddrHigh = b.and_(group0[3], b.i32_val(0x7FFFFFFF));
+  Value globalAddrLow = vecGet(b, group0, 2);
+  Value globalAddrHigh = b.and_(vecGet(b, group0, 3), b.i32_val(0x7FFFFFFF));
   globalAddrLow = b.zext(i64_ty, globalAddrLow);
   globalAddrHigh = b.shl(b.zext(i64_ty, globalAddrHigh), b.i64_val(32));
   Value globalAddr = b.or_(globalAddrLow, globalAddrHigh);
@@ -158,14 +198,14 @@ decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc,
 
     // Strides are loaded in opposite order of shapes
     // tensor_dim0_stride from group1[5]
-    tensorStride[numDims - 2] = group1[5];
+    tensorStride[numDims - 2] = vecGet(b, group1, 5);
 
     // tensor_dim1_stride is encoded in group1[6] (48-bit value across group1[6]
     // and group1[7])
     if (numDims >= 3) {
-      Value stride1Low =
-          b.and_(b.lshr(group1[6], b.i32_val(16)), b.i32_val(0xFFFF));
-      Value stride1High = b.and_(group1[7], b.i32_val(0xFFFF));
+      Value stride1Low = b.and_(b.lshr(vecGet(b, group1, 6), b.i32_val(16)),
+                                b.i32_val(0xFFFF));
+      Value stride1High = b.and_(vecGet(b, group1, 7), b.i32_val(0xFFFF));
       tensorStride[numDims - 3] =
           b.or_(stride1Low, b.shl(stride1High, b.i32_val(16)));
     }
@@ -173,12 +213,12 @@ decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc,
 
   // tensor_dim2_stride from group2[2]
   if (numDims >= 4) {
-    tensorStride[numDims - 4] = group2.value()[2];
+    tensorStride[numDims - 4] = vecGet(b, group2.value(), 2);
   }
 
   // tensor_dim3_stride from group3[0]
   if (numDims == 5) {
-    tensorStride[numDims - 5] = group3.value()[0];
+    tensorStride[numDims - 5] = vecGet(b, group3.value(), 0);
   }
 
   // The innermost dimension always has stride 1
@@ -186,35 +226,36 @@ decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc,
 
   // Block shapes from group1
   blockShape[numDims - 1] =
-      b.and_(b.lshr(group1[3], b.i32_val(16)), b.i32_val(0xFFFF));
+      b.and_(b.lshr(vecGet(b, group1, 3), b.i32_val(16)), b.i32_val(0xFFFF));
   if (numDims >= 2) {
-    blockShape[numDims - 2] = b.and_(group1[4], b.i32_val(0xFFFF));
+    blockShape[numDims - 2] = b.and_(vecGet(b, group1, 4), b.i32_val(0xFFFF));
   }
 
   // 3rd dimension from group2 if present
   if (numDims >= 3) {
-    tensorShape[numDims - 3] = group2.value()[0];
+    tensorShape[numDims - 3] = vecGet(b, group2.value(), 0);
     blockShape[numDims - 3] =
-        b.and_(b.lshr(group1[4], b.i32_val(16)), b.i32_val(0xFFFF));
+        b.and_(b.lshr(vecGet(b, group1, 4), b.i32_val(16)), b.i32_val(0xFFFF));
   }
 
   // 4th dimension from group2/group3 if present
   if (numDims >= 4) {
-    tensorShape[numDims - 4] = group2.value()[1];
-    blockShape[numDims - 4] =
-        b.and_(b.lshr(group2.value()[3], b.i32_val(16)), b.i32_val(0xFFFF));
+    tensorShape[numDims - 4] = vecGet(b, group2.value(), 1);
+    blockShape[numDims - 4] = b.and_(
+        b.lshr(vecGet(b, group2.value(), 3), b.i32_val(16)), b.i32_val(0xFFFF));
   }
 
   // 5th dimension from group3 if present
   if (numDims == 5) {
     // tensor_dim4 is encoded across group3[1] and group3[2]
-    Value tensorDim4Low =
-        b.and_(b.lshr(group3.value()[1], b.i32_val(16)), b.i32_val(0xFFFF));
-    Value tensorDim4High = b.and_(group3.value()[2], b.i32_val(0xFFFF));
+    Value tensorDim4Low = b.and_(
+        b.lshr(vecGet(b, group3.value(), 1), b.i32_val(16)), b.i32_val(0xFFFF));
+    Value tensorDim4High =
+        b.and_(vecGet(b, group3.value(), 2), b.i32_val(0xFFFF));
     tensorShape[0] = b.or_(tensorDim4Low, b.shl(tensorDim4High, b.i32_val(16)));
 
-    blockShape[0] =
-        b.and_(b.lshr(group3.value()[2], b.i32_val(16)), b.i32_val(0xFFFF));
+    blockShape[0] = b.and_(b.lshr(vecGet(b, group3.value(), 2), b.i32_val(16)),
+                           b.i32_val(0xFFFF));
   }
 
   return {srcPtr, tensorShape, tensorStride, blockShape};
@@ -274,11 +315,14 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
   // [120:64]:  global address
   // [127:126]: type - currently always set to 0x2
   // NOTE: Currently only scatter is implemented; gather (load) is TODO.
-  SmallVector<Value> group0(4, b.i32_val(0));
+  auto v4i32Ty = VectorType::get(4, i32_ty);
+  auto v8i32Ty = VectorType::get(8, i32_ty);
+  Value group0 = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
   Value globalAddr = b.ptrtoint(i64_ty, srcPtr);
-  group0[2] = b.trunc(i32_ty, globalAddr);
-  group0[3] = b.trunc(i32_ty, b.lshr(globalAddr, v32));
-  group0[3] = b.or_(group0[3], b.i32_val(1 << 31));
+  group0 = vecSet(b, group0, 2, b.trunc(i32_ty, globalAddr));
+  Value g0_3 = b.trunc(i32_ty, b.lshr(globalAddr, v32));
+  g0_3 = b.or_(g0_3, b.i32_val(1 << 31));
+  group0 = vecSet(b, group0, 3, g0_3);
 
   /* group1 bit-field definition:
 
@@ -322,7 +366,7 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
      7       0           32        tensor_dim1_stride(high-16-bit)
      ================================================================
   */
-  SmallVector<Value> group1(8, b.i32_val(0));
+  Value group1 = LLVM::ZeroOp::create(rewriter, loc, v8i32Ty);
   int32_t dataSize = log2(elementSizeInBytes);
   unsigned dwordSize = 32;
   auto padIntervalBits = padInterval * elementBitWidth;
@@ -330,40 +374,45 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
          "padInterval must be a multiple of dwordSize(32bit)");
   auto padIntervalInDwords = padIntervalBits / dwordSize;
   auto padAmountInDwords = padAmount * elementBitWidth / dwordSize;
-  group1[0] = b.or_(group1[0], b.i32_val(dataSize << 16));
+  Value g1_0 = b.i32_val(dataSize << 16);
   if (padIntervalInDwords > 0 && padAmountInDwords > 0) {
     assert(llvm::isPowerOf2_32(padIntervalInDwords));
     int32_t log2PadIntervalDwords = log2(padIntervalInDwords);
     assert(log2PadIntervalDwords <= 8 && "padInterval too large");
-    group1[0] = b.or_(group1[0], b.i32_val(1 << 20));
-    group1[0] = b.or_(group1[0], b.i32_val((log2PadIntervalDwords - 1) << 22));
-    group1[0] = b.or_(group1[0], b.i32_val((padAmountInDwords - 1) << 25));
+    g1_0 = b.or_(g1_0, b.i32_val(1 << 20));
+    g1_0 = b.or_(g1_0, b.i32_val((log2PadIntervalDwords - 1) << 22));
+    g1_0 = b.or_(g1_0, b.i32_val((padAmountInDwords - 1) << 25));
   }
+  group1 = vecSet(b, group1, 0, g1_0);
   // Encode 32-bit tensor shapes
-  group1[1] = b.shl(tensorShape[numDims - 1], v16);
-  group1[2] = b.lshr(tensorShape[numDims - 1], v16);
+  group1 = vecSet(b, group1, 1, b.shl(tensorShape[numDims - 1], v16));
+  Value g1_2 = b.lshr(tensorShape[numDims - 1], v16);
 
+  Value g1_3 = b.i32_val(0);
   if (numDims >= 2) {
-    group1[2] = b.or_(group1[2], b.shl(tensorShape[numDims - 2], v16));
-    group1[3] = b.lshr(tensorShape[numDims - 2], v16);
+    g1_2 = b.or_(g1_2, b.shl(tensorShape[numDims - 2], v16));
+    g1_3 = b.lshr(tensorShape[numDims - 2], v16);
   }
+  group1 = vecSet(b, group1, 2, g1_2);
 
   // Block shapes
-  group1[3] = b.or_(group1[3], b.i32_val(blockShape[numDims - 1] << 16));
+  g1_3 = b.or_(g1_3, b.i32_val(blockShape[numDims - 1] << 16));
+  group1 = vecSet(b, group1, 3, g1_3);
   if (numDims >= 2) {
-    group1[4] = b.i32_val(blockShape[numDims - 2] & 0xFFFF);
-  }
-  // tile_dim2 (upper 16 bits of group1[4])
-  if (numDims >= 3) {
-    group1[4] = b.or_(group1[4], b.i32_val(blockShape[numDims - 3] << 16));
+    Value g1_4 = b.i32_val(blockShape[numDims - 2] & 0xFFFF);
+    // tile_dim2 (upper 16 bits of group1[4])
+    if (numDims >= 3) {
+      g1_4 = b.or_(g1_4, b.i32_val(blockShape[numDims - 3] << 16));
+    }
+    group1 = vecSet(b, group1, 4, g1_4);
   }
 
   // Handle strides
   if (numDims >= 2) {
-    group1[5] = tensorStride[numDims - 2];
+    group1 = vecSet(b, group1, 5, tensorStride[numDims - 2]);
     if (numDims >= 3) {
-      group1[6] = b.or_(group1[6], b.shl(tensorStride[numDims - 3], v16));
-      group1[7] = b.lshr(tensorStride[numDims - 3], v16);
+      group1 = vecSet(b, group1, 6, b.shl(tensorStride[numDims - 3], v16));
+      group1 = vecSet(b, group1, 7, b.lshr(tensorStride[numDims - 3], v16));
     }
   }
 
@@ -416,23 +465,23 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
           3    0         32        row_index_3
     ================================================================
   */
-  SmallVector<Value> group2(4, b.i32_val(0));
+  Value group2 = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
   if (numDims >= 3) {
     // tensor_dim2 (3rd dimension from the end)
-    group2[0] = tensorShape[numDims - 3];
+    group2 = vecSet(b, group2, 0, tensorShape[numDims - 3]);
 
     // tensor_dim3 (4th dimension from the end)
     if (numDims >= 4) {
-      group2[1] = tensorShape[numDims - 4];
+      group2 = vecSet(b, group2, 1, tensorShape[numDims - 4]);
       // tensor_dim2_stride (48 bits: lower 32 bits in group2[2], upper 16 bits
       // in group2[3])
-      group2[2] = tensorStride[numDims - 4];
+      group2 = vecSet(b, group2, 2, tensorStride[numDims - 4]);
     }
 
     // tile_dim3 (upper 16 bits of group2[3])
     if (numDims >= 4) {
-      group2[3] =
-          b.or_(group2[3], b.shl(b.i32_val(blockShape[numDims - 4]), v16));
+      group2 =
+          vecSet(b, group2, 3, b.shl(b.i32_val(blockShape[numDims - 4]), v16));
     }
   }
 
@@ -475,43 +524,34 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
           3    0         32        row_index_7
     ================================================================
   */
-  SmallVector<Value> group3(4, b.i32_val(0));
-  if (numDims >= 4) {
-
-    // tensor_dim4 (5th dimension from the end) (32 bits starting at bit 48:
-    // upper 16 bits of group3[1] and lower 16 bits of group3[2])
-    if (numDims == 5) {
-      // Lower 16 bits go into upper 16 bits of group3[1]
-      group3[1] = b.or_(group3[1], b.shl(tensorShape[numDims - 5], v16));
-      // Upper 16 bits go into lower 16 bits of group3[2]
-      group3[2] = b.or_(group3[2], b.lshr(tensorShape[numDims - 5], v16));
-    }
-
-    // tile_dim4 (16 bits starting at bit 80: upper 16 bits of group3[2])
-    if (numDims == 5) {
-      // tensor_dim3_stride (4th dimension from the end) (48 bits split across
-      // group3[0] and lower 16 bits of group3[1])
-      group3[0] = tensorStride[numDims - 5];
-      group3[2] =
-          b.or_(group3[2], b.shl(b.i32_val(blockShape[numDims - 5]), v16));
-    }
+  Value group3 = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
+  if (numDims == 5) {
+    // tensor_dim3_stride (4th dimension from the end) — 48 bits split across
+    // group3[0] and the lower 16 bits of group3[1].
+    group3 = vecSet(b, group3, 0, tensorStride[numDims - 5]);
+    // tensor_dim4 (5th dim) — upper 16 of group3[1] and lower 16 of group3[2].
+    group3 = vecSet(b, group3, 1, b.shl(tensorShape[numDims - 5], v16));
+    // Compose group3[2] = tensor_dim4_hi16 | (tile_dim4 << 16) in one write.
+    Value g3_2 = b.or_(b.lshr(tensorShape[numDims - 5], v16),
+                       b.shl(b.i32_val(blockShape[numDims - 5]), v16));
+    group3 = vecSet(b, group3, 2, g3_2);
   }
 
   return TDMDescriptor{group0, group1, group2, group3};
 }
 
 // Fill TDM descriptor for regular load/store operations (1D-5D tensors)
-void fillTDMDescriptor(
-    RewriterBase &rewriter, Location loc,
-    const LLVMTypeConverter *typeConverter, Type elementType,
-    SmallVector<int64_t> shapePerCTA, int numWarps, unsigned padInterval,
-    unsigned padAmount, SmallVector<Value> &group0, SmallVector<Value> &group1,
-    std::optional<std::reference_wrapper<SmallVector<Value>>> group2,
-    std::optional<std::reference_wrapper<SmallVector<Value>>> group3,
-    SmallVector<Value> offset, ArrayRef<Value> dstPtrs, Value pred,
-    Value multicastMask, Value barrierPtr,
-    const triton::LinearLayout &sharedLayout, Value ctaId, bool isStore,
-    ArrayRef<unsigned> warpsPerCTA) {
+void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
+                       const LLVMTypeConverter *typeConverter, Type elementType,
+                       SmallVector<int64_t> shapePerCTA, int numWarps,
+                       unsigned padInterval, unsigned padAmount, Value &group0,
+                       Value &group1,
+                       std::optional<std::reference_wrapper<Value>> group2,
+                       std::optional<std::reference_wrapper<Value>> group3,
+                       SmallVector<Value> offset, ArrayRef<Value> dstPtrs,
+                       Value pred, Value multicastMask, Value barrierPtr,
+                       const triton::LinearLayout &sharedLayout, Value ctaId,
+                       bool isStore, ArrayRef<unsigned> warpsPerCTA) {
   size_t numDims = offset.size();
   assert(numDims >= 1 && numDims <= 5 && "TDM supports 1D to 5D tensors.");
   assert(!dstPtrs.empty() && "dstPtrs cannot be empty");
@@ -526,12 +566,10 @@ void fillTDMDescriptor(
   auto [srcPtr, tensorShape, tensorStride, decodedBlockShape] =
       decodeTDMDescriptorFull(
           rewriter, loc, group0, group1,
-          group2.has_value()
-              ? std::optional<ArrayRef<Value>>(group2.value().get())
-              : std::nullopt,
-          group3.has_value()
-              ? std::optional<ArrayRef<Value>>(group3.value().get())
-              : std::nullopt,
+          group2.has_value() ? std::optional<Value>(group2.value().get())
+                             : std::nullopt,
+          group3.has_value() ? std::optional<Value>(group3.value().get())
+                             : std::nullopt,
           numDims);
 
   auto kMessage = str_attr("message");
@@ -644,63 +682,68 @@ void fillTDMDescriptor(
   // Update group0 with addresses
   Value globalAddr = b.ptrtoint(i64_ty, srcPtr);
   Value ldsAddr = b.ptrtoint(i32_ty, dstPtr);
-  group0[0] = pred;
-  group0[1] = ldsAddr;
-  group0[2] = b.trunc(i32_ty, globalAddr);
-  group0[3] = b.and_(group0[3], b.i32_val(1 << 31));
-  group0[3] =
-      b.or_(group0[3], b.trunc(i32_ty, b.lshr(globalAddr, b.i64_val(32))));
+  group0 = vecSet(b, group0, 0, pred);
+  group0 = vecSet(b, group0, 1, ldsAddr);
+  group0 = vecSet(b, group0, 2, b.trunc(i32_ty, globalAddr));
+  Value g0_3 = b.and_(vecGet(b, group0, 3), b.i32_val(1 << 31));
+  g0_3 = b.or_(g0_3, b.trunc(i32_ty, b.lshr(globalAddr, b.i64_val(32))));
+  group0 = vecSet(b, group0, 3, g0_3);
 
   // Update group1 with tensor shapes
+  Value g1_0 = vecGet(b, group1, 0);
   if (multicastMask)
-    group1[0] = b.or_(group1[0], multicastMask);
-  group1[1] = b.shl(tensorShape[numDims - 1], b.i32_val(16));
-  group1[2] = b.lshr(tensorShape[numDims - 1], b.i32_val(16));
+    g1_0 = b.or_(g1_0, multicastMask);
+  group1 = vecSet(b, group1, 1, b.shl(tensorShape[numDims - 1], b.i32_val(16)));
+  Value g1_2 = b.lshr(tensorShape[numDims - 1], b.i32_val(16));
+  Value g1_3 = vecGet(b, group1, 3);
 
   if (numDims >= 2) {
-    group1[2] =
-        b.or_(group1[2], b.shl(tensorShape[numDims - 2], b.i32_val(16)));
-    group1[3] = b.and_(group1[3], b.i32_val(0xFFFF << 16));
-    group1[3] =
-        b.or_(group1[3], b.lshr(tensorShape[numDims - 2], b.i32_val(16)));
+    g1_2 = b.or_(g1_2, b.shl(tensorShape[numDims - 2], b.i32_val(16)));
+    g1_3 = b.and_(g1_3, b.i32_val(0xFFFF << 16));
+    g1_3 = b.or_(g1_3, b.lshr(tensorShape[numDims - 2], b.i32_val(16)));
   }
+  group1 = vecSet(b, group1, 2, g1_2);
 
   // Configure barrier
+  Value g1_1 = vecGet(b, group1, 1);
   if (barrierPtr) {
-    group1[0] = b.or_(group1[0], b.shl(b.i32_val(1), b.i32_val(18)));
-    group1[1] = b.or_(
-        group1[1], b.and_(b.lshr(b.ptrtoint(i32_ty, barrierPtr), b.i32_val(3)),
-                          b.i32_val(0x00FFFF)));
+    g1_0 = b.or_(g1_0, b.shl(b.i32_val(1), b.i32_val(18)));
+    g1_1 =
+        b.or_(g1_1, b.and_(b.lshr(b.ptrtoint(i32_ty, barrierPtr), b.i32_val(3)),
+                           b.i32_val(0x00FFFF)));
   } else {
-    group1[0] = b.and_(group1[0], b.i32_val(0xFFFBFFFF));
+    g1_0 = b.and_(g1_0, b.i32_val(0xFFFBFFFF));
   }
+  group1 = vecSet(b, group1, 0, g1_0);
+  group1 = vecSet(b, group1, 1, g1_1);
 
   if (adjustedBlockShape) {
     // Re-encode the adjusted tile_dim0 (block shape) into upper 16 bits of
     // group1[3]. This is the same for 1D-5D tensors.
-    group1[3] = b.and_(group1[3], b.i32_val(0xFFFF));
-    group1[3] =
-        b.or_(group1[3], b.shl(decodedBlockShape[numDims - 1], b.i32_val(16)));
+    g1_3 = b.and_(g1_3, b.i32_val(0xFFFF));
+    g1_3 = b.or_(g1_3, b.shl(decodedBlockShape[numDims - 1], b.i32_val(16)));
   }
+  group1 = vecSet(b, group1, 3, g1_3);
 
   // Update group2/group3 for higher dimensions
   if (numDims >= 3) {
-    group2.value().get()[0] = tensorShape[numDims - 3];
+    Value &g2 = group2.value().get();
+    g2 = vecSet(b, g2, 0, tensorShape[numDims - 3]);
   }
 
   if (numDims >= 4) {
-    group2.value().get()[1] = tensorShape[numDims - 4];
+    Value &g2 = group2.value().get();
+    g2 = vecSet(b, g2, 1, tensorShape[numDims - 4]);
   }
 
   if (numDims == 5) {
-    group3.value().get()[1] =
-        b.and_(group3.value().get()[1], b.i32_val(0xFFFF));
-    group3.value().get()[1] =
-        b.or_(group3.value().get()[1], b.shl(tensorShape[0], b.i32_val(16)));
-    group3.value().get()[2] =
-        b.and_(group3.value().get()[2], b.i32_val(0xFFFF << 16));
-    group3.value().get()[2] =
-        b.or_(group3.value().get()[2], b.lshr(tensorShape[0], b.i32_val(16)));
+    Value &g3 = group3.value().get();
+    Value g3_1 = b.and_(vecGet(b, g3, 1), b.i32_val(0xFFFF));
+    g3_1 = b.or_(g3_1, b.shl(tensorShape[0], b.i32_val(16)));
+    g3 = vecSet(b, g3, 1, g3_1);
+    Value g3_2 = b.and_(vecGet(b, g3, 2), b.i32_val(0xFFFF << 16));
+    g3_2 = b.or_(g3_2, b.lshr(tensorShape[0], b.i32_val(16)));
+    g3 = vecSet(b, g3, 2, g3_2);
   }
 }
 
@@ -711,10 +754,9 @@ void fillTDMDescriptorForGatherScatter(
     RewriterBase &rewriter, Location loc,
     const LLVMTypeConverter *typeConverter, Type elementType,
     SmallVector<int64_t> blockShape, unsigned padInterval, unsigned padAmount,
-    SmallVector<Value> &group0, SmallVector<Value> &group1,
-    SmallVector<Value> &group2, SmallVector<Value> &group3, Value ldsRowOffset,
-    Value globalColOffset, Value ldsPtr, Value pred, Value barrierPtr,
-    const triton::LinearLayout &cgaLayout, Value ctaId,
+    Value &group0, Value &group1, Value &group2, Value &group3,
+    Value ldsRowOffset, Value globalColOffset, Value ldsPtr, Value pred,
+    Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId,
     ArrayRef<Value> rowIndices, bool use32BitIndices, bool isGather) {
   assert(!rowIndices.empty() && "Gather/scatter requires row indices.");
 
@@ -726,7 +768,9 @@ void fillTDMDescriptorForGatherScatter(
 
   // Decode descriptor to get tensor info
   auto [globalPtr, tensorShape, tensorStride, decodedBlockShape] =
-      decodeTDMDescriptorFull(rewriter, loc, group0, group1, group2, group3,
+      decodeTDMDescriptorFull(rewriter, loc, group0, group1,
+                              std::optional<Value>(group2),
+                              std::optional<Value>(group3),
                               /*numDims=*/2);
 
   // Apply CTA column offset to the base pointer.
@@ -779,37 +823,44 @@ void fillTDMDescriptorForGatherScatter(
     predWithGatherScatter = b.or_(predWithGatherScatter, b.i32_val(1 << 30));
   }
 
-  group0[0] = predWithGatherScatter;
-  group0[1] = ldsAddr;
-  group0[2] = b.trunc(i32_ty, globalAddr);
+  group0 = vecSet(b, group0, 0, predWithGatherScatter);
+  group0 = vecSet(b, group0, 1, ldsAddr);
+  group0 = vecSet(b, group0, 2, b.trunc(i32_ty, globalAddr));
 
   // group0[3]: preserve type bits, set global_addr upper 25 bits
   Value globalAddrHigh = b.trunc(i32_ty, b.lshr(globalAddr, b.i64_val(32)));
   globalAddrHigh = b.and_(globalAddrHigh, b.i32_val(0x01FFFFFF));
-  Value typeBits = b.and_(group0[3], b.i32_val(0xC0000000));
-  group0[3] = b.or_(typeBits, globalAddrHigh);
+  Value typeBits = b.and_(vecGet(b, group0, 3), b.i32_val(0xC0000000));
+  group0 = vecSet(b, group0, 3, b.or_(typeBits, globalAddrHigh));
 
   // Update group1 with adjusted tensor shapes for proper OOB handling
-  group1[1] = b.shl(tensorShape[1], b.i32_val(16));
-  group1[2] = b.lshr(tensorShape[1], b.i32_val(16));
-  group1[2] = b.or_(group1[2], b.shl(tensorShape[0], b.i32_val(16)));
-  group1[3] = b.and_(group1[3], b.i32_val(0xFFFF << 16));
-  group1[3] = b.or_(group1[3], b.lshr(tensorShape[0], b.i32_val(16)));
+  group1 = vecSet(b, group1, 1, b.shl(tensorShape[1], b.i32_val(16)));
+  Value g1_2 = b.lshr(tensorShape[1], b.i32_val(16));
+  g1_2 = b.or_(g1_2, b.shl(tensorShape[0], b.i32_val(16)));
+  group1 = vecSet(b, group1, 2, g1_2);
+  Value g1_3 = b.and_(vecGet(b, group1, 3), b.i32_val(0xFFFF << 16));
+  g1_3 = b.or_(g1_3, b.lshr(tensorShape[0], b.i32_val(16)));
+  group1 = vecSet(b, group1, 3, g1_3);
 
   // Configure barrier
+  Value g1_0 = vecGet(b, group1, 0);
+  Value g1_1 = vecGet(b, group1, 1);
   if (barrierPtr) {
-    group1[0] = b.or_(group1[0], b.shl(b.i32_val(1), b.i32_val(18)));
-    group1[1] = b.or_(
-        group1[1], b.and_(b.lshr(b.ptrtoint(i32_ty, barrierPtr), b.i32_val(3)),
-                          b.i32_val(0x00FFFF)));
+    g1_0 = b.or_(g1_0, b.shl(b.i32_val(1), b.i32_val(18)));
+    g1_1 =
+        b.or_(g1_1, b.and_(b.lshr(b.ptrtoint(i32_ty, barrierPtr), b.i32_val(3)),
+                           b.i32_val(0x00FFFF)));
   } else {
-    group1[0] = b.and_(group1[0], b.i32_val(0xFFFBFFFF));
+    g1_0 = b.and_(g1_0, b.i32_val(0xFFFBFFFF));
   }
+  group1 = vecSet(b, group1, 0, g1_0);
+  group1 = vecSet(b, group1, 1, g1_1);
 
   // Set tile_dim1 (number of valid indices) in lower 16 bits of group1[4]
   size_t numIndices = rowIndices.size();
-  group1[4] = b.and_(group1[4], b.i32_val(0xFFFF0000));
-  group1[4] = b.or_(group1[4], b.i32_val(numIndices & 0xFFFF));
+  Value g1_4 = b.and_(vecGet(b, group1, 4), b.i32_val(0xFFFF0000));
+  g1_4 = b.or_(g1_4, b.i32_val(numIndices & 0xFFFF));
+  group1 = vecSet(b, group1, 4, g1_4);
 
   // Fix tile_dim0 for gather/scatter: createTDMDescriptor divides the column
   // dimension across warps for regular load/store, but gather and scatter use
@@ -822,23 +873,24 @@ void fillTDMDescriptorForGatherScatter(
     if (!isGather && padInterval > 0 && padAmount > 0)
       tileDim0 += padAmount;
 
-    group1[3] = b.and_(group1[3], b.i32_val(0xFFFF));
-    group1[3] = b.or_(group1[3], b.i32_val(tileDim0 << 16));
+    Value g1_3_gs = b.and_(vecGet(b, group1, 3), b.i32_val(0xFFFF));
+    g1_3_gs = b.or_(g1_3_gs, b.i32_val(tileDim0 << 16));
+    group1 = vecSet(b, group1, 3, g1_3_gs);
   }
 
   // Fill group2 and group3 with row indices
   if (use32BitIndices) {
     // 32-bit indices: 4 in group2, 4 in group3
     for (size_t i = 0; i < 4 && i < numIndices; ++i) {
-      group2[i] = rowIndices[i];
+      group2 = vecSet(b, group2, i, rowIndices[i]);
     }
     for (size_t i = 4; i < 8 && i < numIndices; ++i) {
-      group3[i - 4] = rowIndices[i];
+      group3 = vecSet(b, group3, i - 4, rowIndices[i]);
     }
   } else {
     // 16-bit indices: pack 2 per dword
     // Indices are i16, so zero-extend to i32 before packing
-    auto packIndices = [&](MutableArrayRef<Value> group, size_t baseIdx) {
+    auto packIndices = [&](Value &group, size_t baseIdx) {
       for (size_t i = 0; i < 4; ++i) {
         Value dword = b.i32_val(0);
         size_t idx0 = baseIdx + i * 2;
@@ -854,7 +906,7 @@ void fillTDMDescriptorForGatherScatter(
           dword = b.or_(
               dword, b.shl(b.and_(idx1_i32, b.i32_val(0xFFFF)), b.i32_val(16)));
         }
-        group[i] = dword;
+        group = vecSet(b, group, i, dword);
       }
     };
     packIndices(group2, 0);
@@ -914,26 +966,21 @@ void emitTDMIntrinsic(RewriterBase &rewriter, Location loc,
                       Value ctaId, bool isLoad,
                       ArrayRef<unsigned> warpsPerCTA) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto v4i32Ty = VectorType::get(4, rewriter.getI32Type());
   auto v8i32Ty = VectorType::get(8, rewriter.getI32Type());
   Value group4Zero = LLVM::ZeroOp::create(rewriter, loc, v8i32Ty);
 
   if (numDims > 2) {
-    auto group0Vec = SmallVector<Value>(desc.begin(), desc.begin() + 4);
-    auto group1Vec = SmallVector<Value>(desc.begin() + 4, desc.begin() + 12);
-    auto group2Vec = SmallVector<Value>(desc.begin() + 12, desc.begin() + 16);
-    auto group3Vec = SmallVector<Value>(desc.begin() + 16, desc.end());
+    Value group0 = desc[0];
+    Value group1 = desc[1];
+    Value group2 = desc[2];
+    Value group3 = desc[3];
 
     fillTDMDescriptor(rewriter, loc, typeConverter, elementType,
                       effectiveBlockShape, numWarps, padInterval, padAmount,
-                      group0Vec, group1Vec, std::ref(group2Vec),
-                      std::ref(group3Vec), globalOffset, instrDstPtrs, pred,
-                      multicastMask, barrier, instrSharedLayout, ctaId, !isLoad,
-                      warpsPerCTA);
-
-    auto group0 = packLLVector(loc, group0Vec, rewriter);
-    auto group1 = packLLVector(loc, group1Vec, rewriter);
-    auto group2 = packLLVector(loc, group2Vec, rewriter);
-    auto group3 = packLLVector(loc, group3Vec, rewriter);
+                      group0, group1, std::ref(group2), std::ref(group3),
+                      globalOffset, instrDstPtrs, pred, multicastMask, barrier,
+                      instrSharedLayout, ctaId, !isLoad, warpsPerCTA);
 
     const char *intrinsicName = isLoad ? "llvm.amdgcn.tensor.load.to.lds"
                                        : "llvm.amdgcn.tensor.store.from.lds";
@@ -941,18 +988,15 @@ void emitTDMIntrinsic(RewriterBase &rewriter, Location loc,
         rewriter, loc, intrinsicName, {},
         {group0, group1, group2, group3, group4Zero, b.i32_val(0)});
   } else {
-    auto group0Vec = SmallVector<Value>(desc.begin(), desc.begin() + 4);
-    auto group1Vec = SmallVector<Value>(desc.begin() + 4, desc.end());
+    Value group0 = desc[0];
+    Value group1 = desc[1];
 
     fillTDMDescriptor(rewriter, loc, typeConverter, elementType,
                       effectiveBlockShape, numWarps, padInterval, padAmount,
-                      group0Vec, group1Vec, std::nullopt, std::nullopt,
-                      globalOffset, instrDstPtrs, pred, multicastMask, barrier,
+                      group0, group1, std::nullopt, std::nullopt, globalOffset,
+                      instrDstPtrs, pred, multicastMask, barrier,
                       instrSharedLayout, ctaId, !isLoad, warpsPerCTA);
 
-    auto group0 = packLLVector(loc, group0Vec, rewriter);
-    auto group1 = packLLVector(loc, group1Vec, rewriter);
-    auto v4i32Ty = VectorType::get(4, rewriter.getI32Type());
     Value group2Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
     Value group3Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
 
@@ -1164,13 +1208,15 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
   size_t numIndicesPerWarp = effectiveRowIndices.size();
   size_t numInstructions = batchLdsOffsets.size();
 
-  // Get the descriptor groups (gather/scatter uses 2D format: 12 dwords)
-  auto group0Vec = SmallVector<Value>(desc.begin(), desc.begin() + 4);
-  auto group1Vec = SmallVector<Value>(desc.begin() + 4, desc.end());
+  // Get the descriptor groups (gather/scatter uses 2D format — desc has 2
+  // vector entries: group0 = <4 x i32>, group1 = <8 x i32>)
+  Value group0In = desc[0];
+  Value group1In = desc[1];
 
   // For TDM gather/scatter, we need group2 and group3 for indices
-  SmallVector<Value> group2Vec(4, b.i32_val(0));
-  SmallVector<Value> group3Vec(4, b.i32_val(0));
+  auto v4i32Ty = VectorType::get(4, rewriter.getI32Type());
+  Value group2Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
+  Value group3Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
 
   // Issue multiple TDM instructions if needed
   for (size_t instrIdx = 0; instrIdx < numInstructions; ++instrIdx) {
@@ -1182,10 +1228,10 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
                                     effectiveRowIndices.begin() + endIdx);
 
     // Make copies of the descriptor groups for this iteration
-    auto g0 = group0Vec;
-    auto g1 = group1Vec;
-    auto g2 = group2Vec;
-    auto g3 = group3Vec;
+    Value g0 = group0In;
+    Value g1 = group1In;
+    Value g2 = group2Zero;
+    Value g3 = group3Zero;
 
     Value ldsRowOffset = batchLdsOffsets[instrIdx];
 
@@ -1195,20 +1241,13 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
         pred, barrierPtr, cgaLayout, ctaId, batchIndices, use32BitIndices,
         isGather);
 
-    // Pack and emit the instruction
-    auto group0 = packLLVector(loc, g0, rewriter);
-    auto group1 = packLLVector(loc, g1, rewriter);
-    auto group2 = packLLVector(loc, g2, rewriter);
-    auto group3 = packLLVector(loc, g3, rewriter);
-
     auto v8i32Ty = VectorType::get(8, rewriter.getI32Type());
     Value group4Zero = LLVM::ZeroOp::create(rewriter, loc, v8i32Ty);
 
     const char *intrinsicName = isGather ? "llvm.amdgcn.tensor.load.to.lds"
                                          : "llvm.amdgcn.tensor.store.from.lds";
-    LLVM::createLLVMIntrinsicCallOp(
-        rewriter, loc, intrinsicName, {},
-        {group0, group1, group2, group3, group4Zero, b.i32_val(0)});
+    LLVM::createLLVMIntrinsicCallOp(rewriter, loc, intrinsicName, {},
+                                    {g0, g1, g2, g3, group4Zero, b.i32_val(0)});
   }
 }
 
@@ -1233,25 +1272,19 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
   int numDims = blockShape.size();
   Type globalPtrTy = ptr_ty(loc.getContext(), 1);
 
-  // Decode TDM descriptor to get the base pointer, shape, and strides
-  auto group0Vec = SmallVector<Value>(desc.begin(), desc.begin() + 4);
-  auto group1Vec = SmallVector<Value>(desc.begin() + 4, desc.begin() + 12);
-  std::optional<SmallVector<Value>> group2Vec;
-  std::optional<SmallVector<Value>> group3Vec;
+  // Decode TDM descriptor to get the base pointer, shape, and strides.
+  // desc now has 2 (2D) or 4 (3D-5D) vector entries.
+  Value group0 = desc[0];
+  Value group1 = desc[1];
+  std::optional<Value> group2;
+  std::optional<Value> group3;
   if (numDims > 2) {
-    group2Vec = SmallVector<Value>(desc.begin() + 12, desc.begin() + 16);
-    group3Vec = SmallVector<Value>(desc.begin() + 16, desc.end());
+    group2 = desc[2];
+    group3 = desc[3];
   }
   auto [basePtr, tensorShape, tensorStride, decodedBlockShape] =
-      mlir::LLVM::AMD::decodeTDMDescriptorFull(
-          rewriter, loc, group0Vec, group1Vec,
-          group2Vec.has_value()
-              ? std::optional<ArrayRef<Value>>(group2Vec.value())
-              : std::nullopt,
-          group3Vec.has_value()
-              ? std::optional<ArrayRef<Value>>(group3Vec.value())
-              : std::nullopt,
-          numDims);
+      mlir::LLVM::AMD::decodeTDMDescriptorFull(rewriter, loc, group0, group1,
+                                               group2, group3, numDims);
 
   auto dot64 = [&](ArrayRef<Value> indices, ArrayRef<Value> strides) {
     Value ret = b.i64_val(0);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -12,16 +12,36 @@ using PartitionedSharedEncodingAttr =
 
 namespace mlir::LLVM::AMD {
 
-// Structure to hold TDM descriptor groups
+// Internal vector-grouped representation of a TDM descriptor.
+//   group0: <4 x i32>
+//   group1: <8 x i32>
+//   group2: <4 x i32>  (only for 3D-5D)
+//   group3: <4 x i32>  (only for 3D-5D)
+// The MLIR-visible struct type remains flat {i32 × N} so the in-memory ABI
+// matches the host-side TDMDescriptor struct in third_party/amd/backend/
+// driver.c; the grouping here is a lowering-pass-internal convenience.
 struct TDMDescriptor {
-  SmallVector<Value> group0;
-  SmallVector<Value> group1;
-  std::optional<SmallVector<Value>> group2;
-  std::optional<SmallVector<Value>> group3;
+  Value group0;
+  Value group1;
+  std::optional<Value> group2;
+  std::optional<Value> group3;
 
-  // Get all groups as a flat vector (for compatibility)
+  // Return the group vectors as a flat list.  For 2D: {group0, group1};
+  // for 3D-5D: {group0, group1, group2, group3}.
   SmallVector<Value> getAllGroups() const;
 };
+
+// Unpack the flat `{i32 × 12/20}` descriptor struct that
+// `convertTensorDescType` returns (and that the host-side `TDMDescriptor` in
+// driver.c serializes) into 2 or 4 vector groups suitable for
+// `emitTDMLoadStore` / `emitTDMGatherScatter` / `emitTDMPrefetch`.
+SmallVector<Value> unpackTDMDescriptor(RewriterBase &rewriter, Location loc,
+                                       Value descStruct);
+
+// Inverse of unpackTDMDescriptor for packing via `packLLElements`.  Flattens
+// 2/4 vector groups back into 12/20 scalars.
+SmallVector<Value> scalarizeTDMDescriptor(RewriterBase &rewriter, Location loc,
+                                          ArrayRef<Value> vectors);
 
 // Create a TDM descriptor. This creates a partially filled descriptor, with
 // shared memory address and pred set to zero. User of the descriptor is
@@ -43,17 +63,17 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
 // address and pred in a given TDM descriptor for regular load/store (1D-5D).
 // For partitioned shared memory, dstPtrs contains multiple base pointers and
 // the correct one is selected based on sharedLayout's partition dimension.
-void fillTDMDescriptor(
-    RewriterBase &rewriter, Location loc,
-    const LLVMTypeConverter *typeConverter, Type elementType,
-    SmallVector<int64_t> blockShape, int numWarps, unsigned padInterval,
-    unsigned padAmount, SmallVector<Value> &group0, SmallVector<Value> &group1,
-    std::optional<std::reference_wrapper<SmallVector<Value>>> group2,
-    std::optional<std::reference_wrapper<SmallVector<Value>>> group3,
-    SmallVector<Value> offset, ArrayRef<Value> dstPtrs, Value pred,
-    Value multicastMask, Value barrierPtr,
-    const triton::LinearLayout &sharedLayout, Value ctaId, bool isStore,
-    ArrayRef<unsigned> warpsPerCTA);
+void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
+                       const LLVMTypeConverter *typeConverter, Type elementType,
+                       SmallVector<int64_t> blockShape, int numWarps,
+                       unsigned padInterval, unsigned padAmount, Value &group0,
+                       Value &group1,
+                       std::optional<std::reference_wrapper<Value>> group2,
+                       std::optional<std::reference_wrapper<Value>> group3,
+                       SmallVector<Value> offset, ArrayRef<Value> dstPtrs,
+                       Value pred, Value multicastMask, Value barrierPtr,
+                       const triton::LinearLayout &sharedLayout, Value ctaId,
+                       bool isStore, ArrayRef<unsigned> warpsPerCTA);
 
 // Fill TDM descriptor for gather/scatter operations (2D only).
 // Gather reads from non-contiguous rows in global memory to LDS.
@@ -67,10 +87,9 @@ void fillTDMDescriptorForGatherScatter(
     RewriterBase &rewriter, Location loc,
     const LLVMTypeConverter *typeConverter, Type elementType,
     SmallVector<int64_t> blockShape, unsigned padInterval, unsigned padAmount,
-    SmallVector<Value> &group0, SmallVector<Value> &group1,
-    SmallVector<Value> &group2, SmallVector<Value> &group3, Value ldsRowOffset,
-    Value globalColOffset, Value ldsPtr, Value pred, Value barrierPtr,
-    const triton::LinearLayout &cgaLayout, Value ctaId,
+    Value &group0, Value &group1, Value &group2, Value &group3,
+    Value ldsRowOffset, Value globalColOffset, Value ldsPtr, Value pred,
+    Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId,
     ArrayRef<Value> rowIndices, bool use32BitIndices, bool isGather);
 
 // Emit a TDM load or store for regular (non-scatter) contiguous transfers.

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
@@ -119,10 +119,16 @@ struct MakeTensorDescOpConversion
         rewriter, loc, getTypeConverter(), elementType, shapePerCTA, numWarps,
         padInterval, padAmount, tensorShape, tensorStride, basePtr, sharedEnc);
 
+    // `getAllGroups()` returns 2 (2D) or 4 (3D-5D) vector Values; scalarize
+    // them into 12 or 20 i32 scalars to match the flat MLIR struct type
+    // returned by `convertTensorDescType` (which matches the host-side
+    // TDMDescriptor ABI).
     SmallVector<Value> groups = tdmDesc.getAllGroups();
+    SmallVector<Value> scalars =
+        mlir::LLVM::AMD::scalarizeTDMDescriptor(rewriter, loc, groups);
 
-    auto desc =
-        packLLElements(loc, getTypeConverter(), groups, rewriter, tensorDescTy);
+    auto desc = packLLElements(loc, getTypeConverter(), scalars, rewriter,
+                               tensorDescTy);
 
     rewriter.replaceOp(op, desc);
     return success();


### PR DESCRIPTION
Refactor the TDM descriptor lowering to carry each descriptor group as a single LLVM vector Value inside the lowering functions, instead of as a SmallVector of individual i32 Values.  Groups are:
  group0: <4 x i32>
  group1: <8 x i32>
  group2: <4 x i32>  (3D-5D only)
  group3: <4 x i32>  (3D-5D only)

The MLIR-visible struct type returned by `convertTensorDescType` stays flat `{i32 × N}` so the in-memory ABI matches the host-side `TDMDescriptor` struct in third_party/amd/backend/driver.c (host serializes N consecutive uint32_t).  Boundary helpers bridge between the flat ABI shape and the vector-grouped internal shape:
  - unpackTDMDescriptor(structVal) -> {<4xi32>, <8xi32>[, <4xi32>, <4xi32>]}
  - scalarizeTDMDescriptor({<4xi32>, ...}) -> i32 × 12/20

Internal helpers `vecGet` / `vecSet` wrap `extract_element` / `insert_element` and live in TDMUtility.cpp's anonymous namespace.

Functional scope: refactor only.  No new user-facing ops; no change to host-side ABI.  This sets up the cleaner IR shape that the planned tdm.advance op (follow-up PR) will rely on.