### PR TITLE
[AMD][gfx1250] Fix f32 to fp8*fnuz conversion and test skips

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -7,7 +7,7 @@ import pytest
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_rdna3, is_hip_rdna4
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_rdna3, is_hip_rdna4, is_hip_gfx1250
 
 FP8_DTYPES = ('float8e5', 'float8e4b15', 'float8e4nv', 'float8e4b8', 'float8e5b16')
 
@@ -294,8 +294,8 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
             with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
                 launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)
             return
-        if src_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_rdna4()):
-            pytest.skip(f"{src_dtype} is not supported on AMDGPU CDNA2 and RDNA4")
+        if src_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_rdna4() or is_hip_gfx1250()):
+            pytest.skip(f"{src_dtype} is not supported on current AMD GPU")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias, max_repr)
     stuff = {
@@ -349,8 +349,8 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
     if is_hip():
         if dst_dtype in FP8_DTYPES and is_hip_rdna3():
             pytest.skip(f"{dst_dtype} is not supported on AMDGPU RDNA3")
-        if dst_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_rdna4()):
-            pytest.skip(f"{dst_dtype} is not supported on AMDGPU CDNA2 and RDNA4")
+        if dst_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_rdna4() or is_hip_gfx1250()):
+            pytest.skip(f"{dst_dtype} is not supported on current AMD GPU")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias)
     stuff = {
@@ -382,7 +382,7 @@ def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, mode, device, round
     if dst_dtype in FP8_DTYPES and is_hip_rdna3():
         pytest.skip(f"{dst_dtype} is not supported on AMDGPU RDNA3")
 
-    if mode in ('inf', '-inf') and is_hip_rdna4():
+    if mode in ('inf', '-inf') and (is_hip_rdna4() or is_hip_gfx1250()):
         pytest.skip(f"clamping from `{mode}` is not supported on AMDGPU GFX12")
 
     converter = {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -991,7 +991,8 @@ Fp32_to_Fp8E4M3FNUZ_SW(Location loc, ConversionPatternRewriter &rewriter,
 }
 
 static ConverterT Fp32_to_Fp8E4M3FNUZ(AMD::ISAFamily isaFamily) {
-  return isCDNA4(isaFamily) ? Fp32_to_Fp8E4M3FNUZ_SW : Fp32_to_Fp8E4M3FNUZ_HW;
+  return isaFamily == AMD::ISAFamily::CDNA3 ? Fp32_to_Fp8E4M3FNUZ_HW
+                                            : Fp32_to_Fp8E4M3FNUZ_SW;
 }
 
 // Nanoo Bf8 -> Fp32 on CDNA3+


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/10109
Changed `is_rdna4` to exclude gfx1250 so now
we need to be explicit.