### PR TITLE
[AMD/HIP] Add 29 missing libdevice functions with direct OCML mappings

### DIFF
--- a/third_party/amd/language/hip/libdevice.py
+++ b/third_party/amd/language/hip/libdevice.py
@@ -512,3 +512,262 @@ def isfinited(arg0, _semantic=None):
     return core.extern_elementwise("", "", [arg0], {
         (core.dtype("fp64"), ): ("__ocml_isfinite_f64", core.dtype("int32")),
     }, is_pure=True, _semantic=_semantic).to(core.int1, _semantic=_semantic)
+
+
+# ---------------------------------------------------------------------------
+# Functions below were missing from the HIP libdevice but have direct OCML
+# equivalents. Added to close the parity gap with CUDA libdevice.
+# ---------------------------------------------------------------------------
+
+
+@core.extern
+def cbrt(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_cbrt_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), ): ("__ocml_cbrt_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def rcbrt(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_rcbrt_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), ): ("__ocml_rcbrt_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def exp10(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_exp10_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), ): ("__ocml_exp10_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def erfcinv(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_erfcinv_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), ): ("__ocml_erfcinv_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def tgamma(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_tgamma_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), ): ("__ocml_tgamma_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def logb(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_logb_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), ): ("__ocml_logb_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def remainder(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_remainder_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64")): ("__ocml_remainder_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def rhypot(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_rhypot_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64")): ("__ocml_rhypot_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def fdim(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_fdim_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64")): ("__ocml_fdim_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def scalbn(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("int32")): ("__ocml_scalbn_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("int32")): ("__ocml_scalbn_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def llround(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_llround_f32", core.dtype("int64")),
+            (core.dtype("fp64"), ): ("__ocml_llround_f64", core.dtype("int64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def sinpi(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_sinpi_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), ): ("__ocml_sinpi_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def cospi(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_cospi_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), ): ("__ocml_cospi_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def normcdf(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_ncdf_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), ): ("__ocml_ncdf_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def normcdfinv(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_ncdfinv_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), ): ("__ocml_ncdfinv_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def jn(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("int32"), core.dtype("fp32")): ("__ocml_jn_f32", core.dtype("fp32")),
+            (core.dtype("int32"), core.dtype("fp64")): ("__ocml_jn_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def yn(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("int32"), core.dtype("fp32")): ("__ocml_yn_f32", core.dtype("fp32")),
+            (core.dtype("int32"), core.dtype("fp64")): ("__ocml_yn_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def norm3d(arg0, arg1, arg2, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1, arg2], {
+            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__ocml_len3_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__ocml_len3_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def rnorm3d(arg0, arg1, arg2, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1, arg2], {
+            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__ocml_rlen3_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__ocml_rlen3_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def norm4d(arg0, arg1, arg2, arg3, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1, arg2, arg3], {
+            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__ocml_len4_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__ocml_len4_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def rnorm4d(arg0, arg1, arg2, arg3, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1, arg2, arg3], {
+            (core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32")): ("__ocml_rlen4_f32", core.dtype("fp32")),
+            (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64")): ("__ocml_rlen4_f64", core.dtype("fp64")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def fast_sinf(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_native_sin_f32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def fast_cosf(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_native_cos_f32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def fast_logf(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_native_log_f32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def fast_log2f(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_native_log2_f32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def fast_log10f(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_native_log10_f32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def fast_exp10f(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_native_exp10_f32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def fast_tanf(arg0, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0], {
+            (core.dtype("fp32"), ): ("__ocml_native_tan_f32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)
+
+
+@core.extern
+def fast_powf(arg0, arg1, _semantic=None):
+    return core.extern_elementwise(
+        "", "", [arg0, arg1], {
+            (core.dtype("fp32"), core.dtype("fp32")): ("__ocml_native_powr_f32", core.dtype("fp32")),
+        }, is_pure=True, _semantic=_semantic)


### PR DESCRIPTION
I'm a contributor to FlagGems (open-source GPU kernel library built on OpenAI Triton) and hit this gap when porting operators to ROCm. This PR addresses the root cause systematically.

## What does this PR do?

Adds 29 math functions to `third_party/amd/language/hip/libdevice.py` that were available in the CUDA libdevice but missing from the HIP backend. Each function maps directly to an existing `__ocml_*` function in AMD's OCML math library.

Closes #10375
## Motivation

The HIP libdevice exposes only 57/198 functions compared to CUDA, causing:
- Silent failures for cross-platform Triton kernels
- Users needing manual `IS_HIP` workarounds (see #7135 for `round`)
- FlagGems and other op libraries hitting missing functions when targeting ROCm

## Changes

**File modified:** `third_party/amd/language/hip/libdevice.py`

Added 29 functions across 4 categories:

**Transcendental / special math** — `cbrt`, `rcbrt`, `exp10`, `erfcinv`, `tgamma`, `logb`, `sinpi`, `cospi`

**Statistics / probability** — `normcdf`, `normcdfinv`

**Geometry** — `norm3d`, `rnorm3d`, `norm4d`, `rnorm4d`, `rhypot`

**Arithmetic** — `remainder`, `fdim`, `scalbn`, `llround`, `jn`, `yn`

**Fast native (fp32 only)** — `fast_sinf`, `fast_cosf`, `fast_logf`, `fast_log2f`, `fast_log10f`, `fast_exp10f`, `fast_tanf`, `fast_powf`

## OCML Mapping Table

| Triton function | fp32 OCML | fp64 OCML |
|---|---|---|
| `cbrt` | `__ocml_cbrt_f32` | `__ocml_cbrt_f64` |
| `rcbrt` | `__ocml_rcbrt_f32` | `__ocml_rcbrt_f64` |
| `exp10` | `__ocml_exp10_f32` | `__ocml_exp10_f64` |
| `erfcinv` | `__ocml_erfcinv_f32` | `__ocml_erfcinv_f64` |
| `tgamma` | `__ocml_tgamma_f32` | `__ocml_tgamma_f64` |
| `logb` | `__ocml_logb_f32` | `__ocml_logb_f64` |
| `remainder` | `__ocml_remainder_f32` | `__ocml_remainder_f64` |
| `rhypot` | `__ocml_rhypot_f32` | `__ocml_rhypot_f64` |
| `fdim` | `__ocml_fdim_f32` | `__ocml_fdim_f64` |
| `scalbn` | `__ocml_scalbn_f32` | `__ocml_scalbn_f64` |
| `llround` | `__ocml_llround_f32` | `__ocml_llround_f64` |
| `sinpi` | `__ocml_sinpi_f32` | `__ocml_sinpi_f64` |
| `cospi` | `__ocml_cospi_f32` | `__ocml_cospi_f64` |
| `normcdf` | `__ocml_ncdf_f32` | `__ocml_ncdf_f64` |
| `normcdfinv` | `__ocml_ncdfinv_f32` | `__ocml_ncdfinv_f64` |
| `jn` | `__ocml_jn_f32` | `__ocml_jn_f64` |
| `yn` | `__ocml_yn_f32` | `__ocml_yn_f64` |
| `norm3d` | `__ocml_len3_f32` | `__ocml_len3_f64` |
| `rnorm3d` | `__ocml_rlen3_f32` | `__ocml_rlen3_f64` |
| `norm4d` | `__ocml_len4_f32` | `__ocml_len4_f64` |
| `rnorm4d` | `__ocml_rlen4_f32` | `__ocml_rlen4_f64` |
| `fast_sinf` | `__ocml_native_sin_f32` | — |
| `fast_cosf` | `__ocml_native_cos_f32` | — |
| `fast_logf` | `__ocml_native_log_f32` | — |
| `fast_log2f` | `__ocml_native_log2_f32` | — |
| `fast_log10f` | `__ocml_native_log10_f32` | — |
| `fast_exp10f` | `__ocml_native_exp10_f32` | — |
| `fast_tanf` | `__ocml_native_tan_f32` | — |
| `fast_powf` | `__ocml_native_powr_f32` | — |

## Testing

- [x] Python syntax validated (`ast.parse` passes clean)
- [x] OCML function names verified against AMD ROCm device-libs headers
- [ ] Runtime test on AMD hardware (MI300X) pending — happy to add results if reviewers can run CI

## Follow-up

A follow-up PR will address the remaining 18 implementable functions:
- Bit ops (`clz`, `popc`, `ffs`, `brev`) via LLVM builtins
- Integer ops (`mul24`, `mulhi`, `hadd`, `rhadd`, `sad`)
- Bitcast ops (`float_as_int`, `int_as_float`, etc.)

The 91 CUDA-specific rounding-mode variants (`_rd/_rn/_ru/_rz`) have no direct HIP equivalent and are out of scope.