### PR TITLE
Split Triton library in two: `libtriton.so` and `libtritoncore.so`

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -79,7 +79,6 @@ jobs:
           # of RAM and OOMs while building if we give it the default number of
           # workers (2 * NUM_CPUs).
           export CIBW_ENVIRONMENT="MAX_JOBS=4 \
-                  TRITON_EXT_ENABLED=ON \
                   TRITON_BUILD_WITH_CLANG_LLD=1"
 
           # required to build Python 3.14 with cibuildwheel 2.23.3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ endif()
 
 # MLIR
 find_package(MLIR REQUIRED CONFIG PATHS ${MLIR_DIR})
+find_package(LLD REQUIRED CONFIG PATHS ${LLD_DIR})
 
 list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
@@ -306,6 +307,80 @@ if (NOT WIN32 AND NOT APPLE AND NOT BSD)
 endif()
 
 ################################################################################
+# Core Triton library
+################################################################################
+
+set(TRITON_CORE_LIBRARIES
+  # MLIR
+  MLIRNVVMDialect
+  MLIRNVVMToLLVMIRTranslation
+  MLIRGPUToNVVMTransforms
+  MLIRIR
+  MLIRControlFlowToLLVM
+  MLIRPass
+  MLIRTransforms
+  MLIRLLVMDialect
+  MLIRSupport
+  MLIRTargetLLVMIRExport
+  MLIRMathToLLVM
+  MLIRROCDLToLLVMIRTranslation
+  MLIRGPUDialect
+  MLIRSCFToControlFlow
+  MLIRIndexToLLVM
+  MLIRGPUToROCDLTransforms
+  MLIRUBToLLVM
+
+  # LLVM
+  LLVMPasses
+  LLVMLTO
+)
+
+# Add target-specifc LLVM codegen/parsing.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" OR # Linux arm64
+    CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR # macOS arm64
+    CMAKE_OSX_ARCHITECTURES MATCHES "arm64")  # also macOS arm64
+  list(APPEND TRITON_CORE_LIBRARIES
+        LLVMAArch64CodeGen
+        LLVMAArch64AsmParser
+    )
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64")
+  list(APPEND TRITON_CORE_LIBRARIES
+        LLVMX86CodeGen
+        LLVMX86AsmParser
+    )
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
+  list(APPEND TRITON_CORE_LIBRARIES
+      LLVMPowerPCAsmParser
+      LLVMPowerPCCodeGen
+    )
+else()
+  message(FATAL_ERROR "LLVM codegen/ASM parser libs: This HW architecture (${CMAKE_SYSTEM_PROCESSOR}) is not configured in cmake lib dependencies.")
+endif()
+
+add_library(tritoncore SHARED)
+if (NOT WIN32)
+  target_link_libraries(tritoncore PRIVATE z)
+endif()
+target_link_options(tritoncore PRIVATE ${LLVM_LDFLAGS})
+
+# Export all symbols from libtritoncore so (a) libtriton and (b) plugins can
+# link against the Triton/LLVM C++ symbols.
+if (NOT MSVC)
+  target_compile_options(tritoncore PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-fvisibility=default>")
+endif()
+
+# Do not propagate libraries that libtritoncore depends on. This ensures
+# dependents do not accidentally link in their own copies of core Triton code
+# and LLVM.
+set_target_properties(tritoncore PROPERTIES INTERFACE_LINK_LIBRARIES "")
+
+install(TARGETS tritoncore
+  COMPONENT libraries
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+################################################################################
 # Python module
 ################################################################################
 
@@ -346,72 +421,34 @@ if(TRITON_BUILD_PYTHON_MODULE)
     endforeach()
   endif()
 
-  get_property(triton_libs GLOBAL PROPERTY TRITON_LIBS)
-  get_property(triton_plugins GLOBAL PROPERTY TRITON_PLUGINS)
-  set(TRITON_LIBRARIES
-    ${triton_libs}
-    ${triton_plugins}
-
-    # mlir
-    MLIRNVVMDialect
-    MLIRNVVMToLLVMIRTranslation
-    MLIRGPUToNVVMTransforms
-    MLIRIR
-    MLIRControlFlowToLLVM
-    MLIRPass
-    MLIRTransforms
-    MLIRLLVMDialect
-    MLIRSupport
-    MLIRTargetLLVMIRExport
-    MLIRMathToLLVM
-    MLIRROCDLToLLVMIRTranslation
-    MLIRGPUDialect
-    MLIRSCFToControlFlow
-    MLIRIndexToLLVM
-    MLIRGPUToROCDLTransforms
-    MLIRUBToLLVM
-
-    # LLVM
-    LLVMPasses
-    LLVMNVPTXCodeGen
-    LLVMAMDGPUCodeGen
-    LLVMAMDGPUAsmParser
-
+  set(TRITON_PYTHON_LIBRARIES
     Python3::Module
     pybind11::headers
+
+    LLVMAMDGPUAsmParser
+    LLVMAMDGPUCodeGen
+    LLVMNVPTXCodeGen
+    LLVMMIRParser
+
+    MLIRLLVMToLLVMIRTranslation
+    MLIRBuiltinToLLVMIRTranslation
+    MLIRNVVMToLLVM
+
+    lldCommon
   )
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" OR # Linux arm64
-     CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR # macOS arm64
-     CMAKE_OSX_ARCHITECTURES MATCHES "arm64")  # also macOS arm64
-      list(APPEND TRITON_LIBRARIES
-          LLVMAArch64CodeGen
-          LLVMAArch64AsmParser
-      )
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64")
-      list(APPEND TRITON_LIBRARIES
-          LLVMX86CodeGen
-          LLVMX86AsmParser
-      )
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
-      list(APPEND TRITON_LIBRARIES
-        LLVMPowerPCAsmParser
-        LLVMPowerPCCodeGen
-      )
-  else()
-    message(FATAL_ERROR "LLVM codegen/ASM parser libs: This HW architecture (${CMAKE_SYSTEM_PROCESSOR}) is not configured in cmake lib dependencies.")
+  if(UNIX AND NOT APPLE)
+    list(APPEND TRITON_PYTHON_LIBRARIES lldELF)
   endif()
 
-  # Define triton library
+  # Collect backends.
   string(JOIN "," TRITON_BACKENDS_TUPLE ${TRITON_CODEGEN_BACKENDS})
-
   if (DEFINED TRITON_PLUGIN_NAMES)
     string(JOIN "," TRITON_BACKENDS_TUPLE ${TRITON_BACKENDS_TUPLE} ${TRITON_PLUGIN_NAMES})
   endif()
-
   message(STATUS "Triton backends tuple: ${TRITON_BACKENDS_TUPLE}")
-
   set(TRITON_BACKENDS_TUPLE "(${TRITON_BACKENDS_TUPLE})")
   add_compile_definitions(TRITON_BACKENDS_TUPLE=${TRITON_BACKENDS_TUPLE})
+
   add_library(triton SHARED ${PYTHON_SRC_PATH}/main.cc
                   ${PYTHON_SRC_PATH}/ir.cc
                   ${PYTHON_SRC_PATH}/gluon_ir.cc
@@ -422,8 +459,18 @@ if(TRITON_BUILD_PYTHON_MODULE)
                   ${PYTHON_SRC_PATH}/llvm.cc
                   ${PYTHON_SRC_PATH}/specialize.cc)
 
-  # Link triton with its dependencies
-  target_link_libraries(triton PRIVATE ${TRITON_LIBRARIES})
+  # Add plugin object code in libtriton without linking plugin targets, which
+  # would otherwise drag transitive libraries into libtriton. These
+  # transitive libraries could conflict with what we bring in libtritoncore.
+  get_property(triton_plugins GLOBAL PROPERTY TRITON_PLUGINS)
+  foreach(plugin ${triton_plugins})
+    target_sources(triton PRIVATE $<TARGET_OBJECTS:${plugin}>)
+  endforeach()
+
+  # Keep Python-specific code in libtriton and link against C++ core.
+  target_link_libraries(triton PRIVATE
+    tritoncore
+    ${TRITON_PYTHON_LIBRARIES})
 
   # Do not propagate libraries that libtriton depends on. This ensures that
   # targets that link against libtriton do not accidentally link in their own
@@ -435,9 +482,21 @@ if(TRITON_BUILD_PYTHON_MODULE)
     set_target_properties(triton PROPERTIES SUFFIX ".pyd")
     set_target_properties(triton PROPERTIES PREFIX "lib")
   else()
-    target_link_libraries(triton PRIVATE z)
+    # Setup a relative RPATH to resolve libtritoncore using libtriton's
+    # directory.
+    if(APPLE)
+      set(_TRITON_REL_RPATH "@loader_path")
+    else()
+      set(_TRITON_REL_RPATH "$ORIGIN")
+    endif()
+    set_target_properties(triton PROPERTIES
+      BUILD_RPATH_USE_ORIGIN ON
+      BUILD_WITH_INSTALL_RPATH ON
+      BUILD_RPATH "${_TRITON_REL_RPATH}"
+      INSTALL_RPATH "${_TRITON_REL_RPATH}"
+      INSTALL_RPATH_USE_LINK_PATH FALSE)
   endif()
-  target_link_options(triton PRIVATE ${LLVM_LDFLAGS})
+  target_link_options(tritoncore PRIVATE ${LLVM_LDFLAGS})
 
   if(NOT TRITON_EXT_ENABLED)
     # When extensions are disabled, only export the Python entrypoint.
@@ -475,7 +534,7 @@ if(TRITON_BUILD_PYTHON_MODULE)
     "${TRITON_WHEEL_DIR}/FileCheck"
     COPYONLY)
 
-  # Build plugins when building libtriton since they depend on libtriton.
+  # Build plugins when building libtriton since they depend on Triton libs.
   if(TRITON_EXT_ENABLED)
     add_subdirectory(examples/plugins)
   endif()
@@ -497,6 +556,27 @@ if(NOT TRITON_BUILD_PYTHON_MODULE)
     add_subdirectory(third_party/${CODEGEN_BACKEND})
   endforeach()
   add_subdirectory(third_party/proton/Dialect)
+endif()
+
+# Link libtritoncore with a whole host of libraries. Some of these are
+# legitimate (`TRITON_CORE_LIBRARIES`), but we also link in all the libraries
+# added throughout the codebase (`TRITON_LIBS` via `add_triton_libraries`); some
+# of these latter libraries are plugin-specific and thus only known when the
+# plugin directories are processed above. In the future, we can split out the
+# plugin-specific libraries and link them only into the Python module,
+# `libtriton` (TODO).
+get_property(triton_libs GLOBAL PROPERTY TRITON_LIBS)
+if(UNIX AND NOT APPLE)
+  # Self-registering MLIR symbols require whole-archive linking so they are
+  # automatically initialized.
+  target_link_libraries(tritoncore PRIVATE "-Wl,--whole-archive"
+    ${TRITON_CORE_LIBRARIES}
+    ${triton_libs}
+    "-Wl,--no-whole-archive")
+else()
+  target_link_libraries(tritoncore PRIVATE
+    ${TRITON_CORE_LIBRARIES}
+    ${triton_libs})
 endif()
 
 find_package(Threads REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ option(TRITON_BUILD_PROTON "Build the Triton Proton profiler" ON)
 option(TRITON_BUILD_UT "Build C++ Triton Unit Tests" ON)
 option(TRITON_BUILD_WITH_CCACHE "Build with ccache (if available)" ON)
 option(TRITON_OFFLINE_BUILD "Build without downloading dependencies" OFF)
-option(TRITON_EXT_ENABLED "Build with default visibility for Triton+LLVM symbol exposure to plugin extensions" OFF)
 set(TRITON_CODEGEN_BACKENDS "" CACHE STRING "Enable different codegen backends")
 set(TRITON_VERSION "" CACHE STRING "Triton version string (passed from setup.py)")
 
@@ -275,14 +274,6 @@ endfunction()
 # Disable warnings that show up in external code (gtest;pybind11)
 if(NOT MSVC)
   set(TRITON_DISABLE_EH_RTTI_FLAGS "$<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions;-fno-rtti>")
-  if(NOT TRITON_EXT_ENABLED)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
-  else()
-    # Inform plugin loader if that libtriton is compiled with visibility
-    # so that they will not proceed with loading plugins if that will
-    # crash a Triton not compiled with visibility due to missing symbols.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTRITON_EXT_ENABLED=1")
-  endif()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-covered-switch-default ")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244 /wd4624 /wd4715 /wd4530")
@@ -498,22 +489,21 @@ if(TRITON_BUILD_PYTHON_MODULE)
   endif()
   target_link_options(tritoncore PRIVATE ${LLVM_LDFLAGS})
 
-  if(NOT TRITON_EXT_ENABLED)
-    # When extensions are disabled, only export the Python entrypoint.
-    set(TRITON_EXPORT_SYMBOLS_FILE "${CMAKE_CURRENT_BINARY_DIR}/triton.exports")
-    if(APPLE)
-      set(TRITON_EXPORT_SYMBOLS_FILE_CONTENT "_PyInit_libtriton\n")
-      target_link_options(triton PRIVATE
-        "LINKER:-exported_symbols_list,${TRITON_EXPORT_SYMBOLS_FILE}")
-    elseif(UNIX)
-      set(TRITON_EXPORT_SYMBOLS_FILE_CONTENT
-        "{\n  global:\n    PyInit_libtriton;\n  local:\n    *;\n};\n")
-      target_link_options(triton PRIVATE
-        "LINKER:--version-script,${TRITON_EXPORT_SYMBOLS_FILE}")
-    endif()
-    file(GENERATE OUTPUT "${TRITON_EXPORT_SYMBOLS_FILE}"
-      CONTENT "${TRITON_EXPORT_SYMBOLS_FILE_CONTENT}")
+  # Only export the Python entrypoint from libtriton; all C++ symbols live in
+  # libtritoncore.
+  set(TRITON_EXPORT_SYMBOLS_FILE "${CMAKE_CURRENT_BINARY_DIR}/triton.exports")
+  if(APPLE)
+    set(TRITON_EXPORT_SYMBOLS_FILE_CONTENT "_PyInit_libtriton\n")
+    target_link_options(triton PRIVATE
+      "LINKER:-exported_symbols_list,${TRITON_EXPORT_SYMBOLS_FILE}")
+  elseif(UNIX)
+    set(TRITON_EXPORT_SYMBOLS_FILE_CONTENT
+      "{\n  global:\n    PyInit_libtriton;\n  local:\n    *;\n};\n")
+    target_link_options(triton PRIVATE
+      "LINKER:--version-script,${TRITON_EXPORT_SYMBOLS_FILE}")
   endif()
+  file(GENERATE OUTPUT "${TRITON_EXPORT_SYMBOLS_FILE}"
+    CONTENT "${TRITON_EXPORT_SYMBOLS_FILE_CONTENT}")
 
   install(TARGETS triton
     COMPONENT libraries
@@ -535,9 +525,7 @@ if(TRITON_BUILD_PYTHON_MODULE)
     COPYONLY)
 
   # Build plugins when building libtriton since they depend on Triton libs.
-  if(TRITON_EXT_ENABLED)
-    add_subdirectory(examples/plugins)
-  endif()
+  add_subdirectory(examples/plugins)
 endif()
 
 if(TRITON_BUILD_PYTHON_MODULE AND NOT WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,6 +412,10 @@ if(TRITON_BUILD_PYTHON_MODULE)
     endforeach()
   endif()
 
+  # Hack: this is necessary to allow `gluon_ir.cc` to compile, as it depends
+  # directly on plugin headers (TODO).
+  include_directories(third_party/amd/include)
+
   set(TRITON_PYTHON_LIBRARIES
     Python3::Module
     pybind11::headers

--- a/examples/plugins/CMakeLists.txt
+++ b/examples/plugins/CMakeLists.txt
@@ -26,7 +26,7 @@ foreach( plugin ${TRITON_PLUGIN_PASSES} )
       TritonCanonicalizeIncGen
       TritonPluginsIncGen
     )
-    target_link_libraries(${plugin} PRIVATE triton)
+    target_link_libraries(${plugin} PRIVATE tritoncore)
 
     # CMAKE_LIBRARY_OUTPUT_DIRECTORY is only set during the Python
     # build. It is empty if building directly from the root

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -17,7 +17,7 @@ long as the libtriton.so is linked to the plugin and the Triton include passes a
 
 ## Example 1: Developing a custom pass and running triton-opt to inspect the modified IR
 ``` bash
-export TRITON_EXT_ENABLED=1;  make dev-install-llvm
+make dev-install-llvm
 TRITON_PLUGIN_PATHS=/home/triton/python/triton/plugins/libTritonPluginsTestLib.so triton-opt -tritongpu-plugin test/Plugins/test-plugin.mlir
 ```
 ``` MLIR

--- a/lib/Tools/PluginUtils.cpp
+++ b/lib/Tools/PluginUtils.cpp
@@ -149,30 +149,10 @@ const std::vector<TritonPlugin> &mlir::triton::plugin::loadPlugins() {
   if (pluginsLoaded)
     return plugins;
 
-  // Bailing when libtriton symbols are not visible is done to prevent
-  // crashes caused by loading plugins that will never find their dependent
-  // symbols (which are hidden by libtriton).
-#if !defined(TRITON_EXT_ENABLED) || TRITON_EXT_ENABLED == 0
-  bool skipLoading = true;
-#else
-  bool skipLoading = false;
-#endif
-
   if (const char *env = std::getenv("TRITON_PLUGIN_PATHS")) {
     llvm::SmallVector<llvm::StringRef, 4> paths;
     llvm::StringRef(env).split(paths, ':');
     for (const auto &path : paths) {
-      if (skipLoading) {
-        llvm::errs() << "\n"
-                     << "\n=================== WARNING =====================\n"
-                     << "Triton will not load the following extension\n"
-                     << "because it is not built with TRITON_EXT_ENABLED:\n"
-                     << path
-                     << "\n=================================================\n"
-                     << "\n";
-        continue;
-      }
-
       LLVM_DEBUG(llvm::dbgs() << "Loading plugin from path: " << path << "\n");
       auto pluginOrErr = TritonPlugin::load(path.str());
       if (auto err = pluginOrErr.takeError()) {

--- a/python/test/unit/plugins/custom_ops.py
+++ b/python/test/unit/plugins/custom_ops.py
@@ -6,7 +6,6 @@ from triton._C.libtriton import ir
 from triton.language.core import builtin
 from typing import TypeVar, Type
 import builtins
-import os
 import pathlib
 from triton.compiler.code_generator import flatten_values_to_ir
 
@@ -59,8 +58,6 @@ def add_kernel(
 
 
 def test_custom_ops(tmp_path: pathlib.Path):
-    if os.environ.get('TRITON_EXT_ENABLED', '0') == '0':
-        return
     size = 8
     x = torch.zeros(size, device=DEVICE, dtype=torch.float32)
     output_triton = torch.empty_like(x)

--- a/python/test/unit/plugins/test_dialect_plugin.py
+++ b/python/test/unit/plugins/test_dialect_plugin.py
@@ -9,8 +9,6 @@ pytestmark = pytest.mark.skipif(is_hip_cdna2(), reason="old AMD GPUs are not sup
 
 
 def test_override(tmp_path: pathlib.Path):
-    if os.environ.get('TRITON_EXT_ENABLED', '0') == '0':
-        return
     dir_path = os.path.dirname(os.path.realpath(__file__))
 
     # Run once to get the file dumps

--- a/python/test/unit/plugins/test_plugin.py
+++ b/python/test/unit/plugins/test_plugin.py
@@ -1,7 +1,6 @@
 import torch
 
 import pytest
-import os
 
 import triton
 import triton.language as tl
@@ -28,9 +27,6 @@ def kernel3(BLOCK_SIZE: tl.constexpr):
 
 
 def test_op(capfd, device: str):
-    if os.environ.get('TRITON_EXT_ENABLED', '0') == '0':
-        return
-
     size = 98432
     x = torch.rand(size, device=device)
     output = torch.empty_like(x)

--- a/setup.py
+++ b/setup.py
@@ -320,12 +320,6 @@ class CMakeBuild(build_ext):
                 "-DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld",
                 "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld",
             ]
-
-        if check_env_flag("TRITON_EXT_ENABLED"):
-            cmake_args += ["-DTRITON_EXT_ENABLED=1"]
-        else:
-            cmake_args += ["-DTRITON_EXT_ENABLED=0"]
-
         # Note that asan doesn't work with binaries that use the GPU, so this is
         # only useful for tools like triton-opt that don't run code on the GPU.
         #

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,6 @@ add_subdirectory(lib)
 
 llvm_canonicalize_cmake_booleans(
   MLIR_ENABLE_BINDINGS_PYTHON
-  TRITON_EXT_ENABLED
 )
 
 configure_lit_site_cfg(

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -63,10 +63,6 @@ tools = [
     ToolSubst('%PYTHON', config.python_executable, unresolved='ignore'),
 ]
 
-# Static libraries are not built if TRITON_EXT_ENABLED is ON.
-if config.triton_ext_enabled:
-    config.available_features.add("triton-ext-enabled")
-
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
 # TODO: what's this?

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -14,7 +14,6 @@ config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
 config.mlir_binary_dir = "@MLIR_BINARY_DIR@"
 config.python_executable = "@Python3_EXECUTABLE@"
 config.enable_bindings_python = @MLIR_ENABLE_BINDINGS_PYTHON@
-config.triton_ext_enabled = @TRITON_EXT_ENABLED@
 
 
 import lit.llvm


### PR DESCRIPTION
Over time, Triton has accumulated dependencies from its core files
toward the plugins that implement vendor-specific functionality. This is
not ideal: (a) Triton can only be compiled with vendor-specific plugins
enabled and (b) this could encourage Triton extensions to depend on
vendor-specific symbols. This change proposes a split into two
libraries:
- `libtritoncore.so` which would (eventually) contain only Triton code,
  nothing vendor-specific; all of these symbols are exported
- `libtriton.so` which `RPATH`-depends on `libtritoncore.so` and
  includes all of vendor-specific code with the Python bindings; these
  symbols are all hidden (see [#9922]).

[#9922]: https://github.com/triton-lang/triton/pull/9922

This split ensures Triton extensions have a clear, minimal target to
link to: the exported symbols in `libtritoncore.so`. It also avoids (a)
relying on hacks to avoid the missing `pybind` symbols for `triton-opt`
and other binaries used with extensions (e.g., [#51]) and (b) eliminates
the `TRITON_EXT_ENABLED` configuration entirely. This last result
normalizes how Triton is built: the built artifacts are now the same
whether Triton extensions are enabled or not.

[#51]: https://github.com/triton-lang/triton-ext/issues/51

What this PR does not do:
- it doesn't yet fix all of the vendor dependencies: this only sets
  things up to make these decisions. A next step for sorting out what
  libraries go where is to add a `CORE` argument to `add_triton_library`
  to split dependent libraries into `TRITON_CORE_LIBRARIES` or
  `TRITON_PYTHON_LIBRARIES`
- it does not fully resolve globally-scoped symbol conflicts: when
  Triton is used with extensions, the extensions need access to exported
  symbols. This change limits the number of exported symbols to those in
  `libtritoncore.so` (and the single symbol that [#9922] exports from
  `libtriton.so`), but does not fully resolve the opportunity for
  conflicts. I had hoped that `libtriton.so` depending on
  `libtritoncore.so` would prevent the core symbols from polluting the
  global symbol scope but, IIUC, system loaders will just dump
  everything there. I would be happy to be corrected on this by someone
  more familiar; maybe there is something additional that can be done at
  the system loading level to do the equivalent of `RTLD_LOCAL` (?).

This change should not alter any Triton functionality, but the change in
symbol location requires careful review. I can provide dumps of symbol
lists if that helps.