### PR TITLE
[AMD][gfx1250] Drop ttg.async_commit_group from TDM async chain

### DIFF
--- a/test/TritonGPU/amd/amd-pipeline-tdm.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-tdm.mlir
@@ -60,14 +60,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // CHECK-LABEL: tt.func @matmul_kernel_make_tensor_descriptor
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<512x32xf16, #[[$PADDED_A]]> -> !ttg.memdesc<512x32xf16, #[[$PADDED_A]], #smem, mutable>
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<32x64xf16, #[[$PADDED_B]]> -> !ttg.memdesc<32x64xf16, #[[$PADDED_B]], #smem, mutable>
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: scf.for
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<512x32xf16, #[[$PADDED_A]]> -> !ttg.memdesc<512x32xf16, #[[$PADDED_A]], #smem, mutable>
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<32x64xf16, #[[$PADDED_B]]> -> !ttg.memdesc<32x64xf16, #[[$PADDED_B]], #smem, mutable>
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: }
 // CHECK: tt.descriptor_store {{.*}} : !tt.tensordesc<512x64xf16, #[[$PADDED_C]]>
 
@@ -135,12 +135,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // CHECK-LABEL: tt.func @tdm_padding_fp8
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<256x64xf8E5M2, #[[$PADDED_A]]> -> !ttg.memdesc<256x64xf8E5M2, #[[$PADDED_A]], #smem, mutable>
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<64x64xf8E5M2, #[[$PADDED_B]]> -> !ttg.memdesc<64x64xf8E5M2, #[[$PADDED_B]], #smem, mutable>
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: scf.for
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<256x64xf8E5M2, #[[$PADDED_A]]> -> !ttg.memdesc<256x64xf8E5M2, #[[$PADDED_A]], #smem, mutable>
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<64x64xf8E5M2, #[[$PADDED_B]]> -> !ttg.memdesc<64x64xf8E5M2, #[[$PADDED_B]], #smem, mutable>
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: }
 // CHECK: tt.descriptor_store {{.*}} : !tt.tensordesc<256x64xf16, #[[$PADDED_C]]>
 
@@ -207,12 +209,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // CHECK-LABEL: tt.func @tdm_padding_f32
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<256x16xf32, #[[$PADDED_A]]> -> !ttg.memdesc<256x16xf32, #[[$PADDED_A]], #smem, mutable>
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<16x64xf32, #[[$PADDED_B]]> -> !ttg.memdesc<16x64xf32, #[[$PADDED_B]], #smem, mutable>
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: scf.for
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<256x16xf32, #[[$PADDED_A]]> -> !ttg.memdesc<256x16xf32, #[[$PADDED_A]], #smem, mutable>
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: async_tdm_copy_global_to_local {{.*}} : !tt.tensordesc<16x64xf32, #[[$PADDED_B]]> -> !ttg.memdesc<16x64xf32, #[[$PADDED_B]], #smem, mutable>
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: }
 // CHECK: tt.descriptor_store {{.*}} : !tt.tensordesc<256x64xf32, #[[$PADDED_C]]>
 
@@ -272,13 +276,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK-LABEL: tt.func @gather_dot_pipeline
 // Prologue: two async_tdm_gather ops before the loop
 // CHECK: amdg.async_tdm_gather
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: amdg.async_tdm_gather
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // Loop body: two more async_tdm_gather ops (pipelined next iteration)
 // CHECK: scf.for
 // CHECK: amdg.async_tdm_gather
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: amdg.async_tdm_gather
-// CHECK: ttg.async_commit_group tokens
+// CHECK-NOT: ttg.async_commit_group
 // CHECK: }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -43,7 +43,6 @@ struct AsyncCopyChainOps {
 // gather) is type-erased because every consumer below only needs Operation *.
 struct TDMChainOps {
   Operation *tdmOp;
-  ttg::AsyncCommitGroupOp commitOp;
   triton::amdgpu::AsyncTDMWait waitOp;
   ttg::LocalLoadOp maybeLocalLoadOp;
 };
@@ -55,8 +54,7 @@ using LoadToStreamOpMap = llvm::MapVector<Operation *, StreamOpVariant>;
 // Shared skeleton for building a TDM chain:
 //   <buffer view> = createSingleBufferView(...)
 //   <tdmOp>       = buildTDMOp(builder, view, pred)   <- caller-supplied
-//   <commitOp>    = ttg::AsyncCommitGroupOp(tdmOp)
-//   <waitOp>      = amdgpu::AsyncTDMWait(commitOp)
+//   <waitOp>      = amdgpu::AsyncTDMWait(tdmOp)
 //   replace uses of original load with a local_load after waitOp
 TDMChainOps createTDMAsync(
     Operation *origLoad, Value alloc, Value extractIdx,
@@ -71,15 +69,13 @@ TDMChainOps createTDMAsync(
 
   Operation *tdmOp = buildTDMOp(builder, loc, viewLoad, pred);
 
-  auto commitOp =
-      ttg::AsyncCommitGroupOp::create(builder, loc, tdmOp->getResult(0));
   auto waitOp = triton::amdgpu::AsyncTDMWait::create(builder, loc,
-                                                     commitOp->getResult(0), 0);
+                                                     tdmOp->getResult(0), 0);
 
   auto maybeSharedLoad = tt::replaceUsesWithLocalLoad(
       builder, origLoad->getResult(0), viewLoad, waitOp);
 
-  return {tdmOp, commitOp, waitOp, maybeSharedLoad};
+  return {tdmOp, waitOp, maybeSharedLoad};
 }
 
 TDMChainOps createTDMAsyncCopy(tt::DescriptorLoadOp loadOp, Value alloc,
@@ -623,15 +619,12 @@ LogicalResult initSchedule(int maxDist, Stages &stages, int numStages,
   return success();
 }
 
-void scheduleTDMOps(Operation *tdmOp, Operation *commitOp, Operation *waitOp,
+void scheduleTDMOps(Operation *tdmOp, Operation *waitOp,
                     ttg::LocalLoadOp maybeLocalLoadOp, Operation *origLoadOp,
                     tt::CoarseSchedule &schedule, const Stages &stages,
                     const Clusters &clusters) {
   auto [loadStage, loadCluster] = schedule[origLoadOp];
   schedule.insert(tdmOp, loadStage, loadCluster);
-  // Place ttg.async_commit_group op in the same stage/cluster as the TDM op so
-  // the later UpdateAsyncWaitCount pass can deduce better waitcnts.
-  schedule.insert(commitOp, loadStage, loadCluster);
   // If the LocalLoads are scheduled to a later stage than AsyncCopy we need to
   // place the AsyncCopy prefetches after the AsyncWaits which create a barrier
   // to ensure all warps are finished reading the shared buffer we will write
@@ -695,9 +688,8 @@ void scheduleStreamOps(const LoadToStreamOpMap &loadToStreamOp,
                        const Clusters &clusters) {
   for (auto [l, streamOps] : loadToStreamOp) {
     if (auto asyncOps = std::get_if<TDMChainOps>(&streamOps)) {
-      auto [tdmOp, commitOp, waitOp, localLoad] = *asyncOps;
-      scheduleTDMOps(tdmOp, commitOp, waitOp, localLoad, l, schedule, stages,
-                     clusters);
+      auto [tdmOp, waitOp, localLoad] = *asyncOps;
+      scheduleTDMOps(tdmOp, waitOp, localLoad, l, schedule, stages, clusters);
     } else if (auto asyncOps = std::get_if<AsyncCopyChainOps>(&streamOps)) {
       auto loadOp = cast<tt::LoadOp>(l);
       scheduleAsyncCopy(*asyncOps, loadOp, schedule, stages, clusters);


### PR DESCRIPTION
- Remove the unnecessary `ttg.async_commit_group` from the TDM async chain. TDM ops (`async_tdm_copy_global_to_local`, `async_tdm_gather`) feed `amdgpu.async_tdm_wait` directly — they use a separate hardware counter from the generic async copy path, so the intervening commit group is unnecessary.
- Update `TDMChainOps` struct, `createTDMAsync`, `scheduleTDMOps`, and `scheduleStreamOps` in `LowerLoops.cpp` to remove the commit group plumbing.
- Update `amd-pipeline-tdm.mlir` lit test to verify `ttg.async_commit_group` is no longer emitted in TDM chains.