### PR TITLE
[FRONTEND] Fix passing tuples to constexpr kernel arguments

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5813,6 +5813,7 @@ def test_constexpr_assignment(literal, tensor_ty):
         tl.static_assert(assigned_literal == patched_literal)
 
         if tensor_type is not None:
+            tl.static_assert(input_literal.type == constexpr_type(PATCHED))
             assigned_variable = input_literal
             tl.static_assert(assigned_variable.type == tensor_type)
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5813,7 +5813,6 @@ def test_constexpr_assignment(literal, tensor_ty):
         tl.static_assert(assigned_literal == patched_literal)
 
         if tensor_type is not None:
-            tl.static_assert(input_literal.type == constexpr_type(PATCHED))
             assigned_variable = input_literal
             tl.static_assert(assigned_variable.type == tensor_type)
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5805,15 +5805,16 @@ def test_constexpr_assignment(literal, tensor_ty):
     def kernel(input_literal: tl.constexpr, tensor_type: tl.constexpr):
         patched_literal: tl.constexpr = PATCHED
         # Sanity checks
-        tl.static_assert(patched_literal.type == constexpr_type(PATCHED))
-        tl.static_assert(input_literal.type == constexpr_type(PATCHED))
+        tl.static_assert(patched_literal.type == (PATCHED).type)
+        tl.static_assert(input_literal.type == (PATCHED).type)
 
         assigned_literal: tl.constexpr = input_literal
-        tl.static_assert(assigned_literal.type == constexpr_type(PATCHED))
+        tl.static_assert(assigned_literal.type == (PATCHED).type)
         tl.static_assert(assigned_literal == patched_literal)
 
         if tensor_type is not None:
             assigned_variable = input_literal
+            tl.static_assert(input_literal.type == constexpr_type(PATCHED))
             tl.static_assert(assigned_variable.type == tensor_type)
 
     kernel_patched = patch_kernel(kernel, {'PATCHED': f"{literal}"})

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -385,6 +385,42 @@ def test_tuple_assignment_respects_prior_constexpr_annotation():
     run_parser(kernel)
 
 
+def test_tuple_assignment_constexpr_tuple_matches_annassign():
+
+    @triton.jit
+    def kernel():
+        a: tl.constexpr
+        a, b = (0, 1), 2
+
+        assigned_a: tl.constexpr = (0, 1)
+        assigned_b = 2
+
+        tl.static_assert(a == assigned_a)
+        tl.static_assert(a.type == ((0, 1)).type)
+        tl.static_assert(assigned_a.type == ((0, 1)).type)
+        tl.static_assert(b.dtype == tl.int32)
+        tl.static_assert(assigned_b.dtype == tl.int32)
+
+    run_parser(kernel)
+
+
+def test_tuple_assignment_constexpr_tuple_normalizes_recursively():
+
+    @triton.jit
+    def kernel():
+        a: tl.constexpr
+        a, b = ((0, 1), (2, 3)), 4
+
+        assigned_a: tl.constexpr = ((0, 1), (2, 3))
+
+        tl.static_assert(a == assigned_a)
+        tl.static_assert(a.type == (((0, 1), (2, 3))).type)
+        tl.static_assert(assigned_a.type == (((0, 1), (2, 3))).type)
+        tl.static_assert(b.dtype == tl.int32)
+
+    run_parser(kernel)
+
+
 def test_named_expr_respects_prior_constexpr_annotation():
 
     @triton.jit

--- a/python/test/unit/language/test_tuple.py
+++ b/python/test/unit/language/test_tuple.py
@@ -383,3 +383,66 @@ def test_tuple_constexpr_function():
         tl.static_assert(passthrough_constexpr(TrivialTuple(0)).foo == 0)
 
     kernel[(1, )]()
+
+
+@pytest.mark.interpreter
+def test_constexpr_tuple_arg_unpack(device):
+    """A Python tuple passed as tl.constexpr must support unpacking
+    (`d0, d1, d2 = shape`) in both value positions (arithmetic) and
+    shape positions (tl.zeros / tl.full / tl.reshape)."""
+
+    @triton.jit
+    def kernel_value(out_ptr, shape: tl.constexpr):
+        d0, d1, d2 = shape
+        x = tl.full((1, ), d0 * 100 + d1 * 10 + d2, dtype=tl.int32)
+        tl.store(out_ptr + tl.arange(0, 1), x)
+
+    @triton.jit
+    def kernel_shape(out_ptr, shape: tl.constexpr):
+        d0, d1 = shape
+        x = tl.full((d0, d1), 1.0, dtype=tl.float32)
+        x = tl.reshape(x, (d0 * d1, ))
+        tl.store(out_ptr + tl.arange(0, d0 * d1), x)
+
+    out = torch.zeros(1, dtype=torch.int32, device=device)
+    kernel_value[(1, )](out, shape=(8, 4, 2))
+    assert out.item() == 842
+
+    out = torch.zeros(4, dtype=torch.float32, device=device)
+    kernel_shape[(1, )](out, shape=(2, 2))
+    assert out.sum().item() == 4.0
+
+
+@pytest.mark.interpreter
+def test_constexpr_nested_tuple_arg_unpack(device):
+    """A nested Python tuple passed as tl.constexpr must support nested unpacking
+    (`(d0, d1), d2 = shape`) without crashing."""
+
+    @triton.jit
+    def kernel_nested(out_ptr, shape: tl.constexpr):
+        (d0, d1), d2 = shape
+        x = tl.full((1, ), d0 * 100 + d1 * 10 + d2, dtype=tl.int32)
+        tl.store(out_ptr + tl.arange(0, 1), x)
+
+    out = torch.zeros(1, dtype=torch.int32, device=device)
+    kernel_nested[(1, )](out, shape=((8, 4), 2))
+    assert out.item() == 842
+
+
+@pytest.mark.interpreter
+def test_constexpr_tuple_arg_subscript(device):
+    """Subscripting a tl.constexpr Python-tuple argument must yield a
+    constexpr value (not a stripped Python int), so it can be used where
+    constexpr is required (e.g. tl.reshape shape, tl.full shape)."""
+
+    @triton.jit
+    def kernel(out_ptr, shape: tl.constexpr):
+        v = shape[0] * 100 + shape[1] * 10 + shape[2]
+        x = tl.full((1, ), v, dtype=tl.int32)
+        # use subscript value as a constexpr shape element too
+        x = tl.reshape(x, (shape[0] // shape[0], ))
+        tl.store(out_ptr + tl.arange(0, 1), x)
+
+    out = torch.zeros(1, dtype=torch.int32, device=device)
+    kernel[(1, )](out, shape=(8, 4, 2))
+    assert out.item() == 842

--- a/python/test/unit/language/test_tuple.py
+++ b/python/test/unit/language/test_tuple.py
@@ -256,6 +256,19 @@ def test_passing_tuple_with_constexpr(device):
     torch.testing.assert_close(x, expected_x, rtol=0, atol=0)
 
 
+def test_passing_tuple_with_mixed_constexpr_and_non_constexpr_values(device):
+
+    @triton.jit
+    def kernel(out_ptr, values):
+        tl.static_assert(values[1].type == tl.constexpr_type(3))
+        tl.store(out_ptr, tl.load(values[0]) + values[1])
+
+    x = torch.tensor([8], dtype=torch.int32, device=device)
+    out = torch.empty_like(x)
+    kernel[(1, )](out, (x, tl.constexpr(3)))
+    assert out.item() == 11
+
+
 @triton.jit
 def _nested_tuple_kernel(x):
     # This creates a new scope, which will force a copy of liveins. It's

--- a/python/test/unit/language/test_tuple.py
+++ b/python/test/unit/language/test_tuple.py
@@ -393,12 +393,17 @@ def test_constexpr_tuple_arg_unpack(device):
 
     @triton.jit
     def kernel_value(out_ptr, shape: tl.constexpr):
+        d0: tl.constexpr
+        d1: tl.constexpr
+        d2: tl.constexpr
         d0, d1, d2 = shape
         x = tl.full((1, ), d0 * 100 + d1 * 10 + d2, dtype=tl.int32)
         tl.store(out_ptr + tl.arange(0, 1), x)
 
     @triton.jit
     def kernel_shape(out_ptr, shape: tl.constexpr):
+        d0: tl.constexpr
+        d1: tl.constexpr
         d0, d1 = shape
         x = tl.full((d0, d1), 1.0, dtype=tl.float32)
         x = tl.reshape(x, (d0 * d1, ))
@@ -420,6 +425,9 @@ def test_constexpr_nested_tuple_arg_unpack(device):
 
     @triton.jit
     def kernel_nested(out_ptr, shape: tl.constexpr):
+        d0: tl.constexpr
+        d1: tl.constexpr
+        d2: tl.constexpr
         (d0, d1), d2 = shape
         x = tl.full((1, ), d0 * 100 + d1 * 10 + d2, dtype=tl.int32)
         tl.store(out_ptr + tl.arange(0, 1), x)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -721,6 +721,11 @@ class CodeGenerator(ast.NodeVisitor):
                 return _apply_to_tuple_values(value, _sanitize_value)
             native_nontensor_types = (language.dtype, language.tuple)
             value = _unwrap_if_constexpr(value)
+            # Unwrapped Python tuple from constexpr arg: convert to language.tuple with constexpr elements.
+            # Recurse for nested tuples.
+            if isinstance(value, builtins.tuple) and not is_namedtuple(type(value)):
+                return language.tuple(
+                    [_sanitize_value(constexpr(v)) if isinstance(v, builtins.tuple) else constexpr(v) for v in value])
             if value is not None and \
                 not _is_triton_value(value) and \
                 not isinstance(value, native_nontensor_types):

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -721,11 +721,6 @@ class CodeGenerator(ast.NodeVisitor):
                 return _apply_to_tuple_values(value, _sanitize_value)
             native_nontensor_types = (language.dtype, language.tuple)
             value = _unwrap_if_constexpr(value)
-            # Unwrapped Python tuple from constexpr arg: convert to language.tuple with constexpr elements.
-            # Recurse for nested tuples.
-            if isinstance(value, builtins.tuple) and not is_namedtuple(type(value)):
-                return language.tuple(
-                    [_sanitize_value(constexpr(v)) if isinstance(v, builtins.tuple) else constexpr(v) for v in value])
             if value is not None and \
                 not _is_triton_value(value) and \
                 not isinstance(value, native_nontensor_types):

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1669,13 +1669,19 @@ def ast_to_ttir(fn, src, context, options, codegen_fns, module_map, module=None)
         idx = fn.arg_names.index(k)
         arg_types[idx] = str_to_ty(v, None)
 
+    def constexpr_type(value):
+        if isinstance(value, builtins.tuple):
+            fields = value._fields if is_namedtuple(type(value)) else None
+            return language.tuple_type([constexpr_type(v) for v in value], fields)
+        return constexpr(value).type
+
     def apply_constexpr_types(argument, indices, value):
         index = indices.pop()
         if len(indices) == 0:
             if isinstance(argument, list):
-                argument[index] = constexpr(value).type
+                argument[index] = constexpr_type(value)
             else:
-                argument.types[index] = constexpr(value).type
+                argument.types[index] = constexpr_type(value)
         else:
             apply_constexpr_types(argument[index], indices, value)
 

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -746,7 +746,7 @@ class CodeGenerator(ast.NodeVisitor):
             if isinstance(target, ast.Name):
                 annotation = self.pending_annotations.pop(target.id, None)
                 if annotation == constexpr:
-                    return constexpr(value)
+                    return normalize_value(value)
             return _sanitize_value(value)
 
         targets = [node.target] if isinstance(node, ast.AnnAssign) else node.targets

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -79,6 +79,8 @@ def _check(cond, msg_fn, category=TypeError):
 def _apply_to_tuple_values(value, fn):
     if is_namedtuple(type(value)):
         fields = value._fields
+    elif isinstance(value, builtins.tuple):
+        fields = None
     elif isinstance(value, language.tuple):
         fields = value.type.fields
     else:
@@ -88,6 +90,14 @@ def _apply_to_tuple_values(value, fn):
     vals = [constexpr(v) if v is None else v for v in vals]
     types = [v.type for v in vals]
     return language.tuple(vals, language.tuple_type(types, fields))
+
+
+def normalize_value(value):
+    if isinstance(value, (builtins.tuple, language.tuple)):
+        return _apply_to_tuple_values(value, normalize_value)
+    if _is_triton_value(value):
+        return value
+    return constexpr(value)
 
 
 def flatten_values_to_ir(values: Iterable[base_value]):
@@ -695,7 +705,7 @@ class CodeGenerator(ast.NodeVisitor):
             if target in self.lscope:
                 raise ValueError(f'{target} is already defined.'
                                  f' constexpr cannot be reassigned.')
-            value = constexpr(value)
+            value = normalize_value(value)
             self.lscope[target] = value
             return self.lscope[target]
         # default: call visit_Assign
@@ -1351,15 +1361,8 @@ class CodeGenerator(ast.NodeVisitor):
         args = bound_args.arguments
         args = [args[name] for name in fn.arg_names]
 
-        def normalize_arg(arg):
-            if isinstance(arg, language.tuple):
-                return _apply_to_tuple_values(arg, normalize_arg)
-            if not isinstance(arg, base_value) or isinstance(arg, JITCallable):
-                return language.core.constexpr(arg)
-            return arg
-
         for i, arg in enumerate(args):
-            args[i] = normalize_arg(arg)
+            args[i] = normalize_value(arg)
         # mangle
         caller_context = caller_context or self.caller_context
         arg_types = [arg.type for arg in args]
@@ -1442,14 +1445,7 @@ class CodeGenerator(ast.NodeVisitor):
             args = map(_unwrap_if_constexpr, args)
         ret = fn(*args, **kws)
 
-        def wrap_constexpr(x):
-            if _is_triton_value(x):
-                return x
-            return constexpr(x)
-
-        if isinstance(ret, (builtins.tuple, language.tuple)):
-            return _apply_to_tuple_values(ret, wrap_constexpr)
-        return wrap_constexpr(ret)
+        return normalize_value(ret)
 
     def call_Method(self, node, fn, fn_self, args, kws):
         if isinstance(fn, JITFunction):
@@ -1468,7 +1464,8 @@ class CodeGenerator(ast.NodeVisitor):
         for arg in node.args:
             if isinstance(arg, ast.Starred):
                 arg = self.visit(arg.value)
-                arg = _unwrap_if_constexpr(arg)
+                if isinstance(arg, constexpr):
+                    arg = arg.value
                 if isinstance(arg, tuple):
                     arg = language.core.tuple(arg)
                 assert isinstance(arg, language.core.tuple)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -231,13 +231,19 @@ class DependenciesFinder(ast.NodeVisitor):
         visit_defaults(node.defaults)
 
     def visitAssnTarget(self, node):
-        # Target is either a single string, or a list of strings (if the assn
-        # target is a tuple).
+        # Target is either a single string, or a (possibly nested) list of
+        # strings (if the assn target is a tuple, including nested tuples
+        # like `(a, b), c = ...`).
         target = self.visit(node)
-        if isinstance(target, list):
-            self.local_names |= set(target)
-        else:
-            self.local_names.add(target)
+
+        def _add(t):
+            if isinstance(t, list):
+                for sub in t:
+                    _add(sub)
+            else:
+                self.local_names.add(t)
+
+        _add(target)
 
     def visit_Assign(self, node):
         if len(node.targets) != 1:

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -231,9 +231,7 @@ class DependenciesFinder(ast.NodeVisitor):
         visit_defaults(node.defaults)
 
     def visitAssnTarget(self, node):
-        # Target is either a single string, or a (possibly nested) list of
-        # strings (if the assn target is a tuple, including nested tuples
-        # like `(a, b), c = ...`).
+        # Target is either a single string, or a (possibly nested) list of strings if the assign target is a tuple.
         target = self.visit(node)
 
         def _add(t):

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -189,7 +189,7 @@ class DependenciesFinder(ast.NodeVisitor):
         lhs_name = getattr(lhs, "__name__", "")
         if lhs is None or lhs_name in self.supported_modules:
             return None
-        ret = getattr(lhs, node.attr)
+        ret = getattr(lhs, node.attr, None)
         self.record_reference(ret)
         return ret
 


### PR DESCRIPTION
Closes #10279

Currently if an argument annotated with `tl.constexpr` is passed a tuple, you get a `tl.constexpr(builtin.tuple)` instead of `tl.tuple([tl.constexpr(...), ...)])`.

This also fixes annotated assignment, e.g.
```
t: tl.constexpr = (0, 1, 2)
```
previously gave `tl.constexpr((0, 1, 2))` but now gives `tl.tuple([tl.constexpr(0), ...])` 