### PR TITLE
Disable autotune disk cache for custom do_bench

### DIFF
--- a/python/test/unit/runtime/test_autotune_listener.py
+++ b/python/test/unit/runtime/test_autotune_listener.py
@@ -104,7 +104,7 @@ def test_autotune_listener_disk_cache_hit(device: str, fresh_knobs, fresh_triton
 
     configs = [triton.Config({"BLOCK_SIZE": 32}), triton.Config({"BLOCK_SIZE": 128})]
 
-    @triton.autotune(configs=configs, key=["N"], do_bench=do_bench, cache_results=True)
+    @triton.autotune(configs=configs, key=["N"], cache_results=True)
     @triton.jit
     def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
         offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -15,6 +15,30 @@ def do_bench(kernel_call, quantiles, use_cuda_graph=False):
     return triton.testing.do_bench(kernel_call, quantiles=quantiles, warmup=1, rep=1)
 
 
+def make_autotuner(**autotune_kwargs):
+    configs = [triton.Config({"BLOCK_SIZE": 32}), triton.Config({"BLOCK_SIZE": 128})]
+
+    @triton.autotune(configs=configs, key=["N"], cache_results=True, **autotune_kwargs)
+    @triton.jit
+    def _kernel(dst, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        tl.store(dst + offsets, offsets, mask=offsets < N)
+
+    return _kernel
+
+
+def test_custom_do_bench_disables_cache_results():
+    assert not make_autotuner(do_bench=do_bench).cache_results
+
+
+def test_default_do_bench_keeps_cache_results():
+    assert make_autotuner().cache_results
+
+
+def test_legacy_bench_options_disable_cache_results():
+    assert not make_autotuner(warmup=1).cache_results
+
+
 @pytest.mark.parametrize('use_cuda_graph', [False, True])
 def test_kwargs(use_cuda_graph: bool, device: str):
     if use_cuda_graph and not torch.cuda.is_available():

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -37,6 +37,10 @@ class Autotuner(KernelInterface):
         self.cache: Dict[Tuple, Config] = {}
         self.arg_names = arg_names
         self.cache_results = (cache_results or knobs.autotuning.cache) and not knobs.runtime.interpret
+        # Custom benchmark functions may depend on arbitrary Python helpers, so
+        # disk cache keys cannot reliably track their full behavior.
+        if do_bench is not None or warmup is not None or rep is not None or use_cuda_graph:
+            self.cache_results = False
 
         # Reset to zero or restore values
         self.reset_to_zero = []
@@ -452,7 +456,9 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_va
     :type rep: int
     :param do_bench: a benchmark function to measure the time of each run.
     :type do_bench: lambda fn, quantiles
-    :param cache_results: whether to cache autotune timings to disk.  Defaults to False.
+    :param cache_results: whether to cache autotune timings to disk. Disabled when
+        a custom benchmark function or deprecated benchmark option is provided.
+        Defaults to False.
     "type cache_results: bool
     """
 


### PR DESCRIPTION
## Summary

- disable autotune disk caching when a custom `do_bench` function is supplied
- also disable disk caching for deprecated benchmark options (`warmup`, `rep`, `use_cuda_graph`) because they customize benchmark behavior
- keep disk caching enabled for the default benchmark path
- add unit coverage for custom benchmark disabling, default benchmark caching, and deprecated benchmark options

## Context

Closes #9118.

Custom benchmark functions can call arbitrary Python helper functions. Instead of trying to recursively hash all possible Python dependencies, this PR avoids stale disk-cache results by not using `cache_results` when benchmark behavior is customized.

## Testing

- `python3 -m py_compile python/triton/runtime/autotuner.py python/triton/runtime/jit.py python/test/unit/runtime/test_autotuner.py python/test/unit/runtime/test_autotune_listener.py`
- `python3 -m ruff check python/triton/runtime/autotuner.py python/triton/runtime/jit.py python/test/unit/runtime/test_autotuner.py python/test/unit/runtime/test_autotune_listener.py`
- `git diff --check`
- source validation that custom benchmark paths disable `cache_results` and the previous callable cache-key helper is removed

Note: I could not run the focused pytest locally because this macOS checkout does not have `pytest` installed and the local Triton package is not built (`triton._C.libtriton` import fails).
