### PR TITLE
[AMD] Disable true16 on gfx11 for fp8/fp4 kernels to avoid compile-time reg…

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -331,6 +331,11 @@ class HIPBackend(BaseBackend):
     @staticmethod
     def make_llir(src, metadata, options):
         mod = src
+        if "gfx11" in options.arch:
+            ttgir_str = str(mod)
+            if ("f8E" in ttgir_str or "fp4_to_fp" in ttgir_str or "lhs = e2m1" in ttgir_str
+                    or "rhs = e2m1" in ttgir_str):
+                metadata["disable_true16"] = True
         # TritonGPU -> LLVM-IR (MLIR)
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
@@ -517,7 +522,7 @@ class HIPBackend(BaseBackend):
         metadata["name"] = names[0]
         # llvm -> hsaco
         flags = []
-        features = ''
+        features = '-real-true16' if metadata.get("disable_true16") else ''
         ir_hash = hashlib.sha256(src.encode("utf-8")).hexdigest()
         dump_file_id = names[0] + '_' + ir_hash
         _ = llvm.translate_to_mir(src, amd.TARGET_TRIPLE, options.arch, features, flags, options.enable_fp_fusion,
@@ -543,6 +548,8 @@ class HIPBackend(BaseBackend):
         target_features = ''
         if knobs.compilation.enable_asan:
             target_features = '+xnack'
+        if metadata.get("disable_true16"):
+            target_features = (target_features + ',-real-true16').lstrip(',')
         hsaco = amd.assemble_amdgcn(src, options.arch, target_features)
         with tempfile.NamedTemporaryFile() as tmp_out:
             with tempfile.NamedTemporaryFile() as tmp_in:


### PR DESCRIPTION
 Conditionally disable the AMDGPU -real-true16 target feature on gfx11 for kernels containing fp8/fp4 types, to avoid a large LLVM compile-time regression introduced by #10301. Pure fp16 /
 bf16 / fp32 kernels are unaffected and continue to benefit from PR #10301's runtime wins.

  #10301 removed Triton's -real-true16 override on gfx11 so LLVM could emit native 16-bit ops. That PR benchmarked GEMM / FlashAttention runtime; compile time wasn't measured. Compile time for fp8/fp4 kernels regressed badly:

  | kernel | true16 ON | true16 OFF |
  |---|---|---|
  | pure fp16 GEMM (LLVM → asm) | 0.140 s | 0.133 s |
  | pure bf16 GEMM (LLVM → asm) | 0.133 s | 0.131 s |
  | fp8 `dot_scale_kernel` (LLVM → asm) | **92.46 s** | **1.18 s** |

Triton unit suite end-to-end:

  |  | wall |
  |---|---|
  | pre-#10301 baseline | ~45 min |
  | post-#10301 (current main) | ~1h 47 min |
  | **this PR** | ~47 min |


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it reduces the total time of unit tests on gfx11`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
