### PR TITLE
[proton] Group launch metadata metric work by owner

### DIFF
--- a/third_party/proton/csrc/include/Driver/GPU/CudaApi.h
+++ b/third_party/proton/csrc/include/Driver/GPU/CudaApi.h
@@ -30,6 +30,9 @@ CUresult streamCreateWithPriority(CUstream *pStream, unsigned int flags,
 
 template <bool CheckSuccess> CUresult streamSynchronize(CUstream stream);
 
+template <bool CheckSuccess>
+CUresult streamIsCapturing(CUstream stream, CUstreamCaptureStatus *status);
+
 template <bool CheckSuccess> CUresult streamDestroy(CUstream stream);
 
 template <bool CheckSuccess>

--- a/third_party/proton/csrc/include/Profiler/GPUProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/GPUProfiler.h
@@ -230,7 +230,14 @@ protected:
     doAddMetrics(size_t scopeId,
                  const std::map<std::string, MetricValueType> &scalarMetrics,
                  const std::map<std::string, TensorMetric> &tensorMetrics) {
-      if (threadState.isStreamCapturing) { // Graph capture mode
+      auto &metricKernelLaunchState = profiler.metricKernelLaunchState;
+      bool isStreamCapturing = threadState.isStreamCapturing;
+      if (!isStreamCapturing) {
+        isStreamCapturing =
+            profiler.metricBuffer->getRuntime()->isStreamCapturing(
+                metricKernelLaunchState.stream);
+      }
+      if (isStreamCapturing) { // Graph capture mode
         std::vector<uint64_t> metricOrdinals;
         metricOrdinals.reserve(tensorMetrics.size() + scalarMetrics.size());
         // The CUDA graph resource callback records the same ordinal that the
@@ -249,7 +256,6 @@ protected:
           reserveMetricOrdinal();
         }
         // Launch metric kernels
-        auto &metricKernelLaunchState = profiler.metricKernelLaunchState;
         // Keep the metric-node marker scoped to Proton's metric-copy launch.
         // Metadata hooks may launch helper kernels during graph capture, and
         // CUPTI can report those graph-node callbacks while add_metrics is

--- a/third_party/proton/csrc/include/Profiler/Graph.h
+++ b/third_party/proton/csrc/include/Profiler/Graph.h
@@ -54,6 +54,10 @@ struct GraphState {
     // created at capture time and won't change for the same node id. This is
     // used to link the graph node to the captured call path in Data.
     std::map<Data *, size_t> dataToEntryId;
+    // Metric-copy kernels can be shown under launch-metadata scopes while their
+    // flexible metrics still belong to the owning compute kernel's <metric>
+    // child. When present, this is that owner target.
+    std::map<Data *, size_t> dataToFlexibleMetricEntryId;
     // Whether the node has missing name or is a metric node, which is
     // determined at capture time and won't change for the same node id.
     NodeStatus status{};

--- a/third_party/proton/csrc/include/Runtime/CudaRuntime.h
+++ b/third_party/proton/csrc/include/Runtime/CudaRuntime.h
@@ -29,6 +29,7 @@ public:
   void *getPriorityStream() override;
   void synchronizeStream(void *stream) override;
   void synchronizeDevice() override;
+  bool isStreamCapturing(void *stream) override;
   void destroyStream(void *stream) override;
   void
   processHostBuffer(uint8_t *hostBuffer, size_t hostBufferSize,

--- a/third_party/proton/csrc/include/Runtime/Runtime.h
+++ b/third_party/proton/csrc/include/Runtime/Runtime.h
@@ -49,6 +49,8 @@ public:
 
   virtual void synchronizeDevice() = 0;
 
+  virtual bool isStreamCapturing(void *stream) { return false; }
+
   virtual void
   processHostBuffer(uint8_t *hostBuffer, size_t hostBufferSize,
                     uint8_t *deviceBuffer, size_t deviceBufferSize,

--- a/third_party/proton/csrc/lib/Driver/GPU/CudaApi.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/CudaApi.cpp
@@ -39,6 +39,9 @@ DEFINE_DISPATCH(ExternLibCuda, streamCreateWithPriority,
 
 DEFINE_DISPATCH(ExternLibCuda, streamSynchronize, cuStreamSynchronize, CUstream)
 
+DEFINE_DISPATCH(ExternLibCuda, streamIsCapturing, cuStreamIsCapturing, CUstream,
+                CUstreamCaptureStatus *)
+
 DEFINE_DISPATCH(ExternLibCuda, streamDestroy, cuStreamDestroy, CUstream)
 
 DEFINE_DISPATCH(ExternLibCuda, memcpyDToHAsync, cuMemcpyDtoHAsync, void *,

--- a/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/Cupti/CuptiProfiler.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
@@ -33,6 +34,26 @@ thread_local GPUProfiler<CuptiProfiler>::ThreadState
     GPUProfiler<CuptiProfiler>::threadState(CuptiProfiler::instance());
 
 namespace {
+
+std::optional<std::pair<size_t, std::string>>
+findMetadataOwnerContext(const std::vector<Context> &contexts) {
+  const auto prefix = std::string(GraphState::metadataTag) + ":";
+  for (size_t i = 0; i < contexts.size(); ++i) {
+    const auto &name = contexts[i].name;
+    if (name.rfind(prefix, 0) == 0 && name.size() > prefix.size()) {
+      return std::make_pair(i, name.substr(prefix.size()));
+    }
+  }
+  return std::nullopt;
+}
+
+std::string findCurrentOpName(const std::vector<Scope> &scopeStack,
+                              const std::string &fallback) {
+  if (!scopeStack.empty() && !scopeStack.back().name.empty()) {
+    return scopeStack.back().name;
+  }
+  return fallback;
+}
 
 std::unique_ptr<Metric>
 convertKernelActivityToMetric(CUpti_Activity *activity,
@@ -226,9 +247,16 @@ void queueGraphMetrics(const DataToEntryMap &dataToEntry,
       auto &nodeState = nodeIter->second;
       auto entryIdIter = nodeState.dataToEntryId.find(data);
       if (entryIdIter != nodeState.dataToEntryId.end()) {
+        auto flexibleMetricEntryId = entryIdIter->second;
+        auto flexibleMetricEntryIt =
+            nodeState.dataToFlexibleMetricEntryId.find(data);
+        if (flexibleMetricEntryIt !=
+            nodeState.dataToFlexibleMetricEntryId.end()) {
+          flexibleMetricEntryId = flexibleMetricEntryIt->second;
+        }
         metricNodeEntries[metricOrdinal].insert_or_assign(
-            data,
-            DataEntry(entryIdIter->second, phase, graphEntry.metricSet.get()));
+            data, DataEntry(flexibleMetricEntryId, phase,
+                            graphEntry.metricSet.get()));
       } else {
         // Indicate that we'll call upsertFlexibleMetric instead of
         // upsertLinkedFlexibleMetric in queueGraphMetrics, so that the kernel
@@ -498,8 +526,19 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphResourceCallbacks(
       }
       for (auto *data : profiler.dataSet) {
         auto contexts = data->getContexts();
+        std::optional<std::vector<Context>> flexibleMetricTargetContexts;
         if (isMetricKernelNode) {
-          if (threadState.isApiExternOp) { // API extern ops
+          if (auto metadataOwner = findMetadataOwnerContext(contexts)) {
+            auto [metadataIndex, ownerName] = *metadataOwner;
+            auto metricOwnerName =
+                findCurrentOpName(threadState.scopeStack, ownerName);
+            flexibleMetricTargetContexts = std::vector<Context>(
+                contexts.begin(), contexts.begin() + metadataIndex);
+            flexibleMetricTargetContexts->push_back(Context(metricOwnerName));
+            flexibleMetricTargetContexts->push_back(
+                Context(GraphState::metricTag));
+            contexts.push_back(std::string(GraphState::metricTag));
+          } else if (threadState.isApiExternOp) { // API extern ops
             contexts.push_back(std::string(GraphState::metricTag));
           } else { // Triton ops
             contexts.push_back(name);
@@ -511,6 +550,18 @@ void CuptiProfiler::CuptiProfilerPimpl::handleGraphResourceCallbacks(
         auto staticEntry =
             data->addOp(Data::kVirtualPhase, Data::kRootEntryId, contexts);
         nodeState.dataToEntryId.insert_or_assign(data, staticEntry.id);
+        if (isMetricKernelNode) {
+          if (flexibleMetricTargetContexts) {
+            auto flexibleMetricTargetEntry =
+                data->addOp(Data::kVirtualPhase, Data::kRootEntryId,
+                            *flexibleMetricTargetContexts);
+            nodeState.dataToFlexibleMetricEntryId.insert_or_assign(
+                data, flexibleMetricTargetEntry.id);
+          } else {
+            nodeState.dataToFlexibleMetricEntryId.insert_or_assign(
+                data, staticEntry.id);
+          }
+        }
         graphState.dataToEntryIdToNodeStates[data][staticEntry.id].insert(
             &nodeState);
       }

--- a/third_party/proton/csrc/lib/Runtime/CudaRuntime.cpp
+++ b/third_party/proton/csrc/lib/Runtime/CudaRuntime.cpp
@@ -96,6 +96,12 @@ void CudaRuntime::synchronizeDevice() {
   }
 }
 
+bool CudaRuntime::isStreamCapturing(void *stream) {
+  CUstreamCaptureStatus status = CU_STREAM_CAPTURE_STATUS_NONE;
+  cuda::streamIsCapturing<true>(reinterpret_cast<CUstream>(stream), &status);
+  return status == CU_STREAM_CAPTURE_STATUS_ACTIVE;
+}
+
 void CudaRuntime::processHostBuffer(
     uint8_t *hostBuffer, size_t hostBufferSize, uint8_t *deviceBuffer,
     size_t deviceBufferSize, void *stream,

--- a/third_party/proton/proton/hooks/launch.py
+++ b/third_party/proton/proton/hooks/launch.py
@@ -1,4 +1,10 @@
-from ..state import enter_state, exit_state, is_metadata_state_active, metadata_state_name
+from ..state import (
+    COMPUTE_METADATA_SCOPE_NAME as COMPUTE_METADATA_SCOPE_NAME,
+    enter_state,
+    exit_state,
+    is_metadata_state_active,
+    metadata_state_name,
+)
 from ..metric import transform_tensor_metrics, set_metric_kernels
 from triton.compiler import LazyDict
 from .hook import Hook
@@ -96,12 +102,12 @@ class LaunchHook(Hook):
             enabled.set(False)
             return
 
-        owner_metadata_scope = metadata_state_name(kernel_name)
-        enter_state(owner_metadata_scope)
+        enter_state(metadata_state_name(kernel_name))
         try:
             lazy_metadata = metadata.get()
 
             kernel_name = lazy_metadata["name"]
+            owner_metadata_scope = metadata_state_name(kernel_name)
             # If name wasn't available (or changed), apply filters using the evaluated name.
             if not self._matches_kernel_name(kernel_name):
                 enabled.set(False)

--- a/third_party/proton/proton/hooks/launch.py
+++ b/third_party/proton/proton/hooks/launch.py
@@ -1,4 +1,4 @@
-from ..state import enter_state, exit_state, COMPUTE_METADATA_SCOPE_NAME
+from ..state import enter_state, exit_state, is_metadata_state_active, metadata_state_name
 from ..metric import transform_tensor_metrics, set_metric_kernels
 from triton.compiler import LazyDict
 from .hook import Hook
@@ -85,31 +85,53 @@ class LaunchHook(Hook):
         pass
 
     def enter(self, metadata: LazyDict) -> None:
+        if is_metadata_state_active():
+            enabled.set(False)
+            return
+
         # Fast path: if the kernel name is already available without evaluating launch_metadata,
         # apply include/exclude filters and potentially skip metadata evaluation entirely.
         kernel_name = metadata.data.get("name")
         if not self._matches_kernel_name(kernel_name):
             enabled.set(False)
             return
-        enter_state(COMPUTE_METADATA_SCOPE_NAME)
-        lazy_metadata = metadata.get()
-        exit_state()
 
-        kernel_name = lazy_metadata["name"]
-        # If name wasn't available (or changed), apply filters using the evaluated name.
-        if not self._matches_kernel_name(kernel_name):
-            enabled.set(False)
-            return
+        owner_metadata_scope = metadata_state_name(kernel_name)
+        enter_state(owner_metadata_scope)
+        try:
+            lazy_metadata = metadata.get()
 
-        enabled.set(True)
-        fn_metrics = LaunchHook._extract_metrics(lazy_metadata)
+            kernel_name = lazy_metadata["name"]
+            # If name wasn't available (or changed), apply filters using the evaluated name.
+            if not self._matches_kernel_name(kernel_name):
+                enabled.set(False)
+                return
+
+            fn_metrics = LaunchHook._extract_metrics(lazy_metadata)
+            if fn_metrics:
+                set_metric_kernels()
+            scalar_metrics, tensor_metrics = transform_tensor_metrics(fn_metrics)
+        finally:
+            exit_state()
+
         op_name.set(kernel_name)
         id.set(libproton.record_scope())
-        if fn_metrics:
-            set_metric_kernels()
-        scalar_metrics, tensor_metrics = transform_tensor_metrics(fn_metrics)
-        libproton.enter_op(id.get(), lazy_metadata["name"])
-        libproton.add_metrics(id.get(), scalar_metrics, tensor_metrics)
+        op_entered = False
+        try:
+            libproton.enter_op(id.get(), lazy_metadata["name"])
+            op_entered = True
+            # The flexible metrics are attached to the compute op, but any GPU
+            # work needed to copy tensor metrics belongs to launch metadata.
+            enter_state(owner_metadata_scope)
+            try:
+                libproton.add_metrics(id.get(), scalar_metrics, tensor_metrics)
+            finally:
+                exit_state()
+        except Exception:
+            if op_entered:
+                libproton.exit_op(id.get(), op_name.get())
+            raise
+        enabled.set(True)
 
     def exit(self, metadata: LazyDict) -> None:
         if not enabled.get():

--- a/third_party/proton/proton/metric.py
+++ b/third_party/proton/proton/metric.py
@@ -4,7 +4,7 @@ import triton.runtime.driver as driver
 import triton.language as tl
 import triton
 from triton import MockTensor
-from .state import exit_state, enter_state, COMPUTE_METADATA_SCOPE_NAME
+from .state import exit_state, enter_state, COMPUTE_METADATA_SCOPE_NAME, is_metadata_state_active
 
 
 @triton.jit
@@ -158,9 +158,15 @@ def transform_tensor_metrics(metrics: dict[str, Any]) -> tuple[dict[str, Any], d
             if value.device.type == "cpu":
                 scalar_metrics[key] = _scalar_metric_value(key, value)
             else:  # device tensor
-                enter_state(COMPUTE_METADATA_SCOPE_NAME)
-                value, metric_index = _tensor_metric_value_and_index(key, value)
-                exit_state()
+                entered_state = False
+                try:
+                    if not is_metadata_state_active():
+                        enter_state(COMPUTE_METADATA_SCOPE_NAME)
+                        entered_state = True
+                    value, metric_index = _tensor_metric_value_and_index(key, value)
+                finally:
+                    if entered_state:
+                        exit_state()
                 tensor_metrics[key] = _TensorMetric(value, metric_index)
         else:
             scalar_metrics[key] = _scalar_metric_value(key, value)

--- a/third_party/proton/proton/state.py
+++ b/third_party/proton/proton/state.py
@@ -1,8 +1,12 @@
+from functools import wraps
+import threading
+
 from triton._C.libproton import proton as libproton
 from .flags import flags
-from functools import wraps
 
 COMPUTE_METADATA_SCOPE_NAME = "__proton_launch_metadata"
+COMPUTE_METADATA_SCOPE_PREFIX = f"{COMPUTE_METADATA_SCOPE_NAME}:"
+_thread_state = threading.local()
 
 
 class state:
@@ -63,7 +67,32 @@ class metadata_state(state):
 
 def enter_state(name: str) -> None:
     libproton.enter_state(name)
+    stack = getattr(_thread_state, "state_stack", None)
+    if stack is None:
+        stack = []
+        _thread_state.state_stack = stack
+    stack.append(name)
 
 
 def exit_state() -> None:
-    libproton.exit_state()
+    stack = getattr(_thread_state, "state_stack", None)
+    if stack:
+        stack.pop()
+    if stack:
+        libproton.enter_state(stack[-1])
+    else:
+        libproton.exit_state()
+
+
+def metadata_state_name(kernel_name=None) -> str:
+    if not kernel_name:
+        return COMPUTE_METADATA_SCOPE_NAME
+    return f"{COMPUTE_METADATA_SCOPE_PREFIX}{kernel_name}"
+
+
+def is_metadata_state_active() -> bool:
+    stack = getattr(_thread_state, "state_stack", None)
+    if not stack:
+        return False
+    state_name = stack[-1]
+    return state_name == COMPUTE_METADATA_SCOPE_NAME or state_name.startswith(COMPUTE_METADATA_SCOPE_PREFIX)

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -13,14 +13,24 @@ import pathlib
 import threading
 
 import triton.language as tl
-from triton.profiler.hooks.launch import COMPUTE_METADATA_SCOPE_NAME
 import triton.profiler.hooks.launch as proton_launch
+from triton.profiler.state import COMPUTE_METADATA_SCOPE_NAME
 import triton.profiler.viewer as viewer
 from triton._internal_testing import is_hip, is_cuda, is_blackwell
 
 
 def _find_child_by_name(frame, name):
     return next((child for child in frame["children"] if child["frame"]["name"] == name), None)
+
+
+def _find_frame_by_name(frame, name):
+    queue = [frame]
+    while queue:
+        current = queue.pop(0)
+        if current["frame"]["name"] == name:
+            return current
+        queue.extend(current["children"])
+    return None
 
 
 @pytest.mark.parametrize("context", ["shadow", "python"])
@@ -648,9 +658,67 @@ def test_hook_launch_context(tmp_path: pathlib.Path, context: str, device: str):
         parent_frame = queue.pop(0)
         for child in parent_frame["children"]:
             if "reduce" in child["frame"]["name"]:
-                assert parent_frame["frame"]["name"] == COMPUTE_METADATA_SCOPE_NAME
+                assert parent_frame["frame"]["name"].startswith(COMPUTE_METADATA_SCOPE_NAME)
                 return
             queue.append(child)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Only CUDA backend supports metrics profiling in cudagraphs")
+def test_hook_launch_metadata_cudagraph_metric_work_grouping(tmp_path: pathlib.Path, device: str):
+    owner_name = "metadata_owner_kernel"
+    metadata_scope_name = f"{COMPUTE_METADATA_SCOPE_NAME}:{owner_name}"
+
+    @triton.jit
+    def metadata_helper_kernel(metric_value):
+        tl.store(metric_value, 8.0)
+
+    def metadata_fn(grid: tuple, metadata: NamedTuple, args: dict):
+        metadata_helper_kernel[(1, )](args["metric_value"], num_warps=1)
+        return {"name": owner_name, "flops": args["metric_value"], "bytes": args["bytes_value"]}
+
+    @triton.jit(launch_metadata=metadata_fn)
+    def metadata_owner_kernel(x, y, metric_value, bytes_value):
+        tl.store(y, tl.load(x) + 1.0)
+
+    x = torch.tensor([1.0], device=device)
+    y = torch.empty_like(x)
+    metric_value = torch.tensor([0.0], device=device)
+    bytes_value = torch.tensor([64], device=device, dtype=torch.int64)
+
+    temp_file = tmp_path / "test_hook_metadata_metric_work_grouping.hatchet"
+    session = proton.start(str(temp_file.with_suffix("")), context="shadow", hook="triton")
+    try:
+        metadata_owner_kernel[(1, )](x, y, metric_value, bytes_value, num_warps=1)
+        torch.cuda.synchronize()
+        metric_value.zero_()
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            metadata_owner_kernel[(1, )](x, y, metric_value, bytes_value, num_warps=1)
+
+        with proton.scope("replay"):
+            graph.replay()
+        torch.cuda.synchronize()
+    finally:
+        proton.finalize(session)
+
+    with temp_file.open() as f:
+        data = json.load(f)
+
+    replay_frame = _find_frame_by_name(data[0], "replay")
+    assert replay_frame is not None
+    capture_frame = _find_frame_by_name(replay_frame, "<captured_at>")
+    assert capture_frame is not None
+
+    owner_frame = _find_frame_by_name(capture_frame, owner_name)
+    metadata_frame = _find_frame_by_name(capture_frame, metadata_scope_name)
+    assert owner_frame is not None
+    assert metadata_frame is not None
+    assert owner_frame["metrics"]["flops"] == 8.0
+    assert owner_frame["metrics"]["bytes"] == 64
+    assert _find_frame_by_name(metadata_frame, "<metric>") is not None
+    assert _find_frame_by_name(metadata_frame, "metadata_helper_kernel") is not None
 
 
 def test_hook_with_third_party(tmp_path: pathlib.Path, device: str):
@@ -1244,8 +1312,8 @@ def test_trace_cudagraph_graph_scope_ranges(tmp_path: pathlib.Path, device: str)
     foo_events = [event for event in replay_kernel_events if event["name"] == "foo"]
     metric_kernel_events = [event for event in replay_kernel_events if event["name"] == "<metric>"]
     metadata_kernel_events = [
-        event for event in replay_kernel_events
-        if COMPUTE_METADATA_SCOPE_NAME in event.get("args", {}).get("call_stack", [])
+        event for event in replay_kernel_events if any(
+            frame.startswith(COMPUTE_METADATA_SCOPE_NAME) for frame in event.get("args", {}).get("call_stack", []))
     ]
 
     assert len(foo_events) == 3

--- a/third_party/proton/test/test_profile.py
+++ b/third_party/proton/test/test_profile.py
@@ -1579,8 +1579,8 @@ def test_tensor_metrics_cudagraph(tmp_path: pathlib.Path, device: str):
         data = json.load(f)
 
     children = data[0]["children"]
-    # metadata scope + kernels + scope_a + scope_b + test0 + scope_d
-    assert len(children) == 8
+    # Warmup and graph-capture metadata scopes can add helper frames; validate
+    # the semantic frames below instead of pinning the root child count.
     test0_frame = None
     for child in children:
         if child["frame"]["name"] == "test0":
@@ -1603,6 +1603,9 @@ def test_tensor_metrics_cudagraph(tmp_path: pathlib.Path, device: str):
             scope_b_frame = child
         if child["frame"]["name"] == "scope_d":
             scope_d_frame = child
+    metadata_foo_test_frame = _find_frame_by_name(capture_at_frame, f"{COMPUTE_METADATA_SCOPE_NAME}:foo_test")
+    assert metadata_foo_test_frame is not None
+    assert _find_frame_by_name(metadata_foo_test_frame, "<metric>") is not None
     assert foo_test_frame is not None
     assert foo_test_frame["metrics"]["bytes"] == 160
     assert foo_test_frame["metrics"]["flops"] == 40


### PR DESCRIPTION
Depends on #10203.

## Summary
Group launch-metadata GPU work under a per-kernel metadata node while keeping roofline metrics on the compute kernel.

```text
compute_kernel_x                         # flops/bytes/util
__proton_launch_metadata:compute_kernel_x
  <metric>
  metadata_helper_kernel
```

## Changes
- Use `__proton_launch_metadata:<kernel>` as the metadata state name.
- Keep tensor metric conversion and metric-copy kernels under that metadata state.
- Link CUDA graph metric-copy values back to the compute kernel's `<metric>` target.
- Add a CUDA graph repro test for the profile shape above.

## Tests
- `pre-commit run --files <touched proton files>`
- `qnie-f33-16pods-0`: focused CUDA graph Proton tests -> `4 passed`
- `qnie-f33-16pods-0`: broader Proton suite -> `132 passed, 2 skipped, 2 deselected`
