### PR TITLE
Custom Intermediate split-k dtype 

### DIFF
--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_split_k.py
@@ -6,15 +6,17 @@ import types
 import torch
 
 import triton_kernels.matmul_details.opt_flags as opt_flags
-from triton_kernels.tensor_details.dtype import FP16
+from triton_kernels.matmul import FusedActivation, PrecisionConfig, init_allocation
+from triton_kernels.tensor_details.dtype import BF16, FP16, FP32
 
 class _DummyPrecisionConfig:
-    def __init__(self):
+    def __init__(self, intermediate_out_dtype=torch.float32):
         self.b_mx_scale = None
         self.max_num_imprecise_acc = None
         self.a_mx_scale = None
         self.c_mx_scale = None
         self.enforce_bitwise_invariance = False
+        self.intermediate_out_dtype = intermediate_out_dtype
 
 
 def _stub_cuda_props(*_args, **_kwargs):
@@ -129,6 +131,44 @@ def test_make_default_opt_flags_nvidia_split_k_constraint(monkeypatch):
     )
 
     assert flags.split_k == 3
+
+
+def test_split_k_uses_intermediate_out_dtype(monkeypatch):
+    setup_nvidia(monkeypatch)
+
+    x = torch.empty((7, 11), dtype=torch.bfloat16)
+    w = torch.empty((11, 13), dtype=torch.bfloat16)
+    seen = {}
+
+    def capture_num_stages(*args, **kwargs):
+        seen["out_dtype"] = args[5]
+        return 2
+
+    monkeypatch.setattr(opt_flags.opt_flags_nvidia, "compute_num_stages", capture_num_stages)
+
+    cases = [
+        (PrecisionConfig(), _DummyPrecisionConfig(), torch.float32, FP32),
+        (
+            PrecisionConfig(intermediate_out_dtype=torch.bfloat16),
+            _DummyPrecisionConfig(torch.bfloat16),
+            torch.bfloat16,
+            BF16,
+        ),
+    ]
+    for precision_config, dummy_config, scratch_dtype, opt_dtype in cases:
+        allocation = init_allocation(
+            x, w, precision_config, FusedActivation(), None, None, 1, 1,
+            types.SimpleNamespace(split_k=3),
+        )
+        assert allocation.scratchpads["matmul"] == ((3, 1, 7, 13), scratch_dtype)
+
+        opt_flags.make_default_opt_flags_nvidia(
+            torch.float16, torch.float16, torch.float16, dummy_config,
+            4, 256, 128, 64, None, False, False, False, 0, False, False,
+            {"split_k": 3, "epilogue_subtile": 1},
+        )
+        assert seen["out_dtype"] == opt_dtype
+
 
 def test_max_allowable_mn_and_split_k_constraints(monkeypatch):
     setup_nvidia(monkeypatch)

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -176,7 +176,7 @@ def init_allocation(x, w, precision_config, fused_activation,
     scratchpad = dict()
     N_scratch = N // fused_activation.specs.reduction_n if opt_flags.split_k == 1 else N
     if opt_flags.split_k > 1:
-        scratch_out_dtype = precision_config.intermediate_out_dtype
+        scratch_out_dtype = dtype_to_torch_dtype(precision_config.intermediate_out_dtype)
         scratchpad["matmul"] = ((opt_flags.split_k, batch_dim, M, N_scratch), scratch_out_dtype)
     if "matmul" in scratchpad and precision_config.c_mx_scale is not None:
         assert batch_dim == 1, "batch_dim > 1 not supported yet"

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -135,6 +135,7 @@ class PrecisionConfig:
     c_microblock_size: int | None = None
     c_value_pack_factor: int = 1
     out_dtype: torch.dtype | None = None
+    intermediate_out_dtype: torch.dtype = torch.float32
     enforce_bitwise_invariance: bool = False
 
 # TODO: merge in opt_flags
@@ -175,7 +176,7 @@ def init_allocation(x, w, precision_config, fused_activation,
     scratchpad = dict()
     N_scratch = N // fused_activation.specs.reduction_n if opt_flags.split_k == 1 else N
     if opt_flags.split_k > 1:
-        scratch_out_dtype = torch.float32 if opt_flags.split_k > 1 else out_dtype
+        scratch_out_dtype = precision_config.intermediate_out_dtype
         scratchpad["matmul"] = ((opt_flags.split_k, batch_dim, M, N_scratch), scratch_out_dtype)
     if "matmul" in scratchpad and precision_config.c_mx_scale is not None:
         assert batch_dim == 1, "batch_dim > 1 not supported yet"
@@ -470,7 +471,7 @@ def matmul(a, b, bias,
     has_scratchpad = "matmul" in memory["scratchpad"]
     # Canonical output tensor (matmul scratchpad if present, otherwise final output tensor)
     out_matmul = memory["scratchpad"].get("matmul", memory["output"])
-    out_matmul_flex = OutFlexData() if out_matmul.dtype == torch.float32 else precision_config.flex_ctx.out_data
+    out_matmul_flex = OutFlexData() if has_scratchpad or out_matmul.dtype == torch.float32 else precision_config.flex_ctx.out_data
     # Unified mx-scale pointer; when scratchpad exists, prefer its mx buffer
     out_matmul_scale = precision_config.c_mx_scale
     if out_matmul_scale is not None:
@@ -499,7 +500,7 @@ def matmul(a, b, bias,
     a = Tensor(_canonicalize_storage(a.storage, 2 if has_gather_tma else 3, flex.lhs_data), dtype=a.dtype, shape=a.shape, shape_max=a.shape_max)
     b_storage_ndim = 5 if b_is_shuffled else 3
     b = Tensor(_canonicalize_storage(b.storage, b_storage_ndim, flex.rhs_data), dtype=b.dtype, shape=b.shape, shape_max=b.shape_max)
-    c = Tensor(_canonicalize_storage(c.storage, 2 if has_scatter_tma else 3, flex.out_data), dtype=c.dtype, shape=c.shape, shape_max=c.shape_max)
+    c = Tensor(_canonicalize_storage(c.storage, 2 if has_scatter_tma else 3, out_matmul_flex), dtype=c.dtype, shape=c.shape, shape_max=c.shape_max)
     # create tma descriptor for x
     if c_acc_in is not None:
         assert opt_flags.split_k == 1, "c_acc_in + split_k is not supported."

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import triton
 from triton_kernels import target_info
 from triton_kernels.target_info import get_cdna_version, get_rdna_version, cuda_capability_geq
-from triton_kernels.tensor import FP4, FP32, Tensor
+from triton_kernels.tensor import FP4, FP32, Tensor, torch_dtype_to_dtype
 import torch
 from triton_kernels.tensor_details.layout_details.hopper_scale import HopperMXScaleLayout
 from triton_kernels.tensor_details.layout_details.strided import StridedLayout
@@ -302,7 +302,7 @@ def make_default_opt_flags_nvidia(
         estimated_actual_grid_size = opt_flags_nvidia.compute_grid_size(None, batch_size, m, n, block_m, block_n)
         split_k = opt_flags_nvidia.compute_split_k(block_k, k, estimated_actual_grid_size)
     if split_k > 1:
-        # Split-K writes full-N fp32 scratch and applies fused reductions in the
+        # Split-K writes full-N scratch and applies fused reductions in the
         # reduce kernel, not in the matmul epilogue.
         epilogue_reduction_n = 1
     compute_num_stages_args = (
@@ -311,7 +311,7 @@ def make_default_opt_flags_nvidia(
         block_m,
         block_n,
         block_k,
-        FP32 if split_k > 1 else out_dtype,
+        torch_dtype_to_dtype(precision_config.intermediate_out_dtype) if split_k > 1 else out_dtype,
         lhs_dtype,
         rhs_dtype,
         x_transpose,


### PR DESCRIPTION
Adds PrecisionConfig.intermediate_out_dtype so split-K matmul can store intermediate scratch outputs in a configurable dtype, defaulting to the existing fp32 behavior. Also threads the dtype through split-K allocation and opt-flag shared-memory sizing, with tests covering bf16 scratch allocation and dtype normalization.