### PR TITLE
[Proton] Normalize roofline metric dtypes

### DIFF
--- a/third_party/proton/proton/hooks/launch.py
+++ b/third_party/proton/proton/hooks/launch.py
@@ -16,10 +16,6 @@ enabled = ContextVar("enabled", default=False)
 class LaunchHook(Hook):
     # Highest priority
     priority = 100
-    flops_width = [8, 16, 32, 64]
-    # Historical/derived metrics (e.g., used by viewer utilization computations).
-    # Launch metadata can carry *additional* metrics; see _extract_metrics().
-    metrics = [f"flops{width}" for width in flops_width] + ["bytes"] + ["flops"]
 
     # Reserved keys that Triton’s runtime always attaches to launch_metadata.
     # We never treat these as metrics.

--- a/third_party/proton/proton/metric.py
+++ b/third_party/proton/proton/metric.py
@@ -91,30 +91,68 @@ class _TensorMetric(libproton.TensorMetric):
         self._value = value
 
 
+FLOPS_WIDTHS = (8, 16, 32, 64)
+FLOPS_DTYPES = {
+    **{"flops": (float, libproton.metric_type_double_index, libproton.metric_type_vector_double_index)},
+    **{
+        f"flops{width}": (float, libproton.metric_type_double_index, libproton.metric_type_vector_double_index)
+        for width in FLOPS_WIDTHS
+    },
+}
+ROOFLINE_DTYPES = {
+    **FLOPS_DTYPES,
+    "bytes": (int, libproton.metric_type_int64_index, libproton.metric_type_vector_int64_index),
+}
+
+
+def _scalar_or_vector_value(value: Any, convert: type) -> Any:
+    if hasattr(value, "data_ptr"):
+        value = value.tolist() if value.numel() > 1 else value.item()
+    if isinstance(value, (list, tuple)):
+        return [convert(v) for v in value]
+    return convert(value)
+
+
+def _scalar_metric_value(key: str, value: Any) -> Any:
+    # Proton's built-in roofline metrics should have stable dtypes regardless of
+    # whether launch_metadata produced a Python scalar or a device tensor.
+    if key in ROOFLINE_DTYPES:
+        convert, _, _ = ROOFLINE_DTYPES[key]
+        return _scalar_or_vector_value(value, convert)
+    return value
+
+
+def _tensor_metric_value_and_index(key: str, value: Any) -> tuple[Any, int]:
+    if key in ROOFLINE_DTYPES:
+        _, scalar_index, vector_index = ROOFLINE_DTYPES[key]
+        value = value.long() if key == "bytes" else value.double()
+        return value, vector_index if value.numel() > 1 else scalar_index
+
+    # implicit casting to double or int64 tensors
+    if value.is_floating_point():
+        value = value.double()
+        if value.numel() > 1:
+            return value, libproton.metric_type_vector_double_index
+        return value, libproton.metric_type_double_index
+
+    value = value.long()
+    if value.numel() > 1:
+        return value, libproton.metric_type_vector_int64_index
+    return value, libproton.metric_type_int64_index
+
+
 def transform_tensor_metrics(metrics: dict[str, Any]) -> tuple[dict[str, Any], dict[str, libproton.TensorMetric]]:
     tensor_metrics = {}
     scalar_metrics: dict[str, Any] = {}
     for key, value in metrics.items():
         if hasattr(value, "data_ptr"):  # tensor
             if value.device.type == "cpu":
-                scalar_metrics[key] = value
+                scalar_metrics[key] = _scalar_metric_value(key, value)
             else:  # device tensor
                 enter_state(COMPUTE_METADATA_SCOPE_NAME)
-                # implicit casting to double or int64 tensors
-                if value.is_floating_point():
-                    value = value.double()
-                    if value.numel() > 1:
-                        metric_index = libproton.metric_type_vector_double_index
-                    else:
-                        metric_index = libproton.metric_type_double_index
-                else:
-                    value = value.long()
-                    if value.numel() > 1:
-                        metric_index = libproton.metric_type_vector_int64_index
-                    else:
-                        metric_index = libproton.metric_type_int64_index
+                value, metric_index = _tensor_metric_value_and_index(key, value)
                 exit_state()
                 tensor_metrics[key] = _TensorMetric(value, metric_index)
         else:
-            scalar_metrics[key] = value
+            scalar_metrics[key] = _scalar_metric_value(key, value)
     return scalar_metrics, tensor_metrics

--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -10,7 +10,7 @@ except ImportError:
     raise ImportError("Failed to import hatchet. `pip install llnl-hatchet` to get the correct version.")
 import numpy as np
 from triton.profiler.state import COMPUTE_METADATA_SCOPE_NAME
-from triton.profiler.hooks.launch import LaunchHook
+from triton.profiler.metric import FLOPS_WIDTHS
 from triton.profiler import specs
 
 
@@ -80,7 +80,7 @@ def get_min_time_flops(df, device_info):
             arch = device_info[device_type][device_index]["arch"]
             num_sms = device_info[device_type][device_index]["num_sms"]
             clock_rate = device_info[device_type][device_index]["clock_rate"]
-            for width in LaunchHook.flops_width:
+            for width in FLOPS_WIDTHS:
                 idx = df["device_id"] == device_index
                 device_frames = df[idx]
                 if f"flops{width}" not in device_frames.columns:
@@ -124,7 +124,7 @@ default_flop_factor_dict = {"flop/s": 1, "gflop/s": 1e9, "tflop/s": 1e12}
 derivable_metrics.update(
     {key: FactorDict("flops", default_flop_factor_dict)
      for key in default_flop_factor_dict.keys()})
-for width in LaunchHook.flops_width:
+for width in FLOPS_WIDTHS:
     factor_name = f"flops{width}"
     factor_dict = {f"flop{width}/s": 1, f"gflop{width}/s": 1e9, f"tflop{width}/s": 1e12}
     derivable_metrics.update({key: FactorDict(factor_name, factor_dict) for key in factor_dict.keys()})

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -6,11 +6,13 @@ Profile correctness tests involving GPU kernels should be placed in `test_profil
 
 import pytest
 import json
+import torch
 import triton.profiler as proton
 import pathlib
 from triton.profiler.hooks.hook import HookManager
 from triton.profiler.hooks.launch import LaunchHook
 from triton.profiler.hooks.instrumentation import InstrumentationHook
+from triton.profiler.metric import transform_tensor_metrics
 from triton._internal_testing import is_hip
 
 
@@ -37,6 +39,33 @@ def test_profile_single_session(tmp_path: pathlib.Path):
     assert session_id2 == session_id1 + 1
     assert pathlib.Path("test.hatchet").exists()
     pathlib.Path("test.hatchet").unlink()
+
+
+def test_roofline_scalar_metric_types():
+    scalar_metrics, tensor_metrics = transform_tensor_metrics({
+        "flops": 1,
+        "flops16": 2,
+        "flops32": [5, 6],
+        "flops64": torch.tensor([7, 8], dtype=torch.int64),
+        "bytes": 3.0,
+        "custom": 4,
+    })
+
+    assert tensor_metrics == {}
+    assert scalar_metrics["flops"] == 1.0
+    assert type(scalar_metrics["flops"]) is float
+    assert scalar_metrics["flops16"] == 2.0
+    assert type(scalar_metrics["flops16"]) is float
+    assert scalar_metrics["flops32"] == [5.0, 6.0]
+    assert scalar_metrics["flops64"] == [7.0, 8.0]
+    assert scalar_metrics["bytes"] == 3
+    assert type(scalar_metrics["bytes"]) is int
+    assert scalar_metrics["custom"] == 4
+    assert type(scalar_metrics["custom"]) is int
+
+    scalar_metrics, tensor_metrics = transform_tensor_metrics({"bytes": torch.tensor([9.0, 10.0])})
+    assert tensor_metrics == {}
+    assert scalar_metrics["bytes"] == [9, 10]
 
 
 def test_profile_multiple_sessions(tmp_path: pathlib.Path):


### PR DESCRIPTION
## Summary

Proton currently preserves the Python scalar type returned by `launch_metadata`, while device tensor metrics are normalized to either double or int64 in `transform_tensor_metrics()`. That means the same built-in roofline metric can be registered with different types depending on which producer runs first.

For example, `flops16` can first be registered from a Python int scalar, then later recorded by a device tensor metadata path as double, which raises:

```text
MetricBuffer: type mismatch for metric flops16: current=int64_t, new=double
```

This PR makes Proton normalize built-in roofline metric names at the Python metric conversion boundary:

- `flops`, `flops8`, `flops16`, ... -> double / vector double
- `bytes` -> int64 / vector int64
- all other metrics keep the existing behavior

This keeps individual launch metadata producers from needing local casts just to satisfy Proton's metric registry.

The separate CUDA graph metric-ownership fix is in #10203.

## Testing

- `pre-commit run ruff --files third_party/proton/proton/metric.py third_party/proton/test/test_api.py`
- `pre-commit run yapf --files third_party/proton/proton/metric.py third_party/proton/test/test_api.py`
- `python3 -m py_compile third_party/proton/proton/metric.py third_party/proton/test/test_api.py`
