### PR TITLE
[AMD] Ignore tf32 precision for fp64 mfma dots

### DIFF
--- a/test/TritonGPU/amd/mfma-xf32.mlir
+++ b/test/TritonGPU/amd/mfma-xf32.mlir
@@ -37,3 +37,20 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
     tt.return
   }
 }
+
+// -----
+
+// CHECK-LABEL:mfma_f64_ignore_xf32
+
+#mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [16, 16, 4], isTransposed = true, elementBitWidth = 64}>
+#blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @mfma_f64_ignore_xf32(
+    %a: tensor<32x256xf64, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>>,
+    %b: tensor<256x32xf64, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>>) {
+    %zero_f64 = arith.constant dense<0.000000e+00> : tensor<32x32xf64, #mma>
+    // CHECK: rocdl.mfma.f64.16x16x4f64
+    %dot = tt.dot %a, %b, %zero_f64, inputPrecision = tf32 : tensor<32x256xf64, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 1}>> * tensor<256x32xf64, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 1}>> -> tensor<32x32xf64, #mma>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -495,9 +495,9 @@ struct DotOpMFMAConversionHelper {
           }
 
           // Step 2: process rawElems based on element type
-          // Note that for f32/fp64 input and XF32 is not allowed, nothing needs
+          // Note that for f32 and XF32 is not allowed or f64, nothing needs
           // to be done and rawElems is inserted into the ValueTable directly
-          if ((type.isF32() || type.isF64()) && !allowXF32) {
+          if ((type.isF32() && !allowXF32) || type.isF64()) {
             dotOpVals[{b, nonK, kBaseVec}] =
                 tb.extract_element(type, rawElems, tb.i32_val(0));
           } else {


### PR DESCRIPTION
Ensures we don't assert or generate invalid IR when packing elements for fp64 mfma intrinsic

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
