### PR TITLE
[CD] Pin DOCKER_API_VERSION job-wide for Wheels workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,6 +27,13 @@ jobs:
       id-token: write
       contents: read
 
+    # The self-hosted x86_64 runner ships a docker CLI (1.52) newer than the
+    # daemon's max API version (1.43), so unpinned docker commands fail with
+    # "client version 1.52 is too new". Pin at the job level so every step
+    # (including cibuildwheel's internal docker invocations) inherits it.
+    env:
+      DOCKER_API_VERSION: "1.43"
+
     steps:
 
       - name: Prune stale docker containers


### PR DESCRIPTION
## Summary

The scheduled `Wheels` workflow has been failing on the self-hosted x86_64 runner because its docker CLI is newer than its docker daemon:

```
Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.43
```

First hit: the `Prune stale docker containers` step (run [25428878519](https://github.com/triton-lang/triton/actions/runs/25428878519/job/74589527785)).

After setting the env on just that step, `cibuildwheel` itself shells out to `docker version` from the Build step and fails the same way (run [25437471726](https://github.com/triton-lang/triton/actions/runs/25437471726/job/74619233438?pr=10245)).

Fix: set `DOCKER_API_VERSION=1.43` at the **job** level so every step — including subprocesses spawned by cibuildwheel — inherits the pin.

Fix pattern from: https://stackoverflow.com/questions/62079794/error-response-from-daemon-client-version-1-40-is-too-new-maximum-supported-ap

## Test plan

- [ ] Trigger the `Wheels` workflow (workflow_dispatch) and confirm both `Prune stale docker containers` and `Build wheels` succeed on `self-hosted, CPU, x86_64`.