### PR TITLE
[fpsan] Store to scratch buffers in embedded form

### DIFF
--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -27,6 +27,9 @@ namespace ttng = mlir::triton::nvidia_gpu;
 
 namespace {
 
+Type getIntTypeLike(Type ty);
+bool isFloatLike(Type ty) { return isa<FloatType>(getElementTypeOrSelf(ty)); }
+
 static bool isValueAvailableInScope(Value value, Region *scope) {
   if (!scope)
     return false;
@@ -104,6 +107,48 @@ struct ScratchState {
   DenseMap<Region *, ScratchInfo> byScope;
 };
 
+Type getScratchStorageElementType(Type elemTy) {
+  if (auto floatTy = dyn_cast<FloatType>(elemTy))
+    return IntegerType::get(elemTy.getContext(), floatTy.getWidth());
+  return elemTy;
+}
+
+RankedTensorType getScratchStorageType(RankedTensorType tensorTy) {
+  auto elemTy = getScratchStorageElementType(tensorTy.getElementType());
+  return tensorTy.clone(elemTy);
+}
+
+Value embedToInt(PatternRewriter &rewriter, Location loc, Value v) {
+  if (isa<IntegerType>(getElementTypeOrSelf(v.getType())))
+    return v;
+  return ExperimentalFPSanEmbedOp::create(rewriter, loc,
+                                          getIntTypeLike(v.getType()), v);
+}
+
+Value unembedToFloat(PatternRewriter &rewriter, Location loc, Value v,
+                     Type floatTy) {
+  return ExperimentalFPSanUnembedOp::create(rewriter, loc, floatTy, v);
+}
+
+Value loadFpSanScratchMemory(PatternRewriter &rewriter, Location loc,
+                             Value alloc, RankedTensorType tensorTy) {
+  auto storageTy = getScratchStorageType(tensorTy);
+  Value stored = createLoadScratchMemory(rewriter, loc, alloc, storageTy);
+  if (isFloatLike(tensorTy))
+    return unembedToFloat(rewriter, loc, stored, tensorTy);
+  return stored;
+}
+
+Operation *storeFpSanScratchMemory(PatternRewriter &rewriter, Location loc,
+                                   Value alloc, Value tensor,
+                                   RankedTensorType tensorTy) {
+  auto storageTy = getScratchStorageType(tensorTy);
+  Value stored = tensor;
+  if (isFloatLike(tensorTy))
+    stored = embedToInt(rewriter, loc, tensor);
+  return createStoreScratchMemory(rewriter, loc, alloc, stored, storageTy);
+}
+
 class TmemScratchManager {
 public:
   ttg::BlockedEncodingAttr getScratchEncoding(PatternRewriter &rewriter,
@@ -173,11 +218,12 @@ public:
       auto layout = getScratchEncoding(rewriter, memdesc, memTy);
       auto tensorTy = RankedTensorType::get(memTy.getShape(),
                                             memTy.getElementType(), layout);
+      auto storageElemTy = getScratchStorageElementType(memTy.getElementType());
 
       int64_t elSize = memTy.getElementType().getIntOrFloatBitWidth() / 8;
       int64_t alignment = std::max<int64_t>(elSize, 16);
       int64_t sizeInBytes = product(memTy.getShape()) * elSize;
-      auto ptrTy = triton::getPointerType(memTy.getElementType());
+      auto ptrTy = triton::getPointerType(storageElemTy);
       auto allocOp = createThirdPartyScratchAlloc(rewriter, loc, ptrTy,
                                                   sizeInBytes, alignment);
       allocOp->setDiscardableAttr("tt.divisibility",
@@ -186,7 +232,7 @@ public:
 
       if (Value init = alloc.getSrc()) {
         auto initTy = cast<RankedTensorType>(init.getType());
-        if (!createStoreScratchMemory(rewriter, loc, ptr, init, initTy))
+        if (!storeFpSanScratchMemory(rewriter, loc, ptr, init, initTy))
           return std::nullopt;
       }
 
@@ -270,7 +316,8 @@ public:
       rewriter.setInsertionPoint(view);
       auto loc = view.getLoc();
       Value ptr = baseInfo->ptr;
-      auto ptrTy = triton::getPointerType(memTy.getElementType());
+      auto ptrTy = triton::getPointerType(
+          getScratchStorageElementType(memTy.getElementType()));
       if (ptr.getType() != ptrTy) {
         ptr = tt::BitcastOp::create(rewriter, loc, ptrTy, ptr);
       }
@@ -323,16 +370,17 @@ private:
 
 Value createScratchAndStore(PatternRewriter &rewriter, Location loc, Value val,
                             RankedTensorType tensorTy) {
+  auto storageTy = getScratchStorageType(tensorTy);
   int64_t elSize = tensorTy.getElementType().getIntOrFloatBitWidth() / 8;
   int64_t alignment = std::max<int64_t>(elSize, 16);
   int64_t sizeInBytes = product(tensorTy.getShape()) * elSize;
-  auto ptrTy = triton::getPointerType(tensorTy.getElementType());
+  auto ptrTy = triton::getPointerType(storageTy.getElementType());
   auto allocOp = createThirdPartyScratchAlloc(rewriter, loc, ptrTy, sizeInBytes,
                                               alignment);
   allocOp->setDiscardableAttr("tt.divisibility",
                               rewriter.getI64IntegerAttr(alignment));
-  if (!createStoreScratchMemory(rewriter, loc, allocOp.getResult(), val,
-                                tensorTy))
+  if (!storeFpSanScratchMemory(rewriter, loc, allocOp.getResult(), val,
+                               tensorTy))
     return Value();
   return allocOp.getResult();
 }
@@ -366,8 +414,6 @@ Type getElementType(Type ty) {
     return shaped.getElementType();
   return ty;
 }
-
-bool isFloatLike(Type ty) { return isa<FloatType>(getElementType(ty)); }
 
 LogicalResult emitFpSanUnsupported(Operation *op) {
   op->emitOpError() << "unsupported by fpsan";
@@ -488,18 +534,6 @@ uint64_t invOddU64(uint64_t a) {
   for (unsigned correctBits = 2; correctBits < 64; correctBits *= 2)
     x *= 2 - a * x;
   return x;
-}
-
-Value embedToInt(PatternRewriter &rewriter, Location loc, Value v) {
-  if (isa<IntegerType>(getElementType(v.getType())))
-    return v;
-  return ExperimentalFPSanEmbedOp::create(rewriter, loc,
-                                          getIntTypeLike(v.getType()), v);
-}
-
-Value unembedToFloat(PatternRewriter &rewriter, Location loc, Value v,
-                     Type floatTy) {
-  return ExperimentalFPSanUnembedOp::create(rewriter, loc, floatTy, v);
 }
 
 Value embedFloatBitsToInt(PatternRewriter &rewriter, Location loc,
@@ -802,7 +836,7 @@ createOperandScratch(PatternRewriter &rewriter, Location loc,
     auto info = scratch.getOrCreate(memdesc, rewriter, scope);
     if (!info)
       return std::nullopt;
-    fullVal = createLoadScratchMemory(rewriter, loc, info->ptr, tensorTy);
+    fullVal = loadFpSanScratchMemory(rewriter, loc, info->ptr, tensorTy);
     if (!fullVal)
       return std::nullopt;
   } else {
@@ -813,13 +847,14 @@ createOperandScratch(PatternRewriter &rewriter, Location loc,
   int64_t elSize = memTy.getElementType().getIntOrFloatBitWidth() / 8;
   int64_t alignment = std::max<int64_t>(elSize, 16);
   int64_t sizeInBytes = product(memTy.getShape()) * elSize;
-  auto ptrTy = triton::getPointerType(memTy.getElementType());
+  auto ptrTy = triton::getPointerType(
+      getScratchStorageElementType(memTy.getElementType()));
   auto allocOp = createThirdPartyScratchAlloc(rewriter, loc, ptrTy, sizeInBytes,
                                               alignment);
   allocOp->setDiscardableAttr("tt.divisibility",
                               rewriter.getI64IntegerAttr(alignment));
   Value ptr = allocOp.getResult();
-  if (!createStoreScratchMemory(rewriter, loc, ptr, fullVal, tensorTy))
+  if (!storeFpSanScratchMemory(rewriter, loc, ptr, fullVal, tensorTy))
     return std::nullopt;
   return ScratchInfo{ptr, tensorTy};
 }
@@ -916,10 +951,15 @@ Value createPointerTensorStrided2D(PatternRewriter &rewriter, Location loc,
 Value loadScratchStrided2D(PatternRewriter &rewriter, Location loc, Value base,
                            RankedTensorType tensorTy, int64_t stride0,
                            int64_t stride1) {
-  auto ptrTensor = createPointerTensorStrided2D(rewriter, loc, base, tensorTy,
+  auto storageTy = getScratchStorageType(tensorTy);
+  auto ptrTensor = createPointerTensorStrided2D(rewriter, loc, base, storageTy,
                                                 stride0, stride1);
-  return tt::LoadOp::create(rewriter, loc, ptrTensor, CacheModifier::NONE,
-                            EvictionPolicy::NORMAL, false);
+  Value stored =
+      tt::LoadOp::create(rewriter, loc, ptrTensor, CacheModifier::NONE,
+                         EvictionPolicy::NORMAL, false);
+  if (isFloatLike(tensorTy))
+    return unembedToFloat(rewriter, loc, stored, tensorTy);
+  return stored;
 }
 
 Value loadScratchStrided2D(PatternRewriter &rewriter, Location loc, Value base,
@@ -932,9 +972,13 @@ Operation *storeScratchStrided2D(PatternRewriter &rewriter, Location loc,
                                  Value base, Value tensor,
                                  RankedTensorType tensorTy, int64_t stride0,
                                  int64_t stride1) {
-  auto ptrTensor = createPointerTensorStrided2D(rewriter, loc, base, tensorTy,
+  auto storageTy = getScratchStorageType(tensorTy);
+  auto ptrTensor = createPointerTensorStrided2D(rewriter, loc, base, storageTy,
                                                 stride0, stride1);
-  return tt::StoreOp::create(rewriter, loc, ptrTensor, tensor,
+  Value stored = tensor;
+  if (isFloatLike(tensorTy))
+    stored = embedToInt(rewriter, loc, tensor);
+  return tt::StoreOp::create(rewriter, loc, ptrTensor, stored,
                              CacheModifier::NONE, EvictionPolicy::NORMAL);
 }
 
@@ -1671,7 +1715,7 @@ struct DotPattern : public OpRewritePattern<tt::DotOp> {
     Value out = aTy.getRank() == 2
                     ? loadScratchStrided2D(rewriter, loc, dPtr, cTy,
                                            /*stride1=*/m)
-                    : createLoadScratchMemory(rewriter, loc, dPtr, cTy);
+                    : loadFpSanScratchMemory(rewriter, loc, dPtr, cTy);
     if (!out)
       return emitFpSanCodegenError(op.getOperation());
     rewriter.replaceOp(op, out);
@@ -1832,7 +1876,7 @@ struct TMEMLoadPattern : public OpRewritePattern<ttng::TMEMLoadOp> {
     auto resultTy = cast<RankedTensorType>(op.getResult().getType());
     if (!resultTy.getEncoding())
       return emitFpSanUnsupported(op.getOperation());
-    Value result = createLoadScratchMemory(rewriter, loc, info->ptr, resultTy);
+    Value result = loadFpSanScratchMemory(rewriter, loc, info->ptr, resultTy);
     if (!result)
       return emitFpSanCodegenError(op.getOperation());
 
@@ -1869,7 +1913,7 @@ struct TMEMStorePattern : public OpRewritePattern<ttng::TMEMStoreOp> {
     auto srcTy = cast<RankedTensorType>(op.getSrc().getType());
     if (!srcTy.getEncoding())
       return emitFpSanUnsupported(op.getOperation());
-    if (!createStoreScratchMemory(rewriter, loc, info->ptr, op.getSrc(), srcTy))
+    if (!storeFpSanScratchMemory(rewriter, loc, info->ptr, op.getSrc(), srcTy))
       return emitFpSanCodegenError(op.getOperation());
 
     createGlobalScratchBarrier(rewriter, loc);
@@ -1911,7 +1955,7 @@ struct TMEMCopyPattern : public OpRewritePattern<ttng::TMEMCopyOp> {
     Value srcReg =
         ttg::LocalLoadOp::create(rewriter, loc, srcRegTy, op.getSrc(), Value())
             .getResult();
-    if (!createStoreScratchMemory(rewriter, loc, info->ptr, srcReg, srcRegTy))
+    if (!storeFpSanScratchMemory(rewriter, loc, info->ptr, srcReg, srcRegTy))
       return emitFpSanCodegenError(op.getOperation());
 
     createGlobalScratchBarrier(rewriter, loc);

--- a/test/TritonGPU/fpsan.mlir
+++ b/test/TritonGPU/fpsan.mlir
@@ -74,11 +74,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @warp_group_dot_emulation
   tt.func public @warp_group_dot_emulation() -> tensor<64x32xf32, #mma> {
+    // CHECK: ttg.local_load
+    // CHECK: tti.experimental_fpsan_embed
+    // CHECK: tt.store
     // CHECK: ttg.barrier global_read|global_write
     // CHECK: scf.for
     // CHECK: ttg.barrier global_read|global_write
+    // CHECK: %[[RAW:.*]] = tt.load
+    // CHECK: %[[OUT:.*]] = tti.experimental_fpsan_unembed %[[RAW]]
     // CHECK-NOT: ttng.warp_group_dot {{.*}} :
-    // CHECK: ttng.warp_group_dot_wait
+    // CHECK: ttng.warp_group_dot_wait %[[OUT]]
     %a = ttg.local_alloc : () -> !ttg.memdesc<64x32xf32, #shared, #smem, mutable>
     %b = ttg.local_alloc : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %c = arith.constant dense<0.000000e+00> : tensor<64x32xf32, #mma>
@@ -86,6 +91,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %d = ttng.warp_group_dot %a, %b, %c, %true {inputPrecision = 1 : i32, isAsync = true} : !ttg.memdesc<64x32xf32, #shared, #smem, mutable> * !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<64x32xf32, #mma>
     %wait = ttng.warp_group_dot_wait %d {pendings = 0 : i32} : tensor<64x32xf32, #mma>
     tt.return %wait : tensor<64x32xf32, #mma>
+  }
+}
+
+// -----
+
+#tmem_linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_scratch_payloads
+  tt.func public @tmem_scratch_payloads(%arg0: tensor<128x64xf32, #tmem_linear>) -> tensor<128x64xf32, #tmem_linear> {
+    // CHECK: %[[PAYLOAD:.*]] = tti.experimental_fpsan_embed %arg0
+    // CHECK: tt.store {{.*}}, %[[PAYLOAD]]
+    // CHECK: %[[RAW:.*]] = tt.load
+    // CHECK: %[[OUT:.*]] = tti.experimental_fpsan_unembed %[[RAW]]
+    // CHECK: tt.return %[[OUT]]
+    // CHECK-NOT: ttng.tmem_store
+    // CHECK-NOT: ttng.tmem_load
+    %true = arith.constant true
+    %tmem = ttng.tmem_alloc : () -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %arg0, %tmem, %true : tensor<128x64xf32, #tmem_linear> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    %out = ttng.tmem_load %tmem : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #tmem_linear>
+    tt.return %out : tensor<128x64xf32, #tmem_linear>
   }
 }
 

--- a/test/TritonGPU/nvidia-fpsan.mlir
+++ b/test/TritonGPU/nvidia-fpsan.mlir
@@ -230,8 +230,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   tt.func public @ws_partition_tmem_load() {
     // CHECK: %[[SCRATCH:.*]] = ttg.global_scratch_alloc
     // CHECK: ttg.warp_specialize(%{{.*}}, %{{.*}}, %{{.*}}, %[[SCRATCH]])
-    // CHECK: partition0(%{{.*}}: !ttg.memdesc<1xi64, #{{[^,>]+}}, #smem, mutable>, %{{.*}}: !ttg.memdesc<128x128xf32, #{{[^,>]+}}, #smem, mutable>, %{{.*}}: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %[[SCRATCH_ARG:.*]]: !tt.ptr<f32>) num_warps(4)
-    // CHECK: %[[PTRS:.*]] = tt.splat %[[SCRATCH_ARG]] : !tt.ptr<f32> -> tensor<128x128x!tt.ptr<f32>, #blocked>
+    // CHECK: partition0(%{{.*}}: !ttg.memdesc<1xi64, #{{[^,>]+}}, #smem, mutable>, %{{.*}}: !ttg.memdesc<128x128xf32, #{{[^,>]+}}, #smem, mutable>, %{{.*}}: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %[[SCRATCH_ARG:.*]]: !tt.ptr<i32>) num_warps(4)
+    // CHECK: %[[PTRS:.*]] = tt.splat %[[SCRATCH_ARG]] : !tt.ptr<i32> -> tensor<128x128x!tt.ptr<i32>, #blocked>
     // CHECK: tt.load
     // CHECK: ttg.local_store
     // CHECK-NOT: ttng.tmem_load


### PR DESCRIPTION
<git-pr-chain>


[fpsan] Store to scratch buffers in embedded form

Currently in the emulated mma loop, we have a sequence like:
```
load
embed
compute
unembed
store
```

and since we accumulate many times into the same accumulator, this ends up with a
lot of redundant embedding and unembedding. Instead, this changes the
scratch manager to store the embedded form directly.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #10233 👈 **YOU ARE HERE**
1. #10235


</git-pr-chain>



