### PR TITLE
Enable true16 for gfx11

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -517,7 +517,7 @@ class HIPBackend(BaseBackend):
         metadata["name"] = names[0]
         # llvm -> hsaco
         flags = []
-        features = '-real-true16' if 'gfx11' in options.arch else ''
+        features = ''
         ir_hash = hashlib.sha256(src.encode("utf-8")).hexdigest()
         dump_file_id = names[0] + '_' + ir_hash
         _ = llvm.translate_to_mir(src, amd.TARGET_TRIPLE, options.arch, features, flags, options.enable_fp_fusion,
@@ -543,8 +543,6 @@ class HIPBackend(BaseBackend):
         target_features = ''
         if knobs.compilation.enable_asan:
             target_features = '+xnack'
-        if 'gfx11' in options.arch:
-            target_features += ',-real-true16'
         hsaco = amd.assemble_amdgcn(src, options.arch, target_features)
         with tempfile.NamedTemporaryFile() as tmp_out:
             with tempfile.NamedTemporaryFile() as tmp_in:


### PR DESCRIPTION
                                                                                                                                        
                                                                                                                                                                                                                           # Description                                                                                                                                                                                                              
                                                                                                                                                                                                                           
  True16 was disabled on gfx11 a while back due to correctness regressions in LLVM. Those have since been resolved upstream, so this PR drops the -real-true16 target-feature override in make_amdgcn / make_hsaco and lets
   the backend emit native 16-bit ops (e.g. v_add_u16 v0.l, v1.h, v2.h). Benchmarks across GEMM and FlashAttention show this is roughly perf-neutral with a slight positive lean and no major regressions.
                                                                                                                                                                                                                           
  Benchmark results

 GEMM (bf16, TFLOPs)      
                                                                            
M | N | K | no_true16 | true16 | Δ%
-- | -- | -- | -- | -- | --
1024 | 1024 | 1024 | 44.13 | 43.85 | −0.65
2048 | 2048 | 2048 | 65.58 | 66.37 | +1.20
4096 | 4096 | 4096 | 78.80 | 79.88 | +1.36
8192 | 8192 | 8192 | 74.98 | 77.71 | +3.65
4096 | 11008 | 4096 | 74.62 | 75.73 | +1.49
4096 | 4096 | 11008 | 74.76 | 75.52 | +1.02
4096 | 14336 | 4096 | 74.99 | 76.88 | +2.53
4096 | 4096 | 14336 | 74.55 | 76.77 | +2.97
4096 | 12288 | 4096 | 76.61 | 77.50 | +1.16
                                                                                                                                                             
                  
  FlashAttention-2 fwd (causal=True, TFLOPs)                                                                                                                                                                               
                  
headdim | batch | seqlen | no_true16 | true16 | Δ%
-- | -- | -- | -- | -- | --
64 | 32 | 512 | 33.34 | 34.14 | +2.41
64 | 16 | 1024 | 42.94 | 43.47 | +1.24
64 | 8 | 2048 | 49.84 | 48.75 | −2.19
64 | 4 | 4096 | 53.32 | 52.62 | −1.31
64 | 2 | 8192 | 53.46 | 54.63 | +2.19
64 | 1 | 16384 | 50.09 | 52.35 | +4.51
64 | 1 | 32768 | 43.80 | 44.52 | +1.65
128 | 32 | 512 | 30.81 | 31.18 | +1.20
128 | 16 | 1024 | 43.24 | 44.80 | +3.61
128 | 8 | 2048 | 52.88 | 53.39 | +0.96
128 | 4 | 4096 | 58.80 | 58.87 | +0.13
128 | 2 | 8192 | 61.43 | 64.05 | +4.26
128 | 1 | 16384 | 59.82 | 61.31 | +2.49
128 | 1 | 32768 | 55.20 | 55.94 | +1.33

# New contributor declaration                                                                 
  - [x] I am not making a trivial change, such as fixing a typo in a comment.                                                                                                                                              
                                                                                                                                                                                                                           
  - [x] I have written a PR description following these                                                                                                                                                                    
    [rules](https://cbea.ms/git-commit/#why-not-how).                                                                                                                                                                      
                                                                                                                                                                                                                           
  - [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
                                                                                                                                                                                                                           
  - Select one of the following.                                                                                                                                                                                           
    - [ ] I have added tests.
      - `/test` for `lit` tests                                                                                                                                                                                            
      - `/unittest` for C++ tests
      - `/python/test` for end-to-end tests                                                                                                                                                                                
    - [x] This PR does not need a test because `this only removes a previously-applied codegen workaround (`-real-true16`); correctness on gfx11 is already exercised by the existing end-to-end test suite (`python/test`)
   and AMD backend lit tests, all of which now run with True16 enabled.`                                                                                                                                                   
           
  - Select one of the following.                                                                                                                                                                                           
    - [x] I have not added any `lit` tests.
    - [ ] The `lit` tests I have added follow these [best practices]...            