### PR TITLE
[proton] Make launch metadata graph metrics deterministic

### DIFF
--- a/third_party/proton/csrc/include/Context/Context.h
+++ b/third_party/proton/csrc/include/Context/Context.h
@@ -36,7 +36,17 @@ public:
   std::vector<Context> getContexts() {
     auto contexts = getContextsImpl();
     if (state.has_value()) {
-      contexts.push_back(state.value());
+      // Metadata launch scopes are also installed as state; avoid emitting the
+      // same context twice when that scope is already in the context stack.
+      bool isStateInContext = false;
+      for (const auto &context : contexts) {
+        if (context == state.value()) {
+          isStateInContext = true;
+          break;
+        }
+      }
+      if (!isStateInContext)
+        contexts.push_back(state.value());
     }
     return contexts;
   }

--- a/third_party/proton/csrc/include/Data/Metric.h
+++ b/third_party/proton/csrc/include/Data/Metric.h
@@ -414,7 +414,9 @@ collectTensorMetrics(Runtime *runtime,
 ///
 ///  host ->                             -------- kernel0 --------
 ///                                     /                         \
-/// [device0] -> metric buffer -> {metric_id, value, metric_id, value, ...}
+/// [device0] -> metric buffer ->
+///     {metric_ordinal, metric_id, value, metric_ordinal, metric_id, value,
+///     ...}
 ///                   |                            /|\
 ///                   |                             |
 ///                   | deviceOffsetPtr -------------
@@ -437,7 +439,8 @@ public:
 
   void receive(const std::map<std::string, TensorMetric> &tensorMetrics,
                const std::map<std::string, MetricValueType> &scalarMetrics,
-               const MetricKernelLaunchState &metricKernelLaunchState);
+               const MetricKernelLaunchState &metricKernelLaunchState,
+               const std::vector<uint64_t> &metricOrdinals);
 
   void reserve() { getOrCreateBuffer(); }
 
@@ -451,6 +454,15 @@ public:
       auto &buffer = it->second;
       callback(buffer.hostPtr);
     }
+  }
+
+  uint64_t getWrittenWords(Device *device) {
+    std::lock_guard<std::mutex> lock(bufferMutex);
+    auto it = deviceBuffers.find(device);
+    if (it == deviceBuffers.end() || it->second.hostOffset == nullptr) {
+      return 0;
+    }
+    return *it->second.hostOffset;
   }
 
   template <typename Func> void flush(Func callback, bool flushAll = false) {
@@ -492,10 +504,11 @@ private:
 
   DeviceBuffer &getOrCreateBuffer();
 
-  void queue(size_t metricId, TensorMetric tensorMetric, void *stream,
-             const MetricKernelLaunchConfig &launchConfig);
+  void queue(uint64_t metricOrdinal, size_t metricId, TensorMetric tensorMetric,
+             void *stream, const MetricKernelLaunchConfig &launchConfig);
 
-  void queue(size_t metricId, MetricValueType scalarMetric, void *stream,
+  void queue(uint64_t metricOrdinal, size_t metricId,
+             MetricValueType scalarMetric, void *stream,
              const MetricKernelLaunchConfig &launchConfig);
 
   void synchronize(DeviceBuffer &buffer);
@@ -528,12 +541,19 @@ private:
 
   template <typename MetricsT>
   void queueMetrics(const MetricsT &metrics, void *stream,
-                    const MetricKernelLaunchConfig &launchConfig) {
+                    const MetricKernelLaunchConfig &launchConfig,
+                    const std::vector<uint64_t> &metricOrdinals,
+                    size_t &ordinalIndex) {
     for (const auto &[name, metric] : metrics) {
       size_t typeIndex = getMetricTypeIndex(metric);
       size_t size = getMetricSize(metric);
       auto descriptor = getOrCreateMetricDescriptor(name, typeIndex, size);
-      queue(descriptor.id, metric, stream, launchConfig);
+      if (ordinalIndex >= metricOrdinals.size()) {
+        throw std::runtime_error(
+            "[PROTON] MetricBuffer: missing metric ordinal");
+      }
+      queue(metricOrdinals[ordinalIndex++], descriptor.id, metric, stream,
+            launchConfig);
     }
   }
 

--- a/third_party/proton/csrc/include/Profiler/GPUProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/GPUProfiler.h
@@ -123,6 +123,8 @@ protected:
     bool isStreamCapturing{false};
     bool isMetricKernelLaunching{false};
     std::deque<size_t> metricKernelNumWordsQueue;
+    std::deque<uint64_t> metricKernelOrdinalQueue;
+    uint64_t nextMetricKernelOrdinal{};
 
     ThreadState(ConcreteProfilerT &profiler) : profiler(profiler) {}
 
@@ -231,18 +233,26 @@ protected:
                  const std::map<std::string, TensorMetric> &tensorMetrics) {
       if (threadState.isStreamCapturing) { // Graph capture mode
         threadState.isMetricKernelLaunching = true;
+        std::vector<uint64_t> metricOrdinals;
+        metricOrdinals.reserve(tensorMetrics.size() + scalarMetrics.size());
         for (const auto &[_, metric] : tensorMetrics) {
           threadState.metricKernelNumWordsQueue.push_back(
-              /*metric_id=*/1 + metric.size); // metric_id + num_values
+              /*ordinal=*/1 + /*metric_id=*/1 + metric.size);
+          auto metricOrdinal = threadState.nextMetricKernelOrdinal++;
+          threadState.metricKernelOrdinalQueue.push_back(metricOrdinal);
+          metricOrdinals.push_back(metricOrdinal);
         }
         for (const auto &[_, metric] : scalarMetrics) {
           threadState.metricKernelNumWordsQueue.push_back(
-              /*metric_id=*/1 + 1); // scalar metric has 1 value
+              /*ordinal=*/1 + /*metric_id=*/1 + 1); // scalar metric has 1 value
+          auto metricOrdinal = threadState.nextMetricKernelOrdinal++;
+          threadState.metricKernelOrdinalQueue.push_back(metricOrdinal);
+          metricOrdinals.push_back(metricOrdinal);
         }
         // Launch metric kernels
         auto &metricKernelLaunchState = profiler.metricKernelLaunchState;
         profiler.metricBuffer->receive(tensorMetrics, scalarMetrics,
-                                       metricKernelLaunchState);
+                                       metricKernelLaunchState, metricOrdinals);
         threadState.isMetricKernelLaunching = false;
       } else { // Eager mode, directly copy
         // Populate tensor metrics

--- a/third_party/proton/csrc/include/Profiler/Graph.h
+++ b/third_party/proton/csrc/include/Profiler/Graph.h
@@ -54,6 +54,11 @@ struct GraphState {
     // created at capture time and won't change for the same node id. This is
     // used to link the graph node to the captured call path in Data.
     std::map<Data *, size_t> dataToEntryId;
+    // For metric-copy nodes grouped under launch metadata, flexible launch
+    // metrics still belong to the owner kernel's <metric> child, not to the
+    // metadata node that runs the copy kernel. TreeData promotes linked
+    // flexible metrics from <metric> children onto the owner kernel frame.
+    std::map<Data *, size_t> dataToFlexibleMetricEntryId;
     // Whether the node has missing name or is a metric node, which is
     // determined at capture time and won't change for the same node id.
     NodeStatus status{};
@@ -61,6 +66,10 @@ struct GraphState {
     bool operator<(const NodeState &other) const {
       return nodeId < other.nodeId;
     }
+  };
+  struct MetricNodeInfo {
+    size_t numWords{};
+    uint64_t ordinal{};
   };
   using NodeIdToStateMap = std::map<uint64_t, NodeState>;
   // Precomputed per-Data launch links maintained on graph node
@@ -71,11 +80,19 @@ struct GraphState {
   // Mapping from node id to node state, has to be ordered based on node id
   // which is the order of node creation.
   NodeIdToStateMap nodeIdToState;
-  // Metric nodes and their per-node metric words, ordered by node id.
-  std::map<uint64_t, size_t> metricNodeIdToNumWords;
+  // Metric nodes and their replay metadata, ordered by node id.
+  std::map<uint64_t, MetricNodeInfo> metricNodeIdToInfo;
   // If the graph is launched after profiling started,
   // we need to throw an error and this error is only thrown once
   bool captureStatusChecked{};
+  // True when this state is for a graph created through GRAPHNODE_CLONED. Its
+  // node ids are suitable for synthesizing graph-exec state if CUPTI reports
+  // the graph/exec relationship separately from node clone callbacks.
+  bool clonedGraph{};
+  // True when graph-exec state was synthesized from cloned graph state. If
+  // later GRAPHNODE_CLONED callbacks provide exact exec-node ids, the
+  // synthesized state should be replaced by cloned state.
+  bool copiedFromSourceGraph{};
   // Total number of uint64 words written by all metric nodes in this graph.
   size_t numMetricWords{};
 };
@@ -84,9 +101,10 @@ struct PendingGraphQueue {
   struct PendingGraph {
     size_t numNodes;
     size_t numWords;
-    // Metric target entries grouped per Data sink and aligned with
-    // graph metric-node order.
-    std::map<Data *, std::vector<DataEntry>> dataToEntries;
+    // Metric target entries keyed by the ordinal written by each metric-copy
+    // kernel. CUDA graphs may replay metric-copy nodes in a different order
+    // than graph node creation, especially when captured work spans streams.
+    std::map<uint64_t, std::map<Data *, DataEntry>> ordinalToEntries;
   };
 
   std::vector<PendingGraph> pendingGraphs;
@@ -105,9 +123,11 @@ struct PendingGraphQueue {
                              void *device)
       : startBufferOffset(startBufferOffset), phase(phase), device(device) {}
 
-  void push(size_t numNodes, size_t numWords,
-            const std::map<Data *, std::vector<DataEntry>> &dataToEntries) {
-    pendingGraphs.emplace_back(PendingGraph{numNodes, numWords, dataToEntries});
+  void push(
+      size_t numNodes, size_t numWords,
+      const std::map<uint64_t, std::map<Data *, DataEntry>> &ordinalToEntries) {
+    pendingGraphs.emplace_back(
+        PendingGraph{numNodes, numWords, ordinalToEntries});
     this->numNodes += numNodes;
     this->numWords += numWords;
   }
@@ -118,9 +138,10 @@ public:
   explicit PendingGraphPool(MetricBuffer *metricBuffer)
       : metricBuffer(metricBuffer), runtime(metricBuffer->getRuntime()) {}
 
-  void push(size_t phase,
-            const std::map<Data *, std::vector<DataEntry>> &dataToEntries,
-            size_t numNodes, size_t numWords);
+  void
+  push(size_t phase,
+       const std::map<uint64_t, std::map<Data *, DataEntry>> &ordinalToEntries,
+       size_t numNodes, size_t numWords);
 
   // No GPU synchronization, No CPU locks
   void peek(size_t phase);

--- a/third_party/proton/csrc/lib/Data/Metric.cpp
+++ b/third_party/proton/csrc/lib/Data/Metric.cpp
@@ -30,11 +30,18 @@ MetricBuffer::~MetricBuffer() {
 void MetricBuffer::receive(
     const std::map<std::string, TensorMetric> &tensorMetrics,
     const std::map<std::string, MetricValueType> &scalarMetrics,
-    const MetricKernelLaunchState &metricKernelLaunchState) {
+    const MetricKernelLaunchState &metricKernelLaunchState,
+    const std::vector<uint64_t> &metricOrdinals) {
+  const size_t numMetrics = tensorMetrics.size() + scalarMetrics.size();
+  if (metricOrdinals.size() != numMetrics) {
+    throw std::runtime_error(
+        "[PROTON] MetricBuffer: metric ordinal count mismatch");
+  }
+  size_t ordinalIndex = 0;
   queueMetrics(tensorMetrics, metricKernelLaunchState.stream,
-               metricKernelLaunchState.tensor);
+               metricKernelLaunchState.tensor, metricOrdinals, ordinalIndex);
   queueMetrics(scalarMetrics, metricKernelLaunchState.stream,
-               metricKernelLaunchState.scalar);
+               metricKernelLaunchState.scalar, metricOrdinals, ordinalIndex);
 }
 
 MetricBuffer::MetricDescriptor
@@ -132,8 +139,8 @@ collectTensorMetrics(Runtime *runtime,
   return tensorMetricsHost;
 }
 
-void MetricBuffer::queue(size_t metricId, TensorMetric tensorMetric,
-                         void *stream,
+void MetricBuffer::queue(uint64_t metricOrdinal, size_t metricId,
+                         TensorMetric tensorMetric, void *stream,
                          const MetricKernelLaunchConfig &launchConfig) {
   auto &buffer = getOrCreateBuffer();
   uint64_t numWords = capacity / sizeof(uint64_t);
@@ -143,6 +150,7 @@ void MetricBuffer::queue(size_t metricId, TensorMetric tensorMetric,
   void *kernelParams[] = {reinterpret_cast<void *>(&buffer.devicePtr),
                           reinterpret_cast<void *>(&buffer.deviceOffsetPtr),
                           reinterpret_cast<void *>(&numWords),
+                          reinterpret_cast<void *>(&metricOrdinal),
                           reinterpret_cast<void *>(&metricId),
                           reinterpret_cast<void *>(&tensorMetric.ptr),
                           reinterpret_cast<void *>(&metricValueSize),
@@ -154,8 +162,8 @@ void MetricBuffer::queue(size_t metricId, TensorMetric tensorMetric,
                         nullptr);
 }
 
-void MetricBuffer::queue(size_t metricId, MetricValueType scalarMetric,
-                         void *stream,
+void MetricBuffer::queue(uint64_t metricOrdinal, size_t metricId,
+                         MetricValueType scalarMetric, void *stream,
                          const MetricKernelLaunchConfig &launchConfig) {
   auto &buffer = getOrCreateBuffer();
   uint64_t numWords = capacity / sizeof(uint64_t);
@@ -182,6 +190,7 @@ void MetricBuffer::queue(size_t metricId, MetricValueType scalarMetric,
   void *kernelParams[] = {reinterpret_cast<void *>(&buffer.devicePtr),
                           reinterpret_cast<void *>(&buffer.deviceOffsetPtr),
                           reinterpret_cast<void *>(&numWords),
+                          reinterpret_cast<void *>(&metricOrdinal),
                           reinterpret_cast<void *>(&metricId),
                           reinterpret_cast<void *>(&metricBits),
                           reinterpret_cast<void *>(&globalScratchPtr),

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
@@ -33,6 +34,26 @@ thread_local GPUProfiler<CuptiProfiler>::ThreadState
     GPUProfiler<CuptiProfiler>::threadState(CuptiProfiler::instance());
 
 namespace {
+
+std::optional<std::pair<size_t, std::string>>
+findMetadataOwnerContext(const std::vector<Context> &contexts) {
+  const auto prefix = std::string(GraphState::metadataTag) + ":";
+  for (size_t i = 0; i < contexts.size(); ++i) {
+    const auto &name = contexts[i].name;
+    if (name.rfind(prefix, 0) == 0 && name.size() > prefix.size()) {
+      return std::make_pair(i, name.substr(prefix.size()));
+    }
+  }
+  return std::nullopt;
+}
+
+std::string findCurrentOpName(const std::vector<Scope> &scopeStack,
+                              const std::string &fallback) {
+  if (!scopeStack.empty() && !scopeStack.back().name.empty()) {
+    return scopeStack.back().name;
+  }
+  return fallback;
+}
 
 std::unique_ptr<Metric>
 convertKernelActivityToMetric(CUpti_Activity *activity,
@@ -208,15 +229,16 @@ void queueGraphMetrics(const DataToEntryMap &dataToEntry,
                        const CUpti_CallbackData *callbackData,
                        const GraphState &graphState,
                        CuptiProfiler::ExternIdState &externIdState) {
-  if (graphState.metricNodeIdToNumWords.empty()) {
+  if (graphState.metricNodeIdToInfo.empty()) {
     return;
   }
-  std::map<Data *, std::vector<DataEntry>> metricNodeEntries;
+  std::map<uint64_t, std::map<Data *, DataEntry>> metricNodeEntries;
   size_t phase = Data::kNoCompletePhase;
   for (const auto &[data, graphEntry] : externIdState.dataToGraphEntry) {
     phase = graphEntry.phase;
-    for (const auto &metricNode : graphState.metricNodeIdToNumWords) {
+    for (const auto &metricNode : graphState.metricNodeIdToInfo) {
       auto nodeId = metricNode.first;
+      auto metricOrdinal = metricNode.second.ordinal;
       auto nodeIter = graphState.nodeIdToState.find(nodeId);
       if (nodeIter ==
           graphState.nodeIdToState
@@ -225,25 +247,49 @@ void queueGraphMetrics(const DataToEntryMap &dataToEntry,
       auto &nodeState = nodeIter->second;
       auto entryIdIter = nodeState.dataToEntryId.find(data);
       if (entryIdIter != nodeState.dataToEntryId.end()) {
-        metricNodeEntries[data].emplace_back(
-            DataEntry(entryIdIter->second, phase, graphEntry.metricSet.get()));
+        auto flexibleMetricEntryId = entryIdIter->second;
+        auto flexibleMetricEntryIt =
+            nodeState.dataToFlexibleMetricEntryId.find(data);
+        if (flexibleMetricEntryIt !=
+            nodeState.dataToFlexibleMetricEntryId.end()) {
+          flexibleMetricEntryId = flexibleMetricEntryIt->second;
+        }
+        metricNodeEntries[metricOrdinal].insert_or_assign(
+            data, DataEntry(flexibleMetricEntryId, phase,
+                            graphEntry.metricSet.get()));
       } else {
         // Indicate that we'll call upsertFlexibleMetric instead of
         // upsertLinkedFlexibleMetric in queueGraphMetrics, so that the kernel
         // metric can be attached to the graph launch entry when node entry is
         // not found.
-        metricNodeEntries[data].emplace_back(
+        metricNodeEntries[metricOrdinal].insert_or_assign(
+            data,
             DataEntry(Scope::DummyScopeId, phase, graphEntry.metricSet.get()));
       }
     }
   }
 
-  const auto numMetricNodes = graphState.metricNodeIdToNumWords.size();
+  const auto numMetricNodes = graphState.metricNodeIdToInfo.size();
   const auto numMetricWords = graphState.numMetricWords;
   if (callbackData->context != nullptr)
     pendingGraphPool->flushIfNeeded(numMetricWords);
   pendingGraphPool->push(phase, metricNodeEntries, numMetricNodes,
                          numMetricWords);
+}
+
+GraphState cloneSourceGraphState(const GraphState &sourceGraphState) {
+  GraphState graphExecState;
+  graphExecState.nodeIdToState = sourceGraphState.nodeIdToState;
+  graphExecState.metricNodeIdToInfo = sourceGraphState.metricNodeIdToInfo;
+  graphExecState.numMetricWords = sourceGraphState.numMetricWords;
+  graphExecState.copiedFromSourceGraph = true;
+  for (auto &[_, nodeState] : graphExecState.nodeIdToState) {
+    for (const auto &[data, entryId] : nodeState.dataToEntryId) {
+      graphExecState.dataToEntryIdToNodeStates[data][entryId].insert(
+          &nodeState);
+    }
+  }
+  return graphExecState;
 }
 
 constexpr std::array<CUpti_CallbackId, 11> kGraphCallbacks = {
@@ -276,7 +322,10 @@ constexpr std::array<CUpti_CallbackId, 10> kKernelCallbacks = {
     PROTON_KERNEL_CALLBACK_LIST(PROTON_KERNEL_CB_AS_ID)};
 #undef PROTON_KERNEL_CB_AS_ID
 
-constexpr std::array<CUpti_CallbackId, 2> kGraphResourceCallbacks = {
+constexpr std::array<CUpti_CallbackId, 5> kGraphResourceCallbacks = {
+    CUPTI_CBID_RESOURCE_GRAPH_DESTROY_STARTING,
+    CUPTI_CBID_RESOURCE_GRAPHEXEC_DESTROY_STARTING,
+    CUPTI_CBID_RESOURCE_GRAPHEXEC_CREATED,
     CUPTI_CBID_RESOURCE_GRAPHNODE_CREATED,
     CUPTI_CBID_RESOURCE_GRAPHNODE_CLONED};
 
@@ -380,7 +429,12 @@ struct CuptiProfiler::CuptiProfilerPimpl
   CUpti_SubscriberHandle subscriber{};
   CuptiPCSampling pcSampling;
 
+  // CUPTI graph ids (CUgraph) and graph exec ids (CUgraphExec) are separate
+  // namespaces. Keep them in separate maps so a graph launch cannot pick up
+  // stale source-graph metadata whose numeric id happens to match the exec id.
   ThreadSafeMap<uint32_t, GraphState> graphStates;
+  ThreadSafeMap<uint32_t, GraphState> graphExecStates;
+  ThreadSafeMap<uint32_t, uint32_t> graphExecIdToGraphId;
 
 private:
   void handleGraphResourceCallbacks(CuptiProfiler &profiler,
@@ -458,6 +512,28 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphResourceCallbacks(
     cupti::getGraphId<true>(graphData->graph, &graphId);
   if (graphData->graphExec)
     cupti::getGraphExecId<true>(graphData->graphExec, &graphExecId);
+  if (cbId == CUPTI_CBID_RESOURCE_GRAPH_DESTROY_STARTING) {
+    if (graphId != 0)
+      graphStates.erase(graphId);
+    return;
+  }
+  if (cbId == CUPTI_CBID_RESOURCE_GRAPHEXEC_DESTROY_STARTING) {
+    if (graphExecId != 0) {
+      graphExecStates.erase(graphExecId);
+      graphExecIdToGraphId.erase(graphExecId);
+    }
+    return;
+  }
+  if (cbId == CUPTI_CBID_RESOURCE_GRAPHEXEC_CREATED) {
+    if (graphId != 0 && graphExecId != 0) {
+      graphExecIdToGraphId[graphExecId] = graphId;
+      if (graphStates.contain(graphId) && graphStates[graphId].clonedGraph) {
+        graphExecStates[graphExecId] =
+            cloneSourceGraphState(graphStates[graphId]);
+      }
+    }
+    return;
+  }
   if (cbId == CUPTI_CBID_RESOURCE_GRAPHNODE_CREATED ||
       cbId == CUPTI_CBID_RESOURCE_GRAPHNODE_CLONED) {
     if (graphData->nodeType != CU_GRAPH_NODE_TYPE_KERNEL) {
@@ -479,19 +555,37 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphResourceCallbacks(
       const auto &name = threadState.scopeStack.back().name;
       if (name.empty())
         nodeState.status.setMissingName();
-      if (threadState.isMetricKernelLaunching) {
+      const bool isMetricKernelNode =
+          threadState.isMetricKernelLaunching &&
+          !threadState.metricKernelNumWordsQueue.empty() &&
+          !threadState.metricKernelOrdinalQueue.empty();
+      if (isMetricKernelNode) {
         nodeState.status.setMetricNode();
         auto metricKernelNumWords =
             threadState.metricKernelNumWordsQueue.front();
         threadState.metricKernelNumWordsQueue.pop_front();
-        graphState.metricNodeIdToNumWords.insert_or_assign(
-            nodeId, metricKernelNumWords);
+        auto metricKernelOrdinal = threadState.metricKernelOrdinalQueue.front();
+        threadState.metricKernelOrdinalQueue.pop_front();
+        graphState.metricNodeIdToInfo.insert_or_assign(
+            nodeId, GraphState::MetricNodeInfo{metricKernelNumWords,
+                                               metricKernelOrdinal});
         graphState.numMetricWords += metricKernelNumWords;
       }
       for (auto *data : profiler.dataSet) {
         auto contexts = data->getContexts();
-        if (threadState.isMetricKernelLaunching) {
-          if (threadState.isApiExternOp) { // API extern ops
+        std::optional<std::vector<Context>> flexibleMetricTargetContexts;
+        if (isMetricKernelNode) {
+          if (auto metadataOwner = findMetadataOwnerContext(contexts)) {
+            auto [metadataIndex, ownerName] = *metadataOwner;
+            auto metricOwnerName =
+                findCurrentOpName(threadState.scopeStack, ownerName);
+            flexibleMetricTargetContexts = std::vector<Context>(
+                contexts.begin(), contexts.begin() + metadataIndex);
+            flexibleMetricTargetContexts->push_back(Context(metricOwnerName));
+            flexibleMetricTargetContexts->push_back(
+                Context(GraphState::metricTag));
+            contexts.push_back(std::string(GraphState::metricTag));
+          } else if (threadState.isApiExternOp) { // API extern ops
             contexts.push_back(std::string(GraphState::metricTag));
           } else { // Triton ops
             contexts.push_back(name);
@@ -503,18 +597,40 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphResourceCallbacks(
         auto staticEntry =
             data->addOp(Data::kVirtualPhase, Data::kRootEntryId, contexts);
         nodeState.dataToEntryId.insert_or_assign(data, staticEntry.id);
+        if (isMetricKernelNode) {
+          if (flexibleMetricTargetContexts) {
+            auto flexibleMetricTargetEntry =
+                data->addOp(Data::kVirtualPhase, Data::kRootEntryId,
+                            *flexibleMetricTargetContexts);
+            nodeState.dataToFlexibleMetricEntryId.insert_or_assign(
+                data, flexibleMetricTargetEntry.id);
+          } else {
+            nodeState.dataToFlexibleMetricEntryId.insert_or_assign(
+                data, staticEntry.id);
+          }
+        }
         graphState.dataToEntryIdToNodeStates[data][staticEntry.id].insert(
             &nodeState);
       }
     } else { // CUPTI_CBID_RESOURCE_GRAPHNODE_CLONED
-      // When a graph is cloned under the stream capture mode, graphId is the
-      // same as the graphExecId to be created
+      // Prefer graphExecId when CUPTI provides it. Older code assumed the
+      // cloned graphId was the same key later reported by cuGraphLaunch, but
+      // CUDA graph instantiate/clone paths can report distinct graph and exec
+      // ids. If we store cloned node state under graphId in that case, graph
+      // launch can pick up stale capture metadata from a different graph exec.
       uint32_t originalGraphId = 0;
       uint64_t originalNodeId = 0;
       cupti::getGraphId<true>(graphData->originalGraph, &originalGraphId);
       cupti::getGraphNodeId<true>(graphData->originalNode, &originalNodeId);
       auto &originalGraphState = graphStates[originalGraphId];
-      auto &graphState = graphStates[graphId];
+      auto &graphState = graphExecId != 0 ? graphExecStates[graphExecId]
+                                          : graphStates[graphId];
+      if (graphState.copiedFromSourceGraph) {
+        graphState = GraphState{};
+      }
+      if (graphExecId == 0) {
+        graphState.clonedGraph = true;
+      }
       graphState.nodeIdToState[nodeId] =
           originalGraphState.nodeIdToState[originalNodeId];
       auto &nodeState = graphState.nodeIdToState[nodeId];
@@ -523,13 +639,11 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphResourceCallbacks(
         graphState.dataToEntryIdToNodeStates[data][entryId].insert(&nodeState);
       }
       auto originalMetricNodeIt =
-          originalGraphState.metricNodeIdToNumWords.find(originalNodeId);
-      if (originalMetricNodeIt !=
-          originalGraphState.metricNodeIdToNumWords.end()) {
-        const auto numMetricWords = originalMetricNodeIt->second;
-        graphState.metricNodeIdToNumWords.insert_or_assign(nodeId,
-                                                           numMetricWords);
-        graphState.numMetricWords += numMetricWords;
+          originalGraphState.metricNodeIdToInfo.find(originalNodeId);
+      if (originalMetricNodeIt != originalGraphState.metricNodeIdToInfo.end()) {
+        const auto metricNodeInfo = originalMetricNodeIt->second;
+        graphState.metricNodeIdToInfo.insert_or_assign(nodeId, metricNodeInfo);
+        graphState.numMetricWords += metricNodeInfo.numWords;
       }
     }
   }
@@ -621,19 +735,31 @@ void CuptiProfiler::CuptiProfilerPimpl::handleApiEnterLaunchCallbacks(
     cupti::getGraphExecId<true>(graphExec, &graphExecId);
     numNodes = std::numeric_limits<size_t>::max();
     auto findGraph = false;
-    if (graphStates.contain(graphExecId)) {
-      if (!graphStates[graphExecId].captureStatusChecked)
-        numNodes = graphStates[graphExecId].nodeIdToState.size();
+    if (graphStates.contain(graphExecId) &&
+        graphStates[graphExecId].clonedGraph) {
+      graphExecStates[graphExecId] =
+          cloneSourceGraphState(graphStates[graphExecId]);
+    }
+    uint32_t graphId = 0;
+    if (graphExecIdToGraphId.withRead(
+            graphExecId, [&graphId](uint32_t value) { graphId = value; }) &&
+        graphStates.contain(graphId) && graphStates[graphId].clonedGraph &&
+        !graphExecStates.contain(graphExecId)) {
+      graphExecStates[graphExecId] =
+          cloneSourceGraphState(graphStates[graphId]);
+    }
+    if (graphExecStates.contain(graphExecId)) {
+      if (!graphExecStates[graphExecId].captureStatusChecked)
+        numNodes = graphExecStates[graphExecId].nodeIdToState.size();
       findGraph = true;
     }
-    if (!findGraph && !graphStates[graphExecId].captureStatusChecked) {
-      graphStates[graphExecId].captureStatusChecked = true;
+    if (!findGraph) {
       std::cerr << "[PROTON] Cannot find graph for graphExecId: " << graphExecId
                 << ", and it may cause memory leak. To avoid this problem, "
                    "please start profiling before the graph is created."
                 << std::endl;
-    } else if (findGraph && !graphStates[graphExecId].captureStatusChecked) {
-      auto &graphState = graphStates[graphExecId];
+    } else if (!graphExecStates[graphExecId].captureStatusChecked) {
+      auto &graphState = graphExecStates[graphExecId];
       auto &externIdState = profiler.correlation.externIdToState[scope.scopeId];
       static const bool timingEnabled =
           getBoolEnv("PROTON_GRAPH_LAUNCH_TIMING", false);

--- a/third_party/proton/csrc/lib/Profiler/Graph.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Graph.cpp
@@ -4,6 +4,8 @@
 #include "Runtime/Runtime.h"
 
 #include <cstring>
+#include <deque>
+#include <optional>
 #include <stdexcept>
 
 namespace proton {
@@ -14,101 +16,129 @@ constexpr size_t bytesForWords(size_t numWords) {
 }
 
 void emitMetricRecords(MetricBuffer &metricBuffer, uint64_t *hostBasePtr,
-                       const PendingGraphQueue &queue) {
+                       const PendingGraphQueue &queue, uint64_t endWordOffset) {
   const auto &pendingGraphs = queue.pendingGraphs;
   const size_t capacityWords = metricBuffer.getCapacity() / sizeof(uint64_t);
-  size_t wordOffset = queue.startBufferOffset / sizeof(uint64_t);
+  const uint64_t startWordOffset = queue.startBufferOffset / sizeof(uint64_t);
+  if (endWordOffset < startWordOffset) {
+    endWordOffset = startWordOffset + queue.numWords;
+  }
+  uint64_t wordOffset = startWordOffset;
   auto readWord = [&](size_t offset) -> uint64_t {
     return hostBasePtr[offset % capacityWords];
   };
 
+  std::map<uint64_t, std::deque<std::map<Data *, DataEntry>>>
+      ordinalToEntryQueue;
   for (const auto &pendingGraph : pendingGraphs) {
-    for (size_t i = 0; i < pendingGraph.numNodes; ++i) {
-      const uint64_t metricId = readWord(wordOffset);
-      wordOffset = (wordOffset + 1) % capacityWords;
+    for (const auto &[ordinal, entries] : pendingGraph.ordinalToEntries) {
+      ordinalToEntryQueue[ordinal].push_back(entries);
+    }
+  }
 
-      auto metricDesc = metricBuffer.getMetricDescriptor(metricId);
-      const auto &metricName = metricDesc.name;
-      const auto metricTypeIndex = metricDesc.typeIndex;
+  while (wordOffset < endWordOffset) {
+    const uint64_t metricOrdinal = readWord(wordOffset);
+    wordOffset += 1;
 
-      MetricValueType metricValueVariant{};
-      switch (metricTypeIndex) {
-      case variant_index_v<uint64_t, MetricValueType>: {
-        const uint64_t bits = readWord(wordOffset);
-        uint64_t typedValue{};
-        std::memcpy(&typedValue, &bits, sizeof(typedValue));
-        metricValueVariant = typedValue;
-        break;
-      }
-      case variant_index_v<int64_t, MetricValueType>: {
-        const uint64_t bits = readWord(wordOffset);
-        int64_t typedValue{};
-        std::memcpy(&typedValue, &bits, sizeof(typedValue));
-        metricValueVariant = typedValue;
-        break;
-      }
-      case variant_index_v<double, MetricValueType>: {
-        const uint64_t bits = readWord(wordOffset);
-        double typedValue{};
-        std::memcpy(&typedValue, &bits, sizeof(typedValue));
-        metricValueVariant = typedValue;
-        break;
-      }
-      case variant_index_v<std::vector<uint64_t>, MetricValueType>: {
-        std::vector<uint64_t> values(metricDesc.size);
-        for (size_t j = 0; j < metricDesc.size; ++j) {
-          values[j] = readWord(wordOffset + j);
-        }
-        metricValueVariant = std::move(values);
-        break;
-      }
-      case variant_index_v<std::vector<int64_t>, MetricValueType>: {
-        std::vector<int64_t> values(metricDesc.size);
-        for (size_t j = 0; j < metricDesc.size; ++j) {
-          const uint64_t bits = readWord(wordOffset + j);
-          std::memcpy(&values[j], &bits, sizeof(bits));
-        }
-        metricValueVariant = std::move(values);
-        break;
-      }
-      case variant_index_v<std::vector<double>, MetricValueType>: {
-        std::vector<double> values(metricDesc.size);
-        for (size_t j = 0; j < metricDesc.size; ++j) {
-          const uint64_t bits = readWord(wordOffset + j);
-          std::memcpy(&values[j], &bits, sizeof(bits));
-        }
-        metricValueVariant = std::move(values);
-        break;
-      }
-      default:
-        throw std::runtime_error("[PROTON] Unsupported metric type index: " +
-                                 std::to_string(metricTypeIndex));
-        break;
-      }
+    const uint64_t metricId = readWord(wordOffset);
+    wordOffset += 1;
 
-      wordOffset = (wordOffset + metricDesc.size) % capacityWords;
+    auto metricDesc = metricBuffer.getMetricDescriptor(metricId);
+    const auto &metricName = metricDesc.name;
+    const auto metricTypeIndex = metricDesc.typeIndex;
 
-      for (auto &[data, entries] : pendingGraph.dataToEntries) {
-        auto &dataEntry = entries[i];
-        if (dataEntry.id != Scope::DummyScopeId) {
-          dataEntry.upsertLinkedFlexibleMetric(metricName, metricValueVariant,
-                                               dataEntry.id);
-        } else {
-          dataEntry.upsertFlexibleMetric(metricName, metricValueVariant);
-        }
+    MetricValueType metricValueVariant{};
+    switch (metricTypeIndex) {
+    case variant_index_v<uint64_t, MetricValueType>: {
+      const uint64_t bits = readWord(wordOffset);
+      uint64_t typedValue{};
+      std::memcpy(&typedValue, &bits, sizeof(typedValue));
+      metricValueVariant = typedValue;
+      break;
+    }
+    case variant_index_v<int64_t, MetricValueType>: {
+      const uint64_t bits = readWord(wordOffset);
+      int64_t typedValue{};
+      std::memcpy(&typedValue, &bits, sizeof(typedValue));
+      metricValueVariant = typedValue;
+      break;
+    }
+    case variant_index_v<double, MetricValueType>: {
+      const uint64_t bits = readWord(wordOffset);
+      double typedValue{};
+      std::memcpy(&typedValue, &bits, sizeof(typedValue));
+      metricValueVariant = typedValue;
+      break;
+    }
+    case variant_index_v<std::vector<uint64_t>, MetricValueType>: {
+      std::vector<uint64_t> values(metricDesc.size);
+      for (size_t j = 0; j < metricDesc.size; ++j) {
+        values[j] = readWord(wordOffset + j);
+      }
+      metricValueVariant = std::move(values);
+      break;
+    }
+    case variant_index_v<std::vector<int64_t>, MetricValueType>: {
+      std::vector<int64_t> values(metricDesc.size);
+      for (size_t j = 0; j < metricDesc.size; ++j) {
+        const uint64_t bits = readWord(wordOffset + j);
+        std::memcpy(&values[j], &bits, sizeof(bits));
+      }
+      metricValueVariant = std::move(values);
+      break;
+    }
+    case variant_index_v<std::vector<double>, MetricValueType>: {
+      std::vector<double> values(metricDesc.size);
+      for (size_t j = 0; j < metricDesc.size; ++j) {
+        const uint64_t bits = readWord(wordOffset + j);
+        std::memcpy(&values[j], &bits, sizeof(bits));
+      }
+      metricValueVariant = std::move(values);
+      break;
+    }
+    default:
+      throw std::runtime_error("[PROTON] Unsupported metric type index: " +
+                               std::to_string(metricTypeIndex));
+      break;
+    }
+
+    wordOffset += metricDesc.size;
+
+    auto ordinalEntryIt = ordinalToEntryQueue.find(metricOrdinal);
+    if (ordinalEntryIt == ordinalToEntryQueue.end() ||
+        ordinalEntryIt->second.empty()) {
+      continue;
+    }
+    for (auto &[data, dataEntry] : ordinalEntryIt->second.front()) {
+      if (dataEntry.id != Scope::DummyScopeId) {
+        dataEntry.upsertLinkedFlexibleMetric(metricName, metricValueVariant,
+                                             dataEntry.id);
+      } else {
+        dataEntry.upsertFlexibleMetric(metricName, metricValueVariant);
       }
     }
+    ordinalEntryIt->second.pop_front();
+  }
+
+  size_t remainingRecords = 0;
+  for (const auto &[_, entries] : ordinalToEntryQueue) {
+    remainingRecords += entries.size();
+  }
+  if (remainingRecords != 0) {
+    throw std::runtime_error(
+        "[PROTON] Missing CUDA graph metric records during flush");
   }
 }
 } // namespace
 
 void PendingGraphPool::push(
-    size_t phase, const std::map<Data *, std::vector<DataEntry>> &dataToEntries,
+    size_t phase,
+    const std::map<uint64_t, std::map<Data *, DataEntry>> &ordinalToEntries,
     size_t numNodes, size_t numWords) {
   const size_t requiredBytes = bytesForWords(numWords);
   void *device = runtime->getDevice();
   std::shared_ptr<Slot> slot;
-  auto startBufferOffset = 0;
+  size_t startBufferOffset = 0;
   {
     std::lock_guard<std::mutex> lock(mutex);
     auto &devicePool = pool[device];
@@ -123,7 +153,7 @@ void PendingGraphPool::push(
     if (slot->queue == std::nullopt) {
       slot->queue = PendingGraphQueue(startBufferOffset, phase, device);
     }
-    slot->queue->push(numNodes, numWords, dataToEntries);
+    slot->queue->push(numNodes, numWords, ordinalToEntries);
   }
   {
     std::lock_guard<std::mutex> lock(mutex);
@@ -131,45 +161,18 @@ void PendingGraphPool::push(
         deviceRemainingCapacity.try_emplace(device, metricBuffer->getCapacity())
             .first->second;
     auto &bufferOffset = deviceBufferOffset[device];
-    bufferOffset = (bufferOffset + requiredBytes) % metricBuffer->getCapacity();
+    bufferOffset += requiredBytes;
     remainingCapacity -= requiredBytes;
   }
 }
 
 void PendingGraphPool::peek(size_t phase) {
-  std::vector<std::pair<void *, std::shared_ptr<Slot>>> slots;
-  {
-    std::lock_guard<std::mutex> lock(mutex);
-    for (auto &[device, devicePool] : pool) {
-      auto slotIt = devicePool.find(phase);
-      if (slotIt != devicePool.end()) {
-        slots.emplace_back(device, slotIt->second);
-      }
-    }
-    for (auto &[device, slotPtr] : slots) {
-      pool[device].erase(phase);
-    }
-  }
-  std::vector<std::pair<void *, size_t>> deviceNumWords;
-  for (auto &[device, slotPtr] : slots) {
-    std::lock_guard<std::mutex> slotLock(slotPtr->mutex);
-    if (!slotPtr->queue.has_value())
-      continue;
-    auto &queue = slotPtr->queue.value();
-    auto numWords = queue.numWords;
-    metricBuffer->peek(static_cast<Device *>(device), [&](uint8_t *hostPtr) {
-      emitMetricRecords(*metricBuffer, reinterpret_cast<uint64_t *>(hostPtr),
-                        queue);
-    });
-    deviceNumWords.emplace_back(device, numWords);
-    slotPtr->queue.reset();
-  }
-  {
-    std::lock_guard<std::mutex> lock(mutex);
-    for (auto &[device, numWords] : deviceNumWords) {
-      deviceRemainingCapacity[device] += bytesForWords(numWords);
-    }
-  }
+  (void)phase;
+  // Graph metric-copy kernels append records through device-side atomics, and
+  // the shared metric buffer order is the actual GPU execution order. A no-sync
+  // phase peek can observe only a prefix of that stream. Defer graph flexible
+  // metric decoding to synchronized flushAll(), where all records in the buffer
+  // can be scanned and matched back to queued graph launches by metric ordinal.
 }
 
 bool PendingGraphPool::flushIfNeeded(size_t numWords) {
@@ -201,15 +204,32 @@ bool PendingGraphPool::flushAll() {
         auto deviceIt = poolCopy.find(device);
         if (deviceIt == poolCopy.end())
           return;
+        auto combinedQueue = std::optional<PendingGraphQueue>(std::nullopt);
         for (auto &[_, slot] : deviceIt->second) {
           std::lock_guard<std::mutex> lock(slot->mutex);
           if (!slot->queue.has_value())
             continue;
-          deviceNumWords.emplace_back(device, slot->queue->numWords);
-          emitMetricRecords(*metricBuffer,
-                            reinterpret_cast<uint64_t *>(hostPtr),
-                            *slot->queue);
+          auto &queue = *slot->queue;
+          if (!combinedQueue.has_value()) {
+            combinedQueue.emplace(queue.startBufferOffset, queue.phase,
+                                  queue.device);
+          } else if (queue.startBufferOffset <
+                     combinedQueue->startBufferOffset) {
+            combinedQueue->startBufferOffset = queue.startBufferOffset;
+          }
+          combinedQueue->pendingGraphs.insert(
+              combinedQueue->pendingGraphs.end(), queue.pendingGraphs.begin(),
+              queue.pendingGraphs.end());
+          combinedQueue->numNodes += queue.numNodes;
+          combinedQueue->numWords += queue.numWords;
+          deviceNumWords.emplace_back(device, queue.numWords);
           slot->queue.reset();
+        }
+        if (combinedQueue.has_value()) {
+          emitMetricRecords(
+              *metricBuffer, reinterpret_cast<uint64_t *>(hostPtr),
+              *combinedQueue,
+              metricBuffer->getWrittenWords(static_cast<Device *>(device)));
         }
       },
       true);

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -38,9 +38,11 @@ class CudaAllocator:
 
         # Create the buffer
         import torch
-        enter_state(COMPUTE_METADATA_SCOPE_NAME)
-        buffer = torch.zeros((aligned_size, ), dtype=torch.uint8, device="cuda")
-        exit_state()
+        try:
+            enter_state(COMPUTE_METADATA_SCOPE_NAME)
+            buffer = torch.zeros((aligned_size, ), dtype=torch.uint8, device="cuda")
+        finally:
+            exit_state()
         self.instrumentation_hook.buffer = buffer
         return buffer
 

--- a/third_party/proton/proton/hooks/launch.py
+++ b/third_party/proton/proton/hooks/launch.py
@@ -1,4 +1,9 @@
-from ..state import enter_state, exit_state, COMPUTE_METADATA_SCOPE_NAME
+from ..state import (
+    enter_metadata_scope,
+    exit_metadata_scope,
+    is_metadata_state_active,
+    metadata_state_name,
+)
 from ..metric import transform_tensor_metrics, set_metric_kernels
 from triton.compiler import LazyDict
 from .hook import Hook
@@ -89,31 +94,56 @@ class LaunchHook(Hook):
         pass
 
     def enter(self, metadata: LazyDict) -> None:
+        if is_metadata_state_active():
+            enabled.set(False)
+            return
+
         # Fast path: if the kernel name is already available without evaluating launch_metadata,
         # apply include/exclude filters and potentially skip metadata evaluation entirely.
         kernel_name = metadata.data.get("name")
         if not self._matches_kernel_name(kernel_name):
             enabled.set(False)
             return
-        enter_state(COMPUTE_METADATA_SCOPE_NAME)
-        lazy_metadata = metadata.get()
-        exit_state()
+        metadata_scope_name = metadata_state_name(kernel_name)
+        metadata_scope_id = None
+        try:
+            metadata_scope_id = enter_metadata_scope(metadata_scope_name)
+            lazy_metadata = metadata.get()
 
-        kernel_name = lazy_metadata["name"]
-        # If name wasn't available (or changed), apply filters using the evaluated name.
-        if not self._matches_kernel_name(kernel_name):
-            enabled.set(False)
-            return
+            kernel_name = lazy_metadata["name"]
+            # If name wasn't available (or changed), apply filters using the evaluated name.
+            if not self._matches_kernel_name(kernel_name):
+                enabled.set(False)
+                return
 
-        enabled.set(True)
-        fn_metrics = LaunchHook._extract_metrics(lazy_metadata)
+            fn_metrics = LaunchHook._extract_metrics(lazy_metadata)
+            if fn_metrics:
+                set_metric_kernels()
+            scalar_metrics, tensor_metrics = transform_tensor_metrics(fn_metrics)
+        finally:
+            if metadata_scope_id is not None:
+                exit_metadata_scope(metadata_scope_id, metadata_scope_name)
+
         op_name.set(kernel_name)
         id.set(libproton.record_scope())
-        if fn_metrics:
-            set_metric_kernels()
-        scalar_metrics, tensor_metrics = transform_tensor_metrics(fn_metrics)
-        libproton.enter_op(id.get(), lazy_metadata["name"])
-        libproton.add_metrics(id.get(), scalar_metrics, tensor_metrics)
+        metadata_scope_id = None
+        op_entered = False
+        try:
+            libproton.enter_op(id.get(), lazy_metadata["name"])
+            op_entered = True
+            # Keep metric-copy kernels launched by add_metrics grouped with the
+            # launch metadata work that produced their values.
+            metadata_scope_id = enter_metadata_scope(metadata_scope_name)
+            libproton.add_metrics(id.get(), scalar_metrics, tensor_metrics)
+        except Exception:
+            if op_entered:
+                libproton.exit_op(id.get(), op_name.get())
+            raise
+        finally:
+            if metadata_scope_id is not None:
+                exit_metadata_scope(metadata_scope_id, metadata_scope_name)
+
+        enabled.set(True)
 
     def exit(self, metadata: LazyDict) -> None:
         if not enabled.get():

--- a/third_party/proton/proton/metric.py
+++ b/third_party/proton/proton/metric.py
@@ -4,14 +4,22 @@ import triton.runtime.driver as driver
 import triton.language as tl
 import triton
 from triton import MockTensor
-from .state import exit_state, enter_state, COMPUTE_METADATA_SCOPE_NAME
+from .state import (
+    COMPUTE_METADATA_SCOPE_NAME,
+    enter_state,
+    exit_state,
+    is_metadata_state_active,
+)
 
 
 @triton.jit
-def tensor_metric_kernel(device_ptr, device_offset_ptr, size: tl.uint64, metric_id: tl.uint64, metric_value_ptr,
-                         metric_value_size: tl.uint64):
+def tensor_metric_kernel(device_ptr, device_offset_ptr, size: tl.uint64, metric_ordinal: tl.uint64,
+                         metric_id: tl.uint64, metric_value_ptr, metric_value_size: tl.uint64):
     BLOCK_SIZE: tl.constexpr = 128
-    device_offset = tl.load(device_offset_ptr)
+    record_size = metric_value_size + 2
+    device_offset = tl.atomic_add(device_offset_ptr, record_size, sem="relaxed") % size
+    tl.store(device_ptr + device_offset, metric_ordinal)
+    device_offset = (device_offset + 1) % size
     tl.store(device_ptr + device_offset, metric_id)
     device_offset = (device_offset + 1) % size
     num_iters = tl.cdiv(metric_value_size, BLOCK_SIZE)
@@ -22,19 +30,18 @@ def tensor_metric_kernel(device_ptr, device_offset_ptr, size: tl.uint64, metric_
         metric_value = tl.load(metric_value_ptr + cur_offsets, mask=mask)
         tl.store(device_ptr + (device_offset + cur_offsets) % size, metric_value, mask=mask)
     tl.debug_barrier()
-    device_offset = (device_offset + metric_value_size) % size
-    tl.store(device_offset_ptr, device_offset)
 
 
 @triton.jit
-def scalar_metric_kernel(device_ptr, device_offset_ptr, size: tl.uint64, metric_id: tl.uint64, metric_value: tl.uint64):
-    device_offset = tl.load(device_offset_ptr)
+def scalar_metric_kernel(device_ptr, device_offset_ptr, size: tl.uint64, metric_ordinal: tl.uint64,
+                         metric_id: tl.uint64, metric_value: tl.uint64):
+    device_offset = tl.atomic_add(device_offset_ptr, 3, sem="relaxed") % size
+    tl.store(device_ptr + device_offset, metric_ordinal)
+    device_offset = (device_offset + 1) % size
     tl.store(device_ptr + device_offset, metric_id)
     device_offset = (device_offset + 1) % size
     tl.store(device_ptr + device_offset, metric_value)
-    device_offset = (device_offset + 1) % size
     tl.debug_barrier()
-    tl.store(device_offset_ptr, device_offset)
 
 
 def _get_kernel(kernel_fn, *args):
@@ -51,6 +58,7 @@ def _get_kernel(kernel_fn, *args):
 def set_metric_kernels():
     mock_ptr = MockTensor(tl.uint64)
     mock_metric_id = 0
+    mock_metric_ordinal = 0
     mock_size = 1
     mock_metric_value_size = 1
     tensor_metric_kernel_fn, tensor_metric_kernel_num_threads, tensor_metric_kernel_shared = _get_kernel(
@@ -58,6 +66,7 @@ def set_metric_kernels():
         mock_ptr,
         mock_ptr,
         mock_size,
+        mock_metric_ordinal,
         mock_metric_id,
         mock_ptr,
         mock_metric_value_size,
@@ -67,6 +76,7 @@ def set_metric_kernels():
         mock_ptr,
         mock_ptr,
         mock_size,
+        mock_metric_ordinal,
         mock_metric_id,
         mock_metric_id,
     )
@@ -97,24 +107,33 @@ def transform_tensor_metrics(metrics: dict[str, Any]) -> tuple[dict[str, Any], d
     for key, value in metrics.items():
         if hasattr(value, "data_ptr"):  # tensor
             if value.device.type == "cpu":
-                scalar_metrics[key] = value
+                scalar_metrics[key] = float(value) if key.startswith("flops") else value
             else:  # device tensor
-                enter_state(COMPUTE_METADATA_SCOPE_NAME)
-                # implicit casting to double or int64 tensors
-                if value.is_floating_point():
-                    value = value.double()
-                    if value.numel() > 1:
-                        metric_index = libproton.metric_type_vector_double_index
+                entered_state = False
+                try:
+                    if not is_metadata_state_active():
+                        enter_state(COMPUTE_METADATA_SCOPE_NAME)
+                        entered_state = True
+                    # Keep Proton's state balanced if a dtype conversion raises.
+                    # Keep metric descriptors type-stable across kernels. FLOP metrics
+                    # are always represented as doubles, even when computed by integer
+                    # counter kernels.
+                    if key.startswith("flops") or value.is_floating_point():
+                        value = value.double()
+                        if value.numel() > 1:
+                            metric_index = libproton.metric_type_vector_double_index
+                        else:
+                            metric_index = libproton.metric_type_double_index
                     else:
-                        metric_index = libproton.metric_type_double_index
-                else:
-                    value = value.long()
-                    if value.numel() > 1:
-                        metric_index = libproton.metric_type_vector_int64_index
-                    else:
-                        metric_index = libproton.metric_type_int64_index
-                exit_state()
+                        value = value.long()
+                        if value.numel() > 1:
+                            metric_index = libproton.metric_type_vector_int64_index
+                        else:
+                            metric_index = libproton.metric_type_int64_index
+                finally:
+                    if entered_state:
+                        exit_state()
                 tensor_metrics[key] = _TensorMetric(value, metric_index)
         else:
-            scalar_metrics[key] = value
+            scalar_metrics[key] = float(value) if key.startswith("flops") else value
     return scalar_metrics, tensor_metrics

--- a/third_party/proton/proton/state.py
+++ b/third_party/proton/proton/state.py
@@ -1,8 +1,12 @@
+from functools import wraps
+import threading
+
 from triton._C.libproton import proton as libproton
 from .flags import flags
-from functools import wraps
 
 COMPUTE_METADATA_SCOPE_NAME = "__proton_launch_metadata"
+COMPUTE_METADATA_SCOPE_PREFIX = f"{COMPUTE_METADATA_SCOPE_NAME}:"
+_thread_state = threading.local()
 
 
 class state:
@@ -33,24 +37,25 @@ class state:
     def __enter__(self):
         if not flags.profiling_on:
             return self
-        libproton.enter_state(self.name)
+        enter_state(self.name)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         if not flags.profiling_on:
             return
-        libproton.exit_state()
+        exit_state()
 
     def __call__(self, func):
 
         @wraps(func)
         def wrapper(*args, **kwargs):
             if flags.profiling_on:
-                libproton.enter_state(self.name)
-            ret = func(*args, **kwargs)
-            if flags.profiling_on:
-                libproton.exit_state()
-            return ret
+                enter_state(self.name)
+            try:
+                return func(*args, **kwargs)
+            finally:
+                if flags.profiling_on:
+                    exit_state()
 
         return wrapper
 
@@ -63,7 +68,43 @@ class metadata_state(state):
 
 def enter_state(name: str) -> None:
     libproton.enter_state(name)
+    _thread_state.name = name
 
 
 def exit_state() -> None:
     libproton.exit_state()
+    _thread_state.name = None
+
+
+def _current_state() -> str | None:
+    return getattr(_thread_state, "name", None)
+
+
+def metadata_state_name(kernel_name=None) -> str:
+    if not kernel_name:
+        return COMPUTE_METADATA_SCOPE_NAME
+    return f"{COMPUTE_METADATA_SCOPE_PREFIX}{kernel_name}"
+
+
+def enter_metadata_scope(name: str) -> int:
+    scope_id = libproton.record_scope()
+    libproton.enter_scope(scope_id, name)
+    try:
+        enter_state(name)
+    except Exception:
+        libproton.exit_scope(scope_id, name)
+        raise
+    return scope_id
+
+
+def exit_metadata_scope(scope_id: int, name: str) -> None:
+    try:
+        exit_state()
+    finally:
+        libproton.exit_scope(scope_id, name)
+
+
+def is_metadata_state_active() -> bool:
+    state_name = _current_state()
+    return bool(state_name
+                and (state_name == COMPUTE_METADATA_SCOPE_NAME or state_name.startswith(COMPUTE_METADATA_SCOPE_PREFIX)))

--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -41,7 +41,7 @@ def remove_frames(database: json):
     def remove_frame_helper(node):
         if "frame" not in node:
             return node
-        if node["frame"]["name"] == COMPUTE_METADATA_SCOPE_NAME:
+        if node["frame"]["name"].startswith(COMPUTE_METADATA_SCOPE_NAME):
             return None
         if len(node["metrics"]) == 0 and len(node["children"]) == 0:
             return None

--- a/third_party/proton/test/test_instrumentation.py
+++ b/third_party/proton/test/test_instrumentation.py
@@ -32,6 +32,16 @@ pytestmark = pytest.mark.skipif(is_hip_cdna2(), reason="old AMD GPUs are not sup
 HAS_WARP_SPECIALIZE = supports_ws() and supports_tma()
 
 
+def find_frame(node, name: str):
+    queue = [node]
+    while queue:
+        current = queue.pop(0)
+        if "frame" in current and current["frame"]["name"] == name:
+            return current
+        queue.extend(current.get("children", []))
+    return None
+
+
 @pytest.mark.parametrize(
     "mode",
     [
@@ -304,8 +314,11 @@ def test_tree(tmp_path: pathlib.Path, hook):
     with open(temp_file, "rb") as f:
         data = json.load(f)
         if hook:
-            assert "add_1024" == data[0]["children"][0]["frame"]["name"]
-        kernel_frame = data[0]["children"][0]["children"][0]
+            owner_frame = find_frame(data[0], "add_1024")
+            assert owner_frame is not None
+            kernel_frame = owner_frame["children"][0]
+        else:
+            kernel_frame = data[0]["children"][0]["children"][0]
         load_ops = kernel_frame["children"][0]
         assert "load_ops" in load_ops["frame"]["name"]
         assert ("load_x" in load_ops["children"][0]["frame"]["name"]

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -13,10 +13,31 @@ import pathlib
 import threading
 
 import triton.language as tl
-from triton.profiler.hooks.launch import COMPUTE_METADATA_SCOPE_NAME
 import triton.profiler.hooks.launch as proton_launch
+from triton.profiler.state import COMPUTE_METADATA_SCOPE_NAME
 import triton.profiler.viewer as viewer
 from triton._internal_testing import is_hip, is_cuda, is_blackwell
+
+
+def find_frame(node, name: str):
+    queue = [node]
+    while queue:
+        current = queue.pop(0)
+        if current["frame"]["name"] == name:
+            return current
+        queue.extend(current["children"])
+    return None
+
+
+def find_frame_path(node, name_substr: str):
+    queue = [(node, [node])]
+    while queue:
+        current, path = queue.pop(0)
+        if name_substr in current["frame"]["name"]:
+            return path
+        for child in current["children"]:
+            queue.append((child, [*path, child]))
+    return None
 
 
 @pytest.mark.parametrize("context", ["shadow", "python"])
@@ -546,12 +567,13 @@ def test_hook_launch(tmp_path: pathlib.Path, device: str):
     proton.finalize()
     with temp_file.open() as f:
         data = json.load(f)
-    assert len(data[0]["children"]) == 1
-    assert data[0]["children"][0]["frame"]["name"] == "test0"
-    assert data[0]["children"][0]["children"][0]["frame"]["name"] == "foo_test_1ctas_1elems"
-    assert data[0]["children"][0]["children"][0]["metrics"]["flops32"] == 1.0
-    assert data[0]["children"][0]["children"][0]["metrics"]["extra_metric"] == 7.0
-    assert data[0]["children"][0]["children"][0]["metrics"]["time (ns)"] > 0
+    test0_frame = find_frame(data[0], "test0")
+    assert test0_frame is not None
+    foo_frame = find_frame(test0_frame, "foo_test_1ctas_1elems")
+    assert foo_frame is not None
+    assert foo_frame["metrics"]["flops32"] == 1.0
+    assert foo_frame["metrics"]["extra_metric"] == 7.0
+    assert foo_frame["metrics"]["time (ns)"] > 0
 
 
 def test_hook_launch_filter(tmp_path: pathlib.Path, device: str):
@@ -641,9 +663,314 @@ def test_hook_launch_context(tmp_path: pathlib.Path, context: str, device: str):
         parent_frame = queue.pop(0)
         for child in parent_frame["children"]:
             if "reduce" in child["frame"]["name"]:
-                assert parent_frame["frame"]["name"] == COMPUTE_METADATA_SCOPE_NAME
+                assert parent_frame["frame"]["name"].startswith(COMPUTE_METADATA_SCOPE_NAME)
                 return
             queue.append(child)
+
+
+def test_hook_launch_metadata_work_grouped_by_owner_matmul(tmp_path: pathlib.Path, monkeypatch, device: str):
+    """Check the eager before/after profile shape for owner-scoped metadata.
+
+    metadata_fn launches Triton helper kernels and returns tensor metrics. The
+    monkeypatched transform hook launches one more marker kernel to stand in for
+    GPU work from transform_tensor_metrics, such as dtype casts. All of those
+    kernels should be grouped under __proton_launch_metadata:<owner>, while the
+    real matmul frame owns the flops/bytes metrics.
+    """
+    owner_name = "owner_matmul_test"
+    owner_metadata_scope = f"{COMPUTE_METADATA_SCOPE_NAME}:{owner_name}"
+
+    @triton.jit
+    def matmul_metadata_counter_kernel(a, metadata_flops, metadata_bytes, BLOCK: tl.constexpr):
+        offs = tl.arange(0, BLOCK)
+        flops = tl.sum(tl.load(a + offs).to(tl.float32), axis=0)
+        tl.store(metadata_flops, flops)
+        tl.store(metadata_bytes, BLOCK * BLOCK * 4)
+
+    @triton.jit
+    def matmul_metadata_scoped_kernel(metadata_flops):
+        tl.store(metadata_flops, tl.load(metadata_flops) + 1.0)
+
+    @triton.jit
+    def matmul_metadata_transform_marker_kernel(metadata_flops, transform_scratch):
+        tl.store(transform_scratch, tl.load(metadata_flops) + 2.0)
+
+    def metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        matmul_metadata_counter_kernel[(1, )](
+            args["a"],
+            args["metadata_flops"],
+            args["metadata_bytes"],
+            BLOCK=args["BLOCK"],
+            num_warps=1,
+        )
+        with proton.scope("matmul_metadata_child_scope"):
+            matmul_metadata_scoped_kernel[(1, )](args["metadata_flops"], num_warps=1)
+        return {
+            "name": owner_name,
+            "flops": args["metadata_flops"],
+            "bytes": args["metadata_bytes"],
+        }
+
+    @triton.jit(repr=lambda _: owner_name, launch_metadata=metadata_fn)
+    def owner_matmul_kernel(a, b, c, metadata_flops, metadata_bytes, BLOCK: tl.constexpr):
+        offs = tl.arange(0, BLOCK)
+        a_tile = tl.load(a + offs[:, None] * BLOCK + offs[None, :])
+        b_tile = tl.load(b + offs[:, None] * BLOCK + offs[None, :])
+        acc = tl.dot(a_tile, b_tile)
+        tl.store(c + offs[:, None] * BLOCK + offs[None, :], acc)
+
+    transform_scratch = torch.empty((1, ), device=device, dtype=torch.float32)
+    original_transform_tensor_metrics = proton_launch.transform_tensor_metrics
+
+    def transform_tensor_metrics_with_marker(metrics):
+        matmul_metadata_transform_marker_kernel[(1, )](
+            metrics["flops"],
+            transform_scratch,
+            num_warps=1,
+        )
+        return original_transform_tensor_metrics(metrics)
+
+    monkeypatch.setattr(proton_launch, "transform_tensor_metrics", transform_tensor_metrics_with_marker)
+
+    block = 16
+    a = torch.randn((block, block), device=device, dtype=torch.float16)
+    b = torch.randn((block, block), device=device, dtype=torch.float16)
+    c = torch.empty((block, block), device=device, dtype=torch.float32)
+    metadata_flops = torch.empty((1, ), device=device, dtype=torch.float32)
+    metadata_bytes = torch.empty((1, ), device=device, dtype=torch.int32)
+    temp_file = tmp_path / "test_hook_metadata_owner_matmul.hatchet"
+
+    proton.start(str(temp_file.with_suffix("")), hook="triton")
+    with proton.scope("test0"):
+        owner_matmul_kernel[(1, )](
+            a,
+            b,
+            c,
+            metadata_flops,
+            metadata_bytes,
+            BLOCK=block,
+            num_warps=4,
+        )
+    proton.finalize()
+
+    with temp_file.open() as f:
+        data = json.load(f)
+
+    owner_frame = find_frame(data[0], owner_name)
+    assert owner_frame is not None
+    assert "flops" in owner_frame["metrics"]
+    assert "bytes" in owner_frame["metrics"]
+    assert find_frame(data[0], owner_metadata_scope) is not None
+    assert find_frame(data[0], COMPUTE_METADATA_SCOPE_NAME) is None
+
+    for kernel_name in [
+            "matmul_metadata_counter_kernel",
+            "matmul_metadata_scoped_kernel",
+            "matmul_metadata_transform_marker_kernel",
+    ]:
+        path = find_frame_path(data[0], kernel_name)
+        assert path is not None
+        path_names = [node["frame"]["name"] for node in path]
+        assert owner_metadata_scope in path_names
+        assert path_names.index(owner_metadata_scope) < len(path_names) - 1
+
+    scoped_path_names = [node["frame"]["name"] for node in find_frame_path(data[0], "matmul_metadata_scoped_kernel")]
+    assert (scoped_path_names.index(owner_metadata_scope) < scoped_path_names.index("matmul_metadata_child_scope") <
+            len(scoped_path_names) - 1)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports CUDA graph resource callbacks")
+def test_hook_launch_metadata_cudagraph_metric_copy_under_metadata_scope(tmp_path: pathlib.Path, device: str):
+    """Keep graph metric-copy kernels under the owner launch metadata scope.
+
+    Tensor launch metadata makes add_metrics launch a Proton metric-copy kernel
+    during CUDA graph capture. That <metric> node should be grouped under the
+    same __proton_launch_metadata:<owner> scope as the metadata kernels whose
+    values it copies, while the owner kernel remains a sibling of that metadata
+    scope. Metadata helper kernels can still have child Proton scopes; moving
+    <metric> under the metadata owner must not flatten those child scopes.
+    """
+    owner_name = "foo_metric_scope"
+    owner_metadata_scope = f"{COMPUTE_METADATA_SCOPE_NAME}:{owner_name}"
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    @triton.jit
+    def metadata_before_metric_kernel(x, scratch):
+        tl.store(scratch, tl.load(x) + 1.0)
+
+    @triton.jit
+    def metadata_after_metric_kernel(scratch, scratch2):
+        tl.store(scratch2, tl.load(scratch) + 2.0)
+
+    def metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        metadata_before_metric_kernel[(1, )](args["x"], args["scratch"], num_warps=1)
+        with proton.scope("metadata_child_scope"):
+            metadata_after_metric_kernel[(1, )](args["scratch"], args["scratch2"], num_warps=1)
+        return {"name": owner_name, "flops": args["scratch2"].sum()}
+
+    @triton.jit(repr=lambda _: owner_name, launch_metadata=metadata_fn)
+    def foo(x, scratch, scratch2, y):
+        tl.store(y, tl.load(x) + tl.load(scratch2))
+
+    x = torch.tensor([2], device=device, dtype=torch.float32)
+    scratch = torch.zeros_like(x)
+    scratch2 = torch.zeros_like(x)
+    y = torch.zeros_like(x)
+    temp_file = tmp_path / "test_hook_metadata_metric_scope.chrome_trace"
+    session = proton.start(str(temp_file.with_suffix("")), data="trace", context="shadow", hook="triton")
+    try:
+        foo[(1, )](x, scratch, scratch2, y, num_warps=1)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            foo[(1, )](x, scratch, scratch2, y, num_warps=1)
+
+        with proton.scope("replay"):
+            graph.replay()
+        torch.cuda.synchronize()
+    finally:
+        proton.finalize(session)
+
+    with temp_file.open() as f:
+        trace_events = json.load(f)["traceEvents"]
+
+    replay_kernel_events = [
+        event for event in trace_events
+        if event.get("cat") == "kernel" and event.get("args", {}).get("call_stack", [])[:2] == ["ROOT", "replay"]
+    ]
+    metric_kernel_events = [event for event in replay_kernel_events if event["name"] == "<metric>"]
+    owner_kernel_events = [event for event in replay_kernel_events if event["name"] == owner_name]
+    metadata_kernel_events = [
+        event for event in replay_kernel_events if any(
+            name.startswith(COMPUTE_METADATA_SCOPE_NAME) for name in event.get("args", {}).get("call_stack", []))
+    ]
+    metadata_kernel_events_by_name = {event["name"]: event for event in metadata_kernel_events}
+    expected_metadata_parent = [
+        "ROOT",
+        "replay",
+        "<captured_at>",
+        owner_metadata_scope,
+    ]
+
+    assert len(metric_kernel_events) == 1
+    assert metric_kernel_events[0]["args"]["call_stack"] == [
+        *expected_metadata_parent,
+        "<metric>",
+    ]
+    assert {
+        "metadata_before_metric_kernel",
+        "metadata_after_metric_kernel",
+    }.issubset(metadata_kernel_events_by_name)
+    assert metadata_kernel_events_by_name["metadata_before_metric_kernel"]["args"]["call_stack"] == [
+        *expected_metadata_parent,
+        "metadata_before_metric_kernel",
+    ]
+    assert metadata_kernel_events_by_name["metadata_after_metric_kernel"]["args"]["call_stack"] == [
+        *expected_metadata_parent,
+        "metadata_child_scope",
+        "metadata_after_metric_kernel",
+    ]
+    assert len(owner_kernel_events) == 1
+    assert owner_kernel_events[0]["args"]["call_stack"] == [
+        "ROOT",
+        "replay",
+        "<captured_at>",
+        owner_name,
+    ]
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
+def test_hook_launch_metadata_cudagraph_metric_records_attach_by_owner(tmp_path: pathlib.Path, device: str):
+    """Exercise graph metric records whose GPU append order can differ from CPU order.
+
+    The slow kernel is launched first during capture, so the old positional
+    pending queue would expect its tensor metric record first. Its metadata runs
+    a long helper kernel before Proton launches the metric-copy kernel. The fast
+    kernel is launched second on an independent stream and can append its metric
+    record first during graph replay. Correctness must therefore come from the
+    per-record owner identity, not from pending queue position.
+    """
+    capture_stream = torch.cuda.Stream()
+    slow_stream = torch.cuda.Stream()
+    fast_stream = torch.cuda.Stream()
+    torch.cuda.set_stream(capture_stream)
+
+    slow_name = "metric_order_slow"
+    fast_name = "metric_order_fast"
+    slow_flops = 111.0
+    fast_flops = 222.0
+
+    @triton.jit
+    def metadata_delay_kernel(scratch, BLOCK: tl.constexpr, ITERS: tl.constexpr):
+        pid = tl.program_id(0)
+        offsets = pid * BLOCK + tl.arange(0, BLOCK)
+        values = offsets.to(tl.float32)
+        for _ in tl.static_range(0, ITERS):
+            values = values * 1.0001 + 1.0
+        tl.store(scratch + offsets, values)
+
+    def slow_metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        metadata_delay_kernel[(2048, )](args["delay_scratch"], BLOCK=256, ITERS=64, num_warps=8)
+        return {"name": slow_name, "flops": args["slow_metric"]}
+
+    def fast_metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        return {"name": fast_name, "flops": args["fast_metric"]}
+
+    @triton.jit(launch_metadata=slow_metadata_fn)
+    def slow_kernel(x, y, slow_metric, delay_scratch):
+        tl.store(y, tl.load(x) + 1.0)
+
+    @triton.jit(launch_metadata=fast_metadata_fn)
+    def fast_kernel(x, y, fast_metric):
+        tl.store(y, tl.load(x) + 2.0)
+
+    x = torch.tensor([1.0], device=device)
+    y_slow = torch.empty_like(x)
+    y_fast = torch.empty_like(x)
+    slow_metric = torch.tensor([slow_flops], device=device)
+    fast_metric = torch.tensor([fast_flops], device=device)
+    delay_scratch = torch.empty((2048 * 256, ), device=device)
+
+    temp_file = tmp_path / "test_hook_metadata_metric_record_order.hatchet"
+    session = proton.start(str(temp_file.with_suffix("")), context="shadow", hook="triton")
+    try:
+        # Warm up compilation and allocations before graph capture.
+        slow_kernel[(1, )](x, y_slow, slow_metric, delay_scratch, num_warps=1)
+        fast_kernel[(1, )](x, y_fast, fast_metric, num_warps=1)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=capture_stream):
+            slow_stream.wait_stream(capture_stream)
+            fast_stream.wait_stream(capture_stream)
+            with torch.cuda.stream(slow_stream):
+                slow_kernel[(1, )](x, y_slow, slow_metric, delay_scratch, num_warps=1)
+            with torch.cuda.stream(fast_stream):
+                fast_kernel[(1, )](x, y_fast, fast_metric, num_warps=1)
+            capture_stream.wait_stream(slow_stream)
+            capture_stream.wait_stream(fast_stream)
+
+        with proton.scope("replay"):
+            graph.replay()
+        torch.cuda.synchronize()
+    finally:
+        proton.finalize(session)
+
+    with temp_file.open() as f:
+        data = json.load(f)
+
+    replay_frame = find_frame(data[0], "replay")
+    assert replay_frame is not None
+    capture_frame = find_frame(replay_frame, "<captured_at>")
+    assert capture_frame is not None
+    slow_frame = find_frame(capture_frame, slow_name)
+    fast_frame = find_frame(capture_frame, fast_name)
+    assert slow_frame is not None
+    assert fast_frame is not None
+    assert slow_frame["metrics"]["flops"] == slow_flops
+    assert fast_frame["metrics"]["flops"] == fast_flops
 
 
 def test_hook_with_third_party(tmp_path: pathlib.Path, device: str):
@@ -676,9 +1003,9 @@ def test_hook_with_third_party(tmp_path: pathlib.Path, device: str):
     triton.knobs.runtime.launch_enter_hook.remove(third_party_hook)
     with temp_file.open() as f:
         data = json.load(f)
-    assert len(data[0]["children"]) == 1
-    assert data[0]["children"][0]["frame"]["name"] == "foo_test"
-    assert data[0]["children"][0]["metrics"]["time (ns)"] > 0
+    foo_frame = find_frame(data[0], "foo_test")
+    assert foo_frame is not None
+    assert foo_frame["metrics"]["time (ns)"] > 0
 
 
 def test_hook_multiple_threads(tmp_path: pathlib.Path, device: str):
@@ -732,11 +1059,12 @@ def test_hook_multiple_threads(tmp_path: pathlib.Path, device: str):
 
     with temp_file.open() as f:
         data = json.load(f)
-    root = data[0]["children"]
-    assert "foo_test" in root[0]["frame"]["name"] or root[1]["frame"]["name"]
-    assert "bar_test" in root[0]["frame"]["name"] or root[1]["frame"]["name"]
-    assert root[0]["metrics"]["count"] == 100
-    assert root[1]["metrics"]["count"] == 100
+    foo_frame = find_frame(data[0], "foo_test")
+    bar_frame = find_frame(data[0], "bar_test")
+    assert foo_frame is not None
+    assert bar_frame is not None
+    assert foo_frame["metrics"]["count"] == 100
+    assert bar_frame["metrics"]["count"] == 100
 
 
 def test_pcsampling(tmp_path: pathlib.Path, device: str):
@@ -1367,30 +1695,15 @@ def test_tensor_metrics_cudagraph(tmp_path: pathlib.Path, device: str):
     with temp_file.open() as f:
         data = json.load(f)
 
-    children = data[0]["children"]
-    # metadata scope + kernels + scope_a + scope_b + test0 + scope_d
-    assert len(children) == 8
-    test0_frame = None
-    for child in children:
-        if child["frame"]["name"] == "test0":
-            test0_frame = child
-            break
+    test0_frame = find_frame(data[0], "test0")
     assert test0_frame is not None
-    capture_at_frame = test0_frame["children"][0]
+    capture_at_frame = find_frame(test0_frame, "<captured_at>")
+    assert capture_at_frame is not None
 
-    foo_test_frame = None
-    scope_a_frame = None
-    scope_b_frame = None
-    scope_d_frame = None
-    for child in capture_at_frame["children"]:
-        if child["frame"]["name"] == "foo_test":
-            foo_test_frame = child
-        if child["frame"]["name"] == "scope_a":
-            scope_a_frame = child
-        if child["frame"]["name"] == "scope_b":
-            scope_b_frame = child
-        if child["frame"]["name"] == "scope_d":
-            scope_d_frame = child
+    foo_test_frame = find_frame(capture_at_frame, "foo_test")
+    scope_a_frame = find_frame(capture_at_frame, "scope_a")
+    scope_b_frame = find_frame(capture_at_frame, "scope_b")
+    scope_d_frame = find_frame(capture_at_frame, "scope_d")
     assert foo_test_frame is not None
     assert foo_test_frame["metrics"]["bytes"] == 160
     assert foo_test_frame["metrics"]["flops"] == 40

--- a/third_party/proton/test/test_viewer.py
+++ b/third_party/proton/test/test_viewer.py
@@ -1,7 +1,7 @@
 import pytest
 import subprocess
 from triton.profiler.viewer import get_min_time_flops, get_min_time_bytes, read, format_frames, derive_metrics, filter_frames, parse, apply_diff_profile
-from triton.profiler.hooks.launch import COMPUTE_METADATA_SCOPE_NAME
+from triton.profiler.state import COMPUTE_METADATA_SCOPE_NAME
 import numpy as np
 
 file_path = __file__


### PR DESCRIPTION
## Why

This PR fixes two related Proton problems for Triton `launch_metadata` with CUDA graphs:

1. Metadata-side GPU work was hard to separate from real compute. When `launch_metadata` launches helper kernels to compute tensor metrics, those kernels should be visible under a metadata parent, while the real compute kernel keeps the reported `flops` / `bytes` metrics.
2. CUDA graph replay metric attachment was order-dependent. During capture, Proton queues metric targets in CPU callback order: metric node A belongs to compute kernel A, metric node B belongs to compute kernel B. During replay, the metric-copy kernels write into one shared metric buffer from GPU code. Those writes happen when the graph nodes actually execute, and CUDA is free to run independent graph nodes from different streams, branches, or graph-exec launches in an order that differs from CUPTI graph-node creation/callback order. The old decoder assumed "next record in the buffer == next pending target". If metric-copy node B appends before metric-copy node A, positional decode can attach B's `flops` / `bytes` to kernel A.

Expected profile shape:

```text
compute_kernel_x                       # has flops/bytes/util metrics
__proton_launch_metadata:compute_kernel_x
  <metric>
  metadata_helper_kernel
  metadata-side aten/triton work
```

## What Changed

### Owner-scoped metadata work

- `third_party/proton/proton/state.py`
  - Adds owner metadata names like `__proton_launch_metadata:<kernel>` and helpers to enter/exit them as both Proton scopes and Proton state.
  - Tracks the active metadata state in Python so recursive Triton launches from metadata evaluation can be ignored by `LaunchHook`.
- `third_party/proton/proton/hooks/launch.py`
  - Evaluates `LazyDict` launch metadata inside the owner metadata scope.
  - Skips hook recursion while metadata work is already active.
  - Calls `add_metrics()` under the same owner metadata scope so `<metric>` kernels appear below `__proton_launch_metadata:<kernel>` instead of as unrelated work.
- `third_party/proton/proton/metric.py`
  - Keeps tensor metric dtype conversions under metadata state so their helper kernels are grouped with the metadata owner.
- `third_party/proton/proton/hooks/instrumentation.py`
  - Balances metadata state with `finally` while allocating instrumentation buffers.
- `third_party/proton/csrc/include/Context/Context.h`
  - Avoids duplicating a metadata context when the same metadata name is present as both scope and state.
- `third_party/proton/proton/viewer.py`, `third_party/proton/test/test_viewer.py`
  - Treats all `__proton_launch_metadata:*` scopes like the existing metadata scope for default viewer filtering.

### Deterministic CUDA graph metric attachment

- `third_party/proton/proton/metric.py`
  - Metric-copy kernels now write `[metric_ordinal, metric_id, values...]` records.
  - Uses a device-side atomic offset reservation so graph replay records can be decoded in actual GPU append order.
- `third_party/proton/csrc/include/Data/Metric.h`, `third_party/proton/csrc/lib/Data/Metric.cpp`
  - Passes per-metric ordinals into metric-copy kernels.
  - Exposes the written metric-buffer word count needed by graph flush decode.
- `third_party/proton/csrc/include/Profiler/GPUProfiler.h`
  - Assigns monotonically increasing ordinals while capturing graph metric kernels and stores each metric record size.
- `third_party/proton/csrc/include/Profiler/Graph.h`, `third_party/proton/csrc/lib/Profiler/Graph.cpp`
  - Queues pending graph metric targets by ordinal instead of by position.
  - On synchronized flush, scans the metric buffer in actual append order and attaches each record to the matching ordinal target.
  - Defers graph metric decode from no-sync `peek()` because partial GPU append order is not safe to decode positionally.
- `third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp`
  - Stores metric graph nodes with `{num_words, ordinal}`.
  - Routes metric records to the owning compute kernel's flexible metric entry while keeping metric-copy kernels under the metadata scope in the trace tree.
  - Tracks graph source ids and graph-exec ids separately so replay cannot pick up stale source graph metadata when CUPTI reports distinct ids.

### Tests

- `third_party/proton/test/test_profile.py`
  - Adds coverage for owner-scoped eager metadata work, CUDA graph metric-copy grouping, graph tensor metrics, and stable lookup of frames after metadata nodes are inserted.
  - Adds `test_hook_launch_metadata_cudagraph_metric_records_attach_by_owner`, a targeted repro close to the full-model failure: two tensor-metric launches are captured into one CUDA graph on independent streams. The first launch is recorded first on the CPU side but runs a long metadata helper before its metric-copy kernel, allowing the second launch's metric-copy kernel to append first on replay. Without ordinal matching, the two `flops` values swap owners; with this PR, they stay attached to `metric_order_slow` and `metric_order_fast`.
  - Existing CUDA graph tensor metric tests (`test_tensor_metrics_cudagraph`, `test_tensor_metrics_multi_device_cudagraph`, `test_periodic_flushing_cudagraph`) continue to validate that replayed tensor metrics attach to intended frames and aggregate to expected values.
- `third_party/proton/test/test_instrumentation.py`
  - Makes instrumentation tree assertions robust to metadata grouping nodes.

## Simplification Done

- Squashed the branch to one commit.
- Removed the native `get_state` API and Python compatibility fallback; metadata state is now tracked only where it is needed.
- Removed redundant metadata tests covered by the owner-scoped eager and CUDA graph metric-copy tests.
- Removed debug-only logging/env plumbing from the final diff.

## Testing

- `pre-commit run clang-format --files third_party/proton/csrc/include/Context/Context.h third_party/proton/csrc/include/Data/Metric.h third_party/proton/csrc/include/Profiler/GPUProfiler.h third_party/proton/csrc/include/Profiler/Graph.h third_party/proton/csrc/lib/Data/Metric.cpp third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp third_party/proton/csrc/lib/Profiler/Graph.cpp`
- `pre-commit run yapf --files third_party/proton/proton/state.py third_party/proton/proton/metric.py third_party/proton/proton/hooks/launch.py third_party/proton/proton/hooks/instrumentation.py third_party/proton/proton/viewer.py third_party/proton/test/test_instrumentation.py third_party/proton/test/test_profile.py third_party/proton/test/test_viewer.py`
- `python3 -m ruff check third_party/proton/proton/state.py third_party/proton/proton/metric.py third_party/proton/proton/hooks/launch.py third_party/proton/proton/hooks/instrumentation.py third_party/proton/proton/viewer.py third_party/proton/test/test_instrumentation.py third_party/proton/test/test_profile.py third_party/proton/test/test_viewer.py`
- `python3 -m py_compile third_party/proton/proton/state.py third_party/proton/proton/metric.py third_party/proton/proton/hooks/launch.py third_party/proton/proton/hooks/instrumentation.py third_party/proton/proton/viewer.py third_party/proton/test/test_instrumentation.py third_party/proton/test/test_profile.py third_party/proton/test/test_viewer.py`
- `git diff --check`
- Remote targeted repro on `qnie-f29-16pods-0` before installing the PR build:
  - `python -m pytest third_party/proton/test/test_profile.py::test_hook_launch_metadata_cudagraph_metric_records_attach_by_owner -q -s`
  - Failed as expected: `metric_order_slow` got `222.0` instead of `111.0`.
- Remote targeted repro on `qnie-f29-16pods-0` after `python -m pip install -e ~/code/triton` from this branch:
  - Same pytest command passed: `1 passed in 2.38s`.


