### PR TITLE
[BACKEND] Disallow split-N 64-row MMAv5 TMEM lhs

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -469,6 +469,9 @@ LogicalResult impl::verifyMMAv5Op(Operation *op) {
     auto accEnc = dyn_cast<TensorMemoryEncodingAttr>(acc.getEncoding());
     if (!lhsEnc || !accEnc)
       return false;
+    // For 64-row TMEM LHS allocations, the lhs row index and accumulator row
+    // index must match for each emitted MMA, so the accumulator cannot be
+    // split across multiple row groups along N.
     auto accShapePerCTA = getShapePerCTA(acc);
     return getTmemAllocSizes(lhs).numRows == 64 &&
            accEnc.getBlockN() < accShapePerCTA[1];

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -464,12 +464,27 @@ LogicalResult impl::verifyMMAv5Op(Operation *op) {
     return enc && getTmemAllocSizes(memdesc).numRows != 64 &&
            enc.getBlockM() == 64;
   };
+  auto isSplitN64RowTMemLHS = [](MemDescType lhs, MemDescType acc) {
+    auto lhsEnc = dyn_cast<TensorMemoryEncodingAttr>(lhs.getEncoding());
+    auto accEnc = dyn_cast<TensorMemoryEncodingAttr>(acc.getEncoding());
+    if (!lhsEnc || !accEnc)
+      return false;
+    auto accShapePerCTA = ttg::getShapePerCTA(acc);
+    return getTmemAllocSizes(lhs).numRows == 64 &&
+           accEnc.getBlockN() < accShapePerCTA[1];
+  };
 
   auto itf = cast<MMAv5OpInterface>(op);
   if (isInterleaved(itf.getA().getType()) &&
       isInterleaved(itf.getAccumulator().getType())) {
     return op->emitOpError(
         "does not support blockM=64 with interleaved blocks in TMEM layout");
+  }
+  if (isSplitN64RowTMemLHS(itf.getA().getType(),
+                           itf.getAccumulator().getType())) {
+    return op->emitOpError(
+        "does not support a 64-row TMEM LHS when the accumulator blockN is "
+        "smaller than the result N dimension per CTA");
   }
   return success();
 }

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -469,7 +469,7 @@ LogicalResult impl::verifyMMAv5Op(Operation *op) {
     auto accEnc = dyn_cast<TensorMemoryEncodingAttr>(acc.getEncoding());
     if (!lhsEnc || !accEnc)
       return false;
-    auto accShapePerCTA = ttg::getShapePerCTA(acc);
+    auto accShapePerCTA = getShapePerCTA(acc);
     return getTmemAllocSizes(lhs).numRows == 64 &&
            accEnc.getBlockN() < accShapePerCTA[1];
   };

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
@@ -44,6 +44,9 @@ public:
     auto srcLayout = srcType.getEncoding();
     auto accTMemEncoding = dyn_cast<TensorMemoryEncodingAttr>(
         tcGen5MMAOp.getD().getType().getEncoding());
+    if (!accTMemEncoding)
+      return failure();
+    auto dstPerCTA = ttg::getShapePerCTA(tcGen5MMAOp.getD().getType());
     auto cgaLayout = triton::gpu::getCGALayout(srcLayout);
     // TMem encoding for A operand is the same as for D (Acc), but packed for
     // bitwidth=16
@@ -63,6 +66,14 @@ public:
         lhs.getType().getShape(), lhs.getType().getElementType(), aTMemEncoding,
         tensorMemorySpace,
         /*mutableMemory=*/false);
+    if (getTmemAllocSizes(lhsMemDescType).numRows == 64 &&
+        accTMemEncoding.getBlockN() < dstPerCTA[1]) {
+      // For 64-row TMEM LHS allocations, the LHS and accumulator slices need
+      // to stay on the same row. When blockN is smaller than the result N dim,
+      // the MMA is split across N and later accumulator slices no longer share
+      // rows with the fixed LHS allocation.
+      return failure();
+    }
     bool layoutTmemCompatible =
         isDistributedLayoutTMemCompatible(tcGen5MMAOp, srcType, lhsMemDescType);
     Attribute newLayout = srcLayout;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
@@ -308,6 +308,14 @@ allocateTMem(Operation *parentOp,
       if (isa<TensorMemoryEncodingAttr>(mmaOp.getA().getType().getEncoding())) {
         TMemAllocation allocSize = getTmemAllocSizes(mmaOp.getA().getType());
         if (allocSize.numRows == 64) {
+          auto accType = mmaOp.getAccumulator().getType();
+          auto accEncoding =
+              cast<TensorMemoryEncodingAttr>(accType.getEncoding());
+          auto accShapePerCTA = ttg::getShapePerCTA(accType);
+          assert(accEncoding.getBlockN() == accShapePerCTA[1] &&
+                 "64-row TMEM LHS requires the accumulator row index to match "
+                 "the lhs row index, so the accumulator cannot be split across "
+                 "multiple row groups along N");
           // HW restriction, the A alloc and accumulator needs to be in the same
           // rows.
           SmallVector<Operation *> lhsAllocs = getAlloc(mmaOp.getA());

--- a/test/TritonGPU/promote-lhs-to-tmem.mlir
+++ b/test/TritonGPU/promote-lhs-to-tmem.mlir
@@ -7,6 +7,7 @@
 #blocked4 = #ttg.blocked<{sizePerThread = [4, 16], threadsPerWarp = [4, 8], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked5 = #ttg.blocked<{sizePerThread = [4, 64], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 #tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 256, colStride = 1>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
@@ -162,13 +163,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttng.tc_gen5_mma %[[A_SMEM]]
   tt.func public @dont_promote_lhs_when_acc_blockn_is_smaller_than_n(%A_ptr: tensor<64x16x!tt.ptr<f16>, #blocked3>, %B_ptr: tensor<16x512x!tt.ptr<f16>, #blocked4>) {
     %true = arith.constant true
-    %cst = arith.constant dense<0.000000e+00> : tensor<64x512xf32, #blocked5>
+    %false = arith.constant false
     %A = tt.load %A_ptr : tensor<64x16x!tt.ptr<f16>, #blocked3>
     %B = tt.load %B_ptr : tensor<16x512x!tt.ptr<f16>, #blocked4>
-    %A_sh = ttg.local_alloc %A : (tensor<64x16xf16, #blocked3>) -> !ttg.memdesc<64x16xf16, #shared, #ttg.shared_memory, mutable>
-    %B_sh = ttg.local_alloc %B : (tensor<16x512xf16, #blocked4>) -> !ttg.memdesc<16x512xf16, #shared, #ttg.shared_memory, mutable>
-    %acc_tm = ttng.tmem_alloc %cst : (tensor<64x512xf32, #blocked5>) -> !ttg.memdesc<64x512xf32, #tmem1, #ttng.tensor_memory, mutable>
-    ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true : !ttg.memdesc<64x16xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<16x512xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<64x512xf32, #tmem1, #ttng.tensor_memory, mutable>
+    %A_sh = ttg.local_alloc %A : (tensor<64x16xf16, #blocked3>) -> !ttg.memdesc<64x16xf16, #shared1, #ttg.shared_memory, mutable>
+    %B_sh = ttg.local_alloc %B : (tensor<16x512xf16, #blocked4>) -> !ttg.memdesc<16x512xf16, #shared1, #ttg.shared_memory, mutable>
+    %acc_tm = ttng.tmem_alloc : () -> !ttg.memdesc<64x512xf32, #tmem1, #ttng.tensor_memory, mutable>
+    ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %false, %true : !ttg.memdesc<64x16xf16, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<16x512xf16, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<64x512xf32, #tmem1, #ttng.tensor_memory, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/promote-lhs-to-tmem.mlir
+++ b/test/TritonGPU/promote-lhs-to-tmem.mlir
@@ -3,8 +3,12 @@
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [4, 2], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [4, 16], threadsPerWarp = [4, 8], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [4, 64], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 256, colStride = 1>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
@@ -148,6 +152,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %A_sh = ttg.local_alloc %A_f16 : (tensor<128x128xf16, #blocked2>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>
     %acc_tm = ttng.tmem_alloc %cst : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true : !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @dont_promote_lhs_when_acc_blockn_is_smaller_than_n
+  // CHECK: %[[A:.+]] = tt.load
+  // CHECK: %[[A_SMEM:.+]] = ttg.local_alloc %[[A]]
+  // CHECK-NOT: ttng.tmem_alloc %[[A]]
+  // CHECK: ttng.tc_gen5_mma %[[A_SMEM]]
+  tt.func public @dont_promote_lhs_when_acc_blockn_is_smaller_than_n(%A_ptr: tensor<64x16x!tt.ptr<f16>, #blocked3>, %B_ptr: tensor<16x512x!tt.ptr<f16>, #blocked4>) {
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x512xf32, #blocked5>
+    %A = tt.load %A_ptr : tensor<64x16x!tt.ptr<f16>, #blocked3>
+    %B = tt.load %B_ptr : tensor<16x512x!tt.ptr<f16>, #blocked4>
+    %A_sh = ttg.local_alloc %A : (tensor<64x16xf16, #blocked3>) -> !ttg.memdesc<64x16xf16, #shared, #ttg.shared_memory, mutable>
+    %B_sh = ttg.local_alloc %B : (tensor<16x512xf16, #blocked4>) -> !ttg.memdesc<16x512xf16, #shared, #ttg.shared_memory, mutable>
+    %acc_tm = ttng.tmem_alloc %cst : (tensor<64x512xf32, #blocked5>) -> !ttg.memdesc<64x512xf32, #tmem1, #ttng.tensor_memory, mutable>
+    ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true : !ttg.memdesc<64x16xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<16x512xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<64x512xf32, #tmem1, #ttng.tensor_memory, mutable>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -302,6 +302,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#lhs_tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 16, colStride = 1>
+#acc_tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 256, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tcgen5_lhs_tmem_split_n(
+      %a: !ttg.memdesc<64x16xf16, #lhs_tmem, #ttng.tensor_memory>,
+      %b: !ttg.memdesc<16x512xf16, #shared, #ttg.shared_memory>,
+      %c: !ttg.memdesc<64x512xf32, #acc_tmem, #ttng.tensor_memory, mutable>,
+      %accUse: i1, %pred: i1) {
+    // expected-error @below {{does not support a 64-row TMEM LHS when the accumulator blockN is smaller than the result N dimension per CTA}}
+    ttng.tc_gen5_mma %a, %b, %c, %accUse, %pred :
+       !ttg.memdesc<64x16xf16, #lhs_tmem, #ttng.tensor_memory>,
+       !ttg.memdesc<16x512xf16, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<64x512xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 0]]}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 1]]}>
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>


### PR DESCRIPTION
Those cases cannot be lowered correctly due to restrictions in Blackwell HW