### PR TITLE
[runtime] Show config index and median timing in autotuner print

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -125,12 +125,13 @@ class Autotuner(KernelInterface):
             return driver.active.get_benchmarker()
         return self._do_bench
 
-    def _bench(self, *args, config, **meta):
+    def _bench(self, *args, config, config_index, total_configs, **meta):
         from ..compiler.errors import CompileTimeAssertionFailure
 
         verbose = knobs.autotuning.print
         if verbose:
-            print(f"Autotuning kernel {self.base_fn.__name__} with config {config}")
+            print(f"Autotuning kernel {self.base_fn.__name__} with config [{config_index}/{total_configs}] {config}",
+                  end="", flush=True)
 
         # check for conflicts, i.e. meta-parameters both provided
         # as kwargs and by the autotuner
@@ -161,11 +162,18 @@ class Autotuner(KernelInterface):
             self.post_hook(full_nargs, exception=None)
 
         try:
-            return self.do_bench(kernel_call, quantiles=(0.5, 0.2, 0.8))
+            ret = self.do_bench(kernel_call, quantiles=(0.5, 0.2, 0.8))
+            if verbose:
+                print(f" (median = {ret[0]:.3f} ms)")
+            return ret
         except (OutOfResources, CompileTimeAssertionFailure, PTXASError) as e:
             if verbose:
-                print(f"Autotuning failed with {e}")
+                print(f"\nAutotuning failed with {e}")
             return [float("inf"), float("inf"), float("inf")]
+        except BaseException:
+            if verbose:
+                print()
+            raise
 
     def check_disk_cache(self, tuning_key, configs, bench_fn):
         # We can't serialize prehooks, so just give up and run the benchmarks.
@@ -226,7 +234,12 @@ class Autotuner(KernelInterface):
 
                 def benchmark():
                     bench_start = time.time()
-                    timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
+                    timings = {
+                        config:
+                        self._bench(*args, config=config, config_index=i + 1, total_configs=len(pruned_configs),
+                                    **kwargs)
+                        for i, config in enumerate(pruned_configs)
+                    }
                     bench_end = time.time()
                     self.bench_time = bench_end - bench_start
                     self.cache[key] = builtins.min(timings, key=timings.get)


### PR DESCRIPTION
Currently the verbose setting of the autotuner only prints out the config that is currently being run:

```Autotuning kernel add_kernel with config BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None```

This minor change updates it so that it prints the progress through the current batch of configs in addition to the performance of this config, making the log more interesting and informative:

```Autotuning kernel add_kernel with config [1/5] BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.014 ms)```

The diff is slightly bigger than it could be to ensure that all errors are printed on a new line.

Several different formats were considered before settling on this one:

<details>
<summary><strong>Click to view considered formats</strong></summary>

### index: no index  |  result: took X ms

```
Autotuning kernel add_kernel with config BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None took 0.014 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None took 0.010 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None took 0.009 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None took 0.008 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None took 0.008 ms
```

### index: no index  |  result: (X ms) bare parens

```
Autotuning kernel add_kernel with config BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (0.014 ms)
Autotuning kernel add_kernel with config BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (0.010 ms)
Autotuning kernel add_kernel with config BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (0.009 ms)
Autotuning kernel add_kernel with config BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (0.008 ms)
Autotuning kernel add_kernel with config BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None (0.008 ms)
```

### index: no index  |  result: : X ms colon

```
Autotuning kernel add_kernel with config BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None: 0.014 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None: 0.010 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None: 0.009 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None: 0.008 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None: 0.008 ms
```

### index: no index  |  result: -> X ms arrow

```
Autotuning kernel add_kernel with config BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.014 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.010 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.009 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.008 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.008 ms
```

### index: no index  |  result: ran in X ms

```
Autotuning kernel add_kernel with config BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.014 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.010 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.009 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.008 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.008 ms
```

### index: no index  |  result: at X ms

```
Autotuning kernel add_kernel with config BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None at 0.014 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None at 0.010 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None at 0.009 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None at 0.008 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None at 0.008 ms
```

### index: no index  |  result: @ X ms

```
Autotuning kernel add_kernel with config BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.014 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.010 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.009 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.008 ms
Autotuning kernel add_kernel with config BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.008 ms
```

### index: no index  |  result: (median = X ms) parens

```
Autotuning kernel add_kernel with config BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.014 ms)
Autotuning kernel add_kernel with config BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.010 ms)
Autotuning kernel add_kernel with config BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.009 ms)
Autotuning kernel add_kernel with config BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.008 ms)
Autotuning kernel add_kernel with config BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.008 ms)
```

### index: no index  |  result: [median = X ms] brackets

```
Autotuning kernel add_kernel with config BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.014 ms]
Autotuning kernel add_kernel with config BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.010 ms]
Autotuning kernel add_kernel with config BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.009 ms]
Autotuning kernel add_kernel with config BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.008 ms]
Autotuning kernel add_kernel with config BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.008 ms]
```

### index: (i/N) parens  |  result: took X ms

```
Autotuning kernel add_kernel with config (1/5) BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None took 0.014 ms
Autotuning kernel add_kernel with config (2/5) BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None took 0.010 ms
Autotuning kernel add_kernel with config (3/5) BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None took 0.009 ms
Autotuning kernel add_kernel with config (4/5) BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None took 0.008 ms
Autotuning kernel add_kernel with config (5/5) BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None took 0.008 ms
```

### index: (i/N) parens  |  result: (X ms) bare parens

```
Autotuning kernel add_kernel with config (1/5) BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (0.014 ms)
Autotuning kernel add_kernel with config (2/5) BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (0.010 ms)
Autotuning kernel add_kernel with config (3/5) BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (0.009 ms)
Autotuning kernel add_kernel with config (4/5) BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (0.008 ms)
Autotuning kernel add_kernel with config (5/5) BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None (0.008 ms)
```

### index: (i/N) parens  |  result: : X ms colon

```
Autotuning kernel add_kernel with config (1/5) BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None: 0.014 ms
Autotuning kernel add_kernel with config (2/5) BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None: 0.010 ms
Autotuning kernel add_kernel with config (3/5) BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None: 0.009 ms
Autotuning kernel add_kernel with config (4/5) BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None: 0.008 ms
Autotuning kernel add_kernel with config (5/5) BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None: 0.008 ms
```

### index: (i/N) parens  |  result: -> X ms arrow

```
Autotuning kernel add_kernel with config (1/5) BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.014 ms
Autotuning kernel add_kernel with config (2/5) BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.010 ms
Autotuning kernel add_kernel with config (3/5) BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.009 ms
Autotuning kernel add_kernel with config (4/5) BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.008 ms
Autotuning kernel add_kernel with config (5/5) BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.008 ms
```

### index: (i/N) parens  |  result: ran in X ms

```
Autotuning kernel add_kernel with config (1/5) BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.014 ms
Autotuning kernel add_kernel with config (2/5) BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.010 ms
Autotuning kernel add_kernel with config (3/5) BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.009 ms
Autotuning kernel add_kernel with config (4/5) BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.008 ms
Autotuning kernel add_kernel with config (5/5) BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.008 ms
```

### index: (i/N) parens  |  result: at X ms

```
Autotuning kernel add_kernel with config (1/5) BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None at 0.014 ms
Autotuning kernel add_kernel with config (2/5) BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None at 0.010 ms
Autotuning kernel add_kernel with config (3/5) BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None at 0.009 ms
Autotuning kernel add_kernel with config (4/5) BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None at 0.008 ms
Autotuning kernel add_kernel with config (5/5) BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None at 0.008 ms
```

### index: (i/N) parens  |  result: @ X ms

```
Autotuning kernel add_kernel with config (1/5) BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.014 ms
Autotuning kernel add_kernel with config (2/5) BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.010 ms
Autotuning kernel add_kernel with config (3/5) BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.009 ms
Autotuning kernel add_kernel with config (4/5) BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.008 ms
Autotuning kernel add_kernel with config (5/5) BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.008 ms
```

### index: (i/N) parens  |  result: (median = X ms) parens

```
Autotuning kernel add_kernel with config (1/5) BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.014 ms)
Autotuning kernel add_kernel with config (2/5) BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.010 ms)
Autotuning kernel add_kernel with config (3/5) BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.009 ms)
Autotuning kernel add_kernel with config (4/5) BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.008 ms)
Autotuning kernel add_kernel with config (5/5) BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.008 ms)
```

### index: (i/N) parens  |  result: [median = X ms] brackets

```
Autotuning kernel add_kernel with config (1/5) BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.014 ms]
Autotuning kernel add_kernel with config (2/5) BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.010 ms]
Autotuning kernel add_kernel with config (3/5) BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.009 ms]
Autotuning kernel add_kernel with config (4/5) BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.008 ms]
Autotuning kernel add_kernel with config (5/5) BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.008 ms]
```

### index: [i/N] brackets  |  result: took X ms

```
Autotuning kernel add_kernel with config [1/5] BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None took 0.014 ms
Autotuning kernel add_kernel with config [2/5] BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None took 0.010 ms
Autotuning kernel add_kernel with config [3/5] BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None took 0.009 ms
Autotuning kernel add_kernel with config [4/5] BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None took 0.008 ms
Autotuning kernel add_kernel with config [5/5] BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None took 0.008 ms
```

### index: [i/N] brackets  |  result: (X ms) bare parens

```
Autotuning kernel add_kernel with config [1/5] BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (0.014 ms)
Autotuning kernel add_kernel with config [2/5] BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (0.010 ms)
Autotuning kernel add_kernel with config [3/5] BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (0.009 ms)
Autotuning kernel add_kernel with config [4/5] BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (0.008 ms)
Autotuning kernel add_kernel with config [5/5] BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None (0.008 ms)
```

### index: [i/N] brackets  |  result: : X ms colon

```
Autotuning kernel add_kernel with config [1/5] BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None: 0.014 ms
Autotuning kernel add_kernel with config [2/5] BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None: 0.010 ms
Autotuning kernel add_kernel with config [3/5] BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None: 0.009 ms
Autotuning kernel add_kernel with config [4/5] BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None: 0.008 ms
Autotuning kernel add_kernel with config [5/5] BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None: 0.008 ms
```

### index: [i/N] brackets  |  result: -> X ms arrow

```
Autotuning kernel add_kernel with config [1/5] BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.014 ms
Autotuning kernel add_kernel with config [2/5] BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.010 ms
Autotuning kernel add_kernel with config [3/5] BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.009 ms
Autotuning kernel add_kernel with config [4/5] BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.008 ms
Autotuning kernel add_kernel with config [5/5] BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None -> 0.008 ms
```

### index: [i/N] brackets  |  result: ran in X ms

```
Autotuning kernel add_kernel with config [1/5] BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.014 ms
Autotuning kernel add_kernel with config [2/5] BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.010 ms
Autotuning kernel add_kernel with config [3/5] BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.009 ms
Autotuning kernel add_kernel with config [4/5] BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.008 ms
Autotuning kernel add_kernel with config [5/5] BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None ran in 0.008 ms
```

### index: [i/N] brackets  |  result: at X ms

```
Autotuning kernel add_kernel with config [1/5] BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None at 0.014 ms
Autotuning kernel add_kernel with config [2/5] BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None at 0.010 ms
Autotuning kernel add_kernel with config [3/5] BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None at 0.009 ms
Autotuning kernel add_kernel with config [4/5] BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None at 0.008 ms
Autotuning kernel add_kernel with config [5/5] BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None at 0.008 ms
```

### index: [i/N] brackets  |  result: @ X ms

```
Autotuning kernel add_kernel with config [1/5] BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.014 ms
Autotuning kernel add_kernel with config [2/5] BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.010 ms
Autotuning kernel add_kernel with config [3/5] BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.009 ms
Autotuning kernel add_kernel with config [4/5] BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.008 ms
Autotuning kernel add_kernel with config [5/5] BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None @ 0.008 ms
```

### index: [i/N] brackets  |  result: (median = X ms) parens

```
Autotuning kernel add_kernel with config [1/5] BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.014 ms)
Autotuning kernel add_kernel with config [2/5] BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.010 ms)
Autotuning kernel add_kernel with config [3/5] BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.009 ms)
Autotuning kernel add_kernel with config [4/5] BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.008 ms)
Autotuning kernel add_kernel with config [5/5] BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None (median = 0.008 ms)
```

### index: [i/N] brackets  |  result: [median = X ms] brackets

```
Autotuning kernel add_kernel with config [1/5] BLOCK_SIZE: 64, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.014 ms]
Autotuning kernel add_kernel with config [2/5] BLOCK_SIZE: 128, num_warps: 2, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.010 ms]
Autotuning kernel add_kernel with config [3/5] BLOCK_SIZE: 256, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.009 ms]
Autotuning kernel add_kernel with config [4/5] BLOCK_SIZE: 512, num_warps: 4, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.008 ms]
Autotuning kernel add_kernel with config [5/5] BLOCK_SIZE: 1024, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None [median = 0.008 ms]
```



</details>





<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `Purely visual change to autotuner prints`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
