### PR TITLE
[NFC] Delete dead variables and functions

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonOpInterfaces.td
@@ -69,7 +69,6 @@ def DotOpInterface : OpInterface<"DotOpInterface"> {
         auto aTy = cast<ShapedType>($_op.getA().getType());
         auto bTy = cast<ShapedType>($_op.getB().getType());
         auto cTy = cast<ShapedType>($_op->getOperand(2).getType());
-        auto dTy = cast<ShapedType>($_op.getD().getType());
         auto aShape = aTy.getShape();
         auto bShape = bTy.getShape();
         auto cShape = cTy.getShape();

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -599,7 +599,6 @@ struct MapElementwiseOpConversion
     }
 
     auto &scalarOp = op.getScalarOp();
-    Region &parent = *rewriter.getBlock()->getParent();
 
     auto nOutputs = op.getNumResults();
     SmallVector<Value> scalarOutputs(nOutputs * nElems);

--- a/lib/Dialect/Gluon/Transforms/ResolveAutoEncodings.cpp
+++ b/lib/Dialect/Gluon/Transforms/ResolveAutoEncodings.cpp
@@ -50,7 +50,6 @@ public:
   using BaseT::BaseT;
 
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
 
     // Do layout inference

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -702,7 +702,7 @@ static SmallVector<T> repeatInterleave(const SmallVectorImpl<T> &vs,
   SmallVector<T> result;
   result.reserve(vs.size() * nRepeat);
   for (auto v : vs)
-    for (auto _ : llvm::seq(nRepeat))
+    for (int i = 0; i < nRepeat; ++i)
       result.push_back(v);
   return result;
 }

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -4356,9 +4356,6 @@ bool triton::gpu::areLayoutsEquivalent(ArrayRef<int64_t> shape,
 }
 
 bool triton::gpu::isInnermostContiguous(MemDescType type, unsigned numElems) {
-  Attribute enc = type.getEncoding();
-  MLIRContext *ctx = enc.getContext();
-
   LinearLayout actual = toLinearLayout(type);
 
   // Flatten actual outs in reverse order to produce a row-major flattening

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1428,7 +1428,6 @@ LinearLayout chooseScaledWmmaScaleLayout(
     MLIRContext *ctx, int dotOperandIdx, ArrayRef<int64_t> dotOperandShape,
     unsigned wmmaMDim, unsigned wmmaNDim, bool isTransposed,
     unsigned scaleFactor, LinearLayout ctaLayout, CGAEncodingAttr cgaLayout) {
-  using basisT = std::vector<std::vector<int32_t>>;
   unsigned rank = dotOperandShape.size();
   bool hasBatchDim = rank == 3;
   auto outDimNames = standardOutDimNames(ctx, rank);
@@ -1568,7 +1567,6 @@ LinearLayout chooseScaledMfmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
                                          unsigned mfmaMDim,
                                          ArrayRef<unsigned> tilesPerWarp,
                                          ArrayRef<unsigned> warpsPerCTA) {
-  using basisT = std::vector<std::vector<int32_t>>;
   unsigned rank = dotOperandShape.size();
   auto order = mlir::triton::gpu::getMatrixOrder(rank, /*rowMajor=*/true);
   auto standardOutDims = standardOutDimNames(ctx, rank);

--- a/lib/Dialect/TritonGPU/Transforms/CombineTensorSelectAndIf.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CombineTensorSelectAndIf.cpp
@@ -81,7 +81,6 @@ class CombineTensorSelectAndIfPass
           CombineTensorSelectAndIfPass> {
 public:
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
     canonicalizeSelectUsersInSCFIf(m);
 

--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -709,9 +709,6 @@ static void fuseOneLevel(LoopNestNode *parent, mlir::DominanceInfo &domInfo) {
   Value curI = fused.getRegionIterArg(1);
   Value i;
 
-  auto lenInnersIt =
-      ValueRange(fused.getRegionIterArgs()).begin() + lenInnersStartIdx;
-
   ArrayRef<BlockArgument> ivars = fused.getRegionIterArgs().slice(ivarStartIdx);
   auto bodyOutsIt =
       ValueRange(fused.getRegionIterArgs()).begin() + innerOutsStartIdx;

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
@@ -21,7 +21,6 @@ public:
 
   LogicalResult matchAndRewrite(triton::nvidia_gpu::TMEMAllocOp op,
                                 PatternRewriter &rewriter) const override {
-    MLIRContext *ctx = op.getContext();
     if (op.getSrc() == nullptr)
       return failure();
     SmallVector<Operation *> users(op.getResult().getUsers().begin(),

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -308,8 +308,6 @@ class TritonGPUOptimizeThreadLocalityPass
       auto srcEncoding = srcType.getEncoding();
       assert(isa<triton::gpu::BlockedEncodingAttr>(srcEncoding) &&
              "Thread locality optimization only supports blocked encoding");
-      auto elemsPerThread =
-          triton::gpu::getElemsPerThread(srcType)[reduce.getAxis()];
       auto rank = srcShape.size();
       // create new layouts
       auto blocked3d = getThreadLocalityOptimizedEncoding(reduce);
@@ -354,8 +352,8 @@ class TritonGPUOptimizeThreadLocalityPass
       // create new accum update
       auto newUpdate = createUpdate(builder, newLoop, newReduce, oldUpdate);
       // create new yield
-      auto newYield = createYield(builder, newLoop, oldYield,
-                                  newUpdate->getResult(0), blockArgNum);
+      createYield(builder, newLoop, oldYield, newUpdate->getResult(0),
+                  blockArgNum);
       // create post loop reduction on the original reduce axis
       auto newReduce2 = createPostLoopReduce(builder, newLoop, reduce);
       // add convert_layout to get back to original layout, the result layout

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -209,8 +209,6 @@ void createTMAAsyncCopy(
 
   Operation *firstUse = getFirstUseOfPipelinedOp({loadOp}, forOp, schedule);
   assert(firstUse && "LoadOp has no users");
-  Attribute sharedMemorySpace =
-      ttg::SharedMemorySpaceAttr::get(forOp.getContext());
 
   builder.setInsertionPoint(loadOp);
   builder.setStageCluster(schedule[loadOp]);
@@ -957,9 +955,6 @@ void multibufferTensorMemory(scf::ForOp forOp, CoarseSchedule &schedule,
 
 scf::ForOp lowerMMA(ttng::MMAv5OpInterface mma, scf::ForOp forOp,
                     CoarseSchedule &schedule) {
-  auto isLoadToBePipelined = [&](Operation *op) {
-    return schedule[mma].first > schedule[op].first;
-  };
   Value alloc = mma.getAccumulator();
 
   int mmaSelfLatency = getSelfLatencyFromAttr(mma.getOperation());

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -106,12 +106,10 @@ std::unique_ptr<Graph> buildGraph(Operation *region) {
 
           // init iter args
           {
-            size_t idx = 0;
-            for (auto operand : forOp.getInitArgs()) {
+            for (size_t idx = 0; idx < forOp.getInitArgs().size(); ++idx) {
               auto iter_arg_node = node->getDefines()[idx + 1];
               operands[std::make_pair(op, idx + 3)] =
                   InputPort(iter_arg_node, 0);
-              idx++;
             }
           }
 

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -436,7 +436,7 @@ void FunctionBuilder::createSetWaitingCall(ImplicitLocOpBuilder &b, Value mbar,
   createCallToCachedFunction(
       b, "set_waiting", args,
       /*assertInfo=*/std::nullopt, {barriersType, waitingType},
-      [barriersType, waitingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      [waitingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value baseThread = entryBlock->getArgument(2);
@@ -537,7 +537,7 @@ void FunctionBuilder::createClearWaitingCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "clear_waiting", args,
       /*assertInfo=*/std::nullopt, {barriersType, waitingType},
-      [barriersType, waitingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      [waitingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value baseThread = entryBlock->getArgument(2);
@@ -785,8 +785,7 @@ void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "verify_barrier_can_init", args, assertInfo,
       {barriersType, barrierStatesType},
-      [barriersType, barrierStatesType](ImplicitLocOpBuilder &fb,
-                                        Block *entryBlock) {
+      [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -841,8 +840,7 @@ void FunctionBuilder::createVerifyBarrierInitializedCall(
   createCallToCachedFunction(
       b, "verify_barrier_initialized", args, assertInfo,
       {barriersType, barrierStatesType},
-      [barriersType, barrierStatesType](ImplicitLocOpBuilder &fb,
-                                        Block *entryBlock) {
+      [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -899,8 +897,7 @@ void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
   createCallToCachedFunction(
       b, "init_barrier_state", args,
       /*assertInfo=*/std::nullopt, {barriersType, barrierStatesType},
-      [barriersType, barrierStatesType](ImplicitLocOpBuilder &fb,
-                                        Block *entryBlock) {
+      [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value count = entryBlock->getArgument(2);
@@ -975,8 +972,8 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
       b, "invalidate_barrier_state", args,
       /*assertInfo=*/std::nullopt,
       {barriersType, barrierStatesType, waitingType},
-      [barriersType, barrierStatesType, waitingType](ImplicitLocOpBuilder &fb,
-                                                     Block *entryBlock) {
+      [barrierStatesType, waitingType](ImplicitLocOpBuilder &fb,
+                                       Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1058,8 +1055,7 @@ void FunctionBuilder::createVerifyBarrierArriveCall(
   createCallToCachedFunction(
       b, "verify_barrier_arrive", args, assertInfo,
       {barriersType, barrierStatesType},
-      [barriersType, barrierStatesType](ImplicitLocOpBuilder &fb,
-                                        Block *entryBlock) {
+      [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value count = entryBlock->getArgument(2);
@@ -1176,8 +1172,7 @@ void FunctionBuilder::createUpdateBarrierStateCall(
   createCallToCachedFunction(
       b, "update_barrier_state", args,
       /*assertInfo=*/std::nullopt, {barriersType, barrierStatesType},
-      [barriersType, barrierStatesType](ImplicitLocOpBuilder &fb,
-                                        Block *entryBlock) {
+      [barrierStatesType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value count = entryBlock->getArgument(2);
@@ -1307,8 +1302,7 @@ void FunctionBuilder::createSetWriteVisibilityCall(
       b, "set_write_visibility", args,
       /*assertInfo=*/std::nullopt,
       {buffersType, writeVisibilityType, (uint64_t)memType},
-      [buffersType, writeVisibilityType](ImplicitLocOpBuilder &fb,
-                                         Block *entryBlock) {
+      [writeVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value bufOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1368,8 +1362,7 @@ void FunctionBuilder::createSetReadVisibilityCall(
       b, "set_read_visibility", args,
       /*assertInfo=*/std::nullopt,
       {buffersType, readVisibilityType, (uint64_t)memType},
-      [buffersType, readVisibilityType](ImplicitLocOpBuilder &fb,
-                                        Block *entryBlock) {
+      [readVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value bufOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1434,8 +1427,7 @@ void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
       b, "clear_write_tracking", args,
       /*assertInfo=*/std::nullopt,
       {buffersType, writeTrackingType, (uint64_t)memType},
-      [buffersType, writeTrackingType](ImplicitLocOpBuilder &fb,
-                                       Block *entryBlock) {
+      [writeTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value bufOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1491,8 +1483,7 @@ void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
       b, "clear_read_visibility", args,
       /*assertInfo=*/std::nullopt,
       {buffersType, readVisibilityType, (uint64_t)memType},
-      [buffersType, readVisibilityType](ImplicitLocOpBuilder &fb,
-                                        Block *entryBlock) {
+      [readVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value bufOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1549,8 +1540,7 @@ void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
       b, "clear_read_tracking", args,
       /*assertInfo=*/std::nullopt,
       {buffersType, readTrackingType, (uint64_t)memType},
-      [buffersType, readTrackingType](ImplicitLocOpBuilder &fb,
-                                      Block *entryBlock) {
+      [readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value bufOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1614,8 +1604,8 @@ void FunctionBuilder::createTrackVisibleWritesCall(ImplicitLocOpBuilder &b,
       b, "track_visible_writes", args,
       /*assertInfo=*/std::nullopt,
       {barriersType, writeVisibilityType, writeTrackingType, (uint64_t)memType},
-      [barriersType, writeVisibilityType,
-       writeTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      [writeVisibilityType, writeTrackingType](ImplicitLocOpBuilder &fb,
+                                               Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1699,8 +1689,8 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
       b, "track_visible_reads", args,
       /*assertInfo=*/std::nullopt,
       {barriersType, readVisibilityType, readTrackingType, (uint64_t)memType},
-      [barriersType, readVisibilityType,
-       readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      [readVisibilityType, readTrackingType](ImplicitLocOpBuilder &fb,
+                                             Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1791,7 +1781,7 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
       /*assertInfo=*/std::nullopt,
       {barriersType, buffersType, writeTrackingType, barrierWriteRecipientsType,
        (uint64_t)memType, (uint64_t)diagonalEffectRecipientCTAs},
-      [barriersType, buffersType, writeTrackingType, barrierWriteRecipientsType,
+      [writeTrackingType, barrierWriteRecipientsType,
        diagonalEffectRecipientCTAs](ImplicitLocOpBuilder &fb,
                                     Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
@@ -1909,8 +1899,8 @@ void FunctionBuilder::createClearBarrierWriteTrackingCall(
       /*assertInfo=*/std::nullopt,
       {barriersType, writeTrackingType, barrierWriteRecipientsType,
        (uint64_t)memType},
-      [barriersType, writeTrackingType, barrierWriteRecipientsType](
-          ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      [writeTrackingType, barrierWriteRecipientsType](ImplicitLocOpBuilder &fb,
+                                                      Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1989,8 +1979,7 @@ void FunctionBuilder::createClearBarrierReadTrackingCall(
       b, "clear_barrier_read_tracking", args,
       /*assertInfo=*/std::nullopt,
       {barriersType, readTrackingType, (uint64_t)memType},
-      [barriersType, readTrackingType](ImplicitLocOpBuilder &fb,
-                                       Block *entryBlock) {
+      [readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -2063,9 +2052,8 @@ void FunctionBuilder::createTransferVisibleWritesCall(
       /*assertInfo=*/std::nullopt,
       {barriersType, writeVisibilityType, writeTrackingType,
        barrierWriteRecipientsType, (uint64_t)memType},
-      [barriersType, writeVisibilityType, writeTrackingType,
-       barrierWriteRecipientsType](ImplicitLocOpBuilder &fb,
-                                   Block *entryBlock) {
+      [writeVisibilityType, writeTrackingType, barrierWriteRecipientsType](
+          ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -2170,8 +2158,8 @@ void FunctionBuilder::createTransferVisibleReadsCall(
       b, "transfer_visible_reads", args,
       /*assertInfo=*/std::nullopt,
       {barriersType, readVisibilityType, readTrackingType, (uint64_t)memType},
-      [barriersType, readVisibilityType,
-       readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      [readVisibilityType, readTrackingType](ImplicitLocOpBuilder &fb,
+                                             Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -2627,7 +2615,7 @@ void FunctionBuilder::createStageAccessForCommitCall(
   createCallToCachedFunction(
       b, "stage_access_for_commit", args,
       /*assertInfo=*/std::nullopt, {buffersType, commitsType},
-      [buffersType, commitsType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      [commitsType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value bufOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -71,7 +71,7 @@ findBufferAccessMemdescSubview(Operation *subview) {
     src = indexOp.getSrc();
     shape = to_vector(indexOp.getType().getShape());
     offsets = {indexOp.getIndex()};
-    for (auto i : llvm::seq(std::max<int>(0, shape.size() - 1)))
+    for (int i = 0, e = std::max<int>(0, shape.size() - 1); i < e; ++i)
       offsets.push_back(arith::ConstantIntOp::create(builder, loc, 0, 32));
   } else {
     auto subsliceOp = cast<ttg::MemDescSubsliceOp>(subview);
@@ -261,7 +261,6 @@ struct TritonNvidiaGPUInterleaveTMemPass
       TritonNvidiaGPUInterleaveTMemPass>::TritonNvidiaGPUInterleaveTMemPassBase;
 
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
     SmallVector<std::pair<Operation *, Value>> opsToSink;
     m.walk([&](Operation *op) {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
@@ -82,7 +82,6 @@ struct TCGen5MMAScaleSharedToTmemConversion
 
   LogicalResult matchAndRewrite(TCGen5MMAScaledOp op,
                                 PatternRewriter &rewriter) const override {
-    MLIRContext *context = op->getContext();
     auto aScaleType = op.getAScale().getType();
     auto bScaleType = op.getBScale().getType();
     if (aScaleType.getShape() != aScaleType.getAllocShape() ||

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
@@ -102,7 +102,6 @@ public:
   using BaseT::BaseT;
 
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
     ModuleOp m = getOperation();
     NvidiaGPUAssignDescriptorMemoryLayouts assignMemoryLayouts;
     assignMemoryLayouts.assignMemoryLayouts(m);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -168,7 +168,6 @@ public:
 
   LogicalResult matchAndRewrite(MakeTensorDescOp op,
                                 PatternRewriter &rewriter) const override {
-    MLIRContext *ctx = op.getContext();
     auto loc = op.getLoc();
     auto alloc = triton::gpu::GlobalScratchAllocOp::create(
         rewriter, loc, getPointerType(rewriter.getI8Type()), TMA_SIZE_BYTES,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
@@ -138,7 +138,6 @@ FailureOr<int> getTMAElementType(Location loc, tt::TensorDescInterface ty) {
 LogicalResult createTMADesc(Value tmaPtr, MakeTensorDescOp op,
                             OpBuilder &builder) {
   using namespace mlir;
-  MLIRContext *ctx = op.getContext();
   auto loc = op.getLoc();
   auto mkI32Constant = [&](int32_t val) {
     return arith::ConstantOp::create(builder, loc, builder.getI32Type(),

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
@@ -398,7 +398,6 @@ public:
 
   void runOnOperation() override {
     ModuleOp mod = getOperation();
-    MLIRContext *ctx = &getContext();
 
     DenseMap<triton::nvidia_gpu::TMEMAllocOp, int> offsets;
     // TODO: handle cases with multiple function with TMEMAllocOp.

--- a/lib/Target/LLVMIR/LLVMDILocalVariable.cpp
+++ b/lib/Target/LLVMIR/LLVMDILocalVariable.cpp
@@ -90,8 +90,8 @@ struct LLVMDILocalVariablePass
       // a subclass of mlir::Value, which is the value defined by this operation
       OpResult opResult = op->getResult(0);
       // create and insert this call-dbg-value intrinsic after the op
-      Operation *dbgOp = LLVM::DbgValueOp::create(builder, childLoc, opResult,
-                                                  diLocalVarAttr, diExprAttr);
+      LLVM::DbgValueOp::create(builder, childLoc, opResult, diLocalVarAttr,
+                               diExprAttr);
     }
   }
 
@@ -117,7 +117,7 @@ struct LLVMDILocalVariablePass
 
     // Filename, line and colmun to associate to the function.
     LLVM::DIFileAttr fileAttr;
-    int64_t line = 1, col = 1;
+    int64_t line = 1;
     FileLineColLoc fileLoc = extractFileLoc(loc);
     if (!fileLoc && compileUnitAttr) {
       fileAttr = compileUnitAttr.getFile();
@@ -125,7 +125,6 @@ struct LLVMDILocalVariablePass
       fileAttr = LLVM::DIFileAttr::get(context, "<unknown>", "");
     } else {
       line = fileLoc.getLine();
-      col = fileLoc.getColumn();
       StringRef inputFilePath = fileLoc.getFilename().getValue();
       fileAttr = LLVM::DIFileAttr::get(
           context, llvm::sys::path::filename(inputFilePath),
@@ -367,8 +366,6 @@ struct LLVMDILocalVariablePass
   LLVM::DISubprogramAttr diSubprogramAttr = {};
 
   void runOnOperation() override {
-    Operation *op = getOperation();
-
     getOperation()->walk<WalkOrder::PreOrder>([&](Operation *op) -> void {
       if (isa<LLVM::LLVMFuncOp>(op)) {
         auto funcOp = cast<LLVM::LLVMFuncOp>(op);

--- a/lib/Target/LLVMIR/LLVMDIScope.cpp
+++ b/lib/Target/LLVMIR/LLVMDIScope.cpp
@@ -44,7 +44,7 @@ struct LLVMDIScopePass : public impl::LLVMDIScopeBase<LLVMDIScopePass> {
 
     // Filename, line and colmun to associate to the function.
     LLVM::DIFileAttr fileAttr;
-    int64_t line = 1, col = 1;
+    int64_t line = 1;
     FileLineColLoc fileLoc = extractFileLoc(loc);
     if (!fileLoc && compileUnitAttr) {
       fileAttr = compileUnitAttr.getFile();
@@ -52,7 +52,6 @@ struct LLVMDIScopePass : public impl::LLVMDIScopeBase<LLVMDIScopePass> {
       fileAttr = LLVM::DIFileAttr::get(context, "<unknown>", "");
     } else {
       line = fileLoc.getLine();
-      col = fileLoc.getColumn();
       StringRef inputFilePath = fileLoc.getFilename().getValue();
       fileAttr = LLVM::DIFileAttr::get(
           context, llvm::sys::path::filename(inputFilePath),

--- a/python/src/interpreter.cc
+++ b/python/src/interpreter.cc
@@ -610,8 +610,6 @@ makeAtomicRMWOp(pybind11::dtype dtype, const uint64_t *ptr, const void *val,
 } // namespace
 
 void init_triton_interpreter(py::module &&m) {
-  using ret = py::return_value_policy;
-
   py::enum_<MemSemantic>(m, "MEM_SEMANTIC", py::module_local())
       .value("ACQUIRE_RELEASE", MemSemantic::ACQUIRE_RELEASE)
       .value("ACQUIRE", MemSemantic::ACQUIRE)

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -468,8 +468,6 @@ LogicalResult ConcatOp::verify() {
     // 3.   find, which input tile holds the dst value
     auto multiDimOperandIdx = LLVM::AMD::multiDimElementwise<int32_t, int64_t>(
         elemCoordsArray, srcShape, std::divides<unsigned>());
-    auto linearOperandIdx =
-        mlir::LLVM::linearize(multiDimOperandIdx, srcToDstShape, defaultOrder);
 
     // 4.   subtract dst coordinates and start coordinates of the tile
 

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ConcatOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/ConcatOpToLLVM.cpp
@@ -29,7 +29,6 @@ struct ConcatOpConversion : public ConvertOpToLLVMPattern<amdgpu::ConcatOp> {
     RankedTensorType srcType = cast<RankedTensorType>(srcVal.getType());
     ArrayRef<int64_t> srcShape = srcType.getShape();
 
-    MLIRContext *context = resultType.getContext();
     auto linearLayoutSrc = triton::gpu::toLinearLayout(srcType);
     auto outDimNames = llvm::to_vector(linearLayoutSrc.getOutDimNames());
     // Call transposeOuts, to ensure that order of input and output tensor

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -130,7 +130,6 @@ BufferEmitter::emitLoadToLds(Type type, Value byteWidth, Value rsrcDesc,
   SmallVector<Value, 6> commonArgs;
   fillCommonArgs(type, rsrcDesc, offset, pred, cm, /*isBufferLoad=*/true,
                  commonArgs);
-  Type bufferType = getBufferOpType(type, false);
 
   // buffer_load_to_lds is only supported on gfx942/gfx950 which always use
   // asyncmark. Emit the async intrinsic so LLVM's SIInsertWaitcnts tracks

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -273,10 +273,8 @@ class ConvertLayoutOpInThreadSwap
 
 public:
   ConvertLayoutOpInThreadSwap(LLVMTypeConverter &typeConverter,
-                              const TargetInfoBase &targetInfo,
-                              PatternBenefit benefit)
-      : ConvertOpToLLVMPattern(typeConverter, benefit), targetInfo(targetInfo) {
-  }
+                              const TargetInfoBase &, PatternBenefit benefit)
+      : ConvertOpToLLVMPattern(typeConverter, benefit) {}
 
   struct ByteLocation {
     int regIdx;
@@ -720,9 +718,6 @@ public:
   LogicalResult
   matchAndRewrite(triton::gpu::ConvertLayoutOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto &amdTargInfo =
-        static_cast<const mlir::triton::AMD::TargetInfo &>(targetInfo);
-
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getType();
 
@@ -768,9 +763,6 @@ public:
     transferWithVPerm(op, conversion, adaptor, rewriter);
     return success();
   }
-
-private:
-  const TargetInfoBase &targetInfo;
 };
 
 } // namespace

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -139,8 +139,7 @@ private:
     // Set barrier before starting the loop. This resolves any outstanding
     // synchronization before beginning the specialized asymmetric
     // synchronization.
-    auto preBarrier = mlir::triton::gpu::BarrierOp::create(
-        b, loc, triton::gpu::AddrSpace::Local);
+    mlir::triton::gpu::BarrierOp::create(b, loc, triton::gpu::AddrSpace::Local);
 
     // Insert condbarrier::second_half before starting the loop
     // FIXME : correctly calculate numbers per the arch

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1820,7 +1820,6 @@ struct BufferAtomicCASOpConversion
     }
 
     mlir::Operation *lastCASOp;
-    MLIRContext *ctx = rewriter.getContext();
     GCNBuilder waitcntBuilder;
 
     // Check if the op has users, if it does we set GLC=1, otherwise GLC=0
@@ -2528,8 +2527,6 @@ struct TDMPrefetchConversion
 
     // Return offsets
     Type llvmResultStructTy = getTypeConverter()->convertType(op.getType(0));
-    auto structType = dyn_cast<LLVM::LLVMStructType>(
-        getTypeConverter()->convertType(op.getType(0)));
     Value resultStruct = packLLElements(loc, getTypeConverter(), offsets,
                                         rewriter, llvmResultStructTy);
     rewriter.replaceOp(op, {resultStruct});

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
@@ -48,9 +48,7 @@ Operation *createIglpOpt(PatternRewriter &rewriter, Location loc, int value) {
 struct InstructionSchedHintsRewriter
     : public OpRewritePattern<triton::amdgpu::InstructionSchedHint> {
 
-  InstructionSchedHintsRewriter(MLIRContext *ctx, StringRef arch,
-                                int32_t numStages)
-      : OpRewritePattern(ctx), numStages(numStages) {}
+  InstructionSchedHintsRewriter(MLIRContext *ctx) : OpRewritePattern(ctx) {}
 
   LogicalResult
   matchAndRewrite(triton::amdgpu::InstructionSchedHint instructionSchedHint,
@@ -94,9 +92,6 @@ struct InstructionSchedHintsRewriter
     rewriter.eraseOp(instructionSchedHint);
     return success();
   }
-
-private:
-  int32_t numStages;
 };
 
 struct TritonAMDGPULowerInstructionSchedHints
@@ -121,8 +116,7 @@ struct TritonAMDGPULowerInstructionSchedHints
 
     RewritePatternSet patterns(ctx);
 
-    patterns.add<InstructionSchedHintsRewriter>(ctx, this->gfxArch,
-                                                this->numStages);
+    patterns.add<InstructionSchedHintsRewriter>(ctx);
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns)))) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
@@ -43,34 +43,6 @@ LogicalResult validateStridesAndSharedOrder(triton::MakeTensorDescOp op,
   return success();
 }
 
-// Collects all users of the value beyond the basic block boundaries
-// defining a given value.
-void collectUsers(Value value, llvm::SetVector<Operation *> &users) {
-  for (OpOperand &use : value.getUses()) {
-    Operation *userOp = use.getOwner();
-    if (users.contains(userOp)) {
-      // stop recursion; avoid loops
-      return;
-    }
-    users.insert(userOp);
-    const unsigned argIdx = use.getOperandNumber();
-
-    if (auto unrealCast = dyn_cast<mlir::UnrealizedConversionCastOp>(userOp)) {
-      collectUsers(unrealCast->getResult(argIdx), users);
-    }
-
-    if (auto branch = dyn_cast<mlir::BranchOpInterface>(userOp)) {
-      auto successors = branch->getSuccessors();
-      for (auto [idx, successor] : llvm::enumerate(successors)) {
-        auto operands = branch.getSuccessorOperands(idx);
-        if (argIdx < operands.size()) {
-          collectUsers(successor->getArgument(argIdx), users);
-        }
-      }
-    }
-  }
-}
-
 struct MakeTensorDescOpConversion
     : public ConvertOpToLLVMPattern<triton::MakeTensorDescOp> {
   using ConvertOpToLLVMPattern<
@@ -113,7 +85,6 @@ struct MakeTensorDescOpConversion
     }
     auto sharedOrder = triton::gpu::getOrder(
         cast<triton::gpu::SharedEncodingTrait>(sharedEnc), shapePerCTA);
-    bool isRowMajor = sharedOrder[0] == (sharedOrder.size() - 1);
     // Create TDM descriptor for 2D-5D tensors
     auto tdmDesc = LLVM::AMD::createTDMDescriptor(
         rewriter, loc, getTypeConverter(), elementType, shapePerCTA, numWarps,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -156,18 +156,8 @@ struct ConvertTritonAMDGPUToLLVM
     // Make benefit for AMD specific patterns higher so they apply before common
     // patterns
     int AMDBenefit = commonBenefit + 1;
-    auto populatePatterns1 = [&](auto populateFunc, int benefit) {
-      populateFunc(typeConverter, patterns, axisInfoAnalysis, allocation,
-                   benefit);
-    };
-
     auto populatePatterns5 = [&](auto populateFunc, int benefit) {
       populateFunc(typeConverter, patterns, benefit);
-    };
-
-    auto populatePatterns6 = [&](auto populateFunc, int benefit) {
-      populateFunc(typeConverter, patterns, axisInfoAnalysis, allocation,
-                   targetInfo, benefit);
     };
 
     auto populatePatterns7 = [&](auto populateFunc, int benefit) {
@@ -274,9 +264,10 @@ private:
     // Ask for 16B alignment on global_smem because that's the largest we should
     // ever need (4xi32).
     auto arrayTy = LLVM::LLVMArrayType::get(elemTy, 0);
-    auto global = LLVM::GlobalOp::create(
+    LLVM::GlobalOp::create(
         b, loc, arrayTy, /*isConstant=*/false, LLVM::Linkage::External,
-        "global_smem", /*value=*/Attribute(), /*alignment=*/16,
+        "global_smem",
+        /*value=*/Attribute(), /*alignment=*/16,
         // Add ROCm support.
         static_cast<unsigned>(NVVM::NVVMMemorySpace::Shared));
   }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -980,7 +980,6 @@ public:
     // kWidth is 16 for fp4.
     const unsigned kWidth = kBase;
     assert(kWidth == 32);
-    using basisT = std::vector<std::vector<int32_t>>;
 
     auto aShape = a.getType().getShape();
     auto bShape = b.getType().getShape();
@@ -1178,8 +1177,6 @@ public:
 
     auto order = ttg::getMatrixOrder(rank, /*rowMajor=*/true);
     auto standardOutDims = standardOutDimNames(ctx, rank);
-
-    using basisT = std::vector<std::vector<int32_t>>;
 
     RankedTensorType aType = a.getType();
     RankedTensorType bType = b.getType();
@@ -1382,9 +1379,6 @@ FailureOr<WmmaIntrinsic> chooseWmmaInstruction(Location loc, int wmmaVersion,
                                                Type cElemType, int inputKSize) {
   // number of matrix elements along k dim per one WMMA instruction
   unsigned kDim = 0;
-
-  auto resShape = cType.getShape();
-  auto rank = resShape.size();
 
   unsigned mDim = 16;
   unsigned nDim = 16;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -939,13 +939,11 @@ void Pingponger::addAsymmetricSyncToLoop(OpBuilder &builder, Location loc) {
                                        warpIDX, constZero);
   auto warpHigh = arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::ne,
                                         warpIDX, constZero);
-  auto condBarrierHigh =
-      tt::amdgpu::CondBarrierOp::create(builder, loc, warpHigh);
+  tt::amdgpu::CondBarrierOp::create(builder, loc, warpHigh);
 
   // Insert condbarrier::first_half after the end of the loop
   builder.setInsertionPointAfter(forOp);
-  auto condBarrierLow =
-      tt::amdgpu::CondBarrierOp::create(builder, loc, warpLow);
+  tt::amdgpu::CondBarrierOp::create(builder, loc, warpLow);
 }
 
 void Pingponger::getDotPingponged() {
@@ -957,7 +955,6 @@ void Pingponger::getDotPingponged() {
   }
 
   OpBuilder builder(forOp);
-  MLIRContext *ctx = forOp.getContext();
   Location loc = forOp.getLoc();
 
   forOp->walk([&](Operation *op) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -344,8 +344,6 @@ createDecomposeOffsetFromAdd(RewriterBase &rewriter, Location loc, Value expr,
       createAddOffsetsOfSameKind(rewriter, loc, uniformOffsetL, uniformOffsetR);
   Value nonUniformAdd = createAddOffsetsOfSameKind(
       rewriter, loc, nonUniformOffsetL, nonUniformOffsetR);
-  Value maybeDeadValue[] = {nonUniformOffsetL, nonUniformOffsetR,
-                            uniformOffsetL, uniformOffsetR};
   return {uniformAdd, nonUniformAdd};
 }
 
@@ -459,16 +457,6 @@ struct FatPointers {
     FatPtrAttrs &operator=(const FatPtrAttrs &other) = default;
     // for map default insert
     FatPtrAttrs() = default;
-
-    friend bool operator==(const FatPtrAttrs &lhs, const FatPtrAttrs &rhs) {
-      return lhs.canNarrow == rhs.canNarrow &&
-             lhs.isSmallTensor == rhs.isSmallTensor &&
-             lhs.attributes.getArrayRef() == rhs.attributes.getArrayRef();
-    }
-
-    friend bool operator!=(const FatPtrAttrs &lhs, const FatPtrAttrs &rhs) {
-      return !(lhs == rhs);
-    }
 
     static FatPtrAttrs intersect(const FatPtrAttrs &lhs,
                                  const FatPtrAttrs &rhs) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -49,9 +49,7 @@ public:
     bool hasElse = false;
     funcOp->walk([&](scf::IfOp ifOp) {
       if (ifOp.elseBlock()) {
-        for (Operation &op : ifOp.elseBlock()->getOperations()) {
-          hasElse = true;
-        }
+        hasElse = true;
       }
     });
     if (hasElse)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.cpp
@@ -30,8 +30,6 @@ void setAsyncTaskIds(Operation *op, ArrayRef<AsyncTaskId> asyncTaskIds) {
   SmallVector<AsyncTaskId> sortedAsyncTaskIds(asyncTaskIds.begin(),
                                               asyncTaskIds.end());
   sort(sortedAsyncTaskIds);
-  auto i32Ty = IntegerType::get(op->getContext(), 32);
-  auto size = static_cast<int64_t>(sortedAsyncTaskIds.size());
   op->setAttr("async_task_id",
               DenseI32ArrayAttr::get(op->getContext(), sortedAsyncTaskIds));
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
@@ -142,8 +142,7 @@ scf::IfOp rewriteIfOp(scf::IfOp ifOp, SmallVector<Operation *> &taskTopOps,
 
   // Go through region ops in the thenBlock. updateAccumLoopCount takes current
   // accumCnt value and returns the value at the end of the thenBlock.
-  Value endAccum =
-      updateAccumLoopCount(opList, taskTopOps, regionsWithChannels, prevAccum);
+  updateAccumLoopCount(opList, taskTopOps, regionsWithChannels, prevAccum);
 
   SmallVector<Value> ifYieldOperands = newIfOp.thenYield().getOperands();
 
@@ -482,8 +481,7 @@ scf::ForOp createNewLoopWrapper(scf::ForOp origForOp,
     if (auto tOp = dyn_cast<scf::IfOp>(&op))
       opList.push_back(&op);
   }
-  Value endAccum =
-      updateAccumLoopCount(opList, taskTopOps, regionsWithChannels, prevAccum);
+  updateAccumLoopCount(opList, taskTopOps, regionsWithChannels, prevAccum);
   LLVM_DEBUG({
     LDBG("-- before replacing yieldOp ");
     newForOp.dump();

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -1080,8 +1080,7 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
     for (unsigned i = 0; i < forOp.getInitArgs().size(); i++) {
       auto initArg = forOp.getInitArgs()[i];
       Value newInitArg;
-      auto newInitArgOp =
-          sliceOp(initArg, offset, mappings, reverseMappings, partitionScheme);
+      sliceOp(initArg, offset, mappings, reverseMappings, partitionScheme);
       if (auto bbArg = dyn_cast<BlockArgument>(initArg)) {
         // find the corresponding new block argument
         Block *parentBlock = bbArg.getOwner();
@@ -1095,8 +1094,6 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
         assert(argIndex < parentBlock->getNumArguments() &&
                "new init argment not found");
         Region *parentRegion = parentBlock->getParent();
-        Region &newParentRegion =
-            newInitArgOp->getRegion(parentRegion->getRegionNumber());
         newInitArg = parentRegion->getArgument(argIndex);
       } else {
         newInitArg = mappings.lookupOrNull(initArg);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -204,8 +204,8 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
   auto prodBarrier =
       getBarrierForPipelineStage(builder, barrierAlloc, bufferIdx);
   auto pred = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 1);
-  auto expect = builder.createWithAsyncTaskIds<ttng::BarrierExpectOp>(
-      loc, prodBarrier, sizeInBytes, pred);
+  builder.createWithAsyncTaskIds<ttng::BarrierExpectOp>(loc, prodBarrier,
+                                                        sizeInBytes, pred);
 
   // Convert all the producers to async_tma_copy_global_to_local
   Operation *copy = nullptr;
@@ -225,8 +225,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
       getBarrierForPipelineStage(builder, barrierAlloc, bufferIdxExtract);
   phase = builder.createWithAsyncTaskIds<arith::ExtSIOp>(
       loc, builder.getI32Type(), phase);
-  auto wait = builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
-      loc, consBarrier, phase);
+  builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(loc, consBarrier, phase);
 
   // Convert all the consumers to local_load
   for (auto [tmaLoad, buffer] : zip(tmaLoads, buffers)) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskPartition.cpp
@@ -52,19 +52,6 @@ void doTaskPartition(triton::FuncOp &funcOp, unsigned numWarpGroups) {
   if (loops.empty() || loads.empty() || dots.empty())
     return;
 
-  auto getLoopLevel = [&](Operation *op) {
-    // Compute loop depth
-    unsigned depth = 0;
-    Operation *parent = op->getParentOp();
-    while (parent) {
-      if (isa<scf::ForOp>(parent)) {
-        ++depth;
-      }
-      parent = parent->getParentOp();
-    }
-    return depth;
-  };
-
   // Step 1. Select loads into the first task, which is the producer task by
   // default. Place dots into the second task, which is the consumer.
   // Only consider loads that are connected to a dot op in a loop.

--- a/third_party/nvidia/include/cublas_instance.h
+++ b/third_party/nvidia/include/cublas_instance.h
@@ -209,8 +209,7 @@ private:
     cublasOperation_t transa = CUBLAS_OP_T;
     cublasOperation_t transb = CUBLAS_OP_N;
 
-    cublasLtMatrixLayout_t Adesc = NULL, Bdesc = NULL, Cdesc = NULL,
-                           Ddesc = NULL;
+    cublasLtMatrixLayout_t Adesc = NULL, Bdesc = NULL, Cdesc = NULL;
 
     // Use FP32 compute and accumulation
     cublasComputeType_t computeType = CUBLAS_COMPUTE_32F;
@@ -266,8 +265,6 @@ private:
     successOrExit(cublasLtMatrixLayoutCreate(&Adesc, dataType, k, m, k));
     successOrExit(cublasLtMatrixLayoutCreate(&Bdesc, dataType, k, n, k));
     successOrExit(cublasLtMatrixLayoutCreate(&Cdesc, CUDA_R_16F, m, n, m));
-    Ddesc = Cdesc;
-
     float alpha = 1.0f;
     float beta = 0.0f; // No bias
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
@@ -550,7 +550,6 @@ class NVWSAssignStagePhase
     : public impl::NVWSAssignStagePhaseBase<NVWSAssignStagePhase> {
 public:
   void runOnOperation() override {
-    MLIRContext *context = &getContext();
     mlir::ModuleOp m = getOperation();
 
     m.walk([&](triton::FuncOp funcOp) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -30,10 +30,9 @@ struct ScaledDotOpConversion
     : public ConvertOpToLLVMPattern<triton::DotScaledOp> {
   using ConvertOpToLLVMPattern<triton::DotScaledOp>::ConvertOpToLLVMPattern;
 
-  ScaledDotOpConversion(LLVMTypeConverter &converter, int computeCapability,
+  ScaledDotOpConversion(LLVMTypeConverter &converter, int,
                         PatternBenefit benefit)
-      : ConvertOpToLLVMPattern<triton::DotScaledOp>(converter, benefit),
-        computeCapability(computeCapability) {}
+      : ConvertOpToLLVMPattern<triton::DotScaledOp>(converter, benefit) {}
 
   LogicalResult
   matchAndRewrite(triton::DotScaledOp op, triton::DotScaledOp::Adaptor adaptor,
@@ -46,24 +45,18 @@ struct ScaledDotOpConversion
               "linear layout");
     return convertMMADotScaled(op, adaptor, getTypeConverter(), rewriter);
   }
-
-private:
-  int computeCapability;
 };
 
 struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
   using ConvertOpToLLVMPattern<triton::DotOp>::ConvertOpToLLVMPattern;
 
-  DotOpConversion(LLVMTypeConverter &converter, int computeCapability,
-                  PatternBenefit benefit)
-      : ConvertOpToLLVMPattern<triton::DotOp>(converter, benefit),
-        computeCapability(computeCapability) {}
+  DotOpConversion(LLVMTypeConverter &converter, int, PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<triton::DotOp>(converter, benefit) {}
 
   LogicalResult
   matchAndRewrite(triton::DotOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // D = A * B + C
-    Value D = op.getResult();
     auto dType = op.getResult().getType();
     auto dEncoding = dType.getEncoding();
 
@@ -90,9 +83,6 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
     llvm::report_fatal_error(
         "Unsupported DotOp found when converting TritonGPU to LLVM.");
   }
-
-private:
-  int computeCapability;
 };
 
 struct WarpGroupDotOpConversion

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1103,7 +1103,6 @@ static LinearLayout getMsgToPackedOffsetLayout(ttg::MemDescType ty,
                                                ttg::TMAMode mode) {
   auto ctx = ty.getContext();
   auto kMsg = str_attr("msg");
-  auto kBlock = str_attr("block");
   auto shapePerCTA = ttg::getShapePerCTA(ty);
   int rank = shapePerCTA.size();
   auto blockShape = ttng::getTMABlockShape(ty, /*packedSize=*/true, mode);
@@ -1194,7 +1193,6 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     auto kMsg = str_attr("msg");
     auto kBlock = str_attr("block");
     const auto numCopies = msgToOffset.getInDimSize(kMsg);
-    auto zero = b.i32_val(0);
     auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
     // We multicast if the flag is on and the block layout has broadcasting
     bool multicast = op.getMulticast();

--- a/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
+++ b/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
@@ -142,8 +142,6 @@ LogicalResult replaceProtonRecordOp(OpBuilder &builder, FuncOp func,
 int getAllocSharedMemSize(int maxSharedMemSize, int sharedMemUsed,
                           int segmentNum) {
   const int bytesPerEntry = gpu::getBytesPerClockEntry();
-  const int wordsPerEntry = bytesPerEntry / 4; // 1 word = 4 bytes
-  const int circularHeaderSize = gpu::getCircularHeaderSize(); // byte size
   sharedMemUsed = llvm::alignTo(sharedMemUsed, bytesPerEntry);
   if (sharedMemUsed >= maxSharedMemSize) {
     // We just assume there's enough shared memory and error out if not during

--- a/third_party/proton/csrc/Proton.cpp
+++ b/third_party/proton/csrc/Proton.cpp
@@ -36,7 +36,6 @@ std::map<std::string, MetricValueType> convertPythonMetrics(
 } // namespace
 
 static void initProton(pybind11::module &&m) {
-  using ret = pybind11::return_value_policy;
   using namespace pybind11::literals;
 
   // Accept raw integer pointers from Python (e.g., Tensor.data_ptr()) instead

--- a/third_party/proton/csrc/include/Session/Session.h
+++ b/third_party/proton/csrc/include/Session/Session.h
@@ -36,11 +36,11 @@ public:
   Profiler *getProfiler() const { return profiler; }
 
 private:
-  Session(size_t id, const std::string &path, Profiler *profiler,
+  Session(const std::string &path, Profiler *profiler,
           std::unique_ptr<ContextSource> contextSource,
           std::unique_ptr<Data> data)
-      : id(id), path(path), profiler(profiler),
-        contextSource(std::move(contextSource)), data(std::move(data)) {}
+      : path(path), profiler(profiler), contextSource(std::move(contextSource)),
+        data(std::move(data)) {}
 
   template <typename T> std::vector<T *> getInterfaces() {
     std::vector<T *> interfaces;
@@ -60,7 +60,6 @@ private:
   }
 
   const std::string path{};
-  size_t id{};
   Profiler *profiler{};
   std::unique_ptr<ContextSource> contextSource{};
   std::unique_ptr<Data> data{};
@@ -136,7 +135,7 @@ private:
   Profiler *validateAndSetProfilerMode(Profiler *profiler,
                                        const std::string &mode);
 
-  std::unique_ptr<Session> makeSession(size_t id, const std::string &path,
+  std::unique_ptr<Session> makeSession(const std::string &path,
                                        const std::string &profilerName,
                                        const std::string &contextSourceName,
                                        const std::string &dataName,

--- a/third_party/proton/csrc/lib/Data/TraceData.cpp
+++ b/third_party/proton/csrc/lib/Data/TraceData.cpp
@@ -539,12 +539,6 @@ json buildCallStackJson(const std::vector<Context> &contexts) {
   return callStack;
 }
 
-json buildCallStackJson(const Context &context) {
-  json callStack = json::array();
-  callStack.push_back(context.name);
-  return callStack;
-}
-
 json buildFlexibleMetricsJson(
     const DataEntry::FlexibleMetricMap &flexibleMetrics) {
   json metrics = json::object();

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -88,15 +88,15 @@ Profiler *SessionManager::validateAndSetProfilerMode(Profiler *profiler,
 }
 
 std::unique_ptr<Session> SessionManager::makeSession(
-    size_t id, const std::string &path, const std::string &profilerName,
+    const std::string &path, const std::string &profilerName,
     const std::string &contextSourceName, const std::string &dataName,
     const std::string &mode) {
   auto *profiler = makeProfiler(profilerName);
   profiler = validateAndSetProfilerMode(profiler, mode);
   auto contextSource = makeContextSource(contextSourceName);
   auto data = makeData(dataName, path, contextSource.get());
-  auto *session = new Session(id, path, profiler, std::move(contextSource),
-                              std::move(data));
+  auto *session =
+      new Session(path, profiler, std::move(contextSource), std::move(data));
   return std::unique_ptr<Session>(session);
 }
 
@@ -191,8 +191,8 @@ size_t SessionManager::addSession(const std::string &path,
     return sessionId;
   }
   auto sessionId = nextSessionId++;
-  auto newSession = makeSession(sessionId, path, profilerName,
-                                contextSourceName, dataName, mode);
+  auto newSession =
+      makeSession(path, profilerName, contextSourceName, dataName, mode);
   sessionPaths[path] = sessionId;
   sessions[sessionId] = std::move(newSession);
   return sessionId;


### PR DESCRIPTION

Delete some dead variables and functions identified by running with
`-Wunused`.

---
[//]: # (BEGIN SAPLING FOOTER)
* #10267
* __->__ #10261