### PR TITLE
[AMD] Add Triton-level tt.descriptor_gather and tt.descriptor_scatter support for gfx1250

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -1306,7 +1306,7 @@ def TT_DescriptorGatherOp : TT_Op<"descriptor_gather", [TT_DescriptorLoadLikeOpI
 
   let arguments = (ins
     Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
-    RankedTensorOf<[I32]>:$x_offsets,
+    RankedTensorOf<[I16, I32]>:$x_offsets,
     I32:$y_offset
   );
   let results = (outs TT_Tensor:$result);
@@ -1332,7 +1332,7 @@ def TT_DescriptorScatterOp : TT_Op<"descriptor_scatter", [TT_DescriptorStoreLike
 
   let arguments = (ins
     Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
-    RankedTensorOf<[I32]>:$x_offsets,
+    RankedTensorOf<[I16, I32]>:$x_offsets,
     I32:$y_offset,
     TT_Tensor:$src
   );

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -83,6 +83,10 @@ struct TMAGatherLowering : public OpRewritePattern<DescriptorGatherOp> {
 
   LogicalResult matchAndRewrite(DescriptorGatherOp op,
                                 PatternRewriter &rewriter) const override {
+    auto indicesType = cast<RankedTensorType>(op.getXOffsets().getType());
+    if (!indicesType.getElementType().isInteger(32))
+      return op.emitOpError("NVIDIA TMA gather only supports i32 indices");
+
     auto createLoad = [&](Value desc, Value barrierAlloc, Value alloc,
                           Value pred) {
       triton::nvidia_gpu::AsyncTMAGatherOp::create(
@@ -147,6 +151,10 @@ struct TMAScatterLowering : public OpRewritePattern<DescriptorScatterOp> {
 
   LogicalResult matchAndRewrite(DescriptorScatterOp op,
                                 PatternRewriter &rewriter) const override {
+    auto indicesType = cast<RankedTensorType>(op.getXOffsets().getType());
+    if (!indicesType.getElementType().isInteger(32))
+      return op.emitOpError("NVIDIA TMA scatter only supports i32 indices");
+
     auto createStore = [&](Value desc, Value alloc) {
       triton::nvidia_gpu::AsyncTMAScatterOp::create(rewriter, op.getLoc(), desc,
                                                     op.getXOffsets(),

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -1376,10 +1376,13 @@ def torch_gather_rows(input, idx, y, block_y):
 @pytest.mark.parametrize("BLOCK_X, BLOCK_Y", [(32, 32), (64, 128), (16, 128), (512, 16)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.int8])
 @pytest.mark.parametrize("y", [0, 32, 48])
+@pytest.mark.parametrize("idx_dtype", [torch.int32, torch.int16])
 @pytest.mark.skipif(is_hopper(), reason="TMA Scatter is not supported on hopper")
-def test_tma_gather(X, Y, BLOCK_X, BLOCK_Y, dtype, y, device):
+def test_tma_gather(X, Y, BLOCK_X, BLOCK_Y, dtype, y, idx_dtype, device):
     if BLOCK_X > X or y + BLOCK_Y > Y:
         pytest.skip()
+    if idx_dtype == torch.int16 and not is_hip():
+        pytest.skip("I16 gather indices only supported on AMD")
 
     torch.manual_seed(42)
     if dtype != torch.int8:
@@ -1388,7 +1391,7 @@ def test_tma_gather(X, Y, BLOCK_X, BLOCK_Y, dtype, y, device):
         input = torch.arange(X * Y, dtype=dtype, device=device).reshape(X, Y)
     output = torch.empty((BLOCK_X, BLOCK_Y), dtype=dtype, device=device)
 
-    idx = torch.randint(BLOCK_X, (BLOCK_X, ), dtype=torch.int32, device=device)
+    idx = torch.randint(BLOCK_X, (BLOCK_X, ), dtype=idx_dtype, device=device)
 
     def alloc_fn(size: int, align: int, steam):
         return torch.empty(size, dtype=torch.int8, device=device)
@@ -1475,17 +1478,20 @@ def tma_scatter_rows_kernel(out_ptr, in_ptr, idx_ptr, y, X: tl.constexpr, Y: tl.
 @pytest.mark.parametrize("BLOCK_X, BLOCK_Y", [(32, 32), (64, 128), (16, 128), (512, 16)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.int8])
 @pytest.mark.parametrize("y", [0, 32, 48])
+@pytest.mark.parametrize("idx_dtype", [torch.int32, torch.int16])
 @pytest.mark.skipif(is_hopper(), reason="TMA Scatter is not supported on hopper")
 @pytest.mark.skipif(is_sm12x(), reason="TMA Scatter is not supported on sm120")
-def test_tma_scatter(X, Y, BLOCK_X, BLOCK_Y, dtype, y, device):
+def test_tma_scatter(X, Y, BLOCK_X, BLOCK_Y, dtype, y, idx_dtype, device):
     if BLOCK_X > X or y + BLOCK_Y > Y:
         pytest.skip()
+    if idx_dtype == torch.int16 and not is_hip():
+        pytest.skip("I16 scatter indices only supported on AMD")
 
     torch.manual_seed(42)
     input = torch.arange(BLOCK_X * BLOCK_Y, dtype=dtype, device=device).reshape(BLOCK_X, BLOCK_Y)
     output = torch.zeros((X, Y), dtype=dtype, device=device)
 
-    idx = torch.randperm(BLOCK_X, dtype=torch.int32, device=device)
+    idx = torch.randperm(BLOCK_X, dtype=idx_dtype, device=device)
 
     def alloc_fn(size: int, align: int, steam):
         return torch.empty(size, dtype=torch.int8, device=device)

--- a/test/TritonGPU/amd/amd-convert-tensor-ops.mlir
+++ b/test/TritonGPU/amd/amd-convert-tensor-ops.mlir
@@ -1,5 +1,109 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-tensor-ops | FileCheck %s
 
+// Gather i32: indices arrive with the NVIDIA-oriented slice encoding (#nv_slice)
+// from the shared TritonToTritonGPU pass. The pass re-layouts them to AMD's TDM
+// encoding and lowers to amdg.async_tdm_gather.
+
+#nv_slice = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_res = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#padded_desc = #ttg.padded_shared<[32:+16] {order = [1, 0], shape = [1, 32]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$AMD_IDX_I32:.*]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK-LABEL: @test_gather_i32
+// CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I32]]}>>
+// CHECK: ttg.local_alloc
+// CHECK: amdg.async_tdm_gather {{.*}} pred = %{{.*}} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I32]]
+// CHECK: amdg.async_tdm_wait {num = 0 : i32}
+// CHECK: ttg.local_load
+tt.func public @test_gather_i32(%desc: !tt.tensordesc<1x32xi8, #padded_desc>,
+                                %indices: tensor<32xi32, #ttg.slice<{dim = 0, parent = #nv_slice}>>,
+                                %y_off: i32) -> tensor<32x32xi8, #blocked_res> {
+  %0 = tt.descriptor_gather %desc[%indices, %y_off] : (!tt.tensordesc<1x32xi8, #padded_desc>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #nv_slice}>>, i32) -> tensor<32x32xi8, #blocked_res>
+  tt.return %0 : tensor<32x32xi8, #blocked_res>
+}
+}
+
+// -----
+
+// Gather i16: same NVIDIA-oriented slice encoding on the indices (the shared
+// pass doesn't special-case index element type). i16 indices are AMD-only.
+
+#nv_slice16 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_res16 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#padded_desc16 = #ttg.padded_shared<[32:+16] {order = [1, 0], shape = [1, 32]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$AMD_IDX_I16:.*]] = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK-LABEL: @test_gather_i16
+// CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I16]]}>>
+// CHECK: ttg.local_alloc
+// CHECK: amdg.async_tdm_gather {{.*}} pred = %{{.*}} : tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I16]]
+// CHECK: amdg.async_tdm_wait {num = 0 : i32}
+// CHECK: ttg.local_load
+tt.func public @test_gather_i16(%desc: !tt.tensordesc<1x32xi8, #padded_desc16>,
+                                %indices: tensor<32xi16, #ttg.slice<{dim = 0, parent = #nv_slice16}>>,
+                                %y_off: i32) -> tensor<32x32xi8, #blocked_res16> {
+  %0 = tt.descriptor_gather %desc[%indices, %y_off] : (!tt.tensordesc<1x32xi8, #padded_desc16>, tensor<32xi16, #ttg.slice<{dim = 0, parent = #nv_slice16}>>, i32) -> tensor<32x32xi8, #blocked_res16>
+  tt.return %0 : tensor<32x32xi8, #blocked_res16>
+}
+}
+
+// -----
+
+// Scatter i32: indices arrive with the NVIDIA-oriented slice encoding (#nv_slice)
+// from the shared TritonToTritonGPU pass. The pass re-layouts them to AMD's TDM
+// encoding and lowers to amdg.async_tdm_scatter.
+
+#nv_slice_s = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#padded_desc_s = #ttg.padded_shared<[32:+16] {order = [1, 0], shape = [1, 32]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$AMD_IDX_S_I32:.*]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK-LABEL: @test_scatter_i32
+// CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I32]]}>>
+// CHECK: ttg.local_alloc {{.*}} : (tensor<32x32xi8
+// CHECK: amdg.async_tdm_scatter {{.*}} from {{.*}} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I32]]
+// CHECK: amdg.async_tdm_wait {num = 0 : i32}
+// CHECK-NOT: ttg.local_load
+tt.func public @test_scatter_i32(%desc: !tt.tensordesc<1x32xi8, #padded_desc_s>,
+                                 %indices: tensor<32xi32, #ttg.slice<{dim = 0, parent = #nv_slice_s}>>,
+                                 %y_off: i32,
+                                 %src: tensor<32x32xi8, #blocked_src>) {
+  tt.descriptor_scatter %desc[%indices, %y_off], %src : !tt.tensordesc<1x32xi8, #padded_desc_s>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #nv_slice_s}>>, i32, tensor<32x32xi8, #blocked_src>
+  tt.return
+}
+}
+
+// -----
+
+// Scatter i16: same NVIDIA-oriented slice encoding on the indices (the shared
+// pass doesn't special-case index element type). i16 indices are AMD-only.
+
+#nv_slice_s16 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_src16 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#padded_desc_s16 = #ttg.padded_shared<[32:+16] {order = [1, 0], shape = [1, 32]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$AMD_IDX_S_I16:.*]] = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK-LABEL: @test_scatter_i16
+// CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I16]]}>>
+// CHECK: ttg.local_alloc {{.*}} : (tensor<32x32xi8
+// CHECK: amdg.async_tdm_scatter {{.*}} from {{.*}} : tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I16]]
+// CHECK: amdg.async_tdm_wait {num = 0 : i32}
+// CHECK-NOT: ttg.local_load
+tt.func public @test_scatter_i16(%desc: !tt.tensordesc<1x32xi8, #padded_desc_s16>,
+                                 %indices: tensor<32xi16, #ttg.slice<{dim = 0, parent = #nv_slice_s16}>>,
+                                 %y_off: i32,
+                                 %src: tensor<32x32xi8, #blocked_src16>) {
+  tt.descriptor_scatter %desc[%indices, %y_off], %src : !tt.tensordesc<1x32xi8, #padded_desc_s16>, tensor<32xi16, #ttg.slice<{dim = 0, parent = #nv_slice_s16}>>, i32, tensor<32x32xi8, #blocked_src16>
+  tt.return
+}
+}
+
+// -----
+
 // CHECK-LABEL: test_cvt1
 // CHECK: amdg.async_tdm_copy_global_to_local {{.*}}: !tt.tensordesc<128x16xf16, #shared> -> !ttg.memdesc<128x16xf16, #shared, #smem, mutable>
 // CHECK: amdg.async_tdm_wait  {num = 0 : i32}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToTensorOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToTensorOps.cpp
@@ -66,6 +66,51 @@ public:
   }
 };
 
+struct TensorGatherLowering : public OpRewritePattern<DescriptorGatherOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(DescriptorGatherOp op,
+                                PatternRewriter &rewriter) const override {
+    MLIRContext *ctx = op.getContext();
+    Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
+    auto loc = op.getLoc();
+    auto tensorType = op.getResult().getType();
+
+    auto encoding = getEncodingFromDescriptor(op, tensorType, op.getDesc());
+    if (!encoding) {
+      op.emitError() << "Could not create encoding for descriptor gather";
+      return failure();
+    }
+
+    auto indices = op.getXOffsets();
+    auto indicesType = cast<RankedTensorType>(indices.getType());
+    auto idxEnc = getTDMGatherScatterIndexEncoding(op, indicesType);
+
+    // NOTE: The shared TritonToTritonGPU conversion (GatherScatterOpPattern)
+    // unconditionally applies an NVIDIA-oriented index layout. Because of
+    // this, the indices arriving here already carry that layout, making default
+    // index encoding never matches most desirable AMD index encoding, and
+    // therefore an additional ConvertLayoutOp emitted.
+    if (indicesType.getEncoding() != idxEnc) {
+      auto newIdxType = RankedTensorType::get(
+          indicesType.getShape(), indicesType.getElementType(), idxEnc);
+      indices = ConvertLayoutOp::create(rewriter, loc, newIdxType, indices);
+    }
+
+    MemDescType memDescType =
+        MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
+                         encoding, sharedMemorySpace, /*mutableMemory=*/true);
+    Value alloc = LocalAllocOp::create(rewriter, loc, memDescType);
+    Value pred = arith::ConstantIntOp::create(rewriter, loc, 1, 32);
+
+    amdgpu::AsyncTDMGatherOp::create(rewriter, loc, op.getDesc(), indices,
+                                     op.getYOffset(), alloc, pred);
+    amdgpu::AsyncTDMWait::create(rewriter, loc, ArrayRef<Value>{}, 0);
+    rewriter.replaceOpWithNewOp<LocalLoadOp>(op, op.getType(), alloc);
+    return success();
+  }
+};
+
 class TensorStoreLowering : public OpRewritePattern<DescriptorStoreOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
@@ -97,6 +142,51 @@ public:
   }
 };
 
+struct TensorScatterLowering : public OpRewritePattern<DescriptorScatterOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(DescriptorScatterOp op,
+                                PatternRewriter &rewriter) const override {
+    MLIRContext *ctx = op.getContext();
+    Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
+    auto loc = op.getLoc();
+    Value desc = op.getDesc();
+    mlir::TypedValue<RankedTensorType> src = op.getSrc();
+    auto tensorType = src.getType();
+
+    auto encoding = getEncodingFromDescriptor(op, tensorType, desc);
+    if (!encoding) {
+      op.emitError() << "Could not create encoding for descriptor scatter";
+      return failure();
+    }
+
+    auto indices = op.getXOffsets();
+    auto indicesType = cast<RankedTensorType>(indices.getType());
+    auto idxEnc = getTDMGatherScatterIndexEncoding(op, indicesType);
+
+    // NOTE: The shared TritonToTritonGPU conversion (GatherScatterOpPattern)
+    // unconditionally applies an NVIDIA-oriented index layout. Re-layout the
+    // indices into the AMD TDM-friendly encoding so the LLVM lowering can use
+    // a single TDM instruction per row group.
+    if (indicesType.getEncoding() != idxEnc) {
+      auto newIdxType = RankedTensorType::get(
+          indicesType.getShape(), indicesType.getElementType(), idxEnc);
+      indices = ConvertLayoutOp::create(rewriter, loc, newIdxType, indices);
+    }
+
+    MemDescType memDescType =
+        MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
+                         encoding, sharedMemorySpace, /*mutableMemory=*/true);
+    Value alloc = LocalAllocOp::create(rewriter, loc, memDescType, src);
+    amdgpu::AsyncTDMScatterOp::create(rewriter, loc, op.getDesc(), indices,
+                                      op.getYOffset(), alloc,
+                                      /*barrier=*/Value{});
+    amdgpu::AsyncTDMWait::create(rewriter, loc, ArrayRef<Value>{}, 0);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct TritonAMDGPUConvertToTensorOps
     : impl::TritonAMDGPUConvertToTensorOpsBase<TritonAMDGPUConvertToTensorOps> {
 
@@ -105,7 +195,8 @@ struct TritonAMDGPUConvertToTensorOps
     ModuleOp m = getOperation();
 
     mlir::RewritePatternSet patterns(context);
-    patterns.add<TensorLoadLowering, TensorStoreLowering>(context);
+    patterns.add<TensorLoadLowering, TensorGatherLowering, TensorStoreLowering,
+                 TensorScatterLowering>(context);
     if (applyPatternsGreedily(m, std::move(patterns)).failed())
       signalPassFailure();
   }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -470,6 +470,28 @@ composePaddedLayoutWMMA(int opIdx, unsigned vecWidth,
       context, {{padInterval, padAmount}}, order, shape, CGALayout);
 }
 
+ttg::SliceEncodingAttr
+getTDMGatherScatterIndexEncoding(Operation *op, RankedTensorType indicesType) {
+  MLIRContext *ctx = op->getContext();
+  unsigned idxBitWidth = indicesType.getElementType().getIntOrFloatBitWidth();
+  assert((idxBitWidth == 16 || idxBitWidth == 32) &&
+         "TDM gather/scatter indices must be i16 or i32");
+  unsigned maxIndicesPerInstr = 256 / idxBitWidth;
+
+  unsigned numWarps = ttg::lookupNumWarps(op);
+  unsigned threadsPerWarp =
+      ttg::TritonGPUDialect::getThreadsPerWarp(op->getParentOfType<ModuleOp>());
+  auto cgaLayout = ttg::CGAEncodingAttr::get1CTALayout(ctx, /*rank=*/2);
+
+  std::array<unsigned, 2> sizePerThread = {1, maxIndicesPerInstr};
+  std::array<unsigned, 2> tPerWarp = {threadsPerWarp, 1};
+  std::array<unsigned, 2> warpsPerCTA = {1, numWarps};
+  std::array<unsigned, 2> order = {0, 1};
+  auto parentEnc = ttg::BlockedEncodingAttr::get(ctx, sizePerThread, tPerWarp,
+                                                 warpsPerCTA, order, cgaLayout);
+  return ttg::SliceEncodingAttr::get(ctx, /*dim=*/0, parentEnc);
+}
+
 ttg::SharedEncodingTrait getEncodingFromDescriptor(Operation *op,
                                                    RankedTensorType tensorType,
                                                    Value desc) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
@@ -43,6 +43,16 @@ triton::gpu::SharedEncodingTrait
 getEncodingFromDescriptor(Operation *op, RankedTensorType tensorType,
                           Value desc);
 
+// Build the index encoding for TDM gather/scatter.
+//
+// Layout: BlockedLayout([1, M], [threadsPerWarp, 1], [1, numWarps], [0, 1])
+// sliced along dim 0 to produce a 1D encoding. M is the max number of row
+// indices per TDM instruction (256 bits / index element bitwidth). The
+// freeVarMasks mechanism in the LLVM lowering adapts the number of active
+// warps and gathers per warp to the actual problem size.
+triton::gpu::SliceEncodingAttr
+getTDMGatherScatterIndexEncoding(Operation *op, RankedTensorType indicesType);
+
 // Returns the given |inputValue|'s dot user result encoding and updates |opIdx|
 // and |vecSize| with which dot operand |inputValue| is fed into if possible.
 template <class T>


### PR DESCRIPTION
This patch adds AMD TDM (Tensor Data Mover) lowering for the Triton `tt.descriptor_gather` and `tt.descriptor_scatter` operations on gfx1250.

Key changes:
- Widen `x_offsets` type in `tt.descriptor_gather` and `tt.descriptor_scatter` from i32-only to {i16, i32} to support AMD TDM's native 16-bit index mode.
- Add NVIDIA TMA guard to reject i16 indices (NVIDIA TMA only supports i32).
- Add `TensorGatherLowering` and `TensorScatterLowering` patterns in the AMD `ConvertToTensorOps` pass, lowering to `amdgpu.async_tdm_gather` / `amdgpu.async_tdm_scatter` with proper index layout conversion.
- Extract `getTDMGatherScatterIndexEncoding` into shared Utility to build the TDM-friendly blocked+sliced index encoding for both gather and scatter.
- Add MLIR lit tests for gather/scatter with both i32 and i16 indices.
- Add Python test parametrization for i16 index dtype on AMD.

Pipelined gather/scatter support in LowerLoops is deferred to a follow-up PR.