### PR TITLE
[gsan] Fix uses of node->size that should be node->allocSize

### DIFF
--- a/python/test/gsan/test_allocator.py
+++ b/python/test/gsan/test_allocator.py
@@ -12,6 +12,10 @@ from triton.experimental.gsan._allocator import (export_allocation_handles, free
 from triton.experimental.gsan._testing_utils import shadow_tensor_for
 from triton.experimental.gsan._utils import uint8_cuda_tensor_from_ptr
 
+# With 2 MiB pages, this rounds to a 6 MiB allocation inside an 8 MiB tree node.
+# This tests cases where AllocNode.size != AllocNode.allocSize
+_ODD_LARGE_ALLOCATION_SIZE = 4 * 1024 * 1024 + 1
+
 
 @pytest.fixture
 def _direct_allocator():
@@ -99,6 +103,17 @@ def test_malloc_fragmentation_reuse_and_coalesce(_direct_allocator):
 
 
 @pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+def test_malloc_free_large_odd_size(_direct_allocator):
+    malloc, free, _, _ = _direct_allocator
+
+    ptr = malloc(_ODD_LARGE_ALLOCATION_SIZE)
+    assert ptr != 0
+
+    free(ptr)
+    torch.cuda.synchronize()
+
+
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
 def test_free_invalid_pointer_and_double_free(_direct_allocator):
     malloc, free, _, _ = _direct_allocator
 
@@ -151,11 +166,12 @@ def test_mem_pool():
 
 
 @pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
-def test_export_import_allocation_handles_maps_real_and_shadow(_direct_allocator):
+@pytest.mark.parametrize("size", [4096, _ODD_LARGE_ALLOCATION_SIZE])
+def test_export_import_allocation_handles_maps_real_and_shadow(_direct_allocator, size):
     malloc, free, reserve_ptr, reserve_size = _direct_allocator
     device = torch.cuda.current_device()
 
-    real_ptr = malloc(4096)
+    real_ptr = malloc(size)
     assert real_ptr != 0
 
     imported_ptr = 0

--- a/python/triton/experimental/gsan/src/GSanAllocator.cc
+++ b/python/triton/experimental/gsan/src/GSanAllocator.cc
@@ -459,16 +459,17 @@ error:
 
 CUresult mapNodeHandles(AllocNode *node,
                         CUmemGenericAllocationHandle realHandle,
-                        CUmemGenericAllocationHandle shadowHandle, int device,
-                        bool *realMapped, bool *shadowMapped) {
+                        CUmemGenericAllocationHandle shadowHandle,
+                        size_t allocSize, int device, bool *realMapped,
+                        bool *shadowMapped) {
   assert(node != nullptr);
   assert(realMapped != nullptr);
   assert(shadowMapped != nullptr);
 
   const auto shadowAddress = gsan::getShadowAddress(node->virtualAddress);
-  const auto shadowSize = getShadowSize(node->size);
+  const auto shadowSize = getShadowSize(allocSize);
 
-  CUresult err = cuMemMap(node->virtualAddress, node->size, /*offset*/ 0,
+  CUresult err = cuMemMap(node->virtualAddress, allocSize, /*offset*/ 0,
                           realHandle, /*flags*/ 0);
   if (err != CUDA_SUCCESS)
     return err;
@@ -485,21 +486,28 @@ CUresult mapNodeHandles(AllocNode *node,
   accessDesc.location.id = device;
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
 
-  err = cuMemSetAccess(node->virtualAddress, node->size, &accessDesc, 1);
+  err = cuMemSetAccess(node->virtualAddress, allocSize, &accessDesc, 1);
   if (err != CUDA_SUCCESS)
     return err;
 
-  return cuMemSetAccess(shadowAddress, shadowSize, &accessDesc, 1);
+  err = cuMemSetAccess(shadowAddress, shadowSize, &accessDesc, 1);
+  if (err != CUDA_SUCCESS)
+    return err;
+
+  node->allocSize = allocSize;
+  node->realHandle = realHandle;
+  node->shadowHandle = shadowHandle;
+  return CUDA_SUCCESS;
 }
 
 void unmapNodeHandles(AllocNode *node, bool realMapped, bool shadowMapped) {
   assert(node != nullptr);
   const auto shadowAddress = gsan::getShadowAddress(node->virtualAddress);
-  const auto shadowSize = getShadowSize(node->size);
+  const auto shadowSize = getShadowSize(node->allocSize);
   if (shadowMapped)
     cuMemUnmap(shadowAddress, shadowSize);
   if (realMapped)
-    cuMemUnmap(node->virtualAddress, node->size);
+    cuMemUnmap(node->virtualAddress, node->allocSize);
 }
 
 } // namespace
@@ -550,7 +558,6 @@ extern "C" void *gsanMalloc(ssize_t size, int device,
   auto cuStream = reinterpret_cast<CUstream>(stream);
   auto shadowAddress = gsan::getShadowAddress(node->virtualAddress);
   auto shadowSize = getShadowSize(allocSize);
-
   err = cuMemCreate(&realHandle, allocSize, &prop, 0);
   if (err != CUDA_SUCCESS)
     goto error;
@@ -559,8 +566,8 @@ extern "C" void *gsanMalloc(ssize_t size, int device,
   if (err != CUDA_SUCCESS)
     goto error;
 
-  err = mapNodeHandles(node, realHandle, shadowHandle, device, &realMapped,
-                       &shadowMapped);
+  err = mapNodeHandles(node, realHandle, shadowHandle, allocSize, device,
+                       &realMapped, &shadowMapped);
   if (err != CUDA_SUCCESS)
     goto error;
 
@@ -569,9 +576,6 @@ extern "C" void *gsanMalloc(ssize_t size, int device,
   if (err != CUDA_SUCCESS)
     goto error;
 
-  node->allocSize = allocSize;
-  node->realHandle = realHandle;
-  node->shadowHandle = shadowHandle;
   LOGF("gsanMalloc: %p, 0x%zxu", reinterpret_cast<void *>(node->virtualAddress),
        size);
   return reinterpret_cast<void *>(node->virtualAddress);
@@ -686,7 +690,7 @@ int gsanExportAllocationHandles(void *void_ptr, int *realFd, int *shadowFd,
 
   *realFd = realFdLocal;
   *shadowFd = shadowFdLocal;
-  *allocSize = node->size;
+  *allocSize = node->allocSize;
   return 0;
 }
 
@@ -754,12 +758,6 @@ void *gsanImportAllocationHandles(int realFd, int shadowFd, size_t allocSize,
   if (node == nullptr)
     return nullptr;
 
-  if (node->size != allocSize) {
-    freeNode(node);
-    fprintf(stderr, "gsanImportAllocationHandles requires power-of-two size\n");
-    return nullptr;
-  }
-
   CUmemGenericAllocationHandle realHandle = 0;
   CUmemGenericAllocationHandle shadowHandle = 0;
   bool realMapped = false;
@@ -776,14 +774,11 @@ void *gsanImportAllocationHandles(int realFd, int shadowFd, size_t allocSize,
   if (err != CUDA_SUCCESS)
     goto error;
 
-  err = mapNodeHandles(node, realHandle, shadowHandle, device, &realMapped,
-                       &shadowMapped);
+  err = mapNodeHandles(node, realHandle, shadowHandle, allocSize, device,
+                       &realMapped, &shadowMapped);
   if (err != CUDA_SUCCESS)
     goto error;
 
-  node->allocSize = allocSize;
-  node->realHandle = realHandle;
-  node->shadowHandle = shadowHandle;
   return reinterpret_cast<void *>(node->virtualAddress);
 
 error:


### PR DESCRIPTION
<git-pr-chain>


[gsan] Fix uses of node->size that should be node->allocSize

When writing the allocator I initially had only `node->size` which is
always a power of 2, but decided that rounding every allocation up to
a power of 2 might be too pessimistic. Looks like I missed a few
cases that should have been changed.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #10197 👈 **YOU ARE HERE**


</git-pr-chain>
