### PR TITLE
Export constexpr_function from triton.language

### DIFF
--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -28,6 +28,7 @@ from .standard import (
     zeros,
     zeros_like,
 )
+from ..runtime.jit import constexpr_function
 from .core import (
     PropagateNan,
     TRITON_MAX_TENSOR_NUMEL,
@@ -176,6 +177,7 @@ __all__ = [
     "condition",
     "const",
     "constexpr",
+    "constexpr_function",
     "constexpr_type",
     "cos",
     "cumprod",


### PR DESCRIPTION
## Summary

Fixes #9200. `constexpr_function` is defined in `triton.runtime.jit` and is already imported and used internally by `triton.language.standard` (`from ..runtime.jit import jit, constexpr_function`), but it is not exported from `triton.language`. So `from triton.language import constexpr_function` (and `tl.constexpr_function`) fails, which breaks downstream libraries that rely on it (e.g. `triton_kernels` / unsloth, per the issue).

## Change

- Import `constexpr_function` from `..runtime.jit` in `triton/language/__init__.py`
- Add `"constexpr_function"` to `__all__` (kept alphabetical, next to `constexpr`/`constexpr_type`)

The import mirrors the existing, working one in `triton/language/standard.py`.

## Verification

- `python -m py_compile triton/language/__init__.py` passes; `ruff check` is clean.
- `constexpr_function` is a module-level definition in `runtime/jit.py`, so the new import resolves the same way `standard.py`'s already does.

> Authored with the assistance of an AI coding assistant; all changes were reviewed and verified by me.
