### PR TITLE
Fix interpreter storing i64 scalar args in a uint32 buffer

### DIFF
--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1258,11 +1258,13 @@ def _implicit_cvt(arg):
         return tl.tensor(handle, tl.int1)
     if isinstance(arg, int):
         ty = tl.str_to_ty(triton.runtime.jit.mangle_type(arg), None)
+        # The numpy storage dtype must match the triton scalar type `ty` chosen by
+        # mangle_type: ints in [-2**31, 2**31) are i32, [2**31, 2**63) are i64, and
+        # [2**63, 2**64) are u64. (Note there is no uint32 mangling: a value in
+        # [2**31, 2**32) is i64, so it must be stored as int64, not uint32.)
         dtype = np.int32
         if -2**31 <= arg < 2**31:
             dtype = np.int32
-        elif 2**31 <= arg < 2**32:
-            dtype = np.uint32
         elif -2**63 <= arg < 2**63:
             dtype = np.int64
         elif 2**63 <= arg < 2**64:


### PR DESCRIPTION
## Problem

In interpreter mode (`TRITON_INTERPRET=1`), `_implicit_cvt` (`python/triton/runtime/interpreter.py`) derives a Python `int`'s triton scalar type from `mangle_type`, then **independently** re-derives the numpy storage dtype with a separate if-ladder. The two disagree for ints in `[2**31, 2**32)`:

```python
ty = tl.str_to_ty(triton.runtime.jit.mangle_type(arg), None)   # -> i64 for arg in [2**31, 2**63)
dtype = np.int32
if -2**31 <= arg < 2**31:
    dtype = np.int32
elif 2**31 <= arg < 2**32:
    dtype = np.uint32        # <-- but ty is i64
elif -2**63 <= arg < 2**63:
    dtype = np.int64
...
```

There is **no uint32 mangling** in triton — `python/src/specialize.cc` emits only `i32`/`i64`/`u64`, and `i32` covers only `[-2**31, 2**31)` (line 281: `(val >= INT32_MIN && val <= INT32_MAX) ? i32_str : i64_str`). The Python reference `reference_specialize_impl` in `test/unit/runtime/test_specialize.py` agrees. So a value in `[2**31, 2**32)` is type `i64` but gets stored in a 4-byte `uint32` buffer.

The declared type (`primitive_bitwidth == 64`) and the actual storage (4 bytes) then disagree, corrupting width-sensitive operations:

```
arg          mangle  storage   bytes  declared
2147483648   i64     uint32    4      8        <-- mismatch (e.g. data.view(np.int64) fails: 4 bytes can't view as int64)
4294967295   i64     uint32    4      8        <-- mismatch
4294967296   i64     int64     8      8        ok
```

## Fix

Remove the spurious `uint32` branch so `[2**31, 2**63)` is stored as `int64`, matching the type `mangle_type` assigns:

```
after:  2147483648 -> int64 (8 bytes) ;  4294967295 -> int64 (8 bytes)  — all consistent
```

No existing test covered the `[2**31, 2**32)` interpreter scalar range, which is why this was latent. The patch only touches `interpreter.py`; the authoritative mangling in `specialize.cc` / `test_specialize.py` is unchanged and unaffected.

(My machine has no GPU/`libtriton` build, so I verified by reproducing the exact storage ladder against the authoritative mangle reference and showing the byte-width mismatch before / consistency after, as above.)