### PR TITLE
[release/3.7.x] Include examples/ in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 graft bin
 graft cmake
 graft docs
+graft examples
 graft include
 graft lib
 graft python/src


### PR DESCRIPTION
## What

Cherry-pick of #10349 onto `release/3.7.x`.

Adds `graft examples` to `MANIFEST.in` so the `examples/` directory (currently only `examples/plugins/`) ships in the sdist produced by `python -m build -s` (which is what [`.github/workflows/create_release.yml`](https://github.com/triton-lang/triton/blob/main/.github/workflows/create_release.yml) uploads as the `triton-*.tar.gz` release asset).

## Why

`CMakeLists.txt` on `release/3.7.x` (line 342) calls

```cmake
add_subdirectory(examples/plugins)
```

so building from the v3.7.0 source tarball fails because that directory was stripped by the sdist build. Reported in #10262.

## Verification

With the pre-cherry-pick `MANIFEST.in`, no top-level `examples/` entries exist in the sdist:

```
$ tar tzf dist/triton-*.tar.gz | grep -c '^triton-[^/]*/examples/'
0
```

With the cherry-pick applied, all 22 files under `examples/plugins/` are included.

Fixes #10262 on `release/3.7.x`.