### PR TITLE
[AMD] Add buffer atomic support for RDNA3

### DIFF
--- a/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
@@ -1,6 +1,7 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx942 analyze-small-tensor-ofst=true"| FileCheck %s --check-prefixes=COMMON,GFX942-ONLY,CDNA
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx950 analyze-small-tensor-ofst=true"| FileCheck %s --check-prefixes=COMMON,GFX950-PLUS,CDNA
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx1250 analyze-small-tensor-ofst=true"| FileCheck %s --check-prefixes=COMMON,GFX950-PLUS
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx1100 analyze-small-tensor-ofst=true"| FileCheck %s --check-prefixes=COMMON,GFX1100
 
 #blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
@@ -707,6 +708,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %4 = tt.splat %3 : !tt.ptr<bf16> -> tensor<512x!tt.ptr<bf16>, #blocked>
     %5 = tt.addptr %4, %2 : tensor<512x!tt.ptr<bf16>, #blocked>, tensor<512xi32, #blocked>
     // GFX942-ONLY-NOT: amdg.buffer_atomic_rmw
+    // GFX1100-NOT: amdg.buffer_atomic_rmw
     // GFX950-PLUS: amdg.buffer_atomic_rmw
     %6 = tt.atomic_rmw fadd, acq_rel, gpu, %5, %cst_0, %cst : (tensor<512x!tt.ptr<bf16>, #blocked>, tensor<512xbf16, #blocked>, tensor<512xi1, #blocked>) -> tensor<512xbf16, #blocked>
     tt.return
@@ -944,5 +946,21 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %20 = tt.addptr %19, %18 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
     %21 = tt.atomic_rmw fadd, relaxed, gpu, %20, %15, %cst : (tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xf32, #blocked>, tensor<64xi1, #blocked>) -> tensor<64xf32, #blocked>
     tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // COMMON-LABEL: atomic_rmw_buffer_fadd_f32
+  tt.func public @atomic_rmw_buffer_fadd_f32(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: tensor<512xf32, #blocked>) -> tensor<512xf32, #blocked> {
+    %cst = arith.constant dense<true> : tensor<512xi1, #blocked>
+    %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32, #blocked>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<512x!tt.ptr<f32>, #blocked>
+    %2 = tt.addptr %1, %0 : tensor<512x!tt.ptr<f32>, #blocked>, tensor<512xi32, #blocked>
+    // COMMON: amdg.buffer_atomic_rmw fadd
+    %3 = tt.atomic_rmw fadd, acq_rel, gpu, %2, %arg1, %cst : (tensor<512x!tt.ptr<f32>, #blocked>, tensor<512xf32, #blocked>, tensor<512xi1, #blocked>) -> tensor<512xf32, #blocked>
+    tt.return %3 : tensor<512xf32, #blocked>
   }
 }

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
@@ -248,7 +248,8 @@ bool TargetFeatures::supportsClusterLoadBitWidth(int bitWidth) const {
 
 bool TargetFeatures::supportsBufferAtomicRMW() const {
   return llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4,
-                             ISAFamily::RDNA4, ISAFamily::GFX1250},
+                             ISAFamily::RDNA3, ISAFamily::RDNA4,
+                             ISAFamily::GFX1250},
                             getISAFamily());
 }
 
@@ -257,6 +258,8 @@ bool TargetFeatures::supportsBufferAtomicFadd(Type elementType) const {
   if (isaFamily == ISAFamily::CDNA3 && elementType.isBF16())
     return false;
   if (isaFamily == ISAFamily::RDNA4 && elementType.isF64())
+    return false;
+  if (isaFamily == ISAFamily::RDNA3 && !elementType.isF32())
     return false;
   return true;
 }


### PR DESCRIPTION
This PR enables buffer atomic RMW on RDNA3 (gfx11) for supported data types, mirroring the RDNA4 enablement in [#8778](https://github.com/triton-lang/triton/pull/8778). RDNA3 already exposes `BUFFER_ATOMIC_*` for every integer op and for the f32 floating-point ops we care about, but `TargetFeatures::supportsBufferAtomicRMW()` was not extended when RDNA4 was added, so generic `tt.atomic_rmw` ops on gfx11 currently fall through to the legacy non-buffer atomic path.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
