### PR TITLE
[release/3.7.x][CI] Reduce wheel size and pin DOCKER_API_VERSION

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,6 +27,13 @@ jobs:
       id-token: write
       contents: read
 
+    # The self-hosted x86_64 runner ships a docker CLI (1.52) newer than the
+    # daemon's max API version (1.43), so unpinned docker commands fail with
+    # "client version 1.52 is too new". Pin at the job level so every step
+    # (including cibuildwheel's internal docker invocations) inherits it.
+    env:
+      DOCKER_API_VERSION: "1.43"
+
     steps:
 
       - name: Prune stale docker containers

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -83,6 +83,12 @@ jobs:
           # With this install, it gets clang 16.0.6.
           export CIBW_BEFORE_ALL="dnf install clang lld -y"
 
+          # Skip auditwheel's dependency-bundling pass on libtriton.so. Without
+          # this, every shared library libtriton.so links against is copied into
+          # triton.libs/ and the wheel grows by ~130MB. PyTorch's build script
+          # uses the same flag for the same reason.
+          export CIBW_REPAIR_WHEEL_COMMAND_LINUX="auditwheel repair --exclude libtriton.so -w {dest_dir} {wheel}"
+
           if [[ ${{ matrix.config.arch }} == 'x86_64' ]]; then
             export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux_2_28_${{ matrix.config.arch }}:latest"
           else


### PR DESCRIPTION
Cherry-picks of two CI fixes from `main` onto `release/3.7.x`.

## Commits

1. **Reduce wheel size** (cherry-pick of #10238) — pass `--exclude libtriton.so` to `auditwheel repair` via `CIBW_REPAIR_WHEEL_COMMAND_LINUX`. Without this, every transitive dependency of `libtriton.so` gets bundled into `triton.libs/`, inflating the wheel from ~200MB to ~330MB. Matches PyTorch's `build_triton_wheel.py` behavior.
2. **Pin DOCKER_API_VERSION job-wide** (cherry-pick of #10245) — the self-hosted x86_64 runner has a docker CLI (1.52) newer than the daemon's max API version (1.43); both the prune step and cibuildwheel's internal `docker version` call fail with `client version 1.52 is too new`. Setting `DOCKER_API_VERSION: "1.43"` at the job level fixes both.

Build flags (`TritonRelBuildWithAsserts`, `TRITON_EXT_ENABLED=ON`, `TRITON_BUILD_WITH_CLANG_LLD=1`) are unchanged.

## Test plan

- [ ] Trigger the `Wheels` workflow on this branch and confirm `Prune stale docker containers` and `Build wheels` both succeed on `self-hosted, CPU, x86_64`.
- [ ] Confirm the produced wheel for `manylinux_2_28_x86_64` / `manylinux_2_28_aarch64` is in the ~200MB range.
- [ ] `unzip -l` the produced wheel and confirm there is no `triton.libs/` directory of bundled shared objects.
- [ ] Install the wheel in a clean env and run a basic kernel to confirm `libtriton.so` still loads.