### PR TITLE
[Interpreter] Fix maximum/minimum/clamp NaN handling to match JIT semantics

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6130,6 +6130,7 @@ def test_num_ctas_pre_sm90(device, fresh_knobs):
 # -----------------------
 
 
+@pytest.mark.interpreter
 @pytest.mark.parametrize("dtype", ['float16', 'float32'])
 @pytest.mark.parametrize("propagate_nan", ['NONE', 'ALL'])
 @pytest.mark.parametrize("func", ['minimum', 'maximum', 'clamp'])

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -582,11 +582,11 @@ class InterpreterBuilder:
     create_minsi = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.minimum)
     create_minui = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.minimum)
     create_minimumf = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.minimum)
-    create_minnumf = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.minimum)
+    create_minnumf = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.fmin)
     create_maxsi = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.maximum)
     create_maxui = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.maximum)
     create_maximumf = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.maximum)
-    create_maxnumf = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.maximum)
+    create_maxnumf = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.fmax)
     create_icmpSLE = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.less_equal)
     create_icmpSLT = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.less)
     create_icmpSGE = lambda self, lhs, rhs: self.binary_op(lhs, rhs, np.greater_equal)
@@ -650,7 +650,12 @@ class InterpreterBuilder:
 
         return TensorHandle(output, tl_dtype)
 
-    create_clampf = lambda self, arg, lo, hi, propagate_nans: self.ternary_op(arg, lo, hi, np.clip)
+    def create_clampf(self, arg, lo, hi, propagate_nans):
+        if propagate_nans == _ir.PROPAGATE_NAN.NONE:
+            return self.binary_op(self.binary_op(arg, lo, np.fmax), hi, np.fmin)
+        else:
+            return self.ternary_op(arg, lo, hi, np.clip)
+
     create_select = lambda self, cond, lhs, rhs: self.ternary_op(cond, lhs, rhs, np.where)
 
     def create_fma(self, x, y, z):


### PR DESCRIPTION
Follow-up to #10298, which fixed NaN handling for the reduce path (argmax/argmin).
This PR fixes the elementwise path: `tl.maximum`, `tl.minimum`, and `tl.clamp`.

When `propagate_nan=NONE` (the default), the intended semantics are "skip NaN,
return the non-NaN operand." The JIT path is correct; the interpreter was
incorrectly propagating NaN:

- `create_maxnumf` used `np.maximum` (NaN-propagating); replaced with `np.fmax` (NaN-skipping)
- `create_minnumf` used `np.minimum` (NaN-propagating); replaced with `np.fmin` (NaN-skipping)
- `create_clampf` ignored the `propagate_nans` parameter and always used `np.clip`
  (NaN-propagating); now dispatches on `_ir.PROPAGATE_NAN.NONE`/`ALL`: `NONE` uses
  an `fmax`/`fmin` chain, `ALL` keeps `np.clip`

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these rules.
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

Select one of the following.
- [x] I have added tests.
  - `python/test/unit/language/test_core.py::test_propagate_nan` — added
    `@pytest.mark.interpreter` so the existing test now also covers the interpreter
    path (2 dtypes × 2 `propagate_nan` values × 3 functions = 12 cases)

Select one of the following.
- [x] I have not added any lit tests.