### PR TITLE
[kernels] change heuristic of smem calculation to be more accurate

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -358,6 +358,7 @@ def matmul(a, b, bias,
         FnName.QUANTIZE_NVFP4.name,
     ) else 1
     a_transpose = a.stride(-1) != 1
+    b_transpose = b_is_shuffled or b.storage.data.stride()[-2] == 1
     # determine shapes
     has_gather = gather_indx is not None
     has_scatter = scatter_indx is not None
@@ -418,6 +419,7 @@ def matmul(a, b, bias,
         block_k = block_k,
         mx_block_size = mx_block_size,
         x_uses_tma_when_persistent = a_uses_tma_when_persistent,
+        w_transpose = b_transpose,
         rhs_layout=b.storage.layout,
         epilogue_reduction_n=fused_activation.specs.reduction_n,
     )
@@ -548,7 +550,6 @@ def matmul(a, b, bias,
         b_tensor_or_tma.round_f32_to_tf32 = True
     # create tma descriptor for w_scale
     b_scale_has_tma = opt_flags.is_persistent and b_scale is not None
-    b_transpose = b_is_shuffled or b.storage.data.stride()[-2] == 1
     if b_scale_has_tma:
         scale_block_k = opt_flags.block_k // mx_block_size
         b_scale_storage = b_scale.storage

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -194,6 +194,7 @@ def make_default_opt_flags_nvidia(
     has_y_acc_in,
     constraints,
     x_uses_tma_when_persistent=True,
+    w_transpose=False,
     mx_block_size=None,
     epilogue_reduction_n=1,
 ):
@@ -363,7 +364,8 @@ def make_default_opt_flags_nvidia(
     num_stages = -1
     for ep in subtiles_to_check:
         ns = opt_flags_nvidia.compute_num_stages(*compute_num_stages_args, epilogue_subtile=ep,
-                                                 occupancy_target=occupancy_target)
+                                                 occupancy_target=occupancy_target,
+                                                 w_transpose=w_transpose)
         if ns > num_stages:
             epilogue_subtile, num_stages = ep, ns
 
@@ -461,6 +463,7 @@ def make_opt_flags(
     block_k,
     mx_block_size=None,
     x_uses_tma_when_persistent=True,
+    w_transpose=False,
     rhs_layout=None,
     epilogue_reduction_n=1,
 ):
@@ -497,6 +500,7 @@ def make_opt_flags(
         return make_default_opt_flags_nvidia(
             *args,
             x_uses_tma_when_persistent=x_uses_tma_when_persistent,
+            w_transpose=w_transpose,
             mx_block_size=mx_block_size,
             epilogue_reduction_n=epilogue_reduction_n,
         )

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -134,6 +134,7 @@ def compute_num_stages(
     *,
     epilogue_subtile,
     occupancy_target,
+    w_transpose=False,
 ):
     if precision_config.max_num_imprecise_acc is not None:
         return 3
@@ -199,11 +200,11 @@ def compute_num_stages(
         smem_capacity -= epilogue_smem
         if x_transpose:
             smem_capacity -= int(block_m * block_k * act_size)
-
-    # Persistent fp32 kernels need extra smem headroom (metadata/barriers/TMA state)
-    # that is not fully captured by the simple stage_size model above.
-    if is_persistent and (lhs_dtype == FP32 or rhs_dtype == FP32):
-        smem_capacity -= 32 * 1024
+        if rhs_dtype == FP32 and not w_transpose:
+            # For fp32 B, a non-transposed input requires a transpose after its
+            # TMA load before MMA. Persistent lowering materializes one extra
+            # BLOCK_K x BLOCK_N tile for that conversion.
+            smem_capacity -= int(block_k * block_n * weight_size)
     if is_persistent and not has_native_mxfp and epilogue_reduction_n > 1:
         # Hopper fused reductions materialize an additional reduced-N output
         # tile in smem.
@@ -219,9 +220,6 @@ def compute_num_stages(
         # exceed H100's launch limit.
         max_stages = 4
     num_stages = min(smem_capacity // int(stage_size), max_stages)
-    # Keep one stage of headroom for persistent fp32 to avoid launch-time OOR.
-    if is_persistent and (lhs_dtype == FP32 or rhs_dtype == FP32):
-        num_stages = min(num_stages, 3)
     if num_stages == 0:
         num_stages = 1
     return num_stages


### PR DESCRIPTION
More accurately account the smem usage of the persistent tf32 matmul kernel. This makes it so that we correctly enable 4-stage for tf32 persistent matmul when B is provided in the correct layout.

For M=N=K=4096 matmul this leads to an improvement of about ~13% on GB200, from 560 TFLOP/s to 630 TFLOP/s.

Validated that both NNN and NNT matmuls still run. Note that NNN does _not_ run with 4 stages, so some level of accounting / capping is necessary.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it is a straightforward heuristics change`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
