### PR TITLE
[Docs] Document tl.histogram input range and out-of-range behavior

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3182,10 +3182,9 @@ def histogram(input, num_bins, mask=None, _semantic=None, _generator=None):
     many values in :code:`input` are equal to :code:`i`, for :code:`i` in the range
     ``[0, num_bins)``.
 
-    Input values must lie in ``[0, num_bins)``. The result is unspecified for
-    values outside this range, and the behavior may differ between backends
-    (some drop such values while others fold them into the wrong bin), so do not
-    rely on it. Use :code:`mask` to drop out-of-range values explicitly:
+    Input values must lie in ``[0, num_bins)``. Values outside this range
+    produce undefined behavior, as the backend implementation may change. Use
+    :code:`mask` to drop out-of-range values explicitly:
 
     .. highlight:: python
     .. code-block:: python

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3177,14 +3177,27 @@ def associative_scan(input, axis, combine_fn, reverse=False, _semantic=None, _ge
 @_tensor_member_fn
 @builtin
 def histogram(input, num_bins, mask=None, _semantic=None, _generator=None):
-    """computes an histogram based on input tensor with num_bins bins, the bins have a width of 1 and start at 0.
+    """Computes a histogram of :code:`input` with :code:`num_bins` bins. The bins
+    have a width of 1 and start at 0, so element :code:`i` of the result counts how
+    many values in :code:`input` are equal to :code:`i`, for :code:`i` in the range
+    ``[0, num_bins)``.
+
+    Input values must lie in ``[0, num_bins)``. The result is unspecified for
+    values outside this range, and the behavior may differ between backends
+    (some drop such values while others fold them into the wrong bin), so do not
+    rely on it. Use :code:`mask` to drop out-of-range values explicitly:
+
+    .. highlight:: python
+    .. code-block:: python
+
+        counts = tl.histogram(x, num_bins, mask=(x >= 0) & (x < num_bins))
 
     :param input: the input tensor
     :type input: Tensor
     :param num_bins: number of histogram bins
     :type num_bins: int
-    :param mask: if `mask[idx]` is false, exclude `input[idx]` from histogram
-    :type mask: Block of `triton.int1`, optional
+    :param mask: if :code:`mask[idx]` is false, exclude :code:`input[idx]` from the histogram
+    :type mask: Block of :code:`triton.int1`, optional
 
     """
     num_bins = _unwrap_if_constexpr(num_bins)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3053,10 +3053,9 @@ def histogram(input, num_bins, mask=None, _semantic=None, _generator=None):
     many values in :code:`input` are equal to :code:`i`, for :code:`i` in the range
     ``[0, num_bins)``.
 
-    Input values must lie in ``[0, num_bins)``. The result is unspecified for
-    values outside this range, and the behavior may differ between backends
-    (some drop such values while others fold them into the wrong bin), so do not
-    rely on it. Use :code:`mask` to drop out-of-range values explicitly:
+    Input values must lie in ``[0, num_bins)``. Values outside this range
+    produce undefined behavior, as the backend implementation may change. Use
+    :code:`mask` to drop out-of-range values explicitly:
 
     .. highlight:: python
     .. code-block:: python

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3048,14 +3048,27 @@ def associative_scan(input, axis, combine_fn, reverse=False, _semantic=None, _ge
 @_tensor_member_fn
 @builtin
 def histogram(input, num_bins, mask=None, _semantic=None, _generator=None):
-    """computes an histogram based on input tensor with num_bins bins, the bins have a width of 1 and start at 0.
+    """Computes a histogram of :code:`input` with :code:`num_bins` bins. The bins
+    have a width of 1 and start at 0, so element :code:`i` of the result counts how
+    many values in :code:`input` are equal to :code:`i`, for :code:`i` in the range
+    ``[0, num_bins)``.
+
+    Input values must lie in ``[0, num_bins)``. The result is unspecified for
+    values outside this range, and the behavior may differ between backends
+    (some drop such values while others fold them into the wrong bin), so do not
+    rely on it. Use :code:`mask` to drop out-of-range values explicitly:
+
+    .. highlight:: python
+    .. code-block:: python
+
+        counts = tl.histogram(x, num_bins, mask=(x >= 0) & (x < num_bins))
 
     :param input: the input tensor
     :type input: Tensor
     :param num_bins: number of histogram bins
     :type num_bins: int
-    :param mask: if `mask[idx]` is false, exclude `input[idx]` from histogram
-    :type mask: Block of `triton.int1`, optional
+    :param mask: if :code:`mask[idx]` is false, exclude :code:`input[idx]` from the histogram
+    :type mask: Block of :code:`triton.int1`, optional
 
     """
     num_bins = _unwrap_if_constexpr(num_bins)


### PR DESCRIPTION
The `tl.histogram` docstring did not say which input values are valid or what happens to values that fall outside the bin range. Issue #9050 asks exactly this, and the answer is that out-of-range values are not supported.

The bins have width 1 starting at 0, so element `i` of the result counts values equal to `i` for `i` in `[0, num_bins)`. Values outside that range are unspecified, and the two backends disagree on what they do. The NVIDIA lowering in `HistogramOpToLLVM.cpp` guards each update with an unsigned `icmp_ult(value, num_bins)` and drops anything out of range. The AMD lowering computes the bin from the low `log2(num_bins)` bits of the value, so an out-of-range value silently lands in the wrong bin and miscounts. Because of that divergence, the docstring now states the `[0, num_bins)` contract, says the result is unspecified outside it, and shows the `mask` idiom that the existing `mask` parameter was added for.

Docs-only change. `ruff check` passes and the file is unchanged under yapf.

Closes #9050