### PR TITLE
Fix ptr->int->ptr canonicalizer if types don't match

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -77,6 +77,7 @@ def TT_BitcastOp : TT_Op<"bitcast", [Elementwise,
     let results = (outs TT_Type:$result);
 
     let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+    let hasFolder = 1;
     let hasVerifier = 1;
 }
 

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1029,6 +1029,12 @@ LogicalResult FpToFpOp::verify() {
 }
 
 //-- BitcastOp --
+OpFoldResult BitcastOp::fold(FoldAdaptor adaptor) {
+  if (getSrc().getType() == getType())
+    return getSrc();
+  return {};
+}
+
 LogicalResult BitcastOp::verify() {
   // Bitcast only allows conversion between types with the same bit width.
   Type dstType = getType();
@@ -1141,9 +1147,8 @@ struct CanonicalizeIntToPtrOfPtrToInt : public OpRewritePattern<IntToPtrOp> {
     auto ptrToIntOp = intToPtrOp.getSrc().getDefiningOp<PtrToIntOp>();
     if (!ptrToIntOp)
       return failure();
-
-    // Replace with the original pointer
-    rewriter.replaceOp(intToPtrOp, ptrToIntOp.getSrc());
+    rewriter.replaceOpWithNewOp<BitcastOp>(intToPtrOp, intToPtrOp.getType(),
+                                           ptrToIntOp.getSrc());
     return success();
   }
 };

--- a/test/Triton/canonicalize.mlir
+++ b/test/Triton/canonicalize.mlir
@@ -180,10 +180,24 @@ tt.func @fold_transpose_constant() -> tensor<128x16xf32> {
 tt.func @canonicalize_int_to_ptr_of_ptr_to_int(%ptr: tensor<64x!tt.ptr<f32>>) -> tensor<64x!tt.ptr<f32>> {
   // CHECK-NOT: tt.ptr_to_int
   // CHECK-NOT: tt.int_to_ptr
+  // CHECK-NOT: tt.bitcast
   // CHECK: tt.return %{{.*}} : tensor<64x!tt.ptr<f32>>
   %int = tt.ptr_to_int %ptr : tensor<64x!tt.ptr<f32>> -> tensor<64xi64>
   %result = tt.int_to_ptr %int : tensor<64xi64> -> tensor<64x!tt.ptr<f32>>
   tt.return %result : tensor<64x!tt.ptr<f32>>
+}
+
+// -----
+
+// CHECK-LABEL: @canonicalize_int_to_ptr_of_ptr_to_int_with_different_ptr_type
+tt.func @canonicalize_int_to_ptr_of_ptr_to_int_with_different_ptr_type(%ptr: !tt.ptr<f32>) -> !tt.ptr<f16> {
+  // CHECK-NOT: tt.ptr_to_int
+  // CHECK-NOT: tt.int_to_ptr
+  // CHECK: %[[RESULT:.*]] = tt.bitcast %{{.*}} : !tt.ptr<f32> -> !tt.ptr<f16>
+  %int = tt.ptr_to_int %ptr : !tt.ptr<f32> -> i64
+  %result = tt.int_to_ptr %int : i64 -> !tt.ptr<f16>
+  // CHECK-NEXT: tt.return %[[RESULT]] : !tt.ptr<f16>
+  tt.return %result : !tt.ptr<f16>
 }
 
 // -----


### PR DESCRIPTION

The canonicalization of `ptr->int->ptr` to avoid the roundtrip through
int does not check that both pointers have the same type. This can
result in verifier errors if the types don't match.

To fix this, turn the cast sequence into a bitcast, and add a pattern to
flatten away identity bitcasts.
