### PR TITLE
Add Gluon cluster CTA rank helper

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -10,6 +10,7 @@
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/Types.h"
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Gluon/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -886,6 +887,11 @@ void init_gluon_ir(py::module &&m) {
           [](GluonOpBuilder &self,
              bool relaxed) { self.create<ttng::ClusterBarrierOp>(relaxed); },
           py::arg("relaxed") = false)
+      .def("create_cluster_cta_rank",
+           [](GluonOpBuilder &self) -> Value {
+             return self.create<mlir::triton::nvgpu::ClusterCTAIdOp>()
+                 .getResult();
+           })
       // CLC (Cluster Launch Control) ops - SM100+
       .def("create_clc_try_cancel",
            [](GluonOpBuilder &self, Value result, Value mbarrier) {

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -1655,6 +1655,12 @@ def cluster_barrier_multi_cta_kernel():
     ttgl.barrier(cluster=True)
 
 
+@gluon.jit
+def cluster_cta_rank_kernel(out):
+    rank = cluster.cta_rank()
+    ttgl.store(out, rank)
+
+
 def test_cluster_barrier_multi_cta():
     mod = run_parser(cluster_barrier_multi_cta_kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
     expecttest.assert_expected_inline(
@@ -1662,6 +1668,20 @@ def test_cluster_barrier_multi_cta():
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @cluster_barrier_multi_cta_kernel() attributes {noinline = false} {
     ttng.cluster_barrier
+    tt.return
+  }
+}
+""")
+
+
+def test_cluster_cta_rank():
+    mod = run_parser(cluster_cta_rank_kernel, *make_args(MockTensor(ttgl.int32), num_ctas=2), target=BLACKWELL_TARGET)
+    expecttest.assert_expected_inline(
+        anonymize_ir(mod.str_nodebug()), """\
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @cluster_cta_rank_kernel(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %0 = nvg.cluster_id
+    tt.store %arg0, %0 : !tt.ptr<i32>
     tt.return
   }
 }

--- a/python/triton/experimental/gluon/language/nvidia/hopper/cluster.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/cluster.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import triton.experimental.gluon.language._core as ttgl
 from triton.experimental.gluon.language._core import builtin, _unwrap_if_constexpr
 
-__all__ = ["arrive", "wait", "barrier"]
+__all__ = ["arrive", "wait", "barrier", "cta_rank"]
 
 
 @builtin
@@ -36,3 +37,15 @@ def barrier(relaxed: bool = False, _semantic=None):
     """
     relaxed = _unwrap_if_constexpr(relaxed)
     _semantic.builder.create_cluster_barrier(relaxed)
+
+
+@builtin
+def cta_rank(_semantic=None):
+    """
+    Return the linear rank of the current CTA within its cluster.
+
+    The result is in the range [0, num_ctas). For single-CTA launches this is
+    zero.
+    """
+    handle = _semantic.builder.create_cluster_cta_rank()
+    return ttgl.tensor(handle, ttgl.int32)


### PR DESCRIPTION
## Summary

Add a Gluon builtin for cluster-local CTA rank.

This exposes `triton.experimental.gluon.language.nvidia.hopper.cluster.cta_rank()`,
which returns the current CTA's rank within the cluster as an `i32` value.

## What changed

- Added a Gluon builder hook for `nvgpu.cluster_id`
- Added `cluster.cta_rank()` in `python/triton/experimental/gluon/language/nvidia/hopper/cluster.py`
- Added a frontend test in `python/test/gluon/test_frontend.py` to verify IR generation

## Validation

- `pytest -s --tb=short python/test/gluon/test_frontend.py -k cluster_cta_rank`


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
