### PR TITLE
[triton-ext] Allow testing triton plugins in isolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ test-unit: all
 	$(PYTEST) python/tutorials/06-fused-attention.py
 	TRITON_ALWAYS_COMPILE=1 TRITON_DISABLE_LINE_INFO=0 LLVM_PASS_PLUGIN_PATH=python/triton/instrumentation/libGPUInstrumentationTestLib.so \
 		$(PYTEST) --capture=tee-sys -rfs -vvv python/test/unit/instrumentation/test_gpuhello.py
+
+.PHONY: test-plugins
+test-plugins: all
 	TRITON_PLUGIN_PATHS=python/triton/plugins/libTritonPluginsTestLib.so \
 		$(PYTEST) -vvv python/test/unit/plugins/test_plugin.py
 	TRITON_PLUGIN_PATHS=python/triton/plugins/libMLIRDialectPlugin.so \
@@ -80,7 +83,7 @@ test-proton: all
 	$(PYTEST) third_party/proton/test/test_instrumentation.py::test_overhead
 
 .PHONY: test-python
-test-python: test-unit test-regression test-interpret test-proton
+test-python: test-unit test-plugins test-regression test-interpret test-proton
 
 .PHONY: test-nogpu
 test-nogpu: test-lit test-cpp


### PR DESCRIPTION
Here's another ease-of-use commit that I'm separating out from an unrelated change. This makes it easy to test Triton's plugin system with a single command: `make test-plugins`.
