### PR TITLE
[Gluon][Examples] Add 2 CTA to 05-moe-bmm1-fused-gather

### DIFF
--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -58,14 +58,6 @@ def unpack_block_schedule(schedule: gl.tensor) -> tuple[gl.tensor, gl.tensor]:
 
 
 @gluon.jit
-def unpack_full_tile_schedule(schedule: gl.tensor) -> tuple[gl.tensor, gl.tensor, gl.tensor]:
-    slice_idx = (schedule & 0xFFFF).to(gl.int32)
-    pid_m = ((schedule >> 16) & 0xFFFF).to(gl.int32)
-    pid_n = ((schedule >> 32) & 0xFFFF).to(gl.int32)
-    return pid_m, pid_n, slice_idx
-
-
-@gluon.jit
 def banded_row_major(lin_idx, m_tiles, n_tiles, BAND_N: gl.constexpr):
     if BAND_N >= n_tiles:
         return lin_idx // n_tiles, lin_idx % n_tiles
@@ -103,63 +95,17 @@ def banded_row_major_m(lin_idx, m_tiles, n_tiles, BAND_N: gl.constexpr):
 
 
 @gluon.jit
-def planar_snake(lin_idx, m_tiles, n_tiles, MINOR_DIM: gl.constexpr, TILE_WIDTH: gl.constexpr):
-    major_size = n_tiles if MINOR_DIM == 0 else m_tiles
-    minor_size = m_tiles if MINOR_DIM == 0 else n_tiles
-
-    full_minor_tiles = minor_size // TILE_WIDTH
-    full_minor_size = full_minor_tiles * TILE_WIDTH
-    full_elements = full_minor_tiles * TILE_WIDTH * major_size
-
-    minor_tile_idx = lin_idx // (TILE_WIDTH * major_size)
-
-    full_minor_within = lin_idx % TILE_WIDTH
-    full_major_within = (lin_idx // TILE_WIDTH) % major_size
-    full_minor = minor_tile_idx * TILE_WIDTH + full_minor_within
-    full_major = gl.where((minor_tile_idx % 2) == 0, full_major_within, major_size - 1 - full_major_within)
-
-    partial_width = minor_size - full_minor_size
-    partial_width = gl.where(partial_width > 0, partial_width, 1)
-    partial_lin = lin_idx - full_elements
-    partial_minor_within = partial_lin % partial_width
-    partial_major_within = (partial_lin // partial_width) % major_size
-    partial_minor = minor_tile_idx * TILE_WIDTH + partial_minor_within
-    partial_major = gl.where((minor_tile_idx % 2) == 0, partial_major_within, major_size - 1 - partial_major_within)
-
-    in_full_tile = lin_idx < full_elements
-    minor = gl.where(in_full_tile, full_minor, partial_minor)
-    major = gl.where(in_full_tile, full_major, partial_major)
-
-    if MINOR_DIM == 0:
-        return minor, major
-    return major, minor
-
-
-@gluon.jit
 def apply_block_schedule(
     block_id: gl.tensor,
     grid_m: gl.tensor,
     GRID_N: gl.constexpr,
     slice_offsets: gl.tensor,
     block_schedule: gl.tensor,
-    USE_PLANAR_SNAKE: gl.constexpr,
-    GRID_MINOR_DIM: gl.constexpr,
-    GRID_TILE_WIDTH: gl.constexpr,
     BAND_N: gl.constexpr,
 ) -> tuple[gl.tensor, gl.tensor, gl.tensor, gl.tensor]:
     # The persistent loop bounds block_id by grid_m * GRID_N, so no wraparound
     # modulo is needed on the hot scheduling path.
-    pid_mn = block_id
-    if USE_PLANAR_SNAKE:
-        schedule_pid_m, pid_n = planar_snake(
-            pid_mn,
-            grid_m,
-            GRID_N,
-            MINOR_DIM=GRID_MINOR_DIM,
-            TILE_WIDTH=GRID_TILE_WIDTH,
-        )
-    else:
-        schedule_pid_m, pid_n = banded_row_major(pid_mn, grid_m, GRID_N, BAND_N=BAND_N)
+    schedule_pid_m, pid_n = banded_row_major(block_id, grid_m, GRID_N, BAND_N=BAND_N)
 
     slice_idx, pid_m = unpack_block_schedule(gl.load(block_schedule + schedule_pid_m))
     pid_n = pid_n.to(gl.int32)
@@ -169,44 +115,14 @@ def apply_block_schedule(
 
 
 @gluon.jit
-def apply_full_tile_schedule(
-    block_id: gl.tensor,
-    slice_offsets: gl.tensor,
-    tile_schedule: gl.tensor,
-) -> tuple[gl.tensor, gl.tensor, gl.tensor, gl.tensor]:
-    pid_m, pid_n, slice_idx = unpack_full_tile_schedule(gl.load(tile_schedule + block_id))
-    slice_offset = gl.load(slice_offsets + slice_idx)
-    return pid_m, pid_n, slice_idx, slice_offset
-
-
-@gluon.jit
 def apply_weight_schedule(
     block_id: gl.tensor,
     grid_m: gl.tensor,
     GRID_N: gl.constexpr,
     block_schedule: gl.tensor,
-    tile_schedule: gl.tensor,
-    USE_FULL_TILE_SCHEDULE: gl.constexpr,
-    USE_PLANAR_SNAKE: gl.constexpr,
-    GRID_MINOR_DIM: gl.constexpr,
-    GRID_TILE_WIDTH: gl.constexpr,
     BAND_N: gl.constexpr,
 ) -> tuple[gl.tensor, gl.tensor]:
-    if USE_FULL_TILE_SCHEDULE:
-        _, pid_n, slice_idx = unpack_full_tile_schedule(gl.load(tile_schedule + block_id))
-        return pid_n, slice_idx
-
-    if USE_PLANAR_SNAKE:
-        schedule_pid_m, pid_n = planar_snake(
-            block_id,
-            grid_m,
-            GRID_N,
-            MINOR_DIM=GRID_MINOR_DIM,
-            TILE_WIDTH=GRID_TILE_WIDTH,
-        )
-    else:
-        schedule_pid_m, pid_n = banded_row_major(block_id, grid_m, GRID_N, BAND_N=BAND_N)
-
+    schedule_pid_m, pid_n = banded_row_major(block_id, grid_m, GRID_N, BAND_N=BAND_N)
     slice_idx, _ = unpack_block_schedule(gl.load(block_schedule + schedule_pid_m))
     return pid_n.to(gl.int32), slice_idx
 
@@ -218,29 +134,9 @@ def apply_activation_schedule(
     GRID_N: gl.constexpr,
     slice_offsets: gl.tensor,
     block_schedule: gl.tensor,
-    tile_schedule: gl.tensor,
-    USE_FULL_TILE_SCHEDULE: gl.constexpr,
-    USE_PLANAR_SNAKE: gl.constexpr,
-    GRID_MINOR_DIM: gl.constexpr,
-    GRID_TILE_WIDTH: gl.constexpr,
     BAND_N: gl.constexpr,
 ) -> tuple[gl.tensor, gl.tensor, gl.tensor]:
-    if USE_FULL_TILE_SCHEDULE:
-        pid_m, _, slice_idx = unpack_full_tile_schedule(gl.load(tile_schedule + block_id))
-        slice_offset = gl.load(slice_offsets + slice_idx)
-        return pid_m, slice_idx, slice_offset
-
-    if USE_PLANAR_SNAKE:
-        schedule_pid_m, _ = planar_snake(
-            block_id,
-            grid_m,
-            GRID_N,
-            MINOR_DIM=GRID_MINOR_DIM,
-            TILE_WIDTH=GRID_TILE_WIDTH,
-        )
-    else:
-        schedule_pid_m = banded_row_major_m(block_id, grid_m, GRID_N, BAND_N=BAND_N)
-
+    schedule_pid_m = banded_row_major_m(block_id, grid_m, GRID_N, BAND_N=BAND_N)
     slice_idx, pid_m = unpack_block_schedule(gl.load(block_schedule + schedule_pid_m))
     slice_offset = gl.load(slice_offsets + slice_idx)
     return pid_m, slice_idx, slice_offset
@@ -362,7 +258,6 @@ class PartitionArgs:
     x_slice_offs: gl.tensor
     x_block_offs: gl.tensor
     x_block_schedule: gl.tensor
-    x_tile_schedule: gl.tensor
 
     x_bufs: gl.shared_memory_descriptor
     x_empty_bars: gl.shared_memory_descriptor
@@ -415,36 +310,20 @@ class PartitionArgs:
 
     SWIGLU_SUBTILE_FACTOR: gl.constexpr
     EPILOGUE_BUFFER_DEPTH: gl.constexpr
-    USE_PLANAR_SNAKE: gl.constexpr
-    GRID_MINOR_DIM: gl.constexpr
-    GRID_TILE_WIDTH: gl.constexpr
     BAND_N: gl.constexpr
-    USE_FULL_TILE_SCHEDULE: gl.constexpr
     X_GATHER_MULTICAST: gl.constexpr
     W_SCALE_MULTICAST: gl.constexpr
     FORCE_EPILOGUE_WARPS_N1: gl.constexpr
-    USE_WIDE_STORE_HANDOFF: gl.constexpr
     USE_DIRECT_EPILOGUE_STORE: gl.constexpr
-    REUSE_GATHER_INDICES: gl.constexpr
-    INLINE_MMA_INPUT_RELEASE: gl.constexpr
 
     @gluon.jit
     def apply_block_schedule(self, block_id: gl.tensor) -> tuple[gl.tensor, gl.tensor, gl.tensor, gl.tensor]:
-        if self.USE_FULL_TILE_SCHEDULE:
-            return apply_full_tile_schedule(
-                block_id=block_id,
-                slice_offsets=self.x_slice_offs,
-                tile_schedule=self.x_tile_schedule,
-            )
         return apply_block_schedule(
             block_id=block_id,
             grid_m=self.grid_m,
             GRID_N=self.GRID_N,
             slice_offsets=self.x_slice_offs,
             block_schedule=self.x_block_schedule,
-            USE_PLANAR_SNAKE=self.USE_PLANAR_SNAKE,
-            GRID_MINOR_DIM=self.GRID_MINOR_DIM,
-            GRID_TILE_WIDTH=self.GRID_TILE_WIDTH,
             BAND_N=self.BAND_N,
         )
 
@@ -455,11 +334,6 @@ class PartitionArgs:
             grid_m=self.grid_m,
             GRID_N=self.GRID_N,
             block_schedule=self.x_block_schedule,
-            tile_schedule=self.x_tile_schedule,
-            USE_FULL_TILE_SCHEDULE=self.USE_FULL_TILE_SCHEDULE,
-            USE_PLANAR_SNAKE=self.USE_PLANAR_SNAKE,
-            GRID_MINOR_DIM=self.GRID_MINOR_DIM,
-            GRID_TILE_WIDTH=self.GRID_TILE_WIDTH,
             BAND_N=self.BAND_N,
         )
 
@@ -471,11 +345,6 @@ class PartitionArgs:
             GRID_N=self.GRID_N,
             slice_offsets=self.x_slice_offs,
             block_schedule=self.x_block_schedule,
-            tile_schedule=self.x_tile_schedule,
-            USE_FULL_TILE_SCHEDULE=self.USE_FULL_TILE_SCHEDULE,
-            USE_PLANAR_SNAKE=self.USE_PLANAR_SNAKE,
-            GRID_MINOR_DIM=self.GRID_MINOR_DIM,
-            GRID_TILE_WIDTH=self.GRID_TILE_WIDTH,
             BAND_N=self.BAND_N,
         )
 
@@ -493,83 +362,38 @@ def load_activations(p: PartitionArgs):
     phase = 1
     issued = 0
 
-    if p.REUSE_GATHER_INDICES:
-        cached_pid_m = gl.full((), -1, dtype=gl.int32)
-        cached_slice_idx = gl.full((), -1, dtype=gl.int32)
-        cached_shape_m = gl.full((), 0, dtype=gl.int32)
-        cached_offs_x_m = gl.full((p.BLOCK_M, ), p.x_desc.shape[0], dtype=gl.int32, layout=offs_layout)
+    for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
+        pid_m, slice_idx, slice_offset = p.apply_activation_schedule(block_id)
+        off_m = pid_m * p.BLOCK_M
+        shape_m = gl.load(p.x_slice_sizes + slice_idx)
+        offs_m = off_m + gl.arange(0, p.BLOCK_M, layout=offs_layout)
+        mask_m = offs_m < shape_m
+        offs_x_m = gl.load(
+            p.gather_indx_ptr + slice_offset + offs_m,
+            mask=mask_m,
+            other=p.x_desc.shape[0],
+        )
 
-        for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
-            pid_m, slice_idx, slice_offset = p.apply_activation_schedule(block_id)
-            off_m = pid_m * p.BLOCK_M
-            reuse_gather = (pid_m == cached_pid_m) & (slice_idx == cached_slice_idx)
-            load_gather = ~reuse_gather
-            shape_m = gl.load(p.x_slice_sizes + slice_idx, mask=load_gather, other=cached_shape_m)
-            offs_m = off_m + gl.arange(0, p.BLOCK_M, layout=offs_layout)
-            mask_m = (offs_m < shape_m) & load_gather
-            offs_x_m = gl.load(
-                p.gather_indx_ptr + slice_offset + offs_m,
-                mask=mask_m,
-                other=cached_offs_x_m,
-            )
-            cached_pid_m = pid_m
-            cached_slice_idx = slice_idx
-            cached_shape_m = shape_m
-            cached_offs_x_m = offs_x_m
+        for ki in range(p.K_TILES):
+            off_k_x = ki * p.BLOCK_K
 
-            for ki in range(p.K_TILES):
-                off_k_x = ki * p.BLOCK_K
+            empty_bar = p.x_empty_bars.index(idx)
+            ready_bar = p.x_ready_bars.index(idx)
+            x_buf = p.x_bufs.index(idx)
 
-                empty_bar = p.x_empty_bars.index(idx)
-                ready_bar = p.x_ready_bars.index(idx)
-                x_buf = p.x_bufs.index(idx)
-
-                mbarrier.wait(empty_bar, phase, pred=issued >= p.x_num_bufs)
-                mbarrier.expect(ready_bar, tile_x_bytes)
-                tma.async_gather(
-                    p.x_desc,
-                    offs_x_m,
-                    off_k_x,
-                    ready_bar,
-                    x_buf,
-                    multicast=p.USE_2CTA and p.X_GATHER_MULTICAST,
-                )
-
-                idx, phase = advance(idx, phase, p.x_num_bufs)
-                issued += 1
-    else:
-        for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
-            pid_m, slice_idx, slice_offset = p.apply_activation_schedule(block_id)
-            off_m = pid_m * p.BLOCK_M
-            shape_m = gl.load(p.x_slice_sizes + slice_idx)
-            offs_m = off_m + gl.arange(0, p.BLOCK_M, layout=offs_layout)
-            mask_m = offs_m < shape_m
-            offs_x_m = gl.load(
-                p.gather_indx_ptr + slice_offset + offs_m,
-                mask=mask_m,
-                other=p.x_desc.shape[0],
+            mbarrier.wait(empty_bar, phase, pred=issued >= p.x_num_bufs)
+            mbarrier.expect(ready_bar, tile_x_bytes)
+            tma.async_gather(
+                p.x_desc,
+                offs_x_m,
+                off_k_x,
+                ready_bar,
+                x_buf,
+                multicast=p.USE_2CTA and p.X_GATHER_MULTICAST,
             )
 
-            for ki in range(p.K_TILES):
-                off_k_x = ki * p.BLOCK_K
-
-                empty_bar = p.x_empty_bars.index(idx)
-                ready_bar = p.x_ready_bars.index(idx)
-                x_buf = p.x_bufs.index(idx)
-
-                mbarrier.wait(empty_bar, phase, pred=issued >= p.x_num_bufs)
-                mbarrier.expect(ready_bar, tile_x_bytes)
-                tma.async_gather(
-                    p.x_desc,
-                    offs_x_m,
-                    off_k_x,
-                    ready_bar,
-                    x_buf,
-                    multicast=p.USE_2CTA and p.X_GATHER_MULTICAST,
-                )
-
-                idx, phase = advance(idx, phase, p.x_num_bufs)
-                issued += 1
+            idx, phase = advance(idx, phase, p.x_num_bufs)
+            issued += 1
 
 
 @gluon.jit
@@ -643,31 +467,18 @@ def mma_partition(p: PartitionArgs):
             x_buf = p.x_bufs.index(x_idx)
             mbarrier.wait(x_ready_bar, x_phase)
 
-            if p.INLINE_MMA_INPUT_RELEASE:
-                blackwell.tcgen05_mma_scaled(
-                    w_buf.reshape((p.BLOCK_N, p.BLOCK_K // 2)),
-                    x_buf.permute((1, 0)),
-                    acc_buf,
-                    p.w_scale_tmem,
-                    p.x_scale_tmem,
-                    a_type="e2m1",
-                    b_type="e4m3",
-                    use_acc=use_acc,
-                    mbarriers=[x_empty_bar, w_empty_bar],
-                )
-            else:
-                blackwell.tcgen05_mma_scaled(
-                    w_buf.reshape((p.BLOCK_N, p.BLOCK_K // 2)),
-                    x_buf.permute((1, 0)),
-                    acc_buf,
-                    p.w_scale_tmem,
-                    p.x_scale_tmem,
-                    a_type="e2m1",
-                    b_type="e4m3",
-                    use_acc=use_acc,
-                )
-                blackwell.tcgen05_commit(x_empty_bar)
-                blackwell.tcgen05_commit(w_empty_bar)
+            blackwell.tcgen05_mma_scaled(
+                w_buf.reshape((p.BLOCK_N, p.BLOCK_K // 2)),
+                x_buf.permute((1, 0)),
+                acc_buf,
+                p.w_scale_tmem,
+                p.x_scale_tmem,
+                a_type="e2m1",
+                b_type="e4m3",
+                use_acc=use_acc,
+            )
+            blackwell.tcgen05_commit(x_empty_bar)
+            blackwell.tcgen05_commit(w_empty_bar)
 
             x_idx, x_phase = advance(x_idx, x_phase, p.x_num_bufs)
             w_idx, w_phase = advance(w_idx, w_phase, p.w_num_bufs)
@@ -744,10 +555,9 @@ def _store_out_subtile(
 @gluon.jit
 def get_store_layout(p: PartitionArgs):
     frag_rows: gl.constexpr = p.BLOCK_M // p.SWIGLU_SUBTILE_FACTOR
-    store_rows: gl.constexpr = p.BLOCK_M if p.USE_WIDE_STORE_HANDOFF else frag_rows
     local_cga_layout: gl.constexpr = ((0, 1), ) if p.USE_2CTA else ()
     return gl.BlockedLayout(
-        [store_rows // gl.num_warps(), 2],
+        [frag_rows // gl.num_warps(), 2],
         [1, 32],
         [gl.num_warps(), 1],
         [1, 0],
@@ -848,35 +658,6 @@ def epilogue_overlapped_store(
 
 
 @gluon.jit
-def epilogue_wide_store_handoff(
-    p: PartitionArgs,
-    acc_packed,
-    out_recip,
-    store_idx,
-    store_phase,
-    store_issued,
-):
-    gl.static_assert(p.SWIGLU_SUBTILE_FACTOR == 2, "wide store handoff is specialized for two M fragments")
-    acc_packed_0, acc_packed_1 = split_m_subtiles(acc_packed, p.SWIGLU_SUBTILE_FACTOR)
-    gelu_0, linear_0 = _swiglu_step1(acc_packed_0, p.SWIGLU_LIMIT)
-    gelu_1, linear_1 = _swiglu_step1(acc_packed_1, p.SWIGLU_LIMIT)
-    out_packed_0 = _swiglu_step2(gelu_0, linear_0, p.SWIGLU_ALPHA)
-    out_packed_1 = _swiglu_step2(gelu_1, linear_1, p.SWIGLU_ALPHA)
-    payload_0 = pack_fp8_out_fragment(out_packed_0, out_recip)
-    payload_1 = pack_fp8_out_fragment(out_packed_1, out_recip)
-    wide_payload = (gl.join(payload_0, payload_1).permute((2, 0, 1)).reshape(
-        (p.BLOCK_M, p.BLOCK_N // p.REDUCTION_N // 2)))
-
-    empty_bar = p.store_empty_bars.index(store_idx)
-    ready_bar = p.store_ready_bars.index(store_idx)
-    mbarrier.wait(empty_bar, store_phase, pred=store_issued >= p.EPILOGUE_BUFFER_DEPTH)
-    p.store_bufs.index(store_idx).store(wide_payload)
-    mbarrier.arrive(ready_bar)
-    next_store_idx, next_store_phase = advance(store_idx, store_phase, p.EPILOGUE_BUFFER_DEPTH)
-    return next_store_idx, next_store_phase, store_issued + 1
-
-
-@gluon.jit
 def apply_bias_and_scale(
     p: PartitionArgs,
     idx,
@@ -934,7 +715,8 @@ def epilogue_store_partition(p: PartitionArgs):
         off_m = pid_m * p.BLOCK_M
         shape_m = gl.load(p.x_slice_sizes + slice_idx)
         out_off_n_packed = pid_n * (p.BLOCK_N // p.REDUCTION_N // 4)
-        if p.USE_WIDE_STORE_HANDOFF:
+        for frag_idx in gl.static_range(p.SWIGLU_SUBTILE_FACTOR):
+            frag_off_m = off_m + frag_idx * frag_rows
             ready_bar = p.store_ready_bars.index(store_idx)
             empty_bar = p.store_empty_bars.index(store_idx)
             mbarrier.wait(ready_bar, store_phase)
@@ -943,29 +725,12 @@ def epilogue_store_partition(p: PartitionArgs):
             store_packed_out(
                 p,
                 packed_fp8,
-                off_m,
+                frag_off_m,
                 out_off_n_packed,
                 shape_m,
                 slice_offset,
             )
             store_idx, store_phase = advance(store_idx, store_phase, p.EPILOGUE_BUFFER_DEPTH)
-        else:
-            for frag_idx in gl.static_range(p.SWIGLU_SUBTILE_FACTOR):
-                frag_off_m = off_m + frag_idx * frag_rows
-                ready_bar = p.store_ready_bars.index(store_idx)
-                empty_bar = p.store_empty_bars.index(store_idx)
-                mbarrier.wait(ready_bar, store_phase)
-                packed_fp8 = p.store_bufs.index(store_idx).load(store_layout)
-                mbarrier.arrive(empty_bar)
-                store_packed_out(
-                    p,
-                    packed_fp8,
-                    frag_off_m,
-                    out_off_n_packed,
-                    shape_m,
-                    slice_offset,
-                )
-                store_idx, store_phase = advance(store_idx, store_phase, p.EPILOGUE_BUFFER_DEPTH)
 
 
 @gluon.jit
@@ -1022,15 +787,6 @@ def epilogue_partition(p: PartitionArgs):
                 slice_offset,
                 store_layout,
             )
-        elif p.USE_WIDE_STORE_HANDOFF:
-            store_idx, store_phase, store_issued = epilogue_wide_store_handoff(
-                p,
-                acc_packed,
-                out_recip,
-                store_idx,
-                store_phase,
-                store_issued,
-            )
         else:
             store_idx, store_phase, store_issued = epilogue_overlapped_store(
                 p,
@@ -1059,7 +815,6 @@ def ws_matmul_kernel(
     x_slice_offs: gl.tensor,
     x_block_offs: gl.tensor,
     x_block_schedule: gl.tensor,
-    x_tile_schedule: gl.tensor,
     #
     x_scale_ptr: gl.tensor,
     w_scale_ptr: gl.tensor,
@@ -1094,18 +849,11 @@ def ws_matmul_kernel(
     STORE_HELPER_REGS: gl.constexpr,
     SWIGLU_SUBTILE_FACTOR: gl.constexpr,
     EPILOGUE_BUFFER_DEPTH: gl.constexpr,
-    USE_PLANAR_SNAKE: gl.constexpr,
-    GRID_MINOR_DIM: gl.constexpr,
-    GRID_TILE_WIDTH: gl.constexpr,
     BAND_N: gl.constexpr,
-    USE_FULL_TILE_SCHEDULE: gl.constexpr,
     X_GATHER_MULTICAST: gl.constexpr,
     W_SCALE_MULTICAST: gl.constexpr,
     FORCE_EPILOGUE_WARPS_N1: gl.constexpr,
-    USE_WIDE_STORE_HANDOFF: gl.constexpr,
     USE_DIRECT_EPILOGUE_STORE: gl.constexpr,
-    REUSE_GATHER_INDICES: gl.constexpr,
-    INLINE_MMA_INPUT_RELEASE: gl.constexpr,
     SCALE_SIZE_OUTER: gl.constexpr,
     SCALE_SIZE_INNER: gl.constexpr,
     MXFP_BLOCK_SIZE: gl.constexpr,
@@ -1177,11 +925,10 @@ def ws_matmul_kernel(
         gl.static_assert(SWIGLU_SUBTILE_FACTOR > 1, "store helper requires row fragments")
         gl.static_assert(EPILOGUE_BUFFER_DEPTH >= 2, "store helper depth must be at least 2")
         frag_rows: gl.constexpr = BLOCK_M // SWIGLU_SUBTILE_FACTOR
-        store_rows: gl.constexpr = BLOCK_M if USE_WIDE_STORE_HANDOFF else frag_rows
         out_packed_n: gl.constexpr = BLOCK_N // REDUCTION_N // 2
         store_bufs = gl.allocate_shared_memory(
             gl.int16,
-            [EPILOGUE_BUFFER_DEPTH, store_rows, out_packed_n],
+            [EPILOGUE_BUFFER_DEPTH, frag_rows, out_packed_n],
             gl.SwizzledSharedLayout(1, 1, 1, [1, 0], cga_layout=((0, 1), ) if use_2cta else ()),
         )
         store_empty_bars, store_ready_bars = alloc_empty_ready_barriers(EPILOGUE_BUFFER_DEPTH)
@@ -1205,7 +952,6 @@ def ws_matmul_kernel(
         x_slice_offs=x_slice_offs,
         x_block_offs=x_block_offs,
         x_block_schedule=x_block_schedule,
-        x_tile_schedule=x_tile_schedule,
         #
         x_bufs=x_bufs,
         x_empty_bars=x_empty_bars,
@@ -1258,18 +1004,11 @@ def ws_matmul_kernel(
         #
         SWIGLU_SUBTILE_FACTOR=SWIGLU_SUBTILE_FACTOR,
         EPILOGUE_BUFFER_DEPTH=EPILOGUE_BUFFER_DEPTH,
-        USE_PLANAR_SNAKE=USE_PLANAR_SNAKE,
-        GRID_MINOR_DIM=GRID_MINOR_DIM,
-        GRID_TILE_WIDTH=GRID_TILE_WIDTH,
         BAND_N=BAND_N,
-        USE_FULL_TILE_SCHEDULE=USE_FULL_TILE_SCHEDULE,
         X_GATHER_MULTICAST=X_GATHER_MULTICAST,
         W_SCALE_MULTICAST=W_SCALE_MULTICAST,
         FORCE_EPILOGUE_WARPS_N1=FORCE_EPILOGUE_WARPS_N1,
-        USE_WIDE_STORE_HANDOFF=USE_WIDE_STORE_HANDOFF,
         USE_DIRECT_EPILOGUE_STORE=USE_DIRECT_EPILOGUE_STORE,
-        REUSE_GATHER_INDICES=REUSE_GATHER_INDICES,
-        INLINE_MMA_INPUT_RELEASE=INLINE_MMA_INPUT_RELEASE,
     )
 
     if USE_DIRECT_EPILOGUE_STORE:
@@ -1397,18 +1136,11 @@ class KernelConfig:
 
     SWIGLU_SUBTILE_FACTOR: int = 8
     EPILOGUE_BUFFER_DEPTH: int = 2
-    USE_PLANAR_SNAKE: bool = False
-    GRID_MINOR_DIM: int = 0
-    GRID_TILE_WIDTH: int = 8
     BAND_N: int = 20
-    USE_FULL_TILE_SCHEDULE: bool = False
     X_GATHER_MULTICAST: bool = True
     W_SCALE_MULTICAST: bool = True
     FORCE_EPILOGUE_WARPS_N1: bool = False
-    USE_WIDE_STORE_HANDOFF: bool = False
     USE_DIRECT_EPILOGUE_STORE: bool = False
-    REUSE_GATHER_INDICES: bool = False
-    INLINE_MMA_INPUT_RELEASE: bool = False
 
     LOAD_ACTIVATION_REGS: int = 112
     LOAD_WEIGHT_REGS: int = 48
@@ -1600,8 +1332,6 @@ def select_kernel_config(slice_size: int) -> KernelConfig:
 
 
 _dynamic_block_schedule_cache: dict[tuple[int, int], tuple[torch.Tensor, torch.Tensor]] = {}
-_dynamic_full_tile_schedule_cache: dict[tuple[int, int, int, bool, int, int, int], torch.Tensor] = {}
-_dummy_full_tile_schedule_cache: dict[torch.device, torch.Tensor] = {}
 
 
 def get_block_schedule_tensors(
@@ -1633,118 +1363,6 @@ def get_block_schedule_tensors(
     block_schedule_t = torch.tensor(packed_schedule, dtype=torch.int32, device=device)
     _dynamic_block_schedule_cache[key] = (block_offs_t, block_schedule_t)
     return block_offs_t, block_schedule_t
-
-
-def _host_banded_row_major(lin_idx: int, m_tiles: int, n_tiles: int, band_n: int) -> tuple[int, int]:
-    full_band_tiles = m_tiles * band_n
-    n_full_bands = n_tiles // band_n
-    full_band_work = n_full_bands * full_band_tiles
-
-    if lin_idx < full_band_work:
-        band_id = lin_idx // full_band_tiles
-        within_band = lin_idx % full_band_tiles
-        return within_band // band_n, band_id * band_n + (within_band % band_n)
-
-    tail_n = n_tiles - n_full_bands * band_n
-    assert tail_n > 0
-    tail_idx = lin_idx - full_band_work
-    return tail_idx // tail_n, n_full_bands * band_n + (tail_idx % tail_n)
-
-
-def _host_planar_snake(
-    lin_idx: int,
-    m_tiles: int,
-    n_tiles: int,
-    minor_dim: int,
-    tile_width: int,
-) -> tuple[int, int]:
-    major_size = n_tiles if minor_dim == 0 else m_tiles
-    minor_size = m_tiles if minor_dim == 0 else n_tiles
-
-    full_minor_tiles = minor_size // tile_width
-    full_minor_size = full_minor_tiles * tile_width
-    full_elements = full_minor_tiles * tile_width * major_size
-    minor_tile_idx = lin_idx // (tile_width * major_size)
-
-    if lin_idx < full_elements:
-        minor_within = lin_idx % tile_width
-        major_within = (lin_idx // tile_width) % major_size
-    else:
-        partial_width = minor_size - full_minor_size
-        partial_width = partial_width if partial_width > 0 else 1
-        partial_lin = lin_idx - full_elements
-        minor_within = partial_lin % partial_width
-        major_within = (partial_lin // partial_width) % major_size
-
-    minor = minor_tile_idx * tile_width + minor_within
-    major = major_within if (minor_tile_idx % 2) == 0 else major_size - 1 - major_within
-    if minor_dim == 0:
-        return minor, major
-    return major, minor
-
-
-def get_full_tile_schedule_tensor(
-    ragged_metadata: RaggedTensorMetadata,
-    block_size: int,
-    grid_n: int,
-    *,
-    use_planar_snake: bool,
-    grid_minor_dim: int,
-    grid_tile_width: int,
-    band_n: int,
-) -> torch.Tensor:
-    key = (
-        id(ragged_metadata),
-        block_size,
-        grid_n,
-        use_planar_snake,
-        grid_minor_dim,
-        grid_tile_width,
-        band_n,
-    )
-    cached = _dynamic_full_tile_schedule_cache.get(key)
-    if cached is not None:
-        return cached
-
-    block_offs, block_schedule = get_block_schedule_tensors(ragged_metadata, block_size)
-    grid_m = int(block_offs[ragged_metadata.n_slices].item())
-    assert ragged_metadata.n_slices < (1 << 16)
-    assert grid_m < (1 << 16)
-    assert grid_n < (1 << 16)
-
-    block_schedule_cpu = block_schedule.cpu().tolist()
-    packed_schedule: list[int] = []
-    for lin_idx in range(grid_m * grid_n):
-        if use_planar_snake:
-            schedule_pid_m, pid_n = _host_planar_snake(
-                lin_idx,
-                grid_m,
-                grid_n,
-                grid_minor_dim,
-                grid_tile_width,
-            )
-        else:
-            schedule_pid_m, pid_n = _host_banded_row_major(lin_idx, grid_m, grid_n, band_n)
-
-        m_entry = int(block_schedule_cpu[schedule_pid_m])
-        slice_idx = m_entry & 0xFFFF
-        pid_m = m_entry >> 16
-        assert slice_idx < (1 << 16)
-        assert pid_m < (1 << 16)
-        assert pid_n < (1 << 16)
-        packed_schedule.append(slice_idx | (pid_m << 16) | (pid_n << 32))
-
-    tile_schedule = torch.tensor(packed_schedule, dtype=torch.int64, device=ragged_metadata.slice_sizes.device)
-    _dynamic_full_tile_schedule_cache[key] = tile_schedule
-    return tile_schedule
-
-
-def get_dummy_full_tile_schedule_tensor(device: torch.device) -> torch.Tensor:
-    cached = _dummy_full_tile_schedule_cache.get(device)
-    if cached is None:
-        cached = torch.zeros((1, ), dtype=torch.int64, device=device)
-        _dummy_full_tile_schedule_cache[device] = cached
-    return cached
 
 
 def matmul(
@@ -1788,15 +1406,6 @@ def matmul(
     sms = torch.cuda.get_device_properties(bias.device).multi_processor_count
     sms *= p.OCCUPANCY
     launch_grid = max(1, min(max(1, sms // p.NUM_CTAS), expected_grid_m * grid_n))
-    x_tile_schedule = (get_full_tile_schedule_tensor(
-        a_ragged_metadata,
-        p.BLOCK_M,
-        grid_n,
-        use_planar_snake=p.USE_PLANAR_SNAKE,
-        grid_minor_dim=p.GRID_MINOR_DIM,
-        grid_tile_width=p.GRID_TILE_WIDTH,
-        band_n=p.BAND_N,
-    ) if p.USE_FULL_TILE_SCHEDULE else get_dummy_full_tile_schedule_tensor(a_ragged_metadata.slice_sizes.device))
     grid = (launch_grid, )
 
     acc_cga_layout = get_acc_cga_layout(p.NUM_CTAS)
@@ -1840,7 +1449,6 @@ def matmul(
         x_slice_offs=a_ragged_metadata.slice_offs,
         x_block_offs=x_block_offs,
         x_block_schedule=x_block_schedule,
-        x_tile_schedule=x_tile_schedule,
         #
         x_scale_ptr=flex_ctx.lhs_data.scale,
         w_scale_ptr=flex_ctx.rhs_data.scale,
@@ -1875,18 +1483,11 @@ def matmul(
         STORE_HELPER_REGS=p.STORE_HELPER_REGS,
         SWIGLU_SUBTILE_FACTOR=p.SWIGLU_SUBTILE_FACTOR,
         EPILOGUE_BUFFER_DEPTH=p.EPILOGUE_BUFFER_DEPTH,
-        USE_PLANAR_SNAKE=p.USE_PLANAR_SNAKE,
-        GRID_MINOR_DIM=p.GRID_MINOR_DIM,
-        GRID_TILE_WIDTH=p.GRID_TILE_WIDTH,
         BAND_N=p.BAND_N,
-        USE_FULL_TILE_SCHEDULE=p.USE_FULL_TILE_SCHEDULE,
         X_GATHER_MULTICAST=p.X_GATHER_MULTICAST,
         W_SCALE_MULTICAST=p.W_SCALE_MULTICAST,
         FORCE_EPILOGUE_WARPS_N1=p.FORCE_EPILOGUE_WARPS_N1,
-        USE_WIDE_STORE_HANDOFF=p.USE_WIDE_STORE_HANDOFF,
         USE_DIRECT_EPILOGUE_STORE=p.USE_DIRECT_EPILOGUE_STORE,
-        REUSE_GATHER_INDICES=p.REUSE_GATHER_INDICES,
-        INLINE_MMA_INPUT_RELEASE=p.INLINE_MMA_INPUT_RELEASE,
         #
         SCALE_SIZE_OUTER=p.SCALE_SIZE_OUTER,
         SCALE_SIZE_INNER=p.SCALE_SIZE_INNER,

--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -58,7 +58,18 @@ def unpack_block_schedule(schedule: gl.tensor) -> tuple[gl.tensor, gl.tensor]:
 
 
 @gluon.jit
+def unpack_full_tile_schedule(schedule: gl.tensor) -> tuple[gl.tensor, gl.tensor, gl.tensor]:
+    slice_idx = (schedule & 0xFFFF).to(gl.int32)
+    pid_m = ((schedule >> 16) & 0xFFFF).to(gl.int32)
+    pid_n = ((schedule >> 32) & 0xFFFF).to(gl.int32)
+    return pid_m, pid_n, slice_idx
+
+
+@gluon.jit
 def banded_row_major(lin_idx, m_tiles, n_tiles, BAND_N: gl.constexpr):
+    if BAND_N >= n_tiles:
+        return lin_idx // n_tiles, lin_idx % n_tiles
+
     full_band_tiles = m_tiles * BAND_N
     n_full_bands = n_tiles // BAND_N
     full_band_work = n_full_bands * full_band_tiles
@@ -74,21 +85,165 @@ def banded_row_major(lin_idx, m_tiles, n_tiles, BAND_N: gl.constexpr):
 
 
 @gluon.jit
+def banded_row_major_m(lin_idx, m_tiles, n_tiles, BAND_N: gl.constexpr):
+    if BAND_N >= n_tiles:
+        return lin_idx // n_tiles
+
+    full_band_tiles = m_tiles * BAND_N
+    n_full_bands = n_tiles // BAND_N
+    full_band_work = n_full_bands * full_band_tiles
+
+    if lin_idx < full_band_work:
+        within_band = lin_idx % full_band_tiles
+        return within_band // BAND_N
+
+    tail_n = n_tiles - n_full_bands * BAND_N
+    tail_idx = lin_idx - full_band_work
+    return tail_idx // tail_n
+
+
+@gluon.jit
+def planar_snake(lin_idx, m_tiles, n_tiles, MINOR_DIM: gl.constexpr, TILE_WIDTH: gl.constexpr):
+    major_size = n_tiles if MINOR_DIM == 0 else m_tiles
+    minor_size = m_tiles if MINOR_DIM == 0 else n_tiles
+
+    full_minor_tiles = minor_size // TILE_WIDTH
+    full_minor_size = full_minor_tiles * TILE_WIDTH
+    full_elements = full_minor_tiles * TILE_WIDTH * major_size
+
+    minor_tile_idx = lin_idx // (TILE_WIDTH * major_size)
+
+    full_minor_within = lin_idx % TILE_WIDTH
+    full_major_within = (lin_idx // TILE_WIDTH) % major_size
+    full_minor = minor_tile_idx * TILE_WIDTH + full_minor_within
+    full_major = gl.where((minor_tile_idx % 2) == 0, full_major_within, major_size - 1 - full_major_within)
+
+    partial_width = minor_size - full_minor_size
+    partial_width = gl.where(partial_width > 0, partial_width, 1)
+    partial_lin = lin_idx - full_elements
+    partial_minor_within = partial_lin % partial_width
+    partial_major_within = (partial_lin // partial_width) % major_size
+    partial_minor = minor_tile_idx * TILE_WIDTH + partial_minor_within
+    partial_major = gl.where((minor_tile_idx % 2) == 0, partial_major_within, major_size - 1 - partial_major_within)
+
+    in_full_tile = lin_idx < full_elements
+    minor = gl.where(in_full_tile, full_minor, partial_minor)
+    major = gl.where(in_full_tile, full_major, partial_major)
+
+    if MINOR_DIM == 0:
+        return minor, major
+    return major, minor
+
+
+@gluon.jit
 def apply_block_schedule(
     block_id: gl.tensor,
     grid_m: gl.tensor,
     GRID_N: gl.constexpr,
     slice_offsets: gl.tensor,
     block_schedule: gl.tensor,
+    USE_PLANAR_SNAKE: gl.constexpr,
+    GRID_MINOR_DIM: gl.constexpr,
+    GRID_TILE_WIDTH: gl.constexpr,
     BAND_N: gl.constexpr,
 ) -> tuple[gl.tensor, gl.tensor, gl.tensor, gl.tensor]:
-    pid_mn = block_id % (grid_m * GRID_N)
-    schedule_pid_m, pid_n = banded_row_major(pid_mn, grid_m, GRID_N, BAND_N=BAND_N)
+    # The persistent loop bounds block_id by grid_m * GRID_N, so no wraparound
+    # modulo is needed on the hot scheduling path.
+    pid_mn = block_id
+    if USE_PLANAR_SNAKE:
+        schedule_pid_m, pid_n = planar_snake(
+            pid_mn,
+            grid_m,
+            GRID_N,
+            MINOR_DIM=GRID_MINOR_DIM,
+            TILE_WIDTH=GRID_TILE_WIDTH,
+        )
+    else:
+        schedule_pid_m, pid_n = banded_row_major(pid_mn, grid_m, GRID_N, BAND_N=BAND_N)
 
     slice_idx, pid_m = unpack_block_schedule(gl.load(block_schedule + schedule_pid_m))
+    pid_n = pid_n.to(gl.int32)
     slice_offset = gl.load(slice_offsets + slice_idx)
 
     return pid_m, pid_n, slice_idx, slice_offset
+
+
+@gluon.jit
+def apply_full_tile_schedule(
+    block_id: gl.tensor,
+    slice_offsets: gl.tensor,
+    tile_schedule: gl.tensor,
+) -> tuple[gl.tensor, gl.tensor, gl.tensor, gl.tensor]:
+    pid_m, pid_n, slice_idx = unpack_full_tile_schedule(gl.load(tile_schedule + block_id))
+    slice_offset = gl.load(slice_offsets + slice_idx)
+    return pid_m, pid_n, slice_idx, slice_offset
+
+
+@gluon.jit
+def apply_weight_schedule(
+    block_id: gl.tensor,
+    grid_m: gl.tensor,
+    GRID_N: gl.constexpr,
+    block_schedule: gl.tensor,
+    tile_schedule: gl.tensor,
+    USE_FULL_TILE_SCHEDULE: gl.constexpr,
+    USE_PLANAR_SNAKE: gl.constexpr,
+    GRID_MINOR_DIM: gl.constexpr,
+    GRID_TILE_WIDTH: gl.constexpr,
+    BAND_N: gl.constexpr,
+) -> tuple[gl.tensor, gl.tensor]:
+    if USE_FULL_TILE_SCHEDULE:
+        _, pid_n, slice_idx = unpack_full_tile_schedule(gl.load(tile_schedule + block_id))
+        return pid_n, slice_idx
+
+    if USE_PLANAR_SNAKE:
+        schedule_pid_m, pid_n = planar_snake(
+            block_id,
+            grid_m,
+            GRID_N,
+            MINOR_DIM=GRID_MINOR_DIM,
+            TILE_WIDTH=GRID_TILE_WIDTH,
+        )
+    else:
+        schedule_pid_m, pid_n = banded_row_major(block_id, grid_m, GRID_N, BAND_N=BAND_N)
+
+    slice_idx, _ = unpack_block_schedule(gl.load(block_schedule + schedule_pid_m))
+    return pid_n.to(gl.int32), slice_idx
+
+
+@gluon.jit
+def apply_activation_schedule(
+    block_id: gl.tensor,
+    grid_m: gl.tensor,
+    GRID_N: gl.constexpr,
+    slice_offsets: gl.tensor,
+    block_schedule: gl.tensor,
+    tile_schedule: gl.tensor,
+    USE_FULL_TILE_SCHEDULE: gl.constexpr,
+    USE_PLANAR_SNAKE: gl.constexpr,
+    GRID_MINOR_DIM: gl.constexpr,
+    GRID_TILE_WIDTH: gl.constexpr,
+    BAND_N: gl.constexpr,
+) -> tuple[gl.tensor, gl.tensor, gl.tensor]:
+    if USE_FULL_TILE_SCHEDULE:
+        pid_m, _, slice_idx = unpack_full_tile_schedule(gl.load(tile_schedule + block_id))
+        slice_offset = gl.load(slice_offsets + slice_idx)
+        return pid_m, slice_idx, slice_offset
+
+    if USE_PLANAR_SNAKE:
+        schedule_pid_m, _ = planar_snake(
+            block_id,
+            grid_m,
+            GRID_N,
+            MINOR_DIM=GRID_MINOR_DIM,
+            TILE_WIDTH=GRID_TILE_WIDTH,
+        )
+    else:
+        schedule_pid_m = banded_row_major_m(block_id, grid_m, GRID_N, BAND_N=BAND_N)
+
+    slice_idx, pid_m = unpack_block_schedule(gl.load(block_schedule + schedule_pid_m))
+    slice_offset = gl.load(slice_offsets + slice_idx)
+    return pid_m, slice_idx, slice_offset
 
 
 @gluon.jit
@@ -107,16 +262,23 @@ def unswizzle_mx_scale(
 
 
 @gluon.jit
-def alloc_barrier_ring(num_bufs: gl.constexpr):
-    bars = gl.allocate_shared_memory(gl.int64, [num_bufs, 1], mbarrier.MBarrierLayout())
+def alloc_barrier_ring(num_bufs: gl.constexpr, two_ctas: gl.constexpr = False, count: gl.constexpr = 1):
+    bars = mbarrier.allocate_mbarrier(batch=num_bufs, two_ctas=two_ctas)
     for i in gl.static_range(num_bufs):
-        mbarrier.init(bars.index(i), count=1)
+        mbarrier.init(bars.index(i), count=count)
     return bars
 
 
 @gluon.jit
-def alloc_empty_ready_barriers(num_bufs: gl.constexpr):
-    return alloc_barrier_ring(num_bufs), alloc_barrier_ring(num_bufs)
+def alloc_empty_ready_barriers(
+    num_bufs: gl.constexpr,
+    empty_two_ctas: gl.constexpr = False,
+    ready_two_ctas: gl.constexpr = False,
+):
+    return (
+        alloc_barrier_ring(num_bufs, two_ctas=empty_two_ctas),
+        alloc_barrier_ring(num_bufs, two_ctas=ready_two_ctas),
+    )
 
 
 @gluon.jit
@@ -200,6 +362,7 @@ class PartitionArgs:
     x_slice_offs: gl.tensor
     x_block_offs: gl.tensor
     x_block_schedule: gl.tensor
+    x_tile_schedule: gl.tensor
 
     x_bufs: gl.shared_memory_descriptor
     x_empty_bars: gl.shared_memory_descriptor
@@ -210,10 +373,14 @@ class PartitionArgs:
     w_scale_bufs: gl.shared_memory_descriptor
     w_empty_bars: gl.shared_memory_descriptor
     w_ready_bars: gl.shared_memory_descriptor
+    w_scale_empty_bars: gl.shared_memory_descriptor
+    w_scale_ready_bars: gl.shared_memory_descriptor
     w_num_bufs: gl.constexpr
+    w_scale_num_bufs: gl.constexpr
 
     x_scale_tmem: blackwell.tensor_memory_descriptor
     w_scale_tmem: blackwell.tensor_memory_descriptor
+    w_scale_tmem_alt: blackwell.tensor_memory_descriptor
     acc_bufs: blackwell.tensor_memory_descriptor
     acc_empty_bars: gl.shared_memory_descriptor
     acc_ready_bars: gl.shared_memory_descriptor
@@ -231,6 +398,9 @@ class PartitionArgs:
     num_blocks: gl.tensor
 
     NUM_SMS: gl.constexpr
+    NUM_WARPS: gl.constexpr
+    USE_2CTA: gl.constexpr
+    BLOCK_M_PER_CTA: gl.constexpr
     BLOCK_M: gl.constexpr
     BLOCK_N: gl.constexpr
     BLOCK_K: gl.constexpr
@@ -245,85 +415,199 @@ class PartitionArgs:
 
     SWIGLU_SUBTILE_FACTOR: gl.constexpr
     EPILOGUE_BUFFER_DEPTH: gl.constexpr
+    USE_PLANAR_SNAKE: gl.constexpr
+    GRID_MINOR_DIM: gl.constexpr
+    GRID_TILE_WIDTH: gl.constexpr
     BAND_N: gl.constexpr
+    USE_FULL_TILE_SCHEDULE: gl.constexpr
+    X_GATHER_MULTICAST: gl.constexpr
+    W_SCALE_MULTICAST: gl.constexpr
+    FORCE_EPILOGUE_WARPS_N1: gl.constexpr
+    USE_WIDE_STORE_HANDOFF: gl.constexpr
+    USE_DIRECT_EPILOGUE_STORE: gl.constexpr
+    REUSE_GATHER_INDICES: gl.constexpr
+    INLINE_MMA_INPUT_RELEASE: gl.constexpr
 
     @gluon.jit
     def apply_block_schedule(self, block_id: gl.tensor) -> tuple[gl.tensor, gl.tensor, gl.tensor, gl.tensor]:
+        if self.USE_FULL_TILE_SCHEDULE:
+            return apply_full_tile_schedule(
+                block_id=block_id,
+                slice_offsets=self.x_slice_offs,
+                tile_schedule=self.x_tile_schedule,
+            )
         return apply_block_schedule(
             block_id=block_id,
             grid_m=self.grid_m,
             GRID_N=self.GRID_N,
             slice_offsets=self.x_slice_offs,
             block_schedule=self.x_block_schedule,
+            USE_PLANAR_SNAKE=self.USE_PLANAR_SNAKE,
+            GRID_MINOR_DIM=self.GRID_MINOR_DIM,
+            GRID_TILE_WIDTH=self.GRID_TILE_WIDTH,
+            BAND_N=self.BAND_N,
+        )
+
+    @gluon.jit
+    def apply_weight_schedule(self, block_id: gl.tensor) -> tuple[gl.tensor, gl.tensor]:
+        return apply_weight_schedule(
+            block_id=block_id,
+            grid_m=self.grid_m,
+            GRID_N=self.GRID_N,
+            block_schedule=self.x_block_schedule,
+            tile_schedule=self.x_tile_schedule,
+            USE_FULL_TILE_SCHEDULE=self.USE_FULL_TILE_SCHEDULE,
+            USE_PLANAR_SNAKE=self.USE_PLANAR_SNAKE,
+            GRID_MINOR_DIM=self.GRID_MINOR_DIM,
+            GRID_TILE_WIDTH=self.GRID_TILE_WIDTH,
+            BAND_N=self.BAND_N,
+        )
+
+    @gluon.jit
+    def apply_activation_schedule(self, block_id: gl.tensor) -> tuple[gl.tensor, gl.tensor, gl.tensor]:
+        return apply_activation_schedule(
+            block_id=block_id,
+            grid_m=self.grid_m,
+            GRID_N=self.GRID_N,
+            slice_offsets=self.x_slice_offs,
+            block_schedule=self.x_block_schedule,
+            tile_schedule=self.x_tile_schedule,
+            USE_FULL_TILE_SCHEDULE=self.USE_FULL_TILE_SCHEDULE,
+            USE_PLANAR_SNAKE=self.USE_PLANAR_SNAKE,
+            GRID_MINOR_DIM=self.GRID_MINOR_DIM,
+            GRID_TILE_WIDTH=self.GRID_TILE_WIDTH,
             BAND_N=self.BAND_N,
         )
 
 
 @gluon.jit
 def load_activations(p: PartitionArgs):
+    local_cga_layout: gl.constexpr = ((0, 1), ) if p.USE_2CTA else ()
     offs_layout: gl.constexpr = gl.SliceLayout(
         dim=0,
-        parent=gl.BlockedLayout([1, 4], [32, 1], [1, gl.num_warps()], [1, 0]),
+        parent=gl.BlockedLayout([1, 4], [32, 1], [1, gl.num_warps()], [1, 0], cga_layout=local_cga_layout),
     )
-    tile_x_bytes: gl.constexpr = p.x_desc.block_type.nbytes * p.BLOCK_M
+    tile_x_bytes: gl.constexpr = p.x_desc.block_type.nbytes * (p.BLOCK_M_PER_CTA if p.USE_2CTA else p.BLOCK_M)
 
     idx = 0
     phase = 1
+    issued = 0
 
-    for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
-        pid_m, _, slice_idx, slice_offset = p.apply_block_schedule(block_id)
-        off_m = pid_m * p.BLOCK_M
-        shape_m = gl.load(p.x_slice_sizes + slice_idx)
+    if p.REUSE_GATHER_INDICES:
+        cached_pid_m = gl.full((), -1, dtype=gl.int32)
+        cached_slice_idx = gl.full((), -1, dtype=gl.int32)
+        cached_shape_m = gl.full((), 0, dtype=gl.int32)
+        cached_offs_x_m = gl.full((p.BLOCK_M, ), p.x_desc.shape[0], dtype=gl.int32, layout=offs_layout)
 
-        offs_m = off_m + gl.arange(0, p.BLOCK_M, layout=offs_layout)
-        mask_m = offs_m < shape_m
-        offs_x_m = gl.load(
-            p.gather_indx_ptr + slice_offset + offs_m,
-            mask=mask_m,
-            other=p.x_desc.shape[0],
-        )
+        for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
+            pid_m, slice_idx, slice_offset = p.apply_activation_schedule(block_id)
+            off_m = pid_m * p.BLOCK_M
+            reuse_gather = (pid_m == cached_pid_m) & (slice_idx == cached_slice_idx)
+            load_gather = ~reuse_gather
+            shape_m = gl.load(p.x_slice_sizes + slice_idx, mask=load_gather, other=cached_shape_m)
+            offs_m = off_m + gl.arange(0, p.BLOCK_M, layout=offs_layout)
+            mask_m = (offs_m < shape_m) & load_gather
+            offs_x_m = gl.load(
+                p.gather_indx_ptr + slice_offset + offs_m,
+                mask=mask_m,
+                other=cached_offs_x_m,
+            )
+            cached_pid_m = pid_m
+            cached_slice_idx = slice_idx
+            cached_shape_m = shape_m
+            cached_offs_x_m = offs_x_m
 
-        for ki in range(p.K_TILES):
-            off_k_x = ki * p.BLOCK_K
+            for ki in range(p.K_TILES):
+                off_k_x = ki * p.BLOCK_K
 
-            empty_bar = p.x_empty_bars.index(idx)
-            ready_bar = p.x_ready_bars.index(idx)
-            x_buf = p.x_bufs.index(idx)
+                empty_bar = p.x_empty_bars.index(idx)
+                ready_bar = p.x_ready_bars.index(idx)
+                x_buf = p.x_bufs.index(idx)
 
-            mbarrier.wait(empty_bar, phase)
-            mbarrier.expect(ready_bar, tile_x_bytes)
-            tma.async_gather(p.x_desc, offs_x_m, off_k_x, ready_bar, x_buf)
+                mbarrier.wait(empty_bar, phase, pred=issued >= p.x_num_bufs)
+                mbarrier.expect(ready_bar, tile_x_bytes)
+                tma.async_gather(
+                    p.x_desc,
+                    offs_x_m,
+                    off_k_x,
+                    ready_bar,
+                    x_buf,
+                    multicast=p.USE_2CTA and p.X_GATHER_MULTICAST,
+                )
 
-            idx, phase = advance(idx, phase, p.x_num_bufs)
+                idx, phase = advance(idx, phase, p.x_num_bufs)
+                issued += 1
+    else:
+        for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
+            pid_m, slice_idx, slice_offset = p.apply_activation_schedule(block_id)
+            off_m = pid_m * p.BLOCK_M
+            shape_m = gl.load(p.x_slice_sizes + slice_idx)
+            offs_m = off_m + gl.arange(0, p.BLOCK_M, layout=offs_layout)
+            mask_m = offs_m < shape_m
+            offs_x_m = gl.load(
+                p.gather_indx_ptr + slice_offset + offs_m,
+                mask=mask_m,
+                other=p.x_desc.shape[0],
+            )
+
+            for ki in range(p.K_TILES):
+                off_k_x = ki * p.BLOCK_K
+
+                empty_bar = p.x_empty_bars.index(idx)
+                ready_bar = p.x_ready_bars.index(idx)
+                x_buf = p.x_bufs.index(idx)
+
+                mbarrier.wait(empty_bar, phase, pred=issued >= p.x_num_bufs)
+                mbarrier.expect(ready_bar, tile_x_bytes)
+                tma.async_gather(
+                    p.x_desc,
+                    offs_x_m,
+                    off_k_x,
+                    ready_bar,
+                    x_buf,
+                    multicast=p.USE_2CTA and p.X_GATHER_MULTICAST,
+                )
+
+                idx, phase = advance(idx, phase, p.x_num_bufs)
+                issued += 1
 
 
 @gluon.jit
 def load_weights(p: PartitionArgs):
-    tile_w_bytes: gl.constexpr = p.w_desc.block_type.nbytes
-    tile_scale_bytes: gl.constexpr = p.scale_desc.block_type.nbytes
+    tile_w_bytes: gl.constexpr = p.w_desc.nbytes_per_cta
+    tile_scale_bytes: gl.constexpr = p.scale_desc.nbytes_per_cta
     bytes_per_stage: gl.constexpr = tile_w_bytes + tile_scale_bytes
 
     idx = 0
     phase = 1
+    issued = 0
 
     for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
-        _, pid_n, slice_idx, _ = p.apply_block_schedule(block_id)
+        pid_n, slice_idx = p.apply_weight_schedule(block_id)
 
         scale_idx = slice_idx * p.SCALE_FLAT_N + pid_n * p.SCALE_BLOCK_N_DIV
+        scale_k_stride: gl.constexpr = p.BLOCK_K // (p.MXFP_BLOCK_SIZE * p.SCALE_SIZE_INNER)
         for ki in range(p.K_TILES):
-            off_k_scale = ki * p.BLOCK_K // (p.MXFP_BLOCK_SIZE * p.SCALE_SIZE_INNER)
+            off_k_scale = ki * scale_k_stride
 
             w_empty_bar = p.w_empty_bars.index(idx)
             w_ready_bar = p.w_ready_bars.index(idx)
             w_buf = p.w_bufs.index(idx)
             scale_buf = p.w_scale_bufs.index(idx)
 
-            mbarrier.wait(w_empty_bar, phase)
+            mbarrier.wait(w_empty_bar, phase, pred=issued >= p.w_num_bufs)
             mbarrier.expect(w_ready_bar, bytes_per_stage)
             tma.async_copy_global_to_shared(p.w_desc, [slice_idx, ki, pid_n, 0, 0], w_ready_bar, w_buf)
-            tma.async_copy_global_to_shared(p.scale_desc, [0, scale_idx, off_k_scale, 0, 0], w_ready_bar, scale_buf)
+            tma.async_copy_global_to_shared(
+                p.scale_desc,
+                [0, scale_idx, off_k_scale, 0, 0],
+                w_ready_bar,
+                scale_buf,
+                multicast=p.USE_2CTA and p.W_SCALE_MULTICAST,
+            )
 
             idx, phase = advance(idx, phase, p.w_num_bufs)
+            issued += 1
 
 
 @gluon.jit
@@ -359,18 +643,31 @@ def mma_partition(p: PartitionArgs):
             x_buf = p.x_bufs.index(x_idx)
             mbarrier.wait(x_ready_bar, x_phase)
 
-            blackwell.tcgen05_mma_scaled(
-                w_buf.reshape((p.BLOCK_N, p.BLOCK_K // 2)),
-                x_buf.permute((1, 0)),
-                acc_buf,
-                p.w_scale_tmem,
-                p.x_scale_tmem,
-                a_type="e2m1",
-                b_type="e4m3",
-                use_acc=use_acc,
-            )
-            blackwell.tcgen05_commit(x_empty_bar)
-            blackwell.tcgen05_commit(w_empty_bar)
+            if p.INLINE_MMA_INPUT_RELEASE:
+                blackwell.tcgen05_mma_scaled(
+                    w_buf.reshape((p.BLOCK_N, p.BLOCK_K // 2)),
+                    x_buf.permute((1, 0)),
+                    acc_buf,
+                    p.w_scale_tmem,
+                    p.x_scale_tmem,
+                    a_type="e2m1",
+                    b_type="e4m3",
+                    use_acc=use_acc,
+                    mbarriers=[x_empty_bar, w_empty_bar],
+                )
+            else:
+                blackwell.tcgen05_mma_scaled(
+                    w_buf.reshape((p.BLOCK_N, p.BLOCK_K // 2)),
+                    x_buf.permute((1, 0)),
+                    acc_buf,
+                    p.w_scale_tmem,
+                    p.x_scale_tmem,
+                    a_type="e2m1",
+                    b_type="e4m3",
+                    use_acc=use_acc,
+                )
+                blackwell.tcgen05_commit(x_empty_bar)
+                blackwell.tcgen05_commit(w_empty_bar)
 
             x_idx, x_phase = advance(x_idx, x_phase, p.x_num_bufs)
             w_idx, w_phase = advance(w_idx, w_phase, p.w_num_bufs)
@@ -385,14 +682,14 @@ def store_packed_out(
     p: PartitionArgs,
     packed_out,
     off_m,
-    out_off_n,
+    out_off_n_packed,
     shape_m,
     slice_offset,
 ):
     values = pack_fp8x4(packed_out)
     layout: gl.constexpr = values.type.layout
     offs_m = off_m + gl.arange(0, values.shape[0], layout=gl.SliceLayout(1, layout))
-    offs_n = out_off_n // 4 + gl.arange(0, values.shape[1], layout=gl.SliceLayout(0, layout))
+    offs_n = out_off_n_packed + gl.arange(0, values.shape[1], layout=gl.SliceLayout(0, layout))
     mask_m = gl.expand_dims(offs_m < shape_m, 1)
     mask_n = gl.expand_dims(offs_n < (p.out_desc.shape[1] + 3) // 4, 0)
     mask = mask_m & mask_n
@@ -406,7 +703,7 @@ def store_packed_out(
 def _swiglu_step1(acc_packed, limit):
     gelu, linear = float2.unpack2(acc_packed)
     gelu = gl.minimum(gelu.to(gl.float32), limit)
-    linear = gl.clamp(linear.to(gl.float32), -limit, limit)
+    linear = gl.minimum(gl.maximum(linear.to(gl.float32), -limit), limit)
     return gelu, linear
 
 
@@ -432,14 +729,57 @@ def _store_out_subtile(
     out_recip,
     store_idx,
     store_phase,
+    store_issued,
 ):
     payload = pack_fp8_out_fragment(out_packed, out_recip)
     empty_bar = p.store_empty_bars.index(store_idx)
     ready_bar = p.store_ready_bars.index(store_idx)
-    mbarrier.wait(empty_bar, store_phase)
+    mbarrier.wait(empty_bar, store_phase, pred=store_issued >= p.EPILOGUE_BUFFER_DEPTH)
     p.store_bufs.index(store_idx).store(payload)
     mbarrier.arrive(ready_bar)
-    return advance(store_idx, store_phase, p.EPILOGUE_BUFFER_DEPTH)
+    next_store_idx, next_store_phase = advance(store_idx, store_phase, p.EPILOGUE_BUFFER_DEPTH)
+    return next_store_idx, next_store_phase, store_issued + 1
+
+
+@gluon.jit
+def get_store_layout(p: PartitionArgs):
+    frag_rows: gl.constexpr = p.BLOCK_M // p.SWIGLU_SUBTILE_FACTOR
+    store_rows: gl.constexpr = p.BLOCK_M if p.USE_WIDE_STORE_HANDOFF else frag_rows
+    local_cga_layout: gl.constexpr = ((0, 1), ) if p.USE_2CTA else ()
+    return gl.BlockedLayout(
+        [store_rows // gl.num_warps(), 2],
+        [1, 32],
+        [gl.num_warps(), 1],
+        [1, 0],
+        cga_layout=local_cga_layout,
+    )
+
+
+@gluon.jit
+def epilogue_direct_store(
+    p: PartitionArgs,
+    acc_packed,
+    out_recip,
+    off_m,
+    out_off_n_packed,
+    shape_m,
+    slice_offset,
+    store_layout: gl.constexpr,
+):
+    frag_rows: gl.constexpr = p.BLOCK_M // p.SWIGLU_SUBTILE_FACTOR
+    acc_packed_subtiles = split_m_subtiles(acc_packed, p.SWIGLU_SUBTILE_FACTOR)
+    for frag_idx in gl.static_range(p.SWIGLU_SUBTILE_FACTOR):
+        gelu, linear = _swiglu_step1(acc_packed_subtiles[frag_idx], p.SWIGLU_LIMIT)
+        out_packed = _swiglu_step2(gelu, linear, p.SWIGLU_ALPHA)
+        packed_fp8 = gl.convert_layout(pack_fp8_out_fragment(out_packed, out_recip), store_layout)
+        store_packed_out(
+            p,
+            packed_fp8,
+            off_m + frag_idx * frag_rows,
+            out_off_n_packed,
+            shape_m,
+            slice_offset,
+        )
 
 
 @gluon.jit
@@ -449,6 +789,7 @@ def epilogue_overlapped_store(
     out_recip,
     store_idx,
     store_phase,
+    store_issued,
 ):
     gl.static_assert(p.SWIGLU_SUBTILE_FACTOR > 1, "store helper requires row fragments")
     acc_packed_subtiles = split_m_subtiles(acc_packed, p.SWIGLU_SUBTILE_FACTOR)
@@ -470,37 +811,69 @@ def epilogue_overlapped_store(
             p.SWIGLU_ALPHA,
         )
         if frag_idx > 1:
-            store_idx, store_phase = _store_out_subtile(
+            store_idx, store_phase, store_issued = _store_out_subtile(
                 p,
                 ready_out_packed,
                 out_recip,
                 store_idx,
                 store_phase,
+                store_issued,
             )
         ready_out_packed = next_ready_out_packed
         prepared_gelu = cur_gelu
         prepared_linear = cur_linear
 
-    store_idx, store_phase = _store_out_subtile(
+    store_idx, store_phase, store_issued = _store_out_subtile(
         p,
         ready_out_packed,
         out_recip,
         store_idx,
         store_phase,
+        store_issued,
     )
     last_out_packed = _swiglu_step2(
         prepared_gelu,
         prepared_linear,
         p.SWIGLU_ALPHA,
     )
-    store_idx, store_phase = _store_out_subtile(
+    store_idx, store_phase, store_issued = _store_out_subtile(
         p,
         last_out_packed,
         out_recip,
         store_idx,
         store_phase,
+        store_issued,
     )
-    return store_idx, store_phase
+    return store_idx, store_phase, store_issued
+
+
+@gluon.jit
+def epilogue_wide_store_handoff(
+    p: PartitionArgs,
+    acc_packed,
+    out_recip,
+    store_idx,
+    store_phase,
+    store_issued,
+):
+    gl.static_assert(p.SWIGLU_SUBTILE_FACTOR == 2, "wide store handoff is specialized for two M fragments")
+    acc_packed_0, acc_packed_1 = split_m_subtiles(acc_packed, p.SWIGLU_SUBTILE_FACTOR)
+    gelu_0, linear_0 = _swiglu_step1(acc_packed_0, p.SWIGLU_LIMIT)
+    gelu_1, linear_1 = _swiglu_step1(acc_packed_1, p.SWIGLU_LIMIT)
+    out_packed_0 = _swiglu_step2(gelu_0, linear_0, p.SWIGLU_ALPHA)
+    out_packed_1 = _swiglu_step2(gelu_1, linear_1, p.SWIGLU_ALPHA)
+    payload_0 = pack_fp8_out_fragment(out_packed_0, out_recip)
+    payload_1 = pack_fp8_out_fragment(out_packed_1, out_recip)
+    wide_payload = (gl.join(payload_0, payload_1).permute((2, 0, 1)).reshape(
+        (p.BLOCK_M, p.BLOCK_N // p.REDUCTION_N // 2)))
+
+    empty_bar = p.store_empty_bars.index(store_idx)
+    ready_bar = p.store_ready_bars.index(store_idx)
+    mbarrier.wait(empty_bar, store_phase, pred=store_issued >= p.EPILOGUE_BUFFER_DEPTH)
+    p.store_bufs.index(store_idx).store(wide_payload)
+    mbarrier.arrive(ready_bar)
+    next_store_idx, next_store_phase = advance(store_idx, store_phase, p.EPILOGUE_BUFFER_DEPTH)
+    return next_store_idx, next_store_phase, store_issued + 1
 
 
 @gluon.jit
@@ -518,16 +891,27 @@ def apply_bias_and_scale(
     acc_empty_bar = p.acc_empty_bars.index(idx)
     acc_ready_bar = p.acc_ready_bars.index(idx)
     acc_buf = p.acc_bufs.index(idx)
-    mbarrier.wait(acc_ready_bar, phase)
-    mbarrier.arrive(acc_empty_bar)
-    idx, phase = advance(idx, phase, p.acc_num_bufs)
 
     offs_bias_n = off_n + gl.arange(0, p.BLOCK_N, layout=bias_layout)
-    bias = gl.convert_layout(
-        gl.expand_dims(gl.load(p.bias_ptr + slice_idx * p.bias_stride + offs_bias_n), axis=0),
-        split_layout,
-    )
-    acc_regs = acc_buf.load().permute((1, 0))
+    if p.USE_DIRECT_EPILOGUE_STORE:
+        bias = gl.convert_layout(
+            gl.expand_dims(gl.load(p.bias_ptr + slice_idx * p.bias_stride + offs_bias_n), axis=0),
+            split_layout,
+        )
+        mbarrier.wait(acc_ready_bar, phase)
+        idx, phase = advance(idx, phase, p.acc_num_bufs)
+        acc_regs_raw = acc_buf.load()
+        mbarrier.arrive(acc_empty_bar)
+        acc_regs = acc_regs_raw.permute((1, 0))
+    else:
+        mbarrier.wait(acc_ready_bar, phase)
+        idx, phase = advance(idx, phase, p.acc_num_bufs)
+        bias = gl.convert_layout(
+            gl.expand_dims(gl.load(p.bias_ptr + slice_idx * p.bias_stride + offs_bias_n), axis=0),
+            split_layout,
+        )
+        acc_regs = acc_buf.load().permute((1, 0))
+        mbarrier.arrive(acc_empty_bar)
     acc = gl.convert_layout(acc_regs, split_layout)
     acc_packed = float2.pack(acc, axis=1)
     bias_packed = float2.pack(bias, axis=1)
@@ -539,13 +923,8 @@ def apply_bias_and_scale(
 @gluon.jit
 def epilogue_store_partition(p: PartitionArgs):
     gl.static_assert(p.SWIGLU_SUBTILE_FACTOR > 1, "store helper requires row fragments")
+    store_layout: gl.constexpr = get_store_layout(p)
     frag_rows: gl.constexpr = p.BLOCK_M // p.SWIGLU_SUBTILE_FACTOR
-    store_layout: gl.constexpr = gl.BlockedLayout(
-        [frag_rows // gl.num_warps(), 2],
-        [1, 32],
-        [gl.num_warps(), 1],
-        [1, 0],
-    )
     gl.static_assert(p.EPILOGUE_BUFFER_DEPTH >= 2, "store helper depth must be at least 2")
 
     store_idx = 0
@@ -554,9 +933,8 @@ def epilogue_store_partition(p: PartitionArgs):
         pid_m, pid_n, slice_idx, slice_offset = p.apply_block_schedule(block_id)
         off_m = pid_m * p.BLOCK_M
         shape_m = gl.load(p.x_slice_sizes + slice_idx)
-        out_off_n = (pid_n * p.BLOCK_N) // p.REDUCTION_N
-        for frag_idx in gl.static_range(p.SWIGLU_SUBTILE_FACTOR):
-            frag_off_m = off_m + frag_idx * frag_rows
+        out_off_n_packed = pid_n * (p.BLOCK_N // p.REDUCTION_N // 4)
+        if p.USE_WIDE_STORE_HANDOFF:
             ready_bar = p.store_ready_bars.index(store_idx)
             empty_bar = p.store_empty_bars.index(store_idx)
             mbarrier.wait(ready_bar, store_phase)
@@ -565,12 +943,29 @@ def epilogue_store_partition(p: PartitionArgs):
             store_packed_out(
                 p,
                 packed_fp8,
-                frag_off_m,
-                out_off_n,
+                off_m,
+                out_off_n_packed,
                 shape_m,
                 slice_offset,
             )
             store_idx, store_phase = advance(store_idx, store_phase, p.EPILOGUE_BUFFER_DEPTH)
+        else:
+            for frag_idx in gl.static_range(p.SWIGLU_SUBTILE_FACTOR):
+                frag_off_m = off_m + frag_idx * frag_rows
+                ready_bar = p.store_ready_bars.index(store_idx)
+                empty_bar = p.store_empty_bars.index(store_idx)
+                mbarrier.wait(ready_bar, store_phase)
+                packed_fp8 = p.store_bufs.index(store_idx).load(store_layout)
+                mbarrier.arrive(empty_bar)
+                store_packed_out(
+                    p,
+                    packed_fp8,
+                    frag_off_m,
+                    out_off_n_packed,
+                    shape_m,
+                    slice_offset,
+                )
+                store_idx, store_phase = advance(store_idx, store_phase, p.EPILOGUE_BUFFER_DEPTH)
 
 
 @gluon.jit
@@ -579,6 +974,7 @@ def epilogue_partition(p: PartitionArgs):
     phase = 0
     store_idx = 0
     store_phase = 1
+    store_issued = 0
 
     x_scale = 1.0 if p.x_scale_ptr is None else gl.load(p.x_scale_ptr)
     w_scale = 1.0 if p.w_scale_ptr is None else gl.load(p.w_scale_ptr)
@@ -586,17 +982,24 @@ def epilogue_partition(p: PartitionArgs):
     out_recip = 1.0 / gl.load(p.out_scale_ptr)
 
     num_warps: gl.constexpr = gl.num_warps()
-    warps_n: gl.constexpr = 2 if num_warps >= 8 and p.BLOCK_N >= 256 else 1
+    warps_n: gl.constexpr = 1 if p.FORCE_EPILOGUE_WARPS_N1 else (2 if num_warps >= 8 and p.BLOCK_N >= 256 else 1)
+    split_cga_layout: gl.constexpr = ((0, 1), ) if p.USE_2CTA else ()
     split_layout: gl.constexpr = gl.BlockedLayout(
         [1, 4],
         [1, 32],
         [num_warps // warps_n, warps_n],
         [1, 0],
+        cga_layout=split_cga_layout,
     )
     bias_layout: gl.constexpr = gl.SliceLayout(0, split_layout)
+    store_layout: gl.constexpr = get_store_layout(p)
 
     for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
-        pid_m, pid_n, slice_idx, _ = p.apply_block_schedule(block_id)
+        pid_m, pid_n, slice_idx, slice_offset = p.apply_block_schedule(block_id)
+        if p.USE_DIRECT_EPILOGUE_STORE:
+            off_m = pid_m * p.BLOCK_M
+            shape_m = gl.load(p.x_slice_sizes + slice_idx)
+            out_off_n_packed = pid_n * (p.BLOCK_N // p.REDUCTION_N // 4)
         idx, phase, acc_packed = apply_bias_and_scale(
             p,
             idx,
@@ -608,13 +1011,35 @@ def epilogue_partition(p: PartitionArgs):
             acc_scale,
         )
 
-        store_idx, store_phase = epilogue_overlapped_store(
-            p,
-            acc_packed,
-            out_recip,
-            store_idx,
-            store_phase,
-        )
+        if p.USE_DIRECT_EPILOGUE_STORE:
+            epilogue_direct_store(
+                p,
+                acc_packed,
+                out_recip,
+                off_m,
+                out_off_n_packed,
+                shape_m,
+                slice_offset,
+                store_layout,
+            )
+        elif p.USE_WIDE_STORE_HANDOFF:
+            store_idx, store_phase, store_issued = epilogue_wide_store_handoff(
+                p,
+                acc_packed,
+                out_recip,
+                store_idx,
+                store_phase,
+                store_issued,
+            )
+        else:
+            store_idx, store_phase, store_issued = epilogue_overlapped_store(
+                p,
+                acc_packed,
+                out_recip,
+                store_idx,
+                store_phase,
+                store_issued,
+            )
 
 
 @gluon.jit
@@ -634,6 +1059,7 @@ def ws_matmul_kernel(
     x_slice_offs: gl.tensor,
     x_block_offs: gl.tensor,
     x_block_schedule: gl.tensor,
+    x_tile_schedule: gl.tensor,
     #
     x_scale_ptr: gl.tensor,
     w_scale_ptr: gl.tensor,
@@ -654,6 +1080,7 @@ def ws_matmul_kernel(
     BLOCK_N: gl.constexpr,
     BLOCK_K: gl.constexpr,
     NUM_SMS: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
     X_NUM_BUFS: gl.constexpr,
     W_NUM_BUFS: gl.constexpr,
     ACC_NUM_BUFS: gl.constexpr,
@@ -667,11 +1094,26 @@ def ws_matmul_kernel(
     STORE_HELPER_REGS: gl.constexpr,
     SWIGLU_SUBTILE_FACTOR: gl.constexpr,
     EPILOGUE_BUFFER_DEPTH: gl.constexpr,
+    USE_PLANAR_SNAKE: gl.constexpr,
+    GRID_MINOR_DIM: gl.constexpr,
+    GRID_TILE_WIDTH: gl.constexpr,
     BAND_N: gl.constexpr,
+    USE_FULL_TILE_SCHEDULE: gl.constexpr,
+    X_GATHER_MULTICAST: gl.constexpr,
+    W_SCALE_MULTICAST: gl.constexpr,
+    FORCE_EPILOGUE_WARPS_N1: gl.constexpr,
+    USE_WIDE_STORE_HANDOFF: gl.constexpr,
+    USE_DIRECT_EPILOGUE_STORE: gl.constexpr,
+    REUSE_GATHER_INDICES: gl.constexpr,
+    INLINE_MMA_INPUT_RELEASE: gl.constexpr,
     SCALE_SIZE_OUTER: gl.constexpr,
     SCALE_SIZE_INNER: gl.constexpr,
     MXFP_BLOCK_SIZE: gl.constexpr,
 ):
+    use_2cta: gl.constexpr = gl.num_ctas() > 1
+    gl.static_assert(gl.num_ctas() == 1 or gl.num_ctas() == 2, "kernel supports at most 2 CTAs")
+    gl.static_assert(not use_2cta or BLOCK_N >= 256, "2CTA path requires at least 128 columns per CTA")
+
     grid_m = gl.load(x_block_offs + NUM_SLICES)
     grid_n: gl.constexpr = triton.cdiv(N, BLOCK_N)
     k_tiles: gl.constexpr = triton.cdiv(K, BLOCK_K)
@@ -680,9 +1122,16 @@ def ws_matmul_kernel(
     num_blocks = grid_m * grid_n
 
     scale_k: gl.constexpr = BLOCK_K // MXFP_BLOCK_SIZE
-    scale_layout: gl.constexpr = blackwell.TensorMemoryScalesLayout()
-    MMA_BLOCK_COL: gl.constexpr = min(128, BLOCK_N)
-    acc_layout: gl.constexpr = blackwell.TensorMemoryLayout([MMA_BLOCK_COL, BLOCK_M], col_stride=1)
+    block_m_per_cta: gl.constexpr = BLOCK_M // gl.num_ctas()
+    x_scale_layout: gl.constexpr = blackwell.TensorMemoryScalesLayout(cga_layout=((0, 0), ) if use_2cta else (), )
+    w_scale_layout: gl.constexpr = blackwell.TensorMemoryScalesLayout(cga_layout=((1, 0), ) if use_2cta else (), )
+    mma_block_col: gl.constexpr = min(128, BLOCK_N // gl.num_ctas())
+    acc_layout: gl.constexpr = blackwell.TensorMemoryLayout(
+        [mma_block_col, BLOCK_M],
+        col_stride=1,
+        cga_layout=((1, 0), ) if use_2cta else (),
+        two_ctas=use_2cta,
+    )
 
     x_num_bufs: gl.constexpr = X_NUM_BUFS
     x_bufs = gl.allocate_shared_memory(
@@ -690,9 +1139,10 @@ def ws_matmul_kernel(
         [x_num_bufs, BLOCK_M, x_desc.block_type.shape[1]],
         x_desc.layout,
     )
-    x_empty_bars, x_ready_bars = alloc_empty_ready_barriers(x_num_bufs)
+    x_empty_bars, x_ready_bars = alloc_empty_ready_barriers(x_num_bufs, ready_two_ctas=use_2cta)
 
     w_num_bufs: gl.constexpr = W_NUM_BUFS
+    w_scale_num_bufs: gl.constexpr = w_num_bufs
     w_bufs = gl.allocate_shared_memory(
         w_desc.dtype,
         [w_num_bufs] + w_desc.block_type.shape,
@@ -700,28 +1150,41 @@ def ws_matmul_kernel(
     )
     w_scale_bufs = gl.allocate_shared_memory(
         scale_desc.dtype,
-        [w_num_bufs] + scale_desc.block_type.shape,
+        [w_scale_num_bufs] + scale_desc.block_type.shape,
         scale_desc.layout,
     )
-    w_empty_bars, w_ready_bars = alloc_empty_ready_barriers(w_num_bufs)
+    w_empty_bars, w_ready_bars = alloc_empty_ready_barriers(w_num_bufs, ready_two_ctas=use_2cta)
+    w_scale_empty_bars = w_empty_bars
+    w_scale_ready_bars = w_ready_bars
 
-    x_scale_tmem = blackwell.allocate_tensor_memory(gl.uint8, [BLOCK_M, scale_k], scale_layout)
-    w_scale_tmem = blackwell.allocate_tensor_memory(gl.uint8, [BLOCK_N, scale_k], scale_layout)
+    x_scale_tmem = blackwell.allocate_tensor_memory(gl.uint8, [BLOCK_M, scale_k], x_scale_layout)
+    w_scale_tmem = blackwell.allocate_tensor_memory(gl.uint8, [BLOCK_N, scale_k], w_scale_layout)
+    w_scale_tmem_alt = w_scale_tmem
 
     acc_num_bufs: gl.constexpr = ACC_NUM_BUFS
-    acc_tmem = blackwell.allocate_tensor_memory(gl.float32, [acc_num_bufs, BLOCK_N, BLOCK_M], acc_layout)
-    acc_empty_bars, acc_ready_bars = alloc_empty_ready_barriers(acc_num_bufs)
-
-    gl.static_assert(SWIGLU_SUBTILE_FACTOR > 1, "store helper requires row fragments")
-    gl.static_assert(EPILOGUE_BUFFER_DEPTH >= 2, "store helper depth must be at least 2")
-    frag_rows: gl.constexpr = BLOCK_M // SWIGLU_SUBTILE_FACTOR
-    out_packed_n: gl.constexpr = BLOCK_N // REDUCTION_N // 2
-    store_bufs = gl.allocate_shared_memory(
-        gl.int16,
-        [EPILOGUE_BUFFER_DEPTH, frag_rows, out_packed_n],
-        gl.SwizzledSharedLayout(1, 1, 1, [1, 0]),
+    acc_tmem = blackwell.allocate_tensor_memory(
+        gl.float32,
+        [acc_num_bufs, BLOCK_N, BLOCK_M],
+        acc_layout,
     )
-    store_empty_bars, store_ready_bars = alloc_empty_ready_barriers(EPILOGUE_BUFFER_DEPTH)
+    acc_empty_bars, acc_ready_bars = alloc_empty_ready_barriers(acc_num_bufs, empty_two_ctas=use_2cta)
+
+    if USE_DIRECT_EPILOGUE_STORE:
+        store_bufs = x_bufs
+        store_empty_bars = x_empty_bars
+        store_ready_bars = x_ready_bars
+    else:
+        gl.static_assert(SWIGLU_SUBTILE_FACTOR > 1, "store helper requires row fragments")
+        gl.static_assert(EPILOGUE_BUFFER_DEPTH >= 2, "store helper depth must be at least 2")
+        frag_rows: gl.constexpr = BLOCK_M // SWIGLU_SUBTILE_FACTOR
+        store_rows: gl.constexpr = BLOCK_M if USE_WIDE_STORE_HANDOFF else frag_rows
+        out_packed_n: gl.constexpr = BLOCK_N // REDUCTION_N // 2
+        store_bufs = gl.allocate_shared_memory(
+            gl.int16,
+            [EPILOGUE_BUFFER_DEPTH, store_rows, out_packed_n],
+            gl.SwizzledSharedLayout(1, 1, 1, [1, 0], cga_layout=((0, 1), ) if use_2cta else ()),
+        )
+        store_empty_bars, store_ready_bars = alloc_empty_ready_barriers(EPILOGUE_BUFFER_DEPTH)
 
     x_scale_tmem.store(gl.full((BLOCK_M, scale_k), 127, dtype=gl.uint8, layout=x_scale_tmem.get_reg_layout()))
 
@@ -742,6 +1205,7 @@ def ws_matmul_kernel(
         x_slice_offs=x_slice_offs,
         x_block_offs=x_block_offs,
         x_block_schedule=x_block_schedule,
+        x_tile_schedule=x_tile_schedule,
         #
         x_bufs=x_bufs,
         x_empty_bars=x_empty_bars,
@@ -752,10 +1216,14 @@ def ws_matmul_kernel(
         w_scale_bufs=w_scale_bufs,
         w_empty_bars=w_empty_bars,
         w_ready_bars=w_ready_bars,
+        w_scale_empty_bars=w_scale_empty_bars,
+        w_scale_ready_bars=w_scale_ready_bars,
         w_num_bufs=w_num_bufs,
+        w_scale_num_bufs=w_scale_num_bufs,
         #
         x_scale_tmem=x_scale_tmem,
         w_scale_tmem=w_scale_tmem,
+        w_scale_tmem_alt=w_scale_tmem_alt,
         acc_bufs=acc_tmem,
         acc_empty_bars=acc_empty_bars,
         acc_ready_bars=acc_ready_bars,
@@ -773,6 +1241,9 @@ def ws_matmul_kernel(
         num_blocks=num_blocks,
         #
         NUM_SMS=NUM_SMS,
+        NUM_WARPS=NUM_WARPS,
+        USE_2CTA=use_2cta,
+        BLOCK_M_PER_CTA=block_m_per_cta,
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
         BLOCK_K=BLOCK_K,
@@ -787,20 +1258,43 @@ def ws_matmul_kernel(
         #
         SWIGLU_SUBTILE_FACTOR=SWIGLU_SUBTILE_FACTOR,
         EPILOGUE_BUFFER_DEPTH=EPILOGUE_BUFFER_DEPTH,
+        USE_PLANAR_SNAKE=USE_PLANAR_SNAKE,
+        GRID_MINOR_DIM=GRID_MINOR_DIM,
+        GRID_TILE_WIDTH=GRID_TILE_WIDTH,
         BAND_N=BAND_N,
+        USE_FULL_TILE_SCHEDULE=USE_FULL_TILE_SCHEDULE,
+        X_GATHER_MULTICAST=X_GATHER_MULTICAST,
+        W_SCALE_MULTICAST=W_SCALE_MULTICAST,
+        FORCE_EPILOGUE_WARPS_N1=FORCE_EPILOGUE_WARPS_N1,
+        USE_WIDE_STORE_HANDOFF=USE_WIDE_STORE_HANDOFF,
+        USE_DIRECT_EPILOGUE_STORE=USE_DIRECT_EPILOGUE_STORE,
+        REUSE_GATHER_INDICES=REUSE_GATHER_INDICES,
+        INLINE_MMA_INPUT_RELEASE=INLINE_MMA_INPUT_RELEASE,
     )
 
-    gl.warp_specialize(
-        [
-            (epilogue_partition, (p, )),
-            (epilogue_store_partition, (p, )),
-            (load_activations, (p, )),
-            (load_weights, (p, )),
-            (mma_partition, (p, )),
-        ],
-        [STORE_HELPER_WARPS, LOAD_ACTIVATION_WARPS, LOAD_WEIGHT_WARPS, MMA_WARPS],
-        [STORE_HELPER_REGS, LOAD_ACTIVATION_REGS, LOAD_WEIGHT_REGS, MMA_REGS],
-    )
+    if USE_DIRECT_EPILOGUE_STORE:
+        gl.warp_specialize(
+            [
+                (epilogue_partition, (p, )),
+                (load_activations, (p, )),
+                (load_weights, (p, )),
+                (mma_partition, (p, )),
+            ],
+            [LOAD_ACTIVATION_WARPS, LOAD_WEIGHT_WARPS, MMA_WARPS],
+            [LOAD_ACTIVATION_REGS, LOAD_WEIGHT_REGS, MMA_REGS],
+        )
+    else:
+        gl.warp_specialize(
+            [
+                (epilogue_partition, (p, )),
+                (epilogue_store_partition, (p, )),
+                (load_activations, (p, )),
+                (load_weights, (p, )),
+                (mma_partition, (p, )),
+            ],
+            [STORE_HELPER_WARPS, LOAD_ACTIVATION_WARPS, LOAD_WEIGHT_WARPS, MMA_WARPS],
+            [STORE_HELPER_REGS, LOAD_ACTIVATION_REGS, LOAD_WEIGHT_REGS, MMA_REGS],
+        )
 
 
 # ===-----------------------------------------------------------------------===#
@@ -808,7 +1302,7 @@ def ws_matmul_kernel(
 # ===-----------------------------------------------------------------------===#
 
 
-def get_operand_layout(t: Tensor, block_shape: list[int]):
+def get_operand_layout(t: Tensor, block_shape: list[int], cga_layout: tuple[tuple[int, ...], ...] = ()):
     rank = len(block_shape)
     if t.dtype == FP4:
         assert rank == 5
@@ -817,6 +1311,7 @@ def get_operand_layout(t: Tensor, block_shape: list[int]):
             element_bitwidth=8,
             rank=rank,
             fp4_padded=True,
+            cga_layout=cga_layout,
         )
     if t.dtype == UINT8:
         assert rank == 5
@@ -824,12 +1319,14 @@ def get_operand_layout(t: Tensor, block_shape: list[int]):
             swizzle_byte_width=0,
             element_bitwidth=8,
             rank=rank,
+            cga_layout=cga_layout,
         )
     if t.dtype == torch.float32:
         assert rank == 2
         return gl.NVMMASharedLayout.get_default_for(
             block_shape,
             torch.float32,
+            cga_layout=cga_layout,
         )
 
     assert t.dtype == torch.float8_e4m3fn
@@ -837,10 +1334,15 @@ def get_operand_layout(t: Tensor, block_shape: list[int]):
         swizzle_byte_width=block_shape[-1],
         element_bitwidth=8,
         rank=rank,
+        cga_layout=cga_layout,
     )
 
 
-def make_operand_descriptor(t: torch.Tensor | Tensor, block_shape: tuple[int, ...]):
+def make_operand_descriptor(
+        t: torch.Tensor | Tensor,
+        block_shape: tuple[int, ...],
+        cga_layout: tuple[tuple[int, ...], ...] = (),
+):
     from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 
     ptr = t if isinstance(t, torch.Tensor) else t.storage.data
@@ -852,8 +1354,27 @@ def make_operand_descriptor(t: torch.Tensor | Tensor, block_shape: tuple[int, ..
         block_shape = t.storage.layout.swizzle_block_shape(list(block_shape))
         block_shape[strides.index(1)] //= 2
 
-    layout = get_operand_layout(t, list(block_shape))
+    layout = get_operand_layout(t, list(block_shape), cga_layout=cga_layout)
     return TensorDescriptor(ptr, shape, strides, block_shape, layout)
+
+
+def make_gather_operand_descriptor(
+        t: torch.Tensor,
+        block_shape: tuple[int, ...],
+        layout_block_shape: tuple[int, ...],
+        cga_layout: tuple[tuple[int, ...], ...] = (),
+):
+    from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
+
+    layout = get_operand_layout(t, list(layout_block_shape), cga_layout=cga_layout)
+    return TensorDescriptor(t, list(t.shape), list(t.stride()), list(block_shape), layout)
+
+
+def make_output_meta_descriptor(t: torch.Tensor, block_shape: tuple[int, int]):
+    # The output descriptor is only used for shape/stride metadata in the
+    # manual store path, so cap the layout width to a legal FP8 swizzle size.
+    block_m, block_n = block_shape
+    return make_operand_descriptor(t, (block_m, min(block_n, 128)))
 
 
 @dataclass(frozen=True, slots=True)
@@ -862,8 +1383,10 @@ class KernelConfig:
     BLOCK_N: int = 256
     BLOCK_K: int = 128
 
+    NUM_CTAS: int = 1
     X_NUM_BUFS: int = 5
     W_NUM_BUFS: int = 4
+    W_SCALE_NUM_BUFS: int = 0
     ACC_NUM_BUFS: int = 1
 
     NUM_WARPS: int = 8
@@ -874,7 +1397,18 @@ class KernelConfig:
 
     SWIGLU_SUBTILE_FACTOR: int = 8
     EPILOGUE_BUFFER_DEPTH: int = 2
+    USE_PLANAR_SNAKE: bool = False
+    GRID_MINOR_DIM: int = 0
+    GRID_TILE_WIDTH: int = 8
     BAND_N: int = 20
+    USE_FULL_TILE_SCHEDULE: bool = False
+    X_GATHER_MULTICAST: bool = True
+    W_SCALE_MULTICAST: bool = True
+    FORCE_EPILOGUE_WARPS_N1: bool = False
+    USE_WIDE_STORE_HANDOFF: bool = False
+    USE_DIRECT_EPILOGUE_STORE: bool = False
+    REUSE_GATHER_INDICES: bool = False
+    INLINE_MMA_INPUT_RELEASE: bool = False
 
     LOAD_ACTIVATION_REGS: int = 112
     LOAD_WEIGHT_REGS: int = 48
@@ -901,8 +1435,15 @@ class KernelConfig:
 
 
 def _select_occ2_config(slice_size: int) -> KernelConfig:
-    p = KernelConfig(BLOCK_N=128, OCCUPANCY=2, MAXNREG=64, LOAD_ACTIVATION_REGS=48, LOAD_WEIGHT_REGS=32, MMA_REGS=32,
-                     STORE_HELPER_REGS=32)
+    p = KernelConfig(
+        BLOCK_N=128,
+        OCCUPANCY=2,
+        MAXNREG=64,
+        LOAD_ACTIVATION_REGS=48,
+        LOAD_WEIGHT_REGS=32,
+        MMA_REGS=32,
+        STORE_HELPER_REGS=32,
+    )
 
     if slice_size <= 14:
         p = replace(p, BLOCK_M=16)
@@ -955,6 +1496,29 @@ def _select_occ1_config(slice_size: int) -> KernelConfig:
     return p
 
 
+def get_acc_cga_layout(num_ctas: int) -> tuple[tuple[int, int], ...]:
+    if num_ctas == 1:
+        return ()
+    if num_ctas == 2:
+        return ((1, 0), )
+    raise ValueError(f"unsupported CTA count: {num_ctas}")
+
+
+def get_x_desc_cga_layout(acc_cga_layout: tuple[tuple[int, int], ...]) -> tuple[tuple[int, int], ...]:
+    return tuple((basis[0], 0) for basis in acc_cga_layout)
+
+
+def get_w_desc_cga_layout(acc_cga_layout: tuple[tuple[int, int], ...]) -> tuple[tuple[int, int, int, int, int], ...]:
+    # Sharded weight tiles use the physical [1, 1, 1, N, K/2] MX4 shuffled block layout.
+    return tuple((0, 0, 0, basis[0], 0) for basis in acc_cga_layout)
+
+
+def get_w_scale_desc_cga_layout(
+    acc_cga_layout: tuple[tuple[int, int], ...], ) -> tuple[tuple[int, int, int, int, int], ...]:
+    # Weight scale tiles use the physical [1, N//128, K//(32*4), 2, 256] layout.
+    return tuple((0, basis[0], 0, 0, 0) for basis in acc_cga_layout)
+
+
 def _select_band_n(slice_size: int) -> int:
     if slice_size < 32:
         return 22
@@ -964,13 +1528,223 @@ def _select_band_n(slice_size: int) -> int:
         return 26
 
 
+def maybe_enable_2cta(p: KernelConfig, slice_size: int) -> KernelConfig:
+    if p.BLOCK_M == 32 and p.BLOCK_N == 128 and slice_size in (16, 20, 24, 32):
+        # Low-batch 2CTA only wins when the wider N tile is paired with direct
+        # epilogue stores and a four-warp layout. Slice 28 remains on 1CTA
+        # because uniform routing still shows a stable regression there.
+        next_p = replace(
+            p,
+            BLOCK_N=256,
+            NUM_CTAS=2,
+            NUM_WARPS=4,
+            W_NUM_BUFS=5,
+            SWIGLU_SUBTILE_FACTOR=1,
+            LOAD_ACTIVATION_WARPS=2,
+            LOAD_WEIGHT_WARPS=1,
+            MMA_WARPS=1,
+            LOAD_ACTIVATION_REGS=40,
+            LOAD_WEIGHT_REGS=32,
+            MMA_REGS=32,
+            MAXNREG=52,
+            BAND_N=32,
+            FORCE_EPILOGUE_WARPS_N1=True,
+            USE_DIRECT_EPILOGUE_STORE=True,
+        )
+        if slice_size == 16:
+            return replace(next_p, X_NUM_BUFS=5)
+        if slice_size in (20, 24):
+            return replace(next_p, X_NUM_BUFS=6)
+        return replace(next_p, X_NUM_BUFS=6, X_GATHER_MULTICAST=False, W_SCALE_MULTICAST=False)
+    if 36 <= slice_size <= 72:
+        # The tuned 64-row multicta kernel wins through the 72-token slice
+        # crossover once it keeps the deeper x/w pipeline, shallower SwiGLU
+        # fragmentation, and the wider low-batch banded schedule together.
+        return replace(
+            p,
+            BLOCK_M=64,
+            BLOCK_N=256,
+            NUM_CTAS=2,
+            OCCUPANCY=2,
+            X_NUM_BUFS=6,
+            W_NUM_BUFS=5,
+            SWIGLU_SUBTILE_FACTOR=4,
+            EPILOGUE_BUFFER_DEPTH=2,
+            LOAD_ACTIVATION_REGS=64,
+            LOAD_WEIGHT_REGS=48,
+            MMA_REGS=48,
+            STORE_HELPER_REGS=48,
+            MAXNREG=64,
+        )
+    if p.BLOCK_M == 128 and p.BLOCK_N == 256 and slice_size >= 80:
+        # Along N, 2CTA doubles the output tile width without increasing the
+        # per-CTA weight tile footprint, which makes the extra synchronization
+        # pay back across the entire occ1 range.
+        return replace(p, BLOCK_N=512, NUM_CTAS=2, W_NUM_BUFS=5)
+    return p
+
+
 def select_kernel_config(slice_size: int) -> KernelConfig:
     if slice_size <= 64:
         p = _select_occ2_config(slice_size)
     else:
         p = _select_occ1_config(slice_size)
-    p = replace(p, BAND_N=_select_band_n(slice_size))
+    p = maybe_enable_2cta(p, slice_size)
+    if p.BLOCK_M == 32 and p.BLOCK_N == 256 and p.NUM_CTAS == 2 and p.USE_DIRECT_EPILOGUE_STORE and slice_size <= 32:
+        p = replace(p, BAND_N=32)
+    elif p.BLOCK_M == 64 and p.BLOCK_N == 256 and p.NUM_CTAS == 2 and 36 <= slice_size <= 72:
+        p = replace(p, BAND_N=26)
+    else:
+        p = replace(p, BAND_N=_select_band_n(slice_size))
     return p
+
+
+_dynamic_block_schedule_cache: dict[tuple[int, int], tuple[torch.Tensor, torch.Tensor]] = {}
+_dynamic_full_tile_schedule_cache: dict[tuple[int, int, int, bool, int, int, int], torch.Tensor] = {}
+_dummy_full_tile_schedule_cache: dict[torch.device, torch.Tensor] = {}
+
+
+def get_block_schedule_tensors(
+    ragged_metadata: RaggedTensorMetadata,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    precomputed_sizes = RaggedTensorMetadata.block_sizes()
+    if block_size in precomputed_sizes:
+        block_idx = precomputed_sizes.index(block_size)
+        return ragged_metadata.block_offs_data[block_idx], ragged_metadata.block_schedule_data[block_idx]
+
+    key = (id(ragged_metadata), block_size)
+    cached = _dynamic_block_schedule_cache.get(key)
+    if cached is not None:
+        return cached
+
+    slice_sizes_cpu = ragged_metadata.slice_sizes.cpu().tolist()
+    block_counts = [(int(size) + block_size - 1) // block_size for size in slice_sizes_cpu]
+    block_offs = [0]
+    for count in block_counts:
+        block_offs.append(block_offs[-1] + count)
+
+    packed_schedule = [(pid_m << 16) | slice_idx
+                       for slice_idx, count in enumerate(block_counts)
+                       for pid_m in range(count)]
+
+    device = ragged_metadata.slice_sizes.device
+    block_offs_t = torch.tensor(block_offs, dtype=torch.int32, device=device)
+    block_schedule_t = torch.tensor(packed_schedule, dtype=torch.int32, device=device)
+    _dynamic_block_schedule_cache[key] = (block_offs_t, block_schedule_t)
+    return block_offs_t, block_schedule_t
+
+
+def _host_banded_row_major(lin_idx: int, m_tiles: int, n_tiles: int, band_n: int) -> tuple[int, int]:
+    full_band_tiles = m_tiles * band_n
+    n_full_bands = n_tiles // band_n
+    full_band_work = n_full_bands * full_band_tiles
+
+    if lin_idx < full_band_work:
+        band_id = lin_idx // full_band_tiles
+        within_band = lin_idx % full_band_tiles
+        return within_band // band_n, band_id * band_n + (within_band % band_n)
+
+    tail_n = n_tiles - n_full_bands * band_n
+    assert tail_n > 0
+    tail_idx = lin_idx - full_band_work
+    return tail_idx // tail_n, n_full_bands * band_n + (tail_idx % tail_n)
+
+
+def _host_planar_snake(
+    lin_idx: int,
+    m_tiles: int,
+    n_tiles: int,
+    minor_dim: int,
+    tile_width: int,
+) -> tuple[int, int]:
+    major_size = n_tiles if minor_dim == 0 else m_tiles
+    minor_size = m_tiles if minor_dim == 0 else n_tiles
+
+    full_minor_tiles = minor_size // tile_width
+    full_minor_size = full_minor_tiles * tile_width
+    full_elements = full_minor_tiles * tile_width * major_size
+    minor_tile_idx = lin_idx // (tile_width * major_size)
+
+    if lin_idx < full_elements:
+        minor_within = lin_idx % tile_width
+        major_within = (lin_idx // tile_width) % major_size
+    else:
+        partial_width = minor_size - full_minor_size
+        partial_width = partial_width if partial_width > 0 else 1
+        partial_lin = lin_idx - full_elements
+        minor_within = partial_lin % partial_width
+        major_within = (partial_lin // partial_width) % major_size
+
+    minor = minor_tile_idx * tile_width + minor_within
+    major = major_within if (minor_tile_idx % 2) == 0 else major_size - 1 - major_within
+    if minor_dim == 0:
+        return minor, major
+    return major, minor
+
+
+def get_full_tile_schedule_tensor(
+    ragged_metadata: RaggedTensorMetadata,
+    block_size: int,
+    grid_n: int,
+    *,
+    use_planar_snake: bool,
+    grid_minor_dim: int,
+    grid_tile_width: int,
+    band_n: int,
+) -> torch.Tensor:
+    key = (
+        id(ragged_metadata),
+        block_size,
+        grid_n,
+        use_planar_snake,
+        grid_minor_dim,
+        grid_tile_width,
+        band_n,
+    )
+    cached = _dynamic_full_tile_schedule_cache.get(key)
+    if cached is not None:
+        return cached
+
+    block_offs, block_schedule = get_block_schedule_tensors(ragged_metadata, block_size)
+    grid_m = int(block_offs[ragged_metadata.n_slices].item())
+    assert ragged_metadata.n_slices < (1 << 16)
+    assert grid_m < (1 << 16)
+    assert grid_n < (1 << 16)
+
+    block_schedule_cpu = block_schedule.cpu().tolist()
+    packed_schedule: list[int] = []
+    for lin_idx in range(grid_m * grid_n):
+        if use_planar_snake:
+            schedule_pid_m, pid_n = _host_planar_snake(
+                lin_idx,
+                grid_m,
+                grid_n,
+                grid_minor_dim,
+                grid_tile_width,
+            )
+        else:
+            schedule_pid_m, pid_n = _host_banded_row_major(lin_idx, grid_m, grid_n, band_n)
+
+        m_entry = int(block_schedule_cpu[schedule_pid_m])
+        slice_idx = m_entry & 0xFFFF
+        pid_m = m_entry >> 16
+        assert slice_idx < (1 << 16)
+        assert pid_m < (1 << 16)
+        assert pid_n < (1 << 16)
+        packed_schedule.append(slice_idx | (pid_m << 16) | (pid_n << 32))
+
+    tile_schedule = torch.tensor(packed_schedule, dtype=torch.int64, device=ragged_metadata.slice_sizes.device)
+    _dynamic_full_tile_schedule_cache[key] = tile_schedule
+    return tile_schedule
+
+
+def get_dummy_full_tile_schedule_tensor(device: torch.device) -> torch.Tensor:
+    cached = _dummy_full_tile_schedule_cache.get(device)
+    if cached is None:
+        cached = torch.zeros((1, ), dtype=torch.int64, device=device)
+        _dummy_full_tile_schedule_cache[device] = cached
+    return cached
 
 
 def matmul(
@@ -1008,17 +1782,35 @@ def matmul(
     assert isinstance(b.storage.layout, BlackwellMX4ValueShuffledLayout)
     assert b.storage.layout.block_k == p.BLOCK_K
     assert b.storage.layout.block_n == p.BLOCK_N
-    x_block_idx = p.BLOCK_M.bit_length() - 5
-
+    x_block_offs, x_block_schedule = get_block_schedule_tensors(a_ragged_metadata, p.BLOCK_M)
     expected_grid_m = a_ragged_metadata.n_blocks(a_ragged_metadata.n_slices, m, p.BLOCK_M)
     grid_n = triton.cdiv(n, p.BLOCK_N)
     sms = torch.cuda.get_device_properties(bias.device).multi_processor_count
     sms *= p.OCCUPANCY
-    launch_grid = max(1, min(sms, expected_grid_m * grid_n))
+    launch_grid = max(1, min(max(1, sms // p.NUM_CTAS), expected_grid_m * grid_n))
+    x_tile_schedule = (get_full_tile_schedule_tensor(
+        a_ragged_metadata,
+        p.BLOCK_M,
+        grid_n,
+        use_planar_snake=p.USE_PLANAR_SNAKE,
+        grid_minor_dim=p.GRID_MINOR_DIM,
+        grid_tile_width=p.GRID_TILE_WIDTH,
+        band_n=p.BAND_N,
+    ) if p.USE_FULL_TILE_SCHEDULE else get_dummy_full_tile_schedule_tensor(a_ragged_metadata.slice_sizes.device))
     grid = (launch_grid, )
 
-    x_desc = make_operand_descriptor(a, (1, p.BLOCK_K))
-    w_desc = make_operand_descriptor(b, (1, p.BLOCK_K, p.BLOCK_N))
+    acc_cga_layout = get_acc_cga_layout(p.NUM_CTAS)
+    x_desc_cga_layout = get_x_desc_cga_layout(acc_cga_layout)
+    w_desc_cga_layout = get_w_desc_cga_layout(acc_cga_layout)
+    w_scale_desc_cga_layout = get_w_scale_desc_cga_layout(acc_cga_layout)
+
+    x_desc = make_gather_operand_descriptor(
+        a,
+        (1, p.BLOCK_K),
+        (p.BLOCK_M, p.BLOCK_K),
+        cga_layout=x_desc_cga_layout,
+    )
+    w_desc = make_operand_descriptor(b, (1, p.BLOCK_K, p.BLOCK_N), cga_layout=w_desc_cga_layout)
     scale_desc = make_operand_descriptor(
         b_mx_scales,
         (
@@ -1028,8 +1820,9 @@ def matmul(
             2,
             256,
         ),
+        cga_layout=w_scale_desc_cga_layout,
     )
-    out_desc = make_operand_descriptor(c, (p.BLOCK_M, p.BLOCK_N // reduction_n))
+    out_desc = make_output_meta_descriptor(c, (p.BLOCK_M, p.BLOCK_N // reduction_n))
 
     ws_matmul_kernel[grid](
         x_desc=x_desc,
@@ -1045,8 +1838,9 @@ def matmul(
         #
         x_slice_sizes=a_ragged_metadata.slice_sizes,
         x_slice_offs=a_ragged_metadata.slice_offs,
-        x_block_offs=a_ragged_metadata.block_offs_data[x_block_idx],
-        x_block_schedule=a_ragged_metadata.block_schedule_data[x_block_idx],
+        x_block_offs=x_block_offs,
+        x_block_schedule=x_block_schedule,
+        x_tile_schedule=x_tile_schedule,
         #
         x_scale_ptr=flex_ctx.lhs_data.scale,
         w_scale_ptr=flex_ctx.rhs_data.scale,
@@ -1067,6 +1861,7 @@ def matmul(
         BLOCK_N=p.BLOCK_N,
         BLOCK_K=p.BLOCK_K,
         NUM_SMS=launch_grid,
+        NUM_WARPS=p.NUM_WARPS,
         X_NUM_BUFS=p.X_NUM_BUFS,
         W_NUM_BUFS=p.W_NUM_BUFS,
         ACC_NUM_BUFS=p.ACC_NUM_BUFS,
@@ -1080,13 +1875,25 @@ def matmul(
         STORE_HELPER_REGS=p.STORE_HELPER_REGS,
         SWIGLU_SUBTILE_FACTOR=p.SWIGLU_SUBTILE_FACTOR,
         EPILOGUE_BUFFER_DEPTH=p.EPILOGUE_BUFFER_DEPTH,
+        USE_PLANAR_SNAKE=p.USE_PLANAR_SNAKE,
+        GRID_MINOR_DIM=p.GRID_MINOR_DIM,
+        GRID_TILE_WIDTH=p.GRID_TILE_WIDTH,
         BAND_N=p.BAND_N,
+        USE_FULL_TILE_SCHEDULE=p.USE_FULL_TILE_SCHEDULE,
+        X_GATHER_MULTICAST=p.X_GATHER_MULTICAST,
+        W_SCALE_MULTICAST=p.W_SCALE_MULTICAST,
+        FORCE_EPILOGUE_WARPS_N1=p.FORCE_EPILOGUE_WARPS_N1,
+        USE_WIDE_STORE_HANDOFF=p.USE_WIDE_STORE_HANDOFF,
+        USE_DIRECT_EPILOGUE_STORE=p.USE_DIRECT_EPILOGUE_STORE,
+        REUSE_GATHER_INDICES=p.REUSE_GATHER_INDICES,
+        INLINE_MMA_INPUT_RELEASE=p.INLINE_MMA_INPUT_RELEASE,
         #
         SCALE_SIZE_OUTER=p.SCALE_SIZE_OUTER,
         SCALE_SIZE_INNER=p.SCALE_SIZE_INNER,
         MXFP_BLOCK_SIZE=p.MXFP_BLOCK_SIZE,
         #
         num_warps=p.NUM_WARPS,
+        num_ctas=p.NUM_CTAS,
         maxnreg=p.MAXNREG,
     )
 
@@ -1136,11 +1943,16 @@ def alloc_randn(shape: tuple[int, ...], dtype: torch.dtype, device: str) -> torc
     return torch.randn(shape, device=device, dtype=dtype)
 
 
-def alloc_randn_fp4(shape: tuple[int, ...], device: str, p: KernelConfig) -> tuple[Tensor, Tensor]:
+def alloc_randn_fp4(shape: tuple[int, ...], device: str, p: KernelConfig | None) -> tuple[Tensor, Tensor]:
+    if p is not None:
+        block_k, block_n, num_warps = p.BLOCK_K, p.BLOCK_N, p.NUM_WARPS
+    else:
+        block_k, block_n, num_warps = 128, 256, 8
+
     data = alloc_randn(shape, torch.bfloat16, device)
     data, scale = downcast_to_mxfp(data, FP4, axis=1)  # type: ignore[arg-type]
-    data_layout = BlackwellMX4ValueShuffledLayout(block_k=p.BLOCK_K, block_n=p.BLOCK_N)
-    scale_layout = make_default_matmul_mxfp4_w_scale_layout(mx_axis=1, num_warps=p.NUM_WARPS)
+    data_layout = BlackwellMX4ValueShuffledLayout(block_k=block_k, block_n=block_n)
+    scale_layout = make_default_matmul_mxfp4_w_scale_layout(mx_axis=1, num_warps=num_warps)
     data = convert_layout(wrap_torch_tensor(data, dtype=FP4), data_layout)
     scale = convert_layout(wrap_torch_tensor(scale), scale_layout)
     return data, scale
@@ -1210,15 +2022,15 @@ def init_routing_data(c: MLPConfig, batch_size: int, local_rank: int, device: st
     return ragged_metadata, gather_indx
 
 
-def prepare_case(c: MLPConfig, batch_size: int, device: str, seed: int = 0, p: KernelConfig | None = None,
-                 uniform_routing: bool = False) -> PreparedCase:
+def prepare_case(c: MLPConfig, batch_size: int, device: str, seed: int = 0, uniform_routing: bool = False,
+                 reference: bool = False) -> PreparedCase:
     torch.manual_seed(seed)
 
     local_rank = int(torch.randint(0, c.num_expert_shards, size=()).item())
     k, n = c.hidden_size, c.intermediate_size
     n_expts_local = c.num_experts // c.num_expert_shards
     ragged_metadata, gather_indx = init_routing_data(c, batch_size, local_rank, device, uniform_routing)
-    p = p or select_kernel_config(ragged_metadata.expected_slice_size)
+    p = None if reference else select_kernel_config(ragged_metadata.expected_slice_size)
     x = alloc_randn((batch_size, k), dtype=torch.float8_e4m3fn, device=device)
     w, w_scale = alloc_randn_fp4((n_expts_local, k, n), device=device, p=p)
     bias = alloc_randn((n_expts_local, n), dtype=torch.float32, device=device)
@@ -1333,15 +2145,15 @@ GPT_OSS_120B_CONFIG = MLPConfig(
 
 
 def is_blackwell():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda" and torch.cuda.get_device_capability(
-    )[0] == 10
+    return (triton.runtime.driver.active.get_current_target().backend == "cuda"
+            and torch.cuda.get_device_capability()[0] == 10)
 
 
 @pytest.mark.parametrize("c", [GPT_OSS_120B_CONFIG])
 @pytest.mark.parametrize("batch_size", get_batch_sizes(GPT_OSS_120B_CONFIG))
 @pytest.mark.skipif(not is_blackwell(), reason="Gluon MoE BMM1 fused-gather is only supported on Blackwell GPUs")
 def test_op(c: MLPConfig, batch_size: tuple[int, ...]):
-    prepared = prepare_case(c, batch_size, device=f"cuda:{torch.cuda.current_device()}", seed=0)
+    prepared = prepare_case(c, batch_size, device=f"cuda:{torch.cuda.current_device()}")
     ref_y, ref_precision = run_provider(prepared, "reference")
     cand_y, cand_precision = run_provider(prepared, "example")
     description = f"{c.name}-mm1-bs{prepared.batch_size}"
@@ -1382,8 +2194,7 @@ PEAK_TBPS = 8.0
 
 def _format_perf(result: tuple[float, float]) -> str:
     tflops, tbps = result
-    return (f"{tflops:8.2f} TFLOPS ({tflops / PEAK_TFLOPS:6.1%})  "
-            f"{tbps:6.2f} TBPS ({tbps / PEAK_TBPS:6.1%})")
+    return f"{tflops:8.2f} TFLOPS ({tflops / PEAK_TFLOPS:6.1%})  {tbps:6.2f} TBPS ({tbps / PEAK_TBPS:6.1%})"
 
 
 def bench(c: MLPConfig = GPT_OSS_120B_CONFIG, uniform_routing: bool = False):
@@ -1397,9 +2208,7 @@ def bench(c: MLPConfig = GPT_OSS_120B_CONFIG, uniform_routing: bool = False):
     print(BENCH_TITLE, flush=True)
     print(f"Peak: {PEAK_TFLOPS / 1000:g} PFLOPS, {PEAK_TBPS:g} TBPS", flush=True)
     print(
-        f"{'batch_size':>{batch_width}}  "
-        f"{'example':>{perf_width}}  "
-        f"{'reference':>{perf_width}}",
+        f"{'batch_size':>{batch_width}}  {'example':>{perf_width}}  {'reference':>{perf_width}}",
         flush=True,
     )
     print("-" * (batch_width + 2 + perf_width + 2 + perf_width), flush=True)
@@ -1407,12 +2216,25 @@ def bench(c: MLPConfig = GPT_OSS_120B_CONFIG, uniform_routing: bool = False):
     device = f"cuda:{torch.cuda.current_device()}"
     for batch_size in batch_sizes:
         print(f"{batch_size:>{batch_width}}  ", end="", flush=True)
-        prepared = prepare_case(c, batch_size, device=device, seed=0, uniform_routing=uniform_routing)
-        flops, nbytes = estimate_benchmark_work(c, prepared)
 
+        prepared = prepare_case(
+            c,
+            batch_size,
+            device=device,
+            uniform_routing=uniform_routing,
+        )
+        flops, nbytes = estimate_benchmark_work(c, prepared)
         example = benchmark_kernel(prepared, matmul, flops, nbytes)
         print(f"{_format_perf(example):>{perf_width}}  ", end="", flush=True)
 
+        prepared = prepare_case(
+            c,
+            batch_size,
+            device=device,
+            uniform_routing=uniform_routing,
+            reference=True,
+        )
+        flops, nbytes = estimate_benchmark_work(c, prepared)
         reference = benchmark_kernel(prepared, reference_matmul, flops, nbytes)
         print(f"{_format_perf(reference):>{perf_width}}", flush=True)
 

--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -266,6 +266,7 @@ class PartitionArgs:
             BAND_N=self.BAND_N,
         )
 
+
 @gluon.jit
 def load_activations(p: PartitionArgs):
     local_cga_layout: gl.constexpr = ((0, 1), ) if p.USE_2CTA else ()
@@ -766,11 +767,11 @@ def ws_matmul_kernel(
 
 
 def make_tensor_descriptor(
-    t: torch.Tensor | Tensor,
-    block_shape: tuple[int, ...],
-    *,
-    layout_block_shape: tuple[int, ...] | None = None,
-    cga_layout: tuple[tuple[int, ...], ...] = (),
+        t: torch.Tensor | Tensor,
+        block_shape: tuple[int, ...],
+        *,
+        layout_block_shape: tuple[int, ...] | None = None,
+        cga_layout: tuple[tuple[int, ...], ...] = (),
 ):
     from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 

--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -112,7 +112,7 @@ def unswizzle_mx_scale(
 def alloc_barrier_ring(num_bufs: gl.constexpr, two_ctas: gl.constexpr = False):
     bars = mbarrier.allocate_mbarrier(batch=num_bufs, two_ctas=two_ctas)
     for i in gl.static_range(num_bufs):
-        mbarrier.init(bars.index(i))
+        mbarrier.init(bars.index(i), count=1)
     return bars
 
 
@@ -747,7 +747,6 @@ def ws_matmul_kernel(
     BLOCK_N: gl.constexpr,
     BLOCK_K: gl.constexpr,
     NUM_SMS: gl.constexpr,
-    NUM_WARPS: gl.constexpr,
     X_NUM_BUFS: gl.constexpr,
     W_NUM_BUFS: gl.constexpr,
     ACC_NUM_BUFS: gl.constexpr,
@@ -891,7 +890,6 @@ def ws_matmul_kernel(
         num_blocks=num_blocks,
         #
         NUM_SMS=NUM_SMS,
-        NUM_WARPS=NUM_WARPS,
         USE_2CTA=use_2cta,
         BLOCK_M_PER_CTA=block_m_per_cta,
         BLOCK_M=BLOCK_M,
@@ -1339,7 +1337,6 @@ def matmul(
         BLOCK_N=p.BLOCK_N,
         BLOCK_K=p.BLOCK_K,
         NUM_SMS=launch_grid,
-        NUM_WARPS=p.NUM_WARPS,
         X_NUM_BUFS=p.X_NUM_BUFS,
         W_NUM_BUFS=p.W_NUM_BUFS,
         ACC_NUM_BUFS=p.ACC_NUM_BUFS,

--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -765,9 +765,37 @@ def ws_matmul_kernel(
 # ===-----------------------------------------------------------------------===#
 
 
-def get_operand_layout(t: Tensor, block_shape: list[int], cga_layout: tuple[tuple[int, ...], ...] = ()):
+def get_acc_cga_layout(num_ctas: int) -> tuple[tuple[int, int], ...]:
+    if num_ctas == 1:
+        return ()
+    if num_ctas == 2:
+        return ((1, 0), )
+    raise ValueError(f"unsupported CTA count: {num_ctas}")
+
+
+def get_x_desc_cga_layout(acc_cga_layout: tuple[tuple[int, int], ...]) -> tuple[tuple[int, int], ...]:
+    return tuple((basis[0], 0) for basis in acc_cga_layout)
+
+
+def get_w_desc_cga_layout(acc_cga_layout: tuple[tuple[int, int], ...]) -> tuple[tuple[int, int, int, int, int], ...]:
+    # Sharded weight tiles use the physical [1, 1, 1, N, K/2] MX4 shuffled block layout.
+    return tuple((0, 0, 0, basis[0], 0) for basis in acc_cga_layout)
+
+
+def get_w_scale_desc_cga_layout(
+    acc_cga_layout: tuple[tuple[int, int], ...],
+) -> tuple[tuple[int, int, int, int, int], ...]:
+    # Weight scale tiles use the physical [1, N//128, K//(32*4), 2, 256] layout.
+    return tuple((0, basis[0], 0, 0, 0) for basis in acc_cga_layout)
+
+
+def make_shared_layout(
+    dtype,
+    block_shape: list[int],
+    cga_layout: tuple[tuple[int, ...], ...] = (),
+):
     rank = len(block_shape)
-    if t.dtype == FP4:
+    if dtype == FP4:
         assert rank == 5
         return gl.NVMMASharedLayout(
             swizzle_byte_width=128,
@@ -776,7 +804,7 @@ def get_operand_layout(t: Tensor, block_shape: list[int], cga_layout: tuple[tupl
             fp4_padded=True,
             cga_layout=cga_layout,
         )
-    if t.dtype == UINT8:
+    if dtype == UINT8:
         assert rank == 5
         return gl.NVMMASharedLayout(
             swizzle_byte_width=0,
@@ -784,7 +812,7 @@ def get_operand_layout(t: Tensor, block_shape: list[int], cga_layout: tuple[tupl
             rank=rank,
             cga_layout=cga_layout,
         )
-    if t.dtype == torch.float32:
+    if dtype == torch.float32:
         assert rank == 2
         return gl.NVMMASharedLayout.get_default_for(
             block_shape,
@@ -792,7 +820,7 @@ def get_operand_layout(t: Tensor, block_shape: list[int], cga_layout: tuple[tupl
             cga_layout=cga_layout,
         )
 
-    assert t.dtype == torch.float8_e4m3fn
+    assert dtype == torch.float8_e4m3fn
     return gl.NVMMASharedLayout(
         swizzle_byte_width=block_shape[-1],
         element_bitwidth=8,
@@ -801,43 +829,72 @@ def get_operand_layout(t: Tensor, block_shape: list[int], cga_layout: tuple[tupl
     )
 
 
-def make_operand_descriptor(
-        t: torch.Tensor | Tensor,
-        block_shape: tuple[int, ...],
-        cga_layout: tuple[tuple[int, ...], ...] = (),
+def make_tensor_descriptor(
+    t: torch.Tensor | Tensor,
+    block_shape: tuple[int, ...],
+    *,
+    layout_block_shape: tuple[int, ...] | None = None,
+    cga_layout: tuple[tuple[int, ...], ...] = (),
 ):
     from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 
     ptr = t if isinstance(t, torch.Tensor) else t.storage.data
     shape = list(ptr.shape)
     strides = list(ptr.stride())
+    desc_block_shape = list(block_shape)
+    layout_shape = list(layout_block_shape or block_shape)
 
     if isinstance(t, Tensor) and t.dtype == FP4:
         assert isinstance(t.storage.layout, BlackwellMX4ValueShuffledLayout)
-        block_shape = t.storage.layout.swizzle_block_shape(list(block_shape))
-        block_shape[strides.index(1)] //= 2
+        assert layout_block_shape is None
+        desc_block_shape = t.storage.layout.swizzle_block_shape(desc_block_shape)
+        desc_block_shape[strides.index(1)] //= 2
+        layout_shape = desc_block_shape
 
-    layout = get_operand_layout(t, list(block_shape), cga_layout=cga_layout)
-    return TensorDescriptor(ptr, shape, strides, block_shape, layout)
-
-
-def make_gather_operand_descriptor(
-        t: torch.Tensor,
-        block_shape: tuple[int, ...],
-        layout_block_shape: tuple[int, ...],
-        cga_layout: tuple[tuple[int, ...], ...] = (),
-):
-    from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
-
-    layout = get_operand_layout(t, list(layout_block_shape), cga_layout=cga_layout)
-    return TensorDescriptor(t, list(t.shape), list(t.stride()), list(block_shape), layout)
+    layout = make_shared_layout(t.dtype, layout_shape, cga_layout=cga_layout)
+    return TensorDescriptor(ptr, shape, strides, desc_block_shape, layout)
 
 
 def make_output_meta_descriptor(t: torch.Tensor, block_shape: tuple[int, int]):
-    # The output descriptor is only used for shape/stride metadata in the
-    # manual store path, so cap the layout width to a legal FP8 swizzle size.
+    # The output descriptor is only used for shape/stride metadata during
+    # direct stores, so cap the layout width to a legal FP8 swizzle size.
     block_m, block_n = block_shape
-    return make_operand_descriptor(t, (block_m, min(block_n, 128)))
+    return make_tensor_descriptor(t, (block_m, min(block_n, 128)))
+
+
+def make_matmul_descriptors(
+    a: torch.Tensor,
+    b: Tensor,
+    b_mx_scales: Tensor,
+    c: torch.Tensor,
+    p: "KernelConfig",
+    reduction_n: int,
+):
+    acc_cga_layout = get_acc_cga_layout(p.NUM_CTAS)
+    x_desc = make_tensor_descriptor(
+        a,
+        (1, p.BLOCK_K),
+        layout_block_shape=(p.BLOCK_M, p.BLOCK_K),
+        cga_layout=get_x_desc_cga_layout(acc_cga_layout),
+    )
+    w_desc = make_tensor_descriptor(
+        b,
+        (1, p.BLOCK_K, p.BLOCK_N),
+        cga_layout=get_w_desc_cga_layout(acc_cga_layout),
+    )
+    scale_desc = make_tensor_descriptor(
+        b_mx_scales,
+        (
+            1,
+            p.BLOCK_N // p.SCALE_SIZE_OUTER,
+            p.BLOCK_K // p.MXFP_BLOCK_SIZE // p.SCALE_SIZE_INNER,
+            2,
+            256,
+        ),
+        cga_layout=get_w_scale_desc_cga_layout(acc_cga_layout),
+    )
+    out_desc = make_output_meta_descriptor(c, (p.BLOCK_M, p.BLOCK_N // reduction_n))
+    return x_desc, w_desc, scale_desc, out_desc
 
 
 @dataclass(frozen=True, slots=True)
@@ -885,88 +942,39 @@ class KernelConfig:
         return (self.BLOCK_M // self.SWIGLU_SUBTILE_FACTOR) * (self.BLOCK_N // reduction_n)
 
 
-def _select_occ2_config(slice_size: int) -> KernelConfig:
-    p = KernelConfig(
-        BLOCK_N=128,
-        OCCUPANCY=2,
-        MAXNREG=64,
-        LOAD_ACTIVATION_REGS=48,
-        LOAD_WEIGHT_REGS=32,
-        MMA_REGS=32,
-    )
-
+def _select_base_config(slice_size: int) -> KernelConfig:
     if slice_size <= 14:
-        p = replace(p, BLOCK_M=16)
+        block_m = 16
     elif slice_size <= 32:
-        p = replace(p, BLOCK_M=32)
+        block_m = 32
     elif slice_size <= 64:
-        p = replace(p, BLOCK_M=64)
+        block_m = 64
     else:
-        p = replace(p, BLOCK_M=128)
+        block_m = 128
 
-    p = replace(p, SWIGLU_SUBTILE_FACTOR=min(8, p.BLOCK_M // 8))
+    if slice_size <= 64:
+        x_num_bufs, w_num_bufs = {
+            16: (10, 5),
+            32: (5, 5),
+            64: (4, 4),
+        }[block_m]
+        return KernelConfig(
+            BLOCK_M=block_m,
+            BLOCK_N=128,
+            X_NUM_BUFS=x_num_bufs,
+            W_NUM_BUFS=w_num_bufs,
+            SWIGLU_SUBTILE_FACTOR=min(8, block_m // 8),
+            OCCUPANCY=2,
+            MAXNREG=64,
+            LOAD_ACTIVATION_REGS=48,
+            LOAD_WEIGHT_REGS=32,
+            MMA_REGS=32,
+        )
 
-    match p.BLOCK_M:
-        case 16:
-            p = replace(p, X_NUM_BUFS=10, W_NUM_BUFS=5)
-        case 32:
-            p = replace(p, X_NUM_BUFS=5, W_NUM_BUFS=5)
-        case 64:
-            p = replace(p, X_NUM_BUFS=4, W_NUM_BUFS=4)
-        case 128:
-            p = replace(p, X_NUM_BUFS=3, W_NUM_BUFS=3)
-
-    return p
-
-
-def _select_occ1_config(slice_size: int) -> KernelConfig:
-    p = KernelConfig()
-
-    if slice_size < 14:
-        p = replace(p, BLOCK_M=16)
-    elif slice_size < 28:
-        p = replace(p, BLOCK_M=32)
-    elif slice_size < 80:
-        p = replace(p, BLOCK_M=64)
-    else:
-        p = replace(p, BLOCK_M=128)
-
-    p = replace(p, SWIGLU_SUBTILE_FACTOR=min(8, p.BLOCK_M // 8))
-
-    match p.BLOCK_M:
-        case 16:
-            p = replace(p, X_NUM_BUFS=11, W_NUM_BUFS=6)
-        case 32:
-            p = replace(p, X_NUM_BUFS=5, W_NUM_BUFS=6)
-        case 64:
-            p = replace(p, X_NUM_BUFS=6, W_NUM_BUFS=5)
-        case 128:
-            p = replace(p, X_NUM_BUFS=5, W_NUM_BUFS=4)
-
-    return p
-
-
-def get_acc_cga_layout(num_ctas: int) -> tuple[tuple[int, int], ...]:
-    if num_ctas == 1:
-        return ()
-    if num_ctas == 2:
-        return ((1, 0), )
-    raise ValueError(f"unsupported CTA count: {num_ctas}")
-
-
-def get_x_desc_cga_layout(acc_cga_layout: tuple[tuple[int, int], ...]) -> tuple[tuple[int, int], ...]:
-    return tuple((basis[0], 0) for basis in acc_cga_layout)
-
-
-def get_w_desc_cga_layout(acc_cga_layout: tuple[tuple[int, int], ...]) -> tuple[tuple[int, int, int, int, int], ...]:
-    # Sharded weight tiles use the physical [1, 1, 1, N, K/2] MX4 shuffled block layout.
-    return tuple((0, 0, 0, basis[0], 0) for basis in acc_cga_layout)
-
-
-def get_w_scale_desc_cga_layout(
-    acc_cga_layout: tuple[tuple[int, int], ...], ) -> tuple[tuple[int, int, int, int, int], ...]:
-    # Weight scale tiles use the physical [1, N//128, K//(32*4), 2, 256] layout.
-    return tuple((0, basis[0], 0, 0, 0) for basis in acc_cga_layout)
+    return KernelConfig(
+        BLOCK_M=block_m,
+        SWIGLU_SUBTILE_FACTOR=min(8, block_m // 8),
+    )
 
 
 def _select_band_n(slice_size: int) -> int:
@@ -978,72 +986,83 @@ def _select_band_n(slice_size: int) -> int:
         return 26
 
 
-def maybe_enable_2cta(p: KernelConfig, slice_size: int) -> KernelConfig:
+def _enable_low_batch_2cta(p: KernelConfig, slice_size: int) -> KernelConfig:
+    next_p = replace(
+        p,
+        BLOCK_N=256,
+        NUM_CTAS=2,
+        NUM_WARPS=4,
+        W_NUM_BUFS=5,
+        SWIGLU_SUBTILE_FACTOR=1,
+        LOAD_ACTIVATION_WARPS=2,
+        LOAD_WEIGHT_WARPS=1,
+        MMA_WARPS=1,
+        LOAD_ACTIVATION_REGS=40,
+        LOAD_WEIGHT_REGS=32,
+        MMA_REGS=32,
+        MAXNREG=52,
+        BAND_N=32,
+        FORCE_EPILOGUE_WARPS_N1=True,
+    )
+    if slice_size == 16:
+        return replace(next_p, X_NUM_BUFS=5)
+    if slice_size in (20, 24):
+        return replace(next_p, X_NUM_BUFS=6)
+    return replace(next_p, X_NUM_BUFS=6, X_GATHER_MULTICAST=False, W_SCALE_MULTICAST=False)
+
+
+def _enable_mid_batch_2cta(p: KernelConfig) -> KernelConfig:
+    return replace(
+        p,
+        BLOCK_M=64,
+        BLOCK_N=256,
+        NUM_CTAS=2,
+        OCCUPANCY=2,
+        X_NUM_BUFS=6,
+        W_NUM_BUFS=5,
+        SWIGLU_SUBTILE_FACTOR=4,
+        LOAD_ACTIVATION_REGS=64,
+        LOAD_WEIGHT_REGS=48,
+        MMA_REGS=48,
+        MAXNREG=64,
+    )
+
+
+def _enable_large_batch_2cta(p: KernelConfig) -> KernelConfig:
+    return replace(p, BLOCK_N=512, NUM_CTAS=2, W_NUM_BUFS=5)
+
+
+def apply_2cta_tuning(p: KernelConfig, slice_size: int) -> KernelConfig:
     if p.BLOCK_M == 32 and p.BLOCK_N == 128 and slice_size in (16, 20, 24, 32):
         # Low-batch 2CTA only wins when the wider N tile is paired with a
         # four-warp layout. Slice 28 remains on 1CTA because uniform routing
         # still shows a stable regression there.
-        next_p = replace(
-            p,
-            BLOCK_N=256,
-            NUM_CTAS=2,
-            NUM_WARPS=4,
-            W_NUM_BUFS=5,
-            SWIGLU_SUBTILE_FACTOR=1,
-            LOAD_ACTIVATION_WARPS=2,
-            LOAD_WEIGHT_WARPS=1,
-            MMA_WARPS=1,
-            LOAD_ACTIVATION_REGS=40,
-            LOAD_WEIGHT_REGS=32,
-            MMA_REGS=32,
-            MAXNREG=52,
-            BAND_N=32,
-            FORCE_EPILOGUE_WARPS_N1=True,
-        )
-        if slice_size == 16:
-            return replace(next_p, X_NUM_BUFS=5)
-        if slice_size in (20, 24):
-            return replace(next_p, X_NUM_BUFS=6)
-        return replace(next_p, X_NUM_BUFS=6, X_GATHER_MULTICAST=False, W_SCALE_MULTICAST=False)
+        return _enable_low_batch_2cta(p, slice_size)
     if 36 <= slice_size <= 72:
         # The tuned 64-row multicta kernel wins through the 72-token slice
         # crossover once it keeps the deeper x/w pipeline, shallower SwiGLU
         # fragmentation, and the wider low-batch banded schedule together.
-        return replace(
-            p,
-            BLOCK_M=64,
-            BLOCK_N=256,
-            NUM_CTAS=2,
-            OCCUPANCY=2,
-            X_NUM_BUFS=6,
-            W_NUM_BUFS=5,
-            SWIGLU_SUBTILE_FACTOR=4,
-            LOAD_ACTIVATION_REGS=64,
-            LOAD_WEIGHT_REGS=48,
-            MMA_REGS=48,
-            MAXNREG=64,
-        )
+        return _enable_mid_batch_2cta(p)
     if p.BLOCK_M == 128 and p.BLOCK_N == 256 and slice_size >= 80:
         # Along N, 2CTA doubles the output tile width without increasing the
         # per-CTA weight tile footprint, which makes the extra synchronization
         # pay back across the entire occ1 range.
-        return replace(p, BLOCK_N=512, NUM_CTAS=2, W_NUM_BUFS=5)
+        return _enable_large_batch_2cta(p)
     return p
+
+
+def apply_band_n_tuning(p: KernelConfig, slice_size: int) -> KernelConfig:
+    if p.BLOCK_M == 32 and p.BLOCK_N == 256 and p.NUM_CTAS == 2 and slice_size <= 32:
+        return replace(p, BAND_N=32)
+    if p.BLOCK_M == 64 and p.BLOCK_N == 256 and p.NUM_CTAS == 2 and 36 <= slice_size <= 72:
+        return replace(p, BAND_N=26)
+    return replace(p, BAND_N=_select_band_n(slice_size))
 
 
 def select_kernel_config(slice_size: int) -> KernelConfig:
-    if slice_size <= 64:
-        p = _select_occ2_config(slice_size)
-    else:
-        p = _select_occ1_config(slice_size)
-    p = maybe_enable_2cta(p, slice_size)
-    if p.BLOCK_M == 32 and p.BLOCK_N == 256 and p.NUM_CTAS == 2 and slice_size <= 32:
-        p = replace(p, BAND_N=32)
-    elif p.BLOCK_M == 64 and p.BLOCK_N == 256 and p.NUM_CTAS == 2 and 36 <= slice_size <= 72:
-        p = replace(p, BAND_N=26)
-    else:
-        p = replace(p, BAND_N=_select_band_n(slice_size))
-    return p
+    p = _select_base_config(slice_size)
+    p = apply_2cta_tuning(p, slice_size)
+    return apply_band_n_tuning(p, slice_size)
 
 
 def matmul(
@@ -1089,31 +1108,7 @@ def matmul(
     sms *= p.OCCUPANCY
     launch_grid = max(1, min(max(1, sms // p.NUM_CTAS), expected_grid_m * grid_n))
     grid = (launch_grid, )
-
-    acc_cga_layout = get_acc_cga_layout(p.NUM_CTAS)
-    x_desc_cga_layout = get_x_desc_cga_layout(acc_cga_layout)
-    w_desc_cga_layout = get_w_desc_cga_layout(acc_cga_layout)
-    w_scale_desc_cga_layout = get_w_scale_desc_cga_layout(acc_cga_layout)
-
-    x_desc = make_gather_operand_descriptor(
-        a,
-        (1, p.BLOCK_K),
-        (p.BLOCK_M, p.BLOCK_K),
-        cga_layout=x_desc_cga_layout,
-    )
-    w_desc = make_operand_descriptor(b, (1, p.BLOCK_K, p.BLOCK_N), cga_layout=w_desc_cga_layout)
-    scale_desc = make_operand_descriptor(
-        b_mx_scales,
-        (
-            1,
-            p.BLOCK_N // p.SCALE_SIZE_OUTER,
-            p.BLOCK_K // p.MXFP_BLOCK_SIZE // p.SCALE_SIZE_INNER,
-            2,
-            256,
-        ),
-        cga_layout=w_scale_desc_cga_layout,
-    )
-    out_desc = make_output_meta_descriptor(c, (p.BLOCK_M, p.BLOCK_N // reduction_n))
+    x_desc, w_desc, scale_desc, out_desc = make_matmul_descriptors(a, b, b_mx_scales, c, p, reduction_n)
 
     ws_matmul_kernel[grid](
         x_desc=x_desc,

--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -58,40 +58,22 @@ def unpack_block_schedule(schedule: gl.tensor) -> tuple[gl.tensor, gl.tensor]:
 
 
 @gluon.jit
-def banded_row_major(lin_idx, m_tiles, n_tiles, BAND_N: gl.constexpr):
-    if BAND_N >= n_tiles:
-        return lin_idx // n_tiles, lin_idx % n_tiles
+def banded_row_major(block_id, grid_m, GRID_N: gl.constexpr, BAND_N: gl.constexpr):
+    if BAND_N >= GRID_N:
+        return block_id // GRID_N, block_id % GRID_N
 
-    full_band_tiles = m_tiles * BAND_N
-    n_full_bands = n_tiles // BAND_N
+    full_band_tiles = grid_m * BAND_N
+    n_full_bands = GRID_N // BAND_N
     full_band_work = n_full_bands * full_band_tiles
 
-    if lin_idx < full_band_work:
-        band_id = lin_idx // full_band_tiles
-        within_band = lin_idx % full_band_tiles
+    if block_id < full_band_work:
+        band_id = block_id // full_band_tiles
+        within_band = block_id % full_band_tiles
         return within_band // BAND_N, band_id * BAND_N + (within_band % BAND_N)
 
-    tail_n = n_tiles - n_full_bands * BAND_N
-    tail_idx = lin_idx - full_band_work
+    tail_n = GRID_N - n_full_bands * BAND_N
+    tail_idx = block_id - full_band_work
     return tail_idx // tail_n, n_full_bands * BAND_N + (tail_idx % tail_n)
-
-
-@gluon.jit
-def banded_row_major_m(lin_idx, m_tiles, n_tiles, BAND_N: gl.constexpr):
-    if BAND_N >= n_tiles:
-        return lin_idx // n_tiles
-
-    full_band_tiles = m_tiles * BAND_N
-    n_full_bands = n_tiles // BAND_N
-    full_band_work = n_full_bands * full_band_tiles
-
-    if lin_idx < full_band_work:
-        within_band = lin_idx % full_band_tiles
-        return within_band // BAND_N
-
-    tail_n = n_tiles - n_full_bands * BAND_N
-    tail_idx = lin_idx - full_band_work
-    return tail_idx // tail_n
 
 
 @gluon.jit
@@ -103,43 +85,12 @@ def apply_block_schedule(
     block_schedule: gl.tensor,
     BAND_N: gl.constexpr,
 ) -> tuple[gl.tensor, gl.tensor, gl.tensor, gl.tensor]:
-    # The persistent loop bounds block_id by grid_m * GRID_N, so no wraparound
-    # modulo is needed on the hot scheduling path.
     schedule_pid_m, pid_n = banded_row_major(block_id, grid_m, GRID_N, BAND_N=BAND_N)
 
     slice_idx, pid_m = unpack_block_schedule(gl.load(block_schedule + schedule_pid_m))
-    pid_n = pid_n.to(gl.int32)
     slice_offset = gl.load(slice_offsets + slice_idx)
 
     return pid_m, pid_n, slice_idx, slice_offset
-
-
-@gluon.jit
-def apply_weight_schedule(
-    block_id: gl.tensor,
-    grid_m: gl.tensor,
-    GRID_N: gl.constexpr,
-    block_schedule: gl.tensor,
-    BAND_N: gl.constexpr,
-) -> tuple[gl.tensor, gl.tensor]:
-    schedule_pid_m, pid_n = banded_row_major(block_id, grid_m, GRID_N, BAND_N=BAND_N)
-    slice_idx, _ = unpack_block_schedule(gl.load(block_schedule + schedule_pid_m))
-    return pid_n.to(gl.int32), slice_idx
-
-
-@gluon.jit
-def apply_activation_schedule(
-    block_id: gl.tensor,
-    grid_m: gl.tensor,
-    GRID_N: gl.constexpr,
-    slice_offsets: gl.tensor,
-    block_schedule: gl.tensor,
-    BAND_N: gl.constexpr,
-) -> tuple[gl.tensor, gl.tensor, gl.tensor]:
-    schedule_pid_m = banded_row_major_m(block_id, grid_m, GRID_N, BAND_N=BAND_N)
-    slice_idx, pid_m = unpack_block_schedule(gl.load(block_schedule + schedule_pid_m))
-    slice_offset = gl.load(slice_offsets + slice_idx)
-    return pid_m, slice_idx, slice_offset
 
 
 @gluon.jit
@@ -158,22 +109,22 @@ def unswizzle_mx_scale(
 
 
 @gluon.jit
-def alloc_barrier_ring(num_bufs: gl.constexpr, two_ctas: gl.constexpr = False, count: gl.constexpr = 1):
+def alloc_barrier_ring(num_bufs: gl.constexpr, two_ctas: gl.constexpr = False):
     bars = mbarrier.allocate_mbarrier(batch=num_bufs, two_ctas=two_ctas)
     for i in gl.static_range(num_bufs):
-        mbarrier.init(bars.index(i), count=count)
+        mbarrier.init(bars.index(i))
     return bars
 
 
 @gluon.jit
-def alloc_empty_ready_barriers(
+def alloc_ring_barriers(
     num_bufs: gl.constexpr,
-    empty_two_ctas: gl.constexpr = False,
-    ready_two_ctas: gl.constexpr = False,
+    producer_two_ctas: gl.constexpr = False,
+    consumer_two_ctas: gl.constexpr = False,
 ):
     return (
-        alloc_barrier_ring(num_bufs, two_ctas=empty_two_ctas),
-        alloc_barrier_ring(num_bufs, two_ctas=ready_two_ctas),
+        alloc_barrier_ring(num_bufs, two_ctas=producer_two_ctas),
+        alloc_barrier_ring(num_bufs, two_ctas=consumer_two_ctas),
     )
 
 
@@ -268,14 +219,10 @@ class PartitionArgs:
     w_scale_bufs: gl.shared_memory_descriptor
     w_empty_bars: gl.shared_memory_descriptor
     w_ready_bars: gl.shared_memory_descriptor
-    w_scale_empty_bars: gl.shared_memory_descriptor
-    w_scale_ready_bars: gl.shared_memory_descriptor
     w_num_bufs: gl.constexpr
-    w_scale_num_bufs: gl.constexpr
 
     x_scale_tmem: blackwell.tensor_memory_descriptor
     w_scale_tmem: blackwell.tensor_memory_descriptor
-    w_scale_tmem_alt: blackwell.tensor_memory_descriptor
     acc_bufs: blackwell.tensor_memory_descriptor
     acc_empty_bars: gl.shared_memory_descriptor
     acc_ready_bars: gl.shared_memory_descriptor
@@ -293,7 +240,6 @@ class PartitionArgs:
     num_blocks: gl.tensor
 
     NUM_SMS: gl.constexpr
-    NUM_WARPS: gl.constexpr
     USE_2CTA: gl.constexpr
     BLOCK_M_PER_CTA: gl.constexpr
     BLOCK_M: gl.constexpr
@@ -327,28 +273,6 @@ class PartitionArgs:
             BAND_N=self.BAND_N,
         )
 
-    @gluon.jit
-    def apply_weight_schedule(self, block_id: gl.tensor) -> tuple[gl.tensor, gl.tensor]:
-        return apply_weight_schedule(
-            block_id=block_id,
-            grid_m=self.grid_m,
-            GRID_N=self.GRID_N,
-            block_schedule=self.x_block_schedule,
-            BAND_N=self.BAND_N,
-        )
-
-    @gluon.jit
-    def apply_activation_schedule(self, block_id: gl.tensor) -> tuple[gl.tensor, gl.tensor, gl.tensor]:
-        return apply_activation_schedule(
-            block_id=block_id,
-            grid_m=self.grid_m,
-            GRID_N=self.GRID_N,
-            slice_offsets=self.x_slice_offs,
-            block_schedule=self.x_block_schedule,
-            BAND_N=self.BAND_N,
-        )
-
-
 @gluon.jit
 def load_activations(p: PartitionArgs):
     local_cga_layout: gl.constexpr = ((0, 1), ) if p.USE_2CTA else ()
@@ -363,7 +287,7 @@ def load_activations(p: PartitionArgs):
     issued = 0
 
     for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
-        pid_m, slice_idx, slice_offset = p.apply_activation_schedule(block_id)
+        pid_m, _, slice_idx, slice_offset = p.apply_block_schedule(block_id)
         off_m = pid_m * p.BLOCK_M
         shape_m = gl.load(p.x_slice_sizes + slice_idx)
         offs_m = off_m + gl.arange(0, p.BLOCK_M, layout=offs_layout)
@@ -407,12 +331,11 @@ def load_weights(p: PartitionArgs):
     issued = 0
 
     for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
-        pid_n, slice_idx = p.apply_weight_schedule(block_id)
+        _, pid_n, slice_idx, _ = p.apply_block_schedule(block_id)
 
         scale_idx = slice_idx * p.SCALE_FLAT_N + pid_n * p.SCALE_BLOCK_N_DIV
-        scale_k_stride: gl.constexpr = p.BLOCK_K // (p.MXFP_BLOCK_SIZE * p.SCALE_SIZE_INNER)
         for ki in range(p.K_TILES):
-            off_k_scale = ki * scale_k_stride
+            off_k_scale = ki * p.BLOCK_K // (p.MXFP_BLOCK_SIZE * p.SCALE_SIZE_INNER)
 
             w_empty_bar = p.w_empty_bars.index(idx)
             w_ready_bar = p.w_ready_bars.index(idx)
@@ -674,25 +597,14 @@ def apply_bias_and_scale(
     acc_buf = p.acc_bufs.index(idx)
 
     offs_bias_n = off_n + gl.arange(0, p.BLOCK_N, layout=bias_layout)
-    if p.USE_DIRECT_EPILOGUE_STORE:
-        bias = gl.convert_layout(
-            gl.expand_dims(gl.load(p.bias_ptr + slice_idx * p.bias_stride + offs_bias_n), axis=0),
-            split_layout,
-        )
-        mbarrier.wait(acc_ready_bar, phase)
-        idx, phase = advance(idx, phase, p.acc_num_bufs)
-        acc_regs_raw = acc_buf.load()
-        mbarrier.arrive(acc_empty_bar)
-        acc_regs = acc_regs_raw.permute((1, 0))
-    else:
-        mbarrier.wait(acc_ready_bar, phase)
-        idx, phase = advance(idx, phase, p.acc_num_bufs)
-        bias = gl.convert_layout(
-            gl.expand_dims(gl.load(p.bias_ptr + slice_idx * p.bias_stride + offs_bias_n), axis=0),
-            split_layout,
-        )
-        acc_regs = acc_buf.load().permute((1, 0))
-        mbarrier.arrive(acc_empty_bar)
+    bias = gl.convert_layout(
+        gl.expand_dims(gl.load(p.bias_ptr + slice_idx * p.bias_stride + offs_bias_n), axis=0),
+        split_layout,
+    )
+    mbarrier.wait(acc_ready_bar, phase)
+    acc_regs = acc_buf.load().permute((1, 0))
+    mbarrier.arrive(acc_empty_bar)
+    idx, phase = advance(idx, phase, p.acc_num_bufs)
     acc = gl.convert_layout(acc_regs, split_layout)
     acc_packed = float2.pack(acc, axis=1)
     bias_packed = float2.pack(bias, axis=1)
@@ -887,10 +799,9 @@ def ws_matmul_kernel(
         [x_num_bufs, BLOCK_M, x_desc.block_type.shape[1]],
         x_desc.layout,
     )
-    x_empty_bars, x_ready_bars = alloc_empty_ready_barriers(x_num_bufs, ready_two_ctas=use_2cta)
+    x_empty_bars, x_ready_bars = alloc_ring_barriers(x_num_bufs, consumer_two_ctas=use_2cta)
 
     w_num_bufs: gl.constexpr = W_NUM_BUFS
-    w_scale_num_bufs: gl.constexpr = w_num_bufs
     w_bufs = gl.allocate_shared_memory(
         w_desc.dtype,
         [w_num_bufs] + w_desc.block_type.shape,
@@ -898,16 +809,13 @@ def ws_matmul_kernel(
     )
     w_scale_bufs = gl.allocate_shared_memory(
         scale_desc.dtype,
-        [w_scale_num_bufs] + scale_desc.block_type.shape,
+        [w_num_bufs] + scale_desc.block_type.shape,
         scale_desc.layout,
     )
-    w_empty_bars, w_ready_bars = alloc_empty_ready_barriers(w_num_bufs, ready_two_ctas=use_2cta)
-    w_scale_empty_bars = w_empty_bars
-    w_scale_ready_bars = w_ready_bars
+    w_empty_bars, w_ready_bars = alloc_ring_barriers(w_num_bufs, consumer_two_ctas=use_2cta)
 
     x_scale_tmem = blackwell.allocate_tensor_memory(gl.uint8, [BLOCK_M, scale_k], x_scale_layout)
     w_scale_tmem = blackwell.allocate_tensor_memory(gl.uint8, [BLOCK_N, scale_k], w_scale_layout)
-    w_scale_tmem_alt = w_scale_tmem
 
     acc_num_bufs: gl.constexpr = ACC_NUM_BUFS
     acc_tmem = blackwell.allocate_tensor_memory(
@@ -915,7 +823,7 @@ def ws_matmul_kernel(
         [acc_num_bufs, BLOCK_N, BLOCK_M],
         acc_layout,
     )
-    acc_empty_bars, acc_ready_bars = alloc_empty_ready_barriers(acc_num_bufs, empty_two_ctas=use_2cta)
+    acc_empty_bars, acc_ready_bars = alloc_ring_barriers(acc_num_bufs, producer_two_ctas=use_2cta)
 
     if USE_DIRECT_EPILOGUE_STORE:
         store_bufs = x_bufs
@@ -931,7 +839,7 @@ def ws_matmul_kernel(
             [EPILOGUE_BUFFER_DEPTH, frag_rows, out_packed_n],
             gl.SwizzledSharedLayout(1, 1, 1, [1, 0], cga_layout=((0, 1), ) if use_2cta else ()),
         )
-        store_empty_bars, store_ready_bars = alloc_empty_ready_barriers(EPILOGUE_BUFFER_DEPTH)
+        store_empty_bars, store_ready_bars = alloc_ring_barriers(EPILOGUE_BUFFER_DEPTH)
 
     x_scale_tmem.store(gl.full((BLOCK_M, scale_k), 127, dtype=gl.uint8, layout=x_scale_tmem.get_reg_layout()))
 
@@ -962,14 +870,10 @@ def ws_matmul_kernel(
         w_scale_bufs=w_scale_bufs,
         w_empty_bars=w_empty_bars,
         w_ready_bars=w_ready_bars,
-        w_scale_empty_bars=w_scale_empty_bars,
-        w_scale_ready_bars=w_scale_ready_bars,
         w_num_bufs=w_num_bufs,
-        w_scale_num_bufs=w_scale_num_bufs,
         #
         x_scale_tmem=x_scale_tmem,
         w_scale_tmem=w_scale_tmem,
-        w_scale_tmem_alt=w_scale_tmem_alt,
         acc_bufs=acc_tmem,
         acc_empty_bars=acc_empty_bars,
         acc_ready_bars=acc_ready_bars,
@@ -1125,7 +1029,6 @@ class KernelConfig:
     NUM_CTAS: int = 1
     X_NUM_BUFS: int = 5
     W_NUM_BUFS: int = 4
-    W_SCALE_NUM_BUFS: int = 0
     ACC_NUM_BUFS: int = 1
 
     NUM_WARPS: int = 8
@@ -1331,40 +1234,6 @@ def select_kernel_config(slice_size: int) -> KernelConfig:
     return p
 
 
-_dynamic_block_schedule_cache: dict[tuple[int, int], tuple[torch.Tensor, torch.Tensor]] = {}
-
-
-def get_block_schedule_tensors(
-    ragged_metadata: RaggedTensorMetadata,
-    block_size: int,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    precomputed_sizes = RaggedTensorMetadata.block_sizes()
-    if block_size in precomputed_sizes:
-        block_idx = precomputed_sizes.index(block_size)
-        return ragged_metadata.block_offs_data[block_idx], ragged_metadata.block_schedule_data[block_idx]
-
-    key = (id(ragged_metadata), block_size)
-    cached = _dynamic_block_schedule_cache.get(key)
-    if cached is not None:
-        return cached
-
-    slice_sizes_cpu = ragged_metadata.slice_sizes.cpu().tolist()
-    block_counts = [(int(size) + block_size - 1) // block_size for size in slice_sizes_cpu]
-    block_offs = [0]
-    for count in block_counts:
-        block_offs.append(block_offs[-1] + count)
-
-    packed_schedule = [(pid_m << 16) | slice_idx
-                       for slice_idx, count in enumerate(block_counts)
-                       for pid_m in range(count)]
-
-    device = ragged_metadata.slice_sizes.device
-    block_offs_t = torch.tensor(block_offs, dtype=torch.int32, device=device)
-    block_schedule_t = torch.tensor(packed_schedule, dtype=torch.int32, device=device)
-    _dynamic_block_schedule_cache[key] = (block_offs_t, block_schedule_t)
-    return block_offs_t, block_schedule_t
-
-
 def matmul(
     a: torch.Tensor,
     b: torch.Tensor | Tensor,
@@ -1400,7 +1269,8 @@ def matmul(
     assert isinstance(b.storage.layout, BlackwellMX4ValueShuffledLayout)
     assert b.storage.layout.block_k == p.BLOCK_K
     assert b.storage.layout.block_n == p.BLOCK_N
-    x_block_offs, x_block_schedule = get_block_schedule_tensors(a_ragged_metadata, p.BLOCK_M)
+    x_block_offs = a_ragged_metadata.block_offs(p.BLOCK_M)
+    x_block_schedule = a_ragged_metadata.block_schedule(p.BLOCK_M)
     expected_grid_m = a_ragged_metadata.n_blocks(a_ragged_metadata.n_slices, m, p.BLOCK_M)
     grid_n = triton.cdiv(n, p.BLOCK_N)
     sms = torch.cuda.get_device_properties(bias.device).multi_processor_count

--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -207,7 +207,6 @@ class PartitionArgs:
     gather_indx_ptr: gl.tensor
     x_slice_sizes: gl.tensor
     x_slice_offs: gl.tensor
-    x_block_offs: gl.tensor
     x_block_schedule: gl.tensor
 
     x_bufs: gl.shared_memory_descriptor
@@ -227,10 +226,6 @@ class PartitionArgs:
     acc_empty_bars: gl.shared_memory_descriptor
     acc_ready_bars: gl.shared_memory_descriptor
     acc_num_bufs: gl.constexpr
-
-    store_bufs: gl.shared_memory_descriptor
-    store_empty_bars: gl.shared_memory_descriptor
-    store_ready_bars: gl.shared_memory_descriptor
 
     grid_m: gl.tensor
     GRID_N: gl.constexpr
@@ -255,12 +250,10 @@ class PartitionArgs:
     FLEXPOINT_SATURATE_INF: gl.constexpr
 
     SWIGLU_SUBTILE_FACTOR: gl.constexpr
-    EPILOGUE_BUFFER_DEPTH: gl.constexpr
     BAND_N: gl.constexpr
     X_GATHER_MULTICAST: gl.constexpr
     W_SCALE_MULTICAST: gl.constexpr
     FORCE_EPILOGUE_WARPS_N1: gl.constexpr
-    USE_DIRECT_EPILOGUE_STORE: gl.constexpr
 
     @gluon.jit
     def apply_block_schedule(self, block_id: gl.tensor) -> tuple[gl.tensor, gl.tensor, gl.tensor, gl.tensor]:
@@ -457,25 +450,6 @@ def pack_fp8_out_fragment(out_packed, out_recip):
 
 
 @gluon.jit
-def _store_out_subtile(
-    p: PartitionArgs,
-    out_packed,
-    out_recip,
-    store_idx,
-    store_phase,
-    store_issued,
-):
-    payload = pack_fp8_out_fragment(out_packed, out_recip)
-    empty_bar = p.store_empty_bars.index(store_idx)
-    ready_bar = p.store_ready_bars.index(store_idx)
-    mbarrier.wait(empty_bar, store_phase, pred=store_issued >= p.EPILOGUE_BUFFER_DEPTH)
-    p.store_bufs.index(store_idx).store(payload)
-    mbarrier.arrive(ready_bar)
-    next_store_idx, next_store_phase = advance(store_idx, store_phase, p.EPILOGUE_BUFFER_DEPTH)
-    return next_store_idx, next_store_phase, store_issued + 1
-
-
-@gluon.jit
 def get_store_layout(p: PartitionArgs):
     frag_rows: gl.constexpr = p.BLOCK_M // p.SWIGLU_SUBTILE_FACTOR
     local_cga_layout: gl.constexpr = ((0, 1), ) if p.USE_2CTA else ()
@@ -516,71 +490,6 @@ def epilogue_direct_store(
 
 
 @gluon.jit
-def epilogue_overlapped_store(
-    p: PartitionArgs,
-    acc_packed,
-    out_recip,
-    store_idx,
-    store_phase,
-    store_issued,
-):
-    gl.static_assert(p.SWIGLU_SUBTILE_FACTOR > 1, "store helper requires row fragments")
-    acc_packed_subtiles = split_m_subtiles(acc_packed, p.SWIGLU_SUBTILE_FACTOR)
-
-    # Software pipelined and overlapped SwiGLU with transfer to store partition.
-    prepared_gelu, prepared_linear = _swiglu_step1(
-        acc_packed_subtiles[0],
-        p.SWIGLU_LIMIT,
-    )
-    ready_out_packed = acc_packed_subtiles[0]
-    for frag_idx in gl.static_range(1, p.SWIGLU_SUBTILE_FACTOR):
-        cur_gelu, cur_linear = _swiglu_step1(
-            acc_packed_subtiles[frag_idx],
-            p.SWIGLU_LIMIT,
-        )
-        next_ready_out_packed = _swiglu_step2(
-            prepared_gelu,
-            prepared_linear,
-            p.SWIGLU_ALPHA,
-        )
-        if frag_idx > 1:
-            store_idx, store_phase, store_issued = _store_out_subtile(
-                p,
-                ready_out_packed,
-                out_recip,
-                store_idx,
-                store_phase,
-                store_issued,
-            )
-        ready_out_packed = next_ready_out_packed
-        prepared_gelu = cur_gelu
-        prepared_linear = cur_linear
-
-    store_idx, store_phase, store_issued = _store_out_subtile(
-        p,
-        ready_out_packed,
-        out_recip,
-        store_idx,
-        store_phase,
-        store_issued,
-    )
-    last_out_packed = _swiglu_step2(
-        prepared_gelu,
-        prepared_linear,
-        p.SWIGLU_ALPHA,
-    )
-    store_idx, store_phase, store_issued = _store_out_subtile(
-        p,
-        last_out_packed,
-        out_recip,
-        store_idx,
-        store_phase,
-        store_issued,
-    )
-    return store_idx, store_phase, store_issued
-
-
-@gluon.jit
 def apply_bias_and_scale(
     p: PartitionArgs,
     idx,
@@ -614,44 +523,9 @@ def apply_bias_and_scale(
 
 
 @gluon.jit
-def epilogue_store_partition(p: PartitionArgs):
-    gl.static_assert(p.SWIGLU_SUBTILE_FACTOR > 1, "store helper requires row fragments")
-    store_layout: gl.constexpr = get_store_layout(p)
-    frag_rows: gl.constexpr = p.BLOCK_M // p.SWIGLU_SUBTILE_FACTOR
-    gl.static_assert(p.EPILOGUE_BUFFER_DEPTH >= 2, "store helper depth must be at least 2")
-
-    store_idx = 0
-    store_phase = 0
-    for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
-        pid_m, pid_n, slice_idx, slice_offset = p.apply_block_schedule(block_id)
-        off_m = pid_m * p.BLOCK_M
-        shape_m = gl.load(p.x_slice_sizes + slice_idx)
-        out_off_n_packed = pid_n * (p.BLOCK_N // p.REDUCTION_N // 4)
-        for frag_idx in gl.static_range(p.SWIGLU_SUBTILE_FACTOR):
-            frag_off_m = off_m + frag_idx * frag_rows
-            ready_bar = p.store_ready_bars.index(store_idx)
-            empty_bar = p.store_empty_bars.index(store_idx)
-            mbarrier.wait(ready_bar, store_phase)
-            packed_fp8 = p.store_bufs.index(store_idx).load(store_layout)
-            mbarrier.arrive(empty_bar)
-            store_packed_out(
-                p,
-                packed_fp8,
-                frag_off_m,
-                out_off_n_packed,
-                shape_m,
-                slice_offset,
-            )
-            store_idx, store_phase = advance(store_idx, store_phase, p.EPILOGUE_BUFFER_DEPTH)
-
-
-@gluon.jit
 def epilogue_partition(p: PartitionArgs):
     idx = 0
     phase = 0
-    store_idx = 0
-    store_phase = 1
-    store_issued = 0
 
     x_scale = 1.0 if p.x_scale_ptr is None else gl.load(p.x_scale_ptr)
     w_scale = 1.0 if p.w_scale_ptr is None else gl.load(p.w_scale_ptr)
@@ -673,10 +547,9 @@ def epilogue_partition(p: PartitionArgs):
 
     for block_id in range(gl.program_id(0), p.num_blocks, p.NUM_SMS):
         pid_m, pid_n, slice_idx, slice_offset = p.apply_block_schedule(block_id)
-        if p.USE_DIRECT_EPILOGUE_STORE:
-            off_m = pid_m * p.BLOCK_M
-            shape_m = gl.load(p.x_slice_sizes + slice_idx)
-            out_off_n_packed = pid_n * (p.BLOCK_N // p.REDUCTION_N // 4)
+        off_m = pid_m * p.BLOCK_M
+        shape_m = gl.load(p.x_slice_sizes + slice_idx)
+        out_off_n_packed = pid_n * (p.BLOCK_N // p.REDUCTION_N // 4)
         idx, phase, acc_packed = apply_bias_and_scale(
             p,
             idx,
@@ -687,27 +560,16 @@ def epilogue_partition(p: PartitionArgs):
             bias_layout,
             acc_scale,
         )
-
-        if p.USE_DIRECT_EPILOGUE_STORE:
-            epilogue_direct_store(
-                p,
-                acc_packed,
-                out_recip,
-                off_m,
-                out_off_n_packed,
-                shape_m,
-                slice_offset,
-                store_layout,
-            )
-        else:
-            store_idx, store_phase, store_issued = epilogue_overlapped_store(
-                p,
-                acc_packed,
-                out_recip,
-                store_idx,
-                store_phase,
-                store_issued,
-            )
+        epilogue_direct_store(
+            p,
+            acc_packed,
+            out_recip,
+            off_m,
+            out_off_n_packed,
+            shape_m,
+            slice_offset,
+            store_layout,
+        )
 
 
 @gluon.jit
@@ -753,18 +615,14 @@ def ws_matmul_kernel(
     LOAD_ACTIVATION_WARPS: gl.constexpr,
     LOAD_WEIGHT_WARPS: gl.constexpr,
     MMA_WARPS: gl.constexpr,
-    STORE_HELPER_WARPS: gl.constexpr,
     LOAD_ACTIVATION_REGS: gl.constexpr,
     LOAD_WEIGHT_REGS: gl.constexpr,
     MMA_REGS: gl.constexpr,
-    STORE_HELPER_REGS: gl.constexpr,
     SWIGLU_SUBTILE_FACTOR: gl.constexpr,
-    EPILOGUE_BUFFER_DEPTH: gl.constexpr,
     BAND_N: gl.constexpr,
     X_GATHER_MULTICAST: gl.constexpr,
     W_SCALE_MULTICAST: gl.constexpr,
     FORCE_EPILOGUE_WARPS_N1: gl.constexpr,
-    USE_DIRECT_EPILOGUE_STORE: gl.constexpr,
     SCALE_SIZE_OUTER: gl.constexpr,
     SCALE_SIZE_INNER: gl.constexpr,
     MXFP_BLOCK_SIZE: gl.constexpr,
@@ -824,22 +682,6 @@ def ws_matmul_kernel(
     )
     acc_empty_bars, acc_ready_bars = alloc_ring_barriers(acc_num_bufs, producer_two_ctas=use_2cta)
 
-    if USE_DIRECT_EPILOGUE_STORE:
-        store_bufs = x_bufs
-        store_empty_bars = x_empty_bars
-        store_ready_bars = x_ready_bars
-    else:
-        gl.static_assert(SWIGLU_SUBTILE_FACTOR > 1, "store helper requires row fragments")
-        gl.static_assert(EPILOGUE_BUFFER_DEPTH >= 2, "store helper depth must be at least 2")
-        frag_rows: gl.constexpr = BLOCK_M // SWIGLU_SUBTILE_FACTOR
-        out_packed_n: gl.constexpr = BLOCK_N // REDUCTION_N // 2
-        store_bufs = gl.allocate_shared_memory(
-            gl.int16,
-            [EPILOGUE_BUFFER_DEPTH, frag_rows, out_packed_n],
-            gl.SwizzledSharedLayout(1, 1, 1, [1, 0], cga_layout=((0, 1), ) if use_2cta else ()),
-        )
-        store_empty_bars, store_ready_bars = alloc_ring_barriers(EPILOGUE_BUFFER_DEPTH)
-
     x_scale_tmem.store(gl.full((BLOCK_M, scale_k), 127, dtype=gl.uint8, layout=x_scale_tmem.get_reg_layout()))
 
     p = PartitionArgs(
@@ -857,7 +699,6 @@ def ws_matmul_kernel(
         gather_indx_ptr=gather_indx_ptr,
         x_slice_sizes=x_slice_sizes,
         x_slice_offs=x_slice_offs,
-        x_block_offs=x_block_offs,
         x_block_schedule=x_block_schedule,
         #
         x_bufs=x_bufs,
@@ -877,10 +718,6 @@ def ws_matmul_kernel(
         acc_empty_bars=acc_empty_bars,
         acc_ready_bars=acc_ready_bars,
         acc_num_bufs=acc_num_bufs,
-        #
-        store_bufs=store_bufs,
-        store_empty_bars=store_empty_bars,
-        store_ready_bars=store_ready_bars,
         #
         grid_m=grid_m,
         GRID_N=grid_n,
@@ -905,37 +742,22 @@ def ws_matmul_kernel(
         FLEXPOINT_SATURATE_INF=FLEXPOINT_SATURATE_INF,
         #
         SWIGLU_SUBTILE_FACTOR=SWIGLU_SUBTILE_FACTOR,
-        EPILOGUE_BUFFER_DEPTH=EPILOGUE_BUFFER_DEPTH,
         BAND_N=BAND_N,
         X_GATHER_MULTICAST=X_GATHER_MULTICAST,
         W_SCALE_MULTICAST=W_SCALE_MULTICAST,
         FORCE_EPILOGUE_WARPS_N1=FORCE_EPILOGUE_WARPS_N1,
-        USE_DIRECT_EPILOGUE_STORE=USE_DIRECT_EPILOGUE_STORE,
     )
 
-    if USE_DIRECT_EPILOGUE_STORE:
-        gl.warp_specialize(
-            [
-                (epilogue_partition, (p, )),
-                (load_activations, (p, )),
-                (load_weights, (p, )),
-                (mma_partition, (p, )),
-            ],
-            [LOAD_ACTIVATION_WARPS, LOAD_WEIGHT_WARPS, MMA_WARPS],
-            [LOAD_ACTIVATION_REGS, LOAD_WEIGHT_REGS, MMA_REGS],
-        )
-    else:
-        gl.warp_specialize(
-            [
-                (epilogue_partition, (p, )),
-                (epilogue_store_partition, (p, )),
-                (load_activations, (p, )),
-                (load_weights, (p, )),
-                (mma_partition, (p, )),
-            ],
-            [STORE_HELPER_WARPS, LOAD_ACTIVATION_WARPS, LOAD_WEIGHT_WARPS, MMA_WARPS],
-            [STORE_HELPER_REGS, LOAD_ACTIVATION_REGS, LOAD_WEIGHT_REGS, MMA_REGS],
-        )
+    gl.warp_specialize(
+        [
+            (epilogue_partition, (p, )),
+            (load_activations, (p, )),
+            (load_weights, (p, )),
+            (mma_partition, (p, )),
+        ],
+        [LOAD_ACTIVATION_WARPS, LOAD_WEIGHT_WARPS, MMA_WARPS],
+        [LOAD_ACTIVATION_REGS, LOAD_WEIGHT_REGS, MMA_REGS],
+    )
 
 
 # ===-----------------------------------------------------------------------===#
@@ -1033,20 +855,16 @@ class KernelConfig:
     LOAD_ACTIVATION_WARPS: int = 4
     LOAD_WEIGHT_WARPS: int = 1
     MMA_WARPS: int = 1
-    STORE_HELPER_WARPS: int = 2
 
     SWIGLU_SUBTILE_FACTOR: int = 8
-    EPILOGUE_BUFFER_DEPTH: int = 2
     BAND_N: int = 20
     X_GATHER_MULTICAST: bool = True
     W_SCALE_MULTICAST: bool = True
     FORCE_EPILOGUE_WARPS_N1: bool = False
-    USE_DIRECT_EPILOGUE_STORE: bool = False
 
     LOAD_ACTIVATION_REGS: int = 112
     LOAD_WEIGHT_REGS: int = 48
     MMA_REGS: int = 48
-    STORE_HELPER_REGS: int = 48
     MAXNREG: int = None
     OCCUPANCY: int = 1
 
@@ -1075,7 +893,6 @@ def _select_occ2_config(slice_size: int) -> KernelConfig:
         LOAD_ACTIVATION_REGS=48,
         LOAD_WEIGHT_REGS=32,
         MMA_REGS=32,
-        STORE_HELPER_REGS=32,
     )
 
     if slice_size <= 14:
@@ -1163,9 +980,9 @@ def _select_band_n(slice_size: int) -> int:
 
 def maybe_enable_2cta(p: KernelConfig, slice_size: int) -> KernelConfig:
     if p.BLOCK_M == 32 and p.BLOCK_N == 128 and slice_size in (16, 20, 24, 32):
-        # Low-batch 2CTA only wins when the wider N tile is paired with direct
-        # epilogue stores and a four-warp layout. Slice 28 remains on 1CTA
-        # because uniform routing still shows a stable regression there.
+        # Low-batch 2CTA only wins when the wider N tile is paired with a
+        # four-warp layout. Slice 28 remains on 1CTA because uniform routing
+        # still shows a stable regression there.
         next_p = replace(
             p,
             BLOCK_N=256,
@@ -1182,7 +999,6 @@ def maybe_enable_2cta(p: KernelConfig, slice_size: int) -> KernelConfig:
             MAXNREG=52,
             BAND_N=32,
             FORCE_EPILOGUE_WARPS_N1=True,
-            USE_DIRECT_EPILOGUE_STORE=True,
         )
         if slice_size == 16:
             return replace(next_p, X_NUM_BUFS=5)
@@ -1202,11 +1018,9 @@ def maybe_enable_2cta(p: KernelConfig, slice_size: int) -> KernelConfig:
             X_NUM_BUFS=6,
             W_NUM_BUFS=5,
             SWIGLU_SUBTILE_FACTOR=4,
-            EPILOGUE_BUFFER_DEPTH=2,
             LOAD_ACTIVATION_REGS=64,
             LOAD_WEIGHT_REGS=48,
             MMA_REGS=48,
-            STORE_HELPER_REGS=48,
             MAXNREG=64,
         )
     if p.BLOCK_M == 128 and p.BLOCK_N == 256 and slice_size >= 80:
@@ -1223,7 +1037,7 @@ def select_kernel_config(slice_size: int) -> KernelConfig:
     else:
         p = _select_occ1_config(slice_size)
     p = maybe_enable_2cta(p, slice_size)
-    if p.BLOCK_M == 32 and p.BLOCK_N == 256 and p.NUM_CTAS == 2 and p.USE_DIRECT_EPILOGUE_STORE and slice_size <= 32:
+    if p.BLOCK_M == 32 and p.BLOCK_N == 256 and p.NUM_CTAS == 2 and slice_size <= 32:
         p = replace(p, BAND_N=32)
     elif p.BLOCK_M == 64 and p.BLOCK_N == 256 and p.NUM_CTAS == 2 and 36 <= slice_size <= 72:
         p = replace(p, BAND_N=26)
@@ -1343,18 +1157,14 @@ def matmul(
         LOAD_ACTIVATION_WARPS=p.LOAD_ACTIVATION_WARPS,
         LOAD_WEIGHT_WARPS=p.LOAD_WEIGHT_WARPS,
         MMA_WARPS=p.MMA_WARPS,
-        STORE_HELPER_WARPS=p.STORE_HELPER_WARPS,
         LOAD_ACTIVATION_REGS=p.LOAD_ACTIVATION_REGS,
         LOAD_WEIGHT_REGS=p.LOAD_WEIGHT_REGS,
         MMA_REGS=p.MMA_REGS,
-        STORE_HELPER_REGS=p.STORE_HELPER_REGS,
         SWIGLU_SUBTILE_FACTOR=p.SWIGLU_SUBTILE_FACTOR,
-        EPILOGUE_BUFFER_DEPTH=p.EPILOGUE_BUFFER_DEPTH,
         BAND_N=p.BAND_N,
         X_GATHER_MULTICAST=p.X_GATHER_MULTICAST,
         W_SCALE_MULTICAST=p.W_SCALE_MULTICAST,
         FORCE_EPILOGUE_WARPS_N1=p.FORCE_EPILOGUE_WARPS_N1,
-        USE_DIRECT_EPILOGUE_STORE=p.USE_DIRECT_EPILOGUE_STORE,
         #
         SCALE_SIZE_OUTER=p.SCALE_SIZE_OUTER,
         SCALE_SIZE_INNER=p.SCALE_SIZE_INNER,

--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -765,70 +765,6 @@ def ws_matmul_kernel(
 # ===-----------------------------------------------------------------------===#
 
 
-def get_acc_cga_layout(num_ctas: int) -> tuple[tuple[int, int], ...]:
-    if num_ctas == 1:
-        return ()
-    if num_ctas == 2:
-        return ((1, 0), )
-    raise ValueError(f"unsupported CTA count: {num_ctas}")
-
-
-def get_x_desc_cga_layout(acc_cga_layout: tuple[tuple[int, int], ...]) -> tuple[tuple[int, int], ...]:
-    return tuple((basis[0], 0) for basis in acc_cga_layout)
-
-
-def get_w_desc_cga_layout(acc_cga_layout: tuple[tuple[int, int], ...]) -> tuple[tuple[int, int, int, int, int], ...]:
-    # Sharded weight tiles use the physical [1, 1, 1, N, K/2] MX4 shuffled block layout.
-    return tuple((0, 0, 0, basis[0], 0) for basis in acc_cga_layout)
-
-
-def get_w_scale_desc_cga_layout(
-    acc_cga_layout: tuple[tuple[int, int], ...],
-) -> tuple[tuple[int, int, int, int, int], ...]:
-    # Weight scale tiles use the physical [1, N//128, K//(32*4), 2, 256] layout.
-    return tuple((0, basis[0], 0, 0, 0) for basis in acc_cga_layout)
-
-
-def make_shared_layout(
-    dtype,
-    block_shape: list[int],
-    cga_layout: tuple[tuple[int, ...], ...] = (),
-):
-    rank = len(block_shape)
-    if dtype == FP4:
-        assert rank == 5
-        return gl.NVMMASharedLayout(
-            swizzle_byte_width=128,
-            element_bitwidth=8,
-            rank=rank,
-            fp4_padded=True,
-            cga_layout=cga_layout,
-        )
-    if dtype == UINT8:
-        assert rank == 5
-        return gl.NVMMASharedLayout(
-            swizzle_byte_width=0,
-            element_bitwidth=8,
-            rank=rank,
-            cga_layout=cga_layout,
-        )
-    if dtype == torch.float32:
-        assert rank == 2
-        return gl.NVMMASharedLayout.get_default_for(
-            block_shape,
-            torch.float32,
-            cga_layout=cga_layout,
-        )
-
-    assert dtype == torch.float8_e4m3fn
-    return gl.NVMMASharedLayout(
-        swizzle_byte_width=block_shape[-1],
-        element_bitwidth=8,
-        rank=rank,
-        cga_layout=cga_layout,
-    )
-
-
 def make_tensor_descriptor(
     t: torch.Tensor | Tensor,
     block_shape: tuple[int, ...],
@@ -851,50 +787,40 @@ def make_tensor_descriptor(
         desc_block_shape[strides.index(1)] //= 2
         layout_shape = desc_block_shape
 
-    layout = make_shared_layout(t.dtype, layout_shape, cga_layout=cga_layout)
+    rank = len(layout_shape)
+    if t.dtype == FP4:
+        assert rank == 5
+        layout = gl.NVMMASharedLayout(
+            swizzle_byte_width=128,
+            element_bitwidth=8,
+            rank=rank,
+            fp4_padded=True,
+            cga_layout=cga_layout,
+        )
+    elif t.dtype == UINT8:
+        assert rank == 5
+        layout = gl.NVMMASharedLayout(
+            swizzle_byte_width=0,
+            element_bitwidth=8,
+            rank=rank,
+            cga_layout=cga_layout,
+        )
+    elif t.dtype == torch.float32:
+        assert rank == 2
+        layout = gl.NVMMASharedLayout.get_default_for(
+            layout_shape,
+            torch.float32,
+            cga_layout=cga_layout,
+        )
+    else:
+        assert t.dtype == torch.float8_e4m3fn
+        layout = gl.NVMMASharedLayout(
+            swizzle_byte_width=layout_shape[-1],
+            element_bitwidth=8,
+            rank=rank,
+            cga_layout=cga_layout,
+        )
     return TensorDescriptor(ptr, shape, strides, desc_block_shape, layout)
-
-
-def make_output_meta_descriptor(t: torch.Tensor, block_shape: tuple[int, int]):
-    # The output descriptor is only used for shape/stride metadata during
-    # direct stores, so cap the layout width to a legal FP8 swizzle size.
-    block_m, block_n = block_shape
-    return make_tensor_descriptor(t, (block_m, min(block_n, 128)))
-
-
-def make_matmul_descriptors(
-    a: torch.Tensor,
-    b: Tensor,
-    b_mx_scales: Tensor,
-    c: torch.Tensor,
-    p: "KernelConfig",
-    reduction_n: int,
-):
-    acc_cga_layout = get_acc_cga_layout(p.NUM_CTAS)
-    x_desc = make_tensor_descriptor(
-        a,
-        (1, p.BLOCK_K),
-        layout_block_shape=(p.BLOCK_M, p.BLOCK_K),
-        cga_layout=get_x_desc_cga_layout(acc_cga_layout),
-    )
-    w_desc = make_tensor_descriptor(
-        b,
-        (1, p.BLOCK_K, p.BLOCK_N),
-        cga_layout=get_w_desc_cga_layout(acc_cga_layout),
-    )
-    scale_desc = make_tensor_descriptor(
-        b_mx_scales,
-        (
-            1,
-            p.BLOCK_N // p.SCALE_SIZE_OUTER,
-            p.BLOCK_K // p.MXFP_BLOCK_SIZE // p.SCALE_SIZE_INNER,
-            2,
-            256,
-        ),
-        cga_layout=get_w_scale_desc_cga_layout(acc_cga_layout),
-    )
-    out_desc = make_output_meta_descriptor(c, (p.BLOCK_M, p.BLOCK_N // reduction_n))
-    return x_desc, w_desc, scale_desc, out_desc
 
 
 @dataclass(frozen=True, slots=True)
@@ -977,92 +903,60 @@ def _select_base_config(slice_size: int) -> KernelConfig:
     )
 
 
-def _select_band_n(slice_size: int) -> int:
-    if slice_size < 32:
-        return 22
-    elif slice_size < 416:
-        return 18
-    else:
-        return 26
+def select_kernel_config(slice_size: int) -> KernelConfig:
+    p = _select_base_config(slice_size)
 
-
-def _enable_low_batch_2cta(p: KernelConfig, slice_size: int) -> KernelConfig:
-    next_p = replace(
-        p,
-        BLOCK_N=256,
-        NUM_CTAS=2,
-        NUM_WARPS=4,
-        W_NUM_BUFS=5,
-        SWIGLU_SUBTILE_FACTOR=1,
-        LOAD_ACTIVATION_WARPS=2,
-        LOAD_WEIGHT_WARPS=1,
-        MMA_WARPS=1,
-        LOAD_ACTIVATION_REGS=40,
-        LOAD_WEIGHT_REGS=32,
-        MMA_REGS=32,
-        MAXNREG=52,
-        BAND_N=32,
-        FORCE_EPILOGUE_WARPS_N1=True,
-    )
-    if slice_size == 16:
-        return replace(next_p, X_NUM_BUFS=5)
-    if slice_size in (20, 24):
-        return replace(next_p, X_NUM_BUFS=6)
-    return replace(next_p, X_NUM_BUFS=6, X_GATHER_MULTICAST=False, W_SCALE_MULTICAST=False)
-
-
-def _enable_mid_batch_2cta(p: KernelConfig) -> KernelConfig:
-    return replace(
-        p,
-        BLOCK_M=64,
-        BLOCK_N=256,
-        NUM_CTAS=2,
-        OCCUPANCY=2,
-        X_NUM_BUFS=6,
-        W_NUM_BUFS=5,
-        SWIGLU_SUBTILE_FACTOR=4,
-        LOAD_ACTIVATION_REGS=64,
-        LOAD_WEIGHT_REGS=48,
-        MMA_REGS=48,
-        MAXNREG=64,
-    )
-
-
-def _enable_large_batch_2cta(p: KernelConfig) -> KernelConfig:
-    return replace(p, BLOCK_N=512, NUM_CTAS=2, W_NUM_BUFS=5)
-
-
-def apply_2cta_tuning(p: KernelConfig, slice_size: int) -> KernelConfig:
     if p.BLOCK_M == 32 and p.BLOCK_N == 128 and slice_size in (16, 20, 24, 32):
-        # Low-batch 2CTA only wins when the wider N tile is paired with a
-        # four-warp layout. Slice 28 remains on 1CTA because uniform routing
-        # still shows a stable regression there.
-        return _enable_low_batch_2cta(p, slice_size)
-    if 36 <= slice_size <= 72:
-        # The tuned 64-row multicta kernel wins through the 72-token slice
-        # crossover once it keeps the deeper x/w pipeline, shallower SwiGLU
-        # fragmentation, and the wider low-batch banded schedule together.
-        return _enable_mid_batch_2cta(p)
-    if p.BLOCK_M == 128 and p.BLOCK_N == 256 and slice_size >= 80:
-        # Along N, 2CTA doubles the output tile width without increasing the
-        # per-CTA weight tile footprint, which makes the extra synchronization
-        # pay back across the entire occ1 range.
-        return _enable_large_batch_2cta(p)
-    return p
+        p = replace(
+            p,
+            BLOCK_N=256,
+            NUM_CTAS=2,
+            NUM_WARPS=4,
+            W_NUM_BUFS=5,
+            SWIGLU_SUBTILE_FACTOR=1,
+            LOAD_ACTIVATION_WARPS=2,
+            LOAD_WEIGHT_WARPS=1,
+            MMA_WARPS=1,
+            LOAD_ACTIVATION_REGS=40,
+            LOAD_WEIGHT_REGS=32,
+            MMA_REGS=32,
+            MAXNREG=52,
+            BAND_N=32,
+            FORCE_EPILOGUE_WARPS_N1=True,
+        )
+        if slice_size == 16:
+            p = replace(p, X_NUM_BUFS=5)
+        elif slice_size in (20, 24):
+            p = replace(p, X_NUM_BUFS=6)
+        else:
+            p = replace(p, X_NUM_BUFS=6, X_GATHER_MULTICAST=False, W_SCALE_MULTICAST=False)
+    elif 36 <= slice_size <= 72:
+        p = replace(
+            p,
+            BLOCK_M=64,
+            BLOCK_N=256,
+            NUM_CTAS=2,
+            OCCUPANCY=2,
+            X_NUM_BUFS=6,
+            W_NUM_BUFS=5,
+            SWIGLU_SUBTILE_FACTOR=4,
+            LOAD_ACTIVATION_REGS=64,
+            LOAD_WEIGHT_REGS=48,
+            MMA_REGS=48,
+            MAXNREG=64,
+        )
+    elif p.BLOCK_M == 128 and p.BLOCK_N == 256 and slice_size >= 80:
+        p = replace(p, BLOCK_N=512, NUM_CTAS=2, W_NUM_BUFS=5)
 
-
-def apply_band_n_tuning(p: KernelConfig, slice_size: int) -> KernelConfig:
     if p.BLOCK_M == 32 and p.BLOCK_N == 256 and p.NUM_CTAS == 2 and slice_size <= 32:
         return replace(p, BAND_N=32)
     if p.BLOCK_M == 64 and p.BLOCK_N == 256 and p.NUM_CTAS == 2 and 36 <= slice_size <= 72:
         return replace(p, BAND_N=26)
-    return replace(p, BAND_N=_select_band_n(slice_size))
-
-
-def select_kernel_config(slice_size: int) -> KernelConfig:
-    p = _select_base_config(slice_size)
-    p = apply_2cta_tuning(p, slice_size)
-    return apply_band_n_tuning(p, slice_size)
+    if slice_size < 32:
+        return replace(p, BAND_N=22)
+    if slice_size < 416:
+        return replace(p, BAND_N=18)
+    return replace(p, BAND_N=26)
 
 
 def matmul(
@@ -1108,7 +1002,40 @@ def matmul(
     sms *= p.OCCUPANCY
     launch_grid = max(1, min(max(1, sms // p.NUM_CTAS), expected_grid_m * grid_n))
     grid = (launch_grid, )
-    x_desc, w_desc, scale_desc, out_desc = make_matmul_descriptors(a, b, b_mx_scales, c, p, reduction_n)
+    if p.NUM_CTAS == 1:
+        acc_cga_layout = ()
+    elif p.NUM_CTAS == 2:
+        acc_cga_layout = ((1, 0), )
+    else:
+        raise ValueError(f"unsupported CTA count: {p.NUM_CTAS}")
+
+    x_desc = make_tensor_descriptor(
+        a,
+        (1, p.BLOCK_K),
+        layout_block_shape=(p.BLOCK_M, p.BLOCK_K),
+        cga_layout=tuple((basis[0], 0) for basis in acc_cga_layout),
+    )
+    w_desc = make_tensor_descriptor(
+        b,
+        (1, p.BLOCK_K, p.BLOCK_N),
+        # Sharded weight tiles use the physical [1, 1, 1, N, K/2] MX4 shuffled block layout.
+        cga_layout=tuple((0, 0, 0, basis[0], 0) for basis in acc_cga_layout),
+    )
+    scale_desc = make_tensor_descriptor(
+        b_mx_scales,
+        (
+            1,
+            p.BLOCK_N // p.SCALE_SIZE_OUTER,
+            p.BLOCK_K // p.MXFP_BLOCK_SIZE // p.SCALE_SIZE_INNER,
+            2,
+            256,
+        ),
+        # Weight scale tiles use the physical [1, N//128, K//(32*4), 2, 256] layout.
+        cga_layout=tuple((0, basis[0], 0, 0, 0) for basis in acc_cga_layout),
+    )
+    # The output descriptor is only used for shape/stride metadata during
+    # direct stores, so cap the layout width to a legal FP8 swizzle size.
+    out_desc = make_tensor_descriptor(c, (p.BLOCK_M, min(p.BLOCK_N // reduction_n, 128)))
 
     ws_matmul_kernel[grid](
         x_desc=x_desc,


### PR DESCRIPTION
2cta vs. 1cta is flat in the medium batch sizes because it's not actually faster and disabled by the config selector. Gains are primarily concentrated at the large-ish batch sizes, and some small wins at low batch sizes. With 2CTA, some of the low-ish batch sizes are able to hit nearly 90% of roofline memory throughput (see second table below).

| logits | bs | 1cta | 2cta | triton_kernels | 2cta vs 1cta | 2cta vs triton_kernels |
|---|---:|---:|---:|---:|---:|---:|
| synthetic | 128 | 0.011863 | 0.011429 | 0.015301 | +3.8% | +33.9% |
| synthetic | 160 | 0.012237 | 0.011809 | 0.015525 | +3.6% | +31.5% |
| synthetic | 192 | 0.012201 | 0.011835 | 0.015645 | +3.1% | +32.2% |
| synthetic | 224 | 0.012187 | 0.011801 | 0.015853 | +3.3% | +34.3% |
| synthetic | 256 | 0.012808 | 0.012553 | 0.016416 | +2.0% | +30.8% |
| synthetic | 320 | 0.015553 | 0.014752 | 0.019667 | +5.4% | +33.3% |
| synthetic | 384 | 0.015389 | 0.014899 | 0.019696 | +3.3% | +32.2% |
| synthetic | 448 | 0.015380 | 0.014765 | 0.021310 | +4.2% | +44.3% |
| synthetic | 512 | 0.020948 | 0.020994 | 0.023043 | -0.2% | +9.8% |
| synthetic | 640 | 0.020905 | 0.021157 | 0.027922 | -1.2% | +32.0% |
| synthetic | 768 | 0.027629 | 0.026687 | 0.035137 | +3.5% | +31.7% |
| synthetic | 896 | 0.027527 | 0.027404 | 0.035480 | +0.4% | +29.5% |
| synthetic | 1024 | 0.027594 | 0.026152 | 0.036843 | +5.5% | +40.9% |
| synthetic | 1280 | 0.035084 | 0.031113 | 0.034826 | +12.8% | +11.9% |
| synthetic | 1536 | 0.034941 | 0.030318 | 0.035895 | +15.2% | +18.4% |
| synthetic | 1792 | 0.034891 | 0.029538 | 0.035079 | +18.1% | +18.8% |
| synthetic | 2048 | 0.038181 | 0.031135 | 0.035149 | +22.6% | +12.9% |
| synthetic | 2560 | 0.043623 | 0.036280 | 0.044152 | +20.2% | +21.7% |
| synthetic | 3072 | 0.044366 | 0.036220 | 0.046181 | +22.5% | +27.5% |
| synthetic | 3584 | 0.045405 | 0.035985 | 0.044226 | +26.2% | +22.9% |
| synthetic | 4096 | 0.042429 | 0.035829 | 0.044762 | +18.4% | +24.9% |
| synthetic | 5120 | 0.039859 | 0.035822 | 0.044792 | +11.3% | +25.0% |
| synthetic | 6144 | 0.039568 | 0.035748 | 0.043950 | +10.7% | +22.9% |
| synthetic | 7168 | 0.041656 | 0.036198 | 0.043920 | +15.1% | +21.3% |
| synthetic | 8192 | 0.042599 | 0.036309 | 0.043999 | +17.3% | +21.2% |
| synthetic | 9216 | 0.042524 | 0.036256 | 0.046542 | +17.3% | +28.4% |
| synthetic | 10240 | 0.046760 | 0.041645 | 0.052947 | +12.3% | +27.1% |
| synthetic | 11264 | 0.048035 | 0.040742 | 0.051810 | +17.9% | +27.2% |
| synthetic | 12288 | 0.046724 | 0.041623 | 0.051162 | +12.3% | +22.9% |
| synthetic | 13312 | 0.045957 | 0.040795 | 0.051157 | +12.7% | +25.4% |
| synthetic | 14336 | 0.047533 | 0.041000 | 0.051016 | +15.9% | +24.4% |
| synthetic | 15360 | 0.046382 | 0.041190 | 0.050911 | +12.6% | +23.6% |
| synthetic | 16384 | 0.046917 | 0.041259 | 0.053469 | +13.7% | +29.6% |
| synthetic | 17408 | 0.045653 | 0.040959 | 0.050586 | +11.5% | +23.5% |
| synthetic | 18432 | 0.048029 | 0.042429 | 0.054652 | +13.2% | +28.8% |
| synthetic | 19456 | 0.048443 | 0.042584 | 0.051947 | +13.8% | +22.0% |
| synthetic | 20480 | 0.048104 | 0.042482 | 0.051305 | +13.2% | +20.8% |
| synthetic | 21504 | 0.050886 | 0.047921 | 0.057987 | +6.2% | +21.0% |
| synthetic | 22528 | 0.053416 | 0.047155 | 0.059100 | +13.3% | +25.3% |
| synthetic | 23552 | 0.052981 | 0.047234 | 0.059290 | +12.2% | +25.5% |
| synthetic | 24576 | 0.051962 | 0.047616 | 0.061912 | +9.1% | +30.0% |
| synthetic | 25600 | 0.052256 | 0.047632 | 0.062128 | +9.7% | +30.4% |
| synthetic | 26624 | 0.052964 | 0.048465 | 0.060530 | +9.3% | +24.9% |
| synthetic | 27648 | 0.052513 | 0.048563 | 0.060332 | +8.1% | +24.2% |
| synthetic | 28672 | 0.054867 | 0.054648 | 0.061947 | +0.4% | +13.4% |
| synthetic | 29696 | 0.054359 | 0.054348 | 0.061915 | +0.0% | +13.9% |
| synthetic | 30720 | 0.054232 | 0.054600 | 0.063100 | -0.7% | +15.6% |
| synthetic | 31744 | 0.054285 | 0.054601 | 0.062721 | -0.6% | +14.9% |
| uniform | 128 | 0.027280 | 0.026728 | 0.029892 | +2.1% | +11.8% |
| uniform | 160 | 0.027290 | 0.026500 | 0.029906 | +3.0% | +12.9% |
| uniform | 192 | 0.027467 | 0.026777 | 0.029770 | +2.6% | +11.2% |
| uniform | 224 | 0.027193 | 0.026711 | 0.030116 | +1.8% | +12.7% |
| uniform | 256 | 0.027132 | 0.026529 | 0.029726 | +2.3% | +12.1% |
| uniform | 320 | 0.027187 | 0.026600 | 0.030855 | +2.2% | +16.0% |
| uniform | 384 | 0.027215 | 0.026538 | 0.030962 | +2.6% | +16.7% |
| uniform | 448 | 0.027034 | 0.026267 | 0.031011 | +2.9% | +18.1% |
| uniform | 512 | 0.028627 | 0.027687 | 0.031254 | +3.4% | +12.9% |
| uniform | 640 | 0.027814 | 0.027531 | 0.035504 | +1.0% | +29.0% |
| uniform | 768 | 0.027835 | 0.027482 | 0.035322 | +1.3% | +28.5% |
| uniform | 896 | 0.027900 | 0.027030 | 0.035041 | +3.2% | +29.6% |
| uniform | 1024 | 0.030795 | 0.030428 | 0.034714 | +1.2% | +14.1% |
| uniform | 1280 | 0.031702 | 0.029729 | 0.034140 | +6.6% | +14.8% |
| uniform | 1536 | 0.030763 | 0.029714 | 0.034017 | +3.5% | +14.5% |
| uniform | 1792 | 0.031619 | 0.030477 | 0.033434 | +3.7% | +9.7% |
| uniform | 2048 | 0.035950 | 0.032804 | 0.040173 | +9.6% | +22.5% |
| uniform | 2560 | 0.038933 | 0.035958 | 0.041860 | +8.3% | +16.4% |
| uniform | 3072 | 0.037961 | 0.035561 | 0.040587 | +6.7% | +14.1% |
| uniform | 3584 | 0.037874 | 0.035770 | 0.040367 | +5.9% | +12.9% |
| uniform | 4096 | 0.046900 | 0.040832 | 0.050988 | +14.9% | +24.9% |
| uniform | 5120 | 0.053465 | 0.052326 | 0.062106 | +2.2% | +18.7% |
| uniform | 6144 | 0.053205 | 0.053055 | 0.061160 | +0.3% | +15.3% |
| uniform | 7168 | 0.053186 | 0.053400 | 0.060311 | -0.4% | +12.9% |
| uniform | 8192 | 0.068429 | 0.062134 | 0.078977 | +10.1% | +27.1% |
| uniform | 9216 | 0.075559 | 0.068637 | 0.087026 | +10.1% | +26.8% |
| uniform | 10240 | 0.077114 | 0.070082 | 0.088088 | +10.0% | +25.7% |
| uniform | 11264 | 0.077810 | 0.070391 | 0.088168 | +10.5% | +25.3% |
| uniform | 12288 | 0.093385 | 0.083857 | 0.107854 | +11.4% | +28.6% |
| uniform | 13312 | 0.094401 | 0.085389 | 0.108572 | +10.6% | +27.2% |
| uniform | 14336 | 0.095550 | 0.090905 | 0.110206 | +5.1% | +21.2% |
| uniform | 15360 | 0.096379 | 0.091603 | 0.110162 | +5.2% | +20.3% |
| uniform | 16384 | 0.110315 | 0.099611 | 0.124473 | +10.7% | +25.0% |
| uniform | 17408 | 0.113334 | 0.106708 | 0.127829 | +6.2% | +19.8% |
| uniform | 18432 | 0.119447 | 0.107904 | 0.133565 | +10.7% | +23.8% |
| uniform | 19456 | 0.121549 | 0.113657 | 0.137682 | +6.9% | +21.1% |
| uniform | 20480 | 0.130164 | 0.121107 | 0.146509 | +7.5% | +21.0% |
| uniform | 21504 | 0.136851 | 0.122934 | 0.154323 | +11.3% | +25.5% |
| uniform | 22528 | 0.138386 | 0.123689 | 0.154673 | +11.9% | +25.0% |
| uniform | 23552 | 0.140456 | 0.129876 | 0.156781 | +8.1% | +20.7% |
| uniform | 24576 | 0.153471 | 0.138302 | 0.170690 | +11.0% | +23.4% |
| uniform | 25600 | 0.156519 | 0.144702 | 0.174207 | +8.2% | +20.4% |
| uniform | 26624 | 0.158187 | 0.145629 | 0.174170 | +8.6% | +19.6% |
| uniform | 27648 | 0.164956 | 0.152207 | 0.182424 | +8.4% | +19.9% |
| uniform | 28672 | 0.171899 | 0.153590 | 0.190432 | +11.9% | +24.0% |
| uniform | 29696 | 0.179508 | 0.160948 | 0.206165 | +11.5% | +28.1% |
| uniform | 30720 | 0.181081 | 0.165985 | 0.209012 | +9.1% | +25.9% |
| uniform | 31744 | 0.188794 | 0.168659 | 0.216726 | +11.9% | +28.5% |


| logits | bs | TFLOPS | %roofline | TBPS | %roofline |
|---|---:|---:|---:|---:|---:|
| synthetic | 128 | 31.93 | 0.6% | 5.78 | 72.2% |
| synthetic | 160 | 39.33 | 0.8% | 6.39 | 79.9% |
| synthetic | 192 | 42.05 | 0.8% | 6.38 | 79.7% |
| synthetic | 224 | 56.23 | 1.1% | 6.40 | 80.0% |
| synthetic | 256 | 58.15 | 1.2% | 6.77 | 84.6% |
| synthetic | 320 | 71.97 | 1.4% | 7.04 | 88.0% |
| synthetic | 384 | 80.17 | 1.6% | 6.97 | 87.1% |
| synthetic | 448 | 96.62 | 1.9% | 7.04 | 88.0% |
| synthetic | 512 | 85.34 | 1.7% | 5.97 | 74.6% |
| synthetic | 640 | 101.93 | 2.0% | 5.93 | 74.1% |
| synthetic | 768 | 93.24 | 1.9% | 5.06 | 63.3% |
| synthetic | 896 | 99.27 | 2.0% | 4.83 | 60.4% |
| synthetic | 1024 | 133.21 | 2.7% | 5.17 | 64.7% |
| synthetic | 1280 | 147.16 | 2.9% | 4.35 | 54.4% |
| synthetic | 1536 | 180.56 | 3.6% | 4.47 | 55.9% |
| synthetic | 1792 | 212.29 | 4.2% | 4.60 | 57.5% |
| synthetic | 2048 | 232.30 | 4.6% | 4.98 | 62.3% |
| synthetic | 2560 | 255.14 | 5.1% | 4.46 | 55.8% |
| synthetic | 3072 | 313.27 | 6.3% | 4.48 | 56.0% |
| synthetic | 3584 | 364.18 | 7.3% | 4.52 | 56.4% |
| synthetic | 4096 | 421.32 | 8.4% | 4.54 | 56.8% |
| synthetic | 5120 | 517.74 | 10.4% | 4.56 | 57.0% |
| synthetic | 6144 | 628.33 | 12.6% | 4.59 | 57.4% |
| synthetic | 7168 | 723.17 | 14.5% | 4.55 | 56.9% |
| synthetic | 8192 | 811.42 | 16.2% | 4.55 | 56.9% |
| synthetic | 9216 | 886.73 | 17.7% | 4.57 | 57.2% |
| synthetic | 10240 | 848.46 | 17.0% | 3.99 | 49.9% |
| synthetic | 11264 | 951.95 | 19.0% | 4.10 | 51.2% |
| synthetic | 12288 | 1025.87 | 20.5% | 4.03 | 50.3% |
| synthetic | 13312 | 1134.53 | 22.7% | 4.12 | 51.6% |
| synthetic | 14336 | 1226.75 | 24.5% | 4.12 | 51.5% |
| synthetic | 15360 | 1313.73 | 26.3% | 4.12 | 51.5% |
| synthetic | 16384 | 1377.48 | 27.5% | 4.12 | 51.5% |
| synthetic | 17408 | 1465.32 | 29.3% | 4.17 | 52.1% |
| synthetic | 18432 | 1489.64 | 29.8% | 4.03 | 50.4% |
| synthetic | 19456 | 1573.81 | 31.5% | 4.04 | 50.4% |
| synthetic | 20480 | 1655.67 | 33.1% | 4.06 | 50.7% |
| synthetic | 21504 | 1541.83 | 30.8% | 3.61 | 45.1% |
| synthetic | 22528 | 1649.90 | 33.0% | 3.68 | 46.0% |
| synthetic | 23552 | 1717.38 | 34.3% | 3.69 | 46.1% |
| synthetic | 24576 | 1780.24 | 35.6% | 3.67 | 45.9% |
| synthetic | 25600 | 1848.62 | 37.0% | 3.68 | 46.1% |
| synthetic | 26624 | 1882.57 | 37.7% | 3.63 | 45.4% |
| synthetic | 27648 | 1947.09 | 38.9% | 3.64 | 45.5% |
| synthetic | 28672 | 1788.57 | 35.8% | 3.24 | 40.5% |
| synthetic | 29696 | 1858.26 | 37.2% | 3.27 | 40.9% |
| synthetic | 30720 | 1908.61 | 38.2% | 3.27 | 40.8% |
| synthetic | 31744 | 1970.58 | 39.4% | 3.28 | 41.0% |
| uniform | 128 | 76.96 | 1.5% | 5.65 | 70.7% |
| uniform | 160 | 100.16 | 2.0% | 5.71 | 71.3% |
| uniform | 192 | 120.19 | 2.4% | 5.65 | 70.6% |
| uniform | 224 | 146.57 | 2.9% | 5.67 | 70.9% |
| uniform | 256 | 162.58 | 3.3% | 5.71 | 71.4% |
| uniform | 320 | 214.53 | 4.3% | 5.71 | 71.3% |
| uniform | 384 | 261.29 | 5.2% | 5.73 | 71.6% |
| uniform | 448 | 309.45 | 6.2% | 5.79 | 72.4% |
| uniform | 512 | 325.94 | 6.5% | 5.62 | 70.2% |
| uniform | 640 | 424.19 | 8.5% | 5.66 | 70.8% |
| uniform | 768 | 502.21 | 10.0% | 5.69 | 71.1% |
| uniform | 896 | 583.03 | 11.7% | 5.68 | 71.0% |
| uniform | 1024 | 593.17 | 11.9% | 5.16 | 64.5% |
| uniform | 1280 | 746.59 | 14.9% | 5.31 | 66.3% |
| uniform | 1536 | 876.52 | 17.5% | 5.33 | 66.7% |
| uniform | 1792 | 987.39 | 19.7% | 5.22 | 65.3% |
| uniform | 2048 | 1052.86 | 21.1% | 4.87 | 60.9% |
| uniform | 2560 | 1193.02 | 23.9% | 4.66 | 58.3% |
| uniform | 3072 | 1426.51 | 28.5% | 4.75 | 59.4% |
| uniform | 3584 | 1649.13 | 33.0% | 4.77 | 59.6% |
| uniform | 4096 | 1660.81 | 33.2% | 4.21 | 52.6% |
| uniform | 5120 | 1614.92 | 32.3% | 3.34 | 41.8% |
| uniform | 6144 | 1914.16 | 38.3% | 3.35 | 41.9% |
| uniform | 7168 | 2227.38 | 44.5% | 3.39 | 42.3% |
| uniform | 8192 | 2207.94 | 44.2% | 2.96 | 37.0% |
| uniform | 9216 | 2240.45 | 44.8% | 2.72 | 34.0% |
| uniform | 10240 | 2457.46 | 49.1% | 2.71 | 33.9% |
| uniform | 11264 | 2677.66 | 53.6% | 2.74 | 34.3% |
| uniform | 12288 | 2454.59 | 49.1% | 2.34 | 29.2% |
| uniform | 13312 | 2598.61 | 52.0% | 2.33 | 29.1% |
| uniform | 14336 | 2625.59 | 52.5% | 2.22 | 27.7% |
| uniform | 15360 | 2790.31 | 55.8% | 2.23 | 27.9% |
| uniform | 16384 | 2730.52 | 54.6% | 2.08 | 26.0% |
| uniform | 17408 | 2708.12 | 54.2% | 1.97 | 24.6% |
| uniform | 18432 | 2835.52 | 56.7% | 1.98 | 24.7% |
| uniform | 19456 | 2845.24 | 56.9% | 1.90 | 23.8% |
| uniform | 20480 | 2818.43 | 56.4% | 1.81 | 22.7% |
| uniform | 21504 | 2908.79 | 58.2% | 1.81 | 22.6% |
| uniform | 22528 | 3029.17 | 60.6% | 1.82 | 22.8% |
| uniform | 23552 | 3016.16 | 60.3% | 1.76 | 22.0% |
| uniform | 24576 | 2959.07 | 59.2% | 1.67 | 20.9% |
| uniform | 25600 | 2944.91 | 58.9% | 1.62 | 20.2% |
| uniform | 26624 | 3048.49 | 61.0% | 1.63 | 20.4% |
| uniform | 27648 | 3027.70 | 60.6% | 1.58 | 19.7% |
| uniform | 28672 | 3110.60 | 62.2% | 1.58 | 19.8% |
| uniform | 29696 | 3070.01 | 61.4% | 1.53 | 19.1% |
| uniform | 30720 | 3079.40 | 61.6% | 1.50 | 18.7% |
| uniform | 31744 | 3137.40 | 62.7% | 1.49 | 18.7% |