### PR TITLE
Support zero-sized Hopper MX scale layouts

### DIFF
--- a/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -1,7 +1,7 @@
 import pytest
 from triton._internal_testing import is_cuda
 from triton_kernels.tensor import wrap_torch_tensor, convert_layout, FP4
-from triton_kernels.tensor_details.layout import HopperMXScaleLayout, HopperMXValueLayout
+from triton_kernels.tensor_details.layout import HopperMXScaleLayout, HopperMXValueLayout, StridedLayout
 from triton_kernels.numerics_details.mxfp import downcast_to_mxfp, upcast_from_mxfp
 from triton_kernels.tensor_details.layout_details.hopper_value import mxfp4_to_bf16_triton
 from triton_kernels.tensor_details.layout_details.hopper_scale import unswizzle_mxfp4_scale_hopper
@@ -42,6 +42,27 @@ def test_mxfp4_scale_roundtrip(shape, mx_axis, num_warps):
     transformation = layout.make_transformation(x.shape, is_fp4=False)
     res = transformation.unswizzle_data(transformation.swizzle_data(x))
     assert (res[:shape[0], :shape[1]] == x).all()
+
+
+@pytest.mark.parametrize(
+    ("shape", "mx_axis"),
+    [
+        ((0, 64), -2),
+        ((64, 0), -1),
+        ((2, 0), -2),
+        ((0, 2), -1),
+    ],
+)
+@pytest.mark.parametrize("num_warps", [4, 8])
+def test_mxfp4_scale_zero_sized_roundtrip(shape, mx_axis, num_warps):
+    x = torch.empty(shape, dtype=torch.uint8)
+    src = wrap_torch_tensor(x)
+    layout = HopperMXScaleLayout(mx_axis=mx_axis, num_warps=num_warps)
+
+    swizzled = convert_layout(src, layout)
+    roundtrip = convert_layout(swizzled, StridedLayout(mx_axis))
+
+    assert roundtrip.storage.data.shape == x.shape
 
 
 # ------------------------------------------------------------

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_scale.py
@@ -64,8 +64,10 @@ class HopperMXScaleLayoutTransformation(LayoutTransformation):
         SWIZZLE_ALIGN_K = 2
         pad_m = (SWIZZLE_ALIGN_M - (M % SWIZZLE_ALIGN_M)) % SWIZZLE_ALIGN_M
         pad_k = (SWIZZLE_ALIGN_K - (K % SWIZZLE_ALIGN_K)) % SWIZZLE_ALIGN_K
-        data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))
-        *batch, M, K = data.shape
+        if data.numel():
+            data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))
+        M += pad_m
+        K += pad_k
         assert data.is_contiguous()
         assert M % (
             2 * self.num_warps * 2 *

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/strided.py
@@ -60,7 +60,7 @@ class StridedLayoutTransformation(LayoutTransformation):
     order: list[int]
 
     def swizzle_data(self, data):
-        assert data.stride(-1) == 1
+        assert data.numel() == 0 or data.stride(-1) == 1
         r = len(self.shape)
         if r == 0:
             return data


### PR DESCRIPTION
Fix Hopper MX scale layout conversion for zero-sized scale tensors.

`torch.nn.functional.pad` rejects some valid zero-numel outputs. This shows up in Hopper scale swizzle after RHS transpose: for example, `(0, 64)` becomes `(64, 0)`, and row padding still leaves a zero-width output.

The fix mirrors Blackwell scale layout: skip `pad` when there are no elements, update `M`/`K` to the padded extents, and let the existing zero-element reshape produce the swizzled storage shape.

Also relax only `StridedLayoutTransformation.swizzle_data` for zero-numel input. Hopper scale roundtrip can produce a valid empty canonical tensor such as `(2, 0)` with `stride(-1) == 2`; there are no elements for the packed-stride invariant to constrain.

Validation:
- H100: `PYTHONPATH=$PWD/python/triton_kernels python -m pytest -q python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py::test_mxfp4_scale_zero_sized_roundtrip`
