### PR TITLE
Fix AOT linker suffix parsing for multi-digit argument indices

### DIFF
--- a/python/triton/tools/link.py
+++ b/python/triton/tools/link.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Sequence, Union
@@ -29,16 +30,12 @@ class KernelLinkerMeta:
 class HeaderParser:
 
     def __init__(self) -> None:
-        import re
-
         # [kernel_name, c signature]
         self.linker_directives = re.compile("//[\\s]*tt-linker:[\\s]*([\\w]+):(.+):(.+)")
         # [name, hash, suffix]
         self.kernel_name = re.compile("^([\\w]+)_([\\w]+)_([\\w]*)$")
         # [(type, name)]
         self.c_sig = re.compile("[\\s]*(\\w+)\\s(\\w+)[,]?")
-        # [d|c]
-        self.arg_suffix = re.compile("[c,d]")
         # [backend_name]
         self.backend_name_re = re.compile("//[\\s]*tt-linker-backend:[\\s]*([\\w]+)")
 
@@ -98,24 +95,21 @@ class HeaderParser:
         args = c_sig.split(",")
         s2i = {"c": 1, "d": 16}
         num_specs = 0
-        sizes = []
-        # scan through suffix, suffix only includes indexes followed by d or c.
-        for i in range(len(args)):
-            pos = 0
-            idx_matched = suffix.startswith(str(i))
-            if not idx_matched:
-                continue
-            pos += len(str(i))
-            if self.arg_suffix.match(suffix, pos):
-                num_specs += 1
-                sizes.extend([None] * (i - len(sizes)))
-                sizes.append(s2i[suffix[pos]])
-                pos += 1
-            suffix = suffix[pos:]
+        sizes = [None] * len(args)
+        # suffix is a concatenation of `<index><c|d>` tokens, where `<index>`
+        # is the (possibly multi-digit) position of the specialized argument.
+        # Tokenize explicitly so that multi-digit indices (e.g. `11d`) are not
+        # confused with a single-digit index that happens to be a prefix.
+        for idx_str, hint in re.findall(r"(\d+)([cd])", suffix):
+            i = int(idx_str)
+            if i >= len(args):
+                raise Exception(f"Argument index {i} in suffix is out of range for signature: {c_sig}")
+            num_specs += 1
+            sizes[i] = s2i[hint]
 
-        if len(suffix) > 0:
+        # Make sure the suffix contained nothing but valid tokens.
+        if re.sub(r"\d+[cd]", "", suffix):
             raise Exception(f"Has invalid extra suffix: {suffix}")
-        sizes.extend([None] * (len(args) - len(sizes)))
 
         return num_specs, sizes
 


### PR DESCRIPTION
## Problem

`triton.tools.link` fails to link any kernel whose specialization suffix contains a multi-digit argument index — i.e. a kernel with 10+ arguments where a specialized argument has index `>= 10`.

`HeaderParser._match_suffix` scans indices with `suffix.startswith(str(i))`, consuming one index at a time from the front of the suffix. For a suffix like `"11d"` (12-arg kernel, arg 11 specialized) it matches index `1` on the leading `'1'`, finds the next char `'1'` is not `c`/`d`, and leaves `"1d"` behind:

```
>>> HeaderParser()._match_suffix("11d", ",".join("int a%d"%i for i in range(12)))
Exception: Has invalid extra suffix: 1d
```

The generator side emits exactly these tokens with the raw integer index — `python/triton/tools/compile.py`:

```python
suffix += f'{i}c'   # / f'{i}d'
```

so multi-digit indices are a real, producible input, and the linker is broken for any large-signature kernel.

## Fix

Tokenize the suffix explicitly into `<index><c|d>` pairs with a regex, so a multi-digit index is never confused with a single-digit index that happens to be a prefix. Also raise a clear out-of-range error for an index past the signature.

```python
sizes = [None] * len(args)
for idx_str, hint in re.findall(r"(\d+)([cd])", suffix):
    i = int(idx_str)
    if i >= len(args):
        raise Exception(f"Argument index {i} in suffix is out of range for signature: {c_sig}")
    num_specs += 1
    sizes[i] = s2i[hint]
if re.sub(r"\d+[cd]", "", suffix):
    raise Exception(f"Has invalid extra suffix: {suffix}")
```

Also removes the now-redundant local `import re` (a module-level import is added) and the unused `arg_suffix` regex.

## Verification

```
                  before                              after
11d   (12 args)   Exception: invalid extra suffix 1d  (1, [...None x11, 16])
0c1d  (3 args)    (2, [1, 16, None])                  (2, [1, 16, None])     unchanged
2d    (3 args)    (1, [None, None, 16])               (1, [None, None, 16])  unchanged
''    (3 args)    (0, [None, None, None])             (0, [None, None, None]) unchanged
10c11d(12 args)   Exception                           (2, [...1, 16])
'1x'              Exception: invalid extra suffix 1x  Exception (preserved)
'20d' (12 args)   —                                   Exception: index 20 out of range (new, clearer)
```

All previously-valid single-digit suffixes, the empty suffix, and the invalid-leftover error path are preserved; only the multi-digit case is fixed.

(No GPU-built test could run on my machine; `python/test/unit/tools/test_aot.py` needs real kernel compilation. The parser is pure-Python and verified directly against `_match_suffix` as shown above.)