### PR TITLE
[AMD] Revert "[AMD] Disable LLVM vector combine pass (#9260)"

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -654,7 +654,7 @@ void init_triton_llvm(py::module &&m) {
       "optimize_module",
       [](llvm::Module *mod, const llvm::OptimizationLevel &opt,
          std::string arch, std::string features, std::vector<std::string> flags,
-         bool enable_fp_fusion, bool disable_vector_combine) {
+         bool enable_fp_fusion) {
         if (mlir::triton::tools::getBoolEnv("DISABLE_LLVM_OPT"))
           return;
         // Check to see if we are passing a list of flags to disable
@@ -685,24 +685,11 @@ void init_triton_llvm(py::module &&m) {
         PassInstrumentationCallbacks passInstrCb;
         StandardInstrumentations standardInstr(mod->getContext(),
                                                /*DebugLogging*/ true);
-        bool enablePassInstrumentation = false;
-        if (disable_vector_combine) {
-          // VectorCombinePass::name() returns the C++ class name, not the
-          // registry name "vector-combine".
-          const StringRef kVectorCombinePassName = "VectorCombinePass";
-          passInstrCb.registerShouldRunOptionalPassCallback(
-              [kVectorCombinePassName](StringRef passName, Any) {
-                return passName != kVectorCombinePassName;
-              });
-          enablePassInstrumentation = true;
-        }
         if (mlir::triton::tools::getBoolEnv("LLVM_IR_ENABLE_DUMP")) {
           setLLVMOption<bool>("print-after-all", true);
           standardInstr.registerCallbacks(passInstrCb, &mam);
-          enablePassInstrumentation = true;
-        }
-        if (enablePassInstrumentation)
           instrCbPtr = &passInstrCb;
+        }
 
         PipelineTuningOptions tuningOptions;
         tuningOptions.LoopUnrolling = true;
@@ -780,7 +767,6 @@ void init_triton_llvm(py::module &&m) {
       py::arg("arch") = "", py::arg("features") = "",
       py::arg("flags") = std::vector<std::string>{},
       py::arg("enable_fp_fusion") = false,
-      py::arg("disable_vector_combine") = false,
       py::call_guard<py::gil_scoped_release>());
 
   m.def(

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -501,7 +501,7 @@ class HIPBackend(BaseBackend):
             if len(paths) > 0:
                 llvm.link_extern_libs(llvm_mod, paths)
 
-        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, options.arch, '', [], options.enable_fp_fusion, True)
+        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, options.arch, '', [], options.enable_fp_fusion)
 
         # Architectures with architected SGPRs store the workgroup id in ttmp9 (X) and ttmp7 (Y[15:0], Z[31:16]).
         # These attributes are used to determine if Z should be masked out when loading Y. They are inferred during


### PR DESCRIPTION
This reverts commit 36394d4c65a44eec9371012e2d3133107971eae3. We saw some compile failure cases with disabled vector combine. But should be resolved and should re-land this commit once with https://github.com/llvm/llvm-project/pull/193499 or commit `81d618b6bc1e71cda79fe7bf9cbab63933dd5975` gets picked up in the next LLVM bump.
