### PR TITLE
[AMD][GFX1250][FA-BF16] Bug fix: Reorder TDM in Prologue to match the loop body

### DIFF
--- a/third_party/amd/python/examples/gluon/f16_fa_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_fa_gfx1250.py
@@ -545,9 +545,9 @@ def attn_fwd_pipelined_kernel(q_ptr, k_ptr, v_ptr, out_ptr,  #
     # SM0_t0
     p, alpha, m_i = pgm.softmax_part0(qk, m_i)
 
-    # GLDS_V_t1, GLDS_K_t2
-    pgm.tdm_load_global_to_shared_v([BLOCK_N, 0], buffer_index=1)
+    # GLDS_K_t2, GLDS_V_t1,
     pgm.tdm_load_global_to_shared_k([2 * BLOCK_N, 0], buffer_index=0)
+    pgm.tdm_load_global_to_shared_v([BLOCK_N, 0], buffer_index=1)
 
     # LR_K_t1
     k = pgm.tdm_shared_load_k(1, wait_count=3)
@@ -724,9 +724,9 @@ def attn_fwd_pingpong_pipelined_kernel(q_ptr, k_ptr, v_ptr, out_ptr,  #
     # SM0_t0
     p, alpha, m_i = pgm.softmax_part0(qk, m_i)
 
-    # GLDS_V_t1, GLDS_K_t2
-    pgm.tdm_load_global_to_shared_v([BLOCK_N, 0], buffer_index=1)
+    # GLDS_K_t2, GLDS_V_t1
     pgm.tdm_load_global_to_shared_k([2 * BLOCK_N, 0], buffer_index=0)
+    pgm.tdm_load_global_to_shared_v([BLOCK_N, 0], buffer_index=1)
 
     # LR_K_t1
     k = pgm.tdm_shared_load_k(1, wait_count=3)


### PR DESCRIPTION
This PR fixes a bug in BF16 FA kernel related to the mismatch between TDM wait and issue order.
# Details
In the existing BF16 FA code, after prologue is done, we have the following TDM queue, from oldest to newest:

`v0_b0, v1_b1, k2_b0`  Format: `({k,v}{index}_b{buffer_index}`

However, in the loop, we consume v and k in order.

For the follwing line, we have a potential bug:

```
# MISTAKE: top of the loop is v1_b1, not k2_b0
# TDM before: v1_b1, k2_b0, k3_b1
k = pgm.tdm_shared_load_k(iter_id % NUM_BUFFERS, wait_count=2)
# TDM after: k2_b0, k3_b1
```
I think this bug doesnt lead to tests failure because of the large gap between queuing and waiting, so since both `v1_b1`, `k2_b0` likely to arrive at LDS before reading, this bug doesnt manifest itself.

For fixing, I reordered the last 2 TDM issues in the prologue, hence the TDM queue becomes the following before the loop:
`v0_b0, k2_b0, v1_b1` 

Hence, in the loop:
```
# TDM before: k2_b0, v1_b1, k3_b1
k = pgm.tdm_shared_load_k(iter_id % NUM_BUFFERS, wait_count=2)
# TDM after: v1_b1, k3_b1
```
We wait for the right data to finish arriving.

This doesn't change the TDM queue for the steady state:

TDM queue before the loop:
`v0_b0, k2_b0, v1_b1
`
After one iteration:
`v1_b1, k3_b1, v2_b0`

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because they already exist.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
