### PR TITLE
docs: build versioned docs with sphinx-multiversion (#5388)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           # Limit the number of threads to reduce CPU memory usage
           # This CI node has 24 cores
-          MAX_JOBS=24 sudo -E make docs-only
+          MAX_JOBS=24 sudo -E make docs-multiversion
 
       - name: Update docs
         run: |

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,13 @@ docs-requirements:
 docs-only:
 	cd docs; PATH="$(BUILD_DIR):$(PATH)" $(PYTHON) -m sphinx . _build/html/main
 
+# Build every whitelisted branch/tag (see smv_* in docs/conf.py) into
+# _build/html/<version>/ so the published site is versioned. Used by CI;
+# docs-only stays the fast single-version build for local previews.
+.PHONY: docs-multiversion
+docs-multiversion:
+	cd docs; PATH="$(BUILD_DIR):$(PATH)" $(PYTHON) -m sphinx_multiversion . _build/html
+
 .PHONY: docs
 .NOPARALLEL: docs
 docs: docs-requirements docs-only

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,18 @@ def process_gluon_docstring(app, what, name, obj, options, lines):
 def setup_gluon_napoleon(app):
     from sphinx.ext.napoleon import Config as NapoleonConfig
 
-    for name, default, rebuild, types in NapoleonConfig._config_values:
+    # Sphinx >= 8 exposes _config_values as a sequence of
+    # (name, default, rebuild, types) tuples; Sphinx < 8 (required by
+    # sphinx-multiversion) exposes a dict of name -> (default, rebuild).
+    # Support both so the docs build under either.
+    config_values = NapoleonConfig._config_values
+    if isinstance(config_values, dict):
+        entries = ((name, *value) for name, value in config_values.items())
+    else:
+        entries = config_values
+    for entry in entries:
+        name, default, rebuild = entry[0], entry[1], entry[2]
+        types = entry[3] if len(entry) > 3 else ()
         app.add_config_value(name, default, rebuild, types=types)
     app.connect("autodoc-process-docstring", process_gluon_docstring)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -383,9 +383,11 @@ myst_sphinx_gallery_config = GalleryConfig(
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
+# Render the sphinx-multiversion version switcher (docs/_templates/versions.html)
+# in the sidebar so users can move between the documented versions.
 html_sidebars = {
     '**': [
-        '_templates/versions.html',
+        'versions.html',
     ],
 }
 
@@ -453,18 +455,6 @@ html_static_path = ['_static']
 html_css_files = [
     'css/custom.css',
 ]
-
-# Custom sidebar templates, must be a dictionary that maps document names
-# to template names.
-#
-# This is required for the alabaster theme
-# refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    '**': [
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
-    ]
-}
 
 html_logo = "https://cdn.openai.com/triton/assets/triton-logo.png"
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,9 @@
 tabulate
 cmake
-sphinx
+# sphinx-multiversion (used by `make docs-multiversion`) is incompatible with
+# Sphinx >= 8 (it calls the changed Config.read signature). Pin until it (or a
+# maintained successor) supports newer Sphinx.
+sphinx<8
 matplotlib
 myst_parser
 myst-sphinx-gallery


### PR DESCRIPTION
## Summary

Fixes #5388 — as discussed there with @peterbell10, who asked to use `sphinx-multiversion`.

The published docs only ever reflect `main`. As noted on the issue, `sphinx_multiversion` is already configured in `docs/conf.py`, but the build step — `make docs-only`, used by `.github/workflows/documentation.yml` — runs a single-version build (`python -m sphinx . _build/html/main`) and never invokes `sphinx-multiversion`. So users on a released version hit symbols that only exist on `main` (e.g. `get_active_torch_device`).

## Changes

1. **`Makefile`** — new `docs-multiversion` target that runs `sphinx-multiversion`, producing `_build/html/<version>/` per whitelisted branch/tag (`smv_*` in `conf.py`). `docs-only` stays as the fast single-version build for local previews.
2. **`.github/workflows/documentation.yml`** — the Documentation job now runs `make docs-multiversion`. The existing deploy already does `mv docs/_build/html/* …`, so the per-version tree and the gh-pages `index.html` redirect to `/main/` keep working unchanged.
3. **`docs/conf.py`** — there were two `html_sidebars` definitions; the second (leftover alabaster-theme boilerplate) overrode the first, so the `versions.html` switcher never rendered. Consolidated to a single `html_sidebars` with `versions.html` so the version dropdown shows.
4. **`docs/requirements.txt`** — pin `sphinx<8`: `sphinx-multiversion` is incompatible with Sphinx ≥ 8 (the changed `Config.read` signature).

## Verification

I couldn't run Triton's full docs build locally (autodoc imports a compiled Triton), so I verified the mechanics on a **minimal Sphinx project** mirroring this config (`sphinx-rtd-theme` + `sphinx-multiversion` + the same `versions.html` + `html_sidebars = {'**': ['versions.html']}`), with two git refs (a `main` branch and a `v1.0.0` tag):

- `sphinx-multiversion . _build/html` produced `_build/html/main/` **and** `_build/html/v1.0.0/`.
- The **"Other Versions" switcher rendered** in both versions' pages — confirming the `html_sidebars` fix works with the RTD theme.
- On Sphinx 9 it failed with `TypeError: Config.read() takes 2 positional arguments but 3 were given`; on Sphinx 7.4.7 it succeeded — hence the `sphinx<8` pin. Resolving `docs/requirements.txt` with `sphinx<8` is clean.

The full Triton docs build will be validated by the Documentation CI (built Triton + a100 runner). Happy to adjust anything — e.g. `smv_tag_whitelist` currently lists only `v3.7.0` and can be widened to include more releases.

> Authored with the assistance of an AI coding assistant; reviewed and verified by me.
