### PR TITLE
Support returning tensors in TritonToTritonGPU

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -89,13 +89,13 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
     return false;
   });
   addDynamicallyLegalOp<triton::FuncOp>([](triton::FuncOp funcOp) -> bool {
-    for (auto arg : funcOp.getArguments()) {
-      if (auto tensor = dyn_cast<RankedTensorType>(arg.getType())) {
-        if (!tensor.getEncoding())
-          return false;
-      }
-    }
-    return true;
+    auto check = [](auto types) {
+      return llvm::all_of(types, [](auto type) {
+        auto tensor = dyn_cast<RankedTensorType>(type);
+        return !tensor || tensor.getEncoding();
+      });
+    };
+    return check(funcOp.getArgumentTypes()) && check(funcOp.getResultTypes());
   });
 }
 

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -6,6 +6,7 @@
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/Triton/Transforms/FunctionTypeConversion.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -488,55 +489,6 @@ struct TritonMapElementwisePattern
   }
 };
 
-class TritonFuncOpPattern : public OpConversionPattern<triton::FuncOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(triton::FuncOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto converter = getTypeConverter();
-    TypeConverter::SignatureConversion result(op.getNumArguments());
-    auto newOp = rewriter.replaceOpWithNewOp<triton::FuncOp>(
-        op, op.getName(), op.getFunctionType());
-    addNamedAttrs(newOp, adaptor.getAttributes());
-    rewriter.inlineRegionBefore(op.getBody(), newOp.getBody(),
-                                newOp.getBody().end());
-    // Convert just the entry block. The remaining unstructured control flow is
-    // converted by br patterns.
-    if (!newOp.getBody().empty())
-      rewriter.applySignatureConversion(&newOp.getBody().front(), result,
-                                        converter);
-    return success();
-  }
-};
-
-class TritonCallOpPattern : public OpConversionPattern<triton::CallOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(triton::CallOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto newOp = rewriter.replaceOpWithNewOp<triton::CallOp>(
-        op, op.getCallee(), op.getResultTypes(), adaptor.getOperands());
-    addNamedAttrs(newOp, adaptor.getAttributes());
-    return success();
-  }
-};
-
-class TritonReturnOpPattern : public OpConversionPattern<ReturnOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(ReturnOp op, ReturnOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<ReturnOp>(op, adaptor.getOperands());
-    return success();
-  }
-};
-
 void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
                             RewritePatternSet &patterns, unsigned numCTAs) {
   MLIRContext *context = patterns.getContext();
@@ -584,10 +536,7 @@ void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
       GenericOpPattern<triton::DescriptorStoreOp>,
       GenericOpPattern<triton::DescriptorReduceOp>,
       // this assumes the right layout will be set later for dot scaled.
-      GenericOpPattern<triton::DotScaledOp>,
-      GenericOpPattern<triton::CallOp>,
-      GenericOpPattern<ReturnOp>,
-      TritonFuncOpPattern
+      GenericOpPattern<triton::DotScaledOp>
       // clang-format on
       >(typeConverter, context);
 }
@@ -803,6 +752,8 @@ public:
     // add rules
     populateArithPatternsAndLegality(typeConverter, patterns, target);
     populateMathPatternsAndLegality(typeConverter, patterns, target);
+    FuncArgRenamer renamer;
+    populateFunctionTypeConversions(typeConverter, renamer, patterns);
     populateTritonPatterns(typeConverter, patterns, numCTAs);
     // TODO: can we use
     //    mlir::scf::populateSCFStructurealTypeConversionsAndLegality(...) here?

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1312,6 +1312,30 @@ def test_noinline(mode, device):
         assert torch.equal(z, ref + x + y)
 
 
+@triton.jit(noinline=True)
+def noinline_load_block_fn(ptr, BLOCK_SIZE: tl.constexpr):
+    offsets = tl.arange(0, BLOCK_SIZE)
+    return tl.load(ptr + offsets)
+
+
+def test_noinline_returns_tensor(device):
+
+    @triton.jit
+    def kernel(X, Y, Z, BLOCK_SIZE: tl.constexpr):
+        x = noinline_load_block_fn(X, BLOCK_SIZE)
+        y = noinline_load_block_fn(Y, BLOCK_SIZE)
+        offsets = tl.arange(0, BLOCK_SIZE)
+        tl.store(Z + offsets, x + y)
+
+    BLOCK_SIZE = 128
+    torch.manual_seed(0)
+    x = torch.randn(BLOCK_SIZE, device=device, dtype=torch.float32)
+    y = torch.randn(BLOCK_SIZE, device=device, dtype=torch.float32)
+    z = torch.empty_like(x)
+    kernel[(1, )](x, y, z, BLOCK_SIZE=BLOCK_SIZE, num_warps=1)
+    assert torch.equal(z, x + y)
+
+
 # ---------------
 # test atomics
 # ---------------

--- a/test/Conversion/triton_to_tritongpu.mlir
+++ b/test/Conversion/triton_to_tritongpu.mlir
@@ -185,25 +185,43 @@ tt.func @split_op(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) {
 
 // -----
 
-// A tt.func that returns a tensor should have its result
-// type converted (encoded) along with its argument types, and a tt.call
-// site should pick up the encoded result type as well.
-
 // CHECK-LABEL: tt.func private @callee
-// CHECK-SAME: (%{{.*}}: tensor<128xi32, #{{.*}}>) -> tensor<128xi32, #{{.*}}>
-tt.func private @callee(%arg0: tensor<128xi32>) -> tensor<128xi32> {
-  %cst = arith.constant dense<1> : tensor<128xi32>
-  %0 = arith.addi %arg0, %cst : tensor<128xi32>
+// CHECK-SAME: (%{{.*}}: !tt.ptr<i32>) -> tensor<128xi32, #{{.*}}>
+tt.func private @callee(%arg0: !tt.ptr<i32>) -> tensor<128xi32> {
+  %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
   // CHECK: tt.return %{{.*}} : tensor<128xi32, #{{.*}}>
   tt.return %0 : tensor<128xi32>
 }
 
 // CHECK-LABEL: tt.func @caller
 tt.func @caller(%ptr: !tt.ptr<i32>) {
-  %r = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
-  // CHECK: %{{.*}} = tt.call @callee(%{{.*}}) : (tensor<128xi32, #{{.*}}>) -> tensor<128xi32, #{{.*}}>
-  %v = tt.call @callee(%r) : (tensor<128xi32>) -> tensor<128xi32>
+  // CHECK: %{{.*}} = tt.call @callee(%{{.*}}) : (!tt.ptr<i32>) -> tensor<128xi32, #{{.*}}>
+  %v = tt.call @callee(%ptr) : (!tt.ptr<i32>) -> tensor<128xi32>
   %ptrs = tt.splat %ptr : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
   tt.store %ptrs, %v : tensor<128x!tt.ptr<i32>>
+  tt.return
+}
+
+// -----
+
+// When a callee returns a tensor whose default encoding doesn't match what
+// the caller's consumer wants, a ttg.convert_layout should be auto-inserted
+// at the call boundary.
+
+// CHECK-LABEL: tt.func private @make_a
+// CHECK: tt.return %{{.*}} : tensor<128x32xf16, #[[$BLOCKED:[^,>]+]]>
+tt.func private @make_a() -> tensor<128x32xf16> {
+  %a = arith.constant dense<1.0> : tensor<128x32xf16>
+  tt.return %a : tensor<128x32xf16>
+}
+
+// CHECK-LABEL: tt.func @call_into_dot
+// CHECK: %[[V:.*]] = tt.call @make_a() : () -> tensor<128x32xf16, #[[$BLOCKED]]>
+// CHECK: ttg.convert_layout %[[V]] : tensor<128x32xf16, #[[$BLOCKED]]> -> tensor<128x32xf16, #ttg.dot_op<{{.*}}>>
+// CHECK: tt.dot
+tt.func @call_into_dot(%b: tensor<32x128xf16>) {
+  %a = tt.call @make_a() : () -> tensor<128x32xf16>
+  %c = arith.constant dense<0.0> : tensor<128x128xf32>
+  %0 = tt.dot %a, %b, %c : tensor<128x32xf16> * tensor<32x128xf16> -> tensor<128x128xf32>
   tt.return
 }

--- a/test/Conversion/triton_to_tritongpu.mlir
+++ b/test/Conversion/triton_to_tritongpu.mlir
@@ -182,3 +182,28 @@ tt.func @split_op(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) {
   tt.store %2, %res1 : tensor<64x!tt.ptr<f32>>
   tt.return
 }
+
+// -----
+
+// A tt.func that returns a tensor should have its result
+// type converted (encoded) along with its argument types, and a tt.call
+// site should pick up the encoded result type as well.
+
+// CHECK-LABEL: tt.func private @callee
+// CHECK-SAME: (%{{.*}}: tensor<128xi32, #{{.*}}>) -> tensor<128xi32, #{{.*}}>
+tt.func private @callee(%arg0: tensor<128xi32>) -> tensor<128xi32> {
+  %cst = arith.constant dense<1> : tensor<128xi32>
+  %0 = arith.addi %arg0, %cst : tensor<128xi32>
+  // CHECK: tt.return %{{.*}} : tensor<128xi32, #{{.*}}>
+  tt.return %0 : tensor<128xi32>
+}
+
+// CHECK-LABEL: tt.func @caller
+tt.func @caller(%ptr: !tt.ptr<i32>) {
+  %r = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  // CHECK: %{{.*}} = tt.call @callee(%{{.*}}) : (tensor<128xi32, #{{.*}}>) -> tensor<128xi32, #{{.*}}>
+  %v = tt.call @callee(%r) : (tensor<128xi32>) -> tensor<128xi32>
+  %ptrs = tt.splat %ptr : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
+  tt.store %ptrs, %v : tensor<128x!tt.ptr<i32>>
+  tt.return
+}


### PR DESCRIPTION
The conversion patterns in `TritonToTritonGPU` (`TritonFuncOpPattern`, `TritonCallOpPattern`, `TritonReturnOpPattern`) did not handle `tt.func` ops returning tensors: `TritonFuncOpPattern` reused the original `FunctionType` verbatim, and the `triton::FuncOp` legality check inspected only argument types, so tensor result types came out without any layout encoding. There was already a fork of MLIR upstream's signature-conversion pattern in `Dialect/Triton/Transforms/FunctionTypeConversion.h` (added because upstream is unaware of `tt.call`/`tt.return`) which handles inputs, results, one-to-many conversions, and arg-attribute remapping — so this PR drops those three custom patterns and reuses this one. The legality predicate is also extended to require encodings on result tensor types.                                                                                                                                                                                                                  

Adds a regression test in `test/Conversion/triton_to_tritongpu.mlir` covering a `tt.func` returning a tensor and a `tt.call` site picking up the encoded result type.

Making this PR on behalf of @saagarjha (he is waiting on #8913)

- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- [x] I have added tests.
- [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
