### PR TITLE
[codex] Fix ConSan TMA wait visibility tracking

### DIFF
--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1745,6 +1745,10 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
             createBufferDescriptor(fb, mbarOffset, mbarLengthVal);
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, barrierDescriptor);
+        Value barrierCTAMask = createRecipientCTAMask(
+            fb, barrierWriteRecipientsType, barrierRecipientCTAs);
+        Value selectedBarriers =
+            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
         Value effectRecipientCTAsTensor = triton::SplatOp::create(
             fb, barrierWriteRecipientsType, effectRecipientCTAs);
         if (diagonalEffectRecipientCTAs) {
@@ -1774,14 +1778,31 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
         Value updatedBarrierWriteRecipients = arith::OrIOp::create(
             fb, barrierWriteRecipients, effectRecipientCTAsTensor);
         updatedBarrierWriteRecipients = arith::SelectOp::create(
-            fb, barriersEqBar, updatedBarrierWriteRecipients,
+            fb, selectedBarriers, updatedBarrierWriteRecipients,
             barrierWriteRecipients);
         createCTAScopedStoreScratchMemory(
             fb, fb.getLoc(), barrierWriteRecipientsPtr,
             updatedBarrierWriteRecipients, barrierWriteRecipientsType,
             barrierRecipientCTAs);
-        barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {0, 2}, writeTrackingType);
+        Value trackedBarriers = selectedBarriers;
+        if (!diagonalEffectRecipientCTAs) {
+          // The producer barrier can live on a different CTA row than the
+          // buffer it publishes (for example, leader-issued or broadcast
+          // writes). Collapse the barrier row, then re-expand only onto the
+          // buffer rows that the write actually reaches.
+          trackedBarriers = reduce<arith::OrIOp>(fb, trackedBarriers,
+                                                 /*axis=*/0);
+          trackedBarriers =
+              convertAndBroadcast(fb, trackedBarriers, {2},
+                                  writeTrackingType);
+          Value effectCTAMask = createRecipientCTAMask(fb, writeTrackingType,
+                                                       effectRecipientCTAs);
+          trackedBarriers =
+              arith::AndIOp::create(fb, trackedBarriers, effectCTAMask);
+        } else {
+          trackedBarriers = convertAndBroadcast(fb, trackedBarriers, {0, 2},
+                                                writeTrackingType);
+        }
         Value bufferDescriptor =
             createBufferDescriptor(fb, bufOffset, bufLengthVal);
         Value buffersEqBuf =
@@ -1789,7 +1810,7 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
         buffersEqBuf =
             convertAndBroadcast(fb, buffersEqBuf, {0, 1}, writeTrackingType);
         Value trackMask =
-            arith::AndIOp::create(fb, barriersEqBar, buffersEqBuf);
+            arith::AndIOp::create(fb, trackedBarriers, buffersEqBuf);
         Value writeTrackingOne =
             tti::createConstIntTensor(fb, fb.getLoc(), 1, writeTrackingType);
         Value newTracking = arith::SelectOp::create(
@@ -1874,12 +1895,18 @@ void FunctionBuilder::createClearBarrierWriteTrackingCall(
         createCTAScopedStoreScratchMemory(
             fb, fb.getLoc(), barrierWriteRecipientsPtr, updatedRecipients,
             barrierWriteRecipientsType, barrierRecipientCTAs);
-        barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {0, 2}, writeTrackingType);
+        Value trackedBarriers = reduce<arith::OrIOp>(fb, selectedBarrier,
+                                                     /*axis=*/0);
+        trackedBarriers =
+            convertAndBroadcast(fb, trackedBarriers, {2}, writeTrackingType);
+        Value effectCTAMask = createRecipientCTAMask(fb, writeTrackingType,
+                                                     effectRecipientCTAs);
+        trackedBarriers =
+            arith::AndIOp::create(fb, trackedBarriers, effectCTAMask);
         Value zero =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
         Value updated =
-            arith::SelectOp::create(fb, barriersEqBar, zero, writeTracking);
+            arith::SelectOp::create(fb, trackedBarriers, zero, writeTracking);
         createCTAScopedStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
                                           updated, writeTrackingType,
                                           recipientCTAs);
@@ -2030,12 +2057,18 @@ void FunctionBuilder::createTransferVisibleWritesCall(
             fb, arith::ConstantIntOp::create(fb, 1, 32), ctaId);
         Value recipientCTAs =
             arith::OrIOp::create(fb, currentCTA, trackedRecipientCTAs);
-        barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {0, 2}, writeTrackingType);
+        Value trackedBarriers = reduce<arith::OrIOp>(fb, selectedBarrier,
+                                                     /*axis=*/0);
+        trackedBarriers =
+            convertAndBroadcast(fb, trackedBarriers, {2}, writeTrackingType);
+        Value effectCTAMask = createRecipientCTAMask(
+            fb, writeTrackingType, recipientCTAs);
+        trackedBarriers =
+            arith::AndIOp::create(fb, trackedBarriers, effectCTAMask);
         Value zeroTracking =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
         Value trackingBuffers = arith::SelectOp::create(
-            fb, barriersEqBar, writeTracking, zeroTracking);
+            fb, trackedBarriers, writeTracking, zeroTracking);
         trackingBuffers = reduceLastDim<arith::OrIOp>(fb, trackingBuffers);
         trackingBuffers = createConvertLayout(
             fb, trackingBuffers, writeVisibilityType.getEncoding());

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1793,8 +1793,7 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
           trackedBarriers = reduce<arith::OrIOp>(fb, trackedBarriers,
                                                  /*axis=*/0);
           trackedBarriers =
-              convertAndBroadcast(fb, trackedBarriers, {2},
-                                  writeTrackingType);
+              convertAndBroadcast(fb, trackedBarriers, {2}, writeTrackingType);
           Value effectCTAMask = createRecipientCTAMask(fb, writeTrackingType,
                                                        effectRecipientCTAs);
           trackedBarriers =
@@ -1899,8 +1898,8 @@ void FunctionBuilder::createClearBarrierWriteTrackingCall(
                                                      /*axis=*/0);
         trackedBarriers =
             convertAndBroadcast(fb, trackedBarriers, {2}, writeTrackingType);
-        Value effectCTAMask = createRecipientCTAMask(fb, writeTrackingType,
-                                                     effectRecipientCTAs);
+        Value effectCTAMask =
+            createRecipientCTAMask(fb, writeTrackingType, effectRecipientCTAs);
         trackedBarriers =
             arith::AndIOp::create(fb, trackedBarriers, effectCTAMask);
         Value zero =
@@ -2061,8 +2060,8 @@ void FunctionBuilder::createTransferVisibleWritesCall(
                                                      /*axis=*/0);
         trackedBarriers =
             convertAndBroadcast(fb, trackedBarriers, {2}, writeTrackingType);
-        Value effectCTAMask = createRecipientCTAMask(
-            fb, writeTrackingType, recipientCTAs);
+        Value effectCTAMask =
+            createRecipientCTAMask(fb, writeTrackingType, recipientCTAs);
         trackedBarriers =
             arith::AndIOp::create(fb, trackedBarriers, effectCTAMask);
         Value zeroTracking =

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -200,7 +200,8 @@ Value getMulticastRecipientCTAs(ImplicitLocOpBuilder &b, Value alloc) {
 
 Value getTMAEffectRecipientCTAs(ImplicitLocOpBuilder &b,
                                 ttng::TMALoadLikeOpInterface tmaLoad) {
-  if (!tmaLoad.getMulticast() && !ttng::getModuleTwoCTAs(tmaLoad.getOperation()))
+  if (!tmaLoad.getMulticast() &&
+      !ttng::getModuleTwoCTAs(tmaLoad.getOperation()))
     return currentCTAMask(b);
   uint16_t broadcastMask = getBlockBroadcastMask(tmaLoad.getResult());
   if (ttng::getModuleTwoCTAs(tmaLoad.getOperation())) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -198,6 +198,24 @@ Value getMulticastRecipientCTAs(ImplicitLocOpBuilder &b, Value alloc) {
   return createCTABitset(b, encoding.pattern, encoding.fixedBits);
 }
 
+Value getTMAEffectRecipientCTAs(ImplicitLocOpBuilder &b,
+                                ttng::TMALoadLikeOpInterface tmaLoad) {
+  if (!tmaLoad.getMulticast() && !ttng::getModuleTwoCTAs(tmaLoad.getOperation()))
+    return currentCTAMask(b);
+  uint16_t broadcastMask = getBlockBroadcastMask(tmaLoad.getResult());
+  if (ttng::getModuleTwoCTAs(tmaLoad.getOperation())) {
+    // In 2CTA mode, a TMA load always lowers to cta_group::2 and materializes
+    // data for both CTAs in the pair, even when the destination alloc itself
+    // has no block-broadcast bits.
+    broadcastMask |= 0x1;
+  }
+  if (!broadcastMask)
+    return currentCTAMask(b);
+  int numCTAs = ttg::lookupNumCTAs(b);
+  auto encoding = ttng::getTMAMulticastMaskEncoding(numCTAs, broadcastMask);
+  return createCTABitset(b, encoding.pattern, encoding.fixedBits);
+}
+
 Value getLeaderCTA(ImplicitLocOpBuilder &b, Value barrier) {
   uint16_t broadcastMask = getBlockBroadcastMask(barrier);
   if (!broadcastMask)
@@ -266,9 +284,7 @@ Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op);
 
 Value getMemEffectRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
   if (auto tmaLoad = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
-    if (tmaLoad.getMulticast())
-      return getMulticastRecipientCTAs(b, tmaLoad.getResult());
-    return currentCTAMask(b);
+    return getTMAEffectRecipientCTAs(b, tmaLoad);
   }
   if (isa<ttng::CLCTryCancelOp>(op))
     return allCTAsMask(b);

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -831,6 +831,61 @@ def test_tcgen5_copy(FAILURE, MEM_ACCESS_KIND, device, run_wrapper, monkeypatch,
     kernel[(1, )](input, output, FAILURE=FAILURE, MEM_ACCESS_KIND=MEM_ACCESS_KIND, num_warps=4, num_ctas=num_ctas)
 
 
+def run_tcgen5_copy_tma_scale_wait_visibility(device, num_ctas):
+    os.environ["TRITON_INSTRUMENTATION_MODE"] = "consan"
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+    knobs.refresh_knobs()
+    import importlib.util
+    import pathlib
+
+    module_path = pathlib.Path(__file__).resolve().parents[2] / "examples" / "gluon" / "04-2cta-block-scale-matmul.py"
+    spec = importlib.util.spec_from_file_location("two_cta_block_scale_matmul", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    block_m = 256 if num_ctas > 1 else 128
+    block_n = 256
+    epilogue_block_n = 64 if num_ctas > 1 else 256
+    num_buffers = 5 if num_ctas > 1 else 3
+    m = n = 256
+    k = 128
+    torch.manual_seed(0)
+    a, a_scale, a_ref = module.random_quantized_tensor(m, k, "mxfp8")
+    b, b_scale, b_ref = module.random_quantized_tensor(n, k, "mxfp8")
+    a_scale = module.swizzle_scales_packed_block(a_scale)
+    b_scale = module.swizzle_scales_packed_block(b_scale)
+    out = module.mma_scaled_warp_specialized(
+        a,
+        b,
+        a_scale,
+        b_scale,
+        32,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        EPILOGUE_BLOCK_N=epilogue_block_n,
+        num_buffers=num_buffers,
+        num_ctas=num_ctas,
+    )
+    ref = a_ref @ b_ref.T
+    torch.testing.assert_close(ref, out.to(torch.float32), atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
+def test_tcgen5_copy_tma_scale_wait_visibility(device, run_wrapper):
+    if run_wrapper:
+        result = run_in_process(run_tcgen5_copy_tma_scale_wait_visibility, (device, 1))
+        assert result.exc is None
+        assert result.driver_stderr_output == ""
+
+        result = run_in_process(run_tcgen5_copy_tma_scale_wait_visibility, (device, 2))
+        assert result.exc is None
+        assert result.driver_stderr_output == ""
+        return
+
+    run_tcgen5_copy_tma_scale_wait_visibility(device, 1)
+    run_tcgen5_copy_tma_scale_wait_visibility(device, 2)
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] != 9, reason="Requires hopper")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_warpgroup_mma(FAILURE, device, run_wrapper, monkeypatch, num_ctas):


### PR DESCRIPTION
Note from the human: I didn't actually check if this fix is valid

## Summary

- fix ConSan recipient modeling for TMA EffectWrites in the 2CTA path
- keep barrier/write-tracking publication scoped to the actual recipient CTA rows so broader multicta tests do not regress
- add a focused regression for the scale-TMA -> wait -> tcgen05_copy visibility path

## Why

The original MoE repro was a ConSan false positive in a 2CTA TMA/barrier/tcgen05_copy sequence. The first fix addressed the missing 2CTA recipient modeling, but broader ConSan coverage showed that publication was then too broad for other multicta layouts. This change fixes both sides of that model.

## Impact

This removes the false positive on the MoE repro while keeping the broader ConSan suite green.

## Validation

- pytest -s --tb=short python/test/gluon/test_consan.py
- pytest -s --tb=short python/test/unit/language/test_warp_specialization.py -k consan
- pytest -s --tb=short python/test/gluon/test_consan.py::test_multibuffered_loop[4ctas-False]
- pytest -s --tb=short python/test/gluon/test_consan.py::test_tcgen5_copy_tma_scale_wait_visibility
- TRITON_INSTRUMENTATION_MODE=consan CUDA_LAUNCH_BLOCKING=1 pytest -s --tb=short python/examples/gluon/05-moe-bmm1-fused-gather.py::test_op[512-c0]
