### PR TITLE
Restore `matmul` opt-flags constraints export

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -10,7 +10,7 @@ from triton._internal_testing import is_hopper
 # matmul utilities
 import triton_kernels.matmul_details.opt_flags as opt_flags
 from triton_kernels.matmul import FlexCtx, PrecisionConfig, FusedActivation, FnSpecs, FnName, Epilogue
-from triton_kernels.matmul import matmul_set_idle_sms, matmul, matmul_torch
+from triton_kernels.matmul import matmul_set_idle_sms, matmul, matmul_torch, update_opt_flags_constraints
 # numerics utilities
 from triton_kernels.numerics import InFlexData, OutFlexData
 from triton_kernels.numerics_details.mxfp import upcast_from_mxfp, quantize_mxfp8_fn, quantize_nvfp4_fn, downcast_to_mxfp_torch, upcast_from_mxfp_torch, MXFP_BLOCK_SIZE, NVFP_BLOCK_SIZE
@@ -643,3 +643,7 @@ def test_set_idle_sms():
             assert flags.idle_sms == num_idle_sms + 1
     finally:
         matmul_set_idle_sms(0)
+
+
+def test_update_opt_flags_constraints_export():
+    assert update_opt_flags_constraints is opt_flags.update_opt_flags_constraints

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -28,6 +28,7 @@ from .matmul_details.opt_flags import (
     scoped_opt_flags as scoped_opt_flags,
     scoped_opt_flags_constraints as scoped_opt_flags_constraints,
     set_idle_sms,
+    update_opt_flags_constraints as update_opt_flags_constraints,
 )
 from .matmul_details.opt_flags_details import opt_flags_nvidia
 from .specialize import FnSpecs, SpecializationModule, ClosureArg


### PR DESCRIPTION
## Summary

Restore `triton_kernels.matmul.update_opt_flags_constraints` as a compatibility re-export and add a regression test for the public import path.

## Rationale

The process-global `idle_sms` refactor intentionally changed `matmul_set_idle_sms()`, but it also removed the existing `update_opt_flags_constraints` re-export from `triton_kernels.matmul`. Consumers importing the helper through that module now fail at import time even though the helper still exists in `matmul_details.opt_flags`.

Restoring the alias preserves compatibility without changing the new `idle_sms` behavior.

## Validation

- Verified the public re-export resolves to the existing implementation with `PYTHONPATH=python/triton_kernels python -c 'from triton_kernels.matmul import update_opt_flags_constraints; from triton_kernels.matmul_details.opt_flags import update_opt_flags_constraints as implementation; assert update_opt_flags_constraints is implementation'`.
- Added `test_update_opt_flags_constraints_export`.

The focused pytest invocation cannot collect locally because this machine has no active Triton driver.
