### PR TITLE
[Frontend] Unwrap constexpr before semantic

### DIFF
--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -482,7 +482,6 @@ class GluonSemantic(TritonSemantic[TensorTy]):
 
     def associative_scan(self, inputs: Sequence[TensorTy], axis: int, region_builder_fn,
                          reverse: bool) -> Tuple[TensorTy, ...]:
-        reverse = ttgl._unwrap_if_constexpr(reverse)
         shape = inputs[0].type.shape
         rank = len(shape)
 

--- a/python/triton/experimental/gluon/language/amd/_ops.py
+++ b/python/triton/experimental/gluon/language/amd/_ops.py
@@ -52,7 +52,7 @@ def _mma_scaled(a, a_scale, a_format, b, b_scale, b_format, acc, scale_fn, seman
     def _get_scale_shape(op_idx, operand, format, scale_factor):
         operand_shape = [s for s in operand.type.shape]
         scale_shape = operand_shape
-        unpack_factor = 2 if format.value == "e2m1" else 1
+        unpack_factor = 2 if format == "e2m1" else 1
         if op_idx == 0:
             k = scale_shape[-1] * unpack_factor
             scale_shape[-1] = k // scale_factor
@@ -65,12 +65,10 @@ def _mma_scaled(a, a_scale, a_format, b, b_scale, b_format, acc, scale_fn, seman
     def _get_default_scale_dtype_and_unit_value(op_idx):
         default_value_by_dtype = {ttgl.uint8: 0x7F, ttgl.float8e4nv: 1.0}
 
-        a_scale_value = _unwrap_if_constexpr(a_scale)
-        b_scale_value = _unwrap_if_constexpr(b_scale)
-        if a_scale_value is None and b_scale_value is None:
+        if a_scale is None and b_scale is None:
             return ttgl.uint8, 0x7F
 
-        if a_format.value == b_format.value == "e2m1":
+        if a_format == b_format == "e2m1":
             # Fp4 x Fp4 requries to use the same scale dtype for both operands.
             other_scale = b_scale if op_idx == 0 else a_scale
             return other_scale.dtype, default_value_by_dtype[other_scale.dtype]

--- a/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/cdna4/__init__.py
@@ -43,8 +43,12 @@ def mfma_scaled(a, a_scale, a_format, b, b_scale, b_format, acc, _semantic=None)
     assert (isinstance(b.type.layout, DotOperandLayout) and b.type.layout.parent == layout), \
             "Expected rhs layout to be a DotOperandLayout with parent matching MFMA layout"
 
-    assert a_format.value in {"e2m1", "e4m3", "e5m2"}, f"Unsupported lhs_format: {a_format.value}"
-    assert b_format.value in {"e2m1", "e4m3", "e5m2"}, f"Unsupported rhs_format: {b_format.value}"
+    a_format = _unwrap_if_constexpr(a_format)
+    b_format = _unwrap_if_constexpr(b_format)
+    a_scale = _unwrap_if_constexpr(a_scale)
+    b_scale = _unwrap_if_constexpr(b_scale)
+    assert a_format in {"e2m1", "e4m3", "e5m2"}, f"Unsupported lhs_format: {a_format}"
+    assert b_format in {"e2m1", "e4m3", "e5m2"}, f"Unsupported rhs_format: {b_format}"
 
     return _mma_scaled(a, a_scale, a_format, b, b_scale, b_format, acc, get_mfma_scale_layout, _semantic)
 

--- a/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
@@ -65,42 +65,44 @@ def wmma_scaled(a, a_scale, a_format, b, b_scale, b_format, acc, _semantic=None)
         acc (tensor): Accumulator tensor.
     """
     _verify_wmma(3, a, b, acc)
-    if a_format.value == "e2m1":
+    a_format = _unwrap_if_constexpr(a_format)
+    b_format = _unwrap_if_constexpr(b_format)
+    a_scale = _unwrap_if_constexpr(a_scale)
+    b_scale = _unwrap_if_constexpr(b_scale)
+
+    if a_format == "e2m1":
         wmma_layout = a.type.layout.parent
         assert isinstance(wmma_layout, AMDWMMALayout) and wmma_layout.instr_shape in [[16, 16, 64], [32, 16, 64]], \
             "e2m1 format expects instr_shape to be [16, 16, 64] or [32, 16, 64]"
-    if b_format.value == "e2m1":
+    if b_format == "e2m1":
         wmma_layout = b.type.layout.parent
         assert isinstance(wmma_layout, AMDWMMALayout) and wmma_layout.instr_shape in [[16, 16, 64], [32, 16, 64]], \
             "e2m1 format expects instr_shape to be [16, 16, 64] or [32, 16, 64]"
     acc_shapes = [[16, 16, 128]]
-    if a_format.value == "e2m1" and b_format.value == "e2m1":
+    if a_format == "e2m1" and b_format == "e2m1":
         acc_shapes.append([32, 16, 128])
 
     acc_layout = acc.type.layout
     assert isinstance(acc_layout, AMDWMMALayout) and acc_layout.instr_shape in acc_shapes, \
         f"accumulator tensor's layout must be one of {acc_shapes}"
 
-    assert a_format.value in {"e2m1", "e4m3", "e5m2"}, f"Unsupported lhs_format: {a_format.value}"
-    assert b_format.value in {"e2m1", "e4m3", "e5m2"}, f"Unsupported rhs_format: {b_format.value}"
+    assert a_format in {"e2m1", "e4m3", "e5m2"}, f"Unsupported lhs_format: {a_format}"
+    assert b_format in {"e2m1", "e4m3", "e5m2"}, f"Unsupported rhs_format: {b_format}"
 
     scale_dtype_to_format = {float8e4nv: "e4m3"}
 
     # E8M0 scale has various representation in frontend.
     scale_dtype_to_format.update({x: "e8m0" for x in (int8, uint8)})
 
-    a_scale_value = _unwrap_if_constexpr(a_scale)
-    b_scale_value = _unwrap_if_constexpr(b_scale)
-
-    if isinstance(a_scale_value, tensor) and isinstance(b_scale_value, tensor):
+    if isinstance(a_scale, tensor) and isinstance(b_scale, tensor):
         assert a_scale.dtype in scale_dtype_to_format, f"Unsupported a_scale dtype: {a_scale.dtype}"
         assert b_scale.dtype in scale_dtype_to_format, f"Unsupported b_scale dtype: {b_scale.dtype}"
 
         a_scale_format = scale_dtype_to_format[a_scale.dtype]
         b_scale_format = scale_dtype_to_format[b_scale.dtype]
 
-        assert (a_format.value, b_format.value, a_scale_format, b_scale_format) in _valid_dtype_combinations, \
-            f"Unsupported dtype combination: {a_format.value}, {b_format.value}, {a_scale_format}, {b_scale_format}."
+        assert (a_format, b_format, a_scale_format, b_scale_format) in _valid_dtype_combinations, \
+            f"Unsupported dtype combination: {a_format}, {b_format}, {a_scale_format}, {b_scale_format}."
 
     return _mma_scaled(a, a_scale, a_format, b, b_scale, b_format, acc, get_wmma_scale_layout, _semantic)
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2379,8 +2379,13 @@ def dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=None,
     :param rhs_k_pack: If false, the rhs tensor is packed into uint8 along N dimension.
     :type rhs_k_pack: bool, optional
     """
-    out_dtype = _unwrap_if_constexpr(out_dtype)
+    lhs_format = _unwrap_if_constexpr(lhs_format)
+    rhs_format = _unwrap_if_constexpr(rhs_format)
     acc = _unwrap_if_constexpr(acc)
+    fast_math = _unwrap_if_constexpr(fast_math)
+    out_dtype = _unwrap_if_constexpr(out_dtype)
+    lhs_k_pack = _unwrap_if_constexpr(lhs_k_pack)
+    rhs_k_pack = _unwrap_if_constexpr(rhs_k_pack)
     assert out_dtype == float32, "Only float32 is supported for out_dtype at the moment"
     return _semantic.dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc, fast_math, lhs_k_pack,
                                 rhs_k_pack, out_dtype)
@@ -3060,6 +3065,7 @@ def associative_scan(input, axis, combine_fn, reverse=False, _semantic=None, _ge
             builder.create_scan_ret(*handles)
 
     axis = _unwrap_if_constexpr(axis)
+    reverse = _unwrap_if_constexpr(reverse)
     if axis is not None:
         axis = _wrap_axis(axis, len(input[0].shape))
     return _semantic.associative_scan(input, axis, make_combine_region, reverse)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1544,11 +1544,9 @@ class TritonSemantic(Generic[TensorTy]):
 
             return scale.handle
 
-        lhs_format_str = lhs_format.value if hasattr(lhs_format, 'value') else lhs_format
-        rhs_format_str = rhs_format.value if hasattr(rhs_format, 'value') else rhs_format
-        return ir.deduce_scale_factor(lhs.handle, _to_scale_handle(lhs_scale), self._str_to_fp_type(lhs_format_str),
+        return ir.deduce_scale_factor(lhs.handle, _to_scale_handle(lhs_scale), self._str_to_fp_type(lhs_format),
                                       lhs_k_pack, rhs.handle, _to_scale_handle(rhs_scale),
-                                      self._str_to_fp_type(rhs_format_str), rhs_k_pack)
+                                      self._str_to_fp_type(rhs_format), rhs_k_pack)
 
     def verify_scaled_shape(self, M, N, K, lhs_scale, rhs_scale, scale_factor):
         if lhs_scale is not None:
@@ -1565,16 +1563,11 @@ class TritonSemantic(Generic[TensorTy]):
     def dot_scaled(self, lhs: TensorTy, lhs_scale: TensorTy, lhs_format: str, rhs: TensorTy,
                    rhs_scale: Optional[TensorTy], rhs_format: str, acc: TensorTy | None, fast_math: bool,
                    lhs_k_pack: bool, rhs_k_pack: bool, out_dtype: tl.dtype) -> TensorTy:
-        fast_math = tl._unwrap_if_constexpr(fast_math)
-        lhs_k_pack = tl._unwrap_if_constexpr(lhs_k_pack)
-        rhs_k_pack = tl._unwrap_if_constexpr(rhs_k_pack)
         assert lhs.type.is_block() and rhs.type.is_block()
         #TODO: validate types.
         lhs_rank = len(lhs.shape)
         rhs_rank = len(rhs.shape)
         assert lhs_rank == rhs_rank == 2 or lhs_rank == rhs_rank == 3, f"Both inputs must be either 2D or 3D; (lhs: {lhs.shape} vs rhs: {rhs.shape})"
-        lhs_format: str = lhs_format.value
-        rhs_format: str = rhs_format.value
         lhs_format_enum = self._str_to_fp_type(lhs_format)
         rhs_format_enum = self._str_to_fp_type(rhs_format)
         allowed_formats = {"e2m1", "e4m3", "e5m2", "bf16", "fp16"}
@@ -1677,7 +1670,6 @@ class TritonSemantic(Generic[TensorTy]):
 
     def associative_scan(self, inputs: Sequence[TensorTy], axis: int, region_builder_fn,
                          reverse: bool) -> Tuple[TensorTy, ...]:
-        reverse = tl._unwrap_if_constexpr(reverse)
         shape = inputs[0].type.shape
         rank = len(shape)
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1537,12 +1537,9 @@ class TritonSemantic(Generic[TensorTy]):
     def deduce_scale_factor(self, lhs, lhs_scale, lhs_format, lhs_k_pack, rhs, rhs_scale, rhs_format, rhs_k_pack):
 
         def _to_scale_handle(scale):
-            if scale is None or isinstance(scale, tl.constexpr):
-                return None
-            elif isinstance(scale, tl.tensor) and scale.numel.value == 1:
-                return None
-
-            return scale.handle
+            if isinstance(scale, tl.tensor) and scale.numel.value != 1:
+                return scale.handle
+            return None
 
         return ir.deduce_scale_factor(lhs.handle, _to_scale_handle(lhs_scale), self._str_to_fp_type(lhs_format),
                                       lhs_k_pack, rhs.handle, _to_scale_handle(rhs_scale),


### PR DESCRIPTION
Small update to #10219

Unwrapping constexpr is usually done in core.py, not semantic.py. Keeping it in one place makes it easier to spot omissions.