### PR TITLE
[AMD] Improve ld.lld detection for ROCm SDK / ROCM_PATH installs

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -6,6 +6,7 @@ from types import ModuleType
 import hashlib
 import tempfile
 import os
+import shutil
 import re
 import subprocess
 import functools
@@ -178,23 +179,54 @@ class HIPBackend(BaseBackend):
 
     @staticmethod
     def path_to_rocm_lld():
-        # Check env path for ld.lld
-        lld_env_path = os.getenv("TRITON_HIP_LLD_PATH")
-        if lld_env_path is not None:
-            lld = Path(lld_env_path)
-            if lld.is_file():
-                return lld
-        # Check backend for ld.lld (used for pytorch wheels)
-        lld = Path(__file__).parent / "llvm/bin/ld.lld"
-        if lld.is_file():
-            return lld
-        lld = Path("/opt/rocm/llvm/bin/ld.lld")
-        if lld.is_file():
-            return lld
-        lld = Path("/usr/bin/ld.lld")
-        if lld.is_file():
-            return lld
-        raise Exception("ROCm linker /opt/rocm/llvm/bin/ld.lld not found. Set 'TRITON_HIP_LLD_PATH' to its path.")
+        tried = []
+        # 1. Explicit env override.
+        env = os.environ.get("TRITON_HIP_LLD_PATH")
+        if env:
+            p = Path(env)
+            tried.append(str(p))
+            if p.is_file():
+                return p
+        # 2. Bundled with the triton wheel (pytorch wheels).
+        bundled = Path(__file__).parent / "llvm/bin/ld.lld"
+        tried.append(str(bundled))
+        if bundled.is_file():
+            return bundled
+        # 3. ROCM_PATH env (common on system installs).
+        rocm_path = os.environ.get("ROCM_PATH")
+        if rocm_path:
+            p = Path(rocm_path) / "llvm/bin/ld.lld"
+            tried.append(str(p))
+            if p.is_file():
+                return p
+        # 4. TheRock SDK install: ask `rocm-sdk path --root`.
+        if shutil.which("rocm-sdk") is not None:
+            try:
+                root = subprocess.check_output(["rocm-sdk", "path", "--root"], encoding="utf-8", timeout=5).strip()
+            except (subprocess.SubprocessError, OSError):
+                root = ""
+            if root:
+                p = Path(root) / "llvm/bin/ld.lld"
+                tried.append(str(p))
+                if p.is_file():
+                    return p
+        # 5. Default system install location.
+        p = Path("/opt/rocm/llvm/bin/ld.lld")
+        tried.append(str(p))
+        if p.is_file():
+            return p
+        # 6. Distro-installed standalone lld.
+        p = Path("/usr/bin/ld.lld")
+        tried.append(str(p))
+        if p.is_file():
+            return p
+        # 7. Anything on PATH.
+        on_path = shutil.which("ld.lld")
+        tried.append("PATH:ld.lld")
+        if on_path:
+            return Path(on_path)
+        raise Exception("ROCm linker ld.lld not found. Set 'TRITON_HIP_LLD_PATH' to its "
+                        "path. Probed: " + ", ".join(tried))
 
     @staticmethod
     def make_ttir(mod, metadata, options):


### PR DESCRIPTION
Backports a small `path_to_rocm_lld()` change to `release/3.3.x`. On `main` and `release/3.5.x` this code path was already removed by https://github.com/triton-lang/triton/pull/7548 ([AMD] Use lld library API for linking), so this PR is targeted only at the still-shipping branches that PyTorch 2.7.x consumes via `pytorch-triton-rocm` 
**fixes**:  https://github.com/ROCm/TheRock/issues/2006 .

## What changes
`HIPBackend.path_to_rocm_lld()` now also probes:
- `$ROCM_PATH/llvm/bin/ld.lld` when `ROCM_PATH` is set,
- `$(rocm-sdk path --root)/llvm/bin/ld.lld` when `rocm-sdk` is on PATH (TheRock SDK case),
- `shutil.which("ld.lld")` as a final fallback.

The error message now lists every probed location.

## Why
On TheRock SDK installs (Python wheel layout, no `/opt/rocm`), Triton fails to compile any kernel unless `TRITON_HIP_LLD_PATH` is exported manually. The failure fires from `HIPBackend.hash()` via `torch.utils._triton.triton_hash_with_backend()`, which Inductor calls whenever it codegens a Triton kernel — so `torch.compile` and `aoti_compile_and_package` are unusable without the workaround.

Reproduced locally with `torch==2.7.1` + `pytorch-triton-rocm==3.3.1` on a TheRock-only host (no `/opt/rocm`; `ld.lld` only present under `$(rocm-sdk path --root)/llvm/bin/ld.lld`). Original ROCm/triton draft was https://github.com/ROCm/triton/pull/908 (will close in favor of this one).

See https://github.com/ROCm/TheRock/issues/2006 for the full traceback.

Fixes ROCm/TheRock#2006.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because the change is environment-dependent filesystem probing of the ROCm linker path. Exercising the new branches requires either a TheRock SDK install (so `rocm-sdk path --root` resolves to a real directory containing `llvm/bin/ld.lld`) or `ROCM_PATH` pointing at a populated ROCm install, neither of which is available in the upstream CI environment. The pre-existing fallbacks (`TRITON_HIP_LLD_PATH`, bundled `<triton>/llvm/bin/ld.lld`, `/opt/rocm/llvm/bin/ld.lld`, `/usr/bin/ld.lld`) are unchanged and remain exercised by existing builds.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
