### PR TITLE
[AMD] Fix invalid LLVM intrinsic name for float buffer atomic max/min

### DIFF
--- a/test/Conversion/amd/buffer_load_store.mlir
+++ b/test/Conversion/amd/buffer_load_store.mlir
@@ -243,7 +243,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
     // CHECK-LABEL: buffer_atomic_rmw_fmax_f32
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.max
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fmax"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
     tt.func public @buffer_atomic_rmw_fmax_f32(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xf32, #blocked0>) {
         %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xf32, #blocked0>
@@ -256,7 +255,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
     // CHECK-LABEL: buffer_atomic_rmw_fmin_f32
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.min
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fmin"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
     tt.func public @buffer_atomic_rmw_fmin_f32(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xf32, #blocked0>) {
         %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xf32, #blocked0>
@@ -269,9 +267,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
     // CHECK-LABEL: buffer_atomic_rmw_smax_i32
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.max"
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.fmax
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.umax
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.smax"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_smax_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
         %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
@@ -284,9 +279,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
     // CHECK-LABEL: buffer_atomic_rmw_smin_i32
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.min"
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.fmin
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.umin
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.smin"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_smin_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
         %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
@@ -299,8 +291,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
     // CHECK-LABEL: buffer_atomic_rmw_umax_i32
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.smax
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.fmax
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.umax"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_umax_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
         %ret = amdg.buffer_atomic_rmw umax, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
@@ -313,8 +303,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
     // CHECK-LABEL: buffer_atomic_rmw_umin_i32
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.smin
-    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.fmin
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.umin"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
     tt.func public @buffer_atomic_rmw_umin_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
         %ret = amdg.buffer_atomic_rmw umin, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>

--- a/test/Conversion/amd/buffer_load_store.mlir
+++ b/test/Conversion/amd/buffer_load_store.mlir
@@ -266,6 +266,64 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+    // CHECK-LABEL: buffer_atomic_rmw_smax_i32
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.max"
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.fmax
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.umax
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.smax"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
+    tt.func public @buffer_atomic_rmw_smax_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
+        %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+    // CHECK-LABEL: buffer_atomic_rmw_smin_i32
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.min"
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.fmin
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.umin
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.smin"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
+    tt.func public @buffer_atomic_rmw_smin_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
+        %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+    // CHECK-LABEL: buffer_atomic_rmw_umax_i32
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.smax
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.fmax
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.umax"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
+    tt.func public @buffer_atomic_rmw_umax_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
+        %ret = amdg.buffer_atomic_rmw umax, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+    // CHECK-LABEL: buffer_atomic_rmw_umin_i32
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.smin
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.fmin
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.umin"({{.*}}) : (i32, !llvm.ptr<8>, i32, i32, i32) -> i32
+    tt.func public @buffer_atomic_rmw_umin_i32(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xi32, #blocked0>) {
+        %ret = amdg.buffer_atomic_rmw umin, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xi32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 4], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
     // CHECK-LABEL: buffer_load_layout_vectorization

--- a/test/Conversion/amd/buffer_load_store.mlir
+++ b/test/Conversion/amd/buffer_load_store.mlir
@@ -240,6 +240,32 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 
 // -----
 
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+    // CHECK-LABEL: buffer_atomic_rmw_fmax_f32
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.max
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fmax"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
+    tt.func public @buffer_atomic_rmw_fmax_f32(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xf32, #blocked0>) {
+        %ret = amdg.buffer_atomic_rmw max, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+    // CHECK-LABEL: buffer_atomic_rmw_fmin_f32
+    // CHECK-NOT: llvm.amdgcn.raw.ptr.buffer.atomic.min
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.raw.ptr.buffer.atomic.fmin"({{.*}}) : (f32, !llvm.ptr<8>, i32, i32, i32) -> f32
+    tt.func public @buffer_atomic_rmw_fmin_f32(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offsets : tensor<256xi32, #blocked0>{tt.divisibility=16:i32}, %values : tensor<256xf32, #blocked0>) {
+        %ret = amdg.buffer_atomic_rmw min, acq_rel, gpu, %values, %arg0[%offsets] : tensor<256xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 4], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
     // CHECK-LABEL: buffer_load_layout_vectorization

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -190,6 +190,15 @@ Value BufferEmitter::emitAtomicRMW(RMWOp rmwType, Type type, Value rsrcDesc,
   //   LLVM verifier to fail. When this is fixed, the ROCDL ops should be used
   //   here.
   auto rmwOpStr = stringifyRMWOp(rmwType).str();
+  // RMWOp::MAX / MIN stringify to "max" / "min", which is not a real AMDGPU
+  // buffer-atomic intrinsic suffix.
+  if (rmwType == RMWOp::MAX || rmwType == RMWOp::MIN) {
+    assert(isa<FloatType>(getElementTypeOrSelf(type)) &&
+           "RMWOp::MAX/MIN should only reach the buffer-atomic emitter with a "
+           "float element type; integer MAX/MIN must stay as tt.atomic_rmw "
+           "(see ConvertToBufferOps)");
+    rmwOpStr = rmwType == RMWOp::MAX ? "fmax" : "fmin";
+  }
   auto instrinsic = "llvm.amdgcn.raw.ptr.buffer.atomic." + rmwOpStr;
   auto bufferAtomicRMW = LLVM::createLLVMIntrinsicCallOp(
       rewriter, loc, instrinsic, bufferType, args);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -193,7 +193,7 @@ Value BufferEmitter::emitAtomicRMW(RMWOp rmwType, Type type, Value rsrcDesc,
   // RMWOp::MAX / MIN stringify to "max" / "min", which are not real AMDGPU
   // buffer-atomic intrinsic suffixes. The valid suffixes are
   // .{s,u,f}{max,min}. RMWOp::UMAX and RMWOp::UMIN already stringify to
-  // "umax" / "umin" and need no override. 
+  // "umax" / "umin" and need no override.
   if (rmwType == RMWOp::MAX || rmwType == RMWOp::MIN) {
     StringRef prefix = isa<FloatType>(getElementTypeOrSelf(type)) ? "f" : "s";
     rmwOpStr = (prefix + rmwOpStr).str();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BufferOpsEmitter.cpp
@@ -190,14 +190,13 @@ Value BufferEmitter::emitAtomicRMW(RMWOp rmwType, Type type, Value rsrcDesc,
   //   LLVM verifier to fail. When this is fixed, the ROCDL ops should be used
   //   here.
   auto rmwOpStr = stringifyRMWOp(rmwType).str();
-  // RMWOp::MAX / MIN stringify to "max" / "min", which is not a real AMDGPU
-  // buffer-atomic intrinsic suffix.
+  // RMWOp::MAX / MIN stringify to "max" / "min", which are not real AMDGPU
+  // buffer-atomic intrinsic suffixes. The valid suffixes are
+  // .{s,u,f}{max,min}. RMWOp::UMAX and RMWOp::UMIN already stringify to
+  // "umax" / "umin" and need no override. 
   if (rmwType == RMWOp::MAX || rmwType == RMWOp::MIN) {
-    assert(isa<FloatType>(getElementTypeOrSelf(type)) &&
-           "RMWOp::MAX/MIN should only reach the buffer-atomic emitter with a "
-           "float element type; integer MAX/MIN must stay as tt.atomic_rmw "
-           "(see ConvertToBufferOps)");
-    rmwOpStr = rmwType == RMWOp::MAX ? "fmax" : "fmin";
+    StringRef prefix = isa<FloatType>(getElementTypeOrSelf(type)) ? "f" : "s";
+    rmwOpStr = (prefix + rmwOpStr).str();
   }
   auto instrinsic = "llvm.amdgcn.raw.ptr.buffer.atomic." + rmwOpStr;
   auto bufferAtomicRMW = LLVM::createLLVMIntrinsicCallOp(


### PR DESCRIPTION
`BufferOpsEmitter::emitAtomicRMW` builds the AMDGPU buffer-atomic intrinsic name by directly stringifying `RMWOp`:
```cpp
auto rmwOpStr  = stringifyRMWOp(rmwType).str();           // "max" / "min" / ...
auto intrinsic = "llvm.amdgcn.raw.ptr.buffer.atomic." + rmwOpStr;
```
For `RMWOp::MAX` / `RMWOp::MIN` this yields `llvm.amdgcn.raw.ptr.buffer.atomic.max` (or `.min`), which is not a real intrinsic. The valid AMDGPU suffixes are `.smax` / `.umax` / `.fmax` (and the corresponding `min` variants). Any kernel that reaches this path crashes. Example:
```python
@gjit
def gluon_buffer_atomic_fmax(out_ptr, BLOCK: ttgl.constexpr):
    layout: ttgl.constexpr = ttgl.BlockedLayout(
        size_per_thread=[1], threads_per_warp=[64], warps_per_cta=[4], order=[0])
    offs = ttgl.arange(0, BLOCK, layout=layout)
    val = ttgl.full([BLOCK], 1.0, ttgl.float64, layout=layout)
    cdna3.buffer_atomic_max(out_ptr, offs, val)
```

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
