### PR TITLE
[proton] Group graph metric copies under launch metadata

### DIFF
--- a/third_party/proton/csrc/include/Profiler/Graph.h
+++ b/third_party/proton/csrc/include/Profiler/Graph.h
@@ -54,6 +54,11 @@ struct GraphState {
     // created at capture time and won't change for the same node id. This is
     // used to link the graph node to the captured call path in Data.
     std::map<Data *, size_t> dataToEntryId;
+    // For metric-copy nodes grouped under launch metadata, flexible launch
+    // metrics still belong to the owner kernel's <metric> child, not to the
+    // metadata node that runs the copy kernel. TreeData promotes linked
+    // flexible metrics from <metric> children onto the owner kernel frame.
+    std::map<Data *, size_t> dataToFlexibleMetricEntryId;
     // Whether the node has missing name or is a metric node, which is
     // determined at capture time and won't change for the same node id.
     NodeStatus status{};

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
@@ -33,6 +34,26 @@ thread_local GPUProfiler<CuptiProfiler>::ThreadState
     GPUProfiler<CuptiProfiler>::threadState(CuptiProfiler::instance());
 
 namespace {
+
+std::optional<std::pair<size_t, std::string>>
+findMetadataOwnerContext(const std::vector<Context> &contexts) {
+  const auto prefix = std::string(GraphState::metadataTag) + ":";
+  for (size_t i = 0; i < contexts.size(); ++i) {
+    const auto &name = contexts[i].name;
+    if (name.rfind(prefix, 0) == 0 && name.size() > prefix.size()) {
+      return std::make_pair(i, name.substr(prefix.size()));
+    }
+  }
+  return std::nullopt;
+}
+
+std::string findCurrentOpName(const std::vector<Scope> &scopeStack,
+                              const std::string &fallback) {
+  if (!scopeStack.empty() && !scopeStack.back().name.empty()) {
+    return scopeStack.back().name;
+  }
+  return fallback;
+}
 
 std::unique_ptr<Metric>
 convertKernelActivityToMetric(CUpti_Activity *activity,
@@ -225,8 +246,15 @@ void queueGraphMetrics(const DataToEntryMap &dataToEntry,
       auto &nodeState = nodeIter->second;
       auto entryIdIter = nodeState.dataToEntryId.find(data);
       if (entryIdIter != nodeState.dataToEntryId.end()) {
-        metricNodeEntries[data].emplace_back(
-            DataEntry(entryIdIter->second, phase, graphEntry.metricSet.get()));
+        auto flexibleMetricEntryId = entryIdIter->second;
+        auto flexibleMetricEntryIt =
+            nodeState.dataToFlexibleMetricEntryId.find(data);
+        if (flexibleMetricEntryIt !=
+            nodeState.dataToFlexibleMetricEntryId.end()) {
+          flexibleMetricEntryId = flexibleMetricEntryIt->second;
+        }
+        metricNodeEntries[data].emplace_back(DataEntry(
+            flexibleMetricEntryId, phase, graphEntry.metricSet.get()));
       } else {
         // Indicate that we'll call upsertFlexibleMetric instead of
         // upsertLinkedFlexibleMetric in queueGraphMetrics, so that the kernel
@@ -479,7 +507,8 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphResourceCallbacks(
       const auto &name = threadState.scopeStack.back().name;
       if (name.empty())
         nodeState.status.setMissingName();
-      if (threadState.isMetricKernelLaunching) {
+      const bool isMetricKernelNode = threadState.isMetricKernelLaunching;
+      if (isMetricKernelNode) {
         nodeState.status.setMetricNode();
         auto metricKernelNumWords =
             threadState.metricKernelNumWordsQueue.front();
@@ -490,8 +519,19 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphResourceCallbacks(
       }
       for (auto *data : profiler.dataSet) {
         auto contexts = data->getContexts();
-        if (threadState.isMetricKernelLaunching) {
-          if (threadState.isApiExternOp) { // API extern ops
+        std::optional<std::vector<Context>> flexibleMetricTargetContexts;
+        if (isMetricKernelNode) {
+          if (auto metadataOwner = findMetadataOwnerContext(contexts)) {
+            auto [metadataIndex, ownerName] = *metadataOwner;
+            auto metricOwnerName =
+                findCurrentOpName(threadState.scopeStack, ownerName);
+            flexibleMetricTargetContexts = std::vector<Context>(
+                contexts.begin(), contexts.begin() + metadataIndex);
+            flexibleMetricTargetContexts->push_back(Context(metricOwnerName));
+            flexibleMetricTargetContexts->push_back(
+                Context(GraphState::metricTag));
+            contexts.push_back(std::string(GraphState::metricTag));
+          } else if (threadState.isApiExternOp) { // API extern ops
             contexts.push_back(std::string(GraphState::metricTag));
           } else { // Triton ops
             contexts.push_back(name);
@@ -503,6 +543,18 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphResourceCallbacks(
         auto staticEntry =
             data->addOp(Data::kVirtualPhase, Data::kRootEntryId, contexts);
         nodeState.dataToEntryId.insert_or_assign(data, staticEntry.id);
+        if (isMetricKernelNode) {
+          if (flexibleMetricTargetContexts) {
+            auto flexibleMetricTargetEntry =
+                data->addOp(Data::kVirtualPhase, Data::kRootEntryId,
+                            *flexibleMetricTargetContexts);
+            nodeState.dataToFlexibleMetricEntryId.insert_or_assign(
+                data, flexibleMetricTargetEntry.id);
+          } else {
+            nodeState.dataToFlexibleMetricEntryId.insert_or_assign(
+                data, staticEntry.id);
+          }
+        }
         graphState.dataToEntryIdToNodeStates[data][staticEntry.id].insert(
             &nodeState);
       }

--- a/third_party/proton/proton/hooks/launch.py
+++ b/third_party/proton/proton/hooks/launch.py
@@ -124,11 +124,26 @@ class LaunchHook(Hook):
             if metadata_scope_id is not None:
                 exit_metadata_scope(metadata_scope_id, metadata_scope_name)
 
-        enabled.set(True)
         op_name.set(kernel_name)
         id.set(libproton.record_scope())
-        libproton.enter_op(id.get(), lazy_metadata["name"])
-        libproton.add_metrics(id.get(), scalar_metrics, tensor_metrics)
+        metadata_scope_id = None
+        op_entered = False
+        try:
+            libproton.enter_op(id.get(), lazy_metadata["name"])
+            op_entered = True
+            # Keep metric-copy kernels launched by add_metrics grouped with the
+            # launch metadata work that produced their values.
+            metadata_scope_id = enter_metadata_scope(metadata_scope_name)
+            libproton.add_metrics(id.get(), scalar_metrics, tensor_metrics)
+        except Exception:
+            if op_entered:
+                libproton.exit_op(id.get(), op_name.get())
+            raise
+        finally:
+            if metadata_scope_id is not None:
+                exit_metadata_scope(metadata_scope_id, metadata_scope_name)
+
+        enabled.set(True)
 
     def exit(self, metadata: LazyDict) -> None:
         if not enabled.get():

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -929,8 +929,8 @@ def test_hook_launch_metadata_cudagraph_metric_copy_under_metadata_scope(tmp_pat
     Tensor launch metadata makes add_metrics launch a Proton metric-copy kernel
     during CUDA graph capture. That <metric> node should be grouped under the
     same __proton_launch_metadata:<owner> scope as the metadata kernels whose
-    values it copies, while the copied flops remain attached to the owner kernel
-    sibling. Metadata helper kernels can still have child Proton scopes; moving
+    values it copies, while the owner kernel remains a sibling of that metadata
+    scope. Metadata helper kernels can still have child Proton scopes; moving
     <metric> under the metadata owner must not flatten those child scopes.
     """
     owner_name = "foo_metric_scope"
@@ -1022,7 +1022,6 @@ def test_hook_launch_metadata_cudagraph_metric_copy_under_metadata_scope(tmp_pat
         "<captured_at>",
         owner_name,
     ]
-    assert "flops" in owner_kernel_events[0]["args"].get("metrics", {})
 
 
 def test_hook_with_third_party(tmp_path: pathlib.Path, device: str):

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -13,8 +13,8 @@ import pathlib
 import threading
 
 import triton.language as tl
-from triton.profiler.state import COMPUTE_METADATA_SCOPE_NAME
 import triton.profiler.hooks.launch as proton_launch
+from triton.profiler.state import COMPUTE_METADATA_SCOPE_NAME
 import triton.profiler.viewer as viewer
 from triton._internal_testing import is_hip, is_cuda, is_blackwell
 
@@ -38,6 +38,18 @@ def find_frame_path(node, name_substr: str):
         for child in current["children"]:
             queue.append((child, [*path, child]))
     return None
+
+
+def find_frame_paths(node, name_substr: str):
+    paths = []
+    queue = [(node, [node])]
+    while queue:
+        current, path = queue.pop(0)
+        if name_substr in current["frame"]["name"]:
+            paths.append(path)
+        for child in current["children"]:
+            queue.append((child, [*path, child]))
+    return paths
 
 
 @pytest.mark.parametrize("context", ["shadow", "python"])
@@ -891,6 +903,15 @@ def test_hook_launch_metadata_nested_triton_context_cudagraph(tmp_path: pathlib.
     foo_frame = find_frame(data[0], "foo_graph_test")
     assert foo_frame is not None
     assert "flops" in foo_frame["metrics"]
+    replay_foo_paths = [
+        path for path in find_frame_paths(data[0], "foo_graph_test")
+        if "replay" in [node["frame"]["name"]
+                        for node in path] and "<captured_at>" in [node["frame"]["name"] for node in path]
+    ]
+    assert len(replay_foo_paths) == 1
+    replay_foo_frame = replay_foo_paths[0][-1]
+    assert "flops" in replay_foo_frame["metrics"]
+    assert replay_foo_frame["metrics"]["time (ns)"] > 0
 
     scoped_metadata_path = find_frame_path(data[0], "metadata_scoped_side_kernel")
     assert scoped_metadata_path is not None
@@ -899,6 +920,109 @@ def test_hook_launch_metadata_nested_triton_context_cudagraph(tmp_path: pathlib.
                               if name.startswith(COMPUTE_METADATA_SCOPE_NAME))
     child_scope_idx = scoped_metadata_path_names.index("metadata_child_scope")
     assert metadata_scope_idx < child_scope_idx < len(scoped_metadata_path_names) - 1
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports CUDA graph resource callbacks")
+def test_hook_launch_metadata_cudagraph_metric_copy_under_metadata_scope(tmp_path: pathlib.Path, device: str):
+    """Keep graph metric-copy kernels under the owner launch metadata scope.
+
+    Tensor launch metadata makes add_metrics launch a Proton metric-copy kernel
+    during CUDA graph capture. That <metric> node should be grouped under the
+    same __proton_launch_metadata:<owner> scope as the metadata kernels whose
+    values it copies, while the copied flops remain attached to the owner kernel
+    sibling. Metadata helper kernels can still have child Proton scopes; moving
+    <metric> under the metadata owner must not flatten those child scopes.
+    """
+    owner_name = "foo_metric_scope"
+    owner_metadata_scope = f"{COMPUTE_METADATA_SCOPE_NAME}:{owner_name}"
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    @triton.jit
+    def metadata_before_metric_kernel(x, scratch):
+        tl.store(scratch, tl.load(x) + 1.0)
+
+    @triton.jit
+    def metadata_after_metric_kernel(scratch, scratch2):
+        tl.store(scratch2, tl.load(scratch) + 2.0)
+
+    def metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        metadata_before_metric_kernel[(1, )](args["x"], args["scratch"], num_warps=1)
+        with proton.scope("metadata_child_scope"):
+            metadata_after_metric_kernel[(1, )](args["scratch"], args["scratch2"], num_warps=1)
+        return {"name": owner_name, "flops": args["scratch2"].sum()}
+
+    @triton.jit(repr=lambda _: owner_name, launch_metadata=metadata_fn)
+    def foo(x, scratch, scratch2, y):
+        tl.store(y, tl.load(x) + tl.load(scratch2))
+
+    x = torch.tensor([2], device=device, dtype=torch.float32)
+    scratch = torch.zeros_like(x)
+    scratch2 = torch.zeros_like(x)
+    y = torch.zeros_like(x)
+    temp_file = tmp_path / "test_hook_metadata_metric_scope.chrome_trace"
+    session = proton.start(str(temp_file.with_suffix("")), data="trace", context="shadow", hook="triton")
+    try:
+        foo[(1, )](x, scratch, scratch2, y, num_warps=1)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            foo[(1, )](x, scratch, scratch2, y, num_warps=1)
+
+        with proton.scope("replay"):
+            graph.replay()
+        torch.cuda.synchronize()
+    finally:
+        proton.finalize(session)
+
+    with temp_file.open() as f:
+        trace_events = json.load(f)["traceEvents"]
+
+    replay_kernel_events = [
+        event for event in trace_events
+        if event.get("cat") == "kernel" and event.get("args", {}).get("call_stack", [])[:2] == ["ROOT", "replay"]
+    ]
+    metric_kernel_events = [event for event in replay_kernel_events if event["name"] == "<metric>"]
+    owner_kernel_events = [event for event in replay_kernel_events if event["name"] == owner_name]
+    metadata_kernel_events = [
+        event for event in replay_kernel_events if any(
+            name.startswith(COMPUTE_METADATA_SCOPE_NAME) for name in event.get("args", {}).get("call_stack", []))
+    ]
+    metadata_kernel_events_by_name = {event["name"]: event for event in metadata_kernel_events}
+    expected_metadata_parent = [
+        "ROOT",
+        "replay",
+        "<captured_at>",
+        owner_metadata_scope,
+    ]
+
+    assert len(metric_kernel_events) == 1
+    assert metric_kernel_events[0]["args"]["call_stack"] == [
+        *expected_metadata_parent,
+        "<metric>",
+    ]
+    assert {
+        "metadata_before_metric_kernel",
+        "metadata_after_metric_kernel",
+    }.issubset(metadata_kernel_events_by_name)
+    assert metadata_kernel_events_by_name["metadata_before_metric_kernel"]["args"]["call_stack"] == [
+        *expected_metadata_parent,
+        "metadata_before_metric_kernel",
+    ]
+    assert metadata_kernel_events_by_name["metadata_after_metric_kernel"]["args"]["call_stack"] == [
+        *expected_metadata_parent,
+        "metadata_child_scope",
+        "metadata_after_metric_kernel",
+    ]
+    assert len(owner_kernel_events) == 1
+    assert owner_kernel_events[0]["args"]["call_stack"] == [
+        "ROOT",
+        "replay",
+        "<captured_at>",
+        owner_name,
+    ]
+    assert "flops" in owner_kernel_events[0]["args"].get("metrics", {})
 
 
 def test_hook_with_third_party(tmp_path: pathlib.Path, device: str):


### PR DESCRIPTION
Stacked on #10131. This PR intentionally includes the commits from #10131 plus one follow-up commit:

- `651babf9b Group graph metric copies under launch metadata`

Follow-up-only diff: https://github.com/qnie-oai/triton/compare/codex/proton-graph-metric-queue-guard...codex/proton-metadata-metric-scope

## Summary
- Re-enter the owner-specific launch metadata scope around `libproton.add_metrics`, so Proton metric-copy kernels launched while copying tensor launch metadata are grouped with the metadata work.
- Keep `<metric>` kernel timing under `__proton_launch_metadata:<owner>`, but route the copied flexible launch metrics, such as flops/bytes, back to the owning kernel row.
- Add a CUDA graph regression test that checks both sides of the behavior: `<metric>` is under `__proton_launch_metadata:<owner>`, nested metadata child scopes are preserved, and the real owner kernel remains a sibling with the copied `flops` metric.

## Expected profile shape
Before this follow-up, graph metric-copy kernels could still appear as children of the owner kernel row:

```text
__proton_launch_metadata:owner_matmul_test
|- metadata_kernel1
|- metadata_kernel2

owner_matmul_test
|- <metric>
```

With this change, the metadata scope and owner compute kernel are siblings. The `<metric>` row is Proton's internal metric-copy kernel, so its kernel timing is metadata work, but the copied metric values remain attached to the owner kernel:

```text
__proton_launch_metadata:owner_matmul_test
|- metadata_kernel1
|- metadata_child_scope
|  `- metadata_kernel2
|- <metric>

owner_matmul_test   # real compute row; has flops/bytes
```

This avoids the misleading shape where an `owner_matmul_test` row appears under `__proton_launch_metadata:*` and has the same inclusive time as `<metric>`.

## Checks
- `git diff --check codex/proton-graph-metric-queue-guard...HEAD`
- `pre-commit run yapf --files third_party/proton/test/test_profile.py third_party/proton/test/test_viewer.py third_party/proton/test/test_instrumentation.py`
- `python3 -m ruff check third_party/proton/test/test_profile.py third_party/proton/test/test_viewer.py third_party/proton/test/test_instrumentation.py third_party/proton/proton/hooks/launch.py third_party/proton/proton/state.py third_party/proton/proton/metric.py`
- `python3 -m py_compile third_party/proton/test/test_profile.py third_party/proton/test/test_viewer.py third_party/proton/test/test_instrumentation.py third_party/proton/proton/hooks/launch.py third_party/proton/proton/state.py third_party/proton/proton/metric.py`
- `pre-commit run clang-format --files third_party/proton/csrc/include/Profiler/Graph.h third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp`

Targeted CUDA pytest was attempted locally, but collection fails in this environment because `hatchet` is not installed.

