### PR TITLE
[AMD] Enable buffer atomics on older supported archs

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.h
+++ b/include/triton/Tools/Sys/GetEnv.h
@@ -14,6 +14,7 @@ namespace mlir::triton {
 
 inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
     // clang-format off
+    "AMDGCN_ASSUME_NO_FINE_GRAINED_MEMORY",
     "AMDGCN_ENABLE_DUMP",
     "AMDGCN_USE_BUFFER_ATOMICS",
     "AMDGCN_USE_BUFFER_OPS",

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1457,6 +1457,40 @@ def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
     assert f"atom.global.gpu.{sem_str}" in h.asm["ptx"]
 
 
+@pytest.mark.skipif(not is_hip(), reason="Fine-grained (pinned) host memory atomics are an AMD-specific concern")
+@pytest.mark.parametrize("op", ['add', 'max', 'min'])
+def test_atomic_rmw_fine_grained_memory(op, device):
+    # Regression test for the silent buffer-atomic drop on fine-grained (pinned)
+    # host memory. On the unsafe-lineage AMD ISAs (e.g. RDNA3/gfx11, CDNA2) the
+    # FP BUFFER_ATOMIC_* instructions are NOP'd by the hardware when they target
+    # fine-grained allocations: the accumulation disappears with no fault, stall,
+    # or diagnostic (see the AMD GPU atomics documentation).
+    n_programs = 5
+
+    @triton.jit
+    def kernel(X, Z):
+        pid = tl.program_id(0)
+        x = tl.load(X + pid)
+        GENERATE_TEST_HERE
+
+    kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'tl.atomic_{op}(Z, x)'})
+
+    numpy_op = {'add': np.sum, 'max': np.max, 'min': np.min}[op]
+    neutral = {'add': 0.0, 'max': float('-inf'), 'min': float('inf')}[op]
+
+    x = np.array([2**i for i in range(n_programs)], dtype=np.float32)
+    x_tri = to_triton(x, device=device)
+
+    # Allocate the atomic destination in pinned (fine-grained) host memory.
+    z_tri = torch.tensor([neutral], dtype=torch.float32).pin_memory()
+    assert z_tri.is_pinned()
+
+    kernel[(n_programs, )](x_tri, z_tri)
+
+    z_ref = torch.tensor([numpy_op(x)], dtype=torch.float32)
+    torch.testing.assert_close(z_tri.cpu(), z_ref, rtol=0, atol=0)
+
+
 @pytest.mark.interpreter
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_atomic_rmw_predicate(num_ctas, device):

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -519,6 +519,7 @@ class amd_knobs(base_knobs):
     use_buffer_atomics: env_bool = env_bool("AMDGCN_USE_BUFFER_ATOMICS", True)
     # Note: This requires use_buffer_ops be true to have any effect
     buffer_ops_analyze_small_tensor_range: env_bool = env_bool("AMDGCN_ANALYZE_SMALL_TENSOR_RANGE", False)
+    assume_no_fine_grained_memory: env_bool = env_bool("AMDGCN_ASSUME_NO_FINE_GRAINED_MEMORY", False)
     dump_amdgcn: env_bool = env_bool("AMDGCN_ENABLE_DUMP")
     libhip_path: env_opt_str = env_opt_str("TRITON_LIBHIP_PATH")
 

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -2,6 +2,7 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 | FileCheck %s --check-prefixes=GFX950,COMMON
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 | FileCheck %s --check-prefixes=GFX1250,COMMON
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx906 | FileCheck %s --check-prefixes=GFX906,COMMON
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm="gfx-arch=gfx1100 assume-no-fine-grained-memory=true" | FileCheck %s --check-prefixes=NOFINE
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: atomic_add_f32_scalar
@@ -840,6 +841,27 @@ module attributes {"ttg.target" = "hip:gfx906", "ttg.num-ctas" = 1 : i32, "ttg.n
   tt.func @v_dot_i8_gfx906(%arg0: tensor<16x16xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<16x16xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<16x16xi32, #blocked>) {
     // GFX906-COUNT-4: llvm.call_intrinsic "llvm.amdgcn.sdot4"
     %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x16xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<16x16xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: atomic_no_fine_grained_memory
+  // NOFINE-LABEL: atomic_no_fine_grained_memory
+  tt.func @atomic_no_fine_grained_memory(%arg0 : !tt.ptr<f32>, %arg1 : i1, %arg2 : f32, %arg3 : !tt.ptr<i32>) {
+    %c32 = arith.constant 32 : i32
+    %c64 = arith.constant 64 : i32
+    // CHECK: llvm.atomicrmw fadd
+    // CHECK-NOT: rocdl.no_fine_grained_memory
+    // NOFINE: llvm.atomicrmw fadd
+    // NOFINE-SAME: {rocdl.no_fine_grained_memory}
+    %0 = tt.atomic_rmw fadd, relaxed, gpu, %arg0, %arg2, %arg1 : (!tt.ptr<f32>, f32, i1) -> f32
+    tt.store %arg0, %0 : !tt.ptr<f32>
+    // NOFINE: llvm.cmpxchg
+    // NOFINE-NOT: rocdl.no_fine_grained_memory
+    %1 = tt.atomic_cas relaxed, gpu, %arg3, %c32, %c64 : (!tt.ptr<i32>, i32, i32) -> i32
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops.mlir
@@ -1,6 +1,18 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx942 analyze-small-tensor-ofst=true"| FileCheck %s --check-prefixes=COMMON,GFX942-ONLY,CDNA
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx950 analyze-small-tensor-ofst=true"| FileCheck %s --check-prefixes=COMMON,GFX950-PLUS,CDNA
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx1250 analyze-small-tensor-ofst=true"| FileCheck %s --check-prefixes=COMMON,GFX950-PLUS
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx906  analyze-small-tensor-ofst=true assume-no-fine-grained-memory=false" | FileCheck %s --check-prefixes=RMW-INT-AS-GENERIC,RMW-FADD-AS-GENERIC
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx908  analyze-small-tensor-ofst=true assume-no-fine-grained-memory=false" | FileCheck %s --check-prefixes=RMW-INT-AS-GENERIC,RMW-FADD-AS-GENERIC
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx90a  analyze-small-tensor-ofst=true assume-no-fine-grained-memory=false" | FileCheck %s --check-prefixes=RMW-INT-AS-GENERIC,RMW-FADD-AS-GENERIC
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx1010 analyze-small-tensor-ofst=true assume-no-fine-grained-memory=false" | FileCheck %s --check-prefixes=RMW-INT-AS-GENERIC,RMW-FADD-AS-GENERIC
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx1030 analyze-small-tensor-ofst=true assume-no-fine-grained-memory=false" | FileCheck %s --check-prefixes=RMW-INT-AS-GENERIC,RMW-FADD-AS-GENERIC
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx1100 analyze-small-tensor-ofst=true assume-no-fine-grained-memory=false" | FileCheck %s --check-prefixes=RMW-INT-AS-GENERIC,RMW-FADD-AS-GENERIC
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx906  analyze-small-tensor-ofst=true assume-no-fine-grained-memory=true"  | FileCheck %s --check-prefixes=RMW-INT-AS-BUFFER,RMW-FADD-AS-GENERIC
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx908  analyze-small-tensor-ofst=true assume-no-fine-grained-memory=true"  | FileCheck %s --check-prefixes=RMW-INT-AS-BUFFER,RMW-FADD-AS-BUFFER
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx90a  analyze-small-tensor-ofst=true assume-no-fine-grained-memory=true"  | FileCheck %s --check-prefixes=RMW-INT-AS-BUFFER,RMW-FADD-AS-BUFFER
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx1010 analyze-small-tensor-ofst=true assume-no-fine-grained-memory=true"  | FileCheck %s --check-prefixes=RMW-INT-AS-BUFFER,RMW-FADD-AS-GENERIC
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx1030 analyze-small-tensor-ofst=true assume-no-fine-grained-memory=true"  | FileCheck %s --check-prefixes=RMW-INT-AS-BUFFER,RMW-FADD-AS-GENERIC
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx1100 analyze-small-tensor-ofst=true assume-no-fine-grained-memory=true"  | FileCheck %s --check-prefixes=RMW-INT-AS-BUFFER,RMW-FADD-AS-BUFFER
 
 #blocked0 = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
@@ -944,5 +956,58 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %20 = tt.addptr %19, %18 : tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xi32, #blocked>
     %21 = tt.atomic_rmw fadd, relaxed, gpu, %20, %15, %cst : (tensor<64x!tt.ptr<f32>, #blocked>, tensor<64xf32, #blocked>, tensor<64xi1, #blocked>) -> tensor<64xf32, #blocked>
     tt.return
+  }
+}
+
+// -----
+
+// Integer atomic_rmw is supported by BUFFER_ATOMIC_* on every gfx9+ family.
+// The assume-no-fine-grained-memory knob gates the rewrite on the unsafe-lineage
+// families (GCN5_1, CDNA1, CDNA2, RDNA1, RDNA2, RDNA3).
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // RMW-INT-AS-GENERIC-LABEL: assume_no_fine_grained_int
+  // RMW-INT-AS-BUFFER-LABEL:  assume_no_fine_grained_int
+  tt.func @assume_no_fine_grained_int(
+      %arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+      %arg1: tensor<512xi32, #blocked>) -> tensor<512xi32, #blocked> {
+    %c512_i32 = arith.constant 512 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c512_i32 : i32
+    %2 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32, #blocked>
+    %3 = tt.addptr %arg0, %1 : !tt.ptr<i32>, i32
+    %4 = tt.splat %3 : !tt.ptr<i32> -> tensor<512x!tt.ptr<i32>, #blocked>
+    %5 = tt.addptr %4, %2 : tensor<512x!tt.ptr<i32>, #blocked>, tensor<512xi32, #blocked>
+    // RMW-INT-AS-GENERIC-NOT: amdg.buffer_atomic_rmw
+    // RMW-INT-AS-BUFFER:      amdg.buffer_atomic_rmw
+    %6 = tt.atomic_rmw add, acq_rel, gpu, %5, %arg1 : (tensor<512x!tt.ptr<i32>, #blocked>, tensor<512xi32, #blocked>) -> tensor<512xi32, #blocked>
+    tt.return %6 : tensor<512xi32, #blocked>
+  }
+}
+
+// -----
+
+// FP atomic_rmw fadd f32 under the knob is further gated by the per-arch FP
+// truth table from supportsBufferAtomicFadd(): allowed on CDNA1 / CDNA2 / RDNA3
+// (RMW-FADD-AS-BUFFER) and disallowed on GCN5_1 / RDNA1 / RDNA2 (no hardware
+// BUFFER_ATOMIC_ADD_F32, so the op stays generic = RMW-FADD-AS-GENERIC).
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // RMW-FADD-AS-GENERIC-LABEL: assume_no_fine_grained_fadd_f32
+  // RMW-FADD-AS-BUFFER-LABEL:  assume_no_fine_grained_fadd_f32
+  tt.func @assume_no_fine_grained_fadd_f32(
+      %arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+      %arg1: tensor<512xf32, #blocked>) -> tensor<512xf32, #blocked> {
+    %c512_i32 = arith.constant 512 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c512_i32 : i32
+    %2 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32, #blocked>
+    %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
+    %4 = tt.splat %3 : !tt.ptr<f32> -> tensor<512x!tt.ptr<f32>, #blocked>
+    %5 = tt.addptr %4, %2 : tensor<512x!tt.ptr<f32>, #blocked>, tensor<512xi32, #blocked>
+    // RMW-FADD-AS-GENERIC-NOT: amdg.buffer_atomic_rmw
+    // RMW-FADD-AS-BUFFER:      amdg.buffer_atomic_rmw
+    %6 = tt.atomic_rmw fadd, acq_rel, gpu, %5, %arg1 : (tensor<512x!tt.ptr<f32>, #blocked>, tensor<512xf32, #blocked>) -> tensor<512xf32, #blocked>
+    tt.return %6 : tensor<512xf32, #blocked>
   }
 }

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -382,7 +382,7 @@ class HIPBackend(BaseBackend):
         ## 3. __HIP_FTZ is default to 1 and not exposed as a kernel argument.
         ##    For now it is used as a controller for developers only.
         __HIP_FTZ = True
-        amd.passes.ttgpuir.add_to_llvmir(pm, options.arch, __HIP_FTZ)
+        amd.passes.ttgpuir.add_to_llvmir(pm, options.arch, __HIP_FTZ, knobs.amd.assume_no_fine_grained_memory)
         amd.passes.ttgpuir.add_warp_specialize_to_llvm(pm, options.arch)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -308,6 +308,7 @@ class HIPBackend(BaseBackend):
                 options.arch,
                 knobs.amd.use_buffer_atomics,
                 knobs.amd.buffer_ops_analyze_small_tensor_range,
+                knobs.amd.assume_no_fine_grained_memory,
             )
             amd.passes.ttgpuir.add_optimize_buffer_op_ptr(pm)
 

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TargetFeatures.h
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TargetFeatures.h
@@ -75,7 +75,7 @@ public:
   bool supportsMultiCTALaunch() const;
   bool supportsClusterLoadBitWidth(int bitWidth) const;
 
-  bool supportsBufferAtomicRMW() const;
+  bool supportsBufferAtomicRMW(bool assumeNoFineGrainedMemory = false) const;
   bool supportsBufferAtomicFadd(Type elementType) const;
   int32_t getBufferAtomicCachePolicy(bool hasUsers) const;
 

--- a/third_party/amd/include/TritonAMDGPUToLLVM/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/Passes.h
@@ -36,7 +36,8 @@ void runScalarizePackedFOpsPass(llvm::Function &F);
 namespace mlir::triton {
 
 std::unique_ptr<OperationPass<ModuleOp>>
-createConvertTritonAMDGPUToLLVMPass(StringRef gfxArch, bool ftz);
+createConvertTritonAMDGPUToLLVMPass(StringRef gfxArch, bool ftz,
+                                    bool assumeNoFineGrainedMemory);
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertBuiltinFuncToLLVMPass(StringRef gfxArch, bool ftz);
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
@@ -22,7 +22,7 @@ def AllocateAMDGPUSharedMemory : Pass<"allocate-amdgpu-shared-memory", "mlir::Mo
 
 def ConvertTritonAMDGPUToLLVM : Pass<"convert-triton-amdgpu-to-llvm", "mlir::ModuleOp"> {
     let summary = "Convert TritonGPU to LLVM";
-    let constructor = "mlir::triton::createConvertTritonAMDGPUToLLVMPass(\"\", /*ftz=*/true)";
+    let constructor = "mlir::triton::createConvertTritonAMDGPUToLLVMPass(\"\", /*ftz=*/true, /*assumeNoFineGrainedMemory=*/false)";
 
     let dependentDialects = ["mlir::arith::ArithDialect",
                              "mlir::math::MathDialect",
@@ -38,6 +38,9 @@ def ConvertTritonAMDGPUToLLVM : Pass<"convert-triton-amdgpu-to-llvm", "mlir::Mod
                "Specify the GFX architecture name, e.g., gfx942, gfx950, etc.">,
         Option<"ftz", "ftz", "bool", /*default*/"true",
                "flush denorms for math functions">,
+        Option<"assumeNoFineGrainedMemory", "assume-no-fine-grained-memory",
+               "bool", /*default*/"false",
+               "Assume kernel atomic destinations are not fine-grained pinned host memory, and tag llvm.atomicrmw with the corresponding AMDGPU metadata.">,
     ];
 }
 

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -182,7 +182,10 @@ def TritonAMDGPUConvertToBufferOps : Pass<"tritonamdgpu-convert-buffer-ops", "ml
            "Allow buffer atomic operations when the hardware supports it.">,
     Option<"analyzeSmallTensorOfst", "analyze-small-tensor-ofst",
           "bool", /*default=*/"false",
-           "Whether to still analyze index range for tensors whose base has tt.pointer_range = 32 specialization. If false load/store from such tensors will go down buffer ops without analzying index range.">
+           "Whether to still analyze index range for tensors whose base has tt.pointer_range = 32 specialization. If false load/store from such tensors will go down buffer ops without analzying index range.">,
+    Option<"assumeNoFineGrainedMemory", "assume-no-fine-grained-memory",
+           "bool", /*default=*/"false",
+           "Assume kernel atomic destinations are not fine-grained pinned host memory.">
   ];
 }
 

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -182,7 +182,7 @@ def TritonAMDGPUConvertToBufferOps : Pass<"tritonamdgpu-convert-buffer-ops", "ml
            "Allow buffer atomic operations when the hardware supports it.">,
     Option<"analyzeSmallTensorOfst", "analyze-small-tensor-ofst",
           "bool", /*default=*/"false",
-           "Whether to still analyze index range for tensors whose base has tt.pointer_range = 32 specialization. If false load/store from such tensors will go down buffer ops without analzying index range.">,
+           "Whether to still analyze index range for tensors whose base has tt.pointer_range = 32 specialization. If false load/store from such tensors will go down buffer ops without analyzing index range.">,
     Option<"assumeNoFineGrainedMemory", "assume-no-fine-grained-memory",
            "bool", /*default=*/"false",
            "Assume kernel atomic destinations are not fine-grained pinned host memory.">

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
@@ -261,9 +261,8 @@ bool TargetFeatures::supportsBufferAtomicRMW(
   // enable when the user explicitly promises no such allocations reach the
   // kernel.
   if (assumeNoFineGrainedMemory &&
-      llvm::is_contained({ISAFamily::GCN5_1, ISAFamily::CDNA1,
-                          ISAFamily::CDNA2, ISAFamily::RDNA1, ISAFamily::RDNA2,
-                          ISAFamily::RDNA3},
+      llvm::is_contained({ISAFamily::GCN5_1, ISAFamily::CDNA1, ISAFamily::CDNA2,
+                          ISAFamily::RDNA1, ISAFamily::RDNA2, ISAFamily::RDNA3},
                          f))
     return true;
   return false;

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
@@ -246,19 +246,53 @@ bool TargetFeatures::supportsClusterLoadBitWidth(int bitWidth) const {
   return false;
 }
 
-bool TargetFeatures::supportsBufferAtomicRMW() const {
-  return llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4,
-                             ISAFamily::RDNA4, ISAFamily::GFX1250},
-                            getISAFamily());
+bool TargetFeatures::supportsBufferAtomicRMW(
+    bool assumeNoFineGrainedMemory) const {
+  ISAFamily f = getISAFamily();
+  // Inherently safe: these families expose LLVM's
+  // FeatureAgentScopeFineGrainedRemoteMemoryAtomics and their BUFFER_ATOMIC_*
+  // instructions handle fine-grained memory semantics correctly.
+  if (llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4, ISAFamily::RDNA4,
+                          ISAFamily::GFX1250},
+                         f))
+    return true;
+  // On these older families BUFFER_ATOMIC_* silently drops writes against
+  // fine-grained pinned host memory (per AMD GPU atomics documentation). Only
+  // enable when the user explicitly promises no such allocations reach the
+  // kernel.
+  if (assumeNoFineGrainedMemory &&
+      llvm::is_contained({ISAFamily::GCN5_1, ISAFamily::CDNA1,
+                          ISAFamily::CDNA2, ISAFamily::RDNA1, ISAFamily::RDNA2,
+                          ISAFamily::RDNA3},
+                         f))
+    return true;
+  return false;
 }
 
 bool TargetFeatures::supportsBufferAtomicFadd(Type elementType) const {
-  auto isaFamily = getISAFamily();
-  if (isaFamily == ISAFamily::CDNA3 && elementType.isBF16())
+  // The convert-to-buffer-ops pattern only invokes us with f16, bf16, f32, or
+  // f64 element types.
+  switch (getISAFamily()) {
+  case ISAFamily::CDNA3:
+    return !elementType.isBF16();
+  case ISAFamily::CDNA4:
+  case ISAFamily::GFX1250:
+    return true;
+  case ISAFamily::RDNA4:
+    return !elementType.isF64();
+  case ISAFamily::CDNA2:
+    return elementType.isF32() || elementType.isF16() || elementType.isF64();
+  case ISAFamily::CDNA1:
+    return elementType.isF32() || elementType.isF16();
+  case ISAFamily::RDNA3:
+    return elementType.isF32();
+  // gfx906 / gfx1010 / gfx1030 have no FP buffer-atomic-add at all.
+  case ISAFamily::GCN5_1:
+  case ISAFamily::RDNA1:
+  case ISAFamily::RDNA2:
+  default:
     return false;
-  if (isaFamily == ISAFamily::RDNA4 && elementType.isF64())
-    return false;
-  return true;
+  }
 }
 
 int32_t TargetFeatures::getBufferAtomicCachePolicy(bool hasUsers) const {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -2566,6 +2566,20 @@ void adjustModeRegister(ModuleOp mod, const TargetInfo &targetInfo) {
   });
 }
 
+void annotateAtomicNoFineGrainedMemory(ModuleOp mod) {
+  MLIRContext *ctx = mod->getContext();
+  auto *rocdlDialect = ctx->getLoadedDialect<ROCDL::ROCDLDialect>();
+  auto noFineMemHelper = rocdlDialect->getNoFineGrainedMemoryAttrHelper();
+
+  // Only `amdgpu.no.fine.grained.memory` is set, because that is exactly what
+  // the AMDGCN_ASSUME_NO_FINE_GRAINED_MEMORY knob promises (no pinned/
+  // fine-grained allocations), and it is what gates the native atomic on the
+  // older archs that lack AgentScopeFineGrainedRemoteMemoryAtomics.
+  mod->walk([&](LLVM::AtomicRMWOp rmw) {
+    noFineMemHelper.setAttr(rmw, UnitAttr::get(ctx));
+  });
+}
+
 void populateElementwiseOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns, bool ftz,
     ModuleAxisInfoAnalysis &axisInfoAnalysis, ModuleAllocation &allocation,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -31,6 +31,10 @@ void populateElementwiseOpToLLVMPatterns(
 // exception handling, etc.
 void adjustModeRegister(ModuleOp mod, const TargetInfo &targetInfo);
 
+// Tags every `llvm.atomicrmw` with the `amdgpu.no.fine.grained.memory`
+// metadata.
+void annotateAtomicNoFineGrainedMemory(ModuleOp mod);
+
 void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                        const TargetInfo &targetInfo,
                                        RewritePatternSet &patterns,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -755,8 +755,8 @@ bool TargetInfo::useAsyncMarks() const {
   return targetFeatures.useAsyncMarks();
 }
 
-bool TargetInfo::supportsBufferAtomicRMW() const {
-  return targetFeatures.supportsBufferAtomicRMW();
+bool TargetInfo::supportsBufferAtomicRMW(bool assumeNoFineGrainedMemory) const {
+  return targetFeatures.supportsBufferAtomicRMW(assumeNoFineGrainedMemory);
 }
 
 bool TargetInfo::supportsBufferAtomicFadd(mlir::Type elementType) const {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -127,7 +127,11 @@ public:
   // operations. This gates all buffer RMW conversions (BUFFER_ATOMIC_ADD,
   // _AND, _OR, _XOR, _UMIN, _UMAX, _SWAP, _ADD_F32, _PK_ADD_F16, etc.).
   // CAS (BUFFER_ATOMIC_CMPSWAP) is handled separately.
-  bool supportsBufferAtomicRMW() const;
+  // When `assumeNoFineGrainedMemory` is true, the caller asserts that no
+  // atomic destination resides in fine-grained pinned host memory; under that
+  // assumption the unsafe-lineage families (GCN5_1, CDNA1, CDNA2, RDNA1,
+  // RDNA2, RDNA3) are also considered safe.
+  bool supportsBufferAtomicRMW(bool assumeNoFineGrainedMemory = false) const;
   // Additional per-type gate for buffer atomic FADD. Integer RMW ops (ADD,
   // AND, etc.) work on i32/i64 universally, but float FADD has ISA-specific
   // type restrictions for BUFFER_ATOMIC_ADD_{F32,F64} and

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -75,9 +75,11 @@ public:
 struct ConvertTritonAMDGPUToLLVM
     : public triton::impl::ConvertTritonAMDGPUToLLVMBase<
           ConvertTritonAMDGPUToLLVM> {
-  explicit ConvertTritonAMDGPUToLLVM(StringRef gfxArch, bool ftz) {
+  explicit ConvertTritonAMDGPUToLLVM(StringRef gfxArch, bool ftz,
+                                     bool assumeNoFineGrainedMemory) {
     this->gfxArch = gfxArch.str();
     this->ftz = ftz;
+    this->assumeNoFineGrainedMemory = assumeNoFineGrainedMemory;
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -248,6 +250,12 @@ struct ConvertTritonAMDGPUToLLVM
     AMD::adjustModeRegister(mod, targetInfo);
     fixUpLoopAnnotation(mod);
 
+    // When the user promises no fine-grained pinned host memory is used as an
+    // atomic destination, tag atomicrmw ops with the corresponding
+    // AMDGPU metadata.
+    if (this->assumeNoFineGrainedMemory)
+      AMD::annotateAtomicNoFineGrainedMemory(mod);
+
     // Ensure warp group code is isolated from above.
     makeAllWarpGroupsIsolatedFromAbove(mod);
   }
@@ -278,8 +286,10 @@ private:
 namespace mlir::triton {
 
 std::unique_ptr<OperationPass<ModuleOp>>
-createConvertTritonAMDGPUToLLVMPass(StringRef gfxArch, bool ftz) {
-  return std::make_unique<ConvertTritonAMDGPUToLLVM>(gfxArch, ftz);
+createConvertTritonAMDGPUToLLVMPass(StringRef gfxArch, bool ftz,
+                                    bool assumeNoFineGrainedMemory) {
+  return std::make_unique<ConvertTritonAMDGPUToLLVM>(gfxArch, ftz,
+                                                     assumeNoFineGrainedMemory);
 }
 
 } // namespace mlir::triton

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -664,7 +664,8 @@ struct TritonAMDGPUConvertToBufferOpsPass
               this->analyzeSmallTensorOfst);
     }
 
-    if (this->allowBufferAtomics && targetFeatures.supportsBufferAtomicRMW())
+    if (this->allowBufferAtomics &&
+        targetFeatures.supportsBufferAtomicRMW(this->assumeNoFineGrainedMemory))
       patterns.add<ConvertTritonAtomicRMWOpToBufferAtomicRMW>(
           context, assumptions, axisInfoAnalysis, solver, targetFeatures,
           this->analyzeSmallTensorOfst);

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -107,9 +107,9 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
     pm.addNestedPass<mlir::triton::FuncOp>(
         mlir::createTritonAMDGPUMoveUpPrologueLoads());
   });
-  ADD_PASS_OPTION_WRAPPER_3("add_convert_to_buffer_ops",
+  ADD_PASS_OPTION_WRAPPER_4("add_convert_to_buffer_ops",
                             mlir::createTritonAMDGPUConvertToBufferOps,
-                            const std::string &, bool, bool);
+                            const std::string &, bool, bool, bool);
   ADD_FUNC_PASS_WRAPPER_0("add_optimize_buffer_op_ptr",
                           mlir::createTritonAMDGPUOptimizeBufferOpPtr);
   ADD_PASS_WRAPPER_0("add_fold_true_cmpi", mlir::createTritonAMDFoldTrueCmpI);

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -46,10 +46,11 @@ const char *const amdTargetTriple = "amdgcn-amd-amdhsa";
 
 void init_triton_amd_passes_ttgpuir(py::module &&m) {
   using namespace mlir::triton;
-  m.def("add_to_llvmir",
-        [](mlir::PassManager &pm, const std::string &arch, bool ftz) {
-          pm.addPass(createConvertTritonAMDGPUToLLVMPass(arch, ftz));
-        });
+  m.def("add_to_llvmir", [](mlir::PassManager &pm, const std::string &arch,
+                            bool ftz, bool assumeNoFineGrainedMemory) {
+    pm.addPass(
+        createConvertTritonAMDGPUToLLVMPass(arch, ftz, assumeNoFineGrainedMemory));
+  });
   m.def("add_builtin_func_to_llvmir",
         [](mlir::PassManager &pm, const std::string &arch, bool ftz) {
           pm.addPass(createConvertBuiltinFuncToLLVMPass(arch, ftz));


### PR DESCRIPTION
This PR enables buffer atomic RMW on supported archs. RDNA3, and others, already expose BUFFER_ATOMIC_* for every integer op and for the f32 floating-point ops we care about, but `TargetFeatures::supportsBufferAtomicRMW()` currently falls through to the legacy non-buffer atomic path for RDNA3, RDNA2, CDNA2, etc..

I initially opened up a ticket (https://github.com/triton-lang/triton/pull/10371) to just enable these archs in TargetInfo.cpp for RDNA3, but after some investigation, I've deemed that is not the correct decision to make. It silently introduced a correctness regression on RDNA3 (and it would on other older archs that don't support `FeatureAgentScopeFineGrainedRemoteMemoryAtomics` as well). Flipping TargetFeatures::supportsBufferAtomicRMW() to true for gfx11 causes ConvertBufferOps to rewrite generic tt.atomic_rmw into amdg.buffer_atomic_rmw, and RDNA3's BUFFER_ATOMIC_* instructions discard writes against fine-grained allocations with no fault, stall, or diagnostic, the atomic just disappears. We have an empirical reproducer with the following changes in Triton's language/test_core.py:
```
diff --git a/python/test/unit/language/test_core.py b/python/test/unit/language/test_core.py
index 56c79d8ac..051b63560 100644
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1427,7 +1427,18 @@ def test_atomic_rmw(op, dtype_x_str, mode, sem, device):
         x[idx] = np.max(np.abs(x)) + 1
     x_tri = to_triton(x, device=device, dst_type=dst_type)

-    z_tri = to_triton(np.array([neutral], dtype=getattr(np, dtype_x_str)), device=device, dst_type=dst_type)
+    # `dst_type is None` filters out the bf16-stored-as-f32 case (handled via
+    # `dst_type='bfloat16'`); we only want this for *real* f32 destinations.
+    if op == 'add' and dtype_x_str == 'float32' and dst_type is None:
+        # Allocate the atomic destination in pinned (fine-grained) host memory.
+        # Some AMD ISAs (e.g. RDNA3) may silently drop buffer atomics issued
+        # against fine-grained allocations, so this exercises that path.
+        # PyTorch refuses `pin_memory=True` when the constructor copies from a
+        # numpy buffer, so build the tensor first and pin it explicitly.
+        z_tri = torch.from_numpy(np.array([neutral], dtype=getattr(np, dtype_x_str))).pin_memory()
+        assert z_tri.is_pinned()
+    else:
+        z_tri = to_triton(np.array([neutral], dtype=getattr(np, dtype_x_str)), device=device, dst_type=dst_type)
     h = kernel[(n_programs, )](x_tri, z_tri)
     # torch result
     if dst_type == 'bfloat16':
```
where the absolute diff is exactly the value that should have been accumulated and the relative diff is inf, proving the destination stayed bit-for-bit at the neutral initializer. The convert-buffer-ops pass also has no way to gate around it because it cannot know at compile time whether a runtime pointer refers to fine-grained or coarse-grained memory; that information lives in the HSA allocation flags. RDNA4/CDNA3/CDNA4/gfx1250 are fine because their buffer atomics correctly handle fine-grained memory.

This PR introduces a new user-enabled knob in compiler.py that provides extra information when the user knows there is no fine grained memory.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
