### PR TITLE
[INTERPRETER] Extract kernel grid execution into InterpreterBuilder

### DIFF
--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -298,6 +298,13 @@ class InterpreterBuilder:
             raise ValueError("z >= grid_dim[2]")
         self.grid_idx = (x, y, z)
 
+    def execute_kernel(self, fn, args, grid):
+        for x in range(grid[0]):
+            for y in range(grid[1]):
+                for z in range(grid[2]):
+                    self.set_grid_idx(x, y, z)
+                    fn(**args)
+
     def set_grid_dim(self, nx, ny, nz):
         self.grid_dim = (nx, ny, nz)
 
@@ -1290,11 +1297,7 @@ class GridExecutor:
             grid = grid + (1, ) * (3 - len(grid))
             interpreter_builder.set_grid_dim(*grid)
             try:
-                for x in range(grid[0]):
-                    for y in range(grid[1]):
-                        for z in range(grid[2]):
-                            interpreter_builder.set_grid_idx(x, y, z)
-                            self.fn(**args)
+                interpreter_builder.execute_kernel(self.fn, args, grid)
             except Exception as e:
                 if triton.knobs.compilation.front_end_debugging:
                     raise


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
This change makes a small refactor in the interpreter by moving the kernel grid execution loop from `GridExecutor.__call__` into `InterpreterBuilder.execute_kernel`.
This makes the interpreter execution path more centralized and makes future execution-related changes easier to apply.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `this is a refactor only.`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
