### PR TITLE
[BACKEND] Recognise fneg in clamp and use it in the MoE

### DIFF
--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -470,7 +470,7 @@ def store_packed_out(
 def _swiglu_step1(acc_packed, limit):
     gelu, linear = float2.unpack2(acc_packed)
     gelu = gl.minimum(gelu.to(gl.float32), limit)
-    linear = gl.minimum(gl.maximum(linear.to(gl.float32), -limit), limit)
+    linear = gl.clamp(linear.to(gl.float32), -limit, limit)
     return gelu, linear
 
 

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -239,6 +239,49 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+// CHECK-LABEL: clamp_splat_negf
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @clamp_splat_negf(%x : tensor<1024xf32, #blocked>, %limit : f32) {
+    %neg_limit = arith.negf %limit : f32
+    %lower = tt.splat %neg_limit : f32 -> tensor<1024xf32, #blocked>
+    %upper = tt.splat %limit : f32 -> tensor<1024xf32, #blocked>
+
+    // CHECK-COUNT-8: nvvm.fmin.xorsign.abs.f
+    %12 = tt.clampf %x, %lower, %upper, propagateNan = none : tensor<1024xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+// CHECK-LABEL: clamp_negf
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @clamp_negf(%x : tensor<1024xf32, #blocked>, %limit : tensor<1024xf32, #blocked>) {
+    %neg_limit = arith.negf %limit : tensor<1024xf32, #blocked>
+
+    // CHECK-COUNT-8: nvvm.fmin.xorsign.abs.f
+    %12 = tt.clampf %x, %neg_limit, %limit, propagateNan = none : tensor<1024xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: clamp_negf_scalar
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @clamp_negf_scalar(%x : f32, %limit : f32) {
+    %neg_limit = arith.negf %limit : f32
+
+    // CHECK: nvvm.fmin.xorsign.abs.f
+    %12 = tt.clampf %x, %neg_limit, %limit, propagateNan = none : f32
+    tt.return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: clamp_scalar
 module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @clamp_scalar(%x : f32, %limit : f32) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -702,6 +702,20 @@ struct ClampFOpConversion
       return std::nullopt;
     };
 
+    // clampf %x (negf %max) %max
+    if (auto negOp = op.getOperand(1).getDefiningOp<arith::NegFOp>()) {
+      if (negOp.getOperand() == op.getOperand(2)) {
+        return true;
+      }
+    }
+    auto lowerSplat = op.getOperand(1).getDefiningOp<SplatOp>();
+    auto upperSplat = op.getOperand(2).getDefiningOp<SplatOp>();
+    if (lowerSplat && upperSplat) {
+      auto negOp = lowerSplat.getSrc().getDefiningOp<arith::NegFOp>();
+      if (negOp && negOp.getOperand() == upperSplat.getSrc())
+        return true;
+    }
+
     // clampf %x (sub 0.0 %max) %max
     if (auto subOp = op.getOperand(1).getDefiningOp<arith::SubFOp>()) {
       if (subOp.getOperand(1) == op.getOperand(2)) {


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/10270 subtly broke this
pattern. We fix that.
We also use gl.clamp in the MoE kernel to generate `FMNMX.XORSIGN`
instead of the min/max pattern. This gives about a 0.4% speed-up
