### PR TITLE
[BACKEND] Reserve registers for assert and print

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Passes.td
+++ b/include/triton/Conversion/TritonGPUToLLVM/Passes.td
@@ -40,6 +40,11 @@ def TritonGPUAllocateWarpGroups : Pass<"tritongpu-allocate-warp-groups", "mlir::
     the total number of needed warps, then attaches the range of warp IDs to
     each warpgroup function.
   }];
+
+  let options = [
+    Option<"instrumented", "instrumented", "bool", /*default*/"false",
+           "whether later instrumentation will insert assert-like ops">
+  ];
 }
 
 def CanonicalizeLLVMIR : Pass<"canonicalize-llvm-ir", "mlir::LLVM::LLVMFuncOp"> {

--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -1,5 +1,6 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace mlir::triton::gpu {
@@ -10,6 +11,26 @@ namespace mlir::triton::gpu {
 using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
+
+constexpr int32_t kMinRegistersForAssertOrPrint = 32;
+
+static bool regionUsesAssertOrPrint(Region &region) {
+  return region
+      .walk([](Operation *op) {
+        return isa<AssertOp, PrintOp>(op) ? WalkResult::interrupt()
+                                          : WalkResult::advance();
+      })
+      .wasInterrupted();
+}
+
+static int32_t minRegistersForRegion(Region &region, bool instrumented,
+                                     int32_t minRegisters) {
+  // Work around an NVIDIA driver bug: regions that may call device system
+  // functions such as assert or print need at least 32 registers.
+  return instrumented || regionUsesAssertOrPrint(region)
+             ? std::max(minRegisters, kMinRegistersForAssertOrPrint)
+             : minRegisters;
+}
 
 // Given a `ttg.warp_specialize` with a certain number of existing warps, pad it
 // with extra warps until it has the same number of full warp groups as the
@@ -65,8 +86,11 @@ namespace {
 struct AllocateWarpGroups
     : public mlir::triton::gpu::impl::TritonGPUAllocateWarpGroupsBase<
           AllocateWarpGroups> {
+  using TritonGPUAllocateWarpGroupsBase::TritonGPUAllocateWarpGroupsBase;
+
   void runOnOperation() override {
     ModuleOp mod = getOperation();
+    bool laterInstrumentation = instrumented.getValue();
 
     // First determine the maximum number of extra warps.
     int maxExtraWarps = 0;
@@ -157,8 +181,11 @@ struct AllocateWarpGroups
       // Group the partitions into warpgroups.
       SmallVector<WarpGroupPartition> orderedPartitions;
       for (auto [startId, partition, estRegs, numWarps] :
-           llvm::zip(startIds, op.getPartitionRegions(), *regsAttr, arr))
-        orderedPartitions.push_back({startId, partition, estRegs, numWarps});
+           llvm::zip(startIds, op.getPartitionRegions(), *regsAttr, arr)) {
+        int minRegs =
+            minRegistersForRegion(*partition, laterInstrumentation, estRegs);
+        orderedPartitions.push_back({startId, partition, minRegs, numWarps});
+      }
       llvm::sort(orderedPartitions,
                  [&](auto lhs, auto rhs) { return lhs.startId < rhs.startId; });
 
@@ -192,7 +219,9 @@ struct AllocateWarpGroups
       int leftover = registerBudget / (baseNumWarps * threadsPerWarp);
       // Round down to the nearest multiple of 8.
       leftover = leftover / 8 * 8;
-      if (leftover < 24)
+      if (leftover < minRegistersForRegion(op.getDefaultRegion(),
+                                           laterInstrumentation,
+                                           /*minRegisters=*/24))
         return; // too few registers
 
       // Generate setmaxnreg in each partition according to its warp group.

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -83,6 +83,8 @@ void init_triton_passes_ttgpuir(py::module &&m) {
                      createTritonGPUReduceDataDuplication);
   ADD_PASS_WRAPPER_0("add_allocate_warp_groups",
                      createTritonGPUAllocateWarpGroups);
+  ADD_PASS_OPTION_WRAPPER_1("add_allocate_warp_groups",
+                            createTritonGPUAllocateWarpGroups, bool);
   ADD_PASS_WRAPPER_0("add_allocate_shared_memory", createAllocateSharedMemory);
   ADD_PASS_WRAPPER_0("add_allocate_global_scratch_memory",
                      createTritonGPUGlobalScratchAllocationPass);

--- a/test/Conversion/allocate_warp_groups.mlir
+++ b/test/Conversion/allocate_warp_groups.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --tritongpu-allocate-warp-groups | FileCheck %s
+// RUN: triton-opt %s -split-input-file --tritongpu-allocate-warp-groups="instrumented=1" | FileCheck %s --check-prefix=INSTRUMENTED
 
 // CHECK: module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 4 : i32}
 module attributes {"ttg.num-warps" = 4 : i32} {
@@ -86,6 +87,50 @@ tt.func @setmaxnreg() {
     ttg.warp_return
   }
   partition2() num_warps(1) {
+    ttg.warp_return
+  } : () -> ()
+  tt.return
+}
+
+}
+
+// -----
+
+// CHECK: module attributes {ttg.maxnreg = 40 : i32
+module attributes {"ttg.num-warps" = 4 : i32, ttg.maxnreg = 40 : i32} {
+
+tt.func @assert_and_print_min_registers() {
+  // CHECK: actualRegisters = array<i32: 48, 32>
+  // CHECK: requestedRegisters = array<i32: 24>
+  ttg.warp_specialize() attributes {requestedRegisters = array<i32: 24>}
+  default {
+    %zero = arith.constant 0 : i32
+    tt.print "zero: " {hex = false, isSigned = array<i32: 1>} : %zero : i32
+    ttg.warp_yield
+  }
+  partition0() num_warps(4) {
+    %true = arith.constant true
+    tt.assert %true, "assert text" : i1
+    ttg.warp_return
+  } : () -> ()
+  tt.return
+}
+
+}
+
+// -----
+
+// INSTRUMENTED: module attributes {instrumented.test, ttg.maxnreg = 40 : i32
+module attributes {"instrumented.test", "ttg.num-warps" = 4 : i32, ttg.maxnreg = 40 : i32} {
+
+tt.func @instrumented_min_registers() {
+  // INSTRUMENTED: actualRegisters = array<i32: 48, 32>
+  // INSTRUMENTED: requestedRegisters = array<i32: 16>
+  ttg.warp_specialize() attributes {requestedRegisters = array<i32: 16>}
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(4) {
     ttg.warp_return
   } : () -> ()
   tt.return

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -376,7 +376,7 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_global_sanitizer(pm)
 
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
-        passes.ttgpuir.add_allocate_warp_groups(pm)
+        passes.ttgpuir.add_allocate_warp_groups(pm, "consan" in options.instrumentation_mode)
         passes.convert.add_scf_to_cf(pm)
         passes.gluon.add_inliner(pm)
         if "consan" in options.instrumentation_mode:


### PR DESCRIPTION
Workaround for a driver bug that will fail to call assert or print when number of registers is too low