### PR TITLE
[NFC] Remove getElementType helper functions

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -9,17 +9,6 @@
 
 using namespace mlir::triton::gpu;
 
-namespace mlir::triton::gpu {
-
-Type getElementType(Value value) {
-  auto type = value.getType();
-  if (auto tensorType = dyn_cast<RankedTensorType>(type))
-    return tensorType.getElementType();
-  return type;
-}
-
-} // namespace mlir::triton::gpu
-
 namespace {
 
 int getNumElementsPerThreads(Type type,
@@ -233,7 +222,7 @@ struct ElementwiseInlineAsmOpConversion
     SmallVector<Value> packedOperands;
     unsigned numPackedElements = op.getPackedElement();
     for (int i = 0, e = op.getNumOperands(); i < e; i++) {
-      Type elemTy = getElementType(op.getOperand(i));
+      Type elemTy = getElementTypeOrSelf(op.getOperand(i));
       unsigned bitWidth =
           elemTy.isIntOrFloat() ? elemTy.getIntOrFloatBitWidth() : 64;
       unsigned numElementPerReg = std::max(32 / bitWidth, 1u);
@@ -274,7 +263,7 @@ struct ElementwiseInlineAsmOpConversion
     // wrapped in a struct.
     SmallVector<Type> asmRetTypes;
     for (auto result : op.getResult()) {
-      auto ty = getTypeConverter()->convertType(getElementType(result));
+      auto ty = getTypeConverter()->convertType(getElementTypeOrSelf(result));
 
       // Pack return elements into 32-bits.
       unsigned bitWidth = getIntOrFloatOrPtrBitWidth(ty);

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -29,6 +29,12 @@ namespace {
 
 Type getIntTypeLike(Type ty);
 bool isFloatLike(Type ty) { return isa<FloatType>(getElementTypeOrSelf(ty)); }
+bool isIntLike(Type ty) { return isa<IntegerType>(getElementTypeOrSelf(ty)); }
+
+bool isNumericLike(Type ty) {
+  Type elemTy = getElementTypeOrSelf(ty);
+  return isa<FloatType>(elemTy) || isa<IntegerType>(elemTy);
+}
 
 static bool isValueAvailableInScope(Value value, Region *scope) {
   if (!scope)
@@ -409,12 +415,6 @@ Region *getScratchScopeRegion(Operation *anchor) {
 // Utility functions
 // ------------------------------------------------------------
 
-Type getElementType(Type ty) {
-  if (auto shaped = dyn_cast<ShapedType>(ty))
-    return shaped.getElementType();
-  return ty;
-}
-
 LogicalResult emitFpSanUnsupported(Operation *op) {
   op->emitOpError() << "unsupported by fpsan";
   return failure();
@@ -432,7 +432,7 @@ LogicalResult emitFpSanInvariantError(Operation *op) {
 }
 
 Type getIntTypeLike(Type ty) {
-  auto elem = dyn_cast<FloatType>(getElementType(ty));
+  auto elem = dyn_cast<FloatType>(getElementTypeOrSelf(ty));
   if (!elem)
     return Type();
 
@@ -448,7 +448,7 @@ Type getIntTypeLike(Type ty) {
 }
 
 unsigned getIntBitwidth(Type ty) {
-  auto elem = cast<IntegerType>(getElementType(ty));
+  auto elem = cast<IntegerType>(getElementTypeOrSelf(ty));
   return elem.getWidth();
 }
 
@@ -513,7 +513,7 @@ Value castSignedIntValueToType(PatternRewriter &rewriter, Location loc, Value v,
 
 Value castScalarIntToIntLike(PatternRewriter &rewriter, Location loc,
                              Value scalar, Type targetTy) {
-  auto elemTy = cast<IntegerType>(getElementType(targetTy));
+  auto elemTy = cast<IntegerType>(getElementTypeOrSelf(targetTy));
   if (scalar.getType() != elemTy)
     scalar = castSignedIntValueToType(rewriter, loc, scalar, elemTy);
   if (isa<ShapedType>(targetTy))
@@ -654,7 +654,7 @@ Value fpsanExp2FromInt(PatternRewriter &rewriter, Location loc, Value xI,
 }
 
 Value fpsanExp2(PatternRewriter &rewriter, Location loc, Value input) {
-  auto elemTy = dyn_cast<FloatType>(getElementType(input.getType()));
+  auto elemTy = dyn_cast<FloatType>(getElementTypeOrSelf(input.getType()));
   if (!elemTy)
     return Value();
   return fpsanExp2FromInt(rewriter, loc, embedToInt(rewriter, loc, input),
@@ -662,7 +662,7 @@ Value fpsanExp2(PatternRewriter &rewriter, Location loc, Value input) {
 }
 
 Value fpsanExp(PatternRewriter &rewriter, Location loc, Value input) {
-  auto elemTy = dyn_cast<FloatType>(getElementType(input.getType()));
+  auto elemTy = dyn_cast<FloatType>(getElementTypeOrSelf(input.getType()));
   if (!elemTy)
     return Value();
 
@@ -737,7 +737,7 @@ FpSanCosSin fpsanCosSinPayload(PatternRewriter &rewriter, Location loc,
 }
 
 Value fpsanCos(PatternRewriter &rewriter, Location loc, Value input) {
-  if (!isa<FloatType>(getElementType(input.getType())))
+  if (!isFloatLike(input.getType()))
     return Value();
   auto cosSin =
       fpsanCosSinPayload(rewriter, loc, embedToInt(rewriter, loc, input));
@@ -745,18 +745,11 @@ Value fpsanCos(PatternRewriter &rewriter, Location loc, Value input) {
 }
 
 Value fpsanSin(PatternRewriter &rewriter, Location loc, Value input) {
-  if (!isa<FloatType>(getElementType(input.getType())))
+  if (!isFloatLike(input.getType()))
     return Value();
   auto cosSin =
       fpsanCosSinPayload(rewriter, loc, embedToInt(rewriter, loc, input));
   return unembedToFloat(rewriter, loc, cosSin.sin, input.getType());
-}
-
-bool isIntLike(Type ty) { return isa<IntegerType>(getElementType(ty)); }
-
-bool isNumericLike(Type ty) {
-  Type elemTy = getElementType(ty);
-  return isa<FloatType>(elemTy) || isa<IntegerType>(elemTy);
 }
 
 bool externHasNumericOperands(tt::ExternElementwiseOp op) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
@@ -15,10 +16,10 @@
 
 using namespace mlir;
 
+using mlir::getElementTypeOrSelf;
 using mlir::triton::gpu::appendOrGetExternFuncOp;
 using mlir::triton::gpu::ElementwiseOpConversion;
 using mlir::triton::gpu::ElementwiseOpConversionBase;
-using mlir::triton::gpu::getElementType;
 using mlir::triton::gpu::getFunctionType;
 using mlir::triton::gpu::MultipleOperandsRange;
 
@@ -1969,8 +1970,8 @@ struct FpToFpOpConversion
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    auto srcElementType = getElementType(op.getSrc());
-    auto dstElementType = getElementType(op.getResult());
+    auto srcElementType = getElementTypeOrSelf(op.getSrc());
+    auto dstElementType = getElementTypeOrSelf(op.getResult());
 
     auto roundingMode = op.getRounding();
     if (srcElementType.isF32() &&
@@ -2158,8 +2159,8 @@ struct FMulOpConversion
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    auto lhsElemTy = getElementType(op.getLhs());
-    auto rhsElemTy = getElementType(op.getRhs());
+    auto lhsElemTy = getElementTypeOrSelf(op.getLhs());
+    auto rhsElemTy = getElementTypeOrSelf(op.getRhs());
     if (lhsElemTy.isBF16() && rhsElemTy.isBF16()) {
       if (isRDNA(isaFamily)) {
         // To avoid casting to/from fp32, we compute a dot product with one
@@ -2195,8 +2196,8 @@ struct FAddOpConversion
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    auto lhsElemTy = getElementType(op.getLhs());
-    auto rhsElemTy = getElementType(op.getRhs());
+    auto lhsElemTy = getElementTypeOrSelf(op.getLhs());
+    auto rhsElemTy = getElementTypeOrSelf(op.getRhs());
     if (lhsElemTy.isBF16() && rhsElemTy.isBF16()) {
       return {EmitDualBF16ElementwiseOp<LLVM::FAddOp>(loc, rewriter, operands)};
     } else {
@@ -2214,8 +2215,8 @@ struct FSubOpConversion
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    auto lhsElemTy = getElementType(op.getLhs());
-    auto rhsElemTy = getElementType(op.getRhs());
+    auto lhsElemTy = getElementTypeOrSelf(op.getLhs());
+    auto rhsElemTy = getElementTypeOrSelf(op.getRhs());
     if (lhsElemTy.isBF16() && rhsElemTy.isBF16()) {
       return {EmitDualBF16ElementwiseOp<LLVM::FSubOp>(loc, rewriter, operands)};
     } else {
@@ -2246,8 +2247,8 @@ struct SIToFPOpConversion
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    Type inElemTy = getElementType(op.getIn());
-    Type outElemTy = getElementType(op.getOut());
+    Type inElemTy = getElementTypeOrSelf(op.getIn());
+    Type outElemTy = getElementTypeOrSelf(op.getOut());
     if (outElemTy.isBF16() && inElemTy.isInteger(8) && operands.size() >= 4) {
       SmallVector<Value> inVals = {operands[0][0], operands[1][0],
                                    operands[2][0], operands[3][0]};
@@ -2272,7 +2273,7 @@ struct FPToSIOpConversion
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    auto inElemTy = getElementType(op.getIn());
+    auto inElemTy = getElementTypeOrSelf(op.getIn());
     if (inElemTy.isBF16()) {
       auto value = convertBf16ToFp32(loc, rewriter, operands[0][0]);
       return {LLVM::FPToSIOp::create(rewriter, loc, elemTy, value)};
@@ -2290,9 +2291,9 @@ struct ExtFOpConversion
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    auto inElemTy = getElementType(op.getIn());
+    auto inElemTy = getElementTypeOrSelf(op.getIn());
     if (inElemTy.isBF16()) {
-      auto outElemTy = getElementType(op.getOut());
+      auto outElemTy = getElementTypeOrSelf(op.getOut());
       assert(outElemTy.isF32() && "unsupported conversion");
       return {convertBf16ToFp32(loc, rewriter, operands[0][0])};
     } else {
@@ -2316,8 +2317,8 @@ struct TruncFOpConversion
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    auto outElemTy = getElementType(op.getOut());
-    auto inElemTy = getElementType(op.getIn());
+    auto outElemTy = getElementTypeOrSelf(op.getOut());
+    auto inElemTy = getElementTypeOrSelf(op.getIn());
     if (inElemTy.isF32() && (outElemTy.isBF16() || outElemTy.isF16())) {
       return Fp32_to_F16_RTNE(loc, rewriter, inElemTy, outElemTy, operands,
                               isaFamily);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -471,8 +471,8 @@ struct FpToFpOpConversion
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    auto srcElementType = getElementType(op.getSrc());
-    auto dstElementType = getElementType(op.getResult());
+    auto srcElementType = getElementTypeOrSelf(op.getSrc());
+    auto dstElementType = getElementTypeOrSelf(op.getResult());
     auto roundingMode = op.getRounding();
 
     if (llvm::isa<Float8E5M2Type, Float8E4M3FNType>(dstElementType)) {
@@ -594,8 +594,8 @@ struct SIToFPOpConversion
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    Type inElemTy = getElementType(op.getIn());
-    Type outElemTy = getElementType(op.getOut());
+    Type inElemTy = getElementTypeOrSelf(op.getIn());
+    Type outElemTy = getElementTypeOrSelf(op.getOut());
     if (outElemTy.isBF16() && inElemTy.isInteger(8) && operands.size() >= 4) {
       auto cvtFunc = makeConverterFromPtx(
           computeCapability >= 90 ? S8_to_Bf16_sm90 : S8_to_Bf16,


### PR DESCRIPTION
<git-pr-chain>


[NFC] Remove getElementType helper functions

This already exists in mlir itself, called getElementTypeOrSelf.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #10235 👈 **YOU ARE HERE**


</git-pr-chain>



