### PR TITLE
[TritonGPU] Fix zero-swizzle transposed NVMMA layouts

### DIFF
--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -203,11 +203,26 @@ static FailureOr<LinearLayout> buildNvmmaSharedLinearLayout(
   auto shapePerCTA = getShapePerCTA(shared, shape);
   auto kOffset = S("offset");
   if (shared.getSwizzlingByteWidth() == 0) {
+    SmallVector<int64_t> maybeTransposedTmaShape(tmaShape.begin(),
+                                                 tmaShape.end());
+    if (shared.getTransposed()) {
+      std::rotate(maybeTransposedTmaShape.begin(),
+                  maybeTransposedTmaShape.begin() + 1,
+                  maybeTransposedTmaShape.end());
+    }
     auto outDimNames = standardOutDimNames(ctx, rank);
-    LinearLayout layout = LinearLayout::identity1D(tmaShape[rank - 1], kOffset,
-                                                   outDimNames[rank - 1]);
+    LinearLayout layout = LinearLayout::identity1D(
+        maybeTransposedTmaShape[rank - 1], kOffset, outDimNames[rank - 1]);
     for (int i = rank - 2; i >= 0; --i) {
-      layout *= LinearLayout::identity1D(tmaShape[i], kOffset, outDimNames[i]);
+      layout *= LinearLayout::identity1D(maybeTransposedTmaShape[i], kOffset,
+                                         outDimNames[i]);
+    }
+    if (shared.getTransposed()) {
+      SmallVector<int> order = {rank - 1};
+      for (int i = 0; i < rank - 1; i++) {
+        order.push_back(i);
+      }
+      layout = transposeLinearLayout(layout, order);
     }
     layout = ensureLayoutNotSmallerThan(layout, outDimNames, shapePerCTA);
     return combineCtaCgaWithShape(layout, shared.getCGALayout(), shape);

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -1361,6 +1361,33 @@ _ld_st_shared_layouts = _filter_layouts([
 ])
 
 
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_local_load_transposed_nvmma_zero_swizzle(device):
+    rows = 128
+    cols = 16
+    src_layout = ttgl.BlockedLayout([1, 1], [32, 1], [4, 1], [1, 0])
+    dst_layout = ttgl.BlockedLayout([1, 16], [1, 32], [1, 4], [1, 0])
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=0, transposed=False, element_bitwidth=8, rank=2)
+
+    @gluon.jit
+    def kernel(x_ptr, y_ptr, rows: ttgl.constexpr, cols: ttgl.constexpr, src_layout: ttgl.constexpr,
+               dst_layout: ttgl.constexpr, shared_layout: ttgl.constexpr):
+        offs_row = ttgl.arange(0, rows, layout=ttgl.SliceLayout(1, src_layout))[:, None]
+        offs_col = ttgl.arange(0, cols, layout=ttgl.SliceLayout(0, src_layout))[None, :]
+        x = ttgl.load(x_ptr + offs_row * cols + offs_col)
+        smem = ttgl.allocate_shared_memory(ttgl.uint8, [rows, cols], shared_layout, x)
+
+        y = smem.permute((1, 0)).load(dst_layout)
+        offs_col = ttgl.arange(0, cols, layout=ttgl.SliceLayout(1, dst_layout))[:, None]
+        offs_row = ttgl.arange(0, rows, layout=ttgl.SliceLayout(0, dst_layout))[None, :]
+        ttgl.store(y_ptr + offs_col * rows + offs_row, y)
+
+    x = torch.arange(rows * cols, device=device, dtype=torch.int64).to(torch.uint8).reshape(rows, cols)
+    y = torch.empty((cols, rows), device=device, dtype=torch.uint8)
+    kernel[(1, )](x, y, rows, cols, src_layout, dst_layout, shared_layout, num_warps=4)
+    torch.testing.assert_close(y, x.T)
+
+
 @pytest.mark.parametrize("shape, dtype", [
     ((16, 32), "float8_e5m2"),
     ((16, 32), "float16"),

--- a/test/Tools/nvmma_shared_transposed_zero_swizzle.mlir
+++ b/test/Tools/nvmma_shared_transposed_zero_swizzle.mlir
@@ -1,0 +1,5 @@
+// RUN: triton-tensor-layout -l "#ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = true, elementBitWidth = 8}>" -t "tensor<16x128xi8>" -use-hw-view | FileCheck %s
+
+// CHECK:      Offset: 0 -> ( 0,  0)
+// CHECK-NEXT: Offset: 1 -> ( 1,  0)
+// CHECK:      Offset: 16 -> ( 0,  1)


### PR DESCRIPTION
Converting nvvma shared layout transposed 0 swizzle byte width to linear layout was not handled.