### PR TITLE
[NVIDIA] Decouple target feature queries from `TargetInfo`

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -37,6 +37,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h.inc"
 
 #define GET_TYPEDEF_CLASSES

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -37,8 +37,8 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
-#include "triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h.inc"
+#include "triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h"
 
 #define GET_TYPEDEF_CLASSES
 #include "triton/Dialect/TritonNvidiaGPU/IR/Types.h.inc"

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -33,7 +33,9 @@ public:
 
   int getComputeCapability() const { return computeCapability; }
 
-  bool supportClusterOps() const { return computeCapability >= 90; }
+  bool supportClusterOps() const {
+    return computeCapability >= 90 && computeCapability / 10 != 12;
+  }
 
   bool supportMaximumMinimum() const { return computeCapability >= 80; }
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -4,7 +4,6 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
-#include "llvm/ADT/StringRef.h"
 #include <cassert>
 
 namespace mlir::triton::nvidia_gpu {
@@ -14,37 +13,22 @@ public:
   explicit TargetFeatures(int computeCapability)
       : computeCapability(computeCapability) {}
 
-  static TargetFeatures fromTargetName(StringRef targetName) {
-    assert(targetName.starts_with(kTargetPrefix) &&
-           "expected target attribute to be prefixed with \"cuda:\"");
-
-    int computeCapability;
-    bool parseError =
-        targetName.drop_front(sizeof(kTargetPrefix) - 1)
-            .getAsInteger(10, computeCapability);
-    assert(!parseError &&
-           "invalid compute capability string in target attribute");
-
-    return TargetFeatures(computeCapability);
-  }
-
   static TargetFeatures fromModuleOp(ModuleOp moduleOp) {
-    assert(moduleOp && "expected a module operation");
-
     auto targetAttr =
         moduleOp->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName);
     assert(targetAttr && "Expected a target attribute on the module operation");
 
-    return fromTargetName(targetAttr.getValue());
-  }
+    StringRef targetName = targetAttr.getValue();
+    assert(targetName.starts_with(kTargetPrefix) &&
+           "expected target attribute to be prefixed with \"cuda:\"");
 
-  static TargetFeatures fromOperation(Operation *op) {
-    assert(op && "expected an operation");
+    int computeCapability;
+    bool parseError = targetName.drop_front(sizeof(kTargetPrefix) - 1)
+                          .getAsInteger(10, computeCapability);
+    assert(!parseError &&
+           "invalid compute capability string in target attribute");
 
-    if (auto moduleOp = dyn_cast<ModuleOp>(op))
-      return fromModuleOp(moduleOp);
-
-    return fromModuleOp(op->getParentOfType<ModuleOp>());
+    return TargetFeatures(computeCapability);
   }
 
   int getComputeCapability() const { return computeCapability; }

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -1,0 +1,78 @@
+#ifndef TRITON_DIALECT_TRITONNVIDIAGPU_IR_TARGETFEATURES_H_
+#define TRITON_DIALECT_TRITONNVIDIAGPU_IR_TARGETFEATURES_H_
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/ADT/StringRef.h"
+#include <cassert>
+
+namespace mlir::triton::nvidia_gpu {
+
+class TargetFeatures {
+public:
+  explicit TargetFeatures(int computeCapability)
+      : computeCapability(computeCapability) {}
+
+  static TargetFeatures fromTargetName(StringRef targetName) {
+    assert(targetName.starts_with(kTargetPrefix) &&
+           "expected target attribute to be prefixed with \"cuda:\"");
+
+    int computeCapability;
+    bool parseError =
+        targetName.drop_front(sizeof(kTargetPrefix) - 1)
+            .getAsInteger(10, computeCapability);
+    assert(!parseError &&
+           "invalid compute capability string in target attribute");
+
+    return TargetFeatures(computeCapability);
+  }
+
+  static TargetFeatures fromModuleOp(ModuleOp moduleOp) {
+    assert(moduleOp && "expected a module operation");
+
+    auto targetAttr =
+        moduleOp->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName);
+    assert(targetAttr && "Expected a target attribute on the module operation");
+
+    return fromTargetName(targetAttr.getValue());
+  }
+
+  static TargetFeatures fromOperation(Operation *op) {
+    assert(op && "expected an operation");
+
+    if (auto moduleOp = dyn_cast<ModuleOp>(op))
+      return fromModuleOp(moduleOp);
+
+    return fromModuleOp(op->getParentOfType<ModuleOp>());
+  }
+
+  int getComputeCapability() const { return computeCapability; }
+
+  bool supportClusterOps() const { return computeCapability >= 90; }
+
+  bool supportMaximumMinimum() const { return computeCapability >= 80; }
+
+  bool supportLdMatrix() const { return computeCapability >= 75; }
+  bool supportStMatrix() const { return computeCapability >= 90; }
+  bool supportLdStMatrixB8() const { return computeCapability >= 100; }
+
+  bool supportBitwidth16Elementwise() const {
+    // Hopper (sm90) and newer.
+    return computeCapability >= 90;
+  }
+
+  bool supportBitwidth32Elementwise() const {
+    // Blackwell (sm100) and newer.
+    return computeCapability >= 100;
+  }
+
+private:
+  static constexpr char kTargetPrefix[] = "cuda:";
+
+  int computeCapability;
+};
+
+} // namespace mlir::triton::nvidia_gpu
+
+#endif // TRITON_DIALECT_TRITONNVIDIAGPU_IR_TARGETFEATURES_H_

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -58,8 +58,7 @@ def TTNG_FenceAsyncSharedOp : TTNG_Op<"fence_async_shared"> {
 
   let extraClassDeclaration = [{
     static bool isSupported(int computeCapability) {
-      return ::mlir::triton::nvidia_gpu::TargetFeatures(computeCapability)
-          .supportClusterOps();
+      return computeCapability >= 90;
     }
   }];
 }

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -58,7 +58,8 @@ def TTNG_FenceAsyncSharedOp : TTNG_Op<"fence_async_shared"> {
 
   let extraClassDeclaration = [{
     static bool isSupported(int computeCapability) {
-      return computeCapability >= 90;
+      return ::mlir::triton::nvidia_gpu::TargetFeatures(computeCapability)
+          .supportClusterOps();
     }
   }];
 }
@@ -72,7 +73,8 @@ def TTNG_FenceMBarrierInitReleaseClusterOp : TTNG_Op<
 
   let extraClassDeclaration = [{
     static bool isSupported(int computeCapability) {
-      return computeCapability >= 90;
+      return ::mlir::triton::nvidia_gpu::TargetFeatures(computeCapability)
+          .supportClusterOps();
     }
   }];
 }

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1081,7 +1081,8 @@ bool isPureUnaryInlineAsm(Operation *op) {
 }
 
 int getNVIDIAComputeCapability(Operation *module) {
-  return ttng::TargetFeatures::fromOperation(module).getComputeCapability();
+  return ttng::TargetFeatures::fromModuleOp(cast<ModuleOp>(module))
+      .getComputeCapability();
 }
 
 std::optional<StringRef> getAMDArch(Operation *module) {

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1081,21 +1081,7 @@ bool isPureUnaryInlineAsm(Operation *op) {
 }
 
 int getNVIDIAComputeCapability(Operation *module) {
-  StringAttr targetAttr =
-      module->getAttrOfType<StringAttr>(triton::gpu::AttrTargetName);
-  assert(targetAttr && "Expected a target attribute on the module operation");
-
-  StringRef ref = targetAttr.strref();
-  assert(ref.starts_with("cuda:") &&
-         "expected target attribute to be prefixed with \"cuda:\"");
-
-  StringRef capabilityStr = ref.drop_front(5); // drop the "cuda:"
-  int computeCapability;
-  bool parseError = capabilityStr.getAsInteger(10, computeCapability);
-  assert(!parseError &&
-         "invalid compute capability string in target attribute");
-
-  return computeCapability;
+  return ttng::TargetFeatures::fromOperation(module).getComputeCapability();
 }
 
 std::optional<StringRef> getAMDArch(Operation *module) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -493,9 +493,8 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
     return false;
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   bool useNanQualifier = false;
-  if (auto kind =
-          matchReduxKind(op, targetFeatures.getComputeCapability(),
-                         useNanQualifier)) {
+  if (auto kind = matchReduxKind(op, targetFeatures.getComputeCapability(),
+                                 useNanQualifier)) {
     assert(acc.size() == 1);
     Value mask = b.i32_val(0xFFFFFFFF);
     // Even though we currently don't use redux for partitioned reduction

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -127,7 +127,7 @@ matchReduxKind(triton::ReduceOp op, int computeCapability,
 }
 
 bool TargetInfo::supportMaximumMinimum() const {
-  return computeCapability >= 80;
+  return targetFeatures.supportMaximumMinimum();
 }
 
 Value TargetInfo::getClusterCTAId(RewriterBase &rewriter, Location loc) const {
@@ -493,7 +493,9 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
     return false;
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   bool useNanQualifier = false;
-  if (auto kind = matchReduxKind(op, computeCapability, useNanQualifier)) {
+  if (auto kind =
+          matchReduxKind(op, targetFeatures.getComputeCapability(),
+                         useNanQualifier)) {
     assert(acc.size() == 1);
     Value mask = b.i32_val(0xFFFFFFFF);
     // Even though we currently don't use redux for partitioned reduction
@@ -629,7 +631,7 @@ int TargetInfo::getAddressSpace(Attribute addressSpace) const {
 }
 
 bool TargetInfo::supportVectorizedAtomics() const {
-  return computeCapability >= 90 && ptxVersion >= 81;
+  return targetFeatures.getComputeCapability() >= 90 && ptxVersion >= 81;
 }
 
 } // namespace mlir::triton::NVIDIA

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -2,13 +2,14 @@
 #define TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETINFONVIDIA_H
 
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h"
 
 namespace mlir::triton::NVIDIA {
 
 class TargetInfo : public mlir::triton::TargetInfoBase {
 public:
   TargetInfo(int computeCapability, int ptxVersion)
-      : computeCapability(computeCapability), ptxVersion(ptxVersion) {}
+      : targetFeatures(computeCapability), ptxVersion(ptxVersion) {}
 
   bool supportMaximumMinimum() const override;
 
@@ -30,16 +31,20 @@ public:
                     std::optional<Value> ctaId, Type elemTy, Value pred,
                     Operation *localLoadOp = nullptr) const override;
 
-  bool supportLdMatrix() const override { return computeCapability >= 75; }
-  bool supportStMatrix() const override { return computeCapability >= 90; }
-  bool supportLdStMatrixB8() const override { return computeCapability >= 100; }
+  bool supportLdMatrix() const override {
+    return targetFeatures.supportLdMatrix();
+  }
+  bool supportStMatrix() const override {
+    return targetFeatures.supportStMatrix();
+  }
+  bool supportLdStMatrixB8() const override {
+    return targetFeatures.supportLdStMatrixB8();
+  }
   bool supportBitwidth16Elementwise() const override {
-    // Hopper (sm90) and newer.
-    return computeCapability >= 90;
+    return targetFeatures.supportBitwidth16Elementwise();
   }
   bool supportBitwidth32Elementwise() const override {
-    // Blackwell (sm100) and newer.
-    return computeCapability >= 100;
+    return targetFeatures.supportBitwidth32Elementwise();
   }
 
   Value shuffleXor(RewriterBase &rewriter, Location loc, Value val,
@@ -81,12 +86,14 @@ public:
   bool supportVectorizedAtomics() const override;
 
   int getPtxVersion() const { return ptxVersion; }
-  int getComputeCapability() const { return computeCapability; }
+  int getComputeCapability() const {
+    return targetFeatures.getComputeCapability();
+  }
 
   bool isCuda() const override { return true; }
 
 private:
-  int computeCapability;
+  triton::nvidia_gpu::TargetFeatures targetFeatures;
   int ptxVersion;
 };
 


### PR DESCRIPTION
Existing `nvidia::TargetInfo` couples target feature queries like `supportLdMatrix()` with nvidia-specific llvm codegen utilties. Querying target feature availabilities based on the compute capability is useful for code in `lib/Dialect` as well. 

I'm proposing to add the `TargetFeatures` class under `TritonNvidiaGPU` for that purpose. Existing `TargetInfo` is reimplemented using `TargetFeatures`, its API is unchanged.