### PR TITLE
[AMD] Enable InThreadTranspose pass for RDNA3 / RDNA3.5 (gfx110x/115x)

### DIFF
--- a/test/TritonGPU/amd/in-thread-transpose.mlir
+++ b/test/TritonGPU/amd/in-thread-transpose.mlir
@@ -546,3 +546,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+// RDNA3.5 (wave32) WMMA equivalent of inThreadTranspose_simple.
+
+// CHECK-DAG: [[$TRANSPOSABLE:#blocked[0-9]*]] = #ttg.blocked<{sizePerThread = [4, 8], threadsPerWarp = [2, 16], warpsPerCTA = [2, 1], order = [1, 0]}>
+// CHECK-DAG: [[$LINEAR:#linear[0-9]*]] = #ttg.linear<
+// CHECK-LABEL: inThreadTranspose_wmma
+// CHECK: tt.load {{.*}} : tensor<32x128x!tt.ptr<f16>, [[$TRANSPOSABLE]]>
+// CHECK: amdg.in_thread_transpose {{.*}} -> tensor<32x128xf16, [[$LINEAR]]>
+// CHECK: ttg.local_load {{.*}}-> tensor<32x128xf16, #ttg.dot_op<{opIdx = 1, parent = {{.*}}, kWidth = 16}>>
+#blocked_wmma = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [2, 1], order = [1, 0]}>
+#mma_wmma = #ttg.amd_wmma<{version = 1, isTranspose = true, ctaLayout = {warp = [[1, 0]]}}>
+#shared_wmma = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_wmma = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1151", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @inThreadTranspose_wmma(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
+    %0 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<32x128x!tt.ptr<f16>, #blocked_wmma>
+    %1 = tt.load %0 : tensor<32x128x!tt.ptr<f16>, #blocked_wmma>
+    %2 = ttg.local_alloc %1 : (tensor<32x128xf16, #blocked_wmma>) -> !ttg.memdesc<32x128xf16, #shared_wmma, #smem_wmma>
+    %3 = ttg.local_load %2 : !ttg.memdesc<32x128xf16, #shared_wmma, #smem_wmma> -> tensor<32x128xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_wmma, kWidth = 16}>>
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -25,7 +25,7 @@ def is_pingpong_schedule_enabled(arch, use_async_copy):
 
 
 def is_in_thread_transpose_enabled(arch):
-    return (arch == "gfx942" or "gfx120" in arch) \
+    return (arch == "gfx942" or "gfx110" in arch or "gfx115" in arch or "gfx120" in arch) \
         if knobs.amd.use_in_thread_transpose is None else knobs.amd.use_in_thread_transpose
 
 


### PR DESCRIPTION
`InThreadTranspose` rewrites `tt.load -> ttg.local_alloc ->
ttg.local_load -> dot_op` so the K-contiguous WMMA/MFMA operand can be
read from LDS as wide `ds_load_b128` instead of scalar `ds_load_u16`
pairs when the load order doesn't match the consumer's K dimension.
The pattern matcher in `matchInThreadTransposePattern` already accepts
`AMDWmmaEncodingAttr` alongside `AMDMfmaEncodingAttr`, but the gate in
`is_in_thread_transpose_enabled` only activates the pass on gfx942
(CDNA3) and gfx120x (RDNA4, enabled in #10185). Extend it to also
cover RDNA3 (gfx110x/gfx1103) and RDNA3.5 (gfx115x).

Added a `inThreadTranspose_wmma` sub-test to
`test/TritonGPU/amd/in-thread-transpose.mlir` (gfx1151, wave32, WMMA
encoding) that verifies the pass produces an `amdg.in_thread_transpose`
op and that the downstream `ttg.local_load` returns the K-contiguous
`dot_op` layout (`kWidth = 16`).

On AITER's `flash_attn_2.varlen_fwd` at the Qwen3-Omni ViT prefill
shape (B=1, S=3200, H=16, head_dim=72, fp16) on gfx1151, this lifts
the inner-loop V `local_load` from 512 scalar `ds_load_u16(_d16_hi)`
to 144 vectorized `ds_load_b128` and gives a 3.8% median speedup
(3.042 -> 2.925 ms). Stacked with #10389 (D8 int
specialization), the same kernel reaches 2.376 ms (-21.9% vs `main`).

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test/TritonGPU/amd/in-thread-transpose.mlir` (lit)
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section.
