### PR TITLE
Fix scaled MMA partition scheduling dependency

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -229,8 +229,7 @@ SmallVector<OutputPort> initialDataValues(Graph *graph) {
         node->setDataValue(1);
         values.push_back({node, 1});
       }
-      // TODO: Support TCGen5MMAScaledOp
-      if (isa<nvidia_gpu::TCGen5MMAOp>(op)) {
+      if (isa<nvidia_gpu::TCGen5MMAOp, nvidia_gpu::TCGen5MMAScaledOp>(op)) {
         node->setDataValue(0);
         values.push_back({node, 0});
       }

--- a/test/TritonGPU/partition-scheduling-scaled-mma.mlir
+++ b/test/TritonGPU/partition-scheduling-scaled-mma.mlir
@@ -1,0 +1,72 @@
+// RUN: triton-opt %s --split-input-file --tritongpu-hoist-tmem-alloc --tritongpu-partition-scheduling -allow-unregistered-dialect | FileCheck %s
+
+// Verify that TCGen5MMAScaledOp is classified as a data value in partition
+// scheduling, just like TCGen5MMAOp. Both ops have an optional async token
+// as output 0, and initialDataValues should mark it as a data value so that
+// partition scheduling properly propagates the data dependency.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#load_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_T = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#shared_scales = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [4, 3, 2, 1, 0]}>
+
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @scaled_mma_with_loads
+tt.func public @scaled_mma_with_loads(
+  %A_shared: !ttg.memdesc<128x128xf16, #shared, #smem>,
+  %B_desc: !tt.tensordesc<128x128xf16, #shared>,
+  %A_scale_shared: !ttg.memdesc<1x2x32x4x4xi8, #shared_scales, #smem>,
+  %B_scale_shared: !ttg.memdesc<1x2x32x4x4xi8, #shared_scales, #smem>,
+  %n_tiles: i32
+) {
+  %true = arith.constant true
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+
+  %acc_tmem, %acc_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+
+  // CHECK: scf.for
+  %loop_out:2 = scf.for %i = %c0_i32 to %n_tiles step %c1_i32 iter_args(
+    %iter_acc_tok = %acc_tok,
+    %iter_acc_tmem = %acc_tmem
+  ) -> (
+    !ttg.async.token,
+    !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ) : i32 {
+
+    // Load partition. Feeding this load into the MMA keeps the test live after
+    // canonicalization while still requiring the scaled MMA token result to
+    // propagate the dependency to tmem_load.
+    // CHECK-COUNT-2: ttg.partition = array<i32: 2>
+    %B = tt.descriptor_load %B_desc[%i, %c0_i32] : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #load_blocked>
+    %B_shared = ttg.local_alloc %B : (tensor<128x128xf16, #load_blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+
+    // Compute partition: tc_gen5_mma_scaled should get partition 1
+    // just like tc_gen5_mma does in the existing tests.
+    // CHECK: ttg.memdesc_trans {{.*}} {order = array<i32: 1, 0>, ttg.partition = array<i32: 1>}
+    %B_trans = ttg.memdesc_trans %B_shared {order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem> -> !ttg.memdesc<128x128xf16, #shared_T, #smem>
+    // CHECK: ttng.tc_gen5_mma_scaled {{.*}} {ttg.partition = array<i32: 1>}
+    %mma_tok = ttng.tc_gen5_mma_scaled %A_shared, %B_trans, %iter_acc_tmem[%iter_acc_tok], %A_scale_shared, %B_scale_shared, %true, %true lhs = e5m2 rhs = e5m2 : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf16, #shared_T, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x2x32x4x4xi8, #shared_scales, #smem>, !ttg.memdesc<1x2x32x4x4xi8, #shared_scales, #smem>
+
+    // Data partition: tmem_load should get partition 0
+    // CHECK-COUNT-2: ttg.partition = array<i32: 0>
+    %QK, %QK_load_tok = ttng.tmem_load %iter_acc_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+
+    "use"(%QK) {data} : (tensor<128x128xf32, #blocked>) -> ()
+
+    scf.yield %QK_load_tok, %iter_acc_tmem : !ttg.async.token, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // CHECK: scf.yield {ttg.partition = array<i32: 0, 1, 2>}
+    // CHECK: ttg.partition = array<i32: 0, 1, 2>, ttg.partition.outputs = [array<i32: 1>]
+  } {tt.warp_specialize}
+
+  "use"(%loop_out#0) : (!ttg.async.token) -> ()
+  tt.return
+}
+
+}


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

## Summary

Teach partition scheduling to classify `TCGen5MMAScaledOp` token output as a data value, same as `TCGen5MMAOp`.

This preserves the dependency from scaled MMA to token-consuming `tmem_load` and fixes the generated partition output metadata.

## Testing

- `lit -v "$BUILD_DIR/test" --filter partition-scheduling-scaled-mma`


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
