### PR TITLE
[FIX] Fix missing stream wait

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -112,7 +112,12 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None, quantiles=None, return_mod
     import torch
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
-    with torch.cuda.stream(torch.cuda.Stream()):
+    old_stream = torch.cuda.current_stream()
+    new_stream = torch.cuda.Stream()
+
+    with torch.cuda.stream(new_stream):
+        # NOTE: must ensure the data on the old stream is ready
+        new_stream.wait_stream(old_stream)
         # warmup
         fn()
         if grad_to_none is not None:
@@ -191,7 +196,13 @@ def do_bench_cudagraph_proton(fn, rep=20, grad_to_none=None, quantiles=None, ret
 
     import torch
 
-    with torch.cuda.stream(torch.cuda.Stream()):
+    old_stream = torch.cuda.current_stream()
+    new_stream = torch.cuda.Stream()
+
+    with torch.cuda.stream(new_stream):
+        # NOTE: must ensure the data on the old stream is ready
+        new_stream.wait_stream(old_stream)
+        # warmup
         fn()
         if grad_to_none is not None:
             for x in grad_to_none:

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -194,7 +194,7 @@ def do_bench_cudagraph_proton(fn, rep=20, grad_to_none=None, quantiles=None, ret
     import torch
 
     with torch.cuda.stream(torch.cuda.Stream()):
-        # NOTE: must ensure the data on the old stream is ready
+        # NOTE: must ensure the data is ready
         torch.cuda.synchronize()
         # warmup
         fn()

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -112,12 +112,9 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None, quantiles=None, return_mod
     import torch
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
-    old_stream = torch.cuda.current_stream()
-    new_stream = torch.cuda.Stream()
-
-    with torch.cuda.stream(new_stream):
+    with torch.cuda.stream(torch.cuda.Stream()):
         # NOTE: must ensure the data on the old stream is ready
-        new_stream.wait_stream(old_stream)
+        torch.cuda.synchronize()
         # warmup
         fn()
         if grad_to_none is not None:
@@ -196,12 +193,9 @@ def do_bench_cudagraph_proton(fn, rep=20, grad_to_none=None, quantiles=None, ret
 
     import torch
 
-    old_stream = torch.cuda.current_stream()
-    new_stream = torch.cuda.Stream()
-
-    with torch.cuda.stream(new_stream):
+    with torch.cuda.stream(torch.cuda.Stream()):
         # NOTE: must ensure the data on the old stream is ready
-        new_stream.wait_stream(old_stream)
+        torch.cuda.synchronize()
         # warmup
         fn()
         if grad_to_none is not None:


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

When I was running `triton.testing.do_bench_cudagraph` in SGLang JIT kernel, I frequently encountered illegal memory access. After reading through the source code, I found that the cuda-graph benchmark implicitly creates a new cuda stream. However, it does not synchronize with the original cuda stream. If the input data is initialized on the original stream and then used on the new stream, there might be race condition (reading uninitialized data).

To fix this, we add a `wait_stream` to ensure the visibility.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because this is a race-condition bug which is hard to trigger in tests.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
