### PR TITLE
[fpsan] Make embed/unembed IR nodes to enable canonicalization

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -106,6 +106,9 @@ void populateInstrumentationToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                            RewritePatternSet &patterns,
                                            const TargetInfoBase &targetInfo);
 
+void populateFpSanToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                 RewritePatternSet &patterns);
+
 void populateGSanToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                 RewritePatternSet &patterns,
                                 ModuleAxisInfoAnalysis &axisInfoAnalysis,

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -223,6 +223,7 @@ def TTI_ExperimentalFPSanEmbedOp : TTI_Op<"experimental_fpsan_embed", [
     $val attr-dict `:` functional-type(operands, $result)
   }];
 
+  let hasCanonicalizer = true;
   let hasFolder = true;
 }
 
@@ -239,6 +240,7 @@ def TTI_ExperimentalFPSanUnembedOp : TTI_Op<"experimental_fpsan_unembed", [
     $val attr-dict `:` functional-type(operands, $result)
   }];
 
+  let hasCanonicalizer = true;
   let hasFolder = true;
 }
 

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -206,4 +206,40 @@ def TTI_ExperimentalLockReleaseOp : TTI_Op<"experimental_lock_release", [MemoryE
   }];
 }
 
+
+// ===== FPSan ops =====
+
+
+def TTI_ExperimentalFPSanEmbedOp : TTI_Op<"experimental_fpsan_embed", [
+  Pure,
+  Elementwise,
+  SameOperandsAndResultShape,
+  SameOperandsAndResultEncoding
+]> {
+  let summary = "Embed float value in the fpsan integer ring";
+  let arguments = (ins TT_FloatLike:$val);
+  let results = (outs TT_IntLike:$result);
+  let assemblyFormat = [{
+    $val attr-dict `:` functional-type(operands, $result)
+  }];
+
+  let hasFolder = true;
+}
+
+def TTI_ExperimentalFPSanUnembedOp : TTI_Op<"experimental_fpsan_unembed", [
+  Pure,
+  Elementwise,
+  SameOperandsAndResultShape,
+  SameOperandsAndResultEncoding
+]> {
+  let summary = "Unembed fpsan integer payload as a float value";
+  let arguments = (ins TT_IntLike:$val);
+  let results = (outs TT_FloatLike:$result);
+  let assemblyFormat = [{
+    $val attr-dict `:` functional-type(operands, $result)
+  }];
+
+  let hasFolder = true;
+}
+
 #endif // TRITONINSTRUMENT_OPS

--- a/lib/Conversion/TritonInstrumentToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonInstrumentToLLVM/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_triton_library(TritonInstrumentToLLVM
     InstrumentationToLLVM.cpp
+    FpSanToLLVM.cpp
     GSanToLLVM.cpp
 
     LINK_LIBS PUBLIC

--- a/lib/Conversion/TritonInstrumentToLLVM/FpSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/FpSanToLLVM.cpp
@@ -1,0 +1,220 @@
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonInstrument/IR/Dialect.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/bit.h"
+#include <cassert>
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+
+namespace tti = mlir::triton::instrument;
+
+uint64_t invOddU64(uint64_t a) {
+  assert((a & 1) == 1);
+  uint64_t x = 2 - a;
+  for (unsigned correctBits = 2; correctBits < 64; correctBits *= 2)
+    x *= 2 - a * x;
+  return x;
+}
+
+uint64_t getOneBitPattern(FloatType floatTy) {
+  llvm::APFloat one(1.0);
+  bool losesInfo = false;
+  one.convert(floatTy.getFloatSemantics(), llvm::APFloat::rmNearestTiesToEven,
+              &losesInfo);
+  return one.bitcastToAPInt().getZExtValue();
+}
+
+struct PayloadMixConfig {
+  unsigned bitWidth;
+  unsigned shift;
+  uint64_t signMask;
+  uint64_t magMask;
+  uint64_t mulA;
+  uint64_t mulAInv;
+  uint64_t mulBPos;
+  uint64_t mulBNeg;
+  uint64_t mulBPosInv;
+  uint64_t mulBNegInv;
+};
+
+PayloadMixConfig getPayloadMixConfig(FloatType floatTy) {
+  unsigned bitWidth = floatTy.getWidth();
+  assert(bitWidth > 1 && bitWidth <= 64);
+  uint64_t signMask = uint64_t{1} << (bitWidth - 1);
+  uint64_t magMask = signMask - 1;
+
+  uint64_t oneBits = getOneBitPattern(floatTy);
+  assert(oneBits != 0 && "expected non-zero 1.0 bit pattern");
+  unsigned shift = llvm::countr_zero(oneBits);
+  assert(shift != 0 && "expected even 1.0 bit pattern");
+
+  // we firstly multiply by an arbitrary odd constant to mix from low
+  // bits to high whilst remaining invertible:
+  uint64_t mulA = 922291u & magMask;
+  uint64_t oneMixed = (oneBits * mulA) & magMask;
+  oneMixed ^= oneMixed >> shift;
+  assert((oneMixed & 1) == 1 && "expected odd mixed 1.0");
+
+  // the second multiplier is chosen so that the entire payload mixing
+  // operation maps the float 1.0 to the integer 1:
+  uint64_t mulBPos = invOddU64(oneMixed) & magMask;
+  uint64_t mulBNeg = (mulBPos * magMask) & magMask;
+  return PayloadMixConfig{
+      bitWidth,
+      shift,
+      signMask,
+      magMask,
+      mulA,
+      invOddU64(mulA) & magMask,
+      mulBPos,
+      mulBNeg,
+      invOddU64(mulBPos) & magMask,
+      invOddU64(mulBNeg) & magMask,
+  };
+}
+
+Value createUIntConstant(ConversionPatternRewriter &rewriter, Location loc,
+                         Type intTy, uint64_t value) {
+  auto intType = cast<IntegerType>(intTy);
+  auto attr = IntegerAttr::get(intType, llvm::APInt(intType.getWidth(), value));
+  return LLVM::ConstantOp::create(rewriter, loc, intType, attr);
+}
+
+Value selectUIntConstantOnSign(ConversionPatternRewriter &rewriter,
+                               Location loc, Value signSource,
+                               uint64_t signMaskValue,
+                               uint64_t nonNegativeValue,
+                               uint64_t negativeValue) {
+  TritonLLVMOpBuilder b(loc, rewriter);
+  auto intTy = signSource.getType();
+  Value signMask = createUIntConstant(rewriter, loc, intTy, signMaskValue);
+  Value zero = createUIntConstant(rewriter, loc, intTy, 0u);
+  Value sign = b.and_(signSource, signMask);
+  Value isNeg = b.icmp_ne(sign, zero);
+  Value nonNeg = createUIntConstant(rewriter, loc, intTy, nonNegativeValue);
+  Value neg = createUIntConstant(rewriter, loc, intTy, negativeValue);
+  return b.select(isNeg, neg, nonNeg);
+}
+
+Value xorShiftRight(ConversionPatternRewriter &rewriter, Location loc, Value v,
+                    unsigned shift) {
+  TritonLLVMOpBuilder b(loc, rewriter);
+  Value shiftValue = createUIntConstant(rewriter, loc, v.getType(), shift);
+  Value shifted = b.lshr(v, shiftValue);
+  return b.xor_(v, shifted);
+}
+
+Value inverseXorShiftRight(ConversionPatternRewriter &rewriter, Location loc,
+                           Value v, const PayloadMixConfig &cfg) {
+  for (unsigned shift = cfg.shift; shift < cfg.bitWidth; shift *= 2)
+    v = xorShiftRight(rewriter, loc, v, shift);
+  return v;
+}
+
+Value mixFloatToInt(ConversionPatternRewriter &rewriter, Location loc, Value u,
+                    FloatType floatTy) {
+  TritonLLVMOpBuilder b(loc, rewriter);
+  PayloadMixConfig cfg = getPayloadMixConfig(floatTy);
+  Value signFlip =
+      selectUIntConstantOnSign(rewriter, loc, u, cfg.signMask, 0, cfg.signMask);
+  Value x = b.xor_(u, signFlip);
+  Value mulA = createUIntConstant(rewriter, loc, u.getType(), cfg.mulA);
+  Value magMask = createUIntConstant(rewriter, loc, u.getType(), cfg.magMask);
+  Value yMul = b.mul(x, mulA);
+  Value y = b.and_(yMul, magMask);
+  Value z = xorShiftRight(rewriter, loc, y, cfg.shift);
+  Value mulB = selectUIntConstantOnSign(rewriter, loc, u, cfg.signMask,
+                                        cfg.mulBPos, cfg.mulBNeg);
+  Value wMul = b.mul(z, mulB);
+  Value w = b.and_(wMul, magMask);
+  return b.xor_(w, signFlip);
+}
+
+Value unmixIntToFloat(ConversionPatternRewriter &rewriter, Location loc,
+                      Value v, FloatType floatTy) {
+  TritonLLVMOpBuilder b(loc, rewriter);
+  PayloadMixConfig cfg = getPayloadMixConfig(floatTy);
+  Value signFlip =
+      selectUIntConstantOnSign(rewriter, loc, v, cfg.signMask, 0, cfg.signMask);
+  Value w = b.xor_(v, signFlip);
+  Value magMask = createUIntConstant(rewriter, loc, v.getType(), cfg.magMask);
+  Value mulBInv = selectUIntConstantOnSign(rewriter, loc, v, cfg.signMask,
+                                           cfg.mulBPosInv, cfg.mulBNegInv);
+  Value zMul = b.mul(w, mulBInv);
+  Value z = b.and_(zMul, magMask);
+  Value y = inverseXorShiftRight(rewriter, loc, z, cfg);
+  Value mulAInv = createUIntConstant(rewriter, loc, v.getType(), cfg.mulAInv);
+  Value xMul = b.mul(y, mulAInv);
+  Value x = b.and_(xMul, magMask);
+  return b.xor_(x, signFlip);
+}
+
+Value bitcastIfNeeded(ConversionPatternRewriter &rewriter, Location loc,
+                      Value value, Type dstTy) {
+  if (value.getType() == dstTy)
+    return value;
+  TritonLLVMOpBuilder b(loc, rewriter);
+  return b.bitcast(value, dstTy);
+}
+
+struct ExperimentalFPSanEmbedOpConversion
+    : public ConvertOpToLLVMPattern<tti::ExperimentalFPSanEmbedOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(tti::ExperimentalFPSanEmbedOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto floatTy = cast<FloatType>(getElementTypeOrSelf(op.getVal().getType()));
+    Type intTy = rewriter.getIntegerType(floatTy.getWidth());
+
+    SmallVector<Value> resultVals;
+    for (Value elem : unpackLLElements(loc, adaptor.getVal(), rewriter)) {
+      Value raw = bitcastIfNeeded(rewriter, loc, elem, intTy);
+      resultVals.push_back(mixFloatToInt(rewriter, loc, raw, floatTy));
+    }
+
+    Value result = packLLElements(loc, getTypeConverter(), resultVals, rewriter,
+                                  op.getType());
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct ExperimentalFPSanUnembedOpConversion
+    : public ConvertOpToLLVMPattern<tti::ExperimentalFPSanUnembedOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(tti::ExperimentalFPSanUnembedOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto floatTy = cast<FloatType>(getElementTypeOrSelf(op.getType()));
+    Type resultElemTy = getTypeConverter()->convertType(floatTy);
+
+    SmallVector<Value> resultVals;
+    for (Value elem : unpackLLElements(loc, adaptor.getVal(), rewriter)) {
+      Value raw = unmixIntToFloat(rewriter, loc, elem, floatTy);
+      resultVals.push_back(bitcastIfNeeded(rewriter, loc, raw, resultElemTy));
+    }
+
+    Value result = packLLElements(loc, getTypeConverter(), resultVals, rewriter,
+                                  op.getType());
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+} // namespace
+
+void mlir::triton::populateFpSanToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                               RewritePatternSet &patterns) {
+  patterns.add<ExperimentalFPSanEmbedOpConversion,
+               ExperimentalFPSanUnembedOpConversion>(typeConverter);
+}

--- a/lib/Dialect/TritonInstrument/IR/Ops.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Ops.cpp
@@ -6,3 +6,25 @@
 #include "triton/Dialect/TritonInstrument/IR/Ops.cpp.inc"
 
 #include "triton/Dialect/TritonInstrument/IR/OpsEnums.cpp.inc"
+
+namespace mlir {
+namespace triton {
+namespace instrument {
+
+OpFoldResult ExperimentalFPSanEmbedOp::fold(FoldAdaptor adaptor) {
+  if (auto unembed = getVal().getDefiningOp<ExperimentalFPSanUnembedOp>())
+    if (unembed.getVal().getType() == getType())
+      return unembed.getVal();
+  return {};
+}
+
+OpFoldResult ExperimentalFPSanUnembedOp::fold(FoldAdaptor adaptor) {
+  if (auto embed = getVal().getDefiningOp<ExperimentalFPSanEmbedOp>())
+    if (embed.getVal().getType() == getType())
+      return embed.getVal();
+  return {};
+}
+
+} // namespace instrument
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonInstrument/IR/Ops.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Ops.cpp
@@ -1,3 +1,5 @@
+#include "mlir/IR/PatternMatch.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
@@ -11,11 +13,65 @@ namespace mlir {
 namespace triton {
 namespace instrument {
 
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
+template <typename ViewOp, typename FPSanOp>
+struct PushFPSanThroughViewPattern : public OpRewritePattern<ViewOp> {
+  using OpRewritePattern<ViewOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ViewOp view,
+                                PatternRewriter &rewriter) const override {
+    auto fpsan = view->getOperand(0).template getDefiningOp<FPSanOp>();
+    if (!fpsan)
+      return failure();
+
+    auto resultTy = dyn_cast<RankedTensorType>(view->getResult(0).getType());
+    auto payloadTy = dyn_cast<RankedTensorType>(fpsan.getVal().getType());
+    if (!resultTy || !payloadTy)
+      return failure();
+
+    auto payloadViewTy = resultTy.clone(payloadTy.getElementType());
+    OperationState state(view.getLoc(), view->getName());
+    state.addOperands(fpsan.getVal());
+    state.addTypes(payloadViewTy);
+    state.addAttributes(view->getAttrs());
+    Operation *payloadView = rewriter.create(state);
+    auto moved = FPSanOp::create(rewriter, view.getLoc(), resultTy,
+                                 payloadView->getResult(0));
+    rewriter.replaceOp(view, moved->getResults());
+    return success();
+  }
+};
+
+template <typename FPSanOp>
+void addPushFPSanThroughViewPatterns(RewritePatternSet &patterns,
+                                     MLIRContext *context) {
+  patterns.add<PushFPSanThroughViewPattern<ttg::ConvertLayoutOp, FPSanOp>,
+               PushFPSanThroughViewPattern<tt::TransOp, FPSanOp>,
+               PushFPSanThroughViewPattern<tt::ReshapeOp, FPSanOp>,
+               PushFPSanThroughViewPattern<tt::BroadcastOp, FPSanOp>,
+               PushFPSanThroughViewPattern<tt::ExpandDimsOp, FPSanOp>>(context);
+}
+
+void ExperimentalFPSanEmbedOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  // view(embed(x)) -> embed(view(x))
+  addPushFPSanThroughViewPatterns<ExperimentalFPSanEmbedOp>(patterns, context);
+}
+
 OpFoldResult ExperimentalFPSanEmbedOp::fold(FoldAdaptor adaptor) {
   if (auto unembed = getVal().getDefiningOp<ExperimentalFPSanUnembedOp>())
     if (unembed.getVal().getType() == getType())
       return unembed.getVal();
   return {};
+}
+
+void ExperimentalFPSanUnembedOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  // view(unembed(x)) -> unembed(view(x))
+  addPushFPSanThroughViewPatterns<ExperimentalFPSanUnembedOp>(patterns,
+                                                              context);
 }
 
 OpFoldResult ExperimentalFPSanUnembedOp::fold(FoldAdaptor adaptor) {

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -10,10 +10,8 @@
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
 #include "triton/Dialect/TritonInstrument/Transforms/Passes.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
-#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/bit.h"
 #include <cassert>
 
 namespace mlir {
@@ -477,23 +475,6 @@ Value castScalarIntToIntLike(PatternRewriter &rewriter, Location loc,
   return scalar;
 }
 
-Value selectUIntConstantOnSign(PatternRewriter &rewriter, Location loc,
-                               Value signSource, uint64_t signMaskValue,
-                               uint64_t nonNegativeValue,
-                               uint64_t negativeValue) {
-  auto signMask =
-      getUIntConstantLike(rewriter, loc, signSource.getType(), signMaskValue);
-  auto zero = getUIntConstantLike(rewriter, loc, signSource.getType(), 0u);
-  auto sign = arith::AndIOp::create(rewriter, loc, signSource, signMask);
-  auto isNeg = arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::ne,
-                                     sign, zero);
-  auto nonNeg = getUIntConstantLike(rewriter, loc, signSource.getType(),
-                                    nonNegativeValue);
-  auto neg =
-      getUIntConstantLike(rewriter, loc, signSource.getType(), negativeValue);
-  return arith::SelectOp::create(rewriter, loc, isNeg, neg, nonNeg);
-}
-
 uint64_t getLowBitsMask(unsigned bitWidth) {
   assert(bitWidth > 0 && bitWidth <= 64);
   if (bitWidth == 64)
@@ -509,131 +490,25 @@ uint64_t invOddU64(uint64_t a) {
   return x;
 }
 
-uint64_t getOneBitPattern(FloatType floatTy) {
-  llvm::APFloat one(1.0);
-  bool losesInfo = false;
-  one.convert(floatTy.getFloatSemantics(), llvm::APFloat::rmNearestTiesToEven,
-              &losesInfo);
-  return one.bitcastToAPInt().getZExtValue();
-}
-
-struct PayloadMixConfig {
-  unsigned bitWidth;
-  unsigned shift;
-  uint64_t signMask;
-  uint64_t magMask;
-  uint64_t mulA;
-  uint64_t mulAInv;
-  uint64_t mulBPos;
-  uint64_t mulBNeg;
-  uint64_t mulBPosInv;
-  uint64_t mulBNegInv;
-};
-
-PayloadMixConfig getPayloadMixConfig(FloatType floatTy) {
-  unsigned bitWidth = floatTy.getWidth();
-  assert(bitWidth > 1 && bitWidth <= 64);
-  uint64_t signMask = uint64_t{1} << (bitWidth - 1);
-  uint64_t magMask = signMask - 1;
-
-  uint64_t oneBits = getOneBitPattern(floatTy);
-  assert(oneBits != 0 && "expected non-zero 1.0 bit pattern");
-  unsigned shift = llvm::countr_zero(oneBits);
-  assert(shift != 0 && "expected even 1.0 bit pattern");
-
-  // we firstly multiply by an arbitrary odd constant to mix from low
-  // bits to high whilst remaining invertible:
-  uint64_t mulA = 922291u & magMask;
-  uint64_t oneMixed = (oneBits * mulA) & magMask;
-  oneMixed ^= oneMixed >> shift;
-  assert((oneMixed & 1) == 1 && "expected odd mixed 1.0");
-
-  // the second multiplier is chosen so that the entire payload mixing
-  // operation maps the float 1.0 to the integer 1:
-  uint64_t mulBPos = invOddU64(oneMixed) & magMask;
-  uint64_t mulBNeg = (mulBPos * magMask) & magMask;
-  return PayloadMixConfig{
-      bitWidth,
-      shift,
-      signMask,
-      magMask,
-      mulA,
-      invOddU64(mulA) & magMask,
-      mulBPos,
-      mulBNeg,
-      invOddU64(mulBPos) & magMask,
-      invOddU64(mulBNeg) & magMask,
-  };
-}
-
-Value xorShiftRight(PatternRewriter &rewriter, Location loc, Value v,
-                    unsigned shift) {
-  auto shiftValue = getUIntConstantLike(rewriter, loc, v.getType(), shift);
-  auto shifted = arith::ShRUIOp::create(rewriter, loc, v, shiftValue);
-  return arith::XOrIOp::create(rewriter, loc, v, shifted);
-}
-
-Value inverseXorShiftRight(PatternRewriter &rewriter, Location loc, Value v,
-                           const PayloadMixConfig &cfg) {
-  for (unsigned shift = cfg.shift; shift < cfg.bitWidth; shift *= 2)
-    v = xorShiftRight(rewriter, loc, v, shift);
-  return v;
-}
-
-// Move float bit patterns into a payload domain where +0.0 maps to 0 and +1.0
-// maps to 1. Negative values use a different final multiplier so that -1.0
-// maps to the all-ones payload.
-Value mixFloatToInt(PatternRewriter &rewriter, Location loc, Value u,
-                    FloatType floatTy) {
-  PayloadMixConfig cfg = getPayloadMixConfig(floatTy);
-  auto signFlip =
-      selectUIntConstantOnSign(rewriter, loc, u, cfg.signMask, 0, cfg.signMask);
-  auto x = arith::XOrIOp::create(rewriter, loc, u, signFlip);
-  auto mulA = getUIntConstantLike(rewriter, loc, u.getType(), cfg.mulA);
-  auto magMask = getUIntConstantLike(rewriter, loc, u.getType(), cfg.magMask);
-  auto yMul = arith::MulIOp::create(rewriter, loc, x, mulA);
-  auto y = arith::AndIOp::create(rewriter, loc, yMul, magMask);
-  auto z = xorShiftRight(rewriter, loc, y, cfg.shift);
-  auto mulB = selectUIntConstantOnSign(rewriter, loc, u, cfg.signMask,
-                                       cfg.mulBPos, cfg.mulBNeg);
-  auto wMul = arith::MulIOp::create(rewriter, loc, z, mulB);
-  auto w = arith::AndIOp::create(rewriter, loc, wMul, magMask);
-  return arith::XOrIOp::create(rewriter, loc, w, signFlip);
-}
-
-Value unmixIntToFloat(PatternRewriter &rewriter, Location loc, Value v,
-                      FloatType floatTy) {
-  PayloadMixConfig cfg = getPayloadMixConfig(floatTy);
-  auto signFlip =
-      selectUIntConstantOnSign(rewriter, loc, v, cfg.signMask, 0, cfg.signMask);
-  auto w = arith::XOrIOp::create(rewriter, loc, v, signFlip);
-  auto magMask = getUIntConstantLike(rewriter, loc, v.getType(), cfg.magMask);
-  auto mulBInv = selectUIntConstantOnSign(rewriter, loc, v, cfg.signMask,
-                                          cfg.mulBPosInv, cfg.mulBNegInv);
-  auto zMul = arith::MulIOp::create(rewriter, loc, w, mulBInv);
-  auto z = arith::AndIOp::create(rewriter, loc, zMul, magMask);
-  auto y = inverseXorShiftRight(rewriter, loc, z, cfg);
-  auto mulAInv = getUIntConstantLike(rewriter, loc, v.getType(), cfg.mulAInv);
-  auto xMul = arith::MulIOp::create(rewriter, loc, y, mulAInv);
-  auto x = arith::AndIOp::create(rewriter, loc, xMul, magMask);
-  return arith::XOrIOp::create(rewriter, loc, x, signFlip);
-}
-
 Value embedToInt(PatternRewriter &rewriter, Location loc, Value v) {
   if (isa<IntegerType>(getElementType(v.getType())))
     return v;
-  auto intTy = getIntTypeLike(v.getType());
-  Value raw = tt::BitcastOp::create(rewriter, loc, intTy, v);
-  raw = mixFloatToInt(rewriter, loc, raw,
-                      cast<FloatType>(getElementType(v.getType())));
-  return raw;
+  return ExperimentalFPSanEmbedOp::create(rewriter, loc,
+                                          getIntTypeLike(v.getType()), v);
 }
 
 Value unembedToFloat(PatternRewriter &rewriter, Location loc, Value v,
                      Type floatTy) {
-  v = unmixIntToFloat(rewriter, loc, v,
-                      cast<FloatType>(getElementType(floatTy)));
-  return tt::BitcastOp::create(rewriter, loc, floatTy, v);
+  return ExperimentalFPSanUnembedOp::create(rewriter, loc, floatTy, v);
+}
+
+Value embedFloatBitsToInt(PatternRewriter &rewriter, Location loc,
+                          Value rawBits, FloatType floatElemTy) {
+  Type floatTy = floatElemTy;
+  if (auto ranked = dyn_cast<RankedTensorType>(rawBits.getType()))
+    floatTy = ranked.clone(floatElemTy);
+  Value rawFloat = tt::BitcastOp::create(rewriter, loc, floatTy, rawBits);
+  return embedToInt(rewriter, loc, rawFloat);
 }
 
 uint64_t stableStringHash(StringRef str) {
@@ -1134,7 +1009,7 @@ Value castDotScaledOperandToComputePayload(PatternRewriter &rewriter,
           getTypeWithElement(slice.getType(),
                              IntegerType::get(rewriter.getContext(),
                                               storageFloat.getWidth())));
-      payload = mixFloatToInt(rewriter, loc, raw, storageFloat);
+      payload = embedFloatBitsToInt(rewriter, loc, raw, storageFloat);
     }
     return castSignedIntValueToType(rewriter, loc, payload, computeIntTy);
   }
@@ -1153,7 +1028,7 @@ Value scaleI8ToF32Payload(PatternRewriter &rewriter, Location loc,
   Value scaleI32 = arith::ExtUIOp::create(rewriter, loc, i32Ty, scaleI);
   auto shift = getUIntConstantLike(rewriter, loc, i32Ty, 23);
   Value rawF32 = arith::ShLIOp::create(rewriter, loc, scaleI32, shift);
-  return mixFloatToInt(rewriter, loc, rawF32, rewriter.getF32Type());
+  return embedFloatBitsToInt(rewriter, loc, rawF32, rewriter.getF32Type());
 }
 
 Value scaleI8ToComputePayload(PatternRewriter &rewriter, Location loc,
@@ -1174,7 +1049,7 @@ Value scaleI8ToComputePayload(PatternRewriter &rewriter, Location loc,
   unsigned shiftValue = computeElem.getFPMantissaWidth() - 1;
   auto shift = getUIntConstantLike(rewriter, loc, computeIntTy, shiftValue);
   Value rawCompute = arith::ShLIOp::create(rewriter, loc, scaleComputeI, shift);
-  return mixFloatToInt(rewriter, loc, rawCompute, computeElem);
+  return embedFloatBitsToInt(rewriter, loc, rawCompute, computeElem);
 }
 
 Value castDotScaledScaleToComputePayload(PatternRewriter &rewriter,

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -109,3 +109,31 @@ tt.func private @experimental_gsan_tensordesc_info(
   tt.return
 }
 }
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_fpsan_embed
+// CHECK-NOT: tti.experimental_fpsan_embed
+// CHECK: llvm.bitcast %arg0 : f32 to i32
+// CHECK: llvm.mul
+// CHECK: llvm.xor
+tt.func private @experimental_fpsan_embed(%arg0: f32) -> i32 {
+  %0 = tti.experimental_fpsan_embed %arg0 : (f32) -> i32
+  tt.return %0 : i32
+}
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+// CHECK-LABEL: @experimental_fpsan_unembed
+// CHECK-NOT: tti.experimental_fpsan_unembed
+// CHECK: llvm.mul
+// CHECK: llvm.xor
+// CHECK: llvm.bitcast %{{.*}} : i32 to f32
+tt.func private @experimental_fpsan_unembed(%arg0: i32) -> f32 {
+  %0 = tti.experimental_fpsan_unembed %arg0 : (i32) -> f32
+  tt.return %0 : f32
+}
+}

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -1,5 +1,6 @@
 // RUN: split-file %s %t
 // RUN: triton-opt %t/success.mlir -split-input-file -tritoninstrument-fp-sanitizer | FileCheck %t/success.mlir
+// RUN: triton-opt %t/canonicalize.mlir -canonicalize | FileCheck %t/canonicalize.mlir
 // RUN: not triton-opt %t/unsupported.mlir -tritoninstrument-fp-sanitizer 2>&1 | FileCheck %t/unsupported.mlir --check-prefix=FPSANERR
 
 //--- success.mlir
@@ -93,7 +94,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @binary_ops
   tt.func public @binary_ops(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4xf32> {
-    // CHECK: tt.bitcast
+    // CHECK: tti.experimental_fpsan_embed
     // CHECK: arith.addi
     // CHECK: arith.subi
     // CHECK: arith.muli
@@ -112,10 +113,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 // -----
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @chained_ops
+  tt.func public @chained_ops(%a: tensor<4xf32>, %b: tensor<4xf32>, %c: tensor<4xf32>) -> tensor<4xf32> {
+    // CHECK: %[[A:.*]] = tti.experimental_fpsan_embed %arg0 : (tensor<4xf32>) -> tensor<4xi32>
+    // CHECK: %[[B:.*]] = tti.experimental_fpsan_embed %arg1 : (tensor<4xf32>) -> tensor<4xi32>
+    // CHECK: %[[SUM0:.*]] = arith.addi %[[A]], %[[B]] : tensor<4xi32>
+    // CHECK: %[[C:.*]] = tti.experimental_fpsan_embed %arg2 : (tensor<4xf32>) -> tensor<4xi32>
+    // CHECK: %[[SUM1:.*]] = arith.addi %[[SUM0]], %[[C]] : tensor<4xi32>
+    // CHECK: %[[OUT:.*]] = tti.experimental_fpsan_unembed %[[SUM1]] : (tensor<4xi32>) -> tensor<4xf32>
+    // CHECK: tt.return %[[OUT]] : tensor<4xf32>
+    %sum0 = arith.addf %a, %b : tensor<4xf32>
+    %sum1 = arith.addf %sum0, %c : tensor<4xf32>
+    tt.return %sum1 : tensor<4xf32>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @div_rem_ops
   tt.func public @div_rem_ops(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4xf32> {
-    // CHECK: tt.bitcast
-    // CHECK: arith.xori
+    // CHECK: tti.experimental_fpsan_embed
     // CHECK: arith.muli
     // CHECK-NOT: arith.divf
     // CHECK-NOT: arith.remf
@@ -145,7 +163,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @unary_ops
   tt.func public @unary_ops(%a: tensor<4xf32>) -> tensor<4xf32> {
     // CHECK-DAG: arith.constant dense<314159>
-    // CHECK: tt.bitcast
+    // CHECK: tti.experimental_fpsan_embed
     // CHECK: arith.muli
     // CHECK: arith.xori
     // CHECK: arith.xori
@@ -166,7 +184,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-DAG: arith.constant dense<1>
     // CHECK-DAG: arith.constant dense<0>
     // CHECK-DAG: arith.constant dense<-1555856531>
-    // CHECK: tt.bitcast
+    // CHECK: tti.experimental_fpsan_embed
     // CHECK: arith.muli
     // CHECK: arith.andi
     // CHECK: arith.cmpi
@@ -184,7 +202,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @cast_extf
   tt.func public @cast_extf(%a: tensor<4xf16>) -> tensor<4xf32> {
-    // CHECK: tt.bitcast
+    // CHECK: tti.experimental_fpsan_embed
     // CHECK: arith.extsi
     // CHECK-NOT: arith.extf
     %0 = arith.extf %a : tensor<4xf16> to tensor<4xf32>
@@ -197,7 +215,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @cast_truncf
   tt.func public @cast_truncf(%a: tensor<4xf32>) -> tensor<4xf16> {
-    // CHECK: tt.bitcast
+    // CHECK: tti.experimental_fpsan_embed
     // CHECK: arith.trunci
     // CHECK-NOT: arith.truncf
     %0 = arith.truncf %a : tensor<4xf32> to tensor<4xf16>
@@ -210,7 +228,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @cast_fp_to_fp
   tt.func public @cast_fp_to_fp(%a: tensor<4xf8E4M3FN>) -> tensor<4xf16> {
-    // CHECK: tt.bitcast
+    // CHECK: tti.experimental_fpsan_embed
     // CHECK: arith.extsi
     // CHECK-NOT: tt.fp_to_fp
     %0 = tt.fp_to_fp %a : tensor<4xf8E4M3FN> -> tensor<4xf16>
@@ -239,7 +257,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // CHECK-LABEL: @extern_unary
 tt.func public @extern_unary(%a: tensor<4xf32>) -> tensor<4xf32> {
-  // CHECK: tt.bitcast
+  // CHECK: tti.experimental_fpsan_embed
   // CHECK: arith.xori
   // CHECK-NOT: tt.extern_elementwise
   %0 = tt.extern_elementwise %a {libname = "", libpath = "", pure = true, symbol = "__nv_tanf"} : (tensor<4xf32>) -> tensor<4xf32>
@@ -250,7 +268,7 @@ tt.func public @extern_unary(%a: tensor<4xf32>) -> tensor<4xf32> {
 
 // CHECK-LABEL: @extern_binary
 tt.func public @extern_binary(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4xf32> {
-  // CHECK: tt.bitcast
+  // CHECK: tti.experimental_fpsan_embed
   // CHECK: arith.addi
   // CHECK: arith.xori
   // CHECK-NOT: tt.extern_elementwise
@@ -262,7 +280,7 @@ tt.func public @extern_binary(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4x
 
 // CHECK-LABEL: @extern_ternary
 tt.func public @extern_ternary(%a: tensor<4xf32>, %b: tensor<4xf32>, %c: tensor<4xf32>) -> tensor<4xf32> {
-  // CHECK: tt.bitcast
+  // CHECK: tti.experimental_fpsan_embed
   // CHECK: arith.addi
   // CHECK: arith.xori
   // CHECK-NOT: tt.extern_elementwise
@@ -274,12 +292,27 @@ tt.func public @extern_ternary(%a: tensor<4xf32>, %b: tensor<4xf32>, %c: tensor<
 
 // CHECK-LABEL: @extern_mixed
 tt.func public @extern_mixed(%a: tensor<4xf32>, %b: tensor<4xi32>) -> tensor<4xf32> {
-  // CHECK: tt.bitcast
+  // CHECK: tti.experimental_fpsan_embed
   // CHECK: arith.addi
   // CHECK: arith.xori
   // CHECK-NOT: tt.extern_elementwise
   %0 = tt.extern_elementwise %a, %b {libname = "", libpath = "", pure = true, symbol = "__nv_ldexpf"} : (tensor<4xf32>, tensor<4xi32>) -> tensor<4xf32>
   tt.return %0 : tensor<4xf32>
+}
+
+//--- canonicalize.mlir
+
+module {
+  // CHECK-LABEL: @fold_fpsan_embedding_roundtrips
+  tt.func public @fold_fpsan_embedding_roundtrips(%arg0: tensor<4xi32>, %arg1: tensor<4xf32>) -> (tensor<4xi32>, tensor<4xf32>) {
+    // CHECK-NOT: tti.experimental_fpsan
+    // CHECK: tt.return %arg0, %arg1
+    %0 = tti.experimental_fpsan_unembed %arg0 : (tensor<4xi32>) -> tensor<4xf32>
+    %1 = tti.experimental_fpsan_embed %0 : (tensor<4xf32>) -> tensor<4xi32>
+    %2 = tti.experimental_fpsan_embed %arg1 : (tensor<4xf32>) -> tensor<4xi32>
+    %3 = tti.experimental_fpsan_unembed %2 : (tensor<4xi32>) -> tensor<4xf32>
+    tt.return %1, %3 : tensor<4xi32>, tensor<4xf32>
+  }
 }
 
 //--- unsupported.mlir

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -315,6 +315,45 @@ module {
   }
 }
 
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @push_unembed_through_views
+  tt.func public @push_unembed_through_views(
+      %arg0: tensor<16x16xi32, #blocked>,
+      %arg1: tensor<2x4xi32>,
+      %arg2: tensor<8xi32>,
+      %arg3: tensor<1x4xi32>,
+      %arg4: tensor<4xi32>) ->
+      (tensor<16x16xf32, #blocked1>, tensor<4x2xf32>, tensor<2x4xf32>,
+       tensor<2x4xf32>, tensor<1x4xf32>) {
+    // CHECK: %[[CVT:.*]] = ttg.convert_layout %arg0 : tensor<16x16xi32, #blocked> -> tensor<16x16xi32, #blocked1>
+    // CHECK: %[[CVT_OUT:.*]] = tti.experimental_fpsan_unembed %[[CVT]] : (tensor<16x16xi32, #blocked1>) -> tensor<16x16xf32, #blocked1>
+    // CHECK: %[[TRANS:.*]] = tt.trans %arg1 {order = array<i32: 1, 0>} : tensor<2x4xi32> -> tensor<4x2xi32>
+    // CHECK: %[[TRANS_OUT:.*]] = tti.experimental_fpsan_unembed %[[TRANS]] : (tensor<4x2xi32>) -> tensor<4x2xf32>
+    // CHECK: %[[RESHAPE:.*]] = tt.reshape %arg2 : tensor<8xi32> -> tensor<2x4xi32>
+    // CHECK: %[[RESHAPE_OUT:.*]] = tti.experimental_fpsan_unembed %[[RESHAPE]] : (tensor<2x4xi32>) -> tensor<2x4xf32>
+    // CHECK: %[[BCAST:.*]] = tt.broadcast %arg3 : tensor<1x4xi32> -> tensor<2x4xi32>
+    // CHECK: %[[BCAST_OUT:.*]] = tti.experimental_fpsan_unembed %[[BCAST]] : (tensor<2x4xi32>) -> tensor<2x4xf32>
+    // CHECK: %[[EXPAND:.*]] = tt.expand_dims %arg4 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    // CHECK: %[[EXPAND_OUT:.*]] = tti.experimental_fpsan_unembed %[[EXPAND]] : (tensor<1x4xi32>) -> tensor<1x4xf32>
+    %0 = tti.experimental_fpsan_unembed %arg0 : (tensor<16x16xi32, #blocked>) -> tensor<16x16xf32, #blocked>
+    %1 = ttg.convert_layout %0 : tensor<16x16xf32, #blocked> -> tensor<16x16xf32, #blocked1>
+    %2 = tti.experimental_fpsan_unembed %arg1 : (tensor<2x4xi32>) -> tensor<2x4xf32>
+    %3 = tt.trans %2 {order = array<i32: 1, 0>} : tensor<2x4xf32> -> tensor<4x2xf32>
+    %4 = tti.experimental_fpsan_unembed %arg2 : (tensor<8xi32>) -> tensor<8xf32>
+    %5 = tt.reshape %4 : tensor<8xf32> -> tensor<2x4xf32>
+    %6 = tti.experimental_fpsan_unembed %arg3 : (tensor<1x4xi32>) -> tensor<1x4xf32>
+    %7 = tt.broadcast %6 : tensor<1x4xf32> -> tensor<2x4xf32>
+    %8 = tti.experimental_fpsan_unembed %arg4 : (tensor<4xi32>) -> tensor<4xf32>
+    %9 = tt.expand_dims %8 {axis = 0 : i32} : tensor<4xf32> -> tensor<1x4xf32>
+    tt.return %1, %3, %5, %7, %9 : tensor<16x16xf32, #blocked1>, tensor<4x2xf32>,
+                                          tensor<2x4xf32>, tensor<2x4xf32>, tensor<1x4xf32>
+  }
+}
+
 //--- unsupported.mlir
 
 module {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -246,6 +246,7 @@ struct ConvertTritonAMDGPUToLLVM
 
     mlir::triton::populateInstrumentationToLLVMPatterns(typeConverter, patterns,
                                                         targetInfo);
+    mlir::triton::populateFpSanToLLVMPatterns(typeConverter, patterns);
 
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns)))) {
       return signalPassFailure();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -209,6 +209,7 @@ struct ConvertTritonGPUToLLVM
                                                         benefit);
     mlir::triton::populateInstrumentationToLLVMPatterns(typeConverter, patterns,
                                                         targetInfo);
+    mlir::triton::populateFpSanToLLVMPatterns(typeConverter, patterns);
     mlir::triton::populateGSanToLLVMPatterns(typeConverter, patterns,
                                              axisInfoAnalysis, targetInfo);
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. [fpsan] Make embed/unembed IR nodes to enable canonicalization
    
    Currently the embed and unembed operations generate a tonne of IR for
    every operation, and then we rely on llvm instcombine to realize that
    the unembed -> embed flow is a no-op. This instead adds IR nodes which
    we can fold straight away, and greatly reduce the triton IR and llvm IR
    generated.
    
    We also only expand the embed/unembed expressions during llvm lowering,
    which further reduces the ttir bloat generated by fpsan.
1. Prevent view ops from breaking canonicalization

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #10232 👈 **YOU ARE HERE**
1. #10233
1. #10235


</git-pr-chain>


