### PR TITLE
[PROTON] Reduce msgpack serialization overhead-4

### DIFF
--- a/third_party/proton/csrc/lib/Data/TreeData.cpp
+++ b/third_party/proton/csrc/lib/Data/TreeData.cpp
@@ -760,26 +760,11 @@ TreeData::buildHatchetMsgPack(TreeData::Tree *tree,
         }
       }
     }
-    uint32_t concreteChildCount = 0;
-    for (const auto &child : treeNode.children) {
-      const auto &childNode = tree->getNode(child.id);
-      if (!childNode.children.empty() || !childNode.metricSet.metrics.empty() ||
-          !childNode.metricSet.flexibleMetrics.empty() ||
-          !childNode.metricSet.linkedMetrics.empty() ||
-          !childNode.metricSet.linkedFlexibleMetrics.empty()) {
-        ++concreteChildCount;
-      }
-    }
     writer.packFixStrLiteral("children");
-    writer.packArray(concreteChildCount + linkedChildCount);
+    writer.packArray(static_cast<uint32_t>(treeNode.children.size()) +
+                     linkedChildCount);
     for (const auto &child : treeNode.children) {
       auto &childNode = tree->getNode(child.id);
-      if (childNode.children.empty() && childNode.metricSet.metrics.empty() &&
-          childNode.metricSet.flexibleMetrics.empty() &&
-          childNode.metricSet.linkedMetrics.empty() &&
-          childNode.metricSet.linkedFlexibleMetrics.empty()) {
-        continue;
-      }
       packNode(packNode, childNode);
     }
     if (hasLinkedTargets) {

--- a/third_party/proton/csrc/lib/Data/TreeData.cpp
+++ b/third_party/proton/csrc/lib/Data/TreeData.cpp
@@ -758,27 +758,37 @@ TreeData::buildHatchetMsgPack(TreeData::Tree *tree,
     // metrics are attached through linked virtual nodes instead, so a concrete
     // leaf with no metrics, linked metrics, flexible metrics, or children adds
     // no Hatchet information.
+    // Most captured launch scopes have only a few concrete children. Keep that
+    // common case allocation-free while still collecting children once so the
+    // MsgPack array header has an exact count.
+    constexpr size_t kInlineConcreteChildCount = 8;
+    std::array<TreeData::Tree::TreeNode *, kInlineConcreteChildCount>
+        inlineConcreteChildren;
+    std::vector<TreeData::Tree::TreeNode *> overflowConcreteChildren;
     uint32_t concreteChildCount = 0;
     for (const auto &child : treeNode.children) {
-      const auto &childNode = tree->getNode(child.id);
+      auto &childNode = tree->getNode(child.id);
       if (!childNode.children.empty() || !childNode.metricSet.metrics.empty() ||
           !childNode.metricSet.flexibleMetrics.empty() ||
           !childNode.metricSet.linkedMetrics.empty() ||
           !childNode.metricSet.linkedFlexibleMetrics.empty()) {
+        if (concreteChildCount < inlineConcreteChildren.size()) {
+          inlineConcreteChildren[concreteChildCount] = &childNode;
+        } else {
+          overflowConcreteChildren.push_back(&childNode);
+        }
         ++concreteChildCount;
       }
     }
     writer.packFixStrLiteral("children");
     writer.packArray(concreteChildCount + linkedChildCount);
-    for (const auto &child : treeNode.children) {
-      auto &childNode = tree->getNode(child.id);
-      if (childNode.children.empty() && childNode.metricSet.metrics.empty() &&
-          childNode.metricSet.flexibleMetrics.empty() &&
-          childNode.metricSet.linkedMetrics.empty() &&
-          childNode.metricSet.linkedFlexibleMetrics.empty()) {
-        continue;
-      }
-      packNode(packNode, childNode);
+    const auto inlineConcreteCount =
+        std::min<size_t>(concreteChildCount, inlineConcreteChildren.size());
+    for (size_t i = 0; i < inlineConcreteCount; ++i) {
+      packNode(packNode, *inlineConcreteChildren[i]);
+    }
+    for (auto *childNode : overflowConcreteChildren) {
+      packNode(packNode, *childNode);
     }
     if (hasLinkedTargets) {
       for (const auto &virtualChild : virtualRootNode.children) {

--- a/third_party/proton/csrc/lib/Data/TreeData.cpp
+++ b/third_party/proton/csrc/lib/Data/TreeData.cpp
@@ -749,17 +749,10 @@ TreeData::buildHatchetMsgPack(TreeData::Tree *tree,
     const bool hasLinkedTargets =
         !treeNode.metricSet.linkedMetrics.empty() ||
         !treeNode.metricSet.linkedFlexibleMetrics.empty();
-    uint32_t linkedChildCount = 0;
-    if (hasLinkedTargets) {
-      for (const auto &child : virtualRootNode.children) {
-        const auto &childNode = virtualTree->getNode(child.id);
-        if (!childNode.children.empty() ||
-            treeNode.metricSet.linkedMetrics.find(child.id) !=
-                treeNode.metricSet.linkedMetrics.end()) {
-          ++linkedChildCount;
-        }
-      }
-    }
+    uint32_t linkedChildCount =
+        hasLinkedTargets
+            ? static_cast<uint32_t>(virtualRootNode.children.size())
+            : 0;
     writer.packFixStrLiteral("children");
     writer.packArray(static_cast<uint32_t>(treeNode.children.size()) +
                      linkedChildCount);
@@ -769,12 +762,6 @@ TreeData::buildHatchetMsgPack(TreeData::Tree *tree,
     }
     if (hasLinkedTargets) {
       for (const auto &virtualChild : virtualRootNode.children) {
-        const auto &childNode = virtualTree->getNode(virtualChild.id);
-        if (childNode.children.empty() &&
-            treeNode.metricSet.linkedMetrics.find(virtualChild.id) ==
-                treeNode.metricSet.linkedMetrics.end()) {
-          continue;
-        }
         packLinkedVirtualNode(packLinkedVirtualNode, treeNode, virtualChild.id);
       }
     }

--- a/third_party/proton/csrc/lib/Data/TreeData.cpp
+++ b/third_party/proton/csrc/lib/Data/TreeData.cpp
@@ -753,11 +753,31 @@ TreeData::buildHatchetMsgPack(TreeData::Tree *tree,
         hasLinkedTargets
             ? static_cast<uint32_t>(virtualRootNode.children.size())
             : 0;
+    // CUDA stream capture can create concrete launch-name leaves before the
+    // launch callback exits early without correlating metrics. Graph replay
+    // metrics are attached through linked virtual nodes instead, so a concrete
+    // leaf with no metrics, linked metrics, flexible metrics, or children adds
+    // no Hatchet information.
+    uint32_t concreteChildCount = 0;
+    for (const auto &child : treeNode.children) {
+      const auto &childNode = tree->getNode(child.id);
+      if (!childNode.children.empty() || !childNode.metricSet.metrics.empty() ||
+          !childNode.metricSet.flexibleMetrics.empty() ||
+          !childNode.metricSet.linkedMetrics.empty() ||
+          !childNode.metricSet.linkedFlexibleMetrics.empty()) {
+        ++concreteChildCount;
+      }
+    }
     writer.packFixStrLiteral("children");
-    writer.packArray(static_cast<uint32_t>(treeNode.children.size()) +
-                     linkedChildCount);
+    writer.packArray(concreteChildCount + linkedChildCount);
     for (const auto &child : treeNode.children) {
       auto &childNode = tree->getNode(child.id);
+      if (childNode.children.empty() && childNode.metricSet.metrics.empty() &&
+          childNode.metricSet.flexibleMetrics.empty() &&
+          childNode.metricSet.linkedMetrics.empty() &&
+          childNode.metricSet.linkedFlexibleMetrics.empty()) {
+        continue;
+      }
       packNode(packNode, childNode);
     }
     if (hasLinkedTargets) {

--- a/third_party/proton/csrc/lib/Data/TreeData.cpp
+++ b/third_party/proton/csrc/lib/Data/TreeData.cpp
@@ -712,9 +712,25 @@ TreeData::buildHatchetMsgPack(TreeData::Tree *tree,
         }
       }
     }
-    writer.packFixStrLiteral("children");
-    writer.packArray(static_cast<uint32_t>(virtualNode.children.size()));
+    // Linked flexible metrics attached to generated helper leaves are promoted
+    // into the parent metrics map above. Once promoted, a helper leaf with no
+    // linked fixed metrics and no children carries no information in Hatchet.
+    uint32_t linkedChildCount = 0;
     for (const auto &child : virtualNode.children) {
+      const auto &childNode = virtualTree->getNode(child.id);
+      if (!childNode.children.empty() ||
+          linkedMetrics.find(child.id) != linkedMetrics.end()) {
+        ++linkedChildCount;
+      }
+    }
+    writer.packFixStrLiteral("children");
+    writer.packArray(linkedChildCount);
+    for (const auto &child : virtualNode.children) {
+      const auto &childNode = virtualTree->getNode(child.id);
+      if (childNode.children.empty() &&
+          linkedMetrics.find(child.id) == linkedMetrics.end()) {
+        continue;
+      }
       packLinkedVirtualNode(packLinkedVirtualNode, treeNode, child.id);
     }
   };
@@ -733,18 +749,47 @@ TreeData::buildHatchetMsgPack(TreeData::Tree *tree,
     const bool hasLinkedTargets =
         !treeNode.metricSet.linkedMetrics.empty() ||
         !treeNode.metricSet.linkedFlexibleMetrics.empty();
-    uint32_t linkedChildCount =
-        hasLinkedTargets
-            ? static_cast<uint32_t>(virtualRootNode.children.size())
-            : 0;
-    writer.packFixStrLiteral("children");
-    writer.packArray(static_cast<uint32_t>(treeNode.children.size()) +
-                     linkedChildCount);
+    uint32_t linkedChildCount = 0;
+    if (hasLinkedTargets) {
+      for (const auto &child : virtualRootNode.children) {
+        const auto &childNode = virtualTree->getNode(child.id);
+        if (!childNode.children.empty() ||
+            treeNode.metricSet.linkedMetrics.find(child.id) !=
+                treeNode.metricSet.linkedMetrics.end()) {
+          ++linkedChildCount;
+        }
+      }
+    }
+    uint32_t concreteChildCount = 0;
     for (const auto &child : treeNode.children) {
-      packNode(packNode, tree->getNode(child.id));
+      const auto &childNode = tree->getNode(child.id);
+      if (!childNode.children.empty() || !childNode.metricSet.metrics.empty() ||
+          !childNode.metricSet.flexibleMetrics.empty() ||
+          !childNode.metricSet.linkedMetrics.empty() ||
+          !childNode.metricSet.linkedFlexibleMetrics.empty()) {
+        ++concreteChildCount;
+      }
+    }
+    writer.packFixStrLiteral("children");
+    writer.packArray(concreteChildCount + linkedChildCount);
+    for (const auto &child : treeNode.children) {
+      auto &childNode = tree->getNode(child.id);
+      if (childNode.children.empty() && childNode.metricSet.metrics.empty() &&
+          childNode.metricSet.flexibleMetrics.empty() &&
+          childNode.metricSet.linkedMetrics.empty() &&
+          childNode.metricSet.linkedFlexibleMetrics.empty()) {
+        continue;
+      }
+      packNode(packNode, childNode);
     }
     if (hasLinkedTargets) {
       for (const auto &virtualChild : virtualRootNode.children) {
+        const auto &childNode = virtualTree->getNode(virtualChild.id);
+        if (childNode.children.empty() &&
+            treeNode.metricSet.linkedMetrics.find(virtualChild.id) ==
+                treeNode.metricSet.linkedMetrics.end()) {
+          continue;
+        }
         packLinkedVirtualNode(packLinkedVirtualNode, treeNode, virtualChild.id);
       }
     }

--- a/third_party/proton/csrc/lib/Data/TreeData.cpp
+++ b/third_party/proton/csrc/lib/Data/TreeData.cpp
@@ -715,23 +715,19 @@ TreeData::buildHatchetMsgPack(TreeData::Tree *tree,
     // Linked flexible metrics attached to generated helper leaves are promoted
     // into the parent metrics map above. Once promoted, a helper leaf with no
     // linked fixed metrics and no children carries no information in Hatchet.
-    uint32_t linkedChildCount = 0;
+    std::vector<size_t> linkedChildren;
+    linkedChildren.reserve(virtualNode.children.size());
     for (const auto &child : virtualNode.children) {
       const auto &childNode = virtualTree->getNode(child.id);
       if (!childNode.children.empty() ||
           linkedMetrics.find(child.id) != linkedMetrics.end()) {
-        ++linkedChildCount;
+        linkedChildren.push_back(child.id);
       }
     }
     writer.packFixStrLiteral("children");
-    writer.packArray(linkedChildCount);
-    for (const auto &child : virtualNode.children) {
-      const auto &childNode = virtualTree->getNode(child.id);
-      if (childNode.children.empty() &&
-          linkedMetrics.find(child.id) == linkedMetrics.end()) {
-        continue;
-      }
-      packLinkedVirtualNode(packLinkedVirtualNode, treeNode, child.id);
+    writer.packArray(static_cast<uint32_t>(linkedChildren.size()));
+    for (auto childId : linkedChildren) {
+      packLinkedVirtualNode(packLinkedVirtualNode, treeNode, childId);
     }
   };
   auto packNode = [&](auto &&packNode,
@@ -758,36 +754,21 @@ TreeData::buildHatchetMsgPack(TreeData::Tree *tree,
     // metrics are attached through linked virtual nodes instead, so a concrete
     // leaf with no metrics, linked metrics, flexible metrics, or children adds
     // no Hatchet information.
-    // Most captured launch scopes have only a few concrete children. Keep that
-    // common case allocation-free while still collecting children once so the
-    // MsgPack array header has an exact count.
-    constexpr size_t kInlineConcreteChildCount = 8;
-    std::array<TreeData::Tree::TreeNode *, kInlineConcreteChildCount>
-        inlineConcreteChildren;
-    std::vector<TreeData::Tree::TreeNode *> overflowConcreteChildren;
-    uint32_t concreteChildCount = 0;
+    std::vector<TreeData::Tree::TreeNode *> concreteChildren;
+    concreteChildren.reserve(treeNode.children.size());
     for (const auto &child : treeNode.children) {
       auto &childNode = tree->getNode(child.id);
       if (!childNode.children.empty() || !childNode.metricSet.metrics.empty() ||
           !childNode.metricSet.flexibleMetrics.empty() ||
           !childNode.metricSet.linkedMetrics.empty() ||
           !childNode.metricSet.linkedFlexibleMetrics.empty()) {
-        if (concreteChildCount < inlineConcreteChildren.size()) {
-          inlineConcreteChildren[concreteChildCount] = &childNode;
-        } else {
-          overflowConcreteChildren.push_back(&childNode);
-        }
-        ++concreteChildCount;
+        concreteChildren.push_back(&childNode);
       }
     }
     writer.packFixStrLiteral("children");
-    writer.packArray(concreteChildCount + linkedChildCount);
-    const auto inlineConcreteCount =
-        std::min<size_t>(concreteChildCount, inlineConcreteChildren.size());
-    for (size_t i = 0; i < inlineConcreteCount; ++i) {
-      packNode(packNode, *inlineConcreteChildren[i]);
-    }
-    for (auto *childNode : overflowConcreteChildren) {
+    writer.packArray(static_cast<uint32_t>(concreteChildren.size()) +
+                     linkedChildCount);
+    for (auto *childNode : concreteChildren) {
       packNode(packNode, *childNode);
     }
     if (hasLinkedTargets) {


### PR DESCRIPTION
Skip empty leaf nodes. We don't skip empty internal nodes to make the code simpler and more efficient. In fact, most empty nodes are leaves (kernels)