### PR TITLE
[CONSAN] Add barrier before NaN init

### DIFF
--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -247,6 +247,9 @@ void initializeAllocation(ImplicitLocOpBuilder &b, Value alloc) {
   for (Value leaf : leaves) {
     Value poison =
         createPoisonTensor(b, cast<ttg::MemDescType>(leaf.getType()));
+    // Synchronize warps, so in case of re-used memory we won't start poisoning
+    // memory that is still being used.
+    ttg::BarrierOp::create(b, b.getLoc(), ttg::AddrSpace::Local);
     if (isa<ttng::TensorMemorySpaceAttr>(
             cast<ttg::MemDescType>(leaf.getType()).getMemorySpace())) {
       Value pred = arith::ConstantIntOp::create(b, 1, 1);

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -244,20 +244,27 @@ void initializeAllocation(ImplicitLocOpBuilder &b, Value alloc) {
       leaves.push_back(createSingleBufferView(b, alloc, buffer));
   }
 
+  bool isTensorMemory =
+      isa<ttng::TensorMemorySpaceAttr>(allocType.getMemorySpace());
+  ttg::AddrSpace barrierSpace =
+      isTensorMemory
+          ? (ttg::AddrSpace::TensorRead | ttg::AddrSpace::TensorWrite)
+          : ttg::AddrSpace::Local;
+  // Synchronize warps, so in case of re-used memory we won't start poisoning
+  // memory that is still being used, and finish poisoning before the kernel's
+  // first real use of the allocation.
+  ttg::BarrierOp::create(b, b.getLoc(), barrierSpace);
   for (Value leaf : leaves) {
-    Value poison =
-        createPoisonTensor(b, cast<ttg::MemDescType>(leaf.getType()));
-    // Synchronize warps, so in case of re-used memory we won't start poisoning
-    // memory that is still being used.
-    ttg::BarrierOp::create(b, b.getLoc(), ttg::AddrSpace::Local);
-    if (isa<ttng::TensorMemorySpaceAttr>(
-            cast<ttg::MemDescType>(leaf.getType()).getMemorySpace())) {
+    auto leafType = cast<ttg::MemDescType>(leaf.getType());
+    Value poison = createPoisonTensor(b, leafType);
+    if (isTensorMemory) {
       Value pred = arith::ConstantIntOp::create(b, 1, 1);
       ttng::TMEMStoreOp::create(b, leaf, poison, pred);
     } else {
       ttg::LocalStoreOp::create(b, poison, leaf);
     }
   }
+  ttg::BarrierOp::create(b, b.getLoc(), barrierSpace);
 }
 
 bool canInitializeAllocation(Value alloc) {

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -1894,7 +1894,13 @@ def test_ws_two_loads_two_bars_loop(MISSING_BAR, device, run_wrapper, monkeypatc
         result = run_in_process(test_ws_two_loads_two_bars_loop, (MISSING_BAR, device, False, monkeypatch, num_ctas))
         if MISSING_BAR != "none":
             assert_expected_cuda_failure(result.exc)
-            assert "Buffer being accessed has outstanding" in result.driver_stderr_output
+            expected = ["Buffer being accessed has outstanding"]
+            # If the partition with the missing producer wait runs ahead and
+            # retires first, the same broken protocol can be reported as an
+            # mbarrier deadlock instead of an overlapping access.
+            if MISSING_BAR in ("2", "3"):
+                expected.append("Deadlock detected")
+            assert any(msg in result.driver_stderr_output for msg in expected)
         else:
             assert result.exc is None
             assert result.driver_stderr_output == ""

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1582,9 +1582,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   tt.func public @initialize_uninitialized_allocs() {
     // CHECK: %[[SMEM:.*]] = ttg.local_alloc
     // CHECK: %[[SMEM_POISON:.*]] = arith.constant dense<0x7FC00000> : tensor<128x128xf32
+    // CHECK: ttg.barrier local
     // CHECK: ttg.local_store %[[SMEM_POISON]], %[[SMEM]]
     // CHECK: %[[TMEM:.*]] = ttng.tmem_alloc
     // CHECK: %[[TMEM_POISON:.*]] = arith.constant dense<0x7FC00000> : tensor<128x128xf32
+    // CHECK: ttg.barrier local
     // CHECK: %[[TRUE:.*]] = arith.constant true
     // CHECK: ttng.tmem_store %[[TMEM_POISON]], %[[TMEM]], %[[TRUE]]
     // NO-INIT-NOT: ttg.local_store
@@ -1608,12 +1610,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: %[[SMEM:.*]] = ttg.local_alloc
     // CHECK: %[[SMEM_0:.*]] = ttg.memdesc_index %[[SMEM]]
     // CHECK: %[[SMEM_1:.*]] = ttg.memdesc_index %[[SMEM]]
+    // CHECK: ttg.barrier local
     // CHECK: ttg.local_store {{.*}}, %[[SMEM_0]]
+    // CHECK: ttg.barrier local
     // CHECK: ttg.local_store {{.*}}, %[[SMEM_1]]
     // CHECK: %[[TMEM:.*]] = ttng.tmem_alloc
     // CHECK: %[[TMEM_0:.*]] = ttg.memdesc_index %[[TMEM]]
     // CHECK: %[[TMEM_1:.*]] = ttg.memdesc_index %[[TMEM]]
+    // CHECK: ttg.barrier local
     // CHECK: ttng.tmem_store {{.*}}, %[[TMEM_0]],
+    // CHECK: ttg.barrier local
     // CHECK: ttng.tmem_store {{.*}}, %[[TMEM_1]],
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #shared, #smem, mutable>
     %tmem = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1581,14 +1581,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // NO-INIT-LABEL: @initialize_uninitialized_allocs
   tt.func public @initialize_uninitialized_allocs() {
     // CHECK: %[[SMEM:.*]] = ttg.local_alloc
+    // CHECK: ttg.barrier local
     // CHECK: %[[SMEM_POISON:.*]] = arith.constant dense<0x7FC00000> : tensor<128x128xf32
-    // CHECK: ttg.barrier local
     // CHECK: ttg.local_store %[[SMEM_POISON]], %[[SMEM]]
-    // CHECK: %[[TMEM:.*]] = ttng.tmem_alloc
-    // CHECK: %[[TMEM_POISON:.*]] = arith.constant dense<0x7FC00000> : tensor<128x128xf32
     // CHECK: ttg.barrier local
+    // CHECK: %[[TMEM:.*]] = ttng.tmem_alloc
+    // CHECK: ttg.barrier tensor_read|tensor_write
+    // CHECK: %[[TMEM_POISON:.*]] = arith.constant dense<0x7FC00000> : tensor<128x128xf32
     // CHECK: %[[TRUE:.*]] = arith.constant true
     // CHECK: ttng.tmem_store %[[TMEM_POISON]], %[[TMEM]], %[[TRUE]]
+    // CHECK: ttg.barrier tensor_read|tensor_write
     // NO-INIT-NOT: ttg.local_store
     // NO-INIT-NOT: ttng.tmem_store
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #shared, #smem, mutable>
@@ -1612,15 +1614,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: %[[SMEM_1:.*]] = ttg.memdesc_index %[[SMEM]]
     // CHECK: ttg.barrier local
     // CHECK: ttg.local_store {{.*}}, %[[SMEM_0]]
-    // CHECK: ttg.barrier local
     // CHECK: ttg.local_store {{.*}}, %[[SMEM_1]]
+    // CHECK: ttg.barrier local
     // CHECK: %[[TMEM:.*]] = ttng.tmem_alloc
     // CHECK: %[[TMEM_0:.*]] = ttg.memdesc_index %[[TMEM]]
     // CHECK: %[[TMEM_1:.*]] = ttg.memdesc_index %[[TMEM]]
-    // CHECK: ttg.barrier local
+    // CHECK: ttg.barrier tensor_read|tensor_write
     // CHECK: ttng.tmem_store {{.*}}, %[[TMEM_0]],
-    // CHECK: ttg.barrier local
     // CHECK: ttng.tmem_store {{.*}}, %[[TMEM_1]],
+    // CHECK: ttg.barrier tensor_read|tensor_write
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #shared, #smem, mutable>
     %tmem = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return


### PR DESCRIPTION
Initializing shmem and tmem buffers with NaNs in consan had a bug, where some of the warps may race ahead and poison the memory, while other warps still may be using it. We insert a barrier before the initialization to resolve the problem.