### PR TITLE
[BACKEND] Allow broadcasted CTA memdesc subslices

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -553,9 +553,7 @@ SmallVector<Value> computeLocalPtrs(Location loc,
   auto sharedLayout = triton::gpu::isPaddedEncoding(memDescTy.getEncoding())
                           ? paddedLinearLayout(memDescTy)
                           : toLinearLayout(memDescTy);
-  auto kBlock = str_attr("block");
-  LinearLayout invSharedLayout =
-      sharedLayout.removeZeroBasesAlongDim(kBlock).pseudoinvert();
+  LinearLayout invSharedLayout = sharedLayout.pseudoinvert();
 
   // Get layout dimension names for all dims
   SmallVector<StringAttr> allDims;
@@ -1273,8 +1271,7 @@ SharedMemoryObject::getMaskSpanOffsets(triton::gpu::MemDescType srcTy) {
           : triton::gpu::toLinearLayout(allocShape, srcTy.getEncoding());
   auto dimNames = standardOutDimNames(ctx, shape.size());
   // Map from dimNames to offset, block
-  auto kBlock = str_attr("block");
-  auto invLl = totalLl.removeZeroBasesAlongDim(kBlock).pseudoinvert();
+  auto invLl = totalLl.pseudoinvert();
   SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;
   for (auto dim : standardOutDimNames(srcTy.getContext(), shape.size())) {
     logicalOffsets.push_back({dim, 0});
@@ -1321,14 +1318,8 @@ Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
     logicalOffsets.push_back({dim, offset});
   }
 
-  auto kBlock = str_attr("block");
-  // Broadcasted block bases do not affect the logical offset within shared
-  // memory, but they make the full layout non-injective. Strip them before
-  // taking the pseudoinverse, then discard the block component of the result.
   auto offset =
-      applyLinearLayout(loc, rewriter,
-                        ll.removeZeroBasesAlongDim(kBlock).pseudoinvert(),
-                        logicalOffsets)[0]
+      applyLinearLayout(loc, rewriter, ll.pseudoinvert(), logicalOffsets)[0]
           .second;
   return offset;
 }

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -555,7 +555,7 @@ SmallVector<Value> computeLocalPtrs(Location loc,
                           : toLinearLayout(memDescTy);
   auto kBlock = str_attr("block");
   LinearLayout invSharedLayout =
-      sharedLayout.removeZeroBasesAlongDim(kBlock).invert();
+      sharedLayout.removeZeroBasesAlongDim(kBlock).pseudoinvert();
 
   // Get layout dimension names for all dims
   SmallVector<StringAttr> allDims;
@@ -1274,7 +1274,7 @@ SharedMemoryObject::getMaskSpanOffsets(triton::gpu::MemDescType srcTy) {
   auto dimNames = standardOutDimNames(ctx, shape.size());
   // Map from dimNames to offset, block
   auto kBlock = str_attr("block");
-  auto invLl = totalLl.removeZeroBasesAlongDim(kBlock).invert();
+  auto invLl = totalLl.removeZeroBasesAlongDim(kBlock).pseudoinvert();
   SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;
   for (auto dim : standardOutDimNames(srcTy.getContext(), shape.size())) {
     logicalOffsets.push_back({dim, 0});
@@ -1324,9 +1324,10 @@ Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
   auto kBlock = str_attr("block");
   // Broadcasted block bases do not affect the logical offset within shared
   // memory, but they make the full layout non-injective. Strip them before
-  // inverting, then discard the block component of the pseudoinverse result.
+  // taking the pseudoinverse, then discard the block component of the result.
   auto offset = applyLinearLayout(loc, rewriter,
-                                  ll.removeZeroBasesAlongDim(kBlock).invert(),
+                                  ll.removeZeroBasesAlongDim(kBlock)
+                                      .pseudoinvert(),
                                   logicalOffsets)[0]
                     .second;
   return offset;

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -553,7 +553,9 @@ SmallVector<Value> computeLocalPtrs(Location loc,
   auto sharedLayout = triton::gpu::isPaddedEncoding(memDescTy.getEncoding())
                           ? paddedLinearLayout(memDescTy)
                           : toLinearLayout(memDescTy);
-  LinearLayout invSharedLayout = sharedLayout.invert();
+  auto kBlock = str_attr("block");
+  LinearLayout invSharedLayout =
+      sharedLayout.removeZeroBasesAlongDim(kBlock).invert();
 
   // Get layout dimension names for all dims
   SmallVector<StringAttr> allDims;
@@ -1271,7 +1273,8 @@ SharedMemoryObject::getMaskSpanOffsets(triton::gpu::MemDescType srcTy) {
           : triton::gpu::toLinearLayout(allocShape, srcTy.getEncoding());
   auto dimNames = standardOutDimNames(ctx, shape.size());
   // Map from dimNames to offset, block
-  auto invLl = totalLl.invert();
+  auto kBlock = str_attr("block");
+  auto invLl = totalLl.removeZeroBasesAlongDim(kBlock).invert();
   SmallVector<std::pair<StringAttr, int32_t>> logicalOffsets;
   for (auto dim : standardOutDimNames(srcTy.getContext(), shape.size())) {
     logicalOffsets.push_back({dim, 0});
@@ -1318,11 +1321,14 @@ Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
     logicalOffsets.push_back({dim, offset});
   }
 
-  // We don't allow for non-trivial block dimensions in the shared memory layout
-  // We have in practice that offsetAndBlock[1].second is zero, but we cannot
-  // know assert that without constant propagation so we just discard it :)
-  auto offset =
-      applyLinearLayout(loc, rewriter, ll.invert(), logicalOffsets)[0].second;
+  auto kBlock = str_attr("block");
+  // Broadcasted block bases do not affect the logical offset within shared
+  // memory, but they make the full layout non-injective. Strip them before
+  // inverting, then discard the block component of the pseudoinverse result.
+  auto offset = applyLinearLayout(loc, rewriter,
+                                  ll.removeZeroBasesAlongDim(kBlock).invert(),
+                                  logicalOffsets)[0]
+                    .second;
   return offset;
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1318,6 +1318,9 @@ Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
     logicalOffsets.push_back({dim, offset});
   }
 
+  // We don't allow for non-trivial block dimensions in the shared memory
+  // layout. We have in practice that offsetAndBlock[1].second is zero, but we
+  // cannot assert that without constant propagation so we just discard it.
   auto offset =
       applyLinearLayout(loc, rewriter, ll.pseudoinvert(), logicalOffsets)[0]
           .second;

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1325,11 +1325,11 @@ Value SharedMemoryObject::getShmemOffset(Location loc, RewriterBase &rewriter,
   // Broadcasted block bases do not affect the logical offset within shared
   // memory, but they make the full layout non-injective. Strip them before
   // taking the pseudoinverse, then discard the block component of the result.
-  auto offset = applyLinearLayout(loc, rewriter,
-                                  ll.removeZeroBasesAlongDim(kBlock)
-                                      .pseudoinvert(),
-                                  logicalOffsets)[0]
-                    .second;
+  auto offset =
+      applyLinearLayout(loc, rewriter,
+                        ll.removeZeroBasesAlongDim(kBlock).pseudoinvert(),
+                        logicalOffsets)[0]
+          .second;
   return offset;
 }
 

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1115,11 +1115,7 @@ LogicalResult MemDescSubsliceOp::verify() {
     ll = triton::gpu::toLinearLayout(srcTy);
   }
 
-  auto kBlock = mlir::StringAttr::get(ctx, "block");
-  // Broadcasted CTA bases make the shared layout non-injective, but they don't
-  // matter for recovering the unique offset / non-broadcast CTA components of a
-  // split. Strip those zero bases before taking the pseudoinverse.
-  auto llInv = ll.removeZeroBasesAlongDim(kBlock).pseudoinvert();
+  auto llInv = ll.pseudoinvert();
   for (auto dim : splitDims) {
     auto kDim = mlir::StringAttr::get(ctx, "dim" + llvm::Twine(dim));
     llvm::SmallVector<std::pair<mlir::StringAttr, int32_t>> namedOffsets;

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1115,14 +1115,11 @@ LogicalResult MemDescSubsliceOp::verify() {
     ll = triton::gpu::toLinearLayout(srcTy);
   }
 
-  // If any block basis is fully broadcasted, multiple CTAs can alias the same
-  // output tile region. Subslice on such layouts is unsupported.
   auto kBlock = mlir::StringAttr::get(ctx, "block");
-  if (ll.getFreeVariableMasks()[kBlock] != 0) {
-    return emitError("We don't support splitting with broadcasted CTA outputs");
-  }
-
-  auto llInv = ll.invert();
+  // Broadcasted CTA bases make the shared layout non-injective, but they don't
+  // matter for recovering the unique offset / non-broadcast CTA components of a
+  // split. Strip those zero bases before inverting.
+  auto llInv = ll.removeZeroBasesAlongDim(kBlock).invert();
   for (auto dim : splitDims) {
     auto kDim = mlir::StringAttr::get(ctx, "dim" + llvm::Twine(dim));
     llvm::SmallVector<std::pair<mlir::StringAttr, int32_t>> namedOffsets;

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1118,8 +1118,8 @@ LogicalResult MemDescSubsliceOp::verify() {
   auto kBlock = mlir::StringAttr::get(ctx, "block");
   // Broadcasted CTA bases make the shared layout non-injective, but they don't
   // matter for recovering the unique offset / non-broadcast CTA components of a
-  // split. Strip those zero bases before inverting.
-  auto llInv = ll.removeZeroBasesAlongDim(kBlock).invert();
+  // split. Strip those zero bases before taking the pseudoinverse.
+  auto llInv = ll.removeZeroBasesAlongDim(kBlock).pseudoinvert();
   for (auto dim : splitDims) {
     auto kDim = mlir::StringAttr::get(ctx, "dim" + llvm::Twine(dim));
     llvm::SmallVector<std::pair<mlir::StringAttr, int32_t>> namedOffsets;

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -1901,6 +1901,59 @@ def test_memdesc_subslice(M, N, M_tile_size, N_tile_size, shared_layout_cfg, dev
     torch.testing.assert_close(out, out_ref, rtol=0, atol=0)
 
 
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="num_ctas > 1 requires NVIDIA SM90+ (Hopper)")
+def test_memdesc_subslice_multi_cta_broadcasted_cga(device):
+    M, N = 64, 64
+    SLICE_M = 32
+    cga_layout = _make_cga_broadcast(2, 2)
+    blocked_layout = ttgl.BlockedLayout(
+        size_per_thread=[1, 8],
+        threads_per_warp=[THREADS_PER_WARP // 4, 4],
+        warps_per_cta=[4, 1],
+        order=[1, 0],
+        cga_layout=cga_layout,
+    )
+    shared_layout = ttgl.SwizzledSharedLayout(
+        vec=1,
+        per_phase=1,
+        max_phase=1,
+        order=[1, 0],
+        cga_layout=cga_layout,
+    )
+
+    @gluon.jit
+    def kernel(
+        in_ptr,
+        out_ptr,
+        M: ttgl.constexpr,
+        N: ttgl.constexpr,
+        SLICE_M: ttgl.constexpr,
+        blocked_layout: ttgl.constexpr,
+        shared_layout: ttgl.constexpr,
+    ):
+        offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, blocked_layout))[:, None]
+        offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, blocked_layout))[None, :]
+        vals = ttgl.load(in_ptr + offs_m * N + offs_n)
+
+        smem = ttgl.allocate_shared_memory(vals.dtype, (M, N), shared_layout, value=vals)
+        ttgl.barrier(cluster=True)
+
+        tile = smem.slice(0, SLICE_M, dim=0)
+        tile_vals = tile.load(blocked_layout)
+
+        tile_offs_m = ttgl.arange(0, SLICE_M, layout=ttgl.SliceLayout(1, blocked_layout))[:, None]
+        tile_offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, blocked_layout))[None, :]
+        ttgl.store(out_ptr + tile_offs_m * N + tile_offs_n, tile_vals)
+
+    inp = torch.arange(0, M * N, device=device, dtype=torch.int32).reshape((M, N))
+    out = torch.zeros_like(inp)
+    kernel[(1, )](inp, out, M, N, SLICE_M, blocked_layout, shared_layout, num_warps=4, num_ctas=2)
+
+    out_ref = torch.zeros_like(inp)
+    out_ref[:SLICE_M, :] = inp[:SLICE_M, :]
+    torch.testing.assert_close(out, out_ref, rtol=0, atol=0)
+
+
 @pytest.mark.skipif(is_cuda(), reason="PartitionedSharedLayout is not supported in NV backend")
 @pytest.mark.parametrize("M, K", [(64, 32), (128, 64)])
 @pytest.mark.parametrize("num_partitions", [2, 4])

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -1902,55 +1902,51 @@ def test_memdesc_subslice(M, N, M_tile_size, N_tile_size, shared_layout_cfg, dev
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="num_ctas > 1 requires NVIDIA SM90+ (Hopper)")
-def test_memdesc_subslice_multi_cta_broadcasted_cga(device):
-    M, N = 64, 64
-    SLICE_M = 32
-    cga_layout = _make_cga_broadcast(2, 2)
-    blocked_layout = ttgl.BlockedLayout(
-        size_per_thread=[1, 8],
-        threads_per_warp=[THREADS_PER_WARP // 4, 4],
-        warps_per_cta=[4, 1],
-        order=[1, 0],
-        cga_layout=cga_layout,
-    )
+def test_memdesc_subslice_two_cta_broadcasted_cga(device):
+    ALLOC = 512
+    SLICE = 256
+    NUM_CTAS = 2
+    alloc_layout = ttgl.BlockedLayout([4], [THREADS_PER_WARP], [4], [0], cga_layout=[[0]])
+    load_layout = ttgl.BlockedLayout([2], [THREADS_PER_WARP], [4], [0], cga_layout=[[0]])
+    store_layout = ttgl.BlockedLayout([1], [THREADS_PER_WARP], [4], [0], cga_layout=[[1]])
     shared_layout = ttgl.SwizzledSharedLayout(
         vec=1,
         per_phase=1,
         max_phase=1,
-        order=[1, 0],
-        cga_layout=cga_layout,
+        order=[0],
+        cga_layout=[[0]],
     )
 
     @gluon.jit
     def kernel(
         in_ptr,
         out_ptr,
-        M: ttgl.constexpr,
-        N: ttgl.constexpr,
-        SLICE_M: ttgl.constexpr,
-        blocked_layout: ttgl.constexpr,
+        ALLOC: ttgl.constexpr,
+        SLICE: ttgl.constexpr,
+        alloc_layout: ttgl.constexpr,
+        load_layout: ttgl.constexpr,
+        store_layout: ttgl.constexpr,
         shared_layout: ttgl.constexpr,
     ):
-        offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, blocked_layout))[:, None]
-        offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, blocked_layout))[None, :]
-        vals = ttgl.load(in_ptr + offs_m * N + offs_n)
+        alloc_offs = ttgl.arange(0, ALLOC, layout=alloc_layout)
+        vals = ttgl.load(in_ptr + alloc_offs)
 
-        smem = ttgl.allocate_shared_memory(vals.dtype, (M, N), shared_layout, value=vals)
+        smem = ttgl.allocate_shared_memory(vals.dtype, (ALLOC, ), shared_layout, value=vals)
         ttgl.barrier(cluster=True)
 
-        tile = smem.slice(0, SLICE_M, dim=0)
-        tile_vals = tile.load(blocked_layout)
+        tile = smem.slice(0, SLICE)
+        tile_vals = tile.load(load_layout)
 
-        tile_offs_m = ttgl.arange(0, SLICE_M, layout=ttgl.SliceLayout(1, blocked_layout))[:, None]
-        tile_offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, blocked_layout))[None, :]
-        ttgl.store(out_ptr + tile_offs_m * N + tile_offs_n, tile_vals)
+        store_offs = ttgl.arange(0, SLICE, layout=store_layout)
+        store_vals = ttgl.convert_layout(tile_vals, store_layout)
+        ttgl.store(out_ptr + store_offs, store_vals + store_offs + 1)
 
-    inp = torch.arange(0, M * N, device=device, dtype=torch.int32).reshape((M, N))
-    out = torch.zeros_like(inp)
-    kernel[(1, )](inp, out, M, N, SLICE_M, blocked_layout, shared_layout, num_warps=4, num_ctas=2)
+    inp = torch.arange(0, ALLOC, device=device, dtype=torch.int32)
+    out = torch.zeros((SLICE, ), device=device, dtype=torch.int32)
+    kernel[(1, )](inp, out, ALLOC, SLICE, alloc_layout, load_layout, store_layout, shared_layout, num_warps=4,
+                  num_ctas=NUM_CTAS)
 
-    out_ref = torch.zeros_like(inp)
-    out_ref[:SLICE_M, :] = inp[:SLICE_M, :]
+    out_ref = inp[:SLICE] + torch.arange(1, SLICE + 1, device=device, dtype=torch.int32)
     torch.testing.assert_close(out, out_ref, rtol=0, atol=0)
 
 

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -52,18 +52,6 @@ module attributes {"ttg.num-ctas" = 2 : i32} {
 
 // -----
 
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 0]]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 2 : i32} {
-  tt.func public @subslice_broadcasted_cga_output(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {
-      // expected-error @+1 {{broadcasted CTA outputs}}
-      %a = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared, #smem> -> !ttg.memdesc<4x16xf32, #shared, #smem>
-      tt.return
-  }
-}
-
-// -----
-
 #shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1]}>
 #smem = #ttg.shared_memory
 tt.func public @miss_encoding(%arg0: !ttg.memdesc<8x16xf32, #shared, #smem>) {

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -85,6 +85,7 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
 #shared_cga_01 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
 #shared_cga_10 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#shared_cga_00 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 0]]}>
 #shared = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0], [4, 0]], block = [[2, 0]]}, alignment = 16>
 #smem = #ttg.shared_memory
 module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
@@ -99,6 +100,13 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 2 : i32, "ttg.num-w
   tt.func @subslice_non_trivial_block_cga_10(%arg0: !ttg.memdesc<8x16xf32, #shared_cga_10, #smem>) {
     // CHECK: ttg.memdesc_subslice %{{.*}}[0, 0]
     %0 = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared_cga_10, #smem> -> !ttg.memdesc<8x8xf32, #shared_cga_10, #smem>
+    tt.return
+  }
+
+  // CHECK-LABEL: @subslice_broadcasted_block_cga_00
+  tt.func @subslice_broadcasted_block_cga_00(%arg0: !ttg.memdesc<8x16xf32, #shared_cga_00, #smem>) {
+    // CHECK: ttg.memdesc_subslice %{{.*}}[0, 0]
+    %0 = ttg.memdesc_subslice %arg0 [0, 0] : !ttg.memdesc<8x16xf32, #shared_cga_00, #smem> -> !ttg.memdesc<4x16xf32, #shared_cga_00, #smem>
     tt.return
   }
 


### PR DESCRIPTION
Allow slicing memdesc broadcasted across CTAs. This is a common use case