### PR TITLE
[runtime] remove redundant triton._utils import in native specialize

### DIFF
--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -136,7 +136,6 @@ bool init_globals() noexcept try {
   amd_tensor_descriptor_cls =
       import_from("triton.experimental.gluon.amd.gfx1250", "TensorDescriptor");
 
-  auto m_canonicalize = py::module_::import("triton._utils");
   canonicalize_dtype_fn = import_from("triton._utils", "canonicalize_dtype");
   canonicalize_ptr_dtype_fn =
       import_from("triton._utils", "canonicalize_ptr_dtype");


### PR DESCRIPTION
## Summary
Remove an unused `py::module_::import("triton._utils")` in `python/src/specialize.cc`.

`import_from("triton._utils", ...)` already imports the module internally before fetching attributes, so the extra import is redundant and has no behavioral effect.

## Validation
- `ninja -C build/cmake.linux-x86_64-cpython-3.10`
- `PYTHONPATH=python .venv-host-capture/bin/python3 -m pytest -s --tb=short python/test/unit/runtime/test_specialize.py`

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
