### PR TITLE
[CONSAN] Fix cluster_barrier handling

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -213,10 +213,10 @@ struct AuxDataMap {
   // Shared-cluster lock used to serialize ConSan instrumentation updates.
   RegionToValueMap lock;
 
-  // Consan inserts this startup barrier only to finish shared state
-  // initialization before any instrumented operation can run. It is not a
-  // user-visible publication point.
-  Operation *lockInitClusterBarrier = nullptr;
+  // Consan inserts internal cluster barriers for its own protocols. They must
+  // keep their synchronization semantics, but they are not user-visible
+  // publication points.
+  SmallVector<Operation *> nonPublishingClusterBarriers;
 
   // scratch, <Cbar x K x Cthr x i32>
   // Deadlock-detection bitfield. Each base thread uses two bits: waiting flag

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -213,6 +213,11 @@ struct AuxDataMap {
   // Shared-cluster lock used to serialize ConSan instrumentation updates.
   RegionToValueMap lock;
 
+  // Consan inserts this startup barrier only to finish shared state
+  // initialization before any instrumented operation can run. It is not a
+  // user-visible publication point.
+  Operation *lockInitClusterBarrier = nullptr;
+
   // scratch, <Cbar x K x Cthr x i32>
   // Deadlock-detection bitfield. Each base thread uses two bits: waiting flag
   // and stored phase.

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -289,7 +289,7 @@ struct LockReleaseOpConversion
       auto *ptrOpr = ptx.newAddrOperand(adaptor.getLock(), "l");
       auto *valOpr = ptx.newOperand(zero, "r");
       auto &atom = *ptx.create("atom");
-      atom.global().o("acq_rel").o("gpu").o("exch").o("b32");
+      atom.global().o("release").o("gpu").o("exch").o("b32");
       atom(dstOpr, ptrOpr, valOpr).predicate(elect);
       ptx.launch(b, loc, i32);
     } else {

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -95,10 +95,11 @@ Value createCmpIntTensorScalar(
 }
 
 template <typename OpTy>
-Value reduce(ImplicitLocOpBuilder &b, Value tensor, int axis) {
+Value reduceLastDim(ImplicitLocOpBuilder &b, Value tensor) {
   OpBuilder::InsertionGuard guard(b);
   auto tensorType = cast<RankedTensorType>(tensor.getType());
-  assert(axis >= 0 && axis < tensorType.getRank() && "invalid reduction axis");
+  assert(tensorType.getRank() > 0 && "cannot reduce a rank-0 tensor");
+  int axis = tensorType.getRank() - 1;
   auto reduceOp = triton::ReduceOp::create(b, std::vector<Value>{tensor}, axis);
   auto &region = reduceOp.getRegion();
   auto &block = region.emplaceBlock();
@@ -111,10 +112,36 @@ Value reduce(ImplicitLocOpBuilder &b, Value tensor, int axis) {
 }
 
 template <typename OpTy>
-Value reduceLastDim(ImplicitLocOpBuilder &b, Value tensor) {
+Value reduce(ImplicitLocOpBuilder &b, Value tensor, ArrayRef<int> axes) {
   auto tensorType = cast<RankedTensorType>(tensor.getType());
-  assert(tensorType.getRank() > 0 && "cannot reduce a rank-0 tensor");
-  return reduce<OpTy>(b, tensor, tensorType.getRank() - 1);
+  assert(!axes.empty() && "expected at least one reduction axis");
+
+  llvm::SmallDenseSet<int> reducedAxes;
+  for (int axis : axes) {
+    assert(axis >= 0 && axis < tensorType.getRank() &&
+           "invalid reduction axis");
+    assert(reducedAxes.insert(axis).second && "duplicate reduction axis");
+  }
+
+  SmallVector<int32_t> transposeOrder;
+  SmallVector<int64_t> flattenedShape;
+  for (int dim = 0; dim < tensorType.getRank(); ++dim) {
+    if (reducedAxes.contains(dim))
+      continue;
+    transposeOrder.push_back(dim);
+    flattenedShape.push_back(tensorType.getShape()[dim]);
+  }
+
+  int64_t reducedSize = 1;
+  for (int axis : axes) {
+    transposeOrder.push_back(axis);
+    reducedSize *= tensorType.getShape()[axis];
+  }
+  flattenedShape.push_back(reducedSize);
+
+  tensor = triton::TransOp::create(b, tensor, transposeOrder);
+  tensor = triton::ReshapeOp::create(b, flattenedShape, tensor);
+  return reduceLastDim<OpTy>(b, tensor);
 }
 
 template <typename OpTy>
@@ -272,7 +299,7 @@ Value expandAliases(ImplicitLocOpBuilder &b, Value bufferMask,
   Value bufMaskMatrix =
       convertAndBroadcast(b, bufferMask, {0}, aliasMatrixType);
   Value aliasingMask = arith::AndIOp::create(b, aliasMatrix, bufMaskMatrix);
-  Value aliasVector = reduce<arith::OrIOp>(b, aliasingMask, /*axis=*/0);
+  Value aliasVector = reduce<arith::OrIOp>(b, aliasingMask, {0});
   return createConvertLayout(b, aliasVector, bufferMaskType.getEncoding());
 }
 
@@ -764,8 +791,7 @@ void FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
             convertAndBroadcast(fb, phaseIsOne, {0, 1}, waitingGlobalType);
         Value effectiveWaiting = arith::SelectOp::create(
             fb, phaseIsOne, waitingPhase1, waitingPhase0);
-        Value waitingOr = reduce<arith::OrIOp>(fb, effectiveWaiting, 1);
-        waitingOr = reduce<arith::OrIOp>(fb, waitingOr, 0);
+        Value waitingOr = reduce<arith::OrIOp>(fb, effectiveWaiting, {0, 1});
         auto waitingOrType = cast<RankedTensorType>(waitingOr.getType());
         Value activeMasks = tti::createLoadScratchMemory(
             fb, fb.getLoc(), activeMasksPtr, activeMasksGlobalType);
@@ -1800,8 +1826,7 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
             fb, readVisibilityType, /*dim=*/2, createCurrentCTAMask(fb));
         visibleReads = arith::SelectOp::create(fb, sourceCTAMask, visibleReads,
                                                readVisibilityZero);
-        visibleReads = reduce<arith::OrIOp>(fb, visibleReads, /*axis=*/3);
-        visibleReads = reduce<arith::OrIOp>(fb, visibleReads, /*axis=*/2);
+        visibleReads = reduce<arith::OrIOp>(fb, visibleReads, {2, 3});
         visibleReads =
             convertAndBroadcast(fb, visibleReads, {0, 1, 4}, readTrackingType);
         Value readTrackingOrVisible =
@@ -2086,8 +2111,7 @@ void FunctionBuilder::createTransferVisibleWritesCall(
             tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
         Value trackingBuffers = arith::SelectOp::create(
             fb, barriersEqBar, writeTracking, zeroTracking);
-        trackingBuffers = reduceLastDim<arith::OrIOp>(fb, trackingBuffers);
-        trackingBuffers = reduce<arith::OrIOp>(fb, trackingBuffers, /*axis=*/2);
+        trackingBuffers = reduce<arith::OrIOp>(fb, trackingBuffers, {2, 3});
         trackingBuffers = convertAndBroadcast(fb, trackingBuffers, {0, 1},
                                               writeVisibilityType);
         auto trackingBuffersType =
@@ -2181,8 +2205,7 @@ void FunctionBuilder::createTransferVisibleReadsCall(
             tti::createConstIntTensor(fb, fb.getLoc(), 0, readTrackingType);
         Value trackingBar = arith::SelectOp::create(
             fb, barriersEqBar, readTracking, readTrackingZero);
-        trackingBar = reduce<arith::OrIOp>(fb, trackingBar, /*axis=*/3);
-        trackingBar = reduce<arith::OrIOp>(fb, trackingBar, /*axis=*/2);
+        trackingBar = reduce<arith::OrIOp>(fb, trackingBar, {2, 3});
         trackingBar =
             convertAndBroadcast(fb, trackingBar, {0, 1, 4}, readVisibilityType);
         Value readVisibilityOrTracking =
@@ -2369,17 +2392,14 @@ void FunctionBuilder::createVerifyReadVisibilityCall(
           tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
       Value bufVisibility = arith::SelectOp::create(
           fb, buffersEqBuf, readVisibility, readVisibilityZero);
-      Value totalVisibility = reduce<arith::OrIOp>(fb, bufVisibility,
-                                                   /*axis=*/3);
-      totalVisibility = reduce<arith::OrIOp>(fb, totalVisibility, /*axis=*/2);
+      Value totalVisibility = reduce<arith::OrIOp>(fb, bufVisibility, {2, 3});
       Value threadColumnMask =
           createDimMask(fb, threadVal, readVisibilityType, /*dim=*/3);
       Value accessorVisibility = arith::SelectOp::create(
           fb, relationMask, bufVisibility, readVisibilityZero);
       accessorVisibility = arith::SelectOp::create(
           fb, threadColumnMask, accessorVisibility, readVisibilityZero);
-      accessorVisibility =
-          reduce<arith::OrIOp>(fb, accessorVisibility, /*axis=*/3);
+      accessorVisibility = reduce<arith::OrIOp>(fb, accessorVisibility, {3});
       auto accessorVisibilityType =
           cast<RankedTensorType>(accessorVisibility.getType());
       totalVisibility = convertAndBroadcast(fb, totalVisibility, {0, 1, 3},
@@ -2391,10 +2411,7 @@ void FunctionBuilder::createVerifyReadVisibilityCall(
                                 threadAndTotalVisibility, totalVisibility);
       Value selectedAccessors =
           arith::AndIOp::create(fb, buffersEqBuf, relationMask);
-      selectedAccessors =
-          reduce<arith::OrIOp>(fb, selectedAccessors, /*axis=*/4);
-      selectedAccessors =
-          reduce<arith::OrIOp>(fb, selectedAccessors, /*axis=*/3);
+      selectedAccessors = reduce<arith::OrIOp>(fb, selectedAccessors, {3, 4});
       selectedAccessors = convertAndBroadcast(fb, selectedAccessors, {0, 1, 2},
                                               accessorVisibilityType);
       Value one = tti::createConstIntTensor(
@@ -2557,7 +2574,7 @@ void FunctionBuilder::createCopyReadVisibilityCall(ImplicitLocOpBuilder &b,
             createDimMask(fb, sourceThread, readVisibilityType, /*dim=*/3);
         Value sourceColumn = arith::SelectOp::create(
             fb, sourceColumnMask, readVisibility, zeroTensor);
-        Value sourceVector = reduce<arith::OrIOp>(fb, sourceColumn, /*axis=*/3);
+        Value sourceVector = reduce<arith::OrIOp>(fb, sourceColumn, {3});
         Value broadcastRow = convertAndBroadcast(fb, sourceVector, {0, 1, 2, 4},
                                                  readVisibilityType);
         Value replicated = arith::SelectOp::create(fb, destMaskTensor,
@@ -2621,8 +2638,7 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
             arith::AndIOp::create(fb, writeVisibility, baseMask), zeroWrites);
         Value syncWrites = arith::SelectOp::create(fb, hasBaseWrite,
                                                    writeVisibility, zeroWrites);
-        Value writesForCluster =
-            reduce<arith::OrIOp>(fb, syncWrites, /*axis=*/2);
+        Value writesForCluster = reduce<arith::OrIOp>(fb, syncWrites, {2});
         writesForCluster = convertAndBroadcast(fb, writesForCluster, {0, 1},
                                                writeVisibilityType);
         Value newWriteVisibility =
@@ -2640,9 +2656,7 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
             arith::AndIOp::create(fb, readVisibility, readBaseMask), zeroReads);
         Value syncReads =
             arith::SelectOp::create(fb, hasBaseRead, readVisibility, zeroReads);
-        Value readsForCluster = reduce<arith::OrIOp>(fb, syncReads, /*axis=*/4);
-        readsForCluster = reduce<arith::OrIOp>(fb, readsForCluster,
-                                               /*axis=*/2);
+        Value readsForCluster = reduce<arith::OrIOp>(fb, syncReads, {2, 4});
         readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1, 3},
                                               readVisibilityType);
         Value newReadVisibility =

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -2656,8 +2656,8 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
             arith::AndIOp::create(fb, readVisibility, readBaseMask), zeroReads);
         Value syncReads =
             arith::SelectOp::create(fb, hasBaseRead, readVisibility, zeroReads);
-        Value readsForCluster = reduce<arith::OrIOp>(fb, syncReads, {2, 4});
-        readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1, 3},
+        Value readsForCluster = reduce<arith::OrIOp>(fb, syncReads, {2, 3, 4});
+        readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1},
                                               readVisibilityType);
         Value newReadVisibility =
             arith::OrIOp::create(fb, readVisibility, readsForCluster);

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -638,7 +638,7 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
       arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId, zero);
   ExperimentalLockReleaseOp::create(b, lockVal, isCTA0);
   if (numCTAs > 1) {
-    ClusterBarrierOp::create(b, b.getLoc());
+    lockInitClusterBarrier = ClusterBarrierOp::create(b, b.getLoc());
   } else {
     BarrierOp::create(b, b.getLoc(), AddrSpace::Local);
   }

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -638,7 +638,8 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
       arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId, zero);
   ExperimentalLockReleaseOp::create(b, lockVal, isCTA0);
   if (numCTAs > 1) {
-    lockInitClusterBarrier = ClusterBarrierOp::create(b, b.getLoc());
+    auto clusterBarrier = ClusterBarrierOp::create(b, b.getLoc());
+    nonPublishingClusterBarriers.push_back(clusterBarrier.getOperation());
   } else {
     BarrierOp::create(b, b.getLoc(), AddrSpace::Local);
   }

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -543,7 +543,8 @@ private:
         }
       }
       if (auto clusterBarrier = dyn_cast<ttng::ClusterBarrierOp>(op)) {
-        if (!clusterBarrier.getRelaxed()) {
+        if (!clusterBarrier.getRelaxed() &&
+            op != auxData.lockInitClusterBarrier) {
           b.setInsertionPointAfter(op);
           for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM})
             funcBuilder.createPublishClusterVisibilityCall(b, nullptr, memType,

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -544,11 +544,25 @@ private:
       }
       if (auto clusterBarrier = dyn_cast<ttng::ClusterBarrierOp>(op)) {
         if (!clusterBarrier.getRelaxed() &&
-            op != auxData.lockInitClusterBarrier) {
+            !llvm::is_contained(auxData.nonPublishingClusterBarriers, op)) {
           b.setInsertionPointAfter(op);
+          // Publish the cluster-wide frontier once, then keep every CTA at
+          // this synchronization point until the publication completes.
+          b.setListener(nullptr);
+          Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
+          Value zero = arith::ConstantIntOp::create(b, 0, 32);
+          Value isCTA0 =
+              arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId, zero);
+          Value lock = auxData.lock.at(op).value;
+          tti::ExperimentalLockAcquireOp::create(b, lock, isCTA0);
           for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM})
-            funcBuilder.createPublishClusterVisibilityCall(b, nullptr, memType,
+            funcBuilder.createPublishClusterVisibilityCall(b, isCTA0, memType,
                                                            op);
+          tti::ExperimentalLockReleaseOp::create(b, lock, isCTA0);
+          auto publishBarrier = ttng::ClusterBarrierOp::create(b, b.getLoc());
+          auxData.nonPublishingClusterBarriers.push_back(
+              publishBarrier.getOperation());
+          b.setListener(&listener);
         }
       }
 

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -521,6 +521,45 @@ def test_async_tma_multicast_kernel_local_store_race(device, run_wrapper, monkey
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+def test_cluster_barrier_does_not_publish_later_read(device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_cluster_barrier_does_not_publish_later_read, (device, False, monkeypatch))
+        assert_expected_cuda_failure(result.exc)
+        assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(input_desc):
+        cga_layout: ttgl.constexpr = multicast_cga_layout(ttgl.num_ctas(), 2)
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], input_desc.layout)
+        sink = ttgl.allocate_shared_memory(ttgl.float16, [2, XBLOCK, XBLOCK], input_desc.layout)
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+
+        ttgl.barrier(cluster=True)
+        val = smem.load(blocked_layout)
+        # Keep the post-barrier read live long enough to exercise delayed publication from another CTA.
+        for i in ttgl.static_range(2):
+            sink.index(i).store(val)
+
+        mbarrier.expect(bar, input_desc.nbytes_per_cta)
+        tma.async_load(input_desc, [0, 0], bar, smem, multicast=True)
+        mbarrier.wait(bar, 0, deps=[smem])
+
+    input = torch.randn((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
+                                           cga_layout=multicast_cga_layout(4, 2))
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK.value, XBLOCK.value], shared_layout)
+    kernel[(1, )](input_desc, num_warps=4, num_ctas=4)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_async_tma_kernel_2bufs_1bar(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
     if run_wrapper:

--- a/test/Conversion/tritoninstrument_to_llvm.mlir
+++ b/test/Conversion/tritoninstrument_to_llvm.mlir
@@ -56,7 +56,7 @@ tt.func private @experimental_lock_acquire(
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
 // CHECK-LABEL: @experimental_lock_release
 // CHECK: nvvm.barrier0
-// CHECK: atom.global.acq_rel.gpu.exch.b32
+// CHECK: atom.global.release.gpu.exch.b32
 tt.func private @experimental_lock_release(
   %lock: !tt.ptr<i32>,
   %pred: i1

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -51,6 +51,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
     // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 64 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
+    // CHECK-NOT: publish_cluster_visibility
+    // CHECK: tt.return
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1640,3 +1640,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+#shared_cluster_publish = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#smem_cluster_publish = #ttg.shared_memory
+#blocked_cluster_publish = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @cluster_barrier_publish_protocol
+  tt.func public @cluster_barrier_publish_protocol() {
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared_cluster_publish, #smem_cluster_publish, mutable>
+    // CHECK: ttg.local_load
+    // CHECK-NEXT: ttng.cluster_barrier
+    // CHECK: %[[PUB_CTA:.*]] = tti.experimental_cluster_cta_id : i32
+    // CHECK: %[[PUB_ZERO:.*]] = arith.constant 0 : i32
+    // CHECK: %[[PUB_PRED:.*]] = arith.cmpi eq, %[[PUB_CTA]], %[[PUB_ZERO]] : i32
+    // CHECK: tti.experimental_lock_acquire %{{.*}}, %[[PUB_PRED]]
+    // CHECK: tt.call @__triton_consan_publish_cluster_visibility{{.*}}(%[[PUB_PRED]],
+    // CHECK: tti.experimental_lock_release %{{.*}}, %[[PUB_PRED]]
+    // CHECK-NEXT: ttng.cluster_barrier
+    ttg.local_load %buf : !ttg.memdesc<32x32xf32, #shared_cluster_publish, #smem_cluster_publish, mutable> -> tensor<32x32xf32, #blocked_cluster_publish>
+    ttng.cluster_barrier
+    tt.return
+  }
+}


### PR DESCRIPTION
**Reviewers** Read the OP and then review commit by commit as it'll be easier!

There were a number of issues with the previous handling of `cluster_barrier`.

1. We were emitting the shadow memory update from all CTAs without another cluster barrier afterwards, so this was not seen as cross-cta synchronous and this update was tripping updates after it at times
2. There was a reduction that was incorrect (more on this later)
3. (minor) We were emitting the shadow memory update even for a cluster barrier that we were emitting to synchronise the consan shadow memory initialisation.

3 Was triggering 1. which caused the race. We fix these by not instrumenting ClusterBarrierOps emitted by consan. Also, for cluster_barriers we now emit the shadow memory update just from CTA0 and we emit another ClusterBarrierOp so that all CTAs see it.

2 was a different issue found while looking into this.
We had tensors
```
writeVisibility: <Cbuf x B x Cmask>
readVisibility: <Cbuf x B x Cthr x T x Cmask>
```
The first one we were reducing to a  <Cbuf x B> but the second one we were mistakenly reducing just along dims 2, 4, rather than 2, 3, 4. This meant we were not really computing the full visibility of a given buffer.

To fix this, we start adding an [NFC] commit that allows to reduce several axis combined, to simplify multi-axis reduction code. In the next commit we push the fix.

We also add a simplification of the global lock semantics doing the release via `release` rather than `acq_rel`.
