### PR TITLE
Guard cuda sync behind is_cuda check

### DIFF
--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -257,8 +257,9 @@ def _run_in_process_worker(client_fn, q, args, kwargs, env, stderr_file):
 
         try:
             client_fn(*args, **kwargs)
-            # Raise any CUDA errors
-            torch.cuda.synchronize()
+            if is_cuda():
+                # Raise any CUDA errors
+                torch.cuda.synchronize()
         except Exception as e:
             exc = e
         finally:


### PR DESCRIPTION
Guards test util call to `torch.cuda.synchronize()` behind `if is_cuda()` for non-cuda backends.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it's a small test util change for non-cuda backends.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
