### PR TITLE
[Proton] Attach CUDA graph metric records by ordinal

### DIFF
--- a/third_party/proton/csrc/include/Data/Metric.h
+++ b/third_party/proton/csrc/include/Data/Metric.h
@@ -5,6 +5,7 @@
 #include "Utility/String.h"
 #include "Utility/Traits.h"
 #include <atomic>
+#include <functional>
 #include <map>
 #include <mutex>
 #include <set>
@@ -440,7 +441,9 @@ public:
   void receive(const std::map<std::string, TensorMetric> &tensorMetrics,
                const std::map<std::string, MetricValueType> &scalarMetrics,
                const MetricKernelLaunchState &metricKernelLaunchState,
-               const std::vector<uint64_t> &metricOrdinals);
+               const std::vector<uint64_t> &metricOrdinals,
+               const std::function<void(uint64_t, size_t)> &beforeLaunch,
+               const std::function<void()> &afterLaunch);
 
   void reserve() { getOrCreateBuffer(); }
 
@@ -452,7 +455,7 @@ public:
     auto it = deviceBuffers.find(device);
     if (it != deviceBuffers.end()) {
       auto &buffer = it->second;
-      callback(buffer.hostPtr);
+      callback(buffer.hostPtr, *buffer.hostOffset);
     }
   }
 
@@ -468,7 +471,7 @@ public:
     }
     for (auto &[device, buffer] : buffersToFlush) {
       synchronize(buffer);
-      callback(device, buffer.hostPtr);
+      callback(device, buffer.hostPtr, *buffer.hostOffset);
     }
   }
 
@@ -534,7 +537,9 @@ private:
   void queueMetrics(const MetricsT &metrics, void *stream,
                     const MetricKernelLaunchConfig &launchConfig,
                     const std::vector<uint64_t> &metricOrdinals,
-                    size_t &ordinalIndex) {
+                    size_t &ordinalIndex,
+                    const std::function<void(uint64_t, size_t)> &beforeLaunch,
+                    const std::function<void()> &afterLaunch) {
     for (const auto &[name, metric] : metrics) {
       size_t typeIndex = getMetricTypeIndex(metric);
       size_t size = getMetricSize(metric);
@@ -543,8 +548,16 @@ private:
         throw std::runtime_error(
             "[PROTON] MetricBuffer: missing metric ordinal");
       }
-      queue(metricOrdinals[ordinalIndex++], descriptor.id, metric, stream,
-            launchConfig);
+      auto metricOrdinal = metricOrdinals[ordinalIndex++];
+      beforeLaunch(metricOrdinal, /*metric_ordinal=*/1 + /*metric_id=*/1 +
+                                      /*metric_values=*/size);
+      try {
+        queue(metricOrdinal, descriptor.id, metric, stream, launchConfig);
+      } catch (...) {
+        afterLaunch();
+        throw;
+      }
+      afterLaunch();
     }
   }
 

--- a/third_party/proton/csrc/include/Data/Metric.h
+++ b/third_party/proton/csrc/include/Data/Metric.h
@@ -414,7 +414,9 @@ collectTensorMetrics(Runtime *runtime,
 ///
 ///  host ->                             -------- kernel0 --------
 ///                                     /                         \
-/// [device0] -> metric buffer -> {metric_id, value, metric_id, value, ...}
+/// [device0] -> metric buffer ->
+///     {metric_ordinal, metric_id, value, metric_ordinal, metric_id, value,
+///     ...}
 ///                   |                            /|\
 ///                   |                             |
 ///                   | deviceOffsetPtr -------------
@@ -437,7 +439,8 @@ public:
 
   void receive(const std::map<std::string, TensorMetric> &tensorMetrics,
                const std::map<std::string, MetricValueType> &scalarMetrics,
-               const MetricKernelLaunchState &metricKernelLaunchState);
+               const MetricKernelLaunchState &metricKernelLaunchState,
+               const std::vector<uint64_t> &metricOrdinals);
 
   void reserve() { getOrCreateBuffer(); }
 
@@ -492,10 +495,11 @@ private:
 
   DeviceBuffer &getOrCreateBuffer();
 
-  void queue(size_t metricId, TensorMetric tensorMetric, void *stream,
-             const MetricKernelLaunchConfig &launchConfig);
+  void queue(uint64_t metricOrdinal, size_t metricId, TensorMetric tensorMetric,
+             void *stream, const MetricKernelLaunchConfig &launchConfig);
 
-  void queue(size_t metricId, MetricValueType scalarMetric, void *stream,
+  void queue(uint64_t metricOrdinal, size_t metricId,
+             MetricValueType scalarMetric, void *stream,
              const MetricKernelLaunchConfig &launchConfig);
 
   void synchronize(DeviceBuffer &buffer);
@@ -528,12 +532,19 @@ private:
 
   template <typename MetricsT>
   void queueMetrics(const MetricsT &metrics, void *stream,
-                    const MetricKernelLaunchConfig &launchConfig) {
+                    const MetricKernelLaunchConfig &launchConfig,
+                    const std::vector<uint64_t> &metricOrdinals,
+                    size_t &ordinalIndex) {
     for (const auto &[name, metric] : metrics) {
       size_t typeIndex = getMetricTypeIndex(metric);
       size_t size = getMetricSize(metric);
       auto descriptor = getOrCreateMetricDescriptor(name, typeIndex, size);
-      queue(descriptor.id, metric, stream, launchConfig);
+      if (ordinalIndex >= metricOrdinals.size()) {
+        throw std::runtime_error(
+            "[PROTON] MetricBuffer: missing metric ordinal");
+      }
+      queue(metricOrdinals[ordinalIndex++], descriptor.id, metric, stream,
+            launchConfig);
     }
   }
 

--- a/third_party/proton/csrc/include/Profiler/GPUProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/GPUProfiler.h
@@ -123,6 +123,8 @@ protected:
     bool isStreamCapturing{false};
     bool isMetricKernelLaunching{false};
     std::deque<size_t> metricKernelNumWordsQueue;
+    std::deque<uint64_t> metricKernelOrdinalQueue;
+    uint64_t nextMetricKernelOrdinal{};
 
     ThreadState(ConcreteProfilerT &profiler) : profiler(profiler) {}
 
@@ -231,18 +233,29 @@ protected:
                  const std::map<std::string, TensorMetric> &tensorMetrics) {
       if (threadState.isStreamCapturing) { // Graph capture mode
         threadState.isMetricKernelLaunching = true;
+        std::vector<uint64_t> metricOrdinals;
+        metricOrdinals.reserve(tensorMetrics.size() + scalarMetrics.size());
+        // The CUDA graph resource callback records the same ordinal that the
+        // metric-copy kernel writes into the metric buffer. Replay can append
+        // records out of graph-node order, so host-side decode matches by this
+        // ordinal instead of by buffer position.
+        auto queueMetricKernel = [&](size_t metricValueWords) {
+          threadState.metricKernelNumWordsQueue.push_back(
+              /*ordinal=*/1 + /*metric_id=*/1 + metricValueWords);
+          auto metricOrdinal = threadState.nextMetricKernelOrdinal++;
+          threadState.metricKernelOrdinalQueue.push_back(metricOrdinal);
+          metricOrdinals.push_back(metricOrdinal);
+        };
         for (const auto &[_, metric] : tensorMetrics) {
-          threadState.metricKernelNumWordsQueue.push_back(
-              /*metric_id=*/1 + metric.size); // metric_id + num_values
+          queueMetricKernel(metric.size);
         }
-        for (const auto &[_, metric] : scalarMetrics) {
-          threadState.metricKernelNumWordsQueue.push_back(
-              /*metric_id=*/1 + 1); // scalar metric has 1 value
+        for (size_t i = 0; i < scalarMetrics.size(); ++i) {
+          queueMetricKernel(/*metricValueWords=*/1);
         }
         // Launch metric kernels
         auto &metricKernelLaunchState = profiler.metricKernelLaunchState;
         profiler.metricBuffer->receive(tensorMetrics, scalarMetrics,
-                                       metricKernelLaunchState);
+                                       metricKernelLaunchState, metricOrdinals);
         threadState.isMetricKernelLaunching = false;
       } else { // Eager mode, directly copy
         // Populate tensor metrics

--- a/third_party/proton/csrc/include/Profiler/GPUProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/GPUProfiler.h
@@ -232,31 +232,37 @@ protected:
                  const std::map<std::string, MetricValueType> &scalarMetrics,
                  const std::map<std::string, TensorMetric> &tensorMetrics) {
       if (threadState.isStreamCapturing) { // Graph capture mode
-        threadState.isMetricKernelLaunching = true;
         std::vector<uint64_t> metricOrdinals;
         metricOrdinals.reserve(tensorMetrics.size() + scalarMetrics.size());
         // The CUDA graph resource callback records the same ordinal that the
         // metric-copy kernel writes into the metric buffer. Replay can append
         // records out of graph-node order, so host-side decode matches by this
         // ordinal instead of by buffer position.
-        auto queueMetricKernel = [&](size_t metricValueWords) {
-          threadState.metricKernelNumWordsQueue.push_back(
-              /*ordinal=*/1 + /*metric_id=*/1 + metricValueWords);
+        auto reserveMetricOrdinal = [&]() {
           auto metricOrdinal = threadState.nextMetricKernelOrdinal++;
-          threadState.metricKernelOrdinalQueue.push_back(metricOrdinal);
           metricOrdinals.push_back(metricOrdinal);
         };
         for (const auto &[_, metric] : tensorMetrics) {
-          queueMetricKernel(metric.size);
+          reserveMetricOrdinal();
         }
         for (size_t i = 0; i < scalarMetrics.size(); ++i) {
-          queueMetricKernel(/*metricValueWords=*/1);
+          reserveMetricOrdinal();
         }
         // Launch metric kernels
         auto &metricKernelLaunchState = profiler.metricKernelLaunchState;
+        // Keep the metric-node marker scoped to Proton's metric-copy launch.
+        // Metadata hooks may launch helper kernels during graph capture, and CUPTI
+        // can report those graph-node callbacks while add_metrics is preparing or
+        // queueing metric descriptors.
+        auto beforeLaunch = [&](uint64_t metricOrdinal, size_t numWords) {
+          threadState.metricKernelNumWordsQueue.push_back(numWords);
+          threadState.metricKernelOrdinalQueue.push_back(metricOrdinal);
+          threadState.isMetricKernelLaunching = true;
+        };
+        auto afterLaunch = [&]() { threadState.isMetricKernelLaunching = false; };
         profiler.metricBuffer->receive(tensorMetrics, scalarMetrics,
-                                       metricKernelLaunchState, metricOrdinals);
-        threadState.isMetricKernelLaunching = false;
+                                       metricKernelLaunchState, metricOrdinals,
+                                       beforeLaunch, afterLaunch);
       } else { // Eager mode, directly copy
         // Populate tensor metrics
         auto tensorMetricsHost = collectTensorMetrics(

--- a/third_party/proton/csrc/include/Profiler/GPUProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/GPUProfiler.h
@@ -124,8 +124,6 @@ protected:
     bool isMetricKernelLaunching{false};
     std::deque<size_t> metricKernelNumWordsQueue;
     std::deque<uint64_t> metricKernelOrdinalQueue;
-    uint64_t nextMetricKernelOrdinal{};
-
     ThreadState(ConcreteProfilerT &profiler) : profiler(profiler) {}
 
     void enterOp(const Scope &scope) {
@@ -210,6 +208,7 @@ protected:
 
   std::unique_ptr<MetricBuffer> metricBuffer;
   std::unique_ptr<PendingGraphPool> pendingGraphPool;
+  std::atomic<uint64_t> nextMetricKernelOrdinal{0};
 
   Correlation correlation;
 
@@ -239,7 +238,8 @@ protected:
         // records out of graph-node order, so host-side decode matches by this
         // ordinal instead of by buffer position.
         auto reserveMetricOrdinal = [&]() {
-          auto metricOrdinal = threadState.nextMetricKernelOrdinal++;
+          auto metricOrdinal = profiler.nextMetricKernelOrdinal.fetch_add(
+              1, std::memory_order_relaxed);
           metricOrdinals.push_back(metricOrdinal);
         };
         for (const auto &[_, metric] : tensorMetrics) {
@@ -251,15 +251,17 @@ protected:
         // Launch metric kernels
         auto &metricKernelLaunchState = profiler.metricKernelLaunchState;
         // Keep the metric-node marker scoped to Proton's metric-copy launch.
-        // Metadata hooks may launch helper kernels during graph capture, and CUPTI
-        // can report those graph-node callbacks while add_metrics is preparing or
-        // queueing metric descriptors.
+        // Metadata hooks may launch helper kernels during graph capture, and
+        // CUPTI can report those graph-node callbacks while add_metrics is
+        // preparing or queueing metric descriptors.
         auto beforeLaunch = [&](uint64_t metricOrdinal, size_t numWords) {
           threadState.metricKernelNumWordsQueue.push_back(numWords);
           threadState.metricKernelOrdinalQueue.push_back(metricOrdinal);
           threadState.isMetricKernelLaunching = true;
         };
-        auto afterLaunch = [&]() { threadState.isMetricKernelLaunching = false; };
+        auto afterLaunch = [&]() {
+          threadState.isMetricKernelLaunching = false;
+        };
         profiler.metricBuffer->receive(tensorMetrics, scalarMetrics,
                                        metricKernelLaunchState, metricOrdinals,
                                        beforeLaunch, afterLaunch);

--- a/third_party/proton/csrc/include/Profiler/Graph.h
+++ b/third_party/proton/csrc/include/Profiler/Graph.h
@@ -4,8 +4,10 @@
 #include "Context/Context.h"
 #include "Data/Data.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -14,7 +16,6 @@
 #include <shared_mutex>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 namespace proton {
 
@@ -71,8 +72,12 @@ struct GraphState {
   // Mapping from node id to node state, has to be ordered based on node id
   // which is the order of node creation.
   NodeIdToStateMap nodeIdToState;
-  // Metric nodes and their per-node metric words, ordered by node id.
-  std::map<uint64_t, size_t> metricNodeIdToNumWords;
+  struct MetricNodeInfo {
+    size_t numWords{};
+    uint64_t ordinal{};
+  };
+  // Metric nodes and their replay metadata, ordered by node id.
+  std::map<uint64_t, MetricNodeInfo> metricNodeIdToInfo;
   // If the graph is launched after profiling started,
   // we need to throw an error and this error is only thrown once
   bool captureStatusChecked{};
@@ -81,35 +86,35 @@ struct GraphState {
 };
 
 struct PendingGraphQueue {
-  struct PendingGraph {
-    size_t numNodes;
-    size_t numWords;
-    // Metric target entries grouped per Data sink and aligned with
-    // graph metric-node order.
-    std::map<Data *, std::vector<DataEntry>> dataToEntries;
-  };
-
-  std::vector<PendingGraph> pendingGraphs;
+  // Metric target entries keyed by the ordinal written by each metric-copy
+  // kernel. The deque handles repeated launches of the same captured graph.
+  std::map<uint64_t, std::deque<std::map<Data *, DataEntry>>>
+      ordinalToEntryQueues;
   // The start buffer offset in the metric buffer for this queue
   size_t startBufferOffset{};
-  // Total number of metric nodes in the pending graphs
-  size_t numNodes{};
   // Total number of uint64 words written by all nodes in this queue
   size_t numWords{};
-  // Device where the pending graphs are recorded
-  void *device{};
-  // Phase
-  size_t phase{};
 
-  explicit PendingGraphQueue(size_t startBufferOffset, size_t phase,
-                             void *device)
-      : startBufferOffset(startBufferOffset), phase(phase), device(device) {}
+  explicit PendingGraphQueue(size_t startBufferOffset)
+      : startBufferOffset(startBufferOffset) {}
 
-  void push(size_t numNodes, size_t numWords,
-            const std::map<Data *, std::vector<DataEntry>> &dataToEntries) {
-    pendingGraphs.emplace_back(PendingGraph{numNodes, numWords, dataToEntries});
-    this->numNodes += numNodes;
+  void push(
+      size_t numWords,
+      const std::map<uint64_t, std::map<Data *, DataEntry>> &ordinalToEntries) {
+    for (const auto &[ordinal, entries] : ordinalToEntries) {
+      ordinalToEntryQueues[ordinal].push_back(entries);
+    }
     this->numWords += numWords;
+  }
+
+  void append(const PendingGraphQueue &other) {
+    startBufferOffset = std::min(startBufferOffset, other.startBufferOffset);
+    for (const auto &[ordinal, entryQueue] : other.ordinalToEntryQueues) {
+      auto &targetQueue = ordinalToEntryQueues[ordinal];
+      targetQueue.insert(targetQueue.end(), entryQueue.begin(),
+                         entryQueue.end());
+    }
+    numWords += other.numWords;
   }
 };
 
@@ -118,9 +123,10 @@ public:
   explicit PendingGraphPool(MetricBuffer *metricBuffer)
       : metricBuffer(metricBuffer), runtime(metricBuffer->getRuntime()) {}
 
-  void push(size_t phase,
-            const std::map<Data *, std::vector<DataEntry>> &dataToEntries,
-            size_t numNodes, size_t numWords);
+  void
+  push(size_t phase,
+       const std::map<uint64_t, std::map<Data *, DataEntry>> &ordinalToEntries,
+       size_t numWords);
 
   // No GPU synchronization, No CPU locks
   void peek(size_t phase);

--- a/third_party/proton/csrc/include/Profiler/Graph.h
+++ b/third_party/proton/csrc/include/Profiler/Graph.h
@@ -4,7 +4,6 @@
 #include "Context/Context.h"
 #include "Data/Data.h"
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -105,16 +104,6 @@ struct PendingGraphQueue {
       ordinalToEntryQueues[ordinal].push_back(entries);
     }
     this->numWords += numWords;
-  }
-
-  void append(const PendingGraphQueue &other) {
-    startBufferOffset = std::min(startBufferOffset, other.startBufferOffset);
-    for (const auto &[ordinal, entryQueue] : other.ordinalToEntryQueues) {
-      auto &targetQueue = ordinalToEntryQueues[ordinal];
-      targetQueue.insert(targetQueue.end(), entryQueue.begin(),
-                         entryQueue.end());
-    }
-    numWords += other.numWords;
   }
 };
 

--- a/third_party/proton/csrc/lib/Data/Metric.cpp
+++ b/third_party/proton/csrc/lib/Data/Metric.cpp
@@ -31,7 +31,9 @@ void MetricBuffer::receive(
     const std::map<std::string, TensorMetric> &tensorMetrics,
     const std::map<std::string, MetricValueType> &scalarMetrics,
     const MetricKernelLaunchState &metricKernelLaunchState,
-    const std::vector<uint64_t> &metricOrdinals) {
+    const std::vector<uint64_t> &metricOrdinals,
+    const std::function<void(uint64_t, size_t)> &beforeLaunch,
+    const std::function<void()> &afterLaunch) {
   const size_t numMetrics = tensorMetrics.size() + scalarMetrics.size();
   if (metricOrdinals.size() != numMetrics) {
     throw std::runtime_error(
@@ -39,9 +41,11 @@ void MetricBuffer::receive(
   }
   size_t ordinalIndex = 0;
   queueMetrics(tensorMetrics, metricKernelLaunchState.stream,
-               metricKernelLaunchState.tensor, metricOrdinals, ordinalIndex);
+               metricKernelLaunchState.tensor, metricOrdinals, ordinalIndex,
+               beforeLaunch, afterLaunch);
   queueMetrics(scalarMetrics, metricKernelLaunchState.stream,
-               metricKernelLaunchState.scalar, metricOrdinals, ordinalIndex);
+               metricKernelLaunchState.scalar, metricOrdinals, ordinalIndex,
+               beforeLaunch, afterLaunch);
 }
 
 MetricBuffer::MetricDescriptor

--- a/third_party/proton/csrc/lib/Data/Metric.cpp
+++ b/third_party/proton/csrc/lib/Data/Metric.cpp
@@ -30,11 +30,18 @@ MetricBuffer::~MetricBuffer() {
 void MetricBuffer::receive(
     const std::map<std::string, TensorMetric> &tensorMetrics,
     const std::map<std::string, MetricValueType> &scalarMetrics,
-    const MetricKernelLaunchState &metricKernelLaunchState) {
+    const MetricKernelLaunchState &metricKernelLaunchState,
+    const std::vector<uint64_t> &metricOrdinals) {
+  const size_t numMetrics = tensorMetrics.size() + scalarMetrics.size();
+  if (metricOrdinals.size() != numMetrics) {
+    throw std::runtime_error(
+        "[PROTON] MetricBuffer: metric ordinal count mismatch");
+  }
+  size_t ordinalIndex = 0;
   queueMetrics(tensorMetrics, metricKernelLaunchState.stream,
-               metricKernelLaunchState.tensor);
+               metricKernelLaunchState.tensor, metricOrdinals, ordinalIndex);
   queueMetrics(scalarMetrics, metricKernelLaunchState.stream,
-               metricKernelLaunchState.scalar);
+               metricKernelLaunchState.scalar, metricOrdinals, ordinalIndex);
 }
 
 MetricBuffer::MetricDescriptor
@@ -132,8 +139,8 @@ collectTensorMetrics(Runtime *runtime,
   return tensorMetricsHost;
 }
 
-void MetricBuffer::queue(size_t metricId, TensorMetric tensorMetric,
-                         void *stream,
+void MetricBuffer::queue(uint64_t metricOrdinal, size_t metricId,
+                         TensorMetric tensorMetric, void *stream,
                          const MetricKernelLaunchConfig &launchConfig) {
   auto &buffer = getOrCreateBuffer();
   uint64_t numWords = capacity / sizeof(uint64_t);
@@ -143,6 +150,7 @@ void MetricBuffer::queue(size_t metricId, TensorMetric tensorMetric,
   void *kernelParams[] = {reinterpret_cast<void *>(&buffer.devicePtr),
                           reinterpret_cast<void *>(&buffer.deviceOffsetPtr),
                           reinterpret_cast<void *>(&numWords),
+                          reinterpret_cast<void *>(&metricOrdinal),
                           reinterpret_cast<void *>(&metricId),
                           reinterpret_cast<void *>(&tensorMetric.ptr),
                           reinterpret_cast<void *>(&metricValueSize),
@@ -154,8 +162,8 @@ void MetricBuffer::queue(size_t metricId, TensorMetric tensorMetric,
                         nullptr);
 }
 
-void MetricBuffer::queue(size_t metricId, MetricValueType scalarMetric,
-                         void *stream,
+void MetricBuffer::queue(uint64_t metricOrdinal, size_t metricId,
+                         MetricValueType scalarMetric, void *stream,
                          const MetricKernelLaunchConfig &launchConfig) {
   auto &buffer = getOrCreateBuffer();
   uint64_t numWords = capacity / sizeof(uint64_t);
@@ -182,6 +190,7 @@ void MetricBuffer::queue(size_t metricId, MetricValueType scalarMetric,
   void *kernelParams[] = {reinterpret_cast<void *>(&buffer.devicePtr),
                           reinterpret_cast<void *>(&buffer.deviceOffsetPtr),
                           reinterpret_cast<void *>(&numWords),
+                          reinterpret_cast<void *>(&metricOrdinal),
                           reinterpret_cast<void *>(&metricId),
                           reinterpret_cast<void *>(&metricBits),
                           reinterpret_cast<void *>(&globalScratchPtr),

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -208,15 +208,16 @@ void queueGraphMetrics(const DataToEntryMap &dataToEntry,
                        const CUpti_CallbackData *callbackData,
                        const GraphState &graphState,
                        CuptiProfiler::ExternIdState &externIdState) {
-  if (graphState.metricNodeIdToNumWords.empty()) {
+  if (graphState.metricNodeIdToInfo.empty()) {
     return;
   }
-  std::map<Data *, std::vector<DataEntry>> metricNodeEntries;
+  std::map<uint64_t, std::map<Data *, DataEntry>> metricNodeEntries;
   size_t phase = Data::kNoCompletePhase;
   for (const auto &[data, graphEntry] : externIdState.dataToGraphEntry) {
     phase = graphEntry.phase;
-    for (const auto &metricNode : graphState.metricNodeIdToNumWords) {
+    for (const auto &metricNode : graphState.metricNodeIdToInfo) {
       auto nodeId = metricNode.first;
+      auto metricOrdinal = metricNode.second.ordinal;
       auto nodeIter = graphState.nodeIdToState.find(nodeId);
       if (nodeIter ==
           graphState.nodeIdToState
@@ -225,25 +226,25 @@ void queueGraphMetrics(const DataToEntryMap &dataToEntry,
       auto &nodeState = nodeIter->second;
       auto entryIdIter = nodeState.dataToEntryId.find(data);
       if (entryIdIter != nodeState.dataToEntryId.end()) {
-        metricNodeEntries[data].emplace_back(
+        metricNodeEntries[metricOrdinal].insert_or_assign(
+            data,
             DataEntry(entryIdIter->second, phase, graphEntry.metricSet.get()));
       } else {
         // Indicate that we'll call upsertFlexibleMetric instead of
         // upsertLinkedFlexibleMetric in queueGraphMetrics, so that the kernel
         // metric can be attached to the graph launch entry when node entry is
         // not found.
-        metricNodeEntries[data].emplace_back(
+        metricNodeEntries[metricOrdinal].insert_or_assign(
+            data,
             DataEntry(Scope::DummyScopeId, phase, graphEntry.metricSet.get()));
       }
     }
   }
 
-  const auto numMetricNodes = graphState.metricNodeIdToNumWords.size();
   const auto numMetricWords = graphState.numMetricWords;
   if (callbackData->context != nullptr)
     pendingGraphPool->flushIfNeeded(numMetricWords);
-  pendingGraphPool->push(phase, metricNodeEntries, numMetricNodes,
-                         numMetricWords);
+  pendingGraphPool->push(phase, metricNodeEntries, numMetricWords);
 }
 
 constexpr std::array<CUpti_CallbackId, 11> kGraphCallbacks = {
@@ -479,18 +480,25 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphResourceCallbacks(
       const auto &name = threadState.scopeStack.back().name;
       if (name.empty())
         nodeState.status.setMissingName();
-      if (threadState.isMetricKernelLaunching) {
+      const bool isMetricKernelNode =
+          threadState.isMetricKernelLaunching &&
+          !threadState.metricKernelNumWordsQueue.empty() &&
+          !threadState.metricKernelOrdinalQueue.empty();
+      if (isMetricKernelNode) {
         nodeState.status.setMetricNode();
         auto metricKernelNumWords =
             threadState.metricKernelNumWordsQueue.front();
         threadState.metricKernelNumWordsQueue.pop_front();
-        graphState.metricNodeIdToNumWords.insert_or_assign(
-            nodeId, metricKernelNumWords);
+        auto metricKernelOrdinal = threadState.metricKernelOrdinalQueue.front();
+        threadState.metricKernelOrdinalQueue.pop_front();
+        graphState.metricNodeIdToInfo.insert_or_assign(
+            nodeId, GraphState::MetricNodeInfo{metricKernelNumWords,
+                                               metricKernelOrdinal});
         graphState.numMetricWords += metricKernelNumWords;
       }
       for (auto *data : profiler.dataSet) {
         auto contexts = data->getContexts();
-        if (threadState.isMetricKernelLaunching) {
+        if (isMetricKernelNode) {
           if (threadState.isApiExternOp) { // API extern ops
             contexts.push_back(std::string(GraphState::metricTag));
           } else { // Triton ops
@@ -523,13 +531,11 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphResourceCallbacks(
         graphState.dataToEntryIdToNodeStates[data][entryId].insert(&nodeState);
       }
       auto originalMetricNodeIt =
-          originalGraphState.metricNodeIdToNumWords.find(originalNodeId);
-      if (originalMetricNodeIt !=
-          originalGraphState.metricNodeIdToNumWords.end()) {
-        const auto numMetricWords = originalMetricNodeIt->second;
-        graphState.metricNodeIdToNumWords.insert_or_assign(nodeId,
-                                                           numMetricWords);
-        graphState.numMetricWords += numMetricWords;
+          originalGraphState.metricNodeIdToInfo.find(originalNodeId);
+      if (originalMetricNodeIt != originalGraphState.metricNodeIdToInfo.end()) {
+        const auto metricNodeInfo = originalMetricNodeIt->second;
+        graphState.metricNodeIdToInfo.insert_or_assign(nodeId, metricNodeInfo);
+        graphState.numMetricWords += metricNodeInfo.numWords;
       }
     }
   }

--- a/third_party/proton/csrc/lib/Profiler/Graph.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Graph.cpp
@@ -4,7 +4,9 @@
 #include "Runtime/Runtime.h"
 
 #include <cstring>
+#include <optional>
 #include <stdexcept>
+#include <vector>
 
 namespace proton {
 
@@ -15,100 +17,121 @@ constexpr size_t bytesForWords(size_t numWords) {
 
 void emitMetricRecords(MetricBuffer &metricBuffer, uint64_t *hostBasePtr,
                        const PendingGraphQueue &queue) {
-  const auto &pendingGraphs = queue.pendingGraphs;
   const size_t capacityWords = metricBuffer.getCapacity() / sizeof(uint64_t);
-  size_t wordOffset = queue.startBufferOffset / sizeof(uint64_t);
+  const uint64_t startWordOffset = queue.startBufferOffset / sizeof(uint64_t);
+  const uint64_t endWordOffset = startWordOffset + queue.numWords;
+  uint64_t wordOffset = startWordOffset;
   auto readWord = [&](size_t offset) -> uint64_t {
     return hostBasePtr[offset % capacityWords];
   };
 
-  for (const auto &pendingGraph : pendingGraphs) {
-    for (size_t i = 0; i < pendingGraph.numNodes; ++i) {
-      const uint64_t metricId = readWord(wordOffset);
-      wordOffset = (wordOffset + 1) % capacityWords;
+  auto ordinalToEntryQueue = queue.ordinalToEntryQueues;
+  // Metric records are scanned in GPU append order, which can differ from
+  // graph-node creation order. The ordinal in each record identifies the CPU
+  // target queued for that metric-copy kernel.
+  while (wordOffset < endWordOffset) {
+    const uint64_t metricOrdinal = readWord(wordOffset);
+    wordOffset += 1;
 
-      auto metricDesc = metricBuffer.getMetricDescriptor(metricId);
-      const auto &metricName = metricDesc.name;
-      const auto metricTypeIndex = metricDesc.typeIndex;
+    const uint64_t metricId = readWord(wordOffset);
+    wordOffset += 1;
 
-      MetricValueType metricValueVariant{};
-      switch (metricTypeIndex) {
-      case variant_index_v<uint64_t, MetricValueType>: {
-        const uint64_t bits = readWord(wordOffset);
-        uint64_t typedValue{};
-        std::memcpy(&typedValue, &bits, sizeof(typedValue));
-        metricValueVariant = typedValue;
-        break;
-      }
-      case variant_index_v<int64_t, MetricValueType>: {
-        const uint64_t bits = readWord(wordOffset);
-        int64_t typedValue{};
-        std::memcpy(&typedValue, &bits, sizeof(typedValue));
-        metricValueVariant = typedValue;
-        break;
-      }
-      case variant_index_v<double, MetricValueType>: {
-        const uint64_t bits = readWord(wordOffset);
-        double typedValue{};
-        std::memcpy(&typedValue, &bits, sizeof(typedValue));
-        metricValueVariant = typedValue;
-        break;
-      }
-      case variant_index_v<std::vector<uint64_t>, MetricValueType>: {
-        std::vector<uint64_t> values(metricDesc.size);
-        for (size_t j = 0; j < metricDesc.size; ++j) {
-          values[j] = readWord(wordOffset + j);
-        }
-        metricValueVariant = std::move(values);
-        break;
-      }
-      case variant_index_v<std::vector<int64_t>, MetricValueType>: {
-        std::vector<int64_t> values(metricDesc.size);
-        for (size_t j = 0; j < metricDesc.size; ++j) {
-          const uint64_t bits = readWord(wordOffset + j);
-          std::memcpy(&values[j], &bits, sizeof(bits));
-        }
-        metricValueVariant = std::move(values);
-        break;
-      }
-      case variant_index_v<std::vector<double>, MetricValueType>: {
-        std::vector<double> values(metricDesc.size);
-        for (size_t j = 0; j < metricDesc.size; ++j) {
-          const uint64_t bits = readWord(wordOffset + j);
-          std::memcpy(&values[j], &bits, sizeof(bits));
-        }
-        metricValueVariant = std::move(values);
-        break;
-      }
-      default:
-        throw std::runtime_error("[PROTON] Unsupported metric type index: " +
-                                 std::to_string(metricTypeIndex));
-        break;
-      }
+    auto metricDesc = metricBuffer.getMetricDescriptor(metricId);
+    const auto &metricName = metricDesc.name;
+    const auto metricTypeIndex = metricDesc.typeIndex;
 
-      wordOffset = (wordOffset + metricDesc.size) % capacityWords;
+    MetricValueType metricValueVariant{};
+    switch (metricTypeIndex) {
+    case variant_index_v<uint64_t, MetricValueType>: {
+      const uint64_t bits = readWord(wordOffset);
+      uint64_t typedValue{};
+      std::memcpy(&typedValue, &bits, sizeof(typedValue));
+      metricValueVariant = typedValue;
+      break;
+    }
+    case variant_index_v<int64_t, MetricValueType>: {
+      const uint64_t bits = readWord(wordOffset);
+      int64_t typedValue{};
+      std::memcpy(&typedValue, &bits, sizeof(typedValue));
+      metricValueVariant = typedValue;
+      break;
+    }
+    case variant_index_v<double, MetricValueType>: {
+      const uint64_t bits = readWord(wordOffset);
+      double typedValue{};
+      std::memcpy(&typedValue, &bits, sizeof(typedValue));
+      metricValueVariant = typedValue;
+      break;
+    }
+    case variant_index_v<std::vector<uint64_t>, MetricValueType>: {
+      std::vector<uint64_t> values(metricDesc.size);
+      for (size_t j = 0; j < metricDesc.size; ++j) {
+        values[j] = readWord(wordOffset + j);
+      }
+      metricValueVariant = std::move(values);
+      break;
+    }
+    case variant_index_v<std::vector<int64_t>, MetricValueType>: {
+      std::vector<int64_t> values(metricDesc.size);
+      for (size_t j = 0; j < metricDesc.size; ++j) {
+        const uint64_t bits = readWord(wordOffset + j);
+        std::memcpy(&values[j], &bits, sizeof(bits));
+      }
+      metricValueVariant = std::move(values);
+      break;
+    }
+    case variant_index_v<std::vector<double>, MetricValueType>: {
+      std::vector<double> values(metricDesc.size);
+      for (size_t j = 0; j < metricDesc.size; ++j) {
+        const uint64_t bits = readWord(wordOffset + j);
+        std::memcpy(&values[j], &bits, sizeof(bits));
+      }
+      metricValueVariant = std::move(values);
+      break;
+    }
+    default:
+      throw std::runtime_error("[PROTON] Unsupported metric type index: " +
+                               std::to_string(metricTypeIndex));
+      break;
+    }
 
-      for (auto &[data, entries] : pendingGraph.dataToEntries) {
-        auto &dataEntry = entries[i];
-        if (dataEntry.id != Scope::DummyScopeId) {
-          dataEntry.upsertLinkedFlexibleMetric(metricName, metricValueVariant,
-                                               dataEntry.id);
-        } else {
-          dataEntry.upsertFlexibleMetric(metricName, metricValueVariant);
-        }
+    wordOffset += metricDesc.size;
+
+    auto ordinalEntryIt = ordinalToEntryQueue.find(metricOrdinal);
+    if (ordinalEntryIt == ordinalToEntryQueue.end() ||
+        ordinalEntryIt->second.empty()) {
+      continue;
+    }
+    for (auto &[data, dataEntry] : ordinalEntryIt->second.front()) {
+      if (dataEntry.id != Scope::DummyScopeId) {
+        dataEntry.upsertLinkedFlexibleMetric(metricName, metricValueVariant,
+                                             dataEntry.id);
+      } else {
+        dataEntry.upsertFlexibleMetric(metricName, metricValueVariant);
       }
     }
+    ordinalEntryIt->second.pop_front();
+  }
+
+  size_t remainingRecords = 0;
+  for (const auto &[_, entries] : ordinalToEntryQueue) {
+    remainingRecords += entries.size();
+  }
+  if (remainingRecords != 0) {
+    throw std::runtime_error(
+        "[PROTON] Missing CUDA graph metric records during flush");
   }
 }
 } // namespace
 
 void PendingGraphPool::push(
-    size_t phase, const std::map<Data *, std::vector<DataEntry>> &dataToEntries,
-    size_t numNodes, size_t numWords) {
+    size_t phase,
+    const std::map<uint64_t, std::map<Data *, DataEntry>> &ordinalToEntries,
+    size_t numWords) {
   const size_t requiredBytes = bytesForWords(numWords);
   void *device = runtime->getDevice();
   std::shared_ptr<Slot> slot;
-  auto startBufferOffset = 0;
+  size_t startBufferOffset = 0;
   {
     std::lock_guard<std::mutex> lock(mutex);
     auto &devicePool = pool[device];
@@ -121,9 +144,9 @@ void PendingGraphPool::push(
   {
     std::lock_guard<std::mutex> slotLock(slot->mutex);
     if (slot->queue == std::nullopt) {
-      slot->queue = PendingGraphQueue(startBufferOffset, phase, device);
+      slot->queue = PendingGraphQueue(startBufferOffset);
     }
-    slot->queue->push(numNodes, numWords, dataToEntries);
+    slot->queue->push(numWords, ordinalToEntries);
   }
   {
     std::lock_guard<std::mutex> lock(mutex);
@@ -131,7 +154,7 @@ void PendingGraphPool::push(
         deviceRemainingCapacity.try_emplace(device, metricBuffer->getCapacity())
             .first->second;
     auto &bufferOffset = deviceBufferOffset[device];
-    bufferOffset = (bufferOffset + requiredBytes) % metricBuffer->getCapacity();
+    bufferOffset += requiredBytes;
     remainingCapacity -= requiredBytes;
   }
 }
@@ -146,24 +169,25 @@ void PendingGraphPool::peek(size_t phase) {
         slots.emplace_back(device, slotIt->second);
       }
     }
-    for (auto &[device, slotPtr] : slots) {
+    for (auto &[device, _] : slots) {
       pool[device].erase(phase);
     }
   }
+
   std::vector<std::pair<void *, size_t>> deviceNumWords;
-  for (auto &[device, slotPtr] : slots) {
-    std::lock_guard<std::mutex> slotLock(slotPtr->mutex);
-    if (!slotPtr->queue.has_value())
+  for (auto &[device, slot] : slots) {
+    std::lock_guard<std::mutex> slotLock(slot->mutex);
+    if (!slot->queue.has_value())
       continue;
-    auto &queue = slotPtr->queue.value();
-    auto numWords = queue.numWords;
+    auto &queue = *slot->queue;
     metricBuffer->peek(static_cast<Device *>(device), [&](uint8_t *hostPtr) {
       emitMetricRecords(*metricBuffer, reinterpret_cast<uint64_t *>(hostPtr),
                         queue);
     });
-    deviceNumWords.emplace_back(device, numWords);
-    slotPtr->queue.reset();
+    deviceNumWords.emplace_back(device, queue.numWords);
+    slot->queue.reset();
   }
+
   {
     std::lock_guard<std::mutex> lock(mutex);
     for (auto &[device, numWords] : deviceNumWords) {
@@ -201,15 +225,23 @@ bool PendingGraphPool::flushAll() {
         auto deviceIt = poolCopy.find(device);
         if (deviceIt == poolCopy.end())
           return;
+        auto combinedQueue = std::optional<PendingGraphQueue>(std::nullopt);
         for (auto &[_, slot] : deviceIt->second) {
           std::lock_guard<std::mutex> lock(slot->mutex);
           if (!slot->queue.has_value())
             continue;
-          deviceNumWords.emplace_back(device, slot->queue->numWords);
+          auto &queue = *slot->queue;
+          if (!combinedQueue.has_value()) {
+            combinedQueue.emplace(queue.startBufferOffset);
+          }
+          combinedQueue->append(queue);
+          deviceNumWords.emplace_back(device, queue.numWords);
+          slot->queue.reset();
+        }
+        if (combinedQueue.has_value()) {
           emitMetricRecords(*metricBuffer,
                             reinterpret_cast<uint64_t *>(hostPtr),
-                            *slot->queue);
-          slot->queue.reset();
+                            *combinedQueue);
         }
       },
       true);

--- a/third_party/proton/csrc/lib/Profiler/Graph.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Graph.cpp
@@ -16,21 +16,13 @@ constexpr size_t bytesForWords(size_t numWords) {
   return numWords * sizeof(uint64_t);
 }
 
-std::pair<uint64_t, uint64_t> writtenWordRange(MetricBuffer &metricBuffer,
-                                               uint64_t wordsWritten) {
-  const size_t capacityWords = metricBuffer.getCapacity() / sizeof(uint64_t);
-  const uint64_t numWords = std::min<uint64_t>(wordsWritten, capacityWords);
-  const uint64_t startWordOffset =
-      wordsWritten > capacityWords ? wordsWritten - capacityWords : 0;
-  return {startWordOffset, numWords};
-}
-
 void emitMetricRecords(MetricBuffer &metricBuffer, uint64_t *hostBasePtr,
-                       const PendingGraphQueue &queue,
-                       uint64_t scanStartWordOffset, uint64_t scanNumWords,
-                       uint64_t wordsWritten) {
+                       const PendingGraphQueue &queue, uint64_t wordsWritten) {
   const size_t capacityWords = metricBuffer.getCapacity() / sizeof(uint64_t);
-  const uint64_t startWordOffset = queue.startBufferOffset / sizeof(uint64_t);
+  const uint64_t scanStartWordOffset =
+      queue.startBufferOffset / sizeof(uint64_t);
+  const uint64_t scanNumWords = queue.numWords;
+  const uint64_t startWordOffset = scanStartWordOffset;
   const uint64_t endWordOffset = scanStartWordOffset + scanNumWords;
   uint64_t wordOffset = scanStartWordOffset;
   size_t recordsRead = 0;
@@ -163,8 +155,8 @@ void emitMetricRecords(MetricBuffer &metricBuffer, uint64_t *hostBasePtr,
        << " queue_num_words=" << queue.numWords
        << " scan_start_word=" << scanStartWordOffset
        << " scan_num_words=" << scanNumWords
-       << " words_written=" << wordsWritten
-       << " first_seen=[" << join(firstSeenOrdinals) << "]"
+       << " words_written=" << wordsWritten << " first_seen=["
+       << join(firstSeenOrdinals) << "]"
        << " first_unknown=[" << join(firstUnknownOrdinals) << "]"
        << " first_remaining=[" << join(firstRemainingOrdinals) << "]";
     throw std::runtime_error(os.str());
@@ -228,14 +220,13 @@ void PendingGraphPool::peek(size_t phase) {
     if (!slot->queue.has_value())
       continue;
     auto &queue = *slot->queue;
-    metricBuffer->peek(static_cast<Device *>(device), [&](uint8_t *hostPtr,
-                                                          uint64_t wordsWritten) {
-      auto [scanStartWordOffset, scanNumWords] =
-          writtenWordRange(*metricBuffer, wordsWritten);
-      emitMetricRecords(*metricBuffer, reinterpret_cast<uint64_t *>(hostPtr),
-                        queue, scanStartWordOffset, scanNumWords,
-                        wordsWritten);
-    });
+    metricBuffer->peek(static_cast<Device *>(device),
+                       [&](uint8_t *hostPtr, uint64_t wordsWritten) {
+                         emitMetricRecords(
+                             *metricBuffer,
+                             reinterpret_cast<uint64_t *>(hostPtr), queue,
+                             wordsWritten);
+                       });
     deviceNumWords.emplace_back(device, queue.numWords);
     slot->queue.reset();
   }
@@ -277,26 +268,16 @@ bool PendingGraphPool::flushAll() {
         auto deviceIt = poolCopy.find(device);
         if (deviceIt == poolCopy.end())
           return;
-        auto combinedQueue = std::optional<PendingGraphQueue>(std::nullopt);
         for (auto &[_, slot] : deviceIt->second) {
           std::lock_guard<std::mutex> lock(slot->mutex);
           if (!slot->queue.has_value())
             continue;
           auto &queue = *slot->queue;
           deviceNumWords.emplace_back(device, queue.numWords);
-          if (!combinedQueue.has_value()) {
-            combinedQueue.emplace(queue.startBufferOffset);
-          }
-          combinedQueue->append(queue);
-          slot->queue.reset();
-        }
-        if (combinedQueue.has_value()) {
-          auto [scanStartWordOffset, scanNumWords] =
-              writtenWordRange(*metricBuffer, wordsWritten);
           emitMetricRecords(*metricBuffer,
-                            reinterpret_cast<uint64_t *>(hostPtr),
-                            *combinedQueue, scanStartWordOffset, scanNumWords,
+                            reinterpret_cast<uint64_t *>(hostPtr), queue,
                             wordsWritten);
+          slot->queue.reset();
         }
       },
       true);

--- a/third_party/proton/csrc/lib/Profiler/Graph.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Graph.cpp
@@ -5,6 +5,7 @@
 
 #include <cstring>
 #include <optional>
+#include <sstream>
 #include <stdexcept>
 #include <vector>
 
@@ -15,12 +16,28 @@ constexpr size_t bytesForWords(size_t numWords) {
   return numWords * sizeof(uint64_t);
 }
 
+std::pair<uint64_t, uint64_t> writtenWordRange(MetricBuffer &metricBuffer,
+                                               uint64_t wordsWritten) {
+  const size_t capacityWords = metricBuffer.getCapacity() / sizeof(uint64_t);
+  const uint64_t numWords = std::min<uint64_t>(wordsWritten, capacityWords);
+  const uint64_t startWordOffset =
+      wordsWritten > capacityWords ? wordsWritten - capacityWords : 0;
+  return {startWordOffset, numWords};
+}
+
 void emitMetricRecords(MetricBuffer &metricBuffer, uint64_t *hostBasePtr,
-                       const PendingGraphQueue &queue) {
+                       const PendingGraphQueue &queue,
+                       uint64_t scanStartWordOffset, uint64_t scanNumWords,
+                       uint64_t wordsWritten) {
   const size_t capacityWords = metricBuffer.getCapacity() / sizeof(uint64_t);
   const uint64_t startWordOffset = queue.startBufferOffset / sizeof(uint64_t);
-  const uint64_t endWordOffset = startWordOffset + queue.numWords;
-  uint64_t wordOffset = startWordOffset;
+  const uint64_t endWordOffset = scanStartWordOffset + scanNumWords;
+  uint64_t wordOffset = scanStartWordOffset;
+  size_t recordsRead = 0;
+  size_t matchedRecords = 0;
+  size_t unknownOrdinalRecords = 0;
+  std::vector<uint64_t> firstSeenOrdinals;
+  std::vector<uint64_t> firstUnknownOrdinals;
   auto readWord = [&](size_t offset) -> uint64_t {
     return hostBasePtr[offset % capacityWords];
   };
@@ -31,6 +48,9 @@ void emitMetricRecords(MetricBuffer &metricBuffer, uint64_t *hostBasePtr,
   // target queued for that metric-copy kernel.
   while (wordOffset < endWordOffset) {
     const uint64_t metricOrdinal = readWord(wordOffset);
+    ++recordsRead;
+    if (firstSeenOrdinals.size() < 8)
+      firstSeenOrdinals.push_back(metricOrdinal);
     wordOffset += 1;
 
     const uint64_t metricId = readWord(wordOffset);
@@ -100,6 +120,9 @@ void emitMetricRecords(MetricBuffer &metricBuffer, uint64_t *hostBasePtr,
     auto ordinalEntryIt = ordinalToEntryQueue.find(metricOrdinal);
     if (ordinalEntryIt == ordinalToEntryQueue.end() ||
         ordinalEntryIt->second.empty()) {
+      ++unknownOrdinalRecords;
+      if (firstUnknownOrdinals.size() < 8)
+        firstUnknownOrdinals.push_back(metricOrdinal);
       continue;
     }
     for (auto &[data, dataEntry] : ordinalEntryIt->second.front()) {
@@ -111,15 +134,40 @@ void emitMetricRecords(MetricBuffer &metricBuffer, uint64_t *hostBasePtr,
       }
     }
     ordinalEntryIt->second.pop_front();
+    ++matchedRecords;
   }
 
   size_t remainingRecords = 0;
+  std::vector<uint64_t> firstRemainingOrdinals;
   for (const auto &[_, entries] : ordinalToEntryQueue) {
     remainingRecords += entries.size();
+    if (!entries.empty() && firstRemainingOrdinals.size() < 8)
+      firstRemainingOrdinals.push_back(_);
   }
   if (remainingRecords != 0) {
-    throw std::runtime_error(
-        "[PROTON] Missing CUDA graph metric records during flush");
+    auto join = [](const std::vector<uint64_t> &values) {
+      std::ostringstream os;
+      for (size_t i = 0; i < values.size(); ++i) {
+        if (i)
+          os << ",";
+        os << values[i];
+      }
+      return os.str();
+    };
+    std::ostringstream os;
+    os << "[PROTON] Missing CUDA graph metric records during flush"
+       << " remaining=" << remainingRecords << " records_read=" << recordsRead
+       << " matched=" << matchedRecords
+       << " unknown_ordinals=" << unknownOrdinalRecords
+       << " queue_start_word=" << startWordOffset
+       << " queue_num_words=" << queue.numWords
+       << " scan_start_word=" << scanStartWordOffset
+       << " scan_num_words=" << scanNumWords
+       << " words_written=" << wordsWritten
+       << " first_seen=[" << join(firstSeenOrdinals) << "]"
+       << " first_unknown=[" << join(firstUnknownOrdinals) << "]"
+       << " first_remaining=[" << join(firstRemainingOrdinals) << "]";
+    throw std::runtime_error(os.str());
   }
 }
 } // namespace
@@ -154,7 +202,7 @@ void PendingGraphPool::push(
         deviceRemainingCapacity.try_emplace(device, metricBuffer->getCapacity())
             .first->second;
     auto &bufferOffset = deviceBufferOffset[device];
-    bufferOffset += requiredBytes;
+    bufferOffset = (bufferOffset + requiredBytes) % metricBuffer->getCapacity();
     remainingCapacity -= requiredBytes;
   }
 }
@@ -180,9 +228,13 @@ void PendingGraphPool::peek(size_t phase) {
     if (!slot->queue.has_value())
       continue;
     auto &queue = *slot->queue;
-    metricBuffer->peek(static_cast<Device *>(device), [&](uint8_t *hostPtr) {
+    metricBuffer->peek(static_cast<Device *>(device), [&](uint8_t *hostPtr,
+                                                          uint64_t wordsWritten) {
+      auto [scanStartWordOffset, scanNumWords] =
+          writtenWordRange(*metricBuffer, wordsWritten);
       emitMetricRecords(*metricBuffer, reinterpret_cast<uint64_t *>(hostPtr),
-                        queue);
+                        queue, scanStartWordOffset, scanNumWords,
+                        wordsWritten);
     });
     deviceNumWords.emplace_back(device, queue.numWords);
     slot->queue.reset();
@@ -221,7 +273,7 @@ bool PendingGraphPool::flushAll() {
   }
   std::vector<std::pair<void *, size_t>> deviceNumWords;
   metricBuffer->flush(
-      [&](void *device, uint8_t *hostPtr) {
+      [&](void *device, uint8_t *hostPtr, uint64_t wordsWritten) {
         auto deviceIt = poolCopy.find(device);
         if (deviceIt == poolCopy.end())
           return;
@@ -231,17 +283,20 @@ bool PendingGraphPool::flushAll() {
           if (!slot->queue.has_value())
             continue;
           auto &queue = *slot->queue;
+          deviceNumWords.emplace_back(device, queue.numWords);
           if (!combinedQueue.has_value()) {
             combinedQueue.emplace(queue.startBufferOffset);
           }
           combinedQueue->append(queue);
-          deviceNumWords.emplace_back(device, queue.numWords);
           slot->queue.reset();
         }
         if (combinedQueue.has_value()) {
+          auto [scanStartWordOffset, scanNumWords] =
+              writtenWordRange(*metricBuffer, wordsWritten);
           emitMetricRecords(*metricBuffer,
                             reinterpret_cast<uint64_t *>(hostPtr),
-                            *combinedQueue);
+                            *combinedQueue, scanStartWordOffset, scanNumWords,
+                            wordsWritten);
         }
       },
       true);

--- a/third_party/proton/proton/metric.py
+++ b/third_party/proton/proton/metric.py
@@ -8,10 +8,16 @@ from .state import exit_state, enter_state, COMPUTE_METADATA_SCOPE_NAME
 
 
 @triton.jit
-def tensor_metric_kernel(device_ptr, device_offset_ptr, size: tl.uint64, metric_id: tl.uint64, metric_value_ptr,
-                         metric_value_size: tl.uint64):
+def tensor_metric_kernel(device_ptr, device_offset_ptr, size: tl.uint64, metric_ordinal: tl.uint64,
+                         metric_id: tl.uint64, metric_value_ptr, metric_value_size: tl.uint64):
     BLOCK_SIZE: tl.constexpr = 128
-    device_offset = tl.load(device_offset_ptr)
+    record_size = metric_value_size + 2
+    # Reserve the full record atomically so replayed graph streams can append
+    # concurrently. The ordinal lets the host attach this record to its owner
+    # even if replay order differs from graph-node creation order.
+    device_offset = tl.atomic_add(device_offset_ptr, record_size, sem="relaxed") % size
+    tl.store(device_ptr + device_offset, metric_ordinal)
+    device_offset = (device_offset + 1) % size
     tl.store(device_ptr + device_offset, metric_id)
     device_offset = (device_offset + 1) % size
     num_iters = tl.cdiv(metric_value_size, BLOCK_SIZE)
@@ -22,19 +28,19 @@ def tensor_metric_kernel(device_ptr, device_offset_ptr, size: tl.uint64, metric_
         metric_value = tl.load(metric_value_ptr + cur_offsets, mask=mask)
         tl.store(device_ptr + (device_offset + cur_offsets) % size, metric_value, mask=mask)
     tl.debug_barrier()
-    device_offset = (device_offset + metric_value_size) % size
-    tl.store(device_offset_ptr, device_offset)
 
 
 @triton.jit
-def scalar_metric_kernel(device_ptr, device_offset_ptr, size: tl.uint64, metric_id: tl.uint64, metric_value: tl.uint64):
-    device_offset = tl.load(device_offset_ptr)
+def scalar_metric_kernel(device_ptr, device_offset_ptr, size: tl.uint64, metric_ordinal: tl.uint64,
+                         metric_id: tl.uint64, metric_value: tl.uint64):
+    # Record layout is {metric_ordinal, metric_id, metric_value}.
+    device_offset = tl.atomic_add(device_offset_ptr, 3, sem="relaxed") % size
+    tl.store(device_ptr + device_offset, metric_ordinal)
+    device_offset = (device_offset + 1) % size
     tl.store(device_ptr + device_offset, metric_id)
     device_offset = (device_offset + 1) % size
     tl.store(device_ptr + device_offset, metric_value)
-    device_offset = (device_offset + 1) % size
     tl.debug_barrier()
-    tl.store(device_offset_ptr, device_offset)
 
 
 def _get_kernel(kernel_fn, *args):
@@ -51,6 +57,7 @@ def _get_kernel(kernel_fn, *args):
 def set_metric_kernels():
     mock_ptr = MockTensor(tl.uint64)
     mock_metric_id = 0
+    mock_metric_ordinal = 0
     mock_size = 1
     mock_metric_value_size = 1
     tensor_metric_kernel_fn, tensor_metric_kernel_num_threads, tensor_metric_kernel_shared = _get_kernel(
@@ -58,6 +65,7 @@ def set_metric_kernels():
         mock_ptr,
         mock_ptr,
         mock_size,
+        mock_metric_ordinal,
         mock_metric_id,
         mock_ptr,
         mock_metric_value_size,
@@ -67,6 +75,7 @@ def set_metric_kernels():
         mock_ptr,
         mock_ptr,
         mock_size,
+        mock_metric_ordinal,
         mock_metric_id,
         mock_metric_id,
     )

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -19,6 +19,10 @@ import triton.profiler.viewer as viewer
 from triton._internal_testing import is_hip, is_cuda, is_blackwell
 
 
+def _find_child_by_name(frame, name):
+    return next((child for child in frame["children"] if child["frame"]["name"] == name), None)
+
+
 @pytest.mark.parametrize("context", ["shadow", "python"])
 def test_torch(context, tmp_path: pathlib.Path, device: str):
     temp_file = tmp_path / "test_torch.hatchet"
@@ -152,8 +156,8 @@ def test_cudagraph(tmp_path: pathlib.Path, device: str):
     else:
         # cuda backend supports "<captured_at>" annotation
         for test_frame in [test0_frame, test1_frame, test2_frame]:
-            child = test_frame["children"][0]
-            assert child["frame"]["name"] == "<captured_at>"
+            child = _find_child_by_name(test_frame, "<captured_at>")
+            assert child is not None
             # check all iterations
             total_iters = 0
             for child in child["children"]:
@@ -209,8 +213,8 @@ def test_cudagraph_not_captured_by_profiler(tmp_path: pathlib.Path, capfd, devic
             replay1_frame = child
     assert replay0_frame is not None
     assert replay1_frame is not None
-    assert len(replay0_frame["children"]) == 3
-    assert len(replay1_frame["children"]) == 3
+    assert len(replay0_frame["children"]) >= 3
+    assert len(replay1_frame["children"]) >= 3
 
     def has_positive_time_metric(node):
         if node["metrics"].get("time (ns)", 0) > 0:
@@ -270,7 +274,10 @@ def test_cudagraph_deactivate(tmp_path, device: str):
             test0_frame = child
             break
     assert test0_frame is not None
-    iter_frame = test0_frame["children"][0]["children"][0]
+    capture_frame = _find_child_by_name(test0_frame, "<captured_at>")
+    assert capture_frame is not None
+    iter_frame = _find_child_by_name(capture_frame, "iter_0")
+    assert iter_frame is not None
     scope_a_frame = None
     scope_b_frame = None
     scope_c_frame = None
@@ -332,8 +339,8 @@ def test_cudagraph_filters_unlinked_virtual_scopes(tmp_path: pathlib.Path, data_
         None,
     )
     assert replay_frame is not None
-    capture_frame = replay_frame["children"][0]
-    assert capture_frame["frame"]["name"] == "<captured_at>"
+    capture_frame = _find_child_by_name(replay_frame, "<captured_at>")
+    assert capture_frame is not None
 
     capture_children = capture_frame["children"]
     capture_child_names = {child["frame"]["name"] for child in capture_children}
@@ -905,8 +912,10 @@ def test_multiple_sessions_cudagraph_metric_kernels(tmp_path: pathlib.Path, devi
     assert session0_replay_frame is not None
     assert session1_replay_frame is not None
 
-    capture0 = session0_replay_frame["children"][0]
-    capture1 = session1_replay_frame["children"][0]
+    capture0 = _find_child_by_name(session0_replay_frame, "<captured_at>")
+    capture1 = _find_child_by_name(session1_replay_frame, "<captured_at>")
+    assert capture0 is not None
+    assert capture1 is not None
 
     foo_frame0 = get_frame_by_name(capture0, "foo_with_metric")
     bar_frame0 = get_frame_by_name(capture0, "bar_without_metric")
@@ -922,6 +931,98 @@ def test_multiple_sessions_cudagraph_metric_kernels(tmp_path: pathlib.Path, devi
     assert int(foo_frame0["metrics"]["count"]) == foo_iters
     assert "sum_metric" not in bar_frame1["metrics"]
     assert int(bar_frame1["metrics"]["count"]) == bar_iters
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
+def test_hook_launch_metadata_cudagraph_metric_records_attach_by_owner(tmp_path: pathlib.Path, device: str):
+    """Metric-copy kernels may append graph records in a different order than capture order."""
+    capture_stream = torch.cuda.Stream()
+    slow_stream = torch.cuda.Stream()
+    fast_stream = torch.cuda.Stream()
+    torch.cuda.set_stream(capture_stream)
+
+    slow_name = "metric_order_slow"
+    fast_name = "metric_order_fast"
+    slow_flops = 111.0
+    fast_flops = 222.0
+
+    @triton.jit
+    def metadata_delay_kernel(scratch, BLOCK: tl.constexpr, ITERS: tl.constexpr):
+        pid = tl.program_id(0)
+        offsets = pid * BLOCK + tl.arange(0, BLOCK)
+        values = offsets.to(tl.float32)
+        for _ in tl.static_range(0, ITERS):
+            values = values * 1.0001 + 1.0
+        tl.store(scratch + offsets, values)
+
+    def slow_metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        metadata_delay_kernel[(2048, )](args["delay_scratch"], BLOCK=256, ITERS=64, num_warps=8)
+        return {"name": slow_name, "flops": args["slow_metric"]}
+
+    def fast_metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        return {"name": fast_name, "flops": args["fast_metric"]}
+
+    @triton.jit(launch_metadata=slow_metadata_fn)
+    def slow_kernel(x, y, slow_metric, delay_scratch):
+        tl.store(y, tl.load(x) + 1.0)
+
+    @triton.jit(launch_metadata=fast_metadata_fn)
+    def fast_kernel(x, y, fast_metric):
+        tl.store(y, tl.load(x) + 2.0)
+
+    def find_frame(node, name: str):
+        queue = [node]
+        while queue:
+            cur = queue.pop(0)
+            if cur["frame"]["name"] == name:
+                return cur
+            queue.extend(cur["children"])
+        return None
+
+    x = torch.tensor([1.0], device=device)
+    y_slow = torch.empty_like(x)
+    y_fast = torch.empty_like(x)
+    slow_metric = torch.tensor([slow_flops], device=device)
+    fast_metric = torch.tensor([fast_flops], device=device)
+    delay_scratch = torch.empty((2048 * 256, ), device=device)
+
+    temp_file = tmp_path / "test_hook_metadata_metric_record_order.hatchet"
+    session = proton.start(str(temp_file.with_suffix("")), context="shadow", hook="triton")
+    try:
+        slow_kernel[(1, )](x, y_slow, slow_metric, delay_scratch, num_warps=1)
+        fast_kernel[(1, )](x, y_fast, fast_metric, num_warps=1)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=capture_stream):
+            slow_stream.wait_stream(capture_stream)
+            fast_stream.wait_stream(capture_stream)
+            with torch.cuda.stream(slow_stream):
+                slow_kernel[(1, )](x, y_slow, slow_metric, delay_scratch, num_warps=1)
+            with torch.cuda.stream(fast_stream):
+                fast_kernel[(1, )](x, y_fast, fast_metric, num_warps=1)
+            capture_stream.wait_stream(slow_stream)
+            capture_stream.wait_stream(fast_stream)
+
+        with proton.scope("replay"):
+            graph.replay()
+        torch.cuda.synchronize()
+    finally:
+        proton.finalize(session)
+
+    with temp_file.open() as f:
+        data = json.load(f)
+
+    replay_frame = find_frame(data[0], "replay")
+    assert replay_frame is not None
+    capture_frame = find_frame(replay_frame, "<captured_at>")
+    assert capture_frame is not None
+    slow_frame = find_frame(capture_frame, slow_name)
+    fast_frame = find_frame(capture_frame, fast_name)
+    assert slow_frame is not None
+    assert fast_frame is not None
+    assert slow_frame["metrics"]["flops"] == slow_flops
+    assert fast_frame["metrics"]["flops"] == fast_flops
 
 
 def test_trace(tmp_path: pathlib.Path, device: str):
@@ -1376,7 +1477,8 @@ def test_tensor_metrics_cudagraph(tmp_path: pathlib.Path, device: str):
             test0_frame = child
             break
     assert test0_frame is not None
-    capture_at_frame = test0_frame["children"][0]
+    capture_at_frame = _find_child_by_name(test0_frame, "<captured_at>")
+    assert capture_at_frame is not None
 
     foo_test_frame = None
     scope_a_frame = None
@@ -1444,7 +1546,8 @@ def test_tensor_metrics_cudagraph_deactivate(tmp_path: pathlib.Path, device: str
                 test0_frame = child
                 break
         assert test0_frame is not None
-        capture_at_frame = test0_frame["children"][0]
+        capture_at_frame = _find_child_by_name(test0_frame, "<captured_at>")
+        assert capture_at_frame is not None
         scope_b_frame = None
         c_frame = None
         for child in capture_at_frame["children"]:
@@ -1520,8 +1623,8 @@ def test_tensor_metrics_multi_device_cudagraph(tmp_path: pathlib.Path):
         device_name = f"test_device_{device.index}"
         launch_frame = next((child for child in children if child["frame"]["name"] == device_name), None)
         assert launch_frame is not None
-        capture_at_frame = launch_frame["children"][0]
-        assert capture_at_frame["frame"]["name"] == "<captured_at>"
+        capture_at_frame = _find_child_by_name(launch_frame, "<captured_at>")
+        assert capture_at_frame is not None
 
         foo_frame = None
         scope_a_frame = None
@@ -1645,7 +1748,7 @@ def test_periodic_flushing_cudagraph(tmp_path, fresh_knobs, data_format, buffer_
         capture_frame = None
         for child in data[0]["children"]:
             if child["frame"]["name"] == "test0":
-                capture_frame = child["children"][0]
+                capture_frame = _find_child_by_name(child, "<captured_at>")
                 break
         assert capture_frame is not None
         scope_a_frame = None

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -934,100 +934,8 @@ def test_multiple_sessions_cudagraph_metric_kernels(tmp_path: pathlib.Path, devi
 
 
 @pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
-def test_hook_launch_metadata_cudagraph_metric_records_attach_by_owner(tmp_path: pathlib.Path, device: str):
-    """Metric-copy kernels may append graph records in a different order than capture order."""
-    capture_stream = torch.cuda.Stream()
-    slow_stream = torch.cuda.Stream()
-    fast_stream = torch.cuda.Stream()
-    torch.cuda.set_stream(capture_stream)
-
-    slow_name = "metric_order_slow"
-    fast_name = "metric_order_fast"
-    slow_flops = 111.0
-    fast_flops = 222.0
-
-    @triton.jit
-    def metadata_delay_kernel(scratch, BLOCK: tl.constexpr, ITERS: tl.constexpr):
-        pid = tl.program_id(0)
-        offsets = pid * BLOCK + tl.arange(0, BLOCK)
-        values = offsets.to(tl.float32)
-        for _ in tl.static_range(0, ITERS):
-            values = values * 1.0001 + 1.0
-        tl.store(scratch + offsets, values)
-
-    def slow_metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
-        metadata_delay_kernel[(2048, )](args["delay_scratch"], BLOCK=256, ITERS=64, num_warps=8)
-        return {"name": slow_name, "flops": args["slow_metric"]}
-
-    def fast_metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
-        return {"name": fast_name, "flops": args["fast_metric"]}
-
-    @triton.jit(launch_metadata=slow_metadata_fn)
-    def slow_kernel(x, y, slow_metric, delay_scratch):
-        tl.store(y, tl.load(x) + 1.0)
-
-    @triton.jit(launch_metadata=fast_metadata_fn)
-    def fast_kernel(x, y, fast_metric):
-        tl.store(y, tl.load(x) + 2.0)
-
-    def find_frame(node, name: str):
-        queue = [node]
-        while queue:
-            cur = queue.pop(0)
-            if cur["frame"]["name"] == name:
-                return cur
-            queue.extend(cur["children"])
-        return None
-
-    x = torch.tensor([1.0], device=device)
-    y_slow = torch.empty_like(x)
-    y_fast = torch.empty_like(x)
-    slow_metric = torch.tensor([slow_flops], device=device)
-    fast_metric = torch.tensor([fast_flops], device=device)
-    delay_scratch = torch.empty((2048 * 256, ), device=device)
-
-    temp_file = tmp_path / "test_hook_metadata_metric_record_order.hatchet"
-    session = proton.start(str(temp_file.with_suffix("")), context="shadow", hook="triton")
-    try:
-        slow_kernel[(1, )](x, y_slow, slow_metric, delay_scratch, num_warps=1)
-        fast_kernel[(1, )](x, y_fast, fast_metric, num_warps=1)
-        torch.cuda.synchronize()
-
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph, stream=capture_stream):
-            slow_stream.wait_stream(capture_stream)
-            fast_stream.wait_stream(capture_stream)
-            with torch.cuda.stream(slow_stream):
-                slow_kernel[(1, )](x, y_slow, slow_metric, delay_scratch, num_warps=1)
-            with torch.cuda.stream(fast_stream):
-                fast_kernel[(1, )](x, y_fast, fast_metric, num_warps=1)
-            capture_stream.wait_stream(slow_stream)
-            capture_stream.wait_stream(fast_stream)
-
-        with proton.scope("replay"):
-            graph.replay()
-        torch.cuda.synchronize()
-    finally:
-        proton.finalize(session)
-
-    with temp_file.open() as f:
-        data = json.load(f)
-
-    replay_frame = find_frame(data[0], "replay")
-    assert replay_frame is not None
-    capture_frame = find_frame(replay_frame, "<captured_at>")
-    assert capture_frame is not None
-    slow_frame = find_frame(capture_frame, slow_name)
-    fast_frame = find_frame(capture_frame, fast_name)
-    assert slow_frame is not None
-    assert fast_frame is not None
-    assert slow_frame["metrics"]["flops"] == slow_flops
-    assert fast_frame["metrics"]["flops"] == fast_flops
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
-def test_hook_launch_metadata_cudagraph_internal_metric_order_repro(tmp_path: pathlib.Path, device: str):
-    """Reproduce the graph-metric attachment issue seen in internal hook profiles.
+def test_hook_launch_metadata_cudagraph_metric_order_repro(tmp_path: pathlib.Path, device: str):
+    """Reproduce the graph-metric attachment issue seen in hook profiles.
 
     The captured graph mirrors the production launch_fns_in_streams pattern:
     a metadata-bearing kernel is launched on the capture stream, later kernels
@@ -1112,7 +1020,7 @@ def test_hook_launch_metadata_cudagraph_internal_metric_order_repro(tmp_path: pa
     kernel_z_bytes = torch.tensor([kernel_z_metrics["bytes"]], device=device, dtype=torch.int64)
     gate = torch.ones((1, ), device=device, dtype=torch.int32)
 
-    temp_file = tmp_path / "test_hook_metadata_internal_metric_order_repro.hatchet"
+    temp_file = tmp_path / "test_hook_metadata_metric_order_repro.hatchet"
     session = proton.start(str(temp_file.with_suffix("")), context="shadow", hook="triton")
     try:
         kernel_x[(1, )](x, y, kernel_x_flops, kernel_x_bytes, delay_scratch, gate, num_warps=1)

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -1025,6 +1025,140 @@ def test_hook_launch_metadata_cudagraph_metric_records_attach_by_owner(tmp_path:
     assert fast_frame["metrics"]["flops"] == fast_flops
 
 
+@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
+def test_hook_launch_metadata_cudagraph_internal_metric_order_repro(tmp_path: pathlib.Path, device: str):
+    """Reproduce the graph-metric attachment issue seen in internal hook profiles.
+
+    The captured graph mirrors the production launch_fns_in_streams pattern:
+    a metadata-bearing kernel is launched on the capture stream, later kernels
+    are launched on a side stream that waits on the same start event, then the
+    capture stream joins the side stream. The first metadata path is
+    deliberately gated so the side-stream metric-copy kernels append to
+    Proton's shared metric buffer first during graph replay. Positional
+    attachment assigns those records to the wrong kernel; ordinal attachment
+    keeps each kernel's metrics on its owning frame.
+    """
+
+    capture_stream = torch.cuda.Stream()
+    side_stream = torch.cuda.Stream()
+    torch.cuda.set_stream(capture_stream)
+
+    kernel_x_name = "kernel_x"
+    kernel_y_name = "kernel_y"
+    kernel_z_name = "kernel_z"
+
+    kernel_x_metrics = {"flops": 0.0, "bytes": 1_572_864}
+    kernel_y_metrics = {"flops": 134_217_728.0, "bytes": 17_829_888}
+    kernel_z_metrics = {"flops": 1_073_741_824.0, "bytes": 29_818_880}
+
+    @triton.jit
+    def wait_for_flag_kernel(flag):
+        while tl.load(flag, volatile=True) == 0:
+            pass
+
+    @triton.jit
+    def set_flag_kernel(flag):
+        tl.store(flag, 1)
+
+    @triton.jit
+    def metadata_delay_kernel(scratch, BLOCK: tl.constexpr, ITERS: tl.constexpr):
+        pid = tl.program_id(0)
+        offsets = pid * BLOCK + tl.arange(0, BLOCK)
+        values = offsets.to(tl.float32)
+        for _ in tl.static_range(0, ITERS):
+            values = values * 1.0001 + 1.0
+        tl.store(scratch + offsets, values)
+
+    def kernel_x_metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        wait_for_flag_kernel[(1, )](args["gate"], num_warps=1)
+        metadata_delay_kernel[(2048, )](args["delay_scratch"], BLOCK=256, ITERS=64, num_warps=8)
+        return {"name": kernel_x_name, "flops": args["kernel_x_flops"], "bytes": args["kernel_x_bytes"]}
+
+    def kernel_y_metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        return {"name": kernel_y_name, "flops": args["kernel_y_flops"], "bytes": args["kernel_y_bytes"]}
+
+    def kernel_z_metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        return {"name": kernel_z_name, "flops": args["kernel_z_flops"], "bytes": args["kernel_z_bytes"]}
+
+    @triton.jit(launch_metadata=kernel_x_metadata_fn)
+    def kernel_x(x, y, kernel_x_flops, kernel_x_bytes, delay_scratch, gate):
+        tl.store(y, tl.load(x) + 1.0)
+
+    @triton.jit(launch_metadata=kernel_y_metadata_fn)
+    def kernel_y(x, y, kernel_y_flops, kernel_y_bytes):
+        tl.store(y, tl.load(x) + 2.0)
+
+    @triton.jit(launch_metadata=kernel_z_metadata_fn)
+    def kernel_z(x, y, kernel_z_flops, kernel_z_bytes):
+        tl.store(y, tl.load(x) + 3.0)
+
+    def find_frame(node, name: str):
+        queue = [node]
+        while queue:
+            cur = queue.pop(0)
+            if cur["frame"]["name"] == name:
+                return cur
+            queue.extend(cur["children"])
+        return None
+
+    x = torch.tensor([1.0], device=device)
+    y = torch.empty_like(x)
+    delay_scratch = torch.empty((2048 * 256, ), device=device)
+    kernel_x_flops = torch.tensor([kernel_x_metrics["flops"]], device=device)
+    kernel_x_bytes = torch.tensor([kernel_x_metrics["bytes"]], device=device, dtype=torch.int64)
+    kernel_y_flops = torch.tensor([kernel_y_metrics["flops"]], device=device)
+    kernel_y_bytes = torch.tensor([kernel_y_metrics["bytes"]], device=device, dtype=torch.int64)
+    kernel_z_flops = torch.tensor([kernel_z_metrics["flops"]], device=device)
+    kernel_z_bytes = torch.tensor([kernel_z_metrics["bytes"]], device=device, dtype=torch.int64)
+    gate = torch.ones((1, ), device=device, dtype=torch.int32)
+
+    temp_file = tmp_path / "test_hook_metadata_internal_metric_order_repro.hatchet"
+    session = proton.start(str(temp_file.with_suffix("")), context="shadow", hook="triton")
+    try:
+        kernel_x[(1, )](x, y, kernel_x_flops, kernel_x_bytes, delay_scratch, gate, num_warps=1)
+        kernel_y[(1, )](x, y, kernel_y_flops, kernel_y_bytes, num_warps=1)
+        kernel_z[(1, )](x, y, kernel_z_flops, kernel_z_bytes, num_warps=1)
+        torch.cuda.synchronize()
+        gate.zero_()
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        start_event = torch.cuda.Event()
+        with torch.cuda.graph(graph, stream=capture_stream):
+            start_event.record()
+            kernel_x[(1, )](x, y, kernel_x_flops, kernel_x_bytes, delay_scratch, gate, num_warps=1)
+            with torch.cuda.stream(side_stream):
+                side_stream.wait_event(start_event)
+                kernel_y[(1, )](x, y, kernel_y_flops, kernel_y_bytes, num_warps=1)
+                kernel_z[(1, )](x, y, kernel_z_flops, kernel_z_bytes, num_warps=1)
+                set_flag_kernel[(1, )](gate, num_warps=1)
+            capture_stream.wait_stream(side_stream)
+
+        with proton.scope("replay"):
+            graph.replay()
+        torch.cuda.synchronize()
+    finally:
+        proton.finalize(session)
+
+    with temp_file.open() as f:
+        data = json.load(f)
+
+    replay_frame = find_frame(data[0], "replay")
+    assert replay_frame is not None
+    capture_frame = find_frame(replay_frame, "<captured_at>")
+    assert capture_frame is not None
+
+    for name, expected in [
+        (kernel_x_name, kernel_x_metrics),
+        (kernel_y_name, kernel_y_metrics),
+        (kernel_z_name, kernel_z_metrics),
+    ]:
+        frame = find_frame(capture_frame, name)
+        assert frame is not None
+        assert frame["metrics"]["flops"] == expected["flops"]
+        assert frame["metrics"]["bytes"] == expected["bytes"]
+
+
 def test_trace(tmp_path: pathlib.Path, device: str):
     temp_file = tmp_path / "test_trace.chrome_trace"
     proton.start(str(temp_file.with_suffix("")), data="trace")


### PR DESCRIPTION
## Summary

Fix Proton CUDA graph replay metric attachment for Triton launch metadata tensor metrics.

When launch metadata returns device tensor metrics during CUDA graph capture, Proton captures small metric-copy kernels into the graph. The old replay path decoded the shared metric buffer by position, assuming buffer records appear in the same order as CUPTI graph-node creation. That is not guaranteed: graph replay appends records in GPU execution order, so independent graph branches can append in a different order and attach metrics to the wrong kernel.

## What Changed

- Metric-copy kernels now write records as `{metric_ordinal, metric_id, metric_value...}` and reserve each full record with one device-side atomic.
- During capture, Proton assigns each metric-copy kernel a monotonically increasing ordinal and records the same ordinal in CUPTI graph-node metadata.
- During graph replay flush, pending metric destinations are keyed by ordinal. The host scans records in buffer order, then attaches each metric to the destination with the matching ordinal.
- Periodic flushing keeps `PendingGraphPool::peek(phase)` active: it decodes the selected phase before phase data is dumped and cleared, using the same ordinal-based record matching.
- Existing CUDAGraph tests now find the `<captured_at>` child by name instead of assuming it is the first replay child.
- Added CUDA graph regression coverage:
  - a direct owner-order test
  - a gated repro using neutral `kernel_x`, `kernel_y`, `kernel_z` names where replay append order differs from capture order

## Reader Guide

- `third_party/proton/proton/metric.py` and `csrc/lib/Data/Metric.cpp`: metric buffer record format and metric-copy kernel arguments.
- `csrc/include/Profiler/GPUProfiler.h`: ordinal assignment while launch metadata metric kernels are queued.
- `csrc/lib/Profiler/Cupti/CuptiProfiler.cpp`: CUPTI graph-node classification and ordinal storage on metric nodes.
- `csrc/include/Profiler/Graph.h` and `csrc/lib/Profiler/Graph.cpp`: pending replay targets and ordinal-based decode.
- `third_party/proton/test/test_profile.py`: CUDA graph repros plus order-robust CUDAGraph assertions.

## Testing

- `pre-commit run --files third_party/proton/csrc/lib/Profiler/Graph.cpp third_party/proton/test/test_profile.py`
- `brix run --pods qnie-f33-16pods-0 --timeout 1800 -- /bin/bash -lc 'cd /root/code/triton && /root/.pyenv/versions/3.12.9/bin/python -m pip install -e /root/code/triton >/tmp/triton_editable_install.log && /root/.pyenv/versions/3.12.9/bin/python -m pytest third_party/proton/test/test_profile.py::test_periodic_flushing_cudagraph third_party/proton/test/test_profile.py::test_hook_launch_metadata_cudagraph_metric_records_attach_by_owner third_party/proton/test/test_profile.py::test_hook_launch_metadata_cudagraph_internal_metric_order_repro -q'` -> `6 passed`
- `brix run --pods qnie-f33-16pods-0 --timeout 1200 -- /bin/bash -lc 'cd /root/code/triton && PROTON_SKIP_PC_SAMPLING_TEST=1 /root/.pyenv/versions/3.12.9/bin/python -m pytest third_party/proton/test --ignore=third_party/proton/test/test_override.py -k "not test_overhead and not test_hw_trace" -q'` -> `131 passed, 2 skipped, 2 deselected`
