### PR TITLE
Fix small-K swizzled MXFP4 matmul

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -140,6 +140,8 @@ def _build_test_op_cases():
         Case(1024, 1000, 2048, "ragged", "float32", "float32", b_transpose=True)
     ])
     # bfloat16 x mx
+    # Hopper MXFP4 value swizzling pads K to 64 rows, so keep one sub-tile K case.
+    test_cases.append(Case(64, 256, 32, "plain", "bfloat16", "mxfloat4_e2m1", b_hbm_swizzling=True))
     for shape in [odd_shape2, even_shape]:
         test_cases.extend([
             Case(*shape, "plain", "bfloat16", "mxfloat4_e2m1"),

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -153,6 +153,7 @@ def _build_test_op_cases():
             Case(*shape, "ragged", "bfloat16", "mxfloat8_e4m3fn"),
             Case(*shape, "ragged", "bfloat16", "mxfloat8_e4m3fn", b_hbm_swizzling=True)
         ])
+    test_cases.append(Case(64, 256, 32, "plain", "bfloat16", "mxfloat4_e2m1", b_hbm_swizzling=True))
     # float8 x mxfloat
     test_cases.extend([
         Case(16, 256, 256, "ragged", "float8_e5m2", "mxfloat4_e2m1", b_hbm_swizzling=True),

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -140,8 +140,6 @@ def _build_test_op_cases():
         Case(1024, 1000, 2048, "ragged", "float32", "float32", b_transpose=True)
     ])
     # bfloat16 x mx
-    # Hopper MXFP4 value swizzling pads K to 64 rows, so keep one sub-tile K case.
-    test_cases.append(Case(64, 256, 32, "plain", "bfloat16", "mxfloat4_e2m1", b_hbm_swizzling=True))
     for shape in [odd_shape2, even_shape]:
         test_cases.extend([
             Case(*shape, "plain", "bfloat16", "mxfloat4_e2m1"),

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -104,6 +104,36 @@ def test_matmul_hopper_mxfp4_rhs_scale_padding_is_masked(device, constraints):
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
+def test_matmul_hopper_mxfp4_rhs_value_padding_is_loaded(device):
+    if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
+        pytest.skip("requires CUDA")
+    if torch.cuda.get_device_capability()[0] != 9:
+        pytest.skip("requires Hopper")
+
+    torch.manual_seed(0)
+    # Hopper MXFP4 value swizzling pads K to 64 rows before packing. K=32
+    # exercises the tail of that physical tile without involving Blackwell
+    # layouts, which use a different value/scale swizzle.
+    m, k, n = 64, 32, 256
+    a = torch.randn((m, k), device=device, dtype=torch.bfloat16)
+    weight_fp = torch.randn((k, n), device=device, dtype=torch.bfloat16)
+    weight_val, weight_scale = downcast_to_mxfp(weight_fp, torch.uint8, axis=-2)
+
+    value_layout = layout.make_default_matmul_mxfp4_w_layout(mx_axis=-2)
+    scale_layout = layout.make_default_matmul_mxfp4_w_scale_layout(mx_axis=-2, num_warps=8)
+    b = convert_layout(wrap_torch_tensor(weight_val, dtype=FP4), value_layout)
+    b_scale = convert_layout(wrap_torch_tensor(weight_scale, dtype=UINT8), scale_layout)
+    precision_config = PrecisionConfig(
+        b_mx_scale=b_scale,
+        b_microblock_size=MXFP_BLOCK_SIZE.value,
+        out_dtype=a.dtype,
+    )
+
+    tri_y = matmul(a, b, None, precision_config=precision_config)
+    ref_y = matmul_torch(a, b, None, precision_config=precision_config)
+    assert_close(ref_y, tri_y, maxtol=3e-2, rmstol=None)
+
+
 @pytest.mark.parametrize("n, expected", [(64, 128), (200, 256)])
 def test_compute_block_n_blackwell_scale_aligns_to_128(n, expected):
     precision_config = PrecisionConfig(

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -104,36 +104,6 @@ def test_matmul_hopper_mxfp4_rhs_scale_padding_is_masked(device, constraints):
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
-def test_matmul_hopper_mxfp4_rhs_value_padding_is_loaded(device):
-    if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
-        pytest.skip("requires CUDA")
-    if torch.cuda.get_device_capability()[0] != 9:
-        pytest.skip("requires Hopper")
-
-    torch.manual_seed(0)
-    # Hopper MXFP4 value swizzling pads K to 64 rows before packing. K=32
-    # exercises the tail of that physical tile without involving Blackwell
-    # layouts, which use a different value/scale swizzle.
-    m, k, n = 64, 32, 256
-    a = torch.randn((m, k), device=device, dtype=torch.bfloat16)
-    weight_fp = torch.randn((k, n), device=device, dtype=torch.bfloat16)
-    weight_val, weight_scale = downcast_to_mxfp(weight_fp, torch.uint8, axis=-2)
-
-    value_layout = layout.make_default_matmul_mxfp4_w_layout(mx_axis=-2)
-    scale_layout = layout.make_default_matmul_mxfp4_w_scale_layout(mx_axis=-2, num_warps=8)
-    b = convert_layout(wrap_torch_tensor(weight_val, dtype=FP4), value_layout)
-    b_scale = convert_layout(wrap_torch_tensor(weight_scale, dtype=UINT8), scale_layout)
-    precision_config = PrecisionConfig(
-        b_mx_scale=b_scale,
-        b_microblock_size=MXFP_BLOCK_SIZE.value,
-        out_dtype=a.dtype,
-    )
-
-    tri_y = matmul(a, b, None, precision_config=precision_config)
-    ref_y = matmul_torch(a, b, None, precision_config=precision_config)
-    assert_close(ref_y, tri_y, maxtol=3e-2, rmstol=None)
-
-
 @pytest.mark.parametrize("n, expected", [(64, 128), (200, 256)])
 def test_compute_block_n_blackwell_scale_aligns_to_128(n, expected):
     precision_config = PrecisionConfig(

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -250,7 +250,15 @@ def _matmul(
             K_W = K_W // (BLOCK_K // PACKED_BLOCK_K_W)
         K_X = tl.multiple_of(tl.load(XSliceOffs + pid_s + 1), X_SLICE_SIZES_DIVISIBILITY)
     else:
-        K_W = K * (PACKED_BLOCK_K_W // BLOCK_K) if PACKED_BLOCK_K_W >= BLOCK_K else K // (BLOCK_K // PACKED_BLOCK_K_W)
+        if SWIZZLE_MX_VALUE == "HOPPER_VALUE":
+            # Hopper value swizzling physically pads K to a full 64-row tile.
+            K_W = tl.cdiv(K, 64) * 64
+        else:
+            K_W = K
+        if PACKED_BLOCK_K_W > BLOCK_K:
+            K_W = K_W * (PACKED_BLOCK_K_W // BLOCK_K)
+        else:
+            K_W = K_W // (BLOCK_K // PACKED_BLOCK_K_W)
         K_X = K
 
     loop_k = tl.multiple_of(tl.load(XSliceSizes + pid_s), X_SLICE_SIZES_DIVISIBILITY) if RAGGED_DIMENSION == "K" else K - off_k_x

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -245,6 +245,10 @@ def _matmul(
 
     if RAGGED_DIMENSION == "K":
         K_W = tl.multiple_of(tl.load(WSliceOffs + pid_s + 1), W_SLICE_SIZES_DIVISIBILITY)
+        if PACKED_BLOCK_K_W > BLOCK_K:
+            K_W = K_W * (PACKED_BLOCK_K_W // BLOCK_K)
+        else:
+            K_W = K_W // (BLOCK_K // PACKED_BLOCK_K_W)
         K_X = tl.multiple_of(tl.load(XSliceOffs + pid_s + 1), X_SLICE_SIZES_DIVISIBILITY)
     else:
         if SWIZZLE_MX_VALUE == "HOPPER_VALUE":
@@ -252,11 +256,11 @@ def _matmul(
             K_W = tl.cdiv(K, 64) * 64
         else:
             K_W = K
+        if PACKED_BLOCK_K_W > BLOCK_K:
+            K_W = K_W * (PACKED_BLOCK_K_W // BLOCK_K)
+        else:
+            K_W = K_W // (BLOCK_K // PACKED_BLOCK_K_W)
         K_X = K
-    if PACKED_BLOCK_K_W > BLOCK_K:
-        K_W = K_W * (PACKED_BLOCK_K_W // BLOCK_K)
-    else:
-        K_W = K_W // (BLOCK_K // PACKED_BLOCK_K_W)
 
     loop_k = tl.multiple_of(tl.load(XSliceSizes + pid_s), X_SLICE_SIZES_DIVISIBILITY) if RAGGED_DIMENSION == "K" else K - off_k_x
     k_tiles = tl.cdiv(loop_k, BLOCK_K * SPLIT_K)

--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -245,10 +245,6 @@ def _matmul(
 
     if RAGGED_DIMENSION == "K":
         K_W = tl.multiple_of(tl.load(WSliceOffs + pid_s + 1), W_SLICE_SIZES_DIVISIBILITY)
-        if PACKED_BLOCK_K_W > BLOCK_K:
-            K_W = K_W * (PACKED_BLOCK_K_W // BLOCK_K)
-        else:
-            K_W = K_W // (BLOCK_K // PACKED_BLOCK_K_W)
         K_X = tl.multiple_of(tl.load(XSliceOffs + pid_s + 1), X_SLICE_SIZES_DIVISIBILITY)
     else:
         if SWIZZLE_MX_VALUE == "HOPPER_VALUE":
@@ -256,11 +252,11 @@ def _matmul(
             K_W = tl.cdiv(K, 64) * 64
         else:
             K_W = K
-        if PACKED_BLOCK_K_W > BLOCK_K:
-            K_W = K_W * (PACKED_BLOCK_K_W // BLOCK_K)
-        else:
-            K_W = K_W // (BLOCK_K // PACKED_BLOCK_K_W)
         K_X = K
+    if PACKED_BLOCK_K_W > BLOCK_K:
+        K_W = K_W * (PACKED_BLOCK_K_W // BLOCK_K)
+    else:
+        K_W = K_W // (BLOCK_K // PACKED_BLOCK_K_W)
 
     loop_k = tl.multiple_of(tl.load(XSliceSizes + pid_s), X_SLICE_SIZES_DIVISIBILITY) if RAGGED_DIMENSION == "K" else K - off_k_x
     k_tiles = tl.cdiv(loop_k, BLOCK_K * SPLIT_K)

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -60,6 +60,8 @@ def compute_block_n(n: int, arch, precision_config):
 def compute_block_k(m: int, k: int | None, is_persistent: bool, lhs_dtype, rhs_dtype, precision_config, has_y_acc_in):
     lhs_width = lhs_dtype.bitwidth
     rhs_width = rhs_dtype.bitwidth
+    b_mx_scale = None if precision_config is None else precision_config.b_mx_scale
+    b_scale_layout = None if not isinstance(b_mx_scale, Tensor) else b_mx_scale.storage.layout
     # block_k needs to match the cacheline size (1024 bits)
     block_k = int(1024 // min(lhs_width, rhs_width))
     has_native_mxfp = target_info.cuda_capability_geq(10, 0)
@@ -71,11 +73,14 @@ def compute_block_k(m: int, k: int | None, is_persistent: bool, lhs_dtype, rhs_d
     elif k is not None:  # cover small k case
         min_block_k = 32 if is_persistent or lhs_width != 16 or rhs_width != 16 else 16
         block_k = max(min_block_k, min(triton.next_power_of_2(k), block_k))
-    has_mx_weight_scale = precision_config is not None and precision_config.b_mx_scale is not None
+    has_mx_weight_scale = b_mx_scale is not None
     if has_native_mxfp and is_persistent and has_mx_weight_scale:
         # If both inputs are fp4, allow larger block_k.
         max_block_k = 256 if lhs_dtype == FP4 and rhs_dtype == FP4 else 128
         block_k = min(block_k, max_block_k)
+    if isinstance(b_scale_layout, BlackwellMXScaleLayout):
+        # Blackwell scale swizzling loads four K-scale columns at a time.
+        block_k = max(block_k, 4 * MXFP_BLOCK_SIZE.value)
     if has_y_acc_in and lhs_width == rhs_width == 16 and not target_info.cuda_capability_geq(10, 0):
         block_k = min(block_k, 32)
     return block_k

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -86,10 +86,8 @@ def compute_block_k(m: int, k: int | None, is_persistent: bool, lhs_dtype, rhs_d
             # If both inputs are fp4, allow larger block_k.
             max_block_k = 256 if lhs_dtype == FP4 and rhs_dtype == FP4 else 128
             block_k = min(block_k, max_block_k)
-        if (
-            isinstance(precision_config.b_mx_scale, Tensor)
-            and isinstance(precision_config.b_mx_scale.storage.layout, BlackwellMXScaleLayout)
-        ):
+        if (isinstance(precision_config.b_mx_scale, Tensor)
+                and isinstance(precision_config.b_mx_scale.storage.layout, BlackwellMXScaleLayout)):
             # Blackwell scale swizzling loads four K-scale columns at a time.
             block_k = max(block_k, 4 * MXFP_BLOCK_SIZE.value)
     if has_y_acc_in and lhs_width == rhs_width == 16 and not target_info.cuda_capability_geq(10, 0):

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -60,8 +60,6 @@ def compute_block_n(n: int, arch, precision_config):
 def compute_block_k(m: int, k: int | None, is_persistent: bool, lhs_dtype, rhs_dtype, precision_config, has_y_acc_in):
     lhs_width = lhs_dtype.bitwidth
     rhs_width = rhs_dtype.bitwidth
-    b_mx_scale = None if precision_config is None else precision_config.b_mx_scale
-    b_scale_layout = None if not isinstance(b_mx_scale, Tensor) else b_mx_scale.storage.layout
     # block_k needs to match the cacheline size (1024 bits)
     block_k = int(1024 // min(lhs_width, rhs_width))
     has_native_mxfp = target_info.cuda_capability_geq(10, 0)
@@ -73,14 +71,17 @@ def compute_block_k(m: int, k: int | None, is_persistent: bool, lhs_dtype, rhs_d
     elif k is not None:  # cover small k case
         min_block_k = 32 if is_persistent or lhs_width != 16 or rhs_width != 16 else 16
         block_k = max(min_block_k, min(triton.next_power_of_2(k), block_k))
-    has_mx_weight_scale = b_mx_scale is not None
-    if has_native_mxfp and is_persistent and has_mx_weight_scale:
-        # If both inputs are fp4, allow larger block_k.
-        max_block_k = 256 if lhs_dtype == FP4 and rhs_dtype == FP4 else 128
-        block_k = min(block_k, max_block_k)
-    if isinstance(b_scale_layout, BlackwellMXScaleLayout):
-        # Blackwell scale swizzling loads four K-scale columns at a time.
-        block_k = max(block_k, 4 * MXFP_BLOCK_SIZE.value)
+    if precision_config is not None and precision_config.b_mx_scale is not None:
+        if has_native_mxfp and is_persistent:
+            # If both inputs are fp4, allow larger block_k.
+            max_block_k = 256 if lhs_dtype == FP4 and rhs_dtype == FP4 else 128
+            block_k = min(block_k, max_block_k)
+        if (
+            isinstance(precision_config.b_mx_scale, Tensor)
+            and isinstance(precision_config.b_mx_scale.storage.layout, BlackwellMXScaleLayout)
+        ):
+            # Blackwell scale swizzling loads four K-scale columns at a time.
+            block_k = max(block_k, 4 * MXFP_BLOCK_SIZE.value)
     if has_y_acc_in and lhs_width == rhs_width == 16 and not target_info.cuda_capability_geq(10, 0):
         block_k = min(block_k, 32)
     return block_k


### PR DESCRIPTION
Fix small-K swizzled MXFP4 matmul on NVIDIA.

Hopper value swizzling pads RHS K to a 64-row tile, so the RHS load bound must use the padded K extent. Blackwell scale swizzling loads four K-scale columns at a time, so swizzled MX scale matmuls need `block_k >= 128` even for smaller logical K.

Adds `K=32` swizzled MXFP4 RHS coverage to the main matmul suite.

Validation:

- H100: `test_matmul.py::test_op -k "64 and 256 and 32 and plain and bfloat16 and mxfloat4_e2m1"` (`64 passed, 32 skipped`)
- GB200: same selection (`16 passed, 32 skipped`)
