### PR TITLE
Fix Hopper MXFP4 packed value padding

### DIFF
--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -112,7 +112,8 @@ def _hopper_rhs_packed_n_extent(out, n: tl.constexpr):
     tl.store(out, _compute_packed_n_w(n, 4, "HOPPER_VALUE"))
 
 
-def test_matmul_hopper_mxfp4_rhs_packed_n_padding(device):
+@pytest.mark.parametrize("n", [258, 320])
+def test_matmul_hopper_mxfp4_rhs_packed_n_padding(device, n):
     if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
         pytest.skip("requires CUDA")
     if torch.cuda.get_device_capability()[0] != 9:
@@ -122,7 +123,6 @@ def test_matmul_hopper_mxfp4_rhs_packed_n_padding(device):
     # Hopper MXFP4 RHS values are stored with N packed by 4 and then padded in
     # packed space. The generic kernel must ceil-divide before padding and wrap
     # using that padded packed width.
-    n = 258
     packed_n = torch.empty((1, ), dtype=torch.int32, device=device)
     _hopper_rhs_packed_n_extent[(1, )](packed_n, n)
     assert packed_n.item() == 128
@@ -135,6 +135,7 @@ def test_matmul_hopper_mxfp4_rhs_packed_n_padding(device):
     scale_layout = layout.make_default_matmul_mxfp4_w_scale_layout(mx_axis=-2, num_warps=8)
     b = convert_layout(wrap_torch_tensor(weight_val, dtype=FP4), value_layout)
     b_scale = convert_layout(wrap_torch_tensor(weight_scale, dtype=UINT8), scale_layout)
+    assert b.storage.data.shape[-1] == packed_n.item()
     precision_config = PrecisionConfig(
         b_mx_scale=b_scale,
         b_microblock_size=MXFP_BLOCK_SIZE.value,

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -83,10 +83,10 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         batch = data.ndim - 2
         assert batch >= 0
         assert self.mma_version in (2, 3)
-        # Pre-pad both matrix dims to multiples of 64
+        # Pre-pad both matrix dims before packing one of them by four.
         *_, M_in, K_in = data.shape
-        SWIZZLE_ALIGN_M = 64
-        SWIZZLE_ALIGN_K = 64
+        SWIZZLE_ALIGN_M = 64 if self.mx_axis == batch else 256
+        SWIZZLE_ALIGN_K = 256 if self.mx_axis == batch else 64
         pad_m = (SWIZZLE_ALIGN_M - (M_in % SWIZZLE_ALIGN_M)) % SWIZZLE_ALIGN_M
         pad_k = (SWIZZLE_ALIGN_K - (K_in % SWIZZLE_ALIGN_K)) % SWIZZLE_ALIGN_K
         data = torch.nn.functional.pad(data, (0, pad_k, 0, pad_m))

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py
@@ -83,7 +83,7 @@ class HopperMXValueLayoutTransformation(LayoutTransformation):
         batch = data.ndim - 2
         assert batch >= 0
         assert self.mma_version in (2, 3)
-        # Pre-pad both matrix dims before packing one of them by four.
+        # Align the dimension packed by four to a 64-byte load extent.
         *_, M_in, K_in = data.shape
         SWIZZLE_ALIGN_M = 64 if self.mx_axis == batch else 256
         SWIZZLE_ALIGN_K = 256 if self.mx_axis == batch else 64


### PR DESCRIPTION
## Summary

- pad the Hopper MXFP4 value dimension packed by four to a 256-element boundary before swizzling
- verify transformed Hopper MXFP4 RHS storage width matches the kernel packed-N extent for `N=258` and `N=320`

## Root cause

The Hopper MXFP4 RHS kernel rounds packed N up to 64 bytes. The host storage transform padded logical N to 64 elements before packing, so shapes such as `N=320` allocated 80 packed bytes while loads addressed a 128-byte packed extent. Padding the dimension packed by four to 256 logical elements keeps host storage and kernel addressing consistent.

## Testing

- exact host layout round trips for `N=258`, `N=320`, and `N=640`
- H100: `pytest -s --tb=short python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py::test_matmul_hopper_mxfp4_rhs_packed_n_padding`
- H100: `pytest -s --tb=short python/triton_kernels/tests/test_tensor_details/test_layout_hopper.py`