### PR TITLE
Treat incomplete cache groups as misses

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -14,6 +14,60 @@ import torch
 import triton
 import triton.language as tl
 from triton._internal_testing import is_hip
+from triton.runtime.cache import FileCacheManager, RemoteCacheManager
+
+
+def test_file_cache_manager_get_group_rejects_missing_child(fresh_knobs, tmp_path):
+    fresh_knobs.cache.dir = str(tmp_path)
+    manager = FileCacheManager("key")
+    metadata_path = manager.put("{}", "kernel.json", binary=False)
+    artifact_path = manager.put("binary", "kernel.cubin", binary=False)
+
+    manager.put_group("kernel.json", {
+        "kernel.json": metadata_path,
+        "kernel.cubin": artifact_path,
+    })
+    assert manager.get_group("kernel.json") == {
+        "kernel.json": metadata_path,
+        "kernel.cubin": artifact_path,
+    }
+
+    os.remove(artifact_path)
+    assert manager.get_group("kernel.json") is None
+
+
+def test_remote_cache_manager_get_group_rejects_missing_child(fresh_knobs, tmp_path):
+
+    class DictRemoteCacheBackend:
+        data = {}
+
+        def __init__(self, key):
+            self.key = key
+
+        def get(self, filenames):
+            return {filename: self.data[filename] for filename in filenames if filename in self.data}
+
+        def put(self, filename, data):
+            self.data[filename] = data
+
+    fresh_knobs.cache.dir = str(tmp_path)
+    fresh_knobs.cache.remote_manager_class = DictRemoteCacheBackend
+    DictRemoteCacheBackend.data = {}
+
+    manager = RemoteCacheManager("key")
+    manager.put("{}", "kernel.json", binary=False)
+    manager.put(b"binary", "kernel.cubin")
+    manager.put_group("kernel.json", {
+        "kernel.json": "unused-local-path",
+        "kernel.cubin": "unused-local-path",
+    })
+
+    group = manager.get_group("kernel.json")
+    assert group is not None
+    assert set(group) == {"kernel.json", "kernel.cubin"}
+
+    del DictRemoteCacheBackend.data["kernel.cubin"]
+    assert manager.get_group("kernel.json") is None
 
 
 @triton.jit

--- a/python/triton/runtime/cache.py
+++ b/python/triton/runtime/cache.py
@@ -87,8 +87,9 @@ class FileCacheManager(CacheManager):
             return None
         result = {}
         for c, p in child_paths.items():
-            if os.path.exists(p):
-                result[c] = p
+            if not os.path.exists(p):
+                return None
+            result[c] = p
         return result
 
     # Note a group of pushed files as being part of a group
@@ -230,8 +231,11 @@ class RemoteCacheManager(CacheManager):
 
         # Found group data.
         if child_paths is not None:
+            child_data = self._backend.get(child_paths)
+            if len(child_data) != len(child_paths):
+                return None
             result = {}
-            for child_path, data in self._backend.get(child_paths).items():
+            for child_path, data in child_data.items():
                 result[child_path] = self._materialize(child_path, data)
 
         return result


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Summary

Make local and remote cache group reads reject incomplete groups instead of returning a partial mapping. A partial group can make compilation treat a corrupted cache entry as a cache hit, only to fail later when loading the missing binary or IR artifact.

## What changed

- Return `None` from `FileCacheManager.get_group()` if any recorded child path is missing.
- Return `None` from `RemoteCacheManager.get_group()` if the remote backend does not return all recorded children.
- Add regression coverage for both local and remote cache managers.

## Testing

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- Added Python unit coverage in `python/test/unit/runtime/test_cache.py`
