### PR TITLE
[Docs] Clarify multiple_of / max_contiguous / max_constancy semantics

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3305,7 +3305,18 @@ def debug_barrier(_semantic=None):
 @builtin
 def multiple_of(input, values, _semantic=None):
     """
-    Let the compiler know that the values in :code:`input` are all multiples of :code:`value`.
+    Let the compiler know that ``values[d]`` is the largest power of two that
+    divides the first element of every contiguous group along dimension ``d``
+    of :code:`input` (see :func:`max_contiguous` for the definition of contiguous
+    group). ``values`` must have one entry per dimension of :code:`input`.
+
+    For a 1D input with contiguity 1, this is equivalent to saying that every
+    element of :code:`input` is a multiple of ``values[0]``. For example, if
+    :code:`values` is ``[16]`` and :code:`input` is ``[64, 80, 96, 112]``, the
+    hint is valid because 16 divides 64.
+
+    This hint enables alignment-dependent optimizations such as vectorized
+    memory accesses.
     """
     if isinstance(values, constexpr):
         values = [values]
@@ -3321,7 +3332,19 @@ def multiple_of(input, values, _semantic=None):
 @builtin
 def max_contiguous(input, values, _semantic=None):
     """
-    Let the compiler know that the `value` first values in :code:`input` are contiguous.
+    Let the compiler know that the elements of :code:`input` along dimension
+    ``d`` form contiguous groups of length ``values[d]``. ``values`` must have
+    one entry per dimension of :code:`input` and each entry must be a power of
+    two.
+
+    A 1D array of ``N`` elements with contiguity ``C`` is viewed as ``N/C``
+    runs of ``C`` integers each, where the integers in a run are
+    sequentially contiguous. For example, if :code:`values` is ``[4]``, the
+    array ``[0, 1, 2, 3, 8, 9, 10, 11]`` satisfies the hint because it
+    consists of two runs of 4 contiguous values.
+
+    Together with :func:`multiple_of`, this hint enables vectorized loads and
+    stores of contiguous, aligned regions.
     """
     if isinstance(values, constexpr):
         values = [values]
@@ -3337,10 +3360,14 @@ def max_contiguous(input, values, _semantic=None):
 @builtin
 def max_constancy(input, values, _semantic=None):
     """
-    Let the compiler know that the `value` first values in :code:`input` are constant.
+    Let the compiler know that the elements of :code:`input` along dimension
+    ``d`` form constant groups of length ``values[d]``. ``values`` must have
+    one entry per dimension of :code:`input` and each entry must be a power of
+    two.
 
-    e.g. if :code:`values` is [4], then each group of 4 values in :code:`input` should all be equal,
-    for example [0, 0, 0, 0, 1, 1, 1, 1].
+    A 1D array of ``N`` elements with constancy ``C`` is viewed as ``N/C``
+    runs of ``C`` identical values. For example, if :code:`values` is ``[4]``,
+    the array ``[0, 0, 0, 0, 1, 1, 1, 1]`` satisfies the hint.
     """
     if isinstance(values, constexpr):
         values = [values]


### PR DESCRIPTION
The current docstrings for `tl.multiple_of`, `tl.max_contiguous`, and `tl.max_constancy` do not match the underlying semantics modeled by `AxisInfo`. `multiple_of` describes its argument as "multiples of value" without explaining how the hint composes with contiguity, and the other two use the phrase "the value first values in input are contiguous/constant", which conflates the hint with its per-dimension length argument and confused at least one reader (#1324).

This PR rewrites each docstring to mirror the precise definitions in `include/triton/Analysis/AxisInfo.h`. `multiple_of` now states that `values[d]` is the largest power of two that divides the first element of every contiguous group along dimension `d`. `max_contiguous` and `max_constancy` now say that the input forms contiguous (resp. constant) groups of length `values[d]` along dimension `d`, that `values` must have one entry per dimension, and that each entry must be a power of two.

Each docstring includes a concrete 1D example taken from `AxisInfo.h` so the meaning is obvious from the rendered Sphinx page. `multiple_of` and `max_contiguous` now cross-reference each other via `:func:` so users can see how they compose to enable vectorized memory accesses. Behavior is unchanged; this is documentation only.

Closes #1324.