### PR TITLE
[AMD] Fix conservative behavior for 'add' leaf nodes in AnnotateBufferOpSplitSafety

### DIFF
--- a/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
+++ b/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
@@ -1,0 +1,50 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-annotate-buffer-op-split-safety | FileCheck %s
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_negative_summand
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_negative_summand(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %cn64 = arith.constant -64 : i32
+        %neg = tt.splat %cn64 : i32 -> tensor<128xi32, #blocked0>
+        %range = tt.make_range {end = 192 : i32, start = 64 : i32} : tensor<128xi32, #blocked0>
+        %offset = arith.addi %neg, %range : tensor<128xi32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<128xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @split_all_nonneg
+    // CHECK: amdg.buffer_load
+    // CHECK-SAME: amdgpu.split_soffset_safe
+    tt.func @split_all_nonneg(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %c5 = arith.constant 5 : i32
+        %base = tt.splat %c5 : i32 -> tensor<128xi32, #blocked0>
+        %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked0>
+        %offset = arith.addi %base, %range : tensor<128xi32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<128xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_negative_summand_store
+    // CHECK: amdg.buffer_store
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_negative_summand_store(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %value : tensor<128xf32, #blocked0>) {
+        %cn64 = arith.constant -64 : i32
+        %neg = tt.splat %cn64 : i32 -> tensor<128xi32, #blocked0>
+        %range = tt.make_range {end = 192 : i32, start = 64 : i32} : tensor<128xi32, #blocked0>
+        %offset = arith.addi %neg, %range : tensor<128xi32, #blocked0>
+        amdg.buffer_store %value, %arg0[%offset] : tensor<128xf32, #blocked0>
+        tt.return
+    }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
@@ -25,6 +25,13 @@ constexpr llvm::StringLiteral kSplitSafeAttrName = "amdgpu.split_soffset_safe";
 // additive/shape expression proves non-negative. This may miss safe splits,
 // but never annotates an offset with a possibly-negative voffset.
 static bool isLeafNonNegative(Value v, DataFlowSolver &solver) {
+  // An `add` is never a leaf to the soffset splitter. It peels the summands
+  // apart and lifts the uniform ones into the unsigned soffset. So a sum whose
+  // range is non-negative can still hide a negative summand.
+  if (Operation *def = v.getDefiningOp())
+    if (isa<arith::AddIOp>(def))
+      return false;
+
   const auto *range = solver.lookupState<dataflow::IntegerValueRangeLattice>(v);
   if (!range || range->getValue().isUninitialized())
     return false;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
@@ -28,9 +28,8 @@ static bool isLeafNonNegative(Value v, DataFlowSolver &solver) {
   // An `add` is never a leaf to the soffset splitter. It peels the summands
   // apart and lifts the uniform ones into the unsigned soffset. So a sum whose
   // range is non-negative can still hide a negative summand.
-  if (Operation *def = v.getDefiningOp())
-    if (isa<arith::AddIOp>(def))
-      return false;
+  if (v.getDefiningOp<arith::AddIOp>())
+    return false;
 
   const auto *range = solver.lookupState<dataflow::IntegerValueRangeLattice>(v);
   if (!range || range->getValue().isUninitialized())


### PR DESCRIPTION
AnnotateBufferOpSplitSafety tags `amdgpu.buffer_*` ops with `amdgpu.split_soffset_safe` when their offsets are provably non-negative, which lets the LLVM-stage splitter lift uniform offset components into the unsigned soffset SGPR. The previous logic treated any value whose integer range proved non-negative as a safe leaf, including `arith.addi`. However, the splitter peels the additive tree apart and routes each uniform summand into soffset, so a sum that is non-negative overall (e.g. [64,191] + (-64)) can still hide a negative summand that would wrap to a huge unsigned soffset and produce out-of-bounds addresses (and therefore give incorrect results). This change makes `addi` never qualify as a leaf, forcing the recursive walk to prove every summand non-negative before the op is tagged.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [X] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
