### PR TITLE
[AMD] Enable IN_THREAD_TRANSPOSE to GFX1201 by default 

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -25,7 +25,8 @@ def is_pingpong_schedule_enabled(arch, use_async_copy):
 
 
 def is_in_thread_transpose_enabled(arch):
-    return (arch == "gfx942") if knobs.amd.use_in_thread_transpose is None else knobs.amd.use_in_thread_transpose
+    return (arch in ("gfx942",
+                     "gfx1201")) if knobs.amd.use_in_thread_transpose is None else knobs.amd.use_in_thread_transpose
 
 
 def is_async_copy_enabled(arch):

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -25,8 +25,8 @@ def is_pingpong_schedule_enabled(arch, use_async_copy):
 
 
 def is_in_thread_transpose_enabled(arch):
-    return (arch in ("gfx942",
-                     "gfx1201")) if knobs.amd.use_in_thread_transpose is None else knobs.amd.use_in_thread_transpose
+    return (arch == "gfx942"
+            or "gfx120" in arch) if knobs.amd.use_in_thread_transpose is None else knobs.amd.use_in_thread_transpose
 
 
 def is_async_copy_enabled(arch):

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -25,8 +25,8 @@ def is_pingpong_schedule_enabled(arch, use_async_copy):
 
 
 def is_in_thread_transpose_enabled(arch):
-    return (arch == "gfx942"
-            or "gfx120" in arch) if knobs.amd.use_in_thread_transpose is None else knobs.amd.use_in_thread_transpose
+    return (arch == "gfx942" or "gfx120" in arch) \
+        if knobs.amd.use_in_thread_transpose is None else knobs.amd.use_in_thread_transpose
 
 
 def is_async_copy_enabled(arch):


### PR DESCRIPTION

Enables in-thread transpose on by default for gfx1201, matching the existing default for gfx942. It will transpose   
 the elements within a thread using registers after global load and before local write in order to maintain good global memory coalescing and wide ds instruction bitwidth and avoid shared memory bank conflicts.

### Flash-Attention 2 Results (bf16):

| headdim | batch_size | seqlen | TFLOPs ITT=0 | TFLOPS ITT=1 | Δ |
| :--- | :--- | :--- | :--- | :--- | :--- |
| 128 | 32 | 512 | 45.16 | 47.74 | +5.7% |
| 128 | 16 | 1024 | 53.34 | 63.69 | +19.4% |
| 128 | 8 | 2048 | 57.77 | 70.62 | +22.3% |
| 128 | 4 | 4096 | 61.90 | 76.49 | +23.6% |
| 128 | 2 | 8192 | 64.18 | 79.10 | +23.3% |
| 128 | 1 | 16384 | 62.15 | 73.48 | +18.2% |
| 128 | 1 | 32768 | 61.45 | 71.19 | +15.9% |


### GEMM Results (bf16)

| M | N | K | TFLOPS ITT=0 | TFLOPS ITT=1 | Δ |
| :--- | :--- | :--- | :--- | :--- | :--- |
| 1024 | 1024 | 1024 | 60.64 | 66.26 | +9.3% |
| 2048 | 2048 | 2048 | 101.69 | 101.26 | -0.4% |
| 4096 | 4096 | 4096 | 109.69 | 120.89 | +10.2% |
| 8192 | 8192 | 8192 | 107.64 | 118.09 | +9.7% |
| 4096 | 11008 | 4096 | 107.50 | 117.04 | +8.9% |
| 4096 | 4096 | 11008 | 109.55 | 119.10 | +8.7% |
| 4096 | 14336 | 4096 | 108.94 | 118.11 | +8.4% |
| 4096 | 4096 | 14336 | 109.35 | 118.83 | +8.7% |
| 4096 | 12288 | 4096 | 108.27 | 117.76 | +8.8% |


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it only flips the default value of is_in_thread_transpose_enabled for a new architecture (gfx1201).

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
