### PR TITLE
Add -Wunused to default Triton builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,8 +180,11 @@ endif()
 
 # Customized release build type with assertions: TritonRelBuildWithAsserts
 if(NOT MSVC)
-  set(CMAKE_C_FLAGS_TRITONRELBUILDWITHASSERTS "-O2 -g")
-  set(CMAKE_CXX_FLAGS_TRITONRELBUILDWITHASSERTS "-O2 -g")
+  # We only enforce -Wunused in this build mode where we know NDEBUG is not set.
+  # This avoids spurious warnings in NDEBUG builds about things that are only
+  # used in asserts.
+  set(CMAKE_C_FLAGS_TRITONRELBUILDWITHASSERTS "-O2 -g -Wunused")
+  set(CMAKE_CXX_FLAGS_TRITONRELBUILDWITHASSERTS "-O2 -g -Wunused")
   set(CMAKE_C_FLAGS_TRITONBUILDWITHO1 "-O1")
   set(CMAKE_CXX_FLAGS_TRITONBUILDWITHO1 "-O1")
 else()

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -29,8 +29,8 @@ using namespace mlir::triton;
 
 namespace {
 
-void printBasis(const llvm::SmallVector<int32_t> &basis,
-                const std::string &name) {
+[[maybe_unused]] void printBasis(const llvm::SmallVector<int32_t> &basis,
+                                 const std::string &name) {
   llvm::errs() << name << ": ";
   for (int32_t b : basis)
     llvm::errs() << b << " ";

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -54,7 +54,7 @@ BasesT makeBasesMap(
 }
 
 // Dump the matrix to stderr in a human-readable format for debugging.
-void dumpMatrix(uint64_t *m, int numRows, int numCols) {
+[[maybe_unused]] void dumpMatrix(uint64_t *m, int numRows, int numCols) {
   assert(numCols <= 64);
   for (int r = 0; r < numRows; r++) {
     llvm::errs() << "0b";

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -66,7 +66,9 @@ template <typename AttrOrType>
 constexpr auto hasVerifier(AttrOrType t) -> decltype(t.verifyInvariants, true) {
   return true;
 }
-constexpr auto hasVerifier(...) { return false; }
+template <typename... ArgTs> constexpr auto hasVerifier(ArgTs...) {
+  return false;
+}
 
 // Print a diagnostic without its location. The frontend will attach the AST
 // location to the error message.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -30,8 +30,7 @@ struct ScaledDotOpConversion
     : public ConvertOpToLLVMPattern<triton::DotScaledOp> {
   using ConvertOpToLLVMPattern<triton::DotScaledOp>::ConvertOpToLLVMPattern;
 
-  ScaledDotOpConversion(LLVMTypeConverter &converter, int,
-                        PatternBenefit benefit)
+  ScaledDotOpConversion(LLVMTypeConverter &converter, PatternBenefit benefit)
       : ConvertOpToLLVMPattern<triton::DotScaledOp>(converter, benefit) {}
 
   LogicalResult
@@ -163,6 +162,5 @@ void mlir::triton::NVIDIA::populateDotOpToLLVMPatterns(
   patterns.add<DotOpConversion>(typeConverter, computeCapability, benefit);
   patterns.add<WarpGroupDotOpConversion>(typeConverter, benefit);
   patterns.add<WarpGroupDotWaitOpConversion>(typeConverter, benefit);
-  patterns.add<ScaledDotOpConversion>(typeConverter, computeCapability,
-                                      benefit);
+  patterns.add<ScaledDotOpConversion>(typeConverter, benefit);
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -329,10 +329,10 @@ private:
   }
 };
 
-static Value getOffsetedBase(Value v, gpu::MemDescType memDescTy,
-                             const TypeConverter *typeConverter,
-                             ConversionPatternRewriter &rewriter,
-                             Location loc) {
+static inline Value getOffsetedBase(Value v, gpu::MemDescType memDescTy,
+                                    const TypeConverter *typeConverter,
+                                    ConversionPatternRewriter &rewriter,
+                                    Location loc) {
   TritonLLVMOpBuilder tb(loc, rewriter);
   auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
   auto smemObj =


### PR DESCRIPTION

Add `-Wunused` in the default build mode. This catches dead variables,
fields, and functions.

Setting it only in this mode avoids issues when switching between modes
(e.g. release builds where vars only used in asserts become unused).
