### PR TITLE
[Frontend] Accept float8_e8m0fnu scale tensors in dot_scaled (#10008)

### DIFF
--- a/python/test/unit/runtime/test_specialize.py
+++ b/python/test/unit/runtime/test_specialize.py
@@ -129,10 +129,15 @@ def tuples_to_specialize():
 
 
 def tensors_to_specialize():
+    dtypes = [torch.float64, torch.float32, torch.float16, torch.bfloat16, torch.int32, torch.int64]
+    # float8_e8m0fnu (E8M0 exponent-only) is the native MXFP4/MXFP8 scale dtype on AMD. It must
+    # canonicalize to u8 so JIT specialization doesn't raise a KeyError (issue #10008).
+    if hasattr(torch, "float8_e8m0fnu"):
+        dtypes.append(torch.float8_e8m0fnu)
     return [
         torch.empty(shape, dtype=dtype, device="cpu")
         for shape in [(1, ), (1, 1), (16, ), (16, 16), (128, ), (128, 128)]
-        for dtype in [torch.float64, torch.float32, torch.float16, torch.bfloat16, torch.int32, torch.int64]
+        for dtype in dtypes
     ]
 
 
@@ -144,13 +149,17 @@ def tensordescriptors_to_specialize():
     ]
 
 
+_gluon_supported_dtypes = {torch.float64, torch.float32, torch.float16, torch.bfloat16, torch.int32, torch.int64}
+
+
 def gluon_tensordescriptors_to_specialize():
     return [
         GluonTensorDescriptor.from_tensor(
             tensor,
             block_shape=tensor.shape,
             layout=NVMMASharedLayout(0, tensor.dtype.itemsize * 8, len(tensor.shape)),
-        ) for tensor in tensors_to_specialize() if tensor.shape[-1] % 16 == 0 and tensor.dtype.itemsize <= 4
+        ) for tensor in tensors_to_specialize()
+        if tensor.shape[-1] % 16 == 0 and tensor.dtype in _gluon_supported_dtypes
     ]
 
 

--- a/python/triton/_utils.py
+++ b/python/triton/_utils.py
@@ -89,6 +89,7 @@ type_canonicalisation_dict = {
     "float8_e5m2": "fp8e5",
     "float8e5b16": "fp8e5b16",
     "float8_e5m2fnuz": "fp8e5b16",
+    "float8_e8m0fnu": "u8",
     "half": "fp16",
     "float16": "fp16",
     "bfloat16": "bf16",


### PR DESCRIPTION
`float8_e8m0fnu` is the E8M0 exponent-only dtype used as the native MXFP4/MXFP8 scale format on AMD hardware. When a scale tensor with this dtype was passed to `tl.dot_scaled`, JIT specialization raised a `KeyError` in `canonicalize_dtype` because `"float8_e8m0fnu"` was missing from `type_canonicalisation_dict`. The workaround was `.view(torch.uint8)`, which is bit-identical.

This adds the missing alias alongside the other PyTorch fp8 aliases already in the dict, and extends `tensors_to_specialize()` so the existing `test_specialize_impl` covers the fix through both Python and native C++ specialization paths.

Fixes #10008.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)