### PR TITLE
[triton_kernels] nvfp4 x nvfp4 tuning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Working on Triton
 
 ## Build and Testing Guidelines
-- Before running any tests, run `make` in the triton directory to rebuild triton.
+- Before running tests for native/compiler changes, run `make` in the triton directory to rebuild triton. DO NOT RUN `make` if you only changed Python code or code in `python/triton_kernels`.
 - For compiler changes, add tests in `python/test/` (pytest) or test (lit). Keep GPU-only tests in `python/test/unit/` or `python/test/gluon/`, name them `test_<feature>_<condition>`, and avoid creating new test files unless requested.
 - Run pytest with `-s --tb=short`. Run a single test with `pytest file.py::test_name`.
 - The build dir is given by `BUILD_DIR := $(shell PYTHONPATH="./python" python3 -c 'from build_helpers import get_cmake_dir; print(get_cmake_dir())')`

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -21,6 +21,7 @@ from triton_kernels.target_info import is_cuda, is_hip, is_hip_cdna3, is_hip_cdn
 from triton_kernels.swiglu import swiglu, swiglu_fn
 from triton_kernels.swiglu import PrecisionConfig as SwiGLUPrecisionConfig
 from triton_kernels.tensor_details import layout
+from triton_kernels.tensor import Tensor, convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details.dtype import FP32
 
 # ---------------
@@ -93,6 +94,7 @@ class Case:
     split_k: int = 1
     a_hbm_swizzling: bool = False
     b_hbm_swizzling: bool = False
+    c_hbm_swizzling: bool = False
     shuffle_mxfp4_w_layout: bool = False
     epilogue_subtile: Union[int, None] = None
     a_transpose: bool = False
@@ -185,6 +187,8 @@ def _build_test_op_cases():
         Case(1000, 704, 800, "ragged", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", b_hbm_swizzling=True, a_hbm_swizzling=True),
         Case(300, 400, 416, "ragged", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", b_hbm_swizzling=True, a_hbm_swizzling=True),
         Case(256, 1024, 512, "ragged", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", b_hbm_swizzling=True, a_hbm_swizzling=True),
+        Case(128, 256, 256, "ragged", "nvfp4_e2m1", "nvfp4_e2m1", "nvfp4_e2m1"),
+        Case(128, 256, 256, "ragged", "nvfp4_e2m1", "nvfp4_e2m1", "nvfp4_e2m1", c_hbm_swizzling=True, b_hbm_swizzling=True, a_hbm_swizzling=True),
         Case(1024, 1024, 1024, "batched", "nvfp4_e2m1", "nvfp4_e2m1", "bfloat16", b_hbm_swizzling=True),
     ])
     # amd-specific float8
@@ -252,7 +256,7 @@ def _build_test_op_cases():
 def test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, num_warps, n_slices,
             mode, act_dtype_str, weight_dtype_str, output_dtype_str, block_m, b_hbm_swizzling, shuffle_mxfp4_w_layout, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
             a_transpose, b_transpose, c_transpose,
-            swiglu_opts, device, opt_flags_scope):
+            swiglu_opts, c_hbm_swizzling, device, opt_flags_scope):
     # We catch and re-invoke pytest.skip(), because otherwise pytest may hold a reference to
     # the frame that called pytest.skip, including all the tensors, leading to OOM.
     skip_message = None
@@ -260,7 +264,7 @@ def test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, i
         _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, num_warps, n_slices,
                  mode, act_dtype_str, weight_dtype_str, output_dtype_str, block_m, b_hbm_swizzling, shuffle_mxfp4_w_layout, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
                  a_transpose, b_transpose, c_transpose,
-                 swiglu_opts, device, opt_flags_scope)
+                 swiglu_opts, c_hbm_swizzling, device, opt_flags_scope)
     except pytest.skip.Exception as e:
         skip_message = str(e)
 
@@ -270,7 +274,7 @@ def test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, i
 def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, num_warps, n_slices,
             mode, act_dtype_str, weight_dtype_str, output_dtype_str, block_m, b_hbm_swizzling, shuffle_mxfp4_w_layout, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
             a_transpose, b_transpose, c_transpose,
-            swiglu_opts, device, opt_flags_scope):
+            swiglu_opts, c_hbm_swizzling, device, opt_flags_scope):
     act_uses_mx = act_dtype_str.startswith("mx") or act_dtype_str == "nvfp4_e2m1"
     weight_uses_mx = weight_dtype_str.startswith("mx") or weight_dtype_str == "nvfp4_e2m1"
     # TODO: remove when Triton FP8 supports proper RTNE
@@ -335,6 +339,12 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
             pytest.skip("X swizzling requires block_m >= 128")
         if do_gather:
             pytest.skip("X swizzling does not support gathered activations")
+
+    if c_hbm_swizzling:
+        if is_hip() or torch.cuda.get_device_capability()[0] < 10:
+            pytest.skip("NYI. Output scale swizzling is only implemented on Blackwell")
+        if do_scatter:
+            pytest.skip("NYI. Output scale swizzling does not support fused scatter")
 
     expt_is_inner = (inner_expt_opt is not None)
     if expt_is_inner:
@@ -469,6 +479,10 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
     if c_dtype.has_mx_scale:
         c_scale_shape = c_shape[:-1] + (triton.cdiv(c_shape[-1], c_dtype.microblock_size),)
         c_scale = torch.empty(c_scale_shape, dtype=c_dtype.scale_dtype, device=a.device)
+        if c_hbm_swizzling:
+            c_scale = wrap_torch_tensor(c_scale)
+            c_ragged_metadata = a_ragged_metadata if mode == "ragged" else None
+            c_scale = convert_layout(c_scale, layout.BlackwellActMXScaleLayout(c_ragged_metadata))
         precision_opt.c_mx_scale = c_scale
         precision_opt.c_microblock_size = c_dtype.microblock_size
         precision_opt.c_value_pack_factor = 2 if c_dtype.is_mxfloat4 else 1
@@ -477,7 +491,7 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
             if c_dtype.is_nvfp4
             else FnSpecs(FnName.QUANTIZE_MXFP8.name, quantize_mxfp8_fn, (), ())
         )
-        epilogue = Epilogue(epilogue_spec, tuple(), tuple(), effective_itemsize=6.0)
+        epilogue = Epilogue(epilogue_spec, tuple(), tuple(), effective_itemsize=2.0 if c_dtype.is_nvfp4 else 6.0)
 
 
     # --- triton implementation ---
@@ -497,14 +511,19 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
     # float32 until that final downcast instead of letting matmul_torch
     # return bf16 and apply the output scale early.
     ref_y = matmul_torch(
-        a.float() if c_dtype.is_nvfp4 else a,
-        b.float() if c_dtype.is_nvfp4 else b,
+        a.float() if c_dtype.is_nvfp4 and not a_dtype.is_nvfp4 else a,
+        b.float() if c_dtype.is_nvfp4 and not b_dtype.is_nvfp4 else b,
         bias,
         a_ragged_metadata,
         b_ragged_metadata,
         gather_indx,
         scatter_indx,
-        PrecisionConfig() if c_dtype.is_nvfp4 else precision_opt,
+        PrecisionConfig(
+            a_mx_scale=a_scales,
+            a_microblock_size=a_dtype.microblock_size,
+            b_mx_scale=b_scale_tri,
+            b_microblock_size=b_dtype.microblock_size,
+        ) if c_dtype.is_nvfp4 else precision_opt,
         gammas=gammas,
     )
     if swiglu_opts is not None:
@@ -514,7 +533,10 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
 
     # --- check results ---
     if c_dtype.has_mx_scale:
-        tri_y = upcast_from_mxfp(tri_y, precision_opt.c_mx_scale, target_dtype=torch.bfloat16, axis=-1).to(ref_y.dtype)
+        tri_y_scale = precision_opt.c_mx_scale
+        if isinstance(tri_y_scale, Tensor):
+            tri_y_scale = convert_layout(tri_y_scale, layout.StridedLayout()).storage.data
+        tri_y = upcast_from_mxfp(tri_y, tri_y_scale, target_dtype=torch.bfloat16, axis=-1).to(ref_y.dtype)
         ref_target_dtype = ref_y.dtype
         ref_y, ref_scale = downcast_to_mxfp_torch(
             ref_y,
@@ -526,7 +548,9 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
         )
         ref_y = upcast_from_mxfp_torch(ref_y, ref_scale, target_dtype=ref_target_dtype, axis=-1)
     maxtol, rmstol = None, None
-    if c_dtype.has_mx_scale:
+    if c_dtype.is_nvfp4 and a_dtype.is_nvfp4 and b_dtype.is_nvfp4:
+        maxtol, rmstol = 6e-1, 4e-2
+    elif c_dtype.has_mx_scale:
         maxtol, rmstol = 4e-1, 4e-2
     elif b_dtype.is_mxfloat4:
         maxtol, rmstol = 3e-2, None

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -533,7 +533,7 @@ def matmul(a, b, bias,
     )
     c_logical_block_n = opt_flags.block_n // opt_flags.epilogue_subtile // matmul_fused_activation.specs.reduction_n
     c_tma_block_n = c_logical_block_n // precision_config.c_value_pack_factor
-    out_tile_n = c_logical_block_n if opt_flags.is_persistent else opt_flags.block_n // matmul_fused_activation.specs.reduction_n
+    out_tile_n = opt_flags.block_n // matmul_fused_activation.specs.reduction_n
     c_tma_block_size = [1, c_tma_block_n] if has_scatter_tma else [1, opt_flags.block_m, c_tma_block_n]
     c_tma_mode = None if not c_has_tma else "ragged" if is_c_ragged and not has_scatter_tma else "dense"
     c_tensor_or_tma = make_tma(c, c_tma_block_size, c_tma_mode) if c_has_tma else c.storage.data

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -19,7 +19,7 @@ from .matmul_details._p_matmul import _p_matmul, get_per_device_per_stream_alloc
 from .numerics_details.mxfp import MXFP_BLOCK_SIZE
 from .numerics_details.mxfp_details._downcast_to_mxfp import NVFP_BLOCK_SIZE
 from .tensor_details.layout_details.strided import StridedLayout
-from .tensor_details.layout_details.blackwell_scale import BlackwellActMXScaleLayout
+from .tensor_details.layout_details.blackwell_scale import BlackwellActMXScaleLayout, SWIZZLE_SIZE_OUTER
 from .tensor_details.layout_details.blackwell_value_shuffled import BlackwellMX4ValueShuffledLayout
 from .matmul_details.opt_flags import (
     InapplicableConstraint,
@@ -31,7 +31,7 @@ from .matmul_details.opt_flags import (
 )
 from .matmul_details.opt_flags_details import opt_flags_nvidia
 from .specialize import FnSpecs, SpecializationModule, ClosureArg
-from .tensor import Storage, Tensor, FP4, wrap_torch_tensor, RaggedTensorMetadata, is_tma_compliant, make_tma, convert_layout
+from .tensor import Storage, Tensor, UINT8, FP4, wrap_torch_tensor, RaggedTensorMetadata, is_tma_compliant, make_tma, convert_layout
 from .tensor import dtype_to_torch_dtype, torch_dtype_to_dtype
 from .reduce import reduce
 from .reduce import PostprocessFn as ReducePostprocessFn
@@ -138,10 +138,10 @@ class PrecisionConfig:
     enforce_bitwise_invariance: bool = False
 
 # TODO: merge in opt_flags
-def get_swap_xw(precision_config, opt_flags):
+def get_swap_xw(precision_config, opt_flags, lhs_dtype, rhs_dtype):
     if triton.runtime.driver.active.get_current_target().backend != "cuda":
         return False
-    return opt_flags_nvidia.compute_swap_xw(precision_config, opt_flags.block_m, opt_flags.is_persistent)
+    return opt_flags_nvidia.compute_swap_xw(precision_config, opt_flags.block_m, opt_flags.is_persistent, lhs_dtype, rhs_dtype)
 
 # ---------------------
 # Allocation
@@ -280,6 +280,8 @@ def matmul(a, b, bias,
         fused_activation = FusedActivation(FnSpecs.default(), tuple())
     if epilogue is None:
         epilogue = Epilogue(FnSpecs.default(), tuple(), tuple(), False)
+    if fused_comm is not None and precision_config.c_mx_scale is not None:
+        raise NotImplementedError("fused comm with output MX scales is not supported")
     n_slices = max(1, b.shape[0]) if a_ragged_metadata is None else a_ragged_metadata.n_slices
     # unpack b scale
     b_scale = precision_config.b_mx_scale
@@ -377,6 +379,8 @@ def matmul(a, b, bias,
     # compute optimization flags
     out_dtype = precision_config.out_dtype or a.dtype
     out_dtype = torch_dtype_to_dtype(out_dtype)
+    if out_dtype == UINT8 and precision_config.c_mx_scale is not None:
+        out_dtype = FP4
     can_use_tma = (
         a.numel() > 0 and is_tma_compliant(a) and
         b.numel() > 0 and is_tma_compliant(b) and
@@ -474,9 +478,9 @@ def matmul(a, b, bias,
     # Unified mx-scale pointer; when scratchpad exists, prefer its mx buffer
     out_matmul_scale = precision_config.c_mx_scale
     if out_matmul_scale is not None:
-        out_matmul_scale = out_matmul_scale.data
+        out_matmul_scale = out_matmul_scale if isinstance(out_matmul_scale, Tensor) else wrap_torch_tensor(out_matmul_scale)
         if has_scratchpad and "mx_c_mx_scale" in memory["scratchpad"]:
-            out_matmul_scale = memory["scratchpad"]["mx_c_mx_scale"]
+            out_matmul_scale = wrap_torch_tensor(memory["scratchpad"]["mx_c_mx_scale"])
     out_matmul_has_mx = out_matmul_scale is not None and out_matmul.element_size() == 1
     # matrix multiplication
     flex = precision_config.flex_ctx
@@ -522,10 +526,15 @@ def matmul(a, b, bias,
         and is_tma_compliant(c)
         and (c_acc_in is None or c_acc_is_c)
         and fused_comm is None
-        and precision_config.c_value_pack_factor == 1
+        and (
+            precision_config.c_value_pack_factor == 1
+            or matmul_fused_activation.specs.reduction_n == 1
+        )
     )
-    block_n = opt_flags.block_n // opt_flags.epilogue_subtile // matmul_fused_activation.specs.reduction_n
-    c_tma_block_size = [1, block_n] if has_scatter_tma else [1, opt_flags.block_m, block_n]
+    c_logical_block_n = opt_flags.block_n // opt_flags.epilogue_subtile // matmul_fused_activation.specs.reduction_n
+    c_tma_block_n = c_logical_block_n // precision_config.c_value_pack_factor
+    out_tile_n = c_logical_block_n if opt_flags.is_persistent else opt_flags.block_n // matmul_fused_activation.specs.reduction_n
+    c_tma_block_size = [1, c_tma_block_n] if has_scatter_tma else [1, opt_flags.block_m, c_tma_block_n]
     c_tma_mode = None if not c_has_tma else "ragged" if is_c_ragged and not has_scatter_tma else "dense"
     c_tensor_or_tma = make_tma(c, c_tma_block_size, c_tma_mode) if c_has_tma else c.storage.data
     # create tma descriptor for w
@@ -577,8 +586,19 @@ def matmul(a, b, bias,
     b_scale_strides = b_scale.stride() if b_has_mx and not b_scale_has_tma else (None, None, None)
     b_scale_strides = (0, ) * (3 - len(b_scale_strides)) + b_scale_strides
 
-    out_matmul_scale_strides = out_matmul_scale.stride() if out_matmul_has_mx else (None, None, None, None)
+    out_matmul_scale_strides = out_matmul_scale.storage.data.stride() if out_matmul_has_mx else (None, None, None, None)
     out_matmul_scale_strides = (0, ) * (4 - len(out_matmul_scale_strides)) + out_matmul_scale_strides
+    out_matmul_scale_layout = None if out_matmul_scale is None else out_matmul_scale.storage.layout.name
+    if (
+        scatter_indx is not None
+        and out_matmul_scale is not None
+        and isinstance(out_matmul_scale.storage.layout, BlackwellActMXScaleLayout)
+        and out_matmul_scale.storage.layout.ragged_metadata is not None
+    ):
+        raise NotImplementedError("scatter with ragged Blackwell ACT output MX scales is not supported")
+    output_scale_block_offs = None
+    if ragged_dimension == "M" and out_matmul_scale_layout == "BLACKWELL_ACT_SCALE":
+        output_scale_block_offs = a_ragged_metadata.block_offs(int(SWIZZLE_SIZE_OUTER))
     # launch kernel
     kernels = specializations.get(epilogue=epilogue.specs, activation=matmul_fused_activation.specs)
     # When stride(-2) == stride(-1) == 1, it's ambiguous whether W is transposed
@@ -597,7 +617,7 @@ def matmul(a, b, bias,
     n_valid_slices = b_tensor_or_tma.shape[0] if ragged_dimension == "M" else n_slices
     (kernels._p_matmul if opt_flags.is_persistent else kernels._matmul)[(grid,)](
                    c_tensor_or_tma, c.storage.data, *out_matmul.stride(),
-                   *((out_matmul_flex.expected_scale, out_matmul_scale, None) if out_matmul_has_mx else out_matmul_flex),
+                   *((out_matmul_flex.expected_scale, out_matmul_scale.storage.data, None) if out_matmul_has_mx else out_matmul_flex),
                    *out_matmul_scale_strides[-4:],
                    a_tensor_or_tma, a.storage.data, *a_strides, a_transpose,
                    flex.lhs_data.scale,
@@ -616,6 +636,7 @@ def matmul(a, b, bias,
                    None if scatter_indx is None else scatter_indx.shape[0],
                    ragged_dimension,
                    *expt_data_x,
+                   output_scale_block_offs,
                    *expt_data_w,
                    batch_size, grid_m, grid_n,
                    out_alpha,
@@ -647,7 +668,9 @@ def matmul(a, b, bias,
                    UPCAST_INDICES=should_upcast_indices(a, b, out_matmul),
                    X_TMA_MODE=a_tma_mode,
                    Y_TMA_MODE=c_tma_mode,
-                   SWAP_XW=get_swap_xw(precision_config, opt_flags),
+                   Y_MX_SCALE_LAYOUT=out_matmul_scale_layout,
+                   OUT_N_TILE_ALIGNED=(N // matmul_fused_activation.specs.reduction_n) % out_tile_n == 0,
+                   SWAP_XW=get_swap_xw(precision_config, opt_flags, a.dtype, b.dtype),
                    IS_EPILOGUE_QUANT_MX=epilogue.specs.name in (
                        FnName.QUANTIZE_MXFP8.name,
                        FnName.QUANTIZE_MXFP4.name,
@@ -687,7 +710,11 @@ def matmul(a, b, bias,
             out_final_mx_scale = y_mx_scale.view(*memory["output"].shape[1:-1], triton.cdiv(logical_out_n, precision_config.c_microblock_size))
     else:
         out_final = out_matmul.squeeze(0)
-        out_final_mx_scale = out_matmul_scale
+        out_final_mx_scale = (
+            None if out_matmul_scale is None
+            else out_matmul_scale if isinstance(precision_config.c_mx_scale, Tensor)
+            else out_matmul_scale.storage.data
+        )
 
     if not (is_input_batched or b_ragged_metadata is not None):
         out_final = out_final.squeeze(0)

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -1,5 +1,10 @@
 import triton
 import triton.language as tl
+from triton_kernels.tensor_details.layout_details.blackwell_scale import (
+    SWIZZLE_SIZE_OUTER,
+    swizzle_act_mx_scale_bw_store_ptr,
+    swizzle_mx_scale_bw_store_ptr,
+)
 
 # -----------------------------------------------------------------------------
 #                                  Utilities
@@ -133,6 +138,93 @@ def compute_offsets(
         off_x_k,
         off_w_k,
     )
+
+
+@triton.jit
+def output_mx_scale_store_ptr(
+    base,
+    local_rows,
+    output_rows,
+    cols,
+    start_z,
+    start_m,
+    M,
+    n_cols,
+    scale_block_offs,
+    expt_id,
+    pid_k,
+    pid_k_direct,
+    batch_size,
+    stride_k,
+    stride_z,
+    stride_m,
+    stride_n,
+    HAS_SCATTER: tl.constexpr,
+    USE_SCATTER_TMA: tl.constexpr,
+    Y_TMA_MODE: tl.constexpr,
+    RAGGED_DIMENSION: tl.constexpr,
+    Y_MX_SCALE_LAYOUT: tl.constexpr,
+    INDEX_TYPE: tl.constexpr = tl.int64,
+):
+    if Y_MX_SCALE_LAYOUT == "BLACKWELL_ACT_SCALE":
+        if HAS_SCATTER:
+            scale_m_block = 0
+            scale_rows = output_rows
+        elif RAGGED_DIMENSION == "M":
+            scale_m_block = tl.load(scale_block_offs + expt_id)
+            scale_rows = local_rows
+        else:
+            scale_m_block = start_z * tl.cdiv(M, SWIZZLE_SIZE_OUTER)
+            scale_rows = local_rows
+        return swizzle_act_mx_scale_bw_store_ptr(
+            base,
+            scale_rows,
+            cols,
+            scale_m_block,
+            stride_k,
+            stride_z,
+            stride_m,
+            stride_n,
+            INDEX_TYPE=INDEX_TYPE,
+        )
+    elif Y_MX_SCALE_LAYOUT == "BLACKWELL_SCALE":
+        return swizzle_mx_scale_bw_store_ptr(
+            base,
+            output_rows,
+            cols,
+            start_z,
+            n_cols,
+            stride_k,
+            stride_z,
+            stride_m,
+            stride_n,
+            INDEX_TYPE=INDEX_TYPE,
+        )
+    else:
+        tl.static_assert(Y_MX_SCALE_LAYOUT == "STRIDED")
+        zero = tl.full((), 0, tl.int32)
+        scale_k = zero
+        if USE_SCATTER_TMA:
+            scale_z = zero
+            scale_rows = (output_rows.to(tl.uint32, bitcast=True) & 0x7FFFFFFF).to(tl.int32, bitcast=True)
+        elif Y_TMA_MODE == "dense":
+            scale_z = pid_k * batch_size + start_z
+            scale_rows = local_rows
+        elif Y_TMA_MODE == "ragged":
+            scale_z = pid_k
+            scale_rows = start_m + local_rows
+        else:
+            tl.static_assert(Y_TMA_MODE is None)
+            scale_k = pid_k_direct
+            scale_z = start_z
+            scale_rows = output_rows
+        return (
+            base
+            + scale_k.to(INDEX_TYPE) * stride_k
+            + scale_z.to(INDEX_TYPE) * stride_z
+            + scale_rows.to(INDEX_TYPE)[:, None] * stride_m
+            + cols.to(INDEX_TYPE)[None, :] * stride_n
+        )
 
 
 def make_matmul_repr(base_name, order):

--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -218,13 +218,8 @@ def output_mx_scale_store_ptr(
             scale_k = pid_k_direct
             scale_z = start_z
             scale_rows = output_rows
-        return (
-            base
-            + scale_k.to(INDEX_TYPE) * stride_k
-            + scale_z.to(INDEX_TYPE) * stride_z
-            + scale_rows.to(INDEX_TYPE)[:, None] * stride_m
-            + cols.to(INDEX_TYPE)[None, :] * stride_n
-        )
+        return (base + scale_k.to(INDEX_TYPE) * stride_k + scale_z.to(INDEX_TYPE) * stride_z +
+                scale_rows.to(INDEX_TYPE)[:, None] * stride_m + cols.to(INDEX_TYPE)[None, :] * stride_n)
 
 
 def make_matmul_repr(base_name, order):

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -2,7 +2,9 @@
 # fmt: off
 import triton
 import triton.language as tl
-from triton_kernels.tensor_details.layout_details.blackwell_scale import unswizzle_mx_scale_bw
+from triton_kernels.tensor_details.layout_details.blackwell_scale import (
+    unswizzle_mx_scale_bw,
+)
 from triton_kernels.tensor_details.layout_details.hopper_scale import unswizzle_mxfp4_scale_hopper
 from triton_kernels.tensor_details.layout_details.hopper_value import mxfp4_to_bf16_triton
 from triton_kernels.tensor_details.layout_details.cdna4_scale import unswizzle_mx_scale_cdna4
@@ -16,6 +18,7 @@ from ._common import (
     make_matmul_repr,
     matmul_launch_metadata,
     compute_pids,
+    output_mx_scale_store_ptr,
 )
 
 
@@ -48,6 +51,7 @@ def _matmul(
              WriteBackIndx, writeback_size,
              RAGGED_DIMENSION: tl.constexpr,
              XSliceSizes, XSliceOffs, XBlockOffs, XBlockSchedule, X_EXPECTED_SLICE_SIZE: tl.constexpr, X_SLICE_SIZES_DIVISIBILITY: tl.constexpr,
+             XOutputScaleBlockOffs,
              WSliceSizes, WSliceOffs, WBlockOffs, WBlockSchedule, W_EXPECTED_SLICE_SIZE: tl.constexpr, _W_SLICE_SIZES_DIVISIBILITY: tl.constexpr,
              # true grid size
              batch_size, grid_m, grid_n,
@@ -79,6 +83,8 @@ def _matmul(
              NUM_SMS: tl.constexpr,
              X_TMA_MODE: tl.constexpr,
              Y_TMA_MODE: tl.constexpr,
+             Y_MX_SCALE_LAYOUT: tl.constexpr = None,
+             OUT_N_TILE_ALIGNED: tl.constexpr = False,
              TOKENS_PER_EXPT_FOR_ANNOTATION=None,
              UPCAST_INDICES: tl.constexpr = False,
              SWAP_XW: tl.constexpr = False,
@@ -215,7 +221,7 @@ def _matmul(
 
     (
         expt_id, start_z, start_z_out,
-        start_m, _, off_m,
+        start_m, slice_block_off_m, off_m,
         off_k_x, off_k_w
     ) = compute_offsets(
             pid_s, pid_m, pid_k,
@@ -503,11 +509,11 @@ def _matmul(
         tl.static_assert(Y_TMA_MODE is None, "FP4 outputs are only supported without output TMA")
         offs_y_n_store = pid_n * (OUT_BLOCK_N // 2) + tl.arange(0, OUT_BLOCK_N // 2)
         YPtrs = Y + offs_y_m.to(index_type)[:, None] * stride_y_m + offs_y_n_store.to(index_type)[None, :] * stride_y_n
-        mask_store = mask_m[:, None] & (offs_y_n_store[None, :] < tl.cdiv(yN, 2))
+        mask_store = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & (offs_y_n_store[None, :] < tl.cdiv(yN, 2))
     else:
         YPtrs = Y + offs_y_m.to(index_type)[:, None] * stride_y_m + offs_y_n.to(index_type)[None, :] * stride_y_n
-        mask_store = mask_m[:, None] & mask_n[None, :]
-    mask = mask_m[:, None] & mask_n[None, :]
+        mask_store = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
+    mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
 
     if OutAcc is not None:
         if PER_BATCH_ACC_SCALE:
@@ -534,14 +540,35 @@ def _matmul(
         out, out_scale = EPILOGUE_FN(out, mask, *epilogue_fn_args)
         tl.static_assert(BLOCK_N % MX_SCALE_BLOCK_N == 0, "")
         offs_y_n_scale = MX_SCALE_BLOCK_N * pid_n + tl.arange(0, MX_SCALE_BLOCK_N)
+        output_scale_rows = offs_y_m if WriteBackIndx is not None else start_m + offs_y_m
+        YActualScalePtrs = output_mx_scale_store_ptr(
+            YActualScale,
+            offs_m,
+            output_scale_rows,
+            offs_y_n_scale,
+            start_z_out,
+            start_m,
+            M,
+            N_MX_BLOCK,
+            XOutputScaleBlockOffs,
+            expt_id,
+            pid_k - pid_k,
+            pid_k - pid_k,
+            batch_size,
+            stride_y_mx_k,
+            stride_y_mx_z,
+            stride_y_mx_m,
+            stride_y_mx_n,
+            WriteBackIndx is not None,
+            False,
+            Y_TMA_MODE,
+            RAGGED_DIMENSION,
+            Y_MX_SCALE_LAYOUT,
+            INDEX_TYPE=index_type,
+        )
         mask_n_scale = offs_y_n_scale < N_MX_BLOCK
-        YActualScale += start_z_out.to(index_type) * stride_y_mx_z
-        if WriteBackIndx is None:
-            YActualScale += start_m * stride_y_mx_m
-            YActualScalePtrs = YActualScale + offs_y_m.to(index_type)[:, None] * stride_y_mx_m + offs_y_n_scale.to(index_type)[None, :] * stride_y_mx_n
-        else:
-            YActualScalePtrs = YActualScale + offs_y_m.to(index_type)[:, None] * stride_y_mx_m + offs_y_n_scale.to(index_type)[None, :] * stride_y_mx_n
-        tl.store(YActualScalePtrs, out_scale, mask=mask_m[:, None] & mask_n_scale[None, :])
+        scale_store_mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n_scale[None, :]
+        tl.store(YActualScalePtrs, out_scale, mask=scale_store_mask)
     else:
         if PER_BATCH_OUT_SCALE:
             YExpectedScale = YExpectedScale + start_z_out

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -6,7 +6,10 @@ import triton
 import triton.language as tl
 from triton.tools.ragged_tma import load_ragged, store_ragged
 from triton_kernels import target_info
-from triton_kernels.tensor_details.layout_details.blackwell_scale import unswizzle_mx_scale_bw, unswizzle_act_mx_scale_bw
+from triton_kernels.tensor_details.layout_details.blackwell_scale import (
+    unswizzle_mx_scale_bw,
+    unswizzle_act_mx_scale_bw,
+)
 from triton_kernels.numerics_details.flexpoint import (
     float_to_flex,
     load_scale,
@@ -22,6 +25,7 @@ from ._common import (
     make_matmul_repr,
     matmul_launch_metadata,
     compute_pids,
+    output_mx_scale_store_ptr,
 )
 
 
@@ -74,6 +78,7 @@ def _p_matmul(
              WriteBackIndx, writeback_size,
              RAGGED_DIMENSION: tl.constexpr,
              XSliceSizes, XSliceOffs, XBlockOffs, XBlockSchedule, X_EXPECTED_SLICE_SIZE: tl.constexpr, X_SLICE_SIZES_DIVISIBILITY: tl.constexpr,
+             XOutputScaleBlockOffs,
              WSliceSizes, WSliceOffs, WBlockOffs, WBlockSchedule, W_EXPECTED_SLICE_SIZE: tl.constexpr, W_SLICE_SIZES_DIVISIBILITY: tl.constexpr,
              # true grid size
              batch_size, grid_m, grid_n,
@@ -105,6 +110,8 @@ def _p_matmul(
              NUM_SMS: tl.constexpr,
              X_TMA_MODE: tl.constexpr,
              Y_TMA_MODE: tl.constexpr,
+             Y_MX_SCALE_LAYOUT: tl.constexpr = None,
+             OUT_N_TILE_ALIGNED: tl.constexpr = False,
              TOKENS_PER_EXPT_FOR_ANNOTATION=None,
              UPCAST_INDICES: tl.constexpr=False,
              SWAP_XW: tl.constexpr = False,
@@ -440,8 +447,8 @@ def _p_matmul(
         if INDEPENDENT_EPILOGUE:
             tile_id1 += NUM_SMS
             pid_s1, pid_m1, pid_n1, pid_k1 = compute_pids(tile_id1, useful_grid_m, grid_n, num_blocks, XCD_SWIZZLE, GROUP_M, SPLIT_K)
-            expt_id1, _, start_z1, start_m1, _, off_m1, _, _ = compute_offsets(
-                pid_z, pid_m, pid_k,
+            expt_id1, _, start_z1, start_m1, slice_block_off_m1, off_m1, _, _ = compute_offsets(
+                pid_s1, pid_m1, pid_k1,
                 XBlockSchedule, XSliceOffs, XBlockOffs, X_SLICE_SIZES_DIVISIBILITY,
                 WBlockSchedule, WSliceOffs, W_SLICE_SIZES_DIVISIBILITY,
                 RAGGED_DIMENSION,
@@ -454,7 +461,7 @@ def _p_matmul(
                 eM1 = M
         else:
             tile_id1, expt_id1, start_z1, start_m1, eM1 = block_id, off_w_z, off_y_z, slice_off_m, shape_m
-            off_m1, off_n1, pid_k1 = off_m, off_n, pid_k
+            slice_block_off_m1, off_m1, off_n1, pid_k1 = slice_block_off_m, off_m, off_n, pid_k
 
         offs_m = off_m1 + tl.arange(0, BLOCK_M)
         mask_m = offs_m < eM1
@@ -572,7 +579,7 @@ def _p_matmul(
                     mask_n = offs_y_n < yN
 
                     AccPtrs = YPtr + pid_k1.to(index_type) * stride_y_k + start_z1.to(index_type) * stride_y_z + offs_y_m.to(index_type)[:, None] * stride_y_m + offs_y_n[None, :] * stride_y_n
-                    mask = mask_m[:, None] & mask_n[None, :]
+                    mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
                     acc = tl.load(AccPtrs, mask=mask, other=0.0)
                     out += acc * load_scale(ScalePtr)
 
@@ -584,6 +591,7 @@ def _p_matmul(
                 tl.static_assert(EPILOGUE_FN is not None)
                 offs_y_n = out_off_n + tl.arange(0, OUT_BLOCK_N)
                 mask_n = offs_y_n < yN
+                out_mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
                 if PER_BATCH_OUT_SCALE:
                     ExpectedScale = YExpectedScale + start_z1
                 else:
@@ -597,33 +605,42 @@ def _p_matmul(
                     ExpectedScale,
                     None,
                     None,
-                    mask_m[:, None] & mask_n[None, :],
+                    out_mask,
                     YPtr,
                     False,
                 )
-                out, out_scale = EPILOGUE_FN(out, mask_m[:, None] & mask_n[None, :], *epilogue_fn_args)
+                out, out_scale = EPILOGUE_FN(out, out_mask, *epilogue_fn_args)
                 tl.static_assert(BLOCK_N % MX_SCALE_BLOCK_N == 0, "")
                 offs_y_n_scale = off_n1 // ACTIVATION_REDUCTION_N // MX_BLOCK_SIZE + a_i * MX_SCALE_BLOCK_N + tl.arange(0, MX_SCALE_BLOCK_N)
-                mask_n_scale = offs_y_n_scale < tl.cdiv(yN, MX_BLOCK_SIZE)
-                offs_y_mx_k = 0
-                if USE_SCATTER_TMA:
-                    # Convert -1 offsets to INT_MAX. We do this by clearing the leading bit. Note that
-                    # there shouldn't be any other negative values.
-                    offs_y_mx_z = 0
-                    offs_y_mx_m = (offs_y_m.to(tl.uint32, bitcast=True) & 0x7FFFFFFF).to(tl.int32, bitcast=True)
-                elif Y_TMA_MODE == "dense":
-                    offs_y_mx_z = pid_k * batch_size + start_z1
-                    offs_y_mx_m = off_m1 + tl.arange(0, BLOCK_M)
-                elif Y_TMA_MODE == "ragged":
-                    offs_y_mx_z = pid_k
-                    offs_y_mx_m = start_m1 + off_m1 + tl.arange(0, BLOCK_M)
-                else:
-                    tl.static_assert(Y_TMA_MODE is None)
-                    offs_y_mx_k = pid_k1
-                    offs_y_mx_z = start_z1
-                    offs_y_mx_m = offs_y_m
-                YActualScalePtrs = YActualScale + offs_y_mx_k.to(index_type) * stride_y_mx_k + offs_y_mx_z.to(index_type) * stride_y_mx_z + offs_y_mx_m.to(index_type)[:, None] * stride_y_mx_m + offs_y_n_scale.to(index_type)[None, :] * stride_y_mx_n
-                tl.store(YActualScalePtrs, out_scale, mask=mask_m[:, None] & mask_n_scale[None, :])
+                n_mx_blocks = tl.cdiv(yN, MX_BLOCK_SIZE)
+                YActualScalePtrs = output_mx_scale_store_ptr(
+                    YActualScale,
+                    offs_m,
+                    offs_y_m,
+                    offs_y_n_scale,
+                    start_z1,
+                    start_m1,
+                    M,
+                    n_mx_blocks,
+                    XOutputScaleBlockOffs,
+                    expt_id1,
+                    pid_k,
+                    pid_k1,
+                    batch_size,
+                    stride_y_mx_k,
+                    stride_y_mx_z,
+                    stride_y_mx_m,
+                    stride_y_mx_n,
+                    HAS_SCATTER,
+                    USE_SCATTER_TMA,
+                    Y_TMA_MODE,
+                    RAGGED_DIMENSION,
+                    Y_MX_SCALE_LAYOUT,
+                    INDEX_TYPE=index_type,
+                )
+                mask_n_scale = offs_y_n_scale < n_mx_blocks
+                scale_store_mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n_scale[None, :]
+                tl.store(YActualScalePtrs, out_scale, mask=scale_store_mask)
             else:
                 # Flexpoint
                 if USE_LOCAL_ABSMAX:
@@ -647,7 +664,6 @@ def _p_matmul(
 
             out = out.to(YPtr.dtype.element_ty)
             if is_out_fp4:
-                tl.static_assert(Y_TMA_MODE is None, "FP4 outputs are only supported without output TMA")
                 out_off_n = out_off_n // 2
                 offs_y_n = out_off_n + tl.arange(0, OUT_BLOCK_N // 2)
                 mask_n = offs_y_n < tl.cdiv(yN, 2)
@@ -672,7 +688,7 @@ def _p_matmul(
                     if is_out_fp4:
                         offs_y_n = out_off_n + tl.arange(0, OUT_BLOCK_N // 2)
                         mask_n = offs_y_n < tl.cdiv(yN, 2)
-                    mask = mask_m[:, None] & mask_n[None, :]
+                    mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
                     offs_kzmn = pid_k1.to(index_type) * stride_y_k + start_z1.to(index_type) * stride_y_z + offs_y_m.to(index_type)[:, None] * stride_y_m + offs_y_n[None, :] * stride_y_n
                     tl.store(YPtr + offs_kzmn, out, mask=mask)
             else:
@@ -680,7 +696,7 @@ def _p_matmul(
                 tl.static_assert(Y_TMA_MODE is None, "TMA is not supported with fused comms")
                 offs_y_n = out_off_n + tl.arange(0, OUT_BLOCK_N)
                 mask_n = offs_y_n < yN
-                mask = mask_m[:, None] & mask_n[None, :]
+                mask = mask_m[:, None] if OUT_N_TILE_ALIGNED else mask_m[:, None] & mask_n[None, :]
 
                 dst_shard_idx, dst_y_m, dst_y_n = map_dst_coord.fn(
                     start_m1 + off_m1 if WriteBackIndx is None else None, offs_y_m,

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -461,7 +461,7 @@ def _p_matmul(
                 eM1 = M
         else:
             tile_id1, expt_id1, start_z1, start_m1, eM1 = block_id, off_w_z, off_y_z, slice_off_m, shape_m
-            slice_block_off_m1, off_m1, off_n1, pid_k1 = slice_block_off_m, off_m, off_n, pid_k
+            _, off_m1, off_n1, pid_k1 = slice_block_off_m, off_m, off_n, pid_k
 
         offs_m = off_m1 + tl.arange(0, BLOCK_M)
         mask_m = offs_m < eM1

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -209,6 +209,8 @@ def make_default_opt_flags_nvidia(
         slice_size = routing_data.expected_slice_size
     # pid swizzling
     group_m = 8
+    if lhs_dtype == FP4 and rhs_dtype == FP4:
+        group_m = 16
     xcd_swizzle = 1
     # block_m
     if constraints.get("block_m", None):
@@ -341,7 +343,7 @@ def make_default_opt_flags_nvidia(
     if constraints.get("epilogue_subtile", None) is not None:
         subtiles_to_check = [constraints["epilogue_subtile"]]
     else:
-        subtiles_to_check = [1, 2, 4]
+        subtiles_to_check = [1] if out_dtype == FP4 else [1, 2, 4]
     num_stages = -1
     for ep in subtiles_to_check:
         ns = opt_flags_nvidia.compute_num_stages(*compute_num_stages_args, epilogue_subtile=ep,

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -13,8 +13,10 @@ def is_x_scale_swizzled(precision_config):
             and isinstance(precision_config.a_mx_scale.storage.layout, BlackwellActMXScaleLayout))
 
 
-def compute_swap_xw(precision_config, block_m, is_persistent):
+def compute_swap_xw(precision_config, block_m, is_persistent, lhs_dtype, rhs_dtype):
     if target_info.cuda_capability_geq(10, 0):
+        if lhs_dtype == FP4 and rhs_dtype == FP4:
+            return block_m <= 128 and is_persistent
         if precision_config.b_mx_scale is not None:
             return block_m <= 64 and is_persistent
         else:
@@ -71,8 +73,9 @@ def compute_block_k(m: int, k: int | None, is_persistent: bool, lhs_dtype, rhs_d
         block_k = max(min_block_k, min(triton.next_power_of_2(k), block_k))
     has_mx_weight_scale = precision_config is not None and precision_config.b_mx_scale is not None
     if has_native_mxfp and is_persistent and has_mx_weight_scale:
-        # Cap block_k to conserve smem to increase num_stages
-        block_k = min(block_k, 128)
+        # If both inputs are fp4, allow larger block_k.
+        max_block_k = 256 if lhs_dtype == FP4 and rhs_dtype == FP4 else 128
+        block_k = min(block_k, max_block_k)
     if has_y_acc_in and lhs_width == rhs_width == 16 and not target_info.cuda_capability_geq(10, 0):
         block_k = min(block_k, 32)
     return block_k
@@ -120,6 +123,7 @@ def compute_num_stages(
 ):
     if precision_config.max_num_imprecise_acc is not None:
         return 3
+    act_size = lhs_dtype.bitwidth / 8
     weight_size = rhs_dtype.bitwidth / 8
     has_native_mxfp = target_info.cuda_capability_geq(10, 0)
     if has_native_mxfp and precision_config.b_mx_scale is not None and lhs_dtype in [FP16, BF16]:
@@ -131,14 +135,16 @@ def compute_num_stages(
         # block_m=64, block_n=256, block_k=128, split_k=1, is_persistent=True -> leading to num_stages=4
         weight_size = 2
 
-    stage_size = block_m * block_k * (max(8, lhs_dtype.bitwidth) // 8) + block_k * block_n * weight_size
+    stage_size = block_m * block_k * act_size + block_k * block_n * weight_size
     device_props = torch.cuda.get_device_properties(0)
     smem_capacity = device_props.shared_memory_per_block_optin
     smem_capacity //= occupancy_target
-    if has_native_mxfp and getattr(precision_config, "b_mx_scale", None) is not None:
-        if rhs_dtype == FP4:
-            # 4-bit e2m1 weights are padded 2x
-            # https://docs.nvidia.com/cuda/parallel-thread-execution/#packing-format-used-for-matrix-a-and-b-by-kind-mxf8f6f4-in-shared-memory
+    if has_native_mxfp:
+        # 4-bit e2m1 operands are padded 2x
+        # https://docs.nvidia.com/cuda/parallel-thread-execution/#packing-format-used-for-matrix-a-and-b-by-kind-mxf8f6f4-in-shared-memory
+        if precision_config.a_mx_scale is not None and lhs_dtype == FP4 and rhs_dtype != FP4:
+            stage_size += block_k * block_n * act_size
+        if precision_config.b_mx_scale is not None and rhs_dtype == FP4 and lhs_dtype != FP4:
             stage_size += block_k * block_n * weight_size
 
     if precision_config.a_mx_scale is not None:
@@ -166,15 +172,15 @@ def compute_num_stages(
         # pipelined layout conversion before store of the accumulator
         # note: layout conversion has some padding
         epilogue_smem = int((block_m + 4) * acc_block_n * acc_size)
-        if compute_swap_xw(precision_config, block_m, is_persistent):
+        if compute_swap_xw(precision_config, block_m, is_persistent, lhs_dtype, rhs_dtype):
             # The fp32 accumulator stays in TMEM for the Blackwell SWAP_XW
             # persistent path. Fused reductions such as swiglu still need smem
             # for the unreduced output tile before the narrower TMA-store tile.
-            if epilogue_reduction_n > 1:
+            if epilogue_reduction_n > 1 or epilogue_subtile > 1:
                 epilogue_smem += int(block_m * block_n * out_itemsize)
         smem_capacity -= epilogue_smem
         if x_transpose:
-            smem_capacity -= block_m * block_k * (max(8, lhs_dtype.bitwidth) // 8)
+            smem_capacity -= int(block_m * block_k * act_size)
 
     # Persistent fp32 kernels need extra smem headroom (metadata/barriers/TMA state)
     # that is not fully captured by the simple stage_size model above.

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -176,6 +176,8 @@ class BlackwellMXScaleLayoutTransformation(LayoutTransformation):
 SWIZZLE_ALIGN_INNER = tl.constexpr(8)
 SWIZZLE_SIZE_INNER = tl.constexpr(4)
 SWIZZLE_SIZE_OUTER = tl.constexpr(128)
+SWIZZLE_SIZE_LANE = tl.constexpr(32)
+SWIZZLE_SIZE_HALF = tl.constexpr(256)
 
 
 @triton.jit
@@ -409,13 +411,14 @@ def unswizzle_mx_scale_bw(
     x,
     SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,
     SIZE_INNER: tl.constexpr = SWIZZLE_SIZE_INNER,
+    SIZE_LANE: tl.constexpr = SWIZZLE_SIZE_LANE,
     ALIGN_INNER: tl.constexpr = SWIZZLE_ALIGN_INNER,
 ):
     shape_0: tl.constexpr = x.shape[0]
     shape_1: tl.constexpr = x.shape[1]
     tl.static_assert(shape_1 % SIZE_OUTER == 0)
-    tl.static_assert(shape_1 // SIZE_OUTER <= ALIGN_INNER)
-    x = x.reshape(shape_0, (shape_1 // SIZE_OUTER) // SIZE_INNER, 32, SIZE_OUTER // 32, SIZE_INNER)
+    tl.static_assert((shape_1 // SIZE_OUTER) % SIZE_INNER == 0)
+    x = x.reshape(shape_0, (shape_1 // SIZE_OUTER) // SIZE_INNER, SIZE_LANE, SIZE_OUTER // SIZE_LANE, SIZE_INNER)
     x = x.trans(0, 3, 2, 1, 4).reshape(shape_0 * SIZE_OUTER, shape_1 // SIZE_OUTER)
     return x
 
@@ -423,6 +426,7 @@ def unswizzle_mx_scale_bw(
 @triton.jit
 def unswizzle_act_mx_scale_bw(x, SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,  # 128
                               SIZE_INNER: tl.constexpr = SWIZZLE_SIZE_INNER,  # 4
+                              SIZE_LANE: tl.constexpr = SWIZZLE_SIZE_LANE,
                               ):
     # input block shape is [1, BLOCK_M//128, BLOCK_K//32//4, 2, 256] and we want to unswizzle it to [BLOCK_M, BLOCK_K//32]
     shape_1: tl.constexpr = x.shape[1]
@@ -430,5 +434,66 @@ def unswizzle_act_mx_scale_bw(x, SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER, 
     unswizzled_block_m: tl.constexpr = shape_1 * SIZE_OUTER  # BLOCK_M
     unswizzled_block_k: tl.constexpr = shape_2 * SIZE_INNER  # BLOCK_K // 32
 
-    x = x.reshape(shape_1, shape_2, 32, 4, 4).trans(0, 3, 2, 1, 4).reshape(unswizzled_block_m, unswizzled_block_k)
+    x = x.reshape(shape_1, shape_2, SIZE_LANE, SIZE_OUTER // SIZE_LANE, SIZE_INNER)
+    x = x.trans(0, 3, 2, 1, 4).reshape(unswizzled_block_m, unswizzled_block_k)
     return x
+
+
+@triton.jit
+def swizzle_mx_scale_bw_store_ptr(base, rows, cols, leading_idx, n_cols,
+                                  stride_outer, stride_inner, stride_half, stride_lane,
+                                  SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,
+                                  SIZE_INNER: tl.constexpr = SWIZZLE_SIZE_INNER,
+                                  SIZE_LANE: tl.constexpr = SWIZZLE_SIZE_LANE,
+                                  SIZE_HALF: tl.constexpr = SWIZZLE_SIZE_HALF,
+                                  INDEX_TYPE: tl.constexpr = tl.int64):
+    col_block = cols // SIZE_OUTER
+    outer = leading_idx * tl.cdiv(n_cols, SIZE_OUTER) + col_block
+    inner_group = rows // SIZE_INNER
+    col_lane = cols - col_block * SIZE_OUTER
+    col_quad = col_lane // SIZE_LANE
+    col_lane_inner = col_lane - col_quad * SIZE_LANE
+    row_lane = rows - inner_group * SIZE_INNER
+    inner_linear = (
+        (col_lane_inner[None, :] * (SIZE_OUTER // SIZE_LANE) + col_quad[None, :]) * SIZE_INNER
+        + row_lane[:, None]
+    )
+    half = inner_linear // SIZE_HALF
+    inner = inner_linear - half * SIZE_HALF
+    return (
+        base
+        + outer.to(INDEX_TYPE)[None, :] * stride_outer
+        + inner_group.to(INDEX_TYPE)[:, None] * stride_inner
+        + half.to(INDEX_TYPE) * stride_half
+        + inner.to(INDEX_TYPE) * stride_lane
+    )
+
+
+@triton.jit
+def swizzle_act_mx_scale_bw_store_ptr(base, rows, cols, leading_m_block,
+                                      stride_outer, stride_inner, stride_half, stride_lane,
+                                      SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,
+                                      SIZE_INNER: tl.constexpr = SWIZZLE_SIZE_INNER,
+                                      SIZE_LANE: tl.constexpr = SWIZZLE_SIZE_LANE,
+                                      SIZE_HALF: tl.constexpr = SWIZZLE_SIZE_HALF,
+                                      INDEX_TYPE: tl.constexpr = tl.int64):
+    row_block = rows // SIZE_OUTER
+    outer = leading_m_block + row_block
+    inner_group = cols // SIZE_INNER
+    col_lane = cols - inner_group * SIZE_INNER
+    row_lane = rows - row_block * SIZE_OUTER
+    row_quad = row_lane // SIZE_LANE
+    row_lane_inner = row_lane - row_quad * SIZE_LANE
+    inner_linear = (
+        (row_lane_inner[:, None] * (SIZE_OUTER // SIZE_LANE) + row_quad[:, None]) * SIZE_INNER
+        + col_lane[None, :]
+    )
+    half = inner_linear // SIZE_HALF
+    inner = inner_linear - half * SIZE_HALF
+    return (
+        base
+        + outer.to(INDEX_TYPE)[:, None] * stride_outer
+        + inner_group.to(INDEX_TYPE)[None, :] * stride_inner
+        + half.to(INDEX_TYPE) * stride_half
+        + inner.to(INDEX_TYPE) * stride_lane
+    )

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_scale.py
@@ -424,10 +424,12 @@ def unswizzle_mx_scale_bw(
 
 
 @triton.jit
-def unswizzle_act_mx_scale_bw(x, SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,  # 128
-                              SIZE_INNER: tl.constexpr = SWIZZLE_SIZE_INNER,  # 4
-                              SIZE_LANE: tl.constexpr = SWIZZLE_SIZE_LANE,
-                              ):
+def unswizzle_act_mx_scale_bw(
+    x,
+    SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,  # 128
+    SIZE_INNER: tl.constexpr = SWIZZLE_SIZE_INNER,  # 4
+    SIZE_LANE: tl.constexpr = SWIZZLE_SIZE_LANE,
+):
     # input block shape is [1, BLOCK_M//128, BLOCK_K//32//4, 2, 256] and we want to unswizzle it to [BLOCK_M, BLOCK_K//32]
     shape_1: tl.constexpr = x.shape[1]
     shape_2: tl.constexpr = x.shape[2]
@@ -440,13 +442,11 @@ def unswizzle_act_mx_scale_bw(x, SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER, 
 
 
 @triton.jit
-def swizzle_mx_scale_bw_store_ptr(base, rows, cols, leading_idx, n_cols,
-                                  stride_outer, stride_inner, stride_half, stride_lane,
-                                  SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,
+def swizzle_mx_scale_bw_store_ptr(base, rows, cols, leading_idx, n_cols, stride_outer, stride_inner, stride_half,
+                                  stride_lane, SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,
                                   SIZE_INNER: tl.constexpr = SWIZZLE_SIZE_INNER,
                                   SIZE_LANE: tl.constexpr = SWIZZLE_SIZE_LANE,
-                                  SIZE_HALF: tl.constexpr = SWIZZLE_SIZE_HALF,
-                                  INDEX_TYPE: tl.constexpr = tl.int64):
+                                  SIZE_HALF: tl.constexpr = SWIZZLE_SIZE_HALF, INDEX_TYPE: tl.constexpr = tl.int64):
     col_block = cols // SIZE_OUTER
     outer = leading_idx * tl.cdiv(n_cols, SIZE_OUTER) + col_block
     inner_group = rows // SIZE_INNER
@@ -454,29 +454,20 @@ def swizzle_mx_scale_bw_store_ptr(base, rows, cols, leading_idx, n_cols,
     col_quad = col_lane // SIZE_LANE
     col_lane_inner = col_lane - col_quad * SIZE_LANE
     row_lane = rows - inner_group * SIZE_INNER
-    inner_linear = (
-        (col_lane_inner[None, :] * (SIZE_OUTER // SIZE_LANE) + col_quad[None, :]) * SIZE_INNER
-        + row_lane[:, None]
-    )
+    inner_linear = ((col_lane_inner[None, :] * (SIZE_OUTER // SIZE_LANE) + col_quad[None, :]) * SIZE_INNER +
+                    row_lane[:, None])
     half = inner_linear // SIZE_HALF
     inner = inner_linear - half * SIZE_HALF
-    return (
-        base
-        + outer.to(INDEX_TYPE)[None, :] * stride_outer
-        + inner_group.to(INDEX_TYPE)[:, None] * stride_inner
-        + half.to(INDEX_TYPE) * stride_half
-        + inner.to(INDEX_TYPE) * stride_lane
-    )
+    return (base + outer.to(INDEX_TYPE)[None, :] * stride_outer + inner_group.to(INDEX_TYPE)[:, None] * stride_inner +
+            half.to(INDEX_TYPE) * stride_half + inner.to(INDEX_TYPE) * stride_lane)
 
 
 @triton.jit
-def swizzle_act_mx_scale_bw_store_ptr(base, rows, cols, leading_m_block,
-                                      stride_outer, stride_inner, stride_half, stride_lane,
-                                      SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,
+def swizzle_act_mx_scale_bw_store_ptr(base, rows, cols, leading_m_block, stride_outer, stride_inner, stride_half,
+                                      stride_lane, SIZE_OUTER: tl.constexpr = SWIZZLE_SIZE_OUTER,
                                       SIZE_INNER: tl.constexpr = SWIZZLE_SIZE_INNER,
                                       SIZE_LANE: tl.constexpr = SWIZZLE_SIZE_LANE,
-                                      SIZE_HALF: tl.constexpr = SWIZZLE_SIZE_HALF,
-                                      INDEX_TYPE: tl.constexpr = tl.int64):
+                                      SIZE_HALF: tl.constexpr = SWIZZLE_SIZE_HALF, INDEX_TYPE: tl.constexpr = tl.int64):
     row_block = rows // SIZE_OUTER
     outer = leading_m_block + row_block
     inner_group = cols // SIZE_INNER
@@ -484,16 +475,9 @@ def swizzle_act_mx_scale_bw_store_ptr(base, rows, cols, leading_m_block,
     row_lane = rows - row_block * SIZE_OUTER
     row_quad = row_lane // SIZE_LANE
     row_lane_inner = row_lane - row_quad * SIZE_LANE
-    inner_linear = (
-        (row_lane_inner[:, None] * (SIZE_OUTER // SIZE_LANE) + row_quad[:, None]) * SIZE_INNER
-        + col_lane[None, :]
-    )
+    inner_linear = ((row_lane_inner[:, None] * (SIZE_OUTER // SIZE_LANE) + row_quad[:, None]) * SIZE_INNER +
+                    col_lane[None, :])
     half = inner_linear // SIZE_HALF
     inner = inner_linear - half * SIZE_HALF
-    return (
-        base
-        + outer.to(INDEX_TYPE)[:, None] * stride_outer
-        + inner_group.to(INDEX_TYPE)[None, :] * stride_inner
-        + half.to(INDEX_TYPE) * stride_half
-        + inner.to(INDEX_TYPE) * stride_lane
-    )
+    return (base + outer.to(INDEX_TYPE)[:, None] * stride_outer + inner_group.to(INDEX_TYPE)[None, :] * stride_inner +
+            half.to(INDEX_TYPE) * stride_half + inner.to(INDEX_TYPE) * stride_lane)


### PR DESCRIPTION
Add support for nvfp4 output with swizzled scales and tune fp4 opt flags, mostly increasing block sizes and adjusting stage counts.

For nvfp4 x nvfp4 -> nvfp4 mm1, I was able to easily hit >= 5 pflops. For mm2, this PR will give 4.5 pflops but you can autotune up to 4.8. However the winning config is not straightforward to encode into opt_flags.

I also added a small optimization to skip masking N when we know it's even multiple of BLOCK_N, as this saves instruction pressure in the epilogue.