### PR TITLE
[CD][Release Only] Increase timeout for Release wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
 
   Build-Wheels:
-    timeout-minutes: 120
+    timeout-minutes: 240
     runs-on: ${{ matrix.config.runs_on }}
 
     strategy:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
 
   Build-Wheels:
-    timeout-minutes: 240
+    timeout-minutes: 180
     runs-on: ${{ matrix.config.runs_on }}
 
     strategy:


### PR DESCRIPTION
Increase build timeout for aarch64 builds.
Main builds where already increased to 180 min:
https://github.com/triton-lang/triton/blob/main/.github/workflows/wheels.yml#L15