### PR TITLE
Extend tensor memory (Blackwell) optimizations

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -119,7 +119,8 @@ LinearLayout getTileLayout(MLIRContext *ctx, TMemAccessAtom atom, bool unpacked,
 
 TMemAllocation getTmemAllocSizes(gpu::MemDescType memDescType);
 
-uint32_t getTMemSubSliceOffset(gpu::MemDescType memDescType, int32_t nOffset);
+uint32_t getTMemSubSliceOffset(gpu::MemDescType memDescType, int32_t mOffset,
+                               int32_t nOffset);
 
 SmallVector<gpu::DistributedEncodingTrait>
 getTmemCompatibleLayouts(gpu::MemDescType memType, unsigned numWarps,

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -942,10 +942,15 @@ def TTNG_TMEMSubSliceOp : TTNG_Op<"tmem_subslice", [Pure,
   let description = [{
     This operation takes a subslice of a tensor memory allocation and returns a new descriptor
     containing the address and a view of the subslice.
-    This is similar to ttg.memdesc_subslice except we can only slice along the inner dimension
-    of a 2D memdesc as this is the only one we can do for TMem.
+    This is similar to ttg.memdesc_subslice. The N offset selects a sub-range of the inner
+    dimension. The M offset selects a sub-range of the outer dimension and must be a multiple
+    of blockM; it is used to address an individual block of a multi-block (M > blockM)
+    allocation. The result type encodes the new shape; the size of each subsliced dimension
+    comes from the corresponding dim of the result type.
   }];
-  let arguments = (ins TTG_MemDescType:$src, I32Attr:$N);
+  let arguments = (ins TTG_MemDescType:$src,
+                       DefaultValuedAttr<I32Attr, "0">:$M,
+                       I32Attr:$N);
 
   let assemblyFormat = [{
     $src attr-dict `:` qualified(type($src)) `->` qualified(type($result))
@@ -953,6 +958,8 @@ def TTNG_TMEMSubSliceOp : TTNG_Op<"tmem_subslice", [Pure,
 
   let builders = [
       OpBuilder<(ins "Value":$alloc, "int":$offset, "int":$size)>,
+      OpBuilder<(ins "Value":$alloc, "int":$mOffset, "int":$mSize,
+                     "int":$nOffset, "int":$nSize)>,
     ];
   let results = (outs TTG_MemDescType:$result);
   let hasVerifier = 1;

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -258,7 +258,7 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     RegionInfo in = operands[0]->getValue();
     uint32_t subBufferSize = getMemDescSize(tmemSubsliceOp.getType());
     uint32_t relativeOffset = ttng::getTMemSubSliceOffset(
-        tmemSubsliceOp.getType(), tmemSubsliceOp.getN());
+        tmemSubsliceOp.getType(), tmemSubsliceOp.getM(), tmemSubsliceOp.getN());
     for (auto &region : in.regions) {
       regionInfo.regions.insert(
           {region.baseOffset + relativeOffset, subBufferSize});

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -92,13 +92,19 @@ TMemAllocation getTmemAllocSizes(MemDescType memDescType) {
   return {nRow, nCol};
 }
 
-uint32_t getTMemSubSliceOffset(MemDescType memDescType, int32_t nOffset) {
+uint32_t getTMemSubSliceOffset(MemDescType memDescType, int32_t mOffset,
+                               int32_t nOffset) {
   auto llInv = toLinearLayout(memDescType).pseudoinvert();
   auto dimNames = llvm::to_vector(llInv.getInDimNames());
   SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;
   logicalOffsets.reserve(dimNames.size());
   for (auto dim : dimNames)
     logicalOffsets.push_back({dim, 0});
+  // The pseudoinverse maps logical (M, N) -> physical (row, col). Setting both
+  // dims gives us the combined physical offset, which works for any layout
+  // that puts M-extension data into either rows or cols.
+  assert(dimNames.size() >= 2);
+  logicalOffsets[dimNames.size() - 2].second = mOffset;
   logicalOffsets.back().second = nOffset;
 
   auto rowCol = llInv.apply(logicalOffsets);

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1481,15 +1481,31 @@ LogicalResult TMEMSubSliceOp::verify() {
     return emitOpError("The result must be a 2D tensor memory buffer.");
   if (dstTy.getRank() != 2)
     return emitOpError("The result must be a 2D tensor memory buffer.");
-  if (dstTy.getDimSize(0) != srcTy.getDimSize(0))
-    return emitOpError("The result must have the same number of rows as the "
-                       "source.");
-  auto offset = getN();
-  if (offset & (dstTy.getDimSize(1) - 1)) {
-    return emitError("The split offset may not touch the tile");
+  auto nOffset = getN();
+  if (nOffset & (dstTy.getDimSize(1) - 1)) {
+    return emitError("The N split offset may not touch the tile");
   }
-  if (offset >= srcTy.getDimSize(1)) {
-    return emitError("The split offset may not exceed the source shape");
+  if (nOffset >= srcTy.getDimSize(1)) {
+    return emitError("The N split offset may not exceed the source shape");
+  }
+  // M-direction subslicing: the result M dim must be a multiple of blockM,
+  // and the M offset must be aligned to blockM. This restricts M-subslicing
+  // to selecting whole blocks of a multi-block (M > blockM) source.
+  auto mOffset = getM();
+  int64_t blockM = encoding.getBlockM();
+  if (dstTy.getDimSize(0) != srcTy.getDimSize(0)) {
+    if (dstTy.getDimSize(0) % blockM != 0)
+      return emitError("The result M dim must be a multiple of blockM");
+    if (mOffset % blockM != 0)
+      return emitError("The M split offset must be a multiple of blockM");
+  }
+  if (mOffset + dstTy.getDimSize(0) > srcTy.getDimSize(0)) {
+    return emitError("The M split offset + result M dim may not exceed the "
+                     "source shape");
+  }
+  if (mOffset != 0 && dstTy.getDimSize(0) == srcTy.getDimSize(0)) {
+    return emitError("Non-zero M split offset requires a smaller result M "
+                     "dim");
   }
 
   return success();
@@ -1501,7 +1517,18 @@ void TMEMSubSliceOp::build(OpBuilder &builder, OperationState &state,
   SmallVector<int64_t> shape(allocTy.getShape());
   shape.back() = size;
   auto subsliceType = allocTy.cloneWith(shape, allocTy.getElementType());
-  build(builder, state, subsliceType, alloc, offset);
+  build(builder, state, subsliceType, alloc, /*M=*/0, offset);
+}
+
+void TMEMSubSliceOp::build(OpBuilder &builder, OperationState &state,
+                           Value alloc, int mOffset, int mSize, int nOffset,
+                           int nSize) {
+  auto allocTy = cast<triton::gpu::MemDescType>(alloc.getType());
+  SmallVector<int64_t> shape(allocTy.getShape());
+  shape[shape.size() - 2] = mSize;
+  shape.back() = nSize;
+  auto subsliceType = allocTy.cloneWith(shape, allocTy.getElementType());
+  build(builder, state, subsliceType, alloc, mOffset, nOffset);
 }
 
 // -- TensormapCreateOp --

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
@@ -196,6 +196,143 @@ public:
   }
 };
 
+// M-direction analogue of TMemSplitLoadPattern. Matches the pattern:
+//   tmem_load -> reshape  : <M, N> -> <2, M/2, N>
+//             -> trans    : (order = [1, 2, 0])  -> <M/2, N, 2>
+//             -> split    : -> 2 x <M/2, N>
+// and rewrites to two ttng.tmem_subslice + ttng.tmem_load pairs with M offsets
+// 0 and M/2. The split is only valid when M/2 is a multiple of blockM, since
+// TMEM addressing requires M-direction subslicing to land on whole-block
+// boundaries.
+class TMemSplitMLoadPattern : public OpRewritePattern<SplitOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(SplitOp splitOp,
+                                PatternRewriter &rewriter) const override {
+    Value src = stripConvertLayout(splitOp.getSrc());
+    auto transOp = src.getDefiningOp<TransOp>();
+    if (!transOp || transOp.getOrder() != ArrayRef<int>({1, 2, 0}))
+      return failure();
+    auto reshapeOp = transOp.getSrc().getDefiningOp<ReshapeOp>();
+    if (!reshapeOp)
+      return failure();
+    Value reshapeSrc = stripConvertLayout(reshapeOp.getSrc());
+    auto tmemLoad = reshapeSrc.getDefiningOp<TMEMLoadOp>();
+    if (!tmemLoad)
+      return failure();
+
+    auto reshapeShape = reshapeOp.getResult().getType().getShape();
+    auto reshapeSrcShape =
+        cast<RankedTensorType>(reshapeSrc.getType()).getShape();
+    // Ensure N dimension is preserved by the reshape and the outer factor is 2.
+    if (reshapeShape[2] != reshapeSrcShape[1] || reshapeShape[0] != 2)
+      return failure();
+    int splitMSize = reshapeShape[1];
+    auto encoding = cast<nvidia_gpu::TensorMemoryEncodingAttr>(
+        tmemLoad.getSrc().getType().getEncoding());
+    int blockM = encoding.getBlockM();
+    if (splitMSize % blockM != 0)
+      return failure();
+
+    Value tmem = tmemLoad.getSrc();
+    int splitNSize = reshapeShape[2];
+    int numWarps = ttg::lookupNumWarps(tmemLoad);
+    rewriter.setInsertionPoint(tmemLoad);
+
+    auto createSliceLoad =
+        [&](int64_t mOffset) -> std::pair<TMEMLoadOp, ttg::ConvertLayoutOp> {
+      Value subSlice = TMEMSubSliceOp::create(
+          rewriter, tmemLoad.getLoc(), tmem, /*mOffset=*/mOffset,
+          /*mSize=*/splitMSize, /*nOffset=*/0, /*nSize=*/splitNSize);
+
+      gpu::MemDescType subSliceType =
+          cast<gpu::MemDescType>(subSlice.getType());
+      auto distLayout =
+          nvidia_gpu::getDefaultLayoutForTmemLdSt(subSliceType, numWarps);
+
+      RankedTensorType newLoadType =
+          splitOp.getOutLHS().getType().cloneWithEncoding(distLayout);
+
+      auto load = TMEMLoadOp::create(rewriter, tmemLoad.getLoc(), newLoadType,
+                                     subSlice);
+      auto cvt = ttg::ConvertLayoutOp::create(
+          rewriter, tmemLoad.getLoc(), splitOp.getOutLHS().getType(), load);
+
+      return {load, cvt};
+    };
+
+    auto [load0, cvt0] = createSliceLoad(/*mOffset=*/0);
+    auto [load1, cvt1] = createSliceLoad(/*mOffset=*/splitMSize);
+    rewriter.replaceOp(splitOp, {cvt0, cvt1});
+    return success();
+  }
+};
+
+// M-direction analogue of TMemStoreJoinPattern. Matches the pattern:
+//   join     : 2 x <M/2, N> -> <M/2, N, 2>
+//   trans    : (order = [2, 0, 1])  -> <2, M/2, N>
+//   reshape  : -> <M, N>
+//   tmem_store
+// and rewrites to two ttng.tmem_subslice + ttng.tmem_store pairs.
+class TMemStoreJoinMPattern : public OpRewritePattern<TMEMStoreOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(TMEMStoreOp storeOp,
+                                PatternRewriter &b) const override {
+    Value src = storeOp.getSrc();
+    while (auto cvt = src.getDefiningOp<ttg::ConvertLayoutOp>()) {
+      src = cvt.getSrc();
+    }
+
+    auto reshapeOp = src.getDefiningOp<ReshapeOp>();
+    if (!reshapeOp)
+      return failure();
+    auto reshapeSrcShape = reshapeOp.getSrc().getType().getShape();
+    auto reshapeDstShape = reshapeOp.getType().getShape();
+    // The reshape must collapse a leading factor of 2 in the M dimension.
+    if (reshapeSrcShape.size() != 3 || reshapeSrcShape[0] != 2 ||
+        reshapeDstShape.back() != reshapeSrcShape.back())
+      return failure();
+    auto transOp = reshapeOp.getSrc().getDefiningOp<TransOp>();
+    if (!transOp || transOp.getOrder() != ArrayRef<int>({2, 0, 1}))
+      return failure();
+    auto joinOp = transOp.getSrc().getDefiningOp<JoinOp>();
+    if (!joinOp)
+      return failure();
+
+    int splitMSize = reshapeSrcShape[1];
+    int splitNSize = reshapeSrcShape[2];
+    auto encoding = cast<nvidia_gpu::TensorMemoryEncodingAttr>(
+        storeOp.getDst().getType().getEncoding());
+    int blockM = encoding.getBlockM();
+    if (splitMSize % blockM != 0)
+      return failure();
+
+    Location loc = storeOp.getLoc();
+    Value tmem = storeOp.getDst();
+    int numWarps = ttg::lookupNumWarps(storeOp);
+    Value truePred = arith::ConstantOp::create(b, loc, b.getBoolAttr(true));
+
+    auto createSlice = [&](TypedValue<RankedTensorType> input, int mOffset) {
+      auto subSlice = TMEMSubSliceOp::create(
+          b, loc, tmem, /*mOffset=*/mOffset, /*mSize=*/splitMSize,
+          /*nOffset=*/0, /*nSize=*/splitNSize);
+      auto distLayout =
+          nvidia_gpu::getDefaultLayoutForTmemLdSt(subSlice.getType(), numWarps);
+      auto newType = input.getType().cloneWithEncoding(distLayout);
+      auto cvt = ttg::ConvertLayoutOp::create(b, loc, newType, input);
+      TMEMStoreOp::create(b, loc, subSlice, cvt.getResult(), truePred);
+    };
+
+    createSlice(joinOp.getLhs(), 0);
+    createSlice(joinOp.getRhs(), splitMSize);
+    b.eraseOp(storeOp);
+    return success();
+  }
+};
+
 // Pick an optimized tmem load layout based on its users. When there are
 // multiple warpgroups tmem_load results can be distirbuted along M or N across
 // the warpgroups. By default distribute along N but when there is a reduction
@@ -419,7 +556,8 @@ public:
 
     mlir::RewritePatternSet patterns(context);
     patterns
-        .add<TMemSplitLoadPattern, TMemStoreJoinPattern, TMemLoadReducePattern,
+        .add<TMemSplitLoadPattern, TMemSplitMLoadPattern, TMemStoreJoinPattern,
+             TMemStoreJoinMPattern, TMemLoadReducePattern,
              TMemFromSharedMemPattern, TMemToSharedMemPattern>(context);
     if (failed(applyPatternsGreedily(m, std::move(patterns))))
       signalPassFailure();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
@@ -98,7 +98,7 @@ public:
     if (shape[0] != cast<RankedTensorType>(reshapeSrc.getType()).getShape()[0])
       return failure();
     int mDim = getShapePerCTA(tmemLoad.getSrc().getType())[0];
-    if (mDim != 128 && mDim != 64)
+    if (mDim != 128 && mDim != 64 && mDim != 256)
       return failure();
     int splitNSize = shape[2];
     if (splitNSize < 8)
@@ -169,7 +169,7 @@ public:
     // We found a tmem_store that is joined on the N dimension. We can split it
     // into multiple tmem_stores.
     int mDim = getShapePerCTA(storeOp.getDst().getType())[0];
-    if (mDim != 128 && mDim != 64)
+    if (mDim != 128 && mDim != 64 && mDim != 256)
       return failure();
     int splitNSize = shape[2];
     if (splitNSize < 8)

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeTMemLayouts.cpp
@@ -98,8 +98,7 @@ public:
     if (shape[0] != cast<RankedTensorType>(reshapeSrc.getType()).getShape()[0])
       return failure();
     int mDim = getShapePerCTA(tmemLoad.getSrc().getType())[0];
-    // TODO: enable other M cases. (the layout is a bit more complex).
-    if (mDim != 128)
+    if (mDim != 128 && mDim != 64)
       return failure();
     int splitNSize = shape[2];
     if (splitNSize < 8)
@@ -170,8 +169,7 @@ public:
     // We found a tmem_store that is joined on the N dimension. We can split it
     // into multiple tmem_stores.
     int mDim = getShapePerCTA(storeOp.getDst().getType())[0];
-    // TODO: enable other M cases. (the layout is a bit more complex).
-    if (mDim != 128)
+    if (mDim != 128 && mDim != 64)
       return failure();
     int splitNSize = shape[2];
     if (splitNSize < 8)

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -841,7 +841,8 @@ void init_gluon_ir(py::module &&m) {
       .def("create_tmem_subslice",
            [](GluonOpBuilder &self, Type resultTy, Value memDesc,
               int N) -> Value {
-             return self.create<ttng::TMEMSubSliceOp>(resultTy, memDesc, N);
+             return self.create<ttng::TMEMSubSliceOp>(resultTy, memDesc,
+                                                     /*M=*/0, N);
            })
       .def("create_mbarrier_init",
            [](GluonOpBuilder &self, Value memDesc, int count) {

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -765,7 +765,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_rows_mismatch() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    // expected-error @+1 {{The result must have the same number of rows as the source.}}
+    // expected-error @+1 {{The result M dim must be a multiple of blockM}}
     %sub = ttng.tmem_subslice %md {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
     tt.return
   }
@@ -801,7 +801,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_offset_alignment_invalid() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>
-    // expected-error @+1 {{The split offset may not touch the tile}}
+    // expected-error @+1 {{The N split offset may not touch the tile}}
     %sub = ttng.tmem_subslice %md {N = 32 : i32} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x256>
     tt.return
   }
@@ -813,7 +813,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   tt.func public @tmem_subslice_offset_exceed() {
     %md = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    // expected-error @+1 {{The split offset may not exceed the source shape}}
+    // expected-error @+1 {{The N split offset may not exceed the source shape}}
     %sub = ttng.tmem_subslice %md {N = 128 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
     tt.return
   }

--- a/test/TritonNvidiaGPU/tmem_layouts.mlir
+++ b/test/TritonNvidiaGPU/tmem_layouts.mlir
@@ -183,16 +183,58 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
-  // CHECK-LABEL: @subtile_tmem_load_256
-  // CHECK-NOT: ttng.tmem_subslice
-  // CHECK: tt.return
-  tt.func public @subtile_tmem_load_256(%arg0: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<256x64xf32, #blocked>, tensor<256x64xf32, #blocked>) {
+  // The tensor M dim is 256 (two stacked blockM=128 tiles); the helper is
+  // responsible for picking a layout whose warp basis spans the second tile.
+  // CHECK-LABEL: @subtile_tmem_load_m256
+  tt.func public @subtile_tmem_load_m256(%arg0: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<256x64xf32, #blocked>, tensor<256x64xf32, #blocked>) {
+    // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
+    // CHECK: %[[L0:.+]] = ttng.tmem_load %[[S0]] : !ttg.memdesc<256x64xf32
+    // CHECK: %[[C0:.+]] = ttg.convert_layout %[[L0]]
+    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %{{.+}} {N = 64 : i32}
+    // CHECK: %[[L1:.+]] = ttng.tmem_load %[[S1]] : !ttg.memdesc<256x64xf32
+    // CHECK: %[[C1:.+]] = ttg.convert_layout %[[L1]]
+    // CHECK: tt.return %[[C0]], %[[C1]]
     %0 = ttng.tmem_load %arg0 : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x128xf32, #linear>
     %1 = tt.reshape %0 : tensor<256x128xf32, #linear> -> tensor<256x2x64xf32, #blocked2>
     %2 = tt.trans %1 {order = array<i32: 0, 2, 1>} : tensor<256x2x64xf32, #blocked2> -> tensor<256x64x2xf32, #blocked3>
     %3 = ttg.convert_layout %2 : tensor<256x64x2xf32, #blocked3> -> tensor<256x64x2xf32, #blocked4>
     %outLHS, %outRHS = tt.split %3 : tensor<256x64x2xf32, #blocked4> -> tensor<256x64xf32, #blocked>
     tt.return %outLHS, %outRHS : tensor<256x64xf32, #blocked>, tensor<256x64xf32, #blocked>
+  }
+}
+
+// -----
+
+// Same join-store optimization as @subtile_tmem_store, but with the tensor M
+// dim spanning two stacked blockM=128 tiles (mDim=256) under 8 warps.
+
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [0, 1]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 64, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [8, 1, 1], order = [2, 0, 1]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 2, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [8, 1, 1], order = [1, 0, 2]}>
+#linear = #ttg.linear<{register = [[0, 64], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [128, 0]], block = []}>
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
+
+  // CHECK-LABEL: @subtile_tmem_store_m256
+  tt.func public @subtile_tmem_store_m256(
+    %arg0: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %arg1: tensor<256x64xf32, #blocked5>,
+    %arg2: tensor<256x64xf32, #blocked5>
+  ) {
+    // CHECK: [[S0:%.+]] = ttng.tmem_subslice %arg0 {N = 0 : i32}
+    // CHECK: [[V0:%.+]] = ttg.convert_layout %arg1
+    // CHECK: ttng.tmem_store [[V0]], [[S0]]
+    // CHECK: [[S1:%.+]] = ttng.tmem_subslice %arg0 {N = 64 : i32}
+    // CHECK: [[V1:%.+]] = ttg.convert_layout %arg2
+    // CHECK: ttng.tmem_store [[V1]], [[S1]]
+    %true = arith.constant true
+    %joined = tt.join %arg1, %arg2 : tensor<256x64xf32, #blocked5> -> tensor<256x64x2xf32, #blocked6>
+    %trans = tt.trans %joined {order = array<i32: 0, 2, 1>} : tensor<256x64x2xf32, #blocked6> -> tensor<256x2x64xf32, #blocked7>
+    %reshaped = tt.reshape %trans : tensor<256x2x64xf32, #blocked7> -> tensor<256x128xf32, #linear>
+    ttng.tmem_store %reshaped, %arg0, %true : tensor<256x128xf32, #linear> -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
   }
 }
 

--- a/test/TritonNvidiaGPU/tmem_layouts.mlir
+++ b/test/TritonNvidiaGPU/tmem_layouts.mlir
@@ -205,6 +205,211 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // -----
 
+// M-direction split-load optimization: <256x128> blockM=128 split into
+// 2x <128x128> by reshape + trans(order = [1, 2, 0]) + split. The optimization
+// rewrites this to two ttng.tmem_subslice + ttng.tmem_load pairs at M offsets
+// 0 and 128, each addressing one of the two physical blocks of the source.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [128, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 0, 64]], lane = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0]], warp = [[0, 32, 0], [0, 64, 0], [1, 0, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 64, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 0, 1]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @subtile_tmem_load_m_split
+  tt.func public @subtile_tmem_load_m_split(%arg0: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>) {
+    // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
+    // CHECK: %[[L0:.+]] = ttng.tmem_load %[[S0]] : !ttg.memdesc<128x128xf32
+    // CHECK: %[[C0:.+]] = ttg.convert_layout %[[L0]]
+    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %{{.+}} {M = 128 : i32, N = 0 : i32}
+    // CHECK: %[[L1:.+]] = ttng.tmem_load %[[S1]] : !ttg.memdesc<128x128xf32
+    // CHECK: %[[C1:.+]] = ttg.convert_layout %[[L1]]
+    // CHECK: tt.return %[[C0]], %[[C1]]
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x128xf32, #linear>
+    %1 = tt.reshape %0 : tensor<256x128xf32, #linear> -> tensor<2x128x128xf32, #linear1>
+    %2 = tt.trans %1 {order = array<i32: 1, 2, 0>} : tensor<2x128x128xf32, #linear1> -> tensor<128x128x2xf32, #linear2>
+    %3 = ttg.convert_layout %2 : tensor<128x128x2xf32, #linear2> -> tensor<128x128x2xf32, #blocked1>
+    %outLHS, %outRHS = tt.split %3 : tensor<128x128x2xf32, #blocked1> -> tensor<128x128xf32, #blocked>
+    tt.return %outLHS, %outRHS : tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// M-direction join-store optimization: 2x <128x128> joined into <256x128>
+// blockM=128 by join + trans(order = [2, 0, 1]) + reshape + tmem_store.
+
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [2, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 4, 2], order = [0, 2, 1]}>
+#linear = #ttg.linear<{register = [[128, 0], [0, 64], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [1, 0], [2, 0]], block = []}>
+#tmem_dist = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [128, 0]], block = []}>
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @subtile_tmem_store_m_join
+  tt.func public @subtile_tmem_store_m_join(
+    %arg0: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %arg1: tensor<128x128xf32, #blocked5>,
+    %arg2: tensor<128x128xf32, #blocked5>
+  ) {
+    // CHECK: [[S0:%.+]] = ttng.tmem_subslice %arg0 {N = 0 : i32}
+    // CHECK: [[V0:%.+]] = ttg.convert_layout %arg1
+    // CHECK: ttng.tmem_store [[V0]], [[S0]]
+    // CHECK: [[S1:%.+]] = ttng.tmem_subslice %arg0 {M = 128 : i32, N = 0 : i32}
+    // CHECK: [[V1:%.+]] = ttg.convert_layout %arg2
+    // CHECK: ttng.tmem_store [[V1]], [[S1]]
+    %true = arith.constant true
+    %joined = tt.join %arg1, %arg2 : tensor<128x128xf32, #blocked5> -> tensor<128x128x2xf32, #blocked6>
+    %trans = tt.trans %joined {order = array<i32: 2, 0, 1>} : tensor<128x128x2xf32, #blocked6> -> tensor<2x128x128xf32, #blocked7>
+    %reshaped = tt.reshape %trans : tensor<2x128x128xf32, #blocked7> -> tensor<256x128xf32, #linear>
+    %cvt = ttg.convert_layout %reshaped : tensor<256x128xf32, #linear> -> tensor<256x128xf32, #tmem_dist>
+    ttng.tmem_store %cvt, %arg0, %true : tensor<256x128xf32, #tmem_dist> -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Same M-direction split-load as @subtile_tmem_load_m_split, but with srcM=512
+// (four stacked blockM=128 tiles). The 2-way split produces halves of M=256
+// (still a multiple of blockM=128), so the pattern fires once with M offsets
+// 0 and 256.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [256, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [128, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 0, 64], [1, 0, 0]], lane = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0]], warp = [[0, 32, 0], [0, 64, 0], [0, 128, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 64, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [128, 0, 0]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @subtile_tmem_load_m_split_512
+  tt.func public @subtile_tmem_load_m_split_512(%arg0: !ttg.memdesc<512x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<256x128xf32, #blocked>, tensor<256x128xf32, #blocked>) {
+    // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
+    // CHECK: %[[L0:.+]] = ttng.tmem_load %[[S0]] : !ttg.memdesc<256x128xf32
+    // CHECK: %[[C0:.+]] = ttg.convert_layout %[[L0]]
+    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %{{.+}} {M = 256 : i32, N = 0 : i32}
+    // CHECK: %[[L1:.+]] = ttng.tmem_load %[[S1]] : !ttg.memdesc<256x128xf32
+    // CHECK: %[[C1:.+]] = ttg.convert_layout %[[L1]]
+    // CHECK: tt.return %[[C0]], %[[C1]]
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<512x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<512x128xf32, #linear>
+    %1 = tt.reshape %0 : tensor<512x128xf32, #linear> -> tensor<2x256x128xf32, #linear1>
+    %2 = tt.trans %1 {order = array<i32: 1, 2, 0>} : tensor<2x256x128xf32, #linear1> -> tensor<256x128x2xf32, #linear2>
+    %3 = ttg.convert_layout %2 : tensor<256x128x2xf32, #linear2> -> tensor<256x128x2xf32, #blocked1>
+    %outLHS, %outRHS = tt.split %3 : tensor<256x128x2xf32, #blocked1> -> tensor<256x128xf32, #blocked>
+    tt.return %outLHS, %outRHS : tensor<256x128xf32, #blocked>, tensor<256x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// M-direction split-load with 4 warps: srcM=256, blockM=128. With only 4 warps
+// the natural TMEM-load layout uses fewer warp basis vectors and one extra
+// register basis to extend M coverage from 128 (4 warps x 32) to 256.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [128, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 0, 64], [1, 0, 0]], lane = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0]], warp = [[0, 32, 0], [0, 64, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 64, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @subtile_tmem_load_m_split_4warp
+  tt.func public @subtile_tmem_load_m_split_4warp(%arg0: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>) {
+    // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
+    // CHECK: %[[L0:.+]] = ttng.tmem_load %[[S0]] : !ttg.memdesc<128x128xf32
+    // CHECK: %[[C0:.+]] = ttg.convert_layout %[[L0]]
+    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %{{.+}} {M = 128 : i32, N = 0 : i32}
+    // CHECK: %[[L1:.+]] = ttng.tmem_load %[[S1]] : !ttg.memdesc<128x128xf32
+    // CHECK: %[[C1:.+]] = ttg.convert_layout %[[L1]]
+    // CHECK: tt.return %[[C0]], %[[C1]]
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x128xf32, #linear>
+    %1 = tt.reshape %0 : tensor<256x128xf32, #linear> -> tensor<2x128x128xf32, #linear1>
+    %2 = tt.trans %1 {order = array<i32: 1, 2, 0>} : tensor<2x128x128xf32, #linear1> -> tensor<128x128x2xf32, #linear2>
+    %3 = ttg.convert_layout %2 : tensor<128x128x2xf32, #linear2> -> tensor<128x128x2xf32, #blocked1>
+    %outLHS, %outRHS = tt.split %3 : tensor<128x128x2xf32, #blocked1> -> tensor<128x128xf32, #blocked>
+    tt.return %outLHS, %outRHS : tensor<128x128xf32, #blocked>, tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// M-direction split-load with blockM=64: srcM=128 = 2 * blockM, 4 warps. The
+// natural TMEM-load layout for blockM=64 places one lane bit in N (col 64) and
+// uses warp bases [32,0],[16,0] to interleave the two physical sub-block halves
+// across the 128 TMEM rows. Splitting halves it into two single-block <64,128>
+// loads at M offsets 0 and 64.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [64, 0]], warp = [[16, 0], [32, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 0, 64]], lane = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [1, 0, 0]], warp = [[0, 16, 0], [0, 32, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 64, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [0, 0, 1]], warp = [[16, 0, 0], [32, 0, 0]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @subtile_tmem_load_m_split_blockm64
+  tt.func public @subtile_tmem_load_m_split_blockm64(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<64x128xf32, #blocked>, tensor<64x128xf32, #blocked>) {
+    // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
+    // CHECK: %[[L0:.+]] = ttng.tmem_load %[[S0]] : !ttg.memdesc<64x128xf32
+    // CHECK: %[[C0:.+]] = ttg.convert_layout %[[L0]]
+    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %{{.+}} {M = 64 : i32, N = 0 : i32}
+    // CHECK: %[[L1:.+]] = ttng.tmem_load %[[S1]] : !ttg.memdesc<64x128xf32
+    // CHECK: %[[C1:.+]] = ttg.convert_layout %[[L1]]
+    // CHECK: tt.return %[[C0]], %[[C1]]
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    %1 = tt.reshape %0 : tensor<128x128xf32, #linear> -> tensor<2x64x128xf32, #linear1>
+    %2 = tt.trans %1 {order = array<i32: 1, 2, 0>} : tensor<2x64x128xf32, #linear1> -> tensor<64x128x2xf32, #linear2>
+    %3 = ttg.convert_layout %2 : tensor<64x128x2xf32, #linear2> -> tensor<64x128x2xf32, #blocked1>
+    %outLHS, %outRHS = tt.split %3 : tensor<64x128x2xf32, #blocked1> -> tensor<64x128xf32, #blocked>
+    tt.return %outLHS, %outRHS : tensor<64x128xf32, #blocked>, tensor<64x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// M-direction join-store with 4 warps: same as @subtile_tmem_store_m_join but
+// with warpsPerCTA cut in half. Verifies the store rewrite is independent of
+// warp count.
+
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [2, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 4, 1], order = [0, 2, 1]}>
+#linear = #ttg.linear<{register = [[128, 0], [0, 32], [0, 64], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[1, 0], [2, 0]], block = []}>
+#tmem_dist = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [128, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @subtile_tmem_store_m_join_4warp
+  tt.func public @subtile_tmem_store_m_join_4warp(
+    %arg0: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %arg1: tensor<128x128xf32, #blocked5>,
+    %arg2: tensor<128x128xf32, #blocked5>
+  ) {
+    // CHECK: [[S0:%.+]] = ttng.tmem_subslice %arg0 {N = 0 : i32}
+    // CHECK: [[V0:%.+]] = ttg.convert_layout %arg1
+    // CHECK: ttng.tmem_store [[V0]], [[S0]]
+    // CHECK: [[S1:%.+]] = ttng.tmem_subslice %arg0 {M = 128 : i32, N = 0 : i32}
+    // CHECK: [[V1:%.+]] = ttg.convert_layout %arg2
+    // CHECK: ttng.tmem_store [[V1]], [[S1]]
+    %true = arith.constant true
+    %joined = tt.join %arg1, %arg2 : tensor<128x128xf32, #blocked5> -> tensor<128x128x2xf32, #blocked6>
+    %trans = tt.trans %joined {order = array<i32: 2, 0, 1>} : tensor<128x128x2xf32, #blocked6> -> tensor<2x128x128xf32, #blocked7>
+    %reshaped = tt.reshape %trans : tensor<2x128x128xf32, #blocked7> -> tensor<256x128xf32, #linear>
+    %cvt = ttg.convert_layout %reshaped : tensor<256x128xf32, #linear> -> tensor<256x128xf32, #tmem_dist>
+    ttng.tmem_store %cvt, %arg0, %true : tensor<256x128xf32, #tmem_dist> -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 // Same join-store optimization as @subtile_tmem_store, but with the tensor M
 // dim spanning two stacked blockM=128 tiles (mDim=256) under 8 warps.
 

--- a/test/TritonNvidiaGPU/tmem_layouts.mlir
+++ b/test/TritonNvidiaGPU/tmem_layouts.mlir
@@ -106,6 +106,75 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// Same split-load optimization as @subtile_tmem_load, but with blockM = 64.
+// The TMEM layout helper is responsible for producing a valid distributed
+// layout for the 64xN subslice; this test pins down what gets emitted so a
+// regression in the helper would be caught here.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 32]], warp = [[16, 0], [32, 0], [0, 64]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [0, 0, 32]], warp = [[16, 0, 0], [32, 0, 0], [0, 1, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [0, 32, 0]], warp = [[16, 0, 0], [32, 0, 0], [0, 0, 1]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @subtile_tmem_load_m64
+  tt.func public @subtile_tmem_load_m64(%arg0: !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> (tensor<64x64xf32, #blocked>, tensor<64x64xf32, #blocked>) {
+    // CHECK: %[[S0:.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
+    // CHECK: %[[L0:.+]] = ttng.tmem_load %[[S0]] : !ttg.memdesc<64x64xf32
+    // CHECK: %[[C0:.+]] = ttg.convert_layout %[[L0]]
+    // CHECK: %[[S1:.+]] = ttng.tmem_subslice %{{.+}} {N = 64 : i32}
+    // CHECK: %[[L1:.+]] = ttng.tmem_load %[[S1]] : !ttg.memdesc<64x64xf32
+    // CHECK: %[[C1:.+]] = ttg.convert_layout %[[L1]]
+    // CHECK: tt.return %[[C0]], %[[C1]]
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear>
+    %1 = tt.reshape %0 : tensor<64x128xf32, #linear> -> tensor<64x2x64xf32, #linear1>
+    %2 = tt.trans %1 {order = array<i32: 0, 2, 1>} : tensor<64x2x64xf32, #linear1> -> tensor<64x64x2xf32, #linear2>
+    %3 = ttg.convert_layout %2 : tensor<64x64x2xf32, #linear2> -> tensor<64x64x2xf32, #blocked1>
+    %outLHS, %outRHS = tt.split %3 : tensor<64x64x2xf32, #blocked1> -> tensor<64x64xf32, #blocked>
+    tt.return %outLHS, %outRHS : tensor<64x64xf32, #blocked>, tensor<64x64xf32, #blocked>
+  }
+}
+
+// -----
+
+// Same join-store optimization as @subtile_tmem_store, but with blockM = 64.
+
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 64, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [2, 0, 1]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 2, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [1, 0, 2]}>
+#linear = #ttg.linear<{register = [[0, 64], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [0, 0]], block = []}>
+#tmem_dist = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 64]], warp = [[16, 0], [32, 0]], block = []}>
+
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+  // CHECK-LABEL: @subtile_tmem_store_m64
+  tt.func public @subtile_tmem_store_m64(
+    %arg0: !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %arg1: tensor<64x64xf32, #blocked5>,
+    %arg2: tensor<64x64xf32, #blocked5>
+  ) {
+    // CHECK: [[S0:%.+]] = ttng.tmem_subslice %arg0 {N = 0 : i32}
+    // CHECK: [[V0:%.+]] = ttg.convert_layout %arg1
+    // CHECK: ttng.tmem_store [[V0]], [[S0]]
+    // CHECK: [[S1:%.+]] = ttng.tmem_subslice %arg0 {N = 64 : i32}
+    // CHECK: [[V1:%.+]] = ttg.convert_layout %arg2
+    // CHECK: ttng.tmem_store [[V1]], [[S1]]
+    %true = arith.constant true
+    %joined = tt.join %arg1, %arg2 : tensor<64x64xf32, #blocked5> -> tensor<64x64x2xf32, #blocked6>
+    %trans = tt.trans %joined {order = array<i32: 0, 2, 1>} : tensor<64x64x2xf32, #blocked6> -> tensor<64x2x64xf32, #blocked7>
+    %reshaped = tt.reshape %trans : tensor<64x2x64xf32, #blocked7> -> tensor<64x128xf32, #linear>
+    %cvt = ttg.convert_layout %reshaped : tensor<64x128xf32, #linear> -> tensor<64x128xf32, #tmem_dist>
+    ttng.tmem_store %cvt, %arg0, %true : tensor<64x128xf32, #tmem_dist> -> !ttg.memdesc<64x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
 #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [128, 0]], block = []}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 2, 64], threadsPerWarp = [32, 1, 1], warpsPerCTA = [8, 1, 1], order = [0, 2, 1]}>

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -836,7 +836,7 @@ struct TMEMSubSliceOpConversion
     Location loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     auto dstTy = cast<MemDescType>(op.getResult().getType());
-    uint32_t offset = getTMemSubSliceOffset(dstTy, op.getN());
+    uint32_t offset = getTMemSubSliceOffset(dstTy, op.getM(), op.getN());
 
     Value tmemBase = adaptor.getSrc();
     Value offsetVal = b.i32_val(offset);


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

# Description

This PR adds support for subslicing Blackwell tensor memory along the M direction (along block boundaries), allowing optimizations such as split-load and store-join to be extended to the M-dimension.

- The sublice API has been modified to accept an M-dimension offset, but this is defaulted to zero to avoid changing existing logic.
- Tests for the split-load and store-join optimizations have been added, similar in spirit to the existing N-dimension case.