### PR TITLE
[PROTON] Detect wrong hatchet package at import time

### DIFF
--- a/third_party/proton/proton/viewer.py
+++ b/third_party/proton/proton/viewer.py
@@ -14,6 +14,24 @@ from triton.profiler.metric import FLOPS_WIDTHS
 from triton.profiler import specs
 
 
+def _check_hatchet(module):
+    # `import hatchet` can resolve to an unrelated package that also publishes a top-level
+    # `hatchet` module (for example the task-queue project on PyPI). Those packages import
+    # fine but lack the GraphFrame API the viewer relies on, which used to surface much later
+    # as a cryptic `AttributeError` deep inside `read`. Detect the wrong package up front and
+    # tell the user which distribution to install.
+    graph_frame = getattr(module, "GraphFrame", None)
+    required = ("from_literal", "update_inclusive_columns")
+    if graph_frame is None or not all(hasattr(graph_frame, attr) for attr in required):
+        location = getattr(module, "__file__", "unknown location")
+        raise ImportError(f"The imported `hatchet` package ({location}) is not llnl-hatchet. "
+                          "Another package named `hatchet` is shadowing it. "
+                          "`pip uninstall hatchet && pip install llnl-hatchet` to get the correct version.")
+
+
+_check_hatchet(ht)
+
+
 def match_available_metrics(metrics, inclusive_metrics, exclusive_metrics):
     ret = []
     if not isinstance(metrics, list):

--- a/third_party/proton/test/test_viewer.py
+++ b/third_party/proton/test/test_viewer.py
@@ -197,3 +197,39 @@ def test_diff_profile():
     gf2, _ = parse(["time/s"], cuda_example_file)
     gf = apply_diff_profile(gf, derived_metrics, cuda_example_file, ["time/s"], None, None, 0.0)
     assert "time/s (inc)" in gf.dataframe.columns
+
+
+def test_check_hatchet_rejects_wrong_package():
+    from types import SimpleNamespace
+    from triton.profiler.viewer import _check_hatchet
+
+    # No GraphFrame at all (an unrelated package named `hatchet`).
+    with pytest.raises(ImportError, match="llnl-hatchet"):
+        _check_hatchet(SimpleNamespace(__file__="/some/wrong/hatchet/__init__.py"))
+
+    # GraphFrame present but missing the API the viewer depends on.
+    class PartialGraphFrame:
+
+        @staticmethod
+        def from_literal(graph_dict):
+            return None
+
+    with pytest.raises(ImportError, match="llnl-hatchet"):
+        _check_hatchet(SimpleNamespace(GraphFrame=PartialGraphFrame))
+
+
+def test_check_hatchet_accepts_llnl_hatchet():
+    from types import SimpleNamespace
+    from triton.profiler.viewer import _check_hatchet
+
+    class GraphFrame:
+
+        @staticmethod
+        def from_literal(graph_dict):
+            return None
+
+        def update_inclusive_columns(self):
+            return None
+
+    # A module exposing the llnl-hatchet API must pass without raising.
+    _check_hatchet(SimpleNamespace(GraphFrame=GraphFrame))


### PR DESCRIPTION
`proton-viewer` imports the top-level `hatchet` module, but more than one PyPI project publishes a package under that name. When a non llnl-hatchet `hatchet` ends up on the path, the import in `viewer.py` succeeds and the problem only surfaces much later inside `read` as a cryptic error:

```
AttributeError: 'GraphFrame' object has no attribute 'update_inclusive_columns'
```

This is exactly what #8590 reports, and the fix there is to install `llnl-hatchet`, but nothing tells the user that until the viewer is already deep into parsing a profile.

This PR validates the imported module right after the import by checking that `GraphFrame` exposes the two APIs the viewer depends on, `from_literal` and `update_inclusive_columns`. If they are missing, it raises an `ImportError` that names the install location that got picked up and the package to install, so the failure is immediate and actionable instead of a confusing `AttributeError`.

Added `test_check_hatchet_rejects_wrong_package` and `test_check_hatchet_accepts_llnl_hatchet` in `test_viewer.py`, which exercise the new check against stand-in modules with and without the required GraphFrame API. Both run on CPU.

Fixes #8590