### PR TITLE
[Frontend] Allow specification of vector register usage for inline asm op

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -876,8 +876,27 @@ def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [
     elems it receives is unspecified.
   }];
 
-  let arguments = (ins StrAttr:$asm_string, StrAttr:$constraints, BoolAttr:$pure, I32Attr:$packed_element, Variadic<AnyTypeOf<[TT_Type]>>:$args);
+  let arguments = (ins StrAttr:$asm_string, StrAttr:$constraints, BoolAttr:$pure,
+                   I32Attr:$packed_element,
+                   OptionalAttr<DenseI32ArrayAttr>:$operand_vec_sizes,
+                   OptionalAttr<DenseI32ArrayAttr>:$result_vec_sizes,
+                   Variadic<AnyTypeOf<[TT_Type]>>:$args);
   let results = (outs Variadic<TT_Type>:$result);
+
+  let builders = [
+    OpBuilder<(ins "TypeRange":$resultTypes, "StringRef":$asmString,
+                   "StringRef":$constraints, "bool":$pure,
+                   "int32_t":$packedElement,
+                   CArg<"ValueRange", "{}">:$args), [{
+      $_state.addTypes(resultTypes);
+      $_state.addAttribute("asm_string", $_builder.getStringAttr(asmString));
+      $_state.addAttribute("constraints", $_builder.getStringAttr(constraints));
+      $_state.addAttribute("pure", $_builder.getBoolAttr(pure));
+      $_state.addAttribute("packed_element",
+                           $_builder.getI32IntegerAttr(packedElement));
+      $_state.addOperands(args);
+    }]>
+  ];
 
   let assemblyFormat = [{
     $asm_string attr-dict ($args^ `:` type($args))? `->` type($result)

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -259,11 +259,14 @@ struct ElementwiseInlineAsmOpConversion
           packedOperands.push_back(value);
           continue;
         }
-        Type ty = vec_ty(value.getType(), vecSize);
+        Type asmValueTy = value.getType();
+        Type ty = vec_ty(asmValueTy, vecSize);
         value = b.insert_element(b.undef(ty), value, b.i32_val(0));
         for (int k = 1; k < vecSize; k++)
           value = b.insert_element(
               value, packOperand(i, j + k * numElementPerReg), b.i32_val(k));
+        unsigned bitWidth = getIntOrFloatOrPtrBitWidth(asmValueTy);
+        value = b.bitcast(value, int_ty(bitWidth * vecSize));
         packedOperands.push_back(value);
       }
     }
@@ -302,7 +305,12 @@ struct ElementwiseInlineAsmOpConversion
       int32_t vecSize = resultVecSizes ? (*resultVecSizes)[resultIdx] : 1;
       for (unsigned i = 0; i < op.getPackedElement() / numElemsPerReg;
            i += vecSize) {
-        asmRetTypes.push_back(vecSize == 1 ? ty : vec_ty(ty, vecSize));
+        Type retTy = ty;
+        if (vecSize != 1) {
+          unsigned bitWidth = getIntOrFloatOrPtrBitWidth(ty);
+          retTy = int_ty(bitWidth * vecSize);
+        }
+        asmRetTypes.push_back(retTy);
       }
     }
     Type asmRetType =
@@ -321,8 +329,8 @@ struct ElementwiseInlineAsmOpConversion
                            /*operand_attrs=*/ArrayAttr())
                            ->getResult(0);
 
-    // asmResults can be a scalar, a vector, or a struct mixing both. We unpack
-    // into per-result element lists ret[resultIdx][elementIdx].
+    // asmResults is may be struct of possibly bitcasted requested types. We
+    // unpack into per-result element lists ret[resultIdx][elementIdx].
     SmallVector<SmallVector<Value>> ret(op->getNumResults());
     int structIdx = 0;
     for (int i = 0; i < op->getNumResults(); i++) {
@@ -331,6 +339,8 @@ struct ElementwiseInlineAsmOpConversion
       unsigned bitWidth = getIntOrFloatOrPtrBitWidth(elemTy);
       unsigned numElemsPerReg =
           std::min(std::max(32 / bitWidth, 1u), op.getPackedElement());
+      Type asmValueTy =
+          numElemsPerReg == 1 ? elemTy : int_ty(bitWidth * numElemsPerReg);
       Type packedTy =
           numElemsPerReg == 1 ? elemTy : vec_ty(elemTy, numElemsPerReg);
       int32_t vecSize = resultVecSizes ? (*resultVecSizes)[i] : 1;
@@ -339,6 +349,10 @@ struct ElementwiseInlineAsmOpConversion
         Value val = asmRetTypes.size() > 1
                         ? b.extract_val(asmResults, structIdx++)
                         : asmResults;
+        if (vecSize != 1) {
+          Type vecTy = vec_ty(asmValueTy, vecSize);
+          val = b.bitcast(val, vecTy);
+        }
         for (int k = 0; k < vecSize; k++) {
           Value packed =
               vecSize == 1 ? val : b.extract_element(val, b.i32_val(k));

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -213,7 +213,9 @@ struct ElementwiseInlineAsmOpConversion
   using Adaptor = typename Base::OpAdaptor;
   typedef typename Base::OpAdaptor OpAdaptor;
 
-  // If operand size is smaller than 32 bits, pack in groups of 32 bits.
+  // Build the asm operands for one packed invocation. Each operand contributes
+  // consecutive packed values; sub-32-bit elements are combined and bitcast
+  // to integer types before optional operand_vec_sizes vectorization.
   SmallVector<Value> packOperands(ElementwiseInlineAsmOp op,
                                   MultipleOperandsRange operands,
                                   ConversionPatternRewriter &rewriter,
@@ -221,24 +223,48 @@ struct ElementwiseInlineAsmOpConversion
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     SmallVector<Value> packedOperands;
     unsigned numPackedElements = op.getPackedElement();
-    for (int i = 0, e = op.getNumOperands(); i < e; i++) {
-      Type elemTy = getElementTypeOrSelf(op.getOperand(i));
+
+    auto getNumElementPerReg = [&](int operandIdx) {
+      Type elemTy = getElementTypeOrSelf(op.getOperand(operandIdx));
       unsigned bitWidth =
           elemTy.isIntOrFloat() ? elemTy.getIntOrFloatBitWidth() : 64;
       unsigned numElementPerReg = std::max(32 / bitWidth, 1u);
-      numElementPerReg = std::min(numElementPerReg, numPackedElements);
-      for (int j = 0; j < numPackedElements; j += numElementPerReg) {
-        if (numElementPerReg == 1) {
-          packedOperands.push_back(operands[j][i]);
+      return std::min(numElementPerReg, numPackedElements);
+    };
+    auto packOperand = [&](int operandIdx, int elemIdx) {
+      Type elemTy = getElementTypeOrSelf(op.getOperand(operandIdx));
+      unsigned bitWidth =
+          elemTy.isIntOrFloat() ? elemTy.getIntOrFloatBitWidth() : 64;
+      unsigned numElementPerReg = getNumElementPerReg(operandIdx);
+      Value value = operands[elemIdx][operandIdx];
+      if (numElementPerReg > 1) {
+        Type ty =
+            vec_ty(getTypeConverter()->convertType(elemTy), numElementPerReg);
+        value = b.undef(ty);
+        for (int k = 0; k < numElementPerReg; k++)
+          value = b.insert_element(value, operands[elemIdx + k][operandIdx],
+                                   b.i32_val(k));
+        value = b.bitcast(value, int_ty(bitWidth * numElementPerReg));
+      }
+      return value;
+    };
+
+    std::optional<ArrayRef<int32_t>> vecSizes = op.getOperandVecSizes();
+    for (int i = 0, e = op.getNumOperands(); i < e; i++) {
+      unsigned numElementPerReg = getNumElementPerReg(i);
+      int32_t vecSize = vecSizes ? (*vecSizes)[i] : 1;
+      for (int j = 0; j < numPackedElements; j += numElementPerReg * vecSize) {
+        Value value = packOperand(i, j);
+        if (vecSize == 1) {
+          packedOperands.push_back(value);
           continue;
         }
-        Type t =
-            vec_ty(getTypeConverter()->convertType(elemTy), numElementPerReg);
-        Value packed = b.undef(t);
-        for (int k = 0; k < numElementPerReg; k++) {
-          packed = b.insert_element(packed, operands[j + k][i], b.i32_val(k));
-        }
-        packedOperands.push_back(packed);
+        Type ty = vec_ty(value.getType(), vecSize);
+        value = b.insert_element(b.undef(ty), value, b.i32_val(0));
+        for (int k = 1; k < vecSize; k++)
+          value = b.insert_element(
+              value, packOperand(i, j + k * numElementPerReg), b.i32_val(k));
+        packedOperands.push_back(value);
       }
     }
     return packedOperands;
@@ -255,26 +281,28 @@ struct ElementwiseInlineAsmOpConversion
       llvm::report_fatal_error("Inline asm op has more packed elements than "
                                "number of elements per thread.");
 
-    // Pack elems smaller than 32 bits into 32-bit registers.
     SmallVector<Value> packedOperands =
         packOperands(op, operands, rewriter, loc);
 
     // Types returned by the LLVM asm op.  If there's more than one, they'll be
     // wrapped in a struct.
     SmallVector<Type> asmRetTypes;
-    for (auto result : op.getResult()) {
+    std::optional<ArrayRef<int32_t>> resultVecSizes = op.getResultVecSizes();
+    for (auto [resultIdx, result] : llvm::enumerate(op.getResult())) {
       auto ty = getTypeConverter()->convertType(getElementTypeOrSelf(result));
 
-      // Pack return elements into 32-bits.
+      // Pack return elements up to 32 bits.
       unsigned bitWidth = getIntOrFloatOrPtrBitWidth(ty);
       unsigned numElemsPerReg =
           std::min(std::max(32 / bitWidth, 1u), op.getPackedElement());
       assert(op.getPackedElement() % numElemsPerReg == 0);
       if (numElemsPerReg > 1) {
-        ty = vec_ty(ty, numElemsPerReg);
+        ty = int_ty(bitWidth * numElemsPerReg);
       }
-      for (unsigned i = 0; i < op.getPackedElement() / numElemsPerReg; i++) {
-        asmRetTypes.push_back(ty);
+      int32_t vecSize = resultVecSizes ? (*resultVecSizes)[resultIdx] : 1;
+      for (unsigned i = 0; i < op.getPackedElement() / numElemsPerReg;
+           i += vecSize) {
+        asmRetTypes.push_back(vecSize == 1 ? ty : vec_ty(ty, vecSize));
       }
     }
     Type asmRetType =
@@ -293,25 +321,35 @@ struct ElementwiseInlineAsmOpConversion
                            /*operand_attrs=*/ArrayAttr())
                            ->getResult(0);
 
-    // asmResults is a flat struct; pack its values into
-    // [return_value][op.getPackedElement()].
+    // asmResults can be a scalar, a vector, or a struct mixing both. We unpack
+    // into per-result element lists ret[resultIdx][elementIdx].
     SmallVector<SmallVector<Value>> ret(op->getNumResults());
     int structIdx = 0;
     for (int i = 0; i < op->getNumResults(); i++) {
-      for (int j = 0; j < op.getPackedElement(); j++) {
-        Value val;
-        if (asmRetTypes.size() > 1) {
-          val = b.extract_val(asmResults, structIdx++);
-        } else {
-          val = asmResults;
-        }
-        if (auto vectorTy = dyn_cast<VectorType>(val.getType())) {
-          for (int k = 0; k < vectorTy.getNumElements(); k++) {
-            ret[i].push_back(b.extract_element(val, b.i32_val(k)));
+      Type elemTy = getTypeConverter()->convertType(
+          getElementTypeOrSelf(op->getResult(i)));
+      unsigned bitWidth = getIntOrFloatOrPtrBitWidth(elemTy);
+      unsigned numElemsPerReg =
+          std::min(std::max(32 / bitWidth, 1u), op.getPackedElement());
+      Type packedTy =
+          numElemsPerReg == 1 ? elemTy : vec_ty(elemTy, numElemsPerReg);
+      int32_t vecSize = resultVecSizes ? (*resultVecSizes)[i] : 1;
+      for (int j = 0; j < op.getPackedElement();
+           j += numElemsPerReg * vecSize) {
+        Value val = asmRetTypes.size() > 1
+                        ? b.extract_val(asmResults, structIdx++)
+                        : asmResults;
+        for (int k = 0; k < vecSize; k++) {
+          Value packed =
+              vecSize == 1 ? val : b.extract_element(val, b.i32_val(k));
+          if (numElemsPerReg == 1) {
+            ret[i].push_back(packed);
+            continue;
           }
-          j += vectorTy.getNumElements() - 1;
-        } else {
-          ret[i].push_back(val);
+          if (packed.getType() != packedTy)
+            packed = b.bitcast(packed, packedTy);
+          for (int l = 0; l < numElemsPerReg; l++)
+            ret[i].push_back(b.extract_element(packed, b.i32_val(l)));
         }
       }
     }

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1476,6 +1476,48 @@ LogicalResult ElementwiseInlineAsmOp::verify() {
              << getPackedElement();
     }
   }
+  auto getNumPackedValues = [&](Type type, StringRef attrName,
+                                int64_t &numValues) -> LogicalResult {
+    Type elemTy = getElementTypeOrSelf(type);
+    unsigned bitWidth =
+        elemTy.isIntOrFloat() ? elemTy.getIntOrFloatBitWidth() : 64;
+    unsigned numElemsPerReg = std::min(
+        std::max(32 / bitWidth, 1u), static_cast<unsigned>(getPackedElement()));
+    if (getPackedElement() % numElemsPerReg != 0)
+      return emitError(attrName)
+             << " requires packed_element to be divisible by the number of "
+                "elements per packed asm value";
+    numValues = getPackedElement() / numElemsPerReg;
+    return success();
+  };
+  auto verifyVecSizes = [&](std::optional<ArrayRef<int32_t>> vecSizes,
+                            TypeRange types, StringRef attrName,
+                            StringRef valueKind) -> LogicalResult {
+    if (!vecSizes)
+      return success();
+    if (vecSizes->size() != types.size())
+      return emitError(attrName) << " must have one element per " << valueKind;
+    for (auto [i, size] : llvm::enumerate(*vecSizes)) {
+      if (size <= 0)
+        return emitError(attrName)
+               << " element #" << i << " must be greater than zero";
+      int64_t numValues;
+      if (failed(getNumPackedValues(types[i], attrName, numValues)))
+        return failure();
+      if (numValues % size != 0)
+        return emitError(attrName)
+               << " element #" << i
+               << " must evenly divide the packed asm values for " << valueKind
+               << " #" << i;
+    }
+    return success();
+  };
+  if (failed(verifyVecSizes(getOperandVecSizes(), getOperandTypes(),
+                            "operand_vec_sizes", "operand")))
+    return failure();
+  if (failed(verifyVecSizes(getResultVecSizes(), getResultTypes(),
+                            "result_vec_sizes", "result")))
+    return failure();
   return success();
 }
 

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1801,10 +1801,20 @@ void init_triton_ir(py::module &&m) {
       .def("create_inline_asm",
            [](TritonOpBuilder &self, const std::string &inlineAsm,
               const std::string &constraints, const std::vector<Value> &values,
-              const std::vector<Type> &types, bool isPure,
-              int pack) -> OpState {
+              const std::vector<Type> &types, bool isPure, int pack,
+              const std::vector<int32_t> &operandVecSizes,
+              const std::vector<int32_t> &resultVecSizes) -> OpState {
+             DenseI32ArrayAttr operandVecSizesAttr;
+             DenseI32ArrayAttr resultVecSizesAttr;
+             if (!operandVecSizes.empty())
+               operandVecSizesAttr =
+                   DenseI32ArrayAttr::get(self.getContext(), operandVecSizes);
+             if (!resultVecSizes.empty())
+               resultVecSizesAttr =
+                   DenseI32ArrayAttr::get(self.getContext(), resultVecSizes);
              return self.create<ElementwiseInlineAsmOp>(
-                 types, inlineAsm, constraints, isPure, pack, values);
+                 types, inlineAsm, constraints, isPure, pack,
+                 operandVecSizesAttr, resultVecSizesAttr, values);
            })
       .def("create_print",
            [](TritonOpBuilder &self, const std::string &prefix, bool hex,

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3447,7 +3447,8 @@ def device_assert(cond, msg="", mask=None, _semantic=None):
 
 @builtin
 def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Union[dtype, Sequence[dtype]],
-                           is_pure: bool, pack: int, _semantic=None):
+                           is_pure: bool, pack: int, operand_vec_sizes: Sequence[int] | None = None,
+                           result_vec_sizes: Sequence[int] | None = None, _semantic=None):
     '''
         Execute inline assembly over a tensor.  Essentially, this is :code:`map`
         where the function is inline assembly.
@@ -3532,12 +3533,22 @@ def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Un
         :param dtype: the element type(s) of the returned tensor(s)
         :param is_pure: if true, the compiler assumes the asm block has no side-effects
         :param pack: the number of elements to be processed by one instance of inline assembly
+        :param operand_vec_sizes: optional LLVM inline asm operand register vectorization degree.
+            If set, this must have one value per value in ``args``, and each value N must evenly
+            divide the number of LLVM asm registers generated for that argument in one instance
+            of inline assembly.
+        :param result_vec_sizes: optional LLVM inline asm result vector register sizes.
+            If set, this must have one value per output tensor, and each value N must evenly
+            divide the number of LLVM asm registers generated for that output tensor in one instance
+            of inline assembly.
         :return: one tensor or a tuple of tensors of the given dtypes
     '''
     asm = _unwrap_if_constexpr(asm)
     constraints = _unwrap_if_constexpr(constraints)
     pack = _unwrap_if_constexpr(pack)
     is_pure = _unwrap_if_constexpr(is_pure)
+    operand_vec_sizes = _unwrap_if_constexpr(operand_vec_sizes) or []
+    result_vec_sizes = _unwrap_if_constexpr(result_vec_sizes) or []
 
     # Wrap `dtype` in a tuple if it's not already.
     try:
@@ -3568,7 +3579,8 @@ def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Un
             res_tys = [broadcast_arg.type.with_element_ty(dt) for dt in dtype]
     handles = [t.handle for t in dispatch_args]
     builder = _semantic.builder
-    call = builder.create_inline_asm(asm, constraints, handles, [ty.to_ir(builder) for ty in res_tys], is_pure, pack)
+    call = builder.create_inline_asm(asm, constraints, handles, [ty.to_ir(builder) for ty in res_tys], is_pure, pack,
+                                     operand_vec_sizes, result_vec_sizes)
 
     if not has_multiple_outputs:
         return tensor(call.get_result(0), res_tys[0])

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3526,7 +3526,7 @@ def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Un
                 tl.store(C + tl.arange(0, BLOCK), c)
                 tl.store(D + tl.arange(0, BLOCK), d)
 
-        Example using AMDGPU assembly with vector operands andresults:
+        Example using AMDGPU assembly with vector operands and results:
 
         .. code-block:: python
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3526,6 +3526,43 @@ def inline_asm_elementwise(asm: str, constraints: str, args: Sequence, dtype: Un
                 tl.store(C + tl.arange(0, BLOCK), c)
                 tl.store(D + tl.arange(0, BLOCK), d)
 
+        Example using AMDGPU assembly with vector operands andresults:
+
+        .. code-block:: python
+
+            @triton.jit
+            def kernel(idx_ptr, lut_ptr, out_ptr, BLOCK: tl.constexpr):
+                offsets = tl.arange(0, BLOCK)
+
+                # Each uint8 index element contains two packed u4 indices.
+                idx = tl.load(idx_ptr + offsets)
+
+                # The LUT halves are scalar values that broadcast across the
+                # packed asm call.
+                lut0 = tl.load(lut_ptr + 0)
+                lut1 = tl.load(lut_ptr + 1)
+
+                out = tl.inline_asm_elementwise(
+                    asm="v_perm_pk16_b8_u4 $0, $1, $9, $17",
+                    constraints=(
+                        "=v,"
+                        "s,s,s,s,s,s,s,s,"
+                        "s,s,s,s,s,s,s,s,"
+                        "v"
+                    ),
+                    args=[lut0, lut1, idx],
+                    dtype=tl.uint16,
+                    is_pure=True,
+                    pack=8,
+                    # LUT operands stay scalar.  The packed index values are
+                    # passed as one adjacent register pair.
+                    operand_vec_sizes=[1, 1, 2],
+                    # The instruction returns one group of four adjacent registers,
+                    # unpacked back to eight uint16 tensor elements.
+                    result_vec_sizes=[4],
+                )
+                tl.store(out_ptr + offsets, out)
+
         :param asm: assembly to run.  Must match target's assembly format.
         :param constraints: asm constraints in
             `LLVM format <https://llvm.org/docs/LangRef.html#inline-asm-constraint-string>`_

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -782,7 +782,8 @@ class InterpreterBuilder:
     def create_extern_elementwise(self, libName, libPath, symbol, argList, retType, isPure):
         raise NotImplementedError("extern_elementwise not supported in interpreter mode")
 
-    def create_inline_asm(self, inlineAsm, constraints, values, type, isPure, pack):
+    def create_inline_asm(self, inlineAsm, constraints, values, type, isPure, pack, operandVecSizes=None,
+                          resultVecSizes=None):
         raise NotImplementedError("inline_asm not supported in interpreter mode")
 
     def create_print(self, prefix, hex, values, isSigned):

--- a/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
@@ -110,3 +110,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     tt.return %0 : tensor<64xbf16, #blocked>
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#linear = #ttg.linear<{register = [[1], [2], [4], [8]], lane = [[16], [32], [64], [128], [256]], warp = [], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // GFX1250-LABEL: inline_asm_vec_sizes
+  tt.func @inline_asm_vec_sizes(
+      %arg0: tensor<32xi32, #blocked>,
+      %arg1: tensor<32xi32, #blocked>) -> tensor<32xi32, #blocked> {
+    // GFX1250: llvm.inline_asm asm_dialect = att "test $0, $1, $2, $3", "=v,v,v,v" %{{.*}}, %{{.*}}, %{{.*}} : (vector<4xi32>, vector<2xi32>, vector<2xi32>) -> vector<4xi32>
+    %0 = tt.elementwise_inline_asm "test $0, $1, $2, $3" {constraints = "=v,v,v,v", operand_vec_sizes = array<i32: 4, 2>, packed_element = 4 : i32, pure = true, result_vec_sizes = array<i32: 4>} %arg0, %arg1 : tensor<32xi32, #blocked>, tensor<32xi32, #blocked> -> tensor<32xi32, #blocked>
+    tt.return %0 : tensor<32xi32, #blocked>
+  }
+
+  // GFX1250-LABEL: inline_asm_vec_sizes_i8_carriers
+  tt.func @inline_asm_vec_sizes_i8_carriers(%arg0: tensor<512xi8, #linear>) -> tensor<512xi8, #linear> {
+    // GFX1250: llvm.inline_asm asm_dialect = att "test $0, $1", "=v,v" %{{.*}} : (vector<4xi32>) -> vector<4xi32>
+    %0 = tt.elementwise_inline_asm "test $0, $1" {constraints = "=v,v", operand_vec_sizes = array<i32: 4>, packed_element = 16 : i32, pure = true, result_vec_sizes = array<i32: 4>} %arg0 : tensor<512xi8, #linear> -> tensor<512xi8, #linear>
+    tt.return %0 : tensor<512xi8, #linear>
+  }
+}

--- a/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
@@ -120,14 +120,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   tt.func @inline_asm_vec_sizes(
       %arg0: tensor<32xi32, #blocked>,
       %arg1: tensor<32xi32, #blocked>) -> tensor<32xi32, #blocked> {
-    // GFX1250: llvm.inline_asm asm_dialect = att "test $0, $1, $2, $3", "=v,v,v,v" %{{.*}}, %{{.*}}, %{{.*}} : (vector<4xi32>, vector<2xi32>, vector<2xi32>) -> vector<4xi32>
+    // GFX1250: llvm.inline_asm asm_dialect = att "test $0, $1, $2, $3", "=v,v,v,v" %{{.*}}, %{{.*}}, %{{.*}} : (i128, i64, i64) -> i128
     %0 = tt.elementwise_inline_asm "test $0, $1, $2, $3" {constraints = "=v,v,v,v", operand_vec_sizes = array<i32: 4, 2>, packed_element = 4 : i32, pure = true, result_vec_sizes = array<i32: 4>} %arg0, %arg1 : tensor<32xi32, #blocked>, tensor<32xi32, #blocked> -> tensor<32xi32, #blocked>
     tt.return %0 : tensor<32xi32, #blocked>
   }
 
   // GFX1250-LABEL: inline_asm_vec_sizes_i8_carriers
   tt.func @inline_asm_vec_sizes_i8_carriers(%arg0: tensor<512xi8, #linear>) -> tensor<512xi8, #linear> {
-    // GFX1250: llvm.inline_asm asm_dialect = att "test $0, $1", "=v,v" %{{.*}} : (vector<4xi32>) -> vector<4xi32>
+    // GFX1250: llvm.inline_asm asm_dialect = att "test $0, $1", "=v,v" %{{.*}} : (i128) -> i128
     %0 = tt.elementwise_inline_asm "test $0, $1" {constraints = "=v,v", operand_vec_sizes = array<i32: 4>, packed_element = 16 : i32, pure = true, result_vec_sizes = array<i32: 4>} %arg0 : tensor<512xi8, #linear> -> tensor<512xi8, #linear>
     tt.return %0 : tensor<512xi8, #linear>
   }

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1917,7 +1917,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
     %1 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<512x!tt.ptr<i8>, #blocked>
     %2 = tt.addptr %1, %0 : tensor<512x!tt.ptr<i8>, #blocked>, tensor<512xi32, #blocked>
     %3 = tt.load %2 : tensor<512x!tt.ptr<i8>, #blocked>
-// CHECK: %{{.*}} = llvm.inline_asm asm_dialect = att "shl.b32 $0, $0, 3;", "=r,r" %{{.*}} : (vector<4xi8>) -> vector<4xi8>
+// CHECK: %{{.*}} = llvm.inline_asm asm_dialect = att "shl.b32 $0, $0, 3;", "=r,r" %{{.*}} : (i32) -> i32
     %4 = tt.elementwise_inline_asm "shl.b32 $0, $0, 3;" {constraints = "=r,r", packed_element = 4 : i32, pure = true} %3 : tensor<512xi8, #blocked> -> tensor<512xi8, #blocked>
     %5 = tt.splat %arg1 : !tt.ptr<i8> -> tensor<512x!tt.ptr<i8>, #blocked>
     %6 = tt.addptr %5, %0 : tensor<512x!tt.ptr<i8>, #blocked>, tensor<512xi32, #blocked>
@@ -1936,7 +1936,7 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
     %1 = tt.splat %arg0 : !tt.ptr<i8> -> tensor<512x!tt.ptr<i8>, #blocked>
     %2 = tt.addptr %1, %0 : tensor<512x!tt.ptr<i8>, #blocked>, tensor<512xi32, #blocked>
     %3 = tt.load %2 : tensor<512x!tt.ptr<i8>, #blocked>
-// CHECK: %{{.*}} = llvm.inline_asm asm_dialect = att "shl.b16 $0, $0, 3;", "=h,h" %{{.*}} : (vector<2xi8>) -> vector<2xi8>
+// CHECK: %{{.*}} = llvm.inline_asm asm_dialect = att "shl.b16 $0, $0, 3;", "=h,h" %{{.*}} : (i16) -> i16
     %4 = tt.elementwise_inline_asm "shl.b16 $0, $0, 3;" {constraints = "=h,h", packed_element = 2 : i32, pure = true} %3 : tensor<512xi8, #blocked> -> tensor<512xi8, #blocked>
     %5 = tt.splat %arg1 : !tt.ptr<i8> -> tensor<512x!tt.ptr<i8>, #blocked>
     %6 = tt.addptr %5, %0 : tensor<512x!tt.ptr<i8>, #blocked>, tensor<512xi32, #blocked>
@@ -2407,7 +2407,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // check specifically for the case where asm has two results, pack > 1, and the result bitwidth is < 32
   tt.func public @inline_asm_pack(%80: tensor<64x64xi8, #blocked>) {
-    // CHECK: llvm.inline_asm asm_dialect {{.*}} (vector<4xi8>) -> !llvm.struct<(vector<2xbf16>, vector<2xbf16>, vector<2xbf16>, vector<2xbf16>)>
+    // CHECK: llvm.inline_asm asm_dialect {{.*}} (i32) -> !llvm.struct<(i32, i32, i32, i32)>
     %83:2 = tt.elementwise_inline_asm "" {constraints = "=r,=r,=r,=r,r", packed_element = 4 : i32, pure = true} %80 : tensor<64x64xi8, #blocked> -> tensor<64x64xbf16, #blocked>, tensor<64x64xbf16, #blocked>
     tt.return
   }

--- a/third_party/amd/python/test/test_inline_asm_gfx1250.py
+++ b/third_party/amd/python/test/test_inline_asm_gfx1250.py
@@ -1,0 +1,245 @@
+"""Compile-only GFX1250 checks for inline assembly."""
+
+import re
+
+import triton
+from triton.backends.compiler import GPUTarget
+from triton.experimental import gluon
+import triton.experimental.gluon.language as ttgl
+
+
+@gluon.jit
+def inline_asm_perm_pk16_b4_u4_kernel(idx_ptr, out_ptr, lut_ptr):
+    """
+    Use 128 logical u4 elements per lane, packed as 64 u8 elements, to index
+    into a 16-entry LUT of logical b4 values, packed as two u32 values.
+    """
+    layout: ttgl.constexpr = ttgl.DistributedLinearLayout(
+        reg_bases=[[0, 1], [0, 2], [0, 4], [1, 0], [2, 0], [4, 0]],
+        lane_bases=[[8, 0], [16, 0], [32, 0], [64, 0], [128, 0]],
+        warp_bases=[],
+        block_bases=[],
+        shape=[256, 8],
+    )
+    rows = ttgl.arange(0, 256, ttgl.SliceLayout(1, layout))[:, None]
+    cols = ttgl.arange(0, 8, ttgl.SliceLayout(0, layout))[None, :]
+    offsets = rows * 8 + cols
+    idx = ttgl.load(idx_ptr + offsets)
+    lut0 = ttgl.load(lut_ptr + 0)
+    lut1 = ttgl.load(lut_ptr + 1)
+    # lut0/lut1 are scalar values, so they broadcast to the idx shape. With
+    # pack=8 each scalar contributes eight identical asm operands; use the
+    # first copy of each LUT register. This does not affect the final assembly.
+    out = ttgl.inline_asm_elementwise(
+        "v_perm_pk16_b4_u4 $0, $1, $9, $17",
+        ("=v,"
+         "s,s,s,s,s,s,s,s,"
+         "s,s,s,s,s,s,s,s,"
+         "0"),  # The `0` forces the output to be held in the registers used for the indices.
+        [lut0, lut1, idx], dtype=idx.dtype, is_pure=True, pack=8,
+        operand_vec_sizes=[1, 1, 2],  # Use 2 32-bit registers for idx per asm invocation.
+        result_vec_sizes=[2],  # Produce 2 32-bit registers of output per asm invocation.
+    )
+    ttgl.store(out_ptr + offsets, out)
+
+
+@gluon.jit
+def inline_asm_perm_pk16_b8_u4_kernel(idx_ptr, out_ptr, lut_ptr):
+    """
+    Use 8 uint8 elements as 16 packed u4 indices. Each asm call produces 16 b8
+    values, stored as 8 uint16 elements containing two b8 values each.
+    """
+    layout: ttgl.constexpr = ttgl.DistributedLinearLayout(
+        reg_bases=[[0, 1], [0, 2], [0, 4], [1, 0], [2, 0], [4, 0]],
+        lane_bases=[[8, 0], [16, 0], [32, 0], [64, 0], [128, 0]],
+        warp_bases=[],
+        block_bases=[],
+        shape=[256, 8],
+    )
+    rows = ttgl.arange(0, 256, ttgl.SliceLayout(1, layout))[:, None]
+    cols = ttgl.arange(0, 8, ttgl.SliceLayout(0, layout))[None, :]
+    offsets = rows * 8 + cols
+    idx = ttgl.load(idx_ptr + offsets)
+    lut0 = ttgl.load(lut_ptr + 0)
+    lut1 = ttgl.load(lut_ptr + 1)
+    out = ttgl.inline_asm_elementwise(
+        "v_perm_pk16_b8_u4 $0, $1, $9, $17",
+        ("=v,"
+         "s,s,s,s,s,s,s,s,"
+         "s,s,s,s,s,s,s,s,"
+         "v"),
+        [lut0, lut1, idx],
+        dtype=ttgl.uint16,
+        is_pure=True,
+        pack=8,
+        operand_vec_sizes=[1, 1, 2],
+        result_vec_sizes=[4],
+    )
+    ttgl.store(out_ptr + offsets, out)
+
+
+@gluon.jit
+def inline_asm_perm_pk16_b8_u4_vgpr_lut_kernel(idx_ptr, out_ptr, lut0_ptr, lut1_ptr):
+    """
+    Use per-element dynamic LUTs from VGPRs instead of uniform scalar LUTs.
+    """
+    layout: ttgl.constexpr = ttgl.DistributedLinearLayout(
+        reg_bases=[[0, 1], [0, 2], [0, 4], [1, 0], [2, 0], [4, 0]],
+        lane_bases=[[8, 0], [16, 0], [32, 0], [64, 0], [128, 0]],
+        warp_bases=[],
+        block_bases=[],
+        shape=[256, 8],
+    )
+    rows = ttgl.arange(0, 256, ttgl.SliceLayout(1, layout))[:, None]
+    cols = ttgl.arange(0, 8, ttgl.SliceLayout(0, layout))[None, :]
+    offsets = rows * 8 + cols
+    idx = ttgl.load(idx_ptr + offsets)
+    lut0 = ttgl.load(lut0_ptr + offsets)
+    lut1 = ttgl.load(lut1_ptr + offsets)
+    out = ttgl.inline_asm_elementwise(
+        "v_perm_pk16_b8_u4 $0, $1, $2, $3",
+        "=v,v,v,v",
+        [lut0, lut1, idx],
+        dtype=ttgl.uint16,
+        is_pure=True,
+        pack=8,
+        operand_vec_sizes=[2, 2, 2],
+        result_vec_sizes=[4],
+    )
+    ttgl.store(out_ptr + offsets, out)
+
+
+@gluon.jit
+def inline_asm_perm_pk16_b8_u4_static_lut_kernel(idx_ptr, out_ptr):
+    """
+    Materialize a static LUT in registers, then use it for packed u4 indices.
+    """
+    layout: ttgl.constexpr = ttgl.DistributedLinearLayout(
+        reg_bases=[[0, 1], [0, 2], [0, 4], [1, 0], [2, 0], [4, 0]],
+        lane_bases=[[8, 0], [16, 0], [32, 0], [64, 0], [128, 0]],
+        warp_bases=[],
+        block_bases=[],
+        shape=[256, 8],
+    )
+    rows = ttgl.arange(0, 256, ttgl.SliceLayout(1, layout))[:, None]
+    cols = ttgl.arange(0, 8, ttgl.SliceLayout(0, layout))[None, :]
+    offsets = rows * 8 + cols
+    idx = ttgl.load(idx_ptr + offsets)
+    # Produce statically known LUTs without global loads.
+    lut0, lut1 = ttgl.inline_asm_elementwise(
+        """
+        s_mov_b64 $0, 0x8675309
+        s_mov_b64 $1, 0x24601
+        """,
+        "=s,=s",
+        args=[],
+        dtype=[ttgl.uint64, ttgl.uint64],
+        is_pure=True,
+        pack=1,
+    )
+    out = ttgl.inline_asm_elementwise(
+        "v_perm_pk16_b8_u4 $0, $1, $9, $17",
+        ("=v,"
+         "s,s,s,s,s,s,s,s,"
+         "s,s,s,s,s,s,s,s,"
+         "v"),
+        [lut0, lut1, idx],
+        dtype=ttgl.uint16,
+        is_pure=True,
+        pack=8,
+        operand_vec_sizes=[1, 1, 2],
+        result_vec_sizes=[4],
+    )
+    ttgl.store(out_ptr + offsets, out)
+
+
+def compile_kernel(kernel, signature):
+    return triton.compile(
+        src=gluon._runtime.GluonASTSource(kernel, signature, {}),
+        target=GPUTarget("hip", "gfx1250", 32),
+        options={"num_warps": 1},
+    )
+
+
+def compile_b4_kernel():
+    return compile_kernel(inline_asm_perm_pk16_b4_u4_kernel, {
+        "idx_ptr": "*u8",
+        "out_ptr": "*u8",
+        "lut_ptr": "*u32",
+    })
+
+
+def compile_b8_kernel():
+    return compile_kernel(inline_asm_perm_pk16_b8_u4_kernel, {
+        "idx_ptr": "*u8",
+        "out_ptr": "*u16",
+        "lut_ptr": "*u64",
+    })
+
+
+def compile_b8_vgpr_lut_kernel():
+    return compile_kernel(inline_asm_perm_pk16_b8_u4_vgpr_lut_kernel, {
+        "idx_ptr": "*u8",
+        "out_ptr": "*u16",
+        "lut0_ptr": "*u8",
+        "lut1_ptr": "*u8",
+    })
+
+
+def compile_b8_static_lut_kernel():
+    return compile_kernel(inline_asm_perm_pk16_b8_u4_static_lut_kernel, {
+        "idx_ptr": "*u8",
+        "out_ptr": "*u16",
+    })
+
+
+def get_perm_pk16_instructions(amdgcn, mnemonic):
+    pattern = re.compile(rf"{mnemonic}\s+"
+                         r"(v\[[^\]]+\]|v\d+),\s*"
+                         r"([sv]\[[^\]]+\]|[sv]\d+),\s*"
+                         r"([sv]\[[^\]]+\]|[sv]\d+),\s*"
+                         r"(v\[[^\]]+\]|v\d+)")
+    return pattern.findall(amdgcn)
+
+
+def test_inline_asm_perm_pk16_b4_u4_in_asm():
+    """Vector operands/results should lower to the packed B4 permute instruction."""
+    amdgcn = compile_b4_kernel().asm["amdgcn"]
+    instructions = get_perm_pk16_instructions(amdgcn, "v_perm_pk16_b4_u4")
+
+    assert len(instructions) >= 4
+    assert all(dst == idx for dst, _, _, idx in instructions)
+    assert len({(lut0, lut1) for _, lut0, lut1, _ in instructions}) == 1
+    assert all(lut0.startswith("s") and lut1.startswith("s") for _, lut0, lut1, _ in instructions)
+
+
+def test_inline_asm_perm_pk16_b8_u4_in_asm():
+    """Vector results should support the GFX1250 B8 permute form."""
+    amdgcn = compile_b8_kernel().asm["amdgcn"]
+    instructions = get_perm_pk16_instructions(amdgcn, "v_perm_pk16_b8_u4")
+
+    assert len(instructions) >= 4
+    assert len({(lut0, lut1) for _, lut0, lut1, _ in instructions}) == 1
+    assert all(lut0.startswith("s") and lut1.startswith("s") for _, lut0, lut1, _ in instructions)
+
+
+def test_inline_asm_perm_pk16_b8_u4_vgpr_lut_in_asm():
+    """Dynamic LUT tensors should be usable as adjacent VGPR operands."""
+    amdgcn = compile_b8_vgpr_lut_kernel().asm["amdgcn"]
+    instructions = get_perm_pk16_instructions(amdgcn, "v_perm_pk16_b8_u4")
+
+    assert len(instructions) >= 4
+    assert all(lut0.startswith("v") and lut1.startswith("v") for _, lut0, lut1, _ in instructions)
+
+
+def test_inline_asm_perm_pk16_b8_u4_static_lut_in_asm():
+    """Static LUT values should be materialized with asm, not loaded."""
+    amdgcn = compile_b8_static_lut_kernel().asm["amdgcn"]
+    instructions = get_perm_pk16_instructions(amdgcn, "v_perm_pk16_b8_u4")
+
+    assert "s_mov_b64" in amdgcn
+    assert "0x8675309" in amdgcn
+    assert "0x24601" in amdgcn
+    assert len(instructions) >= 4
+    assert len({(lut0, lut1) for _, lut0, lut1, _ in instructions}) == 1
+    assert all(lut0.startswith("s") and lut1.startswith("s") for _, lut0, lut1, _ in instructions)


### PR DESCRIPTION
The NVPTX and AMDGPU backends handle register classes differently for the `LLVM:InlineAsmOp`. NVPTX specifies vector registers (consecutively indexed hardware registers) through the constraint string (plus some compatibility checks on the value type passed in) while AMDGPU determines it by the value type. 

AMDGPU does not specify `<4xi8>` as a legal type and so the current lowering would fail if the user wanted to perform an `inline_asm_elementwise` op on an `int8` tensor with `pack==4`. Additionally, there seems to be no way of specifying vector register usage for small dtypes in the current Triton implementation.

We remedy these issues by bitcasting to and from i32/i16 types before and after the LLVM op invocation, and un/packing vectors as specified by the optional new parameters `operand_vec_sizes` and `result_vec_sizes`. This should have no effect on Nvidia behavior outside of some textual LLVM IR changes.