### PR TITLE
[INTERPRETER] Implement tl.dot_scaled for the interpreter

### DIFF
--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -127,6 +127,14 @@ LogicalResult verifyDescriptorLoadStoreOp(Operation *op,
                                           TensorDescInterface desc,
                                           ShapedType tensor);
 
+LogicalResult deduceScaleFactor(ArrayRef<int64_t> lhsShape,
+                                std::optional<ArrayRef<int64_t>> lhsScaleShape,
+                                ScaleDotElemType lhsFormat, bool lhsKPack,
+                                ArrayRef<int64_t> rhsShape,
+                                std::optional<ArrayRef<int64_t>> rhsScaleShape,
+                                ScaleDotElemType rhsFormat, bool rhsKPack,
+                                int32_t &scaleFactor, std::string &errMsg);
+
 } // namespace triton
 } // namespace mlir
 

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -372,27 +372,27 @@ LogicalResult DotScaledOp::verify() {
   return success();
 }
 
-LogicalResult DotScaledOp::deduceScaleFactor(
-    Value lhs, Value lhsScale, ScaleDotElemType lhsFormat, bool lhsKPack,
-    Value rhs, Value rhsScale, ScaleDotElemType rhsFormat, bool rhsKPack,
-    int32_t &scaleFactor, std::string &errMsg) {
-  auto deduceByShape = [&errMsg](Value operand, Value scale, int opIdx,
-                                 ScaleDotElemType format,
+LogicalResult deduceScaleFactor(ArrayRef<int64_t> lhsShape,
+                                std::optional<ArrayRef<int64_t>> lhsScaleShape,
+                                ScaleDotElemType lhsFormat, bool lhsKPack,
+                                ArrayRef<int64_t> rhsShape,
+                                std::optional<ArrayRef<int64_t>> rhsScaleShape,
+                                ScaleDotElemType rhsFormat, bool rhsKPack,
+                                int32_t &scaleFactor, std::string &errMsg) {
+  auto deduceByShape = [&errMsg](ArrayRef<int64_t> operandShape,
+                                 std::optional<ArrayRef<int64_t>> scaleShape,
+                                 int opIdx, ScaleDotElemType format,
                                  bool kPack) -> int32_t {
-    if (!scale)
+    if (!scaleShape)
       return 0;
-    auto scaleTy = cast<RankedTensorType>(scale.getType());
-    if (scaleTy.getNumElements() == 1)
+    if (llvm::product_of(*scaleShape) == 1)
       return 0;
-
-    auto operandShape = cast<RankedTensorType>(operand.getType()).getShape();
-    auto scaleShape = scaleTy.getShape();
 
     int64_t unpackFactor = (format == ScaleDotElemType::E2M1 && kPack) ? 2 : 1;
     int64_t kdim = operandShape[opIdx == 0 ? operandShape.size() - 1
                                            : operandShape.size() - 2] *
                    unpackFactor;
-    int32_t scaleFactor = kdim / scaleShape[scaleShape.size() - 1];
+    int32_t scaleFactor = kdim / (*scaleShape)[scaleShape->size() - 1];
     if (scaleFactor != 16 && scaleFactor != 32) {
       std::ostringstream oss;
       oss << "scale factor must be 16 or 32. Got " << scaleFactor;
@@ -403,10 +403,12 @@ LogicalResult DotScaledOp::deduceScaleFactor(
   };
 
   errMsg.clear();
-  int32_t scaleFactorA = deduceByShape(lhs, lhsScale, 0, lhsFormat, lhsKPack);
+  int32_t scaleFactorA =
+      deduceByShape(lhsShape, lhsScaleShape, 0, lhsFormat, lhsKPack);
   if (!errMsg.empty())
     return failure();
-  int32_t scaleFactorB = deduceByShape(rhs, rhsScale, 1, rhsFormat, rhsKPack);
+  int32_t scaleFactorB =
+      deduceByShape(rhsShape, rhsScaleShape, 1, rhsFormat, rhsKPack);
   if (!errMsg.empty())
     return failure();
 
@@ -427,6 +429,26 @@ LogicalResult DotScaledOp::deduceScaleFactor(
   }
   scaleFactor = scaleFactorA != 0 ? scaleFactorA : scaleFactorB;
   return success();
+}
+
+LogicalResult DotScaledOp::deduceScaleFactor(
+    Value lhs, Value lhsScale, ScaleDotElemType lhsFormat, bool lhsKPack,
+    Value rhs, Value rhsScale, ScaleDotElemType rhsFormat, bool rhsKPack,
+    int32_t &scaleFactor, std::string &errMsg) {
+  auto getScaleShape = [](Value scale) -> std::optional<ArrayRef<int64_t>> {
+    if (!scale) {
+      return std::nullopt;
+    } else {
+      return cast<RankedTensorType>(scale.getType()).getShape();
+    }
+  };
+
+  auto lhsShape = cast<RankedTensorType>(lhs.getType()).getShape();
+  auto rhsShape = cast<RankedTensorType>(rhs.getType()).getShape();
+
+  return triton::deduceScaleFactor(lhsShape, getScaleShape(lhsScale), lhsFormat,
+                                   lhsKPack, rhsShape, getScaleShape(rhsScale),
+                                   rhsFormat, rhsKPack, scaleFactor, errMsg);
 }
 
 int32_t DotScaledOp::deduceScaleFactor() {

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -787,16 +787,16 @@ void init_triton_ir(py::module &&m) {
       ret::take_ownership);
 
   m.def("deduce_scale_factor",
-        [](Value &lhs, std::optional<Value> &lhsScale,
-           ScaleDotElemType lhsFormat, bool lhsKPack, Value &rhs,
-           std::optional<Value> &rhsScale, ScaleDotElemType rhsFormat,
-           bool rhsKPack) -> int32_t {
+        [](std::vector<int64_t> &lhs,
+           std::optional<std::vector<int64_t>> &lhsScale,
+           ScaleDotElemType lhsFormat, bool lhsKPack, std::vector<int64_t> &rhs,
+           std::optional<std::vector<int64_t>> &rhsScale,
+           ScaleDotElemType rhsFormat, bool rhsKPack) -> int32_t {
           int32_t scaleFactor = 0;
           std::string errMsg;
-          if (failed(DotScaledOp::deduceScaleFactor(
-                  lhs, lhsScale.value_or(Value()), lhsFormat, lhsKPack, rhs,
-                  rhsScale.value_or(Value()), rhsFormat, rhsKPack, scaleFactor,
-                  errMsg)))
+          if (failed(deduceScaleFactor(lhs, lhsScale, lhsFormat, lhsKPack, rhs,
+                                       rhsScale, rhsFormat, rhsKPack,
+                                       scaleFactor, errMsg)))
             throw std::runtime_error(errMsg);
           return scaleFactor;
         });

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3630,6 +3630,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         assert re.search(pattern, ptx, flags=re.DOTALL)
 
 
+@pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, num_warps, mma, kpack",
                          [(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, 4, mma, kpack)
                           for M, N, K in itertools.product([32, 64, 128], [32, 64, 128], [64, 128])
@@ -3640,6 +3641,9 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
                           for mma in (mma_nonk_sizes if is_hip() else [16])
                           for kpack in ([1, 2] if (is_hip() and not (is_hip_cdna4() or is_hip_gfx1250())) else [1])])
 def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, num_warps, mma, kpack, device):
+    if is_interpreter() and normal_type != "fp16":
+        pytest.skip("bfloat16 is not supported in the interpreter")
+
     is_SM120 = False
     if is_cuda():
         cc = torch.cuda.get_device_capability()
@@ -3887,6 +3891,8 @@ def test_scaled_dot(M, N, K, col_a, col_b, rhs_scale, mxfp_type, normal_type, nu
     if is_hip_rdna3() and mxfp_type == "e4m3" and normal_type == "fp16":
         large_tolerance = True
     if is_SM120:
+        large_tolerance = True
+    if mxfp_type == 'e4m3' and is_interpreter():
         large_tolerance = True
     atol = 2e-4 if large_tolerance else 1e-5
     rtol = 2e-2 if large_tolerance else 1e-2

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -343,6 +343,7 @@ def fp8e8m0_to_float32(scale):
     return scale
 
 
+@pytest.mark.interpreter
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 128), (256, 128, 128), (128, 256, 128),
                                                        (128, 256, 256), (128, 128, 64), (128, 64, 128), (128, 16, 256)])
 @pytest.mark.parametrize("NUM_STAGES", [1, 3])
@@ -612,6 +613,7 @@ def _gemm_kernel_preshuffled_scales_cdna4(a_ptr, b_ptr, c_ptr, a_scales_ptr, b_s
     tl.store(c_ptrs, c, mask=c_mask, cache_modifier=".wt")
 
 
+@pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K", [(1024, 1024, 1024)])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 256), (64, 64, 512), [32, 32, 64]])
 @pytest.mark.parametrize("DTYPE_A, DTYPE_B, FAST_MATH", [("mxfp4", "mxfp4", False), ("fp16", "mxfp8e5", False),
@@ -741,6 +743,7 @@ def test_preshuffle_scale_mxfp_cdna4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, DTYPE_A
             assert "tilesPerWarp" not in k.asm["ttgir"]
 
 
+@pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K", [(1024, 512, 512), (998, 111, 512), (63, 128, 512)])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 128), (256, 128, 128), (128, 256, 128),
                                                        (128, 128, 256), (128, 256, 256)])
@@ -884,6 +887,7 @@ def lhs_in_tmem_kernel_mxfp(  #
     tl.store(output_ptrs, accumulator)
 
 
+@pytest.mark.interpreter
 @pytest.mark.skipif(is_hip() or torch.cuda.get_device_capability()[0] != 10, reason="Requires compute capability == 10")
 def test_lhs_in_tmem_mxfp(device, monkeypatch):
     _knob_promote_lhs_to_tmem(monkeypatch)
@@ -976,6 +980,7 @@ def block_scale_fp4_matmul(  #
     tl.store(output_ptrs, accumulator, mask=c_mask)
 
 
+@pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K", [(1024, 512, 256)])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 128), (256, 128, 128), (128, 256, 128),
                                                        (128, 256, 256), (128, 128, 64), (128, 64, 128), (16, 256, 256),
@@ -1139,6 +1144,7 @@ def mxfp8_mxfp4_matmul(  #
     tl.store(output_ptrs, accumulator, mask=c_mask)
 
 
+@pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K", [(1024, 512, 512)])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 128), (256, 128, 128), (128, 256, 128),
                                                        (128, 256, 256), (128, 128, 64), (128, 64, 128)])
@@ -1308,6 +1314,7 @@ def batched_mxfp_matmul(  #
     tl.store(output_ptrs, accumulator, mask=c_mask)
 
 
+@pytest.mark.interpreter
 @pytest.mark.parametrize("BATCH_SIZE, BLOCK_BATCH_SIZE", [(1, 1), (16, 1), (16, 4)])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 64), (128, 64, 128), (64, 64, 128)])
 @pytest.mark.parametrize("NUM_STAGES", [1, 2 if is_hip() else 3])

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -1309,6 +1309,7 @@ def mxfp8_mxfp4_matmul_tma(  #
     tl.store(output_ptrs, accumulator, mask=c_mask)
 
 
+@pytest.mark.interpreter
 @pytest.mark.parametrize("M, N, K", [(1024, 512, 256), (128, 256, 256), (8192, 8192, 8192)])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K", [(128, 128, 128), (128, 128, 256), (128, 256, 128),
                                                        (128, 256, 256)])

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1540,11 +1540,11 @@ class TritonSemantic(Generic[TensorTy]):
 
         def _to_scale_handle(scale):
             if isinstance(scale, tl.tensor) and scale.numel.value != 1:
-                return scale.handle
+                return scale.type.shape
             return None
 
-        return ir.deduce_scale_factor(lhs.handle, _to_scale_handle(lhs_scale), self._str_to_fp_type(lhs_format),
-                                      lhs_k_pack, rhs.handle, _to_scale_handle(rhs_scale),
+        return ir.deduce_scale_factor(lhs.type.shape, _to_scale_handle(lhs_scale), self._str_to_fp_type(lhs_format),
+                                      lhs_k_pack, rhs.type.shape, _to_scale_handle(rhs_scale),
                                       self._str_to_fp_type(rhs_format), rhs_k_pack)
 
     def verify_scaled_shape(self, M, N, K, lhs_scale, rhs_scale, scale_factor):

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -249,6 +249,98 @@ def _umulhi_64(a, b):
     return (int(a) * int(b)) >> 64
 
 
+def _e8m0_to_f32(scale):
+    assert scale.dtype in (np.uint8, np.int8)
+    scale = scale.astype(np.uint8)
+    scale = scale.astype(np.int32)
+    scale = scale << 23
+    scale = scale.view(np.float32)
+    return scale
+
+
+def _e2m1_to_f32(value):
+    assert value.dtype == np.uint8
+
+    low = value & np.uint8(0x0F)
+    high = value >> np.uint8(4)
+
+    unpacked_shape = value.shape[:-1] + (value.shape[-1] * 2, )
+    unpacked_val = np.empty(unpacked_shape, dtype=np.uint8)
+    unpacked_val[..., 0::2] = low
+    unpacked_val[..., 1::2] = high
+
+    # 0->0, 1->0.5, 2->1, 3->1.5, 4->2, 5->3, 6->4, 7->6 (from Onnx)
+    positive_e2m1_lut = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=np.float32)
+    abs_values = positive_e2m1_lut[(unpacked_val & np.uint8(0x07))]
+    signs = (unpacked_val & np.uint8(0x08)) != 0
+    return np.where(signs, -abs_values, abs_values)
+
+
+def _mxfp_value_handle_to_float32(value_handle):
+    if value_handle.dtype == tl.uint8:
+        value_float = _e2m1_to_f32(value_handle.data)
+    else:
+        # Decode fp8 values through float16 first, then widen to float32.
+        # This preserves the same intermediate rounding used by the reference
+        # path, which is especially visible for float8e5m2.
+        value_float = _convert_float(
+            value_handle.data,
+            value_handle.dtype,
+            tl.float16,
+            _ir.ROUNDING_MODE.RTNE,
+        ).view(np.float16).astype(np.float32)
+
+    # Handle inf/nan for e5m2/e4m3
+    if value_handle.dtype == tl.float8e5:
+        pos_inf_mask = value_handle.data == np.uint8(0x7C)
+        value_float = np.where(pos_inf_mask, np.float32('inf'), value_float)
+
+        neg_inf_mask = value_handle.data == np.uint8(0xFC)
+        value_float = np.where(neg_inf_mask, -np.float32('inf'), value_float)
+
+        nan_mask = np.logical_and((value_handle.data & np.uint8(0x7C)) == np.uint8(0x7C),
+                                  (value_handle.data & np.uint8(3)) != np.uint8(0))
+        value_float = np.where(nan_mask, np.float32('nan'), value_float)
+    elif value_handle.dtype == tl.float8e4nv:
+        nan_mask = value_handle.data & np.uint8(0x7F) == np.uint8(0x7F)
+        value_float = np.where(nan_mask, np.float32('nan'), value_float)
+
+    return value_float
+
+
+def _unpack_e2m1(data, axis):
+    # E2M1 stores two logical 4-bit values per byte; unpack on the physical
+    # axis that carries the packed logical matrix dimension.
+    data = np.moveaxis(data, axis, -1)
+    unpacked = _e2m1_to_f32(data)
+    return np.moveaxis(unpacked, -1, axis)
+
+
+def _prepare_dot_scaled_operand(value_handle, scale_handle, format_enum, k_pack, is_rhs):
+    if format_enum == _ir.ScaleDotElemTypeTY.E2M1:
+        if is_rhs:
+            unpack_axis = -2 if k_pack else -1
+        else:
+            unpack_axis = -1 if k_pack else -2
+        value = _unpack_e2m1(value_handle.data, unpack_axis)
+    else:
+        value = _mxfp_value_handle_to_float32(value_handle)
+
+    if scale_handle is None:
+        return value
+
+    scale = _e8m0_to_f32(scale_handle.data)
+
+    if is_rhs:
+        # rhs is in [K, N] layout, but rhs_scale is supplied as [N, K / group].
+        scale = np.repeat(scale, value.shape[-2] // scale.shape[-1], axis=-1)
+        scale = np.swapaxes(scale, -1, -2)
+    else:
+        scale = np.repeat(scale, value.shape[-1] // scale.shape[-1], axis=-1)
+
+    return value * scale
+
+
 np_erf_fp32 = np.vectorize(_erf, otypes=[np.float32])
 np_erf_fp64 = np.vectorize(_erf, otypes=[np.float64])
 np_umulhi_u64 = np.vectorize(_umulhi_64, otypes=[np.uint64])
@@ -771,6 +863,17 @@ class InterpreterBuilder:
             return TensorHandle(np.full(1, True, dtype=np_type), type.scalar)
         else:
             raise TypeError(f"unsupported type {type}")
+
+    def create_dot_scaled(self, lhs: TensorHandle, lhs_scale_handle: Optional[TensorHandle],
+                          lhs_format_enum: _ir.ScaleDotElemTypeTY, rhs: TensorHandle,
+                          rhs_scale_handle: Optional[TensorHandle], rhs_format_enum: _ir.ScaleDotElemTypeTY,
+                          fast_math: bool, lhs_k_pack: bool, rhs_k_pack: bool,
+                          acc_handle: TensorHandle) -> TensorHandle:
+        lhs_data = _prepare_dot_scaled_operand(lhs, lhs_scale_handle, lhs_format_enum, lhs_k_pack, is_rhs=False)
+        rhs_data = _prepare_dot_scaled_operand(rhs, rhs_scale_handle, rhs_format_enum, rhs_k_pack, is_rhs=True)
+
+        result = np.matmul(lhs_data, rhs_data) + acc_handle.data
+        return TensorHandle(result, tl.float32)
 
 
 _MISSING = object()


### PR DESCRIPTION
Implement InterpreterBuilder.create_dot_scaled.

deduceScaleFactor relied on mlir::Values. Refactor to be independent of mlir so it can be called
when using the interpreter.

Mark several tests that use tl.dot_scaled to run during the interpreter tests.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because existing tests have been marked to run with the interpreter which covers the new functionality.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
