### PR TITLE
Fix is_power_of_two returning True for 0 in block-shape validation

### DIFF
--- a/python/triton/_utils.py
+++ b/python/triton/_utils.py
@@ -56,7 +56,7 @@ def find_paths_if(iterable: Union[IterableType, Any], pred: Callable[[ObjPath, A
 
 
 def is_power_of_two(x):
-    return (x & (x - 1)) == 0
+    return x > 0 and (x & (x - 1)) == 0
 
 
 def validate_block_shape(shape: List[int]):


### PR DESCRIPTION
## Problem

`is_power_of_two(x)` in `python/triton/_utils.py` is implemented as:

```python
def is_power_of_two(x):
    return (x & (x - 1)) == 0
```

This returns `True` for `x == 0` (since `0 & -1 == 0`). It is the power-of-2 guard used by `validate_block_shape()`, so a block shape containing a `0` dimension passes validation and produces a degenerate `numel == 0` tensor instead of raising the intended `ValueError`:

```python
>>> from triton._utils import validate_block_shape
>>> validate_block_shape([0, 16])   # expected: ValueError
0                                    # actual: silently accepted, numel == 0
```

This path is reachable from `block_type.__init__`, `tl.full`, and the tensor-descriptor / Gluon block-shape constructors.

## Why this is the intended behavior

The repo's own sibling helper already guards against zero — `python/triton/language/standard.py`:

```python
@constexpr_function
def _is_power_of_two(i):
    return (i & (i - 1)) == 0 and i != 0
```

`_utils.is_power_of_two` is the inconsistent one.

## Fix

```python
def is_power_of_two(x):
    return x > 0 and (x & (x - 1)) == 0
```

`x > 0` excludes both `0` and negative dimensions (also invalid for a shape).

## Verification

```
before:  is_power_of_two(0) = True ;  validate_block_shape([0,16]) = 0   (invalid shape accepted)
after :  is_power_of_two(0) = False;  validate_block_shape([0,16]) raises ValueError: Shape element 0 must be a power of 2
         is_power_of_two(1/16) still True; validate_block_shape([8,16]) = 128 (unchanged)
```

One-line change; no existing valid behavior altered.