### PR TITLE
[AMD][gfx1250] Add transposed support for 32x16 scaled WMMA

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -141,12 +141,10 @@ LinearLayout chooseScaledMfmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
                                          ArrayRef<unsigned> tilesPerWarp,
                                          ArrayRef<unsigned> warpsPerCTA);
 
-LinearLayout chooseScaledWmmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
-                                         ArrayRef<int64_t> dotOperandShape,
-                                         unsigned wmmaMDim,
-                                         unsigned scaleFactor,
-                                         LinearLayout ctaLayout,
-                                         CGAEncodingAttr cgaLayout);
+LinearLayout chooseScaledWmmaScaleLayout(
+    MLIRContext *ctx, int dotOperandIdx, ArrayRef<int64_t> dotOperandShape,
+    unsigned wmmaMDim, unsigned wmmaNDim, bool isTransposed,
+    unsigned scaleFactor, LinearLayout ctaLayout, CGAEncodingAttr cgaLayout);
 
 LinearLayout getSM120DotScaledScaleLayout(MLIRContext *ctx,
                                           ArrayRef<int64_t> shape, int opIdx,

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -1250,6 +1250,11 @@ This simplifies both WMMA and dotOperand layouts lowering to linear layout.
       return {16, 16, 16};
     }
 
+    // Returns nonK dim of operand opIdx (swapped for asymmetric transposed WMMA).
+    unsigned getOperandNonKDim(unsigned opIdx) const;
+    static unsigned getOperandNonKDim(unsigned mDim, unsigned nDim,
+                                      bool isTransposed, unsigned opIdx);
+
     // Returns a swizzled shared layout matching this WMMA layout for the
     // dot operand at the given |operandIdx| with |operandShape|.
     SwizzledSharedEncodingAttr composeSharedLayoutForOperand(

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2679,6 +2679,23 @@ AMDWmmaEncodingAttr::getRepOrderForOperand(int opIdx) const {
   return getOrderForDotOperand(opIdx, getRank(), /*kContig*/ true);
 }
 
+// Captures the operand-swap for asymmetric isTransposed WMMA
+unsigned AMDWmmaEncodingAttr::getOperandNonKDim(unsigned mDim, unsigned nDim,
+                                                bool isTransposed,
+                                                unsigned opIdx) {
+  // opIdx=0 -> mDim, opIdx=1 -> nDim. Flipped for asymmetric WMMA with
+  // isTransposed=true as we must swap the operands and per-operand layouts
+  // must match the swap.
+  bool isFlip = isTransposed && (mDim != nDim);
+  unsigned eff = isFlip ? (1 - opIdx) : opIdx;
+  return eff == 0 ? mDim : nDim;
+}
+
+unsigned AMDWmmaEncodingAttr::getOperandNonKDim(unsigned opIdx) const {
+  auto mnk = getInstrShape();
+  return getOperandNonKDim(mnk[0], mnk[1], getIsTransposed(), opIdx);
+}
+
 SwizzledSharedEncodingAttr AMDWmmaEncodingAttr::composeSharedLayoutForOperand(
     CGAEncodingAttr cgaLayout, int operandIdx, ArrayRef<int64_t> operandShape,
     ArrayRef<unsigned> sharedOrder, unsigned kWidth, unsigned elemBitWidth,

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -826,7 +826,7 @@ LinearLayout wmmaDotOperandToLinearLayout(DotOperandEncodingAttr dotWmmaLayout,
 
   auto mnkDim = wmmaLayout.getInstrShape();
   auto kDim = mnkDim[2];
-  auto nonKDim = dotWmmaLayout.getOpIdx() == 0 ? mnkDim[0] : mnkDim[1];
+  auto nonKDim = wmmaLayout.getOperandNonKDim(dotWmmaLayout.getOpIdx());
   auto kWidth = dotWmmaLayout.getKWidth();
   constexpr int warpSize = 32;
 
@@ -1424,12 +1424,10 @@ chooseDsReadTrLayout(Attribute enc, ArrayRef<int64_t> shape,
                                  numLanesInShuffleGroup);
 }
 
-LinearLayout chooseScaledWmmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
-                                         ArrayRef<int64_t> dotOperandShape,
-                                         unsigned wmmaMDim,
-                                         unsigned scaleFactor,
-                                         LinearLayout ctaLayout,
-                                         CGAEncodingAttr cgaLayout) {
+LinearLayout chooseScaledWmmaScaleLayout(
+    MLIRContext *ctx, int dotOperandIdx, ArrayRef<int64_t> dotOperandShape,
+    unsigned wmmaMDim, unsigned wmmaNDim, bool isTransposed,
+    unsigned scaleFactor, LinearLayout ctaLayout, CGAEncodingAttr cgaLayout) {
   using basisT = std::vector<std::vector<int32_t>>;
   unsigned rank = dotOperandShape.size();
   bool hasBatchDim = rank == 3;
@@ -1448,9 +1446,11 @@ LinearLayout chooseScaledWmmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
   auto dimNonK = outDimNames[rank - 2];
 
   // Each lane holds kWidth=4(scale32) or kWidth=8(scale16) consecutive values
-  // along the K dim. The first 16 lanes are distributed along the nonK dim.
+  // along the K dim. The first nonKDim lanes are distributed along the nonK
+  // dim.
   constexpr unsigned warpSize = 32;
-  unsigned nonKDim = (dotOperandIdx == 0) ? wmmaMDim : 16;
+  unsigned nonKDim = AMDWmmaEncodingAttr::getOperandNonKDim(
+      wmmaMDim, wmmaNDim, isTransposed, dotOperandIdx);
   unsigned depth = warpSize / nonKDim;
   unsigned scaleKWidth = scaleFactor == 32 ? 4 : 8;
   auto kSize = dotOperandShape[1];

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1212,7 +1212,8 @@ void init_gluon_ir(py::module &&m) {
 
   m.def("get_amd_wmma_scale_layout",
         [](unsigned opIdx, std::vector<int64_t> &shape, unsigned wmmaMDim,
-           unsigned scaleFactor, std::vector<std::vector<int32_t>> &regBases,
+           unsigned wmmaNDim, bool isTransposed, unsigned scaleFactor,
+           std::vector<std::vector<int32_t>> &regBases,
            std::vector<std::vector<int32_t>> &warpBases,
            std::vector<std::vector<int32_t>> &cgaBases) -> py::object {
           DialectRegistry registry;
@@ -1230,7 +1231,8 @@ void init_gluon_ir(py::module &&m) {
                                tt::standardOutDimNames(&ctx, rank));
           auto cgaLayout = buildCgaLayoutAttr(&ctx, cgaBases, rank);
           auto ll = ttg::chooseScaledWmmaScaleLayout(
-              &ctx, opIdx, shape, wmmaMDim, scaleFactor, ctaLayout, cgaLayout);
+              &ctx, opIdx, shape, wmmaMDim, wmmaNDim, isTransposed, scaleFactor,
+              ctaLayout, cgaLayout);
           auto attr = ttg::LinearEncodingAttr::get(&ctx, ll);
           return layoutToGluon(attr);
         });

--- a/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
@@ -148,7 +148,10 @@ def get_wmma_scale_layout(dot_operand_layout, shape, scale_factor=32):
     parent = dot_operand_layout.parent
     assert isinstance(parent, AMDWMMALayout), "Expected parent to be an instance of AMDWMMALayout"
     mdim = parent.instr_shape[0]
+    ndim = parent.instr_shape[1]
+    transposed = parent.transposed
     reg_bases = parent.reg_bases
     warp_bases = parent.warp_bases
     cga_bases = parent.cga_layout
-    return _get_wmma_scale_layout_impl(op_idx, shape, mdim, scale_factor, reg_bases, warp_bases, cga_bases)
+    return _get_wmma_scale_layout_impl(op_idx, shape, mdim, ndim, transposed, scale_factor, reg_bases, warp_bases,
+                                       cga_bases)

--- a/test/Conversion/amd/tritongpu_wmma_dot_scaled_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_wmma_dot_scaled_to_llvm.mlir
@@ -277,3 +277,45 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// 32x16 WMMA with isTranspose=true
+// Scale A 16 lanes cover M, 1 broadcast bit.
+#linear = #ttg.linear<{register = [[0, 1], [0, 2]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 0]], warp = [[0, 0], [16, 0]], block = []}>
+// Scale B 32 lanes cover N, no broadcast.
+#linear1 = #ttg.linear<{register = [[0, 1], [0, 2]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [0, 0]], block = []}>
+#mma = #ttg.amd_wmma<{version = 3, ctaLayout = {warp = [[0, 1], [1, 0]]}, isTranspose = true, instrShape=[32, 16, 128]}>
+#mma1 = #ttg.amd_wmma<{version = 3, ctaLayout = {warp = [[0, 1], [1, 0]]}, isTranspose = true, instrShape=[32, 16, 64]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: wmma_scaled_dot_fp4_32x16_transposed
+  tt.func @wmma_scaled_dot_fp4_32x16_transposed(%arg0: tensor<32x64xi8, #ttg.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>>, %arg1: tensor<32x4xi8, #linear>, %arg2: tensor<64x64xi8, #ttg.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>>, %arg3: tensor<64x4xi8, #linear1>, %out0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x64xf32, #mma>
+    // Matrix C
+    // CHECK-COUNT-16: llvm.insertelement {{.*}} : vector<16xf32>
+    // Matrix A (frontend A -> slot-2, kBase=32 i8 after swap; vector<32xi8>)
+    // CHECK-COUNT-32: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
+    // CHECK-COUNT-32: llvm.insertelement {{.*}} : vector<32xi8>
+    // CHECK: llvm.bitcast {{.*}} : vector<32xi8> to vector<8xi32>
+    // Matrix B (frontend B -> slot-1, kBase=64 i8 after swap; vector<64xi8>)
+    // CHECK-COUNT-64: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
+    // CHECK-COUNT-64: llvm.insertelement {{.*}} : vector<64xi8>
+    // CHECK: llvm.bitcast {{.*}} : vector<64xi8> to vector<16xi32>
+    // Scale A
+    // CHECK-COUNT-4: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8, i8, i8)>
+    // CHECK-COUNT-4: llvm.insertelement {{.*}} : vector<4xi8>
+    // CHECK: llvm.bitcast {{.*}} : vector<4xi8> to i32
+    // Scale B
+    // CHECK-COUNT-4: llvm.extractvalue {{.*}} : !llvm.struct<(i8, i8, i8, i8)>
+    // CHECK-COUNT-4: llvm.insertelement {{.*}} : vector<4xi8>
+    // CHECK: llvm.bitcast {{.*}} : vector<4xi8> to i32
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.wmma.scale.f32.32x16x128.f4"{{.*}} : (vector<16xi32>, vector<8xi32>, i16, vector<16xf32>, i32, i32, i32, i32, i32, i32, i1, i1) -> vector<16xf32>
+    %c = tt.dot_scaled %arg0 scale %arg1, %arg2 scale %arg3, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<32x64xi8, #ttg.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>>, tensor<32x4xi8, #linear> * tensor<64x64xi8, #ttg.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>>, tensor<64x4xi8, #linear1> -> tensor<32x64xf32, #mma>
+    // CHECK-COUNT-16: llvm.extractelement {{.*}} : vector<16xf32>
+    // CHECK-COUNT-16: llvm.insertelement {{.*}} : vector<1xf32>
+    %ptr0 = tt.splat %out0 : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>, #mma>
+    tt.store %ptr0, %c : tensor<32x64x!tt.ptr<f32>, #mma>
+    tt.return
+  }
+}

--- a/third_party/amd/include/TritonAMDGPUTransforms/WmmaGroup.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/WmmaGroup.h
@@ -49,7 +49,7 @@ struct WmmaScaleIntrinsic {
   static FailureOr<WmmaScaleIntrinsic> get(int version, unsigned mDim,
                                            unsigned nDim, Type aElemType,
                                            Type bElemType, Type dElemType,
-                                           bool isScale16);
+                                           bool isScale16, bool isTransposed);
 
   WmmaScaleIntrinsic(StringRef symbol, unsigned m, unsigned n, unsigned kDim,
                      unsigned kBaseAVal, unsigned kBaseBVal, Type dET)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -98,7 +98,7 @@ static int computeKPadding(int kBase, int64_t tensorK,
   // means if tensorK is smaller than one k repetition we get broadcasts in the
   // lane dimension so we have tensorK valid elements per nonKRepeat subtile.
   constexpr int wmmaTileDim = 16;
-  int nonKDim = dotEnc.getOpIdx() == 0 ? mnkDim[0] : mnkDim[1];
+  int nonKDim = wmmaLayout.getOperandNonKDim(dotEnc.getOpIdx());
   int nonKRepeat = nonKDim / wmmaTileDim;
   int lanesInKDim = warpSize / wmmaTileDim;
   int elemsPerKRep = lanesInKDim * dotEnc.getKWidth();
@@ -213,8 +213,7 @@ Value getOperandVals(ConversionPatternRewriter &rewriter,
   // Padding must be applied per-subtile so each nonK half is padded
   // independently.
   auto wmmaLayout = cast<AMDWmmaEncodingAttr>(dotEnc.getParent());
-  auto mnkDim = wmmaLayout.getInstrShape();
-  int nonKDim = dotEnc.getOpIdx() == 0 ? mnkDim[0] : mnkDim[1];
+  int nonKDim = wmmaLayout.getOperandNonKDim(dotEnc.getOpIdx());
   const int nonKTileDim = 16;
   int nonKRepeat = nonKDim / nonKTileDim;
   int kPerSubtile = kBase / nonKRepeat;
@@ -580,6 +579,16 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
   return success();
 }
 
+// For asymmetric WMMA (e.g. 32x16) with isTransposed=true the dot's operand A
+// is 16xK and operand B is Kx32, but the intrinsic expects A as 32xK and B as
+// Kx16, so we swap A and B and adjust the layouts for the operands and scale
+// accordingly:
+//  - layout adjustment uses AMDWmmaEncodingAttr::getOperandNonKDim which
+//    returns the swapped nonK dim for asymmetric transposed WMMA
+//  - WmmaScaleIntrinsic::get returns swapped kBaseA and kBaseB for
+//    asymmetric transposed WMMA
+//  - Intrinsic call created with (hb, sb, ha, sa) matches the expected LLVM
+//  types
 LogicalResult convertScaledDot(triton::DotScaledOp op,
                                triton::DotScaledOp::Adaptor adaptor,
                                ConversionPatternRewriter &rewriter,
@@ -634,7 +643,8 @@ LogicalResult convertScaledDot(triton::DotScaledOp op,
   FailureOr<WmmaScaleIntrinsic> maybeWmmaScaleIntrinsic =
       WmmaScaleIntrinsic::get(wmmaVer, mnkDim[0], mnkDim[1], scaledAElemType,
                               scaledBElemType, dTensorTy.getElementType(),
-                              (scaleFactor == 16) /*isScale16*/);
+                              (scaleFactor == 16) /*isScale16*/,
+                              wmmaLayout.getIsTransposed());
   if (failed(maybeWmmaScaleIntrinsic)) {
     return op.emitError("no matching wmma scale intrinsic ")
            << "for wmma version " << wmmaVer << " with instruction shape ["

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1247,7 +1247,8 @@ public:
       }
 
       LinearLayout newLL = ttg::chooseScaledWmmaScaleLayout(
-          ctx, idx, shape, mDim, scaleFactor, ctaLayout, cgaLayout);
+          ctx, idx, shape, mDim, nDim, wmmaEnc.getIsTransposed(), scaleFactor,
+          ctaLayout, cgaLayout);
       Attribute newScaleEncoding = ttg::LinearEncodingAttr::get(ctx, newLL);
       auto newScaleType =
           RankedTensorType::get(shape, scaleType, newScaleEncoding);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/WmmaGroup.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/WmmaGroup.cpp
@@ -321,7 +321,7 @@ getIntrinsicFamily(Type aElemType, Type bElemType, unsigned mDim) {
 FailureOr<WmmaScaleIntrinsic>
 WmmaScaleIntrinsic::get(int version, unsigned mDim, unsigned nDim,
                         Type aElemType, Type bElemType, Type dElemType,
-                        bool isScale16) {
+                        bool isScale16, bool isTransposed) {
   const auto intrinsicFamily = getIntrinsicFamily(aElemType, bElemType, mDim);
   const WmmaScaleMap &wmmaScaleMap =
       WmmaScaleDatabase::get(dElemType.getContext());
@@ -337,6 +337,9 @@ WmmaScaleIntrinsic::get(int version, unsigned mDim, unsigned nDim,
   auto [symbol, kDim] = values.back();
   auto [kBaseA, kBaseB] =
       kBaseForWmmaScale(aElemType, bElemType, mDim, nDim, kDim);
+  // On asymmetric and transposed we swap the operands, layouts and kBase.
+  if (isTransposed && mDim != nDim)
+    std::swap(kBaseA, kBaseB);
   return WmmaScaleIntrinsic(symbol, mDim, nDim, kDim, kBaseA, kBaseB,
                             dElemType);
 }

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -907,6 +907,7 @@ def get_test_mxfp_variants():
 
 @pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("wmma_shape", [(16, 16), (32, 16)])
+@pytest.mark.parametrize("transposed", [False, True])
 @pytest.mark.parametrize(
     "M, N, K",
     get_test_mxfp_block_mnk() +
@@ -918,8 +919,8 @@ def get_test_mxfp_variants():
 @pytest.mark.parametrize("a_scale_type, b_scale_type", itertools.product(["e8m0", "e4m3"], repeat=2))
 @pytest.mark.parametrize("scale_factor", [16, 32])
 @pytest.mark.parametrize("with_a_scale, with_b_scale", itertools.product([True, False], repeat=2))
-def test_amd_wmma_scaled(wmma_shape, M, N, K, a_type, b_type, a_scale_type, b_scale_type, scale_factor, with_a_scale,
-                         with_b_scale):
+def test_amd_wmma_scaled(wmma_shape, transposed, M, N, K, a_type, b_type, a_scale_type, b_scale_type, scale_factor,
+                         with_a_scale, with_b_scale):
     instr_m, instr_n = wmma_shape
 
     if instr_m == 32:
@@ -930,10 +931,10 @@ def test_amd_wmma_scaled(wmma_shape, M, N, K, a_type, b_type, a_scale_type, b_sc
     def kernel(c_ptr, a_ptr, a_scale_ptr, b_ptr, b_scale_ptr,  #
                a_type: ttgl.constexpr, b_type: ttgl.constexpr,  #
                BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr,  #
-               SCALE_FACTOR: ttgl.constexpr, INSTR_SHAPE_M: ttgl.constexpr, INSTR_SHAPE_N: ttgl.constexpr):
+               SCALE_FACTOR: ttgl.constexpr, INSTR_SHAPE_M: ttgl.constexpr, INSTR_SHAPE_N: ttgl.constexpr,  #
+               TRANSPOSED: ttgl.constexpr):
         DIV_FACTOR_A: ttgl.constexpr = 2 if a_type == "e2m1" else 1
         DIV_FACTOR_B: ttgl.constexpr = 2 if b_type == "e2m1" else 1
-        TRANSPOSED: ttgl.constexpr = INSTR_SHAPE_M == INSTR_SHAPE_N
 
         wmma_layout: ttgl.constexpr = ttgl.amd.AMDWMMALayout(  #
             version=3, transposed=TRANSPOSED, warp_bases=[[0, 1], [1, 0]],
@@ -1002,7 +1003,8 @@ def test_amd_wmma_scaled(wmma_shape, M, N, K, a_type, b_type, a_scale_type, b_sc
         b_scale_ref = 1.0
 
     c = torch.zeros((M, N), dtype=torch.float32).cuda()
-    pgm = kernel[(1, )](c, a, a_scale, b, b_scale, a_type, b_type, M, N, K, scale_factor, instr_m, instr_n, num_warps=4)
+    pgm = kernel[(1, )](c, a, a_scale, b, b_scale, a_type, b_type, M, N, K, scale_factor, instr_m, instr_n, transposed,
+                        num_warps=4)
 
     no_scales = not with_a_scale and not with_b_scale
 


### PR DESCRIPTION
- Add transposed support for asymmetric WMMA instruction shape (32x16)
- Support for FP4 scaled wmma
- Add lit tests and gluon tests for validation