### PR TITLE
[GSAN] Add CUDA feature flag for PTX 7.0 support in GSan build

### DIFF
--- a/third_party/nvidia/CMakeLists.txt
+++ b/third_party/nvidia/CMakeLists.txt
@@ -39,6 +39,7 @@ if(TRITON_BUILD_PYTHON_MODULE)
               -fno-exceptions
               -fcuda-flush-denormals-to-zero
               --cuda-gpu-arch=sm_80
+              --cuda-feature=+ptx70
               ${TRITON_GSAN_INCLUDE_FLAGS}
               "${GSAN_RUNTIME_SRC}" -o "${GSAN_RUNTIME_IR}"
       DEPENDS "${GSAN_RUNTIME_SRC}" ${GSAN_RUNTIME_HDRS}


### PR DESCRIPTION
The GSan runtime is compiled with --cuda-gpu-arch=sm_80, which requires PTX 7.0 or newer. Most LLVM builds infer a compatible PTX version automatically, but some do not and will yield the following error message:

```
PTX version 4.2 does not support target 'sm_80'. Minimum required PTX version is 7.0.
```