### PR TITLE
[triton_kernels] Optimize matmul metadata metrics

### DIFF
--- a/python/triton_kernels/bench/bench_matmul_metadata.py
+++ b/python/triton_kernels/bench/bench_matmul_metadata.py
@@ -46,9 +46,9 @@ def _old_flops_and_bytes_from_slices(args, M, N, K, X, Y, W, slice_sizes, nbits,
 
 def _make_slice_sizes(n_slices, max_slice_size, active_fraction, device):
     n_active = max(1, min(n_slices, round(n_slices * active_fraction)))
-    slice_sizes = torch.zeros((n_slices,), dtype=torch.int32, device=device)
+    slice_sizes = torch.zeros((n_slices, ), dtype=torch.int32, device=device)
     active = torch.randperm(n_slices, device=device)[:n_active]
-    slice_sizes[active] = torch.randint(1, max_slice_size + 1, (n_active,), dtype=torch.int32, device=device)
+    slice_sizes[active] = torch.randint(1, max_slice_size + 1, (n_active, ), dtype=torch.int32, device=device)
     return slice_sizes
 
 
@@ -140,7 +140,7 @@ def main():
     device = torch.device("cuda", args.device)
     torch.manual_seed(0)
 
-    modes = ("ragged_m", "ragged_k") if args.mode == "both" else (args.mode,)
+    modes = ("ragged_m", "ragged_k") if args.mode == "both" else (args.mode, )
     print(
         "mode,n_slices,max_slice_size,active_fraction,old_gpu_us,new_gpu_us,gpu_speedup,old_wall_us,new_wall_us,wall_speedup"
     )

--- a/python/triton_kernels/bench/bench_matmul_metadata.py
+++ b/python/triton_kernels/bench/bench_matmul_metadata.py
@@ -97,10 +97,11 @@ def _run_case(args, mode, device):
     case = _make_case(args, mode, device)
     metadata_args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size = case
 
-    old_fn = lambda: _old_flops_and_bytes_from_slices(
-        metadata_args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size)
-    new_fn = lambda: _matmul_flops_and_bytes_from_slices(
-        metadata_args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size)
+    def old_fn():
+        return _old_flops_and_bytes_from_slices(metadata_args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size)
+
+    def new_fn():
+        return _matmul_flops_and_bytes_from_slices(metadata_args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size)
 
     old = old_fn()
     new = new_fn()
@@ -140,7 +141,9 @@ def main():
     torch.manual_seed(0)
 
     modes = ("ragged_m", "ragged_k") if args.mode == "both" else (args.mode, )
-    print("mode,n_slices,max_slice_size,active_fraction,old_gpu_us,new_gpu_us,gpu_speedup,old_wall_us,new_wall_us,wall_speedup")
+    print(
+        "mode,n_slices,max_slice_size,active_fraction,old_gpu_us,new_gpu_us,gpu_speedup,old_wall_us,new_wall_us,wall_speedup"
+    )
     for mode in modes:
         _run_case(args, mode, device)
 

--- a/python/triton_kernels/bench/bench_matmul_metadata.py
+++ b/python/triton_kernels/bench/bench_matmul_metadata.py
@@ -46,9 +46,9 @@ def _old_flops_and_bytes_from_slices(args, M, N, K, X, Y, W, slice_sizes, nbits,
 
 def _make_slice_sizes(n_slices, max_slice_size, active_fraction, device):
     n_active = max(1, min(n_slices, round(n_slices * active_fraction)))
-    slice_sizes = torch.zeros((n_slices, ), dtype=torch.int32, device=device)
+    slice_sizes = torch.zeros((n_slices,), dtype=torch.int32, device=device)
     active = torch.randperm(n_slices, device=device)[:n_active]
-    slice_sizes[active] = torch.randint(1, max_slice_size + 1, (n_active, ), dtype=torch.int32, device=device)
+    slice_sizes[active] = torch.randint(1, max_slice_size + 1, (n_active,), dtype=torch.int32, device=device)
     return slice_sizes
 
 
@@ -140,7 +140,7 @@ def main():
     device = torch.device("cuda", args.device)
     torch.manual_seed(0)
 
-    modes = ("ragged_m", "ragged_k") if args.mode == "both" else (args.mode, )
+    modes = ("ragged_m", "ragged_k") if args.mode == "both" else (args.mode,)
     print(
         "mode,n_slices,max_slice_size,active_fraction,old_gpu_us,new_gpu_us,gpu_speedup,old_wall_us,new_wall_us,wall_speedup"
     )

--- a/python/triton_kernels/bench/bench_matmul_metadata.py
+++ b/python/triton_kernels/bench/bench_matmul_metadata.py
@@ -1,0 +1,149 @@
+import argparse
+import dataclasses
+import math
+import time
+
+import torch
+
+from triton_kernels.matmul_details._common import _matmul_flops_and_bytes_from_slices
+
+
+@dataclasses.dataclass(frozen=True)
+class FakeTensor:
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+
+    def element_size(self) -> int:
+        return torch.empty((), dtype=self.dtype).element_size()
+
+    def numel(self) -> int:
+        return math.prod(self.shape)
+
+
+def _old_flops_and_bytes_from_slices(args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size):
+    n_tokens = slice_sizes.sum()
+    z = 1 if args["RAGGED_DIMENSION"] == "K" else batch_size
+
+    if args["RAGGED_DIMENSION"] == "K":
+        flops = n_tokens.to(torch.float64) * (2.0 * M * N * z)
+        n_x_bytes = n_tokens * X.shape[-2] * X.element_size()
+        n_y_bytes = Y.numel() * Y.element_size() * (2 if args["OutAcc"] is not None else 1)
+        n_w_bytes = n_tokens * W.shape[-1] * W.element_size()
+    else:
+        if M is None:
+            flops = n_tokens.to(torch.float64) * (2.0 * N * K * z)
+        elif K is None:
+            flops = n_tokens.to(torch.float64) * (2.0 * M * N * z)
+        else:
+            flops = torch.empty((), dtype=torch.float64, device=slice_sizes.device)
+            flops.fill_(2.0 * M * N * K * z)
+        n_x_bytes = n_tokens * X.shape[-1] * X.element_size()
+        n_y_bytes = n_tokens * Y.shape[-1] * Y.element_size()
+        n_w_bytes = (W.numel() * W.element_size() // slice_sizes.numel()) * (slice_sizes > 0).sum()
+
+    return {f"flops{nbits}": flops, "bytes": n_x_bytes + n_y_bytes + n_w_bytes}
+
+
+def _make_slice_sizes(n_slices, max_slice_size, active_fraction, device):
+    n_active = max(1, min(n_slices, round(n_slices * active_fraction)))
+    slice_sizes = torch.zeros((n_slices, ), dtype=torch.int32, device=device)
+    active = torch.randperm(n_slices, device=device)[:n_active]
+    slice_sizes[active] = torch.randint(1, max_slice_size + 1, (n_active, ), dtype=torch.int32, device=device)
+    return slice_sizes
+
+
+def _make_case(args, mode, device):
+    dtype = getattr(torch, args.dtype)
+    slice_sizes = _make_slice_sizes(args.n_slices, args.max_slice_size, args.active_fraction, device)
+    total_capacity = args.n_slices * args.max_slice_size
+
+    if mode == "ragged_k":
+        metadata_args = {"RAGGED_DIMENSION": "K", "OutAcc": object() if args.out_acc else None}
+        X = FakeTensor((args.m, total_capacity), dtype)
+        Y = FakeTensor((args.m, args.n), dtype)
+        W = FakeTensor((total_capacity, args.n), dtype)
+        return metadata_args, args.m, args.n, None, X, Y, W, slice_sizes, dtype.itemsize * 8, 1
+
+    metadata_args = {"RAGGED_DIMENSION": "M", "OutAcc": None}
+    X = FakeTensor((total_capacity, args.k), dtype)
+    Y = FakeTensor((total_capacity, args.n), dtype)
+    W = FakeTensor((args.n_slices, args.k, args.n), dtype)
+    return metadata_args, None, args.n, args.k, X, Y, W, slice_sizes, dtype.itemsize * 8, args.batch_size
+
+
+def _bench(fn, iters, warmup, device):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize(device)
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    wall_start = time.perf_counter()
+    start_event.record()
+    last = None
+    for _ in range(iters):
+        last = fn()
+    end_event.record()
+    torch.cuda.synchronize(device)
+    wall_s = time.perf_counter() - wall_start
+    # Touch the result once after timing to catch bad kernels without putting .item()
+    # synchronization in the measured loop.
+    for value in last.values():
+        assert value.numel() == 1
+    return start_event.elapsed_time(end_event) * 1000.0 / iters, wall_s * 1e6 / iters
+
+
+def _run_case(args, mode, device):
+    case = _make_case(args, mode, device)
+    metadata_args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size = case
+
+    old_fn = lambda: _old_flops_and_bytes_from_slices(
+        metadata_args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size)
+    new_fn = lambda: _matmul_flops_and_bytes_from_slices(
+        metadata_args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size)
+
+    old = old_fn()
+    new = new_fn()
+    torch.cuda.synchronize(device)
+    torch.testing.assert_close(new[f"flops{nbits}"].cpu(), old[f"flops{nbits}"].cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(new["bytes"].cpu(), old["bytes"].to(torch.int64).cpu(), rtol=0, atol=0)
+
+    old_gpu_us, old_wall_us = _bench(old_fn, args.iters, args.warmup, device)
+    new_gpu_us, new_wall_us = _bench(new_fn, args.iters, args.warmup, device)
+    print(
+        f"{mode},{args.n_slices},{args.max_slice_size},{args.active_fraction},"
+        f"{old_gpu_us:.3f},{new_gpu_us:.3f},{old_gpu_us / new_gpu_us:.2f},"
+        f"{old_wall_us:.3f},{new_wall_us:.3f},{old_wall_us / new_wall_us:.2f}",
+        flush=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark ragged matmul launch-metadata flops/bytes counters.")
+    parser.add_argument("--mode", choices=("ragged_m", "ragged_k", "both"), default="both")
+    parser.add_argument("--dtype", choices=("float16", "bfloat16"), default="float16")
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--m", type=int, default=128)
+    parser.add_argument("--n", type=int, default=8192)
+    parser.add_argument("--k", type=int, default=8192)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--n-slices", type=int, default=256)
+    parser.add_argument("--max-slice-size", type=int, default=256)
+    parser.add_argument("--active-fraction", type=float, default=0.8)
+    parser.add_argument("--out-acc", action="store_true")
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--iters", type=int, default=500)
+    args = parser.parse_args()
+
+    torch.cuda.set_device(args.device)
+    device = torch.device("cuda", args.device)
+    torch.manual_seed(0)
+
+    modes = ("ragged_m", "ragged_k") if args.mode == "both" else (args.mode, )
+    print("mode,n_slices,max_slice_size,active_fraction,old_gpu_us,new_gpu_us,gpu_speedup,old_wall_us,new_wall_us,wall_speedup")
+    for mode in modes:
+        _run_case(args, mode, device)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/triton_kernels/tests/test_matmul_metadata.py
+++ b/python/triton_kernels/tests/test_matmul_metadata.py
@@ -112,3 +112,34 @@ def test_matmul_launch_metadata_nosync_matches_old_formula(case):
     torch.testing.assert_close(direct_actual["bytes"].cpu(), expected["bytes"].to(torch.int64).cpu(), rtol=0, atol=0)
     torch.testing.assert_close(actual[f"flops{nbits}"].cpu(), expected[f"flops{nbits}"].cpu(), rtol=0, atol=0)
     torch.testing.assert_close(actual["bytes"].cpu(), expected["bytes"].to(torch.int64).cpu(), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_matmul_flops_and_bytes_from_slices_handles_large_slice_count():
+    device = torch.device("cuda")
+    slice_sizes = torch.arange(1501, dtype=torch.int32, device=device) % 17
+    n_tokens = int(slice_sizes.cpu().sum())
+    nbits = 16
+    M, N, K = None, 16, 8
+    batch_size = 2
+    X = torch.empty((n_tokens, K), dtype=torch.float16, device=device)
+    Y = torch.empty((n_tokens, N), dtype=torch.float16, device=device)
+    W = torch.empty((slice_sizes.numel(), K, N), dtype=torch.float16, device=device)
+    args = _metadata_args(
+        ragged_dimension="M",
+        M=M,
+        N=N,
+        K=K,
+        X=X,
+        Y=Y,
+        W=W,
+        slice_sizes=slice_sizes,
+        batch_size=batch_size,
+    )
+
+    expected = _old_flops_and_bytes(args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size)
+    actual = _matmul_flops_and_bytes_from_slices(args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size)
+    torch.cuda.synchronize(device)
+
+    torch.testing.assert_close(actual[f"flops{nbits}"].cpu(), expected[f"flops{nbits}"].cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(actual["bytes"].cpu(), expected["bytes"].to(torch.int64).cpu(), rtol=0, atol=0)

--- a/python/triton_kernels/tests/test_matmul_metadata.py
+++ b/python/triton_kernels/tests/test_matmul_metadata.py
@@ -108,8 +108,7 @@ def test_matmul_launch_metadata_nosync_matches_old_formula(case):
     assert actual["name"].startswith(_Kernel.name)
     assert actual[f"flops{nbits}"].dtype == torch.float64
     assert actual["bytes"].dtype == torch.int64
-    torch.testing.assert_close(
-        direct_actual[f"flops{nbits}"].cpu(), expected[f"flops{nbits}"].cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(direct_actual[f"flops{nbits}"].cpu(), expected[f"flops{nbits}"].cpu(), rtol=0, atol=0)
     torch.testing.assert_close(direct_actual["bytes"].cpu(), expected["bytes"].to(torch.int64).cpu(), rtol=0, atol=0)
     torch.testing.assert_close(actual[f"flops{nbits}"].cpu(), expected[f"flops{nbits}"].cpu(), rtol=0, atol=0)
     torch.testing.assert_close(actual["bytes"].cpu(), expected["bytes"].to(torch.int64).cpu(), rtol=0, atol=0)

--- a/python/triton_kernels/tests/test_matmul_metadata.py
+++ b/python/triton_kernels/tests/test_matmul_metadata.py
@@ -1,0 +1,115 @@
+import pytest
+import torch
+
+from triton_kernels.matmul_details._common import _matmul_flops_and_bytes_from_slices, matmul_launch_metadata
+from triton_kernels.proton_opts import set_launch_metadata_allow_sync
+
+
+class _Kernel:
+    name = "_p_matmul_test"
+    num_stages = 4
+
+
+def _old_flops_and_bytes(args, M, N, K, X, Y, W, slice_sizes, nbits, batch_size):
+    n_tokens = slice_sizes.sum()
+    z = 1 if args["RAGGED_DIMENSION"] == "K" else batch_size
+    fM = M if M is not None else n_tokens
+    fK = K if K is not None else n_tokens
+    flops = 2.0 * fM * N * fK * z
+
+    if args["RAGGED_DIMENSION"] == "K":
+        n_x_bytes = n_tokens * X.shape[-2] * X.element_size()
+        n_y_bytes = Y.numel() * Y.element_size() * (2 if args["OutAcc"] is not None else 1)
+        n_w_bytes = n_tokens * W.shape[-1] * W.element_size()
+    else:
+        n_x_bytes = n_tokens * X.shape[-1] * X.element_size()
+        n_y_bytes = n_tokens * Y.shape[-1] * Y.element_size()
+        n_w_bytes = (W.numel() * W.element_size() // slice_sizes.numel()) * (slice_sizes > 0).sum()
+
+    return {f"flops{nbits}": flops.to(torch.float64), "bytes": n_x_bytes + n_y_bytes + n_w_bytes}
+
+
+def _metadata_args(*, ragged_dimension, M, N, K, X, Y, W, slice_sizes, batch_size=1, out_acc=None):
+    return {
+        "M": M,
+        "N": N,
+        "K": K,
+        "YPtr": Y,
+        "XPtr": X,
+        "WPtr": W,
+        "XSliceSizes": slice_sizes,
+        "X_EXPECTED_SLICE_SIZE": None,
+        "RAGGED_DIMENSION": ragged_dimension,
+        "OutAcc": out_acc,
+        "batch_size": batch_size,
+        "EPILOGUE_SUBTILE": None,
+    }
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    "case",
+    [
+        "ragged_m",
+        "ragged_k",
+        "ragged_k_out_acc",
+    ],
+)
+def test_matmul_launch_metadata_nosync_matches_old_formula(case):
+    device = torch.device("cuda")
+    slice_sizes = torch.tensor([7, 0, 13, 4, 1], dtype=torch.int32, device=device)
+    nbits = 16
+
+    if case == "ragged_m":
+        M, N, K = None, 16, 8
+        batch_size = 2
+        X = torch.empty((40, K), dtype=torch.float16, device=device)
+        Y = torch.empty((40, N), dtype=torch.float16, device=device)
+        W = torch.empty((slice_sizes.numel(), K, N), dtype=torch.float16, device=device)
+        args = _metadata_args(
+            ragged_dimension="M",
+            M=M,
+            N=N,
+            K=K,
+            X=X,
+            Y=Y,
+            W=W,
+            slice_sizes=slice_sizes,
+            batch_size=batch_size,
+        )
+    else:
+        M, N, K = 8, 16, None
+        out_acc = torch.empty((M, N), dtype=torch.float32, device=device) if case == "ragged_k_out_acc" else None
+        X = torch.empty((M, 40), dtype=torch.float16, device=device)
+        Y = torch.empty((M, N), dtype=torch.float16, device=device)
+        W = torch.empty((40, N), dtype=torch.float16, device=device)
+        args = _metadata_args(
+            ragged_dimension="K",
+            M=M,
+            N=N,
+            K=K,
+            X=X,
+            Y=Y,
+            W=W,
+            slice_sizes=slice_sizes,
+            out_acc=out_acc,
+        )
+
+    expected = _old_flops_and_bytes(args, M, N, K, X, Y, W, slice_sizes, nbits, args["batch_size"])
+    direct_actual = _matmul_flops_and_bytes_from_slices(args, M, N, K, X, Y, W, slice_sizes, nbits, args["batch_size"])
+
+    try:
+        set_launch_metadata_allow_sync(False)
+        actual = matmul_launch_metadata(None, _Kernel(), args)
+        torch.cuda.synchronize(device)
+    finally:
+        set_launch_metadata_allow_sync(True)
+
+    assert actual["name"].startswith(_Kernel.name)
+    assert actual[f"flops{nbits}"].dtype == torch.float64
+    assert actual["bytes"].dtype == torch.int64
+    torch.testing.assert_close(
+        direct_actual[f"flops{nbits}"].cpu(), expected[f"flops{nbits}"].cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(direct_actual["bytes"].cpu(), expected["bytes"].to(torch.int64).cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(actual[f"flops{nbits}"].cpu(), expected[f"flops{nbits}"].cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(actual["bytes"].cpu(), expected["bytes"].to(torch.int64).cpu(), rtol=0, atol=0)

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -193,11 +193,8 @@ def _matmul_flops_and_bytes_from_slices_kernel(
     n_active_slices = tl.sum(tl.where(slice_sizes > 0, 1, 0), axis=0).to(tl.int64)
 
     flops = STATIC_FLOPS + n_tokens.to(tl.float64) * FLOPS_PER_TOKEN
-    total_bytes = (
-        STATIC_BYTES
-        + n_tokens * (X_BYTES_PER_TOKEN + Y_BYTES_PER_TOKEN + W_BYTES_PER_TOKEN)
-        + n_active_slices * W_BYTES_PER_ACTIVE_SLICE
-    )
+    total_bytes = (STATIC_BYTES + n_tokens * (X_BYTES_PER_TOKEN + Y_BYTES_PER_TOKEN + W_BYTES_PER_TOKEN) +
+                   n_active_slices * W_BYTES_PER_ACTIVE_SLICE)
     tl.store(Flops, flops)
     tl.store(Bytes, total_bytes)
 
@@ -305,20 +302,18 @@ def matmul_launch_metadata(grid, kernel, args):
         ret["name"] += f" ep/{ep_subtile}"
 
     if slice_sizes is not None and not allow_sync:
-        ret.update(
-            _matmul_flops_and_bytes_from_slices(
-                args,
-                M,
-                N,
-                K,
-                X,
-                Y,
-                W,
-                slice_sizes,
-                nbits,
-                batch_size,
-            )
-        )
+        ret.update(_matmul_flops_and_bytes_from_slices(
+            args,
+            M,
+            N,
+            K,
+            X,
+            Y,
+            W,
+            slice_sizes,
+            nbits,
+            batch_size,
+        ))
         return ret
 
     if slice_sizes is not None and n_tokens is None:

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -54,9 +54,8 @@ def swizzle2d(pid, grid_m, grid_n, GROUP_M: tl.constexpr):
 
 
 @triton.jit
-def compute_pids(
-    block_id, grid_m, grid_n, num_blocks, XCD_SWIZZLE: tl.constexpr, GROUP_M: tl.constexpr, SPLIT_K: tl.constexpr
-):
+def compute_pids(block_id, grid_m, grid_n, num_blocks, XCD_SWIZZLE: tl.constexpr, GROUP_M: tl.constexpr,
+                 SPLIT_K: tl.constexpr):
     pid_zmnk = block_id
     if XCD_SWIZZLE != 1:
         pid_zmnk = xcd_swizzle(pid_zmnk, num_blocks, XCD_SWIZZLE)
@@ -197,11 +196,8 @@ def _matmul_flops_and_bytes_from_slices_kernel(
         n_active_slices += tl.sum(tl.where(slice_sizes > 0, 1, 0), axis=0).to(tl.int64)
 
     flops = STATIC_FLOPS + n_tokens.to(tl.float64) * FLOPS_PER_TOKEN
-    total_bytes = (
-        STATIC_BYTES
-        + n_tokens * (X_BYTES_PER_TOKEN + Y_BYTES_PER_TOKEN + W_BYTES_PER_TOKEN)
-        + n_active_slices * W_BYTES_PER_ACTIVE_SLICE
-    )
+    total_bytes = (STATIC_BYTES + n_tokens * (X_BYTES_PER_TOKEN + Y_BYTES_PER_TOKEN + W_BYTES_PER_TOKEN) +
+                   n_active_slices * W_BYTES_PER_ACTIVE_SLICE)
     tl.store(Flops, flops)
     tl.store(Bytes, total_bytes)
 
@@ -254,7 +250,7 @@ def _matmul_flops_and_bytes_from_slices(
     flops = torch.empty((), dtype=torch.float64, device=slice_sizes.device)
     total_bytes = torch.empty((), dtype=torch.int64, device=slice_sizes.device)
     block_size = min(triton.next_power_of_2(slice_sizes.numel()), 1024)
-    _matmul_flops_and_bytes_from_slices_kernel[(1,)](
+    _matmul_flops_and_bytes_from_slices_kernel[(1, )](
         slice_sizes,
         flops,
         total_bytes,
@@ -303,27 +299,24 @@ def matmul_launch_metadata(grid, kernel, args):
     if batch_size > 1:
         batch_repr = repr("B", args["batch_size"]) + ", "
     ret["name"] = (
-        f"{kernel.name} [{batch_repr}{repr('M', M)}, {repr('N', N)}, {repr('K', K_repr)}] stg{kernel.num_stages}"
-    )
+        f"{kernel.name} [{batch_repr}{repr('M', M)}, {repr('N', N)}, {repr('K', K_repr)}] stg{kernel.num_stages}")
     ep_subtile = args["EPILOGUE_SUBTILE"]
     if ep_subtile is not None and ep_subtile > 1:
         ret["name"] += f" ep/{ep_subtile}"
 
     if slice_sizes is not None and not allow_sync:
-        ret.update(
-            _matmul_flops_and_bytes_from_slices(
-                args,
-                M,
-                N,
-                K,
-                X,
-                Y,
-                W,
-                slice_sizes,
-                nbits,
-                batch_size,
-            )
-        )
+        ret.update(_matmul_flops_and_bytes_from_slices(
+            args,
+            M,
+            N,
+            K,
+            X,
+            Y,
+            W,
+            slice_sizes,
+            nbits,
+            batch_size,
+        ))
         return ret
 
     if slice_sizes is not None and n_tokens is None:
@@ -357,6 +350,5 @@ def matmul_launch_metadata(grid, kernel, args):
 
 @triton.jit
 def threadfence_system():
-    tl.inline_asm_elementwise(
-        "mov.u32 $0, 0x0; fence.sc.sys;", args=(), dtype=(tl.int32,), is_pure=False, pack=1, constraints="=r"
-    )
+    tl.inline_asm_elementwise("mov.u32 $0, 0x0; fence.sc.sys;", args=(), dtype=(tl.int32, ), is_pure=False, pack=1,
+                              constraints="=r")

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -54,8 +54,9 @@ def swizzle2d(pid, grid_m, grid_n, GROUP_M: tl.constexpr):
 
 
 @triton.jit
-def compute_pids(block_id, grid_m, grid_n, num_blocks, XCD_SWIZZLE: tl.constexpr, GROUP_M: tl.constexpr,
-                 SPLIT_K: tl.constexpr):
+def compute_pids(
+    block_id, grid_m, grid_n, num_blocks, XCD_SWIZZLE: tl.constexpr, GROUP_M: tl.constexpr, SPLIT_K: tl.constexpr
+):
     pid_zmnk = block_id
     if XCD_SWIZZLE != 1:
         pid_zmnk = xcd_swizzle(pid_zmnk, num_blocks, XCD_SWIZZLE)
@@ -186,15 +187,21 @@ def _matmul_flops_and_bytes_from_slices_kernel(
     W_BYTES_PER_ACTIVE_SLICE: tl.constexpr,
     STATIC_BYTES: tl.constexpr,
 ):
-    offs = tl.arange(0, BLOCK_SIZE)
-    mask = offs < NUM_SLICES
-    slice_sizes = tl.load(SliceSizes + offs, mask=mask, other=0).to(tl.int64)
-    n_tokens = tl.sum(slice_sizes, axis=0)
-    n_active_slices = tl.sum(tl.where(slice_sizes > 0, 1, 0), axis=0).to(tl.int64)
+    n_tokens = tl.full((), 0, dtype=tl.int64)
+    n_active_slices = tl.full((), 0, dtype=tl.int64)
+    for start in range(0, NUM_SLICES, BLOCK_SIZE):
+        offs = start + tl.arange(0, BLOCK_SIZE)
+        mask = offs < NUM_SLICES
+        slice_sizes = tl.load(SliceSizes + offs, mask=mask, other=0).to(tl.int64)
+        n_tokens += tl.sum(slice_sizes, axis=0)
+        n_active_slices += tl.sum(tl.where(slice_sizes > 0, 1, 0), axis=0).to(tl.int64)
 
     flops = STATIC_FLOPS + n_tokens.to(tl.float64) * FLOPS_PER_TOKEN
-    total_bytes = (STATIC_BYTES + n_tokens * (X_BYTES_PER_TOKEN + Y_BYTES_PER_TOKEN + W_BYTES_PER_TOKEN) +
-                   n_active_slices * W_BYTES_PER_ACTIVE_SLICE)
+    total_bytes = (
+        STATIC_BYTES
+        + n_tokens * (X_BYTES_PER_TOKEN + Y_BYTES_PER_TOKEN + W_BYTES_PER_TOKEN)
+        + n_active_slices * W_BYTES_PER_ACTIVE_SLICE
+    )
     tl.store(Flops, flops)
     tl.store(Bytes, total_bytes)
 
@@ -246,8 +253,8 @@ def _matmul_flops_and_bytes_from_slices(
 
     flops = torch.empty((), dtype=torch.float64, device=slice_sizes.device)
     total_bytes = torch.empty((), dtype=torch.int64, device=slice_sizes.device)
-    block_size = triton.next_power_of_2(slice_sizes.numel())
-    _matmul_flops_and_bytes_from_slices_kernel[(1, )](
+    block_size = min(triton.next_power_of_2(slice_sizes.numel()), 1024)
+    _matmul_flops_and_bytes_from_slices_kernel[(1,)](
         slice_sizes,
         flops,
         total_bytes,
@@ -296,24 +303,27 @@ def matmul_launch_metadata(grid, kernel, args):
     if batch_size > 1:
         batch_repr = repr("B", args["batch_size"]) + ", "
     ret["name"] = (
-        f"{kernel.name} [{batch_repr}{repr('M', M)}, {repr('N', N)}, {repr('K', K_repr)}] stg{kernel.num_stages}")
+        f"{kernel.name} [{batch_repr}{repr('M', M)}, {repr('N', N)}, {repr('K', K_repr)}] stg{kernel.num_stages}"
+    )
     ep_subtile = args["EPILOGUE_SUBTILE"]
     if ep_subtile is not None and ep_subtile > 1:
         ret["name"] += f" ep/{ep_subtile}"
 
     if slice_sizes is not None and not allow_sync:
-        ret.update(_matmul_flops_and_bytes_from_slices(
-            args,
-            M,
-            N,
-            K,
-            X,
-            Y,
-            W,
-            slice_sizes,
-            nbits,
-            batch_size,
-        ))
+        ret.update(
+            _matmul_flops_and_bytes_from_slices(
+                args,
+                M,
+                N,
+                K,
+                X,
+                Y,
+                W,
+                slice_sizes,
+                nbits,
+                batch_size,
+            )
+        )
         return ret
 
     if slice_sizes is not None and n_tokens is None:
@@ -347,5 +357,6 @@ def matmul_launch_metadata(grid, kernel, args):
 
 @triton.jit
 def threadfence_system():
-    tl.inline_asm_elementwise("mov.u32 $0, 0x0; fence.sc.sys;", args=(), dtype=(tl.int32, ), is_pure=False, pack=1,
-                              constraints="=r")
+    tl.inline_asm_elementwise(
+        "mov.u32 $0, 0x0; fence.sc.sys;", args=(), dtype=(tl.int32,), is_pure=False, pack=1, constraints="=r"
+    )

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -171,10 +171,107 @@ def make_matmul_repr(base_name, order):
     return matmul_repr
 
 
+@triton.jit
+def _matmul_flops_and_bytes_from_slices_kernel(
+    SliceSizes,
+    Flops,
+    Bytes,
+    NUM_SLICES: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    FLOPS_PER_TOKEN: tl.constexpr,
+    STATIC_FLOPS: tl.constexpr,
+    X_BYTES_PER_TOKEN: tl.constexpr,
+    Y_BYTES_PER_TOKEN: tl.constexpr,
+    W_BYTES_PER_TOKEN: tl.constexpr,
+    W_BYTES_PER_ACTIVE_SLICE: tl.constexpr,
+    STATIC_BYTES: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK_SIZE)
+    mask = offs < NUM_SLICES
+    slice_sizes = tl.load(SliceSizes + offs, mask=mask, other=0).to(tl.int64)
+    n_tokens = tl.sum(slice_sizes, axis=0)
+    n_active_slices = tl.sum(tl.where(slice_sizes > 0, 1, 0), axis=0).to(tl.int64)
+
+    flops = STATIC_FLOPS + n_tokens.to(tl.float64) * FLOPS_PER_TOKEN
+    total_bytes = (
+        STATIC_BYTES
+        + n_tokens * (X_BYTES_PER_TOKEN + Y_BYTES_PER_TOKEN + W_BYTES_PER_TOKEN)
+        + n_active_slices * W_BYTES_PER_ACTIVE_SLICE
+    )
+    tl.store(Flops, flops)
+    tl.store(Bytes, total_bytes)
+
+
+def _matmul_flops_and_bytes_from_slices(
+    args,
+    M,
+    N,
+    K,
+    X,
+    Y,
+    W,
+    slice_sizes,
+    nbits,
+    batch_size,
+):
+    import torch
+
+    ragged_k = args["RAGGED_DIMENSION"] == "K"
+    z = 1 if ragged_k else batch_size
+
+    static_flops = 0.0
+    flops_per_token = 0.0
+    if ragged_k:
+        assert M is not None
+        flops_per_token = 2.0 * M * N * z
+    elif M is None:
+        assert K is not None
+        flops_per_token = 2.0 * N * K * z
+    elif K is None:
+        flops_per_token = 2.0 * M * N * z
+    else:
+        static_flops = 2.0 * M * N * K * z
+
+    static_bytes = 0
+    x_bytes_per_token = 0
+    y_bytes_per_token = 0
+    w_bytes_per_token = 0
+    w_bytes_per_active_slice = 0
+    if ragged_k:
+        x_bytes_per_token = X.shape[-2] * X.element_size()
+        # Here, we're computing dW = X.T@dY, so "W" is actually dY and "Y" is actually dW.
+        static_bytes = Y.numel() * Y.element_size() * (2 if args["OutAcc"] is not None else 1)
+        w_bytes_per_token = W.shape[-1] * W.element_size()
+    else:
+        x_bytes_per_token = X.shape[-1] * X.element_size()
+        y_bytes_per_token = Y.shape[-1] * Y.element_size()
+        w_bytes_per_active_slice = W.numel() * W.element_size() // slice_sizes.numel()
+
+    flops = torch.empty((), dtype=torch.float64, device=slice_sizes.device)
+    total_bytes = torch.empty((), dtype=torch.int64, device=slice_sizes.device)
+    block_size = triton.next_power_of_2(slice_sizes.numel())
+    _matmul_flops_and_bytes_from_slices_kernel[(1, )](
+        slice_sizes,
+        flops,
+        total_bytes,
+        NUM_SLICES=slice_sizes.numel(),
+        BLOCK_SIZE=block_size,
+        FLOPS_PER_TOKEN=flops_per_token,
+        STATIC_FLOPS=static_flops,
+        X_BYTES_PER_TOKEN=x_bytes_per_token,
+        Y_BYTES_PER_TOKEN=y_bytes_per_token,
+        W_BYTES_PER_TOKEN=w_bytes_per_token,
+        W_BYTES_PER_ACTIVE_SLICE=w_bytes_per_active_slice,
+        STATIC_BYTES=static_bytes,
+    )
+    return {f"flops{nbits}": flops, "bytes": total_bytes}
+
+
 def matmul_launch_metadata(grid, kernel, args):
     from ..proton_opts import launch_metadata_allow_sync
 
     ret = dict()
+    allow_sync = launch_metadata_allow_sync()
     M, N, K = args["M"], args["N"], args["K"]
     Y, X, W = args["YPtr"], args["XPtr"], args["WPtr"]
     expected_slice_sizes = args.get("X_EXPECTED_SLICE_SIZE")
@@ -183,21 +280,18 @@ def matmul_launch_metadata(grid, kernel, args):
     n_rows = "unknown"
     if expected_slice_sizes is not None:
         n_rows = f"{expected_slice_sizes}*"
-    elif slice_sizes is not None and launch_metadata_allow_sync():
+    elif slice_sizes is not None and allow_sync:
         n_rows = int(slice_sizes.float().mean())
 
     n_tokens = None
     if slice_sizes is not None:
-        if launch_metadata_allow_sync():
+        if allow_sync:
             n_tokens = int(slice_sizes.sum())
-        else:
-            n_tokens = slice_sizes.sum()  # n_tokens can stay in gpu
 
     K_repr = K
     if args["RAGGED_DIMENSION"] == "K":
         K = None if n_tokens is None else n_tokens
-        K_repr = K if launch_metadata_allow_sync(
-        ) else None  # make sure K_repr is string compatible as K can be on a GPU tensor
+        K_repr = K if allow_sync else None
 
     repr = lambda s, x: f"{s} = {x}" if x is not None else f"E_{len(slice_sizes)}({s}) = {n_rows}"
     nbits = X.dtype.itemsize * 8
@@ -209,6 +303,23 @@ def matmul_launch_metadata(grid, kernel, args):
     ep_subtile = args["EPILOGUE_SUBTILE"]
     if ep_subtile is not None and ep_subtile > 1:
         ret["name"] += f" ep/{ep_subtile}"
+
+    if slice_sizes is not None and not allow_sync:
+        ret.update(
+            _matmul_flops_and_bytes_from_slices(
+                args,
+                M,
+                N,
+                K,
+                X,
+                Y,
+                W,
+                slice_sizes,
+                nbits,
+                batch_size,
+            )
+        )
+        return ret
 
     if slice_sizes is not None and n_tokens is None:
         return ret  # Don't fill metadata because we can't compute them properly.


### PR DESCRIPTION
## Why

Proton's Triton hook needs matmul launch metadata to report `flops*` and `bytes` without CPU syncs. For ragged matmuls, the existing no-sync metadata path computed those values through several small Torch GPU ops over `slice_sizes`.

That path is numerically correct, but it adds avoidable metadata overhead. This PR keeps the same reported metadata values while reducing the ragged matmul no-sync path to one small Triton counter kernel per profiled launch.

## What is included

- Adds `_matmul_flops_and_bytes_from_slices_kernel`.
- Uses it in the no-sync ragged matmul launch metadata path.
- Loops over `slice_sizes` in capped chunks (`BLOCK_SIZE <= 1024`) so large slice counts are handled correctly.
- Keeps the synchronous launch metadata path unchanged.
- Adds correctness coverage for M-ragged, K-ragged, K-ragged-with-`OutAcc`, and a large-slice-count case that exercises the multi-chunk loop.
- Adds `python/triton_kernels/bench/bench_matmul_metadata.py` for old-vs-new metadata timing.

This PR is intentionally matmul-only. The Proton graph-safety support is tracked separately in:

- https://github.com/triton-lang/triton/pull/10131

## Metadata microbenchmark

Representative output from `python/triton_kernels/bench/bench_matmul_metadata.py --iters 200 --warmup 10` on the current PR SHA `5a3354095a288f206c47c7234689279d3398cbce`:

```csv
mode,n_slices,max_slice_size,active_fraction,old_gpu_us,new_gpu_us,gpu_speedup,old_wall_us,new_wall_us,wall_speedup
ragged_m,256,256,0.8,136.131,28.020,4.86,136.620,28.262,4.83
ragged_k,256,256,0.8,89.660,29.318,3.06,89.899,29.490,3.05
```

Before this PR, the metadata path launched several Torch kernels such as `aten.mul`, `aten.sum`, `aten.add`, `aten._to_copy`, and `aten.gt`. After this PR, the ragged matmul metadata path uses one `_matmul_flops_and_bytes_from_slices_kernel`.

## Test plan

Pre-push/static checks:

```bash
python3 -m pre_commit run --from-ref 31db1189656b944a131bf60206cc2a9046aef072 --to-ref HEAD --hook-stage pre-push
git diff --check
python3 -m py_compile \
  python/triton_kernels/triton_kernels/matmul_details/_common.py \
  python/triton_kernels/tests/test_matmul_metadata.py \
  python/triton_kernels/bench/bench_matmul_metadata.py
```

Correctness:

```bash
python3 -m pytest -q python/triton_kernels/tests/test_matmul_metadata.py
# 4 passed in 2.61s
```

Benchmark:

```bash
python3 python/triton_kernels/bench/bench_matmul_metadata.py --iters 200 --warmup 10
```
