### PR TITLE
[AMD] Fix RDNA DPP bound control

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -163,7 +163,9 @@ Value shuffleCommonImpl(Location loc, RewriterBase &rewriter,
     if (triton::amdgpu::isRDNA(isaFamily) || isaFamily == ISAFamily::GFX1250) {
       if (mask < 16)
         return emitDpp(loc, rewriter, val, val,
-                       makeDppCtrl(DppCtrl::ROW_XMASK0, mask));
+                       makeDppCtrl(DppCtrl::ROW_XMASK0, mask), 0xf, 0xf,
+                       !triton::amdgpu::isRDNA(isaFamily) ||
+                           isaFamily == ISAFamily::RDNA4);
       else if (mask < 32)
         return emitPermlaneX16Xor(loc, rewriter, val, mask & 0xf);
     } else if ((triton::amdgpu::isCDNA(isaFamily) ||


### PR DESCRIPTION
Keep DPP bound control enabled for non-RDNA and RDNA4 shuffles while disabling it for earlier RDNA row_xmask shuffles that can fold invalid immediate operands.

Fixes the CI test failures seen on triton-windows which should also affect linux since it's related to llvm
Failures seen here (before fix): https://github.com/triton-lang/triton-windows/actions/runs/26747960400/job/78828245586
After this PR fix: https://github.com/triton-lang/triton-windows/actions/runs/26829584309/job/79106736169

cc @FrederickVu 