### PR TITLE
[AMD] Gate DPP bound_ctrl:1 on safe targets to fix gfx110x regression

### DIFF
--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TargetFeatures.h
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TargetFeatures.h
@@ -97,6 +97,17 @@ private:
 bool isCDNA(ISAFamily isaFamily);
 bool isRDNA(ISAFamily isaFamily);
 
+// Returns false on RDNA3 silicon where LLVM's AMDGPU DPP combiner fuses
+// `v_mov_dpp` into a VOP3 consumer with immediate src1/src2 (e.g.
+// `v_bfe_i32_e64_dpp v, v, 0, 16`), which gfx1100/1101/1102/1103 reject.
+// gfx1150/1151 accept the fused form; so do RDNA4, GFX1250 and
+// CDNA. Used to gate `bound_ctrl:1` on DPP emissions, which is what
+// unlocks the broken fusion.
+//
+// The arch string is only inspected when isaFamily == RDNA3 (gfx110x vs.
+// gfx115x disambiguation); for all other targets the moduleOp is unused.
+bool isDppBoundCtrlSafe(ModuleOp moduleOp, ISAFamily isaFamily);
+
 } // namespace mlir::triton::amdgpu
 
 #endif // TRITON_THIRD_PARTY_AMD_INCLUDE_DIALECT_TRITONAMDGPU_IR_TARGETFEATURES_H_

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/TargetFeatures.cpp
@@ -343,4 +343,11 @@ bool isRDNA(ISAFamily isaFamily) {
   }
 }
 
+bool isDppBoundCtrlSafe(ModuleOp moduleOp, ISAFamily isaFamily) {
+  if (isaFamily != ISAFamily::RDNA3)
+    return true;
+  StringRef arch = TargetFeatures::fromModuleOp(moduleOp).getArch();
+  return arch == "gfx1150" || arch == "gfx1151";
+}
+
 } // namespace mlir::triton::amdgpu

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -160,10 +160,18 @@ Value shuffleCommonImpl(Location loc, RewriterBase &rewriter,
     };
     bool usePermlaneSwap = isaFamily == ISAFamily::CDNA4 && (mask & 0x30);
 
+    // bound_ctrl:1 lets LLVM's AMDGPU DPP combiner fuse v_mov_dpp into a
+    // VOP3 consumer; on gfx110x this can produce e.g.
+    // `v_bfe_i32_e64_dpp v, v, 0, 16` which the assembler rejects (immediate
+    // src1/src2 not allowed in VOP3_DPP on that silicon). Gate on the helper
+    // so gfx110x stays unfused while every other target keeps the perf win.
+    const bool boundCtrl = triton::amdgpu::isDppBoundCtrlSafe(mod, isaFamily);
+
     if (triton::amdgpu::isRDNA(isaFamily) || isaFamily == ISAFamily::GFX1250) {
       if (mask < 16)
         return emitDpp(loc, rewriter, val, val,
-                       makeDppCtrl(DppCtrl::ROW_XMASK0, mask));
+                       makeDppCtrl(DppCtrl::ROW_XMASK0, mask),
+                       /*rowMask=*/0xf, /*bankMask=*/0xf, boundCtrl);
       else if (mask < 32)
         return emitPermlaneX16Xor(loc, rewriter, val, mask & 0xf);
     } else if ((triton::amdgpu::isCDNA(isaFamily) ||
@@ -192,12 +200,14 @@ Value shuffleCommonImpl(Location loc, RewriterBase &rewriter,
           highBitsDppCtrl = DppCtrl::ROW_MIRROR;
           break;
         }
-        result = emitDpp(loc, rewriter, result, result, highBitsDppCtrl);
+        result = emitDpp(loc, rewriter, result, result, highBitsDppCtrl,
+                         /*rowMask=*/0xf, /*bankMask=*/0xf, boundCtrl);
       }
 
       if (quadMask) {
         result =
-            emitDpp(loc, rewriter, result, result, makeQuadPermCtrl(quadMask));
+            emitDpp(loc, rewriter, result, result, makeQuadPermCtrl(quadMask),
+                    /*rowMask=*/0xf, /*bankMask=*/0xf, boundCtrl);
       }
 
       if (usePermlaneSwap) {


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

Narrows the `bound_ctrl:1` change from #10414 so it only applies on targets where LLVM's AMDGPU DPP combiner produces legal code. On gfx110x the fusion that #10414 enabled generates 
**`v_bfe_i32_e64_dpp v, v, 0, 16 ... bound_ctrl:1`, which the assembler rejects.** All other RDNA / GFX1250 / CDNA targets keep the perf win.

After #10414, every bf16/f16 `test_scan2d` and `test_flip` test in `python/test/unit/language/` fails to compile on gfx1100 with:
**error: src1 immediate operand invalid for instruction
v_bfe_i32_e64_dpp v1, v1, 0, 16 row_xmask:8 row_mask:0xf bank_mask:0xf bound_ctrl:1**
60 failures across `test_scan2d` 

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it fixes tests`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
