### PR TITLE
test/docs: cover Blackwell ptxas overrides

### DIFF
--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -38,6 +38,20 @@ Note that, if llvm is not present on your system, the setup.py script will downl
 
 For building with a custom LLVM, review the `Building with a custom LLVM <https://github.com/triton-lang/triton?tab=readme-ov-file#building-with-a-custom-llvm>`_ section on Github.
 
+If you are bringing up a newer NVIDIA architecture with a system CUDA toolkit that has a newer ``ptxas`` than the one bundled with Triton, point Triton at the system assembler before building:
+
+.. code-block:: bash
+
+      export TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
+
+Triton also supports a separate override for the Blackwell-specific assembler binary:
+
+.. code-block:: bash
+
+      export TRITON_PTXAS_BLACKWELL_PATH=/usr/local/cuda/bin/ptxas
+
+These overrides are useful when validating Blackwell or other newly supported NVIDIA targets without replacing the bundled toolchain for every architecture.
+
 You can then test your installation by running the tests:
 
 .. code-block:: bash

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -50,7 +50,7 @@ Triton also supports a separate override for the Blackwell-specific assembler bi
 
       export TRITON_PTXAS_BLACKWELL_PATH=/usr/local/cuda/bin/ptxas
 
-These overrides are useful when validating Blackwell or other newly supported NVIDIA targets without replacing the bundled toolchain for every architecture.
+Use ``TRITON_PTXAS_PATH`` as the general override for newer NVIDIA bring-up flows, and use ``TRITON_PTXAS_BLACKWELL_PATH`` only when you need a separate Blackwell-specific assembler override without changing the bundled toolchain for other architectures.
 
 You can then test your installation by running the tests:
 

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -241,43 +241,58 @@ def test_set_knob_directly(fresh_knobs_including_libraries, monkeypatch):
 def test_nvidia_tool(fresh_knobs, tmp_path, monkeypatch):
     triton_root = Path(fresh_knobs.__file__).parent
     default_ptxas = triton_root / "backends/nvidia/bin/ptxas"
+    default_ptxas_blackwell = triton_root / "backends/nvidia/bin/ptxas-blackwell"
 
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
+    assert Path(fresh_knobs.nvidia.ptxas_blackwell.path).resolve() == default_ptxas_blackwell.resolve()
     assert fresh_knobs.nvidia.ptxas_options is None
 
     tmp_ptxas = tmp_path / "ptxas-special"
+    tmp_ptxas_blackwell = tmp_path / "ptxas-blackwell-special"
     shutil.copy(default_ptxas, tmp_ptxas)
+    shutil.copy(default_ptxas_blackwell, tmp_ptxas_blackwell)
     monkeypatch.setenv("TRITON_PTXAS_PATH", str(tmp_ptxas))
+    monkeypatch.setenv("TRITON_PTXAS_BLACKWELL_PATH", str(tmp_ptxas_blackwell))
     monkeypatch.setenv("PTXAS_OPTIONS", "--verbose")
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == tmp_ptxas.resolve()
+    assert Path(fresh_knobs.nvidia.ptxas_blackwell.path).resolve() == tmp_ptxas_blackwell.resolve()
     assert fresh_knobs.nvidia.ptxas_options == "--verbose"
 
     # Don't prop so that the `del` is correctly tested
     fresh_knobs.propagate_env = False
     fresh_knobs.nvidia.ptxas = str(default_ptxas)
+    fresh_knobs.nvidia.ptxas_blackwell = str(default_ptxas_blackwell)
     fresh_knobs.nvidia.ptxas_options = "--device-debug"
     fresh_knobs.propagate_env = True
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
+    assert Path(fresh_knobs.nvidia.ptxas_blackwell.path).resolve() == default_ptxas_blackwell.resolve()
     assert fresh_knobs.nvidia.ptxas_options == "--device-debug"
 
     del fresh_knobs.nvidia.ptxas
+    del fresh_knobs.nvidia.ptxas_blackwell
     del fresh_knobs.nvidia.ptxas_options
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == tmp_ptxas.resolve()
+    assert Path(fresh_knobs.nvidia.ptxas_blackwell.path).resolve() == tmp_ptxas_blackwell.resolve()
     assert fresh_knobs.nvidia.ptxas_options == "--verbose"
 
     # Triple check scope works
     with fresh_knobs.nvidia.scope():
         fresh_knobs.nvidia.ptxas = str(default_ptxas)
+        fresh_knobs.nvidia.ptxas_blackwell = str(default_ptxas_blackwell)
         fresh_knobs.nvidia.ptxas_options = "--device-debug"
         assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
+        assert Path(fresh_knobs.nvidia.ptxas_blackwell.path).resolve() == default_ptxas_blackwell.resolve()
         assert fresh_knobs.nvidia.ptxas_options == "--device-debug"
 
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == tmp_ptxas.resolve()
+    assert Path(fresh_knobs.nvidia.ptxas_blackwell.path).resolve() == tmp_ptxas_blackwell.resolve()
     assert fresh_knobs.nvidia.ptxas_options == "--verbose"
 
     monkeypatch.delenv("TRITON_PTXAS_PATH")
+    monkeypatch.delenv("TRITON_PTXAS_BLACKWELL_PATH")
     monkeypatch.delenv("PTXAS_OPTIONS")
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
+    assert Path(fresh_knobs.nvidia.ptxas_blackwell.path).resolve() == default_ptxas_blackwell.resolve()
     assert fresh_knobs.nvidia.ptxas_options is None
 
 

--- a/python/test/unit/tools/test_build_helpers.py
+++ b/python/test/unit/tools/test_build_helpers.py
@@ -1,13 +1,19 @@
 import argparse
+import importlib.util
 import os
+from pathlib import Path
 
-from build_helpers import add_common_args
-from build_helpers import normalize_parsed_args
+BUILD_HELPERS_PATH = Path(__file__).resolve().parents[3] / "build_helpers.py"
+SPEC = importlib.util.spec_from_file_location("triton_build_helpers", BUILD_HELPERS_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+build_helpers = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(build_helpers)
 
 
 def test_normalize_parsed_args_keeps_blackwell_ptxas_override(tmp_path):
     parser = argparse.ArgumentParser()
-    add_common_args(parser)
+    build_helpers.add_common_args(parser)
 
     cache_dir = tmp_path / "cache"
     ptxas_dir = tmp_path / "toolchain"
@@ -22,7 +28,7 @@ def test_normalize_parsed_args_keeps_blackwell_ptxas_override(tmp_path):
         str(ptxas_dir / "ptxas-blackwell"),
     ])
 
-    helper_args = normalize_parsed_args(parsed_args)
+    helper_args = build_helpers.normalize_parsed_args(parsed_args)
 
     assert helper_args.cache_path == os.path.abspath(str(cache_dir))
     assert helper_args.ptxas_path == os.path.abspath(str(ptxas_dir / "ptxas"))

--- a/python/test/unit/tools/test_build_helpers.py
+++ b/python/test/unit/tools/test_build_helpers.py
@@ -1,0 +1,29 @@
+import argparse
+import os
+
+from build_helpers import add_common_args
+from build_helpers import normalize_parsed_args
+
+
+def test_normalize_parsed_args_keeps_blackwell_ptxas_override(tmp_path):
+    parser = argparse.ArgumentParser()
+    add_common_args(parser)
+
+    cache_dir = tmp_path / "cache"
+    ptxas_dir = tmp_path / "toolchain"
+    ptxas_dir.mkdir()
+
+    parsed_args = parser.parse_args([
+        "--triton-cache-path",
+        str(cache_dir),
+        "--triton-ptxas-path",
+        str(ptxas_dir / "ptxas"),
+        "--triton-ptxas-blackwell-path",
+        str(ptxas_dir / "ptxas-blackwell"),
+    ])
+
+    helper_args = normalize_parsed_args(parsed_args)
+
+    assert helper_args.cache_path == os.path.abspath(str(cache_dir))
+    assert helper_args.ptxas_path == os.path.abspath(str(ptxas_dir / "ptxas"))
+    assert helper_args.ptxas_blackwell_path == os.path.abspath(str(ptxas_dir / "ptxas-blackwell"))


### PR DESCRIPTION
This change covers the Blackwell-specific ptxas override end to end.

Failure mechanism:
Triton already exposes a separate `TRITON_PTXAS_BLACKWELL_PATH` override in both `python/triton/knobs.py` and `python/build_helpers.py`, but the user-facing tests only covered `TRITON_PTXAS_PATH`. That leaves the Blackwell-specific path easy to regress silently during future refactors, and the installation guide did not mention either override.

Semantic change:
- extend `python/test/unit/test_knobs.py` so the runtime knob test exercises `TRITON_PTXAS_BLACKWELL_PATH` alongside `TRITON_PTXAS_PATH`
- add a focused unit test for `build_helpers.normalize_parsed_args()` so the CLI `--triton-ptxas-blackwell-path` override is preserved after normalization
- document both overrides in `docs/getting-started/installation.rst` for newer NVIDIA bring-up flows

Preserved invariant:
No runtime behavior changes. This only adds coverage for an existing override path and documents how to use it.

Testing:
- `pytest python/test/unit/tools/test_build_helpers.py -q --basetemp .pytest-tmp`
- `python/test/unit/test_knobs.py` could not be executed in this checkout because local import currently fails before collection at `triton._C.libtriton`, and the bundled `backends/nvidia/bin/ptxas*` artifacts are not present in this tree on Windows
