### PR TITLE
Test Hopper MXFP4 packed RHS bounds

### DIFF
--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -1,11 +1,10 @@
+import multiprocessing
+
 import pytest
 import torch
-import triton
-import triton.language as tl
 from triton._internal_testing import is_cuda
 
 from triton_kernels.matmul import matmul, matmul_torch, PrecisionConfig
-from triton_kernels.matmul_details._matmul import _compute_packed_n_w
 from triton_kernels.matmul_details.opt_flags import InapplicableConstraint, scoped_opt_flags_constraints
 from triton_kernels.matmul_details.opt_flags_details import opt_flags_nvidia
 from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE, downcast_to_mxfp
@@ -107,11 +106,6 @@ def test_matmul_hopper_mxfp4_rhs_scale_padding_is_masked(device, constraints):
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
-@triton.jit
-def _hopper_rhs_packed_n_extent(out, n: tl.constexpr):
-    tl.store(out, _compute_packed_n_w(n, 4, "HOPPER_VALUE"))
-
-
 @pytest.mark.parametrize("n", [258, 320])
 def test_matmul_hopper_mxfp4_rhs_packed_n_padding(device, n):
     if device != "cuda" or not torch.cuda.is_available() or not is_cuda():
@@ -119,14 +113,17 @@ def test_matmul_hopper_mxfp4_rhs_packed_n_padding(device, n):
     if torch.cuda.get_device_capability()[0] != 9:
         pytest.skip("requires Hopper")
 
-    torch.manual_seed(0)
-    # Hopper MXFP4 RHS values are stored with N packed by 4 and then padded in
-    # packed space. The generic kernel must ceil-divide before padding and wrap
-    # using that padded packed width.
-    packed_n = torch.empty((1, ), dtype=torch.int32, device=device)
-    _hopper_rhs_packed_n_extent[(1, )](packed_n, n)
-    assert packed_n.item() == 128
+    process = multiprocessing.get_context("spawn").Process(
+        target=_run_matmul_hopper_mxfp4_rhs_packed_n_padding,
+        args=(device, n),
+    )
+    process.start()
+    process.join()
+    assert process.exitcode == 0
 
+
+def _run_matmul_hopper_mxfp4_rhs_packed_n_padding(device, n):
+    torch.manual_seed(0)
     m, k = 64, 2048
     a = torch.randn((m, k), device=device, dtype=torch.bfloat16)
     weight_fp = torch.randn((n, k), device=device, dtype=torch.bfloat16).T
@@ -135,17 +132,23 @@ def test_matmul_hopper_mxfp4_rhs_packed_n_padding(device, n):
     scale_layout = layout.make_default_matmul_mxfp4_w_scale_layout(mx_axis=-2, num_warps=8)
     b = convert_layout(wrap_torch_tensor(weight_val, dtype=FP4), value_layout)
     b_scale = convert_layout(wrap_torch_tensor(weight_scale, dtype=UINT8), scale_layout)
-    assert b.storage.data.shape[-1] == packed_n.item()
     precision_config = PrecisionConfig(
         b_mx_scale=b_scale,
         b_microblock_size=MXFP_BLOCK_SIZE.value,
         out_dtype=a.dtype,
     )
+    # Place the RHS at an allocation boundary so out-of-bounds packed N loads
+    # fail instead of reading unrelated mapped memory.
+    backing = torch.empty(2 * 1024 * 1024, dtype=torch.uint8, device=device)
+    data = backing[-b.storage.data.numel():].as_strided(b.storage.data.shape, b.storage.data.stride())
+    data.copy_(b.storage.data)
+    b = Tensor(Storage(data, b.storage.layout), dtype=b.dtype, shape=b.shape)
 
     with scoped_opt_flags_constraints({"is_persistent": False, "block_n": 256}):
-        expected = matmul_torch(a, b, None, precision_config=precision_config)
         actual = matmul(a, b, None, precision_config=precision_config)
+        torch.cuda.synchronize()
 
+    expected = matmul_torch(a, b, None, precision_config=precision_config)
     assert torch.isfinite(actual).all()
     assert_close(expected, actual, maxtol=3e-2, rmstol=None)
 


### PR DESCRIPTION
## Summary
- replace the Hopper MXFP4 packed-width implementation assertion with an end-to-end matmul regression
- place the converted RHS at the end of a CUDA allocation so out-of-bounds packed-N loads fail deterministically
- run the operation in a spawned worker to keep an illegal-memory failure from poisoning the parent test process

## Why
Follow-up to #10428. Before that fix, ragged Hopper MXFP4 RHS widths such as `N=258` and `N=320` could allocate narrower packed storage than the regular kernel loaded. The previous regression checked the layout arithmetic directly; this version exercises the actual non-persistent `matmul` path and still compares successful output against `matmul_torch`.

## Validation
- before #10428 (`c0a60dd302`): focused test fails for `N=258` and `N=320` with `Triton Error [CUDA]: an illegal memory access was encountered`
- after #10428: `python3 -m pytest -s --tb=short python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py` on H100 (`6 passed, 2 skipped`)