### PR TITLE
Skip benchmarking single pruned autotune configs

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -237,6 +237,51 @@ def test_prune_configs(with_perf_model: bool, device: str):
         assert records['capture_named_args']
 
 
+@pytest.mark.parametrize("prune_kind", ["early_config_prune", "perf_model"])
+def test_pruned_single_config_skips_benchmark(prune_kind: str, device: str, fresh_knobs):
+    N = 1024
+    src = torch.randn(N, device=device)
+    dst = torch.empty(N, device=device)
+    records = {}
+    captured = []
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
+    fresh_knobs.autotuning.print = True
+    fresh_knobs.autotuning.listener = lambda **kwargs: captured.append(kwargs)
+
+    def do_not_bench(kernel_call, quantiles):
+        records['run_do_bench'] = True
+        raise AssertionError("autotune benchmark should be skipped for a single pruned config")
+
+    if prune_kind == "early_config_prune":
+
+        def early_config_prune(configs, named_args, **kwargs):
+            records['run_early_config_prune'] = True
+            return [configs[1]]
+
+        prune_configs_by = {'early_config_prune': early_config_prune}
+    else:
+
+        def perf_model(*args, **kwargs):
+            records['run_perf_model'] = True
+            return 0 if kwargs['BLOCK_SIZE'] == 128 else 1
+
+        prune_configs_by = {'perf_model': perf_model, 'top_k': 1}
+
+    @triton.autotune(configs=configs, key=['N'], prune_configs_by=prune_configs_by, do_bench=do_not_bench)
+    @triton.jit
+    def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + offsets, mask=offsets < N)
+        tl.store(dst + offsets, x, mask=offsets < N)
+
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
+    _kernel[grid](dst, src, N=N)
+    torch.testing.assert_close(src, dst)
+    assert _kernel.best_config == configs[1]
+    assert 'run_do_bench' not in records
+    assert captured == []
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9,
                     reason="Requires compute capability >= 9 for NV")
 def test_override_ttir(device):

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -229,33 +229,39 @@ class Autotuner(KernelInterface):
                 used_cached_result = False
                 pruned_configs = self.prune_configs(kwargs)
 
-                def benchmark():
-                    bench_start = time.time()
-                    timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
-                    bench_end = time.time()
-                    self.bench_time = bench_end - bench_start
-                    self.cache[key] = builtins.min(timings, key=timings.get)
-                    full_nargs = {**self.nargs, **kwargs, **self.cache[key].all_kwargs()}
-                    self.pre_hook(full_nargs, reset_only=True)
-                    self.configs_timings = timings
-
-                if self.cache_results:
-                    used_cached_result = self.check_disk_cache(key, pruned_configs, benchmark)
+                if len(pruned_configs) == 1:
+                    # Match single-config autotune behavior: no benchmarking is needed.
+                    self.cache[key] = pruned_configs[0]
+                    used_cached_result = True
                 else:
-                    benchmark()
 
-                if knobs.autotuning.listener is not None:
-                    jit_fn = self.fn
-                    while not isinstance(jit_fn, JITFunction):
-                        jit_fn = jit_fn.fn
-                    knobs.autotuning.listener(
-                        fn=jit_fn,
-                        key=key,
-                        best_config=self.cache[key],
-                        configs_timings=self.configs_timings,
-                        duration=getattr(self, 'bench_time', None) if not used_cached_result else None,
-                        cache_hit=used_cached_result,
-                    )
+                    def benchmark():
+                        bench_start = time.time()
+                        timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}
+                        bench_end = time.time()
+                        self.bench_time = bench_end - bench_start
+                        self.cache[key] = builtins.min(timings, key=timings.get)
+                        full_nargs = {**self.nargs, **kwargs, **self.cache[key].all_kwargs()}
+                        self.pre_hook(full_nargs, reset_only=True)
+                        self.configs_timings = timings
+
+                    if self.cache_results:
+                        used_cached_result = self.check_disk_cache(key, pruned_configs, benchmark)
+                    else:
+                        benchmark()
+
+                    if knobs.autotuning.listener is not None:
+                        jit_fn = self.fn
+                        while not isinstance(jit_fn, JITFunction):
+                            jit_fn = jit_fn.fn
+                        knobs.autotuning.listener(
+                            fn=jit_fn,
+                            key=key,
+                            best_config=self.cache[key],
+                            configs_timings=self.configs_timings,
+                            duration=getattr(self, 'bench_time', None) if not used_cached_result else None,
+                            cache_hit=used_cached_result,
+                        )
 
             config = self.cache[key]
         else:


### PR DESCRIPTION
Fixes #9821.

When `prune_configs_by` reduces a multi-config autotune set to one config, the autotuner currently still benchmarks that single option. This makes the pruned-single case slower than an explicit single-config autotune even though there is no choice left to tune.

This change:
- directly selects the only pruned config without benchmarking it
- keeps autotune listener behavior aligned with explicit single-config autotune, where no benchmark event is emitted
- adds regression coverage for both `early_config_prune` and `perf_model`/`top_k=1` paths

Local checks:
- `python3 -m compileall -q python/triton/runtime/autotuner.py python/test/unit/runtime/test_autotuner.py`
- `git diff --check`

Not run locally:
- `PYTHONPATH=python python3 -m pytest -q python/test/unit/runtime/test_autotuner.py::test_pruned_single_config_skips_benchmark` because this checkout does not have a built `triton._C.libtriton` extension.