### PR TITLE
[runtime] Skip None args in autotune restore_value/reset_to_zero hooks

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -84,6 +84,37 @@ def test_restore(pass_kwargs_to_kernel, device):
     triton.testing.assert_close(src, torch.ones_like(src))
 
 
+@pytest.mark.parametrize('src_is_none', [False, True])
+@pytest.mark.parametrize('pass_kwargs_to_kernel', [False, True])
+def test_reset_to_zero(pass_kwargs_to_kernel, src_is_none, device):
+    # Kernels often take optional tensor args (e.g. an extra buffer used only
+    # when a constexpr flag is set), and idiomatically pass None when the arg
+    # is unused. Such an arg may still be listed for reset_to_zero because some
+    # call sites do mutate it. The autotuner's default pre-hook must skip None.
+    N = 1024
+    dst = torch.full((N, ), 2.0, device=device)
+    src = None if src_is_none else dst
+
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
+
+    @triton.autotune(configs=configs, key=['N'], reset_to_zero=['src'], do_bench=do_bench)
+    @triton.jit
+    def _kernel(src, dst, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < N
+        if src is not None:
+            tl.store(src + offsets, tl.full([BLOCK_SIZE], 1, dtype=src.dtype.element_ty), mask=mask)
+        else:
+            tl.store(dst + offsets, tl.full([BLOCK_SIZE], 1, dtype=dst.dtype.element_ty), mask=mask)
+
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
+    if pass_kwargs_to_kernel:
+        _kernel[grid](src=src, dst=dst, N=N)
+    else:
+        _kernel[grid](src, dst, N)
+    triton.testing.assert_close(dst, torch.ones_like(dst))
+
+
 @pytest.mark.parametrize('pass_kwargs_to_kernel', [False, True])
 def test_restore_with_none(pass_kwargs_to_kernel, device):
     # Kernels often take optional tensor args (e.g. an extra buffer used only
@@ -93,7 +124,8 @@ def test_restore_with_none(pass_kwargs_to_kernel, device):
     # skip None entries instead of crashing with
     # "AttributeError: 'NoneType' object has no attribute 'clone'".
     N = 1024
-    dst = torch.zeros(N, device=device)
+    src = None
+    dst = torch.full((N, ), 2.0, device=device)
 
     configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
 
@@ -103,17 +135,15 @@ def test_restore_with_none(pass_kwargs_to_kernel, device):
         offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
         mask = offsets < N
         if src is not None:
-            x = tl.load(src + offsets, mask=mask) + 1
-            tl.store(src + offsets, x, mask=mask)
-            tl.store(dst + offsets, x, mask=mask)
+            tl.store(src + offsets, tl.full([BLOCK_SIZE], 1, dtype=src.dtype.element_ty), mask=mask)
         else:
             tl.store(dst + offsets, tl.full([BLOCK_SIZE], 1, dtype=dst.dtype.element_ty), mask=mask)
 
     grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
     if pass_kwargs_to_kernel:
-        _kernel[grid](src=None, dst=dst, N=N)
+        _kernel[grid](src=src, dst=dst, N=N)
     else:
-        _kernel[grid](None, dst, N)
+        _kernel[grid](src, dst, N)
     triton.testing.assert_close(dst, torch.ones_like(dst))
 
 

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -84,6 +84,39 @@ def test_restore(pass_kwargs_to_kernel, device):
     triton.testing.assert_close(src, torch.ones_like(src))
 
 
+@pytest.mark.parametrize('pass_kwargs_to_kernel', [False, True])
+def test_restore_with_none(pass_kwargs_to_kernel, device):
+    # Kernels often take optional tensor args (e.g. an extra buffer used only
+    # when a constexpr flag is set), and idiomatically pass None when the arg
+    # is unused. Such an arg may still be listed in restore_value because some
+    # call sites do mutate it. The autotuner's default pre/post hooks must
+    # skip None entries instead of crashing with
+    # "AttributeError: 'NoneType' object has no attribute 'clone'".
+    N = 1024
+    dst = torch.zeros(N, device=device)
+
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
+
+    @triton.autotune(configs=configs, key=['N'], restore_value=['src'], do_bench=do_bench)
+    @triton.jit
+    def _kernel(src, dst, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < N
+        if src is not None:
+            x = tl.load(src + offsets, mask=mask) + 1
+            tl.store(src + offsets, x, mask=mask)
+            tl.store(dst + offsets, x, mask=mask)
+        else:
+            tl.store(dst + offsets, tl.full([BLOCK_SIZE], 1, dtype=dst.dtype.element_ty), mask=mask)
+
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
+    if pass_kwargs_to_kernel:
+        _kernel[grid](src=None, dst=dst, N=N)
+    else:
+        _kernel[grid](None, dst, N)
+    triton.testing.assert_close(dst, torch.ones_like(dst))
+
+
 @pytest.mark.skipif(is_hip_cdna2(), reason="Hit LLVM assertion in splitLiveThroughBlock")
 def test_hooks(device):
     # Autotuner's pre- and post- hooks should be called the same number of times

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -75,9 +75,8 @@ class Autotuner(KernelInterface):
         elif len(self.restore_value) > 0:
 
             def _post_hook(kwargs, exception):
-                for name in self.restore_value:
-                    if name in self.restore_copies:
-                        kwargs[name].copy_(self.restore_copies[name])
+                for name, value in self.restore_copies.items():
+                    kwargs[name].copy_(value)
                 self.restore_copies = {}
 
             self.post_hook = _post_hook

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -58,9 +58,14 @@ class Autotuner(KernelInterface):
 
             def _pre_hook(kwargs, reset_only=False):
                 for name in self.reset_to_zero:
-                    kwargs[name].zero_()
+                    if kwargs[name] is not None:
+                        kwargs[name].zero_()
                 if not reset_only:
-                    self.restore_copies = {name: kwargs[name].clone() for name in self.restore_value}
+                    self.restore_copies = {
+                        name: kwargs[name].clone()
+                        for name in self.restore_value
+                        if kwargs[name] is not None
+                    }
 
             self.pre_hook = _pre_hook
 
@@ -71,7 +76,8 @@ class Autotuner(KernelInterface):
 
             def _post_hook(kwargs, exception):
                 for name in self.restore_value:
-                    kwargs[name].copy_(self.restore_copies[name])
+                    if name in self.restore_copies:
+                        kwargs[name].copy_(self.restore_copies[name])
                 self.restore_copies = {}
 
             self.post_hook = _post_hook


### PR DESCRIPTION
The default pre/post hooks installed by Autotuner unconditionally call ``kwargs[name].clone()`` (and ``kwargs[name].copy_(...)``, ``kwargs[name].zero_()``) for every name listed in ``restore_value`` and ``reset_to_zero``. When such an argument is ``None`` at call time, this raises::

    AttributeError: 'NoneType' object has no attribute 'clone'

This is reachable with the idiomatic optional-pointer pattern used together with ``@triton.heuristics`` — e.g. a kernel that takes an extra buffer used only when a constexpr flag is set, and passes ``None`` when the flag is off while still listing the arg in ``restore_value`` for the calls that do mutate it.

Filter ``None`` entries out at hook execution time:
- ``_pre_hook`` skips ``None`` for both ``reset_to_zero`` and ``restore_value`` (and only records clones for non-None entries).
- ``_post_hook`` only restores names that were actually saved.

A regression test ``test_restore_with_none`` extends the existing restore coverage with multiple configs (to exercise the benchmark path that invokes the pre-hook) and passes ``src=None``.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
