### PR TITLE
[BACKEND] Allow to lower a cluster_barrier within a warp_specialized region

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -89,6 +89,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::gpu::registerTritonGPUGlobalScratchAllocationPass();
   mlir::triton::gpu::registerCanonicalizeLLVMIR();
   mlir::triton::registerConvertWarpSpecializeToLLVM();
+  mlir::triton::registerInitializeWSClusterBarriers();
   mlir::triton::registerConvertTritonGPUToLLVMPass();
   mlir::triton::registerConvertNVGPUToLLVMPass();
   mlir::triton::registerAllocateSharedMemoryNvPass();

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -22,7 +22,8 @@ public:
   virtual void barrier(Location loc, RewriterBase &rewriter,
                        triton::gpu::AddrSpace targets) const = 0;
   // Emit a cluster-level barrier when supported. Defaults to CTA barrier.
-  virtual void clusterBarrier(Location loc, RewriterBase &rewriter) const = 0;
+  virtual void clusterBarrier(Location loc, RewriterBase &rewriter,
+                              Operation *sourceOp) const = 0;
   // Insert a warp syncronization barrier that also guarantees local address
   // space visibility at warp level when supported by the backend.
   // Backends that do not support warp-level barriers should conservatively

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -96,8 +96,9 @@ def TTNG_ClusterBarrierOp : TTNG_Op<"cluster_barrier", []> {
     Lowers to a cluster arrive/wait pair.
 
     In warp-specialized kernels, lowering wraps the barrier in a synthetic
-    `ttg.warp_specialize` region so worker warps also execute the barrier.
-    This op cannot be placed inside an existing `ttg.warp_specialize`.
+    `ttg.warp_specialize` region so worker warps also execute a barrier outside
+    existing warp-specialized code. A barrier inside `ttg.warp_specialize`
+    lowers through a cluster-scoped mbarrier.
   }];
   let assemblyFormat = "attr-dict";
   let hasVerifier = 1;

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h
@@ -1,0 +1,29 @@
+#ifndef TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_CLUSTERBARRIERMBARALLOCATOR_H_
+#define TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_CLUSTERBARRIERMBARALLOCATOR_H_
+
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+inline constexpr llvm::StringLiteral kClusterBarrierMbarOffsetAttrName =
+    "ttg.mbar_offset";
+inline constexpr llvm::StringLiteral kWSClusterBarrierCountAttrName =
+    "ttg.ws_cluster_barrier_count";
+
+inline void copyClusterBarrierMbarOffset(Operation *src, Operation *dst) {
+  if (Attribute attr = src->getAttr(kClusterBarrierMbarOffsetAttrName))
+    dst->setAttr(kClusterBarrierMbarOffsetAttrName, attr);
+}
+
+bool needsClusterBarrier(Operation *op);
+
+void runClusterBarrierMbarAllocator(ModuleOp mod);
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_CLUSTERBARRIERMBARALLOCATOR_H_

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -97,6 +97,15 @@ def TritonNvidiaGPUTMemBarrierInsertionPass : Pass<"triton-nvidia-gpu-tmem-barri
   ];
 }
 
+def TritonNvidiaGPUClusterBarrierMbarAllocatorPass : Pass<"triton-nvidia-gpu-cluster-barrier-mbar-allocator", "mlir::ModuleOp"> {
+  let summary = "Allocate mbarriers for warp-specialized cluster barriers";
+
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+}
+
 def TritonNvidiaGPUTMALoweringPass : Pass<"triton-nvidia-tma-lowering", "mlir::ModuleOp"> {
   let summary = "lower to TMA load/store operations";
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -110,7 +110,8 @@ struct ConvertLayoutOpConversion
   SmallVector<Value> transferSwizzlingLocalMemImpl(
       Location loc, ConversionPatternRewriter &rewriter,
       const LinearLayout &srcLayout, const LinearLayout &dstLayout,
-      ArrayRef<Value> inVals, Type llvmElemTy, Value smemBase) const {
+      ArrayRef<Value> inVals, Type llvmElemTy, Value smemBase,
+      Operation *sourceOp) const {
     auto *ctx = rewriter.getContext();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     // We handle transformations recursively as they all need a preprocessing
@@ -122,9 +123,9 @@ struct ConvertLayoutOpConversion
       auto newInVals = llvm::to_vector(llvm::map_range(inVals, [&](Value v) {
         return b.ptrtoint(llvmElemTyPtr, v).getResult();
       }));
-      auto outVals =
-          transferSwizzlingLocalMemImpl(loc, rewriter, srcLayout, dstLayout,
-                                        newInVals, llvmElemTyPtr, smemBase);
+      auto outVals = transferSwizzlingLocalMemImpl(
+          loc, rewriter, srcLayout, dstLayout, newInVals, llvmElemTyPtr,
+          smemBase, sourceOp);
       for (auto &v : outVals) {
         v = b.inttoptr(llvmElemTy, v);
       }
@@ -138,7 +139,8 @@ struct ConvertLayoutOpConversion
       auto newInVals = llvm::to_vector(llvm::map_range(
           inVals, [&](Value v) { return b.zext(i8ElemTy, v).getResult(); }));
       auto outVals = transferSwizzlingLocalMemImpl(
-          loc, rewriter, srcLayout, dstLayout, newInVals, i8ElemTy, smemBase);
+          loc, rewriter, srcLayout, dstLayout, newInVals, i8ElemTy, smemBase,
+          sourceOp);
       for (auto &v : outVals) {
         v = b.trunc(llvmElemTy, v);
       }
@@ -151,15 +153,17 @@ struct ConvertLayoutOpConversion
       auto prmtSrc = removeBroadcastSrc.apply(srcLayout);
       auto newInVals = removeBroadcastSrc.apply(inVals);
       return transferSwizzlingLocalMemImpl(loc, rewriter, prmtSrc, dstLayout,
-                                           newInVals, llvmElemTy, smemBase);
+                                           newInVals, llvmElemTy, smemBase,
+                                           sourceOp);
     }
 
     // Remove broadcasting in dst
     auto removeBroadcastDst = actionRemoveBroadcastedRegs(dstLayout);
     if (!removeBroadcastDst.isIdentity()) {
       auto prmtDst = removeBroadcastDst.apply(dstLayout);
-      auto outVals = transferSwizzlingLocalMemImpl(
-          loc, rewriter, srcLayout, prmtDst, inVals, llvmElemTy, smemBase);
+      auto outVals =
+          transferSwizzlingLocalMemImpl(loc, rewriter, srcLayout, prmtDst,
+                                        inVals, llvmElemTy, smemBase, sourceOp);
       return broadcastAs(outVals, dstLayout);
     }
 
@@ -219,7 +223,7 @@ struct ConvertLayoutOpConversion
       } else if (isBlockSync) {
         targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
       } else {
-        targetInfo.clusterBarrier(loc, rewriter);
+        targetInfo.clusterBarrier(loc, rewriter, sourceOp);
       }
     };
 
@@ -259,7 +263,7 @@ struct ConvertLayoutOpConversion
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
     auto inVals = unpackLLElements(loc, src, rewriter);
     auto outVals = transferSwizzlingLocalMemImpl(
-        loc, rewriter, srcLayout, dstLayout, inVals, llvmElemTy, smemBase);
+        loc, rewriter, srcLayout, dstLayout, inVals, llvmElemTy, smemBase, op);
 
     Value result =
         packLLElements(loc, getTypeConverter(), outVals, rewriter, dstTy);

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -13,6 +13,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/Support/MathExtras.h"
 
@@ -79,7 +80,7 @@ public:
 
       // Emit a barrier if we are reusing the shmem
       if (i > 0) {
-        sync(rewriter, loc, lastCvtCrossesCTAs);
+        sync(rewriter, loc, lastCvtCrossesCTAs, op);
       }
       accs = convertLayoutValues(loc, rewriter, op, regLl, tmpLl, accs);
       lastCvtCrossesCTAs = !mlir::isCvtDimSync(regLl, tmpLl, kBlock);
@@ -99,7 +100,7 @@ public:
       auto outputLayout = triton::gpu::toLinearLayout(resultTy);
       if (regLl != outputLayout) {
         // Reuse the shmem
-        sync(rewriter, loc, lastCvtCrossesCTAs);
+        sync(rewriter, loc, lastCvtCrossesCTAs, op);
         accs =
             convertLayoutValues(loc, rewriter, op, regLl, outputLayout, accs);
       }
@@ -163,10 +164,10 @@ private:
     return srcValues;
   }
 
-  void sync(ConversionPatternRewriter &rewriter, Location loc,
-            bool crossCTA) const {
+  void sync(ConversionPatternRewriter &rewriter, Location loc, bool crossCTA,
+            Operation *sourceOp) const {
     if (crossCTA) {
-      targetInfo.clusterBarrier(loc, rewriter);
+      targetInfo.clusterBarrier(loc, rewriter, sourceOp);
     } else {
       targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
     }
@@ -433,6 +434,7 @@ private:
               .getResult(0);
       auto cvt =
           triton::gpu::ConvertLayoutOp::create(rewriter, loc, dstTy, srcTensor);
+      triton::nvidia_gpu::copyClusterBarrierMbarOffset(op, cvt);
       cvt->setAttr("allocation.offset",
                    IntegerAttr::get(offsetTy, baseOffset + smemBaseOffsets[i]));
       Type packedDstTy = getTypeConverter()->convertType(dstTy);

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -332,9 +332,18 @@ LogicalResult ClusterBarrierOp::verify() {
   if (failed(verifyClusterIsMultiCTA(getOperation())))
     return failure();
   auto func = getOperation()->getParentOfType<FunctionOpInterface>();
-  if (!func || !triton::isKernel(func))
+  if (!func)
     return emitOpError("must be inside a kernel function");
-  return success();
+  if (triton::isKernel(func))
+    return success();
+  // Inlineable Triton helpers are verified before the inliner moves their
+  // bodies into the kernel.
+  if (auto tritonFunc = dyn_cast<triton::FuncOp>(func.getOperation())) {
+    auto noinline = tritonFunc->getAttrOfType<BoolAttr>("noinline");
+    if (!noinline || !noinline.getValue())
+      return success();
+  }
+  return emitOpError("must be inside a kernel function");
 }
 
 // -- TMA operation verifiers --

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -331,13 +331,9 @@ LogicalResult ClusterWaitOp::verify() {
 LogicalResult ClusterBarrierOp::verify() {
   if (failed(verifyClusterIsMultiCTA(getOperation())))
     return failure();
-  // A verifier cannot infer whether a noinline callee executes inside a
-  // warp-specialized caller, so conservatively reject all noinline functions.
-  if (auto func = getOperation()->getParentOfType<mlir::triton::FuncOp>()) {
-    auto noinline = func->getAttrOfType<BoolAttr>("noinline");
-    if (noinline && noinline.getValue())
-      return emitOpError("inside a non-inline function is not yet implemented");
-  }
+  auto func = getOperation()->getParentOfType<FunctionOpInterface>();
+  if (!func || !triton::isKernel(func))
+    return emitOpError("must be inside a kernel function");
   return success();
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -297,18 +297,21 @@ TypedValue<MemDescType> AsyncSharedStoreOp::getBarrier() {
   return getMbarrier();
 }
 
-// -- FenceMBarrierInitReleaseClusterOp --
-LogicalResult FenceMBarrierInitReleaseClusterOp::verify() {
-  int numCTAs = triton::gpu::lookupNumCTAs(getOperation());
-  if (numCTAs <= 1)
-    return emitOpError("requires ttg.num-ctas > 1");
-  return success();
-}
-
-static LogicalResult verifyClusterSyncOp(Operation *op) {
+static LogicalResult verifyClusterIsMultiCTA(Operation *op) {
   int numCTAs = triton::gpu::lookupNumCTAs(op);
   if (numCTAs <= 1)
     return op->emitOpError("requires ttg.num-ctas > 1");
+  return success();
+}
+
+// -- FenceMBarrierInitReleaseClusterOp --
+LogicalResult FenceMBarrierInitReleaseClusterOp::verify() {
+  return verifyClusterIsMultiCTA(getOperation());
+}
+
+static LogicalResult verifyClusterSyncOp(Operation *op) {
+  if (failed(verifyClusterIsMultiCTA(op)))
+    return failure();
   if (op->getParentOfType<mlir::triton::gpu::WarpSpecializeOp>())
     return op->emitOpError("cannot be used inside `ttg.warp_specialize`");
   return success();
@@ -326,7 +329,16 @@ LogicalResult ClusterWaitOp::verify() {
 
 // -- ClusterBarrierOp --
 LogicalResult ClusterBarrierOp::verify() {
-  return verifyClusterSyncOp(getOperation());
+  if (failed(verifyClusterIsMultiCTA(getOperation())))
+    return failure();
+  // A verifier cannot infer whether a noinline callee executes inside a
+  // warp-specialized caller, so conservatively reject all noinline functions.
+  if (auto func = getOperation()->getParentOfType<mlir::triton::FuncOp>()) {
+    auto noinline = func->getAttrOfType<BoolAttr>("noinline");
+    if (noinline && noinline.getValue())
+      return emitOpError("inside a non-inline function is not yet implemented");
+  }
+  return success();
 }
 
 // -- TMA operation verifiers --

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_triton_library(TritonNvidiaGPUTransforms
+  ClusterBarrierMbarAllocator.cpp
   ClusterBarrierInsertion.cpp
   CheckMatmulTwoCTAs.cpp
   ConSanNVIDIA.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.cpp
@@ -87,9 +87,11 @@ void runClusterBarrierMbarAllocator(ModuleOp mod) {
 
   if (regionOffsets.empty())
     mod->removeAttr(kWSClusterBarrierCountAttrName);
-  else
+  else {
     mod->setAttr(kWSClusterBarrierCountAttrName,
                  builder.getI32IntegerAttr(regionOffsets.size()));
+    mod->setAttr("ttg.shared", builder.getI32IntegerAttr(nextOffset));
+  }
 }
 
 } // namespace mlir::triton::nvidia_gpu

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.cpp
@@ -1,0 +1,95 @@
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/MathExtras.h"
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+#define GEN_PASS_DEF_TRITONNVIDIAGPUCLUSTERBARRIERMBARALLOCATORPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+
+namespace mlir::triton::nvidia_gpu {
+
+namespace {
+
+bool atomicNeedsClusterBarrier(Operation *op) {
+  if (!isa<AtomicCASOp, AtomicRMWOp>(op) || op->getResult(0).use_empty() ||
+      isa<RankedTensorType>(op->getResult(0).getType()))
+    return false;
+  return gpu::lookupNumCTAs(op) > 1;
+}
+
+struct ClusterBarrierMbarAllocatorPass
+    : public impl::TritonNvidiaGPUClusterBarrierMbarAllocatorPassBase<
+          ClusterBarrierMbarAllocatorPass> {
+  void runOnOperation() override {
+    runClusterBarrierMbarAllocator(getOperation());
+  }
+};
+
+} // namespace
+
+bool needsClusterBarrier(Operation *op) {
+  if (isa<ClusterBarrierOp>(op))
+    return true;
+  if (auto cvt = dyn_cast<gpu::ConvertLayoutOp>(op)) {
+    auto kBlock = StringAttr::get(op->getContext(), "block");
+    return !isCvtDimSync(gpu::toLinearLayout(cvt.getSrc().getType()),
+                         gpu::toLinearLayout(cvt.getType()), kBlock);
+  }
+  if (auto reduce = dyn_cast<ReduceOp>(op))
+    return !ReduceOpHelper(reduce).isReduceWithinCTA();
+  return atomicNeedsClusterBarrier(op);
+}
+
+void runClusterBarrierMbarAllocator(ModuleOp mod) {
+  auto funcs = mod.getOps<triton::FuncOp>();
+  auto kernelIt = llvm::find_if(
+      funcs, [](triton::FuncOp func) { return triton::isKernel(func); });
+  if (kernelIt == funcs.end())
+    return;
+  triton::FuncOp kernel = *kernelIt;
+
+  auto sharedAttr = mod->getAttrOfType<IntegerAttr>("ttg.shared");
+  int64_t shared = sharedAttr ? sharedAttr.getInt() : 0;
+  int64_t nextOffset = llvm::alignTo(shared, int64_t{8});
+  DenseMap<Region *, IntegerAttr> regionOffsets;
+  Builder builder(mod.getContext());
+
+  kernel.walk([&](Operation *op) {
+    if (!needsClusterBarrier(op))
+      return;
+    if (!op->getParentOfType<gpu::WarpSpecializeOp>())
+      return;
+    Region *region = op->getParentRegion();
+    while (!isa<gpu::WarpSpecializeOp, gpu::WarpSpecializePartitionsOp>(
+        region->getParentOp()))
+      region = region->getParentOp()->getParentRegion();
+
+    auto [it, inserted] = regionOffsets.try_emplace(region);
+    if (inserted) {
+      it->second = builder.getI32IntegerAttr(nextOffset);
+      nextOffset += 16;
+    }
+    op->setAttr(kClusterBarrierMbarOffsetAttrName, it->second);
+  });
+
+  if (regionOffsets.empty())
+    mod->removeAttr(kWSClusterBarrierCountAttrName);
+  else
+    mod->setAttr(kWSClusterBarrierCountAttrName,
+                 builder.getI32IntegerAttr(regionOffsets.size()));
+}
+
+} // namespace mlir::triton::nvidia_gpu

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -174,6 +174,81 @@ def test_convert_1d_to_2d_slice_cga(num_ctas, device):
     torch.testing.assert_close(out, torch.arange(head, device=device, dtype=torch.float32))
 
 
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires NVIDIA Hopper or newer")
+def test_cluster_barrier_in_warp_specialize(device):
+    BLOCK = ttgl.constexpr(128)
+
+    @gluon.jit
+    def partition(out, offset: ttgl.constexpr):
+        layout: ttgl.constexpr = ttgl.BlockedLayout([1], [32], [4], [0], cga_layout=[[0]])
+        offs = offset + ttgl.arange(0, BLOCK, layout=layout)
+        ttgl.barrier(cluster=True)
+        ttgl.store(out + offs, offs)
+
+    @gluon.jit
+    def kernel(out):
+        ttgl.warp_specialize([
+            (partition, (out, 0)),
+            (partition, (out, BLOCK)),
+        ], [4])
+
+    out = torch.empty((2 * BLOCK.value, ), device=device, dtype=torch.int32)
+    compiled = kernel[(1, )](out, num_warps=4, num_ctas=2)
+
+    ptx = compiled.asm["ptx"]
+    assert ptx.count("mbarrier.arrive.release.cluster.shared::cluster.b64") >= 2
+    assert "mapa" not in ptx
+    torch.testing.assert_close(out, torch.arange(2 * BLOCK.value, device=device, dtype=torch.int32))
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires NVIDIA Hopper or newer")
+@pytest.mark.parametrize("use_worker_partition", [False, True])
+def test_convert_layout_cross_cta_in_warp_specialize(use_worker_partition, device):
+    M = ttgl.constexpr(64)
+    N = ttgl.constexpr(128)
+    src_cga_layout = [[0, 1], [0, 2]]
+    dst_cga_layout = [[0, 1], [1, 0]]
+    src_layout = _with_cga_layout(_2d_layouts[0], src_cga_layout)
+    dst_layout = _with_cga_layout(_2d_layouts[1], dst_cga_layout)
+
+    @gluon.jit
+    def convert_partition(x_ptr, y_ptr, src_layout: ttgl.constexpr, dst_layout: ttgl.constexpr):
+        offs_m_src = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, src_layout))[:, None]
+        offs_n_src = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, src_layout))[None, :]
+        x = ttgl.load(x_ptr + offs_m_src * N + offs_n_src)
+        y = ttgl.convert_layout(x, layout=dst_layout)
+        offs_m_dst = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, dst_layout))[:, None]
+        offs_n_dst = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, dst_layout))[None, :]
+        ttgl.store(y_ptr + offs_m_dst * N + offs_n_dst, y)
+
+    @gluon.jit
+    def empty_partition():
+        pass
+
+    @gluon.jit
+    def kernel(x_ptr, y_ptr, src_layout: ttgl.constexpr, dst_layout: ttgl.constexpr,
+               use_worker_partition: ttgl.constexpr):
+        if use_worker_partition:
+            ttgl.warp_specialize([
+                (empty_partition, ()),
+                (convert_partition, (x_ptr, y_ptr, src_layout, dst_layout)),
+            ], [4])
+        else:
+            ttgl.warp_specialize([
+                (convert_partition, (x_ptr, y_ptr, src_layout, dst_layout)),
+                (empty_partition, ()),
+            ], [4])
+
+    torch.manual_seed(0)
+    x = torch.randn((M.value, N.value), dtype=torch.float16, device=device)
+    y = torch.zeros_like(x)
+    compiled = kernel[(1, )](x, y, src_layout, dst_layout, use_worker_partition, num_warps=4, num_ctas=4)
+
+    ptx = compiled.asm["ptx"]
+    assert "ld.shared::cluster" in ptx
+    torch.testing.assert_close(y, x, rtol=0, atol=0)
+
+
 def _swizzled_warp_layouts_1d():
     """1D DistributedLinearLayout test layouts (non-injective, lowered as GenericLinearEncoding)."""
 

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -21,6 +21,35 @@ def test_compile_only_sm100() -> None:
     assert k.asm["cubin"] != b""
 
 
+def test_compile_only_ws_cluster_barrier_shared_memory(tmp_path) -> None:
+    src = """
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @ws_cluster_barrier() {
+    %alloc = ttg.local_alloc : () -> !ttg.memdesc<5xi8, #shared, #ttg.shared_memory, mutable>
+    ttg.warp_specialize()
+    default {
+      ttng.cluster_barrier
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+"""
+    temp_file = tmp_path / "ws_cluster_barrier.ttgir"
+    temp_file.write_text(src)
+    k = triton.compile(str(temp_file), target=GPUTarget("cuda", 90, 32))
+    ptx = k.asm["ptx"]
+    assert "mbarrier.arrive.release.cluster.shared::cluster.b64" in ptx
+    assert "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64" in ptx
+    assert "mapa" not in ptx
+    assert k.metadata.shared == 24
+    assert k.asm["cubin"] != b""
+
+
 def test_compile_only_expect_zero() -> None:
 
     @triton.jit

--- a/test/Conversion/nvgpu_invalid.mlir
+++ b/test/Conversion/nvgpu_invalid.mlir
@@ -1,40 +1,6 @@
 // RUN: triton-opt -split-input-file %s -verify-diagnostics
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
-  llvm.func @cluster_barrier_in_default_region_invalid() {
-    ttg.warp_specialize()
-    default {
-      // expected-error @below {{cannot be used inside `ttg.warp_specialize`}}
-      ttng.cluster_barrier
-      ttg.warp_yield
-    }
-    partition0() num_warps(4) {
-      ttg.warp_return
-    } : () -> ()
-    llvm.return
-  }
-}
-
-// -----
-
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
-  llvm.func @cluster_barrier_in_partition_invalid() {
-    ttg.warp_specialize()
-    default {
-      ttg.warp_yield
-    }
-    partition0() num_warps(4) {
-      // expected-error @below {{cannot be used inside `ttg.warp_specialize`}}
-      ttng.cluster_barrier
-      ttg.warp_return
-    } : () -> ()
-    llvm.return
-  }
-}
-
-// -----
-
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   llvm.func @cluster_arrive_in_default_region_invalid() {
     ttg.warp_specialize()
     default {

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -1,6 +1,6 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm=compute-capability=90 -reconcile-unrealized-casts | FileCheck %s
-// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=85' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX85 %s
-// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=86' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX86 %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm=compute-capability=90 --initialize-ws-cluster-barriers=compute-capability=90 -reconcile-unrealized-casts | FileCheck %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=85' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=85' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX85 %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=86' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=86' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX86 %s
 
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -701,9 +701,38 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   tt.func @cluster_barrier_created_during_conversion(%arg0: !tt.ptr<i32>) {
     ttg.warp_specialize()
     default {
+      %c0_i32 = arith.constant 0 : i32
       %c1_i32 = arith.constant 1 : i32
-      %0 = tt.atomic_rmw add, acq_rel, gpu, %arg0, %c1_i32 {allocation.offset = 0 : i32} : (!tt.ptr<i32>, i32) -> i32
+      %0 = tt.atomic_cas acq_rel, gpu, %arg0, %c0_i32, %c1_i32 {allocation.offset = 0 : i32} : (!tt.ptr<i32>, i32, i32) -> i32
       tt.store %arg0, %0 : !tt.ptr<i32>
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#slice0 = #ttg.slice<{dim = 0, parent = #blockedSplitM}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 16384 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: ttg.ws_cluster_barrier_count = 1 : i32
+  // CHECK-LABEL: @cluster_barrier_created_within_reduce_lowering
+  // CHECK: mbarrier.init.shared::cta.b64
+  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
+  tt.func @cluster_barrier_created_within_reduce_lowering() {
+    ttg.warp_specialize()
+    default {
+      %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+      %red = "tt.reduce"(%cst) ({
+      ^bb0(%lhs: f16, %rhs: f16):
+        %add = arith.addf %lhs, %rhs : f16
+        tt.reduce.return %add : f16
+      }) {allocation.offset = 0 : i32, axis = 0 : i32} : (tensor<256x128xf16, #blockedSplitM>) -> tensor<128xf16, #slice0>
       ttg.warp_yield
     }
     partition0() num_warps(4) {

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -613,7 +613,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.tot
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: module attributes {
-  // CHECK-DAG: ttg.shared = 5 : i32
+  // CHECK-DAG: ttg.shared = 24 : i32
   // CHECK-DAG: ttg.ws_cluster_barrier_count = 1 : i32
   // CHECK-LABEL: @cluster_barrier_inside_warp_specialize
   // CHECK: "@$0 mbarrier.init.shared::cta.b64 [$1], 1;"
@@ -668,7 +668,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK: module attributes {
-  // CHECK-DAG: ttg.shared = 5 : i32
+  // CHECK-DAG: ttg.shared = 40 : i32
   // CHECK-DAG: ttg.ws_cluster_barrier_count = 2 : i32
   // CHECK-LABEL: @cluster_barrier_inside_warp_specialize_reuses_slots
   // CHECK-COUNT-2: mbarrier.init.shared::cta.b64

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -1,4 +1,6 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm=compute-capability=90 -reconcile-unrealized-casts | FileCheck %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=85' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX85 %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=86' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX86 %s
 
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -604,6 +606,110 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.tot
     // CHECK-NEXT: ttg.warp_return
     ttng.cluster_arrive {relaxed = true}
     llvm.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: module attributes {
+  // CHECK-DAG: ttg.shared = 5 : i32
+  // CHECK-DAG: ttg.ws_cluster_barrier_count = 1 : i32
+  // CHECK-LABEL: @cluster_barrier_inside_warp_specialize
+  // CHECK: "@$0 mbarrier.init.shared::cta.b64 [$1], 1;"
+  // CHECK: fence.mbarrier_init.release.cluster
+  // CHECK: nvvm.cluster.arrive.relaxed
+  // CHECK-NEXT: nvvm.cluster.wait
+  tt.func @cluster_barrier_inside_warp_specialize() {
+    ttg.warp_specialize()
+    default {
+      // CHECK: nvvm.barrier0
+      // CHECK: %[[PARITY:.*]] = llvm.load
+      // CHECK: %[[BARRIER_INT:.*]] = llvm.ptrtoint
+      // CHECK: %[[PEER_BARRIER_INT:.*]] = llvm.xor %[[BARRIER_INT]],
+      // CHECK: llvm.inttoptr %[[PEER_BARRIER_INT]]
+      // CHECK-NOT: mapa
+      // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
+      // CHECK: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+      // CHECK: llvm.xor %[[PARITY]],
+      // CHECK: st.shared::cta.b32
+      // CHECK: nvvm.barrier0
+      ttng.cluster_barrier
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 0 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // PTX85-LABEL: @relaxed_cluster_barrier_inside_warp_specialize
+  // PTX85: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // PTX86-LABEL: @relaxed_cluster_barrier_inside_warp_specialize
+  // PTX86: mbarrier.arrive.relaxed.cluster.shared::cluster.b64
+  tt.func @relaxed_cluster_barrier_inside_warp_specialize() {
+    ttg.warp_specialize()
+    default {
+      ttng.cluster_barrier {relaxed = true}
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: module attributes {
+  // CHECK-DAG: ttg.shared = 5 : i32
+  // CHECK-DAG: ttg.ws_cluster_barrier_count = 2 : i32
+  // CHECK-LABEL: @cluster_barrier_inside_warp_specialize_reuses_slots
+  // CHECK-COUNT-2: mbarrier.init.shared::cta.b64
+  // CHECK-COUNT-1: fence.mbarrier_init.release.cluster
+  // CHECK-COUNT-1: nvvm.cluster.arrive.relaxed
+  // CHECK-COUNT-3: mbarrier.arrive.release.cluster.shared::cluster.b64
+  tt.func @cluster_barrier_inside_warp_specialize_reuses_slots() {
+    ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 4>}
+    default {
+      ttng.cluster_barrier
+      ttng.cluster_barrier
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttng.cluster_barrier
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: ttg.ws_cluster_barrier_count = 1 : i32
+  // CHECK-LABEL: @cluster_barrier_created_during_conversion
+  // CHECK: llvm.mlir.constant(8 : i32)
+  // CHECK: mbarrier.init.shared::cta.b64
+  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
+  tt.func @cluster_barrier_created_during_conversion(%arg0: !tt.ptr<i32>) {
+    ttg.warp_specialize()
+    default {
+      %c1_i32 = arith.constant 1 : i32
+      %0 = tt.atomic_rmw add, acq_rel, gpu, %arg0, %c1_i32 {allocation.offset = 0 : i32} : (!tt.ptr<i32>, i32) -> i32
+      tt.store %arg0, %0 : !tt.ptr<i32>
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
   }
 }
 

--- a/test/TritonNvidiaGPU/cluster-barrier-mbar-allocator.mlir
+++ b/test/TritonNvidiaGPU/cluster-barrier-mbar-allocator.mlir
@@ -1,0 +1,39 @@
+// RUN: triton-opt %s --triton-nvidia-gpu-cluster-barrier-mbar-allocator | FileCheck %s
+
+#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#blockedSplitN = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#slice0 = #ttg.slice<{dim = 0, parent = #blockedSplitM}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: module attributes {
+  // CHECK-DAG: ttg.shared = 40 : i32
+  // CHECK-DAG: ttg.ws_cluster_barrier_count = 2 : i32
+  // CHECK-LABEL: @cluster_barrier_mbar_allocator
+  tt.func @cluster_barrier_mbar_allocator(%ptr: !tt.ptr<i32>) {
+    ttg.warp_specialize()
+    default {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+      // CHECK: ttg.convert_layout {{.*}} {ttg.mbar_offset = 8 : i32}
+      %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedSplitM> -> tensor<256x128xf16, #blockedSplitN>
+      // CHECK: "tt.reduce"
+      // CHECK: }) {ttg.mbar_offset = 8 : i32}
+      %red = "tt.reduce"(%cst) ({
+      ^bb0(%lhs: f16, %rhs: f16):
+        %add = arith.addf %lhs, %rhs : f16
+        tt.reduce.return %add : f16
+      }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedSplitM>) -> tensor<128xf16, #slice0>
+      // CHECK: tt.atomic_cas {{.*}} {ttg.mbar_offset = 8 : i32}
+      %cas = tt.atomic_cas acq_rel, gpu, %ptr, %c0, %c1 : (!tt.ptr<i32>, i32, i32) -> i32
+      tt.store %ptr, %cas : !tt.ptr<i32>
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      // CHECK: ttng.cluster_barrier {ttg.mbar_offset = 24 : i32}
+      ttng.cluster_barrier
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -504,8 +504,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // -----
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-  tt.func @cluster_barrier_in_noinline_function_invalid() attributes {noinline = true} {
-    // expected-error @below {{inside a non-inline function is not yet implemented}}
+  tt.func public @cluster_barrier_in_noinline_kernel_valid() attributes {noinline = true} {
+    ttng.cluster_barrier
+    tt.return
+  }
+
+  tt.func private @cluster_barrier_in_non_kernel_function_invalid() {
+    // expected-error @below {{must be inside a kernel function}}
     ttng.cluster_barrier
     tt.return
   }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -504,33 +504,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // -----
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-  tt.func @cluster_barrier_in_default_region_invalid() {
-    ttg.warp_specialize()
-    default {
-      // expected-error @below {{cannot be used inside `ttg.warp_specialize`}}
-      ttng.cluster_barrier
-      ttg.warp_yield
-    }
-    partition0() num_warps(4) {
-      ttg.warp_return
-    } : () -> ()
-    tt.return
-  }
-}
-
-// -----
-
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
-  tt.func @cluster_barrier_in_partition_invalid() {
-    ttg.warp_specialize()
-    default {
-      ttg.warp_yield
-    }
-    partition0() num_warps(4) {
-      // expected-error @below {{cannot be used inside `ttg.warp_specialize`}}
-      ttng.cluster_barrier
-      ttg.warp_return
-    } : () -> ()
+  tt.func @cluster_barrier_in_noinline_function_invalid() attributes {noinline = true} {
+    // expected-error @below {{inside a non-inline function is not yet implemented}}
+    ttng.cluster_barrier
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -509,7 +509,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 
-  tt.func private @cluster_barrier_in_non_kernel_function_invalid() {
+  tt.func private @cluster_barrier_in_non_kernel_function_invalid() attributes {noinline = true} {
     // expected-error @below {{must be inside a kernel function}}
     ttng.cluster_barrier
     tt.return

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -1,5 +1,4 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory -test-print-membar | FileCheck --dump-input=fail --dump-input-context=30 %s
-// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-cluster-barrier-mbar-allocator | FileCheck --check-prefix=ALLOC %s
 
 // -----
 
@@ -20,46 +19,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.local_store %cvt, %buf : tensor<256x128xf16, #blockedSplitN> -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
     %ld = ttg.local_load %buf : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #blockedSplitM>
     tt.return %ld : tensor<256x128xf16, #blockedSplitM>
-  }
-}
-
-// -----
-
-#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
-#blockedSplitN = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
-#slice0 = #ttg.slice<{dim = 0, parent = #blockedSplitM}>
-
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  // ALLOC: module attributes {
-  // ALLOC-DAG: ttg.shared = 40 : i32
-  // ALLOC-DAG: ttg.ws_cluster_barrier_count = 2 : i32
-  // ALLOC-LABEL: @cluster_barrier_mbar_allocator
-  tt.func @cluster_barrier_mbar_allocator(%ptr: !tt.ptr<i32>) {
-    ttg.warp_specialize()
-    default {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
-      // ALLOC: ttg.convert_layout {{.*}} {ttg.mbar_offset = 8 : i32}
-      %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedSplitM> -> tensor<256x128xf16, #blockedSplitN>
-      // ALLOC: "tt.reduce"
-      // ALLOC: }) {ttg.mbar_offset = 8 : i32}
-      %red = "tt.reduce"(%cst) ({
-      ^bb0(%lhs: f16, %rhs: f16):
-        %add = arith.addf %lhs, %rhs : f16
-        tt.reduce.return %add : f16
-      }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedSplitM>) -> tensor<128xf16, #slice0>
-      // ALLOC: tt.atomic_cas {{.*}} {ttg.mbar_offset = 8 : i32}
-      %cas = tt.atomic_cas acq_rel, gpu, %ptr, %c0, %c1 : (!tt.ptr<i32>, i32, i32) -> i32
-      tt.store %ptr, %cas : !tt.ptr<i32>
-      ttg.warp_yield
-    }
-    partition0() num_warps(4) {
-      // ALLOC: ttng.cluster_barrier {ttg.mbar_offset = 24 : i32}
-      ttng.cluster_barrier
-      ttg.warp_return
-    } : () -> ()
-    tt.return
   }
 }
 

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory -test-print-membar | FileCheck --dump-input=fail --dump-input-context=30 %s
+// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-cluster-barrier-mbar-allocator | FileCheck --check-prefix=ALLOC %s
 
 // -----
 
@@ -19,6 +20,46 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttg.local_store %cvt, %buf : tensor<256x128xf16, #blockedSplitN> -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
     %ld = ttg.local_load %buf : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #blockedSplitM>
     tt.return %ld : tensor<256x128xf16, #blockedSplitM>
+  }
+}
+
+// -----
+
+#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#blockedSplitN = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#slice0 = #ttg.slice<{dim = 0, parent = #blockedSplitM}>
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // ALLOC: module attributes {
+  // ALLOC-DAG: ttg.shared = 5 : i32
+  // ALLOC-DAG: ttg.ws_cluster_barrier_count = 2 : i32
+  // ALLOC-LABEL: @cluster_barrier_mbar_allocator
+  tt.func @cluster_barrier_mbar_allocator(%ptr: !tt.ptr<i32>) {
+    ttg.warp_specialize()
+    default {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+      // ALLOC: ttg.convert_layout {{.*}} {ttg.mbar_offset = 8 : i32}
+      %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedSplitM> -> tensor<256x128xf16, #blockedSplitN>
+      // ALLOC: "tt.reduce"
+      // ALLOC: }) {ttg.mbar_offset = 8 : i32}
+      %red = "tt.reduce"(%cst) ({
+      ^bb0(%lhs: f16, %rhs: f16):
+        %add = arith.addf %lhs, %rhs : f16
+        tt.reduce.return %add : f16
+      }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedSplitM>) -> tensor<128xf16, #slice0>
+      // ALLOC: tt.atomic_cas {{.*}} {ttg.mbar_offset = 8 : i32}
+      %cas = tt.atomic_cas acq_rel, gpu, %ptr, %c0, %c1 : (!tt.ptr<i32>, i32, i32) -> i32
+      tt.store %ptr, %cas : !tt.ptr<i32>
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      // ALLOC: ttng.cluster_barrier {ttg.mbar_offset = 24 : i32}
+      ttng.cluster_barrier
+      ttg.warp_return
+    } : () -> ()
+    tt.return
   }
 }
 

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -31,7 +31,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 5 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // ALLOC: module attributes {
-  // ALLOC-DAG: ttg.shared = 5 : i32
+  // ALLOC-DAG: ttg.shared = 40 : i32
   // ALLOC-DAG: ttg.ws_cluster_barrier_count = 2 : i32
   // ALLOC-LABEL: @cluster_barrier_mbar_allocator
   tt.func @cluster_barrier_mbar_allocator(%ptr: !tt.ptr<i32>) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -171,7 +171,8 @@ void TargetInfo::barrier(Location loc, RewriterBase &rewriter,
   b.barrier(targets);
 }
 
-void TargetInfo::clusterBarrier(Location loc, RewriterBase &rewriter) const {
+void TargetInfo::clusterBarrier(Location loc, RewriterBase &rewriter,
+                                Operation * /*sourceOp*/) const {
   triton::amdgpu::ClusterBarrierArriveOp::create(rewriter, loc);
   triton::amdgpu::ClusterBarrierWaitOp::create(rewriter, loc);
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -39,7 +39,8 @@ public:
 
   void barrier(Location loc, RewriterBase &rewriter,
                triton::gpu::AddrSpace targets) const override;
-  void clusterBarrier(Location loc, RewriterBase &rewriter) const override;
+  void clusterBarrier(Location loc, RewriterBase &rewriter,
+                      Operation *sourceOp) const override;
 
   void warpSync(Location loc, RewriterBase &rewriter) const override;
 

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -451,7 +451,10 @@ class CUDABackend(BaseBackend):
         total_num_warps = src.get_int_attr("ttg.total-num-warps")
         if total_num_warps is not None:
             metadata["num_warps"] = total_num_warps
-        metadata["shared"] = src.get_int_attr("ttg.shared")
+        align_as = lambda x, a: (x + a - 1) // a * a
+        shared = src.get_int_attr("ttg.shared")
+        ws_cluster_barriers = src.get_int_attr("ttg.ws_cluster_barrier_count") or 0
+        metadata["shared"] = align_as(shared, 8) + 16 * ws_cluster_barriers if ws_cluster_barriers else shared
         metadata["tmem_size"] = src.get_int_attr("ttg.tensor_memory_size")
         metadata["global_scratch_size"] = src.get_int_attr("ttg.global_scratch_memory_size") or 0
         metadata["global_scratch_align"] = src.get_int_attr("ttg.global_scratch_memory_alignment") or 1

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -390,6 +390,7 @@ class CUDABackend(BaseBackend):
         nvidia.passes.ttnvgpuir.add_proxy_fence_insertion(pm, capability)
         nvidia.passes.ttnvgpuir.add_tmem_barrier_insertion(pm)
         nvidia.passes.ttgpuir.add_to_llvmir(pm, capability, ptx_version, "consan" in options.instrumentation_mode)
+        nvidia.passes.ttnvgpuir.add_initialize_ws_cluster_barriers(pm, capability, ptx_version)
         passes.ttgpuir.add_canonicalize_llvm_ir(pm)
         passes.common.add_cse(pm)
         nvidia.passes.ttnvgpuir.add_warp_specialize_to_llvm(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -452,10 +452,7 @@ class CUDABackend(BaseBackend):
         total_num_warps = src.get_int_attr("ttg.total-num-warps")
         if total_num_warps is not None:
             metadata["num_warps"] = total_num_warps
-        align_as = lambda x, a: (x + a - 1) // a * a
-        shared = src.get_int_attr("ttg.shared")
-        ws_cluster_barriers = src.get_int_attr("ttg.ws_cluster_barrier_count") or 0
-        metadata["shared"] = align_as(shared, 8) + 16 * ws_cluster_barriers if ws_cluster_barriers else shared
+        metadata["shared"] = src.get_int_attr("ttg.shared")
         metadata["tmem_size"] = src.get_int_attr("ttg.tensor_memory_size")
         metadata["global_scratch_size"] = src.get_int_attr("ttg.global_scratch_memory_size") or 0
         metadata["global_scratch_align"] = src.get_int_attr("ttg.global_scratch_memory_alignment") or 1

--- a/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Passes.td
+++ b/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Passes.td
@@ -33,6 +33,24 @@ def ConvertTritonGPUToLLVM : Pass<"convert-triton-gpu-to-llvm", "mlir::ModuleOp"
                "run ConSan after fence and membar preparation">,
     ];
 }
+
+def InitializeWSClusterBarriers : Pass<"initialize-ws-cluster-barriers", "mlir::ModuleOp"> {
+    let summary = "Initialize warp-specialized cluster barrier mbarriers";
+
+    let dependentDialects = ["mlir::LLVM::LLVMDialect",
+                             "mlir::NVVM::NVVMDialect",
+                             "mlir::triton::gpu::TritonGPUDialect"];
+
+    let options = [
+        Option<"computeCapability", "compute-capability",
+               "int32_t", /*default*/"80",
+               "device compute capability">,
+        Option<"ptxVersion", "ptx-version",
+               "int32_t", /*default*/"80",
+               "PTX version">,
+    ];
+}
+
 def AllocateSharedMemoryNv : Pass<"allocate-shared-memory-nv", "mlir::ModuleOp"> {
   let summary = "Add metadata for shared memory allocation for Nvidia";
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -38,6 +38,14 @@ using namespace mlir::triton;
 
 namespace ttg = mlir::triton::gpu;
 
+void mlir::triton::NVIDIA::createFenceMBarrierInitReleaseCluster(
+    OpBuilder &builder, Location loc, Value pred) {
+  PTXBuilder ptxBuilder;
+  auto &fence = *ptxBuilder.create("fence.mbarrier_init.release.cluster");
+  fence().predicate(pred);
+  ptxBuilder.launch(builder, loc, void_ty(builder.getContext()));
+}
+
 namespace {
 Value getElectWarp0OrThread0(const NVIDIA::TargetInfo &targetInfo,
                              TritonLLVMOpBuilder &b) {
@@ -85,11 +93,7 @@ struct FenceMBarrierInitReleaseClusterOpConversion
     Value tid = getThreadId(rewriter, loc);
     Value pred = b.icmp_eq(tid, b.i32_val(0));
 
-    PTXBuilder ptxBuilder;
-    auto &fence = *ptxBuilder.create("fence.mbarrier_init.release.cluster");
-    fence().predicate(pred);
-    auto voidTy = void_ty(op->getContext());
-    ptxBuilder.launch(rewriter, loc, voidTy);
+    NVIDIA::createFenceMBarrierInitReleaseCluster(rewriter, loc, pred);
 
     rewriter.eraseOp(op);
     return success();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -31,7 +31,6 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h"
-#include "llvm/Support/MathExtras.h"
 
 #include <type_traits>
 
@@ -271,8 +270,8 @@ struct InitializeWSClusterBarriers
     Value initPred = b.icmp_eq(tid, b.i32_val(0));
     auto sharedAttr = mod->getAttrOfType<IntegerAttr>("ttg.shared");
     int64_t shared = sharedAttr ? sharedAttr.getInt() : 0;
-    int64_t offset = llvm::alignTo(shared, int64_t{8});
     int64_t count = countAttr.getInt();
+    int64_t offset = shared - count * 16;
     int numCTAs = triton::gpu::lookupNumCTAs(kernel);
     for (int64_t i = 0; i < count; ++i, offset += 16) {
       Value barrierPtr =

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -188,23 +188,12 @@ void mlir::triton::NVIDIA::populateClusterOpsToLLVMPatterns(
 LogicalResult mlir::triton::NVIDIA::lowerWarpSpecializedClusterBarriers(
     ModuleOp mod, const NVIDIA::TargetInfo &targetInfo) {
   Builder builder(mod.getContext());
-  LLVM::LLVMFuncOp kernel;
-  for (LLVM::LLVMFuncOp func : mod.getOps<LLVM::LLVMFuncOp>()) {
-    if (triton::isKernel(func)) {
-      kernel = func;
-      continue;
-    }
-    WalkResult result = func.walk([&](triton::nvidia_gpu::ClusterBarrierOp op) {
-      op.emitError("cluster_barrier inside a non-inline function is not "
-                   "supported");
-      return WalkResult::interrupt();
-    });
-    if (result.wasInterrupted())
-      return failure();
-  }
-
-  if (!kernel)
+  auto funcs = mod.getOps<LLVM::LLVMFuncOp>();
+  auto kernelIt = llvm::find_if(
+      funcs, [](LLVM::LLVMFuncOp func) { return triton::isKernel(func); });
+  if (kernelIt == funcs.end())
     return success();
+  LLVM::LLVMFuncOp kernel = *kernelIt;
 
   SmallVector<triton::nvidia_gpu::ClusterBarrierOp> barriers;
   kernel.walk(

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -23,16 +23,22 @@
 
 #include "PatternTritonGPUOpToLLVM.h"
 #include "TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
+#include "TritonNVIDIAGPUToLLVM/Passes.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
-#include "llvm/ADT/DenseMap.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h"
 #include "llvm/Support/MathExtras.h"
 
 #include <type_traits>
+
+namespace mlir::triton {
+#define GEN_PASS_DEF_INITIALIZEWSCLUSTERBARRIERS
+#include "TritonNVIDIAGPUToLLVM/Passes.h.inc"
+} // namespace mlir::triton
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -90,13 +96,14 @@ static void createMBarrierWait(OpBuilder &b, Location loc, Value barrierPtr,
   ptxBuilder.launch(b, loc, void_ty(b.getContext()));
 }
 
-static Value getWSRegionThread0Predicate(OpBuilder &rewriter, Location loc) {
+static Value getClusterBarrierMbarPtr(Location loc, RewriterBase &rewriter,
+                                      FunctionOpInterface func, int64_t offset,
+                                      const NVIDIA::TargetInfo &targetInfo) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-  // This runs after GPU and arith conversion, so emit only NVVM/LLVM ops.
-  Value tid = NVVM::ThreadIdXOp::create(rewriter, loc, i32_ty);
-  int startThreadId =
-      getWarpGroupStartThreadId(rewriter.getInsertionBlock()).value_or(0);
-  return b.icmp_eq(tid, b.i32_val(startThreadId));
+  auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext(),
+                                          targetInfo.getSharedAddressSpace());
+  return b.gep(ptrTy, i8_ty, LLVM::getStackPointer(rewriter, func),
+               b.i32_val(offset));
 }
 
 template <typename EmitFn>
@@ -173,89 +180,49 @@ struct ClusterSyncOpConversion : public ConvertOpToLLVMPattern<Op> {
     return success();
   }
 };
-} // namespace
 
-void mlir::triton::NVIDIA::populateClusterOpsToLLVMPatterns(
-    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
-    PatternBenefit benefit) {
-  patterns.add<ClusterSyncOpConversion<triton::nvidia_gpu::ClusterArriveOp>,
-               ClusterSyncOpConversion<triton::nvidia_gpu::ClusterWaitOp>,
-               ClusterSyncOpConversion<triton::nvidia_gpu::ClusterBarrierOp>>(
-      typeConverter, benefit);
-  return;
-}
+struct ClusterBarrierOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::ClusterBarrierOp> {
+  ClusterBarrierOpConversion(LLVMTypeConverter &typeConverter,
+                             PatternBenefit benefit,
+                             const NVIDIA::TargetInfo &targetInfo)
+      : ConvertOpToLLVMPattern(typeConverter, benefit), targetInfo(targetInfo) {
+  }
 
-LogicalResult mlir::triton::NVIDIA::lowerWarpSpecializedClusterBarriers(
-    ModuleOp mod, const NVIDIA::TargetInfo &targetInfo) {
-  Builder builder(mod.getContext());
-  auto funcs = mod.getOps<LLVM::LLVMFuncOp>();
-  auto kernelIt = llvm::find_if(
-      funcs, [](LLVM::LLVMFuncOp func) { return triton::isKernel(func); });
-  if (kernelIt == funcs.end())
-    return success();
-  LLVM::LLVMFuncOp kernel = *kernelIt;
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::ClusterBarrierOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto mbarOffset = op->getAttrOfType<IntegerAttr>(
+        triton::nvidia_gpu::kClusterBarrierMbarOffsetAttrName);
+    if (!mbarOffset) {
+      auto mod = op->getParentOfType<ModuleOp>();
+      int defaultNumWarps = triton::gpu::lookupNumWarps(op);
+      int totalNumWarps = defaultNumWarps;
+      if (auto attr = mod->getAttrOfType<IntegerAttr>("ttg.total-num-warps"))
+        totalNumWarps = attr.getInt();
 
-  SmallVector<triton::nvidia_gpu::ClusterBarrierOp> barriers;
-  kernel.walk(
-      [&](triton::nvidia_gpu::ClusterBarrierOp op) { barriers.push_back(op); });
-  if (barriers.empty())
-    return success();
-  int64_t shared = mod->getAttrOfType<IntegerAttr>("ttg.shared").getInt();
-
-  DenseMap<unsigned, IntegerAttr> regionOffsets;
-  SmallVector<triton::nvidia_gpu::ClusterBarrierOp> initBarriers;
-  for (triton::nvidia_gpu::ClusterBarrierOp op : barriers) {
-    // Regions executed by the same warp group share a barrier.
-    unsigned regionId = getWarpGroupStartWarpId(op->getBlock()).value_or(0);
-
-    auto [offsetIt, inserted] = regionOffsets.try_emplace(regionId);
-    if (inserted) {
-      int64_t offset = llvm::alignTo(shared, int64_t{8}) +
-                       int64_t(regionOffsets.size() - 1) * 16;
-      offsetIt->second = builder.getI32IntegerAttr(offset);
-      initBarriers.push_back(op);
+      rewriter.setInsertionPoint(op);
+      lowerClusterSyncForAllWarps(op.getLoc(), rewriter, defaultNumWarps,
+                                  totalNumWarps, [&](OpBuilder &b) {
+                                    createClusterArrive(b, op.getLoc(),
+                                                        op.getRelaxed());
+                                    createClusterWait(b, op.getLoc());
+                                  });
+      rewriter.eraseOp(op);
+      return success();
     }
-    op->setAttr("allocation.offset", offsetIt->second);
-  }
-  mod->setAttr("ttg.ws_cluster_barrier_count",
-               builder.getI32IntegerAttr(regionOffsets.size()));
 
-  auto loc = initBarriers.front().getLoc();
-  TritonLLVMIRRewriter rewriter(loc, mod.getContext());
-  rewriter.setInsertionPointToStart(&kernel.getBody().front());
-  Value initPred = getWSRegionThread0Predicate(rewriter, loc);
-  for (triton::nvidia_gpu::ClusterBarrierOp op : initBarriers) {
-    loc = op.getLoc();
+    auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    Value barrierPtr = LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op);
-    auto ptrTy = cast<LLVM::LLVMPointerType>(barrierPtr.getType());
-    Value parityPtr = b.gep(ptrTy, i8_ty, barrierPtr, LLVM::GEPArg(8));
-    createMBarrierInit(rewriter, loc, initPred, barrierPtr,
-                       triton::gpu::lookupNumCTAs(op) - 1);
-    targetInfo.storeShared(rewriter, loc, parityPtr, b.i32_val(0), initPred);
-  }
-  createFenceMBarrierInitReleaseCluster(rewriter, loc, initPred);
-  int defaultNumWarps = triton::gpu::lookupNumWarps(kernel);
-  int totalNumWarps = defaultNumWarps;
-  if (auto attr = mod->getAttrOfType<IntegerAttr>("ttg.total-num-warps"))
-    totalNumWarps = attr.getInt();
-  lowerClusterSyncForAllWarps(loc, rewriter, defaultNumWarps, totalNumWarps,
-                              [&](OpBuilder &b) {
-                                createClusterArrive(b, loc, /*relaxed=*/true);
-                                createClusterWait(b, loc);
-                              });
-
-  for (triton::nvidia_gpu::ClusterBarrierOp op : barriers) {
-    loc = op.getLoc();
-    TritonLLVMIRRewriter rewriter(loc, op);
-    auto b = TritonLLVMOpBuilder(loc, rewriter);
-    Value barrierPtr = LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op);
+    auto func = op->getParentOfType<FunctionOpInterface>();
+    Value barrierPtr = getClusterBarrierMbarPtr(
+        loc, rewriter, func, mbarOffset.getInt(), targetInfo);
     auto ptrTy = cast<LLVM::LLVMPointerType>(barrierPtr.getType());
     Value parityPtr = b.gep(ptrTy, i8_ty, barrierPtr, LLVM::GEPArg(8));
 
     NVVM::Barrier0Op::create(rewriter, loc);
     Value parity = b.load(i32_ty, parityPtr);
-    Value pred = getWSRegionThread0Predicate(rewriter, loc);
+    Value pred = b.icmp_eq(getThreadId(rewriter, loc), b.i32_val(0));
     Value barrierInt = b.ptrtoint(i32_ty, barrierPtr);
     int numCTAs = triton::gpu::lookupNumCTAs(op);
     bool relaxed = op.getRelaxed() && targetInfo.getPtxVersion() >= 86;
@@ -269,6 +236,73 @@ LogicalResult mlir::triton::NVIDIA::lowerWarpSpecializedClusterBarriers(
                            b.xor_(parity, b.i32_val(1)), pred);
     NVVM::Barrier0Op::create(rewriter, loc);
     rewriter.eraseOp(op);
+    return success();
   }
-  return success();
+
+private:
+  const NVIDIA::TargetInfo &targetInfo;
+};
+
+struct InitializeWSClusterBarriers
+    : public mlir::triton::impl::InitializeWSClusterBarriersBase<
+          InitializeWSClusterBarriers> {
+  using InitializeWSClusterBarriersBase::InitializeWSClusterBarriersBase;
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    auto countAttr = mod->getAttrOfType<IntegerAttr>(
+        triton::nvidia_gpu::kWSClusterBarrierCountAttrName);
+    if (!countAttr || countAttr.getInt() == 0)
+      return;
+
+    auto funcs = mod.getOps<LLVM::LLVMFuncOp>();
+    auto kernelIt = llvm::find_if(
+        funcs, [](LLVM::LLVMFuncOp func) { return triton::isKernel(func); });
+    if (kernelIt == funcs.end())
+      return;
+    LLVM::LLVMFuncOp kernel = *kernelIt;
+
+    NVIDIA::TargetInfo targetInfo(computeCapability, ptxVersion);
+    Location loc = kernel.getLoc();
+    TritonLLVMIRRewriter rewriter(loc, mod.getContext());
+    rewriter.setInsertionPointToStart(&kernel.getBody().front());
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    Value tid = NVVM::ThreadIdXOp::create(rewriter, loc, i32_ty);
+    Value initPred = b.icmp_eq(tid, b.i32_val(0));
+    auto sharedAttr = mod->getAttrOfType<IntegerAttr>("ttg.shared");
+    int64_t shared = sharedAttr ? sharedAttr.getInt() : 0;
+    int64_t offset = llvm::alignTo(shared, int64_t{8});
+    int64_t count = countAttr.getInt();
+    int numCTAs = triton::gpu::lookupNumCTAs(kernel);
+    for (int64_t i = 0; i < count; ++i, offset += 16) {
+      Value barrierPtr =
+          getClusterBarrierMbarPtr(loc, rewriter, kernel, offset, targetInfo);
+      auto ptrTy = cast<LLVM::LLVMPointerType>(barrierPtr.getType());
+      Value parityPtr = b.gep(ptrTy, i8_ty, barrierPtr, LLVM::GEPArg(8));
+      createMBarrierInit(rewriter, loc, initPred, barrierPtr, numCTAs - 1);
+      targetInfo.storeShared(rewriter, loc, parityPtr, b.i32_val(0), initPred);
+    }
+
+    NVIDIA::createFenceMBarrierInitReleaseCluster(rewriter, loc, initPred);
+    int defaultNumWarps = triton::gpu::lookupNumWarps(kernel);
+    int totalNumWarps = defaultNumWarps;
+    if (auto attr = mod->getAttrOfType<IntegerAttr>("ttg.total-num-warps"))
+      totalNumWarps = attr.getInt();
+    lowerClusterSyncForAllWarps(loc, rewriter, defaultNumWarps, totalNumWarps,
+                                [&](OpBuilder &b) {
+                                  createClusterArrive(b, loc,
+                                                      /*relaxed=*/true);
+                                  createClusterWait(b, loc);
+                                });
+  }
+};
+} // namespace
+
+void mlir::triton::NVIDIA::populateClusterOpsToLLVMPatterns(
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    PatternBenefit benefit, const NVIDIA::TargetInfo &targetInfo) {
+  patterns.add<ClusterSyncOpConversion<triton::nvidia_gpu::ClusterArriveOp>,
+               ClusterSyncOpConversion<triton::nvidia_gpu::ClusterWaitOp>>(
+      typeConverter, benefit);
+  patterns.add<ClusterBarrierOpConversion>(typeConverter, benefit, targetInfo);
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -22,11 +22,17 @@
  */
 
 #include "PatternTritonGPUOpToLLVM.h"
+#include "TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/MathExtras.h"
+
+#include <type_traits>
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -44,31 +50,63 @@ static void createClusterWait(OpBuilder &b, Location loc) {
   NVVM::ClusterWaitOp::create(b, loc, UnitAttr::get(b.getContext()));
 }
 
+static void createMBarrierInit(OpBuilder &b, Location loc, Value pred,
+                               Value barrierPtr, int count) {
+  PTXBuilder ptxBuilder;
+  auto &init = *ptxBuilder.create("@$0 mbarrier.init.shared::cta.b64 [$1], " +
+                                  std::to_string(count) + ";");
+  init({ptxBuilder.newOperand(pred, "b"),
+        ptxBuilder.newOperand(barrierPtr, "r")},
+       /*onlyAttachMLIRArgs=*/true);
+  ptxBuilder.launch(b, loc, void_ty(b.getContext()));
+}
+
+static void createMBarrierArrive(OpBuilder &b, Location loc, Value pred,
+                                 Value barrierPtr, bool relaxed) {
+  PTXBuilder ptxBuilder;
+  auto &arrive = *ptxBuilder.create(
+      "@$0 mbarrier.arrive." + std::string(relaxed ? "relaxed" : "release") +
+      ".cluster.shared::cluster.b64 _, [$1];");
+  arrive({ptxBuilder.newOperand(pred, "b"),
+          ptxBuilder.newOperand(barrierPtr, "r")},
+         /*onlyAttachMLIRArgs=*/true);
+  ptxBuilder.launch(b, loc, void_ty(b.getContext()));
+}
+
+static void createMBarrierWait(OpBuilder &b, Location loc, Value barrierPtr,
+                               Value parity) {
+  PTXBuilder ptxBuilder;
+  auto &wait =
+      *ptxBuilder.create("{\n"
+                         "\t.reg .pred complete;\n"
+                         "waitLoop:\n"
+                         "\tmbarrier.try_wait.parity.acquire.cluster.shared::"
+                         "cta.b64 complete, [$0], $1;\n"
+                         "\t@!complete bra.uni waitLoop;\n"
+                         "}\n");
+  wait({ptxBuilder.newOperand(barrierPtr, "r"),
+        ptxBuilder.newOperand(parity, "r")},
+       /*onlyAttachMLIRArgs=*/true);
+  ptxBuilder.launch(b, loc, void_ty(b.getContext()));
+}
+
+static Value getWSRegionThread0Predicate(OpBuilder &rewriter, Location loc) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  // This runs after GPU and arith conversion, so emit only NVVM/LLVM ops.
+  Value tid = NVVM::ThreadIdXOp::create(rewriter, loc, i32_ty);
+  int startThreadId =
+      getWarpGroupStartThreadId(rewriter.getInsertionBlock()).value_or(0);
+  return b.icmp_eq(tid, b.i32_val(startThreadId));
+}
+
 template <typename EmitFn>
-LogicalResult lowerClusterSyncForAllWarps(Operation *op,
-                                          ConversionPatternRewriter &rewriter,
-                                          EmitFn emit) {
-  auto loc = op->getLoc();
-  auto mod = op->getParentOfType<ModuleOp>();
-  if (!mod)
-    return rewriter.notifyMatchFailure(op, "expected parent module");
-
-  auto defaultNumWarps = triton::gpu::maybeLookupNumWarps(op);
-  if (!defaultNumWarps)
-    return rewriter.notifyMatchFailure(op, "missing contextual num-warps");
-  int totalNumWarps = *defaultNumWarps;
-  if (auto totalNumWarpsAttr =
-          mod->getAttrOfType<IntegerAttr>("ttg.total-num-warps"))
-    totalNumWarps = totalNumWarpsAttr.getInt();
-  int workerNumWarps = totalNumWarps - *defaultNumWarps;
-  if (workerNumWarps < 0)
-    return rewriter.notifyMatchFailure(op, "invalid total/default num-warps");
-
-  rewriter.setInsertionPoint(op);
+void lowerClusterSyncForAllWarps(Location loc, OpBuilder &rewriter,
+                                 int defaultNumWarps, int totalNumWarps,
+                                 EmitFn emit) {
+  int workerNumWarps = totalNumWarps - defaultNumWarps;
   if (workerNumWarps == 0) {
     emit(rewriter);
-    rewriter.eraseOp(op);
-    return success();
+    return;
   }
 
   SmallVector<int32_t> partitionNumWarps;
@@ -82,7 +120,7 @@ LogicalResult lowerClusterSyncForAllWarps(Operation *op,
   auto wsOp = triton::gpu::WarpSpecializeOp::create(rewriter, loc, TypeRange{},
                                                     partitionNumWarps);
   SmallVector<int32_t> startIds;
-  int startId = *defaultNumWarps;
+  int startId = defaultNumWarps;
   for (int32_t partitionWarps : partitionNumWarps) {
     startIds.push_back(startId);
     startId += partitionWarps;
@@ -105,50 +143,34 @@ LogicalResult lowerClusterSyncForAllWarps(Operation *op,
     emit(rewriter);
     triton::gpu::WarpReturnOp::create(rewriter, loc);
   }
-
-  rewriter.eraseOp(op);
-  return success();
 }
 
-struct ClusterArriveOpConversion
-    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::ClusterArriveOp> {
-  using ConvertOpToLLVMPattern<
-      triton::nvidia_gpu::ClusterArriveOp>::ConvertOpToLLVMPattern;
+template <typename Op>
+struct ClusterSyncOpConversion : public ConvertOpToLLVMPattern<Op> {
+  using ConvertOpToLLVMPattern<Op>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(triton::nvidia_gpu::ClusterArriveOp op, OpAdaptor adaptor,
+  matchAndRewrite(Op op, typename Op::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    return lowerClusterSyncForAllWarps(op, rewriter, [&](OpBuilder &b) {
-      createClusterArrive(b, op.getLoc(), op.getRelaxed());
-    });
-  }
-};
+    auto mod = op->template getParentOfType<ModuleOp>();
+    int defaultNumWarps = triton::gpu::lookupNumWarps(op);
+    int totalNumWarps = defaultNumWarps;
+    if (auto attr =
+            mod->template getAttrOfType<IntegerAttr>("ttg.total-num-warps"))
+      totalNumWarps = attr.getInt();
 
-struct ClusterWaitOpConversion
-    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::ClusterWaitOp> {
-  using ConvertOpToLLVMPattern<
-      triton::nvidia_gpu::ClusterWaitOp>::ConvertOpToLLVMPattern;
-
-  LogicalResult
-  matchAndRewrite(triton::nvidia_gpu::ClusterWaitOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    return lowerClusterSyncForAllWarps(
-        op, rewriter, [&](OpBuilder &b) { createClusterWait(b, op.getLoc()); });
-  }
-};
-
-struct ClusterBarrierOpConversion
-    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::ClusterBarrierOp> {
-  using ConvertOpToLLVMPattern<
-      triton::nvidia_gpu::ClusterBarrierOp>::ConvertOpToLLVMPattern;
-
-  LogicalResult
-  matchAndRewrite(triton::nvidia_gpu::ClusterBarrierOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    return lowerClusterSyncForAllWarps(op, rewriter, [&](OpBuilder &b) {
-      createClusterArrive(b, op.getLoc(), op.getRelaxed());
-      createClusterWait(b, op.getLoc());
-    });
+    rewriter.setInsertionPoint(op);
+    lowerClusterSyncForAllWarps(
+        op.getLoc(), rewriter, defaultNumWarps, totalNumWarps,
+        [&](OpBuilder &b) {
+          if constexpr (!std::is_same_v<Op, triton::nvidia_gpu::ClusterWaitOp>)
+            createClusterArrive(b, op.getLoc(), op.getRelaxed());
+          if constexpr (!std::is_same_v<Op,
+                                        triton::nvidia_gpu::ClusterArriveOp>)
+            createClusterWait(b, op.getLoc());
+        });
+    rewriter.eraseOp(op);
+    return success();
   }
 };
 } // namespace
@@ -156,8 +178,108 @@ struct ClusterBarrierOpConversion
 void mlir::triton::NVIDIA::populateClusterOpsToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     PatternBenefit benefit) {
-  patterns.add<ClusterArriveOpConversion>(typeConverter, benefit);
-  patterns.add<ClusterWaitOpConversion>(typeConverter, benefit);
-  patterns.add<ClusterBarrierOpConversion>(typeConverter, benefit);
+  patterns.add<ClusterSyncOpConversion<triton::nvidia_gpu::ClusterArriveOp>,
+               ClusterSyncOpConversion<triton::nvidia_gpu::ClusterWaitOp>,
+               ClusterSyncOpConversion<triton::nvidia_gpu::ClusterBarrierOp>>(
+      typeConverter, benefit);
   return;
+}
+
+LogicalResult mlir::triton::NVIDIA::lowerWarpSpecializedClusterBarriers(
+    ModuleOp mod, const NVIDIA::TargetInfo &targetInfo) {
+  Builder builder(mod.getContext());
+  LLVM::LLVMFuncOp kernel;
+  for (LLVM::LLVMFuncOp func : mod.getOps<LLVM::LLVMFuncOp>()) {
+    if (triton::isKernel(func)) {
+      kernel = func;
+      continue;
+    }
+    WalkResult result = func.walk([&](triton::nvidia_gpu::ClusterBarrierOp op) {
+      op.emitError("cluster_barrier inside a non-inline function is not "
+                   "supported");
+      return WalkResult::interrupt();
+    });
+    if (result.wasInterrupted())
+      return failure();
+  }
+
+  if (!kernel)
+    return success();
+
+  SmallVector<triton::nvidia_gpu::ClusterBarrierOp> barriers;
+  kernel.walk(
+      [&](triton::nvidia_gpu::ClusterBarrierOp op) { barriers.push_back(op); });
+  if (barriers.empty())
+    return success();
+  int64_t shared = mod->getAttrOfType<IntegerAttr>("ttg.shared").getInt();
+
+  DenseMap<unsigned, IntegerAttr> regionOffsets;
+  SmallVector<triton::nvidia_gpu::ClusterBarrierOp> initBarriers;
+  for (triton::nvidia_gpu::ClusterBarrierOp op : barriers) {
+    // Regions executed by the same warp group share a barrier.
+    unsigned regionId = getWarpGroupStartWarpId(op->getBlock()).value_or(0);
+
+    auto [offsetIt, inserted] = regionOffsets.try_emplace(regionId);
+    if (inserted) {
+      int64_t offset = llvm::alignTo(shared, int64_t{8}) +
+                       int64_t(regionOffsets.size() - 1) * 16;
+      offsetIt->second = builder.getI32IntegerAttr(offset);
+      initBarriers.push_back(op);
+    }
+    op->setAttr("allocation.offset", offsetIt->second);
+  }
+  mod->setAttr("ttg.ws_cluster_barrier_count",
+               builder.getI32IntegerAttr(regionOffsets.size()));
+
+  auto loc = initBarriers.front().getLoc();
+  TritonLLVMIRRewriter rewriter(loc, mod.getContext());
+  rewriter.setInsertionPointToStart(&kernel.getBody().front());
+  Value initPred = getWSRegionThread0Predicate(rewriter, loc);
+  for (triton::nvidia_gpu::ClusterBarrierOp op : initBarriers) {
+    loc = op.getLoc();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    Value barrierPtr = LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op);
+    auto ptrTy = cast<LLVM::LLVMPointerType>(barrierPtr.getType());
+    Value parityPtr = b.gep(ptrTy, i8_ty, barrierPtr, LLVM::GEPArg(8));
+    createMBarrierInit(rewriter, loc, initPred, barrierPtr,
+                       triton::gpu::lookupNumCTAs(op) - 1);
+    targetInfo.storeShared(rewriter, loc, parityPtr, b.i32_val(0), initPred);
+  }
+  createFenceMBarrierInitReleaseCluster(rewriter, loc, initPred);
+  int defaultNumWarps = triton::gpu::lookupNumWarps(kernel);
+  int totalNumWarps = defaultNumWarps;
+  if (auto attr = mod->getAttrOfType<IntegerAttr>("ttg.total-num-warps"))
+    totalNumWarps = attr.getInt();
+  lowerClusterSyncForAllWarps(loc, rewriter, defaultNumWarps, totalNumWarps,
+                              [&](OpBuilder &b) {
+                                createClusterArrive(b, loc, /*relaxed=*/true);
+                                createClusterWait(b, loc);
+                              });
+
+  for (triton::nvidia_gpu::ClusterBarrierOp op : barriers) {
+    loc = op.getLoc();
+    TritonLLVMIRRewriter rewriter(loc, op);
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    Value barrierPtr = LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op);
+    auto ptrTy = cast<LLVM::LLVMPointerType>(barrierPtr.getType());
+    Value parityPtr = b.gep(ptrTy, i8_ty, barrierPtr, LLVM::GEPArg(8));
+
+    NVVM::Barrier0Op::create(rewriter, loc);
+    Value parity = b.load(i32_ty, parityPtr);
+    Value pred = getWSRegionThread0Predicate(rewriter, loc);
+    Value barrierInt = b.ptrtoint(i32_ty, barrierPtr);
+    int numCTAs = triton::gpu::lookupNumCTAs(op);
+    bool relaxed = op.getRelaxed() && targetInfo.getPtxVersion() >= 86;
+    for (int i = 1; i < numCTAs; ++i) {
+      Value peerBarrierInt = b.xor_(barrierInt, b.i32_val(i << 24));
+      Value peerBarrierPtr = b.inttoptr(barrierPtr.getType(), peerBarrierInt);
+      createMBarrierArrive(rewriter, loc, pred, peerBarrierPtr, relaxed);
+    }
+    createMBarrierWait(rewriter, loc, barrierPtr, parity);
+    targetInfo.storeShared(rewriter, loc, parityPtr,
+                           b.xor_(parity, b.i32_val(1)), pred);
+    NVVM::Barrier0Op::create(rewriter, loc);
+    rewriter.eraseOp(op);
+  }
+  return success();
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -47,8 +47,9 @@ struct ConvertLayoutOpSwizzlingConversion
       auto smemBase = LLVM::getSharedMemoryBase(loc, rewriter, targetInfo,
                                                 op.getOperation());
       auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
-      auto outVals = transferWithinBlockSwizzling(
-          loc, rewriter, srcLayout, dstLayout, inVals, llvmElemTy, smemBase);
+      auto outVals =
+          transferWithinBlockSwizzling(loc, rewriter, srcLayout, dstLayout,
+                                       inVals, llvmElemTy, smemBase, op);
 
       Value result =
           packLLElements(loc, getTypeConverter(), outVals, rewriter, dstTy);
@@ -61,7 +62,8 @@ struct ConvertLayoutOpSwizzlingConversion
   SmallVector<Value> transferWithinBlockSwizzling(
       Location loc, ConversionPatternRewriter &rewriter,
       const LinearLayout &srcLayout, const LinearLayout &dstLayout,
-      ArrayRef<Value> inVals, Type llvmElemTy, Value smemBase) const {
+      ArrayRef<Value> inVals, Type llvmElemTy, Value smemBase,
+      Operation *sourceOp) const {
     auto *ctx = rewriter.getContext();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     // We handle transformations recursively as they all need a preprocessing
@@ -73,9 +75,9 @@ struct ConvertLayoutOpSwizzlingConversion
       auto newInVals = llvm::to_vector(llvm::map_range(inVals, [&](Value v) {
         return b.ptrtoint(llvmElemTyPtr, v).getResult();
       }));
-      auto outVals =
-          transferWithinBlockSwizzling(loc, rewriter, srcLayout, dstLayout,
-                                       newInVals, llvmElemTyPtr, smemBase);
+      auto outVals = transferWithinBlockSwizzling(
+          loc, rewriter, srcLayout, dstLayout, newInVals, llvmElemTyPtr,
+          smemBase, sourceOp);
       for (auto &v : outVals) {
         v = b.inttoptr(llvmElemTy, v);
       }
@@ -88,8 +90,9 @@ struct ConvertLayoutOpSwizzlingConversion
       auto i8ElemTy = i8_ty;
       auto newInVals = llvm::to_vector(llvm::map_range(
           inVals, [&](Value v) { return b.zext(i8ElemTy, v).getResult(); }));
-      auto outVals = transferWithinBlockSwizzling(
-          loc, rewriter, srcLayout, dstLayout, newInVals, i8ElemTy, smemBase);
+      auto outVals =
+          transferWithinBlockSwizzling(loc, rewriter, srcLayout, dstLayout,
+                                       newInVals, i8ElemTy, smemBase, sourceOp);
       for (auto &v : outVals) {
         v = b.trunc(llvmElemTy, v);
       }
@@ -102,15 +105,17 @@ struct ConvertLayoutOpSwizzlingConversion
       auto prmtSrc = removeBroadcastSrc.apply(srcLayout);
       auto newInVals = removeBroadcastSrc.apply(inVals);
       return transferWithinBlockSwizzling(loc, rewriter, prmtSrc, dstLayout,
-                                          newInVals, llvmElemTy, smemBase);
+                                          newInVals, llvmElemTy, smemBase,
+                                          sourceOp);
     }
 
     // Remove broadcasting in dst
     auto removeBroadcastDst = actionRemoveBroadcastedRegs(dstLayout);
     if (!removeBroadcastDst.isIdentity()) {
       auto prmtDst = removeBroadcastDst.apply(dstLayout);
-      auto outVals = transferWithinBlockSwizzling(
-          loc, rewriter, srcLayout, prmtDst, inVals, llvmElemTy, smemBase);
+      auto outVals =
+          transferWithinBlockSwizzling(loc, rewriter, srcLayout, prmtDst,
+                                       inVals, llvmElemTy, smemBase, sourceOp);
       return broadcastAs(outVals, dstLayout);
     }
 
@@ -175,7 +180,7 @@ struct ConvertLayoutOpSwizzlingConversion
       } else if (isBlockSync) {
         targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
       } else {
-        targetInfo.clusterBarrier(loc, rewriter);
+        targetInfo.clusterBarrier(loc, rewriter, sourceOp);
       }
     };
     auto dropBlock = [&](const LinearLayout &cvt) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -19,6 +19,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "triton/Tools/LayoutUtils.h"
 
@@ -507,12 +508,13 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
 };
 
 void createBarrier(ConversionPatternRewriter &rewriter, Location loc,
-                   int numCTAs) {
+                   int numCTAs, Operation *sourceOp) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   if (numCTAs == 1) {
     b.barrier(ttg::AddrSpace::Local);
   } else {
-    triton::nvidia_gpu::ClusterBarrierOp::create(rewriter, loc);
+    auto barrier = triton::nvidia_gpu::ClusterBarrierOp::create(rewriter, loc);
+    triton::nvidia_gpu::copyClusterBarrierMbarOffset(sourceOp, barrier);
   }
 }
 
@@ -596,7 +598,7 @@ struct AtomicCASOpConversion
         st(dstOprStore, valOprStore).maybePredicate(threadPred);
         auto ASMReturnTy = void_ty(ctx);
         ptxBuilderStore.launch(rewriter, loc, ASMReturnTy);
-        createBarrier(rewriter, loc, numCTAs);
+        createBarrier(rewriter, loc, numCTAs, op);
         Value ret = b.load(valueElemTy, atomPtr);
         rewriter.replaceOp(op, {ret});
         return success();
@@ -790,7 +792,7 @@ public:
         atomPtr = b.bitcast(atomPtr, ptr_ty(ctx, 3));
         // Only threads with rmwMask = True store the result
         targetInfo.storeShared(rewriter, loc, atomPtr, loadAcquireOp, pred);
-        createBarrier(rewriter, loc, numCTAs);
+        createBarrier(rewriter, loc, numCTAs, op);
         Value ret = b.load(valueElemTy, atomPtr);
         rewriter.replaceOp(op, {ret});
         return success();
@@ -925,7 +927,7 @@ public:
         atomPtr = b.bitcast(atomPtr, ptr_ty(ctx, 3));
         // Only threads with rmwMask = True store the result
         targetInfo.storeShared(rewriter, loc, atomPtr, *old, pred);
-        createBarrier(rewriter, loc, numCTAs);
+        createBarrier(rewriter, loc, numCTAs, op);
         Value ret = b.load(valueElemTy, atomPtr);
         rewriter.replaceOp(op, {ret});
         return success();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -20,11 +20,8 @@ void createFenceMBarrierInitReleaseCluster(OpBuilder &builder, Location loc,
 
 void populateClusterOpsToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                       RewritePatternSet &patterns,
-                                      PatternBenefit benefit);
-
-LogicalResult
-lowerWarpSpecializedClusterBarriers(ModuleOp mod,
-                                    const NVIDIA::TargetInfo &info);
+                                      PatternBenefit benefit,
+                                      const NVIDIA::TargetInfo &targetInfo);
 
 void populateConvertLayoutOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                            const TargetInfo &targetInfo,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -15,9 +15,16 @@ void populateBarrierOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                      PatternBenefit benefit,
                                      NVIDIA::TargetInfo &info);
 
+void createFenceMBarrierInitReleaseCluster(OpBuilder &builder, Location loc,
+                                           Value pred);
+
 void populateClusterOpsToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                       RewritePatternSet &patterns,
                                       PatternBenefit benefit);
+
+LogicalResult
+lowerWarpSpecializedClusterBarriers(ModuleOp mod,
+                                    const NVIDIA::TargetInfo &info);
 
 void populateConvertLayoutOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                            const TargetInfo &targetInfo,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -7,6 +7,7 @@
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h"
 #include "llvm/Support/MathExtras.h"
 
 using namespace mlir;
@@ -152,8 +153,10 @@ void TargetInfo::barrier(Location loc, RewriterBase &rewriter,
   b.barrier(targets);
 }
 
-void TargetInfo::clusterBarrier(Location loc, RewriterBase &rewriter) const {
-  triton::nvidia_gpu::ClusterBarrierOp::create(rewriter, loc);
+void TargetInfo::clusterBarrier(Location loc, RewriterBase &rewriter,
+                                Operation *sourceOp) const {
+  auto barrier = triton::nvidia_gpu::ClusterBarrierOp::create(rewriter, loc);
+  triton::nvidia_gpu::copyClusterBarrierMbarOffset(sourceOp, barrier);
 }
 
 void TargetInfo::warpSync(Location loc, RewriterBase &rewriter) const {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -20,7 +20,8 @@ public:
 
   void barrier(Location loc, RewriterBase &rewriter,
                triton::gpu::AddrSpace targets) const override;
-  void clusterBarrier(Location loc, RewriterBase &rewriter) const override;
+  void clusterBarrier(Location loc, RewriterBase &rewriter,
+                      Operation *sourceOp) const override;
 
   void warpSync(Location loc, RewriterBase &rewriter) const override;
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -24,6 +24,7 @@
 #include "triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h"
 
 #include "Allocation.h"
 #include "PatternTritonGPUOpToLLVM.h"
@@ -77,12 +78,6 @@ public:
     addLegalOp<triton::gpu::WarpYieldOp>();
     addLegalOp<triton::gpu::WarpSpecializePartitionsOp>();
     addLegalOp<triton::gpu::WarpReturnOp>();
-    // LLVM conversion may synthesize more cluster barriers. Lower all
-    // warp-specialized barriers together after conversion.
-    addDynamicallyLegalOp<triton::nvidia_gpu::ClusterBarrierOp>(
-        [](triton::nvidia_gpu::ClusterBarrierOp op) {
-          return bool(op->getParentOfType<triton::gpu::WarpSpecializeOp>());
-        });
   }
 };
 
@@ -127,6 +122,7 @@ struct ConvertTritonGPUToLLVM
       if (failed(cleanupPm.run(mod)))
         return signalPassFailure();
     }
+    mlir::triton::nvidia_gpu::runClusterBarrierMbarAllocator(mod);
     bool hasGlobalScratchAlloc = false;
     mod.walk([&](triton::gpu::GlobalScratchAllocOp) {
       hasGlobalScratchAlloc = true;
@@ -180,7 +176,8 @@ struct ConvertTritonGPUToLLVM
                                                  targetInfo, benefit);
     populateBarrierOpToLLVMPatterns(typeConverter, patterns, benefit,
                                     targetInfo);
-    populateClusterOpsToLLVMPatterns(typeConverter, patterns, benefit);
+    populateClusterOpsToLLVMPatterns(typeConverter, patterns, benefit,
+                                     targetInfo);
     mlir::triton::populateHistogramOpToLLVMPatterns(typeConverter, patterns,
                                                     targetInfo, benefit);
     mlir::triton::populatePrintOpToLLVMPattern(typeConverter, patterns,
@@ -221,9 +218,6 @@ struct ConvertTritonGPUToLLVM
 
     TritonLLVMConversionTarget convTarget(*context);
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))
-      return signalPassFailure();
-
-    if (failed(lowerWarpSpecializedClusterBarriers(mod, targetInfo)))
       return signalPassFailure();
 
     // Lower CF ops separately to avoid breaking analysis.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -77,6 +77,12 @@ public:
     addLegalOp<triton::gpu::WarpYieldOp>();
     addLegalOp<triton::gpu::WarpSpecializePartitionsOp>();
     addLegalOp<triton::gpu::WarpReturnOp>();
+    // LLVM conversion may synthesize more cluster barriers. Lower all
+    // warp-specialized barriers together after conversion.
+    addDynamicallyLegalOp<triton::nvidia_gpu::ClusterBarrierOp>(
+        [](triton::nvidia_gpu::ClusterBarrierOp op) {
+          return bool(op->getParentOfType<triton::gpu::WarpSpecializeOp>());
+        });
   }
 };
 
@@ -215,6 +221,9 @@ struct ConvertTritonGPUToLLVM
 
     TritonLLVMConversionTarget convTarget(*context);
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))
+      return signalPassFailure();
+
+    if (failed(lowerWarpSpecializedClusterBarriers(mod, targetInfo)))
       return signalPassFailure();
 
     // Lower CF ops separately to avoid breaking analysis.

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -156,6 +156,15 @@ createTritonGPUProxyFenceInsertionWrapper(int32_t capability) {
   return ttng::createTritonGPUProxyFenceInsertion(options);
 }
 
+std::unique_ptr<mlir::Pass>
+createInitializeWSClusterBarriersWrapper(int32_t capability,
+                                         int32_t ptxVersion) {
+  mlir::triton::InitializeWSClusterBarriersOptions options;
+  options.computeCapability = capability;
+  options.ptxVersion = ptxVersion;
+  return mlir::triton::createInitializeWSClusterBarriers(options);
+}
+
 void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_plan_cta", ttng::createTritonNvidiaGPUPlanCTAPass);
   ADD_PASS_WRAPPER_1("add_fence_insertion",
@@ -174,6 +183,9 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      ttng::createTritonNvidiaGPUCheckMatmulTwoCTAPass);
   ADD_PASS_WRAPPER_0("add_nvgpu_to_llvm",
                      mlir::triton::createConvertNVGPUToLLVM);
+  ADD_PASS_WRAPPER_2("add_initialize_ws_cluster_barriers",
+                     createInitializeWSClusterBarriersWrapper, int32_t,
+                     int32_t);
   ADD_PASS_WRAPPER_0("add_warp_specialize_to_llvm",
                      mlir::triton::createConvertWarpSpecializeToLLVM);
   ADD_PASS_WRAPPER_0("add_allocate_tensor_memory",


### PR DESCRIPTION
- We set aside a region of shmem where we allocate the mbars + their phases.
  (We need to use phases in smem for now as weaving the phase value all
  the way to the ops at that lowering point is pretty much impossible)
- We set the smem allocation while lowering the `cluster_barrier`s
  themselves, as other ops like `convert_layout` and `reduce` emit
  `cluster_barrier`s internally.
- We initialise the barriers at the top of the LLVM::Func
