### PR TITLE
[BACKEND] Use read-only waits for pipelined TMA stores

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/TMAStoresPipeline.cpp
@@ -32,6 +32,24 @@ static SmallVector<TMAStore> getTMAStores(scf::ForOp forOp) {
   return tmaStores;
 }
 
+static bool hasAcquireOrReleaseSemantic(tt::MemSemantic sem) {
+  return sem != tt::MemSemantic::RELAXED;
+}
+
+static bool hasAcquireOrReleaseOp(scf::ForOp forOp) {
+  bool hasAcquireOrRelease = false;
+  forOp.getBody()->walk([&](Operation *op) {
+    if (auto atomicRMW = dyn_cast<tt::AtomicRMWOp>(op)) {
+      hasAcquireOrRelease = hasAcquireOrReleaseSemantic(atomicRMW.getSem());
+    } else if (auto atomicCAS = dyn_cast<tt::AtomicCASOp>(op)) {
+      hasAcquireOrRelease = hasAcquireOrReleaseSemantic(atomicCAS.getSem());
+    }
+    return hasAcquireOrRelease ? WalkResult::interrupt()
+                               : WalkResult::advance();
+  });
+  return hasAcquireOrRelease;
+}
+
 static Value createAlloc(scf::ForOp &forOp, const TMAStore &store) {
   OpBuilder builder(forOp);
   RankedTensorType ty = store.src.getType();
@@ -52,9 +70,9 @@ static void createTMAAsyncCopy(scf::ForOp forOp, const TMAStore &store,
   OpBuilder builder(store.op);
   Location loc = store.op->getLoc();
 
-  // Put wait before the local_store make the store truly async. We know
-  // that we are the only user of the CopyLocalToGlobal.
-  ttng::TMAStoreWaitOp::create(builder, loc, 0, /*read_only=*/false);
+  // Put wait before the local_store to make the store truly async. We only
+  // need the TMA read from the allocation to complete before reusing it.
+  ttng::TMAStoreWaitOp::create(builder, loc, 0, /*read_only=*/true);
   ttg::LocalStoreOp::create(builder, loc, store.src, alloc);
   ttng::FenceAsyncSharedOp::create(builder, loc, false);
   auto desc = store.desc;
@@ -84,6 +102,8 @@ static void lowerTMADescriptorCreation(scf::ForOp forOp) {
 bool mlir::triton::pipelineTMAStores(scf::ForOp forOp) {
   SmallVector<TMAStore> tmaStores = getTMAStores(forOp);
   if (tmaStores.empty())
+    return false;
+  if (hasAcquireOrReleaseOp(forOp))
     return false;
 
   DenseMap<Operation *, Value> storeToAlloc;

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -459,7 +459,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: scf.for
     scf.for %arg4 = %c0_i32 to %arg3 step %arg2  : i32 {
       %1 = arith.divsi %arg4, %arg2 : i32
-      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32, read_only}
       // CHECK-NEXT: ttg.local_store
       // CHECK-NEXT: ttng.fence_async_shared
       // CHECK-NEXT: ttng.async_tma_copy_local_to_global
@@ -482,7 +482,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     scf.for %arg4 = %c0_i32 to %arg3 step %arg2  : i32 {
       %1 = arith.divsi %arg4, %arg2 : i32
       %2 = tt.splat %1 : i32 -> tensor<8xi32, #blocked1>
-      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32, read_only}
       // CHECK-NEXT: ttg.local_store
       // CHECK-NEXT: ttng.fence_async_shared
       // CHECK-NEXT: ttng.async_tma_scatter
@@ -510,7 +510,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %desc = tt.make_tensor_descriptor %arg1, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] : <f32>, <128x128xf32, #shared>
       // CHECK: ttng.tensormap_create
       // CHECK: ttng.tensormap_fenceproxy_acquire
-      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32, read_only}
       // CHECK-NEXT: ttg.local_store
       // CHECK-NEXT: ttng.fence_async_shared
       // CHECK-NEXT: ttng.async_tma_copy_local_to_global
@@ -534,11 +534,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     scf.for %arg4 = %c0_i32 to %arg3 step %arg2  : i32 {
       %1 = arith.divsi %arg4, %arg2 : i32
       %2 = arith.divsi %arg2, %arg4 : i32
-      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32, read_only}
       // CHECK-NEXT: ttg.local_store %{{.+}}, %[[ALLOC]]
       // CHECK-NEXT: ttng.fence_async_shared
       // CHECK-NEXT: ttng.async_tma_copy_local_to_global %{{.*}} %[[ALLOC]]
-      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
+      // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32, read_only}
       // CHECK-NEXT: ttg.local_store %{{.+}}, %[[ALLOC]]
       // CHECK-NEXT: ttng.fence_async_shared
       // CHECK-NEXT: ttng.async_tma_copy_local_to_global %{{.*}} %[[ALLOC]]
@@ -549,6 +549,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   }
 }
 
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tma_store_release_not_pipelined
+  tt.func public @tma_store_release_not_pipelined(%arg0: tensor<128x128xf32, #blocked>, %arg1: !tt.tensordesc<128x128xf32, #shared>, %arg2: i32, %arg3: i32, %arg4: !tt.ptr<i32>) {
+    %c0_i32 = arith.constant 0 : i32
+    // CHECK: scf.for
+    scf.for %arg5 = %c0_i32 to %arg3 step %arg2  : i32 {
+      %1 = arith.divsi %arg5, %arg2 : i32
+      // CHECK: tt.descriptor_store
+      // CHECK-NEXT: tt.atomic_rmw add, release, gpu
+      // CHECK-NOT: ttng.async_tma_copy_local_to_global
+      tt.descriptor_store %arg1[%1, %1], %arg0 : !tt.tensordesc<128x128xf32, #shared>, tensor<128x128xf32, #blocked>
+      %2 = tt.atomic_rmw add, release, gpu, %arg4, %c0_i32 : (!tt.ptr<i32>, i32) -> i32
+    }
+    // CHECK: tt.return
+    tt.return
+  }
+}
 
 // -----
 

--- a/test/TritonGPU/samples/simulated-grouped-gemm.mlir
+++ b/test/TritonGPU/samples/simulated-grouped-gemm.mlir
@@ -134,7 +134,7 @@
 // CHECK:             %[[VAL_119:.*]] = arith.cmpi ne, %[[VAL_66]], %[[VAL_44]] : i32
 // CHECK:             scf.if %[[VAL_118]] {
 // CHECK:               %[[VAL_120:.*]] = arith.truncf %[[VAL_117]]#0 : tensor<128x256xf32, #[[$ATTR_1]]> to tensor<128x256xf16, #[[$ATTR_1]]>
-// CHECK:               ttng.async_tma_store_wait {pendings = 0 : i32}
+// CHECK:               ttng.async_tma_store_wait {pendings = 0 : i32, read_only}
 // CHECK:               ttg.local_store %[[VAL_120]], %[[VAL_45]] : tensor<128x256xf16, #[[$ATTR_1]]> -> !ttg.memdesc<128x256xf16, #[[$ATTR_2]], #[[$ATTR_4]], mutable>
 // CHECK:               ttng.fence_async_shared {bCluster = false}
 // CHECK:               ttng.async_tma_copy_local_to_global %[[VAL_111]]#2{{\[}}%[[VAL_111]]#5, %[[VAL_111]]#6] %[[VAL_45]] : !tt.tensordesc<128x256xf16, #[[$ATTR_2]]>, !ttg.memdesc<128x256xf16, #[[$ATTR_2]], #[[$ATTR_4]], mutable>


### PR DESCRIPTION
Use read-only waits for pipelined TMA stores so the in-loop wait only protects shared-memory staging buffer reuse.

Skip TMA store pipelining when the loop contains acquire or release atomics so those memory-ordering cases keep the non-pipelined descriptor store lowering.

This recovers some performance regression caused by [triton-lang/triton#10415](https://github.com/triton-lang/triton/pull/10415)