### PR TITLE
[AMD][CI] Allow continue-on-error for all targets

### DIFF
--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -11,7 +11,7 @@ jobs:
   integration-tests-amd:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
-    continue-on-error: ${{ matrix.runner[1] == 'gfx90a' || matrix.runner[0] == 'amd-gfx942' }}
+    continue-on-error: true
     strategy:
       matrix:
         runner: ${{ fromJson(inputs.matrix) }}


### PR DESCRIPTION
This avoids losing signal on all targets if some have issues.
