### PR TITLE
[DOCS] Clarify tl.load semantics when other is None

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2422,7 +2422,7 @@ def load(pointer, mask=None, other=None, boundary_check=(), padding_option="", c
     :param mask: if `mask[idx]` is false, do not load the data at address `pointer[idx]`
         (must be `None` with block pointers)
     :type mask: Block of `triton.int1`, optional
-    :param other: if `mask[idx]` is false, return `other[idx]`
+    :param other: if `mask[idx]` is false, return `other[idx]`. If `other` is `None`, the masked-out value is undefined.
     :type other: Block, optional
     :param boundary_check: tuple of integers, indicating the dimensions which should do the boundary check
     :type boundary_check: tuple of ints, optional


### PR DESCRIPTION
The `tl.load` docstring previously did not specify the value returned at masked-out positions when `other` is `None`. Per the maintainer comment on #9917, those values are undefined — this change updates the `:param other:` description to state that explicitly, mirroring the wording already used for `padding_option` (`"" means an undefined value`).

Fixes #9917

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is a docstring-only clarification with no behavior change.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)