### PR TITLE
[RUNTIME] Initialize profile scratch on stream 0

### DIFF
--- a/python/test/unit/runtime/test_driver.py
+++ b/python/test/unit/runtime/test_driver.py
@@ -1,10 +1,11 @@
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 import torch
 
 import triton
 import triton.language as tl
-from triton.backends.driver import expand_signature, wrap_handle_tensordesc_impl
+from triton.backends.driver import GPUDriver, expand_signature, wrap_handle_tensordesc_impl
 
 
 def test_is_lazy():
@@ -16,6 +17,57 @@ def test_is_lazy():
     assert isinstance(triton.runtime.driver.active, getattr(triton.backends.driver, "DriverBase"))
     assert isinstance(triton.runtime.driver.default, getattr(triton.backends.driver, "DriverBase"))
     utils = triton.runtime.driver.active.utils  # noqa: F841
+
+
+def test_profile_scratch_stream_zero_uses_default_stream(monkeypatch):
+
+    class Scratch:
+
+        def __init__(self):
+            self.recorded_streams = []
+
+        def record_stream(self, stream):
+            self.recorded_streams.append(stream)
+
+    class DeviceInterface:
+
+        def __init__(self):
+            self.default_stream_arg = None
+            self.stream_args = []
+
+        def ExternalStream(self, stream, device):
+            raise AssertionError("stream 0 must use the default stream")
+
+        def stream(self, stream):
+            self.stream_args.append(stream)
+            return stream
+
+        def default_stream(self, device):
+            self.default_stream_arg = device
+            return self
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    zeros_calls = []
+
+    def zeros(size, dtype, device):
+        zeros_calls.append((size, dtype, device))
+        return Scratch()
+
+    device_interface = DeviceInterface()
+    driver = SimpleNamespace(get_active_torch_device=lambda: "cuda:0", get_device_interface=lambda: device_interface)
+    monkeypatch.setattr(torch, "zeros", zeros)
+
+    scratch = GPUDriver.allocate_default_profile_scratch(driver, 16, 8, 0)
+
+    assert device_interface.default_stream_arg == "cuda:0"
+    assert device_interface.stream_args == [device_interface]
+    assert zeros_calls == [(16, torch.int8, "cuda:0")]
+    assert scratch.recorded_streams == []
 
 
 def test_kernel_in_thread(device):

--- a/python/triton/backends/driver.py
+++ b/python/triton/backends/driver.py
@@ -180,6 +180,9 @@ class GPUDriver(DriverBase):
         device_interface = self.get_device_interface()
         if stream is None:
             return torch.zeros(size, dtype=torch.int8, device=device)
+        if stream == 0:
+            with device_interface.stream(device_interface.default_stream(device)):
+                return torch.zeros(size, dtype=torch.int8, device=device)
         launch_stream = device_interface.ExternalStream(stream, device=device)
         with device_interface.stream(launch_stream):
             scratch = torch.zeros(size, dtype=torch.int8, device=device)


### PR DESCRIPTION
Codex found an intersting one that was causing some consan failures (i.e., kernels that need an HBM scratch) to fail.
This empirically fixes a race that was consistently reproduced in my multicta consan branch.

Here's the post mortem

Root cause:

- Triton launches kernels on the current raw CUDA stream.
- In these tests, that current stream is the default stream, whose raw handle is 0.
- The profile-scratch allocator received stream == 0 and did:

  torch.cuda.ExternalStream(0)

- In PyTorch, ExternalStream(0) does not mean the default stream. Its C++ constructor treats stream_ptr == 0 as “no external pointer was supplied” and falls back to
  getStreamFromPool(...), returning a nonzero pooled stream.
- So:
    - profile scratch was zeroed on a pooled stream
    - the Triton kernel ran on raw stream 0
- Those two streams were unordered. Under enough load, the kernel could read ConSan shadow tables before zeroing finished, or have valid shadow state zeroed after writes had begun.

Why xdist exposed it:

- xdist did not create a special stream.
- Each worker simply used the ordinary default CUDA stream, so Triton saw raw stream 0.
- Running many workers at once made the scratch-zeroing race much easier to hit.
