### PR TITLE
[BACKEND] Add TargetInfoBase::supportsVectorOfPointers capability flag

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -125,6 +125,8 @@ public:
   virtual void localLoadOpAnnotation(triton::gpu::LocalLoadOp localLoadOp,
                                      Operation *llLoadOp) const {}
 
+  virtual bool supportsVectorOfPointers() const { return true; }
+
   virtual ~TargetInfoBase() {}
 };
 } // namespace mlir::triton

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -653,9 +653,12 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
   auto inDimNames = to_vector(cvt.getInDimNames());
   LinearLayout partitionLayout;
   Value basesVec;
+  bool useVectorOfPointers =
+      isPartitioned && targetInfo.supportsVectorOfPointers();
   if (isPartitioned) {
     partitionLayout = cvt.sublayout(inDimNames, {kPartition});
-    basesVec = LLVM::buildBasePtrVector(loc, rewriter, smemBases);
+    if (useVectorOfPointers)
+      basesVec = LLVM::buildBasePtrVector(loc, rewriter, smemBases);
   }
 
   // Strip kPartition output for vectorization analysis.
@@ -755,7 +758,14 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
                                                   {kWarp, warpId},
                                                   {kBlock, blockId}});
         Value partitionIdx = partitionResult[0].second;
-        smemBase = b.extract_element(basesVec, partitionIdx);
+        if (useVectorOfPointers) {
+          smemBase = b.extract_element(basesVec, partitionIdx);
+        } else {
+          for (size_t p = 1; p < smemBases.size(); ++p) {
+            Value cmp = b.icmp_eq(partitionIdx, b.i32_val(p));
+            smemBase = b.select(cmp, smemBases[p], smemBase);
+          }
+        }
       }
 
       std::optional<Value> innerCtaOffset;


### PR DESCRIPTION
 Add a supportsVectorOfPointers() capability flag on TargetInfoBase (default true). When a backend returns false, lowerLdSt emits a per-base select chain instead of buildBasePtrVector + llvm.extractelement on a vector-of-pointers.

**Motivation**

lowerLdSt selects the base pointer for partitioned shared layouts via buildBasePtrVector + llvm.extractelement on <N x ptr>. This lowers cleanly on NVIDIA PTX and AMD ROCm, but not every downstream toolchain accepts vector-of-pointers as input. In those cases the common lowering forces the backend to either carry a local patch that replaces extractelement with an equivalent construct, or to add a backend-specific scalarization pass. Both duplicate the selection logic outside the common lowering.

This flag lets such a backend opt out without affecting the default IR path.

No IR-level change. NVIDIA and AMD keep the default true. Existing partitioned shared lit tests continue to pass unchanged.

Closes #10181

  ---
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because the default path (`supportsVectorOfPointers=true`) is unchanged and already covered by the existing partitioned shared lit tests in `test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir`. The `false` branch has no in-tree
  consumer to exercise it, so it is validated by downstream backends that override the flag.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
