### PR TITLE
[mxfp4] Fix Hopper scale padding mask

### DIFF
--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from triton_kernels.matmul import matmul, matmul_torch, PrecisionConfig
-from triton_kernels.matmul_details.opt_flags import scoped_opt_flags_constraints
+from triton_kernels.matmul_details.opt_flags import InapplicableConstraint, scoped_opt_flags_constraints
 from triton_kernels.matmul_details.opt_flags_details import opt_flags_nvidia
 from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE, downcast_to_mxfp
 from triton_kernels.tensor import FP4, UINT8, Storage, Tensor, convert_layout, wrap_torch_tensor
@@ -40,6 +40,67 @@ def _make_batched_blackwell_mxfp4_weight(device, batch_size, k, n):
 def _shuffle_blackwell_mxfp4_weight(weight):
     shuffled_layout = BlackwellMX4ValueShuffledLayout()
     return convert_layout(weight, shuffled_layout)
+
+
+@pytest.mark.parametrize(
+    "constraints",
+    [
+        pytest.param({"is_persistent": False}, id="regular"),
+        pytest.param({"is_persistent": True, "block_m": 128}, id="persistent"),
+    ],
+)
+def test_matmul_hopper_mxfp4_rhs_scale_padding_is_masked(device, constraints):
+    if device != "cuda" or not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    if torch.cuda.get_device_capability()[0] != 9:
+        pytest.skip("requires Hopper")
+
+    torch.manual_seed(0)
+    # k=1504 gives 47 MXFP scale columns along K. Hopper scale swizzling pads
+    # that to 48 columns, so dirtying swizzled zero bytes targets the K-tail
+    # scale padding. n=256 is one full Hopper N tile, avoiding unrelated N padding.
+    m, k, n = 64, 1504, 256
+    a = torch.randn((m, k), device=device, dtype=torch.bfloat16)
+    weight_fp = torch.randn((n, k), device=device, dtype=torch.bfloat16).T
+    weight_val, weight_scale = downcast_to_mxfp(weight_fp, torch.uint8, axis=-2)
+
+    value_layout = layout.make_default_matmul_mxfp4_w_layout(mx_axis=-2)
+    scale_layout = layout.make_default_matmul_mxfp4_w_scale_layout(mx_axis=-2, num_warps=8)
+    b = convert_layout(wrap_torch_tensor(weight_val, dtype=FP4), value_layout)
+    b_scale = convert_layout(wrap_torch_tensor(weight_scale, dtype=UINT8), scale_layout)
+
+    # Ones remain ones through the scale swizzle; zeros identify padded bytes.
+    scale_padding = convert_layout(
+        wrap_torch_tensor(torch.ones_like(weight_scale), dtype=UINT8),
+        scale_layout,
+    ).storage.data == 0
+    assert bool(scale_padding.any().item())
+
+    b_scale_dirty_padding = convert_layout(wrap_torch_tensor(weight_scale.clone(), dtype=UINT8), scale_layout)
+    b_scale_dirty_padding.storage.data[scale_padding] = 0xFF
+
+    precision_kwargs = {
+        "b_microblock_size": MXFP_BLOCK_SIZE.value,
+        "out_dtype": a.dtype,
+    }
+    try:
+        with scoped_opt_flags_constraints(constraints):
+            expected = matmul(
+                a,
+                b,
+                None,
+                precision_config=PrecisionConfig(b_mx_scale=b_scale, **precision_kwargs),
+            )
+            actual = matmul(
+                a,
+                b,
+                None,
+                precision_config=PrecisionConfig(b_mx_scale=b_scale_dirty_padding, **precision_kwargs),
+            )
+    except (InapplicableConstraint, NotImplementedError) as e:
+        pytest.skip(f"inapplicable opt_flags constraint {e}")
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("n, expected", [(64, 128), (200, 256)])

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+from triton._internal_testing import is_cuda
 
 from triton_kernels.matmul import matmul, matmul_torch, PrecisionConfig
 from triton_kernels.matmul_details.opt_flags import InapplicableConstraint, scoped_opt_flags_constraints
@@ -50,7 +51,7 @@ def _shuffle_blackwell_mxfp4_weight(weight):
     ],
 )
 def test_matmul_hopper_mxfp4_rhs_scale_padding_is_masked(device, constraints):
-    if device != "cuda" or not torch.cuda.is_available():
+    if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
         pytest.skip("requires CUDA")
     if torch.cuda.get_device_capability()[0] != 9:
         pytest.skip("requires Hopper")

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -405,7 +405,8 @@ def _matmul(
                 tl.static_assert(num_warps == 8 or num_warps == 4)
                 w_scales = unswizzle_mxfp4_scale_hopper(tl.load(WMxScalePtrs), mx_axis=1, num_warps=num_warps)
                 mask_k_scale = off_k_x + tl.arange(0, MX_SCALE_BLOCK_K) * MX_PACK_DIVISOR < x_k_limit
-                w_scales = tl.where(mask_k_scale[None, :], w_scales, 0)
+                scale_zero = tl.full(w_scales.shape, 0, dtype=w_scales.dtype)
+                w_scales = tl.where(mask_k_scale[None, :], w_scales, scale_zero)
             elif SWIZZLE_MX_SCALE == "CDNA4_SCALE":
                 w_scales = unswizzle_mx_scale_cdna4(tl.load(WMxScalePtrs), BLOCK_N, MX_SCALE_BLOCK_K)
             elif SWIZZLE_MX_SCALE == "GFX1250_SCALE":

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -404,6 +404,8 @@ def _matmul(
                 num_warps: tl.constexpr = tl.extra.cuda.num_warps()
                 tl.static_assert(num_warps == 8 or num_warps == 4)
                 w_scales = unswizzle_mxfp4_scale_hopper(tl.load(WMxScalePtrs), mx_axis=1, num_warps=num_warps)
+                mask_k_scale = off_k_x + tl.arange(0, MX_SCALE_BLOCK_K) * MX_PACK_DIVISOR < x_k_limit
+                w_scales = tl.where(mask_k_scale[None, :], w_scales, 0)
             elif SWIZZLE_MX_SCALE == "CDNA4_SCALE":
                 w_scales = unswizzle_mx_scale_cdna4(tl.load(WMxScalePtrs), BLOCK_N, MX_SCALE_BLOCK_K)
             elif SWIZZLE_MX_SCALE == "GFX1250_SCALE":

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -404,8 +404,9 @@ def _p_matmul(
                     w_scales = tl.reshape(w_scales, *w_scales.shape[1:])
                     num_warps: tl.constexpr = tl.extra.cuda.num_warps()
                     w_scales = unswizzle_mxfp4_scale_hopper(w_scales, mx_axis=1, num_warps=num_warps)
-                    mask_k_scale = off_k_mx + tl.arange(0, MX_SCALE_BLOCK_K) < tl.cdiv(K, MX_PACK_DIVISOR)
-                    w_scales = tl.where(mask_k_scale[None, :], w_scales, 0)
+                    mask_k_scale = off_k_x + tl.arange(0, MX_SCALE_BLOCK_K) * MX_PACK_DIVISOR < off_k_x0 + loop_k
+                    scale_zero = tl.full(w_scales.shape, 0, dtype=w_scales.dtype)
+                    w_scales = tl.where(mask_k_scale[None, :], w_scales, scale_zero)
                 else:
                     w_scales = WMxScale.load([off_w_z, off_k_mx, off_n])
                     w_scales = tl.reshape(w_scales, *w_scales.shape[1:]).T

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -404,6 +404,8 @@ def _p_matmul(
                     w_scales = tl.reshape(w_scales, *w_scales.shape[1:])
                     num_warps: tl.constexpr = tl.extra.cuda.num_warps()
                     w_scales = unswizzle_mxfp4_scale_hopper(w_scales, mx_axis=1, num_warps=num_warps)
+                    mask_k_scale = off_k_mx + tl.arange(0, MX_SCALE_BLOCK_K) < tl.cdiv(K, MX_PACK_DIVISOR)
+                    w_scales = tl.where(mask_k_scale[None, :], w_scales, 0)
                 else:
                     w_scales = WMxScale.load([off_w_z, off_k_mx, off_n])
                     w_scales = tl.reshape(w_scales, *w_scales.shape[1:]).T


### PR DESCRIPTION
## Why

Hopper MXFP4 weight-scale swizzling can introduce padded scale bytes when the RHS K dimension does not fill the final scale tile.

The regular RHS value load already masks invalid K-tail values, but the Hopper scale path was loading and unswizzling the full scale tile without clearing invalid K-scale columns. If those padded scale bytes contain non-zero data, the matmul result can become sensitive to padding contents.

## What is included

* Masks invalid K-scale columns after `unswizzle_mxfp4_scale_hopper` in the regular matmul kernel.
* Applies the same padding handling in the persistent/TMA matmul kernel.
* Adds Hopper-only regression coverage for RHS MXFP4 scale padding:
  * uses `k=1504`, which gives 47 MXFP scale columns and forces Hopper scale-layout K padding;
  * uses `n=256`, one full Hopper N tile, to avoid testing unrelated N padding;
  * dirties swizzled scale padding bytes with `0xFF`;
  * verifies clean vs dirty scale-padding outputs are bit-exact;
  * covers both regular and persistent/TMA opt-flag paths when applicable.

## Test plan
- Tested on my gpu setup with unit tests and real models on hopper devices
