### PR TITLE
[BACKEND] Fix bug in lowering ttg.local_alloc for i1 type. (#6851)

### DIFF
--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -202,9 +202,11 @@ private:
         totalNumElems = product<int64_t>(shapePerCTA);
       }
 
-      int64_t totalBytes =
-          totalNumElems *
-          getIntOrFloatOrPtrBitWidth(allocType.getElementType()) / 8;
+      // Use ceil(bitwidth, 8) for sub-byte element types (e.g. i1, i4) to
+      // avoid 0-byte element sizes, consistent with the lowering in lowerLdSt.
+      int64_t bytesPerElem = ceil<int64_t>(
+          getIntOrFloatOrPtrBitWidth(allocType.getElementType()), 8);
+      int64_t totalBytes = totalNumElems * bytesPerElem;
       int64_t pieceSize = totalBytes / numLogicalPieces;
 
       // Each partition buffer contains all groups concatenated
@@ -227,8 +229,11 @@ private:
       auto shapePerCTA = gpu::getAllocationShapePerCTA(allocType);
       numElems = product<int64_t>(shapePerCTA);
     }
-    int64_t bytes =
-        numElems * getIntOrFloatOrPtrBitWidth(allocType.getElementType()) / 8;
+    // Use ceil(bitwidth, 8) for sub-byte element types (e.g. i1, i4) to
+    // avoid 0-byte element sizes, consistent with the lowering in lowerLdSt.
+    int64_t bytesPerElem = ceil<int64_t>(
+        getIntOrFloatOrPtrBitWidth(allocType.getElementType()), 8);
+    int64_t bytes = numElems * bytesPerElem;
 
     allocation->addBuffer<BufferT::BufferKind::Explicit>(alloc, bytes,
                                                          alignment);

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -42,7 +42,10 @@ unsigned getMemDescSize(ttg::MemDescType ty) {
   }
   assert(isa<ttg::SharedMemorySpaceAttr>(ty.getMemorySpace()) &&
          "Unsupported memory space");
-  unsigned elSize = ty.getElementType().getIntOrFloatBitWidth() / 8;
+  // Use ceil(bitwidth, 8) for sub-byte element types (e.g. i1, i4) to avoid
+  // 0-byte element sizes, consistent with the lowering in lowerLdSt.
+  unsigned elSize =
+      mlir::ceil<unsigned>(ty.getElementType().getIntOrFloatBitWidth(), 8u);
   return product(ttg::getShapePerCTA(ty)) * elSize;
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -792,10 +792,13 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
 
   // PTX expects the address increments to be done in bytes
   // If we don't perform the computations in i8, the compiler would
-  // have to divide the computation by bitwdith / 8 and then lift this
+  // have to divide the computation by ceil(bitwidth, 8) and then lift this
   // shl, which often it's not able to do.
+  // Use ceil(bitwidth, 8) for sub-byte element types (e.g. i1, i4) to avoid
+  // 0-byte element sizes.
+  auto bytesPerElem = ceil(bitwidth, 8);
   auto i8Tile =
-      LinearLayout::zeros1D(bitwidth / 8, kReg, kOffset, bitwidth / 8);
+      LinearLayout::zeros1D(bytesPerElem, kReg, kOffset, bytesPerElem);
   auto i8AddrLayout = i8Tile * addrLayout;
 
   Value blockId = b.i32_val(0);
@@ -817,7 +820,7 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
 
   // It's fine that we don't compute the offset in bytes as affineOffset
   // will be folded into a constant
-  auto affineOffsetI8 = b.mul(affineOffset, b.i32_val(bitwidth / 8));
+  auto affineOffsetI8 = b.mul(affineOffset, b.i32_val(bytesPerElem));
   bool hasPadding = !paddingShifts.empty();
   Value paddedAffineOffsetI8 = b.i32_val(0);
   if (hasPadding && maskSpanAffineOffset != 0) {
@@ -836,7 +839,7 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
   for (int i = 0; i < cvt.getInDimSize(kReg); i += nAdditive) {
     auto idxAndBlock =
         reps.apply({{kReg, i}, {kLane, 0}, {kWarp, 0}, {kBlock, 0}});
-    auto regIdxI8 = idxAndBlock[0].second * (bitwidth / 8);
+    auto regIdxI8 = idxAndBlock[0].second * bytesPerElem;
     Value offset = b.xor_(regBaseI8, b.i32_val(regIdxI8));
     if (hasPadding) {
       offset = applyPadding(loc, rewriter, offset, paddingShifts);
@@ -851,7 +854,7 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
       // all these constants will go as immediate values to LDS/STS
       auto idxAndBlockAdd =
           reps.apply({{kReg, j}, {kLane, 0}, {kWarp, 0}, {kBlock, 0}});
-      auto regIdxAddI8 = idxAndBlockAdd[0].second * (bitwidth / 8);
+      auto regIdxAddI8 = idxAndBlockAdd[0].second * bytesPerElem;
       // `actionAdditiveStrides` forces `regIdxAddI8` and `offset` to be bitwise
       // disjoint, so we can calculate their padding contributions separately.
       regIdxAddI8 = applyPadding(regIdxAddI8, paddingShifts);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -693,18 +693,37 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
                       VectorType vecTy,
                       std::optional<Value> ctaId) -> SmallVector<Value> {
     auto length = vecTy.getNumElements();
+    Type elemTy = vecTy.getElementType();
+    unsigned elemBitwidth = getIntOrFloatOrPtrBitWidth(elemTy);
     if (isStore) {
-      Value valsVec =
-          packLLVector(loc, ArrayRef<Value>(vals).slice(idx, length), rewriter);
+      SmallVector<Value> storeVals;
+      for (const Value &v : ArrayRef<Value>(vals).slice(idx, length)) {
+        if (elemBitwidth < 8) {
+          storeVals.push_back(
+              b.zext(int_ty(8), b.bitcast(v, int_ty(elemBitwidth))));
+        } else {
+          storeVals.push_back(v);
+        }
+      }
+      Value valsVec = packLLVector(loc, storeVals, rewriter);
+
       targetInfo.storeDShared(rewriter, loc, shmemAddr, ctaId, valsVec,
                               /*pred=*/b.true_val());
       return {};
     } else {
       assert(vals.empty());
-      Value valsVec =
-          targetInfo.loadDShared(rewriter, loc, shmemAddr, ctaId, vecTy,
-                                 /*pred=*/b.true_val(), localLoadOp);
-      return unpackLLVector(loc, valsVec, rewriter);
+      Value valsVec = targetInfo.loadDShared(
+          rewriter, loc, shmemAddr, ctaId,
+          elemBitwidth < 8 ? vec_ty(i8_ty, length) : vecTy,
+          /*pred=*/b.true_val(), localLoadOp);
+
+      SmallVector<Value> vals = unpackLLVector(loc, valsVec, rewriter);
+      if (elemBitwidth < 8) {
+        for (Value &v : vals) {
+          v = b.bitcast(b.trunc(int_ty(elemBitwidth), v), elemTy);
+        }
+      }
+      return vals;
     }
   };
   auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F821,F841
 import contextlib
 import itertools
+import pathlib
 import re
 from typing import Optional
 import math
@@ -7015,3 +7016,56 @@ def test_libdevice_rint(dtype_str, device):
     rint_kernel[(triton.cdiv(numel, BLOCK_SIZE), )](res_out, x_tri, numel, BLOCK_SIZE)
     ref_out = np.rint(x_np)
     np.testing.assert_allclose(to_numpy(res_out), ref_out, rtol=0, atol=0, equal_nan=True)
+
+
+@pytest.mark.parametrize("blocked", [
+    # row-major: threads laid out along the first dimension
+    "#ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>",
+    # column-major: threads laid out along the second dimension
+    "#ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>",
+])
+def test_local_alloc_sub_byte_element_type(device, tmp_path: pathlib.Path, blocked):
+    # Regression test for https://github.com/triton-lang/triton/pull/10285.
+    # Previously, local_alloc for sub-byte element types (e.g. i1) would compute
+    # an allocation size of 0 (bitwidth/8 = 1/8 = 0), while the lowering used
+    # ceil(bitwidth, 8) = 1 byte per element, causing a size mismatch.
+    # This test verifies that local_alloc and local_load work end-to-end for i1
+    # with two different blocked layouts.
+    ir = f"""
+    #blocked = {blocked}
+    #shared = #ttg.swizzled_shared<{{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}}>
+    #smem = #ttg.shared_memory
+    module attributes {{"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32}} {{
+      tt.func public @test_local_alloc_i1(%arg0: !tt.ptr<i8> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<i8> {{tt.divisibility = 16 : i32}}) {{
+        %range = tt.make_range {{end = 128 : i32, start = 0 : i32}} : tensor<128xi32, #ttg.slice<{{dim = 1, parent = #blocked}}>>
+        %range2d = tt.expand_dims %range {{axis = 1 : i32}} : tensor<128xi32, #ttg.slice<{{dim = 1, parent = #blocked}}>> -> tensor<128x1xi32, #blocked>
+        %ptr0 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<128x1x!tt.ptr<i8>, #blocked>
+        %addr0 = tt.addptr %ptr0, %range2d : tensor<128x1x!tt.ptr<i8>, #blocked>, tensor<128x1xi32, #blocked>
+        %vals_i8 = tt.load %addr0 : tensor<128x1x!tt.ptr<i8>, #blocked>
+        %zero_i8 = arith.constant dense<0> : tensor<128x1xi8, #blocked>
+        %vals_i1 = arith.cmpi ne, %vals_i8, %zero_i8 : tensor<128x1xi8, #blocked>
+        %smem = ttg.local_alloc %vals_i1 : (tensor<128x1xi1, #blocked>) -> !ttg.memdesc<128x1xi1, #shared, #smem>
+        %loaded_i1 = ttg.local_load %smem : !ttg.memdesc<128x1xi1, #shared, #smem> -> tensor<128x1xi1, #blocked>
+        %loaded_i8 = arith.extui %loaded_i1 : tensor<128x1xi1, #blocked> to tensor<128x1xi8, #blocked>
+        %ptr1 = tt.splat %arg1 : !tt.ptr<i8> -> tensor<128x1x!tt.ptr<i8>, #blocked>
+        %addr1 = tt.addptr %ptr1, %range2d : tensor<128x1x!tt.ptr<i8>, #blocked>, tensor<128x1xi32, #blocked>
+        tt.store %addr1, %loaded_i8 : tensor<128x1x!tt.ptr<i8>, #blocked>
+        tt.return
+      }}
+    }}
+    """
+
+    # Input: mix of zero and non-zero values to exercise both i1 paths.
+    x = torch.tensor([i % 3 - 1 for i in range(128)], dtype=torch.int8, device=device).reshape(128, 1)
+    z = torch.zeros(128, 1, dtype=torch.int8, device=device)
+
+    temp_file = tmp_path / "test_local_alloc_i1.ttgir"
+    temp_file.write_text(ir)
+    kernel = triton.compile(str(temp_file))
+
+    kernel[(1, 1, 1)](x.data_ptr(), z.data_ptr())
+
+    # The kernel reads i8, casts to i1 (!=0), stores/loads via shared memory,
+    # then zero-extends back to i8 and writes out. Expected: 1 if input != 0 else 0.
+    expected = (x != 0).to(torch.int8)
+    assert torch.equal(z, expected)

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -35,6 +35,9 @@
 #PARTITIONED_SHARED_SWIZZLE = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #A_SHARED}>
 #PARTITIONED_SHARED_PADDED = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 1, partitionDim = 1, partitionLayout = #PADDED_SHARED_0_16x32}>
 
+// Shared encoding with vec=1 for testing sub-byte element types
+#SHARED_VEC1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
@@ -1081,6 +1084,17 @@ tt.func @partitioned_shared_padded_alloc() {
   // expected-remark @below {{offset = 2112, size = 1052}}
   // expected-remark @below {{offset = 3168, size = 1052}}
   %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_SHARED_PADDED, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// Regression test for sub-byte element types (i1): bytes per element must use
+// ceil(bitwidth, 8) = 1, not bitwidth/8 = 0, to avoid a zero-size allocation.
+// 32x16 = 512 elements, ceil(1 bit / 8 bits per byte) = 1 byte/elem -> size = 512.
+// expected-remark @below {{sub_byte_elem_type_alloc}}
+// expected-remark @below {{size = 512}}
+tt.func @sub_byte_elem_type_alloc() {
+  // expected-remark @below {{offset = 0, size = 512}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<32x16xi1, #SHARED_VEC1, #ttg.shared_memory, mutable>
   tt.return
 }
 }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -2828,3 +2828,29 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.prof
     tt.return
   }
 }
+
+// -----
+
+// Test that local_alloc and local_load for sub-byte element types (i1) are
+// lowered correctly. With bytesPerElem = ceil(bitwidth, 8) = 1, each element
+// is stored/loaded as an i8 byte with correct non-zero byte offsets.
+#blocked0 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: test_bitwidth_smaller_than_i8
+  tt.func @test_bitwidth_smaller_than_i8(%arg0: tensor<128x1xi1, #blocked0>) {
+    // CHECK: nvvm.read.ptx.sreg.tid.x
+    // i1 elements are zero-extended to i8 and stored as vector<1xi8>.
+    // CHECK: %[[BYTE_OFF:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-NEXT: llvm.mul {{.*}}, %[[BYTE_OFF]] : i32
+    // CHECK: llvm.store {{.*}} vector<1xi8>
+    %0 = ttg.local_alloc %arg0 : (tensor<128x1xi1, #blocked0>) -> !ttg.memdesc<128x1xi1, #shared, #smem>
+    // i1 elements are loaded as i8 and truncated back to i1.
+    // CHECK: %[[BYTE_OFF:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-NEXT: llvm.mul {{.*}}, %[[BYTE_OFF]] : i32
+    // CHECK: llvm.load {{.*}} i8
+    %1 = ttg.local_load %0 : !ttg.memdesc<128x1xi1, #shared, #smem> -> tensor<128x1xi1, #blocked0>
+    tt.return
+  }
+}


### PR DESCRIPTION
This PR aims to fix an assertion triggered when lowering `ttg.local_alloc` for sub-byte element types (specifically i1) in the TritonGPU-to-LLVM conversion pipeline.

Changes:

- Updates shared-memory load/store address layout computation to use a ceil-div-by-8 element size (to avoid 0-byte element cases).
- Adds an MLIR regression test that exercises ttg.local_alloc on an i1 tensor to ensure the lowering pipeline no longer asserts.