### PR TITLE
[AMD] Skip triton-to-gluon translator tests on RDNA3/RDNA4

### DIFF
--- a/python/test/unit/tools/test_triton_to_gluon.py
+++ b/python/test/unit/tools/test_triton_to_gluon.py
@@ -16,8 +16,14 @@ from triton._internal_testing import (
     is_hip_cdna4,
     is_hip_gfx1250,
     is_hip_cdna3_or_newer,
+    is_hip_rdna,
 )
 from triton.language.target_info import current_target
+
+pytestmark = pytest.mark.skipif(
+    is_hip_rdna(),
+    reason="triton-to-gluon translator does not support AMD RDNA3/RDNA4",
+)
 
 
 def _convert_host_descriptor(desc):


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
`python/test/unit/tools/test_triton_to_gluon.py` fails on AMD RDNA3 (gfx11xx)
  and RDNA4 (gfx120x) hardware because `TranslatorTarget` only enumerates the
  gfx targets the translator currently supports. Every test in the file errors at setup with:

  ValueError: 'gfx1201' is not a valid TranslatorTarget

  (observed with 9 failures on a gfx1201/gfx1100 box).

  This PR adds a module-level `pytestmark` that skips the file when
  `is_hip_rdna()` is true, so CI / local runs on RDNA hardware are clean. 

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `I fixed a test`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
