### PR TITLE
[BugFix] remove legacy assertion for `tl.dot` when `K < 16`

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -392,40 +392,6 @@ def test_fp8_support(fresh_triton_cache, dtype):
             raise assertion_err from e.value
 
 
-@pytest.mark.parametrize("dtype", [tl.float8e5, tl.int8, tl.float16])
-def test_min_dot_size(dtype):
-    error_msg = "Input shapes should have "
-    if is_cuda():
-        if dtype.primitive_bitwidth == 8:
-            error_msg += "M >= 1, N >= 1 and K >= 32"
-        else:
-            error_msg = "M >= 1, N >= 1 and K >= 16"
-    elif is_hip():
-        # hip supports arbitrary sizes
-        error_msg = None
-    else:
-        pytest.skip("Test only supported on CUDA and HIP")
-
-    @triton.jit
-    def dot_kernel(dtype: tl.constexpr):
-        SIZE: tl.constexpr = 8
-        a = tl.full((SIZE, SIZE), 0.0, dtype)
-        b = tl.full((SIZE, SIZE), 0.0, dtype)
-        tl.dot(a, b)
-
-    if error_msg is None:
-        triton.compile(
-            triton.compiler.ASTSource(fn=dot_kernel, signature={"dtype": "constexpr"}, constexprs={"dtype": dtype}))
-    else:
-        with pytest.raises(CompilationError) as e:
-            triton.compile(
-                triton.compiler.ASTSource(fn=dot_kernel, signature={"dtype": "constexpr"}, constexprs={"dtype": dtype}))
-        try:
-            assert (error_msg in str(e.value.__cause__))
-        except AssertionError as assertion_err:
-            raise assertion_err from e.value
-
-
 def test_max_num_imprecise_acc_limit():
 
     @triton.jit

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3580,6 +3580,52 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         assert re.search(pattern, ptx, flags=re.DOTALL)
 
 
+@pytest.mark.parametrize("M, N, K, in_dtype", [
+    (1, 1, 4, "float16"),
+    (1, 1, 4, "int8"),
+    (1, 2, 4, "float8e5"),
+])
+def test_dot_cuda_small_k(M, N, K, in_dtype, device):
+    if not is_cuda():
+        pytest.skip("small K dot regression test is CUDA-only")
+
+    @triton.jit
+    def kernel(X, Y, Z, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+               OUT_DTYPE: tl.constexpr):
+        off_m = tl.arange(0, BLOCK_M)
+        off_n = tl.arange(0, BLOCK_N)
+        off_k = tl.arange(0, BLOCK_K)
+        x = tl.load(X + off_m[:, None] * BLOCK_K + off_k[None, :])
+        y = tl.load(Y + off_k[:, None] * BLOCK_N + off_n[None, :])
+        z = tl.dot(x, y, input_precision="ieee", out_dtype=OUT_DTYPE)
+        tl.store(Z + off_m[:, None] * BLOCK_N + off_n[None, :], z)
+
+    rs = RandomState(17)
+    x = numpy_random((M, K), dtype_str=in_dtype, rs=rs)
+    y = numpy_random((K, N), dtype_str=in_dtype, rs=rs)
+    x_tri = to_triton(x, device=device, dst_type=in_dtype)
+    y_tri = to_triton(y, device=device, dst_type=in_dtype)
+
+    if in_dtype == "int8":
+        z = np.empty((M, N), dtype=np.int32)
+        z_ref = np.matmul(x.astype(np.int32), y.astype(np.int32))
+        out_ty = tl.int8
+    elif in_dtype == "float8e5":
+        z = np.empty((M, N), dtype=np.float32)
+        x_ref = convert_fp8_to_fp32(x, device, in_dtype)
+        y_ref = convert_fp8_to_fp32(y, device, in_dtype)
+        z_ref = to_numpy(torch.matmul(x_ref, y_ref))
+        out_ty = tl.float32
+    else:
+        z = np.empty((M, N), dtype=np.float32)
+        z_ref = np.matmul(x, y)
+        out_ty = tl.float32
+
+    z_tri = to_triton(z, device=device)
+    kernel[(1, )](x_tri, y_tri, z_tri, BLOCK_M=M, BLOCK_N=N, BLOCK_K=K, OUT_DTYPE=out_ty, num_warps=1)
+    np.testing.assert_allclose(z_ref, to_numpy(z_tri), rtol=0.01, atol=1e-3)
+
+
 @pytest.mark.parametrize("M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, num_warps, mma, kpack",
                          [(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, 4, mma, kpack)
                           for M, N, K in itertools.product([32, 64, 128], [32, 64, 128], [64, 128])

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1460,10 +1460,6 @@ class TritonSemantic(Generic[TensorTy]):
             -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
         assert self.builder.codegen_fns.get(
             "min_dot_size") is not None, "target doesn't provide lower shape bounds for dot."
-        min_dot_size = self.builder.codegen_fns["min_dot_size"](lhs.type, rhs.type)
-        assert lhs.shape[-2].value >= min_dot_size[0] and lhs.shape[-1].value >= min_dot_size[2] \
-            and rhs.shape[-1].value >= min_dot_size[1], \
-                f"Input shapes should have M >= {min_dot_size[0]}, N >= {min_dot_size[1]} and K >= {min_dot_size[2]}"
         if lhs.type.scalar.is_int():
             assert lhs.type.scalar == tl.int8, "only int8 supported!"
             _0 = self.builder.get_int32(0)


### PR DESCRIPTION
Fixes #10141
Detailed information about this bug can be found in the issue.

This PR removes the assertion in `semantic.py` because I found that the triton jit backend now automatically handles this case.

It is not yet clear whether there will be a regression in other tests. We need to wait for the complete CICD logs.