### PR TITLE
[AMD] Fixing mi350 BlockPingpong update waits

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -111,17 +111,22 @@ static int minNumInterleavedCommitOps(Operation *waitOp) {
     return 0;
   };
 
-  if (waitOp->getNumOperands() != 1)
+  if (waitOp->getNumOperands() == 0)
     return 0;
-  Value val = waitOp->getOperand(0);
-  // If the value resides in a region other than the region of the wait op, then
-  // the wait op must be in some nested region. Measure the number of commits
-  // between the definition value and the parent op.
-  // TODO: We could measure commits in nested regions along the path if
-  // necessary.
-  while (waitOp->getParentRegion() != val.getParentRegion())
-    waitOp = waitOp->getParentOp();
-  int minCommits = minOverHistories(val, waitOp, 0);
+  // Multi-token waits: take the min of minOverHistories across operands. Both
+  // the captured `minCommitNumber` and the returned bailout-0s are folded in.
+  int minCommits = INT_MAX;
+  for (Value val : waitOp->getOperands()) {
+    Operation *anchor = waitOp;
+    // If the value resides in a region other than the region of the wait op,
+    // then the wait op must be in some nested region. Measure the number of
+    // commits between the definition value and the parent op.
+    // TODO: We could measure commits in nested regions along the path if
+    // necessary.
+    while (anchor->getParentRegion() != val.getParentRegion())
+      anchor = anchor->getParentOp();
+    minCommits = std::min(minCommits, minOverHistories(val, anchor, 0));
+  }
   return minCommits;
 }
 

--- a/test/TritonGPU/amd/amd-block-pingpong-asyncmark-multi-token.mlir
+++ b/test/TritonGPU/amd/amd-block-pingpong-asyncmark-multi-token.mlir
@@ -2,10 +2,10 @@
 // RUN: triton-opt %s --tritonamdgpu-block-pingpong=num-stages=3 --tritonamdgpu-update-async-wait-count=gfx-arch=gfx950 | FileCheck %s
 
 // BlockPingpong's transformTwoClusterWithLocalLoadAndAll combines per-operand
-// ttg.async_waits into a single multi-token wait. The Pipeline pass's
-// updateWaits already set each input wait's `num` to the in-flight commit-
-// group count it can tolerate; the merged wait must preserve the *minimum*
-// of those counts so the pipeline isn't accidentally serialized.
+// ttg.async_waits into a single multi-token wait, then reorders async copies
+// and commits around it. After the reorder the pass re-runs updateWaits, so
+// the merged wait's `num` is derived via minNumInterleavedCommitOps against
+// the post-reorder IR (with multi-token support added in the same patch).
 //
 // On asyncmark targets (CDNA3/CDNA4) this `num` lowers straight to
 // rocdl.wait.asyncmark(N), and UpdateAsyncWaitCount is a no-op since PR #9883
@@ -21,9 +21,14 @@
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   // CHECK-LABEL: async_ns3_gemm_pingpong_multi_token
   // The two per-operand waits in the input carry num=2 and num=1; pingpong
-  // fuses them into a single multi-token wait that preserves min(2, 1) = 1.
+  // fuses them into a single multi-token wait whose num is recomputed against
+  // the post-reorder IR. In this synthetic test the tokens come from tt.func
+  // args (no prologue commit chain), so minNumInterleavedCommitOps bails to
+  // its conservative N=0; in a real kernel the chains terminate at prologue
+  // async_commit_groups and yield a tighter bound (e.g. 1 for a real
+  // gfx950 simple_persistent_matmul kernel).
   // CHECK: scf.for
-  // CHECK: ttg.async_wait %{{[^,]+}}, %{{[^,]+}} {num = 1 : i32}
+  // CHECK: ttg.async_wait %{{[^,]+}}, %{{[^,]+}} {num = 0 : i32}
   tt.func public @async_ns3_gemm_pingpong_multi_token(
       %arg0: i32,
       %arg1: tensor<256x32x!tt.ptr<bf16>, #blocked>,

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -9,6 +9,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -865,14 +866,14 @@ Pingponger::transformTwoClusterWithLocalLoadAndAll(OpBuilder &builder,
   auto newAsyncWaitOp = asyncWaitOps[0];
   if (asyncWaitOps.size() > 1) {
     SmallVector<Value> tokens;
-    int32_t minNum = std::numeric_limits<int32_t>::max();
     for (auto asyncWaitOp : asyncWaitOps) {
       for (auto token : asyncWaitOp.getAsyncToken()) {
         tokens.push_back(token);
       }
-      minNum = std::min<int32_t>(minNum, asyncWaitOp.getNum());
     }
-    newAsyncWaitOp = ttg::AsyncWaitOp::create(builder, loc, tokens, minNum);
+    // Seed `num` with the conservative 0; runOnOperation re-derives the
+    // tight value via updateWaits after the reorder below.
+    newAsyncWaitOp = ttg::AsyncWaitOp::create(builder, loc, tokens, /*num=*/0);
     for (auto asyncWaitOp : asyncWaitOps) {
       asyncWaitOp.getResult().replaceAllUsesWith(newAsyncWaitOp.getResult());
       asyncWaitOp->erase();
@@ -1267,12 +1268,19 @@ struct TritonAMDGPUBlockPingpongPass
 
   void runOnOperation() override {
     ModuleOp m = getOperation();
+    bool transformed = false;
     for (auto funcOp : m.getOps<tt::FuncOp>()) {
       funcOp.walk([&](scf::ForOp forOp) {
         Pingponger pingponger(forOp, ttg::lookupNumWarps(forOp), numStages);
         pingponger.getDotPingponged();
+        transformed = true;
       });
     }
+    // Pingpong reorders async copies/commits around the merged ttg.async_wait,
+    // invalidating any `num` Pipeline.cpp set earlier. Recompute against the
+    // post-reorder IR.
+    if (transformed)
+      mlir::triton::updateWaits(m);
   }
 };
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -871,8 +871,9 @@ Pingponger::transformTwoClusterWithLocalLoadAndAll(OpBuilder &builder,
         tokens.push_back(token);
       }
     }
-    // Seed `num` with the conservative 0; runOnOperation re-derives the
-    // tight value via updateWaits after the reorder below.
+    // Drop pre-calculated mark_num and conservatively set 0 before
+    // updateWaits (in runOnOperation) re-evaluates against the token chain
+    // post-reorder.
     newAsyncWaitOp = ttg::AsyncWaitOp::create(builder, loc, tokens, /*num=*/0);
     for (auto asyncWaitOp : asyncWaitOps) {
       asyncWaitOp.getResult().replaceAllUsesWith(newAsyncWaitOp.getResult());


### PR DESCRIPTION
The PR fixed the new flakiness that appear in CI recently, examples like below:

https://github.com/triton-lang/triton/actions/runs/25174291873/job/73802168761?pr=10183
https://github.com/triton-lang/triton/actions/runs/25142654367/job/73695694895?pr=10100

The previous PR https://github.com/triton-lang/triton/pull/10081 correctly identified the degenerative case with vmcnt(0) inserted.  However, the problem is that #10081 added updateWaits() to compute a tighter num value based on the pre-reorder IR, but then BlockPingpong reorders the code and changes the def-use distances, making that pre-computed num value unsafe.

IR Sample before:

```mlir
scf.for %iv = 0 to N step 1
    iter_args(..., %a_123 = %a_101,
                   %a_127 = %a_92, %b_128 = %b_100, ...) -> (...)
{
    %a_159 = ttg.async_copy_global_to_local ...   // this iter's a-copy
    %a_160 = ttg.async_commit_group %a_159
    %a_161 = ttg.local_load %a_121 token %a_123   // feeds the dot
    %b_166 = ttg.async_copy_global_to_local ...   // this iter's b-copy
    %b_167 = ttg.async_commit_group %b_166
    %b_168 = ttg.local_load %b_124 token %a_123
    %dot   = tt.dot %a_161, %b_168, %arg13
    %a_170 = ttg.async_wait %a_127, %b_128 {num = 2}   // <-- IN-LOOP WAIT, num=2
    scf.yield ..., %a_160, %b_167, ...
}
```

IR Sample aftger BlockPingpong (no updateWaits() fix)
```mlir
scf.for %iv = 0 to N step 1
    iter_args(..., %a_129 = %a_101,
                   %a_133 = %a_92, %b_134 = %b_100, ...) -> (...)
{
    %a_169 = ttg.local_load %a_127 token %a_129      // moved up: dot operand A
    %b_170 = ttg.local_load %b_130 token %a_129      // moved up: dot operand B
    %a_171 = ttg.async_copy_global_to_local ...      // a-copy moved BEFORE wait
    %a_172 = ttg.async_commit_group %a_171           // a-commit moved BEFORE wait
    %a_173 = ttg.async_wait %a_133, %b_134 {num = 2} // <-- SAME wait, SAME num=2 (STALE)
    %b_174 = ttg.async_copy_global_to_local ...      // b-copy moved AFTER wait
    %b_175 = ttg.async_commit_group %b_174           // b-commit moved AFTER wait
    %dot   = tt.dot %a_169, %b_170, %arg13
    scf.yield ..., %a_172, %b_175, ...
}
```

Since the %a_172 is now before the `async_wait`, it should drain every load before this iteration so the `tt.dot` can load and compute the right value. Keeping the `num = 2` will leave `%b_175` on flight from previous iteration and create a race condition. 

### Verification:

>   python -m pytest test/unit/language/test_matmul.py::test_simple_persistent_matmul --count=1000 -p no:cacheprovider --tb=line --no-header -q

This is guaranteed to run into failure at roughly 0.5% rate, now after this PR the flakiness is gone.

### Code change

- Reverted `transformTwoClusterWithLocalLoadAndAll` change from #10081 since the wait it computes is incorrect if (asyncWaitOps.size() > 1). Though realistically the combine always happen and this shouldn't hit.
- Added `updateWaits` if BlockPingPong pass transform the IR
- Fix `updateWaits` so it can correctly derive the num for multi-token wait