### PR TITLE
[ConSan] Fix missing captureBytes argument in passToWarpSpecialize call

### DIFF
--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -590,7 +590,7 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
                        {createInitStateTensor(b, {numCTAs}, 32, 1, fb),
                         getIntTensorType(entryRegion, {numCTAs}, 32)});
     passToWarpSpecialize(entryPoint, activeMasks.at(entryRegion), activeMasks,
-                         captureCounter);
+                         captureCounter, captureBytes);
 
     barrierWriteRecipients.insert(
         entryRegion,


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/10171 changed the API for passToWarpSpecialize. Need to update stale callsites.
