### PR TITLE
[AMD][Tests] Move part of ISA checks to aggregate functions

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -11,14 +11,16 @@ from triton._internal_testing import (
     is_ampere_or_newer,
     is_blackwell,
     is_blackwell_ultra,
+    is_hopper_or_newer,
+    is_hopper,
+)
+from triton.language.target_info import (
     is_hip_rdna,
     is_hip_rdna3,
     is_hip_rdna4,
     is_hip_cdna,
     is_hip_cdna3,
     is_hip_cdna4,
-    is_hopper_or_newer,
-    is_hopper,
 )
 from triton.compiler import max_shared_mem
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -8,7 +8,8 @@ import triton
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 from triton import language as tl
-from triton._internal_testing import is_blackwell, is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_gfx1250, is_hopper, is_interpreter
+from triton._internal_testing import is_blackwell, is_cuda, is_hopper, is_interpreter
+from triton.language.target_info import is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_gfx1250
 from triton.experimental.gluon.language.nvidia import hopper
 from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -4,7 +4,8 @@ import pytest
 import triton
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
-from triton._internal_testing import is_cuda, is_hip, is_hopper_or_newer, get_hip_lds_size
+from triton._internal_testing import is_cuda, is_hopper_or_newer, get_hip_lds_size
+from triton.language.target_info import is_hip
 from triton._C.libtriton.gluon_ir import make_cga_layout
 from triton.experimental.gluon.language.amd.gfx1250 import PartitionedSharedLayout
 

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -4,8 +4,8 @@ import pytest
 import triton
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
-from triton._internal_testing import is_cuda, is_hopper_or_newer, get_hip_lds_size
-from triton.language.target_info import is_hip
+from triton._internal_testing import is_cuda, is_hopper_or_newer
+from triton.language.target_info import is_hip, get_hip_lds_size
 from triton._C.libtriton.gluon_ir import make_cga_layout
 from triton.experimental.gluon.language.amd.gfx1250 import PartitionedSharedLayout
 

--- a/python/test/regression/test_cast_matmul.py
+++ b/python/test/regression/test_cast_matmul.py
@@ -11,7 +11,7 @@ import torch
 
 import triton
 import triton.language as tl
-from triton._internal_testing import is_hip_cdna3, is_cuda, is_hip
+from triton.language.target_info import is_cuda, is_hip_cdna3, is_hip
 
 input_dtypes = ["bfloat16", "float16", "float32"]
 if is_cuda():

--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -7,7 +7,7 @@ import triton
 import triton.language as tl
 from triton.compiler.errors import CompilationError, CompileTimeAssertionFailure
 import traceback
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna4
+from triton.language.target_info import is_cuda, is_hip, is_hip_cdna4
 
 
 def format_exception(type, value, tb):

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -7,7 +7,7 @@ import pytest
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_rdna3, is_hip_rdna4, is_hip_gfx1250
+from triton.language.target_info import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_rdna3, is_hip_rdna4, is_hip_gfx1250
 
 FP8_DTYPES = ('float8e5', 'float8e4b15', 'float8e4nv', 'float8e4b8', 'float8e5b16')
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -37,6 +37,7 @@ from triton._internal_testing import (
     is_hip_rdna4,
     is_hip_gfx1250,
     hip_supports_bf16xX,
+    hip_supports_float8_uz,
     hip_supports_f8e4m3fn_cast,
     hip_supports_vdot,
     hip_supports_f8e5,
@@ -44,8 +45,9 @@ from triton._internal_testing import (
     hip_supports_f8e4m3,
     hip_supports_kpack,
     hip_supports_scaled_dot,
-    hip_supports_mxfp_dot,
     hip_wmma_version,
+    get_arch,
+    hip_supports_mxfp_dot,
     is_xpu,
     torch_float8_dtypes,
     torch_dtypes,
@@ -1973,10 +1975,12 @@ def test_cast(dtype_x, dtype_z, bitcast, size, num_ctas, device):
         check_type_supported(dtype_z, device)
 
     if is_hip():
-        if (dtype_x == 'float8_e4m3fn' or dtype_z == 'float8_e4m3fn') and not hip_supports_f8e4m3fn_cast():
-            pytest.skip(f'test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA3 and above.')
-        if (sorted([dtype_x, dtype_z]) == ['bfloat16', 'float8_e4m3fn']) and is_hip_cdna3():
-            pytest.skip(f'test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA4 and above.')
+        if (dtype_x == 'float8_e4m3fn' or dtype_z == 'float8_e4m3fn'):
+            if not hip_supports_f8e4m3fn_cast():
+                pytest.skip(f'test_cast{(dtype_x, dtype_z)} is not supported on {get_arch()} architecture.')
+            # following checks bfloat16<->float8_e4m3fn cast cases
+            if ('bfloat16' in [dtype_x, dtype_z]) and is_hip_cdna3():
+                pytest.skip(f'test_cast{(dtype_x, dtype_z)} is not supported on HIP CDNA3.')
 
     torch.manual_seed(0)
     # This is tricky because numpy doesn't have bfloat, and torch doesn't have uints.
@@ -3524,7 +3528,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
             if (in_dtype == "float8e5" and not hip_supports_f8e5()) or (in_dtype == "float8e4nv"
                                                                         and not hip_supports_f8e4nv()):
                 pytest.skip(f"{in_dtype} only supported on CDNA4, RDNA4 and above")
-            if in_dtype in ("float8e5b16", "float8e4b8") and not is_hip_cdna3():
+            if in_dtype in ("float8e5b16", "float8e4b8") and not hip_supports_float8_uz():
                 pytest.skip(f"{in_dtype} only supported on CDNA3")
             if input_precision in ("bf16x3", "bf16x6") and not hip_supports_bf16xX():
                 pytest.skip(f"{input_precision} not fully supported on gfx1250")
@@ -3765,7 +3769,6 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
                    r'cvt\.rn\.f16x2\.f32')
         assert re.search(pattern, ptx, flags=re.DOTALL)
 
-
 @pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, num_warps, mma, kpack",
                          [(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, 4, mma, kpack)
@@ -3788,13 +3791,11 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
         is_SM120 = cc >= (12, 0)
     if is_hip():
         if not hip_supports_scaled_dot():
-            pytest.skip("scaled_dot only implemented for HIP CDNA, RDNA3, RDNA4 and above")
+            pytest.skip(f"scaled_dot is not supported on {get_arch()} architecture")
         if "e4m3" in (mxfp_type, normal_type):
             if not hip_supports_f8e4m3():
-                pytest.skip(
-                    f"scaled_dot({mxfp_type}, {normal_type}) only implemented for CDNA3, CDNA4, RDNA3, RDNA4, and above"
-                )
-        if mma == 16 and K == 64 and not (is_hip_rdna4() or is_hip_rdna3()):
+                pytest.skip(f"scaled_dot({mxfp_type}, {normal_type}) is not supported on {get_arch()} architecture")
+        if mma == 16 and K == 64 and is_hip_cdna():
             pytest.skip(f"K == {K} too small for mfma {mma} in scaled_dot")
 
     @triton.jit
@@ -6067,11 +6068,11 @@ def test_dot_max_num_imprecise_acc(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, in_type_s
             pytest.skip("Dot op does not support fp8e4b15 on CUDA arch >= 90")
     elif is_hip():
         num_stages = 2
-        if in_type_str in ("float8e5b16", "float8e4b8") and not is_hip_cdna3():
+        if in_type_str in ("float8e5b16", "float8e4b8") and not hip_supports_float8_uz():
             pytest.skip(f"{in_type_str} only supported on CDNA3")
         if (in_type_str == "float8e4nv" and not hip_supports_f8e4nv()) or (in_type_str == "float8e5"
                                                                            and not hip_supports_f8e5()):
-            pytest.skip(f"{in_type_str} only supported on CDNA4, RDNA4 and above")
+            pytest.skip(f"{in_type_str} is not supported on {get_arch()} architecture")
 
     check_type_supported(in_type_str, device)
     A = numpy_random((M, K), dtype_str=in_type_str)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -36,6 +36,16 @@ from triton._internal_testing import (
     is_hip_rdna3,
     is_hip_rdna4,
     is_hip_gfx1250,
+    hip_supports_bf16xX,
+    hip_supports_f8e4m3fn_cast,
+    hip_supports_vdot,
+    hip_supports_f8e5,
+    hip_supports_f8e4nv,
+    hip_supports_f8e4m3,
+    hip_supports_kpack,
+    hip_supports_scaled_dot,
+    hip_supports_mxfp_dot,
+    hip_wmma_version,
     is_xpu,
     torch_float8_dtypes,
     torch_dtypes,
@@ -77,7 +87,7 @@ elif is_hip():
     # 0 is a special value for automatic heuristic
     if is_hip_cdna():
         mma_nonk_sizes = [0, 16, 32]
-    elif is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250():
+    else:
         mma_nonk_sizes = [16]
 else:
     THREADS_PER_WARP = 32
@@ -1963,11 +1973,9 @@ def test_cast(dtype_x, dtype_z, bitcast, size, num_ctas, device):
         check_type_supported(dtype_z, device)
 
     if is_hip():
-        if not is_hip_cdna3() and not is_hip_cdna4() and not is_hip_gfx1250() and (dtype_x == 'float8_e4m3fn'
-                                                                                   or dtype_z == 'float8_e4m3fn'):
-            pytest.skip(f'test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA3/CDNA4 and above.')
-        if (not (is_hip_cdna4() or is_hip_gfx1250())) and ((dtype_x == 'bfloat16' and dtype_z == "float8_e4m3fn") or
-                                                           (dtype_x == "float8_e4m3fn" and dtype_z == 'bfloat16')):
+        if (dtype_x == 'float8_e4m3fn' or dtype_z == 'float8_e4m3fn') and not hip_supports_f8e4m3fn_cast():
+            pytest.skip(f'test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA3 and above.')
+        if (sorted([dtype_x, dtype_z]) == ['bfloat16', 'float8_e4m3fn']) and is_hip_cdna3():
             pytest.skip(f'test_cast{(dtype_x, dtype_z)} only supported on HIP CDNA4 and above.')
 
     torch.manual_seed(0)
@@ -3367,7 +3375,7 @@ def get_test_dot_h100_shortcut_cases():
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 # introduced in #3908
 def get_test_dot_mfma_edge_cases():
-    if not (is_hip_cdna() or is_hip_gfx1250()):
+    if not is_hip_cdna():
         return []
     return [(16, 16, 8, 4, False, False, 'None', 'ieee', 'float32', 'float32', 1, None),
             (32, 16, 8, 4, False, False, 'None', 'ieee', 'float16', 'float16', 1, None)]
@@ -3383,7 +3391,7 @@ def get_test_dot_fp8_output_cases():
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 # introduced in #5406
 def get_test_dot_small_k_mfma_cases():
-    if not (is_hip_cdna() or is_hip_gfx1250()):
+    if not is_hip_cdna():
         return []
     return [(32, 32, k_size, 4, False, False, 'None', 'ieee', in_dtype, out_dtype, 1, mma_nonk_size)
             for k_size in [1, 2, 4, 8]
@@ -3394,7 +3402,7 @@ def get_test_dot_small_k_mfma_cases():
 # M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, kpack, mma_nonk_size
 # introduced in #4516
 def get_test_dot_small_mn_mfma_cases():
-    if not (is_hip_cdna() or is_hip_gfx1250()):
+    if not is_hip_cdna():
         return []
     return [(*shape_nw, False, False, epilogue, 'ieee', in_dtype, out_dtype, 1, None)
             for shape_nw in [(4, 64, 64, 1), (64, 4, 64, 1)]
@@ -3418,7 +3426,8 @@ def get_test_dot_kpack_kwidth_mfma_cases():
 
 
 def get_test_dot_double_rate_cases():
-    if not (is_hip_cdna() or is_hip_gfx1250()):
+    # Test double rate MFMA instrucitons introduced in CDNA4
+    if not is_hip_cdna4():
         return []
     return [(32, 32, 16, 4, False, False, 'None', 'ieee', 'float16', 'float32', 1, None),
             (32, 32, 16, 4, False, False, 'None', 'ieee', 'bfloat16', 'float32', 1, None),
@@ -3427,21 +3436,21 @@ def get_test_dot_double_rate_cases():
 
 
 def get_test_dot_vdot2_cases():
-    if not (is_hip_cdna() or is_hip_gfx1250()):
+    if not hip_supports_vdot():
         return []
     return [(4, 32, 32, 4, False, False, 'None', 'ieee', 'float16', 'float32', 1, None),
             (4, 32, 32, 4, False, False, 'None', 'ieee', 'bfloat16', 'float32', 1, None)]
 
 
 def get_test_dot_small_mn_wmma_cases():
-    if not is_hip_gfx1250():
+    if hip_wmma_version() < 3:
         return []
     return [(*shape_nw, False, False, 'none', 'ieee', 'float16', 'float32', 1, None)
             for shape_nw in [(8, 8, 32, 1), (8, 32, 32, 1), (32, 8, 32, 1)]]
 
 
 def get_test_dot_small_k_wmma_cases():
-    if not is_hip_gfx1250():
+    if hip_wmma_version() < 3:
         return []
     return [(16, 64, k_size, 4, False, False, 'none', 'ieee', 'float32', 'float32', 1, None) for k_size in [2]] + \
            [(16, 64, k_size, 4, False, False, 'none', 'ieee', 'float16', 'float32', 1, None) for k_size in [2, 4, 8, 16, 32]] + \
@@ -3512,11 +3521,12 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
                 pytest.skip("Only IEEE precision is supported for float64 dot")
 
         if is_hip():
-            if in_dtype in ("float8e5", "float8e4nv") and not (is_hip_gfx1250() or is_hip_cdna4() or is_hip_rdna4()):
+            if (in_dtype == "float8e5" and not hip_supports_f8e5()) or (in_dtype == "float8e4nv"
+                                                                        and not hip_supports_f8e4nv()):
                 pytest.skip(f"{in_dtype} only supported on CDNA4, RDNA4 and above")
             if in_dtype in ("float8e5b16", "float8e4b8") and not is_hip_cdna3():
                 pytest.skip(f"{in_dtype} only supported on CDNA3")
-            if input_precision in ("bf16x3", "bf16x6") and is_hip_gfx1250():
+            if input_precision in ("bf16x3", "bf16x6") and not hip_supports_bf16xX():
                 pytest.skip(f"{input_precision} not fully supported on gfx1250")
             if not ((input_precision in ("bf16x3", "bf16x6")) or (input_precision == "ieee") or
                     (input_precision == "tf32" and is_hip_cdna3())):
@@ -3672,10 +3682,10 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         # added atol, to loose precision for float16xfloat16->float32 case
         np.testing.assert_allclose(z_ref, to_numpy(z_tri), rtol=0.01, atol=1e-3)
 
-    if not (is_cuda() or is_hip_cdna() or is_hip_gfx1250()):
+    if not (is_cuda() or is_hip_cdna()):
         return
 
-    if is_hip_cdna() or is_hip_gfx1250():
+    if is_hip_cdna():
         amdgcn = pgm.asm['amdgcn']
 
         if is_hip_cdna() and ((M, N) == (4, 64) or (M, N) == (64, 4)):
@@ -3683,7 +3693,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         elif is_hip_cdna() and (M, N) == (4, 32):
             if in_dtype == 'float16':
                 assert 'v_dot2c_f32_f16' in amdgcn
-            elif (in_dtype == 'bfloat16') and (is_hip_cdna4() or is_hip_gfx1250()):
+            elif in_dtype == 'bfloat16' and is_hip_cdna4():
                 assert 'v_dot2c_f32_bf16' in amdgcn
         return
 
@@ -3765,7 +3775,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
                           for mxfp_type in ["e2m1", "e4m3", "e5m2"]
                           for normal_type in ["e4m3", "e5m2", "bf16", "fp16"]
                           for mma in (mma_nonk_sizes if is_hip() else [16])
-                          for kpack in ([1, 2] if (is_hip() and not (is_hip_cdna4() or is_hip_gfx1250())) else [1])])
+                          for kpack in ([1, 2] if hip_supports_kpack() else [1])])
 def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, num_warps, mma, kpack, device):
     if is_interpreter() and normal_type != "fp16":
         pytest.skip("bfloat16 is not supported in the interpreter")
@@ -3777,14 +3787,14 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
             pytest.skip("float8e4nv not supported on CUDA < 8.9")
         is_SM120 = cc >= (12, 0)
     if is_hip():
-        if not (is_hip_cdna() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()):
+        if not hip_supports_scaled_dot():
             pytest.skip("scaled_dot only implemented for HIP CDNA, RDNA3, RDNA4 and above")
         if "e4m3" in (mxfp_type, normal_type):
-            if not (is_hip_cdna3() or is_hip_cdna4() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()):
+            if not hip_supports_f8e4m3():
                 pytest.skip(
                     f"scaled_dot({mxfp_type}, {normal_type}) only implemented for CDNA3, CDNA4, RDNA3, RDNA4, and above"
                 )
-        if mma == 16 and K == 64 and not (is_hip_rdna4() or is_hip_rdna3() or is_hip_gfx1250()):
+        if mma == 16 and K == 64 and not (is_hip_rdna4() or is_hip_rdna3()):
             pytest.skip(f"K == {K} too small for mfma {mma} in scaled_dot")
 
     @triton.jit
@@ -3956,7 +3966,7 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
             # Clamp to avoid relative error issues
             ret.clamp_(-2**comp_dtype_max_exp, 2**comp_dtype_max_exp - 1)
         else:
-            if is_hip_cdna4() or is_hip_gfx1250():
+            if hip_supports_mxfp_dot():
                 # On other chips, the A/B operands are upcasted to fp16/bf16
                 # before matmul, which has larger range to avoid overflow.
                 # On CDNA4, we use the V_MFMA_*_F8F6F4 instructions to
@@ -6059,7 +6069,8 @@ def test_dot_max_num_imprecise_acc(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, in_type_s
         num_stages = 2
         if in_type_str in ("float8e5b16", "float8e4b8") and not is_hip_cdna3():
             pytest.skip(f"{in_type_str} only supported on CDNA3")
-        if in_type_str in ("float8e5", "float8e4nv") and not (is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()):
+        if (in_type_str == "float8e4nv" and not hip_supports_f8e4nv()) or (in_type_str == "float8e5"
+                                                                           and not hip_supports_f8e5()):
             pytest.skip(f"{in_type_str} only supported on CDNA4, RDNA4 and above")
 
     check_type_supported(in_type_str, device)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -28,6 +28,17 @@ from triton._internal_testing import (
     is_cuda,
     is_interpreter,
     is_hopper,
+    get_arch,
+    is_xpu,
+    torch_float8_dtypes,
+    torch_dtypes,
+    numpy_random,
+    to_triton,
+    torch_dtype_name,
+    to_numpy,
+)
+
+from triton.language.target_info import (
     is_hip,
     is_hip_cdna,
     is_hip_cdna2,
@@ -46,15 +57,7 @@ from triton._internal_testing import (
     hip_supports_kpack,
     hip_supports_scaled_dot,
     hip_wmma_version,
-    get_arch,
     hip_supports_mxfp_dot,
-    is_xpu,
-    torch_float8_dtypes,
-    torch_dtypes,
-    numpy_random,
-    to_triton,
-    torch_dtype_name,
-    to_numpy,
 )
 from triton.runtime.errors import InterpreterError
 
@@ -3768,6 +3771,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
                    r'(?:(?!st\.shared).)*'
                    r'cvt\.rn\.f16x2\.f32')
         assert re.search(pattern, ptx, flags=re.DOTALL)
+
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, num_warps, mma, kpack",

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -5,7 +5,7 @@ import triton
 import triton.language as tl
 from test_mxfp import MXFP4Tensor, MXScaleTensor
 import re
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_cdna, is_hip_gfx1250
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_cdna, hip_supports_mxfp_dot, hip_supports_mn_pack_scales
 
 
 def f8_to_f16(x, dtype):
@@ -349,7 +349,7 @@ def fp8e8m0_to_float32(scale):
                                                        (128, 16, 64)])
 @pytest.mark.parametrize("NUM_STAGES", [1, 3])
 @pytest.mark.parametrize("NUM_WARPS", [4, 8])
-@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if (is_hip_cdna() or is_hip_gfx1250()) else [0]))
+@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else [0]))
 def test_mxfp(BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS, device):
     M = 1024
     N = 512
@@ -359,7 +359,7 @@ def test_mxfp(BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS, device)
     if is_cuda() and torch.cuda.get_device_capability()[0] < 10:
         pytest.skip("Requires compute capability >= 10")
     elif is_hip():
-        if not (is_hip_cdna4() or is_hip_gfx1250()):
+        if not hip_supports_mxfp_dot():
             pytest.skip("Scaled mxfp8 matmul is only natively supported on CDNA4 or above")
         if (nonKDim == 16 and BLOCK_K < 128) or (nonKDim == 32 and BLOCK_K < 64):
             pytest.skip(f"CDNA4 does not support {BLOCK_K=} for scaled mfma {nonKDim=} variants")
@@ -623,8 +623,7 @@ def _gemm_kernel_preshuffled_scales_cdna4(a_ptr, b_ptr, c_ptr, a_scales_ptr, b_s
 @pytest.mark.parametrize("preshuffle", [True, False])
 @pytest.mark.skipif(is_cuda() and torch.cuda.get_device_capability()[0] in [10, 11],
                     reason="Compilation bug for GB200.")
-@pytest.mark.skipif(is_hip() and not (is_hip_cdna4() or is_hip_gfx1250()),
-                    reason="Scaled dot is not emulated on other archs yet.")
+@pytest.mark.skipif(is_hip() and not hip_supports_mxfp_dot(), reason="Scaled dot is not emulated on other archs yet.")
 def test_preshuffle_scale_mxfp_cdna4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, DTYPE_A, DTYPE_B, FAST_MATH, mfma_nonkdim,
                                      preshuffle, device):
     # For details about scale shuffling on AMD GPUs please take a look at documentation in 10-block-scaled-matmu.py.
@@ -991,7 +990,7 @@ def block_scale_fp4_matmul(  #
 @pytest.mark.parametrize("pack_along_k", [True, False])
 @pytest.mark.parametrize(("scale_type", "VEC_SIZE"), [("float8_e8m0fnu", 32), ("float8_e4m3fn", 16)],
                          ids=["mxfp4", "nvfp4"])
-@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if (is_hip_cdna() or is_hip_gfx1250()) else [0]))
+@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else [0]))
 def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, with_a_scale, with_b_scale, pack_along_k,
                          scale_type, nonKDim, device):
     assert M % BLOCK_M == 0
@@ -1010,9 +1009,9 @@ def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, with_a_sc
         if not (with_a_scale and with_b_scale):
             pytest.skip("None aScale/bScale is only tested on AMD backend for now")
     elif is_hip():
-        if not (is_hip_cdna4() or is_hip_gfx1250()):
-            pytest.skip("Scaled fp4 matmul is only natively supported on CDNA4")
-        if is_hip_gfx1250() and scale_type == "float8_e8m0fnu" and not pack_along_k:
+        if not (hip_supports_mxfp_dot()):
+            pytest.skip("Scaled fp4 matmul is only natively supported on CDNA4 and above")
+        if not hip_supports_mn_pack_scales() and scale_type == "float8_e8m0fnu" and not pack_along_k:
             pytest.skip("fp4 matmul packed along M/N unsupported on gfx1250")
         if scale_type != 'float8_e8m0fnu':
             pytest.skip("CDNA4 only supports E8M0 scale")
@@ -1157,7 +1156,7 @@ def mxfp8_mxfp4_matmul(  #
 @pytest.mark.parametrize("B_DATA_TYPE", ["float8e5", "float8e4nv", "float4"])
 @pytest.mark.parametrize("WITH_A_SCALE", [True, False])
 @pytest.mark.parametrize("WITH_B_SCALE", [True, False])
-@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if (is_hip_cdna() or is_hip_gfx1250()) else [0]))
+@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else [0]))
 def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TRANS, PACK_B_ALONG_K, CONST_SCALE,
                             A_DATA_TYPE, B_DATA_TYPE, WITH_A_SCALE, WITH_B_SCALE, nonKDim, device):
     if is_cuda():
@@ -1168,13 +1167,13 @@ def test_mxfp8_mxfp4_matmul(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, B_TR
         if not (A_DATA_TYPE == "float8e5" and B_DATA_TYPE == "float4"):
             pytest.skip(f"(A: {A_DATA_TYPE}, B: {B_DATA_TYPE}) has not been tested on NV backend")
     elif is_hip():
-        if not (is_hip_cdna4() or is_hip_gfx1250()):
+        if not hip_supports_mxfp_dot():
             pytest.skip("Scaled mxfp4 & mxfp8 matmul is only natively supported on CDNA4 and above")
         if (nonKDim == 16 and BLOCK_K < 128) or (nonKDim == 32 and BLOCK_K < 64):
             pytest.skip(f"CDNA4 does not support {BLOCK_K=} for scaled mfma {nonKDim=} variants")
         if (A_DATA_TYPE == 'float4' and not WITH_A_SCALE) or (B_DATA_TYPE == 'float4' and not WITH_B_SCALE):
             pytest.skip("Float4 without scale is tested in test_block_scale_fp4")
-        if (is_hip_gfx1250() and B_DATA_TYPE == 'float4' and not PACK_B_ALONG_K):
+        if (not hip_supports_mn_pack_scales() and B_DATA_TYPE == 'float4' and not PACK_B_ALONG_K):
             pytest.skip("Float4 matmul packed along M/N unsupported on gfx1250")
         if (BLOCK_M == 256 or BLOCK_N == 256) and BLOCK_K == 256:
             pytest.skip("Config requires too much shared memory")
@@ -1320,7 +1319,7 @@ def batched_mxfp_matmul(  #
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 64), (128, 64, 128), (64, 64, 128)])
 @pytest.mark.parametrize("NUM_STAGES", [1, 2 if is_hip() else 3])
 @pytest.mark.parametrize("NUM_WARPS", [4, 8])
-@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if (is_hip_cdna() or is_hip_gfx1250()) else [0]))
+@pytest.mark.parametrize("nonKDim", ([0, 16, 32] if is_hip_cdna() else [0]))
 def test_batched_mxfp(BATCH_SIZE, BLOCK_BATCH_SIZE, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS, device):
     M, N, K = 1024, 512, 2048
 
@@ -1329,7 +1328,7 @@ def test_batched_mxfp(BATCH_SIZE, BLOCK_BATCH_SIZE, BLOCK_M, BLOCK_N, BLOCK_K, N
     if is_cuda() and torch.cuda.get_device_capability()[0] < 10:
         pytest.skip("Requires compute capability >= 10")
     elif is_hip():
-        if not (is_hip_cdna4() or is_hip_gfx1250()):
+        if not hip_supports_mxfp_dot():
             pytest.skip("Scaled mxfp8 matmul is only natively supported on CDNA4 and above")
         if (nonKDim == 16 and BLOCK_K < 128) or (nonKDim == 32 and BLOCK_K < 64):
             pytest.skip(f"CDNA4 does not support {BLOCK_K=} for scaled mfma {nonKDim=} variants")

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -5,7 +5,7 @@ import triton
 import triton.language as tl
 from test_mxfp import MXFP4Tensor, MXScaleTensor
 import re
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_cdna, hip_supports_mxfp_dot, hip_supports_mn_pack_scales
+from triton.language.target_info import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_cdna, hip_supports_mxfp_dot, hip_supports_mn_pack_scales
 
 
 def f8_to_f16(x, dtype):

--- a/python/test/unit/language/test_pipeliner.py
+++ b/python/test/unit/language/test_pipeliner.py
@@ -5,7 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda, is_hopper_or_newer, is_hip_cdna, is_hip_cdna2, is_hip
+from triton._internal_testing import is_cuda, is_hopper_or_newer
+from triton.language.target_info import is_hip_cdna, is_hip_cdna2, is_hip
 
 
 def check_capabilities():

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -7,7 +7,7 @@ import triton.language as tl
 from triton._internal_testing import is_hopper, is_sm12x, is_interpreter, numpy_random, to_triton, unwrap_tensor, tma_dtypes, to_numpy
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from typing import Optional
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3
+from triton.language.target_info import is_cuda, is_hip, is_hip_cdna3
 from triton.tools.tensor_descriptor import TensorDescriptor
 from triton import CompilationError
 

--- a/python/test/unit/language/test_warp_specialization.py
+++ b/python/test/unit/language/test_warp_specialization.py
@@ -4,7 +4,8 @@ import pathlib
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_hip, is_hopper, is_blackwell
+from triton._internal_testing import is_hopper, is_blackwell
+from triton.language.target_info import is_hip
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 if not is_hip() and torch.cuda.is_available() and torch.cuda.get_device_capability()[0] in [9, 10, 11]:

--- a/python/test/unit/plugins/test_dialect_plugin.py
+++ b/python/test/unit/plugins/test_dialect_plugin.py
@@ -3,7 +3,7 @@ import subprocess
 import pathlib
 import pytest
 
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2
+from triton.language.target_info import is_cuda, is_hip, is_hip_cdna2
 
 pytestmark = pytest.mark.skipif(is_hip_cdna2(), reason="old AMD GPUs are not supported")
 

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -6,7 +6,8 @@ import pytest
 
 import pathlib
 import uuid
-from triton._internal_testing import is_cuda, is_hip_cdna
+
+from triton.language.target_info import is_cuda, is_hip_cdna
 
 
 def do_bench(kernel_call, quantiles, use_cuda_graph=False):

--- a/python/test/unit/runtime/test_blaslt.py
+++ b/python/test/unit/runtime/test_blaslt.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4
+from triton.language.target_info import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 
 

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -13,7 +13,7 @@ import torch
 
 import triton
 import triton.language as tl
-from triton._internal_testing import is_hip
+from triton.language.target_info import is_hip
 from triton.runtime.cache import FileCacheManager, RemoteCacheManager
 
 

--- a/python/test/unit/runtime/test_launch.py
+++ b/python/test/unit/runtime/test_launch.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 import triton
 import triton.language as tl
-from triton._internal_testing import is_cuda, is_hip
+from triton.language.target_info import is_cuda, is_hip
 
 
 def test_metadata() -> None:

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import shutil
 import triton
-from triton._internal_testing import is_hip
+from triton.language.target_info import is_hip
 
 from pathlib import Path
 

--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import triton
 import triton.language as tl
-from triton._internal_testing import is_cuda, is_hip
+from triton.language.target_info import is_cuda, is_hip
 
 
 @contextmanager

--- a/python/test/unit/tools/test_aot.py
+++ b/python/test/unit/tools/test_aot.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import triton
 from triton.backends.compiler import GPUTarget
-from triton._internal_testing import is_cuda, is_hip
+from triton.language.target_info import is_cuda, is_hip
 
 if is_cuda():
     from triton.backends.nvidia.driver import include_dirs, library_dirs

--- a/python/test/unit/tools/test_triton_to_gluon.py
+++ b/python/test/unit/tools/test_triton_to_gluon.py
@@ -13,6 +13,8 @@ from triton._internal_testing import (
     is_blackwell,
     is_hopper_or_newer,
     is_cuda,
+)
+from triton.language.target_info import (
     is_hip_cdna4,
     is_hip_gfx1250,
     get_cdna_version,

--- a/python/test/unit/tools/test_triton_to_gluon.py
+++ b/python/test/unit/tools/test_triton_to_gluon.py
@@ -15,7 +15,7 @@ from triton._internal_testing import (
     is_cuda,
     is_hip_cdna4,
     is_hip_gfx1250,
-    is_hip_cdna3_or_newer,
+    get_cdna_version,
     is_hip_rdna,
 )
 from triton.language.target_info import current_target
@@ -98,7 +98,7 @@ def matmul_tile_kernel(a_ptr, b_ptr, c_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.c
 
 
 def test_triton_to_gluon_dot_minimal(tmp_path):
-    if not (is_hopper_or_newer() or is_hip_cdna3_or_newer() or is_hip_gfx1250()):
+    if not (is_hopper_or_newer() or get_cdna_version() >= 3 or is_hip_gfx1250()):
         pytest.skip("Requires Hopper, Blackwell, CDNA3+, or gfx1250")
     kernel = convert_kernel(matmul_tile_kernel, "matmul_tile_kernel", tmp_path)
     M, N, K = 128, 128, 128

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -133,6 +133,21 @@ def hip_supports_bf16xX():
     return True
 
 
+def hip_supports_float8_uz():
+    """
+    Returns true if current architecture supports float8e4b8 and float8e5b16(aka E4M3FNUZ and E5M2FNUZ)
+    """
+    return is_hip_cdna3()
+
+
+def hip_supports_cast_inf_clamping():
+    return not (is_hip_rdna4() or is_hip_gfx1250())
+
+
+def hip_supports_descriptor_scatter():
+    return is_hip_gfx1250()
+
+
 def hip_supports_f8e4m3fn_cast():
     return is_hip_cdna3() or is_hip_cdna4() or is_hip_gfx1250()
 
@@ -161,14 +176,6 @@ def hip_supports_scaled_dot():
     return is_hip_cdna() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()
 
 
-def hip_supports_mxfp_dot():
-    return is_hip_cdna4() or is_hip_gfx1250()
-
-
-def hip_supports_mn_pack_scales():
-    return is_hip_cdna4()
-
-
 def hip_wmma_version():
     if is_hip_rdna3():
         return 1
@@ -176,7 +183,19 @@ def hip_wmma_version():
         return 2
     if is_hip_gfx1250():
         return 3
-    return 0
+
+
+def get_arch():
+    target = get_current_target()
+    return "" if target is None else str(target.arch)
+
+
+def hip_supports_mxfp_dot():
+    return is_hip_cdna4() or is_hip_gfx1250()
+
+
+def hip_supports_mn_pack_scales():
+    return is_hip_cdna4()
 
 
 def numpy_random(shape, dtype_str, rs: Optional[RandomState] = None, low=None, high=None):

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -124,6 +124,61 @@ def is_xpu():
     return False if target is None else target.backend == "xpu"
 
 
+def hip_supports_bf16xX():
+    """
+    Returns true if current architecture fully supports bf16x3 and bf16x6 precision
+    """
+    if is_hip_gfx1250():
+        return False
+    return True
+
+
+def hip_supports_f8e4m3fn_cast():
+    return is_hip_cdna3() or is_hip_cdna4() or is_hip_gfx1250()
+
+
+def hip_supports_vdot():
+    return is_hip_cdna() or is_hip_rdna() or is_hip_gfx1250() or is_hip_gfx1250()
+
+
+def hip_supports_f8e5():
+    return is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()
+
+
+def hip_supports_f8e4nv():
+    return is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()
+
+
+def hip_supports_f8e4m3():
+    return is_hip_cdna3() or is_hip_cdna4() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()
+
+
+def hip_supports_kpack():
+    return is_hip_cdna2() or is_hip_cdna3()
+
+
+def hip_supports_scaled_dot():
+    return is_hip_cdna() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()
+
+
+def hip_supports_mxfp_dot():
+    return is_hip_cdna4() or is_hip_gfx1250()
+
+
+def hip_supports_mn_pack_scales():
+    return is_hip_cdna4()
+
+
+def hip_wmma_version():
+    if is_hip_rdna3():
+        return 1
+    if is_hip_cdna4():
+        return 2
+    if is_hip_gfx1250():
+        return 3
+    return 0
+
+
 def numpy_random(shape, dtype_str, rs: Optional[RandomState] = None, low=None, high=None):
     """
     Override `rs` if you're calling this function twice and don't want the same

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -67,135 +67,14 @@ def is_sm12x():
     return is_cuda() and torch.cuda.get_device_capability()[0] == 12
 
 
-def is_hip():
-    target = get_current_target()
-    return False if target is None else target.backend == "hip"
-
-
-def is_hip_cdna2():
-    target = get_current_target()
-    return target is not None and target.backend == 'hip' and target.arch == 'gfx90a'
-
-
-def is_hip_cdna3():
-    target = get_current_target()
-    return target is not None and target.backend == 'hip' and target.arch == 'gfx942'
-
-
-def is_hip_cdna4():
-    target = get_current_target()
-    return target is not None and target.backend == 'hip' and target.arch == 'gfx950'
-
-
-def is_hip_rdna3():
-    target = get_current_target()
-    return target is not None and target.backend == 'hip' and 'gfx11' in target.arch
-
-
-def is_hip_rdna4():
-    target = get_current_target()
-    # check for gfx120 instead of gfx12, to avoid matching gfx1250
-    return target is not None and target.backend == 'hip' and 'gfx120' in target.arch
-
-
-def is_hip_gfx1250():
-    target = get_current_target()
-    return target is not None and target.backend == 'hip' and 'gfx1250' in target.arch
-
-
-def is_hip_cdna3_or_newer():
-    return is_hip_cdna3() or is_hip_cdna4()
-
-
-def is_hip_cdna():
-    return is_hip_cdna2() or is_hip_cdna3() or is_hip_cdna4()
-
-
-def is_hip_rdna():
-    return is_hip_rdna3() or is_hip_rdna4()
-
-
-def get_hip_lds_size():
-    return 163840 if is_hip_cdna4() else 65536
-
-
 def is_xpu():
     target = get_current_target()
     return False if target is None else target.backend == "xpu"
 
 
-def hip_supports_bf16xX():
-    """
-    Returns true if current architecture fully supports bf16x3 and bf16x6 precision
-    """
-    if is_hip_gfx1250():
-        return False
-    return True
-
-
-def hip_supports_float8_uz():
-    """
-    Returns true if current architecture supports float8e4b8 and float8e5b16(aka E4M3FNUZ and E5M2FNUZ)
-    """
-    return is_hip_cdna3()
-
-
-def hip_supports_cast_inf_clamping():
-    return not (is_hip_rdna4() or is_hip_gfx1250())
-
-
-def hip_supports_descriptor_scatter():
-    return is_hip_gfx1250()
-
-
-def hip_supports_f8e4m3fn_cast():
-    return is_hip_cdna3() or is_hip_cdna4() or is_hip_gfx1250()
-
-
-def hip_supports_vdot():
-    return is_hip_cdna() or is_hip_rdna() or is_hip_gfx1250() or is_hip_gfx1250()
-
-
-def hip_supports_f8e5():
-    return is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()
-
-
-def hip_supports_f8e4nv():
-    return is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()
-
-
-def hip_supports_f8e4m3():
-    return is_hip_cdna3() or is_hip_cdna4() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()
-
-
-def hip_supports_kpack():
-    return is_hip_cdna2() or is_hip_cdna3()
-
-
-def hip_supports_scaled_dot():
-    return is_hip_cdna() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()
-
-
-def hip_wmma_version():
-    if is_hip_rdna3():
-        return 1
-    if is_hip_cdna4():
-        return 2
-    if is_hip_gfx1250():
-        return 3
-
-
 def get_arch():
     target = get_current_target()
     return "" if target is None else str(target.arch)
-
-
-def hip_supports_mxfp_dot():
-    return is_hip_cdna4() or is_hip_gfx1250()
-
-
-def hip_supports_mn_pack_scales():
-    return is_hip_cdna4()
 
 
 def numpy_random(shape, dtype_str, rs: Optional[RandomState] = None, low=None, high=None):

--- a/python/triton/language/target_info.py
+++ b/python/triton/language/target_info.py
@@ -42,61 +42,62 @@ def is_hip():
     return False if target is None else target.backend == "hip"
 
 
+if is_hip():
+    from triton._C.libtriton import amd
+
+
 @constexpr_function
 def is_hip_cdna2():
     target = current_target()
-    return target is not None and target.backend == 'hip' and target.arch == 'gfx90a'
+    return is_hip() and amd.is_hip_cdna2(target.arch)
 
 
 @constexpr_function
 def is_hip_cdna3():
     target = current_target()
-    return target is not None and target.backend == 'hip' and target.arch == 'gfx942'
+    return is_hip() and amd.is_hip_cdna3(target.arch)
 
 
 @constexpr_function
 def is_hip_cdna4():
     target = current_target()
-    return target is not None and target.backend == 'hip' and target.arch == 'gfx950'
+    return is_hip() and amd.is_hip_cdna4(target.arch)
 
 
 @constexpr_function
 def is_hip_rdna3():
     target = current_target()
-    return target is not None and target.backend == 'hip' and 'gfx11' in target.arch
+    return is_hip() and amd.is_hip_rdna3(target.arch)
 
 
 @constexpr_function
 def is_hip_rdna4():
     target = current_target()
-    # check for gfx120 instead of gfx12, to avoid matching gfx1250
-    return target is not None and target.backend == 'hip' and 'gfx120' in target.arch
+    return is_hip() and amd.is_hip_rdna4(target.arch)
 
 
 @constexpr_function
 def is_hip_gfx1250():
     target = current_target()
-    return target is not None and target.backend == 'hip' and 'gfx1250' in target.arch
-
-
-@constexpr_function
-def is_hip_cdna3_or_newer():
-    return is_hip_cdna3() or is_hip_cdna4()
+    return is_hip() and amd.is_hip_gfx1250(target.arch)
 
 
 @constexpr_function
 def is_hip_cdna():
-    return is_hip_cdna2() or is_hip_cdna3() or is_hip_cdna4()
+    target = current_target()
+    return is_hip() and amd.is_hip_cdna(target.arch)
 
 
 @constexpr_function
 def is_hip_rdna():
-    return is_hip_rdna3() or is_hip_rdna4()
+    target = current_target()
+    return is_hip() and amd.is_hip_rdna(target.arch)
 
 
 @constexpr_function
 def get_hip_lds_size():
-    return 163840 if is_hip_cdna4() else 65536
+    target = current_target()
+    return amd.get_hip_lds_size(target.arch) if is_hip() else 0
 
 
 @constexpr_function
@@ -104,9 +105,8 @@ def hip_supports_bf16xX():
     """
     Returns true if current architecture fully supports bf16x3 and bf16x6 precision
     """
-    if is_hip_gfx1250():
-        return False
-    return True
+    target = current_target()
+    return is_hip() and amd.hip_supports_bf16xX(target.arch)
 
 
 @constexpr_function
@@ -114,103 +114,95 @@ def hip_supports_float8_uz():
     """
     Returns true if current architecture supports float8e4b8 and float8e5b16(aka E4M3FNUZ and E5M2FNUZ)
     """
-    return is_hip_cdna3()
+    target = current_target()
+    return is_hip() and amd.hip_supports_float8_uz(target.arch)
 
 
 @constexpr_function
 def hip_supports_cast_inf_clamping():
-    return not (is_hip_rdna4() or is_hip_gfx1250())
+    target = current_target()
+    return is_hip() and amd.hip_supports_cast_inf_clamping(target.arch)
 
 
 @constexpr_function
 def hip_supports_descriptor_scatter():
-    return is_hip_gfx1250()
+    target = current_target()
+    return is_hip() and amd.hip_supports_descriptor_scatter(target.arch)
 
 
 @constexpr_function
 def hip_supports_f8e4m3fn_cast():
-    return is_hip_cdna3() or is_hip_cdna4() or is_hip_gfx1250()
+    target = current_target()
+    return is_hip() and amd.hip_supports_f8e4m3fn_cast(target.arch)
 
 
 @constexpr_function
 def hip_supports_vdot():
-    return is_hip_cdna() or is_hip_rdna() or is_hip_gfx1250() or is_hip_gfx1250()
+    target = current_target()
+    return is_hip() and amd.hip_supports_vdot(target.arch)
 
 
 @constexpr_function
 def hip_supports_f8e5():
-    return is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()
+    target = current_target()
+    return is_hip() and amd.hip_supports_f8e5(target.arch)
 
 
 @constexpr_function
 def hip_supports_f8e4nv():
-    return is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()
+    target = current_target()
+    return is_hip() and amd.hip_supports_f8e4nv(target.arch)
 
 
 @constexpr_function
 def hip_supports_f8e4m3():
-    return is_hip_cdna3() or is_hip_cdna4() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()
+    target = current_target()
+    return is_hip() and amd.hip_supports_f8e4m3(target.arch)
 
 
 @constexpr_function
 def hip_supports_kpack():
-    return is_hip_cdna2() or is_hip_cdna3()
+    target = current_target()
+    return is_hip() and amd.hip_supports_kpack(target.arch)
 
 
 @constexpr_function
 def hip_supports_scaled_dot():
-    return is_hip_cdna() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()
+    target = current_target()
+    return is_hip() and amd.hip_supports_scaled_dot(target.arch)
 
 
 @constexpr_function
 def hip_wmma_version():
-    if is_hip_rdna3():
-        return 1
-    if is_hip_cdna4():
-        return 2
-    if is_hip_gfx1250():
-        return 3
+    target = current_target()
+    return amd.hip_wmma_version(target.arch) if is_hip() else 0
 
 
 @constexpr_function
 def hip_supports_mxfp_dot():
-    return is_hip_cdna4() or is_hip_gfx1250()
+    target = current_target()
+    return is_hip() and amd.hip_supports_mxfp_dot(target.arch)
 
 
 @constexpr_function
 def hip_supports_mn_pack_scales():
-    return is_hip_cdna4()
+    target = current_target()
+    return is_hip() and amd.hip_supports_mn_pack_scales(target.arch)
 
 
 @constexpr_function
 def get_cdna_version():
     """
-    Gets the AMD architecture version, i.e. CDNA3 or CDNA4, currently
-    only supports 3 (gfx942) or 4 (gfx950). Returns -1 if it is not AMD
-    hardware or unsupported architecture
+    Gets the CDNA architecture generation (1-4), or -1 if not CDNA.
     """
     target = current_target()
-    if target.backend != 'hip':
-        return -1
-    if target.arch == 'gfx942':
-        return 3
-    if target.arch == 'gfx950':
-        return 4
-    return -1
+    return amd.get_cdna_version(target.arch) if is_hip() else -1
 
 
 @constexpr_function
 def get_rdna_version():
     """
-    Gets the AMD architecture version, i.e. RDNA3 or RDNA4, by matching
-    gfx11* (RDNA3) or gfx12* (RDNA4). Returns -1 if it is not AMD
-    hardware or unsupported architecture.
+    Gets the RDNA architecture generation (1-4), or -1 if not RDNA.
     """
     target = current_target()
-    if target.backend != 'hip':
-        return -1
-    if target.arch.startswith('gfx11'):
-        return 3
-    if target.arch.startswith('gfx12') and not target.arch.startswith('gfx125'):
-        return 4
-    return -1
+    return amd.get_rdna_version(target.arch) if is_hip() else -1

--- a/python/triton/language/target_info.py
+++ b/python/triton/language/target_info.py
@@ -39,22 +39,178 @@ def cuda_capability_geq(major, minor=0):
 @constexpr_function
 def is_hip():
     target = current_target()
-    return target is not None and target.backend == "hip"
+    return False if target is None else target.backend == "hip"
+
+
+@constexpr_function
+def is_hip_cdna2():
+    target = current_target()
+    return target is not None and target.backend == 'hip' and target.arch == 'gfx90a'
 
 
 @constexpr_function
 def is_hip_cdna3():
     target = current_target()
-    return target is not None and target.arch == "gfx942"
+    return target is not None and target.backend == 'hip' and target.arch == 'gfx942'
 
 
 @constexpr_function
 def is_hip_cdna4():
     target = current_target()
-    return target is not None and target.arch == "gfx950"
+    return target is not None and target.backend == 'hip' and target.arch == 'gfx950'
+
+
+@constexpr_function
+def is_hip_rdna3():
+    target = current_target()
+    return target is not None and target.backend == 'hip' and 'gfx11' in target.arch
+
+
+@constexpr_function
+def is_hip_rdna4():
+    target = current_target()
+    # check for gfx120 instead of gfx12, to avoid matching gfx1250
+    return target is not None and target.backend == 'hip' and 'gfx120' in target.arch
 
 
 @constexpr_function
 def is_hip_gfx1250():
     target = current_target()
-    return target is not None and target.arch == "gfx1250"
+    return target is not None and target.backend == 'hip' and 'gfx1250' in target.arch
+
+
+@constexpr_function
+def is_hip_cdna3_or_newer():
+    return is_hip_cdna3() or is_hip_cdna4()
+
+
+@constexpr_function
+def is_hip_cdna():
+    return is_hip_cdna2() or is_hip_cdna3() or is_hip_cdna4()
+
+
+@constexpr_function
+def is_hip_rdna():
+    return is_hip_rdna3() or is_hip_rdna4()
+
+
+@constexpr_function
+def get_hip_lds_size():
+    return 163840 if is_hip_cdna4() else 65536
+
+
+@constexpr_function
+def hip_supports_bf16xX():
+    """
+    Returns true if current architecture fully supports bf16x3 and bf16x6 precision
+    """
+    if is_hip_gfx1250():
+        return False
+    return True
+
+
+@constexpr_function
+def hip_supports_float8_uz():
+    """
+    Returns true if current architecture supports float8e4b8 and float8e5b16(aka E4M3FNUZ and E5M2FNUZ)
+    """
+    return is_hip_cdna3()
+
+
+@constexpr_function
+def hip_supports_cast_inf_clamping():
+    return not (is_hip_rdna4() or is_hip_gfx1250())
+
+
+@constexpr_function
+def hip_supports_descriptor_scatter():
+    return is_hip_gfx1250()
+
+
+@constexpr_function
+def hip_supports_f8e4m3fn_cast():
+    return is_hip_cdna3() or is_hip_cdna4() or is_hip_gfx1250()
+
+
+@constexpr_function
+def hip_supports_vdot():
+    return is_hip_cdna() or is_hip_rdna() or is_hip_gfx1250() or is_hip_gfx1250()
+
+
+@constexpr_function
+def hip_supports_f8e5():
+    return is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()
+
+
+@constexpr_function
+def hip_supports_f8e4nv():
+    return is_hip_cdna4() or is_hip_rdna4() or is_hip_gfx1250()
+
+
+@constexpr_function
+def hip_supports_f8e4m3():
+    return is_hip_cdna3() or is_hip_cdna4() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()
+
+
+@constexpr_function
+def hip_supports_kpack():
+    return is_hip_cdna2() or is_hip_cdna3()
+
+
+@constexpr_function
+def hip_supports_scaled_dot():
+    return is_hip_cdna() or is_hip_rdna3() or is_hip_rdna4() or is_hip_gfx1250()
+
+
+@constexpr_function
+def hip_wmma_version():
+    if is_hip_rdna3():
+        return 1
+    if is_hip_cdna4():
+        return 2
+    if is_hip_gfx1250():
+        return 3
+
+
+@constexpr_function
+def hip_supports_mxfp_dot():
+    return is_hip_cdna4() or is_hip_gfx1250()
+
+
+@constexpr_function
+def hip_supports_mn_pack_scales():
+    return is_hip_cdna4()
+
+
+@constexpr_function
+def get_cdna_version():
+    """
+    Gets the AMD architecture version, i.e. CDNA3 or CDNA4, currently
+    only supports 3 (gfx942) or 4 (gfx950). Returns -1 if it is not AMD
+    hardware or unsupported architecture
+    """
+    target = current_target()
+    if target.backend != 'hip':
+        return -1
+    if target.arch == 'gfx942':
+        return 3
+    if target.arch == 'gfx950':
+        return 4
+    return -1
+
+
+@constexpr_function
+def get_rdna_version():
+    """
+    Gets the AMD architecture version, i.e. RDNA3 or RDNA4, by matching
+    gfx11* (RDNA3) or gfx12* (RDNA4). Returns -1 if it is not AMD
+    hardware or unsupported architecture.
+    """
+    target = current_target()
+    if target.backend != 'hip':
+        return -1
+    if target.arch.startswith('gfx11'):
+        return 3
+    if target.arch.startswith('gfx12') and not target.arch.startswith('gfx125'):
+        return 4
+    return -1

--- a/python/triton/language/target_info.py
+++ b/python/triton/language/target_info.py
@@ -1,5 +1,9 @@
 from triton.runtime import driver
 from triton.runtime.jit import constexpr_function
+from triton.backends import backends
+
+if "amd" in backends:
+    from triton._C.libtriton import amd
 
 __all__ = ["current_target"]
 
@@ -39,11 +43,7 @@ def cuda_capability_geq(major, minor=0):
 @constexpr_function
 def is_hip():
     target = current_target()
-    return False if target is None else target.backend == "hip"
-
-
-if is_hip():
-    from triton._C.libtriton import amd
+    return target is not None and target.backend == "hip"
 
 
 @constexpr_function

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -17,7 +17,8 @@ from triton_kernels.numerics_details.mxfp import upcast_from_mxfp, quantize_mxfp
 # testing utilities
 from triton_kernels.testing import assert_close, make_random_tensor
 # target-specific utilities
-from triton_kernels.target_info import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_gfx1250
+from triton_kernels.target_info import is_cuda
+from triton.language.target_info import is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_gfx1250
 from triton_kernels.swiglu import swiglu, swiglu_fn
 from triton_kernels.swiglu import PrecisionConfig as SwiGLUPrecisionConfig
 from triton_kernels.tensor_details import layout

--- a/python/triton_kernels/tests/test_reduce.py
+++ b/python/triton_kernels/tests/test_reduce.py
@@ -5,7 +5,8 @@ from triton_kernels.reduce import reduce, reduce_torch, PostprocessFn, FnSpecs
 from triton_kernels.reduce import scoped_opt_flags_constraints
 from triton_kernels.numerics_details.mxfp import upcast_from_mxfp_torch, downcast_to_mxfp_torch
 from triton_kernels.numerics import InFlexData, OutFlexData
-from triton_kernels.target_info import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4
+from triton_kernels.target_info import is_cuda
+from triton.language.target_info import is_hip, is_hip_cdna3, is_hip_cdna4
 import triton
 import triton.language as tl
 

--- a/python/triton_kernels/triton_kernels/target_info.py
+++ b/python/triton_kernels/triton_kernels/target_info.py
@@ -1,6 +1,5 @@
 import torch
 import triton
-import triton.language as tl
 
 from triton.language.target_info import (
     cuda_capability_geq,
@@ -13,8 +12,6 @@ from triton.language.target_info import (
 
 __all__ = [
     "cuda_capability_geq",
-    "get_cdna_version",
-    "get_rdna_version",
     "has_tma_gather",
     "has_native_mxfp",
     "is_cuda",
@@ -24,40 +21,6 @@ __all__ = [
     "is_hip_gfx1250",
     "num_sms",
 ]
-
-
-@triton.constexpr_function
-def get_cdna_version():
-    """
-    Gets the AMD architecture version, i.e. CDNA3 or CDNA4, currently
-    only supports 3 (gfx942) or 4 (gfx950). Returns -1 if it is not AMD
-    hardware or unsupported architecture
-    """
-    target = tl.target_info.current_target()
-    if target.backend != 'hip':
-        return -1
-    if target.arch == 'gfx942':
-        return 3
-    if target.arch == 'gfx950':
-        return 4
-    return -1
-
-
-@triton.constexpr_function
-def get_rdna_version():
-    """
-    Gets the AMD architecture version, i.e. RDNA3 or RDNA4, by matching
-    gfx11* (RDNA3) or gfx12* (RDNA4). Returns -1 if it is not AMD
-    hardware or unsupported architecture.
-    """
-    target = tl.target_info.current_target()
-    if target.backend != 'hip':
-        return -1
-    if target.arch.startswith('gfx11'):
-        return 3
-    if target.arch.startswith('gfx12') and not target.arch.startswith('gfx125'):
-        return 4
-    return -1
 
 
 @triton.constexpr_function

--- a/python/triton_kernels/triton_kernels/target_info.py
+++ b/python/triton_kernels/triton_kernels/target_info.py
@@ -8,6 +8,8 @@ from triton.language.target_info import (
     is_hip_cdna3,
     is_hip_cdna4,
     is_hip_gfx1250,
+    get_cdna_version,
+    get_rdna_version,
 )
 
 __all__ = [
@@ -19,6 +21,8 @@ __all__ = [
     "is_hip_cdna3",
     "is_hip_cdna4",
     "is_hip_gfx1250",
+    "get_cdna_version",
+    "get_rdna_version",
     "num_sms",
 ]
 

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TargetFeatures.h
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TargetFeatures.h
@@ -52,9 +52,30 @@ public:
 
   bool isCDNA() const;
   bool isRDNA() const;
+  bool isCDNA2() const;
   bool isCDNA3() const;
   bool isCDNA4() const;
+  bool isRDNA3() const;
+  bool isRDNA4() const;
   bool isGFX1250() const;
+
+  int getCDNAVersion() const;
+  int getRDNAVersion() const;
+
+  bool hipSupportsBf16xX() const;
+  bool hipSupportsFloat8Uz() const;
+  bool hipSupportsCastInfClamping() const;
+  bool hipSupportsDescriptorScatter() const;
+  bool hipSupportsF8e4m3fnCast() const;
+  bool hipSupportsVdot() const;
+  bool hipSupportsF8e5() const;
+  bool hipSupportsF8e4nv() const;
+  bool hipSupportsF8e4m3() const;
+  bool hipSupportsKpack() const;
+  bool hipSupportsScaledDot() const;
+  int hipWMMAVersion() const;
+  bool hipSupportsMxFpDot() const;
+  bool hipSupportsMNPackScales() const;
 
   int getWarpSize() const;
   bool supportsWaveId() const;

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
@@ -106,6 +106,10 @@ bool TargetFeatures::isRDNA() const {
   return mlir::triton::amdgpu::isRDNA(getISAFamily());
 }
 
+bool TargetFeatures::isCDNA2() const {
+  return getISAFamily() == ISAFamily::CDNA2;
+}
+
 bool TargetFeatures::isCDNA3() const {
   return getISAFamily() == ISAFamily::CDNA3;
 }
@@ -114,9 +118,101 @@ bool TargetFeatures::isCDNA4() const {
   return getISAFamily() == ISAFamily::CDNA4;
 }
 
+bool TargetFeatures::isRDNA3() const {
+  return getISAFamily() == ISAFamily::RDNA3;
+}
+
+bool TargetFeatures::isRDNA4() const {
+  return getISAFamily() == ISAFamily::RDNA4;
+}
+
 bool TargetFeatures::isGFX1250() const {
   return getISAFamily() == ISAFamily::GFX1250;
 }
+
+int TargetFeatures::getCDNAVersion() const {
+  switch (getISAFamily()) {
+  case ISAFamily::CDNA1:
+    return 1;
+  case ISAFamily::CDNA2:
+    return 2;
+  case ISAFamily::CDNA3:
+    return 3;
+  case ISAFamily::CDNA4:
+    return 4;
+  default:
+    return -1;
+  }
+}
+
+int TargetFeatures::getRDNAVersion() const {
+  switch (getISAFamily()) {
+  case ISAFamily::RDNA1:
+    return 1;
+  case ISAFamily::RDNA2:
+    return 2;
+  case ISAFamily::RDNA3:
+    return 3;
+  case ISAFamily::RDNA4:
+    return 4;
+  default:
+    return -1;
+  }
+}
+
+bool TargetFeatures::hipSupportsBf16xX() const { return !isGFX1250(); }
+
+bool TargetFeatures::hipSupportsFloat8Uz() const { return isCDNA3(); }
+
+bool TargetFeatures::hipSupportsCastInfClamping() const {
+  return !(isRDNA4() || isGFX1250());
+}
+
+bool TargetFeatures::hipSupportsDescriptorScatter() const {
+  return isGFX1250();
+}
+
+bool TargetFeatures::hipSupportsF8e4m3fnCast() const {
+  return isCDNA3() || isCDNA4() || isGFX1250();
+}
+
+bool TargetFeatures::hipSupportsVdot() const {
+  return isCDNA() || isRDNA() || isGFX1250();
+}
+
+bool TargetFeatures::hipSupportsF8e5() const {
+  return isCDNA4() || isRDNA4() || isGFX1250();
+}
+
+bool TargetFeatures::hipSupportsF8e4nv() const {
+  return isCDNA4() || isRDNA4() || isGFX1250();
+}
+
+bool TargetFeatures::hipSupportsF8e4m3() const {
+  return isCDNA3() || isCDNA4() || isRDNA3() || isRDNA4() || isGFX1250();
+}
+
+bool TargetFeatures::hipSupportsKpack() const { return isCDNA2() || isCDNA3(); }
+
+bool TargetFeatures::hipSupportsScaledDot() const {
+  return isCDNA() || isRDNA3() || isRDNA4() || isGFX1250();
+}
+
+int TargetFeatures::hipWMMAVersion() const {
+  if (isRDNA3())
+    return 1;
+  if (isCDNA4())
+    return 2;
+  if (isGFX1250())
+    return 3;
+  return 0;
+}
+
+bool TargetFeatures::hipSupportsMxFpDot() const {
+  return isCDNA4() || isGFX1250();
+}
+
+bool TargetFeatures::hipSupportsMNPackScales() const { return isCDNA4(); }
 
 int TargetFeatures::getWarpSize() const {
   switch (getISAFamily()) {

--- a/third_party/amd/python/test/test_convert_op_permlane_swap.py
+++ b/third_party/amd/python/test/test_convert_op_permlane_swap.py
@@ -4,7 +4,8 @@ import pathlib
 
 import triton
 
-from triton._internal_testing import is_hip_cdna4, is_hip_gfx1250, to_triton, numpy_random
+from triton._internal_testing import to_triton, numpy_random
+from triton.language.target_info import is_hip_cdna4, is_hip_gfx1250
 
 num_ctas_list = [1]
 

--- a/third_party/amd/python/test/test_extract_slice_concat_op.py
+++ b/third_party/amd/python/test/test_extract_slice_concat_op.py
@@ -4,7 +4,7 @@ import pathlib
 
 import triton
 
-from triton._internal_testing import is_hip
+from triton.language.target_info import is_hip
 
 GPU_DIALECT = "ttg"
 

--- a/third_party/amd/python/test/test_f16_gemm_tdm.py
+++ b/third_party/amd/python/test/test_f16_gemm_tdm.py
@@ -3,7 +3,7 @@ import torch
 
 import triton
 import triton.language as tl
-from triton._internal_testing import is_hip_gfx1250
+from triton.language.target_info import is_hip_gfx1250
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -8,7 +8,8 @@ from itertools import product
 import triton
 import triton.language as tl
 from triton.backends.compiler import GPUTarget
-from triton._internal_testing import is_hip_gfx1250, str_to_triton_dtype, numpy_random, to_triton, unwrap_tensor, float_dtypes, int_dtypes, uint_dtypes
+from triton._internal_testing import str_to_triton_dtype, numpy_random, to_triton, unwrap_tensor, float_dtypes, int_dtypes, uint_dtypes
+from triton.language.target_info import is_hip_gfx1250
 from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from triton.experimental import gluon
 import triton.experimental.gluon.language as ttgl

--- a/third_party/amd/python/test/test_gluon_gfx1250_consan.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250_consan.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import os
 
-from triton._internal_testing import is_hip_gfx1250
+from triton.language.target_info import is_hip_gfx1250
 
 
 def _run_consan_subprocess(test_name, *args, timeout=120):

--- a/third_party/amd/python/test/test_llvm_fn_attrs.py
+++ b/third_party/amd/python/test/test_llvm_fn_attrs.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 import triton
 
-from triton._internal_testing import is_hip
+from triton.language.target_info import is_hip
 
 if not is_hip():
     pytest.skip(allow_module_level=True)

--- a/third_party/amd/python/test/test_mxfp_gemm_tdm.py
+++ b/third_party/amd/python/test/test_mxfp_gemm_tdm.py
@@ -19,7 +19,7 @@ import triton.language as tl
 import argparse
 import pytest
 from triton.tools.mxfp import MXScaleTensor, MXFP4Tensor
-from triton._internal_testing import is_hip_gfx1250
+from triton.language.target_info import is_hip_gfx1250
 
 # ============================================================================
 # Constants

--- a/third_party/amd/python/test/test_pointer_optimization.py
+++ b/third_party/amd/python/test/test_pointer_optimization.py
@@ -3,7 +3,7 @@ import torch
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_hip
+from triton.language.target_info import is_hip
 
 if not is_hip():
     pytest.skip(allow_module_level=True)

--- a/third_party/amd/python/test/test_tdm_copy.py
+++ b/third_party/amd/python/test/test_tdm_copy.py
@@ -90,7 +90,7 @@ import torch
 
 import triton
 from triton.backends.compiler import GPUTarget
-from triton._internal_testing import is_hip_gfx1250
+from triton.language.target_info import is_hip_gfx1250
 from triton.experimental import gluon
 import triton.experimental.gluon.language as ttgl
 

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -1,4 +1,5 @@
 #include "Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "Dialect/TritonAMDGPU/IR/TargetFeatures.h"
 #include "TritonAMDGPUToLLVM/Passes.h"
 #include "TritonAMDGPUTransforms/Passes.h"
 #include "amd/include/hipblas_instance.h"
@@ -592,4 +593,129 @@ void init_triton_amd(py::module &&m) {
         self.gemm(init.m, init.n, init.k, A_ptr, B_ptr, C_ptr, D_ptr,
                   init.dtype, init.out_dtype, alpha, beta);
       });
+
+  m.def("is_hip_cdna", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.isCDNA();
+  });
+
+  m.def("is_hip_cdna2", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.isCDNA2();
+  });
+
+  m.def("is_hip_cdna3", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.isCDNA3();
+  });
+
+  m.def("is_hip_cdna4", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.isCDNA4();
+  });
+
+  m.def("is_hip_rdna", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.isRDNA();
+  });
+
+  m.def("is_hip_rdna3", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.isRDNA3();
+  });
+
+  m.def("is_hip_rdna4", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.isRDNA4();
+  });
+
+  m.def("is_hip_gfx1250", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.isGFX1250();
+  });
+
+  m.def("get_cdna_version", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.getCDNAVersion();
+  });
+
+  m.def("get_rdna_version", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.getRDNAVersion();
+  });
+
+  m.def("get_hip_lds_size", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.getSharedMemorySize();
+  });
+
+  m.def("hip_supports_bf16xX", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsBf16xX();
+  });
+
+  m.def("hip_supports_float8_uz", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsFloat8Uz();
+  });
+
+  m.def("hip_supports_cast_inf_clamping", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsCastInfClamping();
+  });
+
+  m.def("hip_supports_descriptor_scatter", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsDescriptorScatter();
+  });
+
+  m.def("hip_supports_f8e4m3fn_cast", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsF8e4m3fnCast();
+  });
+
+  m.def("hip_supports_vdot", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsVdot();
+  });
+
+  m.def("hip_supports_f8e5", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsF8e5();
+  });
+
+  m.def("hip_supports_f8e4nv", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsF8e4nv();
+  });
+
+  m.def("hip_supports_f8e4m3", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsF8e4m3();
+  });
+
+  m.def("hip_supports_kpack", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsKpack();
+  });
+
+  m.def("hip_supports_scaled_dot", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsScaledDot();
+  });
+
+  m.def("hip_wmma_version", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipWMMAVersion();
+  });
+
+  m.def("hip_supports_mxfp_dot", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsMxFpDot();
+  });
+
+  m.def("hip_supports_mn_pack_scales", [](const std::string &arch) {
+    mlir::triton::amdgpu::TargetFeatures tf{llvm::StringRef(arch)};
+    return tf.hipSupportsMNPackScales();
+  });
 }

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -13,7 +13,7 @@ from triton.profiler.hooks.hook import HookManager
 from triton.profiler.hooks.launch import LaunchHook
 from triton.profiler.hooks.instrumentation import InstrumentationHook
 from triton.profiler.metric import transform_tensor_metrics
-from triton._internal_testing import is_hip
+from triton.language.target_info import is_hip
 
 
 def test_profile_single_session(tmp_path: pathlib.Path):

--- a/third_party/proton/test/test_instrumentation.py
+++ b/third_party/proton/test/test_instrumentation.py
@@ -14,7 +14,7 @@ from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
 from triton.experimental.gluon.language.nvidia.blackwell import clc
 from triton.experimental.gluon.language.nvidia.hopper import mbarrier
-from triton._internal_testing import (
+from triton.language.target_info import (
     is_cuda,
     is_hip,
     is_hip_cdna2,

--- a/third_party/proton/test/test_instrumentation.py
+++ b/third_party/proton/test/test_instrumentation.py
@@ -19,6 +19,8 @@ from triton.language.target_info import (
     is_hip,
     is_hip_cdna2,
     is_hip_cdna4,
+)
+from triton._internal_testing import (
     supports_tma,
     supports_ws,
 )

--- a/third_party/proton/test/test_override.py
+++ b/third_party/proton/test/test_override.py
@@ -4,7 +4,7 @@ import pathlib
 import json
 import pytest
 
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2
+from triton.language.target_info import is_cuda, is_hip, is_hip_cdna2
 
 pytestmark = pytest.mark.skipif(is_hip_cdna2(), reason="old AMD GPUs are not supported")
 

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -18,7 +18,8 @@ import triton.language as tl
 import triton.profiler.hooks.launch as proton_launch
 from triton.profiler.state import COMPUTE_METADATA_SCOPE_NAME
 import triton.profiler.viewer as viewer
-from triton._internal_testing import is_hip, is_cuda, is_blackwell
+from triton._internal_testing import is_blackwell
+from triton.language.target_info import is_hip, is_cuda
 
 
 def _find_frame_by_name(frame, name):


### PR DESCRIPTION
This PR:
- Moves part of arch specific checks into aggregate functions that represent specific hardware feature;
- Moves these aggregate functions into C++ part of the code;
- Clean up some checks and test sets, specific to particular architectures(disable tests designed for CDNA architectures on RDNA targets).

Motivation is to simplify hardware feature management, for faster support of future architectures and easier experiments.
Currently there are four main places where architecture related checks for AMD hardware are living. This makes implementation or modification of architecture switches hard and error prone:

- /triton/python/triton/_internal_testing.py
- /triton/python/triton_kernels/triton_kernels/target_info.py
- /triton/python/triton/language/target_info.py
- /triton/third_party/amd/include/Dialect/TritonAMDGPU/IR/TargetFeatures.h/cpp

This PR proposes to put as much as possible of these feature knobs in C++ `TargetFeature` class, expose these knobs in `triton_amd.cc` library and wrap them in `triton.language.target_info.py` for use in python code.

Two main use cases:
- enable or disable some feature for a given architecture. Need to change only one place in C++ code, which will automatically disable related tests and all compiler passes/features;
- add new feature. Need to add it in `TargetFeature` class, expose it in `triton_amd.cc` and implement a wrapper in `triton.language.target_info` module.