### PR TITLE
[TRITONGPU] Add k_chunks_hint attr to tune RS-WGMMA K-split count

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -643,6 +643,9 @@ def TT_DotOp : TT_Op<"dot", [Pure,
         bf16x6: implement the 6xBF16 trick. For more info see the pass in F32DotTC.cpp
         ieee: don't use TC, implement dot in software.
         If the GPU does not have Tensor cores or the inputs are not f32, this flag is ignored.
+        $kChunksHint carries a user hint for the Hopper RS-WGMMA K-split pass; it
+        is consumed when lowering to `ttng.warp_group_dot` and is a no-op on other
+        paths (0 = compiler default, 1 = disabled, >=2 = explicit power of two).
     }];
 
     let arguments = (
@@ -651,7 +654,8 @@ def TT_DotOp : TT_Op<"dot", [Pure,
       TT_FpIntTensor:$b,
       TT_FpIntTensor:$c,
       DefaultValuedAttr<TT_InputPrecisionAttr, "::mlir::triton::InputPrecision::IEEE">:$inputPrecision,
-      DefaultValuedAttr<I32Attr, "0">:$maxNumImpreciseAcc
+      DefaultValuedAttr<I32Attr, "0">:$maxNumImpreciseAcc,
+      DefaultValuedAttr<I32Attr, "0">:$kChunksHint
     );
 
     let results = (outs TT_FpIntTensor:$d);

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -207,7 +207,9 @@ def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [
   let summary = "warp group dot";
 
   let description = [{
-    $d = matrix_multiply($a, $b) + $c. For docs on InputPrecisionAttr, see TT_DotOp
+    $d = matrix_multiply($a, $b) + $c. For docs on InputPrecisionAttr, see TT_DotOp.
+    $kChunksHint tunes the number of K-axis chunks the RS-WGMMA pipeline splits
+    this op into (0 = compiler default, 1 = disabled, >=2 = explicit power of two).
   }];
 
   let arguments = (ins
@@ -217,7 +219,8 @@ def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [
     Optional<I1>:$useC,
     DefaultValuedAttr<TT_InputPrecisionAttr, "::mlir::triton::InputPrecision::IEEE">:$inputPrecision,
     DefaultValuedAttr<I32Attr, "0">:$maxNumImpreciseAcc,
-    DefaultValuedAttr<BoolAttr, "false">:$isAsync
+    DefaultValuedAttr<BoolAttr, "false">:$isAsync,
+    DefaultValuedAttr<I32Attr, "0">:$kChunksHint
   );
 
   let results = (outs TT_FpIntTensor:$d);

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -261,7 +261,8 @@ struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
 
     addNamedAttrs(rewriter.replaceOpWithNewOp<triton::DotOp>(
                       op, retType, a, b, c, adaptor.getInputPrecision(),
-                      adaptor.getMaxNumImpreciseAcc()),
+                      adaptor.getMaxNumImpreciseAcc(),
+                      adaptor.getKChunksHint()),
                   adaptor.getAttributes());
     return success();
   }

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -172,7 +172,9 @@ public:
                                                   rewriter.getF32FloatAttr(0)));
     rewriter.replaceOpWithNewOp<DotOp>(op, expandLhsOp.getSrc(),
                                        expandRhsOp.getSrc(), newAcc,
-                                       InputPrecision::IEEE, 0);
+                                       InputPrecision::IEEE,
+                                       /*maxNumImpreciseAcc=*/0,
+                                       /*kChunksHint=*/0);
     return success();
   }
 };

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -437,8 +437,9 @@ public:
 
       newDot = triton::nvidia_gpu::WarpGroupDotOp::create(
           rewriter, dotOp.getLoc(), mmaResult.newRetType, a, b,
-          mmaResult.newAcc, nullptr, dotOp.getInputPrecision(),
-          dotOp.getMaxNumImpreciseAcc(), false);
+          mmaResult.newAcc, /*useC=*/nullptr, dotOp.getInputPrecision(),
+          dotOp.getMaxNumImpreciseAcc(), /*isAsync=*/false,
+          dotOp.getKChunksHint());
     } else {
       int minBitwidth =
           std::min(computeOrigBitWidth(a), computeOrigBitWidth(b));
@@ -446,9 +447,10 @@ public:
                                   rewriter);
       b = convertDotOperandForMMA(b, 1, minBitwidth, mmaResult.newRetType,
                                   rewriter);
-      newDot = DotOp::create(rewriter, dotOp.getLoc(), mmaResult.newRetType, a,
-                             b, mmaResult.newAcc, dotOp.getInputPrecision(),
-                             dotOp.getMaxNumImpreciseAcc());
+      newDot =
+          DotOp::create(rewriter, dotOp.getLoc(), mmaResult.newRetType, a, b,
+                        mmaResult.newAcc, dotOp.getInputPrecision(),
+                        dotOp.getMaxNumImpreciseAcc(), dotOp.getKChunksHint());
     }
 
     rewriter.replaceOpWithNewOp<ConvertLayoutOp>(dotOp, dotOp.getType(),

--- a/lib/Dialect/TritonGPU/Transforms/F32DotTC.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/F32DotTC.cpp
@@ -47,9 +47,9 @@ Value zeroLike(Value c, PatternRewriter &rewriter) {
 
 Value dot(Value lhs, Value rhs, Value acc, PatternRewriter &rewriter,
           InputPrecision precision = InputPrecision::IEEE,
-          uint32_t maxNumImpreciseAcc = 0) {
+          uint32_t maxNumImpreciseAcc = 0, uint32_t kChunksHint = 0) {
   return DotOp::create(rewriter, lhs.getLoc(), lhs, rhs, acc, precision,
-                       maxNumImpreciseAcc);
+                       maxNumImpreciseAcc, kChunksHint);
 };
 
 Value replaceNansWithZeros(Value value, PatternRewriter &rewriter) {
@@ -178,9 +178,9 @@ public:
     auto zero = zeroLike(dotOp.getC(), rewriter);
 
     auto dot1 = dot(aSmall, bBig, zero, rewriter, InputPrecision::TF32,
-                    dotOp.getMaxNumImpreciseAcc());
+                    dotOp.getMaxNumImpreciseAcc(), dotOp.getKChunksHint());
     auto dot2 = dot(aBig, bSmall, dot1, rewriter, InputPrecision::TF32,
-                    dotOp.getMaxNumImpreciseAcc());
+                    dotOp.getMaxNumImpreciseAcc(), dotOp.getKChunksHint());
 
     // If lhs is 1.0, we will have lhs_high = 1.0 and lhs_low = 0.0.
     // If rhs is +infinity, we will have:
@@ -190,8 +190,9 @@ public:
     // we must override any accumulated result if the last partial product is
     // non-finite.
     auto dot2withZeroedNans = replaceNansWithZeros(dot2, rewriter);
-    auto dot3 = dot(aBig, bBig, dot2withZeroedNans, rewriter,
-                    InputPrecision::TF32, dotOp.getMaxNumImpreciseAcc());
+    auto dot3 =
+        dot(aBig, bBig, dot2withZeroedNans, rewriter, InputPrecision::TF32,
+            dotOp.getMaxNumImpreciseAcc(), dotOp.getKChunksHint());
 
     auto sum = add(dot3, dotOp.getC());
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -308,15 +308,12 @@ SmallVector<Value> splitRhs(OpBuilder &builder,
 }
 
 std::vector<ttng::WarpGroupDotOp> splitRSDot(ttng::WarpGroupDotOp dotOp) {
-  // Splits wgmma(tensor, shmem, acc) into
-  //   wgmma(tensor[:, :K//2], shmem[:K//2, :], acc)
-  //   wgmma(tensor[:, K//2:], shmem[K//2:, :], acc)
-  // which allows for in-register pipelining of the wgmmas.
-  //
-  // Theoretically, it may be beneficial to split even further which allows more
-  // fine-grained overlapping of the wgmma ops but empirically 2 splits gave the
-  // best performance. In future this may be something we want to allow the user
-  // to tune.
+  // Splits wgmma(tensor, shmem, acc) into numSplits chained sub-dots along K,
+  // which allows for in-register pipelining of the wgmmas. The default is 2.
+  // The count is read from the op's `kChunksHint` attr: 0 means "use default",
+  // 1 disables the split, >=2 is an explicit power-of-two chunk count. The op
+  // verifier enforces power-of-two and fit against K/instrK, so we only gate
+  // on the runtime-skip cases here.
   if (!isa<RankedTensorType>(dotOp.getA().getType())) {
     return {dotOp};
   }
@@ -326,14 +323,14 @@ std::vector<ttng::WarpGroupDotOp> splitRSDot(ttng::WarpGroupDotOp dotOp) {
   auto origK = a.getType().getShape().back();
   auto instrK = cast<ttg::NvidiaMmaEncodingAttr>(dotOp.getType().getEncoding())
                     .getInstrShape()[2];
-  // Nothing to split
-  if (origK <= instrK) {
+
+  int32_t userChunks = dotOp.getKChunksHint();
+  if (userChunks == 1 || origK <= instrK) {
     return {dotOp};
   }
-  constexpr int numSplits = 2;
+  size_t numSplits = userChunks != 0 ? userChunks : 2;
   uint32_t newK = origK / numSplits;
 
-  assert(origK % newK == 0 && "origK must be divisible by newK");
   auto builder = OpBuilder(dotOp);
   auto loc = dotOp.getLoc();
   auto lhss = splitLhs(builder, a, newK);
@@ -345,7 +342,7 @@ std::vector<ttng::WarpGroupDotOp> splitRSDot(ttng::WarpGroupDotOp dotOp) {
   Value C = dotOp.getC();
   uint32_t numImpreciseAccLeft = dotOp.getMaxNumImpreciseAcc();
   std::vector<ttng::WarpGroupDotOp> dots;
-  for (int i = 0; i < numSplits; i++) {
+  for (size_t i = 0; i < numSplits; i++) {
     //  2**30 is to prevent the subtile from adding
     // extra imprecise accumulator, See WGMMA.cpp
     auto take = std::min(numImpreciseAccLeft, newK);

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -120,6 +120,24 @@ LogicalResult WarpGroupDotOp::verify() {
     }
   }
 
+  int32_t chunks = getKChunksHint();
+  if (chunks != 0) {
+    if (chunks < 1 || !llvm::isPowerOf2_64(chunks))
+      return emitOpError("kChunksHint must be 0 or a positive power of two, "
+                         "got ")
+             << chunks;
+    // The split only runs on RS dots (tensor-typed LHS). For SS dots the knob
+    // is a no-op; still require the value to be well-formed above, but skip
+    // the K/instrK divisibility check which only makes sense for RS.
+    if (auto aTensorTy = dyn_cast<RankedTensorType>(getA().getType())) {
+      int64_t origK = aTensorTy.getShape().back();
+      int64_t instrK = nvmmaEnc.getInstrShape()[2];
+      if (origK > instrK && (int64_t)chunks * instrK > origK)
+        return emitOpError("kChunksHint=")
+               << chunks << " exceeds K/instrK=" << (origK / instrK);
+    }
+  }
+
   return success();
 }
 

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1679,9 +1679,9 @@ void init_triton_ir(py::module &&m) {
       .def("create_dot",
            [](TritonOpBuilder &self, mlir::Value &a, mlir::Value &b,
               mlir::Value &c, InputPrecision inputPrecision,
-              int maxNumImpreciseAcc) -> mlir::Value {
+              int maxNumImpreciseAcc, int kChunksHint) -> mlir::Value {
              return self.create<DotOp>(c.getType(), a, b, c, inputPrecision,
-                                       maxNumImpreciseAcc);
+                                       maxNumImpreciseAcc, kChunksHint);
            })
       .def("create_dot_scaled",
            [](TritonOpBuilder &self, mlir::Value &lhs,

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -564,6 +564,28 @@ def test_dot_scaled_shape_verification(fresh_triton_cache):
     assert str(e.value.__cause__) == "Operands must have the same scale factor; (lhs: 16 vs rhs: 32)"
 
 
+@pytest.mark.parametrize("k_chunks_hint", [0, 3, True])
+def test_err_dot_invalid_k_chunks_hint(k_chunks_hint):
+
+    @triton.jit
+    def simple_dot(a_base, b_base, out, K_CHUNKS_HINT: tl.constexpr):
+        SIZE: tl.constexpr = 64
+        a_ptr = a_base + tl.arange(0, SIZE)[:, None] * SIZE + tl.arange(0, SIZE)[None, :]
+        b_ptr = b_base + tl.arange(0, SIZE)[:, None] * SIZE + tl.arange(0, SIZE)[None, :]
+        a = tl.load(a_ptr)
+        b = tl.load(b_ptr)
+        c = tl.dot(a, b, k_chunks_hint=K_CHUNKS_HINT)
+        out_ptr = out + tl.arange(0, SIZE)[:, None] * SIZE + tl.arange(0, SIZE)[None, :]
+        tl.store(out_ptr, c)
+
+    with pytest.raises(CompilationError, match="k_chunks_hint must be None or a positive power of two"):
+        triton.compile(
+            triton.compiler.ASTSource(
+                fn=simple_dot,
+                signature={"a_base": "*fp16", "b_base": "*fp16", "out": "*fp32", "K_CHUNKS_HINT":
+                           "constexpr"}, constexprs={"K_CHUNKS_HINT": k_chunks_hint}))
+
+
 def test_err_nested_function_def():
 
     @triton.jit

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -76,6 +76,27 @@ def test_compile_only_dot() -> None:
     assert k.asm["cubin"] != b""
 
 
+def test_compile_only_dot_k_chunks_hint() -> None:
+
+    @triton.jit
+    def simple_dot(a_base, b_base, out, K_CHUNKS_HINT: tl.constexpr):
+        SIZE: tl.constexpr = 64
+        a_ptr = a_base + tl.arange(0, SIZE)[:, None] * SIZE + tl.arange(0, SIZE)[None, :]
+        b_ptr = b_base + tl.arange(0, SIZE)[:, None] * SIZE + tl.arange(0, SIZE)[None, :]
+        a = tl.load(a_ptr)
+        b = tl.load(b_ptr)
+        c = tl.dot(a, b, k_chunks_hint=K_CHUNKS_HINT)
+        out_ptr = out + tl.arange(0, SIZE)[:, None] * SIZE + tl.arange(0, SIZE)[None, :]
+        tl.store(out_ptr, c)
+
+    k = triton.compile(
+        triton.compiler.ASTSource(
+            fn=simple_dot,
+            signature={"a_base": "*fp16", "b_base": "*fp16", "out": "*fp32", "K_CHUNKS_HINT":
+                       "constexpr"}, constexprs={"K_CHUNKS_HINT": 4}), target=GPUTarget("cuda", 90, 32))
+    assert "kChunksHint = 4 : i32" in k.asm["ttir"]
+
+
 def test_compile_only_k_loop() -> None:
 
     @triton.jit

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2273,8 +2273,8 @@ def cast(input, dtype: dtype, fp_downcast_rounding: Optional[str] = None, bitcas
 
 
 @builtin
-def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_imprecise_acc=None, out_dtype=float32,
-        _semantic=None):
+def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_imprecise_acc=None, k_chunks_hint=None,
+        out_dtype=float32, _semantic=None):
     """
     Returns the matrix product of two blocks.
 
@@ -2301,6 +2301,11 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
     :param allow_tf32: *Deprecated.* If true, input_precision is set to "tf32".
       Only one of :code:`input_precision` and :code:`allow_tf32` can be
       specified (i.e. at least one must be :code:`None`).
+    :param k_chunks_hint: Optional positive power of two that sets the number
+      of K-axis chunks used when splitting eligible register-shared WGMMA ops
+      for this dot on Hopper. :code:`1` disables chunking; :code:`None` (the
+      default) leaves the compiler default (currently :code:`2`) in place. This
+      knob has no effect on dots that do not reach the RS WGMMA split path.
     """
     assert input_precision is None or allow_tf32 is None, "Only one of input_precision and allow_tf32 can be specified"
     if input_precision is None:
@@ -2311,6 +2316,7 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
     input_precision = _unwrap_if_constexpr(input_precision)
     out_dtype = _unwrap_if_constexpr(out_dtype)
     max_num_imprecise_acc = _unwrap_if_constexpr(max_num_imprecise_acc)
+    k_chunks_hint = _unwrap_if_constexpr(k_chunks_hint)
     acc = _unwrap_if_constexpr(acc)
 
     # check shapes make sense:
@@ -2335,7 +2341,7 @@ def dot(input, other, acc=None, input_precision=None, allow_tf32=None, max_num_i
         if acc is not None:
             acc = _semantic.reshape(acc, [batch_size] + c_shape[-2:], can_reorder=False)
 
-    res = _semantic.dot(input, other, acc, input_precision, max_num_imprecise_acc, out_dtype)
+    res = _semantic.dot(input, other, acc, input_precision, max_num_imprecise_acc, out_dtype, k_chunks_hint)
 
     if rank >= 4:
         res = _semantic.reshape(res, c_shape, can_reorder=False)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1414,7 +1414,7 @@ class TritonSemantic(Generic[TensorTy]):
         return getattr(ir.INPUT_PRECISION, input_precision)
 
     def dot(self, lhs: TensorTy, rhs: TensorTy, acc: TensorTy, input_precision: Optional[str],
-            max_num_imprecise_acc: int, out_dtype: tl.dtype) -> TensorTy:
+            max_num_imprecise_acc: int, out_dtype: tl.dtype, k_chunks_hint: Optional[int] = None) -> TensorTy:
         assert lhs.type.is_block() and rhs.type.is_block()
 
         if lhs.dtype.is_fp8() and rhs.dtype.is_fp8():
@@ -1503,8 +1503,16 @@ class TritonSemantic(Generic[TensorTy]):
             if lhs.dtype.is_fp8() and rhs.dtype.is_fp8() and max_num_imprecise_acc > K:
                 raise ValueError(f"max_num_imprecise_acc ({max_num_imprecise_acc}) must be <= K ({K})")
 
+        if k_chunks_hint is None:
+            k_chunks_hint = 0
+        else:
+            if not isinstance(k_chunks_hint, int) or isinstance(
+                    k_chunks_hint, bool) or k_chunks_hint < 1 or (k_chunks_hint & (k_chunks_hint - 1)) != 0:
+                raise ValueError(f"k_chunks_hint must be None or a positive power of two, got {k_chunks_hint!r}")
+
         return self.tensor(
-            self.builder.create_dot(lhs.handle, rhs.handle, acc_handle, input_precision, max_num_imprecise_acc), ret_ty)
+            self.builder.create_dot(lhs.handle, rhs.handle, acc_handle, input_precision, max_num_imprecise_acc,
+                                    k_chunks_hint), ret_ty)
 
     def _str_to_fp_type(self, float_format: str):
         ty_enum = getattr(ir.ScaleDotElemTypeTY, float_format.upper(), None)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -602,7 +602,7 @@ class InterpreterBuilder:
     def create_trans(self, arg, perm):
         return TensorHandle(np.transpose(arg.data, perm), arg.dtype.scalar)
 
-    def create_dot(self, a, b, d, input_precision, max_num_imprecise_acc):
+    def create_dot(self, a, b, d, input_precision, max_num_imprecise_acc, k_chunks_hint=0):
         a_data = a.data
         b_data = b.data
         if (a.dtype.primitive_bitwidth == 8 and a.dtype.is_floating()) or \

--- a/test/TritonGPU/wgmma-k-chunks.mlir
+++ b/test/TritonGPU/wgmma-k-chunks.mlir
@@ -1,0 +1,51 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-pipeline -canonicalize | FileCheck %s
+
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 64, 16]}>
+#dot = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @rs_wgmma_k_chunks_4
+  tt.func public @rs_wgmma_k_chunks_4(%a: tensor<128x64xf16, #dot>, %b: !ttg.memdesc<64x64xf16, #shared, #smem>, %ub: i32) -> tensor<128x64xf32, #mma> {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %acc = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #mma>
+    %0 = scf.for %i = %c0 to %ub step %c1 iter_args(%acc_iter = %acc) -> (tensor<128x64xf32, #mma>)  : i32 {
+      // CHECK: tt.reshape
+      // CHECK: = ttng.warp_group_dot %{{.*}} : tensor<128x16xf16
+      // CHECK: = ttng.warp_group_dot %{{.*}} : tensor<128x16xf16
+      // CHECK: = ttng.warp_group_dot %{{.*}} : tensor<128x16xf16
+      // CHECK: = ttng.warp_group_dot %{{.*}} : tensor<128x16xf16
+      // CHECK-NOT: = ttng.warp_group_dot %
+      // CHECK: scf.yield
+      %dot_result = ttng.warp_group_dot %a, %b, %acc_iter {kChunksHint = 4 : i32} : tensor<128x64xf16, #dot> * !ttg.memdesc<64x64xf16, #shared, #smem> -> tensor<128x64xf32, #mma>
+      scf.yield %dot_result : tensor<128x64xf32, #mma>
+    }
+    tt.return %0 : tensor<128x64xf32, #mma>
+  }
+}
+
+// -----
+
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 64, 16]}>
+#dot = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @rs_wgmma_k_chunks_1
+  tt.func public @rs_wgmma_k_chunks_1(%a: tensor<128x64xf16, #dot>, %b: !ttg.memdesc<64x64xf16, #shared, #smem>, %ub: i32) -> tensor<128x64xf32, #mma> {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %acc = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #mma>
+    %0 = scf.for %i = %c0 to %ub step %c1 iter_args(%acc_iter = %acc) -> (tensor<128x64xf32, #mma>)  : i32 {
+      // CHECK: scf.for
+      // CHECK-NOT: tt.reshape
+      // CHECK: = ttng.warp_group_dot %{{.*}}kChunksHint = 1 : i32{{.*}} : tensor<128x64xf16
+      // CHECK-NOT: = ttng.warp_group_dot %
+      // CHECK: scf.yield
+      %dot_result = ttng.warp_group_dot %a, %b, %acc_iter {kChunksHint = 1 : i32} : tensor<128x64xf16, #dot> * !ttg.memdesc<64x64xf16, #shared, #smem> -> tensor<128x64xf32, #mma>
+      scf.yield %dot_result : tensor<128x64xf32, #mma>
+    }
+    tt.return %0 : tensor<128x64xf32, #mma>
+  }
+}

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -116,6 +116,32 @@ tt.func @wgmma(%a: tensor<128x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kW
 
 // -----
 
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 32]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+tt.func @wgmma_k_chunks_not_power_of_two(%a: tensor<128x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>, %b: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, %c: tensor<128x128xf16, #mma>) {
+  // expected-error @below {{kChunksHint must be 0 or a positive power of two, got 3}}
+  %0 = ttng.warp_group_dot %a, %b, %c {kChunksHint = 3 : i32} : tensor<128x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory> -> tensor<128x128xf16, #mma>
+  tt.return
+}
+}
+
+// -----
+
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 32]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
+
+module attributes {"ttg.num-warps" = 4 : i32} {
+tt.func @wgmma_k_chunks_too_large(%a: tensor<128x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>, %b: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory>, %c: tensor<128x128xf16, #mma>) {
+  // expected-error @below {{kChunksHint=8 exceeds K/instrK=4}}
+  %0 = ttng.warp_group_dot %a, %b, %c {kChunksHint = 8 : i32} : tensor<128x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory> -> tensor<128x128xf16, #mma>
+  tt.return
+}
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -759,7 +759,8 @@ public:
                                mfmaInstr->bElementType);
       newDot = tt::DotOp::create(rewriter, dotOp.getLoc(), newAcc.getType(), a,
                                  b, newAcc, dotOp.getInputPrecision(),
-                                 dotOp.getMaxNumImpreciseAcc());
+                                 dotOp.getMaxNumImpreciseAcc(),
+                                 dotOp.getKChunksHint());
     }
 
     Value dotOutput =
@@ -1517,7 +1518,8 @@ public:
                                          operandTypes[1]);
     auto newDot = tt::DotOp::create(
         rewriter, dotOp.getLoc(), newRetType, castedA, castedB, newAcc,
-        dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc());
+        dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc(),
+        dotOp.getKChunksHint());
 
     Value dotOutput = convertAndCastTensor(rewriter, newDot, oldRetEncoding,
                                            oldRetType.getElementType());
@@ -1630,9 +1632,10 @@ public:
     if (dotTypes.a.isF16() && dotTypes.b.isF16() && dotTypes.c.isF16() &&
         dotTypes.d.isF16() && k % 2 == 0) {
       auto newC = castToElTy(rewriter, dotOp.getC(), f32_ty);
-      auto newDot = DotOp::create(
-          rewriter, dotOp.getLoc(), newC.getType(), dotOp.getA(), dotOp.getB(),
-          newC, dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc());
+      auto newDot =
+          DotOp::create(rewriter, dotOp.getLoc(), newC.getType(), dotOp.getA(),
+                        dotOp.getB(), newC, dotOp.getInputPrecision(),
+                        dotOp.getMaxNumImpreciseAcc(), dotOp.getKChunksHint());
       auto newD = castToElTy(rewriter, newDot.getResult(), f16_ty);
       rewriter.replaceOp(dotOp, newD);
       return success();
@@ -1672,9 +1675,10 @@ public:
     auto newB = castToElTy(rewriter, dotOp.getB(), commonTy);
     auto newC = castToElTy(rewriter, dotOp.getC(), commonTy);
 
-    auto newDot = DotOp::create(rewriter, dotOp.getLoc(), newC.getType(), newA,
-                                newB, newC, dotOp.getInputPrecision(),
-                                dotOp.getMaxNumImpreciseAcc());
+    auto newDot =
+        DotOp::create(rewriter, dotOp.getLoc(), newC.getType(), newA, newB,
+                      newC, dotOp.getInputPrecision(),
+                      dotOp.getMaxNumImpreciseAcc(), dotOp.getKChunksHint());
     auto newD = castToElTy(rewriter, newDot.getResult(), dotTypes.d);
 
     rewriter.replaceOp(dotOp, newD);


### PR DESCRIPTION
Hello! We noticed a regression in an internal workload which bisected back to 432880797af65f49c5d22d7fe416955d6d839e9b.

https://github.com/triton-lang/triton/blob/432880797af65f49c5d22d7fe416955d6d839e9b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp#L314-L317

Upon further testing we found the heuristic introduced in Triton 3.7 can degrade performance v.s. 3.6 for kernels around the register limit, pushing them into spilling.

By allowing the user to opt-in to tuning `k_chunks_hint` and choosing the 3.6-like setting (`k_chunks_hint = 1`), we see a ~1.8x speedup in the engineered microbenchmark below.

We have confirmed on other adversarial microbenchmarks that 1-5% wins are possible across a range of `k_chunks_hint` settings, to ensure it should be a dial and not a binary setting between the old and new behaviour.

This change has a significant blast radius and is a special case for rs-wgmma so feedback is especially welcome on this draft implementation! We figured since `max_num_imprecise_acc` is a Hopper-only special case that it wouldn't be unreasonable to consider including another dial in `tl.dot()` args if the performance improvement was meaningful.

We felt that there could be a follow up PR to improve how these optional hint attrs (`max_num_imprecise_acc`/`k_chunks_hint`) are handled (to minimise the number of lines + files that need to be touched), and are looking for input on this. An example is the presence of these optional Hopper features in `AccelerateAMDMatmul.cpp`.

<details>
<summary><b>microbenchmark.py (Click to expand)</b></summary>

```
k_chunks_hint=None took 0.6268 ms
k_chunks_hint=1    took 0.3463 ms
k_chunks_hint=2    took 0.6283 ms
k_chunks_hint=4    took 1.2085 ms
```

```py
import torch
import triton
import triton.language as tl

@triton.jit
def spilling_matmul_kernel(
    a_ptr, b_ptr, c_ptr,
    M, N, K,
    M_BLOCK_SIZE: tl.constexpr,
    N_BLOCK_SIZE: tl.constexpr,
    K_BLOCK_SIZE: tl.constexpr,
    K_CHUNKS_HINT: tl.constexpr,
):
    pid = tl.program_id(axis=0)
    m_off = pid * M_BLOCK_SIZE + tl.arange(0, M_BLOCK_SIZE)
    n_off = tl.arange(0, N_BLOCK_SIZE)

    NUM_K_STEPS = K // K_BLOCK_SIZE

    acc = tl.zeros((M_BLOCK_SIZE, N_BLOCK_SIZE), dtype=tl.float32)
    for k_index in tl.range(0, NUM_K_STEPS):
        k_off = k_index * K_BLOCK_SIZE + tl.arange(0, K_BLOCK_SIZE)
        a = tl.load(a_ptr + m_off[:, None] * K + k_off[None, :])
        b = tl.load(b_ptr + k_off[:, None] * N + n_off[None, :])
        a_reg = a.to(tl.float32) * 1.337 + 1.234
        acc = tl.dot(a_reg.to(tl.bfloat16), b, acc=acc, k_chunks_hint=K_CHUNKS_HINT)
    tl.store(c_ptr + m_off[:, None] * N + n_off[None, :], acc)


if __name__ == "__main__":
    torch.set_default_device("cuda")

    M = 16384
    N = 256
    K = 2048
    M_BLOCK_SIZE = 256
    N_BLOCK_SIZE = 256
    K_BLOCK_SIZE = 64
    torch.manual_seed(0)

    a = torch.randn((M, K), dtype=torch.bfloat16)
    b = torch.randn((K, N), dtype=torch.bfloat16)
    c = torch.empty((M, N), dtype=torch.float32)
    grid = (M // M_BLOCK_SIZE,)

    for K_CHUNKS_HINT in [None, 1, 2, 4]:
        def fn():
            spilling_matmul_kernel[grid](
                a, b, c, 
                M, N, K,
                M_BLOCK_SIZE,
                N_BLOCK_SIZE,
                K_BLOCK_SIZE,
                K_CHUNKS_HINT,
                num_warps=4, num_stages=2,
            )
        ms = triton.testing.do_bench(fn)
        print(f"k_chunks_hint={K_CHUNKS_HINT} took {ms:.4f} ms")

```

</details>



<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
