### PR TITLE
Enable local load/store lowering with generic linear encoding

### DIFF
--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -119,7 +119,7 @@ ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout);
 
 std::pair<int64_t, ColumnAction>
 actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
-                      uint64_t maskSpanOffsets);
+                      uint64_t maskSpanOffsets, int64_t regsPerInst);
 
 // For a layout A with A.hasInDim(kReg), repeat the values so that they have
 // the same broadcasting as layout

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -681,8 +681,8 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
                     {kWarp, reps.getBases().lookup(kWarp)},
                     {kBlock, reps.getBases().lookup(kBlock)}},
                    reps.getOutDims(), false);
-  auto [nAdditive, permStrides] =
-      actionAdditiveStrides(reps, addrLayout, maskSpanAffineOffset);
+  auto [nAdditive, permStrides] = actionAdditiveStrides(
+      reps, addrLayout, maskSpanAffineOffset, elemsPerVec);
   reps = permStrides.apply(reps);
 
   if (isPartitioned) {

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3738,7 +3738,8 @@ struct TritonGPUVerifyTensorLayoutInterface
       return true;
     return isa<triton::MakeRangeOp, triton::SplatOp, triton::BroadcastOp,
                triton::LoadOp, triton::StoreOp, triton::JoinOp, triton::SplitOp,
-               triton::gpu::ConvertLayoutOp, triton::gpu::Fp4ToFpOp>(op);
+               triton::gpu::ConvertLayoutOp, triton::gpu::Fp4ToFpOp,
+               triton::gpu::LocalLoadOp, triton::gpu::LocalStoreOp>(op);
   }
 
   LogicalResult verifyTensorLayout(

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -284,11 +284,11 @@ actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
   // `regsPerInst`. In particular, callers do not need to pre-zero those bases
   // for the invariant to hold.
   assert(layout.getNumInDims() != 0);
-  assert(regsPerInst >= 1 && llvm::isPowerOf2_64(regsPerInst) &&
-         "regsPerInst must be a positive power of two");
+  assert(llvm::isPowerOf2_64(regsPerInst) &&
+         "regsPerInst must be a power of two");
   auto kReg = *layout.getInDimNames().begin();
   assert(kReg.str() == "register");
-  const int regBasisPerVec = llvm::Log2_64(regsPerInst);
+  const size_t regBasisPerVec = llvm::Log2_64(regsPerInst);
   uint32_t bits = maskSpanOffsets;
   auto addrNamedBases = addrLayout.flattenOuts().getBases();
   for (auto bases : llvm::make_second_range(addrNamedBases)) {
@@ -298,11 +298,10 @@ actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
   }
   SmallVector<size_t> front, back;
   auto layoutNamedBases = layout.flattenOuts().getBases();
-  assert(static_cast<int>(layoutNamedBases.lookup(kReg).size()) >=
-             regBasisPerVec &&
+  assert(layoutNamedBases.lookup(kReg).size() >= regBasisPerVec &&
          "layout must have at least log2(regsPerInst) register bases");
   for (auto [idx, basis] : llvm::enumerate(layoutNamedBases.lookup(kReg))) {
-    if (static_cast<int>(idx) < regBasisPerVec || (basis[0] & bits) == 0) {
+    if (idx < regBasisPerVec || (basis[0] & bits) == 0) {
       front.push_back(idx);
     } else {
       back.push_back(idx);

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -268,31 +268,41 @@ ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout) {
 }
 std::pair<int64_t, ColumnAction>
 actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
-                      uint64_t maskSpanOffsets) {
+                      uint64_t maskSpanOffsets, int64_t regsPerInst) {
   // General idea:
-  // We wan to swap an xor into an addition when computing the register offsets.
-  // We can do this if the output bits of this register are disjoint from those
-  // from lanes/warps/blocks or any affine offset (i.e., markSpanOffsets).
-
-  // Note this function assumes that if any registers are used in the addrLayout
-  // of the layout (as in ldmatrix/stmatrix) they will be the first non-zero
-  // registers within `layout`
+  // We want to swap an xor into an addition when computing the register
+  // offsets. We can do this if the output bits of this register are disjoint
+  // from those from lanes/warps/blocks or any affine offset (i.e.,
+  // maskSpanOffsets).
+  //
+  // Additionally, the lowering only ever evaluates register offsets at indices
+  // that are multiples of `regsPerInst` (the inner-loop stride, matching one
+  // vectorised instruction). The first `log2(regsPerInst)` register bases are
+  // therefore never selected by any computed index and are trivially additive,
+  // independent of their basis value. We force them into the "additive" group
+  // unconditionally so that the returned `nAdditive` is always at least
+  // `regsPerInst`. In particular, callers do not need to pre-zero those bases
+  // for the invariant to hold.
   assert(layout.getNumInDims() != 0);
+  assert(regsPerInst >= 1 && llvm::isPowerOf2_64(regsPerInst) &&
+         "regsPerInst must be a positive power of two");
   auto kReg = *layout.getInDimNames().begin();
   assert(kReg.str() == "register");
+  const int regBasisPerVec = llvm::Log2_64(regsPerInst);
   uint32_t bits = maskSpanOffsets;
-  llvm::SetVector<uint32_t> tileBases;
   auto addrNamedBases = addrLayout.flattenOuts().getBases();
   for (auto bases : llvm::make_second_range(addrNamedBases)) {
     for (auto basis : bases) {
       bits |= basis[0];
-      tileBases.insert(basis[0]);
     }
   }
   SmallVector<size_t> front, back;
   auto layoutNamedBases = layout.flattenOuts().getBases();
+  assert(static_cast<int>(layoutNamedBases.lookup(kReg).size()) >=
+             regBasisPerVec &&
+         "layout must have at least log2(regsPerInst) register bases");
   for (auto [idx, basis] : llvm::enumerate(layoutNamedBases.lookup(kReg))) {
-    if ((basis[0] & bits) == 0 || tileBases.contains(basis[0])) {
+    if (static_cast<int>(idx) < regBasisPerVec || (basis[0] & bits) == 0) {
       front.push_back(idx);
     } else {
       back.push_back(idx);

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -414,6 +414,56 @@ def test_broadcast_generic_linear(src_layout, device):
     torch.testing.assert_close(z, x[:, None] + y[None, :])
 
 
+@pytest.mark.parametrize("src_layout", _filter_layouts(_swizzled_warp_layouts()))
+def test_local_load_store_generic_linear(src_layout, device):
+    """Round-trip through shared memory using a swizzled/non-injective DistributedLinearLayout.
+
+    Exercises local_store (smem.store) and local_load (smem.load) lowerings for
+    GenericLinearEncoding sources.
+    """
+    shape = src_layout.shape
+    num_warps = 2**len(src_layout.warp_bases)
+
+    if len(shape) == 1:
+        N, = shape
+        shared_layout = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0])
+
+        @gluon.jit
+        def kernel(x_ptr, y_ptr, N: ttgl.constexpr, layout: ttgl.constexpr, shared_layout: ttgl.constexpr):
+            offs = ttgl.arange(0, N, layout=layout)
+            x = ttgl.load(x_ptr + offs)
+            smem = ttgl.allocate_shared_memory(x.dtype, [N], shared_layout)
+            smem.store(x)
+            y = smem.load(layout)
+            ttgl.store(y_ptr + offs, y)
+
+        torch.manual_seed(0)
+        x = torch.randn(N, dtype=torch.float32, device=device)
+        y = torch.empty_like(x)
+        kernel[(1, )](x, y, N, src_layout, shared_layout, num_warps=num_warps)
+    else:
+        M, N = shape
+        shared_layout = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+
+        @gluon.jit
+        def kernel(x_ptr, y_ptr, M: ttgl.constexpr, N: ttgl.constexpr, layout: ttgl.constexpr,
+                   shared_layout: ttgl.constexpr):
+            offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, layout))[:, None]
+            offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, layout))[None, :]
+            x = ttgl.load(x_ptr + offs_m * N + offs_n)
+            smem = ttgl.allocate_shared_memory(x.dtype, [M, N], shared_layout)
+            smem.store(x)
+            y = smem.load(layout)
+            ttgl.store(y_ptr + offs_m * N + offs_n, y)
+
+        torch.manual_seed(0)
+        x = torch.randn((M, N), dtype=torch.float32, device=device)
+        y = torch.empty_like(x)
+        kernel[(1, )](x, y, M, N, src_layout, shared_layout, num_warps=num_warps)
+
+    torch.testing.assert_close(y, x)
+
+
 def _funky_reduce_layouts():
 
     def ilog2(x):

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -414,52 +414,62 @@ def test_broadcast_generic_linear(src_layout, device):
     torch.testing.assert_close(z, x[:, None] + y[None, :])
 
 
+def _shared_layout_kinds():
+    kinds = ["swizzled_trivial", "swizzled", "padded"]
+    if is_hip():
+        kinds += ["partitioned_swizzled", "partitioned_padded"]
+    return kinds
+
+
+def _make_shared_layout(kind, shape):
+    order = list(reversed(range(len(shape))))
+    if kind == "swizzled_trivial":
+        return ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=order)
+    if kind == "swizzled":
+        return ttgl.SwizzledSharedLayout(vec=4, per_phase=2, max_phase=4, order=order)
+    if kind == "padded":
+        return ttgl.PaddedSharedLayout.with_identity_for(interval_padding_pairs=[[16, 4]], shape=list(shape),
+                                                         order=order)
+    if kind == "partitioned_swizzled":
+        inner = ttgl.SwizzledSharedLayout(vec=4, per_phase=2, max_phase=4, order=order)
+        return PartitionedSharedLayout(num_partitions=2, num_groups=1, partition_dim=0, partition_layout=inner)
+    if kind == "partitioned_padded":
+        inner = ttgl.PaddedSharedLayout.with_identity_for(interval_padding_pairs=[[16, 4]], shape=list(shape),
+                                                          order=order)
+        return PartitionedSharedLayout(num_partitions=2, num_groups=1, partition_dim=0, partition_layout=inner)
+    raise ValueError(f"Unknown shared layout kind: {kind}")
+
+
 @pytest.mark.parametrize("src_layout", _filter_layouts(_swizzled_warp_layouts()))
-def test_local_load_store_generic_linear(src_layout, device):
+@pytest.mark.parametrize("shared_kind", _shared_layout_kinds())
+def test_local_load_store_generic_linear(src_layout, shared_kind, device):
     """Round-trip through shared memory using a swizzled/non-injective DistributedLinearLayout.
 
     Exercises local_store (smem.store) and local_load (smem.load) lowerings for
-    GenericLinearEncoding sources.
+    GenericLinearEncoding sources across various shared-memory layouts.
     """
-    shape = src_layout.shape
+    shape = tuple(src_layout.shape)
+    shared_layout = _make_shared_layout(shared_kind, shape)
     num_warps = 2**len(src_layout.warp_bases)
 
-    if len(shape) == 1:
-        N, = shape
-        shared_layout = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0])
+    @gluon.jit
+    def kernel(x_ptr, y_ptr, shape: ttgl.constexpr, layout: ttgl.constexpr, shared_layout: ttgl.constexpr):
+        if len(shape) == 1:
+            offs = ttgl.arange(0, shape[0], layout=layout)
+        else:
+            offs_m = ttgl.arange(0, shape[0], layout=ttgl.SliceLayout(1, layout))[:, None]
+            offs_n = ttgl.arange(0, shape[1], layout=ttgl.SliceLayout(0, layout))[None, :]
+            offs = offs_m * shape[1] + offs_n
+        x = ttgl.load(x_ptr + offs)
+        smem = ttgl.allocate_shared_memory(x.dtype, shape, shared_layout)
+        smem.store(x)
+        y = smem.load(layout)
+        ttgl.store(y_ptr + offs, y)
 
-        @gluon.jit
-        def kernel(x_ptr, y_ptr, N: ttgl.constexpr, layout: ttgl.constexpr, shared_layout: ttgl.constexpr):
-            offs = ttgl.arange(0, N, layout=layout)
-            x = ttgl.load(x_ptr + offs)
-            smem = ttgl.allocate_shared_memory(x.dtype, [N], shared_layout)
-            smem.store(x)
-            y = smem.load(layout)
-            ttgl.store(y_ptr + offs, y)
-
-        torch.manual_seed(0)
-        x = torch.randn(N, dtype=torch.float32, device=device)
-        y = torch.empty_like(x)
-        kernel[(1, )](x, y, N, src_layout, shared_layout, num_warps=num_warps)
-    else:
-        M, N = shape
-        shared_layout = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
-
-        @gluon.jit
-        def kernel(x_ptr, y_ptr, M: ttgl.constexpr, N: ttgl.constexpr, layout: ttgl.constexpr,
-                   shared_layout: ttgl.constexpr):
-            offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, layout))[:, None]
-            offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, layout))[None, :]
-            x = ttgl.load(x_ptr + offs_m * N + offs_n)
-            smem = ttgl.allocate_shared_memory(x.dtype, [M, N], shared_layout)
-            smem.store(x)
-            y = smem.load(layout)
-            ttgl.store(y_ptr + offs_m * N + offs_n, y)
-
-        torch.manual_seed(0)
-        x = torch.randn((M, N), dtype=torch.float32, device=device)
-        y = torch.empty_like(x)
-        kernel[(1, )](x, y, M, N, src_layout, shared_layout, num_warps=num_warps)
+    torch.manual_seed(0)
+    x = torch.randn(shape, dtype=torch.float32, device=device)
+    y = torch.empty_like(x)
+    kernel[(1, )](x, y, shape, src_layout, shared_layout, num_warps=num_warps)
 
     torch.testing.assert_close(y, x)
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -222,8 +222,8 @@ private:
 
     // Compute the bits that are moved by one instruction
     // Compute elements for which we can swap the xor by an add
-    auto [nAdditive, permStrides] =
-        actionAdditiveStrides(reps, addrLayout, maskSpanAffineOffset);
+    auto [nAdditive, permStrides] = actionAdditiveStrides(
+        reps, addrLayout, maskSpanAffineOffset, fullTile.getInDimSize(kReg));
     reps = permStrides.apply(reps);
     if (isPartitioned) {
       partitionLayout = permStrides.apply(partitionLayout);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -360,8 +360,8 @@ LogicalResult lowerLdStMatrix(
                    {{kOffset, reps.getOutDimSize(kOffset)}}, false);
   // Compute the bits that are moved by one instruction
   // Compute elements for which we can swap the xor by an add
-  auto [nAdditive, permStrides] =
-      actionAdditiveStrides(reps, addrLayout, maskSpanAffineOffset);
+  auto [nAdditive, permStrides] = actionAdditiveStrides(
+      reps, addrLayout, maskSpanAffineOffset, fullTileVec.getInDimSize(kReg));
   reps = permStrides.apply(reps);
   if (isStore) {
     vals = permStrides.apply(vals);


### PR DESCRIPTION
Make actionAdditiveStrides responsible for the nAdditive ≥ regsPerInst invariant instead of relying on callers pre-zeroing bases or on tileBases hack.

The fix: add a regsPerInst parameter and force the first log2(regsPerInst) register bases into the additive group unconditionally, since the inner loop only evaluates offsets at register indices that are multiples of regsPerInst, those bases can never contribute to a computed offset and are trivially additive.
The tileBases detour (which covered ldmatrix/stmatrix lowering case) is no longer needed and gets removed. All three callers (generic ld.shared/st.shared, AMD ds_read_tr*, NVIDIA ldmatrix/stmatrix) now pass their instruction's reg-count.

Why it matters: swizzled / non-injective linear layouts exposed the bug where the old implementation would include bases that are not additive. A new gluon test (test_local_load_store_generic_linear) round-trips such layouts through shared memory to test the fix.