### PR TITLE
[TritonGPU] Enable epilogue peeling for warp-specialized loops

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -113,12 +113,10 @@ static void expandLoops(ModuleOp moduleOp) {
     // Testing feature: allow for unresolved predicate stage ops
     // in the loop body.
     bool keepPredicateStage = forOp->hasAttr("__test_keep_predicate_stage");
-    // TODO: Enable epilogue peeling for warp specialized loops
     // Heuristic: only peel epilogue for MMAv5 loops with waits in the last
     // stage
     bool customEpiloguePeeling =
         hasMMAv5WaitsInLastStage(forOp, schedule) &&
-        !forOp->getParentOfType<triton::gpu::WarpSpecializeOp>() &&
         !keepPredicateStage; // do not peel if we are testing the stage
                              // predication
 

--- a/python/test/unit/language/test_warp_specialization.py
+++ b/python/test/unit/language/test_warp_specialization.py
@@ -754,6 +754,65 @@ def group_gemm_tma_fn(group_A, group_B):
     return group_C
 
 
+@pytest.mark.skipif(is_hip(), reason="warp specialization is not supported on hip devices")
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell for epilogue peeling + MMAv5")
+@pytest.mark.parametrize("M, N, K", [
+    # Small K: only 1 loop iteration (epilogue peeling edge case)
+    (128, 128, 64),
+    (128, 256, 128),
+    # Small K: only 2 loop iterations
+    (128, 128, 128),
+    (128, 256, 256),
+    # Typical size
+    (2048, 2048, 512),
+])
+@pytest.mark.parametrize("BLOCK_SIZE_K", [64, 128])
+@pytest.mark.parametrize("num_stages", [2, 3])
+def test_warp_specialize_epilogue_peeling(M, N, K, BLOCK_SIZE_K, num_stages):
+    """Test warp-specialized matmul with epilogue peeling, especially small K edge cases.
+
+    When epilogue peeling is enabled for warp-specialized loops, the last iteration
+    is peeled out as an unpredicated epilogue. This test verifies correctness for
+    cases with very few loop iterations (K=1 or 2 BLOCK_K tiles), where peeling
+    creates an empty loop body with only the epilogue.
+    """
+    if K % BLOCK_SIZE_K != 0:
+        pytest.skip(f"K={K} not divisible by BLOCK_SIZE_K={BLOCK_SIZE_K}")
+    if exceeds_smem_capacity(num_stages, 128, 128, BLOCK_SIZE_K, use_fp8=False):
+        pytest.skip("uses too much shared memory")
+
+    GROUP_SIZE_M = 8
+    device = "cuda"
+    torch.manual_seed(42)
+    A = torch.randn((M, K), dtype=torch.float16, device=device)
+    B = torch.randn((N, K), dtype=torch.float16, device=device)
+    C = torch.empty((M, N), dtype=torch.float16, device=device)
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+
+    grid = (triton.cdiv(M, 128) * triton.cdiv(N, 128), )
+    kernel = matmul_tma_ws_kernel[grid](A, B, C, *A.stride(), *B.stride(), *C.stride(), M, N, K, num_stages, 128, 128,
+                                        BLOCK_SIZE_K, GROUP_SIZE_M, num_warps=4, USE_FP8=False, A_USE_TMA=True,
+                                        B_USE_TMA=True)
+
+    # Verify epilogue peeling produced the expected IR
+    ttgir = kernel.asm["ttgir"]
+    assert "ttg.warp_specialize" in ttgir
+    k_tiles = K // BLOCK_SIZE_K
+    if k_tiles >= 1 and num_stages > 1:
+        # With epilogue peeling, we should see 2 MMA ops (1 in loop + 1 in peeled epilogue)
+        # when there are enough iterations; for 1 iteration, the loop may be empty
+        assert "ttng.tc_gen5_mma" in ttgir
+
+    # Verify correctness against cuBLAS
+    ref_out = torch.empty((M, N), dtype=torch.float16, device=device)
+    cublas.matmul(A, B, ref_out)
+    torch.testing.assert_close(ref_out, C, atol=0.03, rtol=0.03)
+
+
 @pytest.mark.parametrize("M", [128, 256, 512, 1024, 2048, 4096, 8192])
 @pytest.mark.parametrize("N", [256, 512, 1024, 2048, 4096, 8192])
 @pytest.mark.parametrize("K", [128, 512, 1024, 2048, 4096])

--- a/test/TritonGPU/automatic-warp-specialization.mlir
+++ b/test/TritonGPU/automatic-warp-specialization.mlir
@@ -1,6 +1,7 @@
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization=num-stages=2 | FileCheck %s --check-prefix=CHECK --check-prefix=BASE --check-prefix=CLEAN
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization=num-stages=2 -tritongpu-pipeline | FileCheck %s --check-prefix=CHECK --check-prefix=PIPELINE --check-prefix=CLEAN
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization=num-stages=2 -tritongpu-pipeline -tritongpu-optimize-partition-warps | FileCheck %s --check-prefix=OPT --check-prefix=CLEAN
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-hoist-tmem-alloc -tritongpu-assign-latencies -tritongpu-schedule-loops -tritongpu-automatic-warp-specialization=num-stages=4 -tritongpu-pipeline | FileCheck %s --check-prefix=PEELING
 
 // CLEAN: module
 // CLEAN-NOT: ttg.partition
@@ -391,4 +392,49 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     } {tt.warp_specialize}
     tt.return
   }
+}
+
+// -----
+
+// Test that epilogue peeling works for warp-specialized MMAv5 loops.
+// With num_stages=4, the pipelined loop will have wait barriers in the last
+// stage, triggering customEpiloguePeeling. The peeled iteration produces a
+// second tc_gen5_mma outside the loop (1 in loop + 1 in epilogue).
+#acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#oper_layout = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#acc_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// PEELING-LABEL: @matmul_ws_epilogue_peeling
+tt.func @matmul_ws_epilogue_peeling(
+  %a_desc: !tt.tensordesc<128x64xf16, #shared>,
+  %b_desc: !tt.tensordesc<64x128xf16, #shared>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %false = arith.constant false
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #acc_layout>
+  %k_tiles = arith.constant 32 : i32
+
+  // PEELING-LABEL: ttg.warp_specialize
+  // PEELING: partition0
+  // PEELING-COUNT-2: ttng.tc_gen5_mma
+  // PEELING-NOT: ttng.tc_gen5_mma
+  %loop_out:2 = scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero, %flag = %true) -> (tensor<128x128xf32, #acc_layout>, i1) : i32 {
+    %a = tt.descriptor_load %a_desc[%c0_i32, %k] : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #oper_layout>
+    %b = tt.descriptor_load %b_desc[%c0_i32, %k] : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #oper_layout>
+    %a_shared = ttg.local_alloc %a : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+    %b_shared = ttg.local_alloc %b : (tensor<64x128xf16, #oper_layout>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+    %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_tok = ttng.tc_gen5_mma %a_shared, %b_shared, %c_tmem[%c_tok], %flag, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+    %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>
+    scf.yield %c, %true : tensor<128x128xf32, #acc_layout>, i1
+  } {tt.warp_specialize, tt.num_stages = 4 : i32}
+
+  "use"(%loop_out#0) : (tensor<128x128xf32, #acc_layout>) -> ()
+  tt.return
+}
 }


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
### Summary
Remove the guard that blocked epilogue peeling for loops inside WarpSpecializeOp. Previously, pipelined MMAv5 loops could peel their last iteration into an unpredicated epilogue — but only if the loop was not warp-specialized. This PR extends that optimization to warp-specialized loops as well.

### Why it matters
When epilogue peeling is enabled, the last iteration is extracted outside the loop as a plain (unpredicated) epilogue, eliminating runtime predication overhead inside the loop body and producing cleaner pipelined IR. Warp-specialized MMAv5 kernels (e.g. block-scaled matmul on Blackwell) can now benefit from this optimization.

### Testing
Lit test — new test case @matmul_ws_epilogue_peeling in automatic-warp-specialization.mlir with num_stages=4, verifying PEELING-COUNT-2: ttng.tc_gen5_mma (1 in loop + 1 in peeled epilogue).
Pytest — new test_warp_specialize_epilogue_peeling in test_warp_specialization.py covering small-K edge cases (1-2 loop iterations) where peeling creates an empty loop body, with correctness checks against cuBLAS.


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
