### PR TITLE
[Analysis] Clamp SelectOp divisibility when condConstancy reduces output contiguity

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -960,8 +960,17 @@ public:
                                   rhsInfo.getConstancy(d), condConstancy[d]));
           contiguity.push_back(gcd(lhsInfo.getContiguity(d),
                                    rhsInfo.getContiguity(d), condConstancy[d]));
-          divisibility.push_back(
-              getDivisibilityFromContiguity(lhsInfo, rhsInfo, d));
+          // When condConstancy reduces output contiguity below either input's
+          // contiguity, output "group leaders" include positions that were
+          // non-leaders in lhs/rhs; the value at such a position p is
+          // divisible only by gcd(d_src, p) <= gcd(d_src, outContig). Clamp
+          // divisibility by output contiguity to keep this sound.
+          // getDivisibilityFromContiguity itself does not see condConstancy.
+          int64_t div = getDivisibilityFromContiguity(lhsInfo, rhsInfo, d);
+          if (contiguity.back() < lhsInfo.getContiguity(d) ||
+              contiguity.back() < rhsInfo.getContiguity(d))
+            div = gcd(div, contiguity.back());
+          divisibility.push_back(div);
         }
       }
       if (lhsInfo.getConstantValue().has_value() &&

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -960,17 +960,12 @@ public:
                                   rhsInfo.getConstancy(d), condConstancy[d]));
           contiguity.push_back(gcd(lhsInfo.getContiguity(d),
                                    rhsInfo.getContiguity(d), condConstancy[d]));
-          // When condConstancy reduces output contiguity below either input's
-          // contiguity, output "group leaders" include positions that were
-          // non-leaders in lhs/rhs; the value at such a position p is
-          // divisible only by gcd(d_src, p) <= gcd(d_src, outContig). Clamp
-          // divisibility by output contiguity to keep this sound.
-          // getDivisibilityFromContiguity itself does not see condConstancy.
-          int64_t div = getDivisibilityFromContiguity(lhsInfo, rhsInfo, d);
-          if (contiguity.back() < lhsInfo.getContiguity(d) ||
-              contiguity.back() < rhsInfo.getContiguity(d))
-            div = gcd(div, contiguity.back());
-          divisibility.push_back(div);
+          // getDivisibilityFromContiguity does not see condConstancy; clamp
+          // by the just-computed output contiguity so the result remains
+          // sound when condConstancy reduces it below the input contiguities.
+          divisibility.push_back(
+              gcd(getDivisibilityFromContiguity(lhsInfo, rhsInfo, d),
+                  contiguity.back()));
         }
       }
       if (lhsInfo.getConstantValue().has_value() &&

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -1146,6 +1146,24 @@ tt.func @select_same_value_constancy() {
 
 // -----
 
+// Regression: SelectOp must clamp divisibility when condConstancy reduces the
+// output contiguity below either input's contiguity. Otherwise the helper
+// getDivisibilityFromContiguity overestimates divisibility because it does not
+// see condConstancy. See issue triton-lang/triton#10067.
+tt.func @select_cond_constancy_clamps_divisibility(%arg0: tensor<8xi1>) {
+  // expected-remark @below {{contiguity = [8], divisibility = [8], constancy = [1], constant_value = <none>}}
+  %lhs = tt.make_range {end = 16 : i32, start = 8 : i32} : tensor<8xi32>
+  // expected-remark @below {{contiguity = [8], divisibility = [16], constancy = [1], constant_value = <none>}}
+  %rhs = tt.make_range {end = 24 : i32, start = 16 : i32} : tensor<8xi32>
+  // %arg0 has unknown contents, so condConstancy = 1. Output contiguity must
+  // collapse to gcd(8, 8, 1) = 1; divisibility must clamp to 1 (not gcd(8, 16) = 8).
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>}}
+  %sel = arith.select %arg0, %lhs, %rhs : tensor<8xi1>, tensor<8xi32>
+  tt.return
+}
+
+// -----
+
 tt.func @cmp_after_max_constancy() {
   %c5 = arith.constant dense<5> : tensor<4xi32>
   %c7 = arith.constant dense<7> : tensor<4xi32>


### PR DESCRIPTION
Fixes #10067.

In `SelectOpAxisInfoVisitor`'s tensor-cond branch, the call to `getDivisibilityFromContiguity` only sees the lhs/rhs contiguities and can overestimate divisibility when `condConstancy` further reduces the output contiguity below either input's contiguity.

### Concrete example

- lhs: `[8, 9, 10, 11, 12, 13, 14, 15]` (c=8, d=8)
- rhs: `[16, 17, 18, 19, 20, 21, 22, 23]` (c=8, d=16)
- Element-wise condition, so `condConstancy = 1`

Output contiguity collapses to `gcd(8, 8, 1) = 1` (every position is a leader). But `getDivisibilityFromContiguity` sees `c_lhs == c_rhs == 8` and returns `gcd(8, 16) = 8` — without accounting for `condConstancy`. The output value at position 1 may be 17, which is not divisible by 8.

### Why this didn't blow up

On the current pow2 lattice, `gcd == min` on powers of 2. Codegen's `vec_width = min(c, d/e, ...)` is bounded by contiguity, and contiguity is computed correctly. So the overestimated divisibility is never the binding constraint on `vec_width`. This is a latent soundness regression introduced by #7781 — the pre-#7781 code clamped `divisibility` against the just-computed output contiguity, and that was sound independent of the pow2 invariant.

### Fix

A conditional GCD with the output contiguity at the SelectOp callsite. The clamp fires only when `condConstancy` (or another shrinking factor) reduces the output contiguity strictly below at least one input's contiguity — i.e. it preserves the existing semantics when `condConstancy` is non-binding.

The helper `getDivisibilityFromContiguity` is left unchanged (its other callers — `MaxMinOpAxisInfoVisitor` and `AxisInfo::join` — don't have a `condConstancy`-equivalent, so the same gap doesn't exist there).

### Test

Added `select_cond_constancy_clamps_divisibility` in `test/Analysis/test-alignment.mlir`. The test fails before the fix (`divisibility = [8]`) and passes after (`divisibility = [1]`).

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
