### PR TITLE
[LinearLayout] fix defect in invertAndCompose

### DIFF
--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -1061,9 +1061,11 @@ LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
   // this dimension.
   SmallVector<StringAttr> identityDims;
   for (auto dim : A.getInDimNames()) {
-    if (B.hasInDim(dim) &&
-        A.sublayout(dim, outDims) == B.sublayout(dim, outDims)) {
-      identityDims.push_back(dim);
+    if (B.hasInDim(dim)) {
+      auto aSub = A.sublayout(dim, outDims);
+      auto bSub = B.sublayout(dim, outDims);
+      if (aSub.equalIgnoringOutDimSizes(bSub))
+        identityDims.push_back(dim);
     }
   }
   SmallVector<StringAttr> ANonIdentityInDims;

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -1161,6 +1161,44 @@ TEST_F(LinearLayoutTest, ColumnActionApplyValues) {
   EXPECT_EQ(result, expected);
 }
 
+// The purpose of this test is to make sure the conversion of block dimension
+// is identity, and this decision should be immune to block-sublayout's out-dim
+// sizes.
+TEST_F(LinearLayoutTest, invertAndCompose1) {
+  auto regLayout = LinearLayout(
+      {{S("offset"),
+        {{0, 1}, {0, 2}, {0, 4}, /*gap*/ {0, 16}, {32, 0}, {64, 0}, {128, 0}}},
+
+       {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {0, 8}}},
+       {S("warp"), {{0, 0}, {16, 0}}},
+
+       {S("block"), {{0, 0}}}},
+      {S("dim0"), S("dim1")});
+
+  auto sharedLayout = LinearLayout({{S("offset"),
+                                     {{0, 1},
+                                      {0, 2},
+                                      {0, 4},
+                                      {0, 8},
+                                      {0, 16},
+                                      {0, 32},
+                                      {0, 64},
+                                      {1, 0},
+                                      {2, 0},
+                                      {4, 0},
+                                      {8, 0},
+                                      {16, 0},
+                                      {32, 0},
+                                      {64, 0},
+                                      {128, 0}}},
+                                    {S("block"), {{0, 0}}}},
+                                   {S("dim0"), S("dim1")});
+
+  auto cvt = regLayout.invertAndCompose(sharedLayout);
+
+  EXPECT_TRUE(cvt.isTrivialOver(S("block")));
+}
+
 } // anonymous namespace
 } // namespace mlir::triton
 


### PR DESCRIPTION
I come across bunch of problems when using memdesc_subslice with multi-ctas. This PR is to resolve one of these problems. It is a defect but bug. However, this defect incur lots of troubles about dealing with block layout.

In invertAndCompose(A, B), it uses identity map for common bases shared by A and B. Sublayouts are constructed, say aSub and bSub. It then uses `LineaLayout::== operation(aSub, bSub)` to determine if these two sublayout equal. The `== operation` return true iff
  - bases from both LLs are equal, and
  - out-dim-sizes are equal

The second condition is problematic for memdesc_subslice -- it's out-dim-size is certainly not equals to the shared-memory buffer where it slices from.

This PR is to use equalIgnoringOutDimSizes() instead of `== operaiton` to dodge the 2nd condition.

The unit-test is copied from real example verbatim, where destination layout is following
 
and dest layout is
  ```
  regLayout:
   - register=1 -> (0, 1)
     register=2 -> (0, 2)
     register=4 -> (0, 4)
     register=8 -> (0, 16)
     register=16 -> (32, 0)
     register=32 -> (64, 0)
     register=64 -> (128, 0)
   - lane=1 -> (1, 0)
     lane=2 -> (2, 0)
     lane=4 -> (4, 0)
     lane=8 -> (8, 0)
     lane=16 -> (0, 8)
   - warp=1 -> (0, 0)
     warp=2 -> (16, 0)
   - block=1 -> (0, 0)
  where out dims are: [dim0 (size 256), dim1 (size 32)]
  ```
  
  The src layout is 
  ```
  shared layout:
   - offset=1 -> (0, 1)
     offset=2 -> (0, 2)
     offset=4 -> (0, 4)
     offset=8 -> (0, 8)
     offset=16 -> (0, 16)
     offset=32 -> (0, 32)
     offset=64 -> (0, 64)
     offset=128 -> (1, 0)
     offset=256 -> (2, 0)
     offset=512 -> (4, 0)
     offset=1024 -> (8, 0)
     offset=2048 -> (16, 0)
     offset=4096 -> (32, 0)
     offset=8192 -> (64, 0)
     offset=16384 -> (128, 0)
   - block=1 -> (0, 0)
  where out dims are: [dim0 (size 256), dim1 (size 128)]
  ```

and without this PR, `cvt = regLayout.invertAndCompose(sharedLayout)` yields
   ```
   cvt:
   - register=1 -> (1, 0)
     register=2 -> (2, 0)
     register=4 -> (4, 0)
     register=8 -> (16, 0)
     register=16 -> (4096, 0)
     register=32 -> (8192, 0)
     register=64 -> (16384, 0)
   - lane=1 -> (128, 0)
     lane=2 -> (256, 0)
     lane=4 -> (512, 0)
     lane=8 -> (1024, 0)
     lane=16 -> (8, 0)
   - warp=1 -> (0, 0)
     warp=2 -> (2048, 0)
   - block=1 -> (0, 0)  # !!!!! problematic!!!!!
  where out dims are: [offset (size 32768), block (size 2)]
  ```

with this PR, the "block"-in-dim becomes `block=1 -> (0, 1)`