### PR TITLE
[NVIDIA][WS] Fix fallback retry bugs causing consumer duplication and perf regression on Hopper

### DIFF
--- a/python/test/unit/language/test_warp_specialization.py
+++ b/python/test/unit/language/test_warp_specialization.py
@@ -458,52 +458,6 @@ def test_warp_specialize_tma_matmul_persistent_consan(M, N, K, a_use_tma, b_use_
 
 
 @triton.jit
-def ws_descriptor_dot_chain_kernel(C, K, Out, M: tl.constexpr, N: tl.constexpr, D: tl.constexpr,
-                                   BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
-                                   WARP_SPECIALIZE: tl.constexpr):
-    pid_m = tl.program_id(0)
-    off_m = pid_m * BLOCK_M
-
-    c = C.load([off_m, 0])
-    acc = tl.zeros((BLOCK_M, D), tl.float32)
-    for start_n in tl.range(0, N, BLOCK_N, num_stages=2, warp_specialize=WARP_SPECIALIZE):
-        start_n = tl.multiple_of(start_n, BLOCK_N)
-        k = K.load([start_n, 0])
-        score = tl.dot(k, tl.trans(c), out_dtype=tl.float32)
-        ds = score.to(tl.bfloat16)
-        acc += tl.dot(tl.trans(ds), k, out_dtype=tl.float32)
-
-    Out.store([off_m, 0], acc)
-
-
-@pytest.mark.skipif(is_hip(), reason="warp specialization is not supported on hip devices")
-@pytest.mark.skipif(not is_hopper(), reason="Requires Hopper")
-def test_warp_specialize_descriptor_dot_chain_accum_count():
-    M, N, D = 256, 512, 128
-    BLOCK_M, BLOCK_N = 64, 64
-    torch.manual_seed(0)
-    c = torch.randn((M, D), device="cuda", dtype=torch.bfloat16) * 0.1
-    k = torch.randn((N, D), device="cuda", dtype=torch.bfloat16) * 0.1
-    out_ref = torch.empty((M, D), device="cuda", dtype=torch.float32)
-    out = torch.empty_like(out_ref)
-
-    c_desc = TensorDescriptor(c, shape=[M, D], strides=[D, 1], block_shape=[BLOCK_M, D])
-    k_desc = TensorDescriptor(k, shape=[N, D], strides=[D, 1], block_shape=[BLOCK_N, D])
-    out_ref_desc = TensorDescriptor(out_ref, shape=[M, D], strides=[D, 1], block_shape=[BLOCK_M, D])
-    out_desc = TensorDescriptor(out, shape=[M, D], strides=[D, 1], block_shape=[BLOCK_M, D])
-
-    grid = (triton.cdiv(M, BLOCK_M), )
-    ws_descriptor_dot_chain_kernel[grid](c_desc, k_desc, out_ref_desc, M, N, D, BLOCK_M, BLOCK_N, False,
-                                         num_warps=4, num_stages=2)
-    kernel = ws_descriptor_dot_chain_kernel[grid](c_desc, k_desc, out_desc, M, N, D, BLOCK_M, BLOCK_N, True,
-                                                 num_warps=4, num_stages=2)
-
-    assert "ttg.warp_specialize" in kernel.asm["ttgir"]
-    assert "ttng.async_tma_copy_global_to_local" in kernel.asm["ttgir"]
-    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=1e-1)
-
-
-@triton.jit
 def attention_inner_loop_kernel(  #
         desc_q, desc_k, desc_v,  #
         desc_acc, l_i_ptr, m_i_ptr,  #
@@ -572,8 +526,8 @@ def test_warp_specialize_attention_descriptor_fallback_cleanup():
     grid = (M // BLOCK_M, )
     attention_inner_loop_kernel[grid](desc_q, desc_k, desc_v, desc_acc_ref, l_i_ref, m_i_ref, M, N, 0.5, BLOCK_M,
                                       HEAD_DIM, False, num_stages=2, num_warps=4)
-    kernel = attention_inner_loop_kernel[grid](desc_q, desc_k, desc_v, desc_acc, l_i, m_i, M, N, 0.5, BLOCK_M,
-                                               HEAD_DIM, True, num_stages=2, num_warps=4)
+    kernel = attention_inner_loop_kernel[grid](desc_q, desc_k, desc_v, desc_acc, l_i, m_i, M, N, 0.5, BLOCK_M, HEAD_DIM,
+                                               True, num_stages=2, num_warps=4)
 
     assert "ttg.warp_specialize" in kernel.asm["ttgir"]
     assert "ttng.async_tma_copy_global_to_local" in kernel.asm["ttgir"]

--- a/python/test/unit/language/test_warp_specialization.py
+++ b/python/test/unit/language/test_warp_specialization.py
@@ -458,6 +458,52 @@ def test_warp_specialize_tma_matmul_persistent_consan(M, N, K, a_use_tma, b_use_
 
 
 @triton.jit
+def ws_descriptor_dot_chain_kernel(C, K, Out, M: tl.constexpr, N: tl.constexpr, D: tl.constexpr,
+                                   BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                                   WARP_SPECIALIZE: tl.constexpr):
+    pid_m = tl.program_id(0)
+    off_m = pid_m * BLOCK_M
+
+    c = C.load([off_m, 0])
+    acc = tl.zeros((BLOCK_M, D), tl.float32)
+    for start_n in tl.range(0, N, BLOCK_N, num_stages=2, warp_specialize=WARP_SPECIALIZE):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+        k = K.load([start_n, 0])
+        score = tl.dot(k, tl.trans(c), out_dtype=tl.float32)
+        ds = score.to(tl.bfloat16)
+        acc += tl.dot(tl.trans(ds), k, out_dtype=tl.float32)
+
+    Out.store([off_m, 0], acc)
+
+
+@pytest.mark.skipif(is_hip(), reason="warp specialization is not supported on hip devices")
+@pytest.mark.skipif(not is_hopper(), reason="Requires Hopper")
+def test_warp_specialize_descriptor_dot_chain_accum_count():
+    M, N, D = 256, 512, 128
+    BLOCK_M, BLOCK_N = 64, 64
+    torch.manual_seed(0)
+    c = torch.randn((M, D), device="cuda", dtype=torch.bfloat16) * 0.1
+    k = torch.randn((N, D), device="cuda", dtype=torch.bfloat16) * 0.1
+    out_ref = torch.empty((M, D), device="cuda", dtype=torch.float32)
+    out = torch.empty_like(out_ref)
+
+    c_desc = TensorDescriptor(c, shape=[M, D], strides=[D, 1], block_shape=[BLOCK_M, D])
+    k_desc = TensorDescriptor(k, shape=[N, D], strides=[D, 1], block_shape=[BLOCK_N, D])
+    out_ref_desc = TensorDescriptor(out_ref, shape=[M, D], strides=[D, 1], block_shape=[BLOCK_M, D])
+    out_desc = TensorDescriptor(out, shape=[M, D], strides=[D, 1], block_shape=[BLOCK_M, D])
+
+    grid = (triton.cdiv(M, BLOCK_M), )
+    ws_descriptor_dot_chain_kernel[grid](c_desc, k_desc, out_ref_desc, M, N, D, BLOCK_M, BLOCK_N, False,
+                                         num_warps=4, num_stages=2)
+    kernel = ws_descriptor_dot_chain_kernel[grid](c_desc, k_desc, out_desc, M, N, D, BLOCK_M, BLOCK_N, True,
+                                                 num_warps=4, num_stages=2)
+
+    assert "ttg.warp_specialize" in kernel.asm["ttgir"]
+    assert "ttng.async_tma_copy_global_to_local" in kernel.asm["ttgir"]
+    torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=1e-1)
+
+
+@triton.jit
 def attention_inner_loop_kernel(  #
         desc_q, desc_k, desc_v,  #
         desc_acc, l_i_ptr, m_i_ptr,  #
@@ -496,6 +542,44 @@ def attention_inner_loop_kernel(  #
     desc_acc.store([off_m, 0], acc.to(q.dtype))
     tl.store(l_i_ptr + off_m + tl.arange(0, BLOCK_M), l_i)
     tl.store(m_i_ptr + off_m + tl.arange(0, BLOCK_M), m_i)
+
+
+@pytest.mark.skipif(is_hip(), reason="warp specialization is not supported on hip devices")
+@pytest.mark.skipif(not is_hopper(), reason="Requires Hopper")
+def test_warp_specialize_attention_descriptor_fallback_cleanup():
+    M, N = 256, 256
+    BLOCK_M, HEAD_DIM = 64, 64
+
+    torch.manual_seed(42)
+    q = torch.randn((M, HEAD_DIM), device="cuda", dtype=torch.float16)
+    k = torch.randn((N, HEAD_DIM), device="cuda", dtype=torch.float16)
+    v = torch.randn((N, HEAD_DIM), device="cuda", dtype=torch.float16)
+
+    acc_ref = torch.empty((M, HEAD_DIM), dtype=torch.float16, device="cuda")
+    l_i_ref = torch.empty((M, ), dtype=torch.float16, device="cuda")
+    m_i_ref = torch.empty((M, ), dtype=torch.float16, device="cuda")
+    acc = torch.empty((M, HEAD_DIM), dtype=torch.float16, device="cuda")
+    l_i = torch.empty((M, ), dtype=torch.float16, device="cuda")
+    m_i = torch.empty((M, ), dtype=torch.float16, device="cuda")
+
+    desc_q = TensorDescriptor(q, shape=[M, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+    desc_k = TensorDescriptor(k, shape=[N, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+    desc_v = TensorDescriptor(v, shape=[N, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+    desc_acc_ref = TensorDescriptor(acc_ref, shape=[M, HEAD_DIM], strides=[HEAD_DIM, 1],
+                                    block_shape=[BLOCK_M, HEAD_DIM])
+    desc_acc = TensorDescriptor(acc, shape=[M, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
+
+    grid = (M // BLOCK_M, )
+    attention_inner_loop_kernel[grid](desc_q, desc_k, desc_v, desc_acc_ref, l_i_ref, m_i_ref, M, N, 0.5, BLOCK_M,
+                                      HEAD_DIM, False, num_stages=2, num_warps=4)
+    kernel = attention_inner_loop_kernel[grid](desc_q, desc_k, desc_v, desc_acc, l_i, m_i, M, N, 0.5, BLOCK_M,
+                                               HEAD_DIM, True, num_stages=2, num_warps=4)
+
+    assert "ttg.warp_specialize" in kernel.asm["ttgir"]
+    assert "ttng.async_tma_copy_global_to_local" in kernel.asm["ttgir"]
+    torch.testing.assert_close(acc.to(torch.float32), acc_ref.to(torch.float32), atol=0, rtol=0)
+    torch.testing.assert_close(l_i.to(torch.float32), l_i_ref.to(torch.float32), atol=0, rtol=0)
+    torch.testing.assert_close(m_i.to(torch.float32), m_i_ref.to(torch.float32), atol=0, rtol=0)
 
 
 @pytest.mark.parametrize("M, N", [(8192, 8192), (1024, 1024)])

--- a/test/Hopper/WarpSpecialization/ws_fallback_cleanup.mlir
+++ b/test/Hopper/WarpSpecialization/ws_fallback_cleanup.mlir
@@ -1,0 +1,97 @@
+// RUN: triton-opt %s --nvgpu-warp-specialization='dump-intermediate-steps=true num-stages=2' 2>&1 | FileCheck %s
+//
+// This regression covers two coupled bugs in the warp specialization retry path:
+// 1. A failed 3-warp-group attempt must clear the task ids it generated before
+//    retrying with 2 warp groups.
+// 2. After the retry collapses the consumer to a single task, code partitioning
+//    must still append the i64 accum-count bookkeeping used by buffer indexing.
+//
+// CHECK-LABEL: // -----// WarpSpec internal IR Dump After: doTaskPartition
+// CHECK: ttng.warp_group_dot {{.*}} {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32}
+// CHECK: tt.descriptor_store {{.*}} {async_task_id = array<i32: 1, 2>}
+//
+// CHECK-LABEL: // -----// WarpSpec internal IR Dump After: doTaskPartition
+// CHECK-NOT: async_task_id = array<i32: 1, 2>
+// CHECK: ttng.warp_group_dot {{.*}} {async_task_id = array<i32: 1>, inputPrecision = 0 : i32}
+// CHECK: tt.descriptor_store {{.*}} {async_task_id = array<i32: 1>}
+//
+// CHECK-LABEL: // -----// WarpSpec internal IR Dump After: doCodePartition
+// CHECK: partition0(
+// CHECK: scf.for {{.*}} iter_args({{.*}}%{{.*}} = %c0_i64) -> (
+// CHECK-SAME: i64
+// CHECK: arith.divui %{{.*}}, %{{.*}} : i64
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 64, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @attention_inner_loop_kernel(%arg0: !tt.tensordesc<64x64xf16, #shared>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<64x64xf16, #shared>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<64x64xf16, #shared>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: !tt.tensordesc<64x64xf16, #shared>, %arg16: i32, %arg17: i32, %arg18: i64, %arg19: i64, %arg20: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg21: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg22: i32 {tt.divisibility = 16 : i32}, %arg23: i32 {tt.divisibility = 16 : i32}, %arg24: f32) attributes {noinline = false} {
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma>
+    %cst_0 = arith.constant dense<0xFF800000> : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %cst_1 = arith.constant dense<1.000000e+00> : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c64_i32 : i32
+    %2 = tt.descriptor_load %arg0[%1, %c0_i32] : !tt.tensordesc<64x64xf16, #shared> -> tensor<64x64xf16, #blocked>
+    %3 = ttg.local_alloc %2 : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
+    %4 = tt.splat %arg24 : f32 -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    %5 = tt.splat %arg24 : f32 -> tensor<64x64xf32, #mma>
+    %6:3 = scf.for %arg25 = %c0_i32 to %arg23 step %c64_i32 iter_args(%arg26 = %cst_0, %arg27 = %cst_1, %arg28 = %cst) -> (tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>, tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>, tensor<64x64xf32, #mma>)  : i32 {
+      %20 = tt.descriptor_load %arg5[%arg25, %c0_i32] : !tt.tensordesc<64x64xf16, #shared> -> tensor<64x64xf16, #blocked>
+      %21 = ttg.local_alloc %20 : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
+      %22 = ttg.memdesc_trans %21 {order = array<i32: 1, 0>} : !ttg.memdesc<64x64xf16, #shared, #smem> -> !ttg.memdesc<64x64xf16, #shared1, #smem>
+      %23 = ttng.warp_group_dot %3, %22, %cst {inputPrecision = 0 : i32} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x64xf16, #shared1, #smem> -> tensor<64x64xf32, #mma>
+      %24 = "tt.reduce"(%23) <{axis = 1 : i32}> ({
+      ^bb0(%arg29: f32, %arg30: f32):
+        %45 = arith.maxnumf %arg29, %arg30 : f32
+        tt.reduce.return %45 : f32
+      }) : (tensor<64x64xf32, #mma>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+      %25 = arith.mulf %24, %4 : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+      %26 = arith.maxnumf %arg26, %25 : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+      %27 = arith.mulf %23, %5 : tensor<64x64xf32, #mma>
+      %28 = tt.expand_dims %26 {axis = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>> -> tensor<64x1xf32, #mma>
+      %29 = tt.broadcast %28 : tensor<64x1xf32, #mma> -> tensor<64x64xf32, #mma>
+      %30 = arith.subf %27, %29 : tensor<64x64xf32, #mma>
+      %31 = math.exp2 %30 : tensor<64x64xf32, #mma>
+      %32 = arith.subf %arg26, %26 : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+      %33 = math.exp2 %32 : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+      %34 = "tt.reduce"(%31) <{axis = 1 : i32}> ({
+      ^bb0(%arg29: f32, %arg30: f32):
+        %45 = arith.addf %arg29, %arg30 : f32
+        tt.reduce.return %45 : f32
+      }) : (tensor<64x64xf32, #mma>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+      %35 = tt.expand_dims %33 {axis = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>> -> tensor<64x1xf32, #mma>
+      %36 = tt.broadcast %35 : tensor<64x1xf32, #mma> -> tensor<64x64xf32, #mma>
+      %37 = arith.mulf %arg28, %36 : tensor<64x64xf32, #mma>
+      %38 = tt.descriptor_load %arg10[%arg25, %c0_i32] : !tt.tensordesc<64x64xf16, #shared> -> tensor<64x64xf16, #blocked>
+      %39 = ttg.local_alloc %38 : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem>
+      %40 = arith.truncf %31 : tensor<64x64xf32, #mma> to tensor<64x64xf16, #mma>
+      %41 = ttg.convert_layout %40 : tensor<64x64xf16, #mma> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+      %42 = ttng.warp_group_dot %41, %39, %37 {inputPrecision = 0 : i32} : tensor<64x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * !ttg.memdesc<64x64xf16, #shared, #smem> -> tensor<64x64xf32, #mma>
+      %43 = arith.mulf %arg27, %33 : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+      %44 = arith.addf %43, %34 : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+      scf.yield %26, %44, %42 : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>, tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>>, tensor<64x64xf32, #mma>
+    } {tt.num_stages = 2 : i32, tt.warp_specialize}
+    %7 = arith.truncf %6#2 : tensor<64x64xf32, #mma> to tensor<64x64xf16, #mma>
+    %8 = ttg.convert_layout %7 : tensor<64x64xf16, #mma> -> tensor<64x64xf16, #blocked>
+    tt.descriptor_store %arg15[%1, %c0_i32], %8 : !tt.tensordesc<64x64xf16, #shared>, tensor<64x64xf16, #blocked>
+    %9 = tt.addptr %arg20, %1 : !tt.ptr<f16>, i32
+    %10 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked1>
+    %11 = tt.splat %9 : !tt.ptr<f16> -> tensor<64x!tt.ptr<f16>, #blocked1>
+    %12 = tt.addptr %11, %10 : tensor<64x!tt.ptr<f16>, #blocked1>, tensor<64xi32, #blocked1>
+    %13 = arith.truncf %6#1 : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>> to tensor<64xf16, #ttg.slice<{dim = 1, parent = #mma}>>
+    %14 = ttg.convert_layout %13 : tensor<64xf16, #ttg.slice<{dim = 1, parent = #mma}>> -> tensor<64xf16, #blocked1>
+    tt.store %12, %14 : tensor<64x!tt.ptr<f16>, #blocked1>
+    %15 = tt.addptr %arg21, %1 : !tt.ptr<f16>, i32
+    %16 = tt.splat %15 : !tt.ptr<f16> -> tensor<64x!tt.ptr<f16>, #blocked1>
+    %17 = tt.addptr %16, %10 : tensor<64x!tt.ptr<f16>, #blocked1>, tensor<64xi32, #blocked1>
+    %18 = arith.truncf %6#0 : tensor<64xf32, #ttg.slice<{dim = 1, parent = #mma}>> to tensor<64xf16, #ttg.slice<{dim = 1, parent = #mma}>>
+    %19 = ttg.convert_layout %18 : tensor<64xf16, #ttg.slice<{dim = 1, parent = #mma}>> -> tensor<64xf16, #blocked1>
+    tt.store %17, %19 : tensor<64x!tt.ptr<f16>, #blocked1>
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -61,6 +61,17 @@ public:
     // FIXME: skip data partitioning with on-host TMA.
     bool success = false;
     for (; numWarpGroups >= 2; numWarpGroups--) {
+      bool ownsGeneratedAsyncTasks = true;
+      funcOp->walk([&](Operation *op) {
+        if (!getAsyncTaskIds(op).empty())
+          ownsGeneratedAsyncTasks = false;
+      });
+      auto clearGeneratedAsyncTasks = [&]() {
+        if (!ownsGeneratedAsyncTasks)
+          return;
+        funcOp->walk([](Operation *op) { removeAsyncTaskIds(op); });
+      };
+
       // Partition key ops into multiple async tasks.
       doTaskPartition(funcOp, numWarpGroups);
       if (dumpIntermediateSteps) {
@@ -70,8 +81,10 @@ public:
       }
       // Propagate taskId.
       int retCode = doTaskIdPropagate(funcOp);
-      if (retCode == -1)
+      if (retCode == -1) {
+        clearGeneratedAsyncTasks();
         continue;
+      }
       if (dumpIntermediateSteps) {
         ::mlir::triton::tools::mlirDumpsOrDbgs()
             << "// -----// WarpSpec internal IR Dump After: doTaskIdPropagate\n"
@@ -88,7 +101,7 @@ public:
         success = true;
         break;
       }
-      // Clear async_task.
+      clearGeneratedAsyncTasks();
     }
     if (!success) {
       mlir::emitError(

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -515,10 +515,6 @@ getTaskTopRegion(triton::FuncOp funcOp,
       Operation *op = &bodyOp;
       if (op->getNumRegions() <= 0)
         continue;
-      // If this op does not contain both a producer taskId and a consumer
-      // taskId, continue.
-      if (getAsyncTaskIds(op).size() == 1)
-        continue;
       if (isAsyncTaskTopOp(op))
         asyncTaskOps.push_back(op);
     }


### PR DESCRIPTION
# PR Description

- This PR fixes two coupled issues in Hopper warp specialization when a descriptor-based kernel first attempts 3WG and then retries with 2WG .

# Background

- Warp specialization first seeds producer/consumer task ids with `doTaskPartition()` .
- For descriptor kernels with a `64x64` consumer tile, the initial 3WG attempt seeds consumer ops with `async_task_id = {1, 2}`, but `doDataPartition()` cannot legally split that tile across two consumer warp groups: the retry would produce `32x32` slices, which violate the current partitioning thresholds (for example, sliceM >= 64 or sliceN >= 128). The pass therefore falls back to 2WG.
- Before this change, the retry path did not clear the task ids generated by the failed attempt.
- As a result, the second `doTaskPartition()` inherited stale {1,2} annotations instead of reseeding the consumer as {1} .
- After the retry path correctly clears the stale {1,2} annotations, the 2WG retry reseeds the consumer as a single task {1}. At that point, the enclosing `scf.for` may itself carry only one `async_task_id` even though its body still contains a producer/consumer channel: descriptor loads remain in producer task 0, while the loop result and yield belong to consumer task 1. The old `getTaskTopRegion()` filter rejected such loops with `if (getAsyncTaskIds(op).size() == 1) continue;`, but that predicate is not consistent with how task ids are propagated onto region ops. In `doTaskIdPropagate()`, an op with results derives its async_task_id from the result lattice, not from the union of task ids of all operations nested in its regions. As a result, a loop that structurally contains both producer and consumer work can still appear as a single-task op. When that loop is filtered out, `appendAccumCntsForOps()` never appends the i64 accum-count iter arg, and later code partitioning can read a tensor loop-carried value where it expects the integer accum-count used for buffer index and phase computation.

# Fix

- In `WarpSpecialization.cpp` , clear auto-generated async_task_id annotations before retrying only when the current pass invocation owns those annotations.
- In `WSCodePartition.cpp` , remove the `getAsyncTaskIds(op).size() == 1` filter from `getTaskTopRegion()` .
- This change keeps top-region selection based on channel containment rather than the async_task_id cardinality of the container op itself. The more accurate predicate is whether a producer/consumer channel has both endpoints nested under the same top-level region, which is exactly what `isAsyncTaskTopOp()` checks by walking each channel's source and destination up to their enclosing top-level ops. That criterion matches what `appendAccumCntsForOps()` actually needs: a region that contains channel traffic. In contrast, the number of task ids attached to the container op is only an attribute-level summary of that op and can diverge from the producer/consumer structure inside its regions.

# Why this is needed

- The retry cleanup fix prevents stale {1,2} consumer annotations from leaking from the failed 3WG attempt into the 2WG retry. Without that cleanup, the second doTaskPartition() sees pre-existing async_task_id annotations and does not reseed the retry as a single consumer task. The stale two-consumer shape then survives into later partitioning, which can materialize redundant consumer regions and duplicate the same dot/store work in both consumer partitions. In practice this shows up as repeated consumer computation and a substantial performance regression.
- The `getTaskTopRegion()` fix ensures that, after the retry collapses to a single consumer task, the loop still receives the i64 accum-count iter arg required by `getAccumCount()` .
- Without the second fix, descriptor WS can still fail later in code partitioning when arith.divui receives a tensor loop-carried value instead of the appended integer accum-count.

# Tests

- Added lit regression: `ws_fallback_cleanup.mlir`
  - Verifies the first `doTaskPartition()` seeds consumer ops with {1,2}
  - Verifies the retry reseeds them as {1} instead of preserving stale task ids
  - Verifies `doCodePartition()` appends an i64 accum-count and uses it in arith.divui
- Added Python regression: `test_warp_specialize_attention_descriptor_fallback_cleanup`
  - Exercises a descriptor attention-style Hopper kernel that takes the 3WG -> 2WG retry path
  - Verifies compilation succeeds under warp specialization and matches the non-WS reference
- Kept descriptor integration coverage: `test_warp_specialize_descriptor_dot_chain_accum_count`

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
