### PR TITLE
[TTNG] add cluster-reduce bulk fast path

### DIFF
--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -43,6 +43,37 @@ def _combine(a, b):
     return a + b
 
 
+@gluon.constexpr_function
+def _make_cga_bases_2d(cluster_size):
+    if cluster_size <= 1:
+        return []
+    n = cluster_size.bit_length() - 1
+    return [[1 << i, 0] for i in range(n)]
+
+
+@gluon.constexpr_function
+def _make_cga_bases_1d(cluster_size):
+    if cluster_size <= 1:
+        return []
+    n = cluster_size.bit_length() - 1
+    return [[1 << i] for i in range(n)]
+
+
+@gluon.jit
+def _cluster_reduce_vector_kernel(x_ptr, y_ptr, tile_size: ttgl.constexpr, cluster_size: ttgl.constexpr):
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    cga_bases: ttgl.constexpr = _make_cga_bases_2d(cluster_size)
+    layout_cga: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [1, num_warps], [1, 0], cga_bases)
+
+    rows = ttgl.arange(0, cluster_size, layout=ttgl.SliceLayout(dim=1, parent=layout_cga))[:, None]
+    cols = ttgl.arange(0, tile_size, layout=ttgl.SliceLayout(dim=0, parent=layout_cga))[None, :]
+    offs = rows * tile_size + cols
+
+    x = ttgl.load(x_ptr + offs).to(ttgl.float32)
+    reduced = ttgl.sum(x, axis=0)
+    ttgl.store(y_ptr + offs, reduced[None, :])
+
+
 @gluon.jit
 def scan_kernel(x_ptr, z_ptr, M: ttgl.constexpr, N: ttgl.constexpr, layout: ttgl.constexpr, axis: ttgl.constexpr):
     x_offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, layout))[:, None]
@@ -571,6 +602,39 @@ def test_reduce_funky_layout(src_layout, axis, device):
     # warp-sync
     if is_cuda() and axis_warps + axis_blocks == 0:
         assert pm.asm["ptx"].count("bar.sync") == 0
+
+
+@pytest.mark.parametrize("cluster_size", [2, 4, 8, 16])
+@pytest.mark.parametrize("tile_size", [64, 256, 1024])
+def test_cluster_reduce_bulk_copy_vector(cluster_size, tile_size, device):
+    if not is_cuda():
+        pytest.skip("requires CUDA")
+    if not is_hopper_or_newer():
+        pytest.skip("requires SM90+")
+
+    torch.manual_seed(0)
+    x = torch.randn(cluster_size * tile_size, dtype=torch.float16, device=device)
+    y = torch.zeros(cluster_size * tile_size, dtype=torch.float32, device=device)
+
+    pm = _cluster_reduce_vector_kernel[(1, )](
+        x,
+        y,
+        tile_size=tile_size,
+        cluster_size=cluster_size,
+        num_warps=4,
+        num_ctas=cluster_size,
+    )
+
+    torch.testing.assert_close(
+        y.view(cluster_size, tile_size)[0],
+        x.view(cluster_size, tile_size).float().sum(dim=0),
+        atol=1e-3,
+        rtol=1e-3,
+    )
+
+    ptx = pm.asm["ptx"]
+    assert "cp.async.bulk.shared::cluster.shared::cta" in ptx
+    assert "ld.shared::cluster" not in ptx
 
 
 def _reduce_linear_layouts():

--- a/python/test/microbenchmark/bench_cluster_reduce.py
+++ b/python/test/microbenchmark/bench_cluster_reduce.py
@@ -1,0 +1,248 @@
+import argparse
+import csv
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import torch
+import triton
+from triton.experimental import gluon
+from triton.experimental.gluon import language as ttgl
+
+
+@gluon.constexpr_function
+def _make_cga_bases_2d(cluster_size):
+    if cluster_size <= 1:
+        return []
+    n = cluster_size.bit_length() - 1
+    return [[1 << i, 0] for i in range(n)]
+
+
+@gluon.jit
+def cluster_reduce_vector_kernel(x_ptr, y_ptr, tile_size: ttgl.constexpr, cluster_size: ttgl.constexpr):
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    cga_bases: ttgl.constexpr = _make_cga_bases_2d(cluster_size)
+    layout_cga: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [1, num_warps], [1, 0], cga_bases)
+    rows = ttgl.arange(0, cluster_size, layout=ttgl.SliceLayout(dim=1, parent=layout_cga))[:, None]
+    cols = ttgl.arange(0, tile_size, layout=ttgl.SliceLayout(dim=0, parent=layout_cga))[None, :]
+    offs = rows * tile_size + cols
+    x = ttgl.load(x_ptr + offs).to(ttgl.float32)
+    y = ttgl.sum(x, axis=0)
+    ttgl.store(y_ptr + offs, y[None, :])
+
+
+def _parse_csv_ints(s):
+    return [int(x) for x in s.split(",") if x]
+
+
+def _run_case(cluster_size, tile_size, iters, warmup):
+    torch.manual_seed(0)
+    x = torch.randn(cluster_size * tile_size, device="cuda", dtype=torch.float16)
+    y = torch.zeros(cluster_size * tile_size, device="cuda", dtype=torch.float32)
+    compiled = cluster_reduce_vector_kernel[(1, )](
+        x,
+        y,
+        tile_size=tile_size,
+        cluster_size=cluster_size,
+        num_warps=4,
+        num_ctas=cluster_size,
+    )
+    torch.cuda.synchronize()
+    ref = x.view(cluster_size, tile_size).float().sum(dim=0)
+    got = y.view(cluster_size, tile_size)[0]
+    ok = torch.allclose(got, ref, atol=1e-3, rtol=1e-3)
+    ptx = compiled.asm["ptx"]
+    ms = triton.testing.do_bench(
+        lambda: cluster_reduce_vector_kernel[(1, )](
+            x,
+            y,
+            tile_size=tile_size,
+            cluster_size=cluster_size,
+            num_warps=4,
+            num_ctas=cluster_size,
+        ),
+        warmup=warmup,
+        rep=iters,
+    )
+    return {
+        "cluster_size": cluster_size,
+        "tile_size": tile_size,
+        "ms": ms,
+        "ok": int(ok),
+        "bulk": int("cp.async.bulk.shared::cluster.shared::cta" in ptx),
+        "cluster_ld": int("ld.shared::cluster" in ptx),
+    }
+
+
+def _run_child(args):
+    res = _run_case(args.cluster_size, args.tile_size, args.iters, args.warmup)
+    print(
+        f"{args.mode},{res['cluster_size']},{res['tile_size']},{res['ms']:.6f},"
+        f"{res['ok']},{res['bulk']},{res['cluster_ld']}",
+        flush=True,
+    )
+
+
+def _write_svg(rows, out_svg):
+    import math
+
+    width, height = 1200, 900
+    margin = 70
+    plot_w = (width - 3 * margin) / 2
+    plot_h = (height - 3 * margin) / 2
+    colors = {"old": "#4c78a8", "new": "#f58518"}
+    clusters = sorted({r["cluster_size"] for r in rows})
+    max_y = max(r["ms"] for r in rows) * 1.15
+    min_x = min(r["tile_size"] for r in rows)
+    max_x = max(r["tile_size"] for r in rows)
+    log_min, log_max = math.log2(min_x), math.log2(max_x)
+    if log_min == log_max:
+        log_max = log_min + 1.0
+
+    def sx(x, left):
+        return left + (math.log2(x) - log_min) / (log_max - log_min) * plot_w
+
+    def sy(y, top):
+        return top + plot_h - y / max_y * plot_h
+
+    svg = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">']
+    svg.append('<rect width="100%" height="100%" fill="white"/>')
+    svg.append('<text x="40" y="35" font-size="24" font-family="sans-serif">Cluster Reduce old vs new</text>')
+    for idx, cs in enumerate(clusters):
+        col = idx % 2
+        row = idx // 2
+        left = margin + col * (plot_w + margin)
+        top = margin + row * (plot_h + margin)
+        svg.append(f'<rect x="{left}" y="{top}" width="{plot_w}" height="{plot_h}" fill="none" stroke="#ddd"/>')
+        svg.append(f'<text x="{left+5}" y="{top-10}" font-size="18" font-family="sans-serif">cluster_size={cs}</text>')
+        svg.append(f'<line x1="{left}" y1="{top+plot_h}" x2="{left+plot_w}" y2="{top+plot_h}" stroke="#999"/>')
+        svg.append(f'<line x1="{left}" y1="{top}" x2="{left}" y2="{top+plot_h}" stroke="#999"/>')
+        for mode in ["old", "new"]:
+            sub = sorted((r["tile_size"], r["ms"]) for r in rows if r["cluster_size"] == cs and r["mode"] == mode)
+            path = " ".join(
+                ("M" if i == 0 else "L") + f"{sx(x, left):.1f},{sy(y, top):.1f}" for i, (x, y) in enumerate(sub))
+            svg.append(f'<path d="{path}" fill="none" stroke="{colors[mode]}" stroke-width="3"/>')
+            for x, y in sub:
+                svg.append(f'<circle cx="{sx(x, left):.1f}" cy="{sy(y, top):.1f}" r="3.5" fill="{colors[mode]}"/>')
+        if idx == 0:
+            svg.append(f'<rect x="{left+plot_w-150}" y="{top+10}" width="140" height="50" fill="white" stroke="#ddd"/>')
+            svg.append(
+                f'<line x1="{left+160}" y1="{top+28}" x2="{left+190}" y2="{top+28}" stroke="{colors["old"]}" stroke-width="3"/>'
+            )
+            svg.append(f'<text x="{left+198}" y="{top+32}" font-size="12" font-family="sans-serif">old</text>')
+            svg.append(
+                f'<line x1="{left+160}" y1="{top+45}" x2="{left+190}" y2="{top+45}" stroke="{colors["new"]}" stroke-width="3"/>'
+            )
+            svg.append(f'<text x="{left+198}" y="{top+49}" font-size="12" font-family="sans-serif">new</text>')
+    svg.append("</svg>")
+    out_svg.write_text("\n".join(svg))
+
+
+def _run_parent(args):
+    rows = []
+    for cluster_size in _parse_csv_ints(args.cluster_sizes):
+        for tile_size in _parse_csv_ints(args.tile_sizes):
+            for mode in ["old", "new"]:
+                env = os.environ.copy()
+                if mode == "old":
+                    env["TRITON_DISABLE_CLUSTER_REDUCE_BULK"] = "1"
+                else:
+                    env.pop("TRITON_DISABLE_CLUSTER_REDUCE_BULK", None)
+                env["TRITON_CACHE_DIR"] = os.path.join(tempfile.gettempdir(), f"triton_cluster_reduce_vector_{mode}")
+                proc = subprocess.run(
+                    [
+                        sys.executable,
+                        __file__,
+                        "--mode",
+                        mode,
+                        "--cluster-size",
+                        str(cluster_size),
+                        "--tile-size",
+                        str(tile_size),
+                        "--iters",
+                        str(args.iters),
+                        "--warmup",
+                        str(args.warmup),
+                    ],
+                    cwd=os.getcwd(),
+                    env=env,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                line = proc.stdout.strip()
+                print(line)
+                mode_s, cs, ts, ms, ok, bulk, cluster_ld = line.split(",")
+                rows.append({
+                    "mode": mode_s,
+                    "cluster_size": int(cs),
+                    "tile_size": int(ts),
+                    "ms": float(ms),
+                    "ok": int(ok),
+                    "bulk": int(bulk),
+                    "cluster_ld": int(cluster_ld),
+                })
+
+    out_csv = Path(args.out_csv)
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    with out_csv.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["mode", "cluster_size", "tile_size", "ms", "ok", "bulk", "cluster_ld"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+    grouped = {}
+    for r in rows:
+        key = (r["cluster_size"], r["tile_size"])
+        grouped.setdefault(key, {})[r["mode"]] = r
+    summary = []
+    for (cs, ts), modes in sorted(grouped.items()):
+        old = modes["old"]
+        new = modes["new"]
+        delta_ms = new["ms"] - old["ms"]
+        delta_pct = delta_ms / old["ms"] * 100.0
+        summary.append({
+            "cluster_size": cs,
+            "tile_size": ts,
+            "old_ms": old["ms"],
+            "new_ms": new["ms"],
+            "delta_ms": delta_ms,
+            "delta_pct": delta_pct,
+        })
+
+    out_summary = Path(args.out_summary)
+    with out_summary.open("w", newline="") as f:
+        writer = csv.DictWriter(f,
+                                fieldnames=["cluster_size", "tile_size", "old_ms", "new_ms", "delta_ms", "delta_pct"])
+        writer.writeheader()
+        writer.writerows(summary)
+
+    out_svg = Path(args.out_svg)
+    _write_svg(rows, out_svg)
+    print(f"summary_csv={out_summary}")
+    print(f"plot_svg={out_svg}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark vector multi-CTA cluster reduce lowering.")
+    parser.add_argument("--mode", choices=["old", "new", "both"], default="both")
+    parser.add_argument("--cluster-sizes", default="2,4,8,16")
+    parser.add_argument("--tile-sizes", default="64,256,1024,4096,8192,16384")
+    parser.add_argument("--cluster-size", type=int)
+    parser.add_argument("--tile-size", type=int)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--out-csv", default="/tmp/cluster_reduce_vector_results.csv")
+    parser.add_argument("--out-summary", default="/tmp/cluster_reduce_vector_summary.csv")
+    parser.add_argument("--out-svg", default="/tmp/cluster_reduce_vector_summary.svg")
+    args = parser.parse_args()
+
+    if args.mode == "both":
+        _run_parent(args)
+    else:
+        _run_child(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
@@ -43,6 +43,28 @@ struct AllocateSharedMemoryNv
 
 namespace mlir::triton::nvidia_gpu {
 
+static unsigned
+getCrossCTAClusterReducePayloadBytes(triton::ReduceOp reduceOp) {
+  ReduceOpHelper helper(reduceOp);
+  auto *ctx = reduceOp.getContext();
+  auto regLl = ReduceOpHelper::reducedRegLaneLayout(helper.getSrcTy(),
+                                                    reduceOp.getAxis());
+  unsigned regsPerThread = regLl.getInDimSize(StringAttr::get(ctx, "register"));
+  unsigned numThreads = gpu::lookupNumWarps(reduceOp) *
+                        gpu::TritonGPUDialect::getThreadsPerWarp(
+                            reduceOp->getParentOfType<ModuleOp>());
+
+  unsigned payloadBytes = 0;
+  for (Type elemTy : reduceOp.getElementTypes()) {
+    Type memTy = elemTy;
+    if (memTy.isIntOrFloat() && memTy.getIntOrFloatBitWidth() < 8)
+      memTy = IntegerType::get(ctx, 8);
+    payloadBytes +=
+        numThreads * regsPerThread * (getIntOrFloatOrPtrBitWidth(memTy) / 8);
+  }
+  return llvm::alignTo(payloadBytes, 16u);
+}
+
 static unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
                                               RankedTensorType dstTy,
                                               TargetInfoBase &targetInfo) {
@@ -69,6 +91,15 @@ static unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
 std::function<unsigned(Operation *)>
 getNvidiaAllocationAnalysisScratchSizeFn(TargetInfoBase &targetInfo) {
   auto allocation = [&targetInfo](Operation *op) -> unsigned {
+    if (auto reduceOp = dyn_cast<triton::ReduceOp>(op)) {
+      ReduceOpHelper helper(reduceOp);
+      unsigned bytes = helper.getScratchSizeInBytes();
+      if (!helper.isReduceWithinCTA()) {
+        bytes = getCrossCTAClusterReducePayloadBytes(reduceOp);
+        bytes = llvm::alignTo(bytes * 2, 8u) + 8u;
+      }
+      return bytes;
+    }
     if (auto cvtOp = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
       auto srcTy = cvtOp.getSrc().getType();
       auto dstTy = cvtOp.getType();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
@@ -8,6 +8,7 @@ add_triton_library(TritonNVIDIAGPUToLLVM
     DotOpToLLVM.cpp
     ElementwiseOpToLLVM.cpp
     LoadStoreOpToLLVM.cpp
+    ReduceOpToLLVM.cpp
     BarrierOpToLLVM.cpp
     TritonGPUToLLVM.cpp
     TMAToLLVM.cpp

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -53,6 +53,11 @@ void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                        ModuleAxisInfoAnalysis &axisInfoAnalysis,
                                        PatternBenefit benefit);
 
+void populateReduceOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
+                                    const TargetInfo &targetInfo,
+                                    RewritePatternSet &patterns,
+                                    PatternBenefit benefit);
+
 void populateTMAToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                const TargetInfo &targetInfo,
                                RewritePatternSet &patterns,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ReduceOpToLLVM.cpp
@@ -1,0 +1,677 @@
+#include "PatternTritonGPUOpToLLVM.h"
+#include "lib/Conversion/TritonGPUToLLVM/ReduceScanCommon.h"
+
+#include <cstdlib>
+#include <memory>
+#include <numeric>
+#include <tuple>
+#include <utility>
+
+#include "TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
+#include "Utility.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+#include "mlir/Support/LLVM.h"
+#include "triton/Analysis/Allocation.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Tools/LayoutUtils.h"
+#include "llvm/Support/MathExtras.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace ttg = mlir::triton::gpu;
+namespace ttng = mlir::triton::nvidia_gpu;
+
+namespace {
+
+static bool isConstantTruePred(Value pred) {
+  if (auto constOp = pred.getDefiningOp<LLVM::ConstantOp>())
+    return cast<IntegerAttr>(constOp.getValue()).getInt() == -1;
+  return false;
+}
+
+static bool isClusterReduceBulkDisabled() {
+  if (const char *env = std::getenv("TRITON_DISABLE_CLUSTER_REDUCE_BULK"))
+    return env[0] != '\0' && env[0] != '0';
+  return false;
+}
+
+static Value mapaSharedCluster(RewriterBase &rewriter, Location loc, Value ptr,
+                               Value ctaid, Value pred) {
+  auto *ctx = rewriter.getContext();
+  auto clusterPtrTy = ptr_ty(ctx, /*addrspace=*/7);
+  if (isConstantTruePred(pred))
+    return NVVM::MapaOp::create(rewriter, loc, clusterPtrTy, ptr, ctaid);
+
+  PTXBuilder builder;
+  auto &mapaInstr = *builder.create("mapa");
+  mapaInstr.o("shared::cluster.u32");
+  auto *dstOpr = builder.newOperand("=r");
+  auto *ptrOpr = builder.newOperand(ptr, "r");
+  auto *ctaidOpr = builder.newOperand(ctaid, "r");
+  mapaInstr(dstOpr, ptrOpr, ctaidOpr).predicate(pred, "b");
+  return builder.launch(rewriter, loc, clusterPtrTy, /*hasSideEffect=*/false);
+}
+
+struct ReduceOpConversion
+    : public ConvertTritonGPUReduceScanToLLVMPattern<triton::ReduceOp> {
+  ReduceOpConversion(LLVMTypeConverter &typeConverter,
+                     const NVIDIA::TargetInfo &targetInfo,
+                     PatternBenefit benefit)
+      : ConvertTritonGPUReduceScanToLLVMPattern<triton::ReduceOp>(typeConverter,
+                                                                  benefit),
+        targetInfo(targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(triton::ReduceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (targetInfo.getComputeCapability() < 90 || isClusterReduceBulkDisabled())
+      return failure();
+
+    ReduceOpHelper helper(op);
+    Location loc = op.getLoc();
+    auto accs = unpackInputs(loc, op, adaptor, rewriter);
+    unsigned axis = op.getAxis();
+    auto *ctx = op.getContext();
+
+    LinearLayout regLl = triton::gpu::toLinearLayout(helper.getSrcTy());
+    auto removeBroadcast = actionRemoveBroadcastedRegs(regLl);
+    if (!removeBroadcast.isIdentity()) {
+      regLl = removeBroadcast.apply(regLl);
+      for (auto &vals : accs)
+        vals = removeBroadcast.apply(vals);
+    }
+
+    std::tie(regLl, accs) =
+        reduceWithinThreads(op, std::move(regLl), std::move(accs), rewriter);
+    std::tie(regLl, accs) =
+        reduceWithinWarps(op, std::move(regLl), std::move(accs), rewriter);
+
+    assert(regLl ==
+           ReduceOpHelper::reducedRegLaneLayout(helper.getSrcTy(), axis));
+
+    auto kAxis = *(regLl.getOutDimNames().begin() + axis);
+    auto kBlock = StringAttr::get(ctx, "block");
+    bool lastCvtCrossesCTAs = false;
+    while (regLl.getOutDimSize(kAxis) != 1) {
+      if (hasAxisBlockBasesOnly(regLl, axis)) {
+        if (!llvm::isPowerOf2_32(ttg::lookupNumCTAs(op)))
+          return failure();
+        std::tie(regLl, accs) =
+            reduceAcrossCTAs(op, std::move(regLl), std::move(accs), rewriter);
+        lastCvtCrossesCTAs = true;
+        continue;
+      }
+
+      LinearLayout tmpLl = ReduceOpHelper::getInterLayout(regLl, axis);
+      if (!mlir::isCvtDimSync(regLl, tmpLl, kBlock))
+        return failure();
+      accs = convertLayoutValues(loc, rewriter, op, regLl, tmpLl, accs);
+      std::tie(regLl, accs) =
+          reduceWithinWarps(op, std::move(tmpLl), std::move(accs), rewriter);
+    }
+
+    regLl = removeStandardDim(regLl, axis);
+    if (auto resultTy =
+            dyn_cast<RankedTensorType>(op.getResult()[0].getType())) {
+      auto outputLayout = triton::gpu::toLinearLayout(resultTy);
+      if (regLl != outputLayout) {
+        sync(rewriter, loc, lastCvtCrossesCTAs);
+        accs =
+            convertLayoutValues(loc, rewriter, op, regLl, outputLayout, accs);
+      }
+    }
+
+    packResults(op, accs, rewriter);
+    return success();
+  }
+
+private:
+  const NVIDIA::TargetInfo &targetInfo;
+
+  struct SegmentInfo {
+    Type elemTy;
+    unsigned bitWidth;
+    unsigned regsPerThread;
+    unsigned bytesPerThread;
+    unsigned offsetBytes;
+  };
+
+  static bool hasAxisBases(const LinearLayout &layout, StringAttr dim,
+                           unsigned axis) {
+    auto it = layout.getBases().find(dim);
+    if (it == layout.getBases().end())
+      return false;
+    return llvm::any_of(it->second,
+                        [axis](const auto &basis) { return basis[axis] != 0; });
+  }
+
+  static bool hasAxisBlockBasesOnly(const LinearLayout &layout, unsigned axis) {
+    auto *ctx = layout.getOutDimNames().begin()->getContext();
+    auto kWarp = StringAttr::get(ctx, "warp");
+    auto kBlock = StringAttr::get(ctx, "block");
+    return hasAxisBases(layout, kBlock, axis) &&
+           !hasAxisBases(layout, kWarp, axis);
+  }
+
+  static Type getReduceMemElemTy(Type elemTy, MLIRContext *ctx) {
+    if (elemTy.isIntOrFloat() && elemTy.getIntOrFloatBitWidth() < 8)
+      return IntegerType::get(ctx, 8);
+    return elemTy;
+  }
+
+  SmallVector<SmallVector<Value>>
+  unpackInputs(Location loc, triton::ReduceOp op, OpAdaptor adaptor,
+               ConversionPatternRewriter &rewriter) const {
+    SmallVector<SmallVector<Value>> srcValues(op.getNumOperands());
+    for (unsigned i = 0; i < op.getNumOperands(); ++i)
+      srcValues[i] = unpackLLElements(loc, adaptor.getOperands()[i], rewriter);
+    return srcValues;
+  }
+
+  void sync(ConversionPatternRewriter &rewriter, Location loc,
+            bool crossCTA) const {
+    if (crossCTA)
+      targetInfo.clusterBarrier(loc, rewriter);
+    else
+      targetInfo.barrier(loc, rewriter, ttg::AddrSpace::Local);
+  }
+
+  SmallVector<Value> treeReduce(Location loc,
+                                ConversionPatternRewriter &rewriter,
+                                Region &combineOp,
+                                SmallVector<SmallVector<Value>> values,
+                                unsigned arity) const {
+    while (values.size() > 1) {
+      SmallVector<SmallVector<Value>> next;
+      for (size_t i = 0; i < values.size(); i += arity) {
+        size_t remaining = values.size() - i;
+        size_t groupSize = std::min(static_cast<size_t>(arity), remaining);
+        if (groupSize == 1) {
+          next.push_back(std::move(values[i]));
+        } else {
+          SmallVector<Value> acc = std::move(values[i]);
+          for (size_t j = 1; j < groupSize; ++j)
+            accumulate(loc, rewriter, combineOp, acc, values[i + j]);
+          next.push_back(std::move(acc));
+        }
+      }
+      values = std::move(next);
+    }
+    return values.front();
+  }
+
+  void accumulate(Location loc, ConversionPatternRewriter &rewriter,
+                  Region &combineOp, SmallVector<Value> &acc, ValueRange cur,
+                  Value pred = {}) const {
+    auto results = applyCombineOp(loc, rewriter, combineOp, acc, cur, pred);
+    if (acc.size() < results.size())
+      acc.resize(results.size());
+    for (unsigned i = 0; i < acc.size(); ++i)
+      acc[i] = results[i];
+  }
+
+  void packVectorized(SmallVector<SmallVector<Value>> &accs,
+                      ConversionPatternRewriter &rewriter) const {
+    auto loc = accs.front().front().getLoc();
+    for (auto &acc : accs) {
+      SmallVector<Value> packedAcc;
+      for (unsigned reg = 0; reg < acc.size(); reg += 2)
+        packedAcc.emplace_back(
+            packLLVector(loc, {acc[reg], acc[reg + 1]}, rewriter));
+      acc = std::move(packedAcc);
+    }
+  }
+
+  std::unique_ptr<Region> createVectorCombineRegion(
+      Location loc, Type elemTy,
+      ReduceOpHelper::InThreadVectorizeOpKind vectorizeKind,
+      ConversionPatternRewriter &rewriter) const {
+    if (vectorizeKind == ReduceOpHelper::InThreadVectorizeOpKind::None)
+      return nullptr;
+    auto vecTy = vec_ty(elemTy, 2);
+    auto storage = std::make_unique<Region>();
+    auto *block = new Block();
+    storage->push_back(block);
+    block->addArgument(vecTy, loc);
+    block->addArgument(vecTy, loc);
+    OpBuilder builder(rewriter.getContext());
+    builder.setInsertionPointToStart(block);
+    Value result = ReduceOpHelper::createInThreadVectorizedCombineOp(
+        builder, loc, vectorizeKind, block->getArgument(0),
+        block->getArgument(1));
+    triton::ReduceReturnOp::create(builder, loc, ValueRange{result});
+    return storage;
+  }
+
+  void unpackVectorized(Location loc, SmallVector<SmallVector<Value>> &accs,
+                        ConversionPatternRewriter &rewriter,
+                        Region *reduction) const {
+    for (auto &acc : accs) {
+      SmallVector<Value> unpacked;
+      for (Value val : acc) {
+        auto elems = unpackLLVector(loc, val, rewriter);
+        if (reduction) {
+          SmallVector<Value> cur = {elems[0]};
+          accumulate(loc, rewriter, *reduction, cur, {elems[1]});
+          unpacked.emplace_back(cur[0]);
+        } else {
+          unpacked.emplace_back(elems[0]);
+          unpacked.emplace_back(elems[1]);
+        }
+      }
+      acc = std::move(unpacked);
+    }
+  }
+
+  std::pair<LinearLayout, SmallVector<SmallVector<Value>>>
+  reduceWithinThreads(triton::ReduceOp op, LinearLayout layout,
+                      SmallVector<SmallVector<Value>> accs,
+                      ConversionPatternRewriter &rewriter) const {
+    auto loc = op.getLoc();
+    auto *ctx = op.getContext();
+    unsigned axis = op.getAxis();
+    auto kReg = str_attr("register");
+    auto linearAttr = triton::gpu::LinearEncodingAttr::get(ctx, layout);
+    auto basesPerDim = linearAttr.basesPerDim(kReg, /*skipBroadcast=*/true);
+    unsigned axisPack = basesPerDim[axis];
+    if (axisPack == 1)
+      return {std::move(layout), std::move(accs)};
+
+    ReduceOpHelper helper(op);
+    auto vectorizeKind = helper.getInThreadVectorizeOpKind(
+        axisPack, targetInfo.supportBitwidth16Elementwise(),
+        targetInfo.supportBitwidth32Elementwise());
+    bool vectorize =
+        vectorizeKind != ReduceOpHelper::InThreadVectorizeOpKind::None;
+    auto perm = ReduceOpHelper::moveAxisBasesToFront(layout, axis, vectorize);
+    if (!perm.isIdentity()) {
+      layout = perm.apply(layout);
+      for (auto &vals : accs)
+        vals = perm.apply(vals);
+    }
+    if (vectorize)
+      packVectorized(accs, rewriter);
+
+    const auto &regBases = layout.getBases().lookup(kReg);
+    bool packAlongAxis = vectorize && regBases.front()[axis] != 0;
+    if (packAlongAxis)
+      axisPack /= 2;
+
+    auto elemTy =
+        cast<RankedTensorType>(op.getOperandTypes().front()).getElementType();
+    std::unique_ptr<Region> vectorCombineRegion =
+        createVectorCombineRegion(loc, elemTy, vectorizeKind, rewriter);
+    Region &combineRegion =
+        vectorCombineRegion ? *vectorCombineRegion : op.getCombineOp();
+    Operation &combinerOp = combineRegion.front().front();
+    unsigned arity = targetInfo.getReductionTreeArity(&combinerOp);
+
+    unsigned numOperands = accs.size();
+    SmallVector<SmallVector<Value>> reduced(numOperands);
+    unsigned regs = accs.front().size();
+    for (unsigned regBase = 0; regBase < regs; regBase += axisPack) {
+      SmallVector<SmallVector<Value>> vals;
+      for (unsigned i = 0; i < axisPack; ++i) {
+        SmallVector<Value> cur(numOperands);
+        for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx)
+          cur[opIdx] = accs[opIdx][regBase + i];
+        vals.push_back(std::move(cur));
+      }
+      auto acc =
+          treeReduce(loc, rewriter, combineRegion, std::move(vals), arity);
+      for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx)
+        reduced[opIdx].push_back(acc[opIdx]);
+    }
+    accs = std::move(reduced);
+
+    if (vectorize) {
+      Region *reduceAfterUnpacking =
+          packAlongAxis ? &op.getCombineOp() : nullptr;
+      unpackVectorized(loc, accs, rewriter, reduceAfterUnpacking);
+    }
+
+    layout = ReduceOpHelper::zeroBasesAlongDimAndReorder(layout, axis, kReg);
+    layout = actionRemoveBroadcastedRegs(layout).apply(layout);
+    return {std::move(layout), std::move(accs)};
+  }
+
+  std::pair<LinearLayout, SmallVector<SmallVector<Value>>>
+  reduceWithinWarps(triton::ReduceOp op, LinearLayout layout,
+                    SmallVector<SmallVector<Value>> accs,
+                    ConversionPatternRewriter &rewriter) const {
+    auto *ctx = op.getContext();
+    auto kLane = str_attr("lane");
+    const auto &laneBases = layout.getBases().lookup(kLane);
+    unsigned reduceLaneIdMask = 0;
+    for (unsigned bit = 0; bit < laneBases.size(); ++bit) {
+      if (laneBases[bit][op.getAxis()] != 0)
+        reduceLaneIdMask |= 1u << bit;
+    }
+    if (reduceLaneIdMask == 0)
+      return {std::move(layout), std::move(accs)};
+
+    unsigned regs = accs.front().size();
+    for (unsigned reg = 0; reg < regs; ++reg) {
+      SmallVector<Value> acc(op.getNumOperands());
+      for (unsigned i = 0; i < op.getNumOperands(); ++i)
+        acc[i] = accs[i][reg];
+      warpReduce(op, reduceLaneIdMask, acc, rewriter);
+      for (unsigned i = 0; i < op.getNumOperands(); ++i)
+        accs[i][reg] = acc[i];
+    }
+
+    layout = ReduceOpHelper::zeroBasesAlongDimAndReorder(layout, op.getAxis(),
+                                                         kLane);
+    return {std::move(layout), std::move(accs)};
+  }
+
+  void warpReduce(triton::ReduceOp op, unsigned reduceLaneIdMask,
+                  SmallVector<Value> &acc,
+                  ConversionPatternRewriter &rewriter) const {
+    if (reduceLaneIdMask == 0)
+      return;
+    auto moduleOp = op->getParentOfType<ModuleOp>();
+    unsigned warpSize = ttg::TritonGPUDialect::getThreadsPerWarp(moduleOp);
+    if (targetInfo.warpReduce(rewriter, op.getLoc(), acc, op, reduceLaneIdMask))
+      return;
+    for (int bit = llvm::Log2_32(warpSize) - 1; bit >= 0; --bit) {
+      unsigned mask = 1u << bit;
+      if ((reduceLaneIdMask & mask) == 0)
+        continue;
+      SmallVector<Value> shfl(op.getNumOperands());
+      for (unsigned i = 0; i < op.getNumOperands(); ++i)
+        shfl[i] = targetInfo.shuffleXor(rewriter, op.getLoc(), acc[i], mask);
+      accumulate(op.getLoc(), rewriter, op.getCombineOp(), acc, shfl);
+    }
+  }
+
+  void packResults(triton::ReduceOp op, SmallVector<SmallVector<Value>> &accs,
+                   ConversionPatternRewriter &rewriter) const {
+    Location loc = op.getLoc();
+    SmallVector<Value> results(op.getNumOperands());
+    for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+      if (auto resultTy =
+              dyn_cast<RankedTensorType>(op.getResult()[i].getType()))
+        results[i] = packLLElements(loc, getTypeConverter(), accs[i], rewriter,
+                                    resultTy);
+      else
+        results[i] = accs[i].front();
+    }
+    rewriter.replaceOp(op, results);
+  }
+
+  SmallVector<int64_t> getSmemBaseOffsets(triton::ReduceOp op,
+                                          const LinearLayout &srcLayout,
+                                          const LinearLayout &dstLayout) const {
+    std::vector<unsigned> indices(op.getNumOperands());
+    std::iota(indices.begin(), indices.end(), 0);
+    auto *ctx = op.getContext();
+    std::sort(indices.begin(), indices.end(), [&](unsigned i, unsigned j) {
+      auto lhsTy = getReduceMemElemTy(op.getElementTypes()[i], ctx);
+      auto rhsTy = getReduceMemElemTy(op.getElementTypes()[j], ctx);
+      return getIntOrFloatOrPtrBitWidth(lhsTy) >
+             getIntOrFloatOrPtrBitWidth(rhsTy);
+    });
+    SmallVector<int64_t> offsets(op.getNumOperands());
+    int64_t offset = 0;
+    for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+      unsigned idx = indices[i];
+      offsets[idx] = offset;
+      auto inputTy = op.getInputTypes()[idx];
+      auto bytes = getNumScratchElemsSwizzledCvt(srcLayout, dstLayout,
+                                                 getBitwidth(inputTy)) *
+                   (getBitwidth(inputTy) / 8);
+      offset += bytes;
+    }
+    return offsets;
+  }
+
+  SmallVector<SmallVector<Value>>
+  convertLayoutValues(Location loc, ConversionPatternRewriter &rewriter,
+                      triton::ReduceOp op, const LinearLayout &srcLayout,
+                      const LinearLayout &dstLayout,
+                      const SmallVector<SmallVector<Value>> &inVals) const {
+    SmallVector<SmallVector<Value>> outVals(op.getNumOperands());
+    auto *ctx = rewriter.getContext();
+    SmallVector<int64_t> shape;
+    for (auto dim : srcLayout.getOutDimNames())
+      shape.push_back(srcLayout.getOutDimSize(dim));
+    auto srcEnc = triton::gpu::LinearEncodingAttr::get(ctx, srcLayout);
+    auto dstEnc = triton::gpu::LinearEncodingAttr::get(ctx, dstLayout);
+    auto baseOffsetAttr = op->getAttrOfType<IntegerAttr>("allocation.offset");
+    int64_t baseOffset = baseOffsetAttr.getValue().getZExtValue();
+    auto smemBaseOffsets = getSmemBaseOffsets(op, srcLayout, dstLayout);
+    auto offsetTy = IntegerType::get(ctx, 32);
+    for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+      auto elemTy = op.getElementTypes()[i];
+      auto srcTy = RankedTensorType::get(shape, elemTy, srcEnc);
+      auto dstTy = RankedTensorType::get(shape, elemTy, dstEnc);
+      Value packed =
+          packLLElements(loc, getTypeConverter(), inVals[i], rewriter, srcTy);
+      auto srcTensor =
+          UnrealizedConversionCastOp::create(rewriter, loc, srcTy, packed)
+              .getResult(0);
+      auto cvt = ttg::ConvertLayoutOp::create(rewriter, loc, dstTy, srcTensor);
+      cvt->setAttr("allocation.offset",
+                   IntegerAttr::get(offsetTy, baseOffset + smemBaseOffsets[i]));
+      Type packedDstTy = getTypeConverter()->convertType(dstTy);
+      auto packedDst = UnrealizedConversionCastOp::create(
+                           rewriter, loc, packedDstTy, cvt.getResult())
+                           .getResult(0);
+      outVals[i] = unpackLLElements(loc, packedDst, rewriter);
+    }
+    return outVals;
+  }
+
+  SmallVector<SegmentInfo>
+  getSegmentInfos(triton::ReduceOp op,
+                  const SmallVector<SmallVector<Value>> &accs,
+                  unsigned numThreads) const {
+    auto *ctx = op.getContext();
+    SmallVector<SegmentInfo> infos;
+    unsigned offset = 0;
+    for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+      Type elemTy = getReduceMemElemTy(op.getElementTypes()[i], ctx);
+      unsigned bitWidth = getIntOrFloatOrPtrBitWidth(elemTy);
+      unsigned regsPerThread = accs[i].size();
+      unsigned bytesPerThread = regsPerThread * bitWidth / 8;
+      infos.push_back(
+          {elemTy, bitWidth, regsPerThread, bytesPerThread, offset});
+      offset += numThreads * bytesPerThread;
+    }
+    return infos;
+  }
+
+  std::pair<LinearLayout, SmallVector<SmallVector<Value>>>
+  reduceAcrossCTAs(triton::ReduceOp op, LinearLayout layout,
+                   SmallVector<SmallVector<Value>> accs,
+                   ConversionPatternRewriter &rewriter) const {
+    auto loc = op.getLoc();
+    auto *ctx = op.getContext();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    unsigned numThreads =
+        ttg::lookupNumWarps(op) * ttg::lookupThreadsPerWarp(rewriter);
+    unsigned numCTAs = ttg::lookupNumCTAs(op);
+    auto segments = getSegmentInfos(op, accs, numThreads);
+    unsigned payloadBytes = 0;
+    for (const auto &seg : segments)
+      payloadBytes = std::max(
+          payloadBytes, seg.offsetBytes + numThreads * seg.bytesPerThread);
+    payloadBytes = llvm::alignTo(payloadBytes, 16u);
+    unsigned dstOffset = payloadBytes;
+    unsigned barrierOffset = llvm::alignTo(payloadBytes * 2, 8u);
+
+    Value base =
+        LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
+    auto smemPtrTy =
+        ptr_ty(rewriter.getContext(), targetInfo.getSharedAddressSpace());
+    Value srcBase = base;
+    Value dstBase = b.gep(smemPtrTy, i8_ty, base, b.i32_val(dstOffset),
+                          LLVM::GEPNoWrapFlags::inbounds);
+    Value barrierPtr = b.gep(smemPtrTy, i8_ty, base, b.i32_val(barrierOffset),
+                             LLVM::GEPNoWrapFlags::inbounds);
+
+    Value tid = getThreadId(rewriter, loc);
+    Value thread0 = b.icmp_eq(tid, b.i32_val(0));
+    Value clusterId = targetInfo.getClusterCTAId(rewriter, loc);
+
+    unsigned numStages = llvm::Log2_32(numCTAs);
+    for (unsigned stage = 0; stage < numStages; ++stage) {
+      storeAccsToScratch(loc, rewriter, srcBase, segments, tid, accs);
+      targetInfo.clusterBarrier(loc, rewriter);
+
+      emitMBarrierInit(rewriter, loc, barrierPtr, thread0);
+      ttng::FenceMBarrierInitReleaseClusterOp::create(rewriter, loc);
+      ttng::ClusterBarrierOp::create(rewriter, loc, /*relaxed=*/true);
+
+      emitMBarrierExpect(rewriter, loc, barrierPtr, thread0, payloadBytes);
+      Value peer = b.xor_(clusterId, b.i32_val(1u << stage));
+      Value remoteDst =
+          mapaSharedCluster(rewriter, loc, dstBase, peer, thread0);
+      Value remoteBarrier =
+          mapaSharedCluster(rewriter, loc, barrierPtr, peer, thread0);
+      emitBulkCopy(rewriter, loc, thread0, remoteDst, srcBase, payloadBytes,
+                   remoteBarrier);
+      emitMBarrierWait(rewriter, loc, barrierPtr, /*phase=*/0);
+
+      auto peerVals =
+          loadAccsFromScratch(loc, rewriter, dstBase, segments, tid, accs);
+      for (unsigned operand = 0; operand < accs.size(); ++operand) {
+        for (unsigned reg = 0; reg < accs[operand].size(); ++reg) {
+          SmallVector<Value> cur = {peerVals[operand][reg]};
+          SmallVector<Value> accum = {accs[operand][reg]};
+          accumulate(loc, rewriter, op.getCombineOp(), accum, cur);
+          accs[operand][reg] = accum[0];
+        }
+      }
+      targetInfo.clusterBarrier(loc, rewriter);
+    }
+
+    layout = ReduceOpHelper::zeroBasesAlongDimAndReorder(layout, op.getAxis(),
+                                                         str_attr("block"));
+    layout = actionRemoveBroadcastedRegs(layout).apply(layout);
+    return {std::move(layout), std::move(accs)};
+  }
+
+  void storeAccsToScratch(Location loc, ConversionPatternRewriter &rewriter,
+                          Value base, ArrayRef<SegmentInfo> segments, Value tid,
+                          const SmallVector<SmallVector<Value>> &accs) const {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto smemPtrTy =
+        ptr_ty(rewriter.getContext(), targetInfo.getSharedAddressSpace());
+    for (unsigned operand = 0; operand < segments.size(); ++operand) {
+      const auto &seg = segments[operand];
+      for (unsigned reg = 0; reg < seg.regsPerThread; ++reg) {
+        Value linear =
+            b.add(b.mul(tid, b.i32_val(seg.regsPerThread)), b.i32_val(reg));
+        Value byteOff = b.add(b.i32_val(seg.offsetBytes),
+                              b.mul(linear, b.i32_val(seg.bitWidth / 8)));
+        Value ptr = b.gep(smemPtrTy, i8_ty, base, byteOff,
+                          LLVM::GEPNoWrapFlags::inbounds);
+        targetInfo.storeShared(rewriter, loc, ptr, accs[operand][reg],
+                               b.true_val());
+      }
+    }
+  }
+
+  SmallVector<SmallVector<Value>> loadAccsFromScratch(
+      Location loc, ConversionPatternRewriter &rewriter, Value base,
+      ArrayRef<SegmentInfo> segments, Value tid,
+      const SmallVector<SmallVector<Value>> &accsTemplate) const {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto smemPtrTy =
+        ptr_ty(rewriter.getContext(), targetInfo.getSharedAddressSpace());
+    SmallVector<SmallVector<Value>> loaded(accsTemplate.size());
+    for (unsigned operand = 0; operand < segments.size(); ++operand) {
+      const auto &seg = segments[operand];
+      loaded[operand].reserve(seg.regsPerThread);
+      for (unsigned reg = 0; reg < seg.regsPerThread; ++reg) {
+        Value linear =
+            b.add(b.mul(tid, b.i32_val(seg.regsPerThread)), b.i32_val(reg));
+        Value byteOff = b.add(b.i32_val(seg.offsetBytes),
+                              b.mul(linear, b.i32_val(seg.bitWidth / 8)));
+        Value ptr = b.gep(smemPtrTy, i8_ty, base, byteOff,
+                          LLVM::GEPNoWrapFlags::inbounds);
+        loaded[operand].push_back(targetInfo.loadShared(
+            rewriter, loc, ptr, accsTemplate[operand][reg].getType(),
+            b.true_val()));
+      }
+    }
+    return loaded;
+  }
+
+  void emitMBarrierInit(ConversionPatternRewriter &rewriter, Location loc,
+                        Value barrierPtr, Value pred) const {
+    PTXBuilder ptxBuilder;
+    auto &op = *ptxBuilder.create("@$0 mbarrier.init.shared::cta.b64 [$1], 1;");
+    op({ptxBuilder.newOperand(pred, "b"),
+        ptxBuilder.newAddrOperand(barrierPtr, "r")},
+       /*onlyAttachMLIRArgs=*/true);
+    ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
+  }
+
+  void emitMBarrierExpect(ConversionPatternRewriter &rewriter, Location loc,
+                          Value barrierPtr, Value pred, unsigned bytes) const {
+    PTXBuilder ptxBuilder;
+    std::string ptx =
+        "@$0 mbarrier.arrive.expect_tx.shared::cta.b64 _, [$1], " +
+        std::to_string(bytes) + ";";
+    auto &op = *ptxBuilder.create(ptx);
+    op({ptxBuilder.newOperand(pred, "b"),
+        ptxBuilder.newAddrOperand(barrierPtr, "r")},
+       /*onlyAttachMLIRArgs=*/true);
+    ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
+  }
+
+  void emitBulkCopy(ConversionPatternRewriter &rewriter, Location loc,
+                    Value pred, Value remoteDst, Value localSrc, unsigned bytes,
+                    Value remoteBarrier) const {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    PTXBuilder ptxBuilder;
+    auto ptx = "@$0 cp.async.bulk.shared::cluster.shared::cta"
+               ".mbarrier::complete_tx::bytes [$1], [$2], $3, [$4];";
+    auto &copy = *ptxBuilder.create(ptx);
+    SmallVector<PTXBuilder::Operand *> operands{
+        ptxBuilder.newOperand(pred, "b"),
+        ptxBuilder.newAddrOperand(b.ptrtoint(i32_ty, remoteDst), "r"),
+        ptxBuilder.newAddrOperand(b.ptrtoint(i32_ty, localSrc), "r"),
+        ptxBuilder.newOperand(b.i32_val(bytes), "r"),
+        ptxBuilder.newAddrOperand(b.ptrtoint(i32_ty, remoteBarrier), "r")};
+    copy(operands, /*onlyAttachMLIRArgs=*/true);
+    ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
+  }
+
+  void emitMBarrierWait(ConversionPatternRewriter &rewriter, Location loc,
+                        Value barrierPtr, unsigned phase) const {
+    std::string ptx = R"(
+{
+  .reg .pred complete;
+waitLoop:
+  mbarrier.try_wait.parity.shared::cta.b64 complete, [$0], )" +
+                      std::to_string(phase) + R"(;
+  @!complete bra.uni waitLoop;
+}
+)";
+    PTXBuilder ptxBuilder;
+    auto &wait = *ptxBuilder.create(ptx);
+    wait({ptxBuilder.newAddrOperand(barrierPtr, "r")},
+         /*onlyAttachMLIRArgs=*/true);
+    ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
+  }
+};
+
+} // namespace
+
+void mlir::triton::NVIDIA::populateReduceOpToLLVMPatterns(
+    LLVMTypeConverter &typeConverter, const TargetInfo &targetInfo,
+    RewritePatternSet &patterns, PatternBenefit benefit) {
+  patterns.add<ReduceOpConversion>(typeConverter, targetInfo, benefit);
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -166,6 +166,8 @@ struct ConvertTritonGPUToLLVM
     populateLoadStoreOpToLLVMPatterns(typeConverter, targetInfo,
                                       computeCapability, patterns,
                                       axisInfoAnalysis, benefit);
+    mlir::triton::NVIDIA::populateReduceOpToLLVMPatterns(
+        typeConverter, targetInfo, patterns, benefit + 1);
     mlir::triton::populateReduceOpToLLVMPatterns(typeConverter, patterns,
                                                  targetInfo, benefit);
     mlir::triton::populateScanOpToLLVMPatterns(typeConverter, patterns,


### PR DESCRIPTION
### Description
This PR adds an SM90+ fast path for multi-CTA ```ReduceOp``` lowering that uses ```cp.async.bulk.shared::cluster.shared::cta``` with ```mbarrier``` control flow, while preserving the existing lowering as fallback.

### What changed

- Adds a NVIDIA-specific ```ReduceOp``` lowering path.
- Lowers multi-CTA cluster-reduce through packed shared payload + bulk cluster copy.
- Keeps generic reduce lowering as fallback.
- Reserves the required shared-memory scratch payload for the new path.
- Adds correctness coverage for the vector cluster-reduce case.
- Adds a benchmark script that compares old vs new lowering and emits CSV/SVG summaries.
### Scope / limitations

- Scoped to SM90+ and multi-CTA cluster-reduce only.
- Requires num_ctas to be power-of-two for the current doubling-style communication schedule.
- General path remains unchanged for unsupported cases.
### Validation

- ```PYTHONPATH=./python pytest -s --tb=short python/test/gluon/test_lowerings.py::test_cluster_reduce_bulk_copy_vector```
- Benchmark script: ```python/test/microbenchmark/bench_cluster_reduce.py```
### Benchmark artifacts

- CSV: ```/tmp/cluster_reduce_vector_summary.csv```
- Markdown table: ```/tmp/cluster_reduce_vector_summary.md```
- Plot: ```/tmp/cluster_reduce_vector_summary.svg```

TEST on H800:

| cluster_size | tile_size | old_ms | new_ms | delta_ms | delta_pct |
|---:|---:|---:|---:|---:|---:|
| 2 | 64 | 0.007397 | 0.006573 | -0.000824 | -11.14% |
| 2 | 256 | 0.007234 | 0.007061 | -0.000173 | -2.39% |
| 2 | 1024 | 0.008650 | 0.007189 | -0.001461 | -16.89% |
| 2 | 4096 | 0.015794 | 0.008871 | -0.006923 | -43.83% |
| 2 | 8192 | 0.025019 | 0.010939 | -0.014080 | -56.28% |
| 2 | 16384 | 0.044161 | 0.014879 | -0.029282 | -66.31% |
| 4 | 64 | 0.006940 | 0.007615 | +0.000675 | +9.73% |
| 4 | 256 | 0.007249 | 0.007813 | +0.000564 | +7.78% |
| 4 | 1024 | 0.008297 | 0.008443 | +0.000146 | +1.76% |
| 4 | 4096 | 0.014812 | 0.011635 | -0.003177 | -21.45% |
| 4 | 8192 | 0.023600 | 0.015123 | -0.008477 | -35.92% |
| 4 | 16384 | 0.041707 | 0.022116 | -0.019591 | -46.97% |
| 8 | 64 | 0.007508 | 0.008916 | +0.001408 | +18.75% |
| 8 | 256 | 0.007396 | 0.008898 | +0.001502 | +20.31% |
| 8 | 1024 | 0.009094 | 0.009529 | +0.000435 | +4.78% |
| 8 | 4096 | 0.016044 | 0.015057 | -0.000987 | -6.15% |
| 8 | 8192 | 0.026825 | 0.019724 | -0.007101 | -26.47% |
| 8 | 16384 | 0.048020 | 0.029882 | -0.018138 | -37.77% |
| 16 | 64 | 0.007632 | 0.010217 | +0.002585 | +33.87% |
| 16 | 256 | 0.007950 | 0.010494 | +0.002544 | +32.00% |
| 16 | 1024 | 0.010430 | 0.011274 | +0.000844 | +8.09% |
| 16 | 4096 | 0.019712 | 0.018788 | -0.000924 | -4.69% |
| 16 | 8192 | 0.033114 | 0.025345 | -0.007769 | -23.46% |
| 16 | 16384 | 0.058318 | 0.038396 | -0.019922 | -34.16% |

Performance degrades slightly on small shapes, but the absolute impact is marginal and acceptable.
Meanwhile, the performance gain is quite significant on large shapes.