### PR TITLE
[AMD][BACKEND] Do not truncate TDM strides to 32bit

### DIFF
--- a/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
@@ -242,3 +242,50 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// TDM stride slots are 48 bits wide. Verify that an i64 stride is split
+// into low-32 and high-16 pieces and not silently truncated to i32.
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_load_64bit_stride
+  // CHECK-SAME: %{{.*}}: !llvm.ptr<1> {{.*}}, %[[STRIDE:.*]]: i64,
+  tt.func public @tdm_load_64bit_stride(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                        %stride0: i64, %shape0: i32, %shape1: i32) {
+    %c_stride1 = arith.constant 1 : i64
+    %c_offset = arith.constant 0 : i32
+    %c_pred = arith.constant 1 : i32
+    // CHECK: %[[HI64:.*]] = llvm.lshr %[[STRIDE]], %{{.*}} : i64
+    // CHECK: %[[HI32:.*]] = llvm.trunc %[[HI64]] : i64 to i32
+    // CHECK: llvm.insertelement %{{.*}}, %{{.*}} : vector<8xi32>
+    %0 = tt.make_tensor_descriptor %arg0, [%shape0, %shape1], [%stride0, %c_stride1] : <f16>, <64x64xf16, #shared>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Same as above but for 3D. 4D and 5D share the logic so a test would be redundant.
+#shared = #ttg.padded_shared<[16:+4] {order = [2, 1, 0], shape = [4, 16, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_load_64bit_stride_3d
+  // CHECK-SAME: %{{.*}}: !llvm.ptr<1> {{.*}}, %[[S0:.*]]: i64, %[[S1:.*]]: i64,
+  tt.func public @tdm_load_64bit_stride_3d(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                           %stride0: i64, %stride1: i64,
+                                           %shape0: i32, %shape1: i32, %shape2: i32) {
+    %c_stride2 = arith.constant 1 : i64
+    %c_offset = arith.constant 0 : i32
+    %c_pred = arith.constant 1 : i32
+    // CHECK-DAG: llvm.lshr %[[S0]], %{{.*}} : i64
+    // CHECK-DAG: llvm.lshr %[[S1]], %{{.*}} : i64
+    %0 = tt.make_tensor_descriptor %arg0, [%shape0, %shape1, %shape2], [%stride0, %stride1, %c_stride2] : <f16>, <4x16x64xf16, #shared>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<4x16x64xf16, #shared, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<4x16x64xf16, #shared> -> !ttg.memdesc<4x16x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -115,7 +115,7 @@ static PyTypeObject PyKernelArgType = {
 static bool encodeTDMDescriptor(TDMDescriptor *desc, int elementBitWidth,
                                 uint32_t *blockSize, int numWarps,
                                 int padInterval, int padAmount, uint32_t *shape,
-                                uint32_t *strides, uint64_t globalAddress,
+                                uint64_t *strides, uint64_t globalAddress,
                                 int rank) {
   if (rank < 1 || rank > 5)
     return false;
@@ -184,36 +184,46 @@ static bool encodeTDMDescriptor(TDMDescriptor *desc, int elementBitWidth,
   if (rank >= 3)
     desc->group1_4 |= (adjustedBlockSize[rank - 3] << 16);
 
-  // Strides
-  if (rank >= 2)
-    desc->group1_5 = strides[rank - 2];
+  // TDM strides are 48bit in 2 different groups so we mask against overflows
+  // into other fields.
+  const uint64_t kStrideHi16Mask = (uint64_t)0xFFFFu;
+  if (rank >= 2) {
+    uint64_t s0 = strides[rank - 2];
+    desc->group1_5 = (uint32_t)s0;
+    desc->group1_6 = (uint32_t)((s0 >> 32) & kStrideHi16Mask);
+  }
   if (rank >= 3) {
-    desc->group1_6 = (strides[rank - 3] << 16);
-    desc->group1_7 = (strides[rank - 3] >> 16);
+    uint64_t s1 = strides[rank - 3];
+    desc->group1_6 |= (uint32_t)((s1 & 0xFFFFu) << 16);
+    desc->group1_7 = (uint32_t)((s1 >> 16) & 0xFFFFFFFFu);
   }
 
   // group2 (128 bits / 4 dwords) for 3D-5D tensors:
   // [31:0]:    tensor_dim2 (3rd dimension from end)
   // [63:32]:   tensor_dim3 (4th dimension from end)
-  // [111:64]:  tensor_dim2_stride (48 bits, we use 32 bits)
+  // [111:64]:  tensor_dim2_stride (48 bits)
   // [127:112]: tile_dim3
   if (rank >= 3) {
     desc->group2_0 = shape[rank - 3];
     if (rank >= 4) {
+      uint64_t s2 = strides[rank - 4];
       desc->group2_1 = shape[rank - 4];
-      desc->group2_2 = strides[rank - 4];
-      desc->group2_3 = (adjustedBlockSize[rank - 4] << 16);
+      desc->group2_2 = (uint32_t)s2;
+      desc->group2_3 = (uint32_t)((s2 >> 32) & kStrideHi16Mask);
+      desc->group2_3 |= (adjustedBlockSize[rank - 4] << 16);
     }
   }
 
   // group3 (128 bits / 4 dwords) for 4D-5D tensors:
-  // [47:0]:    tensor_dim3_stride (48 bits, we use 32 bits)
+  // [47:0]:    tensor_dim3_stride (48 bits)
   // [79:48]:   tensor_dim4 (5th dimension from end)
   // [95:80]:   tile_dim4
   // [127:96]:  reserved
   if (rank == 5) {
-    desc->group3_0 = strides[rank - 5];
-    desc->group3_1 = (shape[rank - 5] << 16);
+    uint64_t s3 = strides[rank - 5];
+    desc->group3_0 = (uint32_t)s3;
+    desc->group3_1 = (uint32_t)((s3 >> 32) & kStrideHi16Mask);
+    desc->group3_1 |= (shape[rank - 5] << 16);
     desc->group3_2 = (shape[rank - 5] >> 16);
     desc->group3_2 |= (adjustedBlockSize[rank - 5] << 16);
   }
@@ -534,7 +544,7 @@ static PyObject *createTDMDescriptor(PyObject *self, PyObject *args) {
 
   uint32_t blockSizeInt[5];
   uint32_t shapeInt[5];
-  uint32_t stridesInt[5];
+  uint64_t stridesInt64[5];
 
   blockSizeFast = PySequence_Fast(blockSize, "blockSize must be a sequence");
   if (!blockSizeFast)
@@ -582,10 +592,22 @@ static PyObject *createTDMDescriptor(PyObject *self, PyObject *args) {
   for (int i = 0; i < rank; ++i) {
     PyObject *item = PySequence_Fast_GET_ITEM(stridesFast, i);
     if (!PyLong_Check(item)) {
-      PyErr_SetString(PyExc_TypeError, "shape must be an int");
+      PyErr_SetString(PyExc_TypeError, "stride must be an int");
       goto cleanup;
     }
-    stridesInt[i] = PyLong_AsLong(item);
+    unsigned long long s = PyLong_AsUnsignedLongLong(item);
+    if (PyErr_Occurred()) {
+      goto cleanup;
+    }
+    const uint32_t kTdmStrideMaxBits = 48;
+    if (s >= (1ULL << kTdmStrideMaxBits)) {
+      PyErr_Format(PyExc_ValueError,
+                   "TDM tensor descriptor stride[%d] = %llu is too large, must "
+                   "fit into %u bits (max %llu)",
+                   i, s, kTdmStrideMaxBits, (1ULL << kTdmStrideMaxBits) - 1);
+      goto cleanup;
+    }
+    stridesInt64[i] = (uint64_t)s;
   }
 
   Py_DECREF(blockSizeFast);
@@ -597,7 +619,7 @@ static PyObject *createTDMDescriptor(PyObject *self, PyObject *args) {
 
   bool success = encodeTDMDescriptor(
       &descObj->desc, elementBitWidth, blockSizeInt, numWarps, padInterval,
-      padAmount, shapeInt, stridesInt, globalAddress, rank);
+      padAmount, shapeInt, stridesInt64, globalAddress, rank);
   if (!success) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to encode TDM descriptor");
     goto cleanup;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -341,39 +341,48 @@ decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc, Value group0,
   SmallVector<Value> tensorStride(numDims);
   SmallVector<Value> blockShape(numDims);
 
+  // Helper: combine a 32-bit low part and a 16-bit high part into an i64.
+  auto combine48 = [&](Value lo32, Value hi16InDword) -> Value {
+    Value hi16 = b.and_(hi16InDword, b.i32_val(0xFFFF));
+    return b.or_(b.zext(i64_ty, lo32),
+                 b.shl(b.zext(i64_ty, hi16), b.i64_val(32)));
+  };
+
   // Decode dimensions from the end (inner dimensions first)
   tensorShape[numDims - 1] = decode48BitValue(rewriter, b, group1, 1);
 
   if (numDims >= 2) {
     tensorShape[numDims - 2] = decode48BitValue(rewriter, b, group1, 2);
 
-    // Strides are loaded in opposite order of shapes
-    // tensor_dim0_stride from group1[5]
-    tensorStride[numDims - 2] = vecGet(b, group1, 5);
+    // tensor_dim0_stride: group1[5][0:32] | group1[6][0:16] (48 bits)
+    tensorStride[numDims - 2] =
+        combine48(vecGet(b, group1, 5), vecGet(b, group1, 6));
 
-    // tensor_dim1_stride is encoded in group1[6] (48-bit value across group1[6]
-    // and group1[7])
+    // tensor_dim1_stride: group1[6][16:32] | group1[7][0:32] (48 bits)
     if (numDims >= 3) {
       Value stride1Low = b.and_(b.lshr(vecGet(b, group1, 6), b.i32_val(16)),
                                 b.i32_val(0xFFFF));
-      Value stride1High = b.and_(vecGet(b, group1, 7), b.i32_val(0xFFFF));
+      Value stride1High = vecGet(b, group1, 7);
       tensorStride[numDims - 3] =
-          b.or_(stride1Low, b.shl(stride1High, b.i32_val(16)));
+          b.or_(b.zext(i64_ty, stride1Low),
+                b.shl(b.zext(i64_ty, stride1High), b.i64_val(16)));
     }
   }
 
-  // tensor_dim2_stride from group2[2]
+  // tensor_dim2_stride: group2[2][0:32] | group2[3][0:16] (48 bits)
   if (numDims >= 4) {
-    tensorStride[numDims - 4] = vecGet(b, group2.value(), 2);
+    tensorStride[numDims - 4] =
+        combine48(vecGet(b, group2.value(), 2), vecGet(b, group2.value(), 3));
   }
 
-  // tensor_dim3_stride from group3[0]
+  // tensor_dim3_stride: group3[0][0:32] | group3[1][0:16] (48 bits)
   if (numDims == 5) {
-    tensorStride[numDims - 5] = vecGet(b, group3.value(), 0);
+    tensorStride[numDims - 5] =
+        combine48(vecGet(b, group3.value(), 0), vecGet(b, group3.value(), 1));
   }
 
   // The innermost dimension always has stride 1
-  tensorStride[numDims - 1] = b.i32_val(1);
+  tensorStride[numDims - 1] = b.i64_val(1);
 
   // Block shapes from group1
   blockShape[numDims - 1] =
@@ -435,9 +444,16 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
   auto elementBitWidth = elementType.getIntOrFloatBitWidth();
   auto elementSizeInBytes = elementBitWidth / 8;
 
-  // Cast strides from i64 to i32
+  // Strides come in as i64; the descriptor's stride slots are 48 bits wide.
+  // Separate the low-32 and high-16 bits of the stride.
+  SmallVector<Value> tensorStrideLo32(numDims);
+  SmallVector<Value> tensorStrideHi16(numDims);
   for (size_t i = 0; i < numDims; ++i) {
-    tensorStride[i] = b.trunc(i32_ty, tensorStride[i]);
+    Value s = tensorStride[i];
+    assert(s.getType() == i64_ty && "Expected TDM stride to be i64.");
+    tensorStrideLo32[i] = b.trunc(i32_ty, s);
+    tensorStrideHi16[i] =
+        b.and_(b.trunc(i32_ty, b.lshr(s, b.i64_val(32))), b.i32_val(0xFFFF));
   }
 
   // Compute per-warp tile dimensions for the TDM descriptor.
@@ -558,13 +574,20 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
     group1 = vecSet(b, group1, 4, g1_4);
   }
 
-  // Handle strides
+  // Handle strides (each slot is 48 bits: low-32 + high-16).
   if (numDims >= 2) {
-    group1 = vecSet(b, group1, 5, tensorStride[numDims - 2]);
+    group1 = vecSet(b, group1, 5, tensorStrideLo32[numDims - 2]);
+    Value g1_6 = tensorStrideHi16[numDims - 2];
     if (numDims >= 3) {
-      group1 = vecSet(b, group1, 6, b.shl(tensorStride[numDims - 3], v16));
-      group1 = vecSet(b, group1, 7, b.lshr(tensorStride[numDims - 3], v16));
+      g1_6 = b.or_(
+          g1_6,
+          b.shl(b.and_(tensorStrideLo32[numDims - 3], b.i32_val(0xFFFF)), v16));
+      Value stride1Hi32 =
+          b.or_(b.lshr(tensorStrideLo32[numDims - 3], v16),
+                b.shl(tensorStrideHi16[numDims - 3], b.i32_val(16)));
+      group1 = vecSet(b, group1, 7, stride1Hi32);
     }
+    group1 = vecSet(b, group1, 6, g1_6);
   }
 
   if (numDims <= 2) {
@@ -624,15 +647,11 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
     // tensor_dim3 (4th dimension from the end)
     if (numDims >= 4) {
       group2 = vecSet(b, group2, 1, tensorShape[numDims - 4]);
-      // tensor_dim2_stride (48 bits: lower 32 bits in group2[2], upper 16 bits
-      // in group2[3])
-      group2 = vecSet(b, group2, 2, tensorStride[numDims - 4]);
-    }
-
-    // tile_dim3 (upper 16 bits of group2[3])
-    if (numDims >= 4) {
-      group2 =
-          vecSet(b, group2, 3, b.shl(b.i32_val(blockShape[numDims - 4]), v16));
+      // tensor_dim2_stride: group2[2][0:32] | group2[3][0:16] (48 bits)
+      group2 = vecSet(b, group2, 2, tensorStrideLo32[numDims - 4]);
+      Value g2_3 = b.or_(tensorStrideHi16[numDims - 4],
+                         b.shl(b.i32_val(blockShape[numDims - 4]), v16));
+      group2 = vecSet(b, group2, 3, g2_3);
     }
   }
 
@@ -678,10 +697,12 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
   Value group3 = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
   if (numDims == 5) {
     // tensor_dim3_stride (4th dimension from the end) — 48 bits split across
-    // group3[0] and the lower 16 bits of group3[1].
-    group3 = vecSet(b, group3, 0, tensorStride[numDims - 5]);
-    // tensor_dim4 (5th dim) — upper 16 of group3[1] and lower 16 of group3[2].
-    group3 = vecSet(b, group3, 1, b.shl(tensorShape[numDims - 5], v16));
+    // group3[0] (low 32) and the lower 16 bits of group3[1] (high 16).
+    group3 = vecSet(b, group3, 0, tensorStrideLo32[numDims - 5]);
+    // group3[1] = stride_hi16 | (tensor_dim4_lo16 << 16)
+    Value g3_1 = b.or_(tensorStrideHi16[numDims - 5],
+                       b.shl(tensorShape[numDims - 5], v16));
+    group3 = vecSet(b, group3, 1, g3_1);
     // Compose group3[2] = tensor_dim4_hi16 | (tile_dim4 << 16) in one write.
     Value g3_2 = b.or_(b.lshr(tensorShape[numDims - 5], v16),
                        b.shl(b.i32_val(blockShape[numDims - 5]), v16));
@@ -750,9 +771,9 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
     offset[i] = b.add(offset[i], globalOffset[i]);
   }
 
-  Value baseOffset = b.i32_val(0);
+  Value baseOffset = b.i64_val(0);
   for (size_t i = 0; i < numDims; ++i) {
-    Value dimOffset = b.mul(offset[i], tensorStride[i]);
+    Value dimOffset = b.mul(b.zext(i64_ty, offset[i]), tensorStride[i]);
     baseOffset = b.add(baseOffset, dimOffset);
   }
   srcPtr = b.gep(globalPtrTy, elementType, srcPtr, baseOffset);
@@ -929,12 +950,15 @@ void fillTDMDescriptorForGatherScatter(
   auto kBlock = str_attr("block");
   auto cgaOffsets =
       applyLinearLayout(loc, rewriter, cgaLayout, {{kBlock, ctaId}});
-  Value cgaColOffset = b.mul(cgaOffsets[1].second, tensorStride[1]);
+  // tensorStride is i64 (48-bit slots); zext the i32 offsets before
+  // multiplying so we don't truncate to 32 bits.
+  Value cgaColOffset =
+      b.mul(b.zext(i64_ty, cgaOffsets[1].second), tensorStride[1]);
   globalPtr = b.gep(globalPtrTy, elementType, globalPtr, cgaColOffset);
 
   // For scatter, only apply column offset to global address
   // Row positions are specified by rowIndices
-  Value colOffset = b.mul(globalColOffset, tensorStride[1]);
+  Value colOffset = b.mul(b.zext(i64_ty, globalColOffset), tensorStride[1]);
   globalPtr = b.gep(globalPtrTy, elementType, globalPtr, colOffset);
 
   // Calculate LDS offset based on row offset only (column always starts at 0)
@@ -1417,7 +1441,8 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
   auto dot64 = [&](ArrayRef<Value> indices, ArrayRef<Value> strides) {
     Value ret = b.i64_val(0);
     for (auto [index, stride] : llvm::zip(indices, strides)) {
-      ret = b.add(ret, b.mul(b.zext(i64_ty, index), b.zext(i64_ty, stride)));
+      assert(stride.getType() == i64_ty && "Expected TDM stride to be i64.");
+      ret = b.add(ret, b.mul(b.zext(i64_ty, index), stride));
     }
     return ret;
   };
@@ -1428,7 +1453,7 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
 
   // Calculate the total tensor size for bounds checking.
   Value linearTensorSize =
-      b.mul(b.zext(i64_ty, tensorShape[0]), b.zext(i64_ty, tensorStride[0]));
+      b.mul(b.zext(i64_ty, tensorShape[0]), tensorStride[0]);
 
   // Calculate maximum allowed offset from tilePtr before going out of bounds
   Value maxOffsetFromTile = b.sub(linearTensorSize, tileOffset);
@@ -1455,7 +1480,7 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
 
   // Adjust the inner stride (always 1) to the number of elements per prefetch
   auto scaledStride = tensorStride;
-  scaledStride.back() = b.i32_val(elemPerPrefetch);
+  scaledStride.back() = b.i64_val(elemPerPrefetch);
 
   auto baseIndices = applyLinearLayout(loc, rewriter, ll,
                                        {{kRegister, b.i32_val(0)},


### PR DESCRIPTION
TDM supports strides up to 48-bit but we silently truncated them to 32bit. This happened in the lowering and in the creation of host side descriptors so this PR adjusts both to preserve 48-bit and adds range checks for host side descriptors.