### PR TITLE
Include examples/ in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 graft bin
 graft cmake
 graft docs
+graft examples
 graft include
 graft lib
 graft python/src


### PR DESCRIPTION
Fixes #10262


Add `graft examples` to `MANIFEST.in` so the `examples/` directory (currently only `examples/plugins/`) ships in the sdist produced by `python -m build -s` (which is what [`.github/workflows/create_release.yml`](https://github.com/triton-lang/triton/blob/main/.github/workflows/create_release.yml) uploads as the `triton-*.tar.gz` release asset).

`CMakeLists.txt` calls

```cmake
add_subdirectory(examples/plugins)
```

on `main` (line 480) and on `release/3.7.x` (line 342), so building from the released source tarball fails with a missing-directory error. Reported in #10262.

## Verification

With the current `MANIFEST.in`, no top-level `examples/` entries exist in the sdist (only the `third_party/amd/python/examples/` subdir that comes in via `graft third_party`):

```
$ tar tzf dist/triton-*.tar.gz | grep -c '^triton-[^/]*/examples/'
0
```

After the patch, all 22 files under `examples/plugins/` are included:

```
$ tar tzf dist/triton-*.tar.gz | grep -c '^triton-[^/]*/examples/'
30
```

## Plan

Will cherry-pick this to `release/3.7.x` once it lands here, so the 3.7.x source tarball stops shipping a broken build.