### PR TITLE
[AMD][gfx1250] Add `update_tensor_descriptor` op

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1064,13 +1064,13 @@ void init_gluon_ir(py::module &&m) {
              self.create<ttag::AsyncTDMCopyLocalToGlobalOp>(
                  descPtr, indices, src, barrier, cacheModifier);
            })
-      .def("create_advance_tdm_desc",
-           [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &offsets,
-              std::vector<Value> &bounds, Value lds, Value pred,
-              Value barrier) -> Value {
-             return self.create<ttag::AdvanceTDMDescOp>(
-                 descPtr.getType(), descPtr, ValueRange(offsets),
-                 ValueRange(bounds), lds, pred, barrier);
+      .def("create_update_tensor_descriptor",
+           [](GluonOpBuilder &self, Value descPtr,
+              std::vector<Value> &addOffsets, std::vector<Value> &setBounds,
+              Value dest, Value pred, Value barrier) -> Value {
+             return self.create<ttag::UpdateTensorDescriptorOp>(
+                 descPtr.getType(), descPtr, ValueRange(addOffsets),
+                 ValueRange(setBounds), dest, pred, barrier);
            })
       .def("create_async_tdm_scatter",
            [](GluonOpBuilder &self, Value descPtr, Value dstRowIndices,

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1064,6 +1064,14 @@ void init_gluon_ir(py::module &&m) {
              self.create<ttag::AsyncTDMCopyLocalToGlobalOp>(
                  descPtr, indices, src, barrier, cacheModifier);
            })
+      .def("create_advance_tdm_desc",
+           [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &offsets,
+              std::vector<Value> &bounds, Value lds, Value pred,
+              Value barrier) -> Value {
+             return self.create<ttag::AdvanceTDMDescOp>(
+                 descPtr.getType(), descPtr, ValueRange(offsets),
+                 ValueRange(bounds), lds, pred, barrier);
+           })
       .def("create_async_tdm_scatter",
            [](GluonOpBuilder &self, Value descPtr, Value dstRowIndices,
               Value dstColOffset, Value src, Value barrier) {

--- a/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
     from triton.experimental.gluon.language._core import shared_memory_descriptor
 
 __all__ = [
-    "advance", "async_load", "async_wait", "make_tensor_descriptor", "tensor_descriptor", "tensor_descriptor_type",
-    "prefetch", "async_scatter"
+    "update_tensor_descriptor", "async_load", "async_wait", "make_tensor_descriptor", "tensor_descriptor",
+    "tensor_descriptor_type", "prefetch", "async_scatter"
 ]
 
 
@@ -143,25 +143,26 @@ def make_tensor_descriptor(base: ttgl.tensor, shape: List[ttgl.constexpr | ttgl.
 
 
 @builtin
-def advance(desc: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tensor] = None,
-            bounds: List[ttgl.constexpr | ttgl.tensor] = None, dest: shared_memory_descriptor = None, pred=None,
-            barrier: shared_memory_descriptor = None, _semantic=None) -> tensor_descriptor:
+def update_tensor_descriptor(desc: tensor_descriptor, add_offsets: List[ttgl.constexpr | ttgl.tensor] = None,
+                             set_bounds: List[ttgl.constexpr | ttgl.tensor] = None,
+                             dest: shared_memory_descriptor = None, pred=None, barrier: shared_memory_descriptor = None,
+                             _semantic=None) -> tensor_descriptor:
     """Update selected fields of a TDM descriptor; return a new descriptor SSA value.
 
     Each parameter is independently optional; only the fields the caller
     names are written.  Everything else is inherited from the input
     descriptor.
 
-    NOTE: Unlike the standard tensor-descriptor mental model, `offsets`
+    NOTE: Unlike the standard tensor-descriptor mental model, `add_offsets`
     here moves the tile position only.  It does NOT update the descriptor's
     bounds.  If the loop crosses an OOB boundary, you must also pass
-    `bounds` explicitly to install the correct OOB extent.
+    `set_bounds` explicitly to install the correct OOB extent.
 
     Args:
         desc (tensor_descriptor): the input descriptor.
-        offsets (List[int], optional): per-dim deltas in element units that
-            move the tile position.  Does not touch the bounds.
-        bounds (List[int], optional): per-dim absolute rewrite of the
+        add_offsets (List[int], optional): per-dim deltas in element units
+            that move the tile position.  Does not touch the bounds.
+        set_bounds (List[int], optional): per-dim absolute rewrite of the
             descriptor's bounds.  Use to install OOB extent at a peel
             epilogue.
         dest (shared_memory_descriptor, optional): set the descriptor's
@@ -175,36 +176,36 @@ def advance(desc: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tensor]
         fields rewritten.
 
     Raises:
-        ValueError: if no parameter is provided (no-op advances are forbidden).
+        ValueError: if no parameter is provided (no-op updates are forbidden).
 
     Example:
         # K-loop interior: bump tile position only
-        d = tdm.advance(d, offsets=[0, BLOCK_K])
+        d = tdm.update_tensor_descriptor(d, add_offsets=[0, BLOCK_K])
 
         # Prologue: position at first tile + wire LDS and barrier
-        d = tdm.advance(d, offsets=[pid_m * BLOCK_M, 0],
-                        dest=a_shared, barrier=a_bar)
+        d = tdm.update_tensor_descriptor(d, add_offsets=[pid_m * BLOCK_M, 0],
+                                         dest=a_shared, barrier=a_bar)
 
         # Peel epilogue: install real OOB extent for the partial last tile
-        d = tdm.advance(d, bounds=[M - pid_m * BLOCK_M, K - k_main])
+        d = tdm.update_tensor_descriptor(d, set_bounds=[M - pid_m * BLOCK_M, K - k_main])
     """
-    if offsets is None and bounds is None and dest is None and pred is None and barrier is None:
-        raise ValueError("tdm.advance requires at least one of offsets, bounds, "
-                         "dest, pred, barrier")
+    if add_offsets is None and set_bounds is None and dest is None and pred is None and barrier is None:
+        raise ValueError("tdm.update_tensor_descriptor requires at least one of add_offsets, "
+                         "set_bounds, dest, pred, barrier")
 
     rank = len(desc.block_shape)
 
-    offset_handles = []
-    if offsets is not None:
-        if len(offsets) != rank:
-            raise ValueError(f"offsets must have length {rank} (descriptor rank), got {len(offsets)}")
-        offset_handles = _semantic._convert_to_ir_values(offsets, require_i64=False)
+    add_offset_handles = []
+    if add_offsets is not None:
+        if len(add_offsets) != rank:
+            raise ValueError(f"add_offsets must have length {rank} (descriptor rank), got {len(add_offsets)}")
+        add_offset_handles = _semantic._convert_to_ir_values(add_offsets, require_i64=False)
 
-    bounds_handles = []
-    if bounds is not None:
-        if len(bounds) != rank:
-            raise ValueError(f"bounds must have length {rank} (descriptor rank), got {len(bounds)}")
-        bounds_handles = _semantic._convert_to_ir_values(bounds, require_i64=False)
+    set_bounds_handles = []
+    if set_bounds is not None:
+        if len(set_bounds) != rank:
+            raise ValueError(f"set_bounds must have length {rank} (descriptor rank), got {len(set_bounds)}")
+        set_bounds_handles = _semantic._convert_to_ir_values(set_bounds, require_i64=False)
 
     dest = _unwrap_if_constexpr(dest)
     dest_handle = dest.handle if dest is not None else ttgl.ir.value()
@@ -217,8 +218,8 @@ def advance(desc: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tensor]
     barrier = _unwrap_if_constexpr(barrier)
     barrier_handle = barrier.handle if barrier is not None else ttgl.ir.value()
 
-    new_handle = _semantic.builder.create_advance_tdm_desc(desc.handle, offset_handles, bounds_handles, dest_handle,
-                                                           pred_handle, barrier_handle)
+    new_handle = _semantic.builder.create_update_tensor_descriptor(desc.handle, add_offset_handles, set_bounds_handles,
+                                                                   dest_handle, pred_handle, barrier_handle)
     # Rebuild shape/strides tuples so the returned descriptor's tuple objects
     # don't alias the original's (the frontend's SSA tracking assumes distinct
     # tuples per descriptor value).

--- a/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
     from triton.experimental.gluon.language._core import shared_memory_descriptor
 
 __all__ = [
-    "async_load", "async_wait", "make_tensor_descriptor", "tensor_descriptor", "tensor_descriptor_type", "prefetch",
-    "async_scatter"
+    "advance", "async_load", "async_wait", "make_tensor_descriptor", "tensor_descriptor", "tensor_descriptor_type",
+    "prefetch", "async_scatter"
 ]
 
 
@@ -140,6 +140,91 @@ def make_tensor_descriptor(base: ttgl.tensor, shape: List[ttgl.constexpr | ttgl.
                                                              stride_handles, padding)
 
     return tensor_descriptor(handle, shape, strides, type)
+
+
+@builtin
+def advance(desc: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tensor] = None,
+            bounds: List[ttgl.constexpr | ttgl.tensor] = None, dest: shared_memory_descriptor = None, pred=None,
+            barrier: shared_memory_descriptor = None, _semantic=None) -> tensor_descriptor:
+    """Update selected fields of a TDM descriptor; return a new descriptor SSA value.
+
+    Each parameter is independently optional; only the fields the caller
+    names are written.  Everything else is inherited from the input
+    descriptor.
+
+    NOTE: Unlike the standard tensor-descriptor mental model, `offsets`
+    here moves the tile position only.  It does NOT update the descriptor's
+    bounds.  If the loop crosses an OOB boundary, you must also pass
+    `bounds` explicitly to install the correct OOB extent.
+
+    Args:
+        desc (tensor_descriptor): the input descriptor.
+        offsets (List[int], optional): per-dim deltas in element units that
+            move the tile position.  Does not touch the bounds.
+        bounds (List[int], optional): per-dim absolute rewrite of the
+            descriptor's bounds.  Use to install OOB extent at a peel
+            epilogue.
+        dest (shared_memory_descriptor, optional): set the descriptor's
+            shared-memory slot used by subsequent loads/stores.
+        pred (int, optional): set the descriptor's predicate.
+        barrier (shared_memory_descriptor, optional): enable barrier
+            signaling on this descriptor and set the barrier address.
+
+    Returns:
+        tensor_descriptor: a new descriptor SSA value with the requested
+        fields rewritten.
+
+    Raises:
+        ValueError: if no parameter is provided (no-op advances are forbidden).
+
+    Example:
+        # K-loop interior: bump tile position only
+        d = tdm.advance(d, offsets=[0, BLOCK_K])
+
+        # Prologue: position at first tile + wire LDS and barrier
+        d = tdm.advance(d, offsets=[pid_m * BLOCK_M, 0],
+                        dest=a_shared, barrier=a_bar)
+
+        # Peel epilogue: install real OOB extent for the partial last tile
+        d = tdm.advance(d, bounds=[M - pid_m * BLOCK_M, K - k_main])
+    """
+    if offsets is None and bounds is None and dest is None and pred is None and barrier is None:
+        raise ValueError("tdm.advance requires at least one of offsets, bounds, "
+                         "dest, pred, barrier")
+
+    rank = len(desc.block_shape)
+
+    offset_handles = []
+    if offsets is not None:
+        if len(offsets) != rank:
+            raise ValueError(f"offsets must have length {rank} (descriptor rank), got {len(offsets)}")
+        offset_handles = _semantic._convert_to_ir_values(offsets, require_i64=False)
+
+    bounds_handles = []
+    if bounds is not None:
+        if len(bounds) != rank:
+            raise ValueError(f"bounds must have length {rank} (descriptor rank), got {len(bounds)}")
+        bounds_handles = _semantic._convert_to_ir_values(bounds, require_i64=False)
+
+    dest = _unwrap_if_constexpr(dest)
+    dest_handle = dest.handle if dest is not None else ttgl.ir.value()
+
+    pred_handle = ttgl.ir.value()
+    if pred is not None:
+        pred_t = _semantic.to_tensor(pred)
+        pred_handle = pred_t.handle
+
+    barrier = _unwrap_if_constexpr(barrier)
+    barrier_handle = barrier.handle if barrier is not None else ttgl.ir.value()
+
+    new_handle = _semantic.builder.create_advance_tdm_desc(desc.handle, offset_handles, bounds_handles, dest_handle,
+                                                           pred_handle, barrier_handle)
+    # Rebuild shape/strides tuples so the returned descriptor's tuple objects
+    # don't alias the original's (the frontend's SSA tracking assumes distinct
+    # tuples per descriptor value).
+    new_shape = ttgl.tuple(list(desc.shape))
+    new_strides = ttgl.tuple(list(desc.strides))
+    return tensor_descriptor(new_handle, new_shape, new_strides, desc.type)
 
 
 @builtin

--- a/test/Conversion/amd/tritongpu_tdm_advance.mlir
+++ b/test/Conversion/amd/tritongpu_tdm_advance.mlir
@@ -1,0 +1,145 @@
+// RUN: triton-opt %s --split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 | FileCheck %s
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: advance_offsets_only
+  // The offsets kwarg bumps global_addr: offsets are sext'd (signed), stride
+  // is zext'd (unsigned), multiplied in i64 (so offsets[0]*stride doesn't
+  // overflow i32), added to global_addr, then re-packed into group0[2..3].
+  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK-DAG: llvm.sext{{.*}}i32 to i64
+  // CHECK-DAG: llvm.zext{{.*}}i32 to i64
+  // CHECK: llvm.mul{{.*}}: i64
+  // CHECK: llvm.add{{.*}}: i64
+  // CHECK: llvm.insertelement{{.*}}vector<4xi32>
+  tt.func public @advance_offsets_only(
+      %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %dx: i32, %dy: i32)
+      -> !tt.tensordesc<64x64xf16, #shared> {
+    %c_shape = arith.constant 128 : i32
+    %c_stride0 = arith.constant 128 : i64
+    %c_stride1 = arith.constant 1 : i64
+    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
+    %1 = amdg.tdm_advance_descriptor %0 offsets = [%dx, %dy] : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: advance_bounds_only
+  // The bounds kwarg writes tensor_dim (lo16/hi16 across group1[1..3]).
+  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK: llvm.insertelement{{.*}}vector<8xi32>
+  tt.func public @advance_bounds_only(
+      %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %m: i32, %k: i32)
+      -> !tt.tensordesc<64x64xf16, #shared> {
+    %c_shape = arith.constant 128 : i32
+    %c_stride0 = arith.constant 128 : i64
+    %c_stride1 = arith.constant 1 : i64
+    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
+    %1 = amdg.tdm_advance_descriptor %0 bounds = [%m, %k] : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: advance_dest_only
+  // The dest parameter ptrtoints the smem ptr and stamps into group0[1].
+  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK: llvm.ptrtoint
+  // CHECK: llvm.insertelement{{.*}}vector<4xi32>
+  tt.func public @advance_dest_only(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32})
+      -> !tt.tensordesc<64x64xf16, #shared> {
+    %c_shape = arith.constant 128 : i32
+    %c_stride0 = arith.constant 128 : i64
+    %c_stride1 = arith.constant 1 : i64
+    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
+    %lds = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %1 = amdg.tdm_advance_descriptor %0 dest = %lds : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: advance_pred_only
+  // The pred kwarg stamps into group0[0].
+  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK: llvm.insertelement{{.*}}vector<4xi32>
+  tt.func public @advance_pred_only(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %p: i32)
+      -> !tt.tensordesc<64x64xf16, #shared> {
+    %c_shape = arith.constant 128 : i32
+    %c_stride0 = arith.constant 128 : i64
+    %c_stride1 = arith.constant 1 : i64
+    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
+    %1 = amdg.tdm_advance_descriptor %0 pred = %p : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: advance_barrier_only
+  // The barrier kwarg ptrtoints the barrier ptr, shifts and stamps into
+  // group1[1] lo-16 plus the enable bit (group1[0] bit 18).
+  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK: llvm.ptrtoint
+  // CHECK: llvm.insertelement{{.*}}vector<8xi32>
+  tt.func public @advance_barrier_only(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32})
+      -> !tt.tensordesc<64x64xf16, #shared> {
+    %c_shape = arith.constant 128 : i32
+    %c_stride0 = arith.constant 128 : i64
+    %c_stride1 = arith.constant 1 : i64
+    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    %1 = amdg.tdm_advance_descriptor %0 barrier = %bar : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable> : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: advance_prologue
+  // The K-loop prologue pattern: position at first tile + wire LDS + barrier + pred.
+  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK: llvm.ptrtoint
+  // CHECK: llvm.add{{.*}}: i64
+  // CHECK: llvm.insertelement{{.*}}vector<4xi32>
+  // CHECK: llvm.insertelement{{.*}}vector<8xi32>
+  tt.func public @advance_prologue(
+      %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %dx: i32, %dy: i32, %p: i32) -> !tt.tensordesc<64x64xf16, #shared> {
+    %c_shape = arith.constant 128 : i32
+    %c_stride0 = arith.constant 128 : i64
+    %c_stride1 = arith.constant 1 : i64
+    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
+    %lds = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    %1 = amdg.tdm_advance_descriptor %0
+            offsets = [%dx, %dy]
+            dest = %lds : !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+            pred = %p
+            barrier = %bar : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+            : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
+  }
+}

--- a/test/Conversion/amd/tritongpu_update_tensor_descriptor.mlir
+++ b/test/Conversion/amd/tritongpu_update_tensor_descriptor.mlir
@@ -3,24 +3,24 @@
 #shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: advance_offsets_only
+  // CHECK-LABEL: update_tensor_descriptor_offsets_only
   // The offsets kwarg bumps global_addr: offsets are sext'd (signed), stride
   // is zext'd (unsigned), multiplied in i64 (so offsets[0]*stride doesn't
   // overflow i32), added to global_addr, then re-packed into group0[2..3].
-  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK-NOT: amdg.update_tensor_descriptor
   // CHECK-DAG: llvm.sext{{.*}}i32 to i64
   // CHECK-DAG: llvm.zext{{.*}}i32 to i64
   // CHECK: llvm.mul{{.*}}: i64
   // CHECK: llvm.add{{.*}}: i64
   // CHECK: llvm.insertelement{{.*}}vector<4xi32>
-  tt.func public @advance_offsets_only(
+  tt.func public @update_tensor_descriptor_offsets_only(
       %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %dx: i32, %dy: i32)
       -> !tt.tensordesc<64x64xf16, #shared> {
     %c_shape = arith.constant 128 : i32
     %c_stride0 = arith.constant 128 : i64
     %c_stride1 = arith.constant 1 : i64
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
-    %1 = amdg.tdm_advance_descriptor %0 offsets = [%dx, %dy] : !tt.tensordesc<64x64xf16, #shared>
+    %1 = amdg.update_tensor_descriptor %0 add_offsets = [%dx, %dy] : !tt.tensordesc<64x64xf16, #shared>
     tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
   }
 }
@@ -30,18 +30,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: advance_bounds_only
+  // CHECK-LABEL: update_tensor_descriptor_bounds_only
   // The bounds kwarg writes tensor_dim (lo16/hi16 across group1[1..3]).
-  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK-NOT: amdg.update_tensor_descriptor
   // CHECK: llvm.insertelement{{.*}}vector<8xi32>
-  tt.func public @advance_bounds_only(
+  tt.func public @update_tensor_descriptor_bounds_only(
       %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %m: i32, %k: i32)
       -> !tt.tensordesc<64x64xf16, #shared> {
     %c_shape = arith.constant 128 : i32
     %c_stride0 = arith.constant 128 : i64
     %c_stride1 = arith.constant 1 : i64
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
-    %1 = amdg.tdm_advance_descriptor %0 bounds = [%m, %k] : !tt.tensordesc<64x64xf16, #shared>
+    %1 = amdg.update_tensor_descriptor %0 set_bounds = [%m, %k] : !tt.tensordesc<64x64xf16, #shared>
     tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
   }
 }
@@ -51,19 +51,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: advance_dest_only
+  // CHECK-LABEL: update_tensor_descriptor_dest_only
   // The dest parameter ptrtoints the smem ptr and stamps into group0[1].
-  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK-NOT: amdg.update_tensor_descriptor
   // CHECK: llvm.ptrtoint
   // CHECK: llvm.insertelement{{.*}}vector<4xi32>
-  tt.func public @advance_dest_only(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32})
+  tt.func public @update_tensor_descriptor_dest_only(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32})
       -> !tt.tensordesc<64x64xf16, #shared> {
     %c_shape = arith.constant 128 : i32
     %c_stride0 = arith.constant 128 : i64
     %c_stride1 = arith.constant 1 : i64
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
     %lds = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-    %1 = amdg.tdm_advance_descriptor %0 dest = %lds : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> : !tt.tensordesc<64x64xf16, #shared>
+    %1 = amdg.update_tensor_descriptor %0 dest = %lds : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> : !tt.tensordesc<64x64xf16, #shared>
     tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
   }
 }
@@ -73,17 +73,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: advance_pred_only
+  // CHECK-LABEL: update_tensor_descriptor_pred_only
   // The pred kwarg stamps into group0[0].
-  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK-NOT: amdg.update_tensor_descriptor
   // CHECK: llvm.insertelement{{.*}}vector<4xi32>
-  tt.func public @advance_pred_only(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %p: i32)
+  tt.func public @update_tensor_descriptor_pred_only(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %p: i32)
       -> !tt.tensordesc<64x64xf16, #shared> {
     %c_shape = arith.constant 128 : i32
     %c_stride0 = arith.constant 128 : i64
     %c_stride1 = arith.constant 1 : i64
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
-    %1 = amdg.tdm_advance_descriptor %0 pred = %p : !tt.tensordesc<64x64xf16, #shared>
+    %1 = amdg.update_tensor_descriptor %0 pred = %p : !tt.tensordesc<64x64xf16, #shared>
     tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
   }
 }
@@ -94,20 +94,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: advance_barrier_only
+  // CHECK-LABEL: update_tensor_descriptor_barrier_only
   // The barrier kwarg ptrtoints the barrier ptr, shifts and stamps into
   // group1[1] lo-16 plus the enable bit (group1[0] bit 18).
-  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK-NOT: amdg.update_tensor_descriptor
   // CHECK: llvm.ptrtoint
   // CHECK: llvm.insertelement{{.*}}vector<8xi32>
-  tt.func public @advance_barrier_only(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32})
+  tt.func public @update_tensor_descriptor_barrier_only(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32})
       -> !tt.tensordesc<64x64xf16, #shared> {
     %c_shape = arith.constant 128 : i32
     %c_stride0 = arith.constant 128 : i64
     %c_stride1 = arith.constant 1 : i64
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
     %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
-    %1 = amdg.tdm_advance_descriptor %0 barrier = %bar : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable> : !tt.tensordesc<64x64xf16, #shared>
+    %1 = amdg.update_tensor_descriptor %0 barrier = %bar : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable> : !tt.tensordesc<64x64xf16, #shared>
     tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
   }
 }
@@ -118,14 +118,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: advance_prologue
+  // CHECK-LABEL: update_tensor_descriptor_prologue
   // The K-loop prologue pattern: position at first tile + wire LDS + barrier + pred.
-  // CHECK-NOT: amdg.tdm_advance_descriptor
+  // CHECK-NOT: amdg.update_tensor_descriptor
   // CHECK: llvm.ptrtoint
   // CHECK: llvm.add{{.*}}: i64
   // CHECK: llvm.insertelement{{.*}}vector<4xi32>
   // CHECK: llvm.insertelement{{.*}}vector<8xi32>
-  tt.func public @advance_prologue(
+  tt.func public @update_tensor_descriptor_prologue(
       %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
       %dx: i32, %dy: i32, %p: i32) -> !tt.tensordesc<64x64xf16, #shared> {
     %c_shape = arith.constant 128 : i32
@@ -134,8 +134,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
     %lds = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
-    %1 = amdg.tdm_advance_descriptor %0
-            offsets = [%dx, %dy]
+    %1 = amdg.update_tensor_descriptor %0
+            add_offsets = [%dx, %dy]
             dest = %lds : !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
             pred = %p
             barrier = %bar : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -336,11 +336,11 @@ module attributes {"ttg.target" = "hip:gfx950", "ttg.num-ctas" = 1 : i32, "ttg.n
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @advance_wrong_offset_count(
+  tt.func public @update_tensor_descriptor_wrong_offset_count(
     %desc: !tt.tensordesc<64x64xf16, #shared>, %dx: i32
   ) -> !tt.tensordesc<64x64xf16, #shared> {
-    // expected-error @+1 {{expected 2 offsets to match descriptor rank, got 1}}
-    %result = amdg.tdm_advance_descriptor %desc offsets = [%dx] : !tt.tensordesc<64x64xf16, #shared>
+    // expected-error @+1 {{expected 2 add_offsets to match descriptor rank, got 1}}
+    %result = amdg.update_tensor_descriptor %desc add_offsets = [%dx] : !tt.tensordesc<64x64xf16, #shared>
     tt.return %result : !tt.tensordesc<64x64xf16, #shared>
   }
 }
@@ -349,11 +349,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @advance_wrong_bounds_count(
+  tt.func public @update_tensor_descriptor_wrong_bounds_count(
     %desc: !tt.tensordesc<64x64xf16, #shared>, %m: i32, %n: i32, %k: i32
   ) -> !tt.tensordesc<64x64xf16, #shared> {
-    // expected-error @+1 {{expected 2 bounds to match descriptor rank, got 3}}
-    %result = amdg.tdm_advance_descriptor %desc bounds = [%m, %n, %k] : !tt.tensordesc<64x64xf16, #shared>
+    // expected-error @+1 {{expected 2 set_bounds to match descriptor rank, got 3}}
+    %result = amdg.update_tensor_descriptor %desc set_bounds = [%m, %n, %k] : !tt.tensordesc<64x64xf16, #shared>
     tt.return %result : !tt.tensordesc<64x64xf16, #shared>
   }
 }
@@ -362,11 +362,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @advance_no_kwargs(
+  tt.func public @update_tensor_descriptor_no_kwargs(
     %desc: !tt.tensordesc<64x64xf16, #shared>
   ) -> !tt.tensordesc<64x64xf16, #shared> {
-    // expected-error @+1 {{must provide at least one of offsets, bounds, dest, pred, or barrier}}
-    %result = amdg.tdm_advance_descriptor %desc : !tt.tensordesc<64x64xf16, #shared>
+    // expected-error @+1 {{must provide at least one of add_offsets, set_bounds, dest, pred, or barrier}}
+    %result = amdg.update_tensor_descriptor %desc : !tt.tensordesc<64x64xf16, #shared>
     tt.return %result : !tt.tensordesc<64x64xf16, #shared>
   }
 }

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -331,3 +331,42 @@ module attributes {"ttg.target" = "hip:gfx950", "ttg.num-ctas" = 1 : i32, "ttg.n
     tt.return
   }
 }
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @advance_wrong_offset_count(
+    %desc: !tt.tensordesc<64x64xf16, #shared>, %dx: i32
+  ) -> !tt.tensordesc<64x64xf16, #shared> {
+    // expected-error @+1 {{expected 2 offsets to match descriptor rank, got 1}}
+    %result = amdg.tdm_advance_descriptor %desc offsets = [%dx] : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %result : !tt.tensordesc<64x64xf16, #shared>
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @advance_wrong_bounds_count(
+    %desc: !tt.tensordesc<64x64xf16, #shared>, %m: i32, %n: i32, %k: i32
+  ) -> !tt.tensordesc<64x64xf16, #shared> {
+    // expected-error @+1 {{expected 2 bounds to match descriptor rank, got 3}}
+    %result = amdg.tdm_advance_descriptor %desc bounds = [%m, %n, %k] : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %result : !tt.tensordesc<64x64xf16, #shared>
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @advance_no_kwargs(
+    %desc: !tt.tensordesc<64x64xf16, #shared>
+  ) -> !tt.tensordesc<64x64xf16, #shared> {
+    // expected-error @+1 {{must provide at least one of offsets, bounds, dest, pred, or barrier}}
+    %result = amdg.tdm_advance_descriptor %desc : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %result : !tt.tensordesc<64x64xf16, #shared>
+  }
+}

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -989,10 +989,10 @@ def TDMPrefetchOp : TT_AMDGPU_Op<"tdm_prefetch", [
 }
 
 //===----------------------------------------------------------------------===//
-// AdvanceTDMDescOp
+// UpdateTensorDescriptorOp
 //===----------------------------------------------------------------------===//
 
-def AdvanceTDMDescOp : TT_AMDGPU_Op<"tdm_advance_descriptor", [Pure,
+def UpdateTensorDescriptorOp : TT_AMDGPU_Op<"update_tensor_descriptor", [Pure,
     AttrSizedOperandSegments,
     TypesMatchWith<"result type matches desc type", "desc", "result", "$_self">]> {
   let summary = "Update selected fields of a TDM descriptor; produce a new descriptor SSA value";
@@ -1002,41 +1002,41 @@ def AdvanceTDMDescOp : TT_AMDGPU_Op<"tdm_advance_descriptor", [Pure,
     parameter is independently optional; only the fields the caller names
     are written.  Everything else is inherited from the input descriptor.
 
-    | parameter      | kind        | effect on descriptor                                        |
-    |----------------|-------------|-------------------------------------------------------------|
-    | `offsets`      | incremental | `global_addr += sum(offsets[i] * stride[i] * elem_size)`    |
-    | `bounds`       | rewrite     | `tensor_dim[i] = bounds[i]` (absolute)                      |
-    | `dest`         | rewrite     | `lds_addr = dest`                                           |
-    | `pred`         | rewrite     | `pred = pred`                                               |
-    | `barrier`      | rewrite     | `barrier_addr = barrier`                                    |
+    | parameter      | kind        | effect on descriptor                                            |
+    |----------------|-------------|-----------------------------------------------------------------|
+    | `add_offsets`  | incremental | `global_addr += sum(add_offsets[i] * stride[i] * elem_size)`    |
+    | `set_bounds`   | rewrite     | `tensor_dim[i] = set_bounds[i]` (absolute)                      |
+    | `dest`         | rewrite     | `lds_addr = dest`                                               |
+    | `pred`         | rewrite     | `pred = pred`                                                   |
+    | `barrier`      | rewrite     | `barrier_addr = barrier`                                        |
 
-    `offsets` is incremental (deltas in element units) and does not
-    touch `tensor_dim` — for OOB-correct loops, set `bounds` once
+    `add_offsets` is incremental (deltas in element units) and does not
+    touch `tensor_dim` — for OOB-correct loops, set `set_bounds` once
     outside the loop (interior tiles see a loop-invariant tensor_dim
-    that hoists), or set `bounds` per iteration when OOB must fire.
+    that hoists), or set `set_bounds` per iteration when OOB must fire.
 
     Examples:
     ```
     // K-loop interior: bump tile position only
-    %d1 = amdg.tdm_advance_descriptor %d, offsets=[%c0, %BLOCK_K]
+    %d1 = amdg.update_tensor_descriptor %d, add_offsets=[%c0, %BLOCK_K]
             : !tt.tensordesc<64x64xf16, #shared>
 
     // Prologue: position at first tile + wire LDS and barrier
-    %d1 = amdg.tdm_advance_descriptor %d,
-            offsets=[%pid_m_off, %c0],
+    %d1 = amdg.update_tensor_descriptor %d,
+            add_offsets=[%pid_m_off, %c0],
             dest=%a_shared, barrier=%a_bar
             : !tt.tensordesc<64x64xf16, #shared>
 
     // Peel epilogue: install real OOB extent for the partial last tile
-    %d1 = amdg.tdm_advance_descriptor %d, bounds=[%m_remain, %k_remain]
+    %d1 = amdg.update_tensor_descriptor %d, set_bounds=[%m_remain, %k_remain]
             : !tt.tensordesc<64x64xf16, #shared>
     ```
   }];
 
   let arguments = (ins
     TT_TensorDescType:$desc,
-    Variadic<I32>:$offsets,
-    Variadic<I32>:$bounds,
+    Variadic<I32>:$add_offsets,
+    Variadic<I32>:$set_bounds,
     Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$dest,
     Optional<I32>:$pred,
     Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$barrier
@@ -1047,8 +1047,8 @@ def AdvanceTDMDescOp : TT_AMDGPU_Op<"tdm_advance_descriptor", [Pure,
   let assemblyFormat = [{
     $desc
     oilist(
-        `offsets` `=` `[` $offsets `]`
-      | `bounds` `=` `[` $bounds `]`
+        `add_offsets` `=` `[` $add_offsets `]`
+      | `set_bounds` `=` `[` $set_bounds `]`
       | `dest` `=` $dest `:` qualified(type($dest))
       | `pred` `=` $pred
       | `barrier` `=` $barrier `:` qualified(type($barrier))

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -988,7 +988,76 @@ def TDMPrefetchOp : TT_AMDGPU_Op<"tdm_prefetch", [
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// AdvanceTDMDescOp
+//===----------------------------------------------------------------------===//
 
+def AdvanceTDMDescOp : TT_AMDGPU_Op<"tdm_advance_descriptor", [Pure,
+    AttrSizedOperandSegments,
+    TypesMatchWith<"result type matches desc type", "desc", "result", "$_self">]> {
+  let summary = "Update selected fields of a TDM descriptor; produce a new descriptor SSA value";
+
+  let description = [{
+    Returns a new TDM descriptor with selected fields rewritten.  Each
+    parameter is independently optional; only the fields the caller names
+    are written.  Everything else is inherited from the input descriptor.
+
+    | parameter      | kind        | effect on descriptor                                        |
+    |----------------|-------------|-------------------------------------------------------------|
+    | `offsets`      | incremental | `global_addr += sum(offsets[i] * stride[i] * elem_size)`    |
+    | `bounds`       | rewrite     | `tensor_dim[i] = bounds[i]` (absolute)                      |
+    | `dest`         | rewrite     | `lds_addr = dest`                                           |
+    | `pred`         | rewrite     | `pred = pred`                                               |
+    | `barrier`      | rewrite     | `barrier_addr = barrier`                                    |
+
+    `offsets` is incremental (deltas in element units) and does not
+    touch `tensor_dim` — for OOB-correct loops, set `bounds` once
+    outside the loop (interior tiles see a loop-invariant tensor_dim
+    that hoists), or set `bounds` per iteration when OOB must fire.
+
+    Examples:
+    ```
+    // K-loop interior: bump tile position only
+    %d1 = amdg.tdm_advance_descriptor %d, offsets=[%c0, %BLOCK_K]
+            : !tt.tensordesc<64x64xf16, #shared>
+
+    // Prologue: position at first tile + wire LDS and barrier
+    %d1 = amdg.tdm_advance_descriptor %d,
+            offsets=[%pid_m_off, %c0],
+            dest=%a_shared, barrier=%a_bar
+            : !tt.tensordesc<64x64xf16, #shared>
+
+    // Peel epilogue: install real OOB extent for the partial last tile
+    %d1 = amdg.tdm_advance_descriptor %d, bounds=[%m_remain, %k_remain]
+            : !tt.tensordesc<64x64xf16, #shared>
+    ```
+  }];
+
+  let arguments = (ins
+    TT_TensorDescType:$desc,
+    Variadic<I32>:$offsets,
+    Variadic<I32>:$bounds,
+    Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$dest,
+    Optional<I32>:$pred,
+    Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$barrier
+  );
+
+  let results = (outs TT_TensorDescType:$result);
+
+  let assemblyFormat = [{
+    $desc
+    oilist(
+        `offsets` `=` `[` $offsets `]`
+      | `bounds` `=` `[` $bounds `]`
+      | `dest` `=` $dest `:` qualified(type($dest))
+      | `pred` `=` $pred
+      | `barrier` `=` $barrier `:` qualified(type($barrier))
+    )
+    attr-dict `:` qualified(type($desc))
+  }];
+
+  let hasVerifier = 1;
+}
 
 //===----------------------------------------------------------------------===//
 // AsyncWait

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -831,6 +831,31 @@ LogicalResult AsyncTDMGatherOp::verify() {
   return success();
 }
 
+// -- AdvanceTDMDescOp --
+LogicalResult AdvanceTDMDescOp::verify() {
+  auto descTy = getDesc().getType();
+  size_t rank = descTy.getShape().size();
+
+  if (!getOffsets().empty() && getOffsets().size() != rank)
+    return emitOpError("expected ")
+           << rank << " offsets to match descriptor rank, got "
+           << getOffsets().size();
+
+  if (!getBounds().empty() && getBounds().size() != rank)
+    return emitOpError("expected ")
+           << rank << " bounds to match descriptor rank, got "
+           << getBounds().size();
+
+  // At least one mutation parameter must be provided -- a no-op advance is
+  // either a user mistake or should be folded by canonicalizer.
+  if (getOffsets().empty() && getBounds().empty() && !getDest() && !getPred() &&
+      !getBarrier())
+    return emitOpError("must provide at least one of offsets, bounds, dest, "
+                       "pred, or barrier");
+
+  return success();
+}
+
 // -- InitBarrierOp --
 LogicalResult InitBarrierOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -831,27 +831,27 @@ LogicalResult AsyncTDMGatherOp::verify() {
   return success();
 }
 
-// -- AdvanceTDMDescOp --
-LogicalResult AdvanceTDMDescOp::verify() {
+// -- UpdateTensorDescriptorOp --
+LogicalResult UpdateTensorDescriptorOp::verify() {
   auto descTy = getDesc().getType();
   size_t rank = descTy.getShape().size();
 
-  if (!getOffsets().empty() && getOffsets().size() != rank)
+  if (!getAddOffsets().empty() && getAddOffsets().size() != rank)
     return emitOpError("expected ")
-           << rank << " offsets to match descriptor rank, got "
-           << getOffsets().size();
+           << rank << " add_offsets to match descriptor rank, got "
+           << getAddOffsets().size();
 
-  if (!getBounds().empty() && getBounds().size() != rank)
+  if (!getSetBounds().empty() && getSetBounds().size() != rank)
     return emitOpError("expected ")
-           << rank << " bounds to match descriptor rank, got "
-           << getBounds().size();
+           << rank << " set_bounds to match descriptor rank, got "
+           << getSetBounds().size();
 
-  // At least one mutation parameter must be provided -- a no-op advance is
+  // At least one mutation parameter must be provided -- a no-op update is
   // either a user mistake or should be folded by canonicalizer.
-  if (getOffsets().empty() && getBounds().empty() && !getDest() && !getPred() &&
-      !getBarrier())
-    return emitOpError("must provide at least one of offsets, bounds, dest, "
-                       "pred, or barrier");
+  if (getAddOffsets().empty() && getSetBounds().empty() && !getDest() &&
+      !getPred() && !getBarrier())
+    return emitOpError("must provide at least one of add_offsets, set_bounds, "
+                       "dest, pred, or barrier");
 
   return success();
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -231,7 +231,6 @@ void updateTensorDescriptor(RewriterBase &rewriter, Location loc,
                             Value barrier) {
   size_t numDims = blockShape.size();
   assert(numDims == 2 && "updateTensorDescriptor currently supports 2D");
-  (void)numDims;
 
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value v16 = b.i32_val(16);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -223,20 +223,21 @@ SmallVector<Value> scalarizeTDMDescriptor(RewriterBase &rewriter, Location loc,
   return scalars;
 }
 
-void advanceTDMDescriptor(RewriterBase &rewriter, Location loc,
-                          Type elementType, ArrayRef<int64_t> blockShape,
-                          Value &group0, Value &group1, ArrayRef<Value> offsets,
-                          ArrayRef<Value> bounds, Value lds, Value pred,
-                          Value barrier) {
+void updateTensorDescriptor(RewriterBase &rewriter, Location loc,
+                            Type elementType, ArrayRef<int64_t> blockShape,
+                            Value &group0, Value &group1,
+                            ArrayRef<Value> addOffsets,
+                            ArrayRef<Value> setBounds, Value dest, Value pred,
+                            Value barrier) {
   size_t numDims = blockShape.size();
-  assert(numDims == 2 && "advanceTDMDescriptor currently supports 2D");
+  assert(numDims == 2 && "updateTensorDescriptor currently supports 2D");
   (void)numDims;
 
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value v16 = b.i32_val(16);
 
-  // ---- offsets: bump global_addr ----
-  if (!offsets.empty()) {
+  // ---- add_offsets: bump global_addr ----
+  if (!addOffsets.empty()) {
     auto elementBitWidth = elementType.getIntOrFloatBitWidth();
     Value elemSize = b.i64_val(elementBitWidth / 8);
 
@@ -247,15 +248,15 @@ void advanceTDMDescriptor(RewriterBase &rewriter, Location loc,
                        b.shl(b.zext(i64_ty, addrHi), b.i64_val(32)));
 
     // Byte delta:
-    //   offsets[1] (innermost, stride 1) +
-    //   offsets[0] * tensor_dim0_stride (from group1[5]),
+    //   addOffsets[1] (innermost, stride 1) +
+    //   addOffsets[0] * tensor_dim0_stride (from group1[5]),
     // all scaled by element size.  Promote to i64 before the multiply so
-    // offsets[0] * stride0 doesn't overflow i32 for large tensors.
+    // addOffsets[0] * stride0 doesn't overflow i32 for large tensors.
     // Offsets are signed (advancing backward is allowed) so sext; stride is
     // unsigned so zext.
     Value stride0 = vecGet(b, group1, 5);
-    Value off0_64 = b.sext(i64_ty, offsets[0]);
-    Value off1_64 = b.sext(i64_ty, offsets[1]);
+    Value off0_64 = b.sext(i64_ty, addOffsets[0]);
+    Value off1_64 = b.sext(i64_ty, addOffsets[1]);
     Value stride0_64 = b.zext(i64_ty, stride0);
     Value deltaElem = b.add(off1_64, b.mul(off0_64, stride0_64));
     Value byteDelta = b.mul(deltaElem, elemSize);
@@ -269,12 +270,12 @@ void advanceTDMDescriptor(RewriterBase &rewriter, Location loc,
     group0 = vecSet(b, group0, 3, newHi);
   }
 
-  // ---- bounds: absolute rewrite of tensor_dim ----
-  // tensor_dim_inner (bounds[1] for 2D) spans
+  // ---- set_bounds: absolute rewrite of tensor_dim ----
+  // tensor_dim_inner (setBounds[1] for 2D) spans
   //   group1[1] hi-16 | group1[2] lo-16
-  // tensor_dim_outer (bounds[0]) spans
+  // tensor_dim_outer (setBounds[0]) spans
   //   group1[2] hi-16 | group1[3] lo-16
-  if (!bounds.empty()) {
+  if (!setBounds.empty()) {
     auto stampDim = [&](int loDword, int hiDword, Value newDim) {
       // loDword: keep lo-16, replace hi-16 with (newDim & 0xFFFF) << 16
       Value loHi = b.shl(b.and_(newDim, b.i32_val(0xFFFF)), v16);
@@ -287,13 +288,13 @@ void advanceTDMDescriptor(RewriterBase &rewriter, Location loc,
           b.and_(vecGet(b, group1, hiDword), b.i32_val(0xFFFF0000)), hiLo);
       group1 = vecSet(b, group1, hiDword, g_hi);
     };
-    stampDim(/*loDword=*/1, /*hiDword=*/2, bounds[1]); // inner
-    stampDim(/*loDword=*/2, /*hiDword=*/3, bounds[0]); // outer
+    stampDim(/*loDword=*/1, /*hiDword=*/2, setBounds[1]); // inner
+    stampDim(/*loDword=*/2, /*hiDword=*/3, setBounds[0]); // outer
   }
 
-  // ---- lds: rewrite lds_addr in group0[1] ----
-  if (lds) {
-    Value ldsAddr = b.ptrtoint(i32_ty, lds);
+  // ---- dest: rewrite lds_addr in group0[1] ----
+  if (dest) {
+    Value ldsAddr = b.ptrtoint(i32_ty, dest);
     group0 = vecSet(b, group0, 1, ldsAddr);
   }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -223,6 +223,102 @@ SmallVector<Value> scalarizeTDMDescriptor(RewriterBase &rewriter, Location loc,
   return scalars;
 }
 
+void advanceTDMDescriptor(RewriterBase &rewriter, Location loc,
+                          Type elementType, ArrayRef<int64_t> blockShape,
+                          Value &group0, Value &group1, ArrayRef<Value> offsets,
+                          ArrayRef<Value> bounds, Value lds, Value pred,
+                          Value barrier) {
+  size_t numDims = blockShape.size();
+  assert(numDims == 2 && "advanceTDMDescriptor currently supports 2D");
+  (void)numDims;
+
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value v16 = b.i32_val(16);
+
+  // ---- offsets: bump global_addr ----
+  if (!offsets.empty()) {
+    auto elementBitWidth = elementType.getIntOrFloatBitWidth();
+    Value elemSize = b.i64_val(elementBitWidth / 8);
+
+    // Decode current 48-bit global_addr from group0[2:3] (valid bit masked).
+    Value addrLo = vecGet(b, group0, 2);
+    Value addrHi = b.and_(vecGet(b, group0, 3), b.i32_val(0x7FFFFFFF));
+    Value addr = b.or_(b.zext(i64_ty, addrLo),
+                       b.shl(b.zext(i64_ty, addrHi), b.i64_val(32)));
+
+    // Byte delta:
+    //   offsets[1] (innermost, stride 1) +
+    //   offsets[0] * tensor_dim0_stride (from group1[5]),
+    // all scaled by element size.  Promote to i64 before the multiply so
+    // offsets[0] * stride0 doesn't overflow i32 for large tensors.
+    // Offsets are signed (advancing backward is allowed) so sext; stride is
+    // unsigned so zext.
+    Value stride0 = vecGet(b, group1, 5);
+    Value off0_64 = b.sext(i64_ty, offsets[0]);
+    Value off1_64 = b.sext(i64_ty, offsets[1]);
+    Value stride0_64 = b.zext(i64_ty, stride0);
+    Value deltaElem = b.add(off1_64, b.mul(off0_64, stride0_64));
+    Value byteDelta = b.mul(deltaElem, elemSize);
+    addr = b.add(addr, byteDelta);
+
+    // Re-pack, restoring the valid bit in group0[3] bit 31.
+    Value newLo = b.trunc(i32_ty, addr);
+    Value newHi = b.trunc(i32_ty, b.lshr(addr, b.i64_val(32)));
+    newHi = b.or_(newHi, b.i32_val(1 << 31));
+    group0 = vecSet(b, group0, 2, newLo);
+    group0 = vecSet(b, group0, 3, newHi);
+  }
+
+  // ---- bounds: absolute rewrite of tensor_dim ----
+  // tensor_dim_inner (bounds[1] for 2D) spans
+  //   group1[1] hi-16 | group1[2] lo-16
+  // tensor_dim_outer (bounds[0]) spans
+  //   group1[2] hi-16 | group1[3] lo-16
+  if (!bounds.empty()) {
+    auto stampDim = [&](int loDword, int hiDword, Value newDim) {
+      // loDword: keep lo-16, replace hi-16 with (newDim & 0xFFFF) << 16
+      Value loHi = b.shl(b.and_(newDim, b.i32_val(0xFFFF)), v16);
+      Value g_lo = b.or_(
+          b.and_(vecGet(b, group1, loDword), b.i32_val(0x0000FFFF)), loHi);
+      group1 = vecSet(b, group1, loDword, g_lo);
+      // hiDword: keep hi-16, replace lo-16 with (newDim >> 16) & 0xFFFF
+      Value hiLo = b.and_(b.lshr(newDim, v16), b.i32_val(0xFFFF));
+      Value g_hi = b.or_(
+          b.and_(vecGet(b, group1, hiDword), b.i32_val(0xFFFF0000)), hiLo);
+      group1 = vecSet(b, group1, hiDword, g_hi);
+    };
+    stampDim(/*loDword=*/1, /*hiDword=*/2, bounds[1]); // inner
+    stampDim(/*loDword=*/2, /*hiDword=*/3, bounds[0]); // outer
+  }
+
+  // ---- lds: rewrite lds_addr in group0[1] ----
+  if (lds) {
+    Value ldsAddr = b.ptrtoint(i32_ty, lds);
+    group0 = vecSet(b, group0, 1, ldsAddr);
+  }
+
+  // ---- pred: rewrite group0[0] ----
+  if (pred) {
+    // Note: this clobbers any mode bits stored in group0[0] (gather/scatter
+    // mode bit in bit 31, index-size bit in bit 30).  TODO: Gather/scatter
+    // mutation is not yet supported here; a future revision should preserve
+    // them.
+    group0 = vecSet(b, group0, 0, pred);
+  }
+
+  // ---- barrier: enable bit (group1[0] bit 18) + addr (group1[1] lo-16) ----
+  if (barrier) {
+    Value g1_0 = vecGet(b, group1, 0);
+    Value g1_1 = vecGet(b, group1, 1);
+    g1_0 = b.or_(g1_0, b.shl(b.i32_val(1), b.i32_val(18)));
+    g1_1 = b.or_(b.and_(g1_1, b.i32_val(0xFFFF0000)),
+                 b.and_(b.lshr(b.ptrtoint(i32_ty, barrier), b.i32_val(3)),
+                        b.i32_val(0x0000FFFF)));
+    group1 = vecSet(b, group1, 0, g1_0);
+    group1 = vecSet(b, group1, 1, g1_1);
+  }
+}
+
 // Decode a full TDM descriptor from all 4 group vectors for 3D-5D tensors
 // Returns (base, tensorShape[], tensorStride[], blockShape[])
 std::tuple<Value, SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -44,22 +44,23 @@ SmallVector<Value> scalarizeTDMDescriptor(RewriterBase &rewriter, Location loc,
                                           ArrayRef<Value> vectors);
 
 // Updates TDM descriptor fields in place.
-// Mirrors the parameter semantics of `amdg.tdm_advance_descriptor`.
+// Mirrors the parameter semantics of `amdg.update_tensor_descriptor`.
 //
-// - offsets (incremental): bumps global_addr by sum(offsets[i]*stride[i])
-//   scaled by element size.  Empty = skip.
-// - bounds  (rewrite):     overwrites tensor_dim absolutely.  Empty = skip.
-// - lds     (rewrite):     overwrites lds_addr.  Null = skip.
-// - pred    (rewrite):     overwrites pred.  Null = skip.
-// - barrier (rewrite):     enables barrier signaling and writes barrier addr.
-//                          Null = skip.
+// - addOffsets (incremental): bumps global_addr by
+//   sum(addOffsets[i]*stride[i]) scaled by element size.  Empty = skip.
+// - setBounds  (rewrite):     overwrites tensor_dim absolutely.  Empty = skip.
+// - dest       (rewrite):     overwrites lds_addr.  Null = skip.
+// - pred       (rewrite):     overwrites pred.  Null = skip.
+// - barrier    (rewrite):     enables barrier signaling and writes barrier
+//                             addr.  Null = skip.
 //
 // Currently 2D-only; 3D-5D support TBD.
-void advanceTDMDescriptor(RewriterBase &rewriter, Location loc,
-                          Type elementType, ArrayRef<int64_t> blockShape,
-                          Value &group0, Value &group1, ArrayRef<Value> offsets,
-                          ArrayRef<Value> bounds, Value lds, Value pred,
-                          Value barrier);
+void updateTensorDescriptor(RewriterBase &rewriter, Location loc,
+                            Type elementType, ArrayRef<int64_t> blockShape,
+                            Value &group0, Value &group1,
+                            ArrayRef<Value> addOffsets,
+                            ArrayRef<Value> setBounds, Value dest, Value pred,
+                            Value barrier);
 
 // Create a TDM descriptor. This creates a partially filled descriptor, with
 // shared memory address and pred set to zero. User of the descriptor is

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -43,6 +43,24 @@ SmallVector<Value> unpackTDMDescriptor(RewriterBase &rewriter, Location loc,
 SmallVector<Value> scalarizeTDMDescriptor(RewriterBase &rewriter, Location loc,
                                           ArrayRef<Value> vectors);
 
+// Updates TDM descriptor fields in place.
+// Mirrors the parameter semantics of `amdg.tdm_advance_descriptor`.
+//
+// - offsets (incremental): bumps global_addr by sum(offsets[i]*stride[i])
+//   scaled by element size.  Empty = skip.
+// - bounds  (rewrite):     overwrites tensor_dim absolutely.  Empty = skip.
+// - lds     (rewrite):     overwrites lds_addr.  Null = skip.
+// - pred    (rewrite):     overwrites pred.  Null = skip.
+// - barrier (rewrite):     enables barrier signaling and writes barrier addr.
+//                          Null = skip.
+//
+// Currently 2D-only; 3D-5D support TBD.
+void advanceTDMDescriptor(RewriterBase &rewriter, Location loc,
+                          Type elementType, ArrayRef<int64_t> blockShape,
+                          Value &group0, Value &group1, ArrayRef<Value> offsets,
+                          ArrayRef<Value> bounds, Value lds, Value pred,
+                          Value barrier);
+
 // Create a TDM descriptor. This creates a partially filled descriptor, with
 // shared memory address and pred set to zero. User of the descriptor is
 // expected to fill these fields later.

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
@@ -134,11 +134,76 @@ struct MakeTensorDescOpConversion
     return success();
   }
 };
+
+struct AdvanceTDMDescOpConversion
+    : public ConvertOpToLLVMPattern<triton::amdgpu::AdvanceTDMDescOp> {
+  using ConvertOpToLLVMPattern<
+      triton::amdgpu::AdvanceTDMDescOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::amdgpu::AdvanceTDMDescOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto tensorDescTy = op.getDesc().getType();
+    Type elementType =
+        getTypeConverter()->convertType(tensorDescTy.getElementType());
+    SmallVector<int64_t> blockShape = to_vector(tensorDescTy.getShape());
+
+    if (blockShape.size() != 2) {
+      return rewriter.notifyMatchFailure(
+          op, "AdvanceTDMDescOp lowering currently supports 2D only");
+    }
+
+    // Unpack the input descriptor into vector groups (group0: <4 x i32>,
+    // group1: <8 x i32> for 2D).
+    SmallVector<Value> groups =
+        mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
+    assert(groups.size() == 2 && "2D descriptor expects 2 vector groups");
+    Value group0 = groups[0];
+    Value group1 = groups[1];
+
+    SmallVector<Value> offsets = llvm::to_vector(adaptor.getOffsets());
+    SmallVector<Value> bounds = llvm::to_vector(adaptor.getBounds());
+
+    Value ldsPtr;
+    if (op.getDest()) {
+      auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
+          loc, adaptor.getDest(), elementType, rewriter);
+      ldsPtr = smemObj.getBase();
+    }
+    Value barrierPtr;
+    if (op.getBarrier()) {
+      auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
+          loc, adaptor.getBarrier(),
+          getTypeConverter()->convertType(
+              op.getBarrier().getType().getElementType()),
+          rewriter);
+      barrierPtr = smemObj.getBase();
+    }
+    Value pred = adaptor.getPred();
+
+    mlir::LLVM::AMD::advanceTDMDescriptor(rewriter, loc, elementType,
+                                          blockShape, group0, group1, offsets,
+                                          bounds, ldsPtr, pred, barrierPtr);
+
+    // Re-pack the mutated groups back into the flat MLIR struct that
+    // matches convertTensorDescType / the host-side TDMDescriptor ABI.
+    SmallVector<Value> mutated = {group0, group1};
+    SmallVector<Value> scalars =
+        mlir::LLVM::AMD::scalarizeTDMDescriptor(rewriter, loc, mutated);
+    Value newDesc = packLLElements(loc, getTypeConverter(), scalars, rewriter,
+                                   tensorDescTy);
+
+    rewriter.replaceOp(op, newDesc);
+    return success();
+  }
+};
 } // namespace
 
 void mlir::triton::AMD::populateTensorPtrOpsToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     PatternBenefit benefit) {
   patterns.add<MakeTensorDescOpConversion>(typeConverter, benefit);
+  patterns.add<AdvanceTDMDescOpConversion>(typeConverter, benefit);
   return;
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
@@ -135,13 +135,14 @@ struct MakeTensorDescOpConversion
   }
 };
 
-struct AdvanceTDMDescOpConversion
-    : public ConvertOpToLLVMPattern<triton::amdgpu::AdvanceTDMDescOp> {
+struct UpdateTensorDescriptorOpConversion
+    : public ConvertOpToLLVMPattern<triton::amdgpu::UpdateTensorDescriptorOp> {
   using ConvertOpToLLVMPattern<
-      triton::amdgpu::AdvanceTDMDescOp>::ConvertOpToLLVMPattern;
+      triton::amdgpu::UpdateTensorDescriptorOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(triton::amdgpu::AdvanceTDMDescOp op, OpAdaptor adaptor,
+  matchAndRewrite(triton::amdgpu::UpdateTensorDescriptorOp op,
+                  OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto tensorDescTy = op.getDesc().getType();
@@ -151,7 +152,7 @@ struct AdvanceTDMDescOpConversion
 
     if (blockShape.size() != 2) {
       return rewriter.notifyMatchFailure(
-          op, "AdvanceTDMDescOp lowering currently supports 2D only");
+          op, "UpdateTensorDescriptorOp lowering currently supports 2D only");
     }
 
     // Unpack the input descriptor into vector groups (group0: <4 x i32>,
@@ -162,14 +163,14 @@ struct AdvanceTDMDescOpConversion
     Value group0 = groups[0];
     Value group1 = groups[1];
 
-    SmallVector<Value> offsets = llvm::to_vector(adaptor.getOffsets());
-    SmallVector<Value> bounds = llvm::to_vector(adaptor.getBounds());
+    SmallVector<Value> addOffsets = llvm::to_vector(adaptor.getAddOffsets());
+    SmallVector<Value> setBounds = llvm::to_vector(adaptor.getSetBounds());
 
-    Value ldsPtr;
+    Value destPtr;
     if (op.getDest()) {
       auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
           loc, adaptor.getDest(), elementType, rewriter);
-      ldsPtr = smemObj.getBase();
+      destPtr = smemObj.getBase();
     }
     Value barrierPtr;
     if (op.getBarrier()) {
@@ -182,9 +183,9 @@ struct AdvanceTDMDescOpConversion
     }
     Value pred = adaptor.getPred();
 
-    mlir::LLVM::AMD::advanceTDMDescriptor(rewriter, loc, elementType,
-                                          blockShape, group0, group1, offsets,
-                                          bounds, ldsPtr, pred, barrierPtr);
+    mlir::LLVM::AMD::updateTensorDescriptor(
+        rewriter, loc, elementType, blockShape, group0, group1, addOffsets,
+        setBounds, destPtr, pred, barrierPtr);
 
     // Re-pack the mutated groups back into the flat MLIR struct that
     // matches convertTensorDescType / the host-side TDMDescriptor ABI.
@@ -204,6 +205,6 @@ void mlir::triton::AMD::populateTensorPtrOpsToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     PatternBenefit benefit) {
   patterns.add<MakeTensorDescOpConversion>(typeConverter, benefit);
-  patterns.add<AdvanceTDMDescOpConversion>(typeConverter, benefit);
+  patterns.add<UpdateTensorDescriptorOpConversion>(typeConverter, benefit);
   return;
 }


### PR DESCRIPTION
  ## Summary

  Introduces `amdg.update_tensor_descriptor` as the only op that mutates a TDM
  descriptor's mutable fields. Each kwarg is independently optional; only the
  fields the caller names are written, everything else is inherited from the
  input descriptor.

  | kwarg         | kind        | effect on descriptor|
  |---------------|-------------|---------------------------------------------------------------------|
  | `add_offsets` | incremental | `global_addr += sum(add_offsets[i] * stride[i] * elem_size)`|
  | `set_bounds`  | rewrite     | `tensor_dim[i] = set_bounds[i]` (absolute)|
  | `dest`        | rewrite     | `lds_addr = dest`|
  | `pred`        | rewrite     | `pred = pred`|
  | `barrier`     | rewrite     | `barrier_addr = barrier` (and enables barrier signaling)|

  The kwarg names embed the semantics:
  - `add_offsets` is *incremental* (delta added to `global_addr`).
  - `set_bounds` is an *absolute* rewrite of the descriptor's bounds.

  The op mnemonic mirrors `tt.make_tensor_descriptor` (no `tdm_` prefix; the
  `amdg.` dialect provides the namespace).

  Existing `async_load` / `async_store` / `async_gather` / `async_scatter` /
  `fillTDMDescriptor` paths are unchanged, so existing kernels keep working
  unmodified. The intent is for `update_tensor_descriptor()` plus a future
  pure `async_load(d)` to replace the current per-call-operands forms; this
  PR ships only the update op as the foundation.

  ## Implementation

  **Op definition**
  - `TritonAMDGPUOps.td`: `UpdateTensorDescriptorOp` with `Pure` +
    `AttrSizedOperandSegments` + `TypesMatchWith`. Assembly format uses
    `oilist` so the kwargs can appear in any order.
  - `Dialect.cpp`: verifier checks rank match on `add_offsets`/`set_bounds`
    and rejects the no-kwarg form (must provide at least one).

  **Lowering (2D only for now; 3D-5D TBD)**
  - `TDMUtility.{h,cpp}`: `updateTensorDescriptor()` does per-field stamping.
    `add_offsets` bumps the 48-bit `global_addr` through `group0[2..3]`,
    preserving the VALID bit; `set_bounds` rewrites `tensor_dim` straddling
    `group1[1..3]`; `dest` writes `group0[1]`; `pred` writes `group0[0]`;
    `barrier` sets the enable bit in `group1[0]` and stamps the addr into
    `group1[1]` low-16. The `add_offsets[i] * stride[i]` multiply is
    performed in i64 (offsets sext'd as signed, stride zext'd as unsigned)
    so it doesn't overflow i32 for large tensors.
  - `TensorPtrOpsToLLVM.cpp`: `UpdateTensorDescriptorOpConversion` unpacks
    the input descriptor into vector groups, applies
    `updateTensorDescriptor()` in place, and re-packs into the flat MLIR
    struct that matches `convertTensorDescType` / the host-side
    `TDMDescriptor` ABI.

  **Frontend**
  - `gluon_ir.cc`: `create_update_tensor_descriptor` binding takes all
    kwargs; optional ones use `ttgl.ir.value()` for "absent".
  - `python/.../tdm.py`: `update_tensor_descriptor()` builtin with
    `add_offsets`/`set_bounds`/`dest`/`pred`/`barrier` kwargs; validates
    rank match, requires at least one kwarg.

  ## Naming history

  The op was originally named `tdm_advance_descriptor` with kwargs `offsets`
  / `bounds` / `lds`. Reviewers (Lei, OAI) flagged that "advance" suggested
  forward iteration even though the op rewrites independent fields, that
  "offsets"/"bounds" didn't convey the incremental-vs-absolute distinction,
  and that "lds" was inconsistent with the operand spelling "dest" used
  elsewhere. Renamed accordingly:

  ```
  advance              -> update_tensor_descriptor
  offsets= kwarg       -> add_offsets=
  bounds= kwarg        -> set_bounds=
  (C++ helper param) lds -> dest
  ```

  The rename is a separate commit on top so reviewers who already approved
  the original commit can confirm the rename is purely lexical.

## Performance impact

For a normal gemm kernel with tdm tile A and tile B inside the loop, this pr reduces the salu instruction counts from 28 to 8 without bounds checking