### PR TITLE
[CONSAN] Fix shmem/tmem init check for subslices

### DIFF
--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -267,6 +267,86 @@ Value convertAndBroadcast(ImplicitLocOpBuilder &b, Value tensor,
   return triton::BroadcastOp::create(b, resultType, tensor);
 }
 
+Value createIntervalCoverageMask(ImplicitLocOpBuilder &b, Value descriptors,
+                                 Value initializedRows, Value offsetI32,
+                                 Value lengthI32) {
+  auto descriptorsType = cast<RankedTensorType>(descriptors.getType());
+  auto initializedRowsType = cast<RankedTensorType>(initializedRows.getType());
+  assert(descriptorsType.getRank() == 2 && initializedRowsType.getRank() == 2 &&
+         "expected [C x B] descriptors and initialized rows");
+  Value offsetMask =
+      tti::createConstIntTensor(b, b.getLoc(), 0xffffffffull, descriptorsType);
+  Value descriptorOffsets = arith::AndIOp::create(b, descriptors, offsetMask);
+  Value shiftAmount =
+      tti::createConstIntTensor(b, b.getLoc(), 32, descriptorsType);
+  Value descriptorLengths = arith::ShRUIOp::create(b, descriptors, shiftAmount);
+  Value requestedOffset = arith::ExtUIOp::create(b, b.getI64Type(), offsetI32);
+  Value requestedLength = arith::ExtUIOp::create(b, b.getI64Type(), lengthI32);
+  Value requestedEnd =
+      arith::AddIOp::create(b, requestedOffset, requestedLength);
+  Value descriptorEnds =
+      arith::AddIOp::create(b, descriptorOffsets, descriptorLengths);
+
+  // An interval is covered iff the following are true:
+  // 1. The requested start is covered.
+  // 2. Every descriptor end inside the requested interval is covered.
+  Value startsBeforeRequested = createCmpIntTensorScalar(
+      b, descriptorOffsets, requestedOffset, arith::CmpIPredicate::ule);
+  Value endsAfterRequested = createCmpIntTensorScalar(
+      b, descriptorEnds, requestedOffset, arith::CmpIPredicate::ugt);
+  Value coversRequestedStart =
+      arith::AndIOp::create(b, startsBeforeRequested, endsAfterRequested);
+  coversRequestedStart =
+      arith::AndIOp::create(b, coversRequestedStart, initializedRows);
+  Value requestedStartCovered =
+      reduceLastDim<arith::OrIOp>(b, coversRequestedStart);
+
+  SmallVector<int64_t> coverageShape = {initializedRowsType.getShape()[0],
+                                        initializedRowsType.getShape()[1],
+                                        initializedRowsType.getShape()[1]};
+  auto coverageType =
+      tti::getIntTensorType(b.getInsertionBlock()->getParent(), coverageShape,
+                            /*bitWidth=*/1);
+  Value candidateStarts =
+      convertAndBroadcast(b, descriptorOffsets, {0, 1}, coverageType);
+  Value candidateEnds =
+      convertAndBroadcast(b, descriptorEnds, {0, 1}, coverageType);
+  Value probePoints =
+      convertAndBroadcast(b, descriptorEnds, {0, 2}, coverageType);
+  Value candidateStartsBeforeProbe = arith::CmpIOp::create(
+      b, arith::CmpIPredicate::ule, candidateStarts, probePoints);
+  Value candidateEndsAfterProbe = arith::CmpIOp::create(
+      b, arith::CmpIPredicate::ugt, candidateEnds, probePoints);
+  Value candidateCoversProbe = arith::AndIOp::create(
+      b, candidateStartsBeforeProbe, candidateEndsAfterProbe);
+  Value initializedCandidates =
+      convertAndBroadcast(b, initializedRows, {0, 1}, coverageType);
+  Value coveredProbesByCandidate =
+      arith::AndIOp::create(b, candidateCoversProbe, initializedCandidates);
+  Value coveredProbes =
+      reduce<arith::OrIOp>(b, coveredProbesByCandidate, /*axis=*/1);
+  coveredProbes =
+      createConvertLayout(b, coveredProbes, initializedRowsType.getEncoding());
+
+  Value probeAfterStart = createCmpIntTensorScalar(
+      b, descriptorEnds, requestedOffset, arith::CmpIPredicate::uge);
+  Value probeBeforeEnd = createCmpIntTensorScalar(
+      b, descriptorEnds, requestedEnd, arith::CmpIPredicate::ult);
+  Value probesInInterval =
+      arith::AndIOp::create(b, probeAfterStart, probeBeforeEnd);
+  Value one = tti::createConstIntTensor(
+      b, b.getLoc(), 1, cast<RankedTensorType>(probesInInterval.getType()));
+  Value probesOutOfInterval = arith::XOrIOp::create(b, probesInInterval, one);
+  Value coveredOrOutOfInterval =
+      arith::OrIOp::create(b, coveredProbes, probesOutOfInterval);
+  Value allProbePointsCovered =
+      reduceLastDim<arith::AndIOp>(b, coveredOrOutOfInterval);
+  allProbePointsCovered = createConvertLayout(
+      b, allProbePointsCovered,
+      cast<RankedTensorType>(requestedStartCovered.getType()).getEncoding());
+  return arith::AndIOp::create(b, requestedStartCovered, allProbePointsCovered);
+}
+
 Value expandAliases(ImplicitLocOpBuilder &b, Value bufferMask,
                     Value aliasMatrix, RankedTensorType aliasMatrixType) {
   assert(aliasMatrixType.getRank() == 3 &&
@@ -2263,11 +2343,10 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
           fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
       Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
       Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
-      if (useAlias) {
+      if (useAlias && allowNoWrite)
         buffersEqBuf =
             expandAliases(fb, buffersEqBuf, aliasMatrix,
                           cast<RankedTensorType>(aliasMatrixTypeBase));
-      }
       buffersEqBuf =
           convertAndBroadcast(fb, buffersEqBuf, {0, 1}, writeVisibilityType);
       Value ctaMask =
@@ -2292,23 +2371,49 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
           fb, arith::CmpIPredicate::eq, bufferHasVisibility, bufferThreadBit);
       Value result;
       if (!allowNoWrite) {
-        Value rowOne = tti::createConstIntTensor(
-            fb, fb.getLoc(), 1, cast<RankedTensorType>(buffersEqBuf.getType()));
-        Value rowInitialized =
-            arith::XOrIOp::create(fb, noOneIsWriting, rowOne);
-        Value initializedRows =
-            arith::AndIOp::create(fb, rowInitialized, buffersEqBuf);
-        // Alias rows are alternatives within a CTA, but every selected CTA must
-        // have at least one initialized row.
-        Value initializedCTAs =
-            reduceLastDim<arith::OrIOp>(fb, initializedRows);
-        Value selectedCTAs = reduceLastDim<arith::OrIOp>(fb, buffersEqBuf);
-        Value ctaOne = tti::createConstIntTensor(
-            fb, fb.getLoc(), 1, cast<RankedTensorType>(selectedCTAs.getType()));
-        Value unmatchedCTAs = arith::XOrIOp::create(fb, selectedCTAs, ctaOne);
-        Value initializedOrUnmatched =
-            arith::OrIOp::create(fb, initializedCTAs, unmatchedCTAs);
-        result = reduceAll<arith::AndIOp>(fb, initializedOrUnmatched);
+        if (useAlias) {
+          // Initialization needs the union of exact initialized rows to cover
+          // the whole interval; mere overlap is not enough.
+          Value visibleRows = arith::SelectOp::create(
+              fb, ctaMask, writeVisibility, writeVisibilityZero);
+          Value uninitializedRows = arith::CmpIOp::create(
+              fb, arith::CmpIPredicate::eq, visibleRows, writeVisibilityZero);
+          Value rowOne = tti::createConstIntTensor(
+              fb, fb.getLoc(), 1,
+              cast<RankedTensorType>(uninitializedRows.getType()));
+          Value initializedRows =
+              arith::XOrIOp::create(fb, uninitializedRows, rowOne);
+          Value intervalCovered = createIntervalCoverageMask(
+              fb, buffers, initializedRows, bufOffset, lengthVal);
+          Value selectedCTAs = reduceLastDim<arith::OrIOp>(fb, ctaMask);
+          Value ctaOne = tti::createConstIntTensor(
+              fb, fb.getLoc(), 1,
+              cast<RankedTensorType>(selectedCTAs.getType()));
+          Value unmatchedCTAs = arith::XOrIOp::create(fb, selectedCTAs, ctaOne);
+          Value coveredOrUnmatched =
+              arith::OrIOp::create(fb, intervalCovered, unmatchedCTAs);
+          result = reduceAll<arith::AndIOp>(fb, coveredOrUnmatched);
+        } else {
+          Value rowOne = tti::createConstIntTensor(
+              fb, fb.getLoc(), 1,
+              cast<RankedTensorType>(buffersEqBuf.getType()));
+          Value rowInitialized =
+              arith::XOrIOp::create(fb, noOneIsWriting, rowOne);
+          Value initializedRows =
+              arith::AndIOp::create(fb, rowInitialized, buffersEqBuf);
+          // Alias rows are alternatives within a CTA, but every selected CTA
+          // must have at least one initialized row.
+          Value initializedCTAs =
+              reduceLastDim<arith::OrIOp>(fb, initializedRows);
+          Value selectedCTAs = reduceLastDim<arith::OrIOp>(fb, buffersEqBuf);
+          Value ctaOne = tti::createConstIntTensor(
+              fb, fb.getLoc(), 1,
+              cast<RankedTensorType>(selectedCTAs.getType()));
+          Value unmatchedCTAs = arith::XOrIOp::create(fb, selectedCTAs, ctaOne);
+          Value initializedOrUnmatched =
+              arith::OrIOp::create(fb, initializedCTAs, unmatchedCTAs);
+          result = reduceAll<arith::AndIOp>(fb, initializedOrUnmatched);
+        }
       } else {
         Value writeVisible =
             arith::OrIOp::create(fb, noOneIsWriting, bufferHasVisibility);

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -2371,6 +2371,19 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
           fb, arith::CmpIPredicate::eq, bufferHasVisibility, bufferThreadBit);
       Value result;
       if (!allowNoWrite) {
+        // Every selected CTA must have a covering initialized row set.
+        auto allSelectedCTAsCovered = [&](Value coveredCTAs,
+                                          Value selectedRows) {
+          Value selectedCTAs = reduceLastDim<arith::OrIOp>(fb, selectedRows);
+          Value ctaOne = tti::createConstIntTensor(
+              fb, fb.getLoc(), 1,
+              cast<RankedTensorType>(selectedCTAs.getType()));
+          Value unselectedCTAs =
+              arith::XOrIOp::create(fb, selectedCTAs, ctaOne);
+          Value coveredOrUnselected =
+              arith::OrIOp::create(fb, coveredCTAs, unselectedCTAs);
+          return reduceAll<arith::AndIOp>(fb, coveredOrUnselected);
+        };
         if (useAlias) {
           // Initialization needs the union of exact initialized rows to cover
           // the whole interval; mere overlap is not enough.
@@ -2385,14 +2398,7 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
               arith::XOrIOp::create(fb, uninitializedRows, rowOne);
           Value intervalCovered = createIntervalCoverageMask(
               fb, buffers, initializedRows, bufOffset, lengthVal);
-          Value selectedCTAs = reduceLastDim<arith::OrIOp>(fb, ctaMask);
-          Value ctaOne = tti::createConstIntTensor(
-              fb, fb.getLoc(), 1,
-              cast<RankedTensorType>(selectedCTAs.getType()));
-          Value unmatchedCTAs = arith::XOrIOp::create(fb, selectedCTAs, ctaOne);
-          Value coveredOrUnmatched =
-              arith::OrIOp::create(fb, intervalCovered, unmatchedCTAs);
-          result = reduceAll<arith::AndIOp>(fb, coveredOrUnmatched);
+          result = allSelectedCTAsCovered(intervalCovered, ctaMask);
         } else {
           Value rowOne = tti::createConstIntTensor(
               fb, fb.getLoc(), 1,
@@ -2401,18 +2407,9 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
               arith::XOrIOp::create(fb, noOneIsWriting, rowOne);
           Value initializedRows =
               arith::AndIOp::create(fb, rowInitialized, buffersEqBuf);
-          // Alias rows are alternatives within a CTA, but every selected CTA
-          // must have at least one initialized row.
           Value initializedCTAs =
               reduceLastDim<arith::OrIOp>(fb, initializedRows);
-          Value selectedCTAs = reduceLastDim<arith::OrIOp>(fb, buffersEqBuf);
-          Value ctaOne = tti::createConstIntTensor(
-              fb, fb.getLoc(), 1,
-              cast<RankedTensorType>(selectedCTAs.getType()));
-          Value unmatchedCTAs = arith::XOrIOp::create(fb, selectedCTAs, ctaOne);
-          Value initializedOrUnmatched =
-              arith::OrIOp::create(fb, initializedCTAs, unmatchedCTAs);
-          result = reduceAll<arith::AndIOp>(fb, initializedOrUnmatched);
+          result = allSelectedCTAsCovered(initializedCTAs, buffersEqBuf);
         }
       } else {
         Value writeVisible =

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -2615,6 +2615,47 @@ def test_aliasing_tensor_visibility_outstanding_read(FAILURE, device, run_wrappe
     kernel[(1, )](FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
 
 
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
+@pytest.mark.parametrize("num_written", [3, 4])
+def test_aliasing_tensor_subslice_writes_initialize_full_alias(num_written, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_aliasing_tensor_subslice_writes_initialize_full_alias,
+                                (num_written, device, False, monkeypatch))
+        if num_written == 3:
+            assert result.exc is not None
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being read before any write" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(NUM_WRITTEN: ttgl.constexpr):
+        blocked_layout_read: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1],
+                                                                 warps_per_cta=[4, 1], order=[0, 1])
+        blocked_layout_write: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK // 4],
+                                                                  threads_per_warp=[32, 1], warps_per_cta=[4, 1],
+                                                                  order=[0, 1])
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0, 1])
+        tmem_layout: ttgl.constexpr = blackwell.TensorMemoryLayout([XBLOCK, XBLOCK * 2], col_stride=1)
+        tmem = blackwell.allocate_tensor_memory(ttgl.float32, [XBLOCK, XBLOCK * 2], tmem_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float32, [XBLOCK, XBLOCK], smem_layout)
+        full = tmem.slice(0, XBLOCK)
+        for i in ttgl.static_range(4):
+            if NUM_WRITTEN == 4 or i != 2:
+                quarter = tmem.slice(i * (XBLOCK // 4), XBLOCK // 4)
+                quarter.store(ttgl.zeros([XBLOCK, XBLOCK // 4], ttgl.float32, blocked_layout_write))
+        val = full.load(blocked_layout_read)
+        smem.store(val)
+
+    kernel[(1, )](NUM_WRITTEN=num_written, num_warps=4, num_ctas=1)
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 @pytest.mark.parametrize("MISSING_WAIT", [True, False])
 @pytest.mark.parametrize("OVERLAP", [True, False])


### PR DESCRIPTION
We implement a check that checks that all read shmem/tmem memory is
actually initialised. Before we just checked if any of it was. The
algorithm goes roughyl as:

An interval is covered iff the following are true:
1. The requested start is covered
2. Every descriptor end inside the requested interval is covered
