### PR TITLE
[AMD] Add LLVM flag passthrough for AMDGPU codegen

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -529,10 +529,11 @@ class amd_knobs(base_knobs):
 
     scalarize_packed_fops: env_bool = env_bool("AMDGCN_SCALARIZE_PACKED_FOPS")
 
-    # Comma-separated LLVM flags passed to the AMDGPU codegen backend.
-    # Supports key=value pairs for non-boolean options.
-    # Example: TRITON_AMD_LLVM_FLAGS="amdgpu-loop-carried-load-percent=0,amdgpu-coexec-window-singular-flavor=1"
-    llvm_flags: env_opt_str = env_opt_str("TRITON_AMD_LLVM_FLAGS")
+    # Comma-separated LLVM cl::opt options for the AMDGPU codegen backend.
+    # Experimental: intended for development and debugging; may change or be
+    # removed without notice.
+    # Example: AMDGCN_LLVM_OPTIONS="amdgpu-early-inline-all,enable-misched=0"
+    llvm_options: env_opt_str = env_opt_str("AMDGCN_LLVM_OPTIONS")
 
     # Path to dump MIR files for debugging/analysis
     dump_mir: env_opt_str = env_opt_str("TRITON_DUMP_MIR")

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -529,6 +529,11 @@ class amd_knobs(base_knobs):
 
     scalarize_packed_fops: env_bool = env_bool("AMDGCN_SCALARIZE_PACKED_FOPS")
 
+    # Comma-separated LLVM flags passed to the AMDGPU codegen backend.
+    # Supports key=value pairs for non-boolean options.
+    # Example: TRITON_AMD_LLVM_FLAGS="amdgpu-loop-carried-load-percent=0,amdgpu-coexec-window-singular-flavor=1"
+    llvm_flags: env_opt_str = env_opt_str("TRITON_AMD_LLVM_FLAGS")
+
     # Path to dump MIR files for debugging/analysis
     dump_mir: env_opt_str = env_opt_str("TRITON_DUMP_MIR")
     # Path to externally-provided MIR files to use instead of generated ones

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -89,9 +89,11 @@ class HIPOptions:
     # schedule_hint="attention,memory-bound-attention"
     schedule_hint: str = 'none'
 
-    # Extra LLVM cl::opt flags for the AMDGPU codegen backend (e.g. "flag=value").
-    # Set per-kernel via llvm_flags=(...) or globally via TRITON_AMD_LLVM_FLAGS.
-    llvm_flags: tuple = ()
+    # Extra LLVM cl::opt options for the AMDGPU codegen backend (e.g. "option=value").
+    # Experimental: intended for development and debugging; may change or be
+    # removed without notice.
+    # Set per-kernel via llvm_amdgpu_options=(...) or globally via AMDGCN_LLVM_OPTIONS.
+    llvm_amdgpu_options: tuple = ()
 
     def __post_init__(self):
         gfx_major = int(self.arch[3:-2])  # Drop "gfx" prefix and minor/patch number
@@ -106,9 +108,10 @@ class HIPOptions:
             )
             object.__setattr__(self, 'kpack', 1)
 
-        env_llvm_flags = knobs.amd.llvm_flags
-        if env_llvm_flags:
-            object.__setattr__(self, 'llvm_flags', tuple(env_llvm_flags.split(",")) + self.llvm_flags)
+        env_llvm_options = knobs.amd.llvm_options
+        if env_llvm_options:
+            object.__setattr__(self, 'llvm_amdgpu_options',
+                               tuple(env_llvm_options.split(",")) + self.llvm_amdgpu_options)
 
         default_libdir = Path(__file__).parent / 'lib'
         extern_libs = {} if self.extern_libs is None else dict(self.extern_libs)
@@ -525,7 +528,7 @@ class HIPBackend(BaseBackend):
         metadata["name"] = names[0]
         # llvm -> hsaco
         flags = []
-        modified = amd.set_llvm_flags(list(options.llvm_flags)) if options.llvm_flags else []
+        modified = amd.set_llvm_options(list(options.llvm_amdgpu_options)) if options.llvm_amdgpu_options else []
         features = '-real-true16' if 'gfx11' in options.arch else ''
         ir_hash = hashlib.sha256(src.encode("utf-8")).hexdigest()
         dump_file_id = names[0] + '_' + ir_hash
@@ -542,8 +545,8 @@ class HIPBackend(BaseBackend):
         else:
             amdgcn = llvm.translate_to_asm(src, amd.TARGET_TRIPLE, options.arch, features, flags,
                                            options.enable_fp_fusion, False)
-        if modified:  # Reset flags to defaults so they don't leak into other kernels.
-            amd.restore_llvm_flags(modified)
+        if modified:  # Reset options to defaults so they don't leak into other kernels.
+            amd.restore_llvm_options(modified)
         if knobs.amd.dump_amdgcn:
             print("// -----// AMDGCN Dump //----- //")
             print(amdgcn)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -528,7 +528,8 @@ class HIPBackend(BaseBackend):
         metadata["name"] = names[0]
         # llvm -> hsaco
         flags = []
-        modified = amd.set_llvm_options(list(options.llvm_amdgpu_options)) if options.llvm_amdgpu_options else []
+        if options.llvm_amdgpu_options:
+            amd.set_llvm_options(list(options.llvm_amdgpu_options))
         features = '-real-true16' if 'gfx11' in options.arch else ''
         ir_hash = hashlib.sha256(src.encode("utf-8")).hexdigest()
         dump_file_id = names[0] + '_' + ir_hash
@@ -545,8 +546,6 @@ class HIPBackend(BaseBackend):
         else:
             amdgcn = llvm.translate_to_asm(src, amd.TARGET_TRIPLE, options.arch, features, flags,
                                            options.enable_fp_fusion, False)
-        if modified:  # Reset options to defaults so they don't leak into other kernels.
-            amd.restore_llvm_options(modified)
         if knobs.amd.dump_amdgcn:
             print("// -----// AMDGCN Dump //----- //")
             print(amdgcn)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -89,11 +89,6 @@ class HIPOptions:
     # schedule_hint="attention,memory-bound-attention"
     schedule_hint: str = 'none'
 
-    # Extra LLVM cl::opt options for the AMDGPU codegen backend (e.g. "option=value").
-    # For experimental usage and may change/removed without guarantees.
-    # Set per-kernel via llvm_amdgpu_options=(...) or globally via AMDGCN_LLVM_OPTIONS.
-    llvm_amdgpu_options: tuple = ()
-
     def __post_init__(self):
         gfx_major = int(self.arch[3:-2])  # Drop "gfx" prefix and minor/patch number
         warp_size = 32 if gfx_major >= 10 else 64
@@ -106,11 +101,6 @@ class HIPOptions:
                 f"kpack is deprecated starting from gfx950 and will be removed in later releases. So for now kpack = {self.kpack} will be overwritten to 1 to make transitioning easier."
             )
             object.__setattr__(self, 'kpack', 1)
-
-        env_llvm_options = knobs.amd.llvm_options
-        if env_llvm_options:
-            object.__setattr__(self, 'llvm_amdgpu_options',
-                               tuple(env_llvm_options.split(",")) + self.llvm_amdgpu_options)
 
         default_libdir = Path(__file__).parent / 'lib'
         extern_libs = {} if self.extern_libs is None else dict(self.extern_libs)
@@ -527,8 +517,8 @@ class HIPBackend(BaseBackend):
         metadata["name"] = names[0]
         # llvm -> hsaco
         flags = []
-        if options.llvm_amdgpu_options:
-            amd.set_llvm_options(list(options.llvm_amdgpu_options))
+        if knobs.amd.llvm_options:
+            amd.set_llvm_options(knobs.amd.llvm_options.split(","))
         features = '-real-true16' if 'gfx11' in options.arch else ''
         ir_hash = hashlib.sha256(src.encode("utf-8")).hexdigest()
         dump_file_id = names[0] + '_' + ir_hash

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -89,6 +89,10 @@ class HIPOptions:
     # schedule_hint="attention,memory-bound-attention"
     schedule_hint: str = 'none'
 
+    # Extra LLVM cl::opt flags for the AMDGPU codegen backend (e.g. "flag=value").
+    # Set per-kernel via llvm_flags=(...) or globally via TRITON_AMD_LLVM_FLAGS.
+    llvm_flags: tuple = ()
+
     def __post_init__(self):
         gfx_major = int(self.arch[3:-2])  # Drop "gfx" prefix and minor/patch number
         warp_size = 32 if gfx_major >= 10 else 64
@@ -101,6 +105,10 @@ class HIPOptions:
                 f"kpack is deprecated starting from gfx950 and will be removed in later releases. So for now kpack = {self.kpack} will be overwritten to 1 to make transitioning easier."
             )
             object.__setattr__(self, 'kpack', 1)
+
+        env_llvm_flags = knobs.amd.llvm_flags
+        if env_llvm_flags:
+            object.__setattr__(self, 'llvm_flags', tuple(env_llvm_flags.split(",")) + self.llvm_flags)
 
         default_libdir = Path(__file__).parent / 'lib'
         extern_libs = {} if self.extern_libs is None else dict(self.extern_libs)
@@ -517,6 +525,7 @@ class HIPBackend(BaseBackend):
         metadata["name"] = names[0]
         # llvm -> hsaco
         flags = []
+        modified = amd.set_llvm_flags(list(options.llvm_flags)) if options.llvm_flags else []
         features = '-real-true16' if 'gfx11' in options.arch else ''
         ir_hash = hashlib.sha256(src.encode("utf-8")).hexdigest()
         dump_file_id = names[0] + '_' + ir_hash
@@ -533,6 +542,8 @@ class HIPBackend(BaseBackend):
         else:
             amdgcn = llvm.translate_to_asm(src, amd.TARGET_TRIPLE, options.arch, features, flags,
                                            options.enable_fp_fusion, False)
+        if modified:  # Reset flags to defaults so they don't leak into other kernels.
+            amd.restore_llvm_flags(modified)
         if knobs.amd.dump_amdgcn:
             print("// -----// AMDGCN Dump //----- //")
             print(amdgcn)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -90,8 +90,7 @@ class HIPOptions:
     schedule_hint: str = 'none'
 
     # Extra LLVM cl::opt options for the AMDGPU codegen backend (e.g. "option=value").
-    # Experimental: intended for development and debugging; may change or be
-    # removed without notice.
+    # For experimental usage and may change/removed without guarantees.
     # Set per-kernel via llvm_amdgpu_options=(...) or globally via AMDGCN_LLVM_OPTIONS.
     llvm_amdgpu_options: tuple = ()
 

--- a/third_party/amd/python/test/test_llvm_flags.py
+++ b/third_party/amd/python/test/test_llvm_flags.py
@@ -31,28 +31,18 @@ def test_multiple_options():
     amd.set_llvm_options(["amdgpu-early-inline-all", "inline-threshold=500"])
 
 
-# -- Integration test: compile attn_fwd.ttir with llvm_amdgpu_options (GPU needed) --
+# -- Integration test: compile with AMDGCN_LLVM_OPTIONS env var (GPU needed) --
 
 
 @pytest.mark.skipif(current_target.backend != "hip", reason="requires HIP backend")
-def test_compile_accepts_llvm_amdgpu_options():
-    """Compilation with llvm_amdgpu_options succeeds and produces valid assembly."""
-    kernel = triton.compile(
-        TTIR_PATH,
-        target=current_target,
-        options={"llvm_amdgpu_options": ("enable-misched=0", )},
-    )
-    assert "attn_fwd" in kernel.asm["amdgcn"]
+def test_llvm_amdgpu_options_change_codegen(monkeypatch):
+    """Setting AMDGCN_LLVM_OPTIONS env var produces different assembly."""
+    monkeypatch.setattr(triton.knobs.compilation, "always_compile", True)
 
-
-@pytest.mark.skipif(current_target.backend != "hip", reason="requires HIP backend")
-def test_llvm_amdgpu_options_change_codegen():
-    """llvm_amdgpu_options produce different assembly than the default."""
     baseline = triton.compile(TTIR_PATH, target=current_target)
-    with_options = triton.compile(
-        TTIR_PATH,
-        target=current_target,
-        options={"llvm_amdgpu_options": ("enable-misched=0", )},
-    )
+
+    monkeypatch.setenv("AMDGCN_LLVM_OPTIONS", "enable-misched=0")
+
+    with_options = triton.compile(TTIR_PATH, target=current_target)
     assert baseline.asm["amdgcn"] != with_options.asm["amdgcn"], \
-        "expected llvm_amdgpu_options to change generated assembly"
+        "expected AMDGCN_LLVM_OPTIONS to change generated assembly"

--- a/third_party/amd/python/test/test_llvm_flags.py
+++ b/third_party/amd/python/test/test_llvm_flags.py
@@ -10,61 +10,61 @@ TTIR_PATH = str(Path(__file__).parent / "attn_fwd.ttir")
 # -- Unit tests for the C++ bindings (no GPU needed) --
 
 
-def test_set_and_restore_bool_flag():
-    """set_llvm_flags handles bare boolean flags and restore resets them."""
-    modified = amd.set_llvm_flags(["amdgpu-early-inline-all"])
+def test_set_and_restore_bool_option():
+    """set_llvm_options handles bare boolean flags and restore resets them."""
+    modified = amd.set_llvm_options(["amdgpu-early-inline-all"])
     assert modified == ["amdgpu-early-inline-all"]
-    amd.restore_llvm_flags(modified)
+    amd.restore_llvm_options(modified)
 
 
-def test_set_and_restore_value_flag():
-    """set_llvm_flags handles key=value flags and restore resets them."""
-    modified = amd.set_llvm_flags(["inline-threshold=500"])
+def test_set_and_restore_value_option():
+    """set_llvm_options handles key=value options and restore resets them."""
+    modified = amd.set_llvm_options(["inline-threshold=500"])
     assert modified == ["inline-threshold"]
-    amd.restore_llvm_flags(modified)
+    amd.restore_llvm_options(modified)
 
 
-def test_unknown_flag_skipped():
-    """Unknown flags are skipped and not included in the modified list."""
-    modified = amd.set_llvm_flags(["this-flag-does-not-exist=42"])
-    assert modified == []
+def test_unknown_option_raises():
+    """Unknown options raise std::invalid_argument."""
+    with pytest.raises(ValueError):
+        amd.set_llvm_options(["this-flag-does-not-exist=42"])
 
 
-def test_multiple_flags():
-    """Multiple flags can be set and restored in one call."""
+def test_multiple_options():
+    """Multiple options can be set and restored in one call."""
     flags = ["amdgpu-early-inline-all", "inline-threshold=500"]
-    modified = amd.set_llvm_flags(flags)
+    modified = amd.set_llvm_options(flags)
     assert len(modified) == 2
-    amd.restore_llvm_flags(modified)
+    amd.restore_llvm_options(modified)
 
 
 def test_restore_empty_list():
     """Restoring an empty list is a no-op."""
-    amd.restore_llvm_flags([])
+    amd.restore_llvm_options([])
 
 
-# -- Integration test: compile attn_fwd.ttir with llvm_flags (GPU needed) --
+# -- Integration test: compile attn_fwd.ttir with llvm_amdgpu_options (GPU needed) --
 
 
 @pytest.mark.skipif(current_target.backend != "hip", reason="requires HIP backend")
-def test_compile_accepts_llvm_flags():
-    """Compilation with llvm_flags succeeds and produces valid assembly."""
+def test_compile_accepts_llvm_amdgpu_options():
+    """Compilation with llvm_amdgpu_options succeeds and produces valid assembly."""
     kernel = triton.compile(
         TTIR_PATH,
         target=current_target,
-        options={"llvm_flags": ("enable-misched=0", )},
+        options={"llvm_amdgpu_options": ("enable-misched=0", )},
     )
     assert "attn_fwd" in kernel.asm["amdgcn"]
 
 
 @pytest.mark.skipif(current_target.backend != "hip", reason="requires HIP backend")
-def test_llvm_flags_change_codegen():
-    """llvm_flags produce different assembly than the default."""
+def test_llvm_amdgpu_options_change_codegen():
+    """llvm_amdgpu_options produce different assembly than the default."""
     baseline = triton.compile(TTIR_PATH, target=current_target)
-    with_flags = triton.compile(
+    with_options = triton.compile(
         TTIR_PATH,
         target=current_target,
-        options={"llvm_flags": ("enable-misched=0", )},
+        options={"llvm_amdgpu_options": ("enable-misched=0", )},
     )
-    assert baseline.asm["amdgcn"] != with_flags.asm["amdgcn"], \
-        "expected llvm_flags to change generated assembly"
+    assert baseline.asm["amdgcn"] != with_options.asm["amdgcn"], \
+        "expected llvm_amdgpu_options to change generated assembly"

--- a/third_party/amd/python/test/test_llvm_flags.py
+++ b/third_party/amd/python/test/test_llvm_flags.py
@@ -7,7 +7,6 @@ import triton
 current_target = triton.runtime.driver.active.get_current_target()
 TTIR_PATH = str(Path(__file__).parent / "attn_fwd.ttir")
 
-
 # -- Unit tests for the C++ bindings (no GPU needed) --
 
 
@@ -53,7 +52,7 @@ def test_compile_accepts_llvm_flags():
     kernel = triton.compile(
         TTIR_PATH,
         target=current_target,
-        options={"llvm_flags": ("enable-misched=0",)},
+        options={"llvm_flags": ("enable-misched=0", )},
     )
     assert "attn_fwd" in kernel.asm["amdgcn"]
 
@@ -65,7 +64,7 @@ def test_llvm_flags_change_codegen():
     with_flags = triton.compile(
         TTIR_PATH,
         target=current_target,
-        options={"llvm_flags": ("enable-misched=0",)},
+        options={"llvm_flags": ("enable-misched=0", )},
     )
     assert baseline.asm["amdgcn"] != with_flags.asm["amdgcn"], \
         "expected llvm_flags to change generated assembly"

--- a/third_party/amd/python/test/test_llvm_flags.py
+++ b/third_party/amd/python/test/test_llvm_flags.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+from triton._C.libtriton import amd
+import triton
+
+current_target = triton.runtime.driver.active.get_current_target()
+TTIR_PATH = str(Path(__file__).parent / "attn_fwd.ttir")
+
+
+# -- Unit tests for the C++ bindings (no GPU needed) --
+
+
+def test_set_and_restore_bool_flag():
+    """set_llvm_flags handles bare boolean flags and restore resets them."""
+    modified = amd.set_llvm_flags(["amdgpu-early-inline-all"])
+    assert modified == ["amdgpu-early-inline-all"]
+    amd.restore_llvm_flags(modified)
+
+
+def test_set_and_restore_value_flag():
+    """set_llvm_flags handles key=value flags and restore resets them."""
+    modified = amd.set_llvm_flags(["inline-threshold=500"])
+    assert modified == ["inline-threshold"]
+    amd.restore_llvm_flags(modified)
+
+
+def test_unknown_flag_skipped():
+    """Unknown flags are skipped and not included in the modified list."""
+    modified = amd.set_llvm_flags(["this-flag-does-not-exist=42"])
+    assert modified == []
+
+
+def test_multiple_flags():
+    """Multiple flags can be set and restored in one call."""
+    flags = ["amdgpu-early-inline-all", "inline-threshold=500"]
+    modified = amd.set_llvm_flags(flags)
+    assert len(modified) == 2
+    amd.restore_llvm_flags(modified)
+
+
+def test_restore_empty_list():
+    """Restoring an empty list is a no-op."""
+    amd.restore_llvm_flags([])
+
+
+# -- Integration test: compile attn_fwd.ttir with llvm_flags (GPU needed) --
+
+
+@pytest.mark.skipif(current_target.backend != "hip", reason="requires HIP backend")
+def test_compile_accepts_llvm_flags():
+    """Compilation with llvm_flags succeeds and produces valid assembly."""
+    kernel = triton.compile(
+        TTIR_PATH,
+        target=current_target,
+        options={"llvm_flags": ("enable-misched=0",)},
+    )
+    assert "attn_fwd" in kernel.asm["amdgcn"]
+
+
+@pytest.mark.skipif(current_target.backend != "hip", reason="requires HIP backend")
+def test_llvm_flags_change_codegen():
+    """llvm_flags produce different assembly than the default."""
+    baseline = triton.compile(TTIR_PATH, target=current_target)
+    with_flags = triton.compile(
+        TTIR_PATH,
+        target=current_target,
+        options={"llvm_flags": ("enable-misched=0",)},
+    )
+    assert baseline.asm["amdgcn"] != with_flags.asm["amdgcn"], \
+        "expected llvm_flags to change generated assembly"

--- a/third_party/amd/python/test/test_llvm_flags.py
+++ b/third_party/amd/python/test/test_llvm_flags.py
@@ -10,18 +10,14 @@ TTIR_PATH = str(Path(__file__).parent / "attn_fwd.ttir")
 # -- Unit tests for the C++ bindings (no GPU needed) --
 
 
-def test_set_and_restore_bool_option():
-    """set_llvm_options handles bare boolean flags and restore resets them."""
-    modified = amd.set_llvm_options(["amdgpu-early-inline-all"])
-    assert modified == ["amdgpu-early-inline-all"]
-    amd.restore_llvm_options(modified)
+def test_set_bool_option():
+    """set_llvm_options handles bare boolean flags."""
+    amd.set_llvm_options(["amdgpu-early-inline-all"])
 
 
-def test_set_and_restore_value_option():
-    """set_llvm_options handles key=value options and restore resets them."""
-    modified = amd.set_llvm_options(["inline-threshold=500"])
-    assert modified == ["inline-threshold"]
-    amd.restore_llvm_options(modified)
+def test_set_value_option():
+    """set_llvm_options handles key=value options."""
+    amd.set_llvm_options(["inline-threshold=500"])
 
 
 def test_unknown_option_raises():
@@ -31,16 +27,8 @@ def test_unknown_option_raises():
 
 
 def test_multiple_options():
-    """Multiple options can be set and restored in one call."""
-    flags = ["amdgpu-early-inline-all", "inline-threshold=500"]
-    modified = amd.set_llvm_options(flags)
-    assert len(modified) == 2
-    amd.restore_llvm_options(modified)
-
-
-def test_restore_empty_list():
-    """Restoring an empty list is a no-op."""
-    amd.restore_llvm_options([])
+    """Multiple options can be set in one call."""
+    amd.set_llvm_options(["amdgpu-early-inline-all", "inline-threshold=500"])
 
 
 # -- Integration test: compile attn_fwd.ttir with llvm_amdgpu_options (GPU needed) --

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -551,11 +551,11 @@ void init_triton_amd(py::module &&m) {
     }
   });
 
-  // Set LLVM cl::opt flags for the duration of a codegen call.
+  // Set LLVM cl::opt options for the AMDGPU codegen backend.
   // Handles both bare boolean flags ("flag-name") and key=value pairs
   // ("flag-name=value"). Returns the list of option names that were modified
-  // so they can be restored via restore_llvm_flags.
-  m.def("set_llvm_flags",
+  // so they can be restored via restore_llvm_options.
+  m.def("set_llvm_options",
         [](const std::vector<std::string> &flags) -> std::vector<std::string> {
           auto options = llvm::cl::getRegisteredOptions();
           std::vector<std::string> modified;
@@ -571,8 +571,7 @@ void init_triton_amd(py::module &&m) {
             }
             auto it = options.find(key);
             if (it == options.end()) {
-              llvm::errs() << "Warning: unknown LLVM option '" << key << "'\n";
-              continue;
+              throw std::invalid_argument("Unknown LLVM option '" + key + "'");
             }
             it->second->addOccurrence(1, key, val);
             modified.push_back(key);
@@ -580,8 +579,8 @@ void init_triton_amd(py::module &&m) {
           return modified;
         });
 
-  // Restore LLVM cl::opt flags to their compile-time defaults.
-  m.def("restore_llvm_flags", [](const std::vector<std::string> &modified) {
+  // Restore LLVM cl::opt options to their compile-time defaults.
+  m.def("restore_llvm_options", [](const std::vector<std::string> &modified) {
     auto options = llvm::cl::getRegisteredOptions();
     for (const auto &key : modified) {
       auto it = options.find(key);

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -554,8 +554,6 @@ void init_triton_amd(py::module &&m) {
   // Set LLVM cl::opt options for the AMDGPU codegen backend.
   // Handles both bare boolean flags ("flag-name") and key=value pairs
   // ("flag-name=value").
-  // Options are set once and persist for the process lifetime; they are
-  // never restored, so that concurrent compilations see a consistent view.
   m.def("set_llvm_options", [](const std::vector<std::string> &flags) {
     auto options = llvm::cl::getRegisteredOptions();
     for (const auto &flag : flags) {

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -28,6 +28,7 @@
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCTargetOptions.h"
 #include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/TargetParser/TargetParser.h"
@@ -547,6 +548,45 @@ void init_triton_amd(py::module &&m) {
       if (arg.hasByRefAttr() || arg.hasNestAttr())
         continue;
       arg.addAttr(llvm::Attribute::InReg);
+    }
+  });
+
+  // Set LLVM cl::opt flags for the duration of a codegen call.
+  // Handles both bare boolean flags ("flag-name") and key=value pairs
+  // ("flag-name=value"). Returns the list of option names that were modified
+  // so they can be restored via restore_llvm_flags.
+  m.def("set_llvm_flags",
+        [](const std::vector<std::string> &flags) -> std::vector<std::string> {
+          auto options = llvm::cl::getRegisteredOptions();
+          std::vector<std::string> modified;
+          for (const auto &flag : flags) {
+            std::string key, val;
+            auto eq = flag.find('=');
+            if (eq != std::string::npos) {
+              key = flag.substr(0, eq);
+              val = flag.substr(eq + 1);
+            } else {
+              key = flag;
+              val = "true";
+            }
+            auto it = options.find(key);
+            if (it == options.end()) {
+              llvm::errs() << "Warning: unknown LLVM option '" << key << "'\n";
+              continue;
+            }
+            it->second->addOccurrence(1, key, val);
+            modified.push_back(key);
+          }
+          return modified;
+        });
+
+  // Restore LLVM cl::opt flags to their compile-time defaults.
+  m.def("restore_llvm_flags", [](const std::vector<std::string> &modified) {
+    auto options = llvm::cl::getRegisteredOptions();
+    for (const auto &key : modified) {
+      auto it = options.find(key);
+      if (it != options.end())
+        it->second->setDefault();
     }
   });
 

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -553,39 +553,26 @@ void init_triton_amd(py::module &&m) {
 
   // Set LLVM cl::opt options for the AMDGPU codegen backend.
   // Handles both bare boolean flags ("flag-name") and key=value pairs
-  // ("flag-name=value"). Returns the list of option names that were modified
-  // so they can be restored via restore_llvm_options.
-  m.def("set_llvm_options",
-        [](const std::vector<std::string> &flags) -> std::vector<std::string> {
-          auto options = llvm::cl::getRegisteredOptions();
-          std::vector<std::string> modified;
-          for (const auto &flag : flags) {
-            std::string key, val;
-            auto eq = flag.find('=');
-            if (eq != std::string::npos) {
-              key = flag.substr(0, eq);
-              val = flag.substr(eq + 1);
-            } else {
-              key = flag;
-              val = "true";
-            }
-            auto it = options.find(key);
-            if (it == options.end()) {
-              throw std::invalid_argument("Unknown LLVM option '" + key + "'");
-            }
-            it->second->addOccurrence(1, key, val);
-            modified.push_back(key);
-          }
-          return modified;
-        });
-
-  // Restore LLVM cl::opt options to their compile-time defaults.
-  m.def("restore_llvm_options", [](const std::vector<std::string> &modified) {
+  // ("flag-name=value").
+  // Options are set once and persist for the process lifetime; they are
+  // never restored, so that concurrent compilations see a consistent view.
+  m.def("set_llvm_options", [](const std::vector<std::string> &flags) {
     auto options = llvm::cl::getRegisteredOptions();
-    for (const auto &key : modified) {
+    for (const auto &flag : flags) {
+      std::string key, val;
+      auto eq = flag.find('=');
+      if (eq != std::string::npos) {
+        key = flag.substr(0, eq);
+        val = flag.substr(eq + 1);
+      } else {
+        key = flag;
+        val = "true";
+      }
       auto it = options.find(key);
-      if (it != options.end())
-        it->second->setDefault();
+      if (it == options.end()) {
+        throw std::invalid_argument("Unknown LLVM option '" + key + "'");
+      }
+      it->second->addOccurrence(1, key, val);
     }
   });
 


### PR DESCRIPTION
[AMD] Add LLVM flag passthrough for AMDGPU codegen
Some AMDGPU backend behaviors can be modified by LLVM cl::opt flags.
This adds a lightweight mechanism to pass arbitrary LLVM flags
per-kernel or globally so users can tune codegen without patching
the compiler.

- Add `llvm_flags` field to HIPOptions (participates in cache key).
- Add `TRITON_AMD_LLVM_FLAGS` env var for global flag control via knobs.
- Add `set_llvm_flags`/`restore_llvm_flags` C++ bindings in triton_amd.cc.

Signed-off-by: Stanley Winata <stanley.winata@amd.com>
