### PR TITLE
[nvidia] Treat cuInit CUDA_ERROR_NOT_INITIALIZED as GPU present in is_active()

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -72,7 +72,17 @@ def _cuda_driver_is_active():
     cu_init = libcuda.cuInit
     cu_init.argtypes = [ctypes.c_uint]
     cu_init.restype = ctypes.c_int
-    if cu_init(0) != 0:
+    rc = cu_init(0)
+    # CUDA_ERROR_NOT_INITIALIZED (3) is what cuInit returns in a process that was
+    # fork()ed after its parent already initialized CUDA (e.g. a PyTorch Inductor
+    # compile worker). libcuda loaded and a GPU exists; only this fork's CUDA
+    # context is unusable. Treat that as "GPU present" so driver selection does
+    # not spuriously fail (pytorch/pytorch#184643). cuDeviceGetCount would also
+    # return rc=3 here, so short-circuit before it.
+    CUDA_ERROR_NOT_INITIALIZED = 3
+    if rc == CUDA_ERROR_NOT_INITIALIZED:
+        return True
+    if rc != 0:
         return False
 
     cu_device_get_count = libcuda.cuDeviceGetCount


### PR DESCRIPTION
After #9578, the NVIDIA backend's is_active() probes the driver with a raw
cuInit(0). A process that was fork()ed after its parent already initialized CUDA
gets CUDA_ERROR_NOT_INITIALIZED (rc=3) from cuInit, so is_active() returns False
even though libcuda is present and a GPU exists -- only this fork's CUDA context
is unusable. That breaks consumers that fork worker processes after CUDA has been
initialized, most notably PyTorch Inductor's compile-worker pool, where driver
resolution then raises "0 active drivers ([]). There should only be one."
(pytorch/pytorch#184643).

Fix: treat rc=3 as "GPU present". Reaching this point means libcuda already
loaded successfully, so a CUDA installation and a device exist; the only thing
missing is a usable per-process context, which the caller establishes on first
real use. cuDeviceGetCount would itself return rc=3 in this state, so the check
short-circuits before it.

Test Plan:
Verified on an 8x H100 box. In a process forked after CUDA init, is_active()
returned False before and True after this change:

```
import os, torch, triton
torch.cuda.get_device_properties(0)            # initialize CUDA in the parent
nvidia = triton.backends.backends["nvidia"]
if os.fork() == 0:
    print("is_active:", nvidia.driver.is_active())   # before: False, after: True
    os._exit(0)
os.wait()
```

End to end, the PyTorch Inductor reproducer for pytorch/pytorch#184643
(worker_start_method="fork", compile_threads>1, caches disabled) goes from
"0 active drivers" to a successful compile with this change alone.

Authored with Claude.