### PR TITLE
[Frontend] Support bare annotation expressions

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5725,6 +5725,16 @@ def test_poison_return(device):
         assert "poison" in h.asm["llir"], h.asm["llir"]
 
 
+def test_named_expr(device):
+
+    @triton.jit
+    def test():
+        x = (y := 0)
+        assert x == 0 and x == y
+
+    test[(1, )]()
+
+
 # -----------------------
 # test extra
 # -----------------------

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5725,16 +5725,6 @@ def test_poison_return(device):
         assert "poison" in h.asm["llir"], h.asm["llir"]
 
 
-def test_named_expr(device):
-
-    @triton.jit
-    def test():
-        x = (y := 0)
-        assert x == 0 and x == y
-
-    test[(1, )]()
-
-
 # -----------------------
 # test extra
 # -----------------------

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -361,6 +361,60 @@ def test_constexpr_function_from_python():
     assert constexpr_function(7) == 8
 
 
+@filecheck_test
+@triton.jit
+def test_named_expr():
+    # CHECK-LABEL: test_named_expr
+    x = (y := 0)
+    # CHECK: %c0_i32 = arith.constant 0 : i32
+    # CHECK-NEXT: call @{{.*}}anchor{{.*}}(%c0_i32)
+    anchor(x)
+    # CHECK-NEXT: call @{{.*}}anchor{{.*}}(%c0_i32)
+    anchor(y)
+
+
+def test_tuple_assignment_respects_prior_constexpr_annotation():
+
+    @triton.jit
+    def kernel():
+        y: tl.constexpr
+        x, y = 0, 0
+        tl.static_assert(x.dtype == tl.int32)
+        tl.static_assert(y.type == tl.constexpr_type(0))
+
+    run_parser(kernel)
+
+
+def test_named_expr_respects_prior_constexpr_annotation():
+
+    @triton.jit
+    def kernel():
+        x: tl.constexpr
+        if (x := constexpr_function(10)) != 10:
+            tl.static_assert(isinstance(x.type, tl.constexpr_type))
+        else:
+            tl.static_assert(False)
+
+    run_parser(kernel)
+
+
+@filecheck_test
+@triton.jit
+def test_named_expr_without_prior_annotation_decays():
+    # CHECK-LABEL: test_named_expr_without_prior_annotation_decays
+    # CHECK: [[COND:%.*]] = arith.cmpi ne, %c11_i32, %c10_i32 : i32
+    # CHECK: scf.if [[COND]] {
+    # CHECK:   tt.call @{{.*}}anchor{{.*}}(%c11_i32) : (i32) -> ()
+    # CHECK: } else {
+    # CHECK:   [[ADD:%.*]] = arith.addi %c11_i32, %c1_i32_0 : i32
+    # CHECK:   tt.call @{{.*}}anchor{{.*}}([[ADD]]) : (i32) -> ()
+    # CHECK: }
+    if (x := constexpr_function(10)) != 10:
+        anchor(x)
+    else:
+        anchor(x + 1)
+
+
 @triton.jit
 def swap(pair):
     return pair.second, pair.first

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -742,6 +742,14 @@ class CodeGenerator(ast.NodeVisitor):
         self.visit(assign)
         return self.visit(lhs)
 
+    def visit_NamedExpr(self, node: ast.NamedExpr):
+        # Named expressions are simple and can only be of the form x := value
+        target = node.target.id
+        with self._name_loc_prefix(target):
+            value = self.visit(node.value)
+            self.set_value(target, value)
+            return value
+
     def visit_Name(self, node):
         if type(node.ctx) is ast.Store:
             return node.id

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -117,6 +117,7 @@ class enter_sub_region:
         # record lscope & local_defs in the parent scope
         self.liveins = dict(self.generator.lscope)
         self.prev_defs = dict(self.generator.local_defs)
+        self.prev_pending_annotations = dict(self.generator.pending_annotations)
         self.generator.local_defs = {}
         self.insert_block = self.generator.builder.get_insertion_block()
         self.insert_point = self.generator.builder.get_insertion_point()
@@ -126,6 +127,7 @@ class enter_sub_region:
         self.generator.builder.restore_insertion_point(self.insert_point)
         self.generator.lscope = self.liveins
         self.generator.local_defs = self.prev_defs
+        self.generator.pending_annotations = self.prev_pending_annotations
 
 
 # Check if the given syntax node has an "early" return
@@ -334,6 +336,8 @@ class CodeGenerator(ast.NodeVisitor):
         # SSA-construction
         # name => language.tensor
         self.local_defs: Dict[str, tensor] = {}
+        # Bare local annotations such as `x: tl.constexpr`
+        self.pending_annotations: Dict[str, Any] = {}
         self.dereference_name: Callable[[str], Any] = self._define_name_lookup()
         self.fn = None
         # Are we currently visiting an ast.arg's default value?  These have some
@@ -682,6 +686,10 @@ class CodeGenerator(ast.NodeVisitor):
         annotation = self.visit(node.annotation)
         target = self.visit(node.target)
         value = self.visit(node.value)
+        # Bare annotation, without assigment
+        if node.value is None:
+            self.pending_annotations[target] = annotation
+            return None
         # constexpr
         if annotation == constexpr:
             if target in self.lscope:
@@ -719,14 +727,26 @@ class CodeGenerator(ast.NodeVisitor):
                 value = self.semantic.to_tensor(value)
             return value
 
+        def _sanitize_target_value(target, value):
+            if isinstance(target, ast.Tuple) and isinstance(value, language.tuple):
+                vals = [_sanitize_target_value(elt, val) for elt, val in zip(target.elts, value.values)]
+                vals = [constexpr(val) if val is None else val for val in vals]
+                types = [val.type for val in vals]
+                return language.tuple(vals, language.tuple_type(types, value.type.fields))
+            if isinstance(target, ast.Name):
+                annotation = self.pending_annotations.pop(target.id, None)
+                if annotation == constexpr:
+                    return constexpr(value)
+            return _sanitize_value(value)
+
         targets = [node.target] if isinstance(node, ast.AnnAssign) else node.targets
         assert len(targets) == 1
         target = targets[0]
         if isinstance(target, ast.Name):
             with self._name_loc_prefix(target.id):
-                values = _sanitize_value(self.visit(node.value))
+                values = _sanitize_target_value(target, self.visit(node.value))
         else:
-            values = _sanitize_value(self.visit(node.value))
+            values = _sanitize_target_value(target, self.visit(node.value))
         self.assignTarget(target, values)
 
     def visit_AugAssign(self, node):
@@ -744,11 +764,8 @@ class CodeGenerator(ast.NodeVisitor):
 
     def visit_NamedExpr(self, node: ast.NamedExpr):
         # Named expressions are simple and can only be of the form x := value
-        target = node.target.id
-        with self._name_loc_prefix(target):
-            value = self.visit(node.value)
-            self.set_value(target, value)
-            return value
+        self.visit_Assign(ast.Assign(targets=[node.target], value=node.value))
+        return self.dereference_name(node.target.id)
 
     def visit_Name(self, node):
         if type(node.ctx) is ast.Store:
@@ -805,6 +822,7 @@ class CodeGenerator(ast.NodeVisitor):
     }
 
     def visit_then_else_blocks(self, node, liveins, then_block, else_block):
+        pending_annotations = self.pending_annotations.copy()
         # then block
         self.builder.set_insertion_point_to_start(then_block)
         self.visit_compound_statement(node.body)
@@ -818,6 +836,7 @@ class CodeGenerator(ast.NodeVisitor):
             self.builder.set_insertion_point_to_start(else_block)
             self.lscope = liveins.copy()
             self.local_defs = {}
+            self.pending_annotations = pending_annotations.copy()
             self.visit_compound_statement(node.orelse)
             else_defs = self.local_defs.copy()
             else_block = self.builder.get_insertion_block()


### PR DESCRIPTION
Closes #8913

It isn't always possible to use annotated assignment, i.e.
```
name: type = value
```

Examples include walrus assignment, or tuple assignment. This allows
such expressions to be annotated with the syntax:
```
name: type
name = value
```

which generalizes to other forms, e.g.
```
x: tl.constexpr
x, y = 0, 0
```

or
```
x: tl.constexpr
if (x := foo()) != 0:
    tl.static_assert(isinstance(x, tl.constexpr))
```


