### PR TITLE
Fix WarpSpecialization heuristic bugs and style inconsistencies

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -202,7 +202,7 @@ std::unique_ptr<Graph> buildGraph(Operation *region) {
     for (auto &use : value.getUses()) {
       auto op = use.getOwner();
       auto key = std::make_pair(op, use.getOperandNumber());
-      if (operands.find(key) != operands.end()) {
+      if (operands.contains(key)) {
         auto inputPort = operands[key];
         Node::addEdge(outputPort, inputPort);
       }
@@ -303,7 +303,7 @@ SmallVector<Edge> getOutCrossingEdges(Partition *partition) {
 }
 
 void deserializeManualPartitions(Operation *region, Graph *graph) {
-  std::map<int, Partition *> manual_partitions;
+  DenseMap<int, Partition *> manual_partitions;
   graph->walk([&](Node *node) {
     if (node->isOp()) {
       auto op = node->getOp();
@@ -312,7 +312,7 @@ void deserializeManualPartitions(Operation *region, Graph *graph) {
             cast<DenseI32ArrayAttr>(op->getAttr(kPartitionAttrName))
                 .asArrayRef();
         for (auto id : partitionIds) {
-          if (manual_partitions.find(id) == manual_partitions.end()) {
+          if (!manual_partitions.contains(id)) {
             auto partition = graph->addPartition();
             partition->addFlag(Flags::MANUAL);
             manual_partitions[id] = partition;
@@ -528,6 +528,7 @@ SmallVector<std::pair<std::string, std::function<bool(Edge)>>> heuristics = {
        auto to = edge.getToNode();
        if (!isMMA(from)) {
          // skip if not from an MMA
+         return false;
        }
        if (!isIfResult(to))
          // skip if not to an if op result
@@ -1133,7 +1134,7 @@ void duplicateCheapOps(Graph *graph, std::string funcName,
         continue;
 
       auto update = [&]() {
-        std::map<Node *, Node *> parentMap;
+        DenseMap<Node *, Node *> parentMap;
 
         SmallVector<Node *> stack;
         stack.push_back(start);
@@ -1155,7 +1156,7 @@ void duplicateCheapOps(Graph *graph, std::string funcName,
                 } else if (child->getPartition() == startPartition) {
                   // found a path, set all nodes on the path to the partition
                   node->addPartition(startPartition);
-                  while (parentMap.find(node) != parentMap.end()) {
+                  while (parentMap.contains(node)) {
                     node = parentMap[node];
                     node->addPartition(startPartition);
                   }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionScheduling.cpp
@@ -1151,7 +1151,7 @@ void duplicateCheapOps(Graph *graph, std::string funcName,
                 if (child->getPartitions().size() != 1 || !isCandidate(child)) {
                   // do nothing
                 } else if (child->getPartition() == partition) {
-                  parentMap.emplace(child, node);
+                  parentMap.try_emplace(child, node);
                   stack.push_back(child);
                 } else if (child->getPartition() == startPartition) {
                   // found a path, set all nodes on the path to the partition


### PR DESCRIPTION
## Summary

Addresses several issues in PartitionScheduling WarpSpecialization heuristics reported in #9853:

1. **Bug fix**: `if_op_result_token` heuristic had empty body after `!isMMA(from)` guard — added missing `return false` so non-MMA nodes are correctly skipped
2. **Style**: Replaced `std::map` with `DenseMap` (2 occurrences) to align with codebase convention
3. **Modernization**: Replaced `.find() != .end()` / `.find() == .end()` with `.contains()` (3 occurrences)

## Test plan
- [ ] Existing lit tests pass
- [ ] CI passes

Fixes #9853