### PR TITLE
[AMD][BACKEND] Fix TDM gather/scatter intrinsic waitcnt computation

### DIFF
--- a/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
@@ -569,35 +569,38 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
+#idx_i32_parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#idx_i16_parent = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tdm_gather_scatter_multiple_instructions
   tt.func public @tdm_gather_scatter_multiple_instructions(
     %memDesc: !ttg.memdesc<256x128xf16, #shared, #smem, mutable>,
     %tensorDesc: !tt.tensordesc<64x128xf16>,
-    %row_indices_i32: tensor<64xi32>,
-    %row_indices_i16: tensor<256xi16>,
+    %row_indices_i32: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>,
+    %row_indices_i16: tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>,
     %pred: i32
   ) {
     %c0_i32 = arith.constant 0 : i32
 
-    // Gather with 64xi32 indices: 64/8 = 8 instructions
-    amdg.async_tdm_gather %tensorDesc[%row_indices_i32, %c0_i32] to %memDesc, pred = %pred : tensor<64xi32>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
-    // Scatter with 64xi32 indices: 64/8 = 8 instructions
-    amdg.async_tdm_scatter %tensorDesc[%row_indices_i32, %c0_i32] from %memDesc : tensor<64xi32>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
-    // Gather with 128xi16 indices: 256/16 = 16 instructions
-    amdg.async_tdm_gather %tensorDesc[%row_indices_i16, %c0_i32] to %memDesc, pred = %pred : tensor<256xi16>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
-    // Scatter with 128xi16 indices: 256/16 = 16 instructions
-    amdg.async_tdm_scatter %tensorDesc[%row_indices_i16, %c0_i32] from %memDesc : tensor<256xi16>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Gather with i32 indices: sizePerThread=16, 4 warps, maxPerInstr=8 => 2 instructions
+    amdg.async_tdm_gather %tensorDesc[%row_indices_i32, %c0_i32] to %memDesc, pred = %pred : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Scatter with i32 indices: 2 instructions
+    amdg.async_tdm_scatter %tensorDesc[%row_indices_i32, %c0_i32] from %memDesc : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Gather with i16 indices: sizePerThread=64, 4 warps, maxPerInstr=16 => 4 instructions
+    amdg.async_tdm_gather %tensorDesc[%row_indices_i16, %c0_i32] to %memDesc, pred = %pred : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Scatter with i16 indices: 4 instructions
+    amdg.async_tdm_scatter %tensorDesc[%row_indices_i16, %c0_i32] from %memDesc : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
 
+    // i32 ops emit 2 instructions each, i16 ops emit 4 each => total 12 instructions
     // CHECK: amdg.async_tdm_intrinsic_wait {count = 0
     amdg.async_tdm_wait {num = 0 : i32}
-    // CHECK: amdg.async_tdm_intrinsic_wait {count = 16
+    // CHECK: amdg.async_tdm_intrinsic_wait {count = 4
     amdg.async_tdm_wait {num = 1 : i32}
-    // CHECK: amdg.async_tdm_intrinsic_wait {count = 32
+    // CHECK: amdg.async_tdm_intrinsic_wait {count = 8
     amdg.async_tdm_wait {num = 2 : i32}
-    // CHECK: amdg.async_tdm_intrinsic_wait {count = 40
+    // CHECK: amdg.async_tdm_intrinsic_wait {count = 10
     amdg.async_tdm_wait {num = 3 : i32}
-    // CHECK: amdg.async_tdm_intrinsic_wait {count = 48
+    // CHECK: amdg.async_tdm_intrinsic_wait {count = 12
     amdg.async_tdm_wait {num = 4 : i32}
 
     tt.return

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -604,33 +604,35 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
+#idx_i32_parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#idx_i16_parent = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tdm_gather_scatter_multiple_instructions
   tt.func public @tdm_gather_scatter_multiple_instructions(
     %memDesc: !ttg.memdesc<256x128xf16, #shared, #smem, mutable>,
     %tensorDesc: !tt.tensordesc<64x128xf16>,
-    %row_indices_i32: tensor<64xi32>,
-    %row_indices_i16: tensor<256xi16>,
+    %row_indices_i32: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>,
+    %row_indices_i16: tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>,
     %pred: i32
   ) {
     %c0_i32 = arith.constant 0 : i32
 
-    // Gather with 64xi32 indices: 64/8 = 8 instructions
-    %token1 = amdg.async_tdm_gather %tensorDesc[%row_indices_i32, %c0_i32] to %memDesc, pred = %pred : tensor<64xi32>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
-    // Scatter with 64xi32 indices: 64/8 = 8 instructions
-    %token2 = amdg.async_tdm_scatter %tensorDesc[%row_indices_i32, %c0_i32] from %memDesc : tensor<64xi32>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
-    // Gather with 128xi16 indices: 256/16 = 16 instructions
-    %token3 = amdg.async_tdm_gather %tensorDesc[%row_indices_i16, %c0_i32] to %memDesc, pred = %pred : tensor<256xi16>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
-    // Scatter with 128xi16 indices: 256/16 = 16 instructions
-    %token4 = amdg.async_tdm_scatter %tensorDesc[%row_indices_i16, %c0_i32] from %memDesc : tensor<256xi16>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Gather with i32 indices: sizePerThread=16, 4 warps, maxPerInstr=8 => 2 instructions
+    %token1 = amdg.async_tdm_gather %tensorDesc[%row_indices_i32, %c0_i32] to %memDesc, pred = %pred : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Scatter with i32 indices: 2 instructions
+    %token2 = amdg.async_tdm_scatter %tensorDesc[%row_indices_i32, %c0_i32] from %memDesc : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Gather with i16 indices: sizePerThread=64, 4 warps, maxPerInstr=16 => 4 instructions
+    %token3 = amdg.async_tdm_gather %tensorDesc[%row_indices_i16, %c0_i32] to %memDesc, pred = %pred : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Scatter with i16 indices: 4 instructions
+    %token4 = amdg.async_tdm_scatter %tensorDesc[%row_indices_i16, %c0_i32] from %memDesc : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
 
     // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 0
     %w1 = amdg.async_tdm_wait %token4 {num = 0 : i32}
-    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 16
+    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 4
     %w2 = amdg.async_tdm_wait %token3 {num = 0 : i32}
-    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 32
+    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 8
     %w3 = amdg.async_tdm_wait %token2 {num = 0 : i32}
-    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 40
+    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 10
     %w4 = amdg.async_tdm_wait %token1 {num = 0 : i32}
 
     tt.return

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -112,6 +112,61 @@ std::pair<SmallVector<unsigned>, unsigned> distributeTDMWarpsAlignToPartition(
   return {warps, numTDMInstructions};
 }
 
+// Shared layout analysis for TDM gather/scatter, used by both
+// getTDMGatherScatterInstrinsicCount (wait-count pass) and
+// emitTDMGatherScatter (lowering) so the instruction-count logic
+// cannot get out of sync.
+//
+// Uses the LinearLayout of the index tensor to determine:
+// 1. Which registers are broadcasted — remove duplicates
+// 2. Which warps are redundant (freeVarMasks)
+// 3. The effective number of indices per warp and max indices per instruction
+// This analysis is direction-agnostic: the index layout determines which warp
+// owns which rows in LDS, regardless of whether data flows to LDS (gather) or
+// from LDS (scatter).
+struct GatherScatterLayoutAnalysis {
+  triton::LinearLayout indexLL; // post-broadcast-removal
+  ColumnAction removeBcastAction;
+  size_t maxIndicesPerInstr;
+  size_t effectiveRegCount;
+  size_t numInstructions;
+  llvm::MapVector<StringAttr, int32_t> freeVarMasks; // from original layout
+};
+
+GatherScatterLayoutAnalysis
+analyzeGatherScatterLayout(RankedTensorType indicesType) {
+  assert(indicesType.getEncoding());
+
+  bool use32BitIndices =
+      indicesType.getElementType().getIntOrFloatBitWidth() == 32;
+  size_t maxIndicesPerInstr = use32BitIndices ? 8 : 16;
+
+  auto indexLL = triton::gpu::toLinearLayout(indicesType);
+  assert(indexLL.getNumOutDims() == 1 &&
+         "Gather/scatter index layout must have exactly one output dimension");
+  auto freeVarMasks = indexLL.getFreeVariableMasks();
+
+  // Remove broadcasted (duplicated) register entries so indexLL has a compact
+  // register dimension containing only unique index values.
+  auto removeBcastAction = actionRemoveBroadcastedRegs(indexLL);
+  if (!removeBcastAction.isIdentity())
+    indexLL = removeBcastAction.apply(indexLL);
+
+  size_t contigIndiceCount = indexLL.getNumConsecutiveInOut();
+  maxIndicesPerInstr = std::min(maxIndicesPerInstr, contigIndiceCount);
+
+  auto kRegister = StringAttr::get(indicesType.getContext(), "register");
+  size_t effectiveRegCount = indexLL.getInDimSize(kRegister);
+  size_t numInstructions =
+      effectiveRegCount == 0
+          ? 0
+          : llvm::divideCeil(effectiveRegCount, maxIndicesPerInstr);
+
+  return {std::move(indexLL), std::move(removeBcastAction),
+          maxIndicesPerInstr, effectiveRegCount,
+          numInstructions,    std::move(freeVarMasks)};
+}
+
 } // namespace
 
 std::pair<SmallVector<unsigned>, unsigned>
@@ -1110,16 +1165,8 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
   }
 }
 
-// Emit a TDM gather or scatter operation for non-contiguous row access.
-size_t getTDMGatherScatterInstrinsicCount(size_t numIndices,
-                                          bool use32BitIndices) {
-  if (numIndices == 0)
-    return 0;
-
-  // Determine max indices per instruction based on index size
-  size_t maxIndicesPerInstr = use32BitIndices ? 8 : 16;
-
-  return llvm::divideCeil(numIndices, maxIndicesPerInstr);
+size_t getTDMGatherScatterInstrinsicCount(RankedTensorType indicesType) {
+  return analyzeGatherScatterLayout(indicesType).numInstructions;
 }
 
 void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
@@ -1139,32 +1186,19 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
 
   bool use32BitIndices =
       indicesType.getElementType().getIntOrFloatBitWidth() == 32;
-  size_t maxIndicesPerInstr = use32BitIndices ? 8 : 16;
 
-  // Use LinearLayout to determine:
-  // 1. Which registers are broadcasted — remove duplicates
-  // 2. Which warps are redundant — zero the pred to make instruction a no-op
-  // 3. Per-batch LDS row offset — via applyLinearLayout per batch
-  // This analysis is direction-agnostic: the index layout determines which warp
-  // owns which rows in LDS, regardless of whether data flows to LDS (gather) or
-  // from LDS (scatter).
-  auto indexLL = triton::gpu::toLinearLayout(indicesType);
-  assert(indexLL.getNumOutDims() == 1 &&
-         "Gather/scatter index layout must have exactly one output dimension");
-  auto freeVarMasks = indexLL.getFreeVariableMasks();
+  auto analysis = analyzeGatherScatterLayout(indicesType);
+  auto &indexLL = analysis.indexLL;
+  size_t maxIndicesPerInstr = analysis.maxIndicesPerInstr;
 
   auto kRegister = rewriter.getStringAttr("register");
   auto kLane = rewriter.getStringAttr("lane");
   auto kWarp = rewriter.getStringAttr("warp");
 
-  // Remove broadcasted (duplicated) register entries. After this, indexLL
-  // has a compact register dimension and effectiveRowIndices contains only
-  // unique index values.
+  // Apply broadcast removal to the actual row indices.
   SmallVector<Value> effectiveRowIndices(rowIndices.begin(), rowIndices.end());
-  auto removeBcast = actionRemoveBroadcastedRegs(indexLL);
-  if (!removeBcast.isIdentity()) {
-    indexLL = removeBcast.apply(indexLL);
-    effectiveRowIndices = removeBcast.apply(
+  if (!analysis.removeBcastAction.isIdentity()) {
+    effectiveRowIndices = analysis.removeBcastAction.apply(
         SmallVector<Value>(rowIndices.begin(), rowIndices.end()));
   }
 
@@ -1172,7 +1206,7 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
 
   // If any warp bits are free, those warps hold redundant copies.
   // Zero the pred so the instruction becomes a no-op.
-  int32_t warpFreeMask = freeVarMasks.lookup(kWarp);
+  int32_t warpFreeMask = analysis.freeVarMasks.lookup(kWarp);
   if (warpFreeMask != 0) {
     Value isActive =
         b.icmp_eq(b.and_(warpId, b.i32_val(warpFreeMask)), b.i32_val(0));
@@ -1188,9 +1222,6 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
     pred = b.select(inRange, pred, b.i32_val(0));
   }
 
-  size_t contigIndiceCount = indexLL.getNumConsecutiveInOut();
-  maxIndicesPerInstr = std::min(maxIndicesPerInstr, contigIndiceCount);
-
   // Precompute LDS row offset for each instruction batch via
   // applyLinearLayout with the actual register index and warp ID.
   SmallVector<Value> batchLdsOffsets;
@@ -1204,9 +1235,9 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
                                       {kBlock, b.i32_val(0)}});
     batchLdsOffsets.push_back(offsets[0].second);
   }
+  assert(batchLdsOffsets.size() == analysis.numInstructions);
 
   size_t numIndicesPerWarp = effectiveRowIndices.size();
-  size_t numInstructions = batchLdsOffsets.size();
 
   // Get the descriptor groups (gather/scatter uses 2D format — desc has 2
   // vector entries: group0 = <4 x i32>, group1 = <8 x i32>)
@@ -1219,7 +1250,7 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
   Value group3Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
 
   // Issue multiple TDM instructions if needed
-  for (size_t instrIdx = 0; instrIdx < numInstructions; ++instrIdx) {
+  for (size_t instrIdx = 0; instrIdx < analysis.numInstructions; ++instrIdx) {
     size_t startIdx = instrIdx * maxIndicesPerInstr;
     size_t endIdx = std::min(startIdx + maxIndicesPerInstr, numIndicesPerWarp);
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -123,13 +123,10 @@ std::pair<SmallVector<unsigned>, unsigned>
 distributeTDMWarpsAlignToPartition(ArrayRef<int64_t> blockShape, int numWarps,
                                    Attribute encoding);
 
-// Calculate the number of TDM gather/scatter instructions needed.
-// - numIndices: number of row indices
-// - use32BitIndices: true for 32-bit indices (max 8 rows/instr), false for
-//   16-bit (max 16 rows/instr)
-// Returns: the number of TDM instructions that will be emitted
-size_t getTDMGatherScatterInstrinsicCount(size_t numIndices,
-                                          bool use32BitIndices);
+// Calculate the number of TDM gather/scatter instructions needed using the
+// same LinearLayout analysis as emitTDMGatherScatter: broadcasts are removed
+// and contiguity is considered when batching indices per instruction.
+size_t getTDMGatherScatterInstrinsicCount(RankedTensorType indicesType);
 
 // Emit a TDM gather or scatter operation for non-contiguous row access.
 // Gather: reads from non-contiguous global rows into LDS

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -488,15 +488,10 @@ struct TritonAMDGPUUpdateAsyncWaitCountPass
                   smemTy.getShape(), numWarps, smemTy.getEncoding());
           return numInstr;
         } else if (isa<AsyncTDMScatterOp, AsyncTDMGatherOp>(op)) {
-          // For scatter and gather we need to get the count of TDM intrinsics
-          // based on the row indices tensor type
           auto rowIndicesType =
               cast<RankedTensorType>(op->getOperandTypes()[1]);
-          bool use32BitIndices =
-              rowIndicesType.getElementType().getIntOrFloatBitWidth() == 32;
-          size_t numIndices = rowIndicesType.getNumElements();
           return mlir::LLVM::AMD::getTDMGatherScatterInstrinsicCount(
-              numIndices, use32BitIndices);
+              rowIndicesType);
         } else {
           return 0;
         }


### PR DESCRIPTION
After https://github.com/triton-lang/triton/pull/10019 the waitcnt computation got out of sync with the lowering for TDM scatter and gather. This PR unifies the logic again and adds asserts to prevent this in the future.